### PR TITLE
Enforce shared object-state validation in compiled patches

### DIFF
--- a/crates/noon-compile/src/lib.rs
+++ b/crates/noon-compile/src/lib.rs
@@ -268,7 +268,10 @@ impl PartialEq<Vec<CompiledTrack>> for CompiledTracks<'_> {
 pub enum CompileError {
     TooManyObjects(usize),
     UnknownObject(ObjectId),
-    DiscontinuousPresence { previous: TrackId, next: TrackId },
+    DiscontinuousPresence {
+        previous: TrackId,
+        next: TrackId,
+    },
     UnsupportedTransformGeometry(TrackId),
     PathTransformRequiresRetessellation(TrackId),
     UnsafeFilledPathTransform(TrackId),

--- a/crates/noon-compile/src/lib.rs
+++ b/crates/noon-compile/src/lib.rs
@@ -268,10 +268,7 @@ impl PartialEq<Vec<CompiledTrack>> for CompiledTracks<'_> {
 pub enum CompileError {
     TooManyObjects(usize),
     UnknownObject(ObjectId),
-    DiscontinuousPresence {
-        previous: TrackId,
-        next: TrackId,
-    },
+    DiscontinuousPresence { previous: TrackId, next: TrackId },
     UnsupportedTransformGeometry(TrackId),
     PathTransformRequiresRetessellation(TrackId),
     UnsafeFilledPathTransform(TrackId),
@@ -325,7 +322,10 @@ pub enum CompilePatchError {
         field: ObjectStateField,
     },
     InvalidTrack(TimelineError),
-    DiscontinuousPresence { previous: TrackId, next: TrackId },
+    DiscontinuousPresence {
+        previous: TrackId,
+        next: TrackId,
+    },
     UnsupportedTransformGeometry(TrackId),
     PathTransformRequiresRetessellation(TrackId),
     UnsafeFilledPathTransform(TrackId),

--- a/crates/noon-compile/src/lib.rs
+++ b/crates/noon-compile/src/lib.rs
@@ -6,9 +6,10 @@ use std::cmp::Ordering;
 use std::collections::BTreeMap;
 
 use noon_core::{
-    validate_track_definition, CompositionTimeMap, GeometryRef, MutationTransaction, ObjectId,
-    Property, SceneDefinition, ScenePatch, Style, TimelineError, TrackDefinition, TrackId,
-    TrackTiming, TrackValues, Transform2D, VectorPath,
+    validate_object_definition, validate_property_patch, validate_track_definition,
+    CompositionTimeMap, GeometryRef, MutationTransaction, ObjectId, ObjectStateField, Property,
+    SceneDefinition, ScenePatch, Style, TimelineError, TrackDefinition, TrackId, TrackTiming,
+    TrackValues, Transform2D, VectorPath,
 };
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -316,6 +317,10 @@ pub enum CompilePatchError {
     UnknownObject(ObjectId),
     DuplicateTrack(TrackId),
     UnknownTrack(TrackId),
+    InvalidObjectState {
+        object: ObjectId,
+        field: ObjectStateField,
+    },
     InvalidTrack(TimelineError),
     DiscontinuousPresence { previous: TrackId, next: TrackId },
     UnsupportedTransformGeometry(TrackId),
@@ -333,6 +338,11 @@ impl std::fmt::Display for CompilePatchError {
             Self::UnknownObject(id) => write!(formatter, "unknown object id {}", id.get()),
             Self::DuplicateTrack(id) => write!(formatter, "duplicate track id {}", id.get()),
             Self::UnknownTrack(id) => write!(formatter, "unknown track id {}", id.get()),
+            Self::InvalidObjectState { object, field } => write!(
+                formatter,
+                "object {} contains non-finite {field} state",
+                object.get()
+            ),
             Self::InvalidTrack(error) => write!(formatter, "invalid track: {error}"),
             Self::DiscontinuousPresence { previous, next } => write!(
                 formatter,
@@ -538,6 +548,7 @@ impl CompiledScene {
                     }
                     let index = u32::try_from(next_object_index)
                         .map_err(|_| CompilePatchError::TooManyObjects(next_object_index))?;
+                    validate_object_definition(object).map_err(map_object_state_error)?;
                     next_object_index += 1;
                     object_indices.insert(object.id, index);
                 }
@@ -553,6 +564,7 @@ impl CompiledScene {
                     if !object_indices.contains_key(object) {
                         return Err(CompilePatchError::UnknownObject(*object));
                     }
+                    validate_property_patch(patch).map_err(map_object_state_error)?;
                 }
                 ScenePatch::AddTrack(track) => {
                     if tracks.iter().any(|existing| existing.id == track.id) {
@@ -625,6 +637,7 @@ impl CompiledScene {
                 }
                 let index = u32::try_from(self.objects.len())
                     .map_err(|_| CompilePatchError::TooManyObjects(self.objects.len()))?;
+                validate_object_definition(object).map_err(map_object_state_error)?;
                 self.objects.push(CompiledObject {
                     id: object.id,
                     geometry: object.geometry.clone(),
@@ -668,18 +681,21 @@ impl CompiledScene {
                 let index = self
                     .object_index(*object)
                     .ok_or(CompilePatchError::UnknownObject(*object))?;
+                validate_property_patch(patch).map_err(map_object_state_error)?;
                 self.objects[index as usize].geometry = geometry.clone();
             }
             ScenePatch::SetTransform { object, transform } => {
                 let index = self
                     .object_index(*object)
                     .ok_or(CompilePatchError::UnknownObject(*object))?;
+                validate_property_patch(patch).map_err(map_object_state_error)?;
                 self.objects[index as usize].base_transform = *transform;
             }
             ScenePatch::SetStyle { object, style } => {
                 let index = self
                     .object_index(*object)
                     .ok_or(CompilePatchError::UnknownObject(*object))?;
+                validate_property_patch(patch).map_err(map_object_state_error)?;
                 self.objects[index as usize].base_style = *style;
             }
             ScenePatch::AddTrack(track) => {
@@ -1027,6 +1043,15 @@ fn compile_patch_error(id: TrackId, error: TransformCompileFailure) -> CompilePa
         TransformCompileFailure::UnsafeFilledPath => {
             CompilePatchError::UnsafeFilledPathTransform(id)
         }
+    }
+}
+
+fn map_object_state_error(error: noon_core::PatchError) -> CompilePatchError {
+    match error {
+        noon_core::PatchError::InvalidObjectState { object, field } => {
+            CompilePatchError::InvalidObjectState { object, field }
+        }
+        other => unreachable!("object-state validator returned unexpected error: {other}"),
     }
 }
 
@@ -1718,6 +1743,7 @@ mod tests {
         );
         assert_eq!(compiled.tracks(), before);
     }
+
     #[test]
     fn removing_middle_object_keeps_compiled_slots_and_track_targets_stable() {
         let mut scene = SceneDefinition::new();

--- a/crates/noon-compile/tests/object_state_patch_validation.rs
+++ b/crates/noon-compile/tests/object_state_patch_validation.rs
@@ -1,0 +1,113 @@
+use noon_compile::{CompilePatchError, CompiledScene};
+use noon_core::{
+    GeometryRef, MutationTransaction, ObjectDefinition, ObjectId, ObjectStateField, SceneDefinition,
+    ScenePatch, Style, Transform2D, Vec2, VectorPath,
+};
+
+#[test]
+fn compiled_property_patches_reject_non_finite_state_without_mutation() {
+    let mut scene = SceneDefinition::new();
+    let object = scene.add(GeometryRef::circle(1.0));
+    let mut compiled = CompiledScene::compile(&scene).expect("valid scene must compile");
+
+    let cases = [
+        (
+            ScenePatch::SetGeometry {
+                object,
+                geometry: GeometryRef::path(
+                    VectorPath::new()
+                        .move_to(Vec2::ZERO)
+                        .line_to(Vec2::new(f32::NAN, 1.0)),
+                ),
+            },
+            ObjectStateField::Geometry,
+        ),
+        (
+            ScenePatch::SetTransform {
+                object,
+                transform: Transform2D {
+                    translation: Vec2::new(f32::NAN, 0.0),
+                    ..Transform2D::IDENTITY
+                },
+            },
+            ObjectStateField::Transform,
+        ),
+        (
+            ScenePatch::SetStyle {
+                object,
+                style: Style {
+                    opacity: f32::INFINITY,
+                    ..Style::default()
+                },
+            },
+            ObjectStateField::Style,
+        ),
+    ];
+
+    for (patch, field) in cases {
+        let before = compiled.clone();
+        assert_eq!(
+            compiled.apply_patch(&patch),
+            Err(CompilePatchError::InvalidObjectState { object, field })
+        );
+        assert_eq!(compiled, before, "rejected {field} patch mutated compiled state");
+    }
+}
+
+#[test]
+fn compiled_create_rejects_invalid_object_before_allocating_a_slot() {
+    let scene = SceneDefinition::new();
+    let mut compiled = CompiledScene::compile(&scene).expect("empty scene must compile");
+    let before = compiled.clone();
+    let object = ObjectId::new(7);
+    let mut invalid = ObjectDefinition::new(object, GeometryRef::circle(1.0));
+    invalid.transform = Transform2D {
+        rotation: f32::NAN,
+        ..Transform2D::IDENTITY
+    };
+
+    assert_eq!(
+        compiled.apply_patch(&ScenePatch::CreateObject(invalid)),
+        Err(CompilePatchError::InvalidObjectState {
+            object,
+            field: ObjectStateField::Transform,
+        })
+    );
+    assert_eq!(compiled, before);
+    assert_eq!(compiled.objects().len(), 0);
+    assert_eq!(compiled.live_object_count(), 0);
+    assert_eq!(compiled.object_index(object), None);
+}
+
+#[test]
+fn compiled_transaction_preflight_rejects_late_invalid_object_state_atomically() {
+    let mut scene = SceneDefinition::new();
+    let object = scene.add(GeometryRef::circle(1.0));
+    let compiled = CompiledScene::compile(&scene).expect("valid scene must compile");
+    let before = compiled.clone();
+    let transaction = MutationTransaction::from_mutations([
+        ScenePatch::SetTransform {
+            object,
+            transform: Transform2D {
+                translation: Vec2::new(3.0, -2.0),
+                ..Transform2D::IDENTITY
+            },
+        },
+        ScenePatch::SetStyle {
+            object,
+            style: Style {
+                stroke_width: f32::NAN,
+                ..Style::default()
+            },
+        },
+    ]);
+
+    assert_eq!(
+        compiled.preflight_transaction(&transaction),
+        Err(CompilePatchError::InvalidObjectState {
+            object,
+            field: ObjectStateField::Style,
+        })
+    );
+    assert_eq!(compiled, before);
+}

--- a/crates/noon-compile/tests/object_state_patch_validation.rs
+++ b/crates/noon-compile/tests/object_state_patch_validation.rs
@@ -1,7 +1,7 @@
 use noon_compile::{CompilePatchError, CompiledScene};
 use noon_core::{
-    GeometryRef, MutationTransaction, ObjectDefinition, ObjectId, ObjectStateField, SceneDefinition,
-    ScenePatch, Style, Transform2D, Vec2, VectorPath,
+    GeometryRef, MutationTransaction, ObjectDefinition, ObjectId, ObjectStateField,
+    SceneDefinition, ScenePatch, Style, Transform2D, Vec2, VectorPath,
 };
 
 #[test]
@@ -50,7 +50,10 @@ fn compiled_property_patches_reject_non_finite_state_without_mutation() {
             compiled.apply_patch(&patch),
             Err(CompilePatchError::InvalidObjectState { object, field })
         );
-        assert_eq!(compiled, before, "rejected {field} patch mutated compiled state");
+        assert_eq!(
+            compiled, before,
+            "rejected {field} patch mutated compiled state"
+        );
     }
 }
 

--- a/crates/noon-core/src/patch.rs
+++ b/crates/noon-core/src/patch.rs
@@ -148,7 +148,8 @@ impl std::fmt::Display for PatchError {
 
 impl std::error::Error for PatchError {}
 
-pub(super) fn validate_object_definition(object: &ObjectDefinition) -> Result<(), PatchError> {
+/// Validates all renderer-independent state carried by one object definition.
+pub fn validate_object_definition(object: &ObjectDefinition) -> Result<(), PatchError> {
     validate_geometry(object.id, &object.geometry)?;
     validate_transform(object.id, object.transform)?;
     validate_style(object.id, object.style)
@@ -219,7 +220,9 @@ fn vector_path_is_finite(path: &VectorPath) -> bool {
     }) && path.morph_target().is_none_or(vector_path_is_finite)
 }
 
-pub(super) fn validate_property_patch(patch: &ScenePatch) -> Result<(), PatchError> {
+/// Validates renderer-independent state carried by an object-property patch.
+/// Non-property patch variants carry no object-state payload and are accepted.
+pub fn validate_property_patch(patch: &ScenePatch) -> Result<(), PatchError> {
     match patch {
         ScenePatch::SetGeometry { object, geometry } => validate_geometry(*object, geometry),
         ScenePatch::SetTransform { object, transform } => validate_transform(*object, *transform),

--- a/crates/noon-runtime/tests/non_finite_property_patch.rs
+++ b/crates/noon-runtime/tests/non_finite_property_patch.rs
@@ -1,0 +1,43 @@
+use noon_compile::{CompilePatchError, CompiledScene};
+use noon_core::{GeometryRef, ObjectStateField, SceneDefinition, ScenePatch, Transform2D, Vec2};
+use noon_runtime::{RuntimePatchStats, SceneInstance};
+
+#[test]
+fn runtime_rejects_non_finite_transform_without_dirty_or_partial_state() {
+    let mut scene = SceneDefinition::new();
+    let object = scene.add(GeometryRef::circle(1.0));
+    let compiled = CompiledScene::compile(&scene).expect("valid scene must compile");
+    let mut live = SceneInstance::new(compiled);
+    live.take_frame_changes();
+    let before = live.frame().objects[0].clone();
+
+    let error = live
+        .apply_patch(&ScenePatch::SetTransform {
+            object,
+            transform: Transform2D {
+                translation: Vec2::new(f32::NAN, 0.0),
+                ..Transform2D::IDENTITY
+            },
+        })
+        .expect_err("non-finite live transform must be rejected");
+    assert_eq!(
+        error,
+        CompilePatchError::InvalidObjectState {
+            object,
+            field: ObjectStateField::Transform,
+        }
+    );
+    assert_eq!(live.frame().objects[0], before);
+    assert_eq!(live.last_patch_stats(), RuntimePatchStats::default());
+    assert!(live.take_frame_changes().is_empty());
+
+    live.apply_patch(&ScenePatch::SetTransform {
+        object,
+        transform: Transform2D {
+            translation: Vec2::new(2.0, -1.0),
+            ..Transform2D::IDENTITY
+        },
+    })
+    .expect("runtime must remain usable after rejection");
+    assert_eq!(live.take_frame_changes().object_indices(), &[0]);
+}


### PR DESCRIPTION
## Summary
- expose the existing `noon-core` whole-object and property-patch validators as the shared semantic admission contract
- enforce that contract in `CompiledScene` for `CreateObject`, `SetGeometry`, `SetTransform`, and `SetStyle`
- enforce the same contract during compiled transaction preflight
- map non-finite object payloads to an explicit `CompilePatchError::InvalidObjectState` without duplicating geometry/transform/style validation rules
- add compiled-state and live-runtime regressions for transactional rejection and recovery

## Invariants
- duplicate/unknown identity and object-capacity errors keep their existing precedence
- validation happens before any compiled slot, payload, live-count, frame, dirty-state, or patch-stat mutation
- object-local property edits remain O(patch payload); no scene scan or alternate mutation path is introduced
- `SceneDefinition`, `CompiledScene`, and `SceneInstance` now share one authoritative finite-state contract

## Regression coverage
- non-finite geometry, transform, and style patches preserve compiled state exactly
- invalid object creation allocates no slot and changes no live accounting
- a later invalid property in transaction preflight rejects atomically
- the exact NaN live transform that exposed the bug leaves frame state, dirty indices, and `RuntimePatchStats` untouched, then a valid local patch still succeeds

Fixes #499. Related to #114.