### PR TITLE
Add native multiline text layout semantics

### DIFF
--- a/crates/noon-text-native/src/lib.rs
+++ b/crates/noon-text-native/src/lib.rs
@@ -5,8 +5,8 @@
 //! This crate is a backend, not a renderer. It accepts exact immutable font bytes,
 //! shapes source text with Swash, and normalizes the result directly into Noon's
 //! backend-neutral `TextResource` + `FontResourceArena` contract. Public Manim-style
-//! font discovery, multiline layout, markup spans, and fallback are layered above
-//! this low-level deterministic boundary.
+//! font discovery, markup spans, fallback, and richer script itemization are layered
+//! above this low-level deterministic boundary.
 
 use std::{fmt, sync::Arc};
 
@@ -19,7 +19,8 @@ use noon_core::{
 use swash::{shape::ShapeContext, text::Script, FontRef};
 
 pub const NATIVE_TEXT_BACKEND_VERSION: &str = "swash-0.2.10";
-const NATIVE_TEXT_TEMPLATE_VERSION: &str = "noon-native-single-run-v1";
+const NATIVE_TEXT_TEMPLATE_VERSION: &str = "noon-native-multiline-v1";
+const MANIM_DEFAULT_LINE_SPACING: f32 = 0.3;
 
 /// Exact immutable OpenType face input. `face_key` is derived from the bytes and
 /// collection index so a shaped glyph identity can never silently resolve to a
@@ -59,6 +60,10 @@ impl NativeFontFace {
 #[derive(Clone, Debug, PartialEq)]
 pub struct NativeTextOptions {
     pub font_size: f32,
+    /// Manim-compatible line-spacing input. `-1` selects the default 30% extra
+    /// spacing; any other value produces a line advance of
+    /// `font_size * (1 + line_spacing)`.
+    pub line_spacing: f32,
     pub fill: Option<Color>,
     pub variations: Arc<[FontVariationSetting]>,
 }
@@ -67,6 +72,7 @@ impl NativeTextOptions {
     pub fn new(font_size: f32) -> Self {
         Self {
             font_size,
+            line_spacing: -1.0,
             fill: None,
             variations: Arc::from([]),
         }
@@ -83,8 +89,8 @@ pub struct NativeTextResourceArtifact {
 pub enum NativeTextError {
     InvalidFontFace { face_index: u32 },
     InvalidFontSize,
+    InvalidLineSpacing,
     SourceTooLarge,
-    MultilineNotYetSupported,
     InvalidResource(TextResourceValidationError),
     FontResource(FontResourceError),
 }
@@ -102,13 +108,13 @@ impl fmt::Display for NativeTextError {
                 formatter,
                 "native text font size must be finite and positive"
             ),
+            Self::InvalidLineSpacing => write!(
+                formatter,
+                "native text line spacing must produce a finite positive line advance"
+            ),
             Self::SourceTooLarge => write!(
                 formatter,
                 "native text source exceeds Noon's text span space"
-            ),
-            Self::MultilineNotYetSupported => write!(
-                formatter,
-                "multiline native text layout is not yet implemented by this backend slice"
             ),
             Self::InvalidResource(error) => {
                 write!(formatter, "invalid normalized text resource: {error}")
@@ -119,6 +125,12 @@ impl fmt::Display for NativeTextError {
 }
 
 impl std::error::Error for NativeTextError {}
+
+#[derive(Clone, Copy)]
+struct SourceLine<'a> {
+    start: u32,
+    text: &'a str,
+}
 
 /// Persistent native shaper. Keeping the Swash context alive amortizes its internal
 /// shaping caches across repeated compilation without retaining per-object glyph
@@ -134,11 +146,13 @@ impl NativeTextCompiler {
         }
     }
 
-    /// Shape one deterministic single-line LTR run directly into `TextResource`.
+    /// Shape deterministic LTR text directly into backend-neutral retained runs.
     ///
-    /// This foundation intentionally keeps itemization narrow. Multiline layout,
-    /// bidi reordering, script runs, fallback, and MarkupText span splitting remain
-    /// explicit follow-up work rather than being approximated here.
+    /// Newlines are layout boundaries rather than glyphs. Each visual line becomes
+    /// one `GlyphRun`, while source-cluster spans continue to address the original
+    /// UTF-8 input including bytes before/after CR/LF separators. Script itemization,
+    /// bidi reordering, fallback and styled run splitting remain explicit follow-up
+    /// work instead of being approximated in frontend wrappers.
     pub fn compile_plain(
         &mut self,
         source: &str,
@@ -148,16 +162,10 @@ impl NativeTextCompiler {
         if !options.font_size.is_finite() || options.font_size <= 0.0 {
             return Err(NativeTextError::InvalidFontSize);
         }
-        if source.contains('\n') || source.contains('\r') {
-            return Err(NativeTextError::MultilineNotYetSupported);
-        }
+        let line_advance = line_advance(options)?;
         let source_len =
             u32::try_from(source.len()).map_err(|_| NativeTextError::SourceTooLarge)?;
-        let font_ref = FontRef::from_index(font.data.as_ref(), font.face_index as usize).ok_or(
-            NativeTextError::InvalidFontFace {
-                face_index: font.face_index,
-            },
-        )?;
+        let lines = split_source_lines(source)?;
         let variations = options
             .variations
             .iter()
@@ -170,89 +178,117 @@ impl NativeTextCompiler {
             variation_key: Arc::from(variation_identity(options.variations.as_ref())),
         };
 
-        let mut shaper = self
-            .shape_context
-            .builder_with_id(
-                font_ref,
-                [
-                    fingerprint_u64(font.face_key.as_bytes()),
-                    u64::from(font.face_index),
-                ],
-            )
-            .script(Script::Latin)
-            .size(options.font_size)
-            .variations(&variations)
-            .build();
-        let metrics = shaper.metrics();
-        shaper.add_str(source);
-
-        let mut glyphs = Vec::new();
-        let mut cursor_x = 0.0_f32;
+        let mut runs = Vec::with_capacity(lines.len());
+        let mut render_items = Vec::with_capacity(lines.len());
         let mut cluster_ordinal = 0_u32;
-        shaper.shape_with(|cluster| {
-            let source_span = TextSourceSpan::new(cluster.source.start, cluster.source.end);
-            for glyph in cluster.glyphs {
-                let origin = Vec2::new(cursor_x + glyph.x, glyph.y);
-                let advance = Vec2::new(glyph.advance, 0.0);
-                let right = origin.x + glyph.advance.max(0.0);
-                glyphs.push(PositionedGlyph {
-                    glyph_id: u32::from(glyph.id),
-                    cluster: TextClusterIdentity {
-                        source_span,
-                        cluster_ordinal,
-                        semantic_key: None,
-                    },
-                    origin,
-                    advance,
-                    // Exact outlines remain lazy. The line-box bound is conservative
-                    // and sufficient for semantic layout until exact ink metrics land.
-                    bounds: Rect::new(
-                        Vec2::new(origin.x.min(right), metrics.descent),
-                        Vec2::new(origin.x.max(right), metrics.ascent),
-                    ),
-                });
-                cluster_ordinal = cluster_ordinal.saturating_add(1);
-            }
-            cursor_x += cluster.advance();
-        });
+        let mut layout_bounds: Option<Rect> = None;
 
-        let line_bounds = if glyphs.is_empty() {
-            Rect::new(Vec2::ZERO, Vec2::ZERO)
-        } else {
-            Rect::new(
-                Vec2::new(0.0_f32.min(cursor_x), metrics.descent),
-                Vec2::new(0.0_f32.max(cursor_x), metrics.ascent),
-            )
-        };
-        let center = line_bounds.center();
-        let centered_bounds = Rect::new(line_bounds.min - center, line_bounds.max - center);
-        let run = GlyphRun {
-            font: font_identity.clone(),
-            variations: options.variations.clone(),
-            font_size: options.font_size,
-            direction: TextDirection::LeftToRight,
-            fill: options.fill,
-            stroke: None,
-            transform: TextAffineTransform::translation(-center.x, -center.y),
-            glyphs: glyphs.into(),
-        };
-        let glyph_count = u32::try_from(run.glyphs.len()).unwrap_or(u32::MAX);
+        for (line_index, line) in lines.iter().copied().enumerate() {
+            let font_ref = FontRef::from_index(font.data.as_ref(), font.face_index as usize)
+                .ok_or(NativeTextError::InvalidFontFace {
+                    face_index: font.face_index,
+                })?;
+            let mut shaper = self
+                .shape_context
+                .builder_with_id(
+                    font_ref,
+                    [
+                        fingerprint_u64(font.face_key.as_bytes()),
+                        u64::from(font.face_index),
+                    ],
+                )
+                .script(Script::Latin)
+                .size(options.font_size)
+                .variations(&variations)
+                .build();
+            let metrics = shaper.metrics();
+            shaper.add_str(line.text);
+
+            let mut glyphs = Vec::new();
+            let mut cursor_x = 0.0_f32;
+            shaper.shape_with(|cluster| {
+                let source_span = TextSourceSpan::new(
+                    line.start.saturating_add(cluster.source.start),
+                    line.start.saturating_add(cluster.source.end),
+                );
+                for glyph in cluster.glyphs {
+                    let origin = Vec2::new(cursor_x + glyph.x, glyph.y);
+                    let advance = Vec2::new(glyph.advance, 0.0);
+                    let right = origin.x + glyph.advance.max(0.0);
+                    glyphs.push(PositionedGlyph {
+                        glyph_id: u32::from(glyph.id),
+                        cluster: TextClusterIdentity {
+                            source_span,
+                            cluster_ordinal,
+                            semantic_key: None,
+                        },
+                        origin,
+                        advance,
+                        // Exact outlines remain lazy. The line-box bound is conservative
+                        // and sufficient for semantic layout until exact ink metrics land.
+                        bounds: Rect::new(
+                            Vec2::new(origin.x.min(right), metrics.descent),
+                            Vec2::new(origin.x.max(right), metrics.ascent),
+                        ),
+                    });
+                    cluster_ordinal = cluster_ordinal.saturating_add(1);
+                }
+                cursor_x += cluster.advance();
+            });
+
+            let baseline_y = -(line_index as f32) * line_advance;
+            let line_bounds = if source.is_empty() {
+                Rect::new(Vec2::ZERO, Vec2::ZERO)
+            } else {
+                Rect::new(
+                    Vec2::new(0.0_f32.min(cursor_x), metrics.descent + baseline_y),
+                    Vec2::new(0.0_f32.max(cursor_x), metrics.ascent + baseline_y),
+                )
+            };
+            layout_bounds = Some(match layout_bounds {
+                Some(bounds) => bounds.union(line_bounds),
+                None => line_bounds,
+            });
+
+            let run_index = u32::try_from(runs.len())
+                .expect("native text line count exceeds u32 retained run limits");
+            runs.push(GlyphRun {
+                font: font_identity.clone(),
+                variations: options.variations.clone(),
+                font_size: options.font_size,
+                direction: TextDirection::LeftToRight,
+                fill: options.fill,
+                stroke: None,
+                transform: TextAffineTransform::translation(0.0, baseline_y),
+                glyphs: glyphs.into(),
+            });
+            render_items.push(TextRenderItem::GlyphRun(run_index));
+        }
+
+        let layout_bounds = layout_bounds.unwrap_or_else(|| Rect::new(Vec2::ZERO, Vec2::ZERO));
+        let center = layout_bounds.center();
+        let recenter = TextAffineTransform::translation(-center.x, -center.y);
+        for run in &mut runs {
+            run.transform = run.transform.then(recenter);
+        }
+        let centered_bounds = Rect::new(layout_bounds.min - center, layout_bounds.max - center);
         let full_span = TextSourceSpan::new(0, source_len);
         let resource = TextResource {
             source: Arc::from(source),
             kind: TextSourceKind::Plain,
-            runs: Arc::from([run]),
+            runs: runs.into(),
             vector_items: Arc::from([]),
-            render_items: Arc::from([TextRenderItem::GlyphRun(0)]),
+            render_items: render_items.into(),
             parts: Arc::from([TextPart {
                 source_span: full_span,
                 first_cluster: 0,
-                cluster_count: glyph_count,
+                cluster_count: cluster_ordinal,
                 first_vector: 0,
                 vector_count: 0,
                 semantic_key: None,
             }]),
             bounds: centered_bounds,
+            // The first visual line owns the resource baseline before recentering.
             baseline: -center.y,
             layout_artifact: Some(layout_artifact(source, font, options)),
         };
@@ -274,16 +310,64 @@ impl Default for NativeTextCompiler {
     }
 }
 
+fn line_advance(options: &NativeTextOptions) -> Result<f32, NativeTextError> {
+    if !options.line_spacing.is_finite() {
+        return Err(NativeTextError::InvalidLineSpacing);
+    }
+    let extra = if options.line_spacing == -1.0 {
+        MANIM_DEFAULT_LINE_SPACING
+    } else {
+        options.line_spacing
+    };
+    let advance = options.font_size * (1.0 + extra);
+    if !advance.is_finite() || advance <= 0.0 {
+        return Err(NativeTextError::InvalidLineSpacing);
+    }
+    Ok(advance)
+}
+
+fn split_source_lines(source: &str) -> Result<Vec<SourceLine<'_>>, NativeTextError> {
+    let bytes = source.as_bytes();
+    let mut lines = Vec::new();
+    let mut start = 0_usize;
+    let mut index = 0_usize;
+
+    while index < bytes.len() {
+        let separator_len = match bytes[index] {
+            b'\n' => 1,
+            b'\r' if bytes.get(index + 1) == Some(&b'\n') => 2,
+            b'\r' => 1,
+            _ => {
+                index += 1;
+                continue;
+            }
+        };
+        lines.push(SourceLine {
+            start: u32::try_from(start).map_err(|_| NativeTextError::SourceTooLarge)?,
+            text: &source[start..index],
+        });
+        index += separator_len;
+        start = index;
+    }
+
+    lines.push(SourceLine {
+        start: u32::try_from(start).map_err(|_| NativeTextError::SourceTooLarge)?,
+        text: &source[start..],
+    });
+    Ok(lines)
+}
+
 fn layout_artifact(
     source: &str,
     font: &NativeFontFace,
     options: &NativeTextOptions,
 ) -> TextLayoutArtifact {
     let mut identity = format!(
-        "{NATIVE_TEXT_BACKEND_VERSION}\0{NATIVE_TEXT_TEMPLATE_VERSION}\0{}\0{}\0{:08x}\0{source}",
+        "{NATIVE_TEXT_BACKEND_VERSION}\0{NATIVE_TEXT_TEMPLATE_VERSION}\0{}\0{}\0{:08x}\0{:08x}\0{source}",
         font.face_key,
         font.face_index,
-        options.font_size.to_bits()
+        options.font_size.to_bits(),
+        options.line_spacing.to_bits()
     );
     for setting in options.variations.iter() {
         identity.push('\0');
@@ -391,6 +475,56 @@ mod tests {
     }
 
     #[test]
+    fn multiline_layout_preserves_global_source_offsets_and_line_runs() {
+        let font = bundled_font();
+        let mut compiler = NativeTextCompiler::new();
+        let artifact = compiler
+            .compile_plain("A\r\ncafé", &font, &NativeTextOptions::new(24.0))
+            .unwrap();
+
+        assert_eq!(artifact.resource.runs.len(), 2);
+        assert_eq!(
+            artifact.resource.render_items.as_ref(),
+            &[TextRenderItem::GlyphRun(0), TextRenderItem::GlyphRun(1)]
+        );
+        assert!(!artifact.resource.runs[1].glyphs.is_empty());
+        assert!(artifact.resource.runs[1].glyphs.iter().all(|glyph| glyph
+            .cluster
+            .source_span
+            .start
+            >= 3));
+        assert!(artifact.resource.bounds.height() > 24.0);
+    }
+
+    #[test]
+    fn manim_line_spacing_semantics_change_multiline_height() {
+        let font = bundled_font();
+        let mut compiler = NativeTextCompiler::new();
+        let mut tight = NativeTextOptions::new(24.0);
+        tight.line_spacing = 0.0;
+        let mut wide = NativeTextOptions::new(24.0);
+        wide.line_spacing = 4.0;
+
+        let tight = compiler.compile_plain("A\nB", &font, &tight).unwrap();
+        let wide = compiler.compile_plain("A\nB", &font, &wide).unwrap();
+        assert!(wide.resource.bounds.height() > tight.resource.bounds.height());
+        assert!((line_advance(&NativeTextOptions::new(20.0)).unwrap() - 26.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn blank_lines_are_retained_as_layout_spacing_without_fake_glyphs() {
+        let font = bundled_font();
+        let mut compiler = NativeTextCompiler::new();
+        let artifact = compiler
+            .compile_plain("A\n\nB", &font, &NativeTextOptions::new(20.0))
+            .unwrap();
+        assert_eq!(artifact.resource.runs.len(), 3);
+        assert!(artifact.resource.runs[1].glyphs.is_empty());
+        assert_eq!(artifact.resource.glyph_count(), 2);
+        assert!(artifact.resource.bounds.height() > 40.0);
+    }
+
+    #[test]
     fn identical_input_has_deterministic_font_and_layout_identity() {
         let first_font = bundled_font();
         let second_font = bundled_font();
@@ -422,6 +556,36 @@ mod tests {
     }
 
     #[test]
+    fn line_spacing_participates_in_layout_identity() {
+        let font = bundled_font();
+        let mut first_options = NativeTextOptions::new(24.0);
+        first_options.line_spacing = 0.0;
+        let mut second_options = first_options.clone();
+        second_options.line_spacing = 2.0;
+        let mut compiler = NativeTextCompiler::new();
+        let first = compiler
+            .compile_plain("A\nB", &font, &first_options)
+            .unwrap();
+        let second = compiler
+            .compile_plain("A\nB", &font, &second_options)
+            .unwrap();
+        assert_ne!(
+            first
+                .resource
+                .layout_artifact
+                .as_ref()
+                .unwrap()
+                .artifact_fingerprint,
+            second
+                .resource
+                .layout_artifact
+                .as_ref()
+                .unwrap()
+                .artifact_fingerprint
+        );
+    }
+
+    #[test]
     fn layout_is_centered_without_outlining_glyphs() {
         let font = bundled_font();
         let mut compiler = NativeTextCompiler::new();
@@ -436,20 +600,22 @@ mod tests {
     }
 
     #[test]
-    fn multiline_and_invalid_font_size_fail_explicitly() {
+    fn invalid_font_size_and_line_spacing_fail_explicitly() {
         let font = bundled_font();
         let mut compiler = NativeTextCompiler::new();
-        assert_eq!(
-            compiler
-                .compile_plain("a\nb", &font, &NativeTextOptions::new(20.0))
-                .unwrap_err(),
-            NativeTextError::MultilineNotYetSupported
-        );
         assert_eq!(
             compiler
                 .compile_plain("a", &font, &NativeTextOptions::new(0.0))
                 .unwrap_err(),
             NativeTextError::InvalidFontSize
+        );
+        let mut invalid_spacing = NativeTextOptions::new(20.0);
+        invalid_spacing.line_spacing = -1.5;
+        assert_eq!(
+            compiler
+                .compile_plain("a\nb", &font, &invalid_spacing)
+                .unwrap_err(),
+            NativeTextError::InvalidLineSpacing
         );
     }
 }


### PR DESCRIPTION
## Summary
- extend `NativeTextOptions` with Manim-compatible `line_spacing` semantics
- split CR, LF, and CRLF source into visual lines while preserving original UTF-8 byte offsets
- emit one retained `GlyphRun` per visual line and preserve one backend painter stream
- retain blank lines as layout spacing without inventing glyphs or geometry
- center the combined multiline line-box while keeping the first visual line as the resource baseline
- include line-spacing semantics in deterministic layout fingerprints
- add multiline source-offset, CRLF, blank-line, spacing, identity, and validation tests

## Manim compatibility
ManimCE v0.21 maps `line_spacing=-1` to 30% extra spacing and otherwise uses `font_size * (1 + line_spacing)`. This slice preserves that rule in backend units before any eventual public mobject scaling.

## Scope
This remains LTR/Latin shaping inherited from #374. Script/direction itemization, bidi, fallback, styled spans, MarkupText, and frontend wrappers remain follow-up slices under #364.

## Stack
Based on #374 (`text/native-swash-backend`) so CI isolates this multiline/layout delta. Retarget to `master` after #374 lands.

Tracks #364. Architecture parent #361.