### PR TITLE
Add cross-language semantic parity gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,9 @@ jobs:
           npm install --no-save --ignore-scripts playwright@1.62.1 pngjs@7.0.0
           npx playwright install --with-deps chromium
 
+      - name: Test Rust/Python semantic parity
+        run: node scripts/cross-language-parity.mjs
+
       - name: Test Manim-style Python compatibility
         run: node scripts/manim-compat-smoke.mjs
 

--- a/crates/noon/Cargo.toml
+++ b/crates/noon/Cargo.toml
@@ -7,3 +7,6 @@ description = "Ergonomic language-neutral authoring facade for Noon"
 
 [dependencies]
 noon-core = { path = "../noon-core" }
+
+[dev-dependencies]
+noon-ir = { path = "../noon-ir" }

--- a/crates/noon/examples/cross_language_parity.rs
+++ b/crates/noon/examples/cross_language_parity.rs
@@ -29,12 +29,9 @@ fn nonlinear_composition() -> String {
     let mut scene = Scene::new();
     let circle = scene.add(Circle::new(0.4));
     let square = scene.add(Square::new(0.8));
-    let group = AnimationGroup::new((
-        circle.animate().shift(UP),
-        square.animate().shift(DOWN),
-    ))
-    .lag_ratio(0.5)
-    .rate_func(RateFunction::ThereAndBack);
+    let group = AnimationGroup::new((circle.animate().shift(UP), square.animate().shift(DOWN)))
+        .lag_ratio(0.5)
+        .rate_func(RateFunction::ThereAndBack);
     scene.play(group).run_time(3.0).unwrap();
     encode_scene(scene.definition()).unwrap()
 }

--- a/crates/noon/examples/cross_language_parity.rs
+++ b/crates/noon/examples/cross_language_parity.rs
@@ -1,0 +1,61 @@
+use noon::prelude::*;
+use noon_ir::{encode_scene, encode_timed_semantic_scene};
+
+fn emit(name: &str, document: String) {
+    println!("{name}\t{document}");
+}
+
+fn animate_options() -> String {
+    let mut scene = Scene::new();
+    let circle = scene.add(Circle::new(1.0));
+    scene
+        .play(circle.animate().shift(RIGHT).rotate(0.25))
+        .rate_func(RateFunction::Smooth)
+        .run_time(2.0)
+        .unwrap();
+    encode_scene(scene.definition()).unwrap()
+}
+
+fn lifecycle() -> String {
+    let mut scene = Scene::new();
+    let circle = scene.add(Circle::new(0.5));
+    scene.play(Create::new(circle)).run_time(1.0).unwrap();
+    scene.play(FadeOut::new(circle)).run_time(0.5).unwrap();
+    scene.play(FadeIn::new(circle)).run_time(0.5).unwrap();
+    encode_scene(scene.definition()).unwrap()
+}
+
+fn nonlinear_composition() -> String {
+    let mut scene = Scene::new();
+    let circle = scene.add(Circle::new(0.4));
+    let square = scene.add(Square::new(0.8));
+    let group = AnimationGroup::new((
+        circle.animate().shift(UP),
+        square.animate().shift(DOWN),
+    ))
+    .lag_ratio(0.5)
+    .rate_func(RateFunction::ThereAndBack);
+    scene.play(group).run_time(3.0).unwrap();
+    encode_scene(scene.definition()).unwrap()
+}
+
+fn value_tracker() -> String {
+    let mut scene = ReactiveTimelineScene::new();
+    let circle = scene.add(Circle::new(0.3));
+    let tracker = scene.value_tracker(0.0);
+    let position = scene.position_from_tracker(tracker, RIGHT, UP);
+    scene.bind_position(circle, position);
+    scene
+        .play_value(tracker, 2.0)
+        .rate_func(RateFunction::Linear)
+        .run_time(2.0)
+        .unwrap();
+    encode_timed_semantic_scene(&scene.timed_semantic_scene().unwrap()).unwrap()
+}
+
+fn main() {
+    emit("animate_options", animate_options());
+    emit("lifecycle", lifecycle());
+    emit("nonlinear_composition", nonlinear_composition());
+    emit("value_tracker", value_tracker());
+}

