### PR TITLE
Add shared Manim object state semantics

### DIFF
--- a/crates/noon-web/src/authoring_mobject.rs
+++ b/crates/noon-web/src/authoring_mobject.rs
@@ -261,6 +261,49 @@ impl FrontendMobjectHandle {
         self.snapshot.style.opacity = self.semantic_style.object_opacity as f32;
     }
 
+    pub fn become_handle(&mut self, other: &Self) {
+        self.snapshot = other.snapshot.clone();
+        self.semantic_style = other.semantic_style.clone();
+    }
+
+    pub fn replace_handle(
+        &mut self,
+        other: &Self,
+        dim_to_match: u32,
+        stretch: bool,
+    ) -> Result<(), String> {
+        if dim_to_match > 1 {
+            return Err(
+                "replace currently supports width (0) or height (1) in the 2D authoring model"
+                    .to_owned(),
+            );
+        }
+        let target_center = other.center();
+        let source_width = self.width();
+        let source_height = self.height();
+        let target_width = other.width();
+        let target_height = other.height();
+
+        if stretch {
+            if source_width == 0.0 || source_height == 0.0 {
+                return Err("cannot stretch-replace an object with zero width or height".to_owned());
+            }
+            self.scale(target_width / source_width, target_height / source_height)?;
+        } else {
+            let (source_length, target_length) = if dim_to_match == 0 {
+                (source_width, target_width)
+            } else {
+                (source_height, target_height)
+            };
+            if source_length == 0.0 {
+                return Err("cannot replace along a zero-length dimension".to_owned());
+            }
+            let factor = target_length / source_length;
+            self.scale(factor, factor)?;
+        }
+        self.move_to(target_center.0, target_center.1)
+    }
+
     pub fn next_to_handle(
         &mut self,
         other: &Self,
@@ -645,6 +688,23 @@ mod wasm {
             self.0.set_opacity(opacity).map_err(js_error)
         }
 
+        #[wasm_bindgen(js_name = becomeHandle)]
+        pub fn become_handle(&mut self, other: &WasmAuthoringMobjectHandle) {
+            self.0.become_handle(&other.0);
+        }
+
+        #[wasm_bindgen(js_name = replaceHandle)]
+        pub fn replace_handle(
+            &mut self,
+            other: &WasmAuthoringMobjectHandle,
+            dim_to_match: u32,
+            stretch: bool,
+        ) -> Result<(), JsValue> {
+            self.0
+                .replace_handle(&other.0, dim_to_match, stretch)
+                .map_err(js_error)
+        }
+
         #[wasm_bindgen(js_name = nextToHandle)]
         pub fn next_to_handle(
             &mut self,
@@ -795,6 +855,32 @@ mod tests {
         assert_eq!(handle.stroke_opacity(), 0.2);
         handle.disable_fill();
         assert_eq!(handle.fill_opacity(), 0.0);
+    }
+
+    #[test]
+    fn become_and_replace_keep_state_inside_shared_handle() {
+        let mut source = FrontendMobjectHandle::from_snapshot(snapshot(GeometryRef::circle(0.5)));
+        source.shift(-2.0, 0.5).unwrap();
+        let mut target =
+            FrontendMobjectHandle::from_snapshot(snapshot(GeometryRef::rectangle(2.0, 1.0)));
+        target.shift(1.0, -0.25).unwrap();
+
+        source.become_handle(&target);
+        assert_eq!(source.snapshot(), target.snapshot());
+
+        let mut replacement =
+            FrontendMobjectHandle::from_snapshot(snapshot(GeometryRef::circle(0.25)));
+        replacement.replace_handle(&target, 0, false).unwrap();
+        assert!((replacement.width() - 2.0).abs() < 1e-6);
+        assert!((replacement.height() - 2.0).abs() < 1e-6);
+        assert!((replacement.center().0 - 1.0).abs() < 1e-6);
+        assert!((replacement.center().1 + 0.25).abs() < 1e-6);
+
+        let mut stretched =
+            FrontendMobjectHandle::from_snapshot(snapshot(GeometryRef::circle(0.25)));
+        stretched.replace_handle(&target, 0, true).unwrap();
+        assert!((stretched.width() - 2.0).abs() < 1e-6);
+        assert!((stretched.height() - 1.0).abs() < 1e-6);
     }
 
     #[test]

--- a/scripts/manim-differential.py
+++ b/scripts/manim-differential.py
@@ -329,6 +329,72 @@ def _manim_vgroup_rotate() -> Any:
     return _members_observation(group)
 
 
+def _noon_generate_target() -> Any:
+    source = noon.Circle(radius=0.4).shift(noon.LEFT * 0.6)
+    target = source.generate_target().shift(noon.RIGHT * 1.5).scale(1.5)
+    return {"source": _object_observation(source), "target": _object_observation(target)}
+
+
+def _manim_generate_target() -> Any:
+    source = manim.Circle(radius=0.4).shift(manim.LEFT * 0.6)
+    target = source.generate_target().shift(manim.RIGHT * 1.5).scale(1.5)
+    return {"source": _object_observation(source), "target": _object_observation(target)}
+
+
+def _noon_save_restore() -> Any:
+    obj = noon.Rectangle(width=1.2, height=0.6).shift(noon.LEFT * 0.5)
+    obj.save_state().shift(noon.RIGHT * 2.0).scale(1.75).restore()
+    return _object_observation(obj)
+
+
+def _manim_save_restore() -> Any:
+    obj = manim.Rectangle(width=1.2, height=0.6).shift(manim.LEFT * 0.5)
+    obj.save_state().shift(manim.RIGHT * 2.0).scale(1.75).restore()
+    return _object_observation(obj)
+
+
+def _noon_become() -> Any:
+    source = noon.Circle(radius=0.4).shift(noon.LEFT)
+    target = noon.Rectangle(width=1.6, height=0.8).shift(noon.RIGHT * 1.25 + noon.UP * 0.4)
+    source.become(target)
+    return _object_observation(source)
+
+
+def _manim_become() -> Any:
+    source = manim.Circle(radius=0.4).shift(manim.LEFT)
+    target = manim.Rectangle(width=1.6, height=0.8).shift(manim.RIGHT * 1.25 + manim.UP * 0.4)
+    source.become(target)
+    return _object_observation(source)
+
+
+def _noon_replace_width() -> Any:
+    source = noon.Circle(radius=0.25)
+    target = noon.Rectangle(width=2.0, height=1.0).shift(noon.RIGHT * 0.8 + noon.DOWN * 0.3)
+    source.replace(target)
+    return _object_observation(source)
+
+
+def _manim_replace_width() -> Any:
+    source = manim.Circle(radius=0.25)
+    target = manim.Rectangle(width=2.0, height=1.0).shift(manim.RIGHT * 0.8 + manim.DOWN * 0.3)
+    source.replace(target)
+    return _object_observation(source)
+
+
+def _noon_replace_stretch() -> Any:
+    source = noon.Circle(radius=0.25)
+    target = noon.Rectangle(width=2.0, height=1.0).shift(noon.LEFT * 0.7 + noon.UP * 0.2)
+    source.replace(target, stretch=True)
+    return _object_observation(source)
+
+
+def _manim_replace_stretch() -> Any:
+    source = manim.Circle(radius=0.25)
+    target = manim.Rectangle(width=2.0, height=1.0).shift(manim.LEFT * 0.7 + manim.UP * 0.2)
+    source.replace(target, stretch=True)
+    return _object_observation(source)
+
+
 FIXTURES = [
     Fixture("circle_dimensions", _noon_circle_dimensions, _manim_circle_dimensions),
     Fixture("rectangle_dimensions", _noon_rectangle_dimensions, _manim_rectangle_dimensions),
@@ -358,6 +424,11 @@ FIXTURES = [
     Fixture("vgroup_arrange_grid", _noon_vgroup_arrange_grid, _manim_vgroup_arrange_grid),
     Fixture("vgroup_scale", _noon_vgroup_scale, _manim_vgroup_scale),
     Fixture("vgroup_rotate", _noon_vgroup_rotate, _manim_vgroup_rotate),
+    Fixture("generate_target", _noon_generate_target, _manim_generate_target),
+    Fixture("save_restore", _noon_save_restore, _manim_save_restore),
+    Fixture("become", _noon_become, _manim_become),
+    Fixture("replace_width", _noon_replace_width, _manim_replace_width),
+    Fixture("replace_stretch", _noon_replace_stretch, _manim_replace_stretch),
 ]
 
 # Explicitly tracked but not yet differential-gated.  Keep this list close to the

--- a/web/python/_manim_compat.py
+++ b/web/python/_manim_compat.py
@@ -695,6 +695,96 @@ class Scene(_BaseScene):
         )
 
 
+def _state_target(self: _BaseMobject, mobject: _BaseMobject, *, match_height: bool, match_width: bool, match_depth: bool, match_center: bool, stretch: bool) -> _BaseMobject:
+    if not isinstance(mobject, _BaseMobject):
+        raise TypeError("state target must be a Mobject")
+    if match_depth:
+        raise NotImplementedError("depth matching requires the shared 2.5D family model")
+    if not (match_height or match_width or match_center or stretch):
+        return mobject
+    target = mobject.copy()
+    if stretch:
+        if target.width == 0.0 or target.height == 0.0:
+            raise ValueError("cannot stretch a zero-width or zero-height target")
+        target.scale((self.width / target.width, self.height / target.height))
+    else:
+        if match_height:
+            if target.height == 0.0:
+                raise ValueError("cannot match height from a zero-height target")
+            target.scale(self.height / target.height)
+        if match_width:
+            if target.width == 0.0:
+                raise ValueError("cannot match width from a zero-width target")
+            target.scale(self.width / target.width)
+    if match_center:
+        target.move_to(self.get_center())
+    return target
+
+
+def _mobject_generate_target(self: _BaseMobject, use_deepcopy: bool = False) -> _BaseMobject:
+    # Noon's copy already performs a deep semantic clone. In the browser the payload
+    # remains in the Rust/WASM handle, so both Manim modes avoid Python snapshot ownership.
+    del use_deepcopy
+    self.target = None
+    self.target = self.copy()
+    return self.target
+
+
+def _mobject_save_state(self: _BaseMobject) -> _BaseMobject:
+    if hasattr(self, "saved_state"):
+        self.saved_state = None
+    self.saved_state = self.copy()
+    return self
+
+
+def _mobject_restore(self: _BaseMobject) -> _BaseMobject:
+    if not hasattr(self, "saved_state") or self.saved_state is None:
+        raise Exception("Trying to restore without having saved")
+    return self.become(self.saved_state)
+
+
+def _mobject_become(
+    self: _BaseMobject,
+    mobject: _BaseMobject,
+    match_height: bool = False,
+    match_width: bool = False,
+    match_depth: bool = False,
+    match_center: bool = False,
+    stretch: bool = False,
+) -> _BaseMobject:
+    target = _state_target(
+        self,
+        mobject,
+        match_height=match_height,
+        match_width=match_width,
+        match_depth=match_depth,
+        match_center=match_center,
+        stretch=stretch,
+    )
+    return self._apply(_base._raw_mobject(target._current_raw()))
+
+
+def _mobject_replace(
+    self: _BaseMobject, mobject: _BaseMobject, dim_to_match: int = 0, stretch: bool = False
+) -> _BaseMobject:
+    if not isinstance(mobject, _BaseMobject):
+        raise TypeError("replacement target must be a Mobject")
+    if dim_to_match not in (0, 1):
+        raise NotImplementedError("replace currently supports width (0) or height (1)")
+    if stretch:
+        if self.width == 0.0 or self.height == 0.0:
+            raise ValueError("cannot stretch-replace an object with zero width or height")
+        self.scale((mobject.width / self.width, mobject.height / self.height))
+    else:
+        source_length = self.width if dim_to_match == 0 else self.height
+        target_length = mobject.width if dim_to_match == 0 else mobject.height
+        if source_length == 0.0:
+            raise ValueError("cannot replace along a zero-length dimension")
+        self.scale(target_length / source_length)
+    self.move_to(mobject.get_center())
+    return self
+
+
 def install() -> None:
     """Install the compatibility surface into the public ``noon`` module."""
 
@@ -707,6 +797,11 @@ def install() -> None:
     # so replacing that helper makes inherited transforms/layout accept z=0 vectors.
     _base._as_vec2 = _as_vec2
     _BaseMobject.animate = property(lambda self: _CompatAnimationBuilder(self))
+    _BaseMobject.generate_target = _mobject_generate_target
+    _BaseMobject.save_state = _mobject_save_state
+    _BaseMobject.restore = _mobject_restore
+    _BaseMobject.become = _mobject_become
+    _BaseMobject.replace = _mobject_replace
 
     public = {
         "VMobject": VMobject,

--- a/web/python/_manim_semantic_handles.py
+++ b/web/python/_manim_semantic_handles.py
@@ -35,6 +35,8 @@ _ORIGINAL_SET_COLOR = _base.Mobject.set_color
 _ORIGINAL_NEXT_TO = _base.Mobject.next_to
 _ORIGINAL_ALIGN_TO = _base.Mobject.align_to
 _ORIGINAL_ALIGN_ON_FRAME = _base.Mobject._align_on_frame
+_ORIGINAL_BECOME = _base.Mobject.become
+_ORIGINAL_REPLACE = _base.Mobject.replace
 
 _ORIGINAL_SET_FILL = _compat.VMobject.set_fill
 _ORIGINAL_SET_STROKE = _compat.VMobject.set_stroke
@@ -67,7 +69,7 @@ def _handle_for(value: object):
 def _init(self: _base.Mobject, raw: _ir.Mobject) -> None:
     _ORIGINAL_INIT(self, raw)
     if _create_handle is not None:
-        # Preserve the exact Python authoring values before the wire/render snapshot
+        # Preserve exact Python authoring opacity before the wire/render snapshot
         # lowers color alpha to f32. The semantic handle owns the f64 API contract.
         fill = raw.style.get("fill")
         stroke = raw.style.get("stroke")
@@ -111,7 +113,10 @@ def _copy_mobject(self: _base.Mobject) -> _base.Mobject:
 
     for name, value in self.__dict__.items():
         if name not in {"_raw", "_scene", "_object", "_semantic_handle"}:
-            setattr(clone, name, copy.deepcopy(value))
+            if isinstance(value, _base.Mobject):
+                setattr(clone, name, value.copy())
+            else:
+                setattr(clone, name, copy.deepcopy(value))
     return clone
 
 
@@ -185,6 +190,51 @@ def _set_color(self: _base.Mobject, color: _base.Color) -> _base.Mobject:
         raise TypeError("color must be a Color")
     handle.setColor(color.red, color.green, color.blue, color.alpha)
     return self
+
+
+def _become(
+    self: _base.Mobject,
+    mobject: _base.Mobject,
+    match_height: bool = False,
+    match_width: bool = False,
+    match_depth: bool = False,
+    match_center: bool = False,
+    stretch: bool = False,
+) -> _base.Mobject:
+    handle = _handle_for(self)
+    other_handle = _handle_for(mobject)
+    if (
+        handle is not None
+        and other_handle is not None
+        and not (match_height or match_width or match_depth or match_center or stretch)
+    ):
+        handle.becomeHandle(other_handle)
+        return self
+    return _ORIGINAL_BECOME(
+        self,
+        mobject,
+        match_height=match_height,
+        match_width=match_width,
+        match_depth=match_depth,
+        match_center=match_center,
+        stretch=stretch,
+    )
+
+
+def _replace(
+    self: _base.Mobject,
+    mobject: _base.Mobject,
+    dim_to_match: int = 0,
+    stretch: bool = False,
+) -> _base.Mobject:
+    handle = _handle_for(self)
+    other_handle = _handle_for(mobject)
+    if handle is not None and other_handle is not None:
+        if dim_to_match not in (0, 1):
+            raise NotImplementedError("replace currently supports width (0) or height (1)")
+        handle.replaceHandle(other_handle, int(dim_to_match), bool(stretch))
+        return self
+    return _ORIGINAL_REPLACE(self, mobject, dim_to_match=dim_to_match, stretch=stretch)
 
 
 def _critical(value: _base.Mobject, direction: _base.Vec2) -> _base.Vec2:
@@ -367,6 +417,8 @@ def install() -> None:
     _base.Mobject.scale = _scale
     _base.Mobject.rotate = _rotate
     _base.Mobject.set_color = _set_color
+    _base.Mobject.become = _become
+    _base.Mobject.replace = _replace
     _base.Mobject.next_to = _next_to
     _base.Mobject.align_to = _align_to
     _base.Mobject._align_on_frame = _align_on_frame


### PR DESCRIPTION
## Summary
- add Manim-compatible `generate_target`, `save_state`, `restore`, `become`, and `replace` to the O1 Mobject surface;
- keep detached `become` and `replace` on the Rust/WASM `FrontendMobjectHandle`, avoiding Python-owned snapshot round-trips on the browser fast path;
- preserve Rust-owned handle semantics for generated targets and saved-state copies;
- copy the shared `SemanticStyle` f64 authoring state when `become` replaces detached state, so style precision is not lost through the render snapshot;
- extend the pinned ManimCE v0.21 differential suite from 20 to 25 cases with target generation, save/restore, become, width-matched replace, and stretched replace.

## Validation
- strict Rust Clippy/tests and wasm32 compilation;
- Python compile validation;
- all 25 pinned ManimCE differential fixtures pass;
- generated browser package passes;
- exact Manim browser compatibility smoke passes, including semantic style precision.

Tracks #61.
Tracks #62.
Tracks #74.