### PR TITLE
Add shared RegularPolygram and Star semantics

### DIFF
--- a/crates/noon/src/geometry_authoring.rs
+++ b/crates/noon/src/geometry_authoring.rs
@@ -9,7 +9,10 @@ use noon_core::{Color, ObjectSnapshot, Vec2, VectorPath, BLUE, TAU};
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum GeometryAuthoringError {
+    NoRegularPolygramVertices,
     TooFewRegularPolygonVertices(usize),
+    InvalidDensity(usize),
+    IncompatibleStarDensity { points: usize, density: usize },
     InvalidRadius(f32),
     InvalidStartAngle(f32),
 }
@@ -17,18 +20,30 @@ pub enum GeometryAuthoringError {
 impl std::fmt::Display for GeometryAuthoringError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::NoRegularPolygramVertices => {
+                formatter.write_str("regular polygram requires at least 1 vertex")
+            }
             Self::TooFewRegularPolygonVertices(value) => write!(
                 formatter,
                 "regular polygon requires at least 3 vertices, got {value}"
             ),
+            Self::InvalidDensity(value) => {
+                write!(
+                    formatter,
+                    "regular polygram density must be positive, got {value}"
+                )
+            }
+            Self::IncompatibleStarDensity { points, density } => write!(
+                formatter,
+                "incompatible density {density} for number of star points {points}"
+            ),
             Self::InvalidRadius(value) => write!(
                 formatter,
-                "regular polygon radius must be finite and positive, got {value}"
+                "polygon radius must be finite and positive, got {value}"
             ),
-            Self::InvalidStartAngle(value) => write!(
-                formatter,
-                "regular polygon start angle must be finite, got {value}"
-            ),
+            Self::InvalidStartAngle(value) => {
+                write!(formatter, "polygon start angle must be finite, got {value}")
+            }
         }
     }
 }
@@ -100,26 +115,36 @@ macro_rules! define_path_shape {
 }
 
 define_path_shape!(Polygon);
+define_path_shape!(RegularPolygram);
 define_path_shape!(RegularPolygon);
+define_path_shape!(Star);
 define_path_shape!(Triangle);
 
