### PR TITLE
Carry Python compatibility bundle into browser matrix

### DIFF
--- a/.github/workflows/playground-cross-browser.yml
+++ b/.github/workflows/playground-cross-browser.yml
@@ -74,11 +74,13 @@ jobs:
           NOON_WASM_SKIP_OPT: "1"
         run: bash scripts/build-web-demo.sh
 
-      - name: Upload browser package
+      - name: Upload browser runtime assets
         uses: actions/upload-artifact@v4
         with:
-          name: playground-cross-browser-web-pkg
-          path: web/pkg
+          name: playground-cross-browser-web-runtime
+          path: |
+            web/pkg
+            web/python/compat-bundle.json
           if-no-files-found: error
           retention-days: 1
 
@@ -100,11 +102,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Download browser package
+      - name: Download browser runtime assets
         uses: actions/download-artifact@v4
         with:
-          name: playground-cross-browser-web-pkg
-          path: web/pkg
+          name: playground-cross-browser-web-runtime
+          path: web
 
       - name: Cache Playwright browser
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary
- upload the generated `web/python/compat-bundle.json` together with the WASM browser package
- restore both artifacts under `web/` in each cross-browser job
- keep one build as the source of truth for Chromium/Firefox/WebKit

## Why
The browser-package build now generates the Python compatibility bundle, but the cross-browser artifact only contained `web/pkg`. On a fresh browser runner Chromium therefore requested `/web/python/compat-bundle.json` and received 404, leaving the supported Playground runtime at `0 objects` until the E2E timed out. Firefox/WebKit did not exercise that same supported path.

The sound CI boundary is to transport all generated runtime assets from the single build job, not regenerate or silently fall back per browser.

## Evidence
Fresh #454 matrix diagnostics showed `GET /web/python/compat-bundle.json 404` immediately before Chromium stalled waiting for the authored scene.

Related: #416, #110, #454.