### PR TITLE
Add Manim palette and translucent compositing parity probes

### DIFF
--- a/parity/manim-v0.21/manifest.json
+++ b/parity/manim-v0.21/manifest.json
@@ -60,6 +60,16 @@
       "id": "set-color-independent-opacity",
       "scene": "SetColorIndependentOpacity",
       "expected_duration": 1.0
+    },
+    {
+      "id": "palette-swatches",
+      "scene": "PaletteSwatches",
+      "expected_duration": 1.0
+    },
+    {
+      "id": "translucent-painter-order",
+      "scene": "TranslucentPainterOrder",
+      "expected_duration": 1.0
     }
   ],
   "sample_fractions": [

--- a/parity/manim-v0.21/quickstart.py
+++ b/parity/manim-v0.21/quickstart.py
@@ -107,3 +107,38 @@ class SetColorIndependentOpacity(Scene):
         # Keep a real one-second animation interval so the raster oracle samples
         # normal Manim frames instead of save-last-frame collapsing a static wait.
         self.play(square.animate.shift(ORIGIN))
+
+
+class PaletteSwatches(Scene):
+    def construct(self):
+        colors = [RED, GREEN, BLUE, YELLOW, PURPLE]
+        swatches = []
+        for index, color in enumerate(colors):
+            swatch = Square(
+                side_length=0.9,
+                fill_color=color,
+                fill_opacity=1.0,
+                stroke_opacity=0.0,
+            )
+            swatch.move_to((index - 2) * 1.2 * RIGHT)
+            swatches.append(swatch)
+        self.add(*swatches)
+        self.play(swatches[-1].animate.shift(ORIGIN))
+
+
+class TranslucentPainterOrder(Scene):
+    def construct(self):
+        back = Square(
+            side_length=2.4,
+            fill_color=RED,
+            fill_opacity=0.5,
+            stroke_opacity=0.0,
+        ).shift(0.4 * LEFT)
+        front = Square(
+            side_length=2.4,
+            fill_color=BLUE,
+            fill_opacity=0.5,
+            stroke_opacity=0.0,
+        ).shift(0.4 * RIGHT)
+        self.add(back, front)
+        self.play(front.animate.shift(ORIGIN))


### PR DESCRIPTION
Continues #180 with source-equivalent raster coverage for two remaining style/color acceptance areas.

- add representative RED/GREEN/BLUE/YELLOW/PURPLE swatches with opaque fill and disabled stroke
- add overlapping 50%-alpha RED/BLUE squares with explicit painter order
- keep both probes on a real one-second no-op animation interval so timing and the #210 seek/playback invariant are exercised
- use the existing ManimCE 0.21.0 raster oracle on both WebGPU and WebGL

Measured oracle results:
- palette swatches: exact interior RGB bytes for all five colors on both backends; max differing ratio 0.4635%, MAE 0.377; the only category is a 3 px geometry/bounds difference owned by the geometry/layout parity lanes
- translucent painter order: max differing ratio 0.4105%, MAE 0.155, bounds within 2 px; single-layer colors are exact and the overlap differs by only one blue-channel level from Manim due to raster rounding
- WebGPU and WebGL results are identical
- direct seek == incremental playback at all sampled Manim frame times

This remains partial #180; opacity ladders/global opacity and animated style interpolation still need dedicated acceptance coverage.