### PR TITLE
Align JavaScript moving-camera opacity semantics

### DIFF
--- a/web/noon-moving-camera.js
+++ b/web/noon-moving-camera.js
@@ -13,9 +13,11 @@ export const DEFAULT_FRAME_WIDTH = DEFAULT_FRAME_HEIGHT * 16.0 / 9.0;
 export class MovingCameraScene extends Scene {
   constructor() {
     super();
-    const frame = new Rectangle(DEFAULT_FRAME_WIDTH, DEFAULT_FRAME_HEIGHT)
-      .setOpacity(0.0);
+    const frame = new Rectangle(DEFAULT_FRAME_WIDTH, DEFAULT_FRAME_HEIGHT);
     this.add(frame);
+    // Hide the semantic camera frame through the bound Rust scene editor so its
+    // canonical object opacity matches Rust/Python and is preserved by transforms.
+    frame.setOpacity(0.0);
     this.camera = Object.freeze({ frame });
   }
 


### PR DESCRIPTION
Fix the remaining tri-language MovingCameraCenter semantic mismatch. The JS adapter now binds the camera frame before setting opacity, routing the hide operation through the canonical Rust scene editor. This preserves `style.opacity = 0` in the camera object and its transform targets, matching Rust and Python without changing generic raster thresholds or camera math.