### PR TITLE
Add self-hosted physical-device perf dispatch and DPR runs

### DIFF
--- a/.github/workflows/perf-physical-device.yml
+++ b/.github/workflows/perf-physical-device.yml
@@ -1,0 +1,91 @@
+name: Physical device performance baseline
+
+on:
+  workflow_dispatch:
+    inputs:
+      device_id:
+        description: Stable physical device ID (for example macbook-m4-pro)
+        required: true
+        type: string
+      backends:
+        description: Comma-separated renderer backends
+        required: true
+        default: webgpu,webgl
+        type: string
+      suites:
+        description: Comma-separated suites (frame,corpus,authoring)
+        required: true
+        default: frame,corpus,authoring
+        type: string
+      width:
+        description: Canvas backing width
+        required: true
+        default: '1920'
+        type: string
+      height:
+        description: Canvas backing height
+        required: true
+        default: '1080'
+        type: string
+      dpr:
+        description: Browser device pixel ratio
+        required: true
+        default: '1'
+        type: string
+      target_hz:
+        description: Target refresh rate used for frame-budget reporting
+        required: true
+        default: '60'
+        type: string
+      notes:
+        description: Power/thermal/browser/device notes
+        required: false
+        default: ''
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  baseline:
+    # This workflow is intentionally physical-runner-only. Do not replace this
+    # with github-hosted runners or SwiftShader and call the result a P8 baseline.
+    runs-on: self-hosted
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: taiki-e/install-action@13608cbb45b01feb47ef444ab1a42dc41ad56f1a
+        with:
+          tool: wasm-pack@0.15.0
+          fallback: none
+      - name: Install pinned browser tooling
+        run: |
+          npm install --no-save --ignore-scripts playwright@1.62.1 pngjs@7.0.0
+          npx playwright install chromium
+      - name: Build optimized production WASM
+        run: bash scripts/build-web-demo.sh
+      - name: Record named physical-device bundle
+        env:
+          NOON_PERF_DEVICE_ID: ${{ inputs.device_id }}
+          NOON_PERF_BACKENDS: ${{ inputs.backends }}
+          NOON_PERF_SUITES: ${{ inputs.suites }}
+          NOON_PERF_WIDTH: ${{ inputs.width }}
+          NOON_PERF_HEIGHT: ${{ inputs.height }}
+          NOON_PERF_DPR: ${{ inputs.dpr }}
+          NOON_PERF_TARGET_HZ: ${{ inputs.target_hz }}
+          NOON_PERF_DEVICE_NOTES: ${{ inputs.notes }}
+          NOON_PERF_RUN_DIR: perf-artifacts/physical-dispatch
+        run: node scripts/perf-device-run.mjs
+      - name: Upload performance bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: noon-perf-${{ inputs.device_id }}-${{ github.run_id }}
+          path: perf-artifacts/physical-dispatch
+          if-no-files-found: error
+          retention-days: 30

--- a/docs/performance-devices.md
+++ b/docs/performance-devices.md
@@ -4,9 +4,9 @@ Shared CI protects correctness, not wall-clock budgets. Browser performance base
 
 The known profiles live in `benchmarks/performance-devices.json`. A new machine does not need to be committed before experimentation, but a result used as a long-lived baseline should get a stable profile ID.
 
-## Record a baseline
+## Record a baseline locally
 
-Build the release web package and install the pinned Playwright dependencies used by the browser smoke tests, then run:
+Build the optimized release web package and install the pinned Playwright dependencies used by the browser smoke tests, then run:
 
 ```bash
 NOON_PERF_DEVICE_ID=my-machine node scripts/perf-device-run.mjs
@@ -19,9 +19,12 @@ NOON_PERF_DEVICE_ID=my-machine \
 NOON_PERF_BACKENDS=webgpu \
 NOON_PERF_WIDTH=1920 \
 NOON_PERF_HEIGHT=1080 \
+NOON_PERF_DPR=2 \
 NOON_PERF_COUNTS=1000,10000,100000 \
 node scripts/perf-device-run.mjs
 ```
+
+`NOON_PERF_DPR` drives Playwright's `deviceScaleFactor` for the canonical frame suite and is recorded both in its report and in the named-device manifest. Use DPR 1 for the normal resolution matrix and a separate DPR 2 run for the high-density display case.
 
 Use `NOON_PERF_SUITES` to choose `frame`, `corpus`, and/or `authoring`. A complete release characterization can run all three:
 
@@ -33,7 +36,13 @@ node scripts/perf-device-run.mjs
 
 The bundle manifest and per-suite JSON files are written under `perf-artifacts/<device>/<timestamp>/` by default.
 
