### PR TITLE
[Parity infra] Support per-fixture Manim raster sources

### DIFF
--- a/scripts/manim-raster-differential.mjs
+++ b/scripts/manim-raster-differential.mjs
@@ -15,8 +15,24 @@ const repoRoot = path.resolve(scriptDir, "..");
 const manifestPath = path.join(repoRoot, "parity", "manim-v0.21", "manifest.json");
 const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
 const reference = manifest.reference;
-const fixtureSourcePath = path.join(repoRoot, reference.source);
-const fixtureSource = await readFile(fixtureSourcePath, "utf8");
+const fixtureSources = new Map();
+for (const fixture of manifest.fixtures) {
+  const relativeSource = fixture.source ?? reference.source;
+  if (!fixtureSources.has(relativeSource)) {
+    fixtureSources.set(relativeSource, await readFile(path.join(repoRoot, relativeSource), "utf8"));
+  }
+}
+
+function fixtureSourceFor(fixture) {
+  const relativeSource = fixture.source ?? reference.source;
+  const source = fixtureSources.get(relativeSource);
+  assert.ok(source, `${fixture.id}: missing canonical source ${relativeSource}`);
+  return source;
+}
+
+function fixtureSourcePathFor(fixture) {
+  return path.join(repoRoot, fixture.source ?? reference.source);
+}
 const artifactRoot = path.resolve(
   repoRoot,
   process.env.NOON_MANIM_RASTER_ARTIFACTS ?? "manim-raster-artifacts",
@@ -36,7 +52,12 @@ for (const backend of backends) {
 }
 assert.equal(reference.version, "0.21.0", "raster oracle must stay pinned to ManimCE 0.21.0");
 assert.equal(reference.renderer, "cairo", "initial raster oracle is defined against Cairo");
-assert.ok(fixtureSource.includes("from manim import *"), "canonical source must import real Manim");
+for (const fixture of manifest.fixtures) {
+  assert.ok(
+    fixtureSourceFor(fixture).includes("from manim import *"),
+    `${fixture.id}: canonical source must import real Manim`,
+  );
+}
 
 await rm(artifactRoot, { recursive: true, force: true });
 await mkdir(artifactRoot, { recursive: true });
@@ -143,7 +164,7 @@ async function renderManimReferences() {
       `${reference.pixel_width},${reference.pixel_height}`,
       "--fps",
       String(reference.frame_rate),
-      fixtureSourcePath,
+      fixtureSourcePathFor(fixture),
       fixture.scene,
     ]);
 
@@ -182,9 +203,9 @@ async function renderManimReferences() {
   return results;
 }
 
