### PR TITLE
Match principal-axis Rotating projection

### DIFF
--- a/web/python/_manim_updaters.py
+++ b/web/python/_manim_updaters.py
@@ -376,9 +376,9 @@ def _install_rotating_breadth() -> None:
     """Install source-execution breadth for Manim's literal ``RotatingDemo``.
 
     The qualified centered-leaf implementation stays in ``_manim_rotate``. This final
-    bootstrap wrapper handles retained groups, external pivots, and the 180-degree x/y
-    projections used by the upstream documentation scene. It intentionally remains a
-    parity candidate until curved z-pivot and 3D intermediate-frame tracks are native.
+    bootstrap wrapper handles retained groups, external pivots, curved z-axis family
+    motion, and the planar principal-axis projection used by the documentation scene.
+    Arbitrary 3D retained state remains a separate representation problem.
     """
 
     compat = sys.modules.get("_manim_compat")
@@ -464,24 +464,59 @@ def _install_rotating_breadth() -> None:
             return compat._critical_for(group, compat._as_vec2(animation.about_edge))
         return group.get_center()
 
-    def reflected_target(
-        current: _base.Mobject, *, axis: str, pivot_point: _base.Vec2
+    def projection_scale_key(current: _base.Mobject, *, axis: str) -> str:
+        """Return the local scale channel matching the projected world dimension.
+
+        The scene wire stores legacy rotation as f32, so exact quarter turns authored
+        through repeated retained Transforms can return with O(1e-7) rad quantization
+        residue. Classify against the nearest quarter turn using a bound derived from
+        f32 machine epsilon; larger residuals are genuine non-principal bases whose
+        projected affine map would require shear in Noon's rotation+scale transform.
+        """
+
+        rotation = float(current.to_ir()["transform"]["rotation"])
+        quarter_turn = math.pi / 2.0
+        quarter_index = round(rotation / quarter_turn)
+        nearest = quarter_index * quarter_turn
+        f32_epsilon = 2.0**-23
+        tolerance = 8.0 * f32_epsilon * max(1.0, abs(rotation), abs(nearest))
+        if abs(rotation - nearest) > tolerance:
+            raise NotImplementedError(
+                "non-z Rotating projection would require shear for a non-axis-aligned retained leaf"
+            )
+        local_x_is_world_x = quarter_index % 2 == 0
+        if axis == "y":
+            return "x" if local_x_is_world_x else "y"
+        if axis == "x":
+            return "y" if local_x_is_world_x else "x"
+        raise ValueError(f"unsupported projection axis {axis!r}")
+
+    def projected_target(
+        current: _base.Mobject,
+        *,
+        axis: str,
+        pivot_point: _base.Vec2,
+        angle: float,
+        scale_key: str,
     ) -> _base.Mobject:
+        """Project a planar principal-axis rotation back onto the xy authoring plane."""
+
         target_snapshot = current.to_ir()
         transform = target_snapshot["transform"]
         translation = transform["translation"]
-        rotation = float(transform["rotation"])
         scale = transform["scale"]
+        compression = math.cos(angle)
         if axis == "y":
-            translation["x"] = 2.0 * pivot_point.x - float(translation["x"])
-            transform["rotation"] = math.pi - rotation
-            scale["y"] = -float(scale["y"])
+            translation["x"] = pivot_point.x + compression * (
+                float(translation["x"]) - pivot_point.x
+            )
         elif axis == "x":
-            translation["y"] = 2.0 * pivot_point.y - float(translation["y"])
-            transform["rotation"] = -rotation
-            scale["y"] = -float(scale["y"])
+            translation["y"] = pivot_point.y + compression * (
+                float(translation["y"]) - pivot_point.y
+            )
         else:
-            raise ValueError(f"unsupported reflection axis {axis!r}")
+            raise ValueError(f"unsupported projection axis {axis!r}")
+        scale[scale_key] = float(scale[scale_key]) * compression
         return animate._snapshot_mobject(target_snapshot)
 
     def schedule_family(
@@ -491,7 +526,7 @@ def _install_rotating_breadth() -> None:
         start_time: float,
         duration: float,
         easing: str,
-    ) -> None:
+    ) -> list[tuple[_base.Mobject, _base.Mobject]]:
         sources, detached = current_detached_members(scene, animation.mobject, start_time)
         pivot_point = pivot(detached, animation)
         axis, sign = axis_kind(animation.axis)
