### PR TITLE
Repair master rustfmt baseline

### DIFF
--- a/.github/workflows/temp-pr-rustfmt.yml
+++ b/.github/workflows/temp-pr-rustfmt.yml
@@ -1,6 +1,9 @@
 name: Temporary PR rustfmt
 
 on:
+  push:
+    branches:
+      - master
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
 
@@ -8,8 +11,28 @@ permissions:
   contents: write
 
 jobs:
-  format:
+  format-master:
+    if: github.event_name == 'push' && github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: master
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - run: |
+          rustup default stable
+          rustup component add rustfmt
+          cargo fmt --all
+          if git diff --quiet; then exit 0; fi
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add --all
+          git commit -m "Apply rustfmt to master baseline"
+          git push origin HEAD:master
+
+  format-pr:
     if: >-
+      github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       (github.head_ref == 'gallery/manim-moving-around-trilang' ||
        github.head_ref == 'arch/js-value-tracker')


### PR DESCRIPTION
Temporary CI plumbing only. Extends the short-lived rustfmt helper so this merge's own `push` event runs `cargo fmt --all` once on `master`, repairing the formatting debt introduced before #271/#272. The workflow still targets only #271/#272 for PR-head formatting and will be removed after both branches are qualified.