### PR TITLE
Match Manim aligned layout placement

### DIFF
--- a/web/python/_manim_semantic_handles.py
+++ b/web/python/_manim_semantic_handles.py
@@ -15,6 +15,120 @@ import noon as _base
 import _manim_compat as _compat
 import _manim_phase_b as _phase_b
 
+
+def _alignment_mask2(value: object) -> _base.Vec2:
+    try:
+        length = len(value)  # type: ignore[arg-type]
+    except (TypeError, AttributeError):
+        length = None
+    if length in (2, 3):
+        try:
+            return _base.Vec2(float(value[0]), float(value[1]))  # type: ignore[index]
+        except (TypeError, ValueError, IndexError) as error:
+            raise TypeError("coordinate mask must contain numeric x/y values") from error
+    raise TypeError("coordinate mask must be a two- or three-component vector")
+
+
+def _alignment_is_mobject(value: object) -> bool:
+    return isinstance(value, _base.Mobject)
+
+
+def _alignment_critical(value: object, direction: _base.Vec2) -> _base.Vec2:
+    if not _alignment_is_mobject(value):
+        raise TypeError("critical-point target must be a Mobject")
+    return value.get_critical_point(direction)  # type: ignore[union-attr]
+
+
+def _alignment_indexed(value: object, index: int | None) -> object:
+    if index is None:
+        return value
+    try:
+        return value[index]  # type: ignore[index]
+    except (TypeError, AttributeError, IndexError) as error:
+        raise IndexError("alignment submobject index is unavailable") from error
+
+
+def _manim_move_to(
+    self: _base.Mobject,
+    point_or_mobject: object,
+    aligned_edge: object = _base.ORIGIN,
+    coor_mask: object = (1.0, 1.0, 1.0),
+) -> _base.Mobject:
+    """Pinned ManimCE v0.21.0 ``Mobject.move_to`` in Noon's x/y plane."""
+
+    edge = _base._as_vec2(aligned_edge)
+    if _alignment_is_mobject(point_or_mobject):
+        target = _alignment_critical(point_or_mobject, edge)
+    else:
+        target = _base._as_vec2(point_or_mobject)
+    source = _alignment_critical(self, edge)
+    mask = _alignment_mask2(coor_mask)
+    delta = target - source
+    return self.shift(_base.Vec2(delta.x * mask.x, delta.y * mask.y))
+
+
+def _manim_next_to(
+    self: _base.Mobject,
+    mobject_or_point: object,
+    direction: object = _base.RIGHT,
+    buff: float = _base.DEFAULT_MOBJECT_TO_MOBJECT_BUFFER,
+    aligned_edge: object = _base.ORIGIN,
+    submobject_to_align: object | None = None,
+    index_of_submobject_to_align: int | None = None,
+    coor_mask: object = (1.0, 1.0, 1.0),
+) -> _base.Mobject:
+    """Pinned Manim ``next_to`` semantics, including unnormalized direction."""
+
+    vector = _base._as_vec2(direction)
+    edge = _base._as_vec2(aligned_edge)
+
+    if _alignment_is_mobject(mobject_or_point):
+        target_aligner = _alignment_indexed(
+            mobject_or_point, index_of_submobject_to_align
+        )
+        target = _alignment_critical(target_aligner, edge + vector)
+    else:
+        target = _base._as_vec2(mobject_or_point)
+
+    if submobject_to_align is not None:
+        aligner = submobject_to_align
+    elif index_of_submobject_to_align is not None:
+        aligner = _alignment_indexed(self, index_of_submobject_to_align)
+    else:
+        aligner = self
+    source = _alignment_critical(aligner, edge - vector)
+
+    mask = _alignment_mask2(coor_mask)
+    delta = target - source + vector * float(buff)
+    return self.shift(_base.Vec2(delta.x * mask.x, delta.y * mask.y))
+
+
+def _manim_arrange(
+    self: _compat.Group,
+    direction: object = _base.RIGHT,
+    buff: float = _base.DEFAULT_MOBJECT_TO_MOBJECT_BUFFER,
+    center: bool = True,
+    **kwargs: Any,
+) -> _compat.Group:
+    """Pinned Manim ``arrange`` forwarding placement kwargs to ``next_to``."""
+
+    vector = _base.RIGHT if direction is None else direction
+    for previous, current in zip(self.submobjects, self.submobjects[1:]):
+        current.next_to(previous, vector, buff, **kwargs)
+    if center:
+        self.center()
+    return self
+
+
+# Install compatibility placement before capturing fallbacks below. The generic
+# formulas use dynamic ``shift``/query dispatch, so after semantic-handle install
+# the same code mutates Rust/WASM-owned detached objects and ordinary scene objects.
+_base.Mobject.move_to = _manim_move_to
+_base.Mobject.next_to = _manim_next_to
+_compat.Group.move_to = _manim_move_to
+_compat.Group.next_to = _manim_next_to
+_compat.Group.arrange = _manim_arrange
+
 _ir = _base._ir
 
 try:
