### PR TITLE
Keep performance samples complete across GPU recovery

### DIFF
--- a/scripts/build-web-demo.sh
+++ b/scripts/build-web-demo.sh
@@ -35,6 +35,7 @@ node --check web/gpu-profile.js
 node --check web/morph-profile.js
 node --check web/browser-jank.js
 node --check web/perf-profile.js
+node --check web/player-frame-metrics.js
 node --check web/perf-workloads.js
 node --check web/authoring-perf.js
 node --check web/scene-perf.js
@@ -74,6 +75,7 @@ node --test web/python-compat-bundle.test.mjs
 node --test web/python-worker-source.test.mjs
 node --test web/scene-identity.test.mjs
 node --test web/frame-metrics.test.mjs
+node --test web/player-frame-metrics.test.mjs
 node --test web/browser-jank.test.mjs
 node --test web/perf-workloads.test.mjs
 node --test web/performance-corpus-manifest.test.mjs

--- a/web/perf-profile.js
+++ b/web/perf-profile.js
@@ -1,6 +1,7 @@
 import init, { NoonCanvasPlayer } from "./pkg/noon_web.js";
 import { BrowserJankMonitor, estimateUnattributedFrameMs } from "./browser-jank.js";
 import { FrameMetrics, SampleWindow } from "./frame-metrics.js";
+import { readCompletePlayerFrameMetrics } from "./player-frame-metrics.js";
 import { ANALYTIC_LAYOUTS, buildAnalyticScene } from "./perf-workloads.js";
 
 const parameters = new URLSearchParams(location.search);
