### PR TITLE
Rollback failed execution worker startup

### DIFF
--- a/scripts/build-web-demo.sh
+++ b/scripts/build-web-demo.sh
@@ -13,6 +13,7 @@ node --check web/python-editor.js
 node --check web/python-worker.js
 node --check web/native-inputs.js
 node --check web/execution-transport.js
+node --check web/execution-canvas.js
 node --check web/execution-engine-worker.js
 node --check web/execution-render-worker.js
 node --check web/execution-worker-client.js
@@ -59,6 +60,7 @@ node --check scripts/updater-callback-smoke.mjs
 node --test web/example-gallery.test.mjs
 node --test web/execution-transport.test.mjs
 node --test web/execution-worker-client.test.mjs
+node --test web/execution-worker-startup.test.mjs
 node --test web/authoring-client.test.mjs
 node --test web/playground-generation.test.mjs
 node --test web/playground-startup.test.mjs

--- a/web/authoring-execution-client.js
+++ b/web/authoring-execution-client.js
@@ -1,3 +1,4 @@
+import { replaceExecutionCanvas } from "./execution-canvas.js";
 import { ExecutionWorkerClient } from "./execution-worker-client.js";
 import { RetainedExecutionWorkerClient } from "./retained-execution-worker-client.js";
 
@@ -171,14 +172,19 @@ export class AuthoringExecutionClient {
 
   async restart() {
     return this.#withStablePlayer(async (player, mode) => {
-      const ready = await player.restart();
-      this.#canvas = player.canvas;
-      this.#mode = mode;
-      this.#rendererBackend = ready.render.backend;
-      this.#transportMode = ready.transportMode;
-      this.#observeCanvas();
-      this.#resizeCurrentCanvas();
-      return { ...ready, mode };
+      try {
+        const ready = await player.restart();
+        this.#canvas = player.canvas;
+        this.#mode = mode;
+        this.#rendererBackend = ready.render.backend;
+        this.#transportMode = ready.transportMode;
+        this.#observeCanvas();
+        this.#resizeCurrentCanvas();
+        return { ...ready, mode };
+      } catch (error) {
+        this.#adoptPlayerCanvas(player);
+        throw error;
+      }
     });
   }
 
@@ -221,6 +227,7 @@ export class AuthoringExecutionClient {
       return ready;
     } catch (error) {
       player.terminate();
+      this.#adoptPlayerCanvas(player);
       throw error;
     }
   }
@@ -250,6 +257,7 @@ export class AuthoringExecutionClient {
       };
     } catch (error) {
       player.terminate();
+      this.#adoptPlayerCanvas(player);
       throw error;
     }
   }
@@ -282,6 +290,7 @@ export class AuthoringExecutionClient {
       };
     } catch (error) {
       player.terminate();
+      this.#adoptPlayerCanvas(player);
       throw error;
     }
   }
@@ -332,24 +341,20 @@ export class AuthoringExecutionClient {
 
   #replaceTransferredCanvas() {
     this.#player?.terminate();
-    const previous = this.#canvas;
-    const replacement = previous.cloneNode(false);
-    replacement.width = previous.width;
-    replacement.height = previous.height;
-    replacement.className = previous.className;
-    replacement.id = previous.id;
-    for (const attribute of previous.getAttributeNames()) {
-      if (attribute !== "width" && attribute !== "height" && attribute !== "class" && attribute !== "id") {
-        replacement.setAttribute(attribute, previous.getAttribute(attribute));
-      }
-    }
-    previous.replaceWith(replacement);
-    this.#canvas = replacement;
+    this.#canvas = replaceExecutionCanvas(this.#canvas);
     this.#player = null;
     this.#mode = null;
     this.#rendererBackend = "";
     this.#observeCanvas();
-    return replacement;
+    return this.#canvas;
+  }
+
+  #adoptPlayerCanvas(player) {
+    if (this.#canvas === player.canvas) {
+      return;
+    }
+    this.#canvas = player.canvas;
+    this.#observeCanvas();
   }
 
   #observeCanvas() {

--- a/web/execution-canvas.js
+++ b/web/execution-canvas.js
@@ -1,0 +1,10 @@
+export function replaceExecutionCanvas(canvas) {
+  if (!(canvas instanceof HTMLCanvasElement)) {
+    throw new TypeError("replaceExecutionCanvas requires an HTMLCanvasElement");
+  }
+  const replacement = canvas.cloneNode(false);
+  replacement.width = canvas.width;
+  replacement.height = canvas.height;
+  canvas.replaceWith(replacement);
+  return replacement;
+}

