### PR TITLE
Use retained frame dirtiness in production text rendering

### DIFF
--- a/crates/noon-render-wgpu/src/gpu/retained_text.rs
+++ b/crates/noon-render-wgpu/src/gpu/retained_text.rs
@@ -11,7 +11,7 @@ use noon_core::{
     StrokeJoin, StrokeWidthMode, Style, TextAffineTransform, TextGlyphStroke, TextRenderItem,
     TextResourceArena, TextVectorItem, Transform2D, Vec2, VectorPath,
 };
-use noon_runtime::{FrameObjectState, FrameState, RetainedFrameState};
+use noon_runtime::{FrameChanges, FrameObjectState, FrameState, RetainedFrameState};
 use noon_text_atlas::GpuGlyphAtlas;
 use noon_text_render_wgpu::{
     GlyphQuadInstance, PreparedRetainedTextFrame, PreparedTextItem, RetainedTextPrepareStats,
@@ -591,15 +591,40 @@ impl RetainedFramePreparer {
         geometries: &GeometryResourceArena,
         metrics: TextDeviceMetrics,
     ) -> Result<PreparedRetainedGpuFrame<'a>, RetainedPrepareError> {
+        let changes = FrameChanges::all();
+        self.prepare_with_changes(
+            device,
+            queue,
+            frame,
+            &changes,
+            texts,
+            fonts,
+            geometries,
+            metrics,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn prepare_with_changes<'a>(
+        &'a mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        frame: &RetainedFrameState,
+        changes: &FrameChanges,
+        texts: &TextResourceArena,
+        fonts: &FontResourceArena,
+        geometries: &GeometryResourceArena,
+        metrics: TextDeviceMetrics,
+    ) -> Result<PreparedRetainedGpuFrame<'a>, RetainedPrepareError> {
         self.build_scratch_frame(frame, texts, fonts, geometries)?;
 
         // #339/#341 intentionally keep the atlas inside the retained text preparer.
         // Snapshot the lightweight prepared records once so that borrow can end and
         // the atlas can be borrowed alongside them for the parent GPU renderer.
         {
-            let prepared = self
-                .text
-                .prepare(device, queue, frame, texts, fonts, metrics)?;
+            let prepared = self.text.prepare_with_changes(
+                device, queue, frame, changes, texts, fonts, metrics,
+            )?;
             self.snapshot_mask_quads.clear();
             self.snapshot_mask_quads
                 .extend_from_slice(prepared.mask_quads);

--- a/crates/noon-render-wgpu/src/gpu/retained_text.rs
+++ b/crates/noon-render-wgpu/src/gpu/retained_text.rs
@@ -593,14 +593,7 @@ impl RetainedFramePreparer {
     ) -> Result<PreparedRetainedGpuFrame<'a>, RetainedPrepareError> {
         let changes = FrameChanges::all();
         self.prepare_with_changes(
-            device,
-            queue,
-            frame,
-            &changes,
-            texts,
-            fonts,
-            geometries,
-            metrics,
+            device, queue, frame, &changes, texts, fonts, geometries, metrics,
         )
     }
 
@@ -622,9 +615,9 @@ impl RetainedFramePreparer {
         // Snapshot the lightweight prepared records once so that borrow can end and
         // the atlas can be borrowed alongside them for the parent GPU renderer.
         {
-            let prepared = self.text.prepare_with_changes(
-                device, queue, frame, changes, texts, fonts, metrics,
-            )?;
+            let prepared = self
+                .text
+                .prepare_with_changes(device, queue, frame, changes, texts, fonts, metrics)?;
             self.snapshot_mask_quads.clear();
             self.snapshot_mask_quads
                 .extend_from_slice(prepared.mask_quads);

--- a/crates/noon-web/src/retained_execution_canvas.rs
+++ b/crates/noon-web/src/retained_execution_canvas.rs
@@ -2,6 +2,7 @@
 mod wasm {
     use noon_core::Vec2;
     use noon_render_wgpu::{Camera2D, GpuRenderer, RetainedFramePreparer, RetainedTextGpuState};
+    use noon_runtime::FrameChanges;
     use noon_text_render_wgpu::TextDeviceMetrics;
     use wasm_bindgen::prelude::*;
     use web_sys::OffscreenCanvas;
@@ -42,6 +43,7 @@ mod wasm {
         drawable: bool,
         mirror: InstalledRetainedExecutionMirror,
         pending_frame: bool,
+        pending_changes: FrameChanges,
         preparer: RetainedFramePreparer,
         renderer: GpuRenderer,
         text_gpu: RetainedTextGpuState,
@@ -118,6 +120,7 @@ mod wasm {
                 drawable: true,
                 mirror,
                 pending_frame: false,
+                pending_changes: FrameChanges::default(),
                 preparer: RetainedFramePreparer::new(),
                 renderer,
                 text_gpu,
@@ -140,7 +143,7 @@ mod wasm {
                     "render worker must present the retained execution delta before accepting another",
                 ));
             }
-            let (outcome, _) = self.mirror.apply_json(json).map_err(js_error)?;
+            let (outcome, changes) = self.mirror.apply_json(json).map_err(js_error)?;
             match outcome {
                 RetainedTransportApplyOutcome::Applied => {
                     let camera = self.mirror.camera();
@@ -149,6 +152,7 @@ mod wasm {
                         self.camera_height = camera.height;
                         self.update_camera()?;
                     }
+                    self.pending_changes = changes;
                     self.pending_frame = true;
                     Ok(true)
                 }
@@ -196,10 +200,11 @@ mod wasm {
             .map_err(js_error)?;
             let prepared = self
                 .preparer
-                .prepare(
+                .prepare_with_changes(
                     &self.device,
                     &self.queue,
                     frame,
+                    &self.pending_changes,
                     resources.texts(),
                     resources.fonts(),
                     resources.geometries(),
@@ -242,6 +247,7 @@ mod wasm {
                 .instances_drawn
                 .saturating_add(draw.text.instances_drawn);
             self.pending_frame = false;
+            self.pending_changes = FrameChanges::default();
             if reconfigure_after_present {
                 self.surface.configure(&self.device, &self.config);
             }

--- a/crates/noon-web/src/retained_typst_canvas.rs
+++ b/crates/noon-web/src/retained_typst_canvas.rs
@@ -124,12 +124,14 @@ mod wasm {
                 self.config.height as f32 / camera.world_size.y,
             ))
             .map_err(js_error)?;
+            let changes = self.runtime.take_frame_changes();
             let prepared = self
                 .preparer
-                .prepare(
+                .prepare_with_changes(
                     &self.device,
                     &self.queue,
                     self.runtime.frame(),
+                    &changes,
                     self.scene.texts(),
                     self.scene.fonts(),
                     self.scene.geometries(),


### PR DESCRIPTION
## Summary
- add `RetainedFramePreparer::prepare_with_changes(...)` and preserve the existing `prepare(...)` API as a full-dirty compatibility wrapper
- forward runtime/transport `FrameChanges` into `RetainedTextQuadPreparer::prepare_with_changes(...)`
- stop discarding `InstalledRetainedExecutionMirror::apply_json(...)` dirtiness in the retained execution render worker
- preserve pending changes across surface timeout/loss until a frame is actually presented
- consume `RetainedSceneInstance::take_frame_changes()` in the retained Typst canvas

## Why
The lower-level text preparer already had a zero-raster/atlas-work unchanged-frame path, but production never used it: the mixed retained renderer always called the compatibility `prepare()` entry point, which synthesized `FrameChanges::all()`. This made the optimization test-only.

This first #362 slice makes existing dirtiness real in production without changing painter order, resource identity, transport shape, or glyph raster policy.

## Important remaining O(total) work
This is intentionally **not** yet the final O(changed) renderer. `RetainedFramePreparer` still rebuilds the mixed scratch geometry/order frame and copies the already-prepared text snapshot arrays on each render. Those costs remain visible for the next slices rather than being hidden behind the lower-level cache fast path.

## Follow-up
The next #362 slice will retain per-object prepared ranges so translation/paint/opacity/appearance changes mutate only the affected object's quads. Scale/rotation/content/presence/reveal/morph/metrics/structural changes will conservatively rebuild. A subsequent renderer snapshot/upload slice will eliminate unchanged full-array copying/upload where generation identity is stable.

Tracks #362. Architecture parent #361.