### PR TITLE
Add play-time Manim FadeToColor wrapper

### DIFF
--- a/web/python/_manim_animation_options.py
+++ b/web/python/_manim_animation_options.py
@@ -104,6 +104,21 @@ def resolve(
     )
 
 
+def _play_begin_target(
+    source: _base.Mobject,
+    *,
+    animate_module: Any,
+) -> _base.Mobject:
+    """Copy the retained mobject state visible when ``Scene.play`` begins."""
+
+    scene = source._scene
+    obj = source._object
+    if scene is not None and obj is not None:
+        snapshot = scene._snapshot_for_object_at(obj, scene._cursor)
+        return animate_module._snapshot_mobject(snapshot)
+    return source.copy()
+
+
 def _scale_in_place_builder(
     mobject: object,
     scale_factor: float,
@@ -151,19 +166,7 @@ def _scale_in_place_builder(
 
         @property
         def target(self) -> _base.Mobject:
-            source = self.source
-            scene = source._scene
-            obj = source._object
-            if scene is not None and obj is not None:
-                # _aligned_scene_play binds method-animation sources before expanding
-                # them. The cursor is therefore the Manim-compatible play-begin time and
-                # the retained snapshot includes all earlier authored animations.
-                snapshot = scene._snapshot_for_object_at(obj, scene._cursor)
-                target = _animate._snapshot_mobject(snapshot)
-            else:
-                # This fallback is mainly useful for introspection outside Scene.play;
-                # normal scheduling reaches the bound retained-snapshot branch above.
-                target = source.copy()
+            target = _play_begin_target(self.source, animate_module=_animate)
             target.scale(self.scale_factor)
             return target
 
@@ -182,9 +185,47 @@ def ShrinkToCenter(mobject: object, **kwargs: Any) -> object:
     return _scale_in_place_builder(mobject, 0.0, kwargs)
 
 
+def FadeToColor(mobject: object, color: object, **kwargs: Any) -> object:
+    """Animate one 2D leaf to ``color`` through a play-begin ApplyMethod target.
+
+    ManimCE v0.21 defines ``FadeToColor`` as
+    ``ApplyMethod(mobject.set_color, color, **kwargs)``. Its target copy is created from
+    the mobject in ``Transform.begin()``, so style/transform mutations that happen after
+    animation construction must be visible. Noon reconstructs that play-begin retained
+    snapshot, applies ``set_color`` to the detached copy, then uses the ordinary retained
+    Transform path for interpolation and deterministic seek.
+    """
+
+    if isinstance(mobject, _compat.Group):
+        raise NotImplementedError(
+            "FadeToColor Group/VGroup family recoloring is not yet supported"
+        )
+    if not isinstance(mobject, _base.Mobject):
+        raise TypeError("FadeToColor target must be a Mobject")
+
+    import _manim_animate as _animate
+
+    class _DeferredFadeToColorBuilder(_animate._AlignedAnimationBuilder):
+        def __init__(self) -> None:
+            self.source = mobject
+            self.mobject = mobject
+            self.anim_args = dict(kwargs)
+            self.cannot_pass_args = True
+            self.is_chaining = False
+
+        @property
+        def target(self) -> _base.Mobject:
+            target = _play_begin_target(self.source, animate_module=_animate)
+            target.set_color(color)
+            return target
+
+    return _DeferredFadeToColorBuilder()
+
+
 public = {
     "ScaleInPlace": ScaleInPlace,
     "ShrinkToCenter": ShrinkToCenter,
+    "FadeToColor": FadeToColor,
 }
 for _name, _value in public.items():
     setattr(_base, _name, _value)

--- a/web/python/examples/manim_parity_fade_to_color.py
+++ b/web/python/examples/manim_parity_fade_to_color.py
@@ -1,0 +1,18 @@
+# Source-equivalent ManimCE v0.21.0 FadeToColor parity candidate.
+# The upstream reference example uses Text, which is outside Noon's current exact
+# text subset. This geometry scene exercises the same FadeToColor animation API
+# without substituting a Noon-only animation path.
+
+from noon import *
+
+scene = Scene()
+square = Square(
+    side_length=1.5,
+    fill_color=BLUE,
+    fill_opacity=0.35,
+    stroke_color=GREEN,
+    stroke_opacity=0.65,
+    stroke_width=6,
+).shift(1.25 * RIGHT)
+scene.play(FadeToColor(square, RED))
+result = scene

--- a/web/python/test_manim_fade_to_color.py
+++ b/web/python/test_manim_fade_to_color.py
@@ -141,8 +141,9 @@ class ManimFadeToColorTests(unittest.TestCase):
             assert abs(source_state["style"]["stroke"]["alpha"] - 0.25) < 1e-12
             assert abs(target_state["style"]["fill"]["alpha"] - 0.55) < 1e-12
             assert abs(target_state["style"]["stroke"]["alpha"] - 0.25) < 1e-12
-            assert abs(source_state["style"]["stroke_width"] - 7.0) < 1e-12
-            assert abs(target_state["style"]["stroke_width"] - 7.0) < 1e-12
+            # Manim-authored stroke widths are stored in Cairo scene units (7 -> 0.07).
+            assert abs(source_state["style"]["stroke_width"] - 0.07) < 1e-12
+            assert target_state["style"]["stroke_width"] == source_state["style"]["stroke_width"]
 
             try:
                 FadeToColor(VGroup(Square(), Square()), RED)

--- a/web/python/test_manim_fade_to_color.py
+++ b/web/python/test_manim_fade_to_color.py
@@ -1,0 +1,172 @@
+import os
+import subprocess
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+
+
+class ManimFadeToColorTests(unittest.TestCase):
+    def test_fade_to_color_uses_retained_target_state_style_transform(self) -> None:
+        python_dir = Path(__file__).resolve().parent
+        env = os.environ.copy()
+        existing_pythonpath = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = (
+            str(python_dir)
+            if not existing_pythonpath
+            else os.pathsep.join((str(python_dir), existing_pythonpath))
+        )
+
+        source = textwrap.dedent(
+            """
+            import math
+            import sys
+            import types
+
+            fake_js = types.ModuleType("js")
+
+            class Result:
+                ok = True
+                errorKind = ""
+                message = ""
+
+            def resolve_animation_options(
+                default_lag_ratio,
+                animation_run_time,
+                animation_rate_func,
+                animation_lag_ratio,
+                path_arc,
+                reverse_rate_function,
+                play_run_time,
+                play_rate_func,
+                play_lag_ratio,
+            ):
+                result = Result()
+                result.runTime = (
+                    play_run_time
+                    if math.isfinite(play_run_time)
+                    else animation_run_time
+                    if math.isfinite(animation_run_time)
+                    else 1.0
+                )
+                result.rateFunc = play_rate_func or animation_rate_func or "smooth"
+                result.lagRatio = (
+                    play_lag_ratio
+                    if math.isfinite(play_lag_ratio)
+                    else animation_lag_ratio
+                    if math.isfinite(animation_lag_ratio)
+                    else default_lag_ratio
+                )
+                result.pathArc = path_arc if math.isfinite(path_arc) else 0.0
+                result.reverseRateFunction = reverse_rate_function == 1
+                return result
+
+            def resolve_uniform_schedule(child_count, lag_ratio, run_time):
+                result = Result()
+                result.intervals = []
+                return result
+
+            fake_js.noonResolveAnimationOptions = resolve_animation_options
+            fake_js.noonResolveUniformCompositionSchedule = resolve_uniform_schedule
+            sys.modules["js"] = fake_js
+
+            import _manim_compat
+            _manim_compat.install()
+            import _manim_rate_functions
+            _manim_rate_functions.install()
+            import _manim_phase_b  # noqa: F401
+            import _manim_animate  # noqa: F401
+
+            from noon import (
+                BLUE,
+                GREEN,
+                RED,
+                FadeToColor,
+                Scene,
+                Square,
+                VGroup,
+                linear,
+            )
+
+            scene = Scene()
+            square = Square(
+                side_length=1.4,
+                fill_color=BLUE,
+                fill_opacity=0.35,
+                stroke_color=GREEN,
+                stroke_opacity=0.65,
+                stroke_width=6,
+            ).shift((1.25, -0.5)).rotate(0.2)
+
+            animation = FadeToColor(square, RED, run_time=2.0, rate_func=linear)
+            assert animation.source is square
+            assert animation.anim_args["run_time"] == 2.0
+            assert animation.anim_args["rate_func"] is linear
+
+            # FadeToColor is ApplyMethod(mobject.set_color, ...), whose target is copied
+            # in Transform.begin(). Later mutations must therefore supply the source
+            # alpha/transform state while only color channels change in the target.
+            square.set_fill(BLUE, opacity=0.55)
+            square.set_stroke(GREEN, opacity=0.25, width=7)
+            square.shift((0.5, 0.25))
+
+            scene.play(animation)
+            assert abs(scene.time - 2.0) < 1e-12
+            assert square._scene is scene
+
+            tracks = [
+                track
+                for track in scene.to_document()["tracks"]
+                if track["object"] == square.id and track["property"] == "transform"
+            ]
+            assert len(tracks) == 1
+            track = tracks[0]
+            assert track["timing"] == {
+                "start_time": 0.0,
+                "duration": 2.0,
+                "easing": "linear",
+            }
+
+            source_state = track["values"]["object"]["from"]
+            target_state = track["values"]["object"]["to"]
+            assert source_state["transform"]["translation"] == {"x": 1.75, "y": -0.25}
+            assert target_state["transform"] == source_state["transform"]
+            assert target_state["style"]["fill"]["red"] == RED.red
+            assert target_state["style"]["fill"]["green"] == RED.green
+            assert target_state["style"]["fill"]["blue"] == RED.blue
+            assert target_state["style"]["stroke"]["red"] == RED.red
+            assert target_state["style"]["stroke"]["green"] == RED.green
+            assert target_state["style"]["stroke"]["blue"] == RED.blue
+            assert abs(source_state["style"]["fill"]["alpha"] - 0.55) < 1e-12
+            assert abs(source_state["style"]["stroke"]["alpha"] - 0.25) < 1e-12
+            assert abs(target_state["style"]["fill"]["alpha"] - 0.55) < 1e-12
+            assert abs(target_state["style"]["stroke"]["alpha"] - 0.25) < 1e-12
+            assert abs(source_state["style"]["stroke_width"] - 7.0) < 1e-12
+            assert abs(target_state["style"]["stroke_width"] - 7.0) < 1e-12
+
+            try:
+                FadeToColor(VGroup(Square(), Square()), RED)
+            except NotImplementedError:
+                pass
+            else:
+                raise AssertionError("retained family FadeToColor must stay explicit")
+            """
+        )
+
+        completed = subprocess.run(
+            [sys.executable, "-c", source],
+            cwd=python_dir,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(
+            completed.returncode,
+            0,
+            msg=f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Tracks #82 and #185. Cleanly restacked on `master` after #269 merged.

## Scope
- adds ManimCE v0.21 `FadeToColor` for one 2D leaf mobject
- matches upstream `ApplyMethod(mobject.set_color, color)` lifecycle: target state is copied when `Scene.play` begins, not when the animation object is constructed
- factors the already-qualified play-begin target snapshot logic from `ScaleInPlace` / `ShrinkToCenter` into a shared adapter helper and reuses it here
- preserves fill/stroke alpha, stroke width, transform state, timing options, implicit binding, rollback, and deterministic seek
- rejects Group/VGroup family recoloring instead of approximating family alignment
- regression mutates opacity, stroke width, and position after `FadeToColor(...)` construction and verifies those late values are preserved in both source and target while only color changes

## Qualification boundary
The public Manim docs example uses `Text`, which is outside Noon's current exact text subset, so this is a deterministic geometry/internal parity slice rather than a `parity-qualified` public-doc example. No tolerance changes and no new renderer/scheduler primitive are introduced. Keep `FadeToColor` partial until a literal upstream source fixture can pass the full #176/#185 exact-output gate.