### PR TITLE
Avoid default painter-order rebuild allocation

### DIFF
--- a/crates/noon-render-wgpu/examples/frame_preparation_perf.rs
+++ b/crates/noon-render-wgpu/examples/frame_preparation_perf.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use noon_core::{GeometryRef, ObjectId, Style, Transform2D, Vec2};
-use noon_render_wgpu::{CircleInstance, FramePreparer};
+use noon_render_wgpu::{CircleInstance, FramePreparer, RenderOrderKey};
 use noon_runtime::{FrameChanges, FrameObjectState, FrameState};
 
 const DEFAULT_SIZES: [usize; 3] = [1_000, 10_000, 100_000];
@@ -22,6 +22,7 @@ struct Config {
 struct Timing {
     median: Duration,
     p95: Duration,
+    p99: Duration,
 }
 
 fn main() {
@@ -31,8 +32,10 @@ fn main() {
         config.warmups, config.samples
     );
     println!();
-    println!("| Objects | Operation | Median | p95 | Repacked | Upload bytes | Full / operation |");
-    println!("|---:|---|---:|---:|---:|---:|---:|");
+    println!(
+        "| Objects | Operation | Median | p95 | p99 | Repacked | Upload bytes | Full / operation |"
+    );
+    println!("|---:|---|---:|---:|---:|---:|---:|---:|");
     for object_count in sizes {
         benchmark_size(object_count, config);
     }
@@ -45,6 +48,19 @@ fn benchmark_size(object_count: usize, config: Config) {
     full_preparer.prepare(&frame);
     let full = measure(config, |_| {
         let prepared = full_preparer.prepare(black_box(&frame));
+        black_box(prepared.stats.instances_repacked);
+    });
+
+    let mut keyed_preparer = FramePreparer::new();
+    let keyed_order = (0..object_count)
+        .map(|index| RenderOrderKey::new((index % 7) as i32, index as u64))
+        .collect::<Vec<_>>();
+    keyed_preparer
+        .set_render_order_keys(&frame, &keyed_order)
+        .expect("benchmark render-order key count must match frame");
+    keyed_preparer.prepare(&frame);
+    let explicit_order = measure(config, |_| {
+        let prepared = keyed_preparer.prepare(black_box(&frame));
         black_box(prepared.stats.instances_repacked);
     });
 
@@ -68,8 +84,16 @@ fn benchmark_size(object_count: usize, config: Config) {
 
     print_row(
         object_count,
-        "full rebuild",
+        "full rebuild / default order",
         full,
+        object_count,
+        object_count * size_of::<CircleInstance>(),
+        full,
+    );
+    print_row(
+        object_count,
+        "full rebuild / explicit z order",
+        explicit_order,
         object_count,
         object_count * size_of::<CircleInstance>(),
         full,
@@ -122,6 +146,7 @@ fn measure(config: Config, mut operation: impl FnMut(usize)) -> Timing {
     Timing {
         median: percentile(&durations, 0.50),
         p95: percentile(&durations, 0.95),
+        p99: percentile(&durations, 0.99),
     }
 }
 
@@ -140,9 +165,10 @@ fn print_row(
 ) {
     let speedup = full.median.as_secs_f64() / timing.median.as_secs_f64();
     println!(
-        "| {object_count} | {operation} | {:.6} ms | {:.6} ms | {repacked} | {upload_bytes} | {speedup:.1}x |",
+        "| {object_count} | {operation} | {:.6} ms | {:.6} ms | {:.6} ms | {repacked} | {upload_bytes} | {speedup:.1}x |",
         milliseconds(timing.median),
         milliseconds(timing.p95),
+        milliseconds(timing.p99),
     );
 }
 

--- a/crates/noon-render-wgpu/src/render_order.rs
+++ b/crates/noon-render-wgpu/src/render_order.rs
@@ -88,40 +88,50 @@ impl FramePreparer {
 
     pub(crate) fn rebuild_ordered_render_batches(&mut self) {
         self.render_batches.clear();
-        let mut object_indices = (0..self.slots.len()).collect::<Vec<_>>();
+
         if self.render_order_keys.len() == self.slots.len() {
+            // Explicit z-order is comparatively uncommon and genuinely needs a
+            // sortable indirection. Keep that allocation isolated to this path.
+            let mut object_indices = (0..self.slots.len()).collect::<Vec<_>>();
             object_indices.sort_by_key(|&index| self.render_order_keys[index]);
+            for object_index in object_indices {
+                push_slot_batches(&mut self.render_batches, self.slots[object_index]);
+            }
+            return;
         }
 
-        for object_index in object_indices {
-            match self.slots[object_index] {
-                PreparedSlot::Absent | PreparedSlot::Unsupported(_) => {}
-                PreparedSlot::Circle(index) => {
-                    push_batch(&mut self.render_batches, RenderPrimitive::Circle, index);
-                }
-                PreparedSlot::Rectangle(index) => {
-                    push_batch(&mut self.render_batches, RenderPrimitive::Rectangle, index);
-                }
-                PreparedSlot::Line(index) => {
-                    push_batch(&mut self.render_batches, RenderPrimitive::Line, index);
-                }
-                PreparedSlot::Path {
-                    index,
-                    batch,
-                    reveal_head,
-                    ..
-                } => {
-                    push_batch(
-                        &mut self.render_batches,
-                        RenderPrimitive::Path { batch },
-                        index,
-                    );
-                    // The animated reveal head belongs to this object's painter
-                    // position and should sit immediately above its path body.
-                    if let Some(line_index) = reveal_head {
-                        push_batch(&mut self.render_batches, RenderPrimitive::Line, line_index);
-                    }
-                }
+        // Default painter order is already the semantic object-vector order.
+        // Walking slots directly avoids allocating/filling a temporary index
+        // vector on every full preparation or structural rebuild.
+        for slot in self.slots.iter().copied() {
+            push_slot_batches(&mut self.render_batches, slot);
+        }
+    }
+}
+
+fn push_slot_batches(batches: &mut Vec<OrderedRenderBatch>, slot: PreparedSlot) {
+    match slot {
+        PreparedSlot::Absent | PreparedSlot::Unsupported(_) => {}
+        PreparedSlot::Circle(index) => {
+            push_batch(batches, RenderPrimitive::Circle, index);
+        }
+        PreparedSlot::Rectangle(index) => {
+            push_batch(batches, RenderPrimitive::Rectangle, index);
+        }
+        PreparedSlot::Line(index) => {
+            push_batch(batches, RenderPrimitive::Line, index);
+        }
+        PreparedSlot::Path {
+            index,
+            batch,
+            reveal_head,
+            ..
+        } => {
+            push_batch(batches, RenderPrimitive::Path { batch }, index);
+            // The animated reveal head belongs to this object's painter
+            // position and should sit immediately above its path body.
+            if let Some(line_index) = reveal_head {
+                push_batch(batches, RenderPrimitive::Line, line_index);
             }
         }
     }


### PR DESCRIPTION
## Summary
Starts #127 with a measured renderer-CPU cleanup in the full-preparation/structural-rebuild path.

### Root cause
`rebuild_ordered_render_batches()` always allocated and filled a temporary `Vec<usize>` containing every object index before walking painter order. That indirection is only necessary when explicit z/order keys require sorting; the normal default painter order is already scene-object order.

### Change
- walk prepared slots directly for default painter order, eliminating the temporary index-vector allocation/fill;
- preserve the existing allocation/sort path only when explicit render-order keys are installed;
- factor slot-to-batch emission into one helper so default and keyed paths keep identical painter/path-reveal semantics;
- extend `frame_preparation_perf` with p99 and an explicit-z-order full-rebuild row, making the default-vs-sorted cost directly comparable at 1k/10k/100k objects.

Run with:

```bash
cargo run --release -p noon-render-wgpu --example frame_preparation_perf
```

Tracks #127