### PR TITLE
Add retained execution spatial index

### DIFF
--- a/crates/noon-runtime/src/execution_slots.rs
+++ b/crates/noon-runtime/src/execution_slots.rs
@@ -1,9 +1,12 @@
 use std::collections::HashMap;
 
 use noon_compile::{CompilePatchError, CompiledScene, CompiledTransactionPreflightStats};
-use noon_core::{MutationTransaction, ObjectId, Property, ScenePatch, TrackId};
+use noon_core::{MutationTransaction, ObjectId, Property, Rect, ScenePatch, TrackId, Vec2};
 
-use crate::{EvaluationError, FrameChanges, FrameState, SceneInstance};
+use crate::{
+    EvaluationError, ExecutionSpatialIndex, FrameChanges, FrameState, SceneInstance,
+    SpatialIndexUpdateStats, SpatialQueryResult,
+};
 
 /// Stable runtime identity independent of semantic IDs and dense frame indices.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -438,6 +441,8 @@ struct PatchContext {
 pub struct SlottedSceneInstance {
     inner: SceneInstance,
     slots: ExecutionSlotTable,
+    spatial_index: ExecutionSpatialIndex,
+    last_spatial_update: SpatialIndexUpdateStats,
     last_delta: ExecutionDelta,
     layout_generation: u64,
 }
