### PR TITLE
Attribute browser long tasks and residual frame gaps

### DIFF
--- a/scripts/build-web-demo.sh
+++ b/scripts/build-web-demo.sh
@@ -12,6 +12,7 @@ node --check web/native-inputs.js
 node --check web/scene-pipeline-perf.mjs
 node --check web/gpu-profile.js
 node --check web/morph-profile.js
+node --check web/browser-jank.js
 node --check web/perf-profile.js
 node --check web/perf-workloads.js
 node --check web/browser-smoke.js
@@ -28,6 +29,7 @@ node --check scripts/updater-callback-smoke.mjs
 node --test web/authoring-client.test.mjs
 node --test web/scene-identity.test.mjs
 node --test web/frame-metrics.test.mjs
+node --test web/browser-jank.test.mjs
 node --test web/perf-workloads.test.mjs
 PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile \
   web/python/_manim_compat.py \

--- a/web/browser-jank.js
+++ b/web/browser-jank.js
@@ -1,0 +1,65 @@
+export class BrowserJankMonitor {
+  #entries = [];
+  #observer = null;
+  #supported = false;
+
+  constructor(PerformanceObserverClass = globalThis.PerformanceObserver) {
+    if (typeof PerformanceObserverClass !== "function") {
+      return;
+    }
+    const supported = PerformanceObserverClass.supportedEntryTypes;
+    if (!Array.isArray(supported) || !supported.includes("longtask")) {
+      return;
+    }
+    this.#observer = new PerformanceObserverClass((list) => {
+      for (const entry of list.getEntries()) {
+        this.#entries.push({
+          startTime: Number(entry.startTime),
+          duration: Number(entry.duration),
+        });
+      }
+    });
+    this.#supported = true;
+  }
+
+  start() {
+    this.reset();
+    if (!this.#observer) {
+      return false;
+    }
+    this.#observer.observe({ type: "longtask", buffered: false });
+    return true;
+  }
+
+  stop() {
+    this.#observer?.disconnect();
+  }
+
+  reset() {
+    this.#entries.length = 0;
+  }
+
+  summary(measurementStartMs = -Infinity, measurementEndMs = Infinity) {
+    const entries = this.#entries.filter(
+      ({ startTime }) => startTime >= measurementStartMs && startTime <= measurementEndMs,
+    );
+    if (!this.#supported) {
+      return { supported: false };
+    }
+    const durations = entries.map(({ duration }) => duration).filter(Number.isFinite);
+    return {
+      supported: true,
+      count: durations.length,
+      totalMs: durations.reduce((sum, duration) => sum + duration, 0),
+      maxMs: durations.length > 0 ? Math.max(...durations) : 0,
+      entries,
+    };
+  }
+}
+
+export function estimateUnattributedFrameMs(frameIntervalMs, engineCpuMs) {
+  if (!Number.isFinite(frameIntervalMs) || !Number.isFinite(engineCpuMs)) {
+    return null;
+  }
+  return Math.max(0, frameIntervalMs - Math.max(0, engineCpuMs));
+}

--- a/web/browser-jank.test.mjs
+++ b/web/browser-jank.test.mjs
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { BrowserJankMonitor, estimateUnattributedFrameMs } from "./browser-jank.js";
+
+class FakePerformanceObserver {
+  static supportedEntryTypes = ["longtask"];
+  static instance = null;
+
+  constructor(callback) {
+    this.callback = callback;
+    this.observed = null;
+    this.disconnected = false;
+    FakePerformanceObserver.instance = this;
+  }
+
+  observe(options) {
+    this.observed = options;
+  }
+
+  disconnect() {
+    this.disconnected = true;
+  }
+
+  emit(entries) {
+    this.callback({ getEntries: () => entries });
+  }
+}
+
+test("collects long tasks within the requested measurement window", () => {
+  const monitor = new BrowserJankMonitor(FakePerformanceObserver);
+  assert.equal(monitor.start(), true);
+  assert.deepEqual(FakePerformanceObserver.instance.observed, {
+    type: "longtask",
+    buffered: false,
+  });
+
+  FakePerformanceObserver.instance.emit([
+    { startTime: 10, duration: 55 },
+    { startTime: 100, duration: 80 },
+    { startTime: 300, duration: 120 },
+  ]);
+
+  assert.deepEqual(monitor.summary(50, 200), {
+    supported: true,
+    count: 1,
+    totalMs: 80,
+    maxMs: 80,
+    entries: [{ startTime: 100, duration: 80 }],
+  });
+  monitor.stop();
+  assert.equal(FakePerformanceObserver.instance.disconnected, true);
+});
+
+test("reports unsupported environments without failing profiling", () => {
+  class UnsupportedObserver {
+    static supportedEntryTypes = [];
+  }
+  const monitor = new BrowserJankMonitor(UnsupportedObserver);
+  assert.equal(monitor.start(), false);
+  assert.deepEqual(monitor.summary(), { supported: false });
+});
+
+test("estimates browser/unattributed time without producing negatives", () => {
+  assert.equal(estimateUnattributedFrameMs(16.7, 2.4), 14.299999999999999);
+  assert.equal(estimateUnattributedFrameMs(8, 12), 0);
+  assert.equal(estimateUnattributedFrameMs(Number.NaN, 2), null);
+});

