### PR TITLE
Add exact Manim Restore parity

### DIFF
--- a/.github/workflows/manim-raster-differential.yml
+++ b/.github/workflows/manim-raster-differential.yml
@@ -68,15 +68,25 @@ jobs:
           npm install --no-save --ignore-scripts playwright@1.62.1 pngjs@7.0.0
           npx playwright install chromium
 
+      - name: Assemble exact raster source corpus
+        run: |
+          test "$(head -n 1 parity/manim-v0.21/upstream-examples/restore_example.py)" = "from manim import *"
+          printf '\n\n' >> parity/manim-v0.21/quickstart.py
+          tail -n +2 parity/manim-v0.21/upstream-examples/restore_example.py >> parity/manim-v0.21/quickstart.py
+
       - name: Render and compare canonical Manim scenes
         env:
           NOON_MANIM_RASTER_BACKENDS: webgpu,webgl
           NOON_MANIM_RASTER_ARTIFACTS: manim-raster-artifacts
+          NOON_MANIM_MATERIALIZE_STATIC_WAITS: "1"
+          PYTHONPATH: ${{ github.workspace }}/scripts/manim-raster-sitecustomize
         run: node scripts/manim-raster-differential.mjs
 
       - name: Capture semantic state at raster frame times
         env:
           NOON_MANIM_RASTER_ARTIFACTS: manim-raster-artifacts
+          NOON_MANIM_MATERIALIZE_STATIC_WAITS: "1"
+          PYTHONPATH: ${{ github.workspace }}/scripts/manim-raster-sitecustomize
         run: node scripts/manim-raster-semantic-state.mjs
 
       - name: Enforce per-fixture raster ratchet

--- a/.github/workflows/manim-raster-differential.yml
+++ b/.github/workflows/manim-raster-differential.yml
@@ -54,6 +54,12 @@ jobs:
           tool: wasm-pack@0.15.0
           fallback: none
 
+      - name: Assemble exact raster source corpus
+        run: |
+          test "$(head -n 1 parity/manim-v0.21/upstream-examples/restore_example.py)" = "from manim import *"
+          printf '\n\n' >> parity/manim-v0.21/quickstart.py
+          tail -n +2 parity/manim-v0.21/upstream-examples/restore_example.py >> parity/manim-v0.21/quickstart.py
+
       - name: Build browser package
         run: bash scripts/build-web-demo.sh
 
@@ -67,12 +73,6 @@ jobs:
         run: |
           npm install --no-save --ignore-scripts playwright@1.62.1 pngjs@7.0.0
           npx playwright install chromium
-
-      - name: Assemble exact raster source corpus
-        run: |
-          test "$(head -n 1 parity/manim-v0.21/upstream-examples/restore_example.py)" = "from manim import *"
-          printf '\n\n' >> parity/manim-v0.21/quickstart.py
-          tail -n +2 parity/manim-v0.21/upstream-examples/restore_example.py >> parity/manim-v0.21/quickstart.py
 
       - name: Render and compare canonical Manim scenes
         env:

--- a/compat/manim-v0.21.0.json
+++ b/compat/manim-v0.21.0.json
@@ -45,6 +45,7 @@
     "Transform": {"status": "supported", "category": "animation", "evidence": "generic transform tests"},
     "ReplacementTransform": {"status": "supported", "category": "animation", "evidence": "lifecycle tests"},
     "TransformFromCopy": {"status": "supported", "category": "animation", "evidence": "transform-from-copy tests"},
+    "Restore": {"status": "partial", "category": "animation-transform", "dependency": "#82", "reason": "Leaf 2D Mobjects restore the latest save_state() snapshot at Scene.play time through the retained Transform path; retained Group/VGroup family restore and broader ApplyMethod family alignment remain pending."},
     "TransformMatchingShapes": {"status": "supported", "category": "animation", "evidence": "matching-shapes tests"},
     "AnimationGroup": {"status": "supported", "category": "animation-composition", "evidence": "composition tests"},
     "LaggedStart": {"status": "supported", "category": "animation-composition", "evidence": "composition tests"},

--- a/parity/manim-v0.21/manifest.json
+++ b/parity/manim-v0.21/manifest.json
@@ -289,6 +289,11 @@
       "id": "shrink-to-center-rectangle",
       "scene": "ShrinkToCenterRectangle",
       "expected_duration": 1.0
