### PR TITLE
Fallback to WebGL when WebGPU device creation fails

### DIFF
--- a/.github/workflows/renderer-recovery.yml
+++ b/.github/workflows/renderer-recovery.yml
@@ -13,6 +13,8 @@ on:
       - "scripts/webgpu-device-capture.mjs"
       - "web/browser-smoke.html"
       - "web/browser-smoke.js"
+      - "web/execution-renderer-smoke.html"
+      - "web/execution-renderer-smoke.js"
   push:
     branches:
       - master
@@ -27,6 +29,8 @@ on:
       - "scripts/webgpu-device-capture.mjs"
       - "web/browser-smoke.html"
       - "web/browser-smoke.js"
+      - "web/execution-renderer-smoke.html"
+      - "web/execution-renderer-smoke.js"
   workflow_dispatch:
 
 permissions:

--- a/crates/noon-web/src/execution_canvas.rs
+++ b/crates/noon-web/src/execution_canvas.rs
@@ -32,6 +32,15 @@ mod wasm {
         }
     }
 
+    struct InitializedGpu {
+        instance: wgpu::Instance,
+        surface: wgpu::Surface<'static>,
+        device: wgpu::Device,
+        queue: wgpu::Queue,
+        backend: wgpu::Backend,
+        config: wgpu::SurfaceConfiguration,
+    }
+
     #[wasm_bindgen(js_name = ExecutionCanvasRenderer)]
     pub struct WasmExecutionCanvasRenderer {
         instance: wgpu::Instance,
@@ -71,43 +80,16 @@ mod wasm {
                 ));
             }
             let camera = mirror.camera();
-
-            let mut instance_descriptor = wgpu::InstanceDescriptor::new_without_display_handle();
-            instance_descriptor.backends = wgpu::Backends::BROWSER_WEBGPU | wgpu::Backends::GL;
-            instance_descriptor.display = Some(Box::new(WebDisplaySource));
-            let instance =
-                wgpu::util::new_instance_with_webgpu_detection(instance_descriptor).await;
-            let surface = create_surface(&instance, &canvas)?;
-            let adapter = instance
-                .request_adapter(&wgpu::RequestAdapterOptions {
-                    power_preference: wgpu::PowerPreference::HighPerformance,
-                    force_fallback_adapter: false,
-                    compatible_surface: Some(&surface),
-                })
-                .await
-                .map_err(js_error)?;
-            let backend = adapter.get_info().backend;
-            let required_limits = if backend == wgpu::Backend::Gl {
-                wgpu::Limits::downlevel_webgl2_defaults().using_resolution(adapter.limits())
-            } else {
-                wgpu::Limits::default()
-            };
-            let (device, queue) = adapter
-                .request_device(&wgpu::DeviceDescriptor {
-                    label: Some("Noon execution render worker GPU device"),
-                    required_features: wgpu::Features::empty(),
-                    required_limits,
-                    ..Default::default()
-                })
-                .await
-                .map_err(js_error)?;
-
             let width = canvas.width().max(1);
             let height = canvas.height().max(1);
-            let config = surface
-                .get_default_config(&adapter, width, height)
-                .ok_or_else(|| js_message("GPU adapter cannot present to this OffscreenCanvas"))?;
-            surface.configure(&device, &config);
+            let InitializedGpu {
+                instance,
+                surface,
+                device,
+                queue,
+                backend,
+                config,
+            } = initialize_gpu(&canvas, width, height).await?;
             let renderer = GpuRenderer::new(&device, config.format);
 
             let mut result = Self {
@@ -309,6 +291,133 @@ mod wasm {
         }
     }
 
