### PR TITLE
Add test inventory and cross-language coverage observability

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -1,0 +1,120 @@
+name: Test coverage
+
+on:
+  pull_request:
+    paths:
+      - "crates/**"
+      - "web/**"
+      - "scripts/**"
+      - ".github/workflows/test-coverage.yml"
+  push:
+    branches:
+      - master
+    paths:
+      - "crates/**"
+      - "web/**"
+      - "scripts/**"
+      - ".github/workflows/test-coverage.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: test-coverage-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  inventory:
+    name: Test inventory
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Generate inventory
+        run: |
+          python3 scripts/test-inventory.py \
+            --check \
+            --json test-artifacts/test-inventory.json \
+            --markdown test-artifacts/test-inventory.md
+
+      - name: Upload inventory
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-inventory
+          path: test-artifacts/test-inventory.*
+          if-no-files-found: error
+          retention-days: 14
+
+  rust:
+    name: Rust coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use stable Rust
+        run: rustup default stable
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@13608cbb45b01feb47ef444ab1a42dc41ad56f1a
+        with:
+          tool: cargo-llvm-cov
+          fallback: none
+
+      - name: Generate Rust coverage
+        run: |
+          mkdir -p test-artifacts
+          cargo llvm-cov --workspace --all-features \
+            --lcov --output-path test-artifacts/rust.lcov
+
+      - name: Upload Rust coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: rust-coverage
+          path: test-artifacts/rust.lcov
+          if-no-files-found: error
+          retention-days: 14
+
+  scripting:
+    name: Python and JavaScript coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Python coverage
+        run: |
+          python -m pip install --disable-pip-version-check "coverage==7.6.12"
+          mkdir -p test-artifacts
+          coverage run --source=web/python \
+            -m unittest discover -s web/python -p 'test_*.py'
+          coverage json -o test-artifacts/python-coverage.json
+          coverage report > test-artifacts/python-coverage.txt
+          cat test-artifacts/python-coverage.txt
+
+      - name: JavaScript coverage
+        run: |
+          npm install --no-save --ignore-scripts c8@10.1.3
+          npx c8 \
+            --reporter=json-summary \
+            --reporter=text \
+            --report-dir=test-artifacts/js \
+            node --test web/*.test.mjs
+
+      - name: Upload scripting coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: scripting-coverage
+          path: |
+            test-artifacts/python-coverage.json
+            test-artifacts/python-coverage.txt
+            test-artifacts/js
+          if-no-files-found: error
+          retention-days: 14

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,46 +1,87 @@
 # Continuous integration policy
 
-Noon's redesign uses CI as a correctness gate, but not as the inner development loop.
+Noon uses CI as a correctness gate, but not as the inner development loop. The required workflow is split by subsystem so expensive browser work fans out after one reusable WASM build instead of rebuilding the package in every job.
+
+## Main CI workflow
+
+`.github/workflows/ci.yml` runs on pull requests, pushes to `master`, and manual dispatch.
+
+### Rust
+
+The Rust job runs on Ubuntu and requires:
+
+- `cargo fmt --all -- --check`;
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings`;
+- `cargo test --workspace --all-features`.
+
+Cargo sources and compiled Rust work are accelerated with sccache. The workspace is treated as one current architecture; there is no separate legacy compatibility gate.
+
+### Browser package build
+
+The web-build job:
+
+- syntax-checks the checked-in JavaScript harnesses;
+- runs Node unit tests;
+- compiles/checks the Python compatibility modules and examples;
+- runs the Python unittest suite;
+- builds `noon-web` for `wasm32-unknown-unknown` with pinned `wasm-pack`;
+- validates the generated JavaScript/TypeScript/WASM package surface;
+- uploads the package once for downstream browser jobs.
+
+PR CI intentionally skips `wasm-opt` in this fast package build. The production-optimized artifact is validated separately by the release/platform testing lane rather than making every browser job pay the optimization cost.
+
+### Browser authoring
+
+The authoring job consumes the shared browser package and runs:
+
+- Rust/Python semantic parity;
+- Manim-style Python compatibility;
+- composition authoring;
+- the executable Manim tutorial corpus.
+
+### Browser reactive/editor
+
+The reactive/editor job runs:
+
+- native reactive Python authoring;
+- native reactive browser runtime;
+- Python updater callback bridge;
+- Python editor syntax-highlighting/linting smoke coverage.
+
+### Browser rendering
+
+Rendering is a two-entry matrix over WebGPU and WebGL2 fallback. Both run the deterministic playground/browser smoke corpus and upload screenshots on success or failure. The required Linux browser path uses Playwright Chromium/SwiftShader so it is repeatable on hosted runners.
+
+## Manim compatibility workflows
+
+Manim API-surface and semantic compatibility are separate workflows because they require a pinned ManimCE/Python environment. Manim Community v0.21.0 is the reference version. API inventory and semantic differential tests should remain separate: surface presence does not prove behavior, and behavioral fixtures should not become a second API manifest.
+
+## Test inventory and coverage
+
+`.github/workflows/test-coverage.yml` is the observability workflow introduced by #104. It runs in parallel with normal CI when production/test files change and produces:
+
+- a generated machine-readable/Markdown test inventory;
+- Rust LCOV data from `cargo llvm-cov`;
+- Python coverage from the normal unit suite;
+- V8/c8 coverage for browser JavaScript unit modules.
+
+The inventory has a small required ratchet now: every production module must belong to an explicit test strategy. Line coverage is initially diagnostic. After a stable baseline is established, use changed-code or per-layer non-regression ratchets rather than an arbitrary global percentage.
+
+See `docs/testing.md` for the verification hierarchy and local commands.
+
+## Performance policy
+
+Shared GitHub runners are too noisy for small wall-clock regressions to be a reliable correctness gate. Required CI should prefer deterministic structural invariants such as:
+
+- objects/tracks/reactive nodes visited;
+- dirty slots and instances repacked;
+- upload bytes;
+- geometry/cache misses and rebuild counts;
+- host callback slots/payload size;
+- retained resource counts.
+
+Named-machine p50/p95 measurements remain useful diagnostic/release evidence and are documented in `docs/performance.md`.
 
 ## Development cadence
 
-During active architecture work:
-
-1. group several related edits into one coherent batch;
-2. stage connector-based changes as unreferenced Git objects when useful, so intermediate files do not trigger Actions;
-3. update the implementation branch once per batch;
-4. run the fast architecture gate on every draft-PR update;
-5. use the full legacy compatibility gate only at milestone boundaries, before review/merge, or when legacy code is touched intentionally.
-
-A batch can contain several implementation steps when they share one architectural seam. A failed fast gate blocks the next batch, but individual formatting or lint repairs should be folded into the next repair batch rather than serialized into separate CI cycles.
-
-## Fast architecture gate
-
-Every draft PR update validates the new engine crates only:
-
-- `cargo fmt --all -- --check`;
-- compile `noon-core`, `noon-compile`, and `noon-runtime` with all targets/features;
-- strict Clippy with `-D warnings` for those crates;
-- tests for those crates.
-
-As new architecture crates are introduced, they are added to this fast gate immediately.
-
-## Full compatibility gate
-
-The original `noon` and `examples` crates predate the redesign and carry substantial lint debt and heavy Nannou/wgpu dependencies. Full-workspace validation therefore runs when:
-
-- the pull request is no longer draft;
-- CI is manually dispatched;
-- changes land on `master`.
-
-The full gate compiles the complete workspace, runs legacy Clippy with lint levels capped to warnings, and runs all workspace tests except the explicitly documented broken legacy Lyon partial-path test.
-
-## Why this split exists
-
-The new architecture has no Nannou dependency and should iterate at Rust-library speed. Recompiling hundreds of legacy graphics dependencies after every semantic-core edit adds latency without increasing confidence in the code being changed. The split keeps new code strict while preserving a full compatibility check before integration.
-
-Cargo registry and target caches are enabled in both jobs to reduce repeated dependency work.
-
-Browser target checks, structural renderer checks, differential CPU/GPU checks, and visual regression tests will be added to the fast gate as those subsystems enter the workspace.
-
-Timing benchmarks remain separate from required correctness CI because shared GitHub runners are noisy. Required CI should prefer deterministic structural performance invariants such as batching counts, cache behavior, active-track work, and buffer-upload counts.
+Use local focused tests as the inner loop and update branches in coherent batches. A change should run the cheapest relevant subsystem tests first; the full required CI is the integration gate before merge. Avoid serializing tiny formatting/lint-only commits solely to trigger Actions repeatedly.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,61 @@
+# Testing strategy
+
+Noon uses several different correctness oracles because no single test style is sufficient for an interactive animation engine. Prefer the cheapest deterministic oracle that can prove a behavior and escalate to browser/raster testing only when the lower layer cannot observe the contract.
+
+## Test pyramid
+
+1. **Unit and structural tests** validate pure semantic, geometry, compiler, runtime, cache, and protocol invariants.
+2. **Integration tests** exercise crate boundaries, authoring lowering, patch/reconcile behavior, and shared runtime semantics.
+3. **Property/model tests** cover stateful mutation spaces where hand-written examples are incomplete.
+4. **Cross-layer differential/equivalence tests** compare independently implemented paths such as Rust/Python, native/WASM, direct seek/playback, and Noon/ManimCE.
+5. **Browser E2E tests** validate the deployed authoring/player stack and user-visible workflow.
+6. **Visual goldens** are reserved for raster-visible behavior that cannot be asserted structurally.
+7. **Performance measurements** use deterministic work counters in required CI and wall-clock measurements only on named/diagnostic runners.
+
+## Current required gates
+
+The main `CI` workflow runs:
+
+- workspace formatting, strict Clippy, and Rust tests;
+- the browser/WASM package build and package-surface validation;
+- Node unit tests and Python unit tests as part of the web build;
+- Rust/Python semantic parity, Manim compatibility, composition authoring, and the executable tutorial corpus;
+- native reactive authoring/runtime, updater callback bridge, and Python editor smoke tests;
+- browser rendering on both WebGPU and forced WebGL2 fallback paths.
+
+The separate Manim workflows pin ManimCE v0.21.0 for API-surface and semantic differential coverage.
+
+## Test inventory
+
+`scripts/test-inventory.py` scans production modules and test entry points across Rust, JavaScript, Python, browser smoke, and compatibility tooling. It emits JSON and Markdown reports and fails `--check` when a production module has no explicit layer/module test strategy.
+
+Run it locally with:
+
+```bash
+python3 scripts/test-inventory.py \
+  --check \
+  --json test-artifacts/test-inventory.json \
+  --markdown test-artifacts/test-inventory.md
+```
+
+The inventory is intentionally not a line-coverage number. It answers a different question: **which verification layer owns each production module, and what kinds of tests exist?**
+
+## Coverage reports
+
+`.github/workflows/test-coverage.yml` produces diagnostic line-coverage artifacts for the three source-language layers:
+
+- Rust: `cargo llvm-cov` LCOV output;
+- Python: `coverage.py` JSON/text output from the unit suite;
+- browser JavaScript unit modules: V8 coverage through `c8`.
+
+Generated wasm-bindgen output is not included. Coverage is initially a baseline/reporting signal rather than a global pass/fail percentage. Once the baseline is stable, ratchets should be applied per layer or to changed code; Noon should not optimize for an arbitrary repository-wide percentage.
+
+## Adding production code
+
+A new production module must have an explicit test strategy visible to the inventory. Depending on the behavior, that may be an inline unit suite, crate integration suite, Python/JS module suite, browser smoke/E2E coverage, or a combination.
+
+New compatibility surface should update the existing Manim coverage/differential infrastructure rather than adding a separate compatibility tracker. New renderer-visible behavior should reuse the shared browser/golden infrastructure rather than inventing feature-local screenshot tooling.
+
+## Performance testing policy
+
+Shared GitHub runners are noisy, so required correctness CI should not fail on small p50/p95 timing differences. Gate complexity with deterministic counters—objects/tracks visited, slots repacked, upload bytes, cache misses, callback slots, resource churn—then use the named-machine harnesses in `docs/performance.md` to measure wall-clock trends.

--- a/scripts/test-inventory.py
+++ b/scripts/test-inventory.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Generate a machine-readable inventory of Noon's production and test surface."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter, defaultdict
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+RUST_SOURCE = "crates/*/src/**/*.rs"
+RUST_INTEGRATION = "crates/*/tests/**/*.rs"
+JS_SOURCE = "web/*.js"
+JS_TEST = "web/*.test.mjs"
+PY_SOURCE = "web/python/*.py"
+PY_TEST = "web/python/test_*.py"
+BROWSER_TEST = "scripts/*smoke.mjs"
+
+GENERATED_OR_SUPPORT = {
+    "web/browser-smoke.js",  # harness loaded by scripts/browser-smoke.mjs
+}
+
+
+def rel(path: Path) -> str:
+    return path.relative_to(ROOT).as_posix()
+
+
+def crate_name(path: Path) -> str:
+    parts = path.relative_to(ROOT).parts
+    return parts[1] if len(parts) > 1 and parts[0] == "crates" else "unknown"
+
+
+def classify_test(path: Path) -> str:
+    name = path.name.lower()
+    text = rel(path)
+    if "manim-differential" in text:
+        return "differential"
+    if "perf" in name or "profile" in name:
+        return "performance"
+    if "smoke" in name:
+        return "browser-smoke"
+    if "property" in name or "fuzz" in name or "stress" in name:
+        return "property-stress"
+    if path.suffix == ".rs" and "/tests/" in f"/{text}":
+        return "integration"
+    return "unit"
+
+
+def production_layer(path: Path) -> str:
+    text = rel(path)
+    if text.startswith("crates/"):
+        return crate_name(path)
+    if text.startswith("web/python/"):
+        return "web-python"
+    if text.startswith("web/"):
+        return "web-js"
+    return "other"
+
+
+def source_strategy(
+    path: Path,
+    rust_tests_by_crate: dict[str, list[str]],
+    rust_inline_by_crate: set[str],
+    js_tests: set[str],
+    python_tests: list[str],
+) -> list[str]:
+    text = rel(path)
+    strategies: list[str] = []
+    if path.suffix == ".rs":
+        contents = path.read_text(encoding="utf-8")
+        crate = crate_name(path)
+        if "#[cfg(test)]" in contents:
+            strategies.append("inline-unit")
+        if crate in rust_inline_by_crate:
+            strategies.append("crate-unit")
+        if rust_tests_by_crate.get(crate):
+            strategies.append("crate-integration")
+    elif text.startswith("web/python/"):
+        module = path.stem
+        exact = f"web/python/test_{module.lstrip('_')}.py"
+        if exact in python_tests:
+            strategies.append("module-unit")
+        if python_tests:
+            strategies.append("python-suite")
+    elif text.startswith("web/"):
+        exact = path.with_suffix(".test.mjs").name
+        if f"web/{exact}" in js_tests:
+            strategies.append("module-unit")
+        if text in GENERATED_OR_SUPPORT:
+            strategies.append("browser-harness")
+        strategies.append("browser-smoke")
+    return sorted(set(strategies))
+
+
+def collect() -> dict[str, object]:
+    rust_sources = sorted(ROOT.glob(RUST_SOURCE))
+    rust_tests = sorted(ROOT.glob(RUST_INTEGRATION))
+    js_sources = sorted(ROOT.glob(JS_SOURCE))
+    js_tests_paths = sorted(ROOT.glob(JS_TEST))
+    python_sources = sorted(
+        path
+        for path in ROOT.glob(PY_SOURCE)
+        if not path.name.startswith("test_") and path.name != "playground_examples.py"
+    )
+    python_tests_paths = sorted(ROOT.glob(PY_TEST))
+    browser_tests = sorted(ROOT.glob(BROWSER_TEST))
+
+    special_tests = [
+        ROOT / "scripts/manim-differential.py",
+        ROOT / "scripts/manim-api-coverage.py",
+    ]
+    all_tests = [*rust_tests, *js_tests_paths, *python_tests_paths, *browser_tests]
+    all_tests.extend(path for path in special_tests if path.exists())
+
+    rust_tests_by_crate: dict[str, list[str]] = defaultdict(list)
+    for path in rust_tests:
+        rust_tests_by_crate[crate_name(path)].append(rel(path))
+    rust_inline_by_crate = {
+        crate_name(path)
+        for path in rust_sources
+        if "#[cfg(test)]" in path.read_text(encoding="utf-8")
+    }
+    js_test_names = {rel(path) for path in js_tests_paths}
+    python_test_names = [rel(path) for path in python_tests_paths]
+
+    production = [*rust_sources, *js_sources, *python_sources]
+    modules = []
+    uncovered = []
+    for path in production:
+        strategies = source_strategy(
+            path,
+            rust_tests_by_crate,
+            rust_inline_by_crate,
+            js_test_names,
+            python_test_names,
+        )
+        entry = {
+            "path": rel(path),
+            "layer": production_layer(path),
+            "strategies": strategies,
+        }
+        modules.append(entry)
+        if not strategies:
+            uncovered.append(entry["path"])
+
+    tests = [
+        {
+            "path": rel(path),
+            "layer": production_layer(path)
+            if not rel(path).startswith("scripts/")
+            else "browser/compat",
+            "type": classify_test(path),
+        }
+        for path in all_tests
+    ]
+
+    return {
+        "schema_version": 1,
+        "production_modules": modules,
+        "tests": tests,
+        "summary": {
+            "production_modules": len(modules),
+            "tests": len(tests),
+            "production_by_layer": dict(
+                sorted(Counter(item["layer"] for item in modules).items())
+            ),
+            "tests_by_type": dict(
+                sorted(Counter(item["type"] for item in tests).items())
+            ),
+            "uncovered_modules": uncovered,
+        },
+    }
+
+
+def markdown(report: dict[str, object]) -> str:
+    summary = report["summary"]
+    lines = [
+        "# Noon test inventory",
+        "",
+        "> Generated by `scripts/test-inventory.py`. The inventory describes test ownership/strategy; line coverage is emitted separately by the coverage workflow.",
+        "",
+        f"- Production modules: **{summary['production_modules']}**",
+        f"- Test entry points: **{summary['tests']}**",
+        f"- Modules without an explicit test strategy: **{len(summary['uncovered_modules'])}**",
+        "",
+        "## Production layers",
+        "",
+        "| Layer | Modules |",
+        "|---|---:|",
+    ]
+    for layer, count in summary["production_by_layer"].items():
+        lines.append(f"| `{layer}` | {count} |")
+    lines.extend(["", "## Test types", "", "| Type | Entry points |", "|---|---:|"])
+    for kind, count in summary["tests_by_type"].items():
+        lines.append(f"| `{kind}` | {count} |")
+    if summary["uncovered_modules"]:
+        lines.extend(["", "## Modules without an explicit strategy", ""])
+        lines.extend(f"- `{path}`" for path in summary["uncovered_modules"])
+    lines.extend(["", "## Test entry points", ""])
+    for item in report["tests"]:
+        lines.append(f"- `{item['path']}` — {item['type']}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--json", type=Path)
+    parser.add_argument("--markdown", type=Path)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="fail when a production module has no explicit test strategy",
+    )
+    args = parser.parse_args()
+
+    report = collect()
+    if args.json:
+        args.json.parent.mkdir(parents=True, exist_ok=True)
+        args.json.write_text(
+            json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+    if args.markdown:
+        args.markdown.parent.mkdir(parents=True, exist_ok=True)
+        args.markdown.write_text(markdown(report), encoding="utf-8")
+
+    summary = report["summary"]
+    print(
+        f"test inventory: {summary['production_modules']} production modules, "
+        f"{summary['tests']} test entry points, "
+        f"{len(summary['uncovered_modules'])} modules without explicit strategy"
+    )
+    if args.check and summary["uncovered_modules"]:
+        for path in summary["uncovered_modules"]:
+            print(f"uncovered: {path}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a generated Rust/Python/JavaScript/browser/compat test inventory with a required module-strategy check
- add diagnostic Rust `llvm-cov`, Python `coverage.py`, and JavaScript `c8` coverage artifacts in a separate parallel workflow
- document Noon's test pyramid, coverage policy, and performance-test policy
- replace the stale fast/legacy CI documentation with the current Rust/web-build/browser job topology

The initial ratchet is intentionally structural: every production module must belong to an explicit verification strategy. Line coverage is reported as a baseline first; changed-code/per-layer thresholds should be introduced only after that baseline is stable rather than inventing an arbitrary repository-wide percentage.

Closes #104.
Part of #116 Wave T0.