### PR TITLE
Qualify MoveToTarget exact parity

### DIFF
--- a/web/example-gallery.test.mjs
+++ b/web/example-gallery.test.mjs
@@ -77,6 +77,11 @@ assertQualifiedFixture(
   "MovingDots must keep its qualified updater/raster/timeline evidence",
 );
 assertQualifiedFixture(
+  "manim-move-to-target",
+  "move-to-target-circle",
+  "MoveToTargetExample must keep its qualified transform/raster/timeline evidence",
+);
+assertQualifiedFixture(
   "manim-moving-camera-center",
   "moving-camera-center",
   "MovingCameraCenter must keep its qualified camera/raster/timeline evidence",

--- a/web/python/examples/manim_tutorial_manifest.json
+++ b/web/python/examples/manim_tutorial_manifest.json
@@ -560,7 +560,7 @@
       "upstream": "reference/manim.animation.transform.MoveToTarget.html",
       "upstream_source": "parity/manim-v0.21/upstream-examples/move_to_target_example.py",
       "reuse": "source-equivalent-manim-v0.21",
-      "parity_status": "candidate",
+      "parity_status": "parity-qualified",
       "parity_fixture": "move-to-target-circle",
       "expected_duration": 1,
       "thumbnail": "thumbnails/manim/generated/move-to-target.png",


### PR DESCRIPTION
## Summary
- promote the exact-source `MoveToTargetExample` from `candidate` to `parity-qualified`
- keep the canonical `move-to-target-circle` fixture and existing pixel/time evidence
- add the exact leaf-object example to the reusable qualified-fixture gallery regression

## Evidence
#318 added the literal ManimCE v0.21 `MoveToTargetExample` with import-only adaptation and a canonical 1.0s semantic/raster/timeline fixture with no fixture-specific tolerance. Its exact head passed CI, test coverage, Manim semantic differential, API coverage, and the full canonical raster oracle, including per-fixture enforcement and direct-seek/incremental-playback equivalence.

This PR changes no transform/runtime behavior and no tolerances; it only makes the public gallery status match evidence already enforced by CI.

## Scope boundary
This qualifies the exact leaf-object `MoveToTargetExample` only. Retained Group/VGroup targets remain explicitly unsupported pending the broader #82 transform-family work.

Tracks #82/#185.