### PR TITLE
Prevent authoring workers from resurrecting after terminate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,9 @@ jobs:
       - name: Test Python authoring execution routing
         run: node scripts/authoring-execution-router-smoke.mjs
 
+      - name: Test authoring execution termination races
+        run: node scripts/authoring-execution-lifecycle-smoke.mjs
+
       - name: Test slow Python callbacks do not block rendering
         run: node scripts/execution-worker-host-smoke.mjs
 

--- a/scripts/authoring-execution-lifecycle-smoke.mjs
+++ b/scripts/authoring-execution-lifecycle-smoke.mjs
@@ -1,0 +1,246 @@
+import assert from "node:assert/strict";
+import { createReadStream } from "node:fs";
+import { stat } from "node:fs/promises";
+import { createServer } from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import playwright from "playwright";
+
+const { chromium } = playwright;
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const port = Number(process.env.NOON_AUTHORING_EXECUTION_LIFECYCLE_PORT ?? "4183");
+const baseUrl = `http://127.0.0.1:${port}`;
+
+const contentTypes = new Map([
+  [".html", "text/html; charset=utf-8"],
+  [".js", "text/javascript; charset=utf-8"],
+  [".mjs", "text/javascript; charset=utf-8"],
+  [".wasm", "application/wasm"],
+  [".json", "application/json; charset=utf-8"],
+  [".py", "text/x-python; charset=utf-8"],
+]);
+
+const server = createServer(async (request, response) => {
+  try {
+    const url = new URL(request.url, baseUrl);
+    const relative = decodeURIComponent(url.pathname).replace(/^\/+/, "");
+    const resolved = path.resolve(repoRoot, relative || "web/execution-worker-smoke.html");
+    if (resolved !== repoRoot && !resolved.startsWith(`${repoRoot}${path.sep}`)) {
+      response.writeHead(403).end("forbidden");
+      return;
+    }
+    const info = await stat(resolved);
+    if (!info.isFile()) {
+      response.writeHead(404).end("not found");
+      return;
+    }
+    response.setHeader("Cross-Origin-Opener-Policy", "same-origin");
+    response.setHeader("Cross-Origin-Embedder-Policy", "require-corp");
+    response.setHeader("Cross-Origin-Resource-Policy", "same-origin");
+    response.setHeader("Cache-Control", "no-store");
+    response.setHeader(
+      "Content-Type",
+      contentTypes.get(path.extname(resolved)) ?? "application/octet-stream",
+    );
+    response.writeHead(200);
+    createReadStream(resolved).pipe(response);
+  } catch (error) {
+    response.writeHead(error?.code === "ENOENT" ? 404 : 500).end(String(error));
+  }
+});
+await new Promise((resolve, reject) => {
+  server.once("error", reject);
+  server.listen(port, "127.0.0.1", resolve);
+});
+
+const mixedSource = `from noon import *
+
+class MixedLifecycleScene(Scene):
+    def construct(self):
+        self.add(Circle(radius=0.4))
+        self.add(Typst("middle", font_size=56))
+        self.add(Square(side_length=0.8))
+`;
+
+const legacySource = `from noon import *
+
+class LegacyLifecycleScene(Scene):
+    def construct(self):
+        self.add(Circle(radius=0.5))
+        self.add(Square(side_length=0.7).shift(RIGHT * 1.5))
+`;
+
+const browserArgs = [
+  "--enable-unsafe-webgpu",
+  "--enable-unsafe-swiftshader",
+  "--use-webgpu-adapter=swiftshader",
+  "--use-gpu-in-tests",
+  "--ignore-gpu-blocklist",
+  "--enable-features=Vulkan",
+  "--use-gl=angle",
+  "--use-angle=swiftshader",
+  "--use-vulkan=swiftshader",
+  "--disable-gpu-sandbox",
+  "--disable-dev-shm-usage",
+];
+
+let browser = null;
+try {
+  browser = await chromium.launch({
+    channel: "chromium",
+    headless: true,
+    args: browserArgs,
+  });
+  const page = await browser.newPage({ viewport: { width: 800, height: 500 } });
+  const browserErrors = [];
+  page.on("pageerror", (error) => browserErrors.push(`pageerror: ${error}`));
+  page.on("console", (message) => {
+    if (message.type() === "error") browserErrors.push(`console: ${message.text()}`);
+  });
+  await page.goto(`${baseUrl}/web/execution-worker-smoke.html`, { waitUntil: "load" });
+
+  const result = await page.evaluate(async ({ mixedSource, legacySource }) => {
+    const NativeWorker = globalThis.Worker;
+    const workerTerminateCounts = [];
+    globalThis.Worker = new Proxy(NativeWorker, {
+      construct(Target, args, newTarget) {
+        const worker = Reflect.construct(Target, args, newTarget);
+        const index = workerTerminateCounts.length;
+        workerTerminateCounts.push(0);
+        const nativeTerminate = worker.terminate.bind(worker);
+        worker.terminate = () => {
+          workerTerminateCounts[index] += 1;
+          nativeTerminate();
+        };
+        return worker;
+      },
+    });
+
+    const { PythonAuthoringClient } = await import("./authoring-client.js");
+    const { AuthoringExecutionClient, AUTHORING_EXECUTION_RETAINED } = await import(
+      "./authoring-execution-client.js"
+    );
+
+    const authoring = new PythonAuthoringClient();
+    const emptySceneJson = '{"version":1,"objects":[],"tracks":[]}';
+    const mixed = await authoring.run(mixedSource, {});
+    const legacy = await authoring.run(legacySource, {});
+
+    function freshCanvas() {
+      const canvas = document.createElement("canvas");
+      canvas.width = 640;
+      canvas.height = 360;
+      canvas.style.width = "640px";
+      canvas.style.height = "360px";
+      document.body.append(canvas);
+      return canvas;
+    }
+
+    async function expectTerminated(execution, operation) {
+      const promise = operation();
+      execution.terminate();
+      let operationError = null;
+      try {
+        await promise;
+      } catch (error) {
+        operationError = String(error);
+      }
+      let stateError = null;
+      let metricsError = null;
+      try {
+        await execution.state();
+      } catch (error) {
+        stateError = String(error);
+      }
+      try {
+        await execution.metrics();
+      } catch (error) {
+        metricsError = String(error);
+      }
+      return {
+        operationError,
+        mode: execution.mode,
+        rendererBackend: execution.rendererBackend,
+        stateError,
+        metricsError,
+      };
+    }
+
+    const startupExecution = new AuthoringExecutionClient(freshCanvas());
+    const startup = await expectTerminated(startupExecution, () =>
+      startupExecution.start(emptySceneJson, {
+        loopDurationSeconds: 4,
+        transportMode: "transferable",
+      }),
+    );
+
+    const retainedExecution = new AuthoringExecutionClient(freshCanvas());
+    await retainedExecution.start(emptySceneJson, {
+      loopDurationSeconds: 4,
+      transportMode: "transferable",
+    });
+    const toRetained = await expectTerminated(retainedExecution, () =>
+      retainedExecution.reconcileScene(JSON.stringify(mixed.document), {
+        retainedDocumentJson: JSON.stringify(mixed.retainedDocument),
+        callbacks: mixed.callbacks,
+        authoringClient: authoring,
+        loopDurationSeconds: mixed.duration > 0 ? mixed.duration : null,
+      }),
+    );
+
+    const legacyExecution = new AuthoringExecutionClient(freshCanvas());
+    await legacyExecution.start(emptySceneJson, {
+      loopDurationSeconds: 4,
+      transportMode: "transferable",
+    });
+    const retainedReady = await legacyExecution.reconcileScene(JSON.stringify(mixed.document), {
+      retainedDocumentJson: JSON.stringify(mixed.retainedDocument),
+      callbacks: mixed.callbacks,
+      authoringClient: authoring,
+      loopDurationSeconds: mixed.duration > 0 ? mixed.duration : null,
+    });
+    const toLegacy = await expectTerminated(legacyExecution, () =>
+      legacyExecution.reconcileScene(JSON.stringify(legacy.document), {
+        retainedDocumentJson: JSON.stringify(legacy.retainedDocument),
+        callbacks: legacy.callbacks,
+        authoringClient: authoring,
+        loopDurationSeconds: legacy.duration > 0 ? legacy.duration : null,
+      }),
+    );
+
+    authoring.terminate();
+    globalThis.Worker = NativeWorker;
+    return {
+      startup,
+      toRetained,
+      retainedReadyMode: retainedReady.mode,
+      retainedMode: AUTHORING_EXECUTION_RETAINED,
+      toLegacy,
+      workerTerminateCounts,
+    };
+  }, { mixedSource, legacySource });
+
+  for (const scenario of [result.startup, result.toRetained, result.toLegacy]) {
+    assert.match(
+      scenario.operationError,
+      /AuthoringExecutionClient was terminated during an asynchronous operation/,
+    );
+    assert.equal(scenario.mode, null);
+    assert.equal(scenario.rendererBackend, "");
+    assert.match(scenario.stateError, /AuthoringExecutionClient has not been started/);
+    assert.match(scenario.metricsError, /AuthoringExecutionClient has not been started/);
+  }
+  assert.equal(result.retainedReadyMode, result.retainedMode);
+  assert.ok(result.workerTerminateCounts.length >= 6, "all three scenarios should create worker pairs");
+  assert.ok(
+    result.workerTerminateCounts.every((count) => count <= 1),
+    `workers must be terminated at most once: ${result.workerTerminateCounts.join(",")}`,
+  );
+  assert.deepEqual(browserErrors, []);
+  console.log("✓ authoring execution termination invalidates unpublished worker generations");
+} finally {
+  await browser?.close();
+  await new Promise((resolve) => server.close(resolve));
+}

