### PR TITLE
Add shared 2D moving-camera semantic path

### DIFF
--- a/crates/noon-core/src/camera.rs
+++ b/crates/noon-core/src/camera.rs
@@ -1,0 +1,67 @@
+use crate::{Camera2DState, GeometryRef, Transform2D};
+
+impl Camera2DState {
+    /// Derive the renderer-facing viewport from an evaluated semantic camera frame.
+    ///
+    /// The initial moving-camera contract deliberately accepts only an unrotated
+    /// rectangle. Translation and scale therefore flow through the ordinary object
+    /// transform timeline, while unsupported camera rotation fails explicitly rather
+    /// than being approximated differently by individual frontends.
+    pub fn from_frame_object(geometry: &GeometryRef, transform: Transform2D) -> Option<Self> {
+        let GeometryRef::Rectangle { size } = geometry else {
+            return None;
+        };
+        if !transform.translation.x.is_finite()
+            || !transform.translation.y.is_finite()
+            || !transform.rotation.is_finite()
+            || transform.rotation.abs() > 1.0e-6
+            || !transform.scale.y.is_finite()
+        {
+            return None;
+        }
+        let height = size.y * transform.scale.y.abs();
+        if !height.is_finite() || height <= 0.0 {
+            return None;
+        }
+        Some(Self {
+            center: transform.translation,
+            height,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        Camera2DState, GeometryRef, Transform2D, Vec2, DEFAULT_FRAME_HEIGHT, DEFAULT_FRAME_WIDTH,
+    };
+
+    #[test]
+    fn camera_state_is_derived_from_shared_frame_transform() {
+        let geometry = GeometryRef::rectangle(DEFAULT_FRAME_WIDTH, DEFAULT_FRAME_HEIGHT);
+        let moved = Transform2D {
+            translation: Vec2::new(3.0, -2.0),
+            scale: Vec2::new(0.5, 0.5),
+            ..Transform2D::IDENTITY
+        };
+        let camera = Camera2DState::from_frame_object(&geometry, moved).unwrap();
+        assert_eq!(camera.center, Vec2::new(3.0, -2.0));
+        assert_eq!(camera.height, DEFAULT_FRAME_HEIGHT * 0.5);
+    }
+
+    #[test]
+    fn camera_state_rejects_non_frame_and_rotated_geometry() {
+        assert!(
+            Camera2DState::from_frame_object(&GeometryRef::circle(1.0), Transform2D::IDENTITY,)
+                .is_none()
+        );
+        assert!(Camera2DState::from_frame_object(
+            &GeometryRef::rectangle(DEFAULT_FRAME_WIDTH, DEFAULT_FRAME_HEIGHT),
+            Transform2D {
+                rotation: 0.25,
+                ..Transform2D::IDENTITY
+            },
+        )
+        .is_none());
+    }
+}

--- a/crates/noon-core/src/lib.rs
+++ b/crates/noon-core/src/lib.rs
@@ -157,6 +157,23 @@ pub const DEFAULT_MOBJECT_TO_MOBJECT_BUFFER: f32 = MED_SMALL_BUFF;
 pub const DEFAULT_FRAME_HEIGHT: f32 = 8.0;
 pub const DEFAULT_FRAME_WIDTH: f32 = DEFAULT_FRAME_HEIGHT * 16.0 / 9.0;
 
+/// Runtime-facing 2D camera state. Camera authoring may use an ordinary semantic
+/// frame object, but renderers consume only this normalized center/height contract.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Camera2DState {
+    pub center: Vec2,
+    pub height: f32,
+}
+
+impl Default for Camera2DState {
+    fn default() -> Self {
+        Self {
+            center: ORIGIN,
+            height: DEFAULT_FRAME_HEIGHT,
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Transform2D {
     pub translation: Vec2,
@@ -828,6 +845,7 @@ pub struct SceneDefinition {
     pub(crate) next_object_id: u64,
     pub(crate) tracks: Vec<TrackDefinition>,
     pub(crate) next_track_id: u64,
+    pub(crate) camera_object: Option<ObjectId>,
 }
 
 impl SceneDefinition {
@@ -865,6 +883,27 @@ impl SceneDefinition {
         object.transform = snapshot.transform;
         object.style = snapshot.style;
         true
+    }
+
+    /// Select an ordinary semantic object whose transform/rectangle bounds define
+    /// the active 2D camera frame. The same transform timeline remains available to
+    /// every frontend; this marker only gives the runtime a viewport role.
+    pub fn set_camera_object(&mut self, id: ObjectId) -> bool {
+        if self.object(id).is_none() {
+            return false;
+        }
+        self.camera_object = Some(id);
+        true
+    }
+
+    pub const fn camera_object(&self) -> Option<ObjectId> {
+        self.camera_object
+    }
+
+    pub(crate) fn clear_camera_object_if(&mut self, id: ObjectId) {
+        if self.camera_object == Some(id) {
+            self.camera_object = None;
+        }
     }
 
     pub fn objects(&self) -> &[ObjectDefinition] {
@@ -921,6 +960,22 @@ mod tests {
         assert_eq!(object.id, circle);
         assert_eq!(object.transform.translation, Vec2::new(4.0, -2.0));
         assert_eq!(object.style.opacity, 0.5);
+    }
+
+    #[test]
+    fn camera_object_is_explicit_shared_scene_identity() {
+        let mut scene = SceneDefinition::new();
+        let frame = scene.add(GeometryRef::rectangle(
+            DEFAULT_FRAME_WIDTH,
+            DEFAULT_FRAME_HEIGHT,
+        ));
+        assert_eq!(scene.camera_object(), None);
+        assert!(scene.set_camera_object(frame));
+        assert_eq!(scene.camera_object(), Some(frame));
+        assert!(!scene.set_camera_object(ObjectId::new(99)));
+        assert_eq!(scene.camera_object(), Some(frame));
+        assert_eq!(Camera2DState::default().center, ORIGIN);
+        assert_eq!(Camera2DState::default().height, DEFAULT_FRAME_HEIGHT);
     }
 
     #[test]

--- a/crates/noon-core/src/patch.rs
+++ b/crates/noon-core/src/patch.rs
@@ -166,6 +166,7 @@ impl SceneDefinition {
             next_object_id,
             tracks,
             next_track_id,
+            camera_object: None,
         })
     }
 
@@ -254,6 +255,7 @@ impl SceneDefinition {
             return Err(PatchError::UnknownObject(id));
         }
         self.tracks.retain(|track| track.object != id);
+        self.clear_camera_object_if(id);
         Ok(())
     }
 
@@ -478,6 +480,7 @@ mod tests {
                 TrackTiming::new(0.0, 1.0, RateFunction::Linear),
             )
             .expect("valid track");
+        assert!(scene.set_camera_object(object));
 
         scene
             .apply_patch(ScenePatch::RemoveObject(object))
@@ -485,6 +488,7 @@ mod tests {
 
         assert!(scene.object(object).is_none());
         assert!(scene.tracks().is_empty());
+        assert_eq!(scene.camera_object(), None);
     }
 
     #[test]
@@ -544,6 +548,7 @@ mod tests {
 
         assert_eq!(scene.objects(), objects);
         assert_eq!(scene.tracks(), tracks);
+        assert_eq!(scene.camera_object(), None);
         assert_eq!(scene.add(GeometryRef::circle(0.5)), ObjectId::new(8));
         assert_eq!(
             scene

--- a/crates/noon-core/src/reactive.rs
+++ b/crates/noon-core/src/reactive.rs
@@ -10,6 +10,9 @@ pub use composition::*;
 mod host_callbacks;
 pub use host_callbacks::*;
 
+#[path = "camera.rs"]
+mod camera;
+
 mod host_semantics;
 pub use host_semantics::*;
 

--- a/crates/noon-ir/src/legacy.rs
+++ b/crates/noon-ir/src/legacy.rs
@@ -6,7 +6,9 @@
 
 #![forbid(unsafe_code)]
 
-use noon_core::{ObjectDefinition, PatchError, SceneDefinition, ScenePatch, TrackDefinition};
+use noon_core::{
+    ObjectDefinition, ObjectId, PatchError, SceneDefinition, ScenePatch, TrackDefinition,
+};
 use serde::{Deserialize, Serialize};
 
 pub const FORMAT_VERSION: u32 = 1;
@@ -26,6 +28,8 @@ pub struct SceneDocument {
     pub version: u32,
     pub objects: Vec<ObjectDefinition>,
     pub tracks: Vec<TrackDefinition>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub camera_object: Option<ObjectId>,
 }
 
 impl SceneDocument {
@@ -34,12 +38,20 @@ impl SceneDocument {
             version: FORMAT_VERSION,
             objects: scene.objects().to_vec(),
             tracks: scene.tracks().to_vec(),
+            camera_object: scene.camera_object(),
         }
     }
 
     pub fn into_scene(self) -> Result<SceneDefinition, IrError> {
         ensure_version(self.version)?;
-        SceneDefinition::from_parts(self.objects, self.tracks).map_err(IrError::Patch)
+        let mut scene =
+            SceneDefinition::from_parts(self.objects, self.tracks).map_err(IrError::Patch)?;
+        if let Some(camera_object) = self.camera_object {
+            if !scene.set_camera_object(camera_object) {
+                return Err(IrError::Patch(PatchError::UnknownObject(camera_object)));
+            }
+        }
+        Ok(scene)
     }
 }
 
@@ -126,6 +138,7 @@ mod tests {
     use noon_core::{
         CompositionTimeMap, CompositionTimeMapStep, Easing, GeometryRef, ObjectId, Property,
         RateFunction, Style, TrackTiming, TrackValues, Transform2D, Vec2, VectorPath,
+        DEFAULT_FRAME_HEIGHT, DEFAULT_FRAME_WIDTH,
     };
 
     use super::*;
@@ -157,6 +170,24 @@ mod tests {
         assert_eq!(decoded.objects(), scene.objects());
         assert_eq!(decoded.tracks(), scene.tracks());
         assert_eq!(decoded.add(GeometryRef::circle(1.0)), ObjectId::new(1));
+    }
+
+    #[test]
+    fn camera_object_is_additive_on_version_one_wire_format() {
+        let mut scene = SceneDefinition::new();
+        let frame = scene.add(GeometryRef::rectangle(
+            DEFAULT_FRAME_WIDTH,
+            DEFAULT_FRAME_HEIGHT,
+        ));
+        assert!(scene.set_camera_object(frame));
+        let json = encode_scene(&scene).expect("camera scene must serialize");
+        assert!(json.contains("\"version\":1"));
+        assert!(json.contains("\"camera_object\":0"));
+        let decoded = decode_scene(&json).expect("camera scene must decode");
+        assert_eq!(decoded.camera_object(), Some(frame));
+
+        let ordinary = encode_scene(&sample_scene()).expect("ordinary scene must serialize");
+        assert!(!ordinary.contains("camera_object"));
     }
 
     #[test]

--- a/crates/noon-ir/src/semantic/signal_timeline.rs
+++ b/crates/noon-ir/src/semantic/signal_timeline.rs
@@ -144,6 +144,7 @@ pub fn timed_document_from_parts_with_native_inputs(
             version,
             objects,
             tracks,
+            camera_object: None,
             reactive,
         },
         signal_tracks,

--- a/crates/noon-ir/src/semantic_impl.rs
+++ b/crates/noon-ir/src/semantic_impl.rs
@@ -1,6 +1,6 @@
 use noon_core::{
-    ObjectDefinition, PatchError, ReactiveBinding, ReactiveError, ReactiveGraphDefinition,
-    SemanticScene, SignalDefinition, TrackDefinition,
+    ObjectDefinition, ObjectId, PatchError, ReactiveBinding, ReactiveError,
+    ReactiveGraphDefinition, SemanticScene, SignalDefinition, TrackDefinition,
 };
 use serde::{Deserialize, Serialize};
 
@@ -41,6 +41,8 @@ pub struct SemanticSceneDocument {
     pub version: u32,
     pub objects: Vec<ObjectDefinition>,
     pub tracks: Vec<TrackDefinition>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub camera_object: Option<ObjectId>,
     #[serde(default, skip_serializing_if = "ReactiveGraphDocument::is_empty")]
     pub reactive: ReactiveGraphDocument,
 }
@@ -51,6 +53,7 @@ impl SemanticSceneDocument {
             version: FORMAT_VERSION,
             objects: scene.definition().objects().to_vec(),
             tracks: scene.definition().tracks().to_vec(),
+            camera_object: scene.definition().camera_object(),
             reactive: ReactiveGraphDocument::from_graph(scene.reactive()),
         }
     }
@@ -61,9 +64,16 @@ impl SemanticSceneDocument {
                 self.version,
             )));
         }
-        let definition = noon_core::SceneDefinition::from_parts(self.objects, self.tracks)
+        let mut definition = noon_core::SceneDefinition::from_parts(self.objects, self.tracks)
             .map_err(IrError::Patch)
             .map_err(SemanticIrError::Scene)?;
+        if let Some(camera_object) = self.camera_object {
+            if !definition.set_camera_object(camera_object) {
+                return Err(SemanticIrError::Scene(IrError::Patch(
+                    PatchError::UnknownObject(camera_object),
+                )));
+            }
+        }
         let reactive = self
             .reactive
             .into_graph()
@@ -181,6 +191,16 @@ mod tests {
             state.value(position),
             Some(&ReactiveValue::Vec2(Vec2::new(0.25, 1.0)))
         );
+    }
+
+    #[test]
+    fn semantic_camera_role_round_trips_with_reactive_graph() {
+        let mut scene = SemanticScene::new();
+        let frame = scene.add(GeometryRef::rectangle(14.0, 8.0));
+        assert!(scene.definition_mut().set_camera_object(frame));
+        let json = encode_semantic_scene(&scene).expect("semantic camera scene must serialize");
+        let decoded = decode_semantic_scene(&json).expect("semantic camera scene must decode");
+        assert_eq!(decoded.definition().camera_object(), Some(frame));
     }
 
     #[test]

--- a/crates/noon-web/src/execution_canvas.rs
+++ b/crates/noon-web/src/execution_canvas.rs
@@ -70,6 +70,7 @@ mod wasm {
                     "execution renderer must start from an applied transport snapshot",
                 ));
             }
