### PR TITLE
Evaluate authoring snapshots at semantic time

### DIFF
--- a/docs/evaluated-authoring-snapshots.md
+++ b/docs/evaluated-authoring-snapshots.md
@@ -35,13 +35,15 @@ Until Transform progress itself becomes a first-class snapshot representation, N
 
 `ReplacementTransform` evaluates the target at the exact handoff time. `TransformFromCopy` evaluates the source at copy start and the target at handoff. This means Position, Rotation, and Opacity animation can compose naturally with lifecycle authoring instead of being rejected merely because those tracks already exist.
 
+There is one important asymmetry. `ReplacementTransform` runs the generic Transform on the original source object, so any source Position/Rotation/Opacity track that has started before the handoff would continue to override the replacement Transform at runtime. Noon therefore rejects such source tracks for `ReplacementTransform`; otherwise the source could approach a state different from the target and visibly jump at the presence handoff. A source narrow-property track that starts at or after the handoff is harmless because the source is already absent. `TransformFromCopy` does not have this restriction because the transient copy is a fresh object with no narrow-property tracks of its own.
+
 Lifecycle snapshots still reject channels that `ObjectSnapshot` does not encode, currently Presence, Reveal, and standalone Morph state. This is an explicit correctness boundary: the source/copy Transform endpoint must not claim to reproduce visual state it cannot carry.
 
 ## Generic Transform use
 
 Plain generic `Transform` also uses the evaluator for its `from` snapshot. This fixes continuity when a Transform begins after or during a narrow Position/Rotation/Opacity track. `Transform(source, VectorPath(...))` therefore preserves the actually evaluated transform/style state at its start while replacing only geometry.
 
-Narrow-property runtime precedence remains unchanged: Position, Rotation, and Opacity groups are applied after generic Transform, so tracks that remain active after Transform start continue to override those channels during playback.
+Narrow-property runtime precedence remains unchanged: Position, Rotation, and Opacity groups are applied after generic Transform, so tracks that remain active after Transform start continue to override those channels during playback. That precedence is valid for ordinary Transform composition; lifecycle handoffs impose the stricter source rule above because they require the disappearing source and appearing target to agree exactly at the boundary.
 
 ## Validation
 
@@ -53,4 +55,5 @@ Python regression coverage verifies:
 - completed generic Transform target state is available to later lifecycle handoffs;
 - a copy operation can occur before an already-authored future Transform on its source;
 - active generic Transform snapshots are rejected transactionally;
-- lifecycle state outside `ObjectSnapshot`, such as Reveal, is rejected transactionally.
+- lifecycle state outside `ObjectSnapshot`, such as Reveal, is rejected transactionally;
+- `ReplacementTransform` rejects source narrow-property overrides before handoff but allows tracks that begin after the source has disappeared.

--- a/docs/evaluated-authoring-snapshots.md
+++ b/docs/evaluated-authoring-snapshots.md
@@ -1,0 +1,56 @@
+# Evaluated authoring snapshots
+
+## Motivation
+
+A generic `Transform` stores explicit `from` and `to` `ObjectSnapshot` values. Those snapshots must match the semantic object state at the time the Transform begins or a lifecycle handoff occurs.
+
+Using only the object's base definition or the last scheduled generic-Transform target is insufficient once ordinary narrow-property tracks exist. For example, if Position is halfway from `(0, 0)` to `(4, 0)` at `t=2`, a Transform beginning at `t=2` must start from `(2, 0)`, not the original `(0, 0)`.
+
+## Authoring-time evaluator
+
+Python authoring now evaluates the snapshot-representable portion of an object's timeline at a requested time.
+
+Evaluation mirrors the runtime grouping rules:
+
+1. start from the object's base semantic snapshot;
+2. select the latest-started generic Transform at or before the requested time;
+3. if that Transform is complete, use its exact target snapshot; if it is still active, reject the snapshot request;
+4. apply the latest-started Position track at or before the time;
+5. apply the latest-started Rotation track;
+6. apply the latest-started Opacity track.
+
+Narrow tracks use the same clamped normalized progress and easing equations as runtime playback, including `ease_in_out_cubic`. When two tracks for the same property have started, the later start wins; track ID breaks equal-time ties, matching compiled runtime ordering.
+
+The evaluator deliberately does not attempt to replay frames. It computes the state directly at the requested time, preserving deterministic direct-seek semantics.
+
+## Why active generic Transform is still bounded
+
+An in-progress generic Transform cannot always be represented by a single semantic `ObjectSnapshot`.
+
+Analytic primitive geometry could be sampled directly, but a vector-path Transform may use a compiler-prepared fixed-topology pair whose visible intermediate geometry is renderer preparation state rather than semantic endpoint geometry. Pretending that an arbitrary active path Transform has one exact `ObjectSnapshot` would therefore make Python authoring disagree with runtime/rendering semantics.
+
+Until Transform progress itself becomes a first-class snapshot representation, Noon rejects authoring snapshots taken inside an active generic Transform. Exact completed endpoints are supported.
+
+## Lifecycle use
+
+`ReplacementTransform` evaluates the target at the exact handoff time. `TransformFromCopy` evaluates the source at copy start and the target at handoff. This means Position, Rotation, and Opacity animation can compose naturally with lifecycle authoring instead of being rejected merely because those tracks already exist.
+
+Lifecycle snapshots still reject channels that `ObjectSnapshot` does not encode, currently Presence, Reveal, and standalone Morph state. This is an explicit correctness boundary: the source/copy Transform endpoint must not claim to reproduce visual state it cannot carry.
+
+## Generic Transform use
+
+Plain generic `Transform` also uses the evaluator for its `from` snapshot. This fixes continuity when a Transform begins after or during a narrow Position/Rotation/Opacity track. `Transform(source, VectorPath(...))` therefore preserves the actually evaluated transform/style state at its start while replacing only geometry.
+
+Narrow-property runtime precedence remains unchanged: Position, Rotation, and Opacity groups are applied after generic Transform, so tracks that remain active after Transform start continue to override those channels during playback.
+
+## Validation
+
+Python regression coverage verifies:
+
+- Position, Rotation, and Opacity are sampled into a Transform `from` snapshot;
+- cubic easing matches expected midpoint state;
+- the latest-started narrow track wins when narrow tracks overlap;
+- completed generic Transform target state is available to later lifecycle handoffs;
+- a copy operation can occur before an already-authored future Transform on its source;
+- active generic Transform snapshots are rejected transactionally;
+- lifecycle state outside `ObjectSnapshot`, such as Reveal, is rejected transactionally.

