### PR TITLE
Gate atomic working-set swap churn

### DIFF
--- a/crates/noon-runtime/tests/atomic_working_set_swap_churn.rs
+++ b/crates/noon-runtime/tests/atomic_working_set_swap_churn.rs
@@ -36,12 +36,15 @@ fn atomic_working_set_swaps_reuse_execution_slots_without_capacity_growth() {
 
         let mut next_objects = Vec::with_capacity(WORKING_SET);
         let mut mutations = Vec::with_capacity(WORKING_SET * 2);
-        mutations.extend(current_objects.iter().copied().map(ScenePatch::RemoveObject));
+        mutations.extend(
+            current_objects
+                .iter()
+                .copied()
+                .map(ScenePatch::RemoveObject),
+        );
 
         for index in 0..WORKING_SET {
-            let object = ObjectId::new(
-                OBJECT_ID_BASE + (swap * WORKING_SET + index) as u64,
-            );
+            let object = ObjectId::new(OBJECT_ID_BASE + (swap * WORKING_SET + index) as u64);
             let geometry = if swap % 2 == 0 {
                 GeometryRef::rectangle(1.0, 1.0)
             } else {

--- a/crates/noon-runtime/tests/atomic_working_set_swap_churn.rs
+++ b/crates/noon-runtime/tests/atomic_working_set_swap_churn.rs
@@ -1,0 +1,91 @@
+use noon_compile::CompiledScene;
+use noon_core::{
+    GeometryRef, MutationTransaction, ObjectDefinition, ObjectId, SceneDefinition, ScenePatch,
+};
+use noon_runtime::SlottedSceneInstance;
+
+const WORKING_SET: usize = 32;
+const SWAPS: usize = 1_000;
+const OBJECT_ID_BASE: u64 = 20_000_000;
+
+#[test]
+fn atomic_working_set_swaps_reuse_execution_slots_without_capacity_growth() {
+    let mut definition = SceneDefinition::new();
+    let mut current_objects = Vec::with_capacity(WORKING_SET);
+    for _ in 0..WORKING_SET {
+        current_objects.push(definition.add(GeometryRef::circle(1.0)));
+    }
+
+    let compiled = CompiledScene::compile(&definition).expect("working-set scene must compile");
+    let mut live = SlottedSceneInstance::new(compiled);
+    let baseline_capacity = live.slot_table().slot_capacity();
+
+    assert_eq!(baseline_capacity, WORKING_SET);
+    assert_eq!(live.live_object_count(), WORKING_SET);
+    assert_eq!(live.slot_table().len(), WORKING_SET);
+
+    for swap in 0..SWAPS {
+        let stale_slots = current_objects
+            .iter()
+            .copied()
+            .map(|object| {
+                live.slot_for_object(object)
+                    .expect("every current object must own an execution slot")
+            })
+            .collect::<Vec<_>>();
+
+        let mut next_objects = Vec::with_capacity(WORKING_SET);
+        let mut mutations = Vec::with_capacity(WORKING_SET * 2);
+        mutations.extend(current_objects.iter().copied().map(ScenePatch::RemoveObject));
+
+        for index in 0..WORKING_SET {
+            let object = ObjectId::new(
+                OBJECT_ID_BASE + (swap * WORKING_SET + index) as u64,
+            );
+            let geometry = if swap % 2 == 0 {
+                GeometryRef::rectangle(1.0, 1.0)
+            } else {
+                GeometryRef::circle(1.0)
+            };
+            mutations.push(ScenePatch::CreateObject(ObjectDefinition::new(
+                object, geometry,
+            )));
+            next_objects.push(object);
+        }
+
+        let transaction = MutationTransaction::from_mutations(mutations);
+        let preflight = live
+            .preflight_transaction(&transaction)
+            .expect("bounded whole-set replacement must preflight");
+        assert_eq!(preflight.slots_indexed, WORKING_SET);
+        assert_eq!(preflight.staged_runtime_clones, 0);
+
+        live.apply_transaction(&transaction)
+            .expect("bounded whole-set replacement must commit atomically");
+
+        assert_eq!(live.slot_table().slot_capacity(), baseline_capacity);
+        assert_eq!(live.slot_table().len(), WORKING_SET);
+        assert_eq!(live.live_object_count(), WORKING_SET);
+
+        for stale_slot in stale_slots {
+            assert_eq!(
+                live.slot_table().object_for_slot(stale_slot),
+                None,
+                "pre-swap handles must remain stale after full-set replacement",
+            );
+        }
+        for object in next_objects.iter().copied() {
+            let slot = live
+                .slot_for_object(object)
+                .expect("replacement object must receive a reused execution slot");
+            assert_eq!(slot.generation(), (swap + 1) as u32);
+            assert_eq!(live.slot_table().object_for_slot(slot), Some(object));
+        }
+
+        current_objects = next_objects;
+    }
+
+    assert_eq!(live.slot_table().slot_capacity(), baseline_capacity);
+    assert_eq!(live.slot_table().len(), WORKING_SET);
+    assert_eq!(live.live_object_count(), WORKING_SET);
+}


### PR DESCRIPTION
## Summary
- add a deterministic 32-object execution working-set stress
- perform 1,000 atomic full-set remove/create transactions
- alternate circle/rectangle payloads across generations
- require sparse transaction preflight to index only the 32 affected execution slots with zero staged runtime clones
- require every replacement generation to reuse the existing execution-slot plateau
- require every pre-swap execution handle to remain stale after commit

## Why
#114 requires alternating bounded scene/resource working sets to reach a steady-state plateau. Existing churn coverage proves single-slot replacement and rotating one-object-at-a-time replacement, but not whole-working-set transactional turnover. This closes the gap where transaction preflight/free-list handling could grow execution capacity or alias stale generations despite local single-object churn remaining bounded.

## Architecture
Test-only. Uses the public `MutationTransaction`, `SlottedSceneInstance`, `ExecutionTransactionPreflightStats`, and execution-slot identity contracts. No timing thresholds, allocator hooks, runtime clones, or alternate mutation path are introduced.

## Validation
The first head exposed a formatting-only CI failure before Clippy/tests. The file was updated with the exact `rustfmt` output; corrected head: `503136852197342137096b1f82ab8391ac6944a6`.

On the corrected head, `cargo fmt --all -- --check` is green. Rust Clippy/tests, web package validation, and coverage are running and remain the merge authority.

Tracks #114 and #68.