### PR TITLE
Preserve runtime timing across renderer recovery

### DIFF
--- a/crates/noon-web/src/legacy.rs
+++ b/crates/noon-web/src/legacy.rs
@@ -1362,7 +1362,8 @@ mod wasm {
             self.last_bytes_uploaded = 0;
             self.last_geometry_cache_misses = 0;
             self.last_cpu_frame_ms = f64::NAN;
-            self.last_runtime_evaluation_ms = f64::NAN;
+            // Runtime evaluation is independent of renderer generation and may already
+            // have been measured for the frame that installs a recovered renderer.
             self.last_frame_prepare_ms = f64::NAN;
             self.last_upload_ms = f64::NAN;
             self.last_encode_submit_ms = f64::NAN;


### PR DESCRIPTION
## Summary
- stop `reset_renderer_metrics()` from clearing `last_runtime_evaluation_ms`
- preserve the current frame's runtime evaluation measurement across renderer installation/recovery
- keep renderer-local frame/prepare/upload/encode metrics invalidated exactly as before

## Why
`renderFrame()` records runtime evaluation before entering `render_current_frame()`. A successful renderer recovery inside that render path calls `reset_renderer_metrics()`, which previously erased the already-valid runtime measurement to `NaN`. The frame can then present successfully while the sustained profiler observes `runtimeMs = NaN`.

Runtime evaluation is independent of renderer generation, so renderer reset must not invalidate it.

## Validation
- source replacement matched exactly one reset block
- `cargo fmt --all` and `git diff --check` passed while producing the source blob
- branch was rebuilt as one source-only commit on exact current master
- final diff is only `crates/noon-web/src/legacy.rs` (+2/-1)
- existing WebGPU painter-order sustained 10,000-object profile is the regression oracle that reproduced the failure on #442/#452/#463

Current clean head: `b3f4b9f5`.

This replaces the need for #463's profiler warmup workaround once the WebGPU oracle is green.