### PR TITLE
Wire mixed retained authoring through execution workers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,9 @@ jobs:
       - name: Test engine/render worker transports
         run: node scripts/execution-worker-smoke.mjs
 
+      - name: Test mixed retained worker transports
+        run: node scripts/retained-execution-worker-smoke.mjs
+
       - name: Test slow Python callbacks do not block rendering
         run: node scripts/execution-worker-host-smoke.mjs
 

--- a/scripts/retained-execution-worker-smoke.mjs
+++ b/scripts/retained-execution-worker-smoke.mjs
@@ -1,0 +1,231 @@
+import assert from "node:assert/strict";
+import { createReadStream } from "node:fs";
+import { stat } from "node:fs/promises";
+import { createServer } from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import playwright from "playwright";
+
+const { chromium } = playwright;
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const port = Number(process.env.NOON_RETAINED_EXECUTION_WORKER_PORT ?? "4181");
+const baseUrl = `http://127.0.0.1:${port}`;
+
+const contentTypes = new Map([
+  [".html", "text/html; charset=utf-8"],
+  [".js", "text/javascript; charset=utf-8"],
+  [".mjs", "text/javascript; charset=utf-8"],
+  [".wasm", "application/wasm"],
+  [".json", "application/json; charset=utf-8"],
+]);
+
+const server = createServer(async (request, response) => {
+  try {
+    const url = new URL(request.url, baseUrl);
+    const relative = decodeURIComponent(url.pathname).replace(/^\/+/, "");
+    const resolved = path.resolve(repoRoot, relative || "web/execution-worker-smoke.html");
+    if (resolved !== repoRoot && !resolved.startsWith(`${repoRoot}${path.sep}`)) {
+      response.writeHead(403).end("forbidden");
+      return;
+    }
+    const info = await stat(resolved);
+    if (!info.isFile()) {
+      response.writeHead(404).end("not found");
+      return;
+    }
+    response.setHeader("Cross-Origin-Opener-Policy", "same-origin");
+    response.setHeader("Cross-Origin-Embedder-Policy", "require-corp");
+    response.setHeader("Cross-Origin-Resource-Policy", "same-origin");
+    response.setHeader("Cache-Control", "no-store");
+    response.setHeader(
+      "Content-Type",
+      contentTypes.get(path.extname(resolved)) ?? "application/octet-stream",
+    );
+    response.writeHead(200);
+    createReadStream(resolved).pipe(response);
+  } catch (error) {
+    response.writeHead(error?.code === "ENOENT" ? 404 : 500).end(String(error));
+  }
+});
+await new Promise((resolve, reject) => {
+  server.once("error", reject);
+  server.listen(port, "127.0.0.1", resolve);
+});
+
+const browserArgs = [
+  "--enable-unsafe-webgpu",
+  "--enable-unsafe-swiftshader",
+  "--use-webgpu-adapter=swiftshader",
+  "--use-gpu-in-tests",
+  "--ignore-gpu-blocklist",
+  "--enable-features=Vulkan",
+  "--use-gl=angle",
+  "--use-angle=swiftshader",
+  "--use-vulkan=swiftshader",
+  "--disable-gpu-sandbox",
+  "--disable-dev-shm-usage",
+];
+
+const textA = 4503599627370496;
+const textB = 4503599627370497;
+const retainedScene = JSON.stringify({
+  channel: "noon.authoring.retained",
+  protocol_version: 1,
+  objects: [
+    {
+      object: textA,
+      order: 1,
+      text: {
+        source: "*Hello* from _Typst!_",
+        math: false,
+        font_size: 64,
+        transform: {
+          translation: { x: 0, y: 1.1 },
+          scale: { x: 1, y: 1 },
+          rotation: 0,
+        },
+        color: { red: 1, green: 1, blue: 1, alpha: 1 },
+        opacity: 1,
+      },
+    },
+    {
+      object: textB,
+      order: 4,
+      text: {
+        source: "frac(x, 2)",
+        math: true,
+        font_size: 72,
+        transform: {
+          translation: { x: 0, y: -1.0 },
+          scale: { x: 1, y: 1 },
+          rotation: 0,
+        },
+        color: { red: 1, green: 0.8, blue: 0.2, alpha: 1 },
+        opacity: 0.9,
+      },
+    },
+  ],
+});
+
+async function runMode(browser, transportMode) {
+  const page = await browser.newPage({ viewport: { width: 800, height: 500 } });
+  const browserErrors = [];
+  page.on("pageerror", (error) => browserErrors.push(`pageerror: ${error}`));
+  page.on("console", (message) => {
+    if (message.type() === "error") {
+      browserErrors.push(`console: ${message.text()}`);
+    }
+  });
+  await page.goto(`${baseUrl}/web/execution-worker-smoke.html`, { waitUntil: "load" });
+
+  const started = await page.evaluate(async ({ mode, retainedDocumentJson }) => {
+    const wasm = await import("./pkg/noon_web.js");
+    await wasm.default();
+    const { RetainedExecutionWorkerClient } = await import(
+      "./retained-execution-worker-client.js"
+    );
+    const canvas = document.querySelector("#scene");
+    const errors = [];
+    const client = new RetainedExecutionWorkerClient(canvas, {
+      onError(error, owner) {
+        errors.push(`${owner}: ${error}`);
+      },
+    });
+    window.retainedExecutionSmoke = { client, errors };
+    const sceneJson = wasm.demoSceneJson();
+    const ready = await client.start(sceneJson, retainedDocumentJson, {
+      loopDurationSeconds: 4,
+      transportMode: mode,
+      sharedSlotCapacity: 1024 * 1024,
+    });
+    return {
+      ready,
+      legacyObjectCount: JSON.parse(sceneJson).objects.length,
+      crossOriginIsolated: window.crossOriginIsolated,
+      hasSharedArrayBuffer: typeof SharedArrayBuffer === "function",
+    };
+  }, { mode: transportMode, retainedDocumentJson: retainedScene });
+
+  assert.equal(started.crossOriginIsolated, true);
+  assert.equal(started.hasSharedArrayBuffer, true);
+  assert.equal(started.legacyObjectCount, 4);
+  assert.equal(started.ready.transportMode, transportMode);
+  assert.equal(started.ready.engine.retained, true);
+  assert.equal(started.ready.engine.mixed, true);
+  assert.equal(started.ready.render.retained, true);
+  assert.equal(started.ready.render.mixed, true);
+  assert.match(started.ready.render.backend, /WebGPU|WebGL2/);
+
+  await page.waitForTimeout(450);
+  const before = await page.evaluate(() => window.retainedExecutionSmoke.client.metrics());
+  assert.equal(before.metrics.ready, true);
+  assert.equal(before.metrics.retained, true);
+  assert.equal(before.metrics.mixed, true);
+  assert.equal(before.metrics.objectCount, 6);
+  assert.ok(before.metrics.presentedFrames >= 1, `${transportMode}: mixed retained frame was not presented`);
+  assert.ok(before.metrics.drawCalls > 0, `${transportMode}: mixed retained scene produced no draw calls`);
+  assert.ok(before.metrics.instancesDrawn > 0, `${transportMode}: mixed retained scene produced no instances`);
+  assert.ok(before.metrics.bytesUploaded > 0, `${transportMode}: mixed retained scene uploaded no GPU data`);
+  assert.equal(before.engineMetrics.retained, true);
+  assert.equal(before.engineMetrics.mixed, true);
+  assert.equal(before.engineMetrics.resourceBundleTransfers, 1);
+  assert.ok(before.engineMetrics.resourceBundleBytes > 0);
+  assert.ok(before.engineMetrics.time > 0, `${transportMode}: mixed retained engine playhead did not advance`);
+
+  const state = await page.evaluate(() => window.retainedExecutionSmoke.client.state());
+  const legacyDocument = JSON.parse(state.sceneJson);
+  const retainedDocument = JSON.parse(state.retainedDocumentJson);
+  assert.equal(legacyDocument.objects.length, 4);
+  assert.equal(retainedDocument.channel, "noon.authoring.retained");
+  assert.deepEqual(retainedDocument.objects.map((object) => object.object), [textA, textB]);
+  assert.deepEqual(retainedDocument.objects.map((object) => object.order), [1, 4]);
+  assert.equal(state.nextPatchSequence, "0");
+
+  const retimed = await page.evaluate(() =>
+    window.retainedExecutionSmoke.client.setLoopDurationSeconds(0.9),
+  );
+  assert.equal(retimed.nextPatchSequence, "0");
+  await page.waitForTimeout(1050);
+  const afterRetime = await page.evaluate(() => window.retainedExecutionSmoke.client.metrics());
+  assert.ok(afterRetime.engineMetrics.time >= 0 && afterRetime.engineMetrics.time < 0.9);
+  assert.equal(afterRetime.engineMetrics.resourceBundleTransfers, 1);
+  assert.equal(afterRetime.metrics.objectCount, 6);
+
+  const restarted = await page.evaluate(() => window.retainedExecutionSmoke.client.restart());
+  assert.equal(restarted.session, 2);
+  assert.equal(restarted.transportMode, transportMode);
+  assert.equal(restarted.render.retained, true);
+  assert.equal(restarted.render.mixed, true);
+  await page.waitForTimeout(350);
+  const afterRestart = await page.evaluate(() => window.retainedExecutionSmoke.client.metrics());
+  assert.equal(afterRestart.metrics.ready, true);
+  assert.equal(afterRestart.metrics.objectCount, 6);
+  assert.equal(afterRestart.engineMetrics.resourceBundleTransfers, 1);
+  assert.ok(afterRestart.engineMetrics.resourceBundleBytes > 0);
+
+  const clientErrors = await page.evaluate(() => window.retainedExecutionSmoke.errors.slice());
+  assert.deepEqual(clientErrors, []);
+  assert.deepEqual(browserErrors, []);
+  await page.evaluate(() => window.retainedExecutionSmoke.client.terminate());
+  await page.close();
+  console.log(
+    `✓ mixed retained execution workers ${transportMode}: ${before.metrics.backend}, ` +
+      `${before.engineMetrics.resourceBundleBytes} resource bytes`,
+  );
+}
+
+let browser = null;
+try {
+  browser = await chromium.launch({
+    channel: "chromium",
+    headless: true,
+    args: browserArgs,
+  });
+  await runMode(browser, "transferable");
+  await runMode(browser, "shared");
+} finally {
+  await browser?.close();
+  await new Promise((resolve) => server.close(resolve));
+}

