### PR TITLE
Tighten retained Typst raster ratchets

### DIFF
--- a/parity/manim-v0.21/typst-manifest.json
+++ b/parity/manim-v0.21/typst-manifest.json
@@ -17,8 +17,8 @@
       "source": "*Hello* from _Typst!_",
       "font_size": 96,
       "ratchet": {
-        "max_differing_ratio": 0.009,
-        "max_mean_absolute_channel_error": 0.35,
+        "max_differing_ratio": 0.008,
+        "max_mean_absolute_channel_error": 0.28,
         "max_abs_centroid_x_delta": 0,
         "max_abs_centroid_y_delta": 0,
         "max_abs_width_delta": 0,
@@ -32,8 +32,8 @@
       "source": "sum_(k=1)^n k = (n(n + 1)) / 2",
       "font_size": 72,
       "ratchet": {
-        "max_differing_ratio": 0.008,
-        "max_mean_absolute_channel_error": 0.3,
+        "max_differing_ratio": 0.007,
+        "max_mean_absolute_channel_error": 0.24,
         "max_abs_centroid_x_delta": 0,
         "max_abs_centroid_y_delta": 0,
         "max_abs_width_delta": 2,
@@ -46,6 +46,7 @@
     "reference_capture": "cairo-save-last-frame",
     "noon_path": "retained-text-resource",
     "mode": "enforced-per-fixture-ratchet",
+    "max_background_channel_delta_sum": 0,
     "ratchet_rule": "thresholds may only stay equal or tighten after source-level parity improvements"
   }
 }

--- a/scripts/manim-typst-raster-enforce.mjs
+++ b/scripts/manim-typst-raster-enforce.mjs
@@ -36,6 +36,11 @@ assert.equal(
   "enforced-per-fixture-ratchet",
   "Typst raster manifest must explicitly enable ratchet enforcement",
 );
+finiteNonnegative(
+  manifest.policy?.max_background_channel_delta_sum,
+  "policy.max_background_channel_delta_sum",
+);
+assert.deepEqual(report.reference, manifest.reference, "Typst raster report/reference drifted from manifest");
 assert.ok(Array.isArray(report.fixtures), "Typst raster report must contain fixture results");
 
 const fixturesById = new Map(manifest.fixtures.map((fixture) => [fixture.id, fixture]));
@@ -67,7 +72,20 @@ for (const fixture of manifest.fixtures) {
     assert.equal(matches.length, 1, `${backend}/${fixture.id}: expected exactly one raster result`);
     const result = matches[0];
     assert.ok(result.bboxDelta, `${backend}/${fixture.id}: missing bbox delta`);
+    assert.equal(
+      result.reference.background.length,
+      result.actual.background.length,
+      `${backend}/${fixture.id}: background channel count mismatch`,
+    );
+    const backgroundDelta = result.reference.background
+      .map((value, index) => Math.abs(value - result.actual.background[index]))
+      .reduce((sum, value) => sum + value, 0);
 
+    enforceMaximum(
+      backgroundDelta,
+      manifest.policy.max_background_channel_delta_sum,
+      `${backend}/${fixture.id} background channel delta sum`,
+    );
     enforceMaximum(
       result.differingRatio,
       ratchet.max_differing_ratio,


### PR DESCRIPTION
## Summary
- tighten the retained Typst raster ceilings already landed in #348 to the measured #347 parity level
- require the raster report reference identity to exactly match the pinned manifest
- require exact background-channel parity for every retained Typst fixture/backend result

## Why this is a follow-up
#348 merged concurrently while this branch was validating. Its enforcement architecture is good and is now the base of this PR, so the duplicate implementation was discarded. This PR is only the stricter delta on top of #348.

## Measured baseline
Pinned ManimCE v0.21 Cairo at 960x540 on the fully green centering head:
- `HelloTypst`: differing ratio 0.00789738, MAE 0.274983, bbox delta 0 px
- `HelloMathTypst`: differing ratio 0.00687886, MAE 0.233963, bbox delta +2 px width / 0 px center and height
- WebGPU and WebGL produced the same geometry and effectively identical error metrics

## Tightened ceilings
- `HelloTypst`: differing ratio 0.008, MAE 0.28, centroid/width/height delta 0 px
- `HelloMathTypst`: differing ratio 0.007, MAE 0.24, centroid/height delta 0 px, width delta <=2 px
- background channel delta sum: exactly 0
- report reference metadata must exactly equal the manifest reference

The ratchet rule remains monotonic: future changes may only keep these thresholds or tighten them after source-level parity improvements.