### PR TITLE
Gate failed text resource churn without leaks

### DIFF
--- a/crates/noon-core/tests/resource_failure_churn.rs
+++ b/crates/noon-core/tests/resource_failure_churn.rs
@@ -1,0 +1,78 @@
+use std::sync::Arc;
+
+use noon_core::{
+    Rect, TextRenderItem, TextResource, TextResourceArena, TextResourceError, TextResourceStats,
+    TextResourceValidationError, TextSourceKind, Vec2,
+};
+
+const CHURN_ITERATIONS: u64 = 1_000;
+
+fn empty_text(source: &str) -> TextResource {
+    TextResource {
+        source: Arc::from(source),
+        kind: TextSourceKind::Plain,
+        runs: Arc::from([]),
+        vector_items: Arc::from([]),
+        render_items: Arc::from([]),
+        parts: Arc::from([]),
+        bounds: Rect::new(Vec2::ZERO, Vec2::ZERO),
+        baseline: 0.0,
+        layout_artifact: None,
+    }
+}
+
+fn invalid_text(source: &str) -> TextResource {
+    let mut resource = empty_text(source);
+    resource.render_items = Arc::from([TextRenderItem::GlyphRun(0)]);
+    resource
+}
+
+#[test]
+fn repeated_invalid_text_insertions_do_not_consume_ids_or_accounting() {
+    let mut arena = TextResourceArena::new();
+
+    for iteration in 0..CHURN_ITERATIONS {
+        let source = format!("invalid-{iteration}");
+        assert_eq!(
+            arena.insert(invalid_text(&source)),
+            Err(TextResourceValidationError::InvalidRenderItem),
+        );
+        assert_eq!(arena.stats(), TextResourceStats::default());
+        assert!(arena.is_empty());
+    }
+
+    let first = arena
+        .insert(empty_text("valid"))
+        .expect("first valid resource must still receive the first identity");
+    assert_eq!(first.id.get(), 0);
+    assert_eq!(first.version, 0);
+}
+
+#[test]
+fn repeated_invalid_text_replacements_preserve_live_version_and_plateau() {
+    let mut arena = TextResourceArena::new();
+    let initial = arena
+        .insert(empty_text("stable"))
+        .expect("initial resource must be valid");
+    let baseline = arena.stats();
+
+    for iteration in 0..CHURN_ITERATIONS {
+        let source = format!("invalid-replacement-{iteration}");
+        assert_eq!(
+            arena.replace(initial.id, invalid_text(&source)),
+            Err(TextResourceError::InvalidResource(
+                TextResourceValidationError::InvalidRenderItem,
+            )),
+        );
+        assert_eq!(arena.stats(), baseline);
+        assert_eq!(arena.current_handle(initial.id), Some(initial));
+        assert_eq!(
+            arena
+                .get(initial)
+                .expect("failed replacement must retain prior resource")
+                .source
+                .as_ref(),
+            "stable",
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add a 1,000-cycle invalid `TextResource` insertion churn gate
- prove rejected admissions leave the arena empty, accounting at zero, and do not consume stable resource IDs
- add a 1,000-cycle invalid replacement churn gate
- prove failed validation preserves the live handle/version/source and exact resource-accounting plateau

## Why
#114 requires failed transactions/resource loads not to leak partially created resources. #460 now gates successful geometry/text/font churn, but failure paths were previously covered only by short unit cases rather than long-running deterministic plateau checks.

## Architecture
Test-only. This exercises the public `TextResourceArena` admission/replacement boundary rather than adding another lifecycle mechanism or test hook. Invalid render-item references are rejected before admission/mutation, and the regression verifies that atomicity remains true across sustained churn.

## Validation
Refreshed as one commit directly on current master after #476 fixed the cross-browser compatibility-bundle baseline. Exact head: `ef349a72`.

Green on the refreshed head:
- rustfmt, Clippy, full Rust workspace tests
- test coverage
- Manim API coverage and semantic differential
- Playground Chromium/Firefox/WebKit matrix
- WebGPU/WebGL rendering and reactive/editor browser lanes

The Manim raster job has passed environment setup, package build, retained Typst rendering/ratchets, and is running the canonical Manim corpus. Do not merge until that final required gate completes.

Tracks #114.