+    },
+    {
+      "id": "restore-example",
+      "scene": "RestoreExample",
+      "expected_duration": 6.0
     }
   ],
   "sample_fractions": [

--- a/parity/manim-v0.21/manifest.json
+++ b/parity/manim-v0.21/manifest.json
@@ -293,6 +293,7 @@
     {
       "id": "restore-example",
       "scene": "RestoreExample",
+      "source": "parity/manim-v0.21/upstream-examples/restore_example.py",
       "expected_duration": 6.0
     }
   ],

--- a/parity/manim-v0.21/upstream-examples/restore_example.py
+++ b/parity/manim-v0.21/upstream-examples/restore_example.py
@@ -1,0 +1,12 @@
+from manim import *
+
+
+class RestoreExample(Scene):
+    def construct(self):
+        s = Square()
+        s.save_state()
+        self.play(FadeIn(s))
+        self.play(s.animate.set_color(PURPLE).set_opacity(0.5).shift(2*LEFT).scale(3))
+        self.play(s.animate.shift(5*DOWN).rotate(PI/4))
+        self.wait()
+        self.play(Restore(s), run_time=2)

--- a/scripts/manim-raster-sitecustomize/sitecustomize.py
+++ b/scripts/manim-raster-sitecustomize/sitecustomize.py
@@ -1,0 +1,29 @@
+"""Qualification-only Manim runtime tweaks for the exact raster oracle.
+
+The canonical source stays byte-for-byte upstream.  This module is injected through
+``PYTHONPATH`` only in the raster qualification workflow so Cairo materializes a
+static ``Wait`` at the pinned frame rate instead of writing one PNG with a repeat
+count.  Rendering every static-wait frame keeps materialized frame indices aligned
+with Manim's logical renderer time without changing scene state or animation output.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+if os.environ.get("NOON_MANIM_MATERIALIZE_STATIC_WAITS") == "1":
+    from manim.scene.scene import Scene
+
+    _original_should_update_mobjects = Scene.should_update_mobjects
+
+    def _materialize_static_wait_frames(self: Scene) -> bool:
+        # Scene.should_update_mobjects() is only consulted for a single Wait.
+        # Returning True disables Cairo's frozen-frame/repeat-count optimization;
+        # genuinely dynamic waits already take this path, while static waits render
+        # identical frames at the configured frame rate.
+        return True
+
+    _materialize_static_wait_frames.__name__ = _original_should_update_mobjects.__name__
+    _materialize_static_wait_frames.__doc__ = _original_should_update_mobjects.__doc__
+    Scene.should_update_mobjects = _materialize_static_wait_frames

--- a/web/python/_manim_animate.py
+++ b/web/python/_manim_animate.py
@@ -104,6 +104,26 @@ class Transform(_ORIGINAL_TRANSFORM):
         _store_animation_args(self, kwargs)
 
 
+class Restore:
+    """Restore one leaf mobject to its latest saved state when playback is compiled.
+
+    Manim implements ``Restore`` as ``ApplyMethod(mobject.restore)``. The restore target
+    is therefore created by ``Transform.begin()``, rather than frozen when ``Restore``
+    itself is constructed. Noon mirrors that authoring contract while lowering the
+    result to its ordinary retained Transform track.
+    """
+
+    def __init__(self, mobject: object, **kwargs: Any) -> None:
+        if isinstance(mobject, _compat.Group):
+            raise NotImplementedError(
+                "Restore(Group/VGroup) requires generic retained-family Transform alignment"
+            )
+        if not isinstance(mobject, _base.Mobject):
+            raise TypeError("Restore target must be a Mobject")
+        self.mobject = mobject
+        _store_animation_args(self, kwargs)
+
+
 class Indicate:
     """ManimCE ``Indicate`` lowered without a Python-owned frame callback.
 
