### PR TITLE
Gate failed runtime patch churn recovery

### DIFF
--- a/crates/noon-runtime/tests/failed_property_churn.rs
+++ b/crates/noon-runtime/tests/failed_property_churn.rs
@@ -1,5 +1,8 @@
 use noon_compile::CompiledScene;
-use noon_core::{GeometryRef, ObjectId, SceneDefinition, ScenePatch, Transform2D, Vec2};
+use noon_core::{
+    Easing, GeometryRef, ObjectId, Property, SceneDefinition, ScenePatch, TrackDefinition, TrackId,
+    TrackTiming, TrackValues, Transform2D, Vec2,
+};
 use noon_runtime::{RuntimePatchStats, SceneInstance};
 
 const SCENE_OBJECTS: usize = 10_000;
@@ -7,7 +10,7 @@ const FAILURE_ITERATIONS: u64 = 1_000;
 const TARGET_INDEX: usize = SCENE_OBJECTS / 2;
 
 #[test]
-fn rejected_property_churn_preserves_runtime_and_allows_recovery() {
+fn rejected_patch_churn_preserves_runtime_and_allows_recovery() {
     let mut definition = SceneDefinition::new();
     let mut objects = Vec::with_capacity(SCENE_OBJECTS);
     for _ in 0..SCENE_OBJECTS {
@@ -26,25 +29,29 @@ fn rejected_property_churn_preserves_runtime_and_allows_recovery() {
     for iteration in 0..FAILURE_ITERATIONS {
         let patch = if iteration % 2 == 0 {
             ScenePatch::SetTransform {
-                object: target,
-                transform: Transform2D {
-                    translation: Vec2::new(f32::NAN, 0.0),
-                    ..Transform2D::IDENTITY
-                },
-            }
-        } else {
-            ScenePatch::SetTransform {
                 object: ObjectId::new(1_000_000 + iteration),
                 transform: Transform2D {
                     translation: Vec2::new(1.0, -1.0),
                     ..Transform2D::IDENTITY
                 },
             }
+        } else {
+            ScenePatch::AddTrack(TrackDefinition {
+                id: TrackId::new(2_000_000 + iteration),
+                object: target,
+                property: Property::Opacity,
+                values: TrackValues::Scalar {
+                    from: f32::NAN,
+                    to: 0.5,
+                },
+                timing: TrackTiming::new(0.0, 1.0, Easing::Linear),
+                time_map: Default::default(),
+            })
         };
 
         assert!(
             live.apply_patch(&patch).is_err(),
-            "iteration {iteration} must reject the invalid property edit"
+            "iteration {iteration} must reject the invalid patch"
         );
         assert_eq!(live.frame().objects.len(), frame_slots);
         assert_eq!(live.frame().objects[TARGET_INDEX], target_before);

--- a/crates/noon-runtime/tests/failed_property_churn.rs
+++ b/crates/noon-runtime/tests/failed_property_churn.rs
@@ -1,7 +1,7 @@
 use noon_compile::CompiledScene;
 use noon_core::{
-    Easing, GeometryRef, ObjectId, Property, SceneDefinition, ScenePatch, TrackDefinition, TrackId,
-    TrackTiming, TrackValues, Transform2D, Vec2,
+    CompositionTimeMap, Easing, GeometryRef, ObjectId, Property, SceneDefinition, ScenePatch,
+    TrackDefinition, TrackId, TrackTiming, TrackValues, Transform2D, Vec2,
 };
 use noon_runtime::{RuntimePatchStats, SceneInstance};
 
@@ -45,7 +45,7 @@ fn rejected_patch_churn_preserves_runtime_and_allows_recovery() {
                     to: 0.5,
                 },
                 timing: TrackTiming::new(0.0, 1.0, Easing::Linear),
-                time_map: Default::default(),
+                time_map: CompositionTimeMap::identity(),
             })
         };
 

--- a/crates/noon-runtime/tests/failed_property_churn.rs
+++ b/crates/noon-runtime/tests/failed_property_churn.rs
@@ -1,0 +1,80 @@
+use noon_compile::CompiledScene;
+use noon_core::{GeometryRef, ObjectId, SceneDefinition, ScenePatch, Transform2D, Vec2};
+use noon_runtime::{RuntimePatchStats, SceneInstance};
+
+const SCENE_OBJECTS: usize = 10_000;
+const FAILURE_ITERATIONS: u64 = 1_000;
+const TARGET_INDEX: usize = SCENE_OBJECTS / 2;
+
+#[test]
+fn rejected_property_churn_preserves_runtime_and_allows_recovery() {
+    let mut definition = SceneDefinition::new();
+    let mut objects = Vec::with_capacity(SCENE_OBJECTS);
+    for _ in 0..SCENE_OBJECTS {
+        objects.push(definition.add(GeometryRef::circle(0.25)));
+    }
+
+    let compiled = CompiledScene::compile(&definition).expect("large static scene must compile");
+    let mut live = SceneInstance::new(compiled);
+    live.take_frame_changes();
+
+    let target = objects[TARGET_INDEX];
+    let target_before = live.frame().objects[TARGET_INDEX].clone();
+    let adjacent_before = live.frame().objects[TARGET_INDEX + 1].clone();
+    let frame_slots = live.frame().objects.len();
+
+    for iteration in 0..FAILURE_ITERATIONS {
+        let patch = if iteration % 2 == 0 {
+            ScenePatch::SetTransform {
+                object: target,
+                transform: Transform2D {
+                    translation: Vec2::new(f32::NAN, 0.0),
+                    ..Transform2D::IDENTITY
+                },
+            }
+        } else {
+            ScenePatch::SetTransform {
+                object: ObjectId::new(1_000_000 + iteration),
+                transform: Transform2D {
+                    translation: Vec2::new(1.0, -1.0),
+                    ..Transform2D::IDENTITY
+                },
+            }
+        };
+
+        assert!(
+            live.apply_patch(&patch).is_err(),
+            "iteration {iteration} must reject the invalid property edit"
+        );
+        assert_eq!(live.frame().objects.len(), frame_slots);
+        assert_eq!(live.frame().objects[TARGET_INDEX], target_before);
+        assert_eq!(live.frame().objects[TARGET_INDEX + 1], adjacent_before);
+        assert_eq!(live.last_patch_stats(), RuntimePatchStats::default());
+        assert!(
+            live.take_frame_changes().is_empty(),
+            "iteration {iteration} must not publish dirty state"
+        );
+    }
+
+    let valid = ScenePatch::SetTransform {
+        object: target,
+        transform: Transform2D {
+            translation: Vec2::new(3.0, -2.0),
+            ..Transform2D::IDENTITY
+        },
+    };
+    live.apply_patch(&valid)
+        .expect("runtime must remain usable after rejected churn");
+
+    assert_eq!(
+        live.take_frame_changes().object_indices(),
+        &[TARGET_INDEX],
+        "recovery edit must remain object-local"
+    );
+    assert_eq!(
+        live.frame().objects[TARGET_INDEX].transform.translation,
+        Vec2::new(3.0, -2.0)
+    );
+    assert_eq!(live.frame().objects[TARGET_INDEX + 1], adjacent_before);
+    assert_eq!(live.frame().objects.len(), frame_slots);
+}


### PR DESCRIPTION
## Summary
- add a deterministic 1,000-failure live-patch stress over a 10,000-object static scene
- alternate unknown-object property edits with invalid timeline payloads
- require every rejection to preserve frame-slot count, target/adjacent object state, empty `RuntimePatchStats`, and empty `FrameChanges`
- apply a valid transform after the stress and require the same runtime to recover with exactly one local dirty index

## Why
#114 requires failed scene/patch loads followed by successful recovery without partial leaks or retained mutation state. Existing runtime tests prove one rejected patch is transactional, while text-resource failure churn covers the resource arena. There was no sustained live-runtime rejection/recovery gate across independent failure classes.

## CI finding
The first version intentionally included a non-finite `SetTransform` as one rejected case. Rust CI exposed that `SceneInstance`/`CompiledScene` currently accepts that payload even though `SceneDefinition` rejects it. That is a real compiled-mutation validation inconsistency, now documented separately in #499 with the required shared-validation architecture. This PR does not duplicate finite checks or widen the core validation API opportunistically; it keeps #114's independent churn scope on rejection contracts already owned by the runtime/compiler.

## Architecture
Test-only. The regression exercises the existing public `SceneInstance` patch, stats, and dirty-state contracts. It adds no failure injection hooks, alternate mutation path, timing threshold, or resource policy.

## Parallelism
One `noon-runtime` integration test file. It does not touch active demo startup/memory work, renderer recovery/GPU diagnostics, retained text/rendering, resource versioning, or the resource-arena ID reuse policy.

## Validation
The initial head passed Manim semantic differential, API coverage, raster differential, and cross-browser; Rust CI and coverage failed only because they correctly executed the new test and exposed #499. The revised exact head uses unknown-object and invalid-track rejection classes and is re-running required CI.

Tracks #114 and #68. Follow-up bug: #499.