### PR TITLE
Complete Manim primitive geometry parity coverage

### DIFF
--- a/parity/manim-v0.21/manifest.json
+++ b/parity/manim-v0.21/manifest.json
@@ -219,6 +219,11 @@
       "id": "camera-frame-edges",
       "scene": "CameraFrameEdges",
       "expected_duration": 1.0
+    },
+    {
+      "id": "primitive-geometry-matrix",
+      "scene": "PrimitiveGeometryMatrix",
+      "expected_duration": 1.0
     }
   ],
   "sample_fractions": [

--- a/parity/manim-v0.21/manifest.json
+++ b/parity/manim-v0.21/manifest.json
@@ -218,7 +218,12 @@
     {
       "id": "camera-frame-edges",
       "scene": "CameraFrameEdges",
-      "expected_duration": 1.0
+      "expected_duration": 1.0,
+      "raster_tolerance": {
+        "max_bounds_delta_px": 0,
+        "max_differing_ratio": 0.00029,
+        "max_mean_absolute_channel_error": 0.0052
+      }
     },
     {
       "id": "primitive-geometry-matrix",

--- a/parity/manim-v0.21/quickstart.py
+++ b/parity/manim-v0.21/quickstart.py
@@ -358,3 +358,42 @@ class CameraFrameEdges(Scene):
         bottom = marker(YELLOW, half_height * DOWN)
         self.add(center, left, right, top, bottom)
         self.play(center.animate.shift(ORIGIN))
+
+
+class PrimitiveGeometryMatrix(Scene):
+    def construct(self):
+        circle = Circle(
+            radius=0.75,
+            fill_color=RED,
+            fill_opacity=1.0,
+            stroke_opacity=0.0,
+        ).move_to(4.5 * LEFT + 1.5 * UP)
+        rectangle = Rectangle(
+            width=2.4,
+            height=1.1,
+            fill_color=GREEN,
+            fill_opacity=1.0,
+            stroke_opacity=0.0,
+        ).move_to(1.6 * LEFT + 1.5 * UP)
+        square = Square(
+            side_length=1.3,
+            fill_color=BLUE,
+            fill_opacity=1.0,
+            stroke_opacity=0.0,
+        ).move_to(1.2 * RIGHT + 1.5 * UP)
+        diagonal = Line(
+            1.0 * LEFT + 0.6 * DOWN,
+            1.2 * RIGHT + 0.8 * UP,
+            color=YELLOW,
+            stroke_width=4,
+        ).shift(3.8 * LEFT + 1.6 * DOWN)
+        rotated = Rectangle(
+            width=2.0,
+            height=1.0,
+            fill_color=PURPLE,
+            fill_opacity=1.0,
+            stroke_opacity=0.0,
+        ).rotate(PI / 6).move_to(2.4 * RIGHT + 1.5 * DOWN)
+
+        self.add(circle, rectangle, square, diagonal, rotated)
+        self.play(rotated.animate.shift(ORIGIN))

--- a/web/python/test_manim_geometry_defaults.py
+++ b/web/python/test_manim_geometry_defaults.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 
 class ManimGeometryDefaultsTests(unittest.TestCase):
-    def test_public_rectangle_and_square_defaults_match_manim_v021(self) -> None:
+    def _run_compat_source(self, source: str) -> None:
         python_dir = Path(__file__).resolve().parent
         env = os.environ.copy()
         existing_pythonpath = env.get("PYTHONPATH")
@@ -17,7 +17,22 @@ class ManimGeometryDefaultsTests(unittest.TestCase):
             else os.pathsep.join((str(python_dir), existing_pythonpath))
         )
 
-        source = textwrap.dedent(
+        completed = subprocess.run(
+            [sys.executable, "-c", textwrap.dedent(source)],
+            check=False,
+            cwd=python_dir,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            completed.returncode,
+            0,
+            f"compatibility subprocess failed:\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
+        )
+
+    def test_public_rectangle_and_square_defaults_match_manim_v021(self) -> None:
+        self._run_compat_source(
             """
             import inspect
 
@@ -47,18 +62,57 @@ class ManimGeometryDefaultsTests(unittest.TestCase):
             """
         )
 
-        completed = subprocess.run(
-            [sys.executable, "-c", source],
-            check=False,
-            cwd=python_dir,
-            env=env,
-            capture_output=True,
-            text=True,
+    def test_circle_line_and_rotated_rectangle_bounds_match_manim_geometry(self) -> None:
+        self._run_compat_source(
+            """
+            import math
+
+            import _manim_compat
+
+            _manim_compat.install()
+            import _manim_phase_b  # noqa: F401 - installs pinned Phase-B semantics
+            from noon import Circle, LEFT, Line, PI, RIGHT, Rectangle
+
+            circle = Circle(radius=1.25)
+            assert abs(circle.width - 2.5) < 1e-12
+            assert abs(circle.height - 2.5) < 1e-12
+            assert circle.geometry["circle"]["radius"] == 1.25
+
+            line = Line()
+            assert line.geometry["line"]["start"] == {"x": LEFT.x, "y": LEFT.y}
+            assert line.geometry["line"]["end"] == {"x": RIGHT.x, "y": RIGHT.y}
+            assert abs(line.width - 2.0) < 1e-12
+            assert abs(line.height) < 1e-12
+
+            rectangle = Rectangle(width=4.0, height=2.0).rotate(PI / 6)
+            expected_width = 4.0 * math.cos(PI / 6) + 2.0 * math.sin(PI / 6)
+            expected_height = 4.0 * math.sin(PI / 6) + 2.0 * math.cos(PI / 6)
+            assert abs(rectangle.width - expected_width) < 1e-12
+            assert abs(rectangle.height - expected_height) < 1e-12
+            """
         )
-        self.assertEqual(
-            completed.returncode,
-            0,
-            f"compatibility subprocess failed:\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
+
+    def test_vector_path_bounds_use_bezier_extrema_not_control_hull(self) -> None:
+        self._run_compat_source(
+            """
+            import _manim_compat
+
+            _manim_compat.install()
+            import _manim_phase_b  # noqa: F401 - installs pinned Phase-B semantics
+            from noon import Path, VectorPath
+
+            curve = (
+                VectorPath()
+                .move_to((0.0, 0.0))
+                .cubic_to((0.0, 3.0), (2.0, 3.0), (2.0, 0.0))
+            )
+            path = Path(curve)
+
+            # The cubic reaches y=2.25 at t=0.5. The control hull reaches y=3,
+            # so this catches conservative-control-box layout regressions.
+            assert abs(path.width - 2.0) < 1e-12
+            assert abs(path.height - 2.25) < 1e-12
+            """
         )
 
 


### PR DESCRIPTION
## Summary
- extend the pinned Manim primitive-default regression beyond Rectangle/Square to Circle and Line
- pin rotated Rectangle world bounds analytically
- pin cubic Bézier layout bounds to the actual curve extrema instead of the control-point hull
- add a source-equivalent static `PrimitiveGeometryMatrix` covering explicit Circle, Rectangle, Square, diagonal Line, and a rotated non-square Rectangle

## Why
#190 established the exact ManimCE v0.21 primitive contour ordering/parameterization, and later parity work fixed constructor defaults and tight layout bounds. This final #178 slice makes the remaining supported primitive contracts fail-fast below the browser and through the real pinned ManimCE Cairo oracle.

The raster matrix is on the global blocking policy with no custom exemption/tolerance. Closed shapes are fill-only to isolate contour dimensions/orientation; the Line uses the already-qualified Manim stroke contract. The rotated Rectangle catches transformed bounds/silhouette errors that axis-aligned fixtures miss.

Built on merged #233 camera unit/frame-edge mapping, so raster geometry is no longer confounded by global scene-space mapping.

Tracks #178.