--- a/docs/manim-aligned-authoring-plan.md
+++ b/docs/manim-aligned-authoring-plan.md
@@ -1,30 +1,26 @@
 # Manim-compatible cross-language authoring plan
 
-This document is the authoritative current roadmap for Noon's user-facing authoring model.
+This is the authoritative roadmap for Noon's user-facing authoring model.
 
 ## Product target
 
-Noon's Python API targets **source compatibility with the common 2D Manim Community API**. For a supported feature, ordinary ManimCE source should ideally require only:
-
-```python
-from noon import *
-```
-
-instead of:
+Noon's Python API targets source compatibility with common 2D Manim Community scenes. For a supported feature, normal ManimCE source should ideally require only replacing:
 
 ```python
 from manim import *
 ```
 
-The compatibility reference is Manim Community v0.21.x.
+with:
 
-Compatibility is the default goal. Noon should intentionally diverge only when reproducing Manim semantics would create a fundamental design constraint or a material performance regression. A suspected blocker should be measured or demonstrated rather than assumed.
+```python
+from noon import *
+```
 
-The target is broader than Python compatibility: **Manim's useful object/animation semantics are the language-neutral authoring contract.** Rust and future frontends should expose the same concepts, defaults, lifecycle behavior, timing model, and observable results in idiomatic forms.
+The compatibility reference is Manim Community v0.21.x. Compatibility is the default goal; Noon should diverge only when matching Manim would impose a demonstrated architectural or material performance cost.
+
+The target is broader than Python compatibility: useful Manim object and animation semantics form a language-neutral authoring contract. Rust and future frontends should expose the same concepts and observable behavior idiomatically.
 
 ## Architecture contract
-
-The intended layering is:
 
 ```text
 Manim-compatible Python          idiomatic Rust          future frontends
@@ -34,19 +30,19 @@ Manim-compatible Python          idiomatic Rust          future frontends
                                       v
                          shared Rust authoring semantics
                                       |
-                       +--------------+--------------+
-                       | lifecycle / scene membership |
-                       | animation options/defaults   |
-                       | target-state animation       |
-                       | groups / composition         |
-                       | layout / style semantics     |
-                       | deterministic rate funcs     |
-                       | unsupported-feature policy   |
-                       +--------------+--------------+
+                   +------------------+------------------+
+                   | lifecycle / membership              |
+                   | animation options/defaults          |
+                   | target-state animation              |
+                   | groups/composition/nested time maps |
+                   | layout/style semantics              |
+                   | deterministic rate functions        |
+                   | signals/reactive dependencies       |
+                   | unsupported-feature policy          |
+                   +------------------+------------------+
                                       |
                                       v
-                              SceneDefinition
-                              / ScenePatch
+                      semantic scene / timed semantic scene
                                       |
                                       v
                                  noon-compile
@@ -58,307 +54,208 @@ Manim-compatible Python          idiomatic Rust          future frontends
                             WebGPU / WebGL2 renderer
 ```
 
-`SceneDefinition` remains the one canonical serialized semantic scene. The shared authoring layer may hold transient state while resolving fluent operations, but it must not become a second persistent scene model.
+The semantic scene is authoritative. Frontends may keep transient wrapper state needed for language ergonomics, but they must not implement a second scheduler, lifecycle engine, reactive evaluator, or playback model.
 
-### What belongs in shared Rust authoring semantics
+## Shared-semantics rule
 
-Rust should own semantics that must agree across languages:
+Rust owns behavior that must agree across languages:
 
-- `Scene.add/remove/clear` and object presence/lifecycle;
-- detached-object introduction by animations;
-- `.animate` target-state construction and lowering;
-- animation defaults and option precedence (`run_time`, `rate_func`, `lag_ratio`, etc.);
-- `Transform`, creation/fading animations, removers and introducers;
-- group/family expansion and animation composition;
-- layout operations such as `next_to`, `align_to`, `arrange`, `to_edge`, and bounds rules;
-- style semantics and defaults;
-- known deterministic Manim rate functions;
-- declarative trackers/signals when introduced;
-- decisions about whether a feature has a compiled representation or is explicitly unsupported.
+- scene membership and lifecycle;
+- detached-object introduction;
+- `.animate` target-state lowering;
+- animation option defaults and precedence;
+- creation/fading/remover/introducer semantics;
+- group/family scheduling and nested composition;
+- deterministic rate functions;
+- signal/tracker graphs and signal timelines;
+- layout/style/bounds semantics as they are consolidated;
+- decisions about deterministic lowering versus host-dynamic execution.
 
