### PR TITLE
Add Manim Create/Uncreate Line raster parity probes

### DIFF
--- a/parity/manim-v0.21/manifest.json
+++ b/parity/manim-v0.21/manifest.json
@@ -32,6 +32,16 @@
       "expected_duration": 4.0
     },
     {
+      "id": "create-line",
+      "scene": "CreateLine",
+      "expected_duration": 1.0
+    },
+    {
+      "id": "uncreate-line",
+      "scene": "UncreateLine",
+      "expected_duration": 1.0
+    },
+    {
       "id": "uncreate-square",
       "scene": "UncreateSquare",
       "expected_duration": 1.0

--- a/parity/manim-v0.21/quickstart.py
+++ b/parity/manim-v0.21/quickstart.py
@@ -53,9 +53,22 @@ class AnimatedSquareToCircle(Scene):
         self.play(square.animate.set_fill(PINK, opacity=0.5))
 
 
-# Supplemental source-equivalent parity probe. This is deliberately ordinary
-# Manim source (not a Noon-specific adaptation) and exercises the exact inverse
-# lifecycle/reveal contract paired with Create above.
+# Supplemental source-equivalent parity probes. These are deliberately ordinary
+# Manim source (not Noon-specific adaptations) and exercise reveal/lifecycle
+# contracts that are not covered directly by the quickstart examples above.
+class CreateLine(Scene):
+    def construct(self):
+        line = Line(LEFT, RIGHT)
+        self.play(Create(line))
+
+
+class UncreateLine(Scene):
+    def construct(self):
+        line = Line(LEFT, RIGHT)
+        self.add(line)
+        self.play(Uncreate(line))
+
+
 class UncreateSquare(Scene):
     def construct(self):
         square = Square()


### PR DESCRIPTION
## Summary
- add source-equivalent ManimCE v0.21.0 `Create(Line(LEFT, RIGHT))` and `Uncreate(Line(LEFT, RIGHT))` probes to the canonical raster corpus
- sample them at the existing dense reveal fractions, including 0.95, 0.98, 0.99, and exact 1.0
- cover the #182 acceptance requirement that moving line endpoints/caps remain smooth through the final reveal frames and that Uncreate is the exact inverse lifecycle/reveal behavior

## Why
After #198/#201, Circle Create is now very close to the Manim Cairo oracle on WebGPU. However, #182 explicitly requires `Create(Line(...))`, smooth moving endpoint caps, and no final-frame snap, and the raster corpus did not contain a Line fixture. That left the original line-end jump class of regressions unguarded.

These probes are ordinary Manim source and require no Noon-specific tuning.

## Validation target
- exact 1.0s duration for both fixtures
- matching start/end direction and endpoint progression
- no systematic late-frame delta at 0.95/0.98/0.99/final
- lifecycle removal for `Uncreate` at the exact boundary

Tracks #182.