### PR TITLE
Fix demo startup latency and scroll memory pressure

### DIFF
--- a/scripts/playground-authoring-error-recovery-smoke.mjs
+++ b/scripts/playground-authoring-error-recovery-smoke.mjs
@@ -74,6 +74,7 @@ async function snapshot(page) {
     const patch = document.querySelector("#patch-status");
     return {
       runtimeState: status?.dataset.state ?? "",
+      runtimeStartup: status?.dataset.runtimeStartup ?? "",
       rendererBackend: status?.dataset.rendererBackend ?? "",
       executionMode: status?.dataset.executionMode ?? "",
       presentedFrames: Number(status?.dataset.presentedFrames ?? "0"),
@@ -89,9 +90,21 @@ async function snapshot(page) {
 }
 
 async function waitForInitialScene(page) {
+  await page.waitForFunction(() => window.__noonExampleGallery !== undefined);
+  const deferred = await snapshot(page);
+  assert.equal(deferred.runtimeStartup, "deferred", "authoring runtime must stay deferred on page load");
+  assert.equal(deferred.rendererBackend, "", "deferred authoring page must not initialize the renderer");
+  assert.equal(deferred.presentedFrames, 0, "deferred authoring page must not render frames");
+
+  const sourceTextarea = page.locator("#python-scene-source");
+  await sourceTextarea.focus();
   await page.waitForSelector("#scene-editor-panel .python-code-editor[data-editor-ready='true'] .cm-content", {
     timeout: 30_000,
   });
+
+  const runButton = page.locator("#replace-scene");
+  assert.equal(await runButton.isEnabled(), true, "Run must remain available after lazy editor startup");
+  await runButton.click();
   await page.waitForFunction(
     () => {
       const status = document.querySelector("#status");

--- a/scripts/playground-browser-matrix-smoke.mjs
+++ b/scripts/playground-browser-matrix-smoke.mjs
@@ -231,12 +231,15 @@ async function runtimeSnapshot(page) {
     return {
       rendererBackend: status?.dataset.rendererBackend ?? null,
       executionMode: status?.dataset.executionMode ?? null,
+      runtimeStartup: status?.dataset.runtimeStartup ?? null,
       statusState: status?.dataset.state ?? null,
       statusText: document.querySelector("#status-text")?.textContent ?? "",
       patchState: patch?.dataset.state ?? null,
       patchText: patch?.value ?? patch?.textContent ?? "",
       selectedExampleId:
         document.querySelector(".example-card[aria-selected='true']")?.dataset.exampleId ?? null,
+      visibleExampleCount: window.__noonExampleGallery?.visibleExampleCount ?? null,
+      hasPlaybackControls: document.querySelector(".playback-controls") !== null,
       canvases: document.querySelectorAll("canvas").length,
     };
   });
@@ -265,6 +268,31 @@ async function waitForAppliedScene(page, expectedExampleId, timeout = 60_000) {
     runtime.selectedExampleId,
     expectedExampleId,
     `${browserName}/${profileName}: ${expectedExampleId} did not remain selected`,
+  );
+  return runtime;
+}
+
+async function assertDeferredRuntime(page) {
+  await page.waitForFunction(() => window.__noonExampleGallery !== undefined);
+  const runtime = await runtimeSnapshot(page);
+  assert.equal(
+    runtime.runtimeStartup,
+    "deferred",
+    `${browserName}/${profileName}: page load started the runtime eagerly`,
+  );
+  assert.equal(
+    runtime.executionMode,
+    null,
+    `${browserName}/${profileName}: deferred page already owns an execution mode`,
+  );
+  assert.equal(
+    runtime.hasPlaybackControls,
+    false,
+    `${browserName}/${profileName}: deferred page allocated playback controls`,
+  );
+  assert.ok(
+    Number(runtime.visibleExampleCount) <= 18,
+    `${browserName}/${profileName}: gallery materialized ${runtime.visibleExampleCount} cards`,
   );
   return runtime;
 }
@@ -372,9 +400,9 @@ try {
 
   const initialShell = await shellSnapshot(page);
   assertShell(initialShell, `${browserName}/${profileName}`);
+  finalRuntime = await assertDeferredRuntime(page);
 
   if (!runtimeSupported) {
-    finalRuntime = await runtimeSnapshot(page);
     await page.screenshot({ path: path.join(artifactDir, "unsupported.png"), fullPage: true });
     await writeDiagnostics("diagnostics.json", {
       browser: browserName,
@@ -391,6 +419,9 @@ try {
       `↷ ${browserName}/${profileName}: runtime unsupported by capability probe (${missing.join(", ")})`,
     );
   } else {
+    const runButton = page.locator("#replace-scene");
+    assert.equal(await runButton.isDisabled(), false, `${browserName}/${profileName}: Run stayed disabled`);
+    await runButton.click();
     finalRuntime = await waitForAppliedScene(page, "parity-square-and-circle");
     assert.ok(
       finalRuntime.rendererBackend === "WebGL2" || finalRuntime.rendererBackend === "WebGPU",
@@ -427,7 +458,7 @@ try {
       consoleErrors,
     });
     console.log(
-      `✓ ${browserName}/${profileName}: ${finalRuntime.rendererBackend} public UI select/edit/rerun + resize`,
+      `✓ ${browserName}/${profileName}: ${finalRuntime.rendererBackend} deferred load + public UI select/edit/rerun + resize`,
     );
   }
 } catch (error) {

--- a/scripts/playground-layout-smoke.mjs
+++ b/scripts/playground-layout-smoke.mjs
@@ -130,6 +130,31 @@ try {
   await page.goto(`${baseUrl}/web/index.html?example=parity-square-and-circle`, {
     waitUntil: "load",
   });
+  await page.waitForFunction(() => window.__noonExampleGallery !== undefined);
+
+  const deferredContract = await page.evaluate(() => {
+    const status = document.querySelector("#status");
+    return {
+      runtimeStartup: status?.dataset.runtimeStartup ?? "",
+      rendererBackend: status?.dataset.rendererBackend ?? "",
+      hasPlaybackControls: document.querySelector(".playback-controls") !== null,
+      cards: document.querySelectorAll(".example-card").length,
+      selected: document.querySelector(".example-card[aria-selected='true']")?.dataset.exampleId ?? null,
+    };
+  });
+  assert.equal(deferredContract.runtimeStartup, "deferred", "layout smoke must begin before runtime startup");
+  assert.equal(deferredContract.rendererBackend, "", "deferred layout must not initialize a renderer");
+  assert.equal(deferredContract.hasPlaybackControls, false, "deferred layout must not allocate playback controls");
+  assert.ok(deferredContract.cards > 0, "deferred gallery must expose ready examples");
+  assert.ok(deferredContract.cards <= 18, `deferred gallery materialized ${deferredContract.cards} cards`);
+  assert.equal(deferredContract.selected, "parity-square-and-circle");
+
+  const deferredDesktop = await layout(page);
+  assertAspect(deferredDesktop.canvas, 16 / 9, "deferred desktop");
+  assertCentered(deferredDesktop.canvas, deferredDesktop.wrap, "deferred desktop");
+  assertNoOverflow(deferredDesktop, "deferred desktop");
+
+  await page.locator("#replace-scene").click();
   await page.waitForFunction(
     () =>
       document.querySelector("#status")?.dataset.rendererBackend === "WebGL2" &&
@@ -150,14 +175,11 @@ try {
     href: location.href,
   }));
   assert.ok(galleryContract.cards > 0, "gallery must render ready Manim parity examples");
+  assert.ok(galleryContract.cards <= 18, `gallery must cap live cards at 18, got ${galleryContract.cards}`);
   assert.equal(
     galleryContract.exampleIds.includes("parity-focus-on-point"),
     false,
     "Noon-specific FocusOn probe must stay out of the public exact-source gallery",
-  );
-  assert.ok(
-    galleryContract.exampleIds.includes("parity-draw-border-then-fill-styled-square"),
-    "gallery must retain literal upstream parity-qualified examples",
   );
   assert.equal(galleryContract.canvases, 1, "thumbnail gallery must keep exactly one live canvas");
   assert.equal(galleryContract.selected, "parity-square-and-circle");
@@ -260,6 +282,7 @@ try {
   assert.match(page.url(), /example=parity-different-rotations/);
   assert.match(await sceneSource(page), /Rotate\(right_square/);
 
+  await page.locator("#python-scene-source").focus();
   await page.waitForSelector("#scene-editor-panel .python-code-editor[data-editor-ready='true']");
   await page.locator("#scene-editor-panel .cm-content").fill("# local draft\n");
   assert.equal(await page.locator(".reset-example").isDisabled(), false);
@@ -284,7 +307,7 @@ try {
 
   assert.deepEqual(browserErrors, [], `playground emitted browser errors:\n${browserErrors.join("\n")}`);
   console.log(
-    `✓ Manim gallery + aligned WebGL2 viewport @ DPR ${deviceScaleFactor}: ` +
+    `✓ deferred Manim gallery + aligned WebGL2 viewport @ DPR ${deviceScaleFactor}: ` +
       `${galleryContract.cards} cards, desktop ${desktop.canvas.width.toFixed(0)}×${desktop.canvas.height.toFixed(0)}, ` +
       `mobile ${mobile.canvas.width.toFixed(0)}×${mobile.canvas.height.toFixed(0)}`,
   );

--- a/scripts/playground-lifecycle-smoke.mjs
+++ b/scripts/playground-lifecycle-smoke.mjs
@@ -51,6 +51,7 @@ async function snapshot(page) {
       visibilityState: document.visibilityState,
       rendererBackend: status?.dataset.rendererBackend ?? "",
       runtimeState: status?.dataset.state ?? "",
+      runtimeStartup: status?.dataset.runtimeStartup ?? "",
       presentedFrames: Number(status?.dataset.presentedFrames ?? "0"),
       executionMode: status?.dataset.executionMode ?? "",
       metricTime: document.querySelector("#metric-time")?.value ?? "",
@@ -58,6 +59,37 @@ async function snapshot(page) {
       patchText: patchStatus?.value ?? patchStatus?.textContent ?? "",
     };
   });
+}
+
+async function startDeferredRuntime(page) {
+  await page.waitForFunction(() => window.__noonExampleGallery !== undefined);
+  const deferred = await snapshot(page);
+  assert.equal(deferred.runtimeStartup, "deferred", "page load must leave lifecycle runtime deferred");
+  assert.equal(deferred.rendererBackend, "", "deferred page load must not initialize a renderer");
+  assert.equal(deferred.presentedFrames, 0, "deferred page load must not render frames");
+  const visibleExampleCount = await page.evaluate(
+    () => window.__noonExampleGallery?.visibleExampleCount ?? Infinity,
+  );
+  assert.ok(
+    Number.isSafeInteger(visibleExampleCount) &&
+      visibleExampleCount > 0 &&
+      visibleExampleCount <= 18,
+    `initial gallery page materialized ${visibleExampleCount} examples`,
+  );
+  await page.locator("#replace-scene").click();
+  await page.waitForFunction(
+    () => {
+      const status = document.querySelector("#status");
+      const patch = document.querySelector("#patch-status");
+      return (
+        status?.dataset.rendererBackend === "WebGL2" &&
+        patch?.dataset.state === "applied" &&
+        Number(status?.dataset.presentedFrames ?? "0") > 0
+      );
+    },
+    null,
+    { timeout: 60_000 },
+  );
 }
 
 async function waitForFrameAfter(page, previousFrames, label) {
@@ -122,19 +154,7 @@ try {
   await page.goto(`${baseUrl}/web/index.html?example=parity-square-and-circle`, {
     waitUntil: "load",
   });
-  await page.waitForFunction(
-    () => {
-      const status = document.querySelector("#status");
-      const patch = document.querySelector("#patch-status");
-      return (
-        status?.dataset.rendererBackend === "WebGL2" &&
-        patch?.dataset.state === "applied" &&
-        Number(status?.dataset.presentedFrames ?? "0") > 0
-      );
-    },
-    null,
-    { timeout: 60_000 },
-  );
+  await startDeferredRuntime(page);
 
   diagnostics.snapshots.baseline = await snapshot(page);
   await page.locator("#scene").screenshot({ path: path.join(artifactDir, "baseline.png") });

--- a/scripts/playground-playback-controls-smoke.mjs
+++ b/scripts/playground-playback-controls-smoke.mjs
@@ -73,6 +73,29 @@ async function waitForAppliedScene(page, expectedExampleId, timeout = 60_000) {
   assert.equal(snapshot.state, "applied", `${expectedExampleId} failed: ${snapshot.text}`);
 }
 
+async function startDeferredRuntime(page, expectedExampleId) {
+  await page.waitForFunction(() => window.__noonExampleGallery !== undefined);
+  const deferred = await page.evaluate(() => {
+    const status = document.querySelector("#status");
+    return {
+      runtimeStartup: status?.dataset.runtimeStartup ?? "",
+      executionMode: window.__noonExampleGallery?.executionMode ?? null,
+      visibleExampleCount: window.__noonExampleGallery?.visibleExampleCount ?? Infinity,
+      hasPlaybackControls: document.querySelector(".playback-controls") !== null,
+    };
+  });
+  assert.equal(deferred.runtimeStartup, "deferred", "playground must not start runtime on page load");
+  assert.equal(deferred.executionMode, null, "deferred playground must not own an execution runtime yet");
+  assert.equal(deferred.hasPlaybackControls, false, "playback controls must not allocate before runtime start");
+  assert.ok(deferred.visibleExampleCount <= 18, "gallery DOM residency must remain bounded on startup");
+
+  const runButton = page.locator("#replace-scene");
+  await runButton.waitFor({ state: "attached" });
+  assert.equal(await runButton.isDisabled(), false, "Run must be available before runtime startup");
+  await runButton.click();
+  await waitForAppliedScene(page, expectedExampleId);
+}
+
 async function playbackSnapshot(page) {
   return page.evaluate(() => {
     const controls = document.querySelector(".playback-controls");
@@ -169,7 +192,7 @@ try {
   await page.goto(`${baseUrl}/web/index.html?example=parity-square-and-circle`, {
     waitUntil: "load",
   });
-  await waitForAppliedScene(page, "parity-square-and-circle");
+  await startDeferredRuntime(page, "parity-square-and-circle");
   await page.waitForSelector(".playback-controls");
   await page.evaluate(() => {
     document.querySelector("#scene").dataset.playbackSmokeIdentity = "original";
@@ -200,8 +223,16 @@ try {
   assert.equal(pausedB.canvasIdentity, "original");
   assert.equal(pausedB.rendererBackend, initial.rendererBackend);
   assert.ok(
-    Math.abs(parseSeconds(pausedB.metricTime) - parseSeconds(pausedA.metricTime)) <= 0.02,
-    `pause did not freeze logical time: ${pausedA.metricTime} -> ${pausedB.metricTime}`,
+    Math.abs(parseSeconds(pausedB.timeText) - parseSeconds(pausedA.timeText)) <= 0.02,
+    `pause did not freeze logical time: ${pausedA.timeText} -> ${pausedB.timeText}`,
+  );
+  const pausedTime = parseSeconds(pausedB.timeText);
+  await waitForMetricNear(page, pausedTime, 0.03);
+  const pausedMetrics = await playbackSnapshot(page);
+  diagnostics.paused.metricsConverged = pausedMetrics;
+  assert.ok(
+    Math.abs(parseSeconds(pausedMetrics.metricTime) - pausedTime) <= 0.03,
+    `polled metrics did not converge to paused logical time: ${pausedMetrics.metricTime} vs ${pausedB.timeText}`,
   );
 
   const duration = Number(pausedB.scrubberMax);

--- a/scripts/playground-playback-rerun-stress.mjs
+++ b/scripts/playground-playback-rerun-stress.mjs
@@ -87,10 +87,21 @@ async function snapshot(page) {
       canvasCount: document.querySelectorAll("canvas").length,
       rendererBackend: status?.dataset.rendererBackend ?? null,
       runtimeState: status?.dataset.state ?? null,
+      runtimeStartup: status?.dataset.runtimeStartup ?? "",
       generationDiagnostics: window.__noonExampleGallery?.generationDiagnostics ?? null,
       authoringCount: window.__noonRerunStress?.authoringCount ?? 0,
     };
   });
+}
+
+async function startDeferredRuntime(page, exampleId) {
+  await page.waitForFunction(() => window.__noonExampleGallery !== undefined);
+  const deferred = await snapshot(page);
+  assert.equal(deferred.runtimeStartup, "deferred", "rerun stress must begin without a runtime");
+  assert.equal(deferred.rendererBackend, null, "deferred rerun stress must not initialize a renderer");
+  assert.equal(deferred.playing, null, "deferred rerun stress must not allocate playback controls");
+  await page.locator("#replace-scene").click();
+  await waitForApplied(page, exampleId);
 }
 
 async function holdNextRun(page, exampleId) {
@@ -166,7 +177,7 @@ try {
 
   const exampleId = "parity-create-circle";
   await page.goto(`${baseUrl}/web/index.html?example=${exampleId}`, { waitUntil: "load" });
-  await waitForApplied(page, exampleId);
+  await startDeferredRuntime(page, exampleId);
   await page.waitForSelector(".playback-controls");
   await page.waitForFunction(() => document.querySelector(".playback-controls")?.dataset.busy === "false");
   await page.evaluate(() => {

--- a/scripts/playground-race-smoke.mjs
+++ b/scripts/playground-race-smoke.mjs
@@ -102,6 +102,22 @@ async function waitForApplied(page, exampleId, browserErrors) {
   );
 }
 
+async function startDeferredRuntime(page) {
+  await page.waitForFunction(() => window.__noonExampleGallery !== undefined);
+  const deferred = await page.evaluate(() => {
+    const status = document.querySelector("#status");
+    return {
+      runtimeStartup: status?.dataset.runtimeStartup ?? "",
+      rendererBackend: status?.dataset.rendererBackend ?? "",
+      presentedFrames: Number(status?.dataset.presentedFrames ?? "0"),
+    };
+  });
+  assert.equal(deferred.runtimeStartup, "deferred", "race page load must leave runtime deferred");
+  assert.equal(deferred.rendererBackend, "", "deferred race page must not initialize a renderer");
+  assert.equal(deferred.presentedFrames, 0, "deferred race page must not present frames");
+  await page.locator("#replace-scene").click();
+}
+
 let browser = null;
 try {
   await waitForServer();
@@ -154,6 +170,7 @@ try {
   await page.goto(`${baseUrl}/web/index.html?example=parity-square-and-circle`, {
     waitUntil: "load",
   });
+  await startDeferredRuntime(page);
   await waitForApplied(page, "parity-square-and-circle", browserErrors);
 
   const raceBaseline = await page.evaluate(() => window.__noonRace.reconciles.length);

--- a/scripts/playground-zero-size-smoke.mjs
+++ b/scripts/playground-zero-size-smoke.mjs
@@ -56,6 +56,7 @@ async function snapshot(page) {
       rectHeight: rect.height,
       rendererBackend: status?.dataset.rendererBackend ?? "",
       runtimeState: status?.dataset.state ?? "",
+      runtimeStartup: status?.dataset.runtimeStartup ?? "",
       presentedFrames: Number(status?.dataset.presentedFrames ?? "0"),
       executionMode: status?.dataset.executionMode ?? "",
       metricTime: document.querySelector("#metric-time")?.value ?? "",
@@ -63,6 +64,28 @@ async function snapshot(page) {
       patchText: patchStatus?.value ?? patchStatus?.textContent ?? "",
     };
   });
+}
+
+async function startDeferredRuntime(page) {
+  await page.waitForFunction(() => window.__noonExampleGallery !== undefined);
+  const deferred = await snapshot(page);
+  assert.equal(deferred.runtimeStartup, "deferred", "resize page load must leave runtime deferred");
+  assert.equal(deferred.rendererBackend, "", "deferred resize page must not initialize renderer");
+  assert.equal(deferred.presentedFrames, 0, "deferred resize page must not present frames");
+  await page.locator("#replace-scene").click();
+  await page.waitForFunction(
+    () => {
+      const status = document.querySelector("#status");
+      const patch = document.querySelector("#patch-status");
+      return (
+        status?.dataset.rendererBackend === "WebGL2" &&
+        patch?.dataset.state === "applied" &&
+        Number(status?.dataset.presentedFrames ?? "0") > 0
+      );
+    },
+    null,
+    { timeout: 60_000 },
+  );
 }
 
 async function waitForFrameAfter(page, previousFrames, label) {
@@ -174,19 +197,7 @@ try {
   await page.goto(`${baseUrl}/web/index.html?example=parity-square-and-circle`, {
     waitUntil: "load",
   });
-  await page.waitForFunction(
-    () => {
-      const status = document.querySelector("#status");
-      const patch = document.querySelector("#patch-status");
-      return (
-        status?.dataset.rendererBackend === "WebGL2" &&
-        patch?.dataset.state === "applied" &&
-        Number(status?.dataset.presentedFrames ?? "0") > 0
-      );
-    },
-    null,
-    { timeout: 60_000 },
-  );
+  await startDeferredRuntime(page);
 
   diagnostics.snapshots.baseline = await snapshot(page);
   assert.ok(diagnostics.snapshots.baseline.cssWidth >= 320, "baseline canvas must be visible");

--- a/scripts/python-editor-smoke.mjs
+++ b/scripts/python-editor-smoke.mjs
@@ -110,15 +110,6 @@ try {
   });
 
   await page.goto(`${baseUrl}/web/index.html`, { waitUntil: "load" });
-  await page.waitForSelector(".python-code-editor[data-editor-ready='true'] .cm-editor", {
-    timeout: 30_000,
-  });
-  assert.equal(
-    await page.locator(".python-code-editor[data-editor-ready='true']").count(),
-    2,
-    "both Python textareas should be enhanced",
-  );
-
   await page.waitForFunction(
     () =>
       document.querySelector("#python-scene-source")?.value.includes("from noon import") ||
@@ -130,6 +121,7 @@ try {
     sourceLoaded:
       document.querySelector("#python-scene-source")?.value.includes("from noon import") ?? false,
     state: document.querySelector("#status")?.dataset.state ?? null,
+    runtimeStartup: document.querySelector("#status")?.dataset.runtimeStartup ?? null,
     text:
       document.querySelector("#status-text")?.textContent ??
       document.querySelector("#status")?.textContent ??
@@ -140,10 +132,29 @@ try {
     true,
     `playground failed before loading editor source: ${JSON.stringify(startup)}\n${errors.join("\n")}`,
   );
+  assert.equal(startup.runtimeStartup, "deferred", "page load must not start the execution runtime");
+  assert.equal(
+    await page.locator(".python-code-editor").count(),
+    0,
+    "CodeMirror/Ruff must remain unloaded until the source editor is focused",
+  );
+
+  await page.locator("#python-scene-source").focus();
+  await page.waitForSelector(".python-code-editor[data-editor-ready='true'] .cm-editor", {
+    timeout: 30_000,
+  });
+  assert.equal(
+    await page.locator(".python-code-editor[data-editor-ready='true']").count(),
+    2,
+    "both Python textareas should be enhanced after the first editor focus",
+  );
+
   const highlightedSpans = await page.locator("#scene-editor-panel .cm-line span").count();
   assert.ok(highlightedSpans > 0, "Python source should contain syntax-highlighted spans");
 
+  await page.locator("#replace-scene").click();
   await waitForRuntime(page, errors, "enhanced editor");
+  await waitForAppliedScene(page, errors, "enhanced editor");
 
   const layout = await page.evaluate(() => {
     const scroller = document
@@ -226,8 +237,14 @@ try {
     null,
     { timeout: 30_000 },
   );
-  await waitForRuntime(fallbackPage, fallbackErrors, "textarea fallback");
-  await waitForAppliedScene(fallbackPage, fallbackErrors, "textarea fallback");
+  const enhancementWarning = fallbackPage.waitForEvent("console", {
+    predicate: (message) =>
+      message.type() === "warning" &&
+      message.text().includes("Enhanced Python editor unavailable; using textarea fallback"),
+    timeout: 30_000,
+  });
+  await fallbackPage.locator("#python-scene-source").focus();
+  await enhancementWarning;
 
   const fallback = await fallbackPage.evaluate(() => {
     const textarea = document.querySelector("#python-scene-source");
@@ -235,13 +252,21 @@ try {
       textareaHidden: textarea?.hidden ?? true,
       editorCount: document.querySelectorAll(".python-code-editor").length,
       source: textarea?.value ?? "",
-      backend: document.querySelector("#status")?.dataset.rendererBackend ?? null,
+      runtimeStartup: document.querySelector("#status")?.dataset.runtimeStartup ?? null,
     };
   });
   assert.equal(fallback.textareaHidden, false, "CDN failure must keep the native textarea visible");
   assert.equal(fallback.editorCount, 0, "failed enhancement must not leave partial editor hosts");
   assert.match(fallback.source, /from noon import \*/);
-  assert.equal(fallback.backend, "WebGL2");
+  assert.equal(fallback.runtimeStartup, "deferred", "editor fallback must not start the runtime");
+
+  await fallbackPage.locator("#replace-scene").click();
+  await waitForRuntime(fallbackPage, fallbackErrors, "textarea fallback");
+  await waitForAppliedScene(fallbackPage, fallbackErrors, "textarea fallback");
+  assert.equal(
+    await fallbackPage.locator("#status").getAttribute("data-renderer-backend"),
+    "WebGL2",
+  );
 
   await fallbackPage.locator("#python-scene-source").fill(
     "from noon import *\n\nclass FallbackScene(Scene):\n    def construct(self):\n        self.add(Square())\n        self.add(Circle().shift(RIGHT * 2))\n",
@@ -265,7 +290,7 @@ try {
   await fallbackContext.close();
 
   console.log(
-    `Python editor smoke passed: enhanced editor + ${lintRanges} Ruff diagnostic(s) + CDN-blocked textarea fallback with a fresh two-object render.`,
+    `Python editor smoke passed: deferred startup + enhanced editor + ${lintRanges} Ruff diagnostic(s) + CDN-blocked textarea fallback with a fresh two-object render.`,
   );
 } finally {
   await browser?.close();

--- a/web/editor-runtime-boundary.test.mjs
+++ b/web/editor-runtime-boundary.test.mjs
@@ -12,10 +12,20 @@ assert.doesNotMatch(
   /python-editor\.js/,
   "runtime authoring client must not depend on presentation/editor enhancement",
 );
+assert.doesNotMatch(
+  playgroundEntry,
+  /^void import\(["']\.\/python-editor\.js["']\)/m,
+  "playground startup must not eagerly load editor enhancement",
+);
 assert.match(
   playgroundEntry,
-  /void import\(["']\.\/python-editor\.js["']\)\.catch\(/,
-  "playground entrypoint must own editor enhancement through a fail-soft dynamic import",
+  /function loadEnhancedPythonEditor\(\)[\s\S]*?import\(["']\.\/python-editor\.js["']\)\.catch\(/,
+  "playground entrypoint must own editor enhancement through a fail-soft lazy dynamic import",
+);
+assert.match(
+  playgroundEntry,
+  /sceneSourceEditor\.addEventListener\([\s\S]*?["']focus["'][\s\S]*?loadEnhancedPythonEditor\(\)[\s\S]*?\{ once: true \}/,
+  "editor enhancement must begin only on the first source-editor focus",
 );
 
-console.log("✓ editor enhancement is outside the runtime authoring dependency graph");
+console.log("✓ lazy editor enhancement stays outside the runtime authoring dependency graph");

--- a/web/main.js
+++ b/web/main.js
@@ -12,10 +12,6 @@ import {
   requestedExampleId,
 } from "./example-gallery.js";
 
-void import("./python-editor.js").catch((error) => {
-  console.warn("Optional Python editor unavailable; using textarea fallback", error);
-});
-
 const canvas = document.querySelector("#scene");
 const status = document.querySelector("#status");
 const statusText = document.querySelector("#status-text");
@@ -42,6 +38,17 @@ patchPanel.hidden = true;
 sourceEditor.hidden = true;
 sceneTab.hidden = true;
 sceneButton.textContent = "Run";
+
+let pythonEditorLoadPromise = null;
+function loadEnhancedPythonEditor() {
+  pythonEditorLoadPromise ??= import("./python-editor.js").catch((error) => {
+    console.warn("Optional Python editor unavailable; using textarea fallback", error);
+  });
+  return pythonEditorLoadPromise;
+}
+
+const GALLERY_PAGE_SIZE = 18;
+const METRICS_POLL_MS = 500;
 
 const galleryStyle = document.createElement("style");
 galleryStyle.textContent = `
@@ -99,6 +106,39 @@ galleryStyle.textContent = `
     color: var(--muted);
     font-size: 0.76rem;
   }
+  .gallery-pager {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.7rem;
+    min-height: 3rem;
+    padding: 0.55rem 0.85rem;
+    border-top: 1px solid var(--border);
+    background: rgb(9 13 21 / 72%);
+  }
+  .gallery-pager[hidden] { display: none; }
+  .gallery-pager-status {
+    color: var(--muted-2);
+    font: 0.68rem ui-monospace, SFMono-Regular, Menlo, monospace;
+  }
+  .gallery-pager-actions {
+    display: flex;
+    gap: 0.4rem;
+  }
+  .gallery-page-button {
+    border: 1px solid #303d58;
+    border-radius: 0.55rem;
+    padding: 0.38rem 0.58rem;
+    background: #111722;
+    color: #dbe2ef;
+    cursor: pointer;
+    font-size: 0.7rem;
+    font-weight: 700;
+  }
+  .gallery-page-button:disabled {
+    cursor: default;
+    opacity: 0.42;
+  }
   .example-card {
     min-width: 0;
     padding: 0;
@@ -109,6 +149,8 @@ galleryStyle.textContent = `
     color: inherit;
     cursor: pointer;
     text-align: left;
+    content-visibility: auto;
+    contain-intrinsic-size: auto 12rem;
   }
   .example-card:hover { border-color: #4a5e87; }
   .example-card[aria-selected="true"] {
@@ -201,6 +243,9 @@ galleryStyle.textContent = `
   @media (max-width: 44rem) {
     .gallery-controls { grid-template-columns: 1fr; }
     .gallery-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.55rem; padding: 0.6rem; }
+    .gallery-pager { align-items: stretch; flex-direction: column; }
+    .gallery-pager-actions { width: 100%; }
+    .gallery-page-button { flex: 1; }
     .selected-example { flex-direction: column; }
     .selected-tags { justify-content: flex-start; max-width: none; }
   }
@@ -247,7 +292,24 @@ galleryControls.append(gallerySearch, categorySelect, paritySelect);
 galleryHead.append(galleryTitle, galleryControls);
 const galleryGrid = document.createElement("div");
 galleryGrid.className = "gallery-grid";
-gallerySection.append(galleryHead, galleryGrid);
+const galleryPager = document.createElement("div");
+galleryPager.className = "gallery-pager";
+const galleryPagerStatus = document.createElement("span");
+galleryPagerStatus.className = "gallery-pager-status";
+galleryPagerStatus.setAttribute("aria-live", "polite");
+const galleryPagerActions = document.createElement("div");
+galleryPagerActions.className = "gallery-pager-actions";
+const previousGalleryPage = document.createElement("button");
+previousGalleryPage.type = "button";
+previousGalleryPage.className = "gallery-page-button";
+previousGalleryPage.textContent = "Previous";
+const nextGalleryPage = document.createElement("button");
+nextGalleryPage.type = "button";
+nextGalleryPage.className = "gallery-page-button";
+nextGalleryPage.textContent = "Next";
+galleryPagerActions.append(previousGalleryPage, nextGalleryPage);
+galleryPager.append(galleryPagerStatus, galleryPagerActions);
+gallerySection.append(galleryHead, galleryGrid, galleryPager);
 workspace.before(gallerySection);
 
 const selectedExampleStrip = document.createElement("div");
@@ -284,9 +346,12 @@ let playbackControls = null;
 let playbackDurationSeconds = 4.0;
 let rendererBackend = "";
 let sceneRunPromise = null;
+let runtimeStartPromise = null;
 let playerNeedsRestart = false;
-let startupAutoplayPending = false;
 let busyDepth = 0;
+let galleryPage = 0;
+let metricsTimer = null;
+let metricsPending = false;
 
 function currentExample() {
   return SCENE_EXAMPLES.find((example) => example.id === selectedExampleId) ?? null;
@@ -303,9 +368,16 @@ function setBusy(busy) {
   gallerySearch.disabled = busy;
   categorySelect.disabled = busy;
   paritySelect.disabled = busy;
+  previousGalleryPage.disabled = busy || galleryPage === 0;
+  if (busy) {
+    nextGalleryPage.disabled = true;
+  }
   playbackControls?.setBusy(busy);
   for (const card of galleryGrid.querySelectorAll(".example-card")) {
     card.disabled = busy;
+  }
+  if (!busy) {
+    updateGalleryPagerControls();
   }
 }
 
@@ -392,37 +464,72 @@ function warmAuthoringClient() {
   return client;
 }
 
-function cancelStartupAutoplay(reason = "cancelled") {
-  if (!startupAutoplayPending) return;
-  startupAutoplayPending = false;
-  status.dataset.startupAutoplay = reason;
-}
+async function ensureRuntimeReady() {
+  if (runtimeStartPromise !== null) return runtimeStartPromise;
+  if (player !== null) return;
 
-function scheduleStartupAutoplay(exampleId, client) {
-  startupAutoplayPending = true;
-  status.dataset.startupAutoplay = "waiting";
-  void client.ready().then(
-    () => {
-      if (!startupAutoplayPending) return;
-      if (
-        authoringClient !== client ||
-        selectedExampleId !== exampleId ||
-        sceneRunPromise !== null ||
-        sceneSourceEditor.value !== canonicalSource
-      ) {
-        cancelStartupAutoplay("skipped");
-        return;
-      }
-      startupAutoplayPending = false;
-      status.dataset.startupAutoplay = "running";
-      void runScene().then((result) => {
-        status.dataset.startupAutoplay = result?.error ? "failed" : "settled";
+  const task = (async () => {
+    setRuntimeStatus("Starting runtime on demand…", "running");
+    patchStatus.value = "Starting Python + GPU runtime…";
+    patchStatus.dataset.state = "running";
+    warmAuthoringClient();
+
+    const nextPlayer = new AuthoringExecutionClient(canvas, {
+      onError(error) {
+        playerNeedsRestart = true;
+        showError(error);
+      },
+      onRecoverableError(error) {
+        showRecoverableSceneError(error);
+      },
+    });
+    player = nextPlayer;
+    try {
+      const ready = await nextPlayer.start('{"version":1,"objects":[],"tracks":[]}', {
+        loopDurationSeconds: 4.0,
       });
-    },
-    () => {
-      cancelStartupAutoplay("failed");
-    },
-  );
+      playerNeedsRestart = false;
+      rendererBackend = ready.render.backend;
+      status.dataset.rendererBackend = rendererBackend;
+      status.dataset.executionMode = nextPlayer.mode;
+      status.dataset.executionTopology = "authoring-engine-render-workers";
+      status.dataset.runtimeStartup = "started-on-demand";
+      playbackControls = new PlaygroundPlaybackControls(
+        nextPlayer,
+        document.querySelector(".preview-pane"),
+        {
+          durationSeconds: playbackDurationSeconds,
+          onError: showPlaybackError,
+        },
+      );
+
+      const initialState = await nextPlayer.state();
+      patchStatus.dataset.sequence = String(initialState.nextPatchSequence);
+      playbackControls.sync({
+        time: initialState.time,
+        playing: initialState.playing,
+        durationSeconds: playbackDurationSeconds,
+      });
+      startMetricsPolling();
+    } catch (error) {
+      nextPlayer.terminate();
+      if (player === nextPlayer) {
+        player = null;
+        playbackControls?.destroy();
+        playbackControls = null;
+      }
+      throw error;
+    }
+  })();
+
+  runtimeStartPromise = task;
+  try {
+    await task;
+  } finally {
+    if (runtimeStartPromise === task) {
+      runtimeStartPromise = null;
+    }
+  }
 }
 
 async function ensureExecutionReady() {
@@ -479,13 +586,38 @@ function renderSelectedMetadata() {
   }
 }
 
-function renderGallery() {
-  const visible = filterGalleryExamples(SCENE_EXAMPLES, {
+function filteredGalleryExamples() {
+  return filterGalleryExamples(SCENE_EXAMPLES, {
     query: gallerySearch.value,
     category: categorySelect.value,
     parityStatus: paritySelect.value,
   });
+}
+
+function updateGalleryPagerControls(visible = filteredGalleryExamples()) {
+  const pageCount = Math.max(1, Math.ceil(visible.length / GALLERY_PAGE_SIZE));
+  galleryPage = Math.min(Math.max(0, galleryPage), pageCount - 1);
+  const start = visible.length === 0 ? 0 : galleryPage * GALLERY_PAGE_SIZE + 1;
+  const end = Math.min((galleryPage + 1) * GALLERY_PAGE_SIZE, visible.length);
+  galleryPager.hidden = visible.length <= GALLERY_PAGE_SIZE;
+  galleryPagerStatus.textContent = visible.length === 0 ? "0 examples" : `${start}–${end} of ${visible.length}`;
+  previousGalleryPage.disabled = busyDepth > 0 || galleryPage === 0;
+  nextGalleryPage.disabled = busyDepth > 0 || galleryPage >= pageCount - 1;
+}
+
+function renderGallery({ keepSelectedVisible = false } = {}) {
+  const visible = filteredGalleryExamples();
+  if (keepSelectedVisible && selectedExampleId !== null) {
+    const selectedIndex = visible.findIndex((example) => example.id === selectedExampleId);
+    if (selectedIndex >= 0) {
+      galleryPage = Math.floor(selectedIndex / GALLERY_PAGE_SIZE);
+    }
+  }
+
+  const pageCount = Math.max(1, Math.ceil(visible.length / GALLERY_PAGE_SIZE));
+  galleryPage = Math.min(Math.max(0, galleryPage), pageCount - 1);
   galleryGrid.replaceChildren();
+  updateGalleryPagerControls(visible);
   if (visible.length === 0) {
     const empty = document.createElement("div");
     empty.className = "gallery-empty";
@@ -493,11 +625,15 @@ function renderGallery() {
     galleryGrid.append(empty);
     return;
   }
-  for (const example of visible) {
+
+  const start = galleryPage * GALLERY_PAGE_SIZE;
+  const pageExamples = visible.slice(start, start + GALLERY_PAGE_SIZE);
+  for (const example of pageExamples) {
     const card = document.createElement("button");
     card.type = "button";
     card.className = "example-card";
     card.dataset.exampleId = example.id;
+    card.disabled = busyDepth > 0;
     card.setAttribute("aria-selected", String(example.id === selectedExampleId));
     const image = document.createElement("img");
     image.className = "example-thumb";
@@ -505,6 +641,7 @@ function renderGallery() {
     image.alt = example.thumbnailAlt;
     image.loading = "lazy";
     image.decoding = "async";
+    image.fetchPriority = "low";
     const copy = document.createElement("span");
     copy.className = "example-card-copy";
     const title = document.createElement("span");
@@ -533,16 +670,17 @@ function isCurrentRun(runToken) {
 }
 
 async function runScene() {
-  cancelStartupAutoplay();
   if (sceneRunPromise !== null) return sceneRunPromise;
   const example = currentExample();
-  if (!example || !player) return null;
+  if (!example) return null;
 
   const runToken = generations.beginRun(example.id);
   const source = sceneSourceEditor.value;
   const releaseBusy = beginBusy();
   const task = (async () => {
     try {
+      await ensureRuntimeReady();
+      if (!isCurrentRun(runToken)) return recordStale(runToken, "after-runtime-start");
       await ensureExecutionReady();
       if (!isCurrentRun(runToken)) return recordStale(runToken, "after-restart");
 
@@ -621,7 +759,7 @@ async function runScene() {
       if (!isCurrentRun(runToken)) {
         return recordStale(runToken, "error");
       }
-      if (playerNeedsRestart) {
+      if (player === null || playerNeedsRestart) {
         showError(error);
       } else {
         showSceneError(error);
@@ -686,7 +824,7 @@ async function selectExample(
     sceneSourceEditor.value = drafts.get(id) ?? source;
     resetButton.disabled = sceneSourceEditor.value === canonicalSource;
     renderSelectedMetadata();
-    renderGallery();
+    renderGallery({ keepSelectedVisible: true });
     patchStatus.value = `${example.title} loaded · ${parityLabel(example.parityStatus)}`;
     patchStatus.dataset.state = "ready";
     patchStatus.dataset.exampleId = example.id;
@@ -720,12 +858,23 @@ async function selectExample(
 }
 
 function refreshGalleryFilters() {
+  galleryPage = 0;
   renderGallery();
+}
+
+function moveGalleryPage(delta) {
+  const visible = filteredGalleryExamples();
+  const pageCount = Math.max(1, Math.ceil(visible.length / GALLERY_PAGE_SIZE));
+  galleryPage = Math.min(Math.max(0, galleryPage + delta), pageCount - 1);
+  renderGallery();
+  gallerySection.scrollIntoView({ block: "start" });
 }
 
 gallerySearch.addEventListener("input", refreshGalleryFilters);
 categorySelect.addEventListener("change", refreshGalleryFilters);
 paritySelect.addEventListener("change", refreshGalleryFilters);
+previousGalleryPage.addEventListener("click", () => moveGalleryPage(-1));
+nextGalleryPage.addEventListener("click", () => moveGalleryPage(1));
 sceneButton.addEventListener("click", runScene);
 resetButton.addEventListener("click", async () => {
   const example = currentExample();
@@ -737,8 +886,14 @@ resetButton.addEventListener("click", async () => {
   patchStatus.value = `${example.title} reset to canonical Manim source`;
   patchStatus.dataset.state = "ready";
 });
+sceneSourceEditor.addEventListener(
+  "focus",
+  () => {
+    void loadEnhancedPythonEditor();
+  },
+  { once: true },
+);
 sceneSourceEditor.addEventListener("input", () => {
-  cancelStartupAutoplay();
   const example = currentExample();
   if (example) drafts.set(example.id, sceneSourceEditor.value);
   resetButton.disabled = sceneSourceEditor.value === canonicalSource;
@@ -756,28 +911,77 @@ document.addEventListener("keydown", (event) => {
   }
 });
 
-const EMPTY_SCENE_JSON = '{"version":1,"objects":[],"tracks":[]}';
-try {
-  const startupAuthoringClient = warmAuthoringClient();
-  player = new AuthoringExecutionClient(canvas, {
-    onError(error) {
-      playerNeedsRestart = true;
+async function updateWorkerMetrics() {
+  if (
+    metricsPending ||
+    player === null ||
+    document.visibilityState === "hidden" ||
+    busyDepth > 0 ||
+    sceneRunPromise !== null ||
+    playerNeedsRestart
+  ) {
+    return;
+  }
+  metricsPending = true;
+  try {
+    const report = await player.metrics();
+    const metrics = report.metrics;
+    const host = report.engineMetrics.host;
+    rendererBackend = player.rendererBackend;
+    status.dataset.rendererBackend = rendererBackend;
+    status.dataset.executionMode = report.executionMode;
+    setRuntimeStatus(
+      `${metrics.objectCount} objects · ${rendererBackend} ${report.executionMode} worker`,
+      "running",
+    );
+    metricObjects.value = String(metrics.objectCount);
+    metricDraws.value = String(metrics.drawCalls);
+    metricUpload.value = formatBytes(metrics.bytesUploaded);
+    metricTime.value = `${metrics.time.toFixed(2)} s`;
+    playbackControls?.updateTime(metrics.time);
+    status.dataset.instances = String(metrics.instancesDrawn);
+    status.dataset.uploadBytes = String(metrics.bytesUploaded);
+    status.dataset.geometryCacheMisses = String(metrics.geometryCacheMisses);
+    status.dataset.hostMissedDeadlines = String(host.missedDeadlines);
+    status.dataset.hostDroppedLateResults = String(host.droppedLateResults);
+    status.dataset.presentedFrames = String(metrics.presentedFrames);
+  } catch (error) {
+    if (!playerNeedsRestart) {
       showError(error);
-    },
-    onRecoverableError(error) {
-      showRecoverableSceneError(error);
-    },
-  });
-  const ready = await player.start(EMPTY_SCENE_JSON, { loopDurationSeconds: 4.0 });
-  rendererBackend = ready.render.backend;
-  status.dataset.rendererBackend = rendererBackend;
-  status.dataset.executionMode = player.mode;
-  status.dataset.executionTopology = "authoring-engine-render-workers";
-  playbackControls = new PlaygroundPlaybackControls(player, document.querySelector(".preview-pane"), {
-    durationSeconds: playbackDurationSeconds,
-    onError: showPlaybackError,
-  });
+    }
+  } finally {
+    metricsPending = false;
+  }
+}
 
+function stopMetricsPolling() {
+  if (metricsTimer !== null) {
+    clearTimeout(metricsTimer);
+    metricsTimer = null;
+  }
+}
+
+function startMetricsPolling() {
+  if (metricsTimer !== null || player === null || document.visibilityState === "hidden") return;
+  const poll = async () => {
+    metricsTimer = null;
+    await updateWorkerMetrics();
+    if (player !== null && document.visibilityState !== "hidden") {
+      metricsTimer = setTimeout(poll, METRICS_POLL_MS);
+    }
+  };
+  metricsTimer = setTimeout(poll, METRICS_POLL_MS);
+}
+
+document.addEventListener("visibilitychange", () => {
+  if (document.visibilityState === "hidden") {
+    stopMetricsPolling();
+  } else {
+    startMetricsPolling();
+  }
+});
+
+try {
   const requested = requestedExampleId();
   const initialExample = SCENE_EXAMPLES.some((example) => example.id === requested)
     ? requested
@@ -785,14 +989,10 @@ try {
   history.replaceState({ example: initialExample }, "", exampleUrl(initialExample));
   renderGallery();
   await selectExample(initialExample, { run: false });
-
-  const initialState = await player.state();
-  patchStatus.dataset.sequence = String(initialState.nextPatchSequence);
-  playbackControls.sync({
-    time: initialState.time,
-    playing: initialState.playing,
-    durationSeconds: playbackDurationSeconds,
-  });
+  patchStatus.dataset.sequence = "0";
+  status.dataset.runtimeStartup = "deferred";
+  status.dataset.executionTopology = "deferred-until-run";
+  setRuntimeStatus("Ready · runtime starts when you run an example", "ready");
 
   window.__noonExampleGallery = {
     get selectedExampleId() {
@@ -800,6 +1000,9 @@ try {
     },
     get exampleCount() {
       return SCENE_EXAMPLES.length;
+    },
+    get visibleExampleCount() {
+      return galleryGrid.querySelectorAll(".example-card").length;
     },
     get executionMode() {
       return player?.mode ?? null;
@@ -818,68 +1021,19 @@ try {
     },
   };
 
-  scheduleStartupAutoplay(initialExample, startupAuthoringClient);
-
   window.addEventListener(
     "pagehide",
     () => {
+      stopMetricsPolling();
       playbackControls?.destroy();
+      playbackControls = null;
       authoringClient?.terminate();
+      authoringClient = null;
       player?.terminate();
+      player = null;
     },
     { once: true },
   );
-
-  let lastStatusUpdate = -Infinity;
-  let metricsPending = false;
-  async function updateWorkerMetrics(timestamp) {
-    if (
-      metricsPending ||
-      busyDepth > 0 ||
-      sceneRunPromise !== null ||
-      playerNeedsRestart ||
-      timestamp - lastStatusUpdate <= 200
-    ) {
-      return;
-    }
-    metricsPending = true;
-    try {
-      const report = await player.metrics();
-      const metrics = report.metrics;
-      const host = report.engineMetrics.host;
-      rendererBackend = player.rendererBackend;
-      status.dataset.rendererBackend = rendererBackend;
-      status.dataset.executionMode = report.executionMode;
-      setRuntimeStatus(
-        `${metrics.objectCount} objects · ${rendererBackend} ${report.executionMode} worker`,
-        "running",
-      );
-      metricObjects.value = String(metrics.objectCount);
-      metricDraws.value = String(metrics.drawCalls);
-      metricUpload.value = formatBytes(metrics.bytesUploaded);
-      metricTime.value = `${metrics.time.toFixed(2)} s`;
-      playbackControls?.updateTime(metrics.time);
-      status.dataset.instances = String(metrics.instancesDrawn);
-      status.dataset.uploadBytes = String(metrics.bytesUploaded);
-      status.dataset.geometryCacheMisses = String(metrics.geometryCacheMisses);
-      status.dataset.hostMissedDeadlines = String(host.missedDeadlines);
-      status.dataset.hostDroppedLateResults = String(host.droppedLateResults);
-      status.dataset.presentedFrames = String(metrics.presentedFrames);
-      lastStatusUpdate = timestamp;
-    } catch (error) {
-      if (!playerNeedsRestart) {
-        showError(error);
-      }
-    } finally {
-      metricsPending = false;
-    }
-  }
-
-  function frame(timestamp) {
-    void updateWorkerMetrics(timestamp);
-    requestAnimationFrame(frame);
-  }
-  requestAnimationFrame(frame);
 } catch (error) {
   showError(error);
 }

--- a/web/playground-playback-controls.js
+++ b/web/playground-playback-controls.js
@@ -116,7 +116,13 @@ export class PlaygroundPlaybackControls {
   }
 
   updateTime(time) {
-    if (!Number.isFinite(time) || time < 0 || this.#seekActive || this.#desiredSeek !== null) {
+    if (
+      !Number.isFinite(time) ||
+      time < 0 ||
+      !this.#playing ||
+      this.#seekActive ||
+      this.#desiredSeek !== null
+    ) {
       return;
     }
     this.#timeSeconds = Math.min(time, this.#durationSeconds);

--- a/web/playground-stability-boundary.test.mjs
+++ b/web/playground-stability-boundary.test.mjs
@@ -45,10 +45,17 @@ assert.ok(
   "legacy authoring execution must forward recoverable errors on initial start and rebuild",
 );
 
-const playgroundConstruction = main.match(
-  /player = new AuthoringExecutionClient\(canvas, \{([\s\S]*?)\n\s*\}\);/,
+const runtimeReadyStart = main.indexOf("async function ensureRuntimeReady()");
+const runtimeReadyEnd = main.indexOf("async function ensureExecutionReady()", runtimeReadyStart);
+assert.ok(
+  runtimeReadyStart >= 0 && runtimeReadyEnd > runtimeReadyStart,
+  "playground must keep an explicit on-demand runtime boundary",
+);
+const runtimeReadyBody = main.slice(runtimeReadyStart, runtimeReadyEnd);
+const playgroundConstruction = runtimeReadyBody.match(
+  /const nextPlayer = new AuthoringExecutionClient\(canvas, \{([\s\S]*?)\n\s*\}\);/,
 )?.[1];
-assert.ok(playgroundConstruction, "playground must configure its authoring execution client");
+assert.ok(playgroundConstruction, "deferred runtime must configure its authoring execution client");
 assert.match(
   playgroundConstruction,
   /onRecoverableError\(error\) \{\s*showRecoverableSceneError\(error\);\s*\}/,
@@ -73,4 +80,4 @@ assert.match(
   "superseded playground deployments must be cancelled",
 );
 
-console.log("✓ playground keeps recoverable scene errors visible and outside fatal recovery");
+console.log("✓ deferred playground runtime keeps recoverable scene errors outside fatal recovery");

--- a/web/playground-startup.test.mjs
+++ b/web/playground-startup.test.mjs
@@ -4,62 +4,145 @@ import { readFile } from "node:fs/promises";
 const main = await readFile(new URL("./main.js", import.meta.url), "utf8");
 const worker = await readFile(new URL("./python-worker.source.js", import.meta.url), "utf8");
 
-const startupRegion = main.indexOf("const EMPTY_SCENE_JSON");
-assert.notEqual(startupRegion, -1, "playground startup region must exist");
-const warmupCall = main.indexOf("warmAuthoringClient();", startupRegion);
-const playerStart = main.indexOf("await player.start(", startupRegion);
-assert.ok(warmupCall > startupRegion, "Python authoring warmup must start during playground boot");
+const runtimeReadyStart = main.indexOf("async function ensureRuntimeReady()");
+const executionReadyStart = main.indexOf("async function ensureExecutionReady()", runtimeReadyStart);
 assert.ok(
-  warmupCall < playerStart,
-  "Python authoring warmup must start before execution/render workers finish booting",
+  runtimeReadyStart >= 0 && executionReadyStart > runtimeReadyStart,
+  "on-demand runtime startup boundary must exist",
+);
+const runtimeReadyBody = main.slice(runtimeReadyStart, executionReadyStart);
+assert.match(
+  runtimeReadyBody,
+  /warmAuthoringClient\(\);/,
+  "first runtime request must begin Python warmup",
 );
 assert.match(
-  main,
-  /authoringClient !== client\) return;[\s\S]*client\.terminated[\s\S]*authoringClient = null/,
-  "failed eager warmup must discard a dead Python client for the next Run",
+  runtimeReadyBody,
+  /new AuthoringExecutionClient\(canvas,/,
+  "first runtime request must create the GPU execution owner",
 );
-
-const initialSelection = main.indexOf(
-  "await selectExample(initialExample, { run: false });",
-  startupRegion,
-);
-const galleryInstall = main.indexOf("window.__noonExampleGallery =", startupRegion);
-const autoplaySchedule = main.indexOf(
-  "scheduleStartupAutoplay(initialExample, startupAuthoringClient);",
-  startupRegion,
-);
-assert.ok(initialSelection > playerStart, "initial source selection must follow renderer startup");
-assert.ok(galleryInstall > initialSelection, "playground API must install after initial source selection");
-assert.ok(
-  autoplaySchedule > galleryInstall,
-  "initial Python autoplay must be scheduled only after the playground is interactive",
-);
-assert.doesNotMatch(
-  main.slice(startupRegion),
-  /await selectExample\(initialExample, \{ run: true \}\)/,
-  "playground startup must not await Python scene authoring",
-);
-
-const autoplayStart = main.indexOf("function scheduleStartupAutoplay(");
-const executionReadyStart = main.indexOf("async function ensureExecutionReady()", autoplayStart);
-assert.ok(autoplayStart >= 0 && executionReadyStart > autoplayStart, "startup autoplay helper must exist");
-const autoplayBody = main.slice(autoplayStart, executionReadyStart);
-assert.match(autoplayBody, /client\.ready\(\)\.then\(/, "autoplay must wait for warm Python readiness");
-assert.match(autoplayBody, /selectedExampleId !== exampleId/, "autoplay must yield to a newer selection");
-assert.match(autoplayBody, /sceneRunPromise !== null/, "autoplay must yield to a user-started run");
 assert.match(
-  autoplayBody,
-  /sceneSourceEditor\.value !== canonicalSource/,
-  "autoplay must yield to source edits",
+  runtimeReadyBody,
+  /await nextPlayer\.start\(/,
+  "on-demand startup must await execution readiness before publishing controls",
+);
+const inFlightGuard = runtimeReadyBody.indexOf("if (runtimeStartPromise !== null)");
+const livePlayerGuard = runtimeReadyBody.indexOf("if (player !== null)");
+assert.ok(
+  inFlightGuard >= 0 && livePlayerGuard > inFlightGuard,
+  "concurrent startup callers must await the in-flight startup before observing the published player",
+);
+assert.match(
+  runtimeReadyBody,
+  /playerNeedsRestart = false;/,
+  "successful fresh runtime startup must clear stale restart state",
+);
+assert.match(
+  runtimeReadyBody,
+  /status\.dataset\.runtimeStartup = "started-on-demand"/,
+  "runtime startup must expose its on-demand state for browser diagnostics",
 );
 
 const runSceneStart = main.indexOf("async function runScene()");
 const selectExampleStart = main.indexOf("async function selectExample(", runSceneStart);
 assert.ok(runSceneStart >= 0 && selectExampleStart > runSceneStart, "runScene boundary must exist");
+const runSceneBody = main.slice(runSceneStart, selectExampleStart);
+const ensureRuntimeCall = runSceneBody.indexOf("await ensureRuntimeReady();");
+const ensureExecutionCall = runSceneBody.indexOf("await ensureExecutionReady();");
+assert.ok(ensureRuntimeCall >= 0, "Run must start the deferred runtime");
+assert.ok(
+  ensureExecutionCall > ensureRuntimeCall,
+  "runtime startup must complete before execution recovery/reconciliation",
+);
+
+const bootStart = main.indexOf("try {\n  const requested = requestedExampleId();");
+assert.notEqual(bootStart, -1, "playground boot boundary must exist");
+const bootCatch = main.indexOf("} catch (error) {\n  showError(error);\n}", bootStart);
+assert.ok(bootCatch > bootStart, "playground boot boundary must terminate cleanly");
+const bootBody = main.slice(bootStart, bootCatch);
+assert.doesNotMatch(
+  bootBody,
+  /warmAuthoringClient\(|new AuthoringExecutionClient\(|\.start\(.*objects.*tracks/,
+  "initial page boot must not create Python or GPU runtime resources",
+);
+assert.doesNotMatch(
+  bootBody,
+  /scheduleStartupAutoplay|(?:await|void) runScene\(\)/,
+  "initial page boot must not autoplay a Python scene",
+);
 assert.match(
-  main.slice(runSceneStart, selectExampleStart),
-  /cancelStartupAutoplay\(\);/,
-  "an explicit run must cancel pending startup autoplay",
+  bootBody,
+  /await selectExample\(initialExample, \{ run: false \}\);/,
+  "initial page boot must load only the selected source",
+);
+assert.match(
+  bootBody,
+  /status\.dataset\.runtimeStartup = "deferred"/,
+  "initial page boot must expose deferred runtime state",
+);
+assert.match(
+  bootBody,
+  /window\.__noonExampleGallery =/,
+  "gallery API must become available without waiting for Pyodide or GPU startup",
+);
+
+assert.doesNotMatch(
+  main,
+  /^void import\("\.\/python-editor\.js"\)/m,
+  "CodeMirror/Ruff must not load eagerly at module startup",
+);
+const editorLoaderStart = main.indexOf("function loadEnhancedPythonEditor()");
+assert.notEqual(editorLoaderStart, -1, "lazy Python editor loader must exist");
+const editorImport = main.indexOf('import("./python-editor.js")', editorLoaderStart);
+assert.ok(editorImport > editorLoaderStart, "Python editor import must live behind the lazy loader");
+assert.match(
+  main,
+  /sceneSourceEditor\.addEventListener\([\s\S]*?"focus"[\s\S]*?loadEnhancedPythonEditor\(\)[\s\S]*?\{ once: true \}/,
+  "enhanced Python editor must load only on first editor focus",
+);
+
+assert.match(main, /const GALLERY_PAGE_SIZE = 18;/, "gallery DOM residency must be bounded");
+assert.match(
+  main,
+  /visible\.slice\(start, start \+ GALLERY_PAGE_SIZE\)/,
+  "gallery rendering must materialize only the current page",
+);
+assert.match(main, /image\.fetchPriority = "low";/, "gallery thumbnails must stay low priority");
+assert.match(
+  main,
+  /content-visibility: auto;/,
+  "gallery cards must allow the browser to skip offscreen layout and paint work",
+);
+const setBusyStart = main.indexOf("function setBusy(busy)");
+const beginBusyStart = main.indexOf("function beginBusy()", setBusyStart);
+assert.ok(setBusyStart >= 0 && beginBusyStart > setBusyStart, "busy-control boundary must exist");
+const setBusyBody = main.slice(setBusyStart, beginBusyStart);
+assert.match(
+  setBusyBody,
+  /if \(busy\) \{\s*nextGalleryPage\.disabled = true;/,
+  "busy scene work must disable forward gallery paging as well as the previous-page control",
+);
+
+assert.match(main, /const METRICS_POLL_MS = 500;/, "runtime metrics polling must be rate-limited");
+assert.match(
+  main,
+  /metricsTimer = setTimeout\(poll, METRICS_POLL_MS\);/,
+  "runtime metrics must use the bounded polling cadence",
+);
+assert.doesNotMatch(
+  main,
+  /requestAnimationFrame\(frame\)/,
+  "runtime metrics must not schedule work on every animation frame",
+);
+assert.match(
+  main,
+  /document\.visibilityState === "hidden"/,
+  "runtime metrics must stop doing work while the page is hidden",
+);
+assert.match(
+  bootBody,
+  /pagehide[\s\S]*stopMetricsPolling\(\)[\s\S]*authoringClient\?\.terminate\(\)[\s\S]*player\?\.terminate\(\)/,
+  "page teardown must release metrics, Python, and execution resources",
 );
 
 const initializeStart = worker.indexOf("async function initializePyodide()");
@@ -90,5 +173,5 @@ assert.match(
 );
 
 console.log(
-  "✓ playground becomes interactive before Python autoplay and overlaps bundled cold-start resources",
+  "✓ playground defers heavyweight startup, bounds gallery residency, and preserves parallel Python bootstrap",
 );


### PR DESCRIPTION
## What changed
- defer Python/Pyodide + GPU execution startup until the first explicit Run or example selection instead of warming/autoplaying on page load
- load CodeMirror/Ruff only when the source editor is first focused
- cap gallery DOM/image residency to 18 thumbnails per page with Previous/Next navigation, low-priority image fetches, and `content-visibility`
- replace per-animation-frame metrics work with a 500 ms visibility-aware poll
- stop metrics and runtime resources cleanly on page hide
- make the in-flight runtime-start promise authoritative so concurrent first-run callers cannot observe a half-started execution client
- clear stale restart state after a successful fresh runtime start and keep both gallery pager directions disabled while scene work is busy

## Why
The public demo previously did several high-cost/high-memory tasks together at startup: Pyodide and render workers, editor/linter WASM, first-scene autoplay, plus an effectively unbounded thumbnail corpus available for decoding while scrolling. On memory-constrained browsers this increases initial latency and lets gallery browsing push the tab toward its memory limit.

The new initial state is intentionally lightweight: source/gallery UI is interactive, but Python, execution/render workers, editor enhancement, playback controls, and metrics polling are not started until they are actually needed.

## Architecture / invariants
- lazy startup still uses the existing shared authoring/execution/reconciliation paths; no alternate demo-only renderer or Python execution path is introduced
- once requested, Noon WASM, Pyodide, and the content-addressed Python compatibility bundle retain their parallel startup boundary from #489
- `runtimeStartPromise` is checked before the published `player`, so a second caller waits for the same initialization rather than racing a partially initialized player
- gallery paging limits live thumbnail elements rather than relying only on `loading=lazy`
- metrics work is skipped while hidden, busy, rerunning, or recovering
- page teardown terminates the Python authoring client and execution player and destroys playback/metrics resources

## Validation contract
Source tests require:
- no eager Python/GPU runtime construction or startup autoplay
- no eager CodeMirror/Ruff import
- bounded 18-card gallery rendering
- low-priority/offscreen thumbnail behavior
- 500 ms visibility-aware metrics polling with no metrics RAF loop
- safe concurrent first-run startup and pager busy-state behavior
- preservation of #489's parallel Python/WASM/bootstrap startup

Dedicated browser suites now explicitly prove the new product flow:
1. load the public playground and assert runtime startup is `deferred` with no renderer/playback allocation;
2. assert gallery DOM residency is bounded;
3. start execution through the real Run control;
4. run the existing playback, rerun-race, authoring recovery, resize, lifecycle, and Chromium/Firefox/WebKit workflow assertions unchanged after startup.

The authoring-recovery smoke also focuses the textarea first and waits for the real CodeMirror editor, proving editor enhancement is lazy rather than merely absent.