### PR TITLE
Make playground interactive before Python warmup completes

### DIFF
--- a/web/main.js
+++ b/web/main.js
@@ -282,6 +282,7 @@ let player = null;
 let rendererBackend = "";
 let sceneRunPromise = null;
 let playerNeedsRestart = false;
+let startupAutoplayPending = false;
 let busyDepth = 0;
 
 function currentExample() {
@@ -365,12 +366,46 @@ function warmAuthoringClient() {
       }
     },
     () => {
-    if (authoringClient !== client) return;
-    if (client.terminated) {
-      authoringClient = null;
-    }
-    status.dataset.authoringWarmup = "failed";
-  },
+      if (authoringClient !== client) return;
+      if (client.terminated) {
+        authoringClient = null;
+      }
+      status.dataset.authoringWarmup = "failed";
+    },
+  );
+  return client;
+}
+
+function cancelStartupAutoplay(reason = "cancelled") {
+  if (!startupAutoplayPending) return;
+  startupAutoplayPending = false;
+  status.dataset.startupAutoplay = reason;
+}
+
+function scheduleStartupAutoplay(exampleId, client) {
+  startupAutoplayPending = true;
+  status.dataset.startupAutoplay = "waiting";
+  void client.ready().then(
+    () => {
+      if (!startupAutoplayPending) return;
+      if (
+        authoringClient !== client ||
+        selectedExampleId !== exampleId ||
+        sceneRunPromise !== null ||
+        sceneSourceEditor.value !== canonicalSource
+      ) {
+        cancelStartupAutoplay("skipped");
+        return;
+      }
+      startupAutoplayPending = false;
+      status.dataset.startupAutoplay = "running";
+      void runScene().then((result) => {
+        status.dataset.startupAutoplay = result?.error ? "failed" : "settled";
+      });
+    },
+    () => {
+      cancelStartupAutoplay("failed");
+    },
   );
 }
 
