### PR TITLE
Add tri-language Manim MovingAround example

### DIFF
--- a/crates/noon-web/src/authoring_facade.rs
+++ b/crates/noon-web/src/authoring_facade.rs
@@ -434,9 +434,9 @@ impl FrontendAuthoringScene {
         handle: u32,
         angle: f64,
     ) -> Result<(), String> {
-        batch.animations.push(
-            Rotate::new(self.object(handle)?, finite_f32("rotation angle", angle)?).into(),
-        );
+        batch
+            .animations
+            .push(Rotate::new(self.object(handle)?, finite_f32("rotation angle", angle)?).into());
         Ok(())
     }
 

--- a/crates/noon/examples/manim_gallery_moving_around.rs
+++ b/crates/noon/examples/manim_gallery_moving_around.rs
@@ -1,0 +1,37 @@
+use noon::prelude::*;
+use noon_ir::encode_scene;
+
+fn moving_around() -> Scene {
+    let mut scene = Scene::new();
+    let square = scene.add(
+        Square::default()
+            .color(BLUE)
+            .set_fill(Some(BLUE), Some(1.0)),
+    );
+
+    scene
+        .play(square.animate().shift(LEFT))
+        .run_time(1.0)
+        .unwrap();
+    scene
+        .play(square.animate().set_fill(Some(ORANGE), None))
+        .run_time(1.0)
+        .unwrap();
+    scene
+        .play(square.animate().scale(0.3))
+        .run_time(1.0)
+        .unwrap();
+    scene
+        .play(square.animate().rotate(0.4))
+        .run_time(1.0)
+        .unwrap();
+    scene
+}
+
+fn main() {
+    let scene = moving_around();
+    println!(
+        "MovingAround\t{}",
+        encode_scene(scene.definition()).unwrap()
+    );
+}

