### PR TITLE
Add host callback runtime protocol

### DIFF
--- a/crates/noon-core/src/host_callbacks.rs
+++ b/crates/noon-core/src/host_callbacks.rs
@@ -1,0 +1,145 @@
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+
+use crate::ObjectId;
+
+/// Stable language-neutral identity for one host callback slot.
+///
+/// The callback implementation itself stays in the host language. Noon transports
+/// only this identity plus the semantic objects whose coherent frame state the
+/// callback needs to observe.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct HostCallbackId(u64);
+
+impl HostCallbackId {
+    pub const fn new(raw: u64) -> Self {
+        Self(raw)
+    }
+
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HostCallbackSlot {
+    pub id: HostCallbackId,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub objects: Vec<ObjectId>,
+}
+
+/// Declarative host-dynamic participation for a semantic scene.
+///
+/// Slots contain no executable code. A Python/JS/native host owns the callable
+/// keyed by `HostCallbackId`; the runtime owns when the callback phase is required
+/// and which object state is captured for that phase.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct HostCallbackRegistry {
+    slots: Vec<HostCallbackSlot>,
+    next_callback_id: u64,
+}
+
+impl HostCallbackRegistry {
+    pub const fn new() -> Self {
+        Self {
+            slots: Vec::new(),
+            next_callback_id: 0,
+        }
+    }
+
+    pub fn from_slots(slots: Vec<HostCallbackSlot>) -> Result<Self, HostCallbackRegistryError> {
+        let mut ids = BTreeSet::new();
+        let mut next_callback_id = 0;
+        for slot in &slots {
+            if !ids.insert(slot.id) {
+                return Err(HostCallbackRegistryError::DuplicateCallback(slot.id));
+            }
+            next_callback_id = next_callback_id.max(
+                slot.id
+                    .get()
+                    .checked_add(1)
+                    .ok_or(HostCallbackRegistryError::CallbackIdExhausted)?,
+            );
+        }
+        Ok(Self {
+            slots,
+            next_callback_id,
+        })
+    }
+
+    pub fn register(
+        &mut self,
+        objects: impl IntoIterator<Item = ObjectId>,
+    ) -> HostCallbackId {
+        let id = HostCallbackId::new(self.next_callback_id);
+        self.next_callback_id = self
+            .next_callback_id
+            .checked_add(1)
+            .expect("Noon host callback ID space exhausted");
+        let mut unique = Vec::new();
+        for object in objects {
+            if !unique.contains(&object) {
+                unique.push(object);
+            }
+        }
+        self.slots.push(HostCallbackSlot {
+            id,
+            objects: unique,
+        });
+        id
+    }
+
+    pub fn slots(&self) -> &[HostCallbackSlot] {
+        &self.slots
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.slots.is_empty()
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HostCallbackRegistryError {
+    DuplicateCallback(HostCallbackId),
+    CallbackIdExhausted,
+}
+
+impl std::fmt::Display for HostCallbackRegistryError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::DuplicateCallback(id) => {
+                write!(formatter, "duplicate host callback id {}", id.get())
+            }
+            Self::CallbackIdExhausted => formatter.write_str("Noon host callback ID space exhausted"),
+        }
+    }
+}
+
+impl std::error::Error for HostCallbackRegistryError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn callback_ids_are_stable_and_object_subscriptions_are_deduplicated() {
+        let mut registry = HostCallbackRegistry::new();
+        let first = ObjectId::new(4);
+        let second = ObjectId::new(7);
+        assert_eq!(registry.register([first, first, second]), HostCallbackId::new(0));
+        assert_eq!(registry.register([]), HostCallbackId::new(1));
+        assert_eq!(registry.slots()[0].objects, vec![first, second]);
+    }
+
+    #[test]
+    fn transported_slots_reject_duplicate_callback_ids() {
+        let slot = HostCallbackSlot {
+            id: HostCallbackId::new(3),
+            objects: vec![ObjectId::new(1)],
+        };
+        assert_eq!(
+            HostCallbackRegistry::from_slots(vec![slot.clone(), slot]),
+            Err(HostCallbackRegistryError::DuplicateCallback(HostCallbackId::new(3)))
+        );
+    }
+}

