### PR TITLE
Add pinned ManimCE v0.21 public API coverage manifest

### DIFF
--- a/.github/workflows/manim-api-coverage.yml
+++ b/.github/workflows/manim-api-coverage.yml
@@ -1,0 +1,52 @@
+name: Manim API coverage
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: manim-api-coverage-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  coverage:
+    name: ManimCE 0.21.0 API inventory
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Manim system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            ffmpeg \
+            libcairo2-dev \
+            libpango1.0-dev \
+            pkg-config
+
+      - name: Install pinned ManimCE reference
+        run: python -m pip install --disable-pip-version-check "manim==0.21.0"
+
+      - name: Validate and report public API coverage
+        run: |
+          python scripts/manim-api-coverage.py \
+            --check \
+            --write-markdown artifacts/manim-v0.21-api-coverage.md
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: manim-v0.21-api-coverage
+          path: artifacts/manim-v0.21-api-coverage.md
+          if-no-files-found: error
+          retention-days: 14

--- a/compat/manim-v0.21.0.json
+++ b/compat/manim-v0.21.0.json
@@ -1,0 +1,72 @@
+{
+  "reference": {
+    "package": "manim",
+    "version": "0.21.0"
+  },
+  "statuses": [
+    "supported",
+    "partial",
+    "blocked",
+    "deferred",
+    "intentional-divergence",
+    "missing"
+  ],
+  "overrides": {
+    "Mobject": {"status": "partial", "category": "core-object", "dependency": "#74", "reason": "Common transform/style/layout methods exist; full family/state/query parity is pending."},
+    "VMobject": {"status": "partial", "category": "core-object", "dependency": "#74/#78", "reason": "Vector object facade exists; full path-building/query semantics are pending."},
+    "Group": {"status": "partial", "category": "core-object", "dependency": "#51/#74", "reason": "Authoring group exists but retained semantic family identity is still being migrated."},
+    "VGroup": {"status": "partial", "category": "core-object", "dependency": "#51/#74", "reason": "Authoring group exists but retained semantic family identity is still being migrated."},
+    "Scene": {"status": "partial", "category": "scene", "dependency": "#89", "reason": "Core add/remove/play/wait lifecycle exists; ordering/camera/section breadth is pending."},
+    "Circle": {"status": "supported", "category": "geometry", "evidence": "#57"},
+    "Rectangle": {"status": "supported", "category": "geometry", "evidence": "#57"},
+    "Square": {"status": "supported", "category": "geometry", "evidence": "#57"},
+    "Line": {"status": "supported", "category": "geometry", "evidence": "#57"},
+    "Create": {"status": "supported", "category": "animation", "evidence": "browser compatibility tests"},
+    "FadeIn": {"status": "supported", "category": "animation", "evidence": "browser compatibility tests"},
+    "FadeOut": {"status": "supported", "category": "animation", "evidence": "browser compatibility tests"},
+    "Transform": {"status": "supported", "category": "animation", "evidence": "generic transform tests"},
+    "ReplacementTransform": {"status": "supported", "category": "animation", "evidence": "lifecycle tests"},
+    "TransformFromCopy": {"status": "supported", "category": "animation", "evidence": "transform-from-copy tests"},
+    "TransformMatchingShapes": {"status": "supported", "category": "animation", "evidence": "matching-shapes tests"},
+    "AnimationGroup": {"status": "supported", "category": "animation-composition", "evidence": "composition tests"},
+    "LaggedStart": {"status": "supported", "category": "animation-composition", "evidence": "composition tests"},
+    "Succession": {"status": "supported", "category": "animation-composition", "evidence": "composition tests"},
+    "ValueTracker": {"status": "supported", "category": "reactive", "evidence": "reactive authoring/runtime tests"},
+    "linear": {"status": "supported", "category": "rate-function", "evidence": "shared rate-function tests"},
+    "smooth": {"status": "supported", "category": "rate-function", "evidence": "shared rate-function tests"},
+    "rush_into": {"status": "supported", "category": "rate-function", "evidence": "shared rate-function tests"},
+    "rush_from": {"status": "supported", "category": "rate-function", "evidence": "shared rate-function tests"},
+    "there_and_back": {"status": "supported", "category": "rate-function", "evidence": "shared rate-function tests"}
+  },
+  "module_rules": [
+    {"prefix": "manim.mobject.text", "status": "blocked", "category": "text-math", "dependency": "#65/#83"},
+    {"prefix": "manim.mobject.graph", "status": "blocked", "category": "graph-network", "dependency": "#87"},
+    {"prefix": "manim.mobject.matrix", "status": "blocked", "category": "matrix-table", "dependency": "#84"},
+    {"prefix": "manim.mobject.table", "status": "blocked", "category": "matrix-table", "dependency": "#84"},
+    {"prefix": "manim.mobject.coordinate_systems", "status": "blocked", "category": "plotting", "dependency": "#85"},
+    {"prefix": "manim.mobject.functions", "status": "blocked", "category": "plotting", "dependency": "#85"},
+    {"prefix": "manim.mobject.number_line", "status": "blocked", "category": "plotting", "dependency": "#85"},
+    {"prefix": "manim.mobject.probability", "status": "blocked", "category": "visualization", "dependency": "#88"},
+    {"prefix": "manim.mobject.vector_field", "status": "blocked", "category": "visualization", "dependency": "#88"},
+    {"prefix": "manim.mobject.svg", "status": "blocked", "category": "asset-import", "dependency": "#79"},
+    {"prefix": "manim.mobject.three_d", "status": "deferred", "category": "3d", "dependency": "#90"},
+    {"prefix": "manim.scene.three_d_scene", "status": "deferred", "category": "3d", "dependency": "#90"},
+    {"prefix": "manim.scene.vector_space_scene", "status": "deferred", "category": "vector-space-scene", "dependency": "#90"},
+    {"prefix": "manim.scene.moving_camera_scene", "status": "blocked", "category": "scene-camera", "dependency": "#89"},
+    {"prefix": "manim.scene.zoomed_scene", "status": "blocked", "category": "scene-camera", "dependency": "#89"},
+    {"prefix": "manim.animation.transform_matching_parts", "status": "blocked", "category": "animation-transform", "dependency": "#82/#83"},
+    {"prefix": "manim.animation.transform", "status": "missing", "category": "animation-transform", "dependency": "#82"},
+    {"prefix": "manim.animation.indication", "status": "missing", "category": "animation-indication", "dependency": "#81"},
+    {"prefix": "manim.animation.changing", "status": "missing", "category": "animation-dynamic", "dependency": "#81"},
+    {"prefix": "manim.animation.updaters", "status": "missing", "category": "animation-dynamic", "dependency": "#81/#70"},
+    {"prefix": "manim.animation", "status": "missing", "category": "animation", "dependency": "#80/#81/#82"},
+    {"prefix": "manim.mobject.geometry", "status": "missing", "category": "geometry", "dependency": "#76/#77"},
+    {"prefix": "manim.mobject.types.vectorized_mobject", "status": "missing", "category": "vector-path", "dependency": "#74/#78"},
+    {"prefix": "manim.scene", "status": "missing", "category": "scene", "dependency": "#89"}
+  ],
+  "default": {
+    "status": "missing",
+    "category": "other-public-api",
+    "reason": "Public in ManimCE v0.21.0 and not yet classified as supported by Noon."
+  }
+}

