### PR TITLE
Centralize lifecycle and scene membership semantics

### DIFF
--- a/crates/noon-core/src/lifecycle.rs
+++ b/crates/noon-core/src/lifecycle.rs
@@ -1,0 +1,322 @@
+use serde::{Deserialize, Serialize};
+
+/// Where an authoring object currently belongs relative to the scene handling it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LifecycleBinding {
+    Detached,
+    ThisScene,
+    OtherScene,
+}
+
+/// High-level lifecycle operation requested by an authoring frontend.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LifecycleIntent {
+    /// `Scene.add`: bind detached objects, or reintroduce an absent bound object.
+    Add,
+    /// `Scene.remove`: hide a present object immediately; unrelated objects are no-ops.
+    Remove,
+    /// `Create` / `FadeIn`: bind detached objects and introduce them at animation start.
+    Introduce,
+    /// `FadeOut` and equivalent removers: require presence and hide at animation end.
+    RemoveAfterAnimation,
+    /// Transform/replacement source requirement.
+    RequirePresent,
+    /// Replacement/copy/matching target requirement.
+    RequireAvailableTarget,
+}
+
+/// Minimal transient lifecycle facts needed to make a cross-language decision.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+pub struct LifecycleState {
+    pub binding: LifecycleBinding,
+    pub has_presence_timeline: bool,
+    pub present: bool,
+    pub has_future_event: bool,
+    pub at_time_zero: bool,
+}
+
+impl LifecycleState {
+    pub const fn detached(at_time_zero: bool) -> Self {
+        Self {
+            binding: LifecycleBinding::Detached,
+            has_presence_timeline: false,
+            present: true,
+            has_future_event: false,
+            at_time_zero,
+        }
+    }
+
+    pub const fn bound(
+        has_presence_timeline: bool,
+        present: bool,
+        has_future_event: bool,
+        at_time_zero: bool,
+    ) -> Self {
+        Self {
+            binding: LifecycleBinding::ThisScene,
+            has_presence_timeline,
+            present,
+            has_future_event,
+            at_time_zero,
+        }
+    }
+}
+
+/// Actions emitted by the shared lifecycle planner.
+///
+/// Frontends remain responsible only for binding their language wrapper to the
+/// canonical scene object and writing the indicated presence transition at the
+/// current animation boundary.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LifecyclePlan {
+    pub bind: bool,
+    pub show_now: bool,
+    pub hide_now: bool,
+    pub show_at_start: bool,
+    pub hide_at_end: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LifecycleError {
+    BelongsToAnotherScene,
+    RequiresBoundObject,
+    FutureLifecycleEvent,
+    RequiresPresent,
+    RequiresAbsent,
+}
+
+impl std::fmt::Display for LifecycleError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::BelongsToAnotherScene => formatter.write_str("object already belongs to another Scene"),
+            Self::RequiresBoundObject => formatter.write_str("lifecycle operation requires an object bound to this Scene"),
+            Self::FutureLifecycleEvent => formatter.write_str(
+                "object has a future lifecycle event; lifecycle operations must be authored chronologically",
+            ),
+            Self::RequiresPresent => formatter.write_str("lifecycle operation requires the object to be present"),
+            Self::RequiresAbsent => formatter.write_str("lifecycle operation requires the object to be absent"),
+        }
+    }
+}
+
+impl std::error::Error for LifecycleError {}
+
+/// Resolve one lifecycle operation using the shared Manim-compatible authoring rules.
+pub fn resolve_lifecycle_plan(
+    intent: LifecycleIntent,
+    state: LifecycleState,
+) -> Result<LifecyclePlan, LifecycleError> {
+    use LifecycleBinding::{Detached, OtherScene, ThisScene};
+    use LifecycleIntent::{
+        Add, Introduce, Remove, RemoveAfterAnimation, RequireAvailableTarget, RequirePresent,
+    };
+
+    if state.binding == OtherScene {
+        return match intent {
+            Remove => Ok(LifecyclePlan::default()),
+            _ => Err(LifecycleError::BelongsToAnotherScene),
+        };
+    }
+
+    if state.binding == ThisScene && state.has_future_event {
+        return Err(LifecycleError::FutureLifecycleEvent);
+    }
+
+    match intent {
+        Add => match state.binding {
+            Detached => Ok(LifecyclePlan {
+                bind: true,
+                show_now: !state.at_time_zero,
+                ..LifecyclePlan::default()
+            }),
+            ThisScene => Ok(LifecyclePlan {
+                show_now: state.has_presence_timeline && !state.present,
+                ..LifecyclePlan::default()
+            }),
+            OtherScene => unreachable!(),
+        },
+        Remove => match state.binding {
+            Detached => Ok(LifecyclePlan::default()),
+            ThisScene => Ok(LifecyclePlan {
+                hide_now: state.present,
+                ..LifecyclePlan::default()
+            }),
+            OtherScene => unreachable!(),
+        },
+        Introduce => match state.binding {
+            Detached => Ok(LifecyclePlan {
+                bind: true,
+                show_at_start: true,
+                ..LifecyclePlan::default()
+            }),
+            ThisScene => {
+                if state.has_presence_timeline && state.present {
+                    Err(LifecycleError::RequiresAbsent)
+                } else {
+                    Ok(LifecyclePlan {
+                        show_at_start: true,
+                        ..LifecyclePlan::default()
+                    })
+                }
+            }
+            OtherScene => unreachable!(),
+        },
+        RemoveAfterAnimation => match state.binding {
+            Detached => Err(LifecycleError::RequiresBoundObject),
+            ThisScene if !state.present => Err(LifecycleError::RequiresPresent),
+            ThisScene => Ok(LifecyclePlan {
+                hide_at_end: true,
+                ..LifecyclePlan::default()
+            }),
+            OtherScene => unreachable!(),
+        },
+        RequirePresent => match state.binding {
+            Detached => Err(LifecycleError::RequiresBoundObject),
+            ThisScene if !state.present => Err(LifecycleError::RequiresPresent),
+            ThisScene => Ok(LifecyclePlan::default()),
+            OtherScene => unreachable!(),
+        },
+        RequireAvailableTarget => match state.binding {
+            Detached => Err(LifecycleError::RequiresBoundObject),
+            ThisScene if state.has_presence_timeline && state.present => {
+                Err(LifecycleError::RequiresAbsent)
+            }
+            ThisScene => Ok(LifecyclePlan::default()),
+            OtherScene => unreachable!(),
+        },
+    }
+}
+
+/// Validate continuity and chronology before appending a zero-duration presence event.
+pub fn validate_presence_transition(
+    previous: Option<(f64, bool)>,
+    time: f64,
+    from: bool,
+) -> Result<(), PresenceTransitionError> {
+    if !time.is_finite() || time < 0.0 {
+        return Err(PresenceTransitionError::InvalidTime);
+    }
+    if let Some((previous_time, previous_to)) = previous {
+        if time < previous_time {
+            return Err(PresenceTransitionError::OutOfOrder);
+        }
+        if previous_to != from {
+            return Err(PresenceTransitionError::Discontinuous);
+        }
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PresenceTransitionError {
+    InvalidTime,
+    OutOfOrder,
+    Discontinuous,
+}
+
+impl std::fmt::Display for PresenceTransitionError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidTime => formatter.write_str("presence event time must be finite and non-negative"),
+            Self::OutOfOrder => formatter.write_str("presence events must be scheduled in chronological order"),
+            Self::Discontinuous => formatter.write_str("presence event chain must be continuous"),
+        }
+    }
+}
+
+impl std::error::Error for PresenceTransitionError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_binds_detached_and_only_backfills_absence_after_time_zero() {
+        assert_eq!(
+            resolve_lifecycle_plan(LifecycleIntent::Add, LifecycleState::detached(true)).unwrap(),
+            LifecyclePlan {
+                bind: true,
+                ..LifecyclePlan::default()
+            }
+        );
+        assert_eq!(
+            resolve_lifecycle_plan(LifecycleIntent::Add, LifecycleState::detached(false)).unwrap(),
+            LifecyclePlan {
+                bind: true,
+                show_now: true,
+                ..LifecyclePlan::default()
+            }
+        );
+    }
+
+    #[test]
+    fn readd_and_remove_are_idempotent_membership_operations() {
+        let absent = LifecycleState::bound(true, false, false, false);
+        assert!(resolve_lifecycle_plan(LifecycleIntent::Add, absent).unwrap().show_now);
+        assert!(!resolve_lifecycle_plan(LifecycleIntent::Remove, absent).unwrap().hide_now);
+
+        let present = LifecycleState::bound(true, true, false, false);
+        assert!(!resolve_lifecycle_plan(LifecycleIntent::Add, present).unwrap().show_now);
+        assert!(resolve_lifecycle_plan(LifecycleIntent::Remove, present).unwrap().hide_now);
+    }
+
+    #[test]
+    fn introducers_allow_initial_objects_but_reject_present_reintroductions() {
+        let initial = LifecycleState::bound(false, true, false, true);
+        assert!(
+            resolve_lifecycle_plan(LifecycleIntent::Introduce, initial)
+                .unwrap()
+                .show_at_start
+        );
+        assert_eq!(
+            resolve_lifecycle_plan(
+                LifecycleIntent::Introduce,
+                LifecycleState::bound(true, true, false, false),
+            ),
+            Err(LifecycleError::RequiresAbsent)
+        );
+    }
+
+    #[test]
+    fn removers_and_source_target_requirements_share_presence_rules() {
+        let present = LifecycleState::bound(true, true, false, false);
+        assert!(
+            resolve_lifecycle_plan(LifecycleIntent::RemoveAfterAnimation, present)
+                .unwrap()
+                .hide_at_end
+        );
+        assert!(resolve_lifecycle_plan(LifecycleIntent::RequirePresent, present).is_ok());
+
+        let absent = LifecycleState::bound(true, false, false, false);
+        assert_eq!(
+            resolve_lifecycle_plan(LifecycleIntent::RemoveAfterAnimation, absent),
+            Err(LifecycleError::RequiresPresent)
+        );
+        assert!(resolve_lifecycle_plan(LifecycleIntent::RequireAvailableTarget, absent).is_ok());
+    }
+
+    #[test]
+    fn future_events_are_rejected_before_operation_specific_rules() {
+        let state = LifecycleState::bound(true, false, true, false);
+        assert_eq!(
+            resolve_lifecycle_plan(LifecycleIntent::Add, state),
+            Err(LifecycleError::FutureLifecycleEvent)
+        );
+    }
+
+    #[test]
+    fn presence_transition_validation_is_shared() {
+        assert!(validate_presence_transition(None, 0.0, false).is_ok());
+        assert!(validate_presence_transition(Some((1.0, true)), 1.0, true).is_ok());
+        assert_eq!(
+            validate_presence_transition(Some((2.0, true)), 1.0, true),
+            Err(PresenceTransitionError::OutOfOrder)
+        );
+        assert_eq!(
+            validate_presence_transition(Some((1.0, false)), 2.0, true),
+            Err(PresenceTransitionError::Discontinuous)
+        );
+    }
+}

