### PR TITLE
Reuse canonical Manim outlines for cross-kind transforms

### DIFF
--- a/crates/noon-compile/src/lib.rs
+++ b/crates/noon-compile/src/lib.rs
@@ -8,7 +8,7 @@ use std::collections::BTreeMap;
 use noon_core::{
     validate_track_definition, CompositionTimeMap, GeometryRef, MutationTransaction, ObjectId,
     Property, SceneDefinition, ScenePatch, Style, TimelineError, TrackDefinition, TrackId,
-    TrackTiming, TrackValues, Transform2D, Vec2, VectorPath,
+    TrackTiming, TrackValues, Transform2D, VectorPath,
 };
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -952,9 +952,9 @@ fn compile_transform_geometry_plan(
         }
         (GeometryRef::Circle { .. }, GeometryRef::Rectangle { .. })
         | (GeometryRef::Rectangle { .. }, GeometryRef::Circle { .. }) => {
-            let source = closed_analytic_path(&from.geometry)
+            let source = noon_geometry::canonical_outline_path(&from.geometry)
                 .expect("closed analytic source geometry must convert to a path");
-            let target = closed_analytic_path(&to.geometry)
+            let target = noon_geometry::canonical_outline_path(&to.geometry)
                 .expect("closed analytic target geometry must convert to a path");
             compile_path_pair(from, to, source, target)?
         }
@@ -988,55 +988,6 @@ fn compile_path_pair(
     Ok(TransformGeometryPlan::PathPair(GeometryRef::path(
         source.with_morph_target(target),
     )))
-}
-
-fn closed_analytic_path(geometry: &GeometryRef) -> Option<VectorPath> {
-    match geometry {
-        GeometryRef::Circle { radius } => Some(circle_path(*radius)),
-        GeometryRef::Rectangle { size } => Some(rectangle_path(*size)),
-        _ => None,
-    }
-}
-
-fn circle_path(radius: f32) -> VectorPath {
-    let handle = radius * 0.552_284_8;
-    VectorPath::new()
-        .move_to(Vec2::new(radius, 0.0))
-        .cubic_to(
-            Vec2::new(radius, handle),
-            Vec2::new(handle, radius),
-            Vec2::new(0.0, radius),
-        )
-        .cubic_to(
-            Vec2::new(-handle, radius),
-            Vec2::new(-radius, handle),
-            Vec2::new(-radius, 0.0),
-        )
-        .cubic_to(
-            Vec2::new(-radius, -handle),
-            Vec2::new(-handle, -radius),
-            Vec2::new(0.0, -radius),
-        )
-        .cubic_to(
-            Vec2::new(handle, -radius),
-            Vec2::new(radius, -handle),
-            Vec2::new(radius, 0.0),
-        )
-        .close()
-}
-
-fn rectangle_path(size: Vec2) -> VectorPath {
-    let half = size * 0.5;
-    VectorPath::new()
-        .move_to(Vec2::new(half.x, 0.0))
-        .line_to(Vec2::new(half.x, half.y))
-        .line_to(Vec2::new(0.0, half.y))
-        .line_to(Vec2::new(-half.x, half.y))
-        .line_to(Vec2::new(-half.x, 0.0))
-        .line_to(Vec2::new(-half.x, -half.y))
-        .line_to(Vec2::new(0.0, -half.y))
-        .line_to(Vec2::new(half.x, -half.y))
-        .close()
 }
 
 fn compile_error(id: TrackId, error: TransformCompileFailure) -> CompileError {

--- a/crates/noon-compile/tests/generic_transform.rs
+++ b/crates/noon-compile/tests/generic_transform.rs
@@ -114,8 +114,22 @@ fn circle_to_rectangle_transform_uses_renderer_only_path_pair() {
     else {
         panic!("cross-kind closed analytic Transform must use a prepared path pair");
     };
-    assert!(!prepared.commands().is_empty());
-    assert!(prepared.morph_target().is_some());
+    let canonical_source =
+        noon_geometry::canonical_outline_path(&from.geometry).expect("canonical circle outline");
+    let canonical_target =
+        noon_geometry::canonical_outline_path(&to.geometry).expect("canonical rectangle outline");
+    assert_eq!(prepared.commands(), canonical_source.commands());
+    assert_eq!(prepared.morph_target(), Some(&canonical_target));
+    assert_eq!(
+        prepared.commands().len(),
+        10,
+        "Manim circle uses eight cubic curves"
+    );
+    assert_eq!(
+        canonical_target.commands().len(),
+        5,
+        "Manim rectangle uses four edges"
+    );
 
     let TrackValues::Object {
         from: compiled_from,


### PR DESCRIPTION
## Summary
- make Circle↔Rectangle `TransformGeometryPlan::PathPair` reuse `noon_geometry::canonical_outline_path`
- delete the compiler's stale duplicate four-cubic circle and midpoint-subdivided rectangle converters
- preserve analytic semantic geometry while ensuring renderer-only transform paths use the same pinned ManimCE v0.21 contour source as Create/reveal
- strengthen the compiler regression to require the exact canonical source/target paths: 8 cubic circle segments and 4 rectangle edges

## Why
#190 fixed canonical primitive outlines, but `noon-compile` still carried an older private conversion used only by cross-kind Transform. That meant static/Create geometry and Circle↔Rectangle Transform intermediate geometry disagreed about VMobject path topology. This PR removes that second source of truth.

## Validation before PR
A branch-local surgical edit ran `cargo fmt --all`, `cargo test -p noon-compile`, and `git diff --check` successfully. The branch was then reconstructed as one clean commit on current master, with only the two intended compiler/test files changed.

Tracks #183.