--- a/docs/manim-api-coverage.md
+++ b/docs/manim-api-coverage.md
@@ -1,0 +1,29 @@
+# ManimCE v0.21.0 API coverage
+
+Noon pins user-facing compatibility work to **Manim Community v0.21.0**.
+
+API presence and behavioral parity are intentionally separate gates:
+
+- `scripts/manim-api-coverage.py` inventories the complete pinned Manim public namespace and classifies every symbol as `supported`, `partial`, `blocked`, `deferred`, `intentional-divergence`, or `missing`.
+- `scripts/manim-differential.py` compares renderer-independent behavior for features Noon actually claims to support.
+
+The classification policy lives in `compat/manim-v0.21.0.json`. Module-level rules make large known gaps such as text/math, plotting, graph networks, and 3D explicit, while individual overrides record supported or partially supported public symbols.
+
+## Running the report
+
+Install the pinned reference and run:
+
+```bash
+python -m pip install "manim==0.21.0"
+python scripts/manim-api-coverage.py --check
+```
+
+CI also writes `manim-v0.21-api-coverage.md` as a workflow artifact. The report includes status totals, category totals, and the complete non-supported symbol list with issue dependencies where known.
+
+## Updating compatibility
+
+A parity PR that exposes a new Manim-compatible public symbol should update `compat/manim-v0.21.0.json` and add behavioral evidence when applicable. Exporting a name alone does not prove compatibility: unreviewed Noon exports resolve to `partial` rather than being automatically promoted to `supported`.
+
+Features blocked by architectural work should remain visibly `blocked` and name the relevant issue. Full 3D/vector-space behavior is deliberately `deferred` until #90 defines the intended compatibility target.
+
+This coverage report is an inventory, not a promise that every Manim symbol will be implemented. Intentional browser/runtime divergences should be recorded explicitly rather than silently omitted.

