### PR TITLE
Add independent Manim fill and stroke opacity

### DIFF
--- a/docs/manim-style-semantics.md
+++ b/docs/manim-style-semantics.md
@@ -1,0 +1,49 @@
+# Manim style compatibility semantics
+
+This note records the style decisions behind the ManimCE v0.21.x compatibility work. It supplements `manim-aligned-authoring-plan.md` and keeps compatibility changes aligned with Noon's existing renderer-independent semantic model.
+
+## Independent fill and stroke opacity
+
+Manim exposes independent `fill_opacity` and `stroke_opacity`. Noon does not need new serialized style fields to represent that distinction: `Style.fill` and `Style.stroke` already carry independent RGBA `Color` values.
+
+The compatibility mapping is therefore:
+
+```text
+Manim fill_color + fill_opacity
+        -> Noon Style.fill RGBA
+
+Manim stroke_color + stroke_opacity
+        -> Noon Style.stroke RGBA
+
+Noon overall opacity
+        -> Style.opacity multiplier
+```
+
+This has useful architectural properties:
+
+- no `SceneDefinition` format-version change;
+- no compiler/runtime property expansion;
+- no GPU instance-layout change;
+- no shader-interface change;
+- no path-cache identity change;
+- generic Transform already interpolates each color's alpha independently;
+- existing low-level overall-opacity animation remains available as a Noon extension.
+
+The public compatibility layer accepts constructor keywords `fill_color`, `fill_opacity`, `stroke_color`, and `stroke_opacity`. `set_fill(..., opacity=...)` changes only fill alpha; `set_stroke(..., opacity=...)` changes only stroke alpha; Manim-style `VMobject.set_opacity(...)` updates both layer alphas.
+
+For backwards compatibility, historical Noon `set_fill(None)` / `set_stroke(None)` with no other arguments still explicitly disable that layer. In contrast, `set_fill(opacity=x)` and `set_stroke(width=..., opacity=...)` preserve the current color as Manim users expect.
+
+## Stroke-width units: unresolved semantic mismatch
+
+ManimCE v0.21 uses a default VMobject `stroke_width=4`, and ordinary `VMobject.scale(...)` does not scale the stroke unless `scale_stroke=True` is requested. This makes stroke width behave like a display-space style quantity rather than ordinary local geometry.
+
+Noon's current analytic and tessellated paths use `stroke_width` in local/world geometry units. Object scale therefore naturally scales stroke geometry. Simply passing Manim values such as `4`, `8`, or `20` through unchanged would produce grossly incorrect visuals, while silently applying a fixed conversion constant would only approximate one camera/frame configuration.
+
+Until this is resolved, the compatibility layer should not claim numeric Manim stroke-width parity. Existing Noon world-space stroke widths remain supported, and independent stroke opacity can land without choosing a stroke-width policy.
+
+The two coherent long-term options are:
+
+1. **Display-space Manim stroke widths.** Add an explicit display-space stroke-width semantic to the renderer. This gives stronger visual/source compatibility but requires renderer work for analytic primitives and vector paths, including non-uniform transforms and cache/tessellation policy.
+2. **World-space Noon stroke widths with a compatibility conversion.** Keep the simpler current renderer model and translate Manim-style widths at the Python boundary. This preserves the current fast geometry architecture but cannot exactly match Manim across camera/output-scale changes.
+
+This is a real semantic choice, not merely an API spelling issue, and should be decided before changing compatibility defaults from Noon's existing stroke-width behavior.

