### PR TITLE
Validate canonical mixed scene tracks

### DIFF
--- a/crates/noon-ir/src/mixed.rs
+++ b/crates/noon-ir/src/mixed.rs
@@ -1,6 +1,9 @@
 use std::collections::HashSet;
 
-use noon_core::{GeometryRef, ObjectDefinition, ObjectId, Style, TrackDefinition, Transform2D};
+use noon_core::{
+    validate_track_definition, GeometryRef, ObjectDefinition, ObjectId, Style, TimelineError,
+    TrackDefinition, TrackId, Transform2D,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::{IrError, SceneDocument};
@@ -272,6 +275,19 @@ impl SceneSpec {
             }
         }
 
+        for track in &self.tracks {
+            if !ids.contains(&track.object) {
+                return Err(SceneSpecError::UnknownTrackObject {
+                    track: track.id,
+                    object: track.object,
+                });
+            }
+            validate_track_definition(track).map_err(|error| SceneSpecError::InvalidTrack {
+                track: track.id,
+                error,
+            })?;
+        }
+
         if let Some(camera) = self.camera_object {
             if !ids.contains(&camera) {
                 return Err(SceneSpecError::UnknownCameraObject(camera));
@@ -299,8 +315,19 @@ pub enum SceneSpecError {
     InvalidTextFontSize(f32),
     DuplicateObject(ObjectId),
     DuplicatePainterOrder(u32),
-    PainterOrderOutOfRange { order: u32, object_count: usize },
+    PainterOrderOutOfRange {
+        order: u32,
+        object_count: usize,
+    },
     OrderedObjectIsNotText(ObjectId),
+    UnknownTrackObject {
+        track: TrackId,
+        object: ObjectId,
+    },
+    InvalidTrack {
+        track: TrackId,
+        error: TimelineError,
+    },
     UnknownCameraObject(ObjectId),
     ObjectCountOverflow,
     Legacy(IrError),
@@ -335,6 +362,15 @@ impl std::fmt::Display for SceneSpecError {
                 "ordered text adapter object {} does not contain text",
                 object.get()
             ),
+            Self::UnknownTrackObject { track, object } => write!(
+                formatter,
+                "mixed SceneSpec track {} targets unknown object {}",
+                track.get(),
+                object.get()
+            ),
+            Self::InvalidTrack { track, error } => {
+                write!(formatter, "invalid mixed SceneSpec track {}: {error}", track.get())
+            }
             Self::UnknownCameraObject(object) => {
                 write!(formatter, "unknown SceneSpec camera object {}", object.get())
             }
@@ -349,7 +385,7 @@ impl std::error::Error for SceneSpecError {}
 
 #[cfg(test)]
 mod tests {
-    use noon_core::{Color, GeometryRef, SceneDefinition, Vec2};
+    use noon_core::{Color, GeometryRef, RateFunction, SceneDefinition, TrackTiming, Vec2};
 
     use super::*;
     use crate::SceneDocument;
@@ -361,6 +397,20 @@ mod tests {
         scene.object_mut(first).unwrap().transform.translation = Vec2::new(-2.0, 0.0);
         scene.object_mut(second).unwrap().style.opacity = 0.6;
         SceneDocument::from_scene(&scene)
+    }
+
+    fn scene_with_position_track() -> SceneDefinition {
+        let mut scene = SceneDefinition::new();
+        let object = scene.add(GeometryRef::circle(1.0));
+        scene
+            .animate_position(
+                object,
+                Vec2::ZERO,
+                Vec2::ONE,
+                TrackTiming::new(0.0, 1.0, RateFunction::Linear),
+            )
+            .unwrap();
+        scene
     }
 
     #[test]
@@ -476,6 +526,58 @@ mod tests {
                 vec![OrderedTextObjectSpec::new(1, collision).unwrap()],
             ),
             Err(SceneSpecError::DuplicateObject(_))
+        ));
+    }
+
+    #[test]
+    fn canonical_tracks_must_target_existing_mixed_objects() {
+        let scene = scene_with_position_track();
+        let track = scene.tracks()[0].clone();
+        let spec = SceneSpec {
+            version: SCENE_SPEC_VERSION,
+            objects: vec![ObjectSpec::text(
+                ObjectId::new(99),
+                TextSpec::typst("x", 24.0),
+            )],
+            tracks: vec![track.clone()],
+            camera_object: None,
+        };
+
+        assert!(matches!(
+            spec.validate(),
+            Err(SceneSpecError::UnknownTrackObject { track: id, object })
+                if id == track.id && object == track.object
+        ));
+    }
+
+    #[test]
+    fn canonical_tracks_reuse_shared_timeline_validation() {
+        let scene = scene_with_position_track();
+        let object = scene.objects()[0].id;
+        let mut track = scene.tracks()[0].clone();
+        track.timing.duration = 0.0;
+        let spec = SceneSpec {
+            version: SCENE_SPEC_VERSION,
+            objects: vec![ObjectSpec::geometry(object, GeometryRef::circle(1.0))],
+            tracks: vec![track.clone()],
+            camera_object: None,
+        };
+
+        assert!(matches!(
+            spec.validate(),
+            Err(SceneSpecError::InvalidTrack {
+                track: id,
+                error: TimelineError::InvalidDuration(0.0),
+            }) if id == track.id
+        ));
+
+        let json = serde_json::to_string(&spec).unwrap();
+        assert!(matches!(
+            SceneSpec::from_json(&json),
+            Err(SceneSpecError::InvalidTrack {
+                track: id,
+                error: TimelineError::InvalidDuration(0.0),
+            }) if id == track.id
         ));
     }
 


### PR DESCRIPTION
## Summary
- validate every canonical mixed `SceneSpec` track against the shared `noon-core` timeline validator
- reject tracks whose target `ObjectId` is absent from the mixed geometry/text identity domain
- preserve the offending `TrackId` and target/timeline error in typed diagnostics
- exercise both direct `validate()` and JSON admission through `SceneSpec::from_json()`

## Why
`SceneSpec::validate()` currently checks document version, object identity, text source settings, and camera identity, but does not validate its `TrackDefinition`s. The legacy `SceneDocument` path receives those checks through `SceneDefinition::from_parts`, while a directly-authored canonical mixed scene can currently admit an unknown track target or invalid timing/value/time-map definition.

That creates an inconsistent trust boundary precisely where #367 is converging geometry and text authoring. Malformed canonical input should fail before compilation/runtime rather than being allowed deeper into execution.

## Architecture
This does not duplicate timeline rules in `noon-ir`. The mixed IR only verifies that a track target belongs to its own canonical object set, then delegates structural timing/value/time-map checks to the existing shared `validate_track_definition()` implementation in `noon-core`.

## Parallelism
Only `crates/noon-ir/src/mixed.rs` changes. It does not overlap active resource-arena PRs (#445/#446), playback controls, browser recovery, retained-renderer performance, or geometry frontend adapters.

## Validation
Two focused tests cover unknown mixed-object targets and invalid non-instant duration; the latter is also serialized and rejected through `SceneSpec::from_json()`. Normal workspace CI will run the `noon-ir` suite.

Tracks #367 and #108.