### PR TITLE
Add deterministic TransformMatchingShapes

### DIFF
--- a/crates/noon-runtime/tests/matching_shapes.rs
+++ b/crates/noon-runtime/tests/matching_shapes.rs
@@ -1,0 +1,128 @@
+use noon_compile::CompiledScene;
+use noon_core::{
+    Easing, GeometryRef, ObjectSnapshot, SceneDefinition, TrackTiming, Vec2,
+};
+use noon_runtime::SceneInstance;
+
+fn matching_scene() -> CompiledScene {
+    let mut scene = SceneDefinition::new();
+    let source_circle = scene.add(GeometryRef::circle(1.0));
+    let source_rectangle = scene.add(GeometryRef::rectangle(2.0, 1.0));
+    let target_circle = scene.add(GeometryRef::circle(2.0));
+    let target_rectangle = scene.add(GeometryRef::rectangle(4.0, 2.0));
+
+    scene.object_mut(target_circle).expect("target circle exists").transform.translation =
+        Vec2::new(3.0, 1.0);
+    scene
+        .object_mut(target_rectangle)
+        .expect("target rectangle exists")
+        .transform
+        .translation = Vec2::new(-2.0, -1.0);
+
+    let source_circle_snapshot =
+        ObjectSnapshot::from(scene.object(source_circle).expect("source circle exists"));
+    let source_rectangle_snapshot = ObjectSnapshot::from(
+        scene
+            .object(source_rectangle)
+            .expect("source rectangle exists"),
+    );
+    let target_circle_snapshot =
+        ObjectSnapshot::from(scene.object(target_circle).expect("target circle exists"));
+    let target_rectangle_snapshot = ObjectSnapshot::from(
+        scene
+            .object(target_rectangle)
+            .expect("target rectangle exists"),
+    );
+
+    scene
+        .animate_transform(
+            source_circle,
+            source_circle_snapshot,
+            target_circle_snapshot,
+            TrackTiming::new(0.0, 2.0, Easing::Linear),
+        )
+        .expect("circle match transform is valid");
+    scene
+        .animate_transform(
+            source_rectangle,
+            source_rectangle_snapshot,
+            target_rectangle_snapshot,
+            TrackTiming::new(0.0, 2.0, Easing::Linear),
+        )
+        .expect("rectangle match transform is valid");
+
+    scene
+        .set_presence_at(source_circle, true, false, 2.0)
+        .expect("source circle hide is valid");
+    scene
+        .set_presence_at(target_circle, false, true, 2.0)
+        .expect("target circle show is valid");
+    scene
+        .set_presence_at(source_rectangle, true, false, 2.0)
+        .expect("source rectangle hide is valid");
+    scene
+        .set_presence_at(target_rectangle, false, true, 2.0)
+        .expect("target rectangle show is valid");
+
+    CompiledScene::compile(&scene).expect("matching-shape lowering must compile")
+}
+
+#[test]
+fn simultaneous_matches_keep_sources_until_atomic_handoff() {
+    let mut instance = SceneInstance::new(matching_scene());
+
+    let before = instance.seek(0.5).expect("valid time");
+    assert!(before.is_present(0));
+    assert!(before.is_present(1));
+    assert!(!before.is_present(2));
+    assert!(!before.is_present(3));
+
+    let middle = instance.seek(1.0).expect("valid time");
+    assert!(middle.is_present(0));
+    assert!(middle.is_present(1));
+    assert!(!middle.is_present(2));
+    assert!(!middle.is_present(3));
+    assert_eq!(middle.objects[0].geometry, GeometryRef::circle(1.5));
+    assert_eq!(
+        middle.objects[1].geometry,
+        GeometryRef::rectangle(3.0, 1.5)
+    );
+    assert_eq!(middle.objects[0].transform.translation, Vec2::new(1.5, 0.5));
+    assert_eq!(
+        middle.objects[1].transform.translation,
+        Vec2::new(-1.0, -0.5)
+    );
+
+    let handoff = instance.seek(2.0).expect("valid time");
+    assert!(!handoff.is_present(0));
+    assert!(!handoff.is_present(1));
+    assert!(handoff.is_present(2));
+    assert!(handoff.is_present(3));
+    assert_eq!(handoff.objects[2].geometry, GeometryRef::circle(2.0));
+    assert_eq!(
+        handoff.objects[3].geometry,
+        GeometryRef::rectangle(4.0, 2.0)
+    );
+}
+
+#[test]
+fn simultaneous_matches_direct_seek_matches_forward_and_rewind() {
+    let compiled = matching_scene();
+    let mut sequential = SceneInstance::new(compiled.clone());
+    let mut direct = SceneInstance::new(compiled);
+
+    for time in [0.25, 0.5, 1.0, 1.5, 2.0] {
+        sequential.advance_to(time).expect("valid forward time");
+    }
+    direct.seek(2.0).expect("valid direct seek");
+    assert_eq!(sequential.frame(), direct.frame());
+
+    direct.seek(1.0).expect("valid rewind");
+    assert!(direct.frame().is_present(0));
+    assert!(direct.frame().is_present(1));
+    assert!(!direct.frame().is_present(2));
+    assert!(!direct.frame().is_present(3));
+
+    direct.seek(2.0).expect("valid second direct seek");
+    assert_eq!(sequential.frame(), direct.frame());
+}