-fn polygon_path(vertices: impl IntoIterator<Item = Vec2>) -> VectorPath {
-    let mut vertices = vertices.into_iter();
-    let Some(first) = vertices.next() else {
-        return VectorPath::new();
+fn append_closed_group(mut path: VectorPath, vertices: &[Vec2]) -> VectorPath {
+    let Some((&first, rest)) = vertices.split_first() else {
+        return path;
     };
-
-    let mut path = VectorPath::new().move_to(first);
-    for vertex in vertices {
+    path = path.move_to(first);
+    for &vertex in rest {
         path = path.line_to(vertex);
     }
     path.close()
 }
 
-fn manim_polygon_snapshot(vertices: impl IntoIterator<Item = Vec2>) -> ObjectSnapshot {
-    // `Path` already owns the canonical VMobject stroke width/cap/join policy. Polygon
+fn polygon_path(vertices: impl IntoIterator<Item = Vec2>) -> VectorPath {
+    let vertices: Vec<_> = vertices.into_iter().collect();
+    append_closed_group(VectorPath::new(), &vertices)
+}
+
+fn polygram_path(vertex_groups: &[Vec<Vec2>]) -> VectorPath {
+    vertex_groups.iter().fold(VectorPath::new(), |path, group| {
+        append_closed_group(path, group)
+    })
+}
+
+fn manim_path_snapshot(path: VectorPath) -> ObjectSnapshot {
+    // `Path` already owns the canonical VMobject stroke width/cap/join policy. Polygram
     // only differs in Manim's default BLUE color; keep the transparent fill opacity.
-    let path = polygon_path(vertices);
     let mut snapshot = Path::new(path).into_snapshot();
     let mut transparent_fill = BLUE;
     transparent_fill.alpha = 0.0;
@@ -128,15 +153,17 @@ fn manim_polygon_snapshot(vertices: impl IntoIterator<Item = Vec2>) -> ObjectSna
     snapshot
 }
 
-fn regular_polygon_vertices(
+fn manim_polygon_snapshot(vertices: impl IntoIterator<Item = Vec2>) -> ObjectSnapshot {
+    manim_path_snapshot(polygon_path(vertices))
+}
+
+fn regular_vertices(
     num_vertices: usize,
     radius: f32,
     start_angle: Option<f32>,
 ) -> Result<(Vec<Vec2>, f32), GeometryAuthoringError> {
-    if num_vertices < 3 {
-        return Err(GeometryAuthoringError::TooFewRegularPolygonVertices(
-            num_vertices,
-        ));
+    if num_vertices == 0 {
+        return Err(GeometryAuthoringError::NoRegularPolygramVertices);
     }
     if !radius.is_finite() || radius <= 0.0 {
         return Err(GeometryAuthoringError::InvalidRadius(radius));
@@ -163,10 +190,92 @@ fn regular_polygon_vertices(
     Ok((vertices, start_angle))
 }
 
+fn regular_polygon_vertices(
+    num_vertices: usize,
+    radius: f32,
+    start_angle: Option<f32>,
+) -> Result<(Vec<Vec2>, f32), GeometryAuthoringError> {
+    if num_vertices < 3 {
+        return Err(GeometryAuthoringError::TooFewRegularPolygonVertices(
+            num_vertices,
+        ));
+    }
+    regular_vertices(num_vertices, radius, start_angle)
+}
+
+fn greatest_common_divisor(mut lhs: usize, mut rhs: usize) -> usize {
+    while rhs != 0 {
+        let remainder = lhs % rhs;
+        lhs = rhs;
+        rhs = remainder;
+    }
+    lhs
+}
+
+fn regular_polygram_groups(
+    num_vertices: usize,
+    density: usize,
+    radius: f32,
+    start_angle: Option<f32>,
+) -> Result<Vec<Vec<Vec2>>, GeometryAuthoringError> {
+    if num_vertices == 0 {
+        return Err(GeometryAuthoringError::NoRegularPolygramVertices);
+    }
+    if density == 0 {
+        return Err(GeometryAuthoringError::InvalidDensity(density));
+    }
+
+    // Manim reduces the Schlaefli symbol by gcd first. A {6/2} therefore becomes
+    // two separately closed {3/1} triangles rather than one self-crossing loop.
+    let num_groups = greatest_common_divisor(num_vertices, density);
+    let reduced_vertices = num_vertices / num_groups;
+    let reduced_density = density / num_groups;
+
+    let build_group = |angle: Option<f32>| -> Result<(Vec<Vec2>, f32), GeometryAuthoringError> {
+        let (regular, resolved_angle) = regular_vertices(reduced_vertices, radius, angle)?;
+        let mut group = Vec::with_capacity(reduced_vertices);
+        let mut index = 0;
+        loop {
+            group.push(regular[index]);
+            index = (index + reduced_density) % reduced_vertices;
+            if index == 0 {
+                break;
+            }
+        }
+        Ok((group, resolved_angle))
+    };
+
+    let (first_group, resolved_start) = build_group(start_angle)?;
+    let mut groups = vec![first_group];
+    for index in 1..num_groups {
+        let angle =
+            resolved_start + (index as f32 / num_groups as f32) * TAU / reduced_vertices as f32;
+        groups.push(build_group(Some(angle))?.0);
+    }
+    Ok(groups)
+}
+
 impl Polygon {
     /// Build one closed straight-edged loop in the authored vertex order.
     pub fn new(vertices: impl IntoIterator<Item = Vec2>) -> Self {
         Self(manim_polygon_snapshot(vertices))
+    }
+}
+
+impl RegularPolygram {
+    /// Build a Manim-compatible regular polygram with the default density of two.
+    pub fn new(num_vertices: usize) -> Result<Self, GeometryAuthoringError> {
+        Self::with_options(num_vertices, 2, 1.0, None)
+    }
+
+    pub fn with_options(
+        num_vertices: usize,
+        density: usize,
+        radius: f32,
+        start_angle: Option<f32>,
+    ) -> Result<Self, GeometryAuthoringError> {
+        let groups = regular_polygram_groups(num_vertices, density, radius, start_angle)?;
+        Ok(Self(manim_path_snapshot(polygram_path(&groups))))
     }
 }
 
@@ -192,6 +301,70 @@ impl Default for RegularPolygon {
         let (vertices, _) = regular_polygon_vertices(6, 1.0, None)
             .expect("the built-in RegularPolygon default is valid");
         Self(manim_polygon_snapshot(vertices))
+    }
+}
+
+impl Star {
+    /// Build Manim's default five-point star. The inner radius is derived from the
+    /// corresponding density-two regular polygram.
+    pub fn new() -> Self {
+        Self::with_options(5, 1.0, None, 2, Some(TAU / 4.0))
+            .expect("the built-in Star default is valid")
+    }
+
+    pub fn with_options(
+        points: usize,
+        outer_radius: f32,
+        inner_radius: Option<f32>,
+        density: usize,
+        start_angle: Option<f32>,
+    ) -> Result<Self, GeometryAuthoringError> {
+        if points < 3 {
+            return Err(GeometryAuthoringError::TooFewRegularPolygonVertices(points));
+        }
+        if !outer_radius.is_finite() || outer_radius <= 0.0 {
+            return Err(GeometryAuthoringError::InvalidRadius(outer_radius));
+        }
+
+        let inner_angle = TAU / (2.0 * points as f32);
+        let inner_radius = match inner_radius {
+            Some(radius) => {
+                if !radius.is_finite() || radius <= 0.0 {
+                    return Err(GeometryAuthoringError::InvalidRadius(radius));
+                }
+                radius
+            }
+            None => {
+                if density == 0 || density as f32 >= points as f32 / 2.0 {
+                    return Err(GeometryAuthoringError::IncompatibleStarDensity {
+                        points,
+                        density,
+                    });
+                }
+                let outer_angle = TAU * density as f32 / points as f32;
+                let inverse_x =
+                    1.0 - inner_angle.tan() * ((outer_angle.cos() - 1.0) / outer_angle.sin());
+                outer_radius / (inner_angle.cos() * inverse_x)
+            }
+        };
+
+        let (outer_vertices, resolved_start) =
+            regular_polygon_vertices(points, outer_radius, start_angle)?;
+        let (inner_vertices, _) =
+            regular_polygon_vertices(points, inner_radius, Some(resolved_start + inner_angle))?;
+
+        let mut vertices = Vec::with_capacity(points * 2);
+        for (outer, inner) in outer_vertices.into_iter().zip(inner_vertices) {
+            vertices.push(outer);
+            vertices.push(inner);
+        }
+        Ok(Self(manim_polygon_snapshot(vertices)))
+    }
+}
+
+impl Default for Star {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -274,6 +447,35 @@ mod tests {
     }
 
     #[test]
+    fn regular_polygram_pentagram_uses_density_hop_order() {
+        let polygram = RegularPolygram::with_options(5, 2, 1.0, None).unwrap();
+        let commands = commands(polygram.snapshot());
+        assert_eq!(commands.len(), 6);
+        let (regular, _) = regular_vertices(5, 1.0, None).unwrap();
+        assert_eq!(move_point(commands[0]), regular[0]);
+        assert_eq!(line_point(commands[1]), regular[2]);
+        assert_eq!(line_point(commands[2]), regular[4]);
+        assert_eq!(line_point(commands[3]), regular[1]);
+        assert_eq!(line_point(commands[4]), regular[3]);
+        assert_eq!(commands[5], PathCommand::Close);
+    }
+
+    #[test]
+    fn regular_polygram_reduces_hexagram_into_two_triangle_subpaths() {
+        let polygram = RegularPolygram::with_options(6, 2, 1.0, None).unwrap();
+        let commands = commands(polygram.snapshot());
+        assert_eq!(commands.len(), 8);
+        let first = move_point(commands[0]);
+        let second = move_point(commands[4]);
+        assert_close(first.x, 0.0);
+        assert_close(first.y, 1.0);
+        assert_close(second.x, -(3.0_f32.sqrt() * 0.5));
+        assert_close(second.y, 0.5);
+        assert_eq!(commands[3], PathCommand::Close);
+        assert_eq!(commands[7], PathCommand::Close);
+    }
+
+    #[test]
     fn regular_polygon_matches_manim_default_even_orientation() {
         let polygon = RegularPolygon::new(6).unwrap();
         let commands = commands(polygon.snapshot());
@@ -303,6 +505,40 @@ mod tests {
     }
 
     #[test]
+    fn star_interleaves_outer_and_inner_vertices() {
+        let star = Star::new();
+        let commands = commands(star.snapshot());
+        assert_eq!(commands.len(), 11);
+        let outer = move_point(commands[0]);
+        let inner = line_point(commands[1]);
+        assert_close(outer.x, 0.0);
+        assert_close(outer.y, 1.0);
+        let inner_angle = TAU / 10.0;
+        let expected_angle = TAU / 4.0 + inner_angle;
+        let expected_radius = {
+            let outer_angle = TAU * 2.0 / 5.0;
+            let inverse_x =
+                1.0 - inner_angle.tan() * ((outer_angle.cos() - 1.0) / outer_angle.sin());
+            1.0 / (inner_angle.cos() * inverse_x)
+        };
+        assert_close(inner.x, expected_radius * expected_angle.cos());
+        assert_close(inner.y, expected_radius * expected_angle.sin());
+        assert_eq!(commands[10], PathCommand::Close);
+    }
+
+    #[test]
+    fn star_explicit_inner_radius_ignores_density_compatibility() {
+        let star = Star::with_options(5, 2.0, Some(0.75), 99, Some(0.0)).unwrap();
+        let commands = commands(star.snapshot());
+        let outer = move_point(commands[0]);
+        let inner = line_point(commands[1]);
+        assert_close(outer.x, 2.0);
+        assert_close(outer.y, 0.0);
+        assert_close(inner.x, 0.75 * (TAU / 10.0).cos());
+        assert_close(inner.y, 0.75 * (TAU / 10.0).sin());
+    }
+
+    #[test]
     fn triangle_is_the_regular_three_vertex_specialization() {
         let triangle = Triangle::new();
         let regular = RegularPolygon::new(3).unwrap();
@@ -310,10 +546,21 @@ mod tests {
     }
 
     #[test]
-    fn regular_polygon_rejects_invalid_parameters() {
+    fn polygon_family_rejects_invalid_parameters() {
         assert_eq!(
             RegularPolygon::new(2),
             Err(GeometryAuthoringError::TooFewRegularPolygonVertices(2))
+        );
+        assert_eq!(
+            RegularPolygram::with_options(5, 0, 1.0, None),
+            Err(GeometryAuthoringError::InvalidDensity(0))
+        );
+        assert_eq!(
+            Star::with_options(5, 1.0, None, 3, None),
+            Err(GeometryAuthoringError::IncompatibleStarDensity {
+                points: 5,
+                density: 3,
+            })
         );
         assert_eq!(
             RegularPolygon::with_options(4, 0.0, None),

--- a/crates/noon/src/lib.rs
+++ b/crates/noon/src/lib.rs
@@ -23,8 +23,8 @@ pub mod prelude {
     pub use crate::legacy::prelude::*;
     pub use crate::{
         GeometryAuthoringError, MathTypst, MovingCameraScene, Polygon, ReactiveScene,
-        ReactiveTimelineScene, RegularPolygon, RetainedMobject, RetainedScene, TextAuthoringError,
-        Triangle, Typst, ValueTracker, VectorSignal,
+        ReactiveTimelineScene, RegularPolygon, RegularPolygram, RetainedMobject, RetainedScene,
+        Star, TextAuthoringError, Triangle, Typst, ValueTracker, VectorSignal,
     };
     pub use noon_core::{
         resolve_animation_options, resolve_composition_schedule, resolve_lifecycle_plan,


### PR DESCRIPTION
## Summary
- add shared Rust `RegularPolygram` and `Star` authoring on top of #358
- represent disconnected polygram components as multiple closed subpaths in the existing retained `VectorPath`
- reproduce Manim's Schlaefli/GCD reduction, so e.g. `{6/2}` becomes two separately closed triangles
- preserve density-hop vertex ordering for coprime regular polygrams such as `{5/2}`
- reproduce Manim's star inner-radius calculation when `inner_radius` is omitted
- preserve Manim's rule that explicit `inner_radius` makes `density` irrelevant
- export `RegularPolygram` and `Star` through the Rust prelude
- add focused tests for pentagram ordering, disconnected hexagrams, star interleaving/derived radius, explicit-inner-radius behavior, and invalid inputs

## Architecture
No new renderer primitive or frontend-specific geometry engine is introduced. Both shapes lower to the same retained `GeometryRef::VectorPath` used by ordinary paths. Disconnected polygram components are encoded as normal multiple `MoveTo`/`Close` subpaths.

## Parallelism
This is stacked on #358 and modifies only:
- `crates/noon/src/geometry_authoring.rs`
- `crates/noon/src/lib.rs`

It does not touch the active text/font/Typst resource transport, `noon-web`, the render worker, or the Python authoring worker/client path.

## Upstream semantics
The implementation follows the pinned ManimCE v0.21 `RegularPolygram` GCD/density construction and `Star` inner-radius/interleaving rules.

## Scope boundary
This remains part of #76. Arcs/sectors, rounded rectangles, remaining polygram helpers, frontend wiring, differential fixtures, and renderer goldens stay separate.

Depends on #358. Tracks #76.