### PR TITLE
Route Python authoring through mixed execution workers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,9 @@ jobs:
       - name: Test mixed retained worker transports
         run: node scripts/retained-execution-worker-smoke.mjs
 
+      - name: Test Python authoring execution routing
+        run: node scripts/authoring-execution-router-smoke.mjs
+
       - name: Test slow Python callbacks do not block rendering
         run: node scripts/execution-worker-host-smoke.mjs
 

--- a/scripts/authoring-execution-router-smoke.mjs
+++ b/scripts/authoring-execution-router-smoke.mjs
@@ -134,7 +134,7 @@ try {
     });
     const mixedTransitionMetrics = execution.metrics();
     const mixedTransitionState = execution.state();
-    const [legacyRaceMetrics, mixedResult, mixedRaceMetrics, mixedRaceState] = await Promise.all([
+    const [preMixedRaceMetrics, mixedResult, mixedRaceMetrics, mixedRaceState] = await Promise.all([
       inFlightLegacyMetrics,
       mixedTransition,
       mixedTransitionMetrics,
@@ -188,7 +188,7 @@ try {
       retainedMode: AUTHORING_EXECUTION_RETAINED,
       initialReady,
       initialCanvasChanged: initialCanvas !== originalCanvas,
-      legacyRaceModeBeforeMixed: legacyRaceMetrics.executionMode,
+      legacyRaceModeBeforeMixed: preMixedRaceMetrics.executionMode,
       mixedMode: mixedResult.mode,
       mixedRebuilt: mixedResult.rebuilt,
       mixedCanvasChanged: mixedCanvas !== initialCanvas,

--- a/scripts/authoring-execution-router-smoke.mjs
+++ b/scripts/authoring-execution-router-smoke.mjs
@@ -1,0 +1,261 @@
+import assert from "node:assert/strict";
+import { createReadStream } from "node:fs";
+import { stat } from "node:fs/promises";
+import { createServer } from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import playwright from "playwright";
+
+const { chromium } = playwright;
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const port = Number(process.env.NOON_AUTHORING_EXECUTION_ROUTER_PORT ?? "4182");
+const baseUrl = `http://127.0.0.1:${port}`;
+
+const contentTypes = new Map([
+  [".html", "text/html; charset=utf-8"],
+  [".js", "text/javascript; charset=utf-8"],
+  [".mjs", "text/javascript; charset=utf-8"],
+  [".wasm", "application/wasm"],
+  [".json", "application/json; charset=utf-8"],
+  [".py", "text/x-python; charset=utf-8"],
+]);
+
+const server = createServer(async (request, response) => {
+  try {
+    const url = new URL(request.url, baseUrl);
+    const relative = decodeURIComponent(url.pathname).replace(/^\/+/, "");
+    const resolved = path.resolve(repoRoot, relative || "web/execution-worker-smoke.html");
+    if (resolved !== repoRoot && !resolved.startsWith(`${repoRoot}${path.sep}`)) {
+      response.writeHead(403).end("forbidden");
+      return;
+    }
+    const info = await stat(resolved);
+    if (!info.isFile()) {
+      response.writeHead(404).end("not found");
+      return;
+    }
+    response.setHeader("Cross-Origin-Opener-Policy", "same-origin");
+    response.setHeader("Cross-Origin-Embedder-Policy", "require-corp");
+    response.setHeader("Cross-Origin-Resource-Policy", "same-origin");
+    response.setHeader("Cache-Control", "no-store");
+    response.setHeader(
+      "Content-Type",
+      contentTypes.get(path.extname(resolved)) ?? "application/octet-stream",
+    );
+    response.writeHead(200);
+    createReadStream(resolved).pipe(response);
+  } catch (error) {
+    response.writeHead(error?.code === "ENOENT" ? 404 : 500).end(String(error));
+  }
+});
+await new Promise((resolve, reject) => {
+  server.once("error", reject);
+  server.listen(port, "127.0.0.1", resolve);
+});
+
+const mixedSource = `from noon import *
+
+class MixedRouterScene(Scene):
+    def construct(self):
+        self.add(Circle(radius=0.4))
+        self.add(Typst("middle", font_size=56))
+        self.add(Square(side_length=0.8))
+`;
+
+const legacySource = `from noon import *
+
+class LegacyRouterScene(Scene):
+    def construct(self):
+        self.add(Circle(radius=0.5))
+        self.add(Square(side_length=0.7).shift(RIGHT * 1.5))
+`;
+
+const browserArgs = [
+  "--enable-unsafe-webgpu",
+  "--enable-unsafe-swiftshader",
+  "--use-webgpu-adapter=swiftshader",
+  "--use-gpu-in-tests",
+  "--ignore-gpu-blocklist",
+  "--enable-features=Vulkan",
+  "--use-gl=angle",
+  "--use-angle=swiftshader",
+  "--use-vulkan=swiftshader",
+  "--disable-gpu-sandbox",
+  "--disable-dev-shm-usage",
+];
+
+let browser = null;
+try {
+  browser = await chromium.launch({
+    channel: "chromium",
+    headless: true,
+    args: browserArgs,
+  });
+  const page = await browser.newPage({ viewport: { width: 800, height: 500 } });
+  const browserErrors = [];
+  page.on("pageerror", (error) => browserErrors.push(`pageerror: ${error}`));
+  page.on("console", (message) => {
+    if (message.type() === "error") browserErrors.push(`console: ${message.text()}`);
+  });
+  await page.goto(`${baseUrl}/web/execution-worker-smoke.html`, { waitUntil: "load" });
+
+  const result = await page.evaluate(async ({ mixedSource, legacySource }) => {
+    const { PythonAuthoringClient } = await import("./authoring-client.js");
+    const {
+      AuthoringExecutionClient,
+      AUTHORING_EXECUTION_LEGACY,
+      AUTHORING_EXECUTION_RETAINED,
+    } = await import("./authoring-execution-client.js");
+
+    const originalCanvas = document.querySelector("#scene");
+    const errors = [];
+    const authoring = new PythonAuthoringClient();
+    const execution = new AuthoringExecutionClient(originalCanvas, {
+      onError(error, owner) {
+        errors.push(`${owner}: ${error}`);
+      },
+    });
+    const emptySceneJson = '{"version":1,"objects":[],"tracks":[]}';
+    const initialReady = await execution.start(emptySceneJson, {
+      loopDurationSeconds: 4,
+      transportMode: "transferable",
+    });
+    const initialCanvas = execution.canvas;
+
+    const mixed = await authoring.run(mixedSource, {});
+    const inFlightLegacyMetrics = execution.metrics();
+    const mixedTransition = execution.reconcileScene(JSON.stringify(mixed.document), {
+      retainedDocumentJson: JSON.stringify(mixed.retainedDocument),
+      callbacks: mixed.callbacks,
+      authoringClient: authoring,
+      loopDurationSeconds: mixed.duration > 0 ? mixed.duration : null,
+    });
+    const mixedTransitionMetrics = execution.metrics();
+    const mixedTransitionState = execution.state();
+    const [legacyRaceMetrics, mixedResult, mixedRaceMetrics, mixedRaceState] = await Promise.all([
+      inFlightLegacyMetrics,
+      mixedTransition,
+      mixedTransitionMetrics,
+      mixedTransitionState,
+    ]);
+    await new Promise((resolve) => setTimeout(resolve, 350));
+    const mixedMetrics = await execution.metrics();
+    const mixedCanvas = execution.canvas;
+
+    let callbackError = null;
+    try {
+      await execution.reconcileScene(JSON.stringify(mixed.document), {
+        retainedDocumentJson: JSON.stringify(mixed.retainedDocument),
+        callbacks: { session_id: 1, slots: [{}] },
+        authoringClient: authoring,
+      });
+    } catch (error) {
+      callbackError = String(error);
+    }
+
+    const legacy = await authoring.run(legacySource, {});
+    const legacyRetainedObjectCount = legacy.retainedDocument?.objects?.length ?? -1;
+    const inFlightRetainedMetrics = execution.metrics();
+    const legacyTransition = execution.reconcileScene(JSON.stringify(legacy.document), {
+      retainedDocumentJson: JSON.stringify(legacy.retainedDocument),
+      callbacks: legacy.callbacks,
+      authoringClient: authoring,
+      loopDurationSeconds: legacy.duration > 0 ? legacy.duration : null,
+    });
+    const legacyTransitionMetrics = execution.metrics();
+    const legacyTransitionState = execution.state();
+    const [retainedRaceMetrics, legacyResult, legacyRaceMetrics, legacyRaceState] = await Promise.all([
+      inFlightRetainedMetrics,
+      legacyTransition,
+      legacyTransitionMetrics,
+      legacyTransitionState,
+    ]);
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    const legacyMetrics = await execution.metrics();
+    const legacyCanvas = execution.canvas;
+
+    const secondLegacy = await execution.reconcileScene(JSON.stringify(legacy.document), {
+      retainedDocumentJson: JSON.stringify(legacy.retainedDocument),
+      callbacks: legacy.callbacks,
+      authoringClient: authoring,
+    });
+
+    const state = await execution.state();
+    const summary = {
+      initialMode: AUTHORING_EXECUTION_LEGACY,
+      retainedMode: AUTHORING_EXECUTION_RETAINED,
+      initialReady,
+      initialCanvasChanged: initialCanvas !== originalCanvas,
+      legacyRaceModeBeforeMixed: legacyRaceMetrics.executionMode,
+      mixedMode: mixedResult.mode,
+      mixedRebuilt: mixedResult.rebuilt,
+      mixedCanvasChanged: mixedCanvas !== initialCanvas,
+      mixedRaceMode: mixedRaceMetrics.executionMode,
+      mixedRaceRetainedChannel: JSON.parse(mixedRaceState.retainedDocumentJson).channel,
+      mixedMetrics,
+      callbackError,
+      legacyRetainedObjectCount,
+      retainedRaceModeBeforeLegacy: retainedRaceMetrics.executionMode,
+      legacyMode: legacyResult.mode,
+      legacyRebuilt: legacyResult.rebuilt,
+      legacyCanvasChanged: legacyCanvas !== mixedCanvas,
+      legacyRaceMode: legacyRaceMetrics.executionMode,
+      legacyRaceObjectCount: JSON.parse(legacyRaceState.sceneJson).objects.length,
+      legacyMetrics,
+      secondLegacyMode: secondLegacy.mode,
+      secondLegacyRebuilt: secondLegacy.rebuilt,
+      sameLegacyCanvas: execution.canvas === legacyCanvas,
+      state,
+      transportMode: execution.transportMode,
+      rendererBackend: execution.rendererBackend,
+      clientErrors: errors.slice(),
+    };
+    execution.terminate();
+    authoring.terminate();
+    return summary;
+  }, { mixedSource, legacySource });
+
+  assert.equal(result.initialCanvasChanged, false);
+  assert.equal(result.initialReady.transportMode, "transferable");
+  assert.equal(result.transportMode, "transferable");
+  assert.ok([result.initialMode, result.retainedMode].includes(result.legacyRaceModeBeforeMixed));
+  assert.equal(result.mixedMode, result.retainedMode);
+  assert.equal(result.mixedRebuilt, true);
+  assert.equal(result.mixedCanvasChanged, true);
+  assert.equal(result.mixedRaceMode, result.retainedMode);
+  assert.equal(result.mixedRaceRetainedChannel, "noon.authoring.retained");
+  assert.equal(result.mixedMetrics.executionMode, result.retainedMode);
+  assert.equal(result.mixedMetrics.metrics.ready, true);
+  assert.equal(result.mixedMetrics.metrics.objectCount, 3);
+  assert.ok(result.mixedMetrics.metrics.presentedFrames >= 1);
+  assert.equal(result.mixedMetrics.engineMetrics.resourceBundleTransfers, 1);
+  assert.ok(result.mixedMetrics.engineMetrics.resourceBundleBytes > 0);
+  assert.equal(result.mixedMetrics.engineMetrics.host.enabled, false);
+  assert.match(result.callbackError, /retained authoring with Python host callbacks is not supported yet/);
+
+  assert.equal(result.legacyRetainedObjectCount, 0, "geometry-only authoring should emit an empty sidecar");
+  assert.ok([result.retainedMode, result.initialMode].includes(result.retainedRaceModeBeforeLegacy));
+  assert.equal(result.legacyMode, result.initialMode);
+  assert.equal(result.legacyRebuilt, true);
+  assert.equal(result.legacyCanvasChanged, true);
+  assert.equal(result.legacyRaceMode, result.initialMode);
+  assert.equal(result.legacyRaceObjectCount, 2);
+  assert.equal(result.legacyMetrics.executionMode, result.initialMode);
+  assert.equal(result.legacyMetrics.metrics.objectCount, 2);
+  assert.equal(typeof result.legacyMetrics.engineMetrics.host.enabled, "boolean");
+  assert.equal(result.secondLegacyMode, result.initialMode);
+  assert.equal(result.secondLegacyRebuilt, false);
+  assert.equal(result.sameLegacyCanvas, true);
+  assert.equal(JSON.parse(result.state.sceneJson).objects.length, 2);
+  assert.match(result.rendererBackend, /WebGPU|WebGL2/);
+  assert.deepEqual(result.clientErrors, []);
+  assert.deepEqual(browserErrors, []);
+  console.log(
+    `✓ authoring execution router: legacy → retained → legacy on ${result.rendererBackend}`,
+  );
+} finally {
+  await browser?.close();
+  await new Promise((resolve) => server.close(resolve));
+}

--- a/web/authoring-execution-client.js
+++ b/web/authoring-execution-client.js
@@ -1,0 +1,403 @@
+import { ExecutionWorkerClient } from "./execution-worker-client.js";
+import { RetainedExecutionWorkerClient } from "./retained-execution-worker-client.js";
+
+export const AUTHORING_EXECUTION_LEGACY = "legacy";
+export const AUTHORING_EXECUTION_RETAINED = "retained";
+
+const DEFAULT_LOOP_DURATION_SECONDS = 4;
+const DEFAULT_SHARED_SLOT_CAPACITY = 1024 * 1024;
+const EMPTY_HOST_METRICS = Object.freeze({
+  enabled: false,
+  missedDeadlines: 0,
+  droppedLateResults: 0,
+});
+
+/// One browser execution owner for Python authoring output.
+///
+/// Legacy SceneDocument-only results keep using the mature execution worker pair.
+/// Results with retained objects in a `noon.authoring.retained` sidecar switch
+/// atomically to the mixed retained engine/render workers. Empty sidecars remain on
+/// legacy execution so ordinary geometry scenes do not pay retained rebuild costs.
+/// Because the retained worker does not yet support in-place scene reconciliation,
+/// retained edits rebuild only at authoring boundaries; playback remains fully
+/// retained and performs no per-frame Python/source work.
+export class AuthoringExecutionClient {
+  #canvas;
+  #player = null;
+  #mode = null;
+  #rendererBackend = "";
+  #loopDurationSeconds = DEFAULT_LOOP_DURATION_SECONDS;
+  #transportMode = null;
+  #sharedSlotCapacity = DEFAULT_SHARED_SLOT_CAPACITY;
+  #onError;
+  #resizeObserver = null;
+  #transition = null;
+
+  constructor(canvas, { onError = null } = {}) {
+    if (!(canvas instanceof HTMLCanvasElement)) {
+      throw new TypeError("AuthoringExecutionClient requires an HTMLCanvasElement");
+    }
+    if (onError !== null && typeof onError !== "function") {
+      throw new TypeError("AuthoringExecutionClient onError must be a function");
+    }
+    this.#canvas = canvas;
+    this.#onError = onError;
+    this.#observeCanvas();
+  }
+
+  get canvas() {
+    return this.#canvas;
+  }
+
+  get mode() {
+    return this.#mode;
+  }
+
+  get rendererBackend() {
+    return this.#rendererBackend;
+  }
+
+  get transportMode() {
+    return this.#transportMode;
+  }
+
+  async start(
+    sceneJson,
+    {
+      loopDurationSeconds = DEFAULT_LOOP_DURATION_SECONDS,
+      transportMode = undefined,
+      sharedSlotCapacity = DEFAULT_SHARED_SLOT_CAPACITY,
+    } = {},
+  ) {
+    if (this.#player !== null || this.#transition !== null) {
+      throw new Error("AuthoringExecutionClient is already started");
+    }
+    validateSceneJson(sceneJson);
+    this.#loopDurationSeconds = validateLoopDurationSeconds(loopDurationSeconds);
+    this.#sharedSlotCapacity = validateSharedSlotCapacity(sharedSlotCapacity);
+    const options = {
+      loopDurationSeconds: this.#loopDurationSeconds,
+      sharedSlotCapacity: this.#sharedSlotCapacity,
+    };
+    if (transportMode !== undefined) {
+      options.transportMode = transportMode;
+    }
+    const ready = await this.#startLegacy(sceneJson, options);
+    this.#transportMode = ready.transportMode;
+    return ready;
+  }
+
+  async reconcileScene(
+    sceneJson,
+    {
+      retainedDocumentJson = null,
+      callbacks = null,
+      authoringClient = null,
+      loopDurationSeconds = null,
+    } = {},
+  ) {
+    if (this.#transition !== null) {
+      await this.#transition;
+    }
+    this.#requireStarted();
+    validateSceneJson(sceneJson);
+    const duration = validateOptionalLoopDurationSeconds(loopDurationSeconds);
+    if (duration !== null) {
+      this.#loopDurationSeconds = duration;
+    }
+
+    let retainedDocument = null;
+    if (retainedDocumentJson !== null && retainedDocumentJson !== undefined) {
+      retainedDocument = validateRetainedDocumentJson(retainedDocumentJson);
+    }
+    if (retainedDocument !== null && retainedDocument.objects.length > 0) {
+      if (callbacks !== null && callbacks !== undefined) {
+        throw new Error(
+          "retained authoring with Python host callbacks is not supported yet; " +
+            "split the callback work from retained text instead of silently dropping either",
+        );
+      }
+      return this.#runTransition(() => this.#rebuildRetained(sceneJson, retainedDocumentJson));
+    }
+
+    if (this.#mode === AUTHORING_EXECUTION_LEGACY) {
+      const result = await this.#player.reconcileScene(sceneJson, {
+        callbacks,
+        authoringClient,
+        loopDurationSeconds: duration,
+      });
+      return { ...result, mode: this.#mode, rebuilt: false };
+    }
+
+    return this.#runTransition(() => this.#rebuildLegacy(sceneJson, { callbacks, authoringClient }));
+  }
+
+  async state() {
+    return this.#withStablePlayer((player) => player.state());
+  }
+
+  async metrics() {
+    const report = await this.#withStablePlayer((player) => player.metrics());
+    return {
+      ...report,
+      executionMode: this.#mode,
+      engineMetrics: {
+        ...(report.engineMetrics ?? {}),
+        host: report.engineMetrics?.host ?? EMPTY_HOST_METRICS,
+      },
+    };
+  }
+
+  async setLoopDurationSeconds(loopDurationSeconds) {
+    const duration = validateLoopDurationSeconds(loopDurationSeconds);
+    const result = await this.#withStablePlayer((player) =>
+      player.setLoopDurationSeconds(duration),
+    );
+    this.#loopDurationSeconds = duration;
+    return result;
+  }
+
+  async applyPatchBatch(patchBatchJson) {
+    return this.#withStablePlayer((player, mode) => {
+      if (mode !== AUTHORING_EXECUTION_LEGACY) {
+        throw new Error("patch batches are not supported by mixed retained execution yet");
+      }
+      return player.applyPatchBatch(patchBatchJson);
+    });
+  }
+
+  resize(width, height, devicePixelRatio = 1) {
+    if (this.#player === null) {
+      if (this.#transition !== null) {
+        return;
+      }
+      this.#requireStarted();
+    }
+    this.#player.resize(width, height, devicePixelRatio);
+  }
+
+  terminate() {
+    this.#resizeObserver?.disconnect();
+    this.#resizeObserver = null;
+    this.#player?.terminate();
+    this.#player = null;
+    this.#mode = null;
+    this.#rendererBackend = "";
+  }
+
+  async #startLegacy(sceneJson, options) {
+    const player = new ExecutionWorkerClient(this.#canvas, { onError: this.#onError });
+    try {
+      const ready = await player.start(sceneJson, options);
+      this.#player = player;
+      this.#mode = AUTHORING_EXECUTION_LEGACY;
+      this.#rendererBackend = ready.render.backend;
+      this.#resizeCurrentCanvas();
+      return ready;
+    } catch (error) {
+      player.terminate();
+      throw error;
+    }
+  }
+
+  async #rebuildRetained(sceneJson, retainedDocumentJson) {
+    const canvas = this.#replaceTransferredCanvas();
+    const player = new RetainedExecutionWorkerClient(canvas, { onError: this.#onError });
+    try {
+      const ready = await player.start(sceneJson, retainedDocumentJson, {
+        loopDurationSeconds: this.#loopDurationSeconds,
+        transportMode: this.#transportMode,
+        sharedSlotCapacity: this.#sharedSlotCapacity,
+      });
+      this.#player = player;
+      this.#mode = AUTHORING_EXECUTION_RETAINED;
+      this.#rendererBackend = ready.render.backend;
+      this.#resizeCurrentCanvas();
+      const state = await player.state();
+      return {
+        type: "result",
+        operation: "rebuild_retained_scene",
+        incremental: false,
+        rebuilt: true,
+        mode: this.#mode,
+        ready,
+        ...state,
+      };
+    } catch (error) {
+      player.terminate();
+      throw error;
+    }
+  }
+
+  async #rebuildLegacy(sceneJson, { callbacks, authoringClient }) {
+    const canvas = this.#replaceTransferredCanvas();
+    const player = new ExecutionWorkerClient(canvas, { onError: this.#onError });
+    try {
+      const ready = await player.start(sceneJson, {
+        loopDurationSeconds: this.#loopDurationSeconds,
+        transportMode: this.#transportMode,
+        sharedSlotCapacity: this.#sharedSlotCapacity,
+      });
+      if (callbacks !== null && callbacks !== undefined) {
+        await player.configureHostCallbacks(callbacks, authoringClient);
+      }
+      this.#player = player;
+      this.#mode = AUTHORING_EXECUTION_LEGACY;
+      this.#rendererBackend = ready.render.backend;
+      this.#resizeCurrentCanvas();
+      const state = await player.state();
+      return {
+        type: "result",
+        operation: "rebuild_legacy_scene",
+        incremental: false,
+        rebuilt: true,
+        mode: this.#mode,
+        ready,
+        ...state,
+      };
+    } catch (error) {
+      player.terminate();
+      throw error;
+    }
+  }
+
+  async #runTransition(rebuild) {
+    if (this.#transition !== null) {
+      await this.#transition;
+    }
+    const transition = rebuild();
+    this.#transition = transition;
+    try {
+      return await transition;
+    } finally {
+      if (this.#transition === transition) {
+        this.#transition = null;
+      }
+    }
+  }
+
+  async #withStablePlayer(operation) {
+    for (;;) {
+      if (this.#transition !== null) {
+        await this.#transition;
+        continue;
+      }
+      this.#requireStarted();
+      const player = this.#player;
+      const mode = this.#mode;
+      try {
+        const result = await operation(player, mode);
+        if (this.#player !== player) {
+          continue;
+        }
+        return result;
+      } catch (error) {
+        const transition = this.#transition;
+        if (transition !== null) {
+          await transition;
+          continue;
+        }
+        if (this.#player !== null && this.#player !== player) {
+          continue;
+        }
+        throw error;
+      }
+    }
+  }
+
+  #replaceTransferredCanvas() {
+    this.#player?.terminate();
+    const previous = this.#canvas;
+    const replacement = previous.cloneNode(false);
+    replacement.width = previous.width;
+    replacement.height = previous.height;
+    replacement.className = previous.className;
+    replacement.id = previous.id;
+    for (const attribute of previous.getAttributeNames()) {
+      if (attribute !== "width" && attribute !== "height" && attribute !== "class" && attribute !== "id") {
+        replacement.setAttribute(attribute, previous.getAttribute(attribute));
+      }
+    }
+    previous.replaceWith(replacement);
+    this.#canvas = replacement;
+    this.#player = null;
+    this.#mode = null;
+    this.#rendererBackend = "";
+    this.#observeCanvas();
+    return replacement;
+  }
+
+  #observeCanvas() {
+    this.#resizeObserver?.disconnect();
+    if (typeof ResizeObserver !== "function") {
+      this.#resizeObserver = null;
+      return;
+    }
+    this.#resizeObserver = new ResizeObserver(() => {
+      if (this.#player !== null) {
+        this.#resizeCurrentCanvas();
+      }
+    });
+    this.#resizeObserver.observe(this.#canvas);
+  }
+
+  #resizeCurrentCanvas() {
+    if (this.#player === null) {
+      return;
+    }
+    const scale = window.devicePixelRatio || 1;
+    this.#player.resize(this.#canvas.clientWidth, this.#canvas.clientHeight, scale);
+  }
+
+  #requireStarted() {
+    if (this.#player === null) {
+      throw new Error("AuthoringExecutionClient has not been started");
+    }
+  }
+}
+
+function validateSceneJson(sceneJson) {
+  if (typeof sceneJson !== "string" || sceneJson.trim() === "") {
+    throw new TypeError("scene must be non-empty JSON text");
+  }
+}
+
+function validateRetainedDocumentJson(retainedDocumentJson) {
+  if (typeof retainedDocumentJson !== "string" || retainedDocumentJson.trim() === "") {
+    throw new TypeError("retained document must be non-empty JSON text");
+  }
+  let document;
+  try {
+    document = JSON.parse(retainedDocumentJson);
+  } catch (error) {
+    throw new TypeError(`retained document must be valid JSON: ${error}`);
+  }
+  if (document?.channel !== "noon.authoring.retained") {
+    throw new TypeError("retained document must use noon.authoring.retained");
+  }
+  if (!Array.isArray(document.objects)) {
+    throw new TypeError("retained document objects must be an array");
+  }
+  return document;
+}
+
+function validateLoopDurationSeconds(loopDurationSeconds) {
+  if (!Number.isFinite(loopDurationSeconds) || loopDurationSeconds <= 0) {
+    throw new TypeError("loop duration must be positive and finite");
+  }
+  return loopDurationSeconds;
+}
+
+function validateOptionalLoopDurationSeconds(loopDurationSeconds) {
+  if (loopDurationSeconds === null || loopDurationSeconds === undefined) {
+    return null;
+  }
+  return validateLoopDurationSeconds(loopDurationSeconds);
+}
+
+function validateSharedSlotCapacity(sharedSlotCapacity) {
+  if (!Number.isSafeInteger(sharedSlotCapacity) || sharedSlotCapacity <= 0) {
+    throw new TypeError("shared execution slot capacity must be a positive safe integer");
+  }
+  return sharedSlotCapacity;
+}

