### PR TITLE
Add deterministic Manim Indicate parity

### DIFF
--- a/compat/manim-v0.21.0.json
+++ b/compat/manim-v0.21.0.json
@@ -25,6 +25,7 @@
     "FadeIn": {"status": "supported", "category": "animation", "evidence": "browser compatibility tests"},
     "FadeOut": {"status": "supported", "category": "animation", "evidence": "browser compatibility tests"},
     "Rotate": {"status": "partial", "category": "animation", "dependency": "#183", "reason": "Centered 2D OUT/IN rotation is exact; external pivots, retained groups, path overrides, and non-z axes remain pending."},
+    "Indicate": {"status": "partial", "category": "animation-indication", "dependency": "#81", "reason": "Single-mobject 2D Indicate preserves Manim defaults, there-and-back timing, and return-to-source semantics; retained Group/VGroup family indication remains pending."},
     "Transform": {"status": "supported", "category": "animation", "evidence": "generic transform tests"},
     "ReplacementTransform": {"status": "supported", "category": "animation", "evidence": "lifecycle tests"},
     "TransformFromCopy": {"status": "supported", "category": "animation", "evidence": "transform-from-copy tests"},

--- a/parity/manim-v0.21/manifest.json
+++ b/parity/manim-v0.21/manifest.json
@@ -54,6 +54,11 @@
       "expected_duration": 3.0
     },
     {
+      "id": "indicate-square",
+      "scene": "IndicateSquare",
+      "expected_duration": 1.0
+    },
+    {
       "id": "create-line",
       "scene": "CreateLine",
       "expected_duration": 1.0,

--- a/parity/manim-v0.21/quickstart.py
+++ b/parity/manim-v0.21/quickstart.py
@@ -397,3 +397,15 @@ class PrimitiveGeometryMatrix(Scene):
 
         self.add(circle, rectangle, square, diagonal, rotated)
         self.play(rotated.animate.shift(ORIGIN))
+
+
+class IndicateSquare(Scene):
+    def construct(self):
+        square = Square(
+            side_length=1.5,
+            fill_color=BLUE,
+            fill_opacity=1.0,
+            stroke_opacity=0.0,
+        )
+        self.add(square)
+        self.play(Indicate(square))

--- a/web/main.js
+++ b/web/main.js
@@ -126,6 +126,14 @@ const SCENE_EXAMPLES = [
     parityFixture: "different-rotations",
   },
   {
+    name: "Manim parity · IndicateSquare",
+    path: "./python/examples/manim_parity_indicate_square.py",
+    summary:
+      "Source-equivalent ManimCE v0.21 Indicate: scale and recolor through the default there-and-back path.",
+    features: "exact parity candidate · Indicate · pixels + time",
+    parityFixture: "indicate-square",
+  },
+  {
     name: "Analytic Transform",
     path: "./python/examples/analytic_transform.py",
     summary:

--- a/web/python/_manim_animate.py
+++ b/web/python/_manim_animate.py
@@ -18,6 +18,7 @@ import noon as _base
 import _manim_animation_options as _options
 import _manim_compat as _compat
 import _manim_phase_b as _phase_b
+import _manim_rate_functions as _rate_functions
 
 
 _ORIGINAL_TRANSFORM = _base.Transform
@@ -28,6 +29,7 @@ _ORIGINAL_CREATE = _base.Create
 _ORIGINAL_UNCREATE = _base.Uncreate
 _ORIGINAL_FADE_IN = _base.FadeIn
 _ORIGINAL_FADE_OUT = _base.FadeOut
+_PURE_YELLOW = _base.color_from_hex("#FFFF00")
 
 
 def _store_animation_args(animation: object, kwargs: dict[str, Any]) -> None:
@@ -100,6 +102,41 @@ class Transform(_ORIGINAL_TRANSFORM):
     ) -> None:
         super().__init__(source, target, key)
         _store_animation_args(self, kwargs)
+
+
+class Indicate:
+    """ManimCE ``Indicate`` lowered without a Python-owned frame callback.
+
+    The default ``there_and_back`` curve is represented by two deterministic smooth
+    Transform intervals. Besides matching the rendered path, this preserves Manim's
+    crucial post-animation semantic state: the indicated mobject returns to its source
+    appearance and scale, so a following animation starts from the original object.
+    """
+
+    def __init__(
+        self,
+        mobject: object,
+        scale_factor: float = 1.2,
+        color: _base.Color = _PURE_YELLOW,
+        rate_func: object = _rate_functions.there_and_back,
+        **kwargs: Any,
+    ) -> None:
+        if isinstance(mobject, _compat.Group):
+            raise NotImplementedError(
+                "Indicate(Group/VGroup) requires retained family Transform semantics and is not yet supported"
+            )
+        if not isinstance(mobject, _base.Mobject):
+            raise TypeError("Indicate target must be a Mobject")
+        factor = float(scale_factor)
+        if not math.isfinite(factor):
+            raise ValueError("Indicate scale_factor must be finite")
+
+        self.mobject = mobject
+        self.scale_factor = factor
+        self.color = color
+        animation_kwargs = dict(kwargs)
+        animation_kwargs["rate_func"] = rate_func
+        _store_animation_args(self, animation_kwargs)
 
 
 class ReplacementTransform(_ORIGINAL_REPLACEMENT_TRANSFORM):
@@ -192,6 +229,7 @@ class FadeOut(_ORIGINAL_FADE_OUT):
 # continues to work because the module globals now point at these subclasses.
 for _name, _value in {
     "Transform": Transform,
+    "Indicate": Indicate,
     "ReplacementTransform": ReplacementTransform,
     "TransformFromCopy": TransformFromCopy,
     "TransformMatchingShapes": TransformMatchingShapes,
@@ -201,6 +239,9 @@ for _name, _value in {
     "FadeOut": FadeOut,
 }.items():
     setattr(_base, _name, _value)
+
+if "Indicate" not in _base.__all__:
+    _base.__all__.append("Indicate")
 
 
 class _AnimateBuilderMixin:
@@ -271,6 +312,8 @@ _compat._GroupAnimationBuilder = _AlignedGroupAnimationBuilder
 
 
 def _builder_source(animation: object) -> object | None:
+    if isinstance(animation, Indicate):
+        return animation.mobject
     if isinstance(animation, (_AlignedAnimationBuilder, _AlignedGroupAnimationBuilder)):
         return animation.source
     return None
@@ -379,6 +422,14 @@ def _expanded_schedule(
     easing: str,
     lag_ratio: float,
 ) -> list[tuple[object, float, float, str]]:
+    if isinstance(animation, Indicate):
+        return _indicate_schedule(
+            scene,
+            animation,
+            start_time=start_time,
+            run_time=run_time,
+            easing=easing,
+        )
     if isinstance(animation, _AlignedAnimationBuilder):
         expanded = [_base.Transform(animation.source, animation.target)]
     else:
@@ -410,6 +461,36 @@ def _snapshot_mobject(snapshot: dict[str, Any]) -> _base.Mobject:
             style=copy.deepcopy(snapshot["style"]),
         )
     )