--- a/crates/noon-runtime/tests/matching_shapes.rs
+++ b/crates/noon-runtime/tests/matching_shapes.rs
@@ -1,7 +1,5 @@
 use noon_compile::CompiledScene;
-use noon_core::{
-    Easing, GeometryRef, ObjectSnapshot, SceneDefinition, TrackTiming, Vec2,
-};
+use noon_core::{Easing, GeometryRef, ObjectSnapshot, SceneDefinition, TrackTiming, Vec2};
 use noon_runtime::SceneInstance;
 
 fn matching_scene() -> CompiledScene {
@@ -11,8 +9,11 @@ fn matching_scene() -> CompiledScene {
     let target_circle = scene.add(GeometryRef::circle(2.0));
     let target_rectangle = scene.add(GeometryRef::rectangle(4.0, 2.0));
 
-    scene.object_mut(target_circle).expect("target circle exists").transform.translation =
-        Vec2::new(3.0, 1.0);
+    scene
+        .object_mut(target_circle)
+        .expect("target circle exists")
+        .transform
+        .translation = Vec2::new(3.0, 1.0);
     scene
         .object_mut(target_rectangle)
         .expect("target rectangle exists")
@@ -83,10 +84,7 @@ fn simultaneous_matches_keep_sources_until_atomic_handoff() {
     assert!(!middle.is_present(2));
     assert!(!middle.is_present(3));
     assert_eq!(middle.objects[0].geometry, GeometryRef::circle(1.5));
-    assert_eq!(
-        middle.objects[1].geometry,
-        GeometryRef::rectangle(3.0, 1.5)
-    );
+    assert_eq!(middle.objects[1].geometry, GeometryRef::rectangle(3.0, 1.5));
     assert_eq!(middle.objects[0].transform.translation, Vec2::new(1.5, 0.5));
     assert_eq!(
         middle.objects[1].transform.translation,

--- a/docs/transform-matching-shapes.md
+++ b/docs/transform-matching-shapes.md
@@ -1,0 +1,87 @@
+# TransformMatchingShapes composition
+
+## Goal
+
+`TransformMatchingShapes` is a deterministic authoring primitive for moving a collection of stable source objects into a collection of stable target objects by shape identity. It is deliberately a frontend composition feature: matching happens while authoring, then each matched pair lowers to the same generic `Transform` plus `Presence` handoff already used by `ReplacementTransform`.
+
+No runtime, compiler, or renderer special case is introduced.
+
+## Authoring form
+
+```python
+scene.play(
+    TransformMatchingShapes(
+        [left_circle, left_square, right_circle],
+        [new_square, new_circle_a, new_circle_b],
+        key="rearrange",
+    ),
+    duration=2.0,
+)
+```
+
+Sources and targets are ordered collections of scene-owned `Object` handles. They must be non-empty, internally unique, and disjoint from one another.
+
+## Matching contract
+
+Matching uses each source's evaluated geometry at animation start and each target's evaluated geometry at handoff. Style, position, rotation, scale, and opacity do not participate in the match key; they remain ordinary generic-Transform channels after a pair is selected.
+
+The initial deterministic shape signatures are intentionally conservative:
+
+- `Circle`: all circles share one signature; radius is a transformable size parameter.
+- `Line`: all line segments share one signature.
+- `Rectangle`: rectangles match when their normalized aspect ratio is equal; width/height ordering is ignored so a rotated aspect-equivalent rectangle remains matchable.
+- `VectorPath`: paths match only when their local renderer-independent command geometry is exactly equal. This is sufficient for repeated glyph-like/path objects authored from the same outline while avoiding approximate contour heuristics.
+
+For duplicate signatures, stable input order is the tie-breaker: the first unmatched source of a signature pairs with the first unmatched target of that signature.
+
+Every source and target must be matched exactly once. A signature/cardinality mismatch is rejected transactionally. Noon does not emulate unmatched-part fades with opacity tracks because Fade does not yet have first-class lifecycle semantics.
+
+## Lowering
+
+After matching, pair `i` lowers exactly as:
+
+```python
+ReplacementTransform(source_i, target_i, key=f"{root}.match:{i}")
+```
+
+All pairs share the caller's start time, duration, and easing. The existing lifecycle state machine therefore supplies:
+
+- source-present validation;
+- target-absent validation;
+- evaluated snapshots;
+- exact end-time source hide / target show;
+- chained lifecycle composition;
+- transactional rollback;
+- direct-seek and rewind determinism.
+
+The default root key is derived deterministically from the ordered source and target authoring keys. Explicit keys remain preferable for long or externally reconciled scenes.
+
+## Safety boundaries
+
+The first version rejects:
+
+- foreign objects;
+- duplicate source or target handles;
+- any object appearing in both source and target collections;
+- empty source or target collections;
+- unmatched shape signatures or counts;
+- vector paths that are merely geometrically similar rather than exactly equal in local command form;
+- any pair that violates the existing `ReplacementTransform` snapshot, precedence, or lifecycle rules.
+
+These are authoring errors rather than renderer fallbacks.
+
+## Validation
+
+Coverage should verify:
+
+- deterministic pairing independent of target shape ordering;
+- stable tie-breaking for duplicate shapes;
+- analytic aspect-ratio matching;
+- exact local-vector-path matching;
+- deterministic generated track identities;
+- transactional mismatch/duplicate/foreign-object rejection;
+- simultaneous multi-pair runtime handoff and direct-seek/rewind parity through the existing lifecycle runtime.
+
+## Follow-up
+
+When text outlines and richer groups land, they can feed the same matching primitive. A later canonical path-signature layer may normalize contour start, winding, translation, scale, and compatible curve representations. Unmatched-part behavior should wait for explicit Fade/appearance semantics rather than being hidden inside this feature.

--- a/web/python/noon.py
+++ b/web/python/noon.py
@@ -100,6 +100,28 @@ def _lerp(from_: float, to: float, progress: float) -> float:
     return from_ + (to - from_) * progress
 
 
+def _matching_shape_signature(geometry: dict[str, Any]) -> tuple[Any, ...]:
+    if "circle" in geometry:
+        return ("circle",)
+    if "line" in geometry:
+        return ("line",)
+    if "rectangle" in geometry:
+        size = geometry["rectangle"]["size"]
+        width = float(size["x"])
+        height = float(size["y"])
+        ratio = min(width, height) / max(width, height)
+        return ("rectangle", round(ratio, 12))
+    if "vector_path" in geometry:
+        canonical = json.dumps(
+            geometry["vector_path"],
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        )
+        return ("vector_path", canonical)
+    raise ValueError("matching shapes does not support this geometry")
+
+
 @dataclass(frozen=True, slots=True)
 class Color:
     red: float
@@ -307,6 +329,15 @@ class TransformFromCopy:
     key: str | None = None
 
 
+@dataclass(frozen=True, slots=True)
+class TransformMatchingShapes:
+    """Pair scene objects by deterministic shape signature, then replace them."""
+
+    sources: tuple[Object, ...] | list[Object]
+    targets: tuple[Object, ...] | list[Object]
+    key: str | None = None
+
+
 class Scene:
     """Complete, versioned Noon scene document."""
 
@@ -452,7 +483,10 @@ class Scene:
 
     def play(
         self,
-        *animations: Transform | ReplacementTransform | TransformFromCopy,
+        *animations: Transform
+        | ReplacementTransform
+        | TransformFromCopy
+        | TransformMatchingShapes,
         duration: float,
         start_time: float = 0.0,
         easing: str = "linear",
@@ -462,7 +496,14 @@ class Scene:
         checkpoint = self._authoring_checkpoint()
         try:
             for animation in animations:
-                if isinstance(animation, TransformFromCopy):
+                if isinstance(animation, TransformMatchingShapes):
+                    self._schedule_transform_matching_shapes(
+                        animation,
+                        duration=duration,
+                        start_time=start_time,
+                        easing=easing,
+                    )
+                elif isinstance(animation, TransformFromCopy):
                     self._schedule_transform_from_copy(
                         animation,
                         duration=duration,
@@ -485,7 +526,8 @@ class Scene:
                     )
                 else:
                     raise TypeError(
-                        "unsupported animation; expected Transform, ReplacementTransform, or TransformFromCopy"
+                        "unsupported animation; expected Transform, ReplacementTransform, "
+                        "TransformFromCopy, or TransformMatchingShapes"
                     )
         except Exception:
             self._restore_authoring_checkpoint(checkpoint)
@@ -560,6 +602,115 @@ class Scene:
         )
         self._scheduled_transform_targets[obj.id] = copy.deepcopy(target_snapshot)
         self._scheduled_transform_ends[obj.id] = start + run_duration
+
+    def _schedule_transform_matching_shapes(
+        self,
+        animation: TransformMatchingShapes,
+        *,
+        duration: float,
+        start_time: float,
+        easing: str,
+    ) -> None:
+        if not isinstance(animation.sources, (tuple, list)) or not isinstance(
+            animation.targets, (tuple, list)
+        ):
+            raise TypeError("matching sources and targets must be lists or tuples")
+        sources = list(animation.sources)
+        targets = list(animation.targets)
+        if not sources or not targets:
+            raise ValueError("matching sources and targets must be non-empty")
+
+        def validate_collection(objects: list[Object], label: str) -> list[int]:
+            ids: list[int] = []
+            for obj in objects:
+                if not isinstance(obj, Object) or obj._owner is not self._owner:
+                    raise ValueError(
+                        f"matching {label} objects must belong to this Scene"
+                    )
+                ids.append(obj.id)
+            if len(ids) != len(set(ids)):
+                raise ValueError(f"matching {label} objects must be unique")
+            return ids
+
+        source_ids = validate_collection(sources, "source")
+        target_ids = validate_collection(targets, "target")
+        if set(source_ids) & set(target_ids):
+            raise ValueError("matching sources and targets must be disjoint")
+
+        start = _finite_number("start_time", start_time)
+        run_duration = _positive_number("duration", duration)
+        end = start + run_duration
+
+        source_signatures: list[tuple[Any, ...]] = []
+        for source in sources:
+            self._ensure_lifecycle_source_present(source, start, "matching source")
+            self._ensure_snapshot_representable(source, end, "matching source")
+            self._ensure_replacement_source_unoverridden(source, end)
+            try:
+                snapshot = self._snapshot_for_object_at(source, start)
+            except ValueError as error:
+                raise ValueError(
+                    f"matching source cannot be snapshotted: {error}"
+                ) from error
+            source_signatures.append(
+                _matching_shape_signature(snapshot["geometry"])
+            )
+
+        target_signatures: list[tuple[Any, ...]] = []
+        for target in targets:
+            self._ensure_lifecycle_target_available(target, start, "matching")
+            self._ensure_snapshot_representable(target, end, "matching target")
+            try:
+                snapshot = self._snapshot_for_object_at(target, end)
+            except ValueError as error:
+                raise ValueError(
+                    f"matching target cannot be snapshotted at handoff: {error}"
+                ) from error
+            target_signatures.append(
+                _matching_shape_signature(snapshot["geometry"])
+            )
+
+        remaining_targets = list(zip(targets, target_signatures))
+        pairs: list[tuple[Object, Object]] = []
+        for source, signature in zip(sources, source_signatures):
+            match_index = next(
+                (
+                    index
+                    for index, (_, target_signature) in enumerate(remaining_targets)
+                    if target_signature == signature
+                ),
+                None,
+            )
+            if match_index is None:
+                raise ValueError(f"unmatched shape for source object {source.id}")
+            target, _ = remaining_targets.pop(match_index)
+            pairs.append((source, target))
+        if remaining_targets:
+            target, _ = remaining_targets[0]
+            raise ValueError(f"unmatched shape for target object {target.id}")
+
+        source_keys = [self._object_keys[source.id] for source in sources]
+        target_keys = [self._object_keys[target.id] for target in targets]
+        root_key = _authoring_key(
+            "key",
+            animation.key,
+            f"@matching:{'|'.join(source_keys)}->{'|'.join(target_keys)}",
+        )
+        pair_keys = [f"{root_key}.match:{index}" for index in range(len(pairs))]
+        existing_track_keys = set(self._track_keys.values())
+        collision = next(
+            (key for key in pair_keys if key in existing_track_keys), None
+        )
+        if collision is not None:
+            raise ValueError(f"duplicate track key: {collision}")
+
+        for index, (source, target) in enumerate(pairs):
+            self._schedule_replacement_transform(
+                ReplacementTransform(source, target, key=pair_keys[index]),
+                duration=run_duration,
+                start_time=start,
+                easing=easing,
+            )
 
     def _validate_lifecycle_target(
         self,

--- a/web/python/test_matching_shapes.py
+++ b/web/python/test_matching_shapes.py
@@ -2,7 +2,9 @@ import unittest
 
 from noon import (
     Color,
+    Rectangle,
     Scene,
+    Transform,
     TransformMatchingShapes,
     VectorPath,
 )
@@ -108,6 +110,36 @@ class TransformMatchingShapesTests(unittest.TestCase):
         self.assertEqual(
             transform["values"]["object"]["to"]["geometry"],
             {"rectangle": {"size": {"x": 1.0, "y": 2.0}}},
+        )
+
+    def test_matching_uses_evaluated_geometry_after_completed_transform(self) -> None:
+        scene = Scene()
+        source = scene.circle(1.0, key="source")
+        target = scene.rectangle(4.0, 2.0, key="target")
+
+        scene.play(
+            Transform(source, Rectangle(2.0, 1.0), key="become-rectangle"),
+            duration=1.0,
+        )
+        scene.play(
+            TransformMatchingShapes([source], [target], key="match-evaluated"),
+            duration=1.0,
+            start_time=1.0,
+        )
+
+        transforms = [
+            track
+            for track in scene.to_document()["tracks"]
+            if track["property"] == "transform"
+        ]
+        self.assertEqual(len(transforms), 2)
+        self.assertEqual(
+            transforms[-1]["values"]["object"]["from"]["geometry"],
+            {"rectangle": {"size": {"x": 2.0, "y": 1.0}}},
+        )
+        self.assertEqual(
+            transforms[-1]["values"]["object"]["to"]["geometry"],
+            {"rectangle": {"size": {"x": 4.0, "y": 2.0}}},
         )
 
     def test_exact_local_vector_paths_match(self) -> None:

--- a/web/python/test_matching_shapes.py
+++ b/web/python/test_matching_shapes.py
@@ -1,0 +1,193 @@
+import unittest
+
+from noon import (
+    Color,
+    Scene,
+    TransformMatchingShapes,
+    VectorPath,
+)
+
+
+class TransformMatchingShapesTests(unittest.TestCase):
+    def _build_scene(self) -> Scene:
+        scene = Scene()
+        source_circle_a = scene.circle(1.0, key="source-circle-a")
+        source_rectangle = scene.rectangle(2.0, 1.0, key="source-rectangle")
+        source_circle_b = scene.circle(0.5, key="source-circle-b")
+
+        target_rectangle = scene.rectangle(
+            4.0,
+            2.0,
+            position=(4.0, 0.0),
+            key="target-rectangle",
+        )
+        target_circle_a = scene.circle(
+            2.0,
+            position=(1.0, 2.0),
+            fill=Color(0.2, 0.6, 0.9),
+            key="target-circle-a",
+        )
+        target_circle_b = scene.circle(
+            3.0,
+            position=(-3.0, -1.0),
+            key="target-circle-b",
+        )
+
+        scene.play(
+            TransformMatchingShapes(
+                [source_circle_a, source_rectangle, source_circle_b],
+                [target_rectangle, target_circle_a, target_circle_b],
+                key="rearrange",
+            ),
+            duration=2.0,
+            start_time=1.0,
+            easing="ease_in_out_cubic",
+        )
+        return scene
+
+    def test_matches_by_shape_with_stable_duplicate_tie_breaking(self) -> None:
+        scene = self._build_scene()
+        document = scene.to_document()
+        transforms = [
+            track for track in document["tracks"] if track["property"] == "transform"
+        ]
+
+        self.assertEqual([track["object"] for track in transforms], [0, 1, 2])
+        self.assertEqual(
+            [track["values"]["object"]["to"]["geometry"] for track in transforms],
+            [
+                {"circle": {"radius": 2.0}},
+                {"rectangle": {"size": {"x": 4.0, "y": 2.0}}},
+                {"circle": {"radius": 3.0}},
+            ],
+        )
+        self.assertEqual(
+            [track["timing"] for track in transforms],
+            [
+                {
+                    "start_time": 1.0,
+                    "duration": 2.0,
+                    "easing": "ease_in_out_cubic",
+                }
+            ]
+            * 3,
+        )
+
+        identities = scene.identity_document()["tracks"]
+        transform_keys = [
+            entry["key"]
+            for entry, track in zip(identities, document["tracks"])
+            if track["property"] == "transform"
+        ]
+        self.assertEqual(
+            transform_keys,
+            [
+                "rearrange.match:0",
+                "rearrange.match:1",
+                "rearrange.match:2",
+            ],
+        )
+
+    def test_identity_is_deterministic_across_equivalent_reruns(self) -> None:
+        self.assertEqual(
+            self._build_scene().identity_document(),
+            self._build_scene().identity_document(),
+        )
+
+    def test_rectangle_matching_uses_normalized_aspect_ratio(self) -> None:
+        scene = Scene()
+        source = scene.rectangle(2.0, 1.0)
+        target = scene.rectangle(1.0, 2.0)
+        scene.play(TransformMatchingShapes([source], [target]), duration=1.0)
+
+        transform = next(
+            track
+            for track in scene.to_document()["tracks"]
+            if track["property"] == "transform"
+        )
+        self.assertEqual(
+            transform["values"]["object"]["to"]["geometry"],
+            {"rectangle": {"size": {"x": 1.0, "y": 2.0}}},
+        )
+
+    def test_exact_local_vector_paths_match(self) -> None:
+        def triangle() -> VectorPath:
+            return (
+                VectorPath()
+                .move_to((0.0, 1.0))
+                .line_to((-1.0, -1.0))
+                .line_to((1.0, -1.0))
+                .close()
+            )
+
+        scene = Scene()
+        source = scene.path(triangle(), key="source")
+        target = scene.path(
+            triangle(),
+            position=(3.0, 2.0),
+            fill=Color(0.8, 0.3, 0.2),
+            key="target",
+        )
+        scene.play(TransformMatchingShapes([source], [target]), duration=1.0)
+
+        transform = next(
+            track
+            for track in scene.to_document()["tracks"]
+            if track["property"] == "transform"
+        )
+        self.assertEqual(
+            transform["values"]["object"]["from"]["geometry"],
+            transform["values"]["object"]["to"]["geometry"],
+        )
+        self.assertEqual(
+            transform["values"]["object"]["to"]["transform"]["translation"],
+            {"x": 3.0, "y": 2.0},
+        )
+
+    def test_mismatch_is_rejected_transactionally(self) -> None:
+        scene = Scene()
+        source_circle = scene.circle(1.0)
+        source_rectangle = scene.rectangle(2.0, 1.0)
+        target_circle_a = scene.circle(2.0)
+        target_circle_b = scene.circle(3.0)
+        before_document = scene.to_document()
+        before_identity = scene.identity_document()
+
+        with self.assertRaisesRegex(ValueError, "unmatched shape"):
+            scene.play(
+                TransformMatchingShapes(
+                    [source_circle, source_rectangle],
+                    [target_circle_a, target_circle_b],
+                ),
+                duration=1.0,
+            )
+
+        self.assertEqual(scene.to_document(), before_document)
+        self.assertEqual(scene.identity_document(), before_identity)
+
+    def test_duplicate_overlap_and_foreign_objects_are_rejected(self) -> None:
+        scene = Scene()
+        source = scene.circle(1.0)
+        target = scene.circle(2.0)
+        other = scene.circle(3.0)
+        foreign = Scene().circle(4.0)
+
+        with self.assertRaisesRegex(ValueError, "unique"):
+            scene.play(
+                TransformMatchingShapes([source, source], [target, other]),
+                duration=1.0,
+            )
+        with self.assertRaisesRegex(ValueError, "disjoint"):
+            scene.play(
+                TransformMatchingShapes([source], [source]),
+                duration=1.0,
+            )
+        with self.assertRaisesRegex(ValueError, "belong"):
+            scene.play(
+                TransformMatchingShapes([source], [foreign]),
+                duration=1.0,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Scope

Add a conservative, deterministic `TransformMatchingShapes` authoring primitive without introducing a new runtime execution path.

- match source/target collections from evaluated geometry at animation start/handoff;
- use shape signatures for circles, lines, normalized rectangle aspect ratio, and exact local vector-path command geometry;
- use stable input-order tie-breaking for duplicate signatures;
- require every source and target to match exactly once;
- reject empty, duplicate, overlapping, foreign, or unmatched collections transactionally;
- lower every matched pair through the existing `ReplacementTransform` lifecycle path;
- preserve stable generated authoring identities;
- add Python authoring tests, simultaneous multi-pair runtime seek/rewind tests, and design documentation.

Unmatched-part fade behavior is intentionally not emulated with opacity; it remains a later feature once appearance/fade semantics are first-class.