### PR TITLE
Enforce per-fixture Manim raster tolerances

### DIFF
--- a/.github/workflows/manim-raster-differential.yml
+++ b/.github/workflows/manim-raster-differential.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Validate raster ratchet policy
+        run: node scripts/manim-raster-policy.test.mjs
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -70,6 +73,11 @@ jobs:
           NOON_MANIM_RASTER_BACKENDS: webgpu,webgl
           NOON_MANIM_RASTER_ARTIFACTS: manim-raster-artifacts
         run: node scripts/manim-raster-differential.mjs
+
+      - name: Enforce per-fixture raster ratchet
+        env:
+          NOON_MANIM_RASTER_ARTIFACTS: manim-raster-artifacts
+        run: node scripts/manim-raster-enforce.mjs
 
       - name: Verify direct seek and incremental playback at Manim frame times
         env:

--- a/docs/manim-raster-differential.md
+++ b/docs/manim-raster-differential.md
@@ -4,14 +4,9 @@ Noon's semantic Manim differential suite (`scripts/manim-differential.py`) answe
 
 The reference is pinned to **Manim Community v0.21.0 using the Cairo renderer**. The canonical source lives under `parity/manim-v0.21/` and imports real `manim`. The Noon side changes only that import to `noon` and appends a scene-selection wrapper required by the browser authoring worker. Do not tune geometry, colors, runtimes, waits, or positions for Noon in these fixtures.
 
-## Initial corpus
+## Canonical corpus
 
-The first tranche is the source-equivalent Manim quickstart subset:
-
-- `CreateCircle`
-- `SquareToCircle`
-- `SquareAndCircle`
-- `AnimatedSquareToCircle`
+The corpus started with the source-equivalent Manim quickstart subset and now also contains focused reveal, style, palette, and alpha-compositing probes. The fixture list and its expected durations live in `parity/manim-v0.21/manifest.json`.
 
 These are intentionally separate from the demo's pedagogical Noon adaptations. A demo being `ready` means it executes; it does not mean its output is Manim-parity-qualified.
 
@@ -19,13 +14,14 @@ These are intentionally separate from the demo's pedagogical Noon adaptations. A
 
 `parity/manim-v0.21/manifest.json` fixes:
 
-- ManimCE version: 0.21.0
-- renderer: Cairo
-- output: 960×540
-- frame rate: 30 fps
-- sample fractions: begin, 25%, 50%, 75%, final rendered frame
+- ManimCE version: 0.21.0;
+- renderer: Cairo;
+- output: 960×540;
+- frame rate: 30 fps;
+- sampled reference-frame fractions;
+- blocking raster tolerances, with fixture-specific overrides where required.
 
-The harness renders a real Manim MP4, extracts exact encoded frame indices with FFmpeg, authors the same scene through Noon's Pyodide compatibility frontend, and seeks Noon to the matching frame time. It captures both WebGPU and WebGL2.
+The harness renders real lossless Manim PNG frames, authors the same scene through Noon's Pyodide compatibility frontend, and seeks Noon to the matching Manim frame times. It captures both WebGPU and WebGL2. Each fixture gets an independent browser canvas player so capture state cannot leak between scenes.
 
 The default 2D presentation contract is also part of parity: the camera is centered at the origin with an **8.0-world-unit frame height** (16:9 width at the default aspect) and a **black background**. All browser canvas player entry points must use that same default contract; the differential harness must not compensate for a runtime-specific camera or clear color.
 
@@ -38,20 +34,35 @@ The default 2D presentation contract is also part of parity: the camera is cente
 - `diff-webgpu/` and `diff-webgl/` — amplified absolute pixel differences;
 - `report.json` — timing, foreground bounds/centroid, background color, foreground color summary, pixel error metrics, and categorized mismatch hints.
 
-The current categories are deliberately coarse: timing, background/color pipeline, camera/layout/geometry, and raster/style/animation-state. Focused semantic tests remain the preferred oracle for identifying exact causes; raster output catches what structural observations cannot.
+The diagnostic categories are timing, background/color pipeline, camera/layout/geometry, and raster/style/animation-state. Focused semantic tests remain the preferred oracle for identifying exact causes; raster output catches what structural observations cannot.
 
-## Ratchet policy
+After measurement, `node scripts/manim-raster-enforce.mjs` evaluates every fixture/backend/sample against the explicit manifest ratchet and writes `ratchet-report.json`. The dedicated CI workflow uploads both reports with the reference/Noon/diff images.
 
