### PR TITLE
[Arch] Support reactive values and geometry in host updaters

### DIFF
--- a/crates/noon-compile/src/lib.rs
+++ b/crates/noon-compile/src/lib.rs
@@ -547,7 +547,9 @@ impl CompiledScene {
                         .ok_or(CompilePatchError::UnknownObject(*id))?;
                     tracks.retain(|track| track.object_index != object_index);
                 }
-                ScenePatch::SetTransform { object, .. } | ScenePatch::SetStyle { object, .. } => {
+                ScenePatch::SetGeometry { object, .. }
+                | ScenePatch::SetTransform { object, .. }
+                | ScenePatch::SetStyle { object, .. } => {
                     if !object_indices.contains_key(object) {
                         return Err(CompilePatchError::UnknownObject(*object));
                     }
@@ -661,6 +663,12 @@ impl CompiledScene {
                 stats.object_indices_rewritten = 0;
                 stats.track_object_indices_rewritten = 0;
                 stats.unrelated_track_slots_shifted = 0;
+            }
+            ScenePatch::SetGeometry { object, geometry } => {
+                let index = self
+                    .object_index(*object)
+                    .ok_or(CompilePatchError::UnknownObject(*object))?;
+                self.objects[index as usize].geometry = geometry.clone();
             }
             ScenePatch::SetTransform { object, transform } => {
                 let index = self

--- a/crates/noon-core/src/patch.rs
+++ b/crates/noon-core/src/patch.rs
@@ -2,8 +2,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
 use crate::{
-    validate_track_definition, ObjectDefinition, ObjectId, SceneDefinition, Style, TimelineError,
-    TrackDefinition, TrackId, Transform2D,
+    validate_track_definition, GeometryRef, ObjectDefinition, ObjectId, SceneDefinition, Style,
+    TimelineError, TrackDefinition, TrackId, Transform2D,
 };
 
 mod transaction_preflight;
@@ -28,6 +28,10 @@ pub enum MutationImpact {
 pub enum ScenePatch {
     CreateObject(ObjectDefinition),
     RemoveObject(ObjectId),
+    SetGeometry {
+        object: ObjectId,
+        geometry: GeometryRef,
+    },
     SetTransform {
         object: ObjectId,
         transform: Transform2D,
@@ -44,7 +48,9 @@ pub enum ScenePatch {
 impl ScenePatch {
     pub const fn impact(&self) -> MutationImpact {
         match self {
-            Self::SetTransform { .. } | Self::SetStyle { .. } => MutationImpact::Property,
+            Self::SetGeometry { .. } | Self::SetTransform { .. } | Self::SetStyle { .. } => {
+                MutationImpact::Property
+            }
             Self::AddTrack(_) | Self::ReplaceTrack(_) | Self::RemoveTrack(_) => {
                 MutationImpact::Timeline
             }
@@ -167,6 +173,12 @@ impl SceneDefinition {
         match patch {
             ScenePatch::CreateObject(object) => self.insert_object(object),
             ScenePatch::RemoveObject(id) => self.remove_object(id),
+            ScenePatch::SetGeometry { object, geometry } => {
+                self.object_mut(object)
+                    .ok_or(PatchError::UnknownObject(object))?
+                    .geometry = geometry;
+                Ok(())
+            }
             ScenePatch::SetTransform { object, transform } => {
                 self.object_mut(object)
                     .ok_or(PatchError::UnknownObject(object))?
@@ -197,7 +209,8 @@ impl SceneDefinition {
         if transaction.impact() == Some(MutationImpact::Property) {
             for mutation in transaction.mutations() {
                 let object = match mutation {
-                    ScenePatch::SetTransform { object, .. }
+                    ScenePatch::SetGeometry { object, .. }
+                    | ScenePatch::SetTransform { object, .. }
                     | ScenePatch::SetStyle { object, .. } => *object,
                     _ => unreachable!("property transaction contains only property mutations"),
                 };
@@ -326,6 +339,14 @@ mod tests {
             ScenePatch::SetTransform {
                 object,
                 transform: Transform2D::IDENTITY,
+            }
+            .impact(),
+            MutationImpact::Property
+        );
+        assert_eq!(
+            ScenePatch::SetGeometry {
+                object,
+                geometry: GeometryRef::line(Vec2::ZERO, Vec2::ONE),
             }
             .impact(),
             MutationImpact::Property

--- a/crates/noon-core/src/patch/transaction_preflight.rs
+++ b/crates/noon-core/src/patch/transaction_preflight.rs
@@ -52,7 +52,9 @@ pub fn preflight_transaction(
                 }
                 tracks.retain(|_, object| object != id);
             }
-            ScenePatch::SetTransform { object, .. } | ScenePatch::SetStyle { object, .. } => {
+            ScenePatch::SetGeometry { object, .. }
+            | ScenePatch::SetTransform { object, .. }
+            | ScenePatch::SetStyle { object, .. } => {
                 if !objects.contains(object) {
                     return Err(PatchError::UnknownObject(*object));
                 }

--- a/crates/noon-runtime/src/execution_slots.rs
+++ b/crates/noon-runtime/src/execution_slots.rs
@@ -729,7 +729,9 @@ impl SlottedSceneInstance {
                     ..ExecutionEffects::default()
                 };
             }
-            ScenePatch::SetTransform { object, .. } | ScenePatch::SetStyle { object, .. } => {
+            ScenePatch::SetGeometry { object, .. }
+            | ScenePatch::SetTransform { object, .. }
+            | ScenePatch::SetStyle { object, .. } => {
                 let slot = self
                     .slots
                     .slot_for_object(*object)
@@ -825,6 +827,7 @@ impl SlottedSceneInstance {
         let mut context = PatchContext::default();
         match patch {
             ScenePatch::RemoveObject(object)
+            | ScenePatch::SetGeometry { object, .. }
             | ScenePatch::SetTransform { object, .. }
             | ScenePatch::SetStyle { object, .. } => {
                 context.primary_slot = self.slots.slot_for_object(*object);

--- a/crates/noon-runtime/src/lib.rs
+++ b/crates/noon-runtime/src/lib.rs
@@ -352,7 +352,9 @@ impl SceneInstance {
         self.last_patch_stats = RuntimePatchStats::default();
         if matches!(
             patch,
-            ScenePatch::SetTransform { .. } | ScenePatch::SetStyle { .. }
+            ScenePatch::SetGeometry { .. }
+                | ScenePatch::SetTransform { .. }
+                | ScenePatch::SetStyle { .. }
         ) {
             self.apply_value_patch(patch)?;
             return Ok(&self.frame);
@@ -497,10 +499,10 @@ impl SceneInstance {
 
     fn apply_value_patch(&mut self, patch: &ScenePatch) -> Result<(), CompilePatchError> {
         let object = match patch {
-            ScenePatch::SetTransform { object, .. } | ScenePatch::SetStyle { object, .. } => {
-                *object
-            }
-            _ => unreachable!("value patch helper only accepts transform or style patches"),
+            ScenePatch::SetGeometry { object, .. }
+            | ScenePatch::SetTransform { object, .. }
+            | ScenePatch::SetStyle { object, .. } => *object,
+            _ => unreachable!("value patch helper only accepts object-local property patches"),
         };
         let index = self
             .compiled
@@ -510,6 +512,13 @@ impl SceneInstance {
         self.compiled.apply_patch(patch)?;
 
         match patch {
+            ScenePatch::SetGeometry { geometry, .. } => {
+                self.frame.objects[index].geometry = geometry.clone();
+                // Host callbacks run after ordinary timeline/reactive evaluation for the frame.
+                // Clearing a transient render override makes the callback geometry authoritative
+                // for this phase without rebuilding unrelated runtime slots.
+                self.frame.render_geometries[index] = None;
+            }
             ScenePatch::SetTransform { transform, .. } => {
                 self.frame.objects[index].transform = *transform;
                 self.reapply_properties(
@@ -521,7 +530,7 @@ impl SceneInstance {
                 self.frame.objects[index].style = *style;
                 self.reapply_properties(index, &[Property::Transform, Property::Opacity]);
             }
-            _ => unreachable!("value patch helper only accepts transform or style patches"),
+            _ => unreachable!("value patch helper only accepts object-local property patches"),
         }
         self.reapply_reactive_for_object(index);
         if self.frame.objects[index] != before {

--- a/crates/noon-runtime/src/reactive/host_callbacks.rs
+++ b/crates/noon-runtime/src/reactive/host_callbacks.rs
@@ -3,10 +3,10 @@ use std::collections::BTreeMap;
 use noon_compile::CompilePatchError;
 use noon_core::{
     HostCallbackId, HostCallbackRegistry, MutationImpact, MutationTransaction, ObjectId,
-    ScenePatch, Style, Transform2D,
+    ReactiveValue, ScenePatch, SignalId, Style, Transform2D,
 };
 
-use crate::{EvaluationError, FrameState, SceneInstance};
+use crate::{FrameState, SceneInstance, TimedSceneInstance, TimedSceneRuntimeError};
 
 /// Dynamic object state captured once for one host callback phase.
 ///
@@ -106,7 +106,7 @@ impl From<CompilePatchError> for HostCommitError {
 
 #[derive(Clone, Debug)]
 pub struct HostDrivenScene {
-    scene: SceneInstance,
+    scene: TimedSceneInstance,
     watched_dense_indices: Vec<usize>,
     invocations: Vec<HostCallbackInvocation>,
     last_callback_time: f64,
@@ -116,6 +116,13 @@ pub struct HostDrivenScene {
 impl HostDrivenScene {
     pub fn new(
         scene: SceneInstance,
+        registry: &HostCallbackRegistry,
+    ) -> Result<Self, HostCallbackAttachError> {
+        Self::from_timed(TimedSceneInstance::from_scene_instance(scene), registry)
+    }
+
+    pub fn from_timed(
+        scene: TimedSceneInstance,
         registry: &HostCallbackRegistry,
     ) -> Result<Self, HostCallbackAttachError> {
         let dense_index_by_object = scene
@@ -167,26 +174,30 @@ impl HostDrivenScene {
     }
 
     pub fn scene(&self) -> &SceneInstance {
-        &self.scene
+        self.scene.scene()
     }
 
     pub fn scene_mut(&mut self) -> &mut SceneInstance {
-        &mut self.scene
+        self.scene.scene_mut()
+    }
+
+    pub fn reactive_value(&self, signal: SignalId) -> Option<&ReactiveValue> {
+        self.scene.reactive_value(signal)
     }
 
     pub const fn last_commit_stats(&self) -> HostCommitStats {
         self.last_commit_stats
     }
 
-    pub fn evaluate(&mut self, time: f64) -> Result<&FrameState, EvaluationError> {
+    pub fn evaluate(&mut self, time: f64) -> Result<&FrameState, TimedSceneRuntimeError> {
         self.scene.evaluate(time)
     }
 
-    pub fn seek(&mut self, time: f64) -> Result<&FrameState, EvaluationError> {
+    pub fn seek(&mut self, time: f64) -> Result<&FrameState, TimedSceneRuntimeError> {
         self.scene.seek(time)
     }
 
-    pub fn advance_to(&mut self, time: f64) -> Result<&FrameState, EvaluationError> {
+    pub fn advance_to(&mut self, time: f64) -> Result<&FrameState, TimedSceneRuntimeError> {
         self.scene.advance_to(time)
     }
 
@@ -243,11 +254,12 @@ impl HostDrivenScene {
         if impact == Some(MutationImpact::Property) {
             for patch in transaction.mutations() {
                 let object = match patch {
-                    ScenePatch::SetTransform { object, .. }
+                    ScenePatch::SetGeometry { object, .. }
+                    | ScenePatch::SetTransform { object, .. }
                     | ScenePatch::SetStyle { object, .. } => *object,
                     _ => unreachable!("property-impact transaction must contain property patches"),
                 };
-                if !self.scene.contains_object(object) {
+                if !self.scene.scene().contains_object(object) {
                     return Err(HostCommitError::Patch(CompilePatchError::UnknownObject(
                         object,
                     )));
@@ -255,6 +267,7 @@ impl HostDrivenScene {
             }
             for patch in transaction.mutations() {
                 self.scene
+                    .scene_mut()
                     .apply_patch(patch)
                     .expect("property callback transaction was preflighted");
             }
@@ -266,17 +279,17 @@ impl HostDrivenScene {
             return Ok(self.scene.frame());
         }
 
-        if self.scene.reactive.is_some() {
+        if self.scene.scene().reactive.is_some() {
             return Err(HostCommitError::ReactiveReloweringRequired(
                 impact.expect("non-empty transaction has impact"),
             ));
         }
 
-        let mut staged = self.scene.clone();
+        let mut staged = self.scene.scene().clone();
         for patch in transaction.mutations() {
             staged.apply_patch(patch)?;
         }
-        self.scene = staged;
+        self.scene = TimedSceneInstance::from_scene_instance(staged);
         self.last_commit_stats = HostCommitStats {
             mutations: transaction.mutations().len(),
             impact,
@@ -396,6 +409,36 @@ mod tests {
         ]);
         assert!(driven.commit(&invalid).is_err());
         assert_eq!(driven.scene().frame(), &before);
+    }
+
+    #[test]
+    fn timed_host_scene_exposes_evaluated_signal_values() {
+        let mut semantic = SemanticScene::new();
+        let object = semantic.add(GeometryRef::circle(0.5));
+        let tracker = semantic.add_input(0.0_f32);
+        semantic.bind(tracker, object, noon_core::Property::Rotation);
+        let mut timeline = noon_core::SignalTimelineDefinition::new();
+        timeline
+            .add_scalar_track(
+                semantic.reactive(),
+                tracker,
+                0.0,
+                4.0,
+                noon_core::TrackTiming::new(0.0, 2.0, noon_core::RateFunction::Linear),
+            )
+            .unwrap();
+        let timed = noon_core::TimedSemanticScene::from_parts(semantic, timeline).unwrap();
+        let instance = TimedSceneInstance::from_timed(&timed).unwrap();
+        let mut registry = HostCallbackRegistry::new();
+        registry.register([object]);
+        let mut driven = HostDrivenScene::from_timed(instance, &registry).unwrap();
+
+        driven.advance_to(1.0).unwrap();
+        assert_eq!(
+            driven.reactive_value(tracker),
+            Some(&ReactiveValue::Scalar(2.0))
+        );
+        assert_eq!(driven.callback_frame().objects[0].transform.rotation, 2.0);
     }
 
     #[test]

--- a/crates/noon-runtime/src/reactive/signal_timeline.rs
+++ b/crates/noon-runtime/src/reactive/signal_timeline.rs
@@ -72,6 +72,22 @@ pub struct TimedSceneInstance {
 }
 
 impl TimedSceneInstance {
+    pub fn from_scene_instance(inner: SceneInstance) -> Self {
+        Self {
+            inner,
+            timeline: SignalTimelineDefinition::new(),
+            groups: Vec::new(),
+        }
+    }
+
+    pub fn scene(&self) -> &SceneInstance {
+        &self.inner
+    }
+
+    pub fn scene_mut(&mut self) -> &mut SceneInstance {
+        &mut self.inner
+    }
+
     pub fn from_timed(scene: &TimedSemanticScene) -> Result<Self, TimedSceneRuntimeError> {
         let inner = SceneInstance::from_semantic(scene.semantic())?;
         let timeline = SignalTimelineDefinition::from_parts(

--- a/crates/noon-web/src/host_player.rs
+++ b/crates/noon-web/src/host_player.rs
@@ -1,21 +1,21 @@
-use noon_compile::{CompileError, CompiledScene};
 use noon_core::{
     HostCallbackId, HostCallbackRegistry, HostCallbackRegistryError, HostCallbackSlot,
-    MutationTransaction, ObjectId,
+    MutationTransaction, ObjectId, SignalId,
 };
-use noon_ir::{decode_patch_batch, decode_scene, IrError};
+use noon_ir::{decode_patch_batch, decode_timed_semantic_scene, IrError, TimedSemanticIrError};
 use noon_runtime::{
-    EvaluationError, HostCallbackAttachError, HostCommitError, HostDrivenScene, SceneInstance,
+    HostCallbackAttachError, HostCommitError, HostDrivenScene, TimedSceneInstance,
+    TimedSceneRuntimeError,
 };
 use serde_json::{json, Value};
 
 #[derive(Debug)]
 pub enum HostPlayerError {
     Ir(IrError),
-    Compile(CompileError),
+    TimedIr(TimedSemanticIrError),
     Attach(HostCallbackAttachError),
     Registry(HostCallbackRegistryError),
-    Evaluation(EvaluationError),
+    Runtime(TimedSceneRuntimeError),
     Commit(HostCommitError),
     CallbackJson(String),
     Sequence { expected: u64, actual: u64 },
@@ -26,10 +26,10 @@ impl std::fmt::Display for HostPlayerError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Ir(error) => error.fmt(formatter),
-            Self::Compile(error) => error.fmt(formatter),
+            Self::TimedIr(error) => error.fmt(formatter),
             Self::Attach(error) => error.fmt(formatter),
             Self::Registry(error) => error.fmt(formatter),
-            Self::Evaluation(error) => error.fmt(formatter),
+            Self::Runtime(error) => error.fmt(formatter),
             Self::Commit(error) => error.fmt(formatter),
             Self::CallbackJson(message) => formatter.write_str(message),
             Self::Sequence { expected, actual } => {
@@ -53,9 +53,9 @@ impl From<IrError> for HostPlayerError {
     }
 }
 
-impl From<CompileError> for HostPlayerError {
-    fn from(value: CompileError) -> Self {
-        Self::Compile(value)
+impl From<TimedSemanticIrError> for HostPlayerError {
+    fn from(value: TimedSemanticIrError) -> Self {
+        Self::TimedIr(value)
     }
 }
 
@@ -71,9 +71,9 @@ impl From<HostCallbackRegistryError> for HostPlayerError {
     }
 }
 
-impl From<EvaluationError> for HostPlayerError {
-    fn from(value: EvaluationError) -> Self {
-        Self::Evaluation(value)
+impl From<TimedSceneRuntimeError> for HostPlayerError {
+    fn from(value: TimedSceneRuntimeError) -> Self {
+        Self::Runtime(value)
     }
 }
 
@@ -92,17 +92,26 @@ impl From<HostCommitError> for HostPlayerError {
 #[derive(Clone, Debug)]
 pub struct HostScenePlayer {
     driven: HostDrivenScene,
+    signal_ids: Vec<SignalId>,
     next_sequence: u64,
 }
 
 impl HostScenePlayer {
     pub fn from_json(scene_json: &str, callback_slots_json: &str) -> Result<Self, HostPlayerError> {
-        let definition = decode_scene(scene_json)?;
-        let compiled = CompiledScene::compile(&definition)?;
+        let scene = decode_timed_semantic_scene(scene_json)?;
+        let signal_ids = scene
+            .semantic()
+            .reactive()
+            .signals()
+            .iter()
+            .map(|signal| signal.id)
+            .collect();
         let registry = decode_callback_registry(callback_slots_json)?;
-        let driven = HostDrivenScene::new(SceneInstance::new(compiled), &registry)?;
+        let instance = TimedSceneInstance::from_timed(&scene)?;
+        let driven = HostDrivenScene::from_timed(instance, &registry)?;
         Ok(Self {
             driven,
+            signal_ids,
             next_sequence: 0,
         })
     }
@@ -134,6 +143,18 @@ impl HostScenePlayer {
                 })
             })
             .collect::<Vec<_>>();
+        let signals = self
+            .signal_ids
+            .iter()
+            .filter_map(|signal| {
+                self.driven.reactive_value(*signal).map(|value| {
+                    json!({
+                        "signal": signal.get(),
+                        "value": value,
+                    })
+                })
+            })
+            .collect::<Vec<_>>();
         let invocations = frame
             .invocations
             .into_iter()
@@ -148,6 +169,7 @@ impl HostScenePlayer {
             "time": frame.time,
             "delta_time": frame.delta_time,
             "objects": objects,
+            "signals": signals,
             "invocations": invocations,
         }))
         .map_err(|error| HostPlayerError::CallbackJson(error.to_string()))
@@ -305,6 +327,31 @@ mod tests {
         let frame: Value = serde_json::from_str(&player.callback_frame_json().unwrap()).unwrap();
         assert_eq!(frame["objects"][1]["transform"]["translation"]["x"], 2.0);
         assert_eq!(frame["objects"][1]["transform"]["translation"]["y"], -1.0);
+    }
+
+    #[test]
+    fn callback_frame_reports_timeline_evaluated_signal_values() {
+        let mut semantic = noon_core::SemanticScene::new();
+        let object = semantic.add(GeometryRef::circle(0.5));
+        let tracker = semantic.add_input(0.0_f32);
+        let mut timeline = noon_core::SignalTimelineDefinition::new();
+        timeline
+            .add_scalar_track(
+                semantic.reactive(),
+                tracker,
+                0.0,
+                10.0,
+                noon_core::TrackTiming::new(0.0, 2.0, noon_core::RateFunction::Linear),
+            )
+            .unwrap();
+        let scene = noon_core::TimedSemanticScene::from_parts(semantic, timeline).unwrap();
+        let scene_json = noon_ir::encode_timed_semantic_scene(&scene).unwrap();
+        let slots = format!(r#"[{{"id":0,"objects":[{}]}}]"#, object.get());
+        let mut player = HostScenePlayer::from_json(&scene_json, &slots).unwrap();
+        player.advance_to(0.5).unwrap();
+        let frame: Value = serde_json::from_str(&player.callback_frame_json().unwrap()).unwrap();
+        assert_eq!(frame["signals"][0]["signal"], tracker.get());
+        assert_eq!(frame["signals"][0]["value"]["scalar"], 2.5);
     }
 
     #[test]

--- a/web/python/_manim_compat.py
+++ b/web/python/_manim_compat.py
@@ -611,8 +611,8 @@ class Scene(_BaseScene):
         for index, member in enumerate(leaves):
             newly_bound = member._scene is None
             if newly_bound:
-                raw_object = super().add(
-                    member._current_raw(), key=key if index == 0 else None
+                raw_object = _ir.Scene.add(
+                    self, member._current_raw(), key=key if index == 0 else None
                 )
                 member._bind(self, raw_object)
             elif member._scene is not self:

--- a/web/python/_manim_geometry.py
+++ b/web/python/_manim_geometry.py
@@ -385,6 +385,29 @@ def _bounds_for(value: object) -> tuple[_base.Vec2, _base.Vec2] | None:
     )
 
 
+def match_points(self: _base.Mobject, mobject: object) -> _base.Mobject:
+    if not isinstance(mobject, _base.Mobject):
+        raise TypeError("match_points expects a Mobject")
+    source = self._current_raw()
+    target = mobject._current_raw()
+    source_kind = next(iter(source.geometry), None)
+    target_kind = next(iter(target.geometry), None)
+    if source_kind != target_kind or source_kind not in {"line", "vector_path"}:
+        raise NotImplementedError(
+            "match_points currently supports Line/VMobject-path pairs with matching geometry kinds"
+        )
+    # Manim stores transformed VMobject points directly. Noon separates affine placement,
+    # so copying the target point state also copies its affine placement while source style
+    # (notably MovingDots' red line color) remains untouched. _ir snapshots are immutable,
+    # therefore construct one replacement value rather than mutating a frozen dataclass.
+    raw = _base._ir.Mobject(
+        geometry=copy.deepcopy(target.geometry),
+        transform=copy.deepcopy(target.transform),
+        style=copy.deepcopy(source.style),
+    )
+    return self._apply(raw)
+
+
 def install() -> None:
     public = {
         "DEFAULT_DOT_RADIUS": DEFAULT_DOT_RADIUS,
@@ -416,6 +439,7 @@ def install() -> None:
     # Existing compatibility layout methods resolve this module global at call time,
     # so the hook affects only Manim-facing authoring/layout and never renderer bounds.
     _compat._bounds_for = _bounds_for
+    _base.Mobject.match_points = match_points
 
     exports = list(_base.__all__)
     for name in public:

--- a/web/python/_manim_reactive.py
+++ b/web/python/_manim_reactive.py
@@ -19,6 +19,7 @@ _INSTALLED = False
 _ORIGINAL_SCENE_INIT = _ir.Scene.__init__
 _ORIGINAL_TO_DOCUMENT = _ir.Scene.to_document
 _ORIGINAL_SCENE_PLAY = _base.Scene.play
+_ACTIVE_CALLBACK_SIGNAL_VALUES: dict[int, dict[str, Any]] | None = None
 
 
 def _finite_scalar(name: str, value: object) -> float:
@@ -49,6 +50,20 @@ def _button(value: object) -> int:
     if value < 0 or value > 255:
         raise ValueError("button must be in the range 0..255")
     return value
+
+
+def _enter_callback_signal_values(frame: dict[str, Any]) -> None:
+    global _ACTIVE_CALLBACK_SIGNAL_VALUES
+    if _ACTIVE_CALLBACK_SIGNAL_VALUES is not None:
+        raise RuntimeError("nested Noon callback signal contexts are not supported")
+    _ACTIVE_CALLBACK_SIGNAL_VALUES = {
+        int(item["signal"]): item["value"] for item in frame.get("signals", [])
+    }
+
+
+def _leave_callback_signal_values() -> None:
+    global _ACTIVE_CALLBACK_SIGNAL_VALUES
+    _ACTIVE_CALLBACK_SIGNAL_VALUES = None
 
 
 class _ValueAnimationBuilder:
@@ -87,6 +102,12 @@ class ValueTracker:
         self._signal_id: int | None = None
 
     def get_value(self) -> float:
+        if self._signal_id is not None and _ACTIVE_CALLBACK_SIGNAL_VALUES is not None:
+            payload = _ACTIVE_CALLBACK_SIGNAL_VALUES.get(self._signal_id)
+            if payload is not None:
+                if "scalar" not in payload:
+                    raise TypeError("ValueTracker runtime signal is not scalar")
+                return float(payload["scalar"])
         return self._value
 
     def set_value(self, value: float) -> ValueTracker:

--- a/web/python/_manim_updaters.py
+++ b/web/python/_manim_updaters.py
@@ -187,10 +187,7 @@ class _CallbackContext:
             before = self._baseline[object_id]
             after = self._current[object_id]
             if before.geometry != after.geometry:
-                raise NotImplementedError(
-                    "host updaters cannot mutate geometry yet; use transform/style "
-                    "mutations or native reactive expressions"
-                )
+                batch.set_geometry(object_id, after.geometry)
             if before.transform != after.transform:
                 translation = after.transform["translation"]
                 scale = after.transform["scale"]
@@ -274,11 +271,23 @@ def run_callback_phase(
     if scene_key in _ACTIVE_CONTEXTS:
         raise RuntimeError("nested Noon host callback phases are not supported")
     _ACTIVE_CONTEXTS[scene_key] = context
+
+    # Keep the updater adapter usable by native Python tests and non-reactive scenes:
+    # importing the reactive facade eagerly would require Pyodide's `js` bridge even
+    # when this callback phase has no signals. Only enter the ValueTracker signal
+    # context when the runtime actually supplied signal values.
+    reactive = None
+    if frame.get("signals"):
+        import _manim_reactive as reactive
+
+        reactive._enter_callback_signal_values(frame)
     try:
         for mobject in session.mobjects:
             for callback in list(_updaters(mobject)):
                 _invoke(callback, mobject, context.delta_time)
     finally:
+        if reactive is not None:
+            reactive._leave_callback_signal_values()
         _ACTIVE_CONTEXTS.pop(scene_key, None)
 
     return context.patch_batch(int(sequence)).to_json()

--- a/web/python/_noon_ir.py
+++ b/web/python/_noon_ir.py
@@ -1431,6 +1431,19 @@ class PatchBatch:
         )
         return self
 
+    def set_geometry(self, object_id: int, geometry: dict[str, Any]) -> PatchBatch:
+        if not isinstance(geometry, dict) or len(geometry) != 1:
+            raise TypeError("geometry must be a single-variant Noon geometry dictionary")
+        self._patches.append(
+            {
+                "set_geometry": {
+                    "object": _identifier("object_id", object_id),
+                    "geometry": geometry,
+                }
+            }
+        )
+        return self
+
     def set_transform(
         self,
         object_id: int,

--- a/web/python/test_moving_dots_primitives.py
+++ b/web/python/test_moving_dots_primitives.py
@@ -1,0 +1,109 @@
+import os
+import subprocess
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+
+
+class MovingDotsPrimitiveTests(unittest.TestCase):
+    def test_runtime_tracker_match_points_and_geometry_patch_bridge(self) -> None:
+        python_dir = Path(__file__).resolve().parent
+        env = os.environ.copy()
+        existing_pythonpath = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = (
+            str(python_dir)
+            if not existing_pythonpath
+            else os.pathsep.join((str(python_dir), existing_pythonpath))
+        )
+
+        source = textwrap.dedent(
+            """
+            import json
+            import sys
+            import types
+
+            fake_js = types.ModuleType("js")
+            fake_js.noonResolveAnimationOptions = lambda *args: None
+            sys.modules["js"] = fake_js
+
+            import _manim_compat as manim
+            import _manim_geometry  # noqa: F401 - installs match_points/layout semantics
+            import _manim_reactive as reactive
+            import _manim_updaters as updaters
+            import noon as api
+
+            updaters.install()
+
+            # ValueTracker reads the evaluated runtime signal only while a coherent
+            # callback phase is active, then falls back to its authoring value.
+            scene = manim.Scene()
+            tracker = reactive.value_tracker(scene, 0.0)
+            reactive._enter_callback_signal_values(
+                {"signals": [{"signal": tracker.signal_id, "value": {"scalar": 2.25}}]}
+            )
+            try:
+                assert tracker.get_value() == 2.25
+            finally:
+                reactive._leave_callback_signal_values()
+            assert tracker.get_value() == 0.0
+
+            # ManimCE v0.21 MovingDots relies on match_points replacing geometry and
+            # placement without copying the temporary Line's default style.
+            source_line = manim.Line((-1.0, 0.0), (1.0, 0.0)).set_color(api.RED)
+            target_line = manim.Line((2.0, 3.0), (4.0, 5.0))
+            source_line.match_points(target_line)
+            assert source_line.geometry == target_line.geometry
+            assert source_line.transform == target_line.transform
+            assert source_line.style["stroke"] == api.RED.to_ir()
+
+            # The arbitrary-updater bridge returns one atomic geometry patch batch.
+            callback_scene = manim.Scene()
+            line = manim.Line((-1.0, 0.0), (1.0, 0.0)).set_color(api.RED)
+            callback_scene.add(line)
+            line.add_updater(
+                lambda mob: mob.match_points(manim.Line((0.0, 0.0), (2.0, 1.0)))
+            )
+            registration = updaters.register_scene(callback_scene)
+            assert registration is not None
+            frame = {
+                "time": 0.5,
+                "delta_time": 0.5,
+                "signals": [],
+                "objects": [
+                    {
+                        "object": line.id,
+                        "transform": line.transform,
+                        "style": line.style,
+                        "presence": True,
+                        "appearance": 1.0,
+                        "reveal": 1.0,
+                        "morph": 0.0,
+                    }
+                ],
+                "invocations": [{"callback": 0, "object_indices": [0]}],
+            }
+            batch = json.loads(
+                updaters.run_callback_phase(registration["session_id"], frame, 0)
+            )
+            assert "set_geometry" in batch["patches"][0]
+            """
+        )
+
+        completed = subprocess.run(
+            [sys.executable, "-c", source],
+            cwd=python_dir,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(
+            completed.returncode,
+            0,
+            f"MovingDots primitive subprocess failed:\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Unblock exact ManimCE updater examples such as `MovingDots` by moving the missing behavior into shared runtime semantics instead of adding Python-only special cases.

- add object-local `ScenePatch::SetGeometry` and preserve stable execution slots
- keep timed reactive signal evaluation alive in `HostScenePlayer`
- include evaluated signal values in coherent host callback frames
- make Python `ValueTracker.get_value()` observe the runtime-evaluated value while a callback phase is active
- allow updater callback batches to emit geometry replacement
- add Manim-compatible, style-preserving `Mobject.match_points(...)`
- fix the Manim compatibility `Scene.add()` raw-document boundary after the high-level Noon `Scene.add()` API changed
- add focused regression coverage for runtime tracker reads, `match_points`, and geometry patch emission

## Architecture

Arbitrary Python callbacks remain host-language code, but deterministic timeline/reactive evaluation and geometry patch validation/application stay in Rust. A callback phase still crosses the host boundary once with a coherent snapshot and returns one atomic patch batch.

Geometry replacement is classified as object-local value work: it does not create/remove stable execution slots or introduce a second frontend scene model.

## Validation

Validated before opening this PR:

- `cargo fmt --all`
- `cargo test -p noon-core`
- `cargo test -p noon-compile`
- `cargo test -p noon-runtime`
- `cargo test -p noon-ir`
- `cargo test -p noon-web`
- `PYTHONPATH=web/python python3 -m unittest web.python.test_moving_dots_primitives`

This PR is intentionally only the reusable runtime/frontend prerequisite. The exact ManimCE v0.21 `MovingDots` gallery source/demo case follows after this lands.

Related: #61, #252, #259