### PR TITLE
Make Scene.play authoring transactional

### DIFF
--- a/docs/transactional-authoring.md
+++ b/docs/transactional-authoring.md
@@ -10,20 +10,25 @@ The same rule applies to `Scene.play(a, b, ...)`: animations passed in one play 
 
 `Scene.play(...)` is atomic with respect to authoring state.
 
-Before scheduling the batch, Noon checkpoints:
+Before scheduling the batch, Noon records lightweight rollback state:
 
-- semantic objects and tracks;
-- stable object and track authoring identities;
+- the append boundaries for semantic objects and tracks;
 - scheduled generic-Transform target snapshots and end times;
 - lifecycle participation state.
 
-If any animation raises during validation or lowering, Noon restores that checkpoint and re-raises the original error. Existing scene state from before the play call is preserved exactly.
+Object and track identity entries are append-only and use the same dense IDs, so rollback prunes entries created beyond the saved append boundaries. Existing objects/tracks do not need to be deep-copied.
+
+If any animation raises during validation or lowering, Noon restores the checkpoint and re-raises the original error. Existing scene state from before the play call is preserved exactly.
 
 This includes failures caused by duplicate keys, invalid easing/timing, unsupported animation values, lifecycle conflicts, and failures that occur after a transient lifecycle object has already been authored.
 
 ## Identity guarantee
 
 Rollback also restores ID allocation state because object and track IDs derive from the current list lengths. A failed authoring attempt therefore cannot create ID gaps or change deterministic authoring identities on a subsequent valid rerun.
+
+## Cost model
+
+The transaction boundary does not copy the full scene. Creating a checkpoint is proportional to scheduler/lifecycle bookkeeping, while object and track rollback is proportional only to state appended by the failed `play()` call. This avoids turning repeated Python authoring calls into full-scene copies.
 
 ## Validation
 

--- a/docs/transactional-authoring.md
+++ b/docs/transactional-authoring.md
@@ -1,0 +1,37 @@
+# Transactional authoring semantics
+
+## Motivation
+
+High-level authoring operations can lower to several semantic objects and tracks. `TransformFromCopy`, for example, creates a stable transient object and then adds a Transform plus three Presence events. A validation failure late in that lowering must not leave an incomplete scene behind.
+
+The same rule applies to `Scene.play(a, b, ...)`: animations passed in one play call represent one authoring operation. If a later animation fails, earlier animations from that call must not remain scheduled.
+
+## Contract
+
+`Scene.play(...)` is atomic with respect to authoring state.
+
+Before scheduling the batch, Noon checkpoints:
+
+- semantic objects and tracks;
+- stable object and track authoring identities;
+- scheduled generic-Transform target snapshots and end times;
+- lifecycle participation state.
+
+If any animation raises during validation or lowering, Noon restores that checkpoint and re-raises the original error. Existing scene state from before the play call is preserved exactly.
+
+This includes failures caused by duplicate keys, invalid easing/timing, unsupported animation values, lifecycle conflicts, and failures that occur after a transient lifecycle object has already been authored.
+
+## Identity guarantee
+
+Rollback also restores ID allocation state because object and track IDs derive from the current list lengths. A failed authoring attempt therefore cannot create ID gaps or change deterministic authoring identities on a subsequent valid rerun.
+
+## Validation
+
+Regression tests cover two important cases:
+
+1. a `TransformFromCopy` that creates its transient copy and then hits a duplicate Transform key; the object, tracks, identity maps, and ID allocation all roll back;
+2. a multi-animation `Scene.play` where the first Transform succeeds and the second fails on a duplicate key; the first track and its scheduled target snapshot are rolled back, so a later Transform still starts from the original object snapshot.
+
+## Scope
+
+This transaction boundary intentionally sits at the public high-level `Scene.play` API. Lower-level single-track authoring helpers already validate before mutating their track lists. Future compound authoring APIs should either lower through `Scene.play` or adopt the same checkpoint/rollback rule.

--- a/web/python/noon.py
+++ b/web/python/noon.py
@@ -441,33 +441,60 @@ class Scene:
     ) -> Scene:
         if not animations:
             raise ValueError("play requires at least one animation")
-        for animation in animations:
-            if isinstance(animation, TransformFromCopy):
-                self._schedule_transform_from_copy(
-                    animation,
-                    duration=duration,
-                    start_time=start_time,
-                    easing=easing,
-                )
-            elif isinstance(animation, ReplacementTransform):
-                self._schedule_replacement_transform(
-                    animation,
-                    duration=duration,
-                    start_time=start_time,
-                    easing=easing,
-                )
-            elif isinstance(animation, Transform):
-                self._schedule_transform(
-                    animation,
-                    duration=duration,
-                    start_time=start_time,
-                    easing=easing,
-                )
-            else:
-                raise TypeError(
-                    "unsupported animation; expected Transform, ReplacementTransform, or TransformFromCopy"
-                )
+        checkpoint = self._authoring_checkpoint()
+        try:
+            for animation in animations:
+                if isinstance(animation, TransformFromCopy):
+                    self._schedule_transform_from_copy(
+                        animation,
+                        duration=duration,
+                        start_time=start_time,
+                        easing=easing,
+                    )
+                elif isinstance(animation, ReplacementTransform):
+                    self._schedule_replacement_transform(
+                        animation,
+                        duration=duration,
+                        start_time=start_time,
+                        easing=easing,
+                    )
+                elif isinstance(animation, Transform):
+                    self._schedule_transform(
+                        animation,
+                        duration=duration,
+                        start_time=start_time,
+                        easing=easing,
+                    )
+                else:
+                    raise TypeError(
+                        "unsupported animation; expected Transform, ReplacementTransform, or TransformFromCopy"
+                    )
+        except Exception:
+            self._restore_authoring_checkpoint(checkpoint)
+            raise
         return self
