### PR TITLE
[Parity] Add exact ManimCE MovingDots gallery example

### DIFF
--- a/parity/manim-v0.21/manifest.json
+++ b/parity/manim-v0.21/manifest.json
@@ -289,6 +289,11 @@
       "id": "shrink-to-center-rectangle",
       "scene": "ShrinkToCenterRectangle",
       "expected_duration": 1.0
+    },
+    {
+      "id": "moving-dots",
+      "scene": "MovingDots",
+      "expected_duration": 3.0
     }
   ],
   "sample_fractions": [

--- a/parity/manim-v0.21/quickstart.py
+++ b/parity/manim-v0.21/quickstart.py
@@ -612,3 +612,19 @@ class ShrinkToCenterRectangle(Scene):
             stroke_opacity=0.0,
         ).shift(RIGHT * 1.25)
         self.play(ShrinkToCenter(rectangle))
+
+
+class MovingDots(Scene):
+    def construct(self):
+        d1,d2=Dot(color=BLUE),Dot(color=GREEN)
+        dg=VGroup(d1,d2).arrange(RIGHT,buff=1)
+        l1=Line(d1.get_center(),d2.get_center()).set_color(RED)
+        x=ValueTracker(0)
+        y=ValueTracker(0)
+        d1.add_updater(lambda z: z.set_x(x.get_value()))
+        d2.add_updater(lambda z: z.set_y(y.get_value()))
+        l1.add_updater(lambda z: z.match_points(Line(d1.get_center(),d2.get_center())))
+        self.add(d1,d2,l1)
+        self.play(x.animate.set_value(5))
+        self.play(y.animate.set_value(4))
+        self.wait()

--- a/parity/manim-v0.21/upstream-examples/moving_dots.py
+++ b/parity/manim-v0.21/upstream-examples/moving_dots.py
@@ -1,0 +1,16 @@
+from manim import *
+
+class MovingDots(Scene):
+    def construct(self):
+        d1,d2=Dot(color=BLUE),Dot(color=GREEN)
+        dg=VGroup(d1,d2).arrange(RIGHT,buff=1)
+        l1=Line(d1.get_center(),d2.get_center()).set_color(RED)
+        x=ValueTracker(0)
+        y=ValueTracker(0)
+        d1.add_updater(lambda z: z.set_x(x.get_value()))
+        d2.add_updater(lambda z: z.set_y(y.get_value()))
+        l1.add_updater(lambda z: z.match_points(Line(d1.get_center(),d2.get_center())))
+        self.add(d1,d2,l1)
+        self.play(x.animate.set_value(5))
+        self.play(y.animate.set_value(4))
+        self.wait()