+            let camera = mirror.camera();
 
             let mut instance_descriptor = wgpu::InstanceDescriptor::new_without_display_handle();
             instance_descriptor.backends = wgpu::Backends::BROWSER_WEBGPU | wgpu::Backends::GL;
@@ -122,8 +123,8 @@ mod wasm {
                 pending_changes,
                 preparer: FramePreparer::new(),
                 renderer,
-                camera_center: Vec2::ZERO,
-                camera_height: MANIM_DEFAULT_CAMERA_HEIGHT,
+                camera_center: camera.center,
+                camera_height: camera.height,
                 clear_color: MANIM_DEFAULT_CLEAR_COLOR,
                 last_draw_calls: 0,
                 last_instances_drawn: 0,
@@ -144,6 +145,12 @@ mod wasm {
             let (outcome, changes) = self.mirror.apply_json(json).map_err(js_error)?;
             match outcome {
                 TransportApplyOutcome::Applied => {
+                    let camera = self.mirror.camera();
+                    if camera.center != self.camera_center || camera.height != self.camera_height {
+                        self.camera_center = camera.center;
+                        self.camera_height = camera.height;
+                        self.update_camera()?;
+                    }
                     self.pending_changes = changes;
                     Ok(true)
                 }
@@ -225,6 +232,8 @@ mod wasm {
             Ok(())
         }
 
+        /// Manual camera control remains as a low-level host API. Semantic scene
+        /// deltas automatically overwrite it with their shared Rust camera state.
         #[wasm_bindgen(js_name = setCamera)]
         pub fn set_camera(
             &mut self,

--- a/crates/noon-web/src/execution_transport.rs
+++ b/crates/noon-web/src/execution_transport.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use noon_core::{GeometryRef, ObjectId, Style, Transform2D};
+use noon_core::{Camera2DState, GeometryRef, ObjectId, Style, Transform2D};
 use noon_runtime::{
     ExecutionSlotError, ExecutionSlotId, FrameChanges, FrameObjectState, FrameState,
 };
@@ -49,6 +49,8 @@ pub struct ExecutionDeltaEnvelope {
     pub sequence: u64,
     pub snapshot: bool,
     pub time: f64,
+    #[serde(default)]
+    pub camera: Camera2DState,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub removed: Vec<TransportSlotId>,
     pub objects: Vec<TransportObjectState>,
@@ -69,6 +71,8 @@ pub enum ExecutionTransportError {
     InvalidChannel(String),
     UnsupportedVersion(u32),
     InvalidTime(f64),
+    InvalidCameraState,
+    InvalidCameraObject(ObjectId),
     SequenceExhausted,
     SessionRequiresSnapshot { session: u32, sequence: u64 },
     SequenceGap { expected: u64, actual: u64 },
@@ -99,6 +103,14 @@ impl std::fmt::Display for ExecutionTransportError {
                 )
             }
             Self::InvalidTime(time) => write!(formatter, "invalid execution delta time {time}"),
+            Self::InvalidCameraState => {
+                formatter.write_str("invalid execution transport camera state")
+            }
+            Self::InvalidCameraObject(object) => write!(
+                formatter,
+                "camera object {} is missing or not a supported 2D frame",
+                object.get()
+            ),
             Self::SequenceExhausted => {
                 formatter.write_str("execution transport sequence exhausted")
             }
@@ -178,6 +190,18 @@ impl From<serde_json::Error> for ExecutionTransportError {
     }
 }
 
+#[derive(Clone, Copy, Debug, Default, Deserialize)]
+struct CameraRoleProbe {
+    #[serde(default)]
+    camera_object: Option<ObjectId>,
+}
+
+fn camera_object_from_scene_json(
+    scene_json: &str,
+) -> Result<Option<ObjectId>, ExecutionTransportError> {
+    Ok(serde_json::from_str::<CameraRoleProbe>(scene_json)?.camera_object)
+}
+
 #[derive(Clone, Debug)]
 pub struct ExecutionDeltaEncoder {
     session: u32,
@@ -185,6 +209,7 @@ pub struct ExecutionDeltaEncoder {
     initialized: bool,
     slot_orders: HashMap<TransportSlotId, u32>,
     next_order: u32,
+    camera_object: Option<ObjectId>,
 }
 
 impl ExecutionDeltaEncoder {
@@ -195,6 +220,7 @@ impl ExecutionDeltaEncoder {
             initialized: false,
             slot_orders: HashMap::new(),
             next_order: 0,
+            camera_object: None,
         }
     }
 
@@ -210,6 +236,14 @@ impl ExecutionDeltaEncoder {
         self.initialized
     }
 
+    pub const fn camera_object(&self) -> Option<ObjectId> {
+        self.camera_object
+    }
+
+    pub fn set_camera_object(&mut self, camera_object: Option<ObjectId>) {
+        self.camera_object = camera_object;
+    }
+
     pub fn contains_slot(&self, slot: ExecutionSlotId) -> bool {
         self.slot_orders.contains_key(&TransportSlotId::from(slot))
     }
@@ -220,6 +254,7 @@ impl ExecutionDeltaEncoder {
         live_objects: &[(ExecutionSlotId, usize)],
     ) -> Result<ExecutionDeltaEnvelope, ExecutionTransportError> {
         self.validate_time(frame.time)?;
+        let camera = self.camera_state(frame)?;
         self.slot_orders.clear();
         self.next_order = 0;
         let mut objects = Vec::with_capacity(live_objects.len());
@@ -246,6 +281,7 @@ impl ExecutionDeltaEncoder {
             sequence,
             snapshot: true,
             time: frame.time,
+            camera,
             removed: Vec::new(),
             objects,
         })
@@ -265,6 +301,7 @@ impl ExecutionDeltaEncoder {
         if dirty_objects.is_empty() && added_objects.is_empty() && removed_slots.is_empty() {
             return Ok(None);
         }
+        let camera = self.camera_state(frame)?;
 
         let mut removed = Vec::with_capacity(removed_slots.len());
         let mut seen_removed = HashSet::with_capacity(removed_slots.len());
@@ -314,6 +351,7 @@ impl ExecutionDeltaEncoder {
             sequence,
             snapshot: false,
             time: frame.time,
+            camera,
             removed,
             objects,
         }))
@@ -325,6 +363,19 @@ impl ExecutionDeltaEncoder {
         } else {
             Err(ExecutionTransportError::InvalidTime(time))
         }
+    }
+
+    fn camera_state(&self, frame: &FrameState) -> Result<Camera2DState, ExecutionTransportError> {
+        let Some(camera_object) = self.camera_object else {
+            return Ok(Camera2DState::default());
+        };
+        let object = frame
+            .objects
+            .iter()
+            .find(|object| object.id == camera_object)
+            .ok_or(ExecutionTransportError::InvalidCameraObject(camera_object))?;
+        Camera2DState::from_frame_object(&object.geometry, object.transform)
+            .ok_or(ExecutionTransportError::InvalidCameraObject(camera_object))
     }
 
     fn take_sequence(&mut self) -> Result<u64, ExecutionTransportError> {
@@ -369,12 +420,17 @@ pub struct ExecutionFrameMirror {
     slots: Vec<TransportSlotId>,
     slot_indices: HashMap<TransportSlotId, usize>,
     object_slots: HashMap<ObjectId, TransportSlotId>,
+    camera: Camera2DState,
     frame: Option<FrameState>,
 }
 
 impl ExecutionFrameMirror {
     pub fn frame(&self) -> Option<&FrameState> {
         self.frame.as_ref()
+    }
+
+    pub const fn camera(&self) -> Camera2DState {
+        self.camera
     }
 
     pub fn session(&self) -> Option<u32> {
@@ -432,6 +488,7 @@ impl ExecutionFrameMirror {
         } else {
             self.apply_partial(&delta)?
         };
+        self.camera = delta.camera;
         self.next_sequence = delta
             .sequence
             .checked_add(1)
@@ -456,6 +513,13 @@ impl ExecutionFrameMirror {
         if !delta.time.is_finite() {
             return Err(ExecutionTransportError::InvalidTime(delta.time));
         }
+        if !delta.camera.center.x.is_finite()
+            || !delta.camera.center.y.is_finite()
+            || !delta.camera.height.is_finite()
+            || delta.camera.height <= 0.0
+        {
+            return Err(ExecutionTransportError::InvalidCameraState);
+        }
         Ok(())
     }
 
@@ -465,6 +529,7 @@ impl ExecutionFrameMirror {
         self.slots.clear();
         self.slot_indices.clear();
         self.object_slots.clear();
+        self.camera = Camera2DState::default();
         self.frame = None;
     }
 
@@ -690,10 +755,13 @@ impl EngineScenePlayer {
         loop_duration_seconds: f64,
         session: u32,
     ) -> Result<Self, ExecutionTransportError> {
+        let camera_object = camera_object_from_scene_json(scene_json)?;
+        let mut encoder = ExecutionDeltaEncoder::new(session);
+        encoder.set_camera_object(camera_object);
         Ok(Self {
             player: ScenePlayer::from_scene_json(scene_json)?,
             clock: PlaybackClock::looping(loop_duration_seconds)?,
-            encoder: ExecutionDeltaEncoder::new(session),
+            encoder,
         })
     }
 
@@ -749,7 +817,9 @@ impl EngineScenePlayer {
         &mut self,
         json: &str,
     ) -> Result<String, ExecutionTransportError> {
+        let camera_object = camera_object_from_scene_json(json)?;
         self.player.replace_scene_json(json)?;
+        self.encoder.set_camera_object(camera_object);
         self.clock.reset();
         self.force_snapshot_json()
     }
@@ -758,8 +828,15 @@ impl EngineScenePlayer {
         &mut self,
         json: &str,
     ) -> Result<(ReconcileOutcome, Option<String>), ExecutionTransportError> {
+        let camera_object = camera_object_from_scene_json(json)?;
+        let camera_changed = camera_object != self.encoder.camera_object();
         let outcome = self.player.reconcile_scene_json(json)?;
-        let delta = self.take_delta_json()?;
+        self.encoder.set_camera_object(camera_object);
+        let delta = if camera_changed {
+            Some(self.force_snapshot_json()?)
+        } else {
+            self.take_delta_json()?
+        };
         Ok((outcome, delta))
     }
 
@@ -907,7 +984,10 @@ pub use wasm::*;
 
 #[cfg(test)]
 mod tests {
-    use noon_core::{GeometryRef, ObjectId, SceneDefinition, ScenePatch, TrackTiming, Vec2};
+    use noon_core::{
+        GeometryRef, ObjectId, SceneDefinition, ScenePatch, TrackTiming, Vec2,
+        DEFAULT_FRAME_HEIGHT, DEFAULT_FRAME_WIDTH,
+    };
     use noon_ir::{encode_patch_batch, encode_scene, PatchBatch};
 
     use super::*;
@@ -936,6 +1016,26 @@ mod tests {
         encode_scene(&scene).unwrap()
     }
 
+    fn camera_scene_json() -> String {
+        let mut scene = SceneDefinition::new();
+        scene.add(GeometryRef::circle(1.0));
+        let frame = scene.add(GeometryRef::rectangle(
+            DEFAULT_FRAME_WIDTH,
+            DEFAULT_FRAME_HEIGHT,
+        ));
+        scene.object_mut(frame).unwrap().style.opacity = 0.0;
+        assert!(scene.set_camera_object(frame));
+        scene
+            .animate_position(
+                frame,
+                Vec2::ZERO,
+                Vec2::new(3.0, -1.0),
+                TrackTiming::new(0.0, 2.0, noon_core::Easing::Linear),
+            )
+            .unwrap();
+        encode_scene(&scene).unwrap()
+    }
+
     #[test]
     fn snapshot_then_dirty_delta_round_trip() {
         let mut player = ScenePlayer::from_scene_json(&scene_json()).unwrap();
@@ -957,6 +1057,27 @@ mod tests {
         assert_eq!(outcome, TransportApplyOutcome::Applied);
         assert_eq!(changes.object_indices(), &[0]);
         assert_eq!(mirror.frame().unwrap(), player.frame());
+    }
+
+    #[test]
+    fn camera_state_uses_same_evaluated_transform_as_scene_objects() {
+        let mut player = EngineScenePlayer::new(&camera_scene_json(), 4.0, 19).unwrap();
+        let initial: ExecutionDeltaEnvelope =
+            serde_json::from_str(&player.initial_delta_json().unwrap()).unwrap();
+        assert_eq!(initial.camera, Camera2DState::default());
+
+        let delta_json = player.tick_delta_json(0.0).unwrap();
+        assert!(delta_json.is_none());
+        let delta_json = player.tick_delta_json(1_000.0).unwrap().unwrap();
+        let delta: ExecutionDeltaEnvelope = serde_json::from_str(&delta_json).unwrap();
+        assert!((delta.camera.center.x - 1.5).abs() < 1.0e-5);
+        assert!((delta.camera.center.y + 0.5).abs() < 1.0e-5);
+        assert_eq!(delta.camera.height, DEFAULT_FRAME_HEIGHT);
+
+        let mut mirror = ExecutionFrameMirror::default();
+        mirror.apply(initial).unwrap();
+        mirror.apply(delta).unwrap();
+        assert!((mirror.camera().center.x - 1.5).abs() < 1.0e-5);
     }
 
     #[test]
@@ -1016,6 +1137,7 @@ mod tests {
             sequence: 3,
             snapshot: false,
             time: 0.0,
+            camera: Camera2DState::default(),
             removed: Vec::new(),
             objects: Vec::new(),
         };

--- a/crates/noon-web/tests/moving_camera_determinism.rs
+++ b/crates/noon-web/tests/moving_camera_determinism.rs
@@ -1,0 +1,69 @@
+use noon::prelude::*;
+use noon_core::Camera2DState;
+use noon_ir::{decode_scene, encode_scene};
+use noon_web::{EngineScenePlayer, ExecutionDeltaEnvelope, ScenePlayer};
+
+fn moving_camera_scene_json() -> String {
+    let mut scene = MovingCameraScene::new();
+    let frame = scene.camera_frame();
+    scene.wait(0.3).unwrap();
+    scene
+        .play(frame.animate().move_to(LEFT * 2.0))
+        .run_time(1.0)
+        .unwrap();
+    scene.wait(0.3).unwrap();
+    scene
+        .play(frame.animate().move_to(RIGHT * 2.0))
+        .run_time(1.0)
+        .unwrap();
+    encode_scene(&scene.into_definition()).unwrap()
+}
+
+fn direct_camera(scene_json: &str, time: f64) -> Camera2DState {
+    let definition = decode_scene(scene_json).unwrap();
+    let camera_object = definition.camera_object().unwrap();
+    let mut player = ScenePlayer::from_scene_json(scene_json).unwrap();
+    player.advance_to(time).unwrap();
+    let frame = player
+        .frame()
+        .objects
+        .iter()
+        .find(|object| object.id == camera_object)
+        .unwrap();
+    Camera2DState::from_frame_object(&frame.geometry, frame.transform).unwrap()
+}
+
+fn delta_camera(delta_json: &str) -> Camera2DState {
+    serde_json::from_str::<ExecutionDeltaEnvelope>(delta_json)
+        .unwrap()
+        .camera
+}
+
+fn assert_camera_close(actual: Camera2DState, expected: Camera2DState) {
+    assert!((actual.center.x - expected.center.x).abs() < 1.0e-5);
+    assert!((actual.center.y - expected.center.y).abs() < 1.0e-5);
+    assert!((actual.height - expected.height).abs() < 1.0e-5);
+}
+
+#[test]
+fn direct_seek_incremental_playback_and_loop_rewind_agree_for_camera() {
+    let scene_json = moving_camera_scene_json();
+    let mut engine = EngineScenePlayer::new(&scene_json, 2.6, 41).unwrap();
+
+    let initial = engine.initial_delta_json().unwrap();
+    assert_camera_close(delta_camera(&initial), direct_camera(&scene_json, 0.0));
+    assert!(engine.tick_delta_json(0.0).unwrap().is_none());
+
+    let at_one = engine.tick_delta_json(1_000.0).unwrap().unwrap();
+    assert_camera_close(delta_camera(&at_one), direct_camera(&scene_json, 1.0));
+
+    let at_two_point_two = engine.tick_delta_json(2_200.0).unwrap().unwrap();
+    assert_camera_close(
+        delta_camera(&at_two_point_two),
+        direct_camera(&scene_json, 2.2),
+    );
+
+    // 3.0 seconds on a 2.6-second loop rewinds deterministically to scene time 0.4.
+    let rewound = engine.tick_delta_json(3_000.0).unwrap().unwrap();
+    assert_camera_close(delta_camera(&rewound), direct_camera(&scene_json, 0.4));
+}

--- a/crates/noon/examples/manim_gallery_moving_camera_center.rs
+++ b/crates/noon/examples/manim_gallery_moving_camera_center.rs
@@ -1,0 +1,53 @@
+use noon::prelude::*;
+use noon_ir::encode_scene;
+
+fn triangle() -> Path {
+    let path = VectorPath::new()
+        .move_to(Vec2::new(0.0, 1.0))
+        .line_to(Vec2::new(-0.866_025_4, -0.5))
+        .line_to(Vec2::new(0.866_025_4, -0.5))
+        .close();
+    Path::new(path)
+}
+
+fn moving_camera_center() -> MovingCameraScene {
+    let mut scene = MovingCameraScene::new();
+    scene.wait(0.3).unwrap();
+
+    let square = scene.add(
+        Square::default()
+            .color(RED)
+            .set_fill(Some(RED), Some(0.5))
+            .move_to(LEFT * 2.0),
+    );
+    let triangle = scene.add(
+        triangle()
+            .color(GREEN)
+            .set_fill(Some(GREEN), Some(0.5))
+            .move_to(RIGHT * 2.0),
+    );
+
+    let frame = scene.camera_frame();
+    scene
+        .play(frame.animate().move_to(LEFT * 2.0))
+        .run_time(1.0)
+        .unwrap();
+    scene.wait(0.3).unwrap();
+    scene
+        .play(frame.animate().move_to(RIGHT * 2.0))
+        .run_time(1.0)
+        .unwrap();
+
+    // Keep the target objects live so their semantic identities remain part of the
+    // authored scene just as they are in Manim's MovingCameraCenter example.
+    let _ = (square, triangle);
+    scene
+}
+
+fn main() {
+    let scene = moving_camera_center();
+    println!(
+        "MovingCameraCenter\t{}",
+        encode_scene(&scene.into_definition()).unwrap()
+    );
+}

--- a/crates/noon/src/camera_authoring.rs
+++ b/crates/noon/src/camera_authoring.rs
@@ -1,0 +1,100 @@
+use std::ops::{Deref, DerefMut};
+
+use noon_core::{SceneDefinition, DEFAULT_FRAME_HEIGHT, DEFAULT_FRAME_WIDTH};
+
+use crate::{AuthoringError, Mobject, Rectangle, Scene};
+
+/// Rust authoring facade for a scene with a shared semantic 2D camera frame.
+///
+/// The frame is an ordinary Noon mobject. Its motion is authored through the same
+/// `Animate`/Transform timeline as every other object; converting the facade into a
+/// `SceneDefinition` only assigns the shared camera role understood by the Rust
+/// execution/render pipeline.
+#[derive(Clone, Debug, PartialEq)]
+pub struct MovingCameraScene {
+    scene: Scene,
+    frame: Mobject,
+}
+
+impl MovingCameraScene {
+    pub fn new() -> Self {
+        let mut scene = Scene::new();
+        let frame =
+            scene.add(Rectangle::new(DEFAULT_FRAME_WIDTH, DEFAULT_FRAME_HEIGHT).set_opacity(0.0));
+        Self { scene, frame }
+    }
+
+    pub const fn camera_frame(&self) -> Mobject {
+        self.frame
+    }
+
+    pub fn into_definition(self) -> SceneDefinition {
+        let frame = self.frame;
+        let mut definition = self.scene.into_definition();
+        let assigned = definition.set_camera_object(frame.id());
+        debug_assert!(assigned, "camera frame must belong to the authored scene");
+        definition
+    }
+
+    pub fn try_into_definition(self) -> Result<SceneDefinition, AuthoringError> {
+        let frame = self.frame;
+        let mut definition = self.scene.into_definition();
+        if !definition.set_camera_object(frame.id()) {
+            return Err(AuthoringError::UnknownObject(frame.id()));
+        }
+        Ok(definition)
+    }
+}
+
+impl Default for MovingCameraScene {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Deref for MovingCameraScene {
+    type Target = Scene;
+
+    fn deref(&self) -> &Self::Target {
+        &self.scene
+    }
+}
+
+impl DerefMut for MovingCameraScene {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.scene
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use noon_core::{Property, Vec2, RIGHT};
+
+    use super::*;
+
+    #[test]
+    fn rust_moving_camera_facade_uses_ordinary_transform_tracks() {
+        let mut scene = MovingCameraScene::new();
+        let frame = scene.camera_frame();
+        scene
+            .play(frame.animate().move_to(RIGHT * 3.0))
+            .run_time(1.0)
+            .unwrap();
+
+        let definition = scene.into_definition();
+        assert_eq!(definition.camera_object(), Some(frame.id()));
+        let tracks = definition
+            .tracks()
+            .iter()
+            .filter(|track| track.object == frame.id())
+            .collect::<Vec<_>>();
+        assert_eq!(tracks.len(), 1);
+        assert_eq!(tracks[0].property, Property::Transform);
+        let target = match &tracks[0].values {
+            noon_core::TrackValues::Object { to, .. } => to,
+            other => panic!("camera frame must use shared transform track, got {other:?}"),
+        };
+        assert_eq!(target.transform.translation, Vec2::new(3.0, 0.0));
+        assert_eq!(target.style.opacity, 0.0);
+    }
+}

--- a/crates/noon/src/lib.rs
+++ b/crates/noon/src/lib.rs
@@ -6,16 +6,20 @@
 
 #![forbid(unsafe_code)]
 
+mod camera_authoring;
 mod legacy;
 mod reactive_authoring;
 
+pub use camera_authoring::*;
 pub use legacy::*;
 pub use reactive_authoring::*;
 
 /// Common imports for deterministic and native-reactive Noon authoring.
 pub mod prelude {
     pub use crate::legacy::prelude::*;
-    pub use crate::{ReactiveScene, ReactiveTimelineScene, ValueTracker, VectorSignal};
+    pub use crate::{
+        MovingCameraScene, ReactiveScene, ReactiveTimelineScene, ValueTracker, VectorSignal,
+    };
     pub use noon_core::{
         resolve_animation_options, resolve_composition_schedule, resolve_lifecycle_plan,
         resolve_uniform_composition_schedule, validate_presence_transition, AnimationDefaults,

--- a/docs/manim-raster-differential.md
+++ b/docs/manim-raster-differential.md
@@ -23,6 +23,8 @@ These are intentionally separate from the demo's pedagogical Noon adaptations. A
 
 The harness renders real lossless Manim PNG frames, authors the same scene through Noon's Pyodide compatibility frontend, and seeks Noon to the matching Manim frame times. It captures both WebGPU and WebGL2. Each fixture gets an independent browser canvas player so capture state cannot leak between scenes.
 
+Manim's PNG sequence does not necessarily materialize one image for every logical scene frame: static `wait()` ranges can be represented without duplicate PNG files. The raster oracle therefore takes each materialized PNG's **logical scene time** from the semantic Manim renderer trace; it must not reconstruct time as `frame_index / fps`. Noon rendering, callback advancement, semantic-state capture, and the selected Manim PNG all use that same logical timestamp.
+
 The default 2D presentation contract is also part of parity: the camera is centered at the origin with an **8.0-world-unit frame height** (16:9 width at the default aspect) and a **black background**. All browser canvas player entry points must use that same default contract; the differential harness must not compensate for a runtime-specific camera or clear color.
 
 ## Artifacts and diagnostics

--- a/parity/manim-v0.21/manifest.json
+++ b/parity/manim-v0.21/manifest.json
@@ -294,6 +294,11 @@
       "id": "moving-dots",
       "scene": "MovingDots",
       "expected_duration": 3.0
+    },
+    {
+      "id": "moving-camera-center",
+      "scene": "MovingCameraCenter",
+      "expected_duration": 2.6
     }
   ],
   "sample_fractions": [

--- a/parity/manim-v0.21/quickstart.py
+++ b/parity/manim-v0.21/quickstart.py
@@ -417,7 +417,6 @@ class DotEllipseParity(Scene):
             fill_opacity=1.0,
             stroke_opacity=0.0,
         ).rotate(PI / 6).move_to(2.5 * RIGHT + 1.5 * DOWN)
-
         self.add(default_dot, blue_dot, wide, tall)
         self.play(tall.animate.shift(ORIGIN))
 
@@ -628,3 +627,14 @@ class MovingDots(Scene):
         self.play(x.animate.set_value(5))
         self.play(y.animate.set_value(4))
         self.wait()
+
+
+class MovingCameraCenter(MovingCameraScene):
+    def construct(self):
+        s = Square(color=RED, fill_opacity=0.5).move_to(2 * LEFT)
+        t = Triangle(color=GREEN, fill_opacity=0.5).move_to(2 * RIGHT)
+        self.wait(0.3)
+        self.add(s, t)
+        self.play(self.camera.frame.animate.move_to(s))
+        self.wait(0.3)
+        self.play(self.camera.frame.animate.move_to(t))

--- a/parity/manim-v0.21/upstream-examples/moving_camera_center.py
+++ b/parity/manim-v0.21/upstream-examples/moving_camera_center.py
@@ -1,0 +1,12 @@
+from manim import *
+
+
+class MovingCameraCenter(MovingCameraScene):
+    def construct(self):
+        s = Square(color=RED, fill_opacity=0.5).move_to(2 * LEFT)
+        t = Triangle(color=GREEN, fill_opacity=0.5).move_to(2 * RIGHT)
+        self.wait(0.3)
+        self.add(s, t)
+        self.play(self.camera.frame.animate.move_to(s))
+        self.wait(0.3)
+        self.play(self.camera.frame.animate.move_to(t))

--- a/scripts/cross-language-parity.mjs
+++ b/scripts/cross-language-parity.mjs
@@ -71,6 +71,16 @@ const movingAroundPython = readFileSync(
   path.join(repoRoot, "web", "python", "examples", "manim_gallery_moving_around.py"),
   "utf8",
 );
+const movingCameraPython = readFileSync(
+  path.join(
+    repoRoot,
+    "web",
+    "python",
+    "examples",
+    "manim_example_moving_camera_center.py",
+  ),
+  "utf8",
+);
 
 const javascriptParityCases = new Set([
   "animate_options",
@@ -131,6 +141,21 @@ function assertSemanticEqual(actual, expected, location = "document") {
   assert.equal(actual, expected, `${location}: value mismatch`);
 }
 
+function cameraProjection(document) {
+  assert.ok(Number.isInteger(document.camera_object), "moving camera document must identify camera_object");
+  const cameraObject = document.objects.find((object) => object.id === document.camera_object);
+  assert.ok(cameraObject, "moving camera document must retain its camera frame object");
+  return {
+    camera_object: document.camera_object,
+    camera: cameraObject,
+    // Track ids are allocator-local bookkeeping, not part of the cross-language
+    // camera contract. Compare the authored target/property/timing/value semantics.
+    tracks: document.tracks
+      .filter((track) => track.object === document.camera_object)
+      .map(({ id: _id, ...track }) => track),
+  };
+}
+
 async function javascriptCorpora(page) {
   return page.evaluate(async () => {
     const noon = await import("/web/noon-authoring.js");
@@ -184,7 +209,15 @@ async function javascriptCorpora(page) {
       gallery[name] = build().toJSON();
     }
 
-    return { parity, quickstart, gallery };
+    const cameraExamples = await import(
+      "/web/js/examples/manim-gallery-moving-camera-center.js"
+    );
+    const movingCamera = {};
+    for (const [name, build] of Object.entries(cameraExamples.galleryMovingCameraCenter)) {
+      movingCamera[name] = build().toJSON();
+    }
+
+    return { parity, quickstart, gallery, movingCamera };
   });
 }
 
@@ -217,9 +250,11 @@ try {
   const rust = rustCorpus();
   const rustQuickstart = rustCorpus("manim_quickstart_equivalents");
   const rustMovingAround = rustCorpus("manim_gallery_moving_around");
+  const rustMovingCamera = rustCorpus("manim_gallery_moving_camera_center");
   assert.deepEqual([...rust.keys()].sort(), Object.keys(pythonCases).sort());
   assert.deepEqual([...rustQuickstart.keys()].sort(), [...quickstartEquivalentCases].sort());
   assert.deepEqual([...rustMovingAround.keys()], ["MovingAround"]);
+  assert.deepEqual([...rustMovingCamera.keys()], ["MovingCameraCenter"]);
 
   await waitForServer();
   browser = await chromium.launch({
@@ -258,6 +293,21 @@ try {
     "MovingAround: python/rust",
   );
 
+  const movingCameraResult = await page.evaluate(
+    (pythonSource) => window.noonManimCompat.run(pythonSource),
+    movingCameraPython,
+  );
+  assert.equal(
+    movingCameraResult.kind,
+    "scene_document",
+    "MovingCameraCenter: Python authoring failed",
+  );
+  assertSemanticEqual(
+    cameraProjection(movingCameraResult.document),
+    cameraProjection(rustMovingCamera.get("MovingCameraCenter")),
+    "MovingCameraCenter camera semantics: python/rust",
+  );
+
   const javascript = await javascriptCorpora(page);
   assert.deepEqual(Object.keys(javascript.parity).sort(), [...javascriptParityCases].sort());
   for (const [name, document] of Object.entries(javascript.parity)) {
@@ -278,9 +328,16 @@ try {
     "MovingAround: javascript/rust",
   );
 
+  assert.deepEqual(Object.keys(javascript.movingCamera), ["MovingCameraCenter"]);
+  assertSemanticEqual(
+    cameraProjection(javascript.movingCamera.MovingCameraCenter),
+    cameraProjection(rustMovingCamera.get("MovingCameraCenter")),
+    "MovingCameraCenter camera semantics: javascript/rust",
+  );
+
   assert.equal(errors.length, 0, errors.join("\n"));
   console.log(
-    "Python/Rust parity, JavaScript parity, Rust/JavaScript Quickstart equivalence, and MovingAround tri-language equivalence passed",
+    "Python/Rust parity, JavaScript parity, Rust/JavaScript Quickstart equivalence, MovingAround tri-language equivalence, and MovingCameraCenter camera-semantic equivalence passed",
   );
 } finally {
   if (browser !== null) await browser.close();

--- a/scripts/manim-raster-differential.mjs
+++ b/scripts/manim-raster-differential.mjs
@@ -21,6 +21,8 @@ const artifactRoot = path.resolve(
   repoRoot,
   process.env.NOON_MANIM_RASTER_ARTIFACTS ?? "manim-raster-artifacts",
 );
+const semanticRoot = path.join(artifactRoot, "semantic");
+const manimSemanticPath = path.join(semanticRoot, "manim-all-frames.json");
 const port = Number(process.env.NOON_MANIM_RASTER_PORT ?? "4191");
 const baseUrl = `http://127.0.0.1:${port}`;
 const enforce = process.env.NOON_MANIM_RASTER_ENFORCE === "1";
@@ -86,20 +88,42 @@ async function findPngFrames(root, scene) {
   return frames;
 }
 
-function sampleFrames(frameCount) {
+function sampleFrames(frameTimes) {
+  const frameCount = frameTimes.length;
   assert.ok(Number.isSafeInteger(frameCount) && frameCount > 0, "invalid reference frame count");
+  const previous = frameTimes.reduce((last, time, index) => {
+    assert.ok(Number.isFinite(time) && time >= 0, `invalid logical time for reference frame ${index}`);
+    assert.ok(time + 1e-12 >= last, `reference frame ${index} moves backwards in logical time`);
+    return time;
+  }, -Infinity);
+  void previous;
   const indices = manifest.sample_fractions.map((fraction) =>
     Math.round((frameCount - 1) * Number(fraction)),
   );
   return [...new Set(indices)].map((frameIndex) => ({
     frameIndex,
-    time: frameIndex / reference.frame_rate,
+    time: frameTimes[frameIndex],
     label: `frame-${String(frameIndex).padStart(4, "0")}`,
   }));
 }
 
 async function renderManimReferences() {
   verifyManimVersion();
+  await mkdir(semanticRoot, { recursive: true });
+  runChecked("python3", [
+    path.join("scripts", "manim-raster-semantic-reference.py"),
+    "--manifest",
+    manifestPath,
+    "--output",
+    manimSemanticPath,
+  ]);
+  const semantic = JSON.parse(await readFile(manimSemanticPath, "utf8"));
+  assert.equal(semantic.manim_version, reference.version, "raster semantic Manim version");
+  assert.equal(semantic.frame_rate, reference.frame_rate, "raster semantic frame rate");
+  const semanticByFixture = new Map(
+    semantic.fixtures.map((fixture) => [fixture.id, fixture]),
+  );
+
   const results = new Map();
   for (const fixture of manifest.fixtures) {
     const mediaDir = path.join(artifactRoot, "manim-media", fixture.id);
@@ -124,6 +148,14 @@ async function renderManimReferences() {
     ]);
 
     const frameFiles = await findPngFrames(mediaDir, fixture.scene);
+    const semanticFixture = semanticByFixture.get(fixture.id);
+    assert.ok(semanticFixture, `${fixture.id}: missing semantic reference fixture`);
+    assert.equal(
+      semanticFixture.frame_count,
+      frameFiles.length,
+      `${fixture.id}: semantic/PNG Manim frame count`,
+    );
+    const frameTimes = semanticFixture.frames.map((frame) => Number(frame.time));
     const firstFrame = PNG.sync.read(await readFile(frameFiles[0]));
     const logicalDuration = Number(fixture.expected_duration);
     assert.ok(Number.isFinite(logicalDuration) && logicalDuration >= 0, `${fixture.id}: logical duration`);
@@ -139,13 +171,13 @@ async function renderManimReferences() {
     assert.equal(frames.width, reference.pixel_width, `${fixture.id}: Manim reference width`);
     assert.equal(frames.height, reference.pixel_height, `${fixture.id}: Manim reference height`);
 
-    const samples = sampleFrames(frames.frameCount);
+    const samples = sampleFrames(frameTimes);
     for (const sample of samples) {
       const outputPath = path.join(frameDir, `${sample.label}.png`);
       await writeFile(outputPath, await readFile(frameFiles[sample.frameIndex]));
       sample.referencePath = outputPath;
     }
-    results.set(fixture.id, { fixture, frames, samples });
+    results.set(fixture.id, { fixture, frames, frameTimes, samples });
   }
   return results;
 }
@@ -179,6 +211,7 @@ async function authorNoonScenes() {
         document: result.document,
         duration: Number(result.duration),
         hasCallbacks: result.callbacks !== null,
+        hasSemanticCamera: Number.isInteger(result.document.camera_object),
       });
     }
     return scenes;
@@ -287,18 +320,26 @@ async function captureHostFixture(
   );
   assert.equal(loaded.duration, fixture.expected_duration, `${fixture.id}: host authored duration`);
   assert.equal(loaded.objectCount, authored.document.objects.length, `${fixture.id}: host object count`);
-  assert.ok(loaded.callbackSlots > 0, `${fixture.id}: host callback slots`);
+  if (authored.hasCallbacks) {
+    assert.ok(loaded.callbackSlots > 0, `${fixture.id}: host callback slots`);
+  } else {
+    assert.equal(loaded.callbackSlots, 0, `${fixture.id}: deterministic host callback slots`);
+  }
   assert.equal(loaded.rendererBackend, expectedBackend, `${backend}: host renderer backend`);
 
   const captures = [];
   for (const sample of referenceResult.samples) {
     const metrics = await page.evaluate(
-      ({ frameIndex, frameRate }) => window.noonHostRaster.renderThrough(frameIndex, frameRate),
-      { frameIndex: sample.frameIndex, frameRate: reference.frame_rate },
+      ({ frameIndex, frameTimes }) => window.noonHostRaster.renderThrough(frameIndex, frameTimes),
+      { frameIndex: sample.frameIndex, frameTimes: referenceResult.frameTimes },
     );
     assert.equal(metrics.error, null, `${fixture.id}: host render error at frame ${sample.frameIndex}`);
     assert.equal(metrics.presented, true, `${fixture.id}: host frame ${sample.frameIndex} not presented`);
     assert.equal(metrics.frameIndex, sample.frameIndex, `${fixture.id}: host frame index`);
+    assert.ok(
+      Math.abs(Number(metrics.time) - Number(sample.time)) < 1e-9,
+      `${fixture.id}: host logical time mismatch at frame ${sample.frameIndex}`,
+    );
     const outputPath = path.join(fixtureDir, `${sample.label}.png`);
     await page.locator("#scene").screenshot({ path: outputPath });
     captures.push({ ...sample, noonPath: outputPath, metrics });
@@ -327,7 +368,7 @@ async function captureNoonBackend(backend, authoredScenes, references) {
         const fixtureDir = path.join(artifactRoot, backend, fixture.id);
         await mkdir(fixtureDir, { recursive: true });
 
-        if (authored.hasCallbacks) {
+        if (authored.hasCallbacks || authored.hasSemanticCamera) {
           page = await createHostCapturePage(browser);
           output.set(
             fixture.id,

--- a/scripts/manim-raster-semantic-reference.py
+++ b/scripts/manim-raster-semantic-reference.py
@@ -18,7 +18,10 @@ from typing import Any
 
 import numpy as np
 from manim import config, tempconfig
+from manim.camera.camera import Camera
+from manim.camera.moving_camera import MovingCamera
 from manim.renderer.cairo_renderer import CairoRenderer
+from manim.scene.moving_camera_scene import MovingCameraScene
 
 PINNED_MANIM_VERSION = "0.21.0"
 CAIRO_STROKE_WIDTH_SCALE = 0.01
@@ -41,10 +44,10 @@ class NullFileWriter:
 
 
 class SemanticRenderer(CairoRenderer):
-    def __init__(self) -> None:
+    def __init__(self, camera_class: type[Camera] = Camera) -> None:
         self.frames: list[dict[str, Any]] = []
         self._active_scene = None
-        super().__init__(file_writer_class=NullFileWriter)
+        super().__init__(file_writer_class=NullFileWriter, camera_class=camera_class)
 
     def play(self, scene, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
         self._active_scene = scene
@@ -180,7 +183,11 @@ def _render_fixture(
     frame_rate: float,
 ) -> dict[str, Any]:
     scene_class = getattr(module, fixture["scene"])
-    renderer = SemanticRenderer()
+    # A supplied renderer bypasses Scene's normal camera-class construction. Preserve
+    # that contract explicitly so MovingCameraScene uses a real MovingCamera while
+    # the semantic oracle still intercepts frame materialization.
+    camera_class = MovingCamera if issubclass(scene_class, MovingCameraScene) else Camera
+    renderer = SemanticRenderer(camera_class=camera_class)
     scene = scene_class(renderer=renderer)
     scene.setup()
     try:

--- a/web/js/examples/manim-gallery-moving-camera-center.js
+++ b/web/js/examples/manim-gallery-moving-camera-center.js
@@ -1,0 +1,36 @@
+import {
+  GREEN,
+  LEFT,
+  RED,
+  RIGHT,
+  Square,
+} from "../../noon-authoring.js";
+import { MovingCameraScene } from "../../noon-moving-camera.js";
+
+/**
+ * Browser-language equivalent of ManimCE's MovingCameraCenter camera semantics.
+ *
+ * The JS authoring surface does not yet expose a Path/Triangle constructor, so the
+ * right-hand marker remains a square here. The camera frame timing and target centers
+ * are identical to the upstream example and lower through the same Rust/WASM tracks.
+ */
+export function MovingCameraCenter() {
+  const scene = new MovingCameraScene();
+  const left = new Square()
+    .setColor(RED)
+    .setFill(RED, 0.5)
+    .moveTo(LEFT.mul(2));
+  const right = new Square()
+    .setColor(GREEN)
+    .setFill(GREEN, 0.5)
+    .moveTo(RIGHT.mul(2));
+
+  scene.wait(0.3);
+  scene.add(left, right);
+  scene.play(scene.camera.frame.animate().moveTo(LEFT.mul(2)));
+  scene.wait(0.3);
+  scene.play(scene.camera.frame.animate().moveTo(RIGHT.mul(2)));
+  return scene;
+}
+
+export const galleryMovingCameraCenter = Object.freeze({ MovingCameraCenter });

--- a/web/manim-raster-host.js
+++ b/web/manim-raster-host.js
@@ -9,14 +9,13 @@ const canvas = document.querySelector("#scene");
 const offscreen = canvas.transferControlToOffscreen();
 const client = new PythonAuthoringClient();
 const readyPromise = Promise.all([initNoonWeb(), client.ready()]);
-const MANIM_DEFAULT_CAMERA_HEIGHT = 8.0;
 
 let engine = null;
 let host = null;
 let renderer = null;
 let callbackSessionId = null;
 let currentFrameIndex = -1;
-let activeFrameRate = null;
+let activeFrameTimes = null;
 let authoredDuration = null;
 
 function waitForPaint() {
@@ -57,20 +56,21 @@ async function load(source, loopDurationSeconds) {
   if (result.kind !== "scene_document") {
     throw new Error("host raster harness requires a scene document");
   }
-  if (result.callbacks === null) {
-    throw new Error("host raster harness requires registered host callbacks");
-  }
 
   const sceneJson = JSON.stringify(result.document);
   engine = new EngineScenePlayer(sceneJson, loopDuration, 1);
-  host = new HostScenePlayer(sceneJson, JSON.stringify(result.callbacks.slots));
-  callbackSessionId = result.callbacks.session_id;
+  if (result.callbacks !== null) {
+    host = new HostScenePlayer(sceneJson, JSON.stringify(result.callbacks.slots));
+    callbackSessionId = result.callbacks.session_id;
+  }
   authoredDuration = Number(result.duration);
 
+  // The initial execution delta already carries either the scene's semantic camera
+  // state or the shared default camera. Do not overwrite it with a harness-local
+  // fixed camera; moving-camera fixtures must exercise the production camera role.
   const initialDelta = engine.initialDeltaJson();
   renderer = await ExecutionCanvasRenderer.create(offscreen, initialDelta);
   renderer.resize(canvas.width, canvas.height);
-  renderer.setCamera(0.0, 0.0, MANIM_DEFAULT_CAMERA_HEIGHT);
   let presented = false;
   for (let attempt = 0; attempt < 4 && !presented; attempt += 1) {
     presented = renderer.render();
@@ -85,50 +85,72 @@ async function load(source, loopDurationSeconds) {
     duration: authoredDuration,
     objectCount: result.document.objects.length,
     rendererBackend: renderer.rendererBackend(),
-    callbackSlots: result.callbacks.slots.length,
+    callbackSlots: result.callbacks?.slots.length ?? 0,
   };
 }
 
-async function advanceOneFrame(frameIndex, frameRate) {
-  const time = frameIndex / frameRate;
-
+async function advanceOneFrame(frameIndex, time) {
   const deterministicDelta = engine.tickDeltaJson(time * 1000);
   await presentDelta(deterministicDelta);
 
-  host.advanceTo(time);
-  const frame = JSON.parse(host.callbackFrameJson());
-  const sequence = Number(host.nextSequence());
-  const batch = await client.runCallbackPhase(callbackSessionId, frame, sequence);
-  const batchJson = JSON.stringify(batch);
-  host.commitPatchBatch(batchJson);
+  if (host !== null) {
+    host.advanceTo(time);
+    const frame = JSON.parse(host.callbackFrameJson());
+    const sequence = Number(host.nextSequence());
+    const batch = await client.runCallbackPhase(callbackSessionId, frame, sequence);
+    const batchJson = JSON.stringify(batch);
+    host.commitPatchBatch(batchJson);
 
-  const hostDelta = engine.applyHostPatchBatchDeltaJson(batchJson);
-  await presentDelta(hostDelta);
+    const hostDelta = engine.applyHostPatchBatchDeltaJson(batchJson);
+    await presentDelta(hostDelta);
+  }
   currentFrameIndex = frameIndex;
 }
 
-async function renderThrough(frameIndex, frameRate) {
-  if (renderer === null || engine === null || host === null) {
+function normalizeFrameTimes(frameTimes, targetFrame) {
+  if (!Array.isArray(frameTimes) || frameTimes.length <= targetFrame) {
+    throw new RangeError("host raster frame-time map must cover the target frame");
+  }
+  const normalized = frameTimes.map((value, index) => {
+    const time = Number(value);
+    if (!Number.isFinite(time) || time < 0) {
+      throw new RangeError(`host raster frame ${index} has invalid logical time ${value}`);
+    }
+    if (index > 0 && time + 1e-12 < Number(frameTimes[index - 1])) {
+      throw new RangeError("host raster frame-time map must be monotonic");
+    }
+    return time;
+  });
+  return normalized;
+}
+
+async function renderThrough(frameIndex, frameTimes) {
+  if (renderer === null || engine === null) {
     throw new Error("host raster scene has not been loaded");
   }
   const targetFrame = Number(frameIndex);
-  const fps = Number(frameRate);
   if (!Number.isSafeInteger(targetFrame) || targetFrame < 0) {
     throw new RangeError("host raster frame index must be a non-negative integer");
   }
-  if (!Number.isFinite(fps) || fps <= 0) {
-    throw new RangeError("host raster frame rate must be positive and finite");
-  }
-  if (activeFrameRate === null) activeFrameRate = fps;
-  if (activeFrameRate !== fps) {
-    throw new Error("host raster frame rate cannot change after playback begins");
+  const normalizedTimes = normalizeFrameTimes(frameTimes, targetFrame);
+  if (activeFrameTimes === null) {
+    activeFrameTimes = normalizedTimes;
+  } else {
+    if (activeFrameTimes.length !== normalizedTimes.length) {
+      throw new Error("host raster frame-time map cannot change after playback begins");
+    }
+    for (let index = 0; index < activeFrameTimes.length; index += 1) {
+      if (Math.abs(activeFrameTimes[index] - normalizedTimes[index]) > 1e-12) {
+        throw new Error("host raster frame-time map cannot change after playback begins");
+      }
+    }
   }
   if (targetFrame < currentFrameIndex) {
     throw new RangeError("host raster playback cannot move backwards");
   }
 
   for (let frame = currentFrameIndex + 1; frame <= targetFrame; frame += 1) {
-    await advanceOneFrame(frame, fps);
+    await advanceOneFrame(frame, activeFrameTimes[frame]);
   }
   await waitForPaint();
 

--- a/web/noon-moving-camera.js
+++ b/web/noon-moving-camera.js
@@ -1,0 +1,27 @@
+import { Rectangle, Scene } from "./noon-authoring.js";
+
+export const DEFAULT_FRAME_HEIGHT = 8.0;
+export const DEFAULT_FRAME_WIDTH = DEFAULT_FRAME_HEIGHT * 16.0 / 9.0;
+
+/**
+ * Thin browser-language adapter for Noon's shared semantic 2D camera role.
+ *
+ * Camera motion still lowers through the ordinary Rust/WASM Mobject animation path.
+ * This wrapper only marks the hidden frame object as the camera in the serialized
+ * scene document, matching the Python compatibility adapter.
+ */
+export class MovingCameraScene extends Scene {
+  constructor() {
+    super();
+    const frame = new Rectangle(DEFAULT_FRAME_WIDTH, DEFAULT_FRAME_HEIGHT)
+      .setOpacity(0.0);
+    this.add(frame);
+    this.camera = Object.freeze({ frame });
+  }
+
+  sceneJson() {
+    const document = JSON.parse(super.sceneJson());
+    document.camera_object = this.camera.frame._handle;
+    return JSON.stringify(document);
+  }
+}

--- a/web/python-worker.js
+++ b/web/python-worker.js
@@ -29,6 +29,7 @@ const MANIM_DRAW_BORDER_THEN_FILL_MODULE_PATH = "/tmp/_manim_draw_border_then_fi
 const MANIM_INDICATION_MODULE_PATH = "/tmp/_manim_indication.py";
 const MANIM_REACTIVE_MODULE_PATH = "/tmp/_manim_reactive.py";
 const MANIM_UPDATERS_MODULE_PATH = "/tmp/_manim_updaters.py";
+const MANIM_CAMERA_MODULE_PATH = "/tmp/_manim_camera.py";
 
 const pyodidePromise = initializePyodide();
 let requestQueue = Promise.resolve();
@@ -73,6 +74,7 @@ async function initializePyodide() {
     indicationResponse,
     reactiveResponse,
     updatersResponse,
+    cameraResponse,
   ] = await Promise.all([
     fetch(new URL("./python/noon.py", import.meta.url)),
     fetch(new URL("./python/_noon_ir.py", import.meta.url)),
@@ -91,6 +93,7 @@ async function initializePyodide() {
     fetch(new URL("./python/_manim_indication.py", import.meta.url)),
     fetch(new URL("./python/_manim_reactive.py", import.meta.url)),
     fetch(new URL("./python/_manim_updaters.py", import.meta.url)),
+    fetch(new URL("./python/_manim_camera.py", import.meta.url)),
   ]);
   const responses = [
     [apiResponse, "Noon Python API"],
@@ -110,6 +113,7 @@ async function initializePyodide() {
     [indicationResponse, "Noon Manim indication layer"],
     [reactiveResponse, "Noon reactive compatibility layer"],
     [updatersResponse, "Noon Manim updater layer"],
+    [cameraResponse, "Noon Manim moving-camera adapter"],
   ];
   for (const [response, label] of responses) {
     if (!response.ok) {
@@ -135,6 +139,7 @@ async function initializePyodide() {
     [MANIM_INDICATION_MODULE_PATH, indicationResponse],
     [MANIM_REACTIVE_MODULE_PATH, reactiveResponse],
     [MANIM_UPDATERS_MODULE_PATH, updatersResponse],
+    [MANIM_CAMERA_MODULE_PATH, cameraResponse],
   ];
   for (const [path, response] of modules) {
     pyodide.FS.writeFile(path, await response.text(), { encoding: "utf8" });
@@ -166,6 +171,8 @@ _manim_indication.install()
 import _manim_reactive
 import _manim_updaters
 _manim_updaters.install()
+import _manim_camera
+_manim_camera.install()
 `);
   return pyodide;
 }

--- a/web/python/_manim_camera.py
+++ b/web/python/_manim_camera.py
@@ -1,0 +1,58 @@
+"""Thin Manim moving-camera authoring adapter over Noon's shared Rust camera semantics."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import noon as _base
+import _manim_compat as _compat
+import _manim_phase_b as _phase_b
+
+
+class _CameraFrame(_compat.Rectangle):
+    """Invisible semantic frame object consumed by the Rust execution pipeline."""
+
+    def move_to(self, point: object) -> _CameraFrame:
+        if isinstance(point, (_base.Mobject, _compat.Group)):
+            point = point.get_center()
+        super().move_to(point)
+        return self
+
+
+class _MovingCamera:
+    def __init__(self, frame: _CameraFrame) -> None:
+        self.frame = frame
+
+
+class MovingCameraScene(_compat.Scene):
+    """Manim facade that only authors a shared semantic camera-frame object."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        if kwargs:
+            unsupported = ", ".join(sorted(kwargs))
+            raise NotImplementedError(
+                f"unsupported MovingCameraScene option(s): {unsupported}"
+            )
+        super().__init__()
+        # Author invisibility in the detached snapshot itself so Python, Rust, and
+        # JavaScript serialize the same camera control object before it is bound.
+        frame = _CameraFrame(
+            _base.DEFAULT_FRAME_WIDTH,
+            _base.DEFAULT_FRAME_HEIGHT,
+            opacity=0.0,
+        )
+        _phase_b._bind_raw(self, frame)
+        self.camera = _MovingCamera(frame)
+
+    def to_document(self) -> dict[str, Any]:
+        document = super().to_document()
+        document["camera_object"] = self.camera.frame.id
+        return document
+
+
+def install() -> None:
+    """Expose the Manim name through ``from noon import *``."""
+
+    _base.MovingCameraScene = MovingCameraScene
+    if "MovingCameraScene" not in _base.__all__:
+        _base.__all__.append("MovingCameraScene")

--- a/web/python/examples/manim_example_moving_camera_center.py
+++ b/web/python/examples/manim_example_moving_camera_center.py
@@ -1,0 +1,12 @@
+from noon import *
+
+
+class MovingCameraCenter(MovingCameraScene):
+    def construct(self):
+        s = Square(color=RED, fill_opacity=0.5).move_to(2 * LEFT)
+        t = Triangle(color=GREEN, fill_opacity=0.5).move_to(2 * RIGHT)
+        self.wait(0.3)
+        self.add(s, t)
+        self.play(self.camera.frame.animate.move_to(s))
+        self.wait(0.3)
+        self.play(self.camera.frame.animate.move_to(t))

--- a/web/python/examples/manim_tutorial_manifest.json
+++ b/web/python/examples/manim_tutorial_manifest.json
@@ -427,6 +427,24 @@
       "order": 220
     },
     {
+      "id": "manim-moving-camera-center",
+      "title": "MovingCameraCenter",
+      "summary": "ManimCE v0.21 MovingCameraScene reference example, unchanged except for the import module.",
+      "status": "ready",
+      "path": "python/examples/manim_example_moving_camera_center.py",
+      "category": "tutorial/scene-camera",
+      "features": ["MovingCameraScene", "camera.frame", "animate", "move_to", "Square", "Triangle"],
+      "upstream": "reference/manim.scene.moving_camera_scene.MovingCameraScene.html",
+      "upstream_source": "parity/manim-v0.21/upstream-examples/moving_camera_center.py",
+      "reuse": "source-equivalent-manim-v0.21",
+      "parity_status": "candidate",
+      "expected_duration": 2.6,
+      "thumbnail": "thumbnails/manim/exact-source.svg",
+      "thumbnail_alt": "Exact-source Manim MovingCameraCenter",
+      "thumbnail_time": 1.8,
+      "order": 230
+    },
+    {
       "id": "text-and-math",
       "title": "Full text and mathematical notation parity",
       "status": "blocked",
@@ -451,11 +469,11 @@
       "dependency": "#87/#77/#83"
     },
     {
-      "id": "moving-camera",
-      "title": "Moving and zoomed camera",
+      "id": "zoomed-camera",
+      "title": "Zoomed camera inset support",
       "status": "blocked",
       "category": "tutorial/scene-camera",
-      "features": ["MovingCameraScene", "ZoomedScene"],
+      "features": ["ZoomedScene", "zoomed_camera", "zoomed_display"],
       "dependency": "#89"
     },
     {


### PR DESCRIPTION
Implements the first isolated slice of #89 around ManimCE MovingCameraScene using the exact MovingCameraCenter source case. The camera frame is an ordinary semantic object driven by the existing transform timeline; the scene carries only an explicit camera-object role. This PR will wire that state through IR, compiler, runtime, transport, WebGPU/WebGL rendering, Python compatibility, exact-source demo coverage, and deterministic seek/pixel validation. Kept draft until the cross-crate path and gates are complete.