### PR TITLE
[Parity] Qualify ManimCE RotationUpdater

### DIFF
--- a/parity/manim-v0.21/manifest.json
+++ b/parity/manim-v0.21/manifest.json
@@ -304,6 +304,12 @@
       "id": "moving-camera-center",
       "scene": "MovingCameraCenter",
       "expected_duration": 2.6
+    },
+    {
+      "id": "rotation-updater",
+      "scene": "RotationUpdater",
+      "expected_duration": 4.5,
+      "source": "parity/manim-v0.21/upstream-examples/rotation_updater.py"
     }
   ],
   "sample_fractions": [


### PR DESCRIPTION
Superseded by #512, which re-ports this exact one-file qualification change onto current `master` after this branch became non-mergeable. The replacement keeps the same 4.5 s canonical fixture, checked-in upstream source, and unchanged global parity tolerances.