### PR TITLE
Never show a broken gallery thumbnail

### DIFF
--- a/web/example-gallery.js
+++ b/web/example-gallery.js
@@ -1,5 +1,10 @@
 const MANIM_REUSE = "source-equivalent-manim-v0.21";
 const READY_PARITY = new Set(["candidate", "parity-qualified"]);
+const THUMBNAIL_FALLBACK_MARKER = "noonThumbnailFallbackInstalled";
+
+if (typeof document !== "undefined") {
+  installGalleryThumbnailFallback(document);
+}
 
 export function normalizeGalleryManifest(manifest) {
   if (!manifest || !Array.isArray(manifest.entries)) {
@@ -124,4 +129,71 @@ export function exampleUrl(id, locationLike = globalThis.location) {
 
 export function parityLabel(status) {
   return status === "parity-qualified" ? "Parity qualified" : "Parity candidate";
+}
+
+export function applyGalleryThumbnailFailure(image, documentLike = globalThis.document) {
+  if (
+    !image ||
+    image.tagName !== "IMG" ||
+    !image.classList?.contains("example-thumb") ||
+    image.dataset?.thumbnailFailed === "true" ||
+    typeof documentLike?.createElement !== "function"
+  ) {
+    return false;
+  }
+
+  const alt = typeof image.alt === "string" && image.alt.trim() !== "" ? image.alt.trim() : "Example";
+  const fallback = documentLike.createElement("span");
+  fallback.className = "example-thumb-fallback";
+  fallback.setAttribute("role", "img");
+  fallback.setAttribute("aria-label", `${alt} — preview unavailable`);
+  fallback.textContent = "Preview unavailable";
+
+  image.dataset.thumbnailFailed = "true";
+  image.hidden = true;
+  image.alt = "";
+  image.after(fallback);
+  return true;
+}
+
+export function installGalleryThumbnailFallback(documentLike = globalThis.document) {
+  if (
+    !documentLike?.documentElement?.dataset ||
+    typeof documentLike.addEventListener !== "function" ||
+    typeof documentLike.createElement !== "function"
+  ) {
+    return false;
+  }
+  if (documentLike.documentElement.dataset[THUMBNAIL_FALLBACK_MARKER] === "true") {
+    return false;
+  }
+  documentLike.documentElement.dataset[THUMBNAIL_FALLBACK_MARKER] = "true";
+
+  documentLike.addEventListener(
+    "error",
+    (event) => {
+      applyGalleryThumbnailFailure(event.target, documentLike);
+    },
+    true,
+  );
+
+  const style = documentLike.createElement("style");
+  style.dataset.galleryThumbnailFallback = "true";
+  style.textContent = `
+    .example-thumb-fallback {
+      display: grid;
+      width: 100%;
+      aspect-ratio: 16 / 9;
+      place-items: center;
+      border-bottom: 1px solid #222d41;
+      background:
+        radial-gradient(circle at 50% 45%, rgb(142 124 255 / 12%), transparent 45%),
+        #111722;
+      color: #77849d;
+      font: 0.66rem ui-monospace, SFMono-Regular, Menlo, monospace;
+      letter-spacing: 0.02em;
+    }
+  `;
+  documentLike.head?.append(style);
+  return true;
 }

--- a/web/example-gallery.test.mjs
+++ b/web/example-gallery.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
 import {
+  applyGalleryThumbnailFailure,
   exampleUrl,
   filterGalleryExamples,
   normalizeGalleryManifest,
@@ -122,6 +123,48 @@ assert.equal(
   20,
 );
 
+const insertedFallbacks = [];
+const fakeImage = {
+  tagName: "IMG",
+  classList: { contains: (name) => name === "example-thumb" },
+  dataset: {},
+  alt: "DifferentRotations poster frame",
+  hidden: false,
+  after(node) {
+    insertedFallbacks.push(node);
+  },
+};
+const fakeDocument = {
+  createElement(tagName) {
+    return {
+      tagName: tagName.toUpperCase(),
+      className: "",
+      attributes: new Map(),
+      textContent: "",
+      setAttribute(name, value) {
+        this.attributes.set(name, value);
+      },
+    };
+  },
+};
+assert.equal(applyGalleryThumbnailFailure(fakeImage, fakeDocument), true);
+assert.equal(fakeImage.hidden, true, "failed image must be removed from visual layout");
+assert.equal(fakeImage.alt, "", "hidden failed image must not duplicate fallback accessibility text");
+assert.equal(fakeImage.dataset.thumbnailFailed, "true");
+assert.equal(insertedFallbacks.length, 1);
+assert.equal(insertedFallbacks[0].className, "example-thumb-fallback");
+assert.equal(insertedFallbacks[0].textContent, "Preview unavailable");
+assert.equal(
+  insertedFallbacks[0].attributes.get("aria-label"),
+  "DifferentRotations poster frame — preview unavailable",
+);
+assert.equal(
+  applyGalleryThumbnailFailure(fakeImage, fakeDocument),
+  false,
+  "repeat image errors must not append duplicate fallback UI",
+);
+assert.equal(insertedFallbacks.length, 1);
+
 assert.equal(
   requestedExampleId({ search: "?example=parity-square-to-circle" }),
   "parity-square-to-circle",
@@ -154,4 +197,4 @@ assert.throws(
   /source-equivalent ManimCE/,
 );
 
-console.log("✓ Manim gallery manifest contract");
+console.log("✓ Manim gallery manifest contract + thumbnail fallback");


### PR DESCRIPTION
## Summary
First independent robustness slice for #394.

- install one capture-phase image-error handler for public gallery thumbnails
- replace any missing/corrupt `.example-thumb` with an intentional 16:9 “Preview unavailable” frame instead of the browser broken-image UI
- preserve accessibility by moving the original thumbnail alt text onto the fallback and hiding the failed image from the accessibility tree
- make the failure transformation idempotent so repeated image errors cannot duplicate fallback UI
- add focused unit coverage without requiring the renderer/browser runtime

## Audit finding
This fixes the broken-image presentation path, but it does **not** hide the larger asset debt: the ready manifest still contains 14 exact upstream examples pointing at the generic `thumbnails/manim/exact-source.svg` placeholder. Those need deterministic Noon-generated poster frames as a separate parallel asset-generation pass under #394.

## Scope boundary
No manifest thumbnail is remapped to a synthetic parity-probe image, because that could visually misrepresent the exact upstream example. This PR is intentionally independent of #397 worker recovery, #398 Ruff diagnostics, #399 layout cleanup, and font/text work.

Tracks #394.