--- a/scripts/manim-compat-smoke.mjs
+++ b/scripts/manim-compat-smoke.mjs
@@ -101,6 +101,39 @@ class GroupAndSceneMembership(Scene):
         assert self.mobjects == []
 `;
 
+const styleSource = `
+from noon import *
+
+class IndependentStyleOpacity(Scene):
+    def construct(self):
+        square = Square(
+            side_length=0.8,
+            fill_color=BLUE,
+            fill_opacity=0.25,
+            stroke_color=RED,
+            stroke_opacity=0.6,
+            stroke_width=0.06,
+        )
+        assert abs(square.get_fill_opacity() - 0.25) < 1e-9
+        assert abs(square.get_stroke_opacity() - 0.6) < 1e-9
+
+        square.set_fill(opacity=0.75)
+        assert abs(square.get_fill_opacity() - 0.75) < 1e-9
+        assert abs(square.get_stroke_opacity() - 0.6) < 1e-9
+
+        square.set_stroke(opacity=0.4)
+        assert abs(square.get_fill_opacity() - 0.75) < 1e-9
+        assert abs(square.get_stroke_opacity() - 0.4) < 1e-9
+
+        square.set_opacity(0.2)
+        assert abs(square.get_fill_opacity() - 0.2) < 1e-9
+        assert abs(square.get_stroke_opacity() - 0.2) < 1e-9
+        self.add(square)
+
+        target = square.copy().set_fill(PINK, opacity=0.8).set_stroke(GREEN, opacity=0.3)
+        self.play(Transform(square, target), run_time=0.4, rate_func=linear)
+`;
+
 let browser = null;
 try {
   await waitForServer();
@@ -158,6 +191,20 @@ try {
     "scene membership and grouped fades should lower to deterministic presence events",
   );
 
+  const style = await page.evaluate(
+    (pythonSource) => window.noonManimCompat.run(pythonSource),
+    styleSource,
+  );
+  assert.equal(style.kind, "scene_document");
+  assert.equal(style.document.objects.length, 1);
+  const baseStyle = style.document.objects[0].style;
+  assert.equal(baseStyle.opacity, 1, "independent layer opacity should not consume overall opacity");
+  assert.equal(baseStyle.fill.alpha, 0.2);
+  assert.equal(baseStyle.stroke.alpha, 0.2);
+  const styleTransform = style.document.tracks.find((track) => track.property === "transform");
+  assert.equal(styleTransform.values.object.to.style.fill.alpha, 0.8);
+  assert.equal(styleTransform.values.object.to.style.stroke.alpha, 0.3);
+
   let zError = null;
   try {
     await page.evaluate(
@@ -171,7 +218,7 @@ try {
 
   assert.deepEqual(errors, [], `browser errors while testing Manim compatibility:\n${errors.join("\n")}`);
   console.log(
-    "Manim compatibility smoke passed: construct discovery, shape classes, scene membership, group lowering, generic animate proxying, z=0 vectors, and rate_func lowering.",
+    "Manim compatibility smoke passed: construct discovery, shape classes, scene membership, group lowering, generic animate proxying, independent fill/stroke opacity, z=0 vectors, and rate_func lowering.",
   );
 } finally {
   await browser?.close();

--- a/web/python/_manim_phase_b.py
+++ b/web/python/_manim_phase_b.py
@@ -5,7 +5,7 @@ Kept separate from the compatibility surface while Phase B is under active devel
 
 from __future__ import annotations
 
-from typing import Any
+import copy
 
 import noon as _base
 import _manim_compat as _compat
@@ -105,3 +105,161 @@ def _bind_introducer_target(self: _compat.Scene, target: object) -> None:
 
 _compat.Scene.add = _scene_add
 _compat.Scene._bind_introducer_target = _bind_introducer_target
+
+
+# Independent fill/stroke opacity does not require another serialized style field:
+# Noon colors already carry alpha independently for fill and stroke. The overall
+# style opacity remains available as a low-level multiplier for fades/compositing.
+_ORIGINAL_MAKE_MOBJECT = _base._ir._make_mobject
+_MISSING = object()
+
+
+def _opacity(name: str, value: object) -> float:
+    return _base._ir._unit_interval(name, value)
+
+
+def _with_alpha(color: _base.Color, alpha: float) -> _base.Color:
+    return _base.Color(color.red, color.green, color.blue, alpha)
+
+
+def _compat_make_mobject(
+    geometry: dict[str, object],
+    **kwargs: object,
+):
+    fill_color = kwargs.pop("fill_color", _MISSING)
+    stroke_color = kwargs.pop("stroke_color", _MISSING)
+    fill_opacity = kwargs.pop("fill_opacity", None)
+    stroke_opacity = kwargs.pop("stroke_opacity", None)
+
+    if fill_color is not _MISSING:
+        kwargs["fill"] = fill_color
+    if stroke_color is not _MISSING:
+        kwargs["stroke"] = stroke_color
+
+    raw = _ORIGINAL_MAKE_MOBJECT(geometry, **kwargs)
+    style = raw.style
+
+    if fill_opacity is not None:
+        alpha = _opacity("fill_opacity", fill_opacity)
+        fill = style["fill"]
+        if fill is None:
+            fill = _base.WHITE.to_ir()
+            style["fill"] = fill
+        fill["alpha"] = alpha
+
+    if stroke_opacity is not None:
+        alpha = _opacity("stroke_opacity", stroke_opacity)
+        stroke = style["stroke"]
+        if stroke is None:
+            stroke = _base.WHITE.to_ir()
+            style["stroke"] = stroke
+        stroke["alpha"] = alpha
+
+    return raw
+
+
+_base._ir._make_mobject = _compat_make_mobject
+
+
+def _vmobject_set_fill(
+    self: _compat.VMobject,
+    color: _base.Color | None = None,
+    opacity: float | None = None,
+    family: bool = True,
+) -> _compat.VMobject:
+    del family  # Leaf VMobjects have no Python submobjects in the current facade.
+    raw = _base._raw_mobject(self._current_raw())
+
+    # Hybrid compatibility rule: Manim's set_fill(opacity=...) preserves color,
+    # while historical Noon set_fill(None) disables fill. Both remain useful.
+    if color is not None:
+        if not isinstance(color, _base.Color):
+            raise TypeError("fill color must be a Color or None")
+        previous_alpha = (
+            raw.style["fill"]["alpha"] if raw.style["fill"] is not None else color.alpha
+        )
+        raw.style["fill"] = color.to_ir()
+        raw.style["fill"]["alpha"] = previous_alpha
+    elif opacity is None:
+        raw.style["fill"] = None
+
+    if opacity is not None:
+        alpha = _opacity("fill opacity", opacity)
+        if raw.style["fill"] is None:
+            raw.style["fill"] = _with_alpha(_base.WHITE, alpha).to_ir()
+        else:
+            raw.style["fill"]["alpha"] = alpha
+    return self._apply(raw)
+
+
+def _vmobject_set_stroke(
+    self: _compat.VMobject,
+    color: _base.Color | None = None,
+    width: float | None = None,
+    opacity: float | None = None,
+    family: bool = True,
+) -> _compat.VMobject:
+    del family
+    raw = _base._raw_mobject(self._current_raw())
+
+    # As with fill, an entirely empty call preserves Noon's explicit-disable escape
+    # hatch; Manim-style width=/opacity= calls preserve the current stroke color.
+    if color is not None:
+        if not isinstance(color, _base.Color):
+            raise TypeError("stroke color must be a Color or None")
+        previous_alpha = (
+            raw.style["stroke"]["alpha"]
+            if raw.style["stroke"] is not None
+            else color.alpha
+        )
+        raw.style["stroke"] = color.to_ir()
+        raw.style["stroke"]["alpha"] = previous_alpha
+    elif width is None and opacity is None:
+        raw.style["stroke"] = None
+
+    if width is not None:
+        value = _base._ir._finite_number("stroke width", width)
+        if value < 0.0:
+            raise ValueError("stroke width must be non-negative")
+        raw.style["stroke_width"] = value
+        if raw.style["stroke"] is None:
+            raw.style["stroke"] = _base.WHITE.to_ir()
+
+    if opacity is not None:
+        alpha = _opacity("stroke opacity", opacity)
+        if raw.style["stroke"] is None:
+            raw.style["stroke"] = _with_alpha(_base.WHITE, alpha).to_ir()
+        else:
+            raw.style["stroke"]["alpha"] = alpha
+    return self._apply(raw)
+
+
+def _vmobject_set_opacity(
+    self: _compat.VMobject,
+    opacity: float,
+    family: bool = True,
+) -> _compat.VMobject:
+    del family
+    alpha = _opacity("opacity", opacity)
+    raw = _base._raw_mobject(self._current_raw())
+    for channel in ("fill", "stroke"):
+        if raw.style[channel] is not None:
+            raw.style[channel]["alpha"] = alpha
+    return self._apply(raw)
+
+
+def _vmobject_get_fill_opacity(self: _compat.VMobject) -> float:
+    fill = self._current_raw().style["fill"]
+    return 0.0 if fill is None else float(fill["alpha"])
+
+
+def _vmobject_get_stroke_opacity(self: _compat.VMobject) -> float:
+    stroke = self._current_raw().style["stroke"]
+    return 0.0 if stroke is None else float(stroke["alpha"])
+
+
+_compat.VMobject.set_fill = _vmobject_set_fill
+_compat.VMobject.set_stroke = _vmobject_set_stroke
+_compat.VMobject.set_opacity = _vmobject_set_opacity
+_compat.VMobject.get_fill_opacity = _vmobject_get_fill_opacity
+_compat.VMobject.get_stroke_opacity = _vmobject_get_stroke_opacity

--- a/web/python/_manim_phase_b.py
+++ b/web/python/_manim_phase_b.py
@@ -5,8 +5,6 @@ Kept separate from the compatibility surface while Phase B is under active devel
 
 from __future__ import annotations
 
-import copy
-
 import noon as _base
 import _manim_compat as _compat
 
@@ -118,6 +116,17 @@ def _opacity(name: str, value: object) -> float:
     return _base._ir._unit_interval(name, value)
 
 
+def _as_color(name: str, value: object) -> _base.Color:
+    if isinstance(value, _base.Color):
+        return value
+    if isinstance(value, (str, int)) and not isinstance(value, bool):
+        try:
+            return _base.color_from_hex(value)
+        except (TypeError, ValueError) as error:
+            raise ValueError(f"invalid {name}") from error
+    raise TypeError(f"{name} must be a Color or #RRGGBB value")
+
+
 def _with_alpha(color: _base.Color, alpha: float) -> _base.Color:
     return _base.Color(color.red, color.green, color.blue, alpha)
 
@@ -132,9 +141,11 @@ def _compat_make_mobject(
     stroke_opacity = kwargs.pop("stroke_opacity", None)
 
     if fill_color is not _MISSING:
-        kwargs["fill"] = fill_color
+        kwargs["fill"] = None if fill_color is None else _as_color("fill_color", fill_color)
     if stroke_color is not _MISSING:
-        kwargs["stroke"] = stroke_color
+        kwargs["stroke"] = (
+            None if stroke_color is None else _as_color("stroke_color", stroke_color)
+        )
 
     raw = _ORIGINAL_MAKE_MOBJECT(geometry, **kwargs)
     style = raw.style
@@ -163,7 +174,7 @@ _base._ir._make_mobject = _compat_make_mobject
 
 def _vmobject_set_fill(
     self: _compat.VMobject,
-    color: _base.Color | None = None,
+    color: object = None,
     opacity: float | None = None,
     family: bool = True,
 ) -> _compat.VMobject:
@@ -173,12 +184,11 @@ def _vmobject_set_fill(
     # Hybrid compatibility rule: Manim's set_fill(opacity=...) preserves color,
     # while historical Noon set_fill(None) disables fill. Both remain useful.
     if color is not None:
-        if not isinstance(color, _base.Color):
-            raise TypeError("fill color must be a Color or None")
+        parsed = _as_color("fill color", color)
         previous_alpha = (
-            raw.style["fill"]["alpha"] if raw.style["fill"] is not None else color.alpha
+            raw.style["fill"]["alpha"] if raw.style["fill"] is not None else parsed.alpha
         )
-        raw.style["fill"] = color.to_ir()
+        raw.style["fill"] = parsed.to_ir()
         raw.style["fill"]["alpha"] = previous_alpha
     elif opacity is None:
         raw.style["fill"] = None
@@ -194,7 +204,7 @@ def _vmobject_set_fill(
 
 def _vmobject_set_stroke(
     self: _compat.VMobject,
-    color: _base.Color | None = None,
+    color: object = None,
     width: float | None = None,
     opacity: float | None = None,
     family: bool = True,
@@ -205,14 +215,13 @@ def _vmobject_set_stroke(
     # As with fill, an entirely empty call preserves Noon's explicit-disable escape
     # hatch; Manim-style width=/opacity= calls preserve the current stroke color.
     if color is not None:
-        if not isinstance(color, _base.Color):
-            raise TypeError("stroke color must be a Color or None")
+        parsed = _as_color("stroke color", color)
         previous_alpha = (
             raw.style["stroke"]["alpha"]
             if raw.style["stroke"] is not None
-            else color.alpha
+            else parsed.alpha
         )
-        raw.style["stroke"] = color.to_ir()
+        raw.style["stroke"] = parsed.to_ir()
         raw.style["stroke"]["alpha"] = previous_alpha
     elif width is None and opacity is None:
         raw.style["stroke"] = None


### PR DESCRIPTION
## Summary

- support Manim `fill_color`, `fill_opacity`, `stroke_color`, and `stroke_opacity` constructor keywords in the browser compatibility surface
- make `VMobject.set_fill(..., opacity=...)` and `set_stroke(..., opacity=...)` independent instead of routing through Noon's overall opacity
- make Manim-style `VMobject.set_opacity(...)` update both layer alphas
- add `get_fill_opacity()` and `get_stroke_opacity()`
- preserve historical Noon `set_fill(None)` / `set_stroke(None)` explicit-disable behavior as a backwards-compatible extension
- expand the real Chromium/Pyodide compatibility gate with independent style assertions and Transform endpoint checks
- document the representation and the remaining stroke-width unit mismatch

## Architecture

No serialized style migration is required. Noon already stores fill and stroke as independent RGBA colors, so their alpha components are the canonical independent layer opacities. Existing `Style.opacity` remains an optional overall multiplier. Generic Transform already interpolates color alpha, and the GPU/shader/cache layouts remain unchanged.

## Deliberate scope

This PR does **not** change stroke-width defaults or reinterpret numeric `stroke_width`. Manim's stroke width behaves like a display-space style quantity, while Noon currently tessellates/analytically evaluates width in local/world units. `docs/manim-style-semantics.md` records the two coherent long-term options rather than silently introducing a camera-dependent conversion.