### PR TITLE
Align Python rate functions with shared Manim semantics

### DIFF
--- a/scripts/build-web-demo.sh
+++ b/scripts/build-web-demo.sh
@@ -21,6 +21,7 @@ node --test web/scene-identity.test.mjs
 node --test web/frame-metrics.test.mjs
 PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile \
   web/python/_manim_compat.py \
+  web/python/_manim_rate_functions.py \
   web/python/_manim_phase_b.py \
   web/python/_manim_animate.py \
   web/python/_manim_reactive.py

--- a/scripts/manim-compat-smoke.mjs
+++ b/scripts/manim-compat-smoke.mjs
@@ -40,6 +40,13 @@ from noon import *
 
 class Demo(Scene):
     def construct(self):
+        assert abs(smooth(0.25) - 0.07010372) < 1e-7
+        assert abs(smooth(0.5) - 0.5) < 1e-12
+        assert abs(smooth(0.75) - 0.92989628) < 1e-7
+        assert abs(rush_into(0.5) - 2.0 * smooth(0.25)) < 1e-12
+        assert abs(rush_from(0.5) - (2.0 * smooth(0.75) - 1.0)) < 1e-12
+        assert abs(there_and_back(0.25) - smooth(0.5)) < 1e-12
+
         circle = Circle(radius=0.6, color=BLUE)
         square = Square(side_length=1.0, color=PINK).next_to(circle, RIGHT)
         assert isinstance(circle, Circle)
