### PR TITLE
Lazily materialize Python updater snapshots

### DIFF
--- a/scripts/build-web-demo.sh
+++ b/scripts/build-web-demo.sh
@@ -17,6 +17,7 @@ node --check web/perf-profile.js
 node --check web/perf-workloads.js
 node --check web/authoring-perf.js
 node --check web/scene-perf.js
+node --check web/host-callback-perf.js
 node --check web/browser-smoke.js
 node --check scripts/browser-smoke.mjs
 node --check scripts/perf-profile.mjs
@@ -24,6 +25,7 @@ node --check scripts/authoring-perf.mjs
 node --check scripts/perf-device-run.mjs
 node --check scripts/perf-compare.mjs
 node --check scripts/perf-corpus.mjs
+node --check scripts/host-callback-perf.mjs
 node --check scripts/deterministic-replay-smoke.mjs
 node --check scripts/manim-compat-smoke.mjs
 node --check scripts/manim-tutorial-smoke.mjs

--- a/scripts/host-callback-perf.mjs
+++ b/scripts/host-callback-perf.mjs
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { spawn, spawnSync } from "node:child_process";
+import { mkdir, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import playwright from "playwright";
+
+const { chromium } = playwright;
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const cases = parseCases(process.env.NOON_HOST_CALLBACK_CASES ?? "1000:1,1000:100,10000:1,10000:100");
+const frames = positiveInteger(process.env.NOON_HOST_CALLBACK_FRAMES ?? "300", "frames");
+const warmup = positiveInteger(process.env.NOON_HOST_CALLBACK_WARMUP ?? "30", "warmup");
+const port = positiveInteger(process.env.NOON_HOST_CALLBACK_PORT ?? "4184", "port");
+const artifactPath = path.resolve(repoRoot, process.env.NOON_HOST_CALLBACK_ARTIFACT ?? "perf-artifacts/host-callback-perf.json");
+const baseUrl = `http://127.0.0.1:${port}`;
+
+let serverOutput = "";
+const server = spawn("python3", ["-m", "http.server", String(port), "--bind", "127.0.0.1", "--directory", repoRoot], {
+  cwd: repoRoot,
+  stdio: ["ignore", "pipe", "pipe"],
+});
+server.stdout.on("data", (chunk) => (serverOutput += chunk));
+server.stderr.on("data", (chunk) => (serverOutput += chunk));
+
+let browser = null;
+try {
+  await waitForServer();
+  browser = await chromium.launch({ channel: "chromium", headless: true, args: ["--disable-dev-shm-usage"] });
+  const results = [];
+  for (const testCase of cases) {
+    const page = await browser.newPage();
+    const query = new URLSearchParams({
+      objects: String(testCase.objects),
+      active: String(testCase.active),
+      frames: String(frames),
+      warmup: String(warmup),
+    });
+    process.stdout.write(`Host callback ${testCase.active}/${testCase.objects}… `);
+    await page.goto(`${baseUrl}/web/host-callback-perf.html?${query}`, { waitUntil: "load" });
+    await page.waitForFunction(
+      () => window.__NOON_HOST_CALLBACK_PERF__ || document.querySelector("#status")?.dataset.state === "error",
+      null,
+      { timeout: 600_000 },
+    );
+    const state = await page.locator("#status").getAttribute("data-state");
+    if (state === "error") throw new Error(await page.locator("#status").textContent());
+    const report = await page.evaluate(() => window.__NOON_HOST_CALLBACK_PERF__);
+    results.push(report);
+    console.log(
+      `native ${fmt(report.native.frameWorkMs?.p95)} ms, host ${fmt(report.host.frameWorkMs?.p95)} ms, ` +
+        `callback ${fmt(report.host.callbackRoundTripMs?.p95)} ms, snapshot ${fmt(report.host.callbackSnapshotBytes?.p50)} B`,
+    );
+    await page.close();
+  }
+  const commit = spawnSync("git", ["rev-parse", "HEAD"], { cwd: repoRoot, encoding: "utf8" });
+  const artifact = {
+    schemaVersion: 1,
+    benchmark: "Noon native versus Python host callback matrix",
+    generatedAt: new Date().toISOString(),
+    commit: commit.status === 0 ? commit.stdout.trim() : null,
+    host: { platform: os.platform(), release: os.release(), arch: os.arch(), cpu: os.cpus()[0]?.model ?? null },
+    configuration: { cases, frames, warmup },
+    results,
+  };
+  await mkdir(path.dirname(artifactPath), { recursive: true });
+  await writeFile(artifactPath, `${JSON.stringify(artifact, null, 2)}\n`);
+  console.log(`Wrote ${path.relative(repoRoot, artifactPath)}`);
+} finally {
+  await browser?.close();
+  server.kill("SIGTERM");
+}
+
+async function waitForServer() {
+  let lastError = null;
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    try {
+      const response = await fetch(`${baseUrl}/web/host-callback-perf.html`);
+      if (response.ok) return;
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`host callback perf server did not start: ${lastError}\n${serverOutput}`);
+}
+
+function parseCases(value) {
+  return String(value).split(",").map((entry) => {
+    const [objectsText, activeText] = entry.trim().split(":");
+    const objects = positiveInteger(objectsText, "objects");
+    const active = positiveInteger(activeText, "active");
+    assert.ok(active <= objects, "active must not exceed objects");
+    return { objects, active };
+  });
+}
+
+function positiveInteger(value, name) {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) throw new Error(`${name} must be a positive integer`);
+  return parsed;
+}
+
+function fmt(value) {
+  return Number.isFinite(value) ? Number(value).toFixed(3) : "—";
+}

