### PR TITLE
Add retained Typst Python wrappers

### DIFF
--- a/.github/workflows/retained-typst-authoring.yml
+++ b/.github/workflows/retained-typst-authoring.yml
@@ -1,0 +1,77 @@
+name: Retained Typst authoring
+
+on:
+  pull_request:
+    paths:
+      - "crates/noon-web/src/retained_authoring.rs"
+      - "web/python-worker.js"
+      - "web/python/_manim_typst.py"
+      - "scripts/manim-typst-authoring-smoke.mjs"
+      - ".github/workflows/retained-typst-authoring.yml"
+  push:
+    branches:
+      - master
+    paths:
+      - "crates/noon-web/src/retained_authoring.rs"
+      - "web/python-worker.js"
+      - "web/python/_manim_typst.py"
+      - "scripts/manim-typst-authoring-smoke.mjs"
+      - ".github/workflows/retained-typst-authoring.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: retained-typst-authoring-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  browser-authoring:
+    name: Python retained Typst
+    runs-on: ubuntu-latest
+    env:
+      CARGO_INCREMENTAL: "0"
+      NOON_SKIP_PLAYGROUND_TEST: "1"
+      NOON_WASM_SKIP_OPT: "1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use stable Rust
+        run: |
+          rustup default stable
+          rustup target add wasm32-unknown-unknown
+
+      - name: Cache Cargo sources
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-sources-${{ hashFiles('Cargo.toml', 'crates/**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-sources-
+
+      - name: Install pinned wasm-pack
+        uses: taiki-e/install-action@13608cbb45b01feb47ef444ab1a42dc41ad56f1a
+        with:
+          tool: wasm-pack@0.15.0
+          fallback: none
+
+      - name: Build browser package
+        run: bash scripts/build-web-demo.sh
+
+      - name: Cache Playwright Chromium
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-chromium-1.62.1
+
+      - name: Install browser smoke dependencies
+        run: |
+          npm install --no-save --ignore-scripts playwright@1.62.1 pngjs@7.0.0
+          npx playwright install chromium
+
+      - name: Test retained Typst Python authoring
+        run: node scripts/manim-typst-authoring-smoke.mjs

--- a/scripts/build-web-demo.sh
+++ b/scripts/build-web-demo.sh
@@ -31,6 +31,7 @@ node --check web/browser-smoke.js
 node --check scripts/browser-smoke.mjs
 node --check scripts/manim-raster-differential.mjs
 node --check scripts/manim-seek-playback-raster.mjs
+node --check scripts/manim-typst-authoring-smoke.mjs
 node --check scripts/perf-profile.mjs
 node --check scripts/authoring-perf.mjs
 node --check scripts/perf-device-run.mjs
@@ -58,6 +59,7 @@ node --test web/performance-corpus-manifest.test.mjs
 node --test web/wire-contracts.test.mjs
 PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile \
   web/python/_manim_compat.py \
+  web/python/_manim_typst.py \
   web/python/_manim_rate_functions.py \
   web/python/_manim_phase_b.py \
   web/python/_manim_animation_options.py \

--- a/scripts/manim-typst-authoring-smoke.mjs
+++ b/scripts/manim-typst-authoring-smoke.mjs
@@ -1,0 +1,230 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import playwright from "playwright";
+
+const { chromium } = playwright;
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const port = 4187;
+const baseUrl = `http://127.0.0.1:${port}`;
+
+let serverOutput = "";
+const server = spawn(
+  "python3",
+  ["-m", "http.server", String(port), "--bind", "127.0.0.1", "--directory", repoRoot],
+  { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] },
+);
+server.stdout.on("data", (chunk) => (serverOutput += chunk));
+server.stderr.on("data", (chunk) => (serverOutput += chunk));
+
+async function waitForServer() {
+  let lastError = null;
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    try {
+      const response = await fetch(`${baseUrl}/web/`);
+      if (response.ok) return;
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`retained Typst authoring smoke server did not start: ${lastError}\n${serverOutput}`);
+}
+
+// These are the pinned ManimCE v0.21 examples in parity/manim-v0.21/typst_scenes.py.
+const helloTypstSource = `from manim import *
+
+
+class HelloTypst(Scene):
+    def construct(self):
+        text = Typst(r"*Hello* from _Typst!_", font_size=96)
+        self.add(text)
+`;
+
+const helloMathTypstSource = `from manim import *
+
+
+class HelloMathTypst(Scene):
+    def construct(self):
+        equation = MathTypst(r"sum_(k=1)^n k = (n(n + 1)) / 2", font_size=72)
+        self.add(equation)
+`;
+
+const mixedPainterSource = `from manim import *
+
+
+class MixedPainterOrder(Scene):
+    def construct(self):
+        self.add(Circle(radius=0.25))
+        self.add(Typst("middle", font_size=48))
+        self.add(Square(side_length=0.5))
+`;
+
+function assertSourceLevelSidecar(result, { source, math, fontSize, order }) {
+  assert.equal(result.kind, "scene_document");
+  assert.ok(result.retained_document, "scene result must include a retained authoring document");
+  assert.equal(result.retained_document.channel, "noon.authoring.retained");
+  assert.equal(result.retained_document.protocol_version, 1);
+  assert.equal(result.retained_document.objects.length, 1);
+  const object = result.retained_document.objects[0];
+  assert.ok(Number.isSafeInteger(object.object), "retained object identity must survive JSON exactly");
+  assert.ok(object.object >= 2 ** 52 && object.object < Number.MAX_SAFE_INTEGER);
+  assert.equal(object.order, order);
+  assert.equal(object.text.source, source);
+  assert.equal(object.text.math, math);
+  assert.equal(object.text.font_size, fontSize);
+
+  const wire = JSON.stringify(result.retained_document);
+  for (const forbidden of ["glyph", "font_bytes", "svg", "geometry", "atlas"]) {
+    assert.ok(!wire.includes(forbidden), `retained authoring wire must not contain ${forbidden}`);
+  }
+}
+
+let browser = null;
+try {
+  await waitForServer();
+  browser = await chromium.launch({
+    channel: "chromium",
+    headless: true,
+    args: ["--disable-dev-shm-usage"],
+  });
+  const page = await browser.newPage();
+  const errors = [];
+  page.on("pageerror", (error) => errors.push(`pageerror: ${error}`));
+  page.on("console", (message) => {
+    if (message.type() === "error") errors.push(`console: ${message.text()}`);
+  });
+
+  await page.goto(`${baseUrl}/web/`, { waitUntil: "load" });
+  await page.evaluate(() => {
+    const worker = new Worker(new URL("./python-worker.js", location.href), {
+      name: "noon-retained-typst-authoring-smoke",
+      type: "module",
+    });
+    let nextRequestId = 0;
+    const pending = new Map();
+    let resolveReady;
+    let rejectReady;
+    const ready = new Promise((resolve, reject) => {
+      resolveReady = resolve;
+      rejectReady = reject;
+    });
+
+    worker.addEventListener("error", (event) => {
+      const error = new Error(event.message || "retained Typst worker crashed");
+      rejectReady(error);
+      for (const { reject } of pending.values()) reject(error);
+      pending.clear();
+    });
+    worker.addEventListener("message", (event) => {
+      const message = event.data;
+      if (message?.channel !== "noon.authoring" || message?.protocolVersion !== 5) {
+        const error = new Error("invalid retained Typst worker envelope");
+        rejectReady(error);
+        for (const { reject } of pending.values()) reject(error);
+        pending.clear();
+        return;
+      }
+      if (message.type === "ready") {
+        resolveReady();
+        return;
+      }
+      if (message.type === "error") {
+        const error = new Error(String(message.message || "retained Typst authoring failed"));
+        if (message.requestId === null) {
+          rejectReady(error);
+          for (const { reject } of pending.values()) reject(error);
+          pending.clear();
+          return;
+        }
+        const request = pending.get(message.requestId);
+        if (request) {
+          pending.delete(message.requestId);
+          request.reject(error);
+        }
+        return;
+      }
+      if (message.type === "result") {
+        const request = pending.get(message.requestId);
+        if (!request) return;
+        pending.delete(message.requestId);
+        request.resolve(JSON.parse(message.resultJson));
+      }
+    });
+
+    window.noonRetainedTypstSmoke = {
+      ready: () => ready,
+      run: async (source) => {
+        await ready;
+        const requestId = nextRequestId++;
+        const result = new Promise((resolve, reject) => pending.set(requestId, { resolve, reject }));
+        worker.postMessage({
+          channel: "noon.authoring",
+          protocolVersion: 5,
+          type: "run",
+          requestId,
+          source,
+          context: {},
+        });
+        return result;
+      },
+      stop: () => worker.terminate(),
+    };
+  });
+  await page.evaluate(() => window.noonRetainedTypstSmoke.ready());
+
+  const helloTypst = await page.evaluate(
+    (source) => window.noonRetainedTypstSmoke.run(source),
+    helloTypstSource,
+  );
+  assert.equal(helloTypst.document.objects.length, 0, "Typst must not create placeholder geometry");
+  assertSourceLevelSidecar(helloTypst, {
+    source: "*Hello* from _Typst!_",
+    math: false,
+    fontSize: 96,
+    order: 0,
+  });
+
+  const helloMathTypst = await page.evaluate(
+    (source) => window.noonRetainedTypstSmoke.run(source),
+    helloMathTypstSource,
+  );
+  assert.equal(
+    helloMathTypst.document.objects.length,
+    0,
+    "MathTypst must not create placeholder geometry",
+  );
+  assertSourceLevelSidecar(helloMathTypst, {
+    source: "sum_(k=1)^n k = (n(n + 1)) / 2",
+    math: true,
+    fontSize: 72,
+    order: 0,
+  });
+
+  const mixed = await page.evaluate(
+    (source) => window.noonRetainedTypstSmoke.run(source),
+    mixedPainterSource,
+  );
+  assert.equal(mixed.document.objects.length, 2, "only the circle and square belong to legacy geometry");
+  assert.equal(mixed.document.objects[0].id, 0);
+  assert.equal(mixed.document.objects[1].id, 1);
+  assertSourceLevelSidecar(mixed, {
+    source: "middle",
+    math: false,
+    fontSize: 48,
+    order: 1,
+  });
+
+  await page.evaluate(() => window.noonRetainedTypstSmoke.stop());
+  assert.deepEqual(errors, [], `browser errors while testing retained Typst authoring:\n${errors.join("\n")}`);
+  console.log(
+    "Retained Typst authoring smoke passed: exact Manim v0.21 Typst/MathTypst sources emit source-only retained sidecars, zero placeholder geometry, exact JS-safe identities, and deterministic mixed painter order.",
+  );
+} finally {
+  await browser?.close();
+  server.kill("SIGTERM");
+}

--- a/scripts/manim-typst-authoring-smoke.mjs
+++ b/scripts/manim-typst-authoring-smoke.mjs
@@ -35,8 +35,9 @@ async function waitForServer() {
   throw new Error(`retained Typst authoring smoke server did not start: ${lastError}\n${serverOutput}`);
 }
 
-// These are the pinned ManimCE v0.21 examples in parity/manim-v0.21/typst_scenes.py.
-const helloTypstSource = `from manim import *
+// Pinned ManimCE v0.21 examples from parity/manim-v0.21/typst_scenes.py.
+// As with Noon's existing parity corpus, only the import is substituted.
+const helloTypstSource = `from noon import *
 
 
 class HelloTypst(Scene):
@@ -45,7 +46,7 @@ class HelloTypst(Scene):
         self.add(text)
 `;
 
-const helloMathTypstSource = `from manim import *
+const helloMathTypstSource = `from noon import *
 
 
 class HelloMathTypst(Scene):
@@ -54,7 +55,7 @@ class HelloMathTypst(Scene):
         self.add(equation)
 `;
 
-const mixedPainterSource = `from manim import *
+const mixedPainterSource = `from noon import *
 
 
 class MixedPainterOrder(Scene):
@@ -222,7 +223,7 @@ try {
   await page.evaluate(() => window.noonRetainedTypstSmoke.stop());
   assert.deepEqual(errors, [], `browser errors while testing retained Typst authoring:\n${errors.join("\n")}`);
   console.log(
-    "Retained Typst authoring smoke passed: exact Manim v0.21 Typst/MathTypst sources emit source-only retained sidecars, zero placeholder geometry, exact JS-safe identities, and deterministic mixed painter order.",
+    "Retained Typst authoring smoke passed: pinned Manim v0.21 Typst/MathTypst sources (import-only substitution) emit source-only retained sidecars, zero placeholder geometry, exact JS-safe identities, and deterministic mixed painter order.",
   );
 } finally {
   await browser?.close();

--- a/web/authoring-client.js
+++ b/web/authoring-client.js
@@ -203,14 +203,18 @@ export function parseAuthoringResult(resultJson) {
   }
   if (result.kind === "scene_document") {
     const document = validateSceneDocument(result.document);
-    return {
+    const retainedDocument = validateRetainedAuthoringDocument(result.retained_document);
+    const parsed = {
       kind: result.kind,
       document,
-      retainedDocument: validateRetainedAuthoringDocument(result.retained_document),
       duration: validateSceneDuration(result.duration),
       identities: validateSceneIdentities(result.identities, document),
       callbacks: validateCallbackSession(result.callbacks, document),
     };
+    if (retainedDocument !== null) {
+      parsed.retainedDocument = retainedDocument;
+    }
+    return parsed;
   }
   throw new Error(`Unknown Python authoring result kind: ${result.kind}`);
 }

--- a/web/authoring-client.js
+++ b/web/authoring-client.js
@@ -3,6 +3,8 @@ import "./python-editor.js";
 export const AUTHORING_CHANNEL = "noon.authoring";
 export const AUTHORING_PROTOCOL_VERSION = 5;
 export const NOON_IR_VERSION = 1;
+export const RETAINED_AUTHORING_CHANNEL = "noon.authoring.retained";
+export const RETAINED_AUTHORING_VERSION = 1;
 
 export class PythonAuthoringClient {
   #worker;
@@ -204,6 +206,7 @@ export function parseAuthoringResult(resultJson) {
     return {
       kind: result.kind,
       document,
+      retainedDocument: validateRetainedAuthoringDocument(result.retained_document),
       duration: validateSceneDuration(result.duration),
       identities: validateSceneIdentities(result.identities, document),
       callbacks: validateCallbackSession(result.callbacks, document),
@@ -255,6 +258,84 @@ export function validateSceneDocument(scene) {
     throw new Error("Python Scene tracks must be an array");
   }
   return scene;
+}
+
+export function validateRetainedAuthoringDocument(document) {
+  if (document === null || document === undefined) {
+    return null;
+  }
+  if (!isRecord(document)) {
+    throw new Error("Python retained authoring result must be an object");
+  }
+  if (document.channel !== RETAINED_AUTHORING_CHANNEL) {
+    throw new Error(`Invalid retained authoring channel ${document.channel}`);
+  }
+  if (document.protocol_version !== RETAINED_AUTHORING_VERSION) {
+    throw new Error(
+      `Unsupported retained authoring protocol version ${document.protocol_version}`,
+    );
+  }
+  if (!Array.isArray(document.objects)) {
+    throw new Error("Python retained authoring objects must be an array");
+  }
+
+  const objectIds = new Set();
+  const orders = new Set();
+  for (const object of document.objects) {
+    if (!isRecord(object) || !Number.isSafeInteger(object.object) || object.object < 0) {
+      throw new Error("Python retained authoring object has an invalid object ID");
+    }
+    if (!Number.isSafeInteger(object.order) || object.order < 0) {
+      throw new Error("Python retained authoring object has an invalid painter order");
+    }
+    if (objectIds.has(object.object)) {
+      throw new Error("Python retained authoring document has duplicate object IDs");
+    }
+    if (orders.has(object.order)) {
+      throw new Error("Python retained authoring document has duplicate painter orders");
+    }
+    objectIds.add(object.object);
+    orders.add(object.order);
+    validateRetainedTypstSpec(object.text);
+  }
+  return document;
+}
+
+function validateRetainedTypstSpec(text) {
+  if (!isRecord(text) || typeof text.source !== "string" || text.source.length === 0) {
+    throw new Error("Python retained Typst source must be a non-empty string");
+  }
+  if (typeof text.math !== "boolean") {
+    throw new Error("Python retained Typst math flag must be boolean");
+  }
+  if (!Number.isFinite(text.font_size) || text.font_size <= 0) {
+    throw new Error("Python retained Typst font size must be finite and positive");
+  }
+  if (!Number.isFinite(text.opacity) || text.opacity < 0 || text.opacity > 1) {
+    throw new Error("Python retained Typst opacity must be between zero and one");
+  }
+  if (!isRecord(text.transform) || !isRecord(text.transform.translation) || !isRecord(text.transform.scale)) {
+    throw new Error("Python retained Typst transform is malformed");
+  }
+  for (const value of [
+    text.transform.translation.x,
+    text.transform.translation.y,
+    text.transform.scale.x,
+    text.transform.scale.y,
+    text.transform.rotation,
+  ]) {
+    if (!Number.isFinite(value)) {
+      throw new Error("Python retained Typst transform must be finite");
+    }
+  }
+  if (!isRecord(text.color)) {
+    throw new Error("Python retained Typst color is malformed");
+  }
+  for (const value of [text.color.red, text.color.green, text.color.blue, text.color.alpha]) {
+    if (!Number.isFinite(value)) {
+      throw new Error("Python retained Typst color must be finite");
+    }
+  }
 }
 
 export function validateSceneDuration(duration) {

--- a/web/authoring-client.test.mjs
+++ b/web/authoring-client.test.mjs
@@ -8,6 +8,7 @@ import {
   parseAuthoringResult,
   validateCallbackSession,
   validatePatchBatch,
+  validateRetainedAuthoringDocument,
   validateSceneDocument,
   validateSceneDuration,
   validateSceneIdentities,
@@ -48,6 +49,31 @@ function workerMessage(type, payload = {}) {
   };
 }
 
+function retainedDocument() {
+  return {
+    channel: "noon.authoring.retained",
+    protocol_version: 1,
+    objects: [
+      {
+        object: 2 ** 52,
+        order: 1,
+        text: {
+          source: "*Hello* from _Typst!_",
+          math: false,
+          font_size: 96,
+          transform: {
+            translation: { x: 0, y: 0 },
+            scale: { x: 1, y: 1 },
+            rotation: 0,
+          },
+          color: { red: 1, green: 1, blue: 1, alpha: 1 },
+          opacity: 1,
+        },
+      },
+    ],
+  };
+}
+
 test("correlates a Python request with a validated PatchBatch response", async () => {
   const worker = new FakeWorker();
   const client = new PythonAuthoringClient(worker);
@@ -76,7 +102,7 @@ test("correlates a Python request with a validated PatchBatch response", async (
   assert.deepEqual(await resultPromise, { kind: "patch_batch", document: batch });
 });
 
-test("correlates a Python request with Scene callback and duration metadata", async () => {
+test("correlates a Python request with Scene callback, retained, and duration metadata", async () => {
   const worker = new FakeWorker();
   const client = new PythonAuthoringClient(worker);
   worker.emit("message", workerMessage("ready"));
@@ -87,6 +113,7 @@ test("correlates a Python request with Scene callback and duration metadata", as
   const scene = { version: 1, objects: [{ id: 0 }], tracks: [] };
   const identities = { objects: [{ id: 0, key: "@object:0" }], tracks: [] };
   const callbacks = { session_id: 3, slots: [{ id: 0, objects: [0] }] };
+  const retained = retainedDocument();
   worker.emit(
     "message",
     workerMessage("result", {
@@ -94,6 +121,7 @@ test("correlates a Python request with Scene callback and duration metadata", as
       resultJson: JSON.stringify({
         kind: "scene_document",
         document: scene,
+        retained_document: retained,
         duration: 2.75,
         identities,
         callbacks,
@@ -104,10 +132,47 @@ test("correlates a Python request with Scene callback and duration metadata", as
   assert.deepEqual(await resultPromise, {
     kind: "scene_document",
     document: scene,
+    retainedDocument: retained,
     duration: 2.75,
     identities,
     callbacks,
   });
+});
+
+test("older scene results without a retained sidecar remain compatible", () => {
+  const scene = { version: 1, objects: [], tracks: [] };
+  const parsed = parseAuthoringResult(
+    JSON.stringify({
+      kind: "scene_document",
+      document: scene,
+      duration: 0,
+      identities: { objects: [], tracks: [] },
+      callbacks: null,
+    }),
+  );
+  assert.equal(parsed.retainedDocument, null);
+});
+
+test("validates retained Typst authoring documents and JS-safe identities", () => {
+  const retained = retainedDocument();
+  assert.equal(validateRetainedAuthoringDocument(retained), retained);
+
+  const unsafe = structuredClone(retained);
+  unsafe.objects[0].object = Number.MAX_SAFE_INTEGER + 1;
+  assert.throws(
+    () => validateRetainedAuthoringDocument(unsafe),
+    /invalid object ID/,
+  );
+
+  const duplicateOrder = structuredClone(retained);
+  duplicateOrder.objects.push({
+    ...structuredClone(duplicateOrder.objects[0]),
+    object: 2 ** 52 + 1,
+  });
+  assert.throws(
+    () => validateRetainedAuthoringDocument(duplicateOrder),
+    /duplicate painter orders/,
+  );
 });
 
 test("Scene duration accepts zero and rejects missing, negative, or non-finite values", () => {

--- a/web/authoring-client.test.mjs
+++ b/web/authoring-client.test.mjs
@@ -150,7 +150,7 @@ test("older scene results without a retained sidecar remain compatible", () => {
       callbacks: null,
     }),
   );
-  assert.equal(parsed.retainedDocument, null);
+  assert.equal("retainedDocument" in parsed, false);
 });
 
 test("validates retained Typst authoring documents and JS-safe identities", () => {

--- a/web/python-worker.js
+++ b/web/python-worker.js
@@ -171,14 +171,16 @@ import _manim_phase_b
 import _manim_geometry
 import _manim_semantic_handles
 _manim_semantic_handles.install()
-import _manim_typst
-_manim_typst.install()
 import _manim_animate
 import _manim_rotate
 _manim_rotate.install()
 import _manim_composition
 _manim_composition.install()
 import _manim_lifecycle
+# Retained text must wrap the final lifecycle-aware Scene.add implementation so
+# it is intercepted before any legacy geometry binding occurs.
+import _manim_typst
+_manim_typst.install()
 import _manim_growing
 _manim_growing.install()
 import _manim_draw_border_then_fill

--- a/web/python-worker.js
+++ b/web/python-worker.js
@@ -1,10 +1,12 @@
 import initNoonWeb, {
+  RetainedTypstAuthoringHandle,
   WasmAuthoringStore,
   resolveAnimationOptions,
   resolveCompositionSchedule,
   resolveLifecyclePlan,
   resolveUniformCompositionSchedule,
   validatePresenceTransition,
+  validateRetainedAuthoringDocumentJson,
 } from "./pkg/noon_web.js";
 import { loadPyodide } from "https://cdn.jsdelivr.net/pyodide/v314.0.5/full/pyodide.mjs";
 
@@ -16,6 +18,7 @@ const PYTHON_MODULE_PATH = "/tmp/noon.py";
 const PYTHON_IR_MODULE_PATH = "/tmp/_noon_ir.py";
 const MANIM_COMPAT_MODULE_PATH = "/tmp/_manim_compat.py";
 const MANIM_SEMANTIC_HANDLES_MODULE_PATH = "/tmp/_manim_semantic_handles.py";
+const MANIM_TYPST_MODULE_PATH = "/tmp/_manim_typst.py";
 const MANIM_RATE_FUNCTIONS_MODULE_PATH = "/tmp/_manim_rate_functions.py";
 const MANIM_PHASE_B_MODULE_PATH = "/tmp/_manim_phase_b.py";
 const MANIM_GEOMETRY_MODULE_PATH = "/tmp/_manim_geometry.py";
@@ -55,6 +58,8 @@ async function initializePyodide() {
   self.noonCreateAuthoringLineHandle = (startX, startY, endX, endY) =>
     authoringStore.createManimLine(startX, startY, endX, endY);
   self.noonCreateAuthoringFamilyHandle = () => authoringStore.createFamily();
+  self.noonCreateRetainedTypstHandle = (source, math, fontSize) =>
+    new RetainedTypstAuthoringHandle(source, math, fontSize);
   self.noonResolveAnimationOptions = resolveAnimationOptionsPlain;
   self.noonResolveCompositionSchedule = resolveCompositionSchedulePlain;
   self.noonResolveUniformCompositionSchedule = resolveUniformCompositionSchedulePlain;
@@ -67,6 +72,7 @@ async function initializePyodide() {
     irResponse,
     compatResponse,
     semanticHandlesResponse,
+    typstResponse,
     rateFunctionsResponse,
     phaseBResponse,
     geometryResponse,
@@ -86,6 +92,7 @@ async function initializePyodide() {
     fetch(new URL("./python/_noon_ir.py", import.meta.url)),
     fetch(new URL("./python/_manim_compat.py", import.meta.url)),
     fetch(new URL("./python/_manim_semantic_handles.py", import.meta.url)),
+    fetch(new URL("./python/_manim_typst.py", import.meta.url)),
     fetch(new URL("./python/_manim_rate_functions.py", import.meta.url)),
     fetch(new URL("./python/_manim_phase_b.py", import.meta.url)),
     fetch(new URL("./python/_manim_geometry.py", import.meta.url)),
@@ -106,6 +113,7 @@ async function initializePyodide() {
     [irResponse, "Noon Python IR emitter"],
     [compatResponse, "Noon Manim compatibility layer"],
     [semanticHandlesResponse, "Noon shared semantic handle layer"],
+    [typstResponse, "Noon retained Typst compatibility layer"],
     [rateFunctionsResponse, "Noon Manim rate functions"],
     [phaseBResponse, "Noon Manim Phase B layer"],
     [geometryResponse, "Noon Manim geometry layer"],
@@ -132,6 +140,7 @@ async function initializePyodide() {
     [PYTHON_IR_MODULE_PATH, irResponse],
     [MANIM_COMPAT_MODULE_PATH, compatResponse],
     [MANIM_SEMANTIC_HANDLES_MODULE_PATH, semanticHandlesResponse],
+    [MANIM_TYPST_MODULE_PATH, typstResponse],
     [MANIM_RATE_FUNCTIONS_MODULE_PATH, rateFunctionsResponse],
     [MANIM_PHASE_B_MODULE_PATH, phaseBResponse],
     [MANIM_GEOMETRY_MODULE_PATH, geometryResponse],
@@ -162,6 +171,8 @@ import _manim_phase_b
 import _manim_geometry
 import _manim_semantic_handles
 _manim_semantic_handles.install()
+import _manim_typst
+_manim_typst.install()
 import _manim_animate
 import _manim_rotate
 _manim_rotate.install()
@@ -327,7 +338,7 @@ async function runAuthoringSource(pyodide, source, context) {
   globals.set("__noon_context_json", JSON.stringify(context));
 
   try {
-    return await pyodide.runPythonAsync(
+    const resultJson = await pyodide.runPythonAsync(
       `
 import json
 import _manim_updaters
@@ -372,17 +383,20 @@ if isinstance(__noon_result, Scene):
     __noon_duration = float(__noon_result.time)
     __noon_identities = __noon_result.identity_document()
     __noon_callbacks = _manim_updaters.register_scene(__noon_result)
+    __noon_retained = __noon_result.retained_document()
 elif isinstance(__noon_result, PatchBatch):
     __noon_kind = "patch_batch"
     __noon_duration = None
     __noon_identities = None
     __noon_callbacks = None
+    __noon_retained = None
 else:
     raise TypeError("Python authoring result must be a noon.Scene or noon.PatchBatch")
 json.dumps(
     {
         "kind": __noon_kind,
         "document": __noon_result.to_document(),
+        "retained_document": __noon_retained,
         "duration": __noon_duration,
         "identities": __noon_identities,
         "callbacks": __noon_callbacks,
@@ -393,6 +407,11 @@ json.dumps(
 `,
       { globals },
     );
+    const result = JSON.parse(resultJson);
+    if (result.retained_document !== null) {
+      validateRetainedAuthoringDocumentJson(JSON.stringify(result.retained_document));
+    }
+    return resultJson;
   } finally {
     globals.destroy();
   }

--- a/web/python/_manim_typst.py
+++ b/web/python/_manim_typst.py
@@ -21,7 +21,9 @@ except ImportError:  # Native CPython tests use the source-level fallback below.
     _create_retained_handle = None
 
 
-_RETAINED_OBJECT_ID_BASE = 1 << 63
+# Reserve the upper half of JavaScript's exact-integer range for retained text IDs.
+# Legacy geometry IDs start at zero and no practical scene can approach 2^52 objects.
+_RETAINED_OBJECT_ID_BASE = 1 << 52
 _INSTALLED = False
 _ORIGINAL_SCENE_ADD = _compat.Scene.add
 _ORIGINAL_SCENE_IS_PRESENT = _compat.Scene._is_present

--- a/web/python/_manim_typst.py
+++ b/web/python/_manim_typst.py
@@ -1,0 +1,355 @@
+"""ManimCE Typst/MathTypst wrappers over Noon's retained authoring handle.
+
+The wrappers are intentionally not geometry adapters. They never synthesize an
+``_ir.Mobject`` and ``Scene.add`` intercepts them before legacy geometry lowering.
+Only source-level Typst authoring state crosses the Python-worker boundary; shaping,
+fonts, vector decorations, and GPU glyph state remain Rust-owned retained resources.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from typing import Any
+
+import noon as _base
+import _manim_compat as _compat
+
+try:
+    from js import noonCreateRetainedTypstHandle as _create_retained_handle
+except ImportError:  # Native CPython tests use the source-level fallback below.
+    _create_retained_handle = None
+
+
+_RETAINED_OBJECT_ID_BASE = 1 << 63
+_INSTALLED = False
+_ORIGINAL_SCENE_ADD = _compat.Scene.add
+_ORIGINAL_SCENE_IS_PRESENT = _compat.Scene._is_present
+
+
+def _color_dict(color: _base.Color) -> dict[str, float]:
+    return {
+        "red": float(color.red),
+        "green": float(color.green),
+        "blue": float(color.blue),
+        "alpha": float(color.alpha),
+    }
+
+
+class _FallbackRetainedTypstHandle:
+    """CPython-only stand-in with the exact source-level WASM wire shape."""
+
+    def __init__(self, source: str, math_mode: bool, font_size: float) -> None:
+        self._spec = {
+            "source": str(source),
+            "math": bool(math_mode),
+            "font_size": float(font_size),
+            "transform": {
+                "translation": {"x": 0.0, "y": 0.0},
+                "scale": {"x": 1.0, "y": 1.0},
+                "rotation": 0.0,
+            },
+            "color": _color_dict(_base.WHITE),
+            "opacity": 1.0,
+        }
+
+    def shift(self, x: float, y: float) -> None:
+        self._spec["transform"]["translation"]["x"] += float(x)
+        self._spec["transform"]["translation"]["y"] += float(y)
+
+    def moveTo(self, x: float, y: float) -> None:
+        self._spec["transform"]["translation"] = {"x": float(x), "y": float(y)}
+
+    def scale(self, factor: float) -> None:
+        self._spec["transform"]["scale"]["x"] *= float(factor)
+        self._spec["transform"]["scale"]["y"] *= float(factor)
+
+    def rotate(self, angle: float) -> None:
+        self._spec["transform"]["rotation"] += float(angle)
+
+    def setOpacity(self, opacity: float) -> None:
+        self._spec["opacity"] = float(opacity)
+
+    def setColor(self, red: float, green: float, blue: float, alpha: float) -> None:
+        self._spec["color"] = {
+            "red": float(red),
+            "green": float(green),
+            "blue": float(blue),
+            "alpha": float(alpha),
+        }
+
+    def specJson(self) -> str:
+        return json.dumps(self._spec, separators=(",", ":"), allow_nan=False)
+
+
+def _new_handle(source: str, math_mode: bool, font_size: float):
+    if not isinstance(source, str) or source == "":
+        raise ValueError("Typst source must be a non-empty string")
+    font_size = float(font_size)
+    if not math.isfinite(font_size) or font_size <= 0.0:
+        raise ValueError("font_size must be finite and positive")
+    if _create_retained_handle is None:
+        return _FallbackRetainedTypstHandle(source, math_mode, font_size)
+    return _create_retained_handle(source, bool(math_mode), font_size)
+
+
+def _as_color(value: object) -> _base.Color:
+    if isinstance(value, _base.Color):
+        return value
+    raise TypeError("Typst color must be a Noon/Manim Color")
+
+
+class _RetainedTypstMobject(_base.Mobject):
+    """Python semantic identity for one retained Typst resource-backed object."""
+
+    _math_mode = False
+
+    def __init__(
+        self,
+        source: str,
+        *,
+        font_size: float = 48.0,
+        color: _base.Color = _base.WHITE,
+        **kwargs: Any,
+    ) -> None:
+        opacity = float(kwargs.pop("opacity", 1.0))
+        if kwargs:
+            unsupported = ", ".join(sorted(kwargs))
+            raise NotImplementedError(f"unsupported Typst option(s): {unsupported}")
+        if not math.isfinite(opacity) or not 0.0 <= opacity <= 1.0:
+            raise ValueError("opacity must be finite and between 0 and 1")
+
+        # Do not call Mobject.__init__: that constructor requires legacy geometry.
+        self._raw = None
+        self._scene = None
+        self._object = None
+        self._retained_object_id: int | None = None
+        self._retained_order: int | None = None
+        self._source = str(source)
+        self._font_size = float(font_size)
+        self._retained_handle = _new_handle(self._source, self._math_mode, self._font_size)
+        self.set_color(_as_color(color))
+        self.set_opacity(opacity)
+
+    @property
+    def font_size(self) -> float:
+        return self._font_size
+
+    @property
+    def source(self) -> str:
+        return self._source
+
+    @property
+    def id(self) -> int:
+        if self._retained_object_id is None:
+            raise AttributeError("detached retained Typst Mobject has no scene object id")
+        return self._retained_object_id
+
+    def _current_raw(self):
+        raise TypeError("retained Typst objects do not have legacy geometry snapshots")
+
+    def _apply(self, raw):
+        del raw
+        raise TypeError("retained Typst objects cannot be lowered through legacy geometry")
+
+    def _bind_retained(self, scene: _compat.Scene, object_id: int, order: int) -> None:
+        if self._scene is not None and self._scene is not scene:
+            raise ValueError("Typst Mobject already belongs to another Scene")
+        self._scene = scene
+        self._retained_object_id = int(object_id)
+        self._retained_order = int(order)
+
+    def _retained_entry(self) -> dict[str, Any]:
+        if self._retained_object_id is None or self._retained_order is None:
+            raise ValueError("retained Typst object must belong to a Scene before serialization")
+        return {
+            "object": self._retained_object_id,
+            "order": self._retained_order,
+            "text": json.loads(str(self._retained_handle.specJson())),
+        }
+
+    def get_center(self) -> _base.Vec2:
+        spec = json.loads(str(self._retained_handle.specJson()))
+        point = spec["transform"]["translation"]
+        return _base.Vec2(float(point["x"]), float(point["y"]))
+
+    def shift(self, direction: object) -> _RetainedTypstMobject:
+        offset = _compat._as_vec2(direction)
+        self._retained_handle.shift(float(offset.x), float(offset.y))
+        return self
+
+    def move_to(self, point: object, *args: Any, **kwargs: Any) -> _RetainedTypstMobject:
+        if args or kwargs:
+            raise NotImplementedError("retained Typst move_to currently supports point targets only")
+        target = _compat._as_vec2(point)
+        self._retained_handle.moveTo(float(target.x), float(target.y))
+        return self
+
+    def center(self) -> _RetainedTypstMobject:
+        return self.move_to(_base.ORIGIN)
+
+    def set_x(self, x: float) -> _RetainedTypstMobject:
+        center = self.get_center()
+        self._retained_handle.moveTo(float(x), float(center.y))
+        return self
+
+    def set_y(self, y: float) -> _RetainedTypstMobject:
+        center = self.get_center()
+        self._retained_handle.moveTo(float(center.x), float(y))
+        return self
+
+    def scale(self, factor: float, **kwargs: Any) -> _RetainedTypstMobject:
+        if kwargs:
+            unsupported = ", ".join(sorted(kwargs))
+            raise NotImplementedError(f"unsupported retained Typst scale option(s): {unsupported}")
+        value = float(factor)
+        if not math.isfinite(value) or value <= 0.0:
+            raise ValueError("scale factor must be finite and positive")
+        self._retained_handle.scale(value)
+        return self
+
+    def rotate(self, angle: float, *args: Any, **kwargs: Any) -> _RetainedTypstMobject:
+        if args or kwargs:
+            raise NotImplementedError("retained Typst rotate currently supports angle only")
+        value = float(angle)
+        if not math.isfinite(value):
+            raise ValueError("rotation angle must be finite")
+        self._retained_handle.rotate(value)
+        return self
+
+    def set_color(self, color: _base.Color, family: bool = True) -> _RetainedTypstMobject:
+        del family
+        value = _as_color(color)
+        self._retained_handle.setColor(
+            float(value.red),
+            float(value.green),
+            float(value.blue),
+            float(value.alpha),
+        )
+        return self
+
+    def set_opacity(self, opacity: float, family: bool = True) -> _RetainedTypstMobject:
+        del family
+        value = float(opacity)
+        if not math.isfinite(value) or not 0.0 <= value <= 1.0:
+            raise ValueError("opacity must be finite and between 0 and 1")
+        self._retained_handle.setOpacity(value)
+        return self
+
+    def copy(self) -> _RetainedTypstMobject:
+        spec = json.loads(str(self._retained_handle.specJson()))
+        clone = type(self)(self._source, font_size=self._font_size, color=_base.WHITE)
+        transform = spec["transform"]
+        translation = transform["translation"]
+        scale = transform["scale"]
+        if not math.isclose(float(scale["x"]), float(scale["y"]), rel_tol=0.0, abs_tol=1e-12):
+            raise NotImplementedError("copy of non-uniform retained Typst scale is not implemented")
+        clone._retained_handle.moveTo(float(translation["x"]), float(translation["y"]))
+        clone._retained_handle.scale(float(scale["x"]))
+        clone._retained_handle.rotate(float(transform["rotation"]))
+        color = spec["color"]
+        clone._retained_handle.setColor(
+            float(color["red"]),
+            float(color["green"]),
+            float(color["blue"]),
+            float(color["alpha"]),
+        )
+        clone._retained_handle.setOpacity(float(spec["opacity"]))
+        return clone
+
+
+class Typst(_RetainedTypstMobject):
+    _math_mode = False
+
+
+class MathTypst(_RetainedTypstMobject):
+    _math_mode = True
+
+
+def _ensure_scene_state(scene: _compat.Scene) -> None:
+    if not hasattr(scene, "_retained_text_objects"):
+        scene._retained_text_objects = []
+        scene._retained_next_object_id = _RETAINED_OBJECT_ID_BASE
+        # Existing geometry objects already occupy the leading global painter slots.
+        scene._retained_next_painter_order = len(scene._objects)
+
+
+def _add_retained(scene: _compat.Scene, mobject: _RetainedTypstMobject, key: str | None) -> None:
+    if key is not None:
+        raise NotImplementedError("explicit Scene.add keys for retained Typst are not implemented")
+    _ensure_scene_state(scene)
+    if mobject._scene is scene:
+        scene._register_top_level(mobject)
+        return
+    if mobject._scene is not None:
+        raise ValueError("Typst Mobject already belongs to another Scene")
+    object_id = int(scene._retained_next_object_id)
+    order = int(scene._retained_next_painter_order)
+    scene._retained_next_object_id += 1
+    scene._retained_next_painter_order += 1
+    mobject._bind_retained(scene, object_id, order)
+    scene._retained_text_objects.append(mobject)
+    scene._register_top_level(mobject)
+
+
+def _scene_add(self: _compat.Scene, *mobjects: object, key: str | None = None):
+    if not mobjects:
+        return self
+    if key is not None and len(mobjects) != 1:
+        raise ValueError("an explicit key can only be used when adding one Mobject")
+    _ensure_scene_state(self)
+
+    single_result: object = self
+    for value in mobjects:
+        if isinstance(value, _RetainedTypstMobject):
+            _add_retained(self, value, key)
+            single_result = value
+            continue
+
+        before = len(self._objects)
+        result = _ORIGINAL_SCENE_ADD(self, value, key=key)
+        added = len(self._objects) - before
+        if added > 0:
+            self._retained_next_painter_order += added
+        single_result = result
+
+    return single_result if len(mobjects) == 1 else self
+
+
+def _scene_is_present(self: _compat.Scene, value: object) -> bool:
+    if isinstance(value, _RetainedTypstMobject):
+        return value._scene is self
+    return _ORIGINAL_SCENE_IS_PRESENT(self, value)
+
+
+def _retained_document(self: _compat.Scene) -> dict[str, Any]:
+    _ensure_scene_state(self)
+    objects = [mobject._retained_entry() for mobject in self._retained_text_objects]
+    return {
+        "channel": "noon.authoring.retained",
+        "protocol_version": 1,
+        "objects": objects,
+    }
+
+
+def install() -> None:
+    """Install retained Typst authoring without changing legacy geometry lowering."""
+
+    global _INSTALLED
+    if _INSTALLED:
+        return
+    _INSTALLED = True
+
+    _compat.Scene.add = _scene_add
+    _compat.Scene._is_present = _scene_is_present
+    _compat.Scene.retained_document = _retained_document
+    _base.Scene = _compat.Scene
+
+    public = {"Typst": Typst, "MathTypst": MathTypst}
+    for name, value in public.items():
+        setattr(_base, name, value)
+    exports = list(_base.__all__)
+    for name in public:
+        if name not in exports:
+            exports.append(name)
+    _base.__all__ = exports


### PR DESCRIPTION
## Summary
- add ManimCE-compatible `Typst` / `MathTypst` Python wrappers backed by the Rust/WASM retained authoring handle from #350
- intercept retained text in `Scene.add` before legacy geometry lowering
- preserve JS-safe stable retained object identity and absolute mixed painter order
- emit a Rust-validated `retained_document` sidecar from the Pyodide worker
- expose that sidecar as additive `retainedDocument` metadata from `PythonAuthoringClient` without changing the legacy geometry-only result shape
- add an executable browser gate using the pinned Manim v0.21 `HelloTypst` / `HelloMathTypst` bodies with the repository-standard import-only substitution, plus geometry→text→geometry ordering
- include the retained Typst Python module and browser smoke in the shared web-build syntax gates

## Invariants
- text-only scenes emit zero legacy geometry objects
- the Python/worker wire remains source-level only: no glyph arrays, font bytes, SVG, geometry placeholders, or atlas state
- `MathTypst` stays distinct from future `MathTex`; `Tex`/`MathTex` are not changed here
- retained IDs stay inside JavaScript's exact-integer range
- geometry-only/older worker results retain their existing public client shape exactly
- upstream parity snippets differ only at `from manim import *` → `from noon import *`, matching the rest of the repository parity corpus

## Scope
This PR completes the Python authoring + worker + normal client handoff for retained Typst/MathTypst. The next slice consumes the legacy `SceneDocument` and retained sidecar together in Rust: merge them into one painter-ordered `RetainedScene`, compile/evaluate them through the existing mixed retained runtime, and then connect the retained execution/render transport. No second renderer, overlay canvas, dummy geometry, or browser-side scene model will be introduced.