### PR TITLE
Establish GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - agent/browser-realtime-architecture
+      - agent/ci-base
+
+permissions:
+  contents: read
+
+jobs:
+  rust:
+    name: Rust quality gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install stable Rust
+        run: |
+          rustup update stable --no-self-update
+          rustup default stable
+          rustup component add rustfmt clippy
+
+      - name: Format
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+      - name: Tests
+        run: cargo test --workspace --all-features


### PR DESCRIPTION
Adds the repository's baseline Rust CI gate so subsequent architecture implementation can be validated on every pull request before advancing.

Checks:
- rustfmt
- clippy with warnings denied
- workspace tests/all features

This PR contains CI infrastructure only; the Noon architecture implementation remains on `agent/browser-realtime-architecture`.