-The Python implementation should not independently define these rules.
-
-### What may remain Python-specific
-
-A thin Python layer is still required for language behavior:
-
-- Python class hierarchy, subclassing and `isinstance` behavior;
-- positional/keyword argument normalization;
-- accepting tuples, lists, NumPy-like vectors and other Python protocols;
-- adapting Python iterables and copying Python wrapper metadata;
-- discovering `Scene` subclasses and invoking `setup()/construct()/tear_down()`;
-- mapping a known Python callable such as `smooth` to a shared semantic rate-function identifier;
-- reporting Python-appropriate exceptions.
-
-These adapters should translate into shared semantics rather than implement an independent scheduler or animation engine.
-
-## Compatibility rule
-
-For Python:
-
-> Supported common 2D ManimCE source should run unchanged except for the import.
-
-For Rust and other languages:
-
-> Expose the same semantic vocabulary and behavior idiomatically rather than copying Python syntax.
-
-Compatibility includes public names, constructor forms, common defaults, lifecycle behavior, timing/animation behavior, layout/style semantics, and observable results. It does not require copying Manim's Cairo/OpenGL renderer, internal point-array representation, or imperative Python frame loop.
+Python may own language-specific adaptation only: class hierarchy behavior, argument normalization, Python iterable/vector protocols, wrapper metadata, Scene subclass discovery, callable-to-semantic-ID mapping, and Python-appropriate exceptions.
 
 ## Blocker policy
 
-A Manim feature is not considered blocked merely because Manim implements it imperatively.
+An imperative Manim implementation is not itself a blocker. Use this order:
 
-Use this order:
+1. reproduce the observable behavior using existing deterministic semantics;
+2. add a deterministic core representation when needed;
+3. compile/sample authoring-time behavior when that remains correct and bounded;
+4. use a host callback slot when arbitrary host execution is semantically required;
+5. only then declare a compatibility gap.
 
-1. reproduce the observable behavior with existing deterministic semantic tracks;
-2. add a deterministic/core representation when doing so preserves Noon's architecture and performance;
-3. compile or sample authoring-time Python behavior into a deterministic representation when reasonable;
-4. only then declare an explicit compatibility gap.
+Silent approximation is not acceptable.
 
-Examples:
+## Completed foundation — 2026-08-24
 
-- known rate functions are not blockers; evaluate them in Rust;
-- display-space stroke width should be evaluated as a renderer/core semantic option before accepting an approximation;
-- `ValueTracker` should prefer a declarative signal/expression representation;
-- arbitrary stateful `add_updater(lambda ...)` may be a real blocker for the normal compiled playback path if it cannot be compiled or safely sampled.
+The cross-language authoring consolidation milestone is complete through A5.
 
-Unsupported behavior must fail clearly. Silent semantic drift is not acceptable.
+### A1 — shared deterministic rate functions
 
-## Current state — 2026-08-23
+Complete:
 
