### PR TITLE
Propagate uncaptured WebGPU errors to the host

### DIFF
--- a/.github/workflows/renderer-recovery.yml
+++ b/.github/workflows/renderer-recovery.yml
@@ -9,6 +9,8 @@ on:
       - "scripts/renderer-init-failure-smoke.mjs"
       - "scripts/renderer-webgl-context-loss-smoke.mjs"
       - "scripts/renderer-webgpu-device-loss-smoke.mjs"
+      - "scripts/renderer-webgpu-validation-error-smoke.mjs"
+      - "scripts/webgpu-device-capture.mjs"
       - "web/browser-smoke.html"
       - "web/browser-smoke.js"
   push:
@@ -21,6 +23,8 @@ on:
       - "scripts/renderer-init-failure-smoke.mjs"
       - "scripts/renderer-webgl-context-loss-smoke.mjs"
       - "scripts/renderer-webgpu-device-loss-smoke.mjs"
+      - "scripts/renderer-webgpu-validation-error-smoke.mjs"
+      - "scripts/webgpu-device-capture.mjs"
       - "web/browser-smoke.html"
       - "web/browser-smoke.js"
   workflow_dispatch:
@@ -104,6 +108,12 @@ jobs:
           NOON_RENDERER_DEVICE_LOSS_ARTIFACTS: browser-smoke-artifacts/renderer-device-loss
         run: node scripts/renderer-webgpu-device-loss-smoke.mjs
 
+      - name: Test WebGPU validation-error propagation
+        id: webgpu_validation_error
+        env:
+          NOON_RENDERER_VALIDATION_ERROR_ARTIFACTS: browser-smoke-artifacts/renderer-validation-error
+        run: node scripts/renderer-webgpu-validation-error-smoke.mjs
+
       - name: Upload renderer initialization diagnostics
         if: always()
         uses: actions/upload-artifact@v4
@@ -128,5 +138,14 @@ jobs:
         with:
           name: renderer-webgpu-device-loss
           path: browser-smoke-artifacts/renderer-device-loss
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Upload WebGPU validation-error diagnostics
+        if: always() && steps.webgpu_validation_error.outcome != 'skipped'
+        uses: actions/upload-artifact@v4
+        with:
+          name: renderer-webgpu-validation-error
+          path: browser-smoke-artifacts/renderer-validation-error
           if-no-files-found: error
           retention-days: 7

--- a/crates/noon-web/src/legacy.rs
+++ b/crates/noon-web/src/legacy.rs
@@ -422,7 +422,7 @@ mod wasm {
         rc::Rc,
         sync::{
             atomic::{AtomicU32, Ordering},
-            Arc,
+            Arc, Mutex,
         },
     };
 
