### PR TITLE
Keep Rotating families rigid through z-axis turns

### DIFF
--- a/web/python/_manim_updaters.py
+++ b/web/python/_manim_updaters.py
@@ -502,14 +502,59 @@ def _install_rotating_breadth() -> None:
                 "non-z Rotating currently supports the 180-degree projection used by Manim RotatingDemo"
             )
 
+        if axis == "z":
+            # Generic Transform's pointwise-rotation interpolation is intentionally
+            # target-state semantics: for a 180-degree source/target pair its matrix
+            # blend passes through zero scale at alpha=0.5. That is correct for
+            # ``mobject.animate.rotate`` but wrong for procedural Rotating families:
+            # circles collapse and independently retained Arrow shaft/tip members can
+            # visibly separate. Approximate the missing curved family-pivot channel
+            # with short deterministic Transform arcs, all sampled from the same
+            # global rate function. At <=5 degrees per interval the pointwise blend's
+            # worst midpoint scale factor is cos(2.5 degrees) > 0.999, while every
+            # family member remains synchronized at identical segment boundaries.
+            max_step = math.pi / 36.0
+            segment_count = max(1, math.ceil(abs(animation.angle) / max_step))
+            end_time = start_time + duration
+            for segment in range(segment_count):
+                alpha = (segment + 1) / segment_count
+                eased_alpha = rates.evaluate_rate_function(easing, alpha)
+                cumulative_angle = sign * animation.angle * eased_alpha
+                segment_start = start_time + duration * segment / segment_count
+                segment_end = (
+                    end_time
+                    if segment + 1 == segment_count
+                    else start_time + duration * (segment + 1) / segment_count
+                )
+                segment_duration = segment_end - segment_start
+                for index, (source, current) in enumerate(
+                    zip(sources, detached, strict=True)
+                ):
+                    assert source._object is not None
+                    obj = source._object
+                    target = animate._snapshot_mobject(current.to_ir())
+                    target.rotate(cumulative_angle, compat.OUT, about_point=pivot_point)
+                    object_key = scene._object_keys[obj.id]
+                    compat._BaseScene.play(
+                        scene,
+                        _base.Transform(
+                            source,
+                            target,
+                            key=(
+                                f"@rotating-family:{object_key}:{start_time:g}:{index}"
+                                f":segment:{segment}"
+                            ),
+                        ),
+                        run_time=segment_duration,
+                        start_time=segment_start,
+                        easing="linear",
+                    )
+            return
+
         for index, (source, current) in enumerate(zip(sources, detached, strict=True)):
             assert source._object is not None
             obj = source._object
