### PR TITLE
Preserve authored Manim scene duration across waits

### DIFF
--- a/compat/wire/v1/authoring-result-empty-scene.json
+++ b/compat/wire/v1/authoring-result-empty-scene.json
@@ -1,1 +1,1 @@
-{"kind":"scene_document","document":{"version":1,"objects":[],"tracks":[]},"identities":{"objects":[],"tracks":[]},"callbacks":null}
+{"kind":"scene_document","document":{"version":1,"objects":[],"tracks":[]},"duration":0.0,"identities":{"objects":[],"tracks":[]},"callbacks":null}

--- a/crates/noon-web/src/clock.rs
+++ b/crates/noon-web/src/clock.rs
@@ -76,6 +76,24 @@ impl PlaybackClock {
         })
     }
 
+    pub fn set_loop_duration(&mut self, duration: f64) -> Result<(), ClockError> {
+        if !duration.is_finite() || duration <= 0.0 {
+            return Err(ClockError::InvalidLoopDuration(duration));
+        }
+
+        if let (Some(origin), Some(previous)) = (self.origin_ms, self.previous_ms) {
+            let elapsed = (previous - origin) / 1_000.0;
+            let current_time = match self.loop_duration {
+                Some(previous_duration) => elapsed.rem_euclid(previous_duration),
+                None => elapsed,
+            };
+            let phase = current_time.rem_euclid(duration);
+            self.origin_ms = Some(previous - phase * 1_000.0);
+        }
+        self.loop_duration = Some(duration);
+        Ok(())
+    }
+
     pub fn reset(&mut self) {
         self.origin_ms = None;
         self.previous_ms = None;
@@ -110,6 +128,31 @@ mod tests {
 
         assert_eq!(clock.scene_time(100.0).expect("valid frame"), 0.0);
         assert_eq!(clock.scene_time(2_600.0).expect("valid frame"), 0.5);
+    }
+
+    #[test]
+    fn changing_loop_duration_preserves_the_current_phase() {
+        let mut clock = PlaybackClock::looping(4.0).expect("valid loop");
+        assert_eq!(clock.scene_time(100.0).expect("valid frame"), 0.0);
+        assert_eq!(clock.scene_time(1_600.0).expect("valid frame"), 1.5);
+
+        clock
+            .set_loop_duration(3.0)
+            .expect("updated duration must be valid");
+        assert_eq!(clock.scene_time(1_600.0).expect("same frame"), 1.5);
+        assert_eq!(clock.scene_time(3_100.0).expect("valid frame"), 0.0);
+    }
+
+    #[test]
+    fn shrinking_loop_duration_normalizes_only_when_required() {
+        let mut clock = PlaybackClock::looping(5.0).expect("valid loop");
+        assert_eq!(clock.scene_time(100.0).expect("valid frame"), 0.0);
+        assert_eq!(clock.scene_time(3_600.0).expect("valid frame"), 3.5);
+
+        clock
+            .set_loop_duration(2.0)
+            .expect("updated duration must be valid");
+        assert_eq!(clock.scene_time(3_600.0).expect("same frame"), 1.5);
     }
 
     #[test]

--- a/web/authoring-client.js
+++ b/web/authoring-client.js
@@ -58,7 +58,7 @@ export class PythonAuthoringClient {
       throw new TypeError("callback frame must be an object");
     }
     if (!Number.isSafeInteger(sequence) || sequence < 0) {
-      throw new TypeError("callback patch sequence must be a non-negative safe integer");
+      throw new TypeError("callback sequence must be a non-negative safe integer");
     }
     await this.ready();
     const requestId = this.#beginRequest();
@@ -204,6 +204,7 @@ export function parseAuthoringResult(resultJson) {
     return {
       kind: result.kind,
       document,
+      duration: validateSceneDuration(result.duration),
       identities: validateSceneIdentities(result.identities, document),
       callbacks: validateCallbackSession(result.callbacks, document),
     };
@@ -254,6 +255,13 @@ export function validateSceneDocument(scene) {
     throw new Error("Python Scene tracks must be an array");
   }
   return scene;
+}
+
+export function validateSceneDuration(duration) {
+  if (!Number.isFinite(duration) || duration < 0) {
+    throw new Error("Python Scene duration must be finite and non-negative");
+  }
+  return duration;
 }
 
 export function validateSceneIdentities(identities, scene) {

--- a/web/authoring-client.js
+++ b/web/authoring-client.js
@@ -58,7 +58,7 @@ export class PythonAuthoringClient {
       throw new TypeError("callback frame must be an object");
     }
     if (!Number.isSafeInteger(sequence) || sequence < 0) {
-      throw new TypeError("callback sequence must be a non-negative safe integer");
+      throw new TypeError("callback patch sequence must be a non-negative safe integer");
     }
     await this.ready();
     const requestId = this.#beginRequest();

--- a/web/authoring-client.test.mjs
+++ b/web/authoring-client.test.mjs
@@ -9,6 +9,7 @@ import {
   validateCallbackSession,
   validatePatchBatch,
   validateSceneDocument,
+  validateSceneDuration,
   validateSceneIdentities,
 } from "./authoring-client.js";
 
@@ -75,7 +76,7 @@ test("correlates a Python request with a validated PatchBatch response", async (
   assert.deepEqual(await resultPromise, { kind: "patch_batch", document: batch });
 });
 
-test("correlates a Python request with Scene callback metadata", async () => {
+test("correlates a Python request with Scene callback and duration metadata", async () => {
   const worker = new FakeWorker();
   const client = new PythonAuthoringClient(worker);
   worker.emit("message", workerMessage("ready"));
@@ -93,6 +94,7 @@ test("correlates a Python request with Scene callback metadata", async () => {
       resultJson: JSON.stringify({
         kind: "scene_document",
         document: scene,
+        duration: 2.75,
         identities,
         callbacks,
       }),
@@ -102,9 +104,30 @@ test("correlates a Python request with Scene callback metadata", async () => {
   assert.deepEqual(await resultPromise, {
     kind: "scene_document",
     document: scene,
+    duration: 2.75,
     identities,
     callbacks,
   });
+});
+
+test("Scene duration accepts zero and rejects missing, negative, or non-finite values", () => {
+  assert.equal(validateSceneDuration(0), 0);
+  assert.equal(validateSceneDuration(3.5), 3.5);
+  assert.throws(() => validateSceneDuration(undefined), /finite and non-negative/);
+  assert.throws(() => validateSceneDuration(-0.01), /finite and non-negative/);
+  assert.throws(() => validateSceneDuration(Number.NaN), /finite and non-negative/);
+  assert.throws(() => validateSceneDuration(Number.POSITIVE_INFINITY), /finite and non-negative/);
+
+  const sceneResult = {
+    kind: "scene_document",
+    document: { version: 1, objects: [], tracks: [] },
+    identities: { objects: [], tracks: [] },
+    callbacks: null,
+  };
+  assert.throws(
+    () => parseAuthoringResult(JSON.stringify(sceneResult)),
+    /duration must be finite and non-negative/,
+  );
 });
 
 test("runs one callback phase and validates its PatchBatch", async () => {

--- a/web/python-worker.js
+++ b/web/python-worker.js
@@ -320,10 +320,12 @@ else:
 
 if isinstance(__noon_result, Scene):
     __noon_kind = "scene_document"
+    __noon_duration = float(__noon_result.time)
     __noon_identities = __noon_result.identity_document()
     __noon_callbacks = _manim_updaters.register_scene(__noon_result)
 elif isinstance(__noon_result, PatchBatch):
     __noon_kind = "patch_batch"
+    __noon_duration = None
     __noon_identities = None
     __noon_callbacks = None
 else:
@@ -332,6 +334,7 @@ json.dumps(
     {
         "kind": __noon_kind,
         "document": __noon_result.to_document(),
+        "duration": __noon_duration,
         "identities": __noon_identities,
         "callbacks": __noon_callbacks,
     },
@@ -397,7 +400,7 @@ function validateRequest(request) {
       throw new Error("Python callback request has an invalid session ID");
     }
     if (!Number.isSafeInteger(request.sequence) || request.sequence < 0) {
-      throw new Error("Python callback request has an invalid patch sequence");
+      throw new Error("Python callback request must contain a non-negative sequence");
     }
     if (!isRecord(request.frame)) {
       throw new Error("Python callback request must contain a frame object");

--- a/web/python-worker.js
+++ b/web/python-worker.js
@@ -400,7 +400,7 @@ function validateRequest(request) {
       throw new Error("Python callback request has an invalid session ID");
     }
     if (!Number.isSafeInteger(request.sequence) || request.sequence < 0) {
-      throw new Error("Python callback request must contain a non-negative sequence");
+      throw new Error("Python callback request has an invalid patch sequence");
     }
     if (!isRecord(request.frame)) {
       throw new Error("Python callback request must contain a frame object");

--- a/web/python/test_manim_scene_duration.py
+++ b/web/python/test_manim_scene_duration.py
@@ -1,0 +1,26 @@
+import unittest
+
+from noon import Scene
+
+
+class SceneDurationTests(unittest.TestCase):
+    def test_default_and_explicit_wait_advance_authored_scene_time(self):
+        scene = Scene()
+
+        self.assertEqual(scene.time, 0.0)
+        scene.wait()
+        self.assertEqual(scene.time, 1.0)
+        scene.wait(0.25)
+        self.assertEqual(scene.time, 1.25)
+
+    def test_wait_only_duration_is_not_recoverable_from_tracks(self):
+        scene = Scene()
+        scene.wait(2.5)
+
+        document = scene.to_document()
+        self.assertEqual(document["tracks"], [])
+        self.assertEqual(scene.time, 2.5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- expose authored `Scene.time` as explicit browser authoring-result `duration` metadata
- validate duration as finite and non-negative at the browser boundary
- preserve zero-duration scenes without inventing dummy tracks or changing SceneDocument v1
- add focused regressions proving default/explicit `wait()` advances semantic scene time even when the serialized document has no tracks
- add a phase-preserving `PlaybackClock::set_loop_duration` primitive for the execution handoff

## Why
`Scene.wait()` advances Noon's authoring cursor, but SceneDocument intentionally contains only objects/tracks. A terminal wait (or wait-only scene) therefore cannot be recovered from `max(track end)` and the browser previously lost the authored Manim duration.

The metadata belongs at the authoring/playback boundary rather than in the core object/track IR, so this keeps SceneDocument v1 unchanged.

## Validation
The existing browser Manim compatibility smoke exercises the worker→client result path and now requires every scene result to carry valid duration metadata. Focused Python and JS tests cover wait-only/default waits and malformed duration values.

Tracks #181.