--- a/scripts/manim-api-coverage.py
+++ b/scripts/manim-api-coverage.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Report Noon coverage of the pinned ManimCE public namespace.
+
+This intentionally measures API *presence/classification*, not behavioral parity.
+Behavioral equivalence belongs to scripts/manim-differential.py (#57).
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+PY_ROOT = ROOT / "web" / "python"
+
+
+def _literal_strings(node: ast.AST) -> set[str]:
+    try:
+        value = ast.literal_eval(node)
+    except (ValueError, TypeError):
+        return set()
+    if isinstance(value, (list, tuple, set)):
+        return {item for item in value if isinstance(item, str)}
+    return set()
+
+
+def _dict_string_keys(node: ast.AST) -> set[str]:
+    if not isinstance(node, ast.Dict):
+        return set()
+    result: set[str] = set()
+    for key in node.keys:
+        if isinstance(key, ast.Constant) and isinstance(key.value, str):
+            result.add(key.value)
+    return result
+
+
+def noon_public_exports() -> set[str]:
+    """Statically recover the runtime ``noon.__all__`` construction.
+
+    Noon installs compatibility adapters by extending ``noon.__all__`` from small
+    ``public = {...}`` dictionaries. Static extraction avoids importing Pyodide-only
+    ``js`` bridge modules in this CPython compatibility job.
+    """
+
+    exports: set[str] = set()
+    sources = [PY_ROOT / "noon.py", *sorted(PY_ROOT.glob("_manim*.py"))]
+    for path in sources:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if isinstance(target, ast.Name) and target.id == "__all__":
+                        exports.update(_literal_strings(node.value))
+                    if isinstance(target, ast.Name) and target.id == "public":
+                        exports.update(_dict_string_keys(node.value))
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+                if node.func.attr == "append" and len(node.args) == 1:
+                    arg = node.args[0]
+                    if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                        receiver = ast.unparse(node.func.value)
+                        if receiver.endswith(".__all__") or receiver == "__all__":
+                            exports.add(arg.value)
+    return exports
+
+
+def manim_public_exports(manim: Any) -> list[str]:
+    explicit = getattr(manim, "__all__", None)
+    if explicit:
+        return sorted({name for name in explicit if isinstance(name, str)})
+    return sorted(name for name in dir(manim) if not name.startswith("_"))
+
+
+def module_name(value: Any) -> str:
+    return str(getattr(value, "__module__", ""))
+
+
+def classify(name: str, value: Any, noon_exports: set[str], policy: dict[str, Any]) -> dict[str, Any]:
+    override = policy.get("overrides", {}).get(name)
+    if override is not None:
+        result = dict(override)
+    else:
+        module = module_name(value)
+        result = None
+        for rule in policy.get("module_rules", []):
+            if module.startswith(rule["prefix"]):
+                result = dict(rule)
+                result.pop("prefix", None)
+                break
+        if result is None:
+            result = dict(policy["default"])
+
+    result["module"] = module_name(value)
+    result["noon_exported"] = name in noon_exports
+    if name in noon_exports and name not in policy.get("overrides", {}):
+        # Presence without a feature-specific classification is deliberately not
+        # promoted to supported. It remains visible as partial until reviewed.
+        result["status"] = "partial"
+        result["category"] = result.get("category", "unclassified-noon-export")
+        result.setdefault("reason", "Exported by Noon but not yet behaviorally classified.")
+    return result
+
+
+def validate(policy: dict[str, Any], manim: Any, rows: dict[str, dict[str, Any]]) -> list[str]:
+    errors: list[str] = []
+    expected_version = policy["reference"]["version"]
+    actual_version = str(getattr(manim, "__version__", ""))
+    if actual_version != expected_version:
+        errors.append(f"expected ManimCE {expected_version}, found {actual_version}")
+
+    valid_statuses = set(policy["statuses"])
+    upstream = set(rows)
+    for name, override in policy.get("overrides", {}).items():
+        if name not in upstream:
+            errors.append(f"manifest override {name!r} is not public in pinned ManimCE")
+        if override.get("status") not in valid_statuses:
+            errors.append(f"manifest override {name!r} has invalid status {override.get('status')!r}")
+
+    for name, row in rows.items():
+        if row["status"] not in valid_statuses:
+            errors.append(f"{name}: invalid resolved status {row['status']!r}")
+        if row["status"] in {"supported", "partial"} and not row["noon_exported"]:
+            errors.append(f"{name}: marked {row['status']} but is absent from Noon's public namespace")
+    return errors
+
+
+def render_markdown(version: str, rows: dict[str, dict[str, Any]]) -> str:
+    status_counts = Counter(row["status"] for row in rows.values())
+    category_counts: dict[str, Counter[str]] = defaultdict(Counter)
+    for row in rows.values():
+        category_counts[row["category"]][row["status"]] += 1
+
+    lines = [
+        f"# ManimCE {version} public API coverage",
+        "",
+        f"Total upstream public symbols: **{len(rows)}**",
+        "",
+        "| Status | Count |",
+        "| --- | ---: |",
+    ]
+    for status in sorted(status_counts):
+        lines.append(f"| {status} | {status_counts[status]} |")
+
+    lines.extend(["", "## By category", "", "| Category | supported | partial | blocked | deferred | missing | intentional-divergence |", "| --- | ---: | ---: | ---: | ---: | ---: | ---: |"])
+    for category in sorted(category_counts):
+        counts = category_counts[category]
+        lines.append(
+            f"| {category} | {counts['supported']} | {counts['partial']} | {counts['blocked']} | "
+            f"{counts['deferred']} | {counts['missing']} | {counts['intentional-divergence']} |"
+        )
+
+    lines.extend(["", "## Missing / blocked / deferred symbols", ""])
+    for name in sorted(rows):
+        row = rows[name]
+        if row["status"] == "supported":
+            continue
+        dependency = row.get("dependency", "")
+        reason = row.get("reason", "")
+        suffix = " · ".join(part for part in (dependency, reason) if part)
+        lines.append(f"- `{name}` — **{row['status']}** / {row['category']}" + (f" — {suffix}" if suffix else ""))
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", default="compat/manim-v0.21.0.json")
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--check", action="store_true")
+    parser.add_argument("--write-markdown")
+    args = parser.parse_args()
+
+    manifest_path = ROOT / args.manifest
+    policy = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    try:
+        import manim
+    except ImportError as exc:
+        raise SystemExit("Install pinned ManimCE before running this report") from exc
+
+    noon_exports = noon_public_exports()
+    names = manim_public_exports(manim)
+    rows = {name: classify(name, getattr(manim, name), noon_exports, policy) for name in names}
+    errors = validate(policy, manim, rows)
+
+    payload = {
+        "manim_version": manim.__version__,
+        "noon_public_exports": sorted(noon_exports),
+        "symbols": rows,
+        "errors": errors,
+    }
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(render_markdown(str(manim.__version__), rows))
+
+    if args.write_markdown:
+        output = ROOT / args.write_markdown
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(render_markdown(str(manim.__version__), rows), encoding="utf-8")
+
+    if errors:
+        for error in errors:
+            print(f"coverage error: {error}", file=sys.stderr)
+    return 1 if args.check and errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a machine-readable ManimCE 0.21.0 compatibility policy with supported/partial/blocked/deferred/missing classifications
- inventory the pinned upstream public namespace in CI instead of relying on an informal feature list
- statically recover Noon's runtime `__all__` construction without importing Pyodide-only JS bridge modules
- fail when a symbol is claimed supported/partial but is not actually exported by Noon
- emit a readable Markdown coverage artifact grouped by status/category
- document how parity PRs update the coverage policy

This complements #57: #57 tests behavior for supported features; this PR measures what public surface is present or missing.

Tracks #73.
Part of #93 first wave.