### PR TITLE
Constrain playground preview viewport

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,9 @@ jobs:
           npm install --no-save --ignore-scripts playwright@1.62.1 pngjs@7.0.0
           npx playwright install chromium
 
+      - name: Test playground viewport layout
+        run: node scripts/playground-layout-smoke.mjs
+
       - name: Test native reactive Python authoring
         run: node scripts/reactive-authoring-smoke.mjs
 

--- a/scripts/playground-layout-smoke.mjs
+++ b/scripts/playground-layout-smoke.mjs
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+
+import playwright from "playwright";
+
+const { chromium } = playwright;
+const port = Number(process.env.NOON_PLAYGROUND_LAYOUT_PORT ?? "4174");
+const baseUrl = `http://127.0.0.1:${port}`;
+const desktopMaxCanvasWidth = 44 * 16;
+
+let serverOutput = "";
+const server = spawn(
+  "python3",
+  ["-m", "http.server", String(port), "--bind", "127.0.0.1", "--directory", "."],
+  { stdio: ["ignore", "pipe", "pipe"] },
+);
+server.stdout.on("data", (chunk) => {
+  serverOutput += chunk;
+});
+server.stderr.on("data", (chunk) => {
+  serverOutput += chunk;
+});
+
+async function waitForServer() {
+  let lastError = null;
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    try {
+      const response = await fetch(`${baseUrl}/web/index.html`);
+      if (response.ok) {
+        return;
+      }
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Playground layout server did not start: ${lastError}\n${serverOutput}`);
+}
+
+async function layout(page) {
+  const canvas = await page.locator("#scene").boundingBox();
+  const wrap = await page.locator(".canvas-wrap").boundingBox();
+  assert.ok(canvas, "playground canvas must be laid out");
+  assert.ok(wrap, "canvas wrapper must be laid out");
+  const documentWidth = await page.evaluate(() => document.documentElement.scrollWidth);
+  const viewportWidth = await page.evaluate(() => window.innerWidth);
+  return { canvas, wrap, documentWidth, viewportWidth };
+}
+
+function assertCentered(canvas, wrap, label) {
+  const canvasCenter = canvas.x + canvas.width / 2;
+  const wrapCenter = wrap.x + wrap.width / 2;
+  assert.ok(
+    Math.abs(canvasCenter - wrapCenter) <= 2,
+    `${label}: canvas must stay centered in preview (${canvasCenter} vs ${wrapCenter})`,
+  );
+}
+
+function assertAspect(canvas, expected, label) {
+  const actual = canvas.width / canvas.height;
+  assert.ok(
+    Math.abs(actual - expected) <= 0.02,
+    `${label}: expected aspect ${expected.toFixed(3)}, got ${actual.toFixed(3)}`,
+  );
+}
+
+function assertNoOverflow(result, label) {
+  assert.ok(
+    result.documentWidth <= result.viewportWidth + 1,
+    `${label}: page overflowed horizontally (${result.documentWidth}px > ${result.viewportWidth}px)`,
+  );
+  assert.ok(
+    result.canvas.width <= result.wrap.width + 1,
+    `${label}: canvas overflowed its wrapper`,
+  );
+}
+
+let browser = null;
+try {
+  await waitForServer();
+  browser = await chromium.launch({ channel: "chromium", headless: true });
+  const context = await browser.newContext({
+    javaScriptEnabled: false,
+    viewport: { width: 1440, height: 900 },
+  });
+  const page = await context.newPage();
+  await page.goto(`${baseUrl}/web/index.html`, { waitUntil: "load" });
+
+  const desktop = await layout(page);
+  assert.ok(
+    desktop.canvas.width <= desktopMaxCanvasWidth + 1,
+    `desktop: canvas width ${desktop.canvas.width}px exceeds ${desktopMaxCanvasWidth}px cap`,
+  );
+  assertAspect(desktop.canvas, 16 / 9, "desktop");
+  assertCentered(desktop.canvas, desktop.wrap, "desktop");
+  assertNoOverflow(desktop, "desktop");
+
+  await page.setViewportSize({ width: 900, height: 800 });
+  const stacked = await layout(page);
+  assert.ok(
+    stacked.canvas.width <= desktopMaxCanvasWidth + 1,
+    `stacked: canvas width ${stacked.canvas.width}px exceeds ${desktopMaxCanvasWidth}px cap`,
+  );
+  assertAspect(stacked.canvas, 16 / 9, "stacked");
+  assertCentered(stacked.canvas, stacked.wrap, "stacked");
+  assertNoOverflow(stacked, "stacked");
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  const mobile = await layout(page);
+  assertAspect(mobile.canvas, 4 / 3, "mobile");
+  assertCentered(mobile.canvas, mobile.wrap, "mobile");
+  assertNoOverflow(mobile, "mobile");
+
+  console.log(
+    `✓ playground viewport: desktop ${desktop.canvas.width.toFixed(0)}×${desktop.canvas.height.toFixed(0)}, ` +
+      `stacked ${stacked.canvas.width.toFixed(0)}×${stacked.canvas.height.toFixed(0)}, ` +
+      `mobile ${mobile.canvas.width.toFixed(0)}×${mobile.canvas.height.toFixed(0)}`,
+  );
+} finally {
+  if (browser !== null) {
+    await browser.close();
+  }
+  server.kill("SIGTERM");
+}

--- a/web/index.html
+++ b/web/index.html
@@ -350,7 +350,7 @@
       canvas {
         display: block;
         width: 100%;
-        max-width: 64rem;
+        max-width: 44rem;
         aspect-ratio: 16 / 9;
         border: 1px solid #202a3e;
         border-radius: 0.8rem;


### PR DESCRIPTION
## Summary
- cap the live playground canvas at 44rem (704 CSS px) instead of allowing it to grow to 64rem
- keep the preview centered and preserve the existing 16:9 desktop / 4:3 mobile responsive behavior
- add a Chromium layout regression that checks desktop, stacked, and mobile viewport geometry and horizontal overflow
- run the new regression in the existing browser-reactive CI lane

The GPU renderer is intentionally unchanged: `main.js` already resizes the backing buffer from the canvas CSS dimensions and device-pixel ratio, and the web player recomputes camera width from the actual viewport aspect ratio. Existing browser-rendering smoke tests continue to validate scene pixels on WebGPU and WebGL2.

Closes #117.