--- a/docs/generic-transform.md
+++ b/docs/generic-transform.md
@@ -67,7 +67,7 @@ Round join/cap remain the default. Rust/IR deserialization uses serde defaults f
 
 `Transform(source, VectorPath(...))` remains a convenience form. It snapshots the current/source transform and style and replaces only the target geometry.
 
-Targets are copied when scheduled. Later mutation of a detached target does not change an already-authored Transform. Sequential Transforms on one Python object chain snapshots: the previous target becomes the next source snapshot. Overlapping generic Transforms for the same object are currently rejected because precedence between two whole-object snapshots would otherwise be ambiguous.
+Targets are copied when scheduled. Later mutation of a detached target does not change an already-authored Transform. Sequential Transforms on one Python object chain snapshots, and the source snapshot is evaluated at the Transform start so prior/current Position, Rotation, and Opacity tracks are reflected using the same interpolation and precedence rules as runtime playback. Overlapping generic Transforms for the same object are currently rejected because precedence between two whole-object snapshots would otherwise be ambiguous. See [evaluated-authoring-snapshots.md](evaluated-authoring-snapshots.md) for the authoring-time evaluation contract.
 
 The playground includes stroke path, filled path, and analytic primitive Transform examples.
 
@@ -159,6 +159,12 @@ Transform/style interpolation is deterministic under direct seek and forward pla
 
 Path Transform progress and path reveal remain independent. Filled path runtime coverage also verifies direct-seek/forward parity, interpolated fill/style/transform state, exact semantic endpoints, and the detached prepared render pair.
 
+## Lifecycle composition
+
+`ReplacementTransform` and `TransformFromCopy` are implemented on top of the same generic Transform contract plus explicit zero-duration `Presence` events; they do not require renderer-specific object insertion or deletion. Stable object identities remain in the semantic scene while presence determines whether they produce render instances.
+
+Lifecycle source/target snapshots are evaluated at their semantic start/handoff times when the state can be represented exactly by `ObjectSnapshot`. Ambiguous active generic Transform state and non-snapshot lifecycle channels are rejected instead of silently approximated. `ReplacementTransform` also guards source-side narrow-property precedence so an override cannot create a discontinuous presence handoff. See [transform-lifecycle.md](transform-lifecycle.md) and [transform-from-copy.md](transform-from-copy.md).
+
 ## Performance contract
 
 For an active same-kind analytic Transform:
@@ -186,23 +192,25 @@ The runtime only clones semantic or prepared path geometry when the selected geo
 
 Coverage is intentionally split across independent layers:
 
-- Python: detached targets, snapshot-by-value behavior, stable source identity, multiple/sequential Transforms, overlap rejection, VectorPath convenience syntax, analytic targets, stroke join/cap serialization, and execution of the filled-path playground example;
+- Python: detached targets, evaluated source snapshots, snapshot-by-value behavior, stable source identity, multiple/sequential Transforms, overlap rejection, lifecycle lowering/rollback, VectorPath convenience syntax, analytic targets, stroke join/cap serialization, and execution of the filled-path playground example;
 - IR/core: object-snapshot Transform round trips and backward-compatible stroke-style defaults;
-- compiler: explicit geometry plans, safe filled-path acceptance, distinct `UnsafeFilledPathTransform` rejection, fill-presence rejection, stroke-width/join/cap safety boundaries, and unsupported cross-kind rejection;
+- compiler: explicit geometry plans, safe filled-path acceptance, distinct `UnsafeFilledPathTransform` rejection, fill-presence rejection, stroke-width/join/cap safety boundaries, unsupported cross-kind rejection, and Presence-chain continuity;
 - geometry/stroke: Lyon reference checks, cap/miter theory, contour-start/winding invariance, fixed topology, active-triangle winding, and all nine join/cap parity combinations;
 - geometry/fill: rounded-loop -> concave-star topology, fill-only meshes, fill+stroke meshes, self-intersection/open-contour rejection, static-Lyon endpoint area fidelity, and a regression where both endpoints are individually valid but a fan triangle would invert only inside the animation interval;
-- runtime: exact analytic/path endpoints, seek/forward parity, sequential continuity, precedence, reveal independence, path allocation stability, plus filled-path seek/forward parity and fill interpolation;
-- renderer: stroke/fill-aware cache identity, analytic instance-only dirty ranges, filled-path cold-geometry reuse, no steady retessellation, and path instance-only morph updates;
+- runtime: exact analytic/path endpoints, seek/forward parity, sequential continuity, precedence, reveal independence, lifecycle presence, path allocation stability, plus filled-path seek/forward parity and fill interpolation;
+- renderer: stroke/fill-aware cache identity, analytic instance-only dirty ranges, lifecycle presence topology, filled-path cold-geometry reuse, no steady retessellation, and path instance-only morph updates;
 - full CI: format, workspace compile, strict Clippy, stroke geometry suites, both filled-morph suites, all workspace tests, WebGPU wasm compile, browser-runtime wasm compile, and browser package validation.
 
 ## Current limitations / next work
 
-Completed Transform geometry support now includes:
+Completed Transform and lifecycle support now includes:
 
 - same-kind analytic `Circle`, `Rectangle`, and `Line` interpolation;
 - fixed-topology stroked vector-path Transform;
 - shared round/miter/bevel joins and round/butt/square caps;
-- bounded fixed-topology filled vector-path Transform for one continuously certifiable closed contour.
+- bounded fixed-topology filled vector-path Transform for one continuously certifiable closed contour;
+- first-class `ReplacementTransform` and `TransformFromCopy` lifecycle semantics with stable IDs and `Presence` events;
+- authoring-time Position/Rotation/Opacity snapshot evaluation and transactional compound lowering.
 
 Remaining limitations include:
 
