### PR TITLE
Fix WebGL browser surface color transfer parity

### DIFF
--- a/crates/noon-render-wgpu/src/gpu.rs
+++ b/crates/noon-render-wgpu/src/gpu.rs
@@ -4,6 +4,11 @@ use bytemuck::{Pod, Zeroable};
 use noon_core::Vec2;
 use wgpu::util::DeviceExt;
 
+#[path = "presentation.rs"]
+mod presentation;
+pub use presentation::OutputTransfer;
+use presentation::PresentationBridge;
+
 use crate::{
     CircleInstance, LineInstance, PathBatch, PathInstance, PathVertex, PreparedFrame,
     RectangleInstance, RenderPrimitive,
@@ -265,6 +270,7 @@ pub struct GpuRenderer {
     camera: Camera2D,
     viewport_size: [u32; 2],
     target_format: wgpu::TextureFormat,
+    presentation: PresentationBridge,
     path_msaa_texture: wgpu::Texture,
     path_msaa_view: wgpu::TextureView,
     circle_buffer: wgpu::Buffer,
@@ -290,6 +296,14 @@ pub struct GpuRenderer {
 
 impl GpuRenderer {
     pub fn new(device: &wgpu::Device, target_format: wgpu::TextureFormat) -> Self {
+        Self::new_with_output_transfer(device, target_format, OutputTransfer::Direct)
+    }
+
+    pub fn new_with_output_transfer(
+        device: &wgpu::Device,
+        surface_format: wgpu::TextureFormat,
+        output_transfer: OutputTransfer,
+    ) -> Self {
         assert_eq!(
             size_of::<CircleInstance>(),
             size_of::<RectangleInstance>(),
@@ -303,6 +317,9 @@ impl GpuRenderer {
 
         let camera = Camera2D::DEFAULT;
         let viewport_size = [1, 1];
+        let presentation =
+            PresentationBridge::new(device, surface_format, output_transfer, viewport_size);
+        let target_format = presentation.scene_format();
         let camera_uniform = camera.uniform(viewport_size);
         let camera_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("Noon camera uniform"),
@@ -464,6 +481,7 @@ impl GpuRenderer {
             camera,
             viewport_size,
             target_format,
+            presentation,
             path_msaa_texture,
             path_msaa_view,
             circle_buffer,
@@ -503,6 +521,7 @@ impl GpuRenderer {
         self.viewport_size = [width.max(1), height.max(1)];
         (self.path_msaa_texture, self.path_msaa_view) =
             create_path_msaa_target(device, self.target_format, self.viewport_size);
+        self.presentation.resize(device, self.viewport_size);
         self.write_camera_uniform(queue);
     }
 
@@ -752,13 +771,14 @@ impl GpuRenderer {
         clear_color: wgpu::Color,
         query_set: Option<&wgpu::QuerySet>,
     ) -> DrawStats {
+        let scene_view = self.presentation.scene_view(view);
         let sample_count = ordered_render_sample_count(prepared.path_batches);
-        if sample_count == 1 {
+        let stats = if sample_count == 1 {
             // Analytic SDF primitives already use derivative-based edge coverage. When
             // no visible vector path participates in painter order, avoid 4x sample
             // shading and the multisample resolve without changing alpha ordering.
             let color_attachments = [Some(wgpu::RenderPassColorAttachment {
-                view,
+                view: scene_view,
                 depth_slice: None,
                 resolve_target: None,
                 ops: wgpu::Operations {
@@ -779,35 +799,37 @@ impl GpuRenderer {
                 occlusion_query_set: None,
                 multiview_mask: None,
             });
-            return self.draw_ordered(&mut pass, prepared, true);
-        }
-
-        // Mixed vector/analytic content still shares one 4x multisampled target so
-        // pipeline switches follow semantic painter order. Splitting these primitives
-        // into separate passes would not be alpha-order safe.
-        let color_attachments = [Some(wgpu::RenderPassColorAttachment {
-            view: &self.path_msaa_view,
-            depth_slice: None,
-            resolve_target: Some(view),
-            ops: wgpu::Operations {
-                load: wgpu::LoadOp::Clear(clear_color),
-                store: wgpu::StoreOp::Discard,
-            },
-        })];
-        let timestamp_writes = query_set.map(|query_set| wgpu::RenderPassTimestampWrites {
-            query_set,
-            beginning_of_pass_write_index: Some(0),
-            end_of_pass_write_index: Some(1),
-        });
-        let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-            label: Some("Noon ordered multisampled render pass"),
-            color_attachments: &color_attachments,
-            depth_stencil_attachment: None,
-            timestamp_writes,
-            occlusion_query_set: None,
-            multiview_mask: None,
-        });
-        self.draw_ordered(&mut pass, prepared, false)
+            self.draw_ordered(&mut pass, prepared, true)
+        } else {
+            // Mixed vector/analytic content still shares one 4x multisampled target so
+            // pipeline switches follow semantic painter order. Splitting these primitives
+            // into separate passes would not be alpha-order safe.
+            let color_attachments = [Some(wgpu::RenderPassColorAttachment {
+                view: &self.path_msaa_view,
+                depth_slice: None,
+                resolve_target: Some(scene_view),
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(clear_color),
+                    store: wgpu::StoreOp::Discard,
+                },
+            })];
+            let timestamp_writes = query_set.map(|query_set| wgpu::RenderPassTimestampWrites {
+                query_set,
+                beginning_of_pass_write_index: Some(0),
+                end_of_pass_write_index: Some(1),
+            });
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("Noon ordered multisampled render pass"),
+                color_attachments: &color_attachments,
+                depth_stencil_attachment: None,
+                timestamp_writes,
+                occlusion_query_set: None,
+                multiview_mask: None,
+            });
+            self.draw_ordered(&mut pass, prepared, false)
+        };
+        self.presentation.encode_present(encoder, view);
+        stats
     }
 
     fn draw_ordered<'a>(
@@ -1491,6 +1513,47 @@ mod tests {
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
             format: FORMAT,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            view_formats: &[],
+        });
+        let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+        let mut encoder =
+            device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+        let draw = renderer.encode(&mut encoder, &view, &prepared, wgpu::Color::BLACK);
+        queue.submit(Some(encoder.finish()));
+
+        assert_eq!(draw.draw_calls, 3);
+        assert_eq!(draw.instances_drawn, 3);
+    }
+
+    #[test]
+    fn noop_device_validates_webgl_presentation_transfer() {
+        const WEBGL_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8Unorm;
+        let (device, queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
+        let mut renderer = GpuRenderer::new_with_output_transfer(
+            &device,
+            WEBGL_FORMAT,
+            OutputTransfer::BrowserWebGlSrgb,
+        );
+        renderer.set_viewport(&device, &queue, 64, 64);
+        assert_eq!(renderer.target_format, WEBGL_FORMAT);
+
+        let frame = test_frame();
+        let mut preparer = FramePreparer::new();
+        let prepared = preparer.prepare(&frame);
+        renderer.upload(&device, &queue, &prepared);
+
+        let texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("Noon WebGL presentation noop target"),
+            size: wgpu::Extent3d {
+                width: 64,
+                height: 64,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: WEBGL_FORMAT,
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
             view_formats: &[],
         });

--- a/crates/noon-render-wgpu/src/presentation.rs
+++ b/crates/noon-render-wgpu/src/presentation.rs
@@ -1,0 +1,230 @@
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum OutputTransfer {
+    #[default]
+    Direct,
+    /// The browser WebGL drawing buffer applies an sRGB store transfer even
+    /// though wgpu exposes the surface as `Rgba8Unorm`. Keep scene rendering in
+    /// encoded UNORM space, then decode exactly once before presentation.
+    BrowserWebGlSrgb,
+}
+
+impl OutputTransfer {
+    pub const fn for_browser_backend(backend: wgpu::Backend) -> Self {
+        match backend {
+            wgpu::Backend::Gl => Self::BrowserWebGlSrgb,
+            _ => Self::Direct,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct PresentationBridge {
+    transfer: OutputTransfer,
+    scene_format: wgpu::TextureFormat,
+    viewport_size: [u32; 2],
+    texture: Option<wgpu::Texture>,
+    view: Option<wgpu::TextureView>,
+    bind_group_layout: Option<wgpu::BindGroupLayout>,
+    bind_group: Option<wgpu::BindGroup>,
+    pipeline: Option<wgpu::RenderPipeline>,
+}
+
+impl PresentationBridge {
+    pub(crate) fn new(
+        device: &wgpu::Device,
+        surface_format: wgpu::TextureFormat,
+        transfer: OutputTransfer,
+        viewport_size: [u32; 2],
+    ) -> Self {
+        let scene_format = match transfer {
+            OutputTransfer::Direct => surface_format,
+            OutputTransfer::BrowserWebGlSrgb => surface_format.remove_srgb_suffix(),
+        };
+        let mut result = Self {
+            transfer,
+            scene_format,
+            viewport_size: [viewport_size[0].max(1), viewport_size[1].max(1)],
+            texture: None,
+            view: None,
+            bind_group_layout: None,
+            bind_group: None,
+            pipeline: None,
+        };
+        if transfer == OutputTransfer::BrowserWebGlSrgb {
+            result.initialize_decode_pipeline(device, surface_format);
+            result.recreate_scene_target(device);
+        }
+        result
+    }
+
+    pub(crate) const fn scene_format(&self) -> wgpu::TextureFormat {
+        self.scene_format
+    }
+
+    pub(crate) fn resize(&mut self, device: &wgpu::Device, viewport_size: [u32; 2]) {
+        let viewport_size = [viewport_size[0].max(1), viewport_size[1].max(1)];
+        if self.viewport_size == viewport_size {
+            return;
+        }
+        self.viewport_size = viewport_size;
+        if self.transfer == OutputTransfer::BrowserWebGlSrgb {
+            self.recreate_scene_target(device);
+        }
+    }
+
+    pub(crate) fn scene_view<'a>(
+        &'a self,
+        surface_view: &'a wgpu::TextureView,
+    ) -> &'a wgpu::TextureView {
+        self.view.as_ref().unwrap_or(surface_view)
+    }
+
+    pub(crate) fn encode_present(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        surface_view: &wgpu::TextureView,
+    ) {
+        let (Some(pipeline), Some(bind_group)) = (&self.pipeline, &self.bind_group) else {
+            return;
+        };
+        let color_attachments = [Some(wgpu::RenderPassColorAttachment {
+            view: surface_view,
+            depth_slice: None,
+            resolve_target: None,
+            ops: wgpu::Operations {
+                load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                store: wgpu::StoreOp::Store,
+            },
+        })];
+        let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("Noon browser presentation transfer pass"),
+            color_attachments: &color_attachments,
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        });
+        pass.set_pipeline(pipeline);
+        pass.set_bind_group(0, bind_group, &[]);
+        pass.draw(0..3, 0..1);
+    }
+
+    fn initialize_decode_pipeline(
+        &mut self,
+        device: &wgpu::Device,
+        surface_format: wgpu::TextureFormat,
+    ) {
+        let bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("Noon browser presentation bind group layout"),
+                entries: &[wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: false },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                }],
+            });
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("Noon browser presentation pipeline layout"),
+            bind_group_layouts: &[Some(&bind_group_layout)],
+            immediate_size: 0,
+        });
+        let shader = device.create_shader_module(wgpu::include_wgsl!("presentation.wgsl"));
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("Noon browser sRGB presentation pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_present"),
+                compilation_options: Default::default(),
+                buffers: &[],
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_present"),
+                compilation_options: Default::default(),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: surface_format,
+                    blend: None,
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+            }),
+            primitive: wgpu::PrimitiveState::default(),
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            multiview_mask: None,
+            cache: None,
+        });
+        self.bind_group_layout = Some(bind_group_layout);
+        self.pipeline = Some(pipeline);
+    }
+
+    fn recreate_scene_target(&mut self, device: &wgpu::Device) {
+        let texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("Noon encoded browser scene target"),
+            size: wgpu::Extent3d {
+                width: self.viewport_size[0],
+                height: self.viewport_size[1],
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: self.scene_format,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING,
+            view_formats: &[],
+        });
+        let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("Noon browser presentation bind group"),
+            layout: self
+                .bind_group_layout
+                .as_ref()
+                .expect("decode presentation requires a bind group layout"),
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: wgpu::BindingResource::TextureView(&view),
+            }],
+        });
+        self.texture = Some(texture);
+        self.view = Some(view);
+        self.bind_group = Some(bind_group);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_browser_gl_needs_the_presentation_decode() {
+        assert_eq!(
+            OutputTransfer::for_browser_backend(wgpu::Backend::Gl),
+            OutputTransfer::BrowserWebGlSrgb
+        );
+        assert_eq!(
+            OutputTransfer::for_browser_backend(wgpu::Backend::BrowserWebGpu),
+            OutputTransfer::Direct
+        );
+        assert_eq!(
+            OutputTransfer::for_browser_backend(wgpu::Backend::Vulkan),
+            OutputTransfer::Direct
+        );
+    }
+
+    #[test]
+    fn webgl_scene_target_strips_only_the_surface_srgb_suffix() {
+        assert_eq!(
+            wgpu::TextureFormat::Rgba8UnormSrgb.remove_srgb_suffix(),
+            wgpu::TextureFormat::Rgba8Unorm
+        );
+        assert_eq!(
+            wgpu::TextureFormat::Rgba8Unorm.remove_srgb_suffix(),
+            wgpu::TextureFormat::Rgba8Unorm
+        );
+    }
+}