@@ -229,6 +249,7 @@ class FadeOut(_ORIGINAL_FADE_OUT):
 # continues to work because the module globals now point at these subclasses.
 for _name, _value in {
     "Transform": Transform,
+    "Restore": Restore,
     "Indicate": Indicate,
     "ReplacementTransform": ReplacementTransform,
     "TransformFromCopy": TransformFromCopy,
@@ -240,6 +261,9 @@ for _name, _value in {
 }.items():
     setattr(_base, _name, _value)
 
+setattr(_compat, "Restore", Restore)
+if "Restore" not in _base.__all__:
+    _base.__all__.append("Restore")
 if "Indicate" not in _base.__all__:
     _base.__all__.append("Indicate")
 
@@ -312,7 +336,7 @@ _compat._GroupAnimationBuilder = _AlignedGroupAnimationBuilder
 
 
 def _builder_source(animation: object) -> object | None:
-    if isinstance(animation, Indicate):
+    if isinstance(animation, (Indicate, Restore)):
         return animation.mobject
     if isinstance(animation, (_AlignedAnimationBuilder, _AlignedGroupAnimationBuilder)):
         return animation.source
@@ -430,7 +454,14 @@ def _expanded_schedule(
             run_time=run_time,
             easing=easing,
         )
-    if isinstance(animation, _AlignedAnimationBuilder):
+    if isinstance(animation, Restore):
+        saved_state = getattr(animation.mobject, "saved_state", None)
+        if saved_state is None:
+            raise Exception("Trying to restore without having saved")
+        if not isinstance(saved_state, _base.Mobject):
+            raise TypeError("saved_state must be a Mobject")
+        expanded = [_base.Transform(animation.mobject, saved_state.copy())]
+    elif isinstance(animation, _AlignedAnimationBuilder):
         expanded = [_base.Transform(animation.source, animation.target)]
     else:
         expanded = scene._expand_animation(animation)

--- a/web/python/examples/manim_parity_restore.py
+++ b/web/python/examples/manim_parity_restore.py
@@ -1,0 +1,12 @@
+from noon import *
+
+
+class RestoreExample(Scene):
+    def construct(self):
+        s = Square()
+        s.save_state()
+        self.play(FadeIn(s))
+        self.play(s.animate.set_color(PURPLE).set_opacity(0.5).shift(2*LEFT).scale(3))
+        self.play(s.animate.shift(5*DOWN).rotate(PI/4))
+        self.wait()
+        self.play(Restore(s), run_time=2)

--- a/web/python/test_manim_raster_manifest.py
+++ b/web/python/test_manim_raster_manifest.py
@@ -11,9 +11,18 @@ MANIFEST_PATH = REPO_ROOT / "parity" / "manim-v0.21" / "manifest.json"
 class ManimRasterManifestTests(unittest.TestCase):
     def setUp(self) -> None:
         self.manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
-        self.source_path = REPO_ROOT / self.manifest["reference"]["source"]
-        self.source = self.source_path.read_text(encoding="utf-8")
-        self.tree = ast.parse(self.source)
+        self.default_source_path = REPO_ROOT / self.manifest["reference"]["source"]
+
+    def _source_for_fixture(self, fixture: dict[str, object]) -> tuple[str, ast.Module]:
+        source_path = REPO_ROOT / str(fixture.get("source", self.manifest["reference"]["source"]))
+        source = source_path.read_text(encoding="utf-8")
+        return source, ast.parse(source)
+
+    def _assert_real_manim_source(self, source: str, tree: ast.Module) -> None:
+        self.assertIn("from manim import *", source)
+        self.assertNotIn("from noon import *", source)
+        imports = [node for node in tree.body if isinstance(node, ast.ImportFrom)]
+        self.assertTrue(any(node.module == "manim" for node in imports))
 
     def test_reference_profile_is_pinned(self) -> None:
         reference = self.manifest["reference"]
@@ -22,22 +31,28 @@ class ManimRasterManifestTests(unittest.TestCase):
         self.assertEqual((reference["pixel_width"], reference["pixel_height"]), (960, 540))
         self.assertEqual(reference["frame_rate"], 30)
 
-    def test_canonical_source_uses_real_manim_only(self) -> None:
-        self.assertIn("from manim import *", self.source)
-        self.assertNotIn("from noon import *", self.source)
-        imports = [node for node in self.tree.body if isinstance(node, ast.ImportFrom)]
-        self.assertTrue(any(node.module == "manim" for node in imports))
+    def test_canonical_sources_use_real_manim_only(self) -> None:
+        source_paths = {self.default_source_path}
+        source_paths.update(
+            REPO_ROOT / str(fixture["source"])
+            for fixture in self.manifest["fixtures"]
+            if "source" in fixture
+        )
+        for source_path in source_paths:
+            source = source_path.read_text(encoding="utf-8")
+            self._assert_real_manim_source(source, ast.parse(source))
 
     def test_every_fixture_selects_a_scene_class(self) -> None:
-        classes = {
-            node.name
-            for node in self.tree.body
-            if isinstance(node, ast.ClassDef)
-        }
         fixtures = self.manifest["fixtures"]
         self.assertGreaterEqual(len(fixtures), 4)
         self.assertEqual(len({fixture["id"] for fixture in fixtures}), len(fixtures))
         for fixture in fixtures:
+            _, tree = self._source_for_fixture(fixture)
+            classes = {
+                node.name
+                for node in tree.body
+                if isinstance(node, ast.ClassDef)
+            }
             self.assertIn(fixture["scene"], classes)
             self.assertGreater(float(fixture["expected_duration"]), 0.0)
 
@@ -51,9 +66,17 @@ class ManimRasterManifestTests(unittest.TestCase):
         self.assertEqual(fractions, sorted(set(fractions)))
 
     def test_noon_adaptation_changes_only_import_before_selection_wrapper(self) -> None:
-        adapted = self.source.replace("from manim import *", "from noon import *", 1)
-        restored = adapted.replace("from noon import *", "from manim import *", 1)
-        self.assertEqual(restored, self.source)
+        source_paths = {self.default_source_path}
+        source_paths.update(
+            REPO_ROOT / str(fixture["source"])
+            for fixture in self.manifest["fixtures"]
+            if "source" in fixture
+        )
+        for source_path in source_paths:
+            source = source_path.read_text(encoding="utf-8")
+            adapted = source.replace("from manim import *", "from noon import *", 1)
+            restored = adapted.replace("from noon import *", "from manim import *", 1)
+            self.assertEqual(restored, source)
 
 
 if __name__ == "__main__":

--- a/web/python/test_manim_restore_animation.py
+++ b/web/python/test_manim_restore_animation.py
@@ -1,0 +1,178 @@
+import os
+import subprocess
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+
+
+class ManimRestoreAnimationTests(unittest.TestCase):
+    def test_restore_resolves_latest_saved_state_at_play_time(self) -> None:
+        python_dir = Path(__file__).resolve().parent
+        env = os.environ.copy()
+        existing_pythonpath = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = (
+            str(python_dir)
+            if not existing_pythonpath
+            else os.pathsep.join((str(python_dir), existing_pythonpath))
+        )
+
+        source = textwrap.dedent(
+            """
+            import math
+            import sys
+            import types
+
+            fake_js = types.ModuleType("js")
+
+            class Result:
+                ok = True
+                errorKind = ""
+                message = ""
+
+            def resolve_animation_options(
+                default_lag_ratio,
+                animation_run_time,
+                animation_rate_func,
+                animation_lag_ratio,
+                path_arc,
+                reverse_rate_function,
+                play_run_time,
+                play_rate_func,
+                play_lag_ratio,
+            ):
+                result = Result()
+                result.runTime = (
+                    play_run_time
+                    if math.isfinite(play_run_time)
+                    else animation_run_time
+                    if math.isfinite(animation_run_time)
+                    else 1.0
+                )
+                result.rateFunc = play_rate_func or animation_rate_func or "smooth"
+                result.lagRatio = (
+                    play_lag_ratio
+                    if math.isfinite(play_lag_ratio)
+                    else animation_lag_ratio
+                    if math.isfinite(animation_lag_ratio)
+                    else default_lag_ratio
+                )
+                result.pathArc = path_arc if math.isfinite(path_arc) else 0.0
+                result.reverseRateFunction = reverse_rate_function == 1
+                return result
+
+            def resolve_uniform_schedule(child_count, lag_ratio, run_time):
+                result = Result()
+                result.intervals = []
+                return result
+
+            fake_js.noonResolveAnimationOptions = resolve_animation_options
+            fake_js.noonResolveUniformCompositionSchedule = resolve_uniform_schedule
+            sys.modules["js"] = fake_js
+
+            import _manim_compat
+            _manim_compat.install()
+            import _manim_rate_functions
+            _manim_rate_functions.install()
+            import _manim_phase_b  # noqa: F401
+            import _manim_animate  # noqa: F401
+
+            from noon import BLUE, GREEN, RIGHT, UP, Restore, Scene, Square, VGroup, linear
+
+            # Manim constructs Restore without touching saved_state; the missing-state
+            # error belongs to Transform.begin()/Scene.play. Rollback must undo binding.
+            missing = Square()
+            pending_missing = Restore(missing)
+            missing_scene = Scene()
+            before = missing_scene.to_document()
+            try:
+                missing_scene.play(pending_missing)
+                raise AssertionError("Restore without save_state() must fail at play time")
+            except Exception as error:
+                assert str(error) == "Trying to restore without having saved"
+            assert missing_scene.to_document() == before
+            assert abs(missing_scene.time) < 1e-12
+            assert missing._scene is None
+            assert missing._object is None
+
+            # The target must be resolved at play time. The second save_state() below
+            # happens after Restore(...) construction and therefore supersedes the first.
+            square = Square(fill_color=BLUE, fill_opacity=0.4)
+            square.save_state()
+            square.shift(RIGHT).set_fill(color=GREEN, opacity=0.6)
+            pending = Restore(square, run_time=2.0, rate_func=linear)
+            square.save_state()
+            square.shift(UP).scale(1.5)
+
+            scene = Scene()
+            scene.add(square)
+            scene.play(pending)
+            assert abs(scene.time - 2.0) < 1e-12
+
+            tracks = [
+                track
+                for track in scene.to_document()["tracks"]
+                if track["property"] == "transform"
+            ]
+            assert len(tracks) == 1
+            track = tracks[0]
+            assert track["timing"] == {
+                "start_time": 0.0,
+                "duration": 2.0,
+                "easing": "linear",
+            }
+
+            target = track["values"]["object"]["to"]
+            translation = target["transform"]["translation"]
+            scale = target["transform"]["scale"]
+            fill = target["style"]["fill"]
+            assert abs(translation["x"] - 1.0) < 1e-12
+            assert abs(translation["y"] - 0.0) < 1e-12
+            assert abs(scale["x"] - 1.0) < 1e-12
+            assert abs(scale["y"] - 1.0) < 1e-12
+            assert abs(fill["red"] - GREEN.red) < 1e-12
+            assert abs(fill["green"] - GREEN.green) < 1e-12
+            assert abs(fill["blue"] - GREEN.blue) < 1e-12
+            assert abs(fill["alpha"] - 0.6) < 1e-12
+            assert scene._snapshot_for_object_at(square._object, 2.0) == target
+
+            # Scene.play implicitly adds the animated mobject in Manim. Restore should
+            # use the same binding path rather than requiring an explicit Scene.add().
+            detached = Square()
+            detached.save_state()
+            detached.shift(RIGHT)
+            detached_scene = Scene()
+            detached_scene.play(Restore(detached))
+            assert detached._scene is detached_scene
+            assert detached._object is not None
+            detached_tracks = [
+                track
+                for track in detached_scene.to_document()["tracks"]
+                if track["property"] == "transform"
+            ]
+            assert len(detached_tracks) == 1
+            detached_target = detached_tracks[0]["values"]["object"]["to"]
+            assert abs(detached_target["transform"]["translation"]["x"]) < 1e-12
+            assert abs(detached_target["transform"]["translation"]["y"]) < 1e-12
+
+            try:
+                Restore(VGroup(Square()))
+                raise AssertionError("retained-family Restore must stay explicit partial")
+            except NotImplementedError:
+                pass
+            """
+        )
+
+        completed = subprocess.run(
+            [sys.executable, "-c", source],
+            cwd=python_dir,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Tracks #82 and #185.

## Scope
- implements ManimCE v0.21 `Restore` for leaf 2D mobjects
- resolves `saved_state` when `Scene.play` begins, matching `Restore -> ApplyMethod -> Transform.begin()` semantics rather than freezing the state at constructor time
- lowers to Noon's existing retained `Transform`; no new renderer primitive or Python frame callback
- preserves Manim's `Trying to restore without having saved` failure timing and transactional rollback
- rejects retained `Group`/`VGroup` family restore rather than approximating generic family alignment
- adds a focused regression proving a later `save_state()` supersedes the state that existed when `Restore(...)` was constructed
- checks in the literal ManimCE v0.21 `RestoreExample` source and an import-only Noon mirror
- adds the exact 6.0 s docs example to the canonical Cairo raster/timeline/seek corpus with no tolerance override

## Qualification
Keep draft until the current head passes API/semantic/coverage plus exact-duration, intermediate-frame Cairo raster, direct-seek/incremental-playback, WebGPU and WebGL gates with unchanged tolerances. Only then add a canonical Manim-derived thumbnail, expose the literal upstream example as `parity-qualified`, update #82, and merge.