--- a/web/execution-worker-client.js
+++ b/web/execution-worker-client.js
@@ -3,6 +3,7 @@ import {
   EXECUTION_TRANSPORT_TRANSFERABLE,
   selectExecutionTransportMode,
 } from "./execution-transport.js";
+import { replaceExecutionCanvas } from "./execution-canvas.js";
 import { projectLegacyReactiveSceneJson } from "./legacy-reactive-projection.js";
 
 const ENGINE_CHANNEL = "noon.engine";
@@ -106,48 +107,55 @@ export class ExecutionWorkerClient {
     this.#canvas.width = initialWidth;
     this.#canvas.height = initialHeight;
 
-    const channel = new MessageChannel();
-    const offscreen = this.#canvas.transferControlToOffscreen();
-    this.#engineWorker = new Worker(new URL("./execution-engine-worker.js", import.meta.url), {
-      type: "module",
-      name: "noon-engine",
-    });
-    this.#renderWorker = new Worker(new URL("./execution-render-worker.js", import.meta.url), {
-      type: "module",
-      name: "noon-render",
-    });
+    let canvasTransferred = false;
+    try {
+      const channel = new MessageChannel();
+      const offscreen = this.#canvas.transferControlToOffscreen();
+      canvasTransferred = true;
+      this.#engineWorker = new Worker(new URL("./execution-engine-worker.js", import.meta.url), {
+        type: "module",
+        name: "noon-engine",
+      });
+      this.#renderWorker = new Worker(new URL("./execution-render-worker.js", import.meta.url), {
+        type: "module",
+        name: "noon-render",
+      });
 
-    const engineReady = this.#workerReady(this.#engineWorker, ENGINE_CHANNEL, "engine");
-    const renderReady = this.#workerReady(this.#renderWorker, RENDER_CHANNEL, "render");
-    this.#ready = Promise.all([engineReady, renderReady]).then(([engine, render]) => ({
-      engine,
-      render,
-      transportMode,
-      session: this.#session,
-    }));
-
-    this.#renderWorker.postMessage(
-      renderEnvelope("init", {
-        canvas: offscreen,
-        port: channel.port2,
+      const engineReady = this.#workerReady(this.#engineWorker, ENGINE_CHANNEL, "engine");
+      const renderReady = this.#workerReady(this.#renderWorker, RENDER_CHANNEL, "render");
+      this.#ready = Promise.all([engineReady, renderReady]).then(([engine, render]) => ({
+        engine,
+        render,
         transportMode,
-        width: initialWidth,
-        height: initialHeight,
-      }),
-      [offscreen, channel.port2],
-    );
-    this.#engineWorker.postMessage(
-      engineEnvelope("init", {
-        port: channel.port1,
-        sceneJson,
-        loopDurationSeconds,
-        transportMode,
-        sharedSlotCapacity,
         session: this.#session,
-      }),
-      [channel.port1],
-    );
-    return this.#ready;
+      }));
+
+      this.#renderWorker.postMessage(
+        renderEnvelope("init", {
+          canvas: offscreen,
+          port: channel.port2,
+          transportMode,
+          width: initialWidth,
+          height: initialHeight,
+        }),
+        [offscreen, channel.port2],
+      );
+      this.#engineWorker.postMessage(
+        engineEnvelope("init", {
+          port: channel.port1,
+          sceneJson,
+          loopDurationSeconds,
+          transportMode,
+          sharedSlotCapacity,
+          session: this.#session,
+        }),
+        [channel.port1],
+      );
+      return await this.#ready;
+    } catch (error) {
+      this.#rollbackFailedStart(error, canvasTransferred);
+      throw error;
+    }
   }
 
   ready() {
@@ -280,22 +288,18 @@ export class ExecutionWorkerClient {
   }
 
   async restart() {
-    this.#requireStarted();
+    if (this.#sceneJson === null || this.#transportMode === null) {
+      throw new Error("ExecutionWorkerClient has not been started");
+    }
     const sceneJson = this.#sceneJson;
     const loopDurationSeconds = this.#loopDurationSeconds;
     const transportMode = this.#transportMode;
     const callbacks = this.#hostCallbacks;
     const authoringClient = this.#hostAuthoringClient;
-    this.terminate({ preserveHostConfiguration: true });
-
-    const previous = this.#canvas;
-    const replacement = previous.cloneNode(false);
-    replacement.width = previous.width;
-    replacement.height = previous.height;
-    replacement.className = previous.className;
-    replacement.id = previous.id;
-    previous.replaceWith(replacement);
-    this.#canvas = replacement;
+    if (this.#engineWorker !== null || this.#renderWorker !== null) {
+      this.terminate({ preserveHostConfiguration: true });
+      this.#canvas = replaceExecutionCanvas(this.#canvas);
+    }
     const ready = await this.start(sceneJson, { loopDurationSeconds, transportMode });
     if (callbacks !== null && authoringClient !== null) {
       this.#hostAuthoringClient = null;
@@ -451,6 +455,21 @@ export class ExecutionWorkerClient {
         pending.reject(error);
         this.#pending.delete(key);
       }
+    }
+  }
+
+  #rollbackFailedStart(error, replaceCanvas) {
+    this.#engineWorker?.terminate();
+    this.#renderWorker?.terminate();
+    this.#engineWorker = null;
+    this.#renderWorker = null;
+    this.#ready = null;
+    for (const pending of this.#pending.values()) {
+      pending.reject(error);
+    }
+    this.#pending.clear();
+    if (replaceCanvas) {
+      this.#canvas = replaceExecutionCanvas(this.#canvas);
     }
   }
 

