### PR TITLE
Drop stale Python payloads before parsing

### DIFF
--- a/web/authoring-client.js
+++ b/web/authoring-client.js
@@ -145,14 +145,16 @@ export class PythonAuthoringClient {
       }
 
       if (message.type === "result") {
-        const result = parseAuthoringResult(message.resultJson);
-        this.#settle(message.requestId, ({ resolve }) => resolve(result));
+        this.#settle(message.requestId, ({ resolve }) => {
+          resolve(parseAuthoringResult(message.resultJson));
+        });
         return;
       }
 
       if (message.type === "callback_result") {
-        const batch = parsePatchBatchJson(message.patchBatchJson);
-        this.#settle(message.requestId, ({ resolve }) => resolve(batch));
+        this.#settle(message.requestId, ({ resolve }) => {
+          resolve(parsePatchBatchJson(message.patchBatchJson));
+        });
         return;
       }
 
@@ -179,8 +181,8 @@ export class PythonAuthoringClient {
       }
       throw new Error(`Python authoring response has unissued request ID ${requestId}`);
     }
-    this.#pending.delete(requestId);
     settle(pending);
+    this.#pending.delete(requestId);
     return true;
   }
 

--- a/web/authoring-client.test.mjs
+++ b/web/authoring-client.test.mjs
@@ -325,6 +325,107 @@ test("drops duplicate responses for already-issued requests without killing the 
   assert.equal(client.diagnostics.staleResponses, 1);
 });
 
+test("drops malformed stale result payloads before parsing them", async () => {
+  const worker = new FakeWorker();
+  const client = new PythonAuthoringClient(worker);
+  worker.emit("message", workerMessage("ready"));
+  await client.ready();
+
+  const batch = { version: 1, sequence: 0, patches: [] };
+  const resultPromise = client.run("result = batch");
+  await Promise.resolve();
+  worker.emit(
+    "message",
+    workerMessage("result", {
+      requestId: 0,
+      resultJson: JSON.stringify({ kind: "patch_batch", document: batch }),
+    }),
+  );
+  await resultPromise;
+
+  worker.emit(
+    "message",
+    workerMessage("result", {
+      requestId: 0,
+      resultJson: "{",
+    }),
+  );
+  assert.equal(client.terminated, false);
+  assert.equal(worker.terminated, false);
+  assert.equal(client.diagnostics.staleResponses, 1);
+
+  const retry = client.run("result = retry");
+  await Promise.resolve();
+  worker.emit(
+    "message",
+    workerMessage("result", {
+      requestId: 1,
+      resultJson: JSON.stringify({ kind: "patch_batch", document: batch }),
+    }),
+  );
+  await retry;
+  assert.equal(client.terminated, false);
+});
+
+test("malformed pending payloads remain fatal and reject the pending request", async () => {
+  const worker = new FakeWorker();
+  const client = new PythonAuthoringClient(worker);
+  worker.emit("message", workerMessage("ready"));
+  await client.ready();
+
+  const resultPromise = client.run("result = batch");
+  await Promise.resolve();
+  worker.emit(
+    "message",
+    workerMessage("result", {
+      requestId: 0,
+      resultJson: "{",
+    }),
+  );
+
+  await assert.rejects(resultPromise, /returned invalid JSON/);
+  assert.equal(client.terminated, true);
+  assert.equal(worker.terminated, true);
+  assert.equal(client.diagnostics.pendingRequests, 0);
+  assert.equal(client.diagnostics.staleResponses, 0);
+});
+
+test("drops malformed stale callback payloads before parsing them", async () => {
+  const worker = new FakeWorker();
+  const client = new PythonAuthoringClient(worker);
+  worker.emit("message", workerMessage("ready"));
+  await client.ready();
+
+  const frame = {
+    time: 0.25,
+    delta_time: 0.25,
+    objects: [],
+    invocations: [{ callback: 0, object_indices: [] }],
+  };
+  const batch = { version: 1, sequence: 7, patches: [] };
+  const callbackPromise = client.runCallbackPhase(2, frame, 7);
+  await Promise.resolve();
+  worker.emit(
+    "message",
+    workerMessage("callback_result", {
+      requestId: 0,
+      patchBatchJson: JSON.stringify(batch),
+    }),
+  );
+  await callbackPromise;
+
+  worker.emit(
+    "message",
+    workerMessage("callback_result", {
+      requestId: 0,
+      patchBatchJson: "{",
+    }),
+  );
+  assert.equal(client.terminated, false);
+  assert.equal(worker.terminated, false);
+  assert.equal(client.diagnostics.staleResponses, 1);
+});
+
 test("treats never-issued future response IDs as fatal protocol corruption", async () => {
   const worker = new FakeWorker();
   const client = new PythonAuthoringClient(worker);


### PR DESCRIPTION
## Summary
Follow-up protocol-hardening slice for #112 after #436.

- classify Python authoring response IDs before parsing result/callback payloads
- drop malformed duplicate/late payloads for genuinely issued but already-settled request IDs without terminating a healthy worker
- keep malformed payloads for currently pending requests fatal
- keep a pending entry alive until payload validation succeeds, so fatal parse failures reject the actual waiting promise instead of orphaning it
- add deterministic coverage for malformed stale scene results, malformed current results, and malformed stale callback results

## Invariant
Request correlation precedes payload interpretation. Stale work is ignored without touching its payload; current work must validate fully before it is removed from the pending set.

The existing `scripts/build-web-demo.sh` gate already runs `web/authoring-client.test.mjs`, so these cases are part of the normal browser-package validation.

Tracks #112.