--- a/web/execution-transport.js
+++ b/web/execution-transport.js
@@ -1,8 +1,13 @@
 export const EXECUTION_TRANSPORT_CHANNEL = "noon.execution";
+export const RETAINED_EXECUTION_TRANSPORT_CHANNEL = "noon.execution.retained";
 export const EXECUTION_TRANSPORT_VERSION = 1;
 export const EXECUTION_TRANSPORT_SHARED = "shared";
 export const EXECUTION_TRANSPORT_TRANSFERABLE = "transferable";
 
+const EXECUTION_TRANSPORT_CHANNELS = new Set([
+  EXECUTION_TRANSPORT_CHANNEL,
+  RETAINED_EXECUTION_TRANSPORT_CHANNEL,
+]);
 const SLOT_FREE = 0;
 const SLOT_WRITING = 1;
 const SLOT_READY = 2;
@@ -33,7 +38,7 @@ export function executionDeltaMetadata(json) {
   } catch (error) {
     throw new Error(`execution delta is invalid JSON: ${error.message}`);
   }
-  if (!isRecord(delta) || delta.channel !== EXECUTION_TRANSPORT_CHANNEL) {
+  if (!isRecord(delta) || !EXECUTION_TRANSPORT_CHANNELS.has(delta.channel)) {
     throw new Error("execution delta has an invalid channel");
   }
   if (delta.protocol_version !== EXECUTION_TRANSPORT_VERSION) {

--- a/web/execution-transport.test.mjs
+++ b/web/execution-transport.test.mjs
@@ -5,6 +5,7 @@ import test from "node:test";
 import {
   EXECUTION_TRANSPORT_SHARED,
   EXECUTION_TRANSPORT_TRANSFERABLE,
+  RETAINED_EXECUTION_TRANSPORT_CHANNEL,
   SharedExecutionDeltaReader,
   SharedExecutionDeltaWriter,
   TransferableExecutionDeltaReceiver,
@@ -15,9 +16,9 @@ import {
   selectExecutionTransportMode,
 } from "./execution-transport.js";
 
-function delta(sequence, { session = 1, snapshot = sequence === 0 } = {}) {
+function delta(sequence, { session = 1, snapshot = sequence === 0, channel = "noon.execution" } = {}) {
   return JSON.stringify({
-    channel: "noon.execution",
+    channel,
     protocol_version: 1,
     session,
     sequence,
@@ -76,6 +77,23 @@ test("shared two-slot mailbox retains ownership until consumer accepts", () => {
   assert.equal(writer.send(delta(2, { snapshot: false })), true);
   reader.drain(apply);
   assert.deepEqual(received, [0, 1, 2]);
+});
+
+test("shared transport also carries retained execution framing", () => {
+  const mailbox = createSharedExecutionMailbox(4096);
+  const writer = new SharedExecutionDeltaWriter(mailbox);
+  const reader = new SharedExecutionDeltaReader(mailbox);
+  const retained = delta(0, { channel: RETAINED_EXECUTION_TRANSPORT_CHANNEL });
+  assert.equal(writer.send(retained), true);
+  const received = [];
+  assert.equal(
+    reader.drain((json) => {
+      received.push(JSON.parse(json).channel);
+      return true;
+    }),
+    1,
+  );
+  assert.deepEqual(received, [RETAINED_EXECUTION_TRANSPORT_CHANNEL]);
 });
 
 test("transferable mailbox defers ack until consumer accepts", async () => {
@@ -137,6 +155,23 @@ test("transferable envelope metadata must match encoded payload", () => {
     { session: 1, sequence: 0, snapshot: true },
   );
 
+  const retainedPayload = new TextEncoder().encode(
+    delta(0, { channel: RETAINED_EXECUTION_TRANSPORT_CHANNEL }),
+  );
+  const retainedBuffer = retainedPayload.buffer.slice(
+    retainedPayload.byteOffset,
+    retainedPayload.byteOffset + retainedPayload.byteLength,
+  );
+  assert.deepEqual(
+    decodeTransferableExecutionDelta({
+      type: "execution_delta",
+      session: 1,
+      sequence: 0,
+      buffer: retainedBuffer,
+    }).metadata,
+    { session: 1, sequence: 0, snapshot: true },
+  );
+
   const mismatchPayload = new TextEncoder().encode(delta(0));
   const mismatchBuffer = mismatchPayload.buffer.slice(
     mismatchPayload.byteOffset,
@@ -154,7 +189,19 @@ test("transferable envelope metadata must match encoded payload", () => {
   );
 });
 
-test("metadata rejects future protocols and unsafe sequence values", () => {
+test("metadata accepts only known execution channels and rejects future protocols", () => {
+  assert.equal(
+    executionDeltaMetadata(delta(0, { channel: RETAINED_EXECUTION_TRANSPORT_CHANNEL })).sequence,
+    0,
+  );
+
+  const unrelated = JSON.parse(delta(0));
+  unrelated.channel = "noon.execution.unrelated";
+  assert.throws(
+    () => executionDeltaMetadata(JSON.stringify(unrelated)),
+    /invalid channel/,
+  );
+
   const future = JSON.parse(delta(0));
   future.protocol_version = 2;
   assert.throws(

--- a/web/retained-execution-engine-worker.js
+++ b/web/retained-execution-engine-worker.js
@@ -1,0 +1,273 @@
+import init, { MixedRetainedEngineScenePlayer } from "./pkg/noon_web.js";
+import {
+  EXECUTION_TRANSPORT_SHARED,
+  EXECUTION_TRANSPORT_TRANSFERABLE,
+  SharedExecutionDeltaWriter,
+  TransferableExecutionDeltaSender,
+  createSharedExecutionMailbox,
+} from "./execution-transport.js";
+
+const ENGINE_CHANNEL = "noon.engine";
+const ENGINE_PROTOCOL_VERSION = 1;
+
+let renderPort = null;
+let transportMode = null;
+let transport = null;
+let player = null;
+let latestTick = null;
+let initialized = false;
+let stopped = false;
+let resourceBundleBytes = 0;
+
+self.addEventListener("message", (event) => {
+  void handleMainMessage(event.data);
+});
+
+async function handleMainMessage(message) {
+  try {
+    validateMainMessage(message);
+    switch (message.type) {
+      case "init":
+        await initialize(message);
+        return;
+      case "set_loop_duration":
+        requireInitialized();
+        validateLoopDuration(message.loopDurationSeconds);
+        player.setLoopDurationSeconds(message.loopDurationSeconds);
+        respond(message.requestId, runtimeResult("set_loop_duration"));
+        return;
+      case "state":
+        requireInitialized();
+        respond(message.requestId, {
+          type: "state",
+          time: player.time(),
+          nextPatchSequence: "0",
+          sceneJson: player.legacySceneJson(),
+          retainedDocumentJson: player.retainedDocumentJson(),
+        });
+        return;
+      case "metrics":
+        requireInitialized();
+        respond(message.requestId, {
+          type: "metrics",
+          metrics: {
+            retained: true,
+            mixed: true,
+            time: player.time(),
+            resourceBundleBytes,
+            resourceBundleTransfers: 1,
+          },
+        });
+        return;
+      case "replace_scene":
+      case "reconcile_scene":
+      case "apply_patch":
+      case "configure_callbacks":
+      case "attach_host_port":
+        throw new Error(
+          `${message.type} is not supported by mixed retained execution yet; rebuild the scene instead`,
+        );
+      case "stop":
+        stopped = true;
+        latestTick = null;
+        renderPort?.close?.();
+        self.close();
+        return;
+      default:
+        throw new Error(`unknown mixed retained engine command ${message.type}`);
+    }
+  } catch (error) {
+    fail(error, message?.requestId ?? null);
+  }
+}
+
+async function initialize(message) {
+  if (initialized) {
+    throw new Error("mixed retained execution engine worker is already initialized");
+  }
+  if (!(message.port instanceof MessagePort)) {
+    throw new Error("mixed retained execution engine init requires a render MessagePort");
+  }
+  if (typeof message.sceneJson !== "string" || message.sceneJson.trim() === "") {
+    throw new Error("mixed retained execution engine init requires legacy scene JSON");
+  }
+  if (
+    typeof message.retainedDocumentJson !== "string" ||
+    message.retainedDocumentJson.trim() === ""
+  ) {
+    throw new Error("mixed retained execution engine init requires retained document JSON");
+  }
+  validateLoopDuration(message.loopDurationSeconds);
+  if (!Number.isSafeInteger(message.session) || message.session < 0) {
+    throw new Error("mixed retained execution session must be a non-negative safe integer");
+  }
+  if (
+    message.transportMode !== EXECUTION_TRANSPORT_SHARED &&
+    message.transportMode !== EXECUTION_TRANSPORT_TRANSFERABLE
+  ) {
+    throw new Error(`unsupported mixed retained execution transport mode ${message.transportMode}`);
+  }
+
+  renderPort = message.port;
+  renderPort.addEventListener("message", (event) => handleRenderMessage(event.data));
+  renderPort.start();
+  transportMode = message.transportMode;
+  await init();
+  player = new MixedRetainedEngineScenePlayer(
+    message.sceneJson,
+    message.retainedDocumentJson,
+    message.loopDurationSeconds,
+    message.session,
+  );
+
+  // wasm-bindgen returns a view/copy for Vec<u8>; make an independently owned
+  // transferable buffer so detaching it cannot affect WebAssembly memory.
+  const resources = Uint8Array.from(player.resourceBundleBytes());
+  resourceBundleBytes = resources.byteLength;
+  renderPort.postMessage(
+    { type: "retained_resources", bytes: resources },
+    [resources.buffer],
+  );
+
+  if (transportMode === EXECUTION_TRANSPORT_SHARED) {
+    const mailbox = createSharedExecutionMailbox(message.sharedSlotCapacity ?? 1024 * 1024);
+    transport = new SharedExecutionDeltaWriter(mailbox);
+    renderPort.postMessage({
+      type: "transport_setup",
+      mode: EXECUTION_TRANSPORT_SHARED,
+      mailbox,
+    });
+  } else {
+    transport = new TransferableExecutionDeltaSender(renderPort, {
+      maxInFlight: 2,
+      onWritable: drainWork,
+    });
+  }
+
+  sendDeltaOrThrow(player.initialDeltaJson());
+  initialized = true;
+  postMain({ type: "ready", transportMode, retained: true, mixed: true });
+  drainWork();
+}
+
+function handleRenderMessage(message) {
+  if (!message || typeof message !== "object") {
+    return;
+  }
+  if (message.type === "tick") {
+    if (!Number.isFinite(message.timestamp)) {
+      fail(new Error("render worker sent a non-finite frame timestamp"), null);
+      return;
+    }
+    latestTick = message.timestamp;
+    drainWork();
+    return;
+  }
+  if (message.type === "transport_writable") {
+    drainWork();
+    return;
+  }
+  if (message.type === "render_error") {
+    fail(new Error(`mixed retained render worker failed: ${message.message}`), null);
+  }
+}
+
+function drainWork() {
+  if (!initialized || stopped || player === null || transport === null) {
+    return;
+  }
+  if (latestTick === null || !transportCanSend()) {
+    return;
+  }
+  const timestamp = latestTick;
+  latestTick = null;
+  try {
+    const delta = player.tickDeltaJson(timestamp);
+    if (delta !== undefined && delta !== null) {
+      sendDeltaOrThrow(delta);
+    }
+  } catch (error) {
+    fail(error, null);
+  }
+}
+
+function transportCanSend() {
+  if (transport === null) {
+    return false;
+  }
+  if (typeof transport.canSend === "function") {
+    return transport.canSend();
+  }
+  if (typeof transport.inFlight === "function") {
+    return transport.inFlight() < 2;
+  }
+  return true;
+}
+
+function sendDeltaOrThrow(json) {
+  if (json === undefined || json === null) {
+    return;
+  }
+  if (!transport.send(json)) {
+    throw new Error("mixed retained execution transport became backpressured after work was admitted");
+  }
+  if (transportMode === EXECUTION_TRANSPORT_SHARED) {
+    renderPort.postMessage({ type: "shared_delta" });
+  }
+}
+
+function runtimeResult(operation) {
+  return {
+    type: "result",
+    operation,
+    time: player.time(),
+    nextPatchSequence: "0",
+    sceneJson: player.legacySceneJson(),
+    retainedDocumentJson: player.retainedDocumentJson(),
+  };
+}
+
+function respond(requestId, payload) {
+  if (!Number.isSafeInteger(requestId) || requestId < 0) {
+    throw new Error("mixed retained engine request ID must be a non-negative safe integer");
+  }
+  postMain({ requestId, ...payload });
+}
+
+function fail(error, requestId) {
+  stopped = true;
+  const message = String(error?.message ?? error);
+  renderPort?.postMessage({ type: "render_error", message });
+  postMain({ type: "error", requestId, message });
+}
+
+function postMain(payload) {
+  self.postMessage({
+    channel: ENGINE_CHANNEL,
+    protocolVersion: ENGINE_PROTOCOL_VERSION,
+    ...payload,
+  });
+}
+
+function validateMainMessage(message) {
+  if (
+    !message ||
+    typeof message !== "object" ||
+    message.channel !== ENGINE_CHANNEL ||
+    message.protocolVersion !== ENGINE_PROTOCOL_VERSION
+  ) {
+    throw new Error("invalid mixed retained execution engine control envelope");
+  }
+}
+
+function validateLoopDuration(duration) {
+  if (!Number.isFinite(duration) || duration <= 0) {
+    throw new Error("mixed retained execution loop duration must be positive and finite");
+  }
+}
+
+function requireInitialized() {
+  if (!initialized || player === null) {
+    throw new Error("mixed retained execution engine worker is not initialized");
+  }
+}

--- a/web/retained-execution-render-worker.js
+++ b/web/retained-execution-render-worker.js
@@ -1,0 +1,334 @@
+import init, { RetainedExecutionCanvasRenderer } from "./pkg/noon_web.js";
+import {
+  EXECUTION_TRANSPORT_SHARED,
+  EXECUTION_TRANSPORT_TRANSFERABLE,
+  SharedExecutionDeltaReader,
+  TransferableExecutionDeltaReceiver,
+} from "./execution-transport.js";
+
+const RENDER_CHANNEL = "noon.render";
+const RENDER_PROTOCOL_VERSION = 1;
+const BOOTSTRAP_QUEUE_LIMIT = 1;
+
+let renderPort = null;
+let transportMode = null;
+let sharedReader = null;
+let transferableReceiver = null;
+let renderer = null;
+let resourceBytes = null;
+let canvas = null;
+let width = 1;
+let height = 1;
+let bootstrapQueue = [];
+let bootstrapPromise = null;
+let needsPresent = false;
+let running = false;
+let lastFrameTimestamp = null;
+let presentedFrames = 0;
+
+self.addEventListener("message", (event) => {
+  void handleMainMessage(event.data);
+});
+
+async function handleMainMessage(message) {
+  try {
+    validateMainMessage(message);
+    switch (message.type) {
+      case "init":
+        await initialize(message);
+        return;
+      case "resize":
+        width = normalizedDimension(message.width);
+        height = normalizedDimension(message.height);
+        if (renderer !== null) {
+          renderer.resize(width, height);
+          needsPresent = true;
+          tryPresent();
+        }
+        return;
+      case "metrics":
+        respond(message.requestId, { type: "metrics", metrics: currentMetrics() });
+        return;
+      case "stop":
+        running = false;
+        bootstrapQueue = [];
+        renderPort?.close?.();
+        self.close();
+        return;
+      default:
+        throw new Error(`unknown mixed retained render command ${message.type}`);
+    }
+  } catch (error) {
+    fail(error, message?.requestId ?? null);
+  }
+}
+
+async function initialize(message) {
+  if (renderPort !== null) {
+    throw new Error("mixed retained execution render worker is already initialized");
+  }
+  if (!(message.port instanceof MessagePort)) {
+    throw new Error("mixed retained execution render init requires an engine MessagePort");
+  }
+  if (!(message.canvas instanceof OffscreenCanvas)) {
+    throw new Error("mixed retained execution render init requires an OffscreenCanvas");
+  }
+  if (
+    message.transportMode !== EXECUTION_TRANSPORT_SHARED &&
+    message.transportMode !== EXECUTION_TRANSPORT_TRANSFERABLE
+  ) {
+    throw new Error(`unsupported mixed retained execution transport mode ${message.transportMode}`);
+  }
+
+  canvas = message.canvas;
+  width = normalizedDimension(message.width ?? canvas.width);
+  height = normalizedDimension(message.height ?? canvas.height);
+  transportMode = message.transportMode;
+  renderPort = message.port;
+  await init();
+
+  renderPort.addEventListener("message", (event) => handleEngineMessage(event.data));
+  if (transportMode === EXECUTION_TRANSPORT_TRANSFERABLE) {
+    transferableReceiver = new TransferableExecutionDeltaReceiver(
+      renderPort,
+      (json) => consumeDelta(json),
+    );
+  }
+  renderPort.start();
+}
+
+function handleEngineMessage(message) {
+  if (!message || typeof message !== "object") {
+    return;
+  }
+  if (message.type === "retained_resources") {
+    try {
+      if (resourceBytes !== null || renderer !== null || bootstrapPromise !== null) {
+        throw new Error("retained resource bundle may be installed only once before the snapshot");
+      }
+      if (!(message.bytes instanceof Uint8Array) || message.bytes.byteLength === 0) {
+        throw new Error("retained resource bundle must be a non-empty Uint8Array");
+      }
+      resourceBytes = message.bytes;
+    } catch (error) {
+      fail(error, null);
+    }
+    return;
+  }
+  if (message.type === "transport_setup") {
+    if (transportMode !== EXECUTION_TRANSPORT_SHARED || message.mode !== transportMode) {
+      fail(new Error("mixed retained render worker received an unexpected shared transport setup"), null);
+      return;
+    }
+    try {
+      sharedReader = new SharedExecutionDeltaReader(message.mailbox);
+      drainTransport();
+    } catch (error) {
+      fail(error, null);
+    }
+    return;
+  }
+  if (message.type === "shared_delta") {
+    drainTransport();
+  }
+}
+
+function drainTransport() {
+  try {
+    if (sharedReader !== null) {
+      const drained = sharedReader.drain((json) => consumeDelta(json));
+      if (drained > 0) {
+        renderPort.postMessage({ type: "transport_writable" });
+      }
+    }
+    transferableReceiver?.drain();
+  } catch (error) {
+    fail(error, null);
+  }
+}
+
+function consumeDelta(json) {
+  if (renderer === null) {
+    if (resourceBytes === null) {
+      throw new Error("mixed retained execution snapshot arrived before its resource bundle");
+    }
+    if (bootstrapPromise === null) {
+      bootstrapPromise = bootstrapRenderer(json);
+      return true;
+    }
+    if (bootstrapQueue.length >= BOOTSTRAP_QUEUE_LIMIT) {
+      return false;
+    }
+    bootstrapQueue.push(json);
+    return true;
+  }
+
+  if (needsPresent) {
+    return false;
+  }
+  const applied = renderer.applyDeltaJson(json);
+  if (!applied) {
+    return true;
+  }
+  needsPresent = true;
+  tryPresent();
+  return true;
+}
+
+async function bootstrapRenderer(initial) {
+  try {
+    renderer = await RetainedExecutionCanvasRenderer.create(canvas, resourceBytes);
+    resourceBytes = null;
+    const applied = renderer.applyDeltaJson(initial);
+    if (!applied) {
+      throw new Error("mixed retained execution renderer must begin from an applied snapshot");
+    }
+    renderer.resize(width, height);
+    needsPresent = true;
+    tryPresent();
+    running = true;
+    postMain({
+      type: "ready",
+      transportMode,
+      retained: true,
+      mixed: true,
+      backend: renderer.rendererBackend(),
+    });
+    flushBootstrapQueue();
+    drainTransport();
+    scheduleFrame();
+  } catch (error) {
+    fail(error, null);
+  }
+}
+
+function tryPresent() {
+  if (renderer === null || !needsPresent) {
+    return false;
+  }
+  if (!renderer.render()) {
+    return false;
+  }
+  needsPresent = false;
+  presentedFrames += 1;
+  return true;
+}
+
+function flushBootstrapQueue() {
+  if (renderer === null) {
+    return;
+  }
+  while (!needsPresent && bootstrapQueue.length > 0) {
+    const json = bootstrapQueue.shift();
+    const applied = renderer.applyDeltaJson(json);
+    if (!applied) {
+      continue;
+    }
+    needsPresent = true;
+    if (!tryPresent()) {
+      break;
+    }
+  }
+}
+
+function scheduleFrame() {
+  if (!running) {
+    return;
+  }
+  if (typeof self.requestAnimationFrame === "function") {
+    self.requestAnimationFrame(frame);
+  } else {
+    setTimeout(() => frame(performance.now()), 16);
+  }
+}
+
+function frame(timestamp) {
+  if (!running) {
+    return;
+  }
+  lastFrameTimestamp = timestamp;
+  if (needsPresent && tryPresent()) {
+    flushBootstrapQueue();
+  }
+  drainTransport();
+  if (!needsPresent) {
+    flushBootstrapQueue();
+    drainTransport();
+  }
+  renderPort.postMessage({ type: "tick", timestamp });
+  scheduleFrame();
+}
+
+function currentMetrics() {
+  if (renderer === null) {
+    return {
+      ready: false,
+      retained: true,
+      mixed: true,
+      presentedFrames,
+      lastFrameTimestamp,
+      bufferedDeltas: bootstrapQueue.length + (transferableReceiver?.pendingCount() ?? 0),
+      needsPresent,
+      resourceBundlePending: resourceBytes !== null,
+    };
+  }
+  return {
+    ready: true,
+    retained: true,
+    mixed: true,
+    transportMode,
+    backend: renderer.rendererBackend(),
+    time: renderer.time(),
+    objectCount: renderer.objectCount(),
+    drawCalls: renderer.lastDrawCalls(),
+    instancesDrawn: renderer.lastInstancesDrawn(),
+    bytesUploaded: renderer.lastBytesUploaded(),
+    geometryCacheMisses: renderer.lastGeometryCacheMisses(),
+    outlineCacheMisses: renderer.lastOutlineCacheMisses(),
+    presentedFrames,
+    lastFrameTimestamp,
+    bufferedDeltas: bootstrapQueue.length + (transferableReceiver?.pendingCount() ?? 0),
+    needsPresent,
+    resourceBundlePending: false,
+  };
+}
+
+function respond(requestId, payload) {
+  if (!Number.isSafeInteger(requestId) || requestId < 0) {
+    throw new Error("mixed retained render request ID must be a non-negative safe integer");
+  }
+  postMain({ requestId, ...payload });
+}
+
+function fail(error, requestId) {
+  running = false;
+  const message = String(error?.message ?? error);
+  renderPort?.postMessage({ type: "render_error", message });
+  postMain({ type: "error", requestId, message });
+}
+
+function postMain(payload) {
+  self.postMessage({
+    channel: RENDER_CHANNEL,
+    protocolVersion: RENDER_PROTOCOL_VERSION,
+    ...payload,
+  });
+}
+
+function validateMainMessage(message) {
+  if (
+    !message ||
+    typeof message !== "object" ||
+    message.channel !== RENDER_CHANNEL ||
+    message.protocolVersion !== RENDER_PROTOCOL_VERSION
+  ) {
+    throw new Error("invalid mixed retained execution render control envelope");
+  }
+}
+
+function normalizedDimension(value) {
+  if (!Number.isFinite(value)) {
+    throw new Error(`invalid mixed retained render surface dimension ${value}`);
+  }
+  return Math.max(1, Math.round(value));
+}

--- a/web/retained-execution-worker-client.js
+++ b/web/retained-execution-worker-client.js
@@ -1,0 +1,377 @@
+import {
+  EXECUTION_TRANSPORT_SHARED,
+  EXECUTION_TRANSPORT_TRANSFERABLE,
+  selectExecutionTransportMode,
+} from "./execution-transport.js";
+
+const ENGINE_CHANNEL = "noon.engine";
+const ENGINE_PROTOCOL_VERSION = 1;
+const RENDER_CHANNEL = "noon.render";
+const RENDER_PROTOCOL_VERSION = 1;
+const RETAINED_AUTHORING_CHANNEL = "noon.authoring.retained";
+
+export class RetainedExecutionWorkerClient {
+  #canvas;
+  #engineWorker = null;
+  #renderWorker = null;
+  #nextRequestId = 0;
+  #pending = new Map();
+  #session = 0;
+  #sceneJson = null;
+  #retainedDocumentJson = null;
+  #loopDurationSeconds = 4;
+  #transportMode = null;
+  #ready = null;
+  #onError;
+
+  constructor(canvas, { onError = null } = {}) {
+    if (!(canvas instanceof HTMLCanvasElement)) {
+      throw new TypeError("RetainedExecutionWorkerClient requires an HTMLCanvasElement");
+    }
+    if (onError !== null && typeof onError !== "function") {
+      throw new TypeError("RetainedExecutionWorkerClient onError must be a function");
+    }
+    this.#canvas = canvas;
+    this.#onError = onError;
+  }
+
+  get canvas() {
+    return this.#canvas;
+  }
+
+  get transportMode() {
+    return this.#transportMode;
+  }
+
+  async start(
+    sceneJson,
+    retainedDocumentJson,
+    {
+      loopDurationSeconds = 4,
+      transportMode = selectExecutionTransportMode(),
+      sharedSlotCapacity = 1024 * 1024,
+    } = {},
+  ) {
+    if (this.#engineWorker !== null || this.#renderWorker !== null) {
+      throw new Error("RetainedExecutionWorkerClient is already started");
+    }
+    validateLegacySceneJson(sceneJson);
+    validateRetainedDocumentJson(retainedDocumentJson);
+    validateLoopDurationSeconds(loopDurationSeconds);
+    if (
+      transportMode !== EXECUTION_TRANSPORT_SHARED &&
+      transportMode !== EXECUTION_TRANSPORT_TRANSFERABLE
+    ) {
+      throw new TypeError(`unsupported mixed retained execution transport mode ${transportMode}`);
+    }
+    if (
+      transportMode === EXECUTION_TRANSPORT_SHARED &&
+      selectExecutionTransportMode() !== EXECUTION_TRANSPORT_SHARED
+    ) {
+      throw new Error("shared mixed retained execution transport requires cross-origin isolation");
+    }
+    if (typeof this.#canvas.transferControlToOffscreen !== "function") {
+      throw new Error("OffscreenCanvas transfer is unavailable in this browser");
+    }
+
+    this.#sceneJson = sceneJson;
+    this.#retainedDocumentJson = retainedDocumentJson;
+    this.#loopDurationSeconds = loopDurationSeconds;
+    this.#transportMode = transportMode;
+    this.#session = checkedNext(this.#session, "mixed retained execution session");
+
+    const devicePixelRatio = window.devicePixelRatio || 1;
+    const initialWidth = Math.max(1, Math.round(this.#canvas.clientWidth * devicePixelRatio));
+    const initialHeight = Math.max(1, Math.round(this.#canvas.clientHeight * devicePixelRatio));
+    this.#canvas.width = initialWidth;
+    this.#canvas.height = initialHeight;
+
+    const channel = new MessageChannel();
+    const offscreen = this.#canvas.transferControlToOffscreen();
+    this.#engineWorker = new Worker(
+      new URL("./retained-execution-engine-worker.js", import.meta.url),
+      { type: "module", name: "noon-mixed-retained-engine" },
+    );
+    this.#renderWorker = new Worker(
+      new URL("./retained-execution-render-worker.js", import.meta.url),
+      { type: "module", name: "noon-mixed-retained-render" },
+    );
+
+    const engineReady = this.#workerReady(this.#engineWorker, ENGINE_CHANNEL, "engine");
+    const renderReady = this.#workerReady(this.#renderWorker, RENDER_CHANNEL, "render");
+    this.#ready = Promise.all([engineReady, renderReady]).then(([engine, render]) => ({
+      engine,
+      render,
+      transportMode,
+      session: this.#session,
+    }));
+
+    this.#renderWorker.postMessage(
+      renderEnvelope("init", {
+        canvas: offscreen,
+        port: channel.port2,
+        transportMode,
+        width: initialWidth,
+        height: initialHeight,
+      }),
+      [offscreen, channel.port2],
+    );
+    this.#engineWorker.postMessage(
+      engineEnvelope("init", {
+        port: channel.port1,
+        sceneJson,
+        retainedDocumentJson,
+        loopDurationSeconds,
+        transportMode,
+        sharedSlotCapacity,
+        session: this.#session,
+      }),
+      [channel.port1],
+    );
+    return this.#ready;
+  }
+
+  ready() {
+    if (this.#ready === null) {
+      throw new Error("RetainedExecutionWorkerClient has not been started");
+    }
+    return this.#ready;
+  }
+
+  async state() {
+    return this.#requestEngine("state", {});
+  }
+
+  async metrics() {
+    const [render, engine] = await Promise.all([
+      this.#requestRender("metrics", {}),
+      this.#requestEngine("metrics", {}),
+    ]);
+    return { ...render, engineMetrics: engine.metrics };
+  }
+
+  async setLoopDurationSeconds(loopDurationSeconds) {
+    const duration = validateLoopDurationSeconds(loopDurationSeconds);
+    const result = await this.#requestEngine("set_loop_duration", {
+      loopDurationSeconds: duration,
+    });
+    this.#loopDurationSeconds = duration;
+    return result;
+  }
+
+  resize(width, height, devicePixelRatio = 1) {
+    this.#requireStarted();
+    if (!Number.isFinite(width) || !Number.isFinite(height) || !Number.isFinite(devicePixelRatio)) {
+      throw new TypeError("mixed retained execution canvas dimensions must be finite");
+    }
+    const physicalWidth = Math.max(1, Math.round(width * devicePixelRatio));
+    const physicalHeight = Math.max(1, Math.round(height * devicePixelRatio));
+    this.#renderWorker.postMessage(
+      renderEnvelope("resize", { width: physicalWidth, height: physicalHeight }),
+    );
+  }
+
+  async restart() {
+    this.#requireStarted();
+    const sceneJson = this.#sceneJson;
+    const retainedDocumentJson = this.#retainedDocumentJson;
+    const loopDurationSeconds = this.#loopDurationSeconds;
+    const transportMode = this.#transportMode;
+    this.terminate();
+
+    const previous = this.#canvas;
+    const replacement = previous.cloneNode(false);
+    replacement.width = previous.width;
+    replacement.height = previous.height;
+    replacement.className = previous.className;
+    replacement.id = previous.id;
+    previous.replaceWith(replacement);
+    this.#canvas = replacement;
+    return this.start(sceneJson, retainedDocumentJson, {
+      loopDurationSeconds,
+      transportMode,
+    });
+  }
+
+  terminate() {
+    this.#engineWorker?.terminate();
+    this.#renderWorker?.terminate();
+    this.#engineWorker = null;
+    this.#renderWorker = null;
+    this.#ready = null;
+    const error = new Error("mixed retained execution worker client terminated");
+    for (const pending of this.#pending.values()) {
+      pending.reject(error);
+    }
+    this.#pending.clear();
+  }
+
+  async #requestEngine(type, payload) {
+    await this.ready();
+    return this.#request(this.#engineWorker, "engine", engineEnvelope, type, payload);
+  }
+
+  async #requestRender(type, payload) {
+    await this.ready();
+    return this.#request(this.#renderWorker, "render", renderEnvelope, type, payload);
+  }
+
+  #request(worker, owner, envelopeFactory, type, payload) {
+    const requestId = this.#nextRequestId;
+    this.#nextRequestId = checkedNext(this.#nextRequestId, "mixed retained worker request ID");
+    const result = new Promise((resolve, reject) => {
+      this.#pending.set(`${owner}:${requestId}`, { resolve, reject });
+    });
+    worker.postMessage(envelopeFactory(type, { requestId, ...payload }));
+    return result;
+  }
+
+  #workerReady(worker, channel, owner) {
+    return new Promise((resolve, reject) => {
+      worker.addEventListener("message", (event) => {
+        const message = event.data;
+        try {
+          validateWorkerEnvelope(message, channel);
+          if (message.type === "ready") {
+            resolve(message);
+            return;
+          }
+          if (message.type === "error") {
+            const error = new Error(message.message || `${owner} mixed retained worker failed`);
+            if (message.requestId === null || message.requestId === undefined) {
+              reject(error);
+              this.#onError?.(error, owner);
+              return;
+            }
+            this.#settle(owner, message.requestId, ({ reject: rejectPending }) => {
+              rejectPending(error);
+            });
+            return;
+          }
+          if (message.requestId !== undefined) {
+            this.#settle(owner, message.requestId, ({ resolve: resolvePending }) => {
+              resolvePending(message);
+            });
+          }
+        } catch (error) {
+          reject(error);
+          this.#onError?.(error, owner);
+        }
+      });
+      worker.addEventListener("error", (event) => {
+        const error = new Error(event.message || `${owner} mixed retained worker crashed`);
+        reject(error);
+        this.#rejectOwner(owner, error);
+        this.#onError?.(error, owner);
+      });
+      worker.addEventListener("messageerror", () => {
+        const error = new Error(`${owner} mixed retained worker message could not be decoded`);
+        reject(error);
+        this.#rejectOwner(owner, error);
+        this.#onError?.(error, owner);
+      });
+    });
+  }
+
+  #settle(owner, requestId, settle) {
+    if (!Number.isSafeInteger(requestId) || requestId < 0) {
+      throw new Error(`${owner} mixed retained worker returned an invalid request ID`);
+    }
+    const key = `${owner}:${requestId}`;
+    const pending = this.#pending.get(key);
+    if (!pending) {
+      throw new Error(`${owner} mixed retained worker returned unknown request ID ${requestId}`);
+    }
+    this.#pending.delete(key);
+    settle(pending);
+  }
+
+  #rejectOwner(owner, error) {
+    for (const [key, pending] of this.#pending.entries()) {
+      if (key.startsWith(`${owner}:`)) {
+        pending.reject(error);
+        this.#pending.delete(key);
+      }
+    }
+  }
+
+  #requireStarted() {
+    if (this.#engineWorker === null || this.#renderWorker === null) {
+      throw new Error("RetainedExecutionWorkerClient has not been started");
+    }
+  }
+}
+
+function engineEnvelope(type, payload = {}) {
+  return {
+    channel: ENGINE_CHANNEL,
+    protocolVersion: ENGINE_PROTOCOL_VERSION,
+    type,
+    ...payload,
+  };
+}
+
+function renderEnvelope(type, payload = {}) {
+  return {
+    channel: RENDER_CHANNEL,
+    protocolVersion: RENDER_PROTOCOL_VERSION,
+    type,
+    ...payload,
+  };
+}
+
+function validateWorkerEnvelope(message, channel) {
+  const version = channel === ENGINE_CHANNEL ? ENGINE_PROTOCOL_VERSION : RENDER_PROTOCOL_VERSION;
+  if (
+    !message ||
+    typeof message !== "object" ||
+    message.channel !== channel ||
+    message.protocolVersion !== version
+  ) {
+    throw new Error(`received an invalid mixed retained ${channel} worker envelope`);
+  }
+}
+
+function validateLegacySceneJson(sceneJson) {
+  if (typeof sceneJson !== "string" || sceneJson.trim() === "") {
+    throw new TypeError("legacy scene must be non-empty JSON text");
+  }
+  let document;
+  try {
+    document = JSON.parse(sceneJson);
+  } catch (error) {
+    throw new TypeError(`legacy scene must be valid JSON: ${error}`);
+  }
+  if (!document || typeof document !== "object" || !Array.isArray(document.objects)) {
+    throw new TypeError("legacy scene JSON must contain an objects array");
+  }
+}
+
+function validateRetainedDocumentJson(retainedDocumentJson) {
+  if (typeof retainedDocumentJson !== "string" || retainedDocumentJson.trim() === "") {
+    throw new TypeError("retained document must be non-empty JSON text");
+  }
+  let document;
+  try {
+    document = JSON.parse(retainedDocumentJson);
+  } catch (error) {
+    throw new TypeError(`retained document must be valid JSON: ${error}`);
+  }
+  if (document?.channel !== RETAINED_AUTHORING_CHANNEL) {
+    throw new TypeError(`retained document must use ${RETAINED_AUTHORING_CHANNEL}`);
+  }
+}
+
+function validateLoopDurationSeconds(loopDurationSeconds) {
+  if (!Number.isFinite(loopDurationSeconds) || loopDurationSeconds <= 0) {
+    throw new TypeError("mixed retained loop duration must be positive and finite");
+  }
+  return loopDurationSeconds;
+}
+
+function checkedNext(current, label) {
+  if (!Number.isSafeInteger(current) || current < 0 || current >= Number.MAX_SAFE_INTEGER) {
+    throw new Error(`${label} space exhausted`);
+  }
+  return current + 1;
+}


