### PR TITLE
Add realistic authored-scene performance corpus

### DIFF
--- a/benchmarks/performance-scenes.json
+++ b/benchmarks/performance-scenes.json
@@ -1,0 +1,178 @@
+{
+  "schemaVersion": 1,
+  "reportingPolicy": {
+    "referenceTargetHz": 60,
+    "longFrameThreshold": "1.5x target interval (25 ms at 60 Hz)",
+    "diagnosticTargetHz": 120,
+    "diagnostic120IsGate": false,
+    "sharedRunnerWallClockGate": false,
+    "preserveVisualQualityAndSemantics": true
+  },
+  "tiers": {
+    "interactive60": {
+      "description": "Normal authoring/playback scenes expected to feel continuously interactive on the named baseline device.",
+      "budgets": {
+        "frameIntervalP95Ms": 20,
+        "frameIntervalP99Ms": 25,
+        "longFrameRateMax": 0.02,
+        "cpuFrameP95Ms": 8,
+        "gpuP95Ms": 8
+      }
+    },
+    "heavy60": {
+      "description": "Intentionally heavy but still user-facing scenes; modest frame misses are tolerated.",
+      "budgets": {
+        "frameIntervalP95Ms": 25,
+        "frameIntervalP99Ms": 40,
+        "longFrameRateMax": 0.08,
+        "cpuFrameP95Ms": 12,
+        "gpuP95Ms": 12
+      }
+    },
+    "scalability": {
+      "description": "Adversarial scale workloads used for diagnosis; not release FPS gates.",
+      "budgets": null
+    }
+  },
+  "cases": [
+    {
+      "id": "getting-started",
+      "source": "./python/demo_scene.py",
+      "tier": "interactive60",
+      "classification": "representative",
+      "domains": ["P1", "P2", "P6"],
+      "dimensions": ["python-authoring", "first-run-latency", "timeline", "analytic-primitives"]
+    },
+    {
+      "id": "tutorial-positioning",
+      "source": "./python/examples/tutorial_positioning.py",
+      "tier": "interactive60",
+      "classification": "representative",
+      "domains": ["P1", "P2"],
+      "dimensions": ["groups", "layout", "animate", "independent-transforms"]
+    },
+    {
+      "id": "staggered-choreography",
+      "source": "./python/examples/staggered_choreography.py",
+      "tier": "interactive60",
+      "classification": "representative",
+      "domains": ["P1", "P2"],
+      "dimensions": ["timeline-active-set", "easing", "analytic-primitives"]
+    },
+    {
+      "id": "tutorial-value-tracker",
+      "source": "./python/examples/tutorial_value_tracker.py",
+      "tier": "interactive60",
+      "classification": "representative",
+      "domains": ["P1", "P5"],
+      "dimensions": ["reactive", "ValueTracker", "native-reactive-evaluation", "browser-cadence"]
+    },
+    {
+      "id": "instanced-field",
+      "source": "./python/examples/instanced_field.py",
+      "tier": "interactive60",
+      "classification": "representative",
+      "domains": ["P2", "P3", "P7"],
+      "dimensions": ["batching", "dirty-upload", "many-analytic-objects"]
+    },
+    {
+      "id": "painter-order-overlap",
+      "source": "./python/examples/painter_order_overlap.py",
+      "tier": "heavy60",
+      "classification": "adversarial",
+      "domains": ["P2", "P3"],
+      "dimensions": ["mixed-transparency", "painter-order", "overdraw", "fixed-pixel-footprint"]
+    },
+    {
+      "id": "create-shapes",
+      "source": "./python/examples/create_shapes.py",
+      "tier": "interactive60",
+      "classification": "representative",
+      "domains": ["P2", "P4"],
+      "dimensions": ["reveal", "analytic-to-path", "path-cache"]
+    },
+    {
+      "id": "path-reveal",
+      "source": "./python/examples/path_reveal.py",
+      "tier": "interactive60",
+      "classification": "representative",
+      "domains": ["P4", "P7"],
+      "dimensions": ["vector-path", "reveal", "tessellation"]
+    },
+    {
+      "id": "filled-path-transform",
+      "source": "./python/examples/filled_path_transform.py",
+      "tier": "interactive60",
+      "classification": "representative",
+      "domains": ["P4", "P7"],
+      "dimensions": ["vector-path", "morph", "fixed-topology"]
+    },
+    {
+      "id": "matching-shapes",
+      "source": "./python/examples/matching_shapes.py",
+      "tier": "heavy60",
+      "classification": "representative",
+      "domains": ["P1", "P2", "P4"],
+      "dimensions": ["composition", "semantic-matching", "mixed-primitives"]
+    },
+    {
+      "id": "morph-shared-1000",
+      "source": "./python/examples/morph_stress_test.py",
+      "context": { "object_count": 1000, "target_variant_count": 12 },
+      "cameraHeight": 4.4,
+      "tier": "scalability",
+      "classification": "scalability-only",
+      "domains": ["P4", "P7"],
+      "dimensions": ["morph", "shared-geometry", "1000-objects"]
+    },
+    {
+      "id": "morph-unique-1000",
+      "source": "./python/examples/morph_stress_test.py",
+      "context": { "object_count": 1000, "target_variant_count": 1000 },
+      "cameraHeight": 4.4,
+      "tier": "scalability",
+      "classification": "scalability-only",
+      "domains": ["P4", "P7"],
+      "dimensions": ["morph", "unique-geometry", "cache-pressure"]
+    }
+  ],
+  "auxiliaryCases": [
+    {
+      "id": "host-updater-follow",
+      "source": "web/python/examples/perf_host_updater.py",
+      "runner": "node scripts/updater-callback-smoke.mjs",
+      "classification": "representative",
+      "domains": ["P5", "P7"],
+      "dimensions": ["python-host-callback", "coherent-snapshot", "worker-round-trip", "batched-patch"]
+    },
+    {
+      "id": "authoring-edit-rerun-seek",
+      "source": "web/python/examples/authoring_perf_scene.py",
+      "runner": "node scripts/authoring-perf.mjs",
+      "classification": "scalability-only",
+      "domains": ["P6", "P7"],
+      "dimensions": ["warm-rerun", "one-object-edit", "identity-stabilization", "seek", "time-to-visible"]
+    }
+  ],
+  "domainCoverage": {
+    "P1": ["getting-started", "staggered-choreography", "tutorial-value-tracker"],
+    "P2": ["getting-started", "instanced-field", "painter-order-overlap"],
+    "P3": ["instanced-field", "painter-order-overlap"],
+    "P4": ["create-shapes", "path-reveal", "filled-path-transform"],
+    "P5": ["tutorial-value-tracker", "host-updater-follow"],
+    "P6": ["getting-started", "authoring-edit-rerun-seek"],
+    "P7": ["instanced-field", "path-reveal", "host-updater-follow", "authoring-edit-rerun-seek"]
+  },
+  "futureCoverage": [
+    {
+      "feature": "text-math",
+      "dependency": 83,
+      "note": "Add representative Text/MathTex cases without changing the harness schema."
+    },
+    {
+      "feature": "axes-plotting",
+      "dependency": 85,
+      "note": "Add static and reactive plotting cases without changing the harness schema."
+    }
+  ]
+}