--- a/crates/noon-core/src/host_callbacks.rs
+++ b/crates/noon-core/src/host_callbacks.rs
@@ -67,10 +67,7 @@ impl HostCallbackRegistry {
         })
     }
 
-    pub fn register(
-        &mut self,
-        objects: impl IntoIterator<Item = ObjectId>,
-    ) -> HostCallbackId {
+    pub fn register(&mut self, objects: impl IntoIterator<Item = ObjectId>) -> HostCallbackId {
         let id = HostCallbackId::new(self.next_callback_id);
         self.next_callback_id = self
             .next_callback_id
@@ -110,7 +107,9 @@ impl std::fmt::Display for HostCallbackRegistryError {
             Self::DuplicateCallback(id) => {
                 write!(formatter, "duplicate host callback id {}", id.get())
             }
-            Self::CallbackIdExhausted => formatter.write_str("Noon host callback ID space exhausted"),
+            Self::CallbackIdExhausted => {
+                formatter.write_str("Noon host callback ID space exhausted")
+            }
         }
     }
 }
@@ -126,7 +125,10 @@ mod tests {
         let mut registry = HostCallbackRegistry::new();
         let first = ObjectId::new(4);
         let second = ObjectId::new(7);
-        assert_eq!(registry.register([first, first, second]), HostCallbackId::new(0));
+        assert_eq!(
+            registry.register([first, first, second]),
+            HostCallbackId::new(0)
+        );
         assert_eq!(registry.register([]), HostCallbackId::new(1));
         assert_eq!(registry.slots()[0].objects, vec![first, second]);
     }
@@ -139,7 +141,9 @@ mod tests {
         };
         assert_eq!(
             HostCallbackRegistry::from_slots(vec![slot.clone(), slot]),
-            Err(HostCallbackRegistryError::DuplicateCallback(HostCallbackId::new(3)))
+            Err(HostCallbackRegistryError::DuplicateCallback(
+                HostCallbackId::new(3)
+            ))
         );
     }
 }

--- a/crates/noon-core/src/reactive.rs
+++ b/crates/noon-core/src/reactive.rs
@@ -6,6 +6,10 @@ pub use authoring::*;
 mod composition;
 pub use composition::*;
 
+#[path = "host_callbacks.rs"]
+mod host_callbacks;
+pub use host_callbacks::*;
+
 #[path = "lifecycle.rs"]
 mod lifecycle;
 pub use lifecycle::*;

--- a/crates/noon-runtime/src/reactive.rs
+++ b/crates/noon-runtime/src/reactive.rs
@@ -1,4 +1,7 @@
 include!("reactive_impl.rs");
 
+mod host_callbacks;
+pub use host_callbacks::*;
+
 mod signal_timeline;
 pub use signal_timeline::*;

--- a/crates/noon-runtime/src/reactive/host_callbacks.rs
+++ b/crates/noon-runtime/src/reactive/host_callbacks.rs
@@ -2,8 +2,8 @@ use std::collections::BTreeMap;
 
 use noon_compile::CompilePatchError;
 use noon_core::{
-    HostCallbackId, HostCallbackRegistry, MutationImpact, MutationTransaction, ObjectId, ScenePatch,
-    Style, Transform2D,
+    HostCallbackId, HostCallbackRegistry, MutationImpact, MutationTransaction, ObjectId,
+    ScenePatch, Style, Transform2D,
 };
 
 use crate::{EvaluationError, FrameState, SceneInstance};

