### PR TITLE
Fix blocked Manim example dependencies

### DIFF
--- a/web/example-gallery.test.mjs
+++ b/web/example-gallery.test.mjs
@@ -27,24 +27,26 @@ assert.ok(
   "ready gallery entries must use rendered WebP thumbnails",
 );
 assert.equal(
-  gallery.examples.find((entry) => entry.id === "parity-focus-on-point")?.parityStatus,
+  gallery.examples.find((entry) => entry.id === "parity-draw-border-then-fill-styled-square")
+    ?.parityStatus,
   "parity-qualified",
-  "FocusOn is promoted only after the canonical raster/timeline/direct-seek gate passes",
-);
-assert.equal(
-  gallery.examples.find((entry) => entry.id === "parity-indicate-square")?.parityStatus,
-  "parity-qualified",
-  "Indicate is promoted only after the canonical raster/timeline/direct-seek gate passes",
+  "the literal upstream DrawBorderThenFill example remains parity-qualified",
 );
 for (const id of [
+  "parity-dot-ellipse",
   "parity-add-wait-lagged-start-map",
   "parity-grow-point-center-edge",
   "parity-uncreate-styled-square",
+  "parity-focus-on-point",
+  "parity-rotating-centered",
+  "parity-show-increasing-subsets-two-shapes",
+  "parity-show-submobjects-one-by-one-two-shapes",
+  "parity-indicate-square",
 ]) {
   assert.equal(
-    gallery.examples.find((entry) => entry.id === id)?.parityStatus,
-    "parity-qualified",
-    `${id}: previously qualified examples must remain qualified`,
+    gallery.examples.some((entry) => entry.id === id),
+    false,
+    `${id}: internal parity probes must stay out of the public exact-source gallery`,
   );
 }
 
