### PR TITLE
Add deterministic playback runtime controls

### DIFF
--- a/crates/noon-web/src/clock.rs
+++ b/crates/noon-web/src/clock.rs
@@ -1,6 +1,8 @@
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ClockError {
     InvalidLoopDuration(f64),
+    InvalidSceneTime(f64),
+    SceneTimeOutsideLoop { time: f64, duration: f64 },
     NonFiniteTimestamp(f64),
     TimestampWentBackwards { previous: f64, actual: f64 },
 }
@@ -11,6 +13,11 @@ impl std::fmt::Display for ClockError {
             Self::InvalidLoopDuration(duration) => {
                 write!(formatter, "invalid playback loop duration {duration}")
             }
+            Self::InvalidSceneTime(time) => write!(formatter, "invalid playback scene time {time}"),
+            Self::SceneTimeOutsideLoop { time, duration } => write!(
+                formatter,
+                "playback scene time {time} exceeds loop duration {duration}"
+            ),
             Self::NonFiniteTimestamp(timestamp) => {
                 write!(formatter, "non-finite animation timestamp {timestamp}")
             }
@@ -26,21 +33,27 @@ impl std::error::Error for ClockError {}
 
 /// Converts monotonic `requestAnimationFrame` timestamps to deterministic scene time.
 ///
-/// Browser scheduling remains outside the semantic runtime: the same timestamp always
-/// produces the same scene time, and resetting the clock establishes a new time origin.
+/// Browser scheduling remains outside the semantic runtime. Playback controls mutate
+/// only this logical clock: pausing freezes the current phase, resuming re-anchors it
+/// to the last accepted browser timestamp, and seeking establishes an exact logical
+/// time without replaying intermediate frames.
 #[derive(Clone, Debug, PartialEq)]
 pub struct PlaybackClock {
     loop_duration: Option<f64>,
-    origin_ms: Option<f64>,
+    anchor_ms: Option<f64>,
+    anchor_scene_time: f64,
     previous_ms: Option<f64>,
+    playing: bool,
 }
 
 impl PlaybackClock {
     pub const fn once() -> Self {
         Self {
             loop_duration: None,
-            origin_ms: None,
+            anchor_ms: None,
+            anchor_scene_time: 0.0,
             previous_ms: None,
+            playing: true,
         }
     }
 
@@ -55,6 +68,67 @@ impl PlaybackClock {
     }
 
     pub fn scene_time(&mut self, timestamp_ms: f64) -> Result<f64, ClockError> {
+        self.validate_timestamp(timestamp_ms)?;
+        let anchor = *self.anchor_ms.get_or_insert(timestamp_ms);
+        self.previous_ms = Some(timestamp_ms);
+        if !self.playing {
+            return Ok(self.anchor_scene_time);
+        }
+        Ok(self.running_time(anchor, timestamp_ms))
+    }
+
+    pub fn pause(&mut self) {
+        if !self.playing {
+            return;
+        }
+        self.reanchor_to_current_time();
+        self.playing = false;
+    }
+
+    pub fn resume(&mut self) {
+        if self.playing {
+            return;
+        }
+        self.anchor_ms = self.previous_ms;
+        self.playing = true;
+    }
+
+    pub fn seek(&mut self, scene_time: f64) -> Result<(), ClockError> {
+        self.validate_scene_time(scene_time)?;
+        self.anchor_scene_time = scene_time;
+        self.anchor_ms = self.previous_ms;
+        Ok(())
+    }
+
+    pub fn set_loop_duration(&mut self, duration: f64) -> Result<(), ClockError> {
+        if !duration.is_finite() || duration <= 0.0 {
+            return Err(ClockError::InvalidLoopDuration(duration));
+        }
+
+        self.reanchor_to_current_time();
+        if self.anchor_scene_time > duration {
+            self.anchor_scene_time = self.anchor_scene_time.rem_euclid(duration);
+        }
+        self.loop_duration = Some(duration);
+        Ok(())
+    }
+
+    pub fn reset(&mut self) {
+        self.anchor_ms = None;
+        self.anchor_scene_time = 0.0;
+        self.previous_ms = None;
+        self.playing = true;
+    }
+
+    pub const fn loop_duration(&self) -> Option<f64> {
+        self.loop_duration
+    }
+
+    pub const fn is_playing(&self) -> bool {
+        self.playing
+    }
+
+    fn validate_timestamp(&self, timestamp_ms: f64) -> Result<(), ClockError> {
         if !timestamp_ms.is_finite() {
             return Err(ClockError::NonFiniteTimestamp(timestamp_ms));
         }
@@ -66,41 +140,44 @@ impl PlaybackClock {
                 });
             }
         }
