### PR TITLE
Measure shared versus unique morph geometry scaling

### DIFF
--- a/web/morph-profile.js
+++ b/web/morph-profile.js
@@ -8,6 +8,14 @@ const AUTHORING_SAMPLES = 5;
 const WARMUP_FRAMES = 30;
 const MEASURED_FRAMES = 180;
 const GPU_SETTLE_TIMEOUT_MS = 2000;
+const parameters = new URLSearchParams(location.search);
+const targetVariantMode = parameters.get("variants") ?? "12";
+if (targetVariantMode !== "unique") {
+  const parsed = Number(targetVariantMode);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error("variants must be a positive integer or 'unique'");
+  }
+}
 
 const canvas = document.querySelector("#scene");
 const status = document.querySelector("#status");
@@ -37,6 +45,7 @@ try {
   const importWarmupStarted = performance.now();
   const importWarmup = await authoringClient.run(source, {
     object_count: AUTHORING_IMPORT_WARMUP_OBJECTS,
+    target_variant_count: Math.min(12, AUTHORING_IMPORT_WARMUP_OBJECTS),
   });
   const importWarmupMs = performance.now() - importWarmupStarted;
   assertScene(importWarmup);
@@ -45,16 +54,22 @@ try {
     importWarmupMs,
     importWarmupObjects: AUTHORING_IMPORT_WARMUP_OBJECTS,
     measuredSamplesPerCase: AUTHORING_SAMPLES,
+    targetVariantMode,
   };
   setup.value =
     `One-time setup excluded from authoring rows · worker/Pyodide ${formatNumber(workerStartupMs)} ms · ` +
     `first Noon import/source ${formatNumber(importWarmupMs)} ms · ` +
-    `${AUTHORING_SAMPLES} measured authoring runs per case`;
+    `${AUTHORING_SAMPLES} measured authoring runs per case · targets ${targetVariantMode}`;
 
   for (const objectCount of CASES) {
-    status.value = `Priming ${objectCount.toLocaleString()}-object authoring path…`;
+    const targetVariantCount = variantsFor(objectCount);
+    status.value =
+      `Priming ${objectCount.toLocaleString()} objects / ${targetVariantCount.toLocaleString()} targets…`;
     const caseWarmupStarted = performance.now();
-    const caseWarmup = await authoringClient.run(source, { object_count: objectCount });
+    const caseWarmup = await authoringClient.run(source, {
+      object_count: objectCount,
+      target_variant_count: targetVariantCount,
+    });
     const caseWarmupMs = performance.now() - caseWarmupStarted;
     assertScene(caseWarmup);
     await nextAnimationFrame();
@@ -63,9 +78,13 @@ try {
     let authored = null;
     for (let sample = 0; sample < AUTHORING_SAMPLES; sample += 1) {
       status.value =
-        `Authoring ${objectCount.toLocaleString()} objects · sample ${sample + 1}/${AUTHORING_SAMPLES}…`;
+        `Authoring ${objectCount.toLocaleString()} objects / ${targetVariantCount.toLocaleString()} targets · ` +
+        `sample ${sample + 1}/${AUTHORING_SAMPLES}…`;
       const authoredAt = performance.now();
-      const candidate = await authoringClient.run(source, { object_count: objectCount });
+      const candidate = await authoringClient.run(source, {
+        object_count: objectCount,
+        target_variant_count: targetVariantCount,
+      });
       authoringSamples.record(performance.now() - authoredAt);
       assertScene(candidate);
       authored = candidate;
@@ -145,6 +164,8 @@ try {
 
     const result = {
       objects: objectCount,
+      targetVariants: targetVariantCount,
+      geometryReuse: targetVariantCount === objectCount ? "unique-target" : "shared-targets",
       authoring: {
         samples: AUTHORING_SAMPLES,
         warmupMs: caseWarmupMs,
@@ -196,6 +217,17 @@ try {
   status.dataset.state = "error";
 } finally {
   authoringClient?.terminate();
+}
+
+function variantsFor(objectCount) {
+  if (targetVariantMode === "unique") {
+    return objectCount;
+  }
+  const variants = Number(targetVariantMode);
+  if (variants > objectCount) {
+    throw new Error(`variants ${variants} exceeds object count ${objectCount}`);
+  }
+  return variants;
 }
 
 function buildReport(results) {

--- a/web/python/examples/morph_stress_test.py
+++ b/web/python/examples/morph_stress_test.py
@@ -37,7 +37,17 @@ if requested_count <= 0 or requested_count > 10_000:
     raise ValueError("object_count must be between 1 and 10000")
 
 object_count = requested_count
-variant_count = 12
+requested_variants = (
+    authoring_context.get("target_variant_count", 12)
+    if isinstance(authoring_context, dict)
+    else 12
+)
+if isinstance(requested_variants, bool) or not isinstance(requested_variants, int):
+    raise TypeError("target_variant_count must be an integer")
+if requested_variants <= 0 or requested_variants > object_count:
+    raise ValueError("target_variant_count must be between 1 and object_count")
+
+variant_count = requested_variants
 aspect = 1.5
 columns = math.ceil(math.sqrt(object_count * aspect))
 rows = math.ceil(object_count / columns)
@@ -62,7 +72,6 @@ def rounded_source(radius: float) -> VectorPath:
 
 
 def star_target(variant: int) -> VectorPath:
-    # Twelve target variants create twelve reusable geometry-cache entries.
     phase = (variant / variant_count) * math.pi * 0.36
     outer = source_radius * (1.18 + 0.08 * math.sin(variant * 1.7))
     inner = outer * (0.42 + 0.05 * math.cos(variant * 0.9))


### PR DESCRIPTION
## Summary
Starts #129 by fixing a vector/morph benchmark blind spot.

The existing morph stress scene always reuses 12 target geometries, even for 1k/3k objects. That is valuable for steady interpolation scaling but cannot reveal unique-resource/cache/tessellation pressure.

This PR:
- parameterizes the stress scene with `target_variant_count` while keeping the playground default at 12;
- adds `?variants=<N>` and `?variants=unique` to `morph-profile.html`;
- records target-geometry count and whether a case is shared-target or unique-target;
- keeps authoring, cold-frame cache misses/upload bytes, runtime/prepare/upload/encode, GPU timing and frame cadence directly comparable between the two modes.

Examples:

```text
morph-profile.html?variants=12
morph-profile.html?variants=unique
```

This allows P4 to separate object/morph interpolation cost from unique geometry/resource cost before changing cache or packing architecture.

Tracks #129