### PR TITLE
Match Manim frame sampling and endpoint convention

### DIFF
--- a/.github/workflows/manim-differential.yml
+++ b/.github/workflows/manim-differential.yml
@@ -37,4 +37,6 @@ jobs:
         run: python -m pip install --disable-pip-version-check "manim==0.21.0"
 
       - name: Compare supported Noon semantics with ManimCE
-        run: python scripts/manim-differential.py
+        run: |
+          python scripts/manim-differential.py
+          python scripts/manim-frame-sampling-differential.py

--- a/scripts/build-web-demo.sh
+++ b/scripts/build-web-demo.sh
@@ -56,6 +56,7 @@ PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile \
   web/python/_manim_animation_options.py \
   web/python/_manim_animate.py \
   web/python/_manim_composition.py \
+  web/python/_manim_frame_sampling.py \
   web/python/_manim_lifecycle.py \
   web/python/_manim_reactive.py \
   web/python/_manim_updaters.py

--- a/scripts/manim-frame-sampling-differential.py
+++ b/scripts/manim-frame-sampling-differential.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Compare Noon's canonical frame timestamps with pinned ManimCE v0.21.0."""
+
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WEB_PYTHON = REPO_ROOT / "web" / "python"
+if str(WEB_PYTHON) not in sys.path:
+    sys.path.insert(0, str(WEB_PYTHON))
+
+from _manim_frame_sampling import frame_times, logical_endpoint  # noqa: E402
+
+try:
+    import manim  # noqa: E402
+except ImportError as exc:  # pragma: no cover - CI installs the pinned reference
+    raise SystemExit("ManimCE is required for the frame-sampling differential") from exc
+
+PINNED_MANIM_VERSION = "0.21.0"
+CASES = (
+    ("one-second-30fps", 1.0, 30.0),
+    ("fractional-30fps", 0.85, 30.0),
+    ("sub-frame-30fps", 0.01, 30.0),
+    ("zero-duration-30fps", 0.0, 30.0),
+    ("one-second-60fps", 1.0, 60.0),
+    ("long-60fps", 10.0, 60.0),
+)
+
+
+def manim_frame_times(run_time: float, frame_rate: float) -> tuple[float, ...]:
+    old_frame_rate = manim.config.frame_rate
+    old_progress_bar = manim.config.progress_bar
+    try:
+        manim.config.frame_rate = frame_rate
+        manim.config.progress_bar = "none"
+        scene_stub = SimpleNamespace(renderer=SimpleNamespace(skip_animations=False))
+        progression = manim.Scene.get_time_progression(
+            scene_stub,
+            run_time,
+            "Noon timing differential",
+        )
+        try:
+            return tuple(float(value) for value in progression)
+        finally:
+            progression.close()
+    finally:
+        manim.config.frame_rate = old_frame_rate
+        manim.config.progress_bar = old_progress_bar
+
+
+def compare(case: str, run_time: float, frame_rate: float) -> list[str]:
+    noon_samples = frame_times(run_time, frame_rate)
+    manim_samples = manim_frame_times(run_time, frame_rate)
+    errors: list[str] = []
+
+    if len(noon_samples) != len(manim_samples):
+        errors.append(
+            f"sample-count Noon={len(noon_samples)} Manim={len(manim_samples)}"
+        )
+    for index, (noon_time, manim_time) in enumerate(zip(noon_samples, manim_samples)):
+        if not math.isclose(noon_time, manim_time, rel_tol=0.0, abs_tol=1e-12):
+            errors.append(
+                f"sample[{index}] Noon={noon_time!r} Manim={manim_time!r}"
+            )
+            break
+
+    endpoint = logical_endpoint(run_time)
+    if noon_samples and not noon_samples[-1] < endpoint:
+        errors.append(
+            f"last rendered sample {noon_samples[-1]!r} must be before endpoint {endpoint!r}"
+        )
+    if any(math.isclose(sample, endpoint, rel_tol=0.0, abs_tol=1e-15) for sample in noon_samples):
+        errors.append(f"logical endpoint {endpoint!r} was included as a rendered frame")
+
+    marker = "PASS" if not errors else "FAIL"
+    print(
+        f"[{marker}] {case}: {len(noon_samples)} samples, "
+        f"endpoint={endpoint:g}, fps={frame_rate:g}"
+    )
+    for error in errors:
+        print(f"  {error}")
+    return errors
+
+
+def main() -> int:
+    if manim.__version__ != PINNED_MANIM_VERSION:
+        raise SystemExit(
+            f"expected ManimCE {PINNED_MANIM_VERSION}, found {manim.__version__}"
+        )
+
+    failures = 0
+    for case, run_time, frame_rate in CASES:
+        failures += bool(compare(case, run_time, frame_rate))
+
+    if failures:
+        print(f"\n{failures}/{len(CASES)} frame-sampling fixtures differ from ManimCE")
+        return 1
+    print(f"\nAll {len(CASES)} frame-sampling fixtures match ManimCE {manim.__version__}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/web/python/_manim_frame_sampling.py
+++ b/web/python/_manim_frame_sampling.py
@@ -1,0 +1,47 @@
+"""Canonical ManimCE frame-time sampling for deterministic/offline rendering.
+
+The real-time Noon player remains continuous-time. This helper models the frame
+sampling convention used by ManimCE's renderer: sample ``0, 1/fps, ...`` while
+strictly below the logical animation endpoint, then apply the endpoint state
+separately after rendering the sampled frames.
+"""
+
+from __future__ import annotations
+
+import math
+
+
+def frame_times(run_time: float, frame_rate: float) -> tuple[float, ...]:
+    """Return ManimCE-compatible rendered frame timestamps.
+
+    This is equivalent to ManimCE v0.21's
+    ``np.arange(0, run_time, 1 / frame_rate)`` for finite, non-negative
+    ``run_time`` and positive finite ``frame_rate``. The logical endpoint is
+    deliberately excluded from the returned samples.
+    """
+
+    duration = float(run_time)
+    fps = float(frame_rate)
+    if not math.isfinite(duration) or duration < 0.0:
+        raise ValueError("run_time must be finite and non-negative")
+    if not math.isfinite(fps) or fps <= 0.0:
+        raise ValueError("frame_rate must be finite and positive")
+
+    samples: list[float] = []
+    frame = 0
+    while True:
+        sample = frame / fps
+        if sample >= duration:
+            break
+        samples.append(sample)
+        frame += 1
+    return tuple(samples)
+
+
+def logical_endpoint(run_time: float) -> float:
+    """Validate and return the post-render logical animation endpoint."""
+
+    duration = float(run_time)
+    if not math.isfinite(duration) or duration < 0.0:
+        raise ValueError("run_time must be finite and non-negative")
+    return duration

--- a/web/python/test_manim_frame_sampling.py
+++ b/web/python/test_manim_frame_sampling.py
@@ -1,0 +1,40 @@
+import unittest
+
+from _manim_frame_sampling import frame_times, logical_endpoint
+
+
+class ManimFrameSamplingTests(unittest.TestCase):
+    def test_integral_duration_excludes_logical_endpoint(self):
+        samples = frame_times(1.0, 30.0)
+
+        self.assertEqual(len(samples), 30)
+        self.assertEqual(samples[0], 0.0)
+        self.assertEqual(samples[-1], 29.0 / 30.0)
+        self.assertNotIn(logical_endpoint(1.0), samples)
+
+    def test_fractional_and_subframe_durations_follow_frame_grid(self):
+        self.assertEqual(frame_times(0.85, 30.0), tuple(index / 30.0 for index in range(26)))
+        self.assertEqual(frame_times(0.01, 30.0), (0.0,))
+        self.assertEqual(frame_times(0.0, 30.0), ())
+
+    def test_frame_index_generation_avoids_accumulation_drift(self):
+        samples = frame_times(10.0, 60.0)
+
+        self.assertEqual(len(samples), 600)
+        self.assertEqual(samples[-1], 599.0 / 60.0)
+        self.assertLess(samples[-1], logical_endpoint(10.0))
+
+    def test_invalid_sampling_arguments_are_rejected(self):
+        for run_time in (-0.1, float("nan"), float("inf")):
+            with self.subTest(run_time=run_time):
+                with self.assertRaisesRegex(ValueError, "run_time"):
+                    frame_times(run_time, 30.0)
+
+        for frame_rate in (0.0, -30.0, float("nan"), float("inf")):
+            with self.subTest(frame_rate=frame_rate):
+                with self.assertRaisesRegex(ValueError, "frame_rate"):
+                    frame_times(1.0, frame_rate)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a deterministic canonical frame sampler for Manim-compatible offline/render timing
- match ManimCE v0.21.0's `np.arange(0, run_time, 1 / frame_rate)` convention: rendered samples are strictly before the logical endpoint
- keep endpoint application separate from rendered frame timestamps, matching Manim's post-loop `animation.finish()` behavior
- avoid quantizing Noon's real-time RAF playback clock
- add low-level coverage for integral, fractional, sub-frame, zero-duration, long-duration, and invalid inputs
- gate six frame-sampling cases directly against pinned ManimCE 0.21.0 in the existing differential workflow

## Frame convention
For a duration `T` and render FPS `f`, rendered animation frames occur at `i / f` while `i / f < T`. The logical state at exactly `T` is an endpoint state, not an extra animation frame.

This follows ManimCE v0.21.0 `Scene.get_time_progression`, which uses `np.arange(0, run_time, 1 / frame_rate)`, followed by `animation.finish()` after the render loop.

Tracks #181.