### PR TITLE
Run Manim raster oracle on master

### DIFF
--- a/.github/workflows/manim-raster-differential.yml
+++ b/.github/workflows/manim-raster-differential.yml
@@ -2,6 +2,9 @@ name: Manim raster differential
 
 on:
   pull_request:
+  push:
+    branches:
+      - master
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Ensure the pinned ManimCE v0.21 raster differential also runs after merges to master. This closes the gap where connector-authored PR changes could be merged without the exact-output raster ratchet running on the resulting master commit. No thresholds or raster semantics are changed.