### PR TITLE
Align .animate with Manim builder semantics

### DIFF
--- a/docs/manim-animate-semantics.md
+++ b/docs/manim-animate-semantics.md
@@ -1,0 +1,84 @@
+# Manim `.animate` compatibility semantics
+
+Noon's public Python surface targets the observable authoring behavior of Manim Community v0.21.x while keeping playback compiled and deterministic.
+
+## Supported builder contract
+
+The preferred form is ordinary Manim syntax:
+
+```python
+self.play(
+    square.animate(run_time=2, rate_func=linear)
+        .shift(RIGHT)
+        .rotate(PI / 4)
+)
+```
+
+The compatibility layer mirrors these Manim builder rules:
+
+- animation kwargs are supplied by calling `.animate(...)` before any method access;
+- animation kwargs can be supplied only once;
+- mutating Mobject methods can be chained;
+- all chained mutations build one detached target state and lower to one Noon `Transform` track per runtime object;
+- `.animate` works for Mobjects that have not previously been added to the scene; `Scene.play` binds them automatically;
+- `Scene.play(..., run_time=..., rate_func=..., lag_ratio=...)` overrides the corresponding builder values;
+- animations in one `Scene.play` may have different builder-level run times, and the scene cursor advances by the longest animation;
+- `VGroup.animate(..., lag_ratio=x)` lowers to staggered member tracks using Manim's `get_sub_alpha` interval geometry while the runtime scene remains flat.
+
+For example:
+
+```python
+self.play(
+    left.animate(run_time=0.5).shift(UP),
+    right.animate(run_time=2.0).shift(DOWN),
+)
+```
+
+starts both animations together and advances the scene by two seconds.
+
+## Deterministic lowering
+
+`.animate` remains an authoring-time compiler feature:
+
+```text
+Mobject.animate(...).method(...).method(...)
+                |
+                v
+       detached target snapshot
+                |
+                v
+          Transform track
+                |
+                v
+       Rust/WASM evaluation
+```
+
+No mutator or Python rate-function callback executes once playback begins.
+
+## Animation arguments
+
+Currently represented directly:
+
+- `run_time`
+- `rate_func=linear`
+- `rate_func=smooth` through Noon's current deterministic smooth mapping
+- `lag_ratio` for grouped/family lowering
+- `path_arc=0` as the straight-path case
+- `reverse_rate_function=False`
+- `suspend_mobject_updating` and `name` are accepted metadata/no-op values because Noon has no Python playback updaters
+
+Currently rejected explicitly:
+
+- nonzero `path_arc`, until curved transform paths are represented in the canonical track model;
+- `reverse_rate_function=True`, until reversed easing is represented in the easing IR;
+- arbitrary Python rate functions, because they would require Python execution during playback.
+
+## Remaining rate-function parity
+
+Manim's default `smooth` is a normalized logistic sigmoid with inflection 10. Noon's current deterministic compatibility mapping uses the existing `ease_in_out_cubic` easing. The API and scheduling behavior are aligned, but the exact curve is not yet numerically identical.
+
+The intended follow-up is to add Manim's named rate functions as first-class deterministic runtime easings/curves rather than invoke Python per frame.
+
+## Runtime hierarchy
+
+Groups remain authoring-time structure. A grouped method animation is flattened into member transforms, preserving Noon's existing batching, analytic primitive fast paths, cached path geometry, and stable runtime object identities.

--- a/scripts/build-web-demo.sh
+++ b/scripts/build-web-demo.sh
@@ -17,7 +17,10 @@ node --check scripts/manim-compat-smoke.mjs
 node --test web/authoring-client.test.mjs
 node --test web/scene-identity.test.mjs
 node --test web/frame-metrics.test.mjs
-PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile web/python/_manim_compat.py
+PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile \
+  web/python/_manim_compat.py \
+  web/python/_manim_phase_b.py \
+  web/python/_manim_animate.py
 PYTHONDONTWRITEBYTECODE=1 python3 -m compileall -q web/python/examples
 PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s web/python -p 'test_*.py'
 cargo test -p noon-web --test playground_examples

