### PR TITLE
Make GPU profiler expose pixel and overdraw scaling

### DIFF
--- a/web/gpu-profile.js
+++ b/web/gpu-profile.js
@@ -1,10 +1,16 @@
 import init, { NoonCanvasPlayer } from "./pkg/noon_web.js";
 import { FrameMetrics } from "./frame-metrics.js";
+import { ANALYTIC_LAYOUTS, buildAnalyticScene } from "./perf-workloads.js";
 
 const parameters = new URLSearchParams(location.search);
 const objectCount = positiveInteger("objects", 10_000);
 const warmupFrames = positiveInteger("warmup", 30);
 const measuredFrames = positiveInteger("frames", 180);
+const targetHz = positiveNumber("targetHz", 60);
+const layout = parameters.get("layout") ?? "fit";
+if (!ANALYTIC_LAYOUTS.includes(layout)) {
+  throw new Error(`layout must be one of ${ANALYTIC_LAYOUTS.join(", ")}`);
+}
 const canvas = document.querySelector("#scene");
 const result = document.querySelector("#result");
 
@@ -13,17 +19,21 @@ try {
     throw new Error("This browser does not expose WebGPU");
   }
   await init();
-  const { document, worldHeight } = buildCircleGrid(objectCount);
-  const player = await NoonCanvasPlayer.create(canvas, JSON.stringify(document), 1);
+  const workload = buildAnalyticScene({
+    count: objectCount,
+    layout,
+    aspect: canvas.width / canvas.height,
+  });
+  const player = await NoonCanvasPlayer.create(canvas, JSON.stringify(workload.document), 1);
   player.resize(canvas.width, canvas.height);
-  player.setCamera(0, 0, worldHeight);
+  player.setCamera(0, 0, workload.cameraHeight);
   const gpuSupported = player.gpuProfilingSupported();
   player.setGpuProfilingEnabled(true);
 
-  const metrics = new FrameMetrics();
+  const metrics = new FrameMetrics({ targetHz });
   let renderedFrames = 0;
   let measured = 0;
-  result.value = `Warming ${objectCount.toLocaleString()} objects…`;
+  result.value = `Warming ${layout} / ${objectCount.toLocaleString()} objects…`;
   result.dataset.state = "warming";
   requestAnimationFrame(render);
 
@@ -65,13 +75,17 @@ try {
     const frame = metrics.summary();
     const profile = {
       objects: objectCount,
+      layout,
+      workload: workload.description,
       viewport: [canvas.width, canvas.height],
+      targetHz,
       measuredFrames: frame.frames,
       drawCalls: player.lastDrawCalls(),
       instances: player.lastInstancesDrawn(),
       lastUploadBytes: player.lastBytesUploaded(),
       submissionMs: frame.submission,
       frameIntervalMs: frame.interval,
+      cadence: frame.cadence,
       gpuTimestampSupported: gpuSupported,
       gpuRenderPassMs: gpuSupported
         ? {
@@ -80,6 +94,10 @@ try {
             failed: player.gpuFailedSampleCount(),
             p50: finiteOrNull(player.gpuRenderP50Ms()),
             p95: finiteOrNull(player.gpuRenderP95Ms()),
+            p99:
+              typeof player.gpuRenderP99Ms === "function"
+                ? finiteOrNull(player.gpuRenderP99Ms())
+                : null,
             last: finiteOrNull(player.lastGpuRenderMs()),
           }
         : null,
@@ -87,6 +105,7 @@ try {
     result.value = JSON.stringify(profile, null, 2);
     result.dataset.state = "complete";
     result.dataset.objects = String(profile.objects);
+    result.dataset.layout = profile.layout;
     result.dataset.submitP95Ms = String(profile.submissionMs?.p95 ?? "");
     result.dataset.intervalP95Ms = String(profile.frameIntervalMs?.p95 ?? "");
     result.dataset.gpuSupported = String(profile.gpuTimestampSupported);
@@ -99,34 +118,6 @@ try {
   result.dataset.state = "error";
 }
 
-function buildCircleGrid(count) {
-  const aspect = canvas.width / canvas.height;
-  const columns = Math.ceil(Math.sqrt(count * aspect));
-  const rows = Math.ceil(count / columns);
-  const objects = Array.from({ length: count }, (_, id) => ({
-    id,
-    geometry: { circle: { radius: 0.32 } },
-    transform: {
-      translation: {
-        x: (id % columns) - columns / 2 + 0.5,
-        y: Math.floor(id / columns) - rows / 2 + 0.5,
-      },
-      rotation: 0,
-      scale: { x: 1, y: 1 },
-    },
-    style: {
-      fill: { red: 0.27, green: 0.65, blue: 0.96, alpha: 1 },
-      stroke: null,
-      stroke_width: 0,
-      opacity: 1,
-    },
-  }));
-  return {
-    document: { version: 1, objects, tracks: [] },
-    worldHeight: rows,
-  };
-}
-
 function positiveInteger(name, fallback) {
   const value = parameters.get(name);
   if (value === null) {
@@ -135,6 +126,18 @@ function positiveInteger(name, fallback) {
   const parsed = Number(value);
   if (!Number.isSafeInteger(parsed) || parsed <= 0) {
     throw new Error(`${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function positiveNumber(name, fallback) {
+  const value = parameters.get(name);
+  if (value === null) {
+    return fallback;
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive number`);
   }
   return parsed;
 }


### PR DESCRIPTION
## Summary
Starts #128 by removing a major bias from the dedicated GPU benchmark.

The previous profiler only used a `fit` grid: as object count increased, the camera expanded and every circle became smaller on screen. That is useful for instance scaling but can hide fragment/alpha bottlenecks at high counts.

This PR reuses the canonical P0 analytic workloads and adds a `layout` query parameter:

- `fit` — bounded pixel pressure / instance scaling;
- `fixed` — fixed camera and circle size so fragment work grows with object count;
- `overdraw` — concentrated translucent circles for alpha/overdraw stress.

It also reports the shared p99 frame cadence/jank summary and GPU p99 when the runtime exposes it, while preserving existing draw/instance/upload/GPU timestamp metrics.

Examples:

```text
gpu-profile.html?objects=100000&layout=fit
gpu-profile.html?objects=10000&layout=fixed
gpu-profile.html?objects=10000&layout=overdraw
```

This is measurement infrastructure rather than a speculative shader change; GPU optimizations should follow evidence from these A/B workloads.

Tracks #128