+
+
+def _indicate_schedule(
+    scene: _compat.Scene,
+    animation: Indicate,
+    *,
+    start_time: float,
+    run_time: float,
+    easing: str,
+) -> list[tuple[object, float, float, str]]:
+    """Compile Indicate while preserving both its path and post-animation state."""
+
+    mobject = animation.mobject
+    if mobject._scene is not scene or mobject._object is None:
+        raise ValueError("Indicate target must belong to this Scene")
+
+    snapshot = scene._snapshot_for_object_at(mobject._object, start_time)
+    source = _snapshot_mobject(snapshot)
+    target = _snapshot_mobject(snapshot)
+    target.scale(animation.scale_factor)
+    target.set_color(animation.color)
+
+    if easing == "there_and_back":
+        half = run_time / 2.0
+        return [
+            (_base.Transform(mobject, target), start_time, half, "smooth"),
+            (_base.Transform(mobject, source), start_time + half, half, "smooth"),
+        ]
+
+    return [(_base.Transform(mobject, target), start_time, run_time, easing)]
 
 
 def _fade_endpoint_snapshots(

--- a/web/python/_manim_rate_functions.py
+++ b/web/python/_manim_rate_functions.py
@@ -19,6 +19,7 @@ import _noon_ir as _ir
 INFLECTION = 10.0
 _INSTALLED = False
 _ORIGINAL_ADD_TRACK = _ir.Scene._add_track
+_ORIGINAL_MOBJECT_SET_COLOR = _base.Mobject.set_color
 
 
 def linear(t: float) -> float:
@@ -150,6 +151,23 @@ def _add_track(
     )
 
 
+def _set_color_preserving_opacity(
+    self: _base.Mobject, color: _base.Color
+) -> _base.Mobject:
+    """Match Manim ``set_color`` without coupling RGB to fill/stroke opacity."""
+
+    before = self._current_raw().style
+    result = _ORIGINAL_MOBJECT_SET_COLOR(self, color)
+    raw = _base._raw_mobject(self._current_raw())
+    for channel in ("fill", "stroke"):
+        previous = before[channel]
+        current = raw.style[channel]
+        if previous is not None and current is not None:
+            current["alpha"] = previous["alpha"]
+    result._apply(raw)
+    return result
+
+
 def install() -> None:
     """Install thin public adapters without creating a second playback engine."""
 
@@ -170,6 +188,11 @@ def install() -> None:
         setattr(_base, name, value)
 
     _compat._easing_from_rate_func = easing_from_rate_func
+
+    # Manim's set_color changes fill/stroke RGB while preserving each channel's
+    # independent opacity. This matters for Transform-style effects such as Indicate:
+    # a transparent stroke must not become visible while the color interpolates.
+    _base.Mobject.set_color = _set_color_preserving_opacity
 
     # `_noon_ir` needs progress only while materializing authoring-time snapshots.
     # Runtime playback never calls this mirror; Rust RateFunction remains authoritative.

--- a/web/python/examples/manim_parity_indicate_square.py
+++ b/web/python/examples/manim_parity_indicate_square.py
@@ -1,0 +1,17 @@
+# Source-equivalent ManimCE v0.21.0 Indicate parity demo.
+# Upstream: https://docs.manim.community/en/v0.21.0/reference/manim.animation.indication.Indicate.html
+# Output-affecting scene code intentionally matches the canonical parity fixture.
+
+from noon import *
+
+scene = Scene()
+square = Square(
+    side_length=1.5,
+    fill_color=BLUE,
+    fill_opacity=1.0,
+    stroke_opacity=0.0,
+)
+scene.add(square)
+scene.play(Indicate(square))
+
+result = scene

--- a/web/python/examples/manim_tutorial_manifest.json
+++ b/web/python/examples/manim_tutorial_manifest.json
@@ -150,6 +150,18 @@
       "parity_fixture": "different-rotations"
     },
     {
+      "id": "parity-indicate-square",
+      "title": "Exact parity: IndicateSquare",
+      "status": "ready",
+      "path": "python/examples/manim_parity_indicate_square.py",
+      "category": "parity/animation",
+      "features": ["Indicate", "there_and_back", "Square", "pixel-parity", "time-parity"],
+      "upstream": "reference/manim.animation.indication.Indicate.html",
+      "reuse": "source-equivalent-manim-v0.21",
+      "parity_status": "candidate",
+      "parity_fixture": "indicate-square"
+    },
+    {
       "id": "text-and-math",
       "title": "Text and mathematical notation",
       "status": "blocked",

--- a/web/python/test_manim_indicate_animation.py
+++ b/web/python/test_manim_indicate_animation.py
@@ -77,7 +77,18 @@ class ManimIndicateAnimationTests(unittest.TestCase):
             import _manim_phase_b  # noqa: F401
             import _manim_animate  # noqa: F401
 
-            from noon import BLUE, Indicate, RIGHT, Scene, Square, VGroup, linear
+            from noon import BLUE, GREEN, Indicate, RIGHT, Scene, Square, VGroup, linear
+
+            # Manim set_color changes RGB without changing independent fill/stroke opacity.
+            style_probe = Square(
+                fill_color=BLUE,
+                fill_opacity=0.35,
+                stroke_color=BLUE,
+                stroke_opacity=0.65,
+            )
+            style_probe.set_color(GREEN)
+            assert abs(style_probe.style["fill"]["alpha"] - 0.35) < 1e-12
+            assert abs(style_probe.style["stroke"]["alpha"] - 0.65) < 1e-12
 
             scene = Scene()
             square = Square(
@@ -115,6 +126,12 @@ class ManimIndicateAnimationTests(unittest.TestCase):
             assert abs(indicated_fill["red"] - 1.0) < 1e-12
             assert abs(indicated_fill["green"] - 1.0) < 1e-12
             assert abs(indicated_fill["blue"] - 0.0) < 1e-12
+            assert abs(indicated_fill["alpha"] - 1.0) < 1e-12
+            indicated_stroke = outward_target["style"]["stroke"]
+            assert abs(indicated_stroke["red"] - 1.0) < 1e-12
+            assert abs(indicated_stroke["green"] - 1.0) < 1e-12
+            assert abs(indicated_stroke["blue"] - 0.0) < 1e-12
+            assert abs(indicated_stroke["alpha"] - 0.0) < 1e-12
 
             source_again = returning["values"]["object"]["to"]
             assert abs(source_again["transform"]["scale"]["x"] - 1.0) < 1e-12

--- a/web/python/test_manim_indicate_animation.py
+++ b/web/python/test_manim_indicate_animation.py
@@ -1,0 +1,181 @@
+import os
+import subprocess
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+
+
+class ManimIndicateAnimationTests(unittest.TestCase):
+    def test_indicate_matches_default_there_and_back_semantics(self) -> None:
+        python_dir = Path(__file__).resolve().parent
+        env = os.environ.copy()
+        existing_pythonpath = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = (
+            str(python_dir)
+            if not existing_pythonpath
+            else os.pathsep.join((str(python_dir), existing_pythonpath))
+        )
+
+        source = textwrap.dedent(
+            """
+            import math
+            import sys
+            import types
+
+            fake_js = types.ModuleType("js")
+
+            class Result:
+                ok = True
+                errorKind = ""
+                message = ""
+
+            def resolve_animation_options(
+                default_lag_ratio,
+                animation_run_time,
+                animation_rate_func,
+                animation_lag_ratio,
+                path_arc,
+                reverse_rate_function,
+                play_run_time,
+                play_rate_func,
+                play_lag_ratio,
+            ):
+                result = Result()
+                result.runTime = (
+                    play_run_time
+                    if math.isfinite(play_run_time)
+                    else animation_run_time
+                    if math.isfinite(animation_run_time)
+                    else 1.0
+                )
+                result.rateFunc = play_rate_func or animation_rate_func or "smooth"
+                result.lagRatio = (
+                    play_lag_ratio
+                    if math.isfinite(play_lag_ratio)
+                    else animation_lag_ratio
+                    if math.isfinite(animation_lag_ratio)
+                    else default_lag_ratio
+                )
+                result.pathArc = path_arc if math.isfinite(path_arc) else 0.0
+                result.reverseRateFunction = reverse_rate_function == 1
+                return result
+
+            def resolve_uniform_schedule(child_count, lag_ratio, run_time):
+                result = Result()
+                result.intervals = []
+                return result
+
+            fake_js.noonResolveAnimationOptions = resolve_animation_options
+            fake_js.noonResolveUniformCompositionSchedule = resolve_uniform_schedule
+            sys.modules["js"] = fake_js
+
+            import _manim_compat
+            _manim_compat.install()
+            import _manim_rate_functions
+            _manim_rate_functions.install()
+            import _manim_phase_b  # noqa: F401
+            import _manim_animate  # noqa: F401
+
+            from noon import BLUE, Indicate, RIGHT, Scene, Square, VGroup, linear
+
+            scene = Scene()
+            square = Square(
+                side_length=1.5,
+                fill_color=BLUE,
+                fill_opacity=1.0,
+                stroke_opacity=0.0,
+            )
+            scene.add(square)
+            animation = Indicate(square)
+            assert abs(animation.scale_factor - 1.2) < 1e-12
+            assert animation.anim_args["rate_func"].__name__ == "there_and_back"
+
+            scene.play(animation)
+            assert abs(scene.time - 1.0) < 1e-12
+            tracks = [
+                track
+                for track in scene.to_document()["tracks"]
+                if track["object"] == square.id and track["property"] == "transform"
+            ]
+            assert len(tracks) == 2
+            tracks.sort(key=lambda track: track["timing"]["start_time"])
+            outward, returning = tracks
+            assert abs(outward["timing"]["start_time"] - 0.0) < 1e-12
+            assert abs(outward["timing"]["duration"] - 0.5) < 1e-12
+            assert outward["timing"]["easing"] == "smooth"
+            assert abs(returning["timing"]["start_time"] - 0.5) < 1e-12
+            assert abs(returning["timing"]["duration"] - 0.5) < 1e-12
+            assert returning["timing"]["easing"] == "smooth"
+
+            outward_target = outward["values"]["object"]["to"]
+            assert abs(outward_target["transform"]["scale"]["x"] - 1.2) < 1e-12
+            assert abs(outward_target["transform"]["scale"]["y"] - 1.2) < 1e-12
+            indicated_fill = outward_target["style"]["fill"]
+            assert abs(indicated_fill["red"] - 1.0) < 1e-12
+            assert abs(indicated_fill["green"] - 1.0) < 1e-12
+            assert abs(indicated_fill["blue"] - 0.0) < 1e-12
+
+            source_again = returning["values"]["object"]["to"]
+            assert abs(source_again["transform"]["scale"]["x"] - 1.0) < 1e-12
+            assert abs(source_again["transform"]["scale"]["y"] - 1.0) < 1e-12
+
+            # A following animation must start from the restored source state, not
+            # the temporary enlarged/yellow target used at the midpoint.
+            scene.play(square.animate.shift(RIGHT))
+            later_tracks = [
+                track
+                for track in scene.to_document()["tracks"]
+                if track["object"] == square.id
+                and track["property"] == "transform"
+                and abs(track["timing"]["start_time"] - 1.0) < 1e-12
+            ]
+            assert len(later_tracks) == 1
+            following_source = later_tracks[0]["values"]["object"]["from"]
+            assert abs(following_source["transform"]["scale"]["x"] - 1.0) < 1e-12
+            source_fill = following_source["style"]["fill"]
+            assert abs(source_fill["red"] - BLUE.red) < 1e-12
+            assert abs(source_fill["green"] - BLUE.green) < 1e-12
+            assert abs(source_fill["blue"] - BLUE.blue) < 1e-12
+
+            # Overriding there_and_back with an ordinary rate function has normal
+            # Transform endpoint semantics and remains one deterministic interval.
+            linear_scene = Scene()
+            linear_square = Square(fill_color=BLUE, fill_opacity=1.0, stroke_opacity=0.0)
+            linear_scene.add(linear_square)
+            linear_scene.play(Indicate(linear_square, rate_func=linear), run_time=2.0)
+            linear_tracks = [
+                track
+                for track in linear_scene.to_document()["tracks"]
+                if track["property"] == "transform"
+            ]
+            assert len(linear_tracks) == 1
+            assert abs(linear_tracks[0]["timing"]["duration"] - 2.0) < 1e-12
+            assert linear_tracks[0]["timing"]["easing"] == "linear"
+
+            try:
+                Indicate(VGroup(Square(), Square()))
+            except NotImplementedError:
+                pass
+            else:
+                raise AssertionError("Indicate group/family support must not be approximated")
+            """
+        )
+
+        completed = subprocess.run(
+            [sys.executable, "-c", source],
+            check=False,
+            cwd=python_dir,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            completed.returncode,
+            0,
+            f"compatibility subprocess failed:\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Superseded

This stale draft is superseded by #260, which cleanly replays the reviewed Indicate implementation on the current `master` and current exact-output/gallery architecture.

The implementation/test logic from this branch was preserved where byte-compatible; obsolete hard-coded gallery changes were intentionally dropped.