### PR TITLE
Add exact Manim MoveToTarget parity

### DIFF
--- a/compat/manim-v0.21.0.json
+++ b/compat/manim-v0.21.0.json
@@ -42,6 +42,7 @@
     "Transform": {"status": "supported", "category": "animation", "evidence": "generic transform tests"},
     "ReplacementTransform": {"status": "supported", "category": "animation", "evidence": "lifecycle tests"},
     "TransformFromCopy": {"status": "supported", "category": "animation", "evidence": "transform-from-copy tests"},
+    "MoveToTarget": {"status": "partial", "category": "animation-transform", "dependency": "#82", "reason": "Leaf 2D Mobjects using generate_target() lower exactly to the retained Transform path and are attached to the canonical raster/timeline gate; retained Group/VGroup family targets and broader family alignment remain pending."},
     "TransformMatchingShapes": {"status": "supported", "category": "animation", "evidence": "matching-shapes tests"},
     "AnimationGroup": {"status": "supported", "category": "animation-composition", "evidence": "composition tests"},
     "LaggedStart": {"status": "supported", "category": "animation-composition", "evidence": "composition tests"},

--- a/docs/parity-move-to-target.md
+++ b/docs/parity-move-to-target.md
@@ -1,0 +1,10 @@
+# ManimCE v0.21 `MoveToTarget` parity slice
+
+This slice targets the source-equivalent `MoveToTargetExample` from the ManimCE v0.21
+API documentation. `Mobject.generate_target()` already creates a detached semantic copy
+in Noon. `MoveToTarget` is therefore lowered to the existing Manim-compatible retained
+`Transform` path rather than introducing another scheduler or renderer primitive.
+
+The first exact-output slice covers leaf 2D mobjects and the standard generated-target
+workflow. Retained groups/families remain partial until family alignment semantics are
+represented exactly.

--- a/docs/parity-move-to-target.md
+++ b/docs/parity-move-to-target.md
@@ -5,6 +5,10 @@ API documentation. `Mobject.generate_target()` already creates a detached semant
 in Noon. `MoveToTarget` is therefore lowered to the existing Manim-compatible retained
 `Transform` path rather than introducing another scheduler or renderer primitive.
 
+The generated target is resolved when `Scene.play` lowers the transform, matching Manim's
+observable behavior when callers continue mutating `mobject.target` after constructing
+`MoveToTarget` but before playing it.
+
 The first exact-output slice covers leaf 2D mobjects and the standard generated-target
 workflow. Retained groups/families remain partial until family alignment semantics are
 represented exactly.

--- a/docs/parity-move-to-target.md
+++ b/docs/parity-move-to-target.md
@@ -11,4 +11,5 @@ observable behavior when callers continue mutating `mobject.target` after constr
 
 The first exact-output slice covers leaf 2D mobjects and the standard generated-target
 workflow. Retained groups/families remain partial until family alignment semantics are
-represented exactly.
+represented exactly. Qualification uses the unchanged canonical duration, semantic-state,
+Cairo raster, direct-seek/incremental-playback, WebGPU, and WebGL gates.

--- a/parity/manim-v0.21/manifest.json
+++ b/parity/manim-v0.21/manifest.json
@@ -64,6 +64,11 @@
       "expected_duration": 1.0
     },
     {
+      "id": "move-to-target-circle",
+      "scene": "MoveToTargetExample",
+      "expected_duration": 1.0
+    },
+    {
       "id": "create-line",
       "scene": "CreateLine",
       "expected_duration": 1.0,

--- a/parity/manim-v0.21/quickstart.py
+++ b/parity/manim-v0.21/quickstart.py
@@ -577,3 +577,13 @@ class IndicateSquare(Scene):
         )
         self.add(square)
         self.play(Indicate(square))
+
+
+class MoveToTargetExample(Scene):
+    def construct(self):
+        c = Circle()
+        c.generate_target()
+        c.target.set_fill(color=GREEN, opacity=0.5)
+        c.target.shift(2 * RIGHT + UP).scale(0.5)
+        self.add(c)
+        self.play(MoveToTarget(c))

--- a/web/python/_manim_move_to_target.py
+++ b/web/python/_manim_move_to_target.py
@@ -1,0 +1,7 @@
+"""MoveToTarget compatibility marker.
+
+The implementation intentionally lives in the bootstrap rate-function adapter because
+that module is installed before the Manim-compatible Transform class. MoveToTarget
+resolves ``noon.Transform`` only when instantiated, so playback remains the canonical
+retained Transform path rather than a second scheduler.
+"""

