### PR TITLE
Match Manim explicit Rotate motion

### DIFF
--- a/compat/manim-v0.21.0.json
+++ b/compat/manim-v0.21.0.json
@@ -24,6 +24,7 @@
     "Create": {"status": "supported", "category": "animation", "evidence": "browser compatibility tests"},
     "FadeIn": {"status": "supported", "category": "animation", "evidence": "browser compatibility tests"},
     "FadeOut": {"status": "supported", "category": "animation", "evidence": "browser compatibility tests"},
+    "Rotate": {"status": "partial", "category": "animation", "dependency": "#183", "reason": "Centered 2D OUT/IN rotation is exact; external pivots, retained groups, path overrides, and non-z axes remain pending."},
     "Transform": {"status": "supported", "category": "animation", "evidence": "generic transform tests"},
     "ReplacementTransform": {"status": "supported", "category": "animation", "evidence": "lifecycle tests"},
     "TransformFromCopy": {"status": "supported", "category": "animation", "evidence": "transform-from-copy tests"},

--- a/parity/manim-v0.21/manifest.json
+++ b/parity/manim-v0.21/manifest.json
@@ -49,6 +49,11 @@
       }
     },
     {
+      "id": "different-rotations",
+      "scene": "DifferentRotations",
+      "expected_duration": 3.0
+    },
+    {
       "id": "create-line",
       "scene": "CreateLine",
       "expected_duration": 1.0,

--- a/parity/manim-v0.21/quickstart.py
+++ b/parity/manim-v0.21/quickstart.py
@@ -53,6 +53,16 @@ class AnimatedSquareToCircle(Scene):
         self.play(square.animate.set_fill(PINK, opacity=0.5))
 
 
+class DifferentRotations(Scene):
+    def construct(self):
+        left_square = Square(color=BLUE, fill_opacity=0.7).shift(2 * LEFT)
+        right_square = Square(color=GREEN, fill_opacity=0.7).shift(2 * RIGHT)
+        self.play(
+            left_square.animate.rotate(PI), Rotate(right_square, angle=PI), run_time=2
+        )
+        self.wait()
+
+
 # Supplemental source-equivalent parity probes. These are deliberately ordinary
 # Manim source (not Noon-specific adaptations) and exercise reveal/lifecycle
 # contracts that are not covered directly by the quickstart examples above.

--- a/scripts/build-web-demo.sh
+++ b/scripts/build-web-demo.sh
@@ -56,6 +56,7 @@ PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile \
   web/python/_manim_phase_b.py \
   web/python/_manim_animation_options.py \
   web/python/_manim_animate.py \
+  web/python/_manim_rotate.py \
   web/python/_manim_composition.py \
   web/python/_manim_frame_sampling.py \
   web/python/_manim_lifecycle.py \

--- a/scripts/manim-raster-differential.mjs
+++ b/scripts/manim-raster-differential.mjs
@@ -1,12 +1,6 @@
 import assert from "node:assert/strict";
 import { spawn, spawnSync } from "node:child_process";
-import {
-  mkdir,
-  readFile,
-  readdir,
-  rm,
-  writeFile,
-} from "node:fs/promises";
+import { mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -131,10 +125,16 @@ async function renderManimReferences() {
 
     const frameFiles = await findPngFrames(mediaDir, fixture.scene);
     const firstFrame = PNG.sync.read(await readFile(frameFiles[0]));
+    const logicalDuration = Number(fixture.expected_duration);
+    assert.ok(Number.isFinite(logicalDuration) && logicalDuration >= 0, `${fixture.id}: logical duration`);
     const frames = {
       frameCount: frameFiles.length,
       frameRate: reference.frame_rate,
-      duration: frameFiles.length / reference.frame_rate,
+      // Cairo PNG output can materialize a static wait as one image with a repeat
+      // count. Logical duration is ratcheted separately by the semantic oracle, so
+      // never infer scene duration from the number of PNG files.
+      duration: logicalDuration,
+      materializedFrameSpan: frameFiles.length / reference.frame_rate,
       width: firstFrame.width,
       height: firstFrame.height,
       format: "png-sequence",
@@ -157,14 +157,6 @@ async function renderManimReferences() {
 function noonSourceFor(scene) {
   const adapted = fixtureSource.replace("from manim import *", "from noon import *");
   return `${adapted}\n\nresult = ${scene}()\nresult.setup()\ntry:\n    result.construct()\nfinally:\n    result.tear_down()\n`;
-}
-
-function latestSceneEnd(document) {
-  const tracks = [...(document.tracks ?? []), ...(document.signal_tracks ?? [])];
-  if (tracks.length === 0) return 0;
-  return Math.max(
-    ...tracks.map((track) => Number(track.timing.start_time) + Number(track.timing.duration)),
-  );
 }
 
 async function authorNoonDocuments() {
@@ -248,10 +240,6 @@ async function captureNoonBackend(backend, documents, references) {
     for (const fixture of manifest.fixtures) {
       let page = null;
       try {
-        // Give every parity fixture an independent canvas player. WebGL drawing
-        // buffers may retain the last presented backbuffer while a new scene's
-        // first presentation becomes visible; reusing one player across fixtures
-        // therefore makes frame zero depend on fixture order instead of scene state.
         page = await createCapturePage(browser, expectedBackend, backend);
         const document = documents.get(fixture.id);
         const loaded = await page.evaluate(
@@ -321,9 +309,7 @@ function pixelStats(buffer) {
     }
   }
   const bounds = changedPixels === 0 ? null : { minX, minY, maxX, maxY };
-  const centroid = bounds
-    ? { x: (minX + maxX) / 2, y: (minY + maxY) / 2 }
-    : null;
+  const centroid = bounds ? { x: (minX + maxX) / 2, y: (minY + maxY) / 2 } : null;
   return {
     width: png.width,
     height: png.height,

--- a/scripts/manim-raster-semantic-reference.py
+++ b/scripts/manim-raster-semantic-reference.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
-"""Capture renderer-independent Manim scene state at every canonical raster frame.
+"""Capture Manim semantic state at the exact PNG-sequence sample frames.
 
-This intentionally runs Manim's real Scene/Cairo animation loop while replacing
-pixel/file output with a no-op renderer sink.  The resulting frame indices match
-Manim's rendered frame progression without duplicating the expensive Cairo raster
-work already performed by the differential oracle.
+Manim Cairo can encode a static wait as one materialized PNG frame with a repeat count
+while still advancing renderer time by the full wait duration.  This oracle therefore
+tracks materialized frame state and logical scene time separately.
 """
 
 from __future__ import annotations
@@ -56,7 +55,6 @@ class SemanticRenderer(CairoRenderer):
         return None
 
     def update_frame(self, _scene, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
-        # Semantic capture does not need a camera pixel buffer.
         return None
 
     def render(self, scene, time, moving_mobjects=None) -> None:  # type: ignore[no-untyped-def]
@@ -65,14 +63,13 @@ class SemanticRenderer(CairoRenderer):
         self.time += 1.0 / float(config.frame_rate)
 
     def freeze_current_frame(self, duration: float) -> None:
+        """Mirror Cairo PNG materialization: one state, full logical-time advance."""
         if self._active_scene is None:
             raise RuntimeError("semantic renderer has no active scene for frozen frame")
-        dt = 1.0 / float(config.frame_rate)
-        for _ in range(int(duration / dt)):
-            self.frames.append(
-                _scene_state(self._active_scene, len(self.frames), self.time, 0.0)
-            )
-            self.time += dt
+        self.frames.append(
+            _scene_state(self._active_scene, len(self.frames), self.time, 0.0)
+        )
+        self.time += float(duration)
 
 
 def _scalar(value: Any) -> float:
@@ -91,19 +88,30 @@ def _rgb(color: Any) -> list[float] | None:
     return [float(values[0]), float(values[1]), float(values[2])]
 
 
-def _rgba(mobject: Any, kind: str) -> dict[str, float] | None:
-    color_getter = getattr(mobject, f"get_{kind}_color", None)
-    opacity_getter = getattr(mobject, f"get_{kind}_opacity", None)
-    if color_getter is None or opacity_getter is None:
+def _safe_call(getter: Any) -> Any | None:
+    if getter is None:
         return None
-    rgb = _rgb(color_getter())
+    try:
+        return getter()
+    except AttributeError:
+        # Plain Manim Mobject instances used internally by Wait synthesize style
+        # getters through __getattr__, but have no VMobject paint attributes.
+        return None
+
+
+def _rgba(mobject: Any, kind: str) -> dict[str, float] | None:
+    color = _safe_call(getattr(mobject, f"get_{kind}_color", None))
+    opacity = _safe_call(getattr(mobject, f"get_{kind}_opacity", None))
+    if color is None or opacity is None:
+        return None
+    rgb = _rgb(color)
     if rgb is None:
         return None
     return {
         "red": rgb[0],
         "green": rgb[1],
         "blue": rgb[2],
-        "alpha": _scalar(opacity_getter()),
+        "alpha": _scalar(opacity),
     }
 
 
@@ -114,14 +122,15 @@ def _object_state(mobject: Any, index: int) -> dict[str, Any]:
     height = float(mobject.height)
     half_width = width * 0.5
     half_height = height * 0.5
-    stroke_width_getter = getattr(mobject, "get_stroke_width", None)
+    stroke_width_value = _safe_call(getattr(mobject, "get_stroke_width", None))
     stroke_width = (
-        _scalar(stroke_width_getter()) * CAIRO_STROKE_WIDTH_SCALE
-        if stroke_width_getter is not None
+        _scalar(stroke_width_value) * CAIRO_STROKE_WIDTH_SCALE
+        if stroke_width_value is not None
         else 0.0
     )
     family_getter = getattr(mobject, "get_family", None)
-    family_count = len(family_getter()) if family_getter is not None else 1
+    family = _safe_call(family_getter)
+    family_count = len(family) if family is not None else 1
     return {
         "index": index,
         "type": type(mobject).__name__,
@@ -139,7 +148,12 @@ def _object_state(mobject: Any, index: int) -> dict[str, Any]:
     }
 
 
-def _scene_state(scene: Any, frame_index: int, scene_time: float, animation_time: float) -> dict[str, Any]:
+def _scene_state(
+    scene: Any,
+    frame_index: int,
+    scene_time: float,
+    animation_time: float,
+) -> dict[str, Any]:
     objects = [_object_state(mobject, index) for index, mobject in enumerate(scene.mobjects)]
     return {
         "engine": "manim",
@@ -160,7 +174,11 @@ def _load_source(source_path: Path):
     return module
 
 
-def _render_fixture(module: Any, fixture: dict[str, Any], frame_rate: float) -> dict[str, Any]:
+def _render_fixture(
+    module: Any,
+    fixture: dict[str, Any],
+    frame_rate: float,
+) -> dict[str, Any]:
     scene_class = getattr(module, fixture["scene"])
     renderer = SemanticRenderer()
     scene = scene_class(renderer=renderer)
@@ -170,22 +188,29 @@ def _render_fixture(module: Any, fixture: dict[str, Any], frame_rate: float) -> 
     finally:
         scene.tear_down()
 
-    expected_frames = int(round(float(fixture["expected_duration"]) * frame_rate))
-    if len(renderer.frames) != expected_frames:
+    expected_duration = float(fixture["expected_duration"])
+    if not math.isclose(renderer.time, expected_duration, rel_tol=0.0, abs_tol=1e-9):
         raise RuntimeError(
-            f"{fixture['id']}: semantic frame count {len(renderer.frames)} != "
-            f"expected {expected_frames} from duration/fps"
+            f"{fixture['id']}: logical Manim duration {renderer.time} != "
+            f"expected {expected_duration}"
         )
+
+    previous_time = -math.inf
     for index, frame in enumerate(renderer.frames):
-        expected_time = index / frame_rate
-        if not math.isclose(float(frame["time"]), expected_time, rel_tol=0.0, abs_tol=1e-9):
+        time = float(frame["time"])
+        if time + 1e-12 < previous_time:
             raise RuntimeError(
-                f"{fixture['id']}: semantic frame {index} time {frame['time']} != {expected_time}"
+                f"{fixture['id']}: materialized frame {index} time {time} "
+                f"precedes {previous_time}"
             )
+        previous_time = time
+
     return {
         "id": fixture["id"],
         "scene": fixture["scene"],
         "frame_count": len(renderer.frames),
+        "logical_duration": float(renderer.time),
+        "frame_rate": frame_rate,
         "frames": renderer.frames,
     }
 
@@ -229,7 +254,10 @@ def main() -> int:
         "fixtures": fixtures,
     }
     args.output.parent.mkdir(parents=True, exist_ok=True)
-    args.output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    args.output.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
     print(f"Captured semantic state for {len(fixtures)} Manim raster fixtures")
     return 0
 

--- a/web/python-worker.js
+++ b/web/python-worker.js
@@ -20,6 +20,7 @@ const MANIM_RATE_FUNCTIONS_MODULE_PATH = "/tmp/_manim_rate_functions.py";
 const MANIM_PHASE_B_MODULE_PATH = "/tmp/_manim_phase_b.py";
 const MANIM_ANIMATION_OPTIONS_MODULE_PATH = "/tmp/_manim_animation_options.py";
 const MANIM_ANIMATE_MODULE_PATH = "/tmp/_manim_animate.py";
+const MANIM_ROTATE_MODULE_PATH = "/tmp/_manim_rotate.py";
 const MANIM_COMPOSITION_MODULE_PATH = "/tmp/_manim_composition.py";
 const MANIM_LIFECYCLE_MODULE_PATH = "/tmp/_manim_lifecycle.py";
 const MANIM_REACTIVE_MODULE_PATH = "/tmp/_manim_reactive.py";
@@ -57,6 +58,7 @@ async function initializePyodide() {
     phaseBResponse,
     animationOptionsResponse,
     animateResponse,
+    rotateResponse,
     compositionResponse,
     lifecycleResponse,
     reactiveResponse,
@@ -70,6 +72,7 @@ async function initializePyodide() {
     fetch(new URL("./python/_manim_phase_b.py", import.meta.url)),
     fetch(new URL("./python/_manim_animation_options.py", import.meta.url)),
     fetch(new URL("./python/_manim_animate.py", import.meta.url)),
+    fetch(new URL("./python/_manim_rotate.py", import.meta.url)),
     fetch(new URL("./python/_manim_composition.py", import.meta.url)),
     fetch(new URL("./python/_manim_lifecycle.py", import.meta.url)),
     fetch(new URL("./python/_manim_reactive.py", import.meta.url)),
@@ -84,6 +87,7 @@ async function initializePyodide() {
     [phaseBResponse, "Noon Manim Phase B layer"],
     [animationOptionsResponse, "Noon Manim animation options"],
     [animateResponse, "Noon Manim animate layer"],
+    [rotateResponse, "Noon Manim Rotate layer"],
     [compositionResponse, "Noon Manim composition layer"],
     [lifecycleResponse, "Noon Manim lifecycle layer"],
     [reactiveResponse, "Noon reactive compatibility layer"],
@@ -104,6 +108,7 @@ async function initializePyodide() {
     [MANIM_PHASE_B_MODULE_PATH, phaseBResponse],
     [MANIM_ANIMATION_OPTIONS_MODULE_PATH, animationOptionsResponse],
     [MANIM_ANIMATE_MODULE_PATH, animateResponse],
+    [MANIM_ROTATE_MODULE_PATH, rotateResponse],
     [MANIM_COMPOSITION_MODULE_PATH, compositionResponse],
     [MANIM_LIFECYCLE_MODULE_PATH, lifecycleResponse],
     [MANIM_REACTIVE_MODULE_PATH, reactiveResponse],
@@ -124,6 +129,8 @@ import _manim_phase_b
 import _manim_semantic_handles
 _manim_semantic_handles.install()
 import _manim_animate
+import _manim_rotate
+_manim_rotate.install()
 import _manim_composition
 _manim_composition.install()
 import _manim_lifecycle

--- a/web/python/_manim_rotate.py
+++ b/web/python/_manim_rotate.py
@@ -1,0 +1,323 @@
+"""ManimCE-compatible procedural ``Rotate`` animation for the exact 2D subset.
+
+``mobject.animate.rotate`` is target-state interpolation and intentionally remains a
+regular Transform.  Manim's explicit ``Rotate`` instead follows a rotational path.
+For geometry centered on its authored transform origin, Noon can represent that path
+exactly with the existing scalar rotation track, without adding a new IR primitive.
+External pivots and non-z axes require curved translation/3D support and are rejected
+until the runtime can represent them exactly.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import noon as _base
+import _manim_animation_options as _options
+import _manim_animate as _animate
+import _manim_compat as _compat
+
+
+_INSTALLED = False
+_ORIGINAL_SCENE_PLAY = _compat.Scene.play
+_ORIGINAL_BUILDER_SOURCE = _animate._builder_source
+_UNSUPPORTED_PATH_OPTIONS = {
+    "path_arc",
+    "path_arc_axis",
+    "path_arc_centers",
+    "path_func",
+}
+
+
+class Rotate:
+    """Rotate one centered 2D mobject along Manim's procedural angular path."""
+
+    def __init__(
+        self,
+        mobject: object,
+        angle: float = math.pi,
+        axis: object = _compat.OUT,
+        about_point: object | None = None,
+        about_edge: object | None = None,
+        **kwargs: Any,
+    ) -> None:
+        if isinstance(mobject, _compat.Group):
+            raise NotImplementedError(
+                "Rotate(Group/VGroup) requires retained family pivot motion and is not yet supported"
+            )
+        if not isinstance(mobject, _base.Mobject):
+            raise TypeError("Rotate target must be a Mobject")
+
+        path_options = sorted(_UNSUPPORTED_PATH_OPTIONS.intersection(kwargs))
+        if path_options:
+            raise NotImplementedError(
+                "Rotate path override(s) are not yet supported: " + ", ".join(path_options)
+            )
+
+        value = float(angle)
+        if not math.isfinite(value):
+            raise ValueError("Rotate angle must be finite")
+
+        self.mobject = mobject
+        self.angle = value
+        self.axis = axis
+        # ManimCE eagerly captures the default pivot in Rotate.__init__; do the same
+        # rather than recomputing the center later when Scene.play is called.
+        self.about_point = mobject.get_center() if about_point is None else about_point
+        self.about_edge = about_edge
+        self.anim_args = dict(kwargs)
+
+
+def _axis_sign(axis: object) -> float:
+    try:
+        if len(axis) != 3:  # type: ignore[arg-type]
+            raise NotImplementedError("Rotate currently supports only 3D z-axis vectors")
+        x = float(axis[0])  # type: ignore[index]
+        y = float(axis[1])  # type: ignore[index]
+        z = float(axis[2])  # type: ignore[index]
+    except NotImplementedError:
+        raise
+    except (TypeError, ValueError, IndexError) as error:
+        raise TypeError("Rotate axis must be a three-component numeric vector") from error
+
+    if not all(math.isfinite(value) for value in (x, y, z)):
+        raise ValueError("Rotate axis must be finite")
+    if not math.isclose(x, 0.0, abs_tol=1e-12) or not math.isclose(
+        y, 0.0, abs_tol=1e-12
+    ) or math.isclose(z, 0.0, abs_tol=1e-12):
+        raise NotImplementedError("Rotate currently supports only the 2D OUT/IN z axis")
+    return 1.0 if z > 0.0 else -1.0
+
+
+def _points_close(left: _base.Vec2, right: _base.Vec2) -> bool:
+    return math.isclose(left.x, right.x, abs_tol=1e-9) and math.isclose(
+        left.y, right.y, abs_tol=1e-9
+    )
+
+
+def _validate_exact_pivot(
+    scene: _compat.Scene,
+    animation: Rotate,
+    *,
+    start_time: float,
+) -> tuple[object, dict[str, Any]]:
+    mobject = animation.mobject
+    if mobject._scene is not scene or mobject._object is None:
+        raise ValueError("Rotate target must belong to this Scene")
+    obj = mobject._object
+    snapshot = scene._snapshot_for_object_at(obj, start_time)
+    detached = _animate._snapshot_mobject(snapshot)
+    center = detached.get_center()
+    translation = snapshot["transform"]["translation"]
+    transform_origin = _base.Vec2(
+        float(translation["x"]),
+        float(translation["y"]),
+    )
+
+    # A scalar Noon rotation is around the object's transform origin.  For centered
+    # analytic geometry (including the quickstart Square), that is exactly Manim's
+    # default Rotate pivot.  Offset local geometry would need a circular translation
+    # path to keep its center fixed, so do not approximate it with linear motion.
+    if not _points_close(center, transform_origin):
+        raise NotImplementedError(
+            "Rotate currently requires geometry centered on its transform origin"
+        )
+
+    about_point = _compat._as_vec2(animation.about_point)
+    if not _points_close(about_point, center):
+        raise NotImplementedError(
+            "Rotate about an external point requires curved translation and is not yet supported"
+        )
+
+    # Manim Rotate eagerly defaults about_point to mobject.get_center(); Mobject.rotate
+    # gives about_point precedence over about_edge.  Therefore about_edge does not
+    # alter the supported default/centered Rotate path and can be accepted unchanged.
+    return obj, snapshot
+
+
+def _ensure_rotation_interval_available(
+    scene: _compat.Scene,
+    obj: object,
+    *,
+    start_time: float,
+    duration: float,
+) -> None:
+    end_time = start_time + duration
+    object_id = obj.id  # type: ignore[attr-defined]
+    for track in scene._tracks:
+        if track["object"] != object_id or track["property"] not in {
+            "rotation",
+            "transform",
+        }:
+            continue
+        track_start = float(track["timing"]["start_time"])
+        track_end = track_start + float(track["timing"]["duration"])
+        if track_start < end_time and start_time < track_end:
+            raise ValueError(
+                "Rotate cannot overlap another rotation/generic Transform on the same object"
+            )
+
+
+def _schedule_rotate(
+    scene: _compat.Scene,
+    animation: Rotate,
+    *,
+    start_time: float,
+    duration: float,
+    easing: str,
+) -> None:
+    obj, snapshot = _validate_exact_pivot(scene, animation, start_time=start_time)
+    _ensure_rotation_interval_available(
+        scene,
+        obj,
+        start_time=start_time,
+        duration=duration,
+    )
+
+    from_rotation = float(snapshot["transform"]["rotation"])
+    to_rotation = from_rotation + _axis_sign(animation.axis) * animation.angle
+    object_key = scene._object_keys[obj.id]
+    scene._add_scalar_track(
+        obj,
+        "rotation",
+        from_rotation,
+        to_rotation,
+        start_time,
+        duration,
+        easing,
+        f"@rotate:{object_key}:{start_time:g}",
+    )
+
+
+def _builder_source(animation: object) -> object | None:
+    if isinstance(animation, Rotate):
+        return animation.mobject
+    return _ORIGINAL_BUILDER_SOURCE(animation)
+
+
+def _rotate_scene_play(
+    self: _compat.Scene,
+    *animations: Any,
+    duration: float | None = None,
+    run_time: float | None = None,
+    start_time: float | None = None,
+    easing: str | None = None,
+    rate_func: object | None = None,
+    lag_ratio: float | None = None,
+    **kwargs: Any,
+) -> _compat.Scene:
+    if not any(isinstance(animation, Rotate) for animation in animations):
+        return _ORIGINAL_SCENE_PLAY(
+            self,
+            *animations,
+            duration=duration,
+            run_time=run_time,
+            start_time=start_time,
+            easing=easing,
+            rate_func=rate_func,
+            lag_ratio=lag_ratio,
+            **kwargs,
+        )
+    if not animations:
+        raise ValueError("play requires at least one animation")
+    if duration is not None and run_time is not None:
+        raise ValueError("use either duration or run_time, not both")
+    if easing is not None and rate_func is not None:
+        raise ValueError("use either rate_func or the low-level easing alias, not both")
+    if kwargs:
+        unsupported = ", ".join(sorted(kwargs))
+        raise NotImplementedError(f"unsupported Manim Scene.play option(s): {unsupported}")
+
+    play_run_time = run_time if run_time is not None else duration
+    if play_run_time is not None:
+        play_run_time = float(play_run_time)
+    if lag_ratio is not None:
+        lag_ratio = float(lag_ratio)
+    base_start = self._cursor if start_time is None else float(start_time)
+    if not math.isfinite(base_start) or base_start < 0.0:
+        raise ValueError("start_time must be finite and non-negative")
+
+    checkpoint = self._authoring_checkpoint()
+    cursor_before = self._cursor
+    top_level_before = list(self._compat_top_level)
+    wrapper_states: dict[int, tuple[_base.Mobject, object, object]] = {}
+    for animation in animations:
+        source = _builder_source(animation)
+        if source is not None:
+            _animate._record_wrapper_state(source, wrapper_states)
+        if isinstance(animation, (_base.Create, _base.FadeIn, _base.FadeOut)):
+            _animate._record_wrapper_state(animation.target, wrapper_states)
+
+    max_end = base_start
+    try:
+        for animation in animations:
+            if isinstance(animation, Rotate):
+                _animate._bind_for_animation(
+                    self,
+                    animation.mobject,
+                    start_time=base_start,
+                )
+                resolved = _options.resolve(
+                    builder_args=_options.builder_args(animation),
+                    default_lag_ratio=0.0,
+                    play_run_time=play_run_time,
+                    play_easing=easing,
+                    play_rate_func=rate_func,
+                    play_lag_ratio=lag_ratio,
+                )
+                _schedule_rotate(
+                    self,
+                    animation,
+                    start_time=base_start,
+                    duration=resolved.run_time,
+                    easing=resolved.rate_func,
+                )
+                end = base_start + resolved.run_time
+            else:
+                _ORIGINAL_SCENE_PLAY(
+                    self,
+                    animation,
+                    run_time=play_run_time,
+                    start_time=base_start,
+                    easing=easing,
+                    rate_func=rate_func,
+                    lag_ratio=lag_ratio,
+                )
+                end = self._cursor
+            max_end = max(max_end, end)
+
+        self._cursor = max(cursor_before, max_end)
+        return self
+    except Exception:
+        self._restore_authoring_checkpoint(checkpoint)
+        self._cursor = cursor_before
+        self._compat_top_level = top_level_before
+        for member, old_scene, old_object in wrapper_states.values():
+            member._scene = old_scene
+            member._object = old_object
+        raise
+
+
+def install() -> None:
+    global _INSTALLED
+    if _INSTALLED:
+        return
+    _INSTALLED = True
+
+    public = {"Rotate": Rotate}
+    for name, value in public.items():
+        setattr(_base, name, value)
+        setattr(_compat, name, value)
+        setattr(_animate, name, value)
+
+    exports = list(_base.__all__)
+    for name in public:
+        if name not in exports:
+            exports.append(name)
+    _base.__all__ = exports
+
+    # Composition imports this module before capturing Scene.play, so nested Rotate
+    # leaves share the same timing resolver and rollback path as top-level plays.
+    _animate._builder_source = _builder_source
+    _compat.Scene.play = _rotate_scene_play

--- a/web/python/test_manim_rotate_animation.py
+++ b/web/python/test_manim_rotate_animation.py
@@ -1,0 +1,241 @@
+import os
+import subprocess
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+
+
+class ManimRotateAnimationTests(unittest.TestCase):
+    def test_centered_2d_rotate_uses_procedural_rotation_track(self) -> None:
+        python_dir = Path(__file__).resolve().parent
+        env = os.environ.copy()
+        existing_pythonpath = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = (
+            str(python_dir)
+            if not existing_pythonpath
+            else os.pathsep.join((str(python_dir), existing_pythonpath))
+        )
+
+        source = textwrap.dedent(
+            """
+            import math
+            import sys
+            import types
+
+            fake_js = types.ModuleType("js")
+
+            class Result:
+                ok = True
+                errorKind = ""
+                message = ""
+
+            def resolve_animation_options(
+                default_lag_ratio,
+                animation_run_time,
+                animation_rate_func,
+                animation_lag_ratio,
+                path_arc,
+                reverse_rate_function,
+                play_run_time,
+                play_rate_func,
+                play_lag_ratio,
+            ):
+                result = Result()
+                result.runTime = (
+                    play_run_time
+                    if math.isfinite(play_run_time)
+                    else animation_run_time
+                    if math.isfinite(animation_run_time)
+                    else 1.0
+                )
+                result.rateFunc = play_rate_func or animation_rate_func or "smooth"
+                result.lagRatio = (
+                    play_lag_ratio
+                    if math.isfinite(play_lag_ratio)
+                    else animation_lag_ratio
+                    if math.isfinite(animation_lag_ratio)
+                    else default_lag_ratio
+                )
+                result.pathArc = path_arc if math.isfinite(path_arc) else 0.0
+                result.reverseRateFunction = reverse_rate_function == 1
+                return result
+
+            def resolve_uniform_schedule(child_count, lag_ratio, run_time):
+                result = Result()
+                result.intervals = []
+                return result
+
+            fake_js.noonResolveAnimationOptions = resolve_animation_options
+            fake_js.noonResolveUniformCompositionSchedule = resolve_uniform_schedule
+            sys.modules["js"] = fake_js
+
+            import _manim_compat
+            _manim_compat.install()
+            import _manim_rate_functions
+            _manim_rate_functions.install()
+            import _manim_phase_b  # noqa: F401
+            import _manim_animate  # noqa: F401
+            import _manim_rotate
+            _manim_rotate.install()
+
+            from noon import IN, LEFT, ORIGIN, PI, RIGHT, Line, Rotate, Scene, Square, linear, smooth
+
+            # Canonical quickstart subset: a shifted Square is still centered on its
+            # transform origin, so explicit Rotate is a true angular path rather than
+            # the target-state interpolation used by square.animate.rotate(...).
+            scene = Scene()
+            square = Square().shift(2 * RIGHT)
+            scene.play(Rotate(square, angle=PI, rate_func=linear), run_time=2.0)
+            assert abs(scene.time - 2.0) < 1e-12
+            document = scene.to_document()
+            rotation = next(
+                track
+                for track in document["tracks"]
+                if track["object"] == square.id and track["property"] == "rotation"
+            )
+            values = rotation["values"]["scalar"]
+            assert abs(values["from"] - 0.0) < 1e-12
+            assert abs(values["to"] - PI) < 1e-12
+            assert abs(rotation["timing"]["duration"] - 2.0) < 1e-12
+            assert rotation["timing"]["easing"] == "linear"
+            authored = next(obj for obj in document["objects"] if obj["id"] == square.id)
+            assert abs(authored["transform"]["translation"]["x"] - 2.0) < 1e-12
+            assert abs(authored["transform"]["translation"]["y"]) < 1e-12
+
+            # The upstream DifferentRotations shape is one concurrent Scene.play.
+            # Keep the two semantics structurally different while sharing the same
+            # play start/end interval.
+            mixed_scene = Scene()
+            left_square = Square().shift(2 * LEFT)
+            right_square = Square().shift(2 * RIGHT)
+            mixed_scene.play(
+                left_square.animate.rotate(PI),
+                Rotate(right_square, angle=PI),
+                run_time=2.0,
+                rate_func=linear,
+            )
+            assert abs(mixed_scene.time - 2.0) < 1e-12
+            mixed_document = mixed_scene.to_document()
+            left_tracks = [
+                track
+                for track in mixed_document["tracks"]
+                if track["object"] == left_square.id
+            ]
+            right_tracks = [
+                track
+                for track in mixed_document["tracks"]
+                if track["object"] == right_square.id
+            ]
+            left_transform = next(track for track in left_tracks if track["property"] == "transform")
+            right_rotation = next(track for track in right_tracks if track["property"] == "rotation")
+            assert not any(track["property"] == "rotation" for track in left_tracks)
+            assert not any(track["property"] == "transform" for track in right_tracks)
+            for track in (left_transform, right_rotation):
+                assert abs(track["timing"]["start_time"] - 0.0) < 1e-12
+                assert abs(track["timing"]["duration"] - 2.0) < 1e-12
+                assert track["timing"]["easing"] == "linear"
+
+            # Constructor defaults and Scene.play override precedence are shared with
+            # every other Manim animation through the common Rust option resolver.
+            default_scene = Scene()
+            default_square = Square()
+            default_scene.play(Rotate(default_square))
+            default_track = next(
+                track
+                for track in default_scene.to_document()["tracks"]
+                if track["property"] == "rotation"
+            )
+            assert abs(default_scene.time - 1.0) < 1e-12
+            assert default_track["timing"]["easing"] == "smooth"
+
+            override_scene = Scene()
+            override_square = Square()
+            override_scene.play(
+                Rotate(override_square, run_time=3.0, rate_func=linear),
+                run_time=0.75,
+                rate_func=smooth,
+            )
+            override_track = next(
+                track
+                for track in override_scene.to_document()["tracks"]
+                if track["property"] == "rotation"
+            )
+            assert abs(override_scene.time - 0.75) < 1e-12
+            assert abs(override_track["timing"]["duration"] - 0.75) < 1e-12
+            assert override_track["timing"]["easing"] == "smooth"
+
+            # IN reverses the 2D angular direction exactly; non-z axes are outside the
+            # supported 2D subset and must fail instead of being projected silently.
+            in_scene = Scene()
+            in_square = Square()
+            in_scene.play(Rotate(in_square, angle=PI / 2, axis=IN), rate_func=linear)
+            in_track = next(
+                track
+                for track in in_scene.to_document()["tracks"]
+                if track["property"] == "rotation"
+            )
+            assert abs(in_track["values"]["scalar"]["to"] + PI / 2) < 1e-12
+
+            axis_scene = Scene()
+            try:
+                axis_scene.play(Rotate(Square(), axis=(1.0, 0.0, 0.0)))
+            except NotImplementedError:
+                pass
+            else:
+                raise AssertionError("non-z Rotate axis should be rejected")
+            assert axis_scene.time == 0.0
+            assert axis_scene.to_document()["objects"] == []
+
+            # External pivots and offset-local geometry require a circular translation
+            # path that the scalar rotation channel cannot encode yet. Both cases are
+            # rejected atomically rather than approximated with linear translation.
+            pivot_scene = Scene()
+            pivot_square = Square().shift(2 * RIGHT)
+            try:
+                pivot_scene.play(Rotate(pivot_square, about_point=ORIGIN))
+            except NotImplementedError:
+                pass
+            else:
+                raise AssertionError("external Rotate pivot should be rejected")
+            assert pivot_scene.time == 0.0
+            assert pivot_scene.to_document()["objects"] == []
+            assert pivot_square._scene is None and pivot_square._object is None
+
+            line_scene = Scene()
+            offset_line = Line(ORIGIN, RIGHT)
+            try:
+                line_scene.play(Rotate(offset_line))
+            except NotImplementedError:
+                pass
+            else:
+                raise AssertionError("offset-local Rotate should be rejected")
+            assert line_scene.time == 0.0
+            assert line_scene.to_document()["objects"] == []
+
+            try:
+                Rotate(Square(), path_arc=0.0)
+            except NotImplementedError:
+                pass
+            else:
+                raise AssertionError("explicit Rotate path overrides should be rejected")
+            """
+        )
+
+        completed = subprocess.run(
+            [sys.executable, "-c", source],
+            check=False,
+            cwd=python_dir,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            completed.returncode,
+            0,
+            f"compatibility subprocess failed:\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements the exact first subset of ManimCE v0.21 `Rotate(...)` semantics without adding a new IR primitive.

- adds public `Rotate` for centered 2D Mobjects on the OUT/IN z axis
- lowers procedural rotation to Noon's existing scalar rotation track, keeping it distinct from `.animate.rotate(...)` target-state interpolation
- uses the shared animation-option resolver for constructor/play runtime and rate-function precedence
- preserves implicit Scene.play binding and atomic rollback
- rejects external pivots, offset-local geometry, retained groups, path overrides, and non-z axes rather than approximating them
- adds focused low-level tests
- copies the canonical upstream `DifferentRotations` quickstart scene source-equivalently into the raster/semantic parity corpus with no custom raster tolerance
- classifies `Rotate` as partial until curved-pivot/group/3D cases are exact

Tracks #183.