### PR TITLE
Gate large-scene geometry patch locality

### DIFF
--- a/crates/noon-runtime/tests/geometry_patch_locality.rs
+++ b/crates/noon-runtime/tests/geometry_patch_locality.rs
@@ -1,0 +1,36 @@
+use noon_compile::CompiledScene;
+use noon_core::{GeometryRef, SceneDefinition, ScenePatch, Vec2};
+use noon_runtime::{RuntimePatchStats, SceneInstance};
+
+const OBJECT_COUNT: usize = 100_000;
+const TARGET_INDEX: usize = OBJECT_COUNT / 2;
+const UNTOUCHED_INDEX: usize = TARGET_INDEX + 1;
+
+#[test]
+fn geometry_patch_touches_only_one_object_in_a_100k_scene() {
+    let mut definition = SceneDefinition::new();
+    let mut objects = Vec::with_capacity(OBJECT_COUNT);
+    for _ in 0..OBJECT_COUNT {
+        objects.push(definition.add(GeometryRef::circle(1.0)));
+    }
+
+    let compiled = CompiledScene::compile(&definition).expect("large static scene must compile");
+    let mut live = SceneInstance::new(compiled);
+    live.take_frame_changes();
+
+    let target = objects[TARGET_INDEX];
+    let untouched_before = live.frame().objects[UNTOUCHED_INDEX].clone();
+    let replacement = GeometryRef::line(Vec2::new(-2.0, 1.0), Vec2::new(3.0, -1.0));
+
+    live.apply_patch(&ScenePatch::SetGeometry {
+        object: target,
+        geometry: replacement.clone(),
+    })
+    .expect("local geometry patch must succeed");
+
+    assert_eq!(live.last_patch_stats(), RuntimePatchStats::default());
+    assert_eq!(live.take_frame_changes().object_indices(), &[TARGET_INDEX]);
+    assert_eq!(live.frame().objects[TARGET_INDEX].geometry, replacement);
+    assert_eq!(live.frame().objects[UNTOUCHED_INDEX], untouched_before);
+    assert_eq!(live.frame().objects.len(), OBJECT_COUNT);
+}


### PR DESCRIPTION
## Summary
- add a deterministic 100,000-object runtime fixture for `SetGeometry`
- replace geometry on one middle object
- require exactly one published dirty object index
- require `RuntimePatchStats::default()`: no timeline relowering, scheduler churn, structural slot churn, track-locator removal, full group rebuild, or full seek
- require neighboring object state and total frame-slot count to remain unchanged

## Why
#113 requires one-object edits in very large mostly-static scenes to remain proportional to affected slots/resources. Existing 100k coverage gates transform/style edits, but geometry replacement was not covered by the same public runtime contract.

## Architecture
Test-only. Uses existing `SceneInstance`, `FrameChanges`, and `RuntimePatchStats`; no alternate mutation path, timing threshold, or new instrumentation.

## Parallelism
One new `noon-runtime` integration test file directly on current master. It does not touch #499's validation fix, renderer/text, worker recovery, execution-slot implementation, or resource versioning.

## Validation
One commit / one file, directly on current master. Required Rust/workspace CI is the compile/format/Clippy/test authority for the exact head.

Tracks #113 and #68.