### PR TITLE
Route Python Arc semantics through shared Rust

### DIFF
--- a/crates/noon-web/src/lib.rs
+++ b/crates/noon-web/src/lib.rs
@@ -11,6 +11,7 @@ mod host_player;
 #[path = "legacy.rs"]
 mod legacy;
 mod lifecycle;
+mod manim_arc_bridge;
 mod manim_geometry_bridge;
 mod reactive_authoring_facade;
 mod reactive_player;
@@ -35,6 +36,7 @@ pub use execution_transport::*;
 pub use host_player::*;
 pub use legacy::*;
 pub use lifecycle::*;
+pub use manim_arc_bridge::*;
 pub use manim_geometry_bridge::*;
 pub use reactive_authoring_facade::*;
 pub use reactive_player::*;

--- a/crates/noon-web/src/manim_arc_bridge.rs
+++ b/crates/noon-web/src/manim_arc_bridge.rs
@@ -1,0 +1,357 @@
+use noon::{
+    arc_center_from_snapshot, arc_end_from_snapshot, arc_start_from_snapshot,
+    arc_stop_angle_from_snapshot, Arc, ArcBetweenPoints, ArcMetadata, IntoSnapshot,
+};
+use noon_core::{ObjectSnapshot, Vec2};
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ManimArcBridgeSpec {
+    snapshot: ObjectSnapshot,
+    metadata: ArcMetadata,
+}
+
+impl ManimArcBridgeSpec {
+    fn new(snapshot: ObjectSnapshot, metadata: ArcMetadata) -> Self {
+        Self { snapshot, metadata }
+    }
+
+    pub fn snapshot(&self) -> &ObjectSnapshot {
+        &self.snapshot
+    }
+
+    pub fn metadata(&self) -> ArcMetadata {
+        self.metadata
+    }
+
+    pub fn snapshot_json(&self) -> Result<String, String> {
+        serde_json::to_string(&self.snapshot)
+            .map_err(|error| format!("unable to serialize Manim Arc snapshot: {error}"))
+    }
+}
+
+fn finite_f32(name: &str, value: f64) -> Result<f32, String> {
+    if !value.is_finite() || value.abs() > f64::from(f32::MAX) {
+        return Err(format!("{name} must be a finite f32-compatible number"));
+    }
+    Ok(value as f32)
+}
+
+fn point(name: &str, x: f64, y: f64) -> Result<Vec2, String> {
+    Ok(Vec2::new(
+        finite_f32(&format!("{name}.x"), x)?,
+        finite_f32(&format!("{name}.y"), y)?,
+    ))
+}
+
+pub fn manim_arc_bridge_spec(
+    radius: f64,
+    start_angle: f64,
+    angle: f64,
+    num_components: u32,
+    center_x: f64,
+    center_y: f64,
+) -> Result<ManimArcBridgeSpec, String> {
+    let arc = Arc::with_options(
+        finite_f32("radius", radius)?,
+        finite_f32("start_angle", start_angle)?,
+        finite_f32("angle", angle)?,
+        num_components as usize,
+        point("arc_center", center_x, center_y)?,
+    )
+    .map_err(|error| error.to_string())?;
+    let metadata = arc.metadata();
+    Ok(ManimArcBridgeSpec::new(arc.into_snapshot(), metadata))
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn manim_arc_between_points_bridge_spec(
+    start_x: f64,
+    start_y: f64,
+    end_x: f64,
+    end_y: f64,
+    angle: f64,
+    radius: Option<f64>,
+    num_components: u32,
+) -> Result<ManimArcBridgeSpec, String> {
+    let radius = radius
+        .map(|value| finite_f32("radius", value))
+        .transpose()?;
+    let arc = ArcBetweenPoints::with_options(
+        point("start", start_x, start_y)?,
+        point("end", end_x, end_y)?,
+        finite_f32("angle", angle)?,
+        radius,
+        num_components as usize,
+    )
+    .map_err(|error| error.to_string())?;
+    let metadata = arc.metadata();
+    Ok(ManimArcBridgeSpec::new(arc.into_snapshot(), metadata))
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ManimArcSnapshotQuery {
+    snapshot: ObjectSnapshot,
+}
+
+impl ManimArcSnapshotQuery {
+    pub fn from_json(snapshot_json: &str) -> Result<Self, String> {
+        serde_json::from_str(snapshot_json)
+            .map(|snapshot| Self { snapshot })
+            .map_err(|error| format!("invalid Manim Arc snapshot: {error}"))
+    }
+
+    pub fn start(&self) -> Result<Vec2, String> {
+        arc_start_from_snapshot(&self.snapshot)
+            .ok_or_else(|| "Manim Arc snapshot has no path start".to_owned())
+    }
+
+    pub fn end(&self) -> Result<Vec2, String> {
+        arc_end_from_snapshot(&self.snapshot)
+            .ok_or_else(|| "Manim Arc snapshot has no path end".to_owned())
+    }
+
+    pub fn center(&self) -> Vec2 {
+        arc_center_from_snapshot(&self.snapshot)
+    }
+
+    pub fn stop_angle(&self) -> Result<f32, String> {
+        arc_stop_angle_from_snapshot(&self.snapshot)
+            .ok_or_else(|| "Manim Arc snapshot has no stop angle".to_owned())
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+mod wasm {
+    use wasm_bindgen::prelude::*;
+
+    use super::{
+        manim_arc_between_points_bridge_spec, manim_arc_bridge_spec, ManimArcBridgeSpec,
+        ManimArcSnapshotQuery,
+    };
+
+    fn js_error(error: String) -> JsValue {
+        JsValue::from_str(&error)
+    }
+
+    #[wasm_bindgen]
+    pub struct WasmManimArcSpec(ManimArcBridgeSpec);
+
+    #[wasm_bindgen]
+    impl WasmManimArcSpec {
+        #[wasm_bindgen(js_name = snapshotJson)]
+        pub fn snapshot_json(&self) -> Result<String, JsValue> {
+            self.0.snapshot_json().map_err(js_error)
+        }
+
+        #[wasm_bindgen(getter)]
+        pub fn radius(&self) -> f64 {
+            f64::from(self.0.metadata().radius())
+        }
+
+        #[wasm_bindgen(getter, js_name = startAngle)]
+        pub fn start_angle(&self) -> f64 {
+            f64::from(self.0.metadata().start_angle())
+        }
+
+        #[wasm_bindgen(getter)]
+        pub fn angle(&self) -> f64 {
+            f64::from(self.0.metadata().angle())
+        }
+
+        #[wasm_bindgen(getter, js_name = numComponents)]
+        pub fn num_components(&self) -> usize {
+            self.0.metadata().num_components()
+        }
+    }
+
+    #[wasm_bindgen(js_name = createManimArcSpec)]
+    pub fn create_manim_arc_spec(
+        radius: f64,
+        start_angle: f64,
+        angle: f64,
+        num_components: u32,
+        center_x: f64,
+        center_y: f64,
+    ) -> Result<WasmManimArcSpec, JsValue> {
+        manim_arc_bridge_spec(
+            radius,
+            start_angle,
+            angle,
+            num_components,
+            center_x,
+            center_y,
+        )
+        .map(WasmManimArcSpec)
+        .map_err(js_error)
+    }
+
+    #[wasm_bindgen(js_name = createManimArcBetweenPointsSpec)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn create_manim_arc_between_points_spec(
+        start_x: f64,
+        start_y: f64,
+        end_x: f64,
+        end_y: f64,
+        angle: f64,
+        radius: Option<f64>,
+        num_components: u32,
+    ) -> Result<WasmManimArcSpec, JsValue> {
+        manim_arc_between_points_bridge_spec(
+            start_x,
+            start_y,
+            end_x,
+            end_y,
+            angle,
+            radius,
+            num_components,
+        )
+        .map(WasmManimArcSpec)
+        .map_err(js_error)
+    }
+
+    #[wasm_bindgen]
+    pub struct WasmManimArcSnapshotQuery(ManimArcSnapshotQuery);
+
+    #[wasm_bindgen]
+    impl WasmManimArcSnapshotQuery {
+        #[wasm_bindgen(constructor)]
+        pub fn new(snapshot_json: &str) -> Result<WasmManimArcSnapshotQuery, JsValue> {
+            ManimArcSnapshotQuery::from_json(snapshot_json)
+                .map(WasmManimArcSnapshotQuery)
+                .map_err(js_error)
+        }
+
+        #[wasm_bindgen(getter, js_name = startX)]
+        pub fn start_x(&self) -> Result<f64, JsValue> {
+            self.0
+                .start()
+                .map(|point| f64::from(point.x))
+                .map_err(js_error)
+        }
+
+        #[wasm_bindgen(getter, js_name = startY)]
+        pub fn start_y(&self) -> Result<f64, JsValue> {
+            self.0
+                .start()
+                .map(|point| f64::from(point.y))
+                .map_err(js_error)
+        }
+
+        #[wasm_bindgen(getter, js_name = endX)]
+        pub fn end_x(&self) -> Result<f64, JsValue> {
+            self.0
+                .end()
+                .map(|point| f64::from(point.x))
+                .map_err(js_error)
+        }
+
+        #[wasm_bindgen(getter, js_name = endY)]
+        pub fn end_y(&self) -> Result<f64, JsValue> {
+            self.0
+                .end()
+                .map(|point| f64::from(point.y))
+                .map_err(js_error)
+        }
+
+        #[wasm_bindgen(getter, js_name = centerX)]
+        pub fn center_x(&self) -> f64 {
+            f64::from(self.0.center().x)
+        }
+
+        #[wasm_bindgen(getter, js_name = centerY)]
+        pub fn center_y(&self) -> f64 {
+            f64::from(self.0.center().y)
+        }
+
+        #[wasm_bindgen(getter, js_name = stopAngle)]
+        pub fn stop_angle(&self) -> Result<f64, JsValue> {
+            self.0.stop_angle().map(f64::from).map_err(js_error)
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub use wasm::*;
+
+#[cfg(test)]
+mod tests {
+    use noon::{arc_center_from_snapshot, arc_end_from_snapshot, arc_start_from_snapshot};
+    use noon_core::{GeometryRef, TAU};
+
+    use super::*;
+
+    fn assert_close(left: f32, right: f32) {
+        assert!((left - right).abs() <= 1e-5, "{left} != {right}");
+    }
+
+    fn assert_vec_close(left: Vec2, right: Vec2) {
+        assert_close(left.x, right.x);
+        assert_close(left.y, right.y);
+    }
+
+    #[test]
+    fn arc_bridge_keeps_constructor_metadata_with_rust_snapshot() {
+        let spec = manim_arc_bridge_spec(2.0, 0.25, 1.5, 7, 3.0, -4.0).unwrap();
+        assert_close(spec.metadata().radius(), 2.0);
+        assert_close(spec.metadata().start_angle(), 0.25);
+        assert_close(spec.metadata().angle(), 1.5);
+        assert_eq!(spec.metadata().num_components(), 7);
+        assert!(matches!(
+            spec.snapshot().geometry,
+            GeometryRef::VectorPath(_)
+        ));
+    }
+
+    #[test]
+    fn bridge_queries_current_serialized_snapshot_through_shared_arc_math() {
+        let spec = manim_arc_bridge_spec(1.25, 0.1, f64::from(TAU) / 3.0, 9, 0.5, -0.25).unwrap();
+        let current = spec
+            .snapshot()
+            .clone()
+            .scale_xy(Vec2::new(1.5, 0.75))
+            .rotate_by(0.4)
+            .shift(Vec2::new(-2.0, 3.0));
+        let json = serde_json::to_string(&current).unwrap();
+        let query = ManimArcSnapshotQuery::from_json(&json).unwrap();
+
+        assert_vec_close(
+            query.start().unwrap(),
+            arc_start_from_snapshot(&current).unwrap(),
+        );
+        assert_vec_close(
+            query.end().unwrap(),
+            arc_end_from_snapshot(&current).unwrap(),
+        );
+        assert_vec_close(query.center(), arc_center_from_snapshot(&current));
+        assert_close(
+            query.stop_angle().unwrap(),
+            arc_stop_angle_from_snapshot(&current).unwrap(),
+        );
+    }
+
+    #[test]
+    fn between_points_bridge_preserves_resolved_negative_radius_metadata() {
+        let spec = manim_arc_between_points_bridge_spec(
+            -2.0,
+            0.0,
+            2.0,
+            0.0,
+            TAU as f64 / 4.0,
+            Some(-3.0),
+            9,
+        )
+        .unwrap();
+        assert_close(spec.metadata().radius(), 3.0);
+        assert!(spec.metadata().angle() < 0.0);
+    }
+
+    #[test]
+    fn query_rejects_non_arc_snapshot_shape_for_endpoint_queries() {
+        let snapshot = ObjectSnapshot::new(GeometryRef::circle(1.0));
+        let json = serde_json::to_string(&snapshot).unwrap();
+        let query = ManimArcSnapshotQuery::from_json(&json).unwrap();
+        assert!(query.start().is_err());
+        assert!(query.end().is_err());
+        assert!(query.stop_angle().is_err());
+    }
+}

--- a/web/python-worker-source.test.mjs
+++ b/web/python-worker-source.test.mjs
@@ -10,3 +10,16 @@ test("Python authoring worker keeps request validation helper", () => {
   assert.match(source, /function\s+isRecord\s*\(value\)\s*\{/);
   assert.match(source, /if\s*\(!isRecord\(request\)\s*\|\|\s*request\.channel\s*!==\s*AUTHORING_CHANNEL\)/);
 });
+
+test("Python authoring worker keeps shared Arc bridge wiring", () => {
+  assert.match(source, /createManimArcSpec/);
+  assert.match(source, /createManimArcBetweenPointsSpec/);
+  assert.match(source, /WasmManimArcSnapshotQuery/);
+  assert.match(source, /noonCreateAuthoringArcSpec/);
+  assert.match(source, /noonCreateAuthoringArcBetweenPointsSpec/);
+  assert.match(source, /noonQueryAuthoringArc/);
+  assert.match(source, /function\s+arcSpecPlain\s*\(/);
+  assert.match(source, /function\s+arcSnapshotQueryPlain\s*\(/);
+  assert.match(source, /spec\.free\(\)/);
+  assert.match(source, /query\.free\(\)/);
+});

--- a/web/python-worker.js
+++ b/web/python-worker.js
@@ -1,6 +1,9 @@
 import initNoonWeb, {
   RetainedTypstAuthoringHandle,
   WasmAuthoringStore,
+  WasmManimArcSnapshotQuery,
+  createManimArcBetweenPointsSpec,
+  createManimArcSpec,
   manimDotSnapshotJson,
   manimTriangleSnapshotJson,
   resolveAnimationOptions,
@@ -58,6 +61,11 @@ async function initializePyodide() {
     authoringStore.createMobject(manimDotSnapshotJson(pointX, pointY, radius));
   self.noonCreateAuthoringTriangleHandle = () =>
     authoringStore.createMobject(manimTriangleSnapshotJson());
+  self.noonCreateAuthoringArcSpec = (...args) =>
+    arcSpecPlain(createManimArcSpec(...args));
+  self.noonCreateAuthoringArcBetweenPointsSpec = (...args) =>
+    arcSpecPlain(createManimArcBetweenPointsSpec(...args));
+  self.noonQueryAuthoringArc = arcSnapshotQueryPlain;
   self.noonCreateAuthoringCircleHandle = (radius) => authoringStore.createManimCircle(radius);
   self.noonCreateAuthoringSquareHandle = (sideLength) => authoringStore.createManimSquare(sideLength);
   self.noonCreateAuthoringRectangleHandle = (width, height) =>
@@ -207,6 +215,37 @@ import _manim_camera
 _manim_camera.install()
 `);
   return pyodide;
+}
+
+function arcSpecPlain(spec) {
+  try {
+    return {
+      snapshotJson: spec.snapshotJson(),
+      radius: spec.radius,
+      startAngle: spec.startAngle,
+      angle: spec.angle,
+      numComponents: spec.numComponents,
+    };
+  } finally {
+    spec.free();
+  }
+}
+
+function arcSnapshotQueryPlain(snapshotJson) {
+  const query = new WasmManimArcSnapshotQuery(snapshotJson);
+  try {
+    return {
+      startX: query.startX,
+      startY: query.startY,
+      endX: query.endX,
+      endY: query.endY,
+      centerX: query.centerX,
+      centerY: query.centerY,
+      stopAngle: query.stopAngle,
+    };
+  } finally {
+    query.free();
+  }
 }
 
 function resolveAnimationOptionsPlain(...args) {

--- a/web/python/_manim_shared_geometry.py
+++ b/web/python/_manim_shared_geometry.py
@@ -1,11 +1,16 @@
 """Thin Manim geometry constructor adapters backed by shared Rust semantics.
 
 This module intentionally patches only constructors whose full observable geometry/layout
-contract is already owned by Rust.  Class identity and inheritance remain unchanged.
+contract is already owned by Rust. Class identity and inheritance remain unchanged where
+an established compatibility class already exists; Arc is defined here because no legacy
+Python Arc class predates the shared Rust implementation.
 """
 
 from __future__ import annotations
 
+import math
+import operator
+import warnings
 from typing import Any
 
 import noon as _base
@@ -23,6 +28,21 @@ try:
 except ImportError:  # Native CPython tests keep the existing Python constructor.
     _create_triangle_handle = None
 
+try:
+    from js import noonCreateAuthoringArcSpec as _create_arc_spec
+except ImportError:  # Native CPython keeps a non-authoritative compatibility fallback.
+    _create_arc_spec = None
+
+try:
+    from js import noonCreateAuthoringArcBetweenPointsSpec as _create_arc_between_points_spec
+except ImportError:
+    _create_arc_between_points_spec = None
+
+try:
+    from js import noonQueryAuthoringArc as _query_arc
+except ImportError:
+    _query_arc = None
+
 _ORIGINAL_DOT_INIT = _geometry.Dot.__init__
 _ORIGINAL_TRIANGLE_INIT = _geometry.Triangle.__init__
 _INSTALLED = False
@@ -32,7 +52,7 @@ def _set_shared_color(self: _base.Mobject, color: object) -> None:
     """Apply Manim ``color`` through the shared semantic handle.
 
     The generic Phase-B setter rebuilds a Python snapshot before handing it back to
-    Rust.  Shared constructors must not re-enter that compatibility path: parse the
+    Rust. Shared constructors must not re-enter that compatibility path: parse the
     host color once, then use the semantic-handle mutation that preserves each
     channel's existing opacity.
     """
@@ -91,6 +111,386 @@ def _triangle_init(self: _geometry.Triangle, **kwargs: Any) -> None:
         _set_shared_color(self, color)
 
 
+def _arc_num_components(value: object) -> int:
+    if isinstance(value, bool):
+        raise TypeError("num_components must be an integer")
+    try:
+        result = operator.index(value)
+    except TypeError as error:
+        raise TypeError("num_components must be an integer") from error
+    if result < 2:
+        raise ValueError("num_components must be at least 2")
+    if result > 0xFFFFFFFF:
+        raise ValueError("num_components is too large")
+    return int(result)
+
+
+def _arc_number(name: str, value: object) -> float:
+    return _shared._ir._finite_number(name, value)
+
+
+def _fallback_arc_path(
+    radius: float,
+    start_angle: float,
+    angle: float,
+    num_components: int,
+    center: _base.Vec2,
+) -> _base.VectorPath:
+    """Native-CPython-only mirror of the shared cubic Arc constructor."""
+
+    segment_count = num_components - 1
+    delta = angle / segment_count
+    handle_factor = (4.0 / 3.0) * math.tan(delta / 4.0)
+
+    def point_at(theta: float) -> _base.Vec2:
+        return center + radius * _base.Vec2(math.cos(theta), math.sin(theta))
+
+    def tangent_at(theta: float) -> _base.Vec2:
+        return radius * _base.Vec2(-math.sin(theta), math.cos(theta))
+
+    path = _base.VectorPath().move_to(point_at(start_angle))
+    for index in range(segment_count):
+        theta0 = start_angle + index * delta
+        theta1 = theta0 + delta
+        anchor0 = point_at(theta0)
+        anchor1 = point_at(theta1)
+        path = path.cubic_to(
+            anchor0 + handle_factor * tangent_at(theta0),
+            anchor1 - handle_factor * tangent_at(theta1),
+            anchor1,
+        )
+    return path
+
+
+def _fallback_arc_between_points(
+    start: _base.Vec2,
+    end: _base.Vec2,
+    angle: float,
+    radius: float | None,
+    num_components: int,
+) -> tuple[_base.VectorPath, float, float]:
+    """Native-only ArcBetweenPoints construction matching the shared Rust algorithm."""
+
+    chord = end - start
+    chord_length = chord.length()
+    radius_was_explicit = radius is not None
+    if radius is None:
+        base_radius = 1.0
+        resolved_angle = angle
+    else:
+        sign = -2.0 if radius < 0.0 else 2.0
+        base_radius = abs(radius)
+        half_distance = chord_length * 0.5
+        if base_radius < half_distance:
+            raise ValueError(
+                f"ArcBetweenPoints radius {base_radius} is smaller than half the endpoint distance {half_distance}"
+            )
+        if base_radius == 0.0:
+            raise ValueError("ArcBetweenPoints radius cannot resolve a degenerate chord")
+        adjacent = math.sqrt(max(base_radius * base_radius - half_distance * half_distance, 0.0))
+        resolved_angle = math.acos(adjacent / base_radius) * sign
+
+    if resolved_angle == 0.0:
+        path = _base.VectorPath().move_to(start).line_to(end)
+        resolved_radius = base_radius if radius_was_explicit else math.inf
+        return path, resolved_radius, resolved_angle
+
+    base_start = _base.Vec2(base_radius, 0.0)
+    base_end = base_radius * _base.Vec2(math.cos(resolved_angle), math.sin(resolved_angle))
+    base_chord = base_end - base_start
+    base_chord_length = base_chord.length()
+    if base_chord_length <= 1e-12:
+        raise ValueError("ArcBetweenPoints angle has a zero-length source chord")
+
+    scale = chord_length / base_chord_length
+    rotation = math.atan2(chord.y, chord.x) - math.atan2(base_chord.y, base_chord.x)
+    cosine = math.cos(rotation)
+    sine = math.sin(rotation)
+
+    def transform(point: _base.Vec2) -> _base.Vec2:
+        local = (point - base_start) * scale
+        return start + _base.Vec2(
+            local.x * cosine - local.y * sine,
+            local.x * sine + local.y * cosine,
+        )
+
+    segment_count = num_components - 1
+    delta = resolved_angle / segment_count
+    handle_factor = (4.0 / 3.0) * math.tan(delta / 4.0)
+
+    def point_at(theta: float) -> _base.Vec2:
+        return base_radius * _base.Vec2(math.cos(theta), math.sin(theta))
+
+    def tangent_at(theta: float) -> _base.Vec2:
+        return base_radius * _base.Vec2(-math.sin(theta), math.cos(theta))
+
+    path = _base.VectorPath().move_to(start)
+    for index in range(segment_count):
+        theta0 = index * delta
+        theta1 = theta0 + delta
+        anchor0 = point_at(theta0)
+        anchor1 = point_at(theta1)
+        path = path.cubic_to(
+            transform(anchor0 + handle_factor * tangent_at(theta0)),
+            transform(anchor1 - handle_factor * tangent_at(theta1)),
+            transform(anchor1),
+        )
+    resolved_radius = base_radius if radius_was_explicit else base_radius * scale
+    return path, resolved_radius, resolved_angle
+
+
+def _fallback_arc_vmobject_init(
+    self: _compat.VMobject,
+    path: _base.VectorPath,
+    kwargs: dict[str, Any],
+) -> None:
+    """Initialize the native fallback without making Arc a public Path subtype."""
+
+    options = dict(kwargs)
+    color = options.pop("color", None)
+    raw = _shared._ir.Path(path, **_compat._manim_vmobject_kwargs(options))
+    _compat.VMobject.__init__(self, raw)
+    if color is not None:
+        self.set_color(color)
+
+
+def _arc_snapshot_json(self: _base.Mobject) -> str:
+    handle = _shared._handle_for(self)
+    if handle is not None:
+        return str(handle.snapshotJson())
+    return _shared._snapshot_json(self._current_raw())
+
+
+def _fallback_arc_query(self: _base.Mobject) -> dict[str, float]:
+    raw = self._current_raw()
+    commands = raw.geometry.get("vector_path", {}).get("commands", [])
+    if not commands or not isinstance(commands[0], dict) or "move_to" not in commands[0]:
+        raise ValueError("Arc snapshot has no path start")
+
+    def endpoint(command: object) -> _base.Vec2 | None:
+        if not isinstance(command, dict):
+            return None
+        payload = next(iter(command.values()), None)
+        if not isinstance(payload, dict) or "to" not in payload:
+            return None
+        point = payload["to"]
+        return _geometry._world_point(
+            self,
+            _base.Vec2(float(point["x"]), float(point["y"])),
+        )
+
+    start = endpoint(commands[0])
+    end = next((point for command in reversed(commands) if (point := endpoint(command)) is not None), None)
+    if start is None or end is None:
+        raise ValueError("Arc snapshot has incomplete path endpoints")
+
+    center = _base.ORIGIN
+    if len(commands) > 1 and isinstance(commands[1], dict) and "cubic_to" in commands[1]:
+        payload = commands[1]["cubic_to"]
+        control1 = payload["control1"]
+        control2 = payload["control2"]
+        anchor = payload["to"]
+        first_handle = _geometry._world_point(
+            self, _base.Vec2(float(control1["x"]), float(control1["y"]))
+        )
+        second_handle = _geometry._world_point(
+            self, _base.Vec2(float(control2["x"]), float(control2["y"]))
+        )
+        second_anchor = _geometry._world_point(
+            self, _base.Vec2(float(anchor["x"]), float(anchor["y"]))
+        )
+        if start == second_anchor:
+            center = start
+        else:
+            first_tangent = first_handle - start
+            second_tangent = second_handle - second_anchor
+            first_normal = _base.Vec2(-first_tangent.y, first_tangent.x)
+            second_normal = _base.Vec2(-second_tangent.y, second_tangent.x)
+            denominator = first_normal.x * second_normal.y - first_normal.y * second_normal.x
+            if abs(denominator) > 1e-12:
+                delta = second_anchor - start
+                parameter = (
+                    delta.x * second_normal.y - delta.y * second_normal.x
+                ) / denominator
+                center = start + parameter * first_normal
+
+    stop = math.atan2(end.y - center.y, end.x - center.x) % _base.TAU
+    return {
+        "startX": start.x,
+        "startY": start.y,
+        "endX": end.x,
+        "endY": end.y,
+        "centerX": center.x,
+        "centerY": center.y,
+        "stopAngle": stop,
+    }
+
+
+def _arc_query(self: _base.Mobject) -> object:
+    if _query_arc is not None:
+        return _query_arc(_arc_snapshot_json(self))
+    return _fallback_arc_query(self)
+
+
+def _query_value(record: object, name: str) -> float:
+    if isinstance(record, dict):
+        return float(record[name])
+    return float(getattr(record, name))
+
+
+def _arc_center_failed(self: _base.Mobject) -> bool:
+    raw = self._current_raw()
+    commands = raw.geometry.get("vector_path", {}).get("commands", [])
+    return not (
+        len(commands) > 1
+        and isinstance(commands[0], dict)
+        and "move_to" in commands[0]
+        and isinstance(commands[1], dict)
+        and "cubic_to" in commands[1]
+    )
+
+
+def _attach_arc_spec(
+    self: _base.Mobject,
+    spec: object,
+    kwargs: dict[str, Any],
+    arc_center: _base.Vec2,
+) -> None:
+    snapshot_json = str(getattr(spec, "snapshotJson"))
+    if _shared._create_handle is None:
+        raise RuntimeError("shared Arc construction requires the semantic mobject handle bridge")
+    _shared._attach_shared_handle(self, _shared._create_handle(snapshot_json))
+    self.radius = float(getattr(spec, "radius"))
+    self.start_angle = float(getattr(spec, "startAngle"))
+    self.angle = float(getattr(spec, "angle"))
+    self.num_components = int(getattr(spec, "numComponents"))
+    self.arc_center = arc_center
+    self._failed_to_get_center = False
+
+    options = dict(kwargs)
+    color = options.pop("color", None)
+    _shared._apply_shared_constructor_kwargs(self, options)
+    if color is not None:
+        _set_shared_color(self, color)
+
+
+class Arc(_compat.VMobject):
+    """ManimCE-compatible Arc whose browser geometry and queries are Rust-owned."""
+
+    def __init__(
+        self,
+        radius: float | None = 1.0,
+        start_angle: float = 0.0,
+        angle: float = _base.TAU / 4.0,
+        num_components: int = 9,
+        arc_center: object = _base.ORIGIN,
+        **kwargs: Any,
+    ) -> None:
+        radius_value = 1.0 if radius is None else _arc_number("radius", radius)
+        start_angle_value = _arc_number("start_angle", start_angle)
+        angle_value = _arc_number("angle", angle)
+        component_count = _arc_num_components(num_components)
+        center = _compat._as_vec2(arc_center)
+
+        if _create_arc_spec is not None:
+            spec = _create_arc_spec(
+                radius_value,
+                start_angle_value,
+                angle_value,
+                component_count,
+                center.x,
+                center.y,
+            )
+            _attach_arc_spec(self, spec, kwargs, center)
+            return
+
+        path = _fallback_arc_path(
+            radius_value,
+            start_angle_value,
+            angle_value,
+            component_count,
+            center,
+        )
+        _fallback_arc_vmobject_init(self, path, kwargs)
+        self.radius = radius_value
+        self.start_angle = start_angle_value
+        self.angle = angle_value
+        self.num_components = component_count
+        self.arc_center = center
+        self._failed_to_get_center = False
+
+    def get_start(self) -> _base.Vec2:
+        record = _arc_query(self)
+        return _base.Vec2(_query_value(record, "startX"), _query_value(record, "startY"))
+
+    def get_end(self) -> _base.Vec2:
+        record = _arc_query(self)
+        return _base.Vec2(_query_value(record, "endX"), _query_value(record, "endY"))
+
+    def get_arc_center(self, warning: bool = True) -> _base.Vec2:
+        record = _arc_query(self)
+        failed = _arc_center_failed(self)
+        self._failed_to_get_center = failed
+        if failed and warning:
+            warnings.warn("Can't find Arc center, using ORIGIN instead", stacklevel=1)
+        return _base.Vec2(_query_value(record, "centerX"), _query_value(record, "centerY"))
+
+    def move_arc_center_to(self, point: object) -> Arc:
+        target = _compat._as_vec2(point)
+        return self.shift(target - self.get_arc_center(warning=False))
+
+    def stop_angle(self) -> float:
+        return _query_value(_arc_query(self), "stopAngle")
+
+
+class ArcBetweenPoints(Arc):
+    """ManimCE-compatible endpoint Arc using the shared Rust constructor."""
+
+    def __init__(
+        self,
+        start: object,
+        end: object,
+        angle: float = _base.TAU / 4.0,
+        radius: float | None = None,
+        **kwargs: Any,
+    ) -> None:
+        options = dict(kwargs)
+        component_count = _arc_num_components(options.pop("num_components", 9))
+        start_point = _compat._as_vec2(start)
+        end_point = _compat._as_vec2(end)
+        angle_value = _arc_number("angle", angle)
+        radius_value = None if radius is None else _arc_number("radius", radius)
+
+        if _create_arc_between_points_spec is not None:
+            spec = _create_arc_between_points_spec(
+                start_point.x,
+                start_point.y,
+                end_point.x,
+                end_point.y,
+                angle_value,
+                radius_value,
+                component_count,
+            )
+            _attach_arc_spec(self, spec, options, _base.ORIGIN)
+            self._failed_to_get_center = self.angle == 0.0
+            return
+
+        path, resolved_radius, resolved_angle = _fallback_arc_between_points(
+            start_point,
+            end_point,
+            angle_value,
+            radius_value,
+            component_count,
+        )
+        _fallback_arc_vmobject_init(self, path, options)
+        self.radius = resolved_radius
+        self.start_angle = 0.0
+        self.angle = resolved_angle
+        self.num_components = component_count
+        self.arc_center = _base.ORIGIN
+        self._failed_to_get_center = resolved_angle == 0.0
+
+
 def install() -> None:
     global _INSTALLED
     if _INSTALLED:
@@ -100,6 +500,16 @@ def install() -> None:
         _geometry.Dot.__init__ = _dot_init
     if _create_triangle_handle is not None:
         _geometry.Triangle.__init__ = _triangle_init
+
+    public = {
+        "Arc": Arc,
+        "ArcBetweenPoints": ArcBetweenPoints,
+    }
+    for name, value in public.items():
+        setattr(_base, name, value)
+        setattr(_compat, name, value)
+        if name not in _base.__all__:
+            _base.__all__.append(name)
 
 
 install()

--- a/web/python/test_manim_shared_geometry.py
+++ b/web/python/test_manim_shared_geometry.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 
 class ManimSharedGeometryTests(unittest.TestCase):
-    def test_dot_and_triangle_bypass_python_geometry_construction(self) -> None:
+    def _run_source(self, source: str) -> None:
         python_dir = Path(__file__).resolve().parent
         env = os.environ.copy()
         existing = env.get("PYTHONPATH")
@@ -16,7 +16,22 @@ class ManimSharedGeometryTests(unittest.TestCase):
             if not existing
             else os.pathsep.join((str(python_dir), existing))
         )
-        source = textwrap.dedent(
+        completed = subprocess.run(
+            [sys.executable, "-c", textwrap.dedent(source)],
+            cwd=python_dir,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(
+            completed.returncode,
+            0,
+            f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
+        )
+
+    def test_dot_and_triangle_bypass_python_geometry_construction(self) -> None:
+        self._run_source(
             r"""
             import json
             import sys
@@ -123,18 +138,174 @@ class ManimSharedGeometryTests(unittest.TestCase):
             assert "vector_path" in triangle_obj.geometry
             """
         )
-        completed = subprocess.run(
-            [sys.executable, "-c", source],
-            cwd=python_dir,
-            env=env,
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        self.assertEqual(
-            completed.returncode,
-            0,
-            f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
+
+    def test_arc_uses_shared_constructor_metadata_and_current_snapshot_queries(self) -> None:
+        self._run_source(
+            r"""
+            import json
+            import math
+            import sys
+            import types
+            from types import SimpleNamespace
+
+            fake_js = types.ModuleType("js")
+            calls = []
+            queries = []
+
+            WHITE = (1.0, 1.0, 1.0)
+
+            def base_style():
+                return {
+                    "fill": {"red": 1.0, "green": 1.0, "blue": 1.0, "alpha": 0.0},
+                    "stroke": {"red": 1.0, "green": 1.0, "blue": 1.0, "alpha": 1.0},
+                    "stroke_width": 0.04,
+                    "stroke_width_mode": "screen_space",
+                    "stroke_join": "miter",
+                    "stroke_cap": "butt",
+                    "opacity": 1.0,
+                }
+
+            def arc_snapshot():
+                return {
+                    "geometry": {"vector_path": {"commands": [
+                        {"move_to": {"to": {"x": 1.0, "y": 0.0}}},
+                        {"cubic_to": {
+                            "control1": {"x": 1.0, "y": 0.5},
+                            "control2": {"x": 0.5, "y": 1.0},
+                            "to": {"x": 0.0, "y": 1.0},
+                        }},
+                    ]}},
+                    "transform": {
+                        "translation": {"x": 0.0, "y": 0.0},
+                        "rotation": 0.0,
+                        "scale": {"x": 1.0, "y": 1.0},
+                    },
+                    "style": base_style(),
+                }
+
+            class FakeHandle:
+                def __init__(self, snapshot): self.snapshot = snapshot
+                def snapshotJson(self): return json.dumps(self.snapshot)
+                def shift(self, x, y):
+                    self.snapshot["transform"]["translation"]["x"] += float(x)
+                    self.snapshot["transform"]["translation"]["y"] += float(y)
+                def setStrokeWidth(self, value): self.snapshot["style"]["stroke_width"] = float(value)
+                def setFillOpacity(self, value): self.snapshot["style"]["fill"]["alpha"] = float(value)
+                def setStrokeOpacity(self, value): self.snapshot["style"]["stroke"]["alpha"] = float(value)
+                def setFillColor(self, r, g, b, a):
+                    alpha = self.snapshot["style"]["fill"]["alpha"]
+                    self.snapshot["style"]["fill"] = {"red": float(r), "green": float(g), "blue": float(b), "alpha": alpha}
+                def setStrokeColor(self, r, g, b, a):
+                    alpha = self.snapshot["style"]["stroke"]["alpha"]
+                    self.snapshot["style"]["stroke"] = {"red": float(r), "green": float(g), "blue": float(b), "alpha": alpha}
+
+            def generic_snapshot(value):
+                return FakeHandle(json.loads(value))
+
+            def arc_spec(radius, start_angle, angle, num_components, center_x, center_y):
+                calls.append((
+                    "arc",
+                    float(radius),
+                    float(start_angle),
+                    float(angle),
+                    int(num_components),
+                    float(center_x),
+                    float(center_y),
+                ))
+                snap = arc_snapshot()
+                return SimpleNamespace(
+                    snapshotJson=json.dumps(snap),
+                    radius=float(radius),
+                    startAngle=float(start_angle),
+                    angle=float(angle),
+                    numComponents=int(num_components),
+                )
+
+            def between_spec(start_x, start_y, end_x, end_y, angle, radius, num_components):
+                calls.append((
+                    "between",
+                    float(start_x),
+                    float(start_y),
+                    float(end_x),
+                    float(end_y),
+                    float(angle),
+                    None if radius is None else float(radius),
+                    int(num_components),
+                ))
+                return SimpleNamespace(
+                    snapshotJson=json.dumps(arc_snapshot()),
+                    radius=3.0,
+                    startAngle=0.0,
+                    angle=-math.pi / 2.0,
+                    numComponents=int(num_components),
+                )
+
+            def query_arc(value):
+                snap = json.loads(str(value))
+                queries.append(snap)
+                translation = snap["transform"]["translation"]
+                x = float(translation["x"])
+                y = float(translation["y"])
+                return SimpleNamespace(
+                    startX=1.0 + x,
+                    startY=y,
+                    endX=x,
+                    endY=1.0 + y,
+                    centerX=x,
+                    centerY=y,
+                    stopAngle=math.pi / 2.0,
+                )
+
+            fake_js.noonCreateAuthoringMobjectHandle = generic_snapshot
+            fake_js.noonCreateAuthoringArcSpec = arc_spec
+            fake_js.noonCreateAuthoringArcBetweenPointsSpec = between_spec
+            fake_js.noonQueryAuthoringArc = query_arc
+            sys.modules["js"] = fake_js
+
+            import _manim_compat
+            _manim_compat.install()
+            import _manim_phase_b
+            import _manim_geometry
+            import _manim_semantic_handles as handles
+            handles.install()
+            import _manim_shared_geometry as shared_geometry
+            shared_geometry.install()
+
+            shared_geometry._fallback_arc_path = lambda *args, **kwargs: (_ for _ in ()).throw(
+                AssertionError("Python Arc geometry fallback was called")
+            )
+            shared_geometry._fallback_arc_between_points = lambda *args, **kwargs: (_ for _ in ()).throw(
+                AssertionError("Python ArcBetweenPoints geometry fallback was called")
+            )
+
+            from noon import Arc, ArcBetweenPoints, Vec2
+
+            arc = Arc(
+                radius=2.0,
+                start_angle=0.25,
+                angle=1.5,
+                num_components=7,
+                arc_center=(3.0, -4.0, 0.0),
+            )
+            between = ArcBetweenPoints((-2.0, 0.0), (2.0, 0.0), radius=-3.0)
+
+            assert calls[0] == ("arc", 2.0, 0.25, 1.5, 7, 3.0, -4.0)
+            assert calls[1][0] == "between"
+            assert arc.radius == 2.0
+            assert arc.start_angle == 0.25
+            assert arc.angle == 1.5
+            assert arc.num_components == 7
+            assert between.radius == 3.0
+            assert between.angle < 0.0
+
+            arc.shift((2.0, 3.0))
+            assert arc.get_start() == Vec2(3.0, 3.0)
+            assert arc.get_end() == Vec2(2.0, 4.0)
+            assert arc.get_arc_center() == Vec2(2.0, 3.0)
+            assert math.isclose(arc.stop_angle(), math.pi / 2.0)
+            assert queries
+            assert queries[-1]["transform"]["translation"] == {"x": 2.0, "y": 3.0}
+            """
         )
 
 


### PR DESCRIPTION
## Summary
- expose Manim-compatible `Arc` and `ArcBetweenPoints` through the existing shared-geometry Python adapter
- construct browser Arc geometry from the Rust/WASM Arc spec and attach it to the ordinary shared semantic mobject handle
- keep `radius`, `start_angle`, `angle`, and `num_components` as immutable constructor metadata supplied by Rust
- delegate `get_start`, `get_end`, `get_arc_center`, and `stop_angle` to Rust against the current semantic-handle snapshot
- make `move_arc_center_to` a translation derived from the shared Rust center query
- free temporary WASM Arc spec/query objects in the worker and add source guards for that wiring
- retain a native-CPython-only cubic fallback for local compatibility tests; browser tests make that fallback throw to prove it is not authoritative

## Architecture
The browser path has no Python-owned Arc geometry or center/endpoint math. `ObjectSnapshot` in the semantic handle remains the only mutable Arc state. Python keeps only constructor metadata and forwards explicit queries to the same Rust snapshot functions used by typed Rust Arc authoring. No worker protocol or renderer primitive is added.

Stacked on #412. Tracks #76 and #61.