### PR TITLE
Preserve retained text painter order and font variations

### DIFF
--- a/crates/noon-core/src/text_resources.rs
+++ b/crates/noon-core/src/text_resources.rs
@@ -98,7 +98,21 @@ pub struct FontFaceIdentity {
     pub family: Arc<str>,
     pub face_key: Arc<str>,
     pub face_index: u32,
+    /// Stable cache/identity key for the exact font instance. Renderer-facing
+    /// variation values are retained separately on `GlyphRun`; callers must never
+    /// parse this string to recover axis coordinates.
     pub variation_key: Arc<str>,
+}
+
+/// Exact OpenType variation setting used to shape and later rasterize a glyph run.
+///
+/// Values use the font's design-space coordinates (for example `wght=520.5`). The
+/// renderer may normalize these for its raster backend, but it must not substitute
+/// default-axis values when this list is non-empty.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct FontVariationSetting {
+    pub tag: [u8; 4],
+    pub value: f32,
 }
 
 /// Stable identity for one shaped cluster/part across ordinary transforms.
@@ -191,6 +205,8 @@ pub struct PositionedGlyph {
 #[derive(Clone, Debug, PartialEq)]
 pub struct GlyphRun {
     pub font: FontFaceIdentity,
+    /// Exact variable-font design coordinates used by the shaping backend.
+    pub variations: Arc<[FontVariationSetting]>,
     pub font_size: f32,
     pub direction: TextDirection,
     pub fill: Option<Color>,
@@ -232,6 +248,16 @@ pub struct TextVectorItem {
     pub semantic_key: Option<Arc<str>>,
 }
 
+/// One entry in the layout backend's original painter-order stream.
+///
+/// Runs and vectors live in separate immutable arrays for efficient batching and
+/// semantic lookup, while this compact stream preserves their observable z-order.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum TextRenderItem {
+    GlyphRun(u32),
+    Vector(u32),
+}
+
 /// Logical source part independently addressable by public text/math APIs.
 /// Ranges refer to flattened glyph-cluster and vector-item order.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -251,6 +277,8 @@ pub struct TextResource {
     pub kind: TextSourceKind,
     pub runs: Arc<[GlyphRun]>,
     pub vector_items: Arc<[TextVectorItem]>,
+    /// Backend painter order across shaped runs and non-glyph vector items.
+    pub render_items: Arc<[TextRenderItem]>,
     pub parts: Arc<[TextPart]>,
     pub bounds: Rect,
     pub baseline: f32,
@@ -277,6 +305,13 @@ impl TextResource {
         let vectors = u32::try_from(self.vector_count()).unwrap_or(u32::MAX);
 
         for run in self.runs.iter() {
+            if run
+                .variations
+                .iter()
+                .any(|setting| !setting.value.is_finite())
+            {
+                return Err(TextResourceValidationError::InvalidFontVariation);
+            }
             for glyph in run.glyphs.iter() {
                 validate_span(glyph.cluster.source_span, source_len)?;
             }
@@ -286,6 +321,22 @@ impl TextResource {
             if let Some(span) = item.source_span {
                 validate_span(span, source_len)?;
             }
+        }
+
+        let mut seen_runs = vec![false; self.runs.len()];
+        let mut seen_vectors = vec![false; self.vector_items.len()];
+        for item in self.render_items.iter().copied() {
+            let seen = match item {
+                TextRenderItem::GlyphRun(index) => seen_runs.get_mut(index as usize),
+                TextRenderItem::Vector(index) => seen_vectors.get_mut(index as usize),
+            }
+            .ok_or(TextResourceValidationError::InvalidRenderItem)?;
+            if std::mem::replace(seen, true) {
+                return Err(TextResourceValidationError::DuplicateRenderItem);
+            }
+        }
+        if seen_runs.iter().any(|seen| !seen) || seen_vectors.iter().any(|seen| !seen) {
+            return Err(TextResourceValidationError::MissingRenderItem);
         }
 
         for part in self.parts.iter() {
@@ -305,6 +356,7 @@ impl TextResource {
         bytes = bytes
             .saturating_add(size_of_val(self.runs.as_ref()))
             .saturating_add(size_of_val(self.vector_items.as_ref()))
+            .saturating_add(size_of_val(self.render_items.as_ref()))
             .saturating_add(size_of_val(self.parts.as_ref()));
 
         for run in self.runs.iter() {
@@ -312,6 +364,7 @@ impl TextResource {
                 .saturating_add(run.font.family.len())
                 .saturating_add(run.font.face_key.len())
                 .saturating_add(run.font.variation_key.len())
+                .saturating_add(size_of_val(run.variations.as_ref()))
                 .saturating_add(size_of_val(run.glyphs.as_ref()));
             for glyph in run.glyphs.iter() {
                 if let Some(key) = &glyph.cluster.semantic_key {
@@ -369,6 +422,10 @@ pub enum TextResourceValidationError {
     InvalidSourceSpan,
     InvalidClusterRange,
     InvalidVectorRange,
+    InvalidFontVariation,
+    InvalidRenderItem,
+    DuplicateRenderItem,
+    MissingRenderItem,
 }
 
 impl std::fmt::Display for TextResourceValidationError {
@@ -377,6 +434,10 @@ impl std::fmt::Display for TextResourceValidationError {
             Self::InvalidSourceSpan => write!(formatter, "invalid text source span"),
             Self::InvalidClusterRange => write!(formatter, "invalid text cluster range"),
             Self::InvalidVectorRange => write!(formatter, "invalid text vector range"),
+            Self::InvalidFontVariation => write!(formatter, "invalid font variation value"),
+            Self::InvalidRenderItem => write!(formatter, "invalid text render item reference"),
+            Self::DuplicateRenderItem => write!(formatter, "duplicate text render item reference"),
+            Self::MissingRenderItem => write!(formatter, "missing text render item reference"),
         }
     }
 }
@@ -622,6 +683,7 @@ mod tests {
                     face_index: 0,
                     variation_key: Arc::from(""),
                 },
+                variations: Arc::from([]),
                 font_size: 48.0,
                 direction: TextDirection::LeftToRight,
                 fill: None,
@@ -629,6 +691,7 @@ mod tests {
                 glyphs,
             }]),
             vector_items: Arc::from([]),
+            render_items: Arc::from([TextRenderItem::GlyphRun(0)]),
             parts: Arc::from([TextPart {
                 source_span: TextSourceSpan::new(0, source.len() as u32),
                 first_cluster: 0,
@@ -724,6 +787,53 @@ mod tests {
             semantic_key: Some(Arc::from("fraction-rule")),
         };
         assert_eq!(item.geometry, geometry);
+    }
+
+    #[test]
+    fn render_items_preserve_interleaved_painter_order() {
+        let mut resource = sample_text("x");
+        resource.vector_items = Arc::from([TextVectorItem {
+            geometry: GeometryResourceHandle {
+                id: GeometryId::new(8),
+                version: 0,
+            },
+            transform: TextAffineTransform::IDENTITY,
+            style: TextVectorStyle::default(),
+            source_span: None,
+            semantic_key: Some(Arc::from("background")),
+        }]);
+        resource.render_items = Arc::from([TextRenderItem::Vector(0), TextRenderItem::GlyphRun(0)]);
+        assert_eq!(resource.validate(), Ok(()));
+        assert_eq!(
+            resource.render_items.as_ref(),
+            &[TextRenderItem::Vector(0), TextRenderItem::GlyphRun(0)]
+        );
+    }
+
+    #[test]
+    fn invalid_render_item_references_are_rejected() {
+        let mut resource = sample_text("x");
+        resource.render_items = Arc::from([TextRenderItem::GlyphRun(1)]);
+        assert_eq!(
+            resource.validate().unwrap_err(),
+            TextResourceValidationError::InvalidRenderItem
+        );
+    }
+
+    #[test]
+    fn non_finite_font_variations_are_rejected() {
+        let mut resource = sample_text("x");
+        resource.runs = Arc::from([GlyphRun {
+            variations: Arc::from([FontVariationSetting {
+                tag: *b"wght",
+                value: f32::NAN,
+            }]),
+            ..resource.runs[0].clone()
+        }]);
+        assert_eq!(
+            resource.validate().unwrap_err(),
+            TextResourceValidationError::InvalidFontVariation
+        );
     }
 
     #[test]

--- a/crates/noon-typst/src/lib.rs
+++ b/crates/noon-typst/src/lib.rs
@@ -7,11 +7,11 @@
 use std::{fmt, sync::Arc};
 
 use noon_core::{
-    Color, FontFaceIdentity, FontResourceArena, FontResourceError, GeometryResourceArena, GlyphRun,
-    PositionedGlyph, Rect, TextAffineTransform, TextClusterIdentity, TextDirection,
-    TextLayoutArtifact, TextLayoutBackend, TextLayoutBackendKind, TextPart, TextResource,
-    TextResourceValidationError, TextSourceKind, TextSourceSpan, TextVectorItem, TextVectorStyle,
-    Vec2, VectorPath,
+    Color, FontFaceIdentity, FontResourceArena, FontResourceError, FontVariationSetting,
+    GeometryResourceArena, GlyphRun, PositionedGlyph, Rect, TextAffineTransform,
+    TextClusterIdentity, TextDirection, TextLayoutArtifact, TextLayoutBackend,
+    TextLayoutBackendKind, TextPart, TextRenderItem, TextResource, TextResourceValidationError,
+    TextSourceKind, TextSourceSpan, TextVectorItem, TextVectorStyle, Vec2, VectorPath,
 };
 use typst_as_lib::TypstEngine;
 use typst_layout::PagedDocument;
@@ -160,6 +160,7 @@ pub fn compile_typst_resource(
         },
         runs: Vec::new(),
         vectors: Vec::new(),
+        render_items: Vec::new(),
         parts: Vec::new(),
         geometry: GeometryResourceArena::new(),
         fonts: FontResourceArena::new(),
@@ -186,6 +187,7 @@ pub fn compile_typst_resource(
         kind: mode.source_kind(),
         runs: normalizer.runs.into(),
         vector_items: normalizer.vectors.into(),
+        render_items: normalizer.render_items.into(),
         parts: normalizer.parts.into(),
         bounds: Rect::new(
             Vec2::new(-0.5 * width, -0.5 * height),
@@ -252,6 +254,7 @@ struct FrameNormalizer {
     page_to_noon: TextAffineTransform,
     runs: Vec<GlyphRun>,
     vectors: Vec<TextVectorItem>,
+    render_items: Vec<TextRenderItem>,
     parts: Vec<TextPart>,
     geometry: GeometryResourceArena,
     fonts: FontResourceArena,
@@ -319,12 +322,22 @@ impl FrameNormalizer {
         let face_key = font
             .post_script_name()
             .unwrap_or_else(|| format!("{}#{}", family, font.index()));
-        let variation_key = format!("{:?}", text.font.variations());
+        let variations: Arc<[FontVariationSetting]> = text
+            .font
+            .variations()
+            .0
+            .iter()
+            .map(|(tag, value)| FontVariationSetting {
+                tag: tag.to_bytes(),
+                value: value.0,
+            })
+            .collect::<Vec<_>>()
+            .into();
         let face = FontFaceIdentity {
             family: Arc::from(family),
             face_key: Arc::from(face_key),
             face_index: font.index(),
-            variation_key: Arc::from(variation_key),
+            variation_key: Arc::from(variation_identity(variations.as_ref())),
         };
         let font_data: &[u8] = font.data().as_ref();
         self.fonts
@@ -394,14 +407,17 @@ impl FrameNormalizer {
         };
         let transform = font_y_up_to_frame.then(state).then(self.page_to_noon);
 
+        let run_index = self.runs.len() as u32;
         self.runs.push(GlyphRun {
             font: face,
+            variations,
             font_size,
             direction: TextDirection::LeftToRight,
             fill,
             transform,
             glyphs: glyphs.into(),
         });
+        self.render_items.push(TextRenderItem::GlyphRun(run_index));
         Ok(())
     }
 
@@ -426,6 +442,7 @@ impl FrameNormalizer {
             ),
             None => (None, 0.0),
         };
+        let vector_index = self.vectors.len() as u32;
         self.vectors.push(TextVectorItem {
             geometry: handle,
             transform: state.then(self.page_to_noon),
@@ -437,6 +454,7 @@ impl FrameNormalizer {
             source_span: None,
             semantic_key,
         });
+        self.render_items.push(TextRenderItem::Vector(vector_index));
         Ok(())
     }
 }
@@ -517,6 +535,21 @@ fn solid_color(paint: &Paint) -> Result<Color, TypstBackendError> {
     Ok(Color::rgba(red, green, blue, alpha))
 }
 
+fn variation_identity(settings: &[FontVariationSetting]) -> String {
+    let mut identity = String::new();
+    for setting in settings {
+        if !identity.is_empty() {
+            identity.push(';');
+        }
+        for byte in setting.tag {
+            identity.push(char::from(byte));
+        }
+        identity.push('=');
+        identity.push_str(&format!("{:08x}", setting.value.to_bits()));
+    }
+    identity
+}
+
 pub fn prepare_source(source: &str, mode: TypstMode) -> String {
     let mut prepared = String::with_capacity(TEMPLATE_PREFIX.len() + source.len() + 8);
     prepared.push_str(TEMPLATE_PREFIX);
@@ -577,6 +610,10 @@ mod tests {
         assert_eq!(artifact.resource.kind, TextSourceKind::Typst);
         assert!(artifact.resource.glyph_count() >= 5);
         assert!(!artifact.resource.runs.is_empty());
+        assert_eq!(
+            artifact.resource.render_items.len(),
+            artifact.resource.runs.len() + artifact.resource.vector_items.len()
+        );
         assert!(artifact.resource.bounds.width() > 0.0);
         assert!(artifact.resource.bounds.height() > 0.0);
         assert_eq!(
@@ -592,17 +629,35 @@ mod tests {
         assert!(!artifact.fonts.is_empty());
         for run in artifact.resource.runs.iter() {
             assert!(artifact.fonts.get_for_face(&run.font).is_some());
+            assert!(run
+                .variations
+                .iter()
+                .all(|setting| setting.value.is_finite()));
         }
     }
 
     #[test]
-    fn direct_math_normalization_retains_vector_decorations() {
+    fn direct_math_normalization_retains_vector_decorations_and_painter_order() {
         let artifact = compile_typst_resource("frac(x, 2)", TypstMode::Math).unwrap();
         assert_eq!(artifact.resource.kind, TextSourceKind::MathTypst);
         assert!(artifact.resource.glyph_count() >= 2);
         assert!(artifact.resource.vector_count() >= 1);
         assert!(!artifact.geometry.is_empty());
         assert!(!artifact.fonts.is_empty());
+        assert!(artifact
+            .resource
+            .render_items
+            .iter()
+            .any(|item| matches!(item, TextRenderItem::GlyphRun(_))));
+        assert!(artifact
+            .resource
+            .render_items
+            .iter()
+            .any(|item| matches!(item, TextRenderItem::Vector(_))));
+        assert_eq!(
+            artifact.resource.render_items.len(),
+            artifact.resource.runs.len() + artifact.resource.vector_items.len()
+        );
         for item in artifact.resource.vector_items.iter() {
             assert!(matches!(
                 artifact.geometry.get(item.geometry),
@@ -636,6 +691,25 @@ mod tests {
     }
 
     #[test]
+    fn variation_identity_is_explicit_and_deterministic() {
+        let settings = [
+            FontVariationSetting {
+                tag: *b"wght",
+                value: 520.5,
+            },
+            FontVariationSetting {
+                tag: *b"opsz",
+                value: 14.0,
+            },
+        ];
+        let first = variation_identity(&settings);
+        let second = variation_identity(&settings);
+        assert_eq!(first, second);
+        assert!(first.starts_with("wght="));
+        assert!(first.contains(";opsz="));
+    }
+
+    #[test]
     fn labeled_groups_become_stable_semantic_parts() {
         let artifact = compile_typst_resource("#box[x] <lhs> + y", TypstMode::Markup).unwrap();
         assert!(artifact
@@ -650,6 +724,7 @@ mod tests {
         let first = compile_typst_resource("$ x^2 $", TypstMode::Markup).unwrap();
         let second = compile_typst_resource("$ x^2 $", TypstMode::Markup).unwrap();
         assert_eq!(first.resource.runs, second.resource.runs);
+        assert_eq!(first.resource.render_items, second.resource.render_items);
         assert_eq!(first.fonts.stats(), second.fonts.stats());
         assert_eq!(
             first


### PR DESCRIPTION
## Summary
- retain exact OpenType variation tag/value settings on each `GlyphRun` instead of relying on an opaque debug/cache string
- keep `variation_key` as stable identity only; renderer code must use the explicit settings for rasterization
- add `TextRenderItem::{GlyphRun, Vector}` so retained text preserves backend painter order across shaped glyph runs and non-glyph vector content
- validate render-item references as a complete one-to-one presentation stream and reject non-finite variation values
- include variation settings and render-order storage in retained-memory accounting
- update Typst normalization to emit deterministic variation identity/settings and append painter-order entries while walking frame items
- add core and Typst tests for interleaved order, invalid references, variation validation, mixed math content, and deterministic normalization

This closes the retained variable-font and glyph/vector painter-order gaps before renderer integration. A separate follow-up retains Typst glyph-stroke cap/join/dash/miter metadata and routes stroked glyphs through the outline path instead of silently approximating them with atlas masks.

Part of #65 and #83.