@@ -149,12 +263,20 @@ def _get_center(self: _base.Mobject) -> _base.Vec2:
 
 
 def _width(self: _base.Mobject) -> float:
-    bounds = _layout_bounds(self) if _handle_for(self) is not None else _base._bounds(self._current_raw())
+    bounds = (
+        _layout_bounds(self)
+        if _handle_for(self) is not None
+        else _base._bounds(self._current_raw())
+    )
     return 0.0 if bounds is None else bounds[1].x - bounds[0].x
 
 
 def _height(self: _base.Mobject) -> float:
-    bounds = _layout_bounds(self) if _handle_for(self) is not None else _base._bounds(self._current_raw())
+    bounds = (
+        _layout_bounds(self)
+        if _handle_for(self) is not None
+        else _base._bounds(self._current_raw())
+    )
     return 0.0 if bounds is None else bounds[1].y - bounds[0].y
 
 
@@ -175,14 +297,18 @@ def _shift(self: _base.Mobject, direction: object) -> _base.Mobject:
     return self
 
 
-def _move_to(self: _base.Mobject, point: object) -> _base.Mobject:
-    handle = _handle_for(self)
-    if handle is None:
-        return _ORIGINAL_MOVE_TO(self, point)
-    value = _base._as_vec2(point)
-    center = _layout_center(self)
-    handle.shift(value.x - center.x, value.y - center.y)
-    return self
+def _move_to(
+    self: _base.Mobject,
+    point_or_mobject: object,
+    aligned_edge: object = _base.ORIGIN,
+    coor_mask: object = (1.0, 1.0, 1.0),
+) -> _base.Mobject:
+    return _ORIGINAL_MOVE_TO(
+        self,
+        point_or_mobject,
+        aligned_edge=aligned_edge,
+        coor_mask=coor_mask,
+    )
 
 
 def _scale(self: _base.Mobject, factor: object) -> _base.Mobject:
@@ -277,21 +403,24 @@ def _critical(value: _base.Mobject, direction: _base.Vec2) -> _base.Vec2:
 
 def _next_to(
     self: _base.Mobject,
-    other: object,
+    mobject_or_point: object,
     direction: object = _base.RIGHT,
     buff: float = _base.DEFAULT_MOBJECT_TO_MOBJECT_BUFFER,
+    aligned_edge: object = _base.ORIGIN,
+    submobject_to_align: object | None = None,
+    index_of_submobject_to_align: int | None = None,
+    coor_mask: object = (1.0, 1.0, 1.0),
 ) -> _base.Mobject:
