### PR TITLE
Match Manim animate.rotate target-state semantics

### DIFF
--- a/crates/noon-compile/src/lib.rs
+++ b/crates/noon-compile/src/lib.rs
@@ -64,6 +64,7 @@ pub struct CompiledObject {
 #[derive(Clone, Debug, PartialEq)]
 pub enum TransformGeometryPlan {
     Static,
+    PointwiseRotation,
     Circle {
         from_radius: f32,
         to_radius: f32,
@@ -913,6 +914,11 @@ fn compile_transform_geometry_plan(
     }
 
     if from.geometry == to.geometry {
+        if from.transform.scale == to.transform.scale
+            && from.transform.rotation.to_bits() != to.transform.rotation.to_bits()
+        {
+            return Ok(Some(TransformGeometryPlan::PointwiseRotation));
+        }
         return Ok(Some(TransformGeometryPlan::Static));
     }
 

--- a/crates/noon-runtime/src/lib.rs
+++ b/crates/noon-runtime/src/lib.rs
@@ -949,7 +949,11 @@ fn apply_transform_track(
         .transform_geometry_plan
         .as_ref()
         .expect("compiled Transform track must carry a geometry plan");
-    let next_transform = interpolate_transform(from.transform, to.transform, progress);
+    let next_transform = if matches!(plan, TransformGeometryPlan::PointwiseRotation) {
+        interpolate_pointwise_rotation_transform(from.transform, to.transform, progress)
+    } else {
+        interpolate_transform(from.transform, to.transform, progress)
+    };
     let next_style = interpolate_style(from.style, to.style, progress);
     let next_morph = if matches!(plan, TransformGeometryPlan::PathPair(_)) {
         progress
@@ -990,7 +994,9 @@ fn apply_transform_geometry(
     progress: f32,
 ) -> bool {
     match plan {
-        TransformGeometryPlan::Static => set_geometry_if_changed(current, &from.geometry),
+        TransformGeometryPlan::Static | TransformGeometryPlan::PointwiseRotation => {
+            set_geometry_if_changed(current, &from.geometry)
+        }
         TransformGeometryPlan::Circle {
             from_radius,
             to_radius,
@@ -1087,6 +1093,29 @@ fn set_optional_geometry_if_changed(
             true
         }
         None => false,
+    }
+}
+
+fn interpolate_pointwise_rotation_transform(
+    from: Transform2D,
+    to: Transform2D,
+    progress: f32,
+) -> Transform2D {
+    if progress <= 0.0 {
+        return from;
+    }
+    if progress >= 1.0 {
+        return to;
+    }
+    debug_assert_eq!(from.scale, to.scale);
+    let inverse = 1.0 - progress;
+    let cosine = inverse * from.rotation.cos() + progress * to.rotation.cos();
+    let sine = inverse * from.rotation.sin() + progress * to.rotation.sin();
+    let magnitude = cosine.hypot(sine);
+    Transform2D {
+        translation: interpolate_vec2(from.translation, to.translation, progress),
+        rotation: sine.atan2(cosine),
+        scale: Vec2::new(from.scale.x * magnitude, from.scale.y * magnitude),
     }
 }
 

--- a/crates/noon-runtime/tests/generic_transform.rs
+++ b/crates/noon-runtime/tests/generic_transform.rs
@@ -301,3 +301,60 @@ fn generic_path_transform_does_not_reuse_reveal_channel() {
     assert_eq!(frame.morph(0), 0.5);
     assert_eq!(frame.reveal(0), 0.25);
 }
+
+#[test]
+fn rotation_transform_interpolates_source_and_target_points_not_angle() {
+    let mut scene = SceneDefinition::new();
+    let object = scene.add(GeometryRef::rectangle(2.0, 1.0));
+    let from = ObjectSnapshot::from(scene.object(object).unwrap());
+    let mut to = from.clone();
+    to.transform.translation = Vec2::new(2.0, -1.0);
+    to.transform.rotation = std::f32::consts::PI;
+    scene
+        .animate_transform(
+            object,
+            from.clone(),
+            to.clone(),
+            TrackTiming::new(0.0, 1.0, Easing::Linear),
+        )
+        .unwrap();
+
+    fn world(transform: Transform2D, point: Vec2) -> Vec2 {
+        let scaled = Vec2::new(point.x * transform.scale.x, point.y * transform.scale.y);
+        let (sine, cosine) = transform.rotation.sin_cos();
+        Vec2::new(
+            scaled.x * cosine - scaled.y * sine + transform.translation.x,
+            scaled.x * sine + scaled.y * cosine + transform.translation.y,
+        )
+    }
+
+    let compiled = CompiledScene::compile(&scene).unwrap();
+    let mut instance = SceneInstance::new(compiled);
+    let point = Vec2::new(1.0, 0.5);
+    for progress in [0.25_f32, 0.5, 0.75] {
+        let frame = instance.seek(f64::from(progress)).unwrap();
+        let actual = world(frame.objects[0].transform, point);
+        let start = world(from.transform, point);
+        let end = world(to.transform, point);
+        let expected = Vec2::new(
+            start.x + (end.x - start.x) * progress,
+            start.y + (end.y - start.y) * progress,
+        );
+        assert!(
+            (actual.x - expected.x).abs() < 2.0e-6,
+            "x at {progress}: {actual:?} vs {expected:?}"
+        );
+        assert!(
+            (actual.y - expected.y).abs() < 2.0e-6,
+            "y at {progress}: {actual:?} vs {expected:?}"
+        );
+    }
+    assert_eq!(
+        instance.seek(0.0).unwrap().objects[0].transform,
+        from.transform
+    );
+    assert_eq!(
+        instance.seek(1.0).unwrap().objects[0].transform,
+        to.transform
+    );
+}

--- a/crates/noon-web/src/authoring_mobject.rs
+++ b/crates/noon-web/src/authoring_mobject.rs
@@ -144,6 +144,35 @@ impl FrontendMobjectHandle {
         self.sync_legacy_transform()
     }
 
+    pub fn rotate_about_point(
+        &mut self,
+        angle: f64,
+        point_x: f64,
+        point_y: f64,
+    ) -> Result<(), String> {
+        let angle = render_f64("rotation", angle)?;
+        let pivot = semantic_xy_f64(point_x, point_y)?;
+        let rotation = self.semantic_transform.rotation_z + angle;
+        finite_f32("rotation result", rotation)?;
+
+        let translation = self.semantic_transform.translation;
+        let relative_x = translation.x - pivot.x;
+        let relative_y = translation.y - pivot.y;
+        let cosine = angle.cos();
+        let sine = angle.sin();
+        let next_translation = SemanticVec3::new(
+            pivot.x + relative_x * cosine - relative_y * sine,
+            pivot.y + relative_x * sine + relative_y * cosine,
+            translation.z,
+        );
+        next_translation
+            .lower_xy_f32()
+            .map_err(|error| error.to_string())?;
+        self.semantic_transform.translation = next_translation;
+        self.semantic_transform.rotation_z = rotation;
+        self.sync_legacy_transform()
+    }
+
     pub fn set_color(&mut self, red: f64, green: f64, blue: f64, alpha: f64) -> Result<(), String> {
         let color = opaque_color("color", red, green, blue)?;
         let opacity = unit_opacity("color.alpha", alpha)?;
@@ -660,6 +689,18 @@ mod wasm {
             self.0.rotate(angle).map_err(js_error)
         }
 
+        #[wasm_bindgen(js_name = rotateAboutPoint)]
+        pub fn rotate_about_point(
+            &mut self,
+            angle: f64,
+            point_x: f64,
+            point_y: f64,
+        ) -> Result<(), JsValue> {
+            self.0
+                .rotate_about_point(angle, point_x, point_y)
+                .map_err(js_error)
+        }
+
         #[wasm_bindgen(js_name = setColor)]
         pub fn set_color(
             &mut self,
@@ -867,6 +908,27 @@ mod tests {
         assert_eq!(handle.semantic_transform.scale.x, 1.1);
         assert_eq!(handle.semantic_transform.scale.y, 0.9);
         assert_eq!(handle.semantic_transform.rotation_z, 0.2);
+    }
+
+    #[test]
+    fn pivoted_rotation_preserves_offset_line_center() {
+        let mut handle = FrontendMobjectHandle::from_snapshot(snapshot(GeometryRef::line(
+            Vec2::ZERO,
+            Vec2::new(1.0, 0.0),
+        )));
+        handle.shift(2.0, 0.0).unwrap();
+        let pivot = handle.center();
+        assert!((pivot.0 - 2.5).abs() < 1e-12);
+        assert!(pivot.1.abs() < 1e-12);
+        handle
+            .rotate_about_point(std::f64::consts::FRAC_PI_2, pivot.0, pivot.1)
+            .unwrap();
+        let center = handle.center();
+        assert!((center.0 - 2.5).abs() < 1e-9);
+        assert!(center.1.abs() < 1e-9);
+        assert!((handle.semantic_transform.translation.x - 2.5).abs() < 1e-12);
+        assert!((handle.semantic_transform.translation.y + 0.5).abs() < 1e-12);
+        assert!((handle.semantic_transform.rotation_z - std::f64::consts::FRAC_PI_2).abs() < 1e-12);
     }
 
     #[test]

--- a/parity/manim-v0.21/manifest.json
+++ b/parity/manim-v0.21/manifest.json
@@ -122,6 +122,14 @@
         "max_differing_ratio": 0.0044,
         "max_mean_absolute_channel_error": 0.18
       }
+    },
+    {
+      "id": "animate-rotate-offset-square",
+      "scene": "AnimateRotateOffsetSquare",
+      "expected_duration": 1.0,
+      "raster_tolerance": {
+        "max_bounds_delta_px": 4
+      }
     }
   ],
   "sample_fractions": [

--- a/parity/manim-v0.21/quickstart.py
+++ b/parity/manim-v0.21/quickstart.py
@@ -142,3 +142,15 @@ class TranslucentPainterOrder(Scene):
         ).shift(0.4 * RIGHT)
         self.add(back, front)
         self.play(front.animate.shift(ORIGIN))
+
+
+class AnimateRotateOffsetSquare(Scene):
+    def construct(self):
+        square = Square(
+            side_length=1.5,
+            fill_color=BLUE,
+            fill_opacity=1.0,
+            stroke_opacity=0.0,
+        ).shift(2 * RIGHT)
+        self.add(square)
+        self.play(square.animate(rate_func=linear).rotate(PI))

--- a/web/python/_manim_compat.py
+++ b/web/python/_manim_compat.py
@@ -14,7 +14,11 @@ import noon as _base
 
 _BaseMobject = _base.Mobject
 _BaseScene = _base.Scene
+_NATIVE_MOBJECT_ROTATE = _BaseMobject.rotate
 _ir = _base._ir
+
+OUT = (0.0, 0.0, 1.0)
+IN = (0.0, 0.0, -1.0)
 
 _INSTALLED = False
 
@@ -230,6 +234,57 @@ def _critical_for(value: object, direction: _base.Vec2) -> _base.Vec2:
     )
 
 
+def _rotation_angle_2d(angle: float, axis: object = OUT) -> float:
+    try:
+        if len(axis) != 3:  # type: ignore[arg-type]
+            raise TypeError
+        x = float(axis[0])  # type: ignore[index]
+        y = float(axis[1])  # type: ignore[index]
+        z = float(axis[2])  # type: ignore[index]
+    except (TypeError, ValueError, IndexError) as error:
+        raise TypeError("rotation axis must be a three-component vector") from error
+    if not all(math.isfinite(value) for value in (x, y, z)):
+        raise ValueError("rotation axis must be finite")
+    if not math.isclose(x, 0.0, abs_tol=1e-12) or not math.isclose(y, 0.0, abs_tol=1e-12):
+        raise NotImplementedError("2D authoring supports rotation about the z axis only")
+    if math.isclose(z, 0.0, abs_tol=1e-12):
+        raise ValueError("rotation axis must be non-zero")
+    value = float(angle)
+    if not math.isfinite(value):
+        raise ValueError("rotation angle must be finite")
+    return -value if z < 0.0 else value
+
+
+def _mobject_rotate(
+    self: _BaseMobject,
+    angle: float,
+    axis: object = OUT,
+    *,
+    about_point: object | None = None,
+    about_edge: object | None = None,
+    **kwargs: Any,
+) -> _BaseMobject:
+    if kwargs:
+        unsupported = ", ".join(sorted(kwargs))
+        raise NotImplementedError(f"unsupported Manim rotate option(s): {unsupported}")
+    signed_angle = _rotation_angle_2d(angle, axis)
+    if about_point is not None:
+        pivot = _as_vec2(about_point)
+    else:
+        edge = _base.ORIGIN if about_edge is None else _as_vec2(about_edge)
+        pivot = self.get_critical_point(edge)
+    center = self.get_center()
+    relative = center - pivot
+    cosine = math.cos(signed_angle)
+    sine = math.sin(signed_angle)
+    target_center = pivot + _base.Vec2(
+        relative.x * cosine - relative.y * sine,
+        relative.x * sine + relative.y * cosine,
+    )
+    _NATIVE_MOBJECT_ROTATE(self, signed_angle)
+    return self.move_to(target_center)
+
+
 class _GroupAnimationBuilder:
     def __init__(self, source: Group) -> None:
         leaves = _leaf_mobjects(source)
@@ -362,22 +417,23 @@ class Group(_base.Group, _BaseMobject):
             )
         return self
 
-    def rotate(self, angle: float) -> Group:
-        angle = float(angle)
-        center = self.get_center()
-        cosine = math.cos(angle)
-        sine = math.sin(angle)
+    def rotate(
+        self,
+        angle: float,
+        axis: object = OUT,
+        *,
+        about_point: object | None = None,
+        about_edge: object | None = None,
+        **kwargs: Any,
+    ) -> Group:
+        signed_angle = _rotation_angle_2d(angle, axis)
+        if about_point is not None:
+            pivot = _as_vec2(about_point)
+        else:
+            edge = _base.ORIGIN if about_edge is None else _as_vec2(about_edge)
+            pivot = _critical_for(self, edge)
         for member in self.submobjects:
-            member_center = member.get_center()
-            relative = member_center - center
-            member.rotate(angle)
-            member.move_to(
-                center
-                + _base.Vec2(
-                    relative.x * cosine - relative.y * sine,
-                    relative.x * sine + relative.y * cosine,
-                )
-            )
+            member.rotate(signed_angle, OUT, about_point=pivot, **kwargs)
         return self
 
     def set_color(self, color: _base.Color) -> Group:
@@ -895,31 +951,9 @@ def _mobject_match_y(
 def _mobject_rotate_about_origin(
     self: _BaseMobject, angle: float, axis: object = None
 ) -> _BaseMobject:
-    if axis is not None:
-        try:
-            if len(axis) != 3:  # type: ignore[arg-type]
-                raise TypeError
-            x = float(axis[0])  # type: ignore[index]
-            y = float(axis[1])  # type: ignore[index]
-            z = float(axis[2])  # type: ignore[index]
-        except (TypeError, ValueError, IndexError) as error:
-            raise TypeError("rotation axis must be a three-component vector") from error
-        if not math.isclose(x, 0.0, abs_tol=1e-12) or not math.isclose(
-            y, 0.0, abs_tol=1e-12
-        ) or not math.isclose(abs(z), 1.0, abs_tol=1e-12):
-            raise NotImplementedError("2D authoring supports rotation about the z axis only")
-        if z < 0.0:
-            angle = -float(angle)
-    angle = float(angle)
-    center = self.get_center()
-    cosine = math.cos(angle)
-    sine = math.sin(angle)
-    target = _base.Vec2(
-        center.x * cosine - center.y * sine,
-        center.x * sine + center.y * cosine,
+    return self.rotate(
+        angle, OUT if axis is None else axis, about_point=_base.ORIGIN
     )
-    self.rotate(angle)
-    return self.move_to(target)
 
 
 def _set_width_property(self: _BaseMobject, width: float) -> None:
@@ -1056,6 +1090,7 @@ def install() -> None:
     _BaseMobject.match_coord = _mobject_match_coord
     _BaseMobject.match_x = _mobject_match_x
     _BaseMobject.match_y = _mobject_match_y
+    _BaseMobject.rotate = _mobject_rotate
     _BaseMobject.rotate_about_origin = _mobject_rotate_about_origin
     _BaseMobject.width = property(_BaseMobject.width.fget, _set_width_property)
     _BaseMobject.height = property(_BaseMobject.height.fget, _set_height_property)
@@ -1075,6 +1110,8 @@ def install() -> None:
         "Group": Group,
         "VGroup": VGroup,
         "Scene": Scene,
+        "OUT": OUT,
+        "IN": IN,
     }
     for name, value in public.items():
         setattr(_base, name, value)

--- a/web/python/_manim_semantic_handles.py
+++ b/web/python/_manim_semantic_handles.py
@@ -348,11 +348,35 @@ def _scale(self: _base.Mobject, factor: object) -> _base.Mobject:
     return self
 
 
-def _rotate(self: _base.Mobject, angle: float) -> _base.Mobject:
+def _rotate(
+    self: _base.Mobject,
+    angle: float,
+    axis: object = _compat.OUT,
+    *,
+    about_point: object | None = None,
+    about_edge: object | None = None,
+    **kwargs: Any,
+) -> _base.Mobject:
     handle = _handle_for(self)
     if handle is None:
-        return _ORIGINAL_ROTATE(self, angle)
-    handle.rotate(float(angle))
+        return _ORIGINAL_ROTATE(
+            self,
+            angle,
+            axis,
+            about_point=about_point,
+            about_edge=about_edge,
+            **kwargs,
+        )
+    if kwargs:
+        unsupported = ", ".join(sorted(kwargs))
+        raise NotImplementedError(f"unsupported Manim rotate option(s): {unsupported}")
+    signed_angle = _compat._rotation_angle_2d(angle, axis)
+    if about_point is not None:
+        pivot = _compat._as_vec2(about_point)
+    else:
+        edge = _base.ORIGIN if about_edge is None else _compat._as_vec2(about_edge)
+        pivot = _critical(self, edge)
+    handle.rotateAboutPoint(signed_angle, pivot.x, pivot.y)
     return self
 
 

--- a/web/python/test_manim_rotate_semantics.py
+++ b/web/python/test_manim_rotate_semantics.py
@@ -1,0 +1,107 @@
+import os
+import subprocess
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+
+
+class ManimRotateSemanticsTests(unittest.TestCase):
+    def test_rotate_uses_manim_pivots_for_python_and_semantic_handles(self) -> None:
+        python_dir = Path(__file__).resolve().parent
+        env = os.environ.copy()
+        existing = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = str(python_dir) if not existing else os.pathsep.join((str(python_dir), existing))
+        source = textwrap.dedent(
+  """
+  import json
+  import math
+  import _manim_compat
+  _manim_compat.install()
+  import _manim_phase_b  # noqa: F401
+  from noon import IN, LEFT, Line, ORIGIN, PI, RIGHT
+
+  def close(a, b, eps=1e-9):
+      assert abs(a - b) <= eps, (a, b)
+
+  line = Line(ORIGIN, RIGHT).shift(2 * RIGHT)
+  before = line.get_center()
+  line.rotate(PI / 2)
+  after = line.get_center()
+  close(after.x, before.x)
+  close(after.y, before.y)
+
+  around_origin = Line(ORIGIN, RIGHT).shift(2 * RIGHT)
+  around_origin.rotate(PI / 2, about_point=ORIGIN)
+  close(around_origin.get_center().x, 0.0)
+  close(around_origin.get_center().y, 2.5)
+
+  around_left = Line(ORIGIN, RIGHT).shift(2 * RIGHT)
+  around_left.rotate(PI / 2, about_edge=LEFT)
+  close(around_left.get_center().x, 2.0)
+  close(around_left.get_center().y, 0.5)
+
+  precedence = Line(ORIGIN, RIGHT).shift(2 * RIGHT)
+  precedence.rotate(PI / 2, about_point=ORIGIN, about_edge=RIGHT)
+  close(precedence.get_center().x, 0.0)
+  close(precedence.get_center().y, 2.5)
+
+  clockwise = Line(ORIGIN, RIGHT).shift(2 * RIGHT)
+  clockwise.rotate(PI / 2, axis=IN, about_point=ORIGIN)
+  close(clockwise.get_center().x, 0.0)
+  close(clockwise.get_center().y, -2.5)
+
+  import _manim_semantic_handles as handles
+
+  class FakeHandle:
+      def __init__(self, snapshot_json):
+          self.snapshot = json.loads(snapshot_json)
+      def snapshotJson(self):
+          return json.dumps(self.snapshot, separators=(\",\", \":\"))
+      def replaceSnapshotJson(self, snapshot_json):
+          self.snapshot = json.loads(snapshot_json)
+      def cloneHandle(self):
+          return FakeHandle(self.snapshotJson())
+      def setFillOpacity(self, opacity):
+          if self.snapshot[\"style\"][\"fill\"] is not None:
+              self.snapshot[\"style\"][\"fill\"][\"alpha\"] = float(opacity)
+      def setStrokeOpacity(self, opacity):
+          if self.snapshot[\"style\"][\"stroke\"] is not None:
+              self.snapshot[\"style\"][\"stroke\"][\"alpha\"] = float(opacity)
+      def shift(self, x, y):
+          t = self.snapshot[\"transform\"][\"translation\"]
+          t[\"x\"] += float(x); t[\"y\"] += float(y)
+      def scale(self, x, y):
+          s = self.snapshot[\"transform\"][\"scale\"]
+          s[\"x\"] *= float(x); s[\"y\"] *= float(y)
+      def rotateAboutPoint(self, angle, point_x, point_y):
+          t = self.snapshot[\"transform\"][\"translation\"]
+          dx = t[\"x\"] - point_x; dy = t[\"y\"] - point_y
+          c = math.cos(angle); s = math.sin(angle)
+          t[\"x\"] = point_x + dx * c - dy * s
+          t[\"y\"] = point_y + dx * s + dy * c
+          self.snapshot[\"transform\"][\"rotation\"] += float(angle)
+
+  handles._create_handle = FakeHandle
+  handles.install()
+  semantic = Line(ORIGIN, RIGHT).shift(2 * RIGHT)
+  before = semantic.get_center()
+  semantic.rotate(PI / 2)
+  after = semantic.get_center()
+  close(after.x, before.x)
+  close(after.y, before.y)
+  semantic_origin = Line(ORIGIN, RIGHT).shift(2 * RIGHT)
+  semantic_origin.rotate(PI / 2, about_point=ORIGIN)
+  close(semantic_origin.get_center().x, 0.0)
+  close(semantic_origin.get_center().y, 2.5)
+  """
+        )
+        completed = subprocess.run(
+  [sys.executable, "-c", source], cwd=python_dir, env=env,
+  capture_output=True, text=True, check=False,
+        )
+        self.assertEqual(completed.returncode, 0, f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/python/test_manim_semantic_handle_layout_bounds.py
+++ b/web/python/test_manim_semantic_handle_layout_bounds.py
@@ -67,6 +67,24 @@ class ManimSemanticHandleLayoutBoundsTests(unittest.TestCase):
                 def rotate(self, angle):
                     self.snapshot[\"transform\"][\"rotation\"] += float(angle)
 
+                def rotateAboutPoint(self, angle, point_x, point_y):
+                    translation = self.snapshot[\"transform\"][\"translation\"]
+                    relative_x = translation[\"x\"] - float(point_x)
+                    relative_y = translation[\"y\"] - float(point_y)
+                    cosine = math.cos(float(angle))
+                    sine = math.sin(float(angle))
+                    translation[\"x\"] = (
+                        float(point_x)
+                        + relative_x * cosine
+                        - relative_y * sine
+                    )
+                    translation[\"y\"] = (
+                        float(point_y)
+                        + relative_x * sine
+                        + relative_y * cosine
+                    )
+                    self.snapshot[\"transform\"][\"rotation\"] += float(angle)
+
 
             handles._create_handle = FakeHandle
             handles.install()


### PR DESCRIPTION
## Summary
- match ManimCE v0.21 `Mobject.rotate` pivot semantics for the supported 2D z-axis subset: default current center, explicit `about_point`, `about_edge`, `about_point` precedence, and IN/OUT axis sign
- keep semantic-handle rotation in Rust-owned f64 authoring state with a new pivoted handle operation instead of round-tripping through Python/f32 snapshots
- distinguish `.animate.rotate(...)` target-state interpolation from procedural rotation by compiling same-geometry/unchanged-scale rotation transforms to `PointwiseRotation`
- evaluate that plan as the exact linear interpolation of the two 2D rotation matrices, decomposed back into rotation + scalar scale, preserving analytic geometry and reproducing Manim's collapse/re-expand behavior
- add low-level runtime point-coordinate checks, authoring-handle pivot checks, Python fallback/semantic-handle parity checks, and a source-equivalent offset-Line raster fixture

## Why
Manim's `_AnimationBuilder` creates a rotated target mobject and generic Transform interpolates source/target points. Noon previously incremented rotation around local origin and then linearly interpolated the stored rotation angle, so both the final position of offset geometry and the 25/50/75% visual states differed from Manim. This also violated #183's DifferentRotations acceptance criterion by making `.animate.rotate` act like a future procedural `Rotate` animation.

## Validation before PR
Focused branch validation passed:
- `cargo fmt --all`
- `cargo test -p noon-web authoring_mobject`
- `cargo test -p noon-runtime --test generic_transform`
- `python -m unittest web/python/test_manim_rotate_semantics.py`
- `git diff --check`

The branch was then reconstructed as one clean commit on current master after #215, preserving its palette/compositing fixtures and excluding all temporary edit workflows.

Tracks #183.