### PR TITLE
Fix live playground sizing on Linux WebGL

### DIFF
--- a/scripts/playground-layout-smoke.mjs
+++ b/scripts/playground-layout-smoke.mjs
@@ -57,6 +57,7 @@ async function layout(page) {
   const browserState = await page.evaluate(() => {
     const scene = document.querySelector("#scene");
     const status = document.querySelector("#status");
+    const transfer = window.__noonCanvasTransferSize ?? null;
     return {
       documentWidth: document.documentElement.scrollWidth,
       viewportWidth: window.innerWidth,
@@ -64,6 +65,11 @@ async function layout(page) {
       clientHeight: scene.clientHeight,
       backingWidth: scene.width,
       backingHeight: scene.height,
+      transferWidth: transfer?.width ?? null,
+      transferHeight: transfer?.height ?? null,
+      transferClientWidth: transfer?.clientWidth ?? null,
+      transferClientHeight: transfer?.clientHeight ?? null,
+      transferDevicePixelRatio: transfer?.devicePixelRatio ?? null,
       devicePixelRatio: window.devicePixelRatio,
       rendererBackend: status.dataset.rendererBackend ?? null,
     };
@@ -110,18 +116,35 @@ function assertInitialBackingStore(result, label) {
     deviceScaleFactor,
     `${label}: Chromium must run at the requested fractional DPR`,
   );
-  const expectedWidth = Math.max(1, Math.round(result.clientWidth * result.devicePixelRatio));
-  const expectedHeight = Math.max(1, Math.round(result.clientHeight * result.devicePixelRatio));
   assert.equal(
-    result.backingWidth,
+    result.transferDevicePixelRatio,
+    deviceScaleFactor,
+    `${label}: offscreen transfer must observe the requested fractional DPR`,
+  );
+  assert.ok(
+    result.transferClientWidth > 0 && result.transferClientHeight > 0,
+    `${label}: canvas must be laid out before offscreen transfer`,
+  );
+  const expectedWidth = Math.max(
+    1,
+    Math.round(result.transferClientWidth * result.transferDevicePixelRatio),
+  );
+  const expectedHeight = Math.max(
+    1,
+    Math.round(result.transferClientHeight * result.transferDevicePixelRatio),
+  );
+  assert.equal(
+    result.transferWidth,
     expectedWidth,
-    `${label}: backing width must match CSS content width × DPR before WebGL surface creation`,
+    `${label}: backing width must match CSS content width × DPR at transfer`,
   );
   assert.equal(
-    result.backingHeight,
+    result.transferHeight,
     expectedHeight,
-    `${label}: backing height must match CSS content height × DPR before WebGL surface creation`,
+    `${label}: backing height must match CSS content height × DPR at transfer`,
   );
+  assert.equal(result.backingWidth, expectedWidth, `${label}: transferred backing width drifted`);
+  assert.equal(result.backingHeight, expectedHeight, `${label}: transferred backing height drifted`);
 }
 
 let browser = null;
@@ -151,6 +174,24 @@ try {
     if (message.type() === "error") {
       browserErrors.push(`console: ${message.text()}`);
     }
+  });
+  await page.addInitScript(() => {
+    const original = HTMLCanvasElement.prototype.transferControlToOffscreen;
+    if (typeof original !== "function") {
+      return;
+    }
+    HTMLCanvasElement.prototype.transferControlToOffscreen = function transferControlToOffscreen() {
+      if (this.id === "scene") {
+        window.__noonCanvasTransferSize = {
+          width: this.width,
+          height: this.height,
+          clientWidth: this.clientWidth,
+          clientHeight: this.clientHeight,
+          devicePixelRatio: window.devicePixelRatio,
+        };
+      }
+      return original.call(this);
+    };
   });
 
   await page.goto(`${baseUrl}/web/index.html`, { waitUntil: "load" });

--- a/scripts/playground-layout-smoke.mjs
+++ b/scripts/playground-layout-smoke.mjs
@@ -63,13 +63,12 @@ async function layout(page) {
       viewportWidth: window.innerWidth,
       clientWidth: scene.clientWidth,
       clientHeight: scene.clientHeight,
-      backingWidth: scene.width,
-      backingHeight: scene.height,
       transferWidth: transfer?.width ?? null,
       transferHeight: transfer?.height ?? null,
       transferClientWidth: transfer?.clientWidth ?? null,
       transferClientHeight: transfer?.clientHeight ?? null,
       transferDevicePixelRatio: transfer?.devicePixelRatio ?? null,
+      renderResizes: window.__noonRenderResizes ?? [],
       devicePixelRatio: window.devicePixelRatio,
       rendererBackend: status.dataset.rendererBackend ?? null,
     };
@@ -105,7 +104,7 @@ function assertNoOverflow(result, label) {
   );
 }
 
-function assertInitialBackingStore(result, label) {
+function assertRendererSizing(result, label) {
   assert.equal(
     result.rendererBackend,
     expectedRendererBackend,
@@ -125,26 +124,40 @@ function assertInitialBackingStore(result, label) {
     result.transferClientWidth > 0 && result.transferClientHeight > 0,
     `${label}: canvas must be laid out before offscreen transfer`,
   );
-  const expectedWidth = Math.max(
+
+  const transferWidth = Math.max(
     1,
     Math.round(result.transferClientWidth * result.transferDevicePixelRatio),
   );
-  const expectedHeight = Math.max(
+  const transferHeight = Math.max(
     1,
     Math.round(result.transferClientHeight * result.transferDevicePixelRatio),
   );
   assert.equal(
     result.transferWidth,
-    expectedWidth,
+    transferWidth,
     `${label}: backing width must match CSS content width × DPR at transfer`,
   );
   assert.equal(
     result.transferHeight,
-    expectedHeight,
+    transferHeight,
     `${label}: backing height must match CSS content height × DPR at transfer`,
   );
-  assert.equal(result.backingWidth, expectedWidth, `${label}: transferred backing width drifted`);
-  assert.equal(result.backingHeight, expectedHeight, `${label}: transferred backing height drifted`);
+
+  const lastResize = result.renderResizes.at(-1);
+  assert.ok(lastResize, `${label}: live playground must send a render-worker resize`);
+  const expectedWidth = Math.max(1, Math.round(result.clientWidth * result.devicePixelRatio));
+  const expectedHeight = Math.max(1, Math.round(result.clientHeight * result.devicePixelRatio));
+  assert.equal(
+    lastResize.width,
+    expectedWidth,
+    `${label}: render-worker width drifted; resizes=${JSON.stringify(result.renderResizes)}`,
+  );
+  assert.equal(
+    lastResize.height,
+    expectedHeight,
+    `${label}: render-worker height drifted; resizes=${JSON.stringify(result.renderResizes)}`,
+  );
 }
 
 let browser = null;
@@ -176,8 +189,23 @@ try {
     }
   });
   await page.addInitScript(() => {
-    const original = HTMLCanvasElement.prototype.transferControlToOffscreen;
-    if (typeof original !== "function") {
+    window.__noonRenderResizes = [];
+    const originalWorkerPostMessage = Worker.prototype.postMessage;
+    Worker.prototype.postMessage = function postMessage(message, ...rest) {
+      if (message?.channel === "noon.render" && message?.type === "resize") {
+        const scene = document.querySelector("#scene");
+        window.__noonRenderResizes.push({
+          width: message.width,
+          height: message.height,
+          clientWidth: scene?.clientWidth ?? null,
+          clientHeight: scene?.clientHeight ?? null,
+        });
+      }
+      return originalWorkerPostMessage.call(this, message, ...rest);
+    };
+
+    const originalTransfer = HTMLCanvasElement.prototype.transferControlToOffscreen;
+    if (typeof originalTransfer !== "function") {
       return;
     }
     HTMLCanvasElement.prototype.transferControlToOffscreen = function transferControlToOffscreen() {
@@ -190,7 +218,7 @@ try {
           devicePixelRatio: window.devicePixelRatio,
         };
       }
-      return original.call(this);
+      return originalTransfer.call(this);
     };
   });
 
@@ -203,7 +231,7 @@ try {
   await settleLayout(page);
 
   const desktop = await layout(page);
-  assertInitialBackingStore(desktop, "desktop WebGL");
+  assertRendererSizing(desktop, "desktop WebGL");
   assert.ok(
     desktop.canvas.width <= desktopMaxCanvasWidth + 1,
     `desktop: canvas width ${desktop.canvas.width}px exceeds ${desktopMaxCanvasWidth}px cap`,
@@ -215,7 +243,7 @@ try {
   await page.setViewportSize({ width: 900, height: 800 });
   await settleLayout(page);
   const stacked = await layout(page);
-  assert.equal(stacked.rendererBackend, expectedRendererBackend, "stacked: renderer backend drifted");
+  assertRendererSizing(stacked, "stacked WebGL");
   assert.ok(
     stacked.canvas.width <= desktopMaxCanvasWidth + 1,
     `stacked: canvas width ${stacked.canvas.width}px exceeds ${desktopMaxCanvasWidth}px cap`,
@@ -227,7 +255,7 @@ try {
   await page.setViewportSize({ width: 390, height: 844 });
   await settleLayout(page);
   const mobile = await layout(page);
-  assert.equal(mobile.rendererBackend, expectedRendererBackend, "mobile: renderer backend drifted");
+  assertRendererSizing(mobile, "mobile WebGL");
   assertAspect(mobile.canvas, 4 / 3, "mobile");
   assertCentered(mobile.canvas, mobile.wrap, "mobile");
   assertNoOverflow(mobile, "mobile");

--- a/scripts/playground-layout-smoke.mjs
+++ b/scripts/playground-layout-smoke.mjs
@@ -7,6 +7,8 @@ const { chromium } = playwright;
 const port = Number(process.env.NOON_PLAYGROUND_LAYOUT_PORT ?? "4174");
 const baseUrl = `http://127.0.0.1:${port}`;
 const desktopMaxCanvasWidth = 44 * 16;
+const deviceScaleFactor = 1.25;
+const expectedRendererBackend = "WebGL2";
 
 let serverOutput = "";
 const server = spawn(
@@ -38,14 +40,35 @@ async function waitForServer() {
   throw new Error(`Playground layout server did not start: ${lastError}\n${serverOutput}`);
 }
 
+async function settleLayout(page) {
+  await page.evaluate(
+    () =>
+      new Promise((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(resolve));
+      }),
+  );
+}
+
 async function layout(page) {
   const canvas = await page.locator("#scene").boundingBox();
   const wrap = await page.locator(".canvas-wrap").boundingBox();
   assert.ok(canvas, "playground canvas must be laid out");
   assert.ok(wrap, "canvas wrapper must be laid out");
-  const documentWidth = await page.evaluate(() => document.documentElement.scrollWidth);
-  const viewportWidth = await page.evaluate(() => window.innerWidth);
-  return { canvas, wrap, documentWidth, viewportWidth };
+  const browserState = await page.evaluate(() => {
+    const scene = document.querySelector("#scene");
+    const status = document.querySelector("#status");
+    return {
+      documentWidth: document.documentElement.scrollWidth,
+      viewportWidth: window.innerWidth,
+      clientWidth: scene.clientWidth,
+      clientHeight: scene.clientHeight,
+      backingWidth: scene.width,
+      backingHeight: scene.height,
+      devicePixelRatio: window.devicePixelRatio,
+      rendererBackend: status.dataset.rendererBackend ?? null,
+    };
+  });
+  return { canvas, wrap, ...browserState };
 }
 
 function assertCentered(canvas, wrap, label) {
@@ -76,18 +99,70 @@ function assertNoOverflow(result, label) {
   );
 }
 
+function assertInitialBackingStore(result, label) {
+  assert.equal(
+    result.rendererBackend,
+    expectedRendererBackend,
+    `${label}: live playground must actually initialize the WebGL2 renderer`,
+  );
+  assert.equal(
+    result.devicePixelRatio,
+    deviceScaleFactor,
+    `${label}: Chromium must run at the requested fractional DPR`,
+  );
+  const expectedWidth = Math.max(1, Math.round(result.clientWidth * result.devicePixelRatio));
+  const expectedHeight = Math.max(1, Math.round(result.clientHeight * result.devicePixelRatio));
+  assert.equal(
+    result.backingWidth,
+    expectedWidth,
+    `${label}: backing width must match CSS content width × DPR before WebGL surface creation`,
+  );
+  assert.equal(
+    result.backingHeight,
+    expectedHeight,
+    `${label}: backing height must match CSS content height × DPR before WebGL surface creation`,
+  );
+}
+
 let browser = null;
 try {
   await waitForServer();
-  browser = await chromium.launch({ channel: "chromium", headless: true });
+  browser = await chromium.launch({
+    channel: "chromium",
+    headless: true,
+    args: [
+      "--disable-features=WebGPU",
+      "--enable-unsafe-swiftshader",
+      "--ignore-gpu-blocklist",
+      "--use-gl=angle",
+      "--use-angle=swiftshader",
+      "--disable-gpu-sandbox",
+      "--disable-dev-shm-usage",
+    ],
+  });
   const context = await browser.newContext({
-    javaScriptEnabled: false,
     viewport: { width: 1440, height: 900 },
+    deviceScaleFactor,
   });
   const page = await context.newPage();
+  const browserErrors = [];
+  page.on("pageerror", (error) => browserErrors.push(`pageerror: ${error}`));
+  page.on("console", (message) => {
+    if (message.type() === "error") {
+      browserErrors.push(`console: ${message.text()}`);
+    }
+  });
+
   await page.goto(`${baseUrl}/web/index.html`, { waitUntil: "load" });
+  await page.waitForFunction(
+    (backend) => document.querySelector("#status")?.dataset.rendererBackend === backend,
+    expectedRendererBackend,
+    { timeout: 30_000 },
+  );
+  await settleLayout(page);
 
   const desktop = await layout(page);
+  assertInitialBackingStore(desktop, "desktop WebGL");
   assert.ok(
     desktop.canvas.width <= desktopMaxCanvasWidth + 1,
     `desktop: canvas width ${desktop.canvas.width}px exceeds ${desktopMaxCanvasWidth}px cap`,
@@ -97,7 +172,9 @@ try {
   assertNoOverflow(desktop, "desktop");
 
   await page.setViewportSize({ width: 900, height: 800 });
+  await settleLayout(page);
   const stacked = await layout(page);
+  assert.equal(stacked.rendererBackend, expectedRendererBackend, "stacked: renderer backend drifted");
   assert.ok(
     stacked.canvas.width <= desktopMaxCanvasWidth + 1,
     `stacked: canvas width ${stacked.canvas.width}px exceeds ${desktopMaxCanvasWidth}px cap`,
@@ -107,13 +184,18 @@ try {
   assertNoOverflow(stacked, "stacked");
 
   await page.setViewportSize({ width: 390, height: 844 });
+  await settleLayout(page);
   const mobile = await layout(page);
+  assert.equal(mobile.rendererBackend, expectedRendererBackend, "mobile: renderer backend drifted");
   assertAspect(mobile.canvas, 4 / 3, "mobile");
   assertCentered(mobile.canvas, mobile.wrap, "mobile");
   assertNoOverflow(mobile, "mobile");
 
+  assert.deepEqual(browserErrors, [], `live playground emitted browser errors:\n${browserErrors.join("\n")}`);
+
   console.log(
-    `✓ playground viewport: desktop ${desktop.canvas.width.toFixed(0)}×${desktop.canvas.height.toFixed(0)}, ` +
+    `✓ live WebGL playground viewport @ ${deviceScaleFactor}x DPR: ` +
+      `desktop ${desktop.canvas.width.toFixed(0)}×${desktop.canvas.height.toFixed(0)}, ` +
       `stacked ${stacked.canvas.width.toFixed(0)}×${stacked.canvas.height.toFixed(0)}, ` +
       `mobile ${mobile.canvas.width.toFixed(0)}×${mobile.canvas.height.toFixed(0)}`,
   );

--- a/web/execution-worker-client.js
+++ b/web/execution-worker-client.js
@@ -79,6 +79,11 @@ export class ExecutionWorkerClient {
     this.#transportMode = transportMode;
     this.#session = checkedNextSession(this.#session);
 
+    // Size the bitmap before handing ownership to the render worker. Creating a
+    // WebGL surface from the browser-default 300×150 bitmap and immediately
+    // reconfiguring it after startup is observably unreliable on some Chromium/
+    // Linux WebGL paths, especially at fractional device scale factors.
+    const initialSurface = initializeCanvasBackingStore(this.#canvas);
     const channel = new MessageChannel();
     const offscreen = this.#canvas.transferControlToOffscreen();
     this.#engineWorker = new Worker(new URL("./execution-engine-worker.js", import.meta.url), {
@@ -104,8 +109,8 @@ export class ExecutionWorkerClient {
         canvas: offscreen,
         port: channel.port2,
         transportMode,
-        width: this.#canvas.width,
-        height: this.#canvas.height,
+        width: initialSurface.width,
+        height: initialSurface.height,
       }),
       [offscreen, channel.port2],
     );
@@ -367,6 +372,22 @@ export class ExecutionWorkerClient {
       throw new Error("ExecutionWorkerClient has not been started");
     }
   }
+}
+
+function initializeCanvasBackingStore(canvas) {
+  const cssWidth = canvas.clientWidth;
+  const cssHeight = canvas.clientHeight;
+  if (cssWidth <= 0 || cssHeight <= 0) {
+    return { width: canvas.width, height: canvas.height };
+  }
+
+  const reportedScale = globalThis.devicePixelRatio;
+  const scale = Number.isFinite(reportedScale) && reportedScale > 0 ? reportedScale : 1;
+  const width = Math.max(1, Math.round(cssWidth * scale));
+  const height = Math.max(1, Math.round(cssHeight * scale));
+  canvas.width = width;
+  canvas.height = height;
+  return { width, height };
 }
 
 function engineEnvelope(type, payload = {}) {

--- a/web/index.html
+++ b/web/index.html
@@ -347,11 +347,16 @@
         padding: clamp(0.8rem, 2vw, 1.4rem);
       }
 
-      canvas {
-        display: block;
+      .canvas-frame {
         width: 100%;
         max-width: 44rem;
         aspect-ratio: 16 / 9;
+      }
+
+      canvas {
+        display: block;
+        width: 100%;
+        height: 100%;
         border: 1px solid #202a3e;
         border-radius: 0.8rem;
         background: #090c13;
@@ -560,7 +565,7 @@
           padding: 0.55rem;
         }
 
-        canvas {
+        .canvas-frame {
           aspect-ratio: 4 / 3;
         }
 
@@ -676,7 +681,9 @@
             </div>
           </div>
           <div class="canvas-wrap">
-            <canvas id="scene" aria-label="Animated Noon scene"></canvas>
+            <div class="canvas-frame">
+              <canvas id="scene" aria-label="Animated Noon scene"></canvas>
+            </div>
           </div>
           <div class="metrics" aria-label="Runtime metrics">
             <div class="metric">

--- a/web/index.html
+++ b/web/index.html
@@ -348,12 +348,15 @@
       }
 
       .canvas-frame {
+        position: relative;
         width: 100%;
         max-width: 44rem;
         aspect-ratio: 16 / 9;
       }
 
       canvas {
+        position: absolute;
+        inset: 0;
         display: block;
         width: 100%;
         height: 100%;

--- a/web/index.html
+++ b/web/index.html
@@ -351,7 +351,14 @@
         position: relative;
         width: 100%;
         max-width: 44rem;
-        aspect-ratio: 16 / 9;
+        align-self: center;
+        justify-self: center;
+      }
+
+      .canvas-frame::before {
+        display: block;
+        padding-top: 56.25%;
+        content: "";
       }
 
       canvas {
@@ -568,8 +575,8 @@
           padding: 0.55rem;
         }
 
-        .canvas-frame {
-          aspect-ratio: 4 / 3;
+        .canvas-frame::before {
+          padding-top: 75%;
         }
 
         .metrics,


### PR DESCRIPTION
> Superseded by #229, which incorporates the CSS-owned canvas frame and live Linux WebGL regression together with the ValueTracker execution fix. #229 was merged after the full CI and Manim raster suites passed.

## Summary
- initialize the execution canvas backing store from its laid-out CSS content size and device-pixel ratio before transferring it to `OffscreenCanvas`
- put the playground canvas inside a CSS-owned aspect-ratio frame so OffscreenCanvas backing-size changes cannot feed back into DOM layout
- upgrade the playground layout regression from static HTML (`javaScriptEnabled: false`) to the actual live demo on Linux Chromium with WebGPU disabled, WebGL2/SwiftShader forced, and DPR 1.25
- retain the existing desktop/stacked/mobile presentation bounds, aspect-ratio, centering, and overflow checks

## Root cause
PR #118 fixed the static CSS boundary but its regression never executed `main.js`, `ExecutionWorkerClient`, `OffscreenCanvas`, or WebGL.

The new live Linux/WebGL regression reproduced the remaining failure. The canvas was correctly sized at transfer, but after the render worker changed the OffscreenCanvas backing size the HTML canvas's intrinsic dimensions participated in its auto block-size calculation. `ResizeObserver` then read the enlarged `clientHeight` and sent it back as a new backing size. In CI the backing height grew from 535 px at transfer to 1314 px on the same desktop load.

The fix separates the two responsibilities: `.canvas-frame` owns the responsive 16:9 (4:3 mobile) CSS geometry, while the canvas fills that frame and the render worker owns only its physical backing store.

## Validation
The CI layout smoke now:
- requires the actual demo to initialize `WebGL2` on Ubuntu Chromium;
- forces a fractional DPR of 1.25;
- intercepts `transferControlToOffscreen()` and verifies the backing store is CSS content size × DPR at the exact transfer point;
- verifies the backing store does not drift after renderer initialization;
- exercises desktop, stacked, and mobile layouts and checks aspect ratio, centering, and horizontal overflow.

Closes #117.