### PR TITLE
Add differential ManimCE semantic compatibility gate

### DIFF
--- a/.github/workflows/manim-differential.yml
+++ b/.github/workflows/manim-differential.yml
@@ -23,7 +23,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-          cache: pip
 
       - name: Install Manim system dependencies
         run: |

--- a/.github/workflows/manim-differential.yml
+++ b/.github/workflows/manim-differential.yml
@@ -1,0 +1,41 @@
+name: Manim differential
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: manim-differential-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  semantics:
+    name: ManimCE 0.21.0 semantics
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install Manim system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            ffmpeg \
+            libcairo2-dev \
+            libpango1.0-dev \
+            pkg-config
+
+      - name: Install pinned ManimCE reference
+        run: python -m pip install --disable-pip-version-check "manim==0.21.0"
+
+      - name: Compare supported Noon semantics with ManimCE
+        run: python scripts/manim-differential.py

--- a/docs/manim-differential-testing.md
+++ b/docs/manim-differential-testing.md
@@ -1,0 +1,62 @@
+# ManimCE differential testing
+
+Noon's internal cross-language parity tests answer a necessary but insufficient
+question: do the Rust and Python frontends agree with each other? They do not
+prove that either frontend agrees with ManimCE.
+
+`scripts/manim-differential.py` adds a second, independent compatibility gate.
+It executes equivalent renderer-independent operations through Noon and a
+pinned ManimCE installation and compares normalized semantic observations.
+The CI reference is intentionally pinned to **ManimCE 0.21.0**; changing that
+version is a compatibility-target decision, not a routine dependency upgrade.
+
+## What belongs in the differential suite
+
+Prefer small semantic probes with useful structural diffs:
+
+- object center, width, and height;
+- layout operations such as `next_to`, `align_to`, `to_edge`, and `arrange`;
+- family membership/order and z ordering once the authoritative semantic store
+  exposes them;
+- fill/stroke/style observables;
+- animation timing, lifecycle, and state sampled at selected times;
+- updater/tracker state when the corresponding execution semantics are stable.
+
+Raster comparisons remain valuable, but only for behavior whose correctness
+cannot be expressed structurally. The existing browser rendering tests remain
+responsible for renderer output.
+
+## Supported versus unsupported
+
+A missing feature is not the same thing as a wrong implementation. The harness
+therefore has an explicit `UNSUPPORTED` registry. A semantic area moves from
+that registry into `FIXTURES` when Noon claims to support it. From that point,
+a mismatch is a CI failure.
+
+This rule is particularly important during the architecture reset: it lets the
+suite document gaps without normalizing Noon's current behavior as the Manim
+specification.
+
+## Running locally
+
+Install the same Manim version used by CI and run:
+
+```sh
+python scripts/manim-differential.py
+```
+
+For machine-readable output:
+
+```sh
+python scripts/manim-differential.py --json
+```
+
+Linux systems need Manim's Cairo/Pango/FFmpeg dependencies; the dedicated
+GitHub Actions workflow documents the exact CI setup.
+
+## Expansion policy
+
+Every architecture or compatibility PR should add a focused differential
+fixture when it claims new Manim-compatible semantics. Keep probes small enough
+that a failure identifies the semantic difference directly rather than merely
+reporting that a large demo scene changed.

