### PR TITLE
Expose retained playback worker controls

### DIFF
--- a/crates/noon-web/src/retained_authoring_player.rs
+++ b/crates/noon-web/src/retained_authoring_player.rs
@@ -679,7 +679,10 @@ mod tests {
         )
         .unwrap();
         assert_eq!(restart.time, 0.0);
-        assert!(engine.is_paused(), "restart preserves transport play/pause state");
+        assert!(
+            engine.is_paused(),
+            "restart preserves transport play/pause state"
+        );
         assert_eq!(engine.resource_bundle_bytes(), resources);
     }
 }

--- a/crates/noon-web/src/retained_authoring_player.rs
+++ b/crates/noon-web/src/retained_authoring_player.rs
@@ -199,10 +199,7 @@ impl RetainedAuthoringEnginePlayer {
         timestamp_ms: f64,
     ) -> Result<Option<String>, RetainedAuthoringPlayerError> {
         let scene_time = self.clock.scene_time(timestamp_ms)?;
-        self.player
-            .evaluate_delta(scene_time)?
-            .map(|delta| serde_json::to_string(&delta).map_err(RetainedAuthoringPlayerError::from))
-            .transpose()
+        self.evaluate_scene_time_delta_json(scene_time)
     }
 
     pub fn set_loop_duration(&mut self, duration: f64) -> Result<(), RetainedAuthoringPlayerError> {
@@ -210,8 +207,48 @@ impl RetainedAuthoringEnginePlayer {
         Ok(())
     }
 
+    /// Freeze logical playback without changing the retained scene/resource generation.
+    pub fn pause_playback(&mut self) {
+        self.clock.pause();
+    }
+
+    /// Resume from the frozen logical phase. The next browser tick re-anchors wall time.
+    pub fn resume_playback(&mut self) {
+        self.clock.resume();
+    }
+
+    /// Evaluate an exact logical scene time immediately, without replaying intermediate frames.
+    pub fn seek_playback_delta_json(
+        &mut self,
+        scene_time: f64,
+    ) -> Result<Option<String>, RetainedAuthoringPlayerError> {
+        let scene_time = self.clock.seek(scene_time)?;
+        self.evaluate_scene_time_delta_json(scene_time)
+    }
+
+    /// Return to scene time zero while preserving the current paused/running state.
+    pub fn restart_playback_delta_json(
+        &mut self,
+    ) -> Result<Option<String>, RetainedAuthoringPlayerError> {
+        self.seek_playback_delta_json(0.0)
+    }
+
+    pub const fn is_paused(&self) -> bool {
+        self.clock.is_paused()
+    }
+
     pub fn time(&self) -> f64 {
         self.player.frame().time
+    }
+
+    fn evaluate_scene_time_delta_json(
+        &mut self,
+        scene_time: f64,
+    ) -> Result<Option<String>, RetainedAuthoringPlayerError> {
+        self.player
+            .evaluate_delta(scene_time)?
+            .map(|delta| serde_json::to_string(&delta).map_err(RetainedAuthoringPlayerError::from))
+            .transpose()
     }
 }
 
