### PR TITLE
Keep playground freshness updates atomic on errors

### DIFF
--- a/web/playground-generation.js
+++ b/web/playground-generation.js
@@ -28,14 +28,16 @@ export class PlaygroundGeneration {
   #lastStale = null;
 
   beginSelectionRequest(exampleId) {
-    this.#selectionRequestGeneration = checkedNext(
+    const normalizedExampleId = requireExampleId(exampleId);
+    const nextGeneration = checkedNext(
       this.#selectionRequestGeneration,
       "playground selection request generation",
     );
+    this.#selectionRequestGeneration = nextGeneration;
     return Object.freeze({
       kind: "selection-request",
-      requestGeneration: this.#selectionRequestGeneration,
-      exampleId: requireExampleId(exampleId),
+      requestGeneration: nextGeneration,
+      exampleId: normalizedExampleId,
     });
   }
 
@@ -50,18 +52,20 @@ export class PlaygroundGeneration {
     if (!this.isSelectionRequestCurrent(requestToken)) {
       return null;
     }
-    this.#selectionGeneration = checkedNext(
+    const nextSelectionGeneration = checkedNext(
       this.#selectionGeneration,
       "playground selection generation",
     );
-    // A newly committed selection supersedes any authoring result that belongs
-    // to the previously active example, even before the UI switches examples.
-    this.#runGeneration = checkedNext(this.#runGeneration, "playground run generation");
+    // Preflight both counters before publishing either new generation. A failed
+    // commit must not partially invalidate the currently visible selection/run.
+    const nextRunGeneration = checkedNext(this.#runGeneration, "playground run generation");
+    this.#selectionGeneration = nextSelectionGeneration;
+    this.#runGeneration = nextRunGeneration;
     return Object.freeze({
       kind: "selection",
       requestGeneration: requestToken.requestGeneration,
-      selectionGeneration: this.#selectionGeneration,
-      runGeneration: this.#runGeneration,
+      selectionGeneration: nextSelectionGeneration,
+      runGeneration: nextRunGeneration,
       exampleId: requestToken.exampleId,
     });
   }
@@ -75,12 +79,14 @@ export class PlaygroundGeneration {
   }
 
   beginRun(exampleId) {
-    this.#runGeneration = checkedNext(this.#runGeneration, "playground run generation");
+    const normalizedExampleId = requireExampleId(exampleId);
+    const nextGeneration = checkedNext(this.#runGeneration, "playground run generation");
+    this.#runGeneration = nextGeneration;
     return Object.freeze({
       kind: "run",
       selectionGeneration: this.#selectionGeneration,
-      runGeneration: this.#runGeneration,
-      exampleId: requireExampleId(exampleId),
+      runGeneration: nextGeneration,
+      exampleId: normalizedExampleId,
     });
   }
 

--- a/web/playground-generation.test.mjs
+++ b/web/playground-generation.test.mjs
@@ -61,6 +61,28 @@ test("a newer run supersedes an older run for the same example", () => {
   assert.equal(generations.isRunCurrent(second, "scene"), true);
 });
 
+test("invalid selection requests do not consume freshness generations", () => {
+  const generations = new PlaygroundGeneration();
+  const before = generations.diagnostics;
+
+  assert.throws(() => generations.beginSelectionRequest("   "), /non-empty example ID/);
+  assert.deepEqual(generations.diagnostics, before);
+
+  const request = generations.beginSelectionRequest("scene");
+  assert.equal(request.requestGeneration, 1);
+});
+
+test("invalid runs leave the current run authoritative", () => {
+  const generations = new PlaygroundGeneration();
+  generations.commitSelection(generations.beginSelectionRequest("scene"));
+  const current = generations.beginRun("scene");
+  const before = generations.diagnostics;
+
+  assert.throws(() => generations.beginRun(null), /non-empty example ID/);
+  assert.deepEqual(generations.diagnostics, before);
+  assert.equal(generations.isRunCurrent(current, "scene"), true);
+});
+
 test("stale-result diagnostics are monotonic and retain the last trace", () => {
   const generations = new PlaygroundGeneration();
   generations.commitSelection(generations.beginSelectionRequest("scene"));


### PR DESCRIPTION
## Summary
- validate example IDs before advancing selection-request or run generations
- preflight both selection and run generation increments before publishing a committed selection
- preserve the currently authoritative run when an invalid run request is rejected
- add focused regressions proving rejected selection/run inputs leave diagnostics and freshness state unchanged

## Why
`PlaygroundGeneration` is the public UI freshness authority used to reject stale async authoring work. `beginSelectionRequest()` and `beginRun()` previously incremented their generations before validating `exampleId`, so a rejected call still consumed freshness state. More subtly, `commitSelection()` advanced `selectionGeneration` before checking whether `runGeneration` could advance; a generation-exhaustion error could therefore partially publish a selection transition.

Freshness state should have the same transactional error-path semantics as the retained resource/version machinery: a failed operation must not invalidate otherwise-current work.

## Architecture
This stays inside the existing `PlaygroundGeneration` authority. No new generation domain, worker state, retry mechanism, or protocol field is introduced. Fallible validation/counter checks are simply completed before the private counters are mutated.

## Parallelism
Only `web/playground-generation.js` and its focused unit test change. This does not overlap the active playback worker/client work (#454), recoverable-error UI work (#447), Python worker hardening (#449/#451), renderer recovery, retained text renderer, or canonical mixed-scene files.

## Validation
The branch is directly on current master (`ahead 2, behind 0`). The existing `playground-generation.test.mjs` gate now covers rejected selection and run operations in addition to the 500-operation seeded churn case.

Tracks #112.