### PR TITLE
Test renderer initialization fallback and failure

### DIFF
--- a/.github/workflows/renderer-recovery.yml
+++ b/.github/workflows/renderer-recovery.yml
@@ -1,0 +1,98 @@
+name: Renderer recovery
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/renderer-recovery.yml"
+      - "crates/noon-web/**"
+      - "crates/noon-render-wgpu/**"
+      - "scripts/renderer-init-failure-smoke.mjs"
+      - "web/browser-smoke.html"
+      - "web/browser-smoke.js"
+  push:
+    branches:
+      - master
+    paths:
+      - ".github/workflows/renderer-recovery.yml"
+      - "crates/noon-web/**"
+      - "crates/noon-render-wgpu/**"
+      - "scripts/renderer-init-failure-smoke.mjs"
+      - "web/browser-smoke.html"
+      - "web/browser-smoke.js"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: renderer-recovery-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  initialization-fallback:
+    name: Initialization and fallback
+    runs-on: ubuntu-latest
+    env:
+      CARGO_INCREMENTAL: "0"
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use stable Rust
+        run: |
+          rustup default stable
+          rustup target add wasm32-unknown-unknown
+
+      - name: Cache Cargo sources
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-sources-${{ hashFiles('Cargo.toml', 'crates/**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-sources-
+
+      - name: Use sccache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+        with:
+          version: v0.16.0
+
+      - name: Install pinned wasm-pack
+        uses: taiki-e/install-action@13608cbb45b01feb47ef444ab1a42dc41ad56f1a # v2.79.11
+        with:
+          tool: wasm-pack@0.15.0
+          fallback: none
+
+      - name: Build browser package
+        env:
+          NOON_SKIP_PLAYGROUND_TEST: "1"
+          NOON_WASM_SKIP_OPT: "1"
+        run: bash scripts/build-web-demo.sh
+
+      - name: Cache Playwright Chromium
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-chromium-1.62.1
+
+      - name: Install browser smoke dependencies
+        run: |
+          npm install --no-save --ignore-scripts playwright@1.62.1
+          npx playwright install chromium
+
+      - name: Test renderer initialization and fallback
+        env:
+          NOON_RENDERER_FAILURE_ARTIFACTS: browser-smoke-artifacts/renderer-init-failure
+        run: node scripts/renderer-init-failure-smoke.mjs
+
+      - name: Upload renderer failure diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: renderer-init-failure
+          path: browser-smoke-artifacts/renderer-init-failure
+          if-no-files-found: error
+          retention-days: 7

--- a/scripts/renderer-init-failure-smoke.mjs
+++ b/scripts/renderer-init-failure-smoke.mjs
@@ -1,0 +1,202 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import playwright from "playwright";
+
+const { chromium } = playwright;
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const port = Number(process.env.NOON_RENDERER_FAILURE_PORT ?? "4191");
+const baseUrl = `http://127.0.0.1:${port}`;
+const artifactDir = path.resolve(
+  repoRoot,
+  process.env.NOON_RENDERER_FAILURE_ARTIFACTS ??
+    "browser-smoke-artifacts/renderer-init-failure",
+);
+
+await mkdir(artifactDir, { recursive: true });
+
+let serverOutput = "";
+const server = spawn(
+  "python3",
+  ["-m", "http.server", String(port), "--bind", "127.0.0.1", "--directory", repoRoot],
+  {
+    cwd: repoRoot,
+    stdio: ["ignore", "pipe", "pipe"],
+  },
+);
+server.stdout.on("data", (chunk) => {
+  serverOutput += chunk;
+});
+server.stderr.on("data", (chunk) => {
+  serverOutput += chunk;
+});
+
+async function waitForServer() {
+  let lastError = null;
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    try {
+      const response = await fetch(`${baseUrl}/web/browser-smoke.html`);
+      if (response.ok) return;
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Renderer failure smoke server did not start: ${lastError}\n${serverOutput}`);
+}
+
+async function waitForHarness(page) {
+  await page.goto(`${baseUrl}/web/browser-smoke.html`, { waitUntil: "load" });
+  await page.waitForFunction(() => window.noonSmoke?.state.ready === true, null, {
+    timeout: 30_000,
+  });
+  return page.evaluate(() => window.noonSmoke.metrics());
+}
+
+function collectErrors(page) {
+  const pageErrors = [];
+  const consoleErrors = [];
+  page.on("pageerror", (error) => pageErrors.push(String(error)));
+  page.on("console", (message) => {
+    if (message.type() === "error") consoleErrors.push(message.text());
+  });
+  return { pageErrors, consoleErrors };
+}
+
+async function writeDiagnostics(name, diagnostics) {
+  await writeFile(
+    path.join(artifactDir, `${name}.json`),
+    `${JSON.stringify(diagnostics, null, 2)}\n`,
+    "utf8",
+  );
+}
+
+let browser = null;
+try {
+  await waitForServer();
+  browser = await chromium.launch({
+    channel: "chromium",
+    headless: true,
+    args: [
+      "--disable-features=WebGPU",
+      "--enable-unsafe-swiftshader",
+      "--ignore-gpu-blocklist",
+      "--use-gl=angle",
+      "--use-angle=swiftshader",
+      "--disable-gpu-sandbox",
+      "--disable-dev-shm-usage",
+    ],
+  });
+
+  // Scenario 1: WebGPU is unavailable, but the same production auto-selection
+  // path must fall back to WebGL2 and still present a real frame.
+  const fallbackPage = await browser.newPage({ viewport: { width: 1000, height: 600 } });
+  const fallbackErrors = collectErrors(fallbackPage);
+  const fallbackInitial = await waitForHarness(fallbackPage);
+  assert.equal(fallbackInitial.error, null, `WebGL fallback failed: ${fallbackInitial.error}`);
+  assert.equal(
+    fallbackInitial.rendererBackend,
+    "WebGL2",
+    `WebGPU-disabled renderer selected ${fallbackInitial.rendererBackend}`,
+  );
+  const fallbackFrame = await fallbackPage.evaluate(() => window.noonSmoke.renderAt(0.5));
+  assert.equal(fallbackFrame.error, null, "WebGL fallback reported a runtime error");
+  assert.equal(fallbackFrame.rendererBackend, "WebGL2");
+  assert.equal(fallbackFrame.presented, true, "WebGL fallback did not present a frame");
+  assert.ok(fallbackFrame.drawCalls > 0, "WebGL fallback emitted no draw calls");
+  assert.deepEqual(fallbackErrors.pageErrors, [], "WebGL fallback emitted page errors");
+  assert.deepEqual(fallbackErrors.consoleErrors, [], "WebGL fallback emitted console errors");
+  await fallbackPage.screenshot({
+    path: path.join(artifactDir, "webgl-fallback.png"),
+    fullPage: true,
+  });
+  await writeDiagnostics("webgl-fallback", {
+    browserVersion: browser.version(),
+    initial: fallbackInitial,
+    frame: fallbackFrame,
+    ...fallbackErrors,
+  });
+  await fallbackPage.close();
+  console.log("✓ renderer init: WebGPU unavailable falls back to WebGL2 and presents");
+
+  // Scenario 2: keep WebGPU disabled and deterministically reject browser WebGL
+  // context creation. The harness must resolve to one stable initialization error
+  // instead of hanging, leaving a blank-but-apparently-ready player, or surfacing
+  // an unhandled page exception.
+  const unavailablePage = await browser.newPage({ viewport: { width: 1000, height: 600 } });
+  const unavailableErrors = collectErrors(unavailablePage);
+  await unavailablePage.addInitScript(() => {
+    const originalGetContext = HTMLCanvasElement.prototype.getContext;
+    Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
+      configurable: true,
+      value(type, ...args) {
+        const normalized = String(type).toLowerCase();
+        if (
+          normalized === "webgl" ||
+          normalized === "webgl2" ||
+          normalized === "experimental-webgl"
+        ) {
+          return null;
+        }
+        return originalGetContext.call(this, type, ...args);
+      },
+    });
+  });
+
+  const unavailable = await waitForHarness(unavailablePage);
+  assert.ok(unavailable.error, "both-unavailable renderer unexpectedly initialized");
+  assert.equal(
+    unavailable.rendererBackend ?? null,
+    null,
+    "failed renderer reported a live backend",
+  );
+  assert.match(
+    unavailable.error,
+    /(adapter|backend|canvas|context|gpu|surface|webgl)/i,
+    `renderer failure lacks backend/context information: ${unavailable.error}`,
+  );
+  assert.deepEqual(
+    unavailableErrors.pageErrors,
+    [],
+    `handled renderer init failure emitted page errors: ${unavailableErrors.pageErrors.join("\n")}`,
+  );
+  assert.ok(
+    unavailableErrors.consoleErrors.length >= 1,
+    "renderer init failure should be reported through the harness console diagnostic",
+  );
+  assert.ok(
+    unavailableErrors.consoleErrors.some((message) =>
+      /(adapter|backend|canvas|context|gpu|surface|webgl)/i.test(message),
+    ),
+    `console diagnostic lacks backend/context information: ${unavailableErrors.consoleErrors.join("\n")}`,
+  );
+  await unavailablePage.screenshot({
+    path: path.join(artifactDir, "both-backends-unavailable.png"),
+    fullPage: true,
+  });
+  await writeDiagnostics("both-backends-unavailable", {
+    browserVersion: browser.version(),
+    metrics: unavailable,
+    ...unavailableErrors,
+  });
+  await unavailablePage.close();
+  console.log("✓ renderer init: both backends unavailable fails clearly without an unhandled exception");
+} catch (error) {
+  await writeDiagnostics("failure", {
+    browserVersion: browser?.version() ?? null,
+    error:
+      error instanceof Error
+        ? { name: error.name, message: error.message, stack: error.stack }
+        : String(error),
+    serverOutput,
+  });
+  throw error;
+} finally {
+  await browser?.close();
+  server.kill("SIGTERM");
+}


### PR DESCRIPTION
## Summary
First deterministic initialization/fallback slice for #111.

- add a focused Chromium browser smoke that runs against the real built `NoonCanvasPlayer`/wgpu path
- disable WebGPU and require the existing automatic backend selection to fall back to WebGL2 and present a real frame
- in a second isolated page, keep WebGPU disabled and deterministically reject HTML canvas WebGL/WebGL2 context creation
- require the both-backends-unavailable path to resolve within the normal initialization timeout with a backend/context diagnostic rather than hanging or reporting a live renderer
- assert handled initialization failure produces no unhandled `pageerror`
- retain screenshots and JSON diagnostics for the successful fallback path, both-unavailable path, and harness failures
- run this in a separate path-filtered workflow so it does not conflict with the active demo CI/layout/editor or retained-text branches

## Scope boundary
This is the initialization/fallback tranche only. It does not change renderer production code, worker/runtime semantics, retained text, or the public demo. WebGPU device loss, WebGL context loss/restoration, resource/pipeline failure, stale cache-generation checks, and renderer state restoration remain follow-up #111 slices.

## Failure policy
The test uses the existing production auto-selection path. WebGPU unavailability must end in a working WebGL2 frame. With both browser GPU paths unavailable, initialization must fail clearly and boundedly; the test does not convert that failure into a skip.

Tracks #111.