--- a/crates/noon/src/legacy.rs
+++ b/crates/noon/src/legacy.rs
@@ -19,7 +19,8 @@ pub use composition_authoring::{AnimationGroup, LaggedStart, Succession};
 pub mod prelude {
     pub use crate::{
         Animate, AnimationGroup, AuthoringError, Circle, Create, FadeIn, FadeOut, LaggedStart,
-        Line, Mobject, MobjectEditor, Path, Rectangle, Rotate, Scene, Square, Succession, Transform,
+        Line, Mobject, MobjectEditor, Path, Rectangle, Rotate, Scene, Square, Succession,
+        Transform,
     };
     pub use noon_core::{
         Color, Easing, GeometryRef, ObjectId, ObjectSnapshot, RateFunction, Style, Vec2,
@@ -433,7 +434,9 @@ impl std::fmt::Display for AuthoringError {
         match self {
             Self::UnknownObject(id) => write!(formatter, "unknown object id {}", id.get()),
             Self::InvalidDuration(value) => write!(formatter, "invalid animation duration {value}"),
-            Self::InvalidRotationAngle(value) => write!(formatter, "invalid rotation angle {value}"),
+            Self::InvalidRotationAngle(value) => {
+                write!(formatter, "invalid rotation angle {value}")
+            }
             Self::RotateRequiresCenteredGeometry(id) => write!(
                 formatter,
                 "Rotate currently requires object {} geometry centered on its transform origin",
@@ -915,10 +918,7 @@ mod tests {
         assert_eq!(tracks[1].timing.duration, 2.0);
         assert_eq!(tracks[0].timing.easing, RateFunction::Smooth);
         assert_eq!(tracks[1].timing.easing, RateFunction::Smooth);
-        assert_eq!(
-            tracks[1].values,
-            TrackValues::Scalar { from: 0.0, to: PI }
-        );
+        assert_eq!(tracks[1].values, TrackValues::Scalar { from: 0.0, to: PI });
         assert!((scene.snapshot(left).unwrap().transform.rotation - PI).abs() < 1e-6);
         assert!((scene.snapshot(right).unwrap().transform.rotation - PI).abs() < 1e-6);
         assert_eq!(scene.time(), 2.0);

--- a/crates/noon/tests/manim_gallery_moving_around.rs
+++ b/crates/noon/tests/manim_gallery_moving_around.rs
@@ -1,0 +1,46 @@
+use noon::prelude::*;
+use noon_core::{Property, RateFunction};
+
+#[test]
+fn moving_around_is_four_sequential_target_state_transforms() {
+    let mut scene = Scene::new();
+    let square = scene.add(
+        Square::default()
+            .color(BLUE)
+            .set_fill(Some(BLUE), Some(1.0)),
+    );
+
+    scene
+        .play(square.animate().shift(LEFT))
+        .run_time(1.0)
+        .unwrap();
+    scene
+        .play(square.animate().set_fill(Some(ORANGE), None))
+        .run_time(1.0)
+        .unwrap();
+    scene
+        .play(square.animate().scale(0.3))
+        .run_time(1.0)
+        .unwrap();
+    scene
+        .play(square.animate().rotate(0.4))
+        .run_time(1.0)
+        .unwrap();
+
+    assert_eq!(scene.time(), 4.0);
+    assert_eq!(scene.definition().objects().len(), 1);
+    let tracks = scene.definition().tracks();
+    assert_eq!(tracks.len(), 4);
+    for (index, track) in tracks.iter().enumerate() {
+        assert_eq!(track.property, Property::Transform);
+        assert_eq!(track.timing.start_time, index as f64);
+        assert_eq!(track.timing.duration, 1.0);
+        assert_eq!(track.timing.easing, RateFunction::Smooth);
+    }
+
+    let final_state = scene.snapshot(square).unwrap();
+    assert_eq!(final_state.transform.translation, LEFT);
+    assert_eq!(final_state.transform.scale, Vec2::new(0.3, 0.3));
+    assert!((final_state.transform.rotation - 0.4).abs() < 1e-6);
+    assert_eq!(final_state.style.fill, Some(ORANGE));
+}

--- a/scripts/cross-language-parity.mjs
+++ b/scripts/cross-language-parity.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync, spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -65,6 +66,11 @@ class ParityTracker(Scene):
         )
 `,
 };
+
+const movingAroundPython = readFileSync(
+  path.join(repoRoot, "web", "python", "examples", "manim_gallery_moving_around.py"),
+  "utf8",
+);
 
 const javascriptParityCases = new Set([
   "animate_options",
@@ -158,7 +164,13 @@ async function javascriptCorpora(page) {
       quickstart[name] = build().toJSON();
     }
 
-    return { parity, quickstart };
+    const galleryExamples = await import("/web/js/examples/manim-gallery-moving-around.js");
+    const gallery = {};
+    for (const [name, build] of Object.entries(galleryExamples.galleryMovingAround)) {
+      gallery[name] = build().toJSON();
+    }
+
+    return { parity, quickstart, gallery };
   });
 }
 
@@ -190,8 +202,10 @@ let browser = null;
 try {
   const rust = rustCorpus();
   const rustQuickstart = rustCorpus("manim_quickstart_equivalents");
+  const rustMovingAround = rustCorpus("manim_gallery_moving_around");
   assert.deepEqual([...rust.keys()].sort(), Object.keys(pythonCases).sort());
   assert.deepEqual([...rustQuickstart.keys()].sort(), [...quickstartEquivalentCases].sort());
+  assert.deepEqual([...rustMovingAround.keys()], ["MovingAround"]);
 
   await waitForServer();
   browser = await chromium.launch({
@@ -219,6 +233,17 @@ try {
     assertSemanticEqual(result.document, rust.get(name), `${name}: python/rust`);
   }
 
+  const movingAroundResult = await page.evaluate(
+    (pythonSource) => window.noonManimCompat.run(pythonSource),
+    movingAroundPython,
+  );
+  assert.equal(movingAroundResult.kind, "scene_document", "MovingAround: Python authoring failed");
+  assertSemanticEqual(
+    movingAroundResult.document,
+    rustMovingAround.get("MovingAround"),
+    "MovingAround: python/rust",
+  );
+
   const javascript = await javascriptCorpora(page);
   assert.deepEqual(Object.keys(javascript.parity).sort(), [...javascriptParityCases].sort());
   for (const [name, document] of Object.entries(javascript.parity)) {
@@ -232,8 +257,17 @@ try {
     assertSemanticEqual(document, rustQuickstart.get(name), `${name}: quickstart javascript/rust`);
   }
 
+  assert.deepEqual(Object.keys(javascript.gallery), ["MovingAround"]);
+  assertSemanticEqual(
+    javascript.gallery.MovingAround,
+    rustMovingAround.get("MovingAround"),
+    "MovingAround: javascript/rust",
+  );
+
   assert.equal(errors.length, 0, errors.join("\n"));
-  console.log("Python/Rust parity, JavaScript parity, and Rust/JavaScript Quickstart equivalence passed");
+  console.log(
+    "Python/Rust parity, JavaScript parity, Rust/JavaScript Quickstart equivalence, and MovingAround tri-language equivalence passed",
+  );
 } finally {
   if (browser !== null) await browser.close();
   server.kill("SIGTERM");

--- a/web/js/examples/manim-gallery-moving-around.js
+++ b/web/js/examples/manim-gallery-moving-around.js
@@ -1,0 +1,23 @@
+import {
+  BLUE,
+  LEFT,
+  ORANGE,
+  Scene,
+  Square,
+} from "../../noon-authoring.js";
+
+export function movingAround() {
+  const scene = new Scene();
+  const square = new Square().setColor(BLUE).setFill(BLUE, 1);
+  scene.add(square);
+
+  scene.play(square.animate().shift(LEFT));
+  scene.play(square.animate().setFill(ORANGE));
+  scene.play(square.animate().scale(0.3));
+  scene.play(square.animate().rotate(0.4));
+  return scene;
+}
+
+export const galleryMovingAround = {
+  MovingAround: movingAround,
+};

--- a/web/python/examples/manim_gallery_moving_around.py
+++ b/web/python/examples/manim_gallery_moving_around.py
@@ -1,0 +1,11 @@
+from noon import *
+
+
+class MovingAround(Scene):
+    def construct(self):
+        square = Square(color=BLUE, fill_opacity=1)
+
+        self.play(square.animate.shift(LEFT))
+        self.play(square.animate.set_fill(ORANGE))
+        self.play(square.animate.scale(0.3))
+        self.play(square.animate.rotate(0.4))


### PR DESCRIPTION
Tracks #252, #259, and #91.

## Scope
- adds the source-equivalent ManimCE v0.21 Example Gallery `MovingAround` scene in Python
- adds idiomatic Rust and JavaScript equivalents using the same shared target-state authoring semantics
- exercises four already-supported operations in sequence: shift LEFT, set fill ORANGE, scale 0.3, rotate 0.4
- extends the existing browser-authoring parity gate so the actual Python file, Rust example, and JS example must produce the same canonical semantic document
- includes the mechanical `cargo fmt --all` repair for the two Rust files that were already out of format on `master`

## Validation
Current clean head `6111d9e` is one commit directly on current master.

Feature-relevant results:
- Rust fmt/clippy/workspace tests: **green**
- Rust coverage: **green**
- Manim semantic differential: **green**
- temporary rustfmt check: **green**
- an earlier #271 browser-authoring run executed the new Python/Rust/JS `MovingAround` semantic comparison successfully

The remaining red workflows are pre-existing repository/example-manifest failures introduced around the exact-source transition and tracked by the active #281 cleanup, not failures in this PR:
- Web package and raster build stop at `FocusOn is promoted only after the canonical raster/timeline/direct-seek gate passes`
- Python coverage stops on existing tutorial exact-source/dependency assertions (`parity-create-circle`, `parity-square-to-circle`, blocked parity probes without `dependency`, etc.)
- Manim API coverage is the same manifest/dependency baseline class

This PR intentionally does not modify those unrelated gallery-manifest entries or absorb #281's 32-file WIP cleanup.

## Follow-up
After the canonical Manim raster/timeline fixture for `MovingAround` is added and qualified, this source can be promoted into the public demo manifest with the canonical thumbnail. This PR does not claim external Manim pixel parity yet; it establishes exact upstream source coverage plus Python/Rust/JS semantic equivalence.