### PR TITLE
Add isolated Manim animated color parity probe

### DIFF
--- a/parity/manim-v0.21/manifest.json
+++ b/parity/manim-v0.21/manifest.json
@@ -153,7 +153,12 @@
     {
       "id": "animate-set-color",
       "scene": "AnimateSetColor",
-      "expected_duration": 1.0
+      "expected_duration": 1.0,
+      "raster_tolerance": {
+        "max_bounds_delta_px": 0,
+        "max_differing_ratio": 0.0044,
+        "max_mean_absolute_channel_error": 0.075
+      }
     }
   ],
   "sample_fractions": [

--- a/parity/manim-v0.21/manifest.json
+++ b/parity/manim-v0.21/manifest.json
@@ -149,6 +149,11 @@
         "max_differing_ratio": 0.0045,
         "max_mean_absolute_channel_error": 0.1
       }
+    },
+    {
+      "id": "animate-set-color",
+      "scene": "AnimateSetColor",
+      "expected_duration": 1.0
     }
   ],
   "sample_fractions": [

--- a/parity/manim-v0.21/quickstart.py
+++ b/parity/manim-v0.21/quickstart.py
@@ -185,3 +185,16 @@ class SetGlobalOpacity(Scene):
         square.set_opacity(0.5)
         self.add(square)
         self.play(square.animate.shift(ORIGIN))
+
+
+class AnimateSetColor(Scene):
+    def construct(self):
+        square = Square(
+            fill_color=BLUE,
+            fill_opacity=0.35,
+            stroke_color=RED,
+            stroke_opacity=0.65,
+            stroke_width=8,
+        )
+        self.add(square)
+        self.play(square.animate(rate_func=linear).set_color(GREEN))


### PR DESCRIPTION
Partial #180.

Adds a source-equivalent ManimCE v0.21.0 fixed-geometry fixture for `square.animate(rate_func=linear).set_color(GREEN)` starting from independent fill/stroke colors and alpha values.

The canonical raster sample fractions already include 0.25 / 0.5 / 0.75, so this isolates animated RGB interpolation while also checking that fill/stroke alpha remain independent. The fixture intentionally starts on the global blocking raster policy rather than pre-tuning a tolerance; if it exposes a real semantic/rendering mismatch, that will be fixed before merge.