### PR TITLE
Bound path mesh cache retention

### DIFF
--- a/crates/noon-render-wgpu/src/lib.rs
+++ b/crates/noon-render-wgpu/src/lib.rs
@@ -27,6 +27,7 @@ use std::{
 // progress in this exact domain avoids endpoint wraparound at reveal == 1.0
 // while retaining far more precision than pixel-scale path clipping needs.
 const PATH_PROGRESS_MAX: u32 = 16_777_215;
+const DEFAULT_PATH_MESH_CACHE_LIMIT: usize = 256;
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq, Pod, Zeroable)]
@@ -188,6 +189,7 @@ struct CachedPathMesh {
     stroke_cap: StrokeCap,
     fill_enabled: bool,
     mesh: TessellatedPath,
+    last_used: u64,
 }
 
 #[derive(Debug)]
@@ -213,6 +215,8 @@ pub struct FramePreparer {
     path_batch_cache_indices: Vec<usize>,
     path_mesh_cache: Vec<CachedPathMesh>,
     path_mesh_lookup: HashMap<PathMeshKey, Vec<usize>>,
+    path_mesh_cache_limit: Option<usize>,
+    path_mesh_clock: u64,
     unsupported: Vec<ObjectId>,
     slots: Vec<PreparedSlot>,
     circle_dirty_ranges: Vec<Range<usize>>,
@@ -307,6 +311,7 @@ impl FramePreparer {
     }
 
     fn rebuild<'a>(&'a mut self, frame: &FrameState) -> PreparedFrame<'a> {
+        self.prune_path_mesh_cache();
         let capacities_before = self.capacities();
 
         self.circle_ids.clear();
@@ -618,17 +623,19 @@ impl FramePreparer {
             style.stroke_cap,
             fill_enabled,
         );
