### PR TITLE
Prove authoring remains reusable after stress

### DIFF
--- a/web/authoring-out-of-order-races.test.mjs
+++ b/web/authoring-out-of-order-races.test.mjs
@@ -154,4 +154,17 @@ test("playground freshness admits only the newest result under seeded out-of-ord
   assert.equal(generations.diagnostics.staleDrops, requestCount - 1);
   assert.equal(client.diagnostics.pendingRequests, 0);
   assert.equal(client.terminated, false);
+
+  const postStress = client.run("result = post_stress");
+  await Promise.resolve();
+  assert.equal(worker.messages.at(-1).requestId, requestCount);
+  emitSceneResult(worker, requestCount, requestCount);
+  const postStressResult = await postStress;
+  assert.equal(postStressResult.document.objects[0].id, requestCount);
+  assert.deepEqual(client.diagnostics, {
+    nextRequestId: requestCount + 1,
+    pendingRequests: 0,
+    staleResponses: 0,
+    terminated: false,
+  });
 });


### PR DESCRIPTION
## Summary
- extend the canonical 500-request out-of-order authoring race from #434
- after all shuffled responses settle, issue request 501 and require it to resolve normally
- require final diagnostics to show the next request ID advanced, zero pending requests, zero stale protocol responses, and a live worker

## Why
#434 already owns the long stress and newest-generation freshness contract. This is intentionally a tiny follow-up rather than merging the duplicate #482 suite: it proves the worker is not merely non-terminated after stress, but actually remains usable for subsequent authoring.

Test-only; no production sequencing state is added.

Tracks #112.