### PR TITLE
Support Manim animation constructor timing options

### DIFF
--- a/web/python/_manim_animate.py
+++ b/web/python/_manim_animate.py
@@ -19,6 +19,107 @@ import _manim_compat as _compat
 import _manim_phase_b as _phase_b
 
 
+_ORIGINAL_TRANSFORM = _base.Transform
+_ORIGINAL_REPLACEMENT_TRANSFORM = _base.ReplacementTransform
+_ORIGINAL_TRANSFORM_FROM_COPY = _base.TransformFromCopy
+_ORIGINAL_TRANSFORM_MATCHING_SHAPES = _base.TransformMatchingShapes
+_ORIGINAL_CREATE = _base.Create
+_ORIGINAL_FADE_IN = _base.FadeIn
+_ORIGINAL_FADE_OUT = _base.FadeOut
+
+
+def _store_animation_args(animation: object, kwargs: dict[str, Any]) -> None:
+    """Attach Manim Animation kwargs for the shared option resolver.
+
+    Noon's original animation records are frozen/slotted dataclasses. Subclassing them
+    gives the compatibility facade a small Python ``__dict__`` for authoring metadata
+    while preserving the existing low-level fields and isinstance-based lowering.
+    Validation remains centralized in ``_manim_animation_options`` at play time.
+    """
+
+    animation.anim_args = dict(kwargs)  # type: ignore[attr-defined]
+
+
+class Transform(_ORIGINAL_TRANSFORM):
+    def __init__(
+        self,
+        source: object,
+        target: object,
+        key: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(source, target, key)
+        _store_animation_args(self, kwargs)
+
+
+class ReplacementTransform(_ORIGINAL_REPLACEMENT_TRANSFORM):
+    def __init__(
+        self,
+        source: object,
+        target: object,
+        key: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(source, target, key)
+        _store_animation_args(self, kwargs)
+
+
+class TransformFromCopy(_ORIGINAL_TRANSFORM_FROM_COPY):
+    def __init__(
+        self,
+        source: object,
+        target: object,
+        key: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(source, target, key)
+        _store_animation_args(self, kwargs)
+
+
+class TransformMatchingShapes(_ORIGINAL_TRANSFORM_MATCHING_SHAPES):
+    def __init__(
+        self,
+        sources: object,
+        targets: object,
+        key: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(sources, targets, key)
+        _store_animation_args(self, kwargs)
+
+
+class Create(_ORIGINAL_CREATE):
+    def __init__(self, target: object, key: str | None = None, **kwargs: Any) -> None:
+        super().__init__(target, key)
+        _store_animation_args(self, kwargs)
+
+
+class FadeIn(_ORIGINAL_FADE_IN):
+    def __init__(self, target: object, key: str | None = None, **kwargs: Any) -> None:
+        super().__init__(target, key)
+        _store_animation_args(self, kwargs)
+
+
+class FadeOut(_ORIGINAL_FADE_OUT):
+    def __init__(self, target: object, key: str | None = None, **kwargs: Any) -> None:
+        super().__init__(target, key)
+        _store_animation_args(self, kwargs)
+
+
+# Replace only the public compatibility classes. Their frozen Noon bases remain the
+# low-level representation and existing code using isinstance(..., noon.Create/etc.)
+# continues to work because the module globals now point at these subclasses.
+for _name, _value in {
+    "Transform": Transform,
+    "ReplacementTransform": ReplacementTransform,
+    "TransformFromCopy": TransformFromCopy,
+    "TransformMatchingShapes": TransformMatchingShapes,
+    "Create": Create,
+    "FadeIn": FadeIn,
+    "FadeOut": FadeOut,
+}.items():
+    setattr(_base, _name, _value)
+
 
 class _AnimateBuilderMixin:
     """Mirror Manim's callable/chained ``_AnimationBuilder`` contract."""

--- a/web/python/_manim_animate.py
+++ b/web/python/_manim_animate.py
@@ -37,7 +37,7 @@ def _store_animation_args(animation: object, kwargs: dict[str, Any]) -> None:
     Validation remains centralized in ``_manim_animation_options`` at play time.
     """
 
-    animation.anim_args = dict(kwargs)  # type: ignore[attr-defined]
+    object.__setattr__(animation, "anim_args", dict(kwargs))
 
 
 class Transform(_ORIGINAL_TRANSFORM):

--- a/web/python/test_manim_animation_constructor_options.py
+++ b/web/python/test_manim_animation_constructor_options.py
@@ -1,0 +1,146 @@
+import os
+import subprocess
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+
+
+class ManimAnimationConstructorOptionsTests(unittest.TestCase):
+    def test_constructor_runtime_and_rate_options_flow_into_scene_play(self) -> None:
+        python_dir = Path(__file__).resolve().parent
+        env = os.environ.copy()
+        existing_pythonpath = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = (
+            str(python_dir)
+            if not existing_pythonpath
+            else os.pathsep.join((str(python_dir), existing_pythonpath))
+        )
+
+        source = textwrap.dedent(
+            """
+            import math
+            import sys
+            import types
+
+            fake_js = types.ModuleType("js")
+
+            class Result:
+                ok = True
+                errorKind = ""
+                message = ""
+
+            def resolve_animation_options(
+                default_lag_ratio,
+                animation_run_time,
+                animation_rate_func,
+                animation_lag_ratio,
+                path_arc,
+                reverse_rate_function,
+                play_run_time,
+                play_rate_func,
+                play_lag_ratio,
+            ):
+                result = Result()
+                result.runTime = (
+                    play_run_time
+                    if math.isfinite(play_run_time)
+                    else animation_run_time
+                    if math.isfinite(animation_run_time)
+                    else 1.0
+                )
+                result.rateFunc = play_rate_func or animation_rate_func or "smooth"
+                result.lagRatio = (
+                    play_lag_ratio
+                    if math.isfinite(play_lag_ratio)
+                    else animation_lag_ratio
+                    if math.isfinite(animation_lag_ratio)
+                    else default_lag_ratio
+                )
+                result.pathArc = path_arc if math.isfinite(path_arc) else 0.0
+                result.reverseRateFunction = reverse_rate_function == 1
+                return result
+
+            def resolve_uniform_schedule(child_count, lag_ratio, run_time):
+                result = Result()
+                result.intervals = []
+                return result
+
+            fake_js.noonResolveAnimationOptions = resolve_animation_options
+            fake_js.noonResolveUniformCompositionSchedule = resolve_uniform_schedule
+            sys.modules["js"] = fake_js
+
+            import _manim_compat
+            _manim_compat.install()
+            import _manim_rate_functions
+            _manim_rate_functions.install()
+            import _manim_phase_b  # noqa: F401
+            import _manim_animate  # noqa: F401
+
+            from noon import Circle, Create, FadeIn, Scene, Square, Transform, linear, smooth
+
+            # Constructor options are part of the public animation object, not a
+            # Noon-only Scene.play workaround.
+            transform = Transform(Square(), Circle(), run_time=1.25, path_arc=0.3)
+            assert transform.anim_args == {"run_time": 1.25, "path_arc": 0.3}
+
+            # Unequal intrinsic runtimes remain concurrent. Scene duration is the
+            # longest child, exactly as Manim's play compilation expects.
+            scene = Scene()
+            square = Square()
+            circle = Circle()
+            scene.play(
+                Create(square, run_time=2.0, rate_func=linear),
+                FadeIn(circle, run_time=0.5),
+            )
+            assert abs(scene.time - 2.0) < 1e-12
+
+            document = scene.to_document()
+            reveal = next(track for track in document["tracks"] if track["property"] == "reveal")
+            appearance = next(
+                track
+                for track in document["tracks"]
+                if track["object"] == circle.id and track["property"] == "appearance"
+            )
+            assert abs(reveal["timing"]["duration"] - 2.0) < 1e-12
+            assert reveal["timing"]["easing"] == "linear"
+            assert abs(appearance["timing"]["duration"] - 0.5) < 1e-12
+            assert appearance["timing"]["easing"] == "smooth"
+
+            # Scene.play options override constructor options through the same shared
+            # resolver rather than mutating the animation object or double-applying.
+            override_scene = Scene()
+            override_square = Square()
+            override_scene.play(
+                Create(override_square, run_time=3.0, rate_func=linear),
+                run_time=0.75,
+                rate_func=smooth,
+            )
+            override_track = next(
+                track
+                for track in override_scene.to_document()["tracks"]
+                if track["property"] == "reveal"
+            )
+            assert abs(override_scene.time - 0.75) < 1e-12
+            assert abs(override_track["timing"]["duration"] - 0.75) < 1e-12
+            assert override_track["timing"]["easing"] == "smooth"
+            """
+        )
+
+        completed = subprocess.run(
+            [sys.executable, "-c", source],
+            check=False,
+            cwd=python_dir,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            completed.returncode,
+            0,
+            f"compatibility subprocess failed:\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- let supported ordinary animation constructors carry Manim-style animation kwargs (`run_time`, `rate_func`, `lag_ratio`, `path_arc`, etc.) instead of rejecting them at construction
- preserve Noon's frozen low-level animation records by exposing compatibility subclasses with authoring-only `anim_args`
- feed those options into the existing shared Rust resolver already used by `.animate`
- preserve per-animation runtimes for concurrent `Scene.play(a, b)` and advance scene time by the longest child
- preserve `Scene.play` override precedence over constructor options
- add an isolated regression for constructor metadata, unequal concurrent runtimes, rate functions, and play-level overrides

## Scope
Focused #181 slice. Composition nesting and frame quantization remain separate.

Tracks #181.