@@ -499,75 +534,74 @@ def _install_rotating_breadth() -> None:
             abs(animation.angle), math.pi, rel_tol=0.0, abs_tol=1e-12
         ):
             raise NotImplementedError(
-                "non-z Rotating currently supports the 180-degree projection used by Manim RotatingDemo"
+                "non-z Rotating currently supports the 180-degree planar turn used by Manim RotatingDemo"
             )
 
-        if axis == "z":
-            # Generic Transform's pointwise-rotation interpolation is intentionally
-            # target-state semantics: for a 180-degree source/target pair its matrix
-            # blend passes through zero scale at alpha=0.5. That is correct for
-            # ``mobject.animate.rotate`` but wrong for procedural Rotating families:
-            # circles collapse and independently retained Arrow shaft/tip members can
-            # visibly separate. Approximate the missing curved family-pivot channel
-            # with short deterministic Transform arcs, all sampled from the same
-            # global rate function. At <=5 degrees per interval the pointwise blend's
-            # worst midpoint scale factor is cos(2.5 degrees) > 0.999, while every
-            # family member remains synchronized at identical segment boundaries.
-            max_step = math.pi / 36.0
-            segment_count = max(1, math.ceil(abs(animation.angle) / max_step))
-            end_time = start_time + duration
-            for segment in range(segment_count):
-                alpha = (segment + 1) / segment_count
-                eased_alpha = rates.evaluate_rate_function(easing, alpha)
-                cumulative_angle = sign * animation.angle * eased_alpha
-                segment_start = start_time + duration * segment / segment_count
-                segment_end = (
-                    end_time
-                    if segment + 1 == segment_count
-                    else start_time + duration * (segment + 1) / segment_count
-                )
-                segment_duration = segment_end - segment_start
-                for index, (source, current) in enumerate(
-                    zip(sources, detached, strict=True)
-                ):
-                    assert source._object is not None
-                    obj = source._object
+        projection_keys: list[str] | None = None
+        if axis in {"x", "y"}:
+            projection_keys = [
+                projection_scale_key(current, axis=axis) for current in detached
+            ]
+
+        # Manim procedural Rotating restores the play-start geometry at every alpha
+        # and applies the current rotation. One generic source/target Transform cannot
+        # model that path: a 180-degree z turn collapses its matrix at the midpoint,
+        # while a principal x/y turn should follow an orthographic cos(theta)
+        # compression. Sample the one global rate function into short deterministic
+        # retained intervals, always deriving each endpoint from the original play-start
+        # snapshots. This keeps family members coherent without a Python frame callback
+        # or a renderer-specific primitive. The final interval endpoint is authored
+        # exactly at ``start_time + duration`` to avoid floating handoff drift.
+        max_step = math.pi / 36.0
+        segment_count = max(1, math.ceil(abs(animation.angle) / max_step))
+        end_time = start_time + duration
+        final_targets: list[tuple[_base.Mobject, _base.Mobject]] = []
+        for segment in range(segment_count):
+            alpha = (segment + 1) / segment_count
+            eased_alpha = rates.evaluate_rate_function(easing, alpha)
+            cumulative_angle = sign * animation.angle * eased_alpha
+            segment_start = start_time + duration * segment / segment_count
+            segment_end = (
+                end_time
+                if segment + 1 == segment_count
+                else start_time + duration * (segment + 1) / segment_count
+            )
+            segment_duration = segment_end - segment_start
+            for index, (source, current) in enumerate(
+                zip(sources, detached, strict=True)
+            ):
+                assert source._object is not None
+                obj = source._object
+                if axis == "z":
                     target = animate._snapshot_mobject(current.to_ir())
                     target.rotate(cumulative_angle, compat.OUT, about_point=pivot_point)
