### PR TITLE
Carry glyph atlas page identity into GPU draws

### DIFF
--- a/crates/noon-render-wgpu/src/gpu/retained_text.rs
+++ b/crates/noon-render-wgpu/src/gpu/retained_text.rs
@@ -102,6 +102,7 @@ impl PreparedRetainedTextSnapshot<'_> {
 /// private so its renderer-internal scratch IDs cannot be mistaken for semantic IDs.
 pub struct PreparedRetainedGpuFrame<'a> {
     geometry: PreparedFrame<'a>,
+    text_generation: u64,
     pub text: PreparedRetainedTextSnapshot<'a>,
     pub render_items: &'a [RetainedRenderItem],
     pub stats: RetainedPrepareStats,
@@ -549,6 +550,7 @@ pub struct RetainedFramePreparer {
     snapshot_metrics: Option<TextDeviceMetrics>,
     prepared_generation_ready: bool,
     prepared_generation_reuses: u64,
+    text_generation: u64,
 }
 
 impl Default for RetainedFramePreparer {
@@ -578,6 +580,7 @@ impl Default for RetainedFramePreparer {
             snapshot_metrics: None,
             prepared_generation_ready: false,
             prepared_generation_reuses: 0,
+            text_generation: 0,
         }
     }
 }
@@ -677,6 +680,7 @@ impl RetainedFramePreparer {
             };
             return Ok(PreparedRetainedGpuFrame {
                 geometry,
+                text_generation: self.text_generation,
                 text,
                 render_items: &self.render_items,
                 stats: self.snapshot_prepare_stats,
@@ -705,6 +709,10 @@ impl RetainedFramePreparer {
             self.snapshot_text_items.extend_from_slice(prepared.items);
             self.snapshot_text_stats = prepared.stats;
         }
+        self.text_generation = self
+            .text_generation
+            .checked_add(1)
+            .expect("retained text generation counter exhausted");
 
         let geometry = if scratch_reused {
             let no_changes = FrameChanges::default();
@@ -748,6 +756,7 @@ impl RetainedFramePreparer {
         };
         Ok(PreparedRetainedGpuFrame {
             geometry,
+            text_generation: self.text_generation,
             text,
             render_items: &self.render_items,
             stats,
@@ -1323,6 +1332,7 @@ pub struct RetainedDrawStats {
 
 pub struct RetainedTextGpuState {
     glyphs: TextGlyphGpuRenderer,
+    last_uploaded_generation: Option<u64>,
 }
 
 impl RetainedTextGpuState {
@@ -1334,8 +1344,13 @@ impl RetainedTextGpuState {
     ) -> Self {
         Self {
             glyphs: TextGlyphGpuRenderer::new(device, queue, target_format, text_camera(camera)),
+            last_uploaded_generation: None,
         }
     }
+}
+
+fn text_upload_needed(last_uploaded_generation: Option<u64>, generation: u64) -> bool {
+    last_uploaded_generation != Some(generation)
 }
 
 impl GpuRenderer {
@@ -1358,10 +1373,20 @@ impl GpuRenderer {
         text_state
             .glyphs
             .set_camera(queue, text_camera(self.camera));
-        let text_frame = prepared.text.as_prepared_frame();
-        let text = text_state
-            .glyphs
-            .upload(device, queue, &text_frame, prepared.text.atlas);
+        let text = if text_upload_needed(
+            text_state.last_uploaded_generation,
+            prepared.text_generation,
+        ) {
+            let text_frame = prepared.text.as_prepared_frame();
+            let uploaded =
+                text_state
+                    .glyphs
+                    .upload(device, queue, &text_frame, prepared.text.atlas);
+            text_state.last_uploaded_generation = Some(prepared.text_generation);
+            uploaded
+        } else {
+            TextGpuUploadStats::default()
+        };
         RetainedUploadStats { geometry, text }
     }
 
@@ -1644,6 +1669,13 @@ mod tests {
     }
 
     #[test]
+    fn new_or_changed_text_generation_requires_gpu_upload() {
+        assert!(text_upload_needed(None, 1));
+        assert!(!text_upload_needed(Some(1), 1));
+        assert!(text_upload_needed(Some(1), 2));
+    }
+
+    #[test]
     fn unchanged_frame_reuses_semantic_scratch_generation() {
         let mut frame = RetainedFrameState {
             time: 0.0,
@@ -1665,6 +1697,7 @@ mod tests {
         let metrics = TextDeviceMetrics::uniform(100.0).unwrap();
         let (device, queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
         let mut preparer = RetainedFramePreparer::new();
+        let first_text_generation;
 
         {
             let prepared = preparer
@@ -1681,6 +1714,8 @@ mod tests {
                 .unwrap();
             assert_eq!(prepared.time(), 0.0);
             assert_eq!(prepared.geometry_stats().full_rebuilds, 1);
+            first_text_generation = prepared.text_generation;
+            assert_eq!(first_text_generation, 1);
         }
         assert_eq!(preparer.prepared_generation_reuses, 0);
         assert_eq!(
@@ -1707,6 +1742,7 @@ mod tests {
                 )
                 .unwrap();
             assert_eq!(prepared.time(), 1.0);
+            assert_eq!(prepared.text_generation, first_text_generation);
             let geometry_stats = prepared.geometry_stats();
             assert_eq!(geometry_stats.full_rebuilds, 0);
             assert_eq!(geometry_stats.instances_repacked, 0);
@@ -1747,7 +1783,7 @@ mod tests {
         let (device, queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
         let mut preparer = RetainedFramePreparer::new();
 
-        preparer
+        let first_generation = preparer
             .prepare_with_changes(
                 &device,
                 &queue,
@@ -1758,7 +1794,8 @@ mod tests {
                 &geometries,
                 first_metrics,
             )
-            .unwrap();
+            .unwrap()
+            .text_generation;
         frame.time = 1.0;
         let prepared = preparer
             .prepare_with_changes(
@@ -1775,6 +1812,7 @@ mod tests {
 
         assert_eq!(prepared.time(), 1.0);
         assert_eq!(prepared.geometry_stats().full_rebuilds, 0);
+        assert_ne!(prepared.text_generation, first_generation);
         assert_eq!(preparer.prepared_generation_reuses, 0);
     }
 

--- a/crates/noon-render-wgpu/src/gpu/retained_text.rs
+++ b/crates/noon-render-wgpu/src/gpu/retained_text.rs
@@ -545,6 +545,10 @@ pub struct RetainedFramePreparer {
     snapshot_color_quads: Vec<GlyphQuadInstance>,
     snapshot_text_items: Vec<PreparedTextItem>,
     snapshot_text_stats: RetainedTextPrepareStats,
+    snapshot_prepare_stats: RetainedPrepareStats,
+    snapshot_metrics: Option<TextDeviceMetrics>,
+    prepared_generation_ready: bool,
+    prepared_generation_reuses: u64,
 }
 
 impl Default for RetainedFramePreparer {
@@ -570,6 +574,10 @@ impl Default for RetainedFramePreparer {
             snapshot_color_quads: Vec::new(),
             snapshot_text_items: Vec::new(),
             snapshot_text_stats: RetainedTextPrepareStats::default(),
+            snapshot_prepare_stats: RetainedPrepareStats::default(),
+            snapshot_metrics: None,
+            prepared_generation_ready: false,
+            prepared_generation_reuses: 0,
         }
     }
 }
@@ -633,6 +641,53 @@ impl RetainedFramePreparer {
         let scratch_reused =
             self.prepare_scratch_with_changes(frame, changes, texts, fonts, geometries)?;
 
+        if scratch_reused
+            && self.prepared_generation_ready
+            && self.snapshot_metrics == Some(metrics)
+        {
+            // The child preparer is privately owned and this generation was recorded
+            // only after a complete successful parent preparation. Matching metrics
+            // and an empty semantic change set therefore select its O(1) reuse path.
+            // Invalidate the parent generation first so any future fallible change in
+            // that contract cannot expose stale snapshots.
+            self.prepared_generation_ready = false;
+            {
+                let prepared = self
+                    .text
+                    .prepare_with_changes(device, queue, frame, changes, texts, fonts, metrics)?;
+                debug_assert_eq!(prepared.mask_quads.len(), self.snapshot_mask_quads.len());
+                debug_assert_eq!(prepared.color_quads.len(), self.snapshot_color_quads.len());
+                debug_assert_eq!(prepared.items.len(), self.snapshot_text_items.len());
+                debug_assert_eq!(prepared.stats, self.snapshot_text_stats);
+            }
+
+            let no_changes = FrameChanges::default();
+            let geometry = self
+                .geometry
+                .prepare_incremental(&self.scratch, &no_changes);
+            self.prepared_generation_reuses = self.prepared_generation_reuses.saturating_add(1);
+            self.prepared_generation_ready = true;
+            let text = PreparedRetainedTextSnapshot {
+                time: frame.time,
+                mask_quads: &self.snapshot_mask_quads,
+                color_quads: &self.snapshot_color_quads,
+                items: &self.snapshot_text_items,
+                stats: self.snapshot_text_stats,
+                atlas: self.text.atlas(),
+            };
+            return Ok(PreparedRetainedGpuFrame {
+                geometry,
+                text,
+                render_items: &self.render_items,
+                stats: self.snapshot_prepare_stats,
+            });
+        }
+
+        // Snapshot and painter-order state is only reusable after a complete parent
+        // preparation. Clear validity before the fallible text step so errors cannot
+        // leave an older successful generation eligible for empty-frame reuse.
+        self.prepared_generation_ready = false;
+
         // #339/#341 intentionally keep the atlas inside the retained text preparer.
         // Snapshot the lightweight prepared records once so that borrow can end and
         // the atlas can be borrowed alongside them for the parent GPU renderer.
@@ -680,6 +735,9 @@ impl RetainedFramePreparer {
             outline_cache_hits: outline_cache.hits,
             outline_cache_misses: outline_cache.misses,
         };
+        self.snapshot_prepare_stats = stats;
+        self.snapshot_metrics = Some(metrics);
+        self.prepared_generation_ready = true;
         let text = PreparedRetainedTextSnapshot {
             time: frame.time,
             mask_quads: &self.snapshot_mask_quads,
@@ -1624,6 +1682,7 @@ mod tests {
             assert_eq!(prepared.time(), 0.0);
             assert_eq!(prepared.geometry_stats().full_rebuilds, 1);
         }
+        assert_eq!(preparer.prepared_generation_reuses, 0);
         assert_eq!(
             preparer.incremental_stats(),
             RetainedFrameIncrementalStats {
@@ -1653,6 +1712,7 @@ mod tests {
             assert_eq!(geometry_stats.instances_repacked, 0);
             assert_eq!(geometry_stats.dirty_instance_count, 0);
         }
+        assert_eq!(preparer.prepared_generation_reuses, 1);
         assert_eq!(
             preparer.incremental_stats(),
             RetainedFrameIncrementalStats {
@@ -1661,6 +1721,61 @@ mod tests {
             }
         );
         assert_eq!(preparer.outline_cache_stats(), outline_stats);
+    }
+
+    #[test]
+    fn metric_change_does_not_reuse_parent_generation() {
+        let mut frame = RetainedFrameState {
+            time: 0.0,
+            objects: vec![RetainedFrameObjectState {
+                id: ObjectId::new(1),
+                content: ObjectContentRef::Geometry(GeometryRef::circle(1.0)),
+                transform: Transform2D::default(),
+                style: Style::default(),
+                appearance: 1.0,
+            }],
+            presences: vec![true],
+            reveals: vec![1.0],
+            morphs: vec![0.0],
+            render_geometries: vec![None],
+        };
+        let texts = TextResourceArena::new();
+        let fonts = FontResourceArena::new();
+        let geometries = GeometryResourceArena::new();
+        let first_metrics = TextDeviceMetrics::uniform(100.0).unwrap();
+        let second_metrics = TextDeviceMetrics::uniform(200.0).unwrap();
+        let (device, queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
+        let mut preparer = RetainedFramePreparer::new();
+
+        preparer
+            .prepare_with_changes(
+                &device,
+                &queue,
+                &frame,
+                &FrameChanges::all(),
+                &texts,
+                &fonts,
+                &geometries,
+                first_metrics,
+            )
+            .unwrap();
+        frame.time = 1.0;
+        let prepared = preparer
+            .prepare_with_changes(
+                &device,
+                &queue,
+                &frame,
+                &FrameChanges::default(),
+                &texts,
+                &fonts,
+                &geometries,
+                second_metrics,
+            )
+            .unwrap();
+
+        assert_eq!(prepared.time(), 1.0);
+        assert_eq!(prepared.geometry_stats().full_rebuilds, 0);
+        assert_eq!(preparer.prepared_generation_reuses, 0);
     }
 
     #[test]

--- a/crates/noon-text-render-wgpu/src/gpu.rs
+++ b/crates/noon-text-render-wgpu/src/gpu.rs
@@ -130,6 +130,10 @@ impl std::ops::AddAssign for TextGpuDrawStats {
 pub enum TextGpuDrawError {
     UnsupportedSampleCount(u32),
     MissingAtlasPlane(GlyphAtlasPlane),
+    UnsupportedAtlasPage {
+        plane: GlyphAtlasPlane,
+        page: u32,
+    },
     InstanceRangeOutOfBounds {
         plane: GlyphAtlasPlane,
         end: u32,
@@ -146,6 +150,10 @@ impl std::fmt::Display for TextGpuDrawError {
             Self::MissingAtlasPlane(plane) => {
                 write!(formatter, "{plane:?} glyph atlas texture is not resident")
             }
+            Self::UnsupportedAtlasPage { plane, page } => write!(
+                formatter,
+                "{plane:?} glyph atlas page {page} is not supported by the current GPU binding model"
+            ),
             Self::InstanceRangeOutOfBounds {
                 plane,
                 end,
@@ -416,6 +424,7 @@ impl TextGlyphGpuRenderer {
     ) -> Result<TextGpuDrawStats, TextGpuDrawError> {
         let PreparedTextItem::GlyphBatch {
             plane,
+            page,
             instance_range,
             ..
         } = item
@@ -428,6 +437,7 @@ impl TextGlyphGpuRenderer {
         if instance_range.is_empty() {
             return Ok(TextGpuDrawStats::default());
         }
+        validate_atlas_page(*plane, *page)?;
 
         let (buffer, bind_group, available, pipeline) = match plane {
             GlyphAtlasPlane::Mask => (
@@ -500,6 +510,14 @@ impl TextGlyphGpuRenderer {
             (GlyphAtlasPlane::Color, TEXT_MSAA_SAMPLE_COUNT) => Ok(&self.color_pipeline_msaa),
             (_, count) => Err(TextGpuDrawError::UnsupportedSampleCount(count)),
         }
+    }
+}
+
+fn validate_atlas_page(plane: GlyphAtlasPlane, page: u32) -> Result<(), TextGpuDrawError> {
+    if page == 0 {
+        Ok(())
+    } else {
+        Err(TextGpuDrawError::UnsupportedAtlasPage { plane, page })
     }
 }
 
@@ -682,6 +700,7 @@ mod tests {
             text: text_handle(),
             run_index: 0,
             plane: GlyphAtlasPlane::Mask,
+            page: image.page,
             instance_range: 0..1,
         }];
         let prepared = prepared_mask_frame(&quads, &items);
@@ -773,6 +792,7 @@ mod tests {
             text: text_handle(),
             run_index: 0,
             plane: GlyphAtlasPlane::Mask,
+            page: image.page,
             instance_range: 0..1,
         }];
         let prepared = prepared_mask_frame(&quads, &items);
@@ -851,6 +871,18 @@ mod tests {
         };
         assert_eq!(stats.draw_calls, 0);
         assert_eq!(stats.deferred_items, 1);
+    }
+
+    #[test]
+    fn nonzero_atlas_page_is_rejected_before_draw() {
+        assert_eq!(validate_atlas_page(GlyphAtlasPlane::Mask, 0), Ok(()));
+        assert_eq!(
+            validate_atlas_page(GlyphAtlasPlane::Color, 3),
+            Err(TextGpuDrawError::UnsupportedAtlasPage {
+                plane: GlyphAtlasPlane::Color,
+                page: 3,
+            })
+        );
     }
 
     #[test]

--- a/crates/noon-text-render-wgpu/src/lib.rs
+++ b/crates/noon-text-render-wgpu/src/lib.rs
@@ -97,6 +97,7 @@ pub enum PreparedTextItem {
         text: TextResourceHandle,
         run_index: u32,
         plane: GlyphAtlasPlane,
+        page: u32,
         instance_range: Range<u32>,
     },
     Vector {
@@ -639,6 +640,7 @@ impl RetainedTextQuadPreparer {
                 text_handle,
                 run_index,
                 atlas_image.plane,
+                atlas_image.page,
                 instance_index,
             );
         }
@@ -651,6 +653,7 @@ impl RetainedTextQuadPreparer {
         text: TextResourceHandle,
         run_index: u32,
         plane: GlyphAtlasPlane,
+        page: u32,
         instance_index: usize,
     ) {
         let start = u32::try_from(instance_index).expect("text quad count exceeds u32 draw limits");
@@ -662,6 +665,7 @@ impl RetainedTextQuadPreparer {
             text: last_text,
             run_index: last_run,
             plane: last_plane,
+            page: last_page,
             instance_range,
         }) = self.items.last_mut()
         {
@@ -669,6 +673,7 @@ impl RetainedTextQuadPreparer {
                 && *last_text == text
                 && *last_run == run_index
                 && *last_plane == plane
+                && *last_page == page
                 && instance_range.end == start
             {
                 instance_range.end = end;
@@ -680,6 +685,7 @@ impl RetainedTextQuadPreparer {
             text,
             run_index,
             plane,
+            page,
             instance_range: start..end,
         });
     }


### PR DESCRIPTION
Superseded integration-wise by #562, which replays only the true two-file atlas-page child delta directly on current master after #558 merged. The stale retained-renderer parent history is intentionally excluded.

Please use #562 for review and integration. Tracks #363.