### PR TITLE
Add clean exact Manim MoveToTarget parity

### DIFF
--- a/compat/manim-v0.21.0.json
+++ b/compat/manim-v0.21.0.json
@@ -46,6 +46,7 @@
     "Transform": {"status": "supported", "category": "animation", "evidence": "generic transform tests"},
     "ReplacementTransform": {"status": "supported", "category": "animation", "evidence": "lifecycle tests"},
     "TransformFromCopy": {"status": "supported", "category": "animation", "evidence": "transform-from-copy tests"},
+    "MoveToTarget": {"status": "partial", "category": "animation-transform", "dependency": "#82", "reason": "Leaf 2D Mobjects using generate_target() lower to the retained Transform path and are attached to the canonical raster/timeline gate; retained Group/VGroup family targets and broader family alignment remain pending."},
     "TransformMatchingShapes": {"status": "supported", "category": "animation", "evidence": "matching-shapes tests"},
     "AnimationGroup": {"status": "supported", "category": "animation-composition", "evidence": "composition tests"},
     "LaggedStart": {"status": "supported", "category": "animation-composition", "evidence": "composition tests"},

--- a/docs/parity-move-to-target.md
+++ b/docs/parity-move-to-target.md
@@ -1,0 +1,12 @@
+# ManimCE v0.21 `MoveToTarget` parity slice
+
+This slice uses the literal `MoveToTargetExample` from ManimCE v0.21 with only the
+import changed for the public Noon example. `Mobject.generate_target()` creates a
+detached semantic copy; `MoveToTarget` therefore lowers to the existing retained
+`Transform` path rather than introducing a second scheduler or renderer primitive.
+
+The first exact-output slice covers leaf 2D mobjects and the standard generated-target
+workflow. Group/VGroup family alignment remains partial under #82 and is rejected rather
+than approximated. Qualification uses the unchanged canonical duration, semantic-state,
+Cairo raster, direct-seek/incremental-playback, WebGPU, and WebGL gates. No fixture-specific
+raster tolerance or scheduler exception is introduced by this slice.

