### PR TITLE
Add cross-browser playground E2E matrix

### DIFF
--- a/.github/workflows/playground-cross-browser.yml
+++ b/.github/workflows/playground-cross-browser.yml
@@ -1,0 +1,132 @@
+name: Playground cross-browser matrix
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/playground-cross-browser.yml"
+      - "crates/noon-render-wgpu/**"
+      - "crates/noon-web/**"
+      - "scripts/build-web-demo.sh"
+      - "scripts/playground-browser-matrix-smoke.mjs"
+      - "web/**"
+  push:
+    branches:
+      - master
+    paths:
+      - ".github/workflows/playground-cross-browser.yml"
+      - "crates/noon-render-wgpu/**"
+      - "crates/noon-web/**"
+      - "scripts/build-web-demo.sh"
+      - "scripts/playground-browser-matrix-smoke.mjs"
+      - "web/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: playground-cross-browser-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build browser package
+    runs-on: ubuntu-latest
+    env:
+      CARGO_INCREMENTAL: "0"
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use stable Rust
+        run: |
+          rustup default stable
+          rustup target add wasm32-unknown-unknown
+
+      - name: Cache Cargo sources
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-sources-${{ hashFiles('Cargo.toml', 'crates/**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-sources-
+
+      - name: Use sccache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+        with:
+          version: v0.16.0
+
+      - name: Install pinned wasm-pack
+        uses: taiki-e/install-action@13608cbb45b01feb47ef444ab1a42dc41ad56f1a # v2.79.11
+        with:
+          tool: wasm-pack@0.15.0
+          fallback: none
+
+      - name: Build browser package
+        env:
+          NOON_SKIP_PLAYGROUND_TEST: "1"
+          NOON_WASM_SKIP_OPT: "1"
+        run: bash scripts/build-web-demo.sh
+
+      - name: Upload browser package
+        uses: actions/upload-artifact@v4
+        with:
+          name: playground-cross-browser-web-pkg
+          path: web/pkg
+          if-no-files-found: error
+          retention-days: 1
+
+  browser:
+    name: ${{ matrix.browser }} / ${{ matrix.profile }}
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - browser: chromium
+            profile: desktop-dpr1
+          - browser: firefox
+            profile: desktop-dpr2
+          - browser: webkit
+            profile: mobile-dpr2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download browser package
+        uses: actions/download-artifact@v4
+        with:
+          name: playground-cross-browser-web-pkg
+          path: web/pkg
+
+      - name: Cache Playwright browser
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ matrix.browser }}-1.62.1
+
+      - name: Install browser E2E dependencies
+        run: |
+          npm install --no-save --ignore-scripts playwright@1.62.1
+          npx playwright install --with-deps ${{ matrix.browser }}
+
+      - name: Test public playground workflow
+        env:
+          NOON_PLAYGROUND_BROWSER: ${{ matrix.browser }}
+          NOON_PLAYGROUND_PROFILE: ${{ matrix.profile }}
+          NOON_PLAYGROUND_MATRIX_ARTIFACTS: browser-smoke-artifacts/playground-matrix/${{ matrix.browser }}-${{ matrix.profile }}
+        run: node scripts/playground-browser-matrix-smoke.mjs
+
+      - name: Upload playground diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playground-matrix-${{ matrix.browser }}-${{ matrix.profile }}
+          path: browser-smoke-artifacts/playground-matrix/${{ matrix.browser }}-${{ matrix.profile }}
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/playground-cross-browser.yml
+++ b/.github/workflows/playground-cross-browser.yml
@@ -4,8 +4,9 @@ on:
   pull_request:
     paths:
       - ".github/workflows/playground-cross-browser.yml"
-      - "crates/noon-render-wgpu/**"
-      - "crates/noon-web/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "crates/**"
       - "scripts/build-web-demo.sh"
       - "scripts/playground-browser-matrix-smoke.mjs"
       - "web/**"
@@ -14,8 +15,9 @@ on:
       - master
     paths:
       - ".github/workflows/playground-cross-browser.yml"
-      - "crates/noon-render-wgpu/**"
-      - "crates/noon-web/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "crates/**"
       - "scripts/build-web-demo.sh"
       - "scripts/playground-browser-matrix-smoke.mjs"
       - "web/**"

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -25,6 +25,24 @@ The main `CI` workflow runs:
 
 The separate Manim workflows pin ManimCE v0.21.0 for API-surface and semantic differential coverage.
 
+The separate `Playground cross-browser matrix` workflow is a required user-workflow gate for browser-facing changes. It covers Chromium, Firefox, and WebKit without adding those heavier browser installs to every main-CI run.
+
+## Browser UI matrix
+
+The playground E2E matrix deliberately uses three pairwise profiles instead of multiplying every browser, DPR, and viewport combination:
+
+| Browser | Required profile | Runtime expectation |
+| --- | --- | --- |
+| Chromium | desktop, DPR 1 | Exercise the public authoring workflow through the supported GPU fallback path. |
+| Firefox | desktop, DPR 2 | Exercise the full workflow when Worker + OffscreenCanvas + WebGL2 prerequisites are available; otherwise emit an explicit unsupported-capability record. |
+| WebKit | mobile-like, DPR 2 | Exercise the full workflow when Worker + OffscreenCanvas + WebGL2 prerequisites are available; otherwise emit an explicit unsupported-capability record. |
+
+`scripts/playground-browser-matrix-smoke.mjs` always validates that the public shell lays out without horizontal overflow. When the browser advertises the runtime prerequisites, the test must also load a real gallery example, select another example through the visible gallery, edit the source, rerun it through the public **Run** control, and survive rapid viewport resizing without page or console errors. A browser that advertises those prerequisites but cannot complete the workflow is a failure, not a skip.
+
+Unsupported combinations are never silently skipped. Their diagnostics artifact records the exact missing capabilities, browser version, viewport, DPR, runtime/status state, and browser errors. Supported runs retain the same metadata plus a screenshot; failures retain a failure screenshot and diagnostics JSON.
+
+This matrix is user-workflow coverage, not a replacement for the Chromium WebGPU/WebGL renderer matrix. Renderer pixel/backend qualification remains in the dedicated rendering jobs.
+
 ## Test inventory
 
 `scripts/test-inventory.py` scans production modules and test entry points across Rust, JavaScript, Python, browser smoke, and compatibility tooling. It emits JSON and Markdown reports and fails `--check` when a production module has no explicit layer/module test strategy.

--- a/scripts/playground-browser-matrix-smoke.mjs
+++ b/scripts/playground-browser-matrix-smoke.mjs
@@ -90,10 +90,12 @@ function launchOptions() {
 }
 
 async function capabilityProbe(page) {
-  return page.evaluate(() => {
+  return page.evaluate(async () => {
     const probeCanvas = document.createElement("canvas");
     let webgl2 = false;
     let offscreenWebgl2 = false;
+    let transferredWorkerWebgl2 = false;
+    let transferredWorkerWebgl2Error = "";
     try {
       webgl2 = probeCanvas.getContext("webgl2") !== null;
     } catch {
@@ -106,6 +108,54 @@ async function capabilityProbe(page) {
         offscreenWebgl2 = false;
       }
     }
+
+    const canTransferToWorker =
+      typeof Worker === "function" &&
+      typeof HTMLCanvasElement.prototype.transferControlToOffscreen === "function";
+    if (canTransferToWorker) {
+      const workerSource = `
+        self.onmessage = (event) => {
+          try {
+            const context = event.data.canvas.getContext("webgl2");
+            self.postMessage({ ok: context !== null, error: "" });
+          } catch (error) {
+            self.postMessage({ ok: false, error: String(error) });
+          }
+        };
+      `;
+      const workerUrl = URL.createObjectURL(new Blob([workerSource], { type: "text/javascript" }));
+      const worker = new Worker(workerUrl);
+      try {
+        const transferCanvas = document.createElement("canvas");
+        transferCanvas.width = 2;
+        transferCanvas.height = 2;
+        const offscreen = transferCanvas.transferControlToOffscreen();
+        const result = await new Promise((resolve) => {
+          const timeout = setTimeout(
+            () => resolve({ ok: false, error: "worker WebGL2 probe timed out" }),
+            5000,
+          );
+          worker.onmessage = (event) => {
+            clearTimeout(timeout);
+            resolve(event.data);
+          };
+          worker.onerror = (event) => {
+            clearTimeout(timeout);
+            resolve({ ok: false, error: event.message || "worker WebGL2 probe crashed" });
+          };
+          worker.postMessage({ canvas: offscreen }, [offscreen]);
+        });
+        transferredWorkerWebgl2 = result?.ok === true;
+        transferredWorkerWebgl2Error = typeof result?.error === "string" ? result.error : "";
+      } catch (error) {
+        transferredWorkerWebgl2 = false;
+        transferredWorkerWebgl2Error = String(error);
+      } finally {
+        worker.terminate();
+        URL.revokeObjectURL(workerUrl);
+      }
+    }
+
     return {
       webAssembly: typeof WebAssembly === "object",
       worker: typeof Worker === "function",
@@ -114,6 +164,8 @@ async function capabilityProbe(page) {
         typeof HTMLCanvasElement.prototype.transferControlToOffscreen === "function",
       webgl2,
       offscreenWebgl2,
+      transferredWorkerWebgl2,
+      transferredWorkerWebgl2Error,
       webgpu: typeof navigator.gpu !== "undefined",
       userAgent: navigator.userAgent,
       devicePixelRatio: window.devicePixelRatio,
@@ -130,6 +182,7 @@ function missingRuntimeCapabilities(capabilities) {
     ["transferControlToOffscreen", capabilities.transferControlToOffscreen],
     ["WebGL2", capabilities.webgl2],
     ["OffscreenCanvas WebGL2", capabilities.offscreenWebgl2],
+    ["transferred worker WebGL2", capabilities.transferredWorkerWebgl2],
   ]
     .filter(([, available]) => !available)
     .map(([name]) => name);
@@ -194,7 +247,10 @@ async function waitForAppliedScene(page, expectedExampleId, timeout = 60_000) {
     (id) => {
       const patch = document.querySelector("#patch-status");
       const selected = document.querySelector(".example-card[aria-selected='true']")?.dataset.exampleId;
-      return selected === id && (patch?.dataset.state === "applied" || patch?.dataset.state === "error");
+      if (patch?.dataset.state === "error") {
+        return true;
+      }
+      return selected === id && patch?.dataset.state === "applied";
     },
     expectedExampleId,
     { timeout },
@@ -203,7 +259,12 @@ async function waitForAppliedScene(page, expectedExampleId, timeout = 60_000) {
   assert.equal(
     runtime.patchState,
     "applied",
-    `${browserName}/${profileName}: ${expectedExampleId} failed: ${runtime.patchText}`,
+    `${browserName}/${profileName}: ${expectedExampleId} failed: ${runtime.patchText} ${runtime.statusText}`,
+  );
+  assert.equal(
+    runtime.selectedExampleId,
+    expectedExampleId,
+    `${browserName}/${profileName}: ${expectedExampleId} did not remain selected`,
   );
   return runtime;
 }
@@ -240,7 +301,10 @@ async function editAndRerun(page, expectedExampleId) {
   await runButton.click();
   await waitForAppliedScene(page, expectedExampleId);
 
-  const source = await page.locator("#python-scene-source").inputValue();
+  // CodeMirror installs a JS accessor on the hidden textarea. Playwright's
+  // inputValue() reads the native backing value and bypasses that accessor, so
+  // inspect the same stable integration surface that the playground itself uses.
+  const source = await page.evaluate(() => document.querySelector("#python-scene-source")?.value ?? "");
   assert.ok(source.includes(editMarker), `${browserName}/${profileName}: edited source was not retained`);
 }
 
@@ -290,10 +354,9 @@ try {
     if (message.type() === "error") consoleErrors.push(message.text());
   });
 
-  await page.goto(`${baseUrl}/web/index.html?example=parity-square-and-circle`, {
-    waitUntil: "load",
-  });
-
+  // Probe the exact transferred-canvas worker path before Noon starts. Main-thread
+  // OffscreenCanvas WebGL2 is not sufficient: WebKit can advertise it while
+  // returning null only after an HTML canvas is transferred into a worker.
   capabilities = await capabilityProbe(page);
   assert.equal(
     capabilities.devicePixelRatio,
@@ -302,6 +365,10 @@ try {
   );
   const missing = missingRuntimeCapabilities(capabilities);
   runtimeSupported = missing.length === 0;
+
+  await page.goto(`${baseUrl}/web/index.html?example=parity-square-and-circle`, {
+    waitUntil: "load",
+  });
 
   const initialShell = await shellSnapshot(page);
   assertShell(initialShell, `${browserName}/${profileName}`);
@@ -354,7 +421,7 @@ try {
       profile: profileName,
       runtimeSupported: true,
       missingCapabilities: [],
-      capabilities: await capabilityProbe(page),
+      capabilities,
       runtime: finalRuntime,
       pageErrors,
       consoleErrors,

--- a/scripts/playground-browser-matrix-smoke.mjs
+++ b/scripts/playground-browser-matrix-smoke.mjs
@@ -1,0 +1,391 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import playwright from "playwright";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const browserName = process.env.NOON_PLAYGROUND_BROWSER ?? "chromium";
+const profileName = process.env.NOON_PLAYGROUND_PROFILE ?? "desktop-dpr1";
+const port = Number(process.env.NOON_PLAYGROUND_MATRIX_PORT ?? "4175");
+const baseUrl = `http://127.0.0.1:${port}`;
+const artifactDir = path.resolve(
+  repoRoot,
+  process.env.NOON_PLAYGROUND_MATRIX_ARTIFACTS ??
+    `browser-smoke-artifacts/playground-matrix/${browserName}-${profileName}`,
+);
+
+const profiles = {
+  "desktop-dpr1": { viewport: { width: 1280, height: 800 }, deviceScaleFactor: 1 },
+  "desktop-dpr2": { viewport: { width: 1100, height: 760 }, deviceScaleFactor: 2 },
+  "mobile-dpr2": { viewport: { width: 390, height: 844 }, deviceScaleFactor: 2 },
+};
+
+assert.ok(
+  ["chromium", "firefox", "webkit"].includes(browserName),
+  `unknown playground browser: ${browserName}`,
+);
+assert.ok(profileName in profiles, `unknown playground profile: ${profileName}`);
+
+const browserType = playwright[browserName];
+const profile = profiles[profileName];
+await mkdir(artifactDir, { recursive: true });
+
+let serverOutput = "";
+const server = spawn(
+  "python3",
+  ["-m", "http.server", String(port), "--bind", "127.0.0.1", "--directory", repoRoot],
+  { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] },
+);
+server.stdout.on("data", (chunk) => {
+  serverOutput += chunk;
+});
+server.stderr.on("data", (chunk) => {
+  serverOutput += chunk;
+});
+
+async function waitForServer() {
+  let lastError = null;
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    try {
+      const response = await fetch(`${baseUrl}/web/index.html`);
+      if (response.ok) return;
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Playground matrix server did not start: ${lastError}\n${serverOutput}`);
+}
+
+function launchOptions() {
+  if (browserName === "chromium") {
+    return {
+      headless: true,
+      args: [
+        "--disable-features=WebGPU",
+        "--enable-unsafe-swiftshader",
+        "--ignore-gpu-blocklist",
+        "--use-gl=angle",
+        "--use-angle=swiftshader",
+        "--disable-gpu-sandbox",
+        "--disable-dev-shm-usage",
+      ],
+    };
+  }
+  if (browserName === "firefox") {
+    return {
+      headless: true,
+      firefoxUserPrefs: {
+        "webgl.disabled": false,
+        "webgl.force-enabled": true,
+      },
+    };
+  }
+  return { headless: true };
+}
+
+async function capabilityProbe(page) {
+  return page.evaluate(() => {
+    const probeCanvas = document.createElement("canvas");
+    let webgl2 = false;
+    let offscreenWebgl2 = false;
+    try {
+      webgl2 = probeCanvas.getContext("webgl2") !== null;
+    } catch {
+      webgl2 = false;
+    }
+    if (typeof OffscreenCanvas === "function") {
+      try {
+        offscreenWebgl2 = new OffscreenCanvas(2, 2).getContext("webgl2") !== null;
+      } catch {
+        offscreenWebgl2 = false;
+      }
+    }
+    return {
+      webAssembly: typeof WebAssembly === "object",
+      worker: typeof Worker === "function",
+      offscreenCanvas: typeof OffscreenCanvas === "function",
+      transferControlToOffscreen:
+        typeof HTMLCanvasElement.prototype.transferControlToOffscreen === "function",
+      webgl2,
+      offscreenWebgl2,
+      webgpu: typeof navigator.gpu !== "undefined",
+      userAgent: navigator.userAgent,
+      devicePixelRatio: window.devicePixelRatio,
+      viewport: { width: window.innerWidth, height: window.innerHeight },
+    };
+  });
+}
+
+function missingRuntimeCapabilities(capabilities) {
+  return [
+    ["WebAssembly", capabilities.webAssembly],
+    ["Worker", capabilities.worker],
+    ["OffscreenCanvas", capabilities.offscreenCanvas],
+    ["transferControlToOffscreen", capabilities.transferControlToOffscreen],
+    ["WebGL2", capabilities.webgl2],
+    ["OffscreenCanvas WebGL2", capabilities.offscreenWebgl2],
+  ]
+    .filter(([, available]) => !available)
+    .map(([name]) => name);
+}
+
+async function shellSnapshot(page) {
+  return page.evaluate(() => {
+    const canvas = document.querySelector("#scene");
+    const workspace = document.querySelector(".workspace");
+    const run = document.querySelector("#replace-scene");
+    const editor = document.querySelector("#python-scene-source");
+    const canvasRect = canvas?.getBoundingClientRect() ?? null;
+    const documentWidth = document.documentElement.scrollWidth;
+    return {
+      hasCanvas: canvas !== null,
+      hasWorkspace: workspace !== null,
+      hasRun: run !== null,
+      hasEditor: editor !== null,
+      canvasRect:
+        canvasRect === null
+          ? null
+          : { width: canvasRect.width, height: canvasRect.height, x: canvasRect.x, y: canvasRect.y },
+      documentWidth,
+      viewportWidth: window.innerWidth,
+    };
+  });
+}
+
+function assertShell(snapshot, label) {
+  assert.equal(snapshot.hasCanvas, true, `${label}: public canvas is missing`);
+  assert.equal(snapshot.hasWorkspace, true, `${label}: public workspace is missing`);
+  assert.equal(snapshot.hasRun, true, `${label}: Run control is missing`);
+  assert.equal(snapshot.hasEditor, true, `${label}: source editor is missing`);
+  assert.ok(snapshot.canvasRect?.width > 0, `${label}: canvas must have positive width`);
+  assert.ok(snapshot.canvasRect?.height > 0, `${label}: canvas must have positive height`);
+  assert.ok(
+    snapshot.documentWidth <= snapshot.viewportWidth + 1,
+    `${label}: page overflowed horizontally (${snapshot.documentWidth}px > ${snapshot.viewportWidth}px)`,
+  );
+}
+
+async function runtimeSnapshot(page) {
+  return page.evaluate(() => {
+    const patch = document.querySelector("#patch-status");
+    const status = document.querySelector("#status");
+    return {
+      rendererBackend: status?.dataset.rendererBackend ?? null,
+      executionMode: status?.dataset.executionMode ?? null,
+      statusState: status?.dataset.state ?? null,
+      statusText: document.querySelector("#status-text")?.textContent ?? "",
+      patchState: patch?.dataset.state ?? null,
+      patchText: patch?.value ?? patch?.textContent ?? "",
+      selectedExampleId:
+        document.querySelector(".example-card[aria-selected='true']")?.dataset.exampleId ?? null,
+      canvases: document.querySelectorAll("canvas").length,
+    };
+  });
+}
+
+async function waitForAppliedScene(page, expectedExampleId, timeout = 60_000) {
+  await page.waitForFunction(
+    (id) => {
+      const patch = document.querySelector("#patch-status");
+      const selected = document.querySelector(".example-card[aria-selected='true']")?.dataset.exampleId;
+      return selected === id && (patch?.dataset.state === "applied" || patch?.dataset.state === "error");
+    },
+    expectedExampleId,
+    { timeout },
+  );
+  const runtime = await runtimeSnapshot(page);
+  assert.equal(
+    runtime.patchState,
+    "applied",
+    `${browserName}/${profileName}: ${expectedExampleId} failed: ${runtime.patchText}`,
+  );
+  return runtime;
+}
+
+async function chooseDifferentExample(page) {
+  const targetId = await page.evaluate(() => {
+    const selected = document.querySelector(".example-card[aria-selected='true']")?.dataset.exampleId;
+    return [...document.querySelectorAll(".example-card")]
+      .map((card) => card.dataset.exampleId)
+      .find((id) => id && id !== selected);
+  });
+  assert.ok(targetId, `${browserName}/${profileName}: gallery must expose a second example`);
+  await page.locator(`.example-card[data-example-id="${targetId}"]`).click();
+  await waitForAppliedScene(page, targetId);
+  return targetId;
+}
+
+async function editAndRerun(page, expectedExampleId) {
+  const editMarker = `# cross-browser matrix ${browserName} ${profileName}`;
+  await page.evaluate((marker) => {
+    const editor = document.querySelector("#python-scene-source");
+    if (!(editor instanceof HTMLTextAreaElement)) {
+      throw new Error("Python scene textarea is unavailable");
+    }
+    if (!editor.value.includes(marker)) {
+      editor.value = `${editor.value.trimEnd()}\n\n${marker}\n`;
+      editor.dispatchEvent(new Event("input", { bubbles: true }));
+    }
+  }, editMarker);
+
+  const runButton = page.locator("#replace-scene");
+  await runButton.waitFor({ state: "attached" });
+  assert.equal(await runButton.isDisabled(), false, `${browserName}/${profileName}: Run stayed disabled`);
+  await runButton.click();
+  await waitForAppliedScene(page, expectedExampleId);
+
+  const source = await page.locator("#python-scene-source").inputValue();
+  assert.ok(source.includes(editMarker), `${browserName}/${profileName}: edited source was not retained`);
+}
+
+async function exerciseResize(page) {
+  const sequence =
+    profileName === "mobile-dpr2"
+      ? [
+          { width: 430, height: 760 },
+          { width: 360, height: 780 },
+          { width: 390, height: 844 },
+        ]
+      : [
+          { width: 980, height: 700 },
+          { width: 760, height: 720 },
+          profile.viewport,
+        ];
+  for (const viewport of sequence) {
+    await page.setViewportSize(viewport);
+  }
+  await page.evaluate(() => new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve))));
+  const shell = await shellSnapshot(page);
+  assertShell(shell, `${browserName}/${profileName} after resize`);
+}
+
+async function writeDiagnostics(fileName, diagnostics) {
+  await writeFile(path.join(artifactDir, fileName), `${JSON.stringify(diagnostics, null, 2)}\n`, "utf8");
+}
+
+let browser = null;
+let page = null;
+const pageErrors = [];
+const consoleErrors = [];
+let capabilities = null;
+let runtimeSupported = null;
+let finalRuntime = null;
+
+try {
+  await waitForServer();
+  browser = await browserType.launch(launchOptions());
+  const context = await browser.newContext({
+    viewport: profile.viewport,
+    deviceScaleFactor: profile.deviceScaleFactor,
+  });
+  page = await context.newPage();
+  page.on("pageerror", (error) => pageErrors.push(String(error)));
+  page.on("console", (message) => {
+    if (message.type() === "error") consoleErrors.push(message.text());
+  });
+
+  await page.goto(`${baseUrl}/web/index.html?example=parity-square-and-circle`, {
+    waitUntil: "load",
+  });
+
+  capabilities = await capabilityProbe(page);
+  assert.equal(
+    capabilities.devicePixelRatio,
+    profile.deviceScaleFactor,
+    `${browserName}/${profileName}: unexpected DPR`,
+  );
+  const missing = missingRuntimeCapabilities(capabilities);
+  runtimeSupported = missing.length === 0;
+
+  const initialShell = await shellSnapshot(page);
+  assertShell(initialShell, `${browserName}/${profileName}`);
+
+  if (!runtimeSupported) {
+    finalRuntime = await runtimeSnapshot(page);
+    await page.screenshot({ path: path.join(artifactDir, "unsupported.png"), fullPage: true });
+    await writeDiagnostics("diagnostics.json", {
+      browser: browserName,
+      browserVersion: browser.version(),
+      profile: profileName,
+      runtimeSupported: false,
+      missingCapabilities: missing,
+      capabilities,
+      runtime: finalRuntime,
+      pageErrors,
+      consoleErrors,
+    });
+    console.log(
+      `↷ ${browserName}/${profileName}: runtime unsupported by capability probe (${missing.join(", ")})`,
+    );
+  } else {
+    finalRuntime = await waitForAppliedScene(page, "parity-square-and-circle");
+    assert.ok(
+      finalRuntime.rendererBackend === "WebGL2" || finalRuntime.rendererBackend === "WebGPU",
+      `${browserName}/${profileName}: unexpected renderer backend ${finalRuntime.rendererBackend}`,
+    );
+    assert.equal(finalRuntime.canvases, 1, `${browserName}/${profileName}: expected one live canvas`);
+
+    const selectedExampleId = await chooseDifferentExample(page);
+    await editAndRerun(page, selectedExampleId);
+    await exerciseResize(page);
+    finalRuntime = await runtimeSnapshot(page);
+
+    assert.deepEqual(
+      pageErrors,
+      [],
+      `${browserName}/${profileName}: page errors:\n${pageErrors.join("\n")}`,
+    );
+    assert.deepEqual(
+      consoleErrors,
+      [],
+      `${browserName}/${profileName}: console errors:\n${consoleErrors.join("\n")}`,
+    );
+
+    await page.screenshot({ path: path.join(artifactDir, "success.png"), fullPage: true });
+    await writeDiagnostics("diagnostics.json", {
+      browser: browserName,
+      browserVersion: browser.version(),
+      profile: profileName,
+      runtimeSupported: true,
+      missingCapabilities: [],
+      capabilities: await capabilityProbe(page),
+      runtime: finalRuntime,
+      pageErrors,
+      consoleErrors,
+    });
+    console.log(
+      `✓ ${browserName}/${profileName}: ${finalRuntime.rendererBackend} public UI select/edit/rerun + resize`,
+    );
+  }
+} catch (error) {
+  if (page !== null) {
+    try {
+      finalRuntime = await runtimeSnapshot(page);
+      await page.screenshot({ path: path.join(artifactDir, "failure.png"), fullPage: true });
+    } catch {
+      // Keep the original failure if the page itself is no longer inspectable.
+    }
+  }
+  await writeDiagnostics("diagnostics.json", {
+    browser: browserName,
+    browserVersion: browser?.version() ?? null,
+    profile: profileName,
+    runtimeSupported,
+    capabilities,
+    runtime: finalRuntime,
+    pageErrors,
+    consoleErrors,
+    error: error instanceof Error ? { name: error.name, message: error.message, stack: error.stack } : String(error),
+    serverOutput,
+  });
+  throw error;
+} finally {
+  if (browser !== null) await browser.close();
+  server.kill("SIGTERM");
+}


### PR DESCRIPTION
## Summary
Add a required pairwise public-playground E2E matrix across Chromium, Firefox, and WebKit without bloating the central CI workflow.

- standalone path-filtered `Playground cross-browser matrix` workflow
- Chromium desktop / DPR 1, Firefox desktop / DPR 2, WebKit mobile-like / DPR 2
- probe the actual Worker + OffscreenCanvas + transfer-to-worker + WebGL2 prerequisites used by the runtime
- when supported, drive the real public UI: initial gallery scene, select another example, edit source through the stable editor integration surface, Run, then rapid viewport resizing
- when a browser lacks a required primitive, keep the leg visible as an explicit unsupported-capability result rather than silently skipping it
- retain browser/version, viewport, DPR, capability/runtime/backend state, page/console errors, and screenshots as per-leg artifacts
- document the matrix separately from the existing Chromium WebGPU/WebGL renderer qualification jobs

## Previous failure diagnosis
The old Chromium leg reached a healthy WebGL2 runtime, applied the selected scene, and had no page/console errors. It failed only because the test wrote to the hidden textarea behind CodeMirror and then asserted the edit was retained. The current editor adapter intentionally makes that textarea the stable integration surface and projects programmatic `.value` writes into CodeMirror, so the rebuilt matrix now tests against the current contract. Firefox had already passed the previous run; all three engines are being rerun on current master.

## Scope boundary
This is test/workflow-only. Production playground, worker/runtime, renderer, editor, layout, and text/font code are unchanged. Resize/zero-size and background/freeze lifecycle recovery are already covered by dedicated landed gates. Remaining #110 depth after this slice is broader user-control/error-recovery workflows such as syntax/runtime correction and play/pause/scrub/restart.

## Failure policy
A missing prerequisite is explicitly reported as unsupported. If a browser advertises the required Worker/OffscreenCanvas/WebGL2 stack but the public workflow fails, the matrix leg fails and uploads diagnostics rather than being converted into a skip.

Tracks #110.