--- a/crates/noon-core/src/lifecycle.rs
+++ b/crates/noon-core/src/lifecycle.rs
@@ -90,13 +90,20 @@ pub enum LifecycleError {
 impl std::fmt::Display for LifecycleError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::BelongsToAnotherScene => formatter.write_str("object already belongs to another Scene"),
-            Self::RequiresBoundObject => formatter.write_str("lifecycle operation requires an object bound to this Scene"),
+            Self::BelongsToAnotherScene => {
+                formatter.write_str("object already belongs to another Scene")
+            }
+            Self::RequiresBoundObject => formatter
+                .write_str("lifecycle operation requires an object bound to this Scene"),
             Self::FutureLifecycleEvent => formatter.write_str(
                 "object has a future lifecycle event; lifecycle operations must be authored chronologically",
             ),
-            Self::RequiresPresent => formatter.write_str("lifecycle operation requires the object to be present"),
-            Self::RequiresAbsent => formatter.write_str("lifecycle operation requires the object to be absent"),
+            Self::RequiresPresent => {
+                formatter.write_str("lifecycle operation requires the object to be present")
+            }
+            Self::RequiresAbsent => {
+                formatter.write_str("lifecycle operation requires the object to be absent")
+            }
         }
     }
 }
@@ -219,8 +226,12 @@ pub enum PresenceTransitionError {
 impl std::fmt::Display for PresenceTransitionError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::InvalidTime => formatter.write_str("presence event time must be finite and non-negative"),
-            Self::OutOfOrder => formatter.write_str("presence events must be scheduled in chronological order"),
+            Self::InvalidTime => {
+                formatter.write_str("presence event time must be finite and non-negative")
+            }
+            Self::OutOfOrder => {
+                formatter.write_str("presence events must be scheduled in chronological order")
+            }
             Self::Discontinuous => formatter.write_str("presence event chain must be continuous"),
         }
     }
