### PR TITLE
Reconnect failed engine without replacing render surface

### DIFF
--- a/scripts/execution-worker-host-smoke.mjs
+++ b/scripts/execution-worker-host-smoke.mjs
@@ -123,6 +123,47 @@ try {
   );
   assert.equal(after.engineMetrics.host.errors, 0);
 
+  const reconnected = await page.evaluate(async () => {
+    const client = window.executionHostSmoke.client;
+    const canvas = client.canvas;
+    const beforeReconnect = await client.metrics();
+    const ready = await client.restart({ failedOwner: "engine" });
+    const immediate = await client.metrics();
+    return {
+      ready,
+      sameCanvas: client.canvas === canvas,
+      presentedBefore: beforeReconnect.metrics.presentedFrames,
+      immediate,
+    };
+  });
+  assert.equal(reconnected.ready.session, 2);
+  assert.equal(reconnected.sameCanvas, true, "host-callback engine reconnect replaced canvas");
+  assert.equal(reconnected.immediate.engineMetrics.host.enabled, true);
+  assert.ok(
+    reconnected.immediate.engineMetrics.host.requests >= 1,
+    "engine reconnect did not synchronously request the restored callback phase",
+  );
+  assert.ok(
+    reconnected.immediate.metrics.presentedFrames >= reconnected.presentedBefore,
+    "host-callback engine reconnect reset renderer presentation history",
+  );
+
+  const afterReconnect = await page.evaluate(async () => {
+    const client = window.executionHostSmoke.client;
+    const deadline = performance.now() + 30_000;
+    while (performance.now() < deadline) {
+      const report = await client.metrics();
+      if (report.engineMetrics.host.completed >= 1) {
+        return report;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    throw new Error("reconnected host callback never completed");
+  });
+  assert.ok(afterReconnect.engineMetrics.host.requests >= 1);
+  assert.ok(afterReconnect.engineMetrics.host.completed >= 1);
+  assert.equal(afterReconnect.engineMetrics.host.errors, 0);
+
   const barrierAuthored = await page.evaluate(async (pythonSource) => {
     const { authoring, client } = window.executionHostSmoke;
     const authored = await authoring.run(pythonSource);
@@ -282,7 +323,7 @@ try {
   await page.close();
   console.log(
     `✓ slow Python host callback: ${after.engineMetrics.host.missedDeadlines} missed deadlines, ` +
-      `${after.metrics.presentedFrames - before.metrics.presentedFrames} native frames presented; ` +
+      `${afterReconnect.metrics.presentedFrames} frames across engine reconnect; ` +
       "seek barrier and teardown both dropped stale callback work",
   );
 } finally {

--- a/scripts/execution-worker-smoke.mjs
+++ b/scripts/execution-worker-smoke.mjs
@@ -169,7 +169,7 @@ async function runMode(browser, transportMode) {
   assert.equal(afterRetime.nextPatchSequence, "1");
 
   const beforeStall = await page.evaluate(() => window.executionSmoke.client.metrics());
-  const stallStarted = await page.evaluate(() => {
+  await page.evaluate(() => {
     const worker = new Worker(
       URL.createObjectURL(
         new Blob(
@@ -182,7 +182,6 @@ async function runMode(browser, transportMode) {
     );
     window.executionSmoke.hostStallWorker = worker;
     worker.postMessage(500);
-    return performance.now();
   });
   await page.waitForTimeout(220);
   const duringStall = await page.evaluate(() => window.executionSmoke.client.metrics());
@@ -191,18 +190,41 @@ async function runMode(browser, transportMode) {
     `${transportMode}: render worker stopped while an isolated host worker was stalled`,
   );
 
-  const restarted = await page.evaluate(() => window.executionSmoke.client.restart());
-  assert.equal(restarted.session, 2);
-  assert.equal(restarted.transportMode, transportMode);
-  await page.waitForTimeout(300);
-  const afterRestart = await page.evaluate(() => window.executionSmoke.client.metrics());
-  assert.equal(afterRestart.metrics.ready, true);
-  assert.equal(afterRestart.metrics.objectCount, 4);
-  assert.ok(afterRestart.metrics.presentedFrames >= 1);
+  const reconnected = await page.evaluate(async () => {
+    const client = window.executionSmoke.client;
+    const canvas = client.canvas;
+    const paused = await client.pause();
+    const beforeReconnect = await client.metrics();
+    const ready = await client.restart({ failedOwner: "engine" });
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    const afterReconnect = await client.metrics();
+    const state = await client.state();
+    return {
+      ready,
+      paused,
+      state,
+      sameCanvas: client.canvas === canvas,
+      presentedBefore: beforeReconnect.metrics.presentedFrames,
+      presentedAfter: afterReconnect.metrics.presentedFrames,
+      metrics: afterReconnect.metrics,
+    };
+  });
+  assert.equal(reconnected.ready.session, 2);
+  assert.equal(reconnected.ready.transportMode, transportMode);
+  assert.equal(reconnected.paused.playing, false);
+  assert.equal(reconnected.state.playing, false, `${transportMode}: engine reconnect lost paused mode`);
+  assert.equal(reconnected.sameCanvas, true, `${transportMode}: engine reconnect replaced canvas`);
   assert.ok(
-    afterRestart.metrics.time >= 0 && afterRestart.metrics.time < 0.9,
-    `${transportMode}: restart forgot the authored loop duration`,
+    reconnected.presentedAfter >= reconnected.presentedBefore,
+    `${transportMode}: engine reconnect reset renderer presentation history`,
   );
+  assert.equal(reconnected.metrics.ready, true);
+  assert.equal(reconnected.metrics.objectCount, 4);
+  assert.ok(
+    reconnected.metrics.time >= 0 && reconnected.metrics.time < 0.9,
+    `${transportMode}: engine reconnect forgot the authored loop duration`,
+  );
+  await page.evaluate(() => window.executionSmoke.client.resume());
 
   const clientErrors = await page.evaluate(() => window.executionSmoke.errors.slice());
   assert.deepEqual(clientErrors, []);
@@ -214,7 +236,7 @@ async function runMode(browser, transportMode) {
   await page.close();
   console.log(
     `✓ execution workers ${transportMode}: ${before.metrics.backend}, ` +
-      `${before.metrics.presentedFrames} frames before restart`,
+      `${reconnected.presentedAfter} frames with canvas-preserving engine reconnect`,
   );
 }
 

--- a/scripts/retained-execution-worker-smoke.mjs
+++ b/scripts/retained-execution-worker-smoke.mjs
@@ -193,17 +193,51 @@ async function runMode(browser, transportMode) {
   assert.equal(afterRetime.engineMetrics.resourceBundleTransfers, 1);
   assert.equal(afterRetime.metrics.objectCount, 6);
 
-  const restarted = await page.evaluate(() => window.retainedExecutionSmoke.client.restart());
-  assert.equal(restarted.session, 2);
-  assert.equal(restarted.transportMode, transportMode);
-  assert.equal(restarted.render.retained, true);
-  assert.equal(restarted.render.mixed, true);
-  await page.waitForTimeout(350);
-  const afterRestart = await page.evaluate(() => window.retainedExecutionSmoke.client.metrics());
-  assert.equal(afterRestart.metrics.ready, true);
-  assert.equal(afterRestart.metrics.objectCount, 6);
-  assert.equal(afterRestart.engineMetrics.resourceBundleTransfers, 1);
-  assert.ok(afterRestart.engineMetrics.resourceBundleBytes > 0);
+  const reconnected = await page.evaluate(async () => {
+    const client = window.retainedExecutionSmoke.client;
+    const canvas = client.canvas;
+    const paused = await client.pause();
+    const beforeReconnect = await client.metrics();
+    const ready = await client.restart({ failedOwner: "engine" });
+    await new Promise((resolve) => setTimeout(resolve, 350));
+    const afterReconnect = await client.metrics();
+    const state = await client.state();
+    return {
+      ready,
+      paused,
+      state,
+      sameCanvas: client.canvas === canvas,
+      presentedBefore: beforeReconnect.metrics.presentedFrames,
+      presentedAfter: afterReconnect.metrics.presentedFrames,
+      metrics: afterReconnect.metrics,
+      engineMetrics: afterReconnect.engineMetrics,
+    };
+  });
+  assert.equal(reconnected.ready.session, 2);
+  assert.equal(reconnected.ready.transportMode, transportMode);
+  assert.equal(reconnected.ready.render.retained, true);
+  assert.equal(reconnected.ready.render.mixed, true);
+  assert.equal(reconnected.paused.playing, false);
+  assert.equal(
+    reconnected.state.playing,
+    false,
+    `${transportMode}: retained engine reconnect lost paused mode`,
+  );
+  assert.equal(reconnected.sameCanvas, true, `${transportMode}: retained engine reconnect replaced canvas`);
+  assert.ok(
+    reconnected.presentedAfter >= reconnected.presentedBefore,
+    `${transportMode}: retained engine reconnect reset renderer presentation history`,
+  );
+  assert.equal(reconnected.metrics.ready, true);
+  assert.equal(reconnected.metrics.objectCount, 6);
+  assert.equal(reconnected.metrics.resourceBundlePending, false);
+  assert.equal(reconnected.engineMetrics.resourceBundleTransfers, 1);
+  assert.ok(reconnected.engineMetrics.resourceBundleBytes > 0);
+  assert.ok(
+    reconnected.engineMetrics.time >= 0 && reconnected.engineMetrics.time < 0.9,
+    `${transportMode}: retained engine reconnect forgot the authored loop duration`,
+  );
+  await page.evaluate(() => window.retainedExecutionSmoke.client.resume());
 
   const clientErrors = await page.evaluate(() => window.retainedExecutionSmoke.errors.slice());
   assert.deepEqual(clientErrors, []);
@@ -212,7 +246,7 @@ async function runMode(browser, transportMode) {
   await page.close();
   console.log(
     `✓ mixed retained execution workers ${transportMode}: ${before.metrics.backend}, ` +
-      `${before.engineMetrics.resourceBundleBytes} resource bytes`,
+      `${reconnected.presentedAfter} frames with canvas-preserving engine reconnect`,
   );
 }
 

--- a/web/execution-engine-worker.js
+++ b/web/execution-engine-worker.js
@@ -53,6 +53,7 @@ async function handleMainMessage(message) {
       case "restart_playback":
       case "apply_patch":
       case "configure_callbacks":
+      case "request_callback_phase":
         enqueueControl(message);
         return;
       case "attach_host_port":
@@ -380,6 +381,18 @@ function executeControl(message) {
         type: "callbacks_configured",
         enabled: hostCallbacks !== null,
         generation: hostGeneration,
+      });
+      return;
+    }
+    case "request_callback_phase": {
+      if (hostCallbacks === null || hostPort === null) {
+        throw new Error("callback phase synchronization requires configured host callbacks");
+      }
+      requestLatestHostPhase();
+      respond(message.requestId, {
+        type: "callback_phase_requested",
+        generation: hostGeneration,
+        hostRequestId: hostInFlight?.requestId ?? null,
       });
       return;
     }

--- a/web/execution-render-worker.js
+++ b/web/execution-render-worker.js
@@ -36,6 +36,9 @@ async function handleMainMessage(message) {
       case "init":
         await initialize(message);
         return;
+      case "attach_engine":
+        attachEngine(message);
+        return;
       case "resize":
         width = normalizedDimension(message.width);
         height = normalizedDimension(message.height);
@@ -82,17 +85,50 @@ async function initialize(message) {
   width = normalizedDimension(message.width ?? canvas.width);
   height = normalizedDimension(message.height ?? canvas.height);
   transportMode = message.transportMode;
-  renderPort = message.port;
   await init();
+  attachRenderPort(message.port);
+}
 
-  renderPort.addEventListener("message", (event) => handleEngineMessage(event.data));
-  if (transportMode === EXECUTION_TRANSPORT_TRANSFERABLE) {
-    transferableReceiver = new TransferableExecutionDeltaReceiver(
-      renderPort,
-      (json) => consumeDelta(json),
+function attachEngine(message) {
+  if (renderer === null || renderPort === null) {
+    throw new Error("execution render worker cannot reconnect before renderer bootstrap");
+  }
+  if (!(message.port instanceof MessagePort)) {
+    throw new Error("execution render reconnect requires an engine MessagePort");
+  }
+  if (message.transportMode !== transportMode) {
+    throw new Error(
+      `execution render reconnect transport ${message.transportMode} does not match ${transportMode}`,
     );
   }
-  renderPort.start();
+
+  renderPort.close?.();
+  sharedReader = null;
+  transferableReceiver = null;
+  bootstrapQueue = [];
+  attachRenderPort(message.port);
+  respond(message.requestId, {
+    type: "engine_port_attached",
+    transportMode,
+    backend: renderer.rendererBackend(),
+  });
+}
+
+function attachRenderPort(port) {
+  renderPort = port;
+  port.addEventListener("message", (event) => {
+    if (renderPort !== port) {
+      return;
+    }
+    handleEngineMessage(event.data);
+  });
+  if (transportMode === EXECUTION_TRANSPORT_TRANSFERABLE) {
+    transferableReceiver = new TransferableExecutionDeltaReceiver(
+      port,
+      (json) => (renderPort === port ? consumeDelta(json) : true),
+    );
+  }
+  port.start();
 }
 
 function handleEngineMessage(message) {

--- a/web/execution-worker-client.js
+++ b/web/execution-worker-client.js
@@ -11,6 +11,7 @@ const ENGINE_PROTOCOL_VERSION = 1;
 const RENDER_CHANNEL = "noon.render";
 const RENDER_PROTOCOL_VERSION = 1;
 const WORKER_OWNERS = Object.freeze(["engine", "render"]);
+const DEFAULT_SHARED_SLOT_CAPACITY = 1024 * 1024;
 
 export class ExecutionWorkerClient {
   #canvas;
@@ -22,11 +23,14 @@ export class ExecutionWorkerClient {
   #sceneJson = null;
   #loopDurationSeconds = 4;
   #transportMode = null;
+  #sharedSlotCapacity = DEFAULT_SHARED_SLOT_CAPACITY;
   #ready = null;
+  #playing = true;
   #onError;
   #onRecoverableError;
   #hostAuthoringClient = null;
   #hostCallbacks = null;
+  #fatalOwner = null;
   #staleWorkerEvents = { engine: 0, render: 0 };
   #staleResponses = { engine: 0, render: 0 };
 
@@ -66,7 +70,7 @@ export class ExecutionWorkerClient {
     {
       loopDurationSeconds = 4,
       transportMode = selectExecutionTransportMode(),
-      sharedSlotCapacity = 1024 * 1024,
+      sharedSlotCapacity = DEFAULT_SHARED_SLOT_CAPACITY,
     } = {},
   ) {
     if (this.#engineWorker !== null || this.#renderWorker !== null) {
@@ -94,6 +98,7 @@ export class ExecutionWorkerClient {
     this.#sceneJson = sceneJson;
     this.#loopDurationSeconds = loopDurationSeconds;
     this.#transportMode = transportMode;
+    this.#sharedSlotCapacity = sharedSlotCapacity;
     this.#session = checkedNextSession(this.#session);
 
     // The OffscreenCanvas inherits the HTML canvas backing-store dimensions at
@@ -151,7 +156,10 @@ export class ExecutionWorkerClient {
         }),
         [channel.port1],
       );
-      return await this.#ready;
+      const ready = await this.#ready;
+      this.#playing = true;
+      this.#fatalOwner = null;
+      return ready;
     } catch (error) {
       this.#rollbackFailedStart(error, canvasTransferred);
       throw error;
@@ -176,6 +184,7 @@ export class ExecutionWorkerClient {
       sceneJson,
       loopDurationSeconds: duration,
     });
+    this.#rememberPlaying(result);
     this.#sceneJson = result.sceneJson ?? sceneJson;
     if (duration !== null) {
       this.#loopDurationSeconds = duration;
@@ -195,6 +204,7 @@ export class ExecutionWorkerClient {
       sceneJson,
       loopDurationSeconds: duration,
     });
+    this.#rememberPlaying(result);
     this.#sceneJson = result.sceneJson ?? sceneJson;
     if (duration !== null) {
       this.#loopDurationSeconds = duration;
@@ -208,25 +218,34 @@ export class ExecutionWorkerClient {
     const result = await this.#requestEngine("set_loop_duration", {
       loopDurationSeconds: duration,
     });
+    this.#rememberPlaying(result);
     this.#loopDurationSeconds = duration;
     return result;
   }
 
   async pause() {
-    return this.#requestEngine("pause", {});
+    const result = await this.#requestEngine("pause", {});
+    this.#rememberPlaying(result);
+    return result;
   }
 
   async resume() {
-    return this.#requestEngine("resume", {});
+    const result = await this.#requestEngine("resume", {});
+    this.#rememberPlaying(result);
+    return result;
   }
 
   async seek(timeSeconds) {
     const time = validateSeekTimeSeconds(timeSeconds, this.#loopDurationSeconds);
-    return this.#requestEngine("seek", { time });
+    const result = await this.#requestEngine("seek", { time });
+    this.#rememberPlaying(result);
+    return result;
   }
 
   async restartPlayback() {
-    return this.#requestEngine("restart_playback", {});
+    const result = await this.#requestEngine("restart_playback", {});
+    this.#rememberPlaying(result);
+    return result;
   }
 
   async applyPatchBatch(patchBatchJson) {
@@ -234,6 +253,7 @@ export class ExecutionWorkerClient {
       throw new TypeError("patch batch must be non-empty JSON text");
     }
     const result = await this.#requestEngine("apply_patch", { patchBatchJson });
+    this.#rememberPlaying(result);
     if (typeof result.sceneJson === "string") {
       this.#sceneJson = result.sceneJson;
     }
@@ -291,24 +311,104 @@ export class ExecutionWorkerClient {
     );
   }
 
-  async restart() {
+  async restart({ failedOwner = this.#fatalOwner } = {}) {
     if (this.#sceneJson === null || this.#transportMode === null) {
       throw new Error("ExecutionWorkerClient has not been started");
     }
+    if (failedOwner !== null && failedOwner !== "engine" && failedOwner !== "render") {
+      throw new TypeError(`unsupported failed execution owner ${failedOwner}`);
+    }
+    if (failedOwner === "engine" && this.#renderWorker !== null) {
+      return this.#restartEngine();
+    }
+    return this.#restartAll();
+  }
+
+  async #restartEngine() {
+    const wasPlaying = this.#playing;
+    const callbacks = this.#hostCallbacks;
+    const authoringClient = this.#hostAuthoringClient;
+    const reconnectError = new Error("execution engine worker restarting");
+    this.#engineWorker?.terminate();
+    this.#engineWorker = null;
+    this.#rejectOwner("engine", reconnectError);
+
+    const channel = new MessageChannel();
+    const renderAttached = this.#request(
+      this.#renderWorker,
+      "render",
+      renderEnvelope,
+      "attach_engine",
+      { port: channel.port2, transportMode: this.#transportMode },
+      [channel.port2],
+    ).catch((error) => {
+      this.#markFatalOwner("render");
+      throw error;
+    });
+    this.#session = checkedNextSession(this.#session);
+    this.#engineWorker = new Worker(new URL("./execution-engine-worker.js", import.meta.url), {
+      type: "module",
+      name: "noon-engine",
+    });
+    const engineReady = this.#workerReady(this.#engineWorker, ENGINE_CHANNEL, "engine");
+    const nextReady = Promise.all([engineReady, renderAttached]).then(([engine, render]) => ({
+      engine,
+      render,
+      transportMode: this.#transportMode,
+      session: this.#session,
+    }));
+    this.#ready = nextReady;
+    this.#engineWorker.postMessage(
+      engineEnvelope("init", {
+        port: channel.port1,
+        sceneJson: this.#sceneJson,
+        loopDurationSeconds: this.#loopDurationSeconds,
+        transportMode: this.#transportMode,
+        sharedSlotCapacity: this.#sharedSlotCapacity,
+        session: this.#session,
+      }),
+      [channel.port1],
+    );
+
+    const ready = await nextReady;
+    this.#playing = true;
+    if (!wasPlaying) {
+      await this.pause();
+    }
+    if (callbacks !== null && authoringClient !== null) {
+      this.#hostAuthoringClient = null;
+      await this.configureHostCallbacks(callbacks, authoringClient);
+      await this.#requestEngine("request_callback_phase", {});
+    }
+    this.#fatalOwner = null;
+    return ready;
+  }
+
+  async #restartAll() {
     const sceneJson = this.#sceneJson;
     const loopDurationSeconds = this.#loopDurationSeconds;
     const transportMode = this.#transportMode;
+    const sharedSlotCapacity = this.#sharedSlotCapacity;
+    const wasPlaying = this.#playing;
     const callbacks = this.#hostCallbacks;
     const authoringClient = this.#hostAuthoringClient;
     if (this.#engineWorker !== null || this.#renderWorker !== null) {
       this.terminate({ preserveHostConfiguration: true });
       this.#canvas = replaceExecutionCanvas(this.#canvas);
     }
-    const ready = await this.start(sceneJson, { loopDurationSeconds, transportMode });
+    const ready = await this.start(sceneJson, {
+      loopDurationSeconds,
+      transportMode,
+      sharedSlotCapacity,
+    });
+    if (!wasPlaying) {
+      await this.pause();
+    }
     if (callbacks !== null && authoringClient !== null) {
       this.#hostAuthoringClient = null;
       await this.configureHostCallbacks(callbacks, authoringClient);
     }
+    this.#fatalOwner = null;
     return ready;
   }
 
@@ -327,6 +427,7 @@ export class ExecutionWorkerClient {
       this.#hostAuthoringClient = null;
       this.#hostCallbacks = null;
     }
+    this.#fatalOwner = null;
   }
 
   async #requestEngine(type, payload, transfer = []) {
@@ -472,6 +573,7 @@ export class ExecutionWorkerClient {
       pending.reject(error);
     }
     this.#pending.clear();
+    this.#fatalOwner = null;
     if (replaceCanvas) {
       this.#canvas = replaceExecutionCanvas(this.#canvas);
     }
@@ -500,7 +602,14 @@ export class ExecutionWorkerClient {
     });
   }
 
+  #markFatalOwner(owner) {
+    if (owner === "render" || this.#fatalOwner === null) {
+      this.#fatalOwner = owner;
+    }
+  }
+
   #notifyError(error, owner) {
+    this.#markFatalOwner(owner);
     this.#onError?.(error, owner);
   }
 
@@ -510,6 +619,12 @@ export class ExecutionWorkerClient {
       return;
     }
     console.warn(`[Noon execution] recoverable ${owner} error`, error);
+  }
+
+  #rememberPlaying(result) {
+    if (typeof result?.playing === "boolean") {
+      this.#playing = result.playing;
+    }
   }
 
   #requireStarted() {
@@ -602,8 +717,18 @@ function validateCallbacks(callbacks) {
 function cloneCallbacks(callbacks) {
   return {
     session_id: callbacks.session_id,
-    slots: callbacks.slots.map((slot) => ({ id: slot.id, objects: [...slot.objects] })),
+    slots: callbacks.slots.map(cloneCallbackSlot),
   };
+}
+
+function cloneCallbackSlot(slot) {
+  const cloned = { id: slot.id, objects: [...slot.objects] };
+  for (const field of ["active_after", "active_through"]) {
+    if (Object.prototype.hasOwnProperty.call(slot, field)) {
+      cloned[field] = slot[field];
+    }
+  }
+  return cloned;
 }
 
 function checkedNextRequestId(current) {

--- a/web/execution-worker-client.test.mjs
+++ b/web/execution-worker-client.test.mjs
@@ -134,6 +134,17 @@ function requestMessage(worker, type) {
   return entry.message;
 }
 
+async function waitForRequest(worker, type, occurrence = 1) {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    const entries = worker.messages.filter(({ message }) => message.type === type);
+    if (entries.length >= occurrence) {
+      return entries[occurrence - 1].message;
+    }
+    await Promise.resolve();
+  }
+  assert.fail(`missing ${worker.name} ${type} request`);
+}
+
 test("engine and render requests use independent issuance spaces", async () => {
   const errors = [];
   const { client, engine, render } = await startClient(errors);
@@ -267,3 +278,182 @@ test("ignores queued events from workers that were replaced by restart", async (
   assert.deepEqual(errors, []);
   client.terminate();
 });
+
+test("engine failure reconnects without replacing the render worker or canvas", async () => {
+  const errors = [];
+  const { client, engine: oldEngine, render } = await startClient(errors);
+  const canvas = client.canvas;
+
+  oldEngine.emitError("engine lost");
+  assert.deepEqual(errors, ["engine: engine lost"]);
+
+  const offset = FakeWorker.instances.length;
+  const restartPromise = client.restart();
+  await Promise.resolve();
+  const newEngine = FakeWorker.instances[offset];
+  assert.ok(newEngine, "replacement engine worker must be created");
+  assert.equal(newEngine.name, "noon-engine");
+  assert.equal(FakeWorker.instances.length, offset + 1, "engine reconnect must not create a render worker");
+
+  const attachRequest = requestMessage(render, "attach_engine");
+  render.emitMessage(
+    renderMessage("engine_port_attached", {
+      requestId: attachRequest.requestId,
+      transportMode: "transferable",
+      backend: "WebGL2",
+    }),
+  );
+  newEngine.emitMessage(engineMessage("ready", { transportMode: "transferable" }));
+
+  const restarted = await restartPromise;
+  assert.equal(restarted.session, 2);
+  assert.equal(client.canvas, canvas, "engine reconnect must preserve the transferred canvas");
+  assert.equal(oldEngine.terminated, true);
+  assert.equal(render.terminated, false);
+
+  oldEngine.emitMessage({ malformed: true });
+  oldEngine.emitMessageError();
+  assert.equal(client.diagnostics.engine.staleWorkerEvents, 2);
+  assert.deepEqual(errors, ["engine: engine lost"]);
+
+  const statePromise = client.state();
+  await Promise.resolve();
+  const stateRequest = requestMessage(newEngine, "state");
+  newEngine.emitMessage(
+    engineMessage("state", {
+      requestId: stateRequest.requestId,
+      time: 0,
+      nextPatchSequence: "0",
+      sceneJson: SCENE_JSON,
+    }),
+  );
+  await statePromise;
+  client.terminate();
+});
+
+test("engine reconnect restores pause mode and callback phase configuration", async () => {
+  const errors = [];
+  const { client, engine: oldEngine, render } = await startClient(errors);
+  const callbacks = {
+    session_id: 7,
+    slots: [
+      {
+        id: 3,
+        objects: [0],
+        active_after: 0.25,
+        active_through: 1.75,
+      },
+    ],
+  };
+  const authoringClient = {
+    ports: [],
+    async attachEnginePort(port) {
+      this.ports.push(port);
+    },
+  };
+
+  const configurePromise = client.configureHostCallbacks(callbacks, authoringClient);
+  const initialHostAttach = await waitForRequest(oldEngine, "attach_host_port");
+  oldEngine.emitMessage(
+    engineMessage("host_port_attached", { requestId: initialHostAttach.requestId }),
+  );
+  const initialConfigure = await waitForRequest(oldEngine, "configure_callbacks");
+  assert.deepEqual(initialConfigure.callbacks, callbacks);
+  oldEngine.emitMessage(
+    engineMessage("callbacks_configured", {
+      requestId: initialConfigure.requestId,
+      enabled: true,
+      generation: 1,
+    }),
+  );
+  await configurePromise;
+
+  const pausePromise = client.pause();
+  const initialPause = await waitForRequest(oldEngine, "pause");
+  oldEngine.emitMessage(
+    engineMessage("result", {
+      requestId: initialPause.requestId,
+      operation: "pause",
+      time: 0.5,
+      playing: false,
+      nextPatchSequence: "0",
+      sceneJson: SCENE_JSON,
+    }),
+  );
+  await pausePromise;
+
+  oldEngine.emitError("engine lost");
+  const canvas = client.canvas;
+  const offset = FakeWorker.instances.length;
+  const restartPromise = client.restart();
+  const newEngine = await waitForNewEngine(offset);
+
+  const renderAttach = await waitForRequest(render, "attach_engine");
+  render.emitMessage(
+    renderMessage("engine_port_attached", {
+      requestId: renderAttach.requestId,
+      transportMode: "transferable",
+      backend: "WebGL2",
+    }),
+  );
+  newEngine.emitMessage(engineMessage("ready", { transportMode: "transferable" }));
+
+  const restoredPause = await waitForRequest(newEngine, "pause");
+  newEngine.emitMessage(
+    engineMessage("result", {
+      requestId: restoredPause.requestId,
+      operation: "pause",
+      time: 0,
+      playing: false,
+      nextPatchSequence: "0",
+      sceneJson: SCENE_JSON,
+    }),
+  );
+
+  const restoredHostAttach = await waitForRequest(newEngine, "attach_host_port");
+  newEngine.emitMessage(
+    engineMessage("host_port_attached", { requestId: restoredHostAttach.requestId }),
+  );
+  const restoredConfigure = await waitForRequest(newEngine, "configure_callbacks");
+  assert.deepEqual(
+    restoredConfigure.callbacks,
+    callbacks,
+    "reconnect must preserve callback activation windows",
+  );
+  newEngine.emitMessage(
+    engineMessage("callbacks_configured", {
+      requestId: restoredConfigure.requestId,
+      enabled: true,
+      generation: 1,
+    }),
+  );
+
+  const phaseRequest = await waitForRequest(newEngine, "request_callback_phase");
+  newEngine.emitMessage(
+    engineMessage("callback_phase_requested", {
+      requestId: phaseRequest.requestId,
+      generation: 1,
+      hostRequestId: 0,
+    }),
+  );
+
+  const restarted = await restartPromise;
+  assert.equal(restarted.session, 2);
+  assert.equal(client.canvas, canvas);
+  assert.equal(render.terminated, false);
+  assert.equal(authoringClient.ports.length, 2, "Python host port must be replaced on reconnect");
+  assert.deepEqual(errors, ["engine: engine lost"]);
+  client.terminate();
+});
+
+async function waitForNewEngine(offset) {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    const worker = FakeWorker.instances[offset];
+    if (worker !== undefined) {
+      assert.equal(worker.name, "noon-engine");
+      return worker;
+    }
+    await Promise.resolve();
+  }
+  assert.fail("replacement engine worker must be created");
+}

--- a/web/retained-execution-render-worker.js
+++ b/web/retained-execution-render-worker.js
@@ -16,6 +16,7 @@ let sharedReader = null;
 let transferableReceiver = null;
 let renderer = null;
 let resourceBytes = null;
+let reconnectResourceBundlePending = false;
 let canvas = null;
 let width = 1;
 let height = 1;
@@ -36,6 +37,9 @@ async function handleMainMessage(message) {
     switch (message.type) {
       case "init":
         await initialize(message);
+        return;
+      case "attach_engine":
+        attachEngine(message);
         return;
       case "resize":
         width = normalizedDimension(message.width);
@@ -84,17 +88,53 @@ async function initialize(message) {
   width = normalizedDimension(message.width ?? canvas.width);
   height = normalizedDimension(message.height ?? canvas.height);
   transportMode = message.transportMode;
-  renderPort = message.port;
   await init();
+  attachRenderPort(message.port);
+}
 
-  renderPort.addEventListener("message", (event) => handleEngineMessage(event.data));
-  if (transportMode === EXECUTION_TRANSPORT_TRANSFERABLE) {
-    transferableReceiver = new TransferableExecutionDeltaReceiver(
-      renderPort,
-      (json) => consumeDelta(json),
+function attachEngine(message) {
+  if (renderer === null || renderPort === null) {
+    throw new Error("mixed retained render worker cannot reconnect before renderer bootstrap");
+  }
+  if (!(message.port instanceof MessagePort)) {
+    throw new Error("mixed retained render reconnect requires an engine MessagePort");
+  }
+  if (message.transportMode !== transportMode) {
+    throw new Error(
+      `mixed retained render reconnect transport ${message.transportMode} does not match ${transportMode}`,
     );
   }
-  renderPort.start();
+
+  renderPort.close?.();
+  sharedReader = null;
+  transferableReceiver = null;
+  bootstrapQueue = [];
+  reconnectResourceBundlePending = true;
+  attachRenderPort(message.port);
+  respond(message.requestId, {
+    type: "engine_port_attached",
+    transportMode,
+    retained: true,
+    mixed: true,
+    backend: renderer.rendererBackend(),
+  });
+}
+
+function attachRenderPort(port) {
+  renderPort = port;
+  port.addEventListener("message", (event) => {
+    if (renderPort !== port) {
+      return;
+    }
+    handleEngineMessage(event.data);
+  });
+  if (transportMode === EXECUTION_TRANSPORT_TRANSFERABLE) {
+    transferableReceiver = new TransferableExecutionDeltaReceiver(
+      port,
+      (json) => (renderPort === port ? consumeDelta(json) : true),
+    );
+  }
+  port.start();
 }
 
 function handleEngineMessage(message) {
@@ -103,11 +143,21 @@ function handleEngineMessage(message) {
   }
   if (message.type === "retained_resources") {
     try {
-      if (resourceBytes !== null || renderer !== null || bootstrapPromise !== null) {
-        throw new Error("retained resource bundle may be installed only once before the snapshot");
-      }
       if (!(message.bytes instanceof Uint8Array) || message.bytes.byteLength === 0) {
         throw new Error("retained resource bundle must be a non-empty Uint8Array");
+      }
+      if (renderer !== null) {
+        if (!reconnectResourceBundlePending) {
+          throw new Error("retained resource bundle may be installed only once before the snapshot");
+        }
+        // A replacement engine deterministically recreates the same immutable
+        // resource bundle. The live renderer already owns those GPU resources,
+        // so acknowledge the reconnect generation without rebuilding them.
+        reconnectResourceBundlePending = false;
+        return;
+      }
+      if (resourceBytes !== null || bootstrapPromise !== null) {
+        throw new Error("retained resource bundle may be installed only once before the snapshot");
       }
       resourceBytes = message.bytes;
     } catch (error) {
@@ -163,6 +213,9 @@ function consumeDelta(json) {
     return true;
   }
 
+  if (reconnectResourceBundlePending) {
+    throw new Error("mixed retained reconnect snapshot arrived before its resource bundle");
+  }
   if (needsPresent) {
     return false;
   }
@@ -289,7 +342,7 @@ function currentMetrics() {
     lastFrameTimestamp,
     bufferedDeltas: bootstrapQueue.length + (transferableReceiver?.pendingCount() ?? 0),
     needsPresent,
-    resourceBundlePending: false,
+    resourceBundlePending: reconnectResourceBundlePending,
   };
 }
 

--- a/web/retained-execution-worker-client.js
+++ b/web/retained-execution-worker-client.js
@@ -10,6 +10,7 @@ const ENGINE_PROTOCOL_VERSION = 1;
 const RENDER_CHANNEL = "noon.render";
 const RENDER_PROTOCOL_VERSION = 1;
 const RETAINED_AUTHORING_CHANNEL = "noon.authoring.retained";
+const DEFAULT_SHARED_SLOT_CAPACITY = 1024 * 1024;
 
 export class RetainedExecutionWorkerClient {
   #canvas;
@@ -22,8 +23,12 @@ export class RetainedExecutionWorkerClient {
   #retainedDocumentJson = null;
   #loopDurationSeconds = 4;
   #transportMode = null;
+  #sharedSlotCapacity = DEFAULT_SHARED_SLOT_CAPACITY;
   #ready = null;
+  #playing = true;
   #onError;
+  #fatalOwner = null;
+  #staleWorkerEvents = { engine: 0, render: 0 };
 
   constructor(canvas, { onError = null } = {}) {
     if (!(canvas instanceof HTMLCanvasElement)) {
@@ -44,13 +49,20 @@ export class RetainedExecutionWorkerClient {
     return this.#transportMode;
   }
 
+  get diagnostics() {
+    return Object.freeze({
+      session: this.#session,
+      staleWorkerEvents: Object.freeze({ ...this.#staleWorkerEvents }),
+    });
+  }
+
   async start(
     sceneJson,
     retainedDocumentJson,
     {
       loopDurationSeconds = 4,
       transportMode = selectExecutionTransportMode(),
-      sharedSlotCapacity = 1024 * 1024,
+      sharedSlotCapacity = DEFAULT_SHARED_SLOT_CAPACITY,
     } = {},
   ) {
     if (this.#engineWorker !== null || this.#renderWorker !== null) {
@@ -79,6 +91,7 @@ export class RetainedExecutionWorkerClient {
     this.#retainedDocumentJson = retainedDocumentJson;
     this.#loopDurationSeconds = loopDurationSeconds;
     this.#transportMode = transportMode;
+    this.#sharedSlotCapacity = sharedSlotCapacity;
     this.#session = checkedNext(this.#session, "mixed retained execution session");
 
     const devicePixelRatio = window.devicePixelRatio || 1;
@@ -132,7 +145,10 @@ export class RetainedExecutionWorkerClient {
         }),
         [channel.port1],
       );
-      return await this.#ready;
+      const ready = await this.#ready;
+      this.#playing = true;
+      this.#fatalOwner = null;
+      return ready;
     } catch (error) {
       this.#rollbackFailedStart(error, canvasTransferred);
       throw error;
@@ -163,25 +179,34 @@ export class RetainedExecutionWorkerClient {
     const result = await this.#requestEngine("set_loop_duration", {
       loopDurationSeconds: duration,
     });
+    this.#rememberPlaying(result);
     this.#loopDurationSeconds = duration;
     return result;
   }
 
   async pause() {
-    return this.#requestEngine("pause", {});
+    const result = await this.#requestEngine("pause", {});
+    this.#rememberPlaying(result);
+    return result;
   }
 
   async resume() {
-    return this.#requestEngine("resume", {});
+    const result = await this.#requestEngine("resume", {});
+    this.#rememberPlaying(result);
+    return result;
   }
 
   async seek(timeSeconds) {
     const time = validateSeekTimeSeconds(timeSeconds, this.#loopDurationSeconds);
-    return this.#requestEngine("seek", { time });
+    const result = await this.#requestEngine("seek", { time });
+    this.#rememberPlaying(result);
+    return result;
   }
 
   async restartPlayback() {
-    return this.#requestEngine("restart_playback", {});
+    const result = await this.#requestEngine("restart_playback", {});
+    this.#rememberPlaying(result);
+    return result;
   }
 
   resize(width, height, devicePixelRatio = 1) {
@@ -196,7 +221,7 @@ export class RetainedExecutionWorkerClient {
     );
   }
 
-  async restart() {
+  async restart({ failedOwner = this.#fatalOwner } = {}) {
     if (
       this.#sceneJson === null ||
       this.#retainedDocumentJson === null ||
@@ -204,18 +229,90 @@ export class RetainedExecutionWorkerClient {
     ) {
       throw new Error("RetainedExecutionWorkerClient has not been started");
     }
+    if (failedOwner !== null && failedOwner !== "engine" && failedOwner !== "render") {
+      throw new TypeError(`unsupported failed mixed retained owner ${failedOwner}`);
+    }
+    if (failedOwner === "engine" && this.#renderWorker !== null) {
+      return this.#restartEngine();
+    }
+    return this.#restartAll();
+  }
+
+  async #restartEngine() {
+    const wasPlaying = this.#playing;
+    const reconnectError = new Error("mixed retained engine worker restarting");
+    this.#engineWorker?.terminate();
+    this.#engineWorker = null;
+    this.#rejectOwner("engine", reconnectError);
+
+    const channel = new MessageChannel();
+    const renderAttached = this.#request(
+      this.#renderWorker,
+      "render",
+      renderEnvelope,
+      "attach_engine",
+      { port: channel.port2, transportMode: this.#transportMode },
+      [channel.port2],
+    ).catch((error) => {
+      this.#markFatalOwner("render");
+      throw error;
+    });
+    this.#session = checkedNext(this.#session, "mixed retained execution session");
+    this.#engineWorker = new Worker(
+      new URL("./retained-execution-engine-worker.js", import.meta.url),
+      { type: "module", name: "noon-mixed-retained-engine" },
+    );
+    const engineReady = this.#workerReady(this.#engineWorker, ENGINE_CHANNEL, "engine");
+    const nextReady = Promise.all([engineReady, renderAttached]).then(([engine, render]) => ({
+      engine,
+      render,
+      transportMode: this.#transportMode,
+      session: this.#session,
+    }));
+    this.#ready = nextReady;
+    this.#engineWorker.postMessage(
+      engineEnvelope("init", {
+        port: channel.port1,
+        sceneJson: this.#sceneJson,
+        retainedDocumentJson: this.#retainedDocumentJson,
+        loopDurationSeconds: this.#loopDurationSeconds,
+        transportMode: this.#transportMode,
+        sharedSlotCapacity: this.#sharedSlotCapacity,
+        session: this.#session,
+      }),
+      [channel.port1],
+    );
+
+    const ready = await nextReady;
+    this.#playing = true;
+    if (!wasPlaying) {
+      await this.pause();
+    }
+    this.#fatalOwner = null;
+    return ready;
+  }
+
+  async #restartAll() {
     const sceneJson = this.#sceneJson;
     const retainedDocumentJson = this.#retainedDocumentJson;
     const loopDurationSeconds = this.#loopDurationSeconds;
     const transportMode = this.#transportMode;
+    const sharedSlotCapacity = this.#sharedSlotCapacity;
+    const wasPlaying = this.#playing;
     if (this.#engineWorker !== null || this.#renderWorker !== null) {
       this.terminate();
       this.#canvas = replaceExecutionCanvas(this.#canvas);
     }
-    return this.start(sceneJson, retainedDocumentJson, {
+    const ready = await this.start(sceneJson, retainedDocumentJson, {
       loopDurationSeconds,
       transportMode,
+      sharedSlotCapacity,
     });
+    if (!wasPlaying) {
+      await this.pause();
+    }
+    this.#fatalOwner = null;
+    return ready;
   }
 
   terminate() {
@@ -229,31 +326,36 @@ export class RetainedExecutionWorkerClient {
       pending.reject(error);
     }
     this.#pending.clear();
+    this.#fatalOwner = null;
   }
 
-  async #requestEngine(type, payload) {
+  async #requestEngine(type, payload, transfer = []) {
     await this.ready();
-    return this.#request(this.#engineWorker, "engine", engineEnvelope, type, payload);
+    return this.#request(this.#engineWorker, "engine", engineEnvelope, type, payload, transfer);
   }
 
-  async #requestRender(type, payload) {
+  async #requestRender(type, payload, transfer = []) {
     await this.ready();
-    return this.#request(this.#renderWorker, "render", renderEnvelope, type, payload);
+    return this.#request(this.#renderWorker, "render", renderEnvelope, type, payload, transfer);
   }
 
-  #request(worker, owner, envelopeFactory, type, payload) {
+  #request(worker, owner, envelopeFactory, type, payload, transfer = []) {
     const requestId = this.#nextRequestId;
     this.#nextRequestId = checkedNext(this.#nextRequestId, "mixed retained worker request ID");
     const result = new Promise((resolve, reject) => {
       this.#pending.set(`${owner}:${requestId}`, { resolve, reject });
     });
-    worker.postMessage(envelopeFactory(type, { requestId, ...payload }));
+    worker.postMessage(envelopeFactory(type, { requestId, ...payload }), transfer);
     return result;
   }
 
   #workerReady(worker, channel, owner) {
     return new Promise((resolve, reject) => {
       worker.addEventListener("message", (event) => {
+        if (!this.#isCurrentWorker(owner, worker)) {
+          this.#recordStaleWorkerEvent(owner);
+          return;
+        }
         const message = event.data;
         try {
           validateWorkerEnvelope(message, channel);
@@ -265,7 +367,8 @@ export class RetainedExecutionWorkerClient {
             const error = new Error(message.message || `${owner} mixed retained worker failed`);
             if (message.requestId === null || message.requestId === undefined) {
               reject(error);
-              this.#onError?.(error, owner);
+              this.#rejectOwner(owner, error);
+              this.#notifyError(error, owner);
               return;
             }
             this.#settle(owner, message.requestId, ({ reject: rejectPending }) => {
@@ -280,20 +383,29 @@ export class RetainedExecutionWorkerClient {
           }
         } catch (error) {
           reject(error);
-          this.#onError?.(error, owner);
+          this.#rejectOwner(owner, error);
+          this.#notifyError(error, owner);
         }
       });
       worker.addEventListener("error", (event) => {
+        if (!this.#isCurrentWorker(owner, worker)) {
+          this.#recordStaleWorkerEvent(owner);
+          return;
+        }
         const error = new Error(event.message || `${owner} mixed retained worker crashed`);
         reject(error);
         this.#rejectOwner(owner, error);
-        this.#onError?.(error, owner);
+        this.#notifyError(error, owner);
       });
       worker.addEventListener("messageerror", () => {
+        if (!this.#isCurrentWorker(owner, worker)) {
+          this.#recordStaleWorkerEvent(owner);
+          return;
+        }
         const error = new Error(`${owner} mixed retained worker message could not be decoded`);
         reject(error);
         this.#rejectOwner(owner, error);
-        this.#onError?.(error, owner);
+        this.#notifyError(error, owner);
       });
     });
   }
@@ -330,8 +442,34 @@ export class RetainedExecutionWorkerClient {
       pending.reject(error);
     }
     this.#pending.clear();
+    this.#fatalOwner = null;
     if (replaceCanvas) {
       this.#canvas = replaceExecutionCanvas(this.#canvas);
+    }
+  }
+
+  #isCurrentWorker(owner, worker) {
+    return owner === "engine" ? this.#engineWorker === worker : this.#renderWorker === worker;
+  }
+
+  #recordStaleWorkerEvent(owner) {
+    this.#staleWorkerEvents[owner] += 1;
+  }
+
+  #markFatalOwner(owner) {
+    if (owner === "render" || this.#fatalOwner === null) {
+      this.#fatalOwner = owner;
+    }
+  }
+
+  #notifyError(error, owner) {
+    this.#markFatalOwner(owner);
+    this.#onError?.(error, owner);
+  }
+
+  #rememberPlaying(result) {
+    if (typeof result?.playing === "boolean") {
+      this.#playing = result.playing;
     }
   }
 


### PR DESCRIPTION
## Summary

Remove destructive canvas replacement from **engine-only** worker recovery while retaining the established full-worker/canvas fallback for renderer loss.

- record the fatal owner (`engine` vs `render`) in legacy and mixed-retained execution clients
- reconnect a replacement engine to the existing render worker through a fresh `MessagePort`
- preserve the exact HTML canvas / OffscreenCanvas owner and cumulative renderer presentation state during engine recovery
- preserve authored scene/configuration, loop duration, transport mode, shared-slot capacity, and paused/running mode
- restore Python host callback ports/configuration and explicitly request the current callback phase before recovery completes
- preserve callback activation windows when caching configuration for recovery
- keep render failure dominant so a renderer fault still takes the full-worker/canvas replacement path
- reconnect retained execution without rebuilding immutable GPU-owned retained resources
- ignore queued events from detached worker/port generations
- exercise transferable/shared recovery, callback recovery, and paused recovery in deterministic unit/browser gates

## Retained resources

A replacement retained engine deterministically emits its immutable resource bundle before its fresh snapshot. The live retained renderer accepts exactly one reconnect-generation bundle, validates the envelope, keeps its existing GPU-owned resources, and then applies the replacement engine snapshot. The browser smoke requires the new engine to report one resource transfer while the renderer has no pending resource generation.

## Recovery boundary

This PR preserves the live renderer surface and authored execution configuration across an engine-process restart; it does **not** claim arbitrary in-process engine state can be reconstructed exactly after process loss. A replacement engine is rebuilt from the authoritative authored scene/configuration. Paused/running mode and host callback configuration are restored, but exact checkpoint/replay of logical time or arbitrary side effects from host callbacks would require a separate explicit recovery-checkpoint design.

## Why

Renderer context/device loss already recovers inside the renderer. The remaining common reload-like boundary was engine-process recovery: `restart()` still killed a healthy render worker and replaced the transferred HTML canvas. Engine and renderer are already separated by a `MessageChannel`, so the narrower recovery boundary is to replace only the failed engine and reconnect that channel.

Full surface replacement remains intentionally reserved for actual render-worker loss or legacy↔retained execution-mode changes.