-                    object_key = scene._object_keys[obj.id]
-                    compat._BaseScene.play(
-                        scene,
-                        _base.Transform(
-                            source,
-                            target,
-                            key=(
-                                f"@rotating-family:{object_key}:{start_time:g}:{index}"
-                                f":segment:{segment}"
-                            ),
-                        ),
-                        run_time=segment_duration,
-                        start_time=segment_start,
-                        easing="linear",
+                else:
+                    assert projection_keys is not None
+                    target = projected_target(
+                        current,
+                        axis=axis,
+                        pivot_point=pivot_point,
+                        angle=cumulative_angle,
+                        scale_key=projection_keys[index],
                     )
-            return
-
-        for index, (source, current) in enumerate(zip(sources, detached, strict=True)):
-            assert source._object is not None
-            obj = source._object
-            target = reflected_target(current, axis=axis, pivot_point=pivot_point)
-
-            object_key = scene._object_keys[obj.id]
-            compat._BaseScene.play(
-                scene,
-                _base.Transform(
-                    source,
-                    target,
-                    key=f"@rotating-family:{object_key}:{start_time:g}:{index}",
-                ),
-                run_time=duration,
-                start_time=start_time,
-                easing=easing,
-            )
+                object_key = scene._object_keys[obj.id]
+                compat._BaseScene.play(
+                    scene,
+                    _base.Transform(
+                        source,
+                        target,
+                        key=(
+                            f"@rotating-family:{object_key}:{start_time:g}:{index}"
+                            f":segment:{segment}"
+                        ),
+                    ),
+                    run_time=segment_duration,
+                    start_time=segment_start,
+                    easing="linear",
+                )
+                if segment + 1 == segment_count:
+                    final_targets.append((source, target))
+        return final_targets
 
     def schedule(
         scene: object,
@@ -576,7 +610,7 @@ def _install_rotating_breadth() -> None:
         start_time: float,
         duration: float,
         easing: str,
-    ) -> None:
+    ) -> list[tuple[_base.Mobject, _base.Mobject]]:
         if not isinstance(animation.mobject, compat.Group):
             exact = rotate.Rotating(
                 animation.mobject,
@@ -594,8 +628,8 @@ def _install_rotating_breadth() -> None:
                 duration=duration,
                 easing=easing,
             )