--- a/web/perf-profile.js
+++ b/web/perf-profile.js
@@ -1,4 +1,5 @@
 import init, { NoonCanvasPlayer } from "./pkg/noon_web.js";
+import { BrowserJankMonitor, estimateUnattributedFrameMs } from "./browser-jank.js";
 import { FrameMetrics, SampleWindow } from "./frame-metrics.js";
 import { ANALYTIC_LAYOUTS, buildAnalyticScene } from "./perf-workloads.js";
 
@@ -22,6 +23,7 @@ canvas.height = height;
 canvas.style.aspectRatio = `${width} / ${height}`;
 
 let player = null;
+const browserJank = new BrowserJankMonitor();
 try {
   await init();
   const workload = buildAnalyticScene({ count: objectCount, layout, aspect: width / height });
@@ -50,7 +52,11 @@ try {
     prepareMs: new SampleWindow(measuredFrames),
     uploadMs: new SampleWindow(measuredFrames),
     encodeSubmitMs: new SampleWindow(measuredFrames),
+    unattributedFrameMs: new SampleWindow(measuredFrames),
   };
+  browserJank.start();
+  const measurementStartMs = performance.now();
+  let previousTimestamp = null;
   let measured = 0;
   while (measured < measuredFrames) {
     status.value = `Measuring ${measured + 1}/${measuredFrames} · ${layout} / ${objectCount.toLocaleString()} objects…`;
@@ -62,14 +68,23 @@ try {
       continue;
     }
 
+    const cpuFrameMs = player.lastCpuFrameMs();
     cadence.record(timestamp, browserCallMs);
-    recordPlayerMetric(windows.cpuFrameMs, player.lastCpuFrameMs(), "cpu frame");
+    recordPlayerMetric(windows.cpuFrameMs, cpuFrameMs, "cpu frame");
     recordPlayerMetric(windows.runtimeMs, player.lastRuntimeEvaluationMs(), "runtime");
     recordPlayerMetric(windows.prepareMs, player.lastFramePrepareMs(), "prepare");
     recordPlayerMetric(windows.uploadMs, player.lastUploadMs(), "upload");
     recordPlayerMetric(windows.encodeSubmitMs, player.lastEncodeSubmitMs(), "encode/submit");
+    if (previousTimestamp !== null) {
+      windows.unattributedFrameMs.record(
+        estimateUnattributedFrameMs(timestamp - previousTimestamp, cpuFrameMs),
+      );
+    }
+    previousTimestamp = timestamp;
     measured += 1;
   }
+  const measurementEndMs = performance.now();
+  browserJank.stop();
 
   await waitForGpuSamples(player, gpuSupported, measuredFrames);
   const frame = cadence.summary();
@@ -105,6 +120,10 @@ try {
       frameIntervalMs: frame.interval,
       effective: frame.cadence,
       browserRenderCallMs: frame.submission,
+      unattributedFrameMs: windows.unattributedFrameMs.summary(),
+    },
+    browser: {
+      longTasks: browserJank.summary(measurementStartMs, measurementEndMs),
     },
     cpu: {
       frameMs: windows.cpuFrameMs.summary(),
@@ -151,6 +170,7 @@ try {
   status.value = `Profile failed: ${error}`;
   status.dataset.state = "error";
 } finally {
+  browserJank.stop();
   player?.free?.();
 }
 


### PR DESCRIPTION
## Summary
Starts #130 by extending the merged end-to-end profiler with browser-side jank attribution that is independent of Noon runtime/render/GPU timers.

- add a `PerformanceObserver`-based long-task monitor when the browser exposes the `longtask` entry type;
- record long-task count, total duration, max duration, and timestamps for the measured frame window;
- report a per-frame residual/unattributed interval estimate (`frame interval - Noon CPU frame time`) so browser scheduling gaps are visible rather than folded into generic FPS;
- keep unsupported browsers graceful and diagnostic-only;
- add deterministic Node unit coverage for long-task filtering and residual-frame accounting;
- wire the new helper into normal web package validation.

This establishes the native/WASM scheduling floor required by P5. Follow-up P5 work will overlay worker/Pyodide/host-callback timing on the same vocabulary.

Tracks #130