### PR TITLE
Keep master Manim raster oracle from thrashing

### DIFF
--- a/.github/workflows/manim-raster-differential.yml
+++ b/.github/workflows/manim-raster-differential.yml
@@ -12,7 +12,7 @@ permissions:
 
 concurrency:
   group: manim-raster-differential-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   raster:


### PR DESCRIPTION
Master now runs the pinned ManimCE raster oracle after every merge, but the existing shared concurrency group uses `cancel-in-progress: true`. With multiple parity/text branches merging concurrently, each new master push cancels the 6–8 minute authoritative run before it can reach seek/playback validation. Keep stale PR runs cancellable, but do not cancel an in-progress master oracle. GitHub concurrency still permits at most one running and one pending run in the group, so intermediate pending master pushes collapse to the newest pending run rather than creating an unbounded backlog. No test, renderer, fixture, or tolerance behavior changes.