### PR TITLE
Canonicalize transported host callback subscriptions

### DIFF
--- a/crates/noon-core/src/host_callbacks.rs
+++ b/crates/noon-core/src/host_callbacks.rs
@@ -60,6 +60,11 @@ impl HostCallbackSlot {
         }
         Ok(())
     }
+
+    fn deduplicate_objects(&mut self) {
+        let mut seen = BTreeSet::new();
+        self.objects.retain(|object| seen.insert(*object));
+    }
 }
 
 /// Declarative host-dynamic participation for a semantic scene.
@@ -81,14 +86,15 @@ impl HostCallbackRegistry {
         }
     }
 
-    pub fn from_slots(slots: Vec<HostCallbackSlot>) -> Result<Self, HostCallbackRegistryError> {
+    pub fn from_slots(mut slots: Vec<HostCallbackSlot>) -> Result<Self, HostCallbackRegistryError> {
         let mut ids = BTreeSet::new();
         let mut next_callback_id = 0;
-        for slot in &slots {
+        for slot in &mut slots {
             slot.validate_schedule()?;
             if !ids.insert(slot.id) {
                 return Err(HostCallbackRegistryError::DuplicateCallback(slot.id));
             }
+            slot.deduplicate_objects();
             next_callback_id = next_callback_id.max(
                 slot.id
                     .get()
@@ -108,18 +114,14 @@ impl HostCallbackRegistry {
             .next_callback_id
             .checked_add(1)
             .expect("Noon host callback ID space exhausted");
-        let mut unique = Vec::new();
-        for object in objects {
-            if !unique.contains(&object) {
-                unique.push(object);
-            }
-        }
-        self.slots.push(HostCallbackSlot {
+        let mut slot = HostCallbackSlot {
             id,
-            objects: unique,
+            objects: objects.into_iter().collect(),
             active_after: None,
             active_through: None,
-        });
+        };
+        slot.deduplicate_objects();
+        self.slots.push(slot);
         id
     }
 
@@ -174,6 +176,27 @@ mod tests {
         );
         assert_eq!(registry.register([]), HostCallbackId::new(1));
         assert_eq!(registry.slots()[0].objects, vec![first, second]);
+    }
+
+    #[test]
+    fn local_and_transported_subscriptions_share_canonical_order() {
+        let first = ObjectId::new(4);
+        let second = ObjectId::new(7);
+        let third = ObjectId::new(9);
+        let objects = vec![second, first, second, third, first, third];
+
+        let mut local = HostCallbackRegistry::new();
+        local.register(objects.clone());
+        let transported = HostCallbackRegistry::from_slots(vec![HostCallbackSlot {
+            id: HostCallbackId::new(0),
+            objects,
+            active_after: None,
+            active_through: None,
+        }])
+        .unwrap();
+
+        assert_eq!(local.slots()[0].objects, vec![second, first, third]);
+        assert_eq!(transported.slots()[0].objects, local.slots()[0].objects);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- canonicalize host-callback watched-object lists at one shared `HostCallbackSlot` boundary for both local `register()` and transported `from_slots()` construction
- preserve first-observed object order while removing later duplicates
- remove the local O(n²) `Vec::contains` dedup loop; both paths now use the same O(n log n) `BTreeSet`-backed canonicalization
- keep callback IDs, activation windows, and ID-exhaustion behavior unchanged
- add a focused regression requiring local and transported registrations with the same repeated inputs to produce the same canonical order

## Why
Locally registered callback slots already deduplicated watched objects, but transported slots previously accepted duplicate `ObjectId`s unchanged. The runtime builds callback invocation indices directly from these lists, so equivalent semantic registrations could produce different callback payloads depending on whether they were created in-process or crossed the wire. Duplicate subscriptions also caused redundant callback-state reads.

The registry is the correct canonicalization boundary: every consumer can now assume one watched-object occurrence per callback slot regardless of origin, and there is only one implementation of that contract.

## Architecture / performance
No worker protocol, callback generation, runtime scheduler, renderer, or host-language behavior changes. Canonicalization preserves first occurrence/order and is O(n log n) at registration/admission time; steady-state callback execution avoids redundant indices. Consolidating the local and transported paths also removes semantic/cost-model drift between them.

## Parallelism
Only `crates/noon-core/src/host_callbacks.rs` changes. No other open PR owns this file; this does not overlap the active stale-callback browser work (#451), playback controls, renderer recovery, retained-text preparation, or object-state validation.

## Validation
The first CI run exposed only a `rustfmt` layout difference in this file; that exact formatting was applied. Web package, browser authoring/reactive, WebGL, coverage, API coverage, and Manim differential/raster jobs on the prior head were otherwise green. The WebGPU mixed-painter failure is in the separately active renderer/recovery lane (#450/#453/#459) and is not touched here. The refreshed head reruns normal workspace CI with the unified local/transport regression.

Related: #56, #112.