### PR TITLE
Add canonical end-to-end FPS profiling harness

### DIFF
--- a/docs/performance-harness.md
+++ b/docs/performance-harness.md
@@ -1,0 +1,80 @@
+# End-to-end performance harness
+
+This document describes the browser FPS/frame-time harness tracked by #125. It complements `docs/performance.md`: deterministic structural counters remain the right CI gate for complexity regressions, while wall-clock FPS and stage timings belong on named machines or controlled real devices.
+
+## What the harness measures
+
+Every measured browser case reports:
+
+- effective FPS and requestAnimationFrame interval p50/p95/p99/max;
+- long-frame rate and estimated missed vsyncs against a configurable target refresh rate;
+- browser-visible synchronous `renderFrame` call duration;
+- Noon CPU frame time split into runtime evaluation, frame preparation, upload, and encode/submit;
+- draw calls, rendered instances, upload bytes, and geometry-cache misses;
+- WebGPU render-pass p50/p95 (and p99 when exposed by the runtime) when timestamp queries are supported;
+- browser/backend/resolution/DPR metadata.
+
+The runner records host commit/OS/CPU metadata in the aggregate artifact. Do not compare absolute timing numbers across unlike machines as if they were regressions.
+
+## Canonical analytic workloads
+
+The initial workload family deliberately contains three layouts so different bottlenecks can be isolated:
+
+- `fit`: circles fill the view and shrink as object count rises. This is useful for instance/object-count scaling with bounded pixel pressure.
+- `fixed`: camera scale and circle radius remain fixed while object count rises. This prevents high-count cases from becoming artificially cheap simply because every object becomes sub-pixel.
+- `overdraw`: many translucent circles overlap in a small screen region. This intentionally stresses fragment shading and alpha blending.
+
+These are synthetic attribution workloads, not claims about normal authored scene complexity. Realistic Manim-style cases are tracked separately by #134 and should consume the same result schema.
+
+## Run the matrix
+
+Build the optimized browser package first:
+
+```bash
+bash scripts/build-web-demo.sh
+```
+
+Install Playwright if it is not already available in the working tree, then run:
+
+```bash
+node scripts/perf-profile.mjs
+```
+
+By default this measures 1k, 10k, and 100k objects for all three analytic layouts, with 30 warmup frames and 300 measured frames at a 960x540 backing resolution.
+
+Useful environment overrides:
+
+```text
+NOON_PERF_BACKEND=webgpu|webgl
+NOON_PERF_COUNTS=1000,10000,100000
+NOON_PERF_LAYOUTS=fit,fixed,overdraw
+NOON_PERF_WARMUP=30
+NOON_PERF_FRAMES=300
+NOON_PERF_TARGET_HZ=60
+NOON_PERF_WIDTH=960
+NOON_PERF_HEIGHT=540
+NOON_PERF_ARTIFACT=perf-artifacts/perf-profile-webgpu.json
+```
+
+For a quick smoke run on a developer machine:
+
+```bash
+NOON_PERF_COUNTS=1000 NOON_PERF_LAYOUTS=fit NOON_PERF_FRAMES=60 node scripts/perf-profile.mjs
+```
+
+## Interpretation
+
+Do not attribute a bottleneck from FPS alone. Compare the frame interval distribution with the stage timings:
+
+- high runtime evaluation points toward timeline/reactive/host execution work (#126);
+- high prepare/upload/encode time points toward renderer CPU work (#127);
+- low CPU time with high GPU timestamps points toward raster/overdraw/backend limits (#128);
+- frame intervals much larger than both engine CPU and GPU time point toward browser scheduling, worker/Python activity, long tasks, or GC (#130/#132);
+- vector-heavy workloads require the dedicated geometry/morph attribution in #129;
+- Run/edit/seek latency is measured separately by #131.
+
+The initial browser runner profiles static analytic scenes. Other performance lanes should add workload generators and counters while preserving this result vocabulary rather than creating incompatible one-off formats.
+
+## Regression policy
+
+Do not hard-gate shared CI on wall-clock FPS from hosted runners. Use #113 deterministic work counters for structural/locality regressions. Store named-machine artifacts for trend comparison and add deterministic counters whenever profiling discovers an accidental full-scene scan/repack/upload or other algorithmic regression.

--- a/scripts/build-web-demo.sh
+++ b/scripts/build-web-demo.sh
@@ -11,8 +11,11 @@ node --check web/python-worker.js
 node --check web/scene-pipeline-perf.mjs
 node --check web/gpu-profile.js
 node --check web/morph-profile.js
+node --check web/perf-profile.js
+node --check web/perf-workloads.js
 node --check web/browser-smoke.js
 node --check scripts/browser-smoke.mjs
+node --check scripts/perf-profile.mjs
 node --check scripts/deterministic-replay-smoke.mjs
 node --check scripts/manim-compat-smoke.mjs
 node --check scripts/manim-tutorial-smoke.mjs
@@ -23,6 +26,7 @@ node --check scripts/updater-callback-smoke.mjs
 node --test web/authoring-client.test.mjs
 node --test web/scene-identity.test.mjs
 node --test web/frame-metrics.test.mjs
+node --test web/perf-workloads.test.mjs
 PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile \
   web/python/_manim_compat.py \
   web/python/_manim_rate_functions.py \

--- a/scripts/perf-profile.mjs
+++ b/scripts/perf-profile.mjs
@@ -1,0 +1,199 @@
+import assert from "node:assert/strict";
+import { spawn, spawnSync } from "node:child_process";
+import { mkdir, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import playwright from "playwright";
+
+const { chromium } = playwright;
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const port = Number(process.env.NOON_PERF_PORT ?? "4175");
+const baseUrl = `http://127.0.0.1:${port}`;
+const backend = process.env.NOON_PERF_BACKEND ?? "webgpu";
+assert.ok(backend === "webgpu" || backend === "webgl", `unknown backend: ${backend}`);
+
+const counts = integerList(process.env.NOON_PERF_COUNTS ?? "1000,10000,100000");
+const layouts = stringList(process.env.NOON_PERF_LAYOUTS ?? "fit,fixed,overdraw");
+for (const layout of layouts) {
+  assert.ok(["fit", "fixed", "overdraw"].includes(layout), `unknown layout: ${layout}`);
+}
+const warmup = positiveInteger(process.env.NOON_PERF_WARMUP ?? "30", "NOON_PERF_WARMUP");
+const frames = positiveInteger(process.env.NOON_PERF_FRAMES ?? "300", "NOON_PERF_FRAMES");
+const targetHz = positiveNumber(process.env.NOON_PERF_TARGET_HZ ?? "60", "NOON_PERF_TARGET_HZ");
+const width = positiveInteger(process.env.NOON_PERF_WIDTH ?? "960", "NOON_PERF_WIDTH");
+const height = positiveInteger(process.env.NOON_PERF_HEIGHT ?? "540", "NOON_PERF_HEIGHT");
+const artifactPath = path.resolve(
+  repoRoot,
+  process.env.NOON_PERF_ARTIFACT ?? `perf-artifacts/perf-profile-${backend}.json`,
+);
+
+const commit = spawnSync("git", ["rev-parse", "HEAD"], {
+  cwd: repoRoot,
+  encoding: "utf8",
+});
+const commitSha = commit.status === 0 ? commit.stdout.trim() : null;
+
+let serverOutput = "";
+const server = spawn(
+  "python3",
+  ["-m", "http.server", String(port), "--bind", "127.0.0.1", "--directory", repoRoot],
+  { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] },
+);
+server.stdout.on("data", (chunk) => {
+  serverOutput += chunk;
+});
+server.stderr.on("data", (chunk) => {
+  serverOutput += chunk;
+});
+
+let browser = null;
+try {
+  await waitForServer();
+  browser = await chromium.launch({
+    channel: "chromium",
+    headless: true,
+    args: browserArgs(backend),
+  });
+
+  const results = [];
+  for (const layout of layouts) {
+    for (const objects of counts) {
+      const page = await browser.newPage({ viewport: { width: 1200, height: 900 } });
+      const errors = [];
+      page.on("pageerror", (error) => errors.push(`pageerror: ${error}`));
+      page.on("console", (message) => {
+        if (message.type() === "error") {
+          errors.push(`console: ${message.text()}`);
+        }
+      });
+
+      const query = new URLSearchParams({
+        objects: String(objects),
+        layout,
+        warmup: String(warmup),
+        frames: String(frames),
+        targetHz: String(targetHz),
+        width: String(width),
+        height: String(height),
+      });
+      process.stdout.write(`Profiling ${backend} ${layout} ${objects.toLocaleString()} objects… `);
+      await page.goto(`${baseUrl}/web/perf-profile.html?${query}`, { waitUntil: "load" });
+      await page.waitForFunction(
+        () => window.__NOON_PERF_REPORT__ || document.querySelector("#status")?.dataset.state === "error",
+        null,
+        { timeout: 180_000 },
+      );
+      const state = await page.locator("#status").getAttribute("data-state");
+      if (state === "error") {
+        const message = await page.locator("#status").textContent();
+        throw new Error(`${layout}/${objects} failed: ${message}\n${errors.join("\n")}`);
+      }
+      const report = await page.evaluate(() => window.__NOON_PERF_REPORT__);
+      assert.equal(report.workload.objects, objects);
+      assert.equal(report.workload.layout, layout);
+      results.push(report);
+      console.log(
+        `${format(report.cadence.effective?.effectiveFps)} FPS, ` +
+          `p95 ${format(report.cadence.frameIntervalMs?.p95)} ms, ` +
+          `CPU ${format(report.cpu.frameMs?.p95)} ms, ` +
+          `GPU ${format(report.gpu.renderPassMs?.p95)} ms`,
+      );
+      await page.close();
+    }
+  }
+
+  const artifact = {
+    schemaVersion: 1,
+    benchmark: "Noon canonical browser performance matrix",
+    generatedAt: new Date().toISOString(),
+    commit: commitSha,
+    host: {
+      platform: os.platform(),
+      release: os.release(),
+      arch: os.arch(),
+      cpu: os.cpus()[0]?.model ?? null,
+      logicalCpuCount: os.cpus().length,
+      totalMemoryBytes: os.totalmem(),
+      node: process.version,
+    },
+    configuration: { backend, counts, layouts, warmup, frames, targetHz, width, height },
+    cases: results,
+  };
+  await mkdir(path.dirname(artifactPath), { recursive: true });
+  await writeFile(artifactPath, `${JSON.stringify(artifact, null, 2)}\n`, "utf8");
+  console.log(`Wrote ${path.relative(repoRoot, artifactPath)}`);
+} finally {
+  await browser?.close();
+  server.kill("SIGTERM");
+}
+
+async function waitForServer() {
+  let lastError = null;
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    try {
+      const response = await fetch(`${baseUrl}/web/perf-profile.html`);
+      if (response.ok) {
+        return;
+      }
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Performance server did not start: ${lastError}\n${serverOutput}`);
+}
+
+function browserArgs(mode) {
+  if (mode === "webgpu") {
+    return [
+      "--enable-unsafe-webgpu",
+      "--use-gpu-in-tests",
+      "--ignore-gpu-blocklist",
+      "--disable-gpu-sandbox",
+      "--disable-dev-shm-usage",
+    ];
+  }
+  return [
+    "--disable-features=WebGPU",
+    "--ignore-gpu-blocklist",
+    "--disable-gpu-sandbox",
+    "--disable-dev-shm-usage",
+  ];
+}
+
+function integerList(value) {
+  const values = stringList(value).map((item) => positiveInteger(item, "count"));
+  assert.ok(values.length > 0, "at least one object count is required");
+  return values;
+}
+
+function stringList(value) {
+  return String(value)
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function positiveInteger(value, name) {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must contain positive integers`);
+  }
+  return parsed;
+}
+
+function positiveNumber(value, name) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be positive`);
+  }
+  return parsed;
+}
+
+function format(value) {
+  return Number.isFinite(value) ? Number(value).toFixed(2) : "—";
+}

--- a/web/frame-metrics.js
+++ b/web/frame-metrics.js
@@ -2,6 +2,14 @@ export class FrameMetrics {
   #lastTimestamp = null;
   #submissionMs = [];
   #intervalMs = [];
+  #targetHz;
+
+  constructor({ targetHz = 60 } = {}) {
+    if (!Number.isFinite(targetHz) || targetHz <= 0) {
+      throw new RangeError("targetHz must be a positive finite number");
+    }
+    this.#targetHz = targetHz;
+  }
 
   reset() {
     this.#lastTimestamp = null;
@@ -25,6 +33,7 @@ export class FrameMetrics {
       frames: this.#submissionMs.length,
       submission: summarizeSamples(this.#submissionMs),
       interval: summarizeSamples(this.#intervalMs),
+      cadence: summarizeCadence(this.#intervalMs, this.#targetHz),
     };
   }
 }
@@ -72,10 +81,47 @@ export function summarizeSamples(samples) {
     return null;
   }
   return {
+    min: sorted[0],
     p50: percentile(sorted, 0.5),
     p95: percentile(sorted, 0.95),
+    p99: percentile(sorted, 0.99),
     max: sorted.at(-1),
     mean: sorted.reduce((sum, value) => sum + value, 0) / sorted.length,
+  };
+}
+
+export function summarizeCadence(samples, targetHz = 60) {
+  if (!Number.isFinite(targetHz) || targetHz <= 0) {
+    throw new RangeError("targetHz must be a positive finite number");
+  }
+  const intervals = Array.isArray(samples)
+    ? samples.map(Number).filter((value) => Number.isFinite(value) && value >= 0)
+    : [];
+  if (intervals.length === 0) {
+    return null;
+  }
+
+  const targetFrameMs = 1000 / targetHz;
+  const totalMs = intervals.reduce((sum, value) => sum + value, 0);
+  const longFrameThresholdMs = targetFrameMs * 1.5;
+  const veryLongFrameThresholdMs = targetFrameMs * 2.5;
+  const longFrames = intervals.filter((value) => value >= longFrameThresholdMs).length;
+  const veryLongFrames = intervals.filter((value) => value >= veryLongFrameThresholdMs).length;
+  const missedVsyncs = intervals.reduce(
+    (sum, value) => sum + Math.max(0, Math.round(value / targetFrameMs) - 1),
+    0,
+  );
+
+  return {
+    targetHz,
+    targetFrameMs,
+    effectiveFps: totalMs > 0 ? (intervals.length * 1000) / totalMs : null,
+    longFrameThresholdMs,
+    longFrames,
+    longFrameRate: longFrames / intervals.length,
+    veryLongFrameThresholdMs,
+    veryLongFrames,
+    missedVsyncs,
   };
 }
 

--- a/web/frame-metrics.test.mjs
+++ b/web/frame-metrics.test.mjs
@@ -1,34 +1,72 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { FrameMetrics, SampleWindow, summarizeSamples } from "./frame-metrics.js";
+import {
+  FrameMetrics,
+  SampleWindow,
+  summarizeCadence,
+  summarizeSamples,
+} from "./frame-metrics.js";
 
 test("summarizes deterministic frame percentiles", () => {
   assert.deepEqual(summarizeSamples([4, 1, 3, 2]), {
+    min: 1,
     p50: 2,
     p95: 4,
+    p99: 4,
     max: 4,
     mean: 2.5,
   });
   assert.equal(summarizeSamples([]), null);
 });
 
+test("summarizes effective FPS, long frames, and missed vsyncs", () => {
+  const summary = summarizeCadence([16, 17, 33, 50], 60);
+  assert.equal(summary.targetHz, 60);
+  assert.ok(Math.abs(summary.targetFrameMs - 1000 / 60) < 1e-9);
+  assert.ok(Math.abs(summary.effectiveFps - 1000 / 29) < 1e-9);
+  assert.equal(summary.longFrames, 2);
+  assert.equal(summary.veryLongFrames, 1);
+  assert.equal(summary.missedVsyncs, 3);
+  assert.equal(summary.longFrameRate, 0.5);
+  assert.equal(summarizeCadence([], 60), null);
+  assert.throws(() => summarizeCadence([16], 0), /positive finite/);
+});
+
 test("records submission time separately from presentation cadence", () => {
-  const metrics = new FrameMetrics();
+  const metrics = new FrameMetrics({ targetHz: 60 });
   metrics.record(100, 0.5);
   metrics.record(116, 0.75);
   metrics.record(133, 1.0);
 
-  assert.deepEqual(metrics.summary(), {
-    frames: 3,
-    submission: { p50: 0.75, p95: 1, max: 1, mean: 0.75 },
-    interval: { p50: 16, p95: 17, max: 17, mean: 16.5 },
+  const summary = metrics.summary();
+  assert.deepEqual(summary.submission, {
+    min: 0.5,
+    p50: 0.75,
+    p95: 1,
+    p99: 1,
+    max: 1,
+    mean: 0.75,
   });
+  assert.deepEqual(summary.interval, {
+    min: 16,
+    p50: 16,
+    p95: 17,
+    p99: 17,
+    max: 17,
+    mean: 16.5,
+  });
+  assert.equal(summary.frames, 3);
+  assert.ok(Math.abs(summary.cadence.effectiveFps - 1000 / 16.5) < 1e-9);
+  assert.equal(summary.cadence.longFrames, 0);
+  assert.equal(summary.cadence.missedVsyncs, 0);
+
   metrics.reset();
   assert.deepEqual(metrics.summary(), {
     frames: 0,
     submission: null,
     interval: null,
+    cadence: null,
   });
 });
 
@@ -41,8 +79,10 @@ test("bounded sample windows retain recent measurements", () => {
 
   assert.equal(samples.size, 3);
   assert.deepEqual(samples.summary(), {
+    min: 2,
     p50: 3,
     p95: 10,
+    p99: 10,
     max: 10,
     mean: 5,
   });
@@ -53,8 +93,9 @@ test("bounded sample windows retain recent measurements", () => {
   assert.throws(() => samples.record(Number.NaN), /finite values/);
 });
 
-test("rejects non-finite measurements", () => {
+test("rejects invalid frame-metric inputs", () => {
   const metrics = new FrameMetrics();
   assert.throws(() => metrics.record(Number.NaN, 1), /finite timestamps/);
   assert.throws(() => metrics.record(1, Number.POSITIVE_INFINITY), /finite timestamps/);
+  assert.throws(() => new FrameMetrics({ targetHz: Number.NaN }), /positive finite/);
 });

--- a/web/perf-profile.html
+++ b/web/perf-profile.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="data:," />
+    <title>Noon performance profiler</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        background: #090c13;
+        color: #e9efff;
+      }
+      body {
+        width: min(96vw, 80rem);
+        margin: 1.5rem auto;
+      }
+      canvas {
+        display: block;
+        width: 100%;
+        max-height: 70vh;
+        border: 1px solid #29334b;
+        border-radius: 0.75rem;
+      }
+      output {
+        display: block;
+        margin-bottom: 1rem;
+        white-space: pre-wrap;
+      }
+      pre {
+        overflow: auto;
+        max-height: 28rem;
+        padding: 1rem;
+        border: 1px solid #29334b;
+        border-radius: 0.75rem;
+        background: #0d1220;
+      }
+    </style>
+  </head>
+  <body>
+    <output id="status" data-state="starting">Building performance workload…</output>
+    <canvas id="scene" width="960" height="540" aria-label="Noon performance profiling scene"></canvas>
+    <pre id="json" aria-label="Performance result JSON"></pre>
+    <script type="module" src="./perf-profile.js"></script>
+  </body>
+</html>

--- a/web/perf-profile.js
+++ b/web/perf-profile.js
@@ -1,0 +1,215 @@
+import init, { NoonCanvasPlayer } from "./pkg/noon_web.js";
+import { FrameMetrics, SampleWindow } from "./frame-metrics.js";
+import { ANALYTIC_LAYOUTS, buildAnalyticScene } from "./perf-workloads.js";
+
+const parameters = new URLSearchParams(location.search);
+const objectCount = positiveInteger("objects", 10_000);
+const warmupFrames = positiveInteger("warmup", 30);
+const measuredFrames = positiveInteger("frames", 300);
+const targetHz = positiveNumber("targetHz", 60);
+const width = positiveInteger("width", 960);
+const height = positiveInteger("height", 540);
+const layout = parameters.get("layout") ?? "fit";
+if (!ANALYTIC_LAYOUTS.includes(layout)) {
+  throw new Error(`layout must be one of ${ANALYTIC_LAYOUTS.join(", ")}`);
+}
+
+const canvas = document.querySelector("#scene");
+const status = document.querySelector("#status");
+const output = document.querySelector("#json");
+canvas.width = width;
+canvas.height = height;
+canvas.style.aspectRatio = `${width} / ${height}`;
+
+let player = null;
+try {
+  await init();
+  const workload = buildAnalyticScene({ count: objectCount, layout, aspect: width / height });
+  const createStarted = performance.now();
+  player = await NoonCanvasPlayer.create(canvas, JSON.stringify(workload.document), 4.0);
+  const playerCreateMs = performance.now() - createStarted;
+  player.resize(width, height);
+  player.setCamera(0, 0, workload.cameraHeight);
+
+  const gpuSupported = player.gpuProfilingSupported();
+  player.setGpuProfilingEnabled(gpuSupported);
+  player.resetGpuProfiling();
+
+  status.value = `Warming ${layout} / ${objectCount.toLocaleString()} objects…`;
+  for (let frame = 0; frame < warmupFrames; frame += 1) {
+    const timestamp = await nextAnimationFrame();
+    player.renderFrame(timestamp);
+  }
+
+  player.resetGpuProfiling();
+  player.resetClock();
+  const cadence = new FrameMetrics({ targetHz });
+  const windows = {
+    cpuFrameMs: new SampleWindow(measuredFrames),
+    runtimeMs: new SampleWindow(measuredFrames),
+    prepareMs: new SampleWindow(measuredFrames),
+    uploadMs: new SampleWindow(measuredFrames),
+    encodeSubmitMs: new SampleWindow(measuredFrames),
+  };
+  let measured = 0;
+  while (measured < measuredFrames) {
+    status.value = `Measuring ${measured + 1}/${measuredFrames} · ${layout} / ${objectCount.toLocaleString()} objects…`;
+    const timestamp = await nextAnimationFrame();
+    const started = performance.now();
+    const presented = player.renderFrame(timestamp);
+    const browserCallMs = performance.now() - started;
+    if (!presented) {
+      continue;
+    }
+
+    cadence.record(timestamp, browserCallMs);
+    recordPlayerMetric(windows.cpuFrameMs, player.lastCpuFrameMs(), "cpu frame");
+    recordPlayerMetric(windows.runtimeMs, player.lastRuntimeEvaluationMs(), "runtime");
+    recordPlayerMetric(windows.prepareMs, player.lastFramePrepareMs(), "prepare");
+    recordPlayerMetric(windows.uploadMs, player.lastUploadMs(), "upload");
+    recordPlayerMetric(windows.encodeSubmitMs, player.lastEncodeSubmitMs(), "encode/submit");
+    measured += 1;
+  }
+
+  await waitForGpuSamples(player, gpuSupported, measuredFrames);
+  const frame = cadence.summary();
+  const report = {
+    schemaVersion: 1,
+    benchmark: "Noon end-to-end analytic frame profile",
+    generatedAt: new Date().toISOString(),
+    workload: {
+      family: "analytic-static",
+      layout,
+      description: workload.description,
+      objects: objectCount,
+    },
+    environment: {
+      userAgent: navigator.userAgent,
+      rendererBackend: player.rendererBackend(),
+      hardwareConcurrency: navigator.hardwareConcurrency ?? null,
+      deviceMemoryGiB: navigator.deviceMemory ?? null,
+      devicePixelRatio: window.devicePixelRatio || 1,
+      canvasCssSize: [canvas.clientWidth, canvas.clientHeight],
+      backingResolution: [width, height],
+      targetHz,
+      observedRefreshHz:
+        frame.interval?.p50 > 0 ? 1000 / frame.interval.p50 : null,
+      crossOriginIsolated: window.crossOriginIsolated,
+    },
+    setup: {
+      playerCreateMs,
+      warmupFrames,
+      measuredFrames: frame.frames,
+    },
+    cadence: {
+      frameIntervalMs: frame.interval,
+      effective: frame.cadence,
+      browserRenderCallMs: frame.submission,
+    },
+    cpu: {
+      frameMs: windows.cpuFrameMs.summary(),
+      runtimeEvaluationMs: windows.runtimeMs.summary(),
+      framePrepareMs: windows.prepareMs.summary(),
+      uploadMs: windows.uploadMs.summary(),
+      encodeSubmitMs: windows.encodeSubmitMs.summary(),
+    },
+    renderer: {
+      drawCalls: player.lastDrawCalls(),
+      instances: player.lastInstancesDrawn(),
+      lastUploadBytes: player.lastBytesUploaded(),
+      geometryCacheMisses: player.lastGeometryCacheMisses(),
+    },
+    gpu: gpuSupported
+      ? {
+          timestampSupported: true,
+          samples: player.gpuProfiledFrameCount(),
+          dropped: player.gpuDroppedSampleCount(),
+          failed: player.gpuFailedSampleCount(),
+          renderPassMs: {
+            p50: finiteOrNull(player.gpuRenderP50Ms()),
+            p95: finiteOrNull(player.gpuRenderP95Ms()),
+            p99:
+              typeof player.gpuRenderP99Ms === "function"
+                ? finiteOrNull(player.gpuRenderP99Ms())
+                : null,
+            last: finiteOrNull(player.lastGpuRenderMs()),
+          },
+        }
+      : { timestampSupported: false },
+  };
+
+  window.__NOON_PERF_REPORT__ = report;
+  output.textContent = JSON.stringify(report, null, 2);
+  status.value =
+    `Complete · ${formatNumber(report.cadence.effective?.effectiveFps)} FPS · ` +
+    `frame p95 ${formatNumber(report.cadence.frameIntervalMs?.p95)} ms · ` +
+    `${report.cadence.effective?.longFrames ?? 0} long frames`;
+  status.dataset.state = "complete";
+  console.log("NOON_PERF_REPORT", report);
+} catch (error) {
+  console.error(error);
+  status.value = `Profile failed: ${error}`;
+  status.dataset.state = "error";
+} finally {
+  player?.free?.();
+}
+
+function recordPlayerMetric(window, value, label) {
+  if (!Number.isFinite(value)) {
+    throw new Error(`${label} metric is not finite: ${value}`);
+  }
+  window.record(value);
+}
+
+async function waitForGpuSamples(player, supported, expectedFrames) {
+  if (!supported) {
+    return;
+  }
+  const deadline = performance.now() + 2_000;
+  while (performance.now() < deadline) {
+    const accounted =
+      player.gpuProfiledFrameCount() +
+      player.gpuDroppedSampleCount() +
+      player.gpuFailedSampleCount();
+    if (accounted >= expectedFrames) {
+      return;
+    }
+    await nextAnimationFrame();
+  }
+}
+
+function nextAnimationFrame() {
+  return new Promise((resolve) => requestAnimationFrame(resolve));
+}
+
+function positiveInteger(name, fallback) {
+  const value = parameters.get(name);
+  if (value === null) {
+    return fallback;
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function positiveNumber(name, fallback) {
+  const value = parameters.get(name);
+  if (value === null) {
+    return fallback;
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive number`);
+  }
+  return parsed;
+}
+
+function finiteOrNull(value) {
+  return Number.isFinite(value) ? value : null;
+}
+
+function formatNumber(value) {
+  return Number.isFinite(value) ? Number(value).toFixed(2) : "—";
+}

