### PR TITLE
Add cross-platform and optimized release validation

### DIFF
--- a/.github/workflows/platform-release.yml
+++ b/.github/workflows/platform-release.yml
@@ -1,0 +1,172 @@
+name: Platform and release validation
+
+on:
+  pull_request:
+    paths:
+      - Cargo.toml
+      - Cargo.lock
+      - 'crates/**'
+      - 'scripts/build-web-demo.sh'
+      - 'scripts/build-python-worker.mjs'
+      - 'scripts/check-web-package.mjs'
+      - 'scripts/deterministic-replay-smoke.mjs'
+      - 'web/**'
+      - '.github/workflows/platform-release.yml'
+  push:
+    branches:
+      - master
+    paths:
+      - Cargo.toml
+      - Cargo.lock
+      - 'crates/**'
+      - 'scripts/build-web-demo.sh'
+      - 'scripts/build-python-worker.mjs'
+      - 'scripts/check-web-package.mjs'
+      - 'scripts/deterministic-replay-smoke.mjs'
+      - 'web/**'
+      - '.github/workflows/platform-release.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: platform-release-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  native-platform:
+    name: Native ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    env:
+      CARGO_INCREMENTAL: '0'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use stable Rust
+        run: rustup default stable
+
+      - name: Cache Cargo sources
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-platform-cargo-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'crates/**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-platform-cargo-
+
+      - name: Compile and test native workspace
+        run: cargo test --workspace --all-features --lib --tests
+
+  release-native:
+    name: Native release-mode core
+    runs-on: ubuntu-latest
+    env:
+      CARGO_INCREMENTAL: '0'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use stable Rust
+        run: rustup default stable
+
+      - name: Cache Cargo sources
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: release-cargo-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'crates/**/Cargo.toml') }}
+          restore-keys: |
+            release-cargo-
+
+      - name: Test core execution crates in release mode
+        run: cargo test --release -p noon-core -p noon-geometry -p noon-runtime --all-features
+
+  optimized-wasm:
+    name: Optimized browser artifact
+    runs-on: ubuntu-latest
+    env:
+      CARGO_INCREMENTAL: '0'
+      BINARYEN_VERSION: '132'
+      BINARYEN_LINUX_SHA256: '195ddc94f9bc89f45abdabb0b9eea86023d727ba90eac8b35b80f2544fc30572'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use stable Rust and WASM target
+        run: |
+          rustup default stable
+          rustup target add wasm32-unknown-unknown
+
+      - name: Cache Cargo sources
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: optimized-wasm-cargo-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'crates/**/Cargo.toml') }}
+          restore-keys: |
+            optimized-wasm-cargo-
+
+      - name: Install pinned wasm-pack
+        uses: taiki-e/install-action@13608cbb45b01feb47ef444ab1a42dc41ad56f1a # v2.79.11
+        with:
+          tool: wasm-pack@0.15.0
+          fallback: none
+
+      - name: Install pinned wasm-opt
+        shell: bash
+        run: |
+          archive="binaryen-version_${BINARYEN_VERSION}-x86_64-linux.tar.gz"
+          url="https://github.com/WebAssembly/binaryen/releases/download/version_${BINARYEN_VERSION}/${archive}"
+          curl --fail --location --retry 3 --output "$RUNNER_TEMP/$archive" "$url"
+          echo "${BINARYEN_LINUX_SHA256}  $RUNNER_TEMP/$archive" | sha256sum --check --strict
+          tar -xzf "$RUNNER_TEMP/$archive" -C "$RUNNER_TEMP"
+          binaryen_dir="$RUNNER_TEMP/binaryen-version_${BINARYEN_VERSION}"
+          echo "$binaryen_dir/bin" >> "$GITHUB_PATH"
+          "$binaryen_dir/bin/wasm-opt" --version
+
+      - name: Build and validate optimized browser package
+        env:
+          NOON_SKIP_PLAYGROUND_TEST: '1'
+        run: bash scripts/build-web-demo.sh
+
+      - name: Record optimized WASM size
+        shell: bash
+        run: |
+          test -s web/pkg/noon_web_bg.wasm
+          bytes="$(wc -c < web/pkg/noon_web_bg.wasm | tr -d ' ')"
+          echo "Optimized WASM bytes: ${bytes}"
+          {
+            echo '### Optimized browser artifact'
+            echo
+            echo "- noon_web_bg.wasm: ${bytes} bytes"
+            echo '- wasm-pack: 0.15.0'
+            echo "- Binaryen/wasm-opt: version ${BINARYEN_VERSION}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Install Chromium smoke dependency
+        run: |
+          npm install --no-save --ignore-scripts playwright@1.62.1
+          npx playwright install chromium
+
+      - name: Exercise optimized WASM in Chromium
+        run: node scripts/deterministic-replay-smoke.mjs
+
+      - name: Upload optimized browser package
+        uses: actions/upload-artifact@v4
+        with:
+          name: optimized-web-pkg
+          path: web/pkg
+          if-no-files-found: error
+          retention-days: 3

--- a/crates/noon-web/tests/playground_examples.rs
+++ b/crates/noon-web/tests/playground_examples.rs
@@ -14,6 +14,9 @@ fn every_playground_scene_executes_and_compiles() {
         .arg(&output_dir)
         .current_dir(&repository_root)
         .env("PYTHONDONTWRITEBYTECODE", "1")
+        // Exercise the manifest producer under a hostile inherited encoding.
+        // Its machine-readable stdout contract must remain UTF-8 on every host.
+        .env("PYTHONIOENCODING", "cp1252")
         .output()
         .expect("python3 is available for playground validation");
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -52,6 +52,24 @@ The reactive/editor job runs:
 
 Rendering is a two-entry matrix over WebGPU and WebGL2 fallback. Both run the deterministic playground/browser smoke corpus and upload screenshots on success or failure. The required Linux browser path uses Playwright Chromium/SwiftShader so it is repeatable on hosted runners.
 
+## Platform and release validation
+
+`.github/workflows/platform-release.yml` is the compact portability and production-artifact lane. It runs when native/browser production paths or their build generators change, on pushes to `master`, and by manual dispatch.
+
+The workflow deliberately stays separate from fast main CI and provides three contracts:
+
+- **native platform matrix:** Linux, macOS, and Windows compile and run the workspace library/integration test set with stable Rust;
+- **release-mode native check:** `noon-core`, `noon-geometry`, and `noon-runtime` run their tests with release optimizations enabled to catch optimization-sensitive failures without tripling the cost across every OS;
+- **optimized browser artifact:** pinned `wasm-pack` 0.15.0 and Binaryen/`wasm-opt` version 132 build the real release package, including generated Python-worker assets; the normal package-surface validation runs, the optimized WASM is loaded/evaluated through deterministic Chromium replay, and the resulting package is retained as a short-lived artifact.
+
+The supported Rust policy for this lane is current stable Rust plus `wasm32-unknown-unknown`. If a minimum supported Rust version becomes a product requirement, add it as a separate explicit matrix entry rather than relying on whatever a hosted runner happens to contain. Binaryen is downloaded from its versioned release artifact and checksum-verified before adding its `wasm-opt` to `PATH`; this prevents wasm-pack's default "latest" optimizer download from making release output silently drift.
+
+The optimized job records `noon_web_bg.wasm` byte size in the workflow summary as diagnostic trend data. Size is not yet a required budget; establish a stable baseline before adding a ratchet.
+
+Machine-readable subprocess protocols used by the platform matrix must define their encoding rather than inherit a host locale. In particular, the playground scene manifest is explicitly UTF-8 and its integration test forces a hostile inherited Python encoding so the contract is deterministic on every runner.
+
+This matrix is intentionally compact. Add another operating system, browser, toolchain, or backend only when it proves a distinct product contract or catches a demonstrated class of failure. Browser-engine/DPR/UI variation belongs to the separate #110 lane rather than expanding this workflow combinatorially.
+
 ## Manim compatibility workflows
 
 Manim API-surface and semantic compatibility are separate workflows because they require a pinned ManimCE/Python environment. Manim Community v0.21.0 is the reference version. API inventory and semantic differential tests should remain separate: surface presence does not prove behavior, and behavioral fixtures should not become a second API manifest.

--- a/web/python/playground_examples.py
+++ b/web/python/playground_examples.py
@@ -77,7 +77,16 @@ def emit_scene_documents(output_dir: Path) -> None:
         print(f"{name}\t{output_path}")
 
 
+def _configure_manifest_stdout() -> None:
+    # CLI stdout is a machine-readable UTF-8 manifest. A redirected Windows
+    # stream may otherwise inherit a legacy code page and corrupt non-ASCII names.
+    reconfigure = getattr(sys.stdout, "reconfigure", None)
+    if reconfigure is not None:
+        reconfigure(encoding="utf-8")
+
+
 if __name__ == "__main__":
     if len(sys.argv) != 2:
         raise SystemExit("usage: playground_examples.py OUTPUT_DIR")
+    _configure_manifest_stdout()
     emit_scene_documents(Path(sys.argv[1]).resolve())


### PR DESCRIPTION
## Summary
- add a compact Linux/macOS/Windows native workspace test matrix on stable Rust
- add a focused release-mode test job for `noon-core`, `noon-geometry`, and `noon-runtime`
- build the browser package through the real optimized wasm-pack/wasm-opt path and exercise it in deterministic Chromium replay
- pin wasm-pack 0.15.0 and Binaryen/wasm-opt 132, checksum-verifying the Binaryen release artifact before putting it on `PATH`
- keep optimized WASM size as diagnostic trend data and retain the built package briefly
- include the content-addressed Python-worker generator in production-artifact path triggers
- make the playground scene manifest an explicit UTF-8 machine-readable protocol and regression-test it under a deliberately hostile inherited Python encoding
- document the platform/release matrix and release-toolchain policy

## Why
Normal CI is intentionally optimized for fast iteration: native workspace validation is Ubuntu-centric and the shared browser package skips wasm optimization. That leaves OS-specific and release/optimization-sensitive failures outside the normal gate.

The first version of this PR proved the value immediately: Linux, macOS, release-mode core, and optimized Chromium all passed, while Windows failed in `playground_examples` because the Python manifest inherited the Windows code page and emitted `·` as byte `0xB7`; Rust correctly expected UTF-8. The refreshed implementation fixes the protocol at its producer and makes the regression deterministic on every platform by launching it with `PYTHONIOENCODING=cp1252`.

A second audit found that wasm-pack 0.15.0 downloads wasm-opt using the moving `latest` Binaryen release when no optimizer is already on `PATH`. The final workflow therefore installs Binaryen 132 from its versioned x86_64 Linux artifact, verifies the official SHA-256, and exposes that exact `wasm-opt` before invoking wasm-pack. Release optimization is now reproducible rather than dependent on execution date.

## Architecture
The platform lane remains separate from fast main CI and has three bounded contracts:
- native portability: full library/integration tests on Linux, macOS, Windows;
- optimization sensitivity: core execution crates under release optimization;
- production browser artifact: stable Rust + wasm32, wasm-pack 0.15.0, Binaryen/wasm-opt 132, generated Python-worker assets, package validation, and Chromium replay.

The manifest fix does not loosen validation or special-case Windows. The producer owns its UTF-8 wire contract; the Rust consumer keeps strict UTF-8 decoding.

## Parallelism
The branch is one commit on current master. It does not touch active demo startup work (#491), renderer-worker diagnostics (#483), or retained-text implementation lanes.

Tracks #115.