### PR TITLE
Add reproducible named-device performance baselines

### DIFF
--- a/benchmarks/performance-devices.json
+++ b/benchmarks/performance-devices.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": 1,
+  "description": "Named physical-machine profiles for reproducible Noon browser performance runs. Hosted/shared CI is intentionally not a performance baseline.",
+  "profiles": [
+    {
+      "id": "legacy-macos-i7-9750h",
+      "status": "existing-baseline",
+      "platform": "darwin",
+      "cpuContains": "i7-9750H",
+      "reference": "docs/performance.md#baseline-2026-08-19",
+      "notes": "Existing documented baseline host. Browser adapter identity was not exposed reliably, so GPU attribution remains host-level."
+    }
+  ],
+  "requiredRunMetadata": [
+    "deviceId",
+    "commit",
+    "host.platform",
+    "host.release",
+    "host.arch",
+    "host.cpu",
+    "browser userAgent",
+    "rendererBackend",
+    "backingResolution",
+    "devicePixelRatio"
+  ],
+  "recommendedMatrix": {
+    "backends": ["webgpu", "webgl"],
+    "resolutions": [
+      [960, 540],
+      [1920, 1080]
+    ],
+    "targetHz": [60],
+    "diagnosticTargetHz": [120]
+  }
+}

--- a/docs/performance-devices.md
+++ b/docs/performance-devices.md
@@ -1,0 +1,42 @@
+# Named-device performance runs
+
+Shared CI protects correctness, not wall-clock budgets. Browser performance baselines must come from an identified physical machine and be saved as artifacts with the commit, host CPU/OS, browser user agent, renderer backend, backing resolution and observed DPR.
+
+The known profiles live in `benchmarks/performance-devices.json`. A new machine does not need to be committed before experimentation, but a result used as a long-lived baseline should get a stable profile ID.
+
+## Record a baseline
+
+Build the release web package and install the pinned Playwright dependencies used by the browser smoke tests, then run:
+
+```bash
+NOON_PERF_DEVICE_ID=my-machine node scripts/perf-device-run.mjs
+```
+
+The default records the canonical frame matrix on WebGPU and WebGL2. Control the matrix with the existing `NOON_PERF_*` variables, for example:
+
+```bash
+NOON_PERF_DEVICE_ID=my-machine \
+NOON_PERF_BACKENDS=webgpu \
+NOON_PERF_WIDTH=1920 \
+NOON_PERF_HEIGHT=1080 \
+NOON_PERF_COUNTS=1000,10000,100000 \
+node scripts/perf-device-run.mjs
+```
+
+When the P6 authoring profiler is present, include it with `NOON_PERF_SUITES=frame,authoring`. The bundle manifest and per-suite JSON files are written under `perf-artifacts/<device>/<timestamp>/` by default.
+
+Do not relabel SwiftShader, software rasterization, or a generic hosted runner as a physical-device baseline. If the browser cannot expose the selected GPU identity, record the result at host/backend level rather than guessing the adapter.
+
+## Compare two runs
+
+```bash
+node scripts/perf-compare.mjs old.json new.json
+```
+
+The comparator aligns equivalent workload cases and reports deltas for frame p95/p99, effective FPS, CPU/GPU timing, or authoring time-to-visible metrics. An optional diagnostic threshold can make the command non-zero:
+
+```bash
+NOON_PERF_REGRESSION_PCT=10 node scripts/perf-compare.mjs old.json new.json
+```
+
+That threshold is appropriate for controlled same-machine comparisons. It should not be used as a shared-runner CI gate.

--- a/scripts/build-web-demo.sh
+++ b/scripts/build-web-demo.sh
@@ -20,6 +20,8 @@ node --check web/browser-smoke.js
 node --check scripts/browser-smoke.mjs
 node --check scripts/perf-profile.mjs
 node --check scripts/authoring-perf.mjs
+node --check scripts/perf-device-run.mjs
+node --check scripts/perf-compare.mjs
 node --check scripts/deterministic-replay-smoke.mjs
 node --check scripts/manim-compat-smoke.mjs
 node --check scripts/manim-tutorial-smoke.mjs

