### PR TITLE
Test WebGPU device-loss recovery

### DIFF
--- a/.github/workflows/renderer-recovery.yml
+++ b/.github/workflows/renderer-recovery.yml
@@ -8,6 +8,7 @@ on:
       - "crates/noon-render-wgpu/**"
       - "scripts/renderer-init-failure-smoke.mjs"
       - "scripts/renderer-webgl-context-loss-smoke.mjs"
+      - "scripts/renderer-webgpu-device-loss-smoke.mjs"
       - "web/browser-smoke.html"
       - "web/browser-smoke.js"
   push:
@@ -19,6 +20,7 @@ on:
       - "crates/noon-render-wgpu/**"
       - "scripts/renderer-init-failure-smoke.mjs"
       - "scripts/renderer-webgl-context-loss-smoke.mjs"
+      - "scripts/renderer-webgpu-device-loss-smoke.mjs"
       - "web/browser-smoke.html"
       - "web/browser-smoke.js"
   workflow_dispatch:
@@ -32,7 +34,7 @@ concurrency:
 
 jobs:
   initialization-fallback:
-    name: Initialization, fallback, and WebGL recovery
+    name: Initialization, fallback, WebGL, and WebGPU recovery
     runs-on: ubuntu-latest
     env:
       CARGO_INCREMENTAL: "0"
@@ -96,6 +98,12 @@ jobs:
           NOON_RENDERER_CONTEXT_LOSS_ARTIFACTS: browser-smoke-artifacts/renderer-context-loss
         run: node scripts/renderer-webgl-context-loss-smoke.mjs
 
+      - name: Test WebGPU device loss and recovery
+        id: webgpu_device_loss
+        env:
+          NOON_RENDERER_DEVICE_LOSS_ARTIFACTS: browser-smoke-artifacts/renderer-device-loss
+        run: node scripts/renderer-webgpu-device-loss-smoke.mjs
+
       - name: Upload renderer initialization diagnostics
         if: always()
         uses: actions/upload-artifact@v4
@@ -111,5 +119,14 @@ jobs:
         with:
           name: renderer-webgl-context-loss
           path: browser-smoke-artifacts/renderer-context-loss
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Upload WebGPU recovery diagnostics
+        if: always() && steps.webgpu_device_loss.outcome != 'skipped'
+        uses: actions/upload-artifact@v4
+        with:
+          name: renderer-webgpu-device-loss
+          path: browser-smoke-artifacts/renderer-device-loss
           if-no-files-found: error
           retention-days: 7