@@ -476,6 +511,7 @@ function isCurrentRun(runToken) {
 }
 
 async function runScene() {
+  cancelStartupAutoplay();
   if (sceneRunPromise !== null) return sceneRunPromise;
   const example = currentExample();
   if (!example || !player) return null;
@@ -671,6 +707,7 @@ resetButton.addEventListener("click", async () => {
   patchStatus.dataset.state = "ready";
 });
 sceneSourceEditor.addEventListener("input", () => {
+  cancelStartupAutoplay();
   const example = currentExample();
   if (example) drafts.set(example.id, sceneSourceEditor.value);
   resetButton.disabled = sceneSourceEditor.value === canonicalSource;
@@ -690,7 +727,7 @@ document.addEventListener("keydown", (event) => {
 
 const EMPTY_SCENE_JSON = '{"version":1,"objects":[],"tracks":[]}';
 try {
-  warmAuthoringClient();
+  const startupAuthoringClient = warmAuthoringClient();
   player = new AuthoringExecutionClient(canvas, {
     onError(error) {
       playerNeedsRestart = true;
@@ -709,7 +746,7 @@ try {
     : SCENE_EXAMPLES[0].id;
   history.replaceState({ example: initialExample }, "", exampleUrl(initialExample));
   renderGallery();
-  await selectExample(initialExample, { run: true });
+  await selectExample(initialExample, { run: false });
 
   const initialState = await player.state();
   patchStatus.dataset.sequence = String(initialState.nextPatchSequence);
@@ -737,6 +774,8 @@ try {
       return runScene();
     },
   };
+
+  scheduleStartupAutoplay(initialExample, startupAuthoringClient);
 
   window.addEventListener(
     "pagehide",

--- a/web/playground-startup.test.mjs
+++ b/web/playground-startup.test.mjs
@@ -19,6 +19,49 @@ assert.match(
   "failed eager warmup must discard a dead Python client for the next Run",
 );
 
+const initialSelection = main.indexOf(
+  "await selectExample(initialExample, { run: false });",
+  startupRegion,
+);
+const galleryInstall = main.indexOf("window.__noonExampleGallery =", startupRegion);
+const autoplaySchedule = main.indexOf(
+  "scheduleStartupAutoplay(initialExample, startupAuthoringClient);",
+  startupRegion,
+);
+assert.ok(initialSelection > playerStart, "initial source selection must follow renderer startup");
+assert.ok(galleryInstall > initialSelection, "playground API must install after initial source selection");
+assert.ok(
+  autoplaySchedule > galleryInstall,
+  "initial Python autoplay must be scheduled only after the playground is interactive",
+);
+assert.doesNotMatch(
+  main.slice(startupRegion),
+  /await selectExample\(initialExample, \{ run: true \}\)/,
+  "playground startup must not await Python scene authoring",
+);
+
+const autoplayStart = main.indexOf("function scheduleStartupAutoplay(");
+const executionReadyStart = main.indexOf("async function ensureExecutionReady()", autoplayStart);
+assert.ok(autoplayStart >= 0 && executionReadyStart > autoplayStart, "startup autoplay helper must exist");
+const autoplayBody = main.slice(autoplayStart, executionReadyStart);
+assert.match(autoplayBody, /client\.ready\(\)\.then\(/, "autoplay must wait for warm Python readiness");
+assert.match(autoplayBody, /selectedExampleId !== exampleId/, "autoplay must yield to a newer selection");
+assert.match(autoplayBody, /sceneRunPromise !== null/, "autoplay must yield to a user-started run");
+assert.match(
+  autoplayBody,
+  /sceneSourceEditor\.value !== canonicalSource/,
+  "autoplay must yield to source edits",
+);
+
+const runSceneStart = main.indexOf("async function runScene()");
+const selectExampleStart = main.indexOf("async function selectExample(", runSceneStart);
+assert.ok(runSceneStart >= 0 && selectExampleStart > runSceneStart, "runScene boundary must exist");
+assert.match(
+  main.slice(runSceneStart, selectExampleStart),
+  /cancelStartupAutoplay\(\);/,
+  "an explicit run must cancel pending startup autoplay",
+);
+
 const initializeStart = worker.indexOf("async function initializePyodide()");
 assert.notEqual(initializeStart, -1, "Python worker initializer must exist");
 const firstBarrier = worker.indexOf("await startupResourcesReady;", initializeStart);
@@ -45,4 +88,6 @@ assert.ok(
   "compatibility source preload should cover the full Python compatibility surface",
 );
 
-console.log("✓ playground overlaps renderer, Pyodide, Noon WASM, and compatibility-source cold start");
+console.log(
+  "✓ playground becomes interactive before Python autoplay and overlaps all cold-start resources",
+);


### PR DESCRIPTION
## Summary

Second cold-start slice for the public playground, building on #431.

- keep eager Python/Pyodide warmup, but stop awaiting the initial Python scene during page startup
- load the initial source and install the public gallery API before startup autoplay begins
- schedule initial autoplay only after the warmed Python worker reports ready
- let manual Run, source edits, or a newer example selection cancel pending startup autoplay
- preserve existing autoplay behavior when the user does not interact
- extend the startup contract to pin the interactive-before-Python boundary

## Why

#431 overlaps renderer, Noon WASM, Pyodide, and compatibility-source initialization, but `main.js` still awaited `selectExample(..., { run: true })`. That kept the entire first Python authoring/reconcile path on the module startup critical path and globally marked the playground busy while Pyodide was still cold.

This change keeps the expensive warmup running in parallel while making the renderer, selected source, gallery API, and controls available first. Once Python becomes ready, the original example still autoplays unless the user has already expressed a newer intent.

## Scope

No scene/runtime semantics change after a run starts. No worker topology change. No new dependency. This is intentionally limited to startup ownership and cancellation semantics.