--- a/scripts/perf-compare.mjs
+++ b/scripts/perf-compare.mjs
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const [baselinePath, candidatePath] = process.argv.slice(2);
+assert.ok(baselinePath && candidatePath, "usage: node scripts/perf-compare.mjs BASELINE.json CANDIDATE.json");
+const baseline = JSON.parse(await readFile(baselinePath, "utf8"));
+const candidate = JSON.parse(await readFile(candidatePath, "utf8"));
+assert.equal(baseline.benchmark, candidate.benchmark, "artifacts must be from the same benchmark");
+
+const rows = baseline.benchmark.includes("authoring")
+  ? compareAuthoring(baseline, candidate)
+  : compareFrames(baseline, candidate);
+
+console.log("| Case | Metric | Baseline | Candidate | Delta |");
+console.log("|---|---|---:|---:|---:|");
+for (const row of rows) {
+  console.log(`| ${row.caseName} | ${row.metric} | ${fmt(row.before)} | ${fmt(row.after)} | ${fmtDelta(row.deltaPct)} |`);
+}
+
+const threshold = Number(process.env.NOON_PERF_REGRESSION_PCT ?? "NaN");
+if (Number.isFinite(threshold)) {
+  const regressions = rows.filter((row) => row.regressionPct > threshold);
+  if (regressions.length > 0) {
+    console.error(`${regressions.length} metric(s) regressed by more than ${threshold}%`);
+    process.exitCode = 2;
+  }
+}
+
+function compareFrames(before, after) {
+  const candidateCases = new Map(after.cases.map((item) => [frameKey(item), item]));
+  const rows = [];
+  for (const oldCase of before.cases) {
+    const key = frameKey(oldCase);
+    const next = candidateCases.get(key);
+    if (!next) continue;
+    const metrics = [
+      ["frame p95 ms", oldCase.cadence?.frameIntervalMs?.p95, next.cadence?.frameIntervalMs?.p95, false],
+      ["frame p99 ms", oldCase.cadence?.frameIntervalMs?.p99, next.cadence?.frameIntervalMs?.p99, false],
+      ["effective FPS", oldCase.cadence?.effective?.effectiveFps, next.cadence?.effective?.effectiveFps, true],
+      ["CPU p95 ms", oldCase.cpu?.frameMs?.p95, next.cpu?.frameMs?.p95, false],
+      ["GPU p95 ms", oldCase.gpu?.renderPassMs?.p95, next.gpu?.renderPassMs?.p95, false],
+    ];
+    for (const [metric, oldValue, newValue, higherBetter] of metrics) {
+      pushMetric(rows, key, metric, oldValue, newValue, higherBetter);
+    }
+  }
+  return rows;
+}
+
+function compareAuthoring(before, after) {
+  const candidateCases = new Map(after.cases.map((item) => [String(item.workload.objects), item]));
+  const rows = [];
+  for (const oldCase of before.cases) {
+    const key = String(oldCase.workload.objects);
+    const next = candidateCases.get(key);
+    if (!next) continue;
+    const metrics = [
+      ["unchanged visible p95 ms", oldCase.warmUnchanged?.timeToVisibleMs?.p95, next.warmUnchanged?.timeToVisibleMs?.p95],
+      ["local edit visible p95 ms", oldCase.oneObjectEdit?.timeToVisibleMs?.p95, next.oneObjectEdit?.timeToVisibleMs?.p95],
+      ["scrub p95 ms", oldCase.scrub?.timeToVisibleMs?.p95, next.scrub?.timeToVisibleMs?.p95],
+      ["serialize p95 ms", oldCase.oneObjectEdit?.serializeMs?.p95, next.oneObjectEdit?.serializeMs?.p95],
+      ["reconcile p95 ms", oldCase.oneObjectEdit?.reconcileMs?.p95, next.oneObjectEdit?.reconcileMs?.p95],
+    ];
+    for (const [metric, oldValue, newValue] of metrics) {
+      pushMetric(rows, `${Number(key).toLocaleString()} objects`, metric, oldValue, newValue, false);
+    }
+  }
+  return rows;
+}
+
+function pushMetric(rows, caseName, metric, before, after, higherBetter) {
+  if (!Number.isFinite(before) || !Number.isFinite(after) || before === 0) return;
+  const deltaPct = ((after - before) / before) * 100;
+  rows.push({
+    caseName,
+    metric,
+    before,
+    after,
+    deltaPct,
+    regressionPct: higherBetter ? -deltaPct : deltaPct,
+  });
+}
+
+function frameKey(item) {
+  return `${item.workload.layout}/${item.workload.objects}@${item.environment.backingResolution.join("x")}`;
+}
+
+function fmt(value) {
+  return Number.isFinite(value) ? Number(value).toFixed(3) : "—";
+}
+
+function fmtDelta(value) {
+  return Number.isFinite(value) ? `${value >= 0 ? "+" : ""}${value.toFixed(1)}%` : "—";
+}