-            if axis == "z":
-                target = animate._snapshot_mobject(current.to_ir())
-                target.rotate(sign * animation.angle, compat.OUT, about_point=pivot_point)
-            else:
-                target = reflected_target(current, axis=axis, pivot_point=pivot_point)
+            target = reflected_target(current, axis=axis, pivot_point=pivot_point)
 
             object_key = scene._object_keys[obj.id]
             compat._BaseScene.play(

--- a/web/python/test_manim_rotating_family_rigidity.py
+++ b/web/python/test_manim_rotating_family_rigidity.py
@@ -1,0 +1,172 @@
+import os
+import subprocess
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+
+
+class ManimRotatingFamilyRigidityTests(unittest.TestCase):
+    def test_family_rotation_is_split_before_pointwise_transform_can_collapse(self) -> None:
+        python_dir = Path(__file__).resolve().parent
+        env = os.environ.copy()
+        existing_pythonpath = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = (
+            str(python_dir)
+            if not existing_pythonpath
+            else os.pathsep.join((str(python_dir), existing_pythonpath))
+        )
+
+        source = textwrap.dedent(
+            """
+            import math
+            import sys
+            import types
+
+            fake_js = types.ModuleType("js")
+
+            class Result:
+                ok = True
+                errorKind = ""
+                message = ""
+
+            def resolve_animation_options(
+                default_lag_ratio,
+                animation_run_time,
+                animation_rate_func,
+                animation_lag_ratio,
+                path_arc,
+                reverse_rate_function,
+                play_run_time,
+                play_rate_func,
+                play_lag_ratio,
+            ):
+                result = Result()
+                result.runTime = (
+                    play_run_time
+                    if math.isfinite(play_run_time)
+                    else animation_run_time
+                    if math.isfinite(animation_run_time)
+                    else 1.0
+                )
+                result.rateFunc = play_rate_func or animation_rate_func or "smooth"
+                result.lagRatio = (
+                    play_lag_ratio
+                    if math.isfinite(play_lag_ratio)
+                    else animation_lag_ratio
+                    if math.isfinite(animation_lag_ratio)
+                    else default_lag_ratio
+                )
+                result.pathArc = path_arc if math.isfinite(path_arc) else 0.0
+                result.reverseRateFunction = reverse_rate_function == 1
+                return result
+
+            def resolve_uniform_schedule(child_count, lag_ratio, run_time):
+                result = Result()
+                result.intervals = []
+                return result
+
+            fake_js.noonResolveAnimationOptions = resolve_animation_options
+            fake_js.noonResolveUniformCompositionSchedule = resolve_uniform_schedule
+            sys.modules["js"] = fake_js
+
+            import _manim_compat
+            _manim_compat.install()
+            import _manim_rate_functions
+            _manim_rate_functions.install()
+            import _manim_phase_b  # noqa: F401
+            import _manim_geometry  # noqa: F401
+            import _manim_animate  # noqa: F401
+            import _manim_rotate
+            _manim_rotate.install()
+            import _manim_updaters
+            _manim_updaters.install()
+
+            from noon import Arrow, Circle, Line, ORIGIN, PI, RIGHT, Rotating, Scene, VGroup
+
+            scene = Scene()
+            arrow = Arrow(start=ORIGIN, end=RIGHT, buff=0)
+            scene.add(arrow)
+            pivot = arrow.get_start()
+            scene.play(Rotating(arrow, PI, about_point=pivot, run_time=1.0))
+            # RotatingDemo immediately schedules the same segmented animation again.
+            # Segment boundaries must be computed absolutely rather than accumulated,
+            # or floating-point drift can leave the final Transform microscopically
+            # active at the exact start of this second play.
+            scene.play(Rotating(arrow, PI, about_point=pivot, run_time=1.0))
+            assert scene.time == 2.0
+
+            document = scene.to_document()
+            family_tracks = [
+                track for track in document["tracks"]
+                if track["property"] == "transform"
+            ]
+            assert len(family_tracks) > 2, "a 180-degree Arrow rotation must be segmented"
+
+            # Every retained Arrow member must hand off exactly at the authored scene
+            # boundary. This catches the old repeated-addition drift independently of
+            # whether a following animation happens to query that member immediately.
+            for object_id in {track["object"] for track in family_tracks}:
+                object_tracks = [
+                    track for track in family_tracks if track["object"] == object_id
+                ]
+                final_track = max(
+                    object_tracks,
+                    key=lambda track: track["timing"]["start_time"],
+                )
+                timing = final_track["timing"]
+                assert timing["start_time"] + timing["duration"] == scene.time
+
+            # The runtime's generic pointwise-rotation Transform interpolator is safe
+            # for short arcs, but a single 180-degree interval collapses its scale at
+            # the midpoint. Keep every authored interval small enough that the worst
+            # midpoint scale loss stays visually negligible.
+            for track in family_tracks:
+                values = track["values"]["object"]
+                start_rotation = float(values["from"]["transform"]["rotation"])
+                end_rotation = float(values["to"]["transform"]["rotation"])
+                delta = abs(end_rotation - start_rotation)
+                assert delta <= math.pi / 36.0 + 1e-9, delta
+                assert math.cos(delta / 2.0) > 0.999
+
+            # The public RotatingDemo next rotates a family containing a circle, line,
+            # and the Arrow. That path must use the same segmented lowering rather
+            # than reintroducing a single collapse-prone transform per leaf.
+            group_scene = Scene()
+            circle = Circle(radius=1)
+            line = Line(start=ORIGIN, end=RIGHT)
+            grouped_arrow = Arrow(start=ORIGIN, end=RIGHT, buff=0)
+            family = VGroup(circle, line, grouped_arrow)
+            group_scene.add(family)
+            group_scene.play(Rotating(family, PI, about_point=RIGHT, run_time=1.0))
+            group_document = group_scene.to_document()
+            group_tracks = [
+                track for track in group_document["tracks"]
+                if track["property"] == "transform"
+            ]
+            assert len(group_tracks) > 4
+            for track in group_tracks:
+                values = track["values"]["object"]
+                start_rotation = float(values["from"]["transform"]["rotation"])
+                end_rotation = float(values["to"]["transform"]["rotation"])
+                assert abs(end_rotation - start_rotation) <= math.pi / 36.0 + 1e-9
+            """
+        )
+
+        completed = subprocess.run(
+            [sys.executable, "-c", source],
+            check=False,
+            cwd=python_dir,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            completed.returncode,
+            0,
+            f"compatibility subprocess failed:\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix the public Manim `RotatingDemo` family path where a 180° generic Transform can collapse retained members at the midpoint, making the Arrow shaft/tip appear disconnected and shrinking the Circle
- keep `.animate.rotate` target-state interpolation unchanged
- for broad z-axis `Rotating(Group/VGroup)`, lower the missing curved pivot path into synchronized deterministic Transform segments; the public demo's default linear path uses at most 5° per segment
- compute every segment boundary from the absolute play interval (not repeated floating-point addition), so consecutive `Rotating` plays hand off at the exact same authored timestamp
- retain the existing candidate-only x/y projection behavior unchanged

## Why
The runtime intentionally uses pointwise source/target interpolation for ordinary `Transform`. For a 180° rotation that matrix blend reaches zero scale at alpha=0.5. That behavior is appropriate for target-state Transform semantics but not procedural `Rotating`, especially for composite Arrow geometry and the circle/line/arrow family in the upstream demo.

The first segmented implementation exposed a second issue in end-to-end CI: accumulating `1/36`-second segment starts could leave the final Transform microscopically active at the exact start of the next `Rotating` play. Absolute interval boundaries remove that numerical handoff ambiguity.

This change avoids an Arrow-specific renderer workaround and does not add a Python per-frame callback. All playback remains ordinary deterministic timeline tracks.

## Regression coverage
`test_manim_rotating_family_rigidity.py` verifies:
- two consecutive 180° Arrow rotations execute at exact 1-second handoff boundaries
- each retained Arrow member's final segment ends exactly at the scene cursor
- Arrow and Circle/Line/Arrow family z-rotation intervals remain <=5° for the demo's default linear rate, keeping pointwise midpoint scale above 0.999 instead of collapsing

Broader family/external-pivot `Rotating` remains a parity candidate until Noon has a native curved family-pivot track; this patch fixes the visible public demo without pretending that candidate surface is fully qualified.

Tracks #80 / RotatingDemo parity work.