### PR TITLE
Add TransformFromCopy lifecycle semantics

### DIFF
--- a/crates/noon-compile/src/lib.rs
+++ b/crates/noon-compile/src/lib.rs
@@ -97,6 +97,10 @@ pub struct CompiledScene {
 pub enum CompileError {
     TooManyObjects(usize),
     UnknownObject(ObjectId),
+    DiscontinuousPresence {
+        previous: TrackId,
+        next: TrackId,
+    },
     UnsupportedTransformGeometry(TrackId),
     PathTransformRequiresRetessellation(TrackId),
     UnsafeFilledPathTransform(TrackId),
@@ -111,6 +115,12 @@ impl std::fmt::Display for CompileError {
             Self::UnknownObject(id) => {
                 write!(formatter, "track references unknown object {}", id.get())
             }
+            Self::DiscontinuousPresence { previous, next } => write!(
+                formatter,
+                "presence track {} does not hand off continuously to track {}",
+                previous.get(),
+                next.get()
+            ),
             Self::UnsupportedTransformGeometry(id) => write!(
                 formatter,
                 "transform track {} uses unsupported geometry interpolation",
@@ -140,6 +150,10 @@ pub enum CompilePatchError {
     DuplicateTrack(TrackId),
     UnknownTrack(TrackId),
     InvalidTrack(TimelineError),
+    DiscontinuousPresence {
+        previous: TrackId,
+        next: TrackId,
+    },
     UnsupportedTransformGeometry(TrackId),
     PathTransformRequiresRetessellation(TrackId),
     UnsafeFilledPathTransform(TrackId),
@@ -156,6 +170,12 @@ impl std::fmt::Display for CompilePatchError {
             Self::DuplicateTrack(id) => write!(formatter, "duplicate track id {}", id.get()),
             Self::UnknownTrack(id) => write!(formatter, "unknown track id {}", id.get()),
             Self::InvalidTrack(error) => write!(formatter, "invalid track: {error}"),
+            Self::DiscontinuousPresence { previous, next } => write!(
+                formatter,
+                "presence track {} does not hand off continuously to track {}",
+                previous.get(),
+                next.get()
+            ),
             Self::UnsupportedTransformGeometry(id) => write!(
                 formatter,
                 "transform track {} uses unsupported geometry interpolation",
@@ -207,6 +227,9 @@ impl CompiledScene {
             );
         }
         sort_tracks(&mut tracks);
+        validate_presence_chains(&tracks).map_err(|(previous, next)| {
+            CompileError::DiscontinuousPresence { previous, next }
+        })?;
 
         Ok(Self {
             objects,
@@ -275,8 +298,13 @@ impl CompiledScene {
                     return Err(CompilePatchError::DuplicateTrack(track.id));
                 }
                 let compiled = self.compile_patch_track(track)?;
-                self.tracks.push(compiled);
-                sort_tracks(&mut self.tracks);
+                let mut tracks = self.tracks.clone();
+                tracks.push(compiled);
+                sort_tracks(&mut tracks);
+                validate_presence_chains(&tracks).map_err(|(previous, next)| {
+                    CompilePatchError::DiscontinuousPresence { previous, next }
+                })?;
+                self.tracks = tracks;
                 self.recompute_dynamic();
             }
             ScenePatch::ReplaceTrack(track) => {
@@ -286,8 +314,13 @@ impl CompiledScene {
                     .position(|existing| existing.id == track.id)
                     .ok_or(CompilePatchError::UnknownTrack(track.id))?;
                 let compiled = self.compile_patch_track(track)?;
-                self.tracks[position] = compiled;
-                sort_tracks(&mut self.tracks);
+                let mut tracks = self.tracks.clone();
+                tracks[position] = compiled;
+                sort_tracks(&mut tracks);
+                validate_presence_chains(&tracks).map_err(|(previous, next)| {
+                    CompilePatchError::DiscontinuousPresence { previous, next }
+                })?;
+                self.tracks = tracks;
                 self.recompute_dynamic();
             }
             ScenePatch::RemoveTrack(id) => {
@@ -296,7 +329,12 @@ impl CompiledScene {
                     .iter()
                     .position(|track| track.id == *id)
                     .ok_or(CompilePatchError::UnknownTrack(*id))?;
-                self.tracks.remove(position);
+                let mut tracks = self.tracks.clone();
+                tracks.remove(position);
+                validate_presence_chains(&tracks).map_err(|(previous, next)| {
+                    CompilePatchError::DiscontinuousPresence { previous, next }
+                })?;
+                self.tracks = tracks;
                 self.recompute_dynamic();
             }
         }
@@ -503,6 +541,28 @@ fn sort_tracks(tracks: &mut [CompiledTrack]) {
     });
 }
 
+fn validate_presence_chains(tracks: &[CompiledTrack]) -> Result<(), (TrackId, TrackId)> {
+    let mut previous: Option<(u32, TrackId, bool)> = None;
+
+    for track in tracks
+        .iter()
+        .filter(|track| track.property == Property::Presence)
+    {
+        let TrackValues::Bool { from, to } = &track.values else {
+            unreachable!("validated Presence track must contain bool values");
+        };
+
+        if let Some((object_index, previous_id, previous_to)) = previous {
+            if object_index == track.object_index && previous_to != *from {
+                return Err((previous_id, track.id));
+            }
+        }
+        previous = Some((track.object_index, track.id, *to));
+    }
+
+    Ok(())
+}
+
 const fn property_rank(property: Property) -> u8 {
     match property {
         Property::Presence => 0,
@@ -707,6 +767,91 @@ mod tests {
             }
         );
         assert_eq!(compiled.tracks()[0].timing.duration, 0.0);
+    }
+
+    #[test]
+    fn continuous_presence_chain_compiles() {
+        let mut scene = SceneDefinition::new();
+        let object = scene.add(GeometryRef::circle(1.0));
+        scene
+            .set_presence_at(object, false, true, 1.0)
+            .expect("valid first presence event");
+        scene
+            .set_presence_at(object, true, false, 2.0)
+            .expect("valid second presence event");
+
+        CompiledScene::compile(&scene).expect("continuous presence chain must compile");
+    }
+
+    #[test]
+    fn discontinuous_presence_chain_is_rejected() {
+        let mut scene = SceneDefinition::new();
+        let object = scene.add(GeometryRef::circle(1.0));
+        let previous = scene
+            .set_presence_at(object, false, true, 1.0)
+            .expect("valid first presence event");
+        let next = scene
+            .set_presence_at(object, false, true, 2.0)
+            .expect("each presence event is individually valid");
+
+        assert_eq!(
+            CompiledScene::compile(&scene),
+            Err(CompileError::DiscontinuousPresence { previous, next })
+        );
+    }
+
+    #[test]
+    fn patch_rejects_discontinuous_presence_without_mutating_tracks() {
+        let mut scene = SceneDefinition::new();
+        let object = scene.add(GeometryRef::circle(1.0));
+        let previous = scene
+            .set_presence_at(object, false, true, 1.0)
+            .expect("valid first presence event");
+        let mut compiled = CompiledScene::compile(&scene).expect("scene must compile");
+        let before = compiled.tracks().to_vec();
+        let next = TrackId::new(9);
+
+        let track = TrackDefinition {
+            id: next,
+            object,
+            property: Property::Presence,
+            values: TrackValues::Bool {
+                from: false,
+                to: true,
+            },
+            timing: TrackTiming::new(2.0, 0.0, Easing::Linear),
+        };
+        assert_eq!(
+            compiled.apply_patch(&ScenePatch::AddTrack(track)),
+            Err(CompilePatchError::DiscontinuousPresence { previous, next })
+        );
+        assert_eq!(compiled.tracks(), before);
+    }
+
+    #[test]
+    fn patch_rejects_removing_required_presence_handoff_without_mutating_tracks() {
+        let mut scene = SceneDefinition::new();
+        let object = scene.add(GeometryRef::circle(1.0));
+        let first = scene
+            .set_presence_at(object, false, true, 1.0)
+            .expect("valid first presence event");
+        let middle = scene
+            .set_presence_at(object, true, false, 2.0)
+            .expect("valid middle presence event");
+        let last = scene
+            .set_presence_at(object, false, true, 3.0)
+            .expect("valid last presence event");
+        let mut compiled = CompiledScene::compile(&scene).expect("scene must compile");
+        let before = compiled.tracks().to_vec();
+
+        assert_eq!(
+            compiled.apply_patch(&ScenePatch::RemoveTrack(middle)),
+            Err(CompilePatchError::DiscontinuousPresence {
+                previous: first,
+                next: last,
+            })
+        );
+        assert_eq!(compiled.tracks(), before);
     }
 
     #[test]

--- a/crates/noon-compile/src/lib.rs
+++ b/crates/noon-compile/src/lib.rs
@@ -97,10 +97,7 @@ pub struct CompiledScene {
 pub enum CompileError {
     TooManyObjects(usize),
     UnknownObject(ObjectId),
-    DiscontinuousPresence {
-        previous: TrackId,
-        next: TrackId,
-    },
+    DiscontinuousPresence { previous: TrackId, next: TrackId },
     UnsupportedTransformGeometry(TrackId),
     PathTransformRequiresRetessellation(TrackId),
     UnsafeFilledPathTransform(TrackId),
@@ -150,10 +147,7 @@ pub enum CompilePatchError {
     DuplicateTrack(TrackId),
     UnknownTrack(TrackId),
     InvalidTrack(TimelineError),
-    DiscontinuousPresence {
-        previous: TrackId,
-        next: TrackId,
-    },
+    DiscontinuousPresence { previous: TrackId, next: TrackId },
     UnsupportedTransformGeometry(TrackId),
     PathTransformRequiresRetessellation(TrackId),
     UnsafeFilledPathTransform(TrackId),
@@ -227,9 +221,8 @@ impl CompiledScene {
             );
         }
         sort_tracks(&mut tracks);
-        validate_presence_chains(&tracks).map_err(|(previous, next)| {
-            CompileError::DiscontinuousPresence { previous, next }
-        })?;
+        validate_presence_chains(&tracks)
+            .map_err(|(previous, next)| CompileError::DiscontinuousPresence { previous, next })?;
 
         Ok(Self {
             objects,

--- a/crates/noon-render-wgpu/tests/transform_from_copy_presence.rs
+++ b/crates/noon-render-wgpu/tests/transform_from_copy_presence.rs
@@ -1,0 +1,66 @@
+use noon_compile::CompiledScene;
+use noon_core::{
+    Easing, GeometryRef, ObjectSnapshot, SceneDefinition, TrackTiming, Transform2D, Vec2,
+};
+use noon_render_wgpu::FramePreparer;
+use noon_runtime::SceneInstance;
+
+fn copy_scene() -> SceneInstance {
+    let mut scene = SceneDefinition::new();
+    let source = scene.add(GeometryRef::circle(1.0));
+    let target = scene.add(GeometryRef::circle(3.0));
+    let copy = scene.add(GeometryRef::circle(1.0));
+
+    scene.object_mut(source).expect("source exists").transform = Transform2D {
+        translation: Vec2::new(-2.0, 0.0),
+        ..Transform2D::IDENTITY
+    };
+    scene.object_mut(copy).expect("copy exists").transform = Transform2D {
+        translation: Vec2::new(-2.0, 0.0),
+        ..Transform2D::IDENTITY
+    };
+    scene.object_mut(target).expect("target exists").transform = Transform2D {
+        translation: Vec2::new(4.0, -2.0),
+        ..Transform2D::IDENTITY
+    };
+
+    let source_snapshot = ObjectSnapshot::from(scene.object(source).expect("source exists"));
+    let target_snapshot = ObjectSnapshot::from(scene.object(target).expect("target exists"));
+    scene
+        .animate_transform(
+            copy,
+            source_snapshot,
+            target_snapshot,
+            TrackTiming::new(1.0, 2.0, Easing::Linear),
+        )
+        .expect("copy transform must be valid");
+    scene
+        .set_presence_at(copy, false, true, 1.0)
+        .expect("copy show must be valid");
+    scene
+        .set_presence_at(copy, true, false, 3.0)
+        .expect("copy hide must be valid");
+    scene
+        .set_presence_at(target, false, true, 3.0)
+        .expect("target show must be valid");
+
+    SceneInstance::new(CompiledScene::compile(&scene).expect("scene must compile"))
+}
+
+fn prepared_ids(instance: &mut SceneInstance, preparer: &mut FramePreparer, time: f64) -> Vec<u64> {
+    instance.advance_to(time).expect("valid time");
+    let changes = instance.take_frame_changes();
+    let prepared = preparer.prepare_incremental(instance.frame(), &changes);
+    prepared.circle_ids.iter().map(|id| id.get()).collect()
+}
+
+#[test]
+fn renderer_tracks_transform_from_copy_visible_instance_phases() {
+    let mut instance = copy_scene();
+    let mut preparer = FramePreparer::new();
+
+    assert_eq!(prepared_ids(&mut instance, &mut preparer, 0.5), vec![0]);
+    assert_eq!(prepared_ids(&mut instance, &mut preparer, 1.0), vec![0, 2]);
+    assert_eq!(prepared_ids(&mut instance, &mut preparer, 2.0), vec![0, 2]);
+    assert_eq!(prepared_ids(&mut instance, &mut preparer, 3.0), vec![0, 1]);
+}

--- a/crates/noon-runtime/tests/transform_from_copy.rs
+++ b/crates/noon-runtime/tests/transform_from_copy.rs
@@ -76,7 +76,10 @@ fn transform_from_copy_has_exact_presence_phases() {
     assert!(!middle.is_present(1));
     assert!(middle.is_present(2));
     assert_eq!(middle.objects[2].geometry, GeometryRef::circle(2.0));
-    assert_eq!(middle.objects[2].transform.translation, Vec2::new(1.0, -1.0));
+    assert_eq!(
+        middle.objects[2].transform.translation,
+        Vec2::new(1.0, -1.0)
+    );
 
     let end = instance.seek(3.0).expect("valid time");
     assert!(end.is_present(0));

--- a/crates/noon-runtime/tests/transform_from_copy.rs
+++ b/crates/noon-runtime/tests/transform_from_copy.rs
@@ -1,0 +1,110 @@
+use noon_compile::CompiledScene;
+use noon_core::{
+    Easing, GeometryRef, ObjectId, ObjectSnapshot, SceneDefinition, TrackTiming, Transform2D, Vec2,
+};
+use noon_runtime::SceneInstance;
+
+fn copy_scene() -> (CompiledScene, ObjectId, ObjectId, ObjectId) {
+    let mut scene = SceneDefinition::new();
+    let source = scene.add(GeometryRef::circle(1.0));
+    let target = scene.add(GeometryRef::circle(3.0));
+    let copy = scene.add(GeometryRef::circle(1.0));
+
+    scene.object_mut(source).expect("source exists").transform = Transform2D {
+        translation: Vec2::new(-2.0, 0.0),
+        ..Transform2D::IDENTITY
+    };
+    scene.object_mut(copy).expect("copy exists").transform = Transform2D {
+        translation: Vec2::new(-2.0, 0.0),
+        ..Transform2D::IDENTITY
+    };
+    scene.object_mut(target).expect("target exists").transform = Transform2D {
+        translation: Vec2::new(4.0, -2.0),
+        ..Transform2D::IDENTITY
+    };
+
+    let source_snapshot = ObjectSnapshot::from(scene.object(source).expect("source exists"));
+    let target_snapshot = ObjectSnapshot::from(scene.object(target).expect("target exists"));
+    scene
+        .animate_transform(
+            copy,
+            source_snapshot,
+            target_snapshot,
+            TrackTiming::new(1.0, 2.0, Easing::Linear),
+        )
+        .expect("copy transform must be valid");
+    scene
+        .set_presence_at(copy, false, true, 1.0)
+        .expect("copy show must be valid");
+    scene
+        .set_presence_at(copy, true, false, 3.0)
+        .expect("copy hide must be valid");
+    scene
+        .set_presence_at(target, false, true, 3.0)
+        .expect("target handoff must be valid");
+
+    (
+        CompiledScene::compile(&scene).expect("copy scene must compile"),
+        source,
+        target,
+        copy,
+    )
+}
+
+#[test]
+fn transform_from_copy_has_exact_presence_phases() {
+    let (compiled, source, target, copy) = copy_scene();
+    let mut instance = SceneInstance::new(compiled);
+
+    let before = instance.seek(0.5).expect("valid time");
+    assert_eq!(before.objects[0].id, source);
+    assert_eq!(before.objects[1].id, target);
+    assert_eq!(before.objects[2].id, copy);
+    assert!(before.is_present(0));
+    assert!(!before.is_present(1));
+    assert!(!before.is_present(2));
+
+    let start = instance.seek(1.0).expect("valid time");
+    assert!(start.is_present(0));
+    assert!(!start.is_present(1));
+    assert!(start.is_present(2));
+    assert_eq!(start.objects[2].geometry, GeometryRef::circle(1.0));
+    assert_eq!(start.objects[2].transform.translation, Vec2::new(-2.0, 0.0));
+
+    let middle = instance.seek(2.0).expect("valid time");
+    assert!(middle.is_present(0));
+    assert!(!middle.is_present(1));
+    assert!(middle.is_present(2));
+    assert_eq!(middle.objects[2].geometry, GeometryRef::circle(2.0));
+    assert_eq!(middle.objects[2].transform.translation, Vec2::new(1.0, -1.0));
+
+    let end = instance.seek(3.0).expect("valid time");
+    assert!(end.is_present(0));
+    assert!(end.is_present(1));
+    assert!(!end.is_present(2));
+    assert_eq!(end.objects[1].geometry, GeometryRef::circle(3.0));
+    assert_eq!(end.objects[1].transform.translation, Vec2::new(4.0, -2.0));
+}
+
+#[test]
+fn transform_from_copy_direct_seek_matches_forward_playback_and_rewind() {
+    let (compiled, _, _, _) = copy_scene();
+    let mut sequential = SceneInstance::new(compiled.clone());
+    let mut direct = SceneInstance::new(compiled);
+
+    for time in [0.5, 1.0, 1.5, 2.0, 2.5, 3.0] {
+        sequential.advance_to(time).expect("valid forward time");
+    }
+    direct.seek(3.0).expect("valid direct time");
+    assert_eq!(sequential.frame(), direct.frame());
+
+    direct.seek(2.0).expect("valid rewind");
+    assert!(direct.frame().is_present(0));
+    assert!(!direct.frame().is_present(1));
+    assert!(direct.frame().is_present(2));
+
+    direct.seek(0.5).expect("valid pre-start rewind");
+    assert!(direct.frame().is_present(0));
+    assert!(!direct.frame().is_present(1));
+    assert!(!direct.frame().is_present(2));
+}

--- a/docs/transform-from-copy.md
+++ b/docs/transform-from-copy.md
@@ -1,0 +1,78 @@
+# TransformFromCopy lifecycle semantics
+
+## Goal
+
+`TransformFromCopy` should preserve the original source object while a distinct transient copy moves through Noon's existing generic Transform pipeline toward a stable target object. Object lifetime remains an explicit semantic concern expressed with `Presence`; playback does not create or destroy objects.
+
+This design builds directly on [transform-lifecycle.md](transform-lifecycle.md) and reuses the geometry/interpolation rules in [generic-transform.md](generic-transform.md).
+
+## Initial bounded contract
+
+The authoring form is:
+
+```python
+scene.play(
+    TransformFromCopy(source, target, key="source-copy-to-target"),
+    duration=2.0,
+    start_time=1.0,
+)
+```
+
+The scene owns three stable identities:
+
+1. `source`: visible throughout the animation;
+2. `target`: absent before the end-time handoff, visible afterward;
+3. an internally authored transient copy: absent before `start_time`, visible only during the transform interval, absent afterward.
+
+The transient copy is a snapshot of the source at scheduling time and receives a deterministic authoring identity so Python reruns map it back to the same stable runtime object.
+
+## Lowering
+
+One `TransformFromCopy` lowers to a normal generic Transform plus discrete lifecycle events:
+
+```text
+Presence(copy):   false -> true   at start
+Transform(copy):  source snapshot -> target snapshot   over [start, end]
+Presence(copy):   true -> false   at end
+Presence(target): false -> true   at end
+```
+
+`source` receives no lifecycle event and therefore remains present. At the exact start time both source and copy are visible. At the exact end time the copy disappears and target appears. The copy and target never need playback-time insertion/removal.
+
+## Presence-chain invariant
+
+This is the first lifecycle primitive that naturally gives one object multiple presence events. The copy's chain must be continuous:
+
+```text
+false -> true
+true  -> false
+```
+
+Adjacent events for one object must agree (`previous.to == next.from`). The implementation should validate this invariant rather than silently ignoring an inconsistent later `from` value. This makes arbitrary seek and forward playback describe the same state transition sequence.
+
+## Initial safety boundaries
+
+The first implementation should reject ambiguous composition rather than synthesize hidden precedence rules:
+
+- source and target must be distinct objects owned by the same `Scene`;
+- source/target objects already participating in incompatible lifecycle replacement state are rejected;
+- target generic Transform state overlapping the copy interval is rejected;
+- target narrow-property state at or before handoff is rejected until lifecycle lowering can snapshot evaluated target state exactly;
+- transient copy keys must be deterministic and collision-free within one scene.
+
+## Validation
+
+The first slice should prove:
+
+- Python lowering creates a stable transient copy and exact presence/Transform tracks;
+- transient copy identity is deterministic across equivalent reruns;
+- direct seek, sequential forward playback, and rewind agree at pre-start, start, midpoint, and end;
+- source remains present throughout;
+- copy is visible only during the interval;
+- target appears exactly at the end;
+- renderer preparation contains the correct visible instance count at each lifecycle phase;
+- inconsistent presence chains are rejected before runtime playback.
+
+## Follow-up
+
+After this bounded contract is green, lifecycle composition can be generalized: repeated copy transforms, chained replacements, evaluated target snapshots, and eventually matching-shape Transform variants can build on the same stable-ID/presence machinery.

--- a/docs/transform-from-copy.md
+++ b/docs/transform-from-copy.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-`TransformFromCopy` should preserve the original source object while a distinct transient copy moves through Noon's existing generic Transform pipeline toward a stable target object. Object lifetime remains an explicit semantic concern expressed with `Presence`; playback does not create or destroy objects.
+`TransformFromCopy` preserves the original source object while a distinct transient copy moves through Noon's existing generic Transform pipeline toward a stable target object. Object lifetime remains an explicit semantic concern expressed with `Presence`; playback does not create or destroy objects.
 
 This design builds directly on [transform-lifecycle.md](transform-lifecycle.md) and reuses the geometry/interpolation rules in [generic-transform.md](generic-transform.md).
 
@@ -24,7 +24,7 @@ The scene owns three stable identities:
 2. `target`: absent before the end-time handoff, visible afterward;
 3. an internally authored transient copy: absent before `start_time`, visible only during the transform interval, absent afterward.
 
-The transient copy is a snapshot of the source at scheduling time and receives a deterministic authoring identity so Python reruns map it back to the same stable runtime object.
+The transient copy is a snapshot of the source at scheduling time and receives a deterministic authoring identity so equivalent Python reruns map it back to the same stable runtime object.
 
 ## Lowering
 
@@ -41,38 +41,41 @@ Presence(target): false -> true   at end
 
 ## Presence-chain invariant
 
-This is the first lifecycle primitive that naturally gives one object multiple presence events. The copy's chain must be continuous:
+This is the first lifecycle primitive that naturally gives one object multiple presence events. The copy's chain is continuous:
 
 ```text
 false -> true
 true  -> false
 ```
 
-Adjacent events for one object must agree (`previous.to == next.from`). The implementation should validate this invariant rather than silently ignoring an inconsistent later `from` value. This makes arbitrary seek and forward playback describe the same state transition sequence.
+Adjacent events for one object must agree (`previous.to == next.from`). Python authoring validates the chain as it is built. The Rust compiler independently validates sorted `Presence` tracks before runtime playback, and add/replace/remove-track live patches are validated transactionally before they replace the compiled track set. An inconsistent later `from` value is therefore rejected rather than silently ignored.
 
 ## Initial safety boundaries
 
-The first implementation should reject ambiguous composition rather than synthesize hidden precedence rules:
+The bounded implementation rejects ambiguous composition rather than synthesizing hidden precedence rules:
 
 - source and target must be distinct objects owned by the same `Scene`;
-- source/target objects already participating in incompatible lifecycle replacement state are rejected;
+- source or target objects already participating in another lifecycle animation are rejected;
+- source generic Transform state overlapping the copy start is rejected;
 - target generic Transform state overlapping the copy interval is rejected;
-- target narrow-property state at or before handoff is rejected until lifecycle lowering can snapshot evaluated target state exactly;
-- transient copy keys must be deterministic and collision-free within one scene.
+- source narrow-property state at or before copy start is rejected until source state can be evaluated into an exact snapshot;
+- target narrow-property state at or before handoff is rejected until target state can be evaluated into an exact snapshot;
+- transient copy and generated track keys are deterministic and duplicate keys are rejected within one scene.
+
+Completed generic Transform tracks that end before the relevant snapshot time are supported: the scheduled Transform target snapshot is used as the source or target semantic snapshot.
 
 ## Validation
 
-The first slice should prove:
+The implementation is covered end to end:
 
-- Python lowering creates a stable transient copy and exact presence/Transform tracks;
-- transient copy identity is deterministic across equivalent reruns;
-- direct seek, sequential forward playback, and rewind agree at pre-start, start, midpoint, and end;
-- source remains present throughout;
-- copy is visible only during the interval;
-- target appears exactly at the end;
-- renderer preparation contains the correct visible instance count at each lifecycle phase;
-- inconsistent presence chains are rejected before runtime playback.
+- Python lowering tests verify the stable transient copy and exact presence/Transform tracks;
+- explicit and generated transient-copy identities are deterministic across equivalent reruns;
+- runtime tests verify direct seek, sequential forward playback, and rewind at pre-start, start, midpoint, and end;
+- runtime tests verify the source remains present, the copy is visible only during the interval, and the target appears exactly at the end;
+- renderer incremental preparation verifies visible instance IDs across all lifecycle phases;
+- compiler tests reject discontinuous presence chains before runtime playback;
+- patch tests reject add/remove operations that would break a presence chain without mutating the previously valid compiled tracks.
 
 ## Follow-up
 
-After this bounded contract is green, lifecycle composition can be generalized: repeated copy transforms, chained replacements, evaluated target snapshots, and eventually matching-shape Transform variants can build on the same stable-ID/presence machinery.
+The next useful lifecycle work is to generalize composition without weakening determinism: repeated copy transforms, chained replacements, evaluated source/target snapshots, and matching-shape Transform variants can build on the same stable-ID/presence machinery. Generated lifecycle operations should also become fully transactional at the authoring layer so any late validation error leaves the `Scene` unchanged.

--- a/web/python/noon.py
+++ b/web/python/noon.py
@@ -279,6 +279,15 @@ class ReplacementTransform:
     key: str | None = None
 
 
+@dataclass(frozen=True, slots=True)
+class TransformFromCopy:
+    """Transform a transient copy of source into target while source remains."""
+
+    source: Object
+    target: Object
+    key: str | None = None
+
+
 class Scene:
     """Complete, versioned Noon scene document."""
 
@@ -425,7 +434,7 @@ class Scene:
 
     def play(
         self,
-        *animations: Transform | ReplacementTransform,
+        *animations: Transform | ReplacementTransform | TransformFromCopy,
         duration: float,
         start_time: float = 0.0,
         easing: str = "linear",
@@ -433,7 +442,14 @@ class Scene:
         if not animations:
             raise ValueError("play requires at least one animation")
         for animation in animations:
-            if isinstance(animation, ReplacementTransform):
+            if isinstance(animation, TransformFromCopy):
+                self._schedule_transform_from_copy(
+                    animation,
+                    duration=duration,
+                    start_time=start_time,
+                    easing=easing,
+                )
+            elif isinstance(animation, ReplacementTransform):
                 self._schedule_replacement_transform(
                     animation,
                     duration=duration,
@@ -449,7 +465,7 @@ class Scene:
                 )
             else:
                 raise TypeError(
-                    "unsupported animation; expected Transform or ReplacementTransform"
+                    "unsupported animation; expected Transform, ReplacementTransform, or TransformFromCopy"
                 )
         return self
 
@@ -500,6 +516,32 @@ class Scene:
         self._scheduled_transform_targets[obj.id] = copy.deepcopy(target_snapshot)
         self._scheduled_transform_ends[obj.id] = start + run_duration
 
+    def _validate_lifecycle_target(
+        self,
+        target: Object,
+        *,
+        start: float,
+        end: float,
+        label: str,
+    ) -> dict[str, Any]:
+        target_previous_end = self._scheduled_transform_ends.get(target.id)
+        if target_previous_end is not None and start < target_previous_end:
+            raise ValueError(f"{label} target has an overlapping Transform track")
+        if any(
+            track["object"] == target.id
+            and track["property"] != "transform"
+            and track["timing"]["start_time"] <= end
+            for track in self._tracks
+        ):
+            raise ValueError(
+                f"{label} target has property state not represented by its Transform snapshot"
+            )
+        return copy.deepcopy(
+            self._scheduled_transform_targets.get(
+                target.id, self._snapshot_for_object(target)
+            )
+        )
+
     def _schedule_replacement_transform(
         self,
         animation: ReplacementTransform,
@@ -522,22 +564,8 @@ class Scene:
         start = _finite_number("start_time", start_time)
         run_duration = _positive_number("duration", duration)
         end = start + run_duration
-        target_previous_end = self._scheduled_transform_ends.get(target.id)
-        if target_previous_end is not None and start < target_previous_end:
-            raise ValueError("replacement target has an overlapping Transform track")
-        if any(
-            track["object"] == target.id
-            and track["property"] != "transform"
-            and track["timing"]["start_time"] <= end
-            for track in self._tracks
-        ):
-            raise ValueError(
-                "replacement target has property state not represented by its Transform snapshot"
-            )
-        target_snapshot = copy.deepcopy(
-            self._scheduled_transform_targets.get(
-                target.id, self._snapshot_for_object(target)
-            )
+        target_snapshot = self._validate_lifecycle_target(
+            target, start=start, end=end, label="replacement"
         )
         detached_target = Mobject(
             geometry=target_snapshot["geometry"],
@@ -555,9 +583,118 @@ class Scene:
         self._add_presence_track(target, False, True, end)
         self._lifecycle_objects.update((source.id, target.id))
 
-    def _add_presence_track(
-        self, obj: Object, from_: bool, to: bool, time: float
+    def _schedule_transform_from_copy(
+        self,
+        animation: TransformFromCopy,
+        *,
+        duration: float,
+        start_time: float,
+        easing: str,
     ) -> None:
+        source = animation.source
+        target = animation.target
+        if not isinstance(source, Object) or source._owner is not self._owner:
+            raise ValueError("copy source must belong to this Scene")
+        if not isinstance(target, Object) or target._owner is not self._owner:
+            raise ValueError("copy target must belong to this Scene")
+        if source.id == target.id:
+            raise ValueError("copy source and target must be different objects")
+        if source.id in self._lifecycle_objects or target.id in self._lifecycle_objects:
+            raise ValueError("an object may participate in only one lifecycle animation")
+
+        start = _finite_number("start_time", start_time)
+        run_duration = _positive_number("duration", duration)
+        end = start + run_duration
+
+        source_previous_end = self._scheduled_transform_ends.get(source.id)
+        if source_previous_end is not None and start < source_previous_end:
+            raise ValueError("copy source has an overlapping Transform track")
+        if any(
+            track["object"] == source.id
+            and track["property"] != "transform"
+            and track["timing"]["start_time"] <= start
+            for track in self._tracks
+        ):
+            raise ValueError(
+                "copy source has property state not represented by its snapshot"
+            )
+
+        source_snapshot = copy.deepcopy(
+            self._scheduled_transform_targets.get(
+                source.id, self._snapshot_for_object(source)
+            )
+        )
+        target_snapshot = self._validate_lifecycle_target(
+            target, start=start, end=end, label="copy"
+        )
+
+        source_key = self._object_keys[source.id]
+        target_key = self._object_keys[target.id]
+        copy_key = (
+            f"{animation.key}.copy"
+            if animation.key is not None
+            else f"@copy:{source_key}->{target_key}"
+        )
+        copy_object = self._append_snapshot(source_snapshot, copy_key)
+        transform_key = (
+            animation.key if animation.key is not None else f"{copy_key}.transform"
+        )
+        detached_target = Mobject(
+            geometry=target_snapshot["geometry"],
+            transform=target_snapshot["transform"],
+            style=target_snapshot["style"],
+        )
+        self._schedule_transform(
+            Transform(copy_object, detached_target, key=transform_key),
+            duration=run_duration,
+            start_time=start,
+            easing=easing,
+        )
+
+        self._add_presence_track(
+            copy_object,
+            False,
+            True,
+            start,
+            key=f"{copy_key}.show",
+        )
+        self._add_presence_track(
+            copy_object,
+            True,
+            False,
+            end,
+            key=f"{copy_key}.hide",
+        )
+        self._add_presence_track(
+            target,
+            False,
+            True,
+            end,
+            key=f"{copy_key}.target-show",
+        )
+        self._lifecycle_objects.update((source.id, target.id, copy_object.id))
+
+    def _add_presence_track(
+        self,
+        obj: Object,
+        from_: bool,
+        to: bool,
+        time: float,
+        *,
+        key: str | None = None,
+    ) -> None:
+        existing = [
+            track
+            for track in self._tracks
+            if track["object"] == obj.id and track["property"] == "presence"
+        ]
+        if existing:
+            previous = existing[-1]
+            previous_time = previous["timing"]["start_time"]
+            if time < previous_time:
+                raise ValueError("presence events must be scheduled in chronological order")
+            if previous["values"]["bool"]["to"] is not from_:
+                raise ValueError("presence event chain must be continuous")
         self._add_track(
             obj,
             "presence",
@@ -565,7 +702,7 @@ class Scene:
             time,
             0.0,
             "linear",
-            None,
+            key,
         )
 
     def animate_position(

--- a/web/python/test_lifecycle.py
+++ b/web/python/test_lifecycle.py
@@ -1,6 +1,13 @@
 import unittest
 
-from noon import Circle, Color, ReplacementTransform, Scene, Transform
+from noon import (
+    Circle,
+    Color,
+    ReplacementTransform,
+    Scene,
+    Transform,
+    TransformFromCopy,
+)
 
 
 class ReplacementTransformTests(unittest.TestCase):
@@ -112,6 +119,201 @@ class ReplacementTransformTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             scene.play(
                 ReplacementTransform(source, target),
+                duration=1.0,
+                start_time=1.0,
+            )
+
+
+class TransformFromCopyTests(unittest.TestCase):
+    def _build_scene(self) -> Scene:
+        scene = Scene()
+        source = scene.circle(
+            1.0,
+            position=(-2.0, 0.0),
+            fill=Color(0.9, 0.2, 0.2),
+            key="source",
+        )
+        target = scene.circle(
+            3.0,
+            position=(4.0, -2.0),
+            fill=Color(0.2, 0.5, 0.9),
+            key="target",
+        )
+        scene.play(
+            TransformFromCopy(source, target, key="copy-to-target"),
+            duration=2.0,
+            start_time=1.0,
+            easing="ease_in_out_cubic",
+        )
+        return scene
+
+    def test_transform_from_copy_lowers_to_stable_copy_and_presence_window(self) -> None:
+        scene = self._build_scene()
+        document = scene.to_document()
+
+        self.assertEqual([obj["id"] for obj in document["objects"]], [0, 1, 2])
+        self.assertEqual(
+            [track["property"] for track in document["tracks"]],
+            ["transform", "presence", "presence", "presence"],
+        )
+
+        source_snapshot = {
+            key: value for key, value in document["objects"][0].items() if key != "id"
+        }
+        target_snapshot = {
+            key: value for key, value in document["objects"][1].items() if key != "id"
+        }
+        copy_snapshot = {
+            key: value for key, value in document["objects"][2].items() if key != "id"
+        }
+        self.assertEqual(copy_snapshot, source_snapshot)
+
+        transform, copy_show, copy_hide, target_show = document["tracks"]
+        self.assertEqual(transform["object"], 2)
+        self.assertEqual(transform["values"]["object"]["from"], source_snapshot)
+        self.assertEqual(transform["values"]["object"]["to"], target_snapshot)
+        self.assertEqual(
+            transform["timing"],
+            {
+                "start_time": 1.0,
+                "duration": 2.0,
+                "easing": "ease_in_out_cubic",
+            },
+        )
+
+        self.assertEqual(copy_show["object"], 2)
+        self.assertEqual(copy_show["values"]["bool"], {"from": False, "to": True})
+        self.assertEqual(copy_show["timing"]["start_time"], 1.0)
+        self.assertEqual(copy_show["timing"]["duration"], 0.0)
+
+        self.assertEqual(copy_hide["object"], 2)
+        self.assertEqual(copy_hide["values"]["bool"], {"from": True, "to": False})
+        self.assertEqual(copy_hide["timing"]["start_time"], 3.0)
+        self.assertEqual(copy_hide["timing"]["duration"], 0.0)
+
+        self.assertEqual(target_show["object"], 1)
+        self.assertEqual(target_show["values"]["bool"], {"from": False, "to": True})
+        self.assertEqual(target_show["timing"]["start_time"], 3.0)
+        self.assertEqual(target_show["timing"]["duration"], 0.0)
+
+        identities = scene.identity_document()
+        self.assertEqual(
+            identities["objects"],
+            [
+                {"id": 0, "key": "source"},
+                {"id": 1, "key": "target"},
+                {"id": 2, "key": "copy-to-target.copy"},
+            ],
+        )
+        self.assertEqual(
+            identities["tracks"],
+            [
+                {"id": 0, "key": "copy-to-target"},
+                {"id": 1, "key": "copy-to-target.copy.show"},
+                {"id": 2, "key": "copy-to-target.copy.hide"},
+                {"id": 3, "key": "copy-to-target.copy.target-show"},
+            ],
+        )
+
+    def test_transform_from_copy_identity_is_deterministic_across_reruns(self) -> None:
+        self.assertEqual(
+            self._build_scene().identity_document(),
+            self._build_scene().identity_document(),
+        )
+
+    def test_transform_from_copy_default_identity_is_deterministic(self) -> None:
+        def build() -> Scene:
+            scene = Scene()
+            source = scene.circle(1.0, key="source")
+            target = scene.circle(2.0, key="target")
+            scene.play(TransformFromCopy(source, target), duration=1.0)
+            return scene
+
+        identities = build().identity_document()
+        self.assertEqual(identities, build().identity_document())
+        self.assertEqual(identities["objects"][2]["key"], "@copy:source->target")
+        self.assertEqual(
+            [track["key"] for track in identities["tracks"]],
+            [
+                "@copy:source->target.transform",
+                "@copy:source->target.show",
+                "@copy:source->target.hide",
+                "@copy:source->target.target-show",
+            ],
+        )
+
+    def test_transform_from_copy_rejects_foreign_self_and_reused_objects(self) -> None:
+        scene = Scene()
+        source = scene.circle(1.0)
+        target = scene.circle(2.0)
+        foreign = Scene().circle(3.0)
+
+        with self.assertRaises(ValueError):
+            scene.play(TransformFromCopy(source, foreign), duration=1.0)
+        with self.assertRaises(ValueError):
+            scene.play(TransformFromCopy(source, source), duration=1.0)
+
+        scene.play(TransformFromCopy(source, target), duration=1.0)
+        third = scene.circle(4.0)
+        with self.assertRaises(ValueError):
+            scene.play(TransformFromCopy(source, third), duration=1.0, start_time=2.0)
+        with self.assertRaises(ValueError):
+            scene.play(TransformFromCopy(target, third), duration=1.0, start_time=2.0)
+
+    def test_transform_from_copy_rejects_ambiguous_source_or_target_state(self) -> None:
+        source_scene = Scene()
+        source = source_scene.circle(1.0)
+        target = source_scene.circle(2.0)
+        source_scene.animate_position(
+            source,
+            (0.0, 0.0),
+            (1.0, 0.0),
+            duration=1.0,
+            start_time=0.0,
+        )
+        with self.assertRaises(ValueError):
+            source_scene.play(
+                TransformFromCopy(source, target),
+                duration=1.0,
+                start_time=1.0,
+            )
+
+        target_scene = Scene()
+        source = target_scene.circle(1.0)
+        target = target_scene.circle(2.0)
+        target_scene.animate_opacity(
+            target,
+            1.0,
+            0.5,
+            duration=1.0,
+            start_time=2.0,
+        )
+        with self.assertRaises(ValueError):
+            target_scene.play(
+                TransformFromCopy(source, target),
+                duration=1.0,
+                start_time=1.0,
+            )
+
+    def test_transform_from_copy_rejects_overlapping_source_or_target_transform(self) -> None:
+        source_scene = Scene()
+        source = source_scene.circle(1.0)
+        target = source_scene.circle(2.0)
+        source_scene.play(Transform(source, Circle(1.5)), duration=3.0)
+        with self.assertRaises(ValueError):
+            source_scene.play(
+                TransformFromCopy(source, target),
+                duration=1.0,
+                start_time=1.0,
+            )
+
+        target_scene = Scene()
+        source = target_scene.circle(1.0)
+        target = target_scene.circle(2.0)
+        target_scene.play(Transform(target, Circle(2.5)), duration=3.0)
+        with self.assertRaises(ValueError):
+            target_scene.play(
+                TransformFromCopy(source, target),
                 duration=1.0,
                 start_time=1.0,
             )


### PR DESCRIPTION
## Scope

Continue Noon's Transform lifecycle work after #9 with a bounded first-class `TransformFromCopy` authoring primitive built on stable IDs and explicit `Presence` events.

Implemented contract:

- the original source remains present throughout;
- a dedicated stable transient copy carries the generic Transform from the source snapshot to the target snapshot;
- the transient copy is absent before the animation, present only for the transform interval, then absent again;
- the target is absent before the handoff and becomes present at the exact end time;
- no playback-time object creation/deletion is required;
- transient object and generated track identities are deterministic across equivalent Python reruns;
- ambiguous source/target composition is rejected rather than assigned implicit precedence;
- adjacent Presence events must be continuous (`previous.to == next.from`) in both full compilation and live patches.

Validation added:

- Python lowering and deterministic identity tests;
- runtime pre-start/start/mid/end, direct-seek/forward/rewind parity tests;
- renderer visible-instance lifecycle tests;
- compiler presence-chain rejection tests;
- transactional add/remove live-patch rejection tests for broken presence chains.

See `docs/transform-from-copy.md` for the completed bounded contract and follow-up work.