--- a/web/execution-worker-startup.test.mjs
+++ b/web/execution-worker-startup.test.mjs
@@ -1,0 +1,239 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+class FakeCanvas {
+  clientWidth = 640;
+  clientHeight = 360;
+  width = 640;
+  height = 360;
+  className = "scene-canvas";
+  id = "scene";
+  replacement = null;
+  transferred = false;
+
+  transferControlToOffscreen() {
+    if (this.transferred) {
+      throw new Error("canvas was transferred twice");
+    }
+    this.transferred = true;
+    return { width: this.width, height: this.height };
+  }
+
+  cloneNode() {
+    const clone = new FakeCanvas();
+    clone.clientWidth = this.clientWidth;
+    clone.clientHeight = this.clientHeight;
+    clone.width = this.width;
+    clone.height = this.height;
+    clone.className = this.className;
+    clone.id = this.id;
+    return clone;
+  }
+
+  replaceWith(replacement) {
+    this.replacement = replacement;
+  }
+}
+
+class FakeMessageChannel {
+  constructor() {
+    this.port1 = {};
+    this.port2 = {};
+  }
+}
+
+class FakeWorker {
+  static instances = [];
+  static failNextName = null;
+
+  listeners = new Map();
+  messages = [];
+  terminated = false;
+
+  constructor(_url, options = {}) {
+    this.name = options.name ?? "";
+    if (FakeWorker.failNextName === this.name) {
+      FakeWorker.failNextName = null;
+      throw new Error(`${this.name} constructor failed`);
+    }
+    FakeWorker.instances.push(this);
+  }
+
+  addEventListener(type, listener) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  postMessage(message, transfer = []) {
+    this.messages.push({ message, transfer });
+  }
+
+  terminate() {
+    this.terminated = true;
+  }
+
+  emitMessage(message) {
+    this.#emit("message", { data: message });
+  }
+
+  emitError(message = "worker crashed") {
+    this.#emit("error", { message });
+  }
+
+  #emit(type, event) {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+}
+
+globalThis.HTMLCanvasElement = FakeCanvas;
+globalThis.MessageChannel = FakeMessageChannel;
+globalThis.Worker = FakeWorker;
+globalThis.window = { devicePixelRatio: 1 };
+
+const { AuthoringExecutionClient, AUTHORING_EXECUTION_LEGACY } =
+  await import("./authoring-execution-client.js");
+const { ExecutionWorkerClient } = await import("./execution-worker-client.js");
+const { RetainedExecutionWorkerClient } = await import("./retained-execution-worker-client.js");
+
+const SCENE_JSON = JSON.stringify({ version: 1, objects: [], tracks: [] });
+const RETAINED_JSON = JSON.stringify({
+  channel: "noon.authoring.retained",
+  objects: [{ id: "retained-probe" }],
+});
+
+function envelope(channel, type, payload = {}) {
+  return { channel, protocolVersion: 1, type, ...payload };
+}
+
+function workerByName(offset, name) {
+  const worker = FakeWorker.instances.slice(offset).find((candidate) => candidate.name === name);
+  assert.ok(worker, `missing worker ${name}`);
+  return worker;
+}
+
+function emitLegacyReady(offset) {
+  const engine = workerByName(offset, "noon-engine");
+  const render = workerByName(offset, "noon-render");
+  engine.emitMessage(envelope("noon.engine", "ready", { transportMode: "transferable" }));
+  render.emitMessage(
+    envelope("noon.render", "ready", {
+      transportMode: "transferable",
+      backend: "WebGL2",
+    }),
+  );
+  return { engine, render };
+}
+
+function emitRetainedReady(offset) {
+  const engine = workerByName(offset, "noon-mixed-retained-engine");
+  const render = workerByName(offset, "noon-mixed-retained-render");
+  engine.emitMessage(envelope("noon.engine", "ready", { transportMode: "transferable" }));
+  render.emitMessage(
+    envelope("noon.render", "ready", {
+      transportMode: "transferable",
+      backend: "WebGL2",
+    }),
+  );
+  return { engine, render };
+}
+
+test("legacy constructor failure rolls back transferred canvas and retry succeeds", async () => {
+  const original = new FakeCanvas();
+  const client = new ExecutionWorkerClient(original);
+  const offset = FakeWorker.instances.length;
+  FakeWorker.failNextName = "noon-render";
+
+  await assert.rejects(
+    client.start(SCENE_JSON, { transportMode: "transferable" }),
+    /noon-render constructor failed/,
+  );
+
+  const failedEngine = workerByName(offset, "noon-engine");
+  assert.equal(failedEngine.terminated, true);
+  assert.equal(original.transferred, true);
+  assert.notEqual(client.canvas, original);
+  assert.equal(original.replacement, client.canvas);
+  assert.equal(client.canvas.transferred, false);
+
+  const retryOffset = FakeWorker.instances.length;
+  const retry = client.start(SCENE_JSON, { transportMode: "transferable" });
+  emitLegacyReady(retryOffset);
+  const ready = await retry;
+  assert.equal(ready.session, 2, "failed startup generation must not be reused");
+  client.terminate();
+});
+
+test("retained pre-ready crash rolls back transferred canvas and retry succeeds", async () => {
+  const original = new FakeCanvas();
+  const errors = [];
+  const client = new RetainedExecutionWorkerClient(original, {
+    onError(error, owner) {
+      errors.push(`${owner}: ${error.message}`);
+    },
+  });
+  const offset = FakeWorker.instances.length;
+  const started = client.start(SCENE_JSON, RETAINED_JSON, { transportMode: "transferable" });
+  const engine = workerByName(offset, "noon-mixed-retained-engine");
+  const render = workerByName(offset, "noon-mixed-retained-render");
+  engine.emitMessage(envelope("noon.engine", "ready", { transportMode: "transferable" }));
+  render.emitError("retained render startup crashed");
+
+  await assert.rejects(started, /retained render startup crashed/);
+  assert.equal(engine.terminated, true);
+  assert.equal(render.terminated, true);
+  assert.notEqual(client.canvas, original);
+  assert.equal(original.replacement, client.canvas);
+  assert.deepEqual(errors, ["render: retained render startup crashed"]);
+
+  const retryOffset = FakeWorker.instances.length;
+  const retry = client.start(SCENE_JSON, RETAINED_JSON, { transportMode: "transferable" });
+  emitRetainedReady(retryOffset);
+  const ready = await retry;
+  assert.equal(ready.session, 2);
+  client.terminate();
+});
+
+test("authoring router adopts a low-level replacement after failed initial start", async () => {
+  const original = new FakeCanvas();
+  const router = new AuthoringExecutionClient(original);
+  FakeWorker.failNextName = "noon-render";
+
+  await assert.rejects(
+    router.start(SCENE_JSON, { transportMode: "transferable" }),
+    /noon-render constructor failed/,
+  );
+  assert.notEqual(router.canvas, original);
+  assert.equal(original.replacement, router.canvas);
+
+  const retryOffset = FakeWorker.instances.length;
+  const retry = router.start(SCENE_JSON, { transportMode: "transferable" });
+  emitLegacyReady(retryOffset);
+  await retry;
+  assert.equal(router.mode, AUTHORING_EXECUTION_LEGACY);
+  router.terminate();
+});
+
+test("authoring restart remains retryable after transient startup failure", async () => {
+  const router = new AuthoringExecutionClient(new FakeCanvas());
+  const initialOffset = FakeWorker.instances.length;
+  const initial = router.start(SCENE_JSON, { transportMode: "transferable" });
+  emitLegacyReady(initialOffset);
+  await initial;
+
+  const beforeFailure = router.canvas;
+  FakeWorker.failNextName = "noon-render";
+  await assert.rejects(router.restart(), /noon-render constructor failed/);
+  assert.notEqual(router.canvas, beforeFailure);
+  assert.equal(router.canvas.transferred, false);
+
+  const retryOffset = FakeWorker.instances.length;
+  const retry = router.restart();
+  emitLegacyReady(retryOffset);
+  const ready = await retry;
+  assert.equal(ready.session, 3, "restart retry must advance past the failed generation");
+  assert.equal(router.mode, AUTHORING_EXECUTION_LEGACY);
+  router.terminate();
+});

--- a/web/retained-execution-worker-client.js
+++ b/web/retained-execution-worker-client.js
@@ -3,6 +3,7 @@ import {
   EXECUTION_TRANSPORT_TRANSFERABLE,
   selectExecutionTransportMode,
 } from "./execution-transport.js";
+import { replaceExecutionCanvas } from "./execution-canvas.js";
 
 const ENGINE_CHANNEL = "noon.engine";
 const ENGINE_PROTOCOL_VERSION = 1;
@@ -86,49 +87,56 @@ export class RetainedExecutionWorkerClient {
     this.#canvas.width = initialWidth;
     this.#canvas.height = initialHeight;
 
-    const channel = new MessageChannel();
-    const offscreen = this.#canvas.transferControlToOffscreen();
-    this.#engineWorker = new Worker(
-      new URL("./retained-execution-engine-worker.js", import.meta.url),
-      { type: "module", name: "noon-mixed-retained-engine" },
-    );
-    this.#renderWorker = new Worker(
-      new URL("./retained-execution-render-worker.js", import.meta.url),
-      { type: "module", name: "noon-mixed-retained-render" },
-    );
+    let canvasTransferred = false;
+    try {
+      const channel = new MessageChannel();
+      const offscreen = this.#canvas.transferControlToOffscreen();
+      canvasTransferred = true;
+      this.#engineWorker = new Worker(
+        new URL("./retained-execution-engine-worker.js", import.meta.url),
+        { type: "module", name: "noon-mixed-retained-engine" },
+      );
+      this.#renderWorker = new Worker(
+        new URL("./retained-execution-render-worker.js", import.meta.url),
+        { type: "module", name: "noon-mixed-retained-render" },
+      );
 
