### PR TITLE
Expand shared Mobject query and transform semantics

### DIFF
--- a/crates/noon-web/src/authoring_mobject.rs
+++ b/crates/noon-web/src/authoring_mobject.rs
@@ -1,19 +1,35 @@
 use noon_core::{
     semantic_path_bounds, Bounds2D64, Color, GeometryRef, ObjectSnapshot, SemanticPaint,
-    SemanticStyle, SemanticVec3, Style, Vec2,
+    SemanticStyle, SemanticTransform2_5D, SemanticVec3, Style, Vec2,
 };
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct FrontendMobjectHandle {
     snapshot: ObjectSnapshot,
+    semantic_transform: SemanticTransform2_5D,
     semantic_style: SemanticStyle,
 }
 
 impl FrontendMobjectHandle {
     pub fn from_snapshot(snapshot: ObjectSnapshot) -> Self {
+        let transform = snapshot.transform;
+        let semantic_transform = SemanticTransform2_5D {
+            translation: SemanticVec3::new(
+                f64::from(transform.translation.x),
+                f64::from(transform.translation.y),
+                0.0,
+            ),
+            scale: SemanticVec3::new(
+                f64::from(transform.scale.x),
+                f64::from(transform.scale.y),
+                1.0,
+            ),
+            rotation_z: f64::from(transform.rotation),
+        };
         let semantic_style = authoring_style_from_legacy(snapshot.style);
         Self {
             snapshot,
+            semantic_transform,
             semantic_style,
         }
     }
@@ -39,7 +55,7 @@ impl FrontendMobjectHandle {
     }
 
     pub fn layout_bounds(&self) -> Option<Bounds2D64> {
-        snapshot_layout_bounds(&self.snapshot)
+        snapshot_layout_bounds(&self.snapshot, self.semantic_transform)
     }
 
     pub fn center(&self) -> (f64, f64) {
@@ -51,8 +67,8 @@ impl FrontendMobjectHandle {
                 )
             })
             .unwrap_or_else(|| {
-                let translation = self.snapshot.transform.translation;
-                (translation.x as f64, translation.y as f64)
+                let translation = self.semantic_transform.translation;
+                (translation.x, translation.y)
             })
     }
 
