### PR TITLE
Propagate GPU validation through public render workers

### DIFF
--- a/.github/workflows/renderer-recovery.yml
+++ b/.github/workflows/renderer-recovery.yml
@@ -10,11 +10,18 @@ on:
       - "scripts/renderer-webgl-context-loss-smoke.mjs"
       - "scripts/renderer-webgpu-device-loss-smoke.mjs"
       - "scripts/renderer-webgpu-validation-error-smoke.mjs"
+      - "scripts/renderer-worker-webgpu-validation-error-smoke.mjs"
       - "scripts/webgpu-device-capture.mjs"
       - "web/browser-smoke.html"
       - "web/browser-smoke.js"
       - "web/execution-renderer-smoke.html"
       - "web/execution-renderer-smoke.js"
+      - "web/execution-render-worker.js"
+      - "web/retained-execution-render-worker.js"
+      - "web/execution-worker-client.js"
+      - "web/retained-execution-worker-client.js"
+      - "web/authoring-execution-client.js"
+      - "web/render-gpu-errors.js"
   push:
     branches:
       - master
@@ -26,11 +33,18 @@ on:
       - "scripts/renderer-webgl-context-loss-smoke.mjs"
       - "scripts/renderer-webgpu-device-loss-smoke.mjs"
       - "scripts/renderer-webgpu-validation-error-smoke.mjs"
+      - "scripts/renderer-worker-webgpu-validation-error-smoke.mjs"
       - "scripts/webgpu-device-capture.mjs"
       - "web/browser-smoke.html"
       - "web/browser-smoke.js"
       - "web/execution-renderer-smoke.html"
       - "web/execution-renderer-smoke.js"
+      - "web/execution-render-worker.js"
+      - "web/retained-execution-render-worker.js"
+      - "web/execution-worker-client.js"
+      - "web/retained-execution-worker-client.js"
+      - "web/authoring-execution-client.js"
+      - "web/render-gpu-errors.js"
   workflow_dispatch:
 
 permissions:
@@ -118,6 +132,12 @@ jobs:
           NOON_RENDERER_VALIDATION_ERROR_ARTIFACTS: browser-smoke-artifacts/renderer-validation-error
         run: node scripts/renderer-webgpu-validation-error-smoke.mjs
 
+      - name: Test public render-worker WebGPU validation propagation
+        id: worker_webgpu_validation_error
+        env:
+          NOON_RENDERER_WORKER_VALIDATION_ARTIFACTS: browser-smoke-artifacts/renderer-worker-validation-error
+        run: node scripts/renderer-worker-webgpu-validation-error-smoke.mjs
+
       - name: Upload renderer initialization diagnostics
         if: always()
         uses: actions/upload-artifact@v4
@@ -151,5 +171,14 @@ jobs:
         with:
           name: renderer-webgpu-validation-error
           path: browser-smoke-artifacts/renderer-validation-error
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Upload public render-worker WebGPU validation diagnostics
+        if: always() && steps.worker_webgpu_validation_error.outcome != 'skipped'
+        uses: actions/upload-artifact@v4
+        with:
+          name: renderer-worker-webgpu-validation-error
+          path: browser-smoke-artifacts/renderer-worker-validation-error
           if-no-files-found: error
           retention-days: 7

