### PR TITLE
Sync master baseline into exact-example branch

### DIFF
--- a/.github/workflows/temp-pr-rustfmt.yml
+++ b/.github/workflows/temp-pr-rustfmt.yml
@@ -1,6 +1,9 @@
 name: Temporary PR rustfmt
 
 on:
+  push:
+    branches:
+      - master
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
 
@@ -8,8 +11,28 @@ permissions:
   contents: write
 
 jobs:
-  format:
+  format-master:
+    if: github.event_name == 'push' && github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: master
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - run: |
+          rustup default stable
+          rustup component add rustfmt
+          cargo fmt --all
+          if git diff --quiet; then exit 0; fi
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add --all
+          git commit -m "Apply rustfmt to master baseline"
+          git push origin HEAD:master
+
+  format-pr:
     if: >-
+      github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       (github.head_ref == 'gallery/manim-moving-around-trilang' ||
        github.head_ref == 'arch/js-value-tracker')

--- a/.github/workflows/temp-pr-rustfmt.yml
+++ b/.github/workflows/temp-pr-rustfmt.yml
@@ -28,7 +28,7 @@ jobs:
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
           git add --all
           git commit -m "Apply rustfmt to master baseline"
-          git push origin HEAD:master
+          git push --force origin HEAD:refs/heads/ci/master-rustfmt-output
 
   format-pr:
     if: >-

--- a/crates/noon-web/src/authoring_facade.rs
+++ b/crates/noon-web/src/authoring_facade.rs
@@ -434,9 +434,9 @@ impl FrontendAuthoringScene {
         handle: u32,
         angle: f64,
     ) -> Result<(), String> {
-        batch.animations.push(
-            Rotate::new(self.object(handle)?, finite_f32("rotation angle", angle)?).into(),
-        );
+        batch
+            .animations
+            .push(Rotate::new(self.object(handle)?, finite_f32("rotation angle", angle)?).into());
         Ok(())
     }
 

--- a/crates/noon/src/legacy.rs
+++ b/crates/noon/src/legacy.rs
@@ -19,7 +19,8 @@ pub use composition_authoring::{AnimationGroup, LaggedStart, Succession};
 pub mod prelude {
     pub use crate::{
         Animate, AnimationGroup, AuthoringError, Circle, Create, FadeIn, FadeOut, LaggedStart,
-        Line, Mobject, MobjectEditor, Path, Rectangle, Rotate, Scene, Square, Succession, Transform,
+        Line, Mobject, MobjectEditor, Path, Rectangle, Rotate, Scene, Square, Succession,
+        Transform,
     };
     pub use noon_core::{
         Color, Easing, GeometryRef, ObjectId, ObjectSnapshot, RateFunction, Style, Vec2,
@@ -433,7 +434,9 @@ impl std::fmt::Display for AuthoringError {
         match self {
             Self::UnknownObject(id) => write!(formatter, "unknown object id {}", id.get()),
             Self::InvalidDuration(value) => write!(formatter, "invalid animation duration {value}"),
-            Self::InvalidRotationAngle(value) => write!(formatter, "invalid rotation angle {value}"),
+            Self::InvalidRotationAngle(value) => {
+                write!(formatter, "invalid rotation angle {value}")
+            }
             Self::RotateRequiresCenteredGeometry(id) => write!(
                 formatter,
                 "Rotate currently requires object {} geometry centered on its transform origin",
@@ -915,10 +918,7 @@ mod tests {
         assert_eq!(tracks[1].timing.duration, 2.0);
         assert_eq!(tracks[0].timing.easing, RateFunction::Smooth);
         assert_eq!(tracks[1].timing.easing, RateFunction::Smooth);
-        assert_eq!(
-            tracks[1].values,
-            TrackValues::Scalar { from: 0.0, to: PI }
-        );
+        assert_eq!(tracks[1].values, TrackValues::Scalar { from: 0.0, to: PI });
         assert!((scene.snapshot(left).unwrap().transform.rotation - PI).abs() < 1e-6);
         assert!((scene.snapshot(right).unwrap().transform.rotation - PI).abs() < 1e-6);
         assert_eq!(scene.time(), 2.0);


### PR DESCRIPTION
Bring the current master rustfmt/workflow baseline into #281 without changing the exact-source example work.