### PR TITLE
Enforce retained Typst raster ratchets

### DIFF
--- a/.github/workflows/manim-raster-differential.yml
+++ b/.github/workflows/manim-raster-differential.yml
@@ -94,6 +94,12 @@ jobs:
           NOON_MANIM_TYPST_RASTER_ARTIFACTS: manim-raster-artifacts/retained-typst
         run: node scripts/manim-typst-raster-differential.mjs
 
+      - name: Enforce retained Typst raster ratchets
+        env:
+          NOON_MANIM_TYPST_RASTER_BACKENDS: webgpu,webgl
+          NOON_MANIM_TYPST_RASTER_ARTIFACTS: manim-raster-artifacts/retained-typst
+        run: node scripts/manim-typst-raster-enforce.mjs
+
       - name: Upload retained Typst measurement artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/parity/manim-v0.21/typst-manifest.json
+++ b/parity/manim-v0.21/typst-manifest.json
@@ -15,20 +15,37 @@
       "scene": "HelloTypst",
       "kind": "typst",
       "source": "*Hello* from _Typst!_",
-      "font_size": 96
+      "font_size": 96,
+      "ratchet": {
+        "max_differing_ratio": 0.009,
+        "max_mean_absolute_channel_error": 0.35,
+        "max_abs_centroid_x_delta": 0,
+        "max_abs_centroid_y_delta": 0,
+        "max_abs_width_delta": 0,
+        "max_abs_height_delta": 0
+      }
     },
     {
       "id": "hello-math-typst",
       "scene": "HelloMathTypst",
       "kind": "math-typst",
       "source": "sum_(k=1)^n k = (n(n + 1)) / 2",
-      "font_size": 72
+      "font_size": 72,
+      "ratchet": {
+        "max_differing_ratio": 0.008,
+        "max_mean_absolute_channel_error": 0.3,
+        "max_abs_centroid_x_delta": 0,
+        "max_abs_centroid_y_delta": 0,
+        "max_abs_width_delta": 2,
+        "max_abs_height_delta": 0
+      }
     }
   ],
   "policy": {
     "source_equivalence": "exact-manim-v0.21-doc-example",
     "reference_capture": "cairo-save-last-frame",
     "noon_path": "retained-text-resource",
-    "initial_mode": "measure-before-ratchet"
+    "mode": "enforced-per-fixture-ratchet",
+    "ratchet_rule": "thresholds may only stay equal or tighten after source-level parity improvements"
   }
 }

