### PR TITLE
Make exact Manim parity a support gate and expose parity demos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,6 +232,12 @@ jobs:
           NOON_BROWSER_SMOKE_ARTIFACTS: browser-smoke-artifacts/${{ matrix.backend }}
         run: node scripts/browser-smoke.mjs
 
+      - name: Test camera backing-density invariance
+        env:
+          NOON_BROWSER_SMOKE_BACKEND: ${{ matrix.backend }}
+          NOON_CAMERA_DENSITY_ARTIFACTS: browser-smoke-artifacts/${{ matrix.backend }}/camera-density
+        run: node scripts/camera-density-smoke.mjs
+
       - name: Test mixed painter order in WebGPU
         if: matrix.backend == 'webgpu'
         run: node scripts/painter-order-browser-smoke.mjs

--- a/docs/manim-api-coverage.md
+++ b/docs/manim-api-coverage.md
@@ -2,13 +2,29 @@
 
 Noon pins user-facing compatibility work to **Manim Community v0.21.0**.
 
-API presence, behavioral parity, and executable example coverage are intentionally separate but connected gates:
+API presence, behavioral parity, executable example coverage, and exact observable-output parity are intentionally separate but connected gates:
 
 - `scripts/manim-api-coverage.py` inventories the complete pinned Manim public namespace and classifies every symbol as `supported`, `partial`, `blocked`, `deferred`, `intentional-divergence`, or `missing`.
 - `scripts/manim-differential.py` compares renderer-independent behavior for features Noon actually claims to support.
+- `parity/manim-v0.21/manifest.json` defines the canonical source-equivalent Manim raster + timeline corpus and the pixel/time comparison policy.
 - `web/python/examples/manim_tutorial_manifest.json`, when present, is the single source for tutorial/example coverage. The API report validates and summarizes that same manifest rather than maintaining a second example list.
 
 The API classification policy lives in `compat/manim-v0.21.0.json`. Module-level rules make large known gaps such as text/math, plotting, graph networks, and 3D explicit, while individual overrides record supported or partially supported public symbols and high-value issue ownership.
+
+## Exact-output promotion rule
+
+A public symbol or behavior is not promoted to `supported` merely because the name exists, a semantic probe passes, or a Noon-adapted tutorial renders. For observable Manim-facing behavior, `supported` requires the exact-output gate tracked by #185/#176 for the relevant slice:
+
+- use a source-equivalent ManimCE v0.21.0 fixture with no Noon-only geometry, style, layout, camera, or timing compensation;
+- compare normalized semantic state and rendered pixels against real Manim under the pinned canonical profile;
+- for animated/time-dependent behavior, match duration, child intervals, rate functions, lifecycle boundaries, and intermediate states at begin, 25%, 50%, 75%, the final rendered sample, exact end, and any additional discontinuity-sensitive samples;
+- deterministic direct seek must agree with forward playback;
+- WebGPU and WebGL must both satisfy the reference contract where the backend is claimed supported;
+- expose at least one user-facing demo/gallery example for the same source-equivalent behavior, linked to its canonical parity fixture.
+
+Until those gates pass, keep the item `partial`, `blocked`, `deferred`, or `intentional-divergence` as appropriate. Semantic/numeric tests remain required because they diagnose failures cheaply, but they do not replace pixel/time-level qualification.
+
+Tutorial manifest `status: ready` means the example executes. It does **not** mean visual compatibility. Source-equivalent demo entries therefore carry separate `parity_status` metadata: `candidate` while exact-output work remains, and `parity-qualified` only after the canonical gate passes. Existing `original-noon-adaptation` examples are explicitly marked `adaptation`.
 
 ## Running the report
 
@@ -25,8 +41,8 @@ CI also writes `manim-v0.21-api-coverage.md` as a workflow artifact. The report 
 
 A parity PR that exposes a new Manim-compatible public symbol should update `compat/manim-v0.21.0.json` and add behavioral evidence when applicable. Exporting a name alone does not prove compatibility: unreviewed Noon exports resolve to `partial` rather than being automatically promoted to `supported`.
 
-A parity PR that unlocks a tutorial or gallery example should update `web/python/examples/manim_tutorial_manifest.json` rather than adding a duplicate coverage list. Ready entries require an executable fixture plus upstream provenance/reuse metadata; blocked and deferred entries require an issue dependency.
+A parity PR that unlocks a tutorial or gallery example should update `web/python/examples/manim_tutorial_manifest.json` rather than adding a duplicate coverage list. Ready entries require an executable fixture plus upstream provenance/reuse metadata; blocked and deferred entries require an issue dependency. Source-equivalent parity examples must additionally link a canonical `parity_fixture` and carry their independent `parity_status`.
 
