### PR TITLE
Apply generated rustfmt baseline repair

### DIFF
--- a/crates/noon-web/src/authoring_facade.rs
+++ b/crates/noon-web/src/authoring_facade.rs
@@ -434,9 +434,9 @@ impl FrontendAuthoringScene {
         handle: u32,
         angle: f64,
     ) -> Result<(), String> {
-        batch.animations.push(
-            Rotate::new(self.object(handle)?, finite_f32("rotation angle", angle)?).into(),
-        );
+        batch
+            .animations
+            .push(Rotate::new(self.object(handle)?, finite_f32("rotation angle", angle)?).into());
         Ok(())
     }
 

--- a/crates/noon/src/legacy.rs
+++ b/crates/noon/src/legacy.rs
@@ -19,7 +19,8 @@ pub use composition_authoring::{AnimationGroup, LaggedStart, Succession};
 pub mod prelude {
     pub use crate::{
         Animate, AnimationGroup, AuthoringError, Circle, Create, FadeIn, FadeOut, LaggedStart,
-        Line, Mobject, MobjectEditor, Path, Rectangle, Rotate, Scene, Square, Succession, Transform,
+        Line, Mobject, MobjectEditor, Path, Rectangle, Rotate, Scene, Square, Succession,
+        Transform,
     };
     pub use noon_core::{
         Color, Easing, GeometryRef, ObjectId, ObjectSnapshot, RateFunction, Style, Vec2,
@@ -433,7 +434,9 @@ impl std::fmt::Display for AuthoringError {
         match self {
             Self::UnknownObject(id) => write!(formatter, "unknown object id {}", id.get()),
             Self::InvalidDuration(value) => write!(formatter, "invalid animation duration {value}"),
-            Self::InvalidRotationAngle(value) => write!(formatter, "invalid rotation angle {value}"),
+            Self::InvalidRotationAngle(value) => {
+                write!(formatter, "invalid rotation angle {value}")
+            }
             Self::RotateRequiresCenteredGeometry(id) => write!(
                 formatter,
                 "Rotate currently requires object {} geometry centered on its transform origin",
@@ -915,10 +918,7 @@ mod tests {
         assert_eq!(tracks[1].timing.duration, 2.0);
         assert_eq!(tracks[0].timing.easing, RateFunction::Smooth);
         assert_eq!(tracks[1].timing.easing, RateFunction::Smooth);
-        assert_eq!(
-            tracks[1].values,
-            TrackValues::Scalar { from: 0.0, to: PI }
-        );
+        assert_eq!(tracks[1].values, TrackValues::Scalar { from: 0.0, to: PI });
         assert!((scene.snapshot(left).unwrap().transform.rotation - PI).abs() < 1e-6);
         assert!((scene.snapshot(right).unwrap().transform.rotation - PI).abs() < 1e-6);
         assert_eq!(scene.time(), 2.0);


### PR DESCRIPTION
CI baseline repair generated by the existing `ci/master-rustfmt-output` helper after #282. This PR contains only `cargo fmt --all` output for the two files currently failing stable Rust 1.97.1 formatting checks. No semantic or parity behavior changes.