--- a/crates/noon-web/src/execution_canvas.rs
+++ b/crates/noon-web/src/execution_canvas.rs
@@ -19,7 +19,10 @@ mod wasm {
     use wasm_bindgen::prelude::*;
     use web_sys::OffscreenCanvas;
 
-    use crate::{ExecutionFrameMirror, TransportApplyOutcome};
+    use crate::{
+        gpu_uncaptured_error::{install_uncaptured_error_handler, GpuUncapturedErrorSlot},
+        ExecutionFrameMirror, TransportApplyOutcome,
+    };
 
     use super::{MANIM_DEFAULT_CAMERA_HEIGHT, MANIM_DEFAULT_CLEAR_COLOR};
 
@@ -62,6 +65,8 @@ mod wasm {
         last_instances_drawn: usize,
         last_bytes_uploaded: usize,
         last_geometry_cache_misses: usize,
+        gpu_generation: u32,
+        gpu_errors: GpuUncapturedErrorSlot,
     }
 
     #[wasm_bindgen(js_class = ExecutionCanvasRenderer)]
@@ -90,6 +95,9 @@ mod wasm {
                 backend,
                 config,
             } = initialize_gpu(&canvas, width, height).await?;
+            let gpu_generation = 1;
+            let gpu_errors = GpuUncapturedErrorSlot::default();
+            install_uncaptured_error_handler(&device, gpu_generation, backend, gpu_errors.clone());
             let renderer = GpuRenderer::new(&device, config.format);
 
             let mut result = Self {
@@ -112,6 +120,8 @@ mod wasm {
                 last_instances_drawn: 0,
                 last_bytes_uploaded: 0,
                 last_geometry_cache_misses: 0,
+                gpu_generation,
+                gpu_errors,
             };
             result.update_camera()?;
             Ok(result)
@@ -160,11 +170,10 @@ mod wasm {
                         self.surface.configure(&self.device, &self.config);
                         return Ok(false);
                     }
-                    wgpu::CurrentSurfaceTexture::Validation => {
-                        return Err(js_message(
-                            "GPU backend rejected the OffscreenCanvas surface texture",
-                        ));
-                    }
+                    // wgpu reports this through the device's uncaptured-error handler.
+                    // Keep the pending frame intact so a recoverable validation error
+                    // can be surfaced once and the same frame retried.
+                    wgpu::CurrentSurfaceTexture::Validation => return Ok(false),
                 };
 
             let changes = mem::take(&mut self.pending_changes);
@@ -237,6 +246,19 @@ mod wasm {
                 wgpu::Backend::Gl => "WebGL2".to_owned(),
                 other => format!("{other:?}"),
             }
+        }
+
+        #[wasm_bindgen(js_name = gpuGeneration)]
+        pub fn gpu_generation(&self) -> u32 {
+            self.gpu_generation
+        }
+
+        #[wasm_bindgen(js_name = takeGpuUncapturedErrorJson)]
+        pub fn take_gpu_uncaptured_error_json(&self) -> Result<Option<String>, JsValue> {
+            self.gpu_errors
+                .take(self.gpu_generation)
+                .map(|error| serde_json::to_string(&error).map_err(js_error))
+                .transpose()
         }
 
         pub fn time(&self) -> f64 {

--- a/crates/noon-web/src/gpu_uncaptured_error.rs
+++ b/crates/noon-web/src/gpu_uncaptured_error.rs
@@ -1,0 +1,201 @@
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use serde::Serialize;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum GpuUncapturedErrorKind {
+    Validation,
+    OutOfMemory,
+    Internal,
+}
+
+impl GpuUncapturedErrorKind {
+    #[cfg(target_arch = "wasm32")]
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            Self::Validation => "validation",
+            Self::OutOfMemory => "out-of-memory",
+            Self::Internal => "internal",
+        }
+    }
+
+    pub(crate) const fn is_fatal(self) -> bool {
+        !matches!(self, Self::Validation)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub(crate) struct GpuUncapturedError {
+    pub(crate) generation: u32,
+    pub(crate) kind: GpuUncapturedErrorKind,
+    pub(crate) fatal: bool,
+    pub(crate) message: String,
+}
+
+#[cfg(target_arch = "wasm32")]
+impl GpuUncapturedError {
+    pub(crate) fn from_wgpu(generation: u32, backend: wgpu::Backend, error: wgpu::Error) -> Self {
+        let kind = match &error {
+            wgpu::Error::Validation { .. } => GpuUncapturedErrorKind::Validation,
+            wgpu::Error::OutOfMemory { .. } => GpuUncapturedErrorKind::OutOfMemory,
+            wgpu::Error::Internal { .. } => GpuUncapturedErrorKind::Internal,
+        };
+        let backend = match backend {
+            wgpu::Backend::BrowserWebGpu => "WebGPU",
+            wgpu::Backend::Gl => "WebGL2",
+            _ => "GPU",
+        };
+        Self {
+            generation,
+            kind,
+            fatal: kind.is_fatal(),
+            message: format!(
+                "{backend} generation {generation} {} error: {error}",
+                kind.label()
+            ),
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct GpuUncapturedErrorSlot {
+    pending: Arc<Mutex<Option<GpuUncapturedError>>>,
+}
+
+impl GpuUncapturedErrorSlot {
+    #[cfg(target_arch = "wasm32")]
+    pub(crate) fn report(&self, generation: u32, backend: wgpu::Backend, error: wgpu::Error) {
+        self.report_captured(GpuUncapturedError::from_wgpu(generation, backend, error));
+    }
+
+    pub(crate) fn take(&self, generation: u32) -> Option<GpuUncapturedError> {
+        self.with_pending(|pending| {
+            let pending_generation = pending.as_ref().map(|error| error.generation);
+            match pending_generation {
+                Some(current) if current < generation => {
+                    pending.take();
+                    None
+                }
+                Some(current) if current == generation => pending.take(),
+                _ => None,
+            }
+        })
+    }
+
+    fn report_captured(&self, captured: GpuUncapturedError) {
+        self.with_pending(|pending| {
+            let replace = match pending.as_ref() {
+                None => true,
+                Some(current) if current.generation < captured.generation => true,
+                Some(current) if current.generation > captured.generation => false,
+                Some(current) => !current.fatal && captured.fatal,
+            };
+            if replace {
+                *pending = Some(captured);
+            }
+        });
+    }
+
+    fn with_pending<R>(&self, operation: impl FnOnce(&mut Option<GpuUncapturedError>) -> R) -> R {
+        let mut pending = self.lock();
+        operation(&mut pending)
+    }
+
+    fn lock(&self) -> MutexGuard<'_, Option<GpuUncapturedError>> {
+        self.pending
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub(crate) fn install_uncaptured_error_handler(
+    device: &wgpu::Device,
+    generation: u32,
+    backend: wgpu::Backend,
+    slot: GpuUncapturedErrorSlot,
+) {
+    device.on_uncaptured_error(Arc::new(move |error| {
+        slot.report(generation, backend, error);
+    }));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{GpuUncapturedError, GpuUncapturedErrorKind, GpuUncapturedErrorSlot};
+
+    fn captured(
+        generation: u32,
+        kind: GpuUncapturedErrorKind,
+        message: &str,
+    ) -> GpuUncapturedError {
+        GpuUncapturedError {
+            generation,
+            kind,
+            fatal: kind.is_fatal(),
+            message: message.to_owned(),
+        }
+    }
+
+    #[test]
+    fn validation_is_one_shot_and_recoverable() {
+        let slot = GpuUncapturedErrorSlot::default();
+        slot.report_captured(captured(
+            4,
+            GpuUncapturedErrorKind::Validation,
+            "validation",
+        ));
+
+        let error = slot.take(4).expect("validation error");
+        assert_eq!(error.generation, 4);
+        assert_eq!(error.kind, GpuUncapturedErrorKind::Validation);
+        assert!(!error.fatal);
+        assert!(slot.take(4).is_none());
+    }
+
+    #[test]
+    fn fatal_error_replaces_validation_in_the_same_generation() {
+        let slot = GpuUncapturedErrorSlot::default();
+        slot.report_captured(captured(
+            2,
+            GpuUncapturedErrorKind::Validation,
+            "validation",
+        ));
+        slot.report_captured(captured(2, GpuUncapturedErrorKind::OutOfMemory, "oom"));
+        slot.report_captured(captured(
+            2,
+            GpuUncapturedErrorKind::Validation,
+            "later validation",
+        ));
+
+        let error = slot.take(2).expect("fatal error");
+        assert_eq!(error.kind, GpuUncapturedErrorKind::OutOfMemory);
+        assert!(error.fatal);
+        assert_eq!(error.message, "oom");
+    }
+
+    #[test]
+    fn stale_error_is_dropped_without_consuming_future_generation() {
+        let slot = GpuUncapturedErrorSlot::default();
+        slot.report_captured(captured(3, GpuUncapturedErrorKind::Validation, "old"));
+        assert!(slot.take(4).is_none());
+
+        slot.report_captured(captured(5, GpuUncapturedErrorKind::Internal, "future"));
+        assert!(slot.take(4).is_none());
+        let future = slot.take(5).expect("future error");
+        assert_eq!(future.message, "future");
+        assert!(future.fatal);
+    }
+
+    #[test]
+    fn older_generation_cannot_replace_newer_pending_error() {
+        let slot = GpuUncapturedErrorSlot::default();
+        slot.report_captured(captured(8, GpuUncapturedErrorKind::Validation, "new"));
+        slot.report_captured(captured(7, GpuUncapturedErrorKind::Internal, "old fatal"));
+
+        let error = slot.take(8).expect("new generation error");
+        assert_eq!(error.message, "new");
+        assert!(!error.fatal);
+    }
+}

--- a/crates/noon-web/src/lib.rs
+++ b/crates/noon-web/src/lib.rs
@@ -7,6 +7,8 @@ mod composition;
 mod determinism;
 mod execution_canvas;
 mod execution_transport;
+#[cfg(any(target_arch = "wasm32", test))]
+mod gpu_uncaptured_error;
 mod host_player;
 #[path = "legacy.rs"]
 mod legacy;

--- a/crates/noon-web/src/retained_execution_canvas.rs
+++ b/crates/noon-web/src/retained_execution_canvas.rs
@@ -7,7 +7,10 @@ mod wasm {
     use wasm_bindgen::prelude::*;
     use web_sys::OffscreenCanvas;
 
-    use crate::{InstalledRetainedExecutionMirror, RetainedTransportApplyOutcome};
+    use crate::{
+        gpu_uncaptured_error::{install_uncaptured_error_handler, GpuUncapturedErrorSlot},
+        InstalledRetainedExecutionMirror, RetainedTransportApplyOutcome,
+    };
 
     const CLEAR_COLOR: wgpu::Color = wgpu::Color {
         r: 0.0,
@@ -54,6 +57,8 @@ mod wasm {
         last_bytes_uploaded: usize,
         last_geometry_cache_misses: usize,
         last_outline_cache_misses: u64,
+        gpu_generation: u32,
+        gpu_errors: GpuUncapturedErrorSlot,
     }
 
     #[wasm_bindgen(js_class = RetainedExecutionCanvasRenderer)]
@@ -97,6 +102,14 @@ mod wasm {
                 })
                 .await
                 .map_err(js_error)?;
+            let gpu_generation = 1;
+            let gpu_errors = GpuUncapturedErrorSlot::default();
+            install_uncaptured_error_handler(
+                &device,
+                gpu_generation,
+                backend,
+                gpu_errors.clone(),
+            );
 
             let width = canvas.width().max(1);
             let height = canvas.height().max(1);
@@ -131,6 +144,8 @@ mod wasm {
                 last_bytes_uploaded: 0,
                 last_geometry_cache_misses: 0,
                 last_outline_cache_misses: 0,
+                gpu_generation,
+                gpu_errors,
             };
             result.update_camera()?;
             Ok(result)
@@ -180,11 +195,10 @@ mod wasm {
                         self.surface.configure(&self.device, &self.config);
                         return Ok(false);
                     }
-                    wgpu::CurrentSurfaceTexture::Validation => {
-                        return Err(js_message(
-                            "GPU backend rejected the retained execution surface texture",
-                        ));
-                    }
+                    // The device error callback owns validation diagnostics. Keep
+                    // the retained frame pending so a recoverable validation can
+                    // be reported once and presentation retried unchanged.
+                    wgpu::CurrentSurfaceTexture::Validation => return Ok(false),
                 };
 
             let frame = self
@@ -280,6 +294,19 @@ mod wasm {
                 wgpu::Backend::Gl => "WebGL2".to_owned(),
                 other => format!("{other:?}"),
             }
+        }
+
+        #[wasm_bindgen(js_name = gpuGeneration)]
+        pub fn gpu_generation(&self) -> u32 {
+            self.gpu_generation
+        }
+
+        #[wasm_bindgen(js_name = takeGpuUncapturedErrorJson)]
+        pub fn take_gpu_uncaptured_error_json(&self) -> Result<Option<String>, JsValue> {
+            self.gpu_errors
+                .take(self.gpu_generation)
+                .map(|error| serde_json::to_string(&error).map_err(js_error))
+                .transpose()
         }
 
         pub fn time(&self) -> f64 {

--- a/scripts/renderer-worker-webgpu-validation-error-smoke.mjs
+++ b/scripts/renderer-worker-webgpu-validation-error-smoke.mjs
@@ -1,0 +1,367 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import playwright from "playwright";
+
+import {
+  installWebGpuDeviceCaptureInWorker,
+  readWorkerWebGpuCapture,
+} from "./webgpu-device-capture.mjs";
+
+const { chromium } = playwright;
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const port = Number(process.env.NOON_RENDERER_WORKER_VALIDATION_PORT ?? "4195");
+const baseUrl = `http://127.0.0.1:${port}`;
+const artifactDir = path.resolve(
+  repoRoot,
+  process.env.NOON_RENDERER_WORKER_VALIDATION_ARTIFACTS ??
+    "browser-smoke-artifacts/renderer-worker-validation-error",
+);
+
+await mkdir(artifactDir, { recursive: true });
+
+let serverOutput = "";
+const server = spawn(
+  "python3",
+  ["-m", "http.server", String(port), "--bind", "127.0.0.1", "--directory", repoRoot],
+  { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] },
+);
+server.stdout.on("data", (chunk) => {
+  serverOutput += chunk;
+});
+server.stderr.on("data", (chunk) => {
+  serverOutput += chunk;
+});
+
+async function waitForServer() {
+  let lastError = null;
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    try {
+      const response = await fetch(`${baseUrl}/web/pkg/noon_web.js`);
+      if (response.ok) return;
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`renderer worker validation server did not start: ${lastError}\n${serverOutput}`);
+}
+
+async function waitForWorkerCapture(worker, minimumDevices = 1, timeoutMs = 10_000) {
+  const deadline = Date.now() + timeoutMs;
+  let last = null;
+  while (Date.now() < deadline) {
+    last = await readWorkerWebGpuCapture(worker);
+    if (last.patchError !== null) {
+      throw new Error(`failed to patch render-worker WebGPU: ${last.patchError}`);
+    }
+    if (last.deviceCount >= minimumDevices) return last;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(
+    `Noon render worker did not expose ${minimumDevices} GPUDevice(s): ${JSON.stringify(last)}`,
+  );
+}
+
+async function requestRenderMetrics(page, requestId) {
+  return page.evaluate(
+    ({ requestId }) =>
+      new Promise((resolve, reject) => {
+        const worker = window.__noonWorkerValidation?.renderWorker;
+        if (!worker) {
+          reject(new Error("render worker is unavailable"));
+          return;
+        }
+        const timeout = setTimeout(() => {
+          worker.removeEventListener("message", onMessage);
+          reject(new Error(`render metrics request ${requestId} timed out`));
+        }, 10_000);
+        function onMessage(event) {
+          const message = event.data;
+          if (
+            message?.channel === "noon.render" &&
+            message?.protocolVersion === 1 &&
+            message?.type === "metrics" &&
+            message?.requestId === requestId
+          ) {
+            clearTimeout(timeout);
+            worker.removeEventListener("message", onMessage);
+            resolve(message.metrics);
+          }
+        }
+        worker.addEventListener("message", onMessage);
+        worker.postMessage({
+          channel: "noon.render",
+          protocolVersion: 1,
+          type: "metrics",
+          requestId,
+        });
+      }),
+    { requestId },
+  );
+}
+
+async function writeDiagnostics(value) {
+  await writeFile(
+    path.join(artifactDir, "diagnostics.json"),
+    `${JSON.stringify(value, null, 2)}\n`,
+    "utf8",
+  );
+}
+
+let browser = null;
+const diagnostics = {};
+const pageErrors = [];
+const consoleErrors = [];
+
+try {
+  await waitForServer();
+  browser = await chromium.launch({
+    channel: "chromium",
+    headless: true,
+    args: [
+      "--enable-unsafe-webgpu",
+      "--enable-unsafe-swiftshader",
+      "--use-webgpu-adapter=swiftshader",
+      "--use-gpu-in-tests",
+      "--ignore-gpu-blocklist",
+      "--enable-features=Vulkan",
+      "--use-gl=angle",
+      "--use-angle=swiftshader",
+      "--use-vulkan=swiftshader",
+      "--disable-gpu-sandbox",
+      "--disable-dev-shm-usage",
+    ],
+  });
+
+  const page = await browser.newPage({ viewport: { width: 900, height: 600 } });
+  await page.route("**/favicon.ico", (route) =>
+    route.fulfill({ status: 204, contentType: "image/x-icon", body: "" }),
+  );
+  page.on("pageerror", (error) => pageErrors.push(String(error)));
+  page.on("console", (message) => {
+    if (message.type() === "error") consoleErrors.push(message.text());
+  });
+  await page.goto(baseUrl, { waitUntil: "load" });
+
+  const renderWorkerPromise = page.waitForEvent("worker", {
+    predicate: (worker) => worker.url().endsWith("/web/execution-render-worker.js"),
+    timeout: 10_000,
+  });
+  await page.evaluate(() => {
+    document.body.innerHTML = "<canvas id='scene' width='640' height='360'></canvas>";
+    const renderWorker = new Worker(
+      new URL("./web/execution-render-worker.js", window.location.href),
+      { type: "module", name: "noon-worker-validation-render" },
+    );
+    window.__noonWorkerValidation = {
+      renderWorker,
+      engineWorker: null,
+      renderMessages: [],
+      engineMessages: [],
+    };
+    renderWorker.addEventListener("message", (event) => {
+      window.__noonWorkerValidation.renderMessages.push(event.data);
+    });
+  });
+  const renderWorker = await renderWorkerPromise;
+  await installWebGpuDeviceCaptureInWorker(renderWorker);
+
+  const engineWorkerPromise = page.waitForEvent("worker", {
+    predicate: (worker) => worker.url().endsWith("/web/execution-engine-worker.js"),
+    timeout: 10_000,
+  });
+  await page.evaluate(async () => {
+    const pkg = await import("./web/pkg/noon_web.js");
+    await pkg.default();
+    const sceneJson = pkg.demoSceneJson();
+    const canvas = document.querySelector("#scene");
+    const offscreen = canvas.transferControlToOffscreen();
+    const channel = new MessageChannel();
+    const harness = window.__noonWorkerValidation;
+    const engineWorker = new Worker(
+      new URL("./web/execution-engine-worker.js", window.location.href),
+      { type: "module", name: "noon-worker-validation-engine" },
+    );
+    harness.engineWorker = engineWorker;
+    engineWorker.addEventListener("message", (event) => {
+      harness.engineMessages.push(event.data);
+    });
+    harness.renderWorker.postMessage(
+      {
+        channel: "noon.render",
+        protocolVersion: 1,
+        type: "init",
+        canvas: offscreen,
+        port: channel.port2,
+        transportMode: "transferable",
+        width: 640,
+        height: 360,
+      },
+      [offscreen, channel.port2],
+    );
+    engineWorker.postMessage(
+      {
+        channel: "noon.engine",
+        protocolVersion: 1,
+        type: "init",
+        port: channel.port1,
+        sceneJson,
+        loopDurationSeconds: 4,
+        transportMode: "transferable",
+        sharedSlotCapacity: 1024 * 1024,
+        session: 1,
+      },
+      [channel.port1],
+    );
+  });
+  await engineWorkerPromise;
+
+  await page.waitForFunction(
+    () =>
+      window.__noonWorkerValidation.renderMessages.some(
+        (message) => message?.channel === "noon.render" && message?.type === "ready",
+      ) &&
+      window.__noonWorkerValidation.engineMessages.some(
+        (message) => message?.channel === "noon.engine" && message?.type === "ready",
+      ),
+    null,
+    { timeout: 30_000 },
+  );
+
+  const ready = await page.evaluate(() => ({
+    render: window.__noonWorkerValidation.renderMessages.find(
+      (message) => message?.channel === "noon.render" && message?.type === "ready",
+    ),
+    engine: window.__noonWorkerValidation.engineMessages.find(
+      (message) => message?.channel === "noon.engine" && message?.type === "ready",
+    ),
+  }));
+  diagnostics.ready = ready;
+  assert.equal(ready.render.backend, "WebGPU", `expected WebGPU, got ${ready.render.backend}`);
+  assert.equal(ready.render.gpuGeneration, 1, "public renderer must expose its GPU generation");
+
+  const captureBefore = await waitForWorkerCapture(renderWorker);
+  diagnostics.captureBefore = captureBefore;
+  assert.equal(captureBefore.patched, true, `worker WebGPU patch failed: ${captureBefore.patchError}`);
+  assert.equal(captureBefore.deviceCount, 1, "expected one public renderer GPUDevice");
+  assert.equal(captureBefore.lost[0], null, "public renderer GPUDevice is unexpectedly lost");
+
+  let baseline = null;
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    baseline = await requestRenderMetrics(page, 100 + attempt);
+    if (baseline.presentedFrames >= 2) break;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  diagnostics.baseline = baseline;
+  assert.equal(baseline.backend, "WebGPU");
+  assert.equal(baseline.gpuGeneration, 1);
+  assert.ok(baseline.presentedFrames >= 2, "public renderer did not establish a healthy baseline");
+  assert.ok(baseline.objectCount > 0, "public renderer baseline scene is empty");
+
+  await renderWorker.evaluate(() => {
+    const device = globalThis.__noonWebGpuDeviceCapture?.devices?.[0];
+    if (!device) throw new Error("captured public renderer GPUDevice is unavailable");
+    // WebGPU requires a non-zero usage bitmask. This creates a real uncaptured
+    // validation error without intentionally losing or replacing the device.
+    device.createBuffer({
+      label: "Noon public render-worker validation oracle",
+      size: 4,
+      usage: 0,
+    });
+  });
+
+  await page.waitForFunction(
+    () =>
+      window.__noonWorkerValidation.renderMessages.filter(
+        (message) => message?.channel === "noon.render" && message?.type === "recoverable_error",
+      ).length >= 1,
+    null,
+    { timeout: 10_000 },
+  );
+  await new Promise((resolve) => setTimeout(resolve, 150));
+
+  const reported = await page.evaluate(() => {
+    const messages = window.__noonWorkerValidation.renderMessages;
+    return {
+      recoverable: messages.filter(
+        (message) => message?.channel === "noon.render" && message?.type === "recoverable_error",
+      ),
+      fatal: messages.filter(
+        (message) => message?.channel === "noon.render" && message?.type === "error",
+      ),
+    };
+  });
+  diagnostics.reported = reported;
+  assert.equal(reported.recoverable.length, 1, "validation error must be reported exactly once");
+  assert.equal(reported.fatal.length, 0, "validation error must not become a fatal worker error");
+
+  const diagnostic = reported.recoverable[0].diagnostic;
+  assert.equal(diagnostic.backend, "WebGPU");
+  assert.equal(diagnostic.generation, 1);
+  assert.equal(diagnostic.kind, "validation");
+  assert.equal(diagnostic.fatal, false);
+  assert.match(
+    diagnostic.message,
+    /WebGPU generation 1 validation error:/,
+    `worker diagnostic lacks backend/generation context: ${diagnostic.message}`,
+  );
+
+  let continued = null;
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    continued = await requestRenderMetrics(page, 200 + attempt);
+    if (continued.presentedFrames > baseline.presentedFrames) break;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  diagnostics.continued = continued;
+  assert.equal(continued.backend, baseline.backend, "validation changed public renderer backend");
+  assert.equal(
+    continued.gpuGeneration,
+    baseline.gpuGeneration,
+    "validation changed public renderer GPU generation",
+  );
+  assert.equal(continued.objectCount, baseline.objectCount, "validation changed public scene objects");
+  assert.ok(
+    continued.presentedFrames > baseline.presentedFrames,
+    "public renderer did not continue presenting after validation error",
+  );
+
+  const captureAfter = await readWorkerWebGpuCapture(renderWorker);
+  diagnostics.captureAfter = captureAfter;
+  assert.equal(captureAfter.deviceCount, 1, "validation unexpectedly requested a replacement GPUDevice");
+  assert.equal(captureAfter.lost[0], null, "validation unexpectedly lost the public GPUDevice");
+
+  await page.locator("#scene").screenshot({ path: path.join(artifactDir, "continued.png") });
+
+  const unexpectedConsoleErrors = consoleErrors.filter(
+    (message) => !/(validation|buffer.*usage|usage.*buffer)/i.test(message),
+  );
+  assert.deepEqual(pageErrors, [], `page errors: ${pageErrors.join("\n")}`);
+  assert.deepEqual(
+    unexpectedConsoleErrors,
+    [],
+    `unexpected console errors: ${unexpectedConsoleErrors.join("\n")}`,
+  );
+
+  diagnostics.pageErrors = pageErrors;
+  diagnostics.consoleErrors = consoleErrors;
+  await writeDiagnostics(diagnostics);
+  console.log("✓ public render-worker WebGPU validation is recoverable and rendering continues");
+} catch (error) {
+  diagnostics.failure = error instanceof Error
+    ? { name: error.name, message: error.message, stack: error.stack }
+    : String(error);
+  diagnostics.pageErrors = pageErrors;
+  diagnostics.consoleErrors = consoleErrors;
+  diagnostics.serverOutput = serverOutput;
+  await writeDiagnostics(diagnostics);
+  throw error;
+} finally {
+  await browser?.close();
+  server.kill("SIGTERM");
+}

--- a/scripts/webgpu-device-capture.mjs
+++ b/scripts/webgpu-device-capture.mjs
@@ -1,58 +1,72 @@
-export async function installWebGpuDeviceCapture(page) {
-  await page.addInitScript(() => {
-    const state = {
-      patched: false,
-      patchError: null,
-      devices: [],
-      lost: [],
-    };
-    window.__noonWebGpuDeviceCapture = state;
+function installCaptureState() {
+  const state = {
+    patched: false,
+    patchError: null,
+    devices: [],
+    lost: [],
+  };
+  globalThis.__noonWebGpuDeviceCapture = state;
 
-    try {
-      const gpu = navigator.gpu;
-      if (!gpu || typeof gpu.requestAdapter !== "function") {
-        state.patchError = "navigator.gpu.requestAdapter is unavailable";
-        return;
-      }
-      const originalRequestAdapter = gpu.requestAdapter.bind(gpu);
-      Object.defineProperty(gpu, "requestAdapter", {
-        configurable: true,
-        value: async (...adapterArgs) => {
-          const adapter = await originalRequestAdapter(...adapterArgs);
-          if (!adapter) return adapter;
-
-          const originalRequestDevice = adapter.requestDevice.bind(adapter);
-          Object.defineProperty(adapter, "requestDevice", {
-            configurable: true,
-            value: async (...deviceArgs) => {
-              const device = await originalRequestDevice(...deviceArgs);
-              const index = state.devices.length;
-              state.devices.push(device);
-              state.lost.push(null);
-              device.lost.then((info) => {
-                state.lost[index] = {
-                  reason: String(info.reason ?? "unknown"),
-                  message: String(info.message ?? ""),
-                };
-              });
-              return device;
-            },
-          });
-          return adapter;
-        },
-      });
-      state.patched = true;
-    } catch (error) {
-      state.patchError = String(error);
+  try {
+    const gpu = navigator.gpu;
+    if (!gpu || typeof gpu.requestAdapter !== "function") {
+      state.patchError = "navigator.gpu.requestAdapter is unavailable";
+      return;
     }
-  });
+    const originalRequestAdapter = gpu.requestAdapter.bind(gpu);
+    Object.defineProperty(gpu, "requestAdapter", {
+      configurable: true,
+      value: async (...adapterArgs) => {
+        const adapter = await originalRequestAdapter(...adapterArgs);
+        if (!adapter) return adapter;
+
+        const originalRequestDevice = adapter.requestDevice.bind(adapter);
+        Object.defineProperty(adapter, "requestDevice", {
+          configurable: true,
+          value: async (...deviceArgs) => {
+            const device = await originalRequestDevice(...deviceArgs);
+            const index = state.devices.length;
+            state.devices.push(device);
+            state.lost.push(null);
+            device.lost.then((info) => {
+              state.lost[index] = {
+                reason: String(info.reason ?? "unknown"),
+                message: String(info.message ?? ""),
+              };
+            });
+            return device;
+          },
+        });
+        return adapter;
+      },
+    });
+    state.patched = true;
+  } catch (error) {
+    state.patchError = String(error);
+  }
+}
+
+function captureSnapshot() {
+  return {
+    patched: globalThis.__noonWebGpuDeviceCapture?.patched ?? false,
+    patchError: globalThis.__noonWebGpuDeviceCapture?.patchError ?? null,
+    deviceCount: globalThis.__noonWebGpuDeviceCapture?.devices.length ?? 0,
+    lost: globalThis.__noonWebGpuDeviceCapture?.lost ?? [],
+  };
+}
+
+export async function installWebGpuDeviceCapture(page) {
+  await page.addInitScript(installCaptureState);
 }
 
 export function readWebGpuCapture(page) {
-  return page.evaluate(() => ({
-    patched: window.__noonWebGpuDeviceCapture?.patched ?? false,
-    patchError: window.__noonWebGpuDeviceCapture?.patchError ?? null,
-    deviceCount: window.__noonWebGpuDeviceCapture?.devices.length ?? 0,
-    lost: window.__noonWebGpuDeviceCapture?.lost ?? [],
-  }));
+  return page.evaluate(captureSnapshot);
+}
+
+export function installWebGpuDeviceCaptureInWorker(worker) {
+  return worker.evaluate(installCaptureState);
+}
+
+export function readWorkerWebGpuCapture(worker) {
+  return worker.evaluate(captureSnapshot);
 }

--- a/web/authoring-execution-client.js
+++ b/web/authoring-execution-client.js
@@ -246,7 +246,10 @@ export class AuthoringExecutionClient {
 
   async #rebuildRetained(sceneJson, retainedDocumentJson) {
     const canvas = this.#replaceTransferredCanvas();
-    const player = new RetainedExecutionWorkerClient(canvas, { onError: this.#onError });
+    const player = new RetainedExecutionWorkerClient(canvas, {
+      onError: this.#onError,
+      onRecoverableError: this.#onRecoverableError,
+    });
     try {
       const ready = await player.start(sceneJson, retainedDocumentJson, {
         loopDurationSeconds: this.#loopDurationSeconds,

--- a/web/execution-render-worker.js
+++ b/web/execution-render-worker.js
@@ -1,4 +1,5 @@
 import init, { ExecutionCanvasRenderer } from "./pkg/noon_web.js";
+import { drainRendererGpuErrors } from "./render-gpu-errors.js";
 import {
   EXECUTION_TRANSPORT_SHARED,
   EXECUTION_TRANSPORT_TRANSFERABLE,
@@ -43,8 +44,10 @@ async function handleMainMessage(message) {
         width = normalizedDimension(message.width);
         height = normalizedDimension(message.height);
         renderer?.resize(width, height);
+        drainGpuErrors();
         return;
       case "metrics":
+        if (!drainGpuErrors()) return;
         respond(message.requestId, {
           type: "metrics",
           metrics: currentMetrics(),
@@ -101,6 +104,7 @@ function attachEngine(message) {
       `execution render reconnect transport ${message.transportMode} does not match ${transportMode}`,
     );
   }
+  if (!drainGpuErrors()) return;
 
   renderPort.close?.();
   sharedReader = null;
@@ -111,6 +115,7 @@ function attachEngine(message) {
     type: "engine_port_attached",
     transportMode,
     backend: renderer.rendererBackend(),
+    gpuGeneration: renderer.gpuGeneration(),
   });
 }
 
@@ -196,13 +201,16 @@ async function bootstrapRenderer(initial) {
   try {
     renderer = await ExecutionCanvasRenderer.create(canvas, initial);
     renderer.resize(width, height);
+    if (!drainGpuErrors()) return;
     needsPresent = true;
     tryPresent();
+    if (!drainGpuErrors()) return;
     running = true;
     postMain({
       type: "ready",
       transportMode,
       backend: renderer.rendererBackend(),
+      gpuGeneration: renderer.gpuGeneration(),
     });
     flushBootstrapQueue();
     drainTransport();
@@ -213,15 +221,16 @@ async function bootstrapRenderer(initial) {
 }
 
 function tryPresent() {
-  if (renderer === null || !needsPresent) {
+  if (renderer === null || !needsPresent || !drainGpuErrors()) {
     return false;
   }
   if (!renderer.render()) {
+    drainGpuErrors();
     return false;
   }
   needsPresent = false;
   presentedFrames += 1;
-  return true;
+  return drainGpuErrors();
 }
 
 function flushBootstrapQueue() {
@@ -253,7 +262,7 @@ function scheduleFrame() {
 }
 
 function frame(timestamp) {
-  if (!running) {
+  if (!running || !drainGpuErrors()) {
     return;
   }
   lastFrameTimestamp = timestamp;
@@ -265,8 +274,33 @@ function frame(timestamp) {
     flushBootstrapQueue();
     drainTransport();
   }
+  if (!running || !drainGpuErrors()) {
+    return;
+  }
   renderPort.postMessage({ type: "tick", timestamp });
   scheduleFrame();
+}
+
+function drainGpuErrors() {
+  if (renderer === null) return true;
+  try {
+    return drainRendererGpuErrors(renderer, {
+      onRecoverable(error) {
+        postMain({
+          type: "recoverable_error",
+          owner: "render",
+          message: error.message,
+          diagnostic: error,
+        });
+      },
+      onFatal(error) {
+        fail(new Error(error.message), null);
+      },
+    });
+  } catch (error) {
+    fail(error, null);
+    return false;
+  }
 }
 
 function currentMetrics() {
@@ -283,6 +317,7 @@ function currentMetrics() {
     ready: true,
     transportMode,
     backend: renderer.rendererBackend(),
+    gpuGeneration: renderer.gpuGeneration(),
     time: renderer.time(),
     objectCount: renderer.objectCount(),
     drawCalls: renderer.lastDrawCalls(),

--- a/web/execution-worker-client.js
+++ b/web/execution-worker-client.js
@@ -487,6 +487,12 @@ export class ExecutionWorkerClient {
             );
             return;
           }
+          if (message.type === "recoverable_error") {
+            const error = new Error(message.message || `${owner} worker reported a recoverable error`);
+            error.diagnostic = message.diagnostic ?? null;
+            this.#notifyRecoverableError(error, owner);
+            return;
+          }
           if (message.type === "error") {
             const error = new Error(message.message || `${owner} worker failed`);
             if (message.requestId === null || message.requestId === undefined) {

--- a/web/render-gpu-errors.js
+++ b/web/render-gpu-errors.js
@@ -1,0 +1,50 @@
+export function drainRendererGpuErrors(renderer, { onRecoverable, onFatal }) {
+  if (!renderer || typeof renderer.takeGpuUncapturedErrorJson !== "function") {
+    return true;
+  }
+  if (typeof onRecoverable !== "function" || typeof onFatal !== "function") {
+    throw new TypeError("renderer GPU error routing requires recoverable and fatal handlers");
+  }
+
+  while (true) {
+    const raw = renderer.takeGpuUncapturedErrorJson();
+    if (raw === undefined || raw === null) {
+      return true;
+    }
+    const error = parseGpuError(raw, renderer.rendererBackend());
+    if (error.fatal) {
+      onFatal(error);
+      return false;
+    }
+    onRecoverable(error);
+  }
+}
+
+function parseGpuError(raw, backend) {
+  let error;
+  try {
+    error = JSON.parse(raw);
+  } catch (cause) {
+    throw new Error(`renderer returned invalid GPU error JSON: ${cause}`);
+  }
+  if (!error || typeof error !== "object") {
+    throw new Error("renderer GPU error must be an object");
+  }
+  if (!Number.isSafeInteger(error.generation) || error.generation <= 0) {
+    throw new Error("renderer GPU error generation must be a positive safe integer");
+  }
+  if (!["validation", "out_of_memory", "internal"].includes(error.kind)) {
+    throw new Error(`renderer GPU error has unknown kind ${error.kind}`);
+  }
+  if (typeof error.fatal !== "boolean") {
+    throw new Error("renderer GPU error fatal flag must be boolean");
+  }
+  if (typeof error.message !== "string" || error.message === "") {
+    throw new Error("renderer GPU error message must be non-empty");
+  }
+  const expectedFatal = error.kind !== "validation";
+  if (error.fatal !== expectedFatal) {
+    throw new Error(`renderer GPU error has inconsistent fatal flag for ${error.kind}`);
+  }
+  return Object.freeze({ ...error, backend });
+}

--- a/web/retained-execution-render-worker.js
+++ b/web/retained-execution-render-worker.js
@@ -1,4 +1,5 @@
 import init, { RetainedExecutionCanvasRenderer } from "./pkg/noon_web.js";
+import { drainRendererGpuErrors } from "./render-gpu-errors.js";
 import {
   EXECUTION_TRANSPORT_SHARED,
   EXECUTION_TRANSPORT_TRANSFERABLE,
@@ -46,11 +47,13 @@ async function handleMainMessage(message) {
         height = normalizedDimension(message.height);
         if (renderer !== null) {
           renderer.resize(width, height);
+          if (!drainGpuErrors()) return;
           needsPresent = true;
           tryPresent();
         }
         return;
       case "metrics":
+        if (!drainGpuErrors()) return;
         respond(message.requestId, { type: "metrics", metrics: currentMetrics() });
         return;
       case "stop":
@@ -104,6 +107,7 @@ function attachEngine(message) {
       `mixed retained render reconnect transport ${message.transportMode} does not match ${transportMode}`,
     );
   }
+  if (!drainGpuErrors()) return;
 
   renderPort.close?.();
   sharedReader = null;
@@ -117,6 +121,7 @@ function attachEngine(message) {
     retained: true,
     mixed: true,
     backend: renderer.rendererBackend(),
+    gpuGeneration: renderer.gpuGeneration(),
   });
 }
 
@@ -237,8 +242,10 @@ async function bootstrapRenderer(initial) {
       throw new Error("mixed retained execution renderer must begin from an applied snapshot");
     }
     renderer.resize(width, height);
+    if (!drainGpuErrors()) return;
     needsPresent = true;
     tryPresent();
+    if (!drainGpuErrors()) return;
     running = true;
     postMain({
       type: "ready",
@@ -246,6 +253,7 @@ async function bootstrapRenderer(initial) {
       retained: true,
       mixed: true,
       backend: renderer.rendererBackend(),
+      gpuGeneration: renderer.gpuGeneration(),
     });
     flushBootstrapQueue();
     drainTransport();
@@ -256,15 +264,16 @@ async function bootstrapRenderer(initial) {
 }
 
 function tryPresent() {
-  if (renderer === null || !needsPresent) {
+  if (renderer === null || !needsPresent || !drainGpuErrors()) {
     return false;
   }
   if (!renderer.render()) {
+    drainGpuErrors();
     return false;
   }
   needsPresent = false;
   presentedFrames += 1;
-  return true;
+  return drainGpuErrors();
 }
 
 function flushBootstrapQueue() {
@@ -296,7 +305,7 @@ function scheduleFrame() {
 }
 
 function frame(timestamp) {
-  if (!running) {
+  if (!running || !drainGpuErrors()) {
     return;
   }
   lastFrameTimestamp = timestamp;
@@ -308,8 +317,33 @@ function frame(timestamp) {
     flushBootstrapQueue();
     drainTransport();
   }
+  if (!running || !drainGpuErrors()) {
+    return;
+  }
   renderPort.postMessage({ type: "tick", timestamp });
   scheduleFrame();
+}
+
+function drainGpuErrors() {
+  if (renderer === null) return true;
+  try {
+    return drainRendererGpuErrors(renderer, {
+      onRecoverable(error) {
+        postMain({
+          type: "recoverable_error",
+          owner: "render",
+          message: error.message,
+          diagnostic: error,
+        });
+      },
+      onFatal(error) {
+        fail(new Error(error.message), null);
+      },
+    });
+  } catch (error) {
+    fail(error, null);
+    return false;
+  }
 }
 
 function currentMetrics() {
@@ -331,6 +365,7 @@ function currentMetrics() {
     mixed: true,
     transportMode,
     backend: renderer.rendererBackend(),
+    gpuGeneration: renderer.gpuGeneration(),
     time: renderer.time(),
     objectCount: renderer.objectCount(),
     drawCalls: renderer.lastDrawCalls(),

--- a/web/retained-execution-worker-client.js
+++ b/web/retained-execution-worker-client.js
@@ -27,18 +27,23 @@ export class RetainedExecutionWorkerClient {
   #ready = null;
   #playing = true;
   #onError;
+  #onRecoverableError;
   #fatalOwner = null;
   #staleWorkerEvents = { engine: 0, render: 0 };
 
-  constructor(canvas, { onError = null } = {}) {
+  constructor(canvas, { onError = null, onRecoverableError = null } = {}) {
     if (!(canvas instanceof HTMLCanvasElement)) {
       throw new TypeError("RetainedExecutionWorkerClient requires an HTMLCanvasElement");
     }
     if (onError !== null && typeof onError !== "function") {
       throw new TypeError("RetainedExecutionWorkerClient onError must be a function");
     }
+    if (onRecoverableError !== null && typeof onRecoverableError !== "function") {
+      throw new TypeError("RetainedExecutionWorkerClient onRecoverableError must be a function");
+    }
     this.#canvas = canvas;
     this.#onError = onError;
+    this.#onRecoverableError = onRecoverableError;
   }
 
   get canvas() {
@@ -363,6 +368,14 @@ export class RetainedExecutionWorkerClient {
             resolve(message);
             return;
           }
+          if (message.type === "recoverable_error") {
+            const error = new Error(
+              message.message || `${owner} mixed retained worker reported a recoverable error`,
+            );
+            error.diagnostic = message.diagnostic ?? null;
+            this.#notifyRecoverableError(error, owner);
+            return;
+          }
           if (message.type === "error") {
             const error = new Error(message.message || `${owner} mixed retained worker failed`);
             if (message.requestId === null || message.requestId === undefined) {
@@ -465,6 +478,14 @@ export class RetainedExecutionWorkerClient {
   #notifyError(error, owner) {
     this.#markFatalOwner(owner);
     this.#onError?.(error, owner);
+  }
+
+  #notifyRecoverableError(error, owner) {
+    if (this.#onRecoverableError !== null) {
+      this.#onRecoverableError(error, owner);
+      return;
+    }
+    console.warn(`[Noon retained execution] recoverable ${owner} error`, error);
   }
 
   #rememberPlaying(result) {


### PR DESCRIPTION
Superseded by #496, which consolidates the same worker propagation onto the existing main-thread GPU diagnostic policy through one bounded, generation-aware mailbox and adds explicit JS contract/burst coverage.

## Summary

Follows the direct `NoonCanvasPlayer` uncaptured-WebGPU-error contract merged in #481 and closes the remaining public OffscreenCanvas propagation gap for #111.

- add the same generation-scoped uncaptured GPU error policy to the normal and retained public execution renderers
- keep validation recoverable and one-shot; out-of-memory/internal errors remain terminal, with fatal errors taking precedence within a generation
- install `wgpu::Device::on_uncaptured_error` on the actual render-worker GPU devices
- treat `CurrentSurfaceTexture::Validation` as a retryable frame condition whose diagnostic is owned by the device error callback, avoiding recoverable+fatal double-reporting
- drain asynchronous GPU errors from both render-worker RAF loops, including periods with no pending scene delta
- expose renderer GPU generation in ready/metrics/reconnect responses
- route recoverable render errors through `ExecutionWorkerClient` and `RetainedExecutionWorkerClient` without marking the worker fatal
- preserve `AuthoringExecutionClient.onRecoverableError` when switching between legacy and retained execution
- preserve #453 engine-reconnect and retained-resource reconnect behavior unchanged

## Validation

Adds a separate real-browser oracle for the public worker path instead of replacing #481's direct-renderer validation test. The oracle:

- launches the production `execution-engine-worker.js` + `execution-render-worker.js` pair over transferable transport
- reuses #481's WebGPU device-capture helper, extended to support dedicated workers
- captures the actual render-worker `GPUDevice`
- creates a real uncaptured `GPUValidationError` with `createBuffer({ size: 4, usage: 0 })`
- requires exactly one recoverable render-worker diagnostic with WebGPU/generation context
- requires no fatal worker error, no device replacement, and no device loss
- requires backend, GPU generation, and scene object count to remain unchanged
- requires frame presentation to continue after the validation error

The target-independent precedence/storage policy also has native unit tests; only the `wgpu` conversion and device-handler installation are wasm-gated because `wgpu` is a wasm-only dependency of `noon-web`.

OOM/internal browser fault injection is intentionally not faked; those errors use the same terminal policy established by #481.

Related: #111, #481, #453.