### PR TITLE
Add Manim composition classes over shared scheduler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,9 @@ jobs:
       - name: Test Manim-style Python compatibility
         run: node scripts/manim-compat-smoke.mjs
 
+      - name: Test Manim composition authoring
+        run: node scripts/composition-authoring-smoke.mjs
+
       - name: Test native reactive Python authoring
         run: node scripts/reactive-authoring-smoke.mjs
 

--- a/scripts/build-web-demo.sh
+++ b/scripts/build-web-demo.sh
@@ -25,6 +25,7 @@ PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile \
   web/python/_manim_phase_b.py \
   web/python/_manim_animation_options.py \
   web/python/_manim_animate.py \
+  web/python/_manim_composition.py \
   web/python/_manim_lifecycle.py \
   web/python/_manim_reactive.py
 PYTHONDONTWRITEBYTECODE=1 python3 -m compileall -q web/python/examples

--- a/scripts/build-web-demo.sh
+++ b/scripts/build-web-demo.sh
@@ -14,6 +14,7 @@ node --check web/morph-profile.js
 node --check web/browser-smoke.js
 node --check scripts/browser-smoke.mjs
 node --check scripts/manim-compat-smoke.mjs
+node --check scripts/composition-authoring-smoke.mjs
 node --check scripts/reactive-authoring-smoke.mjs
 node --check scripts/reactive-runtime-smoke.mjs
 node --test web/authoring-client.test.mjs

