### PR TITLE
Qualify MovingDots exact parity

### DIFF
--- a/web/example-gallery.test.mjs
+++ b/web/example-gallery.test.mjs
@@ -53,25 +53,35 @@ assert.ok(
   ),
   "every public example must point to its canonical upstream source fixture",
 );
-assert.equal(
-  gallery.examples.find((entry) => entry.id === "parity-draw-border-then-fill-styled-square")
-    ?.parityStatus,
-  "parity-qualified",
+
+function assertQualifiedFixture(entryId, fixtureId, message) {
+  const entry = readyEntries.find((candidate) => candidate.id === entryId);
+  assert.equal(entry?.parity_status, "parity-qualified", message);
+  assert.equal(entry?.parity_fixture, fixtureId, `${entryId}: canonical fixture must remain stable`);
+  assert.ok(entry?.features.includes("pixel-parity"), `${entryId}: pixel evidence must remain declared`);
+  assert.ok(entry?.features.includes("time-parity"), `${entryId}: time evidence must remain declared`);
+  assert.ok(
+    parityManifest.fixtures.some((fixture) => fixture.id === fixtureId),
+    `${entryId}: qualified gallery entry must point at its canonical Manim fixture`,
+  );
+}
+
+assertQualifiedFixture(
+  "parity-draw-border-then-fill-styled-square",
+  "draw-border-then-fill-styled-square",
   "exact-source DrawBorderThenFill keeps its qualified raster/timeline evidence",
 );
-const movingCamera = readyEntries.find((entry) => entry.id === "manim-moving-camera-center");
-assert.equal(
-  movingCamera?.parity_status,
-  "parity-qualified",
+assertQualifiedFixture(
+  "parity-moving-dots",
+  "moving-dots",
+  "MovingDots must keep its qualified updater/raster/timeline evidence",
+);
+assertQualifiedFixture(
+  "manim-moving-camera-center",
+  "moving-camera-center",
   "MovingCameraCenter must keep its qualified camera/raster/timeline evidence",
 );
-assert.equal(movingCamera?.parity_fixture, "moving-camera-center");
-assert.ok(movingCamera?.features.includes("pixel-parity"));
-assert.ok(movingCamera?.features.includes("time-parity"));
-assert.ok(
-  parityManifest.fixtures.some((fixture) => fixture.id === movingCamera?.parity_fixture),
-  "a parity-qualified gallery entry must point at its canonical Manim fixture",
-);
+
 for (const id of [
   "manim-dot-example",
   "manim-ellipse-example",

--- a/web/python/examples/manim_tutorial_manifest.json
+++ b/web/python/examples/manim_tutorial_manifest.json
@@ -509,7 +509,7 @@
       "upstream": "examples.html",
       "upstream_source": "parity/manim-v0.21/upstream-examples/moving_dots.py",
       "reuse": "source-equivalent-manim-v0.21",
-      "parity_status": "candidate",
+      "parity_status": "parity-qualified",
       "parity_fixture": "moving-dots",
       "expected_duration": 3,
       "thumbnail": "thumbnails/manim/moving-dots.svg",


### PR DESCRIPTION
## Summary
- promote the exact-source `MovingDots` gallery entry from `candidate` to `parity-qualified`
- keep the existing canonical `moving-dots` fixture and pixel/time evidence as the qualification source
- refactor the gallery qualification regression into one reusable assertion shared by DrawBorderThenFill, MovingDots, and MovingCameraCenter

## Evidence
The exact-source MovingDots example landed in #302 on top of the shared updater/runtime work from #294. #310 then fixed the remaining Manim updater lifecycle/frame-boundary regression without changing raster tolerances. The exact #310 head passed CI, test coverage, Manim semantic differential, API coverage, and the full canonical Manim raster differential.

`moving-dots` is a non-exempt fixture in `parity/manim-v0.21/manifest.json`, so that green raster run enforced the normal pixel thresholds and direct-seek/incremental-playback oracle. This PR changes no updater/runtime behavior and no tolerances; it only makes the public gallery status match evidence already enforced by CI.

Tracks #252/#185.