### PR TITLE
Remove misleading demo performance telemetry

### DIFF
--- a/scripts/playground-layout-smoke.mjs
+++ b/scripts/playground-layout-smoke.mjs
@@ -139,6 +139,16 @@ try {
     { timeout: 30_000 },
   );
   await waitForAuthoredScene(page, "parity-square-and-circle", browserErrors);
+  await page.waitForFunction(
+    () =>
+      ["metric-objects", "metric-draws", "metric-upload", "metric-time"].every((id) => {
+        const metric = document.querySelector(`#${id}`);
+        const value = metric?.value ?? metric?.textContent ?? "";
+        return value !== "" && value !== "—";
+      }),
+    null,
+    { timeout: 10_000 },
+  );
 
   const galleryContract = await page.evaluate(() => ({
     cards: document.querySelectorAll(".example-card").length,
@@ -173,10 +183,26 @@ try {
     const workspaceRect = workspace.getBoundingClientRect();
     const editorRect = editor.getBoundingClientRect();
     const previewRect = preview.getBoundingClientRect();
+    const metricLabels = [...document.querySelectorAll(".metric-label")].map(
+      (label) => label.textContent ?? "",
+    );
+    const metricValues = [...document.querySelectorAll(".metric-value")].map(
+      (metric) => metric.value ?? metric.textContent ?? "",
+    );
+    const realMetricIds = ["metric-objects", "metric-draws", "metric-upload", "metric-time"];
     return {
       selectedOutsideWorkspace: selected !== null && !workspace.contains(selected),
       selectedImmediatelyBeforeWorkspace: selected?.nextElementSibling === workspace,
       obsoletePanels: document.querySelectorAll(".below, .info-panel, .pipeline, .api-list").length,
+      placeholderPerformancePanels: document.querySelectorAll(".perf-metrics").length,
+      percentileLabels: metricLabels.filter((label) => /\bp(?:50|95)\b/i.test(label)).length,
+      fakeTimingValues: metricValues.filter((value) => /^(?:engine|render) worker$/i.test(value)).length,
+      realMetricsPresent: realMetricIds.every((id) => document.querySelector(`#${id}`) !== null),
+      realMetricsPopulated: realMetricIds.every((id) => {
+        const metric = document.querySelector(`#${id}`);
+        const value = metric?.value ?? metric?.textContent ?? "";
+        return value !== "" && value !== "—";
+      }),
       editorTop: editorRect.top,
       previewTop: previewRect.top,
       editorShare: editorRect.width / workspaceRect.width,
@@ -197,6 +223,23 @@ try {
     0,
     "obsolete architecture/API presentation panes must not be rendered",
   );
+  assert.equal(
+    presentationContract.placeholderPerformancePanels,
+    0,
+    "playground must not expose a placeholder frame-performance panel",
+  );
+  assert.equal(
+    presentationContract.percentileLabels,
+    0,
+    "playground must not claim p50/p95 telemetry without measured percentiles",
+  );
+  assert.equal(
+    presentationContract.fakeTimingValues,
+    0,
+    "worker ownership strings must not be presented as timing values",
+  );
+  assert.equal(presentationContract.realMetricsPresent, true, "real scene metrics must remain visible");
+  assert.equal(presentationContract.realMetricsPopulated, true, "real scene metrics must keep updating");
   assert.ok(
     Math.abs(presentationContract.editorTop - presentationContract.previewTop) <= 1,
     `desktop source/preview panes must align at the top (${presentationContract.editorTop} vs ${presentationContract.previewTop})`,

--- a/web/index.html
+++ b/web/index.html
@@ -372,20 +372,11 @@
         box-shadow: inset 0 0 0 1px rgb(255 255 255 / 2%);
       }
 
-      .metrics,
-      .perf-metrics {
+      .metrics {
         display: grid;
+        grid-template-columns: repeat(4, minmax(0, 1fr));
         border-top: 1px solid var(--border);
         background: rgb(10 13 21 / 86%);
-      }
-
-      .metrics {
-        grid-template-columns: repeat(4, minmax(0, 1fr));
-      }
-
-      .perf-metrics {
-        grid-template-columns: repeat(3, minmax(0, 1fr));
-        background: rgb(8 11 18 / 92%);
       }
 
       .metric {
@@ -490,8 +481,7 @@
           padding-top: 75%;
         }
 
-        .metrics,
-        .perf-metrics {
+        .metrics {
           grid-template-columns: repeat(2, 1fr);
         }
 
@@ -613,32 +603,6 @@
             <div class="metric">
               <span class="metric-label">Playhead</span>
               <output id="metric-time" class="metric-value">—</output>
-            </div>
-          </div>
-          <div class="perf-metrics" aria-label="Frame performance p50 and p95">
-            <div class="metric">
-              <span class="metric-label">CPU frame · p50 / p95</span>
-              <output id="metric-cpu-frame" class="metric-value">—</output>
-            </div>
-            <div class="metric">
-              <span class="metric-label">Runtime eval · p50 / p95</span>
-              <output id="metric-runtime" class="metric-value">—</output>
-            </div>
-            <div class="metric">
-              <span class="metric-label">Frame prepare · p50 / p95</span>
-              <output id="metric-prepare" class="metric-value">—</output>
-            </div>
-            <div class="metric">
-              <span class="metric-label">GPU upload CPU · p50 / p95</span>
-              <output id="metric-upload-ms" class="metric-value">—</output>
-            </div>
-            <div class="metric">
-              <span class="metric-label">Encode + submit · p50 / p95</span>
-              <output id="metric-encode" class="metric-value">—</output>
-            </div>
-            <div class="metric">
-              <span class="metric-label">GPU render · p50 / p95</span>
-              <output id="metric-gpu" class="metric-value">—</output>
             </div>
           </div>
         </section>

--- a/web/main.js
+++ b/web/main.js
@@ -25,12 +25,6 @@ const metricObjects = document.querySelector("#metric-objects");
 const metricDraws = document.querySelector("#metric-draws");
 const metricUpload = document.querySelector("#metric-upload");
 const metricTime = document.querySelector("#metric-time");
-const metricCpuFrame = document.querySelector("#metric-cpu-frame");
-const metricRuntime = document.querySelector("#metric-runtime");
-const metricPrepare = document.querySelector("#metric-prepare");
-const metricUploadMs = document.querySelector("#metric-upload-ms");
-const metricEncode = document.querySelector("#metric-encode");
-const metricGpu = document.querySelector("#metric-gpu");
 const workspace = document.querySelector(".workspace");
 const toolbarActions = document.querySelector(".actions");
 
@@ -582,12 +576,6 @@ try {
       metricDraws.value = String(metrics.drawCalls);
       metricUpload.value = formatBytes(metrics.bytesUploaded);
       metricTime.value = `${metrics.time.toFixed(2)} s`;
-      metricCpuFrame.value = "engine worker";
-      metricRuntime.value = host.enabled ? `${host.missedDeadlines} host misses` : "engine worker";
-      metricPrepare.value = "render worker";
-      metricUploadMs.value = "render worker";
-      metricEncode.value = "render worker";
-      metricGpu.value = rendererBackend;
       status.dataset.instances = String(metrics.instancesDrawn);
       status.dataset.uploadBytes = String(metrics.bytesUploaded);
       status.dataset.geometryCacheMisses = String(metrics.geometryCacheMisses);


### PR DESCRIPTION
## Superseded on master

The product intent of this stacked PR is already present on current master:

- the placeholder `.perf-metrics` p50/p95 panel is absent from `web/index.html`;
- `web/main.js` has only the truthful object/draw/upload/playhead metric bindings and no worker-name pseudo-timing writes;
- `scripts/playground-layout-smoke.mjs` already rejects `.perf-metrics` and fake p50/p95 labels as part of the presentation contract.

No replay is needed. Closing this stale stack avoids reintroducing old #399-era file state.