### PR TITLE
Add Manim camera unit-mapping parity probe

### DIFF
--- a/parity/manim-v0.21/manifest.json
+++ b/parity/manim-v0.21/manifest.json
@@ -204,6 +204,16 @@
       "id": "fade-out-shift-scale-styled-square",
       "scene": "FadeOutShiftScaleStyledSquare",
       "expected_duration": 1.0
+    },
+    {
+      "id": "camera-unit-offsets",
+      "scene": "CameraUnitOffsets",
+      "expected_duration": 1.0,
+      "raster_tolerance": {
+        "max_bounds_delta_px": 1,
+        "max_differing_ratio": 0.00033,
+        "max_mean_absolute_channel_error": 0.004
+      }
     }
   ],
   "sample_fractions": [

--- a/parity/manim-v0.21/quickstart.py
+++ b/parity/manim-v0.21/quickstart.py
@@ -314,3 +314,17 @@ class FadeOutShiftScaleStyledSquare(Scene):
         )
         self.add(square)
         self.play(FadeOut(square, shift=RIGHT, scale=0.5, rate_func=linear))
+
+
+class CameraUnitOffsets(Scene):
+    def construct(self):
+        def marker(position):
+            return Square(
+                side_length=0.4,
+                fill_color=WHITE,
+                fill_opacity=1.0,
+                stroke_opacity=0.0,
+            ).move_to(position)
+
+        self.add(marker(ORIGIN), marker(RIGHT), marker(UP))
+        self.wait(1)


### PR DESCRIPTION
Superseded by #233, which carries the validated `CameraUnitOffsets` contract on current master and adds the stronger canonical frame-edge clipping probe. Closing this duplicate branch to avoid conflicting manifest/source edits.