### PR TITLE
Move Group family identity into shared semantic store

### DIFF
--- a/compat/semantic-ownership-v1.json
+++ b/compat/semantic-ownership-v1.json
@@ -240,13 +240,19 @@
     },
     {
       "id": "group-family",
-      "surface": "Group/VGroup family membership and flattening",
-      "classification": "python-semantic-duplicate",
-      "owner": {"language": "python", "path": "web/python/_manim_compat.py", "symbol": "Group/VGroup"},
-      "shared_owner": {"language": "rust", "path": "crates/noon-core/src/semantic_store.rs", "symbol": "SemanticStore::add_member/remove_member"},
-      "reason": "Python groups still own child collections and flatten family operations before lowering, while Rust has family references in the semantic store.",
-      "replacement": "Retain family identity in shared semantic handles and lower group operations from that shared representation.",
-      "migration_issue": "#61"
+      "surface": "Group/VGroup direct family identity, membership, and order",
+      "classification": "shared-rust",
+      "owner": {"language": "rust", "path": "crates/noon-core/src/semantic_store.rs", "symbol": "SemanticStore::insert_family/add_member/remove_member"},
+      "adapters": [{"language": "python", "path": "web/python/_manim_semantic_handles.py", "symbol": "_group_init/_group_add/_group_remove"}],
+      "reason": "The shared semantic store assigns stable object/family identities, owns duplicate suppression and direct-member order, and returns membership decisions that Python mirrors for wrapper identity."
+    },
+    {
+      "id": "group-family-wrapper-mirror",
+      "surface": "Python Group wrapper references and leaf iteration",
+      "classification": "python-adapter-only",
+      "owner": {"language": "python", "path": "web/python/_manim_compat.py", "symbol": "Group.submobjects/_leaf_mobjects"},
+      "reason": "Python retains object references for Manim class/protocol identity, but membership transitions are accepted or rejected by the shared family handle before this mirror changes.",
+      "replacement": "Keep the wrapper mirror as host-language identity metadata; deterministic family semantics remain shared."
     },
     {
       "id": "scene-play-lifecycle",

--- a/crates/noon-core/src/semantic_store.rs
+++ b/crates/noon-core/src/semantic_store.rs
@@ -46,6 +46,9 @@ pub enum SourceIdentity {
 pub enum SemanticNodeKind {
     /// Compatibility payload while `SceneDefinition` consumers migrate.
     Object(ObjectDefinition),
+    /// Stable frontend object identity whose mutable authoring payload lives in a
+    /// shared frontend handle rather than the legacy SceneDefinition object shape.
+    AuthoringObject,
     /// A semantic family/collection with no implied transform ownership.
     Family,
 }
@@ -79,14 +82,14 @@ impl SemanticNode {
     pub fn object(&self) -> Option<&ObjectDefinition> {
         match &self.kind {
             SemanticNodeKind::Object(object) => Some(object),
-            SemanticNodeKind::Family => None,
+            SemanticNodeKind::AuthoringObject | SemanticNodeKind::Family => None,
         }
     }
 
     pub fn object_mut(&mut self) -> Option<&mut ObjectDefinition> {
         match &mut self.kind {
             SemanticNodeKind::Object(object) => Some(object),
-            SemanticNodeKind::Family => None,
+            SemanticNodeKind::AuthoringObject | SemanticNodeKind::Family => None,
         }
     }
 
@@ -148,6 +151,10 @@ impl SemanticStore {
         let id = self.insert_kind(SemanticNodeKind::Object(object));
         self.object_nodes.insert(legacy_id, id);
         id
+    }
+
+    pub fn insert_authoring_object(&mut self) -> SemanticNodeId {
+        self.insert_kind(SemanticNodeKind::AuthoringObject)
     }
 
     pub fn insert_family(&mut self) -> SemanticNodeId {
@@ -468,6 +475,31 @@ mod tests {
 
     fn object(id: u64) -> ObjectDefinition {
         ObjectDefinition::new(ObjectId::new(id), GeometryRef::circle(1.0))
+    }
+
+    #[test]
+    fn authoring_objects_have_stable_shared_family_identity() {
+        let mut store = SemanticStore::new();
+        let first = store.insert_authoring_object();
+        let second = store.insert_authoring_object();
+        let family = store.insert_family();
+        let alias = store.insert_family();
+
+        store.add_member(family, first).unwrap();
+        store.add_member(family, second).unwrap();
+        store.add_member(alias, first).unwrap();
+        assert_eq!(store.node(family).unwrap().members(), &[first, second]);
+        assert_eq!(store.node(first).unwrap().parents(), &[family, alias]);
+
+        // SemanticStore owns duplicate suppression and direct-member ordering.
+        store.add_member(family, first).unwrap();
+        assert_eq!(store.node(family).unwrap().members(), &[first, second]);
+        assert_eq!(store.node(first).unwrap().parents(), &[family, alias]);
+
+        assert!(store.remove_member(family, first).unwrap());
+        assert_eq!(store.node(family).unwrap().members(), &[second]);
+        assert_eq!(store.node(first).unwrap().parents(), &[alias]);
+        assert!(!store.remove_member(family, first).unwrap());
     }
 
     #[test]

--- a/crates/noon-web/src/authoring_mobject.rs
+++ b/crates/noon-web/src/authoring_mobject.rs
@@ -795,6 +795,9 @@ fn snapshot_layout_bounds(
 
 #[cfg(target_arch = "wasm32")]
 mod wasm {
+    use std::{cell::RefCell, rc::Rc};
+
+    use noon_core::{SemanticNodeId, SemanticStore};
     use wasm_bindgen::prelude::*;
 
     use super::FrontendMobjectHandle;
@@ -803,21 +806,215 @@ mod wasm {
         JsValue::from_str(&error)
     }
 
+    type SharedSemanticStore = Rc<RefCell<SemanticStore>>;
+
     #[wasm_bindgen]
-    pub struct WasmAuthoringMobjectHandle(FrontendMobjectHandle);
+    pub struct WasmAuthoringStore {
+        semantics: SharedSemanticStore,
+    }
+
+    #[wasm_bindgen]
+    impl WasmAuthoringStore {
+        #[wasm_bindgen(constructor)]
+        pub fn new() -> Self {
+            Self {
+                semantics: Rc::new(RefCell::new(SemanticStore::new())),
+            }
+        }
+
+        #[wasm_bindgen(js_name = createMobject)]
+        pub fn create_mobject(
+            &self,
+            snapshot_json: &str,
+        ) -> Result<WasmAuthoringMobjectHandle, JsValue> {
+            let handle = FrontendMobjectHandle::from_json(snapshot_json).map_err(js_error)?;
+            let id = self.semantics.borrow_mut().insert_authoring_object();
+            Ok(WasmAuthoringMobjectHandle(
+                handle,
+                Some(Rc::clone(&self.semantics)),
+                Some(id),
+            ))
+        }
+
+        #[wasm_bindgen(js_name = createFamily)]
+        pub fn create_family(&self) -> WasmAuthoringFamilyHandle {
+            let id = self.semantics.borrow_mut().insert_family();
+            WasmAuthoringFamilyHandle {
+                semantics: Rc::clone(&self.semantics),
+                id,
+            }
+        }
+    }
+
+    #[wasm_bindgen]
+    pub struct WasmAuthoringFamilyHandle {
+        semantics: SharedSemanticStore,
+        id: SemanticNodeId,
+    }
+
+    impl WasmAuthoringFamilyHandle {
+        fn object_member_id(
+            &self,
+            member: &WasmAuthoringMobjectHandle,
+        ) -> Result<SemanticNodeId, JsValue> {
+            let store = member.1.as_ref().ok_or_else(|| {
+                JsValue::from_str("mobject is not attached to a shared authoring store")
+            })?;
+            if !Rc::ptr_eq(&self.semantics, store) {
+                return Err(JsValue::from_str(
+                    "family and mobject belong to different authoring stores",
+                ));
+            }
+            member
+                .2
+                .ok_or_else(|| JsValue::from_str("mobject has no semantic identity"))
+        }
+
+        fn family_member_id(
+            &self,
+            member: &WasmAuthoringFamilyHandle,
+        ) -> Result<SemanticNodeId, JsValue> {
+            if !Rc::ptr_eq(&self.semantics, &member.semantics) {
+                return Err(JsValue::from_str(
+                    "families belong to different authoring stores",
+                ));
+            }
+            Ok(member.id)
+        }
+
+        fn add_id(&mut self, member: SemanticNodeId) -> Result<bool, JsValue> {
+            let before = self.member_count();
+            self.semantics
+                .borrow_mut()
+                .add_member(self.id, member)
+                .map_err(|error| js_error(error.to_string()))?;
+            Ok(self.member_count() != before)
+        }
+
+        fn remove_id(&mut self, member: SemanticNodeId) -> Result<bool, JsValue> {
+            self.semantics
+                .borrow_mut()
+                .remove_member(self.id, member)
+                .map_err(|error| js_error(error.to_string()))
+        }
+    }
+
+    #[wasm_bindgen]
+    impl WasmAuthoringFamilyHandle {
+        #[wasm_bindgen(getter, js_name = semanticSlot)]
+        pub fn semantic_slot(&self) -> u32 {
+            self.id.slot()
+        }
+
+        #[wasm_bindgen(getter, js_name = semanticGeneration)]
+        pub fn semantic_generation(&self) -> u32 {
+            self.id.generation()
+        }
+
+        #[wasm_bindgen(getter, js_name = memberCount)]
+        pub fn member_count(&self) -> usize {
+            self.semantics
+                .borrow()
+                .node(self.id)
+                .map_or(0, |node| node.members().len())
+        }
+
+        #[wasm_bindgen(js_name = memberSlot)]
+        pub fn member_slot(&self, index: usize) -> Result<u32, JsValue> {
+            self.semantics
+                .borrow()
+                .node(self.id)
+                .and_then(|node| node.members().get(index).copied())
+                .map(SemanticNodeId::slot)
+                .ok_or_else(|| JsValue::from_str("family member index is out of bounds"))
+        }
+
+        #[wasm_bindgen(js_name = memberGeneration)]
+        pub fn member_generation(&self, index: usize) -> Result<u32, JsValue> {
+            self.semantics
+                .borrow()
+                .node(self.id)
+                .and_then(|node| node.members().get(index).copied())
+                .map(SemanticNodeId::generation)
+                .ok_or_else(|| JsValue::from_str("family member index is out of bounds"))
+        }
+
+        #[wasm_bindgen(js_name = addMobject)]
+        pub fn add_mobject(
+            &mut self,
+            member: &WasmAuthoringMobjectHandle,
+        ) -> Result<bool, JsValue> {
+            let id = self.object_member_id(member)?;
+            self.add_id(id)
+        }
+
+        #[wasm_bindgen(js_name = addFamily)]
+        pub fn add_family(&mut self, member: &WasmAuthoringFamilyHandle) -> Result<bool, JsValue> {
+            let id = self.family_member_id(member)?;
+            self.add_id(id)
+        }
+
+        #[wasm_bindgen(js_name = removeMobject)]
+        pub fn remove_mobject(
+            &mut self,
+            member: &WasmAuthoringMobjectHandle,
+        ) -> Result<bool, JsValue> {
+            let id = self.object_member_id(member)?;
+            self.remove_id(id)
+        }
+
+        #[wasm_bindgen(js_name = removeFamily)]
+        pub fn remove_family(
+            &mut self,
+            member: &WasmAuthoringFamilyHandle,
+        ) -> Result<bool, JsValue> {
+            let id = self.family_member_id(member)?;
+            self.remove_id(id)
+        }
+    }
+
+    #[wasm_bindgen]
+    pub struct WasmAuthoringMobjectHandle(
+        FrontendMobjectHandle,
+        Option<SharedSemanticStore>,
+        Option<SemanticNodeId>,
+    );
 
     #[wasm_bindgen]
     impl WasmAuthoringMobjectHandle {
         #[wasm_bindgen(constructor)]
         pub fn new(snapshot_json: &str) -> Result<WasmAuthoringMobjectHandle, JsValue> {
             FrontendMobjectHandle::from_json(snapshot_json)
-                .map(WasmAuthoringMobjectHandle)
+                .map(|handle| WasmAuthoringMobjectHandle(handle, None, None))
                 .map_err(js_error)
+        }
+
+        fn clone_with_handle(&self, handle: FrontendMobjectHandle) -> WasmAuthoringMobjectHandle {
+            if let Some(store) = &self.1 {
+                let id = store.borrow_mut().insert_authoring_object();
+                WasmAuthoringMobjectHandle(handle, Some(Rc::clone(store)), Some(id))
+            } else {
+                WasmAuthoringMobjectHandle(handle, None, None)
+            }
+        }
+
+        #[wasm_bindgen(getter, js_name = semanticSlot)]
+        pub fn semantic_slot(&self) -> Result<u32, JsValue> {
+            self.2
+                .map(SemanticNodeId::slot)
+                .ok_or_else(|| JsValue::from_str("mobject has no shared semantic identity"))
+        }
+
+        #[wasm_bindgen(getter, js_name = semanticGeneration)]
+        pub fn semantic_generation(&self) -> Result<u32, JsValue> {
+            self.2
+                .map(SemanticNodeId::generation)
+                .ok_or_else(|| JsValue::from_str("mobject has no shared semantic identity"))
         }
 
         #[wasm_bindgen(js_name = cloneHandle)]
         pub fn clone_handle(&self) -> WasmAuthoringMobjectHandle {
-            WasmAuthoringMobjectHandle(self.0.clone())
+            self.clone_with_handle(self.0.clone())
         }
 
         /// Start a detached target-state edit from this handle without crossing
@@ -825,7 +1022,7 @@ mod wasm {
         /// is the editor; this alias makes that ownership explicit to frontends.
         #[wasm_bindgen(js_name = targetEditor)]
         pub fn target_editor(&self) -> WasmAuthoringMobjectHandle {
-            WasmAuthoringMobjectHandle(self.0.target_editor())
+            self.clone_with_handle(self.0.target_editor())
         }
 
         #[wasm_bindgen(js_name = snapshotJson)]

--- a/scripts/manim-compat-smoke.mjs
+++ b/scripts/manim-compat-smoke.mjs
@@ -76,6 +76,13 @@ class GroupAndSceneMembership(Scene):
         right = Square(side_length=0.7, color=PINK)
         pair = VGroup(left, right).arrange(RIGHT, buff=0.4)
 
+        assert int(pair._semantic_family_handle.memberCount) == 2
+        pair.add(left)
+        assert len(pair) == 2
+        assert int(pair._semantic_family_handle.memberCount) == 2
+        alias = VGroup(left)
+        assert int(alias._semantic_family_handle.memberCount) == 1
+
         assert isinstance(pair, Mobject)
         assert isinstance(pair, Group)
         self.add(pair)

--- a/web/python-worker.js
+++ b/web/python-worker.js
@@ -1,5 +1,5 @@
 import initNoonWeb, {
-  WasmAuthoringMobjectHandle,
+  WasmAuthoringStore,
   resolveAnimationOptions,
   resolveCompositionSchedule,
   resolveLifecyclePlan,
@@ -44,8 +44,10 @@ self.addEventListener("message", (event) => {
 
 async function initializePyodide() {
   await initNoonWeb();
+  const authoringStore = new WasmAuthoringStore();
   self.noonCreateAuthoringMobjectHandle = (snapshotJson) =>
-    new WasmAuthoringMobjectHandle(snapshotJson);
+    authoringStore.createMobject(snapshotJson);
+  self.noonCreateAuthoringFamilyHandle = () => authoringStore.createFamily();
   self.noonResolveAnimationOptions = resolveAnimationOptionsPlain;
   self.noonResolveCompositionSchedule = resolveCompositionSchedulePlain;
   self.noonResolveUniformCompositionSchedule = resolveUniformCompositionSchedulePlain;

--- a/web/python/_manim_semantic_handles.py
+++ b/web/python/_manim_semantic_handles.py
@@ -160,6 +160,11 @@ try:
 except ImportError:  # Native CPython tests do not have the browser bridge.
     _create_handle = None
 
+try:
+    from js import noonCreateAuthoringFamilyHandle as _create_family_handle
+except ImportError:  # Older/mock bridges may expose only leaf Mobject handles.
+    _create_family_handle = None
+
 _INSTALLED = False
 _ORIGINAL_INIT = _base.Mobject.__init__
 _ORIGINAL_CURRENT_RAW = _base.Mobject._current_raw
@@ -181,6 +186,10 @@ _ORIGINAL_SET_STROKE = _compat.VMobject.set_stroke
 _ORIGINAL_SET_OPACITY = _compat.VMobject.set_opacity
 _ORIGINAL_GET_FILL_OPACITY = _compat.VMobject.get_fill_opacity
 _ORIGINAL_GET_STROKE_OPACITY = _compat.VMobject.get_stroke_opacity
+_ORIGINAL_GROUP_INIT = _compat.Group.__init__
+_ORIGINAL_GROUP_ADD = _compat.Group.add
+_ORIGINAL_GROUP_REMOVE = _compat.Group.remove
+_GROUP_COPY_DELEGATE = None
 
 
 def _snapshot_json(raw: _ir.Mobject) -> str:
@@ -639,8 +648,92 @@ def _compat_bounds_for(value: object) -> tuple[_base.Vec2, _base.Vec2] | None:
     )
 
 
+def _family_member_handle(value: object) -> tuple[str | None, object | None]:
+    if isinstance(value, _compat.Group):
+        return "family", getattr(value, "_semantic_family_handle", None)
+    if isinstance(value, _base.Mobject):
+        # Family identity survives scene binding even though ordinary detached-state
+        # mutations stop using this handle after binding.
+        return "mobject", getattr(value, "_semantic_handle", None)
+    return None, None
+
+
+def _family_add_handle(family_handle: object, value: object) -> bool:
+    kind, handle = _family_member_handle(value)
+    if handle is None:
+        raise RuntimeError("family member has no shared semantic identity")
+    if kind == "family":
+        return bool(family_handle.addFamily(handle))
+    return bool(family_handle.addMobject(handle))
+
+
+def _family_remove_handle(family_handle: object, value: object) -> bool:
+    kind, handle = _family_member_handle(value)
+    if handle is None:
+        raise RuntimeError("family member has no shared semantic identity")
+    if kind == "family":
+        return bool(family_handle.removeFamily(handle))
+    return bool(family_handle.removeMobject(handle))
+
+
+def _validate_group_members(owner: _compat.Group, mobjects: tuple[object, ...]) -> None:
+    for mobject in mobjects:
+        if not isinstance(mobject, (_base.Mobject, _compat.Group)):
+            raise TypeError("Group members must be Mobjects or Groups")
+        if mobject is owner:
+            raise ValueError("Group cannot contain itself")
+
+
+def _group_init(self: _compat.Group, *mobjects: object) -> None:
+    self._semantic_family_handle = _create_family_handle()
+    _ORIGINAL_GROUP_INIT(self, *mobjects)
+
+
+def _group_add(self: _compat.Group, *mobjects: object) -> _compat.Group:
+    _validate_group_members(self, mobjects)
+    family_handle = self._semantic_family_handle
+    for mobject in mobjects:
+        if _family_add_handle(family_handle, mobject):
+            _ORIGINAL_GROUP_ADD(self, mobject)
+    return self
+
+
+def _group_remove(self: _compat.Group, *mobjects: object) -> _compat.Group:
+    family_handle = self._semantic_family_handle
+    for mobject in mobjects:
+        if _family_remove_handle(family_handle, mobject):
+            _ORIGINAL_GROUP_REMOVE(self, mobject)
+    return self
+
+
+def _group_copy(self: _compat.Group) -> _compat.Group:
+    delegate = _GROUP_COPY_DELEGATE
+    if delegate is None:
+        raise RuntimeError("shared Group copy delegate is not installed")
+
+    # The geometry layer owns the constructor-free wrapper-copy algorithm, including
+    # remapping custom subclass attributes such as Arrow._shaft/_tip. A Pyodide
+    # JsProxy cannot be deep-copied, so temporarily remove only the shared family
+    # handle from that host-language metadata pass. Nested Groups recurse through
+    # this adapter and receive their own fresh family identities.
+    family_handle = self.__dict__.pop("_semantic_family_handle", None)
+    try:
+        clone = delegate(self)
+    finally:
+        if family_handle is not None:
+            self._semantic_family_handle = family_handle
+
+    # Constructor-based delegates may already have created a family handle. The
+    # browser geometry delegate uses object.__new__ and therefore needs one here.
+    if getattr(clone, "_semantic_family_handle", None) is None:
+        clone._semantic_family_handle = _create_family_handle()
+        for member in clone.submobjects:
+            _family_add_handle(clone._semantic_family_handle, member)
+    return clone
+
+
 def install() -> None:
-    global _INSTALLED
+    global _INSTALLED, _GROUP_COPY_DELEGATE
     if _INSTALLED or _create_handle is None:
         return
     _INSTALLED = True
@@ -675,3 +768,10 @@ def install() -> None:
     _compat.VMobject.get_fill_opacity = _get_fill_opacity
     _compat.VMobject.get_stroke_opacity = _get_stroke_opacity
     _compat._bounds_for = _compat_bounds_for
+
+    if _create_family_handle is not None:
+        _GROUP_COPY_DELEGATE = _compat.Group.copy
+        _compat.Group.__init__ = _group_init
+        _compat.Group.add = _group_add
+        _compat.Group.remove = _group_remove
+        _compat.Group.copy = _group_copy

--- a/web/python/test_manim_shared_family_identity.py
+++ b/web/python/test_manim_shared_family_identity.py
@@ -1,0 +1,171 @@
+import json
+import os
+import subprocess
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+
+
+class ManimSharedFamilyIdentityTests(unittest.TestCase):
+    def test_group_wrapper_mirrors_shared_family_membership(self) -> None:
+        python_dir = Path(__file__).resolve().parent
+        env = os.environ.copy()
+        existing_pythonpath = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = (
+            str(python_dir)
+            if not existing_pythonpath
+            else os.pathsep.join((str(python_dir), existing_pythonpath))
+        )
+
+        source = textwrap.dedent(
+            """
+            import json
+
+            import _manim_compat
+            _manim_compat.install()
+            import _manim_phase_b  # noqa: F401
+            import _manim_semantic_handles as handles
+
+
+            class FakeObjectHandle:
+                def __init__(self, store, snapshot_json):
+                    self.store = store
+                    self.identity = store.allocate()
+                    self.snapshot = json.loads(snapshot_json)
+
+                def snapshotJson(self):
+                    return json.dumps(self.snapshot, separators=(\",\", \":\"))
+
+                def replaceSnapshotJson(self, snapshot_json):
+                    self.snapshot = json.loads(snapshot_json)
+
+                def cloneHandle(self):
+                    clone = FakeObjectHandle(self.store, self.snapshotJson())
+                    return clone
+
+                def targetEditor(self):
+                    return self.cloneHandle()
+
+                def setFillOpacity(self, opacity):
+                    fill = self.snapshot[\"style\"][\"fill\"]
+                    if fill is not None:
+                        fill[\"alpha\"] = float(opacity)
+
+                def setStrokeOpacity(self, opacity):
+                    stroke = self.snapshot[\"style\"][\"stroke\"]
+                    if stroke is not None:
+                        stroke[\"alpha\"] = float(opacity)
+
+
+            class FakeFamilyHandle:
+                def __init__(self, store):
+                    self.store = store
+                    self.identity = store.allocate()
+                    self.members = []
+
+                @property
+                def memberCount(self):
+                    return len(self.members)
+
+                def _add(self, member):
+                    key = member.identity
+                    if key in self.members:
+                        return False
+                    self.members.append(key)
+                    return True
+
+                def addMobject(self, member):
+                    assert member.store is self.store
+                    return self._add(member)
+
+                def addFamily(self, member):
+                    assert member.store is self.store
+                    return self._add(member)
+
+                def _remove(self, member):
+                    key = member.identity
+                    if key not in self.members:
+                        return False
+                    self.members.remove(key)
+                    return True
+
+                def removeMobject(self, member):
+                    return self._remove(member)
+
+                def removeFamily(self, member):
+                    return self._remove(member)
+
+
+            class FakeStore:
+                def __init__(self):
+                    self.next_identity = 0
+
+                def allocate(self):
+                    value = self.next_identity
+                    self.next_identity += 1
+                    return value
+
+                def createMobject(self, snapshot_json):
+                    return FakeObjectHandle(self, snapshot_json)
+
+                def createFamily(self):
+                    return FakeFamilyHandle(self)
+
+
+            store = FakeStore()
+            handles._create_handle = store.createMobject
+            handles._create_family_handle = store.createFamily
+            handles.install()
+
+            from noon import Circle, Square, VGroup
+
+            first = Circle(radius=0.2)
+            second = Square(side_length=0.4)
+            family = VGroup(first, second)
+            assert len(family) == 2
+            assert family._semantic_family_handle.memberCount == 2
+
+            # The shared family graph owns duplicate suppression. Python mirrors the
+            # returned decision rather than independently appending another wrapper.
+            family.add(first)
+            assert len(family) == 2
+            assert family._semantic_family_handle.memberCount == 2
+
+            family.remove(first)
+            assert list(family) == [second]
+            assert family._semantic_family_handle.memberCount == 1
+            family.remove(first)
+            assert list(family) == [second]
+            assert family._semantic_family_handle.memberCount == 1
+
+            nested = VGroup(first)
+            outer = VGroup(nested, second)
+            assert outer._semantic_family_handle.memberCount == 2
+            assert nested._semantic_family_handle.memberCount == 1
+
+            clone = outer.copy()
+            assert clone is not outer
+            assert clone._semantic_family_handle is not outer._semantic_family_handle
+            assert clone._semantic_family_handle.memberCount == 2
+            assert clone[0] is not nested
+            assert clone[1] is not second
+            """
+        )
+        completed = subprocess.run(
+            [sys.executable, "-c", source],
+            cwd=python_dir,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(
+            completed.returncode,
+            0,
+            msg=f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- give detached authoring Mobjects and Group/VGroup families stable identities in one shared Rust `SemanticStore`
- expose a shared `WasmAuthoringStore` plus family handles; Rust now owns direct membership order, duplicate suppression, alias parentage, and removal decisions
- keep Python `Group.submobjects` only as a wrapper-identity mirror, updated after the shared family handle accepts a membership transition
- preserve semantic identity for cloned/animate-target leaf handles and add CPython + browser-smoke coverage
- ratchet the #61 ownership inventory so direct family identity/membership is `shared-rust`

This intentionally does **not** claim `Group.animate` target derivation is migrated yet. It establishes the stable family handle required for the next #61 tranche while avoiding `_manim_compat.py`, which is touched by the in-progress updater work.

## Focused validation
- `cargo fmt --all`
- `cargo test -p noon-core semantic_store`
- `cargo test -p noon-web authoring_mobject`
- `rustup target add wasm32-unknown-unknown && cargo check -p noon-web --target wasm32-unknown-unknown`
- `PYTHONPATH=web/python python3 -m unittest web.python.test_manim_shared_family_identity web.python.test_manim_group_copy`
- `python3 scripts/semantic_ownership_check.py`
- `git diff --check`

Part of #61.