-The first landing runs in **report mode** because current Noon output is known to differ substantially from Manim. Tooling failures, missing scenes, authoring failures, renderer failures, wrong output dimensions, and missing artifacts are blocking. Known visual differences are recorded rather than normalized into baselines.
+## Blocking ratchet policy
 
-Set `NOON_MANIM_RASTER_ENFORCE=1` to make any categorized mismatch fail. As #177–#184 converge, replace the coarse all-or-nothing enforcement with explicit per-metric tolerances and enable them incrementally. Do not create a Noon-generated golden and call it Manim compatibility.
+The raster workflow is now blocking on explicit metrics rather than on the old coarse category threshold. The manifest defines defaults and may tighten or relax individual fixture metrics with:
+
+- `max_duration_delta_seconds`;
+- `max_background_channel_delta_sum`;
+- `max_bounds_delta_px`;
+- `max_differing_ratio`;
+- `max_mean_absolute_channel_error`.
+
+A fixture override is expected to document **measured deterministic headroom**, not normalize a bad Noon image into a golden. `max_bounds_delta_px: null` is the only supported metric exemption and must be narrowly scoped to a known unconverged geometry gap. Other timing, background, and raster metrics remain blocking even when bounds are exempt.
+
+`scripts/manim-raster-policy.test.mjs` deliberately injects timing, background, bounds, foreground-presence, and pixel-error regressions to prove the policy fails in the expected category. This test runs before the expensive Manim/browser setup in CI.
+
+The legacy `NOON_MANIM_RASTER_ENFORCE=1` mode still makes any coarse diagnostic category fail during measurement and is useful for local investigation. CI does **not** rely on it; CI always runs the explicit per-metric ratchet after `report.json` is produced.
 
 ## Local run
 
-The command requires the same dependencies as the dedicated CI workflow: ManimCE 0.21.0 with Cairo/Pango/FFmpeg, the built Noon browser WASM package, Playwright Chromium, and `pngjs`.
+The render command requires the same dependencies as the dedicated CI workflow: ManimCE 0.21.0 with Cairo/Pango/FFmpeg, the built Noon browser WASM package, Playwright Chromium, and `pngjs`.
 
 ```sh
+node scripts/manim-raster-policy.test.mjs
 node scripts/manim-raster-differential.mjs
+node scripts/manim-raster-enforce.mjs
+node scripts/manim-seek-playback-raster.mjs
 ```
 
 Useful environment variables:
@@ -59,9 +70,9 @@ Useful environment variables:
 ```sh
 NOON_MANIM_RASTER_BACKENDS=webgpu,webgl
 NOON_MANIM_RASTER_ARTIFACTS=manim-raster-artifacts
-NOON_MANIM_RASTER_ENFORCE=1
+NOON_MANIM_RASTER_ENFORCE=1  # optional coarse diagnostic mode
 ```
 
 ## Expansion rule
 
-When Noon claims another Manim example as output-compatible, add a source-equivalent fixture to this corpus and keep its smaller semantic probes in `scripts/manim-differential.py`. Unsupported APIs remain explicit gaps rather than approximate fixtures.
+When Noon claims another Manim example as output-compatible, add a source-equivalent fixture to this corpus and give it a blocking tolerance supported by a current ManimCE-v0.21.0 differential run. Keep smaller semantic probes in `scripts/manim-differential.py`. Unsupported APIs and known unconverged metrics remain explicit gaps rather than approximate fixtures.

--- a/parity/manim-v0.21/manifest.json
+++ b/parity/manim-v0.21/manifest.json
@@ -14,62 +14,114 @@
       "id": "create-circle",
       "scene": "CreateCircle",
       "expected_duration": 1.0,
