### PR TITLE
Preflight canonical SceneSpec version before content decode

### DIFF
--- a/crates/noon-ir/src/mixed.rs
+++ b/crates/noon-ir/src/mixed.rs
@@ -15,6 +15,20 @@ use crate::{IrError, SceneDocument};
 /// is in progress, but new frontend semantics should converge on `SceneSpec`.
 pub const SCENE_SPEC_VERSION: u32 = 1;
 
+#[derive(Deserialize)]
+struct SceneSpecVersionProbe {
+    version: u32,
+}
+
+fn preflight_scene_spec_version(json: &str) -> Result<(), SceneSpecError> {
+    let probe: SceneSpecVersionProbe = serde_json::from_str(json).map_err(SceneSpecError::Json)?;
+    if probe.version == SCENE_SPEC_VERSION {
+        Ok(())
+    } else {
+        Err(SceneSpecError::UnsupportedVersion(probe.version))
+    }
+}
+
 /// Source-language identity at the canonical authoring boundary.
 ///
 /// This mirrors the semantic source kinds without making the IR depend on a
@@ -297,6 +311,7 @@ impl SceneSpec {
     }
 
     pub fn from_json(json: &str) -> Result<Self, SceneSpecError> {
+        preflight_scene_spec_version(json)?;
         let spec: Self = serde_json::from_str(json).map_err(SceneSpecError::Json)?;
         spec.validate()?;
         Ok(spec)
@@ -578,6 +593,46 @@ mod tests {
                 track: id,
                 error: TimelineError::InvalidDuration(0.0),
             }) if id == track.id
+        ));
+    }
+
+    #[test]
+    fn future_scene_spec_version_is_rejected_before_content_decode() {
+        let json = r#"{
+            "version": 2,
+            "objects": [{
+                "id": 7,
+                "content": {
+                    "kind": "future_content_kind",
+                    "value": {"future_only": true}
+                }
+            }],
+            "tracks": []
+        }"#;
+
+        assert!(matches!(
+            SceneSpec::from_json(json),
+            Err(SceneSpecError::UnsupportedVersion(2))
+        ));
+    }
+
+    #[test]
+    fn current_scene_spec_version_still_reports_unknown_content_as_json_error() {
+        let json = r#"{
+            "version": 1,
+            "objects": [{
+                "id": 7,
+                "content": {
+                    "kind": "future_content_kind",
+                    "value": {"future_only": true}
+                }
+            }],
+            "tracks": []
+        }"#;
+
+        assert!(matches!(
+            SceneSpec::from_json(json),
+            Err(SceneSpecError::Json(_))
         ));
     }
 


### PR DESCRIPTION
## Summary
- preflight the canonical mixed `SceneSpec` version before deserializing the full document
- return `UnsupportedVersion` for future-version documents even when they contain future-only content variants that v1 cannot decode
- preserve normal JSON diagnostics for malformed/unknown content in the current v1 format
- add focused regressions for both error-precedence cases

## Why
The legacy Noon IR already probes its version before decoding the full payload. `SceneSpec::from_json()` decoded the entire v1 schema first, so a valid future document containing a new object-content variant could be misreported as malformed JSON instead of an unsupported version. That makes forward-version diagnostics depend on whether the future payload happens to remain deserializable by v1.

The mixed authoring contract should have the same envelope behavior as the legacy IR: the version domain is authoritative before schema-specific content decoding.

## Architecture
The probe is intentionally narrow and allocation-light: deserialize only `{ version }`, reject unsupported versions, then use the existing full `SceneSpec` deserialize + shared validation path. No permissive future-schema parsing, duplicate compatibility layer, or frontend-specific handling is introduced.

## Validation
Focused unit tests cover a v2 payload with an unknown future content variant and a v1 payload with the same unknown variant. Normal `noon-ir`/workspace CI exercises the tests and rustfmt/clippy.

Related: #108, #367, #456.