### PR TITLE
Match Manim primitive constructor defaults

### DIFF
--- a/web/python/_manim_phase_b.py
+++ b/web/python/_manim_phase_b.py
@@ -18,6 +18,15 @@ class _GenericAnimationBuilder(_compat._CompatAnimationBuilder, _base._Animation
 # low-level Scene.play isinstance check for Noon's animation builder.
 _compat._CompatAnimationBuilder = _GenericAnimationBuilder
 
+# Pinned ManimCE v0.21.0 primitive constructor defaults. Rectangle's dimensions
+# are width=4, height=2; Square passes its side length explicitly and is unchanged.
+MANIM_DEFAULT_RECTANGLE_WIDTH = 4.0
+MANIM_DEFAULT_RECTANGLE_HEIGHT = 2.0
+_compat.Rectangle.__init__.__defaults__ = (
+    MANIM_DEFAULT_RECTANGLE_WIDTH,
+    MANIM_DEFAULT_RECTANGLE_HEIGHT,
+)
+
 
 def _bind_raw(
     scene: _compat.Scene,

--- a/web/python/test_manim_geometry_defaults.py
+++ b/web/python/test_manim_geometry_defaults.py
@@ -1,0 +1,66 @@
+import os
+import subprocess
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+
+
+class ManimGeometryDefaultsTests(unittest.TestCase):
+    def test_public_rectangle_and_square_defaults_match_manim_v021(self) -> None:
+        python_dir = Path(__file__).resolve().parent
+        env = os.environ.copy()
+        existing_pythonpath = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = (
+            str(python_dir)
+            if not existing_pythonpath
+            else os.pathsep.join((str(python_dir), existing_pythonpath))
+        )
+
+        source = textwrap.dedent(
+            """
+            import inspect
+
+            import _manim_compat
+
+            _manim_compat.install()
+            import _manim_phase_b  # noqa: F401 - installs pinned Phase-B semantics
+            from noon import Rectangle, Square
+
+            rectangle = Rectangle()
+            assert abs(rectangle.width - 4.0) < 1e-12
+            assert abs(rectangle.height - 2.0) < 1e-12
+            assert rectangle.geometry["rectangle"]["size"] == {"x": 4.0, "y": 2.0}
+
+            signature = inspect.signature(Rectangle)
+            assert signature.parameters["width"].default == 4.0
+            assert signature.parameters["height"].default == 2.0
+
+            explicit = Rectangle(width=1.5, height=0.75)
+            assert abs(explicit.width - 1.5) < 1e-12
+            assert abs(explicit.height - 0.75) < 1e-12
+
+            square = Square()
+            assert abs(square.width - 2.0) < 1e-12
+            assert abs(square.height - 2.0) < 1e-12
+            assert square.geometry["rectangle"]["size"] == {"x": 2.0, "y": 2.0}
+            """
+        )
+
+        completed = subprocess.run(
+            [sys.executable, "-c", source],
+            check=False,
+            cwd=python_dir,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            completed.returncode,
+            0,
+            f"compatibility subprocess failed:\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- correct the public Manim-facing `Rectangle()` default dimensions from Noon's current 2×1 to ManimCE v0.21.0's 4×2 contract
- preserve explicit `Rectangle(width=..., height=...)` behavior and the existing `Square(side_length=2)` default
- update the runtime-visible constructor signature defaults before user source runs
- add an isolated CPython regression that verifies signature defaults, semantic geometry dimensions, explicit dimensions, and Square behavior without contaminating the native Noon test process

## Reference
Pinned ManimCE v0.21.0 `Rectangle` defaults are `height=2.0`, `width=4.0`; `Square` defaults to `side_length=2.0`.

## Scope
This is another focused #178 slice. It is independent of #190's canonical outline/path-parameterization change and can land in parallel.

Tracks #178.