### PR TITLE
Drop in-flight host callbacks after teardown

### DIFF
--- a/scripts/execution-worker-host-smoke.mjs
+++ b/scripts/execution-worker-host-smoke.mjs
@@ -14,7 +14,7 @@ const source = await readFile(
   path.join(repoRoot, "web/python/examples/slow_host_updater.py"),
   "utf8",
 );
-const teardownSource = source.replace("0.080", "0.300");
+const teardownSource = source.replace("0.080", "1.000");
 assert.notEqual(teardownSource, source, "teardown smoke must extend the callback delay");
 
 let serverOutput = "";
@@ -134,25 +134,30 @@ try {
   }, teardownSource);
   assert.equal(teardownAuthored.callbackCount, 1);
 
-  await page.waitForFunction(async () => {
-    const report = await window.executionHostSmoke.client.metrics();
-    return report.engineMetrics.host.enabled && report.engineMetrics.host.inFlight;
-  }, null, { timeout: 30_000 });
-
   const teardown = await page.evaluate(async () => {
     const { client } = window.executionHostSmoke;
-    const beforeState = await client.state();
-    const beforeMetrics = await client.metrics();
-    if (!beforeMetrics.engineMetrics.host.inFlight) {
-      throw new Error("teardown smoke lost the in-flight callback before invalidation");
+    const deadline = performance.now() + 30_000;
+    while (performance.now() < deadline) {
+      const observedMetrics = await client.metrics();
+      if (observedMetrics.engineMetrics.host.enabled && observedMetrics.engineMetrics.host.inFlight) {
+        // Invalidate the callback generation in the same task that first observes
+        // it in flight. A second host round trip here makes this oracle race the
+        // deliberately slow Python callback instead of testing generation invalidation.
+        await client.configureHostCallbacks(null);
+        return {
+          observedMetrics,
+          disabledState: await client.state(),
+          disabledMetrics: await client.metrics(),
+        };
+      }
+      await new Promise((resolve) => setTimeout(resolve, 5));
     }
-    await client.configureHostCallbacks(null);
-    const disabledMetrics = await client.metrics();
-    return { beforeState, beforeMetrics, disabledMetrics };
+    throw new Error("teardown smoke never observed an in-flight host callback");
   });
+  assert.equal(teardown.observedMetrics.engineMetrics.host.inFlight, true);
   assert.equal(teardown.disabledMetrics.engineMetrics.host.enabled, false);
 
-  await page.waitForTimeout(420);
+  await page.waitForTimeout(1_100);
   const afterTeardown = await page.evaluate(async () => ({
     state: await window.executionHostSmoke.client.state(),
     report: await window.executionHostSmoke.client.metrics(),
@@ -160,16 +165,20 @@ try {
 
   assert.equal(
     afterTeardown.state.nextPatchSequence,
-    teardown.beforeState.nextPatchSequence,
+    teardown.disabledState.nextPatchSequence,
     "callback result from an invalidated generation advanced the engine patch sequence",
   );
   assert.equal(afterTeardown.report.engineMetrics.host.enabled, false);
   assert.equal(
     afterTeardown.report.engineMetrics.host.committed,
-    0,
+    teardown.disabledMetrics.engineMetrics.host.committed,
     "callback result from the invalidated generation was committed",
   );
-  assert.equal(afterTeardown.report.engineMetrics.host.errors, 0);
+  assert.equal(
+    afterTeardown.report.engineMetrics.host.errors,
+    teardown.disabledMetrics.engineMetrics.host.errors,
+    "invalidated callback generation introduced a host error",
+  );
   assert.ok(
     afterTeardown.report.metrics.presentedFrames >
       teardown.disabledMetrics.metrics.presentedFrames,

--- a/scripts/execution-worker-host-smoke.mjs
+++ b/scripts/execution-worker-host-smoke.mjs
@@ -14,6 +14,8 @@ const source = await readFile(
   path.join(repoRoot, "web/python/examples/slow_host_updater.py"),
   "utf8",
 );
+const teardownSource = source.replace("0.080", "0.300");
+assert.notEqual(teardownSource, source, "teardown smoke must extend the callback delay");
 
 let serverOutput = "";
 const server = spawn(
@@ -121,6 +123,59 @@ try {
   );
   assert.equal(after.engineMetrics.host.errors, 0);
 
+  const teardownAuthored = await page.evaluate(async (pythonSource) => {
+    const { authoring, client } = window.executionHostSmoke;
+    const authored = await authoring.run(pythonSource);
+    if (authored.kind !== "scene_document" || authored.callbacks === null) {
+      throw new Error("teardown smoke must author a callback scene");
+    }
+    await client.configureHostCallbacks(authored.callbacks, authoring);
+    return { callbackCount: authored.callbacks.slots.length };
+  }, teardownSource);
+  assert.equal(teardownAuthored.callbackCount, 1);
+
+  await page.waitForFunction(async () => {
+    const report = await window.executionHostSmoke.client.metrics();
+    return report.engineMetrics.host.enabled && report.engineMetrics.host.inFlight;
+  }, null, { timeout: 30_000 });
+
+  const teardown = await page.evaluate(async () => {
+    const { client } = window.executionHostSmoke;
+    const beforeState = await client.state();
+    const beforeMetrics = await client.metrics();
+    if (!beforeMetrics.engineMetrics.host.inFlight) {
+      throw new Error("teardown smoke lost the in-flight callback before invalidation");
+    }
+    await client.configureHostCallbacks(null);
+    const disabledMetrics = await client.metrics();
+    return { beforeState, beforeMetrics, disabledMetrics };
+  });
+  assert.equal(teardown.disabledMetrics.engineMetrics.host.enabled, false);
+
+  await page.waitForTimeout(420);
+  const afterTeardown = await page.evaluate(async () => ({
+    state: await window.executionHostSmoke.client.state(),
+    report: await window.executionHostSmoke.client.metrics(),
+  }));
+
+  assert.equal(
+    afterTeardown.state.nextPatchSequence,
+    teardown.beforeState.nextPatchSequence,
+    "callback result from an invalidated generation advanced the engine patch sequence",
+  );
+  assert.equal(afterTeardown.report.engineMetrics.host.enabled, false);
+  assert.equal(
+    afterTeardown.report.engineMetrics.host.committed,
+    0,
+    "callback result from the invalidated generation was committed",
+  );
+  assert.equal(afterTeardown.report.engineMetrics.host.errors, 0);
+  assert.ok(
+    afterTeardown.report.metrics.presentedFrames >
+      teardown.disabledMetrics.metrics.presentedFrames,
+    "native rendering stopped after callback teardown",
+  );
+
   const clientErrors = await page.evaluate(() => window.executionHostSmoke.errors.slice());
   assert.deepEqual(clientErrors, []);
   assert.deepEqual(browserErrors, []);
@@ -132,7 +187,8 @@ try {
   await page.close();
   console.log(
     `✓ slow Python host callback: ${after.engineMetrics.host.missedDeadlines} missed deadlines, ` +
-      `${after.metrics.presentedFrames - before.metrics.presentedFrames} native frames presented`,
+      `${after.metrics.presentedFrames - before.metrics.presentedFrames} native frames presented; ` +
+      "stale callback dropped after teardown",
   );
 } finally {
   await browser?.close();


### PR DESCRIPTION
## Summary
Adversarial callback-generation coverage for #112 using the real browser/Python worker path.

- extend the existing slow-host-callback smoke rather than adding another runtime sequencing mechanism
- author a second callback with a one-second delay so teardown is deterministic on shared CI runners
- in one browser task, poll until the engine first reports that callback in flight and immediately disable host callbacks; no second pre-invalidation round trip races the callback
- baseline patch sequence plus host commit/error counters after invalidation, then wait for the obsolete Python result to arrive
- require that late result to leave those baselines unchanged while native frame presentation continues
- fail on any client/page error

## Invariant
Clearing/replacing callback configuration invalidates the generation that requested any outstanding Python callback. A result from that old generation may arrive, but it cannot mutate the scene or wedge rendering.

This exercises the existing `hostGeneration` contract in `execution-engine-worker.js`; no new production generation state is introduced.

## First-run finding
The first version used `waitForFunction(inFlight)` followed by a second metrics request before invalidation. CI proved that observation was itself racy: the delayed callback could complete between those two host round trips. The revised oracle invalidates in the same task that first observes `inFlight`, so a failure now indicates generation semantics rather than test scheduling.

The smoke is already run by the normal Browser reactive/editor CI job.

Tracks #112.