### PR TITLE
Add transformed Create and Uncreate parity probes

### DIFF
--- a/crates/noon-geometry/tests/partial_path_subpaths.rs
+++ b/crates/noon-geometry/tests/partial_path_subpaths.rs
@@ -1,0 +1,42 @@
+use noon_core::{PathCommand, Vec2, VectorPath};
+use noon_geometry::pointwise_partial_path;
+
+fn assert_vec2(actual: Vec2, expected: Vec2) {
+    assert!(
+        (actual.x - expected.x).abs() < 1e-6 && (actual.y - expected.y).abs() < 1e-6,
+        "{actual:?} != {expected:?}"
+    );
+}
+
+#[test]
+fn partial_reveal_preserves_subpath_break_when_crossing_into_next_contour() {
+    let path = VectorPath::new()
+        .move_to(Vec2::new(0.0, 0.0))
+        .line_to(Vec2::new(1.0, 0.0))
+        .move_to(Vec2::new(10.0, 0.0))
+        .line_to(Vec2::new(11.0, 0.0));
+
+    // Manim divides global reveal progress uniformly by Bezier-curve count.
+    // At 0.75, the first of two curves is complete and the second is halfway.
+    // The second contour must remain a separate MoveTo rather than gaining an
+    // artificial connecting segment from the first contour's endpoint.
+    let partial = pointwise_partial_path(&path, 0.0, 0.75);
+    assert_eq!(partial.commands().len(), 4);
+
+    match partial.commands()[0] {
+        PathCommand::MoveTo { to } => assert_vec2(to, Vec2::new(0.0, 0.0)),
+        ref other => panic!("unexpected command: {other:?}"),
+    }
+    match partial.commands()[1] {
+        PathCommand::LineTo { to } => assert_vec2(to, Vec2::new(1.0, 0.0)),
+        ref other => panic!("unexpected command: {other:?}"),
+    }
+    match partial.commands()[2] {
+        PathCommand::MoveTo { to } => assert_vec2(to, Vec2::new(10.0, 0.0)),
+        ref other => panic!("unexpected command: {other:?}"),
+    }
+    match partial.commands()[3] {
+        PathCommand::LineTo { to } => assert_vec2(to, Vec2::new(10.5, 0.0)),
+        ref other => panic!("unexpected command: {other:?}"),
+    }
+}

--- a/parity/manim-v0.21/manifest.json
+++ b/parity/manim-v0.21/manifest.json
@@ -92,6 +92,16 @@
       }
     },
     {
+      "id": "create-transformed-square",
+      "scene": "CreateTransformedSquare",
+      "expected_duration": 1.0
+    },
+    {
+      "id": "uncreate-transformed-square",
+      "scene": "UncreateTransformedSquare",
+      "expected_duration": 1.0
+    },
+    {
       "id": "uncreate-square",
       "scene": "UncreateSquare",
       "expected_duration": 1.0,

--- a/parity/manim-v0.21/quickstart.py
+++ b/parity/manim-v0.21/quickstart.py
@@ -96,6 +96,33 @@ class UncreateStyledSquare(Scene):
         self.play(Uncreate(square))
 
 
+class CreateTransformedSquare(Scene):
+    def construct(self):
+        square = Square(
+            fill_color=PINK,
+            fill_opacity=0.35,
+            stroke_color=BLUE,
+            stroke_opacity=0.65,
+            stroke_width=8,
+        )
+        square.scale(1.3).rotate(PI / 6).shift(1.5 * RIGHT + 0.75 * UP)
+        self.play(Create(square))
+
+
+class UncreateTransformedSquare(Scene):
+    def construct(self):
+        square = Square(
+            fill_color=PINK,
+            fill_opacity=0.35,
+            stroke_color=BLUE,
+            stroke_opacity=0.65,
+            stroke_width=8,
+        )
+        square.scale(1.3).rotate(PI / 6).shift(1.5 * RIGHT + 0.75 * UP)
+        self.add(square)
+        self.play(Uncreate(square))
+
+
 class UncreateSquare(Scene):
     def construct(self):
         square = Square()


### PR DESCRIPTION
## Summary
- add source-equivalent ManimCE v0.21 `Create` / `Uncreate` fixtures for a pre-scaled, pre-rotated, pre-shifted styled `Square`
- add both fixtures to the blocking raster + semantic-state corpus with no custom per-fixture tolerance
- add a low-level `pointwise_partial_path` regression proving a reveal that crosses into a second contour preserves the `MoveTo` discontinuity instead of inventing a connecting segment

## Why
#182 explicitly requires reveal parity after transform/scale/rotate and coverage of multiple subpaths. The existing corpus already pins line, circle, styled square, dense near-end sampling, and Create/Uncreate lifecycle behavior, but did not yet include a transformed reveal. The geometry implementation already preserves subpath boundaries; this PR makes that contract fail-fast in a focused regression even though the current Manim facade does not expose a generic multi-subpath VMobject construction API.

## Policy
No production behavior or raster tolerance is changed. If the new source-equivalent fixtures expose a mismatch, the implementation should be corrected rather than loosening the oracle.

Tracks #182.