### PR TITLE
Drop stale Python worker responses safely

### DIFF
--- a/web/authoring-client.js
+++ b/web/authoring-client.js
@@ -13,6 +13,7 @@ export class PythonAuthoringClient {
   #rejectReady;
   #ready = false;
   #terminated = false;
+  #staleResponses = 0;
 
   constructor(worker = createAuthoringWorker()) {
     this.#worker = worker;
@@ -28,6 +29,15 @@ export class PythonAuthoringClient {
 
   get terminated() {
     return this.#terminated;
+  }
+
+  get diagnostics() {
+    return Object.freeze({
+      nextRequestId: this.#nextRequestId,
+      pendingRequests: this.#pending.size,
+      staleResponses: this.#staleResponses,
+      terminated: this.#terminated,
+    });
   }
 
   ready() {
@@ -163,10 +173,15 @@ export class PythonAuthoringClient {
     }
     const pending = this.#pending.get(requestId);
     if (!pending) {
-      throw new Error(`Python authoring response has unknown request ID ${requestId}`);
+      if (requestId < this.#nextRequestId) {
+        this.#staleResponses += 1;
+        return false;
+      }
+      throw new Error(`Python authoring response has unissued request ID ${requestId}`);
     }
     this.#pending.delete(requestId);
     settle(pending);
+    return true;
   }
 
   #fail(error) {

--- a/web/authoring-client.test.mjs
+++ b/web/authoring-client.test.mjs
@@ -250,6 +250,104 @@ test("rejects only the request associated with a Python execution error", async 
   assert.equal(client.terminated, false, "ordinary Python errors keep the worker reusable");
 });
 
+test("accepts pending Python responses that complete out of order", async () => {
+  const worker = new FakeWorker();
+  const client = new PythonAuthoringClient(worker);
+  worker.emit("message", workerMessage("ready"));
+  await client.ready();
+
+  const first = client.run("result = first");
+  const second = client.run("result = second");
+  await Promise.resolve();
+  assert.deepEqual(
+    worker.messages.map(({ requestId }) => requestId),
+    [0, 1],
+  );
+
+  const secondBatch = { version: 1, sequence: 2, patches: [] };
+  worker.emit(
+    "message",
+    workerMessage("result", {
+      requestId: 1,
+      resultJson: JSON.stringify({ kind: "patch_batch", document: secondBatch }),
+    }),
+  );
+  assert.deepEqual(await second, { kind: "patch_batch", document: secondBatch });
+
+  const firstBatch = { version: 1, sequence: 1, patches: [] };
+  worker.emit(
+    "message",
+    workerMessage("result", {
+      requestId: 0,
+      resultJson: JSON.stringify({ kind: "patch_batch", document: firstBatch }),
+    }),
+  );
+  assert.deepEqual(await first, { kind: "patch_batch", document: firstBatch });
+  assert.deepEqual(client.diagnostics, {
+    nextRequestId: 2,
+    pendingRequests: 0,
+    staleResponses: 0,
+    terminated: false,
+  });
+});
+
+test("drops duplicate responses for already-issued requests without killing the worker", async () => {
+  const worker = new FakeWorker();
+  const client = new PythonAuthoringClient(worker);
+  worker.emit("message", workerMessage("ready"));
+  await client.ready();
+
+  const batch = { version: 1, sequence: 0, patches: [] };
+  const resultPromise = client.run("result = batch");
+  await Promise.resolve();
+  const response = workerMessage("result", {
+    requestId: 0,
+    resultJson: JSON.stringify({ kind: "patch_batch", document: batch }),
+  });
+  worker.emit("message", response);
+  assert.deepEqual(await resultPromise, { kind: "patch_batch", document: batch });
+
+  worker.emit("message", response);
+  assert.equal(client.terminated, false);
+  assert.equal(worker.terminated, false);
+  assert.equal(client.diagnostics.staleResponses, 1);
+
+  const retry = client.run("result = retry");
+  await Promise.resolve();
+  worker.emit(
+    "message",
+    workerMessage("result", {
+      requestId: 1,
+      resultJson: JSON.stringify({ kind: "patch_batch", document: batch }),
+    }),
+  );
+  await retry;
+  assert.equal(client.diagnostics.staleResponses, 1);
+});
+
+test("treats never-issued future response IDs as fatal protocol corruption", async () => {
+  const worker = new FakeWorker();
+  const client = new PythonAuthoringClient(worker);
+  worker.emit("message", workerMessage("ready"));
+  await client.ready();
+
+  worker.emit(
+    "message",
+    workerMessage("result", {
+      requestId: 7,
+      resultJson: JSON.stringify({
+        kind: "patch_batch",
+        document: { version: 1, sequence: 0, patches: [] },
+      }),
+    }),
+  );
+
+  assert.equal(client.terminated, true);
+  assert.equal(worker.terminated, true);
+  assert.equal(client.diagnostics.staleResponses, 0);
+  await assert.rejects(client.run("result = retry"), /terminated/);
+});
+
 test("exposes fatal Python worker termination to recovery owners", async () => {
   const worker = new FakeWorker();
   const client = new PythonAuthoringClient(worker);


### PR DESCRIPTION
## Summary
First protocol-adversarial slice for #112.

- accept pending Python authoring responses that complete out of order
- treat duplicate/late responses for request IDs that were genuinely issued but are no longer pending as stale work instead of a fatal worker failure
- expose stale-response diagnostics alongside pending/request state
- keep malformed IDs, malformed payloads/envelopes, and never-issued/future request IDs fatal so protocol corruption is not silently hidden
- prove a stale duplicate does not terminate the worker and a subsequent authoring request still succeeds

## Invariant
Only responses for currently pending issued requests may settle work. A response for a previously issued request may be dropped as stale; a response for an ID the client has never issued remains a protocol error.

This reuses the newest-valid-result model from #397 rather than adding a second sequencing system.

## Scope
This PR intentionally owns only `PythonAuthoringClient` response correlation. Engine/render worker generation epochs and stale events from terminated pre-restart workers remain the next #112 tranche and will avoid the active renderer-loss work in #423/#426.

Tracks #112.