-    handle = _handle_for(self)
-    if handle is None:
-        return _ORIGINAL_NEXT_TO(self, other, direction, buff)
-    axis = _base._as_vec2(direction).normalized()
-    source = _critical(self, -axis)
-    target = _critical(other, axis) if isinstance(other, _base.Mobject) else _base._as_vec2(other)
-    handle.shift(
-        target.x - source.x + axis.x * float(buff),
-        target.y - source.y + axis.y * float(buff),
+    return _ORIGINAL_NEXT_TO(
+        self,
+        mobject_or_point,
+        direction,
+        buff,
+        aligned_edge=aligned_edge,
+        submobject_to_align=submobject_to_align,
+        index_of_submobject_to_align=index_of_submobject_to_align,
+        coor_mask=coor_mask,
     )
-    return self
 
 
 def _align_to(
@@ -408,7 +537,11 @@ def _compat_bounds_for(value: object) -> tuple[_base.Vec2, _base.Vec2] | None:
     leaves = _compat._leaf_mobjects(value)
     present: list[tuple[_base.Vec2, _base.Vec2]] = []
     for member in leaves:
-        bounds = _layout_bounds(member) if _handle_for(member) is not None else _base._bounds(member._current_raw())
+        bounds = (
+            _layout_bounds(member)
+            if _handle_for(member) is not None
+            else _base._bounds(member._current_raw())
+        )
         if bounds is not None:
             present.append(bounds)
     if not present:

--- a/web/python/test_manim_layout_alignment.py
+++ b/web/python/test_manim_layout_alignment.py
@@ -1,0 +1,89 @@
+import os
+import subprocess
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+
+
+class ManimLayoutAlignmentTests(unittest.TestCase):
+    def test_next_to_move_to_and_arrange_match_manim_semantics(self) -> None:
+        python_dir = Path(__file__).resolve().parent
+        env = os.environ.copy()
+        existing_pythonpath = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = (
+            str(python_dir)
+            if not existing_pythonpath
+            else os.pathsep.join((str(python_dir), existing_pythonpath))
+        )
+
+        source = textwrap.dedent(
+            """
+            import _manim_compat
+
+            _manim_compat.install()
+            import _manim_phase_b  # noqa: F401 - installs exact Manim layout bounds
+            import _manim_semantic_handles  # noqa: F401 - installs shared placement
+
+            from noon import DOWN, LEFT, Rectangle, RIGHT, Square, UP, UR, VGroup
+
+            target = Square(2.0)
+            diagonal = Square(2.0).next_to(target, UR, buff=0.25)
+            assert abs(diagonal.get_center().x - 2.25) < 1e-12
+            assert abs(diagonal.get_center().y - 2.25) < 1e-12
+
+            reference = Rectangle(width=2.0, height=3.0)
+            top_aligned = Square(1.0).next_to(
+                reference, RIGHT, buff=0.4, aligned_edge=UP
+            )
+            assert abs(top_aligned.get_top().y - reference.get_top().y) < 1e-12
+            assert abs(top_aligned.get_left().x - reference.get_right().x - 0.4) < 1e-12
+
+            moved = Square(1.0).move_to(reference, aligned_edge=UP + LEFT)
+            assert abs(moved.get_top().y - reference.get_top().y) < 1e-12
+            assert abs(moved.get_left().x - reference.get_left().x) < 1e-12
+
+            masked = Square(1.0).shift(DOWN * 2.0).next_to(
+                reference,
+                RIGHT,
+                buff=0.5,
+                aligned_edge=UP,
+                coor_mask=(1.0, 0.0, 0.0),
+            )
+            assert abs(masked.get_center().y + 2.0) < 1e-12
+            assert abs(masked.get_left().x - reference.get_right().x - 0.5) < 1e-12
+
+            short = Rectangle(width=1.0, height=1.0)
+            tall = Rectangle(width=1.0, height=3.0)
+            wide = Rectangle(width=2.0, height=2.0)
+            group = VGroup(short, tall, wide).arrange(
+                RIGHT,
+                buff=0.3,
+                aligned_edge=UP,
+                center=False,
+            )
+            assert group is not None
+            assert abs(short.get_top().y - tall.get_top().y) < 1e-12
+            assert abs(tall.get_top().y - wide.get_top().y) < 1e-12
+            assert abs(tall.get_left().x - short.get_right().x - 0.3) < 1e-12
+            assert abs(wide.get_left().x - tall.get_right().x - 0.3) < 1e-12
+            """
+        )
+
+        completed = subprocess.run(
+            [sys.executable, "-c", source],
+            check=False,
+            cwd=python_dir,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            completed.returncode,
+            0,
+            f"compatibility subprocess failed:\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/python/test_manim_semantic_handle_alignment.py
+++ b/web/python/test_manim_semantic_handle_alignment.py
@@ -1,0 +1,115 @@
+import os
+import subprocess
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+
+
+class ManimSemanticHandleAlignmentTests(unittest.TestCase):
+    def test_semantic_handles_share_manim_placement_formulas(self) -> None:
+        python_dir = Path(__file__).resolve().parent
+        env = os.environ.copy()
+        existing_pythonpath = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = (
+            str(python_dir)
+            if not existing_pythonpath
+            else os.pathsep.join((str(python_dir), existing_pythonpath))
+        )
+
+        source = textwrap.dedent(
+            """
+            import json
+
+            import _manim_compat
+
+            _manim_compat.install()
+            import _manim_phase_b  # noqa: F401 - installs exact Manim layout bounds
+            import _manim_semantic_handles as handles
+
+
+            class FakeHandle:
+                def __init__(self, snapshot_json):
+                    self.snapshot = json.loads(snapshot_json)
+
+                def snapshotJson(self):
+                    return json.dumps(self.snapshot, separators=(\",\", \":\"))
+
+                def replaceSnapshotJson(self, snapshot_json):
+                    self.snapshot = json.loads(snapshot_json)
+
+                def cloneHandle(self):
+                    return FakeHandle(self.snapshotJson())
+
+                def setFillOpacity(self, opacity):
+                    fill = self.snapshot[\"style\"][\"fill\"]
+                    if fill is not None:
+                        fill[\"alpha\"] = float(opacity)
+
+                def setStrokeOpacity(self, opacity):
+                    stroke = self.snapshot[\"style\"][\"stroke\"]
+                    if stroke is not None:
+                        stroke[\"alpha\"] = float(opacity)
+
+                def shift(self, x, y):
+                    translation = self.snapshot[\"transform\"][\"translation\"]
+                    translation[\"x\"] += float(x)
+                    translation[\"y\"] += float(y)
+
+                def scale(self, x, y):
+                    scale = self.snapshot[\"transform\"][\"scale\"]
+                    scale[\"x\"] *= float(x)
+                    scale[\"y\"] *= float(y)
+
+                def rotate(self, angle):
+                    self.snapshot[\"transform\"][\"rotation\"] += float(angle)
+
+
+            handles._create_handle = FakeHandle
+            handles.install()
+
+            from noon import LEFT, Rectangle, RIGHT, Square, UP, UR, VGroup
+
+            target = Square(2.0)
+            diagonal = Square(2.0).next_to(target, UR, buff=0.25)
+            assert abs(diagonal.get_center().x - 2.25) < 1e-12
+            assert abs(diagonal.get_center().y - 2.25) < 1e-12
+
+            reference = Rectangle(width=2.0, height=3.0)
+            aligned = Square(1.0).next_to(
+                reference, RIGHT, buff=0.4, aligned_edge=UP
+            )
+            assert abs(aligned.get_top().y - reference.get_top().y) < 1e-12
+            assert abs(aligned.get_left().x - reference.get_right().x - 0.4) < 1e-12
+
+            moved = Square(1.0).move_to(reference, aligned_edge=UP + LEFT)
+            assert abs(moved.get_top().y - reference.get_top().y) < 1e-12
+            assert abs(moved.get_left().x - reference.get_left().x) < 1e-12
+
+            short = Rectangle(width=1.0, height=1.0)
+            tall = Rectangle(width=1.0, height=3.0)
+            VGroup(short, tall).arrange(
+                RIGHT, buff=0.3, aligned_edge=UP, center=False
+            )
+            assert abs(short.get_top().y - tall.get_top().y) < 1e-12
+            assert abs(tall.get_left().x - short.get_right().x - 0.3) < 1e-12
+            """
+        )
+
+        completed = subprocess.run(
+            [sys.executable, "-c", source],
+            check=False,
+            cwd=python_dir,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            completed.returncode,
+            0,
+            f"compatibility subprocess failed:\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- match ManimCE v0.21.0 `Mobject.next_to` critical-point semantics without normalizing the supplied `direction`
- preserve Manim's `buff * direction` behavior, including full per-axis buffer for diagonal directions such as `UR`
- add `aligned_edge`, `submobject_to_align`, `index_of_submobject_to_align`, and 2D `coor_mask` handling to the shared placement path
- match `move_to(mobject, aligned_edge=..., coor_mask=...)`
- make `VGroup.arrange(..., **kwargs)` forward alignment options to each `next_to`, as Manim does
- install one generic placement formula before semantic-handle fallbacks are captured, so scene-owned and detached WASM-owned objects use the same behavior
- add regressions for ordinary compatibility objects and fake semantic handles covering diagonal buffers, aligned edges, coordinate masks, Mobject-target `move_to`, and aligned `arrange`

## Why
Noon previously normalized `next_to` directions. ManimCE v0.21 does not: it selects critical points with `aligned_edge ± direction` and applies `buff * direction` directly. That makes diagonal placement observably different. Noon also omitted `aligned_edge` propagation through `arrange` and could not use a Mobject target with `move_to` alignment semantics.

These are layout/API parity issues, not renderer behavior, and belong in the authoring compatibility layer.

## Scope
Focused continuation of #184. This does not change renderer/culling bounds or introduce hierarchy into Noon's runtime. Broader layout-family APIs and differential corpus expansion remain separate.

Tracks #184.