--- a/web/perf-workloads.js
+++ b/web/perf-workloads.js
@@ -1,0 +1,100 @@
+export const ANALYTIC_LAYOUTS = Object.freeze(["fit", "fixed", "overdraw"]);
+
+export function buildAnalyticScene({ count, layout = "fit", aspect = 16 / 9 } = {}) {
+  if (!Number.isSafeInteger(count) || count <= 0) {
+    throw new RangeError("count must be a positive integer");
+  }
+  if (!ANALYTIC_LAYOUTS.includes(layout)) {
+    throw new RangeError(`unknown analytic layout: ${layout}`);
+  }
+  if (!Number.isFinite(aspect) || aspect <= 0) {
+    throw new RangeError("aspect must be a positive finite number");
+  }
+
+  if (layout === "fit") {
+    return buildFitGrid(count, aspect);
+  }
+  if (layout === "fixed") {
+    return buildFixedGrid(count, aspect);
+  }
+  return buildOverdraw(count);
+}
+
+function buildFitGrid(count, aspect) {
+  const columns = Math.ceil(Math.sqrt(count * aspect));
+  const rows = Math.ceil(count / columns);
+  return {
+    document: documentFor(count, (id) => ({
+      radius: 0.32,
+      x: (id % columns) - columns / 2 + 0.5,
+      y: Math.floor(id / columns) - rows / 2 + 0.5,
+      alpha: 1,
+    })),
+    cameraHeight: rows,
+    description: "objects fit the viewport; isolates instance/object scaling while visible size shrinks",
+  };
+}
+
+function buildFixedGrid(count, aspect) {
+  const cameraHeight = 6;
+  const cameraWidth = cameraHeight * aspect;
+  const columns = Math.ceil(Math.sqrt(count * aspect));
+  const rows = Math.ceil(count / columns);
+  const cellWidth = cameraWidth / columns;
+  const cellHeight = cameraHeight / rows;
+  return {
+    document: documentFor(count, (id) => {
+      const column = id % columns;
+      const row = Math.floor(id / columns);
+      return {
+        radius: 0.06,
+        x: -cameraWidth / 2 + (column + 0.5) * cellWidth,
+        y: -cameraHeight / 2 + (row + 0.5) * cellHeight,
+        alpha: 1,
+      };
+    }),
+    cameraHeight,
+    description: "fixed apparent circle size; exposes fragment cost as object count grows",
+  };
+}
+
+function buildOverdraw(count) {
+  const cameraHeight = 6;
+  const goldenAngle = Math.PI * (3 - Math.sqrt(5));
+  return {
+    document: documentFor(count, (id) => {
+      const radius = 0.4 * Math.sqrt((id + 0.5) / count);
+      const angle = id * goldenAngle;
+      return {
+        radius: 0.35,
+        x: Math.cos(angle) * radius,
+        y: Math.sin(angle) * radius,
+        alpha: 0.16,
+      };
+    }),
+    cameraHeight,
+    description: "heavily overlapping transparent circles; stresses alpha blending and overdraw",
+  };
+}
+
+function documentFor(count, placement) {
+  const objects = Array.from({ length: count }, (_, id) => {
+    const { radius, x, y, alpha } = placement(id);
+    return {
+      id,
+      geometry: { circle: { radius } },
+      transform: {
+        translation: { x, y },
+        rotation: 0,
+        scale: { x: 1, y: 1 },
+      },
+      style: {
+        fill: { red: 0.27, green: 0.65, blue: 0.96, alpha },
+        stroke: null,
+        stroke_width: 0,
+        opacity: 1,
+      },
+    };
+  });
+  return { version: 1, objects, tracks: [] };
+}

