### PR TITLE
Use authored Manim duration for live playback

### DIFF
--- a/crates/noon-web/src/execution_transport.rs
+++ b/crates/noon-web/src/execution_transport.rs
@@ -266,7 +266,7 @@ impl ExecutionDeltaEncoder {
             return Ok(None);
         }
 
-        let mut removed = Vec::with_capacity(dirty_objects.len() + added_objects.len());
+        let mut removed = Vec::with_capacity(removed_slots.len());
         let mut seen_removed = HashSet::with_capacity(removed_slots.len());
         for &slot in removed_slots {
             let slot = TransportSlotId::from(slot);
@@ -574,7 +574,7 @@ impl ExecutionFrameMirror {
             self.slots.push(object.slot);
             self.slot_indices.insert(object.slot, index);
             self.object_slots.insert(object.object, object.slot);
-            push_frame_object(&mut frame, object.clone());
+            push_frame_object(frame, object.clone());
             added_indices.push(index);
             changed.push(index);
         }
@@ -954,9 +954,9 @@ mod tests {
         assert!(!delta.snapshot);
         assert_eq!(delta.objects.len(), 1);
         let (outcome, changes) = mirror.apply(delta).unwrap();
+        assert_eq!(outcome, TransportApplyOutcome::Applied);
         assert_eq!(changes.object_indices(), &[0]);
         assert_eq!(mirror.frame().unwrap(), player.frame());
-        assert_eq!(outcome, TransportApplyOutcome::Applied);
     }
 
     #[test]

--- a/crates/noon-web/src/execution_transport.rs
+++ b/crates/noon-web/src/execution_transport.rs
@@ -266,7 +266,7 @@ impl ExecutionDeltaEncoder {
             return Ok(None);
         }
 
-        let mut removed = Vec::with_capacity(removed_slots.len());
+        let mut removed = Vec::with_capacity(dirty_objects.len() + added_objects.len());
         let mut seen_removed = HashSet::with_capacity(removed_slots.len());
         for &slot in removed_slots {
             let slot = TransportSlotId::from(slot);
@@ -574,7 +574,7 @@ impl ExecutionFrameMirror {
             self.slots.push(object.slot);
             self.slot_indices.insert(object.slot, index);
             self.object_slots.insert(object.object, object.slot);
-            push_frame_object(frame, object.clone());
+            push_frame_object(&mut frame, object.clone());
             added_indices.push(index);
             changed.push(index);
         }
@@ -713,6 +713,11 @@ impl EngineScenePlayer {
         self.take_delta_json()
     }
 
+    pub fn set_loop_duration(&mut self, duration: f64) -> Result<(), ExecutionTransportError> {
+        self.clock.set_loop_duration(duration)?;
+        Ok(())
+    }
+
     pub fn apply_patch_batch_delta_json(
         &mut self,
         json: &str,
@@ -819,6 +824,11 @@ mod wasm {
         #[wasm_bindgen(js_name = tickDeltaJson)]
         pub fn tick_delta_json(&mut self, timestamp_ms: f64) -> Result<Option<String>, JsValue> {
             self.inner.tick_delta_json(timestamp_ms).map_err(js_error)
+        }
+
+        #[wasm_bindgen(js_name = setLoopDurationSeconds)]
+        pub fn set_loop_duration_seconds(&mut self, duration: f64) -> Result<(), JsValue> {
+            self.inner.set_loop_duration(duration).map_err(js_error)
         }
 
         #[wasm_bindgen(js_name = applyPatchBatchDeltaJson)]
@@ -944,9 +954,9 @@ mod tests {
         assert!(!delta.snapshot);
         assert_eq!(delta.objects.len(), 1);
         let (outcome, changes) = mirror.apply(delta).unwrap();
-        assert_eq!(outcome, TransportApplyOutcome::Applied);
         assert_eq!(changes.object_indices(), &[0]);
         assert_eq!(mirror.frame().unwrap(), player.frame());
+        assert_eq!(outcome, TransportApplyOutcome::Applied);
     }
 
     #[test]
@@ -1016,6 +1026,29 @@ mod tests {
                 sequence: 3
             })
         ));
+    }
+
+    #[test]
+    fn retiming_execution_clock_preserves_phase_and_patch_sequence() {
+        let mut player = EngineScenePlayer::new(&scene_json(), 4.0, 13).unwrap();
+        player.initial_delta_json().unwrap();
+        player.tick_delta_json(100.0).unwrap();
+        player.tick_delta_json(1_600.0).unwrap();
+        assert_eq!(player.time(), 1.5);
+
+        let patch = PatchBatch::new(0, Vec::new());
+        player
+            .apply_patch_batch_delta_json(&encode_patch_batch(&patch).unwrap())
+            .unwrap();
+        assert_eq!(player.next_patch_sequence(), 1);
+
+        player.set_loop_duration(3.0).unwrap();
+        assert_eq!(player.time(), 1.5);
+        assert_eq!(player.next_patch_sequence(), 1);
+
+        player.tick_delta_json(3_100.0).unwrap();
+        assert_eq!(player.time(), 0.0);
+        assert_eq!(player.next_patch_sequence(), 1);
     }
 
     #[test]