-Features blocked by architectural work should remain visibly `blocked` and name the relevant issue. Full 3D/vector-space behavior is deliberately `deferred` until #90 defines the intended compatibility target.
+Features blocked by architectural work should remain visibly `blocked` and name the relevant issue. Full 3D/vector-space behavior is deliberately `deferred` until #90 defines the intended compatibility target; any 3D slice later promoted to supported is still subject to the exact-output promotion rule above.
 
 This coverage report is an inventory, not a promise that every Manim symbol will be implemented. Intentional browser/runtime divergences should be recorded explicitly rather than silently omitted.

--- a/parity/manim-v0.21/manifest.json
+++ b/parity/manim-v0.21/manifest.json
@@ -224,6 +224,11 @@
         "max_differing_ratio": 0.00029,
         "max_mean_absolute_channel_error": 0.0052
       }
+    },
+    {
+      "id": "primitive-geometry-matrix",
+      "scene": "PrimitiveGeometryMatrix",
+      "expected_duration": 1.0
     }
   ],
   "sample_fractions": [

--- a/parity/manim-v0.21/quickstart.py
+++ b/parity/manim-v0.21/quickstart.py
@@ -358,3 +358,42 @@ class CameraFrameEdges(Scene):
         bottom = marker(YELLOW, half_height * DOWN)
         self.add(center, left, right, top, bottom)
         self.play(center.animate.shift(ORIGIN))
+
+
+class PrimitiveGeometryMatrix(Scene):
+    def construct(self):
+        circle = Circle(
+            radius=0.75,
+            fill_color=RED,
+            fill_opacity=1.0,
+            stroke_opacity=0.0,
+        ).move_to(4.5 * LEFT + 1.5 * UP)
+        rectangle = Rectangle(
+            width=2.4,
+            height=1.1,
+            fill_color=GREEN,
+            fill_opacity=1.0,
+            stroke_opacity=0.0,
+        ).move_to(1.6 * LEFT + 1.5 * UP)
+        square = Square(
+            side_length=1.3,
+            fill_color=BLUE,
+            fill_opacity=1.0,
+            stroke_opacity=0.0,
+        ).move_to(1.2 * RIGHT + 1.5 * UP)
+        diagonal = Line(
+            1.0 * LEFT + 0.6 * DOWN,
+            1.2 * RIGHT + 0.8 * UP,
+            color=YELLOW,
+            stroke_width=4,
+        ).shift(3.8 * LEFT + 1.6 * DOWN)
+        rotated = Rectangle(
+            width=2.0,
+            height=1.0,
+            fill_color=PURPLE,
+            fill_opacity=1.0,
+            stroke_opacity=0.0,
+        ).rotate(PI / 6).move_to(2.4 * RIGHT + 1.5 * DOWN)
+
+        self.add(circle, rectangle, square, diagonal, rotated)
+        self.play(rotated.animate.shift(ORIGIN))

--- a/scripts/camera-density-smoke.mjs
+++ b/scripts/camera-density-smoke.mjs
@@ -1,0 +1,216 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import playwright from "playwright";
+import pngjs from "pngjs";
+
+const { chromium } = playwright;
+const { PNG } = pngjs;
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const port = Number(process.env.NOON_CAMERA_DENSITY_PORT ?? "4194");
+const baseUrl = `http://127.0.0.1:${port}`;
+const backendMode = process.env.NOON_BROWSER_SMOKE_BACKEND ?? "webgpu";
+const expectedBackend = backendMode === "webgpu" ? "WebGPU" : "WebGL2";
+const artifactDir = path.resolve(
+  repoRoot,
+  process.env.NOON_CAMERA_DENSITY_ARTIFACTS ?? `browser-smoke-artifacts/${backendMode}/camera-density`,
+);
+assert.ok(
+  backendMode === "webgpu" || backendMode === "webgl",
+  `unknown camera-density backend: ${backendMode}`,
+);
+await mkdir(artifactDir, { recursive: true });
+
+const sceneJson = JSON.stringify({
+  version: 1,
+  objects: [
+    {
+      id: 0,
+      geometry: { rectangle: { size: { x: 2.0, y: 1.0 } } },
+      transform: {
+        translation: { x: 1.25, y: -0.75 },
+        rotation: Math.PI / 6,
+        scale: { x: 1.0, y: 1.0 },
+      },
+      style: {
+        fill: { red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0 },
+        stroke: null,
+        stroke_width: 0.0,
+        stroke_width_mode: "screen_space",
+        stroke_join: "miter",
+        stroke_cap: "butt",
+        opacity: 1.0,
+      },
+    },
+  ],
+  tracks: [],
+});
+
+let serverOutput = "";
+const server = spawn(
+  "python3",
+  ["-m", "http.server", String(port), "--bind", "127.0.0.1", "--directory", repoRoot],
+  { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] },
+);
+server.stdout.on("data", (chunk) => (serverOutput += chunk));
+server.stderr.on("data", (chunk) => (serverOutput += chunk));
+
+async function waitForServer() {
+  let lastError = null;
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    try {
+      const response = await fetch(`${baseUrl}/web/browser-smoke.html`);
+      if (response.ok) return;
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`camera-density server did not start: ${lastError}\n${serverOutput}`);
+}
+
+function browserArgs() {
+  if (backendMode === "webgpu") {
+    return [
+      "--enable-unsafe-webgpu",
+      "--enable-unsafe-swiftshader",
+      "--use-webgpu-adapter=swiftshader",
+      "--use-gpu-in-tests",
+      "--ignore-gpu-blocklist",
+      "--enable-features=Vulkan",
+      "--use-gl=angle",
+      "--use-angle=swiftshader",
+      "--use-vulkan=swiftshader",
+      "--disable-gpu-sandbox",
+      "--disable-dev-shm-usage",
+    ];
+  }
+  return [
+    "--disable-features=WebGPU",
+    "--enable-unsafe-swiftshader",
+    "--ignore-gpu-blocklist",
+    "--use-gl=angle",
+    "--use-angle=swiftshader",
+    "--disable-gpu-sandbox",
+    "--disable-dev-shm-usage",
+  ];
+}
+
+function visibleStats(buffer) {
+  const png = PNG.sync.read(buffer);
+  const background = [png.data[0], png.data[1], png.data[2], png.data[3]];
+  let changedPixels = 0;
+  let minX = png.width;
+  let minY = png.height;
+  let maxX = -1;
+  let maxY = -1;
+  for (let offset = 0; offset < png.data.length; offset += 4) {
+    const distance =
+      Math.abs(png.data[offset] - background[0]) +
+      Math.abs(png.data[offset + 1] - background[1]) +
+      Math.abs(png.data[offset + 2] - background[2]) +
+      Math.abs(png.data[offset + 3] - background[3]);
+    if (distance < 32) continue;
+    changedPixels += 1;
+    const pixel = offset / 4;
+    const x = pixel % png.width;
+    const y = Math.floor(pixel / png.width);
+    minX = Math.min(minX, x);
+    minY = Math.min(minY, y);
+    maxX = Math.max(maxX, x);
+    maxY = Math.max(maxY, y);
+  }
+  assert.ok(changedPixels > 100, "density probe must render a visible object");
+  return {
+    width: png.width,
+    height: png.height,
+    changedPixels,
+    bounds: { minX, minY, maxX, maxY },
+    centroid: { x: (minX + maxX) / 2, y: (minY + maxY) / 2 },
+  };
+}
+
+function boundDelta(left, right) {
+  return Math.max(
+    Math.abs(left.bounds.minX - right.bounds.minX),
+    Math.abs(left.bounds.minY - right.bounds.minY),
+    Math.abs(left.bounds.maxX - right.bounds.maxX),
+    Math.abs(left.bounds.maxY - right.bounds.maxY),
+  );
+}
+
+let browser = null;
+try {
+  await waitForServer();
+  browser = await chromium.launch({ channel: "chromium", headless: true, args: browserArgs() });
+  const page = await browser.newPage({ viewport: { width: 1000, height: 600 } });
+  const browserErrors = [];
+  page.on("pageerror", (error) => browserErrors.push(`pageerror: ${error}`));
+  page.on("console", (message) => {
+    if (message.type() === "error") browserErrors.push(`console: ${message.text()}`);
+  });
+
+  await page.goto(`${baseUrl}/web/browser-smoke.html`, { waitUntil: "load" });
+  await page.waitForFunction(() => window.noonSmoke?.state.ready === true, null, {
+    timeout: 30_000,
+  });
+  const initial = await page.evaluate(() => window.noonSmoke.metrics());
+  assert.equal(initial.error, null, `${backendMode}: browser smoke initialization`);
+  assert.equal(initial.rendererBackend, expectedBackend, `${backendMode}: renderer backend`);
+  const loaded = await page.evaluate((json) => window.noonSmoke.loadScene(json), sceneJson);
+  assert.equal(loaded.objectCount, 1, "density scene object count");
+
+  const profiles = [
+    { label: "1x", width: 960, height: 540 },
+    { label: "1.5x", width: 1440, height: 810 },
+    { label: "2x", width: 1920, height: 1080 },
+  ];
+  const captures = [];
+  for (const profile of profiles) {
+    const resized = await page.evaluate(
+      ({ width, height }) => window.noonSmoke.resizeBacking(width, height),
+      profile,
+    );
+    assert.equal(resized.backingWidth, profile.width, `${profile.label}: backing width`);
+    assert.equal(resized.backingHeight, profile.height, `${profile.label}: backing height`);
+    assert.equal(resized.cssWidth, 960, `${profile.label}: CSS width remains composition viewport`);
+    assert.equal(resized.cssHeight, 540, `${profile.label}: CSS height remains composition viewport`);
+
+    const metrics = await page.evaluate(() => window.noonSmoke.renderAt(1.0));
+    assert.equal(metrics.error, null, `${profile.label}: render error`);
+    assert.equal(metrics.presented, true, `${profile.label}: frame presentation`);
+    assert.ok(metrics.drawCalls > 0, `${profile.label}: expected draw calls`);
+
+    const screenshot = await page.locator("#scene").screenshot({
+      path: path.join(artifactDir, `${profile.label}.png`),
+    });
+    const stats = visibleStats(screenshot);
+    assert.equal(stats.width, 960, `${profile.label}: screenshot CSS width`);
+    assert.equal(stats.height, 540, `${profile.label}: screenshot CSS height`);
+    captures.push({ profile, stats });
+  }
+
+  const baseline = captures[0].stats;
+  for (const { profile, stats } of captures.slice(1)) {
+    const bounds = boundDelta(baseline, stats);
+    const centroid = Math.max(
+      Math.abs(baseline.centroid.x - stats.centroid.x),
+      Math.abs(baseline.centroid.y - stats.centroid.y),
+    );
+    assert.ok(bounds <= 1, `${profile.label}: backing density moved CSS bounds by ${bounds}px`);
+    assert.ok(centroid <= 0.5, `${profile.label}: backing density moved centroid by ${centroid}px`);
+  }
+  assert.deepEqual(browserErrors, [], `camera-density browser errors:\n${browserErrors.join("\n")}`);
+  console.log(
+    `✓ ${backendMode} camera density invariant: 960×540, 1440×810, 1920×1080 backing stores preserve CSS composition`,
+  );
+} finally {
+  await browser?.close();
+  server.kill("SIGTERM");
+}

