### PR TITLE
Add new animation features to the playground demo

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -11,6 +11,8 @@ python3 -m http.server --directory web 8080
 
 Then open <http://localhost:8080> in a WebGPU-capable browser. The JavaScript `requestAnimationFrame` timestamp is converted to deterministic scene time in Rust; JavaScript only owns browser scheduling and canvas sizing.
 
+The **Example** picker includes **Lifecycle · matching · Fade**, an executable showcase of chained `ReplacementTransform`, `TransformFromCopy`, `TransformMatchingShapes`, and `FadeIn`/`FadeOut`. Its Fade lane uses a semantically translucent object to demonstrate that renderer Appearance modulates authored opacity without rewriting it. The showcase completes within the playground's four-second loop so every advertised handoff is visible during normal playback.
+
 Open **Python scene source** and click **Run Python scene** to build a complete versioned `SceneDocument`. Explicit object and track `key` values retain runtime identity across Python reruns. Compatible style, transform, and timeline edits reconcile into semantic patches; unsafe geometry or draw-order changes fall back to transactional replacement. Both paths preserve the playhead and existing canvas/GPU resources and restart ordered patch sequencing at zero. **Run Python patch** then sends an incremental `PatchBatch` to that persistent runtime. The first Python action lazily downloads the pinned Pyodide runtime; playback continues while Python loads or runs, and deployed scenes still work without Pyodide when the authoring controls are unused.
 
 The worker loads Pyodide `314.0.5` from the official jsDelivr distribution, so the Python control requires network access. The render/runtime wasm package remains local under `web/pkg/`.