-            return
-        schedule_family(
+            return []
+        return schedule_family(
             scene,
             animation,
             start_time=start_time,
@@ -656,6 +690,7 @@ def _install_rotating_breadth() -> None:
             animate._record_wrapper_state(animation.mobject, wrapper_states)
 
         max_end = base_start
+        semantic_targets: dict[int, tuple[_base.Mobject, _base.Mobject]] = {}
         try:
             for animation in broad:
                 animate._bind_for_animation(self, animation.mobject, start_time=base_start)
@@ -667,15 +702,22 @@ def _install_rotating_breadth() -> None:
                     play_rate_func=rate_func,
                     play_lag_ratio=lag_ratio,
                 )
-                schedule(
+                for source, target in schedule(
                     self,
                     animation,
                     start_time=base_start,
                     duration=resolved.run_time,
                     easing=resolved.rate_func,
-                )
+                ):
+                    semantic_targets[id(source)] = (source, target)
                 max_end = max(max_end, base_start + resolved.run_time)
             self._cursor = max(cursor_before, max_end)
+            # Internal family segments intentionally bypass the aligned scheduler to
+            # keep one deterministic global rate function. Mirror its successful-play
+            # ownership handoff once, after every segment has scheduled, so browser
+            # semantic handles and the legacy scene timeline agree for the next play.
+            for source, target in semantic_targets.values():
+                animate._semantic_handles.commit_transform_target(source, target)
             return self
         except Exception:
             self._restore_authoring_checkpoint(checkpoint)

--- a/web/python/test_manim_rotating_principal_axis_projection.py
+++ b/web/python/test_manim_rotating_principal_axis_projection.py
@@ -1,0 +1,362 @@
+import os
+import subprocess
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+
+
+class ManimRotatingPrincipalAxisProjectionTests(unittest.TestCase):
+    def test_public_demo_principal_axis_turns_follow_full_history(self) -> None:
+        python_dir = Path(__file__).resolve().parent
+        env = os.environ.copy()
+        existing_pythonpath = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = (
+            str(python_dir)
+            if not existing_pythonpath
+            else os.pathsep.join((str(python_dir), existing_pythonpath))
+        )
+
+        source = textwrap.dedent(
+            """
+            import math
+            import sys
+            import types
+
+            fake_js = types.ModuleType("js")
+
+            class Result:
+                ok = True
+                errorKind = ""
+                message = ""
+
+            class JsArray(list):
+                @property
+                def length(self):
+                    return len(self)
+
+            def resolve_animation_options(
+                default_lag_ratio,
+                animation_run_time,
+                animation_rate_func,
+                animation_lag_ratio,
+                path_arc,
+                reverse_rate_function,
+                play_run_time,
+                play_rate_func,
+                play_lag_ratio,
+            ):
+                result = Result()
+                result.runTime = (
+                    play_run_time
+                    if math.isfinite(play_run_time)
+                    else animation_run_time
+                    if math.isfinite(animation_run_time)
+                    else 1.0
+                )
+                result.rateFunc = play_rate_func or animation_rate_func or "smooth"
+                result.lagRatio = (
+                    play_lag_ratio
+                    if math.isfinite(play_lag_ratio)
+                    else animation_lag_ratio
+                    if math.isfinite(animation_lag_ratio)
+                    else default_lag_ratio
+                )
+                result.pathArc = path_arc if math.isfinite(path_arc) else 0.0
+                result.reverseRateFunction = reverse_rate_function == 1
+                return result
+
+            def resolve_uniform_schedule(child_count, lag_ratio, run_time):
+                result = Result()
+                intrinsic = 1.0 + max(int(child_count) - 1, 0) * float(lag_ratio)
+                scale = float(run_time) / intrinsic
+                result.intervals = JsArray(
+                    [
+                        types.SimpleNamespace(
+                            startTime=index * float(lag_ratio) * scale,
+                            duration=scale,
+                        )
+                        for index in range(int(child_count))
+                    ]
+                )
+                return result
+
+            fake_js.noonResolveAnimationOptions = resolve_animation_options
+            fake_js.noonResolveUniformCompositionSchedule = resolve_uniform_schedule
+            sys.modules["js"] = fake_js
+
+            import _manim_compat
+            _manim_compat.install()
+            import _manim_rate_functions
+            _manim_rate_functions.install()
+            import _manim_phase_b  # noqa: F401
+            import _manim_geometry  # noqa: F401
+            import _manim_animate
+            import _manim_rotate
+            _manim_rotate.install()
+            import _manim_updaters
+            _manim_updaters.install()
+
+            from noon import (
+                Arrow,
+                BLUE,
+                Circle,
+                DEGREES,
+                GOLD,
+                Line,
+                ORIGIN,
+                PI,
+                RIGHT,
+                Rotating,
+                Scene,
+                Square,
+                UP,
+                VGroup,
+            )
+
+            semantic_commits = []
+
+            def record_semantic_commit(source, target):
+                semantic_commits.append((id(source), target.to_ir()))
+
+            # Native tests have no WASM semantic handle. Record the same commit hook
+            # the browser uses so family Rotating cannot silently bypass ownership
+            # synchronization again.
+            _manim_animate._semantic_handles.commit_transform_target = record_semantic_commit
+
+            def world_point(snapshot, x=0.0, y=0.0):
+                transform = snapshot["transform"]
+                scale = transform["scale"]
+                rotation = float(transform["rotation"])
+                translation = transform["translation"]
+                local_x = x * float(scale["x"])
+                local_y = y * float(scale["y"])
+                cosine = math.cos(rotation)
+                sine = math.sin(rotation)
+                return (
+                    local_x * cosine - local_y * sine + float(translation["x"]),
+                    local_x * sine + local_y * cosine + float(translation["y"]),
+                )
+
+            def snapshot_center(snapshot):
+                geometry = snapshot["geometry"]
+                points = []
+                if "circle" in geometry:
+                    radius = float(geometry["circle"]["radius"])
+                    points = [(-radius, -radius), (radius, radius)]
+                elif "rectangle" in geometry:
+                    size = geometry["rectangle"]["size"]
+                    half_x = float(size["x"]) / 2.0
+                    half_y = float(size["y"]) / 2.0
+                    points = [(-half_x, -half_y), (half_x, half_y)]
+                elif "line" in geometry:
+                    line = geometry["line"]
+                    points = [
+                        (float(line["start"]["x"]), float(line["start"]["y"])),
+                        (float(line["end"]["x"]), float(line["end"]["y"])),
+                    ]
+                elif "vector_path" in geometry:
+                    for command in geometry["vector_path"]["commands"]:
+                        if command == "close":
+                            continue
+                        payload = next(iter(command.values()))
+                        for key in ("to", "control", "control1", "control2"):
+                            if key in payload:
+                                point = payload[key]
+                                points.append((float(point["x"]), float(point["y"])))
+                assert points, geometry
+                min_x = min(point[0] for point in points)
+                max_x = max(point[0] for point in points)
+                min_y = min(point[1] for point in points)
+                max_y = max(point[1] for point in points)
+                world_corners = [
+                    world_point(snapshot, x, y)
+                    for x, y in (
+                        (min_x, min_y),
+                        (min_x, max_y),
+                        (max_x, min_y),
+                        (max_x, max_y),
+                    )
+                ]
+                return (
+                    (min(point[0] for point in world_corners) + max(point[0] for point in world_corners)) / 2.0,
+                    (min(point[1] for point in world_corners) + max(point[1] for point in world_corners)) / 2.0,
+                )
+
+            def transform_tracks(document, start, end):
+                return [
+                    track
+                    for track in document["tracks"]
+                    if track["property"] == "transform"
+                    and start <= float(track["timing"]["start_time"]) < end
+                ]
+
+            def endpoint_track(tracks, object_id, time):
+                matches = []
+                for track in tracks:
+                    if track["object"] != object_id:
+                        continue
+                    timing = track["timing"]
+                    track_end = float(timing["start_time"]) + float(timing["duration"])
+                    if math.isclose(track_end, time, rel_tol=0.0, abs_tol=1e-12):
+                        matches.append(track)
+                assert len(matches) == 1, (object_id, time, len(matches))
+                return matches[0]
+
+            scene = Scene()
+            circle = Circle(radius=1, color=BLUE)
+            line = Line(start=ORIGIN, end=RIGHT)
+            arrow = Arrow(start=ORIGIN, end=RIGHT, buff=0, color=GOLD)
+            family = VGroup(circle, line, arrow)
+            scene.add(family)
+
+            circle_id = circle.id
+            shaft_id = arrow._shaft.id
+            tip_id = arrow._tip.id
+
+            # Execute the literal public RotatingDemo history. The first three z-axis
+            # plays are important: browser semantic handles lower their wire rotation
+            # through f32, so exact multiples of pi return with ~1e-7 rad residue.
+            anim_kw = {"about_point": arrow.get_start(), "run_time": 1}
+            scene.play(Rotating(arrow, 180 * DEGREES, **anim_kw))
+            assert len(semantic_commits) == 2
+            scene.play(Rotating(arrow, PI, **anim_kw))
+            assert len(semantic_commits) == 4
+            scene.play(Rotating(family, PI, about_point=RIGHT))
+            assert scene.time == 7.0
+            assert len(semantic_commits) == 8
+
+            scene.play(Rotating(family, PI, axis=UP, about_point=ORIGIN))
+            assert scene.time == 12.0
+            assert len(semantic_commits) == 12
+            scene.play(Rotating(family, PI, axis=RIGHT, about_edge=UP))
+            assert scene.time == 17.0
+            assert len(semantic_commits) == 16
+
+            document = scene.to_document()
+            y_tracks = transform_tracks(document, 7.0, 12.0)
+            x_tracks = transform_tracks(document, 12.0, 17.0)
+            assert len(y_tracks) > 4
+            assert len(x_tracks) > 4
+
+            # At 90 degrees around world y every world-x coordinate projects onto the
+            # pivot plane. Circle therefore becomes edge-on and Arrow's retained shaft
+            # endpoint remains attached to the geometric center of its triangular tip.
+            y_circle_mid = endpoint_track(y_tracks, circle_id, 9.5)["values"]["object"]["to"]
+            y_scale = y_circle_mid["transform"]["scale"]
+            assert abs(float(y_scale["x"])) < 1e-12, y_scale
+
+            y_shaft_mid = endpoint_track(y_tracks, shaft_id, 9.5)["values"]["object"]["to"]
+            y_tip_mid = endpoint_track(y_tracks, tip_id, 9.5)["values"]["object"]["to"]
+            shaft_geometry = y_shaft_mid["geometry"]["line"]
+            shaft_end = shaft_geometry["end"]
+            projected_shaft_end = world_point(
+                y_shaft_mid,
+                float(shaft_end["x"]),
+                float(shaft_end["y"]),
+            )
+            assert math.dist(projected_shaft_end, snapshot_center(y_tip_mid)) < 1e-9
+
+            # The final x-axis turn is likewise a cosine compression in world y.
+            x_circle_mid = endpoint_track(x_tracks, circle_id, 14.5)["values"]["object"]["to"]
+            x_transform = x_circle_mid["transform"]
+            assert abs(float(x_transform["scale"]["y"])) < 1e-12, x_transform
+            assert math.isclose(
+                float(x_transform["translation"]["y"]),
+                1.0,
+                rel_tol=0.0,
+                abs_tol=1e-9,
+            )
+
+            x_shaft_mid = endpoint_track(x_tracks, shaft_id, 14.5)["values"]["object"]["to"]
+            x_tip_mid = endpoint_track(x_tracks, tip_id, 14.5)["values"]["object"]["to"]
+            shaft_geometry = x_shaft_mid["geometry"]["line"]
+            shaft_end = shaft_geometry["end"]
+            projected_shaft_end = world_point(
+                x_shaft_mid,
+                float(shaft_end["x"]),
+                float(shaft_end["y"]),
+            )
+            assert math.dist(projected_shaft_end, snapshot_center(x_tip_mid)) < 1e-9
+
+            # Every retained leaf must hand off at the exact authored play endpoint.
+            for tracks, end_time in ((y_tracks, 12.0), (x_tracks, 17.0)):
+                object_ids = {track["object"] for track in tracks}
+                for object_id in object_ids:
+                    final_track = max(
+                        (track for track in tracks if track["object"] == object_id),
+                        key=lambda track: track["timing"]["start_time"],
+                    )
+                    timing = final_track["timing"]
+                    assert float(timing["start_time"]) + float(timing["duration"]) == end_time
+
+            # The public demo immediately follows the family rotations with a group
+            # animate. Rotating must have committed its final targets to the browser's
+            # shared semantic ownership model before this target-state copy is seeded.
+            scene.play(family.animate.move_to(ORIGIN))
+            assert scene.time == 18.0
+            assert len(semantic_commits) == 20
+
+            # This is the actual f32 wire value obtained near 3*pi. It is a principal
+            # orientation despite representational roundoff and must not be confused
+            # with a genuinely arbitrary basis requiring shear.
+            precision_scene = Scene()
+            wire_pi3 = 9.42477798461914
+            rounded = Circle(rotation=wire_pi3)
+            rounded_family = VGroup(rounded)
+            precision_scene.add(rounded_family)
+            precision_scene.play(
+                Rotating(
+                    rounded_family,
+                    PI,
+                    axis=UP,
+                    about_point=ORIGIN,
+                    run_time=1.0,
+                )
+            )
+            assert precision_scene.time == 1.0
+
+            # A genuinely non-axis-aligned 2D basis still requires shear after
+            # principal-axis projection. Reject that case transactionally rather than
+            # silently broadening the f32 precision allowance into an approximation.
+            unsupported_scene = Scene()
+            diamond = Square().rotate(PI / 4.0)
+            unsupported_family = VGroup(diamond)
+            unsupported_scene.add(unsupported_family)
+            before = unsupported_scene.to_document()
+            try:
+                unsupported_scene.play(
+                    Rotating(
+                        unsupported_family,
+                        PI,
+                        axis=UP,
+                        about_point=ORIGIN,
+                        run_time=1.0,
+                    )
+                )
+            except NotImplementedError as error:
+                assert "shear" in str(error).lower()
+            else:
+                raise AssertionError("non-axis-aligned projected Rotating must be rejected")
+            assert unsupported_scene.time == 0.0
+            assert unsupported_scene.to_document() == before
+            """
+        )
+
+        completed = subprocess.run(
+            [sys.executable, "-c", source],
+            check=False,
+            cwd=python_dir,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            completed.returncode,
+            0,
+            f"compatibility subprocess failed:\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #424.

## Summary
- replace the single 2D reflection Transform used for retained x/y `Rotating` families with deterministic short retained intervals sampled from the same global rate function
- derive every interval endpoint from the play-start snapshot, matching Manim's procedural `Rotating` model
- use exact planar orthographic projection for the public principal-axis turns (`cos(theta)` world-axis compression around the fixed pivot)
- keep Arrow shaft/tip coherent and Circle edge-on behavior through 90 degrees
- preflight retained leaf bases and reject cases whose projection would require shear instead of silently approximating them
- retain exact absolute segment boundaries and the existing transactional authoring rollback

## Tests
Adds a focused principal-axis regression covering the public `UP` / `RIGHT` turns, midpoint projection, Arrow attachment, exact play handoff, and unsupported-shear rollback. Existing z-axis rigidity coverage remains unchanged.