--- a/parity/manim-v0.21/manifest.json
+++ b/parity/manim-v0.21/manifest.json
@@ -64,6 +64,11 @@
       "expected_duration": 1.0
     },
     {
+      "id": "move-to-target-circle",
+      "scene": "MoveToTargetExample",
+      "expected_duration": 1.0
+    },
+    {
       "id": "create-line",
       "scene": "CreateLine",
       "expected_duration": 1.0,

--- a/parity/manim-v0.21/quickstart.py
+++ b/parity/manim-v0.21/quickstart.py
@@ -578,6 +578,18 @@ class IndicateSquare(Scene):
         self.play(Indicate(square))
 
 
+class MoveToTargetExample(Scene):
+    def construct(self):
+        c = Circle()
+
+        c.generate_target()
+        c.target.set_fill(color=GREEN, opacity=0.5)
+        c.target.shift(2*RIGHT + UP).scale(0.5)
+
+        self.add(c)
+        self.play(MoveToTarget(c))
+
+
 class SpinInFromNothingRectangle(Scene):
     def construct(self):
         rectangle = Rectangle(

--- a/parity/manim-v0.21/upstream-examples/move_to_target_example.py
+++ b/parity/manim-v0.21/upstream-examples/move_to_target_example.py
@@ -1,0 +1,12 @@
+from manim import *
+
+class MoveToTargetExample(Scene):
+    def construct(self):
+        c = Circle()
+
+        c.generate_target()
+        c.target.set_fill(color=GREEN, opacity=0.5)
+        c.target.shift(2*RIGHT + UP).scale(0.5)
+
+        self.add(c)
+        self.play(MoveToTarget(c))

--- a/web/python/_manim_compat.py
+++ b/web/python/_manim_compat.py
@@ -1054,6 +1054,31 @@ def _mobject_replace(
     return self
 
 
+class MoveToTarget:
+    """ManimCE ``MoveToTarget`` over Noon's retained ``Transform`` path."""
+
+    def __new__(cls, mobject: object, **kwargs: Any):
+        if isinstance(mobject, Group):
+            raise NotImplementedError(
+                "MoveToTarget(Group/VGroup) requires retained family Transform semantics"
+            )
+        if not isinstance(mobject, _BaseMobject):
+            raise TypeError("MoveToTarget target must be a Mobject")
+        if not hasattr(mobject, "target"):
+            raise ValueError("MoveToTarget called on mobject without attribute 'target'")
+        target = mobject.target
+        if not isinstance(target, _BaseMobject) or isinstance(target, Group):
+            raise NotImplementedError(
+                "MoveToTarget currently requires a leaf Mobject target produced by generate_target()"
+            )
+        unsupported = sorted(set(kwargs) - {"key"})
+        if unsupported:
+            raise NotImplementedError(
+                "unsupported MoveToTarget option(s): " + ", ".join(unsupported)
+            )
+        return _base.Transform(mobject, target, key=kwargs.get("key"))
+
+
 def install() -> None:
     """Install the compatibility surface into the public ``noon`` module."""
 
@@ -1110,6 +1135,7 @@ def install() -> None:
         "Group": Group,
         "VGroup": VGroup,
         "Scene": Scene,
+        "MoveToTarget": MoveToTarget,
         "OUT": OUT,
         "IN": IN,
     }

--- a/web/python/examples/manim_example_move_to_target.py
+++ b/web/python/examples/manim_example_move_to_target.py
@@ -1,0 +1,12 @@
+from noon import *
+
+class MoveToTargetExample(Scene):
+    def construct(self):
+        c = Circle()
+
+        c.generate_target()
+        c.target.set_fill(color=GREEN, opacity=0.5)
+        c.target.shift(2*RIGHT + UP).scale(0.5)
+
+        self.add(c)
+        self.play(MoveToTarget(c))

--- a/web/python/examples/manim_tutorial_manifest.json
+++ b/web/python/examples/manim_tutorial_manifest.json
@@ -409,6 +409,25 @@
       "order": 210
     },
     {
+      "id": "manim-move-to-target",
+      "title": "MoveToTargetExample",
+      "summary": "ManimCE v0.21 MoveToTarget reference example, unchanged except for the import module.",
+      "status": "ready",
+      "path": "python/examples/manim_example_move_to_target.py",
+      "category": "transform",
+      "features": ["MoveToTarget", "generate_target", "Circle", "Transform", "pixel-parity", "time-parity"],
+      "upstream": "reference/manim.animation.transform.MoveToTarget.html",
+      "upstream_source": "parity/manim-v0.21/upstream-examples/move_to_target_example.py",
+      "reuse": "source-equivalent-manim-v0.21",
+      "parity_status": "candidate",
+      "parity_fixture": "move-to-target-circle",
+      "expected_duration": 1.0,
+      "thumbnail": "thumbnails/manim/exact-source.svg",
+      "thumbnail_alt": "Exact-source Manim MoveToTargetExample",
+      "thumbnail_time": 0.5,
+      "order": 215
+    },
+    {
       "id": "parity-moving-around",
       "title": "MovingAround",
       "summary": "ManimCE v0.21 Example Gallery MovingAround, byte-for-byte except for the import module, with Rust and JavaScript semantic equivalents.",

--- a/web/python/test_manim_move_to_target.py
+++ b/web/python/test_manim_move_to_target.py
@@ -1,0 +1,69 @@
+import os
+import subprocess
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+
+
+class ManimMoveToTargetTests(unittest.TestCase):
+    def test_exact_example_lowers_to_retained_transform(self) -> None:
+        python_dir = Path(__file__).resolve().parent
+        repo_root = python_dir.parent.parent
+        env = os.environ.copy()
+        env["PYTHONPATH"] = os.pathsep.join(
+            part for part in (str(python_dir), env.get("PYTHONPATH", "")) if part
+        )
+        source = textwrap.dedent(
+            f"""
+            import runpy
+            import _manim_compat; _manim_compat.install()
+            import _manim_rate_functions; _manim_rate_functions.install()
+            from noon import Circle, MoveToTarget, RIGHT, Scene, Transform, UP, VGroup
+
+            missing = Circle()
+            try:
+                MoveToTarget(missing)
+                raise AssertionError("missing target must fail")
+            except ValueError as error:
+                assert str(error) == "MoveToTarget called on mobject without attribute 'target'"
+
+            group = VGroup(Circle(), Circle())
+            group.generate_target = lambda: None
+            try:
+                MoveToTarget(group)
+                raise AssertionError("group target must fail")
+            except NotImplementedError:
+                pass
+
+            namespace = runpy.run_path({str(repo_root / "web/python/examples/manim_example_move_to_target.py")!r})
+            scene = namespace["MoveToTargetExample"]()
+            scene.construct()
+            assert abs(scene.time - 1.0) < 1e-12
+            tracks = [t for t in scene._tracks if t["property"] == "transform"]
+            assert len(tracks) == 1
+            assert abs(tracks[0]["timing"]["duration"] - 1.0) < 1e-12
+            target = tracks[0]["values"]["object"]["to"]
+            assert abs(target["transform"]["translation"]["x"] - 2.0) < 1e-12
+            assert abs(target["transform"]["translation"]["y"] - 1.0) < 1e-12
+            assert abs(target["transform"]["scale"]["x"] - 0.5) < 1e-12
+
+            c = Circle(); c.generate_target(); pending = MoveToTarget(c); c.target.shift(RIGHT)
+            scene2 = Scene(); scene2.add(c); scene2.play(pending)
+            target2 = [t for t in scene2._tracks if t["property"] == "transform"][0]["values"]["object"]["to"]
+            assert abs(target2["transform"]["translation"]["x"] - 1.0) < 1e-12
+            """
+        )
+        completed = subprocess.run(
+            [sys.executable, "-c", source],
+            cwd=repo_root,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Supersedes #313 with a clean current-master implementation.

## What changed
- keeps the literal ManimCE v0.21 `MoveToTargetExample` with only the import changed in the public Noon source;
- places `MoveToTarget` beside `generate_target()` in `_manim_compat.py` as a thin adapter to the existing retained `Transform` path;
- rejects retained Group/VGroup targets explicitly pending #82 instead of expanding them in Python;
- adds the canonical 1.0s `move-to-target-circle` semantic/raster/timeline fixture with no fixture-specific tolerance;
- adds focused subprocess coverage for missing target, leaf target lowering, late target mutation, duration, translation/scale, and family rejection;
- updates the compatibility and demo manifests additively.

## Architecture / conflict hygiene
- **No changes to `web/python/_manim_rate_functions.py`.** The large unrelated rate-function rewrite present in #313 was stale branch baggage and is intentionally excluded.
- No new scheduler or renderer primitive; playback remains the existing retained Transform implementation.
- Branch is one commit on current master and contains exactly nine intended text files.

Focused staging validation passed Python compile/tests, JSON validation, semantic-ownership checks, exact source equivalence, diff checks, and an explicit zero-diff assertion for `_manim_rate_functions.py`.

Closes/supersedes #313 after this replacement is live. Tracks #82 and #185.