### PR TITLE
Route rustfmt repair through protected-branch PR

### DIFF
--- a/.github/workflows/temp-pr-rustfmt.yml
+++ b/.github/workflows/temp-pr-rustfmt.yml
@@ -28,7 +28,7 @@ jobs:
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
           git add --all
           git commit -m "Apply rustfmt to master baseline"
-          git push origin HEAD:master
+          git push --force origin HEAD:refs/heads/ci/master-rustfmt-output
 
   format-pr:
     if: >-


### PR DESCRIPTION
Temporary CI plumbing only. Change the short-lived rustfmt helper so master formatting is pushed to an unprotected `ci/master-rustfmt-output` branch instead of attempting to bypass branch protection. The resulting formatting commit will then be merged through a normal PR; the helper is removed after #271/#272 are qualified.