--- a/crates/noon-render-wgpu/src/presentation.rs
+++ b/crates/noon-render-wgpu/src/presentation.rs
@@ -36,6 +36,17 @@ impl PresentationBridge {
         transfer: OutputTransfer,
         viewport_size: [u32; 2],
     ) -> Self {
+        // Browser WebGL exposes an ordinary `Rgba8Unorm` wgpu surface, but its
+        // drawing buffer still applies the browser's sRGB presentation transfer.
+        // Resolve that backend fact here so every canvas host gets the same color
+        // contract without duplicating adapter plumbing in noon-web.
+        #[cfg(target_arch = "wasm32")]
+        let transfer = if transfer == OutputTransfer::Direct {
+            OutputTransfer::for_browser_backend(device.adapter_info().backend)
+        } else {
+            transfer
+        };
+
         let scene_format = match transfer {
             OutputTransfer::Direct => surface_format,
             OutputTransfer::BrowserWebGlSrgb => surface_format.remove_srgb_suffix(),
@@ -92,7 +103,12 @@ impl PresentationBridge {
             depth_slice: None,
             resolve_target: None,
             ops: wgpu::Operations {
-                load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                load: wgpu::LoadOp::Clear(wgpu::Color {
+                    r: 0.0,
+                    g: 0.0,
+                    b: 0.0,
+                    a: 0.0,
+                }),
                 store: wgpu::StoreOp::Store,
             },
         })];