@@ -182,6 +189,19 @@ class AnimateParity(Scene):
             assert "only be passed once" in str(error)
 `;
 
+const rateFunctionSource = `
+from noon import *
+
+class SharedRateFunctions(Scene):
+    def construct(self):
+        circle = Circle(radius=0.2, color=BLUE)
+        self.add(circle)
+        self.play(circle.animate.shift(RIGHT), run_time=0.2)
+        self.play(circle.animate.shift(LEFT), run_time=0.2, rate_func=rush_into)
+        self.play(circle.animate.shift(RIGHT), run_time=0.2, rate_func=rush_from)
+        self.play(circle.animate.shift(LEFT), run_time=0.2, rate_func=there_and_back)
+`;
+
 let browser = null;
 try {
   await waitForServer();
@@ -215,8 +235,8 @@ try {
 
   const revealTracks = foundation.document.tracks.filter((track) => track.property === "reveal");
   assert.ok(
-    revealTracks.every((track) => track.timing.easing === "ease_in_out_cubic"),
-    "rate_func=smooth should lower to deterministic ease_in_out_cubic",
+    revealTracks.every((track) => track.timing.easing === "smooth"),
+    "rate_func=smooth should lower to the shared smooth semantic ID",
   );
   const transform = foundation.document.tracks.find((track) => track.property === "transform");
   assert.equal(transform.timing.easing, "linear");
@@ -275,7 +295,7 @@ try {
   assert.equal(byObject.get(0)[1].timing.duration, 0.5);
   assert.equal(byObject.get(1)[0].timing.start_time, 2);
   assert.equal(byObject.get(1)[0].timing.duration, 2);
-  assert.equal(byObject.get(1)[0].timing.easing, "ease_in_out_cubic");
+  assert.equal(byObject.get(1)[0].timing.easing, "smooth");
 
   const groupFirst = byObject.get(2)[0];
   const groupSecond = byObject.get(3)[0];
@@ -283,16 +303,29 @@ try {
   assert.ok(Math.abs(groupFirst.timing.duration - 0.8) < 1e-9);
   assert.ok(Math.abs(groupSecond.timing.start_time - 4.4) < 1e-9);
   assert.ok(Math.abs(groupSecond.timing.duration - 0.8) < 1e-9);
-  assert.equal(groupFirst.timing.easing, "ease_in_out_cubic");
-  assert.equal(groupSecond.timing.easing, "ease_in_out_cubic");
+  assert.equal(groupFirst.timing.easing, "smooth");
+  assert.equal(groupSecond.timing.easing, "smooth");
 
   const overridden = byObject.get(4)[0];
   assert.ok(Math.abs(overridden.timing.start_time - 5.2) < 1e-9);
   assert.ok(Math.abs(overridden.timing.duration - 0.4) < 1e-9);
   assert.equal(
     overridden.timing.easing,
-    "ease_in_out_cubic",
+    "smooth",
     "Scene.play kwargs should override builder animation kwargs",
+  );
+
+  const sharedRates = await page.evaluate(
+    (pythonSource) => window.noonManimCompat.run(pythonSource),
+    rateFunctionSource,
+  );
+  const rateTracks = sharedRates.document.tracks.filter(
+    (track) => track.property === "transform",
+  );
+  assert.deepEqual(
+    rateTracks.map((track) => track.timing.easing),
+    ["smooth", "rush_into", "rush_from", "there_and_back"],
+    "known Python callables should lower directly to shared Rust semantic IDs",
   );
 
   let zError = null;
@@ -308,7 +341,7 @@ try {
 
   assert.deepEqual(errors, [], `browser errors while testing Manim compatibility:\n${errors.join("\n")}`);
   console.log(
-    "Manim compatibility smoke passed: construct discovery, shape classes, scene/group semantics, callable and chained animate builders, detached animate auto-add, per-animation timing, play overrides, independent fill/stroke opacity, z=0 vectors, and deterministic rate_func lowering.",
+    "Manim compatibility smoke passed: construct discovery, shape classes, scene/group semantics, callable and chained animate builders, detached animate auto-add, per-animation timing, play overrides, independent fill/stroke opacity, z=0 vectors, and shared deterministic Manim rate-function lowering.",
   );
 } finally {
   await browser?.close();

--- a/scripts/reactive-authoring-smoke.mjs
+++ b/scripts/reactive-authoring-smoke.mjs
@@ -134,7 +134,7 @@ try {
       signal: 1,
       from: 0,
       to: 2,
-      timing: { start_time: 2, duration: 1, easing: "ease_in_out_cubic" },
+      timing: { start_time: 2, duration: 1, easing: "smooth" },
     },
   ]);
 
@@ -144,7 +144,7 @@ try {
   assert.ok(transform, "mixed tracker/object play should preserve object animation");
   assert.equal(transform.timing.start_time, 2);
   assert.equal(transform.timing.duration, 1);
-  assert.equal(transform.timing.easing, "ease_in_out_cubic");
+  assert.equal(transform.timing.easing, "smooth");
 
   console.log("reactive authoring smoke test passed");
 } finally {

--- a/web/python-worker.js
+++ b/web/python-worker.js
@@ -5,6 +5,7 @@ const AUTHORING_PROTOCOL_VERSION = 4;
 const PYTHON_MODULE_PATH = "/tmp/noon.py";
 const PYTHON_IR_MODULE_PATH = "/tmp/_noon_ir.py";
 const MANIM_COMPAT_MODULE_PATH = "/tmp/_manim_compat.py";
+const MANIM_RATE_FUNCTIONS_MODULE_PATH = "/tmp/_manim_rate_functions.py";
 const MANIM_PHASE_B_MODULE_PATH = "/tmp/_manim_phase_b.py";
 const MANIM_ANIMATE_MODULE_PATH = "/tmp/_manim_animate.py";
 const MANIM_REACTIVE_MODULE_PATH = "/tmp/_manim_reactive.py";
@@ -26,6 +27,7 @@ async function initializePyodide() {
     apiResponse,
     irResponse,
     compatResponse,
+    rateFunctionsResponse,
     phaseBResponse,
     animateResponse,
     reactiveResponse,
@@ -33,6 +35,7 @@ async function initializePyodide() {
     fetch(new URL("./python/noon.py", import.meta.url)),
     fetch(new URL("./python/_noon_ir.py", import.meta.url)),
     fetch(new URL("./python/_manim_compat.py", import.meta.url)),
+    fetch(new URL("./python/_manim_rate_functions.py", import.meta.url)),
     fetch(new URL("./python/_manim_phase_b.py", import.meta.url)),
     fetch(new URL("./python/_manim_animate.py", import.meta.url)),
     fetch(new URL("./python/_manim_reactive.py", import.meta.url)),
@@ -45,6 +48,11 @@ async function initializePyodide() {
   }
   if (!compatResponse.ok) {
     throw new Error(`Unable to load Noon Manim compatibility layer: HTTP ${compatResponse.status}`);
+  }
+  if (!rateFunctionsResponse.ok) {
+    throw new Error(
+      `Unable to load Noon Manim rate functions: HTTP ${rateFunctionsResponse.status}`,
+    );
   }
   if (!phaseBResponse.ok) {
     throw new Error(`Unable to load Noon Manim Phase B layer: HTTP ${phaseBResponse.status}`);
@@ -65,6 +73,11 @@ async function initializePyodide() {
   pyodide.FS.writeFile(MANIM_COMPAT_MODULE_PATH, await compatResponse.text(), {
     encoding: "utf8",
   });
+  pyodide.FS.writeFile(
+    MANIM_RATE_FUNCTIONS_MODULE_PATH,
+    await rateFunctionsResponse.text(),
+    { encoding: "utf8" },
+  );
   pyodide.FS.writeFile(MANIM_PHASE_B_MODULE_PATH, await phaseBResponse.text(), {
     encoding: "utf8",
   });
@@ -79,6 +92,8 @@ import sys
 sys.path.insert(0, "/tmp")
 import _manim_compat
 _manim_compat.install()
+import _manim_rate_functions
+_manim_rate_functions.install()
 import _manim_phase_b
 import _manim_animate
 import _manim_reactive

--- a/web/python/_manim_compat.py
+++ b/web/python/_manim_compat.py
@@ -51,28 +51,6 @@ def _as_vec2(value: object) -> _base.Vec2:
     raise TypeError("expected a two- or three-component vector")
 
 
-def linear(t: float) -> float:
-    return float(t)
-
-
-def smooth(t: float) -> float:
-    # Public callable mirrors Manim ergonomics. Playback lowers this known function
-    # to Noon's deterministic ease_in_out_cubic track easing.
-    value = min(max(float(t), 0.0), 1.0)
-    return value * value * (3.0 - 2.0 * value)
-
-
-def _easing_from_rate_func(rate_func: object) -> str:
-    if rate_func is linear or rate_func == linear or getattr(rate_func, "__name__", None) == "linear":
-        return "linear"
-    if rate_func is smooth or rate_func == smooth or getattr(rate_func, "__name__", None) == "smooth":
-        return "ease_in_out_cubic"
-    raise NotImplementedError(
-        "Noon currently supports deterministic rate_func=linear and rate_func=smooth; "
-        "arbitrary Python per-frame rate functions are intentionally unsupported"
-    )
-
-
 class _CompatAnimationBuilder:
     """Generic Manim-style ``mobject.animate`` target-state proxy.
 
@@ -694,7 +672,7 @@ class Scene(_BaseScene):
         if rate_func is not None and easing is not None:
             raise ValueError("use either rate_func or the low-level easing alias, not both")
         actual_easing = easing or (
-            _easing_from_rate_func(rate_func) if rate_func is not None else "linear"
+            _easing_from_rate_func(rate_func) if rate_func is not None else "smooth"
         )
 
         # Manim introducing animations own the lifecycle transition; users do not
@@ -740,8 +718,6 @@ def install() -> None:
         "Group": Group,
         "VGroup": VGroup,
         "Scene": Scene,
-        "linear": linear,
-        "smooth": smooth,
     }
     for name, value in public.items():
         setattr(_base, name, value)

--- a/web/python/_manim_rate_functions.py
+++ b/web/python/_manim_rate_functions.py
@@ -1,6 +1,6 @@
 """Thin Python adapters for Noon's shared deterministic rate-function vocabulary.
 
-Playback remains authoritative in Rust (`noon_core::RateFunction`).  This module only
+Playback remains authoritative in Rust (`noon_core::RateFunction`). This module only
 provides Manim-compatible public callables, maps known callables to the shared semantic
 IDs written into scene IR, and mirrors those deterministic functions for authoring-time
 snapshot evaluation inside the Python frontend.
@@ -17,6 +17,8 @@ import _noon_ir as _ir
 
 
 INFLECTION = 10.0
+_INSTALLED = False
+_ORIGINAL_ADD_TRACK = _ir.Scene._add_track
 
 
 def linear(t: float) -> float:
@@ -105,8 +107,56 @@ def _track_progress(timing: dict[str, Any], time: float) -> float:
     return evaluate_rate_function(timing["easing"], raw)
 
 
+def _add_track(
+    self: _ir.Scene,
+    obj: _ir.Object,
+    property_name: str,
+    values: dict[str, Any],
+    start_time: float,
+    duration: float,
+    easing: str,
+    key: str | None,
+) -> None:
+    """Bridge the legacy Python IR whitelist to the shared core vocabulary.
+
+    The old IR builder validates only ``linear`` and ``ease_in_out_cubic``. For a
+    known shared semantic ID, reuse all of its existing structural validation with
+    ``linear`` as the temporary accepted token, then restore the semantic ID in the
+    emitted track. Unknown values still flow through the original validator and fail.
+    """
+
+    if easing in _KNOWN_RATE_FUNCTIONS and easing != "linear":
+        _ORIGINAL_ADD_TRACK(
+            self,
+            obj,
+            property_name,
+            values,
+            start_time,
+            duration,
+            "linear",
+            key,
+        )
+        self._tracks[-1]["timing"]["easing"] = easing
+        return
+    _ORIGINAL_ADD_TRACK(
+        self,
+        obj,
+        property_name,
+        values,
+        start_time,
+        duration,
+        easing,
+        key,
+    )
+
+
 def install() -> None:
     """Install thin public adapters without creating a second playback engine."""
+
+    global _INSTALLED
+    if _INSTALLED:
+        return
+    _INSTALLED = True
 
     public = {
         "linear": linear,
@@ -124,6 +174,7 @@ def install() -> None:
     # `_noon_ir` needs progress only while materializing authoring-time snapshots.
     # Runtime playback never calls this mirror; Rust RateFunction remains authoritative.
     _ir._track_progress = _track_progress
+    _ir.Scene._add_track = _add_track
 
     exports = list(_base.__all__)
     for name in public:

--- a/web/python/_manim_rate_functions.py
+++ b/web/python/_manim_rate_functions.py
@@ -1,0 +1,132 @@
+"""Thin Python adapters for Noon's shared deterministic rate-function vocabulary.
+
+Playback remains authoritative in Rust (`noon_core::RateFunction`).  This module only
+provides Manim-compatible public callables, maps known callables to the shared semantic
+IDs written into scene IR, and mirrors those deterministic functions for authoring-time
+snapshot evaluation inside the Python frontend.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Callable
+
+import noon as _base
+import _manim_compat as _compat
+import _noon_ir as _ir
+
+
+INFLECTION = 10.0
+
+
+def linear(t: float) -> float:
+    """Manim's linear rate function."""
+
+    return float(t)
+
+
+def _sigmoid(value: float) -> float:
+    return 1.0 / (1.0 + math.exp(-value))
+
+
+def smooth(t: float, inflection: float = INFLECTION) -> float:
+    """Manim-compatible normalized logistic smooth rate function."""
+
+    value = float(t)
+    sharpness = float(inflection)
+    error = _sigmoid(-sharpness / 2.0)
+    result = (
+        _sigmoid(sharpness * (value - 0.5)) - error
+    ) / (1.0 - 2.0 * error)
+    return min(max(result, 0.0), 1.0)
+
+
+def rush_into(t: float, inflection: float = INFLECTION) -> float:
+    return 2.0 * smooth(float(t) / 2.0, inflection)
+
+
+def rush_from(t: float, inflection: float = INFLECTION) -> float:
+    return 2.0 * smooth(float(t) / 2.0 + 0.5, inflection) - 1.0
+
+
+def there_and_back(t: float, inflection: float = INFLECTION) -> float:
+    value = float(t)
+    mirrored = 2.0 * value if value < 0.5 else 2.0 * (1.0 - value)
+    return smooth(mirrored, inflection)
+
+
+def _ease_in_out_cubic(t: float) -> float:
+    value = min(max(float(t), 0.0), 1.0)
+    if value < 0.5:
+        return 4.0 * value * value * value
+    return 1.0 - ((-2.0 * value + 2.0) ** 3) / 2.0
+
+
+_KNOWN_RATE_FUNCTIONS: dict[str, Callable[..., float]] = {
+    "linear": linear,
+    "smooth": smooth,
+    "rush_into": rush_into,
+    "rush_from": rush_from,
+    "there_and_back": there_and_back,
+}
+
+
+def easing_from_rate_func(rate_func: object) -> str:
+    """Map a known Manim callable to the language-neutral core semantic ID."""
+
+    name = getattr(rate_func, "__name__", None)
+    for semantic_id, function in _KNOWN_RATE_FUNCTIONS.items():
+        if rate_func is function or rate_func == function or name == semantic_id:
+            return semantic_id
+    raise NotImplementedError(
+        "Noon currently supports deterministic rate_func=linear, smooth, rush_into, "
+        "rush_from, and there_and_back; arbitrary Python per-frame rate functions "
+        "are intentionally unsupported"
+    )
+
+
+def evaluate_rate_function(semantic_id: str, progress: float) -> float:
+    """Mirror core RateFunction evaluation for authoring-time snapshots only."""
+
+    value = min(max(float(progress), 0.0), 1.0)
+    if semantic_id == "ease_in_out_cubic":
+        return _ease_in_out_cubic(value)
+    function = _KNOWN_RATE_FUNCTIONS.get(semantic_id)
+    if function is None:
+        raise ValueError(f"unsupported easing: {semantic_id}")
+    return function(value)
+
+
+def _track_progress(timing: dict[str, Any], time: float) -> float:
+    raw = max(
+        0.0,
+        min(1.0, (time - timing["start_time"]) / timing["duration"]),
+    )
+    return evaluate_rate_function(timing["easing"], raw)
+
+
+def install() -> None:
+    """Install thin public adapters without creating a second playback engine."""
+
+    public = {
+        "linear": linear,
+        "smooth": smooth,
+        "rush_into": rush_into,
+        "rush_from": rush_from,
+        "there_and_back": there_and_back,
+    }
+    for name, value in public.items():
+        setattr(_compat, name, value)
+        setattr(_base, name, value)
+
+    _compat._easing_from_rate_func = easing_from_rate_func
+
+    # `_noon_ir` needs progress only while materializing authoring-time snapshots.
+    # Runtime playback never calls this mirror; Rust RateFunction remains authoritative.
+    _ir._track_progress = _track_progress
+
+    exports = list(_base.__all__)
+    for name in public:
+        if name not in exports:
+            exports.append(name)
+    _base.__all__ = exports


### PR DESCRIPTION
## Summary

- remove the legacy cubic `smooth` implementation and callable mapping from `_manim_compat.py`
- add a thin Manim rate-function adapter exposing exact `smooth`, `rush_into`, `rush_from`, and `there_and_back`
- lower known Python callables directly to the shared Rust semantic IDs (`smooth`, `rush_into`, `rush_from`, `there_and_back`)
- retain `ease_in_out_cubic` only as the existing explicit low-level compatibility easing
- use the shared Manim `smooth` ID for default `.animate` and mixed ValueTracker/object authoring
- centralize the small Python mirror used only for authoring-time snapshot materialization; runtime playback remains authoritative in `noon_core::RateFunction`
- extend browser compatibility coverage with Manim reference values and all shared rate-function IDs

This completes A1 of the cross-language authoring consolidation plan without changing the serialized format version.