+    async fn initialize_gpu(
+        canvas: &OffscreenCanvas,
+        width: u32,
+        height: u32,
+    ) -> Result<InitializedGpu, JsValue> {
+        let webgpu_error = if wgpu::util::is_browser_webgpu_supported().await {
+            match initialize_webgpu(canvas, width, height).await {
+                Ok(initialized) => return Ok(initialized),
+                Err(error) => Some(error),
+            }
+        } else {
+            None
+        };
+
+        initialize_webgl(canvas, width, height)
+            .await
+            .map_err(|webgl_error| {
+                if let Some(webgpu_error) = webgpu_error {
+                    js_message(&format!(
+                        "WebGPU initialization failed: {webgpu_error}; WebGL2 fallback failed: {webgl_error}"
+                    ))
+                } else {
+                    js_message(&format!("WebGL2 initialization failed: {webgl_error}"))
+                }
+            })
+    }
+
+    async fn initialize_webgpu(
+        canvas: &OffscreenCanvas,
+        width: u32,
+        height: u32,
+    ) -> Result<InitializedGpu, String> {
+        let instance = create_instance(wgpu::Backends::BROWSER_WEBGPU);
+        let adapter = instance
+            .request_adapter(&wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::HighPerformance,
+                force_fallback_adapter: false,
+                compatible_surface: None,
+            })
+            .await
+            .map_err(|error| error.to_string())?;
+        let backend = adapter.get_info().backend;
+        let (device, queue) = request_device(&adapter, backend).await?;
+
+        // Do not claim a canvas context until WebGPU has a usable device. Once a
+        // canvas is bound to WebGPU, browsers cannot reliably create WebGL2 from
+        // that same canvas for fallback.
+        let surface = create_surface(&instance, canvas).map_err(js_value_message)?;
+        let config = default_surface_config(&surface, &adapter, width, height)?;
+        surface.configure(&device, &config);
+        Ok(InitializedGpu {
+            instance,
+            surface,
+            device,
+            queue,
+            backend,
+            config,
+        })
+    }
+
+    async fn initialize_webgl(
+        canvas: &OffscreenCanvas,
+        width: u32,
+        height: u32,
+    ) -> Result<InitializedGpu, String> {
+        let instance = create_instance(wgpu::Backends::GL);
+        let surface = create_surface(&instance, canvas).map_err(js_value_message)?;
+        let adapter = instance
+            .request_adapter(&wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::HighPerformance,
+                force_fallback_adapter: false,
+                compatible_surface: Some(&surface),
+            })
+            .await
+            .map_err(|error| error.to_string())?;
+        let backend = adapter.get_info().backend;
+        let (device, queue) = request_device(&adapter, backend).await?;
+        let config = default_surface_config(&surface, &adapter, width, height)?;
+        surface.configure(&device, &config);
+        Ok(InitializedGpu {
+            instance,
+            surface,
+            device,
+            queue,
+            backend,
+            config,
+        })
+    }
+
+    fn create_instance(backends: wgpu::Backends) -> wgpu::Instance {
+        let mut descriptor = wgpu::InstanceDescriptor::new_without_display_handle();
+        descriptor.backends = backends;
+        descriptor.display = Some(Box::new(WebDisplaySource));
+        wgpu::Instance::new(descriptor)
+    }
+
+    async fn request_device(
+        adapter: &wgpu::Adapter,
+        backend: wgpu::Backend,
+    ) -> Result<(wgpu::Device, wgpu::Queue), String> {
+        let required_limits = if backend == wgpu::Backend::Gl {
+            wgpu::Limits::downlevel_webgl2_defaults().using_resolution(adapter.limits())
+        } else {
+            wgpu::Limits::default()
+        };
+        adapter
+            .request_device(&wgpu::DeviceDescriptor {
+                label: Some("Noon execution render worker GPU device"),
+                required_features: wgpu::Features::empty(),
+                required_limits,
+                ..Default::default()
+            })
+            .await
+            .map_err(|error| error.to_string())
+    }
+
+    fn default_surface_config(
+        surface: &wgpu::Surface<'_>,
+        adapter: &wgpu::Adapter,
+        width: u32,
+        height: u32,
+    ) -> Result<wgpu::SurfaceConfiguration, String> {
+        surface
+            .get_default_config(adapter, width, height)
+            .ok_or_else(|| "GPU adapter cannot present to this OffscreenCanvas".to_owned())
+    }
+
     fn create_surface(
         instance: &wgpu::Instance,
         canvas: &OffscreenCanvas,
@@ -316,6 +425,10 @@ mod wasm {
         instance
             .create_surface(wgpu::SurfaceTarget::OffscreenCanvas(canvas.clone()))
             .map_err(js_error)
+    }
+
+    fn js_value_message(value: JsValue) -> String {
+        value.as_string().unwrap_or_else(|| format!("{value:?}"))
     }
 
     fn js_error(error: impl std::fmt::Display) -> JsValue {

--- a/scripts/renderer-init-failure-smoke.mjs
+++ b/scripts/renderer-init-failure-smoke.mjs
@@ -17,6 +17,29 @@ const artifactDir = path.resolve(
     "browser-smoke-artifacts/renderer-init-failure",
 );
 
+const webglBrowserArgs = [
+  "--disable-features=WebGPU",
+  "--enable-unsafe-swiftshader",
+  "--ignore-gpu-blocklist",
+  "--use-gl=angle",
+  "--use-angle=swiftshader",
+  "--disable-gpu-sandbox",
+  "--disable-dev-shm-usage",
+];
+const webgpuBrowserArgs = [
+  "--enable-unsafe-webgpu",
+  "--enable-unsafe-swiftshader",
+  "--use-webgpu-adapter=swiftshader",
+  "--use-gpu-in-tests",
+  "--ignore-gpu-blocklist",
+  "--enable-features=Vulkan",
+  "--use-gl=angle",
+  "--use-angle=swiftshader",
+  "--use-vulkan=swiftshader",
+  "--disable-gpu-sandbox",
+  "--disable-dev-shm-usage",
+];
+
 await mkdir(artifactDir, { recursive: true });
 
 let serverOutput = "";
@@ -58,6 +81,17 @@ async function waitForHarness(page) {
   return page.evaluate(() => window.noonSmoke.metrics());
 }
 
+async function waitForExecutionRendererHarness(page) {
+  await page.goto(`${baseUrl}/web/execution-renderer-smoke.html`, { waitUntil: "load" });
+  await page.waitForFunction(() => window.noonExecutionRendererSmoke?.ready === true, null, {
+    timeout: 30_000,
+  });
+  return page.evaluate(() => ({
+    error: window.noonExecutionRendererSmoke.error,
+    metrics: window.noonExecutionRendererSmoke.metrics,
+  }));
+}
+
 function collectErrors(page) {
   const pageErrors = [];
   const consoleErrors = [];
@@ -82,19 +116,11 @@ try {
   browser = await chromium.launch({
     channel: "chromium",
     headless: true,
-    args: [
-      "--disable-features=WebGPU",
-      "--enable-unsafe-swiftshader",
-      "--ignore-gpu-blocklist",
-      "--use-gl=angle",
-      "--use-angle=swiftshader",
-      "--disable-gpu-sandbox",
-      "--disable-dev-shm-usage",
-    ],
+    args: webglBrowserArgs,
   });
 
-  // Scenario 1: WebGPU is unavailable, but the same production auto-selection
-  // path must fall back to WebGL2 and still present a real frame.
+  // Scenario 1: WebGPU is unavailable, but the main browser player must fall
+  // back to WebGL2 and still present a real frame.
   const fallbackPage = await browser.newPage({ viewport: { width: 1000, height: 600 } });
   const fallbackErrors = collectErrors(fallbackPage);
   const fallbackInitial = await waitForHarness(fallbackPage);
@@ -186,6 +212,94 @@ try {
   });
   await unavailablePage.close();
   console.log("✓ renderer init: both backends unavailable fails clearly without an unhandled exception");
+
+  await browser.close();
+  browser = await chromium.launch({
+    channel: "chromium",
+    headless: true,
+    args: webgpuBrowserArgs,
+  });
+
+  // Scenario 3 targets the OffscreenCanvas execution renderer directly. WebGPU
+  // remains discoverable and returns a real adapter, but device creation fails;
+  // the same renderer instance must then initialize WebGL2 and present its
+  // initial execution snapshot.
+  const deviceFailurePage = await browser.newPage({ viewport: { width: 1000, height: 600 } });
+  const deviceFailureErrors = collectErrors(deviceFailurePage);
+  await deviceFailurePage.addInitScript(() => {
+    const state = { patched: false, patchError: null, requestDeviceCalls: 0 };
+    window.__noonWebGpuInitFailure = state;
+    try {
+      const gpu = navigator.gpu;
+      if (!gpu || typeof gpu.requestAdapter !== "function") {
+        state.patchError = "navigator.gpu.requestAdapter is unavailable";
+        return;
+      }
+      const originalRequestAdapter = gpu.requestAdapter.bind(gpu);
+      Object.defineProperty(gpu, "requestAdapter", {
+        configurable: true,
+        value: async (...adapterArgs) => {
+          const adapter = await originalRequestAdapter(...adapterArgs);
+          if (!adapter) return adapter;
+          Object.defineProperty(adapter, "requestDevice", {
+            configurable: true,
+            value: async () => {
+              state.requestDeviceCalls += 1;
+              throw new DOMException(
+                "Noon injected WebGPU requestDevice failure",
+                "OperationError",
+              );
+            },
+          });
+          return adapter;
+        },
+      });
+      state.patched = true;
+    } catch (error) {
+      state.patchError = String(error);
+    }
+  });
+
+  const deviceFailure = await waitForExecutionRendererHarness(deviceFailurePage);
+  const injection = await deviceFailurePage.evaluate(() => window.__noonWebGpuInitFailure);
+  assert.equal(injection.patched, true, `WebGPU device-failure patch failed: ${injection.patchError}`);
+  assert.ok(injection.requestDeviceCalls >= 1, "WebGPU requestDevice failure was not exercised");
+  assert.equal(
+    deviceFailure.error,
+    null,
+    `WebGPU device failure did not fall back cleanly: ${deviceFailure.error}`,
+  );
+  assert.equal(
+    deviceFailure.metrics?.rendererBackend,
+    "WebGL2",
+    `WebGPU device failure selected ${deviceFailure.metrics?.rendererBackend}`,
+  );
+  assert.equal(
+    deviceFailure.metrics?.presented,
+    true,
+    "device-init fallback did not present a frame",
+  );
+  assert.ok(
+    deviceFailure.metrics?.drawCalls > 0,
+    "device-init fallback emitted no draw calls",
+  );
+  assert.ok(
+    deviceFailure.metrics?.objectCount > 0,
+    "device-init fallback lost the initial execution snapshot",
+  );
+  assert.deepEqual(
+    deviceFailureErrors.pageErrors,
+    [],
+    `device-init fallback emitted page errors: ${deviceFailureErrors.pageErrors.join("\n")}`,
+  );
+  await writeDiagnostics("webgpu-device-failure-fallback", {
+    browserVersion: browser.version(),
+    injection,
+    ...deviceFailure,
+    ...deviceFailureErrors,
+  });
+  await deviceFailurePage.close();
+  console.log("✓ execution renderer init: WebGPU device failure falls back to WebGL2 and presents");
 } catch (error) {
   await writeDiagnostics("failure", {
     browserVersion: browser?.version() ?? null,

--- a/web/execution-renderer-smoke.html
+++ b/web/execution-renderer-smoke.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Noon execution renderer smoke</title>
+  </head>
+  <body>
+    <script type="module" src="./execution-renderer-smoke.js"></script>
+  </body>
+</html>

--- a/web/execution-renderer-smoke.js
+++ b/web/execution-renderer-smoke.js
@@ -1,0 +1,41 @@
+import init, {
+  EngineScenePlayer,
+  ExecutionCanvasRenderer,
+  demoSceneJson,
+} from "./pkg/noon_web.js";
+
+const state = {
+  ready: false,
+  error: null,
+  metrics: null,
+};
+
+window.noonExecutionRendererSmoke = state;
+
+async function start() {
+  await init();
+  const engine = new EngineScenePlayer(demoSceneJson(), 4.0, 1);
+  const initialDelta = engine.initialDeltaJson();
+  const canvas = new OffscreenCanvas(960, 540);
+  const renderer = await ExecutionCanvasRenderer.create(canvas, initialDelta);
+  renderer.resize(canvas.width, canvas.height);
+
+  let presented = false;
+  for (let attempt = 0; attempt < 4 && !presented; attempt += 1) {
+    presented = renderer.render();
+  }
+
+  state.metrics = {
+    rendererBackend: renderer.rendererBackend(),
+    presented,
+    drawCalls: renderer.lastDrawCalls(),
+    objectCount: renderer.objectCount(),
+  };
+  state.ready = true;
+}
+
+start().catch((error) => {
+  state.error = String(error);
+  state.ready = true;
+  console.error(error);
+});


### PR DESCRIPTION
## Summary
- harden the OffscreenCanvas `ExecutionCanvasRenderer` initialization path used by the execution render worker / raster host
- prefer WebGPU, but defer claiming the OffscreenCanvas until adapter and device creation succeed
- if WebGPU adapter/device initialization fails before surface creation, retry with a fresh WebGL2-only wgpu instance on the same canvas
- keep fallback policy inside the Rust renderer instead of introducing JS retry/replacement state
- add a direct browser harness for `ExecutionCanvasRenderer` and a real Chromium oracle that injects `GPUAdapter.requestDevice()` failure, then requires a presented WebGL2 execution snapshot

## Why
The existing fallback smoke covered WebGPU being absent, but the OffscreenCanvas renderer could still strand a usable WebGL2 backend when WebGPU was discoverable and an adapter existed but `requestDevice()` failed. Its old constructor also created the canvas surface before device acquisition; after a WebGPU context claims a canvas, switching that same canvas to WebGL is not a reliable fallback strategy.

## Architecture
Initialization now treats surface creation as the backend commit point. WebGPU adapter/device acquisition happens first with no compatible surface. Only after a usable WebGPU device exists does it claim the OffscreenCanvas. A pre-surface WebGPU failure can therefore fall through to a clean GL-only instance without replacing the canvas, semantic runtime, or frontend lifecycle state.

The main-thread `NoonCanvasPlayer` has a separate GPU initialization/recovery implementation in `legacy.rs`; this PR intentionally does not refactor that recently stabilized recovery lane. The new oracle directly exercises the OffscreenCanvas renderer changed here, so test ownership matches production ownership.

## Validation
- existing initialization smoke still covers main-thread WebGPU-unavailable -> WebGL2 and both-backends-unavailable diagnostics
- new lightweight execution-renderer smoke builds a demo execution snapshot through `EngineScenePlayer.initialDeltaJson()` and presents it via `ExecutionCanvasRenderer`
- WebGPU-enabled Chromium intercepts the real adapter's `requestDevice()`, injects a deterministic failure, and requires the OffscreenCanvas renderer to report `WebGL2`, retain objects, emit draw calls, and present the initial snapshot

Related: #111.