--- a/scripts/build-web-demo.sh
+++ b/scripts/build-web-demo.sh
@@ -32,6 +32,7 @@ node --check scripts/execution-worker-smoke.mjs
 node --check scripts/execution-worker-host-smoke.mjs
 node --check scripts/retained-execution-worker-smoke.mjs
 node --check scripts/authoring-execution-router-smoke.mjs
+node --check scripts/authoring-execution-lifecycle-smoke.mjs
 node --check web/scene-pipeline-perf.mjs
 node --check web/gpu-profile.js
 node --check web/morph-profile.js

--- a/web/authoring-execution-client.js
+++ b/web/authoring-execution-client.js
@@ -7,6 +7,8 @@ export const AUTHORING_EXECUTION_RETAINED = "retained";
 
 const DEFAULT_LOOP_DURATION_SECONDS = 4;
 const DEFAULT_SHARED_SLOT_CAPACITY = 1024 * 1024;
+const LIFECYCLE_CANCELLED_MESSAGE =
+  "AuthoringExecutionClient was terminated during an asynchronous operation";
 const EMPTY_HOST_METRICS = Object.freeze({
   enabled: false,
   missedDeadlines: 0,
@@ -34,6 +36,7 @@ export class AuthoringExecutionClient {
   #onRecoverableError;
   #resizeObserver = null;
   #transition = null;
+  #lifecycleGeneration = 0;
 
   constructor(canvas, { onError = null, onRecoverableError = null } = {}) {
     if (!(canvas instanceof HTMLCanvasElement)) {
@@ -217,6 +220,7 @@ export class AuthoringExecutionClient {
   }
 
   terminate() {
+    this.#lifecycleGeneration += 1;
     this.#resizeObserver?.disconnect();
     this.#resizeObserver = null;
     this.#player?.terminate();
@@ -226,37 +230,51 @@ export class AuthoringExecutionClient {
   }
 
   async #startLegacy(sceneJson, options) {
+    const generation = this.#lifecycleGeneration;
     const player = new ExecutionWorkerClient(this.#canvas, {
       onError: this.#onError,
       onRecoverableError: this.#onRecoverableError,
     });
+    const terminateCandidate = createIdempotentTerminator(player);
+    let published = false;
     try {
       const ready = await player.start(sceneJson, options);
+      this.#assertLifecycleCurrent(generation, terminateCandidate);
       this.#player = player;
+      published = true;
       this.#mode = AUTHORING_EXECUTION_LEGACY;
       this.#rendererBackend = ready.render.backend;
       this.#resizeCurrentCanvas();
       return ready;
     } catch (error) {
-      player.terminate();
-      this.#adoptPlayerCanvas(player);
+      if (!published || generation === this.#lifecycleGeneration) {
+        terminateCandidate();
+      }
+      if (generation === this.#lifecycleGeneration) {
+        this.#adoptPlayerCanvas(player);
+      }
       throw error;
     }
   }
 
   async #rebuildRetained(sceneJson, retainedDocumentJson) {
+    const generation = this.#lifecycleGeneration;
     const canvas = this.#replaceTransferredCanvas();
     const player = new RetainedExecutionWorkerClient(canvas, {
       onError: this.#onError,
       onRecoverableError: this.#onRecoverableError,
     });
+    const terminateCandidate = createIdempotentTerminator(player);
+    let published = false;
     try {
       const ready = await player.start(sceneJson, retainedDocumentJson, {
         loopDurationSeconds: this.#loopDurationSeconds,
         transportMode: this.#transportMode,
         sharedSlotCapacity: this.#sharedSlotCapacity,
       });
+      this.#assertLifecycleCurrent(generation, terminateCandidate);
       this.#player = player;
+      published = true;
       this.#mode = AUTHORING_EXECUTION_RETAINED;
       this.#rendererBackend = ready.render.backend;
       this.#resizeCurrentCanvas();
@@ -271,28 +289,38 @@ export class AuthoringExecutionClient {
         ...state,
       };
     } catch (error) {
-      player.terminate();
-      this.#adoptPlayerCanvas(player);
+      if (!published || generation === this.#lifecycleGeneration) {
+        terminateCandidate();
+      }
+      if (generation === this.#lifecycleGeneration) {
+        this.#adoptPlayerCanvas(player);
+      }
       throw error;
     }
   }
 
   async #rebuildLegacy(sceneJson, { callbacks, authoringClient }) {
+    const generation = this.#lifecycleGeneration;
     const canvas = this.#replaceTransferredCanvas();
     const player = new ExecutionWorkerClient(canvas, {
       onError: this.#onError,
       onRecoverableError: this.#onRecoverableError,
     });
+    const terminateCandidate = createIdempotentTerminator(player);
+    let published = false;
     try {
       const ready = await player.start(sceneJson, {
         loopDurationSeconds: this.#loopDurationSeconds,
         transportMode: this.#transportMode,
         sharedSlotCapacity: this.#sharedSlotCapacity,
       });
+      this.#assertLifecycleCurrent(generation, terminateCandidate);
       if (callbacks !== null && callbacks !== undefined) {
         await player.configureHostCallbacks(callbacks, authoringClient);
+        this.#assertLifecycleCurrent(generation, terminateCandidate);
       }
       this.#player = player;
+      published = true;
       this.#mode = AUTHORING_EXECUTION_LEGACY;
       this.#rendererBackend = ready.render.backend;
       this.#resizeCurrentCanvas();
@@ -307,8 +335,12 @@ export class AuthoringExecutionClient {
         ...state,
       };
     } catch (error) {
-      player.terminate();
-      this.#adoptPlayerCanvas(player);
+      if (!published || generation === this.#lifecycleGeneration) {
+        terminateCandidate();
+      }
+      if (generation === this.#lifecycleGeneration) {
+        this.#adoptPlayerCanvas(player);
+      }
       throw error;
     }
   }
@@ -397,11 +429,30 @@ export class AuthoringExecutionClient {
     this.#player.resize(this.#canvas.clientWidth, this.#canvas.clientHeight, scale);
   }
 
+  #assertLifecycleCurrent(generation, terminateCandidate) {
+    if (generation === this.#lifecycleGeneration) {
+      return;
+    }
+    terminateCandidate();
+    throw new Error(LIFECYCLE_CANCELLED_MESSAGE);
+  }
+
   #requireStarted() {
     if (this.#player === null) {
       throw new Error("AuthoringExecutionClient has not been started");
     }
   }