-      "expected_default_stroke": "#FC6255"
+      "expected_default_stroke": "#FC6255",
+      "raster_tolerance": {
+        "max_differing_ratio": 0.0011,
+        "max_mean_absolute_channel_error": 0.027
+      }
     },
     {
       "id": "square-to-circle",
       "scene": "SquareToCircle",
-      "expected_duration": 3.0
+      "expected_duration": 3.0,
+      "raster_tolerance": {
+        "max_bounds_delta_px": null,
+        "max_differing_ratio": 0.02,
+        "max_mean_absolute_channel_error": 1.15
+      }
     },
     {
       "id": "square-and-circle",
       "scene": "SquareAndCircle",
-      "expected_duration": 1.0
+      "expected_duration": 1.0,
+      "raster_tolerance": {
+        "max_differing_ratio": 0.0033,
+        "max_mean_absolute_channel_error": 0.075
+      }
     },
     {
       "id": "animated-square-to-circle",
       "scene": "AnimatedSquareToCircle",
-      "expected_duration": 4.0
+      "expected_duration": 4.0,
+      "raster_tolerance": {
+        "max_differing_ratio": 0.0033,
+        "max_mean_absolute_channel_error": 0.055
+      }
     },
     {
       "id": "create-line",
       "scene": "CreateLine",
-      "expected_duration": 1.0
+      "expected_duration": 1.0,
+      "raster_tolerance": {
+        "max_bounds_delta_px": 3,
+        "max_differing_ratio": 0.00065,
+        "max_mean_absolute_channel_error": 0.0065
+      }
     },
     {
       "id": "uncreate-line",
       "scene": "UncreateLine",
-      "expected_duration": 1.0
+      "expected_duration": 1.0,
+      "raster_tolerance": {
+        "max_bounds_delta_px": 3,
+        "max_differing_ratio": 0.00065,
+        "max_mean_absolute_channel_error": 0.0065
+      }
     },
     {
       "id": "create-styled-square",
       "scene": "CreateStyledSquare",
-      "expected_duration": 1.0
+      "expected_duration": 1.0,
+      "raster_tolerance": {
+        "max_differing_ratio": 0.00005,
+        "max_mean_absolute_channel_error": 0.022
+      }
     },
     {
       "id": "uncreate-styled-square",
       "scene": "UncreateStyledSquare",
-      "expected_duration": 1.0
+      "expected_duration": 1.0,
+      "raster_tolerance": {
+        "max_differing_ratio": 0.0055,
+        "max_mean_absolute_channel_error": 0.07
+      }
     },
     {
       "id": "uncreate-square",
       "scene": "UncreateSquare",
-      "expected_duration": 1.0
+      "expected_duration": 1.0,
+      "raster_tolerance": {
+        "max_differing_ratio": 0.0023,
+        "max_mean_absolute_channel_error": 0.055
+      }
     },
     {
       "id": "set-color-independent-opacity",
       "scene": "SetColorIndependentOpacity",
-      "expected_duration": 1.0
+      "expected_duration": 1.0,
+      "raster_tolerance": {
+        "max_differing_ratio": 0.0044,
+        "max_mean_absolute_channel_error": 0.065
+      }
     },
     {
       "id": "palette-swatches",
       "scene": "PaletteSwatches",
-      "expected_duration": 1.0
+      "expected_duration": 1.0,
+      "raster_tolerance": {
+        "max_bounds_delta_px": 3,
+        "max_differing_ratio": 0.0049,
+        "max_mean_absolute_channel_error": 0.42
+      }
     },
     {
       "id": "translucent-painter-order",
       "scene": "TranslucentPainterOrder",
-      "expected_duration": 1.0
+      "expected_duration": 1.0,
+      "raster_tolerance": {
+        "max_differing_ratio": 0.0044,
+        "max_mean_absolute_channel_error": 0.18
+      }
     }
   ],
   "sample_fractions": [
@@ -86,6 +138,13 @@
   "policy": {
     "source_adaptation": "replace only `from manim import *` with `from noon import *`, then append a scene-selection wrapper for the browser authoring worker",
     "reference_frames": "compare Noon screenshots against Manim Cairo's native lossless PNG frame sequence; never derive parity references from compressed video",
-    "blocking": "oracle/tooling failures are blocking; visual/timing mismatches are reported until the parity ratchet is enabled"
+    "blocking": "tooling failures and per-fixture raster tolerance regressions are blocking; known unconverged metrics must be explicitly exempted",
+    "raster_tolerance": {
+      "max_duration_delta_seconds": 0.034,
+      "max_background_channel_delta_sum": 0,
+      "max_bounds_delta_px": 2,
+      "max_differing_ratio": 0.006,
+      "max_mean_absolute_channel_error": 0.5
+    }
   }
 }

