### PR TITLE
Retain exact glyph stroke semantics

### DIFF
--- a/crates/noon-core/src/text_resources.rs
+++ b/crates/noon-core/src/text_resources.rs
@@ -3,7 +3,7 @@ use std::{
     sync::Arc,
 };
 
-use crate::{Color, GeometryResourceHandle, Rect, Vec2};
+use crate::{Color, GeometryResourceHandle, Rect, StrokeCap, StrokeJoin, Vec2};
 
 /// Stable identity for one retained text/math resource.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -200,6 +200,22 @@ pub struct PositionedGlyph {
     pub bounds: Rect,
 }
 
+/// Exact outline-stroke semantics for one shaped glyph run.
+///
+/// `paint == None` means inherit the owning mobject color, mirroring `GlyphRun::fill`.
+/// Stroked runs require path-outline rendering: bitmap/atlas rasterization cannot
+/// reproduce dash, cap, join, or miter behavior without changing observable output.
+#[derive(Clone, Debug, PartialEq)]
+pub struct TextGlyphStroke {
+    pub paint: Option<Color>,
+    pub width: f32,
+    pub cap: StrokeCap,
+    pub join: StrokeJoin,
+    pub dash_array: Arc<[f32]>,
+    pub dash_phase: f32,
+    pub miter_limit: f32,
+}
+
 /// One shaped run. `fill == None` means inherit the owning mobject's color;
 /// `Some` preserves an intrinsic backend color (for example styled Typst content).
 #[derive(Clone, Debug, PartialEq)]
