### PR TITLE
Wire retained Typst into the browser demo

### DIFF
--- a/crates/noon-web/Cargo.toml
+++ b/crates/noon-web/Cargo.toml
@@ -19,6 +19,7 @@ serde_json = "1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 noon-render-wgpu = { path = "../noon-render-wgpu", default-features = false, features = ["web"] }
+noon-text-render-wgpu = { path = "../noon-text-render-wgpu", default-features = false, features = ["web"] }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 web-sys = { version = "0.3", features = ["HtmlCanvasElement", "OffscreenCanvas", "Performance", "Window"] }

--- a/crates/noon-web/src/lib.rs
+++ b/crates/noon-web/src/lib.rs
@@ -13,6 +13,7 @@ mod legacy;
 mod lifecycle;
 mod reactive_authoring_facade;
 mod reactive_player;
+mod retained_typst_canvas;
 mod semantic_snapshot;
 
 pub use authoring_facade::*;
@@ -28,4 +29,6 @@ pub use legacy::*;
 pub use lifecycle::*;
 pub use reactive_authoring_facade::*;
 pub use reactive_player::*;
+#[cfg(target_arch = "wasm32")]
+pub use retained_typst_canvas::*;
 pub use semantic_snapshot::*;

--- a/crates/noon-web/src/retained_typst_canvas.rs
+++ b/crates/noon-web/src/retained_typst_canvas.rs
@@ -1,0 +1,289 @@
+#[cfg(target_arch = "wasm32")]
+mod wasm {
+    use noon::{MathTypst, RetainedScene, Typst};
+    use noon_core::Vec2;
+    use noon_render_wgpu::{Camera2D, GpuRenderer, RetainedFramePreparer, RetainedTextGpuState};
+    use noon_runtime::RetainedSceneInstance;
+    use noon_text_render_wgpu::TextDeviceMetrics;
+    use wasm_bindgen::prelude::*;
+    use web_sys::OffscreenCanvas;
+
+    const DEFAULT_CAMERA_HEIGHT: f32 = 8.0;
+    const CLEAR_COLOR: wgpu::Color = wgpu::Color {
+        r: 0.0,
+        g: 0.0,
+        b: 0.0,
+        a: 1.0,
+    };
+
+    #[derive(Debug)]
+    struct WebDisplaySource;
+
+    impl wgpu::rwh::HasDisplayHandle for WebDisplaySource {
+        fn display_handle(&self) -> Result<wgpu::rwh::DisplayHandle<'_>, wgpu::rwh::HandleError> {
+            Ok(wgpu::rwh::DisplayHandle::web())
+        }
+    }
+
+    /// End-to-end browser proof for the retained Typst path.
+    ///
+    /// Source is compiled once while constructing the renderer. Every render then
+    /// consumes only the retained scene/runtime/resources and #342's mixed GPU
+    /// painter stream; Python/SVG/full-frame rerendering is not involved.
+    #[wasm_bindgen(js_name = RetainedTypstCanvasRenderer)]
+    pub struct WasmRetainedTypstCanvasRenderer {
+        _instance: wgpu::Instance,
+        surface: wgpu::Surface<'static>,
+        device: wgpu::Device,
+        queue: wgpu::Queue,
+        canvas: OffscreenCanvas,
+        config: wgpu::SurfaceConfiguration,
+        scene: RetainedScene,
+        runtime: RetainedSceneInstance,
+        preparer: RetainedFramePreparer,
+        renderer: GpuRenderer,
+        text_gpu: RetainedTextGpuState,
+        camera_height: f32,
+        last_draw_calls: usize,
+        last_instances_drawn: usize,
+        last_bytes_uploaded: usize,
+    }
+
+    #[wasm_bindgen(js_class = RetainedTypstCanvasRenderer)]
+    impl WasmRetainedTypstCanvasRenderer {
+        #[wasm_bindgen(js_name = create)]
+        pub async fn create(
+            canvas: OffscreenCanvas,
+            typst_source: &str,
+            math_typst_source: &str,
+        ) -> Result<WasmRetainedTypstCanvasRenderer, JsValue> {
+            let mut scene = RetainedScene::new();
+            if !typst_source.is_empty() {
+                scene
+                    .add_typst(
+                        Typst::new(typst_source)
+                            .with_font_size(64.0)
+                            .move_to(Vec2::new(0.0, 1.15)),
+                    )
+                    .map_err(js_error)?;
+            }
+            if !math_typst_source.is_empty() {
+                scene
+                    .add_math_typst(
+                        MathTypst::new(math_typst_source)
+                            .with_font_size(72.0)
+                            .move_to(Vec2::new(0.0, -1.0)),
+                    )
+                    .map_err(js_error)?;
+            }
+            if scene.objects().is_empty() {
+                return Err(js_message(
+                    "retained Typst demo requires Typst or MathTypst source",
+                ));
+            }
+            let compiled = scene.compile().map_err(js_error)?;
+            let runtime = RetainedSceneInstance::new(compiled);
+
+            let mut instance_descriptor = wgpu::InstanceDescriptor::new_without_display_handle();
+            instance_descriptor.backends = wgpu::Backends::BROWSER_WEBGPU | wgpu::Backends::GL;
+            instance_descriptor.display = Some(Box::new(WebDisplaySource));
+            let instance =
+                wgpu::util::new_instance_with_webgpu_detection(instance_descriptor).await;
+            let surface = instance
+                .create_surface(wgpu::SurfaceTarget::OffscreenCanvas(canvas.clone()))
+                .map_err(js_error)?;
+            let adapter = instance
+                .request_adapter(&wgpu::RequestAdapterOptions {
+                    power_preference: wgpu::PowerPreference::HighPerformance,
+                    force_fallback_adapter: false,
+                    compatible_surface: Some(&surface),
+                })
+                .await
+                .map_err(js_error)?;
+            let backend = adapter.get_info().backend;
+            let required_limits = if backend == wgpu::Backend::Gl {
+                wgpu::Limits::downlevel_webgl2_defaults().using_resolution(adapter.limits())
+            } else {
+                wgpu::Limits::default()
+            };
+            let (device, queue) = adapter
+                .request_device(&wgpu::DeviceDescriptor {
+                    label: Some("Noon retained Typst demo GPU device"),
+                    required_features: wgpu::Features::empty(),
+                    required_limits,
+                    ..Default::default()
+                })
+                .await
+                .map_err(js_error)?;
+
+            let width = canvas.width().max(1);
+            let height = canvas.height().max(1);
+            let config = surface
+                .get_default_config(&adapter, width, height)
+                .ok_or_else(|| js_message("GPU adapter cannot present retained Typst demo"))?;
+            surface.configure(&device, &config);
+
+            let mut renderer = GpuRenderer::new(&device, config.format);
+            let camera_height = DEFAULT_CAMERA_HEIGHT;
+            set_camera(&mut renderer, &device, &queue, width, height, camera_height)?;
+            let text_gpu = renderer.create_retained_text_state(&device, &queue);
+
+            Ok(Self {
+                _instance: instance,
+                surface,
+                device,
+                queue,
+                canvas,
+                config,
+                scene,
+                runtime,
+                preparer: RetainedFramePreparer::new(),
+                renderer,
+                text_gpu,
+                camera_height,
+                last_draw_calls: 0,
+                last_instances_drawn: 0,
+                last_bytes_uploaded: 0,
+            })
+        }
+
+        pub fn render(&mut self) -> Result<(), JsValue> {
+            let surface_texture = match self.surface.get_current_texture() {
+                wgpu::CurrentSurfaceTexture::Success(texture)
+                | wgpu::CurrentSurfaceTexture::Suboptimal(texture) => texture,
+                wgpu::CurrentSurfaceTexture::Timeout | wgpu::CurrentSurfaceTexture::Occluded => {
+                    return Ok(())
+                }
+                wgpu::CurrentSurfaceTexture::Outdated | wgpu::CurrentSurfaceTexture::Lost => {
+                    self.surface.configure(&self.device, &self.config);
+                    return Ok(());
+                }
+                wgpu::CurrentSurfaceTexture::Validation => {
+                    return Err(js_message("GPU rejected retained Typst surface texture"))
+                }
+            };
+
+            let camera = self.renderer.camera();
+            let metrics = TextDeviceMetrics::new(Vec2::new(
+                self.config.width as f32 / camera.world_size.x,
+                self.config.height as f32 / camera.world_size.y,
+            ))
+            .map_err(js_error)?;
+            let prepared = self
+                .preparer
+                .prepare(
+                    &self.device,
+                    &self.queue,
+                    self.runtime.frame(),
+                    self.scene.texts(),
+                    self.scene.fonts(),
+                    self.scene.geometries(),
+                    metrics,
+                )
+                .map_err(js_error)?;
+            let upload = self.renderer.upload_retained(
+                &self.device,
+                &self.queue,
+                &prepared,
+                &mut self.text_gpu,
+            );
+            self.last_bytes_uploaded = upload
+                .geometry
+                .bytes_uploaded
+                .saturating_add(upload.text.bytes_uploaded);
+
+            let view = surface_texture
+                .texture
+                .create_view(&wgpu::TextureViewDescriptor::default());
+            let mut encoder = self
+                .device
+                .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                    label: Some("Noon retained Typst demo frame"),
+                });
+            let draw = self
+                .renderer
+                .encode_retained(&mut encoder, &view, &prepared, &self.text_gpu, CLEAR_COLOR)
+                .map_err(js_error)?;
+            self.queue.submit(Some(encoder.finish()));
+            surface_texture.present();
+            self.last_draw_calls = draw
+                .geometry
+                .draw_calls
+                .saturating_add(draw.text.draw_calls);
+            self.last_instances_drawn = draw
+                .geometry
+                .instances_drawn
+                .saturating_add(draw.text.instances_drawn);
+            Ok(())
+        }
+
+        pub fn resize(&mut self, width: u32, height: u32) -> Result<(), JsValue> {
+            if width == 0 || height == 0 {
+                return Ok(());
+            }
+            self.canvas.set_width(width);
+            self.canvas.set_height(height);
+            if self.config.width != width || self.config.height != height {
+                self.config.width = width;
+                self.config.height = height;
+                self.surface.configure(&self.device, &self.config);
+                set_camera(
+                    &mut self.renderer,
+                    &self.device,
+                    &self.queue,
+                    width,
+                    height,
+                    self.camera_height,
+                )?;
+            }
+            Ok(())
+        }
+
+        #[wasm_bindgen(js_name = objectCount)]
+        pub fn object_count(&self) -> usize {
+            self.scene.objects().len()
+        }
+
+        #[wasm_bindgen(js_name = lastDrawCalls)]
+        pub fn last_draw_calls(&self) -> usize {
+            self.last_draw_calls
+        }
+
+        #[wasm_bindgen(js_name = lastInstancesDrawn)]
+        pub fn last_instances_drawn(&self) -> usize {
+            self.last_instances_drawn
+        }
+
+        #[wasm_bindgen(js_name = lastBytesUploaded)]
+        pub fn last_bytes_uploaded(&self) -> usize {
+            self.last_bytes_uploaded
+        }
+    }
+
+    fn set_camera(
+        renderer: &mut GpuRenderer,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        width: u32,
+        height: u32,
+        camera_height: f32,
+    ) -> Result<(), JsValue> {
+        let aspect = width as f32 / height as f32;
+        let camera = Camera2D::new(Vec2::ZERO, Vec2::new(camera_height * aspect, camera_height))
+            .map_err(js_error)?;
+        renderer.set_viewport(device, queue, width, height);
+        renderer.set_camera(queue, camera);
+        Ok(())
+    }
+
+    fn js_error(error: impl std::fmt::Display) -> JsValue {
+        JsValue::from_str(&error.to_string())
+    }
+
+    fn js_message(message: &str) -> JsValue {
+        JsValue::from_str(message)
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub use wasm::*;

--- a/web/retained-typst-demo.html
+++ b/web/retained-typst-demo.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Noon retained Typst demo</title>
+    <style>
+      :root { color-scheme: dark; font-family: Inter, system-ui, sans-serif; background: #07090f; color: #f7f8fb; }
+      body { margin: 0; min-height: 100vh; display: grid; place-items: center; }
+      main { width: min(92vw, 72rem); display: grid; gap: 1rem; }
+      header { display: flex; align-items: end; justify-content: space-between; gap: 1rem; }
+      h1 { margin: 0; font-size: 1.35rem; }
+      p { margin: .35rem 0 0; color: #96a2ba; }
+      #status { color: #75d7b0; font-variant-numeric: tabular-nums; }
+      .frame { aspect-ratio: 16 / 9; border: 1px solid #263149; border-radius: 1rem; overflow: hidden; background: #000; }
+      canvas { display: block; width: 100%; height: 100%; }
+      code { color: #c8c1ff; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <div>
+          <h1>Retained Typst + MathTypst</h1>
+          <p><code>Typst</code> glyph atlas + <code>MathTypst</code> vector decorations in one GPU painter stream.</p>
+        </div>
+        <output id="status">starting…</output>
+      </header>
+      <div class="frame"><canvas id="scene"></canvas></div>
+    </main>
+    <script type="module" src="./retained-typst-demo.js"></script>
+  </body>
+</html>

--- a/web/retained-typst-demo.js
+++ b/web/retained-typst-demo.js
@@ -1,0 +1,30 @@
+import init, { RetainedTypstCanvasRenderer } from "./pkg/noon_web.js";
+
+const canvas = document.querySelector("#scene");
+const status = document.querySelector("#status");
+
+if (!(canvas instanceof HTMLCanvasElement) || !(status instanceof HTMLOutputElement)) {
+  throw new Error("retained Typst demo DOM is incomplete");
+}
+
+await init();
+
+const offscreen = canvas.transferControlToOffscreen();
+const renderer = await RetainedTypstCanvasRenderer.create(
+  offscreen,
+  "*Hello* from _Noon Typst!_",
+  "frac(x^2 + y^2, 2) = sum_(k=1)^n k",
+);
+
+function resize() {
+  const rect = canvas.getBoundingClientRect();
+  const dpr = Math.max(1, globalThis.devicePixelRatio || 1);
+  const width = Math.max(1, Math.round(rect.width * dpr));
+  const height = Math.max(1, Math.round(rect.height * dpr));
+  renderer.resize(width, height);
+  renderer.render();
+  status.value = `${renderer.objectCount()} objects · ${renderer.lastDrawCalls()} draws · ${renderer.lastBytesUploaded()} B upload`;
+}
+
+new ResizeObserver(resize).observe(canvas);
+resize();


### PR DESCRIPTION
## Summary
- add a WASM `RetainedTypstCanvasRenderer` that exercises the real retained path end-to-end
- construct public `Typst` / `MathTypst` objects once, compile into retained resources, and render subsequent frames through the shared mixed geometry/glyph painter stream
- compute glyph raster metrics from the active camera/viewport
- use the same WebGPU/WebGL2 fallback policy as the execution canvas
- add a standalone browser demo showing ordinary Typst glyphs and MathTypst vector decorations together
- expose draw/upload counters to make retained behavior observable

Restacked cleanly on merged #343. This intentionally does not force text through the existing geometry-only Python transport, avoiding `GeometryRef::Text` or placeholder rectangles. Exact Manim Typst raster fixtures are stacked separately in #345.