### PR TITLE
Gate execution slot reuse across long-running churn

### DIFF
--- a/crates/noon-runtime/tests/execution_slot_churn.rs
+++ b/crates/noon-runtime/tests/execution_slot_churn.rs
@@ -1,0 +1,118 @@
+use noon_compile::{CompilePatchError, CompiledScene};
+use noon_core::{
+    GeometryRef, MutationTransaction, ObjectDefinition, ObjectId, SceneDefinition, ScenePatch,
+};
+use noon_runtime::{ExecutionTransactionError, SlottedSceneInstance};
+
+const REPLACEMENTS: u32 = 1_000;
+const REPLACEMENT_ID_BASE: u64 = 1_000_000;
+
+#[test]
+fn execution_slot_capacity_plateaus_across_one_thousand_replacements() {
+    let mut definition = SceneDefinition::new();
+    let initial = definition.add(GeometryRef::circle(1.0));
+    let compiled = CompiledScene::compile(&definition).expect("scene must compile");
+    let mut live = SlottedSceneInstance::new(compiled);
+
+    let mut current_object = initial;
+    let mut current_slot = live
+        .slot_for_object(current_object)
+        .expect("initial object must have a durable execution slot");
+    let stable_slot_index = current_slot.slot();
+    let baseline_capacity = live.slot_table().slot_capacity();
+    assert_eq!(baseline_capacity, 1);
+
+    for generation in 1..=REPLACEMENTS {
+        let stale_slot = current_slot;
+        live.apply_patch(&ScenePatch::RemoveObject(current_object))
+            .expect("bounded replacement removal must succeed");
+        assert_eq!(live.slot_for_object(current_object), None);
+        assert_eq!(live.slot_table().object_for_slot(stale_slot), None);
+
+        let next_object = ObjectId::new(REPLACEMENT_ID_BASE + u64::from(generation));
+        live.apply_patch(&ScenePatch::CreateObject(ObjectDefinition::new(
+            next_object,
+            GeometryRef::circle(1.0),
+        )))
+        .expect("bounded replacement creation must succeed");
+
+        let next_slot = live
+            .slot_for_object(next_object)
+            .expect("replacement must receive a durable execution slot");
+        assert_eq!(next_slot.slot(), stable_slot_index);
+        assert_eq!(next_slot.generation(), generation);
+        assert_eq!(live.slot_table().object_for_slot(stale_slot), None);
+        assert_eq!(
+            live.slot_table().object_for_slot(next_slot),
+            Some(next_object)
+        );
+        assert_eq!(live.slot_table().slot_capacity(), baseline_capacity);
+        assert_eq!(live.slot_table().len(), 1);
+        assert_eq!(live.slot_table().last_mutation_stats().slots_written, 1);
+        assert_eq!(live.slot_table().last_mutation_stats().slots_reused, 1);
+
+        current_object = next_object;
+        current_slot = next_slot;
+    }
+
+    assert_eq!(current_slot.generation(), REPLACEMENTS);
+    assert_eq!(live.live_object_count(), 1);
+    assert_eq!(live.slot_table().len(), 1);
+    assert_eq!(live.slot_table().slot_capacity(), baseline_capacity);
+}
+
+#[test]
+fn rejected_structural_transaction_does_not_consume_slot_generation() {
+    let mut definition = SceneDefinition::new();
+    let current_object = definition.add(GeometryRef::circle(1.0));
+    let compiled = CompiledScene::compile(&definition).expect("scene must compile");
+    let mut live = SlottedSceneInstance::new(compiled);
+
+    let current_slot = live
+        .slot_for_object(current_object)
+        .expect("initial object must have a durable execution slot");
+    let duplicate = ObjectId::new(REPLACEMENT_ID_BASE);
+    let invalid = MutationTransaction::from_mutations([
+        ScenePatch::RemoveObject(current_object),
+        ScenePatch::CreateObject(ObjectDefinition::new(duplicate, GeometryRef::circle(0.5))),
+        ScenePatch::CreateObject(ObjectDefinition::new(
+            duplicate,
+            GeometryRef::rectangle(2.0, 1.0),
+        )),
+    ]);
+
+    assert_eq!(
+        live.apply_transaction(&invalid),
+        Err(ExecutionTransactionError::Compile(
+            CompilePatchError::DuplicateObject(duplicate)
+        ))
+    );
+    assert_eq!(live.slot_for_object(current_object), Some(current_slot));
+    assert_eq!(live.slot_for_object(duplicate), None);
+    assert_eq!(
+        live.slot_table().object_for_slot(current_slot),
+        Some(current_object)
+    );
+    assert_eq!(live.slot_table().len(), 1);
+    assert_eq!(live.slot_table().slot_capacity(), 1);
+
+    let replacement = ObjectId::new(REPLACEMENT_ID_BASE + 1);
+    let valid = MutationTransaction::from_mutations([
+        ScenePatch::RemoveObject(current_object),
+        ScenePatch::CreateObject(ObjectDefinition::new(replacement, GeometryRef::circle(0.5))),
+    ]);
+    live.apply_transaction(&valid)
+        .expect("valid structural replacement must commit");
+
+    let replacement_slot = live
+        .slot_for_object(replacement)
+        .expect("replacement must receive the freed execution slot");
+    assert_eq!(replacement_slot.slot(), current_slot.slot());
+    assert_eq!(replacement_slot.generation(), current_slot.generation() + 1);
+    assert_eq!(live.slot_table().object_for_slot(current_slot), None);
+    assert_eq!(
+        live.slot_table().object_for_slot(replacement_slot),
+        Some(replacement)
+    );
+    assert_eq!(live.slot_table().slot_capacity(), 1);
+}