-The original architecture migration and most of the early Manim compatibility foundation are already complete.
-
-Implemented today:
-
-- canonical deterministic `SceneDefinition`/track/runtime pipeline;
-- analytic circles/rectangles/lines plus vector paths;
-- generic transforms and prepared cross-geometry morphing;
-- path reveal/Create support and lifecycle tracks;
-- `Scene` subclass discovery and normal `construct()` execution in the browser;
-- public Python `Mobject`/`VMobject`/shape classes;
-- detached `Create`, `FadeIn`, and detached `.animate` introduction;
-- Manim-style 2D acceptance of 3-component vectors with explicit nonzero-Z rejection;
-- `Scene.add/remove/clear/mobjects` behavior;
-- `Group`/`VGroup` authoring semantics and grouped transforms;
-- independent fill/stroke opacity;
-- generalized chained `.animate` proxying and builder option precedence;
-- Rust `Scene`, `Mobject`, shapes, `.animate`, `Transform`, `Create`, fades, layout and direct lowering into the canonical core scene;
-- WebGPU renderer with WebGL2 browser fallback;
-- browser compatibility smoke coverage.
-
-The important remaining architectural problem is that the Python compatibility modules still contain too much semantic scheduling/lifecycle/group logic. The next milestone is therefore **cross-language authoring consolidation**, not simply adding more Python wrappers.
-
-## Current milestone — cross-language authoring consolidation
-
-### A1. Shared deterministic rate functions
-
-Make Manim's known rate functions first-class semantic/runtime behavior.
-
-Initial set:
-
-- `linear`;
-- exact Manim `smooth` (normalized logistic, default inflection 10);
-- `rush_into`;
-- `rush_from`;
-- `there_and_back`;
-- retain Noon's low-level `ease_in_out_cubic` for backwards compatibility.
-
-Requirements:
-
+- exact shared `linear`, `smooth`, `rush_into`, `rush_from`, and `there_and_back`;
 - Rust runtime owns numerical evaluation;
-- Python maps known callable identity/name to the semantic identifier only;
-- Rust authoring exposes Manim vocabulary (`rate_func`) while keeping low-level compatibility aliases if useful;
-- Manim-compatible animations default to `smooth`, not Noon's cubic approximation;
-- numerical tests cover endpoints and representative interior values.
+- Python maps known callables to shared semantic IDs;
+- Manim-compatible animation defaults use `smooth`.
 
-### A2. Shared animation options
+### A2 — shared animation options
 
-Introduce one authoring representation for animation options/default resolution, conceptually:
+Complete:
+
+- shared `AnimationOptions`, defaults, validation, and precedence;
+- `Scene.play` overrides animation-local options consistently;
+- Python mobject and `ValueTracker` animation paths use the Rust/WASM resolver.
+
+### A3 — shared lifecycle and membership
+
+Complete:
+
+- shared lifecycle planning for add/remove/reintroduction;
+- detached `.animate`, Create, FadeIn/FadeOut, introducer/remover behavior;
+- presence-chain validation and source/target requirements.
+
+### A4 — shared composition scheduling
+
+Complete:
+
+- shared parallel/lagged/succession scheduling;
+- `AnimationGroup`, `LaggedStart`, and `Succession` in Python and Rust;
+- unequal child durations and explicit group runtime rescaling;
+- deterministic nested `CompositionTimeMap` data for nonlinear and reversing outer rate functions;
+- identity fast path for ordinary tracks.
+
+### A5 — cross-language semantic parity
+
+Current PR establishes this as a permanent CI contract:
+
+- equivalent Rust and Python scenes are authored independently;
+- both emit canonical semantic documents;
+- CI compares the documents recursively with numeric tolerance only;
+- the initial corpus covers target-state animation/options, lifecycle, nonlinear composition/time maps, and timed reactive `ValueTracker` authoring.
+
+New shared features should extend this corpus when equivalent Rust and Python APIs exist.
+
+## Native reactive/interactivity foundation already complete
+
+Noon already has:
+
+- `SemanticScene` with a native typed reactive graph;
+- `ValueTracker` and derived signal expressions;
+- dependency-local dirty propagation;
+- dense runtime binding targets;
+- deterministic signal timelines and `tracker.animate.set_value(...)`;
+- browser-native reactive scene/canvas players;
+- live signal mutation without scene recompilation;
+- static/timeline/reactive execution classification.
+
+The remaining architectural interactivity gap is arbitrary host-language behavior.
+
+## Next milestone — host callbacks and general interaction
+
+Implement host-dynamic execution without putting Python on the normal frame path.
+
+Required model:
 
 ```text
-AnimationOptions
-  run_time
-  rate_func
-  lag_ratio
-  path_arc
-  reverse_rate_function
-  remover / introducer metadata where applicable
+runtime frame
+    |
+    +-- coherent time/dt/input/dynamic snapshot
+    |
+    v
+host callback phase
+    |
+    +-- updater/event callbacks
+    |
+    v
+one mutation transaction
+    |
+    +-- validate atomically
+    +-- apply semantic mutations
+    +-- propagate only affected dirtiness
+    +-- recompile only when mutation impact requires it
+    |
+    v
+render
 ```
 
