### PR TITLE
Support chained lifecycle composition

### DIFF
--- a/crates/noon-runtime/tests/chained_lifecycle.rs
+++ b/crates/noon-runtime/tests/chained_lifecycle.rs
@@ -1,0 +1,97 @@
+use noon_compile::CompiledScene;
+use noon_core::{Easing, GeometryRef, ObjectSnapshot, SceneDefinition, TrackTiming};
+use noon_runtime::SceneInstance;
+
+fn chained_scene() -> CompiledScene {
+    let mut scene = SceneDefinition::new();
+    let first = scene.add(GeometryRef::circle(1.0));
+    let second = scene.add(GeometryRef::circle(2.0));
+    let third = scene.add(GeometryRef::circle(3.0));
+
+    let first_snapshot = ObjectSnapshot::from(scene.object(first).expect("first exists"));
+    let second_snapshot = ObjectSnapshot::from(scene.object(second).expect("second exists"));
+    let third_snapshot = ObjectSnapshot::from(scene.object(third).expect("third exists"));
+
+    scene
+        .animate_transform(
+            first,
+            first_snapshot,
+            second_snapshot.clone(),
+            TrackTiming::new(0.0, 1.0, Easing::Linear),
+        )
+        .expect("first replacement transform is valid");
+    scene
+        .set_presence_at(first, true, false, 1.0)
+        .expect("first hide is valid");
+    scene
+        .set_presence_at(second, false, true, 1.0)
+        .expect("second show is valid");
+
+    scene
+        .animate_transform(
+            second,
+            second_snapshot,
+            third_snapshot,
+            TrackTiming::new(1.0, 1.0, Easing::Linear),
+        )
+        .expect("second replacement transform is valid");
+    scene
+        .set_presence_at(second, true, false, 2.0)
+        .expect("second hide is valid");
+    scene
+        .set_presence_at(third, false, true, 2.0)
+        .expect("third show is valid");
+
+    CompiledScene::compile(&scene).expect("chained lifecycle scene must compile")
+}
+
+#[test]
+fn chained_replacements_have_exact_presence_handoffs() {
+    let mut instance = SceneInstance::new(chained_scene());
+
+    let before_first = instance.seek(0.5).expect("valid time");
+    assert!(before_first.is_present(0));
+    assert!(!before_first.is_present(1));
+    assert!(!before_first.is_present(2));
+
+    let first_handoff = instance.seek(1.0).expect("valid time");
+    assert!(!first_handoff.is_present(0));
+    assert!(first_handoff.is_present(1));
+    assert!(!first_handoff.is_present(2));
+    assert_eq!(first_handoff.objects[1].geometry, GeometryRef::circle(2.0));
+
+    let middle = instance.seek(1.5).expect("valid time");
+    assert!(!middle.is_present(0));
+    assert!(middle.is_present(1));
+    assert!(!middle.is_present(2));
+    assert_eq!(middle.objects[1].geometry, GeometryRef::circle(2.5));
+
+    let second_handoff = instance.seek(2.0).expect("valid time");
+    assert!(!second_handoff.is_present(0));
+    assert!(!second_handoff.is_present(1));
+    assert!(second_handoff.is_present(2));
+    assert_eq!(second_handoff.objects[2].geometry, GeometryRef::circle(3.0));
+}
+
+#[test]
+fn chained_replacements_direct_seek_matches_forward_and_rewind() {
+    let compiled = chained_scene();
+    let mut sequential = SceneInstance::new(compiled.clone());
+    let mut direct = SceneInstance::new(compiled);
+
+    for time in [0.25, 0.5, 1.0, 1.5, 2.0] {
+        sequential.advance_to(time).expect("valid forward time");
+    }
+    direct.seek(2.0).expect("valid direct seek");
+    assert_eq!(sequential.frame(), direct.frame());
+
+    direct.seek(1.0).expect("valid rewind");
+    assert!(!direct.frame().is_present(0));
+    assert!(direct.frame().is_present(1));
+    assert!(!direct.frame().is_present(2));
+
+    direct.seek(0.5).expect("valid rewind before first handoff");
+    assert!(direct.frame().is_present(0));
+    assert!(!direct.frame().is_present(1));
+    assert!(!direct.frame().is_present(2));
+}