@@ -211,6 +219,7 @@ Remaining limitations include:
 - cross-kind geometry interpolation;
 - path stroke-width interpolation across geometry-changing morphs;
 - changing join/cap topology during an active geometry-changing path Transform;
-- `ReplacementTransform`, `TransformFromCopy`, and matching-shape variants.
+- repeated/chained lifecycle composition beyond the current one-lifecycle-animation-per-object guard;
+- matching-shape Transform variants.
 
-The next Transform milestone should focus on lifecycle semantics: `ReplacementTransform` and `TransformFromCopy` first, then matching-shape correspondence. Those can build on the existing stable `ObjectId` plus detached `ObjectSnapshot` model without weakening the fixed-topology renderer contract.
+The next Transform/lifecycle milestone should make repeated lifecycle operations an explicit state machine, then add matching-shape correspondence on top of the existing stable-ID, evaluated-snapshot, and fixed-topology renderer contracts.

--- a/docs/transform-from-copy.md
+++ b/docs/transform-from-copy.md
@@ -4,9 +4,9 @@
 
 `TransformFromCopy` preserves the original source object while a distinct transient copy moves through Noon's existing generic Transform pipeline toward a stable target object. Object lifetime remains an explicit semantic concern expressed with `Presence`; playback does not create or destroy objects.
 
-This design builds directly on [transform-lifecycle.md](transform-lifecycle.md) and reuses the geometry/interpolation rules in [generic-transform.md](generic-transform.md).
+This design builds directly on [transform-lifecycle.md](transform-lifecycle.md), reuses the geometry/interpolation rules in [generic-transform.md](generic-transform.md), and samples timeline state according to [evaluated-authoring-snapshots.md](evaluated-authoring-snapshots.md).
 
-## Initial bounded contract
+## Contract
 
 The authoring form is:
 
@@ -24,7 +24,7 @@ The scene owns three stable identities:
 2. `target`: absent before the end-time handoff, visible afterward;
 3. an internally authored transient copy: absent before `start_time`, visible only during the transform interval, absent afterward.
 
-The transient copy is a snapshot of the source at scheduling time and receives a deterministic authoring identity so equivalent Python reruns map it back to the same stable runtime object.
+The transient copy is a snapshot of the source evaluated at copy start and receives a deterministic authoring identity so equivalent Python reruns map it back to the same stable runtime object.
 
 ## Lowering
 
@@ -32,12 +32,14 @@ One `TransformFromCopy` lowers to a normal generic Transform plus discrete lifec
 
 ```text
 Presence(copy):   false -> true   at start
-Transform(copy):  source snapshot -> target snapshot   over [start, end]
+Transform(copy):  evaluated source snapshot -> evaluated target snapshot   over [start, end]
 Presence(copy):   true -> false   at end
 Presence(target): false -> true   at end
 ```
 
 `source` receives no lifecycle event and therefore remains present. At the exact start time both source and copy are visible. At the exact end time the copy disappears and target appears. The copy and target never need playback-time insertion/removal.
+
+Position, Rotation, and Opacity are sampled from their latest-started tracks at the relevant snapshot time using runtime-equivalent interpolation and easing. Thus the copy visually starts from the source's actual snapshot-representable state, and the Transform destination agrees with the target at handoff.
 
 ## Presence-chain invariant
 
@@ -50,19 +52,23 @@ true  -> false
 
 Adjacent events for one object must agree (`previous.to == next.from`). Python authoring validates the chain as it is built. The Rust compiler independently validates sorted `Presence` tracks before runtime playback, and add/replace/remove-track live patches are validated transactionally before they replace the compiled track set. An inconsistent later `from` value is therefore rejected rather than silently ignored.
 
-## Initial safety boundaries
+## Safety boundaries
 
-The bounded implementation rejects ambiguous composition rather than synthesizing hidden precedence rules:
+The bounded implementation rejects composition that cannot yet be captured exactly:
 
 - source and target must be distinct objects owned by the same `Scene`;
 - source or target objects already participating in another lifecycle animation are rejected;
-- source generic Transform state overlapping the copy start is rejected;
-- target generic Transform state overlapping the copy interval is rejected;
-- source narrow-property state at or before copy start is rejected until source state can be evaluated into an exact snapshot;
-- target narrow-property state at or before handoff is rejected until target state can be evaluated into an exact snapshot;
+- a snapshot taken inside an active generic Transform is rejected;
+- lifecycle state outside `ObjectSnapshot` (`Presence`, `Reveal`, standalone `Morph`) is rejected when it is already active at the relevant snapshot time;
 - transient copy and generated track keys are deterministic and duplicate keys are rejected within one scene.
 
-Completed generic Transform tracks that end before the relevant snapshot time are supported: the scheduled Transform target snapshot is used as the source or target semantic snapshot.
+Completed generic Transform endpoints are supported. Future generic Transforms that have not started at the source-copy or target-handoff time do not contaminate the snapshot and can coexist with the lifecycle operation when their timeline ordering is otherwise valid.
+
+## Transactionality
+
+`Scene.play(...)` is transactional. If TransformFromCopy lowering fails after the transient copy has been allocated—for example because a generated track key collides—the entire play operation rolls back. Objects, tracks, identity allocation, scheduled Transform state, and lifecycle participation return to their exact pre-call state.
+
+See [transactional-authoring.md](transactional-authoring.md).
 
 ## Validation
 
@@ -70,12 +76,14 @@ The implementation is covered end to end:
 
 - Python lowering tests verify the stable transient copy and exact presence/Transform tracks;
 - explicit and generated transient-copy identities are deterministic across equivalent reruns;
+- evaluated source/target tests verify Position and Opacity state at copy start/handoff;
 - runtime tests verify direct seek, sequential forward playback, and rewind at pre-start, start, midpoint, and end;
 - runtime tests verify the source remains present, the copy is visible only during the interval, and the target appears exactly at the end;
 - renderer incremental preparation verifies visible instance IDs across all lifecycle phases;
 - compiler tests reject discontinuous presence chains before runtime playback;
-- patch tests reject add/remove operations that would break a presence chain without mutating the previously valid compiled tracks.
+- patch tests reject add/remove operations that would break a presence chain without mutating the previously valid compiled tracks;
+- transactional authoring tests verify failed compound lowering leaves no transient IDs or scheduled state behind.
 
 ## Follow-up
 
