### PR TITLE
Add Python syntax highlighting and Ruff linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,9 @@ jobs:
           npm install --no-save --ignore-scripts playwright@1.62.1 pngjs@7.0.0
           npx playwright install --with-deps chromium
 
+      - name: Test Python editor highlighting and linting
+        run: node scripts/python-editor-smoke.mjs
+
       - name: Test browser WebGPU rendering
         env:
           NOON_BROWSER_SMOKE_BACKEND: webgpu

--- a/scripts/python-editor-smoke.mjs
+++ b/scripts/python-editor-smoke.mjs
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import playwright from "playwright";
+
+const { chromium } = playwright;
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const port = 4174;
+const baseUrl = `http://127.0.0.1:${port}`;
+
+let serverOutput = "";
+const server = spawn(
+  "python3",
+  ["-m", "http.server", String(port), "--bind", "127.0.0.1", "--directory", repoRoot],
+  { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] },
+);
+server.stdout.on("data", (chunk) => (serverOutput += chunk));
+server.stderr.on("data", (chunk) => (serverOutput += chunk));
+
+async function waitForServer() {
+  let lastError = null;
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    try {
+      const response = await fetch(`${baseUrl}/web/index.html`);
+      if (response.ok) return;
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Python editor smoke server did not start: ${lastError}\n${serverOutput}`);
+}
+
+let browser = null;
+try {
+  await waitForServer();
+  browser = await chromium.launch({
+    channel: "chromium",
+    headless: true,
+    args: [
+      "--disable-features=WebGPU",
+      "--enable-unsafe-swiftshader",
+      "--ignore-gpu-blocklist",
+      "--use-gl=angle",
+      "--use-angle=swiftshader",
+      "--disable-gpu-sandbox",
+      "--disable-dev-shm-usage",
+    ],
+  });
+
+  const page = await browser.newPage({ viewport: { width: 1000, height: 700 } });
+  const errors = [];
+  page.on("pageerror", (error) => errors.push(`pageerror: ${error}`));
+  page.on("console", (message) => {
+    if (message.type() === "error") errors.push(`console: ${message.text()}`);
+  });
+
+  await page.goto(`${baseUrl}/web/index.html`, { waitUntil: "load" });
+  await page.waitForSelector(".python-code-editor[data-editor-ready='true'] .cm-editor", {
+    timeout: 30_000,
+  });
+  assert.equal(
+    await page.locator(".python-code-editor[data-editor-ready='true']").count(),
+    2,
+    "both Python textareas should be enhanced",
+  );
+
+  await page.waitForFunction(
+    () => document.querySelector("#python-scene-source")?.value.includes("from noon import"),
+    null,
+    { timeout: 30_000 },
+  );
+  const highlightedSpans = await page.locator("#scene-editor-panel .cm-line span").count();
+  assert.ok(highlightedSpans > 0, "Python source should contain syntax-highlighted spans");
+
+  await page.evaluate(() => {
+    document.querySelector("#python-scene-source").value =
+      "import os\n\ndef broken():\n    return missing_name\n";
+  });
+  await page.waitForSelector("#scene-editor-panel .cm-lintRange-warning", {
+    timeout: 30_000,
+  });
+  const lintRanges = await page.locator("#scene-editor-panel .cm-lintRange-warning").count();
+  assert.ok(lintRanges >= 1, "Ruff should report inline Python diagnostics");
+
+  assert.deepEqual(errors, [], `browser errors while loading Python editor:\n${errors.join("\n")}`);
+  console.log(
+    `Python editor smoke passed: 2 CodeMirror editors, syntax highlighting, ${lintRanges} Ruff diagnostics.`,
+  );
+} finally {
+  await browser?.close();
+  server.kill("SIGTERM");
+}

--- a/web/authoring-client.js
+++ b/web/authoring-client.js
@@ -1,3 +1,5 @@
+import "./python-editor.js";
+
 export const AUTHORING_CHANNEL = "noon.authoring";
 export const AUTHORING_PROTOCOL_VERSION = 4;
 export const NOON_IR_VERSION = 1;

--- a/web/python-editor.js
+++ b/web/python-editor.js
@@ -1,0 +1,167 @@
+const CODEMIRROR_URL = "https://esm.sh/codemirror@6.0.2";
+const PYTHON_URL = "https://esm.sh/@codemirror/lang-python@6.2.1";
+const LINT_URL = "https://esm.sh/@codemirror/lint@6.9.7";
+const THEME_URL = "https://esm.sh/@codemirror/theme-one-dark@6.1.3";
+const RUFF_URL = "https://esm.sh/@astral-sh/ruff-wasm-web@0.16.4";
+
+let ruffWorkspacePromise = null;
+
+if (typeof document !== "undefined") {
+  await enhancePythonEditors();
+}
+
+async function enhancePythonEditors() {
+  const textareas = [
+    document.querySelector("#python-scene-source"),
+    document.querySelector("#python-source"),
+  ].filter(Boolean);
+  if (textareas.length === 0) {
+    return;
+  }
+
+  const [{ EditorView, basicSetup }, { python }, { linter, lintGutter }, { oneDark }] =
+    await Promise.all([
+      import(CODEMIRROR_URL),
+      import(PYTHON_URL),
+      import(LINT_URL),
+      import(THEME_URL),
+    ]);
+
+  const editorTheme = EditorView.theme({
+    "&": {
+      height: "100%",
+      minHeight: "0",
+      backgroundColor: "#080b12",
+      fontSize: "0.82rem",
+    },
+    ".cm-scroller": {
+      overflow: "auto",
+      fontFamily:
+        "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+      lineHeight: "1.58",
+    },
+    ".cm-content": { padding: "1rem 0 1.4rem" },
+    ".cm-gutters": {
+      backgroundColor: "#0b0f18",
+      borderRight: "1px solid #171f2e",
+      color: "#58647a",
+    },
+    ".cm-activeLineGutter": { backgroundColor: "#141a27" },
+    ".cm-activeLine": { backgroundColor: "rgba(142, 124, 255, 0.055)" },
+    ".cm-lintRange-error": {
+      backgroundImage:
+        "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='6' height='3'%3E%3Cpath d='M0 2.5 1.5 1 3 2.5 4.5 1 6 2.5' fill='none' stroke='%23ff8f9d' stroke-width='1'/%3E%3C/svg%3E\")",
+    },
+    ".cm-lintRange-warning": {
+      backgroundImage:
+        "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='6' height='3'%3E%3Cpath d='M0 2.5 1.5 1 3 2.5 4.5 1 6 2.5' fill='none' stroke='%23e8c36a' stroke-width='1'/%3E%3C/svg%3E\")",
+    },
+  });
+
+  for (const textarea of textareas) {
+    const host = document.createElement("div");
+    host.className = "python-code-editor";
+    textarea.before(host);
+    textarea.hidden = true;
+
+    const view = new EditorView({
+      doc: textarea.value,
+      parent: host,
+      extensions: [
+        basicSetup,
+        python(),
+        oneDark,
+        editorTheme,
+        lintGutter(),
+        linter(runRuff, { delay: 300 }),
+        EditorView.lineWrapping,
+      ],
+    });
+
+    Object.defineProperty(textarea, "value", {
+      configurable: true,
+      get() {
+        return view.state.doc.toString();
+      },
+      set(value) {
+        const next = String(value ?? "");
+        const current = view.state.doc.toString();
+        if (next === current) {
+          return;
+        }
+        view.dispatch({
+          changes: { from: 0, to: view.state.doc.length, insert: next },
+        });
+      },
+    });
+
+    textarea.editorView = view;
+    host.dataset.editorReady = "true";
+  }
+
+  const style = document.createElement("style");
+  style.textContent = `
+    .python-code-editor {
+      width: 100%;
+      min-height: 0;
+      flex: 1;
+      overflow: hidden;
+      background: #080b12;
+    }
+    .python-code-editor .cm-editor { height: 100%; }
+    .python-code-editor .cm-focused { outline: 2px solid #aa9cff; outline-offset: -2px; }
+    @media (max-width: 44rem) {
+      .python-code-editor { min-height: 25rem; }
+      .python-code-editor .cm-editor { font-size: 0.76rem; }
+    }
+  `;
+  document.head.append(style);
+}
+
+async function runRuff(view) {
+  try {
+    const workspace = await getRuffWorkspace();
+    const diagnostics = workspace.check(view.state.doc.toString());
+    return diagnostics.map((diagnostic) => toCodeMirrorDiagnostic(view.state.doc, diagnostic));
+  } catch (error) {
+    console.warn("Ruff linting unavailable", error);
+    return [];
+  }
+}
+
+async function getRuffWorkspace() {
+  ruffWorkspacePromise ??= import(RUFF_URL).then(async (ruff) => {
+    await ruff.default();
+    return new ruff.Workspace(
+      {
+        "line-length": 88,
+        "indent-width": 4,
+        lint: { select: ["E4", "E7", "E9", "F"] },
+      },
+      ruff.PositionEncoding.Utf16,
+    );
+  });
+  return ruffWorkspacePromise;
+}
+
+function toCodeMirrorDiagnostic(doc, diagnostic) {
+  const from = sourceLocationToOffset(doc, diagnostic.start_location);
+  const rawTo = sourceLocationToOffset(doc, diagnostic.end_location);
+  const to = Math.max(from, rawTo);
+  const code = diagnostic.code ? `${diagnostic.code}: ` : "";
+  const severity = diagnostic.code?.startsWith("E9") ? "error" : "warning";
+  return {
+    from,
+    to,
+    severity,
+    message: `${code}${diagnostic.message}`,
+    source: "Ruff",
+  };
+}
+
+function sourceLocationToOffset(doc, location) {
+  const row = Math.min(Math.max(Number(location?.row) || 1, 1), doc.lines);
+  const line = doc.line(row);
+  const column = Math.max((Number(location?.column) || 1) - 1, 0);
+  return Math.min(line.from + column, line.to);
+}


### PR DESCRIPTION
## Summary

- replace the plain-textarea editing experience with CodeMirror 6 while preserving the existing textarea `.value` contract used by the playground runtime
- add Python syntax highlighting, line numbers, indentation/bracket helpers, search, completion basics, and a dark editor theme
- add real client-side Ruff diagnostics using the official `@astral-sh/ruff-wasm-web` package with `E4`, `E7`, `E9`, and `F` rules
- lazy-load Ruff only when linting is needed; the renderer/runtime path remains unchanged
- add a Playwright browser smoke test that verifies both editors are enhanced, Python tokens are highlighted, and Ruff produces inline diagnostics

## Dependencies

Pinned browser ESM dependencies:
- `codemirror@6.0.2`
- `@codemirror/lang-python@6.2.1`
- `@codemirror/lint@6.9.7`
- `@codemirror/theme-one-dark@6.1.3`
- `@astral-sh/ruff-wasm-web@0.16.4`

The demo already depends on a CDN for Pyodide; these editor dependencies use the same static-hosting model.

## Validation

CI #531 is fully green on head `55bcd36056ae5d1adf422739bdb30a6df51303e0`:
- formatting, workspace compile, Clippy, geometry invariants, and workspace tests
- WASM renderer/runtime compilation and browser package build
- actual Chromium playground smoke: both Python textareas enhanced to CodeMirror, syntax-highlighted spans present, and Ruff inline diagnostics produced for intentionally invalid Python
- existing 11-scene browser visual suite passes on WebGPU
- existing 11-scene browser visual suite passes on forced WebGL2 fallback
