### PR TITLE
Route Python Dot and Triangle through shared Rust geometry

### DIFF
--- a/crates/noon-web/src/lib.rs
+++ b/crates/noon-web/src/lib.rs
@@ -11,6 +11,7 @@ mod host_player;
 #[path = "legacy.rs"]
 mod legacy;
 mod lifecycle;
+mod manim_geometry_bridge;
 mod reactive_authoring_facade;
 mod reactive_player;
 mod retained_authoring;
@@ -34,6 +35,7 @@ pub use execution_transport::*;
 pub use host_player::*;
 pub use legacy::*;
 pub use lifecycle::*;
+pub use manim_geometry_bridge::*;
 pub use reactive_authoring_facade::*;
 pub use reactive_player::*;
 pub use retained_authoring::*;

--- a/crates/noon-web/src/manim_geometry_bridge.rs
+++ b/crates/noon-web/src/manim_geometry_bridge.rs
@@ -1,0 +1,96 @@
+use noon::{Dot, IntoSnapshot, Triangle};
+use noon_core::{ObjectSnapshot, Vec2};
+
+fn finite_f32(name: &str, value: f64) -> Result<f32, String> {
+    if !value.is_finite() || value.abs() > f64::from(f32::MAX) {
+        return Err(format!("{name} must be a finite f32-compatible number"));
+    }
+    Ok(value as f32)
+}
+
+fn positive_f32(name: &str, value: f64) -> Result<f32, String> {
+    let value = finite_f32(name, value)?;
+    if value <= 0.0 {
+        return Err(format!("{name} must be positive"));
+    }
+    Ok(value)
+}
+
+fn snapshot_json(snapshot: ObjectSnapshot) -> Result<String, String> {
+    serde_json::to_string(&snapshot)
+        .map_err(|error| format!("unable to serialize Manim geometry snapshot: {error}"))
+}
+
+pub fn manim_dot_snapshot_json(point_x: f64, point_y: f64, radius: f64) -> Result<String, String> {
+    let point = Vec2::new(finite_f32("point.x", point_x)?, finite_f32("point.y", point_y)?);
+    snapshot_json(Dot::new(point, positive_f32("radius", radius)?).into_snapshot())
+}
+
+pub fn manim_triangle_snapshot_json() -> Result<String, String> {
+    snapshot_json(Triangle::new().into_snapshot())
+}
+
+#[cfg(target_arch = "wasm32")]
+mod wasm {
+    use wasm_bindgen::prelude::*;
+
+    use super::{manim_dot_snapshot_json, manim_triangle_snapshot_json};
+
+    fn js_error(error: String) -> JsValue {
+        JsValue::from_str(&error)
+    }
+
+    #[wasm_bindgen(js_name = manimDotSnapshotJson)]
+    pub fn manim_dot_snapshot(point_x: f64, point_y: f64, radius: f64) -> Result<String, JsValue> {
+        manim_dot_snapshot_json(point_x, point_y, radius).map_err(js_error)
+    }
+
+    #[wasm_bindgen(js_name = manimTriangleSnapshotJson)]
+    pub fn manim_triangle_snapshot() -> Result<String, JsValue> {
+        manim_triangle_snapshot_json().map_err(js_error)
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub use wasm::*;
+
+#[cfg(test)]
+mod tests {
+    use noon_core::{GeometryRef, PathCommand, BLUE, WHITE};
+
+    use super::*;
+
+    fn decode(value: &str) -> ObjectSnapshot {
+        serde_json::from_str(value).expect("valid ObjectSnapshot JSON")
+    }
+
+    #[test]
+    fn dot_bridge_uses_shared_rust_constructor_defaults() {
+        let snapshot = decode(&manim_dot_snapshot_json(2.0, -1.0, 0.2).unwrap());
+        assert_eq!(snapshot.transform.translation, Vec2::new(2.0, -1.0));
+        assert_eq!(snapshot.style.fill, Some(WHITE));
+        assert_eq!(snapshot.style.stroke, Some(WHITE));
+        assert_eq!(snapshot.style.stroke_width, 0.0);
+        match snapshot.geometry {
+            GeometryRef::Circle { radius } => assert_eq!(radius, 0.2),
+            other => panic!("expected analytic circle, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn triangle_bridge_uses_shared_polygon_path_and_blue_default() {
+        let snapshot = decode(&manim_triangle_snapshot_json().unwrap());
+        assert_eq!(snapshot.style.stroke, Some(BLUE));
+        let GeometryRef::VectorPath(path) = snapshot.geometry else {
+            panic!("expected retained vector path")
+        };
+        assert_eq!(path.commands().len(), 4);
+        assert!(matches!(path.commands().last(), Some(PathCommand::Close)));
+    }
+
+    #[test]
+    fn dot_bridge_rejects_non_renderable_values() {
+        assert!(manim_dot_snapshot_json(f64::NAN, 0.0, 0.08).is_err());
+        assert!(manim_dot_snapshot_json(0.0, 0.0, 0.0).is_err());
+    }
+}

--- a/crates/noon-web/src/manim_geometry_bridge.rs
+++ b/crates/noon-web/src/manim_geometry_bridge.rs
@@ -22,7 +22,10 @@ fn snapshot_json(snapshot: ObjectSnapshot) -> Result<String, String> {
 }
 
 pub fn manim_dot_snapshot_json(point_x: f64, point_y: f64, radius: f64) -> Result<String, String> {
-    let point = Vec2::new(finite_f32("point.x", point_x)?, finite_f32("point.y", point_y)?);
+    let point = Vec2::new(
+        finite_f32("point.x", point_x)?,
+        finite_f32("point.y", point_y)?,
+    );
     snapshot_json(Dot::new(point, positive_f32("radius", radius)?).into_snapshot())
 }
 

--- a/scripts/build-web-demo.sh
+++ b/scripts/build-web-demo.sh
@@ -57,6 +57,7 @@ node --check scripts/updater-callback-smoke.mjs
 node --test web/example-gallery.test.mjs
 node --test web/execution-transport.test.mjs
 node --test web/authoring-client.test.mjs
+node --test web/python-worker-source.test.mjs
 node --test web/scene-identity.test.mjs
 node --test web/frame-metrics.test.mjs
 node --test web/browser-jank.test.mjs
@@ -68,6 +69,7 @@ PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile \
   web/python/_manim_typst.py \
   web/python/_manim_rate_functions.py \
   web/python/_manim_phase_b.py \
+  web/python/_manim_shared_geometry.py \
   web/python/_manim_animation_options.py \
   web/python/_manim_animate.py \
   web/python/_manim_rotate.py \

--- a/web/python-worker-source.test.mjs
+++ b/web/python-worker-source.test.mjs
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const source = await readFile(new URL("./python-worker.js", import.meta.url), "utf8");
+
+test("Python authoring worker keeps request validation helper", () => {
+  assert.match(source, /function\s+validateRequest\s*\(/);
+  assert.match(source, /function\s+validateHostRequest\s*\(/);
+  assert.match(source, /function\s+isRecord\s*\(value\)\s*\{/);
+  assert.match(source, /if\s*\(!isRecord\(request\)\s*\|\|\s*request\.channel\s*!==\s*AUTHORING_CHANNEL\)/);
+});

--- a/web/python-worker.js
+++ b/web/python-worker.js
@@ -1,6 +1,8 @@
 import initNoonWeb, {
   RetainedTypstAuthoringHandle,
   WasmAuthoringStore,
+  manimDotSnapshotJson,
+  manimTriangleSnapshotJson,
   resolveAnimationOptions,
   resolveCompositionSchedule,
   resolveLifecyclePlan,
@@ -22,6 +24,7 @@ const MANIM_TYPST_MODULE_PATH = "/tmp/_manim_typst.py";
 const MANIM_RATE_FUNCTIONS_MODULE_PATH = "/tmp/_manim_rate_functions.py";
 const MANIM_PHASE_B_MODULE_PATH = "/tmp/_manim_phase_b.py";
 const MANIM_GEOMETRY_MODULE_PATH = "/tmp/_manim_geometry.py";
+const MANIM_SHARED_GEOMETRY_MODULE_PATH = "/tmp/_manim_shared_geometry.py";
 const MANIM_ANIMATION_OPTIONS_MODULE_PATH = "/tmp/_manim_animation_options.py";
 const MANIM_ANIMATE_MODULE_PATH = "/tmp/_manim_animate.py";
 const MANIM_ROTATE_MODULE_PATH = "/tmp/_manim_rotate.py";
@@ -51,6 +54,10 @@ async function initializePyodide() {
   const authoringStore = new WasmAuthoringStore();
   self.noonCreateAuthoringMobjectHandle = (snapshotJson) =>
     authoringStore.createMobject(snapshotJson);
+  self.noonCreateAuthoringDotHandle = (pointX, pointY, radius) =>
+    authoringStore.createMobject(manimDotSnapshotJson(pointX, pointY, radius));
+  self.noonCreateAuthoringTriangleHandle = () =>
+    authoringStore.createMobject(manimTriangleSnapshotJson());
   self.noonCreateAuthoringCircleHandle = (radius) => authoringStore.createManimCircle(radius);
   self.noonCreateAuthoringSquareHandle = (sideLength) => authoringStore.createManimSquare(sideLength);
   self.noonCreateAuthoringRectangleHandle = (width, height) =>
@@ -76,6 +83,7 @@ async function initializePyodide() {
     rateFunctionsResponse,
     phaseBResponse,
     geometryResponse,
+    sharedGeometryResponse,
     animationOptionsResponse,
     animateResponse,
     rotateResponse,
@@ -96,6 +104,7 @@ async function initializePyodide() {
     fetch(new URL("./python/_manim_rate_functions.py", import.meta.url)),
     fetch(new URL("./python/_manim_phase_b.py", import.meta.url)),
     fetch(new URL("./python/_manim_geometry.py", import.meta.url)),
+    fetch(new URL("./python/_manim_shared_geometry.py", import.meta.url)),
     fetch(new URL("./python/_manim_animation_options.py", import.meta.url)),
     fetch(new URL("./python/_manim_animate.py", import.meta.url)),
     fetch(new URL("./python/_manim_rotate.py", import.meta.url)),
@@ -117,6 +126,7 @@ async function initializePyodide() {
     [rateFunctionsResponse, "Noon Manim rate functions"],
     [phaseBResponse, "Noon Manim Phase B layer"],
     [geometryResponse, "Noon Manim geometry layer"],
+    [sharedGeometryResponse, "Noon shared Rust geometry adapter"],
     [animationOptionsResponse, "Noon Manim animation options"],
     [animateResponse, "Noon Manim animate layer"],
     [rotateResponse, "Noon Manim Rotate layer"],
@@ -144,6 +154,7 @@ async function initializePyodide() {
     [MANIM_RATE_FUNCTIONS_MODULE_PATH, rateFunctionsResponse],
     [MANIM_PHASE_B_MODULE_PATH, phaseBResponse],
     [MANIM_GEOMETRY_MODULE_PATH, geometryResponse],
+    [MANIM_SHARED_GEOMETRY_MODULE_PATH, sharedGeometryResponse],
     [MANIM_ANIMATION_OPTIONS_MODULE_PATH, animationOptionsResponse],
     [MANIM_ANIMATE_MODULE_PATH, animateResponse],
     [MANIM_ROTATE_MODULE_PATH, rotateResponse],
@@ -171,6 +182,8 @@ import _manim_phase_b
 import _manim_geometry
 import _manim_semantic_handles
 _manim_semantic_handles.install()
+import _manim_shared_geometry
+_manim_shared_geometry.install()
 import _manim_animate
 import _manim_rotate
 _manim_rotate.install()
@@ -516,8 +529,4 @@ function postError(requestId, error) {
     requestId,
     message: error instanceof Error ? error.message : String(error),
   });
-}
-
-function isRecord(value) {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/web/python-worker.js
+++ b/web/python-worker.js
@@ -530,3 +530,7 @@ function postError(requestId, error) {
     message: error instanceof Error ? error.message : String(error),
   });
 }
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/web/python/_manim_shared_geometry.py
+++ b/web/python/_manim_shared_geometry.py
@@ -28,6 +28,19 @@ _ORIGINAL_TRIANGLE_INIT = _geometry.Triangle.__init__
 _INSTALLED = False
 
 
+def _set_shared_color(self: _base.Mobject, color: object) -> None:
+    """Apply Manim ``color`` through the shared semantic handle.
+
+    The generic Phase-B setter rebuilds a Python snapshot before handing it back to
+    Rust.  Shared constructors must not re-enter that compatibility path: parse the
+    host color once, then use the semantic-handle mutation that preserves each
+    channel's existing opacity.
+    """
+
+    parsed = _shared._phase_b._as_color("color", color)
+    _shared._set_color(self, parsed)
+
+
 def _dot_init(
     self: _geometry.Dot,
     point: object = _base.ORIGIN,
@@ -62,7 +75,7 @@ def _dot_init(
     options["fill_opacity"] = fill_opacity
     _shared._apply_shared_constructor_kwargs(self, options)
     if color is not None:
-        self.set_color(color)
+        _set_shared_color(self, color)
 
 
 def _triangle_init(self: _geometry.Triangle, **kwargs: Any) -> None:
@@ -75,7 +88,7 @@ def _triangle_init(self: _geometry.Triangle, **kwargs: Any) -> None:
     _shared._attach_shared_handle(self, _create_triangle_handle())
     _shared._apply_shared_constructor_kwargs(self, options)
     if color is not None:
-        self.set_color(color)
+        _set_shared_color(self, color)
 
 
 def install() -> None:

--- a/web/python/_manim_shared_geometry.py
+++ b/web/python/_manim_shared_geometry.py
@@ -1,0 +1,92 @@
+"""Thin Manim geometry constructor adapters backed by shared Rust semantics.
+
+This module intentionally patches only constructors whose full observable geometry/layout
+contract is already owned by Rust.  Class identity and inheritance remain unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import noon as _base
+import _manim_compat as _compat
+import _manim_geometry as _geometry
+import _manim_semantic_handles as _shared
+
+try:
+    from js import noonCreateAuthoringDotHandle as _create_dot_handle
+except ImportError:  # Native CPython tests keep the existing Python constructor.
+    _create_dot_handle = None
+
+try:
+    from js import noonCreateAuthoringTriangleHandle as _create_triangle_handle
+except ImportError:  # Native CPython tests keep the existing Python constructor.
+    _create_triangle_handle = None
+
+_ORIGINAL_DOT_INIT = _geometry.Dot.__init__
+_ORIGINAL_TRIANGLE_INIT = _geometry.Triangle.__init__
+_INSTALLED = False
+
+
+def _dot_init(
+    self: _geometry.Dot,
+    point: object = _base.ORIGIN,
+    radius: float = _geometry.DEFAULT_DOT_RADIUS,
+    stroke_width: float = 0.0,
+    fill_opacity: float = 1.0,
+    color: _base.Color = _base.WHITE,
+    **kwargs: Any,
+) -> None:
+    if _create_dot_handle is None:
+        _ORIGINAL_DOT_INIT(
+            self,
+            point=point,
+            radius=radius,
+            stroke_width=stroke_width,
+            fill_opacity=fill_opacity,
+            color=color,
+            **kwargs,
+        )
+        return
+
+    point_value = _compat._as_vec2(point)
+    radius_value = _shared._ir._positive_number("radius", radius)
+    _shared._attach_shared_handle(
+        self,
+        _create_dot_handle(point_value.x, point_value.y, radius_value),
+    )
+    self.radius = radius_value
+
+    options = dict(kwargs)
+    options["stroke_width"] = stroke_width
+    options["fill_opacity"] = fill_opacity
+    _shared._apply_shared_constructor_kwargs(self, options)
+    if color is not None:
+        self.set_color(color)
+
+
+def _triangle_init(self: _geometry.Triangle, **kwargs: Any) -> None:
+    if _create_triangle_handle is None:
+        _ORIGINAL_TRIANGLE_INIT(self, **kwargs)
+        return
+
+    options = dict(kwargs)
+    color = options.pop("color", None)
+    _shared._attach_shared_handle(self, _create_triangle_handle())
+    _shared._apply_shared_constructor_kwargs(self, options)
+    if color is not None:
+        self.set_color(color)
+
+
+def install() -> None:
+    global _INSTALLED
+    if _INSTALLED:
+        return
+    _INSTALLED = True
+    if _create_dot_handle is not None:
+        _geometry.Dot.__init__ = _dot_init
+    if _create_triangle_handle is not None:
+        _geometry.Triangle.__init__ = _triangle_init
+
+
+install()

--- a/web/python/test_manim_shared_geometry.py
+++ b/web/python/test_manim_shared_geometry.py
@@ -1,0 +1,142 @@
+import os
+import subprocess
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+
+
+class ManimSharedGeometryTests(unittest.TestCase):
+    def test_dot_and_triangle_bypass_python_geometry_construction(self) -> None:
+        python_dir = Path(__file__).resolve().parent
+        env = os.environ.copy()
+        existing = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = (
+            str(python_dir)
+            if not existing
+            else os.pathsep.join((str(python_dir), existing))
+        )
+        source = textwrap.dedent(
+            r"""
+            import json
+            import sys
+            import types
+
+            fake_js = types.ModuleType("js")
+            calls = []
+
+            class FakeHandle:
+                def __init__(self, snapshot):
+                    self.snapshot = snapshot
+                def snapshotJson(self): return json.dumps(self.snapshot)
+                def setStrokeWidth(self, value): self.snapshot["style"]["stroke_width"] = float(value)
+                def setFillOpacity(self, value): self.snapshot["style"]["fill"]["alpha"] = float(value)
+                def setFillColor(self, r, g, b, a):
+                    alpha = self.snapshot["style"]["fill"]["alpha"]
+                    self.snapshot["style"]["fill"] = {"red": float(r), "green": float(g), "blue": float(b), "alpha": alpha}
+                def setStrokeColor(self, r, g, b, a):
+                    alpha = self.snapshot["style"]["stroke"]["alpha"]
+                    self.snapshot["style"]["stroke"] = {"red": float(r), "green": float(g), "blue": float(b), "alpha": alpha}
+
+            def base_style(color, *, fill_alpha=0.0, stroke_width=0.04):
+                return {
+                    "fill": {"red": color[0], "green": color[1], "blue": color[2], "alpha": fill_alpha},
+                    "stroke": {"red": color[0], "green": color[1], "blue": color[2], "alpha": 1.0},
+                    "stroke_width": stroke_width,
+                    "stroke_width_mode": "screen_space",
+                    "stroke_join": "miter",
+                    "stroke_cap": "butt",
+                    "opacity": 1.0,
+                }
+
+            def snapshot(geometry, style, x=0.0, y=0.0):
+                return {
+                    "geometry": geometry,
+                    "transform": {
+                        "translation": {"x": float(x), "y": float(y)},
+                        "rotation": 0.0,
+                        "scale": {"x": 1.0, "y": 1.0},
+                    },
+                    "style": style,
+                }
+
+            WHITE = (1.0, 1.0, 1.0)
+            BLUE = (0x58/255, 0xC4/255, 0xDD/255)
+
+            def generic_snapshot(value):
+                return FakeHandle(json.loads(value))
+
+            def dot(x, y, radius):
+                calls.append(("dot", float(x), float(y), float(radius)))
+                return FakeHandle(snapshot(
+                    {"circle": {"radius": float(radius)}},
+                    base_style(WHITE, fill_alpha=1.0, stroke_width=0.0),
+                    x,
+                    y,
+                ))
+
+            def triangle():
+                calls.append(("triangle",))
+                return FakeHandle(snapshot(
+                    {"vector_path": {"commands": [
+                        {"move_to": {"to": {"x": 0.0, "y": 1.0}}},
+                        {"line_to": {"to": {"x": -0.8660254, "y": -0.5}}},
+                        {"line_to": {"to": {"x": 0.8660254, "y": -0.5}}},
+                        "close",
+                    ]}},
+                    base_style(BLUE),
+                ))
+
+            fake_js.noonCreateAuthoringMobjectHandle = generic_snapshot
+            fake_js.noonCreateAuthoringDotHandle = dot
+            fake_js.noonCreateAuthoringTriangleHandle = triangle
+            sys.modules["js"] = fake_js
+
+            import _manim_compat
+            _manim_compat.install()
+            import _manim_phase_b
+            import _manim_geometry
+            import _manim_semantic_handles as handles
+            handles.install()
+
+            _manim_compat._ir.Circle = lambda *args, **kwargs: (_ for _ in ()).throw(
+                AssertionError("Python Circle geometry constructor was called")
+            )
+            _manim_compat._ir.Path = lambda *args, **kwargs: (_ for _ in ()).throw(
+                AssertionError("Python Path geometry constructor was called")
+            )
+
+            import _manim_shared_geometry
+            _manim_shared_geometry.install()
+            from noon import Dot, Triangle
+
+            dot_obj = Dot((2.0, -3.0, 0.0), radius=0.2)
+            triangle_obj = Triangle()
+
+            assert calls == [("dot", 2.0, -3.0, 0.2), ("triangle",)]
+            assert dot_obj.radius == 0.2
+            assert dot_obj.geometry == {"circle": {"radius": 0.2}}
+            assert dot_obj.transform["translation"] == {"x": 2.0, "y": -3.0}
+            assert dot_obj.style["fill"]["alpha"] == 1.0
+            assert dot_obj.style["stroke_width"] == 0.0
+            assert triangle_obj.style["stroke"]["red"] == BLUE[0]
+            assert "vector_path" in triangle_obj.geometry
+            """
+        )
+        completed = subprocess.run(
+            [sys.executable, "-c", source],
+            cwd=python_dir,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(
+            completed.returncode,
+            0,
+            f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a small `noon-web` bridge that serializes shared Rust `Dot` and `Triangle` snapshots for browser-language adapters
- keep `WasmAuthoringStore` and semantic-handle ownership unchanged: the Python worker feeds those Rust snapshots through the existing `createMobject` path
- patch only the existing Python `Dot` / `Triangle` constructors after semantic-handle installation, preserving class identity and inheritance
- remove browser-side Dot composition and Triangle vertex/path construction from the authoritative path while retaining native-CPython fallbacks
- add Rust unit tests for analytic Dot geometry/defaults and retained BLUE Triangle path semantics
- add a Python test that makes the old Python Circle/Path IR constructors throw, proving the browser shared-constructor path bypasses them

## Architecture
This is intentionally a thin adapter. Geometry defaults, Triangle vertex order/orientation, retained representation, and Dot placement come from `noon` Rust constructors. Python only validates/coerces host arguments and applies Manim constructor overrides through the existing shared semantic handle.

## Ellipse intentionally deferred
`Ellipse` is not migrated in this PR. The current Manim-compatible Python wrapper measures the eight-cubic VMobject control hull for rotated non-uniform ellipses, while the generic Rust semantic handle currently reports true analytic ellipse extrema. That difference is observable in layout. A follow-up should move that Manim-specific layout query into Rust before deleting the Python shim rather than silently regressing parity.

Tracks #76 and the #61 shared-semantics migration.