### PR TITLE
Stabilize Playground authoring recovery baseline

### DIFF
--- a/scripts/playground-authoring-error-recovery-smoke.mjs
+++ b/scripts/playground-authoring-error-recovery-smoke.mjs
@@ -192,6 +192,7 @@ try {
   diagnostics.browser = await browser.version();
   await page.goto(`${baseUrl}/web/index.html?example=parity-create-circle`, { waitUntil: "load" });
   await waitForInitialScene(page);
+  await waitForObjectCount(page, 1);
   page.on("framenavigated", (frame) => {
     if (frame === page.mainFrame()) diagnostics.unexpectedNavigations += 1;
   });


### PR DESCRIPTION
## Summary
- wait for the initial `parity-create-circle` object metric to converge before capturing the authoring-recovery baseline
- keep the existing syntax/runtime failure assertions unchanged

## Why
Fresh CI on #454 exposed a test-ordering race: the authoritative patch status already reported `1 objects`, while the asynchronously refreshed metrics pane still showed `0`. The syntax-error run correctly preserved the last good one-object scene, but the test compared it against that premature `0` snapshot and failed.

The recovery oracle should establish a complete successful baseline before injecting failure. This uses the existing `waitForObjectCount()` helper and does not weaken any failure/recovery invariant.

## Evidence
Failure diagnostics showed baseline `patchText = "Scene updated incrementally · CreateCircle · 1 objects"` with `objectCount = "0"`, followed by the syntax-error snapshot with `objectCount = "1"` and unchanged semantic sequence.

Related: #110, #454.