### PR TITLE
Make sustained WebGPU profiler CI deterministic

### DIFF
--- a/scripts/painter-order-browser-smoke.mjs
+++ b/scripts/painter-order-browser-smoke.mjs
@@ -125,15 +125,18 @@ try {
 }
 
 // Keep a compact sustained timestamp-query regression in the existing WebGPU
-// browser gate. The canonical performance suite separately validates 300-frame
-// runs; 64 measured frames here rotate the four readback slots many times while
-// keeping normal PR CI bounded.
+// browser gate. This is a correctness/lifetime oracle, not a performance result,
+// so pin its headless Linux backend to the same deterministic SwiftShader/Vulkan
+// stack used by the dedicated WebGPU recovery tests. Normal perf-profile runs
+// remain hardware-selected unless the caller explicitly requests software WebGPU.
 const sustained = spawnSync(process.execPath, ["scripts/perf-profile.mjs"], {
   cwd: repoRoot,
   encoding: "utf8",
   env: {
     ...process.env,
     NOON_PERF_BACKEND: "webgpu",
+    NOON_PERF_FORCE_SOFTWARE_WEBGPU: "1",
+    NOON_PERF_REQUIRE_GPU_TIMESTAMPS: "1",
     NOON_PERF_COUNTS: "10000",
     NOON_PERF_LAYOUTS: "fixed",
     NOON_PERF_WARMUP: "8",

--- a/scripts/perf-profile.mjs
+++ b/scripts/perf-profile.mjs
@@ -13,7 +13,17 @@ const repoRoot = path.resolve(scriptDir, "..");
 const port = Number(process.env.NOON_PERF_PORT ?? "4175");
 const baseUrl = `http://127.0.0.1:${port}`;
 const backend = process.env.NOON_PERF_BACKEND ?? "webgpu";
+const forceSoftwareWebGpu = process.env.NOON_PERF_FORCE_SOFTWARE_WEBGPU === "1";
+const requireGpuTimestamps = process.env.NOON_PERF_REQUIRE_GPU_TIMESTAMPS === "1";
 assert.ok(backend === "webgpu" || backend === "webgl", `unknown backend: ${backend}`);
+assert.ok(
+  backend === "webgpu" || !forceSoftwareWebGpu,
+  "NOON_PERF_FORCE_SOFTWARE_WEBGPU requires the WebGPU backend",
+);
+assert.ok(
+  backend === "webgpu" || !requireGpuTimestamps,
+  "NOON_PERF_REQUIRE_GPU_TIMESTAMPS requires the WebGPU backend",
+);
 
 const counts = integerList(process.env.NOON_PERF_COUNTS ?? "1000,10000,100000");
 const layouts = stringList(process.env.NOON_PERF_LAYOUTS ?? "fit,fixed,overdraw");
@@ -56,7 +66,7 @@ try {
   browser = await chromium.launch({
     channel: "chromium",
     headless: true,
-    args: browserArgs(backend),
+    args: browserArgs(backend, forceSoftwareWebGpu),
   });
 
   const results = [];
@@ -100,6 +110,27 @@ try {
       assert.equal(report.workload.objects, objects);
       assert.equal(report.workload.layout, layout);
       assert.equal(report.environment.devicePixelRatio, dpr);
+      if (requireGpuTimestamps) {
+        assert.equal(
+          report.gpu?.timestampSupported,
+          true,
+          `${layout}/${objects} did not expose WebGPU timestamp queries`,
+        );
+        const minimumSamples = Math.min(frames, 8);
+        assert.ok(
+          report.gpu.samples >= minimumSamples,
+          `${layout}/${objects} produced ${report.gpu.samples} GPU samples; expected at least ${minimumSamples}`,
+        );
+        assert.equal(
+          report.gpu.failed,
+          0,
+          `${layout}/${objects} reported ${report.gpu.failed} failed GPU timestamp samples`,
+        );
+        assert.ok(
+          report.gpu.samples + report.gpu.dropped + report.gpu.failed >= frames,
+          `${layout}/${objects} left GPU timestamp samples unaccounted for`,
+        );
+      }
       results.push(report);
       console.log(
         `${format(report.cadence.effective?.effectiveFps)} FPS, ` +
@@ -125,7 +156,19 @@ try {
       totalMemoryBytes: os.totalmem(),
       node: process.version,
     },
-    configuration: { backend, counts, layouts, warmup, frames, targetHz, width, height, dpr },
+    configuration: {
+      backend,
+      counts,
+      layouts,
+      warmup,
+      frames,
+      targetHz,
+      width,
+      height,
+      dpr,
+      forceSoftwareWebGpu,
+      requireGpuTimestamps,
+    },
     cases: results,
   };
   await mkdir(path.dirname(artifactPath), { recursive: true });
@@ -153,8 +196,23 @@ async function waitForServer() {
   throw new Error(`Performance server did not start: ${lastError}\n${serverOutput}`);
 }
 
-function browserArgs(mode) {
+function browserArgs(mode, forceSoftware = false) {
   if (mode === "webgpu") {
+    if (forceSoftware) {
+      return [
+        "--enable-unsafe-webgpu",
+        "--enable-unsafe-swiftshader",
+        "--use-webgpu-adapter=swiftshader",
+        "--use-gpu-in-tests",
+        "--ignore-gpu-blocklist",
+        "--enable-features=Vulkan",
+        "--use-gl=angle",
+        "--use-angle=swiftshader",
+        "--use-vulkan=swiftshader",
+        "--disable-gpu-sandbox",
+        "--disable-dev-shm-usage",
+      ];
+    }
     return [
       "--enable-unsafe-webgpu",
       "--use-gpu-in-tests",


### PR DESCRIPTION
## Summary
Restore the sustained WebGPU timestamp-profiler regression to a deterministic headless-Linux backend without changing normal performance profiling.

- add an explicit `NOON_PERF_FORCE_SOFTWARE_WEBGPU=1` opt-in to the generic profiler
- when enabled, launch Chromium with the same SwiftShader/Vulkan WebGPU configuration used by the dedicated renderer-recovery oracle
- keep ordinary `perf-profile.mjs` runs hardware-selected by default
- make the 64-frame sustained CI smoke opt into software WebGPU because it is a correctness/lifetime regression, not a performance measurement
- require that smoke to actually expose timestamp queries, complete at least eight real GPU samples, report zero failed samples, and account for all 64 frames
- record both software-WebGPU and timestamp-requirement choices in profiler configuration metadata

## Why
The previous CI smoke launched a second under-specified headless Chromium. Normal WebGPU rendering passed, but after timestamp-query-induced device loss that process reported no replacement WebGPU adapters. The same production recovery path passes repeated real `GPUDevice.destroy()` recovery under the deterministic SwiftShader/Vulkan configuration in #426/#450.

The timestamp requirement is deliberate: if SwiftShader does not expose timestamp queries, this PR must fail rather than silently turn the sustained profiler regression into a no-op.

This change keeps real performance measurement semantics intact while removing runner/backend selection noise from the functional regression.

Tracks #111 and the sustained-profiler contract from #159/#166.