--- a/scripts/perf-device-run.mjs
+++ b/scripts/perf-device-run.mjs
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const deviceId = process.env.NOON_PERF_DEVICE_ID?.trim();
+assert.ok(deviceId, "NOON_PERF_DEVICE_ID is required for a physical-machine baseline");
+assert.match(deviceId, /^[a-zA-Z0-9._-]+$/, "device ID must be filesystem-safe");
+
+const backends = list(process.env.NOON_PERF_BACKENDS ?? "webgpu,webgl");
+for (const backend of backends) {
+  assert.ok(backend === "webgpu" || backend === "webgl", `unknown backend: ${backend}`);
+}
+const suites = list(process.env.NOON_PERF_SUITES ?? "frame");
+for (const suite of suites) {
+  assert.ok(suite === "frame" || suite === "authoring", `unknown suite: ${suite}`);
+}
+
+const stamp = new Date().toISOString().replaceAll(":", "-").replaceAll(".", "-");
+const relativeDir = process.env.NOON_PERF_RUN_DIR ?? `perf-artifacts/${deviceId}/${stamp}`;
+const runDir = path.resolve(repoRoot, relativeDir);
+await mkdir(runDir, { recursive: true });
+
+const artifacts = [];
+for (const backend of backends) {
+  if (suites.includes("frame")) {
+    const relative = path.join(relativeDir, `frame-${backend}.json`);
+    run("scripts/perf-profile.mjs", {
+      NOON_PERF_BACKEND: backend,
+      NOON_PERF_ARTIFACT: relative,
+    });
+    artifacts.push({ suite: "frame", backend, path: relative });
+  }
+  if (suites.includes("authoring")) {
+    const relative = path.join(relativeDir, `authoring-${backend}.json`);
+    run("scripts/authoring-perf.mjs", {
+      NOON_AUTHORING_PERF_BACKEND: backend,
+      NOON_AUTHORING_PERF_ARTIFACT: relative,
+    });
+    artifacts.push({ suite: "authoring", backend, path: relative });
+  }
+}
+
+const commit = spawnSync("git", ["rev-parse", "HEAD"], { cwd: repoRoot, encoding: "utf8" });
+const bundle = {
+  schemaVersion: 1,
+  benchmark: "Noon named physical-device performance bundle",
+  generatedAt: new Date().toISOString(),
+  deviceId,
+  operatorNotes: process.env.NOON_PERF_DEVICE_NOTES ?? null,
+  commit: commit.status === 0 ? commit.stdout.trim() : null,
+  configuration: {
+    backends,
+    suites,
+    width: process.env.NOON_PERF_WIDTH ?? "960",
+    height: process.env.NOON_PERF_HEIGHT ?? "540",
+    targetHz: process.env.NOON_PERF_TARGET_HZ ?? "60",
+  },
+  artifacts,
+};
+await writeFile(path.join(runDir, "manifest.json"), `${JSON.stringify(bundle, null, 2)}\n`);
+console.log(`Named-device bundle: ${path.relative(repoRoot, runDir)}`);
+
+function run(script, extraEnv) {
+  const result = spawnSync(process.execPath, [script], {
+    cwd: repoRoot,
+    env: { ...process.env, ...extraEnv },
+    stdio: "inherit",
+  });
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+function list(value) {
+  return String(value)
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}


### PR DESCRIPTION
## Summary
Implements the repository-side P8 infrastructure from #133 without treating shared CI or software rasterization as performance truth.

- define a versioned named-device profile catalog, including the existing documented i7-9750H baseline host;
- add `perf-device-run.mjs`, which requires a stable physical-device ID and bundles canonical WebGPU/WebGL artifacts under that ID with commit/configuration metadata;
- add `perf-compare.mjs` to align equivalent cases and report frame p95/p99, effective FPS, CPU/GPU, and authoring deltas; an optional same-machine regression threshold can return non-zero;
- document required metadata, backend/resolution matrix, artifact storage, and the rule against relabeling hosted/SwiftShader runs as device baselines;
- wire both scripts into normal syntax validation.

Actual new physical-device measurements are intentionally not fabricated by this PR: running the harness on each named machine is the remaining execution step. The infrastructure makes those runs reproducible and directly comparable once hardware is available.

Tracks #133.