### PR TITLE
Define host callback realtime, phase, deadline, and seek semantics

### DIFF
--- a/crates/noon-core/src/reactive.rs
+++ b/crates/noon-core/src/reactive.rs
@@ -10,6 +10,9 @@ pub use composition::*;
 mod host_callbacks;
 pub use host_callbacks::*;
 
+mod host_semantics;
+pub use host_semantics::*;
+
 #[path = "lifecycle.rs"]
 mod lifecycle;
 pub use lifecycle::*;

--- a/crates/noon-core/src/reactive/host_semantics.rs
+++ b/crates/noon-core/src/reactive/host_semantics.rs
@@ -1,0 +1,183 @@
+use serde::{Deserialize, Serialize};
+
+/// Ordered phases for one evaluated frame.
+///
+/// The order is semantic, not an implementation suggestion. A backend may fuse
+/// phases internally, but observable writes must be equivalent to this sequence.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FrameExecutionPhase {
+    Timeline,
+    NativeDynamic,
+    HostCallbacks,
+    DerivedState,
+    Render,
+}
+
+impl FrameExecutionPhase {
+    pub const ORDERED: [Self; 5] = [
+        Self::Timeline,
+        Self::NativeDynamic,
+        Self::HostCallbacks,
+        Self::DerivedState,
+        Self::Render,
+    ];
+}
+
+/// Property-producing phases that may intentionally target the same property.
+///
+/// Noon uses ordered composition rather than rejecting the scene globally. The
+/// later phase sees the value produced by the earlier phase and wins when both
+/// phases write the same property in one frame.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DynamicDriverPhase {
+    Timeline,
+    NativeDynamic,
+    HostCallbacks,
+}
+
+impl DynamicDriverPhase {
+    pub const ORDERED: [Self; 3] = [Self::Timeline, Self::NativeDynamic, Self::HostCallbacks];
+
+    pub const fn precedence(self) -> u8 {
+        match self {
+            Self::Timeline => 0,
+            Self::NativeDynamic => 1,
+            Self::HostCallbacks => 2,
+        }
+    }
+
+    pub const fn overrides(self, other: Self) -> bool {
+        self.precedence() >= other.precedence()
+    }
+}
+
+/// How much execution history a host callback needs for an exact seek.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HostCallbackReplayClass {
+    /// Output is a pure function of the coherent current-frame input state.
+    Pure,
+    /// The callback owns deterministic state that can be restored from an engine
+    /// checkpoint and replayed forward.
+    StatefulDeterministic,
+    /// The callback may depend on opaque Python/JS state, I/O, randomness, wall
+    /// time, or other state the engine cannot checkpoint safely.
+    #[default]
+    Opaque,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HostSeekMode {
+    Direct,
+    ReplayFromCheckpoint,
+    ReplayFromInitialization,
+}
+
+impl HostCallbackReplayClass {
+    pub const fn seek_mode(self) -> HostSeekMode {
+        match self {
+            Self::Pure => HostSeekMode::Direct,
+            Self::StatefulDeterministic => HostSeekMode::ReplayFromCheckpoint,
+            Self::Opaque => HostSeekMode::ReplayFromInitialization,
+        }
+    }
+}
+
+/// Whether presentation is allowed to wait for arbitrary host-language code.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HostPlaybackMode {
+    /// Presentation is deadline-driven. Missed callbacks may commit later, but
+    /// they must not synchronously stall the presenter.
+    #[default]
+    Realtime,
+    /// Deterministic/offline evaluation prioritizes exact same-frame host results
+    /// and therefore waits for the callback phase to complete.
+    DeterministicOffline,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HostFrameDisposition {
+    PresentLatestCommitted,
+    WaitForHostCommit,
+}
+
+impl HostPlaybackMode {
+    pub const fn frame_disposition(self) -> HostFrameDisposition {
+        match self {
+            Self::Realtime => HostFrameDisposition::PresentLatestCommitted,
+            Self::DeterministicOffline => HostFrameDisposition::WaitForHostCommit,
+        }
+    }
+}
+
+/// Read semantics available to an arbitrary host callback.
+///
+/// Snapshot-only execution remains useful for traced/declared callbacks, but it
+/// is not sufficient for unrestricted Manim-style Python because a closure may
+/// synchronously inspect any object/tracker/global reachable from Python.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HostReadModel {
+    DeclaredSnapshot,
+    #[default]
+    EngineLocalSemanticView,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn execution_phase_order_is_explicit_and_stable() {
+        assert_eq!(
+            FrameExecutionPhase::ORDERED,
+            [
+                FrameExecutionPhase::Timeline,
+                FrameExecutionPhase::NativeDynamic,
+                FrameExecutionPhase::HostCallbacks,
+                FrameExecutionPhase::DerivedState,
+                FrameExecutionPhase::Render,
+            ]
+        );
+    }
+
+    #[test]
+    fn later_dynamic_phase_overrides_earlier_phase() {
+        assert!(DynamicDriverPhase::HostCallbacks.overrides(DynamicDriverPhase::NativeDynamic));
+        assert!(DynamicDriverPhase::NativeDynamic.overrides(DynamicDriverPhase::Timeline));
+        assert!(!DynamicDriverPhase::Timeline.overrides(DynamicDriverPhase::HostCallbacks));
+    }
+
+    #[test]
+    fn replay_class_maps_to_exact_seek_requirement() {
+        assert_eq!(
+            HostCallbackReplayClass::Pure.seek_mode(),
+            HostSeekMode::Direct
+        );
+        assert_eq!(
+            HostCallbackReplayClass::StatefulDeterministic.seek_mode(),
+            HostSeekMode::ReplayFromCheckpoint
+        );
+        assert_eq!(
+            HostCallbackReplayClass::Opaque.seek_mode(),
+            HostSeekMode::ReplayFromInitialization
+        );
+    }
+
+    #[test]
+    fn realtime_never_requires_presentation_to_wait_for_host() {
+        assert_eq!(
+            HostPlaybackMode::Realtime.frame_disposition(),
+            HostFrameDisposition::PresentLatestCommitted
+        );
+        assert_eq!(
+            HostPlaybackMode::DeterministicOffline.frame_disposition(),
+            HostFrameDisposition::WaitForHostCommit
+        );
+    }
+}