-The next useful lifecycle work is to generalize composition without weakening determinism: repeated copy transforms, chained replacements, evaluated source/target snapshots, and matching-shape Transform variants can build on the same stable-ID/presence machinery. Generated lifecycle operations should also become fully transactional at the authoring layer so any late validation error leaves the `Scene` unchanged.
+The next lifecycle step is explicit repeated/chained lifecycle composition. After that, matching-shape Transform variants can reuse stable IDs, evaluated snapshots, Presence chains, and the existing generic Transform renderer contract.

--- a/docs/transform-lifecycle.md
+++ b/docs/transform-lifecycle.md
@@ -4,7 +4,7 @@
 
 Noon models object lifetime independently from opacity. `Presence` is a first-class, renderer-independent boolean timeline property represented as a zero-duration event. This lets lifecycle animations preserve stable `ObjectId` values while arbitrary seek, forward playback, live reconciliation, and rendering all agree on whether an object exists in the visible scene at a given time.
 
-The first lifecycle animation built on this primitive is `ReplacementTransform`. The geometry/interpolation contract it reuses is documented in [generic-transform.md](generic-transform.md).
+The lifecycle animations built on this primitive are `ReplacementTransform` and `TransformFromCopy`. The geometry/interpolation contract they reuse is documented in [generic-transform.md](generic-transform.md), while authoring-time state evaluation is documented in [evaluated-authoring-snapshots.md](evaluated-authoring-snapshots.md).
 
 ## Presence contract
 
@@ -22,7 +22,7 @@ The first event's `from` value defines the object's pre-event presence state. On
 
 ## ReplacementTransform
 
