### PR TITLE
Gate long sparse timeline locality

### DIFF
--- a/crates/noon-runtime/tests/long_sparse_timeline.rs
+++ b/crates/noon-runtime/tests/long_sparse_timeline.rs
@@ -1,0 +1,46 @@
+use noon_compile::CompiledScene;
+use noon_core::{Easing, GeometryRef, SceneDefinition, TrackTiming, Vec2};
+use noon_runtime::{EvaluationStats, SceneInstance};
+
+const HISTORICAL_TRACKS: usize = 50_000;
+
+#[test]
+fn completed_long_timeline_history_is_not_rescanned_on_forward_frames() {
+    let mut definition = SceneDefinition::new();
+    let object = definition.add(GeometryRef::circle(0.5));
+
+    for index in 0..HISTORICAL_TRACKS {
+        let x = index as f32;
+        definition
+            .animate_position(
+                object,
+                Vec2::new(x, 0.0),
+                Vec2::new(x + 1.0, 0.0),
+                TrackTiming::new(index as f64, 0.5, Easing::Linear),
+            )
+            .expect("historical track must be valid");
+    }
+
+    let compiled = CompiledScene::compile(&definition).expect("long sparse timeline must compile");
+    let mut runtime = SceneInstance::new(compiled);
+    let history_end = HISTORICAL_TRACKS as f64;
+
+    runtime
+        .seek(history_end)
+        .expect("seek past completed history must succeed");
+    runtime.take_frame_changes();
+
+    runtime
+        .advance_to(history_end + 0.25)
+        .expect("steady forward frame after history must succeed");
+
+    assert_eq!(
+        runtime.last_stats(),
+        EvaluationStats::default(),
+        "steady forward evaluation must perform no scheduler work after completed history"
+    );
+    assert!(
+        runtime.take_frame_changes().is_empty(),
+        "completed history must not republish unchanged object state"
+    );
+}


### PR DESCRIPTION
## Summary
- add a deterministic runtime fixture with 50,000 completed tracks on one channel
- seek past the entire history, then advance a steady forward frame
- require `EvaluationStats::default()`: zero group evaluation, zero track advancement, and zero binary-search work after the history is complete
- require no frame-change publication once the completed history is stable

## Why
#113 explicitly requires long sparse timelines to scale with events crossed + active channels rather than total historical track count. Existing coverage exercises the same scheduler invariant only at small internal-unit scale; this adds a normal integration/CI gate large enough to catch accidental historical rescans.

The first exact-head run exposed that the fixture itself was too weak/wrong: it expected one group evaluation, while the runtime correctly reported completely zero steady-state scheduler work. The test now gates that stronger observed invariant rather than weakening runtime behavior.

## Architecture
Test-only. Uses the public `EvaluationStats` and `FrameChanges` contracts. No wall-clock threshold, scheduler hook, alternate execution path, or instrumentation is added.

## Parallelism
One new `noon-runtime` integration test file. It does not touch compiled validation, execution-slot implementation, renderer/text, worker recovery, or resource versioning.

## Validation
Required Rust/workspace CI is the compile/format/Clippy/test authority for the exact head.

Tracks #113 and #68.