### PR TITLE
Do not let transparent strokes erode analytic fills

### DIFF
--- a/crates/noon-render-wgpu/src/analytic.wgsl
+++ b/crates/noon-render-wgpu/src/analytic.wgsl
@@ -272,7 +272,7 @@ fn styled_shape_color(
     let fill_coverage = inside_coverage(signed_distance);
     let outer_coverage = inside_coverage(signed_distance - half_stroke_width);
     let stroke_coverage = outside_coverage(signed_distance + half_stroke_width);
-    let has_stroke = stroke_enabled && stroke_width > 0.0;
+    let has_stroke = stroke_enabled && stroke_width > 0.0 && stroke.a > 0.0;
     if has_stroke {
         if fill_enabled {
             let color = mix(premultiplied(fill), premultiplied(stroke), stroke_coverage);

--- a/crates/noon-render-wgpu/tests/transparent_stroke_shader_contract.rs
+++ b/crates/noon-render-wgpu/tests/transparent_stroke_shader_contract.rs
@@ -1,0 +1,8 @@
+#[test]
+fn transparent_stroke_does_not_enter_visible_stroke_compositing() {
+    let shader = include_str!("../src/analytic.wgsl");
+    assert!(
+        shader.contains("stroke_enabled && stroke_width > 0.0 && stroke.a > 0.0"),
+        "analytic fill/stroke compositing must ignore zero-alpha strokes so an invisible Manim stroke cannot erode the fill edge"
+    );
+}


### PR DESCRIPTION
## Summary
- treat a zero-alpha stroke as non-visible during analytic fill/stroke compositing
- keep the stroke structurally enabled so cached topology and future opacity changes do not churn renderer state
- add a shader contract regression for the zero-alpha visible-stroke predicate

## Root cause
Manim VMobjects keep a default stroke width even when `stroke_opacity=0`. Noon packed that stroke correctly, but `styled_shape_color` considered every enabled non-zero-width stroke visible. Mixing the fill against a fully transparent stroke then attenuated the fill across half the stroke width on each side.

At the canonical 960×540 / 8-unit camera, Manim's default 4px stroke maps to ~2.7 raster pixels total. That matches the measured `PaletteSwatches` shrink: Cairo produced ~60px of full fill while Noon produced ~58px.

The fix changes only the analytic visible-stroke test to require `stroke.a > 0`. CPU packing remains unchanged.

## Expected raster impact
- `palette-swatches`: remove the ~3px foreground-box shrink and reduce ~0.46% diff
- `translucent-painter-order` and `fill-opacity-ladder`: improve fill-edge parity
- opaque-stroke fixtures such as styled Create/Uncreate remain unchanged

Tracks #179, #180, #185.