### PR TITLE
Append structural vector paths locally

### DIFF
--- a/crates/noon-geometry/tests/filled_morph.rs
+++ b/crates/noon-geometry/tests/filled_morph.rs
@@ -57,7 +57,7 @@ fn rounded_loop_to_concave_star_has_stable_fill_topology() {
 
     for progress in [0.0, 0.125, 0.25, 0.5, 0.75, 0.875, 1.0] {
         let vertices = plan.interpolate_vertices(progress);
-        for triangle in plan.indices.chunks_exact(3) {
+        for triangle in plan.indices.as_chunks::<3>().0 {
             let a = vertices[triangle[0] as usize];
             let b = vertices[triangle[1] as usize];
             let c = vertices[triangle[2] as usize];
@@ -97,7 +97,9 @@ fn filled_morph_tessellation_contains_fill_and_stroke_with_one_topology() {
 
 fn fill_mesh_area(mesh: &noon_geometry::TessellatedPath, target: bool) -> f32 {
     mesh.indices
-        .chunks_exact(3)
+        .as_chunks::<3>()
+        .0
+        .iter()
         .filter_map(|triangle| {
             let a = &mesh.vertices[triangle[0] as usize];
             let b = &mesh.vertices[triangle[1] as usize];

--- a/crates/noon-geometry/tests/tessellation_correctness.rs
+++ b/crates/noon-geometry/tests/tessellation_correctness.rs
@@ -61,7 +61,9 @@ fn signed_triangle_area(a: Vec2, b: Vec2, c: Vec2) -> f32 {
 
 fn stroke_triangle_area(mesh: &TessellatedPath) -> f32 {
     mesh.indices
-        .chunks_exact(3)
+        .as_chunks::<3>()
+        .0
+        .iter()
         .filter_map(|triangle| {
             let a = &mesh.vertices[triangle[0] as usize];
             let b = &mesh.vertices[triangle[1] as usize];
@@ -670,7 +672,7 @@ fn morph_active_triangles_keep_winding_through_interpolation() {
 
     for alpha in [0.0, 0.25, 0.5, 0.75, 1.0] {
         let mut active = 0;
-        for triangle in mesh.indices.chunks_exact(3) {
+        for triangle in mesh.indices.as_chunks::<3>().0 {
             let position = |index: u32| {
                 let vertex = mesh.vertices[index as usize];
                 add(

--- a/crates/noon-render-wgpu/src/gpu.rs
+++ b/crates/noon-render-wgpu/src/gpu.rs
@@ -655,11 +655,12 @@ impl GpuRenderer {
             prepared.paths,
             prepared.path_dirty_ranges,
             path_instance_reallocated,
-        ) + upload_full_if(
+        ) + upload_dirty(
             queue,
             &self.mega_path_index_buffer,
             prepared.mega_path_indices,
-            prepared.mega_path_index_dirty || mega_path_index_reallocated,
+            prepared.mega_path_index_dirty_ranges,
+            mega_path_index_reallocated,
         ) + upload_dirty(
             queue,
             &self.mega_path_vertex_instance_buffer,
@@ -1226,20 +1227,6 @@ fn ensure_capacity_with_usage(
     });
     *capacity_bytes = new_capacity;
     true
-}
-
-fn upload_full_if<T: Pod>(
-    queue: &wgpu::Queue,
-    buffer: &wgpu::Buffer,
-    values: &[T],
-    upload: bool,
-) -> usize {
-    if values.is_empty() || !upload {
-        return 0;
-    }
-    let bytes = bytemuck::cast_slice(values);
-    queue.write_buffer(buffer, 0, bytes);
-    bytes.len()
 }
 
 fn upload_dirty<T: Pod>(

--- a/crates/noon-render-wgpu/src/lib.rs
+++ b/crates/noon-render-wgpu/src/lib.rs
@@ -157,6 +157,8 @@ pub struct RenderStats {
     pub mega_path_batch_count: usize,
     /// Index entries in the packed painter-order stream.
     pub mega_path_index_count: usize,
+    /// Packed mega-index entries rewritten by this preparation call.
+    pub mega_path_indices_repacked: usize,
     /// Per-vertex instance records rewritten for dirty unique paths.
     pub mega_path_instance_vertices_repacked: usize,
     /// Number of free vertex chunks retained until the next compaction rebuild.
@@ -209,6 +211,8 @@ pub struct PreparedFrame<'a> {
     /// Dirty packed path-geometry index ranges.
     pub path_index_dirty_ranges: &'a [Range<usize>],
     pub mega_path_instance_dirty_ranges: &'a [Range<usize>],
+    /// Dirty ranges in the packed painter-order mega-index stream.
+    pub mega_path_index_dirty_ranges: &'a [Range<usize>],
     pub mega_path_index_dirty: bool,
     pub path_geometry_dirty: bool,
     pub stats: RenderStats,
@@ -255,6 +259,14 @@ struct PathReplacementStats {
     cache_miss: bool,
     vertices_repacked: usize,
     indices_repacked: usize,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct StructuralAppendStats {
+    instances_repacked: usize,
+    geometry_cache_misses: usize,
+    path_vertices_repacked: usize,
+    path_indices_repacked: usize,
 }
 
 #[derive(Debug)]
@@ -307,6 +319,7 @@ pub struct FramePreparer {
     path_vertex_free_ranges: Vec<Range<u32>>,
     path_index_free_ranges: Vec<Range<u32>>,
     mega_path_instance_dirty_ranges: Vec<Range<usize>>,
+    mega_path_index_dirty_ranges: Vec<Range<usize>>,
     mega_path_index_dirty: bool,
     path_geometry_dirty: bool,
     initialized: bool,
@@ -323,10 +336,10 @@ impl FramePreparer {
 
     /// Updates cached instance records using the runtime's consumed change set.
     ///
-    /// Structural removals retire packed slots in place. Tail-appended analytic
-    /// objects extend packed storage and painter order locally. New vector-path
-    /// resources remain an explicit full-rebuild boundary until append-only
-    /// mega-mesh resource insertion is unified with #174's replacement arena.
+    /// Structural removals retire packed slots in place. Tail-appended objects,
+    /// including new vector paths, extend packed storage and painter order locally.
+    /// New path meshes append one arena chunk and one mega-index suffix; unrelated
+    /// geometry and packed painter-order indices remain untouched.
     pub fn prepare_incremental<'a>(
         &'a mut self,
         frame: &FrameState,
@@ -393,7 +406,11 @@ impl FramePreparer {
             instances_repacked += self.retire_structural_slot(object_index);
         }
         for &object_index in changes.added_indices() {
-            instances_repacked += self.append_structural_slot(frame, object_index);
+            let appended = self.append_structural_slot(frame, object_index);
+            instances_repacked += appended.instances_repacked;
+            geometry_cache_misses += appended.geometry_cache_misses;
+            path_vertices_repacked += appended.path_vertices_repacked;
+            path_indices_repacked += appended.path_indices_repacked;
         }
 
         for &object_index in changes.object_indices() {
@@ -478,6 +495,7 @@ impl FramePreparer {
         normalize_dirty_ranges(&mut self.path_vertex_dirty_ranges);
         normalize_dirty_ranges(&mut self.path_index_dirty_ranges);
         normalize_dirty_ranges(&mut self.mega_path_instance_dirty_ranges);
+        normalize_dirty_ranges(&mut self.mega_path_index_dirty_ranges);
 
         self.prepared_frame(
             frame.time,
@@ -501,19 +519,42 @@ impl FramePreparer {
             GeometryRef::Circle { .. }
                 | GeometryRef::Rectangle { .. }
                 | GeometryRef::Line { .. }
+                | GeometryRef::VectorPath(_)
                 | GeometryRef::External(_)
         )
     }
 
-    fn append_structural_slot(&mut self, frame: &FrameState, object_index: usize) -> usize {
+    fn append_structural_slot(
+        &mut self,
+        frame: &FrameState,
+        object_index: usize,
+    ) -> StructuralAppendStats {
         debug_assert_eq!(object_index, self.slots.len());
         let object = &frame.objects[object_index];
-        let slot = match frame.render_geometry(object_index) {
+        let render_geometry = frame.render_geometry(object_index);
+        let reveal = frame.reveal(object_index);
+        let temporary_reveal = temporary_reveal_path(render_geometry, reveal);
+        let path = temporary_reveal
+            .as_ref()
+            .map(|(_, path)| path)
+            .or(match render_geometry {
+                GeometryRef::VectorPath(path) => Some(path),
+                _ => None,
+            });
+        if let Some(path) = path {
+            return self.append_path_structural_slot(
+                frame,
+                object_index,
+                path,
+                temporary_reveal.as_ref().map(|(key, _)| *key),
+            );
+        }
+
+        let slot = match render_geometry {
             GeometryRef::Circle { .. } => {
                 let index = self.circles.len();
                 self.circle_ids.push(object.id);
-                self.circles
-                    .push(pack_circle(object, frame.reveal(object_index)));
+                self.circles.push(pack_circle(object, reveal));
                 push_dirty_range(&mut self.circle_dirty_ranges, index);
                 PreparedSlot::Circle(index)
             }
@@ -527,8 +568,7 @@ impl FramePreparer {
             GeometryRef::Line { .. } => {
                 let index = self.lines.len();
                 self.line_ids.push(object.id);
-                self.lines
-                    .push(pack_line(object, frame.reveal(object_index)));
+                self.lines.push(pack_line(object, reveal));
                 push_dirty_range(&mut self.line_dirty_ranges, index);
                 PreparedSlot::Line(index)
             }
@@ -537,11 +577,160 @@ impl FramePreparer {
                 self.unsupported.push(object.id);
                 PreparedSlot::Unsupported(index)
             }
-            GeometryRef::VectorPath(_) => unreachable!("path structural append requires rebuild"),
+            GeometryRef::VectorPath(_) => unreachable!("vector path must enter append path branch"),
         };
         self.slots.push(slot);
         self.append_ordered_render_slot(slot);
-        usize::from(!matches!(slot, PreparedSlot::Unsupported(_)))
+        StructuralAppendStats {
+            instances_repacked: usize::from(!matches!(slot, PreparedSlot::Unsupported(_))),
+            ..StructuralAppendStats::default()
+        }
+    }
+
+    fn append_path_structural_slot(
+        &mut self,
+        frame: &FrameState,
+        object_index: usize,
+        path: &VectorPath,
+        analytic_reveal: Option<AnalyticRevealKey>,
+    ) -> StructuralAppendStats {
+        let object = &frame.objects[object_index];
+        let reveal = frame.reveal(object_index);
+        let partial_reveal_bits = analytic_reveal.map(|_| reveal.clamp(0.0, 1.0).to_bits());
+        let (cache_index, cache_miss) = match self.cache_path_mesh(path, object.style) {
+            Ok(value) => value,
+            Err(_) => {
+                let slot = PreparedSlot::Unsupported(self.unsupported.len());
+                self.unsupported.push(object.id);
+                self.slots.push(slot);
+                self.append_ordered_render_slot(slot);
+                return StructuralAppendStats::default();
+            }
+        };
+
+        let packed = if partial_reveal_bits.is_some() {
+            pack_path(object, 1.0, 0.0)
+        } else {
+            pack_path(object, reveal, frame.morph(object_index))
+        };
+        let path_index = self.paths.len();
+        self.path_ids.push(object.id);
+        self.paths.push(packed);
+        push_dirty_range(&mut self.path_dirty_ranges, path_index);
+
+        let reveal_head_instance =
+            if partial_reveal_bits.is_none() && should_create_path_reveal_head(object, reveal) {
+                Some(pack_path_reveal_head(
+                    object,
+                    &self.path_mesh_cache[cache_index].mesh,
+                    reveal,
+                ))
+            } else {
+                None
+            };
+        let reveal_head = reveal_head_instance.map(|instance| {
+            let line_index = self.lines.len();
+            self.line_ids.push(object.id);
+            self.lines.push(instance);
+            push_dirty_range(&mut self.line_dirty_ranges, line_index);
+            line_index
+        });
+
+        let shared_geometry = self
+            .path_batch_cache_indices
+            .iter()
+            .position(|&existing| existing == cache_index);
+        let (vertex_range, index_range, vertices_repacked, indices_repacked, mega_eligible) =
+            if let Some(batch) = shared_geometry {
+                (
+                    self.path_batch_vertex_ranges[batch].clone(),
+                    self.path_batches[batch].index_range.clone(),
+                    0,
+                    0,
+                    false,
+                )
+            } else {
+                let (packed_vertices, local_indices) = {
+                    let mesh = &self.path_mesh_cache[cache_index].mesh;
+                    (
+                        mesh.vertices
+                            .iter()
+                            .map(|vertex| PathVertex {
+                                position: [vertex.position.x, vertex.position.y],
+                                target_position: [
+                                    vertex.target_position.x,
+                                    vertex.target_position.y,
+                                ],
+                                surface: pack_path_surface(vertex.surface, vertex.path_progress),
+                            })
+                            .collect::<Vec<_>>(),
+                        mesh.indices.clone(),
+                    )
+                };
+                let vertex_start = u32::try_from(self.path_vertices.len())
+                    .expect("path vertex count exceeds renderer limits");
+                let index_start = u32::try_from(self.path_indices.len())
+                    .expect("path index count exceeds renderer limits");
+                self.path_vertices.extend_from_slice(&packed_vertices);
+                self.path_indices.extend(local_indices.iter().map(|index| {
+                    index
+                        .checked_add(vertex_start)
+                        .expect("path index exceeds renderer limits")
+                }));
+                let vertex_end = u32::try_from(self.path_vertices.len())
+                    .expect("path vertex count exceeds renderer limits");
+                let index_end = u32::try_from(self.path_indices.len())
+                    .expect("path index count exceeds renderer limits");
+                let vertex_range = vertex_start..vertex_end;
+                let index_range = index_start..index_end;
+                self.path_vertex_dirty_ranges
+                    .push(range_usize_u32(&vertex_range));
+                self.path_index_dirty_ranges
+                    .push(range_usize_u32(&index_range));
+                self.path_geometry_dirty = true;
+                (
+                    vertex_range,
+                    index_range,
+                    packed_vertices.len(),
+                    local_indices.len(),
+                    true,
+                )
+            };
+
+        let batch = self.path_batches.len();
+        let instance_start = u32::try_from(path_index).expect("path instance count exceeds limits");
+        self.path_batch_vertex_ranges.push(vertex_range);
+        self.path_batches.push(PathBatch {
+            index_range,
+            instance_range: instance_start..instance_start + 1,
+        });
+        self.path_batch_cache_indices.push(cache_index);
+        self.mega_path_segments.push(None);
+        self.mega_path_detached.push(false);
+        let slot = PreparedSlot::Path {
+            index: path_index,
+            batch,
+            analytic_reveal,
+            partial_reveal_bits,
+            reveal_head,
+        };
+        self.slots.push(slot);
+
+        let appended_to_mega = mega_eligible && self.append_mega_path_draw(batch, packed);
+        if appended_to_mega {
+            if let Some(line_index) = reveal_head {
+                self.append_ordered_reveal_head(line_index);
+            }
+        } else {
+            self.append_ordered_render_slot(slot);
+        }
+
+        StructuralAppendStats {
+            instances_repacked: 1 + usize::from(reveal_head.is_some()),
+            geometry_cache_misses: usize::from(cache_miss),
+            path_vertices_repacked: vertices_repacked,
+            path_indices_repacked: indices_repacked,
+        }
     }
 
     fn retire_structural_slot(&mut self, object_index: usize) -> usize {
@@ -1006,6 +1195,7 @@ impl FramePreparer {
             path_vertex_dirty_ranges: &self.path_vertex_dirty_ranges,
             path_index_dirty_ranges: &self.path_index_dirty_ranges,
             mega_path_instance_dirty_ranges: &self.mega_path_instance_dirty_ranges,
+            mega_path_index_dirty_ranges: &self.mega_path_index_dirty_ranges,
             mega_path_index_dirty: self.mega_path_index_dirty,
             path_geometry_dirty: self.path_geometry_dirty,
             stats: RenderStats {
@@ -1028,6 +1218,7 @@ impl FramePreparer {
                     .sum(),
                 mega_path_batch_count: self.mega_path_batches.len(),
                 mega_path_index_count: self.mega_path_indices.len(),
+                mega_path_indices_repacked: dirty_len(&self.mega_path_index_dirty_ranges),
                 mega_path_instance_vertices_repacked: dirty_len(
                     &self.mega_path_instance_dirty_ranges,
                 ),
@@ -1063,6 +1254,7 @@ impl FramePreparer {
         self.path_vertex_dirty_ranges.clear();
         self.path_index_dirty_ranges.clear();
         self.mega_path_instance_dirty_ranges.clear();
+        self.mega_path_index_dirty_ranges.clear();
         self.mega_path_index_dirty = false;
         self.path_geometry_dirty = false;
     }
@@ -1139,7 +1331,7 @@ impl FramePreparer {
         }
     }
 
-    fn capacities(&self) -> [usize; 31] {
+    fn capacities(&self) -> [usize; 32] {
         [
             self.circle_ids.capacity(),
             self.circles.capacity(),
@@ -1159,6 +1351,7 @@ impl FramePreparer {
             self.mega_path_segments.capacity(),
             self.mega_path_detached.capacity(),
             self.mega_path_instance_dirty_ranges.capacity(),
+            self.mega_path_index_dirty_ranges.capacity(),
             self.path_batch_cache_indices.capacity(),
             self.path_mesh_cache.capacity(),
             self.path_mesh_lookup.capacity(),
@@ -2329,6 +2522,150 @@ mod tests {
         assert!(matches!(
             prepared.render_batches[0].primitive,
             RenderPrimitive::MegaPath { .. }
+        ));
+    }
+
+    #[test]
+    fn structural_unique_path_append_touches_only_new_mesh_and_mega_suffix() {
+        const OBJECT_COUNT: usize = 10_000;
+        let objects = (0..OBJECT_COUNT)
+            .map(|index| {
+                let y = index as f32 * 0.0001;
+                let mut state = object(
+                    index as u64,
+                    GeometryRef::path(
+                        VectorPath::new()
+                            .move_to(Vec2::new(-0.5, y))
+                            .line_to(Vec2::new(0.5, y)),
+                    ),
+                );
+                state.style.fill = None;
+                state.style.stroke = Some(Color::WHITE);
+                state.style.stroke_width = 0.01;
+                state
+            })
+            .collect();
+        let mut frame = frame(objects);
+        let mut preparer = FramePreparer::new();
+        preparer.prepare(&frame);
+        let first_vertex_range = preparer.path_batch_vertex_ranges[0].clone();
+        let middle_vertex_range = preparer.path_batch_vertex_ranges[OBJECT_COUNT / 2].clone();
+        let last_vertex_range = preparer.path_batch_vertex_ranges[OBJECT_COUNT - 1].clone();
+        let first_index_range = preparer.path_batches[0].index_range.clone();
+        let last_index_range = preparer.path_batches[OBJECT_COUNT - 1].index_range.clone();
+        let old_vertex_count = preparer.path_vertices.len();
+        let old_index_count = preparer.path_indices.len();
+        let old_mega_index_count = preparer.mega_path_indices.len();
+
+        let mut appended = object(
+            OBJECT_COUNT as u64,
+            GeometryRef::path(VectorPath::new().move_to(Vec2::new(-0.75, 1.5)).cubic_to(
+                Vec2::new(-0.25, 2.0),
+                Vec2::new(0.25, 1.0),
+                Vec2::new(0.75, 1.5),
+            )),
+        );
+        appended.style.fill = None;
+        appended.style.stroke = Some(Color::WHITE);
+        appended.style.stroke_width = 0.015;
+        frame.objects.push(appended);
+        frame.presences.push(true);
+        frame.reveals.push(1.0);
+        frame.morphs.push(0.0);
+        frame.render_geometries.push(None);
+
+        let prepared = preparer.prepare_incremental(
+            &frame,
+            &FrameChanges::structural(vec![OBJECT_COUNT], Vec::new()),
+        );
+
+        assert_eq!(prepared.stats.full_rebuilds, 0);
+        assert_eq!(prepared.stats.structural_slots_added, 1);
+        assert_eq!(prepared.stats.geometry_cache_misses, 1);
+        assert_eq!(prepared.path_batches.len(), OBJECT_COUNT + 1);
+        assert_eq!(prepared.stats.mega_path_count, OBJECT_COUNT + 1);
+        assert_eq!(prepared.stats.mega_path_batch_count, 1);
+        assert!(prepared.stats.path_vertices_repacked > 0);
+        assert!(prepared.stats.path_vertices_repacked < old_vertex_count);
+        assert!(prepared.stats.path_indices_repacked > 0);
+        assert!(prepared.stats.path_indices_repacked < old_index_count);
+        assert_eq!(prepared.path_vertex_dirty_ranges.len(), 1);
+        assert_eq!(prepared.path_vertex_dirty_ranges[0].start, old_vertex_count);
+        assert_eq!(prepared.path_index_dirty_ranges.len(), 1);
+        assert_eq!(prepared.path_index_dirty_ranges[0].start, old_index_count);
+        assert_eq!(prepared.mega_path_index_dirty_ranges.len(), 1);
+        assert_eq!(
+            prepared.mega_path_index_dirty_ranges[0].start,
+            old_mega_index_count
+        );
+        assert_eq!(
+            prepared.stats.mega_path_indices_repacked,
+            prepared.mega_path_index_dirty_ranges[0].len()
+        );
+        assert!(prepared.stats.mega_path_indices_repacked < old_mega_index_count);
+        assert_eq!(preparer.path_batch_vertex_ranges[0], first_vertex_range);
+        assert_eq!(
+            preparer.path_batch_vertex_ranges[OBJECT_COUNT / 2],
+            middle_vertex_range
+        );
+        assert_eq!(
+            preparer.path_batch_vertex_ranges[OBJECT_COUNT - 1],
+            last_vertex_range
+        );
+        assert_eq!(preparer.path_batches[0].index_range, first_index_range);
+        assert_eq!(
+            preparer.path_batches[OBJECT_COUNT - 1].index_range,
+            last_index_range
+        );
+    }
+
+    #[test]
+    fn structural_repeated_path_append_reuses_existing_geometry_without_repacking() {
+        let mut original = object(
+            1,
+            GeometryRef::path(
+                VectorPath::new()
+                    .move_to(Vec2::new(-1.0, 0.0))
+                    .line_to(Vec2::new(1.0, 0.0)),
+            ),
+        );
+        original.style.fill = None;
+        original.style.stroke = Some(Color::WHITE);
+        original.style.stroke_width = 0.02;
+        let mut frame = frame(vec![original.clone()]);
+        let mut preparer = FramePreparer::new();
+        preparer.prepare(&frame);
+        let old_vertex_count = preparer.path_vertices.len();
+        let old_index_count = preparer.path_indices.len();
+
+        original.id = ObjectId::new(2);
+        original.transform.translation = Vec2::new(0.0, 1.0);
+        frame.objects.push(original);
+        frame.presences.push(true);
+        frame.reveals.push(1.0);
+        frame.morphs.push(0.0);
+        frame.render_geometries.push(None);
+        let prepared =
+            preparer.prepare_incremental(&frame, &FrameChanges::structural(vec![1], Vec::new()));
+
+        assert_eq!(prepared.stats.full_rebuilds, 0);
+        assert_eq!(prepared.stats.structural_slots_added, 1);
+        assert_eq!(prepared.stats.geometry_cache_misses, 0);
+        assert_eq!(prepared.stats.path_vertices_repacked, 0);
+        assert_eq!(prepared.stats.path_indices_repacked, 0);
+        assert_eq!(prepared.path_vertices.len(), old_vertex_count);
+        assert_eq!(prepared.path_indices.len(), old_index_count);
+        assert!(prepared.path_vertex_dirty_ranges.is_empty());
+        assert!(prepared.path_index_dirty_ranges.is_empty());
+        assert!(prepared.mega_path_index_dirty_ranges.is_empty());
+        assert_eq!(prepared.path_batches.len(), 2);
+        assert_eq!(
+            prepared.path_batches[0].index_range,
+            prepared.path_batches[1].index_range
+        );
+        assert!(matches!(
+            prepared.render_batches.last().unwrap().primitive,
+            RenderPrimitive::Path { batch: 1 }
         ));
     }
 

--- a/crates/noon-render-wgpu/src/mega_mesh.rs
+++ b/crates/noon-render-wgpu/src/mega_mesh.rs
@@ -17,6 +17,7 @@ impl FramePreparer {
         self.mega_path_segments.clear();
         self.mega_path_detached.clear();
         self.mega_path_instance_dirty_ranges.clear();
+        self.mega_path_index_dirty_ranges.clear();
         self.mega_path_index_dirty = false;
 
         let eligible = self
@@ -75,11 +76,88 @@ impl FramePreparer {
         self.rebuild_mega_render_batches();
         if !self.mega_path_indices.is_empty() {
             self.mega_path_index_dirty = true;
+            self.mega_path_index_dirty_ranges
+                .push(0..self.mega_path_indices.len());
         }
         if !self.mega_path_vertex_instances.is_empty() {
             self.mega_path_instance_dirty_ranges
                 .push(0..self.mega_path_vertex_instances.len());
         }
+    }
+
+    /// Appends one unique path to the packed painter-order stream without
+    /// rewriting any existing mega indices or vertex-instance attributes.
+    pub(crate) fn append_mega_path_draw(
+        &mut self,
+        path_batch_index: usize,
+        packed: PathInstance,
+    ) -> bool {
+        let Some(path_batch) = self.path_batches.get(path_batch_index).cloned() else {
+            return false;
+        };
+        if path_batch.instance_range.end != path_batch.instance_range.start + 1
+            || path_batch.index_range.is_empty()
+        {
+            return false;
+        }
+        let Some(vertex_range) = self.path_batch_vertex_ranges.get(path_batch_index).cloned()
+        else {
+            return false;
+        };
+
+        if self.mega_path_segments.len() <= path_batch_index {
+            self.mega_path_segments.resize(path_batch_index + 1, None);
+        }
+        if self.mega_path_detached.len() <= path_batch_index {
+            self.mega_path_detached.resize(path_batch_index + 1, false);
+        }
+
+        let source = range_usize(&path_batch.index_range);
+        let segment_start = u32::try_from(self.mega_path_indices.len())
+            .expect("mega path index count exceeds renderer limits");
+        self.mega_path_indices
+            .extend_from_slice(&self.path_indices[source]);
+        let segment_end = u32::try_from(self.mega_path_indices.len())
+            .expect("mega path index count exceeds renderer limits");
+        let segment = segment_start..segment_end;
+        self.mega_path_segments[path_batch_index] = Some(segment.clone());
+        self.mega_path_detached[path_batch_index] = false;
+        push_dirty_range(
+            &mut self.mega_path_index_dirty_ranges,
+            range_usize(&segment),
+        );
+        self.mega_path_index_dirty = true;
+
+        if self.mega_path_vertex_instances.len() < self.path_vertices.len() {
+            self.mega_path_vertex_instances
+                .resize(self.path_vertices.len(), PathInstance::zeroed());
+        }
+        let vertex_range = range_usize(&vertex_range);
+        self.mega_path_vertex_instances[vertex_range.clone()].fill(packed);
+        push_dirty_range(&mut self.mega_path_instance_dirty_ranges, vertex_range);
+
+        if let Some(ordered) = self.render_batches.last_mut() {
+            if let RenderPrimitive::MegaPath { batch } = ordered.primitive {
+                let mega = &mut self.mega_path_batches[batch];
+                if mega.index_range.end == segment.start {
+                    mega.index_range.end = segment.end;
+                    mega.path_count += 1;
+                    ordered.instance_range.end += 1;
+                    return true;
+                }
+            }
+        }
+
+        let batch = self.mega_path_batches.len();
+        self.mega_path_batches.push(MegaPathBatch {
+            index_range: segment,
+            path_count: 1,
+        });
+        self.render_batches.push(OrderedRenderBatch {
+            primitive: RenderPrimitive::MegaPath { batch },
+            instance_range: 0..1,
+        });
+        true
     }
 
     /// Rebuilds only CPU-side ordered draw descriptors around the immutable packed

--- a/crates/noon-render-wgpu/src/render_order.rs
+++ b/crates/noon-render-wgpu/src/render_order.rs
@@ -99,6 +99,14 @@ impl FramePreparer {
         push_slot_batches(&mut self.render_batches, slot);
     }
 
+    pub(crate) fn append_ordered_reveal_head(&mut self, line_index: usize) {
+        debug_assert!(
+            self.render_order_keys.is_empty(),
+            "explicit render-order keys require structural rebuild",
+        );
+        push_batch(&mut self.render_batches, RenderPrimitive::Line, line_index);
+    }
+
     pub(crate) fn rebuild_ordered_render_batches(&mut self) {
         self.render_batches.clear();
 


### PR DESCRIPTION
## Summary
- let `FramePreparer::prepare_incremental` handle tail-appended `VectorPath` objects without falling back to a full renderer rebuild
- allocate one stable path batch plus local vertex/index arena chunks for the new resource
- reuse cached tessellation when an appended path shares existing geometry/style
- append unique-path entries to the mega-mesh stream without rebuilding or shifting unrelated packed path geometry
- replace the mega-index all-or-nothing dirty flag with range-based dirty uploads so GPU transfer cost stays local too
- preserve painter order by appending the new path batch through the existing ordered-render abstraction
- integrate with #191's Manim partial-Create path slots by preserving `partial_reveal_bits` and the temporary-geometry reveal contract
- update four constant-size geometry-test chunk iterations for the Rust 1.98 Clippy `chunks_exact_to_as_chunks` lint; this is test/CI compatibility only and does not change geometry behavior

## Locality regressions
- append one new unique path after 10,000 existing unique paths and verify first/middle/last pre-existing arena ranges are unchanged
- require one new structural slot, one new path instance, only the new vertex/index chunks dirty, only the mega-index suffix dirty, and zero full preparation rebuilds
- append a second object with identical path geometry and verify zero tessellation and zero path-geometry repack

## Validation
Rebased integration validation on current master passed:
- `cargo test -p noon-render-wgpu -p noon-runtime -p noon-web`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo check -p noon-web --target wasm32-unknown-unknown`

Tracks #58.
Part of #68 Wave 2.