### PR TITLE
Add three-layer Manim painter-order parity probe

### DIFF
--- a/parity/manim-v0.21/manifest.json
+++ b/parity/manim-v0.21/manifest.json
@@ -169,6 +169,11 @@
         "max_differing_ratio": 0.0032,
         "max_mean_absolute_channel_error": 0.036
       }
+    },
+    {
+      "id": "three-layer-painter-order",
+      "scene": "ThreeLayerPainterOrder",
+      "expected_duration": 1.0
     }
   ],
   "sample_fractions": [

--- a/parity/manim-v0.21/manifest.json
+++ b/parity/manim-v0.21/manifest.json
@@ -173,7 +173,12 @@
     {
       "id": "three-layer-painter-order",
       "scene": "ThreeLayerPainterOrder",
-      "expected_duration": 1.0
+      "expected_duration": 1.0,
+      "raster_tolerance": {
+        "max_bounds_delta_px": 0,
+        "max_differing_ratio": 0.0009,
+        "max_mean_absolute_channel_error": 0.034
+      }
     }
   ],
   "sample_fractions": [

--- a/parity/manim-v0.21/quickstart.py
+++ b/parity/manim-v0.21/quickstart.py
@@ -225,3 +225,30 @@ class SetColorExplicitEquivalent(Scene):
 
         self.add(set_color_square, explicit_square)
         self.play(explicit_square.animate.shift(ORIGIN))
+
+
+class ThreeLayerPainterOrder(Scene):
+    def construct(self):
+        def layer(color, offset):
+            return Square(
+                side_length=1.6,
+                fill_color=color,
+                fill_opacity=0.5,
+                stroke_opacity=0.0,
+            ).shift(offset)
+
+        left_center = 1.8 * LEFT
+        left_red = layer(RED, left_center + 0.3 * LEFT)
+        left_green = layer(GREEN, left_center + 0.3 * RIGHT)
+        left_blue = layer(BLUE, left_center + 0.3 * UP)
+
+        right_center = 1.8 * RIGHT
+        right_red = layer(RED, right_center + 0.3 * LEFT)
+        right_green = layer(GREEN, right_center + 0.3 * RIGHT)
+        right_blue = layer(BLUE, right_center + 0.3 * UP)
+
+        # Same colors and geometry, opposite painter order. Each cluster contains
+        # single-layer, pairwise-overlap, and true three-layer overlap regions.
+        self.add(left_red, left_green, left_blue)
+        self.add(right_blue, right_green, right_red)
+        self.play(right_red.animate.shift(ORIGIN))


### PR DESCRIPTION
Partial #180.

Adds a source-equivalent ManimCE v0.21.0 compositing fixture with two geometrically identical three-square clusters. The left cluster paints RED → GREEN → BLUE; the right paints BLUE → GREEN → RED. Each cluster contains single-layer, pairwise-overlap, and true triple-overlap regions, so source-over and painter-order mistakes are directly visible.

The fixture starts on the global blocking raster policy. No renderer behavior or tolerance is changed until the Manim oracle provides measured evidence.