### PR TITLE
Simplify and align the public playground

### DIFF
--- a/scripts/playground-layout-smoke.mjs
+++ b/scripts/playground-layout-smoke.mjs
@@ -165,6 +165,47 @@ try {
   assert.ok(galleryContract.thumbnails.every((src) => src?.includes("thumbnails/manim/")));
   assert.match(galleryContract.href, /example=parity-square-and-circle/);
 
+  const presentationContract = await page.evaluate(() => {
+    const workspace = document.querySelector(".workspace");
+    const editor = document.querySelector(".editor-pane");
+    const preview = document.querySelector(".preview-pane");
+    const selected = document.querySelector(".selected-example");
+    const workspaceRect = workspace.getBoundingClientRect();
+    const editorRect = editor.getBoundingClientRect();
+    const previewRect = preview.getBoundingClientRect();
+    return {
+      selectedOutsideWorkspace: selected !== null && !workspace.contains(selected),
+      selectedImmediatelyBeforeWorkspace: selected?.nextElementSibling === workspace,
+      obsoletePanels: document.querySelectorAll(".below, .info-panel, .pipeline, .api-list").length,
+      editorTop: editorRect.top,
+      previewTop: previewRect.top,
+      editorShare: editorRect.width / workspaceRect.width,
+    };
+  });
+  assert.equal(
+    presentationContract.selectedOutsideWorkspace,
+    true,
+    "selected-example context must not offset only the editor pane",
+  );
+  assert.equal(
+    presentationContract.selectedImmediatelyBeforeWorkspace,
+    true,
+    "selected-example context must sit directly above the shared source/preview workspace",
+  );
+  assert.equal(
+    presentationContract.obsoletePanels,
+    0,
+    "obsolete architecture/API presentation panes must not be rendered",
+  );
+  assert.ok(
+    Math.abs(presentationContract.editorTop - presentationContract.previewTop) <= 1,
+    `desktop source/preview panes must align at the top (${presentationContract.editorTop} vs ${presentationContract.previewTop})`,
+  );
+  assert.ok(
+    presentationContract.editorShare >= 0.42 && presentationContract.editorShare <= 0.5,
+    `desktop editor should receive a balanced workspace share, got ${presentationContract.editorShare}`,
+  );
+
   const initialBacking = await page.evaluate(() => {
     const canvas = document.querySelector("#scene");
     return {
@@ -233,7 +274,7 @@ try {
 
   assert.deepEqual(browserErrors, [], `playground emitted browser errors:\n${browserErrors.join("\n")}`);
   console.log(
-    `✓ Manim gallery + WebGL2 viewport @ DPR ${deviceScaleFactor}: ` +
+    `✓ Manim gallery + aligned WebGL2 viewport @ DPR ${deviceScaleFactor}: ` +
       `${galleryContract.cards} cards, desktop ${desktop.canvas.width.toFixed(0)}×${desktop.canvas.height.toFixed(0)}, ` +
       `mobile ${mobile.canvas.width.toFixed(0)}×${mobile.canvas.height.toFixed(0)}`,
   );

--- a/web/index.html
+++ b/web/index.html
@@ -89,7 +89,6 @@
       }
 
       h1,
-      h2,
       p {
         margin: 0;
       }
@@ -139,7 +138,7 @@
 
       .workspace {
         display: grid;
-        grid-template-columns: minmax(21rem, 0.86fr) minmax(0, 1.34fr);
+        grid-template-columns: minmax(24rem, 1fr) minmax(0, 1.15fr);
         min-height: 38rem;
         overflow: hidden;
         border: 1px solid var(--border);
@@ -417,90 +416,6 @@
         white-space: nowrap;
       }
 
-      .below {
-        display: grid;
-        grid-template-columns: 1.25fr 0.75fr;
-        gap: 1rem;
-        margin-top: 1rem;
-      }
-
-      .info-panel {
-        border: 1px solid var(--border);
-        border-radius: 0.9rem;
-        background: var(--panel);
-        padding: 1rem;
-      }
-
-      .info-panel h2 {
-        margin-bottom: 0.75rem;
-        color: #dce3f1;
-        font-size: 0.8rem;
-      }
-
-      .pipeline {
-        display: flex;
-        align-items: stretch;
-        gap: 0.38rem;
-      }
-
-      .pipeline-step {
-        min-width: 0;
-        flex: 1;
-        padding: 0.72rem 0.7rem;
-        border: 1px solid #263149;
-        border-radius: 0.65rem;
-        background: #0c111b;
-      }
-
-      .pipeline-step strong {
-        display: block;
-        color: #d6dceb;
-        font-size: 0.72rem;
-      }
-
-      .pipeline-step span {
-        display: block;
-        margin-top: 0.2rem;
-        color: var(--muted-2);
-        font-size: 0.66rem;
-      }
-
-      .arrow {
-        align-self: center;
-        color: #58647a;
-        font-size: 0.78rem;
-      }
-
-      .api-list {
-        display: grid;
-        gap: 0.48rem;
-      }
-
-      code {
-        color: #cfc8ff;
-        font: 0.72rem ui-monospace, SFMono-Regular, Menlo, monospace;
-      }
-
-      .api-row {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        gap: 1rem;
-        padding-bottom: 0.45rem;
-        border-bottom: 1px solid #20293b;
-      }
-
-      .api-row:last-child {
-        padding-bottom: 0;
-        border-bottom: 0;
-      }
-
-      .api-row span {
-        color: var(--muted-2);
-        font-size: 0.68rem;
-        text-align: right;
-      }
-
       @media (max-width: 68rem) {
         .workspace {
           grid-template-columns: 1fr;
@@ -514,10 +429,6 @@
 
         .preview-pane {
           min-height: 30rem;
-        }
-
-        .below {
-          grid-template-columns: 1fr;
         }
       }
 
@@ -590,15 +501,6 @@
 
         .metric:nth-child(-n + 2) {
           border-bottom: 1px solid var(--border);
-        }
-
-        .pipeline {
-          display: grid;
-          grid-template-columns: 1fr 1fr;
-        }
-
-        .arrow {
-          display: none;
         }
       }
     </style>
@@ -740,44 +642,6 @@
             </div>
           </div>
         </section>
-      </section>
-
-      <section class="below" aria-label="Architecture and API notes">
-        <article class="info-panel">
-          <h2>What happens when you press Run</h2>
-          <div class="pipeline" aria-label="Noon browser execution pipeline">
-            <div class="pipeline-step">
-              <strong>Python</strong>
-              <span>authoring API</span>
-            </div>
-            <span class="arrow" aria-hidden="true">→</span>
-            <div class="pipeline-step">
-              <strong>Scene IR</strong>
-              <span>document / patches</span>
-            </div>
-            <span class="arrow" aria-hidden="true">→</span>
-            <div class="pipeline-step">
-              <strong>Rust runtime</strong>
-              <span>deterministic timeline</span>
-            </div>
-            <span class="arrow" aria-hidden="true">→</span>
-            <div class="pipeline-step">
-              <strong>WebGPU</strong>
-              <span>persistent renderer</span>
-            </div>
-          </div>
-        </article>
-
-        <aside class="info-panel">
-          <h2>Python API in this demo</h2>
-          <div class="api-list">
-            <div class="api-row"><code>scene.circle(...)</code><span>analytic primitive</span></div>
-            <div class="api-row"><code>scene.rectangle(...)</code><span>analytic primitive</span></div>
-            <div class="api-row"><code>scene.path(...)</code><span>cached vector path</span></div>
-            <div class="api-row"><code>scene.play(Transform(...))</code><span>compiled transform</span></div>
-            <div class="api-row"><code>scene.animate_*(...)</code><span>low-level tracks</span></div>
-          </div>
-        </aside>
       </section>
     </main>
 

--- a/web/main.js
+++ b/web/main.js
@@ -158,8 +158,10 @@ galleryStyle.textContent = `
     align-items: flex-start;
     gap: 0.8rem;
     min-height: 3.8rem;
+    margin-bottom: 1rem;
     padding: 0.75rem 0.85rem;
-    border-bottom: 1px solid var(--border);
+    border: 1px solid var(--border);
+    border-radius: 0.9rem;
     background: rgba(11, 15, 24, 0.92);
   }
   .selected-copy { min-width: 0; flex: 1; }
@@ -250,6 +252,7 @@ workspace.before(gallerySection);
 
 const selectedExampleStrip = document.createElement("div");
 selectedExampleStrip.className = "selected-example";
+selectedExampleStrip.setAttribute("aria-label", "Selected example");
 const selectedCopy = document.createElement("div");
 selectedCopy.className = "selected-copy";
 const selectedTitle = document.createElement("span");
@@ -260,7 +263,7 @@ selectedCopy.append(selectedTitle, selectedSummary);
 const selectedTags = document.createElement("div");
 selectedTags.className = "selected-tags";
 selectedExampleStrip.append(selectedCopy, selectedTags);
-document.querySelector(".editor-stack").before(selectedExampleStrip);
+workspace.before(selectedExampleStrip);
 
 const resetButton = document.createElement("button");
 resetButton.type = "button";
@@ -470,7 +473,7 @@ async function selectExample(
   }
 
   if (scroll) {
-    workspace.scrollIntoView({ behavior: "smooth", block: "start" });
+    selectedExampleStrip.scrollIntoView({ behavior: "smooth", block: "start" });
   }
   if (run) await runScene();
 }

--- a/web/python-editor.js
+++ b/web/python-editor.js
@@ -118,20 +118,6 @@ async function enhancePythonEditors() {
     }
     .python-code-editor .cm-editor { height: 100%; }
     .python-code-editor .cm-focused { outline: 2px solid #aa9cff; outline-offset: -2px; }
-    @media (min-width: 68.01rem) {
-      .canvas-wrap {
-        padding: 0 !important;
-        place-items: stretch !important;
-      }
-      .canvas-wrap > canvas {
-        width: 100%;
-        height: 100%;
-        max-width: none;
-        aspect-ratio: auto;
-        border: 0;
-        border-radius: 0;
-      }
-    }
     @media (max-width: 44rem) {
       .python-code-editor { min-height: 25rem; }
       .python-code-editor .cm-editor { font-size: 0.76rem; }


### PR DESCRIPTION
## Summary
Presentation cleanup for #396.

- move selected-example title/summary/tags out of the editor pane and directly above the shared source/preview workspace
- rebalance desktop workspace width so source gets ~46% instead of the previous narrow ~39% share
- remove the public “What happens when you press Run” pipeline and stale “Python API in this demo” pane
- remove editor-owned desktop canvas CSS so viewport sizing has one clear owner in `index.html`
- preserve the existing responsive 16:9 desktop / 4:3 mobile canvas contract, DPR backing-store behavior, metrics, editor footer, and gallery controls
- extend `playground-layout-smoke.mjs` to assert selected context is outside the panes, editor/preview top alignment, balanced desktop width, and absence of obsolete presentation panels

## Audit rationale
The selected metadata strip was inserted before `.editor-stack`, so only source moved downward while preview began immediately below its toolbar. The stale API pane also described low-level `scene.circle(...)`/`scene.path(...)` APIs even though the public gallery is now a source-equivalent `from noon import *` / Manim-compatible surface.

## Scope boundary
This is intentionally independent of worker recovery (#393/#397), Ruff policy (#395/#398), thumbnail replacement (#394), and the active font/text architecture work.

Tracks #396. Related #117 and #241.