--- a/docs/chained-lifecycle.md
+++ b/docs/chained-lifecycle.md
@@ -1,0 +1,86 @@
+# Chained lifecycle composition
+
+## Goal
+
+Lifecycle participation is a property of an object's timeline, not a one-shot authoring flag. An object that becomes present through one lifecycle animation may later become the source of another; an object that becomes absent may later be shown again when its Presence history makes that transition continuous.
+
+Noon therefore derives lifecycle eligibility from the existing `Presence` tracks instead of maintaining a separate set of objects that have already been used.
+
+## Presence state machine
+
+For an object with no Presence tracks, runtime presence defaults to `true`. A lifecycle target is the deliberate exception at first use: its first generated event is `false -> true`, which establishes that object as absent from time zero until the handoff.
+
+Once Presence history exists, it is authoritative. Events are ordered by `(start_time, track_id)` and adjacent events must remain continuous:
+
+```text
+previous.to == next.from
+```
+
+A normal replacement chain therefore looks like:
+
+```text
+A: true  -> false @ t1
+B: false -> true  @ t1
+B: true  -> false @ t2
+C: false -> true  @ t2
+```
+
+At `t1`, `B` can immediately begin the next replacement because Presence evaluation is inclusive at the event timestamp. Direct seek, forward playback, and rewind all resolve the same state from the same stable object identities.
+
+## Authoring rules
+
+The first chained-lifecycle contract is intentionally sequential per participant.
+
+For every lifecycle source:
+
+- all already-authored Presence events for that object must occur at or before the new animation start;
+- the object must be present at the new animation start;
+- therefore no pre-existing Presence event can make the source disappear during the new interval.
+
+For every lifecycle target:
+
+- all already-authored Presence events for that object must occur at or before the new animation start;
+- if the target already has Presence history, it must be absent at the new animation start;
+- if it has no Presence history, first-use target semantics generate `false -> true` at handoff and establish initial absence.
+
+These rules permit sequential composition while rejecting retroactive lifecycle authoring and overlapping ownership of the same presence timeline.
+
+## Supported chains
+
+Examples that are now valid include:
+
+```python
+scene.play(ReplacementTransform(a, b), duration=1.0, start_time=0.0)
+scene.play(ReplacementTransform(b, c), duration=1.0, start_time=1.0)
+```
+
+and:
+
+```python
+scene.play(TransformFromCopy(a, b), duration=1.0, start_time=0.0)
+scene.play(ReplacementTransform(b, c), duration=1.0, start_time=1.0)
+```
+
+A source that remains present may also seed multiple later `TransformFromCopy` operations. The generated transient copies remain independent stable objects with their own `false -> true -> false` Presence chains.
+
+## Rejected composition
+
+Noon rejects rather than guesses when:
+
+- a lifecycle source is absent at the requested start;
+- a previously-used lifecycle target is already present;
+- an object has a Presence event after the requested new start, meaning the new operation is being inserted retroactively into an already-authored lifecycle timeline;
+- the normal Transform snapshot/precedence restrictions would make source or target visual state ambiguous;
+- generated Presence events would violate the compiler's continuity invariant.
+
+`Scene.play(...)` remains transactional, so any rejection restores all objects, tracks, identity allocation, and Transform scheduling state from before the call.
+
+## Runtime contract
+
+No runtime feature is special-cased for chains. The existing compiled Presence groups already support multiple continuous events per object. Chained runtime tests cover exact handoffs, midpoint geometry, direct seek, forward playback, and rewind for `A -> B -> C`.
+
+This is important architecturally: Python authoring is relaxing an unnecessary frontend restriction, not introducing a second lifecycle execution model.
+
+## Next work
+
+This contract remains intentionally sequential for each participant. Future work can consider genuinely overlapping lifecycle graphs only if ownership and precedence are explicit. The next higher-value Transform feature is matching-shape correspondence, which can build on stable identity, evaluated snapshots, transactional lowering, and the now-composable Presence state machine.

--- a/docs/chained-lifecycle.md
+++ b/docs/chained-lifecycle.md
@@ -63,6 +63,8 @@ scene.play(ReplacementTransform(b, c), duration=1.0, start_time=1.0)
 
 A source that remains present may also seed multiple later `TransformFromCopy` operations. The generated transient copies remain independent stable objects with their own `false -> true -> false` Presence chains.
 
+An object hidden by an earlier lifecycle operation may later be reused as a target. Reactivation does not reset it to its original authoring snapshot: the target snapshot is evaluated from that object's latest timeline-resolved Transform/Position/Rotation/Opacity state at the new handoff. This matches runtime seek semantics and preserves stable identity rather than silently resurrecting stale base state.
+
 ## Rejected composition
 
 Noon rejects rather than guesses when:

--- a/docs/transform-from-copy.md
+++ b/docs/transform-from-copy.md
@@ -4,7 +4,7 @@
 
 `TransformFromCopy` preserves the original source object while a distinct transient copy moves through Noon's existing generic Transform pipeline toward a stable target object. Object lifetime remains an explicit semantic concern expressed with `Presence`; playback does not create or destroy objects.
 
-This design builds directly on [transform-lifecycle.md](transform-lifecycle.md), reuses the geometry/interpolation rules in [generic-transform.md](generic-transform.md), and samples timeline state according to [evaluated-authoring-snapshots.md](evaluated-authoring-snapshots.md).
+This design builds directly on [transform-lifecycle.md](transform-lifecycle.md), reuses the geometry/interpolation rules in [generic-transform.md](generic-transform.md), samples timeline state according to [evaluated-authoring-snapshots.md](evaluated-authoring-snapshots.md), and participates in the sequential state machine described in [chained-lifecycle.md](chained-lifecycle.md).
 
 ## Contract
 
@@ -43,7 +43,7 @@ Position, Rotation, and Opacity are sampled from their latest-started tracks at 
 
 ## Presence-chain invariant
 