@@ -333,6 +370,36 @@ mod wasm {
         #[wasm_bindgen(js_name = setLoopDurationSeconds)]
         pub fn set_loop_duration_seconds(&mut self, duration: f64) -> Result<(), JsValue> {
             self.inner.set_loop_duration(duration).map_err(js_error)
+        }
+
+        #[wasm_bindgen(js_name = pausePlayback)]
+        pub fn pause_playback(&mut self) {
+            self.inner.pause_playback();
+        }
+
+        #[wasm_bindgen(js_name = resumePlayback)]
+        pub fn resume_playback(&mut self) {
+            self.inner.resume_playback();
+        }
+
+        #[wasm_bindgen(js_name = seekPlaybackDeltaJson)]
+        pub fn seek_playback_delta_json(
+            &mut self,
+            scene_time: f64,
+        ) -> Result<Option<String>, JsValue> {
+            self.inner
+                .seek_playback_delta_json(scene_time)
+                .map_err(js_error)
+        }
+
+        #[wasm_bindgen(js_name = restartPlaybackDeltaJson)]
+        pub fn restart_playback_delta_json(&mut self) -> Result<Option<String>, JsValue> {
+            self.inner.restart_playback_delta_json().map_err(js_error)
+        }
+
+        #[wasm_bindgen(js_name = isPaused)]
+        pub fn is_paused(&self) -> bool {
+            self.inner.is_paused()
         }
 
         #[wasm_bindgen(js_name = legacySceneJson)]
@@ -542,5 +609,77 @@ mod tests {
         assert!(!engine.resource_bundle_bytes().is_empty());
         assert_eq!(engine.legacy_scene_json(), legacy_json);
         assert_eq!(engine.retained_document_json(), retained_json);
+    }
+
+    #[test]
+    fn retained_engine_playback_controls_preserve_resource_generation_and_exact_phase() {
+        let mut legacy = SceneDefinition::new();
+        let circle = legacy.add(GeometryRef::circle(0.25));
+        legacy
+            .animate_position(
+                circle,
+                Vec2::ZERO,
+                Vec2::new(2.0, 0.0),
+                TrackTiming::new(0.0, 2.0, RateFunction::Linear),
+            )
+            .unwrap();
+        let text_id = ObjectId::new(1_u64 << 52);
+        let retained = text_document("controls", false, 1, text_id);
+        let legacy_json = noon_ir::encode_scene(&legacy).unwrap();
+        let retained_json = retained.to_json().unwrap();
+        let mut engine =
+            RetainedAuthoringEnginePlayer::new(&legacy_json, &retained_json, 4.0, 32).unwrap();
+        let resources = engine.resource_bundle_bytes().to_vec();
+
+        engine.initial_delta_json().unwrap();
+        assert!(engine.tick_delta_json(100.0).unwrap().is_none());
+        assert!(engine.tick_delta_json(600.0).unwrap().is_some());
+        assert!((engine.time() - 0.5).abs() < 1.0e-9);
+
+        engine.pause_playback();
+        assert!(engine.is_paused());
+        assert!(engine.tick_delta_json(5_600.0).unwrap().is_none());
+        assert!((engine.time() - 0.5).abs() < 1.0e-9);
+
+        engine.resume_playback();
+        assert!(!engine.is_paused());
+        assert!(engine.tick_delta_json(6_000.0).unwrap().is_none());
+        assert!((engine.time() - 0.5).abs() < 1.0e-9);
+        assert!(engine.tick_delta_json(6_250.0).unwrap().is_some());
+        assert!((engine.time() - 0.75).abs() < 1.0e-9);
+
+        let seek: RetainedExecutionDeltaEnvelope = serde_json::from_str(
+            &engine
+                .seek_playback_delta_json(1.25)
+                .unwrap()
+                .expect("forward seek must change animated geometry"),
+        )
+        .unwrap();
+        assert!((seek.time - 1.25).abs() < 1.0e-9);
+        assert!(!seek.snapshot);
+        assert!((engine.time() - 1.25).abs() < 1.0e-9);
+
+        let rewind: RetainedExecutionDeltaEnvelope = serde_json::from_str(
+            &engine
+                .seek_playback_delta_json(0.25)
+                .unwrap()
+                .expect("backward seek must resynchronize retained runtime"),
+        )
+        .unwrap();
+        assert!((rewind.time - 0.25).abs() < 1.0e-9);
+        assert!(rewind.snapshot);
+        assert_eq!(engine.resource_bundle_bytes(), resources);
+
+        engine.pause_playback();
+        let restart: RetainedExecutionDeltaEnvelope = serde_json::from_str(
+            &engine
+                .restart_playback_delta_json()
+                .unwrap()
+                .expect("restart from nonzero time must produce a delta"),
+        )
+        .unwrap();
+        assert_eq!(restart.time, 0.0);
+        assert!(engine.is_paused(), "restart preserves transport play/pause state");
+        assert_eq!(engine.resource_bundle_bytes(), resources);
     }
 }