--- a/web/main.js
+++ b/web/main.js
@@ -1,4 +1,4 @@
-import { ExecutionWorkerClient } from "./execution-worker-client.js";
+import { AuthoringExecutionClient } from "./authoring-execution-client.js";
 import { PythonAuthoringClient } from "./authoring-client.js";
 import { SceneIdentityMap } from "./scene-identity.js";
 import {
@@ -414,10 +414,15 @@ async function runScene() {
         ? sceneIdentities.stabilize(authored.document, authored.identities)
         : authored.document;
     const result = await player.reconcileScene(JSON.stringify(runtimeDocument), {
+      retainedDocumentJson:
+        authored.retainedDocument === null ? null : JSON.stringify(authored.retainedDocument),
       callbacks: authored.callbacks,
       authoringClient,
       loopDurationSeconds: authored.duration > 0 ? authored.duration : null,
     });
+    rendererBackend = player.rendererBackend;
+    status.dataset.rendererBackend = rendererBackend;
+    status.dataset.executionMode = player.mode;
     const report = await player.metrics();
     const operation = result.incremental ? "Scene updated incrementally" : "Scene rebuilt atomically";
     patchStatus.value = `${operation} · ${example.title} · ${report.metrics.objectCount} objects`;
@@ -508,7 +513,7 @@ document.addEventListener("keydown", (event) => {
 
 const EMPTY_SCENE_JSON = '{"version":1,"objects":[],"tracks":[]}';
 try {
-  player = new ExecutionWorkerClient(canvas, {
+  player = new AuthoringExecutionClient(canvas, {
     onError(error) {
       showError(error);
     },
@@ -516,14 +521,8 @@ try {
   const ready = await player.start(EMPTY_SCENE_JSON, { loopDurationSeconds: 4.0 });
   rendererBackend = ready.render.backend;
   status.dataset.rendererBackend = rendererBackend;
-  status.dataset.executionTopology = "engine-render-workers";
-
-  function resize() {
-    const scale = window.devicePixelRatio || 1;
-    player.resize(canvas.clientWidth, canvas.clientHeight, scale);
-  }
-  resize();
-  new ResizeObserver(resize).observe(canvas);
+  status.dataset.executionMode = player.mode;
+  status.dataset.executionTopology = "authoring-engine-render-workers";
 
   const requested = requestedExampleId();
   const initialExample = SCENE_EXAMPLES.some((example) => example.id === requested)
@@ -542,6 +541,9 @@ try {
     },
     get exampleCount() {
       return SCENE_EXAMPLES.length;
+    },
+    get executionMode() {
+      return player?.mode ?? null;
     },
     async select(id) {
       await selectExample(id, { run: true, updateUrl: true });
@@ -566,7 +568,13 @@ try {
       const report = await player.metrics();
       const metrics = report.metrics;
       const host = report.engineMetrics.host;
-      setRuntimeStatus(`${metrics.objectCount} objects · ${rendererBackend} worker`, "running");
+      rendererBackend = player.rendererBackend;
+      status.dataset.rendererBackend = rendererBackend;
+      status.dataset.executionMode = report.executionMode;
+      setRuntimeStatus(
+        `${metrics.objectCount} objects · ${rendererBackend} ${report.executionMode} worker`,
+        "running",
+      );
       metricObjects.value = String(metrics.objectCount);
       metricDraws.value = String(metrics.drawCalls);
       metricUpload.value = formatBytes(metrics.bytesUploaded);


### PR DESCRIPTION
## Summary
- add `AuthoringExecutionClient` as the single frontend owner for Python-authored browser scenes
- keep ordinary geometry scenes on the mature legacy execution worker pair, including the empty `noon.authoring.retained` sidecar that Python currently emits for geometry-only scenes
- route only sidecars with retained objects to the merged mixed retained engine/render workers through an explicit `retainedDocumentJson` handoff
- rebuild retained sessions only at authoring boundaries until localized retained reconciliation exists; playback remains fully retained with no per-frame Python/source work
- own transferred-canvas replacement and `ResizeObserver` rebinding inside the router
- serialize legacy↔retained transitions so concurrent `state()` / `metrics()` requests retry on the stable worker rather than surfacing termination races
- preserve transport mode and loop duration across worker-mode switches
- normalize host metrics across legacy/retained modes
- explicitly reject retained text combined with Python host callbacks rather than silently dropping either side
- route the public demo through this facade without retained-specific renderer logic in `main.js`

## Validation
- browser smoke drives the real `PythonAuthoringClient` through legacy → retained → legacy
- verifies geometry-only Python authoring really emits an empty retained sidecar and that passing that sidecar still stays on legacy execution
- deliberately overlaps `state()` / `metrics()` with both worker/canvas transitions and verifies the calls resolve on a valid execution owner
- verifies one-shot retained resource transfer, GPU presentation, mixed object count, canvas ownership changes, callback rejection, and same-mode legacy reconciliation
- runs as part of the existing browser reactive CI job
- current CI synthetic merge is against current `master`, including merged native-text foundation #374

## Architecture boundaries
- no overlay canvas, SVG text transport, placeholder geometry, or glyph/font/atlas payload on the Python/per-frame wire
- mode switching occurs only after a new Python authoring result and only when retained objects actually exist
- retained scenes use the merged resource-bundle + handle-based delta protocol unchanged
- patch batches remain legacy-only until the retained execution protocol grows an explicit retained mutation/reconcile contract
- localized content/resource hot reload remains owned by #368; this PR does not introduce a full-bundle resend approximation
- Tex / MathTex remain a separate real-LaTeX backend

## Stack
Directly targets `master`. #356, #357, #359, and #370 are merged.

## Follow-up
- #388 adds fast syntax prechecks for the retained/router worker scripts under #112, without expanding this runtime PR.