-        if let Some(candidates) = self.path_mesh_lookup.get(&key) {
-            if let Some(index) = candidates.iter().copied().find(|&index| {
+        let existing = self.path_mesh_lookup.get(&key).and_then(|candidates| {
+            candidates.iter().copied().find(|&index| {
                 let entry = &self.path_mesh_cache[index];
                 entry.path == *path
                     && entry.stroke_width_bits == stroke_width_bits
                     && entry.stroke_join == style.stroke_join
                     && entry.stroke_cap == style.stroke_cap
                     && entry.fill_enabled == fill_enabled
-            }) {
-                return Ok((index, false));
-            }
+            })
+        });
+        if let Some(index) = existing {
+            self.mark_path_mesh_used(index);
+            return Ok((index, false));
         }
 
         let mesh = noon_geometry::tessellate_styled_with_fill(
@@ -639,6 +646,7 @@ impl FramePreparer {
             fill_enabled,
         )?;
         let index = self.path_mesh_cache.len();
+        let last_used = self.next_path_mesh_use();
         self.path_mesh_cache.push(CachedPathMesh {
             path: path.clone(),
             stroke_width_bits,
@@ -646,9 +654,71 @@ impl FramePreparer {
             stroke_cap: style.stroke_cap,
             fill_enabled,
             mesh,
+            last_used,
         });
         self.path_mesh_lookup.entry(key).or_default().push(index);
         Ok((index, true))
+    }
+
+    fn next_path_mesh_use(&mut self) -> u64 {
+        self.path_mesh_clock = self.path_mesh_clock.saturating_add(1);
+        self.path_mesh_clock
+    }
+
+    fn mark_path_mesh_used(&mut self, index: usize) {
+        let last_used = self.next_path_mesh_use();
+        self.path_mesh_cache[index].last_used = last_used;
+    }
+
+    fn prune_path_mesh_cache(&mut self) {
+        let limit = self.path_mesh_cache_limit();
+        if self.path_mesh_cache.len() <= limit {
+            return;
+        }
+
+        let mut order: Vec<usize> = (0..self.path_mesh_cache.len()).collect();
+        order.sort_unstable_by(|&left, &right| {
+            self.path_mesh_cache[right]
+                .last_used
+                .cmp(&self.path_mesh_cache[left].last_used)
+                .then_with(|| right.cmp(&left))
+        });
+        let mut keep = vec![false; self.path_mesh_cache.len()];
+        for index in order.into_iter().take(limit) {
+            keep[index] = true;
+        }
+
+        let old_cache = std::mem::take(&mut self.path_mesh_cache);
+        self.path_mesh_lookup.clear();
+        for (old_index, entry) in old_cache.into_iter().enumerate() {
+            if !keep[old_index] {
+                continue;
+            }
+            let key = path_mesh_key(
+                &entry.path,
+                entry.stroke_width_bits,
+                entry.stroke_join,
+                entry.stroke_cap,
+                entry.fill_enabled,
+            );
+            let new_index = self.path_mesh_cache.len();
+            self.path_mesh_cache.push(entry);
+            self.path_mesh_lookup.entry(key).or_default().push(new_index);
+        }
+    }
+
+    /// Sets the number of recently used path meshes retained between full rebuilds.
+    ///
+    /// The limit is applied at the next full rebuild boundary. A prepared frame may
+    /// temporarily contain more meshes than this limit because meshes created while
+    /// rebuilding are never evicted out from under that frame's batch indices.
+    pub fn set_path_mesh_cache_limit(&mut self, limit: usize) {
+        self.path_mesh_cache_limit = Some(limit);
+    }
+
+    pub fn path_mesh_cache_limit(&self) -> usize {
+        self.path_mesh_cache_limit
+            .unwrap_or(DEFAULT_PATH_MESH_CACHE_LIMIT)
     }
 
     pub fn cached_path_mesh_count(&self) -> usize {

--- a/crates/noon-render-wgpu/src/lib.rs
+++ b/crates/noon-render-wgpu/src/lib.rs
@@ -311,7 +311,7 @@ impl FramePreparer {
     }
 
     fn rebuild<'a>(&'a mut self, frame: &FrameState) -> PreparedFrame<'a> {
-        self.prune_path_mesh_cache();
+        self.prune_path_mesh_cache(frame);
         let capacities_before = self.capacities();
 
         self.circle_ids.clear();
@@ -670,22 +670,59 @@ impl FramePreparer {
         self.path_mesh_cache[index].last_used = last_used;
     }
 
-    fn prune_path_mesh_cache(&mut self) {
+    fn prune_path_mesh_cache(&mut self, frame: &FrameState) {
         let limit = self.path_mesh_cache_limit();
         if self.path_mesh_cache.len() <= limit {
             return;
         }
 
-        let mut order: Vec<usize> = (0..self.path_mesh_cache.len()).collect();
+        let mut keep = vec![false; self.path_mesh_cache.len()];
+        for (object_index, object) in frame.objects.iter().enumerate() {
+            if !frame.is_present(object_index) {
+                continue;
+            }
+            let GeometryRef::VectorPath(path) = frame.render_geometry(object_index) else {
+                continue;
+            };
+            let stroke_width_bits = object.style.stroke_width.to_bits();
+            let fill_enabled = object.style.fill.is_some();
+            let key = path_mesh_key(
+                path,
+                stroke_width_bits,
+                object.style.stroke_join,
+                object.style.stroke_cap,
+                fill_enabled,
+            );
+            if let Some(candidates) = self.path_mesh_lookup.get(&key) {
+                if let Some(index) = candidates.iter().copied().find(|&index| {
+                    let entry = &self.path_mesh_cache[index];
+                    entry.path == *path
+                        && entry.stroke_width_bits == stroke_width_bits
+                        && entry.stroke_join == object.style.stroke_join
+                        && entry.stroke_cap == object.style.stroke_cap
+                        && entry.fill_enabled == fill_enabled
+                }) {
+                    keep[index] = true;
+                }
+            }
+        }
+
+        let pinned_count = keep.iter().filter(|&&pinned| pinned).count();
+        let stale_budget = limit.saturating_sub(pinned_count);
+        let mut order: Vec<usize> = (0..self.path_mesh_cache.len())
+            .filter(|&index| !keep[index])
+            .collect();
         order.sort_unstable_by(|&left, &right| {
             self.path_mesh_cache[right]
                 .last_used
                 .cmp(&self.path_mesh_cache[left].last_used)
                 .then_with(|| right.cmp(&left))
         });
-        let mut keep = vec![false; self.path_mesh_cache.len()];
-        for index in order.into_iter().take(limit) {
+        for index in order.into_iter().take(stale_budget) {
             keep[index] = true;
+        }
+        if keep.iter().all(|&retained| retained) {
+            return;
         }
 
         let old_cache = std::mem::take(&mut self.path_mesh_cache);
@@ -703,15 +740,18 @@ impl FramePreparer {
             );
             let new_index = self.path_mesh_cache.len();
             self.path_mesh_cache.push(entry);
-            self.path_mesh_lookup.entry(key).or_default().push(new_index);
+            self.path_mesh_lookup
+                .entry(key)
+                .or_default()
+                .push(new_index);
         }
     }
 
-    /// Sets the number of recently used path meshes retained between full rebuilds.
+    /// Sets the target number of path meshes retained across full rebuilds.
     ///
-    /// The limit is applied at the next full rebuild boundary. A prepared frame may
-    /// temporarily contain more meshes than this limit because meshes created while
-    /// rebuilding are never evicted out from under that frame's batch indices.
+    /// Incoming-frame meshes are pinned before stale LRU eviction, so a prepared
+    /// frame may contain more meshes than this limit without forcing retessellation
+    /// or invalidating its path-batch cache indices.
     pub fn set_path_mesh_cache_limit(&mut self, limit: usize) {
         self.path_mesh_cache_limit = Some(limit);
     }

--- a/crates/noon-render-wgpu/tests/path_cache_lifecycle.rs
+++ b/crates/noon-render-wgpu/tests/path_cache_lifecycle.rs
@@ -65,7 +65,7 @@ fn path_cache_retains_recent_meshes_and_evicts_stale_entries() {
 }
 
 #[test]
-fn active_frame_geometry_can_exceed_retention_budget() {
+fn active_frame_geometry_can_exceed_retention_budget_without_retessellation() {
     let a = path(0.0);
     let b = path(10.0);
     let mut preparer = FramePreparer::new();
@@ -81,8 +81,8 @@ fn active_frame_geometry_can_exceed_retention_budget() {
     let prepared = preparer.prepare(scene.frame());
     assert_eq!(prepared.path_ids.len(), 2);
     assert_eq!(
-        prepared.stats.geometry_cache_misses, 1,
-        "pruning must happen before rebuild, never by evicting active-frame meshes"
+        prepared.stats.geometry_cache_misses, 0,
+        "incoming-frame meshes must be pinned before stale LRU eviction"
     );
     assert_eq!(preparer.cached_path_mesh_count(), 2);
 }

--- a/crates/noon-render-wgpu/tests/path_cache_lifecycle.rs
+++ b/crates/noon-render-wgpu/tests/path_cache_lifecycle.rs
@@ -1,0 +1,88 @@
+use noon_compile::CompiledScene;
+use noon_core::{Color, GeometryRef, SceneDefinition, Style, Vec2, VectorPath};
+use noon_render_wgpu::FramePreparer;
+use noon_runtime::SceneInstance;
+
+fn path(seed: f32) -> VectorPath {
+    VectorPath::new()
+        .move_to(Vec2::new(seed, 0.0))
+        .line_to(Vec2::new(seed + 1.0, 0.5))
+        .line_to(Vec2::new(seed + 0.25, 1.5))
+}
+
+fn path_scene(paths: &[VectorPath]) -> SceneInstance {
+    let mut scene = SceneDefinition::new();
+    for path in paths {
+        let object = scene.add(GeometryRef::path(path.clone()));
+        scene.object_mut(object).expect("path object exists").style = Style {
+            fill: None,
+            stroke: Some(Color::WHITE),
+            stroke_width: 0.2,
+            ..Style::default()
+        };
+    }
+    SceneInstance::new(CompiledScene::compile(&scene).expect("path scene compiles"))
+}
+
+#[test]
+fn path_cache_retains_recent_meshes_and_evicts_stale_entries() {
+    let a = path(0.0);
+    let b = path(10.0);
+    let c = path(20.0);
+    let mut preparer = FramePreparer::new();
+    preparer.set_path_mesh_cache_limit(2);
+
+    let scene_a = path_scene(std::slice::from_ref(&a));
+    let prepared = preparer.prepare(scene_a.frame());
+    assert_eq!(prepared.stats.geometry_cache_misses, 1);
+    assert_eq!(preparer.cached_path_mesh_count(), 1);
+
+    let scene_b = path_scene(std::slice::from_ref(&b));
+    let prepared = preparer.prepare(scene_b.frame());
+    assert_eq!(prepared.stats.geometry_cache_misses, 1);
+    assert_eq!(preparer.cached_path_mesh_count(), 2);
+
+    let scene_a = path_scene(std::slice::from_ref(&a));
+    let prepared = preparer.prepare(scene_a.frame());
+    assert_eq!(prepared.stats.geometry_cache_misses, 0);
+
+    let scene_c = path_scene(std::slice::from_ref(&c));
+    let prepared = preparer.prepare(scene_c.frame());
+    assert_eq!(prepared.stats.geometry_cache_misses, 1);
+    assert_eq!(preparer.cached_path_mesh_count(), 3);
+
+    let scene_a = path_scene(std::slice::from_ref(&a));
+    let prepared = preparer.prepare(scene_a.frame());
+    assert_eq!(prepared.stats.geometry_cache_misses, 0);
+    assert_eq!(preparer.cached_path_mesh_count(), 2);
+
+    let scene_b = path_scene(std::slice::from_ref(&b));
+    let prepared = preparer.prepare(scene_b.frame());
+    assert_eq!(
+        prepared.stats.geometry_cache_misses, 1,
+        "least-recently-used stale mesh should have been evicted"
+    );
+}
+
+#[test]
+fn active_frame_geometry_can_exceed_retention_budget() {
+    let a = path(0.0);
+    let b = path(10.0);
+    let mut preparer = FramePreparer::new();
+    preparer.set_path_mesh_cache_limit(1);
+
+    let scene = path_scene(&[a.clone(), b.clone()]);
+    let prepared = preparer.prepare(scene.frame());
+    assert_eq!(prepared.path_ids.len(), 2);
+    assert_eq!(prepared.stats.geometry_cache_misses, 2);
+    assert_eq!(preparer.cached_path_mesh_count(), 2);
+
+    let scene = path_scene(&[a, b]);
+    let prepared = preparer.prepare(scene.frame());
+    assert_eq!(prepared.path_ids.len(), 2);
+    assert_eq!(
+        prepared.stats.geometry_cache_misses, 1,
+        "pruning must happen before rebuild, never by evicting active-frame meshes"
+    );
+    assert_eq!(preparer.cached_path_mesh_count(), 2);
+}

--- a/docs/path-cache-lifecycle.md
+++ b/docs/path-cache-lifecycle.md
@@ -1,0 +1,39 @@
+# Path mesh cache lifecycle
+
+Noon's renderer caches tessellated `VectorPath` meshes so transform, color, opacity, reveal, and morph-progress changes can reuse geometry instead of tessellating every frame.
+
+Long-lived interactive authoring changes the cache requirement: a session can create many distinct path/style combinations over time, so retaining every mesh forever would make renderer memory grow monotonically even after those paths disappear from the scene.
+
+## Policy
+
+`FramePreparer` now treats the path mesh cache as a bounded retained working set.
+
+- The default retention target is 256 path/style meshes.
+- Every cache hit and insertion advances a deterministic recency counter.
+- Eviction only runs when entering a full frame rebuild. Incremental frame updates never compact or reindex the cache.
+- Before applying the retention target, meshes already required by the incoming frame are pinned.
+- Remaining stale entries are retained by least-recently-used policy up to the configured target.
+- If the incoming frame itself needs more meshes than the target, all of those active meshes remain cached. The target bounds stale retention; it never makes an active frame incomplete or forces already-cached active geometry to be retessellated.
+- Cache compaction rebuilds the hash lookup from the retained entries, so lookup indices and the compacted mesh vector stay consistent.
+
+This keeps the frame-critical incremental path unchanged while bounding memory retained from historical authoring states.
+
+## Configuration
+
+`FramePreparer::set_path_mesh_cache_limit(limit)` changes the retention target. The setting takes effect at a subsequent full rebuild boundary.
+
+`FramePreparer::path_mesh_cache_limit()` reports the configured target, and `cached_path_mesh_count()` reports the current number of cached meshes. The current count can legitimately exceed the target when the incoming active frame itself needs more unique path/style meshes.
+
+A limit of zero means no stale mesh retention: meshes used by the incoming frame are still pinned and may remain in the cache.
+
+## Correctness invariants
+
+The implementation is tested for these properties:
+
+1. Recently reused meshes survive stale-cache pruning.
+2. A least-recently-used stale mesh is tessellated again after eviction.
+3. Incoming-frame meshes are pinned before eviction, even when the active set exceeds the configured target.
+4. Full-rebuild compaction does not leave stale hash lookup indices.
+5. Incremental animation updates continue to reuse existing path geometry and do not trigger cache pruning.
+
+The cache policy is deliberately CPU-side and renderer-local. It does not change semantic scene identity, timeline evaluation, serialized IR, or the WebGPU instance format.

--- a/docs/vector-geometry-status.md
+++ b/docs/vector-geometry-status.md
@@ -1,0 +1,25 @@
+# Vector geometry milestone status
+
+This note records the implementation state of Milestone 4 after the generic Transform and lifecycle work. It supplements the older checklist in `implementation-plan.md`, whose remaining-work section predates several completed slices.
+
+## Implemented
+
+- Renderer-independent `VectorPath` commands and versioned authoring/serialization.
+- Deterministic Lyon fill/stroke tessellation with structural correctness tests.
+- Cached path meshes and instanced transform/style rendering.
+- Numerically testable path-reveal metadata and runtime reveal progress.
+- Compatible, endpoint-exact morph planning with renderer reuse across morph progress.
+- Generic Transform across analytic and vector geometry, including evaluated authoring snapshots.
+- `ReplacementTransform`, `TransformFromCopy`, chained lifecycle composition, and deterministic `TransformMatchingShapes` lowering.
+- Bounded historical path-mesh retention for long-lived authoring sessions, with incoming-frame pinning and stale LRU eviction.
+
+## Remaining focused work
+
+The vector-geometry foundation no longer has a missing reveal, morph-plan, or cache-lifecycle primitive. Remaining work is primarily hardening and scale validation:
+
+- larger path and morph performance baselines;
+- optional byte-weighted cache budgeting if real workloads show entry count is an insufficient memory proxy;
+- broader property/fuzz coverage for malformed paths, transforms, seeks, and live patches;
+- small controlled raster/golden tests only where structural and numerical tests cannot prove renderer output.
+
+Higher-level appearance behavior such as Fade should be modeled explicitly rather than emulated through matching-shape opacity tricks. Text remains a separate architecture milestone (`GlyphRun` for normal text and `OutlineText` for path-level animation) rather than being folded into generic vector paths.


### PR DESCRIPTION
## Scope

Prevent `FramePreparer` path tessellation cache growth from becoming unbounded by historical authoring states.

- retain a finite default target of 256 recently used path/style meshes;
- update recency on cache hits and inserts;
- prune only at full-rebuild boundaries so incremental-frame cache indices remain stable;
- pin meshes required by the incoming frame before LRU eviction, avoiding needless retessellation when the active set exceeds the target;
- rebuild hash lookup indices deterministically after compaction;
- expose a configurable retention target for tests and future tuning;
- add regressions for LRU retention, stale retessellation, and over-budget active frames;
- document cache lifecycle and tuning semantics.

The current budget is entry-count based rather than byte-weighted. It bounds retained historical entries, while a single unusually complex path can still dominate memory; a byte-weighted budget can be layered on later without changing the lifecycle boundary.