### PR TITLE
Gate Manim camera unit scale and frame-edge clipping

### DIFF
--- a/parity/manim-v0.21/manifest.json
+++ b/parity/manim-v0.21/manifest.json
@@ -204,6 +204,21 @@
       "id": "fade-out-shift-scale-styled-square",
       "scene": "FadeOutShiftScaleStyledSquare",
       "expected_duration": 1.0
+    },
+    {
+      "id": "camera-unit-offsets",
+      "scene": "CameraUnitOffsets",
+      "expected_duration": 1.0,
+      "raster_tolerance": {
+        "max_bounds_delta_px": 1,
+        "max_differing_ratio": 0.00033,
+        "max_mean_absolute_channel_error": 0.004
+      }
+    },
+    {
+      "id": "camera-frame-edges",
+      "scene": "CameraFrameEdges",
+      "expected_duration": 1.0
     }
   ],
   "sample_fractions": [

--- a/parity/manim-v0.21/quickstart.py
+++ b/parity/manim-v0.21/quickstart.py
@@ -314,3 +314,47 @@ class FadeOutShiftScaleStyledSquare(Scene):
         )
         self.add(square)
         self.play(FadeOut(square, shift=RIGHT, scale=0.5, rate_func=linear))
+
+
+class CameraUnitOffsets(Scene):
+    def construct(self):
+        def marker(position):
+            return Square(
+                side_length=0.4,
+                fill_color=WHITE,
+                fill_opacity=1.0,
+                stroke_opacity=0.0,
+            ).move_to(position)
+
+        origin = marker(ORIGIN)
+        x_unit = marker(RIGHT)
+        y_unit = marker(UP)
+        self.add(origin, x_unit, y_unit)
+        # Keep a real one-second frame interval while leaving the camera/markers
+        # static so bounds and centroids isolate world-to-pixel mapping.
+        self.play(y_unit.animate.shift(ORIGIN))
+
+
+class CameraFrameEdges(Scene):
+    def construct(self):
+        # ManimCE v0.21's canonical 16:9 frame is 14.222... x 8 world units.
+        # Centering identical fill-only markers exactly on each frame boundary
+        # makes half of each marker visible and directly exercises clipping.
+        half_width = 64.0 / 9.0
+        half_height = 4.0
+
+        def marker(color, position):
+            return Square(
+                side_length=0.4,
+                fill_color=color,
+                fill_opacity=1.0,
+                stroke_opacity=0.0,
+            ).move_to(position)
+
+        center = marker(WHITE, ORIGIN)
+        left = marker(RED, half_width * LEFT)
+        right = marker(GREEN, half_width * RIGHT)
+        top = marker(BLUE, half_height * UP)
+        bottom = marker(YELLOW, half_height * DOWN)
+        self.add(center, left, right, top, bottom)
+        self.play(center.animate.shift(ORIGIN))


### PR DESCRIPTION
Partial #177.

Recovers the previously validated `CameraUnitOffsets` fixture from superseded #231 onto current master and adds a second source-equivalent camera probe for the canonical ManimCE v0.21 frame boundaries.

Coverage:
- `CameraUnitOffsets`: identical opaque fill-only markers at `ORIGIN`, `RIGHT`, and `UP`, with the previously measured blocking ratchet (`1 px` bbox, `0.00033` differing ratio, `0.004` MAE). The prior oracle measured Manim at exactly 67.5 px/world-unit and Noon within ~0.03 px on both axes.
- `CameraFrameEdges`: identical 0.4-unit fill-only markers centered exactly on the canonical 16:9 frame edges (`x = ±64/9`, `y = ±4`) plus a center marker. Half of each edge marker must be clipped at the output boundary, directly exercising frame extent/origin/clipping rather than playground CSS size.

The frame-edge fixture intentionally starts on the global blocking raster policy with no exemption or calibrated tolerance. No production camera constant or renderer behavior is changed unless the Manim oracle exposes a real mismatch.

Playground presentation sizing remains owned by #117/#229.