### PR TITLE
Centralize group and composition scheduling

### DIFF
--- a/crates/noon-core/src/composition.rs
+++ b/crates/noon-core/src/composition.rs
@@ -1,0 +1,235 @@
+use serde::{Deserialize, Serialize};
+
+/// One child's interval within a resolved animation composition.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+pub struct CompositionInterval {
+    pub start_time: f64,
+    pub duration: f64,
+}
+
+impl CompositionInterval {
+    pub const fn end_time(self) -> f64 {
+        self.start_time + self.duration
+    }
+}
+
+/// A deterministic composition schedule shared by every authoring frontend.
+///
+/// `intrinsic_run_time` is the virtual duration obtained from the child runtimes
+/// and `lag_ratio`. `run_time` is the externally requested total duration after
+/// optional rescaling. Child intervals are expressed in the final time scale.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct CompositionSchedule {
+    pub intrinsic_run_time: f64,
+    pub run_time: f64,
+    pub intervals: Vec<CompositionInterval>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum CompositionError {
+    Empty,
+    InvalidLagRatio(f64),
+    InvalidChildRunTime { index: usize, value: f64 },
+    InvalidRunTime(f64),
+}
+
+impl std::fmt::Display for CompositionError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Empty => formatter.write_str("animation composition requires at least one child"),
+            Self::InvalidLagRatio(value) => write!(
+                formatter,
+                "lag_ratio must be finite and non-negative, got {value}"
+            ),
+            Self::InvalidChildRunTime { index, value } => write!(
+                formatter,
+                "child animation {index} run_time must be finite and non-negative, got {value}"
+            ),
+            Self::InvalidRunTime(value) => write!(
+                formatter,
+                "composition run_time must be finite and positive, got {value}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for CompositionError {}
+
+/// Resolve Manim-compatible animation composition timing.
+///
+/// Child starts follow Manim's timing geometry: every child after the first is
+/// offset by `previous_child_run_time * lag_ratio`. The intrinsic composition
+/// duration is the maximum child end, which is important when child runtimes are
+/// unequal. If `run_time` is supplied, every interval is rescaled uniformly so
+/// that the composition consumes that total duration while preserving relative
+/// timing.
+pub fn resolve_composition_schedule(
+    child_run_times: &[f64],
+    lag_ratio: f64,
+    run_time: Option<f64>,
+) -> Result<CompositionSchedule, CompositionError> {
+    if child_run_times.is_empty() {
+        return Err(CompositionError::Empty);
+    }
+    if !lag_ratio.is_finite() || lag_ratio < 0.0 {
+        return Err(CompositionError::InvalidLagRatio(lag_ratio));
+    }
+    for (index, &child_run_time) in child_run_times.iter().enumerate() {
+        if !child_run_time.is_finite() || child_run_time < 0.0 {
+            return Err(CompositionError::InvalidChildRunTime {
+                index,
+                value: child_run_time,
+            });
+        }
+    }
+    if let Some(value) = run_time {
+        if !value.is_finite() || value <= 0.0 {
+            return Err(CompositionError::InvalidRunTime(value));
+        }
+    }
+
+    let mut starts = Vec::with_capacity(child_run_times.len());
+    let mut start = 0.0;
+    for (index, &child_run_time) in child_run_times.iter().enumerate() {
+        starts.push(start);
+        if index + 1 < child_run_times.len() {
+            start += child_run_time * lag_ratio;
+        }
+    }
+
+    let intrinsic_run_time = starts
+        .iter()
+        .zip(child_run_times)
+        .map(|(&child_start, &child_run_time)| child_start + child_run_time)
+        .fold(0.0_f64, f64::max);
+    let resolved_run_time = run_time.unwrap_or(intrinsic_run_time);
+    let scale = if intrinsic_run_time > 0.0 {
+        resolved_run_time / intrinsic_run_time
+    } else {
+        0.0
+    };
+
+    let intervals = starts
+        .into_iter()
+        .zip(child_run_times.iter().copied())
+        .map(|(child_start, child_run_time)| CompositionInterval {
+            start_time: child_start * scale,
+            duration: child_run_time * scale,
+        })
+        .collect();
+
+    Ok(CompositionSchedule {
+        intrinsic_run_time,
+        run_time: resolved_run_time,
+        intervals,
+    })
+}
+
+/// Convenience planner for family animations whose children have equal intrinsic
+/// duration. This is the shared lowering used by grouped Create/fades and
+/// `VGroup.animate(..., lag_ratio=...)`.
+pub fn resolve_uniform_composition_schedule(
+    child_count: usize,
+    lag_ratio: f64,
+    run_time: f64,
+) -> Result<CompositionSchedule, CompositionError> {
+    if child_count == 0 {
+        return Err(CompositionError::Empty);
+    }
+    let child_run_times = vec![1.0; child_count];
+    resolve_composition_schedule(&child_run_times, lag_ratio, Some(run_time))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parallel_children_start_together_and_keep_longest_runtime() {
+        let schedule = resolve_composition_schedule(&[2.0, 1.0, 3.0], 0.0, None).unwrap();
+        assert_eq!(schedule.intrinsic_run_time, 3.0);
+        assert_eq!(schedule.run_time, 3.0);
+        assert_eq!(
+            schedule.intervals,
+            vec![
+                CompositionInterval {
+                    start_time: 0.0,
+                    duration: 2.0,
+                },
+                CompositionInterval {
+                    start_time: 0.0,
+                    duration: 1.0,
+                },
+                CompositionInterval {
+                    start_time: 0.0,
+                    duration: 3.0,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn lagged_schedule_uses_max_end_not_last_end() {
+        // Matches Manim's canonical edge case: the long first animation ends at
+        // t=10 while the short second animation, lagged by 10%, ends at t=2.
+        let schedule = resolve_composition_schedule(&[10.0, 1.0], 0.1, None).unwrap();
+        assert_eq!(schedule.intrinsic_run_time, 10.0);
+        assert_eq!(schedule.intervals[0].end_time(), 10.0);
+        assert_eq!(schedule.intervals[1].start_time, 1.0);
+        assert_eq!(schedule.intervals[1].end_time(), 2.0);
+    }
+
+    #[test]
+    fn explicit_runtime_uniformly_rescales_virtual_timing() {
+        let schedule = resolve_composition_schedule(&[10.0, 1.0], 0.1, Some(5.0)).unwrap();
+        assert_eq!(schedule.intrinsic_run_time, 10.0);
+        assert_eq!(schedule.run_time, 5.0);
+        assert_eq!(schedule.intervals[0].duration, 5.0);
+        assert_eq!(schedule.intervals[1].start_time, 0.5);
+        assert_eq!(schedule.intervals[1].duration, 0.5);
+    }
+
+    #[test]
+    fn succession_is_lag_ratio_one() {
+        let schedule = resolve_composition_schedule(&[2.0, 1.0, 3.0], 1.0, None).unwrap();
+        let starts: Vec<_> = schedule
+            .intervals
+            .iter()
+            .map(|interval| interval.start_time)
+            .collect();
+        assert_eq!(starts, vec![0.0, 2.0, 3.0]);
+        assert_eq!(schedule.run_time, 6.0);
+    }
+
+    #[test]
+    fn uniform_family_schedule_matches_equal_child_formula() {
+        let schedule = resolve_uniform_composition_schedule(3, 0.5, 1.2).unwrap();
+        assert!((schedule.intervals[0].duration - 0.6).abs() < 1e-12);
+        assert!((schedule.intervals[1].start_time - 0.3).abs() < 1e-12);
+        assert!((schedule.intervals[2].start_time - 0.6).abs() < 1e-12);
+        assert!((schedule.run_time - 1.2).abs() < 1e-12);
+    }
+
+    #[test]
+    fn invalid_inputs_fail_in_shared_semantics() {
+        assert_eq!(
+            resolve_composition_schedule(&[], 0.0, None),
+            Err(CompositionError::Empty)
+        );
+        assert_eq!(
+            resolve_composition_schedule(&[1.0], -0.1, None),
+            Err(CompositionError::InvalidLagRatio(-0.1))
+        );
+        assert_eq!(
+            resolve_composition_schedule(&[1.0, -1.0], 0.0, None),
+            Err(CompositionError::InvalidChildRunTime {
+                index: 1,
+                value: -1.0,
+            })
+        );
+        assert_eq!(
+            resolve_composition_schedule(&[1.0], 0.0, Some(0.0)),
+            Err(CompositionError::InvalidRunTime(0.0))
+        );
+    }
+}

--- a/crates/noon-core/src/reactive.rs
+++ b/crates/noon-core/src/reactive.rs
@@ -2,6 +2,10 @@
 mod authoring;
 pub use authoring::*;
 
+#[path = "composition.rs"]
+mod composition;
+pub use composition::*;
+
 #[path = "lifecycle.rs"]
 mod lifecycle;
 pub use lifecycle::*;

--- a/crates/noon-web/src/composition.rs
+++ b/crates/noon-web/src/composition.rs
@@ -1,0 +1,217 @@
+use noon_core::{
+    resolve_composition_schedule as resolve_core_composition_schedule,
+    resolve_uniform_composition_schedule as resolve_core_uniform_composition_schedule,
+    CompositionError, CompositionSchedule,
+};
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct FrontendCompositionResolution {
+    ok: bool,
+    schedule: Option<CompositionSchedule>,
+    error_kind: Option<String>,
+    message: Option<String>,
+}
+
+impl FrontendCompositionResolution {
+    fn success(schedule: CompositionSchedule) -> Self {
+        Self {
+            ok: true,
+            schedule: Some(schedule),
+            error_kind: None,
+            message: None,
+        }
+    }
+
+    fn failure(kind: &str, message: impl Into<String>) -> Self {
+        Self {
+            ok: false,
+            schedule: None,
+            error_kind: Some(kind.to_owned()),
+            message: Some(message.into()),
+        }
+    }
+
+    pub const fn ok(&self) -> bool {
+        self.ok
+    }
+
+    pub fn schedule(&self) -> Option<&CompositionSchedule> {
+        self.schedule.as_ref()
+    }
+
+    pub fn error_kind(&self) -> Option<String> {
+        self.error_kind.clone()
+    }
+
+    pub fn message(&self) -> Option<String> {
+        self.message.clone()
+    }
+}
+
+fn failure(error: CompositionError) -> FrontendCompositionResolution {
+    let kind = match error {
+        CompositionError::Empty => "empty",
+        CompositionError::InvalidLagRatio(_) => "invalid_lag_ratio",
+        CompositionError::InvalidChildRunTime { .. } => "invalid_child_run_time",
+        CompositionError::InvalidRunTime(_) => "invalid_run_time",
+    };
+    FrontendCompositionResolution::failure(kind, error.to_string())
+}
+
+pub fn resolve_frontend_composition_schedule(
+    child_run_times: &[f64],
+    lag_ratio: f64,
+    run_time: Option<f64>,
+) -> FrontendCompositionResolution {
+    match resolve_core_composition_schedule(child_run_times, lag_ratio, run_time) {
+        Ok(schedule) => FrontendCompositionResolution::success(schedule),
+        Err(error) => failure(error),
+    }
+}
+
+pub fn resolve_frontend_uniform_composition_schedule(
+    child_count: usize,
+    lag_ratio: f64,
+    run_time: f64,
+) -> FrontendCompositionResolution {
+    match resolve_core_uniform_composition_schedule(child_count, lag_ratio, run_time) {
+        Ok(schedule) => FrontendCompositionResolution::success(schedule),
+        Err(error) => failure(error),
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+mod wasm {
+    use wasm_bindgen::prelude::*;
+
+    use super::{
+        resolve_frontend_composition_schedule, resolve_frontend_uniform_composition_schedule,
+        FrontendCompositionResolution,
+    };
+
+    #[wasm_bindgen]
+    pub struct WasmCompositionResolution(FrontendCompositionResolution);
+
+    #[wasm_bindgen]
+    impl WasmCompositionResolution {
+        #[wasm_bindgen(getter)]
+        pub fn ok(&self) -> bool {
+            self.0.ok()
+        }
+
+        #[wasm_bindgen(getter, js_name = runTime)]
+        pub fn run_time(&self) -> f64 {
+            self.0.schedule().map_or(0.0, |schedule| schedule.run_time)
+        }
+
+        #[wasm_bindgen(getter, js_name = intrinsicRunTime)]
+        pub fn intrinsic_run_time(&self) -> f64 {
+            self.0
+                .schedule()
+                .map_or(0.0, |schedule| schedule.intrinsic_run_time)
+        }
+
+        #[wasm_bindgen(getter)]
+        pub fn length(&self) -> usize {
+            self.0
+                .schedule()
+                .map_or(0, |schedule| schedule.intervals.len())
+        }
+
+        #[wasm_bindgen(js_name = startTime)]
+        pub fn start_time(&self, index: usize) -> f64 {
+            self.0
+                .schedule()
+                .and_then(|schedule| schedule.intervals.get(index))
+                .map_or(f64::NAN, |interval| interval.start_time)
+        }
+
+        #[wasm_bindgen(js_name = duration)]
+        pub fn duration(&self, index: usize) -> f64 {
+            self.0
+                .schedule()
+                .and_then(|schedule| schedule.intervals.get(index))
+                .map_or(f64::NAN, |interval| interval.duration)
+        }
+
+        #[wasm_bindgen(js_name = endTime)]
+        pub fn end_time(&self, index: usize) -> f64 {
+            self.0
+                .schedule()
+                .and_then(|schedule| schedule.intervals.get(index))
+                .map_or(f64::NAN, |interval| interval.end_time())
+        }
+
+        #[wasm_bindgen(getter, js_name = errorKind)]
+        pub fn error_kind(&self) -> Option<String> {
+            self.0.error_kind()
+        }
+
+        #[wasm_bindgen(getter)]
+        pub fn message(&self) -> Option<String> {
+            self.0.message()
+        }
+    }
+
+    #[wasm_bindgen(js_name = resolveCompositionSchedule)]
+    pub fn resolve_composition_schedule(
+        child_run_times: Box<[f64]>,
+        lag_ratio: f64,
+        run_time: f64,
+    ) -> WasmCompositionResolution {
+        let run_time = (!run_time.is_nan()).then_some(run_time);
+        WasmCompositionResolution(resolve_frontend_composition_schedule(
+            &child_run_times,
+            lag_ratio,
+            run_time,
+        ))
+    }
+
+    #[wasm_bindgen(js_name = resolveUniformCompositionSchedule)]
+    pub fn resolve_uniform_composition_schedule(
+        child_count: usize,
+        lag_ratio: f64,
+        run_time: f64,
+    ) -> WasmCompositionResolution {
+        WasmCompositionResolution(resolve_frontend_uniform_composition_schedule(
+            child_count,
+            lag_ratio,
+            run_time,
+        ))
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub use wasm::*;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn browser_bridge_preserves_unequal_child_timing() {
+        let resolved = resolve_frontend_composition_schedule(&[10.0, 1.0], 0.1, Some(5.0));
+        assert!(resolved.ok());
+        let schedule = resolved.schedule().unwrap();
+        assert_eq!(schedule.intrinsic_run_time, 10.0);
+        assert_eq!(schedule.intervals[0].duration, 5.0);
+        assert_eq!(schedule.intervals[1].start_time, 0.5);
+        assert_eq!(schedule.intervals[1].duration, 0.5);
+    }
+
+    #[test]
+    fn browser_uniform_bridge_matches_family_lowering() {
+        let resolved = resolve_frontend_uniform_composition_schedule(3, 0.5, 1.2);
+        assert!(resolved.ok());
+        let schedule = resolved.schedule().unwrap();
+        assert!((schedule.intervals[0].duration - 0.6).abs() < 1e-12);
+        assert!((schedule.intervals[2].start_time - 0.6).abs() < 1e-12);
+    }
+
+    #[test]
+    fn browser_bridge_preserves_shared_validation_errors() {
+        let resolved = resolve_frontend_composition_schedule(&[1.0], -0.1, None);
+        assert!(!resolved.ok());
+        assert_eq!(resolved.error_kind().as_deref(), Some("invalid_lag_ratio"));
+    }
+}

--- a/crates/noon-web/src/lib.rs
+++ b/crates/noon-web/src/lib.rs
@@ -1,12 +1,14 @@
 #![forbid(unsafe_code)]
 
 mod authoring_options;
+mod composition;
 #[path = "legacy.rs"]
 mod legacy;
 mod lifecycle;
 mod reactive_player;
 
 pub use authoring_options::*;
+pub use composition::*;
 pub use legacy::*;
 pub use lifecycle::*;
 pub use reactive_player::*;

--- a/crates/noon/src/lib.rs
+++ b/crates/noon/src/lib.rs
@@ -17,9 +17,10 @@ pub mod prelude {
     pub use crate::legacy::prelude::*;
     pub use crate::{ReactiveScene, ReactiveTimelineScene, ValueTracker, VectorSignal};
     pub use noon_core::{
-        resolve_animation_options, resolve_lifecycle_plan, validate_presence_transition,
-        AnimationDefaults, AnimationOptions, AnimationOptionsError, LifecycleBinding,
-        LifecycleError, LifecycleIntent, LifecyclePlan, LifecycleState, PresenceTransitionError,
-        ResolvedAnimationOptions,
+        resolve_animation_options, resolve_composition_schedule, resolve_lifecycle_plan,
+        resolve_uniform_composition_schedule, validate_presence_transition, AnimationDefaults,
+        AnimationOptions, AnimationOptionsError, CompositionError, CompositionInterval,
+        CompositionSchedule, LifecycleBinding, LifecycleError, LifecycleIntent, LifecyclePlan,
+        LifecycleState, PresenceTransitionError, ResolvedAnimationOptions,
     };
 }

--- a/scripts/check-web-package.mjs
+++ b/scripts/check-web-package.mjs
@@ -33,6 +33,8 @@ const expectedJavascriptSurface = [
   "lastGeometryCacheMisses(",
   "export function demoSceneJson(",
   "export function resolveAnimationOptions(",
+  "export function resolveCompositionSchedule(",
+  "export function resolveUniformCompositionSchedule(",
   "export function resolveLifecyclePlan(",
   "export function validatePresenceTransition(",
 ];
@@ -56,6 +58,8 @@ const expectedTypeSurface = [
   "lastGeometryCacheMisses(): number",
   "export function demoSceneJson(): string",
   "export function resolveAnimationOptions(",
+  "export function resolveCompositionSchedule(",
+  "export function resolveUniformCompositionSchedule(",
   "export function resolveLifecyclePlan(",
   "export function validatePresenceTransition(",
 ];

--- a/web/python-worker.js
+++ b/web/python-worker.js
@@ -1,6 +1,8 @@
 import initNoonWeb, {
   resolveAnimationOptions,
+  resolveCompositionSchedule,
   resolveLifecyclePlan,
+  resolveUniformCompositionSchedule,
   validatePresenceTransition,
 } from "./pkg/noon_web.js";
 import { loadPyodide } from "https://cdn.jsdelivr.net/pyodide/v314.0.5/full/pyodide.mjs";
@@ -31,6 +33,8 @@ self.addEventListener("message", (event) => {
 async function initializePyodide() {
   await initNoonWeb();
   self.noonResolveAnimationOptions = resolveAnimationOptionsPlain;
+  self.noonResolveCompositionSchedule = resolveCompositionSchedulePlain;
+  self.noonResolveUniformCompositionSchedule = resolveUniformCompositionSchedulePlain;
   self.noonResolveLifecyclePlan = resolveLifecyclePlanPlain;
   self.noonValidatePresenceTransition = validatePresenceTransitionPlain;
 
@@ -150,6 +154,43 @@ function resolveAnimationOptionsPlain(...args) {
   } finally {
     result.free();
   }
+}
+
+function compositionResultPlain(result) {
+  try {
+    const intervals = [];
+    for (let index = 0; index < result.length; index += 1) {
+      intervals.push({
+        startTime: result.startTime(index),
+        duration: result.duration(index),
+        endTime: result.endTime(index),
+      });
+    }
+    return {
+      ok: result.ok,
+      runTime: result.runTime,
+      intrinsicRunTime: result.intrinsicRunTime,
+      intervals,
+      errorKind: result.errorKind ?? "",
+      message: result.message ?? "",
+    };
+  } finally {
+    result.free();
+  }
+}
+
+function resolveCompositionSchedulePlain(childRunTimesJson, lagRatio, runTime) {
+  const childRunTimes = JSON.parse(childRunTimesJson);
+  if (!Array.isArray(childRunTimes)) {
+    throw new TypeError("child runtimes must decode to an array");
+  }
+  return compositionResultPlain(
+    resolveCompositionSchedule(new Float64Array(childRunTimes), lagRatio, runTime),
+  );
+}
+
+function resolveUniformCompositionSchedulePlain(...args) {
+  return compositionResultPlain(resolveUniformCompositionSchedule(...args));
 }
 
 function lifecycleResultPlain(result) {

--- a/web/python/_manim_animate.py
+++ b/web/python/_manim_animate.py
@@ -1,14 +1,17 @@
 """Manim-compatible ``.animate`` scheduling semantics.
 
 This layer keeps Python syntax adaptation while lowering supported operations to Noon's
-deterministic scene tracks. Animation option defaults, validation, and precedence are
-resolved by shared Rust authoring semantics; no Python callbacks run during playback.
+deterministic scene tracks. Animation option defaults, validation, precedence, and
+composition timing are resolved by shared Rust authoring semantics; no Python callbacks
+run during playback.
 """
 
 from __future__ import annotations
 
 import math
 from typing import Any, Callable
+
+from js import noonResolveUniformCompositionSchedule as _resolve_uniform_composition_schedule
 
 import noon as _base
 import _manim_animation_options as _options
@@ -142,6 +145,27 @@ def _default_lag_ratio(animation: object) -> float:
     return 0.0
 
 
+def _shared_uniform_intervals(
+    child_count: int,
+    *,
+    lag_ratio: float,
+    run_time: float,
+) -> list[tuple[float, float]]:
+    result = _resolve_uniform_composition_schedule(
+        int(child_count), float(lag_ratio), float(run_time)
+    )
+    if not bool(result.ok):
+        raise ValueError(str(result.message))
+    intervals = result.intervals
+    return [
+        (
+            float(intervals[index].startTime),
+            float(intervals[index].duration),
+        )
+        for index in range(int(intervals.length))
+    ]
+
+
 def _expanded_schedule(
     scene: _compat.Scene,
     animation: object,
@@ -165,14 +189,12 @@ def _expanded_schedule(
     if not is_family_animation or len(expanded) == 1:
         return [(item, start_time, run_time, easing) for item in expanded]
 
-    # Group interval expansion remains here until A4. The lag ratio itself has
-    # already been resolved through the shared Rust AnimationOptions contract.
-    full_length = 1.0 + (len(expanded) - 1) * lag_ratio
-    child_duration = run_time / full_length
-    offset = lag_ratio * child_duration
+    intervals = _shared_uniform_intervals(
+        len(expanded), lag_ratio=lag_ratio, run_time=run_time
+    )
     return [
-        (item, start_time + index * offset, child_duration, easing)
-        for index, item in enumerate(expanded)
+        (item, start_time + child_start, child_duration, easing)
+        for item, (child_start, child_duration) in zip(expanded, intervals)
     ]
 
 


### PR DESCRIPTION
## Summary

- add a language-neutral composition scheduler in `noon-core` matching Manim timing geometry for parallel, lagged, succession, and unequal-duration child animations
- define final child intervals from child runtimes + `lag_ratio`, using maximum child end as intrinsic duration and uniform rescaling for explicit composition `run_time`
- expose general and uniform-family composition planners through `noon-web`/WASM
- route Python `VGroup.animate(..., lag_ratio=...)`, grouped `Create`, and grouped fades through Rust-generated intervals instead of calculating timing geometry in Python
- expose the same planner/types from the Rust Noon prelude
- validate the new WASM surface in the browser package check
- keep persisted scene/track formats unchanged

This is A4 of the cross-language authoring consolidation roadmap. The generic planner is intentionally independent of Python class names and is the timing foundation for `AnimationGroup`, `Succession`, and `LaggedStart`; nested/global composition rate-function behavior can build on this without introducing a second scheduler.