### PR TITLE
Stop demo Ruff false-positive cascade

### DIFF
--- a/scripts/build-web-demo.sh
+++ b/scripts/build-web-demo.sh
@@ -8,6 +8,7 @@ cd "$noon_root"
 node --check web/main.js
 node --check web/example-gallery.js
 node --check web/authoring-client.js
+node --check web/python-editor.js
 node --check web/python-worker.js
 node --check web/native-inputs.js
 node --check web/execution-transport.js
@@ -57,6 +58,7 @@ node --check scripts/updater-callback-smoke.mjs
 node --test web/example-gallery.test.mjs
 node --test web/execution-transport.test.mjs
 node --test web/authoring-client.test.mjs
+node --test web/python-editor.test.mjs
 node --test web/scene-identity.test.mjs
 node --test web/frame-metrics.test.mjs
 node --test web/browser-jank.test.mjs

--- a/scripts/python-editor-smoke.mjs
+++ b/scripts/python-editor-smoke.mjs
@@ -35,6 +35,51 @@ async function waitForServer() {
   throw new Error(`Python editor smoke server did not start: ${lastError}\n${serverOutput}`);
 }
 
+async function waitForRuntime(page, errors, label) {
+  let runtimeStatus = null;
+  for (let attempt = 0; attempt < 120; attempt += 1) {
+    runtimeStatus = await page.evaluate(() => {
+      const status = document.querySelector("#status");
+      return {
+        state: status?.dataset.state ?? null,
+        text: document.querySelector("#status-text")?.textContent ?? status?.textContent ?? "",
+      };
+    });
+    if (runtimeStatus.state === "running" || runtimeStatus.state === "error") {
+      break;
+    }
+    await page.waitForTimeout(500);
+  }
+  assert.equal(
+    runtimeStatus?.state,
+    "running",
+    `${label}: playground runtime did not become ready: ${JSON.stringify(runtimeStatus)}\n${errors.join("\n")}`,
+  );
+}
+
+async function waitForAppliedScene(page, errors, label) {
+  await page.waitForFunction(
+    () => {
+      const patch = document.querySelector("#patch-status");
+      return patch?.dataset.state === "applied" || patch?.dataset.state === "error";
+    },
+    null,
+    { timeout: 60_000 },
+  );
+  const patch = await page.evaluate(() => ({
+    state: document.querySelector("#patch-status")?.dataset.state ?? null,
+    text:
+      document.querySelector("#patch-status")?.value ??
+      document.querySelector("#patch-status")?.textContent ??
+      "",
+  }));
+  assert.equal(
+    patch.state,
+    "applied",
+    `${label}: authored scene did not apply: ${JSON.stringify(patch)}\n${errors.join("\n")}`,
+  );
+}
+
 let browser = null;
 try {
   await waitForServer();
@@ -93,25 +138,7 @@ try {
   const highlightedSpans = await page.locator("#scene-editor-panel .cm-line span").count();
   assert.ok(highlightedSpans > 0, "Python source should contain syntax-highlighted spans");
 
-  let runtimeStatus = null;
-  for (let attempt = 0; attempt < 60; attempt += 1) {
-    runtimeStatus = await page.evaluate(() => {
-      const status = document.querySelector("#status");
-      return {
-        state: status?.dataset.state ?? null,
-        text: document.querySelector("#status-text")?.textContent ?? status?.textContent ?? "",
-      };
-    });
-    if (runtimeStatus.state === "running" || runtimeStatus.state === "error") {
-      break;
-    }
-    await page.waitForTimeout(500);
-  }
-  assert.equal(
-    runtimeStatus?.state,
-    "running",
-    `playground runtime did not become ready: ${JSON.stringify(runtimeStatus)}\n${errors.join("\n")}`,
-  );
+  await waitForRuntime(page, errors, "enhanced editor");
 
   const layout = await page.evaluate(() => {
     const scroller = document
@@ -167,8 +194,62 @@ try {
   assert.ok(lintRanges >= 1, "Ruff should report inline Python diagnostics");
 
   assert.deepEqual(errors, [], `browser errors while loading Python editor:\n${errors.join("\n")}`);
+  await page.close();
+
+  const fallbackContext = await browser.newContext({ viewport: { width: 1200, height: 800 } });
+  await fallbackContext.route("https://esm.sh/**", (route) => route.abort("failed"));
+  const fallbackPage = await fallbackContext.newPage();
+  const fallbackErrors = [];
+  const fallbackWarnings = [];
+  fallbackPage.on("pageerror", (error) => fallbackErrors.push(`pageerror: ${error}`));
+  fallbackPage.on("console", (message) => {
+    if (message.type() === "error") fallbackErrors.push(`console: ${message.text()}`);
+    if (message.type() === "warning") fallbackWarnings.push(message.text());
+  });
+
+  await fallbackPage.goto(`${baseUrl}/web/index.html?example=parity-create-circle`, {
+    waitUntil: "load",
+  });
+  await fallbackPage.waitForFunction(
+    () => document.querySelector("#python-scene-source")?.value.includes("from noon import"),
+    null,
+    { timeout: 30_000 },
+  );
+  await waitForRuntime(fallbackPage, fallbackErrors, "textarea fallback");
+  await waitForAppliedScene(fallbackPage, fallbackErrors, "textarea fallback");
+
+  const fallback = await fallbackPage.evaluate(() => {
+    const textarea = document.querySelector("#python-scene-source");
+    return {
+      textareaHidden: textarea?.hidden ?? true,
+      editorCount: document.querySelectorAll(".python-code-editor").length,
+      source: textarea?.value ?? "",
+      backend: document.querySelector("#status")?.dataset.rendererBackend ?? null,
+    };
+  });
+  assert.equal(fallback.textareaHidden, false, "CDN failure must keep the native textarea visible");
+  assert.equal(fallback.editorCount, 0, "failed enhancement must not leave partial editor hosts");
+  assert.match(fallback.source, /from noon import \*/);
+  assert.equal(fallback.backend, "WebGL2");
+
+  await fallbackPage.locator("#python-scene-source").fill(
+    "from noon import *\n\nclass FallbackScene(Scene):\n    def construct(self):\n        self.add(Square())\n",
+  );
+  await fallbackPage.locator("#replace-scene").click();
+  await waitForAppliedScene(fallbackPage, fallbackErrors, "edited textarea fallback");
+  assert.ok(
+    fallbackWarnings.some((warning) => warning.includes("Enhanced Python editor unavailable")),
+    `expected a non-fatal enhancement warning; got ${fallbackWarnings.join("\n")}`,
+  );
+  assert.deepEqual(
+    fallbackErrors,
+    [],
+    `editor CDN failure must not emit unhandled browser errors:\n${fallbackErrors.join("\n")}`,
+  );
+  await fallbackContext.close();
+
   console.log(
-    `Python editor smoke passed: bounded centered preview, 2 CodeMirror editors, syntax highlighting, ${lintRanges} Ruff diagnostics.`,
+    `Python editor smoke passed: enhanced editor + ${lintRanges} Ruff diagnostic(s) + CDN-blocked textarea fallback.`,
   );
 } finally {
   await browser?.close();

--- a/scripts/python-editor-smoke.mjs
+++ b/scripts/python-editor-smoke.mjs
@@ -57,13 +57,15 @@ async function waitForRuntime(page, errors, label) {
   );
 }
 
-async function waitForAppliedScene(page, errors, label) {
+async function waitForAppliedScene(page, errors, label, expectedText = null) {
   await page.waitForFunction(
-    () => {
+    (needle) => {
       const patch = document.querySelector("#patch-status");
-      return patch?.dataset.state === "applied" || patch?.dataset.state === "error";
+      const text = patch?.value ?? patch?.textContent ?? "";
+      if (patch?.dataset.state === "error") return true;
+      return patch?.dataset.state === "applied" && (needle === null || text.includes(needle));
     },
-    null,
+    expectedText,
     { timeout: 60_000 },
   );
   const patch = await page.evaluate(() => ({
@@ -78,6 +80,9 @@ async function waitForAppliedScene(page, errors, label) {
     "applied",
     `${label}: authored scene did not apply: ${JSON.stringify(patch)}\n${errors.join("\n")}`,
   );
+  if (expectedText !== null) {
+    assert.match(patch.text, new RegExp(expectedText.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  }
 }
 
 let browser = null;
@@ -203,8 +208,14 @@ try {
   const fallbackWarnings = [];
   fallbackPage.on("pageerror", (error) => fallbackErrors.push(`pageerror: ${error}`));
   fallbackPage.on("console", (message) => {
-    if (message.type() === "error") fallbackErrors.push(`console: ${message.text()}`);
     if (message.type() === "warning") fallbackWarnings.push(message.text());
+    if (
+      message.type() === "error" &&
+      !message.text().includes("ERR_FAILED") &&
+      !message.text().includes("esm.sh")
+    ) {
+      fallbackErrors.push(`console: ${message.text()}`);
+    }
   });
 
   await fallbackPage.goto(`${baseUrl}/web/index.html?example=parity-create-circle`, {
@@ -233,10 +244,15 @@ try {
   assert.equal(fallback.backend, "WebGL2");
 
   await fallbackPage.locator("#python-scene-source").fill(
-    "from noon import *\n\nclass FallbackScene(Scene):\n    def construct(self):\n        self.add(Square())\n",
+    "from noon import *\n\nclass FallbackScene(Scene):\n    def construct(self):\n        self.add(Square())\n        self.add(Circle().shift(RIGHT * 2))\n",
   );
   await fallbackPage.locator("#replace-scene").click();
-  await waitForAppliedScene(fallbackPage, fallbackErrors, "edited textarea fallback");
+  await waitForAppliedScene(
+    fallbackPage,
+    fallbackErrors,
+    "edited textarea fallback",
+    "2 objects",
+  );
   assert.ok(
     fallbackWarnings.some((warning) => warning.includes("Enhanced Python editor unavailable")),
     `expected a non-fatal enhancement warning; got ${fallbackWarnings.join("\n")}`,
@@ -249,7 +265,7 @@ try {
   await fallbackContext.close();
 
   console.log(
-    `Python editor smoke passed: enhanced editor + ${lintRanges} Ruff diagnostic(s) + CDN-blocked textarea fallback.`,
+    `Python editor smoke passed: enhanced editor + ${lintRanges} Ruff diagnostic(s) + CDN-blocked textarea fallback with a fresh two-object render.`,
   );
 } finally {
   await browser?.close();

--- a/web/python-editor.js
+++ b/web/python-editor.js
@@ -4,6 +4,18 @@ const LINT_URL = "https://esm.sh/@codemirror/lint@6.9.7";
 const THEME_URL = "https://esm.sh/@codemirror/theme-one-dark@6.1.3";
 const RUFF_URL = "https://esm.sh/@astral-sh/ruff-wasm-web@0.16.4";
 
+export const PYTHON_RUFF_SETTINGS = {
+  "line-length": 88,
+  "indent-width": 4,
+  lint: {
+    select: ["E4", "E7", "E9", "F"],
+    // Public gallery sources intentionally preserve Manim's conventional
+    // `from noon import *` shape. F403/F405 cannot resolve that dynamic export
+    // surface, so keeping them enabled turns every canonical API use into noise.
+    ignore: ["F403", "F405"],
+  },
+};
+
 let ruffWorkspacePromise = null;
 
 if (typeof document !== "undefined") {
@@ -154,14 +166,7 @@ async function runRuff(view) {
 async function getRuffWorkspace() {
   ruffWorkspacePromise ??= import(RUFF_URL).then(async (ruff) => {
     await ruff.default();
-    return new ruff.Workspace(
-      {
-        "line-length": 88,
-        "indent-width": 4,
-        lint: { select: ["E4", "E7", "E9", "F"] },
-      },
-      ruff.PositionEncoding.Utf16,
-    );
+    return new ruff.Workspace(PYTHON_RUFF_SETTINGS, ruff.PositionEncoding.Utf16);
   });
   return ruffWorkspacePromise;
 }

--- a/web/python-editor.js
+++ b/web/python-editor.js
@@ -19,7 +19,12 @@ export const PYTHON_RUFF_SETTINGS = {
 let ruffWorkspacePromise = null;
 
 if (typeof document !== "undefined") {
-  await enhancePythonEditors();
+  // CodeMirror/Ruff are progressive enhancement. A transient CDN, CSP, or WASM
+  // failure must leave the native textarea usable instead of rejecting the
+  // playground's module graph and taking Python authoring down with it.
+  void enhancePythonEditors().catch((error) => {
+    console.warn("Enhanced Python editor unavailable; using textarea fallback", error);
+  });
 }
 
 async function enhancePythonEditors() {

--- a/web/python-editor.test.mjs
+++ b/web/python-editor.test.mjs
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { PYTHON_RUFF_SETTINGS } from "./python-editor.js";
+
+test("demo Ruff keeps useful Pyflakes coverage but ignores star-import compatibility noise", () => {
+  assert.deepEqual(PYTHON_RUFF_SETTINGS.lint.select, ["E4", "E7", "E9", "F"]);
+  assert.deepEqual(PYTHON_RUFF_SETTINGS.lint.ignore, ["F403", "F405"]);
+  assert.equal(
+    PYTHON_RUFF_SETTINGS.lint.ignore.includes("F821"),
+    false,
+    "undefined local names must remain lintable",
+  );
+  assert.equal(
+    PYTHON_RUFF_SETTINGS.lint.select.includes("E9"),
+    true,
+    "syntax-error diagnostics must remain enabled",
+  );
+});


### PR DESCRIPTION
## Summary
Fix #395 and the fail-soft portion of #403 without weakening useful Python diagnostics.

- keep Ruff's current `E4`/`E7`/`E9`/`F` selection
- ignore only F403/F405, which are unavoidable for the public gallery's intentional `from noon import *` Manim-compatible source style
- leave F821 enabled so genuinely undefined local names still surface
- leave E9 enabled so syntax errors remain high-signal errors
- centralize/export the browser Ruff settings and pin the policy with a Node unit test
- add `python-editor.js` syntax checking and the new unit test to the normal web build gate
- make CodeMirror/Ruff loading progressive enhancement: a CDN/CSP/WASM import failure is caught and leaves the native textarea available instead of rejecting the module graph

## Why
The demo selected all Pyflakes `F` rules even though canonical source-equivalent examples intentionally use star imports, producing an F403/F405 cascade that hides real errors. Separately, the editor enhancement loads remote CodeMirror/Ruff modules, so enhancement failure must degrade gracefully rather than look like a playground crash.

## Validation
The pre-refresh head passed CI, coverage, API differential, Manim differential, and raster differential. The branch has now been merged forward onto current master with no overlapping upstream changes; fresh merge-head checks are running.

## Remaining #403 follow-up
`authoring-client.js` still imports the editor module for side effects. After the P0 worker-recovery branch (#397) lands, remove that presentation dependency and let the playground entry point own optional editor enhancement, with a browser test that blocks `esm.sh` and proves Run still works through the textarea fallback.

Tracks #395. Related #403.