### PR TITLE
Gate reactive dirty-closure locality at 10k branches

### DIFF
--- a/crates/noon-runtime/tests/reactive_dirty_closure.rs
+++ b/crates/noon-runtime/tests/reactive_dirty_closure.rs
@@ -1,0 +1,49 @@
+use noon_core::{GeometryRef, Property, ReactiveExpr, SemanticScene};
+use noon_runtime::{ReactiveRuntimeStats, SceneInstance};
+
+const BRANCH_COUNT: usize = 10_000;
+
+#[test]
+fn one_input_update_only_evaluates_its_reactive_branch_in_large_graph() {
+    let mut scene = SemanticScene::new();
+    let mut inputs = Vec::with_capacity(BRANCH_COUNT);
+
+    for _ in 0..BRANCH_COUNT {
+        let object = scene.add(GeometryRef::circle(1.0));
+        let input = scene.add_input(0.0_f32);
+        let derived = scene.add_derived(ReactiveExpr::Add(
+            Box::new(ReactiveExpr::signal(input)),
+            Box::new(ReactiveExpr::scalar(1.0)),
+        ));
+        scene.bind(derived, object, Property::Rotation);
+        inputs.push(input);
+    }
+
+    let target_index = BRANCH_COUNT / 2;
+    let target_input = inputs[target_index];
+    let mut instance =
+        SceneInstance::from_semantic(&scene).expect("large reactive graph must compile");
+    instance.take_frame_changes();
+
+    instance
+        .set_reactive_input(target_input, 5.0_f32)
+        .expect("single reactive input update must succeed");
+
+    assert_eq!(
+        instance.frame().objects[target_index].transform.rotation,
+        6.0
+    );
+    assert_eq!(
+        instance.take_frame_changes().object_indices(),
+        &[target_index]
+    );
+    assert_eq!(
+        instance.last_reactive_stats(),
+        ReactiveRuntimeStats {
+            derived_signals_evaluated: 1,
+            bindings_invalidated: 1,
+            dense_targets_applied: 1,
+            dense_targets_changed: 1,
+        }
+    );
+}


### PR DESCRIPTION
## Summary
- add a deterministic 10,000-branch reactive graph fixture
- update one input in the middle of the graph and require exactly one derived signal evaluation
- require exactly one binding invalidation, one dense target application/change, and one published frame-change index

## Why
#113 requires a large reactive graph where work is limited to the dirty dependency closure. Existing coverage proves one small reactive chain stays local in a scene with 50k unrelated static objects, but does not prove that unrelated reactive branches themselves are skipped.

## Architecture
Test-only. This exercises the existing `ReactiveRuntimeStats` and `FrameChanges` contracts; it adds no timing threshold, test hook, graph implementation, or alternate instrumentation.

## Parallelism
One new `noon-runtime` integration test file directly on current master. It does not overlap active execution-slot locality (#471), browser race/recovery work (#453/#482-#484), retained text/rendering (#442/#452/#475), or versioned resource mutation (#392).

## Validation
The initial head passed Manim differential, API coverage, raster differential, test coverage, cross-browser, browser authoring, WebGPU/WebGL rendering, and web-package validation. Main Rust CI stopped before Clippy/workspace tests solely because `cargo fmt --check` required two mechanical line wraps in this new test file.

Those exact rustfmt changes are now applied on head `ebae1a3b74103666b790683f47212ec2e92a225e`. All six required workflows are re-running on that exact head; do not merge until the refreshed Rust CI and remaining required lanes complete.

Tracks #113 and #68.