### PR TITLE
Add styled Create/Uncreate raster parity probes

### DIFF
--- a/crates/noon-render-wgpu/src/lib.rs
+++ b/crates/noon-render-wgpu/src/lib.rs
@@ -1281,6 +1281,7 @@ impl FramePreparer {
             }
             PreparedSlot::Rectangle(index) => {
                 matches!(render_geometry, GeometryRef::Rectangle { .. })
+                    && frame.reveal(object_index) >= 1.0
                     && self.rectangle_ids.get(*index) == Some(&object.id)
             }
             PreparedSlot::Line(index) => {

--- a/crates/noon-render-wgpu/tests/analytic_uncreate_transition.rs
+++ b/crates/noon-render-wgpu/tests/analytic_uncreate_transition.rs
@@ -3,10 +3,12 @@ use noon_render_wgpu::FramePreparer;
 use noon_runtime::{FrameChanges, FrameObjectState, FrameState};
 
 fn rectangle_frame(reveal: f32) -> FrameState {
-    let mut style = Style::default();
-    style.fill = Some(Color::rgba(0.35, 0.75, 0.95, 0.35));
-    style.stroke = Some(Color::rgba(0.95, 0.3, 0.75, 0.65));
-    style.stroke_width = 0.08;
+    let style = Style {
+        fill: Some(Color::rgba(0.35, 0.75, 0.95, 0.35)),
+        stroke: Some(Color::rgba(0.95, 0.3, 0.75, 0.65)),
+        stroke_width: 0.08,
+        ..Style::default()
+    };
 
     FrameState {
         time: 0.0,

--- a/crates/noon-render-wgpu/tests/analytic_uncreate_transition.rs
+++ b/crates/noon-render-wgpu/tests/analytic_uncreate_transition.rs
@@ -1,0 +1,53 @@
+use noon_core::{Color, GeometryRef, ObjectId, Style, Transform2D};
+use noon_render_wgpu::FramePreparer;
+use noon_runtime::{FrameChanges, FrameObjectState, FrameState};
+
+fn rectangle_frame(reveal: f32) -> FrameState {
+    let mut style = Style::default();
+    style.fill = Some(Color::rgba(0.35, 0.75, 0.95, 0.35));
+    style.stroke = Some(Color::rgba(0.95, 0.3, 0.75, 0.65));
+    style.stroke_width = 0.08;
+
+    FrameState {
+        time: 0.0,
+        objects: vec![FrameObjectState {
+            id: ObjectId::new(1),
+            geometry: GeometryRef::rectangle(2.0, 2.0),
+            transform: Transform2D::IDENTITY,
+            style,
+            appearance: 1.0,
+        }],
+        presences: vec![true],
+        reveals: vec![reveal],
+        morphs: vec![0.0],
+        render_geometries: vec![None],
+    }
+}
+
+#[test]
+fn descending_rectangle_reveal_switches_from_analytic_to_partial_path_once() {
+    let mut frame = rectangle_frame(1.0);
+    let mut preparer = FramePreparer::new();
+
+    let full = preparer.prepare(&frame);
+    assert_eq!(full.rectangles.len(), 1);
+    assert!(full.paths.is_empty());
+
+    frame.time = 0.5;
+    frame.reveals[0] = 0.5;
+    let partial = preparer.prepare_incremental(&frame, &FrameChanges::objects(vec![0]));
+    assert!(partial.rectangles.is_empty());
+    assert_eq!(partial.paths.len(), 1);
+    assert_eq!(partial.paths[0].path_params, [1.0, 0.0]);
+    assert!(partial.path_geometry_dirty);
+    assert_eq!(partial.stats.full_rebuilds, 1);
+
+    frame.time = 0.75;
+    frame.reveals[0] = 0.25;
+    let later = preparer.prepare_incremental(&frame, &FrameChanges::objects(vec![0]));
+    assert!(later.rectangles.is_empty());
+    assert_eq!(later.paths.len(), 1);
+    assert_eq!(later.paths[0].path_params, [1.0, 0.0]);
+    assert!(later.path_geometry_dirty);
+    assert_eq!(later.stats.full_rebuilds, 0);
+}

--- a/parity/manim-v0.21/manifest.json
+++ b/parity/manim-v0.21/manifest.json
@@ -42,6 +42,16 @@
       "expected_duration": 1.0
     },
     {
+      "id": "create-styled-square",
+      "scene": "CreateStyledSquare",
+      "expected_duration": 1.0
+    },
+    {
+      "id": "uncreate-styled-square",
+      "scene": "UncreateStyledSquare",
+      "expected_duration": 1.0
+    },
+    {
       "id": "uncreate-square",
       "scene": "UncreateSquare",
       "expected_duration": 1.0

--- a/parity/manim-v0.21/quickstart.py
+++ b/parity/manim-v0.21/quickstart.py
@@ -69,6 +69,23 @@ class UncreateLine(Scene):
         self.play(Uncreate(line))
 
 
+class CreateStyledSquare(Scene):
+    def construct(self):
+        square = Square()
+        square.set_fill(PINK, opacity=0.35)
+        square.set_stroke(BLUE, width=8, opacity=0.65)
+        self.play(Create(square))
+
+
+class UncreateStyledSquare(Scene):
+    def construct(self):
+        square = Square()
+        square.set_fill(PINK, opacity=0.35)
+        square.set_stroke(BLUE, width=8, opacity=0.65)
+        self.add(square)
+        self.play(Uncreate(square))
+
+
 class UncreateSquare(Scene):
     def construct(self):
         square = Square()


### PR DESCRIPTION
## Summary
- add source-equivalent styled Square probes for both `Create` and `Uncreate`
- use independent fill/stroke colors, fill opacity 0.35, stroke opacity 0.65, and stroke width 8
- exercise the existing dense alpha sampling through exact completion

## Why
#182 requires filled VMobject reveal behavior and independent fill/stroke alpha to match Manim at every intermediate frame. Existing fixtures contain fills, but do not isolate explicit independent stroke opacity/width together with fill opacity, and the existing Uncreate fixture is unfilled.

These probes use ordinary ManimCE v0.21.0 source with no Noon-specific tuning. They distinguish reveal-state errors from backend color-transfer differences.

## Validation target
- exact 1.0s Create/Uncreate duration
- partial fill is the fill of the same partial VMobject path, not a separate opacity animation
- explicit fill/stroke alpha remain independent during the full reveal
- no late-frame jump at 0.95/0.98/0.99/1.0
- Uncreate is the visual/lifecycle inverse of Create

Tracks #182.
Also strengthens style coverage relevant to #179/#180.