### PR TITLE
Pin GPU buffer growth and allocation-churn regressions

### DIFF
--- a/crates/noon-render-wgpu/tests/buffer_capacity.rs
+++ b/crates/noon-render-wgpu/tests/buffer_capacity.rs
@@ -1,0 +1,62 @@
+use std::mem::size_of;
+
+use noon_core::{GeometryRef, ObjectId, Style, Transform2D};
+use noon_render_wgpu::{CircleInstance, FramePreparer, GpuRenderer};
+use noon_runtime::{FrameChanges, FrameObjectState, FrameState};
+
+const FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8UnormSrgb;
+
+#[test]
+fn analytic_instance_buffer_grows_geometrically_only_at_capacity_boundary() {
+    let (device, queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
+    let mut renderer = GpuRenderer::new(&device, FORMAT);
+    let mut preparer = FramePreparer::new();
+
+    let initial = circle_frame(1_000);
+    let prepared = preparer.prepare(&initial);
+    let first = renderer.upload(&device, &queue, &prepared);
+    assert_eq!(first.buffer_reallocations, 1);
+
+    let initial_capacity = renderer.circle_capacity_bytes();
+    let instance_bytes = size_of::<CircleInstance>();
+    assert!(initial_capacity.is_power_of_two());
+    assert!(initial_capacity >= initial.objects.len() * instance_bytes);
+    let max_instances_without_growth = initial_capacity / instance_bytes;
+    assert!(max_instances_without_growth >= initial.objects.len());
+
+    let at_capacity = circle_frame(max_instances_without_growth);
+    let prepared = preparer.prepare(&at_capacity);
+    let within = renderer.upload(&device, &queue, &prepared);
+    assert_eq!(within.buffer_reallocations, 0);
+    assert_eq!(renderer.circle_capacity_bytes(), initial_capacity);
+
+    let crossing = circle_frame(max_instances_without_growth + 1);
+    let prepared = preparer.prepare(&crossing);
+    let growth = renderer.upload(&device, &queue, &prepared);
+    assert_eq!(growth.buffer_reallocations, 1);
+    assert_eq!(renderer.circle_capacity_bytes(), initial_capacity * 2);
+
+    let prepared = preparer.prepare_incremental(&crossing, &FrameChanges::default());
+    let steady = renderer.upload(&device, &queue, &prepared);
+    assert_eq!(steady.buffer_reallocations, 0);
+    assert_eq!(steady.bytes_uploaded, 0);
+}
+
+fn circle_frame(object_count: usize) -> FrameState {
+    FrameState {
+        time: 0.0,
+        objects: (0..object_count)
+            .map(|index| FrameObjectState {
+                id: ObjectId::new(index as u64),
+                geometry: GeometryRef::circle(0.5),
+                transform: Transform2D::IDENTITY,
+                style: Style::default(),
+                appearance: 1.0,
+            })
+            .collect(),
+        presences: vec![true; object_count],
+        reveals: vec![1.0; object_count],
+        morphs: vec![0.0; object_count],
+        render_geometries: vec![None; object_count],
+    }
+}

--- a/docs/performance-memory.md
+++ b/docs/performance-memory.md
@@ -1,0 +1,30 @@
+# Allocation and capacity performance
+
+This document tracks transient allocation/churn that can affect frame p95/p99. Eventual reclamation and leak invariants remain owned by #114.
+
+## Ranked sources found so far
+
+| Source | Frequency / scale | Evidence | Status |
+|---|---|---|---|
+| Browser scene JSON parse | Every full authoring result; O(scene bytes) | 2026-08-19 baseline: 220.244 ms to parse the 25.13 MiB / 100k result | Architecture-scale transport ceiling; P6 measures its time-to-visible contribution |
+| Scene identity stabilization | Every keyed Run/rerun; formerly O(objects + tracks) Maps/arrays | baseline: 29.724 ms at 100k before the identity fast path | stable-ID reruns now return the original document without remap Maps/arrays (#146) |
+| Runtime requested/active-group snapshots | Every active frame; formerly O(active groups) copies | code audit plus active-vs-history scheduler benchmark | active-set and requested-group frame snapshots were removed by #137/#152; timeline relowering is channel-local |
+| Python updater callback materialization | Every host callback phase; formerly two deep object graphs per scene object | host protocol necessarily supplies a coherent all-object snapshot; Python then eagerly copied it | #153 changes Python materialization to touched/read objects only and adds native-vs-host callback profiling |
+| GPU instance-buffer growth | Only when packed bytes exceed retained capacity | `UploadStats.buffer_reallocations`; existing noop tests prove zero reallocations after warmup | capacity is geometric (next power of two); `buffer_capacity.rs` pins the exact threshold/no-growth/grow-once behavior |
+| Steady renderer preparation/upload | Every presented frame but intended to be allocation/locality-free | baseline unchanged 100k prep ~0.000061 ms and 0 uploaded bytes | deterministic dirty/upload tests remain the primary regression gate |
+
+The JSON row is not a frame-loop allocation in steady playback, but it dominates interaction stalls during large Run/rerun operations and can overlap presentation. Browser GC timing remains diagnostic; deterministic operation/capacity counters are preferred where the browser does not expose stable GC telemetry.
+
+## GPU buffer capacity policy
+
+Analytic instance records use an 88-byte stride. GPU buffers retain capacity and grow only when required bytes exceed current capacity. A growth rounds the requested byte size to the next power of two (minimum 256 bytes), so repeated small increases within the retained capacity do not allocate/copy a new GPU buffer.
+
+`crates/noon-render-wgpu/tests/buffer_capacity.rs` derives the maximum object count from the actual retained byte capacity rather than hard-coding a threshold. It verifies:
+
+1. the first non-empty upload allocates once;
+2. growing up to the exact retained capacity triggers no reallocation;
+3. the first object beyond capacity triggers exactly one reallocation;
+4. that crossing doubles retained capacity for the tested boundary;
+5. the following unchanged frame performs zero reallocations and zero uploads.
+
+This makes capacity-threshold churn deterministic in CI while real-browser P0/P5/P6 cadence/long-task profiles remain the place to correlate such events with observed jank.


### PR DESCRIPTION
## Summary
Continues #132 with deterministic capacity-threshold coverage and a ranked allocation/churn inventory.

- add an integration test using wgpu's noop device that derives the analytic instance capacity from the actual retained byte buffer;
- prove the initial allocation happens once, growth up to capacity reallocates zero times, the first object above capacity reallocates exactly once, and the new capacity doubles at that boundary;
- prove the immediately following unchanged frame has zero reallocations and zero uploaded bytes;
- document the explicit next-power-of-two capacity policy and keep browser GC timing diagnostic rather than making noisy GC pauses a correctness gate;
- rank the material sources identified so far: full scene JSON parse, identity stabilization, runtime active/request snapshots, Python updater snapshot materialization, GPU buffer growth, and steady renderer upload.

This complements #146's stable-identity allocation fast path and #153's host callback touched-set optimization. Eventual memory reclamation remains owned by #114.

Tracks #132.