@@ -445,9 +450,30 @@ pub struct SlottedSceneInstance {
 impl SlottedSceneInstance {
     pub fn new(compiled: CompiledScene) -> Self {
         let slots = ExecutionSlotTable::from_compiled(&compiled);
+        let mut inner = SceneInstance::new(compiled);
+        let live_slots = inner
+            .compiled
+            .objects()
+            .iter()
+            .enumerate()
+            .filter(|&(_index, object)| object.live)
+            .map(|(index, object)| {
+                (
+                    slots
+                        .slot_for_object(object.id)
+                        .expect("live object has slot"),
+                    index,
+                )
+            })
+            .collect::<Vec<_>>();
+        let mut spatial_index = ExecutionSpatialIndex::default();
+        let last_spatial_update = spatial_index.rebuild(inner.frame(), live_slots);
+        let _ = inner.take_spatial_changes();
         Self {
-            inner: SceneInstance::new(compiled),
+            inner,
             slots,
+            spatial_index,
+            last_spatial_update,
             last_delta: ExecutionDelta::default(),
             layout_generation: 0,
         }
@@ -463,6 +489,22 @@ impl SlottedSceneInstance {
 
     pub fn slot_table(&self) -> &ExecutionSlotTable {
         &self.slots
+    }
+
+    pub fn spatial_index(&self) -> &ExecutionSpatialIndex {
+        &self.spatial_index
+    }
+
+    pub const fn last_spatial_update_stats(&self) -> SpatialIndexUpdateStats {
+        self.last_spatial_update
+    }
+
+    pub fn hit_test(&self, point: Vec2) -> SpatialQueryResult {
+        self.spatial_index.hit_test(point)
+    }
+
+    pub fn query_viewport(&self, bounds: Rect) -> SpatialQueryResult {
+        self.spatial_index.query_rect(bounds)
     }
 
     pub fn slot_for_object(&self, object: ObjectId) -> Option<ExecutionSlotId> {
@@ -523,11 +565,15 @@ impl SlottedSceneInstance {
     }
 
     pub fn seek(&mut self, time: f64) -> Result<&FrameState, EvaluationError> {
-        self.inner.seek(time)
+        self.inner.seek(time)?;
+        self.sync_spatial_index();
+        Ok(self.inner.frame())
     }
 
     pub fn advance_to(&mut self, time: f64) -> Result<&FrameState, EvaluationError> {
-        self.inner.advance_to(time)
+        self.inner.advance_to(time)?;
+        self.sync_spatial_index();
+        Ok(self.inner.frame())
     }
 
     pub fn take_frame_changes(&mut self) -> FrameChanges {
@@ -598,6 +644,7 @@ impl SlottedSceneInstance {
         self.inner = replacement;
         self.layout_generation = next_generation;
         self.last_delta = ExecutionDelta::default();
+        self.sync_spatial_index();
 
         let after = self.frame_slot_capacity();
         debug_assert_eq!(after, live);
@@ -722,7 +769,56 @@ impl SlottedSceneInstance {
         }
 
         self.last_delta = delta;
+        self.sync_spatial_index();
         Ok(self.inner.frame())
+    }
+
+    fn sync_spatial_index(&mut self) {
+        let changes = self.inner.take_spatial_changes();
+        if changes.is_empty() {
+            self.last_spatial_update = SpatialIndexUpdateStats::default();
+            return;
+        }
+        if changes.is_all() {
+            let live_slots = self
+                .inner
+                .compiled
+                .objects()
+                .iter()
+                .enumerate()
+                .filter(|&(_index, object)| object.live)
+                .map(|(index, object)| {
+                    (
+                        self.slots
+                            .slot_for_object(object.id)
+                            .expect("live compiled object has an execution slot"),
+                        index,
+                    )
+                })
+                .collect::<Vec<_>>();
+            self.last_spatial_update = self.spatial_index.rebuild(self.inner.frame(), live_slots);
+            return;
+        }
+
+        let mut stats = SpatialIndexUpdateStats::default();
+        for &object_index in changes.object_indices() {
+            let Some(object) = self.inner.frame().objects.get(object_index) else {
+                continue;
+            };
+            if self.inner.object_slot_is_live(object_index) {
+                if let Some(slot) = self.slots.slot_for_object(object.id) {
+                    stats.merge_from(self.spatial_index.upsert_frame_slot(
+                        self.inner.frame(),
+                        slot,
+                        object_index,
+                        object_index as u64,
+                    ));
+                }
+            } else {
+                stats.merge_from(self.spatial_index.remove_object(object.id));
+            }
+        }
+        self.last_spatial_update = stats;
     }
 
     fn capture_context(&self, patch: &ScenePatch) -> PatchContext {
@@ -1045,5 +1141,72 @@ mod tests {
         assert!(policy.recommends(7_500, 10_000));
         assert!(!policy.recommends(900, 1_000));
         assert!(!policy.recommends(10_000, 10_000));
+    }
+
+    #[test]
+    fn transform_patch_refits_one_spatial_leaf_without_rebuild() {
+        let mut definition = SceneDefinition::new();
+        let object = definition.add(GeometryRef::circle(0.5));
+        let compiled = CompiledScene::compile(&definition).unwrap();
+        let mut live = SlottedSceneInstance::new(compiled);
+        let slot = live.slot_for_object(object).unwrap();
+        assert_eq!(live.hit_test(Vec2::ZERO).slots(), &[slot]);
+
+        live.apply_patch(&ScenePatch::SetTransform {
+            object,
+            transform: noon_core::Transform2D {
+                translation: Vec2::new(20.0, 0.0),
+                ..noon_core::Transform2D::IDENTITY
+            },
+        })
+        .unwrap();
+
+        let stats = live.last_spatial_update_stats();
+        assert_eq!(stats.full_rebuilds, 0);
+        assert_eq!(stats.leaves_upserted, 1);
+        assert!(live.hit_test(Vec2::ZERO).slots().is_empty());
+        assert_eq!(live.hit_test(Vec2::new(20.0, 0.0)).slots(), &[slot]);
+    }
+
+    #[test]
+    fn forward_timeline_motion_refits_only_active_object_leaf() {
+        let mut definition = SceneDefinition::new();
+        let moving = definition.add(GeometryRef::circle(0.5));
+        let static_object = definition.add(GeometryRef::circle(0.5));
+        definition
+            .object_mut(static_object)
+            .unwrap()
+            .transform
+            .translation = Vec2::new(0.0, 10.0);
+        definition
+            .animate_position(
+                moving,
+                Vec2::ZERO,
+                Vec2::new(10.0, 0.0),
+                TrackTiming::new(0.0, 2.0, Easing::Linear),
+            )
+            .unwrap();
+        let mut live = SlottedSceneInstance::new(CompiledScene::compile(&definition).unwrap());
+        live.advance_to(1.0).unwrap();
+        let stats = live.last_spatial_update_stats();
+        assert_eq!(stats.full_rebuilds, 0);
+        assert_eq!(stats.leaves_upserted, 1);
+        assert_eq!(live.hit_test(Vec2::new(5.0, 0.0)).slots().len(), 1);
+    }
+
+    #[test]
+    fn structural_removal_retires_spatial_leaf_locally() {
+        let mut definition = SceneDefinition::new();
+        let first = definition.add(GeometryRef::circle(0.5));
+        let second = definition.add(GeometryRef::circle(0.5));
+        definition.object_mut(second).unwrap().transform.translation = Vec2::new(10.0, 0.0);
+        let mut live = SlottedSceneInstance::new(CompiledScene::compile(&definition).unwrap());
+        assert_eq!(live.spatial_index().len(), 2);
+        live.apply_patch(&ScenePatch::RemoveObject(first)).unwrap();
+        let stats = live.last_spatial_update_stats();
+        assert_eq!(stats.full_rebuilds, 0);
+        assert_eq!(stats.leaves_removed, 1);
+        assert_eq!(live.spatial_index().len(), 1);
+        assert!(live.hit_test(Vec2::ZERO).slots().is_empty());
     }
 }

--- a/crates/noon-runtime/src/lib.rs
+++ b/crates/noon-runtime/src/lib.rs
@@ -4,9 +4,11 @@
 
 mod execution_slots;
 mod reactive;
+mod spatial_index;
 
 pub use execution_slots::*;
 pub use reactive::*;
+pub use spatial_index::*;
 
 use std::collections::BTreeMap;
 
@@ -237,6 +239,7 @@ pub struct SceneInstance {
     last_stats: EvaluationStats,
     last_patch_stats: RuntimePatchStats,
     changes: FrameChanges,
+    spatial_changes: FrameChanges,
     reactive: Option<ReactiveRuntime>,
     last_reactive_stats: ReactiveRuntimeStats,
 }
@@ -254,6 +257,7 @@ impl SceneInstance {
             last_stats: EvaluationStats::default(),
             last_patch_stats: RuntimePatchStats::default(),
             changes: FrameChanges::all(),
+            spatial_changes: FrameChanges::all(),
             reactive: None,
             last_reactive_stats: ReactiveRuntimeStats::default(),
         };
@@ -275,6 +279,30 @@ impl SceneInstance {
 
     pub fn take_frame_changes(&mut self) -> FrameChanges {
         std::mem::take(&mut self.changes)
+    }
+
+    pub(crate) fn take_spatial_changes(&mut self) -> FrameChanges {
+        std::mem::take(&mut self.spatial_changes)
+    }
+
+    pub(crate) fn mark_changed(&mut self, object_index: usize) {
+        self.changes.insert(object_index);
+        self.spatial_changes.insert(object_index);
+    }
+
+    pub(crate) fn mark_added(&mut self, object_index: usize) {
+        self.changes.insert_added(object_index);
+        self.spatial_changes.insert_added(object_index);
+    }
+
+    pub(crate) fn mark_removed(&mut self, object_index: usize) {
+        self.changes.insert_removed(object_index);
+        self.spatial_changes.insert_removed(object_index);
+    }
+
+    pub(crate) fn mark_all_changed(&mut self) {
+        self.changes.invalidate_all();
+        self.spatial_changes.invalidate_all();
     }
 
     pub fn contains_object(&self, id: ObjectId) -> bool {
@@ -380,7 +408,7 @@ impl SceneInstance {
                 append_object_frame(&self.compiled, &mut self.frame, object_index);
                 self.rebind_reactive_object(object.id, object_index);
                 self.reapply_reactive_for_object(object_index);
-                self.changes.insert_added(object_index);
+                self.mark_added(object_index);
             }
             ScenePatch::RemoveObject(_) => {
                 let (object_index, old_channels) = removed.expect("remove context captured above");
@@ -394,7 +422,7 @@ impl SceneInstance {
                 let object_index = object_index as usize;
                 self.frame.presences[object_index] = false;
                 self.frame.render_geometries[object_index] = None;
-                self.changes.insert_removed(object_index);
+                self.mark_removed(object_index);
             }
             _ => unreachable!("structural patch helper accepts only create/remove"),
         }
@@ -458,7 +486,7 @@ impl SceneInstance {
         for object_index in affected_objects.into_iter().flatten() {
             self.relower_object(object_index, self.frame.time, &mut evaluation);
             self.reapply_reactive_for_object(object_index);
-            self.changes.insert(object_index);
+            self.mark_changed(object_index);
             patch_stats.objects_recomputed += 1;
         }
         patch_stats.groups_evaluated = evaluation.groups_evaluated;
@@ -497,7 +525,7 @@ impl SceneInstance {
         }
         self.reapply_reactive_for_object(index);
         if self.frame.objects[index] != before {
-            self.changes.insert(index);
+            self.mark_changed(index);
         }
         Ok(())
     }
@@ -534,7 +562,7 @@ impl SceneInstance {
 
     fn seek_unchecked(&mut self, time: f64) {
         self.frame = base_frame(&self.compiled, time);
-        self.changes.invalidate_all();
+        self.mark_all_changed();
         let mut stats = EvaluationStats::default();
 
         for group in self.groups.values_mut() {
@@ -565,7 +593,7 @@ impl SceneInstance {
                 stats.tracks_advanced += 1;
             }
             if apply_group(&mut self.frame, tracks, group, time) {
-                self.changes.insert(channel.object_index as usize);
+                self.mark_changed(channel.object_index as usize);
             }
             stats.groups_evaluated += 1;
         }

--- a/crates/noon-runtime/src/reactive_impl.rs
+++ b/crates/noon-runtime/src/reactive_impl.rs
@@ -201,7 +201,7 @@ impl SceneInstance {
                 target.property,
                 &change.value,
             ) {
-                self.changes.insert(target.object_index);
+                self.mark_changed(target.object_index);
                 changed_targets += 1;
             }
         }

--- a/crates/noon-runtime/src/spatial_index.rs
+++ b/crates/noon-runtime/src/spatial_index.rs
@@ -1,0 +1,538 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use noon_core::{GeometryRef, ObjectId, Rect, Vec2};
+
+use crate::{ExecutionSlotId, FrameState};
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct SpatialIndexConfig {
+    pub cell_size: f32,
+    pub max_cells_per_object: usize,
+    pub max_cells_per_query: usize,
+}
+
+impl Default for SpatialIndexConfig {
+    fn default() -> Self {
+        Self {
+            cell_size: 2.0,
+            max_cells_per_object: 256,
+            max_cells_per_query: 4_096,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SpatialIndexUpdateStats {
+    pub full_rebuilds: usize,
+    pub leaves_upserted: usize,
+    pub leaves_removed: usize,
+    pub cells_inserted: usize,
+    pub cells_removed: usize,
+}
+
+impl SpatialIndexUpdateStats {
+    pub fn merge_from(&mut self, other: Self) {
+        self.full_rebuilds += other.full_rebuilds;
+        self.leaves_upserted += other.leaves_upserted;
+        self.leaves_removed += other.leaves_removed;
+        self.cells_inserted += other.cells_inserted;
+        self.cells_removed += other.cells_removed;
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SpatialQueryStats {
+    pub cells_visited: usize,
+    pub candidates_tested: usize,
+    pub results: usize,
+    pub full_scan_fallbacks: usize,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct SpatialQueryResult {
+    slots: Vec<ExecutionSlotId>,
+    stats: SpatialQueryStats,
+}
+
+impl SpatialQueryResult {
+    pub fn slots(&self) -> &[ExecutionSlotId] {
+        &self.slots
+    }
+
+    pub const fn stats(&self) -> SpatialQueryStats {
+        self.stats
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct CellKey {
+    x: i32,
+    y: i32,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct SpatialEntry {
+    object: ObjectId,
+    bounds: Rect,
+    painter_order: u64,
+    cells: Vec<CellKey>,
+    global: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct ExecutionSpatialIndex {
+    config: SpatialIndexConfig,
+    cells: BTreeMap<CellKey, Vec<ExecutionSlotId>>,
+    global_slots: BTreeSet<ExecutionSlotId>,
+    entries: BTreeMap<ExecutionSlotId, SpatialEntry>,
+    object_slots: BTreeMap<ObjectId, ExecutionSlotId>,
+}
+
+impl Default for ExecutionSpatialIndex {
+    fn default() -> Self {
+        Self::new(SpatialIndexConfig::default())
+    }
+}
+
+impl ExecutionSpatialIndex {
+    pub fn new(config: SpatialIndexConfig) -> Self {
+        assert!(
+            config.cell_size.is_finite() && config.cell_size > 0.0,
+            "spatial index cell size must be finite and positive"
+        );
+        assert!(
+            config.max_cells_per_object > 0 && config.max_cells_per_query > 0,
+            "spatial index cell limits must be non-zero"
+        );
+        Self {
+            config,
+            cells: BTreeMap::new(),
+            global_slots: BTreeSet::new(),
+            entries: BTreeMap::new(),
+            object_slots: BTreeMap::new(),
+        }
+    }
+
+    pub const fn config(&self) -> SpatialIndexConfig {
+        self.config
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn contains_slot(&self, slot: ExecutionSlotId) -> bool {
+        self.entries.contains_key(&slot)
+    }
+
+    pub fn bounds_for_slot(&self, slot: ExecutionSlotId) -> Option<Rect> {
+        self.entries.get(&slot).map(|entry| entry.bounds)
+    }
+
+    pub fn rebuild(
+        &mut self,
+        frame: &FrameState,
+        live_slots: impl IntoIterator<Item = (ExecutionSlotId, usize)>,
+    ) -> SpatialIndexUpdateStats {
+        self.cells.clear();
+        self.global_slots.clear();
+        self.entries.clear();
+        self.object_slots.clear();
+        let mut stats = SpatialIndexUpdateStats {
+            full_rebuilds: 1,
+            ..SpatialIndexUpdateStats::default()
+        };
+        for (slot, frame_index) in live_slots {
+            stats.merge_from(self.upsert_frame_slot(frame, slot, frame_index, frame_index as u64));
+        }
+        stats
+    }
+
+    pub fn upsert_frame_slot(
+        &mut self,
+        frame: &FrameState,
+        slot: ExecutionSlotId,
+        frame_index: usize,
+        painter_order: u64,
+    ) -> SpatialIndexUpdateStats {
+        let Some(object) = frame.objects.get(frame_index) else {
+            return SpatialIndexUpdateStats::default();
+        };
+        if !frame.presences.get(frame_index).copied().unwrap_or(false)
+            || object.appearance <= 0.0
+            || object.style.opacity <= 0.0
+        {
+            return self.remove_object(object.id);
+        }
+        let Some(bounds) = frame_object_conservative_bounds(frame, frame_index) else {
+            return self.remove_object(object.id);
+        };
+        self.upsert_bounds(slot, object.id, bounds, painter_order)
+    }
+
+    pub fn upsert_bounds(
+        &mut self,
+        slot: ExecutionSlotId,
+        object: ObjectId,
+        bounds: Rect,
+        painter_order: u64,
+    ) -> SpatialIndexUpdateStats {
+        if !rect_is_finite(bounds) {
+            return SpatialIndexUpdateStats::default();
+        }
+
+        if let Some(existing_slot) = self.object_slots.get(&object).copied() {
+            if existing_slot != slot {
+                self.remove_slot(existing_slot);
+            }
+        }
+
+        let coverage = self.object_coverage(bounds);
+        let (cells, global) = match coverage {
+            Coverage::Cells(cells) => (cells, false),
+            Coverage::Global => (Vec::new(), true),
+        };
+        let replacement = SpatialEntry {
+            object,
+            bounds,
+            painter_order,
+            cells,
+            global,
+        };
+        if self.entries.get(&slot) == Some(&replacement) {
+            return SpatialIndexUpdateStats::default();
+        }
+
+        let mut stats = self.remove_slot(slot);
+        if replacement.global {
+            self.global_slots.insert(slot);
+        } else {
+            for cell in &replacement.cells {
+                let slots = self.cells.entry(*cell).or_default();
+                insert_sorted_unique(slots, slot);
+                stats.cells_inserted += 1;
+            }
+        }
+        self.object_slots.insert(object, slot);
+        self.entries.insert(slot, replacement);
+        stats.leaves_upserted += 1;
+        stats
+    }
+
+    pub fn remove_object(&mut self, object: ObjectId) -> SpatialIndexUpdateStats {
+        let Some(slot) = self.object_slots.get(&object).copied() else {
+            return SpatialIndexUpdateStats::default();
+        };
+        self.remove_slot(slot)
+    }
+
+    pub fn remove_slot(&mut self, slot: ExecutionSlotId) -> SpatialIndexUpdateStats {
+        let Some(entry) = self.entries.remove(&slot) else {
+            return SpatialIndexUpdateStats::default();
+        };
+        self.object_slots.remove(&entry.object);
+        let mut stats = SpatialIndexUpdateStats {
+            leaves_removed: 1,
+            ..SpatialIndexUpdateStats::default()
+        };
+        if entry.global {
+            self.global_slots.remove(&slot);
+        } else {
+            for cell in entry.cells {
+                let remove_cell = if let Some(slots) = self.cells.get_mut(&cell) {
+                    if let Ok(index) = slots.binary_search(&slot) {
+                        slots.remove(index);
+                        stats.cells_removed += 1;
+                    }
+                    slots.is_empty()
+                } else {
+                    false
+                };
+                if remove_cell {
+                    self.cells.remove(&cell);
+                }
+            }
+        }
+        stats
+    }
+
+    pub fn query_rect(&self, bounds: Rect) -> SpatialQueryResult {
+        self.query(bounds, false)
+    }
+
+    pub fn hit_test(&self, point: Vec2) -> SpatialQueryResult {
+        self.query(Rect::new(point, point), true)
+    }
+
+    fn query(&self, bounds: Rect, topmost_first: bool) -> SpatialQueryResult {
+        if !rect_is_finite(bounds) {
+            return SpatialQueryResult::default();
+        }
+        let mut stats = SpatialQueryStats::default();
+        let mut candidates = BTreeSet::new();
+        candidates.extend(self.global_slots.iter().copied());
+
+        match self.query_coverage(bounds) {
+            Coverage::Cells(cells) => {
+                stats.cells_visited = cells.len();
+                for cell in cells {
+                    if let Some(slots) = self.cells.get(&cell) {
+                        candidates.extend(slots.iter().copied());
+                    }
+                }
+            }
+            Coverage::Global => {
+                stats.full_scan_fallbacks = 1;
+                candidates.extend(self.entries.keys().copied());
+            }
+        }
+
+        let mut slots = Vec::new();
+        for slot in candidates {
+            let Some(entry) = self.entries.get(&slot) else {
+                continue;
+            };
+            stats.candidates_tested += 1;
+            if rects_intersect(entry.bounds, bounds) {
+                slots.push(slot);
+            }
+        }
+        slots.sort_by(|left, right| {
+            let left_entry = &self.entries[left];
+            let right_entry = &self.entries[right];
+            left_entry
+                .painter_order
+                .cmp(&right_entry.painter_order)
+                .then_with(|| left.cmp(right))
+        });
+        if topmost_first {
+            slots.reverse();
+        }
+        stats.results = slots.len();
+        SpatialQueryResult { slots, stats }
+    }
+
+    fn object_coverage(&self, bounds: Rect) -> Coverage {
+        self.coverage(bounds, self.config.max_cells_per_object)
+    }
+
+    fn query_coverage(&self, bounds: Rect) -> Coverage {
+        self.coverage(bounds, self.config.max_cells_per_query)
+    }
+
+    fn coverage(&self, bounds: Rect, max_cells: usize) -> Coverage {
+        let Some(min_x) = cell_coordinate(bounds.min.x, self.config.cell_size) else {
+            return Coverage::Global;
+        };
+        let Some(max_x) = cell_coordinate(bounds.max.x, self.config.cell_size) else {
+            return Coverage::Global;
+        };
+        let Some(min_y) = cell_coordinate(bounds.min.y, self.config.cell_size) else {
+            return Coverage::Global;
+        };
+        let Some(max_y) = cell_coordinate(bounds.max.y, self.config.cell_size) else {
+            return Coverage::Global;
+        };
+        let width = i64::from(max_x) - i64::from(min_x) + 1;
+        let height = i64::from(max_y) - i64::from(min_y) + 1;
+        if width <= 0
+            || height <= 0
+            || width
+                .checked_mul(height)
+                .is_none_or(|count| count as u128 > max_cells as u128)
+        {
+            return Coverage::Global;
+        }
+        let mut cells = Vec::with_capacity((width * height) as usize);
+        for y in min_y..=max_y {
+            for x in min_x..=max_x {
+                cells.push(CellKey { x, y });
+            }
+        }
+        Coverage::Cells(cells)
+    }
+}
+
+#[derive(Clone, Debug)]
+enum Coverage {
+    Cells(Vec<CellKey>),
+    Global,
+}
+
+pub fn frame_object_conservative_bounds(frame: &FrameState, object_index: usize) -> Option<Rect> {
+    let object = frame.objects.get(object_index)?;
+    let local = geometry_local_bounds(frame.render_geometry(object_index))?;
+    let mut world = transform_rect(local, object.transform);
+    if object.style.stroke.is_some() && object.style.stroke_width.is_finite() {
+        let scale = object
+            .transform
+            .scale
+            .x
+            .abs()
+            .max(object.transform.scale.y.abs());
+        let expansion = object.style.stroke_width.abs() * scale * 0.5;
+        world.min.x -= expansion;
+        world.min.y -= expansion;
+        world.max.x += expansion;
+        world.max.y += expansion;
+    }
+    rect_is_finite(world).then_some(world)
+}
+
+fn geometry_local_bounds(geometry: &GeometryRef) -> Option<Rect> {
+    match geometry {
+        GeometryRef::Circle { radius } => {
+            let radius = radius.abs();
+            Some(Rect::new(
+                Vec2::new(-radius, -radius),
+                Vec2::new(radius, radius),
+            ))
+        }
+        GeometryRef::Rectangle { size } => {
+            let half = Vec2::new(size.x.abs() * 0.5, size.y.abs() * 0.5);
+            Some(Rect::new(-half, half))
+        }
+        GeometryRef::Line { start, end } => Rect::from_points([*start, *end]),
+        GeometryRef::VectorPath(path) => path.conservative_bounds(),
+        GeometryRef::External(_) => None,
+    }
+}
+
+fn transform_rect(bounds: Rect, transform: noon_core::Transform2D) -> Rect {
+    let corners = [
+        bounds.min,
+        Vec2::new(bounds.max.x, bounds.min.y),
+        bounds.max,
+        Vec2::new(bounds.min.x, bounds.max.y),
+    ];
+    Rect::from_points(
+        corners
+            .into_iter()
+            .map(|point| transform.transform_point(point)),
+    )
+    .expect("rectangle has four corners")
+}
+
+fn rects_intersect(left: Rect, right: Rect) -> bool {
+    left.min.x <= right.max.x
+        && left.max.x >= right.min.x
+        && left.min.y <= right.max.y
+        && left.max.y >= right.min.y
+}
+
+fn rect_is_finite(bounds: Rect) -> bool {
+    bounds.min.x.is_finite()
+        && bounds.min.y.is_finite()
+        && bounds.max.x.is_finite()
+        && bounds.max.y.is_finite()
+        && bounds.min.x <= bounds.max.x
+        && bounds.min.y <= bounds.max.y
+}
+
+fn cell_coordinate(value: f32, cell_size: f32) -> Option<i32> {
+    if !value.is_finite() {
+        return None;
+    }
+    let value = (value / cell_size).floor();
+    if value < i32::MIN as f32 || value > i32::MAX as f32 {
+        None
+    } else {
+        Some(value as i32)
+    }
+}
+
+fn insert_sorted_unique(slots: &mut Vec<ExecutionSlotId>, slot: ExecutionSlotId) {
+    if let Err(index) = slots.binary_search(&slot) {
+        slots.insert(index, slot);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use noon_core::{ObjectId, Rect, Vec2};
+
+    use super::*;
+
+    #[test]
+    fn point_query_in_hundred_thousand_objects_does_not_scan_scene() {
+        let mut index = ExecutionSpatialIndex::default();
+        let columns = 400usize;
+        for object_index in 0..100_000usize {
+            let x = (object_index % columns) as f32 * 3.0;
+            let y = (object_index / columns) as f32 * 3.0;
+            index.upsert_bounds(
+                ExecutionSlotId::new(object_index as u32, 0),
+                ObjectId::new(object_index as u64),
+                Rect::new(Vec2::new(x, y), Vec2::new(x + 1.0, y + 1.0)),
+                object_index as u64,
+            );
+        }
+
+        let target = 50_123usize;
+        let x = (target % columns) as f32 * 3.0 + 0.5;
+        let y = (target / columns) as f32 * 3.0 + 0.5;
+        let result = index.hit_test(Vec2::new(x, y));
+        assert_eq!(result.slots(), &[ExecutionSlotId::new(target as u32, 0)]);
+        assert_eq!(result.stats().cells_visited, 1);
+        assert!(result.stats().candidates_tested < 8);
+        assert_eq!(result.stats().full_scan_fallbacks, 0);
+    }
+
+    #[test]
+    fn moving_one_leaf_updates_only_its_cells() {
+        let mut index = ExecutionSpatialIndex::default();
+        let slot = ExecutionSlotId::new(7, 0);
+        index.upsert_bounds(
+            slot,
+            ObjectId::new(7),
+            Rect::new(Vec2::new(0.0, 0.0), Vec2::new(1.0, 1.0)),
+            7,
+        );
+        let stats = index.upsert_bounds(
+            slot,
+            ObjectId::new(7),
+            Rect::new(Vec2::new(12.0, 12.0), Vec2::new(13.0, 13.0)),
+            7,
+        );
+        assert_eq!(stats.full_rebuilds, 0);
+        assert_eq!(stats.leaves_upserted, 1);
+        assert_eq!(stats.leaves_removed, 1);
+        assert!(index.hit_test(Vec2::new(0.5, 0.5)).slots().is_empty());
+        assert_eq!(index.hit_test(Vec2::new(12.5, 12.5)).slots(), &[slot]);
+    }
+
+    #[test]
+    fn hit_test_returns_topmost_painter_candidate_first() {
+        let mut index = ExecutionSpatialIndex::default();
+        let bounds = Rect::new(Vec2::new(-1.0, -1.0), Vec2::new(1.0, 1.0));
+        let lower = ExecutionSlotId::new(2, 0);
+        let upper = ExecutionSlotId::new(9, 0);
+        index.upsert_bounds(lower, ObjectId::new(2), bounds, 2);
+        index.upsert_bounds(upper, ObjectId::new(9), bounds, 9);
+        assert_eq!(index.hit_test(Vec2::ZERO).slots(), &[upper, lower]);
+        assert_eq!(index.query_rect(bounds).slots(), &[lower, upper]);
+    }
+
+    #[test]
+    fn viewport_query_visits_only_intersecting_grid_cells() {
+        let mut index = ExecutionSpatialIndex::default();
+        for object_index in 0..10_000usize {
+            let x = (object_index % 100) as f32 * 4.0;
+            let y = (object_index / 100) as f32 * 4.0;
+            index.upsert_bounds(
+                ExecutionSlotId::new(object_index as u32, 0),
+                ObjectId::new(object_index as u64),
+                Rect::new(Vec2::new(x, y), Vec2::new(x + 1.0, y + 1.0)),
+                object_index as u64,
+            );
+        }
+        let result = index.query_rect(Rect::new(Vec2::new(39.0, 39.0), Vec2::new(61.0, 61.0)));
+        assert!(result.stats().cells_visited < 200);
+        assert!(result.stats().candidates_tested < 100);
+        assert!(!result.slots().is_empty());
+    }
+}

--- a/crates/noon-web/src/legacy.rs
+++ b/crates/noon-web/src/legacy.rs
@@ -13,7 +13,8 @@ use noon_compile::{CompileError, CompilePatchError, CompiledScene};
 use std::collections::{BTreeMap, BTreeSet};
 
 use noon_core::{
-    preflight_transaction, MutationTransaction, ObjectId, PatchError, SceneDefinition, ScenePatch,
+    preflight_transaction, MutationTransaction, ObjectId, PatchError, Rect, SceneDefinition,
+    ScenePatch, Vec2,
 };
 use noon_ir::{decode_patch_batch, decode_scene, encode_scene, IrError};
 use noon_runtime::{
@@ -290,6 +291,14 @@ impl ScenePlayer {
 
     pub fn object_count(&self) -> usize {
         self.instance.live_object_count()
+    }
+
+    pub fn hit_test(&self, point: Vec2) -> noon_runtime::SpatialQueryResult {
+        self.instance.hit_test(point)
+    }
+
+    pub fn query_viewport(&self, bounds: Rect) -> noon_runtime::SpatialQueryResult {
+        self.instance.query_viewport(bounds)
     }
 
     pub(crate) fn live_frame_indices(&self) -> Vec<usize> {

--- a/docs/spatial-index.md
+++ b/docs/spatial-index.md
@@ -1,0 +1,46 @@
+# Retained execution spatial index
+
+Issue #66 introduces a renderer-independent retained spatial index keyed by stable
+`ExecutionSlotId`. The first slice lives in `noon-runtime`; it does not make frame
+indices or Python objects authoritative again.
+
+## Contract
+
+- The index stores conservative world-space AABBs for live frame objects.
+- Stable execution slots are the indexed identity. Compatibility frame rows are
+  used only to derive the current painter order and frame state.
+- A deterministic uniform grid provides `O(cells + candidates)` viewport and point
+  queries. Objects spanning too many cells are retained in a global oversized set;
+  exceptionally large queries fall back explicitly and report that in query stats.
+- Runtime mutation owns a second dirty stream independent from renderer
+  `FrameChanges`, so renderer consumption cannot cause spatial updates to miss work
+  or force repeated scene scans.
+- Transform/style/timeline/structural edits refit or retire only affected leaves.
+  Direct seek and explicit frame-slot compaction are deliberate full-index rebuild
+  boundaries.
+- Point queries return topmost painter candidates first. Rectangle/viewport queries
+  return painter order bottom-to-top. Until #62 presentation metadata is carried in
+  `FrameObjectState`, the runtime uses current semantic/frame insertion order, exactly
+  matching the renderer's default painter-order adapter.
+
+## Bounds
+
+Analytic primitives use exact local boxes. Vector paths reuse their conservative
+control-hull bounds. The box is transformed through the object's scale/rotation/
+translation and conservatively expanded for stroke width. `External` geometry is
+left unindexed until its resource payload is available at the execution boundary.
+
+## Locality instrumentation
+
+`SpatialIndexUpdateStats` reports full rebuilds, leaf upserts/removals, and cell
+membership churn. `SpatialQueryStats` reports visited cells, exact candidates tested,
+result count, and explicit full-scan fallbacks.
+
+Scale regressions cover a 100,000-object point query without a scene scan, bounded
+single-leaf motion, painter-order hits, and localized viewport queries.
+
+## Next #66 slice
+
+Renderer viewport culling should consume `ScenePlayer::query_viewport` / the same
+execution index and filter ordered draw submission without repacking unrelated GPU
+instance or path geometry. Native hover/selection can consume `hit_test` directly.


### PR DESCRIPTION
## Summary
- add a retained, renderer-independent spatial index keyed by stable `ExecutionSlotId`
- use conservative world-space bounds for analytic geometry and vector paths, including transform + stroke expansion
- keep oversized objects in an explicit global set and report full-scan fallbacks for exceptionally large queries
- maintain an independent spatial dirty stream so renderer `FrameChanges` consumption cannot cause missed index updates or force scene scans
- refit/remove only changed execution leaves for property, timeline, reactive, and structural mutations; direct seek and explicit frame-slot compaction remain deliberate rebuild boundaries
- expose painter-ordered viewport queries and topmost-first hit-test candidates through `SlottedSceneInstance` / `ScenePlayer`
- add update/query locality counters and architecture documentation

## Scale / correctness regressions
- 100,000-object point hit query visits one grid cell and tests fewer than eight candidates
- moving one leaf updates only its retained memberships
- forward timeline motion refits only the active object's leaf
- structural removal retires one spatial leaf without a full rebuild
- viewport query over 10,000 objects visits a bounded subset of cells/candidates
- overlapping hit candidates retain painter order

## Validation
Validated before grafting onto current master:
- `cargo test -p noon-runtime -p noon-web`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo check -p noon-web --target wasm32-unknown-unknown`

This is the retained-index core slice of #66. Renderer viewport culling/native browser hit integration remains a follow-up before closing #66.