-This is the first lifecycle primitive that naturally gives one object multiple presence events. The copy's chain is continuous:
+The transient copy has a continuous two-event Presence chain:
 
 ```text
 false -> true
@@ -52,21 +52,38 @@ true  -> false
 
 Adjacent events for one object must agree (`previous.to == next.from`). Python authoring validates the chain as it is built. The Rust compiler independently validates sorted `Presence` tracks before runtime playback, and add/replace/remove-track live patches are validated transactionally before they replace the compiled track set. An inconsistent later `from` value is therefore rejected rather than silently ignored.
 
+## Reuse and chaining
+
+Lifecycle participation is no longer one-shot.
+
+A source that is still present may seed multiple sequential `TransformFromCopy` operations because each moving copy is a fresh stable transient object. A target that became present through an earlier lifecycle handoff can later act as a lifecycle source. For example:
+
+```python
+scene.play(TransformFromCopy(a, b), duration=1.0, start_time=0.0)
+scene.play(ReplacementTransform(b, c), duration=1.0, start_time=1.0)
+```
+
+A target with existing lifecycle history may be reused as a target only when its current Presence state is absent. Lifecycle events for each participant must be authored chronologically; this prevents a later authoring call from inserting ownership into the middle of an already-authored Presence timeline.
+
 ## Safety boundaries
 
-The bounded implementation rejects composition that cannot yet be captured exactly:
+The implementation rejects composition that cannot be captured exactly:
 
 - source and target must be distinct objects owned by the same `Scene`;
-- source or target objects already participating in another lifecycle animation are rejected;
+- lifecycle operations for an existing participant must be authored chronologically;
+- the source must be present at copy start;
+- a reused target must be absent at copy start and remains so until the generated handoff;
 - a snapshot taken inside an active generic Transform is rejected;
-- lifecycle state outside `ObjectSnapshot` (`Presence`, `Reveal`, standalone `Morph`) is rejected when it is already active at the relevant snapshot time;
+- snapshot state outside `ObjectSnapshot` (`Reveal` and standalone `Morph`) is rejected when active at the relevant source/target snapshot time;
 - transient copy and generated track keys are deterministic and duplicate keys are rejected within one scene.
+
+Presence itself is handled by the lifecycle state machine rather than embedded in `ObjectSnapshot`.
 
 Completed generic Transform endpoints are supported. Future generic Transforms that have not started at the source-copy or target-handoff time do not contaminate the snapshot and can coexist with the lifecycle operation when their timeline ordering is otherwise valid.
 
 ## Transactionality
 
-`Scene.play(...)` is transactional. If TransformFromCopy lowering fails after the transient copy has been allocated—for example because a generated track key collides—the entire play operation rolls back. Objects, tracks, identity allocation, scheduled Transform state, and lifecycle participation return to their exact pre-call state.
+`Scene.play(...)` is transactional. If TransformFromCopy lowering fails after the transient copy has been allocated—for example because a generated track key collides—the entire play operation rolls back. Objects, tracks, identity allocation, and scheduled Transform state return to their exact pre-call state.
 
 See [transactional-authoring.md](transactional-authoring.md).
 
@@ -77,8 +94,8 @@ The implementation is covered end to end:
 - Python lowering tests verify the stable transient copy and exact presence/Transform tracks;
 - explicit and generated transient-copy identities are deterministic across equivalent reruns;
 - evaluated source/target tests verify Position and Opacity state at copy start/handoff;
+- lifecycle-chain tests verify source reuse, target-as-later-source composition, absent-source rejection, present-target rejection, and chronological authoring;
 - runtime tests verify direct seek, sequential forward playback, and rewind at pre-start, start, midpoint, and end;
-- runtime tests verify the source remains present, the copy is visible only during the interval, and the target appears exactly at the end;
 - renderer incremental preparation verifies visible instance IDs across all lifecycle phases;
 - compiler tests reject discontinuous presence chains before runtime playback;
 - patch tests reject add/remove operations that would break a presence chain without mutating the previously valid compiled tracks;
@@ -86,4 +103,4 @@ The implementation is covered end to end:
 
 ## Follow-up
 
-The next lifecycle step is explicit repeated/chained lifecycle composition. After that, matching-shape Transform variants can reuse stable IDs, evaluated snapshots, Presence chains, and the existing generic Transform renderer contract.
+Sequential lifecycle composition now removes the artificial one-use restriction. The next higher-value Transform work is matching-shape correspondence; genuinely overlapping lifecycle graphs should be added only if their ownership and precedence semantics are made explicit.

--- a/docs/transform-lifecycle.md
+++ b/docs/transform-lifecycle.md
@@ -4,7 +4,7 @@
 
 Noon models object lifetime independently from opacity. `Presence` is a first-class, renderer-independent boolean timeline property represented as a zero-duration event. This lets lifecycle animations preserve stable `ObjectId` values while arbitrary seek, forward playback, live reconciliation, and rendering all agree on whether an object exists in the visible scene at a given time.
 
-The lifecycle animations built on this primitive are `ReplacementTransform` and `TransformFromCopy`. The geometry/interpolation contract they reuse is documented in [generic-transform.md](generic-transform.md), while authoring-time state evaluation is documented in [evaluated-authoring-snapshots.md](evaluated-authoring-snapshots.md).
+The lifecycle animations built on this primitive are `ReplacementTransform` and `TransformFromCopy`. The geometry/interpolation contract they reuse is documented in [generic-transform.md](generic-transform.md), authoring-time state evaluation is documented in [evaluated-authoring-snapshots.md](evaluated-authoring-snapshots.md), and repeated lifecycle composition is documented in [chained-lifecycle.md](chained-lifecycle.md).
 
 ## Presence contract
 
@@ -17,6 +17,8 @@ TrackTiming { start_time, duration: 0, easing: Linear }
 ```
 
 The first event's `from` value defines the object's pre-event presence state. Once an event time is reached, its `to` value becomes active. Ordinary interpolated tracks still require positive duration; zero duration is accepted only for instant properties such as `Presence`.
+
+Multiple Presence events on one object form a state machine. Adjacent events must be continuous (`previous.to == next.from`), and the compiler independently enforces that invariant before playback and after live track patches.
 
 `FrameState` retains every semantic object and exposes a parallel presence vector. An absent object therefore keeps its stable identity and semantic state, but is excluded from renderer preparation and produces no GPU instance or draw work. When presence changes, renderer preparation treats the slot topology as structural and rebuilds the affected prepared layout rather than pretending that appearance/disappearance is an instance-only value update.
 