@@ -441,6 +441,118 @@ mod wasm {
     const GPU_QUERY_BYTES: u64 = 16;
     const GPU_PROFILE_SLOT_COUNT: usize = 4;
     const GPU_PROFILE_SAMPLE_CAPACITY: usize = 512;
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    enum GpuUncapturedErrorKind {
+        Validation,
+        OutOfMemory,
+        Internal,
+    }
+
+    impl GpuUncapturedErrorKind {
+        const fn label(self) -> &'static str {
+            match self {
+                Self::Validation => "validation",
+                Self::OutOfMemory => "out-of-memory",
+                Self::Internal => "internal",
+            }
+        }
+
+        const fn is_fatal(self) -> bool {
+            !matches!(self, Self::Validation)
+        }
+    }
+
+    #[derive(Debug)]
+    struct GpuUncapturedError {
+        generation: u32,
+        kind: GpuUncapturedErrorKind,
+        message: String,
+    }
+
+    impl GpuUncapturedError {
+        fn from_wgpu(generation: u32, backend: wgpu::Backend, error: wgpu::Error) -> Self {
+            let kind = match &error {
+                wgpu::Error::Validation { .. } => GpuUncapturedErrorKind::Validation,
+                wgpu::Error::OutOfMemory { .. } => GpuUncapturedErrorKind::OutOfMemory,
+                wgpu::Error::Internal { .. } => GpuUncapturedErrorKind::Internal,
+            };
+            let backend = match backend {
+                wgpu::Backend::BrowserWebGpu => "WebGPU",
+                wgpu::Backend::Gl => "WebGL2",
+                _ => "GPU",
+            };
+            Self {
+                generation,
+                kind,
+                message: format!(
+                    "{backend} generation {generation} {} error: {error}",
+                    kind.label()
+                ),
+            }
+        }
+    }
+
+    #[derive(Clone, Default)]
+    struct GpuDeviceSignals {
+        lost_generation: Arc<AtomicU32>,
+        uncaptured_error: Arc<Mutex<Option<GpuUncapturedError>>>,
+    }
+
+    impl GpuDeviceSignals {
+        fn lost_generation(&self) -> u32 {
+            self.lost_generation.load(Ordering::Acquire)
+        }
+
+        fn mark_lost(&self, generation: u32) {
+            self.lost_generation.fetch_max(generation, Ordering::AcqRel);
+        }
+
+        fn report_uncaptured_error(
+            &self,
+            generation: u32,
+            backend: wgpu::Backend,
+            error: wgpu::Error,
+        ) {
+            let captured = GpuUncapturedError::from_wgpu(generation, backend, error);
+            self.with_error_slot(|pending| {
+                let replace = match pending.as_ref() {
+                    None => true,
+                    Some(current) if current.generation < generation => true,
+                    Some(current) if current.generation > generation => false,
+                    Some(current) => !current.kind.is_fatal() && captured.kind.is_fatal(),
+                };
+                if replace {
+                    *pending = Some(captured);
+                }
+            });
+        }
+
+        fn take_uncaptured_error(&self, generation: u32) -> Option<GpuUncapturedError> {
+            self.with_error_slot(|pending| {
+                let pending_generation = pending.as_ref().map(|error| error.generation);
+                match pending_generation {
+                    Some(current) if current < generation => {
+                        pending.take();
+                        None
+                    }
+                    Some(current) if current == generation => pending.take(),
+                    _ => None,
+                }
+            })
+        }
+
+        fn with_error_slot<R>(
+            &self,
+            operation: impl FnOnce(&mut Option<GpuUncapturedError>) -> R,
+        ) -> R {
+            let mut pending = match self.uncaptured_error.lock() {
+                Ok(pending) => pending,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            operation(&mut pending)
+        }
+    }
 
     #[derive(Debug)]
     struct WebDisplaySource;
@@ -722,7 +834,7 @@ mod wasm {
             adapter: wgpu::Adapter,
             format: wgpu::TextureFormat,
             generation: u32,
-            lost_generation: Arc<AtomicU32>,
+            gpu_signals: GpuDeviceSignals,
             profiling_enabled: bool,
         ) -> Result<Self, JsValue> {
             let backend = adapter.get_info().backend;
@@ -748,14 +860,20 @@ mod wasm {
                 .await
                 .map_err(js_error)?;
             device.set_device_lost_callback({
-                let lost_generation = Arc::clone(&lost_generation);
+                let gpu_signals = gpu_signals.clone();
                 move |_reason, _message| {
                     // Device-lost callbacks can arrive after a replacement
                     // generation is already active. Never let an older
                     // callback overwrite a newer loss marker.
-                    lost_generation.fetch_max(generation, Ordering::AcqRel);
+                    gpu_signals.mark_lost(generation);
                 }
             });
+            device.on_uncaptured_error(Arc::new({
+                let gpu_signals = gpu_signals.clone();
+                move |error| {
+                    gpu_signals.report_uncaptured_error(generation, backend, error);
+                }
+            }));
 
             let renderer = GpuRenderer::new(&device, format);
             let mut gpu_profiler =
@@ -784,7 +902,7 @@ mod wasm {
         async fn create(
             format: wgpu::TextureFormat,
             generation: u32,
-            lost_generation: Arc<AtomicU32>,
+            gpu_signals: GpuDeviceSignals,
             profiling_enabled: bool,
         ) -> Result<Self, JsValue> {
             // WebGPU adapters are one-shot after successful device creation.
@@ -808,7 +926,7 @@ mod wasm {
                 adapter,
                 format,
                 generation,
-                lost_generation,
+                gpu_signals,
                 profiling_enabled,
             )
             .await?;
@@ -833,7 +951,7 @@ mod wasm {
             canvas: &HtmlCanvasElement,
             backends: wgpu::Backends,
             generation: u32,
-            lost_generation: Arc<AtomicU32>,
+            gpu_signals: GpuDeviceSignals,
             profiling_enabled: bool,
         ) -> Result<Self, JsValue> {
             let mut instance_descriptor = wgpu::InstanceDescriptor::new_without_display_handle();
@@ -860,7 +978,7 @@ mod wasm {
                 adapter,
                 config.format,
                 generation,
-                lost_generation,
+                gpu_signals,
                 profiling_enabled,
             )
             .await?;
@@ -1024,7 +1142,8 @@ mod wasm {
         gpu_profiling_requested: bool,
         gpu_generation: u32,
         gpu_generation_counter: u32,
-        gpu_device_lost_generation: Arc<AtomicU32>,
+        gpu_signals: GpuDeviceSignals,
+        gpu_fatal_error: Option<String>,
         gpu_recovery_phase: GpuRecoveryPhase,
         gpu_recovery_completion: Rc<RefCell<Option<GpuRecoveryCompletion>>>,
         webgl_context_recovery: Option<WebGlContextRecovery>,
@@ -1042,12 +1161,12 @@ mod wasm {
             let player = ScenePlayer::from_scene_json(scene_json).map_err(js_error)?;
             let clock = PlaybackClock::looping(loop_duration_seconds).map_err(js_error)?;
             let gpu_generation = 1;
-            let gpu_device_lost_generation = Arc::new(AtomicU32::new(0));
+            let gpu_signals = GpuDeviceSignals::default();
             let runtime = BrowserGpuRuntime::create(
                 &canvas,
                 wgpu::Backends::BROWSER_WEBGPU | wgpu::Backends::GL,
                 gpu_generation,
-                Arc::clone(&gpu_device_lost_generation),
+                gpu_signals.clone(),
                 false,
             )
             .await?;
@@ -1105,7 +1224,8 @@ mod wasm {
                 gpu_profiling_requested: false,
                 gpu_generation,
                 gpu_generation_counter: gpu_generation,
-                gpu_device_lost_generation,
+                gpu_signals,
+                gpu_fatal_error: None,
                 gpu_recovery_phase: GpuRecoveryPhase::Ready,
                 gpu_recovery_completion: Rc::new(RefCell::new(None)),
                 webgl_context_recovery,
@@ -1149,12 +1269,14 @@ mod wasm {
 
         #[wasm_bindgen(js_name = renderFrame)]
         pub fn render_frame(&mut self, timestamp_ms: f64) -> Result<bool, JsValue> {
+            self.check_gpu_error()?;
             let frame_started_ms = performance_now_ms();
             let scene_time = self.clock.scene_time(timestamp_ms).map_err(js_error)?;
             let runtime_started_ms = performance_now_ms();
             self.player.advance_to(scene_time).map_err(js_error)?;
             self.last_runtime_evaluation_ms = elapsed_ms(runtime_started_ms);
             let presented = self.render_current_frame()?;
+            self.check_gpu_error()?;
             self.last_cpu_frame_ms = elapsed_ms(frame_started_ms);
             Ok(presented)
         }
@@ -1341,11 +1463,24 @@ mod wasm {
                 .map(|recovery| (recovery.is_lost(), recovery.generation()))
         }
 
+        fn check_gpu_error(&mut self) -> Result<(), JsValue> {
+            if let Some(message) = &self.gpu_fatal_error {
+                return Err(js_message(message));
+            }
+            let Some(error) = self.gpu_signals.take_uncaptured_error(self.gpu_generation) else {
+                return Ok(());
+            };
+            if error.kind.is_fatal() {
+                self.gpu_fatal_error = Some(error.message.clone());
+            }
+            Err(js_message(&error.message))
+        }
+
         fn gpu_commands_ready(&self) -> bool {
             if !matches!(self.gpu_recovery_phase, GpuRecoveryPhase::Ready) {
                 return false;
             }
-            if self.gpu_device_lost_generation.load(Ordering::Acquire) == self.gpu_generation {
+            if self.gpu_signals.lost_generation() == self.gpu_generation {
                 return false;
             }
             if let Some((lost, generation)) = self.current_webgl_context() {
@@ -1419,7 +1554,7 @@ mod wasm {
                 .ok_or_else(|| js_message("GPU recovery generation counter exhausted"))?;
             self.gpu_generation_counter = generation;
             let completion = Rc::clone(&self.gpu_recovery_completion);
-            let lost_generation = Arc::clone(&self.gpu_device_lost_generation);
+            let gpu_signals = self.gpu_signals.clone();
             let profiling_enabled = self.gpu_profiling_requested;
             let backend = self.backend;
             self.gpu_recovery_phase = GpuRecoveryPhase::Recovering {
@@ -1434,7 +1569,7 @@ mod wasm {
                         let runtime = BrowserWebGpuRecoveryRuntime::create(
                             format,
                             generation,
-                            lost_generation,
+                            gpu_signals,
                             profiling_enabled,
                         )
                         .await
@@ -1459,7 +1594,7 @@ mod wasm {
                             &canvas,
                             wgpu::Backends::GL,
                             generation,
-                            lost_generation,
+                            gpu_signals,
                             profiling_enabled,
                         )
                         .await
@@ -1609,9 +1744,7 @@ mod wasm {
 
             match completion.runtime {
                 Ok(runtime) => {
-                    if self.gpu_device_lost_generation.load(Ordering::Acquire)
-                        == completion.generation
-                    {
+                    if self.gpu_signals.lost_generation() == completion.generation {
                         self.gpu_recovery_phase = GpuRecoveryPhase::Ready;
                         self.start_gpu_recovery(completion.context_generation)?;
                         return Ok(false);
@@ -1649,7 +1782,7 @@ mod wasm {
                     return Ok(false);
                 }
             }
-            if self.gpu_device_lost_generation.load(Ordering::Acquire) == self.gpu_generation
+            if self.gpu_signals.lost_generation() == self.gpu_generation
                 && matches!(self.gpu_recovery_phase, GpuRecoveryPhase::Ready)
             {
                 self.start_gpu_recovery(
@@ -1676,8 +1809,7 @@ mod wasm {
                         return Ok(false);
                     }
                     wgpu::CurrentSurfaceTexture::Lost => {
-                        let device_lost = self.gpu_device_lost_generation.load(Ordering::Acquire)
-                            == self.gpu_generation;
+                        let device_lost = self.gpu_signals.lost_generation() == self.gpu_generation;
                         if self.backend == wgpu::Backend::Gl || device_lost {
                             let context_generation = self
                                 .current_webgl_context()
@@ -1694,9 +1826,7 @@ mod wasm {
                         return Ok(false);
                     }
                     wgpu::CurrentSurfaceTexture::Validation => {
-                        if self.gpu_device_lost_generation.load(Ordering::Acquire)
-                            == self.gpu_generation
-                        {
+                        if self.gpu_signals.lost_generation() == self.gpu_generation {
                             self.start_gpu_recovery(
                                 self.current_webgl_context()
                                     .map(|(_, generation)| generation),

--- a/scripts/renderer-webgpu-device-loss-smoke.mjs
+++ b/scripts/renderer-webgpu-device-loss-smoke.mjs
@@ -7,6 +7,8 @@ import { fileURLToPath } from "node:url";
 import playwright from "playwright";
 import pngjs from "pngjs";
 
+import { installWebGpuDeviceCapture, readWebGpuCapture } from "./webgpu-device-capture.mjs";
+
 const { chromium } = playwright;
 const { PNG } = pngjs;
 
@@ -59,56 +61,6 @@ function collectBrowserErrors(page) {
     if (message.type() === "error") consoleErrors.push(message.text());
   });
   return { pageErrors, consoleErrors };
-}
-
-async function installDeviceCapture(page) {
-  await page.addInitScript(() => {
-    const state = {
-      patched: false,
-      patchError: null,
-      devices: [],
-      lost: [],
-    };
-    window.__noonWebGpuDeviceCapture = state;
-
-    try {
-      const gpu = navigator.gpu;
-      if (!gpu || typeof gpu.requestAdapter !== "function") {
-        state.patchError = "navigator.gpu.requestAdapter is unavailable";
-        return;
-      }
-      const originalRequestAdapter = gpu.requestAdapter.bind(gpu);
-      Object.defineProperty(gpu, "requestAdapter", {
-        configurable: true,
-        value: async (...adapterArgs) => {
-          const adapter = await originalRequestAdapter(...adapterArgs);
-          if (!adapter) return adapter;
-
-          const originalRequestDevice = adapter.requestDevice.bind(adapter);
-          Object.defineProperty(adapter, "requestDevice", {
-            configurable: true,
-            value: async (...deviceArgs) => {
-              const device = await originalRequestDevice(...deviceArgs);
-              const index = state.devices.length;
-              state.devices.push(device);
-              state.lost.push(null);
-              device.lost.then((info) => {
-                state.lost[index] = {
-                  reason: String(info.reason ?? "unknown"),
-                  message: String(info.message ?? ""),
-                };
-              });
-              return device;
-            },
-          });
-          return adapter;
-        },
-      });
-      state.patched = true;
-    } catch (error) {
-      state.patchError = String(error);
-    }
-  });
 }
 
 async function waitForHarness(page) {
@@ -279,14 +231,9 @@ try {
 
   const page = await browser.newPage({ viewport: { width: 1000, height: 600 } });
   const browserErrors = collectBrowserErrors(page);
-  await installDeviceCapture(page);
+  await installWebGpuDeviceCapture(page);
   const initial = await waitForHarness(page);
-  const captureBefore = await page.evaluate(() => ({
-    patched: window.__noonWebGpuDeviceCapture?.patched ?? false,
-    patchError: window.__noonWebGpuDeviceCapture?.patchError ?? null,
-    deviceCount: window.__noonWebGpuDeviceCapture?.devices.length ?? 0,
-    lost: window.__noonWebGpuDeviceCapture?.lost ?? [],
-  }));
+  const captureBefore = await readWebGpuCapture(page);
   assert.equal(captureBefore.patched, true, `WebGPU capture patch failed: ${captureBefore.patchError}`);
   assert.ok(captureBefore.deviceCount >= 1, "Noon's WebGPU device creation was not captured");
 

--- a/scripts/renderer-webgpu-validation-error-smoke.mjs
+++ b/scripts/renderer-webgpu-validation-error-smoke.mjs
@@ -1,0 +1,245 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import playwright from "playwright";
+import pngjs from "pngjs";
+
+import { installWebGpuDeviceCapture, readWebGpuCapture } from "./webgpu-device-capture.mjs";
+
+const { chromium } = playwright;
+const { PNG } = pngjs;
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const port = Number(process.env.NOON_RENDERER_VALIDATION_ERROR_PORT ?? "4194");
+const baseUrl = `http://127.0.0.1:${port}`;
+const artifactDir = path.resolve(
+  repoRoot,
+  process.env.NOON_RENDERER_VALIDATION_ERROR_ARTIFACTS ??
+    "browser-smoke-artifacts/renderer-validation-error",
+);
+const sampleTime = 0.75;
+
+await mkdir(artifactDir, { recursive: true });
+
+let serverOutput = "";
+const server = spawn(
+  "python3",
+  ["-m", "http.server", String(port), "--bind", "127.0.0.1", "--directory", repoRoot],
+  { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] },
+);
+server.stdout.on("data", (chunk) => {
+  serverOutput += chunk;
+});
+server.stderr.on("data", (chunk) => {
+  serverOutput += chunk;
+});
+
+async function waitForServer() {
+  let lastError = null;
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    try {
+      const response = await fetch(`${baseUrl}/web/browser-smoke.html`);
+      if (response.ok) return;
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Renderer validation-error server did not start: ${lastError}\n${serverOutput}`);
+}
+
+function collectBrowserErrors(page) {
+  const pageErrors = [];
+  const consoleErrors = [];
+  page.on("pageerror", (error) => pageErrors.push(String(error)));
+  page.on("console", (message) => {
+    if (message.type() === "error") consoleErrors.push(message.text());
+  });
+  return { pageErrors, consoleErrors };
+}
+
+async function waitForHarness(page) {
+  await page.goto(`${baseUrl}/web/browser-smoke.html`, { waitUntil: "load" });
+  await page.waitForFunction(() => window.noonSmoke?.state.ready === true, null, {
+    timeout: 30_000,
+  });
+  const metrics = await page.evaluate(() => window.noonSmoke.metrics());
+  assert.equal(metrics.error, null, `renderer failed to initialize: ${metrics.error}`);
+  assert.equal(metrics.rendererBackend, "WebGPU", `expected WebGPU, got ${metrics.rendererBackend}`);
+  return metrics;
+}
+
+async function renderAndCapture(page, name) {
+  const metrics = await page.evaluate((time) => window.noonSmoke.renderAt(time), sampleTime);
+  assert.equal(metrics.error, null, `${name}: renderer reported an error`);
+  assert.equal(metrics.rendererBackend, "WebGPU", `${name}: backend changed unexpectedly`);
+  assert.equal(metrics.presented, true, `${name}: frame was not presented`);
+  assert.ok(metrics.drawCalls > 0, `${name}: frame emitted no draw calls`);
+  const screenshot = await page.locator("#scene").screenshot({
+    path: path.join(artifactDir, `${name}.png`),
+  });
+  return { metrics, screenshot };
+}
+
+async function triggerValidationError(page) {
+  await page.evaluate(() => {
+    const device = window.__noonWebGpuDeviceCapture?.devices[0];
+    if (!device) throw new Error("captured Noon GPUDevice is unavailable");
+    // WebGPU requires a non-zero usage bitmask. The browser must generate a
+    // GPUValidationError for this real device operation without losing the device.
+    device.createBuffer({ size: 4, usage: 0 });
+  });
+}
+
+async function waitForHostGpuError(page) {
+  let lastSuccess = null;
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    const result = await page.evaluate(async (time) => {
+      try {
+        return { ok: true, metrics: await window.noonSmoke.renderAt(time) };
+      } catch (error) {
+        return { ok: false, error: String(error) };
+      }
+    }, sampleTime);
+    if (!result.ok) return result.error;
+    lastSuccess = result.metrics;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(
+    `uncaptured WebGPU validation error never reached renderFrame; last metrics=${JSON.stringify(lastSuccess)}`,
+  );
+}
+
+function changedPixelCount(leftBuffer, rightBuffer) {
+  const left = PNG.sync.read(leftBuffer);
+  const right = PNG.sync.read(rightBuffer);
+  assert.equal(left.width, right.width, "validation comparison width mismatch");
+  assert.equal(left.height, right.height, "validation comparison height mismatch");
+  let changed = 0;
+  for (let offset = 0; offset < left.data.length; offset += 4) {
+    if (
+      left.data[offset] !== right.data[offset] ||
+      left.data[offset + 1] !== right.data[offset + 1] ||
+      left.data[offset + 2] !== right.data[offset + 2] ||
+      left.data[offset + 3] !== right.data[offset + 3]
+    ) {
+      changed += 1;
+    }
+  }
+  return changed;
+}
+
+async function writeDiagnostics(name, value) {
+  await writeFile(
+    path.join(artifactDir, `${name}.json`),
+    `${JSON.stringify(value, null, 2)}\n`,
+    "utf8",
+  );
+}
+
+let browser = null;
+try {
+  await waitForServer();
+  browser = await chromium.launch({
+    channel: "chromium",
+    headless: true,
+    args: [
+      "--enable-unsafe-webgpu",
+      "--enable-unsafe-swiftshader",
+      "--use-webgpu-adapter=swiftshader",
+      "--use-gpu-in-tests",
+      "--ignore-gpu-blocklist",
+      "--enable-features=Vulkan",
+      "--use-gl=angle",
+      "--use-angle=swiftshader",
+      "--use-vulkan=swiftshader",
+      "--disable-gpu-sandbox",
+      "--disable-dev-shm-usage",
+    ],
+  });
+
+  const page = await browser.newPage({ viewport: { width: 1000, height: 600 } });
+  const browserErrors = collectBrowserErrors(page);
+  await installWebGpuDeviceCapture(page);
+  const initial = await waitForHarness(page);
+  const captureBefore = await readWebGpuCapture(page);
+  assert.equal(captureBefore.patched, true, `WebGPU capture patch failed: ${captureBefore.patchError}`);
+  assert.equal(captureBefore.deviceCount, 1, "expected one initial Noon GPUDevice");
+
+  const baseline = await renderAndCapture(page, "baseline");
+  await triggerValidationError(page);
+  const hostError = await waitForHostGpuError(page);
+  assert.match(
+    hostError,
+    /WebGPU generation 1 validation error:/,
+    `host GPU error lacks backend/generation context: ${hostError}`,
+  );
+
+  const afterErrorMetrics = await page.evaluate(() => window.noonSmoke.metrics());
+  assert.equal(afterErrorMetrics.revision, baseline.metrics.revision, "GPU validation error reset scene revision");
+  assert.equal(
+    afterErrorMetrics.objectCount,
+    baseline.metrics.objectCount,
+    "GPU validation error reset scene objects",
+  );
+  assert.equal(afterErrorMetrics.rendererBackend, "WebGPU", "GPU validation error changed backend identity");
+
+  const captureAfterError = await readWebGpuCapture(page);
+  assert.equal(captureAfterError.deviceCount, 1, "validation error unexpectedly replaced the GPUDevice");
+  assert.equal(captureAfterError.lost[0], null, "validation error unexpectedly lost the GPUDevice");
+
+  const recovered = await renderAndCapture(page, "after-handled-error");
+  assert.equal(recovered.metrics.revision, baseline.metrics.revision, "handled GPU error changed scene revision");
+  assert.equal(recovered.metrics.objectCount, baseline.metrics.objectCount, "handled GPU error changed object count");
+  assert.ok(Math.abs(recovered.metrics.time - sampleTime) < 1e-6, "handled GPU error changed semantic playhead time");
+
+  const changedPixels = changedPixelCount(baseline.screenshot, recovered.screenshot);
+  assert.equal(
+    changedPixels,
+    0,
+    `frame after handled WebGPU validation error differs from baseline at ${changedPixels} pixels`,
+  );
+
+  assert.deepEqual(browserErrors.pageErrors, [], "handled WebGPU validation error emitted page errors");
+  const unexpectedConsoleErrors = browserErrors.consoleErrors.filter(
+    (message) => !/(validation|buffer.*usage|usage.*buffer)/i.test(message),
+  );
+  assert.deepEqual(
+    unexpectedConsoleErrors,
+    [],
+    `handled WebGPU validation error emitted unexpected console errors:\n${unexpectedConsoleErrors.join("\n")}`,
+  );
+
+  await writeDiagnostics("validation-error", {
+    browserVersion: browser.version(),
+    initial,
+    baseline: baseline.metrics,
+    hostError,
+    afterErrorMetrics,
+    recovered: recovered.metrics,
+    captureBefore,
+    captureAfterError,
+    changedPixels,
+    browserErrors,
+  });
+  await page.close();
+  console.log("✓ WebGPU validation errors propagate with context and leave the renderer usable");
+} catch (error) {
+  await writeDiagnostics("failure", {
+    browserVersion: browser?.version() ?? null,
+    error:
+      error instanceof Error
+        ? { name: error.name, message: error.message, stack: error.stack }
+        : String(error),
+    serverOutput,
+  });
+  throw error;
+} finally {
+  await browser?.close();
+  server.kill("SIGTERM");
+}

--- a/scripts/webgpu-device-capture.mjs
+++ b/scripts/webgpu-device-capture.mjs
@@ -1,0 +1,58 @@
+export async function installWebGpuDeviceCapture(page) {
+  await page.addInitScript(() => {
+    const state = {
+      patched: false,
+      patchError: null,
+      devices: [],
+      lost: [],
+    };
+    window.__noonWebGpuDeviceCapture = state;
+
+    try {
+      const gpu = navigator.gpu;
+      if (!gpu || typeof gpu.requestAdapter !== "function") {
+        state.patchError = "navigator.gpu.requestAdapter is unavailable";
+        return;
+      }
+      const originalRequestAdapter = gpu.requestAdapter.bind(gpu);
+      Object.defineProperty(gpu, "requestAdapter", {
+        configurable: true,
+        value: async (...adapterArgs) => {
+          const adapter = await originalRequestAdapter(...adapterArgs);
+          if (!adapter) return adapter;
+
+          const originalRequestDevice = adapter.requestDevice.bind(adapter);
+          Object.defineProperty(adapter, "requestDevice", {
+            configurable: true,
+            value: async (...deviceArgs) => {
+              const device = await originalRequestDevice(...deviceArgs);
+              const index = state.devices.length;
+              state.devices.push(device);
+              state.lost.push(null);
+              device.lost.then((info) => {
+                state.lost[index] = {
+                  reason: String(info.reason ?? "unknown"),
+                  message: String(info.message ?? ""),
+                };
+              });
+              return device;
+            },
+          });
+          return adapter;
+        },
+      });
+      state.patched = true;
+    } catch (error) {
+      state.patchError = String(error);
+    }
+  });
+}
+
+export function readWebGpuCapture(page) {
+  return page.evaluate(() => ({
+    patched: window.__noonWebGpuDeviceCapture?.patched ?? false,
+    patchError: window.__noonWebGpuDeviceCapture?.patchError ?? null,
+    deviceCount: window.__noonWebGpuDeviceCapture?.devices.length ?? 0,
+    lost: window.__noonWebGpuDeviceCapture?.lost ?? [],
+  }));
+}


### PR DESCRIPTION
## Summary

Advance #111 by making uncaptured browser GPU errors part of the host-facing renderer contract instead of console-only failures.

- install wgpu `Device::on_uncaptured_error` alongside the existing device-loss callback and keep both signals generation-scoped;
- surface pending GPU errors through `renderFrame` before semantic advancement and after rendering;
- treat validation errors as one-shot/recoverable while keeping out-of-memory/internal errors terminal;
- keep the mailbox bounded while allowing a fatal same-generation error to replace a pending recoverable validation error;
- ignore stale error callbacks from superseded GPU generations;
- preserve the current renderer-recovery timing semantics (`lastRuntimeEvaluationMs` is not reset by renderer generation changes);
- share the real WebGPU device-capture harness between device-loss and validation-error browser tests;
- extend the existing Renderer recovery workflow with a real `GPUValidationError` oracle and diagnostics artifact.

## Browser oracle

The new smoke test captures Noon's actual WebGPU `GPUDevice`, renders a baseline frame, then calls `device.createBuffer({ size: 4, usage: 0 })`. That invalid real-device operation must reach the host as a contextual `WebGPU generation 1 validation error` without losing/replacing the device or resetting scene revision, object state, backend identity, or playhead. The next render must succeed and match the baseline screenshot exactly.

## Validation before PR

The source transform ran on a hosted runner and passed `cargo fmt --all`, JS syntax checks for all affected smoke helpers, and `git diff --check`. The final branch was rebuilt as one commit directly on current master with only the five durable runtime/test/workflow files.

Tracks #111.