--- a/crates/noon-runtime/src/reactive/host_callbacks.rs
+++ b/crates/noon-runtime/src/reactive/host_callbacks.rs
@@ -1,0 +1,432 @@
+use std::collections::BTreeMap;
+
+use noon_compile::CompilePatchError;
+use noon_core::{
+    HostCallbackId, HostCallbackRegistry, MutationImpact, MutationTransaction, ObjectId, ScenePatch,
+    Style, Transform2D,
+};
+
+use crate::{EvaluationError, FrameState, SceneInstance};
+
+/// Dynamic object state captured once for one host callback phase.
+///
+/// Geometry is intentionally excluded from this frame-critical snapshot. Stable
+/// geometry metadata can be exposed separately; callback phases should not clone
+/// large path payloads merely to read transforms/styles or lifecycle state.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct HostObjectFrameState {
+    pub object: ObjectId,
+    pub transform: Transform2D,
+    pub style: Style,
+    pub presence: bool,
+    pub appearance: f32,
+    pub reveal: f32,
+    pub morph: f32,
+}
+
+/// One callback invocation referencing the phase-wide object snapshot table.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HostCallbackInvocation {
+    pub callback: HostCallbackId,
+    pub object_indices: Vec<u32>,
+}
+
+/// Coherent read-side payload for one host callback phase.
+///
+/// Objects watched by multiple callbacks appear once in `objects`; each callback
+/// references that shared table by compact indices. This is the payload intended
+/// to cross a Python/JS/native host boundary once per callback phase.
+#[derive(Clone, Debug, PartialEq)]
+pub struct HostCallbackFrame {
+    pub time: f64,
+    pub delta_time: f64,
+    pub objects: Vec<HostObjectFrameState>,
+    pub invocations: Vec<HostCallbackInvocation>,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct HostCommitStats {
+    pub mutations: usize,
+    pub impact: Option<MutationImpact>,
+    pub staged: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum HostCallbackAttachError {
+    UnknownObject {
+        callback: HostCallbackId,
+        object: ObjectId,
+    },
+    TooManyWatchedObjects(usize),
+}
+
+impl std::fmt::Display for HostCallbackAttachError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnknownObject { callback, object } => write!(
+                formatter,
+                "host callback {} references unknown object {}",
+                callback.get(),
+                object.get()
+            ),
+            Self::TooManyWatchedObjects(count) => {
+                write!(formatter, "too many host callback watched objects: {count}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for HostCallbackAttachError {}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum HostCommitError {
+    Patch(CompilePatchError),
+    ReactiveReloweringRequired(MutationImpact),
+}
+
+impl std::fmt::Display for HostCommitError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Patch(error) => error.fmt(formatter),
+            Self::ReactiveReloweringRequired(impact) => write!(
+                formatter,
+                "host callback {impact:?} mutation requires reactive semantic re-lowering"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for HostCommitError {}
+
+impl From<CompilePatchError> for HostCommitError {
+    fn from(value: CompilePatchError) -> Self {
+        Self::Patch(value)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct HostDrivenScene {
+    scene: SceneInstance,
+    watched_dense_indices: Vec<usize>,
+    invocations: Vec<HostCallbackInvocation>,
+    last_callback_time: f64,
+    last_commit_stats: HostCommitStats,
+}
+
+impl HostDrivenScene {
+    pub fn new(
+        scene: SceneInstance,
+        registry: &HostCallbackRegistry,
+    ) -> Result<Self, HostCallbackAttachError> {
+        let mut watched_dense_indices = Vec::<usize>::new();
+        let mut snapshot_index_by_object = BTreeMap::<ObjectId, u32>::new();
+        let mut invocations = Vec::with_capacity(registry.slots().len());
+
+        for slot in registry.slots() {
+            let mut object_indices = Vec::with_capacity(slot.objects.len());
+            for object in &slot.objects {
+                let dense_index = scene
+                    .frame()
+                    .objects
+                    .iter()
+                    .position(|candidate| candidate.id == *object)
+                    .ok_or(HostCallbackAttachError::UnknownObject {
+                        callback: slot.id,
+                        object: *object,
+                    })?;
+                let snapshot_index = if let Some(index) = snapshot_index_by_object.get(object) {
+                    *index
+                } else {
+                    let index = u32::try_from(watched_dense_indices.len()).map_err(|_| {
+                        HostCallbackAttachError::TooManyWatchedObjects(watched_dense_indices.len())
+                    })?;
+                    watched_dense_indices.push(dense_index);
+                    snapshot_index_by_object.insert(*object, index);
+                    index
+                };
+                object_indices.push(snapshot_index);
+            }
+            invocations.push(HostCallbackInvocation {
+                callback: slot.id,
+                object_indices,
+            });
+        }
+
+        let last_callback_time = scene.frame().time;
+        Ok(Self {
+            scene,
+            watched_dense_indices,
+            invocations,
+            last_callback_time,
+            last_commit_stats: HostCommitStats::default(),
+        })
+    }
+
+    pub fn scene(&self) -> &SceneInstance {
+        &self.scene
+    }
+
+    pub fn scene_mut(&mut self) -> &mut SceneInstance {
+        &mut self.scene
+    }
+
+    pub const fn last_commit_stats(&self) -> HostCommitStats {
+        self.last_commit_stats
+    }
+
+    pub fn evaluate(&mut self, time: f64) -> Result<&FrameState, EvaluationError> {
+        self.scene.evaluate(time)
+    }
+
+    pub fn seek(&mut self, time: f64) -> Result<&FrameState, EvaluationError> {
+        self.scene.seek(time)
+    }
+
+    pub fn advance_to(&mut self, time: f64) -> Result<&FrameState, EvaluationError> {
+        self.scene.advance_to(time)
+    }
+
+    /// Capture one coherent host callback phase.
+    ///
+    /// `delta_time` is signed. Hosts that need Manim-style forward updater `dt`
+    /// can use normal forward playback; signed deltas keep seeks/reverse control
+    /// deterministic rather than silently fabricating elapsed time.
+    pub fn callback_frame(&mut self) -> HostCallbackFrame {
+        let frame = self.scene.frame();
+        let delta_time = frame.time - self.last_callback_time;
+        self.last_callback_time = frame.time;
+        let objects = self
+            .watched_dense_indices
+            .iter()
+            .map(|index| {
+                let object = &frame.objects[*index];
+                HostObjectFrameState {
+                    object: object.id,
+                    transform: object.transform,
+                    style: object.style,
+                    presence: frame.presences[*index],
+                    appearance: object.appearance,
+                    reveal: frame.reveals[*index],
+                    morph: frame.morphs[*index],
+                }
+            })
+            .collect();
+        HostCallbackFrame {
+            time: frame.time,
+            delta_time,
+            objects,
+            invocations: self.invocations.clone(),
+        }
+    }
+
+    /// Atomically commit one callback-phase mutation batch.
+    ///
+    /// Property-only batches are preflighted and applied in place through the
+    /// existing incremental runtime path. Higher-impact batches stage a cloned
+    /// runtime for atomicity. A runtime with native reactive state rejects those
+    /// higher-impact mutations until semantic graph revalidation/re-lowering is
+    /// available; silently retaining stale reactive dense targets is forbidden.
+    pub fn commit(
+        &mut self,
+        transaction: &MutationTransaction,
+    ) -> Result<&FrameState, HostCommitError> {
+        let impact = transaction.impact();
+        if transaction.is_empty() {
+            self.last_commit_stats = HostCommitStats::default();
+            return Ok(self.scene.frame());
+        }
+
+        if impact == Some(MutationImpact::Property) {
+            for patch in transaction.mutations() {
+                let object = match patch {
+                    ScenePatch::SetTransform { object, .. }
+                    | ScenePatch::SetStyle { object, .. } => *object,
+                    _ => unreachable!("property-impact transaction must contain property patches"),
+                };
+                if !self.scene.contains_object(object) {
+                    return Err(HostCommitError::Patch(CompilePatchError::UnknownObject(
+                        object,
+                    )));
+                }
+            }
+            for patch in transaction.mutations() {
+                self.scene
+                    .apply_patch(patch)
+                    .expect("property callback transaction was preflighted");
+            }
+            self.last_commit_stats = HostCommitStats {
+                mutations: transaction.mutations().len(),
+                impact,
+                staged: false,
+            };
+            return Ok(self.scene.frame());
+        }
+
+        if self.scene.reactive.is_some() {
+            return Err(HostCommitError::ReactiveReloweringRequired(
+                impact.expect("non-empty transaction has impact"),
+            ));
+        }
+
+        let mut staged = self.scene.clone();
+        for patch in transaction.mutations() {
+            staged.apply_patch(patch)?;
+        }
+        self.scene = staged;
+        self.last_commit_stats = HostCommitStats {
+            mutations: transaction.mutations().len(),
+            impact,
+            staged: true,
+        };
+        Ok(self.scene.frame())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use noon_compile::CompiledScene;
+    use noon_core::{
+        GeometryRef, MutationTransaction, ReactiveExpr, SceneDefinition, ScenePatch, SemanticScene,
+        Style, Vec2,
+    };
+
+    use super::*;
+
+    fn plain_scene(count: usize) -> (SceneInstance, Vec<ObjectId>) {
+        let mut definition = SceneDefinition::new();
+        let objects = (0..count)
+            .map(|_| definition.add(GeometryRef::circle(1.0)))
+            .collect::<Vec<_>>();
+        let compiled = CompiledScene::compile(&definition).expect("scene must compile");
+        (SceneInstance::new(compiled), objects)
+    }
+
+    #[test]
+    fn phase_snapshot_deduplicates_objects_shared_by_callbacks() {
+        let (scene, objects) = plain_scene(3);
+        let mut registry = HostCallbackRegistry::new();
+        let first = registry.register([objects[0], objects[1]]);
+        let second = registry.register([objects[1], objects[2]]);
+        let mut driven = HostDrivenScene::new(scene, &registry).unwrap();
+
+        let frame = driven.callback_frame();
+        assert_eq!(frame.objects.len(), 3);
+        assert_eq!(frame.invocations[0].callback, first);
+        assert_eq!(frame.invocations[0].object_indices, vec![0, 1]);
+        assert_eq!(frame.invocations[1].callback, second);
+        assert_eq!(frame.invocations[1].object_indices, vec![1, 2]);
+    }
+
+    #[test]
+    fn callback_delta_time_tracks_the_runtime_playhead_coherently() {
+        let (scene, objects) = plain_scene(1);
+        let mut registry = HostCallbackRegistry::new();
+        registry.register([objects[0]]);
+        let mut driven = HostDrivenScene::new(scene, &registry).unwrap();
+        assert_eq!(driven.callback_frame().delta_time, 0.0);
+        driven.advance_to(0.25).unwrap();
+        assert_eq!(driven.callback_frame().delta_time, 0.25);
+        driven.seek(0.1).unwrap();
+        assert!((driven.callback_frame().delta_time + 0.15).abs() < 1e-12);
+    }
+
+    #[test]
+    fn property_transaction_is_atomic_and_marks_only_changed_dense_object() {
+        let (mut scene, objects) = plain_scene(10_000);
+        scene.take_frame_changes();
+        let mut registry = HostCallbackRegistry::new();
+        registry.register([objects[9_999]]);
+        let mut driven = HostDrivenScene::new(scene, &registry).unwrap();
+
+        let transaction = MutationTransaction::from_mutations([ScenePatch::SetTransform {
+            object: objects[9_999],
+            transform: Transform2D {
+                translation: Vec2::new(3.0, -2.0),
+                ..Transform2D::IDENTITY
+            },
+        }]);
+        driven.commit(&transaction).unwrap();
+        assert_eq!(
+            driven.scene().frame().objects[9_999].transform.translation,
+            Vec2::new(3.0, -2.0)
+        );
+        assert_eq!(
+            driven.scene_mut().take_frame_changes().object_indices(),
+            &[9_999]
+        );
+        assert_eq!(
+            driven.last_commit_stats(),
+            HostCommitStats {
+                mutations: 1,
+                impact: Some(MutationImpact::Property),
+                staged: false,
+            }
+        );
+
+        let before = driven.scene().frame().objects[9_999].transform;
+        let invalid = MutationTransaction::from_mutations([
+            ScenePatch::SetTransform {
+                object: objects[9_999],
+                transform: Transform2D::IDENTITY,
+            },
+            ScenePatch::SetStyle {
+                object: ObjectId::new(999_999),
+                style: Style::default(),
+            },
+        ]);
+        assert!(matches!(
+            driven.commit(&invalid),
+            Err(HostCommitError::Patch(CompilePatchError::UnknownObject(_)))
+        ));
+        assert_eq!(driven.scene().frame().objects[9_999].transform, before);
+    }
+
+    #[test]
+    fn structural_transaction_stages_plain_runtime_and_rolls_back_on_failure() {
+        let (scene, objects) = plain_scene(2);
+        let mut driven = HostDrivenScene::new(scene, &HostCallbackRegistry::new()).unwrap();
+        let before = driven.scene().frame().clone();
+        let invalid = MutationTransaction::from_mutations([
+            ScenePatch::RemoveObject(objects[1]),
+            ScenePatch::RemoveObject(ObjectId::new(500)),
+        ]);
+        assert!(driven.commit(&invalid).is_err());
+        assert_eq!(driven.scene().frame(), &before);
+    }
+
+    #[test]
+    fn reactive_runtime_allows_property_callback_commits_but_rejects_structural_work() {
+        let mut semantic = SemanticScene::new();
+        let object = semantic.add(GeometryRef::circle(1.0));
+        let input = semantic.add_input(1.0_f32);
+        let derived = semantic.add_derived(ReactiveExpr::scalar(0.5));
+        semantic.bind(derived, object, noon_core::Property::Rotation);
+        let scene = SceneInstance::from_semantic(&semantic).unwrap();
+        let mut driven = HostDrivenScene::new(scene, &HostCallbackRegistry::new()).unwrap();
+
+        driven
+            .commit(&MutationTransaction::from_mutations([
+                ScenePatch::SetStyle {
+                    object,
+                    style: Style {
+                        opacity: 0.5,
+                        ..Style::default()
+                    },
+                },
+            ]))
+            .unwrap();
+        assert_eq!(driven.scene().frame().objects[0].style.opacity, 0.5);
+
+        let structure = MutationTransaction::from_mutations([ScenePatch::RemoveObject(object)]);
+        assert_eq!(
+            driven.commit(&structure),
+            Err(HostCommitError::ReactiveReloweringRequired(
+                MutationImpact::Structure
+            ))
+        );
+        assert_eq!(
+            driven.scene().reactive_value(input),
+            Some(&noon_core::ReactiveValue::Scalar(1.0))
+        );
+    }
+}

--- a/docs/host-callback-execution.md
+++ b/docs/host-callback-execution.md
@@ -1,0 +1,99 @@
+# Host callback execution
+
+## Purpose
+
+Noon supports arbitrary host-language behavior without putting Python or another host interpreter on the normal frame path. Host callbacks are an explicit third execution class beside static/timeline work and native reactive dependencies.
+
+The runtime protocol is frame/transaction oriented:
+
+```text
+runtime frame
+    |
+    +-- evaluate timeline/reactive state
+    |
+    v
+coherent callback frame
+    |
+    +-- time / signed delta time
+    +-- deduplicated watched-object table
+    +-- callback invocations referencing that table
+    |
+    v
+host callback phase
+    |
+    +-- arbitrary Python/JS/native code
+    |
+    v
+one MutationTransaction
+    |
+    v
+atomic runtime commit
+    |
+    +-- property work: incremental in-place path
+    +-- timeline/structure: staged commit when safe
+    +-- reactive re-lowering required rather than stale bindings
+    |
+    v
+render
+```
+
+The callback implementation itself is not serialized into Noon. `HostCallbackId` is a stable language-neutral handle used to associate a semantic callback slot with a host-owned callable.
+
+## Callback slots
+
+`HostCallbackRegistry` declares which callback slots participate and which semantic objects each slot needs to observe.
+
+A callback may watch zero or more objects. Empty object lists are useful for time/input-only handlers. Duplicate object subscriptions inside one slot are removed while preserving order.
+
+The runtime validates every watched object when `HostDrivenScene` is built and lowers semantic object IDs once. Unknown objects fail before playback.
+
+## Coherent frame snapshot
+
+`HostDrivenScene::callback_frame()` captures one phase-wide object table. If several callbacks watch the same object, its dynamic state appears only once. `HostCallbackInvocation` entries reference this table by compact indices.
+
+The frame-critical snapshot contains:
+
+- object ID;
+- transform;
+- style;
+- presence;
+- appearance;
+- reveal;
+- morph.
+
+Geometry is deliberately excluded. Large path geometry must not be cloned every frame just because an updater reads position/style. Stable geometry metadata or bounds can be exposed separately when the host API requires them.
+
+`delta_time` is signed. Normal forward playback produces positive updater `dt`; seeks/reverse control remain deterministic instead of fabricating elapsed time.
+
+## Mutation commit
+
+Host code returns one existing `MutationTransaction` for the callback phase.
+
+### Property-only transactions
+
+`SetTransform` and `SetStyle` transactions are preflighted as a batch, then applied through the existing incremental runtime path. They do not clone the complete scene. A later invalid object causes the whole transaction to fail before any mutation is visible.
+
+Changed objects flow through normal `FrameChanges`, so renderer preparation remains localized.
+
+### Timeline/structural transactions
+
+For non-reactive runtime instances, higher-impact transactions currently stage a cloned runtime and swap only after all patches succeed. This provides correct atomic behavior while specialized incremental paths are developed.
+
+For runtime instances carrying native reactive state, timeline/structural host mutations currently return `ReactiveReloweringRequired`. Such changes can invalidate object indices, driver ownership, or reactive bindings; keeping old dense targets would be incorrect. A later semantic re-lowering transaction will close this gap.
+
+## Performance contract
+
+Host callbacks must not turn unrelated content into host-dynamic work.
+
+The runtime lowers callback watched-object sets once, snapshots only their union, and applies property mutation batches only to affected dense objects. CI includes a large static-scene regression demonstrating that one callback property mutation reports only the single changed object.
+
+The language bridge should cross once per callback phase rather than once per getter/setter. Python wrappers should read from the coherent callback snapshot locally, record mutations locally, and submit one transaction at phase end.
+
+## Next slices
+
+1. Serialize/transport host callback slot declarations with the semantic scene.
+2. Expose a browser callback-phase request/commit API around `ReactiveCanvasPlayer`/`ReactiveScenePlayer`.
+3. Add Python `Mobject.add_updater`, `remove_updater`, and `clear_updaters` using snapshot-backed proxy reads and batched mutation recording.
+4. Add native pointer/keyboard/viewport signals so common interaction can bypass host callbacks.
+5. Implement semantic reactive re-lowering for structural/timeline callback transactions.
+6. Add `always_redraw` and native-lowering recognition for common updater patterns where semantics are known.


### PR DESCRIPTION
## Summary

- add stable language-neutral `HostCallbackId`, callback slots, and registry semantics
- add `HostDrivenScene` around `SceneInstance`
- capture one coherent callback phase with a deduplicated watched-object table
- make callback invocations reference that shared table by compact indices
- accept one existing `MutationTransaction` per callback phase
- keep property-only callback commits incremental/in-place and atomic
- stage higher-impact commits for plain runtime instances
- explicitly reject timeline/structural callback commits on reactive instances until semantic re-lowering exists
- add locality, atomicity, dt, and reactive-safety tests
- document the intended Python/JS bridge protocol

## Architectural intent

This is the execution foundation for arbitrary `add_updater`/event callbacks. No host callable is put into the core/runtime. Language bindings will own callables keyed by callback IDs, read one coherent snapshot locally, record mutations locally, and cross the bridge once per callback phase instead of once per property getter/setter.