### PR TITLE
Stress out-of-order authoring freshness

### DIFF
--- a/scripts/build-web-demo.sh
+++ b/scripts/build-web-demo.sh
@@ -35,6 +35,7 @@ node --check web/gpu-profile.js
 node --check web/morph-profile.js
 node --check web/browser-jank.js
 node --check web/perf-profile.js
+node --check web/player-frame-metrics.js
 node --check web/perf-workloads.js
 node --check web/authoring-perf.js
 node --check web/scene-perf.js
@@ -75,6 +76,7 @@ node --test web/python-compat-bundle.test.mjs
 node --test web/python-worker-source.test.mjs
 node --test web/scene-identity.test.mjs
 node --test web/frame-metrics.test.mjs
+node --test web/player-frame-metrics.test.mjs
 node --test web/browser-jank.test.mjs
 node --test web/perf-workloads.test.mjs
 node --test web/performance-corpus-manifest.test.mjs

--- a/scripts/build-web-demo.sh
+++ b/scripts/build-web-demo.sh
@@ -65,6 +65,7 @@ node --test web/execution-transport.test.mjs
 node --test web/execution-worker-client.test.mjs
 node --test web/execution-worker-startup.test.mjs
 node --test web/authoring-client.test.mjs
+node --test web/authoring-out-of-order-stress.test.mjs
 node --test web/playground-generation.test.mjs
 node --test web/playground-startup.test.mjs
 node --test web/python-editor.test.mjs

--- a/web/authoring-out-of-order-stress.test.mjs
+++ b/web/authoring-out-of-order-stress.test.mjs
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  AUTHORING_CHANNEL,
+  AUTHORING_PROTOCOL_VERSION,
+  PythonAuthoringClient,
+} from "./authoring-client.js";
+import { PlaygroundGeneration } from "./playground-generation.js";
+
+class FakeWorker {
+  listeners = new Map();
+  messages = [];
+  terminated = false;
+
+  addEventListener(type, listener) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  postMessage(message) {
+    this.messages.push(message);
+  }
+
+  terminate() {
+    this.terminated = true;
+  }
+
+  emit(type, payload) {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(type === "message" ? { data: payload } : payload);
+    }
+  }
+}
+
+function workerMessage(type, payload = {}) {
+  return {
+    channel: AUTHORING_CHANNEL,
+    protocolVersion: AUTHORING_PROTOCOL_VERSION,
+    type,
+    ...payload,
+  };
+}
+
+function sceneResultJson(objectId) {
+  return JSON.stringify({
+    kind: "scene_document",
+    document: { version: 1, objects: [{ id: objectId }], tracks: [] },
+    duration: 0,
+    identities: {
+      objects: [{ id: objectId, key: `@object:${objectId}` }],
+      tracks: [],
+    },
+    callbacks: null,
+  });
+}
+
+function emitSceneResult(worker, requestId, objectId) {
+  worker.emit(
+    "message",
+    workerMessage("result", {
+      requestId,
+      resultJson: sceneResultJson(objectId),
+    }),
+  );
+}
+
+test("seeded out-of-order authoring stress admits only the newest playground generation", async () => {
+  const worker = new FakeWorker();
+  const client = new PythonAuthoringClient(worker);
+  worker.emit("message", workerMessage("ready"));
+  await client.ready();
+
+  const generations = new PlaygroundGeneration();
+  generations.commitSelection(generations.beginSelectionRequest("scene"));
+
+  const requestCount = 500;
+  const commits = [];
+  const requests = [];
+  for (let index = 0; index < requestCount; index += 1) {
+    const token = generations.beginRun("scene");
+    requests.push(
+      client
+        .run(`result = scene_${index}`, {
+          playground: {
+            example_id: "scene",
+            selection_generation: token.selectionGeneration,
+            run_generation: token.runGeneration,
+          },
+        })
+        .then((authored) => {
+          if (!generations.isRunCurrent(token, "scene")) {
+            generations.recordStale(token, "after-authoring");
+            return false;
+          }
+          commits.push(authored.document.objects[0].id);
+          return true;
+        }),
+    );
+  }
+
+  await Promise.resolve();
+  assert.equal(worker.messages.length, requestCount);
+  assert.equal(worker.messages[0].requestId, 0);
+  assert.equal(worker.messages.at(-1).requestId, requestCount - 1);
+
+  let seed = 0x6e6f6f6e;
+  const random = () => {
+    seed ^= seed << 13;
+    seed ^= seed >>> 17;
+    seed ^= seed << 5;
+    return seed >>> 0;
+  };
+  const completionOrder = Array.from({ length: requestCount }, (_, index) => index);
+  for (let index = completionOrder.length - 1; index > 0; index -= 1) {
+    const swapIndex = random() % (index + 1);
+    [completionOrder[index], completionOrder[swapIndex]] = [
+      completionOrder[swapIndex],
+      completionOrder[index],
+    ];
+  }
+  for (const requestId of completionOrder) {
+    emitSceneResult(worker, requestId, requestId);
+  }
+
+  const committed = await Promise.all(requests);
+  assert.equal(committed.filter(Boolean).length, 1);
+  assert.deepEqual(commits, [requestCount - 1]);
+  assert.equal(generations.diagnostics.staleDrops, requestCount - 1);
+  assert.equal(client.terminated, false);
+  assert.equal(worker.terminated, false);
+
+  const retry = client.run("result = retry");
+  await Promise.resolve();
+  assert.equal(worker.messages.at(-1).requestId, requestCount);
+  emitSceneResult(worker, requestCount, requestCount);
+  const retryResult = await retry;
+  assert.equal(retryResult.document.objects[0].id, requestCount);
+  assert.equal(client.terminated, false);
+});


### PR DESCRIPTION
## Superseded by #434

#434 has now merged the 500-request seeded out-of-order Python authoring/freshness stress into the canonical `web/authoring-out-of-order-races.test.mjs` and gates it in the normal web build.

This PR is intentionally closed rather than merging a second near-identical stress suite. The one additional useful assertion here—prove the Python worker accepts another request after all 500 out-of-order completions—is being carried forward as a minimal follow-up against #434's existing test.

Tracks #112.