### PR TITLE
Add exact Manim Typst raster fixtures

### DIFF
--- a/.github/workflows/manim-raster-differential.yml
+++ b/.github/workflows/manim-raster-differential.yml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CARGO_INCREMENTAL: "0"
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
       NOON_WASM_SKIP_OPT: "1"
       NOON_SKIP_PLAYGROUND_TEST: "1"
     steps:
@@ -44,12 +46,27 @@ jobs:
             pkg-config
 
       - name: Install pinned ManimCE reference
-        run: python -m pip install --disable-pip-version-check "manim==0.21.0"
+        run: python -m pip install --disable-pip-version-check "manim[typst]==0.21.0" "typst==0.15.0"
 
       - name: Use stable Rust
         run: |
           rustup default stable
           rustup target add wasm32-unknown-unknown
+
+      - name: Cache Cargo sources
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-sources-${{ hashFiles('Cargo.toml', 'crates/**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-sources-
+
+      - name: Use sccache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+        with:
+          version: v0.16.0
 
       - name: Install pinned wasm-pack
         uses: taiki-e/install-action@13608cbb45b01feb47ef444ab1a42dc41ad56f1a # v2.79.11
@@ -70,6 +87,21 @@ jobs:
         run: |
           npm install --no-save --ignore-scripts playwright@1.62.1 pngjs@7.0.0
           npx playwright install chromium
+
+      - name: Render and compare retained Typst fixtures
+        env:
+          NOON_MANIM_TYPST_RASTER_BACKENDS: webgpu,webgl
+          NOON_MANIM_TYPST_RASTER_ARTIFACTS: manim-raster-artifacts/retained-typst
+        run: node scripts/manim-typst-raster-differential.mjs
+
+      - name: Upload retained Typst measurement artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: retained-typst-raster-measurement
+          path: manim-raster-artifacts/retained-typst
+          if-no-files-found: warn
+          retention-days: 14
 
       - name: Render and compare canonical Manim scenes
         env:

--- a/crates/noon-typst/src/lib.rs
+++ b/crates/noon-typst/src/lib.rs
@@ -27,8 +27,9 @@ use typst_library::{
 use typst_svg::{svg, SvgOptions};
 
 pub const TYPST_BACKEND_VERSION: &str = "0.15.1";
-const TEMPLATE_VERSION: &str = "noon-typst-page-v1";
-const TEMPLATE_PREFIX: &str = "#set page(width: auto, height: auto, margin: 0pt, fill: none)\n";
+const TEMPLATE_VERSION: &str = "noon-typst-page-v2";
+const TEMPLATE_PREFIX: &str =
+    "#set page(width: auto, height: auto, margin: 0pt, fill: none)\n#set text(size: 10pt)\n";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum TypstMode {
@@ -807,6 +808,8 @@ mod tests {
     fn template_and_source_fingerprints_are_stable() {
         assert_eq!(fingerprint_hex(b"noon"), fingerprint_hex(b"noon"));
         assert_ne!(fingerprint_hex(b"noon"), fingerprint_hex(b"Noon"));
-        assert!(prepare_source("x", TypstMode::Math).starts_with(TEMPLATE_PREFIX));
+        let prepared = prepare_source("x", TypstMode::Math);
+        assert!(prepared.starts_with(TEMPLATE_PREFIX));
+        assert!(prepared.contains("#set text(size: 10pt)"));
     }
 }

--- a/crates/noon-web/src/retained_typst_canvas.rs
+++ b/crates/noon-web/src/retained_typst_canvas.rs
@@ -28,8 +28,8 @@ mod wasm {
     /// End-to-end browser proof for the retained Typst path.
     ///
     /// Source is compiled once while constructing the renderer. Every render then
-    /// consumes only the retained scene/runtime/resources and #342's mixed GPU
-    /// painter stream; Python/SVG/full-frame rerendering is not involved.
+    /// consumes only the retained scene/runtime/resources and the mixed GPU painter
+    /// stream; Python/SVG/full-frame rerendering is not involved.
     #[wasm_bindgen(js_name = RetainedTypstCanvasRenderer)]
     pub struct WasmRetainedTypstCanvasRenderer {
         _instance: wgpu::Instance,
@@ -76,75 +76,30 @@ mod wasm {
                     )
                     .map_err(js_error)?;
             }
-            if scene.objects().is_empty() {
-                return Err(js_message(
-                    "retained Typst demo requires Typst or MathTypst source",
-                ));
-            }
-            let compiled = scene.compile().map_err(js_error)?;
-            let runtime = RetainedSceneInstance::new(compiled);
+            Self::from_scene(canvas, scene).await
+        }
 
-            let mut instance_descriptor = wgpu::InstanceDescriptor::new_without_display_handle();
-            instance_descriptor.backends = wgpu::Backends::BROWSER_WEBGPU | wgpu::Backends::GL;
-            instance_descriptor.display = Some(Box::new(WebDisplaySource));
-            let instance =
-                wgpu::util::new_instance_with_webgpu_detection(instance_descriptor).await;
-            let surface = instance
-                .create_surface(wgpu::SurfaceTarget::OffscreenCanvas(canvas.clone()))
-                .map_err(js_error)?;
-            let adapter = instance
-                .request_adapter(&wgpu::RequestAdapterOptions {
-                    power_preference: wgpu::PowerPreference::HighPerformance,
-                    force_fallback_adapter: false,
-                    compatible_surface: Some(&surface),
-                })
-                .await
-                .map_err(js_error)?;
-            let backend = adapter.get_info().backend;
-            let required_limits = if backend == wgpu::Backend::Gl {
-                wgpu::Limits::downlevel_webgl2_defaults().using_resolution(adapter.limits())
+        /// Construct exactly one centered retained Typst object. This is used by
+        /// raster-differential fixtures so the public font-size transform and
+        /// source-language identity are tested without demo-specific positioning.
+        #[wasm_bindgen(js_name = createSingle)]
+        pub async fn create_single(
+            canvas: OffscreenCanvas,
+            source: &str,
+            math: bool,
+            font_size: f32,
+        ) -> Result<WasmRetainedTypstCanvasRenderer, JsValue> {
+            let mut scene = RetainedScene::new();
+            if math {
+                scene
+                    .add_math_typst(MathTypst::new(source).with_font_size(font_size))
+                    .map_err(js_error)?;
             } else {
-                wgpu::Limits::default()
-            };
-            let (device, queue) = adapter
-                .request_device(&wgpu::DeviceDescriptor {
-                    label: Some("Noon retained Typst demo GPU device"),
-                    required_features: wgpu::Features::empty(),
-                    required_limits,
-                    ..Default::default()
-                })
-                .await
-                .map_err(js_error)?;
-
-            let width = canvas.width().max(1);
-            let height = canvas.height().max(1);
-            let config = surface
-                .get_default_config(&adapter, width, height)
-                .ok_or_else(|| js_message("GPU adapter cannot present retained Typst demo"))?;
-            surface.configure(&device, &config);
-
-            let mut renderer = GpuRenderer::new(&device, config.format);
-            let camera_height = DEFAULT_CAMERA_HEIGHT;
-            set_camera(&mut renderer, &device, &queue, width, height, camera_height)?;
-            let text_gpu = renderer.create_retained_text_state(&device, &queue);
-
-            Ok(Self {
-                _instance: instance,
-                surface,
-                device,
-                queue,
-                canvas,
-                config,
-                scene,
-                runtime,
-                preparer: RetainedFramePreparer::new(),
-                renderer,
-                text_gpu,
-                camera_height,
-                last_draw_calls: 0,
-                last_instances_drawn: 0,
-                last_bytes_uploaded: 0,
-            })
+                scene
+                    .add_typst(Typst::new(source).with_font_size(font_size))
+                    .map_err(js_error)?;
+            }
+            Self::from_scene(canvas, scene).await
         }
 
         pub fn render(&mut self) -> Result<(), JsValue> {
@@ -257,6 +212,83 @@ mod wasm {
         #[wasm_bindgen(js_name = lastBytesUploaded)]
         pub fn last_bytes_uploaded(&self) -> usize {
             self.last_bytes_uploaded
+        }
+    }
+
+    impl WasmRetainedTypstCanvasRenderer {
+        async fn from_scene(
+            canvas: OffscreenCanvas,
+            scene: RetainedScene,
+        ) -> Result<WasmRetainedTypstCanvasRenderer, JsValue> {
+            if scene.objects().is_empty() {
+                return Err(js_message(
+                    "retained Typst renderer requires at least one text object",
+                ));
+            }
+            let compiled = scene.compile().map_err(js_error)?;
+            let runtime = RetainedSceneInstance::new(compiled);
+
+            let mut instance_descriptor = wgpu::InstanceDescriptor::new_without_display_handle();
+            instance_descriptor.backends = wgpu::Backends::BROWSER_WEBGPU | wgpu::Backends::GL;
+            instance_descriptor.display = Some(Box::new(WebDisplaySource));
+            let instance =
+                wgpu::util::new_instance_with_webgpu_detection(instance_descriptor).await;
+            let surface = instance
+                .create_surface(wgpu::SurfaceTarget::OffscreenCanvas(canvas.clone()))
+                .map_err(js_error)?;
+            let adapter = instance
+                .request_adapter(&wgpu::RequestAdapterOptions {
+                    power_preference: wgpu::PowerPreference::HighPerformance,
+                    force_fallback_adapter: false,
+                    compatible_surface: Some(&surface),
+                })
+                .await
+                .map_err(js_error)?;
+            let backend = adapter.get_info().backend;
+            let required_limits = if backend == wgpu::Backend::Gl {
+                wgpu::Limits::downlevel_webgl2_defaults().using_resolution(adapter.limits())
+            } else {
+                wgpu::Limits::default()
+            };
+            let (device, queue) = adapter
+                .request_device(&wgpu::DeviceDescriptor {
+                    label: Some("Noon retained Typst demo GPU device"),
+                    required_features: wgpu::Features::empty(),
+                    required_limits,
+                    ..Default::default()
+                })
+                .await
+                .map_err(js_error)?;
+
+            let width = canvas.width().max(1);
+            let height = canvas.height().max(1);
+            let config = surface
+                .get_default_config(&adapter, width, height)
+                .ok_or_else(|| js_message("GPU adapter cannot present retained Typst demo"))?;
+            surface.configure(&device, &config);
+
+            let mut renderer = GpuRenderer::new(&device, config.format);
+            let camera_height = DEFAULT_CAMERA_HEIGHT;
+            set_camera(&mut renderer, &device, &queue, width, height, camera_height)?;
+            let text_gpu = renderer.create_retained_text_state(&device, &queue);
+
+            Ok(Self {
+                _instance: instance,
+                surface,
+                device,
+                queue,
+                canvas,
+                config,
+                scene,
+                runtime,
+                preparer: RetainedFramePreparer::new(),
+                renderer,
+                text_gpu,
+                camera_height,
+                last_draw_calls: 0,
+                last_instances_drawn: 0,
+                last_bytes_uploaded: 0,
+            })
         }
     }
 

--- a/parity/manim-v0.21/typst-manifest.json
+++ b/parity/manim-v0.21/typst-manifest.json
@@ -1,0 +1,34 @@
+{
+  "reference": {
+    "project": "Manim Community",
+    "version": "0.21.0",
+    "typst_version": "0.15.0",
+    "renderer": "cairo",
+    "pixel_width": 960,
+    "pixel_height": 540,
+    "source": "parity/manim-v0.21/typst_scenes.py",
+    "upstream": "docs/source/guides/using_text.rst"
+  },
+  "fixtures": [
+    {
+      "id": "hello-typst",
+      "scene": "HelloTypst",
+      "kind": "typst",
+      "source": "*Hello* from _Typst!_",
+      "font_size": 96
+    },
+    {
+      "id": "hello-math-typst",
+      "scene": "HelloMathTypst",
+      "kind": "math-typst",
+      "source": "sum_(k=1)^n k = (n(n + 1)) / 2",
+      "font_size": 72
+    }
+  ],
+  "policy": {
+    "source_equivalence": "exact-manim-v0.21-doc-example",
+    "reference_capture": "cairo-save-last-frame",
+    "noon_path": "retained-text-resource",
+    "initial_mode": "measure-before-ratchet"
+  }
+}

--- a/parity/manim-v0.21/typst_scenes.py
+++ b/parity/manim-v0.21/typst_scenes.py
@@ -1,0 +1,13 @@
+from manim import *
+
+
+class HelloTypst(Scene):
+    def construct(self):
+        text = Typst(r"*Hello* from _Typst!_", font_size=96)
+        self.add(text)
+
+
+class HelloMathTypst(Scene):
+    def construct(self):
+        equation = MathTypst(r"sum_(k=1)^n k = (n(n + 1)) / 2", font_size=72)
+        self.add(equation)

--- a/scripts/manim-typst-raster-differential.mjs
+++ b/scripts/manim-typst-raster-differential.mjs
@@ -1,0 +1,327 @@
+import assert from "node:assert/strict";
+import { spawn, spawnSync } from "node:child_process";
+import { copyFile, mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import playwright from "playwright";
+import pngjs from "pngjs";
+
+const { chromium } = playwright;
+const { PNG } = pngjs;
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const manifestPath = path.join(repoRoot, "parity", "manim-v0.21", "typst-manifest.json");
+const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+const reference = manifest.reference;
+const artifactRoot = path.resolve(
+  repoRoot,
+  process.env.NOON_MANIM_TYPST_RASTER_ARTIFACTS ?? "manim-raster-artifacts/retained-typst",
+);
+const port = Number(process.env.NOON_MANIM_TYPST_RASTER_PORT ?? "4197");
+const baseUrl = `http://127.0.0.1:${port}`;
+const backends = (process.env.NOON_MANIM_TYPST_RASTER_BACKENDS ?? "webgpu,webgl")
+  .split(",")
+  .map((value) => value.trim())
+  .filter(Boolean);
+
+for (const backend of backends) {
+  assert.ok(backend === "webgpu" || backend === "webgl", `unknown backend ${backend}`);
+}
+assert.equal(reference.version, "0.21.0", "Typst raster oracle must stay pinned to ManimCE 0.21.0");
+assert.equal(reference.renderer, "cairo", "Typst raster oracle is defined against Cairo");
+
+function runChecked(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    ...options,
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `${command} ${args.join(" ")} failed (${result.status})\n${result.stdout}\n${result.stderr}`,
+    );
+  }
+  return result;
+}
+
+function verifyReferenceEnvironment() {
+  const version = runChecked("python3", ["-m", "manim", "--version"]);
+  assert.ok(
+    `${version.stdout}\n${version.stderr}`.includes(reference.version),
+    `expected ManimCE ${reference.version}`,
+  );
+  const typstVersion = runChecked("python3", [
+    "-c",
+    "import importlib.metadata; print(importlib.metadata.version('typst'))",
+  ]);
+  assert.equal(
+    typstVersion.stdout.trim(),
+    reference.typst_version,
+    `expected Typst ${reference.typst_version}`,
+  );
+}
+
+async function walkFiles(root) {
+  const entries = await readdir(root, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const entryPath = path.join(root, entry.name);
+    if (entry.isDirectory()) files.push(...(await walkFiles(entryPath)));
+    else files.push(entryPath);
+  }
+  return files;
+}
+
+async function renderReference(fixture) {
+  const mediaDir = path.join(artifactRoot, "manim-media", fixture.id);
+  const referenceDir = path.join(artifactRoot, "reference");
+  await mkdir(mediaDir, { recursive: true });
+  await mkdir(referenceDir, { recursive: true });
+  runChecked("python3", [
+    "-m",
+    "manim",
+    "--renderer=cairo",
+    "--disable_caching",
+    "-s",
+    "--media_dir",
+    mediaDir,
+    "-r",
+    `${reference.pixel_width},${reference.pixel_height}`,
+    path.join(repoRoot, reference.source),
+    fixture.scene,
+  ]);
+  const pngs = (await walkFiles(mediaDir)).filter((file) => file.endsWith(".png"));
+  assert.equal(pngs.length, 1, `${fixture.id}: expected one Manim save-last-frame PNG`);
+  const output = path.join(referenceDir, `${fixture.id}.png`);
+  await copyFile(pngs[0], output);
+  return output;
+}
+
+function browserArgs(backend) {
+  if (backend === "webgpu") {
+    return [
+      "--enable-unsafe-webgpu",
+      "--enable-unsafe-swiftshader",
+      "--use-webgpu-adapter=swiftshader",
+      "--use-gpu-in-tests",
+      "--ignore-gpu-blocklist",
+      "--enable-features=Vulkan",
+      "--use-gl=angle",
+      "--use-angle=swiftshader",
+      "--use-vulkan=swiftshader",
+      "--disable-gpu-sandbox",
+      "--disable-dev-shm-usage",
+    ];
+  }
+  return [
+    "--disable-features=WebGPU",
+    "--enable-unsafe-swiftshader",
+    "--ignore-gpu-blocklist",
+    "--use-gl=angle",
+    "--use-angle=swiftshader",
+    "--disable-gpu-sandbox",
+    "--disable-dev-shm-usage",
+  ];
+}
+
+async function waitForServer() {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    try {
+      const response = await fetch(`${baseUrl}/web/retained-typst-raster.html`);
+      if (response.ok) return;
+    } catch {
+      // Server is still starting.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error("timed out waiting for retained Typst raster host");
+}
+
+async function captureFixture(browser, backend, fixture) {
+  const page = await browser.newPage({
+    viewport: { width: reference.pixel_width, height: reference.pixel_height },
+    deviceScaleFactor: 1,
+  });
+  try {
+    await page.goto(`${baseUrl}/web/retained-typst-raster.html`, { waitUntil: "load" });
+    await page.waitForFunction(() => Boolean(window.noonRetainedTypstRaster), null, {
+      timeout: 30_000,
+    });
+    await page.evaluate(() => window.noonRetainedTypstRaster.ready());
+    const metrics = await page.evaluate(
+      (config) => window.noonRetainedTypstRaster.render(config),
+      {
+        source: fixture.source,
+        math: fixture.kind === "math-typst",
+        fontSize: fixture.font_size,
+        width: reference.pixel_width,
+        height: reference.pixel_height,
+      },
+    );
+    assert.equal(metrics.objectCount, 1, `${fixture.id}: retained object count`);
+    assert.ok(metrics.drawCalls > 0, `${fixture.id}: retained draw calls`);
+    const outputDir = path.join(artifactRoot, backend);
+    await mkdir(outputDir, { recursive: true });
+    const output = path.join(outputDir, `${fixture.id}.png`);
+    await page.locator("#scene").screenshot({ path: output });
+    return { output, metrics };
+  } finally {
+    await page.close();
+  }
+}
+
+function pixelStats(buffer) {
+  const png = PNG.sync.read(buffer);
+  const background = [png.data[0], png.data[1], png.data[2], png.data[3]];
+  let changedPixels = 0;
+  let minX = png.width;
+  let minY = png.height;
+  let maxX = -1;
+  let maxY = -1;
+  for (let offset = 0; offset < png.data.length; offset += 4) {
+    const distance =
+      Math.abs(png.data[offset] - background[0]) +
+      Math.abs(png.data[offset + 1] - background[1]) +
+      Math.abs(png.data[offset + 2] - background[2]) +
+      Math.abs(png.data[offset + 3] - background[3]);
+    if (distance >= 24) {
+      changedPixels += 1;
+      const pixel = offset / 4;
+      const x = pixel % png.width;
+      const y = Math.floor(pixel / png.width);
+      minX = Math.min(minX, x);
+      minY = Math.min(minY, y);
+      maxX = Math.max(maxX, x);
+      maxY = Math.max(maxY, y);
+    }
+  }
+  const bounds = changedPixels === 0 ? null : { minX, minY, maxX, maxY };
+  return {
+    width: png.width,
+    height: png.height,
+    background,
+    changedPixels,
+    bounds,
+    centroid: bounds ? { x: (minX + maxX) / 2, y: (minY + maxY) / 2 } : null,
+  };
+}
+
+function comparePng(referenceBuffer, actualBuffer) {
+  const expected = PNG.sync.read(referenceBuffer);
+  const actual = PNG.sync.read(actualBuffer);
+  assert.equal(actual.width, expected.width, "Typst raster comparison width");
+  assert.equal(actual.height, expected.height, "Typst raster comparison height");
+  const diff = new PNG({ width: expected.width, height: expected.height });
+  let differingPixels = 0;
+  let absoluteChannelError = 0;
+  let maxChannelError = 0;
+  for (let offset = 0; offset < expected.data.length; offset += 4) {
+    let pixelError = 0;
+    for (let channel = 0; channel < 4; channel += 1) {
+      const error = Math.abs(expected.data[offset + channel] - actual.data[offset + channel]);
+      absoluteChannelError += error;
+      maxChannelError = Math.max(maxChannelError, error);
+      pixelError += error;
+      if (channel < 3) diff.data[offset + channel] = Math.min(255, error * 4);
+    }
+    diff.data[offset + 3] = 255;
+    if (pixelError >= 24) differingPixels += 1;
+  }
+  return {
+    diffBuffer: PNG.sync.write(diff),
+    differingPixels,
+    differingRatio: differingPixels / (expected.width * expected.height),
+    meanAbsoluteChannelError: absoluteChannelError / expected.data.length,
+    maxChannelError,
+  };
+}
+
+function bboxDelta(referenceStats, actualStats) {
+  if (!referenceStats.bounds || !actualStats.bounds) return null;
+  const referenceWidth = referenceStats.bounds.maxX - referenceStats.bounds.minX;
+  const referenceHeight = referenceStats.bounds.maxY - referenceStats.bounds.minY;
+  const actualWidth = actualStats.bounds.maxX - actualStats.bounds.minX;
+  const actualHeight = actualStats.bounds.maxY - actualStats.bounds.minY;
+  return {
+    centroidX: actualStats.centroid.x - referenceStats.centroid.x,
+    centroidY: actualStats.centroid.y - referenceStats.centroid.y,
+    width: actualWidth - referenceWidth,
+    height: actualHeight - referenceHeight,
+  };
+}
+
+verifyReferenceEnvironment();
+await rm(artifactRoot, { recursive: true, force: true });
+await mkdir(artifactRoot, { recursive: true });
+
+const references = new Map();
+for (const fixture of manifest.fixtures) {
+  references.set(fixture.id, await renderReference(fixture));
+}
+
+const server = spawn("python3", ["-m", "http.server", String(port), "--bind", "127.0.0.1"], {
+  cwd: repoRoot,
+  stdio: "ignore",
+});
+
+const report = {
+  reference,
+  policy: manifest.policy,
+  fixtures: [],
+};
+
+try {
+  await waitForServer();
+  for (const backend of backends) {
+    const browser = await chromium.launch({
+      channel: "chromium",
+      headless: true,
+      args: browserArgs(backend),
+    });
+    try {
+      for (const fixture of manifest.fixtures) {
+        const capture = await captureFixture(browser, backend, fixture);
+        const referenceBuffer = await readFile(references.get(fixture.id));
+        const actualBuffer = await readFile(capture.output);
+        const comparison = comparePng(referenceBuffer, actualBuffer);
+        const referenceStats = pixelStats(referenceBuffer);
+        const actualStats = pixelStats(actualBuffer);
+        assert.ok(referenceStats.changedPixels > 0, `${fixture.id}: Manim reference is blank`);
+        assert.ok(actualStats.changedPixels > 0, `${fixture.id}: Noon retained frame is blank`);
+        const diffPath = path.join(artifactRoot, backend, `${fixture.id}-diff.png`);
+        await writeFile(diffPath, comparison.diffBuffer);
+        report.fixtures.push({
+          id: fixture.id,
+          scene: fixture.scene,
+          backend,
+          kind: fixture.kind,
+          source: fixture.source,
+          fontSize: fixture.font_size,
+          metrics: capture.metrics,
+          reference: referenceStats,
+          actual: actualStats,
+          bboxDelta: bboxDelta(referenceStats, actualStats),
+          differingPixels: comparison.differingPixels,
+          differingRatio: comparison.differingRatio,
+          meanAbsoluteChannelError: comparison.meanAbsoluteChannelError,
+          maxChannelError: comparison.maxChannelError,
+        });
+      }
+    } finally {
+      await browser.close();
+    }
+  }
+} finally {
+  server.kill("SIGTERM");
+}
+
+await writeFile(path.join(artifactRoot, "report.json"), `${JSON.stringify(report, null, 2)}\n`);
+for (const result of report.fixtures) {
+  console.log(
+    `${result.backend}/${result.id}: diff=${result.differingRatio.toFixed(6)} ` +
+      `mae=${result.meanAbsoluteChannelError.toFixed(4)} bbox=${JSON.stringify(result.bboxDelta)}`,
+  );
+}

--- a/web/retained-typst-raster.html
+++ b/web/retained-typst-raster.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Noon retained Typst raster host</title>
+    <style>
+      html, body { margin: 0; width: 100%; height: 100%; overflow: hidden; background: #000; }
+      canvas { display: block; width: 960px; height: 540px; background: #000; }
+    </style>
+  </head>
+  <body>
+    <canvas id="scene" width="960" height="540"></canvas>
+    <script type="module" src="./retained-typst-raster.js"></script>
+  </body>
+</html>

--- a/web/retained-typst-raster.js
+++ b/web/retained-typst-raster.js
@@ -1,0 +1,40 @@
+import init, { RetainedTypstCanvasRenderer } from "./pkg/noon_web.js";
+
+const canvas = document.querySelector("#scene");
+if (!(canvas instanceof HTMLCanvasElement)) {
+  throw new Error("retained Typst raster canvas is missing");
+}
+
+const initialized = init();
+let rendered = false;
+
+window.noonRetainedTypstRaster = {
+  ready: () => initialized,
+  async render({ source, math, fontSize, width, height }) {
+    if (rendered) {
+      throw new Error("retained Typst raster host supports one fixture per page");
+    }
+    rendered = true;
+    await initialized;
+    canvas.width = width;
+    canvas.height = height;
+    canvas.style.width = `${width}px`;
+    canvas.style.height = `${height}px`;
+    const offscreen = canvas.transferControlToOffscreen();
+    const renderer = await RetainedTypstCanvasRenderer.createSingle(
+      offscreen,
+      source,
+      Boolean(math),
+      Number(fontSize),
+    );
+    renderer.resize(width, height);
+    renderer.render();
+    await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+    return {
+      objectCount: renderer.objectCount(),
+      drawCalls: renderer.lastDrawCalls(),
+      instancesDrawn: renderer.lastInstancesDrawn(),
+      bytesUploaded: renderer.lastBytesUploaded(),
+    };
+  },
+};


### PR DESCRIPTION
## Summary
- add the exact ManimCE v0.21 `HelloTypst` and `HelloMathTypst` documentation scenes as canonical reference source
- add an explicit retained-Typst parity manifest with raw source and exact font sizes
- expose a centered single-object retained renderer entry point for fixture capture, separate from demo-specific positioning
- install `manim[typst]==0.21.0` in the pinned raster reference environment
- render Cairo save-last-frame references at 960x540
- capture the same retained resources through both WebGPU and WebGL2
- emit reference/actual/diff PNGs plus foreground bounds, differing-pixel ratio, and channel-error metrics
- align the retained Typst template with Manim's exact 10pt compilation basis and version the template fingerprint

Retargeted directly to master after #343 and #344 merged. Fixture preparation also fixed the public authoring scale to ManimCE v0.21's exact `SCALE_FACTOR_PER_FONT_POINT = 1 / 960` in #343.

The first retained-text raster run measures the exact fixtures before per-fixture tolerance ratchets are committed; discrepancies are fixed at the source where possible rather than hidden with loose thresholds.