--- a/scripts/renderer-webgpu-device-loss-smoke.mjs
+++ b/scripts/renderer-webgpu-device-loss-smoke.mjs
@@ -1,0 +1,314 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import playwright from "playwright";
+import pngjs from "pngjs";
+
+const { chromium } = playwright;
+const { PNG } = pngjs;
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const port = Number(process.env.NOON_RENDERER_DEVICE_LOSS_PORT ?? "4193");
+const baseUrl = `http://127.0.0.1:${port}`;
+const artifactDir = path.resolve(
+  repoRoot,
+  process.env.NOON_RENDERER_DEVICE_LOSS_ARTIFACTS ??
+    "browser-smoke-artifacts/renderer-device-loss",
+);
+const sampleTime = 0.75;
+
+await mkdir(artifactDir, { recursive: true });
+
+let serverOutput = "";
+const server = spawn(
+  "python3",
+  ["-m", "http.server", String(port), "--bind", "127.0.0.1", "--directory", repoRoot],
+  { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] },
+);
+server.stdout.on("data", (chunk) => {
+  serverOutput += chunk;
+});
+server.stderr.on("data", (chunk) => {
+  serverOutput += chunk;
+});
+
+async function waitForServer() {
+  let lastError = null;
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    try {
+      const response = await fetch(`${baseUrl}/web/browser-smoke.html`);
+      if (response.ok) return;
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Renderer device-loss server did not start: ${lastError}\n${serverOutput}`);
+}
+
+function collectBrowserErrors(page) {
+  const pageErrors = [];
+  const consoleErrors = [];
+  page.on("pageerror", (error) => pageErrors.push(String(error)));
+  page.on("console", (message) => {
+    if (message.type() === "error") consoleErrors.push(message.text());
+  });
+  return { pageErrors, consoleErrors };
+}
+
+async function installDeviceCapture(page) {
+  await page.addInitScript(() => {
+    const state = {
+      patched: false,
+      patchError: null,
+      devices: [],
+      lost: [],
+    };
+    window.__noonWebGpuDeviceCapture = state;
+
+    try {
+      const gpu = navigator.gpu;
+      if (!gpu || typeof gpu.requestAdapter !== "function") {
+        state.patchError = "navigator.gpu.requestAdapter is unavailable";
+        return;
+      }
+      const originalRequestAdapter = gpu.requestAdapter.bind(gpu);
+      Object.defineProperty(gpu, "requestAdapter", {
+        configurable: true,
+        value: async (...adapterArgs) => {
+          const adapter = await originalRequestAdapter(...adapterArgs);
+          if (!adapter) return adapter;
+
+          const originalRequestDevice = adapter.requestDevice.bind(adapter);
+          Object.defineProperty(adapter, "requestDevice", {
+            configurable: true,
+            value: async (...deviceArgs) => {
+              const device = await originalRequestDevice(...deviceArgs);
+              const index = state.devices.length;
+              state.devices.push(device);
+              state.lost.push(null);
+              device.lost.then((info) => {
+                state.lost[index] = {
+                  reason: String(info.reason ?? "unknown"),
+                  message: String(info.message ?? ""),
+                };
+              });
+              return device;
+            },
+          });
+          return adapter;
+        },
+      });
+      state.patched = true;
+    } catch (error) {
+      state.patchError = String(error);
+    }
+  });
+}
+
+async function waitForHarness(page) {
+  await page.goto(`${baseUrl}/web/browser-smoke.html`, { waitUntil: "load" });
+  await page.waitForFunction(() => window.noonSmoke?.state.ready === true, null, {
+    timeout: 30_000,
+  });
+  const metrics = await page.evaluate(() => window.noonSmoke.metrics());
+  assert.equal(metrics.error, null, `renderer failed to initialize: ${metrics.error}`);
+  assert.equal(metrics.rendererBackend, "WebGPU", `expected WebGPU, got ${metrics.rendererBackend}`);
+  return metrics;
+}
+
+async function renderAndCapture(page, name) {
+  const metrics = await page.evaluate((time) => window.noonSmoke.renderAt(time), sampleTime);
+  assert.equal(metrics.error, null, `${name}: renderer reported an error`);
+  assert.equal(metrics.rendererBackend, "WebGPU", `${name}: backend changed unexpectedly`);
+  assert.equal(metrics.presented, true, `${name}: frame was not presented`);
+  assert.ok(metrics.drawCalls > 0, `${name}: frame emitted no draw calls`);
+  const screenshot = await page.locator("#scene").screenshot({
+    path: path.join(artifactDir, `${name}.png`),
+  });
+  return { metrics, screenshot };
+}
+
+function changedPixelCount(leftBuffer, rightBuffer) {
+  const left = PNG.sync.read(leftBuffer);
+  const right = PNG.sync.read(rightBuffer);
+  assert.equal(left.width, right.width, "device recovery comparison width mismatch");
+  assert.equal(left.height, right.height, "device recovery comparison height mismatch");
+  let changed = 0;
+  for (let offset = 0; offset < left.data.length; offset += 4) {
+    if (
+      left.data[offset] !== right.data[offset] ||
+      left.data[offset + 1] !== right.data[offset + 1] ||
+      left.data[offset + 2] !== right.data[offset + 2] ||
+      left.data[offset + 3] !== right.data[offset + 3]
+    ) {
+      changed += 1;
+    }
+  }
+  return changed;
+}
+
+async function writeDiagnostics(name, value) {
+  await writeFile(
+    path.join(artifactDir, `${name}.json`),
+    `${JSON.stringify(value, null, 2)}\n`,
+    "utf8",
+  );
+}
+
+let browser = null;
+try {
+  await waitForServer();
+  browser = await chromium.launch({
+    channel: "chromium",
+    headless: true,
+    args: [
+      "--enable-unsafe-webgpu",
+      "--enable-unsafe-swiftshader",
+      "--use-webgpu-adapter=swiftshader",
+      "--use-gpu-in-tests",
+      "--ignore-gpu-blocklist",
+      "--enable-features=Vulkan",
+      "--use-gl=angle",
+      "--use-angle=swiftshader",
+      "--use-vulkan=swiftshader",
+      "--disable-gpu-sandbox",
+      "--disable-dev-shm-usage",
+    ],
+  });
+
+  const page = await browser.newPage({ viewport: { width: 1000, height: 600 } });
+  const browserErrors = collectBrowserErrors(page);
+  await installDeviceCapture(page);
+  const initial = await waitForHarness(page);
+  const captureBefore = await page.evaluate(() => ({
+    patched: window.__noonWebGpuDeviceCapture?.patched ?? false,
+    patchError: window.__noonWebGpuDeviceCapture?.patchError ?? null,
+    deviceCount: window.__noonWebGpuDeviceCapture?.devices.length ?? 0,
+    lost: window.__noonWebGpuDeviceCapture?.lost ?? [],
+  }));
+  assert.equal(captureBefore.patched, true, `WebGPU capture patch failed: ${captureBefore.patchError}`);
+  assert.ok(captureBefore.deviceCount >= 1, "Noon's WebGPU device creation was not captured");
+
+  const baseline = await renderAndCapture(page, "baseline");
+  await page.evaluate(() => {
+    const capture = window.__noonWebGpuDeviceCapture;
+    const device = capture?.devices[0];
+    if (!device) throw new Error("captured Noon GPUDevice is unavailable");
+    device.destroy();
+  });
+  await page.waitForFunction(
+    () => window.__noonWebGpuDeviceCapture?.lost[0] !== null,
+    null,
+    { timeout: 10_000 },
+  );
+
+  const duringLoss = await page.evaluate(() => ({
+    metrics: window.noonSmoke.metrics(),
+    capture: {
+      deviceCount: window.__noonWebGpuDeviceCapture.devices.length,
+      lost: window.__noonWebGpuDeviceCapture.lost,
+    },
+  }));
+  assert.equal(duringLoss.metrics.rendererBackend, "WebGPU", "device loss changed semantic backend identity");
+  assert.equal(duringLoss.metrics.revision, baseline.metrics.revision, "device loss reset scene revision");
+  assert.equal(duringLoss.metrics.objectCount, baseline.metrics.objectCount, "device loss reset scene objects");
+
+  let recovered = null;
+  let lastRecoveryError = null;
+  for (let attempt = 0; attempt < 40 && recovered === null; attempt += 1) {
+    try {
+      const candidate = await page.evaluate((time) => window.noonSmoke.renderAt(time), sampleTime);
+      if (candidate.presented && candidate.rendererBackend === "WebGPU") {
+        recovered = candidate;
+      }
+    } catch (error) {
+      lastRecoveryError = String(error);
+    }
+    if (recovered === null) {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+  }
+  assert.ok(recovered, `WebGPU device did not recover: ${lastRecoveryError ?? "no frame presented"}`);
+  assert.equal(recovered.error, null, "recovered renderer reported an error");
+  assert.equal(recovered.revision, baseline.metrics.revision, "device recovery reset scene revision");
+  assert.equal(recovered.objectCount, baseline.metrics.objectCount, "device recovery reset object count");
+  assert.ok(Math.abs(recovered.time - sampleTime) < 1e-6, "device recovery changed semantic playhead time");
+
+  const recoveryCapture = await page.evaluate(() => {
+    const capture = window.__noonWebGpuDeviceCapture;
+    return {
+      deviceCount: capture.devices.length,
+      lost: capture.lost,
+      replacedDevice: capture.devices.length >= 2 && capture.devices[0] !== capture.devices.at(-1),
+    };
+  });
+  assert.ok(recoveryCapture.deviceCount >= 2, "device recovery did not request a replacement GPUDevice");
+  assert.equal(recoveryCapture.replacedDevice, true, "device recovery reused the lost GPUDevice");
+  assert.equal(recoveryCapture.lost.at(-1), null, "replacement GPUDevice is already lost");
+
+  const recoveredScreenshot = await page.locator("#scene").screenshot({
+    path: path.join(artifactDir, "recovered.png"),
+  });
+
+  const freshPage = await browser.newPage({ viewport: { width: 1000, height: 600 } });
+  const freshErrors = collectBrowserErrors(freshPage);
+  await waitForHarness(freshPage);
+  const fresh = await renderAndCapture(freshPage, "fresh");
+
+  const changedPixels = changedPixelCount(recoveredScreenshot, fresh.screenshot);
+  assert.equal(
+    changedPixels,
+    0,
+    `recovered WebGPU frame differs from fresh renderer at ${changedPixels} pixels`,
+  );
+  assert.equal(fresh.metrics.objectCount, recovered.objectCount, "fresh/recovered object count mismatch");
+  assert.ok(Math.abs(fresh.metrics.time - recovered.time) < 1e-6, "fresh/recovered time mismatch");
+
+  assert.deepEqual(browserErrors.pageErrors, [], "device-loss recovery emitted page errors");
+  assert.deepEqual(freshErrors.pageErrors, [], "fresh comparison renderer emitted page errors");
+  const unexpectedConsoleErrors = browserErrors.consoleErrors.filter(
+    (message) => !/(device.*lost|device.*destroy|destroyed.*device|gpu.*lost)/i.test(message),
+  );
+  assert.deepEqual(
+    unexpectedConsoleErrors,
+    [],
+    `device-loss recovery emitted unexpected console errors:\n${unexpectedConsoleErrors.join("\n")}`,
+  );
+  assert.deepEqual(freshErrors.consoleErrors, [], "fresh comparison renderer emitted console errors");
+
+  await writeDiagnostics("device-loss-recovery", {
+    browserVersion: browser.version(),
+    initial,
+    baseline: baseline.metrics,
+    duringLoss,
+    recovered,
+    fresh: fresh.metrics,
+    captureBefore,
+    recoveryCapture,
+    changedPixels,
+    browserErrors,
+    freshErrors,
+  });
+  await freshPage.close();
+  await page.close();
+  console.log("✓ WebGPU device loss replaces the device and preserves scene, time, and exact output");
+} catch (error) {
+  await writeDiagnostics("failure", {
+    browserVersion: browser?.version() ?? null,
+    error:
+      error instanceof Error
+        ? { name: error.name, message: error.message, stack: error.stack }
+        : String(error),
+    serverOutput,
+  });
+  throw error;
+} finally {
+  await browser?.close();
+  server.kill("SIGTERM");
+}


### PR DESCRIPTION
## Summary
Third deterministic renderer-recovery slice for #111, now directly on master after #423.

- intercept the browser's real WebGPU adapter/device creation before Noon initializes, retaining the actual `GPUDevice` without adding a production test hook
- render a baseline frame, call `GPUDevice.destroy()`, and wait for the real device-lost signal
- require scene revision/object state/backend identity to survive the loss
- require automatic recovery to request a **new** GPUDevice rather than reusing the lost device or stale GPU resources
- render again at the exact same semantic time and require pixel-identical output versus a fresh WebGPU renderer
- reject unexpected page/console errors while allowing the expected device-loss diagnostic
- retain baseline/recovered/fresh screenshots and JSON diagnostics
- extend the dedicated renderer-recovery workflow only; no production renderer changes

## Architecture exercised
#423 established the production recovery boundary: WebGPU loss creates a fresh instance/adapter/device generation while retaining the existing canvas surface, and WebGL context loss rebuilds its full canvas-backed GPU generation. This PR makes the WebGPU path a permanent deterministic browser contract.

## Failure policy
The test uses the browser's real device-loss signal. Do not weaken the invariants or replace it with a synthetic production hook.

Tracks #111.