### PR TITLE
Prove Manim set_color style equivalence

### DIFF
--- a/parity/manim-v0.21/manifest.json
+++ b/parity/manim-v0.21/manifest.json
@@ -163,7 +163,12 @@
     {
       "id": "set-color-explicit-equivalent",
       "scene": "SetColorExplicitEquivalent",
-      "expected_duration": 1.0
+      "expected_duration": 1.0,
+      "raster_tolerance": {
+        "max_bounds_delta_px": 0,
+        "max_differing_ratio": 0.0032,
+        "max_mean_absolute_channel_error": 0.036
+      }
     }
   ],
   "sample_fractions": [

--- a/parity/manim-v0.21/manifest.json
+++ b/parity/manim-v0.21/manifest.json
@@ -159,6 +159,11 @@
         "max_differing_ratio": 0.0044,
         "max_mean_absolute_channel_error": 0.075
       }
+    },
+    {
+      "id": "set-color-explicit-equivalent",
+      "scene": "SetColorExplicitEquivalent",
+      "expected_duration": 1.0
     }
   ],
   "sample_fractions": [

--- a/parity/manim-v0.21/quickstart.py
+++ b/parity/manim-v0.21/quickstart.py
@@ -198,3 +198,30 @@ class AnimateSetColor(Scene):
         )
         self.add(square)
         self.play(square.animate(rate_func=linear).set_color(GREEN))
+
+
+class SetColorExplicitEquivalent(Scene):
+    def construct(self):
+        set_color_square = Square(
+            side_length=1.2,
+            fill_color=PINK,
+            fill_opacity=0.35,
+            stroke_color=BLUE,
+            stroke_opacity=0.65,
+            stroke_width=4,
+        ).shift(1.0 * LEFT)
+        set_color_square.set_color(GREEN)
+
+        explicit_square = Square(
+            side_length=1.2,
+            fill_color=PINK,
+            fill_opacity=0.35,
+            stroke_color=BLUE,
+            stroke_opacity=0.65,
+            stroke_width=4,
+        ).shift(1.0 * RIGHT)
+        explicit_square.set_fill(color=GREEN)
+        explicit_square.set_stroke(color=GREEN)
+
+        self.add(set_color_square, explicit_square)
+        self.play(explicit_square.animate.shift(ORIGIN))

--- a/web/python/test_manim_style_color.py
+++ b/web/python/test_manim_style_color.py
@@ -50,6 +50,17 @@ class ManimStyleColorTests(unittest.TestCase):
             assert abs(square.style["fill"]["alpha"] - 0.35) < 1e-12
             assert abs(square.style["stroke"]["alpha"] - 0.65) < 1e-12
 
+            explicit_square = Square(
+                fill_color=PINK,
+                fill_opacity=0.35,
+                stroke_color=BLUE,
+                stroke_opacity=0.65,
+                stroke_width=8,
+            )
+            explicit_square.set_fill(color=GREEN)
+            explicit_square.set_stroke(color=GREEN)
+            assert square.style == explicit_square.style
+
             # Manim VMobject.set_opacity sets both fill and stroke opacity to the
             # requested value; it does not multiply their previous independent
             # opacities. The normally zero-alpha default fill therefore becomes


### PR DESCRIPTION
Partial #180.

Adds a focused semantic regression requiring `set_color(GREEN)` to produce the exact same Noon style as explicit `set_fill(color=GREEN)` + `set_stroke(color=GREEN)` from identical independent fill/stroke alpha state.

Also adds a source-equivalent ManimCE v0.21.0 raster fixture with the two forms side-by-side. It starts on the global blocking raster policy so CI will expose any real presentation mismatch before a fixture-specific ratchet is set.

This deliberately avoids the translucent fill-edge renderer work currently owned by #225.