### PR TITLE
Gate zero runtime work for 100k static scenes

### DIFF
--- a/crates/noon-runtime/tests/static_frame_locality.rs
+++ b/crates/noon-runtime/tests/static_frame_locality.rs
@@ -1,0 +1,25 @@
+use noon_compile::CompiledScene;
+use noon_core::{GeometryRef, SceneDefinition};
+use noon_runtime::{EvaluationStats, SceneInstance};
+
+const STATIC_OBJECTS: usize = 100_000;
+
+#[test]
+fn hundred_thousand_static_objects_do_zero_timeline_work_on_unchanged_frame() {
+    let mut scene = SceneDefinition::new();
+    for _ in 0..STATIC_OBJECTS {
+        scene.add(GeometryRef::circle(1.0));
+    }
+
+    let compiled = CompiledScene::compile(&scene).expect("static scene must compile");
+    let mut runtime = SceneInstance::new(compiled);
+    assert_eq!(runtime.frame().objects.len(), STATIC_OBJECTS);
+    assert!(runtime.take_frame_changes().is_all());
+
+    runtime
+        .advance_to(1.0)
+        .expect("finite forward time must evaluate");
+
+    assert_eq!(runtime.last_stats(), EvaluationStats::default());
+    assert!(runtime.take_frame_changes().is_empty());
+}


### PR DESCRIPTION
## Summary
- add a deterministic 100,000-object mostly-static runtime fixture
- consume the initial full snapshot, advance an unchanged frame, and require zero timeline groups evaluated, zero tracks advanced, and zero scheduler binary-search work through `EvaluationStats::default()`
- require the unchanged frame to publish no `FrameChanges`

## Why
#113 explicitly requires normal CI coverage for 100k mostly-static scenes and unchanged frames with zero semantic/runtime dirty work. The existing scheduler regression proves completed history is not rescanned for a 1,000-track sparse timeline, but it does not gate scene-size independence for a very large static object set.

## Architecture
Test-only. This uses the existing public `EvaluationStats` and `FrameChanges` contracts rather than adding timing thresholds, test hooks, or alternate instrumentation. The fixture deliberately contains no timeline work, so any future full-scene timeline scan or spurious dirty publication becomes a deterministic failure.

## Scope / parallelism
One new `noon-runtime` integration test file. It does not touch the active execution-slot implementation (#471), retained text/renderer stack (#442/#452/#475), worker recovery, or resource mutation lanes.

## Validation
One commit directly on current master. Normal workspace CI is the compile/format/Clippy/test authority; no wall-clock threshold is used.

Tracks #113 and #68.