--- a/scripts/composition-authoring-smoke.mjs
+++ b/scripts/composition-authoring-smoke.mjs
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import playwright from "playwright";
+
+const { chromium } = playwright;
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const port = 4179;
+const baseUrl = `http://127.0.0.1:${port}`;
+
+let serverOutput = "";
+const server = spawn(
+  "python3",
+  ["-m", "http.server", String(port), "--bind", "127.0.0.1", "--directory", repoRoot],
+  { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] },
+);
+server.stdout.on("data", (chunk) => (serverOutput += chunk));
+server.stderr.on("data", (chunk) => (serverOutput += chunk));
+
+async function waitForServer() {
+  let lastError = null;
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    try {
+      const response = await fetch(`${baseUrl}/web/manim-compat-smoke.html`);
+      if (response.ok) return;
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Composition smoke server did not start: ${lastError}\n${serverOutput}`);
+}
+
+const source = `
+from noon import *
+
+class CompositionScene(Scene):
+    def construct(self):
+        a = Circle(radius=0.2, color=BLUE).shift(LEFT * 3)
+        b = Square(side_length=0.4, color=PINK)
+        c = Circle(radius=0.2, color=GREEN).shift(RIGHT * 3)
+        self.add(a, b, c)
+
+        # Unequal child runtimes: starts are [0, 1], maximum end is 2.
+        self.play(AnimationGroup(
+            a.animate(run_time=2.0, rate_func=linear).shift(UP),
+            b.animate(run_time=1.0, rate_func=linear).shift(DOWN),
+            lag_ratio=0.5,
+        ))
+
+        # LaggedStart uses Manim's 0.05 default and explicit total runtime rescales
+        # the shared virtual schedule.
+        self.play(LaggedStart(
+            a.animate(run_time=1.0, rate_func=linear).shift(RIGHT),
+            b.animate(run_time=1.0, rate_func=linear).shift(RIGHT),
+            c.animate(run_time=1.0, rate_func=linear).shift(RIGHT),
+            run_time=2.2,
+        ))
+
+        # Succession is the same shared scheduler with lag_ratio=1 and supports
+        # multiple animations of one mobject because the flattened intervals do not overlap.
+        self.play(Succession(
+            c.animate(run_time=0.5, rate_func=linear).shift(UP),
+            c.animate(run_time=1.0, rate_func=linear).shift(LEFT),
+        ))
+
+        # Nested linear compositions are recursively rescaled without introducing
+        # another scheduler in Python.
+        self.play(AnimationGroup(
+            Succession(
+                a.animate(run_time=0.5, rate_func=linear).shift(UP),
+                a.animate(run_time=0.5, rate_func=linear).shift(DOWN),
+            ),
+            b.animate(run_time=1.0, rate_func=linear).shift(UP),
+            lag_ratio=0.0,
+            run_time=2.0,
+        ))
+
+        try:
+            self.play(AnimationGroup(
+                a.animate(rate_func=linear).shift(RIGHT),
+                b.animate(rate_func=linear).shift(LEFT),
+                rate_func=smooth,
+            ))
+            raise AssertionError("nonlinear outer composition rate must fail explicitly")
+        except NotImplementedError as error:
+            assert "runtime composition time-map" in str(error)
+`;
+
+let browser = null;
+try {
+  await waitForServer();
+  browser = await chromium.launch({
+    channel: "chromium",
+    headless: true,
+    args: ["--disable-dev-shm-usage"],
+  });
+  const page = await browser.newPage();
+  const errors = [];
+  page.on("pageerror", (error) => errors.push(`pageerror: ${error}`));
+  page.on("console", (message) => {
+    if (message.type() === "error") errors.push(`console: ${message.text()}`);
+  });
+
+  await page.goto(`${baseUrl}/web/manim-compat-smoke.html`, { waitUntil: "load" });
+  await page.waitForFunction(() => window.noonManimCompat, null, { timeout: 30_000 });
+  await page.evaluate(() => window.noonManimCompat.ready());
+
+  const result = await page.evaluate(
+    (pythonSource) => window.noonManimCompat.run(pythonSource),
+    source,
+  );
+  assert.equal(result.kind, "scene_document");
+  assert.equal(errors.length, 0, errors.join("\n"));
+
+  const transforms = result.document.tracks.filter((track) => track.property === "transform");
+  assert.equal(transforms.length, 11);
+  const byObject = new Map();
+  for (const track of transforms) {
+    const list = byObject.get(track.object) ?? [];
+    list.push(track);
+    byObject.set(track.object, list);
+  }
+
+  // AnimationGroup([2, 1], lag=.5): [0..2], [1..2].
+  assert.equal(byObject.get(0)[0].timing.start_time, 0);
+  assert.equal(byObject.get(0)[0].timing.duration, 2);
+  assert.equal(byObject.get(1)[0].timing.start_time, 1);
+  assert.equal(byObject.get(1)[0].timing.duration, 1);
+
+  // LaggedStart default lag=.05, run_time=2.2 over virtual duration 1.1:
+  // each child duration=2, starts 2.0, 2.1, 2.2.
+  assert.ok(Math.abs(byObject.get(0)[1].timing.start_time - 2.0) < 1e-9);
+  assert.ok(Math.abs(byObject.get(0)[1].timing.duration - 2.0) < 1e-9);
+  assert.ok(Math.abs(byObject.get(1)[1].timing.start_time - 2.1) < 1e-9);
+  assert.ok(Math.abs(byObject.get(2)[0].timing.start_time - 2.2) < 1e-9);
+
+  // Succession starts after LaggedStart ends at 4.2 and advances strictly.
+  assert.ok(Math.abs(byObject.get(2)[1].timing.start_time - 4.2) < 1e-9);
+  assert.ok(Math.abs(byObject.get(2)[1].timing.duration - 0.5) < 1e-9);
+  assert.ok(Math.abs(byObject.get(2)[2].timing.start_time - 4.7) < 1e-9);
+  assert.ok(Math.abs(byObject.get(2)[2].timing.duration - 1.0) < 1e-9);
+
+  // Nested group total runtime=2.0. Inner Succession (0.5 + 0.5) is rescaled
+  // to the parent's 2-second parallel child interval => two 1-second leaves.
+  assert.ok(Math.abs(byObject.get(0)[2].timing.start_time - 5.7) < 1e-9);
+  assert.ok(Math.abs(byObject.get(0)[2].timing.duration - 1.0) < 1e-9);
+  assert.ok(Math.abs(byObject.get(0)[3].timing.start_time - 6.7) < 1e-9);
+  assert.ok(Math.abs(byObject.get(0)[3].timing.duration - 1.0) < 1e-9);
+  assert.ok(Math.abs(byObject.get(1)[2].timing.start_time - 5.7) < 1e-9);
+  assert.ok(Math.abs(byObject.get(1)[2].timing.duration - 2.0) < 1e-9);
+
+  console.log("composition authoring smoke test passed");
+} finally {
+  if (browser !== null) await browser.close();
+  server.kill("SIGTERM");
+}

--- a/scripts/composition-authoring-smoke.mjs
+++ b/scripts/composition-authoring-smoke.mjs
@@ -118,7 +118,7 @@ try {
   assert.equal(errors.length, 0, errors.join("\n"));
 
   const transforms = result.document.tracks.filter((track) => track.property === "transform");
-  assert.equal(transforms.length, 11);
+  assert.equal(transforms.length, 10);
   const byObject = new Map();
   for (const track of transforms) {
     const list = byObject.get(track.object) ?? [];

--- a/web/python-worker.js
+++ b/web/python-worker.js
@@ -16,6 +16,7 @@ const MANIM_RATE_FUNCTIONS_MODULE_PATH = "/tmp/_manim_rate_functions.py";
 const MANIM_PHASE_B_MODULE_PATH = "/tmp/_manim_phase_b.py";
 const MANIM_ANIMATION_OPTIONS_MODULE_PATH = "/tmp/_manim_animation_options.py";
 const MANIM_ANIMATE_MODULE_PATH = "/tmp/_manim_animate.py";
+const MANIM_COMPOSITION_MODULE_PATH = "/tmp/_manim_composition.py";
 const MANIM_LIFECYCLE_MODULE_PATH = "/tmp/_manim_lifecycle.py";
 const MANIM_REACTIVE_MODULE_PATH = "/tmp/_manim_reactive.py";
 
@@ -47,6 +48,7 @@ async function initializePyodide() {
     phaseBResponse,
     animationOptionsResponse,
     animateResponse,
+    compositionResponse,
     lifecycleResponse,
     reactiveResponse,
   ] = await Promise.all([
@@ -57,6 +59,7 @@ async function initializePyodide() {
     fetch(new URL("./python/_manim_phase_b.py", import.meta.url)),
     fetch(new URL("./python/_manim_animation_options.py", import.meta.url)),
     fetch(new URL("./python/_manim_animate.py", import.meta.url)),
+    fetch(new URL("./python/_manim_composition.py", import.meta.url)),
     fetch(new URL("./python/_manim_lifecycle.py", import.meta.url)),
     fetch(new URL("./python/_manim_reactive.py", import.meta.url)),
   ]);
@@ -84,6 +87,9 @@ async function initializePyodide() {
   }
   if (!animateResponse.ok) {
     throw new Error(`Unable to load Noon Manim animate layer: HTTP ${animateResponse.status}`);
+  }
+  if (!compositionResponse.ok) {
+    throw new Error(`Unable to load Noon Manim composition layer: HTTP ${compositionResponse.status}`);
   }
   if (!lifecycleResponse.ok) {
     throw new Error(`Unable to load Noon Manim lifecycle layer: HTTP ${lifecycleResponse.status}`);
@@ -117,6 +123,9 @@ async function initializePyodide() {
   pyodide.FS.writeFile(MANIM_ANIMATE_MODULE_PATH, await animateResponse.text(), {
     encoding: "utf8",
   });
+  pyodide.FS.writeFile(MANIM_COMPOSITION_MODULE_PATH, await compositionResponse.text(), {
+    encoding: "utf8",
+  });
   pyodide.FS.writeFile(MANIM_LIFECYCLE_MODULE_PATH, await lifecycleResponse.text(), {
     encoding: "utf8",
   });
@@ -132,6 +141,8 @@ import _manim_rate_functions
 _manim_rate_functions.install()
 import _manim_phase_b
 import _manim_animate
+import _manim_composition
+_manim_composition.install()
 import _manim_lifecycle
 import _manim_reactive
 `);

--- a/web/python/_manim_composition.py
+++ b/web/python/_manim_composition.py
@@ -1,0 +1,333 @@
+"""Manim-compatible animation composition backed by Noon's shared Rust scheduler.
+
+This module owns Python class/iterable adaptation only. Child interval geometry is
+resolved by ``noon_core::resolve_composition_schedule`` through the WASM bridge.
+Composition is recursively lowered to ordinary deterministic Noon tracks.
+
+The current normalized track model can represent an outer composition exactly when
+its rate function is linear. Nonlinear outer time warps require a runtime time-map
+representation, especially for overlapping/same-property children and reversing
+rate functions; those cases fail explicitly rather than being approximated.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from typing import Any, Iterable
+
+from js import noonResolveCompositionSchedule as _resolve_shared_composition
+
+import noon as _base
+import _manim_animation_options as _options
+import _manim_animate as _animate
+import _manim_compat as _compat
+
+
+DEFAULT_LAGGED_START_LAG_RATIO = 0.05
+_ORIGINAL_SCENE_PLAY = _compat.Scene.play
+
+
+def _flatten_animations(values: Iterable[object]) -> list[object]:
+    flattened: list[object] = []
+    for value in values:
+        if isinstance(value, (list, tuple)):
+            flattened.extend(_flatten_animations(value))
+        else:
+            flattened.append(value)
+    return flattened
+
+
+class AnimationGroup:
+    """Play child animations using Manim-compatible composition timing."""
+
+    def __init__(
+        self,
+        *animations: object,
+        group: object | None = None,
+        run_time: float | None = None,
+        rate_func: object = None,
+        lag_ratio: float = 0.0,
+        **kwargs: Any,
+    ) -> None:
+        if kwargs:
+            unsupported = ", ".join(sorted(kwargs))
+            raise NotImplementedError(
+                f"unsupported AnimationGroup option(s): {unsupported}"
+            )
+        self.animations = _flatten_animations(animations)
+        self.group = group
+        self.run_time = None if run_time is None else float(run_time)
+        self.rate_func = _compat.linear if rate_func is None else rate_func
+        self.lag_ratio = float(lag_ratio)
+        if not math.isfinite(self.lag_ratio) or self.lag_ratio < 0.0:
+            raise ValueError("lag_ratio must be finite and non-negative")
+        if self.run_time is not None and (
+            not math.isfinite(self.run_time) or self.run_time <= 0.0
+        ):
+            raise ValueError("run_time must be finite and positive")
+
+
+class Succession(AnimationGroup):
+    def __init__(self, *animations: object, lag_ratio: float = 1.0, **kwargs: Any):
+        super().__init__(*animations, lag_ratio=lag_ratio, **kwargs)
+
+
+class LaggedStart(AnimationGroup):
+    def __init__(
+        self,
+        *animations: object,
+        lag_ratio: float = DEFAULT_LAGGED_START_LAG_RATIO,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*animations, lag_ratio=lag_ratio, **kwargs)
+
+
+def _resolve_schedule(
+    child_run_times: list[float],
+    lag_ratio: float,
+    run_time: float | None,
+):
+    if not child_run_times:
+        raise ValueError("animation composition requires at least one child")
+    result = _resolve_shared_composition(
+        json.dumps(child_run_times, separators=(",", ":"), allow_nan=False),
+        float(lag_ratio),
+        float("nan") if run_time is None else float(run_time),
+    )
+    if not bool(result.ok):
+        raise ValueError(str(result.message))
+    return result
+
+
+def _simple_runtime(animation: object) -> float:
+    builder_args = _options.builder_args(animation)
+    resolved = _options.resolve(
+        builder_args=builder_args,
+        default_lag_ratio=_animate._default_lag_ratio(animation),
+        play_run_time=None,
+        play_easing=None,
+        play_rate_func=None,
+        play_lag_ratio=None,
+    )
+    return resolved.run_time
+
+
+def _composition_local_rate_id(animation: AnimationGroup) -> str:
+    return _compat._easing_from_rate_func(animation.rate_func)
+
+
+def _intrinsic_runtime(animation: object) -> float:
+    if not isinstance(animation, AnimationGroup):
+        return _simple_runtime(animation)
+    child_run_times = [_intrinsic_runtime(child) for child in animation.animations]
+    schedule = _resolve_schedule(
+        child_run_times,
+        animation.lag_ratio,
+        animation.run_time,
+    )
+    return float(schedule.runTime)
+
+
+def _record_composition_wrapper_state(
+    animation: object,
+    states: dict[int, tuple[_base.Mobject, object, object]],
+) -> None:
+    if isinstance(animation, AnimationGroup):
+        for child in animation.animations:
+            _record_composition_wrapper_state(child, states)
+        return
+    source = _animate._builder_source(animation)
+    if source is not None:
+        _animate._record_wrapper_state(source, states)
+    if isinstance(animation, (_base.Create, _base.FadeIn, _base.FadeOut)):
+        _animate._record_wrapper_state(animation.target, states)
+
+
+def _play_leaf(
+    scene: _compat.Scene,
+    animation: object,
+    *,
+    start_time: float,
+    run_time: float,
+) -> None:
+    # Explicit run_time here represents the parent composition's resolved child
+    # interval. Other animation-local options (including the child rate_func) are
+    # still resolved by the ordinary shared AnimationOptions path.
+    _ORIGINAL_SCENE_PLAY(
+        scene,
+        animation,
+        run_time=run_time,
+        start_time=start_time,
+    )
+
+
+def _play_composition(
+    scene: _compat.Scene,
+    animation: AnimationGroup,
+    *,
+    start_time: float,
+    run_time_override: float | None,
+    rate_func_override: object | None,
+    easing_override: str | None,
+    lag_ratio_override: float | None,
+) -> float:
+    if not animation.animations:
+        raise ValueError("animation composition requires at least one child")
+
+    if easing_override is not None:
+        outer_rate_id = str(easing_override)
+    elif rate_func_override is not None:
+        outer_rate_id = _compat._easing_from_rate_func(rate_func_override)
+    else:
+        outer_rate_id = _composition_local_rate_id(animation)
+
+    if outer_rate_id != "linear":
+        raise NotImplementedError(
+            "nonlinear outer AnimationGroup/LaggedStart/Succession rate_func requires "
+            "Noon's runtime composition time-map representation; refusing to flatten "
+            f"rate_func={outer_rate_id!r} approximately"
+        )
+
+    lag_ratio = (
+        animation.lag_ratio
+        if lag_ratio_override is None
+        else float(lag_ratio_override)
+    )
+    child_run_times = [_intrinsic_runtime(child) for child in animation.animations]
+    requested_run_time = (
+        run_time_override
+        if run_time_override is not None
+        else animation.run_time
+    )
+    schedule = _resolve_schedule(child_run_times, lag_ratio, requested_run_time)
+
+    for child, interval in zip(animation.animations, schedule.intervals, strict=True):
+        child_start = start_time + float(interval.startTime)
+        child_duration = float(interval.duration)
+        if isinstance(child, AnimationGroup):
+            # Parent interval rescaling becomes this nested composition's total
+            # runtime. Its own lag ratio/rate function still defines local timing.
+            _play_composition(
+                scene,
+                child,
+                start_time=child_start,
+                run_time_override=child_duration,
+                rate_func_override=None,
+                easing_override=None,
+                lag_ratio_override=None,
+            )
+        else:
+            _play_leaf(
+                scene,
+                child,
+                start_time=child_start,
+                run_time=child_duration,
+            )
+
+    return start_time + float(schedule.runTime)
+
+
+def _composition_scene_play(
+    self: _compat.Scene,
+    *animations: Any,
+    duration: float | None = None,
+    run_time: float | None = None,
+    start_time: float | None = None,
+    easing: str | None = None,
+    rate_func: object | None = None,
+    lag_ratio: float | None = None,
+    **kwargs: Any,
+) -> _compat.Scene:
+    if not any(isinstance(animation, AnimationGroup) for animation in animations):
+        return _ORIGINAL_SCENE_PLAY(
+            self,
+            *animations,
+            duration=duration,
+            run_time=run_time,
+            start_time=start_time,
+            easing=easing,
+            rate_func=rate_func,
+            lag_ratio=lag_ratio,
+            **kwargs,
+        )
+    if not animations:
+        raise ValueError("play requires at least one animation")
+    if duration is not None and run_time is not None:
+        raise ValueError("use either duration or run_time, not both")
+    if easing is not None and rate_func is not None:
+        raise ValueError("use either rate_func or the low-level easing alias, not both")
+    if kwargs:
+        unsupported = ", ".join(sorted(kwargs))
+        raise NotImplementedError(f"unsupported Manim Scene.play option(s): {unsupported}")
+
+    play_run_time = run_time if run_time is not None else duration
+    if play_run_time is not None:
+        play_run_time = float(play_run_time)
+    if lag_ratio is not None:
+        lag_ratio = float(lag_ratio)
+    base_start = self._cursor if start_time is None else float(start_time)
+    if not math.isfinite(base_start) or base_start < 0.0:
+        raise ValueError("start_time must be finite and non-negative")
+
+    checkpoint = self._authoring_checkpoint()
+    cursor_before = self._cursor
+    top_level_before = list(self._compat_top_level)
+    wrapper_states: dict[int, tuple[_base.Mobject, object, object]] = {}
+    for animation in animations:
+        _record_composition_wrapper_state(animation, wrapper_states)
+
+    max_end = base_start
+    try:
+        for animation in animations:
+            if isinstance(animation, AnimationGroup):
+                end = _play_composition(
+                    self,
+                    animation,
+                    start_time=base_start,
+                    run_time_override=play_run_time,
+                    rate_func_override=rate_func,
+                    easing_override=easing,
+                    lag_ratio_override=lag_ratio,
+                )
+            else:
+                _ORIGINAL_SCENE_PLAY(
+                    self,
+                    animation,
+                    run_time=play_run_time,
+                    start_time=base_start,
+                    easing=easing,
+                    rate_func=rate_func,
+                    lag_ratio=lag_ratio,
+                )
+                end = self._cursor
+            max_end = max(max_end, end)
+
+        self._cursor = max(cursor_before, max_end)
+        return self
+    except Exception:
+        self._restore_authoring_checkpoint(checkpoint)
+        self._cursor = cursor_before
+        self._compat_top_level = top_level_before
+        for member, old_scene, old_object in wrapper_states.values():
+            member._scene = old_scene
+            member._object = old_object
+        raise
+
+
+def install() -> None:
+    public = {
+        "AnimationGroup": AnimationGroup,
+        "LaggedStart": LaggedStart,
+        "Succession": Succession,
+    }
+    for name, value in public.items():
+        setattr(_compat, name, value)
+        setattr(_base, name, value)
+
+    exports = list(_base.__all__)
+    for name in public:
+        if name not in exports:
+            exports.append(name)
+    _base.__all__ = exports
+    _compat.Scene.play = _composition_scene_play


### PR DESCRIPTION
## Summary

- add Manim-compatible Python `AnimationGroup`, `LaggedStart`, and `Succession`
- recursively lower composition children using the shared Rust `resolve_composition_schedule` planner
- preserve child-local animation options while rescaling each child to its resolved composition interval
- support unequal child runtimes, nested linear compositions, strict succession, mixed composition + ordinary `Scene.play`, and Manim's `LaggedStart` default lag ratio of 0.05
- keep composition authoring transactional across child failures
- explicitly reject nonlinear outer composition rate functions when flattening would require a runtime time-map, rather than silently approximating them
- add dedicated Pyodide/browser CI coverage for composition timing

The core A4 scheduler remains the semantic authority. This PR adds public Python composition classes as a thin recursive adapter; the remaining nonlinear outer-rate gap requires a richer deterministic runtime time-map before it can be represented exactly.