### PR TITLE
Add deterministic playback clock controls

### DIFF
--- a/crates/noon-web/src/clock.rs
+++ b/crates/noon-web/src/clock.rs
@@ -1,6 +1,7 @@
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ClockError {
     InvalidLoopDuration(f64),
+    InvalidSceneTime(f64),
     NonFiniteTimestamp(f64),
     TimestampWentBackwards { previous: f64, actual: f64 },
 }
@@ -10,6 +11,9 @@ impl std::fmt::Display for ClockError {
         match self {
             Self::InvalidLoopDuration(duration) => {
                 write!(formatter, "invalid playback loop duration {duration}")
+            }
+            Self::InvalidSceneTime(time) => {
+                write!(formatter, "invalid playback scene time {time}")
             }
             Self::NonFiniteTimestamp(timestamp) => {
                 write!(formatter, "non-finite animation timestamp {timestamp}")
@@ -26,21 +30,28 @@ impl std::error::Error for ClockError {}
 
 /// Converts monotonic `requestAnimationFrame` timestamps to deterministic scene time.
 ///
-/// Browser scheduling remains outside the semantic runtime: the same timestamp always
-/// produces the same scene time, and resetting the clock establishes a new time origin.
+/// Browser scheduling remains outside the semantic runtime. Playback controls mutate
+/// only the logical clock anchor: pause freezes scene time, resume establishes a fresh
+/// timestamp anchor on the next frame so background/control latency cannot cause a
+/// catch-up jump, and seek establishes a new exact logical phase without replaying
+/// intermediate frames.
 #[derive(Clone, Debug, PartialEq)]
 pub struct PlaybackClock {
     loop_duration: Option<f64>,
-    origin_ms: Option<f64>,
+    anchor_ms: Option<f64>,
+    anchor_scene_time: f64,
     previous_ms: Option<f64>,
+    paused: bool,
 }
 
 impl PlaybackClock {
     pub const fn once() -> Self {
         Self {
             loop_duration: None,
-            origin_ms: None,
+            anchor_ms: None,
+            anchor_scene_time: 0.0,
             previous_ms: None,
+            paused: false,
         }
     }
 
@@ -55,6 +66,108 @@ impl PlaybackClock {
     }
 
     pub fn scene_time(&mut self, timestamp_ms: f64) -> Result<f64, ClockError> {
+        self.validate_timestamp(timestamp_ms)?;
+        self.previous_ms = Some(timestamp_ms);
+
+        if self.paused {
+            return Ok(self.normalize_scene_time(self.anchor_scene_time));
+        }
+
+        let anchor_ms = *self.anchor_ms.get_or_insert(timestamp_ms);
+        let elapsed = (timestamp_ms - anchor_ms) / 1_000.0;
+        Ok(self.normalize_scene_time(self.anchor_scene_time + elapsed))
+    }
+
+    /// Freeze logical scene time at the last accepted animation timestamp.
+    ///
+    /// Calling this before the first frame pauses at the current logical anchor (zero
+    /// for a fresh clock). Repeated calls are idempotent.
+    pub fn pause(&mut self) {
+        if self.paused {
+            return;
+        }
+        self.anchor_scene_time = self.current_time();
+        self.anchor_ms = self.previous_ms;
+        self.paused = true;
+    }
+
+    /// Resume playback without charging wall-clock time spent paused.
+    ///
+    /// The next accepted frame becomes a fresh timestamp anchor and therefore returns
+    /// the exact paused scene time. Following frames advance normally from that point.
+    pub fn resume(&mut self) {
+        if !self.paused {
+            return;
+        }
+        self.paused = false;
+        self.anchor_ms = None;
+    }
+
+    /// Re-anchor playback at an absolute logical scene time.
+    ///
+    /// Looping clocks normalize the requested time into their loop phase. Non-looping
+    /// clocks require a finite, non-negative time. The next frame returns the exact
+    /// sought phase before subsequent timestamps advance it (unless paused).
+    pub fn seek(&mut self, scene_time: f64) -> Result<f64, ClockError> {
+        if !scene_time.is_finite() || scene_time < 0.0 {
+            return Err(ClockError::InvalidSceneTime(scene_time));
+        }
+        let scene_time = self.normalize_scene_time(scene_time);
+        self.anchor_scene_time = scene_time;
+        self.anchor_ms = if self.paused { self.previous_ms } else { None };
+        Ok(scene_time)
+    }
+
+    pub fn set_loop_duration(&mut self, duration: f64) -> Result<(), ClockError> {
+        if !duration.is_finite() || duration <= 0.0 {
+            return Err(ClockError::InvalidLoopDuration(duration));
+        }
+
+        // `anchor_ms == None` while running is meaningful: the next RAF is waiting to
+        // establish a fresh wall-clock anchor after initial start, resume, or seek. A
+        // retime in that window must preserve the pending re-anchor or it can charge
+        // paused/control latency back into logical scene time.
+        let reanchor_on_next_frame = !self.paused && self.anchor_ms.is_none();
+        let current_time = self.current_time();
+        self.loop_duration = Some(duration);
+        self.anchor_scene_time = current_time.rem_euclid(duration);
+        self.anchor_ms = if reanchor_on_next_frame {
+            None
+        } else {
+            self.previous_ms
+        };
+        Ok(())
+    }
+
+    /// Reset to a running clock at scene time zero with no timestamp origin.
+    pub fn reset(&mut self) {
+        self.anchor_ms = None;
+        self.anchor_scene_time = 0.0;
+        self.previous_ms = None;
+        self.paused = false;
+    }
+
+    pub const fn loop_duration(&self) -> Option<f64> {
+        self.loop_duration
+    }
+
+    pub const fn is_paused(&self) -> bool {
+        self.paused
+    }
+
+    /// Return logical time at the latest accepted frame without mutating the clock.
+    pub fn current_time(&self) -> f64 {
+        if self.paused {
+            return self.normalize_scene_time(self.anchor_scene_time);
+        }
+        let elapsed = match (self.anchor_ms, self.previous_ms) {
+            (Some(anchor), Some(previous)) => (previous - anchor) / 1_000.0,
+            _ => 0.0,
+        };
+        self.normalize_scene_time(self.anchor_scene_time + elapsed)
+    }
+
+    fn validate_timestamp(&self, timestamp_ms: f64) -> Result<(), ClockError> {
         if !timestamp_ms.is_finite() {
             return Err(ClockError::NonFiniteTimestamp(timestamp_ms));
         }
@@ -66,41 +179,14 @@ impl PlaybackClock {
                 });
             }
         }
-
-        let origin = *self.origin_ms.get_or_insert(timestamp_ms);
-        self.previous_ms = Some(timestamp_ms);
-        let elapsed = (timestamp_ms - origin) / 1_000.0;
-        Ok(match self.loop_duration {
-            Some(duration) => elapsed.rem_euclid(duration),
-            None => elapsed,
-        })
-    }
-
-    pub fn set_loop_duration(&mut self, duration: f64) -> Result<(), ClockError> {
-        if !duration.is_finite() || duration <= 0.0 {
-            return Err(ClockError::InvalidLoopDuration(duration));
-        }
-
-        if let (Some(origin), Some(previous)) = (self.origin_ms, self.previous_ms) {
-            let elapsed = (previous - origin) / 1_000.0;
-            let current_time = match self.loop_duration {
-                Some(previous_duration) => elapsed.rem_euclid(previous_duration),
-                None => elapsed,
-            };
-            let phase = current_time.rem_euclid(duration);
-            self.origin_ms = Some(previous - phase * 1_000.0);
-        }
-        self.loop_duration = Some(duration);
         Ok(())
     }
 
-    pub fn reset(&mut self) {
-        self.origin_ms = None;
-        self.previous_ms = None;
-    }
-
-    pub const fn loop_duration(&self) -> Option<f64> {
-        self.loop_duration
+    fn normalize_scene_time(&self, scene_time: f64) -> f64 {
+        match self.loop_duration {
+            Some(duration) => scene_time.rem_euclid(duration),
+            None => scene_time,
+        }
     }
 }
 
@@ -156,12 +242,127 @@ mod tests {
     }
 
     #[test]
-    fn reset_establishes_a_new_time_origin() {
+    fn pause_freezes_time_while_timestamps_continue() {
+        let mut clock = PlaybackClock::looping(4.0).expect("valid loop");
+        assert_eq!(clock.scene_time(100.0).unwrap(), 0.0);
+        assert_eq!(clock.scene_time(600.0).unwrap(), 0.5);
+
+        clock.pause();
+        assert!(clock.is_paused());
+        assert_eq!(clock.current_time(), 0.5);
+        assert_eq!(clock.scene_time(1_600.0).unwrap(), 0.5);
+        assert_eq!(clock.scene_time(4_600.0).unwrap(), 0.5);
+        assert_eq!(clock.current_time(), 0.5);
+    }
+
+    #[test]
+    fn resume_reanchors_on_next_frame_without_catch_up_jump() {
+        let mut clock = PlaybackClock::looping(4.0).expect("valid loop");
+        clock.scene_time(100.0).unwrap();
+        assert_eq!(clock.scene_time(600.0).unwrap(), 0.5);
+        clock.pause();
+        assert_eq!(clock.scene_time(5_600.0).unwrap(), 0.5);
+
+        clock.resume();
+        assert!(!clock.is_paused());
+        assert_eq!(clock.scene_time(6_000.0).unwrap(), 0.5);
+        assert_eq!(clock.scene_time(6_250.0).unwrap(), 0.75);
+    }
+
+    #[test]
+    fn seek_reanchors_running_clock_at_exact_requested_phase() {
+        let mut clock = PlaybackClock::looping(4.0).expect("valid loop");
+        clock.scene_time(100.0).unwrap();
+        clock.scene_time(600.0).unwrap();
+
+        assert_eq!(clock.seek(2.25).unwrap(), 2.25);
+        assert_eq!(clock.current_time(), 2.25);
+        assert_eq!(clock.scene_time(900.0).unwrap(), 2.25);
+        assert_eq!(clock.scene_time(1_150.0).unwrap(), 2.5);
+    }
+
+    #[test]
+    fn seek_while_paused_updates_frozen_phase_and_resume_starts_there() {
+        let mut clock = PlaybackClock::looping(4.0).expect("valid loop");
+        clock.scene_time(100.0).unwrap();
+        clock.scene_time(600.0).unwrap();
+        clock.pause();
+
+        assert_eq!(clock.seek(3.25).unwrap(), 3.25);
+        assert_eq!(clock.scene_time(2_000.0).unwrap(), 3.25);
+        clock.resume();
+        assert_eq!(clock.scene_time(2_500.0).unwrap(), 3.25);
+        assert_eq!(clock.scene_time(2_750.0).unwrap(), 3.5);
+    }
+
+    #[test]
+    fn looping_seek_normalizes_phase_and_once_seek_rejects_invalid_time() {
+        let mut looping = PlaybackClock::looping(4.0).unwrap();
+        assert_eq!(looping.seek(9.5).unwrap(), 1.5);
+
+        let mut once = PlaybackClock::once();
+        assert_eq!(once.seek(9.5).unwrap(), 9.5);
+        assert!(matches!(
+            once.seek(-0.1),
+            Err(ClockError::InvalidSceneTime(time)) if time == -0.1
+        ));
+        assert!(matches!(
+            once.seek(f64::NAN),
+            Err(ClockError::InvalidSceneTime(time)) if time.is_nan()
+        ));
+    }
+
+    #[test]
+    fn retiming_paused_clock_preserves_frozen_phase() {
+        let mut clock = PlaybackClock::looping(5.0).unwrap();
+        clock.scene_time(100.0).unwrap();
+        clock.scene_time(3_600.0).unwrap();
+        clock.pause();
+
+        clock.set_loop_duration(2.0).unwrap();
+        assert_eq!(clock.current_time(), 1.5);
+        assert_eq!(clock.scene_time(8_000.0).unwrap(), 1.5);
+    }
+
+    #[test]
+    fn retiming_during_pending_resume_preserves_no_jump_reanchor() {
+        let mut clock = PlaybackClock::looping(5.0).unwrap();
+        clock.scene_time(100.0).unwrap();
+        clock.scene_time(1_100.0).unwrap();
+        clock.pause();
+        clock.scene_time(6_100.0).unwrap();
+        clock.resume();
+
+        clock.set_loop_duration(3.0).unwrap();
+        assert_eq!(clock.current_time(), 1.0);
+        assert_eq!(clock.scene_time(7_000.0).unwrap(), 1.0);
+        assert_eq!(clock.scene_time(7_250.0).unwrap(), 1.25);
+    }
+
+    #[test]
+    fn retiming_during_pending_seek_preserves_exact_next_frame_phase() {
+        let mut clock = PlaybackClock::looping(5.0).unwrap();
+        clock.scene_time(100.0).unwrap();
+        clock.scene_time(1_100.0).unwrap();
+        clock.seek(2.5).unwrap();
+
+        clock.set_loop_duration(4.0).unwrap();
+        assert_eq!(clock.current_time(), 2.5);
+        assert_eq!(clock.scene_time(4_000.0).unwrap(), 2.5);
+        assert_eq!(clock.scene_time(4_500.0).unwrap(), 3.0);
+    }
+
+    #[test]
+    fn reset_establishes_a_running_zero_time_origin() {
         let mut clock = PlaybackClock::once();
         clock.scene_time(100.0).expect("valid frame");
         clock.scene_time(600.0).expect("valid frame");
+        clock.pause();
+        clock.seek(2.0).unwrap();
         clock.reset();
 
+        assert!(!clock.is_paused());
+        assert_eq!(clock.current_time(), 0.0);
         assert_eq!(clock.scene_time(20.0).expect("valid frame"), 0.0);
     }
 


### PR DESCRIPTION
Superseded by merged #467 (integrated playback runtime controls) and #454 (deterministic re-anchoring, semantic restart, and callback-safe seek/restart hardening). This stacked draft is retained only for historical context.