### PR TITLE
Harden demo worker recovery

### DIFF
--- a/scripts/authoring-execution-router-smoke.mjs
+++ b/scripts/authoring-execution-router-smoke.mjs
@@ -278,3 +278,5 @@ try {
   await browser?.close();
   await new Promise((resolve) => server.close(resolve));
 }
+
+await import("./playground-race-smoke.mjs");

--- a/scripts/authoring-execution-router-smoke.mjs
+++ b/scripts/authoring-execution-router-smoke.mjs
@@ -143,6 +143,10 @@ try {
     await new Promise((resolve) => setTimeout(resolve, 350));
     const mixedMetrics = await execution.metrics();
     const mixedCanvas = execution.canvas;
+    const mixedRestartReady = await execution.restart();
+    const mixedRestartCanvas = execution.canvas;
+    const mixedRestartMetrics = await execution.metrics();
+    const mixedRestartState = await execution.state();
 
     let callbackError = null;
     try {
@@ -181,6 +185,9 @@ try {
       callbacks: legacy.callbacks,
       authoringClient: authoring,
     });
+    const legacyRestartReady = await execution.restart();
+    const legacyRestartCanvas = execution.canvas;
+    const legacyRestartMetrics = await execution.metrics();
 
     const state = await execution.state();
     const summary = {
@@ -195,18 +202,24 @@ try {
       mixedRaceMode: mixedRaceMetrics.executionMode,
       mixedRaceRetainedChannel: JSON.parse(mixedRaceState.retainedDocumentJson).channel,
       mixedMetrics,
+      mixedRestartMode: mixedRestartReady.mode,
+      mixedRestartCanvasChanged: mixedRestartCanvas !== mixedCanvas,
+      mixedRestartObjectCount: mixedRestartMetrics.metrics.objectCount,
+      mixedRestartRetainedChannel: JSON.parse(mixedRestartState.retainedDocumentJson).channel,
       callbackError,
       legacyRetainedObjectCount,
       retainedRaceModeBeforeLegacy: retainedRaceMetrics.executionMode,
       legacyMode: legacyResult.mode,
       legacyRebuilt: legacyResult.rebuilt,
-      legacyCanvasChanged: legacyCanvas !== mixedCanvas,
+      legacyCanvasChanged: legacyCanvas !== mixedRestartCanvas,
       legacyRaceMode: legacyRaceMetrics.executionMode,
       legacyRaceObjectCount: JSON.parse(legacyRaceState.sceneJson).objects.length,
       legacyMetrics,
       secondLegacyMode: secondLegacy.mode,
       secondLegacyRebuilt: secondLegacy.rebuilt,
-      sameLegacyCanvas: execution.canvas === legacyCanvas,
+      legacyRestartMode: legacyRestartReady.mode,
+      legacyRestartCanvasChanged: legacyRestartCanvas !== legacyCanvas,
+      legacyRestartObjectCount: legacyRestartMetrics.metrics.objectCount,
       state,
       transportMode: execution.transportMode,
       rendererBackend: execution.rendererBackend,
@@ -233,6 +246,10 @@ try {
   assert.equal(result.mixedMetrics.engineMetrics.resourceBundleTransfers, 1);
   assert.ok(result.mixedMetrics.engineMetrics.resourceBundleBytes > 0);
   assert.equal(result.mixedMetrics.engineMetrics.host.enabled, false);
+  assert.equal(result.mixedRestartMode, result.retainedMode);
+  assert.equal(result.mixedRestartCanvasChanged, true);
+  assert.equal(result.mixedRestartObjectCount, 3);
+  assert.equal(result.mixedRestartRetainedChannel, "noon.authoring.retained");
   assert.match(result.callbackError, /retained authoring with Python host callbacks is not supported yet/);
 
   assert.equal(result.legacyRetainedObjectCount, 0, "geometry-only authoring should emit an empty sidecar");
@@ -247,13 +264,15 @@ try {
   assert.equal(typeof result.legacyMetrics.engineMetrics.host.enabled, "boolean");
   assert.equal(result.secondLegacyMode, result.initialMode);
   assert.equal(result.secondLegacyRebuilt, false);
-  assert.equal(result.sameLegacyCanvas, true);
+  assert.equal(result.legacyRestartMode, result.initialMode);
+  assert.equal(result.legacyRestartCanvasChanged, true);
+  assert.equal(result.legacyRestartObjectCount, 2);
   assert.equal(JSON.parse(result.state.sceneJson).objects.length, 2);
   assert.match(result.rendererBackend, /WebGPU|WebGL2/);
   assert.deepEqual(result.clientErrors, []);
   assert.deepEqual(browserErrors, []);
   console.log(
-    `✓ authoring execution router: legacy → retained → legacy on ${result.rendererBackend}`,
+    `✓ authoring execution router: legacy → retained → restart → legacy → restart on ${result.rendererBackend}`,
   );
 } finally {
   await browser?.close();

--- a/scripts/build-web-demo.sh
+++ b/scripts/build-web-demo.sh
@@ -6,6 +6,7 @@ noon_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$noon_root"
 
 node --check web/main.js
+node --check web/playground-generation.js
 node --check web/example-gallery.js
 node --check web/authoring-client.js
 node --check web/python-worker.js
@@ -57,6 +58,7 @@ node --check scripts/updater-callback-smoke.mjs
 node --test web/example-gallery.test.mjs
 node --test web/execution-transport.test.mjs
 node --test web/authoring-client.test.mjs
+node --test web/playground-generation.test.mjs
 node --test web/scene-identity.test.mjs
 node --test web/frame-metrics.test.mjs
 node --test web/browser-jank.test.mjs

--- a/scripts/playground-race-smoke.mjs
+++ b/scripts/playground-race-smoke.mjs
@@ -3,6 +3,45 @@ import { spawn } from "node:child_process";
 
 import playwright from "playwright";
 
+import { PlaygroundGeneration } from "../web/playground-generation.js";
+
+function stressGenerationGate() {
+  const generations = new PlaygroundGeneration();
+  let seed = 0x6e6f6f6e;
+  const random = () => {
+    seed ^= seed << 13;
+    seed ^= seed >>> 17;
+    seed ^= seed << 5;
+    return seed >>> 0;
+  };
+
+  let activeExample = "scene-0";
+  generations.commitSelection(generations.beginSelectionRequest(activeExample));
+  let latestRun = generations.beginRun(activeExample);
+  const staleRuns = [];
+
+  for (let index = 0; index < 500; index += 1) {
+    if (random() % 3 === 0) {
+      const request = generations.beginSelectionRequest(`scene-${index + 1}`);
+      const committed = generations.commitSelection(request);
+      assert.ok(committed);
+      staleRuns.push(latestRun);
+      activeExample = committed.exampleId;
+      latestRun = generations.beginRun(activeExample);
+    } else {
+      staleRuns.push(latestRun);
+      latestRun = generations.beginRun(activeExample);
+    }
+    assert.equal(generations.isRunCurrent(latestRun, activeExample), true);
+    const sample = staleRuns[random() % staleRuns.length];
+    if (sample) {
+      assert.equal(generations.isRunCurrent(sample, activeExample), false);
+    }
+  }
+}
+
+stressGenerationGate();
+
 const { chromium } = playwright;
 const port = Number(process.env.NOON_PLAYGROUND_RACE_PORT ?? "4184");
 const baseUrl = `http://127.0.0.1:${port}`;
@@ -197,7 +236,7 @@ try {
 
   assert.deepEqual(browserErrors, [], `playground emitted browser errors:\n${browserErrors.join("\n")}`);
   console.log(
-    `✓ playground generations: ${staleRace.diagnostics.staleDrops} stale result(s) rejected; duplicate Run coalesced`,
+    `✓ playground generations: 500 seeded operations + ${staleRace.diagnostics.staleDrops} stale result(s) rejected; duplicate Run coalesced`,
   );
 } finally {
   if (browser !== null) await browser.close();

--- a/scripts/playground-race-smoke.mjs
+++ b/scripts/playground-race-smoke.mjs
@@ -168,8 +168,14 @@ try {
   await page.evaluate(() => {
     window.__newestSelection = window.__noonExampleGallery.select("parity-create-circle");
   });
+  // A selection request intentionally does not invalidate the current scene while
+  // its source is still loading. Wait for the newer selection to commit: that is
+  // the contract boundary that advances selection/run generations and makes the
+  // held older authoring result stale.
   await page.waitForFunction(
-    () => window.__noonExampleGallery.generationDiagnostics.selectionRequestGeneration >= 3,
+    () => window.__noonExampleGallery.generationDiagnostics.selectionGeneration >= 3,
+    null,
+    { timeout: 30_000 },
   );
   await page.evaluate(() => {
     const release = window.__noonRace.release;

--- a/scripts/playground-race-smoke.mjs
+++ b/scripts/playground-race-smoke.mjs
@@ -1,0 +1,205 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+
+import playwright from "playwright";
+
+const { chromium } = playwright;
+const port = Number(process.env.NOON_PLAYGROUND_RACE_PORT ?? "4184");
+const baseUrl = `http://127.0.0.1:${port}`;
+
+let serverOutput = "";
+const server = spawn(
+  "python3",
+  ["-m", "http.server", String(port), "--bind", "127.0.0.1", "--directory", "."],
+  { stdio: ["ignore", "pipe", "pipe"] },
+);
+server.stdout.on("data", (chunk) => {
+  serverOutput += chunk;
+});
+server.stderr.on("data", (chunk) => {
+  serverOutput += chunk;
+});
+
+async function waitForServer() {
+  let lastError = null;
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    try {
+      const response = await fetch(`${baseUrl}/web/index.html`);
+      if (response.ok) return;
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Playground race server did not start: ${lastError}\n${serverOutput}`);
+}
+
+async function waitForApplied(page, exampleId, browserErrors) {
+  await page.waitForFunction(
+    (id) => {
+      const gallery = window.__noonExampleGallery;
+      const patch = document.querySelector("#patch-status");
+      return (
+        gallery?.selectedExampleId === id &&
+        patch?.dataset.exampleId === id &&
+        (patch.dataset.state === "applied" || patch.dataset.state === "error")
+      );
+    },
+    exampleId,
+    { timeout: 60_000 },
+  );
+  const status = await page.evaluate(() => ({
+    state: document.querySelector("#patch-status")?.dataset.state,
+    text:
+      document.querySelector("#patch-status")?.value ??
+      document.querySelector("#patch-status")?.textContent ??
+      "",
+  }));
+  assert.equal(
+    status.state,
+    "applied",
+    `${exampleId}: authoring failed: ${status.text}\n${browserErrors.join("\n")}`,
+  );
+}
+
+let browser = null;
+try {
+  await waitForServer();
+  browser = await chromium.launch({
+    channel: "chromium",
+    headless: true,
+    args: [
+      "--disable-features=WebGPU",
+      "--enable-unsafe-swiftshader",
+      "--ignore-gpu-blocklist",
+      "--use-gl=angle",
+      "--use-angle=swiftshader",
+      "--disable-gpu-sandbox",
+      "--disable-dev-shm-usage",
+    ],
+  });
+  const page = await browser.newPage({ viewport: { width: 1200, height: 800 } });
+  const browserErrors = [];
+  page.on("pageerror", (error) => browserErrors.push(`pageerror: ${error}`));
+  page.on("console", (message) => {
+    if (message.type() === "error") browserErrors.push(`console: ${message.text()}`);
+  });
+
+  await page.addInitScript(() => {
+    window.__noonRace = {
+      authoringCounts: {},
+      reconciles: [],
+      holdNextExample: null,
+      holdReached: 0,
+      release: null,
+    };
+    window.__NOON_PLAYGROUND_TEST_HOOKS__ = {
+      afterAuthoring(payload) {
+        const race = window.__noonRace;
+        race.authoringCounts[payload.exampleId] =
+          (race.authoringCounts[payload.exampleId] ?? 0) + 1;
+        if (race.holdNextExample !== payload.exampleId) return undefined;
+        race.holdNextExample = null;
+        race.holdReached += 1;
+        return new Promise((resolve) => {
+          race.release = resolve;
+        });
+      },
+      beforeReconcile(payload) {
+        window.__noonRace.reconciles.push(payload.exampleId);
+      },
+    };
+  });
+
+  await page.goto(`${baseUrl}/web/index.html?example=parity-square-and-circle`, {
+    waitUntil: "load",
+  });
+  await waitForApplied(page, "parity-square-and-circle", browserErrors);
+
+  const raceBaseline = await page.evaluate(() => window.__noonRace.reconciles.length);
+  await page.evaluate(() => {
+    window.__noonRace.holdNextExample = "parity-different-rotations";
+    window.__staleSelection = window.__noonExampleGallery.select("parity-different-rotations");
+  });
+  await page.waitForFunction(() => window.__noonRace.holdReached === 1, null, {
+    timeout: 30_000,
+  });
+
+  await page.evaluate(() => {
+    window.__newestSelection = window.__noonExampleGallery.select("parity-create-circle");
+  });
+  await page.waitForFunction(
+    () => window.__noonExampleGallery.generationDiagnostics.selectionRequestGeneration >= 3,
+  );
+  await page.evaluate(() => {
+    const release = window.__noonRace.release;
+    window.__noonRace.release = null;
+    release?.();
+  });
+  await page.evaluate(async () => {
+    await Promise.all([window.__staleSelection, window.__newestSelection]);
+  });
+  await waitForApplied(page, "parity-create-circle", browserErrors);
+
+  const staleRace = await page.evaluate((baseline) => ({
+    selected: window.__noonExampleGallery.selectedExampleId,
+    diagnostics: window.__noonExampleGallery.generationDiagnostics,
+    reconciles: window.__noonRace.reconciles.slice(baseline),
+    patchExample: document.querySelector("#patch-status")?.dataset.exampleId,
+  }), raceBaseline);
+  assert.equal(staleRace.selected, "parity-create-circle");
+  assert.equal(staleRace.patchExample, "parity-create-circle");
+  assert.ok(staleRace.diagnostics.staleDrops >= 1, "stale result must be counted");
+  assert.equal(
+    staleRace.reconciles.includes("parity-different-rotations"),
+    false,
+    "stale authored scene must never reach reconcileScene",
+  );
+  assert.equal(
+    staleRace.reconciles.at(-1),
+    "parity-create-circle",
+    "newest selection must own the final reconciliation",
+  );
+
+  const duplicateBaseline = await page.evaluate(
+    () => window.__noonRace.authoringCounts["parity-create-circle"] ?? 0,
+  );
+  await page.evaluate(() => {
+    window.__noonRace.holdNextExample = "parity-create-circle";
+    window.__runA = window.__noonExampleGallery.run();
+    window.__runB = window.__noonExampleGallery.run();
+  });
+  await page.waitForFunction(() => window.__noonRace.holdReached === 2, null, {
+    timeout: 30_000,
+  });
+  const whileHeld = await page.evaluate(
+    () => window.__noonRace.authoringCounts["parity-create-circle"] ?? 0,
+  );
+  assert.equal(
+    whileHeld,
+    duplicateBaseline + 1,
+    "two simultaneous Run requests must start only one Python authoring request",
+  );
+  await page.evaluate(() => {
+    const release = window.__noonRace.release;
+    window.__noonRace.release = null;
+    release?.();
+  });
+  await page.evaluate(async () => {
+    await Promise.all([window.__runA, window.__runB]);
+  });
+  await waitForApplied(page, "parity-create-circle", browserErrors);
+  const duplicateFinal = await page.evaluate(
+    () => window.__noonRace.authoringCounts["parity-create-circle"] ?? 0,
+  );
+  assert.equal(duplicateFinal, duplicateBaseline + 1);
+
+  assert.deepEqual(browserErrors, [], `playground emitted browser errors:\n${browserErrors.join("\n")}`);
+  console.log(
+    `✓ playground generations: ${staleRace.diagnostics.staleDrops} stale result(s) rejected; duplicate Run coalesced`,
+  );
+} finally {
+  if (browser !== null) await browser.close();
+  server.kill("SIGTERM");
+}

--- a/web/authoring-client.js
+++ b/web/authoring-client.js
@@ -28,6 +28,10 @@ export class PythonAuthoringClient {
     });
   }
 
+  get terminated() {
+    return this.#terminated;
+  }
+
   ready() {
     return this.#readyPromise;
   }

--- a/web/authoring-client.test.mjs
+++ b/web/authoring-client.test.mjs
@@ -247,6 +247,24 @@ test("rejects only the request associated with a Python execution error", async 
   );
 
   await assert.rejects(resultPromise, /broken/);
+  assert.equal(client.terminated, false, "ordinary Python errors keep the worker reusable");
+});
+
+test("exposes fatal Python worker termination to recovery owners", async () => {
+  const worker = new FakeWorker();
+  const client = new PythonAuthoringClient(worker);
+  worker.emit("message", workerMessage("ready"));
+  await client.ready();
+  assert.equal(client.terminated, false);
+
+  const resultPromise = client.run("result = scene");
+  await Promise.resolve();
+  worker.emit("error", { message: "worker crashed" });
+
+  await assert.rejects(resultPromise, /worker crashed/);
+  assert.equal(client.terminated, true);
+  assert.equal(worker.terminated, true);
+  await assert.rejects(client.run("result = retry"), /terminated/);
 });
 
 test("rejects malformed PatchBatch documents before they reach Rust", () => {
@@ -317,5 +335,6 @@ test("terminating the client rejects pending work", async () => {
   client.terminate();
 
   assert.equal(worker.terminated, true);
+  assert.equal(client.terminated, true);
   await assert.rejects(resultPromise, /terminated/);
 });

--- a/web/authoring-execution-client.js
+++ b/web/authoring-execution-client.js
@@ -157,6 +157,19 @@ export class AuthoringExecutionClient {
     return result;
   }
 
+  async restart() {
+    return this.#withStablePlayer(async (player, mode) => {
+      const ready = await player.restart();
+      this.#canvas = player.canvas;
+      this.#mode = mode;
+      this.#rendererBackend = ready.render.backend;
+      this.#transportMode = ready.transportMode;
+      this.#observeCanvas();
+      this.#resizeCurrentCanvas();
+      return { ...ready, mode };
+    });
+  }
+
   async applyPatchBatch(patchBatchJson) {
     return this.#withStablePlayer((player, mode) => {
       if (mode !== AUTHORING_EXECUTION_LEGACY) {

--- a/web/main.js
+++ b/web/main.js
@@ -277,6 +277,8 @@ const drafts = new Map();
 const sourceCache = new Map();
 let player = null;
 let rendererBackend = "";
+let sceneRunInFlight = false;
+let playerNeedsRestart = false;
 
 function currentExample() {
   return SCENE_EXAMPLES.find((example) => example.id === selectedExampleId) ?? null;
@@ -316,6 +318,26 @@ function formatBytes(bytes) {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KiB`;
   return `${(bytes / (1024 * 1024)).toFixed(1)} MiB`;
+}
+
+function ensureAuthoringClient() {
+  if (authoringClient?.terminated) {
+    authoringClient = null;
+  }
+  authoringClient ??= new PythonAuthoringClient();
+  return authoringClient;
+}
+
+async function ensureExecutionReady() {
+  if (!playerNeedsRestart) return;
+  patchStatus.value = "Restarting runtime workers…";
+  patchStatus.dataset.state = "running";
+  setRuntimeStatus("Restarting runtime workers…", "running");
+  const ready = await player.restart();
+  playerNeedsRestart = false;
+  rendererBackend = ready.render.backend;
+  status.dataset.rendererBackend = rendererBackend;
+  status.dataset.executionMode = player.mode;
 }
 
 async function loadDemoAuthoringSource(path) {
@@ -398,13 +420,23 @@ function renderGallery() {
 
 async function runScene() {
   const example = currentExample();
-  if (!example || !player) return;
+  if (!example || !player || sceneRunInFlight) return;
+  sceneRunInFlight = true;
   setBusy(true);
   try {
+    await ensureExecutionReady();
     patchStatus.value = `Building ${example.title} in the Python worker…`;
     patchStatus.dataset.state = "running";
-    authoringClient ??= new PythonAuthoringClient();
-    const authored = await authoringClient.run(sceneSourceEditor.value, {});
+    const client = ensureAuthoringClient();
+    let authored;
+    try {
+      authored = await client.run(sceneSourceEditor.value, {});
+    } catch (error) {
+      if (client.terminated && authoringClient === client) {
+        authoringClient = null;
+      }
+      throw error;
+    }
     if (authored.kind !== "scene_document") {
       throw new Error("Python scene source returned a PatchBatch");
     }
@@ -417,7 +449,7 @@ async function runScene() {
       retainedDocumentJson:
         authored.retainedDocument === null ? null : JSON.stringify(authored.retainedDocument),
       callbacks: authored.callbacks,
-      authoringClient,
+      authoringClient: client,
       loopDurationSeconds: authored.duration > 0 ? authored.duration : null,
     });
     rendererBackend = player.rendererBackend;
@@ -433,6 +465,7 @@ async function runScene() {
   } catch (error) {
     showSceneError(error);
   } finally {
+    sceneRunInFlight = false;
     setBusy(false);
   }
 }
@@ -515,6 +548,7 @@ const EMPTY_SCENE_JSON = '{"version":1,"objects":[],"tracks":[]}';
 try {
   player = new AuthoringExecutionClient(canvas, {
     onError(error) {
+      playerNeedsRestart = true;
       showError(error);
     },
   });
@@ -562,7 +596,14 @@ try {
   let lastStatusUpdate = -Infinity;
   let metricsPending = false;
   async function updateWorkerMetrics(timestamp) {
-    if (metricsPending || timestamp - lastStatusUpdate <= 200) return;
+    if (
+      metricsPending ||
+      sceneRunInFlight ||
+      playerNeedsRestart ||
+      timestamp - lastStatusUpdate <= 200
+    ) {
+      return;
+    }
     metricsPending = true;
     try {
       const report = await player.metrics();
@@ -593,7 +634,9 @@ try {
       status.dataset.presentedFrames = String(metrics.presentedFrames);
       lastStatusUpdate = timestamp;
     } catch (error) {
-      showError(error);
+      if (!playerNeedsRestart) {
+        showError(error);
+      }
     } finally {
       metricsPending = false;
     }

--- a/web/main.js
+++ b/web/main.js
@@ -1,5 +1,6 @@
 import { AuthoringExecutionClient } from "./authoring-execution-client.js";
 import { PythonAuthoringClient } from "./authoring-client.js";
+import { PlaygroundGeneration } from "./playground-generation.js";
 import { SceneIdentityMap } from "./scene-identity.js";
 import {
   exampleUrl,
@@ -275,10 +276,12 @@ let authoringClient = null;
 const sceneIdentities = new SceneIdentityMap();
 const drafts = new Map();
 const sourceCache = new Map();
+const generations = new PlaygroundGeneration();
 let player = null;
 let rendererBackend = "";
-let sceneRunInFlight = false;
+let sceneRunPromise = null;
 let playerNeedsRestart = false;
+let busyDepth = 0;
 
 function currentExample() {
   return SCENE_EXAMPLES.find((example) => example.id === selectedExampleId) ?? null;
@@ -300,6 +303,18 @@ function setBusy(busy) {
   }
 }
 
+function beginBusy() {
+  busyDepth += 1;
+  setBusy(true);
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    busyDepth = Math.max(0, busyDepth - 1);
+    if (busyDepth === 0) setBusy(false);
+  };
+}
+
 function showError(error) {
   console.error(error);
   setRuntimeStatus(`Error: ${error}`, "error");
@@ -311,6 +326,17 @@ function showSceneError(error) {
   console.error(error);
   patchStatus.value = `Python failed: ${error}`;
   patchStatus.dataset.state = "error";
+}
+
+function recordStale(token, stage) {
+  const diagnostics = generations.recordStale(token, stage);
+  status.dataset.staleResults = String(diagnostics.staleDrops);
+  status.dataset.lastStaleStage = diagnostics.lastStale?.stage ?? "";
+  console.debug(
+    `[Noon playground] dropped stale ${token?.kind ?? "unknown"} result`,
+    diagnostics.lastStale,
+  );
+  return { stale: true, stage };
 }
 
 function formatBytes(bytes) {
@@ -338,6 +364,13 @@ async function ensureExecutionReady() {
   rendererBackend = ready.render.backend;
   status.dataset.rendererBackend = rendererBackend;
   status.dataset.executionMode = player.mode;
+}
+
+async function runPlaygroundTestHook(name, payload) {
+  const hook = globalThis.__NOON_PLAYGROUND_TEST_HOOKS__?.[name];
+  if (typeof hook === "function") {
+    await hook(payload);
+  }
 }
 
 async function loadDemoAuthoringSource(path) {
@@ -418,55 +451,106 @@ function renderGallery() {
   }
 }
 
-async function runScene() {
-  const example = currentExample();
-  if (!example || !player || sceneRunInFlight) return;
-  sceneRunInFlight = true;
-  setBusy(true);
-  try {
-    await ensureExecutionReady();
-    patchStatus.value = `Building ${example.title} in the Python worker…`;
-    patchStatus.dataset.state = "running";
-    const client = ensureAuthoringClient();
-    let authored;
-    try {
-      authored = await client.run(sceneSourceEditor.value, {});
-    } catch (error) {
-      if (client.terminated && authoringClient === client) {
-        authoringClient = null;
-      }
-      throw error;
-    }
-    if (authored.kind !== "scene_document") {
-      throw new Error("Python scene source returned a PatchBatch");
-    }
+function isCurrentRun(runToken) {
+  return generations.isRunCurrent(runToken, selectedExampleId);
+}
 
-    const runtimeDocument =
-      authored.callbacks === null
-        ? sceneIdentities.stabilize(authored.document, authored.identities)
-        : authored.document;
-    const result = await player.reconcileScene(JSON.stringify(runtimeDocument), {
-      retainedDocumentJson:
-        authored.retainedDocument === null ? null : JSON.stringify(authored.retainedDocument),
-      callbacks: authored.callbacks,
-      authoringClient: client,
-      loopDurationSeconds: authored.duration > 0 ? authored.duration : null,
-    });
-    rendererBackend = player.rendererBackend;
-    status.dataset.rendererBackend = rendererBackend;
-    status.dataset.executionMode = player.mode;
-    const report = await player.metrics();
-    const operation = result.incremental ? "Scene updated incrementally" : "Scene rebuilt atomically";
-    patchStatus.value = `${operation} · ${example.title} · ${report.metrics.objectCount} objects`;
-    patchStatus.dataset.state = "applied";
-    patchStatus.dataset.exampleId = example.id;
-    patchStatus.dataset.parityStatus = example.parityStatus;
-    patchStatus.dataset.sequence = String(result.nextPatchSequence);
-  } catch (error) {
-    showSceneError(error);
+async function runScene() {
+  if (sceneRunPromise !== null) return sceneRunPromise;
+  const example = currentExample();
+  if (!example || !player) return null;
+
+  const runToken = generations.beginRun(example.id);
+  const source = sceneSourceEditor.value;
+  const releaseBusy = beginBusy();
+  const task = (async () => {
+    try {
+      await ensureExecutionReady();
+      if (!isCurrentRun(runToken)) return recordStale(runToken, "after-restart");
+
+      patchStatus.value = `Building ${example.title} in the Python worker…`;
+      patchStatus.dataset.state = "running";
+      const client = ensureAuthoringClient();
+      let authored;
+      try {
+        authored = await client.run(source, {
+          playground: {
+            example_id: example.id,
+            selection_generation: runToken.selectionGeneration,
+            run_generation: runToken.runGeneration,
+          },
+        });
+      } catch (error) {
+        if (client.terminated && authoringClient === client) {
+          authoringClient = null;
+        }
+        throw error;
+      }
+
+      await runPlaygroundTestHook("afterAuthoring", {
+        exampleId: example.id,
+        selectionGeneration: runToken.selectionGeneration,
+        runGeneration: runToken.runGeneration,
+      });
+      if (!isCurrentRun(runToken)) return recordStale(runToken, "after-authoring");
+      if (authored.kind !== "scene_document") {
+        throw new Error("Python scene source returned a PatchBatch");
+      }
+
+      const runtimeDocument =
+        authored.callbacks === null
+          ? sceneIdentities.stabilize(authored.document, authored.identities)
+          : authored.document;
+      await runPlaygroundTestHook("beforeReconcile", {
+        exampleId: example.id,
+        selectionGeneration: runToken.selectionGeneration,
+        runGeneration: runToken.runGeneration,
+      });
+      if (!isCurrentRun(runToken)) return recordStale(runToken, "before-reconcile");
+
+      const result = await player.reconcileScene(JSON.stringify(runtimeDocument), {
+        retainedDocumentJson:
+          authored.retainedDocument === null ? null : JSON.stringify(authored.retainedDocument),
+        callbacks: authored.callbacks,
+        authoringClient: client,
+        loopDurationSeconds: authored.duration > 0 ? authored.duration : null,
+      });
+      if (!isCurrentRun(runToken)) return recordStale(runToken, "after-reconcile");
+
+      rendererBackend = player.rendererBackend;
+      status.dataset.rendererBackend = rendererBackend;
+      status.dataset.executionMode = player.mode;
+      const report = await player.metrics();
+      if (!isCurrentRun(runToken)) return recordStale(runToken, "after-metrics");
+
+      const operation = result.incremental ? "Scene updated incrementally" : "Scene rebuilt atomically";
+      patchStatus.value = `${operation} · ${example.title} · ${report.metrics.objectCount} objects`;
+      patchStatus.dataset.state = "applied";
+      patchStatus.dataset.exampleId = example.id;
+      patchStatus.dataset.parityStatus = example.parityStatus;
+      patchStatus.dataset.sequence = String(result.nextPatchSequence);
+      return { stale: false, result };
+    } catch (error) {
+      if (!isCurrentRun(runToken)) {
+        return recordStale(runToken, "error");
+      }
+      if (playerNeedsRestart) {
+        showError(error);
+      } else {
+        showSceneError(error);
+      }
+      return { stale: false, error };
+    }
+  })();
+
+  sceneRunPromise = task;
+  try {
+    return await task;
   } finally {
-    sceneRunInFlight = false;
-    setBusy(false);
+    if (sceneRunPromise === task) {
+      sceneRunPromise = null;
+    }
+    releaseBusy();
   }
 }
 
@@ -478,13 +562,38 @@ async function selectExample(
   if (!example) {
     throw new Error(`Unknown Manim example ${id}`);
   }
-  if (selectedExampleId && selectedExampleId !== id && sceneSourceEditor.value !== canonicalSource) {
-    drafts.set(selectedExampleId, sceneSourceEditor.value);
-  }
 
-  setBusy(true);
+  const requestToken = generations.beginSelectionRequest(id);
+  const releaseBusy = beginBusy();
+  let selectionToken = null;
   try {
     const source = await loadDemoAuthoringSource(example.path);
+    if (!generations.isSelectionRequestCurrent(requestToken)) {
+      return recordStale(requestToken, "after-source-load");
+    }
+
+    selectionToken = generations.commitSelection(requestToken);
+    if (selectionToken === null) {
+      return recordStale(requestToken, "before-selection-commit");
+    }
+
+    // If the prior scene has already entered reconciliation, let it settle while
+    // the prior selection is still the visible/active one. The generation bump
+    // above prevents authoring that has not reconciled yet from committing at all.
+    const priorRun = sceneRunPromise;
+    if (priorRun !== null) {
+      await priorRun;
+    }
+    if (
+      !generations.isSelectionRequestCurrent(requestToken) ||
+      !generations.isSelectionCurrent(selectionToken)
+    ) {
+      return recordStale(selectionToken, "after-prior-run");
+    }
+
+    if (selectedExampleId && selectedExampleId !== id && sceneSourceEditor.value !== canonicalSource) {
+      drafts.set(selectedExampleId, sceneSourceEditor.value);
+    }
     selectedExampleId = id;
     canonicalSource = source;
     sceneSourceEditor.value = drafts.get(id) ?? source;
@@ -498,14 +607,29 @@ async function selectExample(
     if (updateUrl) {
       history.pushState({ example: id }, "", exampleUrl(id));
     }
+  } catch (error) {
+    if (generations.isSelectionRequestCurrent(requestToken)) {
+      showSceneError(error);
+    } else {
+      recordStale(requestToken, "selection-error");
+    }
+    return { stale: false, error };
   } finally {
-    setBusy(false);
+    releaseBusy();
   }
 
+  if (
+    selectionToken === null ||
+    !generations.isSelectionRequestCurrent(requestToken) ||
+    !generations.isSelectionCurrent(selectionToken)
+  ) {
+    return recordStale(selectionToken ?? requestToken, "before-selection-run");
+  }
   if (scroll) {
     workspace.scrollIntoView({ behavior: "smooth", block: "start" });
   }
-  if (run) await runScene();
+  if (run) return runScene();
+  return { stale: false };
 }
 
 function refreshGalleryFilters() {
@@ -579,8 +703,17 @@ try {
     get executionMode() {
       return player?.mode ?? null;
     },
+    get runInFlight() {
+      return sceneRunPromise !== null;
+    },
+    get generationDiagnostics() {
+      return generations.diagnostics;
+    },
     async select(id) {
-      await selectExample(id, { run: true, updateUrl: true });
+      return selectExample(id, { run: true, updateUrl: true });
+    },
+    async run() {
+      return runScene();
     },
   };
 
@@ -598,7 +731,8 @@ try {
   async function updateWorkerMetrics(timestamp) {
     if (
       metricsPending ||
-      sceneRunInFlight ||
+      busyDepth > 0 ||
+      sceneRunPromise !== null ||
       playerNeedsRestart ||
       timestamp - lastStatusUpdate <= 200
     ) {

--- a/web/playground-generation.js
+++ b/web/playground-generation.js
@@ -1,0 +1,118 @@
+function checkedNext(current, label) {
+  if (!Number.isSafeInteger(current) || current < 0 || current >= Number.MAX_SAFE_INTEGER) {
+    throw new Error(`${label} space exhausted`);
+  }
+  return current + 1;
+}
+
+function requireExampleId(exampleId) {
+  if (typeof exampleId !== "string" || exampleId.trim() === "") {
+    throw new TypeError("playground generation requires a non-empty example ID");
+  }
+  return exampleId;
+}
+
+/// Tracks three related but distinct notions of freshness in the public playground:
+///
+/// 1. selection requests -- source loads may complete out of order;
+/// 2. committed selections -- only a loaded, newest request may become active;
+/// 3. scene runs -- a run is valid only for the committed selection that started it.
+///
+/// `commitSelection()` also advances the run generation. That explicitly invalidates
+/// authoring work from the previous selection before the new selection becomes visible.
+export class PlaygroundGeneration {
+  #selectionRequestGeneration = 0;
+  #selectionGeneration = 0;
+  #runGeneration = 0;
+  #staleDrops = 0;
+  #lastStale = null;
+
+  beginSelectionRequest(exampleId) {
+    this.#selectionRequestGeneration = checkedNext(
+      this.#selectionRequestGeneration,
+      "playground selection request generation",
+    );
+    return Object.freeze({
+      kind: "selection-request",
+      requestGeneration: this.#selectionRequestGeneration,
+      exampleId: requireExampleId(exampleId),
+    });
+  }
+
+  isSelectionRequestCurrent(token) {
+    return (
+      token?.kind === "selection-request" &&
+      token.requestGeneration === this.#selectionRequestGeneration
+    );
+  }
+
+  commitSelection(requestToken) {
+    if (!this.isSelectionRequestCurrent(requestToken)) {
+      return null;
+    }
+    this.#selectionGeneration = checkedNext(
+      this.#selectionGeneration,
+      "playground selection generation",
+    );
+    // A newly committed selection supersedes any authoring result that belongs
+    // to the previously active example, even before the UI switches examples.
+    this.#runGeneration = checkedNext(this.#runGeneration, "playground run generation");
+    return Object.freeze({
+      kind: "selection",
+      requestGeneration: requestToken.requestGeneration,
+      selectionGeneration: this.#selectionGeneration,
+      runGeneration: this.#runGeneration,
+      exampleId: requestToken.exampleId,
+    });
+  }
+
+  isSelectionCurrent(token) {
+    return (
+      token?.kind === "selection" &&
+      token.requestGeneration === this.#selectionRequestGeneration &&
+      token.selectionGeneration === this.#selectionGeneration
+    );
+  }
+
+  beginRun(exampleId) {
+    this.#runGeneration = checkedNext(this.#runGeneration, "playground run generation");
+    return Object.freeze({
+      kind: "run",
+      selectionGeneration: this.#selectionGeneration,
+      runGeneration: this.#runGeneration,
+      exampleId: requireExampleId(exampleId),
+    });
+  }
+
+  isRunCurrent(token, activeExampleId) {
+    return (
+      token?.kind === "run" &&
+      token.selectionGeneration === this.#selectionGeneration &&
+      token.runGeneration === this.#runGeneration &&
+      token.exampleId === activeExampleId
+    );
+  }
+
+  recordStale(token, stage) {
+    this.#staleDrops = checkedNext(this.#staleDrops, "playground stale-result counter");
+    this.#lastStale = Object.freeze({
+      kind: token?.kind ?? "unknown",
+      exampleId: token?.exampleId ?? null,
+      selectionGeneration: token?.selectionGeneration ?? null,
+      runGeneration: token?.runGeneration ?? null,
+      requestGeneration: token?.requestGeneration ?? null,
+      stage: String(stage ?? "unknown"),
+    });
+    return this.diagnostics;
+  }
+
+  get diagnostics() {
+    return Object.freeze({
+      selectionRequestGeneration: this.#selectionRequestGeneration,
+      selectionGeneration: this.#selectionGeneration,
+      runGeneration: this.#runGeneration,
+      staleDrops: this.#staleDrops,
+      lastStale: this.#lastStale,
+    });
+  }
+}

--- a/web/playground-generation.test.mjs
+++ b/web/playground-generation.test.mjs
@@ -15,6 +15,27 @@ test("newest selection request wins when source loads complete out of order", ()
   assert.equal(generations.isSelectionCurrent(committed), true);
 });
 
+test("loading a newer selection preserves the current run until that selection commits", () => {
+  const generations = new PlaygroundGeneration();
+  generations.commitSelection(generations.beginSelectionRequest("first"));
+  const currentRun = generations.beginRun("first");
+
+  const loadingSecond = generations.beginSelectionRequest("second");
+  assert.equal(
+    generations.isRunCurrent(currentRun, "first"),
+    true,
+    "a slow or failed source load must not cancel the current valid scene",
+  );
+
+  const committedSecond = generations.commitSelection(loadingSecond);
+  assert.ok(committedSecond);
+  assert.equal(
+    generations.isRunCurrent(currentRun, "first"),
+    false,
+    "the loaded selection invalidates prior authoring at commit time",
+  );
+});
+
 test("committing a new selection invalidates authoring from the previous selection", () => {
   const generations = new PlaygroundGeneration();
   const firstSelection = generations.commitSelection(

--- a/web/playground-generation.test.mjs
+++ b/web/playground-generation.test.mjs
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { PlaygroundGeneration } from "./playground-generation.js";
+
+test("newest selection request wins when source loads complete out of order", () => {
+  const generations = new PlaygroundGeneration();
+  const first = generations.beginSelectionRequest("first");
+  const second = generations.beginSelectionRequest("second");
+
+  assert.equal(generations.commitSelection(first), null);
+  const committed = generations.commitSelection(second);
+  assert.ok(committed);
+  assert.equal(committed.exampleId, "second");
+  assert.equal(generations.isSelectionCurrent(committed), true);
+});
+
+test("committing a new selection invalidates authoring from the previous selection", () => {
+  const generations = new PlaygroundGeneration();
+  const firstSelection = generations.commitSelection(
+    generations.beginSelectionRequest("first"),
+  );
+  const firstRun = generations.beginRun("first");
+  assert.equal(generations.isRunCurrent(firstRun, "first"), true);
+
+  const secondSelection = generations.commitSelection(
+    generations.beginSelectionRequest("second"),
+  );
+  assert.ok(secondSelection);
+  assert.equal(generations.isRunCurrent(firstRun, "first"), false);
+});
+
+test("a newer run supersedes an older run for the same example", () => {
+  const generations = new PlaygroundGeneration();
+  generations.commitSelection(generations.beginSelectionRequest("scene"));
+  const first = generations.beginRun("scene");
+  const second = generations.beginRun("scene");
+
+  assert.equal(generations.isRunCurrent(first, "scene"), false);
+  assert.equal(generations.isRunCurrent(second, "scene"), true);
+});
+
+test("stale-result diagnostics are monotonic and retain the last trace", () => {
+  const generations = new PlaygroundGeneration();
+  generations.commitSelection(generations.beginSelectionRequest("scene"));
+  const stale = generations.beginRun("scene");
+  generations.beginRun("scene");
+
+  const diagnostics = generations.recordStale(stale, "after-authoring");
+  assert.equal(diagnostics.staleDrops, 1);
+  assert.deepEqual(diagnostics.lastStale, {
+    kind: "run",
+    exampleId: "scene",
+    selectionGeneration: 1,
+    runGeneration: 2,
+    requestGeneration: null,
+    stage: "after-authoring",
+  });
+});
+
+test("seeded rapid selection/run churn never revives a superseded token", () => {
+  const generations = new PlaygroundGeneration();
+  let seed = 0x6e6f6f6e;
+  const random = () => {
+    seed ^= seed << 13;
+    seed ^= seed >>> 17;
+    seed ^= seed << 5;
+    return seed >>> 0;
+  };
+
+  let activeExample = "scene-0";
+  generations.commitSelection(generations.beginSelectionRequest(activeExample));
+  let latestRun = generations.beginRun(activeExample);
+  const staleRuns = [];
+
+  for (let index = 0; index < 500; index += 1) {
+    const operation = random() % 3;
+    if (operation === 0) {
+      const request = generations.beginSelectionRequest(`scene-${index + 1}`);
+      const committed = generations.commitSelection(request);
+      assert.ok(committed);
+      staleRuns.push(latestRun);
+      activeExample = committed.exampleId;
+      latestRun = generations.beginRun(activeExample);
+    } else {
+      staleRuns.push(latestRun);
+      latestRun = generations.beginRun(activeExample);
+    }
+
+    assert.equal(generations.isRunCurrent(latestRun, activeExample), true);
+    const sample = staleRuns[random() % staleRuns.length];
+    if (sample) {
+      assert.equal(generations.isRunCurrent(sample, activeExample), false);
+    }
+  }
+});


### PR DESCRIPTION
## Summary
P0 stability implementation for #393, extending #112's worker/race direction rather than creating a second runtime model.

- expose fatal `PythonAuthoringClient.terminated` state so the demo can discard a dead Pyodide worker without treating ordinary Python exceptions as infrastructure failure
- add one `AuthoringExecutionClient.restart()` boundary that delegates to the existing legacy or retained worker restart implementation, then rebinds the transferred replacement canvas/resize observer/backend metadata
- recreate a dead Python authoring worker on a later Run and mark execution-worker faults as restart-required
- stop metrics polling while a run/restart/selection transition is active
- add an explicit `PlaygroundGeneration` contract for selection requests, committed selections, and scene runs
- only the newest successfully loaded selection may become active; committing it invalidates prior authoring work
- deliberately keep the current valid scene alive while a newer selection source is merely loading; a failed/slow fetch must not blank or cancel the current scene
- check run freshness after worker restart, after Python authoring, before reconcile, after reconcile, and after metrics so stale work cannot update renderer/status
- coalesce simultaneous Run / Cmd/Ctrl+Enter requests into one Python authoring request
- retain stale-drop diagnostics without spamming the user-facing error surface
- preserve the previous visible selection while an already-reconciling prior run settles, then switch atomically to the newest loaded selection
- exercise retained and legacy execution restart while preserving the authored scene
- add deterministic adversarial browser coverage that holds an old result after authoring but before reconcile, commits a newer selection, and proves the old scene never reaches `reconcileScene`
- add 500-operation seeded generation churn coverage
- add a unit invariant pinning the distinction between `beginSelectionRequest` and `commitSelection`

## Race-test correction
A refreshed CI run exposed a synchronization bug in the new browser smoke itself: it released the held old authoring result when the newer **selection request** generation advanced. That is intentionally too early because source loading may still fail. The smoke now waits for the newer **committed selection generation**, which is the actual invalidation boundary. Production generation semantics were unchanged; the distinction is now directly unit-tested and the unit test is wired into `build-web-demo.sh`.

## Architecture
The generation gate lives at the public playground ownership layer rather than inside Python, the renderer, or text/font semantics. Worker clients retain request correlation and restart responsibility; the playground owns which authored result is still relevant to the visible example.

The branch is stacked on the landed #398 editor/CDN resilience head and preserves current shared-geometry build checks. Once #398 landed, the PR diff reduced back to the recovery/generation files only.

## Validation
The earlier recovery slices passed browser WebGPU/WebGL and worker routing tests. A fresh full run is now executing on the corrected race smoke and the landed #398/current-master base; do not merge this PR on the superseded failed race-smoke run.

## Remaining #112 depth
The core public-demo invariants are covered here. Broader #112 work can still extend deterministic forced-crash/restart generation tests, stale callback results after scene teardown, malformed worker-message ordering, and longer seeded browser stress without changing this ownership model.

Tracks #393. Related #112 and #403.