--- a/scripts/retained-execution-worker-smoke.mjs
+++ b/scripts/retained-execution-worker-smoke.mjs
@@ -170,6 +170,7 @@ async function runMode(browser, transportMode) {
   assert.ok(before.metrics.bytesUploaded > 0, `${transportMode}: mixed retained scene uploaded no GPU data`);
   assert.equal(before.engineMetrics.retained, true);
   assert.equal(before.engineMetrics.mixed, true);
+  assert.equal(before.engineMetrics.paused, false);
   assert.equal(before.engineMetrics.resourceBundleTransfers, 1);
   assert.ok(before.engineMetrics.resourceBundleBytes > 0);
   assert.ok(before.engineMetrics.time > 0, `${transportMode}: mixed retained engine playhead did not advance`);
@@ -182,6 +183,56 @@ async function runMode(browser, transportMode) {
   assert.deepEqual(retainedDocument.objects.map((object) => object.object), [textA, textB]);
   assert.deepEqual(retainedDocument.objects.map((object) => object.order), [1, 4]);
   assert.equal(state.nextPatchSequence, "0");
+  assert.equal(state.paused, false);
+
+  const paused = await page.evaluate(() => window.retainedExecutionSmoke.client.pausePlayback());
+  assert.equal(paused.operation, "pause_playback");
+  assert.equal(paused.paused, true);
+  const pausedTime = paused.time;
+  await page.waitForTimeout(350);
+  const stillPaused = await page.evaluate(() => window.retainedExecutionSmoke.client.state());
+  assert.equal(stillPaused.paused, true);
+  assert.equal(stillPaused.time, pausedTime, `${transportMode}: paused playhead advanced`);
+
+  const sought = await page.evaluate(() => window.retainedExecutionSmoke.client.seekPlayback(1.25));
+  assert.equal(sought.operation, "seek_playback");
+  assert.equal(sought.paused, true);
+  assert.ok(Math.abs(sought.time - 1.25) < 1e-9, `${transportMode}: seek was not exact`);
+  await page.waitForTimeout(100);
+  const afterSeek = await page.evaluate(() => window.retainedExecutionSmoke.client.metrics());
+  assert.equal(afterSeek.engineMetrics.paused, true);
+  assert.ok(Math.abs(afterSeek.engineMetrics.time - 1.25) < 1e-9);
+  assert.equal(afterSeek.engineMetrics.resourceBundleTransfers, 1);
+  assert.equal(afterSeek.metrics.objectCount, 6);
+
+  const restartedPlayback = await page.evaluate(() =>
+    window.retainedExecutionSmoke.client.restartPlayback(),
+  );
+  assert.equal(restartedPlayback.operation, "restart_playback");
+  assert.equal(restartedPlayback.paused, true);
+  assert.equal(restartedPlayback.time, 0);
+
+  const resumed = await page.evaluate(() => window.retainedExecutionSmoke.client.resumePlayback());
+  assert.equal(resumed.operation, "resume_playback");
+  assert.equal(resumed.paused, false);
+  assert.equal(resumed.time, 0);
+  await page.waitForTimeout(250);
+  const afterResume = await page.evaluate(() => window.retainedExecutionSmoke.client.state());
+  assert.equal(afterResume.paused, false);
+  assert.ok(
+    afterResume.time > 0 && afterResume.time < 0.75,
+    `${transportMode}: resume caught up across paused wall time: ${afterResume.time}`,
+  );
+
+  const invalidSeek = await page.evaluate(async () => {
+    try {
+      await window.retainedExecutionSmoke.client.seekPlayback(-0.1);
+      return null;
+    } catch (error) {
+      return String(error);
+    }
+  });
+  assert.match(invalidSeek, /finite and non-negative/);
 
   const retimed = await page.evaluate(() =>
     window.retainedExecutionSmoke.client.setLoopDurationSeconds(0.9),
@@ -193,6 +244,8 @@ async function runMode(browser, transportMode) {
   assert.equal(afterRetime.engineMetrics.resourceBundleTransfers, 1);
   assert.equal(afterRetime.metrics.objectCount, 6);
 
+  // `restart()` remains the separate worker/canvas recovery operation. Playback restart
+  // above must not increment the session; recovery deliberately creates session 2.
   const restarted = await page.evaluate(() => window.retainedExecutionSmoke.client.restart());
   assert.equal(restarted.session, 2);
   assert.equal(restarted.transportMode, transportMode);
@@ -202,6 +255,7 @@ async function runMode(browser, transportMode) {
   const afterRestart = await page.evaluate(() => window.retainedExecutionSmoke.client.metrics());
   assert.equal(afterRestart.metrics.ready, true);
   assert.equal(afterRestart.metrics.objectCount, 6);
+  assert.equal(afterRestart.engineMetrics.paused, false);
   assert.equal(afterRestart.engineMetrics.resourceBundleTransfers, 1);
   assert.ok(afterRestart.engineMetrics.resourceBundleBytes > 0);
 
@@ -212,7 +266,7 @@ async function runMode(browser, transportMode) {
   await page.close();
   console.log(
     `✓ mixed retained execution workers ${transportMode}: ${before.metrics.backend}, ` +
-      `${before.engineMetrics.resourceBundleBytes} resource bytes`,
+      `${before.engineMetrics.resourceBundleBytes} resource bytes + deterministic playback controls`,
   );
 }
 

--- a/web/retained-execution-engine-worker.js
+++ b/web/retained-execution-engine-worker.js
@@ -15,6 +15,7 @@ let transportMode = null;
 let transport = null;
 let player = null;
 let latestTick = null;
+let controlQueue = [];
 let initialized = false;
 let stopped = false;
 let resourceBundleBytes = 0;
@@ -31,16 +32,18 @@ async function handleMainMessage(message) {
         await initialize(message);
         return;
       case "set_loop_duration":
-        requireInitialized();
-        validateLoopDuration(message.loopDurationSeconds);
-        player.setLoopDurationSeconds(message.loopDurationSeconds);
-        respond(message.requestId, runtimeResult("set_loop_duration"));
+      case "pause_playback":
+      case "resume_playback":
+      case "seek_playback":
+      case "restart_playback":
+        enqueueControl(message);
         return;
       case "state":
         requireInitialized();
         respond(message.requestId, {
           type: "state",
           time: player.time(),
+          paused: player.isPaused(),
           nextPatchSequence: "0",
           sceneJson: player.legacySceneJson(),
           retainedDocumentJson: player.retainedDocumentJson(),
@@ -54,6 +57,7 @@ async function handleMainMessage(message) {
             retained: true,
             mixed: true,
             time: player.time(),
+            paused: player.isPaused(),
             resourceBundleBytes,
             resourceBundleTransfers: 1,
           },
@@ -69,6 +73,7 @@ async function handleMainMessage(message) {
         );
       case "stop":
         stopped = true;
+        controlQueue = [];
         latestTick = null;
         renderPort?.close?.();
         self.close();
@@ -172,13 +177,34 @@ function handleRenderMessage(message) {
   }
 }
 
+function enqueueControl(message) {
+  requireInitialized();
+  if (!Number.isSafeInteger(message.requestId) || message.requestId < 0) {
+    throw new Error("mixed retained engine request ID must be a non-negative safe integer");
+  }
+  controlQueue.push(message);
+  drainWork();
+}
+
 function drainWork() {
   if (!initialized || stopped || player === null || transport === null) {
     return;
   }
-  if (latestTick === null || !transportCanSend()) {
+
+  while (controlQueue.length > 0 && transportCanSend()) {
+    const message = controlQueue.shift();
+    try {
+      executeControl(message);
+    } catch (error) {
+      fail(error, message.requestId);
+      return;
+    }
+  }
+
+  if (controlQueue.length > 0 || latestTick === null || !transportCanSend()) {
     return;
   }
+
   const timestamp = latestTick;
   latestTick = null;
   try {
@@ -188,6 +214,51 @@ function drainWork() {
     }
   } catch (error) {
     fail(error, null);
+  }
+}
+
+function executeControl(message) {
+  switch (message.type) {
+    case "set_loop_duration":
+      validateLoopDuration(message.loopDurationSeconds);
+      player.setLoopDurationSeconds(message.loopDurationSeconds);
+      respond(message.requestId, runtimeResult("set_loop_duration"));
+      return;
+    case "pause_playback":
+      // A queued RAF timestamp may have arrived before this user command but not yet
+      // reached the engine because of transport backpressure. Drop it at the control
+      // barrier so playback freezes at the last actually presented logical frame.
+      latestTick = null;
+      player.pausePlayback();
+      respond(message.requestId, runtimeResult("pause_playback"));
+      return;
+    case "resume_playback":
+      // The shared clock intentionally re-anchors on the next post-command RAF.
+      latestTick = null;
+      player.resumePlayback();
+      respond(message.requestId, runtimeResult("resume_playback"));
+      return;
+    case "seek_playback": {
+      validateSceneTime(message.sceneTime);
+      latestTick = null;
+      const delta = player.seekPlaybackDeltaJson(message.sceneTime);
+      if (delta !== undefined && delta !== null) {
+        sendDeltaOrThrow(delta);
+      }
+      respond(message.requestId, runtimeResult("seek_playback"));
+      return;
+    }
+    case "restart_playback": {
+      latestTick = null;
+      const delta = player.restartPlaybackDeltaJson();
+      if (delta !== undefined && delta !== null) {
+        sendDeltaOrThrow(delta);
+      }
+      respond(message.requestId, runtimeResult("restart_playback"));
+      return;
+    }
+    default:
+      throw new Error(`unknown queued mixed retained engine command ${message.type}`);
   }
 }
 
@@ -221,6 +292,7 @@ function runtimeResult(operation) {
     type: "result",
     operation,
     time: player.time(),
+    paused: player.isPaused(),
     nextPatchSequence: "0",
     sceneJson: player.legacySceneJson(),
     retainedDocumentJson: player.retainedDocumentJson(),
@@ -263,6 +335,12 @@ function validateMainMessage(message) {
 function validateLoopDuration(duration) {
   if (!Number.isFinite(duration) || duration <= 0) {
     throw new Error("mixed retained execution loop duration must be positive and finite");
+  }
+}
+
+function validateSceneTime(sceneTime) {
+  if (!Number.isFinite(sceneTime) || sceneTime < 0) {
+    throw new Error("mixed retained playback scene time must be finite and non-negative");
   }
 }
 

--- a/web/retained-execution-worker-client.js
+++ b/web/retained-execution-worker-client.js
@@ -159,6 +159,23 @@ export class RetainedExecutionWorkerClient {
     return result;
   }
 
+  async pausePlayback() {
+    return this.#requestEngine("pause_playback", {});
+  }
+
+  async resumePlayback() {
+    return this.#requestEngine("resume_playback", {});
+  }
+
+  async seekPlayback(sceneTime) {
+    const time = validateSceneTime(sceneTime);
+    return this.#requestEngine("seek_playback", { sceneTime: time });
+  }
+
+  async restartPlayback() {
+    return this.#requestEngine("restart_playback", {});
+  }
+
   resize(width, height, devicePixelRatio = 1) {
     this.#requireStarted();
     if (!Number.isFinite(width) || !Number.isFinite(height) || !Number.isFinite(devicePixelRatio)) {
@@ -367,6 +384,13 @@ function validateLoopDurationSeconds(loopDurationSeconds) {
     throw new TypeError("mixed retained loop duration must be positive and finite");
   }
   return loopDurationSeconds;
+}
+
+function validateSceneTime(sceneTime) {
+  if (!Number.isFinite(sceneTime) || sceneTime < 0) {
+    throw new TypeError("mixed retained playback scene time must be finite and non-negative");
+  }
+  return sceneTime;
 }
 
 function checkedNext(current, label) {


### PR DESCRIPTION
Superseded by merged #467 (integrated playback runtime controls) and #454 (deterministic re-anchoring, semantic restart, and callback-safe seek/restart hardening). This stacked draft is retained only for historical context.