--- a/scripts/manim-raster-enforce.mjs
+++ b/scripts/manim-raster-enforce.mjs
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  evaluateRasterTolerance,
+  formatRasterPolicyFailure,
+  resolveRasterTolerance,
+} from "./manim-raster-policy.mjs";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const artifactRoot = path.resolve(
+  repoRoot,
+  process.env.NOON_MANIM_RASTER_ARTIFACTS ?? "manim-raster-artifacts",
+);
+const manifest = JSON.parse(
+  await readFile(path.join(repoRoot, "parity", "manim-v0.21", "manifest.json"), "utf8"),
+);
+const report = JSON.parse(await readFile(path.join(artifactRoot, "report.json"), "utf8"));
+
+assert.equal(report.reference.version, manifest.reference.version, "ratchet/report Manim version");
+assert.equal(report.reference.renderer, manifest.reference.renderer, "ratchet/report renderer");
+
+const manifestFixtures = new Map(manifest.fixtures.map((fixture) => [fixture.id, fixture]));
+const failures = [];
+const fixtureResults = [];
+
+for (const fixtureReport of report.fixtures) {
+  const fixture = manifestFixtures.get(fixtureReport.id);
+  assert.ok(fixture, `${fixtureReport.id}: report fixture must exist in manifest`);
+  const tolerance = resolveRasterTolerance(manifest, fixture);
+  const backendResults = {};
+
+  for (const [backend, backendReport] of Object.entries(fixtureReport.backends)) {
+    const samples = [];
+    for (const sample of backendReport.samples) {
+      const result = evaluateRasterTolerance({
+        sample,
+        timingDelta: backendReport.durationDelta,
+        tolerance,
+      });
+      samples.push({
+        frameIndex: sample.frameIndex,
+        time: sample.time,
+        passed: result.passed,
+        categories: result.categories,
+        failures: result.failures,
+      });
+      if (!result.passed) {
+        failures.push(
+          formatRasterPolicyFailure(
+            fixtureReport.id,
+            backend,
+            `frame-${String(sample.frameIndex).padStart(4, "0")}`,
+            result,
+          ),
+        );
+      }
+    }
+    backendResults[backend] = {
+      durationDelta: backendReport.durationDelta,
+      samples,
+    };
+  }
+
+  fixtureResults.push({ id: fixtureReport.id, tolerance, backends: backendResults });
+}
+
+for (const fixture of manifest.fixtures) {
+  assert.ok(
+    report.fixtures.some((entry) => entry.id === fixture.id),
+    `${fixture.id}: manifest fixture missing from raster report`,
+  );
+}
+
+const ratchetReport = {
+  generatedAt: new Date().toISOString(),
+  sourceReportEnforceFlag: report.enforce,
+  passed: failures.length === 0,
+  failures,
+  fixtures: fixtureResults,
+};
+await writeFile(
+  path.join(artifactRoot, "ratchet-report.json"),
+  `${JSON.stringify(ratchetReport, null, 2)}\n`,
+);
+
+if (failures.length > 0) {
+  throw new Error(`Manim raster ratchet failures:\n${failures.join("\n")}`);
+}
+console.log(`Manim raster ratchet passed for ${fixtureResults.length} fixtures`);

