### PR TITLE
Avoid unchanged identity-map allocations on rerun

### DIFF
--- a/web/scene-identity.js
+++ b/web/scene-identity.js
@@ -5,20 +5,34 @@ export class SceneIdentityMap {
   stabilize(document, identities) {
     const objectIds = this.#objects.resolve(identities.objects);
     const trackIds = this.#tracks.resolve(identities.tracks);
-    return {
-      ...document,
-      objects: document.objects.map((object) => {
-        const id = requiredId(objectIds, object.id, "object");
-        return id === object.id ? object : { ...object, id };
-      }),
-      tracks: document.tracks.map((track) => {
-        const id = requiredId(trackIds, track.id, "track");
-        const object = requiredId(objectIds, track.object, "track object");
-        return id === track.id && object === track.object
-          ? track
-          : { ...track, id, object };
-      }),
-    };
+    if (objectIds === null && trackIds === null) {
+      return document;
+    }
+
+    const objects =
+      objectIds === null
+        ? document.objects
+        : document.objects.map((object) => {
+            const id = requiredId(objectIds, object.id, "object");
+            return id === object.id ? object : { ...object, id };
+          });
+    const tracks =
+      objectIds === null && trackIds === null
+        ? document.tracks
+        : document.tracks.map((track) => {
+            const id = trackIds === null ? track.id : requiredId(trackIds, track.id, "track");
+            const object =
+              objectIds === null
+                ? track.object
+                : requiredId(objectIds, track.object, "track object");
+            return id === track.id && object === track.object
+              ? track
+              : { ...track, id, object };
+          });
+
+    return objects === document.objects && tracks === document.tracks
+      ? document
+      : { ...document, objects, tracks };
   }
 }
 
@@ -33,13 +47,27 @@ class IdentityNamespace {
   }
 
   resolve(entries) {
-    const localToStable = new Map();
+    let localToStable = null;
     for (const { id: localId, key } of entries) {
       let stableId = this.#keyToId.get(key);
       if (stableId === undefined) {
         stableId = this.#claim(localId, key);
       }
-      localToStable.set(localId, stableId);
+      if (stableId !== localId) {
+        localToStable ??= new Map();
+      }
+      localToStable?.set(localId, stableId);
+    }
+    if (localToStable === null) {
+      return null;
+    }
+
+    // Once one entry needs remapping, callers still need identity mappings for
+    // every other local ID referenced by the same document.
+    for (const { id: localId, key } of entries) {
+      if (!localToStable.has(localId)) {
+        localToStable.set(localId, this.#keyToId.get(key));
+      }
     }
     return localToStable;
   }

--- a/web/scene-identity.test.mjs
+++ b/web/scene-identity.test.mjs
@@ -3,6 +3,25 @@ import test from "node:test";
 
 import { SceneIdentityMap } from "./scene-identity.js";
 
+test("returns the original document when every semantic ID is already stable", () => {
+  const identities = new SceneIdentityMap();
+  const document = {
+    version: 1,
+    objects: [{ id: 0 }, { id: 1 }],
+    tracks: [{ id: 0, object: 1 }],
+  };
+  const keys = {
+    objects: [
+      { id: 0, key: "circle" },
+      { id: 1, key: "line" },
+    ],
+    tracks: [{ id: 0, key: "line.move" }],
+  };
+
+  assert.strictEqual(identities.stabilize(document, keys), document);
+  assert.strictEqual(identities.stabilize(document, keys), document);
+});
+
 test("preserves runtime IDs when Python insertion order changes", () => {
   const identities = new SceneIdentityMap();
   const first = identities.stabilize(


### PR DESCRIPTION
## Summary
Starts the P7 allocation/GC optimization work in #132 with a concrete browser-side allocation reduction on every Run/edit rerun.

### Root cause
`SceneIdentityMap.stabilize()` always built local-to-stable `Map`s and new object/track arrays, even when all Python-local IDs already equal their stable runtime IDs. That is the common stable-key case and grows linearly with scene size.

### Change
- keep semantic key claims exactly as before;
- allocate a remapping Map only after the first actual ID mismatch;
- return the original scene document directly when object and track mappings are both identity;
- reuse the original object or track array independently when only the other namespace requires remapping;
- add identity/reference tests while preserving insertion-order and track-reference remap coverage.

The existing `scene-pipeline-perf.mjs` `stabilize identities` row provides the before/after latency signal at 1k/10k/100k objects, while P6 measures its contribution to time-to-visible Run/edit latency.

Tracks #132.