@@ -210,6 +226,9 @@ pub struct GlyphRun {
     pub font_size: f32,
     pub direction: TextDirection,
     pub fill: Option<Color>,
+    /// Exact outline stroke requested by the layout backend. Any `Some` value
+    /// routes the run through lazy glyph outlines instead of the steady atlas path.
+    pub stroke: Option<TextGlyphStroke>,
     /// Maps the run's backend-local glyph coordinates into the resource coordinate
     /// system. Ordinary native text uses identity; math/layout engines can retain
     /// arbitrary group transforms without outlining every glyph.
@@ -312,6 +331,20 @@ impl TextResource {
             {
                 return Err(TextResourceValidationError::InvalidFontVariation);
             }
+            if let Some(stroke) = &run.stroke {
+                let invalid = !stroke.width.is_finite()
+                    || stroke.width < 0.0
+                    || !stroke.dash_phase.is_finite()
+                    || !stroke.miter_limit.is_finite()
+                    || stroke.miter_limit < 0.0
+                    || stroke
+                        .dash_array
+                        .iter()
+                        .any(|length| !length.is_finite() || *length < 0.0);
+                if invalid {
+                    return Err(TextResourceValidationError::InvalidGlyphStroke);
+                }
+            }
             for glyph in run.glyphs.iter() {
                 validate_span(glyph.cluster.source_span, source_len)?;
             }
@@ -366,6 +399,9 @@ impl TextResource {
                 .saturating_add(run.font.variation_key.len())
                 .saturating_add(size_of_val(run.variations.as_ref()))
                 .saturating_add(size_of_val(run.glyphs.as_ref()));
+            if let Some(stroke) = &run.stroke {
+                bytes = bytes.saturating_add(size_of_val(stroke.dash_array.as_ref()));
+            }
             for glyph in run.glyphs.iter() {
                 if let Some(key) = &glyph.cluster.semantic_key {
                     bytes = bytes.saturating_add(key.len());
@@ -423,6 +459,7 @@ pub enum TextResourceValidationError {
     InvalidClusterRange,
     InvalidVectorRange,
     InvalidFontVariation,
+    InvalidGlyphStroke,
     InvalidRenderItem,
     DuplicateRenderItem,
     MissingRenderItem,
@@ -435,6 +472,7 @@ impl std::fmt::Display for TextResourceValidationError {
             Self::InvalidClusterRange => write!(formatter, "invalid text cluster range"),
             Self::InvalidVectorRange => write!(formatter, "invalid text vector range"),
             Self::InvalidFontVariation => write!(formatter, "invalid font variation value"),
+            Self::InvalidGlyphStroke => write!(formatter, "invalid glyph stroke value"),
             Self::InvalidRenderItem => write!(formatter, "invalid text render item reference"),
             Self::DuplicateRenderItem => write!(formatter, "duplicate text render item reference"),
             Self::MissingRenderItem => write!(formatter, "missing text render item reference"),
@@ -687,6 +725,7 @@ mod tests {
                 font_size: 48.0,
                 direction: TextDirection::LeftToRight,
                 fill: None,
+                stroke: None,
                 transform: TextAffineTransform::IDENTITY,
                 glyphs,
             }]),
@@ -833,6 +872,48 @@ mod tests {
         assert_eq!(
             resource.validate().unwrap_err(),
             TextResourceValidationError::InvalidFontVariation
+        );
+    }
+
+    #[test]
+    fn glyph_stroke_semantics_are_retained_and_validated() {
+        let mut resource = sample_text("x");
+        resource.runs = Arc::from([GlyphRun {
+            stroke: Some(TextGlyphStroke {
+                paint: Some(Color::RED),
+                width: 1.5,
+                cap: StrokeCap::Butt,
+                join: StrokeJoin::Miter,
+                dash_array: Arc::from([3.0, 2.0]),
+                dash_phase: 0.5,
+                miter_limit: 4.0,
+            }),
+            ..resource.runs[0].clone()
+        }]);
+        assert_eq!(resource.validate(), Ok(()));
+        let stroke = resource.runs[0].stroke.as_ref().unwrap();
+        assert_eq!(stroke.paint, Some(Color::RED));
+        assert_eq!(stroke.dash_array.as_ref(), &[3.0, 2.0]);
+    }
+
+    #[test]
+    fn non_finite_glyph_strokes_are_rejected() {
+        let mut resource = sample_text("x");
+        resource.runs = Arc::from([GlyphRun {
+            stroke: Some(TextGlyphStroke {
+                paint: None,
+                width: 1.0,
+                cap: StrokeCap::Round,
+                join: StrokeJoin::Round,
+                dash_array: Arc::from([f32::NAN]),
+                dash_phase: 0.0,
+                miter_limit: 4.0,
+            }),
+            ..resource.runs[0].clone()
+        }]);
+        assert_eq!(
+            resource.validate().unwrap_err(),
+            TextResourceValidationError::InvalidGlyphStroke
         );
     }
 

--- a/crates/noon-text-raster/src/lib.rs
+++ b/crates/noon-text-raster/src/lib.rs
@@ -88,6 +88,7 @@ pub enum GlyphRasterError {
     GlyphIdOutOfRange(u32),
     InvalidPixelSize,
     InvalidVariation,
+    OutlineRequired,
     UnexpectedSubpixelMask,
 }
 
@@ -113,6 +114,10 @@ impl fmt::Display for GlyphRasterError {
                 write!(formatter, "glyph pixel size must be finite and positive")
             }
             Self::InvalidVariation => write!(formatter, "glyph variation values must be finite"),
+            Self::OutlineRequired => write!(
+                formatter,
+                "stroked glyph runs require retained outline rendering"
+            ),
             Self::UnexpectedSubpixelMask => write!(
                 formatter,
                 "Swash returned a subpixel mask for an alpha-only atlas request"
@@ -226,6 +231,9 @@ impl GlyphRasterCache {
             .any(|setting| !setting.value.is_finite())
         {
             return Err(GlyphRasterError::InvalidVariation);
+        }
+        if run.stroke.is_some() {
+            return Err(GlyphRasterError::OutlineRequired);
         }
 
         let glyph_id = GlyphId::try_from(glyph_id)
@@ -385,6 +393,32 @@ mod tests {
         assert!(Arc::ptr_eq(&first, &second));
         assert_eq!(cache.stats().misses, 1);
         assert_eq!(cache.stats().hits, 1);
+    }
+
+    #[test]
+    fn stroked_typst_runs_require_outline_rendering() {
+        let artifact = compile_typst_resource(
+            "#text(stroke: (paint: red, thickness: 1pt, dash: \"dashed\"))[A]",
+            TypstMode::Markup,
+        )
+        .unwrap();
+        let run = artifact
+            .resource
+            .runs
+            .iter()
+            .find(|run| run.stroke.is_some())
+            .expect("Typst should retain the text stroke");
+        let glyph = run.glyphs.first().unwrap();
+        let mut cache = GlyphRasterCache::new();
+
+        assert_eq!(
+            cache
+                .get_or_rasterize(&artifact.fonts, run, glyph.glyph_id, 48.0)
+                .unwrap_err(),
+            GlyphRasterError::OutlineRequired
+        );
+        assert!(cache.is_empty());
+        assert_eq!(cache.stats().misses, 0);
     }
 
     #[test]

--- a/crates/noon-typst/src/lib.rs
+++ b/crates/noon-typst/src/lib.rs
@@ -8,17 +8,21 @@ use std::{fmt, sync::Arc};
 
 use noon_core::{
     Color, FontFaceIdentity, FontResourceArena, FontResourceError, FontVariationSetting,
-    GeometryResourceArena, GlyphRun, PositionedGlyph, Rect, TextAffineTransform,
-    TextClusterIdentity, TextDirection, TextLayoutArtifact, TextLayoutBackend,
-    TextLayoutBackendKind, TextPart, TextRenderItem, TextResource, TextResourceValidationError,
-    TextSourceKind, TextSourceSpan, TextVectorItem, TextVectorStyle, Vec2, VectorPath,
+    GeometryResourceArena, GlyphRun, PositionedGlyph, Rect, StrokeCap, StrokeJoin,
+    TextAffineTransform, TextClusterIdentity, TextDirection, TextGlyphStroke, TextLayoutArtifact,
+    TextLayoutBackend, TextLayoutBackendKind, TextPart, TextRenderItem, TextResource,
+    TextResourceValidationError, TextSourceKind, TextSourceSpan, TextVectorItem, TextVectorStyle,
+    Vec2, VectorPath,
 };
 use typst_as_lib::TypstEngine;
 use typst_layout::PagedDocument;
 use typst_library::{
     layout::{Frame, FrameItem, Point, Transform},
     text::TextItem,
-    visualize::{CurveItem, Geometry, Paint, Shape},
+    visualize::{
+        CurveItem, FixedStroke, Geometry, LineCap as TypstLineCap, LineJoin as TypstLineJoin,
+        Paint, Shape,
+    },
 };
 use typst_svg::{svg, SvgOptions};
 
@@ -345,11 +349,7 @@ impl FrameNormalizer {
             .map_err(TypstBackendError::FontResource)?;
 
         let fill = inherited_color(&text.fill)?;
-        if let Some(stroke) = &text.stroke {
-            // Ensure the retained path does not silently discard a paint mode even
-            // though glyph stroke rendering is a later renderer task.
-            let _ = solid_color(&stroke.paint)?;
-        }
+        let stroke = text.stroke.as_ref().map(text_glyph_stroke).transpose()?;
 
         let mut cursor = Vec2::ZERO;
         let font_size = text.size.to_pt() as f32;
@@ -414,6 +414,7 @@ impl FrameNormalizer {
             font_size,
             direction: TextDirection::LeftToRight,
             fill,
+            stroke,
             transform,
             glyphs: glyphs.into(),
         });
@@ -510,6 +511,38 @@ fn geometry_path(geometry: &Geometry) -> VectorPath {
 
 fn point_vec(point: Point) -> Vec2 {
     Vec2::new(point.x.to_pt() as f32, point.y.to_pt() as f32)
+}
+
+fn text_glyph_stroke(stroke: &FixedStroke) -> Result<TextGlyphStroke, TypstBackendError> {
+    let (dash_array, dash_phase) = match &stroke.dash {
+        Some(dash) => (
+            dash.array
+                .iter()
+                .map(|length| length.to_pt() as f32)
+                .collect::<Vec<_>>()
+                .into(),
+            dash.phase.to_pt() as f32,
+        ),
+        None => (Arc::from([]), 0.0),
+    };
+
+    Ok(TextGlyphStroke {
+        paint: inherited_color(&stroke.paint)?,
+        width: stroke.thickness.to_pt() as f32,
+        cap: match stroke.cap {
+            TypstLineCap::Butt => StrokeCap::Butt,
+            TypstLineCap::Round => StrokeCap::Round,
+            TypstLineCap::Square => StrokeCap::Square,
+        },
+        join: match stroke.join {
+            TypstLineJoin::Miter => StrokeJoin::Miter,
+            TypstLineJoin::Round => StrokeJoin::Round,
+            TypstLineJoin::Bevel => StrokeJoin::Bevel,
+        },
+        dash_array,
+        dash_phase,
+        miter_limit: stroke.miter_limit.get() as f32,
+    })
 }
 
 fn inherited_color(paint: &Paint) -> Result<Option<Color>, TypstBackendError> {
@@ -673,6 +706,34 @@ mod tests {
 
         let styled = compile_typst_resource("#text(fill: red)[Hello]", TypstMode::Markup).unwrap();
         assert!(styled.resource.runs.iter().any(|run| run.fill.is_some()));
+    }
+
+    #[test]
+    fn glyph_stroke_metadata_survives_normalization() {
+        let artifact = compile_typst_resource(
+            "#text(stroke: (paint: red, thickness: 1.5pt, cap: \"round\", join: \"bevel\", dash: (array: (3pt, 2pt), phase: 0.5pt), miter-limit: 5.0))[A]",
+            TypstMode::Markup,
+        )
+        .unwrap();
+        let stroke = artifact
+            .resource
+            .runs
+            .iter()
+            .find_map(|run| run.stroke.as_ref())
+            .expect("stroked Typst text should retain outline semantics");
+        let paint = stroke
+            .paint
+            .expect("authored Typst red should be intrinsic");
+        assert!((paint.red - 1.0).abs() < 1e-6);
+        assert!((paint.green - 65.0 / 255.0).abs() < 1e-6);
+        assert!((paint.blue - 54.0 / 255.0).abs() < 1e-6);
+        assert!((paint.alpha - 1.0).abs() < 1e-6);
+        assert_eq!(stroke.width, 1.5);
+        assert_eq!(stroke.cap, StrokeCap::Round);
+        assert_eq!(stroke.join, StrokeJoin::Bevel);
+        assert_eq!(stroke.dash_array.as_ref(), &[3.0, 2.0]);
+        assert_eq!(stroke.dash_phase, 0.5);
+        assert_eq!(stroke.miter_limit, 5.0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add backend-neutral `TextGlyphStroke` metadata to retained `GlyphRun`s
- preserve stroke paint/inheritance, width, cap, join, dash array/phase, and miter limit
- validate stroke values and account for retained dash storage
- normalize Typst `FixedStroke` directly into the retained text contract
- keep default black stroke paint inheritable from the owning Noon mobject
- make `noon-text-raster` reject stroked runs with `OutlineRequired`, preventing accidental atlas approximation
- add core, Typst, and raster tests including dashed stroked text

Typst's own renderer forces `TextItem.stroke` through outline-path rendering. This PR captures the full observable stroke contract and makes the fast Swash atlas path explicitly unavailable for those runs, so the renderer can later use the lazy glyph-outline path without losing cap/join/dash/miter semantics.

Part of #65 and #83.