### PR TITLE
Use exact world bounds for semantic-handle layout

### DIFF
--- a/scripts/manim-compat-smoke.mjs
+++ b/scripts/manim-compat-smoke.mjs
@@ -119,8 +119,8 @@ class DefaultVmobjectStyle(Scene):
         assert abs(circle.style["stroke_width"] - 0.04) < 1e-9
         assert circle.style["stroke_join"] == "miter"
         assert circle.style["stroke_cap"] == "butt"
-        assert circle.style["fill"]["red"] == 1.0
-        assert circle.style["stroke"]["red"] == 1.0
+        assert abs(circle.style["fill"]["red"] - RED.red) < 1e-7
+        assert abs(circle.style["stroke"]["red"] - RED.red) < 1e-7
 
         explicit = Square(stroke_width=10)
         assert abs(explicit.style["stroke_width"] - 0.10) < 1e-9
@@ -213,7 +213,6 @@ class AnimateParity(Scene):
         except ValueError as error:
             assert "only be passed once" in str(error)
 `;
-
 
 const queryTransformSource = `
 from noon import *
@@ -384,7 +383,6 @@ try {
     "smooth",
     "Scene.play kwargs should override builder animation kwargs",
   );
-
 
   const queryTransforms = await page.evaluate(
     (pythonSource) => window.noonManimCompat.run(pythonSource),

--- a/web/python/_manim_semantic_handles.py
+++ b/web/python/_manim_semantic_handles.py
@@ -66,6 +66,28 @@ def _handle_for(value: object):
     return getattr(value, "_semantic_handle", None)
 
 
+def _layout_bounds(value: _base.Mobject) -> tuple[_base.Vec2, _base.Vec2] | None:
+    """Use the one Manim compatibility bounds contract for every object owner.
+
+    `_manim_phase_b` installs `_base._bounds` before this module is installed. It
+    evaluates transformed quadratic/cubic extrema and analytic primitive extents in
+    world space. Detached semantic handles remain authoritative for object state; we
+    materialize only their current snapshot for this compatibility query instead of
+    using the handle's older transformed-local-AABB shortcuts.
+    """
+
+    return _base._bounds(value._current_raw())
+
+
+def _layout_center(value: _base.Mobject) -> _base.Vec2:
+    raw = value._current_raw()
+    bounds = _base._bounds(raw)
+    if bounds is not None:
+        return (bounds[0] + bounds[1]) * 0.5
+    translation = raw.transform["translation"]
+    return _base.Vec2(float(translation["x"]), float(translation["y"]))
+
+
 def _init(self: _base.Mobject, raw: _ir.Mobject) -> None:
     _ORIGINAL_INIT(self, raw)
     if _create_handle is not None:
@@ -121,25 +143,18 @@ def _copy_mobject(self: _base.Mobject) -> _base.Mobject:
 
 
 def _get_center(self: _base.Mobject) -> _base.Vec2:
-    handle = _handle_for(self)
-    if handle is not None:
-        return _base.Vec2(float(handle.centerX), float(handle.centerY))
+    if _handle_for(self) is not None:
+        return _layout_center(self)
     return _ORIGINAL_GET_CENTER(self)
 
 
 def _width(self: _base.Mobject) -> float:
-    handle = _handle_for(self)
-    if handle is not None:
-        return float(handle.width)
-    bounds = _base._bounds(self._current_raw())
+    bounds = _layout_bounds(self) if _handle_for(self) is not None else _base._bounds(self._current_raw())
     return 0.0 if bounds is None else bounds[1].x - bounds[0].x
 
 
 def _height(self: _base.Mobject) -> float:
-    handle = _handle_for(self)
-    if handle is not None:
-        return float(handle.height)
-    bounds = _base._bounds(self._current_raw())
+    bounds = _layout_bounds(self) if _handle_for(self) is not None else _base._bounds(self._current_raw())
     return 0.0 if bounds is None else bounds[1].y - bounds[0].y
 
 
@@ -165,7 +180,8 @@ def _move_to(self: _base.Mobject, point: object) -> _base.Mobject:
     if handle is None:
         return _ORIGINAL_MOVE_TO(self, point)
     value = _base._as_vec2(point)
-    handle.moveTo(value.x, value.y)
+    center = _layout_center(self)
+    handle.shift(value.x - center.x, value.y - center.y)
     return self
 
 
@@ -246,11 +262,15 @@ def _replace(
 
 
 def _critical(value: _base.Mobject, direction: _base.Vec2) -> _base.Vec2:
-    handle = _handle_for(value)
-    if handle is not None:
+    if _handle_for(value) is not None:
+        bounds = _layout_bounds(value)
+        if bounds is None:
+            return _layout_center(value)
+        minimum, maximum = bounds
+        center = (minimum + maximum) * 0.5
         return _base.Vec2(
-            float(handle.criticalX(direction.x, direction.y)),
-            float(handle.criticalY(direction.x, direction.y)),
+            minimum.x if direction.x < 0 else maximum.x if direction.x > 0 else center.x,
+            minimum.y if direction.y < 0 else maximum.y if direction.y > 0 else center.y,
         )
     return _base._critical(value._current_raw(), direction)
 
@@ -265,15 +285,12 @@ def _next_to(
     if handle is None:
         return _ORIGINAL_NEXT_TO(self, other, direction, buff)
     axis = _base._as_vec2(direction).normalized()
-    other_handle = _handle_for(other)
-    if other_handle is not None:
-        handle.nextToHandle(other_handle, axis.x, axis.y, float(buff))
-    elif isinstance(other, _base.Mobject):
-        target = _critical(other, axis)
-        handle.nextToPoint(target.x, target.y, axis.x, axis.y, float(buff))
-    else:
-        target = _base._as_vec2(other)
-        handle.nextToPoint(target.x, target.y, axis.x, axis.y, float(buff))
+    source = _critical(self, -axis)
+    target = _critical(other, axis) if isinstance(other, _base.Mobject) else _base._as_vec2(other)
+    handle.shift(
+        target.x - source.x + axis.x * float(buff),
+        target.y - source.y + axis.y * float(buff),
+    )
     return self
 
 
@@ -286,12 +303,12 @@ def _align_to(
     if handle is None:
         return _ORIGINAL_ALIGN_TO(self, other, direction)
     axis = _base._as_vec2(direction)
-    other_handle = _handle_for(other)
-    if other_handle is not None:
-        handle.alignToHandle(other_handle, axis.x, axis.y)
-    else:
-        target = _critical(other, axis)
-        handle.alignToPoint(target.x, target.y, axis.x, axis.y)
+    source = _critical(self, axis)
+    target = _critical(other, axis)
+    handle.shift(
+        0.0 if axis.x == 0.0 else target.x - source.x,
+        0.0 if axis.y == 0.0 else target.y - source.y,
+    )
     return self
 
 
@@ -303,9 +320,19 @@ def _align_on_frame(
     handle = _handle_for(self)
     if handle is None:
         return _ORIGINAL_ALIGN_ON_FRAME(self, direction, buff)
-    handle.alignOnFrame(direction.x, direction.y, float(buff))
+    point = _critical(self, direction)
+    shift_x = 0.0
+    shift_y = 0.0
+    if direction.x != 0.0:
+        target_x = direction.x.__class__(_base.DEFAULT_FRAME_WIDTH / 2.0)
+        target_x = (1.0 if direction.x > 0.0 else -1.0) * float(target_x)
+        shift_x = target_x - point.x - direction.x * float(buff)
+    if direction.y != 0.0:
+        target_y = direction.y.__class__(_base.DEFAULT_FRAME_HEIGHT / 2.0)
+        target_y = (1.0 if direction.y > 0.0 else -1.0) * float(target_y)
+        shift_y = target_y - point.y - direction.y * float(buff)
+    handle.shift(shift_x, shift_y)
     return self
-
 
 
 def _set_fill(
@@ -381,13 +408,7 @@ def _compat_bounds_for(value: object) -> tuple[_base.Vec2, _base.Vec2] | None:
     leaves = _compat._leaf_mobjects(value)
     present: list[tuple[_base.Vec2, _base.Vec2]] = []
     for member in leaves:
-        handle = _handle_for(member)
-        if handle is not None:
-            center = _base.Vec2(float(handle.centerX), float(handle.centerY))
-            half = _base.Vec2(float(handle.width) * 0.5, float(handle.height) * 0.5)
-            present.append((center - half, center + half))
-            continue
-        bounds = _base._bounds(member._current_raw())
+        bounds = _layout_bounds(member) if _handle_for(member) is not None else _base._bounds(member._current_raw())
         if bounds is not None:
             present.append(bounds)
     if not present:

--- a/web/python/test_manim_semantic_handle_layout_bounds.py
+++ b/web/python/test_manim_semantic_handle_layout_bounds.py
@@ -1,0 +1,139 @@
+import os
+import subprocess
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+
+
+class ManimSemanticHandleLayoutBoundsTests(unittest.TestCase):
+    def test_detached_handles_use_exact_world_bounds_for_layout(self) -> None:
+        python_dir = Path(__file__).resolve().parent
+        env = os.environ.copy()
+        existing_pythonpath = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = (
+            str(python_dir)
+            if not existing_pythonpath
+            else os.pathsep.join((str(python_dir), existing_pythonpath))
+        )
+
+        source = textwrap.dedent(
+            """
+            import json
+            import math
+
+            import _manim_compat
+
+            _manim_compat.install()
+            import _manim_phase_b  # noqa: F401 - installs exact Manim layout bounds
+            import _manim_semantic_handles as handles
+
+
+            class FakeHandle:
+                # Deliberately omit center/width/height/critical/nextTo/align shortcuts.
+                # The adapter must obtain layout from the shared exact bounds contract.
+                def __init__(self, snapshot_json):
+                    self.snapshot = json.loads(snapshot_json)
+
+                def snapshotJson(self):
+                    return json.dumps(self.snapshot, separators=(\",\", \":\"))
+
+                def replaceSnapshotJson(self, snapshot_json):
+                    self.snapshot = json.loads(snapshot_json)
+
+                def cloneHandle(self):
+                    return FakeHandle(self.snapshotJson())
+
+                def setFillOpacity(self, opacity):
+                    fill = self.snapshot[\"style\"][\"fill\"]
+                    if fill is not None:
+                        fill[\"alpha\"] = float(opacity)
+
+                def setStrokeOpacity(self, opacity):
+                    stroke = self.snapshot[\"style\"][\"stroke\"]
+                    if stroke is not None:
+                        stroke[\"alpha\"] = float(opacity)
+
+                def shift(self, x, y):
+                    translation = self.snapshot[\"transform\"][\"translation\"]
+                    translation[\"x\"] += float(x)
+                    translation[\"y\"] += float(y)
+
+                def scale(self, x, y):
+                    scale = self.snapshot[\"transform\"][\"scale\"]
+                    scale[\"x\"] *= float(x)
+                    scale[\"y\"] *= float(y)
+
+                def rotate(self, angle):
+                    self.snapshot[\"transform\"][\"rotation\"] += float(angle)
+
+
+            handles._create_handle = FakeHandle
+            handles.install()
+
+            from noon import (
+                Circle,
+                DEFAULT_FRAME_WIDTH,
+                PI,
+                Path,
+                RIGHT,
+                Square,
+                UP,
+                VectorPath,
+            )
+
+            curve = Path(
+                VectorPath()
+                .move_to((-1.0, 0.0))
+                .quadratic_to((0.0, 2.0), (1.0, 0.0))
+            ).rotate(PI / 4.0)
+            expected_curve_extent = 9.0 * math.sqrt(2.0) / 8.0
+            assert abs(curve.width - expected_curve_extent) < 1e-12
+            assert abs(curve.height - expected_curve_extent) < 1e-12
+
+            ellipse = Circle(1.0).scale((2.0, 1.0)).rotate(PI / 4.0)
+            expected_ellipse_extent = math.sqrt(10.0)
+            assert abs(ellipse.width - expected_ellipse_extent) < 1e-12
+            assert abs(ellipse.height - expected_ellipse_extent) < 1e-12
+
+            square = Square(1.0).next_to(curve, RIGHT, buff=0.5)
+            gap = (
+                square.get_center().x
+                - square.width * 0.5
+                - curve.get_center().x
+                - curve.width * 0.5
+            )
+            assert abs(gap - 0.5) < 1e-12
+
+            moved = curve.copy().move_to((3.0, -2.0))
+            assert abs(moved.get_center().x - 3.0) < 1e-12
+            assert abs(moved.get_center().y + 2.0) < 1e-12
+
+            aligned = Square(1.0).align_to(curve, UP)
+            aligned_top = aligned.get_center().y + aligned.height * 0.5
+            curve_top = curve.get_center().y + curve.height * 0.5
+            assert abs(aligned_top - curve_top) < 1e-12
+
+            edge = curve.copy().to_edge(RIGHT, buff=0.5)
+            edge_right = edge.get_center().x + edge.width * 0.5
+            assert abs(edge_right - (DEFAULT_FRAME_WIDTH * 0.5 - 0.5)) < 1e-12
+            """
+        )
+
+        completed = subprocess.run(
+            [sys.executable, "-c", source],
+            check=False,
+            cwd=python_dir,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            completed.returncode,
+            0,
+            f"compatibility subprocess failed:\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- route detached/browser semantic-handle layout reads through the exact Manim compatibility world-bounds contract installed by `_manim_phase_b`
- stop using the handle's older `centerX`/`width`/`criticalX`/`nextToHandle`/`alignToHandle`/`alignOnFrame` shortcuts for layout-sensitive behavior
- keep the WASM semantic handle authoritative for object state and mutations; only layout observations materialize the current snapshot
- make `move_to`, `next_to`, `align_to`, `to_edge`/`to_corner`, and group bounds consume the same transformed Bezier/analytic bounds as the fallback/scene-owned path from #193
- add a fake-handle regression that intentionally omits the stale layout shortcuts and verifies rotated quadratic and ellipse bounds plus layout gaps/edges
- update the browser compatibility smoke's stale Circle color assertion after #191 correctly changed Manim `Circle()`'s default color to `RED`

## Why
#193 fixed transformed Bezier extrema and rotated/non-uniform primitive bounds for the fallback/scene-owned compatibility path. The detached browser semantic handle still computed exact local path bounds and then transformed the local AABB, which is conservative for rotated curves and shifts Manim layout operations.

This consolidates observable layout onto one compatibility contract without duplicating extrema math or changing renderer/culling bounds.

The first browser run also exposed an unrelated stale smoke expectation from #191: pinned ManimCE v0.21 defines `Circle(..., color=RED)` by default, while the smoke still expected the older white layer color. The smoke now compares against `RED.red` rather than weakening the parity behavior.

## Scope
Focused continuation of #184. Internal Rust handle bound consolidation can follow separately; this fixes the browser-visible compatibility path while preserving semantic-handle ownership.

Tracks #184.