-Both Rust and Python frontends should lower through the same option precedence rules. `Scene.play` overrides per-animation values where Manim does.
+Priorities:
 
-### A3. Shared lifecycle and scene membership
+1. define host callback slots and callback-phase request/response data;
+2. add native pointer/keyboard/viewport input signals so common interaction avoids host callbacks entirely;
+3. expose Manim-compatible `add_updater`, `remove_updater`, `clear_updaters`, and `always_redraw` with native lowering where possible and host fallback otherwise;
+4. batch callback reads/writes so Python↔WASM does not cross once per getter/setter;
+5. prove a few host-dynamic nodes do not make unrelated static/reactive nodes dynamic;
+6. add browser interaction tests and mixed static/reactive/host execution metrics.
 
-Move reusable rules for:
+## Following milestone — remaining core 2D semantic parity
 
-- implicit addition of animated detached objects;
-- introducers/removers;
-- presence track creation;
-- reintroduction;
-- scene membership transitions;
-- replacement semantics;
-
-out of Python-specific scheduling code and into shared authoring semantics.
-
-### A4. Shared group/composition scheduling
-
-Centralize family expansion, lag interval calculation and composition so Python does not own Manim timing geometry.
-
-This becomes the foundation for:
-
-- `AnimationGroup`;
-- `Succession`;
-- `LaggedStart`;
-- grouped `Create`/`Write`;
-- `VGroup.animate(..., lag_ratio=...)`.
-
-### A5. Cross-language parity tests
-
-For every shared semantic feature, test that equivalent Python and Rust authoring produce the same semantic tracks or equivalent compiled scenes.
-
-The goal is not textually identical APIs; it is one semantic implementation.
-
-## Next compatibility milestones
-
-### B — remaining core 2D semantic parity
-
-Resolve the remaining high-impact differences before expanding breadth:
+Resolve high-impact compatibility differences before expanding breadth:
 
 - stroke-width units and scaling semantics;
-- remaining `Mobject`/`VMobject` bounds/layout methods such as `set_x`, `set_y` and family behavior where not already complete;
-- animation metadata/remover/introducer defaults;
+- remaining Mobject/VMobject family/bounds/layout methods;
+- animation metadata/default details;
 - exact option/error behavior for supported APIs.
 
-Stroke width deserves an explicit design choice. Manim's common VMobject behavior is display-space-like: object scaling generally does not scale stroke width unless requested. Noon currently treats stroke width as local/world geometry. The preferred direction is to support a display/screen-space semantic mode for Manim compatibility while retaining a world-space Noon mode if the renderer can do so efficiently.
+Stroke width needs an explicit semantic mode. Manim's normal VMobject behavior is display-space-like: scaling an object generally does not scale stroke width. Noon should support that efficiently for compatibility, while a world-space stroke mode may remain useful as a Noon-native option.
 
-### C — animation composition and core shape breadth
+## Feature breadth after architectural closure
 
-Add shared Rust semantics first, then thin Python wrappers:
+### Core shapes and animations
 
-- `AnimationGroup`;
-- `Succession`;
-- `LaggedStart`;
-- `Uncreate`;
-- `Write` groundwork;
-- `Dot`, `Ellipse`, `Arc`, `Polygon`, `RegularPolygon`, `Triangle`, `Arrow`, `Vector`, `DashedLine`.
+- `Uncreate` and `Write` groundwork;
+- `Dot`, `Ellipse`, `Arc`, `Polygon`, `RegularPolygon`, `Triangle`;
+- `Arrow`, `Vector`, `DashedLine`.
 
-### D — text and mathematical authoring
+### Text and mathematical authoring
 
-Implement text as a core subsystem rather than a Python-only compatibility layer:
-
-- `Text`;
-- `MarkupText`;
-- `Tex`;
-- `MathTex`;
-- shaped glyph-run/cache/atlas representation for normal text;
-- outline extraction for path-level `Create`/`Write`/matching behavior;
+- `Text`, `MarkupText`, `Tex`, `MathTex`;
+- shaped glyph-run/cache/atlas steady-state representation;
+- outline extraction only where path-level Write/Create/matching requires it;
 - `TransformMatchingTex`.
 