@@ -33,7 +35,7 @@ scene.play(
 )
 ```
 
-Both `source` and `target` are stable scene-owned objects with distinct IDs. The target is semantically present in the scene definition but hidden by its first presence event until the handoff.
+Both `source` and `target` are stable scene-owned objects with distinct IDs. A first-use target receives `Presence(false -> true)` at handoff, which establishes that it is absent before the handoff.
 
 The authoring frontend lowers one replacement into three normal language-neutral tracks:
 
@@ -45,6 +47,28 @@ Before the handoff, only the source renders. During the interval, the source ide
 
 This contract makes direct seek and sequential playback equivalent. Seeking backward before the handoff restores source presence and hides the target without reconstructing identities or replaying authoring code.
 
+## Chained lifecycle composition
+
+Lifecycle participation is no longer one-shot. Python derives whether an object can be reused from its existing Presence timeline.
+
+This permits exact-boundary chains such as:
+
+```python
+scene.play(ReplacementTransform(a, b), duration=1.0, start_time=0.0)
+scene.play(ReplacementTransform(b, c), duration=1.0, start_time=1.0)
+```
+
+`b` receives a continuous Presence chain:
+
+```text
+false -> true  @ 1.0
+true  -> false @ 2.0
+```
+
+An object hidden by an earlier operation may also be a later target when its latest Presence state is false. Likewise, a target made present by `TransformFromCopy` may become a later replacement source.
+
+The initial composition contract is sequential per participant. Existing Presence events for a source or target must not lie after the new animation start. Sources must be present at start; targets with Presence history must be absent at start. This rejects retroactive or overlapping ownership of one object's lifecycle while allowing deterministic chains. See [chained-lifecycle.md](chained-lifecycle.md) for the full state-machine rules.
+
 ## Evaluated handoff state
 
 Python authoring evaluates snapshot-representable timeline state at the relevant lifecycle time instead of requiring the target object to have no prior narrow-property animation.
@@ -53,20 +77,22 @@ For `ReplacementTransform`, target `Position`, `Rotation`, and `Opacity` use the
 
 The source side is stricter. Runtime narrow-property groups override generic Transform channels. Therefore a source Position, Rotation, or Opacity track that starts before the handoff would continue overriding the replacement Transform and could make the disappearing source disagree with the appearing target. `ReplacementTransform` rejects those source tracks. Tracks that begin at or after handoff are allowed because the source is already absent. `TransformFromCopy` does not have this restriction because its moving transient copy has no pre-existing narrow tracks.
 
-Channels that are independent of `ObjectSnapshot`, such as `Presence`, `Reveal`, and standalone `Morph` state, remain explicit safety boundaries for lifecycle snapshots. Noon rejects them rather than pretending the Transform endpoint captures state it does not encode.
+Presence is handled separately by the lifecycle state machine and is not folded into `ObjectSnapshot`. Other independent channels that cannot be represented by `ObjectSnapshot`, currently `Reveal` and standalone `Morph` state, remain explicit snapshot safety boundaries.
 
 ## Current safety boundaries
 
-Lifecycle composition remains deliberately bounded where exact semantics are not yet defined:
+Lifecycle composition remains explicit where exact semantics are not defined:
 
 - source and target must be different objects owned by the same `Scene`;
-- an object may participate in only one lifecycle animation in the current composition model;
+- lifecycle operations for one participant are authored chronologically;
+- a lifecycle source must be present at animation start;
+- a reused lifecycle target must be absent at animation start;
 - a lifecycle snapshot cannot be taken inside an active generic Transform;
-- lifecycle snapshot state that is not representable by `ObjectSnapshot` is rejected;
+- Reveal/Morph snapshot state that is not represented by `ObjectSnapshot` is rejected;
 - target and TransformFromCopy-source `Position`, `Rotation`, and `Opacity` tracks are evaluated with the same latest-started-track precedence and easing rules as runtime playback;
 - `ReplacementTransform` source narrow-property tracks that begin before handoff are rejected because they would override the replacement Transform.
 
-These are explicit authoring restrictions, not renderer fallbacks. Noon should not silently produce a discontinuous handoff.
+These are authoring restrictions, not renderer fallbacks. Noon should not silently produce a discontinuous handoff.
 
 ## Validation
 
@@ -75,10 +101,10 @@ Coverage spans the semantic pipeline:
 - core: zero-duration boolean presence validation and deterministic IDs;
 - IR: human-readable presence/bool JSON round trip;
 - compiler: presence dynamic classification, chain continuity, and patch validation;
-- runtime: direct seek, forward playback, rewind, and live-patch presence parity;
+- runtime: direct seek, forward playback, rewind, live-patch presence parity, and multi-handoff `A -> B -> C` chains;
 - renderer: absent objects keep semantic slots but create no GPU instances; toggling presence rebuilds the prepared slot layout;
-- Python: lifecycle lowering, evaluated Position/Rotation/Opacity snapshots, deterministic transient-copy identity, transactional rollback, replacement-source precedence guards, and rejection of active/unrepresentable snapshot state.
+- Python: lifecycle lowering, exact-boundary chains, valid source/target reuse, absent-source and present-target rejection, chronological composition, evaluated Position/Rotation/Opacity snapshots, deterministic transient-copy identity, and transactional rollback.
 
 ## Next work
 
-The next lifecycle composition step is to support repeated/chained lifecycle operations with explicit state-machine semantics rather than the current one-lifecycle-animation-per-object guard. Matching-shape transforms can then build on the same evaluated snapshot and stable-identity machinery.
+The higher-value Transform milestone after sequential lifecycle composition is matching-shape correspondence. Truly overlapping lifecycle graphs can be considered later only with explicit ownership and precedence rules rather than implicit event insertion.

--- a/web/python/noon.py
+++ b/web/python/noon.py
@@ -318,7 +318,6 @@ class Scene:
         self._track_keys: dict[int, str] = {}
         self._scheduled_transform_targets: dict[int, dict[str, Any]] = {}
         self._scheduled_transform_ends: dict[int, float] = {}
-        self._lifecycle_objects: set[int] = set()
 
     def add(self, mobject: Mobject, *, key: str | None = None) -> Object:
         if not isinstance(mobject, Mobject):
@@ -499,7 +498,6 @@ class Scene:
             len(self._tracks),
             dict(self._scheduled_transform_targets),
             dict(self._scheduled_transform_ends),
-            set(self._lifecycle_objects),
         )
 
     def _restore_authoring_checkpoint(self, checkpoint: tuple[Any, ...]) -> None:
@@ -508,7 +506,6 @@ class Scene:
             track_count,
             scheduled_transform_targets,
             scheduled_transform_ends,
-            lifecycle_objects,
         ) = checkpoint
         for object_id in range(object_count, len(self._objects)):
             self._object_keys.pop(object_id, None)
@@ -518,7 +515,6 @@ class Scene:
         del self._tracks[track_count:]
         self._scheduled_transform_targets = scheduled_transform_targets
         self._scheduled_transform_ends = scheduled_transform_ends
-        self._lifecycle_objects = lifecycle_objects
 
     def _schedule_transform(
         self,
@@ -569,9 +565,11 @@ class Scene:
         self,
         target: Object,
         *,
+        start: float,
         end: float,
         label: str,
     ) -> dict[str, Any]:
+        self._ensure_lifecycle_target_available(target, start, label)
         self._ensure_snapshot_representable(target, end, f"{label} target")
         try:
             return self._snapshot_for_object_at(target, end)
@@ -596,16 +594,15 @@ class Scene:
             raise ValueError("replacement target must belong to this Scene")
         if source.id == target.id:
             raise ValueError("replacement source and target must be different objects")
-        if source.id in self._lifecycle_objects or target.id in self._lifecycle_objects:
-            raise ValueError("an object may participate in only one lifecycle replacement")
 
         start = _finite_number("start_time", start_time)
         run_duration = _positive_number("duration", duration)
         end = start + run_duration
+        self._ensure_lifecycle_source_present(source, start, "replacement source")
         self._ensure_snapshot_representable(source, end, "replacement source")
         self._ensure_replacement_source_unoverridden(source, end)
         target_snapshot = self._validate_lifecycle_target(
-            target, end=end, label="replacement"
+            target, start=start, end=end, label="replacement"
         )
         detached_target = Mobject(
             geometry=target_snapshot["geometry"],
@@ -621,7 +618,6 @@ class Scene:
 
         self._add_presence_track(source, True, False, end)
         self._add_presence_track(target, False, True, end)
-        self._lifecycle_objects.update((source.id, target.id))
 
     def _schedule_transform_from_copy(
         self,
@@ -639,20 +635,19 @@ class Scene:
             raise ValueError("copy target must belong to this Scene")
         if source.id == target.id:
             raise ValueError("copy source and target must be different objects")
-        if source.id in self._lifecycle_objects or target.id in self._lifecycle_objects:
-            raise ValueError("an object may participate in only one lifecycle animation")
 
         start = _finite_number("start_time", start_time)
         run_duration = _positive_number("duration", duration)
         end = start + run_duration
 
+        self._ensure_lifecycle_source_present(source, start, "copy source")
         self._ensure_snapshot_representable(source, start, "copy source")
         try:
             source_snapshot = self._snapshot_for_object_at(source, start)
         except ValueError as error:
             raise ValueError(f"copy source cannot be snapshotted: {error}") from error
         target_snapshot = self._validate_lifecycle_target(
-            target, end=end, label="copy"
+            target, start=start, end=end, label="copy"
         )
 
         source_key = self._object_keys[source.id]
@@ -699,7 +694,53 @@ class Scene:
             end,
             key=f"{copy_key}.target-show",
         )
-        self._lifecycle_objects.update((source.id, target.id, copy_object.id))
+
+    def _presence_tracks(self, obj: Object) -> list[dict[str, Any]]:
+        return sorted(
+            (
+                track
+                for track in self._tracks
+                if track["object"] == obj.id and track["property"] == "presence"
+            ),
+            key=lambda track: (track["timing"]["start_time"], track["id"]),
+        )
+
+    def _presence_at(self, obj: Object, time: float) -> bool:
+        tracks = self._presence_tracks(obj)
+        if not tracks:
+            return True
+        state = tracks[0]["values"]["bool"]["from"]
+        for track in tracks:
+            if track["timing"]["start_time"] > time:
+                break
+            state = track["values"]["bool"]["to"]
+        return state
+
+    def _ensure_lifecycle_timeline_available(
+        self, obj: Object, start: float, label: str
+    ) -> list[dict[str, Any]]:
+        tracks = self._presence_tracks(obj)
+        if tracks and tracks[-1]["timing"]["start_time"] > start:
+            raise ValueError(
+                f"{label} has a future lifecycle event; lifecycle operations must be authored chronologically"
+            )
+        return tracks
+
+    def _ensure_lifecycle_source_present(
+        self, source: Object, start: float, label: str
+    ) -> None:
+        self._ensure_lifecycle_timeline_available(source, start, label)
+        if not self._presence_at(source, start):
+            raise ValueError(f"{label} must be present at animation start")
+
+    def _ensure_lifecycle_target_available(
+        self, target: Object, start: float, label: str
+    ) -> None:
+        tracks = self._ensure_lifecycle_timeline_available(
+            target, start, f"{label} target"
+        )
+        if tracks and self._presence_at(target, start):
+            raise ValueError(f"{label} target must be absent before handoff")
 
     def _add_presence_track(
         self,
@@ -710,11 +751,7 @@ class Scene:
         *,
         key: str | None = None,
     ) -> None:
-        existing = [
-            track
-            for track in self._tracks
-            if track["object"] == obj.id and track["property"] == "presence"
-        ]
+        existing = self._presence_tracks(obj)
         if existing:
             previous = existing[-1]
             previous_time = previous["timing"]["start_time"]
@@ -894,7 +931,7 @@ class Scene:
             track["property"]
             for track in self._tracks
             if track["object"] == obj.id
-            and track["property"] in {"presence", "reveal", "morph"}
+            and track["property"] in {"reveal", "morph"}
             and track["timing"]["start_time"] <= time
         ]
         if unsupported:

--- a/web/python/test_chained_lifecycle.py
+++ b/web/python/test_chained_lifecycle.py
@@ -1,0 +1,149 @@
+import unittest
+
+from noon import ReplacementTransform, Scene, TransformFromCopy
+
+
+class ChainedLifecycleTests(unittest.TestCase):
+    def test_replacement_chain_is_continuous_at_exact_handoff_boundary(self) -> None:
+        scene = Scene()
+        first = scene.circle(1.0, key="first")
+        second = scene.circle(2.0, key="second")
+        third = scene.circle(3.0, key="third")
+
+        scene.play(
+            ReplacementTransform(first, second, key="first-to-second"),
+            duration=1.0,
+            start_time=0.0,
+        )
+        scene.play(
+            ReplacementTransform(second, third, key="second-to-third"),
+            duration=1.0,
+            start_time=1.0,
+        )
+
+        second_presence = [
+            track
+            for track in scene.to_document()["tracks"]
+            if track["object"] == second.id and track["property"] == "presence"
+        ]
+        self.assertEqual(
+            [track["values"]["bool"] for track in second_presence],
+            [
+                {"from": False, "to": True},
+                {"from": True, "to": False},
+            ],
+        )
+        self.assertEqual(
+            [track["timing"]["start_time"] for track in second_presence],
+            [1.0, 2.0],
+        )
+
+    def test_hidden_object_cannot_be_reused_as_source(self) -> None:
+        scene = Scene()
+        first = scene.circle(1.0)
+        second = scene.circle(2.0)
+        third = scene.circle(3.0)
+        scene.play(ReplacementTransform(first, second), duration=1.0)
+        before_document = scene.to_document()
+        before_identity = scene.identity_document()
+
+        with self.assertRaisesRegex(ValueError, "must be present"):
+            scene.play(
+                ReplacementTransform(first, third),
+                duration=1.0,
+                start_time=2.0,
+            )
+
+        self.assertEqual(scene.to_document(), before_document)
+        self.assertEqual(scene.identity_document(), before_identity)
+
+    def test_visible_lifecycle_object_cannot_be_used_as_target(self) -> None:
+        scene = Scene()
+        first = scene.circle(1.0)
+        second = scene.circle(2.0)
+        scene.play(ReplacementTransform(first, second), duration=1.0)
+        before_document = scene.to_document()
+        before_identity = scene.identity_document()
+
+        with self.assertRaisesRegex(ValueError, "target must be absent"):
+            scene.play(
+                TransformFromCopy(second, second),
+                duration=1.0,
+                start_time=2.0,
+            )
+
+        self.assertEqual(scene.to_document(), before_document)
+        self.assertEqual(scene.identity_document(), before_identity)
+
+    def test_visible_previous_target_is_rejected_as_new_distinct_target(self) -> None:
+        scene = Scene()
+        first = scene.circle(1.0)
+        visible_target = scene.circle(2.0)
+        source = scene.circle(3.0)
+        scene.play(ReplacementTransform(first, visible_target), duration=1.0)
+        before_document = scene.to_document()
+
+        with self.assertRaisesRegex(ValueError, "target must be absent"):
+            scene.play(
+                TransformFromCopy(source, visible_target),
+                duration=1.0,
+                start_time=2.0,
+            )
+
+        self.assertEqual(scene.to_document(), before_document)
+
+    def test_retroactive_lifecycle_authoring_is_rejected_transactionally(self) -> None:
+        scene = Scene()
+        first = scene.circle(1.0)
+        second = scene.circle(2.0)
+        third = scene.circle(3.0)
+        scene.play(
+            ReplacementTransform(first, second),
+            duration=1.0,
+            start_time=2.0,
+        )
+        before_document = scene.to_document()
+        before_identity = scene.identity_document()
+
+        with self.assertRaisesRegex(ValueError, "authored chronologically"):
+            scene.play(
+                ReplacementTransform(second, third),
+                duration=1.0,
+                start_time=1.0,
+            )
+
+        self.assertEqual(scene.to_document(), before_document)
+        self.assertEqual(scene.identity_document(), before_identity)
+
+    def test_copy_handoff_target_can_become_later_replacement_source(self) -> None:
+        scene = Scene()
+        source = scene.circle(1.0, key="source")
+        middle = scene.circle(2.0, key="middle")
+        target = scene.circle(3.0, key="target")
+
+        scene.play(
+            TransformFromCopy(source, middle, key="copy-to-middle"),
+            duration=1.0,
+        )
+        scene.play(
+            ReplacementTransform(middle, target, key="middle-to-target"),
+            duration=1.0,
+            start_time=1.0,
+        )
+
+        middle_presence = [
+            track
+            for track in scene.to_document()["tracks"]
+            if track["object"] == middle.id and track["property"] == "presence"
+        ]
+        self.assertEqual(
+            [track["values"]["bool"] for track in middle_presence],
+            [
+                {"from": False, "to": True},
+                {"from": True, "to": False},
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/python/test_chained_lifecycle.py
+++ b/web/python/test_chained_lifecycle.py
@@ -133,9 +133,10 @@ class ChainedLifecycleTests(unittest.TestCase):
             start_time=2.0,
         )
 
+        document = scene.to_document()
         events = [
             track
-            for track in scene.to_document()["tracks"]
+            for track in document["tracks"]
             if track["object"] == first.id and track["property"] == "presence"
         ]
         self.assertEqual(
@@ -147,6 +148,14 @@ class ChainedLifecycleTests(unittest.TestCase):
         )
         self.assertEqual(
             [track["timing"]["start_time"] for track in events], [1.0, 3.0]
+        )
+
+        transforms = [
+            track for track in document["tracks"] if track["property"] == "transform"
+        ]
+        self.assertEqual(
+            transforms[-1]["values"]["object"]["to"]["geometry"],
+            {"circle": {"radius": 2.0}},
         )
 
 

--- a/web/python/test_chained_lifecycle.py
+++ b/web/python/test_chained_lifecycle.py
@@ -4,41 +4,36 @@ from noon import ReplacementTransform, Scene, TransformFromCopy
 
 
 class ChainedLifecycleTests(unittest.TestCase):
-    def test_replacement_chain_is_continuous_at_exact_handoff_boundary(self) -> None:
+    def test_replacement_chain_is_continuous_at_exact_boundary(self) -> None:
         scene = Scene()
         first = scene.circle(1.0, key="first")
         second = scene.circle(2.0, key="second")
         third = scene.circle(3.0, key="third")
 
+        scene.play(ReplacementTransform(first, second), duration=1.0)
         scene.play(
-            ReplacementTransform(first, second, key="first-to-second"),
-            duration=1.0,
-            start_time=0.0,
-        )
-        scene.play(
-            ReplacementTransform(second, third, key="second-to-third"),
+            ReplacementTransform(second, third),
             duration=1.0,
             start_time=1.0,
         )
 
-        second_presence = [
+        events = [
             track
             for track in scene.to_document()["tracks"]
             if track["object"] == second.id and track["property"] == "presence"
         ]
         self.assertEqual(
-            [track["values"]["bool"] for track in second_presence],
+            [track["values"]["bool"] for track in events],
             [
                 {"from": False, "to": True},
                 {"from": True, "to": False},
             ],
         )
         self.assertEqual(
-            [track["timing"]["start_time"] for track in second_presence],
-            [1.0, 2.0],
+            [track["timing"]["start_time"] for track in events], [1.0, 2.0]
         )
 
-    def test_hidden_object_cannot_be_reused_as_source(self) -> None:
+    def test_absent_source_is_rejected_transactionally(self) -> None:
         scene = Scene()
         first = scene.circle(1.0)
         second = scene.circle(2.0)
@@ -57,17 +52,18 @@ class ChainedLifecycleTests(unittest.TestCase):
         self.assertEqual(scene.to_document(), before_document)
         self.assertEqual(scene.identity_document(), before_identity)
 
-    def test_visible_lifecycle_object_cannot_be_used_as_target(self) -> None:
+    def test_present_previous_target_is_rejected_as_target(self) -> None:
         scene = Scene()
         first = scene.circle(1.0)
         second = scene.circle(2.0)
+        other_source = scene.circle(3.0)
         scene.play(ReplacementTransform(first, second), duration=1.0)
         before_document = scene.to_document()
         before_identity = scene.identity_document()
 
         with self.assertRaisesRegex(ValueError, "target must be absent"):
             scene.play(
-                TransformFromCopy(second, second),
+                TransformFromCopy(other_source, second),
                 duration=1.0,
                 start_time=2.0,
             )
@@ -75,24 +71,7 @@ class ChainedLifecycleTests(unittest.TestCase):
         self.assertEqual(scene.to_document(), before_document)
         self.assertEqual(scene.identity_document(), before_identity)
 
-    def test_visible_previous_target_is_rejected_as_new_distinct_target(self) -> None:
-        scene = Scene()
-        first = scene.circle(1.0)
-        visible_target = scene.circle(2.0)
-        source = scene.circle(3.0)
-        scene.play(ReplacementTransform(first, visible_target), duration=1.0)
-        before_document = scene.to_document()
-
-        with self.assertRaisesRegex(ValueError, "target must be absent"):
-            scene.play(
-                TransformFromCopy(source, visible_target),
-                duration=1.0,
-                start_time=2.0,
-            )
-
-        self.assertEqual(scene.to_document(), before_document)
-
-    def test_retroactive_lifecycle_authoring_is_rejected_transactionally(self) -> None:
+    def test_retroactive_authoring_is_rejected_transactionally(self) -> None:
         scene = Scene()
         first = scene.circle(1.0)
         second = scene.circle(2.0)
@@ -115,29 +94,26 @@ class ChainedLifecycleTests(unittest.TestCase):
         self.assertEqual(scene.to_document(), before_document)
         self.assertEqual(scene.identity_document(), before_identity)
 
-    def test_copy_handoff_target_can_become_later_replacement_source(self) -> None:
+    def test_copy_target_can_become_later_replacement_source(self) -> None:
         scene = Scene()
         source = scene.circle(1.0, key="source")
         middle = scene.circle(2.0, key="middle")
         target = scene.circle(3.0, key="target")
 
+        scene.play(TransformFromCopy(source, middle), duration=1.0)
         scene.play(
-            TransformFromCopy(source, middle, key="copy-to-middle"),
-            duration=1.0,
-        )
-        scene.play(
-            ReplacementTransform(middle, target, key="middle-to-target"),
+            ReplacementTransform(middle, target),
             duration=1.0,
             start_time=1.0,
         )
 
-        middle_presence = [
+        events = [
             track
             for track in scene.to_document()["tracks"]
             if track["object"] == middle.id and track["property"] == "presence"
         ]
         self.assertEqual(
-            [track["values"]["bool"] for track in middle_presence],
+            [track["values"]["bool"] for track in events],
             [
                 {"from": False, "to": True},
                 {"from": True, "to": False},

--- a/web/python/test_chained_lifecycle.py
+++ b/web/python/test_chained_lifecycle.py
@@ -120,6 +120,35 @@ class ChainedLifecycleTests(unittest.TestCase):
             ],
         )
 
+    def test_absent_object_can_become_a_later_target(self) -> None:
+        scene = Scene()
+        first = scene.circle(1.0, key="first")
+        second = scene.circle(2.0, key="second")
+        third = scene.circle(3.0, key="third")
+
+        scene.play(ReplacementTransform(first, second), duration=1.0)
+        scene.play(
+            ReplacementTransform(third, first),
+            duration=1.0,
+            start_time=2.0,
+        )
+
+        events = [
+            track
+            for track in scene.to_document()["tracks"]
+            if track["object"] == first.id and track["property"] == "presence"
+        ]
+        self.assertEqual(
+            [track["values"]["bool"] for track in events],
+            [
+                {"from": True, "to": False},
+                {"from": False, "to": True},
+            ],
+        )
+        self.assertEqual(
+            [track["timing"]["start_time"] for track in events], [1.0, 3.0]
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/web/python/test_lifecycle.py
+++ b/web/python/test_lifecycle.py
@@ -71,7 +71,7 @@ class ReplacementTransformTests(unittest.TestCase):
         self.assertEqual(identities[1]["key"], "@track:1")
         self.assertEqual(identities[2]["key"], "@track:2")
 
-    def test_replacement_rejects_foreign_self_and_reused_lifecycle_objects(self) -> None:
+    def test_replacement_rejects_foreign_self_and_allows_chained_objects(self) -> None:
         scene = Scene()
         source = scene.circle(1.0)
         target = scene.circle(2.0)
@@ -84,12 +84,28 @@ class ReplacementTransformTests(unittest.TestCase):
 
         scene.play(ReplacementTransform(source, target), duration=1.0)
         third = scene.circle(4.0)
-        with self.assertRaises(ValueError):
-            scene.play(
-                ReplacementTransform(target, third),
-                duration=1.0,
-                start_time=2.0,
-            )
+        scene.play(
+            ReplacementTransform(target, third),
+            duration=1.0,
+            start_time=1.0,
+        )
+
+        target_presence = [
+            track
+            for track in scene.to_document()["tracks"]
+            if track["object"] == target.id and track["property"] == "presence"
+        ]
+        self.assertEqual(
+            [track["values"]["bool"] for track in target_presence],
+            [
+                {"from": False, "to": True},
+                {"from": True, "to": False},
+            ],
+        )
+        self.assertEqual(
+            [track["timing"]["start_time"] for track in target_presence],
+            [1.0, 2.0],
+        )
 
     def test_replacement_evaluates_target_property_state_at_handoff(self) -> None:
         scene = Scene()
@@ -251,10 +267,10 @@ class TransformFromCopyTests(unittest.TestCase):
             ],
         )
 
-    def test_transform_from_copy_rejects_foreign_self_and_reused_objects(self) -> None:
+    def test_transform_from_copy_rejects_foreign_self_and_allows_valid_reuse(self) -> None:
         scene = Scene()
-        source = scene.circle(1.0)
-        target = scene.circle(2.0)
+        source = scene.circle(1.0, key="source")
+        target = scene.circle(2.0, key="target")
         foreign = Scene().circle(3.0)
 
         with self.assertRaises(ValueError):
@@ -262,12 +278,31 @@ class TransformFromCopyTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             scene.play(TransformFromCopy(source, source), duration=1.0)
 
-        scene.play(TransformFromCopy(source, target), duration=1.0)
-        third = scene.circle(4.0)
-        with self.assertRaises(ValueError):
-            scene.play(TransformFromCopy(source, third), duration=1.0, start_time=2.0)
-        with self.assertRaises(ValueError):
-            scene.play(TransformFromCopy(target, third), duration=1.0, start_time=2.0)
+        scene.play(TransformFromCopy(source, target, key="first"), duration=1.0)
+        third = scene.circle(4.0, key="third")
+        fourth = scene.circle(5.0, key="fourth")
+        scene.play(
+            TransformFromCopy(source, third, key="second"),
+            duration=1.0,
+            start_time=2.0,
+        )
+        scene.play(
+            TransformFromCopy(target, fourth, key="third-copy"),
+            duration=1.0,
+            start_time=2.0,
+        )
+
+        document = scene.to_document()
+        self.assertEqual(len(document["objects"]), 7)
+        target_presence = [
+            track
+            for track in document["tracks"]
+            if track["object"] == target.id and track["property"] == "presence"
+        ]
+        self.assertEqual(
+            [track["values"]["bool"] for track in target_presence],
+            [{"from": False, "to": True}],
+        )
 
     def test_transform_from_copy_evaluates_source_and_target_property_state(self) -> None:
         scene = Scene()


### PR DESCRIPTION
## Scope

Replace the one-lifecycle-animation-per-object restriction with explicit sequential Presence-state validation.

- derive lifecycle eligibility from each object's Presence timeline instead of a side-channel used-object set;
- allow exact-boundary chains such as `ReplacementTransform(A, B)` followed by `ReplacementTransform(B, C)`;
- allow a still-present source to seed multiple `TransformFromCopy` animations;
- allow a previously revealed target to become a later lifecycle source;
- allow a previously hidden object to become a later target when its Presence state is absent;
- require lifecycle operations for a participant to be authored chronologically;
- require sources to be present at animation start and reused targets to be absent before handoff;
- keep first-use targets as the existing `false -> true` contract, establishing them as absent before their first handoff;
- keep Presence continuity compiler/runtime validation as the final semantic invariant;
- preserve transactional `Scene.play(...)` rollback;
- add Python state-machine regression coverage, Rust runtime direct-seek/forward/rewind coverage, and lifecycle documentation.

Fast architecture CI is green on the draft head. The PR is ready for the full non-draft compatibility gate.