### PR TITLE
Route detached layout queries through exact shared bounds

### DIFF
--- a/compat/semantic-ownership-v1.json
+++ b/compat/semantic-ownership-v1.json
@@ -112,12 +112,19 @@
     },
     {
       "id": "mobject.layout-query",
-      "surface": "Mobject.center/width/height/critical_point",
+      "surface": "Detached and animate-target Mobject.center/width/height/critical_point",
+      "classification": "shared-rust",
+      "owner": {"language": "rust", "path": "crates/noon-web/src/authoring_mobject.rs", "symbol": "FrontendMobjectHandle::center/width/height/critical_point"},
+      "adapters": [{"language": "python", "path": "web/python/_manim_semantic_handles.py", "symbol": "_layout_bounds/_layout_center/_width/_height/_critical"}]
+    },
+    {
+      "id": "mobject.scene-layout-query",
+      "surface": "Scene-bound Mobject.center/width/height/critical_point",
       "classification": "python-semantic-duplicate",
-      "owner": {"language": "python", "path": "web/python/_manim_semantic_handles.py", "symbol": "_layout_bounds/_layout_center/_width/_height/_critical"},
+      "owner": {"language": "python", "path": "web/python/_manim_semantic_handles.py", "symbol": "_layout_bounds/_layout_center/_width/_height/_critical fallbacks"},
       "shared_owner": {"language": "rust", "path": "crates/noon-web/src/authoring_mobject.rs", "symbol": "FrontendMobjectHandle::center/width/height/critical_point"},
-      "reason": "Python materializes handle snapshots and evaluates the compatibility bounds contract locally instead of using the shared query result.",
-      "replacement": "Finish #62 bounds integration and route these queries directly to shared semantic handles.",
+      "reason": "Scene-bound wrappers do not yet retain a stable shared semantic handle, so layout queries still evaluate their scene snapshot in Python.",
+      "replacement": "Bind scene-owned wrappers to stable shared handles and reuse the same Rust layout query path.",
       "migration_issue": "#61"
     },
     {

--- a/crates/noon-web/src/authoring_mobject.rs
+++ b/crates/noon-web/src/authoring_mobject.rs
@@ -1,6 +1,6 @@
 use noon_core::{
-    semantic_path_bounds, Bounds2D64, Color, GeometryRef, ObjectSnapshot, SemanticPaint,
-    SemanticStyle, SemanticTransform2_5D, SemanticVec3, Style, Vec2,
+    Bounds2D64, Color, GeometryRef, ObjectSnapshot, PathCommand, SemanticPaint, SemanticStyle,
+    SemanticTransform2_5D, SemanticVec3, Style, Vec2, VectorPath,
 };
 
 #[derive(Clone, Debug, PartialEq)]
@@ -578,58 +578,219 @@ fn normalized_direction(x: f64, y: f64) -> Result<(f64, f64), String> {
     Ok((x / length, y / length))
 }
 
+fn include_layout_point(bounds: &mut Option<Bounds2D64>, point: (f64, f64)) {
+    if let Some(bounds) = bounds {
+        bounds.include(point.0, point.1);
+    } else {
+        *bounds = Some(Bounds2D64::point(point.0, point.1));
+    }
+}
+
+fn transform_layout_point(transform: SemanticTransform2_5D, point: Vec2) -> (f64, f64) {
+    let x = f64::from(point.x) * transform.scale.x;
+    let y = f64::from(point.y) * transform.scale.y;
+    let sine = transform.rotation_z.sin();
+    let cosine = transform.rotation_z.cos();
+    (
+        x * cosine - y * sine + transform.translation.x,
+        x * sine + y * cosine + transform.translation.y,
+    )
+}
+
+fn quadratic_layout_point(p0: (f64, f64), p1: (f64, f64), p2: (f64, f64), t: f64) -> (f64, f64) {
+    let u = 1.0 - t;
+    (
+        u * u * p0.0 + 2.0 * u * t * p1.0 + t * t * p2.0,
+        u * u * p0.1 + 2.0 * u * t * p1.1 + t * t * p2.1,
+    )
+}
+
+fn cubic_layout_point(
+    p0: (f64, f64),
+    p1: (f64, f64),
+    p2: (f64, f64),
+    p3: (f64, f64),
+    t: f64,
+) -> (f64, f64) {
+    let u = 1.0 - t;
+    (
+        u * u * u * p0.0 + 3.0 * u * u * t * p1.0 + 3.0 * u * t * t * p2.0 + t * t * t * p3.0,
+        u * u * u * p0.1 + 3.0 * u * u * t * p1.1 + 3.0 * u * t * t * p2.1 + t * t * t * p3.1,
+    )
+}
+
+fn cubic_layout_derivative_roots(p0: f64, p1: f64, p2: f64, p3: f64) -> Vec<f64> {
+    let a = -p0 + 3.0 * p1 - 3.0 * p2 + p3;
+    let b = 2.0 * (p0 - 2.0 * p1 + p2);
+    let c = p1 - p0;
+    let epsilon = 1.0e-14;
+    if a.abs() <= epsilon {
+        if b.abs() <= epsilon {
+            return Vec::new();
+        }
+        return vec![-c / b];
+    }
+    let discriminant = b * b - 4.0 * a * c;
+    if discriminant < 0.0 {
+        return Vec::new();
+    }
+    let root = discriminant.sqrt();
+    let mut roots = vec![(-b + root) / (2.0 * a)];
+    if root > epsilon {
+        roots.push((-b - root) / (2.0 * a));
+    }
+    roots
+}
+
+fn transformed_path_layout_bounds(
+    path: &VectorPath,
+    transform: SemanticTransform2_5D,
+) -> Option<Bounds2D64> {
+    let mut bounds = None;
+    let mut current = None;
+    let mut subpath_start = None;
+
+    for command in path.commands() {
+        match *command {
+            PathCommand::MoveTo { to } => {
+                let point = transform_layout_point(transform, to);
+                include_layout_point(&mut bounds, point);
+                current = Some(point);
+                subpath_start = Some(point);
+            }
+            PathCommand::LineTo { to } => {
+                let end = transform_layout_point(transform, to);
+                if let Some(start) = current {
+                    include_layout_point(&mut bounds, start);
+                }
+                include_layout_point(&mut bounds, end);
+                current = Some(end);
+            }
+            PathCommand::QuadraticTo { control, to } => {
+                let end = transform_layout_point(transform, to);
+                let Some(start) = current else {
+                    include_layout_point(&mut bounds, end);
+                    current = Some(end);
+                    continue;
+                };
+                let control = transform_layout_point(transform, control);
+                include_layout_point(&mut bounds, start);
+                include_layout_point(&mut bounds, end);
+                for axis in 0..2 {
+                    let (p0, p1, p2) = if axis == 0 {
+                        (start.0, control.0, end.0)
+                    } else {
+                        (start.1, control.1, end.1)
+                    };
+                    let denominator = p0 - 2.0 * p1 + p2;
+                    if denominator.abs() <= 1.0e-14 {
+                        continue;
+                    }
+                    let t = (p0 - p1) / denominator;
+                    if (0.0..1.0).contains(&t) {
+                        include_layout_point(
+                            &mut bounds,
+                            quadratic_layout_point(start, control, end, t),
+                        );
+                    }
+                }
+                current = Some(end);
+            }
+            PathCommand::CubicTo {
+                control1,
+                control2,
+                to,
+            } => {
+                let end = transform_layout_point(transform, to);
+                let Some(start) = current else {
+                    include_layout_point(&mut bounds, end);
+                    current = Some(end);
+                    continue;
+                };
+                let control1 = transform_layout_point(transform, control1);
+                let control2 = transform_layout_point(transform, control2);
+                include_layout_point(&mut bounds, start);
+                include_layout_point(&mut bounds, end);
+                let mut roots =
+                    cubic_layout_derivative_roots(start.0, control1.0, control2.0, end.0);
+                roots.extend(cubic_layout_derivative_roots(
+                    start.1, control1.1, control2.1, end.1,
+                ));
+                for t in roots {
+                    if (0.0..1.0).contains(&t) {
+                        include_layout_point(
+                            &mut bounds,
+                            cubic_layout_point(start, control1, control2, end, t),
+                        );
+                    }
+                }
+                current = Some(end);
+            }
+            PathCommand::Close => {
+                if let Some(end) = current {
+                    include_layout_point(&mut bounds, end);
+                }
+                if let Some(start) = subpath_start {
+                    include_layout_point(&mut bounds, start);
+                    current = Some(start);
+                }
+            }
+        }
+    }
+    bounds
+}
+
 fn snapshot_layout_bounds(
     snapshot: &ObjectSnapshot,
     transform: SemanticTransform2_5D,
 ) -> Option<Bounds2D64> {
-    let local = match &snapshot.geometry {
-        GeometryRef::Circle { radius } => Bounds2D64 {
-            min_x: -f64::from(*radius),
-            min_y: -f64::from(*radius),
-            max_x: f64::from(*radius),
-            max_y: f64::from(*radius),
-        },
-        GeometryRef::Rectangle { size } => Bounds2D64 {
-            min_x: -f64::from(size.x) * 0.5,
-            min_y: -f64::from(size.y) * 0.5,
-            max_x: f64::from(size.x) * 0.5,
-            max_y: f64::from(size.y) * 0.5,
-        },
-        GeometryRef::Line { start, end } => Bounds2D64 {
-            min_x: f64::from(start.x.min(end.x)),
-            min_y: f64::from(start.y.min(end.y)),
-            max_x: f64::from(start.x.max(end.x)),
-            max_y: f64::from(start.y.max(end.y)),
-        },
-        GeometryRef::VectorPath(path) => semantic_path_bounds(path, 0.0).layout?,
-        GeometryRef::External(_) => return None,
-    };
-
-    let sine = transform.rotation_z.sin();
-    let cosine = transform.rotation_z.cos();
-    let scale_x = transform.scale.x;
-    let scale_y = transform.scale.y;
-    let translation_x = transform.translation.x;
-    let translation_y = transform.translation.y;
-    let corners = [
-        (local.min_x, local.min_y),
-        (local.min_x, local.max_y),
-        (local.max_x, local.min_y),
-        (local.max_x, local.max_y),
-    ];
-    let mut world: Option<Bounds2D64> = None;
-    for (x, y) in corners {
-        let x = x * scale_x;
-        let y = y * scale_y;
-        let point_x = x * cosine - y * sine + translation_x;
-        let point_y = x * sine + y * cosine + translation_y;
-        if let Some(bounds) = &mut world {
-            bounds.include(point_x, point_y);
-        } else {
-            world = Some(Bounds2D64::point(point_x, point_y));
+    match &snapshot.geometry {
+        GeometryRef::Circle { radius } => {
+            let radius = f64::from(*radius);
+            let sine = transform.rotation_z.sin();
+            let cosine = transform.rotation_z.cos();
+            let half_width = radius * (transform.scale.x * cosine).hypot(transform.scale.y * sine);
+            let half_height = radius * (transform.scale.x * sine).hypot(transform.scale.y * cosine);
+            Some(Bounds2D64 {
+                min_x: transform.translation.x - half_width,
+                min_y: transform.translation.y - half_height,
+                max_x: transform.translation.x + half_width,
+                max_y: transform.translation.y + half_height,
+            })
         }
+        GeometryRef::Rectangle { size } => {
+            let half_x = f64::from(size.x) * 0.5;
+            let half_y = f64::from(size.y) * 0.5;
+            let mut bounds = None;
+            for (x, y) in [
+                (-half_x, -half_y),
+                (-half_x, half_y),
+                (half_x, -half_y),
+                (half_x, half_y),
+            ] {
+                let sine = transform.rotation_z.sin();
+                let cosine = transform.rotation_z.cos();
+                let x = x * transform.scale.x;
+                let y = y * transform.scale.y;
+                include_layout_point(
+                    &mut bounds,
+                    (
+                        x * cosine - y * sine + transform.translation.x,
+                        x * sine + y * cosine + transform.translation.y,
+                    ),
+                );
+            }
+            bounds
+        }
+        GeometryRef::Line { start, end } => {
+            let mut bounds = None;
+            include_layout_point(&mut bounds, transform_layout_point(transform, *start));
+            include_layout_point(&mut bounds, transform_layout_point(transform, *end));
+            bounds
+        }
+        GeometryRef::VectorPath(path) => transformed_path_layout_bounds(path, transform),
+        GeometryRef::External(_) => None,
     }
-    world
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -989,6 +1150,32 @@ mod tests {
         assert!(bounds.min_y.abs() < 1e-9);
         assert!((bounds.max_y - 1.0).abs() < 1e-9);
         assert!((handle.height() - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn transformed_layout_bounds_match_manim_world_extrema() {
+        let mut ellipse = FrontendMobjectHandle::from_snapshot(snapshot(GeometryRef::circle(1.0)));
+        ellipse.scale(2.0, 1.0).unwrap();
+        ellipse.rotate(std::f64::consts::FRAC_PI_4).unwrap();
+        assert!((ellipse.width() - 10.0_f64.sqrt()).abs() < 1e-12);
+        assert!((ellipse.height() - 10.0_f64.sqrt()).abs() < 1e-12);
+
+        let mut diagonal = FrontendMobjectHandle::from_snapshot(snapshot(GeometryRef::line(
+            Vec2::ZERO,
+            Vec2::new(1.0, 1.0),
+        )));
+        diagonal.rotate(std::f64::consts::FRAC_PI_4).unwrap();
+        assert!(diagonal.width().abs() < 1e-12);
+        assert!((diagonal.height() - 2.0_f64.sqrt()).abs() < 1e-12);
+
+        let path = VectorPath::new()
+            .move_to(Vec2::new(-1.0, 0.0))
+            .quadratic_to(Vec2::new(0.0, 2.0), Vec2::new(1.0, 0.0));
+        let mut curve = FrontendMobjectHandle::from_snapshot(snapshot(GeometryRef::path(path)));
+        curve.rotate(std::f64::consts::FRAC_PI_4).unwrap();
+        let expected = 9.0 * 2.0_f64.sqrt() / 8.0;
+        assert!((curve.width() - expected).abs() < 1e-12);
+        assert!((curve.height() - expected).abs() < 1e-12);
     }
 
     #[test]

--- a/web/python/_manim_semantic_handles.py
+++ b/web/python/_manim_semantic_handles.py
@@ -204,26 +204,41 @@ def _handle_for(value: object):
     return getattr(value, "_semantic_handle", None)
 
 
+def _has_shared_layout_queries(handle: object) -> bool:
+    return handle is not None and all(
+        hasattr(handle, name)
+        for name in ("centerX", "centerY", "width", "height", "criticalX", "criticalY")
+    )
+
+
 def _layout_bounds(value: _base.Mobject) -> tuple[_base.Vec2, _base.Vec2] | None:
-    """Use the one Manim compatibility bounds contract for every object owner.
+    """Read exact world-space layout bounds from a detached shared handle."""
 
-    `_manim_phase_b` installs `_base._bounds` before this module is installed. It
-    evaluates transformed quadratic/cubic extrema and analytic primitive extents in
-    world space. Detached semantic handles remain authoritative for object state; we
-    materialize only their current snapshot for this compatibility query instead of
-    using the handle's older transformed-local-AABB shortcuts.
-    """
-
-    return _base._bounds(value._current_raw())
+    handle = _handle_for(value)
+    if not _has_shared_layout_queries(handle):
+        return _base._bounds(value._current_raw())
+    return (
+        _base.Vec2(
+            float(handle.criticalX(-1.0, 0.0)),
+            float(handle.criticalY(0.0, -1.0)),
+        ),
+        _base.Vec2(
+            float(handle.criticalX(1.0, 0.0)),
+            float(handle.criticalY(0.0, 1.0)),
+        ),
+    )
 
 
 def _layout_center(value: _base.Mobject) -> _base.Vec2:
-    raw = value._current_raw()
-    bounds = _base._bounds(raw)
-    if bounds is not None:
-        return (bounds[0] + bounds[1]) * 0.5
-    translation = raw.transform["translation"]
-    return _base.Vec2(float(translation["x"]), float(translation["y"]))
+    handle = _handle_for(value)
+    if not _has_shared_layout_queries(handle):
+        raw = value._current_raw()
+        bounds = _base._bounds(raw)
+        if bounds is not None:
+            return (bounds[0] + bounds[1]) * 0.5
+        translation = raw.transform["translation"]
+        return _base.Vec2(float(translation["x"]), float(translation["y"]))
+    return _base.Vec2(float(handle.centerX), float(handle.centerY))
 
 
 def _init(self: _base.Mobject, raw: _ir.Mobject) -> None:
@@ -305,20 +320,18 @@ def _get_center(self: _base.Mobject) -> _base.Vec2:
 
 
 def _width(self: _base.Mobject) -> float:
-    bounds = (
-        _layout_bounds(self)
-        if _handle_for(self) is not None
-        else _base._bounds(self._current_raw())
-    )
+    handle = _handle_for(self)
+    if _has_shared_layout_queries(handle):
+        return float(handle.width)
+    bounds = _base._bounds(self._current_raw())
     return 0.0 if bounds is None else bounds[1].x - bounds[0].x
 
 
 def _height(self: _base.Mobject) -> float:
-    bounds = (
-        _layout_bounds(self)
-        if _handle_for(self) is not None
-        else _base._bounds(self._current_raw())
-    )
+    handle = _handle_for(self)
+    if _has_shared_layout_queries(handle):
+        return float(handle.height)
+    bounds = _base._bounds(self._current_raw())
     return 0.0 if bounds is None else bounds[1].y - bounds[0].y
 
 
@@ -472,15 +485,11 @@ def _replace(
 
 
 def _critical(value: _base.Mobject, direction: _base.Vec2) -> _base.Vec2:
-    if _handle_for(value) is not None:
-        bounds = _layout_bounds(value)
-        if bounds is None:
-            return _layout_center(value)
-        minimum, maximum = bounds
-        center = (minimum + maximum) * 0.5
+    handle = _handle_for(value)
+    if _has_shared_layout_queries(handle):
         return _base.Vec2(
-            minimum.x if direction.x < 0 else maximum.x if direction.x > 0 else center.x,
-            minimum.y if direction.y < 0 else maximum.y if direction.y > 0 else center.y,
+            float(handle.criticalX(direction.x, direction.y)),
+            float(handle.criticalY(direction.x, direction.y)),
         )
     return _base._critical(value._current_raw(), direction)
 
@@ -521,20 +530,9 @@ def _align_on_frame(
     buff: float,
 ) -> _base.Mobject:
     handle = _handle_for(self)
-    if handle is None:
+    if handle is None or not hasattr(handle, "alignOnFrame"):
         return _ORIGINAL_ALIGN_ON_FRAME(self, direction, buff)
-    point = _critical(self, direction)
-    shift_x = 0.0
-    shift_y = 0.0
-    if direction.x != 0.0:
-        target_x = direction.x.__class__(_base.DEFAULT_FRAME_WIDTH / 2.0)
-        target_x = (1.0 if direction.x > 0.0 else -1.0) * float(target_x)
-        shift_x = target_x - point.x - direction.x * float(buff)
-    if direction.y != 0.0:
-        target_y = direction.y.__class__(_base.DEFAULT_FRAME_HEIGHT / 2.0)
-        target_y = (1.0 if direction.y > 0.0 else -1.0) * float(target_y)
-        shift_y = target_y - point.y - direction.y * float(buff)
-    handle.shift(shift_x, shift_y)
+    handle.alignOnFrame(direction.x, direction.y, float(buff))
     return self
 
 

--- a/web/python/test_manim_shared_layout_queries.py
+++ b/web/python/test_manim_shared_layout_queries.py
@@ -1,0 +1,193 @@
+import os
+import subprocess
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+
+
+class ManimSharedLayoutQueryTests(unittest.TestCase):
+    def test_detached_layout_queries_do_not_materialize_snapshots(self) -> None:
+        python_dir = Path(__file__).resolve().parent
+        env = os.environ.copy()
+        existing_pythonpath = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = (
+            str(python_dir)
+            if not existing_pythonpath
+            else os.pathsep.join((str(python_dir), existing_pythonpath))
+        )
+        source = textwrap.dedent(
+            """
+            import json
+            import math
+            import sys
+            import types
+
+            fake_js = types.ModuleType("js")
+            fake_js.noonResolveUniformCompositionSchedule = object()
+            fake_js.noonResolveAnimationOptions = object()
+            sys.modules["js"] = fake_js
+
+            import _manim_compat
+            _manim_compat.install()
+            import _manim_phase_b  # noqa: F401 - installs exact Manim world bounds
+            import noon as _base
+            import _manim_semantic_handles as handles
+
+            class FakeHandle:
+                def __init__(self, snapshot_json):
+                    self.snapshot = json.loads(snapshot_json)
+                    self.snapshot_requests = 0
+
+                def _raw(self):
+                    return _base._ir.Mobject(
+                        geometry=self.snapshot["geometry"],
+                        transform=self.snapshot["transform"],
+                        style=self.snapshot["style"],
+                    )
+
+                def _bounds(self):
+                    bounds = _base._bounds(self._raw())
+                    assert bounds is not None
+                    return bounds
+
+                def snapshotJson(self):
+                    self.snapshot_requests += 1
+                    return json.dumps(self.snapshot, separators=(",", ":"))
+
+                def replaceSnapshotJson(self, snapshot_json):
+                    self.snapshot = json.loads(snapshot_json)
+
+                def cloneHandle(self):
+                    return FakeHandle(json.dumps(self.snapshot, separators=(",", ":")))
+
+                @property
+                def centerX(self):
+                    minimum, maximum = self._bounds()
+                    return (minimum.x + maximum.x) * 0.5
+
+                @property
+                def centerY(self):
+                    minimum, maximum = self._bounds()
+                    return (minimum.y + maximum.y) * 0.5
+
+                @property
+                def width(self):
+                    minimum, maximum = self._bounds()
+                    return maximum.x - minimum.x
+
+                @property
+                def height(self):
+                    minimum, maximum = self._bounds()
+                    return maximum.y - minimum.y
+
+                def criticalX(self, direction_x, direction_y):
+                    minimum, maximum = self._bounds()
+                    center = (minimum.x + maximum.x) * 0.5
+                    return minimum.x if direction_x < 0 else maximum.x if direction_x > 0 else center
+
+                def criticalY(self, direction_x, direction_y):
+                    minimum, maximum = self._bounds()
+                    center = (minimum.y + maximum.y) * 0.5
+                    return minimum.y if direction_y < 0 else maximum.y if direction_y > 0 else center
+
+                def setFillOpacity(self, opacity):
+                    fill = self.snapshot["style"]["fill"]
+                    if fill is not None:
+                        fill["alpha"] = float(opacity)
+
+                def setStrokeOpacity(self, opacity):
+                    stroke = self.snapshot["style"]["stroke"]
+                    if stroke is not None:
+                        stroke["alpha"] = float(opacity)
+
+                def shift(self, x, y):
+                    translation = self.snapshot["transform"]["translation"]
+                    translation["x"] += float(x)
+                    translation["y"] += float(y)
+
+                def scale(self, x, y):
+                    scale = self.snapshot["transform"]["scale"]
+                    scale["x"] *= float(x)
+                    scale["y"] *= float(y)
+
+                def rotateAboutPoint(self, angle, point_x, point_y):
+                    translation = self.snapshot["transform"]["translation"]
+                    dx = translation["x"] - float(point_x)
+                    dy = translation["y"] - float(point_y)
+                    cosine = math.cos(float(angle))
+                    sine = math.sin(float(angle))
+                    translation["x"] = float(point_x) + dx * cosine - dy * sine
+                    translation["y"] = float(point_y) + dx * sine + dy * cosine
+                    self.snapshot["transform"]["rotation"] += float(angle)
+
+                def alignOnFrame(self, direction_x, direction_y, buff):
+                    point_x = self.criticalX(direction_x, direction_y)
+                    point_y = self.criticalY(direction_x, direction_y)
+                    shift_x = 0.0
+                    shift_y = 0.0
+                    if direction_x != 0.0:
+                        target_x = math.copysign(_base.DEFAULT_FRAME_WIDTH * 0.5, direction_x)
+                        shift_x = target_x - point_x - direction_x * float(buff)
+                    if direction_y != 0.0:
+                        target_y = math.copysign(_base.DEFAULT_FRAME_HEIGHT * 0.5, direction_y)
+                        shift_y = target_y - point_y - direction_y * float(buff)
+                    self.shift(shift_x, shift_y)
+
+            fake_js.noonCreateAuthoringMobjectHandle = FakeHandle
+            handles._create_handle = FakeHandle
+            handles.install()
+
+            from noon import Circle, DEFAULT_FRAME_WIDTH, PI, Path, RIGHT, VectorPath
+
+            ellipse = Circle(1.0).scale((2.0, 1.0)).rotate(PI / 4.0)
+            handle = ellipse._semantic_handle
+            handle.snapshot_requests = 0
+            expected = math.sqrt(10.0)
+            assert abs(ellipse.width - expected) < 1e-12
+            assert abs(ellipse.height - expected) < 1e-12
+            assert abs(ellipse.get_center().x) < 1e-12
+            assert abs(ellipse.get_center().y) < 1e-12
+            assert abs(ellipse.get_critical_point(RIGHT).x - expected * 0.5) < 1e-12
+            assert handle.snapshot_requests == 0
+
+            curve = Path(
+                VectorPath()
+                .move_to((-1.0, 0.0))
+                .quadratic_to((0.0, 2.0), (1.0, 0.0))
+            ).rotate(PI / 4.0)
+            curve_handle = curve._semantic_handle
+            curve_handle.snapshot_requests = 0
+            expected_curve_extent = 9.0 * math.sqrt(2.0) / 8.0
+            assert abs(curve.width - expected_curve_extent) < 1e-12
+            assert abs(curve.height - expected_curve_extent) < 1e-12
+            assert curve_handle.snapshot_requests == 0
+
+            edge = ellipse.copy().to_edge(RIGHT, buff=0.5)
+            edge_handle = edge._semantic_handle
+            edge_handle.snapshot_requests = 0
+            assert abs(
+                edge.get_critical_point(RIGHT).x
+                - (DEFAULT_FRAME_WIDTH * 0.5 - 0.5)
+            ) < 1e-12
+            assert edge_handle.snapshot_requests == 0
+            """
+        )
+        completed = subprocess.run(
+            [sys.executable, "-c", source],
+            cwd=python_dir,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(
+            completed.returncode,
+            0,
+            "shared layout query subprocess failed:\n"
+            f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- make shared Rust layout bounds exact in world space for transformed circles, rectangles, lines, and vector paths
- route detached/animate-target Python center, width, height, critical-point, and frame-edge queries through shared handles without snapshot JSON round-trips
- add no-snapshot regression coverage and ratchet the ownership inventory to mark detached layout queries as shared Rust semantics

This is the next incremental #61/#62 tranche after #292. Scene-bound wrappers still lack a stable shared semantic handle, and `Group.animate` remains separate #61 migration debt.

## Validation
- `cargo fmt --all`
- `cargo test -p noon-web authoring_mobject`
- `PYTHONPATH=web/python python3 -m unittest web.python.test_manim_semantic_handle_layout_bounds web.python.test_manim_shared_layout_queries`
- `python3 scripts/semantic_ownership_check.py`
- `git diff --check`