--- a/scripts/manim-compat-smoke.mjs
+++ b/scripts/manim-compat-smoke.mjs
@@ -134,6 +134,54 @@ class IndependentStyleOpacity(Scene):
         self.play(Transform(square, target), run_time=0.4, rate_func=linear)
 `;
 
+const animateParitySource = `
+from noon import *
+
+class AnimateParity(Scene):
+    def construct(self):
+        detached = Circle(radius=0.25, color=BLUE)
+        self.play(
+            detached.animate(run_time=2.0, rate_func=linear)
+                .shift(RIGHT)
+                .set_y(1.0)
+        )
+        assert len(self.mobjects) == 1 and self.mobjects[0] is detached
+
+        square = Square(side_length=0.4, color=PINK)
+        self.play(
+            square.animate(run_time=2.0).shift(UP),
+            detached.animate(run_time=0.5, rate_func=linear).shift(LEFT),
+        )
+
+        pair = VGroup(
+            Circle(radius=0.15, color=GREEN),
+            Square(side_length=0.3, color=RED),
+        ).arrange(RIGHT, buff=0.15)
+        self.play(pair.animate(run_time=1.2, lag_ratio=0.5).shift(UP))
+
+        override = Circle(radius=0.2, color=PURPLE)
+        self.play(
+            override.animate(run_time=3.0, rate_func=linear).shift(RIGHT),
+            run_time=0.4,
+            rate_func=smooth,
+        )
+
+        late_args = Circle().animate
+        late_args.shift(RIGHT)
+        try:
+            late_args(run_time=2.0)
+            raise AssertionError("animation kwargs after method access must fail")
+        except ValueError as error:
+            assert "before accessing methods" in str(error)
+
+        duplicate_args = Circle().animate(run_time=1.0)
+        try:
+            duplicate_args(rate_func=linear)
+            raise AssertionError("animation kwargs can only be passed once")
+        except ValueError as error:
+            assert "only be passed once" in str(error)
+`;
+
 let browser = null;
 try {
   await waitForServer();
@@ -205,6 +253,48 @@ try {
   assert.equal(styleTransform.values.object.to.style.fill.alpha, 0.8);
   assert.equal(styleTransform.values.object.to.style.stroke.alpha, 0.3);
 
+  const animateParity = await page.evaluate(
+    (pythonSource) => window.noonManimCompat.run(pythonSource),
+    animateParitySource,
+  );
+  assert.equal(animateParity.kind, "scene_document");
+  assert.equal(animateParity.document.objects.length, 5, "detached animate and groups should auto-bind flat objects");
+  const animateTracks = animateParity.document.tracks.filter((track) => track.property === "transform");
+  assert.equal(animateTracks.length, 6);
+
+  const byObject = new Map();
+  for (const track of animateTracks) {
+    const list = byObject.get(track.object) ?? [];
+    list.push(track);
+    byObject.set(track.object, list);
+  }
+  assert.equal(byObject.get(0)[0].timing.start_time, 0);
+  assert.equal(byObject.get(0)[0].timing.duration, 2);
+  assert.equal(byObject.get(0)[0].timing.easing, "linear");
+  assert.equal(byObject.get(0)[1].timing.start_time, 2);
+  assert.equal(byObject.get(0)[1].timing.duration, 0.5);
+  assert.equal(byObject.get(1)[0].timing.start_time, 2);
+  assert.equal(byObject.get(1)[0].timing.duration, 2);
+  assert.equal(byObject.get(1)[0].timing.easing, "ease_in_out_cubic");
+
+  const groupFirst = byObject.get(2)[0];
+  const groupSecond = byObject.get(3)[0];
+  assert.ok(Math.abs(groupFirst.timing.start_time - 4.0) < 1e-9);
+  assert.ok(Math.abs(groupFirst.timing.duration - 0.8) < 1e-9);
+  assert.ok(Math.abs(groupSecond.timing.start_time - 4.4) < 1e-9);
+  assert.ok(Math.abs(groupSecond.timing.duration - 0.8) < 1e-9);
+  assert.equal(groupFirst.timing.easing, "ease_in_out_cubic");
+  assert.equal(groupSecond.timing.easing, "ease_in_out_cubic");
+
+  const overridden = byObject.get(4)[0];
+  assert.ok(Math.abs(overridden.timing.start_time - 5.2) < 1e-9);
+  assert.ok(Math.abs(overridden.timing.duration - 0.4) < 1e-9);
+  assert.equal(
+    overridden.timing.easing,
+    "ease_in_out_cubic",
+    "Scene.play kwargs should override builder animation kwargs",
+  );
+
   let zError = null;
   try {
     await page.evaluate(
@@ -218,7 +308,7 @@ try {
 
   assert.deepEqual(errors, [], `browser errors while testing Manim compatibility:\n${errors.join("\n")}`);
   console.log(
-    "Manim compatibility smoke passed: construct discovery, shape classes, scene membership, group lowering, generic animate proxying, independent fill/stroke opacity, z=0 vectors, and rate_func lowering.",
+    "Manim compatibility smoke passed: construct discovery, shape classes, scene/group semantics, callable and chained animate builders, detached animate auto-add, per-animation timing, play overrides, independent fill/stroke opacity, z=0 vectors, and deterministic rate_func lowering.",
   );
 } finally {
   await browser?.close();

--- a/web/python-worker.js
+++ b/web/python-worker.js
@@ -6,6 +6,7 @@ const PYTHON_MODULE_PATH = "/tmp/noon.py";
 const PYTHON_IR_MODULE_PATH = "/tmp/_noon_ir.py";
 const MANIM_COMPAT_MODULE_PATH = "/tmp/_manim_compat.py";
 const MANIM_PHASE_B_MODULE_PATH = "/tmp/_manim_phase_b.py";
+const MANIM_ANIMATE_MODULE_PATH = "/tmp/_manim_animate.py";
 
 const pyodidePromise = initializePyodide();
 let requestQueue = Promise.resolve();
@@ -20,12 +21,14 @@ self.addEventListener("message", (event) => {
 
 async function initializePyodide() {
   const pyodide = await loadPyodide();
-  const [apiResponse, irResponse, compatResponse, phaseBResponse] = await Promise.all([
-    fetch(new URL("./python/noon.py", import.meta.url)),
-    fetch(new URL("./python/_noon_ir.py", import.meta.url)),
-    fetch(new URL("./python/_manim_compat.py", import.meta.url)),
-    fetch(new URL("./python/_manim_phase_b.py", import.meta.url)),
-  ]);
+  const [apiResponse, irResponse, compatResponse, phaseBResponse, animateResponse] =
+    await Promise.all([
+      fetch(new URL("./python/noon.py", import.meta.url)),
+      fetch(new URL("./python/_noon_ir.py", import.meta.url)),
+      fetch(new URL("./python/_manim_compat.py", import.meta.url)),
+      fetch(new URL("./python/_manim_phase_b.py", import.meta.url)),
+      fetch(new URL("./python/_manim_animate.py", import.meta.url)),
+    ]);
   if (!apiResponse.ok) {
     throw new Error(`Unable to load Noon Python API: HTTP ${apiResponse.status}`);
   }
@@ -37,6 +40,9 @@ async function initializePyodide() {
   }
   if (!phaseBResponse.ok) {
     throw new Error(`Unable to load Noon Manim Phase B layer: HTTP ${phaseBResponse.status}`);
+  }
+  if (!animateResponse.ok) {
+    throw new Error(`Unable to load Noon Manim animate layer: HTTP ${animateResponse.status}`);
   }
 
   pyodide.FS.writeFile(PYTHON_MODULE_PATH, await apiResponse.text(), {
@@ -51,12 +57,16 @@ async function initializePyodide() {
   pyodide.FS.writeFile(MANIM_PHASE_B_MODULE_PATH, await phaseBResponse.text(), {
     encoding: "utf8",
   });
+  pyodide.FS.writeFile(MANIM_ANIMATE_MODULE_PATH, await animateResponse.text(), {
+    encoding: "utf8",
+  });
   pyodide.runPython(`
 import sys
 sys.path.insert(0, "/tmp")
 import _manim_compat
 _manim_compat.install()
 import _manim_phase_b