--- a/scripts/manim-raster-policy.mjs
+++ b/scripts/manim-raster-policy.mjs
@@ -1,0 +1,121 @@
+const POLICY_FIELDS = [
+  "max_duration_delta_seconds",
+  "max_background_channel_delta_sum",
+  "max_bounds_delta_px",
+  "max_differing_ratio",
+  "max_mean_absolute_channel_error",
+];
+
+function assertLimit(name, value, { allowNull = false } = {}) {
+  if (allowNull && value === null) return;
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    throw new TypeError(`${name} must be a finite non-negative number${allowNull ? " or null" : ""}`);
+  }
+}
+
+export function resolveRasterTolerance(manifest, fixture) {
+  const defaults = manifest?.policy?.raster_tolerance;
+  if (!defaults || typeof defaults !== "object") {
+    throw new TypeError("manifest policy.raster_tolerance is required when raster enforcement is enabled");
+  }
+  const overrides = fixture?.raster_tolerance ?? {};
+  const tolerance = { ...defaults, ...overrides };
+  for (const field of POLICY_FIELDS) {
+    if (!(field in tolerance)) throw new TypeError(`${fixture.id}: missing raster tolerance ${field}`);
+    assertLimit(`${fixture.id}.${field}`, tolerance[field], {
+      allowNull: field === "max_bounds_delta_px",
+    });
+  }
+  return tolerance;
+}
+
+function backgroundDelta(sample) {
+  return sample.reference.background
+    .map((value, index) => Math.abs(value - sample.noon.background[index]))
+    .reduce((sum, value) => sum + value, 0);
+}
+
+function boundsDelta(sample) {
+  if (!sample.boundsDelta) return 0;
+  return Math.max(
+    Math.abs(sample.boundsDelta.centroidX),
+    Math.abs(sample.boundsDelta.centroidY),
+    Math.abs(sample.boundsDelta.width),
+    Math.abs(sample.boundsDelta.height),
+  );
+}
+
+export function evaluateRasterTolerance({ sample, timingDelta, tolerance }) {
+  const failures = [];
+  const record = (category, metric, actual, limit) => {
+    failures.push({ category, metric, actual, limit });
+  };
+
+  const durationDelta = Math.abs(timingDelta);
+  if (durationDelta > tolerance.max_duration_delta_seconds + 1e-12) {
+    record("timing", "duration_delta_seconds", durationDelta, tolerance.max_duration_delta_seconds);
+  }
+
+  const bgDelta = backgroundDelta(sample);
+  if (bgDelta > tolerance.max_background_channel_delta_sum) {
+    record(
+      "background/color-pipeline",
+      "background_channel_delta_sum",
+      bgDelta,
+      tolerance.max_background_channel_delta_sum,
+    );
+  }
+
+  if (tolerance.max_bounds_delta_px !== null) {
+    const referenceHasBounds = sample.reference.bounds !== null;
+    const noonHasBounds = sample.noon.bounds !== null;
+    if (referenceHasBounds !== noonHasBounds) {
+      record("camera/layout/geometry", "bounds_presence_mismatch", 1, 0);
+    } else {
+      const maxBoundsDelta = boundsDelta(sample);
+      if (maxBoundsDelta > tolerance.max_bounds_delta_px + 1e-12) {
+        record(
+          "camera/layout/geometry",
+          "bounds_delta_px",
+          maxBoundsDelta,
+          tolerance.max_bounds_delta_px,
+        );
+      }
+    }
+  }
+
+  if (sample.diff.differingRatio > tolerance.max_differing_ratio + 1e-12) {
+    record(
+      "raster/style/animation-state",
+      "differing_ratio",
+      sample.diff.differingRatio,
+      tolerance.max_differing_ratio,
+    );
+  }
+  if (
+    sample.diff.meanAbsoluteChannelError >
+    tolerance.max_mean_absolute_channel_error + 1e-12
+  ) {
+    record(
+      "raster/style/animation-state",
+      "mean_absolute_channel_error",
+      sample.diff.meanAbsoluteChannelError,
+      tolerance.max_mean_absolute_channel_error,
+    );
+  }
+
+  return {
+    passed: failures.length === 0,
+    categories: [...new Set(failures.map((failure) => failure.category))],
+    failures,
+  };
+}
+
+export function formatRasterPolicyFailure(fixtureId, backend, label, result) {
+  return `${fixtureId}/${backend}/${label}: ${result.failures
+    .map(
+      ({ category, metric, actual, limit }) =>
+        `${category} ${metric}=${actual} > ${limit}`,
+    )
+    .join("; ")}`;
+}