--- a/web/host-callback-perf.html
+++ b/web/host-callback-perf.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="data:," />
+    <title>Noon host callback performance</title>
+    <style>
+      :root { color-scheme: dark; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; background: #090c13; color: #e9efff; }
+      body { width: min(96vw, 72rem); margin: 1.5rem auto; }
+      output { display: block; margin-bottom: 1rem; white-space: pre-wrap; }
+      pre { overflow: auto; max-height: 78vh; padding: 1rem; border: 1px solid #29334b; border-radius: .75rem; background: #0d1220; }
+    </style>
+  </head>
+  <body>
+    <output id="status" data-state="starting">Starting host callback profile…</output>
+    <pre id="json"></pre>
+    <script type="module" src="./host-callback-perf.js"></script>
+  </body>
+</html>

--- a/web/host-callback-perf.js
+++ b/web/host-callback-perf.js
@@ -1,0 +1,252 @@
+import initNoonWeb, { HostScenePlayer } from "./pkg/noon_web.js";
+import { PythonAuthoringClient } from "./authoring-client.js";
+import { BrowserJankMonitor } from "./browser-jank.js";
+import { FrameMetrics, SampleWindow } from "./frame-metrics.js";
+
+const parameters = new URLSearchParams(location.search);
+const objectCount = positiveInteger("objects", 1_000);
+const activeCount = positiveInteger("active", 1);
+const warmupFrames = positiveInteger("warmup", 30);
+const measuredFrames = positiveInteger("frames", 300);
+if (activeCount > objectCount) throw new Error("active updater count cannot exceed object count");
+
+const status = document.querySelector("#status");
+const output = document.querySelector("#json");
+const encoder = new TextEncoder();
+let client = null;
+
+try {
+  await initNoonWeb();
+  client = new PythonAuthoringClient();
+  await client.ready();
+
+  const native = await author(nativeSource(objectCount, activeCount));
+  const host = await author(hostSource(objectCount, activeCount));
+  if (native.callbacks !== null) throw new Error("native comparison scene unexpectedly registered callbacks");
+  if (host.callbacks === null) throw new Error("host comparison scene did not register callbacks");
+
+  status.value = `Native baseline · ${activeCount}/${objectCount} active…`;
+  const nativeResult = await measureNative(native.document);
+  status.value = `Python updater · ${activeCount}/${objectCount} active…`;
+  const hostResult = await measureHost(host);
+
+  const report = {
+    schemaVersion: 1,
+    benchmark: "Noon native versus Python host callback frame cost",
+    generatedAt: new Date().toISOString(),
+    workload: { objects: objectCount, active: activeCount, warmupFrames, measuredFrames },
+    environment: {
+      userAgent: navigator.userAgent,
+      hardwareConcurrency: navigator.hardwareConcurrency ?? null,
+      devicePixelRatio: window.devicePixelRatio || 1,
+    },
+    native: nativeResult,
+    host: hostResult,
+    overhead: {
+      frameWorkP95Ms: difference(hostResult.frameWorkMs?.p95, nativeResult.frameWorkMs?.p95),
+      cadenceP95Ms: difference(hostResult.frameIntervalMs?.p95, nativeResult.frameIntervalMs?.p95),
+      callbackRoundTripP95Ms: hostResult.callbackRoundTripMs?.p95 ?? null,
+      callbackSnapshotBytesP50: hostResult.callbackSnapshotBytes?.p50 ?? null,
+      patchBytesP50: hostResult.patchBytes?.p50 ?? null,
+    },
+  };
+  window.__NOON_HOST_CALLBACK_PERF__ = report;
+  output.textContent = JSON.stringify(report, null, 2);
+  status.value =
+    `Complete · native work p95 ${format(nativeResult.frameWorkMs?.p95)} ms · ` +
+    `host p95 ${format(hostResult.frameWorkMs?.p95)} ms · ` +
+    `callback ${format(hostResult.callbackRoundTripMs?.p95)} ms`;
+  status.dataset.state = "complete";
+  console.log("NOON_HOST_CALLBACK_PERF", report);
+} catch (error) {
+  console.error(error);
+  status.value = `Host callback profile failed: ${error}`;
+  status.dataset.state = "error";
+} finally {
+  client?.terminate();
+}
+
+async function author(source) {
+  const result = await client.run(source);
+  if (result.kind !== "scene_document") throw new Error("performance source did not return a scene");
+  return result;
+}
+
+async function measureNative(document) {
+  const player = new HostScenePlayer(JSON.stringify(document), "[]");
+  try {
+    for (let frame = 0; frame < warmupFrames; frame += 1) {
+      player.advanceTo((frame + 1) / 60);
+    }
+    const cadence = new FrameMetrics();
+    const work = new SampleWindow(measuredFrames);
+    const jank = new BrowserJankMonitor();
+    let firstTimestamp = null;
+    const start = performance.now();
+    jank.start();
+    for (let frame = 0; frame < measuredFrames; frame += 1) {
+      const timestamp = await nextAnimationFrame();
+      firstTimestamp ??= timestamp;
+      const semanticTime = warmupFrames / 60 + (timestamp - firstTimestamp) / 1000 + 1 / 60;
+      const began = performance.now();
+      player.advanceTo(semanticTime);
+      const elapsed = performance.now() - began;
+      cadence.record(timestamp, elapsed);
+      work.record(elapsed);
+    }
+    const end = performance.now();
+    jank.stop();
+    const frame = cadence.summary();
+    return {
+      frameWorkMs: work.summary(),
+      frameIntervalMs: frame.interval,
+      cadence: frame.cadence,
+      longTasks: jank.summary(start, end),
+    };
+  } finally {
+    player.free();
+  }
+}
+
+async function measureHost(authored) {
+  const player = new HostScenePlayer(
+    JSON.stringify(authored.document),
+    JSON.stringify(authored.callbacks.slots),
+  );
+  try {
+    let sequence = 0;
+    for (let frame = 0; frame < warmupFrames; frame += 1) {
+      player.advanceTo((frame + 1) / 60);
+      const snapshot = JSON.parse(player.callbackFrameJson());
+      const batch = await client.runCallbackPhase(authored.callbacks.session_id, snapshot, sequence);
+      player.commitPatchBatch(JSON.stringify(batch));
+      sequence += 1;
+    }
+
+    const cadence = new FrameMetrics();
+    const windows = {
+      work: new SampleWindow(measuredFrames),
+      advance: new SampleWindow(measuredFrames),
+      snapshot: new SampleWindow(measuredFrames),
+      parse: new SampleWindow(measuredFrames),
+      callback: new SampleWindow(measuredFrames),
+      serialize: new SampleWindow(measuredFrames),
+      commit: new SampleWindow(measuredFrames),
+      snapshotBytes: new SampleWindow(measuredFrames),
+      patchBytes: new SampleWindow(measuredFrames),
+      patchCount: new SampleWindow(measuredFrames),
+    };
+    const jank = new BrowserJankMonitor();
+    let firstTimestamp = null;
+    const start = performance.now();
+    jank.start();
+    for (let frame = 0; frame < measuredFrames; frame += 1) {
+      const timestamp = await nextAnimationFrame();
+      firstTimestamp ??= timestamp;
+      const semanticTime = warmupFrames / 60 + (timestamp - firstTimestamp) / 1000 + 1 / 60;
+      const frameStarted = performance.now();
+
+      let began = performance.now();
+      player.advanceTo(semanticTime);
+      windows.advance.record(performance.now() - began);
+
+      began = performance.now();
+      const snapshotJson = player.callbackFrameJson();
+      windows.snapshot.record(performance.now() - began);
+      windows.snapshotBytes.record(encoder.encode(snapshotJson).byteLength);
+
+      began = performance.now();
+      const snapshot = JSON.parse(snapshotJson);
+      windows.parse.record(performance.now() - began);
+
+      began = performance.now();
+      const batch = await client.runCallbackPhase(authored.callbacks.session_id, snapshot, sequence);
+      windows.callback.record(performance.now() - began);
+
+      began = performance.now();
+      const patchJson = JSON.stringify(batch);
+      windows.serialize.record(performance.now() - began);
+      windows.patchBytes.record(encoder.encode(patchJson).byteLength);
+      windows.patchCount.record(batch.patches.length);
+
+      began = performance.now();
+      player.commitPatchBatch(patchJson);
+      windows.commit.record(performance.now() - began);
+      sequence += 1;
+
+      const elapsed = performance.now() - frameStarted;
+      windows.work.record(elapsed);
+      cadence.record(timestamp, elapsed);
+    }
+    const end = performance.now();
+    jank.stop();
+    const frame = cadence.summary();
+    return {
+      frameWorkMs: windows.work.summary(),
+      frameIntervalMs: frame.interval,
+      cadence: frame.cadence,
+      advanceMs: windows.advance.summary(),
+      callbackSnapshotMs: windows.snapshot.summary(),
+      mainThreadParseMs: windows.parse.summary(),
+      callbackRoundTripMs: windows.callback.summary(),
+      patchSerializeMs: windows.serialize.summary(),
+      patchCommitMs: windows.commit.summary(),
+      callbackSnapshotBytes: windows.snapshotBytes.summary(),
+      patchBytes: windows.patchBytes.summary(),
+      patchCount: windows.patchCount.summary(),
+      longTasks: jank.summary(start, end),
+    };
+  } finally {
+    player.free();
+  }
+}
+
+function nativeSource(objects, active) {
+  return `
+from noon import Circle, Scene, Vec2
+scene = Scene()
+dots = [Circle(0.1) for _ in range(${objects})]
+for index, dot in enumerate(dots):
+    scene.add(dot, key=f"dot.{index}")
+for index, dot in enumerate(dots[:${active}]):
+    scene.animate_position(dot, Vec2(0.0, 0.0), Vec2(1.0, 0.0), duration=60.0, key=f"move.{index}")
+result = scene
+`;
+}
+
+function hostSource(objects, active) {
+  return `
+from noon import Circle, RIGHT, Scene
+scene = Scene()
+dots = [Circle(0.1) for _ in range(${objects})]
+for index, dot in enumerate(dots):
+    scene.add(dot, key=f"dot.{index}")
+
+def move(mobject, dt):
+    mobject.shift(RIGHT * (0.1 * dt))
+
+for dot in dots[:${active}]:
+    dot.add_updater(move)
+result = scene
+`;
+}
+
+function nextAnimationFrame() {
+  return new Promise((resolve) => requestAnimationFrame(resolve));
+}
+
+function positiveInteger(name, fallback) {
+  const value = parameters.get(name);
+  if (value === null) return fallback;
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) throw new Error(`${name} must be a positive integer`);
+  return parsed;
+}
+
+function difference(left, right) {
+  return Number.isFinite(left) && Number.isFinite(right) ? left - right : null;
+}
+
+function format(value) {
+  return Number.isFinite(value) ? Number(value).toFixed(3) : "—";
+}

--- a/web/python/_manim_updaters.py
+++ b/web/python/_manim_updaters.py
@@ -140,33 +140,39 @@ class _CallbackContext:
     def __init__(self, scene: _base.Scene, frame: dict[str, Any]) -> None:
         self.scene = scene
         self.delta_time = float(frame["delta_time"])
+        self._frame_items = {
+            int(item["object"]): item
+            for item in frame["objects"]
+        }
         self._baseline: dict[int, _ir.Mobject] = {}
         self._current: dict[int, _ir.Mobject] = {}
 
-        for item in frame["objects"]:
-            object_id = int(item["object"])
-            authored = scene._objects[object_id]
-            raw = _ir.Mobject(
-                geometry=copy.deepcopy(authored["geometry"]),
-                transform=copy.deepcopy(item["transform"]),
-                style=copy.deepcopy(item["style"]),
-            )
-            self._baseline[object_id] = raw
-            self._current[object_id] = copy.deepcopy(raw)
-
-    def current_raw(self, object_id: int) -> _ir.Mobject:
+    def _materialize(self, object_id: int) -> _ir.Mobject:
+        existing = self._current.get(object_id)
+        if existing is not None:
+            return existing
         try:
-            return self._current[object_id]
+            item = self._frame_items[object_id]
         except KeyError as error:
             raise RuntimeError(
                 f"host callback snapshot does not contain object {object_id}"
             ) from error
+        authored = self.scene._objects[object_id]
+        raw = _ir.Mobject(
+            geometry=copy.deepcopy(authored["geometry"]),
+            transform=copy.deepcopy(item["transform"]),
+            style=copy.deepcopy(item["style"]),
+        )
+        self._baseline[object_id] = raw
+        current = copy.deepcopy(raw)
+        self._current[object_id] = current
+        return current
+
+    def current_raw(self, object_id: int) -> _ir.Mobject:
+        return self._materialize(object_id)
 
     def replace_raw(self, object_id: int, raw: _ir.Mobject) -> None:
-        if object_id not in self._current:
-            raise RuntimeError(
-                f"host callback snapshot does not contain object {object_id}"
-            )
+        self._materialize(object_id)
         self._current[object_id] = _ir.Mobject(
             geometry=copy.deepcopy(raw.geometry),
             transform=copy.deepcopy(raw.transform),
@@ -236,7 +242,9 @@ def register_scene(scene: _base.Scene) -> dict[str, Any] | None:
 
     # Arbitrary Python closures may read any bound mobject. Observe the complete
     # semantic object table once per callback phase so all such reads are coherent
-    # and local inside Pyodide. The host runtime deduplicates this table globally.
+    # and local inside Pyodide. The Python callback context materializes the
+    # corresponding Mobject snapshots lazily, so cost scales with the closure's
+    # touched set rather than eagerly deep-copying every scene object.
     object_ids = [int(obj["id"]) for obj in scene._objects]
     return {
         "session_id": session_id,

--- a/web/python/test_updater_snapshot.py
+++ b/web/python/test_updater_snapshot.py
@@ -1,0 +1,83 @@
+import unittest
+from types import SimpleNamespace
+
+import _manim_updaters as updaters
+
+
+def _object(index: int) -> dict:
+    return {
+        "id": index,
+        "geometry": {"circle": {"radius": 0.5}},
+        "transform": {
+            "translation": {"x": float(index), "y": 0.0},
+            "rotation": 0.0,
+            "scale": {"x": 1.0, "y": 1.0},
+        },
+        "style": {
+            "fill": {"red": 1.0, "green": 1.0, "blue": 1.0, "alpha": 1.0},
+            "stroke": None,
+            "stroke_width": 0.0,
+            "stroke_join": "round",
+            "stroke_cap": "round",
+            "opacity": 1.0,
+        },
+    }
+
+
+def _frame(count: int) -> dict:
+    return {
+        "time": 1.0,
+        "delta_time": 1.0 / 60.0,
+        "objects": [
+            {
+                "object": item["id"],
+                "transform": item["transform"],
+                "style": item["style"],
+                "presence": True,
+                "appearance": 1.0,
+                "reveal": 1.0,
+                "morph": 0.0,
+            }
+            for item in (_object(index) for index in range(count))
+        ],
+        "invocations": [{"callback": 0, "object_indices": list(range(count))}],
+    }
+
+
+class CallbackContextTests(unittest.TestCase):
+    def test_large_snapshot_materializes_only_objects_actually_read(self) -> None:
+        objects = [_object(index) for index in range(1000)]
+        context = updaters._CallbackContext(SimpleNamespace(_objects=objects), _frame(1000))
+
+        self.assertEqual(context._current, {})
+        self.assertEqual(context._baseline, {})
+
+        current = context.current_raw(777)
+        self.assertEqual(current.transform["translation"]["x"], 777.0)
+        self.assertEqual(set(context._current), {777})
+        self.assertEqual(set(context._baseline), {777})
+        self.assertEqual(context.patch_batch(0).patches, [])
+
+    def test_replace_materializes_baseline_before_recording_mutation(self) -> None:
+        objects = [_object(index) for index in range(8)]
+        context = updaters._CallbackContext(SimpleNamespace(_objects=objects), _frame(8))
+        current = context.current_raw(3)
+        moved = type(current)(
+            geometry=current.geometry,
+            transform={
+                **current.transform,
+                "translation": {"x": 9.0, "y": -2.0},
+            },
+            style=current.style,
+        )
+        context.replace_raw(3, moved)
+
+        batch = context.patch_batch(4)
+        self.assertEqual(len(batch.patches), 1)
+        self.assertEqual(batch.patches[0]["set_transform"]["object"], 3)
+        self.assertEqual(set(context._current), {3})
+        self.assertEqual(set(context._baseline), {3})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/python/test_updater_snapshot.py
+++ b/web/python/test_updater_snapshot.py
@@ -56,7 +56,7 @@ class CallbackContextTests(unittest.TestCase):
         self.assertEqual(current.transform["translation"]["x"], 777.0)
         self.assertEqual(set(context._current), {777})
         self.assertEqual(set(context._baseline), {777})
-        self.assertEqual(context.patch_batch(0).patches, [])
+        self.assertEqual(context.patch_batch(0).to_document()["patches"], [])
 
     def test_replace_materializes_baseline_before_recording_mutation(self) -> None:
         objects = [_object(index) for index in range(8)]
@@ -72,9 +72,9 @@ class CallbackContextTests(unittest.TestCase):
         )
         context.replace_raw(3, moved)
 
-        batch = context.patch_batch(4)
-        self.assertEqual(len(batch.patches), 1)
-        self.assertEqual(batch.patches[0]["set_transform"]["object"], 3)
+        batch = context.patch_batch(4).to_document()
+        self.assertEqual(len(batch["patches"]), 1)
+        self.assertEqual(batch["patches"][0]["set_transform"]["object"], 3)
         self.assertEqual(set(context._current), {3})
         self.assertEqual(set(context._baseline), {3})
 


### PR DESCRIPTION
## Summary
Continues P5/P7 with a concrete host-boundary optimization and a native-vs-Python updater benchmark.

### Root cause
The host runtime intentionally sends a coherent snapshot of every scene object because arbitrary Python updater closures may read any bound mobject. Python `_CallbackContext` then eagerly constructed and deep-copied **two** `_ir.Mobject` graphs for every object before any updater ran. A one-object updater in a 10k-object scene therefore paid Python materialization cost proportional to the whole scene even if the callback only touched one object.

### Change
- retain the complete coherent host snapshot and arbitrary closure-read semantics;
- index raw frame entries cheaply, then construct baseline/current `_ir.Mobject` snapshots only when an object is actually read or mutated;
- compare/emit patches only for materialized objects;
- add deterministic coverage proving a 1,000-object frame materializes only the requested object and still emits identical transform patches;
- add `host-callback-perf.html` plus a 300-frame matrix runner comparing native timeline motion against equivalent Python updaters at the same total/active counts;
- attribute runtime advance, callback-frame JSON creation, main-thread parse, worker/Python round-trip, patch serialization/commit, payload bytes, frame cadence and long tasks.

This makes typical updater Python object-copy cost scale with the callback's touched set rather than total scene size while preserving the full snapshot needed for arbitrary reads.

Tracks #130 and #132.