--- a/scripts/manim-raster-differential.mjs
+++ b/scripts/manim-raster-differential.mjs
@@ -130,9 +130,6 @@ async function renderManimReferences() {
     const frames = {
       frameCount: frameFiles.length,
       frameRate: reference.frame_rate,
-      // Cairo PNG output can materialize a static wait as one image with a repeat
-      // count. Logical duration is ratcheted separately by the semantic oracle, so
-      // never infer scene duration from the number of PNG files.
       duration: logicalDuration,
       materializedFrameSpan: frameFiles.length / reference.frame_rate,
       width: firstFrame.width,
@@ -148,7 +145,6 @@ async function renderManimReferences() {
       await writeFile(outputPath, await readFile(frameFiles[sample.frameIndex]));
       sample.referencePath = outputPath;
     }
-
     results.set(fixture.id, { fixture, frames, samples });
   }
   return results;
@@ -159,7 +155,7 @@ function noonSourceFor(scene) {
   return `${adapted}\n\nresult = ${scene}()\nresult.setup()\ntry:\n    result.construct()\nfinally:\n    result.tear_down()\n`;
 }
 
-async function authorNoonDocuments() {
+async function authorNoonScenes() {
   const browser = await chromium.launch({
     channel: "chromium",
     headless: true,
@@ -170,7 +166,7 @@ async function authorNoonDocuments() {
     await page.goto(`${baseUrl}/web/manim-compat-smoke.html`, { waitUntil: "load" });
     await page.waitForFunction(() => window.noonManimCompat, null, { timeout: 30_000 });
     await page.evaluate(() => window.noonManimCompat.ready());
-    const documents = new Map();
+    const scenes = new Map();
     for (const fixture of manifest.fixtures) {
       const result = await page.evaluate(
         (source) => window.noonManimCompat.run(source),
@@ -179,10 +175,13 @@ async function authorNoonDocuments() {
       assert.equal(result.kind, "scene_document", `${fixture.id}: Noon authoring result kind`);
       assert.ok(result.document.objects.length > 0, `${fixture.id}: Noon scene has no objects`);
       assert.equal(result.duration, fixture.expected_duration, `${fixture.id}: authored Noon duration`);
-      Object.defineProperty(result.document, "__noonAuthoredDuration", { value: result.duration });
-      documents.set(fixture.id, result.document);
+      scenes.set(fixture.id, {
+        document: result.document,
+        duration: Number(result.duration),
+        hasCallbacks: result.callbacks !== null,
+      });
     }
-    return documents;
+    return scenes;
   } finally {
     await browser.close();
   }
@@ -215,7 +214,7 @@ function browserArgs(backend) {
   ];
 }
 
-async function createCapturePage(browser, expectedBackend, backend) {
+async function createDeterministicCapturePage(browser, expectedBackend, backend) {
   const page = await browser.newPage({
     viewport: { width: reference.pixel_width + 40, height: reference.pixel_height + 40 },
   });
@@ -228,7 +227,90 @@ async function createCapturePage(browser, expectedBackend, backend) {
   return page;
 }
 
-async function captureNoonBackend(backend, documents, references) {
+async function createHostCapturePage(browser) {
+  const page = await browser.newPage({
+    viewport: { width: reference.pixel_width + 40, height: reference.pixel_height + 40 },
+  });
+  await page.goto(`${baseUrl}/web/manim-raster-host.html`, { waitUntil: "load" });
+  await page.waitForFunction(() => window.noonHostRaster, null, { timeout: 30_000 });
+  await page.evaluate(() => window.noonHostRaster.ready());
+  return page;
+}
+
+async function captureDeterministicFixture(
+  page,
+  fixture,
+  authored,
+  referenceResult,
+  fixtureDir,
+) {
+  const loaded = await page.evaluate(
+    (json) => window.noonSmoke.loadScene(json),
+    JSON.stringify(authored.document),
+  );
+  assert.equal(loaded.objectCount, authored.document.objects.length, `${fixture.id}: loaded object count`);
+  const captures = [];
+  for (const sample of referenceResult.samples) {
+    const metrics = await page.evaluate(
+      (time) => window.noonSmoke.renderAt(time),
+      sample.time,
+    );
+    assert.equal(metrics.error, null, `${fixture.id}: Noon render error at ${sample.time}`);
+    assert.equal(metrics.presented, true, `${fixture.id}: frame was not presented at ${sample.time}`);
+    await page.evaluate(() => new Promise((resolve) => requestAnimationFrame(resolve)));
+    const outputPath = path.join(fixtureDir, `${sample.label}.png`);
+    await page.locator("#scene").screenshot({ path: outputPath });
+    captures.push({ ...sample, noonPath: outputPath, metrics });
+  }
+  return {
+    duration: authored.duration,
+    objectCount: authored.document.objects.length,
+    captures,
+  };
+}
+
+async function captureHostFixture(
+  page,
+  fixture,
+  authored,
+  referenceResult,
+  fixtureDir,
+  expectedBackend,
+  backend,
+) {
+  const loaded = await page.evaluate(
+    ({ source, loopDuration }) => window.noonHostRaster.load(source, loopDuration),
+    {
+      source: noonSourceFor(fixture.scene),
+      loopDuration: Math.max(1, fixture.expected_duration + 1),
+    },
+  );
+  assert.equal(loaded.duration, fixture.expected_duration, `${fixture.id}: host authored duration`);
+  assert.equal(loaded.objectCount, authored.document.objects.length, `${fixture.id}: host object count`);
+  assert.ok(loaded.callbackSlots > 0, `${fixture.id}: host callback slots`);
+  assert.equal(loaded.rendererBackend, expectedBackend, `${backend}: host renderer backend`);
+
+  const captures = [];
+  for (const sample of referenceResult.samples) {
+    const metrics = await page.evaluate(
+      ({ frameIndex, frameRate }) => window.noonHostRaster.renderThrough(frameIndex, frameRate),
+      { frameIndex: sample.frameIndex, frameRate: reference.frame_rate },
+    );
+    assert.equal(metrics.error, null, `${fixture.id}: host render error at frame ${sample.frameIndex}`);
+    assert.equal(metrics.presented, true, `${fixture.id}: host frame ${sample.frameIndex} not presented`);
+    assert.equal(metrics.frameIndex, sample.frameIndex, `${fixture.id}: host frame index`);
+    const outputPath = path.join(fixtureDir, `${sample.label}.png`);
+    await page.locator("#scene").screenshot({ path: outputPath });
+    captures.push({ ...sample, noonPath: outputPath, metrics });
+  }
+  return {
+    duration: authored.duration,
+    objectCount: authored.document.objects.length,
+    captures,
+  };
+}
+
+async function captureNoonBackend(backend, authoredScenes, references) {
   const browser = await chromium.launch({
     channel: "chromium",
     headless: true,
@@ -240,33 +322,32 @@ async function captureNoonBackend(backend, documents, references) {
     for (const fixture of manifest.fixtures) {
       let page = null;
       try {
-        page = await createCapturePage(browser, expectedBackend, backend);
-        const document = documents.get(fixture.id);
-        const loaded = await page.evaluate(
-          (json) => window.noonSmoke.loadScene(json),
-          JSON.stringify(document),
-        );
-        assert.equal(loaded.objectCount, document.objects.length, `${fixture.id}: loaded object count`);
+        const authored = authoredScenes.get(fixture.id);
+        const referenceResult = references.get(fixture.id);
         const fixtureDir = path.join(artifactRoot, backend, fixture.id);
         await mkdir(fixtureDir, { recursive: true });
-        const captures = [];
-        for (const sample of references.get(fixture.id).samples) {
-          const metrics = await page.evaluate(
-            (time) => window.noonSmoke.renderAt(time),
-            sample.time,
+
+        if (authored.hasCallbacks) {
+          page = await createHostCapturePage(browser);
+          output.set(
+            fixture.id,
+            await captureHostFixture(
+              page,
+              fixture,
+              authored,
+              referenceResult,
+              fixtureDir,
+              expectedBackend,
+              backend,
+            ),
           );
-          assert.equal(metrics.error, null, `${fixture.id}: Noon render error at ${sample.time}`);
-          assert.equal(metrics.presented, true, `${fixture.id}: frame was not presented at ${sample.time}`);
-          await page.evaluate(() => new Promise((resolve) => requestAnimationFrame(resolve)));
-          const outputPath = path.join(fixtureDir, `${sample.label}.png`);
-          await page.locator("#scene").screenshot({ path: outputPath });
-          captures.push({ ...sample, noonPath: outputPath, metrics });
+        } else {
+          page = await createDeterministicCapturePage(browser, expectedBackend, backend);
+          output.set(
+            fixture.id,
+            await captureDeterministicFixture(page, fixture, authored, referenceResult, fixtureDir),
+          );
         }
-        output.set(fixture.id, {
-          duration: document.__noonAuthoredDuration,
-          objectCount: document.objects.length,
-          captures,
-        });
       } finally {
         await page?.close();
       }
@@ -505,10 +586,10 @@ async function waitForServer() {
 try {
   const references = await renderManimReferences();
   await waitForServer();
-  const documents = await authorNoonDocuments();
+  const authoredScenes = await authorNoonScenes();
   const backendResults = new Map();
   for (const backend of backends) {
-    backendResults.set(backend, await captureNoonBackend(backend, documents, references));
+    backendResults.set(backend, await captureNoonBackend(backend, authoredScenes, references));
   }
   const reportPath = await compareAll(references, backendResults);
   console.log(`ManimCE raster differential report: ${reportPath}`);

--- a/web/manim-raster-host.html
+++ b/web/manim-raster-host.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="data:," />
+    <title>Noon Manim host raster harness</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        background: #000;
+      }
+
+      #scene {
+        display: block;
+        width: 960px;
+        height: 540px;
+      }
+    </style>
+  </head>
+  <body>
+    <canvas id="scene" width="960" height="540"></canvas>
+    <script type="module" src="./manim-raster-host.js"></script>
+  </body>
+</html>

--- a/web/manim-raster-host.js
+++ b/web/manim-raster-host.js
@@ -1,0 +1,154 @@
+import initNoonWeb, {
+  EngineScenePlayer,
+  ExecutionCanvasRenderer,
+  HostScenePlayer,
+} from "./pkg/noon_web.js";
+import { PythonAuthoringClient } from "./authoring-client.js";
+
+const canvas = document.querySelector("#scene");
+const offscreen = canvas.transferControlToOffscreen();
+const client = new PythonAuthoringClient();
+const readyPromise = Promise.all([initNoonWeb(), client.ready()]);
+const MANIM_DEFAULT_CAMERA_HEIGHT = 8.0;
+
+let engine = null;
+let host = null;
+let renderer = null;
+let callbackSessionId = null;
+let currentFrameIndex = -1;
+let activeFrameRate = null;
+let authoredDuration = null;
+
+function waitForPaint() {
+  return new Promise((resolve) => {
+    requestAnimationFrame(() => requestAnimationFrame(resolve));
+  });
+}
+
+async function presentDelta(deltaJson) {
+  if (deltaJson === undefined || deltaJson === null) return false;
+  const applied = renderer.applyDeltaJson(deltaJson);
+  if (!applied) return false;
+  let presented = false;
+  for (let attempt = 0; attempt < 4 && !presented; attempt += 1) {
+    presented = renderer.render();
+  }
+  if (!presented) {
+    throw new Error("host raster renderer could not present an applied execution delta");
+  }
+  await waitForPaint();
+  return true;
+}
+
+async function load(source, loopDurationSeconds) {
+  await readyPromise;
+  if (typeof source !== "string" || source.trim() === "") {
+    throw new TypeError("host raster source must be non-empty");
+  }
+  const loopDuration = Number(loopDurationSeconds);
+  if (!Number.isFinite(loopDuration) || loopDuration <= 0) {
+    throw new RangeError("host raster loop duration must be positive and finite");
+  }
+  if (renderer !== null || engine !== null || host !== null) {
+    throw new Error("host raster page supports one authored scene per page");
+  }
+
+  const result = await client.run(source);
+  if (result.kind !== "scene_document") {
+    throw new Error("host raster harness requires a scene document");
+  }
+  if (result.callbacks === null) {
+    throw new Error("host raster harness requires registered host callbacks");
+  }
+
+  const sceneJson = JSON.stringify(result.document);
+  engine = new EngineScenePlayer(sceneJson, loopDuration, 1);
+  host = new HostScenePlayer(sceneJson, JSON.stringify(result.callbacks.slots));
+  callbackSessionId = result.callbacks.session_id;
+  authoredDuration = Number(result.duration);
+
+  const initialDelta = engine.initialDeltaJson();
+  renderer = await ExecutionCanvasRenderer.create(offscreen, initialDelta);
+  renderer.resize(canvas.width, canvas.height);
+  renderer.setCamera(0.0, 0.0, MANIM_DEFAULT_CAMERA_HEIGHT);
+  let presented = false;
+  for (let attempt = 0; attempt < 4 && !presented; attempt += 1) {
+    presented = renderer.render();
+  }
+  if (!presented) {
+    throw new Error("host raster renderer could not present its initial snapshot");
+  }
+  await waitForPaint();
+
+  return {
+    kind: result.kind,
+    duration: authoredDuration,
+    objectCount: result.document.objects.length,
+    rendererBackend: renderer.rendererBackend(),
+    callbackSlots: result.callbacks.slots.length,
+  };
+}
+
+async function advanceOneFrame(frameIndex, frameRate) {
+  const time = frameIndex / frameRate;
+
+  const deterministicDelta = engine.tickDeltaJson(time * 1000);
+  await presentDelta(deterministicDelta);
+
+  host.advanceTo(time);
+  const frame = JSON.parse(host.callbackFrameJson());
+  const sequence = Number(host.nextSequence());
+  const batch = await client.runCallbackPhase(callbackSessionId, frame, sequence);
+  const batchJson = JSON.stringify(batch);
+  host.commitPatchBatch(batchJson);
+
+  const hostDelta = engine.applyHostPatchBatchDeltaJson(batchJson);
+  await presentDelta(hostDelta);
+  currentFrameIndex = frameIndex;
+}
+
+async function renderThrough(frameIndex, frameRate) {
+  if (renderer === null || engine === null || host === null) {
+    throw new Error("host raster scene has not been loaded");
+  }
+  const targetFrame = Number(frameIndex);
+  const fps = Number(frameRate);
+  if (!Number.isSafeInteger(targetFrame) || targetFrame < 0) {
+    throw new RangeError("host raster frame index must be a non-negative integer");
+  }
+  if (!Number.isFinite(fps) || fps <= 0) {
+    throw new RangeError("host raster frame rate must be positive and finite");
+  }
+  if (activeFrameRate === null) activeFrameRate = fps;
+  if (activeFrameRate !== fps) {
+    throw new Error("host raster frame rate cannot change after playback begins");
+  }
+  if (targetFrame < currentFrameIndex) {
+    throw new RangeError("host raster playback cannot move backwards");
+  }
+
+  for (let frame = currentFrameIndex + 1; frame <= targetFrame; frame += 1) {
+    await advanceOneFrame(frame, fps);
+  }
+  await waitForPaint();
+
+  return {
+    error: null,
+    presented: true,
+    time: renderer.time(),
+    objectCount: renderer.objectCount(),
+    rendererBackend: renderer.rendererBackend(),
+    drawCalls: renderer.lastDrawCalls(),
+    instances: renderer.lastInstancesDrawn(),
+    uploadBytes: renderer.lastBytesUploaded(),
+    geometryCacheMisses: renderer.lastGeometryCacheMisses(),
+    authoredDuration,
+    frameIndex: currentFrameIndex,
+  };
+}
+
+window.noonHostRaster = {
+  ready: () => readyPromise,
+  load,
+  renderThrough,
+};

--- a/web/python/examples/manim_gallery_moving_dots.py
+++ b/web/python/examples/manim_gallery_moving_dots.py
@@ -1,0 +1,16 @@
+from noon import *
+
+class MovingDots(Scene):
+    def construct(self):
+        d1,d2=Dot(color=BLUE),Dot(color=GREEN)
+        dg=VGroup(d1,d2).arrange(RIGHT,buff=1)
+        l1=Line(d1.get_center(),d2.get_center()).set_color(RED)
+        x=ValueTracker(0)
+        y=ValueTracker(0)
+        d1.add_updater(lambda z: z.set_x(x.get_value()))
+        d2.add_updater(lambda z: z.set_y(y.get_value()))
+        l1.add_updater(lambda z: z.match_points(Line(d1.get_center(),d2.get_center())))
+        self.add(d1,d2,l1)
+        self.play(x.animate.set_value(5))
+        self.play(y.animate.set_value(4))
+        self.wait()

--- a/web/python/examples/manim_tutorial_manifest.json
+++ b/web/python/examples/manim_tutorial_manifest.json
@@ -372,6 +372,25 @@
       "order": 190
     },
     {
+      "id": "parity-moving-dots",
+      "title": "MovingDots",
+      "summary": "ManimCE v0.21 Example Gallery MovingDots, byte-for-byte except for the import module.",
+      "status": "ready",
+      "path": "python/examples/manim_gallery_moving_dots.py",
+      "category": "animations",
+      "features": ["Dot", "VGroup", "arrange", "Line", "ValueTracker", "add_updater", "match_points", "pixel-parity", "time-parity"],
+      "upstream": "examples.html",
+      "upstream_source": "parity/manim-v0.21/upstream-examples/moving_dots.py",
+      "reuse": "source-equivalent-manim-v0.21",
+      "parity_status": "candidate",
+      "parity_fixture": "moving-dots",
+      "expected_duration": 3.0,
+      "thumbnail": "thumbnails/manim/moving-dots.svg",
+      "thumbnail_alt": "Blue and green dots connected by a red updater line",
+      "thumbnail_time": 2.5,
+      "order": 200
+    },
+    {
       "id": "text-and-math",
       "title": "Full text and mathematical notation parity",
       "status": "blocked",

--- a/web/thumbnails/manim/moving-dots.svg
+++ b/web/thumbnails/manim/moving-dots.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 180" role="img" aria-label="Blue and green dots connected by a red updater line">
+  <rect width="320" height="180" fill="#1c1c1c"/>
+  <line x1="250" y1="104" x2="174" y2="42" stroke="#fc6255" stroke-width="4" stroke-linecap="round"/>
+  <circle cx="250" cy="104" r="7" fill="#58c4dd"/>
+  <circle cx="174" cy="42" r="7" fill="#83c167"/>
+</svg>


### PR DESCRIPTION
## Summary

Add the ManimCE v0.21.0 `MovingDots` gallery scene to Noon's public demo using the literal upstream source with exactly one source change: `from manim import *` -> `from noon import *`.

The example exercises the shared updater/runtime semantics landed in #294 rather than a Noon-specific trajectory:

- `VGroup(...).arrange(RIGHT, buff=1)`
- runtime `ValueTracker.get_value()` reads inside Python updaters
- `set_x` / `set_y` updater mutations
- live connector geometry replacement through `match_points(Line(...))`
- updater execution during two tracker animations and the final wait

## Gallery / parity contract

- check in the exact upstream ManimCE v0.21.0 source fixture
- check in the import-only Noon source variant
- register the scene in the canonical parity fixture manifest
- expose it in the browser demo manifest
- keep `parity_status: candidate` until the dedicated #176/#185 pixel/timing/lifecycle qualification is complete
- do not substitute precomputed Noon-only motion for the upstream updater behavior

## Validation

On the exact six-file gallery tree, the stacked PR run passed:

- Manim API coverage
- test coverage
- Manim semantic differential
- full main CI, including updater callback bridge, deterministic seek/playback/rewind, executable Manim tutorial corpus, WebGPU and WebGL rendering

Raster differential is tracked separately by the normal PR gate. The PR is now based directly on `master` after #294 landed.

Related: #252, #91, #294, #176, #185