### PR TITLE
Reject non-finite transform track snapshots

### DIFF
--- a/crates/noon-core/src/timeline.rs
+++ b/crates/noon-core/src/timeline.rs
@@ -1,8 +1,9 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    CompositionTimeMap, CompositionTimeMapError, ObjectId, ObjectSnapshot, SceneDefinition,
-    TrackId, Vec2,
+    patch::{validate_geometry, validate_style, validate_transform},
+    CompositionTimeMap, CompositionTimeMapError, ObjectId, ObjectSnapshot, ObjectStateField,
+    PatchError, SceneDefinition, TrackId, Vec2,
 };
 
 /// Language-neutral animation rate functions shared by every authoring frontend.
@@ -118,6 +119,21 @@ impl Property {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TrackValueEndpoint {
+    From,
+    To,
+}
+
+impl std::fmt::Display for TrackValueEndpoint {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            Self::From => "from",
+            Self::To => "to",
+        })
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum TrackValues {
@@ -149,7 +165,11 @@ impl TrackValues {
         }
     }
 
-    fn validate_numeric_values(&self, property: Property) -> Result<(), TimelineError> {
+    fn validate_numeric_values(
+        &self,
+        object: ObjectId,
+        property: Property,
+    ) -> Result<(), TimelineError> {
         match self {
             Self::Scalar { from, to } if !from.is_finite() || !to.is_finite() => {
                 Err(TimelineError::InvalidScalarValues {
@@ -170,8 +190,41 @@ impl TrackValues {
                     to: *to,
                 })
             }
+            Self::Object { from, to } => {
+                validate_object_track_value(object, property, TrackValueEndpoint::From, from)?;
+                validate_object_track_value(object, property, TrackValueEndpoint::To, to)
+            }
             _ => Ok(()),
         }
+    }
+}
+
+fn validate_object_track_value(
+    object: ObjectId,
+    property: Property,
+    endpoint: TrackValueEndpoint,
+    snapshot: &ObjectSnapshot,
+) -> Result<(), TimelineError> {
+    validate_geometry(object, &snapshot.geometry)
+        .map_err(|error| invalid_object_track_value(property, endpoint, error))?;
+    validate_transform(object, snapshot.transform)
+        .map_err(|error| invalid_object_track_value(property, endpoint, error))?;
+    validate_style(object, snapshot.style)
+        .map_err(|error| invalid_object_track_value(property, endpoint, error))
+}
+
+fn invalid_object_track_value(
+    property: Property,
+    endpoint: TrackValueEndpoint,
+    error: PatchError,
+) -> TimelineError {
+    let PatchError::InvalidObjectState { field, .. } = error else {
+        unreachable!("object-state validator returned a non-object validation error")
+    };
+    TimelineError::InvalidObjectValue {
+        property,
+        endpoint,
+        field,
     }
 }
 
@@ -231,6 +284,11 @@ pub enum TimelineError {
         from: Vec2,
         to: Vec2,
     },
+    InvalidObjectValue {
+        property: Property,
+        endpoint: TrackValueEndpoint,
+        field: ObjectStateField,
+    },
     InvalidCompositionTimeMap(CompositionTimeMapError),
     InstantTrackCannotUseTimeMap(Property),
     TrackIdExhausted,
@@ -262,6 +320,14 @@ impl std::fmt::Display for TimelineError {
                 formatter,
                 "non-finite vector values for {property:?}: from=({}, {}), to=({}, {})",
                 from.x, from.y, to.x, to.y
+            ),
+            Self::InvalidObjectValue {
+                property,
+                endpoint,
+                field,
+            } => write!(
+                formatter,
+                "non-finite {field} state in {endpoint} object value for {property:?}"
             ),
             Self::InvalidCompositionTimeMap(error) => error.fmt(formatter),
             Self::InstantTrackCannotUseTimeMap(property) => write!(
@@ -309,7 +375,9 @@ pub fn validate_track_definition(track: &TrackDefinition) -> Result<(), Timeline
             actual,
         });
     }
-    track.values.validate_numeric_values(track.property)?;
+    track
+        .values
+        .validate_numeric_values(track.object, track.property)?;
     if track.property.is_instant() && !track.time_map.is_identity() {
         return Err(TimelineError::InstantTrackCannotUseTimeMap(track.property));
     }