@@ -88,9 +104,17 @@ impl FrontendMobjectHandle {
     }
 
     pub fn shift(&mut self, x: f64, y: f64) -> Result<(), String> {
-        let offset = semantic_xy(x, y)?;
-        self.snapshot.transform.translation += offset;
-        Ok(())
+        let offset = semantic_xy_f64(x, y)?;
+        let translation = SemanticVec3::new(
+            self.semantic_transform.translation.x + offset.x,
+            self.semantic_transform.translation.y + offset.y,
+            self.semantic_transform.translation.z,
+        );
+        translation
+            .lower_xy_f32()
+            .map_err(|error| error.to_string())?;
+        self.semantic_transform.translation = translation;
+        self.sync_legacy_transform()
     }
 
     pub fn move_to(&mut self, x: f64, y: f64) -> Result<(), String> {
@@ -100,25 +124,24 @@ impl FrontendMobjectHandle {
     }
 
     pub fn scale(&mut self, x: f64, y: f64) -> Result<(), String> {
-        let x = finite_f32("scale.x", x)?;
-        let y = finite_f32("scale.y", y)?;
-        self.snapshot.transform.scale =
-            self.snapshot.transform.scale.component_mul(Vec2::new(x, y));
-        if !self.snapshot.transform.scale.x.is_finite()
-            || !self.snapshot.transform.scale.y.is_finite()
-        {
-            return Err("scale result must be finite".to_owned());
-        }
-        Ok(())
+        let x = render_f64("scale.x", x)?;
+        let y = render_f64("scale.y", y)?;
+        let scale = SemanticVec3::new(
+            self.semantic_transform.scale.x * x,
+            self.semantic_transform.scale.y * y,
+            self.semantic_transform.scale.z,
+        );
+        scale.lower_xy_f32().map_err(|error| error.to_string())?;
+        self.semantic_transform.scale = scale;
+        self.sync_legacy_transform()
     }
 
     pub fn rotate(&mut self, angle: f64) -> Result<(), String> {
-        let angle = finite_f32("rotation", angle)?;
-        self.snapshot.transform.rotation += angle;
-        if !self.snapshot.transform.rotation.is_finite() {
-            return Err("rotation result must be finite".to_owned());
-        }
-        Ok(())
+        let angle = render_f64("rotation", angle)?;
+        let rotation = self.semantic_transform.rotation_z + angle;
+        finite_f32("rotation result", rotation)?;
+        self.semantic_transform.rotation_z = rotation;
+        self.sync_legacy_transform()
     }
 
     pub fn set_color(&mut self, red: f64, green: f64, blue: f64, alpha: f64) -> Result<(), String> {
@@ -248,6 +271,22 @@ impl FrontendMobjectHandle {
         Ok(())
     }
 
+    fn sync_legacy_transform(&mut self) -> Result<(), String> {
+        self.snapshot.transform.translation = self
+            .semantic_transform
+            .translation
+            .lower_xy_f32()
+            .map_err(|error| error.to_string())?;
+        self.snapshot.transform.scale = self
+            .semantic_transform
+            .scale
+            .lower_xy_f32()
+            .map_err(|error| error.to_string())?;
+        self.snapshot.transform.rotation =
+            finite_f32("rotation", self.semantic_transform.rotation_z)?;
+        Ok(())
+    }
+
     fn sync_legacy_style(&mut self) {
         self.snapshot.style.fill = legacy_solid_color(
             self.semantic_style.fill.as_ref(),
@@ -263,6 +302,7 @@ impl FrontendMobjectHandle {
 
     pub fn become_handle(&mut self, other: &Self) {
         self.snapshot = other.snapshot.clone();
+        self.semantic_transform = other.semantic_transform;
         self.semantic_style = other.semantic_style.clone();
     }
 
@@ -459,9 +499,15 @@ fn legacy_solid_color(paint: Option<&SemanticPaint>, opacity: f64) -> Option<Col
 }
 
 fn semantic_xy(x: f64, y: f64) -> Result<Vec2, String> {
-    SemanticVec3::new(x, y, 0.0)
+    semantic_xy_f64(x, y)?
         .lower_xy_f32()
         .map_err(|error| error.to_string())
+}
+
+fn semantic_xy_f64(x: f64, y: f64) -> Result<SemanticVec3, String> {
+    let value = SemanticVec3::new(x, y, 0.0);
+    value.lower_xy_f32().map_err(|error| error.to_string())?;
+    Ok(value)
 }
 
 fn normalized_direction(x: f64, y: f64) -> Result<(f64, f64), String> {
@@ -475,7 +521,10 @@ fn normalized_direction(x: f64, y: f64) -> Result<(f64, f64), String> {
     Ok((x / length, y / length))
 }
 
-fn snapshot_layout_bounds(snapshot: &ObjectSnapshot) -> Option<Bounds2D64> {
+fn snapshot_layout_bounds(
+    snapshot: &ObjectSnapshot,
+    transform: SemanticTransform2_5D,
+) -> Option<Bounds2D64> {
     let local = match &snapshot.geometry {
         GeometryRef::Circle { radius } => Bounds2D64 {
             min_x: -f64::from(*radius),
@@ -499,13 +548,12 @@ fn snapshot_layout_bounds(snapshot: &ObjectSnapshot) -> Option<Bounds2D64> {
         GeometryRef::External(_) => return None,
     };
 
-    let transform = snapshot.transform;
-    let sine = f64::from(transform.rotation).sin();
-    let cosine = f64::from(transform.rotation).cos();
-    let scale_x = f64::from(transform.scale.x);
-    let scale_y = f64::from(transform.scale.y);
-    let translation_x = f64::from(transform.translation.x);
-    let translation_y = f64::from(transform.translation.y);
+    let sine = transform.rotation_z.sin();
+    let cosine = transform.rotation_z.cos();
+    let scale_x = transform.scale.x;
+    let scale_y = transform.scale.y;
+    let translation_x = transform.translation.x;
+    let translation_y = transform.translation.y;
     let corners = [
         (local.min_x, local.min_y),
         (local.min_x, local.max_y),
@@ -800,6 +848,24 @@ mod tests {
             handle.snapshot().transform.translation,
             Vec2::new(2.0, -1.0)
         );
+    }
+
+    #[test]
+    fn authoring_transform_keeps_f64_precision_until_render_lowering() {
+        let mut handle =
+            FrontendMobjectHandle::from_snapshot(snapshot(GeometryRef::rectangle(2.0, 1.0)));
+        handle.shift(0.7, 0.3).unwrap();
+        assert_eq!(handle.semantic_transform.translation.x, 0.7);
+        assert_eq!(handle.semantic_transform.translation.y, 0.3);
+        assert!((handle.critical_point(-1.0, 0.0).0 + 0.3).abs() < 1e-12);
+        assert!((handle.critical_point(0.0, 1.0).1 - 0.8).abs() < 1e-12);
+        assert_ne!(f64::from(handle.snapshot().transform.translation.x), 0.7);
+
+        handle.scale(1.1, 0.9).unwrap();
+        handle.rotate(0.2).unwrap();
+        assert_eq!(handle.semantic_transform.scale.x, 1.1);
+        assert_eq!(handle.semantic_transform.scale.y, 0.9);
+        assert_eq!(handle.semantic_transform.rotation_z, 0.2);
     }
 
     #[test]

--- a/scripts/manim-compat-smoke.mjs
+++ b/scripts/manim-compat-smoke.mjs
@@ -189,6 +189,38 @@ class AnimateParity(Scene):
             assert "only be passed once" in str(error)
 `;
 
+
+const queryTransformSource = `
+from noon import *
+
+class SharedQueryTransforms(Scene):
+    def construct(self):
+        box = Rectangle(width=2.0, height=1.0).shift(RIGHT * 0.7 + UP * 0.3)
+        assert abs(box.get_left().x + 0.3) < 1e-9
+        assert abs(box.get_right().x - 1.7) < 1e-9
+        assert abs(box.get_top().y - 0.8) < 1e-9
+        assert abs(box.get_x(LEFT) + 0.3) < 1e-9
+
+        box.set_coord(-1.5, 0, LEFT).set_coord(1.25, 1, UP)
+        assert abs(box.get_left().x + 1.5) < 1e-9
+        assert abs(box.get_top().y - 1.25) < 1e-9
+        box.width = 3.0
+        box.stretch_to_fit_height(2.0)
+        assert abs(box.width - 3.0) < 1e-9
+        assert abs(box.height - 2.0) < 1e-9
+
+        target = Circle(radius=0.4).shift(RIGHT * 1.2 + DOWN * 0.4)
+        box.match_x(target).match_y(target)
+        assert abs(box.get_x() - target.get_x()) < 1e-9
+        assert abs(box.get_y() - target.get_y()) < 1e-9
+
+        orbit = Square(side_length=0.5).shift(RIGHT * 1.5 + UP * 0.5)
+        orbit.rotate_about_origin(PI / 2)
+        assert abs(orbit.get_x() + 0.5) < 1e-9
+        assert abs(orbit.get_y() - 1.5) < 1e-9
+        self.add(box, target, orbit)
+`;
+
 const rateFunctionSource = `
 from noon import *
 
@@ -315,6 +347,14 @@ try {
     "Scene.play kwargs should override builder animation kwargs",
   );
 
+
+  const queryTransforms = await page.evaluate(
+    (pythonSource) => window.noonManimCompat.run(pythonSource),
+    queryTransformSource,
+  );
+  assert.equal(queryTransforms.kind, "scene_document");
+  assert.equal(queryTransforms.document.objects.length, 3);
+
   const sharedRates = await page.evaluate(
     (pythonSource) => window.noonManimCompat.run(pythonSource),
     rateFunctionSource,
@@ -341,7 +381,7 @@ try {
 
   assert.deepEqual(errors, [], `browser errors while testing Manim compatibility:\n${errors.join("\n")}`);
   console.log(
-    "Manim compatibility smoke passed: construct discovery, shape classes, scene/group semantics, callable and chained animate builders, detached animate auto-add, per-animation timing, play overrides, independent fill/stroke opacity, z=0 vectors, and shared deterministic Manim rate-function lowering.",
+    "Manim compatibility smoke passed: construct discovery, shape classes, scene/group semantics, callable and chained animate builders, detached animate auto-add, per-animation timing, play overrides, independent fill/stroke opacity, shared detached query/dimension transforms, z=0 vectors, and shared deterministic Manim rate-function lowering.",
   );
 } finally {
   await browser?.close();

--- a/scripts/manim-differential.py
+++ b/scripts/manim-differential.py
@@ -72,6 +72,10 @@ def _object_observation(obj: Any) -> dict[str, Any]:
     }
 
 
+def _point_observation(point: Any) -> list[float]:
+    return [_round_float(point[0]), _round_float(point[1])]
+
+
 def _members_observation(group: Any) -> dict[str, Any]:
     members = list(group.submobjects)
     center = group.get_center()
@@ -395,6 +399,119 @@ def _manim_replace_stretch() -> Any:
     return _object_observation(source)
 
 
+
+def _noon_critical_points() -> Any:
+    obj = noon.Rectangle(width=2.0, height=1.0).shift(noon.RIGHT * 0.7 + noon.UP * 0.3)
+    return {
+        "left": _point_observation(obj.get_left()),
+        "right": _point_observation(obj.get_right()),
+        "top": _point_observation(obj.get_top()),
+        "bottom": _point_observation(obj.get_bottom()),
+        "corner": _point_observation(obj.get_corner(noon.UR)),
+        "x_left": _round_float(obj.get_x(noon.LEFT)),
+        "y_top": _round_float(obj.get_y(noon.UP)),
+    }
+
+
+def _manim_critical_points() -> Any:
+    obj = manim.Rectangle(width=2.0, height=1.0).shift(manim.RIGHT * 0.7 + manim.UP * 0.3)
+    return {
+        "left": _point_observation(obj.get_left()),
+        "right": _point_observation(obj.get_right()),
+        "top": _point_observation(obj.get_top()),
+        "bottom": _point_observation(obj.get_bottom()),
+        "corner": _point_observation(obj.get_corner(manim.UR)),
+        "x_left": _round_float(obj.get_x(manim.LEFT)),
+        "y_top": _round_float(obj.get_y(manim.UP)),
+    }
+
+
+def _noon_set_coord_direction() -> Any:
+    obj = noon.Square(side_length=1.0).shift(noon.RIGHT * 0.25)
+    obj.set_coord(-1.5, 0, noon.LEFT).set_coord(1.25, 1, noon.UP)
+    return {"object": _object_observation(obj), "left": _point_observation(obj.get_left()), "top": _point_observation(obj.get_top())}
+
+
+def _manim_set_coord_direction() -> Any:
+    obj = manim.Square(side_length=1.0).shift(manim.RIGHT * 0.25)
+    obj.set_coord(-1.5, 0, manim.LEFT).set_coord(1.25, 1, manim.UP)
+    return {"object": _object_observation(obj), "left": _point_observation(obj.get_left()), "top": _point_observation(obj.get_top())}
+
+
+def _noon_scale_to_fit_width() -> Any:
+    return _object_observation(noon.Rectangle(width=2.0, height=1.0).scale_to_fit_width(3.0))
+
+
+def _manim_scale_to_fit_width() -> Any:
+    return _object_observation(manim.Rectangle(width=2.0, height=1.0).scale_to_fit_width(3.0))
+
+
+def _noon_stretch_to_fit_height() -> Any:
+    return _object_observation(noon.Rectangle(width=2.0, height=1.0).stretch_to_fit_height(2.5))
+
+
+def _manim_stretch_to_fit_height() -> Any:
+    return _object_observation(manim.Rectangle(width=2.0, height=1.0).stretch_to_fit_height(2.5))
+
+
+def _noon_match_xy() -> Any:
+    target = noon.Rectangle(width=1.5, height=0.8).shift(noon.RIGHT * 1.2 + noon.DOWN * 0.6)
+    obj = noon.Circle(radius=0.3).match_x(target, noon.RIGHT).match_y(target, noon.DOWN)
+    return {"target": _object_observation(target), "object": _object_observation(obj), "right": _point_observation(obj.get_right()), "bottom": _point_observation(obj.get_bottom())}
+
+
+def _manim_match_xy() -> Any:
+    target = manim.Rectangle(width=1.5, height=0.8).shift(manim.RIGHT * 1.2 + manim.DOWN * 0.6)
+    obj = manim.Circle(radius=0.3).match_x(target, manim.RIGHT).match_y(target, manim.DOWN)
+    return {"target": _object_observation(target), "object": _object_observation(obj), "right": _point_observation(obj.get_right()), "bottom": _point_observation(obj.get_bottom())}
+
+
+def _noon_match_width() -> Any:
+    target = noon.Rectangle(width=2.4, height=0.6)
+    return _object_observation(noon.Circle(radius=0.4).match_width(target))
+
+
+def _manim_match_width() -> Any:
+    target = manim.Rectangle(width=2.4, height=0.6)
+    return _object_observation(manim.Circle(radius=0.4).match_width(target))
+
+
+def _noon_match_height_stretch() -> Any:
+    target = noon.Rectangle(width=0.5, height=1.8)
+    return _object_observation(noon.Rectangle(width=1.4, height=0.7).match_height(target, stretch=True))
+
+
+def _manim_match_height_stretch() -> Any:
+    target = manim.Rectangle(width=0.5, height=1.8)
+    return _object_observation(manim.Rectangle(width=1.4, height=0.7).match_height(target, stretch=True))
+
+
+def _noon_dimension_properties() -> Any:
+    obj = noon.Rectangle(width=2.0, height=1.0)
+    obj.width = 3.0
+    obj.height = 1.5
+    return _object_observation(obj)
+
+
+def _manim_dimension_properties() -> Any:
+    obj = manim.Rectangle(width=2.0, height=1.0)
+    obj.width = 3.0
+    obj.height = 1.5
+    return _object_observation(obj)
+
+
+def _noon_rotate_about_origin() -> Any:
+    obj = noon.Rectangle(width=1.2, height=0.6).shift(noon.RIGHT * 1.5 + noon.UP * 0.5)
+    obj.rotate_about_origin(math.pi / 2.0)
+    return _object_observation(obj)
+
+
+def _manim_rotate_about_origin() -> Any:
+    obj = manim.Rectangle(width=1.2, height=0.6).shift(manim.RIGHT * 1.5 + manim.UP * 0.5)
+    obj.rotate_about_origin(math.pi / 2.0)
+    return _object_observation(obj)
+
+
 FIXTURES = [
     Fixture("circle_dimensions", _noon_circle_dimensions, _manim_circle_dimensions),
     Fixture("rectangle_dimensions", _noon_rectangle_dimensions, _manim_rectangle_dimensions),
@@ -429,6 +546,15 @@ FIXTURES = [
     Fixture("become", _noon_become, _manim_become),
     Fixture("replace_width", _noon_replace_width, _manim_replace_width),
     Fixture("replace_stretch", _noon_replace_stretch, _manim_replace_stretch),
+    Fixture("critical_points", _noon_critical_points, _manim_critical_points),
+    Fixture("set_coord_direction", _noon_set_coord_direction, _manim_set_coord_direction),
+    Fixture("scale_to_fit_width", _noon_scale_to_fit_width, _manim_scale_to_fit_width),
+    Fixture("stretch_to_fit_height", _noon_stretch_to_fit_height, _manim_stretch_to_fit_height),
+    Fixture("match_xy", _noon_match_xy, _manim_match_xy),
+    Fixture("match_width", _noon_match_width, _manim_match_width),
+    Fixture("match_height_stretch", _noon_match_height_stretch, _manim_match_height_stretch),
+    Fixture("dimension_properties", _noon_dimension_properties, _manim_dimension_properties),
+    Fixture("rotate_about_origin", _noon_rotate_about_origin, _manim_rotate_about_origin),
 ]
 
 # Explicitly tracked but not yet differential-gated.  Keep this list close to the

--- a/web/python/_manim_compat.py
+++ b/web/python/_manim_compat.py
@@ -695,6 +695,208 @@ class Scene(_BaseScene):
         )
 
 
+
+def _mobject_get_critical_point(
+    self: _BaseMobject, direction: object
+) -> _base.Vec2:
+    return _critical_for(self, _as_vec2(direction))
+
+
+def _mobject_get_edge_center(self: _BaseMobject, direction: object) -> _base.Vec2:
+    return self.get_critical_point(direction)
+
+
+def _mobject_get_corner(self: _BaseMobject, direction: object) -> _base.Vec2:
+    return self.get_critical_point(direction)
+
+
+def _mobject_get_left(self: _BaseMobject) -> _base.Vec2:
+    return self.get_critical_point(_base.LEFT)
+
+
+def _mobject_get_right(self: _BaseMobject) -> _base.Vec2:
+    return self.get_critical_point(_base.RIGHT)
+
+
+def _mobject_get_top(self: _BaseMobject) -> _base.Vec2:
+    return self.get_critical_point(_base.UP)
+
+
+def _mobject_get_bottom(self: _BaseMobject) -> _base.Vec2:
+    return self.get_critical_point(_base.DOWN)
+
+
+def _mobject_get_coord(
+    self: _BaseMobject, dim: int, direction: object = _base.ORIGIN
+) -> float:
+    if dim not in (0, 1):
+        raise NotImplementedError("Noon currently exposes x/y authoring coordinates only")
+    point = self.get_critical_point(direction)
+    return float(point[dim])
+
+
+def _mobject_get_x(self: _BaseMobject, direction: object = _base.ORIGIN) -> float:
+    return self.get_coord(0, direction)
+
+
+def _mobject_get_y(self: _BaseMobject, direction: object = _base.ORIGIN) -> float:
+    return self.get_coord(1, direction)
+
+
+def _mobject_set_coord(
+    self: _BaseMobject,
+    value: float,
+    dim: int,
+    direction: object = _base.ORIGIN,
+) -> _BaseMobject:
+    if dim not in (0, 1):
+        raise NotImplementedError("Noon currently exposes x/y authoring coordinates only")
+    delta = float(value) - self.get_coord(dim, direction)
+    return self.shift(_base.Vec2(delta, 0.0) if dim == 0 else _base.Vec2(0.0, delta))
+
+
+def _mobject_set_x(
+    self: _BaseMobject, x: float, direction: object = _base.ORIGIN
+) -> _BaseMobject:
+    return self.set_coord(x, 0, direction)
+
+
+def _mobject_set_y(
+    self: _BaseMobject, y: float, direction: object = _base.ORIGIN
+) -> _BaseMobject:
+    return self.set_coord(y, 1, direction)
+
+
+def _mobject_rescale_to_fit(
+    self: _BaseMobject,
+    length: float,
+    dim: int,
+    stretch: bool = False,
+    **kwargs: Any,
+) -> _BaseMobject:
+    if kwargs:
+        unsupported = ", ".join(sorted(kwargs))
+        raise NotImplementedError(
+            f"rescale_to_fit anchor option(s) are not yet supported: {unsupported}"
+        )
+    if dim not in (0, 1):
+        raise NotImplementedError("Noon currently exposes width/height fitting only")
+    old_length = self.width if dim == 0 else self.height
+    if old_length == 0.0:
+        return self
+    factor = float(length) / old_length
+    if stretch:
+        return self.scale((factor, 1.0) if dim == 0 else (1.0, factor))
+    return self.scale(factor)
+
+
+def _mobject_scale_to_fit_width(self: _BaseMobject, width: float, **kwargs: Any) -> _BaseMobject:
+    return self.rescale_to_fit(width, 0, stretch=False, **kwargs)
+
+
+def _mobject_scale_to_fit_height(self: _BaseMobject, height: float, **kwargs: Any) -> _BaseMobject:
+    return self.rescale_to_fit(height, 1, stretch=False, **kwargs)
+
+
+def _mobject_stretch_to_fit_width(self: _BaseMobject, width: float, **kwargs: Any) -> _BaseMobject:
+    return self.rescale_to_fit(width, 0, stretch=True, **kwargs)
+
+
+def _mobject_stretch_to_fit_height(self: _BaseMobject, height: float, **kwargs: Any) -> _BaseMobject:
+    return self.rescale_to_fit(height, 1, stretch=True, **kwargs)
+
+
+def _mobject_match_dim_size(
+    self: _BaseMobject, mobject: _BaseMobject, dim: int, **kwargs: Any
+) -> _BaseMobject:
+    if not isinstance(mobject, _BaseMobject):
+        raise TypeError("dimension match target must be a Mobject")
+    if dim == 0:
+        length = mobject.width
+    elif dim == 1:
+        length = mobject.height
+    else:
+        raise NotImplementedError("Noon currently exposes width/height matching only")
+    return self.rescale_to_fit(length, dim, **kwargs)
+
+
+def _mobject_match_width(
+    self: _BaseMobject, mobject: _BaseMobject, **kwargs: Any
+) -> _BaseMobject:
+    return self.match_dim_size(mobject, 0, **kwargs)
+
+
+def _mobject_match_height(
+    self: _BaseMobject, mobject: _BaseMobject, **kwargs: Any
+) -> _BaseMobject:
+    return self.match_dim_size(mobject, 1, **kwargs)
+
+
+def _mobject_match_coord(
+    self: _BaseMobject,
+    mobject: _BaseMobject,
+    dim: int,
+    direction: object = _base.ORIGIN,
+) -> _BaseMobject:
+    if not isinstance(mobject, _BaseMobject):
+        raise TypeError("coordinate match target must be a Mobject")
+    return self.set_coord(mobject.get_coord(dim, direction), dim, direction)
+
+
+def _mobject_match_x(
+    self: _BaseMobject,
+    mobject: _BaseMobject,
+    direction: object = _base.ORIGIN,
+) -> _BaseMobject:
+    return self.match_coord(mobject, 0, direction)
+
+
+def _mobject_match_y(
+    self: _BaseMobject,
+    mobject: _BaseMobject,
+    direction: object = _base.ORIGIN,
+) -> _BaseMobject:
+    return self.match_coord(mobject, 1, direction)
+
+
+def _mobject_rotate_about_origin(
+    self: _BaseMobject, angle: float, axis: object = None
+) -> _BaseMobject:
+    if axis is not None:
+        try:
+            if len(axis) != 3:  # type: ignore[arg-type]
+                raise TypeError
+            x = float(axis[0])  # type: ignore[index]
+            y = float(axis[1])  # type: ignore[index]
+            z = float(axis[2])  # type: ignore[index]
+        except (TypeError, ValueError, IndexError) as error:
+            raise TypeError("rotation axis must be a three-component vector") from error
+        if not math.isclose(x, 0.0, abs_tol=1e-12) or not math.isclose(
+            y, 0.0, abs_tol=1e-12
+        ) or not math.isclose(abs(z), 1.0, abs_tol=1e-12):
+            raise NotImplementedError("2D authoring supports rotation about the z axis only")
+        if z < 0.0:
+            angle = -float(angle)
+    angle = float(angle)
+    center = self.get_center()
+    cosine = math.cos(angle)
+    sine = math.sin(angle)
+    target = _base.Vec2(
+        center.x * cosine - center.y * sine,
+        center.x * sine + center.y * cosine,
+    )
+    self.rotate(angle)
+    return self.move_to(target)
+
+
+def _set_width_property(self: _BaseMobject, width: float) -> None:
+    self.scale_to_fit_width(float(width))
+
+
+def _set_height_property(self: _BaseMobject, height: float) -> None:
+    self.scale_to_fit_height(float(height))
+
+
 def _state_target(self: _BaseMobject, mobject: _BaseMobject, *, match_height: bool, match_width: bool, match_depth: bool, match_center: bool, stretch: bool) -> _BaseMobject:
     if not isinstance(mobject, _BaseMobject):
         raise TypeError("state target must be a Mobject")
@@ -797,6 +999,33 @@ def install() -> None:
     # so replacing that helper makes inherited transforms/layout accept z=0 vectors.
     _base._as_vec2 = _as_vec2
     _BaseMobject.animate = property(lambda self: _CompatAnimationBuilder(self))
+    _BaseMobject.get_critical_point = _mobject_get_critical_point
+    _BaseMobject.get_edge_center = _mobject_get_edge_center
+    _BaseMobject.get_corner = _mobject_get_corner
+    _BaseMobject.get_left = _mobject_get_left
+    _BaseMobject.get_right = _mobject_get_right
+    _BaseMobject.get_top = _mobject_get_top
+    _BaseMobject.get_bottom = _mobject_get_bottom
+    _BaseMobject.get_coord = _mobject_get_coord
+    _BaseMobject.get_x = _mobject_get_x
+    _BaseMobject.get_y = _mobject_get_y
+    _BaseMobject.set_coord = _mobject_set_coord
+    _BaseMobject.set_x = _mobject_set_x
+    _BaseMobject.set_y = _mobject_set_y
+    _BaseMobject.rescale_to_fit = _mobject_rescale_to_fit
+    _BaseMobject.scale_to_fit_width = _mobject_scale_to_fit_width
+    _BaseMobject.scale_to_fit_height = _mobject_scale_to_fit_height
+    _BaseMobject.stretch_to_fit_width = _mobject_stretch_to_fit_width
+    _BaseMobject.stretch_to_fit_height = _mobject_stretch_to_fit_height
+    _BaseMobject.match_dim_size = _mobject_match_dim_size
+    _BaseMobject.match_width = _mobject_match_width
+    _BaseMobject.match_height = _mobject_match_height
+    _BaseMobject.match_coord = _mobject_match_coord
+    _BaseMobject.match_x = _mobject_match_x
+    _BaseMobject.match_y = _mobject_match_y
+    _BaseMobject.rotate_about_origin = _mobject_rotate_about_origin
+    _BaseMobject.width = property(_BaseMobject.width.fget, _set_width_property)
+    _BaseMobject.height = property(_BaseMobject.height.fget, _set_height_property)
     _BaseMobject.generate_target = _mobject_generate_target
     _BaseMobject.save_state = _mobject_save_state
     _BaseMobject.restore = _mobject_restore

--- a/web/python/_manim_semantic_handles.py
+++ b/web/python/_manim_semantic_handles.py
@@ -143,6 +143,14 @@ def _height(self: _base.Mobject) -> float:
     return 0.0 if bounds is None else bounds[1].y - bounds[0].y
 
 
+def _set_width_property(self: _base.Mobject, width: float) -> None:
+    self.scale_to_fit_width(float(width))
+
+
+def _set_height_property(self: _base.Mobject, height: float) -> None:
+    self.scale_to_fit_height(float(height))
+
+
 def _shift(self: _base.Mobject, direction: object) -> _base.Mobject:
     handle = _handle_for(self)
     if handle is None:
@@ -410,8 +418,8 @@ def install() -> None:
     _base.Mobject._apply = _apply
     _base.Mobject.copy = _copy_mobject
     _base.Mobject.get_center = _get_center
-    _base.Mobject.width = property(_width)
-    _base.Mobject.height = property(_height)
+    _base.Mobject.width = property(_width, _set_width_property)
+    _base.Mobject.height = property(_height, _set_height_property)
     _base.Mobject.shift = _shift
     _base.Mobject.move_to = _move_to
     _base.Mobject.scale = _scale


### PR DESCRIPTION
## Summary
- move detached authoring transform state onto the existing `SemanticTransform2_5D` f64 contract while keeping `ObjectSnapshot.transform` as the synchronized f32 render/wire projection;
- preserve high-precision translation, scale, and z-rotation through shared Rust/WASM handles, including `become`/target-state copies;
- add common Manim O1 queries: critical points, edges/corners, directional `get_x/get_y`, and `get_coord`;
- add directional `set_coord` / `set_x` / `set_y`, width/height property setters, scale/stretch-to-fit, `match_*`, and `rotate_about_origin` by composing shared-handle bounds/shift/scale/rotate primitives;
- explicitly defer z/depth and unsupported anchor options rather than recreating Python-owned scene semantics;
- expand the pinned ManimCE v0.21 differential suite from 25 to 34 cases and add a detached browser semantic-handle smoke for the new APIs.

## Validation
- strict `cargo clippy -p noon-web --all-targets -- -D warnings`;
- `cargo test -p noon-web`, including f64 transform precision regression coverage;
- `cargo check -p noon-web --target wasm32-unknown-unknown`;
- Python compile validation;
- 34/34 pinned ManimCE v0.21 differential fixtures pass;
- generated browser package passes;
- exact browser compatibility smoke passes, including the `0.7` detached-transform precision assertion that initially exposed the f32 leak.

Tracks #61.
Tracks #62.
Tracks #74.