### PR TITLE
Keep text resource mutation transactional on version exhaustion

### DIFF
--- a/crates/noon-core/src/text_resources.rs
+++ b/crates/noon-core/src/text_resources.rs
@@ -579,15 +579,20 @@ impl TextResourceArena {
                 .entries
                 .get_mut(index)
                 .ok_or(TextResourceError::UnknownResource(id))?;
-            let previous = entry
+            entry
                 .value
-                .take()
+                .as_ref()
                 .ok_or(TextResourceError::UnknownResource(id))?;
-            entry.version = entry
+            let version = entry
                 .version
                 .checked_add(1)
                 .ok_or(TextResourceError::VersionExhausted(id))?;
-            (entry.version, previous)
+            let previous = entry
+                .value
+                .take()
+                .expect("text resource presence was preflighted");
+            entry.version = version;
+            (version, previous)
         };
 
         self.subtract_stats(previous.as_ref());
@@ -603,14 +608,19 @@ impl TextResourceArena {
                 .entries
                 .get_mut(index)
                 .ok_or(TextResourceError::UnknownResource(id))?;
-            let resource = entry
+            entry
                 .value
-                .take()
+                .as_ref()
                 .ok_or(TextResourceError::UnknownResource(id))?;
-            entry.version = entry
+            let version = entry
                 .version
                 .checked_add(1)
                 .ok_or(TextResourceError::VersionExhausted(id))?;
+            let resource = entry
+                .value
+                .take()
+                .expect("text resource presence was preflighted");
+            entry.version = version;
             resource
         };
 
@@ -766,6 +776,40 @@ mod tests {
         assert!(arena.get(first).is_none());
         assert_eq!(arena.get(second).unwrap().source.as_ref(), "x^2");
         assert_eq!(arena.stats().glyphs, 3);
+    }
+
+    #[test]
+    fn replacement_version_exhaustion_leaves_resource_and_stats_unchanged() {
+        let mut arena = TextResourceArena::new();
+        let inserted = arena.insert(sample_text("x")).unwrap();
+        arena.entries[inserted.id.get() as usize].version = u64::MAX;
+        let current = arena.current_handle(inserted.id).unwrap();
+        let stats = arena.stats();
+
+        assert_eq!(
+            arena.replace(inserted.id, sample_text("replacement")),
+            Err(TextResourceError::VersionExhausted(inserted.id))
+        );
+        assert_eq!(arena.current_handle(inserted.id), Some(current));
+        assert_eq!(arena.stats(), stats);
+        assert_eq!(arena.get(current).unwrap().source.as_ref(), "x");
+    }
+
+    #[test]
+    fn removal_version_exhaustion_leaves_resource_and_stats_unchanged() {
+        let mut arena = TextResourceArena::new();
+        let inserted = arena.insert(sample_text("xyz")).unwrap();
+        arena.entries[inserted.id.get() as usize].version = u64::MAX;
+        let current = arena.current_handle(inserted.id).unwrap();
+        let stats = arena.stats();
+
+        assert!(matches!(
+            arena.remove(inserted.id),
+            Err(TextResourceError::VersionExhausted(id)) if id == inserted.id
+        ));
+        assert_eq!(arena.current_handle(inserted.id), Some(current));
+        assert_eq!(arena.stats(), stats);
+        assert_eq!(arena.get(current).unwrap().source.as_ref(), "xyz");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- preflight `TextResourceArena` liveness and version capacity before mutating a retained text entry
- prevent `replace` and `remove` from taking the live `Arc<TextResource>` before a possible `VersionExhausted` error
- preserve the existing validation and `UnknownResource` error precedence
- add focused exhaustion regressions proving the current handle, payload, live count, retained bytes, glyph count, vector count, and part count remain unchanged after failed mutation

## Why
`TextResourceArena::{replace,remove}` previously called `entry.value.take()` before `checked_add(1)`. If the resource version had reached `u64::MAX`, the operation returned `VersionExhausted` after already removing the live payload. `remove` could therefore tombstone a live resource on an error path, while `replace` could leave the entry empty even though the replacement never committed.

This is the text-resource sibling of the geometry-arena invariant addressed independently by #445. It matters directly to the transactional/stale-generation guarantees required by #368 and the failed-mutation leak/churn contracts in #114.

## Architecture
The arena remains the single owner of resource generation. The fix does not add a second transaction layer or change handles/protocols: it simply orders fallible checks before mutation. Once liveness and `next_version` are established, taking the old immutable resource, advancing the version, and updating deterministic accounting are infallible arena-local operations.

## Parallelism
Only `crates/noon-core/src/text_resources.rs` changes. This does not overlap #392 (`reactive.rs` / `resource_mutation.rs`), #445 (`resource_arena.rs`), renderer recovery, browser worker races, playback controls, or retained-renderer performance branches.

## Validation
The branch is one commit directly on current master. The commit diff is isolated to the two mutation methods plus two unit regressions; normal `noon-core`/workspace CI will exercise the tests.

Tracks #368 and #114.