+
+    def _authoring_checkpoint(self) -> tuple[Any, ...]:
+        return (
+            copy.deepcopy(self._objects),
+            copy.deepcopy(self._tracks),
+            dict(self._object_keys),
+            dict(self._track_keys),
+            copy.deepcopy(self._scheduled_transform_targets),
+            dict(self._scheduled_transform_ends),
+            set(self._lifecycle_objects),
+        )
+
+    def _restore_authoring_checkpoint(self, checkpoint: tuple[Any, ...]) -> None:
+        (
+            self._objects,
+            self._tracks,
+            self._object_keys,
+            self._track_keys,
+            self._scheduled_transform_targets,
+            self._scheduled_transform_ends,
+            self._lifecycle_objects,
+        ) = checkpoint
 
     def _schedule_transform(
         self,

--- a/web/python/noon.py
+++ b/web/python/noon.py
@@ -476,25 +476,30 @@ class Scene:
 
     def _authoring_checkpoint(self) -> tuple[Any, ...]:
         return (
-            copy.deepcopy(self._objects),
-            copy.deepcopy(self._tracks),
-            dict(self._object_keys),
-            dict(self._track_keys),
-            copy.deepcopy(self._scheduled_transform_targets),
+            len(self._objects),
+            len(self._tracks),
+            dict(self._scheduled_transform_targets),
             dict(self._scheduled_transform_ends),
             set(self._lifecycle_objects),
         )
 
     def _restore_authoring_checkpoint(self, checkpoint: tuple[Any, ...]) -> None:
         (
-            self._objects,
-            self._tracks,
-            self._object_keys,
-            self._track_keys,
-            self._scheduled_transform_targets,
-            self._scheduled_transform_ends,
-            self._lifecycle_objects,
+            object_count,
+            track_count,
+            scheduled_transform_targets,
+            scheduled_transform_ends,
+            lifecycle_objects,
         ) = checkpoint
+        for object_id in range(object_count, len(self._objects)):
+            self._object_keys.pop(object_id, None)
+        for track_id in range(track_count, len(self._tracks)):
+            self._track_keys.pop(track_id, None)
+        del self._objects[object_count:]
+        del self._tracks[track_count:]
+        self._scheduled_transform_targets = scheduled_transform_targets
+        self._scheduled_transform_ends = scheduled_transform_ends
+        self._lifecycle_objects = lifecycle_objects
 
     def _schedule_transform(
         self,

--- a/web/python/test_lifecycle.py
+++ b/web/python/test_lifecycle.py
@@ -319,5 +319,72 @@ class TransformFromCopyTests(unittest.TestCase):
             )
 
 
+class TransactionalPlayTests(unittest.TestCase):
+    def test_transform_from_copy_failure_rolls_back_transient_object_and_ids(self) -> None:
+        scene = Scene()
+        source = scene.circle(1.0, key="source")
+        target = scene.circle(2.0, key="target")
+        scene.animate_opacity(
+            source,
+            1.0,
+            0.5,
+            duration=1.0,
+            start_time=5.0,
+            key="copy-to-target",
+        )
+        before_document = scene.to_document()
+        before_identity = scene.identity_document()
+
+        with self.assertRaises(ValueError):
+            scene.play(
+                TransformFromCopy(source, target, key="copy-to-target"),
+                duration=1.0,
+            )
+
+        self.assertEqual(scene.to_document(), before_document)
+        self.assertEqual(scene.identity_document(), before_identity)
+
+        scene.play(
+            TransformFromCopy(source, target, key="valid-copy"),
+            duration=1.0,
+        )
+        identities = scene.identity_document()
+        self.assertEqual(identities["objects"][-1], {"id": 2, "key": "valid-copy.copy"})
+        self.assertEqual(identities["tracks"][1], {"id": 1, "key": "valid-copy"})
+
+    def test_multi_animation_play_rolls_back_tracks_and_scheduled_snapshots(self) -> None:
+        scene = Scene()
+        first = scene.circle(1.0, key="first")
+        second = scene.circle(1.5, key="second")
+        scene.animate_opacity(
+            second,
+            1.0,
+            0.5,
+            duration=1.0,
+            start_time=5.0,
+            key="taken",
+        )
+        before_document = scene.to_document()
+        before_identity = scene.identity_document()
+
+        with self.assertRaises(ValueError):
+            scene.play(
+                Transform(first, Circle(2.0), key="would-leak"),
+                Transform(second, Circle(3.0), key="taken"),
+                duration=1.0,
+            )
+
+        self.assertEqual(scene.to_document(), before_document)
+        self.assertEqual(scene.identity_document(), before_identity)
+
+        scene.play(Transform(first, Circle(4.0), key="after"), duration=1.0)
+        transform = scene.to_document()["tracks"][1]
+        self.assertEqual(
+            transform["values"]["object"]["from"]["geometry"],
+            {"circle": {"radius": 1.0}},
+        )
+        self.assertEqual(scene.identity_document()["tracks"][1]["key"], "after")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Scope

Make high-level Python authoring operations atomic so validation failures cannot leave partially lowered semantic state behind.

- checkpoint all mutable `Scene.play(...)` authoring state before lowering;
- restore objects, tracks, identity maps, scheduled Transform snapshots/end times, and lifecycle participation on any exception;
- make multi-animation `play()` batches all-or-nothing;
- preserve deterministic ID allocation after failed authoring attempts;
- add regression tests for a late `TransformFromCopy` key collision and for a later failure in a multi-animation batch;
- document the transaction boundary in `docs/transactional-authoring.md`.

This follows directly from the lifecycle composition work in #10.