-Do not make vector outlines the permanent representation for all steady-state text.
+### Values and plotting
 
-### E — signals, values and plotting
+`ValueTracker` and the signal model already exist. Continue with:
 
-Build the declarative signal/expression model before updater-like APIs:
-
-- `ValueTracker`;
-- deterministic expressions driven by time/signals;
 - `DecimalNumber`;
 - `NumberLine`, `Axes`, `NumberPlane`;
 - `FunctionGraph`, `ParametricFunction`;
 - braces and labels.
 
-This is the preferred architectural answer to many Manim scenes that currently use per-frame Python updaters.
+### Advanced VMobject/import surface
 
-### F — advanced VMobject/import surface
-
-- public path-building VMobject APIs (`start_new_path`, `add_line_to`, cubic builders, corner helpers);
+- public path-building methods;
 - `point_from_proportion`;
 - `SVGMobject`;
 - `ImageMobject`;
-- broader matching transforms and compatibility corpus.
-
-### G — hardening and performance
-
-Continue throughout development, with focused later expansion:
-
-- malformed-path/transform/seek/live-patch property and fuzz coverage;
-- larger path/morph performance baselines;
-- cache policy refinement if measured workloads require it;
-- small controlled visual/golden tests where structural/numerical tests cannot prove correctness;
-- browser authoring transport improvements when profiling shows complete-scene JSON remains a material bottleneck.
-
-## Compatibility levels
-
-### Level 1 — common 2D Manim syntax
-
-Target near-source-compatibility for:
-
-- `Scene`, lifecycle and membership;
-- `Mobject`, `VMobject`, `Group`, `VGroup`;
-- common 2D geometry;
-- `Create`, `Uncreate`, fades, transforms;
-- layout and style operations;
-- `.animate`;
-- constants/colors;
-- named deterministic rate functions.
-
-### Level 2 — typical mathematical animation
-
-- text/Tex/MathTex;
-- writing animations;
-- animation composition;
-- axes/graphs;
-- trackers/declarative expressions;
-- braces/labels/decimals.
-
-### Level 3 — rich vector authoring
-
-- broad VMobject path API;
-- SVG/image import;
-- richer matching transforms.
-
-### Level 4 — compatibility requiring special handling
-
-Examples include arbitrary Python per-frame updaters, arbitrary stateful callback animations, camera internals and 3D behavior. These are evaluated feature-by-feature under the blocker policy rather than categorically rejected in advance.
+- broader matching transforms.
 
 ## CI compatibility contract
 
-Compatibility tests should include ordinary Manim-style source such as:
+For shared features, CI should verify as applicable:
 
-```python
-from noon import *
-
-class BasicCreate(Scene):
-    def construct(self):
-        circle = Circle(color=BLUE)
-        square = Square().next_to(circle, RIGHT)
-        self.play(Create(circle), Create(square))
-        self.play(circle.animate.shift(UP), run_time=2, rate_func=smooth)
-```
-
-Tests should verify:
-
-- source execution succeeds;
-- object/track counts and lifecycle are correct;
-- final semantic state matches expectations;
+- ordinary Manim-style Python source executes;
+- equivalent Rust/Python authoring emits equivalent semantic documents;
+- object/track/lifecycle state is correct;
 - direct seek agrees with forward playback;
-- known rate-function values match Manim numerically within defined tolerance;
-- Rust and Python equivalents produce semantic parity;
-- WebGPU and WebGL2 browser smoke remain valid;
-- unsupported features fail with stable, specific messages.
+- deterministic rate-function values match reference behavior;
+- native reactive updates remain dependency-local;
+- WebGPU and WebGL2 browser rendering remain valid;
+- unsupported behavior fails with stable, explicit errors.
 
-## Relationship to older docs
+The cross-language parity corpus is the regression gate against semantic drift between frontends; per-feature smoke tests remain useful for Python-specific ergonomics and browser behavior.
 
