### PR TITLE
Measure authoring time to visible result

### DIFF
--- a/scripts/authoring-perf.mjs
+++ b/scripts/authoring-perf.mjs
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+import { spawn, spawnSync } from "node:child_process";
+import { mkdir, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import playwright from "playwright";
+
+const { chromium } = playwright;
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const port = positiveInteger(process.env.NOON_AUTHORING_PERF_PORT ?? "4177", "port");
+const baseUrl = `http://127.0.0.1:${port}`;
+const counts = integerList(process.env.NOON_AUTHORING_PERF_COUNTS ?? "1000,10000,100000");
+const samples = positiveInteger(process.env.NOON_AUTHORING_PERF_SAMPLES ?? "3", "samples");
+const scrubs = positiveInteger(process.env.NOON_AUTHORING_PERF_SCRUBS ?? "20", "scrubs");
+const backend = process.env.NOON_AUTHORING_PERF_BACKEND ?? "webgpu";
+assert.ok(backend === "webgpu" || backend === "webgl", `unknown backend: ${backend}`);
+const artifactPath = path.resolve(
+  repoRoot,
+  process.env.NOON_AUTHORING_PERF_ARTIFACT ??
+    `perf-artifacts/authoring-perf-${backend}.json`,
+);
+
+const commit = spawnSync("git", ["rev-parse", "HEAD"], {
+  cwd: repoRoot,
+  encoding: "utf8",
+});
+const commitSha = commit.status === 0 ? commit.stdout.trim() : null;
+
+let serverOutput = "";
+const server = spawn(
+  "python3",
+  ["-m", "http.server", String(port), "--bind", "127.0.0.1", "--directory", repoRoot],
+  { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] },
+);
+server.stdout.on("data", (chunk) => (serverOutput += chunk));
+server.stderr.on("data", (chunk) => (serverOutput += chunk));
+
+let browser = null;
+try {
+  await waitForServer();
+  browser = await chromium.launch({ channel: "chromium", headless: true, args: browserArgs(backend) });
+  const cases = [];
+  for (const objects of counts) {
+    const page = await browser.newPage({ viewport: { width: 1200, height: 900 } });
+    const errors = [];
+    page.on("pageerror", (error) => errors.push(`pageerror: ${error}`));
+    page.on("console", (message) => {
+      if (message.type() === "error") errors.push(`console: ${message.text()}`);
+    });
+    const query = new URLSearchParams({
+      objects: String(objects),
+      samples: String(samples),
+      scrubs: String(scrubs),
+    });
+    process.stdout.write(`Authoring ${backend} ${objects.toLocaleString()} objects… `);
+    await page.goto(`${baseUrl}/web/authoring-perf.html?${query}`, { waitUntil: "load" });
+    await page.waitForFunction(
+      () => window.__NOON_AUTHORING_PERF__ || document.querySelector("#status")?.dataset.state === "error",
+      null,
+      { timeout: objects >= 100_000 ? 600_000 : 240_000 },
+    );
+    const state = await page.locator("#status").getAttribute("data-state");
+    if (state === "error") {
+      const message = await page.locator("#status").textContent();
+      throw new Error(`${objects} objects failed: ${message}\n${errors.join("\n")}`);
+    }
+    const report = await page.evaluate(() => window.__NOON_AUTHORING_PERF__);
+    assert.equal(report.workload.objects, objects);
+    cases.push(report);
+    console.log(
+      `cold ${format(report.cold.timeToVisibleMs)} ms, ` +
+        `unchanged p95 ${format(report.warmUnchanged.timeToVisibleMs?.p95)} ms, ` +
+        `local edit p95 ${format(report.oneObjectEdit.timeToVisibleMs?.p95)} ms, ` +
+        `scrub p95 ${format(report.scrub.timeToVisibleMs?.p95)} ms`,
+    );
+    await page.close();
+  }
+
+  const artifact = {
+    schemaVersion: 1,
+    benchmark: "Noon interactive authoring latency matrix",
+    generatedAt: new Date().toISOString(),
+    commit: commitSha,
+    host: {
+      platform: os.platform(),
+      release: os.release(),
+      arch: os.arch(),
+      cpu: os.cpus()[0]?.model ?? null,
+      logicalCpuCount: os.cpus().length,
+      totalMemoryBytes: os.totalmem(),
+      node: process.version,
+    },
+    configuration: { backend, counts, samples, scrubs },
+    cases,
+  };
+  await mkdir(path.dirname(artifactPath), { recursive: true });
+  await writeFile(artifactPath, `${JSON.stringify(artifact, null, 2)}\n`, "utf8");
+  console.log(`Wrote ${path.relative(repoRoot, artifactPath)}`);
+} finally {
+  await browser?.close();
+  server.kill("SIGTERM");
+}
+
+async function waitForServer() {
+  let lastError = null;
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    try {
+      const response = await fetch(`${baseUrl}/web/authoring-perf.html`);
+      if (response.ok) return;
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Authoring performance server did not start: ${lastError}\n${serverOutput}`);
+}
+
+function browserArgs(mode) {
+  if (mode === "webgpu") {
+    return [
+      "--enable-unsafe-webgpu",
+      "--use-gpu-in-tests",
+      "--ignore-gpu-blocklist",
+      "--disable-gpu-sandbox",
+      "--disable-dev-shm-usage",
+    ];
+  }
+  return [
+    "--disable-features=WebGPU",
+    "--ignore-gpu-blocklist",
+    "--disable-gpu-sandbox",
+    "--disable-dev-shm-usage",
+  ];
+}
+
+function integerList(value) {
+  const values = String(value)
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .map((item) => positiveInteger(item, "object count"));
+  assert.ok(values.length > 0, "at least one object count is required");
+  return values;
+}
+
+function positiveInteger(value, name) {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function format(value) {
+  return Number.isFinite(value) ? Number(value).toFixed(2) : "—";
+}

--- a/scripts/build-web-demo.sh
+++ b/scripts/build-web-demo.sh
@@ -15,9 +15,11 @@ node --check web/morph-profile.js
 node --check web/browser-jank.js
 node --check web/perf-profile.js
 node --check web/perf-workloads.js
+node --check web/authoring-perf.js
 node --check web/browser-smoke.js
 node --check scripts/browser-smoke.mjs
 node --check scripts/perf-profile.mjs
+node --check scripts/authoring-perf.mjs
 node --check scripts/deterministic-replay-smoke.mjs
 node --check scripts/manim-compat-smoke.mjs
 node --check scripts/manim-tutorial-smoke.mjs

--- a/web/authoring-perf.html
+++ b/web/authoring-perf.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="data:," />
+    <title>Noon authoring latency profiler</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        background: #090c13;
+        color: #e9efff;
+      }
+      body {
+        width: min(96vw, 80rem);
+        margin: 1.5rem auto;
+      }
+      canvas {
+        display: block;
+        width: 100%;
+        aspect-ratio: 16 / 9;
+        border: 1px solid #29334b;
+        border-radius: 0.75rem;
+      }
+      output {
+        display: block;
+        margin-bottom: 1rem;
+        white-space: pre-wrap;
+      }
+      pre {
+        overflow: auto;
+        max-height: 32rem;
+        padding: 1rem;
+        border: 1px solid #29334b;
+        border-radius: 0.75rem;
+        background: #0d1220;
+      }
+    </style>
+  </head>
+  <body>
+    <output id="status" data-state="starting">Starting authoring benchmark…</output>
+    <canvas id="scene" width="960" height="540" aria-label="Noon authoring performance scene"></canvas>
+    <pre id="json" aria-label="Authoring performance result JSON"></pre>
+    <script type="module" src="./authoring-perf.js"></script>
+  </body>
+</html>

--- a/web/authoring-perf.js
+++ b/web/authoring-perf.js
@@ -1,0 +1,303 @@
+import init, { NoonCanvasPlayer } from "./pkg/noon_web.js";
+import { PythonAuthoringClient } from "./authoring-client.js";
+import { BrowserJankMonitor } from "./browser-jank.js";
+import { summarizeSamples } from "./frame-metrics.js";
+import { SceneIdentityMap } from "./scene-identity.js";
+
+const parameters = new URLSearchParams(location.search);
+const objectCount = positiveInteger("objects", 1_000);
+const samples = positiveInteger("samples", 5);
+const scrubSamples = positiveInteger("scrubs", 20);
+const canvas = document.querySelector("#scene");
+const status = document.querySelector("#status");
+const output = document.querySelector("#json");
+
+let client = null;
+let player = null;
+const identities = new SceneIdentityMap();
+const jank = new BrowserJankMonitor();
+
+try {
+  await init();
+  const source = await loadText("./python/examples/authoring_perf_scene.py");
+  jank.start();
+
+  const cold = await coldRun(source);
+  const unchanged = [];
+  for (let sample = 0; sample < samples; sample += 1) {
+    status.value = `Warm unchanged rerun ${sample + 1}/${samples} · ${objectCount.toLocaleString()} objects…`;
+    unchanged.push(await rerun(source, 0, "unchanged"));
+  }
+
+  const localEdit = [];
+  let variant = 1;
+  for (let sample = 0; sample < samples; sample += 1) {
+    status.value = `One-object edit ${sample + 1}/${samples} · ${objectCount.toLocaleString()} objects…`;
+    localEdit.push(await rerun(source, variant, "one-object-style"));
+    variant = variant === 0 ? 1 : 0;
+  }
+
+  status.value = `Scrub/seek profile · ${scrubSamples} samples…`;
+  const scrubs = profileScrubs(scrubSamples);
+
+  const report = {
+    schemaVersion: 1,
+    benchmark: "Noon interactive authoring time-to-visible profile",
+    generatedAt: new Date().toISOString(),
+    environment: {
+      userAgent: navigator.userAgent,
+      rendererBackend: player.rendererBackend(),
+      devicePixelRatio: window.devicePixelRatio || 1,
+      viewport: [canvas.width, canvas.height],
+      hardwareConcurrency: navigator.hardwareConcurrency ?? null,
+    },
+    workload: {
+      objects: objectCount,
+      warmSamples: samples,
+      scrubSamples,
+      source: "python/examples/authoring_perf_scene.py",
+      localEdit: "one stable-identity circle changes fill color",
+    },
+    cold,
+    warmUnchanged: summarizeOperations(unchanged),
+    oneObjectEdit: summarizeOperations(localEdit),
+    scrub: summarizeScrubs(scrubs),
+  };
+
+  window.__NOON_AUTHORING_PERF__ = report;
+  output.textContent = JSON.stringify(report, null, 2);
+  status.value =
+    `Complete · unchanged visible p95 ${format(report.warmUnchanged.timeToVisibleMs?.p95)} ms · ` +
+    `one-object edit p95 ${format(report.oneObjectEdit.timeToVisibleMs?.p95)} ms`;
+  status.dataset.state = "complete";
+  console.log("NOON_AUTHORING_PERF", report);
+} catch (error) {
+  console.error(error);
+  status.value = `Authoring benchmark failed: ${error}`;
+  status.dataset.state = "error";
+} finally {
+  jank.stop();
+  client?.terminate();
+}
+
+async function coldRun(source) {
+  status.value = `Cold Run · ${objectCount.toLocaleString()} objects…`;
+  const operationStarted = performance.now();
+
+  const workerStarted = performance.now();
+  client = new PythonAuthoringClient();
+  await client.ready();
+  const workerStartupMs = performance.now() - workerStarted;
+
+  const authored = await author(source, 0);
+  const stabilized = stabilize(authored.result);
+  const encoded = serialize(stabilized.document);
+
+  const createStarted = performance.now();
+  player = await NoonCanvasPlayer.create(canvas, encoded.json, 4.0);
+  const playerCreateMs = performance.now() - createStarted;
+  player.resize(canvas.width, canvas.height);
+  player.setCamera(0, 0, cameraHeight(objectCount));
+
+  const visible = await presentNextFrame();
+  const operationEnded = performance.now();
+  return {
+    timeToVisibleMs: operationEnded - operationStarted,
+    workerStartupMs,
+    workerRoundTripMs: authored.ms,
+    stabilizeMs: stabilized.ms,
+    serializeMs: encoded.ms,
+    serializedBytes: encoded.bytes,
+    playerCreateMs,
+    visibleFrameWaitAndSubmitMs: visible.waitAndSubmitMs,
+    frame: visible.frame,
+    longTasks: jank.summary(operationStarted, operationEnded),
+  };
+}
+
+async function rerun(source, variant, kind) {
+  const operationStarted = performance.now();
+  const authored = await author(source, variant);
+  const stabilized = stabilize(authored.result);
+  const encoded = serialize(stabilized.document);
+
+  const reconcileStarted = performance.now();
+  const playheadBefore = player.time();
+  const incremental = player.reconcileScene(encoded.json);
+  const reconcileMs = performance.now() - reconcileStarted;
+  if (player.time() !== playheadBefore) {
+    throw new Error(`${kind} reconciliation changed the current playhead`);
+  }
+
+  const visible = await presentNextFrame();
+  const operationEnded = performance.now();
+  return {
+    kind,
+    timeToVisibleMs: operationEnded - operationStarted,
+    workerRoundTripMs: authored.ms,
+    stabilizeMs: stabilized.ms,
+    serializeMs: encoded.ms,
+    serializedBytes: encoded.bytes,
+    reconcileMs,
+    incremental,
+    visibleFrameWaitAndSubmitMs: visible.waitAndSubmitMs,
+    frame: visible.frame,
+    longTasks: jank.summary(operationStarted, operationEnded),
+  };
+}
+
+async function author(source, variant) {
+  const started = performance.now();
+  const result = await client.run(source, { object_count: objectCount, variant });
+  const ms = performance.now() - started;
+  if (result.kind !== "scene_document") {
+    throw new Error("authoring performance source did not return a Scene");
+  }
+  return { result, ms };
+}
+
+function stabilize(result) {
+  const started = performance.now();
+  const document = identities.stabilize(result.document, result.identities);
+  return { document, ms: performance.now() - started };
+}
+
+function serialize(document) {
+  const started = performance.now();
+  const json = JSON.stringify(document);
+  return {
+    json,
+    ms: performance.now() - started,
+    bytes: new TextEncoder().encode(json).byteLength,
+  };
+}
+
+async function presentNextFrame() {
+  const started = performance.now();
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    const timestamp = await nextAnimationFrame();
+    const submitStarted = performance.now();
+    const presented = player.renderFrame(timestamp);
+    const browserSubmitMs = performance.now() - submitStarted;
+    if (presented) {
+      return {
+        waitAndSubmitMs: performance.now() - started,
+        frame: frameSnapshot(browserSubmitMs),
+      };
+    }
+  }
+  throw new Error("authoring result did not present within eight animation frames");
+}
+
+function profileScrubs(count) {
+  const results = [];
+  for (let index = 0; index < count; index += 1) {
+    const target = ((index * 0.61803398875) % 1) * 3.8;
+    player.resetClock();
+    player.renderFrame(0);
+    const started = performance.now();
+    const presented = player.renderFrame(target * 1000);
+    const elapsed = performance.now() - started;
+    if (!presented) {
+      throw new Error(`scrub frame at ${target.toFixed(3)}s was not presented`);
+    }
+    results.push({
+      targetSeconds: target,
+      timeToVisibleMs: elapsed,
+      frame: frameSnapshot(elapsed),
+    });
+  }
+  return results;
+}
+
+function frameSnapshot(browserSubmitMs) {
+  return {
+    browserSubmitMs,
+    cpuFrameMs: finite(player.lastCpuFrameMs()),
+    runtimeMs: finite(player.lastRuntimeEvaluationMs()),
+    prepareMs: finite(player.lastFramePrepareMs()),
+    uploadMs: finite(player.lastUploadMs()),
+    encodeSubmitMs: finite(player.lastEncodeSubmitMs()),
+    uploadBytes: player.lastBytesUploaded(),
+    drawCalls: player.lastDrawCalls(),
+    instances: player.lastInstancesDrawn(),
+    geometryCacheMisses: player.lastGeometryCacheMisses(),
+  };
+}
+
+function summarizeOperations(operations) {
+  return {
+    samples: operations.length,
+    incrementalCount: operations.filter(({ incremental }) => incremental).length,
+    timeToVisibleMs: summary(operations, "timeToVisibleMs"),
+    workerRoundTripMs: summary(operations, "workerRoundTripMs"),
+    stabilizeMs: summary(operations, "stabilizeMs"),
+    serializeMs: summary(operations, "serializeMs"),
+    serializedBytes: summary(operations, "serializedBytes"),
+    reconcileMs: summary(operations, "reconcileMs"),
+    visibleFrameWaitAndSubmitMs: summary(operations, "visibleFrameWaitAndSubmitMs"),
+    frameCpuMs: summarizeSamples(operations.map(({ frame }) => frame.cpuFrameMs)),
+    framePrepareMs: summarizeSamples(operations.map(({ frame }) => frame.prepareMs)),
+    frameUploadMs: summarizeSamples(operations.map(({ frame }) => frame.uploadMs)),
+    frameEncodeSubmitMs: summarizeSamples(operations.map(({ frame }) => frame.encodeSubmitMs)),
+    uploadBytes: summarizeSamples(operations.map(({ frame }) => frame.uploadBytes)),
+    longTaskCount: operations.reduce(
+      (sum, operation) => sum + (operation.longTasks.supported ? operation.longTasks.count : 0),
+      0,
+    ),
+  };
+}
+
+function summarizeScrubs(scrubs) {
+  return {
+    samples: scrubs.length,
+    timeToVisibleMs: summary(scrubs, "timeToVisibleMs"),
+    runtimeMs: summarizeSamples(scrubs.map(({ frame }) => frame.runtimeMs)),
+    prepareMs: summarizeSamples(scrubs.map(({ frame }) => frame.prepareMs)),
+    uploadMs: summarizeSamples(scrubs.map(({ frame }) => frame.uploadMs)),
+    encodeSubmitMs: summarizeSamples(scrubs.map(({ frame }) => frame.encodeSubmitMs)),
+    uploadBytes: summarizeSamples(scrubs.map(({ frame }) => frame.uploadBytes)),
+  };
+}
+
+function summary(values, field) {
+  return summarizeSamples(values.map((value) => value[field]));
+}
+
+function cameraHeight(count) {
+  const columns = Math.ceil(Math.sqrt(count * (16 / 9)));
+  const rows = Math.ceil(count / columns);
+  return Math.max(4.5, rows * 0.095);
+}
+
+async function loadText(path) {
+  const response = await fetch(path);
+  if (!response.ok) {
+    throw new Error(`Unable to load ${path}: HTTP ${response.status}`);
+  }
+  return response.text();
+}
+
+function nextAnimationFrame() {
+  return new Promise((resolve) => requestAnimationFrame(resolve));
+}
+
+function positiveInteger(name, fallback) {
+  const value = parameters.get(name);
+  if (value === null) {
+    return fallback;
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function finite(value) {
+  return Number.isFinite(value) ? value : 0;
+}
+
+function format(value) {
+  return Number.isFinite(value) ? value.toFixed(2) : "—";
+}

--- a/web/python/examples/authoring_perf_scene.py
+++ b/web/python/examples/authoring_perf_scene.py
@@ -1,0 +1,34 @@
+import math
+
+from noon import BLUE, RED, Circle, Scene, Vec2
+
+context_value = globals().get("context", {})
+if not isinstance(context_value, dict):
+    context_value = {}
+
+object_count = context_value.get("object_count", 1000)
+variant = context_value.get("variant", 0)
+if isinstance(object_count, bool) or not isinstance(object_count, int):
+    raise TypeError("object_count must be an integer")
+if object_count <= 0 or object_count > 100_000:
+    raise ValueError("object_count must be between 1 and 100000")
+if isinstance(variant, bool) or not isinstance(variant, int):
+    raise TypeError("variant must be an integer")
+
+scene = Scene()
+aspect = 16.0 / 9.0
+columns = math.ceil(math.sqrt(object_count * aspect))
+rows = math.ceil(object_count / columns)
+spacing = 0.085
+radius = 0.026
+
+for index in range(object_count):
+    column = index % columns
+    row = index // columns
+    x = (column - (columns - 1) * 0.5) * spacing
+    y = ((rows - 1) * 0.5 - row) * spacing
+    color = RED if variant == 1 and index == object_count // 2 else BLUE
+    dot = Circle(radius, color=color).set_stroke(None).move_to(Vec2(x, y))
+    scene.add(dot, key=f"perf.{index}")
+
+result = scene


### PR DESCRIPTION
## Summary
Implements the P6 measurement boundary from #131 around the actual browser authoring workflow.

- add a scalable Python authoring fixture with stable object identities and a one-object style variant;
- add `authoring-perf.html` / `authoring-perf.js` measuring cold Run, warm unchanged reruns, one-object edits, and deterministic scrubs;
- report Python worker round-trip, identity stabilization, full-scene serialization, Rust reconciliation/create, rAF-to-present, and the first visible frame's runtime/prepare/upload/encode metrics;
- include browser long-task attribution for Run/edit operations;
- report p50/p95/p99 summaries and serialized/upload byte locality;
- add a Playwright matrix runner for 1k/10k/100k objects and WebGPU/WebGL artifacts;
- wire new JS into normal web syntax validation.

A key diagnostic this makes explicit is that the current Run path serializes the entire stabilized scene into WASM before reconciliation, even for a stable-identity one-object change. The new matrix quantifies whether that browser/transport cost, Python authoring, or engine reconciliation dominates before we redesign the path.

Tracks #131.