### PR TITLE
Reject non-finite timeline values

### DIFF
--- a/crates/noon-core/src/timeline.rs
+++ b/crates/noon-core/src/timeline.rs
@@ -148,6 +148,31 @@ impl TrackValues {
             Self::Object { .. } => ValueKind::Object,
         }
     }
+
+    fn validate_numeric_values(&self, property: Property) -> Result<(), TimelineError> {
+        match self {
+            Self::Scalar { from, to } if !from.is_finite() || !to.is_finite() => {
+                Err(TimelineError::InvalidScalarValues {
+                    property,
+                    from: *from,
+                    to: *to,
+                })
+            }
+            Self::Vec2 { from, to }
+                if !from.x.is_finite()
+                    || !from.y.is_finite()
+                    || !to.x.is_finite()
+                    || !to.y.is_finite() =>
+            {
+                Err(TimelineError::InvalidVec2Values {
+                    property,
+                    from: *from,
+                    to: *to,
+                })
+            }
+            _ => Ok(()),
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
@@ -196,6 +221,16 @@ pub enum TimelineError {
         expected: ValueKind,
         actual: ValueKind,
     },
+    InvalidScalarValues {
+        property: Property,
+        from: f32,
+        to: f32,
+    },
+    InvalidVec2Values {
+        property: Property,
+        from: Vec2,
+        to: Vec2,
+    },
     InvalidCompositionTimeMap(CompositionTimeMapError),
     InstantTrackCannotUseTimeMap(Property),
     TrackIdExhausted,
@@ -218,6 +253,15 @@ impl std::fmt::Display for TimelineError {
             } => write!(
                 formatter,
                 "value type mismatch for {property:?}: expected {expected:?}, got {actual:?}"
+            ),
+            Self::InvalidScalarValues { property, from, to } => write!(
+                formatter,
+                "non-finite scalar values for {property:?}: from={from}, to={to}"
+            ),
+            Self::InvalidVec2Values { property, from, to } => write!(
+                formatter,
+                "non-finite vector values for {property:?}: from=({}, {}), to=({}, {})",
+                from.x, from.y, to.x, to.y
             ),
             Self::InvalidCompositionTimeMap(error) => error.fmt(formatter),
             Self::InstantTrackCannotUseTimeMap(property) => write!(
@@ -265,6 +309,7 @@ pub fn validate_track_definition(track: &TrackDefinition) -> Result<(), Timeline
             actual,
         });
     }
+    track.values.validate_numeric_values(track.property)?;
     if track.property.is_instant() && !track.time_map.is_identity() {
         return Err(TimelineError::InstantTrackCannotUseTimeMap(track.property));
     }
@@ -654,6 +699,60 @@ mod tests {
             )
             .expect_err("invalid start time must fail");
         assert!(matches!(error, TimelineError::InvalidStartTime(_)));
+    }
+
+    #[test]
+    fn non_finite_scalar_values_are_rejected_without_consuming_track_ids() {
+        let mut scene = SceneDefinition::new();
+        let object = scene.add(GeometryRef::circle(1.0));
+
+        for (from, to) in [
+            (f32::NAN, 1.0),
+            (0.0, f32::INFINITY),
+            (f32::NEG_INFINITY, 1.0),
+        ] {
+            assert!(matches!(
+                scene.animate_scalar(object, Property::Opacity, from, to, timing()),
+                Err(TimelineError::InvalidScalarValues {
+                    property: Property::Opacity,
+                    ..
+                })
+            ));
+        }
+        assert!(scene.tracks().is_empty());
+        assert_eq!(
+            scene
+                .animate_scalar(object, Property::Opacity, 1.0, 0.0, timing())
+                .unwrap(),
+            TrackId::new(0)
+        );
+    }
+
+    #[test]
+    fn non_finite_position_values_are_rejected_without_consuming_track_ids() {
+        let mut scene = SceneDefinition::new();
+        let object = scene.add(GeometryRef::circle(1.0));
+
+        for (from, to) in [
+            (Vec2::new(f32::NAN, 0.0), Vec2::ONE),
+            (Vec2::ZERO, Vec2::new(1.0, f32::INFINITY)),
+            (Vec2::new(0.0, f32::NEG_INFINITY), Vec2::ONE),
+        ] {
+            assert!(matches!(
+                scene.animate_position(object, from, to, timing()),
+                Err(TimelineError::InvalidVec2Values {
+                    property: Property::Position,
+                    ..
+                })
+            ));
+        }
+        assert!(scene.tracks().is_empty());
+        assert_eq!(
+            scene
+                .animate_position(object, Vec2::ZERO, Vec2::ONE, timing())
+                .unwrap(),
+            TrackId::new(0)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- reject non-finite scalar timeline endpoints at the shared `TrackDefinition` validation boundary
- reject non-finite `Vec2` timeline endpoints before they can enter runtime interpolation/frame state
- preserve existing timing, value-kind, instant-track, and composition-time-map validation order
- add focused regressions proving malformed values do not append tracks or consume deterministic `TrackId`s

## Why
`validate_track_definition()` already rejected non-finite timing but accepted `NaN`/`±inf` scalar and position endpoints. Those values could become authoritative timeline data and then propagate through interpolation into runtime/render state, where comparisons and transforms are no longer well-defined.

The correct boundary is the shared core validator used by all authoring paths, rather than frontend-specific sanitization or renderer-side defensive clamping.

## Architecture
The new validation is local to `TrackValues` and returns typed `TimelineError` variants carrying the property and rejected endpoints. No frontend policy, renderer workaround, or alternate validation path is introduced.

Object-valued transform tracks remain outside this slice: validating the complete numeric/geometry/style contents of `ObjectSnapshot` should be handled through one reusable shared object-state validation contract rather than partially duplicating those rules here.

## Parallelism
Only `crates/noon-core/src/timeline.rs` changes. It does not overlap active playback/worker work (#454), mixed-scene validation (#455), resource-arena work (#445/#446), Playground freshness (#457), renderer recovery, or retained-text renderer branches (#442/#452).

## Validation
Two focused unit regressions cover scalar and position `NaN`/infinity inputs and verify the next valid track still receives ID 0. Normal workspace CI exercises the shared core suite.

Related: #105, #108.