### PR DESCRIPTION
## Summary
- add a deterministic 1,000-replacement runtime churn gate for durable `ExecutionSlotId` reuse
- require the physical execution-slot capacity to remain at one entry while every removal advances the slot generation
- prove every stale pre-reuse generation stops resolving immediately and cannot alias the replacement object
- require per-create slot accounting to report one write and one reuse rather than allocating new durable slots
- add a structural-transaction rollback regression proving a rejected remove/create batch does not consume a slot generation before the next valid replacement

## Why
#114 explicitly requires long-running coverage for retired/reusable execution slots and generations, but existing tests exercise individual reuse/exhaustion cases rather than the required thousand-edit bounded working set. A short correctness test can stay green while allocator capacity or stale-generation bookkeeping grows with edit history.

This test keeps the workload deliberately bounded: one live semantic object is repeatedly replaced 1,000 times. The compatibility frame-row layer remains separately append-only until an explicit compaction barrier; this PR gates the durable execution-slot allocator itself, whose capacity must plateau independently of historical edits.

## Architecture / parallelism
Test-only; no runtime semantics or allocator policy changes. The new integration test consumes the existing public `SlottedSceneInstance`/`ExecutionSlotTable` contract and therefore avoids production hooks or duplicate bookkeeping. It does not overlap renderer recovery, playback, worker races, retained text, or geometry adapters.

## Locality follow-up found
During this audit I also found that `ExecutionSlotTable::preflight_transaction()` currently clones the full slot table for every transaction and `SlottedSceneInstance::preflight_transaction()` reports `slots_indexed = slot_capacity`, leaving a real O(total historical slots) preflight cost. That is documented on #113 with a concrete touched-object/free-list-shadow direction.

## Validation
The first exact-head run passed coverage, API coverage, Manim differential/raster, web package, browser authoring/reactive and WebGL. Its Rust job stopped only at `cargo fmt --check`; the formatter requested two constructor expressions be collapsed, and that exact diff is now applied. The unrelated WebGPU sustained-profile failure remains owned by the active renderer/profiler work.

The final head `b30b326132ea0ca2cc34672da7d1118bd8d69428` is one clean commit directly on current master: ahead 1, behind 0, one added integration-test file. Fresh duplicate gates are running on that exact head.

Tracks #114. Locality follow-up: #113.