### PR TITLE
Tighten playground editor and preview spacing

### DIFF
--- a/scripts/python-editor-smoke.mjs
+++ b/scripts/python-editor-smoke.mjs
@@ -52,7 +52,7 @@ try {
     ],
   });
 
-  const page = await browser.newPage({ viewport: { width: 1000, height: 700 } });
+  const page = await browser.newPage({ viewport: { width: 1400, height: 900 } });
   const errors = [];
   page.on("pageerror", (error) => errors.push(`pageerror: ${error}`));
   page.on("console", (message) => {
@@ -77,6 +77,41 @@ try {
   const highlightedSpans = await page.locator("#scene-editor-panel .cm-line span").count();
   assert.ok(highlightedSpans > 0, "Python source should contain syntax-highlighted spans");
 
+  await page.waitForFunction(
+    () => document.querySelector("#status")?.dataset.state === "running",
+    null,
+    { timeout: 30_000 },
+  );
+  const layout = await page.evaluate(() => {
+    const scroller = document
+      .querySelector("#scene-editor-panel .cm-scroller")
+      .getBoundingClientRect();
+    const content = document
+      .querySelector("#scene-editor-panel .cm-content")
+      .getBoundingClientRect();
+    const wrap = document.querySelector(".canvas-wrap").getBoundingClientRect();
+    const canvas = document.querySelector("#scene").getBoundingClientRect();
+    return {
+      editorTopInset: content.top - scroller.top,
+      canvasTopGap: canvas.top - wrap.top,
+      canvasBottomGap: wrap.bottom - canvas.bottom,
+      canvasLeftGap: canvas.left - wrap.left,
+      canvasRightGap: wrap.right - canvas.right,
+    };
+  });
+  assert.ok(
+    layout.editorTopInset <= 8,
+    `CodeMirror should start near the top of its pane; got ${layout.editorTopInset}px`,
+  );
+  for (const [name, gap] of Object.entries({
+    canvasTopGap: layout.canvasTopGap,
+    canvasBottomGap: layout.canvasBottomGap,
+    canvasLeftGap: layout.canvasLeftGap,
+    canvasRightGap: layout.canvasRightGap,
+  })) {
+    assert.ok(Math.abs(gap) <= 2, `desktop preview should fill its pane; ${name}=${gap}px`);
+  }
+
   await page.evaluate(() => {
     document.querySelector("#python-scene-source").value =
       "import os\n\ndef broken():\n    return missing_name\n";
@@ -89,7 +124,7 @@ try {
 
   assert.deepEqual(errors, [], `browser errors while loading Python editor:\n${errors.join("\n")}`);
   console.log(
-    `Python editor smoke passed: 2 CodeMirror editors, syntax highlighting, ${lintRanges} Ruff diagnostics.`,
+    `Python editor smoke passed: tight desktop layout, 2 CodeMirror editors, syntax highlighting, ${lintRanges} Ruff diagnostics.`,
   );
 } finally {
   await browser?.close();

--- a/web/python-editor.js
+++ b/web/python-editor.js
@@ -40,7 +40,7 @@ async function enhancePythonEditors() {
         "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
       lineHeight: "1.58",
     },
-    ".cm-content": { padding: "1rem 0 1.4rem" },
+    ".cm-content": { padding: "0.35rem 0" },
     ".cm-gutters": {
       backgroundColor: "#0b0f18",
       borderRight: "1px solid #171f2e",
@@ -110,6 +110,20 @@ async function enhancePythonEditors() {
     }
     .python-code-editor .cm-editor { height: 100%; }
     .python-code-editor .cm-focused { outline: 2px solid #aa9cff; outline-offset: -2px; }
+    @media (min-width: 68.01rem) {
+      .canvas-wrap {
+        padding: 0 !important;
+        place-items: stretch !important;
+      }
+      .canvas-wrap > canvas {
+        width: 100%;
+        height: 100%;
+        max-width: none;
+        aspect-ratio: auto;
+        border: 0;
+        border-radius: 0;
+      }
+    }
     @media (max-width: 44rem) {
       .python-code-editor { min-height: 25rem; }
       .python-code-editor .cm-editor { font-size: 0.76rem; }


### PR DESCRIPTION
## Summary

- reduce CodeMirror's top/bottom content padding so Python starts closer to the editor edges
- remove desktop preview letterboxing by letting the GPU canvas fill the available preview pane instead of forcing a centered 16:9 CSS box
- keep the existing fixed-aspect behavior on stacked/mobile layouts
- add a Chromium layout regression that asserts minimal editor top inset and no desktop canvas gaps

## Rationale

The renderer already resizes to the canvas's actual CSS dimensions, so allowing the desktop canvas to fill its pane does not stretch a fixed framebuffer; it renders at the responsive pane aspect ratio.
