### PR TITLE
Pin canonical SceneSpec wire compatibility

### DIFF
--- a/compat/wire-contracts-v1.json
+++ b/compat/wire-contracts-v1.json
@@ -1,10 +1,12 @@
 {
   "manifest_version": 1,
   "noon_ir_version": 1,
+  "scene_spec_version": 1,
   "authoring_protocol": {"channel": "noon.authoring", "version": 5},
   "contracts": [
     {"name":"scene_document","version_domain":"noon_ir","required":["version","objects","tracks"],"optional":[],"unknown_fields":"ignored","ordering":"objects and tracks preserve producer order"},
     {"name":"semantic_scene_document","version_domain":"noon_ir","required":["version","objects","tracks"],"optional":["reactive"],"defaults":{"reactive":{"signals":[],"bindings":[]}},"unknown_fields":"ignored","ordering":"objects, tracks, signals, and bindings preserve producer order"},
+    {"name":"canonical_scene_spec","version_domain":"scene_spec","required":["version","objects","tracks"],"optional":["camera_object"],"unknown_fields":"ignored","ordering":"objects are the canonical mixed geometry/text painter-order stream; tracks preserve producer order"},
     {"name":"patch_batch","version_domain":"noon_ir","required":["version","sequence","patches"],"optional":[],"unknown_fields":"ignored","ordering":"patches are applied in array order"},
     {"name":"authoring_envelope","version_domain":"authoring_protocol","required":["channel","protocolVersion","type"],"optional":["requestId","source","context","sessionId","frame","sequence","resultJson","patchBatchJson","message"],"unknown_fields":"ignored by the current client after envelope validation"},
     {"name":"authoring_result","version_domain":"authoring_protocol","required":["kind","document"],"optional":["identities","callbacks"],"notes":"scene_document results carry identities and optional callback session metadata; patch_batch results carry a Noon IR v1 PatchBatch"},

--- a/compat/wire/v1/scene-spec-mixed.json
+++ b/compat/wire/v1/scene-spec-mixed.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "objects": [
+    {"id": 0, "content": {"kind": "geometry", "value": {"circle": {"radius": 1.0}}}},
+    {"id": 1, "content": {"kind": "text", "value": {"kind": "typst", "source": "x^2", "font_size": 36.0}}},
+    {"id": 2, "content": {"kind": "geometry", "value": {"rectangle": {"size": {"x": 2.0, "y": 1.0}}}}}
+  ],
+  "tracks": [],
+  "metadata": {"fixture": "canonical-mixed-v1"}
+}

--- a/crates/noon-ir/tests/serialization_contracts.rs
+++ b/crates/noon-ir/tests/serialization_contracts.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeSet;
 
 use noon_ir::{
     decode_patch_batch, decode_scene, decode_semantic_scene, encode_patch_batch, encode_scene,
-    IrError, SemanticIrError,
+    IrError, ObjectSpecContent, SceneSpec, SemanticIrError,
 };
 use serde_json::Value;
 
@@ -10,6 +10,7 @@ const MANIFEST: &str = include_str!("../../../compat/wire-contracts-v1.json");
 const EMPTY_SCENE: &str = include_str!("../../../compat/wire/v1/scene-empty.json");
 const UNKNOWN_FIELD_SCENE: &str = include_str!("../../../compat/wire/v1/scene-unknown-field.json");
 const REACTIVE_SCENE: &str = include_str!("../../../compat/wire/v1/semantic-reactive.json");
+const MIXED_SCENE_SPEC: &str = include_str!("../../../compat/wire/v1/scene-spec-mixed.json");
 const EMPTY_PATCH: &str = include_str!("../../../compat/wire/v1/patch-empty.json");
 const FUTURE_SCENE: &str = include_str!("../../../compat/wire/invalid/future-scene.json");
 const FUTURE_PATCH: &str = include_str!("../../../compat/wire/invalid/future-patch.json");
@@ -21,6 +22,7 @@ fn contract_manifest_inventories_current_cross_language_boundaries() {
     let manifest: Value = serde_json::from_str(MANIFEST).expect("contract manifest is JSON");
     assert_eq!(manifest["manifest_version"], 1);
     assert_eq!(manifest["noon_ir_version"], 1);
+    assert_eq!(manifest["scene_spec_version"], 1);
     assert_eq!(manifest["authoring_protocol"]["channel"], "noon.authoring");
     assert_eq!(manifest["authoring_protocol"]["version"], 5);
     let names = manifest["contracts"]
@@ -32,6 +34,7 @@ fn contract_manifest_inventories_current_cross_language_boundaries() {
     for required in [
         "scene_document",
         "semantic_scene_document",
+        "canonical_scene_spec",
         "patch_batch",
         "authoring_envelope",
         "authoring_result",
@@ -55,10 +58,42 @@ fn canonical_v1_fixtures_round_trip_and_preserve_stable_text_where_promised() {
 }
 
 #[test]
+fn canonical_mixed_scene_spec_fixture_preserves_one_painter_order_domain() {
+    let spec = SceneSpec::from_json(MIXED_SCENE_SPEC).expect("v1 mixed SceneSpec decodes");
+    assert_eq!(spec.version, 1);
+    assert_eq!(spec.objects.len(), 3);
+    assert_eq!(spec.objects[0].id.get(), 0);
+    assert_eq!(spec.objects[1].id.get(), 1);
+    assert_eq!(spec.objects[2].id.get(), 2);
+    assert!(matches!(
+        &spec.objects[0].content,
+        ObjectSpecContent::Geometry(_)
+    ));
+    let ObjectSpecContent::Text(text) = &spec.objects[1].content else {
+        panic!("middle canonical object must remain source-level text");
+    };
+    assert_eq!(text.source, "x^2");
+    assert_eq!(text.font_size, 36.0);
+    assert!(matches!(
+        &spec.objects[2].content,
+        ObjectSpecContent::Geometry(_)
+    ));
+
+    let encoded = spec.to_json().expect("mixed SceneSpec re-serializes");
+    let decoded = SceneSpec::from_json(&encoded).expect("re-serialized SceneSpec decodes");
+    assert_eq!(decoded, spec);
+    assert!(!encoded.contains("metadata"));
+}
+
+#[test]
 fn additive_unknown_top_level_fields_are_ignored_by_v1_readers() {
     let decoded = decode_scene(UNKNOWN_FIELD_SCENE).expect("additive metadata remains compatible");
     assert!(decoded.objects().is_empty());
     assert!(decoded.tracks().is_empty());
+
+    let mixed = SceneSpec::from_json(MIXED_SCENE_SPEC)
+        .expect("canonical mixed additive metadata remains compatible");
+    assert_eq!(mixed.objects.len(), 3);
 }
 
 #[test]

--- a/docs/serialization-contracts.md
+++ b/docs/serialization-contracts.md
@@ -4,18 +4,19 @@ Noon's persistent/cross-language wire surface is intentionally smaller than its 
 
 ## Version domains
 
-There are two independent version domains today:
+There are three independent version domains today:
 
-- **Noon IR v1** covers scene documents, semantic/reactive scene documents, and patch batches. Rust readers preflight the top-level `version` before decoding the payload, so a future document containing future-only enum variants still fails as `UnsupportedVersion` rather than malformed current-version JSON.
+- **Noon IR v1** covers legacy geometry scene documents, semantic/reactive scene documents, and patch batches. Rust readers preflight the top-level `version` before decoding the payload, so a future document containing future-only enum variants still fails as `UnsupportedVersion` rather than malformed current-version JSON.
+- **Canonical SceneSpec v1** covers the mixed geometry/text authoring scene introduced for the shared Python/Rust/JavaScript semantic model. Its `objects` array is the single painter-order and identity domain across geometry and source-level text, and it has its own version constant so canonical authoring can evolve independently of the legacy Noon IR envelope.
 - **Authoring protocol v5** covers messages between `PythonAuthoringClient` and the Python worker. Callback slots, callback frame payloads, authoring result metadata, and the request/response envelope are scoped by that protocol. Callback mutation commits themselves use Noon IR v1 `PatchBatch` sequence ordering.
 
-Changing one domain does not implicitly bump the other.
+Changing one domain does not implicitly bump the others.
 
 ## Evolution rules
 
 Required fields remain required for that version. Fields explicitly optional/defaulted in the manifest may be absent. Current Rust serde readers ignore unknown record fields, so a producer may add non-semantic metadata without a version bump; adding a new required field, changing meaning/type, or adding a variant old readers must understand requires a version bump or explicit backward-compatible default.
 
-Arrays whose ordering affects semantics retain producer order. Object/track declaration order remains deterministic for serialization, and patch arrays are applied in order. Do not rely on JSON object-key ordering for semantics.
+Arrays whose ordering affects semantics retain producer order. Legacy object/track declaration order remains deterministic for serialization, canonical `SceneSpec.objects` order is the mixed geometry/text painter stream, and patch arrays are applied in order. Do not rely on JSON object-key ordering for semantics.
 
 Rust wire IDs are JSON integers backed by `u64`. Because the browser/worker boundary uses JavaScript numbers, the cross-language compatibility range is **0 through `Number.MAX_SAFE_INTEGER` (9,007,199,254,740,991)**. Producers must not emit larger IDs or sequences even though a native Rust parser can represent them.
 
@@ -23,12 +24,12 @@ JSON floating-point fields must be finite. `NaN` and infinities are not wire val
 
 ## Canonical fixtures and migrations
 
-`compat/wire/v1/` is the reviewed v1 fixture set. Exact compact text is asserted only where Noon deliberately produces deterministic canonical serialization (currently the minimal scene and patch envelopes); semantic equivalence is the contract elsewhere. `compat/wire/invalid/` contains future-version and malformed examples that fail deterministically.
+`compat/wire/v1/` is the reviewed v1 fixture set. It includes the legacy/semantic Noon IR envelopes plus a canonical mixed `SceneSpec` fixture whose geometry → text → geometry array order is part of the contract. Exact compact text is asserted only where Noon deliberately produces deterministic canonical serialization (currently the minimal legacy scene and patch envelopes); semantic equivalence is the contract elsewhere. `compat/wire/invalid/` contains future-version and malformed examples that fail deterministically.
 
-When v2 is introduced, keep v1 fixtures. Add v2 fixtures and a migration/compatibility test stating explicitly whether v1 remains directly readable or is upgraded through a migration function. Never silently reinterpret an old fixture under new semantics.
+When any domain introduces a v2, keep its v1 fixtures. Add v2 fixtures and a migration/compatibility test stating explicitly whether v1 remains directly readable or is upgraded through a migration function. Never silently reinterpret an old fixture under new semantics.
 
 ## Cross-language CI
 
-Rust contract tests decode fixtures through `noon-ir`. Node tests run the same v1/future fixtures through browser authoring validators. Existing Python→JSON→Rust/WASM parity and browser authoring jobs remain executable producer/consumer integration tests; this fixture suite pins the schema those jobs are expected to produce.
+Rust contract tests decode fixtures through `noon-ir`, including `SceneSpec::from_json` for the canonical mixed scene. Node tests run the legacy Noon IR v1/future fixtures through browser authoring validators. Existing Python→JSON→Rust/WASM parity and browser authoring jobs remain executable producer/consumer integration tests; this fixture suite pins the schema those jobs are expected to produce.
 
 Internal Rust-only structs, renderer cache data, GPU resources, and execution indices are not compatibility contracts unless added to the manifest.


### PR DESCRIPTION
## Summary
- add canonical mixed `SceneSpec` to the machine-readable wire-contract inventory with its own v1 version domain
- add a reviewed geometry → text → geometry fixture that pins one shared painter-order/identity stream and additive unknown-field behavior
- run that fixture through `SceneSpec::from_json()` / `to_json()` in the required `noon-ir` serialization contract suite
- document the separation between legacy Noon IR v1, canonical SceneSpec v1, and authoring protocol v5

## Why
#367 is converging authoring onto `SceneSpec`, but #108's compatibility inventory and checked-in fixtures covered only the legacy/semantic scene envelopes and patch protocol. That left the canonical cross-language scene format outside the repository's independent compatibility gate even though it is becoming the authoritative geometry+text authoring representation.

This PR pins the architectural invariant that geometry and source-level text occupy one ordered object domain, while preserving the existing policy that additive unknown record fields are ignored within a version.

## Version-admission dependency
#468 is now merged underneath this branch. `SceneSpec::from_json()` therefore preflights `SCENE_SPEC_VERSION` before decoding schema-specific content, matching the legacy IR envelope behavior. The fixture/contract documentation in this PR now sits on the corrected production admission boundary rather than documenting a known inconsistency.

## Validation
The final head `5251e7e55e102bedd72300986e2fbceb5b22f014` is one clean commit directly on current master (`6fc09ca6a275365ac6054ccd199fa6f2806de626`): ahead 1, behind 0, and changes only the compatibility manifest, one fixture, the focused `noon-ir` contract test, and documentation.

The same four-file content previously passed Rust format/clippy/workspace tests, coverage, API coverage, Manim differential/raster, web package, browser authoring/reactive, and WebGL. Its historical WebGPU failure was the unrelated sustained-profiler instability corrected by merged #464. Fresh exact-head gates are running on the rebuilt branch.

Tracks #108 and #367.