### PR TITLE
Harden deterministic playback controls

### DIFF
--- a/crates/noon-web/src/clock.rs
+++ b/crates/noon-web/src/clock.rs
@@ -31,12 +31,13 @@ impl std::fmt::Display for ClockError {
 
 impl std::error::Error for ClockError {}
 
-/// Converts monotonic `requestAnimationFrame` timestamps to deterministic scene time.
+/// Converts monotonic browser presentation timestamps into deterministic scene time.
 ///
-/// Browser scheduling remains outside the semantic runtime. Playback controls mutate
-/// only this logical clock: pausing freezes the current phase, resuming re-anchors it
-/// to the last accepted browser timestamp, and seeking establishes an exact logical
-/// time without replaying intermediate frames.
+/// Browser scheduling is never the semantic time owner. Pause freezes the current
+/// logical phase, resume and running seek re-anchor on the next accepted frame so
+/// control latency cannot create a catch-up jump, and seek establishes one exact
+/// logical time without replaying intermediate frames. For looping clocks, the exact
+/// endpoint remains a valid seek target until playback advances positively.
 #[derive(Clone, Debug, PartialEq)]
 pub struct PlaybackClock {
     loop_duration: Option<f64>,
@@ -69,19 +70,23 @@ impl PlaybackClock {
 
     pub fn scene_time(&mut self, timestamp_ms: f64) -> Result<f64, ClockError> {
         self.validate_timestamp(timestamp_ms)?;
-        let anchor = *self.anchor_ms.get_or_insert(timestamp_ms);
         self.previous_ms = Some(timestamp_ms);
+
         if !self.playing {
             return Ok(self.anchor_scene_time);
         }
-        Ok(self.running_time(anchor, timestamp_ms))
+
+        let anchor_ms = *self.anchor_ms.get_or_insert(timestamp_ms);
+        let elapsed = (timestamp_ms - anchor_ms) / 1_000.0;
+        Ok(self.running_time(elapsed))
     }
 
     pub fn pause(&mut self) {
         if !self.playing {
             return;
         }
-        self.reanchor_to_current_time();
+        self.anchor_scene_time = self.current_time();
+        self.anchor_ms = self.previous_ms;
         self.playing = false;
     }
 
@@ -89,15 +94,15 @@ impl PlaybackClock {
         if self.playing {
             return;
         }
-        self.anchor_ms = self.previous_ms;
         self.playing = true;
+        self.anchor_ms = None;
     }
 
-    pub fn seek(&mut self, scene_time: f64) -> Result<(), ClockError> {
+    pub fn seek(&mut self, scene_time: f64) -> Result<f64, ClockError> {
         self.validate_scene_time(scene_time)?;
         self.anchor_scene_time = scene_time;
-        self.anchor_ms = self.previous_ms;
-        Ok(())
+        self.anchor_ms = if self.playing { None } else { self.previous_ms };
+        Ok(scene_time)
     }
 
     pub fn set_loop_duration(&mut self, duration: f64) -> Result<(), ClockError> {
@@ -105,11 +110,22 @@ impl PlaybackClock {
             return Err(ClockError::InvalidLoopDuration(duration));
         }
 
-        self.reanchor_to_current_time();
-        if self.anchor_scene_time > duration {
-            self.anchor_scene_time = self.anchor_scene_time.rem_euclid(duration);
-        }
+        // `anchor_ms == None` while playing means initial start, resume, or seek is
+        // still waiting for the next browser frame to establish a wall-clock anchor.
+        // Retiming in that window must not charge control latency into scene time.
+        let reanchor_on_next_frame = self.playing && self.anchor_ms.is_none();
+        let current_time = self.current_time();
         self.loop_duration = Some(duration);
+        self.anchor_scene_time = if current_time > duration {
+            current_time.rem_euclid(duration)
+        } else {
+            current_time
+        };
+        self.anchor_ms = if reanchor_on_next_frame {
+            None
+        } else {
+            self.previous_ms
+        };
         Ok(())
     }
 
@@ -126,6 +142,17 @@ impl PlaybackClock {
 
     pub const fn is_playing(&self) -> bool {
         self.playing
+    }
+
+    pub fn current_time(&self) -> f64 {
+        if !self.playing {
+            return self.anchor_scene_time;
+        }
+        let elapsed = match (self.anchor_ms, self.previous_ms) {
+            (Some(anchor), Some(previous)) => (previous - anchor) / 1_000.0,
+            _ => 0.0,
+        };
+        self.running_time(elapsed)
     }
 
     fn validate_timestamp(&self, timestamp_ms: f64) -> Result<(), ClockError> {
@@ -158,20 +185,7 @@ impl PlaybackClock {
         Ok(())
     }
 
-    fn reanchor_to_current_time(&mut self) {
-        let Some(previous) = self.previous_ms else {
-            self.anchor_ms = None;
-            return;
-        };
-        if self.playing {
-            let anchor = self.anchor_ms.unwrap_or(previous);
-            self.anchor_scene_time = self.running_time(anchor, previous);
-        }
-        self.anchor_ms = Some(previous);
-    }
-
-    fn running_time(&self, anchor_ms: f64, timestamp_ms: f64) -> f64 {
-        let elapsed = (timestamp_ms - anchor_ms) / 1_000.0;
+    fn running_time(&self, elapsed: f64) -> f64 {
         let raw = self.anchor_scene_time + elapsed;
         match self.loop_duration {
             Some(duration) if elapsed == 0.0 && self.anchor_scene_time == duration => duration,
@@ -194,115 +208,160 @@ mod tests {
     #[test]
     fn clock_uses_first_frame_as_deterministic_origin() {
         let mut clock = PlaybackClock::once();
-
-        assert_eq!(clock.scene_time(4_250.0).expect("valid frame"), 0.0);
-        assert_eq!(clock.scene_time(5_500.0).expect("valid frame"), 1.25);
+        assert_eq!(clock.scene_time(4_250.0).unwrap(), 0.0);
+        assert_eq!(clock.scene_time(5_500.0).unwrap(), 1.25);
     }
 
     #[test]
     fn looping_clock_wraps_at_declared_duration() {
-        let mut clock = PlaybackClock::looping(2.0).expect("valid loop");
-
-        assert_eq!(clock.scene_time(100.0).expect("valid frame"), 0.0);
-        assert_eq!(clock.scene_time(2_600.0).expect("valid frame"), 0.5);
+        let mut clock = PlaybackClock::looping(2.0).unwrap();
+        assert_eq!(clock.scene_time(100.0).unwrap(), 0.0);
+        assert_eq!(clock.scene_time(2_600.0).unwrap(), 0.5);
     }
 
     #[test]
     fn changing_loop_duration_preserves_the_current_phase() {
-        let mut clock = PlaybackClock::looping(4.0).expect("valid loop");
-        assert_eq!(clock.scene_time(100.0).expect("valid frame"), 0.0);
-        assert_eq!(clock.scene_time(1_600.0).expect("valid frame"), 1.5);
-
-        clock
-            .set_loop_duration(3.0)
-            .expect("updated duration must be valid");
-        assert_eq!(clock.scene_time(1_600.0).expect("same frame"), 1.5);
-        assert_eq!(clock.scene_time(3_100.0).expect("valid frame"), 0.0);
+        let mut clock = PlaybackClock::looping(4.0).unwrap();
+        clock.scene_time(100.0).unwrap();
+        assert_eq!(clock.scene_time(1_600.0).unwrap(), 1.5);
+        clock.set_loop_duration(3.0).unwrap();
+        assert_eq!(clock.scene_time(1_600.0).unwrap(), 1.5);
+        assert_eq!(clock.scene_time(3_100.0).unwrap(), 0.0);
     }
 
     #[test]
     fn shrinking_loop_duration_normalizes_only_when_required() {
-        let mut clock = PlaybackClock::looping(5.0).expect("valid loop");
-        assert_eq!(clock.scene_time(100.0).expect("valid frame"), 0.0);
-        assert_eq!(clock.scene_time(3_600.0).expect("valid frame"), 3.5);
-
-        clock
-            .set_loop_duration(2.0)
-            .expect("updated duration must be valid");
-        assert_eq!(clock.scene_time(3_600.0).expect("same frame"), 1.5);
+        let mut clock = PlaybackClock::looping(5.0).unwrap();
+        clock.scene_time(100.0).unwrap();
+        assert_eq!(clock.scene_time(3_600.0).unwrap(), 3.5);
+        clock.set_loop_duration(2.0).unwrap();
+        assert_eq!(clock.scene_time(3_600.0).unwrap(), 1.5);
     }
 
     #[test]
-    fn pause_freezes_and_resume_continues_without_a_jump() {
-        let mut clock = PlaybackClock::looping(4.0).expect("valid loop");
-        assert_eq!(clock.scene_time(100.0).unwrap(), 0.0);
-        assert_eq!(clock.scene_time(1_600.0).unwrap(), 1.5);
-
+    fn pause_freezes_while_browser_timestamps_continue() {
+        let mut clock = PlaybackClock::looping(4.0).unwrap();
+        clock.scene_time(100.0).unwrap();
+        assert_eq!(clock.scene_time(600.0).unwrap(), 0.5);
         clock.pause();
         assert!(!clock.is_playing());
-        assert_eq!(clock.scene_time(5_000.0).unwrap(), 1.5);
-        assert_eq!(clock.scene_time(8_000.0).unwrap(), 1.5);
-
-        clock.resume();
-        assert!(clock.is_playing());
-        assert_eq!(clock.scene_time(8_000.0).unwrap(), 1.5);
-        assert_eq!(clock.scene_time(8_500.0).unwrap(), 2.0);
+        assert_eq!(clock.scene_time(1_600.0).unwrap(), 0.5);
+        assert_eq!(clock.scene_time(5_600.0).unwrap(), 0.5);
+        assert_eq!(clock.current_time(), 0.5);
     }
 
     #[test]
-    fn seek_is_exact_while_paused_and_reanchors_running_playback() {
-        let mut clock = PlaybackClock::looping(4.0).expect("valid loop");
+    fn resume_reanchors_on_next_frame_without_catch_up() {
+        let mut clock = PlaybackClock::looping(4.0).unwrap();
+        clock.scene_time(100.0).unwrap();
+        clock.scene_time(600.0).unwrap();
+        clock.pause();
+        clock.scene_time(5_600.0).unwrap();
+        clock.resume();
+        assert!(clock.is_playing());
+        assert_eq!(clock.scene_time(7_000.0).unwrap(), 0.5);
+        assert_eq!(clock.scene_time(7_250.0).unwrap(), 0.75);
+    }
+
+    #[test]
+    fn running_seek_reanchors_on_next_frame_at_exact_phase() {
+        let mut clock = PlaybackClock::looping(4.0).unwrap();
+        clock.scene_time(100.0).unwrap();
+        clock.scene_time(1_100.0).unwrap();
+        assert_eq!(clock.seek(1.25).unwrap(), 1.25);
+        assert_eq!(clock.current_time(), 1.25);
+        assert_eq!(clock.scene_time(2_000.0).unwrap(), 1.25);
+        assert_eq!(clock.scene_time(2_500.0).unwrap(), 1.75);
+    }
+
+    #[test]
+    fn seek_while_paused_stays_exact_until_resume() {
+        let mut clock = PlaybackClock::looping(4.0).unwrap();
         clock.scene_time(100.0).unwrap();
         clock.scene_time(1_100.0).unwrap();
         clock.pause();
-
-        clock.seek(3.25).unwrap();
-        assert_eq!(clock.scene_time(2_000.0).unwrap(), 3.25);
-        assert_eq!(clock.scene_time(7_000.0).unwrap(), 3.25);
-
+        assert_eq!(clock.seek(3.25).unwrap(), 3.25);
+        assert_eq!(clock.scene_time(5_000.0).unwrap(), 3.25);
         clock.resume();
-        clock.seek(1.25).unwrap();
-        assert_eq!(clock.scene_time(7_000.0).unwrap(), 1.25);
-        assert_eq!(clock.scene_time(7_500.0).unwrap(), 1.75);
+        assert_eq!(clock.scene_time(7_000.0).unwrap(), 3.25);
+        assert_eq!(clock.scene_time(7_250.0).unwrap(), 3.5);
     }
 
     #[test]
     fn exact_loop_endpoint_survives_seek_until_playback_advances() {
-        let mut clock = PlaybackClock::looping(4.0).expect("valid loop");
+        let mut clock = PlaybackClock::looping(4.0).unwrap();
         clock.scene_time(1_000.0).unwrap();
-        clock.seek(4.0).unwrap();
-
-        assert_eq!(clock.scene_time(1_000.0).unwrap(), 4.0);
-        assert_eq!(clock.scene_time(1_250.0).unwrap(), 0.25);
+        assert_eq!(clock.seek(4.0).unwrap(), 4.0);
+        assert_eq!(clock.scene_time(2_000.0).unwrap(), 4.0);
+        assert_eq!(clock.scene_time(2_250.0).unwrap(), 0.25);
     }
 
     #[test]
     fn invalid_seek_does_not_mutate_the_clock() {
-        let mut clock = PlaybackClock::looping(4.0).expect("valid loop");
+        let mut clock = PlaybackClock::looping(4.0).unwrap();
         clock.scene_time(100.0).unwrap();
         clock.scene_time(1_100.0).unwrap();
-
+        let before = clock.clone();
         assert!(matches!(
             clock.seek(-1.0),
             Err(ClockError::InvalidSceneTime(-1.0))
         ));
+        assert_eq!(clock, before);
         assert!(matches!(
             clock.seek(4.1),
             Err(ClockError::SceneTimeOutsideLoop { .. })
         ));
-        assert_eq!(clock.scene_time(1_100.0).unwrap(), 1.0);
+        assert_eq!(clock, before);
     }
 
     #[test]
-    fn reset_establishes_a_new_time_origin_and_resumes_playback() {
-        let mut clock = PlaybackClock::once();
-        clock.scene_time(100.0).expect("valid frame");
-        clock.scene_time(600.0).expect("valid frame");
+    fn retiming_during_pending_resume_preserves_reanchor() {
+        let mut clock = PlaybackClock::looping(5.0).unwrap();
+        clock.scene_time(100.0).unwrap();
+        clock.scene_time(1_100.0).unwrap();
         clock.pause();
-        clock.reset();
+        clock.scene_time(6_100.0).unwrap();
+        clock.resume();
+        clock.set_loop_duration(3.0).unwrap();
+        assert_eq!(clock.current_time(), 1.0);
+        assert_eq!(clock.scene_time(7_000.0).unwrap(), 1.0);
+        assert_eq!(clock.scene_time(7_250.0).unwrap(), 1.25);
+    }
 
+    #[test]
+    fn retiming_during_pending_seek_preserves_exact_next_frame() {
+        let mut clock = PlaybackClock::looping(5.0).unwrap();
+        clock.scene_time(100.0).unwrap();
+        clock.scene_time(1_100.0).unwrap();
+        clock.seek(2.5).unwrap();
+        clock.set_loop_duration(4.0).unwrap();
+        assert_eq!(clock.current_time(), 2.5);
+        assert_eq!(clock.scene_time(4_000.0).unwrap(), 2.5);
+        assert_eq!(clock.scene_time(4_500.0).unwrap(), 3.0);
+    }
+
+    #[test]
+    fn retiming_preserves_exact_endpoint_when_new_duration_matches() {
+        let mut clock = PlaybackClock::looping(5.0).unwrap();
+        clock.scene_time(100.0).unwrap();
+        clock.seek(3.0).unwrap();
+        clock.set_loop_duration(3.0).unwrap();
+        assert_eq!(clock.scene_time(4_000.0).unwrap(), 3.0);
+        let advanced = clock.scene_time(4_100.0).unwrap();
+        assert!((advanced - 0.1).abs() <= 1.0e-12);
+    }
+
+    #[test]
+    fn reset_returns_to_running_zero_origin() {
+        let mut clock = PlaybackClock::once();
+        clock.scene_time(100.0).unwrap();
+        clock.scene_time(600.0).unwrap();
+        clock.pause();
+        clock.seek(2.0).unwrap();
+        clock.reset();
         assert!(clock.is_playing());
-        assert_eq!(clock.scene_time(20.0).expect("valid frame"), 0.0);
+        assert_eq!(clock.current_time(), 0.0);
+        assert_eq!(clock.scene_time(20.0).unwrap(), 0.0);
     }
 
     #[test]
@@ -311,13 +370,14 @@ mod tests {
             PlaybackClock::looping(0.0),
             Err(ClockError::InvalidLoopDuration(0.0))
         ));
-
         let mut clock = PlaybackClock::once();
-        clock.scene_time(100.0).expect("valid frame");
+        clock.scene_time(100.0).unwrap();
+        let before = clock.clone();
         assert!(matches!(
             clock.scene_time(99.0),
             Err(ClockError::TimestampWentBackwards { .. })
         ));
-        assert_eq!(clock.scene_time(200.0).expect("valid frame"), 0.1);
+        assert_eq!(clock, before);
+        assert_eq!(clock.scene_time(200.0).unwrap(), 0.1);
     }
 }

--- a/scripts/authoring-execution-router-smoke.mjs
+++ b/scripts/authoring-execution-router-smoke.mjs
@@ -154,6 +154,9 @@ try {
     const mixedResume = await execution.resume();
     await new Promise((resolve) => setTimeout(resolve, 160));
     const mixedResumedState = await execution.state();
+    const mixedPlaybackRestart = await execution.restartPlayback();
+    const mixedPlaybackRestartCanvas = execution.canvas;
+    const mixedPlaybackRestartState = await execution.state();
 
     const mixedRestartReady = await execution.restart();
     const mixedRestartCanvas = execution.canvas;
@@ -202,6 +205,9 @@ try {
     const legacyResume = await execution.resume();
     await new Promise((resolve) => setTimeout(resolve, 160));
     const legacyResumedState = await execution.state();
+    const legacyPlaybackRestart = await execution.restartPlayback();
+    const legacyPlaybackRestartCanvas = execution.canvas;
+    const legacyPlaybackRestartState = await execution.state();
 
     const secondLegacy = await execution.reconcileScene(JSON.stringify(legacy.document), {
       retainedDocumentJson: JSON.stringify(legacy.retainedDocument),
@@ -233,6 +239,9 @@ try {
       mixedSeekState,
       mixedResume,
       mixedResumedState,
+      mixedPlaybackRestart,
+      mixedPlaybackRestartPreservedCanvas: mixedPlaybackRestartCanvas === mixedCanvas,
+      mixedPlaybackRestartState,
       mixedRestartMode: mixedRestartReady.mode,
       mixedRestartCanvasChanged: mixedRestartCanvas !== mixedCanvas,
       mixedRestartObjectCount: mixedRestartMetrics.metrics.objectCount,
@@ -254,6 +263,9 @@ try {
       legacySeekState,
       legacyResume,
       legacyResumedState,
+      legacyPlaybackRestart,
+      legacyPlaybackRestartPreservedCanvas: legacyPlaybackRestartCanvas === legacyCanvas,
+      legacyPlaybackRestartState,
       secondLegacyMode: secondLegacy.mode,
       secondLegacyRebuilt: secondLegacy.rebuilt,
       legacyRestartMode: legacyRestartReady.mode,
@@ -300,6 +312,12 @@ try {
   assert.equal(result.mixedResume.playing, true);
   assert.ok(result.mixedResumedState.time > 2.5);
   assert.equal(result.mixedResumedState.playing, true);
+  assert.equal(result.mixedPlaybackRestart.operation, "restart_playback");
+  assert.equal(result.mixedPlaybackRestart.time, 0);
+  assert.equal(result.mixedPlaybackRestart.playing, true);
+  assert.equal(result.mixedPlaybackRestartPreservedCanvas, true);
+  assert.equal(result.mixedPlaybackRestartState.time, 0);
+  assert.equal(result.mixedPlaybackRestartState.playing, true);
   assert.equal(result.mixedRestartMode, result.retainedMode);
   assert.equal(result.mixedRestartCanvasChanged, true);
   assert.equal(result.mixedRestartObjectCount, 3);
@@ -331,6 +349,12 @@ try {
   assert.equal(result.legacyResume.playing, true);
   assert.ok(result.legacyResumedState.time > 1.5);
   assert.equal(result.legacyResumedState.playing, true);
+  assert.equal(result.legacyPlaybackRestart.operation, "restart_playback");
+  assert.equal(result.legacyPlaybackRestart.time, 0);
+  assert.equal(result.legacyPlaybackRestart.playing, true);
+  assert.equal(result.legacyPlaybackRestartPreservedCanvas, true);
+  assert.equal(result.legacyPlaybackRestartState.time, 0);
+  assert.equal(result.legacyPlaybackRestartState.playing, true);
   assert.equal(result.secondLegacyMode, result.initialMode);
   assert.equal(result.secondLegacyRebuilt, false);
   assert.equal(result.legacyRestartMode, result.initialMode);

--- a/scripts/execution-worker-host-smoke.mjs
+++ b/scripts/execution-worker-host-smoke.mjs
@@ -123,6 +123,92 @@ try {
   );
   assert.equal(after.engineMetrics.host.errors, 0);
 
+  const barrierAuthored = await page.evaluate(async (pythonSource) => {
+    const { authoring, client } = window.executionHostSmoke;
+    const authored = await authoring.run(pythonSource);
+    if (authored.kind !== "scene_document" || authored.callbacks === null) {
+      throw new Error("seek barrier smoke must author a callback scene");
+    }
+    await client.configureHostCallbacks(authored.callbacks, authoring);
+    return { callbackCount: authored.callbacks.slots.length };
+  }, teardownSource);
+  assert.equal(barrierAuthored.callbackCount, 1);
+
+  const seekBarrier = await page.evaluate(async () => {
+    const { client } = window.executionHostSmoke;
+    const deadline = performance.now() + 30_000;
+    while (performance.now() < deadline) {
+      const observedMetrics = await client.metrics();
+      if (observedMetrics.engineMetrics.host.enabled && observedMetrics.engineMetrics.host.inFlight) {
+        const beforeState = await client.state();
+        const pausePromise = client.pause();
+        const seekPromise = client.seek(0.5);
+        const [paused, sought] = await Promise.all([pausePromise, seekPromise]);
+        return {
+          observedMetrics,
+          beforeState,
+          paused,
+          sought,
+          state: await client.state(),
+          report: await client.metrics(),
+        };
+      }
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    throw new Error("seek barrier smoke never observed an in-flight host callback");
+  });
+
+  assert.equal(seekBarrier.observedMetrics.engineMetrics.host.inFlight, true);
+  assert.equal(seekBarrier.paused.operation, "pause");
+  assert.equal(seekBarrier.sought.operation, "seek");
+  assert.equal(seekBarrier.sought.time, 0.5);
+  assert.equal(seekBarrier.sought.playing, false);
+  assert.equal(seekBarrier.state.time, 0.5);
+  assert.equal(seekBarrier.state.playing, false);
+  assert.equal(seekBarrier.report.engineMetrics.host.enabled, true);
+  assert.equal(
+    seekBarrier.report.engineMetrics.host.generation,
+    seekBarrier.observedMetrics.engineMetrics.host.generation + 1,
+    "seek did not advance the host callback generation",
+  );
+  assert.equal(
+    seekBarrier.report.engineMetrics.host.nextSequence,
+    seekBarrier.observedMetrics.engineMetrics.host.nextSequence,
+    "seek reset the host callback patch sequence",
+  );
+  assert.ok(
+    seekBarrier.report.engineMetrics.host.droppedLateResults >=
+      seekBarrier.observedMetrics.engineMetrics.host.droppedLateResults + 1,
+    "seek did not account for invalidated in-flight callback work",
+  );
+  assert.ok(
+    seekBarrier.report.engineMetrics.host.requests >=
+      seekBarrier.observedMetrics.engineMetrics.host.requests + 1,
+    "seek did not request a replacement callback phase",
+  );
+  assert.equal(seekBarrier.report.engineMetrics.host.inFlight, true);
+  assert.equal(
+    seekBarrier.report.engineMetrics.host.lastFrameTime,
+    0.5,
+    "seek did not request the callback phase at the exact sought time",
+  );
+  assert.equal(
+    seekBarrier.state.nextPatchSequence,
+    seekBarrier.beforeState.nextPatchSequence,
+    "seek consumed the interactive patch sequence",
+  );
+
+  await page.waitForTimeout(250);
+  const afterSeekBarrier = await page.evaluate(async () => ({
+    state: await window.executionHostSmoke.client.state(),
+    report: await window.executionHostSmoke.client.metrics(),
+  }));
+  assert.equal(afterSeekBarrier.state.time, 0.5);
+  assert.equal(afterSeekBarrier.state.playing, false);
+  assert.equal(afterSeekBarrier.report.engineMetrics.host.enabled, true);
+  assert.equal(afterSeekBarrier.report.engineMetrics.host.errors, 0);
+  await page.evaluate(() => window.executionHostSmoke.client.resume());
+
   const teardownAuthored = await page.evaluate(async (pythonSource) => {
     const { authoring, client } = window.executionHostSmoke;
     const authored = await authoring.run(pythonSource);
@@ -197,7 +283,7 @@ try {
   console.log(
     `✓ slow Python host callback: ${after.engineMetrics.host.missedDeadlines} missed deadlines, ` +
       `${after.metrics.presentedFrames - before.metrics.presentedFrames} native frames presented; ` +
-      "stale callback dropped after teardown",
+      "seek barrier and teardown both dropped stale callback work",
   );
 } finally {
   await browser?.close();

--- a/web/authoring-execution-client.js
+++ b/web/authoring-execution-client.js
@@ -175,6 +175,10 @@ export class AuthoringExecutionClient {
     return this.#withStablePlayer((player) => player.seek(timeSeconds));
   }
 
+  async restartPlayback() {
+    return this.#withStablePlayer((player) => player.restartPlayback());
+  }
+
   async restart() {
     return this.#withStablePlayer(async (player, mode) => {
       try {

--- a/web/execution-engine-worker.js
+++ b/web/execution-engine-worker.js
@@ -50,6 +50,7 @@ async function handleMainMessage(message) {
       case "pause":
       case "resume":
       case "seek":
+      case "restart_playback":
       case "apply_patch":
       case "configure_callbacks":
         enqueueControl(message);
@@ -208,7 +209,10 @@ function handleHostMessage(message) {
 
     if (message.type === "error") {
       hostMetrics.errors += 1;
-      postMain({ type: "host_callback_error", message: String(message.message || "host callback failed") });
+      postMain({
+        type: "host_callback_error",
+        message: String(message.message || "host callback failed"),
+      });
       requestLatestHostPhase();
       return;
     }
@@ -331,29 +335,35 @@ function executeControl(message) {
       return;
     }
     case "pause": {
+      beginPlaybackControl(false);
       player.pause();
-      latestTick = null;
       respond(message.requestId, runtimeResult("pause"));
       return;
     }
     case "resume": {
+      beginPlaybackControl(false);
       player.resume();
-      latestTick = null;
       respond(message.requestId, runtimeResult("resume"));
       return;
     }
     case "seek": {
-      if (hostCallbacks !== null) {
-        throw new Error(
-          "deterministic seek is not supported while Python host callbacks are active",
-        );
-      }
+      beginPlaybackControl(true);
       const delta = player.seekDeltaJson(message.time);
-      latestTick = null;
       if (delta !== null && delta !== undefined) {
         sendDeltaOrThrow(delta);
       }
+      requestLatestHostPhase();
       respond(message.requestId, runtimeResult("seek"));
+      return;
+    }
+    case "restart_playback": {
+      beginPlaybackControl(true);
+      const delta = player.seekDeltaJson(0);
+      if (delta !== null && delta !== undefined) {
+        sendDeltaOrThrow(delta);
+      }
+      requestLatestHostPhase();
+      respond(message.requestId, runtimeResult("restart_playback"));
       return;
     }
     case "apply_patch": {
@@ -376,6 +386,20 @@ function executeControl(message) {
     default:
       throw new Error(`unknown queued engine command ${message.type}`);
   }
+}
+
+function beginPlaybackControl(invalidateHostPhase) {
+  latestTick = null;
+  if (!invalidateHostPhase || hostCallbacks === null) {
+    return;
+  }
+  hostGeneration = checkedIncrement(hostGeneration, "host callback generation");
+  if (hostInFlight !== null || pendingHostResult !== null) {
+    hostMetrics.droppedLateResults += 1;
+  }
+  hostInFlight = null;
+  pendingHostResult = null;
+  lastHostPhaseTime = Number.NaN;
 }
 
 function validateRequiredLoopDuration(duration) {
@@ -665,8 +689,10 @@ function validateCallbackConfig(callbacks) {
       }
     }
     if (
-      slot.active_after !== undefined && slot.active_after !== null &&
-      slot.active_through !== undefined && slot.active_through !== null &&
+      slot.active_after !== undefined &&
+      slot.active_after !== null &&
+      slot.active_through !== undefined &&
+      slot.active_through !== null &&
       slot.active_through < slot.active_after
     ) {
       throw new Error("host callback slot has an invalid activation window");

--- a/web/execution-worker-client.js
+++ b/web/execution-worker-client.js
@@ -225,6 +225,10 @@ export class ExecutionWorkerClient {
     return this.#requestEngine("seek", { time });
   }
 
+  async restartPlayback() {
+    return this.#requestEngine("restart_playback", {});
+  }
+
   async applyPatchBatch(patchBatchJson) {
     if (typeof patchBatchJson !== "string" || patchBatchJson.trim() === "") {
       throw new TypeError("patch batch must be non-empty JSON text");

--- a/web/retained-execution-engine-worker.js
+++ b/web/retained-execution-engine-worker.js
@@ -35,6 +35,7 @@ async function handleMainMessage(message) {
       case "pause":
       case "resume":
       case "seek":
+      case "restart_playback":
         enqueueControl(message);
         return;
       case "state":
@@ -242,6 +243,15 @@ function executeControl(message) {
         sendDeltaOrThrow(delta);
       }
       respond(message.requestId, runtimeResult("seek"));
+      return;
+    }
+    case "restart_playback": {
+      const delta = player.seekDeltaJson(0);
+      latestTick = null;
+      if (delta !== undefined && delta !== null) {
+        sendDeltaOrThrow(delta);
+      }
+      respond(message.requestId, runtimeResult("restart_playback"));
       return;
     }
     default:

--- a/web/retained-execution-worker-client.js
+++ b/web/retained-execution-worker-client.js
@@ -180,6 +180,10 @@ export class RetainedExecutionWorkerClient {
     return this.#requestEngine("seek", { time });
   }
 
+  async restartPlayback() {
+    return this.#requestEngine("restart_playback", {});
+  }
+
   resize(width, height, devicePixelRatio = 1) {
     this.#requireStarted();
     if (!Number.isFinite(width) || !Number.isFinite(height) || !Number.isFinite(devicePixelRatio)) {


### PR DESCRIPTION
## Summary
Follow-up hardening for the playback runtime already merged in #467.

- re-anchor running resume/seek on the next accepted browser frame so control-to-RAF latency cannot become logical-time catch-up
- preserve exact loop-endpoint seek behavior and pending re-anchor semantics across loop retiming
- add semantic `restartPlayback()` across legacy, mixed-retained, and `AuthoringExecutionClient`, distinct from worker/device recovery `restart()`
- replace legacy seek rejection with a callback-generation barrier that preserves Python callback configuration and callback patch sequence while dropping only stale pre-seek work
- keep existing worker startup rollback/recovery behavior unchanged

## Callback correctness
Legacy seek/restart advances the host callback generation, clears only in-flight/pending callback work from the old phase, preserves callback configuration and sequence, sends the exact sought scene delta, then requests a callback phase at that exact time. Existing signed `delta_time` semantics therefore remain valid across backward/forward seeks.

Pause/resume do not advance callback generation because they do not introduce a logical-time discontinuity.

## Validation
- clock unit tests cover pause freeze, next-frame resume/seek re-anchor, exact endpoint seek, invalid seek non-mutation, and retiming during pending re-anchor
- authoring-router Chromium smoke distinguishes semantic restart (same canvas, `t=0`) from recovery restart (new transferred canvas) in both retained and legacy modes
- slow-Python-callback smoke forces a 1-second updater in flight, performs pause+seek, and requires generation advance, callback configuration/sequence preservation, exact sought callback phase, and stale-result rejection
- existing callback teardown oracle remains in the same smoke to guard the pre-existing generation invalidation contract

Tracks #438. Related #110.