### PR TITLE
Match Manim primitive outline parameterization

### DIFF
--- a/crates/noon-geometry/src/outline.rs
+++ b/crates/noon-geometry/src/outline.rs
@@ -1,10 +1,11 @@
-use noon_core::{GeometryRef, Vec2, VectorPath};
+use noon_core::{GeometryRef, Vec2, VectorPath, TAU};
 
 /// Convert renderer-supported geometry to a deterministic vector outline.
 ///
-/// This is intended for transient path-level effects such as `Create`: analytic
-/// primitives stay analytic in semantic/runtime state and are converted only
-/// while a renderer needs ordered path progress.
+/// Analytic primitives stay analytic in semantic/runtime state and are converted
+/// only when a renderer needs ordered path progress. The contour ordering here is
+/// intentionally pinned to ManimCE v0.21.0's Cairo VMobject geometry so Create and
+/// other path-sensitive operations see the same primitive path semantics.
 pub fn canonical_outline_path(geometry: &GeometryRef) -> Option<VectorPath> {
     match geometry {
         GeometryRef::Circle { radius } => Some(circle_path(*radius)),
@@ -16,55 +17,66 @@ pub fn canonical_outline_path(geometry: &GeometryRef) -> Option<VectorPath> {
 }
 
 fn circle_path(radius: f32) -> VectorPath {
-    // Standard four-cubic approximation, matching the temporary path used by
-    // cross-kind Transform. The semantic Circle itself remains analytic.
-    let handle = radius * 0.552_284_8;
-    VectorPath::new()
-        .move_to(Vec2::new(radius, 0.0))
-        .cubic_to(
-            Vec2::new(radius, handle),
-            Vec2::new(handle, radius),
-            Vec2::new(0.0, radius),
-        )
-        .cubic_to(
-            Vec2::new(-handle, radius),
-            Vec2::new(-radius, handle),
-            Vec2::new(-radius, 0.0),
-        )
-        .cubic_to(
-            Vec2::new(-radius, -handle),
-            Vec2::new(-handle, -radius),
-            Vec2::new(0.0, -radius),
-        )
-        .cubic_to(
-            Vec2::new(handle, -radius),
-            Vec2::new(radius, -handle),
-            Vec2::new(radius, 0.0),
-        )
-        .close()
+    // ManimCE v0.21.0 Circle is Arc(angle=TAU) with Arc's default
+    // num_components=9. Cairo's _set_pre_positioned_points therefore creates
+    // nine anchors (the first/last coincide) and eight cubic Bezier segments.
+    // For each 45-degree segment Manim uses 4/3 * tan(d_theta/4) as the tangent
+    // handle factor. Preserve that exact parameterization instead of the common
+    // four-cubic circle approximation: path proportion and partial-path reveal
+    // depend on the segment structure, not only on the final silhouette.
+    const CURVES: usize = 8;
+    let step = TAU / CURVES as f32;
+    let handle_factor = 4.0 / 3.0 * (step / 4.0).tan();
+    let handle_length = radius * handle_factor;
+
+    let mut path = VectorPath::new().move_to(Vec2::new(radius, 0.0));
+    for index in 0..CURVES {
+        let start_angle = index as f32 * step;
+        let end_angle = (index + 1) as f32 * step;
+        let (start_sin, start_cos) = start_angle.sin_cos();
+        let (end_sin, end_cos) = end_angle.sin_cos();
+
+        let start = Vec2::new(radius * start_cos, radius * start_sin);
+        let end = Vec2::new(radius * end_cos, radius * end_sin);
+        let start_tangent = Vec2::new(-start_sin, start_cos);
+        let end_tangent = Vec2::new(-end_sin, end_cos);
+
+        path = path.cubic_to(
+            start + start_tangent * handle_length,
+            end - end_tangent * handle_length,
+            end,
+        );
+    }
+    path.close()
 }
 
 fn rectangle_path(size: Vec2) -> VectorPath {
     let half = size * 0.5;
-    // Start at the right midpoint and include side midpoints so the ordering is
-    // identical to the canonical path used for Circle <-> Rectangle Transform.
+    // ManimCE Rectangle constructs Polygon(UR, UL, DL, DR): start at the
+    // upper-right corner and proceed counter-clockwise around the four sides.
+    // Do not insert midpoint subdivisions solely to make morph command counts
+    // line up; those alter point_from_proportion/Create path semantics.
     VectorPath::new()
-        .move_to(Vec2::new(half.x, 0.0))
-        .line_to(Vec2::new(half.x, half.y))
-        .line_to(Vec2::new(0.0, half.y))
+        .move_to(Vec2::new(half.x, half.y))
         .line_to(Vec2::new(-half.x, half.y))
-        .line_to(Vec2::new(-half.x, 0.0))
         .line_to(Vec2::new(-half.x, -half.y))
-        .line_to(Vec2::new(0.0, -half.y))
         .line_to(Vec2::new(half.x, -half.y))
         .close()
 }
 
 #[cfg(test)]
 mod tests {
-    use noon_core::GeometryId;
+    use noon_core::{GeometryId, PathCommand};
 
     use super::*;
+
+    fn assert_vec2_close(actual: Vec2, expected: Vec2) {
+        const EPSILON: f32 = 1.0e-6;
+        assert!(
+            (actual.x - expected.x).abs() <= EPSILON && (actual.y - expected.y).abs() <= EPSILON,
+            "expected {expected:?}, got {actual:?}"
+        );
+    }
 
     #[test]
     fn analytic_shapes_have_stable_outline_paths() {
@@ -78,6 +90,82 @@ mod tests {
             assert_eq!(first, second);
             assert!(!first.commands().is_empty());
         }
+    }
+
+    #[test]
+    fn circle_outline_matches_manim_cairo_eight_curve_contract() {
+        let radius = 2.0;
+        let path = canonical_outline_path(&GeometryRef::circle(radius)).expect("circle path");
+        let commands = path.commands();
+
+        assert_eq!(commands.len(), 10, "move + 8 cubic curves + close");
+        assert_eq!(
+            commands[0],
+            PathCommand::MoveTo {
+                to: Vec2::new(radius, 0.0)
+            }
+        );
+        assert_eq!(commands[9], PathCommand::Close);
+
+        let step = TAU / 8.0;
+        let factor = 4.0 / 3.0 * (step / 4.0).tan();
+        let diagonal = std::f32::consts::FRAC_1_SQRT_2 * radius;
+        match commands[1] {
+            PathCommand::CubicTo {
+                control1,
+                control2,
+                to,
+            } => {
+                assert_vec2_close(control1, Vec2::new(radius, radius * factor));
+                assert_vec2_close(
+                    control2,
+                    Vec2::new(
+                        diagonal + std::f32::consts::FRAC_1_SQRT_2 * radius * factor,
+                        diagonal - std::f32::consts::FRAC_1_SQRT_2 * radius * factor,
+                    ),
+                );
+                assert_vec2_close(to, Vec2::new(diagonal, diagonal));
+            }
+            command => panic!("expected first cubic segment, got {command:?}"),
+        }
+    }
+
+    #[test]
+    fn rectangle_outline_matches_manim_vertex_order_without_midpoints() {
+        let path =
+            canonical_outline_path(&GeometryRef::rectangle(4.0, 2.0)).expect("rectangle path");
+        assert_eq!(
+            path.commands(),
+            &[
+                PathCommand::MoveTo {
+                    to: Vec2::new(2.0, 1.0),
+                },
+                PathCommand::LineTo {
+                    to: Vec2::new(-2.0, 1.0),
+                },
+                PathCommand::LineTo {
+                    to: Vec2::new(-2.0, -1.0),
+                },
+                PathCommand::LineTo {
+                    to: Vec2::new(2.0, -1.0),
+                },
+                PathCommand::Close,
+            ]
+        );
+    }
+
+    #[test]
+    fn line_outline_preserves_start_to_end_direction() {
+        let start = Vec2::new(-3.0, 2.0);
+        let end = Vec2::new(4.0, -1.0);
+        let path = canonical_outline_path(&GeometryRef::line(start, end)).expect("line path");
+        assert_eq!(
+            path.commands(),
+            &[
+                PathCommand::MoveTo { to: start },
+                PathCommand::LineTo { to: end },
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- match ManimCE v0.21.0 Cairo `Circle` path topology with 8 cubic Bézier segments, starting at +X and proceeding counter-clockwise
- use Manim's Arc handle construction (`4/3 * tan(d_theta/4)`) instead of Noon's visually similar four-cubic approximation
- match `Rectangle`/`Square` contour ordering to Manim's `Polygon(UR, UL, DL, DR)` without Noon-only side-midpoint subdivisions
- preserve and explicitly test `Line` start-to-end path direction
- add low-level regression tests for exact command topology and representative circle control points

## Why
The previous outlines could render a similar final silhouette but did not have the same VMobject path semantics as Manim. That directly changes path-proportional sampling, partial paths, `Create`, and any later animation behavior that consumes the canonical contour. #185 explicitly requires observable/path parity rather than hand-tuned visual similarity.

## Scope
This is a first focused #178 slice, not closure of the full issue. Remaining #178 work includes the browser Manim frontend's `Rectangle()` default dimensions (currently 2×1 instead of ManimCE's 4×2), exact transformed/vector-path bounds, and the differential/raster fixtures as #176 becomes available.

Tracks #178.