--- a/crates/noon-render-wgpu/src/presentation.rs
+++ b/crates/noon-render-wgpu/src/presentation.rs
@@ -130,20 +130,19 @@ impl PresentationBridge {
         device: &wgpu::Device,
         surface_format: wgpu::TextureFormat,
     ) {
-        let bind_group_layout =
-            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-                label: Some("Noon browser presentation bind group layout"),
-                entries: &[wgpu::BindGroupLayoutEntry {
-                    binding: 0,
-                    visibility: wgpu::ShaderStages::FRAGMENT,
-                    ty: wgpu::BindingType::Texture {
-                        sample_type: wgpu::TextureSampleType::Float { filterable: false },
-                        view_dimension: wgpu::TextureViewDimension::D2,
-                        multisampled: false,
-                    },
-                    count: None,
-                }],
-            });
+        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("Noon browser presentation bind group layout"),
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Texture {
+                    sample_type: wgpu::TextureSampleType::Float { filterable: false },
+                    view_dimension: wgpu::TextureViewDimension::D2,
+                    multisampled: false,
+                },
+                count: None,
+            }],
+        });
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some("Noon browser presentation pipeline layout"),
             bind_group_layouts: &[Some(&bind_group_layout)],

--- a/crates/noon-render-wgpu/src/presentation.wgsl
+++ b/crates/noon-render-wgpu/src/presentation.wgsl
@@ -1,0 +1,46 @@
+@group(0) @binding(0)
+var scene_texture: texture_2d<f32>;
+
+@vertex
+fn vs_present(@builtin(vertex_index) vertex_index: u32) -> @builtin(position) vec4<f32> {
+    var positions = array<vec2<f32>, 3>(
+        vec2<f32>(-1.0, -1.0),
+        vec2<f32>(3.0, -1.0),
+        vec2<f32>(-1.0, 3.0),
+    );
+    return vec4<f32>(positions[vertex_index], 0.0, 1.0);
+}
+
+fn srgb_to_linear_channel(encoded: f32) -> f32 {
+    if encoded <= 0.04045 {
+        return encoded / 12.92;
+    }
+    return pow((encoded + 0.055) / 1.055, 2.4);
+}
+
+fn srgb_to_linear(encoded: vec3<f32>) -> vec3<f32> {
+    return vec3<f32>(
+        srgb_to_linear_channel(encoded.r),
+        srgb_to_linear_channel(encoded.g),
+        srgb_to_linear_channel(encoded.b),
+    );
+}
+
+@fragment
+fn fs_present(@builtin(position) position: vec4<f32>) -> @location(0) vec4<f32> {
+    let dimensions = textureDimensions(scene_texture);
+    let pixel = clamp(
+        vec2<i32>(position.xy),
+        vec2<i32>(0),
+        vec2<i32>(dimensions) - vec2<i32>(1),
+    );
+    let encoded = textureLoad(scene_texture, pixel, 0);
+
+    // Noon's semantic colors intentionally carry their display/sRGB encoding all
+    // the way through scene blending. WebGL's browser drawing buffer applies an
+    // unavoidable sRGB store transfer, unlike the WebGPU UNORM presentation path.
+    // Decode only at the final presentation boundary so that the browser's store
+    // transfer reconstructs the exact encoded scene bytes without changing any
+    // fill/stroke/alpha blending inside the scene render.
+    return vec4<f32>(srgb_to_linear(encoded.rgb), encoded.a);
+}


### PR DESCRIPTION
## Summary
- keep Noon/Manim scene colors and alpha compositing in the existing encoded UNORM render space
- detect browser WebGL from the wgpu `Device` backend inside the renderer
- render WebGL scenes into an intermediate encoded-color texture
- apply a final sRGB decode presentation pass so the browser drawing buffer's unavoidable store transfer reconstructs the intended output bytes
- leave WebGPU/native direct rendering unchanged

## Why
The original #149 hypothesis focused on surface-format selection, but wgpu 29 already advertises `Rgba8Unorm` first for both browser WebGL and WebGPU. The measured WebGL background `(53,61,77)` from an intended encoded `(9,12,19)` instead points to the browser WebGL drawing-buffer transfer itself.

Applying gamma to individual object fragments would change alpha blending and overlap semantics. This PR preserves the current Manim-compatible encoded-space blending and corrects transfer exactly once at presentation.

## Validation
- noop device validates the intermediate texture, presentation pipeline, shader and resource bindings
- runtime backend policy applies the extra pass only to wasm WebGL
- canonical ManimCE v0.21 Cairo raster workflow is the acceptance oracle
- WebGPU results must remain unchanged while WebGL deltas should converge toward their WebGPU counterparts

Closes #149.
Tracks #180.