-The initial authoring API is deliberately bounded:
+The authoring API is:
 
 ```python
 source = scene.circle(1.0, key="source")
@@ -37,22 +37,31 @@ Both `source` and `target` are stable scene-owned objects with distinct IDs. The
 
 The authoring frontend lowers one replacement into three normal language-neutral tracks:
 
-1. a generic `Transform` on the source from the source snapshot to the target snapshot;
+1. a generic `Transform` on the source from the source state evaluated at the transform start to the target state evaluated at the handoff time;
 2. `Presence(source, true -> false)` at the exact transform end time;
 3. `Presence(target, false -> true)` at the same time.
 
-Before the handoff, only the source renders. During the interval, the source identity carries the normal generic Transform interpolation. At the exact end time the source becomes absent and the target becomes present in its own exact semantic state. Neither object is created or destroyed during playback.
+Before the handoff, only the source renders. During the interval, the source identity carries the normal generic Transform interpolation. At the exact end time the source becomes absent and the target becomes present in the same Position/Rotation/Opacity state used as the Transform destination. Neither object is created or destroyed during playback.
 
 This contract makes direct seek and sequential playback equivalent. Seeking backward before the handoff restores source presence and hides the target without reconstructing identities or replaying authoring code.
 
+## Evaluated handoff state
+
+Python authoring evaluates snapshot-representable timeline state at the relevant lifecycle time instead of requiring the object to have no prior narrow-property animation.
+
+For `ReplacementTransform`, target `Position`, `Rotation`, and `Opacity` use their runtime-equivalent values at the exact handoff. Completed generic Transforms are also reflected in the snapshot. A generic Transform that is still active at the snapshot time remains rejected because an arbitrary in-progress path morph cannot be represented faithfully by one `ObjectSnapshot`.
+
+Channels that are independent of `ObjectSnapshot`, such as `Presence`, `Reveal`, and standalone `Morph` state, remain explicit safety boundaries for lifecycle snapshots. Noon rejects them rather than pretending the Transform endpoint captures state it does not encode.
+
 ## Current safety boundaries
 
-The first `ReplacementTransform` contract rejects cases whose handoff state would otherwise be ambiguous:
+Lifecycle composition remains deliberately bounded where exact semantics are not yet defined:
 
 - source and target must be different objects owned by the same `Scene`;
-- an object may participate in only one lifecycle replacement in this initial slice;
-- overlapping generic Transform state on the target is rejected;
-- target narrow-property state (`Position`, `Rotation`, `Opacity`, reveal/morph, etc.) at or before the handoff is rejected because it is not represented by the target object snapshot the source transforms toward.
+- an object may participate in only one lifecycle animation in the current composition model;
+- a lifecycle snapshot cannot be taken inside an active generic Transform;
+- lifecycle snapshot state that is not representable by `ObjectSnapshot` is rejected;
+- narrow `Position`, `Rotation`, and `Opacity` tracks are evaluated with the same latest-started-track precedence and easing rules as runtime playback.
 
 These are explicit authoring restrictions, not renderer fallbacks. Noon should not silently produce a discontinuous handoff.
 
@@ -62,11 +71,11 @@ Coverage spans the semantic pipeline:
 
 - core: zero-duration boolean presence validation and deterministic IDs;
 - IR: human-readable presence/bool JSON round trip;
-- compiler: presence dynamic classification and patch validation;
+- compiler: presence dynamic classification, chain continuity, and patch validation;
 - runtime: direct seek, forward playback, rewind, and live-patch presence parity;
 - renderer: absent objects keep semantic slots but create no GPU instances; toggling presence rebuilds the prepared slot layout;
-- Python: `ReplacementTransform` lowers to Transform plus the atomic two-object presence handoff, with foreign/self/reused/ambiguous targets rejected.
+- Python: lifecycle lowering, evaluated Position/Rotation/Opacity snapshots, deterministic transient-copy identity, transactional rollback, and rejection of active/unrepresentable snapshot state.
 
 ## Next work
 
-`TransformFromCopy` should reuse the same presence machinery without changing source identity: a dedicated copy object is present only for the animation interval, the original source remains visible, and the destination lifecycle is explicit. After that, lifecycle composition restrictions can be relaxed deliberately, with tests for chained replacements and matching-shape transforms rather than by weakening the current deterministic contract.
+The next lifecycle composition step is to support repeated/chained lifecycle operations with explicit state-machine semantics rather than the current one-lifecycle-animation-per-object guard. Matching-shape transforms can then build on the same evaluated snapshot and stable-identity machinery.

--- a/docs/transform-lifecycle.md
+++ b/docs/transform-lifecycle.md
@@ -47,9 +47,11 @@ This contract makes direct seek and sequential playback equivalent. Seeking back
 
 ## Evaluated handoff state
 
-Python authoring evaluates snapshot-representable timeline state at the relevant lifecycle time instead of requiring the object to have no prior narrow-property animation.
+Python authoring evaluates snapshot-representable timeline state at the relevant lifecycle time instead of requiring the target object to have no prior narrow-property animation.
 
 For `ReplacementTransform`, target `Position`, `Rotation`, and `Opacity` use their runtime-equivalent values at the exact handoff. Completed generic Transforms are also reflected in the snapshot. A generic Transform that is still active at the snapshot time remains rejected because an arbitrary in-progress path morph cannot be represented faithfully by one `ObjectSnapshot`.
+
+The source side is stricter. Runtime narrow-property groups override generic Transform channels. Therefore a source Position, Rotation, or Opacity track that starts before the handoff would continue overriding the replacement Transform and could make the disappearing source disagree with the appearing target. `ReplacementTransform` rejects those source tracks. Tracks that begin at or after handoff are allowed because the source is already absent. `TransformFromCopy` does not have this restriction because its moving transient copy has no pre-existing narrow tracks.
 
 Channels that are independent of `ObjectSnapshot`, such as `Presence`, `Reveal`, and standalone `Morph` state, remain explicit safety boundaries for lifecycle snapshots. Noon rejects them rather than pretending the Transform endpoint captures state it does not encode.
 
@@ -61,7 +63,8 @@ Lifecycle composition remains deliberately bounded where exact semantics are not
 - an object may participate in only one lifecycle animation in the current composition model;
 - a lifecycle snapshot cannot be taken inside an active generic Transform;
 - lifecycle snapshot state that is not representable by `ObjectSnapshot` is rejected;
-- narrow `Position`, `Rotation`, and `Opacity` tracks are evaluated with the same latest-started-track precedence and easing rules as runtime playback.
+- target and TransformFromCopy-source `Position`, `Rotation`, and `Opacity` tracks are evaluated with the same latest-started-track precedence and easing rules as runtime playback;
+- `ReplacementTransform` source narrow-property tracks that begin before handoff are rejected because they would override the replacement Transform.
 
 These are explicit authoring restrictions, not renderer fallbacks. Noon should not silently produce a discontinuous handoff.
 
@@ -74,7 +77,7 @@ Coverage spans the semantic pipeline:
 - compiler: presence dynamic classification, chain continuity, and patch validation;
 - runtime: direct seek, forward playback, rewind, and live-patch presence parity;
 - renderer: absent objects keep semantic slots but create no GPU instances; toggling presence rebuilds the prepared slot layout;
-- Python: lifecycle lowering, evaluated Position/Rotation/Opacity snapshots, deterministic transient-copy identity, transactional rollback, and rejection of active/unrepresentable snapshot state.
+- Python: lifecycle lowering, evaluated Position/Rotation/Opacity snapshots, deterministic transient-copy identity, transactional rollback, replacement-source precedence guards, and rejection of active/unrepresentable snapshot state.
 
 ## Next work
 

--- a/web/python/noon.py
+++ b/web/python/noon.py
@@ -602,6 +602,7 @@ class Scene:
         start = _finite_number("start_time", start_time)
         run_duration = _positive_number("duration", duration)
         end = start + run_duration
+        self._ensure_replacement_source_unoverridden(source, end)
         target_snapshot = self._validate_lifecycle_target(
             target, end=end, label="replacement"
         )
@@ -899,6 +900,23 @@ class Scene:
             properties = ", ".join(sorted(set(unsupported)))
             raise ValueError(
                 f"{label} has state not represented by ObjectSnapshot: {properties}"
+            )
+
+    def _ensure_replacement_source_unoverridden(
+        self, source: Object, end: float
+    ) -> None:
+        blocking = [
+            track["property"]
+            for track in self._tracks
+            if track["object"] == source.id
+            and track["property"] in {"position", "rotation", "opacity"}
+            and track["timing"]["start_time"] < end
+        ]
+        if blocking:
+            properties = ", ".join(sorted(set(blocking)))
+            raise ValueError(
+                "replacement source has narrow-property state that overrides "
+                f"Transform before handoff: {properties}"
             )
 
     def _append_snapshot(

--- a/web/python/noon.py
+++ b/web/python/noon.py
@@ -602,6 +602,7 @@ class Scene:
         start = _finite_number("start_time", start_time)
         run_duration = _positive_number("duration", duration)
         end = start + run_duration
+        self._ensure_snapshot_representable(source, end, "replacement source")
         self._ensure_replacement_source_unoverridden(source, end)
         target_snapshot = self._validate_lifecycle_target(
             target, end=end, label="replacement"

--- a/web/python/noon.py
+++ b/web/python/noon.py
@@ -81,6 +81,25 @@ def _authoring_key(name: str, value: str | None, fallback: str) -> str:
     return value
 
 
+def _track_progress(timing: dict[str, Any], time: float) -> float:
+    raw = max(
+        0.0,
+        min(1.0, (time - timing["start_time"]) / timing["duration"]),
+    )
+    easing = timing["easing"]
+    if easing == "linear":
+        return raw
+    if easing == "ease_in_out_cubic":
+        if raw < 0.5:
+            return 4.0 * raw * raw * raw
+        return 1.0 - ((-2.0 * raw + 2.0) ** 3) / 2.0
+    raise ValueError(f"unsupported easing: {easing}")
+
+
+def _lerp(from_: float, to: float, progress: float) -> float:
+    return from_ + (to - from_) * progress
+
+
 @dataclass(frozen=True, slots=True)
 class Color:
     red: float
@@ -520,9 +539,7 @@ class Scene:
         if previous_end is not None and start < previous_end:
             raise ValueError("generic Transform tracks for one object must not overlap")
 
-        source_snapshot = copy.deepcopy(
-            self._scheduled_transform_targets.get(obj.id, self._snapshot_for_object(obj))
-        )
+        source_snapshot = self._snapshot_for_object_at(obj, start)
         if isinstance(target, VectorPath):
             target_snapshot = copy.deepcopy(source_snapshot)
             target_snapshot["geometry"] = {"vector_path": target.to_ir()}
@@ -552,27 +569,16 @@ class Scene:
         self,
         target: Object,
         *,
-        start: float,
         end: float,
         label: str,
     ) -> dict[str, Any]:
-        target_previous_end = self._scheduled_transform_ends.get(target.id)
-        if target_previous_end is not None and start < target_previous_end:
-            raise ValueError(f"{label} target has an overlapping Transform track")
-        if any(
-            track["object"] == target.id
-            and track["property"] != "transform"
-            and track["timing"]["start_time"] <= end
-            for track in self._tracks
-        ):
+        self._ensure_snapshot_representable(target, end, f"{label} target")
+        try:
+            return self._snapshot_for_object_at(target, end)
+        except ValueError as error:
             raise ValueError(
-                f"{label} target has property state not represented by its Transform snapshot"
-            )
-        return copy.deepcopy(
-            self._scheduled_transform_targets.get(
-                target.id, self._snapshot_for_object(target)
-            )
-        )
+                f"{label} target cannot be snapshotted at handoff: {error}"
+            ) from error
 
     def _schedule_replacement_transform(
         self,
@@ -597,7 +603,7 @@ class Scene:
         run_duration = _positive_number("duration", duration)
         end = start + run_duration
         target_snapshot = self._validate_lifecycle_target(
-            target, start=start, end=end, label="replacement"
+            target, end=end, label="replacement"
         )
         detached_target = Mobject(
             geometry=target_snapshot["geometry"],
@@ -638,26 +644,13 @@ class Scene:
         run_duration = _positive_number("duration", duration)
         end = start + run_duration
 
-        source_previous_end = self._scheduled_transform_ends.get(source.id)
-        if source_previous_end is not None and start < source_previous_end:
-            raise ValueError("copy source has an overlapping Transform track")
-        if any(
-            track["object"] == source.id
-            and track["property"] != "transform"
-            and track["timing"]["start_time"] <= start
-            for track in self._tracks
-        ):
-            raise ValueError(
-                "copy source has property state not represented by its snapshot"
-            )
-
-        source_snapshot = copy.deepcopy(
-            self._scheduled_transform_targets.get(
-                source.id, self._snapshot_for_object(source)
-            )
-        )
+        self._ensure_snapshot_representable(source, start, "copy source")
+        try:
+            source_snapshot = self._snapshot_for_object_at(source, start)
+        except ValueError as error:
+            raise ValueError(f"copy source cannot be snapshotted: {error}") from error
         target_snapshot = self._validate_lifecycle_target(
-            target, start=start, end=end, label="copy"
+            target, end=end, label="copy"
         )
 
         source_key = self._object_keys[source.id]
@@ -838,6 +831,75 @@ class Scene:
             "transform": copy.deepcopy(stored["transform"]),
             "style": copy.deepcopy(stored["style"]),
         }
+
+    def _latest_track_at(
+        self, obj: Object, property_name: str, time: float
+    ) -> dict[str, Any] | None:
+        candidates = [
+            track
+            for track in self._tracks
+            if track["object"] == obj.id
+            and track["property"] == property_name
+            and track["timing"]["start_time"] <= time
+        ]
+        if not candidates:
+            return None
+        return max(
+            candidates,
+            key=lambda track: (track["timing"]["start_time"], track["id"]),
+        )
+
+    def _snapshot_for_object_at(self, obj: Object, time: float) -> dict[str, Any]:
+        snapshot = self._snapshot_for_object(obj)
+        transform_track = self._latest_track_at(obj, "transform", time)
+        if transform_track is not None:
+            timing = transform_track["timing"]
+            if time < timing["start_time"] + timing["duration"]:
+                raise ValueError("object is inside an active generic Transform")
+            snapshot = copy.deepcopy(transform_track["values"]["object"]["to"])
+
+        position_track = self._latest_track_at(obj, "position", time)
+        if position_track is not None:
+            progress = _track_progress(position_track["timing"], time)
+            values = position_track["values"]["vec2"]
+            snapshot["transform"]["translation"] = {
+                "x": _lerp(values["from"]["x"], values["to"]["x"], progress),
+                "y": _lerp(values["from"]["y"], values["to"]["y"], progress),
+            }
+
+        rotation_track = self._latest_track_at(obj, "rotation", time)
+        if rotation_track is not None:
+            progress = _track_progress(rotation_track["timing"], time)
+            values = rotation_track["values"]["scalar"]
+            snapshot["transform"]["rotation"] = _lerp(
+                values["from"], values["to"], progress
+            )
+
+        opacity_track = self._latest_track_at(obj, "opacity", time)
+        if opacity_track is not None:
+            progress = _track_progress(opacity_track["timing"], time)
+            values = opacity_track["values"]["scalar"]
+            snapshot["style"]["opacity"] = _lerp(
+                values["from"], values["to"], progress
+            )
+
+        return snapshot
+
+    def _ensure_snapshot_representable(
+        self, obj: Object, time: float, label: str
+    ) -> None:
+        unsupported = [
+            track["property"]
+            for track in self._tracks
+            if track["object"] == obj.id
+            and track["property"] in {"presence", "reveal", "morph"}
+            and track["timing"]["start_time"] <= time
+        ]
+        if unsupported:
+            properties = ", ".join(sorted(set(unsupported)))
+            raise ValueError(
+                f"{label} has state not represented by ObjectSnapshot: {properties}"
+            )
 
     def _append_snapshot(
         self, snapshot: dict[str, Any], key: str | None

--- a/web/python/test_authoring_snapshots.py
+++ b/web/python/test_authoring_snapshots.py
@@ -1,0 +1,159 @@
+import unittest
+
+from noon import Circle, ReplacementTransform, Scene, Transform, TransformFromCopy
+
+
+class EvaluatedAuthoringSnapshotTests(unittest.TestCase):
+    def test_transform_starts_from_evaluated_narrow_property_state(self) -> None:
+        scene = Scene()
+        source = scene.circle(1.0)
+        scene.animate_position(
+            source,
+            (0.0, 0.0),
+            (4.0, 2.0),
+            duration=4.0,
+            start_time=0.0,
+        )
+        scene.animate_rotation(
+            source,
+            0.0,
+            2.0,
+            duration=4.0,
+            start_time=0.0,
+            easing="ease_in_out_cubic",
+        )
+        scene.animate_opacity(
+            source,
+            1.0,
+            0.2,
+            duration=4.0,
+            start_time=0.0,
+        )
+
+        scene.play(
+            Transform(source, Circle(2.0)),
+            duration=1.0,
+            start_time=2.0,
+        )
+
+        transform = scene.to_document()["tracks"][-1]
+        snapshot = transform["values"]["object"]["from"]
+        self.assertEqual(snapshot["transform"]["translation"], {"x": 2.0, "y": 1.0})
+        self.assertEqual(snapshot["transform"]["rotation"], 1.0)
+        self.assertAlmostEqual(snapshot["style"]["opacity"], 0.6)
+
+    def test_latest_started_narrow_track_matches_runtime_precedence(self) -> None:
+        scene = Scene()
+        source = scene.circle(1.0)
+        scene.animate_position(
+            source,
+            (0.0, 0.0),
+            (10.0, 0.0),
+            duration=10.0,
+            start_time=0.0,
+        )
+        scene.animate_position(
+            source,
+            (100.0, 0.0),
+            (200.0, 0.0),
+            duration=2.0,
+            start_time=2.0,
+        )
+
+        scene.play(
+            Transform(source, Circle(2.0)),
+            duration=1.0,
+            start_time=3.0,
+        )
+
+        snapshot = scene.to_document()["tracks"][-1]["values"]["object"]["from"]
+        self.assertEqual(snapshot["transform"]["translation"], {"x": 150.0, "y": 0.0})
+
+    def test_lifecycle_target_can_use_completed_transform_state(self) -> None:
+        scene = Scene()
+        source = scene.circle(1.0)
+        target = scene.circle(2.0)
+        scene.play(
+            Transform(target, Circle(3.0, position=(4.0, -1.0))),
+            duration=1.0,
+            start_time=0.0,
+        )
+
+        scene.play(
+            ReplacementTransform(source, target),
+            duration=1.0,
+            start_time=2.0,
+        )
+
+        transforms = [
+            track
+            for track in scene.to_document()["tracks"]
+            if track["property"] == "transform"
+        ]
+        replacement = transforms[-1]
+        target_snapshot = replacement["values"]["object"]["to"]
+        self.assertEqual(target_snapshot["geometry"], {"circle": {"radius": 3.0}})
+        self.assertEqual(
+            target_snapshot["transform"]["translation"], {"x": 4.0, "y": -1.0}
+        )
+
+    def test_copy_can_precede_already_scheduled_future_source_transform(self) -> None:
+        scene = Scene()
+        source = scene.circle(1.0, position=(-1.0, 0.0))
+        target = scene.circle(2.0)
+        scene.play(
+            Transform(source, Circle(1.5, position=(5.0, 0.0))),
+            duration=1.0,
+            start_time=5.0,
+        )
+
+        scene.play(
+            TransformFromCopy(source, target),
+            duration=1.0,
+            start_time=1.0,
+        )
+
+        copy_snapshot = {
+            key: value
+            for key, value in scene.to_document()["objects"][2].items()
+            if key != "id"
+        }
+        self.assertEqual(
+            copy_snapshot["transform"]["translation"], {"x": -1.0, "y": 0.0}
+        )
+
+    def test_lifecycle_snapshot_rejects_unrepresentable_reveal_state(self) -> None:
+        scene = Scene()
+        source = scene.circle(1.0)
+        target = scene.circle(2.0)
+        scene.animate_reveal(source, duration=2.0)
+        before = scene.to_document()
+
+        with self.assertRaisesRegex(ValueError, "reveal"):
+            scene.play(
+                TransformFromCopy(source, target),
+                duration=1.0,
+                start_time=1.0,
+            )
+
+        self.assertEqual(scene.to_document(), before)
+
+    def test_lifecycle_target_rejects_active_generic_transform_at_handoff(self) -> None:
+        scene = Scene()
+        source = scene.circle(1.0)
+        target = scene.circle(2.0)
+        scene.play(Transform(target, Circle(3.0)), duration=4.0)
+        before = scene.to_document()
+
+        with self.assertRaisesRegex(ValueError, "active generic Transform"):
+            scene.play(
+                ReplacementTransform(source, target),
+                duration=1.0,
+                start_time=1.0,
+            )
+
+        self.assertEqual(scene.to_document(), before)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/python/test_authoring_snapshots.py
+++ b/web/python/test_authoring_snapshots.py
@@ -154,6 +154,55 @@ class EvaluatedAuthoringSnapshotTests(unittest.TestCase):
 
         self.assertEqual(scene.to_document(), before)
 
+    def test_replacement_rejects_source_narrow_track_before_handoff(self) -> None:
+        scene = Scene()
+        source = scene.circle(1.0)
+        target = scene.circle(2.0, position=(4.0, 0.0))
+        scene.animate_position(
+            source,
+            (0.0, 0.0),
+            (3.0, 0.0),
+            duration=1.0,
+            start_time=0.0,
+        )
+        before_document = scene.to_document()
+        before_identity = scene.identity_document()
+
+        with self.assertRaisesRegex(ValueError, "replacement source.*position"):
+            scene.play(
+                ReplacementTransform(source, target),
+                duration=1.0,
+                start_time=2.0,
+            )
+
+        self.assertEqual(scene.to_document(), before_document)
+        self.assertEqual(scene.identity_document(), before_identity)
+
+    def test_replacement_allows_source_narrow_track_after_handoff(self) -> None:
+        scene = Scene()
+        source = scene.circle(1.0)
+        target = scene.circle(2.0, position=(4.0, 0.0))
+        scene.animate_position(
+            source,
+            (0.0, 0.0),
+            (3.0, 0.0),
+            duration=1.0,
+            start_time=4.0,
+        )
+
+        scene.play(
+            ReplacementTransform(source, target),
+            duration=1.0,
+            start_time=1.0,
+        )
+
+        replacement = next(
+            track
+            for track in scene.to_document()["tracks"]
+            if track["property"] == "transform"
+        )
+        self.assertEqual(replacement["timing"]["start_time"], 1.0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/web/python/test_authoring_snapshots.py
+++ b/web/python/test_authoring_snapshots.py
@@ -178,6 +178,24 @@ class EvaluatedAuthoringSnapshotTests(unittest.TestCase):
         self.assertEqual(scene.to_document(), before_document)
         self.assertEqual(scene.identity_document(), before_identity)
 
+    def test_replacement_rejects_unrepresentable_source_state(self) -> None:
+        scene = Scene()
+        source = scene.circle(1.0)
+        target = scene.circle(2.0)
+        scene.animate_reveal(source, duration=1.0, start_time=0.0)
+        before_document = scene.to_document()
+        before_identity = scene.identity_document()
+
+        with self.assertRaisesRegex(ValueError, "replacement source.*reveal"):
+            scene.play(
+                ReplacementTransform(source, target),
+                duration=1.0,
+                start_time=2.0,
+            )
+
+        self.assertEqual(scene.to_document(), before_document)
+        self.assertEqual(scene.identity_document(), before_identity)
+
     def test_replacement_allows_source_narrow_track_after_handoff(self) -> None:
         scene = Scene()
         source = scene.circle(1.0)

--- a/web/python/test_lifecycle.py
+++ b/web/python/test_lifecycle.py
@@ -91,24 +91,33 @@ class ReplacementTransformTests(unittest.TestCase):
                 start_time=2.0,
             )
 
-    def test_replacement_rejects_target_property_state_before_handoff(self) -> None:
+    def test_replacement_evaluates_target_property_state_at_handoff(self) -> None:
         scene = Scene()
         source = scene.circle(1.0)
         target = scene.circle(1.0)
         scene.animate_position(
             target,
             (0.0, 0.0),
-            (1.0, 0.0),
+            (3.0, 0.0),
             duration=3.0,
             start_time=0.0,
         )
 
-        with self.assertRaises(ValueError):
-            scene.play(
-                ReplacementTransform(source, target),
-                duration=1.0,
-                start_time=1.0,
-            )
+        scene.play(
+            ReplacementTransform(source, target),
+            duration=1.0,
+            start_time=1.0,
+        )
+
+        transform = next(
+            track
+            for track in scene.to_document()["tracks"]
+            if track["property"] == "transform"
+        )
+        self.assertEqual(
+            transform["values"]["object"]["to"]["transform"]["translation"],
+            {"x": 2.0, "y": 0.0},
+        )
 
     def test_replacement_rejects_target_with_overlapping_transform(self) -> None:
         scene = Scene()
@@ -260,40 +269,44 @@ class TransformFromCopyTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             scene.play(TransformFromCopy(target, third), duration=1.0, start_time=2.0)
 
-    def test_transform_from_copy_rejects_ambiguous_source_or_target_state(self) -> None:
-        source_scene = Scene()
-        source = source_scene.circle(1.0)
-        target = source_scene.circle(2.0)
-        source_scene.animate_position(
+    def test_transform_from_copy_evaluates_source_and_target_property_state(self) -> None:
+        scene = Scene()
+        source = scene.circle(1.0)
+        target = scene.circle(2.0)
+        scene.animate_position(
             source,
             (0.0, 0.0),
-            (1.0, 0.0),
-            duration=1.0,
+            (2.0, 0.0),
+            duration=2.0,
             start_time=0.0,
         )
-        with self.assertRaises(ValueError):
-            source_scene.play(
-                TransformFromCopy(source, target),
-                duration=1.0,
-                start_time=1.0,
-            )
-
-        target_scene = Scene()
-        source = target_scene.circle(1.0)
-        target = target_scene.circle(2.0)
-        target_scene.animate_opacity(
+        scene.animate_opacity(
             target,
             1.0,
             0.5,
-            duration=1.0,
-            start_time=2.0,
+            duration=2.0,
+            start_time=1.0,
         )
-        with self.assertRaises(ValueError):
-            target_scene.play(
-                TransformFromCopy(source, target),
-                duration=1.0,
-                start_time=1.0,
-            )
+
+        scene.play(
+            TransformFromCopy(source, target),
+            duration=1.0,
+            start_time=1.0,
+        )
+
+        document = scene.to_document()
+        copy_snapshot = {
+            key: value for key, value in document["objects"][2].items() if key != "id"
+        }
+        self.assertEqual(
+            copy_snapshot["transform"]["translation"], {"x": 1.0, "y": 0.0}
+        )
+        transform = next(
+            track
+            for track in document["tracks"]
+            if track["property"] == "transform" and track["object"] == 2
+        )
+        self.assertEqual(transform["values"]["object"]["to"]["style"]["opacity"], 0.75)
 
     def test_transform_from_copy_rejects_overlapping_source_or_target_transform(self) -> None:
         source_scene = Scene()


### PR DESCRIPTION
## Scope

Make Python authoring snapshots reflect the same narrow-property state that the runtime exposes at the relevant semantic time.

- add a deterministic authoring-time evaluator for Position, Rotation, and Opacity tracks;
- use evaluated state as the source snapshot for generic `Transform`;
- use evaluated target state at lifecycle handoff for `ReplacementTransform` and `TransformFromCopy`;
- sample the `TransformFromCopy` source at copy start;
- preserve runtime precedence: latest-started track wins, easing is applied identically, and progress clamps to the track interval;
- continue rejecting snapshots taken during an active generic Transform because arbitrary in-progress geometry cannot always be represented by one `ObjectSnapshot`;
- continue rejecting lifecycle-only channels such as Presence/Reveal/Morph when they cannot be represented in `ObjectSnapshot`;
- reject Position/Rotation/Opacity tracks on a `ReplacementTransform` source when they start before handoff, because runtime narrow-property precedence would override the replacement Transform and break exact handoff continuity;
- allow source narrow-property tracks that start at or after handoff, when the source is already absent;
- add Python regression coverage and update lifecycle/Transform documentation.

This removes unnecessary source/target snapshot restrictions while preserving explicit boundaries where runtime precedence or non-snapshot state would make a lifecycle handoff ambiguous.