### PR TITLE
Add retained Manim Blink compatibility

### DIFF
--- a/web/python/_manim_updaters.py
+++ b/web/python/_manim_updaters.py
@@ -315,7 +315,7 @@ def _positive_phase_time(value: object) -> float:
 
 
 class Blink(_composition.Succession):
-    """Blink one leaf mobject without running a Python callback during playback."""
+    """Blink one leaf VMobject without running a Python callback during playback."""
 
     def __init__(
         self,
@@ -330,8 +330,14 @@ class Blink(_composition.Succession):
             raise NotImplementedError(
                 "Blink(Group/VGroup) requires retained family opacity semantics and remains partial"
             )
-        if not isinstance(mobject, _base.Mobject):
-            raise TypeError("Blink target must be a Mobject")
+        if not isinstance(mobject, _compat.VMobject):
+            raise NotImplementedError(
+                "Blink currently supports one leaf 2D VMobject; non-vector Mobjects remain partial"
+            )
+        if _updaters(mobject):
+            raise NotImplementedError(
+                "Blink with user mobject updaters has callback-order semantics and remains partial"
+            )
         if isinstance(blinks, bool) or not isinstance(blinks, int):
             raise TypeError("Blink blinks must be an integer")
         if blinks <= 0:

--- a/web/python/_manim_updaters.py
+++ b/web/python/_manim_updaters.py
@@ -3,17 +3,26 @@
 The Python callable stays in Pyodide. During playback the main thread sends one
 coherent runtime snapshot for the callback phase; all getter/setter traffic stays
 inside this module and only one PatchBatch crosses back to WASM.
+
+``Blink`` is a deliberate exception to the host-callback path. Manim implements it
+as a Succession of ``UpdateFromFunc(mobject.set_opacity(...))`` children, but those
+callbacks are fully deterministic. Noon lowers the same on/off phases to retained
+constant style snapshots so playback and seeking never wake Python.
 """
 
 from __future__ import annotations
 
 import copy
 import inspect
+import math
 from dataclasses import dataclass
 from typing import Any, Callable
 
 import _noon_ir as _ir
 import noon as _base
+import _manim_animate as _animate
+import _manim_compat as _compat
+import _manim_composition as _composition
 
 _INSTALLED = False
 _NEXT_SESSION_ID = 0
@@ -23,6 +32,8 @@ _ACTIVE_CONTEXTS: dict[int, "_CallbackContext"] = {}
 
 _ORIGINAL_CURRENT_RAW = _base.Mobject._current_raw
 _ORIGINAL_APPLY = _base.Mobject._apply
+_ORIGINAL_COMPOSITION_PLAY_LEAF = _composition._play_leaf
+_ORIGINAL_RECORD_COMPOSITION_WRAPPER_STATE = _composition._record_composition_wrapper_state
 
 
 def _track(mobject: _base.Mobject) -> None:
@@ -286,6 +297,171 @@ def release_session(session_id: int) -> None:
     _SESSIONS.pop(int(session_id), None)
 
 
+class _BlinkOpacityPhase:
+    """One deterministic replacement for Manim's UpdateFromFunc opacity child."""
+
+    def __init__(self, mobject: _base.Mobject, opacity: float, run_time: float) -> None:
+        self.mobject = mobject
+        self.target = mobject
+        self.opacity = float(opacity)
+        self.anim_args = {"run_time": _positive_phase_time(run_time)}
+
+
+def _positive_phase_time(value: object) -> float:
+    duration = float(value)
+    if not math.isfinite(duration) or duration <= 0.0:
+        raise ValueError("Blink phase durations must be finite and positive")
+    return duration
+
+
+class Blink(_composition.Succession):
+    """Blink one leaf mobject without running a Python callback during playback."""
+
+    def __init__(
+        self,
+        mobject: object,
+        time_on: float = 0.5,
+        time_off: float = 0.5,
+        blinks: int = 1,
+        hide_at_end: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        if isinstance(mobject, _compat.Group):
+            raise NotImplementedError(
+                "Blink(Group/VGroup) requires retained family opacity semantics and remains partial"
+            )
+        if not isinstance(mobject, _base.Mobject):
+            raise TypeError("Blink target must be a Mobject")
+        if isinstance(blinks, bool) or not isinstance(blinks, int):
+            raise TypeError("Blink blinks must be an integer")
+        if blinks <= 0:
+            raise NotImplementedError("Blink currently supports a positive blink count")
+        if "lag_ratio" in kwargs and float(kwargs["lag_ratio"]) != 1.0:
+            raise NotImplementedError(
+                "Blink currently requires Manim Succession's canonical lag_ratio=1"
+            )
+
+        on = _positive_phase_time(time_on)
+        off = _positive_phase_time(time_off)
+        self.mobject = mobject
+        self.time_on = on
+        self.time_off = off
+        self.blinks = blinks
+        self.hide_at_end = bool(hide_at_end)
+
+        phases: list[object] = []
+        for _ in range(blinks):
+            phases.append(_BlinkOpacityPhase(mobject, 1.0, on))
+            phases.append(_BlinkOpacityPhase(mobject, 0.0, off))
+        if not self.hide_at_end:
+            phases.append(_BlinkOpacityPhase(mobject, 1.0, on))
+
+        super().__init__(*phases, **kwargs)
+
+
+def _opacity_snapshot(snapshot: dict[str, Any], opacity: float) -> dict[str, Any]:
+    target = copy.deepcopy(snapshot)
+    for channel in ("fill", "stroke"):
+        value = target["style"][channel]
+        if value is not None:
+            value["alpha"] = opacity
+    return target
+
+
+def _schedule_blink_phase(
+    scene: _compat.Scene,
+    animation: _BlinkOpacityPhase,
+    *,
+    start_time: float,
+    run_time: float,
+) -> None:
+    start = float(start_time)
+    duration = _positive_phase_time(run_time)
+    if not math.isfinite(start) or start < 0.0:
+        raise ValueError("Blink start_time must be finite and non-negative")
+
+    _animate._bind_for_animation(scene, animation.mobject, start_time=start)
+    assert animation.mobject._object is not None
+    obj = animation.mobject._object
+
+    previous_end = scene._scheduled_transform_ends.get(obj.id)
+    if previous_end is not None and start < previous_end:
+        raise ValueError(
+            "Blink cannot overlap a generic Transform on the same object in the retained subset"
+        )
+
+    current = scene._snapshot_for_object_at(obj, start)
+    target = _opacity_snapshot(current, animation.opacity)
+    object_key = scene._object_keys[obj.id]
+    state = "on" if animation.opacity > 0.0 else "off"
+    key = f"@blink:{object_key}:{start:g}.{state}"
+
+    # UpdateFromFunc calls set_opacity on every interpolation sample, including the
+    # child's first sample. Author a constant target snapshot rather than an opacity
+    # ramp so the state changes at the exact phase boundary. A full ObjectSnapshot is
+    # used because Manim VMobject.set_opacity writes fill and stroke alpha separately.
+    scene._add_track(
+        obj,
+        "transform",
+        {
+            "object": {
+                "from": copy.deepcopy(target),
+                "to": copy.deepcopy(target),
+            }
+        },
+        start,
+        duration,
+        "linear",
+        key,
+    )
+    scene._scheduled_transform_targets[obj.id] = copy.deepcopy(target)
+    scene._scheduled_transform_ends[obj.id] = start + duration
+
+
+def _composition_play_leaf(
+    scene: _compat.Scene,
+    animation: object,
+    *,
+    start_time: float,
+    run_time: float,
+    time_map_steps: list[dict[str, Any]],
+    pending_time_maps: list[tuple[int, int, list[dict[str, Any]]]],
+) -> None:
+    if not isinstance(animation, _BlinkOpacityPhase):
+        _ORIGINAL_COMPOSITION_PLAY_LEAF(
+            scene,
+            animation,
+            start_time=start_time,
+            run_time=run_time,
+            time_map_steps=time_map_steps,
+            pending_time_maps=pending_time_maps,
+        )
+        return
+
+    track_start = len(scene._tracks)
+    _schedule_blink_phase(
+        scene,
+        animation,
+        start_time=start_time,
+        run_time=run_time,
+    )
+    track_end = len(scene._tracks)
+    if track_end > track_start and _composition._path_requires_time_map(time_map_steps):
+        pending_time_maps.append(
+            (track_start, track_end, copy.deepcopy(time_map_steps))
+        )
+
+
+def _record_composition_wrapper_state(
+    animation: object,
+    states: dict[int, tuple[_base.Mobject, object, object]],
+) -> None:
+    if isinstance(animation, _BlinkOpacityPhase):
+        _animate._record_wrapper_state(animation.mobject, states)
+        return
+    _ORIGINAL_RECORD_COMPOSITION_WRAPPER_STATE(animation, states)
+
+
 def install() -> None:
     global _INSTALLED
     if _INSTALLED:
@@ -297,4 +473,11 @@ def install() -> None:
     _base.Mobject.has_updaters = has_updaters
     _base.Mobject._current_raw = _current_raw
     _base.Mobject._apply = _apply
+
+    _base.Blink = Blink
+    _compat.Blink = Blink
+    if "Blink" not in _base.__all__:
+        _base.__all__.append("Blink")
+    _composition._play_leaf = _composition_play_leaf
+    _composition._record_composition_wrapper_state = _record_composition_wrapper_state
     _INSTALLED = True

--- a/web/python/test_manim_blink_animation.py
+++ b/web/python/test_manim_blink_animation.py
@@ -1,0 +1,306 @@
+import os
+import subprocess
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+
+
+class ManimBlinkAnimationTests(unittest.TestCase):
+    def test_blink_lowers_to_retained_style_phases(self) -> None:
+        python_dir = Path(__file__).resolve().parent
+        env = os.environ.copy()
+        existing_pythonpath = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = (
+            str(python_dir)
+            if not existing_pythonpath
+            else os.pathsep.join((str(python_dir), existing_pythonpath))
+        )
+
+        source = textwrap.dedent(
+            """
+            import json
+            import math
+            import sys
+            import types
+
+            fake_js = types.ModuleType("js")
+
+            class Result:
+                ok = True
+                errorKind = ""
+                message = ""
+
+            class Interval:
+                def __init__(self, start, duration):
+                    self.startTime = start
+                    self.duration = duration
+                    self.endTime = start + duration
+
+            def resolve_animation_options(
+                default_lag_ratio,
+                animation_run_time,
+                animation_rate_func,
+                animation_lag_ratio,
+                path_arc,
+                reverse_rate_function,
+                play_run_time,
+                play_rate_func,
+                play_lag_ratio,
+            ):
+                result = Result()
+                result.runTime = (
+                    play_run_time
+                    if math.isfinite(play_run_time)
+                    else animation_run_time
+                    if math.isfinite(animation_run_time)
+                    else 1.0
+                )
+                result.rateFunc = play_rate_func or animation_rate_func or "smooth"
+                result.lagRatio = (
+                    play_lag_ratio
+                    if math.isfinite(play_lag_ratio)
+                    else animation_lag_ratio
+                    if math.isfinite(animation_lag_ratio)
+                    else default_lag_ratio
+                )
+                result.pathArc = path_arc if math.isfinite(path_arc) else 0.0
+                result.reverseRateFunction = reverse_rate_function == 1
+                return result
+
+            def resolve_composition_schedule(child_run_times_json, lag_ratio, run_time):
+                child_run_times = [float(value) for value in json.loads(child_run_times_json)]
+                starts = []
+                start = 0.0
+                previous = 0.0
+                for index, child_run_time in enumerate(child_run_times):
+                    if index > 0:
+                        start += float(lag_ratio) * previous
+                    starts.append(start)
+                    previous = child_run_time
+                intrinsic = max(
+                    (start + duration for start, duration in zip(starts, child_run_times)),
+                    default=0.0,
+                )
+                requested = float(run_time)
+                scale = requested / intrinsic if math.isfinite(requested) else 1.0
+                result = Result()
+                result.intrinsicRunTime = intrinsic
+                result.runTime = requested if math.isfinite(requested) else intrinsic
+                result.intervals = [
+                    Interval(start * scale, duration * scale)
+                    for start, duration in zip(starts, child_run_times)
+                ]
+                return result
+
+            def resolve_uniform_schedule(child_count, lag_ratio, run_time):
+                result = Result()
+                result.runTime = run_time
+                result.intrinsicRunTime = run_time
+                if child_count <= 0:
+                    result.intervals = []
+                    return result
+                child_duration = run_time / (1.0 + lag_ratio * (child_count - 1))
+                result.intervals = [
+                    Interval(index * lag_ratio * child_duration, child_duration)
+                    for index in range(child_count)
+                ]
+                return result
+
+            def resolve_lifecycle(*args):
+                result = Result()
+                result.bind = False
+                result.showNow = False
+                result.hideNow = False
+                result.showAtStart = False
+                result.hideAtEnd = False
+                return result
+
+            fake_js.noonResolveAnimationOptions = resolve_animation_options
+            fake_js.noonResolveCompositionSchedule = resolve_composition_schedule
+            fake_js.noonResolveUniformCompositionSchedule = resolve_uniform_schedule
+            fake_js.noonResolveLifecyclePlan = resolve_lifecycle
+            fake_js.noonValidatePresenceTransition = resolve_lifecycle
+            sys.modules["js"] = fake_js
+
+            import _manim_compat
+            _manim_compat.install()
+            import _manim_rate_functions
+            _manim_rate_functions.install()
+            import _manim_phase_b  # noqa: F401
+            import _manim_animate  # noqa: F401
+            import _manim_composition
+            _manim_composition.install()
+            import _manim_updaters
+            _manim_updaters.install()
+
+            from noon import BLUE, WHITE, Blink, Scene, Square, VGroup
+
+            def phase_alphas(track):
+                source = track["values"]["object"]["from"]
+                target = track["values"]["object"]["to"]
+                assert source == target
+                return (
+                    target["style"]["fill"]["alpha"],
+                    target["style"]["stroke"]["alpha"],
+                )
+
+            scene = Scene()
+            square = Square(
+                side_length=1.5,
+                fill_color=BLUE,
+                fill_opacity=0.35,
+                stroke_color=WHITE,
+                stroke_opacity=0.65,
+                stroke_width=4,
+            )
+            scene.add(square)
+            blink = Blink(square)
+            assert blink.time_on == 0.5
+            assert blink.time_off == 0.5
+            assert blink.blinks == 1
+            assert blink.hide_at_end is False
+            assert len(blink.animations) == 3
+
+            scene.play(blink)
+            assert abs(scene.time - 1.5) < 1e-12
+            tracks = [
+                track for track in scene.to_document()["tracks"]
+                if track["object"] == square.id and track["property"] == "transform"
+            ]
+            assert len(tracks) == 3
+            assert [track["timing"] for track in tracks] == [
+                {"start_time": 0.0, "duration": 0.5, "easing": "linear"},
+                {"start_time": 0.5, "duration": 0.5, "easing": "linear"},
+                {"start_time": 1.0, "duration": 0.5, "easing": "linear"},
+            ]
+            assert [phase_alphas(track) for track in tracks] == [
+                (1.0, 1.0),
+                (0.0, 0.0),
+                (1.0, 1.0),
+            ]
+            assert _manim_updaters.register_scene(scene) is None
+
+            # A following retained animation starts from the exact final Blink state.
+            scene.play(square.animate.shift((1.0, 0.0)))
+            following = [
+                track for track in scene.to_document()["tracks"]
+                if track["object"] == square.id
+                and track["property"] == "transform"
+                and abs(track["timing"]["start_time"] - 1.5) < 1e-12
+            ]
+            assert len(following) == 1
+            following_source = following[0]["values"]["object"]["from"]
+            assert following_source["style"]["fill"]["alpha"] == 1.0
+            assert following_source["style"]["stroke"]["alpha"] == 1.0
+
+            hidden_scene = Scene()
+            hidden = Square(
+                fill_color=BLUE,
+                fill_opacity=1.0,
+                stroke_color=WHITE,
+                stroke_opacity=1.0,
+            )
+            hidden_scene.add(hidden)
+            hidden_scene.play(
+                Blink(
+                    hidden,
+                    time_on=0.25,
+                    time_off=0.75,
+                    blinks=2,
+                    hide_at_end=True,
+                )
+            )
+            assert abs(hidden_scene.time - 2.0) < 1e-12
+            hidden_tracks = [
+                track for track in hidden_scene.to_document()["tracks"]
+                if track["object"] == hidden.id and track["property"] == "transform"
+            ]
+            assert len(hidden_tracks) == 4
+            assert [track["timing"]["start_time"] for track in hidden_tracks] == [
+                0.0,
+                0.25,
+                1.0,
+                1.25,
+            ]
+            assert [track["timing"]["duration"] for track in hidden_tracks] == [
+                0.25,
+                0.75,
+                0.25,
+                0.75,
+            ]
+            assert phase_alphas(hidden_tracks[-1]) == (0.0, 0.0)
+
+            # Scene.play(run_time=...) scales the complete Succession exactly.
+            scaled_scene = Scene()
+            scaled = Square(fill_color=BLUE, fill_opacity=1.0, stroke_opacity=0.0)
+            scaled_scene.add(scaled)
+            scaled_scene.play(
+                Blink(scaled, time_on=0.25, time_off=0.75),
+                run_time=2.5,
+            )
+            assert abs(scaled_scene.time - 2.5) < 1e-12
+            scaled_tracks = [
+                track for track in scaled_scene.to_document()["tracks"]
+                if track["object"] == scaled.id and track["property"] == "transform"
+            ]
+            # Intrinsic runtime is 1.25, so the play override scales every phase by 2.
+            assert [track["timing"]["start_time"] for track in scaled_tracks] == [
+                0.0,
+                0.5,
+                2.0,
+            ]
+            assert [track["timing"]["duration"] for track in scaled_tracks] == [
+                0.5,
+                1.5,
+                0.5,
+            ]
+
+            try:
+                Blink(VGroup(Square(), Square()))
+            except NotImplementedError:
+                pass
+            else:
+                raise AssertionError("Blink retained groups must remain explicitly partial")
+
+            for bad_time in (0.0, -1.0, float("inf")):
+                try:
+                    Blink(Square(), time_on=bad_time)
+                except ValueError:
+                    pass
+                else:
+                    raise AssertionError("Blink must reject invalid phase durations")
+
+            try:
+                Blink(Square(), blinks=0)
+            except NotImplementedError:
+                pass
+            else:
+                raise AssertionError("zero-blink edge semantics remain outside the retained subset")
+
+            try:
+                Blink(Square(), lag_ratio=0.5)
+            except NotImplementedError:
+                pass
+            else:
+                raise AssertionError("overlapping Blink phases must not be approximated")
+            """
+        )
+
+        completed = subprocess.run(
+            [sys.executable, "-c", source],
+            cwd=python_dir,
+            env=env,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            completed.returncode,
+            0,
+            msg=f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/python/test_manim_blink_animation.py
+++ b/web/python/test_manim_blink_animation.py
@@ -263,6 +263,15 @@ class ManimBlinkAnimationTests(unittest.TestCase):
             else:
                 raise AssertionError("Blink retained groups must remain explicitly partial")
 
+            updater_target = Square()
+            updater_target.add_updater(lambda mob: mob)
+            try:
+                Blink(updater_target)
+            except NotImplementedError:
+                pass
+            else:
+                raise AssertionError("Blink with user updaters must remain explicitly partial")
+
             for bad_time in (0.0, -1.0, float("inf")):
                 try:
                     Blink(Square(), time_on=bad_time)


### PR DESCRIPTION
Tracks #81.

## Scope
- adds ManimCE v0.21 `Blink` for one leaf 2D `VMobject`
- mirrors upstream `Blink(Succession)` phase structure: opacity-on `UpdateFromFunc`, opacity-off `UpdateFromFunc`, repeated `blinks` times, plus the final on phase unless `hide_at_end=True`
- lowers those deterministic callbacks to constant retained ObjectSnapshot tracks, so fill/stroke alpha switches at the exact child boundary without waking Python during playback
- reuses Noon's shared composition scheduler for intrinsic timing, `run_time` scaling, outer rate functions, nested composition time maps, seek/rewind, and exact final-state selection
- keeps arbitrary user updaters on the existing host-callback path; Blink itself does not create a callback session
- adds a focused CPython regression covering defaults, phase timings, fill/stroke alpha, final state handoff, `hide_at_end`, multiple blinks, play-level runtime scaling, and unsupported boundaries

## Exact retained subset
- one leaf 2D `VMobject`
- positive finite `time_on` / `time_off`
- positive integer `blinks`
- canonical Succession ordering (`lag_ratio=1`)
- no concurrent user mobject updater on the Blink target
- no same-object overlap with another generic Transform

Group/VGroup family opacity, zero-duration/count edge cases, updater-order interactions, and overlapping same-object generic transforms remain explicitly partial rather than approximated.

## Architecture
Manim implements Blink through `UpdateFromFunc`, but the callback ignores alpha and only calls `set_opacity(1/0)`. Noon therefore does not route Blink through the host callback protocol. Each child is represented by a constant retained full-style snapshot because Manim `VMobject.set_opacity` writes fill and stroke alpha independently.

Mapped composition is safe: runtime selection ignores mapped tracks whose child interval has not begun and chooses the latest begun phase; at the exact root endpoint Noon settles to the final authored target, matching Blink cleanup state.

## Qualification / gallery
The branch is based on current master and intentionally does not touch shared parity manifests while several transform-family parity branches are active. After implementation CI is green, attach a canonical source-equivalent geometry fixture to #176/#185 with unchanged tolerances. Do not classify Blink as parity-qualified until semantic, Cairo raster/timeline, direct-seek/incremental-playback, WebGPU, and WebGL gates pass.

No public gallery entry is added here because #273 requires a ready entry to be literal checked-in upstream Manim source with import-only substitution; the public Blink documentation example depends on currently unsupported exact text coverage.