### PR TITLE
Add Manim opacity ladder parity fixtures

### DIFF
--- a/parity/manim-v0.21/manifest.json
+++ b/parity/manim-v0.21/manifest.json
@@ -130,6 +130,25 @@
       "raster_tolerance": {
         "max_bounds_delta_px": 4
       }
+    },
+    {
+      "id": "fill-opacity-ladder",
+      "scene": "FillOpacityLadder",
+      "expected_duration": 1.0,
+      "raster_tolerance": {
+        "max_bounds_delta_px": 3,
+        "max_differing_ratio": 0.005,
+        "max_mean_absolute_channel_error": 0.3
+      }
+    },
+    {
+      "id": "set-global-opacity",
+      "scene": "SetGlobalOpacity",
+      "expected_duration": 1.0,
+      "raster_tolerance": {
+        "max_differing_ratio": 0.0045,
+        "max_mean_absolute_channel_error": 0.1
+      }
     }
   ],
   "sample_fractions": [

--- a/parity/manim-v0.21/quickstart.py
+++ b/parity/manim-v0.21/quickstart.py
@@ -154,3 +154,34 @@ class AnimateRotateOffsetSquare(Scene):
         ).shift(2 * RIGHT)
         self.add(square)
         self.play(square.animate(rate_func=linear).rotate(PI))
+
+
+class FillOpacityLadder(Scene):
+    def construct(self):
+        opacities = [0.0, 0.25, 0.5, 0.75, 1.0]
+        swatches = []
+        for index, opacity in enumerate(opacities):
+            swatch = Square(
+                side_length=0.9,
+                fill_color=PINK,
+                fill_opacity=opacity,
+                stroke_opacity=0.0,
+            )
+            swatch.move_to((index - 2) * 1.2 * RIGHT)
+            swatches.append(swatch)
+        self.add(*swatches)
+        self.play(swatches[-1].animate.shift(ORIGIN))
+
+
+class SetGlobalOpacity(Scene):
+    def construct(self):
+        square = Square(
+            fill_color=PINK,
+            fill_opacity=0.35,
+            stroke_color=BLUE,
+            stroke_opacity=0.65,
+            stroke_width=8,
+        )
+        square.set_opacity(0.5)
+        self.add(square)
+        self.play(square.animate.shift(ORIGIN))

--- a/web/python/test_manim_style_color.py
+++ b/web/python/test_manim_style_color.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 
 class ManimStyleColorTests(unittest.TestCase):
-    def test_set_color_preserves_independent_fill_and_stroke_alpha(self) -> None:
+    def test_set_color_and_opacity_match_vmobject_semantics(self) -> None:
         python_dir = Path(__file__).resolve().parent
         env = os.environ.copy()
         existing_pythonpath = env.get("PYTHONPATH")
@@ -49,6 +49,30 @@ class ManimStyleColorTests(unittest.TestCase):
             assert_rgb(square.style["stroke"], GREEN)
             assert abs(square.style["fill"]["alpha"] - 0.35) < 1e-12
             assert abs(square.style["stroke"]["alpha"] - 0.65) < 1e-12
+
+            # Manim VMobject.set_opacity sets both fill and stroke opacity to the
+            # requested value; it does not multiply their previous independent
+            # opacities. The normally zero-alpha default fill therefore becomes
+            # visible when global opacity is explicitly set.
+            default_circle = Circle()
+            default_circle.set_opacity(0.5)
+            assert default_circle.style["fill"] is not None
+            assert default_circle.style["stroke"] is not None
+            assert abs(default_circle.style["fill"]["alpha"] - 0.5) < 1e-12
+            assert abs(default_circle.style["stroke"]["alpha"] - 0.5) < 1e-12
+
+            opacity_square = Square(
+                fill_color=PINK,
+                fill_opacity=0.35,
+                stroke_color=BLUE,
+                stroke_opacity=0.65,
+                stroke_width=8,
+            )
+            opacity_square.set_opacity(0.5)
+            assert_rgb(opacity_square.style["fill"], PINK)
+            assert_rgb(opacity_square.style["stroke"], BLUE)
+            assert abs(opacity_square.style["fill"]["alpha"] - 0.5) < 1e-12
+            assert abs(opacity_square.style["stroke"]["alpha"] - 0.5) < 1e-12
 
             # Keep the existing Noon compatibility escape hatch: an explicitly
             # disabled layer stays disabled when the remaining style is recolored.


### PR DESCRIPTION
Partial #180.

Adds source-equivalent ManimCE v0.21.0 coverage for the remaining static opacity semantics:

- fill opacity ladder at 0 / .25 / .5 / .75 / 1
- global `set_opacity(0.5)` across independently colored fill and stroke
- focused Python regression that verifies `set_opacity` updates both enabled channels while preserving their colors
- blocking raster fixtures through the canonical #176 oracle

This intentionally does not change renderer/color behavior yet. The new raster cases are meant to prove the current implementation or expose the next concrete alpha/compositing bug. #180 remains open for overlap compositing, edge/AA color, transfer/gamma, and animated color interpolation coverage.