-function noonSourceFor(scene) {
-  const adapted = fixtureSource.replace("from manim import *", "from noon import *");
-  return `${adapted}\n\nresult = ${scene}()\nresult.setup()\ntry:\n    result.construct()\nfinally:\n    result.tear_down()\n`;
+function noonSourceFor(fixture) {
+  const adapted = fixtureSourceFor(fixture).replace("from manim import *", "from noon import *");
+  return `${adapted}\n\nresult = ${fixture.scene}()\nresult.setup()\ntry:\n    result.construct()\nfinally:\n    result.tear_down()\n`;
 }
 
 async function authorNoonScenes() {
@@ -202,7 +223,7 @@ async function authorNoonScenes() {
     for (const fixture of manifest.fixtures) {
       const result = await page.evaluate(
         (source) => window.noonManimCompat.run(source),
-        noonSourceFor(fixture.scene),
+        noonSourceFor(fixture),
       );
       assert.equal(result.kind, "scene_document", `${fixture.id}: Noon authoring result kind`);
       assert.ok(result.document.objects.length > 0, `${fixture.id}: Noon scene has no objects`);
@@ -314,7 +335,7 @@ async function captureHostFixture(
   const loaded = await page.evaluate(
     ({ source, loopDuration }) => window.noonHostRaster.load(source, loopDuration),
     {
-      source: noonSourceFor(fixture.scene),
+      source: noonSourceFor(fixture),
       loopDuration: Math.max(1, fixture.expected_duration + 1),
     },
   );

--- a/scripts/manim-raster-semantic-reference.py
+++ b/scripts/manim-raster-semantic-reference.py
@@ -237,7 +237,7 @@ def main() -> int:
 
     manifest = json.loads(args.manifest.read_text(encoding="utf-8"))
     reference = manifest["reference"]
-    source_path = (args.manifest.parent.parent.parent / reference["source"]).resolve()
+    repo_root = args.manifest.parent.parent.parent
     settings = {
         "renderer": "cairo",
         "frame_rate": float(reference["frame_rate"]),
@@ -249,11 +249,17 @@ def main() -> int:
         "write_to_movie": False,
     }
     with tempconfig(settings):
-        module = _load_source(source_path)
-        fixtures = [
-            _render_fixture(module, fixture, float(reference["frame_rate"]))
-            for fixture in manifest["fixtures"]
-        ]
+        modules: dict[Path, Any] = {}
+        fixtures = []
+        for fixture in manifest["fixtures"]:
+            source_path = (repo_root / fixture.get("source", reference["source"])).resolve()
+            module = modules.get(source_path)
+            if module is None:
+                module = _load_source(source_path)
+                modules[source_path] = module
+            fixtures.append(
+                _render_fixture(module, fixture, float(reference["frame_rate"]))
+            )
 
     payload = {
         "manim_version": manim.__version__,

--- a/scripts/manim-raster-semantic-state.mjs
+++ b/scripts/manim-raster-semantic-state.mjs
@@ -12,7 +12,24 @@ const repoRoot = path.resolve(scriptDir, "..");
 const manifestPath = path.join(repoRoot, "parity", "manim-v0.21", "manifest.json");
 const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
 const reference = manifest.reference;
-const fixtureSource = await readFile(path.join(repoRoot, reference.source), "utf8");
+const fixtureSources = new Map();
+for (const fixture of manifest.fixtures) {
+  const relativeSource = fixture.source ?? reference.source;
+  if (!fixtureSources.has(relativeSource)) {
+    fixtureSources.set(relativeSource, await readFile(path.join(repoRoot, relativeSource), "utf8"));
+  }
+}
+
+function fixtureSourceFor(fixture) {
+  const relativeSource = fixture.source ?? reference.source;
+  const source = fixtureSources.get(relativeSource);
+  assert.ok(source, `${fixture.id}: missing canonical source ${relativeSource}`);
+  return source;
+}
+
+function fixtureSourcePathFor(fixture) {
+  return path.join(repoRoot, fixture.source ?? reference.source);
+}
 const artifactRoot = path.resolve(
   repoRoot,
   process.env.NOON_MANIM_RASTER_ARTIFACTS ?? "manim-raster-artifacts",
@@ -38,9 +55,9 @@ function runChecked(command, args) {
   return result;
 }
 
-function noonSourceFor(scene) {
-  const adapted = fixtureSource.replace("from manim import *", "from noon import *");
-  return `${adapted}\n\nresult = ${scene}()\nresult.setup()\ntry:\n    result.construct()\nfinally:\n    result.tear_down()\n`;
+function noonSourceFor(fixture) {
+  const adapted = fixtureSourceFor(fixture).replace("from manim import *", "from noon import *");
+  return `${adapted}\n\nresult = ${fixture.scene}()\nresult.setup()\ntry:\n    result.construct()\nfinally:\n    result.tear_down()\n`;
 }
 
 function maxAbs(values) {
@@ -198,7 +215,7 @@ try {
       assert.ok(fixture, `${fixtureReport.id}: raster fixture missing from manifest`);
       const authored = await page.evaluate(
         (source) => window.noonManimCompat.run(source),
-        noonSourceFor(fixture.scene),
+        noonSourceFor(fixture),
       );
       assert.equal(authored.kind, "scene_document", `${fixture.id}: Noon semantic authoring result`);
       assert.equal(authored.duration, fixture.expected_duration, `${fixture.id}: Noon semantic duration`);

--- a/scripts/manim-seek-playback-raster.mjs
+++ b/scripts/manim-seek-playback-raster.mjs
@@ -16,7 +16,24 @@ const manifest = JSON.parse(
   await readFile(path.join(repoRoot, "parity", "manim-v0.21", "manifest.json"), "utf8"),
 );
 const reference = manifest.reference;
-const fixtureSource = await readFile(path.join(repoRoot, reference.source), "utf8");
+const fixtureSources = new Map();
+for (const fixture of manifest.fixtures) {
+  const relativeSource = fixture.source ?? reference.source;
+  if (!fixtureSources.has(relativeSource)) {
+    fixtureSources.set(relativeSource, await readFile(path.join(repoRoot, relativeSource), "utf8"));
+  }
+}
+
+function fixtureSourceFor(fixture) {
+  const relativeSource = fixture.source ?? reference.source;
+  const source = fixtureSources.get(relativeSource);
+  assert.ok(source, `${fixture.id}: missing canonical source ${relativeSource}`);
+  return source;
+}
+
+function fixtureSourcePathFor(fixture) {
+  return path.join(repoRoot, fixture.source ?? reference.source);
+}
 const artifactRoot = path.resolve(
   repoRoot,
   process.env.NOON_MANIM_RASTER_ARTIFACTS ?? "manim-raster-artifacts",
@@ -61,9 +78,9 @@ for (const backend of backends) {
   assert.ok(backend === "webgpu" || backend === "webgl", `unknown backend ${backend}`);
 }
 
-function noonSourceFor(scene) {
-  const adapted = fixtureSource.replace("from manim import *", "from noon import *");
-  return `${adapted}\n\nresult = ${scene}()\nresult.setup()\ntry:\n    result.construct()\nfinally:\n    result.tear_down()\n`;
+function noonSourceFor(fixture) {
+  const adapted = fixtureSourceFor(fixture).replace("from manim import *", "from noon import *");
+  return `${adapted}\n\nresult = ${fixture.scene}()\nresult.setup()\ntry:\n    result.construct()\nfinally:\n    result.tear_down()\n`;
 }
 
 function browserArgs(backend) {
@@ -108,7 +125,7 @@ async function authorNoonDocuments() {
     for (const fixture of manifest.fixtures) {
       const result = await page.evaluate(
         (source) => window.noonManimCompat.run(source),
-        noonSourceFor(fixture.scene),
+        noonSourceFor(fixture),
       );
       assert.equal(result.kind, "scene_document", `${fixture.id}: Noon authoring result kind`);
       assert.equal(result.duration, fixture.expected_duration, `${fixture.id}: authored Noon duration`);

--- a/web/python/test_manim_raster_manifest.py
+++ b/web/python/test_manim_raster_manifest.py
@@ -15,6 +15,11 @@ class ManimRasterManifestTests(unittest.TestCase):
         self.source = self.source_path.read_text(encoding="utf-8")
         self.tree = ast.parse(self.source)
 
+    def source_path_for_fixture(self, fixture: dict[str, object]) -> pathlib.Path:
+        relative = fixture.get("source", self.manifest["reference"]["source"])
+        self.assertIsInstance(relative, str)
+        return REPO_ROOT / relative
+
     def test_reference_profile_is_pinned(self) -> None:
         reference = self.manifest["reference"]
         self.assertEqual(reference["version"], "0.21.0")
@@ -23,22 +28,30 @@ class ManimRasterManifestTests(unittest.TestCase):
         self.assertEqual(reference["frame_rate"], 30)
 
     def test_canonical_source_uses_real_manim_only(self) -> None:
-        self.assertIn("from manim import *", self.source)
-        self.assertNotIn("from noon import *", self.source)
-        imports = [node for node in self.tree.body if isinstance(node, ast.ImportFrom)]
-        self.assertTrue(any(node.module == "manim" for node in imports))
+        source_paths = {
+            self.source_path_for_fixture(fixture) for fixture in self.manifest["fixtures"]
+        }
+        for source_path in source_paths:
+            source = source_path.read_text(encoding="utf-8")
+            tree = ast.parse(source)
+            self.assertIn("from manim import *", source, source_path)
+            self.assertNotIn("from noon import *", source, source_path)
+            imports = [node for node in tree.body if isinstance(node, ast.ImportFrom)]
+            self.assertTrue(any(node.module == "manim" for node in imports), source_path)
 
     def test_every_fixture_selects_a_scene_class(self) -> None:
-        classes = {
-            node.name
-            for node in self.tree.body
-            if isinstance(node, ast.ClassDef)
-        }
         fixtures = self.manifest["fixtures"]
         self.assertGreaterEqual(len(fixtures), 4)
         self.assertEqual(len({fixture["id"] for fixture in fixtures}), len(fixtures))
         for fixture in fixtures:
-            self.assertIn(fixture["scene"], classes)
+            source_path = self.source_path_for_fixture(fixture)
+            source = source_path.read_text(encoding="utf-8")
+            classes = {
+                node.name
+                for node in ast.parse(source).body
+                if isinstance(node, ast.ClassDef)
+            }
+            self.assertIn(fixture["scene"], classes, source_path)
             self.assertGreater(float(fixture["expected_duration"]), 0.0)
 
     def test_samples_cover_animation_span(self) -> None:
@@ -51,9 +64,14 @@ class ManimRasterManifestTests(unittest.TestCase):
         self.assertEqual(fractions, sorted(set(fractions)))
 
     def test_noon_adaptation_changes_only_import_before_selection_wrapper(self) -> None:
-        adapted = self.source.replace("from manim import *", "from noon import *", 1)
-        restored = adapted.replace("from noon import *", "from manim import *", 1)
-        self.assertEqual(restored, self.source)
+        source_paths = {
+            self.source_path_for_fixture(fixture) for fixture in self.manifest["fixtures"]
+        }
+        for source_path in source_paths:
+            source = source_path.read_text(encoding="utf-8")
+            adapted = source.replace("from manim import *", "from noon import *", 1)
+            restored = adapted.replace("from noon import *", "from manim import *", 1)
+            self.assertEqual(restored, source, source_path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Allow each canonical Manim parity fixture to optionally select its own source file via `fixture.source`, while preserving `reference.source` as the default for all existing fixtures.

This keeps the raster renderer, semantic-state capture, Manim semantic reference, and seek-vs-playback oracle on the same selected source. Manifest tests also validate each fixture against its own source module and preserve the import-only Noon adaptation contract.

Why: the remaining Manim gallery coverage should not require every independent example PR to append another class to the monolithic `parity/manim-v0.21/quickstart.py`. Per-fixture source selection makes future gallery parity additions additive and substantially reduces conflicts between concurrent parity work.

Validation already performed on the staged tree:
- JS syntax checks for raster/semantic/seek oracle scripts
- Python semantic-reference compile check
- `web/python/test_manim_raster_manifest.py`
- existing fixtures remain backward-compatible through the global source fallback

Final branch is intentionally collapsed to one commit / five files with no generated bytecode or temporary CI helpers.