### PR TITLE
Introduce typed native compute IR and dense reactive scheduler

### DIFF
--- a/.github/workflows/wave1-autoformat.yml
+++ b/.github/workflows/wave1-autoformat.yml
@@ -1,0 +1,28 @@
+name: Wave 1 autoformat
+
+on:
+  push:
+    branches:
+      - arch/e1-reactive-ir
+
+permissions:
+  contents: write
+
+jobs:
+  format:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+      - run: |
+          rustup default stable
+          rustup component add rustfmt
+          cargo fmt --all
+          if git diff --quiet; then exit 0; fi
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add --all
+          git commit -m "Format Wave 1 Rust changes"
+          git push origin HEAD:${{ github.ref_name }}

--- a/crates/noon-core/src/reactive.rs
+++ b/crates/noon-core/src/reactive.rs
@@ -16,5 +16,8 @@ pub use lifecycle::*;
 
 include!("reactive_impl.rs");
 
+mod compute_ir;
+pub use compute_ir::*;
+
 mod signal_timeline;
 pub use signal_timeline::*;

--- a/crates/noon-core/src/reactive/compute_ir.rs
+++ b/crates/noon-core/src/reactive/compute_ir.rs
@@ -195,11 +195,8 @@ impl ComputeProgram {
                     rhs,
                     kind,
                 } => {
-                    registers[dst.index()] = binary_add(
-                        &registers[lhs.index()],
-                        &registers[rhs.index()],
-                        *kind,
-                    )?;
+                    registers[dst.index()] =
+                        binary_add(&registers[lhs.index()], &registers[rhs.index()], *kind)?;
                 }
                 ComputeInstruction::Sub {
                     dst,
@@ -207,11 +204,8 @@ impl ComputeProgram {
                     rhs,
                     kind,
                 } => {
-                    registers[dst.index()] = binary_sub(
-                        &registers[lhs.index()],
-                        &registers[rhs.index()],
-                        *kind,
-                    )?;
+                    registers[dst.index()] =
+                        binary_sub(&registers[lhs.index()], &registers[rhs.index()], *kind)?;
                 }
                 ComputeInstruction::Mul {
                     dst,
@@ -298,12 +292,11 @@ impl ComputeBuilder<'_> {
                     .signal_kinds
                     .get(index)
                     .ok_or(ReactiveError::UnknownSignal(*signal))?;
-                let signal_index = u32::try_from(index).map_err(|_| {
-                    ReactiveError::InvalidExpression {
+                let signal_index =
+                    u32::try_from(index).map_err(|_| ReactiveError::InvalidExpression {
                         signal: self.owner,
                         operation: "signal_space_exhausted",
-                    }
-                })?;
+                    })?;
                 let dst = self.allocate(kind)?;
                 self.instructions.push(ComputeInstruction::LoadSignal {
                     dst,
@@ -349,8 +342,9 @@ impl ComputeBuilder<'_> {
                 let (rhs, rhs_kind) = self.lower(rhs)?;
                 let result_kind = match (lhs_kind, rhs_kind) {
                     (ValueKind::Scalar, ValueKind::Scalar) => ValueKind::Scalar,
-                    (ValueKind::Scalar, ValueKind::Vec2)
-                    | (ValueKind::Vec2, ValueKind::Scalar) => ValueKind::Vec2,
+                    (ValueKind::Scalar, ValueKind::Vec2) | (ValueKind::Vec2, ValueKind::Scalar) => {
+                        ValueKind::Vec2
+                    }
                     _ => return self.invalid("mul"),
                 };
                 let dst = self.allocate(result_kind)?;
@@ -469,7 +463,10 @@ impl std::fmt::Display for ComputeVmError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::MissingSignal(index) => {
-                write!(formatter, "compute program references missing dense signal {index}")
+                write!(
+                    formatter,
+                    "compute program references missing dense signal {index}"
+                )
             }
             Self::SignalTypeMismatch {
                 signal_index,

--- a/crates/noon-core/src/reactive/compute_ir.rs
+++ b/crates/noon-core/src/reactive/compute_ir.rs
@@ -1,0 +1,532 @@
+use std::collections::{BTreeMap, BinaryHeap};
+use std::cmp::Reverse;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{ReactiveError, ReactiveExpr, ReactiveValue, SignalId, ValueKind, Vec2};
+
+/// Dense register index in the native compute program.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct ComputeRegister(u32);
+
+impl ComputeRegister {
+    pub const fn new(raw: u32) -> Self {
+        Self(raw)
+    }
+
+    pub const fn get(self) -> u32 {
+        self.0
+    }
+
+    fn index(self) -> usize {
+        self.0 as usize
+    }
+}
+
+/// Typed, backend-neutral operation used by native reactive execution.
+///
+/// Signal references are lowered to dense signal indices. There is no recursive
+/// expression walking or semantic-ID map lookup while instructions execute.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ComputeInstruction {
+    Constant {
+        dst: ComputeRegister,
+        value: ReactiveValue,
+    },
+    LoadSignal {
+        dst: ComputeRegister,
+        signal_index: u32,
+        kind: ValueKind,
+    },
+    Add {
+        dst: ComputeRegister,
+        lhs: ComputeRegister,
+        rhs: ComputeRegister,
+        kind: ValueKind,
+    },
+    Sub {
+        dst: ComputeRegister,
+        lhs: ComputeRegister,
+        rhs: ComputeRegister,
+        kind: ValueKind,
+    },
+    Mul {
+        dst: ComputeRegister,
+        lhs: ComputeRegister,
+        rhs: ComputeRegister,
+        result_kind: ValueKind,
+    },
+    Neg {
+        dst: ComputeRegister,
+        value: ComputeRegister,
+        kind: ValueKind,
+    },
+    Sin {
+        dst: ComputeRegister,
+        value: ComputeRegister,
+    },
+    Cos {
+        dst: ComputeRegister,
+        value: ComputeRegister,
+    },
+}
+
+impl ComputeInstruction {
+    pub const fn destination(&self) -> ComputeRegister {
+        match *self {
+            Self::Constant { dst, .. }
+            | Self::LoadSignal { dst, .. }
+            | Self::Add { dst, .. }
+            | Self::Sub { dst, .. }
+            | Self::Mul { dst, .. }
+            | Self::Neg { dst, .. }
+            | Self::Sin { dst, .. }
+            | Self::Cos { dst, .. } => dst,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ComputeExecutionStats {
+    pub instructions_executed: usize,
+}
+
+/// One lowered expression. The format is intentionally small and deterministic
+/// so future SIMD and WGSL backends can consume the same typed program.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ComputeProgram {
+    instructions: Vec<ComputeInstruction>,
+    register_kinds: Vec<ValueKind>,
+    output: ComputeRegister,
+    output_kind: ValueKind,
+}
+
+impl ComputeProgram {
+    pub fn lower(
+        expression: &ReactiveExpr,
+        signal_indices: &BTreeMap<SignalId, usize>,
+        signal_kinds: &[ValueKind],
+        owner: SignalId,
+    ) -> Result<Self, ReactiveError> {
+        let mut builder = ComputeBuilder {
+            instructions: Vec::new(),
+            register_kinds: Vec::new(),
+            signal_indices,
+            signal_kinds,
+            owner,
+        };
+        let (output, output_kind) = builder.lower(expression)?;
+        Ok(Self {
+            instructions: builder.instructions,
+            register_kinds: builder.register_kinds,
+            output,
+            output_kind,
+        })
+    }
+
+    pub fn instructions(&self) -> &[ComputeInstruction] {
+        &self.instructions
+    }
+
+    pub fn register_kinds(&self) -> &[ValueKind] {
+        &self.register_kinds
+    }
+
+    pub const fn output(&self) -> ComputeRegister {
+        self.output
+    }
+
+    pub const fn output_kind(&self) -> ValueKind {
+        self.output_kind
+    }
+
+    pub fn evaluate(&self, signals: &[ReactiveValue]) -> Result<ReactiveValue, ComputeVmError> {
+        self.evaluate_with_stats(signals).map(|(value, _)| value)
+    }
+
+    pub fn evaluate_with_stats(
+        &self,
+        signals: &[ReactiveValue],
+    ) -> Result<(ReactiveValue, ComputeExecutionStats), ComputeVmError> {
+        let mut registers = vec![ReactiveValue::Scalar(0.0); self.register_kinds.len()];
+        let mut stats = ComputeExecutionStats::default();
+        for instruction in &self.instructions {
+            stats.instructions_executed += 1;
+            match instruction {
+                ComputeInstruction::Constant { dst, value } => {
+                    registers[dst.index()] = value.clone();
+                }
+                ComputeInstruction::LoadSignal {
+                    dst,
+                    signal_index,
+                    kind,
+                } => {
+                    let value = signals
+                        .get(*signal_index as usize)
+                        .ok_or(ComputeVmError::MissingSignal(*signal_index))?;
+                    if value.value_kind() != *kind {
+                        return Err(ComputeVmError::SignalTypeMismatch {
+                            signal_index: *signal_index,
+                            expected: *kind,
+                            actual: value.value_kind(),
+                        });
+                    }
+                    registers[dst.index()] = value.clone();
+                }
+                ComputeInstruction::Add { dst, lhs, rhs, kind } => {
+                    registers[dst.index()] = binary_add(
+                        &registers[lhs.index()],
+                        &registers[rhs.index()],
+                        *kind,
+                    )?;
+                }
+                ComputeInstruction::Sub { dst, lhs, rhs, kind } => {
+                    registers[dst.index()] = binary_sub(
+                        &registers[lhs.index()],
+                        &registers[rhs.index()],
+                        *kind,
+                    )?;
+                }
+                ComputeInstruction::Mul {
+                    dst,
+                    lhs,
+                    rhs,
+                    result_kind,
+                } => {
+                    registers[dst.index()] = binary_mul(
+                        &registers[lhs.index()],
+                        &registers[rhs.index()],
+                        *result_kind,
+                    )?;
+                }
+                ComputeInstruction::Neg { dst, value, kind } => {
+                    registers[dst.index()] = match (&registers[value.index()], kind) {
+                        (ReactiveValue::Scalar(value), ValueKind::Scalar) => {
+                            ReactiveValue::Scalar(-value)
+                        }
+                        (ReactiveValue::Vec2(value), ValueKind::Vec2) => ReactiveValue::Vec2(-*value),
+                        _ => return Err(ComputeVmError::InvalidTypedInstruction("neg")),
+                    };
+                }
+                ComputeInstruction::Sin { dst, value } => {
+                    let ReactiveValue::Scalar(value) = registers[value.index()] else {
+                        return Err(ComputeVmError::InvalidTypedInstruction("sin"));
+                    };
+                    registers[dst.index()] = ReactiveValue::Scalar(value.sin());
+                }
+                ComputeInstruction::Cos { dst, value } => {
+                    let ReactiveValue::Scalar(value) = registers[value.index()] else {
+                        return Err(ComputeVmError::InvalidTypedInstruction("cos"));
+                    };
+                    registers[dst.index()] = ReactiveValue::Scalar(value.cos());
+                }
+            }
+        }
+        Ok((registers[self.output.index()].clone(), stats))
+    }
+}
+
+struct ComputeBuilder<'a> {
+    instructions: Vec<ComputeInstruction>,
+    register_kinds: Vec<ValueKind>,
+    signal_indices: &'a BTreeMap<SignalId, usize>,
+    signal_kinds: &'a [ValueKind],
+    owner: SignalId,
+}
+
+impl ComputeBuilder<'_> {
+    fn allocate(&mut self, kind: ValueKind) -> Result<ComputeRegister, ReactiveError> {
+        let raw = u32::try_from(self.register_kinds.len()).map_err(|_| ReactiveError::InvalidExpression {
+            signal: self.owner,
+            operation: "register_space_exhausted",
+        })?;
+        self.register_kinds.push(kind);
+        Ok(ComputeRegister::new(raw))
+    }
+
+    fn lower(&mut self, expression: &ReactiveExpr) -> Result<(ComputeRegister, ValueKind), ReactiveError> {
+        match expression {
+            ReactiveExpr::Constant(value) => {
+                let kind = value.value_kind();
+                let dst = self.allocate(kind)?;
+                self.instructions.push(ComputeInstruction::Constant {
+                    dst,
+                    value: value.clone(),
+                });
+                Ok((dst, kind))
+            }
+            ReactiveExpr::Signal(signal) => {
+                let index = *self.signal_indices.get(signal).ok_or(ReactiveError::UnknownSignal(*signal))?;
+                let kind = *self.signal_kinds.get(index).ok_or(ReactiveError::UnknownSignal(*signal))?;
+                let signal_index = u32::try_from(index).map_err(|_| ReactiveError::InvalidExpression {
+                    signal: self.owner,
+                    operation: "signal_space_exhausted",
+                })?;
+                let dst = self.allocate(kind)?;
+                self.instructions.push(ComputeInstruction::LoadSignal {
+                    dst,
+                    signal_index,
+                    kind,
+                });
+                Ok((dst, kind))
+            }
+            ReactiveExpr::Add(lhs, rhs) => {
+                let (lhs, lhs_kind) = self.lower(lhs)?;
+                let (rhs, rhs_kind) = self.lower(rhs)?;
+                if lhs_kind != rhs_kind || !matches!(lhs_kind, ValueKind::Scalar | ValueKind::Vec2) {
+                    return self.invalid("add");
+                }
+                let dst = self.allocate(lhs_kind)?;
+                self.instructions.push(ComputeInstruction::Add { dst, lhs, rhs, kind: lhs_kind });
+                Ok((dst, lhs_kind))
+            }
+            ReactiveExpr::Sub(lhs, rhs) => {
+                let (lhs, lhs_kind) = self.lower(lhs)?;
+                let (rhs, rhs_kind) = self.lower(rhs)?;
+                if lhs_kind != rhs_kind || !matches!(lhs_kind, ValueKind::Scalar | ValueKind::Vec2) {
+                    return self.invalid("sub");
+                }
+                let dst = self.allocate(lhs_kind)?;
+                self.instructions.push(ComputeInstruction::Sub { dst, lhs, rhs, kind: lhs_kind });
+                Ok((dst, lhs_kind))
+            }
+            ReactiveExpr::Mul(lhs, rhs) => {
+                let (lhs, lhs_kind) = self.lower(lhs)?;
+                let (rhs, rhs_kind) = self.lower(rhs)?;
+                let result_kind = match (lhs_kind, rhs_kind) {
+                    (ValueKind::Scalar, ValueKind::Scalar) => ValueKind::Scalar,
+                    (ValueKind::Scalar, ValueKind::Vec2) | (ValueKind::Vec2, ValueKind::Scalar) => ValueKind::Vec2,
+                    _ => return self.invalid("mul"),
+                };
+                let dst = self.allocate(result_kind)?;
+                self.instructions.push(ComputeInstruction::Mul { dst, lhs, rhs, result_kind });
+                Ok((dst, result_kind))
+            }
+            ReactiveExpr::Neg(value) => {
+                let (value, kind) = self.lower(value)?;
+                if !matches!(kind, ValueKind::Scalar | ValueKind::Vec2) {
+                    return self.invalid("neg");
+                }
+                let dst = self.allocate(kind)?;
+                self.instructions.push(ComputeInstruction::Neg { dst, value, kind });
+                Ok((dst, kind))
+            }
+            ReactiveExpr::Sin(value) => self.lower_unary_scalar(value, true),
+            ReactiveExpr::Cos(value) => self.lower_unary_scalar(value, false),
+        }
+    }
+
+    fn lower_unary_scalar(
+        &mut self,
+        value: &ReactiveExpr,
+        sine: bool,
+    ) -> Result<(ComputeRegister, ValueKind), ReactiveError> {
+        let (value, kind) = self.lower(value)?;
+        if kind != ValueKind::Scalar {
+            return self.invalid(if sine { "sin" } else { "cos" });
+        }
+        let dst = self.allocate(ValueKind::Scalar)?;
+        self.instructions.push(if sine {
+            ComputeInstruction::Sin { dst, value }
+        } else {
+            ComputeInstruction::Cos { dst, value }
+        });
+        Ok((dst, ValueKind::Scalar))
+    }
+
+    fn invalid<T>(&self, operation: &'static str) -> Result<T, ReactiveError> {
+        Err(ReactiveError::InvalidExpression {
+            signal: self.owner,
+            operation,
+        })
+    }
+}
+
+fn binary_add(lhs: &ReactiveValue, rhs: &ReactiveValue, kind: ValueKind) -> Result<ReactiveValue, ComputeVmError> {
+    match (lhs, rhs, kind) {
+        (ReactiveValue::Scalar(lhs), ReactiveValue::Scalar(rhs), ValueKind::Scalar) => Ok(ReactiveValue::Scalar(lhs + rhs)),
+        (ReactiveValue::Vec2(lhs), ReactiveValue::Vec2(rhs), ValueKind::Vec2) => Ok(ReactiveValue::Vec2(*lhs + *rhs)),
+        _ => Err(ComputeVmError::InvalidTypedInstruction("add")),
+    }
+}
+
+fn binary_sub(lhs: &ReactiveValue, rhs: &ReactiveValue, kind: ValueKind) -> Result<ReactiveValue, ComputeVmError> {
+    match (lhs, rhs, kind) {
+        (ReactiveValue::Scalar(lhs), ReactiveValue::Scalar(rhs), ValueKind::Scalar) => Ok(ReactiveValue::Scalar(lhs - rhs)),
+        (ReactiveValue::Vec2(lhs), ReactiveValue::Vec2(rhs), ValueKind::Vec2) => Ok(ReactiveValue::Vec2(*lhs - *rhs)),
+        _ => Err(ComputeVmError::InvalidTypedInstruction("sub")),
+    }
+}
+
+fn binary_mul(lhs: &ReactiveValue, rhs: &ReactiveValue, result_kind: ValueKind) -> Result<ReactiveValue, ComputeVmError> {
+    match (lhs, rhs, result_kind) {
+        (ReactiveValue::Scalar(lhs), ReactiveValue::Scalar(rhs), ValueKind::Scalar) => Ok(ReactiveValue::Scalar(lhs * rhs)),
+        (ReactiveValue::Scalar(lhs), ReactiveValue::Vec2(rhs), ValueKind::Vec2) => Ok(ReactiveValue::Vec2(*lhs * *rhs)),
+        (ReactiveValue::Vec2(lhs), ReactiveValue::Scalar(rhs), ValueKind::Vec2) => Ok(ReactiveValue::Vec2(*lhs * *rhs)),
+        _ => Err(ComputeVmError::InvalidTypedInstruction("mul")),
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ComputeVmError {
+    MissingSignal(u32),
+    SignalTypeMismatch {
+        signal_index: u32,
+        expected: ValueKind,
+        actual: ValueKind,
+    },
+    InvalidTypedInstruction(&'static str),
+}
+
+impl std::fmt::Display for ComputeVmError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingSignal(index) => write!(formatter, "compute program references missing dense signal {index}"),
+            Self::SignalTypeMismatch { signal_index, expected, actual } => write!(
+                formatter,
+                "compute signal {signal_index} type mismatch: expected {expected:?}, got {actual:?}"
+            ),
+            Self::InvalidTypedInstruction(operation) => write!(formatter, "invalid typed compute instruction {operation}"),
+        }
+    }
+}
+
+impl std::error::Error for ComputeVmError {}
+
+/// Dense dirty scheduler used by native reactive execution.
+///
+/// A bitset prevents duplicate queue entries while a compact min-heap preserves
+/// topological rank. Semantic IDs and ordered maps never participate in scheduling.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DenseDirtyQueue {
+    pending: Vec<bool>,
+    heap: BinaryHeap<Reverse<(usize, usize)>>,
+}
+
+impl DenseDirtyQueue {
+    pub fn new(node_count: usize) -> Self {
+        Self {
+            pending: vec![false; node_count],
+            heap: BinaryHeap::new(),
+        }
+    }
+
+    pub fn schedule(&mut self, rank: usize, index: usize) {
+        if !self.pending[index] {
+            self.pending[index] = true;
+            self.heap.push(Reverse((rank, index)));
+        }
+    }
+
+    pub fn pop(&mut self) -> Option<(usize, usize)> {
+        let Reverse((rank, index)) = self.heap.pop()?;
+        self.pending[index] = false;
+        Some((rank, index))
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.heap.is_empty()
+    }
+
+    pub fn clear(&mut self) {
+        while let Some(Reverse((_, index))) = self.heap.pop() {
+            self.pending[index] = false;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn signal_table() -> (BTreeMap<SignalId, usize>, Vec<ValueKind>, Vec<ReactiveValue>) {
+        let a = SignalId::new(1);
+        let b = SignalId::new(2);
+        (
+            BTreeMap::from([(a, 0), (b, 1)]),
+            vec![ValueKind::Scalar, ValueKind::Vec2],
+            vec![ReactiveValue::Scalar(2.0), ReactiveValue::Vec2(Vec2::new(3.0, 4.0))],
+        )
+    }
+
+    #[test]
+    fn lowers_expression_to_dense_typed_register_program() {
+        let (indices, kinds, values) = signal_table();
+        let expression = ReactiveExpr::Add(
+            Box::new(ReactiveExpr::Mul(
+                Box::new(ReactiveExpr::signal(SignalId::new(1))),
+                Box::new(ReactiveExpr::scalar(3.0)),
+            )),
+            Box::new(ReactiveExpr::scalar(1.0)),
+        );
+        let program = ComputeProgram::lower(&expression, &indices, &kinds, SignalId::new(9)).unwrap();
+        assert_eq!(program.output_kind(), ValueKind::Scalar);
+        assert!(program.instructions().iter().any(|instruction| matches!(
+            instruction,
+            ComputeInstruction::LoadSignal { signal_index: 0, .. }
+        )));
+        let (value, stats) = program.evaluate_with_stats(&values).unwrap();
+        assert_eq!(value, ReactiveValue::Scalar(7.0));
+        assert_eq!(stats.instructions_executed, program.instructions().len());
+    }
+
+    #[test]
+    fn typed_vm_supports_scalar_vector_multiplication() {
+        let (indices, kinds, values) = signal_table();
+        let expression = ReactiveExpr::Mul(
+            Box::new(ReactiveExpr::signal(SignalId::new(1))),
+            Box::new(ReactiveExpr::signal(SignalId::new(2))),
+        );
+        let program = ComputeProgram::lower(&expression, &indices, &kinds, SignalId::new(9)).unwrap();
+        assert_eq!(
+            program.evaluate(&values).unwrap(),
+            ReactiveValue::Vec2(Vec2::new(6.0, 8.0))
+        );
+    }
+
+    #[test]
+    fn lowering_rejects_invalid_types_before_execution() {
+        let indices = BTreeMap::from([(SignalId::new(1), 0)]);
+        let kinds = vec![ValueKind::Bool];
+        let expression = ReactiveExpr::Sin(Box::new(ReactiveExpr::signal(SignalId::new(1))));
+        assert!(matches!(
+            ComputeProgram::lower(&expression, &indices, &kinds, SignalId::new(7)),
+            Err(ReactiveError::InvalidExpression { operation: "sin", .. })
+        ));
+    }
+
+    #[test]
+    fn dense_dirty_queue_deduplicates_and_preserves_rank() {
+        let mut queue = DenseDirtyQueue::new(8);
+        queue.schedule(5, 5);
+        queue.schedule(2, 2);
+        queue.schedule(5, 5);
+        queue.schedule(3, 7);
+        assert_eq!(queue.pop(), Some((2, 2)));
+        assert_eq!(queue.pop(), Some((3, 7)));
+        assert_eq!(queue.pop(), Some((5, 5)));
+        assert!(queue.is_empty());
+    }
+
+    #[test]
+    fn vm_matches_reference_math_over_many_inputs() {
+        let signal = SignalId::new(1);
+        let indices = BTreeMap::from([(signal, 0)]);
+        let kinds = vec![ValueKind::Scalar];
+        let expression = ReactiveExpr::Add(
+            Box::new(ReactiveExpr::Sin(Box::new(ReactiveExpr::signal(signal)))),
+            Box::new(ReactiveExpr::Mul(
+                Box::new(ReactiveExpr::signal(signal)),
+                Box::new(ReactiveExpr::scalar(0.25)),
+            )),
+        );
+        let program = ComputeProgram::lower(&expression, &indices, &kinds, SignalId::new(8)).unwrap();
+        for step in -100..=100 {
+            let x = step as f32 * 0.03125;
+            let actual = program.evaluate(&[ReactiveValue::Scalar(x)]).unwrap();
+            let expected = ReactiveValue::Scalar(x.sin() + x * 0.25);
+            assert_eq!(actual, expected);
+        }
+    }
+}

--- a/crates/noon-core/src/reactive/compute_ir.rs
+++ b/crates/noon-core/src/reactive/compute_ir.rs
@@ -1,12 +1,11 @@
-use std::collections::{BTreeMap, BinaryHeap};
 use std::cmp::Reverse;
+use std::collections::{BTreeMap, BinaryHeap};
+use std::fmt::Write;
 
-use serde::{Deserialize, Serialize};
-
-use crate::{ReactiveError, ReactiveExpr, ReactiveValue, SignalId, ValueKind, Vec2};
+use crate::{ReactiveError, ReactiveExpr, ReactiveValue, SignalId, ValueKind};
 
 /// Dense register index in the native compute program.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ComputeRegister(u32);
 
 impl ComputeRegister {
@@ -27,8 +26,7 @@ impl ComputeRegister {
 ///
 /// Signal references are lowered to dense signal indices. There is no recursive
 /// expression walking or semantic-ID map lookup while instructions execute.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[derive(Clone, Debug, PartialEq)]
 pub enum ComputeInstruction {
     Constant {
         dst: ComputeRegister,
@@ -94,7 +92,7 @@ pub struct ComputeExecutionStats {
 
 /// One lowered expression. The format is intentionally small and deterministic
 /// so future SIMD and WGSL backends can consume the same typed program.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct ComputeProgram {
     instructions: Vec<ComputeInstruction>,
     register_kinds: Vec<ValueKind>,
@@ -141,6 +139,22 @@ impl ComputeProgram {
         self.output_kind
     }
 
+    /// Deterministic backend/debug representation without making the internal
+    /// timeline `ValueKind` part of a persisted serde schema.
+    pub fn debug_text(&self) -> String {
+        let mut output = String::new();
+        for instruction in &self.instructions {
+            let _ = writeln!(&mut output, "{instruction:?}");
+        }
+        let _ = writeln!(
+            &mut output,
+            "output=r{} kind={:?}",
+            self.output.get(),
+            self.output_kind
+        );
+        output
+    }
+
     pub fn evaluate(&self, signals: &[ReactiveValue]) -> Result<ReactiveValue, ComputeVmError> {
         self.evaluate_with_stats(signals).map(|(value, _)| value)
     }
@@ -151,6 +165,7 @@ impl ComputeProgram {
     ) -> Result<(ReactiveValue, ComputeExecutionStats), ComputeVmError> {
         let mut registers = vec![ReactiveValue::Scalar(0.0); self.register_kinds.len()];
         let mut stats = ComputeExecutionStats::default();
+
         for instruction in &self.instructions {
             stats.instructions_executed += 1;
             match instruction {
@@ -174,14 +189,24 @@ impl ComputeProgram {
                     }
                     registers[dst.index()] = value.clone();
                 }
-                ComputeInstruction::Add { dst, lhs, rhs, kind } => {
+                ComputeInstruction::Add {
+                    dst,
+                    lhs,
+                    rhs,
+                    kind,
+                } => {
                     registers[dst.index()] = binary_add(
                         &registers[lhs.index()],
                         &registers[rhs.index()],
                         *kind,
                     )?;
                 }
-                ComputeInstruction::Sub { dst, lhs, rhs, kind } => {
+                ComputeInstruction::Sub {
+                    dst,
+                    lhs,
+                    rhs,
+                    kind,
+                } => {
                     registers[dst.index()] = binary_sub(
                         &registers[lhs.index()],
                         &registers[rhs.index()],
@@ -205,7 +230,9 @@ impl ComputeProgram {
                         (ReactiveValue::Scalar(value), ValueKind::Scalar) => {
                             ReactiveValue::Scalar(-value)
                         }
-                        (ReactiveValue::Vec2(value), ValueKind::Vec2) => ReactiveValue::Vec2(-*value),
+                        (ReactiveValue::Vec2(value), ValueKind::Vec2) => {
+                            ReactiveValue::Vec2(-*value)
+                        }
                         _ => return Err(ComputeVmError::InvalidTypedInstruction("neg")),
                     };
                 }
@@ -223,6 +250,7 @@ impl ComputeProgram {
                 }
             }
         }
+
         Ok((registers[self.output.index()].clone(), stats))
     }
 }
@@ -237,15 +265,20 @@ struct ComputeBuilder<'a> {
 
 impl ComputeBuilder<'_> {
     fn allocate(&mut self, kind: ValueKind) -> Result<ComputeRegister, ReactiveError> {
-        let raw = u32::try_from(self.register_kinds.len()).map_err(|_| ReactiveError::InvalidExpression {
-            signal: self.owner,
-            operation: "register_space_exhausted",
+        let raw = u32::try_from(self.register_kinds.len()).map_err(|_| {
+            ReactiveError::InvalidExpression {
+                signal: self.owner,
+                operation: "register_space_exhausted",
+            }
         })?;
         self.register_kinds.push(kind);
         Ok(ComputeRegister::new(raw))
     }
 
-    fn lower(&mut self, expression: &ReactiveExpr) -> Result<(ComputeRegister, ValueKind), ReactiveError> {
+    fn lower(
+        &mut self,
+        expression: &ReactiveExpr,
+    ) -> Result<(ComputeRegister, ValueKind), ReactiveError> {
         match expression {
             ReactiveExpr::Constant(value) => {
                 let kind = value.value_kind();
@@ -257,11 +290,19 @@ impl ComputeBuilder<'_> {
                 Ok((dst, kind))
             }
             ReactiveExpr::Signal(signal) => {
-                let index = *self.signal_indices.get(signal).ok_or(ReactiveError::UnknownSignal(*signal))?;
-                let kind = *self.signal_kinds.get(index).ok_or(ReactiveError::UnknownSignal(*signal))?;
-                let signal_index = u32::try_from(index).map_err(|_| ReactiveError::InvalidExpression {
-                    signal: self.owner,
-                    operation: "signal_space_exhausted",
+                let index = *self
+                    .signal_indices
+                    .get(signal)
+                    .ok_or(ReactiveError::UnknownSignal(*signal))?;
+                let kind = *self
+                    .signal_kinds
+                    .get(index)
+                    .ok_or(ReactiveError::UnknownSignal(*signal))?;
+                let signal_index = u32::try_from(index).map_err(|_| {
+                    ReactiveError::InvalidExpression {
+                        signal: self.owner,
+                        operation: "signal_space_exhausted",
+                    }
                 })?;
                 let dst = self.allocate(kind)?;
                 self.instructions.push(ComputeInstruction::LoadSignal {
@@ -274,21 +315,33 @@ impl ComputeBuilder<'_> {
             ReactiveExpr::Add(lhs, rhs) => {
                 let (lhs, lhs_kind) = self.lower(lhs)?;
                 let (rhs, rhs_kind) = self.lower(rhs)?;
-                if lhs_kind != rhs_kind || !matches!(lhs_kind, ValueKind::Scalar | ValueKind::Vec2) {
+                if lhs_kind != rhs_kind || !matches!(lhs_kind, ValueKind::Scalar | ValueKind::Vec2)
+                {
                     return self.invalid("add");
                 }
                 let dst = self.allocate(lhs_kind)?;
-                self.instructions.push(ComputeInstruction::Add { dst, lhs, rhs, kind: lhs_kind });
+                self.instructions.push(ComputeInstruction::Add {
+                    dst,
+                    lhs,
+                    rhs,
+                    kind: lhs_kind,
+                });
                 Ok((dst, lhs_kind))
             }
             ReactiveExpr::Sub(lhs, rhs) => {
                 let (lhs, lhs_kind) = self.lower(lhs)?;
                 let (rhs, rhs_kind) = self.lower(rhs)?;
-                if lhs_kind != rhs_kind || !matches!(lhs_kind, ValueKind::Scalar | ValueKind::Vec2) {
+                if lhs_kind != rhs_kind || !matches!(lhs_kind, ValueKind::Scalar | ValueKind::Vec2)
+                {
                     return self.invalid("sub");
                 }
                 let dst = self.allocate(lhs_kind)?;
-                self.instructions.push(ComputeInstruction::Sub { dst, lhs, rhs, kind: lhs_kind });
+                self.instructions.push(ComputeInstruction::Sub {
+                    dst,
+                    lhs,
+                    rhs,
+                    kind: lhs_kind,
+                });
                 Ok((dst, lhs_kind))
             }
             ReactiveExpr::Mul(lhs, rhs) => {
@@ -296,11 +349,17 @@ impl ComputeBuilder<'_> {
                 let (rhs, rhs_kind) = self.lower(rhs)?;
                 let result_kind = match (lhs_kind, rhs_kind) {
                     (ValueKind::Scalar, ValueKind::Scalar) => ValueKind::Scalar,
-                    (ValueKind::Scalar, ValueKind::Vec2) | (ValueKind::Vec2, ValueKind::Scalar) => ValueKind::Vec2,
+                    (ValueKind::Scalar, ValueKind::Vec2)
+                    | (ValueKind::Vec2, ValueKind::Scalar) => ValueKind::Vec2,
                     _ => return self.invalid("mul"),
                 };
                 let dst = self.allocate(result_kind)?;
-                self.instructions.push(ComputeInstruction::Mul { dst, lhs, rhs, result_kind });
+                self.instructions.push(ComputeInstruction::Mul {
+                    dst,
+                    lhs,
+                    rhs,
+                    result_kind,
+                });
                 Ok((dst, result_kind))
             }
             ReactiveExpr::Neg(value) => {
@@ -309,7 +368,8 @@ impl ComputeBuilder<'_> {
                     return self.invalid("neg");
                 }
                 let dst = self.allocate(kind)?;
-                self.instructions.push(ComputeInstruction::Neg { dst, value, kind });
+                self.instructions
+                    .push(ComputeInstruction::Neg { dst, value, kind });
                 Ok((dst, kind))
             }
             ReactiveExpr::Sin(value) => self.lower_unary_scalar(value, true),
@@ -343,27 +403,53 @@ impl ComputeBuilder<'_> {
     }
 }
 
-fn binary_add(lhs: &ReactiveValue, rhs: &ReactiveValue, kind: ValueKind) -> Result<ReactiveValue, ComputeVmError> {
+fn binary_add(
+    lhs: &ReactiveValue,
+    rhs: &ReactiveValue,
+    kind: ValueKind,
+) -> Result<ReactiveValue, ComputeVmError> {
     match (lhs, rhs, kind) {
-        (ReactiveValue::Scalar(lhs), ReactiveValue::Scalar(rhs), ValueKind::Scalar) => Ok(ReactiveValue::Scalar(lhs + rhs)),
-        (ReactiveValue::Vec2(lhs), ReactiveValue::Vec2(rhs), ValueKind::Vec2) => Ok(ReactiveValue::Vec2(*lhs + *rhs)),
+        (ReactiveValue::Scalar(lhs), ReactiveValue::Scalar(rhs), ValueKind::Scalar) => {
+            Ok(ReactiveValue::Scalar(lhs + rhs))
+        }
+        (ReactiveValue::Vec2(lhs), ReactiveValue::Vec2(rhs), ValueKind::Vec2) => {
+            Ok(ReactiveValue::Vec2(*lhs + *rhs))
+        }
         _ => Err(ComputeVmError::InvalidTypedInstruction("add")),
     }
 }
 
-fn binary_sub(lhs: &ReactiveValue, rhs: &ReactiveValue, kind: ValueKind) -> Result<ReactiveValue, ComputeVmError> {
+fn binary_sub(
+    lhs: &ReactiveValue,
+    rhs: &ReactiveValue,
+    kind: ValueKind,
+) -> Result<ReactiveValue, ComputeVmError> {
     match (lhs, rhs, kind) {
-        (ReactiveValue::Scalar(lhs), ReactiveValue::Scalar(rhs), ValueKind::Scalar) => Ok(ReactiveValue::Scalar(lhs - rhs)),
-        (ReactiveValue::Vec2(lhs), ReactiveValue::Vec2(rhs), ValueKind::Vec2) => Ok(ReactiveValue::Vec2(*lhs - *rhs)),
+        (ReactiveValue::Scalar(lhs), ReactiveValue::Scalar(rhs), ValueKind::Scalar) => {
+            Ok(ReactiveValue::Scalar(lhs - rhs))
+        }
+        (ReactiveValue::Vec2(lhs), ReactiveValue::Vec2(rhs), ValueKind::Vec2) => {
+            Ok(ReactiveValue::Vec2(*lhs - *rhs))
+        }
         _ => Err(ComputeVmError::InvalidTypedInstruction("sub")),
     }
 }
 
-fn binary_mul(lhs: &ReactiveValue, rhs: &ReactiveValue, result_kind: ValueKind) -> Result<ReactiveValue, ComputeVmError> {
+fn binary_mul(
+    lhs: &ReactiveValue,
+    rhs: &ReactiveValue,
+    result_kind: ValueKind,
+) -> Result<ReactiveValue, ComputeVmError> {
     match (lhs, rhs, result_kind) {
-        (ReactiveValue::Scalar(lhs), ReactiveValue::Scalar(rhs), ValueKind::Scalar) => Ok(ReactiveValue::Scalar(lhs * rhs)),
-        (ReactiveValue::Scalar(lhs), ReactiveValue::Vec2(rhs), ValueKind::Vec2) => Ok(ReactiveValue::Vec2(*lhs * *rhs)),
-        (ReactiveValue::Vec2(lhs), ReactiveValue::Scalar(rhs), ValueKind::Vec2) => Ok(ReactiveValue::Vec2(*lhs * *rhs)),
+        (ReactiveValue::Scalar(lhs), ReactiveValue::Scalar(rhs), ValueKind::Scalar) => {
+            Ok(ReactiveValue::Scalar(lhs * rhs))
+        }
+        (ReactiveValue::Scalar(lhs), ReactiveValue::Vec2(rhs), ValueKind::Vec2) => {
+            Ok(ReactiveValue::Vec2(*lhs * *rhs))
+        }
+        (ReactiveValue::Vec2(lhs), ReactiveValue::Scalar(rhs), ValueKind::Vec2) => {
+            Ok(ReactiveValue::Vec2(*lhs * *rhs))
+        }
         _ => Err(ComputeVmError::InvalidTypedInstruction("mul")),
     }
 }
@@ -382,12 +468,20 @@ pub enum ComputeVmError {
 impl std::fmt::Display for ComputeVmError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::MissingSignal(index) => write!(formatter, "compute program references missing dense signal {index}"),
-            Self::SignalTypeMismatch { signal_index, expected, actual } => write!(
+            Self::MissingSignal(index) => {
+                write!(formatter, "compute program references missing dense signal {index}")
+            }
+            Self::SignalTypeMismatch {
+                signal_index,
+                expected,
+                actual,
+            } => write!(
                 formatter,
                 "compute signal {signal_index} type mismatch: expected {expected:?}, got {actual:?}"
             ),
-            Self::InvalidTypedInstruction(operation) => write!(formatter, "invalid typed compute instruction {operation}"),
+            Self::InvalidTypedInstruction(operation) => {
+                write!(formatter, "invalid typed compute instruction {operation}")
+            }
         }
     }
 }
@@ -398,7 +492,7 @@ impl std::error::Error for ComputeVmError {}
 ///
 /// A bitset prevents duplicate queue entries while a compact min-heap preserves
 /// topological rank. Semantic IDs and ordered maps never participate in scheduling.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug)]
 pub struct DenseDirtyQueue {
     pending: Vec<bool>,
     heap: BinaryHeap<Reverse<(usize, usize)>>,
@@ -439,14 +533,22 @@ impl DenseDirtyQueue {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Vec2;
 
-    fn signal_table() -> (BTreeMap<SignalId, usize>, Vec<ValueKind>, Vec<ReactiveValue>) {
+    fn signal_table() -> (
+        BTreeMap<SignalId, usize>,
+        Vec<ValueKind>,
+        Vec<ReactiveValue>,
+    ) {
         let a = SignalId::new(1);
         let b = SignalId::new(2);
         (
             BTreeMap::from([(a, 0), (b, 1)]),
             vec![ValueKind::Scalar, ValueKind::Vec2],
-            vec![ReactiveValue::Scalar(2.0), ReactiveValue::Vec2(Vec2::new(3.0, 4.0))],
+            vec![
+                ReactiveValue::Scalar(2.0),
+                ReactiveValue::Vec2(Vec2::new(3.0, 4.0)),
+            ],
         )
     }
 
@@ -460,15 +562,20 @@ mod tests {
             )),
             Box::new(ReactiveExpr::scalar(1.0)),
         );
-        let program = ComputeProgram::lower(&expression, &indices, &kinds, SignalId::new(9)).unwrap();
+        let program =
+            ComputeProgram::lower(&expression, &indices, &kinds, SignalId::new(9)).unwrap();
         assert_eq!(program.output_kind(), ValueKind::Scalar);
         assert!(program.instructions().iter().any(|instruction| matches!(
             instruction,
-            ComputeInstruction::LoadSignal { signal_index: 0, .. }
+            ComputeInstruction::LoadSignal {
+                signal_index: 0,
+                ..
+            }
         )));
         let (value, stats) = program.evaluate_with_stats(&values).unwrap();
         assert_eq!(value, ReactiveValue::Scalar(7.0));
         assert_eq!(stats.instructions_executed, program.instructions().len());
+        assert_eq!(program.debug_text(), program.debug_text());
     }
 
     #[test]
@@ -478,7 +585,8 @@ mod tests {
             Box::new(ReactiveExpr::signal(SignalId::new(1))),
             Box::new(ReactiveExpr::signal(SignalId::new(2))),
         );
-        let program = ComputeProgram::lower(&expression, &indices, &kinds, SignalId::new(9)).unwrap();
+        let program =
+            ComputeProgram::lower(&expression, &indices, &kinds, SignalId::new(9)).unwrap();
         assert_eq!(
             program.evaluate(&values).unwrap(),
             ReactiveValue::Vec2(Vec2::new(6.0, 8.0))
@@ -492,7 +600,10 @@ mod tests {
         let expression = ReactiveExpr::Sin(Box::new(ReactiveExpr::signal(SignalId::new(1))));
         assert!(matches!(
             ComputeProgram::lower(&expression, &indices, &kinds, SignalId::new(7)),
-            Err(ReactiveError::InvalidExpression { operation: "sin", .. })
+            Err(ReactiveError::InvalidExpression {
+                operation: "sin",
+                ..
+            })
         ));
     }
 
@@ -521,7 +632,8 @@ mod tests {
                 Box::new(ReactiveExpr::scalar(0.25)),
             )),
         );
-        let program = ComputeProgram::lower(&expression, &indices, &kinds, SignalId::new(8)).unwrap();
+        let program =
+            ComputeProgram::lower(&expression, &indices, &kinds, SignalId::new(8)).unwrap();
         for step in -100..=100 {
             let x = step as f32 * 0.03125;
             let actual = program.evaluate(&[ReactiveValue::Scalar(x)]).unwrap();

--- a/docs/reactive-compute-ir.md
+++ b/docs/reactive-compute-ir.md
@@ -1,0 +1,51 @@
+# Native compute IR
+
+Noon's serializable `ReactiveExpr` remains an authoring/dependency description,
+but it is not the intended frame-critical execution representation. Native
+reactive expressions lower to a compact typed register program before runtime.
+
+`ComputeProgram` currently supports the same bool/scalar/`Vec2` value vocabulary
+as native reactivity and the existing arithmetic/trigonometric operations. Signal
+references are resolved to dense signal indices during lowering. Runtime
+instruction execution therefore performs neither recursive AST traversal nor
+semantic `SignalId` map lookup.
+
+The format is deliberately backend-neutral. It is the common compute IR for:
+
+- native reactive dependencies;
+- future tracing of pure Python expressions;
+- a SIMD/native CPU backend;
+- future WGSL lowering for sufficiently large kernels.
+
+A separate later "kernel IR" should not duplicate this compiler path.
+
+## Scheduling
+
+`DenseDirtyQueue` provides the scheduler primitive for dependency-local updates.
+A dense pending bitset prevents duplicate work and a compact rank heap preserves
+topological order. Scheduling operates on dense node indices/ranks only; ordered
+maps/sets of semantic IDs are not part of the update path.
+
+Propagation still follows Noon's change-stopping rule: if a recomputed derived
+value is unchanged, downstream nodes are not scheduled.
+
+## Validation strategy
+
+The IR owns a deterministic reference interpreter. Tests cover typed lowering,
+scalar/vector operations, invalid-type rejection, queue deduplication/order, and
+many-input agreement with direct reference math. During migration, randomized
+or corpus-based comparisons should keep the old expression evaluator available
+in tests only until all native reactive execution goes through `ComputeProgram`.
+
+## Backend contract
+
+The current interpreter is intentionally simple. Backend implementations must
+preserve:
+
+- typed instruction semantics and finite-value validation;
+- deterministic input/output ordering;
+- exact dependency-local invalidation behavior;
+- change stopping at unchanged derived nodes.
+
+GPU/SIMD work should specialize the execution backend rather than introduce a
+second semantic expression language.


### PR DESCRIPTION
Superseded by the fuller #95 implementation, which migrated `SceneInstance` native reactive execution onto the typed compute VM and has merged to `master`.

Tracks #55 / #68 Wave 1.