### PR TITLE
Gate one-object property patch locality at 100k objects

### DIFF
--- a/crates/noon-runtime/tests/property_patch_locality.rs
+++ b/crates/noon-runtime/tests/property_patch_locality.rs
@@ -1,0 +1,66 @@
+use noon_compile::CompiledScene;
+use noon_core::{GeometryRef, SceneDefinition, ScenePatch, Transform2D, Vec2};
+use noon_runtime::SceneInstance;
+
+const OBJECT_COUNT: usize = 100_000;
+const TARGET_INDEX: usize = OBJECT_COUNT / 2;
+const UNTOUCHED_INDEX: usize = TARGET_INDEX + 1;
+
+#[test]
+fn property_patches_touch_only_one_object_in_a_100k_scene() {
+    let mut definition = SceneDefinition::new();
+    let mut objects = Vec::with_capacity(OBJECT_COUNT);
+    for _ in 0..OBJECT_COUNT {
+        objects.push(definition.add(GeometryRef::circle(1.0)));
+    }
+
+    let compiled = CompiledScene::compile(&definition).expect("large static scene must compile");
+    let mut live = SceneInstance::new(compiled);
+    live.take_frame_changes();
+
+    let target = objects[TARGET_INDEX];
+    let untouched_before = live.frame().objects[UNTOUCHED_INDEX].clone();
+    let transform = Transform2D {
+        translation: Vec2::new(3.0, -2.0),
+        ..Transform2D::IDENTITY
+    };
+    live.apply_patch(&ScenePatch::SetTransform {
+        object: target,
+        transform,
+    })
+    .expect("local transform patch must succeed");
+
+    let transform_stats = live.last_patch_stats();
+    assert_eq!(transform_stats.channels_relowered, 0);
+    assert_eq!(transform_stats.scheduler_events_removed, 0);
+    assert_eq!(transform_stats.scheduler_events_inserted, 0);
+    assert_eq!(transform_stats.object_slots_appended, 0);
+    assert_eq!(transform_stats.object_slots_retired, 0);
+    assert_eq!(transform_stats.track_locators_removed, 0);
+    assert_eq!(transform_stats.full_group_rebuilds, 0);
+    assert_eq!(transform_stats.full_seeks, 0);
+    assert_eq!(live.take_frame_changes().object_indices(), &[TARGET_INDEX]);
+    assert_eq!(live.frame().objects[TARGET_INDEX].transform, transform);
+    assert_eq!(live.frame().objects[UNTOUCHED_INDEX], untouched_before);
+
+    let mut style = live.frame().objects[TARGET_INDEX].style;
+    style.opacity = 0.25;
+    live.apply_patch(&ScenePatch::SetStyle {
+        object: target,
+        style,
+    })
+    .expect("local style patch must succeed");
+
+    let style_stats = live.last_patch_stats();
+    assert_eq!(style_stats.channels_relowered, 0);
+    assert_eq!(style_stats.scheduler_events_removed, 0);
+    assert_eq!(style_stats.scheduler_events_inserted, 0);
+    assert_eq!(style_stats.object_slots_appended, 0);
+    assert_eq!(style_stats.object_slots_retired, 0);
+    assert_eq!(style_stats.track_locators_removed, 0);
+    assert_eq!(style_stats.full_group_rebuilds, 0);
+    assert_eq!(style_stats.full_seeks, 0);
+    assert_eq!(live.take_frame_changes().object_indices(), &[TARGET_INDEX]);
+    assert_eq!(live.frame().objects[TARGET_INDEX].style, style);
+    assert_eq!(live.frame().objects[UNTOUCHED_INDEX], untouched_before);
+}


### PR DESCRIPTION
## Summary
- add a deterministic 100,000-object mostly-static runtime fixture
- apply one transform patch and one style patch to an object in the middle of the scene
- require each patch to publish exactly one changed object index
- require zero timeline relowering, scheduler churn, structural slot churn, track-locator removal, full group rebuilds, and full seeks
- verify an adjacent untouched object remains byte-for-byte identical

## Why
#113 explicitly requires one-object transform/style edits in large mostly-static scenes to stay proportional to affected state. Existing coverage already gates 100k unchanged frames and 100k structural create/remove locality, but there was no equivalent deterministic gate for ordinary property patches.

## Architecture
Test-only. The regression exercises the existing `RuntimePatchStats` and `FrameChanges` contracts and does not introduce timing thresholds, test hooks, or alternate instrumentation.

## Parallelism
One new `noon-runtime` integration test file directly on current master. It does not touch active execution-slot implementation (#471), host-callback locality (#486), reactive locality (#485), retained text/rendering, worker recovery, or versioned resource mutation.

## Validation
One commit / one file. Required workspace CI is the compile/format/Clippy/test authority for the exact head.

Tracks #113 and #68.