### PR TITLE
Match Cairo fill-stroke source-over compositing

### DIFF
--- a/crates/noon-render-wgpu/src/analytic.wgsl
+++ b/crates/noon-render-wgpu/src/analytic.wgsl
@@ -257,6 +257,10 @@ fn covered_color(color: vec4<f32>, opacity: f32, coverage: f32) -> vec4<f32> {
     return premultiplied(color) * (opacity * coverage);
 }
 
+fn source_over(source: vec4<f32>, destination: vec4<f32>) -> vec4<f32> {
+    return source + destination * (1.0 - source.a);
+}
+
 fn styled_shape_color(
     fill: vec4<f32>,
     stroke: vec4<f32>,
@@ -266,25 +270,25 @@ fn styled_shape_color(
     signed_distance: f32,
     stroke_width: f32,
 ) -> vec4<f32> {
-    // Match VectorPath/Lyon semantics: the authored outline is the stroke centerline.
-    // A stroke extends half its width outside and half inside the semantic boundary.
+    // Match Cairo/VMobject semantics: fill the semantic contour first, then
+    // source-over a centered stroke onto the preserved path. Mixing the two
+    // premultiplied colors is not equivalent when either layer is translucent.
     let half_stroke_width = max(stroke_width, 0.0) * 0.5;
     let fill_coverage = inside_coverage(signed_distance);
     let outer_coverage = inside_coverage(signed_distance - half_stroke_width);
-    let stroke_coverage = outside_coverage(signed_distance + half_stroke_width);
+    let inner_stroke_coverage = outside_coverage(signed_distance + half_stroke_width);
+    let stroke_band_coverage = outer_coverage * inner_stroke_coverage;
     let has_stroke = stroke_enabled && stroke_width > 0.0 && stroke.a > 0.0;
+    let fill_layer = select(
+        vec4<f32>(0.0),
+        covered_color(fill, opacity, fill_coverage),
+        fill_enabled,
+    );
     if has_stroke {
-        if fill_enabled {
-            let color = mix(premultiplied(fill), premultiplied(stroke), stroke_coverage);
-            return color * (opacity * outer_coverage);
-        }
-        return covered_color(stroke, opacity, outer_coverage * stroke_coverage);
+        let stroke_layer = covered_color(stroke, opacity, stroke_band_coverage);
+        return source_over(stroke_layer, fill_layer);
     }
-
-    if fill_enabled {
-        return covered_color(fill, opacity, fill_coverage);
-    }
-    return vec4<f32>(0.0);
+    return fill_layer;
 }
 
 fn styled_line_color(input: VertexOutput, signed_distance: f32) -> vec4<f32> {

--- a/crates/noon-render-wgpu/src/gpu.rs
+++ b/crates/noon-render-wgpu/src/gpu.rs
@@ -1453,10 +1453,10 @@ mod tests {
         assert!(shader.contains("local_units_per_pixel"));
         assert!(shader.contains("rectangle_signed_distance"));
         assert!(shader.contains("capsule_signed_distance"));
-        assert!(shader.contains("mix(premultiplied(fill), premultiplied(stroke)"));
+        assert!(shader.contains("source_over(stroke_layer, fill_layer)"));
         assert!(
             shader
-                .find("let stroke_coverage =")
+                .find("let inner_stroke_coverage =")
                 .expect("stroke coverage")
                 < shader.find("if has_stroke").expect("stroke branch"),
             "fragment derivatives must run before non-uniform stroke control flow"

--- a/crates/noon-render-wgpu/tests/cairo_source_over_shader_contract.rs
+++ b/crates/noon-render-wgpu/tests/cairo_source_over_shader_contract.rs
@@ -1,0 +1,8 @@
+#[test]
+fn analytic_fill_and_stroke_use_cairo_source_over_order() {
+    let shader = include_str!("../src/analytic.wgsl");
+    assert!(shader.contains("fn source_over(source: vec4<f32>, destination: vec4<f32>)"));
+    assert!(shader.contains("let stroke_band_coverage = outer_coverage * inner_stroke_coverage;"));
+    assert!(shader.contains("return source_over(stroke_layer, fill_layer);"));
+    assert!(!shader.contains("mix(premultiplied(fill), premultiplied(stroke), stroke_coverage)"));
+}


### PR DESCRIPTION
## Summary
- render analytic fill as its own premultiplied coverage layer
- render the centered analytic stroke band as a separate premultiplied layer
- composite stroke source-over fill, matching ManimCE Cairo's `fill_preserve()` then `stroke_preserve()` order
- preserve the transparent-stroke behavior fixed by #225
- add a shader contract regression for the compositing order

## Why
The remaining style raster outliers share one static edge pattern rather than a color/timing bug. For example, `SetColorIndependentOpacity` uses GREEN for both fill and stroke with fill alpha 0.35 and stroke alpha 0.65. Cairo's overlap reaches effective alpha `0.65 + 0.35 * (1 - 0.65) = 0.7725`, which matches the reference edge pixel (~`[101,148,80]`). Noon's old premultiplied `mix()` cannot exceed the 0.65 stroke alpha and produces ~`[85,125,67]` instead.

ManimCE v0.21 Cairo explicitly fills the preserved path first, then strokes it with normal source-over compositing. This PR models that ordering directly instead of tuning colors or AA thresholds.

## Expected raster impact
On both WebGPU and WebGL:
- `set-color-independent-opacity`: ~0.42% -> near edge-AA floor
- `set-global-opacity`: ~0.42% -> near edge-AA floor
- `animate-set-color`: ~0.42% -> near edge-AA floor
- `uncreate-styled-square`: ~0.52% -> materially lower
- opaque/transparent-fill fixtures should remain within their existing ratchets

Tracks #179, #180, and #185.