### PR TITLE
Qualify MovingCameraCenter exact parity

### DIFF
--- a/web/example-gallery.test.mjs
+++ b/web/example-gallery.test.mjs
@@ -13,6 +13,9 @@ import {
 const manifest = JSON.parse(
   await readFile(new URL("./python/examples/manim_tutorial_manifest.json", import.meta.url), "utf8"),
 );
+const parityManifest = JSON.parse(
+  await readFile(new URL("../parity/manim-v0.21/manifest.json", import.meta.url), "utf8"),
+);
 const gallery = normalizeGalleryManifest(manifest);
 const readyEntries = manifest.entries.filter((entry) => entry.status === "ready");
 assert.equal(
@@ -55,6 +58,19 @@ assert.equal(
     ?.parityStatus,
   "parity-qualified",
   "exact-source DrawBorderThenFill keeps its qualified raster/timeline evidence",
+);
+const movingCamera = readyEntries.find((entry) => entry.id === "manim-moving-camera-center");
+assert.equal(
+  movingCamera?.parity_status,
+  "parity-qualified",
+  "MovingCameraCenter must keep its qualified camera/raster/timeline evidence",
+);
+assert.equal(movingCamera?.parity_fixture, "moving-camera-center");
+assert.ok(movingCamera?.features.includes("pixel-parity"));
+assert.ok(movingCamera?.features.includes("time-parity"));
+assert.ok(
+  parityManifest.fixtures.some((fixture) => fixture.id === movingCamera?.parity_fixture),
+  "a parity-qualified gallery entry must point at its canonical Manim fixture",
 );
 for (const id of [
   "manim-dot-example",

--- a/web/python/examples/manim_tutorial_manifest.json
+++ b/web/python/examples/manim_tutorial_manifest.json
@@ -608,12 +608,15 @@
         "animate",
         "move_to",
         "Square",
-        "Triangle"
+        "Triangle",
+        "pixel-parity",
+        "time-parity"
       ],
       "upstream": "reference/manim.scene.moving_camera_scene.MovingCameraScene.html",
       "upstream_source": "parity/manim-v0.21/upstream-examples/moving_camera_center.py",
       "reuse": "source-equivalent-manim-v0.21",
-      "parity_status": "candidate",
+      "parity_status": "parity-qualified",
+      "parity_fixture": "moving-camera-center",
       "expected_duration": 2.6,
       "thumbnail": "thumbnails/manim/generated/moving-camera-center.png",
       "thumbnail_alt": "Exact-source Manim MovingCameraCenter",


### PR DESCRIPTION
## Summary
- promote the exact-source `MovingCameraCenter` public gallery entry from `candidate` to `parity-qualified`
- attach the canonical `moving-camera-center` fixture explicitly
- surface its existing pixel/time parity evidence in feature metadata
- ratchet the gallery contract so the qualification cannot silently regress or lose its canonical fixture

## Evidence
The shared moving-camera implementation and follow-up fixes are already merged (#300, #316, #317). `moving-camera-center` is part of `parity/manim-v0.21/manifest.json`. A later fully green canonical run on #453 passed the Manim raster differential, Manim semantic differential, API coverage, CI, WebGPU/WebGL browser paths, and all demo recovery gates.

The raster workflow itself renders canonical Manim scenes on WebGPU and WebGL, captures semantic state at Manim frame times, enforces the per-fixture raster ratchet, and verifies direct seek against incremental playback. This PR changes no camera/runtime behavior and no tolerances; it only makes the public qualification metadata match the evidence already enforced by CI.

Tracks #89/#185.