-`docs/implementation-plan.md` is the original low-level architecture milestone plan. Several of its "remaining" subsections have been superseded by completed work; use focused status docs such as `docs/vector-geometry-status.md` for those subsystems.
+## Relationship to other docs
 
-`docs/manim-animate-semantics.md` and `docs/manim-style-semantics.md` record detailed compatibility behavior/decisions. This document owns the current cross-language authoring roadmap and priority order.
-
-`docs/codex-handoff.md` is historical implementation handoff material and must not be treated as the current roadmap.
+- `docs/architecture-plan.md` owns the overall static/reactive/host-dynamic execution architecture.
+- `docs/reactive-execution.md` owns native reactive/runtime details.
+- `docs/manim-animate-semantics.md` and `docs/manim-style-semantics.md` record detailed compatibility behavior.
+- older implementation/handoff documents are historical and are not current roadmap sources.
 
 ## Non-goals
 
-- copying Manim's renderer or internal scene implementation;
-- forcing analytic primitives into generic point arrays solely for API compatibility;
-- putting Python on the normal frame-critical playback path;
-- maintaining separate semantic behavior in each language binding;
-- silently pretending unsupported 3D/camera/updater behavior is compatible.
+- copying Manim's renderer or internal point-array implementation;
+- putting Python on the normal frame-critical path;
+- maintaining separate semantic engines per language;
+- forcing analytic geometry into generic path arrays solely for compatibility;
+- silently claiming unsupported camera/3D/host-dynamic behavior is compatible.

