### PR TITLE
Surface recoverable playground callback errors

### DIFF
--- a/web/authoring-execution-client.js
+++ b/web/authoring-execution-client.js
@@ -30,18 +30,23 @@ export class AuthoringExecutionClient {
   #transportMode = null;
   #sharedSlotCapacity = DEFAULT_SHARED_SLOT_CAPACITY;
   #onError;
+  #onRecoverableError;
   #resizeObserver = null;
   #transition = null;
 
-  constructor(canvas, { onError = null } = {}) {
+  constructor(canvas, { onError = null, onRecoverableError = null } = {}) {
     if (!(canvas instanceof HTMLCanvasElement)) {
       throw new TypeError("AuthoringExecutionClient requires an HTMLCanvasElement");
     }
     if (onError !== null && typeof onError !== "function") {
       throw new TypeError("AuthoringExecutionClient onError must be a function");
     }
+    if (onRecoverableError !== null && typeof onRecoverableError !== "function") {
+      throw new TypeError("AuthoringExecutionClient onRecoverableError must be a function");
+    }
     this.#canvas = canvas;
     this.#onError = onError;
+    this.#onRecoverableError = onRecoverableError;
     this.#observeCanvas();
   }
 
@@ -199,7 +204,10 @@ export class AuthoringExecutionClient {
   }
 
   async #startLegacy(sceneJson, options) {
-    const player = new ExecutionWorkerClient(this.#canvas, { onError: this.#onError });
+    const player = new ExecutionWorkerClient(this.#canvas, {
+      onError: this.#onError,
+      onRecoverableError: this.#onRecoverableError,
+    });
     try {
       const ready = await player.start(sceneJson, options);
       this.#player = player;
@@ -244,7 +252,10 @@ export class AuthoringExecutionClient {
 
   async #rebuildLegacy(sceneJson, { callbacks, authoringClient }) {
     const canvas = this.#replaceTransferredCanvas();
-    const player = new ExecutionWorkerClient(canvas, { onError: this.#onError });
+    const player = new ExecutionWorkerClient(canvas, {
+      onError: this.#onError,
+      onRecoverableError: this.#onRecoverableError,
+    });
     try {
       const ready = await player.start(sceneJson, {
         loopDurationSeconds: this.#loopDurationSeconds,

--- a/web/main.js
+++ b/web/main.js
@@ -330,6 +330,12 @@ function showSceneError(error) {
   patchStatus.dataset.state = "error";
 }
 
+function showRecoverableSceneError(error) {
+  console.warn("Recoverable Python callback error", error);
+  patchStatus.value = `Python callback failed: ${error}`;
+  patchStatus.dataset.state = "error";
+}
+
 function recordStale(token, stage) {
   const diagnostics = generations.recordStale(token, stage);
   status.dataset.staleResults = String(diagnostics.staleDrops);
@@ -732,6 +738,9 @@ try {
     onError(error) {
       playerNeedsRestart = true;
       showError(error);
+    },
+    onRecoverableError(error) {
+      showRecoverableSceneError(error);
     },
   });
   const ready = await player.start(EMPTY_SCENE_JSON, { loopDurationSeconds: 4.0 });

--- a/web/playground-stability-boundary.test.mjs
+++ b/web/playground-stability-boundary.test.mjs
@@ -5,6 +5,11 @@ const executionClient = await readFile(
   new URL("./execution-worker-client.js", import.meta.url),
   "utf8",
 );
+const authoringExecutionClient = await readFile(
+  new URL("./authoring-execution-client.js", import.meta.url),
+  "utf8",
+);
+const main = await readFile(new URL("./main.js", import.meta.url), "utf8");
 const pagesWorkflow = await readFile(
   new URL("../.github/workflows/pages.yml", import.meta.url),
   "utf8",
@@ -31,9 +36,41 @@ assert.match(
   "execution client must expose distinct fatal and recoverable error callbacks",
 );
 assert.match(
+  authoringExecutionClient,
+  /constructor\(canvas, \{ onError = null, onRecoverableError = null \} = \{\}\)/,
+  "authoring execution must preserve the recoverable error callback boundary",
+);
+assert.ok(
+  (authoringExecutionClient.match(/onRecoverableError: this\.#onRecoverableError/g) ?? []).length >= 2,
+  "legacy authoring execution must forward recoverable errors on initial start and rebuild",
+);
+
+const playgroundConstruction = main.match(
+  /player = new AuthoringExecutionClient\(canvas, \{([\s\S]*?)\n\s*\}\);/,
+)?.[1];
+assert.ok(playgroundConstruction, "playground must configure its authoring execution client");
+assert.match(
+  playgroundConstruction,
+  /onRecoverableError\(error\) \{\s*showRecoverableSceneError\(error\);\s*\}/,
+  "recoverable execution errors must be presented as scene errors",
+);
+const recoverableHandler = playgroundConstruction.match(
+  /onRecoverableError\(error\) \{([\s\S]*?)\n\s*\}/,
+)?.[1];
+assert.doesNotMatch(
+  recoverableHandler ?? "",
+  /playerNeedsRestart\s*=\s*true/,
+  "recoverable scene errors must not request worker restart",
+);
+assert.match(
+  main,
+  /function showRecoverableSceneError\(error\) \{\s*console\.warn\([\s\S]*?patchStatus\.dataset\.state = "error";/,
+  "recoverable callback errors must be visible without becoming fatal console errors",
+);
+assert.match(
   pagesWorkflow,
   /concurrency:\s*\n\s*group: pages\s*\n\s*cancel-in-progress: true/,
   "superseded playground deployments must be cancelled",
 );
 
-console.log("✓ playground keeps recoverable scene errors and deployments inside stable boundaries");
+console.log("✓ playground keeps recoverable scene errors visible and outside fatal recovery");


### PR DESCRIPTION
## Summary

Complete the recoverable error boundary introduced by #428 without reintroducing destructive runtime restarts.

- propagate `onRecoverableError` through `AuthoringExecutionClient` into legacy execution on initial start and rebuild
- show recoverable Python/updater callback failures in the playground status UI
- log those failures as warnings rather than fatal console errors
- keep `playerNeedsRestart` exclusively on the fatal `onError` path
- extend the stability contract to pin the callback routing and UI boundary

## Why

#428 correctly stopped `host_callback_error` from entering the fatal worker-restart path, but `AuthoringExecutionClient` did not expose/forward the recoverable callback. The public playground therefore fell back to a console warning with no visible scene error, making updater failures look like silent broken animation.

This keeps the runtime alive while making the failure actionable to the user. It does not change worker topology, restart mechanics, or scene reconciliation semantics.