--- a/crates/noon-runtime/src/reactive.rs
+++ b/crates/noon-runtime/src/reactive.rs
@@ -3,6 +3,9 @@ include!("reactive_impl.rs");
 mod host_callbacks;
 pub use host_callbacks::*;
 
+mod host_policy;
+pub use host_policy::*;
+
 mod signal_timeline;
 pub use signal_timeline::*;
 

--- a/crates/noon-runtime/src/reactive/host_policy.rs
+++ b/crates/noon-runtime/src/reactive/host_policy.rs
@@ -1,0 +1,256 @@
+use std::collections::BTreeMap;
+
+use noon_core::{
+    HostCallbackId, HostCallbackReplayClass, HostFrameDisposition, HostPlaybackMode, HostSeekMode,
+};
+
+/// Runtime policy for arbitrary host-language callback execution.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct HostExecutionPolicy {
+    pub playback_mode: HostPlaybackMode,
+    /// Presentation budget assigned to the whole host callback phase.
+    /// `None` disables deadline accounting (useful for offline evaluation).
+    pub frame_budget_ms: Option<f64>,
+}
+
+impl HostExecutionPolicy {
+    pub const REALTIME_60HZ: Self = Self {
+        playback_mode: HostPlaybackMode::Realtime,
+        frame_budget_ms: Some(1000.0 / 60.0),
+    };
+
+    pub const REALTIME_120HZ: Self = Self {
+        playback_mode: HostPlaybackMode::Realtime,
+        frame_budget_ms: Some(1000.0 / 120.0),
+    };
+
+    pub const OFFLINE_DETERMINISTIC: Self = Self {
+        playback_mode: HostPlaybackMode::DeterministicOffline,
+        frame_budget_ms: None,
+    };
+
+    pub const fn disposition(self) -> HostFrameDisposition {
+        self.playback_mode.frame_disposition()
+    }
+}
+
+impl Default for HostExecutionPolicy {
+    fn default() -> Self {
+        Self::REALTIME_60HZ
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct HostCallbackTimingStats {
+    pub calls: u64,
+    pub total_ms: f64,
+    pub last_ms: f64,
+    pub max_ms: f64,
+}
+
+impl HostCallbackTimingStats {
+    pub fn average_ms(self) -> f64 {
+        if self.calls == 0 {
+            0.0
+        } else {
+            self.total_ms / self.calls as f64
+        }
+    }
+
+    fn record(&mut self, elapsed_ms: f64) {
+        self.calls = self.calls.saturating_add(1);
+        self.total_ms += elapsed_ms;
+        self.last_ms = elapsed_ms;
+        self.max_ms = self.max_ms.max(elapsed_ms);
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct HostPhaseReport {
+    pub elapsed_ms: f64,
+    pub deadline_missed: bool,
+    pub missed_deadlines: u64,
+    pub disposition: HostFrameDisposition,
+    pub exact_seek_mode: HostSeekMode,
+}
+
+/// Metrics and semantic classification for the host compatibility slow path.
+///
+/// The host owns actual Python/JS invocation and reports measured durations here.
+/// Keeping the profiler independent of a particular worker transport lets native,
+/// browser, and test hosts share the same deadline/seek contract.
+#[derive(Clone, Debug)]
+pub struct HostCallbackProfiler {
+    policy: HostExecutionPolicy,
+    replay_classes: BTreeMap<HostCallbackId, HostCallbackReplayClass>,
+    callback_timings: BTreeMap<HostCallbackId, HostCallbackTimingStats>,
+    phases: u64,
+    missed_deadlines: u64,
+    last_phase_ms: f64,
+    max_phase_ms: f64,
+}
+
+impl HostCallbackProfiler {
+    pub fn new(policy: HostExecutionPolicy) -> Self {
+        Self {
+            policy,
+            replay_classes: BTreeMap::new(),
+            callback_timings: BTreeMap::new(),
+            phases: 0,
+            missed_deadlines: 0,
+            last_phase_ms: 0.0,
+            max_phase_ms: 0.0,
+        }
+    }
+
+    pub const fn policy(&self) -> HostExecutionPolicy {
+        self.policy
+    }
+
+    pub fn set_policy(&mut self, policy: HostExecutionPolicy) {
+        self.policy = policy;
+    }
+
+    pub fn classify_callback(
+        &mut self,
+        callback: HostCallbackId,
+        replay_class: HostCallbackReplayClass,
+    ) {
+        self.replay_classes.insert(callback, replay_class);
+    }
+
+    pub fn record_callback(&mut self, callback: HostCallbackId, elapsed_ms: f64) {
+        assert!(
+            elapsed_ms.is_finite() && elapsed_ms >= 0.0,
+            "callback duration must be finite and non-negative"
+        );
+        self.callback_timings
+            .entry(callback)
+            .or_default()
+            .record(elapsed_ms);
+    }
+
+    pub fn record_phase(&mut self, elapsed_ms: f64) -> HostPhaseReport {
+        assert!(
+            elapsed_ms.is_finite() && elapsed_ms >= 0.0,
+            "host phase duration must be finite and non-negative"
+        );
+        self.phases = self.phases.saturating_add(1);
+        self.last_phase_ms = elapsed_ms;
+        self.max_phase_ms = self.max_phase_ms.max(elapsed_ms);
+        let deadline_missed = self
+            .policy
+            .frame_budget_ms
+            .is_some_and(|budget| elapsed_ms > budget);
+        if deadline_missed {
+            self.missed_deadlines = self.missed_deadlines.saturating_add(1);
+        }
+        HostPhaseReport {
+            elapsed_ms,
+            deadline_missed,
+            missed_deadlines: self.missed_deadlines,
+            disposition: self.policy.disposition(),
+            exact_seek_mode: self.exact_seek_mode(),
+        }
+    }
+
+    pub fn callback_timing(&self, callback: HostCallbackId) -> Option<HostCallbackTimingStats> {
+        self.callback_timings.get(&callback).copied()
+    }
+
+    pub fn phases(&self) -> u64 {
+        self.phases
+    }
+
+    pub fn missed_deadlines(&self) -> u64 {
+        self.missed_deadlines
+    }
+
+    pub fn last_phase_ms(&self) -> f64 {
+        self.last_phase_ms
+    }
+
+    pub fn max_phase_ms(&self) -> f64 {
+        self.max_phase_ms
+    }
+
+    /// Exact scene seek must satisfy the least-seekable registered callback.
+    pub fn exact_seek_mode(&self) -> HostSeekMode {
+        self.replay_classes
+            .values()
+            .copied()
+            .map(HostCallbackReplayClass::seek_mode)
+            .max_by_key(|mode| match mode {
+                HostSeekMode::Direct => 0,
+                HostSeekMode::ReplayFromCheckpoint => 1,
+                HostSeekMode::ReplayFromInitialization => 2,
+            })
+            .unwrap_or(HostSeekMode::Direct)
+    }
+}
+
+impl Default for HostCallbackProfiler {
+    fn default() -> Self {
+        Self::new(HostExecutionPolicy::default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn realtime_deadline_miss_never_changes_to_waiting_policy() {
+        let mut profiler = HostCallbackProfiler::new(HostExecutionPolicy {
+            playback_mode: HostPlaybackMode::Realtime,
+            frame_budget_ms: Some(8.0),
+        });
+        let report = profiler.record_phase(12.5);
+        assert!(report.deadline_missed);
+        assert_eq!(report.missed_deadlines, 1);
+        assert_eq!(
+            report.disposition,
+            HostFrameDisposition::PresentLatestCommitted
+        );
+    }
+
+    #[test]
+    fn offline_mode_waits_without_deadline_accounting() {
+        let mut profiler = HostCallbackProfiler::new(HostExecutionPolicy::OFFLINE_DETERMINISTIC);
+        let report = profiler.record_phase(250.0);
+        assert!(!report.deadline_missed);
+        assert_eq!(report.disposition, HostFrameDisposition::WaitForHostCommit);
+    }
+
+    #[test]
+    fn exact_seek_mode_uses_least_seekable_callback() {
+        let mut profiler = HostCallbackProfiler::default();
+        profiler.classify_callback(HostCallbackId::new(1), HostCallbackReplayClass::Pure);
+        profiler.classify_callback(
+            HostCallbackId::new(2),
+            HostCallbackReplayClass::StatefulDeterministic,
+        );
+        assert_eq!(
+            profiler.exact_seek_mode(),
+            HostSeekMode::ReplayFromCheckpoint
+        );
+        profiler.classify_callback(HostCallbackId::new(3), HostCallbackReplayClass::Opaque);
+        assert_eq!(
+            profiler.exact_seek_mode(),
+            HostSeekMode::ReplayFromInitialization
+        );
+    }
+
+    #[test]
+    fn callback_costs_are_reported_per_slot() {
+        let mut profiler = HostCallbackProfiler::default();
+        let id = HostCallbackId::new(9);
+        profiler.record_callback(id, 2.0);
+        profiler.record_callback(id, 4.0);
+        let stats = profiler.callback_timing(id).unwrap();
+        assert_eq!(stats.calls, 2);
+        assert_eq!(stats.last_ms, 4.0);
+        assert_eq!(stats.max_ms, 4.0);
+        assert_eq!(stats.average_ms(), 3.0);
+    }
+}

--- a/docs/host-callback-semantics.md
+++ b/docs/host-callback-semantics.md
@@ -1,0 +1,110 @@
+# Host callback execution semantics
+
+Arbitrary Python/JavaScript callbacks are a compatibility path, not part of
+Noon's native frame-critical execution model. They may inspect opaque host state,
+perform untraceable control flow, or take longer than a presentation deadline.
+The engine therefore makes their semantics explicit instead of pretending that
+all three of the following can be guaranteed simultaneously:
+
+1. unrestricted arbitrary host code;
+2. exact same-frame blocking behavior;
+3. guaranteed realtime presentation deadlines.
+
+## Ordered frame phases
+
+Observable evaluation is equivalent to:
+
+```text
+timeline
+  -> native dynamic/reactive
+  -> host callbacks
+  -> derived state (bounds/culling/hit-test inputs)
+  -> render/present
+```
+
+Backends may fuse internal work, but they must preserve this ordering. If more
+than one dynamic phase writes the same property, **later phase wins** and sees
+the value produced by the earlier phase. A timeline animation plus a native
+updater is therefore not intrinsically invalid; nor is a host callback layered
+on top of both. This replaces a global "one driver per property" restriction
+with deterministic phase composition.
+
+The language-neutral enums live in
+`noon_core::{FrameExecutionPhase, DynamicDriverPhase}`.
+
+## Realtime versus deterministic/offline playback
+
+`HostPlaybackMode::Realtime` is presentation-deadline driven. The presenter is
+never required to synchronously wait for arbitrary host code. If a callback
+misses its budget, the render side presents the **latest committed state** and a
+later completed host transaction may become visible on a subsequent frame.
+Missed deadlines are observable profiler events, not silent stalls.
+
+`HostPlaybackMode::DeterministicOffline` prioritizes exact evaluated output and
+waits for the host callback phase to commit before the corresponding frame is
+accepted. This is the mode for deterministic export/reference validation when a
+scene contains arbitrary host callbacks.
+
+The browser worker split in #60 must implement this contract; it must not make
+the renderer synchronously dependent on Pyodide in realtime mode.
+
+## Callback reads
+
+A declared snapshot is an optimization, not a complete semantic model for
+arbitrary Python. A Python closure may synchronously read a different mobject,
+a tracker, or other engine-owned state that was not declared when the callback
+was registered.
+
+Two read models are therefore explicit:
+
+- `DeclaredSnapshot`: sufficient for constrained/traced callbacks whose reads
+  are known ahead of time;
+- `EngineLocalSemanticView`: required for unrestricted callbacks. The host
+  runtime and authoritative engine state must be colocated closely enough that
+  getters do not become per-property cross-worker round trips.
+
+The existing deduplicated callback snapshot remains useful as a fast transport
+for declared state; it is not treated as proof that arbitrary callbacks are
+snapshot-complete.
+
+## Seek/replay classes
+
+Every arbitrary callback belongs to one of three semantic classes:
+
+| Replay class | Exact seek requirement |
+| --- | --- |
+| `Pure` | direct evaluation at the destination |
+| `StatefulDeterministic` | restore a compatible checkpoint and replay forward |
+| `Opaque` | replay from initialization unless the host provides a stronger contract |
+
+`Opaque` is the safe default. Closure state, randomness, wall time, external I/O,
+or other state not owned by Noon cannot be reconstructed from a scene-state
+snapshot alone.
+
+A whole scene's exact seek mode is the least-seekable active callback. The
+runtime `HostCallbackProfiler` exposes that result so editor/profiler UI can tell
+the user whether a seek is direct, checkpoint replay, or initialization replay.
+
+## Deadline and cost instrumentation
+
+`noon_runtime::HostCallbackProfiler` records:
+
+- per-callback call count, latest/average/max duration;
+- callback-phase latest/max duration;
+- accumulated missed presentation deadlines;
+- realtime/offline frame disposition;
+- exact scene seek mode implied by registered callback replay classes.
+
+The host records measured callback and phase durations; the profiler is transport
+independent so the browser, native hosts, and tests share the same contract.
+
+## Commit semantics
+
+Host writes remain an atomic callback-phase mutation transaction. Property-only
+writes may use the current incremental commit path. Structural/timeline edits
+that require re-lowering remain explicit higher-impact operations and must not
+silently leave native reactive bindings or execution indices stale.
+
+Wave 2's stable execution slots and local transaction journal (#58) will remove
+the current full-runtime staging fallback. That optimization does not change the
+phase or deadline semantics defined here.


### PR DESCRIPTION
## Summary
- define the canonical frame execution order and deterministic later-writer precedence across timeline/native/host phases
- classify arbitrary host callbacks by exact-seek/replay requirements
- distinguish realtime presentation (never waits on host) from deterministic/offline evaluation (waits for host commit)
- make unrestricted engine-local reads distinct from declared snapshot optimization
- add transport-independent runtime profiling for per-callback cost, deadline misses, frame disposition, and exact seek mode
- document the contract browser/Pyodide work must implement

This deliberately does not implement the Wave-2 browser worker transport or the stable-slot transaction journal.

Tracks #56.
Part of #68 Wave 1.