-Do not relabel SwiftShader, software rasterization, or a generic hosted runner as a physical-device baseline. If the browser cannot expose the selected GPU identity, record the result at host/backend level rather than guessing the adapter.
+## Run on a physical self-hosted GitHub runner
+
+`.github/workflows/perf-physical-device.yml` is a manual `workflow_dispatch` workflow that targets **only** `self-hosted` runners. It installs the pinned browser tooling, builds optimized production WASM with `scripts/build-web-demo.sh`, runs the named-device bundle, and uploads the result as a workflow artifact.
+
+When registering a real machine as a self-hosted runner, dispatch **Physical device performance baseline** and provide a stable device ID, backend/suite set, backing resolution, DPR, target refresh rate, and power/thermal notes. Use separate dispatches for the 960x540 DPR1, 1920x1080 DPR1, and representative DPR2 cases so same-host trends remain comparable.
+
+Do not change that workflow to a GitHub-hosted runner for baseline collection. A hosted macOS runner can report an Apple CPU while still being `VirtualMac`/`VMAPPLE`, and software adapters such as SwiftShader are useful only for correctness/diagnostics, not real-GPU throughput evidence.
 
 ## Compare two runs
 

--- a/scripts/perf-device-run.mjs
+++ b/scripts/perf-device-run.mjs
@@ -67,6 +67,7 @@ const bundle = {
     suites,
     width: process.env.NOON_PERF_WIDTH ?? "960",
     height: process.env.NOON_PERF_HEIGHT ?? "540",
+    devicePixelRatio: process.env.NOON_PERF_DPR ?? "1",
     targetHz: process.env.NOON_PERF_TARGET_HZ ?? "60",
   },
   artifacts,

--- a/scripts/perf-profile.mjs
+++ b/scripts/perf-profile.mjs
@@ -25,6 +25,7 @@ const frames = positiveInteger(process.env.NOON_PERF_FRAMES ?? "300", "NOON_PERF
 const targetHz = positiveNumber(process.env.NOON_PERF_TARGET_HZ ?? "60", "NOON_PERF_TARGET_HZ");
 const width = positiveInteger(process.env.NOON_PERF_WIDTH ?? "960", "NOON_PERF_WIDTH");
 const height = positiveInteger(process.env.NOON_PERF_HEIGHT ?? "540", "NOON_PERF_HEIGHT");
+const dpr = positiveNumber(process.env.NOON_PERF_DPR ?? "1", "NOON_PERF_DPR");
 const artifactPath = path.resolve(
   repoRoot,
   process.env.NOON_PERF_ARTIFACT ?? `perf-artifacts/perf-profile-${backend}.json`,
@@ -61,7 +62,11 @@ try {
   const results = [];
   for (const layout of layouts) {
     for (const objects of counts) {
-      const page = await browser.newPage({ viewport: { width: 1200, height: 900 } });
+      const context = await browser.newContext({
+        viewport: { width: 1200, height: 900 },
+        deviceScaleFactor: dpr,
+      });
+      const page = await context.newPage();
       const errors = [];
       page.on("pageerror", (error) => errors.push(`pageerror: ${error}`));
       page.on("console", (message) => {
@@ -94,6 +99,7 @@ try {
       const report = await page.evaluate(() => window.__NOON_PERF_REPORT__);
       assert.equal(report.workload.objects, objects);
       assert.equal(report.workload.layout, layout);
+      assert.equal(report.environment.devicePixelRatio, dpr);
       results.push(report);
       console.log(
         `${format(report.cadence.effective?.effectiveFps)} FPS, ` +
@@ -101,7 +107,7 @@ try {
           `CPU ${format(report.cpu.frameMs?.p95)} ms, ` +
           `GPU ${format(report.gpu.renderPassMs?.p95)} ms`,
       );
-      await page.close();
+      await context.close();
     }
   }
 
@@ -119,7 +125,7 @@ try {
       totalMemoryBytes: os.totalmem(),
       node: process.version,
     },
-    configuration: { backend, counts, layouts, warmup, frames, targetHz, width, height },
+    configuration: { backend, counts, layouts, warmup, frames, targetHz, width, height, dpr },
     cases: results,
   };
   await mkdir(path.dirname(artifactPath), { recursive: true });


### PR DESCRIPTION
## Summary
Pushes #133 as far as the connected environment can legitimately take it without inventing real-hardware results.

- add a manual `workflow_dispatch` baseline job that runs **only** on `self-hosted` physical runners;
- build optimized production WASM before measurement;
- run/upload the full named-device bundle with device/backend/suite/resolution/refresh/notes inputs;
- add `NOON_PERF_DPR` support to the canonical browser profiler using Playwright `deviceScaleFactor` and assert/report the observed DPR;
- record DPR in the named-device manifest and document the 960x540 DPR1 / 1920x1080 DPR1 / DPR2 matrix.

## Hardware boundary
The available GitHub-hosted Apple-Silicon probe reports `Apple Virtual Machine 1`, `VirtualMac2,1`, `Apple M1 (Virtual)` / `VMAPPLE`, so it is intentionally excluded from P8 throughput evidence. No self-hosted runner is currently configured. The existing physical i7-9750H Mac baseline remains the only repo-backed real machine.

This PR makes future physical collection a one-click dispatch while preserving the rule that hosted VMs and SwiftShader are diagnostics, not real-GPU baselines.

Tracks #133.