@@ -459,7 +527,7 @@ impl SceneDefinition {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{CompositionTimeMapStep, GeometryRef};
+    use crate::{CompositionTimeMapStep, GeometryRef, Style};
 
     fn timing() -> TrackTiming {
         TrackTiming::new(1.0, 2.0, RateFunction::Linear)
@@ -751,6 +819,53 @@ mod tests {
             scene
                 .animate_position(object, Vec2::ZERO, Vec2::ONE, timing())
                 .unwrap(),
+            TrackId::new(0)
+        );
+    }
+
+    #[test]
+    fn non_finite_transform_snapshots_are_rejected_without_consuming_track_ids() {
+        let mut scene = SceneDefinition::new();
+        let object = scene.add(GeometryRef::circle(1.0));
+        let valid = ObjectSnapshot::new(GeometryRef::circle(1.0));
+
+        let mut invalid_geometry = valid.clone();
+        invalid_geometry.geometry = GeometryRef::circle(f32::NAN);
+        let mut invalid_transform = valid.clone();
+        invalid_transform.transform.rotation = f32::INFINITY;
+        let mut invalid_style = valid.clone();
+        invalid_style.style = Style {
+            opacity: f32::NAN,
+            ..Style::default()
+        };
+
+        for (field, invalid) in [
+            (ObjectStateField::Geometry, invalid_geometry),
+            (ObjectStateField::Transform, invalid_transform),
+            (ObjectStateField::Style, invalid_style),
+        ] {
+            for (endpoint, from, to) in [
+                (TrackValueEndpoint::From, invalid.clone(), valid.clone()),
+                (TrackValueEndpoint::To, valid.clone(), invalid.clone()),
+            ] {
+                assert_eq!(
+                    scene
+                        .animate_transform(object, from, to, timing())
+                        .expect_err("non-finite transform endpoint must fail"),
+                    TimelineError::InvalidObjectValue {
+                        property: Property::Transform,
+                        endpoint,
+                        field,
+                    }
+                );
+            }
+        }
+
+        assert!(scene.tracks().is_empty());
+        assert_eq!(
+            scene
+                .animate_transform(object, valid.clone(), valid, timing())
+                .expect("finite transform track must remain valid"),
             TrackId::new(0)
         );
     }

--- a/crates/noon-core/tests/transform_track_validation.rs
+++ b/crates/noon-core/tests/transform_track_validation.rs
@@ -24,10 +24,12 @@ fn bulk_construction_rejects_non_finite_transform_track_snapshot() {
 
     assert!(matches!(
         SceneDefinition::from_parts(vec![object], vec![track]),
-        Err(PatchError::InvalidTrack(TimelineError::InvalidObjectValue {
-            property: Property::Transform,
-            endpoint: TrackValueEndpoint::To,
-            field: ObjectStateField::Style,
-        }))
+        Err(PatchError::InvalidTrack(
+            TimelineError::InvalidObjectValue {
+                property: Property::Transform,
+                endpoint: TrackValueEndpoint::To,
+                field: ObjectStateField::Style,
+            }
+        ))
     ));
 }

--- a/crates/noon-core/tests/transform_track_validation.rs
+++ b/crates/noon-core/tests/transform_track_validation.rs
@@ -1,0 +1,33 @@
+use noon_core::{
+    CompositionTimeMap, GeometryRef, ObjectDefinition, ObjectId, ObjectSnapshot, ObjectStateField,
+    PatchError, Property, RateFunction, SceneDefinition, Style, TimelineError, TrackDefinition,
+    TrackId, TrackTiming, TrackValueEndpoint, TrackValues,
+};
+
+#[test]
+fn bulk_construction_rejects_non_finite_transform_track_snapshot() {
+    let object = ObjectDefinition::new(ObjectId::new(7), GeometryRef::circle(1.0));
+    let from = ObjectSnapshot::new(GeometryRef::circle(1.0));
+    let mut to = from.clone();
+    to.style = Style {
+        opacity: f32::NAN,
+        ..Style::default()
+    };
+    let track = TrackDefinition {
+        id: TrackId::new(3),
+        object: object.id,
+        property: Property::Transform,
+        values: TrackValues::Object { from, to },
+        timing: TrackTiming::new(0.0, 1.0, RateFunction::Linear),
+        time_map: CompositionTimeMap::identity(),
+    };
+
+    assert!(matches!(
+        SceneDefinition::from_parts(vec![object], vec![track]),
+        Err(PatchError::InvalidTrack(TimelineError::InvalidObjectValue {
+            property: Property::Transform,
+            endpoint: TrackValueEndpoint::To,
+            field: ObjectStateField::Style,
+        }))
+    ));
+}


### PR DESCRIPTION
## Summary
- validate both `from` and `to` `ObjectSnapshot` endpoints on `Property::Transform` tracks
- reuse the existing core geometry/transform/style admission validators instead of duplicating finite-state traversal
- report the exact invalid endpoint and object-state field through `TimelineError`
- preserve track-ID/state atomicity when an invalid transform track is rejected
- gate the same invariant through transported `SceneDefinition::from_parts()` reconstruction

## Why
Scalar and position tracks already reject non-finite endpoints, and transported/current object state is protected by the patch admission validators. Full-object transform tracks were the remaining hole: a snapshot could carry NaN/Infinity in geometry, transform, or style and reach compiler/runtime interpolation despite the equivalent object state being rejected everywhere else.

That makes the timeline boundary inconsistent and can poison runtime geometry/style calculations after otherwise valid scene admission.

## Architecture
The fix keeps one finite-state authority. `timeline.rs` calls the existing internal `validate_geometry`, `validate_transform`, and `validate_style` helpers from the semantic patch layer, then translates only `ObjectStateField` into a timeline-specific `InvalidObjectValue { property, endpoint, field }` diagnostic. No second geometry walker or frontend validation path is introduced.

A repository-wide reference audit found no downstream exhaustive `TimelineError` match that needs synchronized changes; consumers wrap/propagate the error rather than duplicating its variant set.

## Tests
- focused core unit regression covers geometry, transform, and style failures at both `from` and `to` endpoints
- rejected authored tracks leave the track list empty and the next valid transform still receives `TrackId(0)`
- public-boundary integration regression proves `SceneDefinition::from_parts()` rejects the same invalid transported transform endpoint as `PatchError::InvalidTrack(...)`

The branch is directly on current master and changes only `crates/noon-core/src/timeline.rs` plus the focused integration test. Local cloning is unavailable in this runtime because outbound GitHub DNS is blocked, so exact-head Rust/workspace CI is the compile/test authority.

Related hardening: #105, #108.