### PR TITLE
Gate direct seek against incremental Manim-frame playback

### DIFF
--- a/.github/workflows/manim-raster-differential.yml
+++ b/.github/workflows/manim-raster-differential.yml
@@ -71,6 +71,12 @@ jobs:
           NOON_MANIM_RASTER_ARTIFACTS: manim-raster-artifacts
         run: node scripts/manim-raster-differential.mjs
 
+      - name: Verify direct seek and incremental playback at Manim frame times
+        env:
+          NOON_MANIM_RASTER_BACKENDS: webgpu,webgl
+          NOON_MANIM_RASTER_ARTIFACTS: manim-raster-artifacts
+        run: node scripts/manim-seek-playback-raster.mjs
+
       - name: Upload Manim/Noon/diff artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/scripts/build-web-demo.sh
+++ b/scripts/build-web-demo.sh
@@ -27,6 +27,7 @@ node --check web/host-callback-perf.js
 node --check web/browser-smoke.js
 node --check scripts/browser-smoke.mjs
 node --check scripts/manim-raster-differential.mjs
+node --check scripts/manim-seek-playback-raster.mjs
 node --check scripts/perf-profile.mjs
 node --check scripts/authoring-perf.mjs
 node --check scripts/perf-device-run.mjs

--- a/scripts/manim-seek-playback-raster.mjs
+++ b/scripts/manim-seek-playback-raster.mjs
@@ -1,0 +1,394 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import playwright from "playwright";
+import pngjs from "pngjs";
+
+const { chromium } = playwright;
+const { PNG } = pngjs;
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const manifest = JSON.parse(
+  await readFile(path.join(repoRoot, "parity", "manim-v0.21", "manifest.json"), "utf8"),
+);
+const reference = manifest.reference;
+const fixtureSource = await readFile(path.join(repoRoot, reference.source), "utf8");
+const artifactRoot = path.resolve(
+  repoRoot,
+  process.env.NOON_MANIM_RASTER_ARTIFACTS ?? "manim-raster-artifacts",
+);
+const rasterReport = JSON.parse(await readFile(path.join(artifactRoot, "report.json"), "utf8"));
+const backends = (process.env.NOON_MANIM_RASTER_BACKENDS ?? "webgpu,webgl")
+  .split(",")
+  .map((value) => value.trim())
+  .filter(Boolean);
+const port = Number(process.env.NOON_MANIM_SEEK_PLAYBACK_PORT ?? "4192");
+const baseUrl = `http://127.0.0.1:${port}`;
+const MAX_PRESENT_ATTEMPTS = 8;
+
+assert.equal(reference.version, "0.21.0", "seek/playback oracle must stay pinned to ManimCE 0.21.0");
+assert.equal(
+  rasterReport.reference.version,
+  reference.version,
+  "seek/playback oracle must consume the current pinned Manim raster report",
+);
+assert.equal(
+  rasterReport.reference.frame_rate,
+  reference.frame_rate,
+  "seek/playback oracle frame rate must match the pinned Manim report",
+);
+for (const backend of backends) {
+  assert.ok(backend === "webgpu" || backend === "webgl", `unknown backend ${backend}`);
+}
+
+function noonSourceFor(scene) {
+  const adapted = fixtureSource.replace("from manim import *", "from noon import *");
+  return `${adapted}\n\nresult = ${scene}()\nresult.setup()\ntry:\n    result.construct()\nfinally:\n    result.tear_down()\n`;
+}
+
+function browserArgs(backend) {
+  if (backend === "webgpu") {
+    return [
+      "--enable-unsafe-webgpu",
+      "--enable-unsafe-swiftshader",
+      "--use-webgpu-adapter=swiftshader",
+      "--use-gpu-in-tests",
+      "--ignore-gpu-blocklist",
+      "--enable-features=Vulkan",
+      "--use-gl=angle",
+      "--use-angle=swiftshader",
+      "--use-vulkan=swiftshader",
+      "--disable-gpu-sandbox",
+      "--disable-dev-shm-usage",
+    ];
+  }
+  return [
+    "--disable-features=WebGPU",
+    "--enable-unsafe-swiftshader",
+    "--ignore-gpu-blocklist",
+    "--use-gl=angle",
+    "--use-angle=swiftshader",
+    "--disable-gpu-sandbox",
+    "--disable-dev-shm-usage",
+  ];
+}
+
+async function authorNoonDocuments() {
+  const browser = await chromium.launch({
+    channel: "chromium",
+    headless: true,
+    args: ["--disable-dev-shm-usage"],
+  });
+  try {
+    const page = await browser.newPage();
+    await page.goto(`${baseUrl}/web/manim-compat-smoke.html`, { waitUntil: "load" });
+    await page.waitForFunction(() => window.noonManimCompat, null, { timeout: 30_000 });
+    await page.evaluate(() => window.noonManimCompat.ready());
+    const documents = new Map();
+    for (const fixture of manifest.fixtures) {
+      const result = await page.evaluate(
+        (source) => window.noonManimCompat.run(source),
+        noonSourceFor(fixture.scene),
+      );
+      assert.equal(result.kind, "scene_document", `${fixture.id}: Noon authoring result kind`);
+      assert.equal(result.duration, fixture.expected_duration, `${fixture.id}: authored Noon duration`);
+      documents.set(fixture.id, result.document);
+    }
+    return documents;
+  } finally {
+    await browser.close();
+  }
+}
+
+function frameTimesThrough(frameIndex) {
+  assert.ok(Number.isSafeInteger(frameIndex) && frameIndex >= 0, "invalid Manim frame index");
+  return Array.from(
+    { length: frameIndex + 1 },
+    (_, index) => index / reference.frame_rate,
+  );
+}
+
+async function nextAnimationFrame(page) {
+  await page.evaluate(() => new Promise((resolve) => requestAnimationFrame(resolve)));
+}
+
+async function retryPresented(page, invoke, label) {
+  let metrics = null;
+  for (let attempt = 1; attempt <= MAX_PRESENT_ATTEMPTS; attempt += 1) {
+    metrics = await invoke();
+    assert.equal(metrics.error, null, `${label}: render error`);
+    if (metrics.presented) {
+      return { metrics, attempts: attempt };
+    }
+    await nextAnimationFrame(page);
+  }
+  assert.fail(
+    `${label}: browser did not present a frame after ${MAX_PRESENT_ATTEMPTS} attempts; ` +
+      `last metrics=${JSON.stringify(metrics)}`,
+  );
+}
+
+async function presentDirect(page, time, label) {
+  return retryPresented(
+    page,
+    () => page.evaluate((target) => window.noonSmoke.renderAt(target), time),
+    label,
+  );
+}
+
+async function beginIncremental(page, label) {
+  return retryPresented(
+    page,
+    () => page.evaluate(() => window.noonSmoke.beginIncremental()),
+    label,
+  );
+}
+
+async function presentIncremental(page, time, label) {
+  return retryPresented(
+    page,
+    () => page.evaluate((target) => window.noonSmoke.renderIncrementalAt(target), time),
+    label,
+  );
+}
+
+async function assertPngPixelsEqual(directPath, incrementalPath, label) {
+  const direct = PNG.sync.read(await readFile(directPath));
+  const incremental = PNG.sync.read(await readFile(incrementalPath));
+  assert.equal(incremental.width, direct.width, `${label}: raster width changed`);
+  assert.equal(incremental.height, direct.height, `${label}: raster height changed`);
+  assert.ok(
+    direct.data.equals(incremental.data),
+    `${label}: direct seek and incremental playback produced different pixels`,
+  );
+}
+
+async function createRenderPage(browser, expectedBackend, installSnapshotHelpers) {
+  const page = await browser.newPage({
+    viewport: { width: reference.pixel_width + 40, height: reference.pixel_height + 40 },
+  });
+  await page.goto(`${baseUrl}/web/browser-smoke.html`, { waitUntil: "load" });
+  await page.waitForFunction(() => window.noonSmoke?.state.ready === true, null, {
+    timeout: 30_000,
+  });
+  const initial = await page.evaluate(() => window.noonSmoke.metrics());
+  assert.equal(initial.rendererBackend, expectedBackend, "selected renderer backend");
+  if (installSnapshotHelpers) {
+    await page.evaluate(async () => {
+      const wasm = await import("./pkg/noon_web.js");
+      await wasm.default();
+      window.noonSeekPlayback = {
+        direct: wasm.evaluateSceneSnapshot,
+        playback: wasm.evaluateScenePlaybackSnapshot,
+      };
+    });
+  }
+  return page;
+}
+
+async function verifyBackend(backend, documents) {
+  const browser = await chromium.launch({
+    channel: "chromium",
+    headless: true,
+    args: browserArgs(backend),
+  });
+  const expectedBackend = backend === "webgpu" ? "WebGPU" : "WebGL2";
+  try {
+    const backendResult = { backend, fixtures: [] };
+    for (const fixture of manifest.fixtures) {
+      let directPage = null;
+      let incrementalPage = null;
+      try {
+        // Keep the two evaluation modes on independent fresh canvas players. In
+        // particular, WebGL compositors are allowed to retain the last presented
+        // backbuffer while a new surface presentation becomes visible. Reusing one
+        // player after all late direct samples would therefore make the incremental
+        // frame-zero screenshot depend on the preceding direct-render history rather
+        // than on the evaluation mode being tested.
+        directPage = await createRenderPage(browser, expectedBackend, true);
+        incrementalPage = await createRenderPage(browser, expectedBackend, false);
+
+        const document = documents.get(fixture.id);
+        const sceneJson = JSON.stringify(document);
+        const reportFixture = rasterReport.fixtures.find((entry) => entry.id === fixture.id);
+        assert.ok(reportFixture, `${fixture.id}: missing pinned Manim raster report fixture`);
+        const reportBackend = reportFixture.backends[backend];
+        assert.ok(reportBackend, `${fixture.id}: missing ${backend} raster report entry`);
+        const samples = reportBackend.samples;
+        assert.ok(samples.length > 0, `${fixture.id}: pinned Manim report has no samples`);
+
+        const [loadedDirect, loadedIncremental] = await Promise.all([
+          directPage.evaluate((json) => window.noonSmoke.loadScene(json), sceneJson),
+          incrementalPage.evaluate((json) => window.noonSmoke.loadScene(json), sceneJson),
+        ]);
+        assert.equal(
+          loadedDirect.objectCount,
+          document.objects.length,
+          `${fixture.id}: direct player loaded object count`,
+        );
+        assert.equal(
+          loadedIncremental.objectCount,
+          document.objects.length,
+          `${fixture.id}: incremental player loaded object count`,
+        );
+
+        const fixtureDir = path.join(artifactRoot, "seek-playback", backend, fixture.id);
+        await mkdir(fixtureDir, { recursive: true });
+        const directPaths = new Map();
+        const directAttempts = new Map();
+        const sampleResults = [];
+
+        for (const sample of samples) {
+          const expectedTime = sample.frameIndex / reference.frame_rate;
+          assert.ok(
+            Math.abs(sample.time - expectedTime) <= 1e-12,
+            `${fixture.id}/${sample.frameIndex}: raster report timestamp is not the pinned Manim frame time`,
+          );
+          const state = await directPage.evaluate(
+            ({ json, time, times }) => ({
+              direct: JSON.parse(window.noonSeekPlayback.direct(json, time)),
+              incremental: JSON.parse(
+                window.noonSeekPlayback.playback(json, JSON.stringify(times)),
+              ),
+            }),
+            {
+              json: sceneJson,
+              time: sample.time,
+              times: frameTimesThrough(sample.frameIndex),
+            },
+          );
+          assert.deepEqual(
+            state.incremental,
+            state.direct,
+            `${fixture.id}/${backend}/${sample.frameIndex}: normalized state differs between direct seek and Manim-frame incremental playback`,
+          );
+
+          const direct = await presentDirect(
+            directPage,
+            sample.time,
+            `${fixture.id}/${backend}/frame-${sample.frameIndex}/direct`,
+          );
+          assert.ok(
+            Math.abs(direct.metrics.time - sample.time) <= 1e-12,
+            `${fixture.id}: direct render playhead drifted at ${sample.time}`,
+          );
+          await nextAnimationFrame(directPage);
+          const directPath = path.join(fixtureDir, `${sample.frameIndex}-direct.png`);
+          await directPage.locator("#scene").screenshot({ path: directPath });
+          directPaths.set(sample.frameIndex, directPath);
+          directAttempts.set(sample.frameIndex, direct.attempts);
+        }
+
+        const started = await beginIncremental(
+          incrementalPage,
+          `${fixture.id}/${backend}/incremental-start`,
+        );
+        assert.ok(Math.abs(started.metrics.time) <= 1e-12, `${fixture.id}: incremental start drifted`);
+        let previousTime = 0.0;
+        for (const sample of samples) {
+          assert.ok(sample.time >= previousTime, `${fixture.id}: Manim samples are not monotonic`);
+          const incremental = await presentIncremental(
+            incrementalPage,
+            sample.time,
+            `${fixture.id}/${backend}/frame-${sample.frameIndex}/incremental`,
+          );
+          assert.ok(
+            Math.abs(incremental.metrics.time - sample.time) <= 1e-12,
+            `${fixture.id}: incremental render playhead drifted at ${sample.time}`,
+          );
+          await nextAnimationFrame(incrementalPage);
+          const incrementalPath = path.join(fixtureDir, `${sample.frameIndex}-incremental.png`);
+          await incrementalPage.locator("#scene").screenshot({ path: incrementalPath });
+          const directPath = directPaths.get(sample.frameIndex);
+          await assertPngPixelsEqual(
+            directPath,
+            incrementalPath,
+            `${fixture.id}/${backend}/frame-${sample.frameIndex}`,
+          );
+          sampleResults.push({
+            frameIndex: sample.frameIndex,
+            time: sample.time,
+            normalizedStateEqual: true,
+            rasterPixelsEqual: true,
+            directPresentationAttempts: directAttempts.get(sample.frameIndex),
+            incrementalPresentationAttempts: incremental.attempts,
+          });
+          previousTime = sample.time;
+        }
+
+        backendResult.fixtures.push({
+          id: fixture.id,
+          scene: fixture.scene,
+          independentCanvasPlayers: true,
+          incrementalStartPresentationAttempts: started.attempts,
+          samples: sampleResults,
+        });
+        console.log(
+          `✓ ${fixture.id} ${backend}: direct seek == incremental playback at ${sampleResults.length} pinned Manim frames`,
+        );
+      } finally {
+        await directPage?.close();
+        await incrementalPage?.close();
+      }
+    }
+    return backendResult;
+  } finally {
+    await browser.close();
+  }
+}
+
+let serverOutput = "";
+const server = spawn(
+  "python3",
+  ["-m", "http.server", String(port), "--bind", "127.0.0.1", "--directory", repoRoot],
+  { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] },
+);
+server.stdout.on("data", (chunk) => (serverOutput += chunk));
+server.stderr.on("data", (chunk) => (serverOutput += chunk));
+
+async function waitForServer() {
+  let lastError = null;
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    try {
+      const response = await fetch(`${baseUrl}/web/browser-smoke.html`);
+      if (response.ok) return;
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`seek/playback raster server did not start: ${lastError}\n${serverOutput}`);
+}
+
+try {
+  await waitForServer();
+  const documents = await authorNoonDocuments();
+  const results = [];
+  for (const backend of backends) {
+    results.push(await verifyBackend(backend, documents));
+  }
+  const reportPath = path.join(artifactRoot, "seek-playback-report.json");
+  await writeFile(
+    reportPath,
+    `${JSON.stringify(
+      {
+        manimVersion: reference.version,
+        frameRate: reference.frame_rate,
+        sourceRasterReport: "report.json",
+        maxPresentationAttempts: MAX_PRESENT_ATTEMPTS,
+        independentCanvasPlayers: true,
+        results,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  console.log(`Pinned Manim seek/playback differential report: ${reportPath}`);
+} finally {
+  server.kill("SIGTERM");
+}

--- a/web/browser-smoke.js
+++ b/web/browser-smoke.js
@@ -10,6 +10,7 @@ const state = {
 };
 
 let player = null;
+let incrementalTime = null;
 
 window.noonSmoke = {
   state,
@@ -17,6 +18,12 @@ window.noonSmoke = {
     throw new Error("Noon browser smoke harness is not ready");
   },
   renderAt() {
+    throw new Error("Noon browser smoke harness is not ready");
+  },
+  beginIncremental() {
+    throw new Error("Noon browser smoke harness is not ready");
+  },
+  renderIncrementalAt() {
     throw new Error("Noon browser smoke harness is not ready");
   },
   metrics() {
@@ -45,23 +52,65 @@ function metrics() {
   };
 }
 
-function presentAt(timeSeconds) {
+function validateRenderTime(timeSeconds) {
   const time = Number(timeSeconds);
   if (!Number.isFinite(time) || time < 0 || time >= 4.0) {
     throw new RangeError("smoke render time must be finite and in [0, 4)");
   }
+  return time;
+}
+
+function presentAt(timeSeconds) {
+  const time = validateRenderTime(timeSeconds);
 
   // PlaybackClock treats the first timestamp after reset as semantic time zero.
   // A second controlled timestamp therefore renders the requested semantic time
   // through the exact production renderFrame path without depending on RAF speed.
+  // At t=0 the origin frame is already the requested frame, so do not render it
+  // twice; that would test renderer idempotence rather than seek/playback parity.
   player.resetClock();
-  if (player.renderFrame(0)) {
+  incrementalTime = null;
+  let presented = player.renderFrame(0);
+  if (presented) {
     state.frames += 1;
   }
-  if (player.renderFrame(time * 1000)) {
-    state.frames += 1;
+  if (time > 0) {
+    presented = player.renderFrame(time * 1000);
+    if (presented) {
+      state.frames += 1;
+    }
   }
-  return metrics();
+  return { ...metrics(), presented };
+}
+
+function beginIncremental() {
+  player.resetClock();
+  incrementalTime = null;
+  const presented = player.renderFrame(0);
+  if (presented) {
+    state.frames += 1;
+    incrementalTime = 0.0;
+  }
+  return { ...metrics(), presented };
+}
+
+function presentIncrementalAt(timeSeconds) {
+  const time = validateRenderTime(timeSeconds);
+  if (incrementalTime === null) {
+    throw new Error("incremental smoke playback must begin with a presented beginIncremental() frame");
+  }
+  if (time < incrementalTime) {
+    throw new RangeError("incremental smoke render time must not move backwards");
+  }
+  if (time === incrementalTime) {
+    return { ...metrics(), presented: true };
+  }
+  const presented = player.renderFrame(time * 1000);
+  if (presented) {
+    state.frames += 1;
+    incrementalTime = time;
+  }
+  return { ...metrics(), presented };
 }
 
 async function start() {
@@ -75,6 +124,7 @@ async function start() {
       throw new TypeError("sceneJson must be a string");
     }
     const incremental = player.reconcileScene(sceneJson);
+    incrementalTime = null;
     state.revision += 1;
     state.error = null;
     return {
@@ -84,6 +134,8 @@ async function start() {
     };
   };
   window.noonSmoke.renderAt = presentAt;
+  window.noonSmoke.beginIncremental = beginIncremental;
+  window.noonSmoke.renderIncrementalAt = presentIncrementalAt;
   window.noonSmoke.metrics = metrics;
   state.ready = true;
 }


### PR DESCRIPTION
## Summary
- add an explicit browser smoke path that advances `NoonCanvasPlayer.renderFrame()` monotonically without resetting the playback clock
- consume the actual frame indices/timestamps emitted by the pinned ManimCE v0.21.0 raster oracle
- at every sampled Manim frame, compare Noon direct seek with frame-by-frame incremental playback using the normalized deterministic runtime snapshot
- capture direct and incremental browser renders from independent fresh canvas-player pages under the same browser backend and require pixel-for-pixel equality on both WebGPU and WebGL
- retry only transient non-presented surface frames; once presented, equality remains exact
- upload seek/playback screenshots and a machine-readable report beside the existing Manim raster artifacts
- keep this as a blocking invariant even while broader Manim visual mismatches remain independently ratcheted

## Why this closes the remaining #181 gap
The existing raster oracle already renders the canonical scenes incrementally in real ManimCE and compares those frames with Noon direct seeks. This PR adds the missing Noon incremental leg at the same pinned Manim frame timestamps, so CI now proves direct seek == incremental state/raster while retaining the existing cross-engine Manim comparison.

The direct and incremental canvas players are intentionally isolated. Reusing one WebGL canvas after all late direct-seek captures made frame zero depend on the preceding presented backbuffer rather than on the evaluation path being tested. Independent fresh players remove that cross-mode presentation history without weakening the exact state or pixel assertions.

Tracks #181.