### PR TITLE
Merge legacy geometry into retained scenes

### DIFF
--- a/crates/noon/src/text_authoring.rs
+++ b/crates/noon/src/text_authoring.rs
@@ -289,14 +289,15 @@ impl RetainedScene {
             .iter()
             .map(RetainedObjectDefinition::from)
             .collect::<Vec<_>>();
-        let next_object_id = objects
-            .iter()
-            .map(|object| object.id.get())
-            .max()
-            .map_or(Ok(0), |id| {
-                id.checked_add(1)
-                    .ok_or(TextAuthoringError::ObjectIdSpaceExhausted)
-            })?;
+        let next_object_id =
+            objects
+                .iter()
+                .map(|object| object.id.get())
+                .max()
+                .map_or(Ok(0), |id| {
+                    id.checked_add(1)
+                        .ok_or(TextAuthoringError::ObjectIdSpaceExhausted)
+                })?;
         Ok(Self {
             objects,
             tracks: scene.tracks().to_vec(),
@@ -529,7 +530,10 @@ mod tests {
         assert_eq!(retained.objects()[0].id, circle);
         assert_eq!(retained.objects()[1].id, square);
         assert_eq!(retained.tracks(), legacy.tracks());
-        assert!(retained.objects().iter().all(|object| object.content.geometry().is_some()));
+        assert!(retained
+            .objects()
+            .iter()
+            .all(|object| object.content.geometry().is_some()));
 
         let compiled = retained.compile().unwrap();
         assert_eq!(compiled.object_index(circle), Some(0));
@@ -584,7 +588,10 @@ mod tests {
             .unwrap();
 
         let handle = retained.objects()[1].content.text().unwrap();
-        assert_eq!(retained.texts().get(handle).unwrap().kind, TextSourceKind::MathTypst);
+        assert_eq!(
+            retained.texts().get(handle).unwrap().kind,
+            TextSourceKind::MathTypst
+        );
     }
 
     #[test]
@@ -609,7 +616,10 @@ mod tests {
         let duplicate_error = retained
             .insert_typst_at(1, existing, Typst::new("duplicate"))
             .unwrap_err();
-        assert_eq!(duplicate_error, TextAuthoringError::DuplicateObject(existing));
+        assert_eq!(
+            duplicate_error,
+            TextAuthoringError::DuplicateObject(existing)
+        );
         assert!(retained.texts().is_empty());
         assert!(retained.fonts().is_empty());
     }

--- a/crates/noon/src/text_authoring.rs
+++ b/crates/noon/src/text_authoring.rs
@@ -10,8 +10,8 @@ use std::sync::Arc;
 use noon_compile::{RetainedCompileError, RetainedCompiledScene};
 use noon_core::{
     Color, FontResourceArena, FontResourceError, GeometryResource, GeometryResourceArena, ObjectId,
-    RetainedObjectDefinition, Style, TextResource, TextResourceArena, TextResourceValidationError,
-    TextSourceKind, TrackDefinition, Transform2D, Vec2, WHITE,
+    RetainedObjectDefinition, SceneDefinition, Style, TextResource, TextResourceArena,
+    TextResourceValidationError, TextSourceKind, TrackDefinition, Transform2D, Vec2, WHITE,
 };
 use noon_typst::{compile_typst_resource, TypstBackendError, TypstMode, TypstResourceArtifact};
 
@@ -134,24 +134,49 @@ macro_rules! typst_object {
                 self
             }
 
-            fn compile(
-                self,
-                scene: &mut RetainedScene,
-            ) -> Result<RetainedObjectDefinition, TextAuthoringError> {
+            fn validate(&self) -> Result<(), TextAuthoringError> {
                 if !self.0.font_size.is_finite() || self.0.font_size <= 0.0 {
                     return Err(TextAuthoringError::InvalidFontSize(self.0.font_size));
                 }
                 if !self.0.opacity.is_finite() || !(0.0..=1.0).contains(&self.0.opacity) {
                     return Err(TextAuthoringError::InvalidOpacity(self.0.opacity));
                 }
+                Ok(())
+            }
+
+            fn compile(
+                self,
+                scene: &mut RetainedScene,
+            ) -> Result<RetainedObjectDefinition, TextAuthoringError> {
+                self.validate()?;
                 let artifact = compile_typst_resource(self.0.source.as_ref(), $mode)?;
                 debug_assert_eq!(artifact.resource.kind, $kind);
                 let handle = scene.import_typst_artifact(artifact)?;
-                let id = scene.allocate_object_id();
+                let id = scene.allocate_object_id()?;
+                Ok(self.retained_definition(id, handle))
+            }
+
+            fn compile_with_id(
+                self,
+                scene: &mut RetainedScene,
+                id: ObjectId,
+            ) -> Result<RetainedObjectDefinition, TextAuthoringError> {
+                self.validate()?;
+                let artifact = compile_typst_resource(self.0.source.as_ref(), $mode)?;
+                debug_assert_eq!(artifact.resource.kind, $kind);
+                let handle = scene.import_typst_artifact(artifact)?;
+                Ok(self.retained_definition(id, handle))
+            }
+
+            fn retained_definition(
+                &self,
+                id: ObjectId,
+                handle: noon_core::TextResourceHandle,
+            ) -> RetainedObjectDefinition {
                 let mut object = RetainedObjectDefinition::text(id, handle);
                 object.transform = self.0.authored_transform();
                 object.style = self.0.style();
-                Ok(object)
+                object
             }
         }
     };
@@ -166,6 +191,9 @@ pub enum TextAuthoringError {
     InvalidOpacity(f32),
     MissingGeometryResource,
     MissingFontResource,
+    DuplicateObject(ObjectId),
+    InvalidPainterOrder { order: usize, object_count: usize },
+    ObjectIdSpaceExhausted,
     Typst(TypstBackendError),
     Font(FontResourceError),
     Text(TextResourceValidationError),
@@ -182,6 +210,19 @@ impl std::fmt::Display for TextAuthoringError {
             }
             Self::MissingFontResource => {
                 formatter.write_str("Typst artifact references missing font data")
+            }
+            Self::DuplicateObject(id) => {
+                write!(formatter, "duplicate retained object id {}", id.get())
+            }
+            Self::InvalidPainterOrder {
+                order,
+                object_count,
+            } => write!(
+                formatter,
+                "retained painter order {order} is invalid for {object_count} existing objects"
+            ),
+            Self::ObjectIdSpaceExhausted => {
+                formatter.write_str("retained object ID space is exhausted")
             }
             Self::Typst(error) => error.fmt(formatter),
             Self::Font(error) => error.fmt(formatter),
@@ -237,6 +278,35 @@ impl RetainedScene {
         Self::default()
     }
 
+    /// Lift an existing geometry-only scene into the retained object domain.
+    ///
+    /// Object IDs, painter order, and tracks are preserved exactly. Resource-backed
+    /// text can then be inserted into explicit painter slots without changing the
+    /// legacy scene serialization or its track references.
+    pub fn from_legacy(scene: &SceneDefinition) -> Result<Self, TextAuthoringError> {
+        let objects = scene
+            .objects()
+            .iter()
+            .map(RetainedObjectDefinition::from)
+            .collect::<Vec<_>>();
+        let next_object_id = objects
+            .iter()
+            .map(|object| object.id.get())
+            .max()
+            .map_or(Ok(0), |id| {
+                id.checked_add(1)
+                    .ok_or(TextAuthoringError::ObjectIdSpaceExhausted)
+            })?;
+        Ok(Self {
+            objects,
+            tracks: scene.tracks().to_vec(),
+            texts: TextResourceArena::default(),
+            geometries: GeometryResourceArena::default(),
+            fonts: FontResourceArena::default(),
+            next_object_id,
+        })
+    }
+
     pub fn add_typst(&mut self, object: Typst) -> Result<RetainedMobject, TextAuthoringError> {
         let object = object.compile(self)?;
         Ok(self.push_object(object))
@@ -248,6 +318,26 @@ impl RetainedScene {
     ) -> Result<RetainedMobject, TextAuthoringError> {
         let object = object.compile(self)?;
         Ok(self.push_object(object))
+    }
+
+    /// Insert Typst at an exact global painter slot using a caller-owned semantic ID.
+    pub fn insert_typst_at(
+        &mut self,
+        order: usize,
+        id: ObjectId,
+        object: Typst,
+    ) -> Result<RetainedMobject, TextAuthoringError> {
+        self.insert_text_at(order, id, |scene| object.compile_with_id(scene, id))
+    }
+
+    /// Insert MathTypst at an exact global painter slot using a caller-owned semantic ID.
+    pub fn insert_math_typst_at(
+        &mut self,
+        order: usize,
+        id: ObjectId,
+        object: MathTypst,
+    ) -> Result<RetainedMobject, TextAuthoringError> {
+        self.insert_text_at(order, id, |scene| object.compile_with_id(scene, id))
     }
 
     pub fn objects(&self) -> &[RetainedObjectDefinition] {
@@ -274,19 +364,56 @@ impl RetainedScene {
         Ok(RetainedCompiledScene::compile(&self.objects, &self.tracks)?)
     }
 
+    fn insert_text_at<F>(
+        &mut self,
+        order: usize,
+        id: ObjectId,
+        compile: F,
+    ) -> Result<RetainedMobject, TextAuthoringError>
+    where
+        F: FnOnce(&mut Self) -> Result<RetainedObjectDefinition, TextAuthoringError>,
+    {
+        if order > self.objects.len() {
+            return Err(TextAuthoringError::InvalidPainterOrder {
+                order,
+                object_count: self.objects.len(),
+            });
+        }
+        if self.objects.iter().any(|object| object.id == id) {
+            return Err(TextAuthoringError::DuplicateObject(id));
+        }
+        let next_object_id = self.next_object_id_after(id)?;
+        let object = compile(self)?;
+        self.objects.insert(order, object);
+        self.next_object_id = next_object_id;
+        Ok(RetainedMobject { id })
+    }
+
     fn push_object(&mut self, object: RetainedObjectDefinition) -> RetainedMobject {
         let id = object.id;
         self.objects.push(object);
         RetainedMobject { id }
     }
 
-    fn allocate_object_id(&mut self) -> ObjectId {
+    fn allocate_object_id(&mut self) -> Result<ObjectId, TextAuthoringError> {
         let id = ObjectId::new(self.next_object_id);
+        if self.objects.iter().any(|object| object.id == id) {
+            return Err(TextAuthoringError::DuplicateObject(id));
+        }
         self.next_object_id = self
             .next_object_id
             .checked_add(1)
-            .expect("Noon retained object ID space exhausted");
-        id
+            .ok_or(TextAuthoringError::ObjectIdSpaceExhausted)?;
+        Ok(id)
+    }
+
+    fn next_object_id_after(&self, id: ObjectId) -> Result<u64, TextAuthoringError> {
+        if id.get() < self.next_object_id {
+            return Ok(self.next_object_id);
+        }
+        id.get()
+            .checked_add(1)
+            .ok_or(TextAuthoringError::ObjectIdSpaceExhausted)
     }
 
     fn import_typst_artifact(
@@ -320,7 +447,7 @@ impl RetainedScene {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use noon_core::ObjectContentRef;
+    use noon_core::{GeometryRef, ObjectContentRef, RateFunction, TrackTiming};
 
     #[test]
     fn typst_authors_one_retained_text_object_without_geometry_placeholder() {
@@ -381,6 +508,110 @@ mod tests {
             .iter()
             .all(|object| object.text().is_some()));
         assert_eq!(scene.texts().len(), 2);
+    }
+
+    #[test]
+    fn legacy_scene_lifts_with_identity_tracks_and_order_intact() {
+        let mut legacy = SceneDefinition::new();
+        let circle = legacy.add(GeometryRef::circle(0.5));
+        let square = legacy.add(GeometryRef::rectangle(1.0, 1.0));
+        legacy
+            .animate_position(
+                circle,
+                Vec2::ZERO,
+                Vec2::new(2.0, 0.0),
+                TrackTiming::new(0.0, 1.0, RateFunction::Linear),
+            )
+            .unwrap();
+
+        let retained = RetainedScene::from_legacy(&legacy).unwrap();
+        assert_eq!(retained.objects().len(), 2);
+        assert_eq!(retained.objects()[0].id, circle);
+        assert_eq!(retained.objects()[1].id, square);
+        assert_eq!(retained.tracks(), legacy.tracks());
+        assert!(retained.objects().iter().all(|object| object.content.geometry().is_some()));
+
+        let compiled = retained.compile().unwrap();
+        assert_eq!(compiled.object_index(circle), Some(0));
+        assert_eq!(compiled.object_index(square), Some(1));
+        assert_eq!(compiled.track_count(), legacy.tracks().len());
+    }
+
+    #[test]
+    fn explicit_typst_insertion_reconstructs_mixed_global_painter_order() {
+        let mut legacy = SceneDefinition::new();
+        let circle = legacy.add(GeometryRef::circle(0.25));
+        let square = legacy.add(GeometryRef::rectangle(0.5, 0.5));
+        let text_id = ObjectId::new(1_u64 << 52);
+
+        let mut retained = RetainedScene::from_legacy(&legacy).unwrap();
+        let text = retained
+            .insert_typst_at(1, text_id, Typst::new("middle").with_font_size(48.0))
+            .unwrap();
+
+        assert_eq!(text.id(), text_id);
+        assert_eq!(
+            retained
+                .objects()
+                .iter()
+                .map(|object| object.id)
+                .collect::<Vec<_>>(),
+            vec![circle, text_id, square]
+        );
+        assert!(retained.objects()[0].content.geometry().is_some());
+        assert!(retained.objects()[1].content.text().is_some());
+        assert!(retained.objects()[2].content.geometry().is_some());
+        assert_eq!(retained.texts().len(), 1);
+
+        let compiled = retained.compile().unwrap();
+        assert_eq!(compiled.object_index(circle), Some(0));
+        assert_eq!(compiled.object_index(text_id), Some(1));
+        assert_eq!(compiled.object_index(square), Some(2));
+    }
+
+    #[test]
+    fn explicit_math_typst_keeps_math_resource_identity() {
+        let mut legacy = SceneDefinition::new();
+        legacy.add(GeometryRef::circle(0.25));
+        let math_id = ObjectId::new((1_u64 << 52) + 1);
+        let mut retained = RetainedScene::from_legacy(&legacy).unwrap();
+        retained
+            .insert_math_typst_at(
+                1,
+                math_id,
+                MathTypst::new("sum_(k=1)^n k").with_font_size(72.0),
+            )
+            .unwrap();
+
+        let handle = retained.objects()[1].content.text().unwrap();
+        assert_eq!(retained.texts().get(handle).unwrap().kind, TextSourceKind::MathTypst);
+    }
+
+    #[test]
+    fn rejected_explicit_insertion_does_not_compile_text_resources() {
+        let mut legacy = SceneDefinition::new();
+        let existing = legacy.add(GeometryRef::circle(0.25));
+        let mut retained = RetainedScene::from_legacy(&legacy).unwrap();
+
+        let order_error = retained
+            .insert_typst_at(2, ObjectId::new(1_u64 << 52), Typst::new("bad order"))
+            .unwrap_err();
+        assert_eq!(
+            order_error,
+            TextAuthoringError::InvalidPainterOrder {
+                order: 2,
+                object_count: 1,
+            }
+        );
+        assert!(retained.texts().is_empty());
+        assert!(retained.fonts().is_empty());
+
+        let duplicate_error = retained
+            .insert_typst_at(1, existing, Typst::new("duplicate"))
+            .unwrap_err();
+        assert_eq!(duplicate_error, TextAuthoringError::DuplicateObject(existing));
+        assert!(retained.texts().is_empty());
+        assert!(retained.fonts().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add `RetainedScene::from_legacy(&SceneDefinition)` to lift geometry objects and tracks into the existing mixed retained object domain without changing IDs or relative painter order
- add explicit-ID / explicit-painter-slot `insert_typst_at` and `insert_math_typst_at`
- preserve resource-backed text handles in the same `RetainedScene` arenas and compile geometry + text through one `RetainedCompiledScene`
- reject invalid painter slots and semantic ID collisions before Typst compilation/resource insertion
- make retained object-ID exhaustion a recoverable authoring error instead of a panic

## Why this boundary
The Python sidecar records only retained text definitions plus absolute painter positions. The legacy scene preserves geometry relative order. This API lets a frontend merge both in Rust by filling non-text painter slots with the legacy objects, while all legacy tracks keep targeting their original object IDs. No browser-specific scene model, overlay renderer, placeholder geometry, or copied glyph payload is needed.

## Validation
Tests cover legacy object/track identity preservation, geometry→Typst→geometry painter reconstruction with the JS-safe 2^52 text ID range, MathTypst resource identity, and rejection-without-resource-side-effects for invalid order / duplicate ID.

## Stack
Draft stacked on #352. After #352 lands, retarget this PR to `master`. The following slice will decode the Python retained sidecar into this API and drive the existing retained runtime/execution transport.