-    const engineReady = this.#workerReady(this.#engineWorker, ENGINE_CHANNEL, "engine");
-    const renderReady = this.#workerReady(this.#renderWorker, RENDER_CHANNEL, "render");
-    this.#ready = Promise.all([engineReady, renderReady]).then(([engine, render]) => ({
-      engine,
-      render,
-      transportMode,
-      session: this.#session,
-    }));
-
-    this.#renderWorker.postMessage(
-      renderEnvelope("init", {
-        canvas: offscreen,
-        port: channel.port2,
+      const engineReady = this.#workerReady(this.#engineWorker, ENGINE_CHANNEL, "engine");
+      const renderReady = this.#workerReady(this.#renderWorker, RENDER_CHANNEL, "render");
+      this.#ready = Promise.all([engineReady, renderReady]).then(([engine, render]) => ({
+        engine,
+        render,
         transportMode,
-        width: initialWidth,
-        height: initialHeight,
-      }),
-      [offscreen, channel.port2],
-    );
-    this.#engineWorker.postMessage(
-      engineEnvelope("init", {
-        port: channel.port1,
-        sceneJson,
-        retainedDocumentJson,
-        loopDurationSeconds,
-        transportMode,
-        sharedSlotCapacity,
         session: this.#session,
-      }),
-      [channel.port1],
-    );
-    return this.#ready;
+      }));
+
+      this.#renderWorker.postMessage(
+        renderEnvelope("init", {
+          canvas: offscreen,
+          port: channel.port2,
+          transportMode,
+          width: initialWidth,
+          height: initialHeight,
+        }),
+        [offscreen, channel.port2],
+      );
+      this.#engineWorker.postMessage(
+        engineEnvelope("init", {
+          port: channel.port1,
+          sceneJson,
+          retainedDocumentJson,
+          loopDurationSeconds,
+          transportMode,
+          sharedSlotCapacity,
+          session: this.#session,
+        }),
+        [channel.port1],
+      );
+      return await this.#ready;
+    } catch (error) {
+      this.#rollbackFailedStart(error, canvasTransferred);
+      throw error;
+    }
   }
 
   ready() {
@@ -185,21 +193,21 @@ export class RetainedExecutionWorkerClient {
   }
 
   async restart() {
-    this.#requireStarted();
+    if (
+      this.#sceneJson === null ||
+      this.#retainedDocumentJson === null ||
+      this.#transportMode === null
+    ) {
+      throw new Error("RetainedExecutionWorkerClient has not been started");
+    }
     const sceneJson = this.#sceneJson;
     const retainedDocumentJson = this.#retainedDocumentJson;
     const loopDurationSeconds = this.#loopDurationSeconds;
     const transportMode = this.#transportMode;
-    this.terminate();
-
-    const previous = this.#canvas;
-    const replacement = previous.cloneNode(false);
-    replacement.width = previous.width;
-    replacement.height = previous.height;
-    replacement.className = previous.className;
-    replacement.id = previous.id;
-    previous.replaceWith(replacement);
-    this.#canvas = replacement;
+    if (this.#engineWorker !== null || this.#renderWorker !== null) {
+      this.terminate();
+      this.#canvas = replaceExecutionCanvas(this.#canvas);
+    }
     return this.start(sceneJson, retainedDocumentJson, {
       loopDurationSeconds,
       transportMode,
@@ -305,6 +313,21 @@ export class RetainedExecutionWorkerClient {
         pending.reject(error);
         this.#pending.delete(key);
       }
+    }
+  }
+
+  #rollbackFailedStart(error, replaceCanvas) {
+    this.#engineWorker?.terminate();
+    this.#renderWorker?.terminate();
+    this.#engineWorker = null;
+    this.#renderWorker = null;
+    this.#ready = null;
+    for (const pending of this.#pending.values()) {
+      pending.reject(error);
+    }
+    this.#pending.clear();
+    if (replaceCanvas) {
+      this.#canvas = replaceExecutionCanvas(this.#canvas);
     }
   }
 


### PR DESCRIPTION
## Summary
Harden the browser execution lifecycle when worker startup fails after `transferControlToOffscreen()`.

- make legacy engine/render startup transactional after canvas transfer
- apply the same rollback contract to mixed retained/text execution
- terminate partially-created workers and reject pending work on constructor, post/init, protocol, or pre-ready worker failure
- replace a transferred/poisoned DOM canvas with a fresh clone owned by the same client
- keep failed startup generations monotonic so retry never reuses a session
- make `restart()` retryable after a previous restart attempt failed during worker startup
- have `AuthoringExecutionClient` adopt the replacement canvas from failed child starts/rebuilds/restarts and rebind resize observation
- consolidate duplicated canvas replacement logic in `execution-canvas.js`
- preserve the current pause/resume/seek controls from #467 unchanged

## Deterministic regression coverage
`web/execution-worker-startup.test.mjs` proves:

1. legacy render-worker constructor failure after transfer terminates the partial engine worker, replaces the canvas, and a retry succeeds in the next session;
2. retained render-worker crash before readiness terminates both workers, replaces the canvas, reports the worker error once, and a retry succeeds;
3. the authoring router adopts a child replacement canvas after failed initial startup and can start again;
4. a failed public-style restart remains retryable on the next restart attempt, advancing past the failed generation.

The suite and new shared module are gated by `scripts/build-web-demo.sh`.

## Invariant
Once an HTML canvas has been transferred to an OffscreenCanvas, any failed worker generation owns that transfer permanently. Recovery must therefore retire the failed workers and DOM canvas together. The next generation always starts from a fresh DOM canvas and a new session ID; callers never have to know whether failure occurred before or after transfer.

## Scope
This does not change animation semantics, pause/resume/seek behavior, normal worker response correlation, renderer device/context-loss recovery, or Python authoring generation logic. It closes the startup/restart rollback seam left after the stale-worker generation work.

Tracks #112.