--- a/scripts/manim-tutorial-smoke.mjs
+++ b/scripts/manim-tutorial-smoke.mjs
@@ -99,7 +99,7 @@ try {
     );
     assert.equal(result.kind, "scene_document", `${entry.id}: expected scene document`);
     assert.ok(result.document.objects.length > 0, `${entry.id}: expected scene objects`);
-    assert.ok(latestEnd(result.document) < 4.0, `${entry.id}: exceeds interactive loop`);
+    assert.ok(latestEnd(result.document) <= 4.0, `${entry.id}: exceeds interactive loop`);
     console.log(`[PASS] ${entry.id}`);
   }
 

--- a/web/browser-smoke.js
+++ b/web/browser-smoke.js
@@ -27,6 +27,9 @@ window.noonSmoke = {
   renderIncrementalAt() {
     throw new Error("Noon browser smoke harness is not ready");
   },
+  resizeBacking() {
+    throw new Error("Noon browser smoke harness is not ready");
+  },
   metrics() {
     return {
       ready: state.ready,
@@ -50,6 +53,10 @@ function metrics() {
     uploadBytes: player?.lastBytesUploaded() ?? 0,
     geometryCacheMisses: player?.lastGeometryCacheMisses() ?? 0,
     rendererBackend: player?.rendererBackend() ?? null,
+    backingWidth: canvas.width,
+    backingHeight: canvas.height,
+    cssWidth: canvas.clientWidth,
+    cssHeight: canvas.clientHeight,
   };
 }
 
@@ -59,6 +66,14 @@ function validateRenderTime(timeSeconds) {
     throw new RangeError("smoke render time must be finite and in [0, 4)");
   }
   return time;
+}
+
+function validateBackingDimension(name, value) {
+  const dimension = Number(value);
+  if (!Number.isSafeInteger(dimension) || dimension <= 0) {
+    throw new RangeError(`${name} must be a positive integer`);
+  }
+  return dimension;
 }
 
 function recordPresent(timestampMs) {
@@ -136,6 +151,17 @@ async function presentIncrementalAt(timeSeconds) {
   return { ...metrics(), presented };
 }
 
+async function resizeBacking(width, height) {
+  const backingWidth = validateBackingDimension("backing width", width);
+  const backingHeight = validateBackingDimension("backing height", height);
+  canvas.width = backingWidth;
+  canvas.height = backingHeight;
+  player.resize(backingWidth, backingHeight);
+  incrementalTime = null;
+  await waitForPaint();
+  return metrics();
+}
+
 async function start() {
   await init();
   player = await NoonCanvasPlayer.create(canvas, demoSceneJson(), 4.0);
@@ -159,6 +185,7 @@ async function start() {
   window.noonSmoke.renderAt = presentAt;
   window.noonSmoke.beginIncremental = beginIncremental;
   window.noonSmoke.renderIncrementalAt = presentIncrementalAt;
+  window.noonSmoke.resizeBacking = resizeBacking;
   window.noonSmoke.metrics = metrics;
   state.ready = true;
 }

--- a/web/main.js
+++ b/web/main.js
@@ -86,6 +86,46 @@ const SCENE_EXAMPLES = [
     features: "Manim CE · ValueTracker · native reactivity",
   },
   {
+    name: "Manim parity · CreateCircle",
+    path: "./python/examples/manim_parity_create_circle.py",
+    summary:
+      "Source-equivalent ManimCE v0.21 CreateCircle with no Noon visual or timing tuning.",
+    features: "exact parity candidate · create-circle · pixels + time",
+    parityFixture: "create-circle",
+  },
+  {
+    name: "Manim parity · SquareToCircle",
+    path: "./python/examples/manim_parity_square_to_circle.py",
+    summary:
+      "Source-equivalent ManimCE v0.21 Create → Transform → FadeOut sequence used by the parity oracle.",
+    features: "exact parity candidate · square-to-circle · pixels + time",
+    parityFixture: "square-to-circle",
+  },
+  {
+    name: "Manim parity · SquareAndCircle",
+    path: "./python/examples/manim_parity_square_and_circle.py",
+    summary:
+      "Source-equivalent ManimCE v0.21 positioning scene with the canonical next_to(..., buff=0.5) contract.",
+    features: "exact parity candidate · layout · pixels + time",
+    parityFixture: "square-and-circle",
+  },
+  {
+    name: "Manim parity · AnimatedSquareToCircle",
+    path: "./python/examples/manim_parity_animated_square_to_circle.py",
+    summary:
+      "Source-equivalent ManimCE v0.21 .animate and Transform sequence sampled by the raster/timeline oracle.",
+    features: "exact parity candidate · animate · pixels + time",
+    parityFixture: "animated-square-to-circle",
+  },
+  {
+    name: "Manim parity · DifferentRotations",
+    path: "./python/examples/manim_parity_different_rotations.py",
+    summary:
+      "Source-equivalent ManimCE v0.21 comparison of target-state .animate.rotate and Rotate semantics.",
+    features: "exact parity candidate · Rotate · pixels + time",
+    parityFixture: "different-rotations",
+  },
+  {
     name: "Analytic Transform",
     path: "./python/examples/analytic_transform.py",
     summary:

--- a/web/python/examples/manim_parity_animated_square_to_circle.py
+++ b/web/python/examples/manim_parity_animated_square_to_circle.py
@@ -1,0 +1,16 @@
+# Source-equivalent ManimCE v0.21.0 quickstart parity demo.
+# Upstream: https://docs.manim.community/en/v0.21.0/tutorials/quickstart.html
+# Output-affecting scene code intentionally matches the canonical parity fixture.
+
+from noon import *
+
+scene = Scene()
+circle = Circle()
+square = Square()
+
+scene.play(Create(square))
+scene.play(square.animate.rotate(PI / 4))
+scene.play(Transform(square, circle))
+scene.play(square.animate.set_fill(PINK, opacity=0.5))
+
+result = scene

--- a/web/python/examples/manim_parity_create_circle.py
+++ b/web/python/examples/manim_parity_create_circle.py
@@ -1,0 +1,12 @@
+# Source-equivalent ManimCE v0.21.0 quickstart parity demo.
+# Upstream: https://docs.manim.community/en/v0.21.0/tutorials/quickstart.html
+# Output-affecting scene code intentionally matches the canonical parity fixture.
+
+from noon import *
+
+scene = Scene()
+circle = Circle()
+circle.set_fill(PINK, opacity=0.5)
+scene.play(Create(circle))
+
+result = scene

--- a/web/python/examples/manim_parity_different_rotations.py
+++ b/web/python/examples/manim_parity_different_rotations.py
@@ -1,0 +1,17 @@
+# Source-equivalent ManimCE v0.21.0 quickstart parity demo.
+# Upstream: https://docs.manim.community/en/v0.21.0/tutorials/quickstart.html
+# Output-affecting scene code intentionally matches the canonical parity fixture.
+
+from noon import *
+
+scene = Scene()
+left_square = Square(color=BLUE, fill_opacity=0.7).shift(2 * LEFT)
+right_square = Square(color=GREEN, fill_opacity=0.7).shift(2 * RIGHT)
+scene.play(
+    left_square.animate.rotate(PI),
+    Rotate(right_square, angle=PI),
+    run_time=2,
+)
+scene.wait()
+
+result = scene

--- a/web/python/examples/manim_parity_square_and_circle.py
+++ b/web/python/examples/manim_parity_square_and_circle.py
@@ -1,0 +1,17 @@
+# Source-equivalent ManimCE v0.21.0 quickstart parity demo.
+# Upstream: https://docs.manim.community/en/v0.21.0/tutorials/quickstart.html
+# Output-affecting scene code intentionally matches the canonical parity fixture.
+
+from noon import *
+
+scene = Scene()
+circle = Circle()
+circle.set_fill(PINK, opacity=0.5)
+
+square = Square()
+square.set_fill(BLUE, opacity=0.5)
+
+square.next_to(circle, RIGHT, buff=0.5)
+scene.play(Create(circle), Create(square))
+
+result = scene

--- a/web/python/examples/manim_parity_square_to_circle.py
+++ b/web/python/examples/manim_parity_square_to_circle.py
@@ -1,0 +1,18 @@
+# Source-equivalent ManimCE v0.21.0 quickstart parity demo.
+# Upstream: https://docs.manim.community/en/v0.21.0/tutorials/quickstart.html
+# Output-affecting scene code intentionally matches the canonical parity fixture.
+
+from noon import *
+
+scene = Scene()
+circle = Circle()
+circle.set_fill(PINK, opacity=0.5)
+
+square = Square()
+square.rotate(PI / 4)
+
+scene.play(Create(square))
+scene.play(Transform(square, circle))
+scene.play(FadeOut(square))
+
+result = scene

--- a/web/python/examples/manim_tutorial_manifest.json
+++ b/web/python/examples/manim_tutorial_manifest.json
@@ -5,7 +5,12 @@
     "license": "MIT",
     "tutorial_root": "https://docs.manim.community/en/stable/tutorials/index.html"
   },
-  "policy": "Examples are original Noon/browser adaptations of upstream learning goals unless reuse is explicitly marked. Preserve upstream MIT notices for substantial copied code and do not copy protected third-party assets.",
+  "policy": "Examples are original Noon/browser adaptations of upstream learning goals unless reuse is explicitly marked. Preserve upstream MIT notices for substantial copied code and do not copy protected third-party assets. `ready` means the tutorial executes; it does not imply output parity. Source-equivalent parity examples carry `parity_status` and `parity_fixture`; only `parity-qualified` means the canonical Manim raster + timeline gate passes.",
+  "parity_policy": {
+    "candidate": "Source-equivalent ManimCE v0.21.0 behavior is exposed in the demo and linked to the canonical parity fixture, but one or more exact-output gates remain open.",
+    "parity-qualified": "The source-equivalent fixture passes semantic, pixel, timing, lifecycle, intermediate-frame, seek/playback, and supported-backend gates defined by #185/#176.",
+    "adaptation": "Pedagogical Noon/browser adaptation; useful as a demo but not evidence of Manim output parity."
+  },
   "entries": [
     {
       "id": "quickstart-create",
@@ -15,7 +20,8 @@
       "category": "tutorial/quickstart",
       "features": ["Scene", "Circle", "Create", "style"],
       "upstream": "tutorials/quickstart.html",
-      "reuse": "original-noon-adaptation"
+      "reuse": "original-noon-adaptation",
+      "parity_status": "adaptation"
     },
     {
       "id": "square-to-circle",
@@ -25,7 +31,8 @@
       "category": "tutorial/quickstart",
       "features": ["Square", "Circle", "Create", "Transform"],
       "upstream": "tutorials/quickstart.html",
-      "reuse": "original-noon-adaptation"
+      "reuse": "original-noon-adaptation",
+      "parity_status": "adaptation"
     },
     {
       "id": "positioning",
@@ -35,7 +42,8 @@
       "category": "tutorial/quickstart",
       "features": ["VGroup", "arrange", "to_edge", "animate"],
       "upstream": "tutorials/quickstart.html",
-      "reuse": "original-noon-adaptation"
+      "reuse": "original-noon-adaptation",
+      "parity_status": "adaptation"
     },
     {
       "id": "animate",
@@ -45,7 +53,8 @@
       "category": "tutorial/quickstart",
       "features": ["animate", "shift", "rotate", "scale", "set_color"],
       "upstream": "tutorials/quickstart.html",
-      "reuse": "original-noon-adaptation"
+      "reuse": "original-noon-adaptation",
+      "parity_status": "adaptation"
     },
     {
       "id": "transform-lifecycle",
@@ -55,7 +64,8 @@
       "category": "tutorial/building-blocks",
       "features": ["Transform", "ReplacementTransform", "lifecycle"],
       "upstream": "tutorials/building_blocks.html",
-      "reuse": "original-noon-adaptation"
+      "reuse": "original-noon-adaptation",
+      "parity_status": "adaptation"
     },
     {
       "id": "animation-composition",
@@ -65,7 +75,8 @@
       "category": "tutorial/building-blocks",
       "features": ["AnimationGroup", "LaggedStart", "VGroup"],
       "upstream": "reference/manim.animation.composition.html",
-      "reuse": "original-noon-adaptation"
+      "reuse": "original-noon-adaptation",
+      "parity_status": "adaptation"
     },
     {
       "id": "value-tracker",
@@ -75,7 +86,68 @@
       "category": "tutorial/reactivity",
       "features": ["ValueTracker", "bind_position", "native-reactive"],
       "upstream": "reference/manim.mobject.value_tracker.ValueTracker.html",
-      "reuse": "original-noon-adaptation"
+      "reuse": "original-noon-adaptation",
+      "parity_status": "adaptation"
+    },
+    {
+      "id": "parity-create-circle",
+      "title": "Exact parity: CreateCircle",
+      "status": "ready",
+      "path": "python/examples/manim_parity_create_circle.py",
+      "category": "parity/quickstart",
+      "features": ["Scene", "Circle", "Create", "style", "pixel-parity", "time-parity"],
+      "upstream": "tutorials/quickstart.html",
+      "reuse": "source-equivalent-manim-v0.21",
+      "parity_status": "candidate",
+      "parity_fixture": "create-circle"
+    },
+    {
+      "id": "parity-square-to-circle",
+      "title": "Exact parity: SquareToCircle",
+      "status": "ready",
+      "path": "python/examples/manim_parity_square_to_circle.py",
+      "category": "parity/quickstart",
+      "features": ["Square", "Circle", "Create", "Transform", "FadeOut", "pixel-parity", "time-parity"],
+      "upstream": "tutorials/quickstart.html",
+      "reuse": "source-equivalent-manim-v0.21",
+      "parity_status": "candidate",
+      "parity_fixture": "square-to-circle"
+    },
+    {
+      "id": "parity-square-and-circle",
+      "title": "Exact parity: SquareAndCircle",
+      "status": "ready",
+      "path": "python/examples/manim_parity_square_and_circle.py",
+      "category": "parity/quickstart",
+      "features": ["Circle", "Square", "next_to", "Create", "pixel-parity", "time-parity"],
+      "upstream": "tutorials/quickstart.html",
+      "reuse": "source-equivalent-manim-v0.21",
+      "parity_status": "candidate",
+      "parity_fixture": "square-and-circle"
+    },
+    {
+      "id": "parity-animated-square-to-circle",
+      "title": "Exact parity: AnimatedSquareToCircle",
+      "status": "ready",
+      "path": "python/examples/manim_parity_animated_square_to_circle.py",
+      "category": "parity/quickstart",
+      "features": ["Create", "animate", "Transform", "style", "pixel-parity", "time-parity"],
+      "upstream": "tutorials/quickstart.html",
+      "reuse": "source-equivalent-manim-v0.21",
+      "parity_status": "candidate",
+      "parity_fixture": "animated-square-to-circle"
+    },
+    {
+      "id": "parity-different-rotations",
+      "title": "Exact parity: DifferentRotations",
+      "status": "ready",
+      "path": "python/examples/manim_parity_different_rotations.py",
+      "category": "parity/quickstart",
+      "features": ["animate", "Rotate", "wait", "pixel-parity", "time-parity"],
+      "upstream": "tutorials/quickstart.html",
+      "reuse": "source-equivalent-manim-v0.21",
+      "parity_status": "candidate",
+      "parity_fixture": "different-rotations"
     },
     {
       "id": "text-and-math",

--- a/web/python/test_manim_geometry_defaults.py
+++ b/web/python/test_manim_geometry_defaults.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 
 class ManimGeometryDefaultsTests(unittest.TestCase):
-    def test_public_rectangle_and_square_defaults_match_manim_v021(self) -> None:
+    def _run_compat_source(self, source: str) -> None:
         python_dir = Path(__file__).resolve().parent
         env = os.environ.copy()
         existing_pythonpath = env.get("PYTHONPATH")
@@ -17,7 +17,22 @@ class ManimGeometryDefaultsTests(unittest.TestCase):
             else os.pathsep.join((str(python_dir), existing_pythonpath))
         )
 
-        source = textwrap.dedent(
+        completed = subprocess.run(
+            [sys.executable, "-c", textwrap.dedent(source)],
+            check=False,
+            cwd=python_dir,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            completed.returncode,
+            0,
+            f"compatibility subprocess failed:\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
+        )
+
+    def test_public_rectangle_and_square_defaults_match_manim_v021(self) -> None:
+        self._run_compat_source(
             """
             import inspect
 
@@ -47,18 +62,57 @@ class ManimGeometryDefaultsTests(unittest.TestCase):
             """
         )
 
-        completed = subprocess.run(
-            [sys.executable, "-c", source],
-            check=False,
-            cwd=python_dir,
-            env=env,
-            capture_output=True,
-            text=True,
+    def test_circle_line_and_rotated_rectangle_bounds_match_manim_geometry(self) -> None:
+        self._run_compat_source(
+            """
+            import math
+
+            import _manim_compat
+
+            _manim_compat.install()
+            import _manim_phase_b  # noqa: F401 - installs pinned Phase-B semantics
+            from noon import Circle, LEFT, Line, PI, RIGHT, Rectangle
+
+            circle = Circle(radius=1.25)
+            assert abs(circle.width - 2.5) < 1e-12
+            assert abs(circle.height - 2.5) < 1e-12
+            assert circle.geometry["circle"]["radius"] == 1.25
+
+            line = Line()
+            assert line.geometry["line"]["start"] == {"x": LEFT.x, "y": LEFT.y}
+            assert line.geometry["line"]["end"] == {"x": RIGHT.x, "y": RIGHT.y}
+            assert abs(line.width - 2.0) < 1e-12
+            assert abs(line.height) < 1e-12
+
+            rectangle = Rectangle(width=4.0, height=2.0).rotate(PI / 6)
+            expected_width = 4.0 * math.cos(PI / 6) + 2.0 * math.sin(PI / 6)
+            expected_height = 4.0 * math.sin(PI / 6) + 2.0 * math.cos(PI / 6)
+            assert abs(rectangle.width - expected_width) < 1e-12
+            assert abs(rectangle.height - expected_height) < 1e-12
+            """
         )
-        self.assertEqual(
-            completed.returncode,
-            0,
-            f"compatibility subprocess failed:\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
+
+    def test_vector_path_bounds_use_bezier_extrema_not_control_hull(self) -> None:
+        self._run_compat_source(
+            """
+            import _manim_compat
+
+            _manim_compat.install()
+            import _manim_phase_b  # noqa: F401 - installs pinned Phase-B semantics
+            from noon import Path, VectorPath
+
+            curve = (
+                VectorPath()
+                .move_to((0.0, 0.0))
+                .cubic_to((0.0, 3.0), (2.0, 3.0), (2.0, 0.0))
+            )
+            path = Path(curve)
+
+            # The cubic reaches y=2.25 at t=0.5. The control hull reaches y=3,
+            # so this catches conservative-control-box layout regressions.
+            assert abs(path.width - 2.0) < 1e-12
+            assert abs(path.height - 2.25) < 1e-12
+            """
         )
 
 

--- a/web/python/test_manim_tutorial_examples.py
+++ b/web/python/test_manim_tutorial_examples.py
@@ -4,11 +4,17 @@ import unittest
 from pathlib import Path
 
 WEB_ROOT = Path(__file__).parents[1]
+REPO_ROOT = WEB_ROOT.parent
 MANIFEST_PATH = WEB_ROOT / "python" / "examples" / "manim_tutorial_manifest.json"
+PARITY_MANIFEST_PATH = REPO_ROOT / "parity" / "manim-v0.21" / "manifest.json"
 
 
 def load_manifest():
     return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def load_parity_manifest():
+    return json.loads(PARITY_MANIFEST_PATH.read_text(encoding="utf-8"))
 
 
 class ManimTutorialExampleTests(unittest.TestCase):
@@ -57,6 +63,36 @@ class ManimTutorialExampleTests(unittest.TestCase):
                 with self.subTest(entry=entry["id"]):
                     self.assertIn("upstream", entry)
                     self.assertIn("reuse", entry)
+
+    def test_source_equivalent_demo_entries_link_to_canonical_parity_fixtures(self) -> None:
+        entries = load_manifest()["entries"]
+        parity_entries = [
+            entry
+            for entry in entries
+            if entry.get("parity_status") in {"candidate", "parity-qualified"}
+        ]
+        self.assertGreaterEqual(len(parity_entries), 5)
+
+        canonical_fixtures = {
+            fixture["id"] for fixture in load_parity_manifest()["fixtures"]
+        }
+        linked_fixtures = []
+        for entry in parity_entries:
+            with self.subTest(entry=entry["id"]):
+                self.assertEqual(entry["reuse"], "source-equivalent-manim-v0.21")
+                fixture = entry["parity_fixture"]
+                linked_fixtures.append(fixture)
+                self.assertIn(fixture, canonical_fixtures)
+                self.assertIn("pixel-parity", entry["features"])
+                self.assertIn("time-parity", entry["features"])
+
+        self.assertEqual(len(linked_fixtures), len(set(linked_fixtures)))
+
+    def test_adapted_ready_examples_are_not_mislabeled_as_parity(self) -> None:
+        for entry in load_manifest()["entries"]:
+            if entry.get("reuse") == "original-noon-adaptation":
+                with self.subTest(entry=entry["id"]):
+                    self.assertEqual(entry.get("parity_status"), "adaptation")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- expose the five canonical ManimCE v0.21 quickstart parity scenes directly in the playground
- keep existing Noon/browser tutorial adaptations, but label them separately from source-equivalent parity candidates
- add `parity_status` + `parity_fixture` metadata so `ready` cannot be confused with exact visual compatibility
- validate every parity demo points to a real `parity/manim-v0.21/manifest.json` fixture
- document the promotion rule: a Manim-facing feature is not `supported` until semantic + pixel/time parity passes under #176/#185

## Exact-output policy
For supported observable behavior, require source-equivalent input, real Manim reference pixels/state, explicit raster tolerances, and supported-backend parity. Animated behavior additionally requires duration/interval/rate/lifecycle and intermediate-frame parity plus deterministic seek/playback equivalence.

The open breadth issues #74/#76-#90 and tutorial/feature trackers #91/#93 have also been amended in GitHub to make this the closure/promotion rule, including a user-facing demo requirement.

## Demo scenes
- CreateCircle
- SquareToCircle
- SquareAndCircle
- AnimatedSquareToCircle
- DifferentRotations

All five use the same output-affecting scene code as the canonical Manim parity corpus; only the import/Scene wrapper form differs for the browser authoring worker.

Tracks #91 #93 #185. Supports final closure of #177/#178 by making their source-equivalent cases visible in the demo.