### PR TITLE
Add deterministic Playground playback controls

### DIFF
--- a/.github/workflows/playground-playback-controls.yml
+++ b/.github/workflows/playground-playback-controls.yml
@@ -1,0 +1,98 @@
+name: Playground playback controls
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/playground-playback-controls.yml"
+      - "crates/noon-render-wgpu/**"
+      - "crates/noon-web/**"
+      - "scripts/build-web-demo.sh"
+      - "scripts/playground-playback-controls-smoke.mjs"
+      - "web/**"
+  push:
+    branches:
+      - master
+    paths:
+      - ".github/workflows/playground-playback-controls.yml"
+      - "crates/noon-render-wgpu/**"
+      - "crates/noon-web/**"
+      - "scripts/build-web-demo.sh"
+      - "scripts/playground-playback-controls-smoke.mjs"
+      - "web/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: playground-playback-controls-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  playback-controls:
+    name: Public transport controls
+    runs-on: ubuntu-latest
+    env:
+      CARGO_INCREMENTAL: "0"
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use stable Rust
+        run: |
+          rustup default stable
+          rustup target add wasm32-unknown-unknown
+
+      - name: Cache Cargo sources
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-sources-${{ hashFiles('Cargo.toml', 'crates/**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-sources-
+
+      - name: Use sccache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+        with:
+          version: v0.16.0
+
+      - name: Install pinned wasm-pack
+        uses: taiki-e/install-action@13608cbb45b01feb47ef444ab1a42dc41ad56f1a # v2.79.11
+        with:
+          tool: wasm-pack@0.15.0
+          fallback: none
+
+      - name: Build browser package
+        env:
+          NOON_SKIP_PLAYGROUND_TEST: "1"
+          NOON_WASM_SKIP_OPT: "1"
+        run: bash scripts/build-web-demo.sh
+
+      - name: Cache Playwright Chromium
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-chromium-1.62.1
+
+      - name: Install Playwright Chromium
+        run: |
+          npm install --no-save --ignore-scripts playwright@1.62.1
+          npx playwright install chromium
+
+      - name: Test public playback controls
+        env:
+          NOON_PLAYGROUND_PLAYBACK_ARTIFACTS: browser-smoke-artifacts/playground-playback-controls
+        run: node scripts/playground-playback-controls-smoke.mjs
+
+      - name: Upload playback diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playground-playback-controls
+          path: browser-smoke-artifacts/playground-playback-controls
+          if-no-files-found: error
+          retention-days: 7

--- a/scripts/playground-playback-controls-smoke.mjs
+++ b/scripts/playground-playback-controls-smoke.mjs
@@ -1,0 +1,302 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import playwright from "playwright";
+
+const { chromium } = playwright;
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const port = Number(process.env.NOON_PLAYGROUND_PLAYBACK_PORT ?? "4184");
+const baseUrl = `http://127.0.0.1:${port}`;
+const artifactDir = path.resolve(
+  repoRoot,
+  process.env.NOON_PLAYGROUND_PLAYBACK_ARTIFACTS ??
+    "browser-smoke-artifacts/playground-playback-controls",
+);
+
+await mkdir(artifactDir, { recursive: true });
+
+let serverOutput = "";
+const server = spawn(
+  "python3",
+  ["-m", "http.server", String(port), "--bind", "127.0.0.1", "--directory", repoRoot],
+  { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] },
+);
+server.stdout.on("data", (chunk) => {
+  serverOutput += chunk;
+});
+server.stderr.on("data", (chunk) => {
+  serverOutput += chunk;
+});
+
+async function waitForServer() {
+  let lastError = null;
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    try {
+      const response = await fetch(`${baseUrl}/web/index.html`);
+      if (response.ok) return;
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Playground playback server did not start: ${lastError}\n${serverOutput}`);
+}
+
+function parseSeconds(text) {
+  const match = String(text).match(/([0-9]+(?:\.[0-9]+)?)\s*s/);
+  assert.ok(match, `unable to parse seconds from ${JSON.stringify(text)}`);
+  return Number(match[1]);
+}
+
+async function waitForAppliedScene(page, expectedExampleId, timeout = 60_000) {
+  await page.waitForFunction(
+    (id) => {
+      const patch = document.querySelector("#patch-status");
+      if (patch?.dataset.state === "error") return true;
+      return patch?.dataset.state === "applied" && patch?.dataset.exampleId === id;
+    },
+    expectedExampleId,
+    { timeout },
+  );
+  const snapshot = await page.evaluate(() => ({
+    state: document.querySelector("#patch-status")?.dataset.state ?? "",
+    text:
+      document.querySelector("#patch-status")?.value ??
+      document.querySelector("#patch-status")?.textContent ??
+      "",
+  }));
+  assert.equal(snapshot.state, "applied", `${expectedExampleId} failed: ${snapshot.text}`);
+}
+
+async function playbackSnapshot(page) {
+  return page.evaluate(() => {
+    const controls = document.querySelector(".playback-controls");
+    const play = document.querySelector(".playback-toggle");
+    const restart = [...document.querySelectorAll(".playback-button")].find(
+      (button) => button.textContent === "Restart",
+    );
+    const scrubber = document.querySelector(".playback-scrubber");
+    const time = document.querySelector(".playback-time");
+    const canvas = document.querySelector("#scene");
+    const status = document.querySelector("#status");
+    return {
+      hasControls: controls !== null,
+      playing: controls?.dataset.playing ?? null,
+      busy: controls?.dataset.busy ?? null,
+      playText: play?.textContent ?? "",
+      playDisabled: play?.disabled ?? true,
+      restartDisabled: restart?.disabled ?? true,
+      scrubberDisabled: scrubber?.disabled ?? true,
+      scrubberValue: scrubber?.value ?? null,
+      scrubberMax: scrubber?.max ?? null,
+      timeText: time?.value ?? time?.textContent ?? "",
+      metricTime:
+        document.querySelector("#metric-time")?.value ??
+        document.querySelector("#metric-time")?.textContent ??
+        "",
+      rendererBackend: status?.dataset.rendererBackend ?? null,
+      executionMode: status?.dataset.executionMode ?? null,
+      canvasIdentity: canvas?.dataset.playbackSmokeIdentity ?? null,
+      canvasCount: document.querySelectorAll("canvas").length,
+      documentWidth: document.documentElement.scrollWidth,
+      viewportWidth: window.innerWidth,
+    };
+  });
+}
+
+async function waitForMetricNear(page, target, tolerance = 0.08, timeout = 10_000) {
+  await page.waitForFunction(
+    ({ target, tolerance }) => {
+      const raw =
+        document.querySelector("#metric-time")?.value ??
+        document.querySelector("#metric-time")?.textContent ??
+        "";
+      const match = String(raw).match(/([0-9]+(?:\.[0-9]+)?)\s*s/);
+      return match !== null && Math.abs(Number(match[1]) - target) <= tolerance;
+    },
+    { target, tolerance },
+    { timeout },
+  );
+}
+
+async function waitForMetricAdvance(page, lowerBound, timeout = 10_000) {
+  await page.waitForFunction(
+    (minimum) => {
+      const raw =
+        document.querySelector("#metric-time")?.value ??
+        document.querySelector("#metric-time")?.textContent ??
+        "";
+      const match = String(raw).match(/([0-9]+(?:\.[0-9]+)?)\s*s/);
+      return match !== null && Number(match[1]) >= minimum;
+    },
+    lowerBound,
+    { timeout },
+  );
+}
+
+let browser = null;
+let page = null;
+const pageErrors = [];
+const consoleErrors = [];
+const diagnostics = {};
+
+try {
+  await waitForServer();
+  browser = await chromium.launch({
+    channel: "chromium",
+    headless: true,
+    args: [
+      "--disable-features=WebGPU",
+      "--enable-unsafe-swiftshader",
+      "--ignore-gpu-blocklist",
+      "--use-gl=angle",
+      "--use-angle=swiftshader",
+      "--disable-gpu-sandbox",
+      "--disable-dev-shm-usage",
+    ],
+  });
+  page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+  page.on("pageerror", (error) => pageErrors.push(String(error)));
+  page.on("console", (message) => {
+    if (message.type() === "error") consoleErrors.push(message.text());
+  });
+
+  await page.goto(`${baseUrl}/web/index.html?example=parity-square-and-circle`, {
+    waitUntil: "load",
+  });
+  await waitForAppliedScene(page, "parity-square-and-circle");
+  await page.waitForSelector(".playback-controls");
+  await page.evaluate(() => {
+    document.querySelector("#scene").dataset.playbackSmokeIdentity = "original";
+  });
+  await waitForMetricAdvance(page, 0.1);
+
+  const initial = await playbackSnapshot(page);
+  diagnostics.initial = initial;
+  assert.equal(initial.hasControls, true);
+  assert.equal(initial.playText, "Pause");
+  assert.equal(initial.playing, "true");
+  assert.equal(initial.playDisabled, false);
+  assert.equal(initial.restartDisabled, false);
+  assert.equal(initial.scrubberDisabled, false);
+  assert.equal(initial.canvasCount, 1);
+  assert.equal(initial.canvasIdentity, "original");
+  assert.ok(Number(initial.scrubberMax) > 0, "authored duration must be exposed to the scrubber");
+  assert.ok(initial.rendererBackend === "WebGL2" || initial.rendererBackend === "WebGPU");
+
+  await page.locator(".playback-toggle").click();
+  await page.waitForFunction(() => document.querySelector(".playback-toggle")?.textContent === "Play");
+  await new Promise((resolve) => setTimeout(resolve, 350));
+  const pausedA = await playbackSnapshot(page);
+  await new Promise((resolve) => setTimeout(resolve, 450));
+  const pausedB = await playbackSnapshot(page);
+  diagnostics.paused = { first: pausedA, second: pausedB };
+  assert.equal(pausedB.playing, "false");
+  assert.equal(pausedB.canvasIdentity, "original");
+  assert.equal(pausedB.rendererBackend, initial.rendererBackend);
+  assert.ok(
+    Math.abs(parseSeconds(pausedB.metricTime) - parseSeconds(pausedA.metricTime)) <= 0.02,
+    `pause did not freeze logical time: ${pausedA.metricTime} -> ${pausedB.metricTime}`,
+  );
+
+  const duration = Number(pausedB.scrubberMax);
+  const seekTarget = Math.min(duration * 0.6, Math.max(0.05, duration - 0.05));
+  await page.locator(".playback-scrubber").evaluate((input, target) => {
+    input.value = String(target);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  }, seekTarget);
+  await waitForMetricNear(page, seekTarget, 0.08);
+  const sought = await playbackSnapshot(page);
+  diagnostics.sought = sought;
+  assert.equal(sought.playing, "false", "seek must preserve paused state");
+  assert.equal(sought.canvasIdentity, "original", "seek must preserve the canvas");
+  assert.equal(sought.rendererBackend, initial.rendererBackend, "seek must preserve renderer backend");
+  assert.ok(Math.abs(parseSeconds(sought.metricTime) - seekTarget) <= 0.08);
+
+  const restartButton = page.getByRole("button", { name: "Restart animation from the beginning" });
+  await restartButton.click();
+  await waitForMetricNear(page, 0, 0.03);
+  const restarted = await playbackSnapshot(page);
+  diagnostics.restarted = restarted;
+  assert.equal(restarted.playing, "false", "playback restart must preserve paused state");
+  assert.equal(restarted.canvasIdentity, "original", "playback restart must not replace the canvas");
+  assert.equal(restarted.rendererBackend, initial.rendererBackend);
+  assert.ok(parseSeconds(restarted.metricTime) <= 0.03);
+
+  await page.locator(".playback-toggle").click();
+  await page.waitForFunction(() => document.querySelector(".playback-toggle")?.textContent === "Pause");
+  await waitForMetricAdvance(page, 0.12);
+  const resumed = await playbackSnapshot(page);
+  diagnostics.resumed = resumed;
+  assert.equal(resumed.playing, "true");
+  assert.equal(resumed.canvasIdentity, "original");
+  assert.equal(resumed.rendererBackend, initial.rendererBackend);
+  assert.ok(
+    parseSeconds(resumed.metricTime) < 0.8,
+    `resume caught up wall-clock time instead of re-anchoring: ${resumed.metricTime}`,
+  );
+
+  const targetExampleId = await page.evaluate(() => {
+    const selected = document.querySelector(".example-card[aria-selected='true']")?.dataset.exampleId;
+    return [...document.querySelectorAll(".example-card")]
+      .map((card) => card.dataset.exampleId)
+      .find((id) => id && id !== selected);
+  });
+  assert.ok(targetExampleId, "gallery must expose another example");
+  await page.locator(`.example-card[data-example-id="${targetExampleId}"]`).click();
+  await page.waitForFunction(() => document.querySelector(".playback-controls")?.dataset.busy === "true");
+  const busy = await playbackSnapshot(page);
+  diagnostics.busy = busy;
+  assert.equal(busy.playDisabled, true);
+  assert.equal(busy.restartDisabled, true);
+  assert.equal(busy.scrubberDisabled, true);
+  await waitForAppliedScene(page, targetExampleId);
+  await page.waitForFunction(() => document.querySelector(".playback-controls")?.dataset.busy === "false");
+  const switched = await playbackSnapshot(page);
+  diagnostics.switched = switched;
+  assert.equal(switched.canvasCount, 1);
+  assert.ok(Number(switched.scrubberMax) > 0);
+  assert.equal(switched.playDisabled, false);
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.evaluate(() => new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve))));
+  const mobile = await playbackSnapshot(page);
+  diagnostics.mobile = mobile;
+  assert.ok(
+    mobile.documentWidth <= mobile.viewportWidth + 1,
+    `playback controls overflow mobile viewport (${mobile.documentWidth}px > ${mobile.viewportWidth}px)`,
+  );
+  await page.locator(".playback-controls").screenshot({ path: path.join(artifactDir, "controls-mobile.png") });
+  await page.screenshot({ path: path.join(artifactDir, "playground.png"), fullPage: true });
+
+  assert.deepEqual(pageErrors, [], `page errors: ${pageErrors.join("\n")}`);
+  assert.deepEqual(consoleErrors, [], `console errors: ${consoleErrors.join("\n")}`);
+  diagnostics.pageErrors = pageErrors;
+  diagnostics.consoleErrors = consoleErrors;
+  await writeFile(path.join(artifactDir, "diagnostics.json"), `${JSON.stringify(diagnostics, null, 2)}\n`);
+  console.log("✓ public Playground play/pause/seek/restart controls are deterministic");
+} catch (error) {
+  if (page !== null) {
+    try {
+      await page.screenshot({ path: path.join(artifactDir, "failure.png"), fullPage: true });
+      diagnostics.failure = await playbackSnapshot(page);
+    } catch {
+      // Preserve the original failure.
+    }
+  }
+  diagnostics.pageErrors = pageErrors;
+  diagnostics.consoleErrors = consoleErrors;
+  diagnostics.error =
+    error instanceof Error ? { name: error.name, message: error.message, stack: error.stack } : String(error);
+  diagnostics.serverOutput = serverOutput;
+  await writeFile(path.join(artifactDir, "diagnostics.json"), `${JSON.stringify(diagnostics, null, 2)}\n`);
+  throw error;
+} finally {
+  if (browser !== null) await browser.close();
+  server.kill("SIGTERM");
+}

--- a/web/main.js
+++ b/web/main.js
@@ -1,6 +1,7 @@
 import { AuthoringExecutionClient } from "./authoring-execution-client.js";
 import { PythonAuthoringClient } from "./authoring-client.js";
 import { PlaygroundGeneration } from "./playground-generation.js";
+import { PlaygroundPlaybackControls } from "./playground-playback-controls.js";
 import { SceneIdentityMap } from "./scene-identity.js";
 import {
   exampleUrl,
@@ -279,6 +280,8 @@ const drafts = new Map();
 const sourceCache = new Map();
 const generations = new PlaygroundGeneration();
 let player = null;
+let playbackControls = null;
+let playbackDurationSeconds = 4.0;
 let rendererBackend = "";
 let sceneRunPromise = null;
 let playerNeedsRestart = false;
@@ -300,6 +303,7 @@ function setBusy(busy) {
   gallerySearch.disabled = busy;
   categorySelect.disabled = busy;
   paritySelect.disabled = busy;
+  playbackControls?.setBusy(busy);
   for (const card of galleryGrid.querySelectorAll(".example-card")) {
     card.disabled = busy;
   }
@@ -333,6 +337,12 @@ function showSceneError(error) {
 function showRecoverableSceneError(error) {
   console.warn("Recoverable Python callback error", error);
   patchStatus.value = `Python callback failed: ${error}`;
+  patchStatus.dataset.state = "error";
+}
+
+function showPlaybackError(error) {
+  console.error(error);
+  patchStatus.value = `Playback failed: ${error}`;
   patchStatus.dataset.state = "error";
 }
 
@@ -425,6 +435,12 @@ async function ensureExecutionReady() {
   rendererBackend = ready.render.backend;
   status.dataset.rendererBackend = rendererBackend;
   status.dataset.executionMode = player.mode;
+  const playbackState = await player.state();
+  playbackControls?.sync({
+    time: playbackState.time,
+    playing: playbackState.playing,
+    durationSeconds: playbackDurationSeconds,
+  });
 }
 
 async function runPlaygroundTestHook(name, payload) {
@@ -578,6 +594,15 @@ async function runScene() {
         loopDurationSeconds: authored.duration > 0 ? authored.duration : null,
       });
       if (!isCurrentRun(runToken)) return recordStale(runToken, "after-reconcile");
+
+      if (authored.duration > 0) {
+        playbackDurationSeconds = authored.duration;
+      }
+      playbackControls?.sync({
+        time: result.time,
+        playing: result.playing,
+        durationSeconds: playbackDurationSeconds,
+      });
 
       rendererBackend = player.rendererBackend;
       status.dataset.rendererBackend = rendererBackend;
@@ -748,6 +773,10 @@ try {
   status.dataset.rendererBackend = rendererBackend;
   status.dataset.executionMode = player.mode;
   status.dataset.executionTopology = "authoring-engine-render-workers";
+  playbackControls = new PlaygroundPlaybackControls(player, document.querySelector(".preview-pane"), {
+    durationSeconds: playbackDurationSeconds,
+    onError: showPlaybackError,
+  });
 
   const requested = requestedExampleId();
   const initialExample = SCENE_EXAMPLES.some((example) => example.id === requested)
@@ -759,6 +788,11 @@ try {
 
   const initialState = await player.state();
   patchStatus.dataset.sequence = String(initialState.nextPatchSequence);
+  playbackControls.sync({
+    time: initialState.time,
+    playing: initialState.playing,
+    durationSeconds: playbackDurationSeconds,
+  });
 
   window.__noonExampleGallery = {
     get selectedExampleId() {
@@ -789,6 +823,7 @@ try {
   window.addEventListener(
     "pagehide",
     () => {
+      playbackControls?.destroy();
       authoringClient?.terminate();
       player?.terminate();
     },
@@ -823,6 +858,7 @@ try {
       metricDraws.value = String(metrics.drawCalls);
       metricUpload.value = formatBytes(metrics.bytesUploaded);
       metricTime.value = `${metrics.time.toFixed(2)} s`;
+      playbackControls?.updateTime(metrics.time);
       status.dataset.instances = String(metrics.instancesDrawn);
       status.dataset.uploadBytes = String(metrics.bytesUploaded);
       status.dataset.geometryCacheMisses = String(metrics.geometryCacheMisses);

--- a/web/playground-playback-controls.js
+++ b/web/playground-playback-controls.js
@@ -179,7 +179,14 @@ export class PlaygroundPlaybackControls {
         const target = this.#desiredSeek;
         this.#desiredSeek = null;
         const result = await this.#player.seek(target);
-        this.sync(result);
+        if (this.#desiredSeek === null) {
+          this.sync(result);
+        } else if (typeof result.playing === "boolean") {
+          // Keep the latest user-selected playhead visible while an older seek
+          // completion is superseded by another queued direct seek.
+          this.#playing = result.playing;
+          this.#renderDisabled();
+        }
       }
     } catch (error) {
       this.#desiredSeek = null;
@@ -204,7 +211,6 @@ export class PlaygroundPlaybackControls {
       "aria-label",
       this.#playing ? "Pause animation" : "Play animation",
     );
-    this.#playButton.setAttribute("aria-pressed", String(!this.#playing));
     this.#scrubber.max = String(this.#durationSeconds);
     this.#renderTime();
     this.#renderDisabled();
@@ -227,6 +233,7 @@ export class PlaygroundPlaybackControls {
     this.#scrubber.disabled = this.#externalBusy || this.#commandPending;
     this.#root.dataset.busy = String(blockCommands);
     this.#root.dataset.playing = String(this.#playing);
+    this.#root.setAttribute("aria-busy", String(blockCommands));
   }
 }
 

--- a/web/playground-playback-controls.js
+++ b/web/playground-playback-controls.js
@@ -1,0 +1,332 @@
+const STYLE_ID = "noon-playground-playback-controls-style";
+
+export class PlaygroundPlaybackControls {
+  #player;
+  #onError;
+  #root;
+  #playButton;
+  #restartButton;
+  #scrubber;
+  #timeOutput;
+  #durationSeconds;
+  #timeSeconds = 0;
+  #playing = true;
+  #externalBusy = false;
+  #commandPending = false;
+  #seekActive = false;
+  #desiredSeek = null;
+  #destroyed = false;
+
+  constructor(
+    player,
+    previewPane,
+    { durationSeconds = 4, onError = null } = {},
+  ) {
+    validatePlayer(player);
+    if (!(previewPane instanceof HTMLElement)) {
+      throw new TypeError("playback controls require a preview HTMLElement");
+    }
+    if (onError !== null && typeof onError !== "function") {
+      throw new TypeError("playback controls onError must be a function");
+    }
+    this.#player = player;
+    this.#onError = onError;
+    this.#durationSeconds = validateDuration(durationSeconds);
+
+    installStyles();
+
+    this.#root = document.createElement("section");
+    this.#root.className = "playback-controls";
+    this.#root.setAttribute("aria-label", "Animation playback controls");
+
+    this.#playButton = document.createElement("button");
+    this.#playButton.type = "button";
+    this.#playButton.className = "playback-button playback-toggle";
+    this.#playButton.addEventListener("click", this.#handleToggle);
+
+    this.#restartButton = document.createElement("button");
+    this.#restartButton.type = "button";
+    this.#restartButton.className = "playback-button";
+    this.#restartButton.textContent = "Restart";
+    this.#restartButton.setAttribute("aria-label", "Restart animation from the beginning");
+    this.#restartButton.addEventListener("click", this.#handleRestart);
+
+    const timeline = document.createElement("label");
+    timeline.className = "playback-timeline";
+    const timelineLabel = document.createElement("span");
+    timelineLabel.className = "playback-label";
+    timelineLabel.textContent = "Timeline";
+
+    this.#scrubber = document.createElement("input");
+    this.#scrubber.type = "range";
+    this.#scrubber.className = "playback-scrubber";
+    this.#scrubber.min = "0";
+    this.#scrubber.step = "0.001";
+    this.#scrubber.setAttribute("aria-label", "Animation playhead");
+    this.#scrubber.addEventListener("input", this.#handleSeekInput);
+    timeline.append(timelineLabel, this.#scrubber);
+
+    this.#timeOutput = document.createElement("output");
+    this.#timeOutput.className = "playback-time";
+    this.#timeOutput.setAttribute("aria-live", "off");
+    this.#timeOutput.setAttribute("aria-label", "Animation time");
+
+    this.#root.append(this.#playButton, this.#restartButton, timeline, this.#timeOutput);
+    const metrics = previewPane.querySelector(".metrics");
+    if (metrics !== null) {
+      previewPane.insertBefore(this.#root, metrics);
+    } else {
+      previewPane.append(this.#root);
+    }
+    this.#render();
+  }
+
+  get element() {
+    return this.#root;
+  }
+
+  get durationSeconds() {
+    return this.#durationSeconds;
+  }
+
+  setDuration(durationSeconds) {
+    this.#durationSeconds = validateDuration(durationSeconds);
+    this.#timeSeconds = Math.min(this.#timeSeconds, this.#durationSeconds);
+    this.#render();
+  }
+
+  setBusy(busy) {
+    this.#externalBusy = Boolean(busy);
+    this.#renderDisabled();
+  }
+
+  sync({ time, playing, durationSeconds = undefined }) {
+    if (durationSeconds !== undefined) {
+      this.#durationSeconds = validateDuration(durationSeconds);
+    }
+    if (!Number.isFinite(time) || time < 0) {
+      throw new TypeError("playback state time must be finite and non-negative");
+    }
+    if (typeof playing !== "boolean") {
+      throw new TypeError("playback state playing must be boolean");
+    }
+    this.#timeSeconds = Math.min(time, this.#durationSeconds);
+    this.#playing = playing;
+    this.#render();
+  }
+
+  updateTime(time) {
+    if (!Number.isFinite(time) || time < 0 || this.#seekActive || this.#desiredSeek !== null) {
+      return;
+    }
+    this.#timeSeconds = Math.min(time, this.#durationSeconds);
+    this.#renderTime();
+  }
+
+  destroy() {
+    if (this.#destroyed) return;
+    this.#destroyed = true;
+    this.#playButton.removeEventListener("click", this.#handleToggle);
+    this.#restartButton.removeEventListener("click", this.#handleRestart);
+    this.#scrubber.removeEventListener("input", this.#handleSeekInput);
+    this.#root.remove();
+  }
+
+  #handleToggle = () => {
+    void this.#runCommand(async () => {
+      const result = this.#playing ? await this.#player.pause() : await this.#player.resume();
+      this.sync(result);
+    });
+  };
+
+  #handleRestart = () => {
+    void this.#runCommand(async () => {
+      const result = await this.#player.restartPlayback();
+      this.sync(result);
+    });
+  };
+
+  #handleSeekInput = () => {
+    if (this.#destroyed || this.#externalBusy || this.#commandPending) return;
+    const target = Number(this.#scrubber.value);
+    if (!Number.isFinite(target)) return;
+    this.#timeSeconds = Math.min(Math.max(target, 0), this.#durationSeconds);
+    this.#desiredSeek = this.#timeSeconds;
+    this.#renderTime();
+    void this.#drainSeek();
+  };
+
+  async #runCommand(operation) {
+    if (this.#destroyed || this.#externalBusy || this.#commandPending || this.#seekActive) return;
+    this.#commandPending = true;
+    this.#renderDisabled();
+    try {
+      await operation();
+    } catch (error) {
+      this.#reportError(error);
+    } finally {
+      this.#commandPending = false;
+      this.#renderDisabled();
+    }
+  }
+
+  async #drainSeek() {
+    if (this.#seekActive || this.#destroyed) return;
+    this.#seekActive = true;
+    this.#renderDisabled();
+    try {
+      while (!this.#destroyed && this.#desiredSeek !== null) {
+        const target = this.#desiredSeek;
+        this.#desiredSeek = null;
+        const result = await this.#player.seek(target);
+        this.sync(result);
+      }
+    } catch (error) {
+      this.#desiredSeek = null;
+      this.#reportError(error);
+    } finally {
+      this.#seekActive = false;
+      this.#renderDisabled();
+    }
+  }
+
+  #reportError(error) {
+    if (this.#onError !== null) {
+      this.#onError(error);
+      return;
+    }
+    console.error(error);
+  }
+
+  #render() {
+    this.#playButton.textContent = this.#playing ? "Pause" : "Play";
+    this.#playButton.setAttribute(
+      "aria-label",
+      this.#playing ? "Pause animation" : "Play animation",
+    );
+    this.#playButton.setAttribute("aria-pressed", String(!this.#playing));
+    this.#scrubber.max = String(this.#durationSeconds);
+    this.#renderTime();
+    this.#renderDisabled();
+  }
+
+  #renderTime() {
+    const clampedTime = Math.min(this.#timeSeconds, this.#durationSeconds);
+    this.#scrubber.value = String(clampedTime);
+    this.#scrubber.setAttribute(
+      "aria-valuetext",
+      `${formatTime(clampedTime)} of ${formatTime(this.#durationSeconds)}`,
+    );
+    this.#timeOutput.value = `${formatTime(clampedTime)} / ${formatTime(this.#durationSeconds)}`;
+  }
+
+  #renderDisabled() {
+    const blockCommands = this.#externalBusy || this.#commandPending || this.#seekActive;
+    this.#playButton.disabled = blockCommands;
+    this.#restartButton.disabled = blockCommands;
+    this.#scrubber.disabled = this.#externalBusy || this.#commandPending;
+    this.#root.dataset.busy = String(blockCommands);
+    this.#root.dataset.playing = String(this.#playing);
+  }
+}
+
+function installStyles() {
+  if (document.getElementById(STYLE_ID) !== null) return;
+  const style = document.createElement("style");
+  style.id = STYLE_ID;
+  style.textContent = `
+    .playback-controls {
+      display: grid;
+      grid-template-columns: auto auto minmax(8rem, 1fr) auto;
+      align-items: center;
+      gap: 0.55rem;
+      min-height: 3.15rem;
+      padding: 0.55rem 0.85rem;
+      border-top: 1px solid var(--border);
+      background: rgb(9 12 19 / 94%);
+    }
+    .playback-button {
+      appearance: none;
+      min-width: 4.5rem;
+      border: 1px solid var(--border-strong);
+      border-radius: 0.55rem;
+      padding: 0.42rem 0.6rem;
+      background: #171d2a;
+      color: #d9deeb;
+      cursor: pointer;
+      font-size: 0.72rem;
+      font-weight: 700;
+    }
+    .playback-button:hover:not(:disabled) { background: #20283a; }
+    .playback-button:focus-visible,
+    .playback-scrubber:focus-visible {
+      outline: 2px solid var(--accent-strong);
+      outline-offset: 2px;
+    }
+    .playback-timeline {
+      display: grid;
+      grid-template-columns: auto minmax(0, 1fr);
+      align-items: center;
+      gap: 0.5rem;
+      min-width: 0;
+    }
+    .playback-label {
+      color: var(--muted-2);
+      font-size: 0.66rem;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+    }
+    .playback-scrubber {
+      width: 100%;
+      min-width: 0;
+      accent-color: var(--accent);
+      cursor: pointer;
+    }
+    .playback-time {
+      min-width: 7.2rem;
+      color: #b9c3d6;
+      font: 0.7rem ui-monospace, SFMono-Regular, Menlo, monospace;
+      text-align: right;
+      white-space: nowrap;
+    }
+    .playback-controls button:disabled,
+    .playback-controls input:disabled {
+      cursor: wait;
+      opacity: 0.48;
+    }
+    @media (max-width: 44rem) {
+      .playback-controls {
+        grid-template-columns: 1fr 1fr;
+        gap: 0.45rem;
+        padding: 0.55rem;
+      }
+      .playback-button { width: 100%; }
+      .playback-timeline { grid-column: 1 / -1; }
+      .playback-time {
+        grid-column: 1 / -1;
+        min-width: 0;
+        text-align: center;
+      }
+    }
+  `;
+  document.head.append(style);
+}
+
+function formatTime(seconds) {
+  return `${seconds.toFixed(2)} s`;
+}
+
+function validateDuration(durationSeconds) {
+  if (!Number.isFinite(durationSeconds) || durationSeconds <= 0) {
+    throw new TypeError("playback duration must be positive and finite");
+  }
+  return durationSeconds;
+}
+
+function validatePlayer(player) {
+  for (const method of ["pause", "resume", "seek", "restartPlayback"]) {
+    if (typeof player?.[method] !== "function") {
+      throw new TypeError(`playback controls require player.${method}()`);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Completes the public UI tranche of #438 on top of merged runtime controls from #467/#454.

- add an accessible Play/Pause, Restart, timeline scrubber, and current-time/duration strip below the preview
- route all controls through `AuthoringExecutionClient`; no frontend-owned playback clock or worker/canvas restart
- coalesce rapid scrubber input into exact direct seeks rather than replaying intermediate frames
- reflect authoritative worker time through the Playground's existing metrics RAF
- disable transport controls during scene selection/authoring/reconciliation transitions
- resync control state after scene reconcile and runtime recovery
- keep authored scene duration aligned with the scrubber

## Validation

Adds a focused real-Playground Chromium smoke that verifies:

- pause freezes logical time
- exact seek while paused preserves paused state
- semantic restart returns to t=0 without replacing the canvas
- resume re-anchors without wall-clock catch-up
- seek/restart preserve renderer backend and canvas identity
- controls disable while scene transitions are busy and recover afterward
- mobile layout does not overflow
- no page or console errors

A dedicated `Playground playback controls` workflow runs this oracle on PRs and master. Existing CI/cross-browser workflows also run because this changes `web/**`.

Closes #438. Related #110.