### PR TITLE
Fix Rotating arrow family motion

### DIFF
--- a/web/python/_manim_updaters.py
+++ b/web/python/_manim_updaters.py
@@ -377,8 +377,11 @@ def _install_rotating_breadth() -> None:
 
     The qualified centered-leaf implementation stays in ``_manim_rotate``. This final
     bootstrap wrapper handles retained groups, external pivots, and the 180-degree x/y
-    projections used by the upstream documentation scene. It intentionally remains a
-    parity candidate until curved z-pivot and 3D intermediate-frame tracks are native.
+    projections used by the upstream documentation scene. Z-axis family rotation is
+    subdivided into short deterministic transforms so independently retained children
+    follow the same rigid circular path to sub-pixel tolerance instead of taking one
+    long chord. The broader paths remain parity candidates until curved z-pivot and 3D
+    intermediate-frame tracks are native.
     """
 
     compat = sys.modules.get("_manim_compat")
@@ -392,6 +395,8 @@ def _install_rotating_breadth() -> None:
         return
 
     original_scene_play = compat.Scene.play
+    max_z_segment_angle = math.radians(5.0)
+    max_z_segments = 512
 
     class Rotating:
         def __init__(
@@ -484,6 +489,90 @@ def _install_rotating_breadth() -> None:
             raise ValueError(f"unsupported reflection axis {axis!r}")
         return animate._snapshot_mobject(target_snapshot)
 
+    def z_segment_count(angle: float, easing: str) -> int:
+        if easing in {"step_start", "step_end"}:
+            return 1
+        count = max(1, math.ceil(abs(angle) / max_z_segment_angle))
+        while count <= max_z_segments:
+            samples = [
+                rates.evaluate_rate_function(easing, index / count)
+                for index in range(count + 1)
+            ]
+            largest_step = max(
+                (abs(angle * (right - left)) for left, right in zip(samples, samples[1:])),
+                default=0.0,
+            )
+            if largest_step <= max_z_segment_angle + 1e-12:
+                return count
+            count *= 2
+        raise NotImplementedError(
+            "Rotating family z-axis motion would require too many deterministic segments; "
+            "native curved transform tracks are required for this angle/rate function"
+        )
+
+    def schedule_z_family(
+        scene: object,
+        animation: Rotating,
+        sources: list[_base.Mobject],
+        detached: list[_base.Mobject],
+        *,
+        pivot_point: _base.Vec2,
+        sign: float,
+        start_time: float,
+        duration: float,
+        easing: str,
+    ) -> None:
+        segment_count = z_segment_count(animation.angle, easing)
+        if segment_count == 1 and easing in {"step_start", "step_end"}:
+            for index, (source, current) in enumerate(zip(sources, detached, strict=True)):
+                assert source._object is not None
+                target = animate._snapshot_mobject(current.to_ir())
+                target.rotate(sign * animation.angle, compat.OUT, about_point=pivot_point)
+                object_key = scene._object_keys[source._object.id]
+                compat._BaseScene.play(
+                    scene,
+                    _base.Transform(
+                        source,
+                        target,
+                        key=f"@rotating-family:{object_key}:{start_time:g}:{index}",
+                    ),
+                    run_time=duration,
+                    start_time=start_time,
+                    easing=easing,
+                )
+            return
+
+        segment_duration = duration / segment_count
+        current_members = list(detached)
+        previous_progress = rates.evaluate_rate_function(easing, 0.0)
+        for segment_index in range(segment_count):
+            progress = rates.evaluate_rate_function(
+                easing, (segment_index + 1) / segment_count
+            )
+            delta_angle = sign * animation.angle * (progress - previous_progress)
+            segment_start = start_time + segment_index * segment_duration
+            for index, source in enumerate(sources):
+                assert source._object is not None
+                target = animate._snapshot_mobject(current_members[index].to_ir())
+                target.rotate(delta_angle, compat.OUT, about_point=pivot_point)
+                object_key = scene._object_keys[source._object.id]
+                compat._BaseScene.play(
+                    scene,
+                    _base.Transform(
+                        source,
+                        target,
+                        key=(
+                            f"@rotating-family:{object_key}:{start_time:g}:"
+                            f"{segment_index}:{index}"
+                        ),
+                    ),
+                    run_time=segment_duration,
+                    start_time=segment_start,
+                    easing="linear",
+                )
+                current_members[index] = target
+            previous_progress = progress
+
     def schedule_family(
         scene: object,
         animation: Rotating,
@@ -502,15 +591,24 @@ def _install_rotating_breadth() -> None:
                 "non-z Rotating currently supports the 180-degree projection used by Manim RotatingDemo"
             )
 
+        if axis == "z":
+            schedule_z_family(
+                scene,
+                animation,
+                sources,
+                detached,
+                pivot_point=pivot_point,
+                sign=sign,
+                start_time=start_time,
+                duration=duration,
+                easing=easing,
+            )
+            return
+
         for index, (source, current) in enumerate(zip(sources, detached, strict=True)):
             assert source._object is not None
             obj = source._object
-            if axis == "z":
-                target = animate._snapshot_mobject(current.to_ir())
-                target.rotate(sign * animation.angle, compat.OUT, about_point=pivot_point)
-            else:
-                target = reflected_target(current, axis=axis, pivot_point=pivot_point)
-
+            target = reflected_target(current, axis=axis, pivot_point=pivot_point)
             object_key = scene._object_keys[obj.id]
             compat._BaseScene.play(
                 scene,

--- a/web/python/_manim_updaters.py
+++ b/web/python/_manim_updaters.py
@@ -499,7 +499,10 @@ def _install_rotating_breadth() -> None:
                 for index in range(count + 1)
             ]
             largest_step = max(
-                (abs(angle * (right - left)) for left, right in zip(samples, samples[1:])),
+                (
+                    abs(angle * (right - left))
+                    for left, right in zip(samples, samples[1:])
+                ),
                 default=0.0,
             )
             if largest_step <= max_z_segment_angle + 1e-12:
@@ -543,6 +546,7 @@ def _install_rotating_breadth() -> None:
             return
 
         segment_duration = duration / segment_count
+        segment_start = start_time
         current_members = list(detached)
         previous_progress = rates.evaluate_rate_function(easing, 0.0)
         for segment_index in range(segment_count):
@@ -550,7 +554,6 @@ def _install_rotating_breadth() -> None:
                 easing, (segment_index + 1) / segment_count
             )
             delta_angle = sign * animation.angle * (progress - previous_progress)
-            segment_start = start_time + segment_index * segment_duration
             for index, source in enumerate(sources):
                 assert source._object is not None
                 target = animate._snapshot_mobject(current_members[index].to_ir())
@@ -571,6 +574,7 @@ def _install_rotating_breadth() -> None:
                     easing="linear",
                 )
                 current_members[index] = target
+            segment_start += segment_duration
             previous_progress = progress
 
     def schedule_family(

--- a/web/python/test_manim_rotating_family_motion.py
+++ b/web/python/test_manim_rotating_family_motion.py
@@ -1,0 +1,168 @@
+import os
+import subprocess
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+
+
+class ManimRotatingFamilyMotionTests(unittest.TestCase):
+    def test_arrow_tip_stays_on_short_rigid_rotation_intervals(self) -> None:
+        python_dir = Path(__file__).resolve().parent
+        env = os.environ.copy()
+        existing_pythonpath = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = (
+            str(python_dir)
+            if not existing_pythonpath
+            else os.pathsep.join((str(python_dir), existing_pythonpath))
+        )
+
+        source = textwrap.dedent(
+            """
+            import math
+            import sys
+            import types
+
+            fake_js = types.ModuleType("js")
+
+            class Result:
+                ok = True
+                errorKind = ""
+                message = ""
+
+            def resolve_animation_options(
+                default_lag_ratio,
+                animation_run_time,
+                animation_rate_func,
+                animation_lag_ratio,
+                path_arc,
+                reverse_rate_function,
+                play_run_time,
+                play_rate_func,
+                play_lag_ratio,
+            ):
+                result = Result()
+                result.runTime = (
+                    play_run_time
+                    if math.isfinite(play_run_time)
+                    else animation_run_time
+                    if math.isfinite(animation_run_time)
+                    else 1.0
+                )
+                result.rateFunc = play_rate_func or animation_rate_func or "smooth"
+                result.lagRatio = (
+                    play_lag_ratio
+                    if math.isfinite(play_lag_ratio)
+                    else animation_lag_ratio
+                    if math.isfinite(animation_lag_ratio)
+                    else default_lag_ratio
+                )
+                result.pathArc = path_arc if math.isfinite(path_arc) else 0.0
+                result.reverseRateFunction = reverse_rate_function == 1
+                return result
+
+            def resolve_uniform_schedule(child_count, lag_ratio, run_time):
+                result = Result()
+                result.intervals = []
+                return result
+
+            fake_js.noonResolveAnimationOptions = resolve_animation_options
+            fake_js.noonResolveUniformCompositionSchedule = resolve_uniform_schedule
+            sys.modules["js"] = fake_js
+
+            import _manim_compat
+            _manim_compat.install()
+            import _manim_rate_functions
+            _manim_rate_functions.install()
+            import _manim_phase_b  # noqa: F401
+            import _manim_geometry
+            _manim_geometry.install()
+            import _manim_animate  # noqa: F401
+            import _manim_rotate
+            _manim_rotate.install()
+            import _manim_updaters
+            _manim_updaters.install()
+
+            from noon import Arrow, ORIGIN, PI, RIGHT, Rotating, Scene
+
+            scene = Scene()
+            arrow = Arrow(start=ORIGIN, end=RIGHT, buff=0)
+            scene.add(arrow)
+            scene.play(
+                Rotating(
+                    arrow,
+                    angle=PI,
+                    about_point=arrow.get_start(),
+                    run_time=1.0,
+                )
+            )
+
+            assert abs(scene.time - 1.0) < 1e-12
+            document = scene.to_document()
+            shaft_id = arrow._shaft.id
+            tip_id = arrow._tip.id
+            shaft_tracks = [
+                track
+                for track in document["tracks"]
+                if track["object"] == shaft_id and track["property"] == "transform"
+            ]
+            tip_tracks = [
+                track
+                for track in document["tracks"]
+                if track["object"] == tip_id and track["property"] == "transform"
+            ]
+
+            # A half turn is split at a maximum five-degree interval. The old lowering
+            # emitted one one-second Transform per leaf, which sent the tip through the
+            # diameter while the shaft rotated and visibly detached it.
+            assert len(shaft_tracks) == len(tip_tracks) == 36
+            assert all(track["timing"]["easing"] == "linear" for track in shaft_tracks)
+            assert all(track["timing"]["easing"] == "linear" for track in tip_tracks)
+            assert all(
+                abs(track["timing"]["duration"] - 1.0 / 36.0) < 1e-12
+                for track in shaft_tracks + tip_tracks
+            )
+
+            for tracks in (shaft_tracks, tip_tracks):
+                for previous, current in zip(tracks, tracks[1:]):
+                    assert previous["values"]["object"]["to"] == current["values"]["object"]["from"]
+
+            # The interval endpoints are rigid rotations of the same family. With a
+            # five-degree maximum chord, the remaining in-interval radial error is
+            # below 1e-3 scene units at unit radius instead of the old O(1) separation.
+            import _manim_animate
+
+            for shaft_track, tip_track in zip(shaft_tracks, tip_tracks):
+                shaft = _manim_animate._snapshot_mobject(
+                    shaft_track["values"]["object"]["to"]
+                )
+                tip = _manim_animate._snapshot_mobject(
+                    tip_track["values"]["object"]["to"]
+                )
+                shaft_end = shaft.get_end()
+                tip_center = tip.get_center()
+                gap = math.hypot(
+                    shaft_end.x - tip_center.x,
+                    shaft_end.y - tip_center.y,
+                )
+                assert gap < 1e-9, gap
+            """
+        )
+
+        completed = subprocess.run(
+            [sys.executable, "-c", source],
+            check=False,
+            cwd=python_dir,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            completed.returncode,
+            0,
+            f"compatibility subprocess failed:\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix the visible Arrow tip/shaft separation in the public Manim `RotatingDemo`
- keep the existing exact centered-leaf `Rotating` fast path unchanged
- lower candidate z-axis family/external-pivot rotation into deterministic <=5° transform intervals so retained children follow the same circular motion to sub-pixel tolerance instead of one long chord
- preserve global rate-function timing by sampling the shared deterministic rate function at interval boundaries
- add a regression that verifies the Arrow shaft/tip family uses continuous short intervals and remains attached at every interval endpoint

## Root cause
`Arrow` is retained as a family (shaft + triangular tip). The broad `Rotating` compatibility path was lowering each leaf to one generic start/end `Transform`. For a 180° rotation, the tip translation therefore travelled across a straight diameter while the shaft rotation followed its own transform interpolation, producing the visible detachment/collapse.

## Scope
This addresses the z-axis rotations that cause the broken rotating-arrow/circle demo while retaining deterministic seek/rewind semantics. The existing x/y 3D projection portions of upstream `RotatingDemo` remain explicitly candidate parity until native 3D intermediate-frame representation lands.