### PR TITLE
Restore Manim updater lifecycle boundaries

### DIFF
--- a/crates/noon-core/src/host_callbacks.rs
+++ b/crates/noon-core/src/host_callbacks.rs
@@ -26,10 +26,16 @@ pub struct HostCallbackSlot {
     pub id: HostCallbackId,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub objects: Vec<ObjectId>,
-    /// Callback is inactive at this exact time and becomes active immediately after it.
+    /// Registration time. The callback is active at this exact time.
+    ///
+    /// The serialized field name is retained for wire compatibility even though
+    /// Manim updater semantics use an inclusive start boundary.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub active_after: Option<f64>,
-    /// Callback remains active through this exact time, then becomes inactive.
+    /// Removal time. The callback is inactive at this exact time.
+    ///
+    /// The serialized field name is retained for wire compatibility even though
+    /// Manim updater semantics use an exclusive end boundary.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub active_through: Option<f64>,
 }
@@ -37,8 +43,8 @@ pub struct HostCallbackSlot {
 impl HostCallbackSlot {
     pub fn is_active_at(&self, time: f64) -> bool {
         time.is_finite()
-            && self.active_after.is_none_or(|start| time > start)
-            && self.active_through.is_none_or(|end| time <= end)
+            && self.active_after.is_none_or(|start| time >= start)
+            && self.active_through.is_none_or(|end| time < end)
     }
 
     fn validate_schedule(&self) -> Result<(), HostCallbackRegistryError> {
@@ -171,7 +177,7 @@ mod tests {
     }
 
     #[test]
-    fn scheduled_slot_uses_exclusive_start_and_inclusive_end() {
+    fn scheduled_slot_uses_inclusive_start_and_exclusive_end() {
         let slot = HostCallbackSlot {
             id: HostCallbackId::new(2),
             objects: vec![],
@@ -179,10 +185,23 @@ mod tests {
             active_through: Some(2.0),
         };
         HostCallbackRegistry::from_slots(vec![slot.clone()]).unwrap();
-        assert!(!slot.is_active_at(1.0));
-        assert!(slot.is_active_at(1.0 + f64::EPSILON));
-        assert!(slot.is_active_at(2.0));
-        assert!(!slot.is_active_at(2.0 + 1.0e-12));
+        assert!(!slot.is_active_at(1.0 - f64::EPSILON));
+        assert!(slot.is_active_at(1.0));
+        assert!(slot.is_active_at(2.0 - f64::EPSILON));
+        assert!(!slot.is_active_at(2.0));
+    }
+
+    #[test]
+    fn zero_width_slot_is_never_active() {
+        let slot = HostCallbackSlot {
+            id: HostCallbackId::new(4),
+            objects: vec![],
+            active_after: Some(0.0),
+            active_through: Some(0.0),
+        };
+        HostCallbackRegistry::from_slots(vec![slot.clone()]).unwrap();
+        assert!(!slot.is_active_at(0.0));
+        assert!(!slot.is_active_at(f64::EPSILON));
     }
 
     #[test]

--- a/crates/noon-runtime/src/reactive/host_callbacks.rs
+++ b/crates/noon-runtime/src/reactive/host_callbacks.rs
@@ -234,8 +234,8 @@ impl HostDrivenScene {
             .scheduled_invocations
             .iter()
             .filter(|(_, active_after, active_through)| {
-                active_after.is_none_or(|start| frame.time > start)
-                    && active_through.is_none_or(|end| frame.time <= end)
+                active_after.is_none_or(|start| frame.time >= start)
+                    && active_through.is_none_or(|end| frame.time < end)
             })
             .map(|(invocation, _, _)| invocation.clone())
             .collect();
@@ -367,7 +367,10 @@ mod tests {
         .unwrap();
         let mut driven = HostDrivenScene::new(scene, &registry).unwrap();
 
-        assert!(driven.callback_frame().invocations.is_empty());
+        assert_eq!(
+            driven.callback_frame().invocations[0].callback,
+            HostCallbackId::new(0)
+        );
         driven.advance_to(0.5).unwrap();
         assert_eq!(
             driven.callback_frame().invocations[0].callback,
@@ -376,7 +379,7 @@ mod tests {
         driven.advance_to(1.0).unwrap();
         assert_eq!(
             driven.callback_frame().invocations[0].callback,
-            HostCallbackId::new(0)
+            HostCallbackId::new(1)
         );
         driven.advance_to(1.5).unwrap();
         assert_eq!(
@@ -384,11 +387,6 @@ mod tests {
             HostCallbackId::new(1)
         );
         driven.advance_to(2.0).unwrap();
-        assert_eq!(
-            driven.callback_frame().invocations[0].callback,
-            HostCallbackId::new(1)
-        );
-        driven.advance_to(2.1).unwrap();
         assert!(driven.callback_frame().invocations.is_empty());
     }
 

--- a/scripts/updater-callback-smoke.mjs
+++ b/scripts/updater-callback-smoke.mjs
@@ -66,13 +66,17 @@ try {
   assert.equal(errors.length, 0, errors.join("\n"));
   assert.equal(output.result.kind, "scene_document");
   assert.ok(output.result.callbacks);
-  assert.deepEqual(output.result.callbacks.slots, [{ id: 0, objects: [0, 1] }]);
+  assert.deepEqual(output.result.callbacks.slots, [
+    { id: 0, objects: [0, 1], active_after: 0, active_through: 0 },
+    { id: 1, objects: [0, 1], active_after: 0 },
+  ]);
   assert.equal(output.phases.length, 2);
   assert.equal(output.nextSequence, 2);
 
   assert.equal(output.phases[0].frame.time, 0.25);
   assert.equal(output.phases[0].frame.delta_time, 0.25);
   assert.equal(output.phases[0].frame.objects.length, 2);
+  assert.deepEqual(output.phases[0].frame.invocations.map(({ callback }) => callback), [1]);
   assert.equal(output.phases[0].batch.sequence, 0);
   assert.equal(output.phases[0].batch.patches.length, 2);
   const firstTransform = output.phases[0].batch.patches[0].set_transform;
@@ -87,6 +91,7 @@ try {
   assert.equal(output.phases[1].frame.delta_time, 0.5);
   assert.equal(output.phases[1].frame.objects[1].transform.translation.x, 2);
   assert.equal(output.phases[1].frame.objects[1].transform.translation.y, 0.25);
+  assert.deepEqual(output.phases[1].frame.invocations.map(({ callback }) => callback), [1]);
   assert.equal(output.phases[1].batch.sequence, 1);
   const secondTransform = output.phases[1].batch.patches[0].set_transform;
   assert.equal(secondTransform.transform.translation.x, 2);

--- a/web/execution-engine-worker.js
+++ b/web/execution-engine-worker.js
@@ -598,10 +598,10 @@ function freshHostMetrics() {
 }
 
 function callbackSlotActiveAt(slot, time) {
-  if (slot.active_after !== undefined && slot.active_after !== null && !(time > slot.active_after)) {
+  if (slot.active_after !== undefined && slot.active_after !== null && time < slot.active_after) {
     return false;
   }
-  if (slot.active_through !== undefined && slot.active_through !== null && time > slot.active_through) {
+  if (slot.active_through !== undefined && slot.active_through !== null && time >= slot.active_through) {
     return false;
   }
   return true;

--- a/web/python/_manim_updaters.py
+++ b/web/python/_manim_updaters.py
@@ -73,6 +73,17 @@ def _scene_time(mobject: _base.Mobject) -> float | None:
     return float(scene.time)
 
 
+def _registration_end_time(
+    mobject: _base.Mobject, registration: _UpdaterRegistration
+) -> float:
+    scene_time = _scene_time(mobject)
+    if scene_time is not None:
+        return scene_time
+    if registration.active_after is not None:
+        return registration.active_after
+    return 0.0
+
+
 def add_updater(
     self: _base.Mobject,
     update_function: Callable[..., Any],
@@ -112,7 +123,7 @@ def remove_updater(
         if callback is update_function:
             del callbacks[index]
             registration = registrations.pop(index)
-            registration.active_through = _scene_time(self)
+            registration.active_through = _registration_end_time(self, registration)
             break
     return self
 
@@ -121,9 +132,8 @@ def clear_updaters(self: _base.Mobject, recursive: bool = True) -> _base.Mobject
     # Noon has no persisted runtime hierarchy, but Group/VGroup recurse in their own
     # Python wrappers. The flag is accepted for Manim source compatibility.
     del recursive
-    end_time = _scene_time(self)
     for registration in _registrations(self):
-        registration.active_through = end_time
+        registration.active_through = _registration_end_time(self, registration)
     _updaters(self).clear()
     _registrations(self).clear()
     return self

--- a/web/python/test_manim_updater_lifecycle.py
+++ b/web/python/test_manim_updater_lifecycle.py
@@ -87,6 +87,29 @@ class ManimUpdaterLifecycleTests(unittest.TestCase):
             backward_batch = json.loads(updaters.run_callback_phase(session, frame(3.0, 0.25, 1), 1))
             backward_rotation = backward_batch["patches"][0]["set_transform"]["transform"]["rotation"]
             assert abs(backward_rotation + 0.25) < 1e-6, backward_rotation
+
+            detached_scene = Scene()
+            detached = Line(ORIGIN, LEFT)
+
+            def removed_before_bind(mobject):
+                mobject.shift(LEFT * 99)
+
+            def live_after_bind(mobject, dt):
+                mobject.rotate_about_origin(dt)
+
+            detached.add_updater(removed_before_bind)
+            detached.remove_updater(removed_before_bind)
+            detached.add_updater(live_after_bind)
+            detached_scene.add(detached)
+
+            detached_config = updaters.register_scene(detached_scene)
+            assert detached_config is not None
+            assert len(detached_config["slots"]) == 2, detached_config
+            removed_slot, live_slot = detached_config["slots"]
+            assert removed_slot["active_after"] == 0.0
+            assert removed_slot["active_through"] == 0.0
+            assert live_slot["active_after"] == 0.0
+            assert "active_through" not in live_slot
             """
         )
         completed = subprocess.run(


### PR DESCRIPTION
Fix the updater lifecycle regression introduced by scheduled host callbacks and restore Manim's exact updater frame-boundary semantics.

- close updater registrations that are added and removed before `Scene.add` instead of leaving them open-ended
- preserve zero-width authored history slots so callback IDs remain deterministic while never executing them
- use Manim-compatible `[registration, removal)` activation windows: updater runs at the exact registration/frame-start time and is inactive at exact removal time
- apply the same boundary rule in core, native runtime, and the browser execution worker
- assert removed slots are filtered from runtime callback frames
- add focused Python/core/runtime regressions
- keep raster tolerances unchanged; this fixes the `MovingDots` frame-0 parity regression rather than masking it

This is intentionally separate from the Typst resource work in #306.