@@ -254,12 +265,28 @@ mod tests {
     #[test]
     fn readd_and_remove_are_idempotent_membership_operations() {
         let absent = LifecycleState::bound(true, false, false, false);
-        assert!(resolve_lifecycle_plan(LifecycleIntent::Add, absent).unwrap().show_now);
-        assert!(!resolve_lifecycle_plan(LifecycleIntent::Remove, absent).unwrap().hide_now);
+        assert!(
+            resolve_lifecycle_plan(LifecycleIntent::Add, absent)
+                .unwrap()
+                .show_now
+        );
+        assert!(
+            !resolve_lifecycle_plan(LifecycleIntent::Remove, absent)
+                .unwrap()
+                .hide_now
+        );
 
         let present = LifecycleState::bound(true, true, false, false);
-        assert!(!resolve_lifecycle_plan(LifecycleIntent::Add, present).unwrap().show_now);
-        assert!(resolve_lifecycle_plan(LifecycleIntent::Remove, present).unwrap().hide_now);
+        assert!(
+            !resolve_lifecycle_plan(LifecycleIntent::Add, present)
+                .unwrap()
+                .show_now
+        );
+        assert!(
+            resolve_lifecycle_plan(LifecycleIntent::Remove, present)
+                .unwrap()
+                .hide_now
+        );
     }
 
     #[test]

--- a/crates/noon-core/src/reactive.rs
+++ b/crates/noon-core/src/reactive.rs
@@ -2,6 +2,10 @@
 mod authoring;
 pub use authoring::*;
 
+#[path = "lifecycle.rs"]
+mod lifecycle;
+pub use lifecycle::*;
+
 include!("reactive_impl.rs");
 
 mod signal_timeline;

--- a/crates/noon-web/src/lib.rs
+++ b/crates/noon-web/src/lib.rs
@@ -3,8 +3,10 @@
 mod authoring_options;
 #[path = "legacy.rs"]
 mod legacy;
+mod lifecycle;
 mod reactive_player;
 
 pub use authoring_options::*;
 pub use legacy::*;
+pub use lifecycle::*;
 pub use reactive_player::*;

--- a/crates/noon-web/src/lifecycle.rs
+++ b/crates/noon-web/src/lifecycle.rs
@@ -1,7 +1,7 @@
 use noon_core::{
     resolve_lifecycle_plan as resolve_core_lifecycle_plan,
-    validate_presence_transition as validate_core_presence_transition, LifecycleBinding, LifecycleError,
-    LifecycleIntent, LifecyclePlan, LifecycleState, PresenceTransitionError,
+    validate_presence_transition as validate_core_presence_transition, LifecycleBinding,
+    LifecycleError, LifecycleIntent, LifecyclePlan, LifecycleState, PresenceTransitionError,
 };
 
 #[derive(Clone, Debug, PartialEq)]
@@ -234,28 +234,16 @@ mod tests {
 
     #[test]
     fn browser_bridge_uses_shared_reintroduction_rules() {
-        let resolved = resolve_frontend_lifecycle_plan(
-            "add",
-            "this_scene",
-            true,
-            false,
-            false,
-            false,
-        );
+        let resolved =
+            resolve_frontend_lifecycle_plan("add", "this_scene", true, false, false, false);
         assert!(resolved.ok());
         assert!(resolved.plan().show_now);
     }
 
     #[test]
     fn browser_bridge_preserves_lifecycle_errors() {
-        let resolved = resolve_frontend_lifecycle_plan(
-            "introduce",
-            "this_scene",
-            true,
-            true,
-            false,
-            false,
-        );
+        let resolved =
+            resolve_frontend_lifecycle_plan("introduce", "this_scene", true, true, false, false);
         assert!(!resolved.ok());
         assert_eq!(resolved.error_kind().as_deref(), Some("requires_absent"));
     }

--- a/crates/noon-web/src/lifecycle.rs
+++ b/crates/noon-web/src/lifecycle.rs
@@ -1,0 +1,269 @@
+use noon_core::{
+    resolve_lifecycle_plan as resolve_core_lifecycle_plan,
+    validate_presence_transition as validate_core_presence_transition, LifecycleBinding, LifecycleError,
+    LifecycleIntent, LifecyclePlan, LifecycleState, PresenceTransitionError,
+};
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct FrontendLifecycleResolution {
+    ok: bool,
+    plan: LifecyclePlan,
+    error_kind: Option<String>,
+    message: Option<String>,
+}
+
+impl FrontendLifecycleResolution {
+    fn success(plan: LifecyclePlan) -> Self {
+        Self {
+            ok: true,
+            plan,
+            error_kind: None,
+            message: None,
+        }
+    }
+
+    fn failure(kind: &str, message: impl Into<String>) -> Self {
+        Self {
+            ok: false,
+            plan: LifecyclePlan::default(),
+            error_kind: Some(kind.to_owned()),
+            message: Some(message.into()),
+        }
+    }
+
+    pub const fn ok(&self) -> bool {
+        self.ok
+    }
+
+    pub const fn plan(&self) -> LifecyclePlan {
+        self.plan
+    }
+
+    pub fn error_kind(&self) -> Option<String> {
+        self.error_kind.clone()
+    }
+
+    pub fn message(&self) -> Option<String> {
+        self.message.clone()
+    }
+}
+
+fn parse_intent(value: &str) -> Option<LifecycleIntent> {
+    match value {
+        "add" => Some(LifecycleIntent::Add),
+        "remove" => Some(LifecycleIntent::Remove),
+        "introduce" => Some(LifecycleIntent::Introduce),
+        "remove_after_animation" => Some(LifecycleIntent::RemoveAfterAnimation),
+        "require_present" => Some(LifecycleIntent::RequirePresent),
+        "require_available_target" => Some(LifecycleIntent::RequireAvailableTarget),
+        _ => None,
+    }
+}
+
+fn parse_binding(value: &str) -> Option<LifecycleBinding> {
+    match value {
+        "detached" => Some(LifecycleBinding::Detached),
+        "this_scene" => Some(LifecycleBinding::ThisScene),
+        "other_scene" => Some(LifecycleBinding::OtherScene),
+        _ => None,
+    }
+}
+
+pub fn resolve_frontend_lifecycle_plan(
+    intent: &str,
+    binding: &str,
+    has_presence_timeline: bool,
+    present: bool,
+    has_future_event: bool,
+    at_time_zero: bool,
+) -> FrontendLifecycleResolution {
+    let Some(intent) = parse_intent(intent) else {
+        return FrontendLifecycleResolution::failure(
+            "invalid_intent",
+            format!("unsupported lifecycle intent: {intent}"),
+        );
+    };
+    let Some(binding) = parse_binding(binding) else {
+        return FrontendLifecycleResolution::failure(
+            "invalid_binding",
+            format!("unsupported lifecycle binding: {binding}"),
+        );
+    };
+
+    let state = LifecycleState {
+        binding,
+        has_presence_timeline,
+        present,
+        has_future_event,
+        at_time_zero,
+    };
+    match resolve_core_lifecycle_plan(intent, state) {
+        Ok(plan) => FrontendLifecycleResolution::success(plan),
+        Err(error) => {
+            let kind = match error {
+                LifecycleError::BelongsToAnotherScene => "other_scene",
+                LifecycleError::RequiresBoundObject => "requires_bound",
+                LifecycleError::FutureLifecycleEvent => "future_event",
+                LifecycleError::RequiresPresent => "requires_present",
+                LifecycleError::RequiresAbsent => "requires_absent",
+            };
+            FrontendLifecycleResolution::failure(kind, error.to_string())
+        }
+    }
+}
+
+pub fn validate_frontend_presence_transition(
+    has_previous: bool,
+    previous_time: f64,
+    previous_to: bool,
+    time: f64,
+    from: bool,
+) -> FrontendLifecycleResolution {
+    let previous = has_previous.then_some((previous_time, previous_to));
+    match validate_core_presence_transition(previous, time, from) {
+        Ok(()) => FrontendLifecycleResolution::success(LifecyclePlan::default()),
+        Err(error) => {
+            let kind = match error {
+                PresenceTransitionError::InvalidTime => "invalid_time",
+                PresenceTransitionError::OutOfOrder => "out_of_order",
+                PresenceTransitionError::Discontinuous => "discontinuous",
+            };
+            FrontendLifecycleResolution::failure(kind, error.to_string())
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+mod wasm {
+    use wasm_bindgen::prelude::*;
+
+    use super::{
+        resolve_frontend_lifecycle_plan, validate_frontend_presence_transition,
+        FrontendLifecycleResolution,
+    };
+
+    #[wasm_bindgen]
+    pub struct WasmLifecycleResolution(FrontendLifecycleResolution);
+
+    #[wasm_bindgen]
+    impl WasmLifecycleResolution {
+        #[wasm_bindgen(getter)]
+        pub fn ok(&self) -> bool {
+            self.0.ok()
+        }
+
+        #[wasm_bindgen(getter)]
+        pub fn bind(&self) -> bool {
+            self.0.plan().bind
+        }
+
+        #[wasm_bindgen(getter, js_name = showNow)]
+        pub fn show_now(&self) -> bool {
+            self.0.plan().show_now
+        }
+
+        #[wasm_bindgen(getter, js_name = hideNow)]
+        pub fn hide_now(&self) -> bool {
+            self.0.plan().hide_now
+        }
+
+        #[wasm_bindgen(getter, js_name = showAtStart)]
+        pub fn show_at_start(&self) -> bool {
+            self.0.plan().show_at_start
+        }
+
+        #[wasm_bindgen(getter, js_name = hideAtEnd)]
+        pub fn hide_at_end(&self) -> bool {
+            self.0.plan().hide_at_end
+        }
+
+        #[wasm_bindgen(getter, js_name = errorKind)]
+        pub fn error_kind(&self) -> Option<String> {
+            self.0.error_kind()
+        }
+
+        #[wasm_bindgen(getter)]
+        pub fn message(&self) -> Option<String> {
+            self.0.message()
+        }
+    }
+
+    #[wasm_bindgen(js_name = resolveLifecyclePlan)]
+    pub fn resolve_lifecycle_plan(
+        intent: &str,
+        binding: &str,
+        has_presence_timeline: bool,
+        present: bool,
+        has_future_event: bool,
+        at_time_zero: bool,
+    ) -> WasmLifecycleResolution {
+        WasmLifecycleResolution(resolve_frontend_lifecycle_plan(
+            intent,
+            binding,
+            has_presence_timeline,
+            present,
+            has_future_event,
+            at_time_zero,
+        ))
+    }
+
+    #[wasm_bindgen(js_name = validatePresenceTransition)]
+    pub fn validate_presence_transition(
+        has_previous: bool,
+        previous_time: f64,
+        previous_to: bool,
+        time: f64,
+        from: bool,
+    ) -> WasmLifecycleResolution {
+        WasmLifecycleResolution(validate_frontend_presence_transition(
+            has_previous,
+            previous_time,
+            previous_to,
+            time,
+            from,
+        ))
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub use wasm::*;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn browser_bridge_uses_shared_reintroduction_rules() {
+        let resolved = resolve_frontend_lifecycle_plan(
+            "add",
+            "this_scene",
+            true,
+            false,
+            false,
+            false,
+        );
+        assert!(resolved.ok());
+        assert!(resolved.plan().show_now);
+    }
+
+    #[test]
+    fn browser_bridge_preserves_lifecycle_errors() {
+        let resolved = resolve_frontend_lifecycle_plan(
+            "introduce",
+            "this_scene",
+            true,
+            true,
+            false,
+            false,
+        );
+        assert!(!resolved.ok());
+        assert_eq!(resolved.error_kind().as_deref(), Some("requires_absent"));
+    }
+
+    #[test]
+    fn browser_bridge_validates_presence_chain_continuity() {
+        let resolved = validate_frontend_presence_transition(true, 1.0, false, 2.0, true);
+        assert!(!resolved.ok());
+        assert_eq!(resolved.error_kind().as_deref(), Some("discontinuous"));
+    }
+}

--- a/crates/noon/src/lib.rs
+++ b/crates/noon/src/lib.rs
@@ -17,7 +17,9 @@ pub mod prelude {
     pub use crate::legacy::prelude::*;
     pub use crate::{ReactiveScene, ReactiveTimelineScene, ValueTracker, VectorSignal};
     pub use noon_core::{
-        resolve_animation_options, AnimationDefaults, AnimationOptions, AnimationOptionsError,
+        resolve_animation_options, resolve_lifecycle_plan, validate_presence_transition,
+        AnimationDefaults, AnimationOptions, AnimationOptionsError, LifecycleBinding,
+        LifecycleError, LifecycleIntent, LifecyclePlan, LifecycleState, PresenceTransitionError,
         ResolvedAnimationOptions,
     };
 }

--- a/scripts/build-web-demo.sh
+++ b/scripts/build-web-demo.sh
@@ -25,6 +25,7 @@ PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile \
   web/python/_manim_phase_b.py \
   web/python/_manim_animation_options.py \
   web/python/_manim_animate.py \
+  web/python/_manim_lifecycle.py \
   web/python/_manim_reactive.py
 PYTHONDONTWRITEBYTECODE=1 python3 -m compileall -q web/python/examples
 PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s web/python -p 'test_*.py'

--- a/scripts/check-web-package.mjs
+++ b/scripts/check-web-package.mjs
@@ -33,6 +33,8 @@ const expectedJavascriptSurface = [
   "lastGeometryCacheMisses(",
   "export function demoSceneJson(",
   "export function resolveAnimationOptions(",
+  "export function resolveLifecyclePlan(",
+  "export function validatePresenceTransition(",
 ];
 const expectedTypeSurface = [
   "export class NoonCanvasPlayer",
@@ -54,6 +56,8 @@ const expectedTypeSurface = [
   "lastGeometryCacheMisses(): number",
   "export function demoSceneJson(): string",
   "export function resolveAnimationOptions(",
+  "export function resolveLifecyclePlan(",
+  "export function validatePresenceTransition(",
 ];
 
 for (const fragment of expectedJavascriptSurface) {

--- a/web/python-worker.js
+++ b/web/python-worker.js
@@ -1,4 +1,8 @@
-import initNoonWeb, { resolveAnimationOptions } from "./pkg/noon_web.js";
+import initNoonWeb, {
+  resolveAnimationOptions,
+  resolveLifecyclePlan,
+  validatePresenceTransition,
+} from "./pkg/noon_web.js";
 import { loadPyodide } from "https://cdn.jsdelivr.net/pyodide/v314.0.5/full/pyodide.mjs";
 
 const AUTHORING_CHANNEL = "noon.authoring";
@@ -10,6 +14,7 @@ const MANIM_RATE_FUNCTIONS_MODULE_PATH = "/tmp/_manim_rate_functions.py";
 const MANIM_PHASE_B_MODULE_PATH = "/tmp/_manim_phase_b.py";
 const MANIM_ANIMATION_OPTIONS_MODULE_PATH = "/tmp/_manim_animation_options.py";
 const MANIM_ANIMATE_MODULE_PATH = "/tmp/_manim_animate.py";
+const MANIM_LIFECYCLE_MODULE_PATH = "/tmp/_manim_lifecycle.py";
 const MANIM_REACTIVE_MODULE_PATH = "/tmp/_manim_reactive.py";
 
 const pyodidePromise = initializePyodide();
@@ -26,6 +31,8 @@ self.addEventListener("message", (event) => {
 async function initializePyodide() {
   await initNoonWeb();
   self.noonResolveAnimationOptions = resolveAnimationOptionsPlain;
+  self.noonResolveLifecyclePlan = resolveLifecyclePlanPlain;
+  self.noonValidatePresenceTransition = validatePresenceTransitionPlain;
 
   const pyodide = await loadPyodide();
   const [
@@ -36,6 +43,7 @@ async function initializePyodide() {
     phaseBResponse,
     animationOptionsResponse,
     animateResponse,
+    lifecycleResponse,
     reactiveResponse,
   ] = await Promise.all([
     fetch(new URL("./python/noon.py", import.meta.url)),
@@ -45,6 +53,7 @@ async function initializePyodide() {
     fetch(new URL("./python/_manim_phase_b.py", import.meta.url)),
     fetch(new URL("./python/_manim_animation_options.py", import.meta.url)),
     fetch(new URL("./python/_manim_animate.py", import.meta.url)),
+    fetch(new URL("./python/_manim_lifecycle.py", import.meta.url)),
     fetch(new URL("./python/_manim_reactive.py", import.meta.url)),
   ]);
   if (!apiResponse.ok) {
@@ -71,6 +80,9 @@ async function initializePyodide() {
   }
   if (!animateResponse.ok) {
     throw new Error(`Unable to load Noon Manim animate layer: HTTP ${animateResponse.status}`);
+  }
+  if (!lifecycleResponse.ok) {
+    throw new Error(`Unable to load Noon Manim lifecycle layer: HTTP ${lifecycleResponse.status}`);
   }
   if (!reactiveResponse.ok) {
     throw new Error(`Unable to load Noon reactive compatibility layer: HTTP ${reactiveResponse.status}`);
@@ -101,6 +113,9 @@ async function initializePyodide() {
   pyodide.FS.writeFile(MANIM_ANIMATE_MODULE_PATH, await animateResponse.text(), {
     encoding: "utf8",
   });
+  pyodide.FS.writeFile(MANIM_LIFECYCLE_MODULE_PATH, await lifecycleResponse.text(), {
+    encoding: "utf8",
+  });
   pyodide.FS.writeFile(MANIM_REACTIVE_MODULE_PATH, await reactiveResponse.text(), {
     encoding: "utf8",
   });
@@ -113,6 +128,7 @@ import _manim_rate_functions
 _manim_rate_functions.install()
 import _manim_phase_b
 import _manim_animate
+import _manim_lifecycle
 import _manim_reactive
 `);
   return pyodide;
@@ -134,6 +150,31 @@ function resolveAnimationOptionsPlain(...args) {
   } finally {
     result.free();
   }
+}
+
+function lifecycleResultPlain(result) {
+  try {
+    return {
+      ok: result.ok,
+      bind: result.bind,
+      showNow: result.showNow,
+      hideNow: result.hideNow,
+      showAtStart: result.showAtStart,
+      hideAtEnd: result.hideAtEnd,
+      errorKind: result.errorKind ?? "",
+      message: result.message ?? "",
+    };
+  } finally {
+    result.free();
+  }
+}
+
+function resolveLifecyclePlanPlain(...args) {
+  return lifecycleResultPlain(resolveLifecyclePlan(...args));
+}
+
+function validatePresenceTransitionPlain(...args) {
+  return lifecycleResultPlain(validatePresenceTransition(...args));
 }
 
 async function handleRequest(request) {

--- a/web/python/_manim_lifecycle.py
+++ b/web/python/_manim_lifecycle.py
@@ -1,0 +1,403 @@
+"""Thin Python adapter for Noon's shared Rust lifecycle authoring semantics.
+
+Python owns wrapper identity and emits the canonical scene operations requested by
+Rust. Presence legality, reintroduction/removal rules, source/target requirements,
+and presence-chain validation are resolved by the shared core planner.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any
+
+from js import noonResolveLifecyclePlan as _resolve_shared_lifecycle
+from js import noonValidatePresenceTransition as _validate_shared_presence_transition
+
+import noon as _base
+import _noon_ir as _ir
+import _manim_animate as _animate
+import _manim_compat as _compat
+import _manim_phase_b as _phase_b
+
+_INSTALLED = False
+
+
+@dataclass(frozen=True)
+class LifecyclePlan:
+    bind: bool
+    show_now: bool
+    hide_now: bool
+    show_at_start: bool
+    hide_at_end: bool
+
+
+def _resolve(
+    intent: str,
+    *,
+    binding: str,
+    has_presence_timeline: bool,
+    present: bool,
+    has_future_event: bool,
+    at_time_zero: bool,
+    label: str,
+) -> LifecyclePlan:
+    result = _resolve_shared_lifecycle(
+        intent,
+        binding,
+        bool(has_presence_timeline),
+        bool(present),
+        bool(has_future_event),
+        bool(at_time_zero),
+    )
+    if not bool(result.ok):
+        kind = str(result.errorKind)
+        if kind == "requires_present":
+            raise ValueError(f"{label} must be present at animation start")
+        if kind == "requires_absent":
+            raise ValueError(f"{label} must be absent before introduction or handoff")
+        if kind == "future_event":
+            raise ValueError(
+                f"{label} has a future lifecycle event; lifecycle operations must be authored chronologically"
+            )
+        raise ValueError(str(result.message))
+    return LifecyclePlan(
+        bind=bool(result.bind),
+        show_now=bool(result.showNow),
+        hide_now=bool(result.hideNow),
+        show_at_start=bool(result.showAtStart),
+        hide_at_end=bool(result.hideAtEnd),
+    )
+
+
+def _presence_state(scene: _ir.Scene, obj: _ir.Object, time: float) -> tuple[bool, bool, bool]:
+    tracks = scene._presence_tracks(obj)
+    has_future = bool(tracks and tracks[-1]["timing"]["start_time"] > time)
+    return bool(tracks), scene._presence_at(obj, time), has_future
+
+
+def _resolve_ir(
+    scene: _ir.Scene,
+    obj: _ir.Object,
+    intent: str,
+    time: float,
+    label: str,
+) -> LifecyclePlan:
+    has_tracks, present, has_future = _presence_state(scene, obj, time)
+    return _resolve(
+        intent,
+        binding="this_scene",
+        has_presence_timeline=has_tracks,
+        present=present,
+        has_future_event=has_future,
+        at_time_zero=math.isclose(time, 0.0, abs_tol=1e-12),
+        label=label,
+    )
+
+
+def _resolve_wrapper(
+    scene: _compat.Scene,
+    member: _base.Mobject,
+    intent: str,
+    time: float,
+    label: str,
+) -> LifecyclePlan:
+    if member._scene is None:
+        return _resolve(
+            intent,
+            binding="detached",
+            has_presence_timeline=False,
+            present=True,
+            has_future_event=False,
+            at_time_zero=math.isclose(time, 0.0, abs_tol=1e-12),
+            label=label,
+        )
+    if member._scene is not scene:
+        return _resolve(
+            intent,
+            binding="other_scene",
+            has_presence_timeline=False,
+            present=True,
+            has_future_event=False,
+            at_time_zero=math.isclose(time, 0.0, abs_tol=1e-12),
+            label=label,
+        )
+    assert member._object is not None
+    has_tracks, present, has_future = _presence_state(scene, member._object, time)
+    return _resolve(
+        intent,
+        binding="this_scene",
+        has_presence_timeline=has_tracks,
+        present=present,
+        has_future_event=has_future,
+        at_time_zero=math.isclose(time, 0.0, abs_tol=1e-12),
+        label=label,
+    )
+
+
+def _scene_add(
+    self: _compat.Scene,
+    *mobjects: object,
+    key: str | None = None,
+) -> _base.Mobject | _compat.Scene:
+    if not mobjects:
+        return self
+    leaves = [member for value in mobjects for member in _compat._leaf_mobjects(value)]
+    if key is not None and len(leaves) != 1:
+        raise ValueError("an explicit key can only be used when adding one Mobject")
+
+    for index, member in enumerate(leaves):
+        plan = _resolve_wrapper(self, member, "add", self._cursor, "Scene.add target")
+        if plan.bind:
+            _phase_b._bind_raw(self, member, key=key if index == 0 else None)
+        assert member._object is not None
+        if plan.show_now:
+            self._add_presence_track(
+                member._object,
+                False,
+                True,
+                self._cursor,
+                key=f"@scene-add:{member._object.id}:{self._cursor:g}",
+            )
+
+    for value in mobjects:
+        self._register_top_level(value)
+    return leaves[0] if len(leaves) == 1 else self
+
+
+def _scene_remove(self: _compat.Scene, *mobjects: object) -> _compat.Scene:
+    leaves = [member for value in mobjects for member in _compat._leaf_mobjects(value)]
+    for member in leaves:
+        plan = _resolve_wrapper(self, member, "remove", self._cursor, "Scene.remove target")
+        if plan.hide_now:
+            assert member._object is not None
+            self._add_presence_track(
+                member._object,
+                True,
+                False,
+                self._cursor,
+                key=f"@scene-remove:{member._object.id}:{self._cursor:g}",
+            )
+    identities = {id(value) for value in mobjects}
+    self._compat_top_level = [
+        value for value in self._compat_top_level if id(value) not in identities
+    ]
+    return self
+
+
+def _bind_introducer_target(self: _compat.Scene, target: object) -> None:
+    leaves = _compat._leaf_mobjects(target)
+    for member in leaves:
+        plan = _resolve_wrapper(
+            self,
+            member,
+            "introduce",
+            self._cursor,
+            "introducer target",
+        )
+        if plan.bind:
+            _phase_b._bind_raw(self, member)
+    self._register_top_level(target)
+
+
+def _bind_for_animation(
+    scene: _compat.Scene,
+    value: object,
+    *,
+    start_time: float,
+) -> None:
+    for member in _compat._leaf_mobjects(value):
+        plan = _resolve_wrapper(
+            scene,
+            member,
+            "add",
+            start_time,
+            "animated Mobject",
+        )
+        if plan.bind:
+            _phase_b._bind_raw(scene, member)
+        assert member._object is not None
+        if plan.show_now:
+            scene._add_presence_track(
+                member._object,
+                False,
+                True,
+                start_time,
+                key=f"@scene-play-add:{member._object.id}:{start_time:g}",
+            )
+    scene._register_top_level(value)
+
+
+def _ensure_lifecycle_source_present(
+    self: _ir.Scene,
+    source: _ir.Object,
+    start: float,
+    label: str,
+) -> None:
+    _resolve_ir(self, source, "require_present", start, label)
+
+
+def _ensure_lifecycle_target_available(
+    self: _ir.Scene,
+    target: _ir.Object,
+    start: float,
+    label: str,
+) -> None:
+    _resolve_ir(self, target, "require_available_target", start, f"{label} target")
+
+
+def _add_presence_track(
+    self: _ir.Scene,
+    obj: _ir.Object,
+    from_: bool,
+    to: bool,
+    time: float,
+    *,
+    key: str | None = None,
+) -> None:
+    existing = self._presence_tracks(obj)
+    previous = existing[-1] if existing else None
+    result = _validate_shared_presence_transition(
+        previous is not None,
+        0.0 if previous is None else float(previous["timing"]["start_time"]),
+        False if previous is None else bool(previous["values"]["bool"]["to"]),
+        float(time),
+        bool(from_),
+    )
+    if not bool(result.ok):
+        raise ValueError(str(result.message))
+    self._add_track(
+        obj,
+        "presence",
+        {"bool": {"from": bool(from_), "to": bool(to)}},
+        time,
+        0.0,
+        "linear",
+        key,
+    )
+
+
+def _schedule_fade(
+    self: _ir.Scene,
+    obj: _ir.Object,
+    *,
+    fade_in: bool,
+    key: str | None,
+    duration: float,
+    start_time: float,
+    easing: str,
+) -> None:
+    if not isinstance(obj, _ir.Object) or obj._owner is not self._owner:
+        raise ValueError("faded object must belong to this Scene")
+    start = _ir._finite_number("start_time", start_time)
+    run_duration = _ir._positive_number("duration", duration)
+    end = start + run_duration
+    previous_end = self._scheduled_fade_ends.get(obj.id)
+    if previous_end is not None and start < previous_end:
+        raise ValueError("fade animations for one object must not overlap")
+
+    intent = "introduce" if fade_in else "remove_after_animation"
+    plan = _resolve_ir(self, obj, intent, start, "fade target")
+    tracks = self._presence_tracks(obj)
+    object_key = self._object_keys[obj.id]
+    direction = "in" if fade_in else "out"
+    root_key = _ir._authoring_key(
+        "key", key, f"@fade-{direction}:{object_key}:{start:g}"
+    )
+    from_ = self._appearance_at(obj, start)
+    to = 1.0 if fade_in else 0.0
+
+    if plan.show_at_start:
+        self._add_presence_track(obj, False, True, start, key=f"{root_key}.show")
+
+    self._add_scalar_track(
+        obj,
+        "appearance",
+        _ir._unit_interval(
+            "appearance from", from_ if tracks else (0.0 if fade_in else from_)
+        ),
+        to,
+        start,
+        run_duration,
+        easing,
+        root_key,
+    )
+
+    if plan.hide_at_end:
+        self._add_presence_track(obj, True, False, end, key=f"{root_key}.hide")
+    self._scheduled_fade_ends[obj.id] = end
+
+
+def _schedule_create(
+    self: _base.Scene,
+    animation: _base.Create,
+    *,
+    duration: float,
+    start_time: float,
+    easing: str,
+) -> None:
+    obj = self._raw_object(animation.target)
+    start = _ir._finite_number("start_time", start_time)
+    run_duration = _ir._positive_number("duration", duration)
+    end = start + run_duration
+
+    snapshot = self._snapshot_for_object_at(obj, start)
+    geometry = snapshot["geometry"]
+    if not any(name in geometry for name in ("circle", "rectangle", "line", "vector_path")):
+        raise ValueError("Create supports Circle, Rectangle/Square, Line, and VectorPath")
+
+    plan = _resolve_ir(self, obj, "introduce", start, "Create target")
+    for track in self._tracks:
+        if track["object"] != obj.id or track["property"] != "reveal":
+            continue
+        track_start = track["timing"]["start_time"]
+        track_end = track_start + track["timing"]["duration"]
+        if track_start < end and start < track_end:
+            raise ValueError("Create/reveal animations for one object must not overlap")
+
+    object_key = self._object_keys[obj.id]
+    root_key = animation.key or f"@create:{object_key}:{start:g}"
+    if plan.show_at_start:
+        self._add_presence_track(obj, False, True, start, key=f"{root_key}.show")
+    self._add_scalar_track(
+        obj,
+        "reveal",
+        0.0,
+        1.0,
+        start,
+        run_duration,
+        easing,
+        root_key,
+    )
+    if self._appearance_at(obj, start) != 1.0:
+        self._add_scalar_track(
+            obj,
+            "appearance",
+            1.0,
+            1.0,
+            start,
+            run_duration,
+            "linear",
+            f"{root_key}.appearance",
+        )
+
+
+def install() -> None:
+    global _INSTALLED
+    if _INSTALLED:
+        return
+    _INSTALLED = True
+
+    _compat.Scene.add = _scene_add
+    _compat.Scene.remove = _scene_remove
+    _compat.Scene._bind_introducer_target = _bind_introducer_target
+    _animate._bind_for_animation = _bind_for_animation
+
+    _ir.Scene._ensure_lifecycle_source_present = _ensure_lifecycle_source_present
+    _ir.Scene._ensure_lifecycle_target_available = _ensure_lifecycle_target_available
+    _ir.Scene._add_presence_track = _add_presence_track
+    _ir.Scene._schedule_fade = _schedule_fade
+    _base.Scene._schedule_create = _schedule_create
+
+
+install()


### PR DESCRIPTION
## Summary

- add a language-neutral lifecycle planner in `noon-core` for add/re-add/remove, introducers/removers, source/target requirements, chronological lifecycle rules, and presence-chain continuity
- expose the same planner and presence-transition validator through `noon-web`/WASM
- route Manim-compatible Python `Scene.add/remove`, detached `.animate`, `Create`, `FadeIn/FadeOut`, replacement/copy/matching source-target checks, and presence event validation through the Rust planner
- retain only Python wrapper identity, argument normalization, and canonical track emission in the adapter
- expose lifecycle planner types/functions through the Rust Noon prelude
- keep the persisted `SceneDefinition` format unchanged

This is A3 of the cross-language authoring consolidation roadmap. A4 group/composition interval scheduling remains separate.