### PR TITLE
Tighten Manim frame-edge clipping ratchet

### DIFF
--- a/parity/manim-v0.21/manifest.json
+++ b/parity/manim-v0.21/manifest.json
@@ -218,7 +218,12 @@
     {
       "id": "camera-frame-edges",
       "scene": "CameraFrameEdges",
-      "expected_duration": 1.0
+      "expected_duration": 1.0,
+      "raster_tolerance": {
+        "max_bounds_delta_px": 0,
+        "max_differing_ratio": 0.00029,
+        "max_mean_absolute_channel_error": 0.0052
+      }
     }
   ],
   "sample_fractions": [


### PR DESCRIPTION
Follow-up to #233 / partial #177.

#233 auto-merged after its measured passing run but before the policy-only tightening commit could be included. This PR carries only the measured `camera-frame-edges` raster tolerance onto current master:

- bounds/centroid delta: exactly 0 px on WebGPU and WebGL
- differing ratio measured: 0.0002758488 on both backends
- MAE measured: 0.004923804 on both backends
- direct seek == incremental playback at every sampled frame

New blocking ceiling: `max_bounds_delta_px=0`, `max_differing_ratio=0.00029`, `max_mean_absolute_channel_error=0.0052`.

No source fixture or production behavior changes.