### PR TITLE
Add shared Manim Ellipse layout bounds

### DIFF
--- a/crates/noon/src/analytic_geometry_authoring.rs
+++ b/crates/noon/src/analytic_geometry_authoring.rs
@@ -5,7 +5,7 @@
 //! so frontends do not need to rebuild paths and renderers do not need new primitives.
 
 use crate::legacy::{Circle, IntoSnapshot};
-use noon_core::{Color, ObjectSnapshot, Vec2, WHITE};
+use noon_core::{Color, GeometryRef, ObjectSnapshot, Vec2, WHITE};
 
 pub const DEFAULT_DOT_RADIUS: f32 = 0.08;
 
@@ -95,6 +95,46 @@ impl Default for Dot {
     }
 }
 
+/// Return ManimCE's observable VMobject layout hull for an Ellipse snapshot.
+///
+/// Noon deliberately renders Ellipse as an analytic affine circle. ManimCE's Circle,
+/// however, stores eight cubic Bézier segments and its generic layout queries inspect
+/// the full point/control-point array rather than the true analytic extrema. For a
+/// rotated non-uniform ellipse that control hull is slightly larger. This query keeps
+/// that observable layout behavior in shared Rust without changing renderer geometry.
+pub fn manim_ellipse_layout_bounds(snapshot: &ObjectSnapshot) -> Option<(Vec2, Vec2)> {
+    let GeometryRef::Circle { radius } = &snapshot.geometry else {
+        return None;
+    };
+
+    let handle_factor = (4.0 / 3.0) * (std::f32::consts::PI / 16.0).tan();
+    let mut minimum = Vec2::new(f32::INFINITY, f32::INFINITY);
+    let mut maximum = Vec2::new(f32::NEG_INFINITY, f32::NEG_INFINITY);
+
+    for index in 0..8 {
+        let start_angle = index as f32 * std::f32::consts::PI / 4.0;
+        let end_angle = (index + 1) as f32 * std::f32::consts::PI / 4.0;
+        let (start_sin, start_cos) = start_angle.sin_cos();
+        let (end_sin, end_cos) = end_angle.sin_cos();
+        let start = Vec2::new(start_cos, start_sin);
+        let end = Vec2::new(end_cos, end_sin);
+        let start_tangent = Vec2::new(-start_sin, start_cos);
+        let end_tangent = Vec2::new(-end_sin, end_cos);
+        let control1 = start + start_tangent * handle_factor;
+        let control2 = end - end_tangent * handle_factor;
+
+        for point in [start, control1, control2, end] {
+            let world = snapshot.transform.transform_point(point * *radius);
+            minimum.x = minimum.x.min(world.x);
+            minimum.y = minimum.y.min(world.y);
+            maximum.x = maximum.x.max(world.x);
+            maximum.y = maximum.y.max(world.y);
+        }
+    }
+
+    Some((minimum, maximum))
+}
+
 impl Ellipse {
     /// Build an ellipse by affinely stretching the retained unit circle.
     ///
@@ -106,6 +146,11 @@ impl Ellipse {
             .scale_xy(Vec2::new(width * 0.5, height * 0.5))
             .into_snapshot();
         Self(snapshot)
+    }
+
+    /// Return the Manim-visible VMobject control hull after retained transforms.
+    pub fn manim_layout_bounds(&self) -> (Vec2, Vec2) {
+        manim_ellipse_layout_bounds(&self.0).expect("Ellipse retains analytic circle geometry")
     }
 }
 
@@ -126,6 +171,18 @@ mod tests {
             (actual - expected).abs() <= 1e-6,
             "expected {expected}, got {actual}"
         );
+    }
+
+    fn assert_close_with_tolerance(actual: f32, expected: f32, tolerance: f32) {
+        assert!(
+            (actual - expected).abs() <= tolerance,
+            "expected {expected}, got {actual} within {tolerance}"
+        );
+    }
+
+    fn assert_vec_close(actual: Vec2, expected: Vec2) {
+        assert_close(actual.x, expected.x);
+        assert_close(actual.y, expected.y);
     }
 
     #[test]
@@ -180,5 +237,35 @@ mod tests {
             ellipse.snapshot().style.stroke_width_mode,
             StrokeWidthMode::ScreenSpace
         );
+    }
+
+    #[test]
+    fn ellipse_manim_layout_bounds_match_axis_aligned_dimensions() {
+        let ellipse = Ellipse::new(4.0, 1.5).shift(Vec2::new(2.0, -1.0));
+        let (minimum, maximum) = ellipse.manim_layout_bounds();
+        assert_vec_close(minimum, Vec2::new(0.0, -1.75));
+        assert_vec_close(maximum, Vec2::new(4.0, -0.25));
+    }
+
+    #[test]
+    fn rotated_nonuniform_ellipse_uses_manim_control_point_hull() {
+        let ellipse = Ellipse::new(4.0, 1.5)
+            .rotate(std::f32::consts::PI / 6.0)
+            .shift(Vec2::new(2.0, -1.0));
+        let (minimum, maximum) = ellipse.manim_layout_bounds();
+
+        assert_close_with_tolerance(minimum.x, 0.16849303, 1e-5);
+        assert_close_with_tolerance(minimum.y, -2.232114, 1e-5);
+        assert_close_with_tolerance(maximum.x, 3.8315067, 1e-5);
+        assert_close_with_tolerance(maximum.y, 0.23211408, 1e-5);
+        assert!(maximum.x - minimum.x < ellipse.snapshot().width());
+        assert!(maximum.y - minimum.y < ellipse.snapshot().height());
+    }
+
+    #[test]
+    fn ellipse_layout_query_rejects_non_circle_snapshots() {
+        let mut snapshot = Ellipse::default().into_snapshot();
+        snapshot.geometry = GeometryRef::rectangle(2.0, 1.0);
+        assert_eq!(manim_ellipse_layout_bounds(&snapshot), None);
     }
 }


### PR DESCRIPTION
## Summary
- keep `Ellipse` renderer geometry analytic while moving ManimCE's observable VMobject layout hull into shared Rust
- reproduce the eight cubic-circle segments and their control points used by Manim layout queries
- apply the current retained affine transform to those points, so rotated non-uniform ellipses report the same control-point hull without Python geometry math
- expose `manim_ellipse_layout_bounds(&ObjectSnapshot)` plus `Ellipse::manim_layout_bounds()`
- add focused tests for axis-aligned dimensions, a pinned rotated/non-uniform control hull, and non-circle rejection

## Architecture
This is query-only. It does not lower Ellipse to a vector path or add renderer work. Noon continues rendering one analytic circle with affine scale; the cubic points exist only transiently when an authoring/layout query requests Manim-compatible bounds.

This clears the known blocker for migrating the current Python `Ellipse` wrapper to shared Rust semantics without changing its observable width/height behavior after rotation.

Tracks #76 and #61.