+import _manim_animate
 `);
   return pyodide;
 }

--- a/web/python/_manim_animate.py
+++ b/web/python/_manim_animate.py
@@ -329,7 +329,10 @@ def _aligned_scene_play(
                 lag_ratio=item_lag_ratio,
             )
             for lowered, child_start, child_duration, child_easing in schedule:
-                _base.Scene.play(
+                # `noon.Scene` has already been replaced by the compatibility class
+                # during install, so use the original captured facade explicitly to
+                # avoid recursively re-entering this compatibility scheduler.
+                _compat._BaseScene.play(
                     self,
                     lowered,
                     run_time=child_duration,

--- a/web/python/_manim_animate.py
+++ b/web/python/_manim_animate.py
@@ -1,0 +1,352 @@
+"""Manim-compatible ``.animate`` scheduling semantics.
+
+This layer keeps animation authoring in Python while lowering every supported operation
+to Noon's deterministic scene tracks. No Python callbacks run during playback.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Callable
+
+import noon as _base
+import _manim_compat as _compat
+import _manim_phase_b as _phase_b
+
+
+class _AnimateBuilderMixin:
+    """Mirror Manim's callable/chained ``_AnimationBuilder`` contract."""
+
+    source: object
+    target: object
+    mobject: object
+    anim_args: dict[str, Any]
+    cannot_pass_args: bool
+    is_chaining: bool
+
+    def _initialize_builder(self, source: object) -> None:
+        self.source = source
+        self.mobject = source
+        self.target = source.copy()  # type: ignore[attr-defined]
+        self.anim_args = {}
+        self.cannot_pass_args = False
+        self.is_chaining = False
+
+    def __call__(self, **kwargs: Any):
+        if self.cannot_pass_args:
+            raise ValueError(
+                "Animation arguments must be passed before accessing methods and can only be passed once"
+            )
+        self.anim_args = dict(kwargs)
+        self.cannot_pass_args = True
+        return self
+
+    def __getattr__(self, name: str) -> Callable[..., Any]:
+        if name.startswith("_"):
+            raise AttributeError(name)
+        target_attribute = getattr(self.target, name)
+        if not callable(target_attribute):
+            raise AttributeError(f"{name} is not an animatable method")
+
+        # Manim prevents animation arguments from being supplied after the first
+        # method is accessed, even before the returned method proxy is invoked.
+        self.is_chaining = True
+        self.cannot_pass_args = True
+
+        def invoke(*args: Any, **kwargs: Any):
+            result = target_attribute(*args, **kwargs)
+            if result is not None and result is not self.target:
+                raise TypeError(
+                    f"animate.{name} must be a mutating method returning self or None"
+                )
+            return self
+
+        return invoke
+
+
+class _AlignedAnimationBuilder(_AnimateBuilderMixin, _base._AnimationBuilder):
+    """Mobject builder recognizable by Noon's existing Transform lowerer."""
+
+    def __init__(self, source: _base.Mobject) -> None:
+        # Unlike the old Noon builder, Manim allows ``self.play(Circle().animate...)``.
+        # Binding happens when Scene.play compiles the animation.
+        self._initialize_builder(source)
+
+
+class _AlignedGroupAnimationBuilder(_AnimateBuilderMixin):
+    def __init__(self, source: _compat.Group) -> None:
+        self._initialize_builder(source)
+
+
+# Both properties in _manim_compat resolve these globals at access time.
+_compat._CompatAnimationBuilder = _AlignedAnimationBuilder
+_compat._GroupAnimationBuilder = _AlignedGroupAnimationBuilder
+
+
+_SUPPORTED_BUILDER_ARGS = {
+    "run_time",
+    "rate_func",
+    "lag_ratio",
+    "path_arc",
+    "reverse_rate_function",
+    "suspend_mobject_updating",
+    "name",
+}
+
+
+def _positive_duration(name: str, value: object) -> float:
+    result = float(value)
+    if not math.isfinite(result) or result <= 0.0:
+        raise ValueError(f"{name} must be finite and positive")
+    return result
+
+
+def _lag_ratio(value: object) -> float:
+    result = float(value)
+    if not math.isfinite(result) or result < 0.0:
+        raise ValueError("lag_ratio must be finite and non-negative")
+    return result
+
+
+def _validate_builder_args(builder: object) -> dict[str, Any]:
+    args = dict(getattr(builder, "anim_args", {}))
+    unsupported = sorted(set(args) - _SUPPORTED_BUILDER_ARGS)
+    if unsupported:
+        raise NotImplementedError(
+            "unsupported Manim .animate option(s): " + ", ".join(unsupported)
+        )
+
+    if "path_arc" in args:
+        path_arc = float(args["path_arc"])
+        if not math.isfinite(path_arc):
+            raise ValueError("path_arc must be finite")
+        if not math.isclose(path_arc, 0.0, abs_tol=1e-12):
+            raise NotImplementedError(
+                "non-zero .animate(path_arc=...) requires curved transform paths, "
+                "which are not yet represented by Noon's deterministic Transform track"
+            )
+
+    if bool(args.get("reverse_rate_function", False)):
+        raise NotImplementedError(
+            ".animate(reverse_rate_function=True) is not yet represented by Noon's easing IR"
+        )
+
+    if "run_time" in args:
+        args["run_time"] = _positive_duration("run_time", args["run_time"])
+    if "lag_ratio" in args:
+        args["lag_ratio"] = _lag_ratio(args["lag_ratio"])
+    return args
+
+
+def _builder_source(animation: object) -> object | None:
+    if isinstance(animation, (_AlignedAnimationBuilder, _AlignedGroupAnimationBuilder)):
+        return animation.source
+    return None
+
+
+def _record_wrapper_state(value: object, states: dict[int, tuple[_base.Mobject, object, object]]) -> None:
+    if isinstance(value, _compat.Group):
+        for member in _compat._leaf_mobjects(value):
+            _record_wrapper_state(member, states)
+        return
+    if isinstance(value, _base.Mobject):
+        states.setdefault(id(value), (value, value._scene, value._object))
+
+
+def _bind_for_animation(
+    scene: _compat.Scene,
+    value: object,
+    *,
+    start_time: float,
+) -> None:
+    """Match Manim Scene.play's implicit addition of animated mobjects."""
+
+    leaves = _compat._leaf_mobjects(value)
+    for member in leaves:
+        newly_bound = member._scene is None
+        if newly_bound:
+            _phase_b._bind_raw(scene, member)
+        elif member._scene is not scene:
+            raise ValueError("Mobject already belongs to another Scene")
+
+        assert member._object is not None
+        tracks = scene._ensure_lifecycle_timeline_available(
+            member._object, start_time, "animated Mobject"
+        )
+        if (newly_bound and start_time > 0.0) or (
+            tracks and not scene._presence_at(member._object, start_time)
+        ):
+            scene._add_presence_track(
+                member._object,
+                False,
+                True,
+                start_time,
+                key=f"@scene-play-add:{member._object.id}:{start_time:g}",
+            )
+
+    scene._register_top_level(value)
+
+
+def _default_lag_ratio(animation: object) -> float:
+    # Manim Create defaults to lag_ratio=1; ordinary Transform/_MethodAnimation
+    # and fading animations default to zero.
+    if isinstance(animation, _base.Create) and isinstance(animation.target, _compat.Group):
+        return 1.0
+    return 0.0
+
+
+def _resolve_easing(
+    *,
+    builder_args: dict[str, Any],
+    play_easing: str | None,
+    play_rate_func: object | None,
+) -> str:
+    if play_easing is not None:
+        return play_easing
+    if play_rate_func is not None:
+        return _compat._easing_from_rate_func(play_rate_func)
+    if "rate_func" in builder_args:
+        return _compat._easing_from_rate_func(builder_args["rate_func"])
+    # Manim Animation defaults to rate_func=smooth. Noon currently lowers the
+    # known function to its deterministic ease-in-out easing representation.
+    return _compat._easing_from_rate_func(_compat.smooth)
+
+
+def _expanded_schedule(
+    scene: _compat.Scene,
+    animation: object,
+    *,
+    start_time: float,
+    run_time: float,
+    easing: str,
+    lag_ratio: float,
+) -> list[tuple[object, float, float, str]]:
+    expanded = scene._expand_animation(animation)
+    if not expanded:
+        return []
+
+    is_family_animation = isinstance(animation, _AlignedGroupAnimationBuilder) or (
+        isinstance(animation, (_base.Create, _base.FadeIn, _base.FadeOut))
+        and isinstance(animation.target, _compat.Group)
+    )
+    if not is_family_animation or len(expanded) == 1:
+        return [(item, start_time, run_time, easing) for item in expanded]
+
+    # This is Manim Animation.get_sub_alpha's timing geometry written directly as
+    # deterministic child intervals: full_length = 1 + (n-1)*lag_ratio.
+    full_length = 1.0 + (len(expanded) - 1) * lag_ratio
+    child_duration = run_time / full_length
+    offset = lag_ratio * child_duration
+    return [
+        (item, start_time + index * offset, child_duration, easing)
+        for index, item in enumerate(expanded)
+    ]
+
+
+def _aligned_scene_play(
+    self: _compat.Scene,
+    *animations: Any,
+    duration: float | None = None,
+    run_time: float | None = None,
+    start_time: float | None = None,
+    easing: str | None = None,
+    rate_func: object | None = None,
+    lag_ratio: float | None = None,
+    **kwargs: Any,
+) -> _compat.Scene:
+    if not animations:
+        raise ValueError("play requires at least one animation")
+    if duration is not None and run_time is not None:
+        raise ValueError("use either duration or run_time, not both")
+    if easing is not None and rate_func is not None:
+        raise ValueError("use either rate_func or the low-level easing alias, not both")
+    if kwargs:
+        unsupported = ", ".join(sorted(kwargs))
+        raise NotImplementedError(f"unsupported Manim Scene.play option(s): {unsupported}")
+
+    play_duration = None
+    if run_time is not None:
+        play_duration = _positive_duration("run_time", run_time)
+    elif duration is not None:
+        play_duration = _positive_duration("duration", duration)
+    play_lag_ratio = None if lag_ratio is None else _lag_ratio(lag_ratio)
+
+    base_start = self._cursor if start_time is None else float(start_time)
+    if not math.isfinite(base_start) or base_start < 0.0:
+        raise ValueError("start_time must be finite and non-negative")
+
+    checkpoint = self._authoring_checkpoint()
+    cursor_before = self._cursor
+    top_level_before = list(self._compat_top_level)
+    wrapper_states: dict[int, tuple[_base.Mobject, object, object]] = {}
+    for animation in animations:
+        source = _builder_source(animation)
+        if source is not None:
+            _record_wrapper_state(source, wrapper_states)
+        if isinstance(animation, (_base.Create, _base.FadeIn, _base.FadeOut)):
+            _record_wrapper_state(animation.target, wrapper_states)
+
+    max_end = base_start
+    try:
+        # Introducing animations bind their target; method animations and FadeOut
+        # match Manim's normal Scene.play behavior by implicitly adding their mobject.
+        for animation in animations:
+            source = _builder_source(animation)
+            if source is not None:
+                _bind_for_animation(self, source, start_time=base_start)
+            elif isinstance(animation, (_base.Create, _base.FadeIn)):
+                self._bind_introducer_target(animation.target)
+            elif isinstance(animation, _base.FadeOut):
+                _bind_for_animation(self, animation.target, start_time=base_start)
+
+        for animation in animations:
+            builder_args = _validate_builder_args(animation)
+            item_duration = (
+                play_duration
+                if play_duration is not None
+                else builder_args.get("run_time", 1.0)
+            )
+            item_duration = _positive_duration("run_time", item_duration)
+            item_easing = _resolve_easing(
+                builder_args=builder_args,
+                play_easing=easing,
+                play_rate_func=rate_func,
+            )
+            item_lag_ratio = (
+                play_lag_ratio
+                if play_lag_ratio is not None
+                else builder_args.get("lag_ratio", _default_lag_ratio(animation))
+            )
+            item_lag_ratio = _lag_ratio(item_lag_ratio)
+
+            schedule = _expanded_schedule(
+                self,
+                animation,
+                start_time=base_start,
+                run_time=item_duration,
+                easing=item_easing,
+                lag_ratio=item_lag_ratio,
+            )
+            for lowered, child_start, child_duration, child_easing in schedule:
+                _base.Scene.play(
+                    self,
+                    lowered,
+                    run_time=child_duration,
+                    start_time=child_start,
+                    easing=child_easing,
+                )
+            max_end = max(max_end, base_start + item_duration)
+
+        self._cursor = max(cursor_before, max_end)
+        return self
+    except Exception:
+        self._restore_authoring_checkpoint(checkpoint)
+        self._cursor = cursor_before
+        self._compat_top_level = top_level_before
+        for member, old_scene, old_object in wrapper_states.values():
+            member._scene = old_scene
+            member._object = old_object
+        raise
+
+
+_compat.Scene.play = _aligned_scene_play

--- a/web/python/_manim_animate.py
+++ b/web/python/_manim_animate.py
@@ -64,9 +64,7 @@ class _AnimateBuilderMixin:
         return invoke
 
 
-class _AlignedAnimationBuilder(_AnimateBuilderMixin, _base._AnimationBuilder):
-    """Mobject builder recognizable by Noon's existing Transform lowerer."""
-
+class _AlignedAnimationBuilder(_AnimateBuilderMixin):
     def __init__(self, source: _base.Mobject) -> None:
         # Unlike the old Noon builder, Manim allows ``self.play(Circle().animate...)``.
         # Binding happens when Scene.play compiles the animation.
@@ -221,7 +219,10 @@ def _expanded_schedule(
     easing: str,
     lag_ratio: float,
 ) -> list[tuple[object, float, float, str]]:
-    expanded = scene._expand_animation(animation)
+    if isinstance(animation, _AlignedAnimationBuilder):
+        expanded = [_base.Transform(animation.source, animation.target)]
+    else:
+        expanded = scene._expand_animation(animation)
     if not expanded:
         return []
 


### PR DESCRIPTION
## Summary

- make `.animate` callable before method access, matching Manim's `mobject.animate(run_time=..., rate_func=...).shift(...)` syntax and argument-order errors
- preserve arbitrary mutating-method chaining through one detached target snapshot
- allow detached mobjects/groups to be animated directly; `Scene.play` binds them just like Manim adds animated mobjects
- honor per-builder `run_time`, `rate_func`, and `lag_ratio`, with `Scene.play(...)` kwargs overriding builder options
- schedule mixed per-animation durations in one play call and advance scene time by the longest animation
- lower group `lag_ratio` to deterministic staggered child intervals without adding runtime hierarchy
- switch the Manim-compatible `Scene.play` default rate function from Noon's historical linear default to the existing deterministic `smooth` mapping
- reject unsupported nonzero `path_arc` / reversed rate-function behavior explicitly instead of silently drifting
- expand the real Chromium/Pyodide compatibility gate with detached animate, builder call-order, mixed timing, group lag, and override-precedence assertions

## Architecture

The builder remains an authoring-time target-state compiler. Chained methods mutate a detached copy; `Scene.play` emits ordinary Noon Transform/lifecycle tracks. There is no Python work during frame playback.

## Known follow-up

Noon's current deterministic `smooth` mapping is still `ease_in_out_cubic`, while ManimCE's exact default `smooth` function is a normalized logistic sigmoid. This PR aligns builder/scheduling behavior first; exact Manim rate-function curves should become first-class runtime easings in a follow-up rather than approximating them with Python callbacks.