### PR TITLE
Add shared Arc query and metadata semantics

### DIFF
--- a/crates/noon/src/arc_authoring.rs
+++ b/crates/noon/src/arc_authoring.rs
@@ -3,9 +3,12 @@
 //! The authored representation stays on Noon's retained [`VectorPath`] pipeline.
 //! Arc curvature is expressed with the same cubic Bézier construction used by
 //! ManimCE's Cairo VMobject implementation instead of line-segment approximation.
+//! Query methods inspect the retained path after transforms, matching Manim's
+//! point-derived `get_start`, `get_end`, `get_arc_center`, and `stop_angle`
+//! behavior while keeping constructor metadata available separately.
 
 use crate::legacy::{IntoSnapshot, Path};
-use noon_core::{Color, ObjectSnapshot, Vec2, VectorPath, TAU};
+use noon_core::{Color, GeometryRef, ObjectSnapshot, PathCommand, Vec2, VectorPath, TAU};
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum ArcAuthoringError {
@@ -58,62 +61,134 @@ impl std::error::Error for ArcAuthoringError {}
 macro_rules! define_arc_shape {
     ($name:ident) => {
         #[derive(Clone, Debug, PartialEq)]
-        pub struct $name(ObjectSnapshot);
+        pub struct $name {
+            snapshot: ObjectSnapshot,
+            radius: f32,
+            start_angle: f32,
+            angle: f32,
+            num_components: usize,
+        }
 
         impl $name {
+            fn from_parts(
+                snapshot: ObjectSnapshot,
+                radius: f32,
+                start_angle: f32,
+                angle: f32,
+                num_components: usize,
+            ) -> Self {
+                Self {
+                    snapshot,
+                    radius,
+                    start_angle,
+                    angle,
+                    num_components,
+                }
+            }
+
             pub fn color(mut self, color: Color) -> Self {
-                self.0 = self.0.set_color(color);
+                self.snapshot = self.snapshot.set_color(color);
                 self
             }
 
             pub fn shift(mut self, offset: Vec2) -> Self {
-                self.0 = self.0.shift(offset);
+                self.snapshot = self.snapshot.shift(offset);
                 self
             }
 
             pub fn move_to(mut self, point: Vec2) -> Self {
-                self.0 = self.0.move_to(point);
+                self.snapshot = self.snapshot.move_to(point);
                 self
             }
 
             pub fn scale(mut self, factor: f32) -> Self {
-                self.0 = self.0.scale_by(factor);
+                self.snapshot = self.snapshot.scale_by(factor);
                 self
             }
 
             pub fn scale_xy(mut self, factor: Vec2) -> Self {
-                self.0 = self.0.scale_xy(factor);
+                self.snapshot = self.snapshot.scale_xy(factor);
                 self
             }
 
             pub fn rotate(mut self, angle: f32) -> Self {
-                self.0 = self.0.rotate_by(angle);
+                self.snapshot = self.snapshot.rotate_by(angle);
                 self
             }
 
             pub fn set_fill(mut self, color: Option<Color>, opacity: Option<f32>) -> Self {
-                self.0 = self.0.set_fill(color, opacity);
+                self.snapshot = self.snapshot.set_fill(color, opacity);
                 self
             }
 
             pub fn set_stroke(mut self, color: Option<Color>, width: Option<f32>) -> Self {
-                self.0 = self.0.set_stroke(color, width);
+                self.snapshot = self.snapshot.set_stroke(color, width);
                 self
             }
 
             pub fn set_opacity(mut self, opacity: f32) -> Self {
-                self.0 = self.0.set_opacity(opacity);
+                self.snapshot = self.snapshot.set_opacity(opacity);
                 self
             }
 
             pub fn snapshot(&self) -> &ObjectSnapshot {
-                &self.0
+                &self.snapshot
+            }
+
+            /// Constructor-time Manim `radius` metadata.
+            ///
+            /// As in Manim, ordinary affine transforms do not rewrite this attribute.
+            pub fn radius(&self) -> f32 {
+                self.radius
+            }
+
+            /// Constructor-time Manim `start_angle` metadata.
+            pub fn start_angle(&self) -> f32 {
+                self.start_angle
+            }
+
+            /// Constructor/resolution-time Manim `angle` metadata.
+            pub fn angle(&self) -> f32 {
+                self.angle
+            }
+
+            pub fn num_components(&self) -> usize {
+                self.num_components
+            }
+
+            /// Return the transformed first path anchor, matching VMobject `get_start()`.
+            pub fn get_start(&self) -> Vec2 {
+                path_start(&self.snapshot).expect("Arc retains a non-empty VectorPath")
+            }
+
+            /// Return the transformed final path anchor, matching VMobject `get_end()`.
+            pub fn get_end(&self) -> Vec2 {
+                path_end(&self.snapshot).expect("Arc retains a non-empty VectorPath")
+            }
+
+            /// Match Manim `Arc.get_arc_center()` by intersecting normals derived from
+            /// the transformed first cubic segment. A degenerate zero-radius arc returns
+            /// its first anchor; a line/parallel-normal fallback returns world ORIGIN.
+            pub fn get_arc_center(&self) -> Vec2 {
+                arc_center_from_snapshot(&self.snapshot)
+            }
+
+            pub fn move_arc_center_to(mut self, point: Vec2) -> Self {
+                let center = self.get_arc_center();
+                self.snapshot = self.snapshot.shift(point - center);
+                self
+            }
+
+            /// Match Manim `Arc.stop_angle()` in the 2D plane.
+            pub fn stop_angle(&self) -> f32 {
+                let delta = self.get_end() - self.get_arc_center();
+                delta.y.atan2(delta.x).rem_euclid(TAU)
             }
         }
 
         impl IntoSnapshot for $name {
             fn into_snapshot(self) -> ObjectSnapshot {
-                self.0
+                self.snapshot
             }
         }
     };
@@ -124,6 +199,90 @@ define_arc_shape!(ArcBetweenPoints);
 
 fn point_is_finite(point: Vec2) -> bool {
     point.x.is_finite() && point.y.is_finite()
+}
+
+fn path_start(snapshot: &ObjectSnapshot) -> Option<Vec2> {
+    let GeometryRef::VectorPath(path) = &snapshot.geometry else {
+        return None;
+    };
+    match path.commands().first().copied()? {
+        PathCommand::MoveTo { to } => Some(snapshot.transform.transform_point(to)),
+        _ => None,
+    }
+}
+
+fn path_end(snapshot: &ObjectSnapshot) -> Option<Vec2> {
+    let GeometryRef::VectorPath(path) = &snapshot.geometry else {
+        return None;
+    };
+    path.commands().iter().rev().find_map(|command| {
+        let point = match *command {
+            PathCommand::MoveTo { to }
+            | PathCommand::LineTo { to }
+            | PathCommand::QuadraticTo { to, .. }
+            | PathCommand::CubicTo { to, .. } => to,
+            PathCommand::Close => return None,
+        };
+        Some(snapshot.transform.transform_point(point))
+    })
+}
+
+fn cross(left: Vec2, right: Vec2) -> f32 {
+    left.x * right.y - left.y * right.x
+}
+
+fn line_intersection(
+    first_point: Vec2,
+    first_direction: Vec2,
+    second_point: Vec2,
+    second_direction: Vec2,
+) -> Option<Vec2> {
+    let denominator = cross(first_direction, second_direction);
+    if denominator.abs() <= f32::EPSILON {
+        return None;
+    }
+    let parameter = cross(second_point - first_point, second_direction) / denominator;
+    Some(first_point + first_direction * parameter)
+}
+
+fn arc_center_from_snapshot(snapshot: &ObjectSnapshot) -> Vec2 {
+    let GeometryRef::VectorPath(path) = &snapshot.geometry else {
+        return Vec2::ZERO;
+    };
+    let commands = path.commands();
+    let Some(PathCommand::MoveTo { to: first_anchor }) = commands.first().copied() else {
+        return Vec2::ZERO;
+    };
+    let Some(PathCommand::CubicTo {
+        control1: first_handle,
+        control2: second_handle,
+        to: second_anchor,
+    }) = commands.get(1).copied()
+    else {
+        // Manim's zero-angle ArcBetweenPoints line fallback cannot resolve a
+        // circular center and ultimately falls back to world ORIGIN.
+        return Vec2::ZERO;
+    };
+
+    let first_anchor = snapshot.transform.transform_point(first_anchor);
+    let first_handle = snapshot.transform.transform_point(first_handle);
+    let second_handle = snapshot.transform.transform_point(second_handle);
+    let second_anchor = snapshot.transform.transform_point(second_anchor);
+    if first_anchor == second_anchor {
+        return first_anchor;
+    }
+
+    let first_tangent = first_handle - first_anchor;
+    let second_tangent = second_handle - second_anchor;
+    let first_normal = Vec2::new(-first_tangent.y, first_tangent.x);
+    let second_normal = Vec2::new(-second_tangent.y, second_tangent.x);
+    line_intersection(
+        first_anchor,
+        first_normal,
+        second_anchor,
+        second_normal,
+    )
+    .unwrap_or(Vec2::ZERO)
 }
 
 fn validate_arc_inputs(
@@ -208,13 +367,14 @@ impl Arc {
         num_components: usize,
         arc_center: Vec2,
     ) -> Result<Self, ArcAuthoringError> {
-        Ok(Self(arc_snapshot(circular_arc_path(
+        let path = circular_arc_path(radius, start_angle, angle, num_components, arc_center)?;
+        Ok(Self::from_parts(
+            arc_snapshot(path),
             radius,
             start_angle,
             angle,
             num_components,
-            arc_center,
-        )?)))
+        ))
     }
 }
 
@@ -258,6 +418,7 @@ impl ArcBetweenPoints {
 
         let chord = end - start;
         let chord_length = chord.length();
+        let radius_was_explicit = radius.is_some();
         let (base_radius, resolved_angle) = match radius {
             Some(radius) => {
                 if !radius.is_finite() {
@@ -285,7 +446,13 @@ impl ArcBetweenPoints {
 
         if resolved_angle == 0.0 {
             let path = VectorPath::new().move_to(start).line_to(end);
-            return Ok(Self(arc_snapshot(path)));
+            return Ok(Self::from_parts(
+                arc_snapshot(path),
+                base_radius,
+                0.0,
+                resolved_angle,
+                num_components,
+            ));
         }
 
         let base_start = Vec2::new(base_radius, 0.0);
@@ -324,7 +491,18 @@ impl ArcBetweenPoints {
             path = path.cubic_to(transform(control1), transform(control2), transform(anchor1));
         }
 
-        Ok(Self(arc_snapshot(path)))
+        let resolved_radius = if radius_was_explicit {
+            base_radius
+        } else {
+            base_radius * scale
+        };
+        Ok(Self::from_parts(
+            arc_snapshot(path),
+            resolved_radius,
+            0.0,
+            resolved_angle,
+            num_components,
+        ))
     }
 }
 
@@ -346,6 +524,11 @@ mod tests {
             (actual - expected).abs() <= 1e-5,
             "expected {expected}, got {actual}"
         );
+    }
+
+    fn assert_vec_close(actual: Vec2, expected: Vec2) {
+        assert_close(actual.x, expected.x);
+        assert_close(actual.y, expected.y);
     }
 
     fn endpoint(command: PathCommand) -> Vec2 {
@@ -372,6 +555,14 @@ mod tests {
             arc.snapshot().style.stroke_width_mode,
             StrokeWidthMode::ScreenSpace
         );
+        assert_close(arc.radius(), 1.0);
+        assert_close(arc.start_angle(), 0.0);
+        assert_close(arc.angle(), TAU / 4.0);
+        assert_eq!(arc.num_components(), 9);
+        assert_vec_close(arc.get_start(), Vec2::new(1.0, 0.0));
+        assert_vec_close(arc.get_end(), Vec2::new(0.0, 1.0));
+        assert_vec_close(arc.get_arc_center(), Vec2::ZERO);
+        assert_close(arc.stop_angle(), TAU / 4.0);
     }
 
     #[test]
@@ -386,6 +577,37 @@ mod tests {
         assert_close(start.y, 1.0);
         assert_close(end.x, 5.0);
         assert_close(end.y, -1.0);
+        assert_close(arc.radius(), 2.0);
+        assert_close(arc.start_angle(), TAU / 4.0);
+        assert_close(arc.angle(), -TAU / 4.0);
+        assert_vec_close(arc.get_arc_center(), Vec2::new(3.0, -1.0));
+        assert_close(arc.stop_angle(), 0.0);
+    }
+
+    #[test]
+    fn transformed_queries_follow_retained_path_but_metadata_stays_authored() {
+        let arc = Arc::with_options(2.0, 0.0, TAU / 4.0, 9, Vec2::new(1.0, 2.0))
+            .expect("valid arc")
+            .scale(1.5)
+            .rotate(TAU / 8.0)
+            .shift(Vec2::new(-3.0, 4.0));
+        let expected_center = Vec2::new(1.0, 2.0)
+            .scale(1.5)
+            .rotate(TAU / 8.0)
+            + Vec2::new(-3.0, 4.0);
+        assert_vec_close(arc.get_arc_center(), expected_center);
+        assert_close(arc.radius(), 2.0);
+        assert_close(arc.start_angle(), 0.0);
+        assert_close(arc.angle(), TAU / 4.0);
+        assert_close(arc.stop_angle(), 3.0 * TAU / 8.0);
+    }
+
+    #[test]
+    fn move_arc_center_to_uses_derived_current_center() {
+        let arc = Arc::default()
+            .shift(Vec2::new(2.0, -3.0))
+            .move_arc_center_to(Vec2::new(-4.0, 5.0));
+        assert_vec_close(arc.get_arc_center(), Vec2::new(-4.0, 5.0));
     }
 
     #[test]
@@ -399,6 +621,26 @@ mod tests {
         let actual_end = endpoint(*commands.last().expect("arc has commands"));
         assert_close(actual_end.x, end.x);
         assert_close(actual_end.y, end.y);
+        assert_vec_close(arc.get_start(), start);
+        assert_vec_close(arc.get_end(), end);
+        assert_close(arc.angle(), TAU / 4.0);
+        assert_close(arc.start_angle(), 0.0);
+        let center = arc.get_arc_center();
+        assert_close(arc.radius(), (start - center).length());
+    }
+
+    #[test]
+    fn negative_explicit_radius_becomes_positive_metadata_and_negative_angle() {
+        let arc = ArcBetweenPoints::with_options(
+            Vec2::new(-1.0, 0.0),
+            Vec2::new(1.0, 0.0),
+            TAU / 4.0,
+            Some(-2.0),
+            9,
+        )
+        .expect("negative radius selects the opposite bend");
+        assert_close(arc.radius(), 2.0);
+        assert!(arc.angle() < 0.0);
     }
 
     #[test]
@@ -411,6 +653,11 @@ mod tests {
         assert_eq!(commands.len(), 2);
         assert_eq!(endpoint(commands[0]), start);
         assert_eq!(endpoint(commands[1]), end);
+        assert_vec_close(arc.get_start(), start);
+        assert_vec_close(arc.get_end(), end);
+        assert_vec_close(arc.get_arc_center(), Vec2::ZERO);
+        assert_close(arc.radius(), 1.0);
+        assert_close(arc.angle(), 0.0);
     }
 
     #[test]

--- a/crates/noon/src/arc_authoring.rs
+++ b/crates/noon/src/arc_authoring.rs
@@ -514,6 +514,18 @@ mod tests {
         assert_close(actual.y, expected.y);
     }
 
+    fn assert_vec_close_with_tolerance(actual: Vec2, expected: Vec2, tolerance: f32) {
+        assert!(
+            (actual.x - expected.x).abs() <= tolerance
+                && (actual.y - expected.y).abs() <= tolerance,
+            "expected ({}, {}), got ({}, {}) within {tolerance}",
+            expected.x,
+            expected.y,
+            actual.x,
+            actual.y
+        );
+    }
+
     fn endpoint(command: PathCommand) -> Vec2 {
         match command {
             PathCommand::MoveTo { to }
@@ -576,7 +588,7 @@ mod tests {
             .shift(Vec2::new(-3.0, 4.0));
         let expected_center = (Vec2::new(1.0, 2.0) * 1.5).rotate(TAU / 8.0)
             + Vec2::new(-3.0, 4.0);
-        assert_vec_close(arc.get_arc_center(), expected_center);
+        assert_vec_close_with_tolerance(arc.get_arc_center(), expected_center, 1e-4);
         assert_close(arc.radius(), 2.0);
         assert_close(arc.start_angle(), 0.0);
         assert_close(arc.angle(), TAU / 4.0);

--- a/crates/noon/src/arc_authoring.rs
+++ b/crates/noon/src/arc_authoring.rs
@@ -271,13 +271,8 @@ fn arc_center_from_snapshot(snapshot: &ObjectSnapshot) -> Vec2 {
     let second_tangent = second_handle - second_anchor;
     let first_normal = Vec2::new(-first_tangent.y, first_tangent.x);
     let second_normal = Vec2::new(-second_tangent.y, second_tangent.x);
-    line_intersection(
-        first_anchor,
-        first_normal,
-        second_anchor,
-        second_normal,
-    )
-    .unwrap_or(Vec2::ZERO)
+    line_intersection(first_anchor, first_normal, second_anchor, second_normal)
+        .unwrap_or(Vec2::ZERO)
 }
 
 fn validate_arc_inputs(
@@ -509,6 +504,13 @@ mod tests {
         );
     }
 
+    fn assert_close_with_tolerance(actual: f32, expected: f32, tolerance: f32) {
+        assert!(
+            (actual - expected).abs() <= tolerance,
+            "expected {expected}, got {actual} within {tolerance}"
+        );
+    }
+
     fn assert_vec_close(actual: Vec2, expected: Vec2) {
         assert_close(actual.x, expected.x);
         assert_close(actual.y, expected.y);
@@ -586,13 +588,12 @@ mod tests {
             .scale(1.5)
             .rotate(TAU / 8.0)
             .shift(Vec2::new(-3.0, 4.0));
-        let expected_center = (Vec2::new(1.0, 2.0) * 1.5).rotate(TAU / 8.0)
-            + Vec2::new(-3.0, 4.0);
+        let expected_center = (Vec2::new(1.0, 2.0) * 1.5).rotate(TAU / 8.0) + Vec2::new(-3.0, 4.0);
         assert_vec_close_with_tolerance(arc.get_arc_center(), expected_center, 1e-4);
         assert_close(arc.radius(), 2.0);
         assert_close(arc.start_angle(), 0.0);
         assert_close(arc.angle(), TAU / 4.0);
-        assert_close(arc.stop_angle(), 3.0 * TAU / 8.0);
+        assert_close_with_tolerance(arc.stop_angle(), 3.0 * TAU / 8.0, 1e-4);
     }
 
     #[test]

--- a/crates/noon/src/arc_authoring.rs
+++ b/crates/noon/src/arc_authoring.rs
@@ -135,19 +135,16 @@ macro_rules! define_arc_shape {
                 &self.snapshot
             }
 
-            /// Constructor-time Manim `radius` metadata.
-            ///
-            /// As in Manim, ordinary affine transforms do not rewrite this attribute.
+            /// Constructor-time Manim `radius` metadata. Ordinary affine transforms
+            /// alter points, not this authored attribute, matching Manim.
             pub fn radius(&self) -> f32 {
                 self.radius
             }
 
-            /// Constructor-time Manim `start_angle` metadata.
             pub fn start_angle(&self) -> f32 {
                 self.start_angle
             }
 
-            /// Constructor/resolution-time Manim `angle` metadata.
             pub fn angle(&self) -> f32 {
                 self.angle
             }
@@ -259,8 +256,6 @@ fn arc_center_from_snapshot(snapshot: &ObjectSnapshot) -> Vec2 {
         to: second_anchor,
     }) = commands.get(1).copied()
     else {
-        // Manim's zero-angle ArcBetweenPoints line fallback cannot resolve a
-        // circular center and ultimately falls back to world ORIGIN.
         return Vec2::ZERO;
     };
 
@@ -350,16 +345,11 @@ fn arc_snapshot(path: VectorPath) -> ObjectSnapshot {
 }
 
 impl Arc {
-    /// Build ManimCE's default quarter-circle arc.
     pub fn new() -> Self {
         Self::with_options(1.0, 0.0, TAU / 4.0, 9, Vec2::ZERO)
             .expect("the built-in Arc default is valid")
     }
 
-    /// Build a circular arc using ManimCE's anchor/handle construction.
-    ///
-    /// `num_components` matches Manim's Cairo `Arc`: it is the number of anchors,
-    /// so the retained path contains `num_components - 1` cubic Bézier segments.
     pub fn with_options(
         radius: f32,
         start_angle: f32,
@@ -385,17 +375,10 @@ impl Default for Arc {
 }
 
 impl ArcBetweenPoints {
-    /// Build the default quarter-turn arc spanning `start` to `end`.
     pub fn new(start: Vec2, end: Vec2) -> Result<Self, ArcAuthoringError> {
         Self::with_options(start, end, TAU / 4.0, None, 9)
     }
 
-    /// Build an arc spanning two endpoints with ManimCE-compatible angle/radius rules.
-    ///
-    /// When `radius` is supplied, Manim derives the subtended angle from the chord;
-    /// a negative radius selects the opposite bend direction. Without an explicit
-    /// radius, the authored `angle` is preserved and the unit arc is similarity-
-    /// transformed so its endpoints land exactly on `start` and `end`.
     pub fn with_options(
         start: Vec2,
         end: Vec2,
@@ -591,9 +574,7 @@ mod tests {
             .scale(1.5)
             .rotate(TAU / 8.0)
             .shift(Vec2::new(-3.0, 4.0));
-        let expected_center = Vec2::new(1.0, 2.0)
-            .scale(1.5)
-            .rotate(TAU / 8.0)
+        let expected_center = (Vec2::new(1.0, 2.0) * 1.5).rotate(TAU / 8.0)
             + Vec2::new(-3.0, 4.0);
         assert_vec_close(arc.get_arc_center(), expected_center);
         assert_close(arc.radius(), 2.0);


### PR DESCRIPTION
## Summary
- extend shared Rust `Arc` and `ArcBetweenPoints` authoring with ManimCE v0.21 query semantics for `get_start`, `get_end`, `get_arc_center`, `move_arc_center_to`, and `stop_angle`
- retain constructor/resolution metadata for `radius`, `start_angle`, `angle`, and `num_components` without rewriting those attributes during ordinary affine transforms
- derive geometric queries from the transformed retained `VectorPath`, including Manim's first-segment normal-intersection rule for `get_arc_center()` rather than trusting constructor-time center metadata
- match `ArcBetweenPoints` radius semantics: explicit negative radii normalize to positive radius metadata with the opposite signed angle; omitted radii are recomputed after fitting the endpoint chord
- preserve the zero-angle line fallback and its center/radius behavior
- add focused tests for defaults, signed angles, transformed path queries, center movement, endpoint fitting, negative explicit radius, and zero-angle fallback

## Architecture
This changes only `crates/noon/src/arc_authoring.rs`. It does not add renderer primitives or frontend-owned query math; Python/JS adapters can delegate to the same retained Rust semantics.

## Reference semantics
Checked against ManimCE v0.21 `manim/mobject/geometry/arc.py`, especially `Arc.get_arc_center`, `Arc.stop_angle`, and `ArcBetweenPoints.__init__`.

Tracks the query-behavior acceptance work in #76.