--- a/scripts/execution-worker-smoke.mjs
+++ b/scripts/execution-worker-smoke.mjs
@@ -151,6 +151,27 @@ async function runMode(browser, transportMode) {
   }, badPatch);
   assert.match(errorMessage, /expected patch sequence 1, got 9/);
 
+  const beforeRetime = await page.evaluate(() => window.executionSmoke.client.state());
+  const retimed = await page.evaluate(
+    ({ sceneJson, duration }) =>
+      window.executionSmoke.client.reconcileScene(sceneJson, {
+        loopDurationSeconds: duration,
+      }),
+    { sceneJson: beforeRetime.sceneJson, duration: 0.9 },
+  );
+  assert.equal(retimed.nextPatchSequence, "1", `${transportMode}: retime reset patch sequence`);
+  assert.ok(
+    Math.abs(retimed.time - beforeRetime.time) < 0.15,
+    `${transportMode}: retime jumped the current playhead`,
+  );
+  await page.waitForTimeout(650);
+  const afterRetime = await page.evaluate(() => window.executionSmoke.client.state());
+  assert.ok(
+    afterRetime.time >= 0 && afterRetime.time < 0.9,
+    `${transportMode}: authored loop duration did not wrap execution time`,
+  );
+  assert.equal(afterRetime.nextPatchSequence, "1");
+
   const beforeStall = await page.evaluate(() => window.executionSmoke.client.metrics());
   const stallStarted = await page.evaluate(() => {
     const worker = new Worker(
@@ -182,6 +203,10 @@ async function runMode(browser, transportMode) {
   assert.equal(afterRestart.metrics.ready, true);
   assert.equal(afterRestart.metrics.objectCount, 4);
   assert.ok(afterRestart.metrics.presentedFrames >= 1);
+  assert.ok(
+    afterRestart.metrics.time >= 0 && afterRestart.metrics.time < 0.9,
+    `${transportMode}: restart forgot the authored loop duration`,
+  );
 
   const clientErrors = await page.evaluate(() => window.executionSmoke.errors.slice());
   assert.deepEqual(clientErrors, []);

--- a/scripts/execution-worker-smoke.mjs
+++ b/scripts/execution-worker-smoke.mjs
@@ -152,12 +152,8 @@ async function runMode(browser, transportMode) {
   assert.match(errorMessage, /expected patch sequence 1, got 9/);
 
   const beforeRetime = await page.evaluate(() => window.executionSmoke.client.state());
-  const retimed = await page.evaluate(
-    ({ sceneJson, duration }) =>
-      window.executionSmoke.client.reconcileScene(sceneJson, {
-        loopDurationSeconds: duration,
-      }),
-    { sceneJson: beforeRetime.sceneJson, duration: 0.9 },
+  const retimed = await page.evaluate(() =>
+    window.executionSmoke.client.setLoopDurationSeconds(0.9),
   );
   assert.equal(retimed.nextPatchSequence, "1", `${transportMode}: retime reset patch sequence`);
   assert.ok(

--- a/scripts/manim-raster-differential.mjs
+++ b/scripts/manim-raster-differential.mjs
@@ -186,6 +186,8 @@ async function authorNoonDocuments() {
       );
       assert.equal(result.kind, "scene_document", `${fixture.id}: Noon authoring result kind`);
       assert.ok(result.document.objects.length > 0, `${fixture.id}: Noon scene has no objects`);
+      assert.equal(result.duration, fixture.expected_duration, `${fixture.id}: authored Noon duration`);
+      Object.defineProperty(result.document, "__noonAuthoredDuration", { value: result.duration });
       documents.set(fixture.id, result.document);
     }
     return documents;
@@ -262,7 +264,7 @@ async function captureNoonBackend(backend, documents, references) {
         captures.push({ ...sample, noonPath: outputPath, metrics });
       }
       output.set(fixture.id, {
-        duration: latestSceneEnd(document),
+        duration: document.__noonAuthoredDuration,
         objectCount: document.objects.length,
         captures,
       });

--- a/web/execution-engine-worker.js
+++ b/web/execution-engine-worker.js
@@ -46,6 +46,7 @@ async function handleMainMessage(message) {
         return;
       case "replace_scene":
       case "reconcile_scene":
+      case "set_loop_duration":
       case "apply_patch":
       case "configure_callbacks":
         enqueueControl(message);
@@ -318,6 +319,12 @@ function executeControl(message) {
       });
       return;
     }
+    case "set_loop_duration": {
+      validateRequiredLoopDuration(message.loopDurationSeconds);
+      player.setLoopDurationSeconds(message.loopDurationSeconds);
+      respond(message.requestId, runtimeResult("set_loop_duration"));
+      return;
+    }
     case "apply_patch": {
       const delta = player.applyPatchBatchDeltaJson(message.patchBatchJson);
       if (delta !== undefined && delta !== null) {
@@ -340,13 +347,17 @@ function executeControl(message) {
   }
 }
 
+function validateRequiredLoopDuration(duration) {
+  if (!Number.isFinite(duration) || duration <= 0) {
+    throw new Error("execution engine loop duration must be positive and finite");
+  }
+}
+
 function validateOptionalLoopDuration(duration) {
   if (duration === null || duration === undefined) {
     return;
   }
-  if (!Number.isFinite(duration) || duration <= 0) {
-    throw new Error("execution engine loop duration must be positive and finite");
-  }
+  validateRequiredLoopDuration(duration);
 }
 
 function applyOptionalLoopDuration(duration) {

--- a/web/execution-engine-worker.js
+++ b/web/execution-engine-worker.js
@@ -296,15 +296,19 @@ function drainWork() {
 function executeControl(message) {
   switch (message.type) {
     case "replace_scene": {
+      validateOptionalLoopDuration(message.loopDurationSeconds);
       clearHostCallbacks();
       const delta = player.replaceSceneDeltaJson(message.sceneJson);
+      applyOptionalLoopDuration(message.loopDurationSeconds);
       sendDeltaOrThrow(delta);
       respond(message.requestId, runtimeResult("replace_scene"));
       return;
     }
     case "reconcile_scene": {
+      validateOptionalLoopDuration(message.loopDurationSeconds);
       clearHostCallbacks();
       const result = JSON.parse(player.reconcileSceneDeltaJson(message.sceneJson));
+      applyOptionalLoopDuration(message.loopDurationSeconds);
       if (result.delta !== null && result.delta !== undefined) {
         sendDeltaOrThrow(result.delta);
       }
@@ -333,6 +337,21 @@ function executeControl(message) {
     }
     default:
       throw new Error(`unknown queued engine command ${message.type}`);
+  }
+}
+
+function validateOptionalLoopDuration(duration) {
+  if (duration === null || duration === undefined) {
+    return;
+  }
+  if (!Number.isFinite(duration) || duration <= 0) {
+    throw new Error("execution engine loop duration must be positive and finite");
+  }
+}
+
+function applyOptionalLoopDuration(duration) {
+  if (duration !== null && duration !== undefined) {
+    player.setLoopDurationSeconds(duration);
   }
 }
 

--- a/web/execution-worker-client.js
+++ b/web/execution-worker-client.js
@@ -55,9 +55,7 @@ export class ExecutionWorkerClient {
       throw new Error("ExecutionWorkerClient is already started");
     }
     validateSceneJson(sceneJson);
-    if (!Number.isFinite(loopDurationSeconds) || loopDurationSeconds <= 0) {
-      throw new TypeError("loop duration must be positive and finite");
-    }
+    validateLoopDurationSeconds(loopDurationSeconds);
     if (
       transportMode !== EXECUTION_TRANSPORT_SHARED &&
       transportMode !== EXECUTION_TRANSPORT_TRANSFERABLE
@@ -130,18 +128,38 @@ export class ExecutionWorkerClient {
     return this.#ready;
   }
 
-  async replaceScene(sceneJson, { callbacks = null, authoringClient = null } = {}) {
+  async replaceScene(
+    sceneJson,
+    { callbacks = null, authoringClient = null, loopDurationSeconds = null } = {},
+  ) {
     validateSceneJson(sceneJson);
-    const result = await this.#requestEngine("replace_scene", { sceneJson });
+    const duration = validateOptionalLoopDurationSeconds(loopDurationSeconds);
+    const result = await this.#requestEngine("replace_scene", {
+      sceneJson,
+      loopDurationSeconds: duration,
+    });
     this.#sceneJson = result.sceneJson ?? sceneJson;
+    if (duration !== null) {
+      this.#loopDurationSeconds = duration;
+    }
     await this.configureHostCallbacks(callbacks, authoringClient);
     return result;
   }
 
-  async reconcileScene(sceneJson, { callbacks = null, authoringClient = null } = {}) {
+  async reconcileScene(
+    sceneJson,
+    { callbacks = null, authoringClient = null, loopDurationSeconds = null } = {},
+  ) {
     validateSceneJson(sceneJson);
-    const result = await this.#requestEngine("reconcile_scene", { sceneJson });
+    const duration = validateOptionalLoopDurationSeconds(loopDurationSeconds);
+    const result = await this.#requestEngine("reconcile_scene", {
+      sceneJson,
+      loopDurationSeconds: duration,
+    });
     this.#sceneJson = result.sceneJson ?? sceneJson;
+    if (duration !== null) {
+      this.#loopDurationSeconds = duration;
+    }
     await this.configureHostCallbacks(callbacks, authoringClient);
     return result;
   }
@@ -403,6 +421,20 @@ function validateSceneJson(sceneJson) {
   if (typeof sceneJson !== "string" || sceneJson.trim() === "") {
     throw new TypeError("scene must be non-empty JSON text");
   }
+}
+
+function validateLoopDurationSeconds(loopDurationSeconds) {
+  if (!Number.isFinite(loopDurationSeconds) || loopDurationSeconds <= 0) {
+    throw new TypeError("loop duration must be positive and finite");
+  }
+  return loopDurationSeconds;
+}
+
+function validateOptionalLoopDurationSeconds(loopDurationSeconds) {
+  if (loopDurationSeconds === null || loopDurationSeconds === undefined) {
+    return null;
+  }
+  return validateLoopDurationSeconds(loopDurationSeconds);
 }
 
 function validateCallbacks(callbacks) {

--- a/web/execution-worker-client.js
+++ b/web/execution-worker-client.js
@@ -164,6 +164,15 @@ export class ExecutionWorkerClient {
     return result;
   }
 
+  async setLoopDurationSeconds(loopDurationSeconds) {
+    const duration = validateLoopDurationSeconds(loopDurationSeconds);
+    const result = await this.#requestEngine("set_loop_duration", {
+      loopDurationSeconds: duration,
+    });
+    this.#loopDurationSeconds = duration;
+    return result;
+  }
+
   async applyPatchBatch(patchBatchJson) {
     if (typeof patchBatchJson !== "string" || patchBatchJson.trim() === "") {
       throw new TypeError("patch batch must be non-empty JSON text");

--- a/web/main.js
+++ b/web/main.js
@@ -469,6 +469,7 @@ try {
       const result = await player.reconcileScene(JSON.stringify(runtimeDocument), {
         callbacks: authored.callbacks,
         authoringClient,
+        loopDurationSeconds: authored.duration > 0 ? authored.duration : null,
       });
       if (result.time !== before.time) {
         throw new Error("Scene replacement changed the current playhead");


### PR DESCRIPTION
## Summary
- retime the execution worker clock from authored `Scene.time` without rebuilding the scene
- expose a dedicated pure-retime command through the WASM execution player, engine worker, and `ExecutionWorkerClient`
- preserve current playback phase and ordered patch sequence for pure retiming, and retain the authored duration across worker restart
- allow scene replacement/reconciliation to update loop duration while keeping their existing scene/patch lifecycle semantics
- pass positive authored duration from the playground scene-authoring result into live reconciliation; zero-duration static scenes keep the existing valid loop
- make the Manim raster timing oracle use authored duration rather than inferring duration from the last track end

## Validation
- Rust regression verifies pure clock retiming preserves phase and patch sequence
- execution-worker browser smoke exercises both transferable and shared transports, verifies pure retiming preserves sequence, wraps at the new duration, and persists across restart
- raster oracle asserts each authored Noon duration equals the canonical fixture duration before visual comparison

This is the execution handoff follow-up to #206 and tracks #181.