--- a/docs/performance-corpus.md
+++ b/docs/performance-corpus.md
@@ -1,0 +1,55 @@
+# Realistic performance corpus
+
+The synthetic 1k/10k/100k matrices isolate scaling laws. Release performance also needs authored scenes that exercise the same user-facing Python/Manim-style path as the playground. `benchmarks/performance-scenes.json` is the versioned corpus for that purpose.
+
+Each normal playback case names its Python source, stress dimensions, P1-P7 bottleneck domains, classification (`representative`, `adversarial`, or `scalability-only`) and tier. `interactive60` is the normal 60 Hz product target, `heavy60` allows modest misses for intentionally complex user-facing scenes, and `scalability` is diagnostic only. The stress tier must never be used to weaken common-scene budgets.
+
+Run the steady-playback corpus on a named physical machine after building the release web package:
+
+```bash
+node scripts/perf-corpus.mjs
+```
+
+Select cases or a backend with environment variables:
+
+```bash
+NOON_CORPUS_BACKEND=webgpu \
+NOON_CORPUS_CASES=getting-started,filled-path-transform \
+node scripts/perf-corpus.mjs
+```
+
+The runner records Python-worker setup/authoring, scene serialization and player creation, then measures steady production `renderFrame` calls with runtime, preparation, upload, encode/submit, GPU timestamps when available, frame p50/p95/p99, missed-vsync/long-frame rates and browser long tasks.
+
+Budgets are evaluated and stored in the artifact but are diagnostic by default. On a controlled same-machine release baseline they can be enforced with:
+
+```bash
+NOON_CORPUS_ENFORCE_BUDGETS=1 node scripts/perf-corpus.mjs
+```
+
+Do not enable wall-clock budget enforcement on generic shared CI runners. Correctness CI validates the manifest, source paths, domain coverage and harness syntax. Wall-clock release decisions use the named-device workflow documented in `docs/performance-devices.md`.
+
+## Realtime policy
+
+For the reference 60 Hz run, `interactive60` currently requires frame-interval p95 <= 20 ms, p99 <= 25 ms and a long-frame rate <= 2%. The canonical `FrameMetrics` long-frame definition is 1.5x the target interval, or 25 ms at 60 Hz. CPU/GPU p95 budgets are also recorded so average FPS cannot hide a stage-specific regression.
+
+`heavy60` remains a 60 Hz measurement but has relaxed p95/p99/long-frame limits. `scalability` has no absolute FPS release gate: it exists to expose asymptotic behavior and root cause. A 120 Hz run is a headroom diagnostic on capable displays/devices, not an initial compatibility gate. The manifest records that policy explicitly so a future runner or dashboard can consume it without changing the schema.
+
+## Coverage map
+
+The corpus spans the major root-cause lanes rather than maximizing scene count:
+
+- P1 runtime/timeline/reactivity: getting-started, positioning, staggered choreography and ValueTracker;
+- P2 renderer CPU: common analytic scenes, instanced fields and mixed painter order;
+- P3 GPU/raster/overdraw: instanced fields plus the adversarial transparent overlap scene;
+- P4 vector/reveal/morph: Create shapes, path reveal, filled-path transform and the shared/unique morph stress pair;
+- P5 browser/host scheduling: ValueTracker provides the native-reactive browser baseline and `perf_host_updater.py` exercises the Python host-callback fallback through `updater-callback-smoke.mjs`;
+- P6 authoring/edit/seek: realistic scene cold-authoring setup is reported by the normal corpus while `authoring-perf.mjs` measures warm rerun, one-object edit, reconciliation and seek latency explicitly;
+- P7 allocation/churn: instancing, vector reveal/morph, host callback snapshots/patches and the authoring identity path all contribute representative coverage.
+
+The manifest's `domainCoverage` section is executable policy: CI requires every P1-P7 domain to retain at least one representative workload. Text/math (#83) and axes/plotting (#85) are listed as future coverage and can be added without changing the runner design.
+
+## Anti-benchmark-gaming rules
+
+Keep visible object size and backing resolution fixed when investigating pixel scaling, retain overlapping transparent content as well as distributed grids, preserve visual quality and semantics, and report first-run/edit latency separately from steady playback. Do not remove Python/host work from a scene unless the measured optimization replaces it with a semantically equivalent native path.
+
+Host callback work is not fed to the standalone `NoonCanvasPlayer` profiler because doing so would omit callback phases and report falsely optimistic FPS. Instead the same reusable Python fixture is executed by the host callback runner and is declared as an auxiliary corpus case.