--- a/web/main.js
+++ b/web/main.js
@@ -37,6 +37,13 @@ const SCENE_EXAMPLES = [
     features: "primitives · path morph · timeline",
   },
   {
+    name: "Lifecycle · matching · Fade",
+    path: "./python/examples/feature_showcase.py",
+    summary:
+      "Replacement chains, TransformFromCopy, matching-shape handoffs, and Fade appearance composition on one timeline.",
+    features: "ReplacementTransform · TransformFromCopy · matching · FadeIn/FadeOut",
+  },
+  {
     name: "Analytic primitive Transform",
     path: "./python/examples/analytic_transform.py",
     summary:

--- a/web/python/examples/feature_showcase.py
+++ b/web/python/examples/feature_showcase.py
@@ -1,0 +1,158 @@
+from noon import (
+    Circle,
+    Color,
+    FadeIn,
+    FadeOut,
+    Rectangle,
+    ReplacementTransform,
+    Scene,
+    TransformFromCopy,
+    TransformMatchingShapes,
+)
+
+scene = Scene()
+
+# Top lane: one stable semantic object hands off through two lifecycle targets.
+# Exact-boundary chaining exercises Presence continuity while the visible shape
+# moves and changes geometry.
+first = scene.add(
+    Circle(
+        0.42,
+        position=(-2.55, 1.25),
+        fill=Color(0.96, 0.38, 0.42),
+        stroke=Color(1.0, 0.82, 0.84),
+        stroke_width=0.06,
+    ),
+    key="lifecycle-first",
+)
+middle = scene.add(
+    Rectangle(
+        1.05,
+        0.72,
+        position=(0.0, 1.25),
+        rotation=0.25,
+        fill=Color(0.36, 0.64, 0.98),
+        stroke=Color(0.78, 0.9, 1.0),
+        stroke_width=0.07,
+    ),
+    key="lifecycle-middle",
+)
+last = scene.add(
+    Circle(
+        0.7,
+        position=(2.55, 1.25),
+        fill=Color(0.7, 0.42, 0.96),
+        stroke=Color(0.9, 0.8, 1.0),
+        stroke_width=0.08,
+    ),
+    key="lifecycle-last",
+)
+scene.play(
+    ReplacementTransform(first, middle, key="lifecycle.first-to-middle"),
+    duration=2.0,
+    easing="ease_in_out_cubic",
+)
+scene.play(
+    ReplacementTransform(middle, last, key="lifecycle.middle-to-last"),
+    duration=2.0,
+    start_time=2.0,
+    easing="ease_in_out_cubic",
+)
+
+# Middle lane: TransformFromCopy leaves the source untouched. The copied target
+# has authored semantic opacity 0.42, so FadeOut/FadeIn visibly proves that the
+# Appearance channel modulates opacity without rewriting that authored value.
+copy_source = scene.add(
+    Circle(
+        0.34,
+        position=(-2.55, 0.0),
+        fill=Color(0.2, 0.86, 0.68),
+        stroke=Color(0.72, 1.0, 0.9),
+        stroke_width=0.055,
+    ),
+    key="copy-source",
+)
+copy_target = scene.add(
+    Circle(
+        0.68,
+        position=(0.0, 0.0),
+        fill=Color(0.18, 0.78, 0.94),
+        stroke=Color(0.72, 0.94, 1.0),
+        stroke_width=0.08,
+        opacity=0.42,
+    ),
+    key="copy-target",
+)
+scene.play(
+    TransformFromCopy(copy_source, copy_target, key="copy.spawn"),
+    duration=2.0,
+    easing="ease_in_out_cubic",
+)
+scene.play(
+    FadeOut(copy_target, key="copy.fade-out"),
+    duration=1.25,
+    start_time=2.5,
+    easing="ease_in_out_cubic",
+)
+scene.play(
+    FadeIn(copy_target, key="copy.fade-in"),
+    duration=1.25,
+    start_time=4.25,
+    easing="ease_in_out_cubic",
+)
+
+# Bottom lane: targets are deliberately authored out of source order.
+# TransformMatchingShapes pairs by semantic geometry signature, not by list
+# position. Duplicate circles use stable input-order tie breaking.
+source_circle_a = scene.circle(
+    0.28,
+    position=(-2.8, -1.35),
+    fill=Color(0.98, 0.66, 0.22),
+    key="match-source-circle-a",
+)
+source_rectangle = scene.rectangle(
+    0.78,
+    0.46,
+    position=(-1.75, -1.35),
+    fill=Color(0.94, 0.46, 0.32),
+    key="match-source-rectangle",
+)
+source_circle_b = scene.circle(
+    0.42,
+    position=(-0.7, -1.35),
+    fill=Color(0.9, 0.34, 0.64),
+    key="match-source-circle-b",
+)
+
+target_rectangle = scene.rectangle(
+    1.08,
+    0.62,
+    position=(0.45, -1.35),
+    rotation=0.28,
+    fill=Color(0.42, 0.62, 0.98),
+    key="match-target-rectangle",
+)
+target_circle_a = scene.circle(
+    0.48,
+    position=(1.65, -1.35),
+    fill=Color(0.36, 0.86, 0.72),
+    key="match-target-circle-a",
+)
+target_circle_b = scene.circle(
+    0.64,
+    position=(2.85, -1.35),
+    fill=Color(0.62, 0.48, 0.98),
+    key="match-target-circle-b",
+)
+scene.play(
+    TransformMatchingShapes(
+        [source_circle_a, source_rectangle, source_circle_b],
+        [target_rectangle, target_circle_a, target_circle_b],
+        key="matching.rearrange",
+    ),
+    duration=2.0,
+    start_time=4.0,
+    easing="ease_in_out_cubic",
+)
+
+result = scene

--- a/web/python/examples/feature_showcase.py
+++ b/web/python/examples/feature_showcase.py
@@ -12,6 +12,9 @@ from noon import (
 
 scene = Scene()
 
+# The playground loops at four seconds, so every lane completes before the
+# clock wraps and leaves a short hold on its final state.
+
 # Top lane: one stable semantic object hands off through two lifecycle targets.
 # Exact-boundary chaining exercises Presence continuity while the visible shape
 # moves and changes geometry.
@@ -49,13 +52,13 @@ last = scene.add(
 )
 scene.play(
     ReplacementTransform(first, middle, key="lifecycle.first-to-middle"),
-    duration=2.0,
+    duration=1.2,
     easing="ease_in_out_cubic",
 )
 scene.play(
     ReplacementTransform(middle, last, key="lifecycle.middle-to-last"),
-    duration=2.0,
-    start_time=2.0,
+    duration=1.2,
+    start_time=1.2,
     easing="ease_in_out_cubic",
 )
 
@@ -85,19 +88,19 @@ copy_target = scene.add(
 )
 scene.play(
     TransformFromCopy(copy_source, copy_target, key="copy.spawn"),
-    duration=2.0,
+    duration=1.2,
     easing="ease_in_out_cubic",
 )
 scene.play(
     FadeOut(copy_target, key="copy.fade-out"),
-    duration=1.25,
-    start_time=2.5,
+    duration=0.6,
+    start_time=1.5,
     easing="ease_in_out_cubic",
 )
 scene.play(
     FadeIn(copy_target, key="copy.fade-in"),
-    duration=1.25,
-    start_time=4.25,
+    duration=0.6,
+    start_time=2.5,
     easing="ease_in_out_cubic",
 )
 
@@ -152,8 +155,8 @@ scene.play(
         [target_rectangle, target_circle_a, target_circle_b],
         key="matching.rearrange",
     ),
-    duration=2.0,
-    start_time=4.0,
+    duration=1.5,
+    start_time=2.0,
     easing="ease_in_out_cubic",
 )
 

--- a/web/python/examples/feature_showcase.py
+++ b/web/python/examples/feature_showcase.py
@@ -124,10 +124,12 @@ source_circle_b = scene.circle(
     key="match-source-circle-b",
 )
 
+# Matching rectangles preserve normalized aspect ratio; this target is exactly
+# 2x the source dimensions while still changing position, rotation, and style.
 target_rectangle = scene.rectangle(
-    1.08,
-    0.62,
-    position=(0.45, -1.35),
+    1.56,
+    0.92,
+    position=(0.35, -1.35),
     rotation=0.28,
     fill=Color(0.42, 0.62, 0.98),
     key="match-target-rectangle",

--- a/web/python/test_feature_showcase.py
+++ b/web/python/test_feature_showcase.py
@@ -24,6 +24,12 @@ class FeatureShowcaseTests(unittest.TestCase):
         # first, middle, last, copy-source, copy-target
         self.assertEqual(document["objects"][4]["style"]["opacity"], 0.42)
 
+        latest_end = max(
+            track["timing"]["start_time"] + track["timing"]["duration"]
+            for track in document["tracks"]
+        )
+        self.assertLess(latest_end, 4.0)
+
     def test_showcase_is_registered_in_the_playground_gallery(self) -> None:
         main_js = (Path(__file__).parents[1] / "main.js").read_text()
         self.assertIn("./python/examples/feature_showcase.py", main_js)

--- a/web/python/test_feature_showcase.py
+++ b/web/python/test_feature_showcase.py
@@ -1,0 +1,38 @@
+import runpy
+import unittest
+from pathlib import Path
+
+from noon import Scene
+
+
+class FeatureShowcaseTests(unittest.TestCase):
+    def _run_showcase(self) -> Scene:
+        example = Path(__file__).parent / "examples" / "feature_showcase.py"
+        namespace = runpy.run_path(example)
+        result = namespace["result"]
+        self.assertIsInstance(result, Scene)
+        return result
+
+    def test_showcase_exercises_new_animation_features(self) -> None:
+        document = self._run_showcase().to_document()
+        properties = [track["property"] for track in document["tracks"]]
+
+        self.assertGreaterEqual(properties.count("transform"), 7)
+        self.assertGreaterEqual(properties.count("presence"), 10)
+        self.assertEqual(properties.count("appearance"), 2)
+
+        semantic_opacity = next(
+            obj["style"]["opacity"]
+            for obj in document["objects"]
+            if obj["key"] == "copy-target"
+        )
+        self.assertEqual(semantic_opacity, 0.42)
+
+    def test_showcase_is_registered_in_the_playground_gallery(self) -> None:
+        main_js = (Path(__file__).parents[1] / "main.js").read_text()
+        self.assertIn("./python/examples/feature_showcase.py", main_js)
+        self.assertIn("Lifecycle · matching · Fade", main_js)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/python/test_feature_showcase.py
+++ b/web/python/test_feature_showcase.py
@@ -17,16 +17,12 @@ class FeatureShowcaseTests(unittest.TestCase):
         document = self._run_showcase().to_document()
         properties = [track["property"] for track in document["tracks"]]
 
-        self.assertGreaterEqual(properties.count("transform"), 7)
+        self.assertGreaterEqual(properties.count("transform"), 6)
         self.assertGreaterEqual(properties.count("presence"), 10)
         self.assertEqual(properties.count("appearance"), 2)
 
-        semantic_opacity = next(
-            obj["style"]["opacity"]
-            for obj in document["objects"]
-            if obj["key"] == "copy-target"
-        )
-        self.assertEqual(semantic_opacity, 0.42)
+        # first, middle, last, copy-source, copy-target
+        self.assertEqual(document["objects"][4]["style"]["opacity"], 0.42)
 
     def test_showcase_is_registered_in_the_playground_gallery(self) -> None:
         main_js = (Path(__file__).parents[1] / "main.js").read_text()


### PR DESCRIPTION
## Scope

Expose the recently implemented authoring/runtime features directly in the browser playground.

- add a dedicated `Lifecycle · matching · Fade` Python example;
- demonstrate chained `ReplacementTransform`, `TransformFromCopy`, `TransformMatchingShapes`, and `FadeIn`/`FadeOut` on one timeline;
- demonstrate Fade preserving authored semantic opacity via the independent Appearance channel;
- register the scene in the playground example picker;
- add regression coverage that executes the showcase and verifies the gallery wiring.

The showcase is intentionally built only from public Python authoring APIs so it doubles as executable documentation.