### PR TITLE
Align playground gallery smoke with exact-source policy

### DIFF
--- a/scripts/playground-layout-smoke.mjs
+++ b/scripts/playground-layout-smoke.mjs
@@ -150,9 +150,14 @@ try {
     href: location.href,
   }));
   assert.ok(galleryContract.cards > 0, "gallery must render ready Manim parity examples");
-  assert.ok(
+  assert.equal(
     galleryContract.exampleIds.includes("parity-focus-on-point"),
-    "gallery must expose the FocusOn parity example added by this slice",
+    false,
+    "Noon-specific FocusOn probe must stay out of the public exact-source gallery",
+  );
+  assert.ok(
+    galleryContract.exampleIds.includes("parity-draw-border-then-fill-styled-square"),
+    "gallery must retain literal upstream parity-qualified examples",
   );
   assert.equal(galleryContract.canvases, 1, "thumbnail gallery must keep exactly one live canvas");
   assert.equal(galleryContract.selected, "parity-square-and-circle");


### PR DESCRIPTION
Fix the remaining stale gallery assertion after #273/#284.

`scripts/playground-layout-smoke.mjs` still required the Noon-specific `parity-focus-on-point` probe to appear in the public gallery, even though #273 intentionally demoted custom probes and #284 updated the primary gallery/Python contract tests to enforce literal upstream-source exposure.

This PR updates the browser layout smoke to:
- require the internal FocusOn probe to stay out of the public gallery
- require the literal upstream, parity-qualified DrawBorderThenFill example to remain visible

No runtime, renderer, parity tolerance, manifest, or authoring behavior changes. This directly addresses the sole failing CI job currently observed on #269.