### PR TITLE
Add isolated Manim FadeIn/FadeOut parity probes

### DIFF
--- a/parity/manim-v0.21/manifest.json
+++ b/parity/manim-v0.21/manifest.json
@@ -184,6 +184,16 @@
         "max_differing_ratio": 0.0009,
         "max_mean_absolute_channel_error": 0.034
       }
+    },
+    {
+      "id": "fade-in-shift-scale-styled-square",
+      "scene": "FadeInShiftScaleStyledSquare",
+      "expected_duration": 1.0
+    },
+    {
+      "id": "fade-out-shift-scale-styled-square",
+      "scene": "FadeOutShiftScaleStyledSquare",
+      "expected_duration": 1.0
     }
   ],
   "sample_fractions": [

--- a/parity/manim-v0.21/quickstart.py
+++ b/parity/manim-v0.21/quickstart.py
@@ -262,3 +262,28 @@ class ThreeLayerPainterOrder(Scene):
         self.add(left_red, left_green, left_blue)
         self.add(right_blue, right_green, right_red)
         self.play(right_red.animate.shift(ORIGIN))
+
+
+class FadeInShiftScaleStyledSquare(Scene):
+    def construct(self):
+        square = Square(
+            fill_color=PINK,
+            fill_opacity=0.35,
+            stroke_color=BLUE,
+            stroke_opacity=0.65,
+            stroke_width=8,
+        )
+        self.play(FadeIn(square, shift=RIGHT, scale=0.5, rate_func=linear))
+
+
+class FadeOutShiftScaleStyledSquare(Scene):
+    def construct(self):
+        square = Square(
+            fill_color=PINK,
+            fill_opacity=0.35,
+            stroke_color=BLUE,
+            stroke_opacity=0.65,
+            stroke_width=8,
+        )
+        self.add(square)
+        self.play(FadeOut(square, shift=RIGHT, scale=0.5, rate_func=linear))


### PR DESCRIPTION
## Summary
- add source-equivalent `FadeIn` and `FadeOut` raster probes for the #183 acceptance gap
- exercise independent fill/stroke alpha together with supported `shift=` and `scale=` fade endpoints
- use linear rate functions to isolate fade state interpolation from easing
- inherit the blocking ManimCE v0.21 Cairo raster policy and dense 0/25/50/75/90/95/98/99/100% sampling

## Why
The canonical quickstart currently exercises `FadeOut` only after the Square→Circle transform. That can hide fade-specific interpolation/lifecycle errors behind morph differences, and there is no isolated `FadeIn` raster fixture. These probes make the supported shift/scale fade contract independently measurable on WebGPU and WebGL.

If the new fixtures expose a mismatch, this PR will be extended with the corresponding fade implementation fix before merge.

Tracks #183.