--- a/web/perf-workloads.test.mjs
+++ b/web/perf-workloads.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ANALYTIC_LAYOUTS, buildAnalyticScene } from "./perf-workloads.js";
+
+test("analytic workloads are deterministic and preserve requested object count", () => {
+  for (const layout of ANALYTIC_LAYOUTS) {
+    const first = buildAnalyticScene({ count: 100, layout, aspect: 16 / 9 });
+    const second = buildAnalyticScene({ count: 100, layout, aspect: 16 / 9 });
+    assert.deepEqual(first, second);
+    assert.equal(first.document.objects.length, 100);
+    assert.deepEqual(first.document.tracks, []);
+    assert.ok(first.cameraHeight > 0);
+  }
+});
+
+test("fit workload grows camera height while fixed workload preserves apparent radius", () => {
+  const fitSmall = buildAnalyticScene({ count: 100, layout: "fit" });
+  const fitLarge = buildAnalyticScene({ count: 10_000, layout: "fit" });
+  assert.ok(fitLarge.cameraHeight > fitSmall.cameraHeight);
+
+  const fixedSmall = buildAnalyticScene({ count: 100, layout: "fixed" });
+  const fixedLarge = buildAnalyticScene({ count: 10_000, layout: "fixed" });
+  assert.equal(fixedSmall.cameraHeight, fixedLarge.cameraHeight);
+  assert.equal(
+    fixedSmall.document.objects[0].geometry.circle.radius,
+    fixedLarge.document.objects[0].geometry.circle.radius,
+  );
+});
+
+test("overdraw workload keeps transparent objects concentrated near the origin", () => {
+  const result = buildAnalyticScene({ count: 1_000, layout: "overdraw" });
+  for (const object of result.document.objects) {
+    const { x, y } = object.transform.translation;
+    assert.ok(Math.hypot(x, y) <= 0.401);
+    assert.equal(object.style.fill.alpha, 0.16);
+  }
+});
+
+test("analytic workload parameters reject invalid values", () => {
+  assert.throws(() => buildAnalyticScene({ count: 0 }), /positive integer/);
+  assert.throws(() => buildAnalyticScene({ count: 1, layout: "unknown" }), /unknown analytic layout/);
+  assert.throws(() => buildAnalyticScene({ count: 1, aspect: 0 }), /positive finite/);
+});


### PR DESCRIPTION
## Summary
Implements the first tranche of #125 and establishes the shared measurement vocabulary for #124.

- add p99 sample statistics plus effective-FPS, long-frame, and missed-vsync cadence accounting;
- add deterministic analytic workloads for object-bound (`fit`), fixed-apparent-size, and transparent-overdraw profiling;
- add a browser profiler that records rAF cadence plus runtime/prepare/upload/encode-submit CPU stages, renderer counters, backend/resolution/DPR metadata, and GPU timestamp summaries when available;
- add a Playwright named-machine matrix runner that writes JSON artifacts tagged with commit/host metadata;
- keep wall-clock timing diagnostic rather than a shared-runner CI gate; only syntax/unit tests are wired into the normal web build;
- document usage and root-cause interpretation.

The existing `gpu-profile` and `morph-profile` remain usable; this PR provides the common schema/path the specialized P1-P9 lanes can migrate toward.

Tracks #125