-
-        let origin = *self.origin_ms.get_or_insert(timestamp_ms);
-        self.previous_ms = Some(timestamp_ms);
-        let elapsed = (timestamp_ms - origin) / 1_000.0;
-        Ok(match self.loop_duration {
-            Some(duration) => elapsed.rem_euclid(duration),
-            None => elapsed,
-        })
-    }
-
-    pub fn set_loop_duration(&mut self, duration: f64) -> Result<(), ClockError> {
-        if !duration.is_finite() || duration <= 0.0 {
-            return Err(ClockError::InvalidLoopDuration(duration));
-        }
-
-        if let (Some(origin), Some(previous)) = (self.origin_ms, self.previous_ms) {
-            let elapsed = (previous - origin) / 1_000.0;
-            let current_time = match self.loop_duration {
-                Some(previous_duration) => elapsed.rem_euclid(previous_duration),
-                None => elapsed,
-            };
-            let phase = current_time.rem_euclid(duration);
-            self.origin_ms = Some(previous - phase * 1_000.0);
-        }
-        self.loop_duration = Some(duration);
         Ok(())
     }
 
-    pub fn reset(&mut self) {
-        self.origin_ms = None;
-        self.previous_ms = None;
+    fn validate_scene_time(&self, scene_time: f64) -> Result<(), ClockError> {
+        if !scene_time.is_finite() || scene_time < 0.0 {
+            return Err(ClockError::InvalidSceneTime(scene_time));
+        }
+        if let Some(duration) = self.loop_duration {
+            if scene_time > duration {
+                return Err(ClockError::SceneTimeOutsideLoop {
+                    time: scene_time,
+                    duration,
+                });
+            }
+        }
+        Ok(())
     }
 
-    pub const fn loop_duration(&self) -> Option<f64> {
-        self.loop_duration
+    fn reanchor_to_current_time(&mut self) {
+        let Some(previous) = self.previous_ms else {
+            self.anchor_ms = None;
+            return;
+        };
+        if self.playing {
+            let anchor = self.anchor_ms.unwrap_or(previous);
+            self.anchor_scene_time = self.running_time(anchor, previous);
+        }
+        self.anchor_ms = Some(previous);
+    }
+
+    fn running_time(&self, anchor_ms: f64, timestamp_ms: f64) -> f64 {
+        let elapsed = (timestamp_ms - anchor_ms) / 1_000.0;
+        let raw = self.anchor_scene_time + elapsed;
+        match self.loop_duration {
+            Some(duration) if elapsed == 0.0 && self.anchor_scene_time == duration => duration,
+            Some(duration) => raw.rem_euclid(duration),
+            None => raw,
+        }
     }
 }
 
@@ -156,12 +233,75 @@ mod tests {
     }
 
     #[test]
-    fn reset_establishes_a_new_time_origin() {
+    fn pause_freezes_and_resume_continues_without_a_jump() {
+        let mut clock = PlaybackClock::looping(4.0).expect("valid loop");
+        assert_eq!(clock.scene_time(100.0).unwrap(), 0.0);
+        assert_eq!(clock.scene_time(1_600.0).unwrap(), 1.5);
+
+        clock.pause();
+        assert!(!clock.is_playing());
+        assert_eq!(clock.scene_time(5_000.0).unwrap(), 1.5);
+        assert_eq!(clock.scene_time(8_000.0).unwrap(), 1.5);
+
+        clock.resume();
+        assert!(clock.is_playing());
+        assert_eq!(clock.scene_time(8_000.0).unwrap(), 1.5);
+        assert_eq!(clock.scene_time(8_500.0).unwrap(), 2.0);
+    }
+
+    #[test]
+    fn seek_is_exact_while_paused_and_reanchors_running_playback() {
+        let mut clock = PlaybackClock::looping(4.0).expect("valid loop");
+        clock.scene_time(100.0).unwrap();
+        clock.scene_time(1_100.0).unwrap();
+        clock.pause();
+
+        clock.seek(3.25).unwrap();
+        assert_eq!(clock.scene_time(2_000.0).unwrap(), 3.25);
+        assert_eq!(clock.scene_time(7_000.0).unwrap(), 3.25);
+
+        clock.resume();
+        clock.seek(1.25).unwrap();
+        assert_eq!(clock.scene_time(7_000.0).unwrap(), 1.25);
+        assert_eq!(clock.scene_time(7_500.0).unwrap(), 1.75);
+    }
+
+    #[test]
+    fn exact_loop_endpoint_survives_seek_until_playback_advances() {
+        let mut clock = PlaybackClock::looping(4.0).expect("valid loop");
+        clock.scene_time(1_000.0).unwrap();
+        clock.seek(4.0).unwrap();
+
+        assert_eq!(clock.scene_time(1_000.0).unwrap(), 4.0);
+        assert_eq!(clock.scene_time(1_250.0).unwrap(), 0.25);
+    }
+
+    #[test]
+    fn invalid_seek_does_not_mutate_the_clock() {
+        let mut clock = PlaybackClock::looping(4.0).expect("valid loop");
+        clock.scene_time(100.0).unwrap();
+        clock.scene_time(1_100.0).unwrap();
+
+        assert!(matches!(
+            clock.seek(-1.0),
+            Err(ClockError::InvalidSceneTime(-1.0))
+        ));
+        assert!(matches!(
+            clock.seek(4.1),
+            Err(ClockError::SceneTimeOutsideLoop { .. })
+        ));
+        assert_eq!(clock.scene_time(1_100.0).unwrap(), 1.0);
+    }
+
+    #[test]
+    fn reset_establishes_a_new_time_origin_and_resumes_playback() {
         let mut clock = PlaybackClock::once();
         clock.scene_time(100.0).expect("valid frame");
         clock.scene_time(600.0).expect("valid frame");
+        clock.pause();
         clock.reset();
 
+        assert!(clock.is_playing());
         assert_eq!(clock.scene_time(20.0).expect("valid frame"), 0.0);
     }
 

--- a/crates/noon-web/src/execution_transport.rs
+++ b/crates/noon-web/src/execution_transport.rs
@@ -786,6 +786,29 @@ impl EngineScenePlayer {
         Ok(())
     }
 
+    pub fn pause(&mut self) {
+        self.clock.pause();
+    }
+
+    pub fn resume(&mut self) {
+        self.clock.resume();
+    }
+
+    pub fn seek_delta_json(
+        &mut self,
+        scene_time: f64,
+    ) -> Result<Option<String>, ExecutionTransportError> {
+        let mut clock = self.clock.clone();
+        clock.seek(scene_time)?;
+        self.player.advance_to(scene_time)?;
+        self.clock = clock;
+        self.take_delta_json()
+    }
+
+    pub const fn is_playing(&self) -> bool {
+        self.clock.is_playing()
+    }
+
     pub fn apply_patch_batch_delta_json(
         &mut self,
         json: &str,
@@ -906,6 +929,24 @@ mod wasm {
         #[wasm_bindgen(js_name = setLoopDurationSeconds)]
         pub fn set_loop_duration_seconds(&mut self, duration: f64) -> Result<(), JsValue> {
             self.inner.set_loop_duration(duration).map_err(js_error)
+        }
+
+        pub fn pause(&mut self) {
+            self.inner.pause();
+        }
+
+        pub fn resume(&mut self) {
+            self.inner.resume();
+        }
+
+        #[wasm_bindgen(js_name = seekDeltaJson)]
+        pub fn seek_delta_json(&mut self, scene_time: f64) -> Result<Option<String>, JsValue> {
+            self.inner.seek_delta_json(scene_time).map_err(js_error)
+        }
+
+        #[wasm_bindgen(js_name = isPlaying)]
+        pub fn is_playing(&self) -> bool {
+            self.inner.is_playing()
         }
 
         #[wasm_bindgen(js_name = applyPatchBatchDeltaJson)]
@@ -1171,6 +1212,51 @@ mod tests {
         player.tick_delta_json(3_100.0).unwrap();
         assert_eq!(player.time(), 0.0);
         assert_eq!(player.next_patch_sequence(), 1);
+    }
+
+    #[test]
+    fn playback_controls_preserve_session_and_patch_identity() {
+        let mut player = EngineScenePlayer::new(&scene_json(), 4.0, 23).unwrap();
+        let initial: ExecutionDeltaEnvelope =
+            serde_json::from_str(&player.initial_delta_json().unwrap()).unwrap();
+        player.tick_delta_json(100.0).unwrap();
+        player.tick_delta_json(1_100.0).unwrap();
+        assert_eq!(player.time(), 1.0);
+
+        player.pause();
+        assert!(!player.is_playing());
+        assert!(player.tick_delta_json(5_100.0).unwrap().is_none());
+        assert_eq!(player.time(), 1.0);
+
+        let seek: ExecutionDeltaEnvelope =
+            serde_json::from_str(&player.seek_delta_json(0.25).unwrap().expect("seek delta"))
+                .unwrap();
+        assert_eq!(seek.session, initial.session);
+        assert_eq!(seek.time, 0.25);
+        assert_eq!(player.next_patch_sequence(), 0);
+        assert_eq!(player.time(), 0.25);
+        assert!(player.tick_delta_json(8_100.0).unwrap().is_none());
+        assert_eq!(player.time(), 0.25);
+
+        player.resume();
+        assert!(player.is_playing());
+        assert!(player.tick_delta_json(8_100.0).unwrap().is_none());
+        player.tick_delta_json(8_600.0).unwrap();
+        assert_eq!(player.time(), 0.75);
+    }
+
+    #[test]
+    fn exact_endpoint_seek_is_not_implicitly_wrapped() {
+        let mut player = EngineScenePlayer::new(&scene_json(), 4.0, 29).unwrap();
+        player.initial_delta_json().unwrap();
+        player.tick_delta_json(100.0).unwrap();
+
+        player.seek_delta_json(4.0).unwrap();
+        assert_eq!(player.time(), 4.0);
+        assert!(player.tick_delta_json(100.0).unwrap().is_none());
+        assert_eq!(player.time(), 4.0);
+        player.tick_delta_json(350.0).unwrap();
+        assert_eq!(player.time(), 0.25);
     }
 
     #[test]

--- a/crates/noon-web/src/retained_authoring_player.rs
+++ b/crates/noon-web/src/retained_authoring_player.rs
@@ -210,6 +210,33 @@ impl RetainedAuthoringEnginePlayer {
         Ok(())
     }
 
+    pub fn pause(&mut self) {
+        self.clock.pause();
+    }
+
+    pub fn resume(&mut self) {
+        self.clock.resume();
+    }
+
+    pub fn seek_delta_json(
+        &mut self,
+        scene_time: f64,
+    ) -> Result<Option<String>, RetainedAuthoringPlayerError> {
+        let mut clock = self.clock.clone();
+        clock.seek(scene_time)?;
+        let delta = self
+            .player
+            .evaluate_delta(scene_time)?
+            .map(|delta| serde_json::to_string(&delta).map_err(RetainedAuthoringPlayerError::from))
+            .transpose()?;
+        self.clock = clock;
+        Ok(delta)
+    }
+
+    pub const fn is_playing(&self) -> bool {
+        self.clock.is_playing()
+    }
+
     pub fn time(&self) -> f64 {
         self.player.frame().time
     }
@@ -333,6 +360,24 @@ mod wasm {
         #[wasm_bindgen(js_name = setLoopDurationSeconds)]
         pub fn set_loop_duration_seconds(&mut self, duration: f64) -> Result<(), JsValue> {
             self.inner.set_loop_duration(duration).map_err(js_error)
+        }
+
+        pub fn pause(&mut self) {
+            self.inner.pause();
+        }
+
+        pub fn resume(&mut self) {
+            self.inner.resume();
+        }
+
+        #[wasm_bindgen(js_name = seekDeltaJson)]
+        pub fn seek_delta_json(&mut self, scene_time: f64) -> Result<Option<String>, JsValue> {
+            self.inner.seek_delta_json(scene_time).map_err(js_error)
+        }
+
+        #[wasm_bindgen(js_name = isPlaying)]
+        pub fn is_playing(&self) -> bool {
+            self.inner.is_playing()
         }
 
         #[wasm_bindgen(js_name = legacySceneJson)]
@@ -542,5 +587,57 @@ mod tests {
         assert!(!engine.resource_bundle_bytes().is_empty());
         assert_eq!(engine.legacy_scene_json(), legacy_json);
         assert_eq!(engine.retained_document_json(), retained_json);
+    }
+
+    #[test]
+    fn retained_engine_playback_controls_keep_resources_and_session_stable() {
+        let mut legacy = SceneDefinition::new();
+        let circle = legacy.add(GeometryRef::circle(0.25));
+        legacy
+            .animate_position(
+                circle,
+                Vec2::ZERO,
+                Vec2::new(2.0, 0.0),
+                TrackTiming::new(0.0, 2.0, RateFunction::Linear),
+            )
+            .unwrap();
+        let text_id = ObjectId::new(1_u64 << 52);
+        let retained = text_document("controls", false, 1, text_id);
+        let legacy_json = noon_ir::encode_scene(&legacy).unwrap();
+        let retained_json = retained.to_json().unwrap();
+        let mut engine =
+            RetainedAuthoringEnginePlayer::new(&legacy_json, &retained_json, 4.0, 37).unwrap();
+        let bundle = engine.resource_bundle_bytes().to_vec();
+
+        let initial: RetainedExecutionDeltaEnvelope =
+            serde_json::from_str(&engine.initial_delta_json().unwrap()).unwrap();
+        engine.tick_delta_json(100.0).unwrap();
+        engine.tick_delta_json(1_100.0).unwrap();
+        assert_eq!(engine.time(), 1.0);
+
+        engine.pause();
+        assert!(!engine.is_playing());
+        assert!(engine.tick_delta_json(5_100.0).unwrap().is_none());
+        assert_eq!(engine.time(), 1.0);
+
+        let rewind: RetainedExecutionDeltaEnvelope = serde_json::from_str(
+            &engine
+                .seek_delta_json(0.25)
+                .unwrap()
+                .expect("rewind snapshot"),
+        )
+        .unwrap();
+        assert!(rewind.snapshot);
+        assert_eq!(rewind.session, initial.session);
+        assert_eq!(rewind.time, 0.25);
+        assert_eq!(engine.resource_bundle_bytes(), bundle);
+        assert!(engine.tick_delta_json(8_100.0).unwrap().is_none());
+        assert_eq!(engine.time(), 0.25);
+
+        engine.resume();
+        assert!(engine.is_playing());
+        assert!(engine.tick_delta_json(8_100.0).unwrap().is_none());
+        engine.tick_delta_json(8_600.0).unwrap();
+        assert_eq!(engine.time(), 0.75);
     }
 }

--- a/scripts/authoring-execution-router-smoke.mjs
+++ b/scripts/authoring-execution-router-smoke.mjs
@@ -143,6 +143,18 @@ try {
     await new Promise((resolve) => setTimeout(resolve, 350));
     const mixedMetrics = await execution.metrics();
     const mixedCanvas = execution.canvas;
+
+    const mixedPause = await execution.pause();
+    const mixedPausedCanvas = execution.canvas;
+    const mixedPausedState = await execution.state();
+    await new Promise((resolve) => setTimeout(resolve, 160));
+    const mixedStillPausedState = await execution.state();
+    const mixedSeek = await execution.seek(2.5);
+    const mixedSeekState = await execution.state();
+    const mixedResume = await execution.resume();
+    await new Promise((resolve) => setTimeout(resolve, 160));
+    const mixedResumedState = await execution.state();
+
     const mixedRestartReady = await execution.restart();
     const mixedRestartCanvas = execution.canvas;
     const mixedRestartMetrics = await execution.metrics();
@@ -180,6 +192,17 @@ try {
     const legacyMetrics = await execution.metrics();
     const legacyCanvas = execution.canvas;
 
+    const legacyPause = await execution.pause();
+    const legacyPausedCanvas = execution.canvas;
+    const legacyPausedState = await execution.state();
+    await new Promise((resolve) => setTimeout(resolve, 160));
+    const legacyStillPausedState = await execution.state();
+    const legacySeek = await execution.seek(1.5);
+    const legacySeekState = await execution.state();
+    const legacyResume = await execution.resume();
+    await new Promise((resolve) => setTimeout(resolve, 160));
+    const legacyResumedState = await execution.state();
+
     const secondLegacy = await execution.reconcileScene(JSON.stringify(legacy.document), {
       retainedDocumentJson: JSON.stringify(legacy.retainedDocument),
       callbacks: legacy.callbacks,
@@ -202,6 +225,14 @@ try {
       mixedRaceMode: mixedRaceMetrics.executionMode,
       mixedRaceRetainedChannel: JSON.parse(mixedRaceState.retainedDocumentJson).channel,
       mixedMetrics,
+      mixedPause,
+      mixedPausePreservedCanvas: mixedPausedCanvas === mixedCanvas,
+      mixedPausedState,
+      mixedStillPausedState,
+      mixedSeek,
+      mixedSeekState,
+      mixedResume,
+      mixedResumedState,
       mixedRestartMode: mixedRestartReady.mode,
       mixedRestartCanvasChanged: mixedRestartCanvas !== mixedCanvas,
       mixedRestartObjectCount: mixedRestartMetrics.metrics.objectCount,
@@ -215,6 +246,14 @@ try {
       legacyRaceMode: legacyRaceMetrics.executionMode,
       legacyRaceObjectCount: JSON.parse(legacyRaceState.sceneJson).objects.length,
       legacyMetrics,
+      legacyPause,
+      legacyPausePreservedCanvas: legacyPausedCanvas === legacyCanvas,
+      legacyPausedState,
+      legacyStillPausedState,
+      legacySeek,
+      legacySeekState,
+      legacyResume,
+      legacyResumedState,
       secondLegacyMode: secondLegacy.mode,
       secondLegacyRebuilt: secondLegacy.rebuilt,
       legacyRestartMode: legacyRestartReady.mode,
@@ -246,6 +285,21 @@ try {
   assert.equal(result.mixedMetrics.engineMetrics.resourceBundleTransfers, 1);
   assert.ok(result.mixedMetrics.engineMetrics.resourceBundleBytes > 0);
   assert.equal(result.mixedMetrics.engineMetrics.host.enabled, false);
+  assert.equal(result.mixedPause.operation, "pause");
+  assert.equal(result.mixedPause.playing, false);
+  assert.equal(result.mixedPausePreservedCanvas, true);
+  assert.equal(result.mixedPausedState.playing, false);
+  assert.equal(result.mixedStillPausedState.playing, false);
+  assert.equal(result.mixedStillPausedState.time, result.mixedPausedState.time);
+  assert.equal(result.mixedSeek.operation, "seek");
+  assert.equal(result.mixedSeek.playing, false);
+  assert.equal(result.mixedSeek.time, 2.5);
+  assert.equal(result.mixedSeekState.time, 2.5);
+  assert.equal(result.mixedSeekState.playing, false);
+  assert.equal(result.mixedResume.operation, "resume");
+  assert.equal(result.mixedResume.playing, true);
+  assert.ok(result.mixedResumedState.time > 2.5);
+  assert.equal(result.mixedResumedState.playing, true);
   assert.equal(result.mixedRestartMode, result.retainedMode);
   assert.equal(result.mixedRestartCanvasChanged, true);
   assert.equal(result.mixedRestartObjectCount, 3);
@@ -262,6 +316,21 @@ try {
   assert.equal(result.legacyMetrics.executionMode, result.initialMode);
   assert.equal(result.legacyMetrics.metrics.objectCount, 2);
   assert.equal(typeof result.legacyMetrics.engineMetrics.host.enabled, "boolean");
+  assert.equal(result.legacyPause.operation, "pause");
+  assert.equal(result.legacyPause.playing, false);
+  assert.equal(result.legacyPausePreservedCanvas, true);
+  assert.equal(result.legacyPausedState.playing, false);
+  assert.equal(result.legacyStillPausedState.playing, false);
+  assert.equal(result.legacyStillPausedState.time, result.legacyPausedState.time);
+  assert.equal(result.legacySeek.operation, "seek");
+  assert.equal(result.legacySeek.playing, false);
+  assert.equal(result.legacySeek.time, 1.5);
+  assert.equal(result.legacySeekState.time, 1.5);
+  assert.equal(result.legacySeekState.playing, false);
+  assert.equal(result.legacyResume.operation, "resume");
+  assert.equal(result.legacyResume.playing, true);
+  assert.ok(result.legacyResumedState.time > 1.5);
+  assert.equal(result.legacyResumedState.playing, true);
   assert.equal(result.secondLegacyMode, result.initialMode);
   assert.equal(result.secondLegacyRebuilt, false);
   assert.equal(result.legacyRestartMode, result.initialMode);
@@ -272,7 +341,7 @@ try {
   assert.deepEqual(result.clientErrors, []);
   assert.deepEqual(browserErrors, []);
   console.log(
-    `✓ authoring execution router: legacy → retained → restart → legacy → restart on ${result.rendererBackend}`,
+    `✓ authoring execution router: deterministic controls across retained/legacy on ${result.rendererBackend}`,
   );
 } finally {
   await browser?.close();

--- a/web/authoring-execution-client.js
+++ b/web/authoring-execution-client.js
@@ -157,6 +157,18 @@ export class AuthoringExecutionClient {
     return result;
   }
 
+  async pause() {
+    return this.#withStablePlayer((player) => player.pause());
+  }
+
+  async resume() {
+    return this.#withStablePlayer((player) => player.resume());
+  }
+
+  async seek(timeSeconds) {
+    return this.#withStablePlayer((player) => player.seek(timeSeconds));
+  }
+
   async restart() {
     return this.#withStablePlayer(async (player, mode) => {
       const ready = await player.restart();

--- a/web/execution-engine-worker.js
+++ b/web/execution-engine-worker.js
@@ -47,6 +47,9 @@ async function handleMainMessage(message) {
       case "replace_scene":
       case "reconcile_scene":
       case "set_loop_duration":
+      case "pause":
+      case "resume":
+      case "seek":
       case "apply_patch":
       case "configure_callbacks":
         enqueueControl(message);
@@ -60,6 +63,7 @@ async function handleMainMessage(message) {
         respond(message.requestId, {
           type: "state",
           time: player.time(),
+          playing: player.isPlaying(),
           nextPatchSequence: String(player.nextPatchSequence()),
           sceneJson: player.sceneJson(),
         });
@@ -301,6 +305,7 @@ function executeControl(message) {
       clearHostCallbacks();
       const delta = player.replaceSceneDeltaJson(message.sceneJson);
       applyOptionalLoopDuration(message.loopDurationSeconds);
+      latestTick = null;
       sendDeltaOrThrow(delta);
       respond(message.requestId, runtimeResult("replace_scene"));
       return;
@@ -323,6 +328,32 @@ function executeControl(message) {
       validateRequiredLoopDuration(message.loopDurationSeconds);
       player.setLoopDurationSeconds(message.loopDurationSeconds);
       respond(message.requestId, runtimeResult("set_loop_duration"));
+      return;
+    }
+    case "pause": {
+      player.pause();
+      latestTick = null;
+      respond(message.requestId, runtimeResult("pause"));
+      return;
+    }
+    case "resume": {
+      player.resume();
+      latestTick = null;
+      respond(message.requestId, runtimeResult("resume"));
+      return;
+    }
+    case "seek": {
+      if (hostCallbacks !== null) {
+        throw new Error(
+          "deterministic seek is not supported while Python host callbacks are active",
+        );
+      }
+      const delta = player.seekDeltaJson(message.time);
+      latestTick = null;
+      if (delta !== null && delta !== undefined) {
+        sendDeltaOrThrow(delta);
+      }
+      respond(message.requestId, runtimeResult("seek"));
       return;
     }
     case "apply_patch": {
@@ -371,6 +402,7 @@ function runtimeResult(operation) {
     type: "result",
     operation,
     time: player.time(),
+    playing: player.isPlaying(),
     nextPatchSequence: String(player.nextPatchSequence()),
     sceneJson: player.sceneJson(),
   };

--- a/web/execution-worker-client.js
+++ b/web/execution-worker-client.js
@@ -204,6 +204,19 @@ export class ExecutionWorkerClient {
     return result;
   }
 
+  async pause() {
+    return this.#requestEngine("pause", {});
+  }
+
+  async resume() {
+    return this.#requestEngine("resume", {});
+  }
+
+  async seek(timeSeconds) {
+    const time = validateSeekTimeSeconds(timeSeconds, this.#loopDurationSeconds);
+    return this.#requestEngine("seek", { time });
+  }
+
   async applyPatchBatch(patchBatchJson) {
     if (typeof patchBatchJson !== "string" || patchBatchJson.trim() === "") {
       throw new TypeError("patch batch must be non-empty JSON text");
@@ -537,6 +550,18 @@ function validateOptionalLoopDurationSeconds(loopDurationSeconds) {
     return null;
   }
   return validateLoopDurationSeconds(loopDurationSeconds);
+}
+
+function validateSeekTimeSeconds(timeSeconds, loopDurationSeconds) {
+  if (!Number.isFinite(timeSeconds) || timeSeconds < 0) {
+    throw new TypeError("playback seek time must be finite and non-negative");
+  }
+  if (timeSeconds > loopDurationSeconds) {
+    throw new RangeError(
+      `playback seek time ${timeSeconds} exceeds loop duration ${loopDurationSeconds}`,
+    );
+  }
+  return timeSeconds;
 }
 
 function validateCallbacks(callbacks) {

--- a/web/retained-execution-engine-worker.js
+++ b/web/retained-execution-engine-worker.js
@@ -15,6 +15,7 @@ let transportMode = null;
 let transport = null;
 let player = null;
 let latestTick = null;
+let controlQueue = [];
 let initialized = false;
 let stopped = false;
 let resourceBundleBytes = 0;
@@ -31,16 +32,17 @@ async function handleMainMessage(message) {
         await initialize(message);
         return;
       case "set_loop_duration":
-        requireInitialized();
-        validateLoopDuration(message.loopDurationSeconds);
-        player.setLoopDurationSeconds(message.loopDurationSeconds);
-        respond(message.requestId, runtimeResult("set_loop_duration"));
+      case "pause":
+      case "resume":
+      case "seek":
+        enqueueControl(message);
         return;
       case "state":
         requireInitialized();
         respond(message.requestId, {
           type: "state",
           time: player.time(),
+          playing: player.isPlaying(),
           nextPatchSequence: "0",
           sceneJson: player.legacySceneJson(),
           retainedDocumentJson: player.retainedDocumentJson(),
@@ -54,6 +56,7 @@ async function handleMainMessage(message) {
             retained: true,
             mixed: true,
             time: player.time(),
+            playing: player.isPlaying(),
             resourceBundleBytes,
             resourceBundleTransfers: 1,
           },
@@ -69,6 +72,7 @@ async function handleMainMessage(message) {
         );
       case "stop":
         stopped = true;
+        controlQueue = [];
         latestTick = null;
         renderPort?.close?.();
         self.close();
@@ -172,10 +176,33 @@ function handleRenderMessage(message) {
   }
 }
 
+function enqueueControl(message) {
+  requireInitialized();
+  if (!Number.isSafeInteger(message.requestId) || message.requestId < 0) {
+    throw new Error("mixed retained engine request ID must be a non-negative safe integer");
+  }
+  controlQueue.push(message);
+  drainWork();
+}
+
 function drainWork() {
   if (!initialized || stopped || player === null || transport === null) {
     return;
   }
+
+  while (controlQueue.length > 0 && transportCanSend()) {
+    const message = controlQueue.shift();
+    try {
+      executeControl(message);
+    } catch (error) {
+      fail(error, message.requestId);
+      return;
+    }
+  }
+  if (controlQueue.length > 0) {
+    return;
+  }
+
   if (latestTick === null || !transportCanSend()) {
     return;
   }
@@ -188,6 +215,37 @@ function drainWork() {
     }
   } catch (error) {
     fail(error, null);
+  }
+}
+
+function executeControl(message) {
+  switch (message.type) {
+    case "set_loop_duration":
+      validateLoopDuration(message.loopDurationSeconds);
+      player.setLoopDurationSeconds(message.loopDurationSeconds);
+      respond(message.requestId, runtimeResult("set_loop_duration"));
+      return;
+    case "pause":
+      player.pause();
+      latestTick = null;
+      respond(message.requestId, runtimeResult("pause"));
+      return;
+    case "resume":
+      player.resume();
+      latestTick = null;
+      respond(message.requestId, runtimeResult("resume"));
+      return;
+    case "seek": {
+      const delta = player.seekDeltaJson(message.time);
+      latestTick = null;
+      if (delta !== undefined && delta !== null) {
+        sendDeltaOrThrow(delta);
+      }
+      respond(message.requestId, runtimeResult("seek"));
+      return;
+    }
+    default:
+      throw new Error(`unknown mixed retained queued engine command ${message.type}`);
   }
 }
 
@@ -221,6 +279,7 @@ function runtimeResult(operation) {
     type: "result",
     operation,
     time: player.time(),
+    playing: player.isPlaying(),
     nextPatchSequence: "0",
     sceneJson: player.legacySceneJson(),
     retainedDocumentJson: player.retainedDocumentJson(),

--- a/web/retained-execution-worker-client.js
+++ b/web/retained-execution-worker-client.js
@@ -159,6 +159,19 @@ export class RetainedExecutionWorkerClient {
     return result;
   }
 
+  async pause() {
+    return this.#requestEngine("pause", {});
+  }
+
+  async resume() {
+    return this.#requestEngine("resume", {});
+  }
+
+  async seek(timeSeconds) {
+    const time = validateSeekTimeSeconds(timeSeconds, this.#loopDurationSeconds);
+    return this.#requestEngine("seek", { time });
+  }
+
   resize(width, height, devicePixelRatio = 1) {
     this.#requireStarted();
     if (!Number.isFinite(width) || !Number.isFinite(height) || !Number.isFinite(devicePixelRatio)) {
@@ -367,6 +380,18 @@ function validateLoopDurationSeconds(loopDurationSeconds) {
     throw new TypeError("mixed retained loop duration must be positive and finite");
   }
   return loopDurationSeconds;
+}
+
+function validateSeekTimeSeconds(timeSeconds, loopDurationSeconds) {
+  if (!Number.isFinite(timeSeconds) || timeSeconds < 0) {
+    throw new TypeError("mixed retained playback seek time must be finite and non-negative");
+  }
+  if (timeSeconds > loopDurationSeconds) {
+    throw new RangeError(
+      `mixed retained playback seek time ${timeSeconds} exceeds loop duration ${loopDurationSeconds}`,
+    );
+  }
+  return timeSeconds;
 }
 
 function checkedNext(current, label) {


### PR DESCRIPTION
## Summary
Runtime/protocol tranche for #438. This intentionally does **not** add playground UI yet.

This PR is a clean single-commit recovery of the exact integrated tree previously validated on #454's merge ref after the original branch was concurrently rewritten/closed. The code tree is byte-identical to CI-tested merge commit `542b9275b6aca22ac522f65d28d5b7aa6c84053e`.

- make `PlaybackClock` the single logical-time owner for play/pause/resume/exact seek
- preserve the exact loop endpoint on seek; only a later positive playback advance wraps
- expose the same controls through legacy and mixed-retained WASM engine players
- serialize controls ahead of pending render ticks in both engine workers so stale RAF timestamps cannot immediately overwrite a pause/seek
- expose one `pause()`, `resume()`, and `seek(seconds)` contract through both worker clients and `AuthoringExecutionClient`
- keep renderer/device-recovery `restart()` separate and unchanged
- preserve execution session/object/resource identity across playback controls
- cover both execution modes in the existing real Chromium authoring-router smoke, including frozen paused time, exact seek, resume continuity, no canvas rebuild, and separate restart behavior

## Validation
The exact tree passed on #454's current-master merge ref:
- Rust format, clippy, and full workspace tests
- Web/WASM package build and validation
- test coverage, renderer recovery, resize recovery
- engine/render worker transport smoke
- mixed-retained worker transport smoke
- real Python authoring execution router smoke with the new playback assertions
- WebGPU render/camera/painter pixel oracles; the remaining WebGPU job failure was the unrelated existing sustained 10k-object profiler `runtime metric is not finite: NaN` after those actual rendering oracles passed

## Explicit boundary
Arbitrary Python host callbacks do not yet have a deterministic replay model for backward/random seek. Legacy worker seek rejects while host callbacks are active rather than approximating or silently replaying side effects. Pause/resume remain supported.

Tracks #438. Supersedes closed #454 without changing its validated code tree.