--- a/scripts/manim-differential.py
+++ b/scripts/manim-differential.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Differential semantic probes against a pinned ManimCE reference.
+
+This suite intentionally compares small, renderer-independent observables.  It is
+not a screenshot test and it does not require constructing a Manim Scene.  Each
+fixture runs the equivalent operation through Noon and ManimCE, normalizes the
+result to JSON-like data, and reports a structural diff on mismatch.
+
+Add new probes only for behavior Noon claims to support.  Unsupported behavior
+belongs in ``UNSUPPORTED`` below until an implementation PR promotes it to a
+gated fixture.  That distinction prevents the compatibility suite from turning
+missing API surface into an accidental semantic specification.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WEB_PYTHON = REPO_ROOT / "web" / "python"
+if str(WEB_PYTHON) not in sys.path:
+    sys.path.insert(0, str(WEB_PYTHON))
+
+# Import Noon before Manim so the local module is unambiguous.
+import noon as noon  # noqa: E402
+
+try:
+    import manim as manim  # noqa: E402
+except ImportError as exc:  # pragma: no cover - exercised by the CI environment
+    raise SystemExit(
+        "ManimCE is required for the differential suite. "
+        "Install the version pinned by .github/workflows/manim-differential.yml."
+    ) from exc
+
+PINNED_MANIM_VERSION = "0.21.0"
+
+
+@dataclass(frozen=True)
+class Fixture:
+    name: str
+    noon_probe: Callable[[], Any]
+    manim_probe: Callable[[], Any]
+    tolerance: float = 1e-6
+
+
+def _round_float(value: float) -> float:
+    value = float(value)
+    if abs(value) < 1e-12:
+        return 0.0
+    return value
+
+
+def _object_observation(obj: Any) -> dict[str, Any]:
+    center = obj.get_center()
+    return {
+        "center": [_round_float(center[0]), _round_float(center[1])],
+        "width": _round_float(obj.width),
+        "height": _round_float(obj.height),
+    }
+
+
+def _members_observation(group: Any) -> dict[str, Any]:
+    members = list(group.submobjects)
+    center = group.get_center()
+    return {
+        "center": [_round_float(center[0]), _round_float(center[1])],
+        "members": [_object_observation(member) for member in members],
+    }
+
+
+def _noon_circle_dimensions() -> Any:
+    return _object_observation(noon.Circle(radius=0.75))
+
+
+def _manim_circle_dimensions() -> Any:
+    return _object_observation(manim.Circle(radius=0.75))
+
+
+def _noon_rectangle_dimensions() -> Any:
+    return _object_observation(noon.Rectangle(width=3.0, height=1.25))
+
+
+def _manim_rectangle_dimensions() -> Any:
+    return _object_observation(manim.Rectangle(width=3.0, height=1.25))
+
+
+def _noon_shifted_circle() -> Any:
+    obj = noon.Circle(radius=0.5).shift(noon.RIGHT * 2.25 + noon.UP * 1.5)
+    return _object_observation(obj)
+
+
+def _manim_shifted_circle() -> Any:
+    obj = manim.Circle(radius=0.5).shift(manim.RIGHT * 2.25 + manim.UP * 1.5)
+    return _object_observation(obj)
+
+
+def _noon_moved_rectangle() -> Any:
+    obj = noon.Rectangle(width=2.0, height=0.75).move_to(noon.LEFT * 1.75 + noon.DOWN * 0.6)
+    return _object_observation(obj)
+
+
+def _manim_moved_rectangle() -> Any:
+    obj = manim.Rectangle(width=2.0, height=0.75).move_to(manim.LEFT * 1.75 + manim.DOWN * 0.6)
+    return _object_observation(obj)
+
+
+def _noon_scaled_square() -> Any:
+    obj = noon.Square(side_length=1.2).scale(1.75)
+    return _object_observation(obj)
+
+
+def _manim_scaled_square() -> Any:
+    obj = manim.Square(side_length=1.2).scale(1.75)
+    return _object_observation(obj)
+
+
+def _noon_rotated_rectangle() -> Any:
+    obj = noon.Rectangle(width=3.0, height=1.0).rotate(math.pi / 2.0)
+    return _object_observation(obj)
+
+
+def _manim_rotated_rectangle() -> Any:
+    obj = manim.Rectangle(width=3.0, height=1.0).rotate(math.pi / 2.0)
+    return _object_observation(obj)
+
+
+def _noon_next_to() -> Any:
+    left = noon.Circle(radius=0.6).shift(noon.LEFT * 1.0)
+    right = noon.Square(side_length=0.8).next_to(left, noon.RIGHT, buff=0.3)
+    return {"left": _object_observation(left), "right": _object_observation(right)}
+
+
+def _manim_next_to() -> Any:
+    left = manim.Circle(radius=0.6).shift(manim.LEFT * 1.0)
+    right = manim.Square(side_length=0.8).next_to(left, manim.RIGHT, buff=0.3)
+    return {"left": _object_observation(left), "right": _object_observation(right)}
+
+
+def _noon_align_to_top() -> Any:
+    target = noon.Rectangle(width=2.0, height=1.5).shift(noon.RIGHT * 0.8 + noon.UP * 0.5)
+    obj = noon.Circle(radius=0.4).shift(noon.LEFT * 2.0).align_to(target, noon.UP)
+    return {"target": _object_observation(target), "object": _object_observation(obj)}
+
+
+def _manim_align_to_top() -> Any:
+    target = manim.Rectangle(width=2.0, height=1.5).shift(manim.RIGHT * 0.8 + manim.UP * 0.5)
+    obj = manim.Circle(radius=0.4).shift(manim.LEFT * 2.0).align_to(target, manim.UP)
+    return {"target": _object_observation(target), "object": _object_observation(obj)}
+
+
+def _noon_to_edge() -> Any:
+    obj = noon.Square(side_length=1.0).to_edge(noon.LEFT, buff=0.4)
+    return _object_observation(obj)
+
+
+def _manim_to_edge() -> Any:
+    obj = manim.Square(side_length=1.0).to_edge(manim.LEFT, buff=0.4)
+    return _object_observation(obj)
+
+
+def _noon_to_corner() -> Any:
+    obj = noon.Circle(radius=0.5).to_corner(noon.UR, buff=0.25)
+    return _object_observation(obj)
+
+
+def _manim_to_corner() -> Any:
+    obj = manim.Circle(radius=0.5).to_corner(manim.UR, buff=0.25)
+    return _object_observation(obj)
+
+
+def _noon_arrange() -> Any:
+    group = noon.VGroup(
+        noon.Circle(radius=0.25),
+        noon.Square(side_length=0.6),
+        noon.Rectangle(width=0.8, height=0.4),
+    ).arrange(noon.RIGHT, buff=0.2)
+    return _members_observation(group)
+
+
+def _manim_arrange() -> Any:
+    group = manim.VGroup(
+        manim.Circle(radius=0.25),
+        manim.Square(side_length=0.6),
+        manim.Rectangle(width=0.8, height=0.4),
+    ).arrange(manim.RIGHT, buff=0.2)
+    return _members_observation(group)
+
+
+FIXTURES = [
+    Fixture("circle_dimensions", _noon_circle_dimensions, _manim_circle_dimensions),
+    Fixture("rectangle_dimensions", _noon_rectangle_dimensions, _manim_rectangle_dimensions),
+    Fixture("shifted_circle", _noon_shifted_circle, _manim_shifted_circle),
+    Fixture("moved_rectangle", _noon_moved_rectangle, _manim_moved_rectangle),
+    Fixture("scaled_square", _noon_scaled_square, _manim_scaled_square),
+    Fixture("rotated_rectangle", _noon_rotated_rectangle, _manim_rotated_rectangle),
+    Fixture("next_to", _noon_next_to, _manim_next_to),
+    Fixture("align_to_top", _noon_align_to_top, _manim_align_to_top),
+    Fixture("to_edge", _noon_to_edge, _manim_to_edge),
+    Fixture("to_corner", _noon_to_corner, _manim_to_corner),
+    Fixture("vgroup_arrange", _noon_arrange, _manim_arrange),
+]
+
+# Explicitly tracked but not yet differential-gated.  Keep this list close to the
+# harness so unsupported behavior is never silently treated as a mismatch.
+UNSUPPORTED = {
+    "family_aliasing": "Noon does not yet retain semantic family/alias relationships (#51)",
+    "z_index": "Noon does not yet expose the 2.5D/z semantic model (#62)",
+    "updater_frame_semantics": "host/native updater phase semantics are being defined in #56",
+    "animation_lifecycle": "requires a reference Scene/animation-state probe, to be added incrementally",
+    "stroke_scaling": "semantic stroke-width/scaling mode is being defined in #62",
+}
+
+
+def _compare(expected: Any, actual: Any, tolerance: float, path: str = "$") -> list[str]:
+    errors: list[str] = []
+    if isinstance(expected, bool) or isinstance(actual, bool):
+        if expected != actual:
+            errors.append(f"{path}: Noon={expected!r}, Manim={actual!r}")
+        return errors
+    if isinstance(expected, (int, float)) and isinstance(actual, (int, float)):
+        if not math.isclose(float(expected), float(actual), rel_tol=tolerance, abs_tol=tolerance):
+            errors.append(f"{path}: Noon={expected!r}, Manim={actual!r}")
+        return errors
+    if isinstance(expected, dict) and isinstance(actual, dict):
+        if expected.keys() != actual.keys():
+            errors.append(
+                f"{path}: key mismatch Noon={sorted(expected.keys())}, Manim={sorted(actual.keys())}"
+            )
+            return errors
+        for key in expected:
+            errors.extend(_compare(expected[key], actual[key], tolerance, f"{path}.{key}"))
+        return errors
+    if isinstance(expected, (list, tuple)) and isinstance(actual, (list, tuple)):
+        if len(expected) != len(actual):
+            errors.append(f"{path}: length mismatch Noon={len(expected)}, Manim={len(actual)}")
+            return errors
+        for index, (lhs, rhs) in enumerate(zip(expected, actual)):
+            errors.extend(_compare(lhs, rhs, tolerance, f"{path}[{index}]"))
+        return errors
+    if expected != actual:
+        errors.append(f"{path}: Noon={expected!r}, Manim={actual!r}")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--json", action="store_true", help="emit machine-readable results")
+    args = parser.parse_args()
+
+    if manim.__version__ != PINNED_MANIM_VERSION:
+        raise SystemExit(
+            f"expected ManimCE {PINNED_MANIM_VERSION}, found {manim.__version__}; "
+            "update the pin and compatibility target intentionally"
+        )
+
+    results: list[dict[str, Any]] = []
+    failures = 0
+    for fixture in FIXTURES:
+        noon_value = fixture.noon_probe()
+        manim_value = fixture.manim_probe()
+        differences = _compare(noon_value, manim_value, fixture.tolerance)
+        status = "pass" if not differences else "mismatch"
+        failures += bool(differences)
+        results.append(
+            {
+                "fixture": fixture.name,
+                "status": status,
+                "noon": noon_value,
+                "manim": manim_value,
+                "differences": differences,
+            }
+        )
+
+    payload = {
+        "manim_version": manim.__version__,
+        "fixtures": results,
+        "unsupported": UNSUPPORTED,
+    }
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        for result in results:
+            marker = "PASS" if result["status"] == "pass" else "FAIL"
+            print(f"[{marker}] {result['fixture']}")
+            for difference in result["differences"]:
+                print(f"  {difference}")
+        print(f"\n{len(FIXTURES) - failures}/{len(FIXTURES)} supported fixtures match ManimCE {manim.__version__}")
+        if UNSUPPORTED:
+            print(f"{len(UNSUPPORTED)} explicitly unsupported/deferred semantic areas")
+
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a pinned ManimCE 0.21.0 differential semantic harness
- compare 11 supported renderer-independent geometry/layout behaviors with structural diffs
- keep unsupported/deferred semantic areas explicit rather than accepting Noon behavior as reference behavior
- add an independent GitHub Actions compatibility lane and documentation

This is intentionally isolated from the existing browser Manim-style smoke suite: that suite validates Noon's own frontend lowering, while this PR validates supported semantics against ManimCE itself.

Tracks #57.
Part of #68 Wave 1.