--- a/web/python/_manim_move_to_target.py
+++ b/web/python/_manim_move_to_target.py
@@ -1,7 +1,0 @@
-"""MoveToTarget compatibility marker.
-
-The implementation intentionally lives in the bootstrap rate-function adapter because
-that module is installed before the Manim-compatible Transform class. MoveToTarget
-resolves ``noon.Transform`` only when instantiated, so playback remains the canonical
-retained Transform path rather than a second scheduler.
-"""

--- a/web/python/_manim_rate_functions.py
+++ b/web/python/_manim_rate_functions.py
@@ -182,6 +182,34 @@ def _set_color_preserving_opacity(
     return result
 
 
+class MoveToTarget:
+    """ManimCE ``MoveToTarget`` as a thin adapter over the installed Transform.
+
+    ``generate_target`` already stores a detached semantic copy on ``mobject.target``.
+    Resolve ``_base.Transform`` when this animation is instantiated (rather than when
+    this bootstrap module is imported) so the later Manim animation adapter remains the
+    single source of timing, option resolution, and retained Transform lowering.
+    """
+
+    def __new__(cls, mobject: object, **kwargs: Any):
+        if isinstance(mobject, _compat.Group):
+            raise NotImplementedError(
+                "MoveToTarget(Group/VGroup) requires retained family Transform semantics and is not yet supported"
+            )
+        if not isinstance(mobject, _base.Mobject):
+            raise TypeError("MoveToTarget target must be a Mobject")
+        if not hasattr(mobject, "target"):
+            # Preserve ManimCE v0.21's public error wording, including its historical
+            # missing space, for direct source/API compatibility.
+            raise ValueError("MoveToTarget called on mobjectwithout attribute 'target'")
+        target = mobject.target
+        if not isinstance(target, _base.Mobject) or isinstance(target, _compat.Group):
+            raise NotImplementedError(
+                "MoveToTarget currently requires a leaf Mobject target produced by generate_target()"
+            )
+        return _base.Transform(mobject, target, **kwargs)
+
+
 def install() -> None:
     """Install thin public adapters without creating a second playback engine."""
 
@@ -208,13 +236,17 @@ def install() -> None:
     # a transparent stroke must not become visible while the color interpolates.
     _base.Mobject.set_color = _set_color_preserving_opacity
 
+    # ``MoveToTarget`` is a construction-time compatibility adapter; runtime playback
+    # is still the same shared Transform path installed later by ``_manim_animate``.
+    _base.MoveToTarget = MoveToTarget
+
     # `_noon_ir` needs progress only while materializing authoring-time snapshots.
     # Runtime playback never calls this mirror; Rust RateFunction remains authoritative.
     _ir._track_progress = _track_progress
     _ir.Scene._add_track = _add_track
 
     exports = list(_base.__all__)
-    for name in public:
+    for name in [*public, "MoveToTarget"]:
         if name not in exports:
             exports.append(name)
     _base.__all__ = exports

--- a/web/python/examples/manim_parity_move_to_target.py
+++ b/web/python/examples/manim_parity_move_to_target.py
@@ -1,0 +1,15 @@
+# Source-equivalent ManimCE v0.21.0 MoveToTarget parity demo.
+# Upstream: https://docs.manim.community/en/v0.21.0/reference/manim.animation.transform.MoveToTarget.html
+# Output-affecting scene code intentionally matches the canonical parity fixture.
+
+from noon import *
+
+scene = Scene()
+circle = Circle()
+circle.generate_target()
+circle.target.set_fill(color=GREEN, opacity=0.5)
+circle.target.shift(2 * RIGHT + UP).scale(0.5)
+scene.add(circle)
+scene.play(MoveToTarget(circle))
+
+result = scene

--- a/web/python/test_manim_move_to_target.py
+++ b/web/python/test_manim_move_to_target.py
@@ -1,0 +1,152 @@
+import os
+import subprocess
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+
+
+class ManimMoveToTargetTests(unittest.TestCase):
+    def test_docs_example_lowers_to_generic_transform(self) -> None:
+        python_dir = Path(__file__).resolve().parent
+        env = os.environ.copy()
+        existing_pythonpath = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = (
+            str(python_dir)
+            if not existing_pythonpath
+            else os.pathsep.join((str(python_dir), existing_pythonpath))
+        )
+
+        source = textwrap.dedent(
+            """
+            import math
+            import sys
+            import types
+
+            fake_js = types.ModuleType("js")
+
+            class Result:
+                ok = True
+                errorKind = ""
+                message = ""
+
+            def resolve_animation_options(
+                default_lag_ratio,
+                animation_run_time,
+                animation_rate_func,
+                animation_lag_ratio,
+                path_arc,
+                reverse_rate_function,
+                play_run_time,
+                play_rate_func,
+                play_lag_ratio,
+            ):
+                result = Result()
+                result.runTime = (
+                    play_run_time
+                    if math.isfinite(play_run_time)
+                    else animation_run_time
+                    if math.isfinite(animation_run_time)
+                    else 1.0
+                )
+                result.rateFunc = play_rate_func or animation_rate_func or "smooth"
+                result.lagRatio = (
+                    play_lag_ratio
+                    if math.isfinite(play_lag_ratio)
+                    else animation_lag_ratio
+                    if math.isfinite(animation_lag_ratio)
+                    else default_lag_ratio
+                )
+                result.pathArc = path_arc if math.isfinite(path_arc) else 0.0
+                result.reverseRateFunction = reverse_rate_function == 1
+                return result
+
+            def resolve_uniform_schedule(child_count, lag_ratio, run_time):
+                result = Result()
+                result.intervals = []
+                return result
+
+            fake_js.noonResolveAnimationOptions = resolve_animation_options
+            fake_js.noonResolveUniformCompositionSchedule = resolve_uniform_schedule
+            sys.modules["js"] = fake_js
+
+            import _manim_compat
+            _manim_compat.install()
+            import _manim_rate_functions
+            _manim_rate_functions.install()
+            import _manim_phase_b  # noqa: F401
+            import _manim_animate  # noqa: F401
+
+            from noon import Circle, GREEN, MoveToTarget, RIGHT, Scene, Transform, UP
+
+            missing = Circle()
+            try:
+                MoveToTarget(missing)
+                raise AssertionError("MoveToTarget must require generate_target()")
+            except ValueError as error:
+                assert str(error) == "MoveToTarget called on mobjectwithout attribute 'target'"
+
+            circle = Circle()
+            generated = circle.generate_target()
+            assert generated is circle.target
+            assert generated is not circle
+            circle.target.set_fill(color=GREEN, opacity=0.5)
+            circle.target.shift(2 * RIGHT + UP).scale(0.5)
+
+            scene = Scene()
+            scene.add(circle)
+            animation = MoveToTarget(circle)
+            assert isinstance(animation, Transform)
+            scene.play(animation)
+
+            tracks = [track for track in scene.to_ir()["tracks"] if track["property"] == "transform"]
+            assert len(tracks) == 1
+            track = tracks[0]
+            assert abs(track["timing"]["start_time"] - 0.0) < 1e-12
+            assert abs(track["timing"]["duration"] - 1.0) < 1e-12
+            assert track["timing"]["easing"] == "smooth"
+
+            target = track["values"]["object"]["to"]
+            translation = target["transform"]["translation"]
+            scale = target["transform"]["scale"]
+            assert abs(translation["x"] - 2.0) < 1e-12
+            assert abs(translation["y"] - 1.0) < 1e-12
+            assert abs(scale["x"] - 0.5) < 1e-12
+            assert abs(scale["y"] - 0.5) < 1e-12
+            fill = target["style"]["fill"]
+            assert abs(fill["red"] - GREEN.red) < 1e-12
+            assert abs(fill["green"] - GREEN.green) < 1e-12
+            assert abs(fill["blue"] - GREEN.blue) < 1e-12
+            assert abs(fill["alpha"] - 0.5) < 1e-12
+
+            final = scene._snapshot_for_object_at(circle._object, 1.0)
+            assert final == target
+
+            # Transform snapshots its target at play time, matching Manim begin().
+            circle2 = Circle()
+            circle2.generate_target()
+            pending = MoveToTarget(circle2)
+            circle2.target.shift(RIGHT)
+            scene2 = Scene()
+            scene2.add(circle2)
+            scene2.play(pending)
+            target2 = [
+                track for track in scene2.to_ir()["tracks"] if track["property"] == "transform"
+            ][0]["values"]["object"]["to"]
+            assert abs(target2["transform"]["translation"]["x"] - 1.0) < 1e-12
+            """
+        )
+
+        completed = subprocess.run(
+            [sys.executable, "-c", source],
+            cwd=python_dir,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Superseded by #313, which rebuilds this parity slice on current `master`, uses the exact ManimCE v0.21 source with import-only adaptation, excludes stale branch baggage, and re-runs the current CI/raster/seek qualification gates.