--- a/scripts/manim-raster-policy.test.mjs
+++ b/scripts/manim-raster-policy.test.mjs
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+
+import {
+  evaluateRasterTolerance,
+  formatRasterPolicyFailure,
+  resolveRasterTolerance,
+} from "./manim-raster-policy.mjs";
+
+const manifest = {
+  policy: {
+    raster_tolerance: {
+      max_duration_delta_seconds: 1 / 30 + 1e-6,
+      max_background_channel_delta_sum: 0,
+      max_bounds_delta_px: 2,
+      max_differing_ratio: 0.005,
+      max_mean_absolute_channel_error: 0.25,
+    },
+  },
+};
+const fixture = { id: "probe" };
+const tolerance = resolveRasterTolerance(manifest, fixture);
+const baseline = {
+  reference: { background: [0, 0, 0, 255], bounds: { minX: 1, minY: 1, maxX: 10, maxY: 10 } },
+  noon: { background: [0, 0, 0, 255], bounds: { minX: 1, minY: 1, maxX: 10, maxY: 10 } },
+  boundsDelta: { centroidX: 0, centroidY: 0, width: 2, height: -1 },
+  diff: { differingRatio: 0.004, meanAbsoluteChannelError: 0.2 },
+};
+
+assert.equal(
+  evaluateRasterTolerance({ sample: baseline, timingDelta: 0, tolerance }).passed,
+  true,
+);
+
+function expectCategory(sample, timingDelta, category) {
+  const result = evaluateRasterTolerance({ sample, timingDelta, tolerance });
+  assert.equal(result.passed, false);
+  assert.ok(result.categories.includes(category), `${category} should be enforced`);
+  assert.match(
+    formatRasterPolicyFailure("probe", "webgpu", "frame-0000", result),
+    new RegExp(category.replaceAll("/", "\\/")),
+  );
+}
+
+expectCategory(baseline, 0.1, "timing");
+expectCategory(
+  {
+    ...baseline,
+    noon: { ...baseline.noon, background: [1, 0, 0, 255] },
+  },
+  0,
+  "background/color-pipeline",
+);
+expectCategory(
+  {
+    ...baseline,
+    boundsDelta: { centroidX: 0, centroidY: 0, width: 3, height: 0 },
+  },
+  0,
+  "camera/layout/geometry",
+);
+expectCategory(
+  {
+    ...baseline,
+    noon: { ...baseline.noon, bounds: null },
+    boundsDelta: null,
+  },
+  0,
+  "camera/layout/geometry",
+);
+expectCategory(
+  {
+    ...baseline,
+    diff: { differingRatio: 0.02, meanAbsoluteChannelError: 0.2 },
+  },
+  0,
+  "raster/style/animation-state",
+);
+expectCategory(
+  {
+    ...baseline,
+    diff: { differingRatio: 0.004, meanAbsoluteChannelError: 1.0 },
+  },
+  0,
+  "raster/style/animation-state",
+);
+
+const boundsExempt = resolveRasterTolerance(manifest, {
+  id: "known-geometry-gap",
+  raster_tolerance: { max_bounds_delta_px: null },
+});
+assert.equal(
+  evaluateRasterTolerance({
+    sample: {
+      ...baseline,
+      noon: { ...baseline.noon, bounds: null },
+      boundsDelta: null,
+    },
+    timingDelta: 0,
+    tolerance: boundsExempt,
+  }).passed,
+  true,
+);
+
+assert.throws(
+  () =>
+    resolveRasterTolerance(
+      {
+        policy: {
+          raster_tolerance: {
+            ...manifest.policy.raster_tolerance,
+            max_differing_ratio: -1,
+          },
+        },
+      },
+      fixture,
+    ),
+  /finite non-negative number/,
+);
+
+console.log("Manim raster ratchet policy tests passed");


### PR DESCRIPTION
Completes the missing blocking-ratchet slice of #176 without changing the measurement harness.

## What changes
- keep `manim-raster-differential.mjs` as the diagnostic/reference measurement producer
- add an explicit per-fixture/per-metric ratchet over `report.json`
- make timing, background transfer, foreground-bounds presence/delta, differing-pixel ratio, and MAE independently blocking
- encode deterministic per-fixture headroom from the current post-#212/#213/#215 ManimCE v0.21.0 run
- scope the only full bounds exemption to the known `square-to-circle` geometry gap; its timing/background/raster metrics remain enforced
- add deliberate-regression policy tests for timing, background, bounds displacement, missing foreground, differing ratio, and MAE
- write `ratchet-report.json` into the existing uploaded raster artifact
- run the policy unit test before expensive Manim/browser setup, then enforce the ratchet after raster measurement

## Why separate measurement from policy
The existing coarse `NOON_MANIM_RASTER_ENFORCE=1` mode is useful diagnostically but fails any category and cannot ratchet independent metrics incrementally. CI now leaves measurement/report generation deterministic and applies explicit manifest tolerances in a separate step. This makes known gaps visible rather than normalizing them or disabling the entire oracle.

## Baseline
Tolerances are grounded in the refreshed #215 run after #213 isolated fixture capture. WebGPU/WebGL agree on current fixtures. Stable style/color/reveal metrics are tightly capped; line/palette bounds retain their measured 3 px allowance, and only `square-to-circle` bounds are temporarily exempt because that lane still has a 52 px geometry mismatch.

Tracks #176. This also makes #180's "deliberate color/alpha/painter regression fails CI" acceptance enforceable.