### PR TITLE
Require successful presentation before raster capture

### DIFF
--- a/scripts/manim-raster-differential.mjs
+++ b/scripts/manim-raster-differential.mjs
@@ -223,6 +223,19 @@ function browserArgs(backend) {
   ];
 }
 
+async function createCapturePage(browser, expectedBackend, backend) {
+  const page = await browser.newPage({
+    viewport: { width: reference.pixel_width + 40, height: reference.pixel_height + 40 },
+  });
+  await page.goto(`${baseUrl}/web/browser-smoke.html`, { waitUntil: "load" });
+  await page.waitForFunction(() => window.noonSmoke?.state.ready === true, null, {
+    timeout: 30_000,
+  });
+  const initial = await page.evaluate(() => window.noonSmoke.metrics());
+  assert.equal(initial.rendererBackend, expectedBackend, `${backend}: selected renderer backend`);
+  return page;
+}
+
 async function captureNoonBackend(backend, documents, references) {
   const browser = await chromium.launch({
     channel: "chromium",
@@ -231,43 +244,44 @@ async function captureNoonBackend(backend, documents, references) {
   });
   const expectedBackend = backend === "webgpu" ? "WebGPU" : "WebGL2";
   try {
-    const page = await browser.newPage({
-      viewport: { width: reference.pixel_width + 40, height: reference.pixel_height + 40 },
-    });
-    await page.goto(`${baseUrl}/web/browser-smoke.html`, { waitUntil: "load" });
-    await page.waitForFunction(() => window.noonSmoke?.state.ready === true, null, {
-      timeout: 30_000,
-    });
-    const initial = await page.evaluate(() => window.noonSmoke.metrics());
-    assert.equal(initial.rendererBackend, expectedBackend, `${backend}: selected renderer backend`);
-
     const output = new Map();
     for (const fixture of manifest.fixtures) {
-      const document = documents.get(fixture.id);
-      const loaded = await page.evaluate(
-        (json) => window.noonSmoke.loadScene(json),
-        JSON.stringify(document),
-      );
-      assert.equal(loaded.objectCount, document.objects.length, `${fixture.id}: loaded object count`);
-      const fixtureDir = path.join(artifactRoot, backend, fixture.id);
-      await mkdir(fixtureDir, { recursive: true });
-      const captures = [];
-      for (const sample of references.get(fixture.id).samples) {
-        const metrics = await page.evaluate(
-          (time) => window.noonSmoke.renderAt(time),
-          sample.time,
+      let page = null;
+      try {
+        // Give every parity fixture an independent canvas player. WebGL drawing
+        // buffers may retain the last presented backbuffer while a new scene's
+        // first presentation becomes visible; reusing one player across fixtures
+        // therefore makes frame zero depend on fixture order instead of scene state.
+        page = await createCapturePage(browser, expectedBackend, backend);
+        const document = documents.get(fixture.id);
+        const loaded = await page.evaluate(
+          (json) => window.noonSmoke.loadScene(json),
+          JSON.stringify(document),
         );
-        assert.equal(metrics.error, null, `${fixture.id}: Noon render error at ${sample.time}`);
-        await page.evaluate(() => new Promise((resolve) => requestAnimationFrame(resolve)));
-        const outputPath = path.join(fixtureDir, `${sample.label}.png`);
-        await page.locator("#scene").screenshot({ path: outputPath });
-        captures.push({ ...sample, noonPath: outputPath, metrics });
+        assert.equal(loaded.objectCount, document.objects.length, `${fixture.id}: loaded object count`);
+        const fixtureDir = path.join(artifactRoot, backend, fixture.id);
+        await mkdir(fixtureDir, { recursive: true });
+        const captures = [];
+        for (const sample of references.get(fixture.id).samples) {
+          const metrics = await page.evaluate(
+            (time) => window.noonSmoke.renderAt(time),
+            sample.time,
+          );
+          assert.equal(metrics.error, null, `${fixture.id}: Noon render error at ${sample.time}`);
+          assert.equal(metrics.presented, true, `${fixture.id}: frame was not presented at ${sample.time}`);
+          await page.evaluate(() => new Promise((resolve) => requestAnimationFrame(resolve)));
+          const outputPath = path.join(fixtureDir, `${sample.label}.png`);
+          await page.locator("#scene").screenshot({ path: outputPath });
+          captures.push({ ...sample, noonPath: outputPath, metrics });
+        }
+        output.set(fixture.id, {
+          duration: document.__noonAuthoredDuration,
+          objectCount: document.objects.length,
+          captures,
+        });
+      } finally {
+        await page?.close();
       }
-      output.set(fixture.id, {
-        duration: document.__noonAuthoredDuration,
-        objectCount: document.objects.length,
-        captures,
-      });
     }
     return output;
   } finally {

--- a/web/browser-smoke.js
+++ b/web/browser-smoke.js
@@ -2,6 +2,7 @@ import init, { NoonCanvasPlayer, demoSceneJson } from "./pkg/noon_web.js";
 
 const canvas = document.querySelector("#scene");
 const MANIM_DEFAULT_CAMERA_HEIGHT = 8.0;
+const MAX_PRESENT_ATTEMPTS = 4;
 const state = {
   ready: false,
   error: null,
@@ -60,7 +61,32 @@ function validateRenderTime(timeSeconds) {
   return time;
 }
 
-function presentAt(timeSeconds) {
+function recordPresent(timestampMs) {
+  const presented = player.renderFrame(timestampMs);
+  if (presented) {
+    state.frames += 1;
+  }
+  return presented;
+}
+
+function presentTimestamp(timestampMs) {
+  let presented = false;
+  for (let attempt = 0; attempt < MAX_PRESENT_ATTEMPTS && !presented; attempt += 1) {
+    presented = recordPresent(timestampMs);
+  }
+  return presented;
+}
+
+function waitForPaint() {
+  // requestAnimationFrame callbacks run before their frame is painted. Crossing
+  // two callbacks guarantees that the first callback's frame has completed its
+  // paint/compositor handoff before Playwright reads the canvas.
+  return new Promise((resolve) => {
+    requestAnimationFrame(() => requestAnimationFrame(resolve));
+  });
+}
+
+async function presentAt(timeSeconds) {
   const time = validateRenderTime(timeSeconds);
 
   // PlaybackClock treats the first timestamp after reset as semantic time zero.
@@ -70,31 +96,28 @@ function presentAt(timeSeconds) {
   // twice; that would test renderer idempotence rather than seek/playback parity.
   player.resetClock();
   incrementalTime = null;
-  let presented = player.renderFrame(0);
-  if (presented) {
-    state.frames += 1;
-  }
+  let presented = presentTimestamp(0);
   if (time > 0) {
-    presented = player.renderFrame(time * 1000);
-    if (presented) {
-      state.frames += 1;
-    }
+    presented = presentTimestamp(time * 1000);
+  }
+  if (presented) {
+    await waitForPaint();
   }
   return { ...metrics(), presented };
 }
 
-function beginIncremental() {
+async function beginIncremental() {
   player.resetClock();
   incrementalTime = null;
-  const presented = player.renderFrame(0);
+  const presented = recordPresent(0);
   if (presented) {
-    state.frames += 1;
     incrementalTime = 0.0;
+    await waitForPaint();
   }
   return { ...metrics(), presented };
 }
 
-function presentIncrementalAt(timeSeconds) {
+async function presentIncrementalAt(timeSeconds) {
   const time = validateRenderTime(timeSeconds);
   if (incrementalTime === null) {
     throw new Error("incremental smoke playback must begin with a presented beginIncremental() frame");
@@ -105,10 +128,10 @@ function presentIncrementalAt(timeSeconds) {
   if (time === incrementalTime) {
     return { ...metrics(), presented: true };
   }
-  const presented = player.renderFrame(time * 1000);
+  const presented = recordPresent(time * 1000);
   if (presented) {
-    state.frames += 1;
     incrementalTime = time;
+    await waitForPaint();
   }
   return { ...metrics(), presented };
 }


### PR DESCRIPTION
## Summary
- make the browser smoke harness honor `renderFrame`'s presentation boolean
- retry the requested semantic timestamp up to four times on transient surface misses
- wait through a completed browser paint before returning a frame for screenshot capture
- fail explicitly instead of silently screenshotting a stale prior fixture
- leave the production renderer and raster thresholds unchanged

## Why
The #212 WebGL color-transfer run exposed two apparent backend-only regressions that are stale canvas captures:
- `animated-square-to-circle` WebGL frame 0 showed the previous `SquareAndCircle` fixture, inflating worst diff to 6.60%
- `square-to-circle` WebGL frame 0 showed the previous `CreateCircle` fixture, inflating worst diff to 2.90%

The first probe established that `NoonCanvasPlayer.renderFrame` does return `true` for those captures, so the remaining race is after GPU presentation: a `requestAnimationFrame` callback runs before that frame is painted. The smoke API now crosses two RAF callbacks before resolving, which guarantees the first RAF's paint/compositor handoff completed before Playwright screenshots the canvas.

The bounded `renderFrame` retry remains independently useful for timeout/outdated/lost surface states. Neither change alters scene evaluation, animation behavior, renderer output, or comparison tolerances.

## Expected validation
With the same pinned ManimCE v0.21 Cairo oracle:
- `animated-square-to-circle` WebGL should converge from the false 6.60% worst-case toward the ~0.29% WebGPU result
- `square-to-circle` WebGL should converge from 2.90% toward the real ~1.84% midpoint geometry mismatch already visible on WebGPU
- all genuine parity failures remain visible

Tracks #176.