### PR TITLE
Fix Create-to-analytic stroke continuity

### DIFF
--- a/crates/noon-render-wgpu/src/analytic.wgsl
+++ b/crates/noon-render-wgpu/src/analytic.wgsl
@@ -80,6 +80,10 @@ fn local_axis_padding(scale: vec2<f32>, rotation: f32) -> vec2<f32> {
     );
 }
 
+fn stroke_half_width(metrics: vec2<f32>, flags: vec2<u32>) -> f32 {
+    return select(0.0, max(metrics.x, 0.0) * 0.5, flags.y != 0u);
+}
+
 fn make_output(input: VertexInput, local: vec2<f32>) -> VertexOutput {
     var output: VertexOutput;
     let world = transform_point(local, input.translation, input.scale, input.rotation);
@@ -98,7 +102,8 @@ fn make_output(input: VertexInput, local: vec2<f32>) -> VertexOutput {
 fn vs_circle(input: VertexInput) -> VertexOutput {
     let radius = max(abs(input.geometry.x), 0.000001);
     let padding = local_axis_padding(input.scale, input.rotation);
-    let local = input.unit * (vec2<f32>(radius) + padding);
+    let stroke_padding = stroke_half_width(input.metrics, input.flags);
+    let local = input.unit * (vec2<f32>(radius + stroke_padding) + padding);
     return make_output(input, local);
 }
 
@@ -106,7 +111,8 @@ fn vs_circle(input: VertexInput) -> VertexOutput {
 fn vs_rectangle(input: VertexInput) -> VertexOutput {
     let half_size = abs(input.geometry) * 0.5;
     let padding = local_axis_padding(input.scale, input.rotation);
-    let local = input.unit * (half_size + padding);
+    let stroke_padding = stroke_half_width(input.metrics, input.flags);
+    let local = input.unit * (half_size + vec2<f32>(stroke_padding) + padding);
     return make_output(input, local);
 }
 
@@ -172,11 +178,15 @@ fn styled_shape_color(
     opacity: f32,
     fill_enabled: bool,
     stroke_enabled: bool,
-    outer_signed_distance: f32,
+    signed_distance: f32,
     stroke_width: f32,
 ) -> vec4<f32> {
-    let outer_coverage = inside_coverage(outer_signed_distance);
-    let stroke_coverage = outside_coverage(outer_signed_distance + stroke_width);
+    // Match VectorPath/Lyon semantics: the authored outline is the stroke centerline.
+    // A stroke extends half its width outside and half inside the semantic boundary.
+    let half_stroke_width = max(stroke_width, 0.0) * 0.5;
+    let fill_coverage = inside_coverage(signed_distance);
+    let outer_coverage = inside_coverage(signed_distance - half_stroke_width);
+    let stroke_coverage = outside_coverage(signed_distance + half_stroke_width);
     let has_stroke = stroke_enabled && stroke_width > 0.0;
     if has_stroke {
         if fill_enabled {
@@ -187,7 +197,7 @@ fn styled_shape_color(
     }
 
     if fill_enabled {
-        return covered_color(fill, opacity, outer_coverage);
+        return covered_color(fill, opacity, fill_coverage);
     }
     return vec4<f32>(0.0);
 }
@@ -217,7 +227,7 @@ fn capsule_signed_distance(position: vec2<f32>, half_length: f32, radius: f32) -
 fn fs_circle(input: VertexOutput) -> @location(0) vec4<f32> {
     let radius = max(abs(input.geometry.x), 0.000001);
     let signed_distance = length(input.local) - radius;
-    let stroke_width = clamp(input.metrics.x, 0.0, radius);
+    let stroke_width = max(input.metrics.x, 0.0);
     return styled_shape_color(
         input.fill,
         input.stroke,
@@ -233,7 +243,7 @@ fn fs_circle(input: VertexOutput) -> @location(0) vec4<f32> {
 fn fs_rectangle(input: VertexOutput) -> @location(0) vec4<f32> {
     let half_size = max(abs(input.geometry) * 0.5, vec2<f32>(0.000001));
     let signed_distance = rectangle_signed_distance(input.local, half_size);
-    let stroke_width = clamp(input.metrics.x, 0.0, min(half_size.x, half_size.y));
+    let stroke_width = max(input.metrics.x, 0.0);
     return styled_shape_color(
         input.fill,
         input.stroke,

--- a/crates/noon-render-wgpu/tests/analytic_stroke_parity.rs
+++ b/crates/noon-render-wgpu/tests/analytic_stroke_parity.rs
@@ -1,0 +1,61 @@
+use noon_core::{GeometryRef, StrokeCap, StrokeJoin};
+use noon_geometry::{canonical_outline_path, tessellate_styled_with_fill};
+
+const EPS: f32 = 0.015;
+
+fn assert_close(actual: f32, expected: f32) {
+    assert!(
+        (actual - expected).abs() <= EPS,
+        "expected {expected}, got {actual} (tolerance {EPS})"
+    );
+}
+
+#[test]
+fn canonical_create_strokes_match_centered_analytic_outer_bounds() {
+    let stroke_width = 0.12;
+
+    let circle = GeometryRef::circle(0.9);
+    let circle_path = canonical_outline_path(&circle).expect("circle outline");
+    let circle_mesh = tessellate_styled_with_fill(
+        &circle_path,
+        stroke_width,
+        StrokeJoin::Round,
+        StrokeCap::Round,
+        false,
+    )
+    .expect("circle tessellation");
+    let circle_bounds = circle_mesh.bounds.expect("circle bounds");
+    let circle_extent = 0.9 + stroke_width * 0.5;
+    assert_close(circle_bounds.min.x, -circle_extent);
+    assert_close(circle_bounds.min.y, -circle_extent);
+    assert_close(circle_bounds.max.x, circle_extent);
+    assert_close(circle_bounds.max.y, circle_extent);
+
+    let rectangle = GeometryRef::rectangle(1.7, 1.7);
+    let rectangle_path = canonical_outline_path(&rectangle).expect("rectangle outline");
+    let rectangle_mesh = tessellate_styled_with_fill(
+        &rectangle_path,
+        stroke_width,
+        StrokeJoin::Round,
+        StrokeCap::Round,
+        false,
+    )
+    .expect("rectangle tessellation");
+    let rectangle_bounds = rectangle_mesh.bounds.expect("rectangle bounds");
+    let rectangle_extent = 1.7 * 0.5 + stroke_width * 0.5;
+    assert_close(rectangle_bounds.min.x, -rectangle_extent);
+    assert_close(rectangle_bounds.min.y, -rectangle_extent);
+    assert_close(rectangle_bounds.max.x, rectangle_extent);
+    assert_close(rectangle_bounds.max.y, rectangle_extent);
+}
+
+#[test]
+fn analytic_shader_uses_centered_vector_path_stroke_contract() {
+    let shader = include_str!("../src/analytic.wgsl");
+
+    assert!(shader.contains("let stroke_padding = stroke_half_width(input.metrics, input.flags);"));
+    assert!(shader.contains("inside_coverage(signed_distance - half_stroke_width)"));
+    assert!(shader.contains("outside_coverage(signed_distance + half_stroke_width)"));
+    assert!(shader.contains("let stroke_width = max(input.metrics.x, 0.0);"));
+    assert!(!shader.contains("clamp(input.metrics.x"));
+}

--- a/scripts/browser-smoke.mjs
+++ b/scripts/browser-smoke.mjs
@@ -111,12 +111,16 @@ function artifactName(index, name, checkpoint) {
   return `${String(index).padStart(2, "0")}-${slug || "scene"}-${checkpoint}.png`;
 }
 
-function visiblePixelCount(buffer, name) {
+function visiblePixelStats(buffer, name) {
   const png = PNG.sync.read(buffer);
   assert.ok(png.width >= 320 && png.height >= 180, `${name}: canvas screenshot is too small`);
 
   const background = [png.data[0], png.data[1], png.data[2], png.data[3]];
   let changedPixels = 0;
+  let minX = png.width;
+  let minY = png.height;
+  let maxX = -1;
+  let maxY = -1;
   for (let offset = 0; offset < png.data.length; offset += 4) {
     const distance =
       Math.abs(png.data[offset] - background[0]) +
@@ -125,9 +129,16 @@ function visiblePixelCount(buffer, name) {
       Math.abs(png.data[offset + 3] - background[3]);
     if (distance >= 32) {
       changedPixels += 1;
+      const pixel = offset / 4;
+      const x = pixel % png.width;
+      const y = Math.floor(pixel / png.width);
+      minX = Math.min(minX, x);
+      minY = Math.min(minY, y);
+      maxX = Math.max(maxX, x);
+      maxY = Math.max(maxY, y);
     }
   }
-  return changedPixels;
+  return { changedPixels, bounds: { minX, minY, maxX, maxY } };
 }
 
 function latestSceneEnd(document) {
@@ -143,6 +154,16 @@ function sampleTimes(latestEnd) {
   assert.ok(Number.isFinite(latestEnd) && latestEnd > 0, "scene timeline must have positive duration");
   assert.ok(latestEnd < 4.0, "scene timeline must fit the four-second playground loop");
   return [0.35, 0.60, 0.85, 1.0].map((fraction) => latestEnd * fraction);
+}
+
+async function renderAndCapture(page, time, screenshotPath) {
+  const metrics = await page.evaluate(
+    (sceneTime) => window.noonSmoke.renderAt(sceneTime),
+    time,
+  );
+  await page.evaluate(() => new Promise((resolve) => requestAnimationFrame(() => resolve())));
+  const screenshot = await page.locator("#scene").screenshot({ path: screenshotPath });
+  return { metrics, screenshot };
 }
 
 let browser = null;
@@ -204,10 +225,11 @@ try {
     );
 
     for (const [checkpointIndex, time] of sampleTimes(latestEnd).entries()) {
-      const metrics = await page.evaluate(
-        (sceneTime) => window.noonSmoke.renderAt(sceneTime),
-        time,
+      const screenshotPath = path.join(
+        artifactDir,
+        artifactName(index, example.name, checkpointIndex + 1),
       );
+      const { metrics, screenshot } = await renderAndCapture(page, time, screenshotPath);
       assert.equal(metrics.error, null, `${example.name}: browser runtime error`);
       assert.equal(metrics.revision, loaded.revision, `${example.name}: scene revision drifted`);
       assert.equal(metrics.objectCount, expectedObjects, `${example.name}: object count drifted`);
@@ -215,14 +237,7 @@ try {
       assert.ok(metrics.drawCalls > 0, `${example.name}: renderer emitted no draw calls at t=${time}`);
       assert.ok(metrics.instances > 0, `${example.name}: renderer emitted no instances at t=${time}`);
 
-      // Let Chromium composite the just-presented WebGPU surface before capture.
-      await page.evaluate(() => new Promise((resolve) => requestAnimationFrame(() => resolve())));
-      const screenshotPath = path.join(
-        artifactDir,
-        artifactName(index, example.name, checkpointIndex + 1),
-      );
-      const screenshot = await page.locator("#scene").screenshot({ path: screenshotPath });
-      const visiblePixels = visiblePixelCount(screenshot, example.name);
+      const { changedPixels: visiblePixels } = visiblePixelStats(screenshot, example.name);
 
       if (visiblePixels < 100) {
         visualFailures.push(
@@ -239,6 +254,36 @@ try {
             `${visiblePixels} visible pixels`,
         );
       }
+    }
+
+    if (example.name === "Create shapes") {
+      const beforeTime = latestEnd - 0.001;
+      const beforePath = path.join(
+        artifactDir,
+        artifactName(index, example.name, "continuity-before"),
+      );
+      const afterPath = path.join(
+        artifactDir,
+        artifactName(index, example.name, "continuity-after"),
+      );
+      const before = await renderAndCapture(page, beforeTime, beforePath);
+      const after = await renderAndCapture(page, latestEnd, afterPath);
+      assert.equal(before.metrics.error, null, `${example.name}: pre-completion runtime error`);
+      assert.equal(after.metrics.error, null, `${example.name}: completion runtime error`);
+
+      const beforeStats = visiblePixelStats(before.screenshot, `${example.name} before completion`);
+      const afterStats = visiblePixelStats(after.screenshot, `${example.name} at completion`);
+      const boundDelta = Math.max(
+        Math.abs(beforeStats.bounds.minX - afterStats.bounds.minX),
+        Math.abs(beforeStats.bounds.minY - afterStats.bounds.minY),
+        Math.abs(beforeStats.bounds.maxX - afterStats.bounds.maxX),
+        Math.abs(beforeStats.bounds.maxY - afterStats.bounds.maxY),
+      );
+      assert.ok(
+        boundDelta <= 1,
+        `${example.name}: Create-to-analytic visible bounds jumped by ${boundDelta}px`,
+      );
+      console.log(`✓ ${example.name}: Create-to-analytic bounds continuous within ${boundDelta}px`);
     }
   }
 


### PR DESCRIPTION
## Summary

- make analytic Circle and Rectangle strokes use the same centered-stroke contract as VectorPath/Lyon
- expand analytic proxy geometry by half the stroke width so the outer half is not clipped
- remove the old radius/half-size stroke clamp that was specific to inside-only strokes
- add renderer regressions comparing canonical Create path bounds against the analytic centered-stroke contract

## Why

`Create` renders analytic primitives as temporary vector paths until reveal reaches 1.0, then switches back to the analytic fast path. Vector paths center strokes on the authored outline, while the analytic shader previously placed the full stroke inside the outline. The final frame therefore contracted by half the stroke width, causing the visible snap reported in the playground.

## Validation

CI should cover formatting, compilation, Clippy, geometry/runtime/renderer tests, WASM builds, and browser WebGPU smoke rendering.