--- a/scripts/cross-language-parity.mjs
+++ b/scripts/cross-language-parity.mjs
@@ -1,0 +1,173 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import playwright from "playwright";
+
+const { chromium } = playwright;
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const port = 4180;
+const baseUrl = `http://127.0.0.1:${port}`;
+
+const pythonCases = {
+  animate_options: `
+from noon import *
+
+class ParityAnimate(Scene):
+    def construct(self):
+        circle = Circle(radius=1.0)
+        self.add(circle)
+        self.play(
+            circle.animate.shift(RIGHT).rotate(0.25),
+            run_time=2.0,
+            rate_func=smooth,
+        )
+`,
+  lifecycle: `
+from noon import *
+
+class ParityLifecycle(Scene):
+    def construct(self):
+        circle = Circle(radius=0.5)
+        self.play(Create(circle), run_time=1.0)
+        self.play(FadeOut(circle), run_time=0.5)
+        self.play(FadeIn(circle), run_time=0.5)
+`,
+  nonlinear_composition: `
+from noon import *
+
+class ParityComposition(Scene):
+    def construct(self):
+        circle = Circle(radius=0.4)
+        square = Square(side_length=0.8)
+        self.add(circle, square)
+        group = AnimationGroup(
+            circle.animate.shift(UP),
+            square.animate.shift(DOWN),
+            lag_ratio=0.5,
+            rate_func=there_and_back,
+        )
+        self.play(group, run_time=3.0)
+`,
+  value_tracker: `
+from noon import *
+
+class ParityTracker(Scene):
+    def construct(self):
+        circle = Circle(radius=0.3)
+        self.add(circle)
+        tracker = ValueTracker(0.0)
+        self.bind_position(circle, tracker, direction=RIGHT, offset=UP)
+        self.play(
+            tracker.animate(run_time=2.0, rate_func=linear).set_value(2.0)
+        )
+`,
+};
+
+function rustCorpus() {
+  const output = execFileSync(
+    "cargo",
+    ["run", "--quiet", "-p", "noon", "--example", "cross_language_parity"],
+    { cwd: repoRoot, encoding: "utf8" },
+  );
+  const corpus = new Map();
+  for (const line of output.trim().split("\n")) {
+    const separator = line.indexOf("\t");
+    assert.ok(separator > 0, `invalid Rust parity corpus line: ${line}`);
+    corpus.set(line.slice(0, separator), JSON.parse(line.slice(separator + 1)));
+  }
+  return corpus;
+}
+
+function assertSemanticEqual(actual, expected, location = "document") {
+  if (typeof actual === "number" && typeof expected === "number") {
+    const normalizedActual = Object.is(actual, -0) ? 0 : actual;
+    const normalizedExpected = Object.is(expected, -0) ? 0 : expected;
+    assert.ok(
+      Math.abs(normalizedActual - normalizedExpected) <= 1e-6,
+      `${location}: ${normalizedActual} != ${normalizedExpected}`,
+    );
+    return;
+  }
+  if (Array.isArray(actual) || Array.isArray(expected)) {
+    assert.ok(Array.isArray(actual) && Array.isArray(expected), `${location}: array mismatch`);
+    assert.equal(actual.length, expected.length, `${location}: array length mismatch`);
+    for (let index = 0; index < actual.length; index += 1) {
+      assertSemanticEqual(actual[index], expected[index], `${location}[${index}]`);
+    }
+    return;
+  }
+  if (actual !== null && expected !== null && typeof actual === "object" && typeof expected === "object") {
+    const actualKeys = Object.keys(actual).sort();
+    const expectedKeys = Object.keys(expected).sort();
+    assert.deepEqual(actualKeys, expectedKeys, `${location}: object keys differ`);
+    for (const key of actualKeys) {
+      assertSemanticEqual(actual[key], expected[key], `${location}.${key}`);
+    }
+    return;
+  }
+  assert.equal(actual, expected, `${location}: value mismatch`);
+}
+
+let serverOutput = "";
+const server = spawn(
+  "python3",
+  ["-m", "http.server", String(port), "--bind", "127.0.0.1", "--directory", repoRoot],
+  { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] },
+);
+server.stdout.on("data", (chunk) => (serverOutput += chunk));
+server.stderr.on("data", (chunk) => (serverOutput += chunk));
+
+async function waitForServer() {
+  let lastError = null;
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    try {
+      const response = await fetch(`${baseUrl}/web/manim-compat-smoke.html`);
+      if (response.ok) return;
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Parity server did not start: ${lastError}\n${serverOutput}`);
+}
+
+let browser = null;
+try {
+  const rust = rustCorpus();
+  assert.deepEqual([...rust.keys()].sort(), Object.keys(pythonCases).sort());
+
+  await waitForServer();
+  browser = await chromium.launch({
+    channel: "chromium",
+    headless: true,
+    args: ["--disable-dev-shm-usage"],
+  });
+  const page = await browser.newPage();
+  const errors = [];
+  page.on("pageerror", (error) => errors.push(`pageerror: ${error}`));
+  page.on("console", (message) => {
+    if (message.type() === "error") errors.push(`console: ${message.text()}`);
+  });
+
+  await page.goto(`${baseUrl}/web/manim-compat-smoke.html`, { waitUntil: "load" });
+  await page.waitForFunction(() => window.noonManimCompat, null, { timeout: 30_000 });
+  await page.evaluate(() => window.noonManimCompat.ready());
+
+  for (const [name, source] of Object.entries(pythonCases)) {
+    const result = await page.evaluate(
+      (pythonSource) => window.noonManimCompat.run(pythonSource),
+      source,
+    );
+    assert.equal(result.kind, "scene_document", `${name}: Python authoring failed`);
+    assertSemanticEqual(result.document, rust.get(name), name);
+  }
+  assert.equal(errors.length, 0, errors.join("\n"));
+  console.log("cross-language semantic parity corpus passed");
+} finally {
+  if (browser !== null) await browser.close();
+  server.kill("SIGTERM");
+}


### PR DESCRIPTION
## Summary

- add a Rust parity corpus that emits canonical scene/timed-scene documents
- run equivalent Manim-style Python scenes through Pyodide in CI
- compare the two semantic documents recursively with numeric tolerance only
- cover target-state animation/options, lifecycle, nonlinear composition/time maps, and timed reactive ValueTracker authoring
- make this a permanent CI gate for future shared frontend semantics
- refresh the authoritative authoring roadmap to mark A1-A5 and native reactive foundations complete and make host callbacks/general interaction the next architectural milestone

## Architectural intent

This closes the authoring-consolidation milestone with a direct regression check against frontend semantic drift. Python and Rust remain free to have different ergonomic syntax, but equivalent authored behavior must lower to the same canonical semantics.