--- a/scripts/manim-typst-raster-enforce.mjs
+++ b/scripts/manim-typst-raster-enforce.mjs
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const manifest = JSON.parse(
+  await readFile(path.join(repoRoot, "parity", "manim-v0.21", "typst-manifest.json"), "utf8"),
+);
+const artifactRoot = path.resolve(
+  repoRoot,
+  process.env.NOON_MANIM_TYPST_RASTER_ARTIFACTS ?? "manim-raster-artifacts/retained-typst",
+);
+const report = JSON.parse(await readFile(path.join(artifactRoot, "report.json"), "utf8"));
+const expectedBackends = (process.env.NOON_MANIM_TYPST_RASTER_BACKENDS ?? "webgpu,webgl")
+  .split(",")
+  .map((value) => value.trim())
+  .filter(Boolean);
+
+function finiteNonnegative(value, label) {
+  assert.ok(Number.isFinite(value) && value >= 0, `${label} must be finite and nonnegative`);
+  return value;
+}
+
+function enforceMaximum(actual, maximum, label) {
+  assert.ok(Number.isFinite(actual), `${label} must be finite`);
+  assert.ok(
+    actual <= maximum + Number.EPSILON,
+    `${label}: ${actual} exceeds ratchet ${maximum}`,
+  );
+}
+
+assert.equal(
+  manifest.policy?.mode,
+  "enforced-per-fixture-ratchet",
+  "Typst raster manifest must explicitly enable ratchet enforcement",
+);
+assert.ok(Array.isArray(report.fixtures), "Typst raster report must contain fixture results");
+
+const fixturesById = new Map(manifest.fixtures.map((fixture) => [fixture.id, fixture]));
+assert.equal(fixturesById.size, manifest.fixtures.length, "Typst fixture IDs must be unique");
+
+for (const fixture of manifest.fixtures) {
+  const ratchet = fixture.ratchet;
+  assert.ok(ratchet, `${fixture.id}: missing raster ratchet`);
+  finiteNonnegative(ratchet.max_differing_ratio, `${fixture.id}.max_differing_ratio`);
+  finiteNonnegative(
+    ratchet.max_mean_absolute_channel_error,
+    `${fixture.id}.max_mean_absolute_channel_error`,
+  );
+  finiteNonnegative(
+    ratchet.max_abs_centroid_x_delta,
+    `${fixture.id}.max_abs_centroid_x_delta`,
+  );
+  finiteNonnegative(
+    ratchet.max_abs_centroid_y_delta,
+    `${fixture.id}.max_abs_centroid_y_delta`,
+  );
+  finiteNonnegative(ratchet.max_abs_width_delta, `${fixture.id}.max_abs_width_delta`);
+  finiteNonnegative(ratchet.max_abs_height_delta, `${fixture.id}.max_abs_height_delta`);
+
+  for (const backend of expectedBackends) {
+    const matches = report.fixtures.filter(
+      (result) => result.id === fixture.id && result.backend === backend,
+    );
+    assert.equal(matches.length, 1, `${backend}/${fixture.id}: expected exactly one raster result`);
+    const result = matches[0];
+    assert.ok(result.bboxDelta, `${backend}/${fixture.id}: missing bbox delta`);
+
+    enforceMaximum(
+      result.differingRatio,
+      ratchet.max_differing_ratio,
+      `${backend}/${fixture.id} differing ratio`,
+    );
+    enforceMaximum(
+      result.meanAbsoluteChannelError,
+      ratchet.max_mean_absolute_channel_error,
+      `${backend}/${fixture.id} mean absolute channel error`,
+    );
+    enforceMaximum(
+      Math.abs(result.bboxDelta.centroidX),
+      ratchet.max_abs_centroid_x_delta,
+      `${backend}/${fixture.id} centroid X delta`,
+    );
+    enforceMaximum(
+      Math.abs(result.bboxDelta.centroidY),
+      ratchet.max_abs_centroid_y_delta,
+      `${backend}/${fixture.id} centroid Y delta`,
+    );
+    enforceMaximum(
+      Math.abs(result.bboxDelta.width),
+      ratchet.max_abs_width_delta,
+      `${backend}/${fixture.id} width delta`,
+    );
+    enforceMaximum(
+      Math.abs(result.bboxDelta.height),
+      ratchet.max_abs_height_delta,
+      `${backend}/${fixture.id} height delta`,
+    );
+
+    console.log(
+      `${backend}/${fixture.id}: ratchet ok ` +
+        `diff=${result.differingRatio.toFixed(6)} ` +
+        `mae=${result.meanAbsoluteChannelError.toFixed(4)} ` +
+        `bbox=${JSON.stringify(result.bboxDelta)}`,
+    );
+  }
+}
+
+const expectedPairs = manifest.fixtures.length * expectedBackends.length;
+assert.equal(
+  report.fixtures.length,
+  expectedPairs,
+  `Typst raster report must contain exactly ${expectedPairs} fixture/backend results`,
+);


### PR DESCRIPTION
## Summary
- promote the retained Typst Manim fixtures from measure-only mode to enforced per-fixture raster ratchets
- gate both WebGPU and WebGL on differing-pixel ratio, mean channel error, and bbox deltas
- keep capture and enforcement as separate scripts so raw measurements remain independently inspectable
- preserve exact centering: both fixture centroids must remain at zero delta from the Manim Cairo reference

## Ratchets
- `HelloTypst`: diff <= 0.9%, MAE <= 0.35, exact bbox centroid/extent match
- `HelloMathTypst`: diff <= 0.8%, MAE <= 0.30, exact centroid/height with width delta <= 2 px

These ceilings are based on #347's post-centering measurements (about 0.790% / 0.275 and 0.688% / 0.234 respectively) with a small stability margin. Future parity work should tighten, not loosen, them.