### PR DESCRIPTION
## Summary
- wire the mixed Python authoring pair—legacy `SceneDocument` JSON plus `noon.authoring.retained` sidecar—through a focused engine/render worker pair
- reuse the existing `noon.engine` / `noon.render` control envelopes and shared/transferable execution transport primitives
- make the shared/transferable framing layer explicitly accept both `noon.execution` and `noon.execution.retained` version-1 channels while leaving semantic validation to the corresponding runtime mirror
- transfer #359's dependency-closed resource bundle exactly once before the initial retained snapshot
- render only through merged #357's `RetainedExecutionCanvasRenderer`; the render worker never receives Typst source or Python glyph/font payloads
- preserve legacy geometry + retained text in one execution snapshot and one painter-order stream
- add a thin worker client with state, metrics, retime, resize, restart, and lifecycle control
- add Playwright CI coverage for both transport modes with 4 legacy geometry objects + 2 retained text objects in the same frame

## Invariants
- one resource transfer per worker session
- no per-frame source compilation or resource transfer
- no `GeometryRef::Text`, placeholder geometry, overlay renderer, or SVG text transport
- engine wire handles remain distinct from renderer-local arena handles
- mixed geometry/text order is preserved end-to-end
- unrelated execution channels remain rejected by the framing layer

## Validation
- focused shared and transferable transport tests cover the retained execution channel and reject unrelated channels
- Web package gate runs those transport tests before WASM packaging
- mixed retained worker browser smoke passes both shared and transferable transport modes
- retained Typst raster fixtures and ratchets pass on the same product tree

## Stack
Directly on `master`; #357, #356, and #359 are merged. #377 routes normal Python authoring and the public demo through this worker path.