### PR TITLE
Match Manim fade shift and scale semantics

### DIFF
--- a/web/python/_manim_animate.py
+++ b/web/python/_manim_animate.py
@@ -8,6 +8,7 @@ run during playback.
 
 from __future__ import annotations
 
+import copy
 import math
 from typing import Any, Callable
 
@@ -38,6 +39,54 @@ def _store_animation_args(animation: object, kwargs: dict[str, Any]) -> None:
     """
 
     object.__setattr__(animation, "anim_args", dict(kwargs))
+
+
+def _fade_authoring_options(
+    target: object, kwargs: dict[str, Any]
+) -> tuple[dict[str, Any], _base.Vec2, float, bool]:
+    """Separate `_Fade` endpoint options from generic Animation options.
+
+    Manim resolves ``target_position`` during `_Fade.__init__`, while an explicitly
+    supplied ``shift`` takes precedence over it. Preserve that authoring-time behavior
+    and leave generic timing/rate options for the shared Rust option resolver.
+    """
+
+    if not isinstance(target, (_base.Mobject, _compat.Group)):
+        raise TypeError("FadeIn/FadeOut target must be a Mobject or Group")
+
+    animation_kwargs = dict(kwargs)
+    shift = animation_kwargs.pop("shift", None)
+    target_position = animation_kwargs.pop("target_position", None)
+    scale_factor = float(animation_kwargs.pop("scale", 1.0))
+    if not math.isfinite(scale_factor):
+        raise ValueError("fade scale must be finite")
+
+    point_target = False
+    if shift is not None:
+        shift_vector = _base._as_vec2(shift)
+    elif target_position is not None:
+        if isinstance(target_position, (_base.Mobject, _compat.Group)):
+            point = target_position.get_center()
+        else:
+            point = _base._as_vec2(target_position)
+        shift_vector = point - target.get_center()
+        point_target = True
+    else:
+        shift_vector = _base.ORIGIN
+
+    return animation_kwargs, shift_vector, scale_factor, point_target
+
+
+def _store_fade_options(
+    animation: object,
+    *,
+    shift_vector: _base.Vec2,
+    scale_factor: float,
+    point_target: bool,
+) -> None:
+    object.__setattr__(animation, "_fade_shift_vector", shift_vector)
+    object.__setattr__(animation, "_fade_scale_factor", scale_factor)
+    object.__setattr__(animation, "_fade_point_target", point_target)
 
 
 class Transform(_ORIGINAL_TRANSFORM):
@@ -96,14 +145,32 @@ class Create(_ORIGINAL_CREATE):
 
 class FadeIn(_ORIGINAL_FADE_IN):
     def __init__(self, target: object, key: str | None = None, **kwargs: Any) -> None:
+        animation_kwargs, shift_vector, scale_factor, point_target = _fade_authoring_options(
+            target, kwargs
+        )
         super().__init__(target, key)
-        _store_animation_args(self, kwargs)
+        _store_animation_args(self, animation_kwargs)
+        _store_fade_options(
+            self,
+            shift_vector=shift_vector,
+            scale_factor=scale_factor,
+            point_target=point_target,
+        )
 
 
 class FadeOut(_ORIGINAL_FADE_OUT):
     def __init__(self, target: object, key: str | None = None, **kwargs: Any) -> None:
+        animation_kwargs, shift_vector, scale_factor, point_target = _fade_authoring_options(
+            target, kwargs
+        )
         super().__init__(target, key)
-        _store_animation_args(self, kwargs)
+        _store_animation_args(self, animation_kwargs)
+        _store_fade_options(
+            self,
+            shift_vector=shift_vector,
+            scale_factor=scale_factor,
+            point_target=point_target,
+        )
 
 
 # Replace only the public compatibility classes. Their frozen Noon bases remain the
@@ -300,6 +367,108 @@ def _expanded_schedule(
     ]
 
 
+def _snapshot_mobject(snapshot: dict[str, Any]) -> _base.Mobject:
+    return _base.Mobject(
+        _base._ir.Mobject(
+            geometry=copy.deepcopy(snapshot["geometry"]),
+            transform=copy.deepcopy(snapshot["transform"]),
+            style=copy.deepcopy(snapshot["style"]),
+        )
+    )
+
+
+def _fade_endpoint_snapshots(
+    scene: _compat.Scene,
+    animation: object,
+    *,
+    start_time: float,
+) -> dict[int, dict[str, Any]]:
+    """Build Manim's faded copy endpoint for each leaf at play start."""
+
+    if not isinstance(animation, (FadeIn, FadeOut)):
+        return {}
+
+    shift_vector = animation._fade_shift_vector
+    scale_factor = animation._fade_scale_factor
+    if shift_vector == _base.ORIGIN and math.isclose(scale_factor, 1.0, abs_tol=1e-15):
+        return {}
+
+    leaves = _compat._leaf_mobjects(animation.target)
+    temporary: list[_base.Mobject] = []
+    for member in leaves:
+        if member._object is None:
+            raise ValueError("fade target must be bound before endpoint construction")
+        snapshot = scene._snapshot_for_object_at(member._object, start_time)
+        temporary.append(_snapshot_mobject(snapshot))
+
+    endpoint: object
+    if isinstance(animation.target, _compat.Group):
+        endpoint = _compat.Group(*temporary)
+    else:
+        endpoint = temporary[0]
+
+    direction_modifier = -1.0 if isinstance(animation, FadeIn) and not animation._fade_point_target else 1.0
+    if shift_vector != _base.ORIGIN:
+        endpoint.shift(shift_vector * direction_modifier)  # type: ignore[attr-defined]
+    if not math.isclose(scale_factor, 1.0, abs_tol=1e-15):
+        endpoint.scale(scale_factor)  # type: ignore[attr-defined]
+
+    return {
+        id(member): faded.to_ir()
+        for member, faded in zip(leaves, temporary)
+    }
+
+
+def _schedule_fade_endpoint_transform(
+    scene: _compat.Scene,
+    animation: object,
+    member: _base.Mobject,
+    faded_snapshot: dict[str, Any],
+    *,
+    duration: float,
+    start_time: float,
+    easing: str,
+    key: str | None,
+) -> None:
+    """Lower Fade shift/scale to the ordinary deterministic Transform channel."""
+
+    if member._object is None:
+        raise ValueError("fade target must be bound before endpoint scheduling")
+    obj = member._object
+    previous_end = scene._scheduled_transform_ends.get(obj.id)
+    if previous_end is not None and start_time < previous_end:
+        raise ValueError("generic Transform tracks for one object must not overlap")
+
+    current_snapshot = scene._snapshot_for_object_at(obj, start_time)
+    fade_in = isinstance(animation, FadeIn)
+    from_snapshot = faded_snapshot if fade_in else current_snapshot
+    to_snapshot = current_snapshot if fade_in else faded_snapshot
+
+    object_key = scene._object_keys[obj.id]
+    direction = "in" if fade_in else "out"
+    transform_key = (
+        f"{key}.transform"
+        if key is not None
+        else f"@fade-{direction}:{object_key}:{start_time:g}.transform"
+    )
+    scene._add_track(
+        obj,
+        "transform",
+        {
+            "object": {
+                "from": copy.deepcopy(from_snapshot),
+                "to": copy.deepcopy(to_snapshot),
+            }
+        },
+        start_time,
+        duration,
+        easing,
+        transform_key,
+    )
+    scene._scheduled_transform_targets[obj.id] = copy.deepcopy(to_snapshot)
+    scene._scheduled_transform_ends[obj.id] = start_time + duration
+
+
 def _aligned_scene_play(
     self: _compat.Scene,
     *animations: Any,
@@ -366,6 +535,9 @@ def _aligned_scene_play(
                 play_lag_ratio=lag_ratio,
             )
 
+            fade_snapshots = _fade_endpoint_snapshots(
+                self, animation, start_time=base_start
+            )
             schedule = _expanded_schedule(
                 self,
                 animation,
@@ -375,6 +547,23 @@ def _aligned_scene_play(
                 lag_ratio=resolved.lag_ratio,
             )
             for lowered, child_start, child_duration, child_easing in schedule:
+                if isinstance(animation, (FadeIn, FadeOut)) and isinstance(
+                    lowered, (_base.FadeIn, _base.FadeOut)
+                ):
+                    member = lowered.target
+                    faded_snapshot = fade_snapshots.get(id(member))
+                    if faded_snapshot is not None:
+                        _schedule_fade_endpoint_transform(
+                            self,
+                            animation,
+                            member,
+                            faded_snapshot,
+                            duration=child_duration,
+                            start_time=child_start,
+                            easing=child_easing,
+                            key=lowered.key,
+                        )
+
                 # `noon.Scene` has already been replaced by the compatibility class
                 # during install, so use the original captured facade explicitly to
                 # avoid recursively re-entering this compatibility scheduler.

--- a/web/python/test_manim_fade_endpoints.py
+++ b/web/python/test_manim_fade_endpoints.py
@@ -1,0 +1,171 @@
+import os
+import subprocess
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+
+
+class ManimFadeEndpointTests(unittest.TestCase):
+    def test_shift_scale_and_target_position_lower_to_transform_tracks(self) -> None:
+        python_dir = Path(__file__).resolve().parent
+        env = os.environ.copy()
+        existing_pythonpath = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = (
+            str(python_dir)
+            if not existing_pythonpath
+            else os.pathsep.join((str(python_dir), existing_pythonpath))
+        )
+
+        source = textwrap.dedent(
+            """
+            import math
+            import sys
+            import types
+
+            fake_js = types.ModuleType("js")
+
+            class Result:
+                ok = True
+                errorKind = ""
+                message = ""
+
+            def resolve_animation_options(
+                default_lag_ratio,
+                animation_run_time,
+                animation_rate_func,
+                animation_lag_ratio,
+                path_arc,
+                reverse_rate_function,
+                play_run_time,
+                play_rate_func,
+                play_lag_ratio,
+            ):
+                result = Result()
+                result.runTime = (
+                    play_run_time
+                    if math.isfinite(play_run_time)
+                    else animation_run_time
+                    if math.isfinite(animation_run_time)
+                    else 1.0
+                )
+                result.rateFunc = play_rate_func or animation_rate_func or "smooth"
+                result.lagRatio = (
+                    play_lag_ratio
+                    if math.isfinite(play_lag_ratio)
+                    else animation_lag_ratio
+                    if math.isfinite(animation_lag_ratio)
+                    else default_lag_ratio
+                )
+                result.pathArc = path_arc if math.isfinite(path_arc) else 0.0
+                result.reverseRateFunction = reverse_rate_function == 1
+                return result
+
+            def resolve_uniform_schedule(child_count, lag_ratio, run_time):
+                result = Result()
+                result.intervals = []
+                return result
+
+            fake_js.noonResolveAnimationOptions = resolve_animation_options
+            fake_js.noonResolveUniformCompositionSchedule = resolve_uniform_schedule
+            sys.modules["js"] = fake_js
+
+            import _manim_compat
+            _manim_compat.install()
+            import _manim_rate_functions
+            _manim_rate_functions.install()
+            import _manim_phase_b  # noqa: F401
+            import _manim_animate  # noqa: F401
+
+            from noon import FadeIn, FadeOut, RIGHT, Scene, Square, UP
+
+            def tracks(scene, object_id, property_name):
+                return [
+                    track
+                    for track in scene.to_document()["tracks"]
+                    if track["object"] == object_id and track["property"] == property_name
+                ]
+
+            # Manim FadeIn(..., shift=v) creates the faded copy at -v and scales
+            # that copy around its center before interpolating to the authored state.
+            fade_in_scene = Scene()
+            entering = Square().shift(RIGHT * 2.0)
+            fade_in_scene.play(
+                FadeIn(entering, shift=UP, scale=0.5, run_time=2.0)
+            )
+            transform = tracks(fade_in_scene, entering.id, "transform")[0]
+            appearance = tracks(fade_in_scene, entering.id, "appearance")[0]
+            start = transform["values"]["object"]["from"]["transform"]
+            end = transform["values"]["object"]["to"]["transform"]
+            assert start["translation"] == {"x": 2.0, "y": -1.0}
+            assert start["scale"] == {"x": 0.5, "y": 0.5}
+            assert end["translation"] == {"x": 2.0, "y": 0.0}
+            assert end["scale"] == {"x": 1.0, "y": 1.0}
+            assert transform["timing"] == appearance["timing"]
+            assert abs(fade_in_scene.time - 2.0) < 1e-12
+
+            # FadeOut uses the opposite endpoint direction: +shift and the requested
+            # scale are the disappearing target state.
+            fade_out_scene = Scene()
+            leaving = Square()
+            fade_out_scene.add(leaving)
+            fade_out_scene.play(
+                FadeOut(leaving, shift=RIGHT * 2.0, scale=1.5, run_time=0.8)
+            )
+            transform = tracks(fade_out_scene, leaving.id, "transform")[0]
+            appearance = tracks(fade_out_scene, leaving.id, "appearance")[0]
+            start = transform["values"]["object"]["from"]["transform"]
+            end = transform["values"]["object"]["to"]["transform"]
+            assert start["translation"] == {"x": 0.0, "y": 0.0}
+            assert start["scale"] == {"x": 1.0, "y": 1.0}
+            assert end["translation"] == {"x": 2.0, "y": 0.0}
+            assert end["scale"] == {"x": 1.5, "y": 1.5}
+            assert transform["timing"] == appearance["timing"]
+
+            # target_position is resolved at animation construction and is not
+            # direction-reversed for FadeIn: the faded copy begins at that point.
+            point_scene = Scene()
+            point_entering = Square()
+            point_scene.play(
+                FadeIn(point_entering, target_position=RIGHT * 3.0, run_time=1.25)
+            )
+            transform = tracks(point_scene, point_entering.id, "transform")[0]
+            start = transform["values"]["object"]["from"]["transform"]
+            end = transform["values"]["object"]["to"]["transform"]
+            assert start["translation"] == {"x": 3.0, "y": 0.0}
+            assert end["translation"] == {"x": 0.0, "y": 0.0}
+
+            # As in Manim's _Fade.__init__, explicit shift wins when both are given.
+            precedence_scene = Scene()
+            precedence = Square()
+            precedence_scene.play(
+                FadeIn(
+                    precedence,
+                    shift=UP,
+                    target_position=RIGHT * 8.0,
+                    run_time=0.5,
+                )
+            )
+            transform = tracks(precedence_scene, precedence.id, "transform")[0]
+            start = transform["values"]["object"]["from"]["transform"]
+            assert start["translation"] == {"x": 0.0, "y": -1.0}
+            """
+        )
+
+        completed = subprocess.run(
+            [sys.executable, "-c", source],
+            check=False,
+            cwd=python_dir,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            completed.returncode,
+            0,
+            f"compatibility subprocess failed:\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- match ManimCE v0.21.0 `FadeIn`/`FadeOut` endpoint transform semantics for `shift`, `target_position`, and `scale`
- preserve Manim's direction rule: ordinary FadeIn starts at `-shift`, FadeOut ends at `+shift`, while `target_position` is used directly for both
- preserve explicit `shift` precedence over `target_position`
- lower faded endpoint motion/scale to ordinary deterministic transform tracks synchronized with the existing appearance track
- keep generic animation options (`run_time`, `rate_func`, etc.) on the shared resolver introduced in #194
- add isolated regressions for FadeIn/FadeOut endpoint transforms, timing synchronization, target positioning, and precedence

## Architecture
No renderer special case or playback-time Python callback is introduced. The facade computes Manim's faded copy at authoring time and emits the same deterministic object-snapshot transform channel used by ordinary transforms.

## Scope
Focused #183 slice. Multi-animation point alignment and broader Transform/ReplacementTransform interpolation remain separate.

Tracks #183.