### PR TITLE
Normalize Typst frames into retained text resources

### DIFF
--- a/crates/noon-core/src/text_resources.rs
+++ b/crates/noon-core/src/text_resources.rs
@@ -3,7 +3,7 @@ use std::{
     sync::Arc,
 };
 
-use crate::{Color, GeometryResourceHandle, Rect, Transform2D, Vec2};
+use crate::{Color, GeometryResourceHandle, Rect, Vec2};
 
 /// Stable identity for one retained text/math resource.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -109,6 +109,74 @@ pub struct TextClusterIdentity {
     pub semantic_key: Option<Arc<str>>,
 }
 
+/// General 2D affine transform used by retained text layout.
+///
+/// Text backends can legitimately emit skewed or otherwise non-TRS groups. Keeping
+/// the complete matrix at this boundary avoids either baking transforms into glyph
+/// identities or silently dropping layout that cannot be represented by `Transform2D`.
+/// The matrix maps `(x, y)` to `(xx*x + xy*y + tx, yx*x + yy*y + ty)`.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct TextAffineTransform {
+    pub xx: f32,
+    pub yx: f32,
+    pub xy: f32,
+    pub yy: f32,
+    pub tx: f32,
+    pub ty: f32,
+}
+
+impl TextAffineTransform {
+    pub const IDENTITY: Self = Self {
+        xx: 1.0,
+        yx: 0.0,
+        xy: 0.0,
+        yy: 1.0,
+        tx: 0.0,
+        ty: 0.0,
+    };
+
+    pub const fn translation(x: f32, y: f32) -> Self {
+        Self {
+            tx: x,
+            ty: y,
+            ..Self::IDENTITY
+        }
+    }
+
+    pub fn transform_point(self, point: Vec2) -> Vec2 {
+        Vec2::new(
+            self.xx * point.x + self.xy * point.y + self.tx,
+            self.yx * point.x + self.yy * point.y + self.ty,
+        )
+    }
+
+    pub fn transform_vector(self, vector: Vec2) -> Vec2 {
+        Vec2::new(
+            self.xx * vector.x + self.xy * vector.y,
+            self.yx * vector.x + self.yy * vector.y,
+        )
+    }
+
+    /// Compose transforms such that `self.then(next)` applies `self` first and
+    /// `next` second.
+    pub fn then(self, next: Self) -> Self {
+        Self {
+            xx: next.xx * self.xx + next.xy * self.yx,
+            yx: next.yx * self.xx + next.yy * self.yx,
+            xy: next.xx * self.xy + next.xy * self.yy,
+            yy: next.yx * self.xy + next.yy * self.yy,
+            tx: next.xx * self.tx + next.xy * self.ty + next.tx,
+            ty: next.yx * self.tx + next.yy * self.ty + next.ty,
+        }
+    }
+}
+
+impl Default for TextAffineTransform {
+    fn default() -> Self {
+        Self::IDENTITY
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct PositionedGlyph {
     pub glyph_id: u32,
@@ -126,6 +194,10 @@ pub struct GlyphRun {
     pub font_size: f32,
     pub direction: TextDirection,
     pub fill: Option<Color>,
+    /// Maps the run's backend-local glyph coordinates into the resource coordinate
+    /// system. Ordinary native text uses identity; math/layout engines can retain
+    /// arbitrary group transforms without outlining every glyph.
+    pub transform: TextAffineTransform,
     pub glyphs: Arc<[PositionedGlyph]>,
 }
 
@@ -154,7 +226,7 @@ impl Default for TextVectorStyle {
 #[derive(Clone, Debug, PartialEq)]
 pub struct TextVectorItem {
     pub geometry: GeometryResourceHandle,
-    pub transform: Transform2D,
+    pub transform: TextAffineTransform,
     pub style: TextVectorStyle,
     pub source_span: Option<TextSourceSpan>,
     pub semantic_key: Option<Arc<str>>,
@@ -553,6 +625,7 @@ mod tests {
                 font_size: 48.0,
                 direction: TextDirection::LeftToRight,
                 fill: None,
+                transform: TextAffineTransform::IDENTITY,
                 glyphs,
             }]),
             vector_items: Arc::from([]),
@@ -618,6 +691,26 @@ mod tests {
     }
 
     #[test]
+    fn affine_text_transform_preserves_skew() {
+        let transform = TextAffineTransform {
+            xx: 1.0,
+            yx: 0.25,
+            xy: -0.5,
+            yy: 1.0,
+            tx: 3.0,
+            ty: -2.0,
+        };
+        assert_eq!(
+            transform.transform_point(Vec2::new(2.0, 4.0)),
+            Vec2::new(3.0, 2.5)
+        );
+        assert_eq!(
+            transform.transform_vector(Vec2::new(2.0, 4.0)),
+            Vec2::new(0.0, 4.5)
+        );
+    }
+
+    #[test]
     fn vector_math_items_share_geometry_resource_handles() {
         let geometry = GeometryResourceHandle {
             id: GeometryId::new(7),
@@ -625,7 +718,7 @@ mod tests {
         };
         let item = TextVectorItem {
             geometry,
-            transform: Transform2D::IDENTITY,
+            transform: TextAffineTransform::IDENTITY,
             style: TextVectorStyle::default(),
             source_span: Some(TextSourceSpan::new(0, 1)),
             semantic_key: Some(Arc::from("fraction-rule")),

--- a/crates/noon-typst/Cargo.toml
+++ b/crates/noon-typst/Cargo.toml
@@ -9,7 +9,7 @@ description = "Typst text and math layout backend for Noon"
 noon-core = { path = "../noon-core" }
 typst-as-lib = { version = "=0.16.0", default-features = false }
 typst-assets = { version = "=0.15.1", features = ["fonts"] }
-# Direct frame normalization consumes Typst's paged layout model rather than retained SVG.
+# Direct normalization consumes Typst's paged frame layout instead of retained SVG.
 typst-layout = "=0.15.1"
 typst-library = "=0.15.1"
 typst-svg = "=0.15.1"

--- a/crates/noon-typst/Cargo.toml
+++ b/crates/noon-typst/Cargo.toml
@@ -9,6 +9,7 @@ description = "Typst text and math layout backend for Noon"
 noon-core = { path = "../noon-core" }
 typst-as-lib = { version = "=0.16.0", default-features = false }
 typst-assets = { version = "=0.15.1", features = ["fonts"] }
+# Direct frame normalization consumes Typst's paged layout model rather than retained SVG.
 typst-layout = "=0.15.1"
 typst-library = "=0.15.1"
 typst-svg = "=0.15.1"

--- a/crates/noon-typst/Cargo.toml
+++ b/crates/noon-typst/Cargo.toml
@@ -10,4 +10,5 @@ noon-core = { path = "../noon-core" }
 typst-as-lib = { version = "=0.16.0", default-features = false }
 typst-assets = { version = "=0.15.1", features = ["fonts"] }
 typst-layout = "=0.15.1"
+typst-library = "=0.15.1"
 typst-svg = "=0.15.1"

--- a/crates/noon-typst/src/lib.rs
+++ b/crates/noon-typst/src/lib.rs
@@ -1,18 +1,24 @@
 //! Typst-backed text/math layout for Noon.
 //!
-//! This crate is intentionally separate from `noon-core`: Typst is one concrete
-//! layout backend, while the semantic core retains a backend-neutral text resource
-//! contract. The initial bridge emits deterministic shrink-wrapped SVG plus layout
-//! identity. Renderer integration can later walk Typst frames directly and normalize
-//! glyph/vector items without changing the public resource model.
+//! Typst remains one concrete layout backend. This crate owns compilation and
+//! normalization into `noon-core`'s backend-neutral retained text resources so the
+//! renderer never needs to understand Typst frames or retain SVG markup.
 
 use std::{fmt, sync::Arc};
 
 use noon_core::{
-    TextLayoutArtifact, TextLayoutBackend, TextLayoutBackendKind, TextSourceKind, Vec2,
+    Color, FontFaceIdentity, GeometryResourceArena, GlyphRun, PositionedGlyph, Rect,
+    TextAffineTransform, TextClusterIdentity, TextDirection, TextLayoutArtifact, TextLayoutBackend,
+    TextLayoutBackendKind, TextPart, TextResource, TextResourceValidationError, TextSourceKind,
+    TextSourceSpan, TextVectorItem, TextVectorStyle, Vec2, VectorPath,
 };
 use typst_as_lib::TypstEngine;
 use typst_layout::PagedDocument;
+use typst_library::{
+    layout::{Frame, FrameItem, Point, Transform},
+    text::TextItem,
+    visualize::{CurveItem, Geometry, Paint, Shape},
+};
 use typst_svg::{svg, SvgOptions};
 
 pub const TYPST_BACKEND_VERSION: &str = "0.15.1";
@@ -34,11 +40,7 @@ impl TypstMode {
     }
 }
 
-/// First-stage Typst compilation result.
-///
-/// SVG is an integration artifact, not the eventual retained representation. The
-/// renderer should consume normalized `TextResource` glyph/vector data once direct
-/// frame extraction lands.
+/// SVG compatibility/debug result. SVG is never retained by the normalized text path.
 #[derive(Clone, Debug, PartialEq)]
 pub struct TypstSvgArtifact {
     pub mode: TypstMode,
@@ -49,11 +51,30 @@ pub struct TypstSvgArtifact {
     pub layout: TextLayoutArtifact,
 }
 
+/// Direct retained result used by Noon rendering/animation integration.
+///
+/// `resource` contains shaped glyph runs and references into `geometry` for Typst
+/// vector decorations such as fraction rules and authored shapes. No SVG string or
+/// Typst frame is retained after this value is constructed.
+#[derive(Clone, Debug)]
+pub struct TypstResourceArtifact {
+    pub mode: TypstMode,
+    pub source: Arc<str>,
+    pub prepared_source: Arc<str>,
+    pub resource: TextResource,
+    pub geometry: GeometryResourceArena,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum TypstBackendError {
     Compile(Arc<str>),
     EmptyDocument,
     MultiPage { pages: usize },
+    SourceTooLarge,
+    UnsupportedGradientOrTiling,
+    UnsupportedImage,
+    UnsupportedClip,
+    InvalidResource(TextResourceValidationError),
 }
 
 impl fmt::Display for TypstBackendError {
@@ -65,6 +86,24 @@ impl fmt::Display for TypstBackendError {
                 formatter,
                 "Typst text/math resources must produce one page, got {pages}"
             ),
+            Self::SourceTooLarge => {
+                write!(formatter, "Typst source exceeds Noon's text span space")
+            }
+            Self::UnsupportedGradientOrTiling => write!(
+                formatter,
+                "Typst gradients/tilings are not yet representable by retained text styles"
+            ),
+            Self::UnsupportedImage => write!(
+                formatter,
+                "Typst image frame items are not yet representable by retained text resources"
+            ),
+            Self::UnsupportedClip => write!(
+                formatter,
+                "Typst clipped text groups are not yet representable by retained text resources"
+            ),
+            Self::InvalidResource(error) => {
+                write!(formatter, "invalid normalized text resource: {error}")
+            }
         }
     }
 }
@@ -73,9 +112,99 @@ impl std::error::Error for TypstBackendError {}
 
 /// Compile Typst markup/math using bundled Typst fonts and return deterministic SVG.
 ///
-/// No system font scan, filesystem resolver, remote package resolver, or external
-/// executable is involved. This keeps browser/native behavior reproducible.
+/// This stays available for compatibility, diagnostics, and raster-differential
+/// fixtures. Production retained rendering should use [`compile_typst_resource`].
 pub fn compile_typst(source: &str, mode: TypstMode) -> Result<TypstSvgArtifact, TypstBackendError> {
+    let (document, prepared_source) = compile_document(source, mode)?;
+    let page = one_page(&document)?;
+    let size = page.frame.size();
+    let svg = svg(page, &SvgOptions::default());
+
+    Ok(TypstSvgArtifact {
+        mode,
+        source: Arc::from(source),
+        prepared_source: Arc::from(prepared_source.as_str()),
+        svg: Arc::from(svg.as_str()),
+        size_points: Vec2::new(size.x.to_pt() as f32, size.y.to_pt() as f32),
+        layout: layout_artifact(&prepared_source),
+    })
+}
+
+/// Compile Typst directly into Noon's retained glyph/vector resource model.
+pub fn compile_typst_resource(
+    source: &str,
+    mode: TypstMode,
+) -> Result<TypstResourceArtifact, TypstBackendError> {
+    let source_len = u32::try_from(source.len()).map_err(|_| TypstBackendError::SourceTooLarge)?;
+    let (document, prepared_source) = compile_document(source, mode)?;
+    let page = one_page(&document)?;
+    let size = page.frame.size();
+    let width = size.x.to_pt() as f32;
+    let height = size.y.to_pt() as f32;
+    let full_span = TextSourceSpan::new(0, source_len);
+
+    let mut normalizer = FrameNormalizer {
+        full_span,
+        page_to_noon: TextAffineTransform {
+            xx: 1.0,
+            yx: 0.0,
+            xy: 0.0,
+            yy: -1.0,
+            tx: -0.5 * width,
+            ty: 0.5 * height,
+        },
+        runs: Vec::new(),
+        vectors: Vec::new(),
+        parts: Vec::new(),
+        geometry: GeometryResourceArena::new(),
+        clusters: 0,
+    };
+    normalizer.walk_frame(&page.frame, TextAffineTransform::IDENTITY, None)?;
+
+    // The entire mobject is always one addressable part. Labeled Typst groups are
+    // appended as narrower semantic parts during traversal.
+    normalizer.parts.insert(
+        0,
+        TextPart {
+            source_span: full_span,
+            first_cluster: 0,
+            cluster_count: normalizer.clusters,
+            first_vector: 0,
+            vector_count: normalizer.vectors.len() as u32,
+            semantic_key: None,
+        },
+    );
+
+    let resource = TextResource {
+        source: Arc::from(source),
+        kind: mode.source_kind(),
+        runs: normalizer.runs.into(),
+        vector_items: normalizer.vectors.into(),
+        parts: normalizer.parts.into(),
+        bounds: Rect::new(
+            Vec2::new(-0.5 * width, -0.5 * height),
+            Vec2::new(0.5 * width, 0.5 * height),
+        ),
+        baseline: 0.5 * height - page.frame.baseline().to_pt() as f32,
+        layout_artifact: Some(layout_artifact(&prepared_source)),
+    };
+    resource
+        .validate()
+        .map_err(TypstBackendError::InvalidResource)?;
+
+    Ok(TypstResourceArtifact {
+        mode,
+        source: Arc::from(source),
+        prepared_source: Arc::from(prepared_source),
+        resource,
+        geometry: normalizer.geometry,
+    })
+}
+
+fn compile_document(
+    source: &str,
+    mode: TypstMode,
+) -> Result<(PagedDocument, String), TypstBackendError> {
     let prepared_source = prepare_source(source, mode);
     let engine = TypstEngine::builder()
         .main_file(prepared_source.as_str())
@@ -86,34 +215,292 @@ pub fn compile_typst(source: &str, mode: TypstMode) -> Result<TypstSvgArtifact, 
     let document = compiled
         .output
         .map_err(|error| TypstBackendError::Compile(Arc::from(error.to_string())))?;
+    Ok((document, prepared_source))
+}
 
-    let pages = document.pages();
-    let page = match pages {
-        [] => return Err(TypstBackendError::EmptyDocument),
-        [page] => page,
-        pages => return Err(TypstBackendError::MultiPage { pages: pages.len() }),
-    };
+fn one_page(document: &PagedDocument) -> Result<&typst_layout::Page, TypstBackendError> {
+    match document.pages() {
+        [] => Err(TypstBackendError::EmptyDocument),
+        [page] => Ok(page),
+        pages => Err(TypstBackendError::MultiPage { pages: pages.len() }),
+    }
+}
 
-    let size = page.frame.size();
-    let svg = svg(page, &SvgOptions::default());
-    let artifact_fingerprint = fingerprint_hex(svg.as_bytes());
-
-    Ok(TypstSvgArtifact {
-        mode,
-        source: Arc::from(source),
-        prepared_source: Arc::from(prepared_source),
-        svg: Arc::from(svg),
-        size_points: Vec2::new(size.x.to_pt() as f32, size.y.to_pt() as f32),
-        layout: TextLayoutArtifact {
-            backend: TextLayoutBackend {
-                kind: TextLayoutBackendKind::Typst,
-                version: Arc::from(TYPST_BACKEND_VERSION),
-            },
-            template_fingerprint: Arc::from(fingerprint_hex(TEMPLATE_VERSION.as_bytes())),
-            artifact_fingerprint: Arc::from(artifact_fingerprint),
-            backend_payload_key: None,
+fn layout_artifact(prepared_source: &str) -> TextLayoutArtifact {
+    let artifact_identity =
+        format!("{TYPST_BACKEND_VERSION}\0{TEMPLATE_VERSION}\0{prepared_source}");
+    TextLayoutArtifact {
+        backend: TextLayoutBackend {
+            kind: TextLayoutBackendKind::Typst,
+            version: Arc::from(TYPST_BACKEND_VERSION),
         },
-    })
+        template_fingerprint: Arc::from(fingerprint_hex(TEMPLATE_VERSION.as_bytes())),
+        artifact_fingerprint: Arc::from(fingerprint_hex(artifact_identity.as_bytes())),
+        backend_payload_key: None,
+    }
+}
+
+struct FrameNormalizer {
+    full_span: TextSourceSpan,
+    page_to_noon: TextAffineTransform,
+    runs: Vec<GlyphRun>,
+    vectors: Vec<TextVectorItem>,
+    parts: Vec<TextPart>,
+    geometry: GeometryResourceArena,
+    clusters: u32,
+}
+
+impl FrameNormalizer {
+    fn walk_frame(
+        &mut self,
+        frame: &Frame,
+        state: TextAffineTransform,
+        inherited_key: Option<Arc<str>>,
+    ) -> Result<(), TypstBackendError> {
+        for (position, item) in frame.items() {
+            let item_state = point_translation(*position).then(state);
+            match item {
+                FrameItem::Group(group) => {
+                    if group.clip.is_some() {
+                        return Err(TypstBackendError::UnsupportedClip);
+                    }
+                    let key = group
+                        .label
+                        .map(|label| Arc::<str>::from(label.resolve().as_str()))
+                        .or_else(|| inherited_key.clone());
+                    let first_cluster = self.clusters;
+                    let first_vector = self.vectors.len() as u32;
+                    let group_state = typst_transform(group.transform).then(item_state);
+                    self.walk_frame(&group.frame, group_state, key.clone())?;
+                    if let Some(semantic_key) = key {
+                        let cluster_count = self.clusters - first_cluster;
+                        let vector_count = self.vectors.len() as u32 - first_vector;
+                        if cluster_count != 0 || vector_count != 0 {
+                            self.parts.push(TextPart {
+                                source_span: self.full_span,
+                                first_cluster,
+                                cluster_count,
+                                first_vector,
+                                vector_count,
+                                semantic_key: Some(semantic_key),
+                            });
+                        }
+                    }
+                }
+                FrameItem::Text(text) => {
+                    self.push_text(text, item_state, inherited_key.clone())?;
+                }
+                FrameItem::Shape(shape, _) => {
+                    self.push_shape(shape, item_state, inherited_key.clone())?;
+                }
+                FrameItem::Image(_, _, _) => return Err(TypstBackendError::UnsupportedImage),
+                FrameItem::Link(_, _) | FrameItem::Tag(_) => {}
+            }
+        }
+        Ok(())
+    }
+
+    fn push_text(
+        &mut self,
+        text: &TextItem,
+        state: TextAffineTransform,
+        inherited_key: Option<Arc<str>>,
+    ) -> Result<(), TypstBackendError> {
+        let font = text.font.font();
+        let family = font.info().family.clone();
+        let face_key = font
+            .post_script_name()
+            .unwrap_or_else(|| format!("{}#{}", family, font.index()));
+        let variation_key = format!("{:?}", text.font.variations());
+        let fill = inherited_color(&text.fill)?;
+        if let Some(stroke) = &text.stroke {
+            // Ensure the retained path does not silently discard a paint mode even
+            // though glyph stroke rendering is a later renderer task.
+            let _ = solid_color(&stroke.paint)?;
+        }
+
+        let mut cursor = Vec2::ZERO;
+        let font_size = text.size.to_pt() as f32;
+        let mut glyphs = Vec::with_capacity(text.glyphs.len());
+        for glyph in &text.glyphs {
+            let offset = Vec2::new(
+                glyph.x_offset.at(text.size).to_pt() as f32,
+                glyph.y_offset.at(text.size).to_pt() as f32,
+            );
+            let advance = Vec2::new(
+                glyph.x_advance.at(text.size).to_pt() as f32,
+                glyph.y_advance.at(text.size).to_pt() as f32,
+            );
+            let origin = cursor + offset;
+            let semantic_key = inherited_key.clone().or_else(|| {
+                let slice = &text.text[glyph.range()];
+                (!slice.is_empty()).then(|| Arc::<str>::from(slice))
+            });
+
+            // Exact glyph outlines remain lazy. Bounds are conservative layout bounds
+            // and do not require extracting a path from the font.
+            let x1 = origin.x.min(origin.x + advance.x);
+            let mut x2 = origin.x.max(origin.x + advance.x);
+            if (x2 - x1).abs() < f32::EPSILON {
+                x2 = x1 + 0.5 * font_size;
+            }
+            let bounds = Rect::new(
+                Vec2::new(x1, origin.y - 0.3 * font_size),
+                Vec2::new(x2, origin.y + 0.9 * font_size),
+            );
+            glyphs.push(PositionedGlyph {
+                glyph_id: u32::from(glyph.id),
+                cluster: TextClusterIdentity {
+                    // Typst's Span is backend-internal. Until the source-map bridge is
+                    // added, stable glyph/label semantic keys plus ordinal identity are
+                    // retained while the span conservatively addresses the full source.
+                    source_span: self.full_span,
+                    cluster_ordinal: self.clusters,
+                    semantic_key,
+                },
+                origin,
+                advance,
+                bounds,
+            });
+            self.clusters += 1;
+            cursor += advance;
+        }
+
+        // Typst renders glyph outlines in a Y-up font coordinate system while its
+        // frames are Y-down. Conjugating that flip with the accumulated frame state
+        // and final page-to-Noon flip preserves arbitrary group affine transforms.
+        let font_y_up_to_frame = TextAffineTransform {
+            yy: -1.0,
+            ..TextAffineTransform::IDENTITY
+        };
+        let transform = font_y_up_to_frame.then(state).then(self.page_to_noon);
+
+        self.runs.push(GlyphRun {
+            font: FontFaceIdentity {
+                family: Arc::from(family),
+                face_key: Arc::from(face_key),
+                face_index: font.index(),
+                variation_key: Arc::from(variation_key),
+            },
+            font_size,
+            direction: TextDirection::LeftToRight,
+            fill,
+            transform,
+            glyphs: glyphs.into(),
+        });
+        Ok(())
+    }
+
+    fn push_shape(
+        &mut self,
+        shape: &Shape,
+        state: TextAffineTransform,
+        semantic_key: Option<Arc<str>>,
+    ) -> Result<(), TypstBackendError> {
+        let path = geometry_path(&shape.geometry);
+        let handle = self.geometry.insert_path(path);
+        let fill = shape
+            .fill
+            .as_ref()
+            .map(inherited_color)
+            .transpose()?
+            .flatten();
+        let (stroke, stroke_width) = match &shape.stroke {
+            Some(stroke) => (
+                inherited_color(&stroke.paint)?,
+                stroke.thickness.to_pt() as f32,
+            ),
+            None => (None, 0.0),
+        };
+        self.vectors.push(TextVectorItem {
+            geometry: handle,
+            transform: state.then(self.page_to_noon),
+            style: TextVectorStyle {
+                fill,
+                stroke,
+                stroke_width,
+            },
+            source_span: None,
+            semantic_key,
+        });
+        Ok(())
+    }
+}
+
+fn point_translation(point: Point) -> TextAffineTransform {
+    TextAffineTransform::translation(point.x.to_pt() as f32, point.y.to_pt() as f32)
+}
+
+fn typst_transform(transform: Transform) -> TextAffineTransform {
+    TextAffineTransform {
+        xx: transform.sx.get() as f32,
+        yx: transform.ky.get() as f32,
+        xy: transform.kx.get() as f32,
+        yy: transform.sy.get() as f32,
+        tx: transform.tx.to_pt() as f32,
+        ty: transform.ty.to_pt() as f32,
+    }
+}
+
+fn geometry_path(geometry: &Geometry) -> VectorPath {
+    match geometry {
+        Geometry::Line(end) => VectorPath::new()
+            .move_to(Vec2::ZERO)
+            .line_to(point_vec(*end)),
+        Geometry::Rect(size) => {
+            let width = size.x.to_pt() as f32;
+            let height = size.y.to_pt() as f32;
+            VectorPath::new()
+                .move_to(Vec2::ZERO)
+                .line_to(Vec2::new(width, 0.0))
+                .line_to(Vec2::new(width, height))
+                .line_to(Vec2::new(0.0, height))
+                .close()
+        }
+        Geometry::Curve(curve) => {
+            let mut path = VectorPath::new();
+            for item in &curve.0 {
+                path = match item {
+                    CurveItem::Move(point) => path.move_to(point_vec(*point)),
+                    CurveItem::Line(point) => path.line_to(point_vec(*point)),
+                    CurveItem::Cubic(control1, control2, point) => path.cubic_to(
+                        point_vec(*control1),
+                        point_vec(*control2),
+                        point_vec(*point),
+                    ),
+                    CurveItem::Close => path.close(),
+                };
+            }
+            path
+        }
+    }
+}
+
+fn point_vec(point: Point) -> Vec2 {
+    Vec2::new(point.x.to_pt() as f32, point.y.to_pt() as f32)
+}
+
+fn inherited_color(paint: &Paint) -> Result<Option<Color>, TypstBackendError> {
+    let color = solid_color(paint)?;
+    // Typst's default text/shape paint is black. Treat it as inherited so the
+    // owning Noon mobject can apply Manim's color semantics without recompilation.
+    if color.red.abs() < f32::EPSILON
+        && color.green.abs() < f32::EPSILON
+        && color.blue.abs() < f32::EPSILON
+        && (color.alpha - 1.0).abs() < f32::EPSILON
+    {
+        Ok(None)
+    } else {
+        Ok(Some(color))
+    }
+}
+
+fn solid_color(paint: &Paint) -> Result<Color, TypstBackendError> {
+    let Paint::Solid(color) = paint else {
+        return Err(TypstBackendError::UnsupportedGradientOrTiling);
+    };
+    let (red, green, blue, alpha) = color.to_rgb().into_components();
+    Ok(Color::rgba(red, green, blue, alpha))
 }
 
 pub fn prepare_source(source: &str, mode: TypstMode) -> String {
@@ -144,6 +531,7 @@ fn fingerprint_hex(bytes: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use noon_core::GeometryResource;
 
     #[test]
     fn markup_compiles_to_one_shrink_wrapped_svg() {
@@ -170,13 +558,77 @@ mod tests {
     }
 
     #[test]
-    fn compilation_is_deterministic_for_identical_input() {
-        let first = compile_typst("$ x^2 $", TypstMode::Markup).unwrap();
-        let second = compile_typst("$ x^2 $", TypstMode::Markup).unwrap();
-        assert_eq!(first.svg, second.svg);
+    fn direct_markup_normalization_retains_shaped_glyphs_without_svg() {
+        let artifact = compile_typst_resource("Hello", TypstMode::Markup).unwrap();
+        assert_eq!(artifact.resource.kind, TextSourceKind::Typst);
+        assert!(artifact.resource.glyph_count() >= 5);
+        assert!(!artifact.resource.runs.is_empty());
+        assert!(artifact.resource.bounds.width() > 0.0);
+        assert!(artifact.resource.bounds.height() > 0.0);
         assert_eq!(
-            first.layout.artifact_fingerprint,
-            second.layout.artifact_fingerprint
+            artifact
+                .resource
+                .layout_artifact
+                .as_ref()
+                .unwrap()
+                .backend
+                .kind,
+            TextLayoutBackendKind::Typst
+        );
+    }
+
+    #[test]
+    fn direct_math_normalization_retains_vector_decorations() {
+        let artifact = compile_typst_resource("frac(x, 2)", TypstMode::Math).unwrap();
+        assert_eq!(artifact.resource.kind, TextSourceKind::MathTypst);
+        assert!(artifact.resource.glyph_count() >= 2);
+        assert!(artifact.resource.vector_count() >= 1);
+        assert!(!artifact.geometry.is_empty());
+        for item in artifact.resource.vector_items.iter() {
+            assert!(matches!(
+                artifact.geometry.get(item.geometry),
+                Some(GeometryResource::VectorPath(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn authored_typst_color_is_intrinsic_but_default_black_inherits() {
+        let default = compile_typst_resource("Hello", TypstMode::Markup).unwrap();
+        assert!(default.resource.runs.iter().all(|run| run.fill.is_none()));
+
+        let styled = compile_typst_resource("#text(fill: red)[Hello]", TypstMode::Markup).unwrap();
+        assert!(styled.resource.runs.iter().any(|run| run.fill.is_some()));
+    }
+
+    #[test]
+    fn labeled_groups_become_stable_semantic_parts() {
+        let artifact = compile_typst_resource("#box[x] <lhs> + y", TypstMode::Markup).unwrap();
+        assert!(artifact
+            .resource
+            .parts
+            .iter()
+            .any(|part| part.semantic_key.as_deref() == Some("lhs")));
+    }
+
+    #[test]
+    fn compilation_is_deterministic_for_identical_input() {
+        let first = compile_typst_resource("$ x^2 $", TypstMode::Markup).unwrap();
+        let second = compile_typst_resource("$ x^2 $", TypstMode::Markup).unwrap();
+        assert_eq!(first.resource.runs, second.resource.runs);
+        assert_eq!(
+            first
+                .resource
+                .layout_artifact
+                .as_ref()
+                .unwrap()
+                .artifact_fingerprint,
+            second
+                .resource
+                .layout_artifact
+                .as_ref()
+                .unwrap()
+                .artifact_fingerprint
         );
     }
 


### PR DESCRIPTION
## Summary
- add general affine transforms to retained text runs/vector items so Typst layout is not reduced to TRS
- compile Typst `PagedDocument` frames directly into backend-neutral `TextResource` data
- retain shaped glyph IDs/advances/semantic keys without outlining steady-state text
- lower Typst `Line`/`Rect`/`Curve` shapes into the shared geometry arena for math decorations
- preserve authored solid colors while allowing default Typst black to inherit the owning Noon mobject color
- map labeled Typst groups to stable `TextPart` identities
- keep SVG export only as a compatibility/debug API; the retained resource path stores no SVG
- add deterministic normalization tests, including fraction-vector coverage

## Deliberate follow-ups
- exact Typst `Span` -> original source byte mapping (current normalized clusters retain stable ordinal/semantic identity and conservatively use the full source span)
- gradients/tilings, clipped groups, and image/emoji frame items currently fail explicitly rather than silently degrading
- renderer/public `Typst`/`MathTypst` mobject wiring follows once this normalization contract is green

Part of #65 and #83.