--- a/docs/performance-devices.md
+++ b/docs/performance-devices.md
@@ -12,7 +12,7 @@ Build the release web package and install the pinned Playwright dependencies use
 NOON_PERF_DEVICE_ID=my-machine node scripts/perf-device-run.mjs
 ```
 
-The default records the canonical frame matrix on WebGPU and WebGL2. Control the matrix with the existing `NOON_PERF_*` variables, for example:
+The default records both the canonical synthetic frame matrix and the realistic authored-scene corpus on WebGPU and WebGL2, so a named-device bundle contains object-scaling data and normal user-facing scenes together. Control the matrix with the existing `NOON_PERF_*` variables, for example:
 
 ```bash
 NOON_PERF_DEVICE_ID=my-machine \
@@ -23,7 +23,15 @@ NOON_PERF_COUNTS=1000,10000,100000 \
 node scripts/perf-device-run.mjs
 ```
 
-When the P6 authoring profiler is present, include it with `NOON_PERF_SUITES=frame,authoring`. The bundle manifest and per-suite JSON files are written under `perf-artifacts/<device>/<timestamp>/` by default.
+Use `NOON_PERF_SUITES` to choose `frame`, `corpus`, and/or `authoring`. A complete release characterization can run all three:
+
+```bash
+NOON_PERF_DEVICE_ID=my-machine \
+NOON_PERF_SUITES=frame,corpus,authoring \
+node scripts/perf-device-run.mjs
+```
+
+The bundle manifest and per-suite JSON files are written under `perf-artifacts/<device>/<timestamp>/` by default.
 
 Do not relabel SwiftShader, software rasterization, or a generic hosted runner as a physical-device baseline. If the browser cannot expose the selected GPU identity, record the result at host/backend level rather than guessing the adapter.
 

--- a/scripts/build-web-demo.sh
+++ b/scripts/build-web-demo.sh
@@ -16,12 +16,14 @@ node --check web/browser-jank.js
 node --check web/perf-profile.js
 node --check web/perf-workloads.js
 node --check web/authoring-perf.js
+node --check web/scene-perf.js
 node --check web/browser-smoke.js
 node --check scripts/browser-smoke.mjs
 node --check scripts/perf-profile.mjs
 node --check scripts/authoring-perf.mjs
 node --check scripts/perf-device-run.mjs
 node --check scripts/perf-compare.mjs
+node --check scripts/perf-corpus.mjs
 node --check scripts/deterministic-replay-smoke.mjs
 node --check scripts/manim-compat-smoke.mjs
 node --check scripts/manim-tutorial-smoke.mjs
@@ -35,6 +37,7 @@ node --test web/scene-identity.test.mjs
 node --test web/frame-metrics.test.mjs
 node --test web/browser-jank.test.mjs
 node --test web/perf-workloads.test.mjs
+node --test web/performance-corpus-manifest.test.mjs
 node --test web/wire-contracts.test.mjs
 PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile \
   web/python/_manim_compat.py \

--- a/scripts/perf-corpus.mjs
+++ b/scripts/perf-corpus.mjs
@@ -1,0 +1,164 @@
+import assert from "node:assert/strict";
+import { spawn, spawnSync } from "node:child_process";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import playwright from "playwright";
+
+const { chromium } = playwright;
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const manifest = JSON.parse(
+  await readFile(path.join(repoRoot, "benchmarks/performance-scenes.json"), "utf8"),
+);
+assert.equal(manifest.schemaVersion, 1);
+const backend = process.env.NOON_CORPUS_BACKEND ?? "webgpu";
+assert.ok(backend === "webgpu" || backend === "webgl", `unknown backend: ${backend}`);
+const selected = new Set(list(process.env.NOON_CORPUS_CASES ?? ""));
+const cases = manifest.cases.filter((item) => selected.size === 0 || selected.has(item.id));
+assert.ok(cases.length > 0, "performance corpus selection is empty");
+const warmup = positiveInteger(process.env.NOON_CORPUS_WARMUP ?? "30", "warmup");
+const frames = positiveInteger(process.env.NOON_CORPUS_FRAMES ?? "180", "frames");
+const targetHz = positiveNumber(process.env.NOON_CORPUS_TARGET_HZ ?? "60", "target Hz");
+const enforce = process.env.NOON_CORPUS_ENFORCE_BUDGETS === "1";
+const port = positiveInteger(process.env.NOON_CORPUS_PORT ?? "4178", "port");
+const baseUrl = `http://127.0.0.1:${port}`;
+const artifactPath = path.resolve(
+  repoRoot,
+  process.env.NOON_CORPUS_ARTIFACT ?? `perf-artifacts/performance-corpus-${backend}.json`,
+);
+
+const commit = spawnSync("git", ["rev-parse", "HEAD"], { cwd: repoRoot, encoding: "utf8" });
+let serverOutput = "";
+const server = spawn(
+  "python3",
+  ["-m", "http.server", String(port), "--bind", "127.0.0.1", "--directory", repoRoot],
+  { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] },
+);
+server.stdout.on("data", (chunk) => (serverOutput += chunk));
+server.stderr.on("data", (chunk) => (serverOutput += chunk));
+
+let browser = null;
+try {
+  await waitForServer();
+  browser = await chromium.launch({ channel: "chromium", headless: true, args: browserArgs(backend) });
+  const results = [];
+  let failedBudgets = 0;
+  for (const definition of cases) {
+    const page = await browser.newPage({ viewport: { width: 1200, height: 900 } });
+    const query = new URLSearchParams({
+      source: definition.source,
+      context: JSON.stringify(definition.context ?? {}),
+      cameraHeight: String(definition.cameraHeight ?? 6),
+      warmup: String(warmup),
+      frames: String(frames),
+      targetHz: String(targetHz),
+    });
+    process.stdout.write(`Corpus ${backend} ${definition.id}… `);
+    await page.goto(`${baseUrl}/web/scene-perf.html?${query}`, { waitUntil: "load" });
+    await page.waitForFunction(
+      () => window.__NOON_SCENE_PERF__ || document.querySelector("#status")?.dataset.state === "error",
+      null,
+      { timeout: definition.tier === "scalability" ? 600_000 : 240_000 },
+    );
+    const state = await page.locator("#status").getAttribute("data-state");
+    if (state === "error") {
+      throw new Error(`${definition.id}: ${await page.locator("#status").textContent()}`);
+    }
+    const report = await page.evaluate(() => window.__NOON_SCENE_PERF__);
+    const budget = manifest.tiers[definition.tier]?.budgets ?? null;
+    const evaluation = evaluateBudget(report, budget);
+    if (!evaluation.passed) failedBudgets += 1;
+    results.push({ definition, report, budget: evaluation });
+    console.log(
+      `${format(report.cadence.effective?.effectiveFps)} FPS, ` +
+        `p95 ${format(report.cadence.frameIntervalMs?.p95)} ms, ` +
+        `${evaluation.passed ? "budget ok" : "BUDGET FAIL"}`,
+    );
+    await page.close();
+  }
+
+  const artifact = {
+    schemaVersion: 1,
+    benchmark: "Noon realistic authored performance corpus",
+    generatedAt: new Date().toISOString(),
+    commit: commit.status === 0 ? commit.stdout.trim() : null,
+    host: {
+      platform: os.platform(),
+      release: os.release(),
+      arch: os.arch(),
+      cpu: os.cpus()[0]?.model ?? null,
+      logicalCpuCount: os.cpus().length,
+      totalMemoryBytes: os.totalmem(),
+    },
+    configuration: { backend, warmup, frames, targetHz, enforce },
+    results,
+  };
+  await mkdir(path.dirname(artifactPath), { recursive: true });
+  await writeFile(artifactPath, `${JSON.stringify(artifact, null, 2)}\n`);
+  console.log(`Wrote ${path.relative(repoRoot, artifactPath)}`);
+  if (enforce && failedBudgets > 0) process.exitCode = 2;
+} finally {
+  await browser?.close();
+  server.kill("SIGTERM");
+}
+
+function evaluateBudget(report, budget) {
+  if (budget === null) return { passed: true, gated: false, checks: [] };
+  const actual = {
+    frameIntervalP95Ms: report.cadence.frameIntervalMs?.p95,
+    frameIntervalP99Ms: report.cadence.frameIntervalMs?.p99,
+    longFrameRateMax: report.cadence.effective?.longFrameRate,
+    cpuFrameP95Ms: report.cpu.frameMs?.p95,
+    gpuP95Ms: report.gpu?.p95,
+  };
+  const checks = Object.entries(budget).map(([metric, limit]) => ({
+    metric,
+    limit,
+    actual: actual[metric] ?? null,
+    passed: actual[metric] == null || actual[metric] <= limit,
+  }));
+  return { passed: checks.every((check) => check.passed), gated: true, checks };
+}
+
+async function waitForServer() {
+  let lastError = null;
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    try {
+      const response = await fetch(`${baseUrl}/web/scene-perf.html`);
+      if (response.ok) return;
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Corpus server did not start: ${lastError}\n${serverOutput}`);
+}
+
+function browserArgs(mode) {
+  return mode === "webgpu"
+    ? ["--enable-unsafe-webgpu", "--use-gpu-in-tests", "--ignore-gpu-blocklist", "--disable-gpu-sandbox", "--disable-dev-shm-usage"]
+    : ["--disable-features=WebGPU", "--ignore-gpu-blocklist", "--disable-gpu-sandbox", "--disable-dev-shm-usage"];
+}
+
+function list(value) {
+  return String(value).split(",").map((item) => item.trim()).filter(Boolean);
+}
+
+function positiveInteger(value, name) {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) throw new Error(`${name} must be a positive integer`);
+  return parsed;
+}
+
+function positiveNumber(value, name) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) throw new Error(`${name} must be positive`);
+  return parsed;
+}
+
+function format(value) {
+  return Number.isFinite(value) ? Number(value).toFixed(2) : "—";
+}

--- a/scripts/perf-device-run.mjs
+++ b/scripts/perf-device-run.mjs
@@ -13,9 +13,12 @@ const backends = list(process.env.NOON_PERF_BACKENDS ?? "webgpu,webgl");
 for (const backend of backends) {
   assert.ok(backend === "webgpu" || backend === "webgl", `unknown backend: ${backend}`);
 }
-const suites = list(process.env.NOON_PERF_SUITES ?? "frame");
+const suites = list(process.env.NOON_PERF_SUITES ?? "frame,corpus");
 for (const suite of suites) {
-  assert.ok(suite === "frame" || suite === "authoring", `unknown suite: ${suite}`);
+  assert.ok(
+    suite === "frame" || suite === "authoring" || suite === "corpus",
+    `unknown suite: ${suite}`,
+  );
 }
 
 const stamp = new Date().toISOString().replaceAll(":", "-").replaceAll(".", "-");
@@ -32,6 +35,14 @@ for (const backend of backends) {
       NOON_PERF_ARTIFACT: relative,
     });
     artifacts.push({ suite: "frame", backend, path: relative });
+  }
+  if (suites.includes("corpus")) {
+    const relative = path.join(relativeDir, `corpus-${backend}.json`);
+    run("scripts/perf-corpus.mjs", {
+      NOON_CORPUS_BACKEND: backend,
+      NOON_CORPUS_ARTIFACT: relative,
+    });
+    artifacts.push({ suite: "corpus", backend, path: relative });
   }
   if (suites.includes("authoring")) {
     const relative = path.join(relativeDir, `authoring-${backend}.json`);

--- a/scripts/updater-callback-smoke.mjs
+++ b/scripts/updater-callback-smoke.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
+import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -10,6 +11,10 @@ const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, "..");
 const port = 4182;
 const baseUrl = `http://127.0.0.1:${port}`;
+const source = await readFile(
+  path.join(repoRoot, "web/python/examples/perf_host_updater.py"),
+  "utf8",
+);
 
 let serverOutput = "";
 const server = spawn(
@@ -34,31 +39,6 @@ async function waitForServer() {
   }
   throw new Error(`Updater smoke server did not start: ${lastError}\n${serverOutput}`);
 }
-
-const source = `
-from noon import *
-
-class ArbitraryUpdaterScene(Scene):
-    def construct(self):
-        anchor = Circle(radius=0.4, color=RED).shift(RIGHT * 2)
-        follower = Square(side_length=0.5, color=BLUE).shift(LEFT)
-
-        def removed(mobject):
-            mobject.shift(LEFT * 99)
-
-        def follow(mobject, dt):
-            # This deliberately reads another mobject to verify the callback phase
-            # is a coherent scene snapshot rather than a target-only proxy.
-            mobject.move_to(anchor.get_center() + UP * dt)
-            mobject.set_opacity(0.5 + dt)
-
-        follower.add_updater(removed)
-        follower.remove_updater(removed)
-        follower.add_updater(follow)
-        assert follower.has_updaters()
-        assert follower.get_updaters() == [follow]
-        self.add(anchor, follower)
-`;
 
 let browser = null;
 try {

--- a/web/performance-corpus-manifest.test.mjs
+++ b/web/performance-corpus-manifest.test.mjs
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { access, readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const manifest = JSON.parse(
+  await readFile(path.join(repoRoot, "benchmarks/performance-scenes.json"), "utf8"),
+);
+const allCases = [...manifest.cases, ...(manifest.auxiliaryCases ?? [])];
+const byId = new Map(allCases.map((definition) => [definition.id, definition]));
+const domains = Array.from({ length: 7 }, (_, index) => `P${index + 1}`);
+
+function sourcePath(definition) {
+  return definition.source.startsWith("./")
+    ? path.join(repoRoot, "web", definition.source.slice(2))
+    : path.join(repoRoot, definition.source);
+}
+
+test("performance corpus sources and classifications are explicit", async () => {
+  assert.equal(manifest.schemaVersion, 1);
+  assert.equal(byId.size, allCases.length, "performance case IDs must be unique");
+  const allowed = new Set(["representative", "adversarial", "scalability-only"]);
+  for (const definition of allCases) {
+    assert.ok(allowed.has(definition.classification), `${definition.id}: classification`);
+    assert.ok(Array.isArray(definition.domains) && definition.domains.length > 0, `${definition.id}: domains`);
+    assert.ok(Array.isArray(definition.dimensions) && definition.dimensions.length > 0, `${definition.id}: dimensions`);
+    await access(sourcePath(definition));
+  }
+});
+
+test("every P1-P7 domain has a realistic representative", () => {
+  for (const domain of domains) {
+    const ids = manifest.domainCoverage?.[domain];
+    assert.ok(Array.isArray(ids) && ids.length > 0, `${domain}: missing coverage declaration`);
+    const definitions = ids.map((id) => {
+      const definition = byId.get(id);
+      assert.ok(definition, `${domain}: unknown case ${id}`);
+      assert.ok(definition.domains.includes(domain), `${domain}: ${id} does not declare the domain`);
+      return definition;
+    });
+    assert.ok(
+      definitions.some(({ classification }) => classification === "representative"),
+      `${domain}: requires at least one representative scene`,
+    );
+  }
+});
+
+test("60 Hz budgets and 120 Hz diagnostic policy stay explicit", () => {
+  const common = manifest.tiers.interactive60.budgets;
+  assert.ok(common.frameIntervalP95Ms > 0);
+  assert.ok(common.frameIntervalP99Ms >= common.frameIntervalP95Ms);
+  assert.ok(common.longFrameRateMax >= 0 && common.longFrameRateMax < 1);
+  assert.equal(manifest.reportingPolicy.referenceTargetHz, 60);
+  assert.equal(manifest.reportingPolicy.diagnosticTargetHz, 120);
+  assert.equal(manifest.reportingPolicy.diagnostic120IsGate, false);
+  assert.equal(manifest.reportingPolicy.sharedRunnerWallClockGate, false);
+});
+
+test("anti-gaming and host fallback cases remain in the corpus", () => {
+  const overlap = byId.get("painter-order-overlap");
+  assert.ok(overlap?.dimensions.includes("mixed-transparency"));
+  assert.ok(overlap?.dimensions.includes("fixed-pixel-footprint"));
+  const host = byId.get("host-updater-follow");
+  assert.equal(host?.classification, "representative");
+  assert.ok(host?.domains.includes("P5"));
+  assert.match(host?.runner ?? "", /updater-callback-smoke/);
+});

--- a/web/python/examples/perf_host_updater.py
+++ b/web/python/examples/perf_host_updater.py
@@ -1,0 +1,23 @@
+from noon import *
+
+
+class HostUpdaterPerfScene(Scene):
+    def construct(self):
+        anchor = Circle(radius=0.4, color=RED).shift(RIGHT * 2)
+        follower = Square(side_length=0.5, color=BLUE).shift(LEFT)
+
+        def removed(mobject):
+            mobject.shift(LEFT * 99)
+
+        def follow(mobject, dt):
+            # Deliberately read another mobject so the callback phase must expose
+            # a coherent scene snapshot, then emit both transform and style work.
+            mobject.move_to(anchor.get_center() + UP * dt)
+            mobject.set_opacity(0.5 + dt)
+
+        follower.add_updater(removed)
+        follower.remove_updater(removed)
+        follower.add_updater(follow)
+        assert follower.has_updaters()
+        assert follower.get_updaters() == [follow]
+        self.add(anchor, follower)

--- a/web/scene-perf.html
+++ b/web/scene-perf.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="data:," />
+    <title>Noon authored scene profiler</title>
+    <style>
+      :root { color-scheme: dark; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; background: #090c13; color: #e9efff; }
+      body { width: min(96vw, 80rem); margin: 1.5rem auto; }
+      canvas { display: block; width: 100%; aspect-ratio: 16 / 9; border: 1px solid #29334b; border-radius: .75rem; }
+      output { display: block; margin-bottom: 1rem; white-space: pre-wrap; }
+      pre { overflow: auto; max-height: 32rem; padding: 1rem; border: 1px solid #29334b; border-radius: .75rem; background: #0d1220; }
+    </style>
+  </head>
+  <body>
+    <output id="status" data-state="starting">Starting authored-scene profile…</output>
+    <canvas id="scene" width="960" height="540" aria-label="Noon performance scene"></canvas>
+    <pre id="json"></pre>
+    <script type="module" src="./scene-perf.js"></script>
+  </body>
+</html>

--- a/web/scene-perf.js
+++ b/web/scene-perf.js
@@ -1,0 +1,206 @@
+import init, { NoonCanvasPlayer } from "./pkg/noon_web.js";
+import { PythonAuthoringClient } from "./authoring-client.js";
+import { BrowserJankMonitor } from "./browser-jank.js";
+import { FrameMetrics, SampleWindow } from "./frame-metrics.js";
+
+const parameters = new URLSearchParams(location.search);
+const sourcePath = parameters.get("source") ?? "./python/demo_scene.py";
+if (!sourcePath.startsWith("./python/") || !sourcePath.endsWith(".py")) {
+  throw new Error("scene performance source must be a local ./python/*.py file");
+}
+const warmupFrames = positiveInteger("warmup", 30);
+const measuredFrames = positiveInteger("frames", 180);
+const targetHz = positiveNumber("targetHz", 60);
+const cameraHeight = positiveNumber("cameraHeight", 6);
+const context = parseContext(parameters.get("context"));
+const canvas = document.querySelector("#scene");
+const status = document.querySelector("#status");
+const output = document.querySelector("#json");
+
+let client = null;
+let player = null;
+try {
+  await init();
+  const source = await loadText(sourcePath);
+  const workerStarted = performance.now();
+  client = new PythonAuthoringClient();
+  await client.ready();
+  const workerStartupMs = performance.now() - workerStarted;
+
+  status.value = `Authoring ${sourcePath}…`;
+  const authorStarted = performance.now();
+  const authored = await client.run(source, context);
+  const authoringMs = performance.now() - authorStarted;
+  if (authored.kind !== "scene_document") {
+    throw new Error("performance corpus source did not return a Scene");
+  }
+
+  const jsonStarted = performance.now();
+  const sceneJson = JSON.stringify(authored.document);
+  const serializationMs = performance.now() - jsonStarted;
+  const createStarted = performance.now();
+  player = await NoonCanvasPlayer.create(canvas, sceneJson, 4.0);
+  const playerCreateMs = performance.now() - createStarted;
+  player.resize(canvas.width, canvas.height);
+  player.setCamera(0, 0, cameraHeight);
+  const gpuSupported = player.gpuProfilingSupported();
+  player.setGpuProfilingEnabled(gpuSupported);
+
+  for (let frame = 0; frame < warmupFrames; frame += 1) {
+    status.value = `Warm-up ${frame + 1}/${warmupFrames} · ${sourcePath}…`;
+    player.renderFrame(await nextAnimationFrame());
+  }
+
+  player.resetClock();
+  player.resetGpuProfiling();
+  const cadence = new FrameMetrics({ targetHz });
+  const windows = {
+    cpu: new SampleWindow(measuredFrames),
+    runtime: new SampleWindow(measuredFrames),
+    prepare: new SampleWindow(measuredFrames),
+    upload: new SampleWindow(measuredFrames),
+    encode: new SampleWindow(measuredFrames),
+  };
+  const jank = new BrowserJankMonitor();
+  const measurementStart = performance.now();
+  jank.start();
+  let measured = 0;
+  while (measured < measuredFrames) {
+    status.value = `Measuring ${measured + 1}/${measuredFrames} · ${sourcePath}…`;
+    const timestamp = await nextAnimationFrame();
+    const submitStarted = performance.now();
+    const presented = player.renderFrame(timestamp);
+    const browserSubmitMs = performance.now() - submitStarted;
+    if (!presented) continue;
+    cadence.record(timestamp, browserSubmitMs);
+    windows.cpu.record(player.lastCpuFrameMs());
+    windows.runtime.record(player.lastRuntimeEvaluationMs());
+    windows.prepare.record(player.lastFramePrepareMs());
+    windows.upload.record(player.lastUploadMs());
+    windows.encode.record(player.lastEncodeSubmitMs());
+    measured += 1;
+  }
+  const measurementEnd = performance.now();
+  jank.stop();
+  const frame = cadence.summary();
+
+  const report = {
+    schemaVersion: 1,
+    benchmark: "Noon realistic authored scene profile",
+    generatedAt: new Date().toISOString(),
+    scene: {
+      source: sourcePath,
+      context,
+      objects: player.objectCount(),
+      cameraHeight,
+    },
+    environment: {
+      userAgent: navigator.userAgent,
+      rendererBackend: player.rendererBackend(),
+      devicePixelRatio: window.devicePixelRatio || 1,
+      backingResolution: [canvas.width, canvas.height],
+      targetHz,
+    },
+    setup: {
+      workerStartupMs,
+      authoringMs,
+      serializationMs,
+      serializedBytes: new TextEncoder().encode(sceneJson).byteLength,
+      playerCreateMs,
+      warmupFrames,
+    },
+    cadence: {
+      frames: frame.frames,
+      frameIntervalMs: frame.interval,
+      effective: frame.cadence,
+      browserSubmitMs: frame.submission,
+    },
+    cpu: {
+      frameMs: windows.cpu.summary(),
+      runtimeMs: windows.runtime.summary(),
+      prepareMs: windows.prepare.summary(),
+      uploadMs: windows.upload.summary(),
+      encodeSubmitMs: windows.encode.summary(),
+    },
+    renderer: {
+      drawCalls: player.lastDrawCalls(),
+      instances: player.lastInstancesDrawn(),
+      lastUploadBytes: player.lastBytesUploaded(),
+      geometryCacheMisses: player.lastGeometryCacheMisses(),
+    },
+    browser: {
+      longTasks: jank.summary(measurementStart, measurementEnd),
+    },
+    gpu: gpuSupported
+      ? {
+          samples: player.gpuProfiledFrameCount(),
+          dropped: player.gpuDroppedSampleCount(),
+          failed: player.gpuFailedSampleCount(),
+          p50: finite(player.gpuRenderP50Ms()),
+          p95: finite(player.gpuRenderP95Ms()),
+          p99:
+            typeof player.gpuRenderP99Ms === "function"
+              ? finite(player.gpuRenderP99Ms())
+              : null,
+        }
+      : { supported: false },
+  };
+
+  window.__NOON_SCENE_PERF__ = report;
+  output.textContent = JSON.stringify(report, null, 2);
+  status.value =
+    `Complete · ${sourcePath} · ${format(report.cadence.effective?.effectiveFps)} FPS · ` +
+    `p95 ${format(report.cadence.frameIntervalMs?.p95)} ms`;
+  status.dataset.state = "complete";
+  console.log("NOON_SCENE_PERF", report);
+} catch (error) {
+  console.error(error);
+  status.value = `Scene profile failed: ${error}`;
+  status.dataset.state = "error";
+} finally {
+  client?.terminate();
+  player?.free?.();
+}
+
+function parseContext(value) {
+  if (value === null || value === "") return {};
+  const parsed = JSON.parse(value);
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("context must decode to an object");
+  }
+  return parsed;
+}
+
+async function loadText(path) {
+  const response = await fetch(path);
+  if (!response.ok) throw new Error(`Unable to load ${path}: HTTP ${response.status}`);
+  return response.text();
+}
+
+function nextAnimationFrame() {
+  return new Promise((resolve) => requestAnimationFrame(resolve));
+}
+
+function positiveInteger(name, fallback) {
+  const value = parameters.get(name);
+  if (value === null) return fallback;
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) throw new Error(`${name} must be a positive integer`);
+  return parsed;
+}
+
+function positiveNumber(name, fallback) {
+  const value = parameters.get(name);
+  if (value === null) return fallback;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) throw new Error(`${name} must be positive`);
+  return parsed;
+}
+
+function finite(value) {
+  return Number.isFinite(value) ? value : null;
+}
+
+function format(value) {
+  return Number.isFinite(value) ? Number(value).toFixed(2) : "—";
+}


### PR DESCRIPTION
## Summary
Implements P9 from #134 with a versioned corpus of real Python/Manim-style scenes, explicit bottleneck coverage, and executable realtime-budget policy.

- add a generic `scene-perf.html` profiler that runs actual Python scenes through Pyodide authoring, scene serialization, `NoonCanvasPlayer`, runtime evaluation, frame preparation/upload/encode, GPU timestamps, rAF cadence, and browser long-task monitoring;
- classify corpus entries as representative, adversarial, or scalability-only and declare the P1-P7 domains/stress dimensions each scene exercises;
- cover groups/layout, staggered choreography, ValueTracker/native reactivity, instancing, mixed transparent painter order/overdraw, Create/reveal, vector morphing, semantic matching, and shared-vs-unique geometry scaling;
- extract a reusable `perf_host_updater.py` fixture and run it through the existing host-callback smoke path so P5/P7 fallback cost is represented without pretending callbacks execute inside the standalone canvas profiler;
- reference the P6 authoring profiler as an auxiliary corpus case for warm rerun, one-object edit, identity stabilization, reconciliation, seek, and time-to-visible behavior;
- define `interactive60`, `heavy60`, and diagnostic-only `scalability` tiers, including 60 Hz frame p95/p99/long-frame budgets and an explicit non-gating 120 Hz headroom policy;
- keep wall-clock enforcement opt-in for controlled named-device runs rather than noisy shared CI;
- add executable manifest tests requiring every P1-P7 domain to retain representative coverage, source paths to exist, anti-benchmark-gaming cases to remain present, and the 60/120 Hz policy to stay explicit;
- extend the P8 named-device runner with a `corpus` suite; its default bundle now records synthetic frame scaling and realistic authored scenes together on WebGPU/WebGL2, with `frame,corpus,authoring` available for a complete release characterization;
- leave text/math (#83) and axes/plotting (#85) as schema-compatible future corpus additions.

This complements the synthetic P0 matrices with normal authored scenes while preserving separate first-run/edit and steady-playback measurements.

Tracks #134.