@@ -55,8 +57,9 @@ assert.equal(
   readyEntries.filter((entry) => entry.parity_status === "parity-qualified").length,
 );
 assert.equal(
-  filterGalleryExamples(gallery.examples, { category: "parity/composition" })[0].id,
-  "parity-add-wait-lagged-start-map",
+  filterGalleryExamples(gallery.examples, { category: "parity/composition" }).length,
+  0,
+  "Noon-specific composition probes are not public exact-source examples",
 );
 
 const syntheticManifest = {

--- a/web/python/examples/manim_tutorial_manifest.json
+++ b/web/python/examples/manim_tutorial_manifest.json
@@ -128,6 +128,7 @@
       "features": ["Dot", "Ellipse", "geometry"],
       "upstream": "reference/manim.mobject.geometry.arc.html",
       "parity_fixture": "dot-ellipse-parity",
+      "dependency": "#91",
       "reason": "The current combined scene is a Noon parity probe, not either of Manim's upstream DotExample/EllipseExample snippets. Replace it with literal upstream source before exposing it."
     },
     {
@@ -139,6 +140,7 @@
       "features": ["Add", "Wait", "Succession", "LaggedStartMap", "FadeIn"],
       "upstream": "reference/manim.animation.composition.html",
       "parity_fixture": "add-wait-lagged-start-map",
+      "dependency": "#91",
       "reason": "The current combined composition scene is a Noon parity probe and has no matching Manim documentation example. Keep it internal until replaced by an actual upstream snippet."
     },
     {
@@ -150,6 +152,7 @@
       "features": ["GrowFromPoint", "GrowFromCenter", "GrowFromEdge", "LaggedStart"],
       "upstream": "reference/manim.animation.growing.html",
       "parity_fixture": "grow-point-center-edge",
+      "dependency": "#91",
       "reason": "The current staggered three-animation scene is Noon-specific. Manim documents separate GrowFromPointExample, GrowFromCenterExample, and GrowFromEdgeExample scenes."
     },
     {
@@ -161,6 +164,7 @@
       "features": ["Uncreate", "Square", "style", "lifecycle"],
       "upstream": "reference/manim.animation.creation.Uncreate.html",
       "parity_fixture": "uncreate-styled-square",
+      "dependency": "#91",
       "reason": "Manim's upstream example is ShowUncreate with self.play(Uncreate(Square())); the styled-square scene is an internal raster probe."
     },
     {
@@ -172,6 +176,7 @@
       "features": ["FocusOn", "Scene", "lifecycle"],
       "upstream": "reference/manim.animation.indication.FocusOn.html",
       "parity_fixture": "focus-on-point",
+      "dependency": "#91",
       "reason": "Manim's UsingFocusOn example contains Tex and a Dot target. The point-only scene is a Noon parity probe; keep it internal until exact Text/source support exists."
     },
     {
@@ -183,6 +188,7 @@
       "features": ["Rotating", "Square", "rotation"],
       "upstream": "reference/manim.animation.rotation.Rotating.html",
       "parity_fixture": "rotating-centered",
+      "dependency": "#91",
       "reason": "Manim's RotatingDemo uses Circle, Line, Arrow, VGroup, multiple pivots/axes, and several plays. The centered square is only an internal subset probe."
     },
     {
@@ -194,6 +200,7 @@
       "features": ["ShowIncreasingSubsets", "VGroup", "discrete-threshold"],
       "upstream": "reference/manim.animation.creation.ShowIncreasingSubsets.html",
       "parity_fixture": "show-increasing-subsets-two-shapes",
+      "dependency": "#91",
       "reason": "Manim's upstream ShowIncreasingSubsetsScene is VGroup(Dot(), Square(), Triangle()) plus add/play/wait. The two-shape styled scene is not that example."
     },
     {
@@ -205,6 +212,7 @@
       "features": ["ShowSubmobjectsOneByOne", "VGroup", "discrete-threshold"],
       "upstream": "reference/manim.animation.creation.ShowSubmobjectsOneByOne.html",
       "parity_fixture": "show-submobjects-one-by-one-two-shapes",
+      "dependency": "#91",
       "reason": "ManimCE v0.21 does not provide a documentation example for ShowSubmobjectsOneByOne on this reference page; this file is an internal parity probe."
     },
     {
@@ -216,6 +224,7 @@
       "features": ["Indicate", "Square", "there_and_back"],
       "upstream": "reference/manim.animation.indication.Indicate.html",
       "parity_fixture": "indicate-square",
+      "dependency": "#91",
       "reason": "Manim's UsingIndicate example uses Tex(\"Indicate\").scale(3), then Indicate and wait. The square scene is an internal parity probe until exact Text/source support exists."
     },
     {

--- a/web/python/test_manim_tutorial_examples.py
+++ b/web/python/test_manim_tutorial_examples.py
@@ -17,6 +17,18 @@ def load_parity_manifest():
     return json.loads(PARITY_MANIFEST_PATH.read_text(encoding="utf-8"))
 
 
+def noon_source_from_upstream(source: str, example_id: str) -> str:
+    upstream_import = "from manim import *"
+    noon_import = "from noon import *"
+    occurrences = source.count(upstream_import)
+    if occurrences != 1:
+        raise AssertionError(
+            f"{example_id}: canonical upstream source must contain exactly one "
+            f"{upstream_import!r}; found {occurrences}"
+        )
+    return source.replace(upstream_import, noon_import)
+
+
 class ManimTutorialExampleTests(unittest.TestCase):
     def test_manifest_is_versioned_and_has_unique_ids(self) -> None:
         manifest = load_manifest()
@@ -43,16 +55,18 @@ class ManimTutorialExampleTests(unittest.TestCase):
                 path = WEB_ROOT / relative_path
                 self.assertTrue(path.is_file())
                 self.assertTrue((WEB_ROOT / entry["thumbnail"]).is_file())
+                self.assertIn("upstream_source", entry)
+                upstream_path = REPO_ROOT / entry["upstream_source"]
+                self.assertTrue(upstream_path.is_file())
+
                 source = path.read_text(encoding="utf-8")
-                tree = ast.parse(source, filename=str(path))
-                self.assertTrue(
-                    any(
-                        isinstance(node, ast.Assign)
-                        and any(isinstance(target, ast.Name) and target.id == "result" for target in node.targets)
-                        for node in ast.walk(tree)
-                    ),
-                    f"{entry['id']} must assign result",
+                upstream_source = upstream_path.read_text(encoding="utf-8")
+                self.assertEqual(
+                    source,
+                    noon_source_from_upstream(upstream_source, entry["id"]),
+                    f"{entry['id']} must match ManimCE v0.21 source except the import",
                 )
+                tree = ast.parse(source, filename=str(path))
                 compile(tree, str(path), "exec")
         self.assertEqual(len(paths), len(set(paths)))
 


### PR DESCRIPTION
Fix the policy/test regressions introduced by #273's exact-upstream-source migration.

- add `dependency: "#91"` to the nine Noon-specific parity probes that were correctly demoted to `blocked`; #91 owns replacing internal probes with literal upstream Manim tutorial/reference examples
- update the Python tutorial contract test to compare each ready example byte-for-byte with its checked-in upstream source after the single import substitution, instead of requiring the obsolete top-level `result` assignment
- update gallery tests so the nine demoted internal probes are required to stay out of the public gallery, while the literal upstream DrawBorderThenFill example remains parity-qualified

This does not change runnable source, implementation behavior, parity status, raster tolerances, or the exact-source policy itself.