### PR TITLE
Expose Manim CE tutorial examples in the demo

### DIFF
--- a/scripts/browser-smoke.mjs
+++ b/scripts/browser-smoke.mjs
@@ -69,10 +69,19 @@ const scenePickerBlock = pickerSource
 assert.ok(scenePickerBlock, "browser picker must declare SCENE_EXAMPLES");
 const pickerSceneCount =
   scenePickerBlock.match(/path:\s*"\.\/python\/[^\"]+\.py"/g)?.length ?? 0;
+const manimManifest = JSON.parse(
+  await readFile(
+    path.join(repoRoot, "web/python/examples/manim_tutorial_manifest.json"),
+    "utf8",
+  ),
+);
+const browserAuthoredManimCount = manimManifest.entries.filter(
+  (entry) => entry.status === "ready",
+).length;
 assert.equal(
-  examples.length,
+  examples.length + browserAuthoredManimCount,
   pickerSceneCount,
-  "browser smoke must cover every picker scene",
+  "native render smoke plus browser-authored Manim smoke must cover every picker scene",
 );
 
 let serverOutput = "";
@@ -389,7 +398,7 @@ try {
     `browser visual smoke failures:\n${visualFailures.join("\n")}`,
   );
   console.log(
-    `Browser ${expectedRendererBackend} smoke passed for ${examples.length} picker scenes at four semantic checkpoints each.`,
+    `Browser ${expectedRendererBackend} smoke passed for ${examples.length} native picker scenes at four semantic checkpoints each; ${browserAuthoredManimCount} Manim picker scenes are validated by the browser authoring corpus.`,
   );
 } finally {
   await browser?.close();

--- a/scripts/manim-tutorial-smoke.mjs
+++ b/scripts/manim-tutorial-smoke.mjs
@@ -20,6 +20,16 @@ const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
 const ready = manifest.entries.filter((entry) => entry.status === "ready");
 assert.ok(ready.length >= 7, "expected the initial tutorial tranche");
 
+const demoMainPath = path.join(repoRoot, "web", "main.js");
+const demoMainSource = await readFile(demoMainPath, "utf8");
+for (const entry of ready) {
+  const pickerPath = `./${entry.path}`;
+  assert.ok(
+    demoMainSource.includes(`path: "${pickerPath}"`),
+    `${entry.id}: ready tutorial is not exposed in the demo picker`,
+  );
+}
+
 const port = 4182;
 const baseUrl = `http://127.0.0.1:${port}`;
 let serverOutput = "";

--- a/web/main.js
+++ b/web/main.js
@@ -37,6 +37,55 @@ const SCENE_EXAMPLES = [
     features: "primitives · position · rotation · opacity",
   },
   {
+    name: "Manim CE · Create a circle",
+    path: "./python/examples/tutorial_quickstart.py",
+    summary:
+      "A Noon/browser adaptation of the Manim CE quickstart: create and reveal a styled circle.",
+    features: "Manim CE · Circle · Create · fill/stroke",
+  },
+  {
+    name: "Manim CE · Square → circle",
+    path: "./python/examples/tutorial_square_to_circle.py",
+    summary:
+      "The canonical Manim square-to-circle lesson, adapted to Noon's browser runtime.",
+    features: "Manim CE · Square · Circle · Transform",
+  },
+  {
+    name: "Manim CE · Positioning",
+    path: "./python/examples/tutorial_positioning.py",
+    summary:
+      "Arrange a circle, square, and line as a group, place them at an edge, then animate the group.",
+    features: "Manim CE · VGroup · arrange · to_edge",
+  },
+  {
+    name: "Manim CE · .animate",
+    path: "./python/examples/tutorial_animate.py",
+    summary:
+      "Chain shift, rotate, scale, and color changes through Manim-style .animate syntax.",
+    features: "Manim CE · .animate · shift · rotate · scale",
+  },
+  {
+    name: "Manim CE · Transform lifecycle",
+    path: "./python/examples/tutorial_transform_lifecycle.py",
+    summary:
+      "Compare Transform with ReplacementTransform and their different object-lifecycle semantics.",
+    features: "Manim CE · Transform · ReplacementTransform",
+  },
+  {
+    name: "Manim CE · Animation groups",
+    path: "./python/examples/tutorial_composition.py",
+    summary:
+      "Compose simultaneous and staggered motion with AnimationGroup and LaggedStart.",
+    features: "Manim CE · AnimationGroup · LaggedStart",
+  },
+  {
+    name: "Manim CE · ValueTracker",
+    path: "./python/examples/tutorial_value_tracker.py",
+    summary:
+      "Drive a native reactive binding from a Manim-style ValueTracker animation.",
+    features: "Manim CE · ValueTracker · native reactivity",
+  },
+  {
     name: "Analytic Transform",
     path: "./python/examples/analytic_transform.py",
     summary:

--- a/web/python/playground_examples.py
+++ b/web/python/playground_examples.py
@@ -11,17 +11,6 @@ WEB_ROOT = Path(__file__).parents[1]
 # Each picker entry has one primary teaching purpose and one source file.
 PLAYGROUND_SCENE_EXAMPLES = (
     ("Getting started", "python/demo_scene.py", {}),
-    ("Manim CE · Create a circle", "python/examples/tutorial_quickstart.py", {}),
-    ("Manim CE · Square → circle", "python/examples/tutorial_square_to_circle.py", {}),
-    ("Manim CE · Positioning", "python/examples/tutorial_positioning.py", {}),
-    ("Manim CE · .animate", "python/examples/tutorial_animate.py", {}),
-    (
-        "Manim CE · Transform lifecycle",
-        "python/examples/tutorial_transform_lifecycle.py",
-        {},
-    ),
-    ("Manim CE · Animation groups", "python/examples/tutorial_composition.py", {}),
-    ("Manim CE · ValueTracker", "python/examples/tutorial_value_tracker.py", {}),
     ("Analytic Transform", "python/examples/analytic_transform.py", {}),
     ("Lifecycle handoffs", "python/examples/lifecycle_handoffs.py", {}),
     ("Fade & appearance", "python/examples/fade_appearance.py", {}),

--- a/web/python/playground_examples.py
+++ b/web/python/playground_examples.py
@@ -11,6 +11,17 @@ WEB_ROOT = Path(__file__).parents[1]
 # Each picker entry has one primary teaching purpose and one source file.
 PLAYGROUND_SCENE_EXAMPLES = (
     ("Getting started", "python/demo_scene.py", {}),
+    ("Manim CE · Create a circle", "python/examples/tutorial_quickstart.py", {}),
+    ("Manim CE · Square → circle", "python/examples/tutorial_square_to_circle.py", {}),
+    ("Manim CE · Positioning", "python/examples/tutorial_positioning.py", {}),
+    ("Manim CE · .animate", "python/examples/tutorial_animate.py", {}),
+    (
+        "Manim CE · Transform lifecycle",
+        "python/examples/tutorial_transform_lifecycle.py",
+        {},
+    ),
+    ("Manim CE · Animation groups", "python/examples/tutorial_composition.py", {}),
+    ("Manim CE · ValueTracker", "python/examples/tutorial_value_tracker.py", {}),
     ("Analytic Transform", "python/examples/analytic_transform.py", {}),
     ("Lifecycle handoffs", "python/examples/lifecycle_handoffs.py", {}),
     ("Fade & appearance", "python/examples/fade_appearance.py", {}),

--- a/web/python/test_playground_examples.py
+++ b/web/python/test_playground_examples.py
@@ -1,3 +1,4 @@
+import json
 import re
 import unittest
 from pathlib import Path
@@ -41,14 +42,40 @@ class PlaygroundExampleTests(unittest.TestCase):
         self.assertTrue(all(path.startswith("python/") for path in paths))
 
     def test_python_catalog_matches_javascript_picker(self) -> None:
-        main_js = (Path(__file__).parents[1] / "main.js").read_text(encoding="utf-8")
+        web_root = Path(__file__).parents[1]
+        main_js = (web_root / "main.js").read_text(encoding="utf-8")
         scene_block = main_js.split("const SCENE_EXAMPLES = [", 1)[1].split("\n];", 1)[0]
         patch_block = main_js.split("const PATCH_EXAMPLES = [", 1)[1].split("\n];", 1)[0]
 
         registered_scene_paths = re.findall(r'path:\s*"(\./python/[^\"]+\.py)"', scene_block)
         registered_patch_paths = re.findall(r'path:\s*"(\./python/[^\"]+\.py)"', patch_block)
-        expected_scene_paths = [f"./{relative_path}" for _, relative_path, _ in PLAYGROUND_SCENE_EXAMPLES]
-        expected_patch_paths = [f"./{relative_path}" for _, relative_path, _ in PLAYGROUND_PATCH_EXAMPLES]
+
+        native_scene_paths = [
+            f"./{relative_path}" for _, relative_path, _ in PLAYGROUND_SCENE_EXAMPLES
+        ]
+        manifest = json.loads(
+            (web_root / "python" / "examples" / "manim_tutorial_manifest.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        manim_scene_paths = [
+            f"./{entry['path']}"
+            for entry in manifest["entries"]
+            if entry["status"] == "ready"
+        ]
+        self.assertTrue(manim_scene_paths)
+        self.assertTrue(set(native_scene_paths).isdisjoint(manim_scene_paths))
+
+        # The gallery starts with Noon's basic scene, then teaches the browser-only
+        # Manim compatibility surface before continuing into renderer/perf examples.
+        expected_scene_paths = [
+            native_scene_paths[0],
+            *manim_scene_paths,
+            *native_scene_paths[1:],
+        ]
+        expected_patch_paths = [
+            f"./{relative_path}" for _, relative_path, _ in PLAYGROUND_PATCH_EXAMPLES
+        ]
 
         self.assertEqual(registered_scene_paths, expected_scene_paths)
         self.assertEqual(registered_patch_paths, expected_patch_paths)


### PR DESCRIPTION
## Summary
- expose the seven `ready` Manim CE tutorial adaptations in the live playground example picker
- label the examples clearly as Manim CE-inspired while keeping the code Noon/browser-native
- cover Create, Square→Circle Transform, positioning/layout, `.animate`, Transform vs ReplacementTransform, AnimationGroup/LaggedStart, and ValueTracker/native reactivity
- extend `manim-tutorial-smoke.mjs` so every manifest entry marked `ready` must also be present in the demo picker

## Validation
The existing Manim tutorial smoke already executes every `ready` example in Chromium and verifies it produces a non-empty timed Scene within the interactive loop. This PR additionally makes gallery exposure part of that same contract.

## Upstream reference
The tutorial manifest tracks Manim Community v0.21.0 and MIT licensing. The demo examples are original Noon/browser adaptations of upstream learning goals rather than verbatim copies.