### PR TITLE
Fix Rust fill opacity semantics

### DIFF
--- a/crates/noon-core/src/lib.rs
+++ b/crates/noon-core/src/lib.rs
@@ -700,9 +700,24 @@ impl ObjectSnapshot {
     }
 
     pub fn set_fill(mut self, color: Option<Color>, opacity: Option<f32>) -> Self {
-        self.style.fill = color;
-        if let Some(opacity) = opacity {
-            self.style.opacity = opacity;
+        match (color, opacity) {
+            (Some(mut color), Some(opacity)) => {
+                color.alpha = opacity;
+                self.style.fill = Some(color);
+            }
+            (Some(mut color), None) => {
+                if let Some(existing) = self.style.fill {
+                    color.alpha = existing.alpha;
+                }
+                self.style.fill = Some(color);
+            }
+            (None, Some(opacity)) => {
+                if let Some(mut fill) = self.style.fill {
+                    fill.alpha = opacity;
+                    self.style.fill = Some(fill);
+                }
+            }
+            (None, None) => {}
         }
         self
     }

--- a/crates/noon-core/tests/set_fill_semantics.rs
+++ b/crates/noon-core/tests/set_fill_semantics.rs
@@ -1,0 +1,62 @@
+use noon_core::{Color, GeometryRef, ObjectSnapshot, BLUE, GREEN, PINK, RED};
+
+fn assert_rgb_eq(actual: Color, expected: Color) {
+    assert_eq!(actual.red, expected.red);
+    assert_eq!(actual.green, expected.green);
+    assert_eq!(actual.blue, expected.blue);
+}
+
+#[test]
+fn set_fill_color_preserves_existing_fill_opacity() {
+    let mut snapshot = ObjectSnapshot::new(GeometryRef::square(1.0));
+    snapshot.style.fill = Some(Color::rgba(RED.red, RED.green, RED.blue, 0.25));
+    snapshot.style.stroke = Some(Color::rgba(GREEN.red, GREEN.green, GREEN.blue, 0.75));
+    snapshot.style.opacity = 0.8;
+
+    let next = snapshot.clone().set_fill(Some(BLUE), None);
+    let fill = next.style.fill.expect("fill remains enabled");
+    assert_rgb_eq(fill, BLUE);
+    assert_eq!(fill.alpha, 0.25);
+    assert_eq!(next.style.stroke, snapshot.style.stroke);
+    assert_eq!(next.style.opacity, 0.8);
+}
+
+#[test]
+fn set_fill_opacity_preserves_fill_color_stroke_and_object_opacity() {
+    let mut snapshot = ObjectSnapshot::new(GeometryRef::square(1.0));
+    snapshot.style.fill = Some(Color::rgba(RED.red, RED.green, RED.blue, 0.25));
+    snapshot.style.stroke = Some(Color::rgba(GREEN.red, GREEN.green, GREEN.blue, 0.75));
+    snapshot.style.opacity = 0.8;
+
+    let next = snapshot.clone().set_fill(None, Some(0.5));
+    let fill = next.style.fill.expect("fill remains enabled");
+    assert_rgb_eq(fill, RED);
+    assert_eq!(fill.alpha, 0.5);
+    assert_eq!(next.style.stroke, snapshot.style.stroke);
+    assert_eq!(next.style.opacity, 0.8);
+}
+
+#[test]
+fn set_fill_color_and_opacity_do_not_dim_stroke() {
+    let mut snapshot = ObjectSnapshot::new(GeometryRef::square(1.0));
+    snapshot.style.fill = Some(RED);
+    snapshot.style.stroke = Some(Color::rgba(GREEN.red, GREEN.green, GREEN.blue, 0.65));
+    snapshot.style.opacity = 0.7;
+
+    let next = snapshot.clone().set_fill(Some(PINK), Some(0.4));
+    let fill = next.style.fill.expect("fill remains enabled");
+    assert_rgb_eq(fill, PINK);
+    assert_eq!(fill.alpha, 0.4);
+    assert_eq!(next.style.stroke, snapshot.style.stroke);
+    assert_eq!(next.style.opacity, 0.7);
+}
+
+#[test]
+fn set_fill_without_arguments_is_a_noop() {
+    let mut snapshot = ObjectSnapshot::new(GeometryRef::square(1.0));
+    snapshot.style.fill = Some(Color::rgba(RED.red, RED.green, RED.blue, 0.25));
+    snapshot.style.stroke = Some(GREEN);
+    snapshot.style.opacity = 0.6;
+
+    assert_eq!(snapshot.clone().set_fill(None, None), snapshot);
+}

--- a/crates/noon/examples/manim_quickstart_equivalents.rs
+++ b/crates/noon/examples/manim_quickstart_equivalents.rs
@@ -5,21 +5,16 @@ fn emit(name: &str, scene: &Scene) {
     println!("{name}\t{}", encode_scene(scene.definition()).unwrap());
 }
 
-fn fill_with_opacity(mut color: Color, opacity: f32) -> Color {
-    color.alpha = opacity;
-    color
-}
-
 fn create_circle() -> Scene {
     let mut scene = Scene::new();
-    let circle = scene.add(Circle::default().set_fill(Some(fill_with_opacity(PINK, 0.5)), None));
+    let circle = scene.add(Circle::default().set_fill(Some(PINK), Some(0.5)));
     scene.play(Create::new(circle)).run_time(1.0).unwrap();
     scene
 }
 
 fn square_to_circle() -> Scene {
     let mut scene = Scene::new();
-    let circle = Circle::default().set_fill(Some(fill_with_opacity(PINK, 0.5)), None);
+    let circle = Circle::default().set_fill(Some(PINK), Some(0.5));
     let square = scene.add(Square::default().rotate(PI / 4.0));
     scene.play(Create::new(square)).run_time(1.0).unwrap();
     scene
@@ -32,8 +27,8 @@ fn square_to_circle() -> Scene {
 
 fn square_and_circle() -> Scene {
     let mut scene = Scene::new();
-    let circle = scene.add(Circle::default().set_fill(Some(fill_with_opacity(PINK, 0.5)), None));
-    let square = scene.add(Square::default().set_fill(Some(fill_with_opacity(BLUE, 0.5)), None));
+    let circle = scene.add(Circle::default().set_fill(Some(PINK), Some(0.5)));
+    let square = scene.add(Square::default().set_fill(Some(BLUE), Some(0.5)));
     scene
         .edit(square)
         .unwrap()

--- a/crates/noon/tests/set_fill_semantics.rs
+++ b/crates/noon/tests/set_fill_semantics.rs
@@ -1,0 +1,41 @@
+use noon::{Circle, IntoSnapshot, Scene, GREEN, PINK, RED};
+
+#[test]
+fn shape_set_fill_keeps_stroke_and_object_opacity_independent() {
+    let snapshot = Circle::default()
+        .set_stroke(Some(GREEN), Some(4.0))
+        .set_fill(Some(RED), Some(0.25))
+        .into_snapshot();
+
+    let fill = snapshot.style.fill.expect("circle fill remains enabled");
+    assert_eq!(fill.red, RED.red);
+    assert_eq!(fill.green, RED.green);
+    assert_eq!(fill.blue, RED.blue);
+    assert_eq!(fill.alpha, 0.25);
+    assert_eq!(snapshot.style.stroke, Some(GREEN));
+    assert_eq!(snapshot.style.opacity, 1.0);
+}
+
+#[test]
+fn animate_set_fill_keeps_stroke_and_object_opacity_independent() {
+    let mut scene = Scene::new();
+    let circle = scene.add(
+        Circle::default()
+            .set_stroke(Some(GREEN), Some(4.0))
+            .set_fill(Some(RED), Some(0.25)),
+    );
+
+    scene
+        .play(circle.animate().set_fill(Some(PINK), Some(0.5)))
+        .run_time(1.0)
+        .unwrap();
+
+    let target = scene.snapshot(circle).unwrap();
+    let fill = target.style.fill.expect("animated target keeps a fill");
+    assert_eq!(fill.red, PINK.red);
+    assert_eq!(fill.green, PINK.green);
+    assert_eq!(fill.blue, PINK.blue);
+    assert_eq!(fill.alpha, 0.5);
+    assert_eq!(target.style.stroke, Some(GREEN));
+    assert_eq!(target.style.opacity, 1.0);
+}


### PR DESCRIPTION
Fixes #262.

## Problem
`ObjectSnapshot::set_fill(color, opacity)` routed the fill opacity argument through object-wide `Style.opacity`. That made Rust authoring semantically different from Manim and from Noon's semantic-handle/JavaScript path: lowering fill opacity could also dim the stroke.

## Fix
- `color=Some(...)`, `opacity=Some(...)`: set fill RGB and fill alpha together
- `color=Some(...)`, `opacity=None`: change fill RGB while preserving an existing fill alpha
- `color=None`, `opacity=Some(...)`: change only the existing fill alpha
- `None, None`: no-op
- never modify `Style.opacity` or stroke paint/alpha from `set_fill`

## Tests
- core regression coverage for color-only, opacity-only, combined changes, no-op, stroke independence, and object-opacity independence
- Rust facade coverage proving `Circle::set_fill` and `circle.animate().set_fill(...)` inherit the corrected semantics
- Rust Manim Quickstart equivalents use the natural `set_fill(Some(color), Some(opacity))` spelling again, so the Rust↔JS Quickstart parity gate exercises the corrected path directly

This PR was created after #261 merged so its review diff is intentionally limited to the core method, two regression test files, and the Rust Quickstart cleanup.