@@ -57,6 +58,7 @@ try {
   browserJank.start();
   const measurementStartMs = performance.now();
   let previousTimestamp = null;
+  let incompleteMetricFrames = 0;
   let measured = 0;
   while (measured < measuredFrames) {
     status.value = `Measuring ${measured + 1}/${measuredFrames} · ${layout} / ${objectCount.toLocaleString()} objects…`;
@@ -65,19 +67,30 @@ try {
     const presented = player.renderFrame(timestamp);
     const browserCallMs = performance.now() - started;
     if (!presented) {
+      previousTimestamp = null;
       continue;
     }
 
-    const cpuFrameMs = player.lastCpuFrameMs();
+    const metrics = readCompletePlayerFrameMetrics(player);
+    if (metrics === null) {
+      // GPU/context recovery can replace renderer-owned instrumentation between
+      // runtime evaluation and presentation. Exclude that whole frame rather than
+      // mixing partial measurements into percentile windows. The skipped count is
+      // reported so repeated recovery remains visible instead of being hidden.
+      incompleteMetricFrames += 1;
+      previousTimestamp = null;
+      continue;
+    }
+
     cadence.record(timestamp, browserCallMs);
-    recordPlayerMetric(windows.cpuFrameMs, cpuFrameMs, "cpu frame");
-    recordPlayerMetric(windows.runtimeMs, player.lastRuntimeEvaluationMs(), "runtime");
-    recordPlayerMetric(windows.prepareMs, player.lastFramePrepareMs(), "prepare");
-    recordPlayerMetric(windows.uploadMs, player.lastUploadMs(), "upload");
-    recordPlayerMetric(windows.encodeSubmitMs, player.lastEncodeSubmitMs(), "encode/submit");
+    windows.cpuFrameMs.record(metrics.cpuFrameMs);
+    windows.runtimeMs.record(metrics.runtimeMs);
+    windows.prepareMs.record(metrics.prepareMs);
+    windows.uploadMs.record(metrics.uploadMs);
+    windows.encodeSubmitMs.record(metrics.encodeSubmitMs);
     if (previousTimestamp !== null) {
       windows.unattributedFrameMs.record(
-        estimateUnattributedFrameMs(timestamp - previousTimestamp, cpuFrameMs),
+        estimateUnattributedFrameMs(timestamp - previousTimestamp, metrics.cpuFrameMs),
       );
     }
     previousTimestamp = timestamp;
@@ -115,6 +128,7 @@ try {
       playerCreateMs,
       warmupFrames,
       measuredFrames: frame.frames,
+      incompleteMetricFrames,
     },
     cadence: {
       frameIntervalMs: frame.interval,
@@ -172,13 +186,6 @@ try {
 } finally {
   browserJank.stop();
   player?.free?.();
-}
-
-function recordPlayerMetric(window, value, label) {
-  if (!Number.isFinite(value)) {
-    throw new Error(`${label} metric is not finite: ${value}`);
-  }
-  window.record(value);
 }
 
 async function waitForGpuSamples(player, supported, expectedFrames) {

--- a/web/player-frame-metrics.js
+++ b/web/player-frame-metrics.js
@@ -1,0 +1,11 @@
+export function readCompletePlayerFrameMetrics(player) {
+  const metrics = {
+    cpuFrameMs: player.lastCpuFrameMs(),
+    runtimeMs: player.lastRuntimeEvaluationMs(),
+    prepareMs: player.lastFramePrepareMs(),
+    uploadMs: player.lastUploadMs(),
+    encodeSubmitMs: player.lastEncodeSubmitMs(),
+  };
+
+  return Object.values(metrics).every(Number.isFinite) ? metrics : null;
+}

--- a/web/player-frame-metrics.test.mjs
+++ b/web/player-frame-metrics.test.mjs
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { readCompletePlayerFrameMetrics } from "./player-frame-metrics.js";
+
+function player(overrides = {}) {
+  const values = {
+    cpuFrameMs: 4.5,
+    runtimeMs: 1.25,
+    prepareMs: 0.75,
+    uploadMs: 0.5,
+    encodeSubmitMs: 0.9,
+    ...overrides,
+  };
+  return {
+    lastCpuFrameMs: () => values.cpuFrameMs,
+    lastRuntimeEvaluationMs: () => values.runtimeMs,
+    lastFramePrepareMs: () => values.prepareMs,
+    lastUploadMs: () => values.uploadMs,
+    lastEncodeSubmitMs: () => values.encodeSubmitMs,
+  };
+}
+
+test("returns one complete frame metric snapshot", () => {
+  assert.deepEqual(readCompletePlayerFrameMetrics(player()), {
+    cpuFrameMs: 4.5,
+    runtimeMs: 1.25,
+    prepareMs: 0.75,
+    uploadMs: 0.5,
+    encodeSubmitMs: 0.9,
+  });
+});
+
+test("rejects the whole frame when any metric is unavailable", () => {
+  assert.equal(
+    readCompletePlayerFrameMetrics(player({ runtimeMs: Number.NaN })),
+    null,
+  );
+  assert.equal(
+    readCompletePlayerFrameMetrics(player({ uploadMs: Number.POSITIVE_INFINITY })),
+    null,
+  );
+});


### PR DESCRIPTION
## Summary
- sample the five per-frame player timing metrics as one atomic measurement vector
- exclude a presented frame when any timing value is temporarily unavailable instead of partially updating percentile windows or aborting the profile
- reset cadence-gap attribution across excluded/recovery frames so wall time spent outside a complete sample is not charged to the next frame
- expose `incompleteMetricFrames` in the performance report so recovery/instrumentation gaps remain observable
- add focused unit coverage for complete and partially unavailable metric snapshots and gate it in the normal web package build

## Why
Fresh required CI exposed a real instrumentation seam during the sustained WebGPU timestamp-profile regression: a GPU runtime recovery can reinstall renderer-owned state after runtime evaluation has already been measured for the same `renderFrame()` call. The recovered frame can still present successfully while one timing getter is reset to `NaN`, causing `perf-profile.js` to abort after the painter-order pixel oracle already passed.

A performance percentile must be built from complete frame vectors. Recording some fields before discovering another is unavailable corrupts cross-metric comparability; coercing missing values would be worse. This change therefore admits only complete samples and reports every excluded frame explicitly.

## Architecture / parallelism
This stays in the performance instrumentation layer and does not modify GPU recovery ownership, renderer state, playback, or runtime semantics. It avoids conflicts with active recovery PR #450 and the engine/reconnect work. A separate renderer-metric ownership cleanup could later make every recovered presented frame expose a complete timing vector, but the profiler should remain robust to transient instrumentation gaps regardless.

## Validation
The normal web-package gate now runs `player-frame-metrics.test.mjs`. The existing required WebGPU painter-order job also runs the 64-frame / 10k-object sustained timestamp profile that exposed this failure, providing the end-to-end regression gate.

Related: #113, #111.