+}
+
+function createIdempotentTerminator(player) {
+  let terminated = false;
+  return () => {
+    if (terminated) {
+      return;
+    }
+    terminated = true;
+    player.terminate();
+  };
 }
 
 function validateSceneJson(sceneJson) {


### PR DESCRIPTION
## Summary
- add one monotonic client-lifetime generation to `AuthoringExecutionClient`
- invalidate that generation before teardown so unpublished startup/rebuild candidates cannot publish afterward
- terminate stale candidates through an idempotent local terminator and avoid adopting stale candidate canvases
- guard initial legacy startup, legacy -> retained rebuilds, and retained -> legacy rebuilds, including the async host-callback configuration boundary
- add a deterministic Chromium race oracle covering all three cancellation boundaries and worker termination counts

## Architecture
The generation belongs only to the `AuthoringExecutionClient` lifetime. It is not a renderer generation, authoring revision, timeout, or second worker-ownership mechanism. Candidates remain locally owned until they pass the generation check; only then are they published to `#player`.

A stale candidate is terminated exactly once by an idempotent candidate terminator. Stale catches do not adopt its canvas or restore mode/backend state. Normal successful transitions keep the existing worker/canvas architecture unchanged.

## Tests
- terminate during initial `start()` rejects with the stable lifecycle-cancelled diagnostic and leaves state/metrics unstarted
- terminate during legacy -> retained cannot publish the retained worker pair
- terminate during retained -> legacy cannot publish the replacement legacy pair
- a normal legacy -> retained transition still succeeds before the reverse-race scenario
- instrumented Worker instances are terminated at most once
- the new smoke runs in the existing browser-reactive CI lane; web build syntax-checks the new script and modified client

Fixes #504. Related: #114, #491, #492.