### PR TITLE
Integrate native reactivity into SceneInstance

### DIFF
--- a/crates/noon-runtime/src/lib.rs
+++ b/crates/noon-runtime/src/lib.rs
@@ -235,6 +235,11 @@ impl SceneInstance {
         Ok(&self.frame)
     }
 
+    /// Applies a low-level patch to the compiled timeline/object program.
+    ///
+    /// Reactive semantic scenes currently support value-only patches on this path.
+    /// Structural/timeline mutations must be revalidated and rebuilt from the
+    /// `SemanticScene` until reactive-aware transactional lowering is implemented.
     pub fn apply_patch(&mut self, patch: &ScenePatch) -> Result<&FrameState, CompilePatchError> {
         if matches!(
             patch,

--- a/crates/noon-runtime/src/lib.rs
+++ b/crates/noon-runtime/src/lib.rs
@@ -2,6 +2,10 @@
 
 #![forbid(unsafe_code)]
 
+mod reactive;
+
+pub use reactive::*;
+
 use noon_compile::{CompilePatchError, CompiledScene, CompiledTrack, TransformGeometryPlan};
 use noon_core::{
     Color, GeometryRef, ObjectId, ObjectSnapshot, Property, ScenePatch, Style, TrackValues,
@@ -161,6 +165,8 @@ pub struct SceneInstance {
     groups: Vec<TrackGroup>,
     last_stats: EvaluationStats,
     changes: FrameChanges,
+    reactive: Option<ReactiveRuntime>,
+    last_reactive_stats: ReactiveRuntimeStats,
 }
 
 impl SceneInstance {
@@ -173,6 +179,8 @@ impl SceneInstance {
             groups,
             last_stats: EvaluationStats::default(),
             changes: FrameChanges::all(),
+            reactive: None,
+            last_reactive_stats: ReactiveRuntimeStats::default(),
         };
         instance.seek_unchecked(0.0);
         instance
@@ -270,6 +278,7 @@ impl SceneInstance {
             }
             _ => unreachable!("value patch helper only accepts transform or style patches"),
         }
+        self.reapply_reactive_for_object(index);
         if self.frame.objects[index] != before {
             self.changes.insert(index);
         }
@@ -304,6 +313,7 @@ impl SceneInstance {
             stats.groups_evaluated += 1;
         }
 
+        self.reapply_reactive();
         self.last_stats = stats;
     }
 

--- a/crates/noon-runtime/src/reactive.rs
+++ b/crates/noon-runtime/src/reactive.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 
 use noon_compile::{CompileError, CompiledScene};
 use noon_core::{
@@ -53,7 +53,6 @@ pub struct ReactiveRuntimeStats {
 #[derive(Clone, Copy, Debug)]
 struct ReactiveTarget {
     signal: SignalId,
-    object: ObjectId,
     object_index: usize,
     property: Property,
 }
@@ -84,7 +83,6 @@ impl ReactiveRuntime {
             let target_index = targets.len();
             targets.push(ReactiveTarget {
                 signal: binding.signal,
-                object: binding.object,
                 object_index,
                 property: binding.property,
             });
@@ -149,7 +147,6 @@ impl SceneInstance {
             .set_input(signal, value)?;
         let evaluation = update.stats();
         let mut changed_targets = 0;
-        let mut changed_objects = BTreeSet::new();
 
         for change in update.property_changes() {
             let target = self
@@ -165,12 +162,11 @@ impl SceneInstance {
             ) {
                 self.changes.insert(target.object_index);
                 changed_targets += 1;
-                changed_objects.insert(target.object_index);
             }
         }
 
-        self.last_reactive_stats = runtime_stats(evaluation, update.property_changes().len(), changed_targets);
-        debug_assert!(changed_objects.len() <= changed_targets);
+        self.last_reactive_stats =
+            runtime_stats(evaluation, update.property_changes().len(), changed_targets);
         Ok(&self.frame)
     }
 
@@ -329,7 +325,8 @@ mod tests {
         ));
         scene.bind(doubled, target, Property::Rotation);
 
-        let mut instance = SceneInstance::from_semantic(&scene).expect("semantic scene must compile");
+        let mut instance =
+            SceneInstance::from_semantic(&scene).expect("semantic scene must compile");
         instance.take_frame_changes();
         instance
             .set_reactive_input(input, 2.0_f32)
@@ -367,13 +364,17 @@ mod tests {
         let rotation = scene.add_input(0.25_f32);
         scene.bind(rotation, object, Property::Rotation);
 
-        let mut instance = SceneInstance::from_semantic(&scene).expect("semantic scene must compile");
+        let mut instance =
+            SceneInstance::from_semantic(&scene).expect("semantic scene must compile");
         instance
             .set_reactive_input(rotation, 1.25_f32)
             .expect("input update must work");
         instance.seek(1.0).expect("seek must work");
 
-        assert_eq!(instance.frame().objects[0].transform.translation, Vec2::new(5.0, 0.0));
+        assert_eq!(
+            instance.frame().objects[0].transform.translation,
+            Vec2::new(5.0, 0.0)
+        );
         assert_eq!(instance.frame().objects[0].transform.rotation, 1.25);
     }
 
@@ -395,7 +396,8 @@ mod tests {
         ));
         scene.bind(shifted, target, Property::Rotation);
 
-        let mut instance = SceneInstance::from_semantic(&scene).expect("semantic scene must compile");
+        let mut instance =
+            SceneInstance::from_semantic(&scene).expect("semantic scene must compile");
         instance.take_frame_changes();
         let timeline_stats_before = instance.last_stats();
         instance

--- a/crates/noon-runtime/src/reactive.rs
+++ b/crates/noon-runtime/src/reactive.rs
@@ -1,0 +1,419 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use noon_compile::{CompileError, CompiledScene};
+use noon_core::{
+    ObjectId, Property, ReactiveBinding, ReactiveError, ReactiveEvaluationStats, ReactiveProgram,
+    ReactiveState, ReactiveValue, SemanticScene, SignalId,
+};
+
+use crate::{FrameState, SceneInstance};
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum SceneBuildError {
+    Compile(CompileError),
+    Reactive(ReactiveError),
+}
+
+impl std::fmt::Display for SceneBuildError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Compile(error) => write!(formatter, "scene compilation failed: {error}"),
+            Self::Reactive(error) => write!(formatter, "reactive compilation failed: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for SceneBuildError {}
+
+impl From<CompileError> for SceneBuildError {
+    fn from(value: CompileError) -> Self {
+        Self::Compile(value)
+    }
+}
+
+impl From<ReactiveError> for SceneBuildError {
+    fn from(value: ReactiveError) -> Self {
+        Self::Reactive(value)
+    }
+}
+
+/// Work performed by the most recent native reactive input update.
+///
+/// These counters deliberately exclude total scene/object counts. Once a semantic
+/// scene is lowered, an input update performs dependency evaluation plus direct
+/// writes to precomputed dense frame targets only.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ReactiveRuntimeStats {
+    pub derived_signals_evaluated: usize,
+    pub bindings_invalidated: usize,
+    pub dense_targets_applied: usize,
+    pub dense_targets_changed: usize,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ReactiveTarget {
+    signal: SignalId,
+    object: ObjectId,
+    object_index: usize,
+    property: Property,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ReactiveRuntime {
+    state: ReactiveState,
+    targets: Vec<ReactiveTarget>,
+    target_lookup: BTreeMap<(u64, u8), usize>,
+    targets_by_object: Vec<Vec<usize>>,
+}
+
+impl ReactiveRuntime {
+    fn new(
+        compiled: &CompiledScene,
+        bindings: &[ReactiveBinding],
+        program: ReactiveProgram,
+    ) -> Self {
+        let mut targets = Vec::with_capacity(bindings.len());
+        let mut target_lookup = BTreeMap::new();
+        let mut targets_by_object = vec![Vec::new(); compiled.objects().len()];
+
+        for binding in bindings {
+            let object_index = compiled
+                .object_index(binding.object)
+                .expect("reactive graph was validated against the compiled definition")
+                as usize;
+            let target_index = targets.len();
+            targets.push(ReactiveTarget {
+                signal: binding.signal,
+                object: binding.object,
+                object_index,
+                property: binding.property,
+            });
+            target_lookup.insert(binding_key(binding.object, binding.property), target_index);
+            targets_by_object[object_index].push(target_index);
+        }
+
+        Self {
+            state: program.instantiate(),
+            targets,
+            target_lookup,
+            targets_by_object,
+        }
+    }
+
+    fn target(&self, object: ObjectId, property: Property) -> ReactiveTarget {
+        let index = *self
+            .target_lookup
+            .get(&binding_key(object, property))
+            .expect("reactive update must reference a lowered binding");
+        self.targets[index]
+    }
+}
+
+impl SceneInstance {
+    /// Compile a high-level semantic scene once and attach its validated native
+    /// reactive program to this runtime instance.
+    ///
+    /// Reactive bindings are lowered to dense frame object indices here. Later
+    /// input updates therefore do not rebuild `SceneDefinition`, recompile the
+    /// timeline, or scan unrelated objects.
+    pub fn from_semantic(scene: &SemanticScene) -> Result<Self, SceneBuildError> {
+        let compiled = CompiledScene::compile(scene.definition())?;
+        let program = scene.compile_reactive()?;
+        let reactive = ReactiveRuntime::new(&compiled, scene.reactive().bindings(), program);
+        let mut instance = Self::new(compiled);
+        instance.reactive = Some(reactive);
+        instance.reapply_reactive();
+        Ok(instance)
+    }
+
+    pub const fn last_reactive_stats(&self) -> ReactiveRuntimeStats {
+        self.last_reactive_stats
+    }
+
+    pub fn reactive_value(&self, signal: SignalId) -> Option<&ReactiveValue> {
+        self.reactive.as_ref()?.state.value(signal)
+    }
+
+    /// Change one native input and apply only its invalidated bindings to the
+    /// already-compiled dense frame state.
+    pub fn set_reactive_input(
+        &mut self,
+        signal: SignalId,
+        value: impl Into<ReactiveValue>,
+    ) -> Result<&FrameState, ReactiveError> {
+        let update = self
+            .reactive
+            .as_mut()
+            .ok_or(ReactiveError::UnknownSignal(signal))?
+            .state
+            .set_input(signal, value)?;
+        let evaluation = update.stats();
+        let mut changed_targets = 0;
+        let mut changed_objects = BTreeSet::new();
+
+        for change in update.property_changes() {
+            let target = self
+                .reactive
+                .as_ref()
+                .expect("reactive state exists while applying its update")
+                .target(change.object, change.property);
+            if apply_reactive_value(
+                &mut self.frame,
+                target.object_index,
+                target.property,
+                &change.value,
+            ) {
+                self.changes.insert(target.object_index);
+                changed_targets += 1;
+                changed_objects.insert(target.object_index);
+            }
+        }
+
+        self.last_reactive_stats = runtime_stats(evaluation, update.property_changes().len(), changed_targets);
+        debug_assert!(changed_objects.len() <= changed_targets);
+        Ok(&self.frame)
+    }
+
+    pub(crate) fn reapply_reactive(&mut self) {
+        let Self {
+            reactive, frame, ..
+        } = self;
+        let Some(reactive) = reactive.as_ref() else {
+            return;
+        };
+        for target in &reactive.targets {
+            let value = reactive
+                .state
+                .value(target.signal)
+                .expect("lowered reactive target references a valid signal");
+            apply_reactive_value(frame, target.object_index, target.property, value);
+        }
+    }
+
+    pub(crate) fn reapply_reactive_for_object(&mut self, object_index: usize) {
+        let Self {
+            reactive, frame, ..
+        } = self;
+        let Some(reactive) = reactive.as_ref() else {
+            return;
+        };
+        let Some(target_indices) = reactive.targets_by_object.get(object_index) else {
+            return;
+        };
+        for target_index in target_indices {
+            let target = reactive.targets[*target_index];
+            let value = reactive
+                .state
+                .value(target.signal)
+                .expect("lowered reactive target references a valid signal");
+            apply_reactive_value(frame, target.object_index, target.property, value);
+        }
+    }
+}
+
+fn runtime_stats(
+    evaluation: ReactiveEvaluationStats,
+    dense_targets_applied: usize,
+    dense_targets_changed: usize,
+) -> ReactiveRuntimeStats {
+    ReactiveRuntimeStats {
+        derived_signals_evaluated: evaluation.derived_signals_evaluated,
+        bindings_invalidated: evaluation.bindings_invalidated,
+        dense_targets_applied,
+        dense_targets_changed,
+    }
+}
+
+fn binding_key(object: ObjectId, property: Property) -> (u64, u8) {
+    (object.get(), property_slot(property))
+}
+
+const fn property_slot(property: Property) -> u8 {
+    match property {
+        Property::Presence => 0,
+        Property::Transform => 1,
+        Property::Position => 2,
+        Property::Rotation => 3,
+        Property::Opacity => 4,
+        Property::Appearance => 5,
+        Property::Reveal => 6,
+        Property::Morph => 7,
+    }
+}
+
+fn apply_reactive_value(
+    frame: &mut FrameState,
+    object_index: usize,
+    property: Property,
+    value: &ReactiveValue,
+) -> bool {
+    match (property, value) {
+        (Property::Presence, ReactiveValue::Bool(value)) => {
+            let changed = frame.presences[object_index] != *value;
+            frame.presences[object_index] = *value;
+            changed
+        }
+        (Property::Position, ReactiveValue::Vec2(value)) => {
+            let object = &mut frame.objects[object_index];
+            let changed = object.transform.translation != *value;
+            object.transform.translation = *value;
+            changed
+        }
+        (Property::Rotation, ReactiveValue::Scalar(value)) => {
+            let object = &mut frame.objects[object_index];
+            let changed = object.transform.rotation != *value;
+            object.transform.rotation = *value;
+            changed
+        }
+        (Property::Opacity, ReactiveValue::Scalar(value)) => {
+            let object = &mut frame.objects[object_index];
+            let changed = object.style.opacity != *value;
+            object.style.opacity = *value;
+            changed
+        }
+        (Property::Appearance, ReactiveValue::Scalar(value)) => {
+            let value = value.clamp(0.0, 1.0);
+            let object = &mut frame.objects[object_index];
+            let changed = object.appearance != value;
+            object.appearance = value;
+            changed
+        }
+        (Property::Reveal, ReactiveValue::Scalar(value)) => {
+            let value = value.clamp(0.0, 1.0);
+            let changed = frame.reveals[object_index] != value;
+            frame.reveals[object_index] = value;
+            changed
+        }
+        (Property::Morph, ReactiveValue::Scalar(value)) => {
+            let value = value.clamp(0.0, 1.0);
+            let changed = frame.morphs[object_index] != value;
+            frame.morphs[object_index] = value;
+            changed
+        }
+        (Property::Transform, _) => {
+            unreachable!("reactive values cannot drive object-snapshot Transform properties")
+        }
+        _ => unreachable!("validated reactive binding value type must match its property"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use noon_core::{GeometryRef, RateFunction, ReactiveExpr, TrackTiming, Vec2};
+
+    use super::*;
+
+    #[test]
+    fn initial_reactive_values_are_lowered_into_frame_state() {
+        let mut scene = SemanticScene::new();
+        let object = scene.add(GeometryRef::circle(1.0));
+        let position = scene.add_input(Vec2::new(3.0, -2.0));
+        scene.bind(position, object, Property::Position);
+
+        let instance = SceneInstance::from_semantic(&scene).expect("semantic scene must compile");
+        assert_eq!(
+            instance.frame().objects[0].transform.translation,
+            Vec2::new(3.0, -2.0)
+        );
+    }
+
+    #[test]
+    fn input_update_mutates_only_lowered_dense_target() {
+        let mut scene = SemanticScene::new();
+        let untouched = scene.add(GeometryRef::circle(1.0));
+        let target = scene.add(GeometryRef::circle(1.0));
+        let input = scene.add_input(1.0_f32);
+        let doubled = scene.add_derived(ReactiveExpr::Mul(
+            Box::new(ReactiveExpr::signal(input)),
+            Box::new(ReactiveExpr::scalar(2.0)),
+        ));
+        scene.bind(doubled, target, Property::Rotation);
+
+        let mut instance = SceneInstance::from_semantic(&scene).expect("semantic scene must compile");
+        instance.take_frame_changes();
+        instance
+            .set_reactive_input(input, 2.0_f32)
+            .expect("input update must work");
+
+        assert_eq!(instance.frame().objects[0].id, untouched);
+        assert_eq!(instance.frame().objects[0].transform.rotation, 0.0);
+        assert_eq!(instance.frame().objects[1].id, target);
+        assert_eq!(instance.frame().objects[1].transform.rotation, 4.0);
+        assert_eq!(instance.take_frame_changes().object_indices(), &[1]);
+        assert_eq!(
+            instance.last_reactive_stats(),
+            ReactiveRuntimeStats {
+                derived_signals_evaluated: 1,
+                bindings_invalidated: 1,
+                dense_targets_applied: 1,
+                dense_targets_changed: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn seeks_reapply_reactive_values_after_timeline_evaluation() {
+        let mut scene = SemanticScene::new();
+        let object = scene.add(GeometryRef::circle(1.0));
+        scene
+            .definition_mut()
+            .animate_position(
+                object,
+                Vec2::ZERO,
+                Vec2::new(10.0, 0.0),
+                TrackTiming::new(0.0, 2.0, RateFunction::Linear),
+            )
+            .expect("timeline must be valid");
+        let rotation = scene.add_input(0.25_f32);
+        scene.bind(rotation, object, Property::Rotation);
+
+        let mut instance = SceneInstance::from_semantic(&scene).expect("semantic scene must compile");
+        instance
+            .set_reactive_input(rotation, 1.25_f32)
+            .expect("input update must work");
+        instance.seek(1.0).expect("seek must work");
+
+        assert_eq!(instance.frame().objects[0].transform.translation, Vec2::new(5.0, 0.0));
+        assert_eq!(instance.frame().objects[0].transform.rotation, 1.25);
+    }
+
+    #[test]
+    fn reactive_update_cost_does_not_scale_with_static_object_count() {
+        let mut scene = SemanticScene::new();
+        for _ in 0..50_000 {
+            scene.add(GeometryRef::circle(1.0));
+        }
+        let target = scene.add(GeometryRef::circle(1.0));
+        let input = scene.add_input(1.0_f32);
+        let doubled = scene.add_derived(ReactiveExpr::Mul(
+            Box::new(ReactiveExpr::signal(input)),
+            Box::new(ReactiveExpr::scalar(2.0)),
+        ));
+        let shifted = scene.add_derived(ReactiveExpr::Add(
+            Box::new(ReactiveExpr::signal(doubled)),
+            Box::new(ReactiveExpr::scalar(1.0)),
+        ));
+        scene.bind(shifted, target, Property::Rotation);
+
+        let mut instance = SceneInstance::from_semantic(&scene).expect("semantic scene must compile");
+        instance.take_frame_changes();
+        let timeline_stats_before = instance.last_stats();
+        instance
+            .set_reactive_input(input, 3.0_f32)
+            .expect("input update must work");
+
+        assert_eq!(instance.frame().objects[50_000].id, target);
+        assert_eq!(instance.frame().objects[50_000].transform.rotation, 7.0);
+        assert_eq!(instance.take_frame_changes().object_indices(), &[50_000]);
+        assert_eq!(instance.last_stats(), timeline_stats_before);
+        assert_eq!(
+            instance.last_reactive_stats(),
+            ReactiveRuntimeStats {
+                derived_signals_evaluated: 2,
+                bindings_invalidated: 1,
+                dense_targets_applied: 1,
+                dense_targets_changed: 1,
+            }
+        );
+    }
+}

--- a/docs/reactive-execution.md
+++ b/docs/reactive-execution.md
@@ -12,12 +12,13 @@ A large scene with one interactive tracker should keep unrelated objects static 
 
 ## Scene layers
 
-The initial implementation distinguishes two related representations:
+The implementation distinguishes related representations:
 
 - `SemanticScene`: the mutable high-level semantic scene. It owns the normalized deterministic `SceneDefinition` plus a native reactive graph. Future host callback slots and richer authoring state belong at this level.
 - `SceneDefinition`: the normalized object/timeline program consumed by the existing compiler/runtime. Reactive dependencies are not encoded as fake or infinite timeline tracks.
+- `SceneInstance`: the dense mutable execution state. Instances created with `SceneInstance::from_semantic` own a `ReactiveState` beside the compiled timeline and lower semantic bindings to dense frame targets once.
 
-This distinction is intentional. Timeline animation and reactive state have different execution and invalidation rules and should meet during lowering rather than being conflated in the authoring model.
+This distinction is intentional. Timeline animation and reactive state have different execution and invalidation rules and meet during lowering rather than being conflated in the authoring model.
 
 ## Native reactive graph
 
@@ -48,14 +49,25 @@ Different properties on the same object may use different execution strategies. 
 
 Changing one input does not scan the whole graph. It schedules only direct dependents. A derived signal schedules its own dependents only if its evaluated value actually changed. Therefore an unchanged intermediate value terminates dirty propagation.
 
-Each input update returns a `ReactiveUpdate` containing:
+Each input update returns a `ReactiveUpdate` containing changed signals and invalidated object/property bindings. `SceneInstance` consumes that update directly:
 
-- changed signals;
-- invalidated object/property bindings;
-- affected object identities; and
-- evaluation statistics.
+1. semantic bindings are mapped once to dense `FrameState` object indices when the instance is built;
+2. `set_reactive_input` evaluates only the affected dependency branch;
+3. each invalidated binding writes directly to its precomputed dense property target;
+4. changed object indices are inserted into `FrameChanges` for renderer-side incremental preparation; and
+5. no `SceneDefinition` reconstruction, timeline recompilation, or whole-scene diff occurs on the native input path.
 
-This result is the boundary that the mutable runtime will consume. The runtime should map object/property changes directly to compact runtime slots and renderer dirty ranges rather than reconstructing or diffing a complete scene.
+`ReactiveRuntimeStats` reports dependency work and dense-target writes separately from ordinary timeline `EvaluationStats`. CI includes a mixed scene with 50,000 unrelated static objects and verifies that one reactive input still evaluates only its two derived signals, applies one dense target, and invalidates one object.
+
+## Timeline and seek interaction
+
+Timeline and reactive ownership remains property-local. The compiler rejects a timeline track and reactive binding that drive the same property in the semantic scene, while different properties may coexist on one object.
+
+A forward timeline step mutates only timeline-owned properties, so reactive values remain in place. A seek is different: `SceneInstance` reconstructs its base frame and evaluates the timeline from deterministic state, then reapplies current reactive values. Seek cost therefore includes the number of attached reactive bindings, not arbitrary host execution or a full reactive graph reevaluation.
+
+Value-only live patches also reapply reactive values for the patched object after timeline-owned properties are reconciled. This preserves a reactive position/rotation/opacity when unrelated base transform or style fields are edited.
+
+Reactive-aware structural/timeline graph mutation is intentionally a later slice: structural changes need the semantic reactive graph to be revalidated and re-lowered atomically rather than silently inventing precedence between drivers.
 
 ## Execution analysis
 
@@ -70,20 +82,20 @@ This is intentionally object-local rather than a scene-wide mode switch. Later e
 
 ## Mutation transactions
 
-Arbitrary host callbacks and editor actions converge on `MutationTransaction`. Property-only transactions now use a preflight-and-commit path that avoids cloning the entire scene. Timeline or structural transactions retain staged rollback until they have specialized incremental commit paths.
+Arbitrary host callbacks and editor actions converge on `MutationTransaction`. Property-only transactions use a preflight-and-commit path that avoids cloning the entire scene. Timeline or structural transactions retain staged rollback until they have specialized incremental commit paths.
 
-Native reactive evaluation is not itself expressed as generic scene patches. It produces typed property invalidations so the runtime can update the dense execution representation directly. This avoids paying transport/patch machinery costs for every native signal change.
+Native reactive evaluation is not itself expressed as generic scene patches. It produces typed property invalidations consumed directly by the dense runtime representation. This avoids paying transport/patch machinery costs for every native signal change.
 
 ## Next implementation slices
 
-1. Integrate `ReactiveProgram`/`ReactiveState` with `SceneInstance`, including direct property-slot updates and renderer dirty propagation.
-2. Add semantic signal/property APIs to the shared Rust authoring facade and thin Python bindings.
-3. Add input/event signals for pointer, keyboard, viewport, and user controls.
+1. Add semantic signal/property APIs to the shared Rust authoring facade and thin Python bindings.
+2. Add input/event signals for pointer, keyboard, viewport, and user controls.
+3. Add reactive-aware structural/timeline mutation that revalidates and re-lowers affected bindings atomically.
 4. Add host callback slots that read a coherent frame snapshot and submit one batched mutation transaction per callback phase.
 5. Extend execution analysis with host-dynamic dependencies and report static/native/host participation and costs.
-6. Profile mixed scenes where a small reactive region sits beside tens or hundreds of thousands of static objects; CI performance tests should ensure reactive cost scales with affected dependencies rather than total scene size.
+6. Profile mixed scenes where a small reactive region sits beside tens or hundreds of thousands of static objects; add explicit performance budgets in CI once stable runner variance is characterized.
 
-## Non-goals of this slice
+## Non-goals
 
 - encoding native reactivity as timeline tracks;
 - running arbitrary Python on every frame by default;


### PR DESCRIPTION
## Summary

- add `SceneInstance::from_semantic` to compile timeline + native reactive state together
- lower reactive bindings once to dense `FrameState` object/property targets
- add `SceneInstance::set_reactive_input` for dependency-local updates without scene recompilation
- feed reactive writes into existing `FrameChanges` renderer invalidation
- preserve reactive values across seeks and value-only live patches
- expose separate `ReactiveRuntimeStats` from timeline evaluation stats
- add a 50,000-static-object regression proving one reactive branch still performs constant dependency/target work
- document the runtime lowering and seek semantics

## Architectural intent

Native reactivity stays separate from timeline tracks in the semantic model but meets the timeline in `SceneInstance`. Input updates mutate only pre-lowered dense runtime slots; they do not reconstruct `SceneDefinition`, recompile `CompiledScene`, or scan unrelated objects.

Reactive-aware structural/timeline mutation remains a follow-up because it must revalidate driver ownership atomically rather than invent precedence after a live patch.