### PR TITLE
Propagate GPU validation diagnostics through render workers

### DIFF
--- a/.github/workflows/renderer-recovery.yml
+++ b/.github/workflows/renderer-recovery.yml
@@ -10,11 +10,18 @@ on:
       - "scripts/renderer-webgl-context-loss-smoke.mjs"
       - "scripts/renderer-webgpu-device-loss-smoke.mjs"
       - "scripts/renderer-webgpu-validation-error-smoke.mjs"
+      - "scripts/renderer-worker-webgpu-validation-error-smoke.mjs"
       - "scripts/webgpu-device-capture.mjs"
       - "web/browser-smoke.html"
       - "web/browser-smoke.js"
       - "web/execution-renderer-smoke.html"
       - "web/execution-renderer-smoke.js"
+      - "web/execution-render-worker.js"
+      - "web/retained-execution-render-worker.js"
+      - "web/execution-worker-client.js"
+      - "web/retained-execution-worker-client.js"
+      - "web/authoring-execution-client.js"
+      - "web/render-gpu-diagnostics.js"
   push:
     branches:
       - master
@@ -26,11 +33,18 @@ on:
       - "scripts/renderer-webgl-context-loss-smoke.mjs"
       - "scripts/renderer-webgpu-device-loss-smoke.mjs"
       - "scripts/renderer-webgpu-validation-error-smoke.mjs"
+      - "scripts/renderer-worker-webgpu-validation-error-smoke.mjs"
       - "scripts/webgpu-device-capture.mjs"
       - "web/browser-smoke.html"
       - "web/browser-smoke.js"
       - "web/execution-renderer-smoke.html"
       - "web/execution-renderer-smoke.js"
+      - "web/execution-render-worker.js"
+      - "web/retained-execution-render-worker.js"
+      - "web/execution-worker-client.js"
+      - "web/retained-execution-worker-client.js"
+      - "web/authoring-execution-client.js"
+      - "web/render-gpu-diagnostics.js"
   workflow_dispatch:
 
 permissions:
@@ -118,6 +132,12 @@ jobs:
           NOON_RENDERER_VALIDATION_ERROR_ARTIFACTS: browser-smoke-artifacts/renderer-validation-error
         run: node scripts/renderer-webgpu-validation-error-smoke.mjs
 
+      - name: Test render-worker WebGPU validation propagation
+        id: worker_webgpu_validation_error
+        env:
+          NOON_RENDERER_VALIDATION_ARTIFACTS: browser-smoke-artifacts/render-worker-validation-error
+        run: node scripts/renderer-worker-webgpu-validation-error-smoke.mjs
+
       - name: Upload renderer initialization diagnostics
         if: always()
         uses: actions/upload-artifact@v4
@@ -151,5 +171,14 @@ jobs:
         with:
           name: renderer-webgpu-validation-error
           path: browser-smoke-artifacts/renderer-validation-error
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Upload render-worker WebGPU validation diagnostics
+        if: always() && steps.worker_webgpu_validation_error.outcome != 'skipped'
+        uses: actions/upload-artifact@v4
+        with:
+          name: render-worker-webgpu-validation-error
+          path: browser-smoke-artifacts/render-worker-validation-error
           if-no-files-found: error
           retention-days: 7

--- a/crates/noon-web/src/execution_canvas.rs
+++ b/crates/noon-web/src/execution_canvas.rs
@@ -19,7 +19,10 @@ mod wasm {
     use wasm_bindgen::prelude::*;
     use web_sys::OffscreenCanvas;
 
-    use crate::{ExecutionFrameMirror, TransportApplyOutcome};
+    use crate::{
+        gpu_diagnostics::{install_wgpu_error_handler, GpuDiagnosticMailbox},
+        ExecutionFrameMirror, TransportApplyOutcome,
+    };
 
     use super::{MANIM_DEFAULT_CAMERA_HEIGHT, MANIM_DEFAULT_CLEAR_COLOR};
 
@@ -62,6 +65,8 @@ mod wasm {
         last_instances_drawn: usize,
         last_bytes_uploaded: usize,
         last_geometry_cache_misses: usize,
+        gpu_generation: u32,
+        gpu_diagnostics: GpuDiagnosticMailbox,
     }
 
     #[wasm_bindgen(js_class = ExecutionCanvasRenderer)]
@@ -90,6 +95,9 @@ mod wasm {
                 backend,
                 config,
             } = initialize_gpu(&canvas, width, height).await?;
+            let gpu_generation = 1;
+            let gpu_diagnostics = GpuDiagnosticMailbox::default();
+            install_wgpu_error_handler(&device, gpu_generation, backend, gpu_diagnostics.clone());
             let renderer = GpuRenderer::new(&device, config.format);
 
             let mut result = Self {
@@ -112,6 +120,8 @@ mod wasm {
                 last_instances_drawn: 0,
                 last_bytes_uploaded: 0,
                 last_geometry_cache_misses: 0,
+                gpu_generation,
+                gpu_diagnostics,
             };
             result.update_camera()?;
             Ok(result)
@@ -160,11 +170,10 @@ mod wasm {
                         self.surface.configure(&self.device, &self.config);
                         return Ok(false);
                     }
-                    wgpu::CurrentSurfaceTexture::Validation => {
-                        return Err(js_message(
-                            "GPU backend rejected the OffscreenCanvas surface texture",
-                        ));
-                    }
+                    // The device error callback owns validation diagnostics. Keep
+                    // the pending frame intact so a recoverable validation can be
+                    // reported once and presentation retried unchanged.
+                    wgpu::CurrentSurfaceTexture::Validation => return Ok(false),
                 };
 
             let changes = mem::take(&mut self.pending_changes);
@@ -237,6 +246,19 @@ mod wasm {
                 wgpu::Backend::Gl => "WebGL2".to_owned(),
                 other => format!("{other:?}"),
             }
+        }
+
+        #[wasm_bindgen(js_name = gpuGeneration)]
+        pub fn gpu_generation(&self) -> u32 {
+            self.gpu_generation
+        }
+
+        #[wasm_bindgen(js_name = takeGpuDiagnosticJson)]
+        pub fn take_gpu_diagnostic_json(&self) -> Result<Option<String>, JsValue> {
+            self.gpu_diagnostics
+                .take_for_generation(self.gpu_generation)
+                .map(|diagnostic| serde_json::to_string(&diagnostic).map_err(js_error))
+                .transpose()
         }
 
         pub fn time(&self) -> f64 {

--- a/crates/noon-web/src/gpu_diagnostics.rs
+++ b/crates/noon-web/src/gpu_diagnostics.rs
@@ -1,0 +1,238 @@
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use serde::Serialize;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum GpuDiagnosticKind {
+    Validation,
+    OutOfMemory,
+    Internal,
+}
+
+impl GpuDiagnosticKind {
+    const fn severity(self) -> GpuDiagnosticSeverity {
+        match self {
+            Self::Validation => GpuDiagnosticSeverity::Recoverable,
+            Self::OutOfMemory | Self::Internal => GpuDiagnosticSeverity::Fatal,
+        }
+    }
+
+    const fn is_fatal(self) -> bool {
+        matches!(self.severity(), GpuDiagnosticSeverity::Fatal)
+    }
+
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Validation => "validation",
+            Self::OutOfMemory => "out-of-memory",
+            Self::Internal => "internal",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum GpuDiagnosticSeverity {
+    Recoverable,
+    Fatal,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub(crate) struct GpuDiagnostic {
+    pub generation: u32,
+    pub backend: String,
+    pub kind: GpuDiagnosticKind,
+    pub severity: GpuDiagnosticSeverity,
+    pub message: String,
+}
+
+impl GpuDiagnostic {
+    fn new(
+        generation: u32,
+        backend: impl Into<String>,
+        kind: GpuDiagnosticKind,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            generation,
+            backend: backend.into(),
+            kind,
+            severity: kind.severity(),
+            message: message.into(),
+        }
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    fn from_wgpu(generation: u32, backend: wgpu::Backend, error: wgpu::Error) -> Self {
+        let kind = match &error {
+            wgpu::Error::Validation { .. } => GpuDiagnosticKind::Validation,
+            wgpu::Error::OutOfMemory { .. } => GpuDiagnosticKind::OutOfMemory,
+            wgpu::Error::Internal { .. } => GpuDiagnosticKind::Internal,
+        };
+        let backend = match backend {
+            wgpu::Backend::BrowserWebGpu => "WebGPU".to_owned(),
+            wgpu::Backend::Gl => "WebGL2".to_owned(),
+            other => format!("{other:?}"),
+        };
+        Self::new(generation, backend, kind, error.to_string())
+    }
+
+    pub(crate) fn is_fatal(&self) -> bool {
+        self.kind.is_fatal()
+    }
+
+    pub(crate) fn formatted_message(&self) -> String {
+        format!(
+            "{} generation {} {} error: {}",
+            self.backend,
+            self.generation,
+            self.kind.label(),
+            self.message,
+        )
+    }
+}
+
+/// Bounded, generation-aware handoff from wgpu's asynchronous error callback.
+///
+/// At most one diagnostic is retained. A newer GPU generation replaces an older
+/// pending diagnostic, and a fatal diagnostic may replace a recoverable diagnostic
+/// from the same generation. This prevents validation-error bursts from growing
+/// memory or delaying an out-of-memory/internal failure behind recoverable noise.
+#[derive(Clone, Default)]
+pub(crate) struct GpuDiagnosticMailbox {
+    pending: Arc<Mutex<Option<GpuDiagnostic>>>,
+}
+
+impl GpuDiagnosticMailbox {
+    #[cfg(target_arch = "wasm32")]
+    pub(crate) fn record_wgpu(&self, generation: u32, backend: wgpu::Backend, error: wgpu::Error) {
+        self.record(GpuDiagnostic::from_wgpu(generation, backend, error));
+    }
+
+    fn record(&self, diagnostic: GpuDiagnostic) {
+        self.with_slot(|pending| {
+            let replace = match pending.as_ref() {
+                None => true,
+                Some(current) if current.generation < diagnostic.generation => true,
+                Some(current) if current.generation > diagnostic.generation => false,
+                Some(current) => !current.is_fatal() && diagnostic.is_fatal(),
+            };
+            if replace {
+                *pending = Some(diagnostic);
+            }
+        });
+    }
+
+    pub(crate) fn take_for_generation(&self, generation: u32) -> Option<GpuDiagnostic> {
+        self.with_slot(|pending| {
+            let pending_generation = pending.as_ref().map(|diagnostic| diagnostic.generation);
+            match pending_generation {
+                Some(current) if current < generation => {
+                    pending.take();
+                    None
+                }
+                Some(current) if current == generation => pending.take(),
+                _ => None,
+            }
+        })
+    }
+
+    fn with_slot<R>(&self, operation: impl FnOnce(&mut Option<GpuDiagnostic>) -> R) -> R {
+        let mut pending = self.lock();
+        operation(&mut pending)
+    }
+
+    fn lock(&self) -> MutexGuard<'_, Option<GpuDiagnostic>> {
+        self.pending
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub(crate) fn install_wgpu_error_handler(
+    device: &wgpu::Device,
+    generation: u32,
+    backend: wgpu::Backend,
+    mailbox: GpuDiagnosticMailbox,
+) {
+    device.on_uncaptured_error(Arc::new(move |error| {
+        mailbox.record_wgpu(generation, backend, error);
+    }));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{GpuDiagnostic, GpuDiagnosticKind, GpuDiagnosticMailbox, GpuDiagnosticSeverity};
+
+    fn diagnostic(generation: u32, kind: GpuDiagnosticKind, message: &str) -> GpuDiagnostic {
+        GpuDiagnostic::new(generation, "WebGPU", kind, message)
+    }
+
+    #[test]
+    fn validation_is_recoverable_and_one_shot() {
+        let mailbox = GpuDiagnosticMailbox::default();
+        mailbox.record(diagnostic(4, GpuDiagnosticKind::Validation, "first"));
+        mailbox.record(diagnostic(4, GpuDiagnosticKind::Validation, "second"));
+
+        let captured = mailbox.take_for_generation(4).expect("diagnostic");
+        assert_eq!(captured.message, "first");
+        assert_eq!(captured.severity, GpuDiagnosticSeverity::Recoverable);
+        assert!(mailbox.take_for_generation(4).is_none());
+    }
+
+    #[test]
+    fn fatal_same_generation_replaces_pending_validation() {
+        let mailbox = GpuDiagnosticMailbox::default();
+        mailbox.record(diagnostic(7, GpuDiagnosticKind::Validation, "recoverable"));
+        mailbox.record(diagnostic(7, GpuDiagnosticKind::Internal, "fatal"));
+        mailbox.record(diagnostic(
+            7,
+            GpuDiagnosticKind::Validation,
+            "late validation",
+        ));
+
+        let captured = mailbox.take_for_generation(7).expect("fatal diagnostic");
+        assert_eq!(captured.message, "fatal");
+        assert_eq!(captured.severity, GpuDiagnosticSeverity::Fatal);
+        assert!(mailbox.take_for_generation(7).is_none());
+    }
+
+    #[test]
+    fn newer_generation_replaces_older_and_stale_cannot_replace_future() {
+        let mailbox = GpuDiagnosticMailbox::default();
+        mailbox.record(diagnostic(2, GpuDiagnosticKind::Internal, "old fatal"));
+        mailbox.record(diagnostic(3, GpuDiagnosticKind::Validation, "current"));
+        mailbox.record(diagnostic(2, GpuDiagnosticKind::Internal, "stale"));
+
+        assert!(mailbox.take_for_generation(2).is_none());
+        let captured = mailbox.take_for_generation(3).expect("current diagnostic");
+        assert_eq!(captured.generation, 3);
+        assert_eq!(captured.message, "current");
+    }
+
+    #[test]
+    fn validation_burst_remains_bounded() {
+        let mailbox = GpuDiagnosticMailbox::default();
+        for index in 0..10_000 {
+            mailbox.record(diagnostic(
+                1,
+                GpuDiagnosticKind::Validation,
+                &format!("validation {index}"),
+            ));
+        }
+
+        assert!(mailbox.take_for_generation(1).is_some());
+        assert!(mailbox.take_for_generation(1).is_none());
+    }
+
+    #[test]
+    fn formatting_preserves_browser_error_context() {
+        let diagnostic = diagnostic(5, GpuDiagnosticKind::OutOfMemory, "allocation failed");
+        assert_eq!(
+            diagnostic.formatted_message(),
+            "WebGPU generation 5 out-of-memory error: allocation failed",
+        );
+    }
+}

--- a/crates/noon-web/src/legacy.rs
+++ b/crates/noon-web/src/legacy.rs
@@ -422,7 +422,7 @@ mod wasm {
         rc::Rc,
         sync::{
             atomic::{AtomicU32, Ordering},
-            Arc, Mutex,
+            Arc,
         },
     };
 
@@ -436,67 +436,18 @@ mod wasm {
     use wasm_bindgen_futures::spawn_local;
     use web_sys::{Event, HtmlCanvasElement};
 
+    use crate::gpu_diagnostics::{GpuDiagnostic, GpuDiagnosticMailbox};
+
     use super::{PlaybackClock, ReconcileOutcome, ScenePlayer};
 
     const GPU_QUERY_BYTES: u64 = 16;
     const GPU_PROFILE_SLOT_COUNT: usize = 4;
     const GPU_PROFILE_SAMPLE_CAPACITY: usize = 512;
 
-    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-    enum GpuUncapturedErrorKind {
-        Validation,
-        OutOfMemory,
-        Internal,
-    }
-
-    impl GpuUncapturedErrorKind {
-        const fn label(self) -> &'static str {
-            match self {
-                Self::Validation => "validation",
-                Self::OutOfMemory => "out-of-memory",
-                Self::Internal => "internal",
-            }
-        }
-
-        const fn is_fatal(self) -> bool {
-            !matches!(self, Self::Validation)
-        }
-    }
-
-    #[derive(Debug)]
-    struct GpuUncapturedError {
-        generation: u32,
-        kind: GpuUncapturedErrorKind,
-        message: String,
-    }
-
-    impl GpuUncapturedError {
-        fn from_wgpu(generation: u32, backend: wgpu::Backend, error: wgpu::Error) -> Self {
-            let kind = match &error {
-                wgpu::Error::Validation { .. } => GpuUncapturedErrorKind::Validation,
-                wgpu::Error::OutOfMemory { .. } => GpuUncapturedErrorKind::OutOfMemory,
-                wgpu::Error::Internal { .. } => GpuUncapturedErrorKind::Internal,
-            };
-            let backend = match backend {
-                wgpu::Backend::BrowserWebGpu => "WebGPU",
-                wgpu::Backend::Gl => "WebGL2",
-                _ => "GPU",
-            };
-            Self {
-                generation,
-                kind,
-                message: format!(
-                    "{backend} generation {generation} {} error: {error}",
-                    kind.label()
-                ),
-            }
-        }
-    }
-
     #[derive(Clone, Default)]
     struct GpuDeviceSignals {
         lost_generation: Arc<AtomicU32>,
-        uncaptured_error: Arc<Mutex<Option<GpuUncapturedError>>>,
+        uncaptured_error: GpuDiagnosticMailbox,
     }
 
     impl GpuDeviceSignals {
@@ -514,43 +465,12 @@ mod wasm {
             backend: wgpu::Backend,
             error: wgpu::Error,
         ) {
-            let captured = GpuUncapturedError::from_wgpu(generation, backend, error);
-            self.with_error_slot(|pending| {
-                let replace = match pending.as_ref() {
-                    None => true,
-                    Some(current) if current.generation < generation => true,
-                    Some(current) if current.generation > generation => false,
-                    Some(current) => !current.kind.is_fatal() && captured.kind.is_fatal(),
-                };
-                if replace {
-                    *pending = Some(captured);
-                }
-            });
+            self.uncaptured_error
+                .record_wgpu(generation, backend, error);
         }
 
-        fn take_uncaptured_error(&self, generation: u32) -> Option<GpuUncapturedError> {
-            self.with_error_slot(|pending| {
-                let pending_generation = pending.as_ref().map(|error| error.generation);
-                match pending_generation {
-                    Some(current) if current < generation => {
-                        pending.take();
-                        None
-                    }
-                    Some(current) if current == generation => pending.take(),
-                    _ => None,
-                }
-            })
-        }
-
-        fn with_error_slot<R>(
-            &self,
-            operation: impl FnOnce(&mut Option<GpuUncapturedError>) -> R,
-        ) -> R {
-            let mut pending = match self.uncaptured_error.lock() {
-                Ok(pending) => pending,
-                Err(poisoned) => poisoned.into_inner(),
-            };
-            operation(&mut pending)
+        fn take_uncaptured_error(&self, generation: u32) -> Option<GpuDiagnostic> {
+            self.uncaptured_error.take_for_generation(generation)
         }
     }
 
@@ -1470,10 +1390,11 @@ mod wasm {
             let Some(error) = self.gpu_signals.take_uncaptured_error(self.gpu_generation) else {
                 return Ok(());
             };
-            if error.kind.is_fatal() {
-                self.gpu_fatal_error = Some(error.message.clone());
+            let message = error.formatted_message();
+            if error.is_fatal() {
+                self.gpu_fatal_error = Some(message.clone());
             }
-            Err(js_message(&error.message))
+            Err(js_message(&message))
         }
 
         fn gpu_commands_ready(&self) -> bool {

--- a/crates/noon-web/src/lib.rs
+++ b/crates/noon-web/src/lib.rs
@@ -7,6 +7,7 @@ mod composition;
 mod determinism;
 mod execution_canvas;
 mod execution_transport;
+#[cfg(any(target_arch = "wasm32", test))]
 mod gpu_diagnostics;
 mod host_player;
 #[path = "legacy.rs"]

--- a/crates/noon-web/src/lib.rs
+++ b/crates/noon-web/src/lib.rs
@@ -7,6 +7,7 @@ mod composition;
 mod determinism;
 mod execution_canvas;
 mod execution_transport;
+mod gpu_diagnostics;
 mod host_player;
 #[path = "legacy.rs"]
 mod legacy;

--- a/crates/noon-web/src/retained_execution_canvas.rs
+++ b/crates/noon-web/src/retained_execution_canvas.rs
@@ -7,7 +7,10 @@ mod wasm {
     use wasm_bindgen::prelude::*;
     use web_sys::OffscreenCanvas;
 
-    use crate::{InstalledRetainedExecutionMirror, RetainedTransportApplyOutcome};
+    use crate::{
+        gpu_diagnostics::{install_wgpu_error_handler, GpuDiagnosticMailbox},
+        InstalledRetainedExecutionMirror, RetainedTransportApplyOutcome,
+    };
 
     const CLEAR_COLOR: wgpu::Color = wgpu::Color {
         r: 0.0,
@@ -54,6 +57,8 @@ mod wasm {
         last_bytes_uploaded: usize,
         last_geometry_cache_misses: usize,
         last_outline_cache_misses: u64,
+        gpu_generation: u32,
+        gpu_diagnostics: GpuDiagnosticMailbox,
     }
 
     #[wasm_bindgen(js_class = RetainedExecutionCanvasRenderer)]
@@ -97,6 +102,14 @@ mod wasm {
                 })
                 .await
                 .map_err(js_error)?;
+            let gpu_generation = 1;
+            let gpu_diagnostics = GpuDiagnosticMailbox::default();
+            install_wgpu_error_handler(
+                &device,
+                gpu_generation,
+                backend,
+                gpu_diagnostics.clone(),
+            );
 
             let width = canvas.width().max(1);
             let height = canvas.height().max(1);
@@ -131,6 +144,8 @@ mod wasm {
                 last_bytes_uploaded: 0,
                 last_geometry_cache_misses: 0,
                 last_outline_cache_misses: 0,
+                gpu_generation,
+                gpu_diagnostics,
             };
             result.update_camera()?;
             Ok(result)
@@ -180,11 +195,10 @@ mod wasm {
                         self.surface.configure(&self.device, &self.config);
                         return Ok(false);
                     }
-                    wgpu::CurrentSurfaceTexture::Validation => {
-                        return Err(js_message(
-                            "GPU backend rejected the retained execution surface texture",
-                        ));
-                    }
+                    // The device error callback owns validation diagnostics. Keep
+                    // the retained frame pending so a recoverable validation can
+                    // be reported once and presentation retried unchanged.
+                    wgpu::CurrentSurfaceTexture::Validation => return Ok(false),
                 };
 
             let frame = self
@@ -280,6 +294,19 @@ mod wasm {
                 wgpu::Backend::Gl => "WebGL2".to_owned(),
                 other => format!("{other:?}"),
             }
+        }
+
+        #[wasm_bindgen(js_name = gpuGeneration)]
+        pub fn gpu_generation(&self) -> u32 {
+            self.gpu_generation
+        }
+
+        #[wasm_bindgen(js_name = takeGpuDiagnosticJson)]
+        pub fn take_gpu_diagnostic_json(&self) -> Result<Option<String>, JsValue> {
+            self.gpu_diagnostics
+                .take_for_generation(self.gpu_generation)
+                .map(|diagnostic| serde_json::to_string(&diagnostic).map_err(js_error))
+                .transpose()
         }
 
         pub fn time(&self) -> f64 {

--- a/crates/noon-web/src/retained_execution_canvas.rs
+++ b/crates/noon-web/src/retained_execution_canvas.rs
@@ -104,12 +104,7 @@ mod wasm {
                 .map_err(js_error)?;
             let gpu_generation = 1;
             let gpu_diagnostics = GpuDiagnosticMailbox::default();
-            install_wgpu_error_handler(
-                &device,
-                gpu_generation,
-                backend,
-                gpu_diagnostics.clone(),
-            );
+            install_wgpu_error_handler(&device, gpu_generation, backend, gpu_diagnostics.clone());
 
             let width = canvas.width().max(1);
             let height = canvas.height().max(1);

--- a/scripts/build-web-demo.sh
+++ b/scripts/build-web-demo.sh
@@ -19,6 +19,7 @@ node --check web/execution-transport.js
 node --check web/execution-canvas.js
 node --check web/execution-engine-worker.js
 node --check web/execution-render-worker.js
+node --check web/render-gpu-diagnostics.js
 node --check web/execution-worker-client.js
 node --check web/retained-execution-engine-worker.js
 node --check web/retained-execution-render-worker.js
@@ -65,6 +66,7 @@ node --check scripts/updater-callback-smoke.mjs
 node --test web/example-gallery.test.mjs
 node --test web/execution-transport.test.mjs
 node --test web/execution-worker-client.test.mjs
+node --test web/render-gpu-diagnostics.test.mjs
 node --test web/execution-worker-startup.test.mjs
 node --test web/authoring-client.test.mjs
 node --test web/authoring-out-of-order-races.test.mjs

--- a/scripts/renderer-worker-webgpu-validation-error-smoke.mjs
+++ b/scripts/renderer-worker-webgpu-validation-error-smoke.mjs
@@ -1,0 +1,363 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import playwright from "playwright";
+
+import {
+  installWebGpuDeviceCaptureInWorker,
+  readWorkerWebGpuCapture,
+} from "./webgpu-device-capture.mjs";
+
+const { chromium } = playwright;
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const port = Number(process.env.NOON_RENDERER_VALIDATION_PORT ?? "4186");
+const baseUrl = `http://127.0.0.1:${port}`;
+const artifactDir = path.resolve(
+  repoRoot,
+  process.env.NOON_RENDERER_VALIDATION_ARTIFACTS ??
+    "browser-smoke-artifacts/renderer-webgpu-validation",
+);
+
+await mkdir(artifactDir, { recursive: true });
+
+let serverOutput = "";
+const server = spawn(
+  "python3",
+  ["-m", "http.server", String(port), "--bind", "127.0.0.1", "--directory", repoRoot],
+  { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] },
+);
+server.stdout.on("data", (chunk) => {
+  serverOutput += chunk;
+});
+server.stderr.on("data", (chunk) => {
+  serverOutput += chunk;
+});
+
+async function waitForServer() {
+  let lastError = null;
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    try {
+      const response = await fetch(`${baseUrl}/web/execution-worker-smoke.html`);
+      if (response.ok) return;
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`renderer validation server did not start: ${lastError}\n${serverOutput}`);
+}
+
+async function waitForWorkerCapture(worker, minimumDevices = 1, timeoutMs = 10_000) {
+  const deadline = Date.now() + timeoutMs;
+  let last = null;
+  while (Date.now() < deadline) {
+    last = await readWorkerWebGpuCapture(worker);
+    if (last.patchError !== null) {
+      throw new Error(`failed to patch render-worker WebGPU: ${last.patchError}`);
+    }
+    if (last.deviceCount >= minimumDevices) return last;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`Noon render worker did not expose ${minimumDevices} GPUDevice(s): ${JSON.stringify(last)}`);
+}
+
+async function renderMetrics(page, requestId) {
+  return page.evaluate(
+    ({ requestId }) =>
+      new Promise((resolve, reject) => {
+        const worker = window.__noonValidationHarness?.renderWorker;
+        if (!worker) {
+          reject(new Error("render worker is unavailable"));
+          return;
+        }
+        const timeout = setTimeout(() => {
+          worker.removeEventListener("message", onMessage);
+          reject(new Error(`render metrics request ${requestId} timed out`));
+        }, 10_000);
+        function onMessage(event) {
+          const message = event.data;
+          if (
+            message?.channel === "noon.render" &&
+            message?.protocolVersion === 1 &&
+            message?.requestId === requestId &&
+            message?.type === "metrics"
+          ) {
+            clearTimeout(timeout);
+            worker.removeEventListener("message", onMessage);
+            resolve(message.metrics);
+          }
+        }
+        worker.addEventListener("message", onMessage);
+        worker.postMessage({
+          channel: "noon.render",
+          protocolVersion: 1,
+          type: "metrics",
+          requestId,
+        });
+      }),
+    { requestId },
+  );
+}
+
+let browser = null;
+let page = null;
+const pageErrors = [];
+const consoleErrors = [];
+const diagnostics = {};
+
+try {
+  await waitForServer();
+  browser = await chromium.launch({
+    channel: "chromium",
+    headless: true,
+    args: [
+      "--enable-unsafe-webgpu",
+      "--enable-unsafe-swiftshader",
+      "--use-webgpu-adapter=swiftshader",
+      "--use-gpu-in-tests",
+      "--ignore-gpu-blocklist",
+      "--enable-features=Vulkan",
+      "--use-gl=angle",
+      "--use-angle=swiftshader",
+      "--use-vulkan=swiftshader",
+      "--disable-gpu-sandbox",
+      "--disable-dev-shm-usage",
+    ],
+  });
+  page = await browser.newPage({ viewport: { width: 900, height: 600 } });
+  page.on("pageerror", (error) => pageErrors.push(String(error)));
+  page.on("console", (message) => {
+    if (message.type() === "error") consoleErrors.push(message.text());
+  });
+
+  await page.goto(`${baseUrl}/web/execution-worker-smoke.html`, { waitUntil: "load" });
+  const renderWorkerPromise = page.waitForEvent("worker", {
+    predicate: (worker) => worker.url().endsWith("/web/execution-render-worker.js"),
+    timeout: 10_000,
+  });
+  await page.evaluate(() => {
+    const renderWorker = new Worker(
+      new URL("./execution-render-worker.js", window.location.href),
+      { type: "module", name: "noon-validation-render" },
+    );
+    window.__noonValidationHarness = {
+      renderWorker,
+      engineWorker: null,
+      renderMessages: [],
+      engineMessages: [],
+    };
+    renderWorker.addEventListener("message", (event) => {
+      window.__noonValidationHarness.renderMessages.push(event.data);
+    });
+  });
+  const renderWorker = await renderWorkerPromise;
+
+  await installWebGpuDeviceCaptureInWorker(renderWorker);
+
+  const engineWorkerPromise = page.waitForEvent("worker", {
+    predicate: (worker) => worker.url().endsWith("/web/execution-engine-worker.js"),
+    timeout: 10_000,
+  });
+  await page.evaluate(async () => {
+    const pkg = await import("./pkg/noon_web.js");
+    await pkg.default();
+    const sceneJson = pkg.demoSceneJson();
+    const canvas = document.querySelector("#scene");
+    const offscreen = canvas.transferControlToOffscreen();
+    const channel = new MessageChannel();
+    const harness = window.__noonValidationHarness;
+    const engineWorker = new Worker(
+      new URL("./execution-engine-worker.js", window.location.href),
+      { type: "module", name: "noon-validation-engine" },
+    );
+    harness.engineWorker = engineWorker;
+    engineWorker.addEventListener("message", (event) => {
+      harness.engineMessages.push(event.data);
+    });
+    harness.renderWorker.postMessage(
+      {
+        channel: "noon.render",
+        protocolVersion: 1,
+        type: "init",
+        canvas: offscreen,
+        port: channel.port2,
+        transportMode: "transferable",
+        width: 640,
+        height: 360,
+      },
+      [offscreen, channel.port2],
+    );
+    engineWorker.postMessage(
+      {
+        channel: "noon.engine",
+        protocolVersion: 1,
+        type: "init",
+        port: channel.port1,
+        sceneJson,
+        loopDurationSeconds: 4,
+        transportMode: "transferable",
+        sharedSlotCapacity: 1024 * 1024,
+        session: 1,
+      },
+      [channel.port1],
+    );
+  });
+  await engineWorkerPromise;
+
+  await page.waitForFunction(
+    () =>
+      window.__noonValidationHarness.renderMessages.some(
+        (message) => message?.channel === "noon.render" && message?.type === "ready",
+      ) &&
+      window.__noonValidationHarness.engineMessages.some(
+        (message) => message?.channel === "noon.engine" && message?.type === "ready",
+      ),
+    null,
+    { timeout: 30_000 },
+  );
+
+  const ready = await page.evaluate(() => ({
+    render: window.__noonValidationHarness.renderMessages.find(
+      (message) => message?.channel === "noon.render" && message?.type === "ready",
+    ),
+    engine: window.__noonValidationHarness.engineMessages.find(
+      (message) => message?.channel === "noon.engine" && message?.type === "ready",
+    ),
+  }));
+  diagnostics.ready = ready;
+  assert.equal(ready.render.backend, "WebGPU", `expected WebGPU, got ${ready.render.backend}`);
+  assert.equal(ready.render.gpuGeneration, 1, "initial GPU generation must be explicit");
+
+  const capturedBefore = await waitForWorkerCapture(renderWorker, 1);
+  diagnostics.captureBefore = capturedBefore;
+  assert.equal(capturedBefore.deviceCount, 1, "renderer must own exactly one initial GPU device");
+  assert.equal(capturedBefore.lost[0], null, "initial renderer device must be healthy");
+
+  let baseline = null;
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    baseline = await renderMetrics(page, 100 + attempt);
+    if (baseline.presentedFrames >= 2) break;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  diagnostics.baseline = baseline;
+  assert.equal(baseline.backend, "WebGPU");
+  assert.equal(baseline.gpuGeneration, 1);
+  assert.ok(baseline.presentedFrames >= 2, "renderer did not establish a healthy baseline");
+  assert.ok(baseline.objectCount > 0, "baseline scene is unexpectedly empty");
+
+  await renderWorker.evaluate(() => {
+    const device = globalThis.__noonWebGpuDeviceCapture?.devices?.[0];
+    if (!device) throw new Error("captured Noon GPUDevice is unavailable");
+    // WebGPU requires a non-zero buffer usage. usage=0 therefore generates a
+    // real GPUValidationError while returning an invalid buffer object; it does
+    // not intentionally lose or replace the device.
+    globalThis.__noonInvalidValidationBuffer = device.createBuffer({
+      label: "Noon validation diagnostic oracle",
+      size: 4,
+      usage: 0,
+    });
+  });
+
+  let diagnosticMetrics = null;
+  let recoverableCount = 0;
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    diagnosticMetrics = await renderMetrics(page, 150 + attempt);
+    recoverableCount = await page.evaluate(
+      () =>
+        window.__noonValidationHarness.renderMessages.filter(
+          (message) => message?.channel === "noon.render" && message?.type === "recoverable_error",
+        ).length,
+    );
+    if (recoverableCount >= 1) break;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  diagnostics.diagnosticMetrics = diagnosticMetrics;
+  assert.ok(
+    recoverableCount >= 1,
+    `worker control boundaries never surfaced the WebGPU validation diagnostic; last metrics=${JSON.stringify(diagnosticMetrics)}`,
+  );
+
+  // Cross several additional public worker boundaries to prove the mailbox is
+  // one-shot rather than merely delayed. No test-only production hook is needed.
+  for (let requestId = 190; requestId < 193; requestId += 1) {
+    await renderMetrics(page, requestId);
+  }
+
+  const afterDiagnostic = await page.evaluate(() => {
+    const messages = window.__noonValidationHarness.renderMessages;
+    return {
+      recoverable: messages.filter(
+        (message) => message?.channel === "noon.render" && message?.type === "recoverable_error",
+      ),
+      fatal: messages.filter(
+        (message) => message?.channel === "noon.render" && message?.type === "error",
+      ),
+    };
+  });
+  diagnostics.afterDiagnostic = afterDiagnostic;
+  assert.equal(afterDiagnostic.recoverable.length, 1, "validation must be reported exactly once");
+  assert.equal(afterDiagnostic.fatal.length, 0, "validation must not become a fatal worker error");
+  const diagnostic = afterDiagnostic.recoverable[0].diagnostic;
+  assert.equal(diagnostic.backend, "WebGPU");
+  assert.equal(diagnostic.generation, 1);
+  assert.equal(diagnostic.kind, "validation");
+  assert.equal(diagnostic.severity, "recoverable");
+  assert.match(diagnostic.message, /validation|buffer|usage/i);
+
+  let continued = null;
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    continued = await renderMetrics(page, 200 + attempt);
+    if (continued.presentedFrames > baseline.presentedFrames) break;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  diagnostics.continued = continued;
+  assert.equal(continued.backend, baseline.backend, "validation changed renderer backend");
+  assert.equal(continued.gpuGeneration, baseline.gpuGeneration, "validation changed GPU generation");
+  assert.equal(continued.objectCount, baseline.objectCount, "validation changed scene objects");
+  assert.ok(
+    continued.presentedFrames > baseline.presentedFrames,
+    "renderer did not continue presenting after validation error",
+  );
+
+  const capturedAfter = await waitForWorkerCapture(renderWorker, 1);
+  diagnostics.captureAfter = capturedAfter;
+  assert.equal(capturedAfter.deviceCount, 1, "validation must not request a replacement GPUDevice");
+  assert.equal(capturedAfter.lost[0], null, "validation must not lose the active GPUDevice");
+
+  await page.locator("#scene").screenshot({ path: path.join(artifactDir, "continued.png") });
+
+  const unexpectedConsoleErrors = consoleErrors.filter(
+    (message) => !/validation|buffer|usage|WebGPU/i.test(message),
+  );
+  assert.deepEqual(pageErrors, [], `page errors: ${pageErrors.join("\n")}`);
+  assert.deepEqual(
+    unexpectedConsoleErrors,
+    [],
+    `unexpected console errors: ${unexpectedConsoleErrors.join("\n")}`,
+  );
+
+  diagnostics.pageErrors = pageErrors;
+  diagnostics.consoleErrors = consoleErrors;
+  await writeFile(
+    path.join(artifactDir, "diagnostics.json"),
+    `${JSON.stringify(diagnostics, null, 2)}\n`,
+  );
+} catch (error) {
+  diagnostics.failure = String(error?.stack ?? error);
+  diagnostics.pageErrors = pageErrors;
+  diagnostics.consoleErrors = consoleErrors;
+  diagnostics.serverOutput = serverOutput;
+  await writeFile(
+    path.join(artifactDir, "diagnostics.json"),
+    `${JSON.stringify(diagnostics, null, 2)}\n`,
+  );
+  throw error;
+} finally {
+  await browser?.close();
+  server.kill("SIGTERM");
+}

--- a/scripts/webgpu-device-capture.mjs
+++ b/scripts/webgpu-device-capture.mjs
@@ -1,58 +1,72 @@
-export async function installWebGpuDeviceCapture(page) {
-  await page.addInitScript(() => {
-    const state = {
-      patched: false,
-      patchError: null,
-      devices: [],
-      lost: [],
-    };
-    window.__noonWebGpuDeviceCapture = state;
+function installCaptureState() {
+  const state = {
+    patched: false,
+    patchError: null,
+    devices: [],
+    lost: [],
+  };
+  globalThis.__noonWebGpuDeviceCapture = state;
 
-    try {
-      const gpu = navigator.gpu;
-      if (!gpu || typeof gpu.requestAdapter !== "function") {
-        state.patchError = "navigator.gpu.requestAdapter is unavailable";
-        return;
-      }
-      const originalRequestAdapter = gpu.requestAdapter.bind(gpu);
-      Object.defineProperty(gpu, "requestAdapter", {
-        configurable: true,
-        value: async (...adapterArgs) => {
-          const adapter = await originalRequestAdapter(...adapterArgs);
-          if (!adapter) return adapter;
-
-          const originalRequestDevice = adapter.requestDevice.bind(adapter);
-          Object.defineProperty(adapter, "requestDevice", {
-            configurable: true,
-            value: async (...deviceArgs) => {
-              const device = await originalRequestDevice(...deviceArgs);
-              const index = state.devices.length;
-              state.devices.push(device);
-              state.lost.push(null);
-              device.lost.then((info) => {
-                state.lost[index] = {
-                  reason: String(info.reason ?? "unknown"),
-                  message: String(info.message ?? ""),
-                };
-              });
-              return device;
-            },
-          });
-          return adapter;
-        },
-      });
-      state.patched = true;
-    } catch (error) {
-      state.patchError = String(error);
+  try {
+    const gpu = navigator.gpu;
+    if (!gpu || typeof gpu.requestAdapter !== "function") {
+      state.patchError = "navigator.gpu.requestAdapter is unavailable";
+      return;
     }
-  });
+    const originalRequestAdapter = gpu.requestAdapter.bind(gpu);
+    Object.defineProperty(gpu, "requestAdapter", {
+      configurable: true,
+      value: async (...adapterArgs) => {
+        const adapter = await originalRequestAdapter(...adapterArgs);
+        if (!adapter) return adapter;
+
+        const originalRequestDevice = adapter.requestDevice.bind(adapter);
+        Object.defineProperty(adapter, "requestDevice", {
+          configurable: true,
+          value: async (...deviceArgs) => {
+            const device = await originalRequestDevice(...deviceArgs);
+            const index = state.devices.length;
+            state.devices.push(device);
+            state.lost.push(null);
+            device.lost.then((info) => {
+              state.lost[index] = {
+                reason: String(info.reason ?? "unknown"),
+                message: String(info.message ?? ""),
+              };
+            });
+            return device;
+          },
+        });
+        return adapter;
+      },
+    });
+    state.patched = true;
+  } catch (error) {
+    state.patchError = String(error);
+  }
+}
+
+function captureSnapshot() {
+  return {
+    patched: globalThis.__noonWebGpuDeviceCapture?.patched ?? false,
+    patchError: globalThis.__noonWebGpuDeviceCapture?.patchError ?? null,
+    deviceCount: globalThis.__noonWebGpuDeviceCapture?.devices.length ?? 0,
+    lost: globalThis.__noonWebGpuDeviceCapture?.lost ?? [],
+  };
+}
+
+export async function installWebGpuDeviceCapture(page) {
+  await page.addInitScript(installCaptureState);
 }
 
 export function readWebGpuCapture(page) {
-  return page.evaluate(() => ({
-    patched: window.__noonWebGpuDeviceCapture?.patched ?? false,
-    patchError: window.__noonWebGpuDeviceCapture?.patchError ?? null,
-    deviceCount: window.__noonWebGpuDeviceCapture?.devices.length ?? 0,
-    lost: window.__noonWebGpuDeviceCapture?.lost ?? [],
-  }));
+  return page.evaluate(captureSnapshot);
+}
+
+export function installWebGpuDeviceCaptureInWorker(worker) {
+  return worker.evaluate(installCaptureState);
+}
+
+export function readWorkerWebGpuCapture(worker) {
+  return worker.evaluate(captureSnapshot);
 }

--- a/web/authoring-execution-client.js
+++ b/web/authoring-execution-client.js
@@ -246,7 +246,10 @@ export class AuthoringExecutionClient {
 
   async #rebuildRetained(sceneJson, retainedDocumentJson) {
     const canvas = this.#replaceTransferredCanvas();
-    const player = new RetainedExecutionWorkerClient(canvas, { onError: this.#onError });
+    const player = new RetainedExecutionWorkerClient(canvas, {
+      onError: this.#onError,
+      onRecoverableError: this.#onRecoverableError,
+    });
     try {
       const ready = await player.start(sceneJson, retainedDocumentJson, {
         loopDurationSeconds: this.#loopDurationSeconds,

--- a/web/execution-render-worker.js
+++ b/web/execution-render-worker.js
@@ -1,5 +1,9 @@
 import init, { ExecutionCanvasRenderer } from "./pkg/noon_web.js";
 import {
+  drainRendererGpuDiagnostics,
+  formatGpuDiagnostic,
+} from "./render-gpu-diagnostics.js";
+import {
   EXECUTION_TRANSPORT_SHARED,
   EXECUTION_TRANSPORT_TRANSFERABLE,
   SharedExecutionDeltaReader,
@@ -43,8 +47,10 @@ async function handleMainMessage(message) {
         width = normalizedDimension(message.width);
         height = normalizedDimension(message.height);
         renderer?.resize(width, height);
+        drainGpuDiagnostics();
         return;
       case "metrics":
+        if (!drainGpuDiagnostics()) return;
         respond(message.requestId, {
           type: "metrics",
           metrics: currentMetrics(),
@@ -111,6 +117,7 @@ function attachEngine(message) {
     type: "engine_port_attached",
     transportMode,
     backend: renderer.rendererBackend(),
+    gpuGeneration: renderer.gpuGeneration(),
   });
 }
 
@@ -196,13 +203,16 @@ async function bootstrapRenderer(initial) {
   try {
     renderer = await ExecutionCanvasRenderer.create(canvas, initial);
     renderer.resize(width, height);
+    if (!drainGpuDiagnostics()) return;
     needsPresent = true;
-    tryPresent();
     running = true;
+    tryPresent();
+    if (!running || !drainGpuDiagnostics()) return;
     postMain({
       type: "ready",
       transportMode,
       backend: renderer.rendererBackend(),
+      gpuGeneration: renderer.gpuGeneration(),
     });
     flushBootstrapQueue();
     drainTransport();
@@ -213,15 +223,16 @@ async function bootstrapRenderer(initial) {
 }
 
 function tryPresent() {
-  if (renderer === null || !needsPresent) {
+  if (renderer === null || !needsPresent || !drainGpuDiagnostics()) {
     return false;
   }
   if (!renderer.render()) {
+    drainGpuDiagnostics();
     return false;
   }
   needsPresent = false;
   presentedFrames += 1;
-  return true;
+  return drainGpuDiagnostics();
 }
 
 function flushBootstrapQueue() {
@@ -253,7 +264,7 @@ function scheduleFrame() {
 }
 
 function frame(timestamp) {
-  if (!running) {
+  if (!running || !drainGpuDiagnostics()) {
     return;
   }
   lastFrameTimestamp = timestamp;
@@ -265,8 +276,33 @@ function frame(timestamp) {
     flushBootstrapQueue();
     drainTransport();
   }
+  if (!running || !drainGpuDiagnostics()) {
+    return;
+  }
   renderPort.postMessage({ type: "tick", timestamp });
   scheduleFrame();
+}
+
+function drainGpuDiagnostics() {
+  if (renderer === null) return true;
+  try {
+    return drainRendererGpuDiagnostics(renderer, {
+      onRecoverable(diagnostic) {
+        postMain({
+          type: "recoverable_error",
+          owner: "render",
+          message: formatGpuDiagnostic(diagnostic),
+          diagnostic,
+        });
+      },
+      onFatal(diagnostic) {
+        fail(new Error(formatGpuDiagnostic(diagnostic)), null);
+      },
+    });
+  } catch (error) {
+    fail(error, null);
+    return false;
+  }
 }
 
 function currentMetrics() {
@@ -283,6 +319,7 @@ function currentMetrics() {
     ready: true,
     transportMode,
     backend: renderer.rendererBackend(),
+    gpuGeneration: renderer.gpuGeneration(),
     time: renderer.time(),
     objectCount: renderer.objectCount(),
     drawCalls: renderer.lastDrawCalls(),

--- a/web/execution-worker-client.js
+++ b/web/execution-worker-client.js
@@ -487,6 +487,14 @@ export class ExecutionWorkerClient {
             );
             return;
           }
+          if (message.type === "recoverable_error") {
+            const error = new Error(
+              message.message || `${owner} worker reported a recoverable error`,
+            );
+            error.diagnostic = message.diagnostic ?? null;
+            this.#notifyRecoverableError(error, owner);
+            return;
+          }
           if (message.type === "error") {
             const error = new Error(message.message || `${owner} worker failed`);
             if (message.requestId === null || message.requestId === undefined) {

--- a/web/render-gpu-diagnostics.js
+++ b/web/render-gpu-diagnostics.js
@@ -1,0 +1,66 @@
+export function drainRendererGpuDiagnostics(renderer, { onRecoverable, onFatal }) {
+  if (!renderer || typeof renderer.takeGpuDiagnosticJson !== "function") {
+    return true;
+  }
+  if (typeof onRecoverable !== "function" || typeof onFatal !== "function") {
+    throw new TypeError("renderer GPU diagnostics require recoverable and fatal handlers");
+  }
+
+  while (true) {
+    const raw = renderer.takeGpuDiagnosticJson();
+    if (raw === undefined || raw === null) {
+      return true;
+    }
+    const diagnostic = parseGpuDiagnostic(raw);
+    if (diagnostic.severity === "recoverable") {
+      onRecoverable(diagnostic);
+      continue;
+    }
+    onFatal(diagnostic);
+    return false;
+  }
+}
+
+export function formatGpuDiagnostic(diagnostic) {
+  const generation = Number.isSafeInteger(diagnostic?.generation)
+    ? ` generation ${diagnostic.generation}`
+    : "";
+  const backend = diagnostic?.backend || "GPU";
+  const kind = diagnostic?.kind ? ` ${diagnostic.kind}` : "";
+  const message = diagnostic?.message ? `: ${diagnostic.message}` : "";
+  return `${backend}${generation}${kind}${message}`;
+}
+
+function parseGpuDiagnostic(raw) {
+  let diagnostic;
+  try {
+    diagnostic = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`renderer returned invalid GPU diagnostic JSON: ${error}`);
+  }
+  if (!diagnostic || typeof diagnostic !== "object") {
+    throw new Error("renderer GPU diagnostic must be an object");
+  }
+  if (!Number.isSafeInteger(diagnostic.generation) || diagnostic.generation <= 0) {
+    throw new Error("renderer GPU diagnostic generation must be a positive safe integer");
+  }
+  if (typeof diagnostic.backend !== "string" || diagnostic.backend === "") {
+    throw new Error("renderer GPU diagnostic backend must be non-empty");
+  }
+  if (!["validation", "out_of_memory", "internal"].includes(diagnostic.kind)) {
+    throw new Error(`renderer GPU diagnostic has unknown kind ${diagnostic.kind}`);
+  }
+  if (!["recoverable", "fatal"].includes(diagnostic.severity)) {
+    throw new Error(`renderer GPU diagnostic has unknown severity ${diagnostic.severity}`);
+  }
+  if (typeof diagnostic.message !== "string" || diagnostic.message === "") {
+    throw new Error("renderer GPU diagnostic message must be non-empty");
+  }
+  if (diagnostic.kind === "validation" && diagnostic.severity !== "recoverable") {
+    throw new Error("renderer validation diagnostics must be recoverable");
+  }
+  if (diagnostic.kind !== "validation" && diagnostic.severity !== "fatal") {
+    throw new Error("renderer OOM/internal diagnostics must be fatal");
+  }
+  return diagnostic;
+}

--- a/web/render-gpu-diagnostics.test.mjs
+++ b/web/render-gpu-diagnostics.test.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { drainRendererGpuDiagnostics, formatGpuDiagnostic } from "./render-gpu-diagnostics.js";
+
+function fakeRenderer(records) {
+  const queue = [...records];
+  return { takeGpuDiagnosticJson: () => queue.shift() ?? null };
+}
+
+function encoded(kind, severity, message = "diagnostic") {
+  return JSON.stringify({ generation: 3, backend: "WebGPU", kind, severity, message });
+}
+
+test("recoverable validation drains without stopping", () => {
+  const recoverable = [];
+  const fatal = [];
+  assert.equal(
+    drainRendererGpuDiagnostics(
+      fakeRenderer([encoded("validation", "recoverable", "invalid usage")]),
+      {
+        onRecoverable: (value) => recoverable.push(value),
+        onFatal: (value) => fatal.push(value),
+      },
+    ),
+    true,
+  );
+  assert.equal(recoverable.length, 1);
+  assert.deepEqual(fatal, []);
+});
+
+test("fatal diagnostics stop draining", () => {
+  const recoverable = [];
+  const fatal = [];
+  assert.equal(
+    drainRendererGpuDiagnostics(
+      fakeRenderer([
+        encoded("out_of_memory", "fatal", "oom"),
+        encoded("validation", "recoverable", "must not drain"),
+      ]),
+      {
+        onRecoverable: (value) => recoverable.push(value),
+        onFatal: (value) => fatal.push(value),
+      },
+    ),
+    false,
+  );
+  assert.deepEqual(recoverable, []);
+  assert.equal(fatal.length, 1);
+});
+
+test("rejects inconsistent severity", () => {
+  assert.throws(
+    () =>
+      drainRendererGpuDiagnostics(fakeRenderer([encoded("validation", "fatal")]), {
+        onRecoverable() {},
+        onFatal() {},
+      }),
+    /validation diagnostics must be recoverable/,
+  );
+});
+
+test("formats diagnostic context", () => {
+  assert.equal(
+    formatGpuDiagnostic({
+      generation: 5,
+      backend: "WebGPU",
+      kind: "validation",
+      message: "invalid buffer",
+    }),
+    "WebGPU generation 5 validation: invalid buffer",
+  );
+});

--- a/web/retained-execution-render-worker.js
+++ b/web/retained-execution-render-worker.js
@@ -1,5 +1,9 @@
 import init, { RetainedExecutionCanvasRenderer } from "./pkg/noon_web.js";
 import {
+  drainRendererGpuDiagnostics,
+  formatGpuDiagnostic,
+} from "./render-gpu-diagnostics.js";
+import {
   EXECUTION_TRANSPORT_SHARED,
   EXECUTION_TRANSPORT_TRANSFERABLE,
   SharedExecutionDeltaReader,
@@ -46,11 +50,13 @@ async function handleMainMessage(message) {
         height = normalizedDimension(message.height);
         if (renderer !== null) {
           renderer.resize(width, height);
+          if (!drainGpuDiagnostics()) return;
           needsPresent = true;
           tryPresent();
         }
         return;
       case "metrics":
+        if (!drainGpuDiagnostics()) return;
         respond(message.requestId, { type: "metrics", metrics: currentMetrics() });
         return;
       case "stop":
@@ -117,6 +123,7 @@ function attachEngine(message) {
     retained: true,
     mixed: true,
     backend: renderer.rendererBackend(),
+    gpuGeneration: renderer.gpuGeneration(),
   });
 }
 
@@ -237,15 +244,18 @@ async function bootstrapRenderer(initial) {
       throw new Error("mixed retained execution renderer must begin from an applied snapshot");
     }
     renderer.resize(width, height);
+    if (!drainGpuDiagnostics()) return;
     needsPresent = true;
-    tryPresent();
     running = true;
+    tryPresent();
+    if (!running || !drainGpuDiagnostics()) return;
     postMain({
       type: "ready",
       transportMode,
       retained: true,
       mixed: true,
       backend: renderer.rendererBackend(),
+      gpuGeneration: renderer.gpuGeneration(),
     });
     flushBootstrapQueue();
     drainTransport();
@@ -256,15 +266,16 @@ async function bootstrapRenderer(initial) {
 }
 
 function tryPresent() {
-  if (renderer === null || !needsPresent) {
+  if (renderer === null || !needsPresent || !drainGpuDiagnostics()) {
     return false;
   }
   if (!renderer.render()) {
+    drainGpuDiagnostics();
     return false;
   }
   needsPresent = false;
   presentedFrames += 1;
-  return true;
+  return drainGpuDiagnostics();
 }
 
 function flushBootstrapQueue() {
@@ -296,7 +307,7 @@ function scheduleFrame() {
 }
 
 function frame(timestamp) {
-  if (!running) {
+  if (!running || !drainGpuDiagnostics()) {
     return;
   }
   lastFrameTimestamp = timestamp;
@@ -308,8 +319,33 @@ function frame(timestamp) {
     flushBootstrapQueue();
     drainTransport();
   }
+  if (!running || !drainGpuDiagnostics()) {
+    return;
+  }
   renderPort.postMessage({ type: "tick", timestamp });
   scheduleFrame();
+}
+
+function drainGpuDiagnostics() {
+  if (renderer === null) return true;
+  try {
+    return drainRendererGpuDiagnostics(renderer, {
+      onRecoverable(diagnostic) {
+        postMain({
+          type: "recoverable_error",
+          owner: "render",
+          message: formatGpuDiagnostic(diagnostic),
+          diagnostic,
+        });
+      },
+      onFatal(diagnostic) {
+        fail(new Error(formatGpuDiagnostic(diagnostic)), null);
+      },
+    });
+  } catch (error) {
+    fail(error, null);
+    return false;
+  }
 }
 
 function currentMetrics() {
@@ -331,6 +367,7 @@ function currentMetrics() {
     mixed: true,
     transportMode,
     backend: renderer.rendererBackend(),
+    gpuGeneration: renderer.gpuGeneration(),
     time: renderer.time(),
     objectCount: renderer.objectCount(),
     drawCalls: renderer.lastDrawCalls(),

--- a/web/retained-execution-worker-client.js
+++ b/web/retained-execution-worker-client.js
@@ -27,18 +27,23 @@ export class RetainedExecutionWorkerClient {
   #ready = null;
   #playing = true;
   #onError;
+  #onRecoverableError;
   #fatalOwner = null;
   #staleWorkerEvents = { engine: 0, render: 0 };
 
-  constructor(canvas, { onError = null } = {}) {
+  constructor(canvas, { onError = null, onRecoverableError = null } = {}) {
     if (!(canvas instanceof HTMLCanvasElement)) {
       throw new TypeError("RetainedExecutionWorkerClient requires an HTMLCanvasElement");
     }
     if (onError !== null && typeof onError !== "function") {
       throw new TypeError("RetainedExecutionWorkerClient onError must be a function");
     }
+    if (onRecoverableError !== null && typeof onRecoverableError !== "function") {
+      throw new TypeError("RetainedExecutionWorkerClient onRecoverableError must be a function");
+    }
     this.#canvas = canvas;
     this.#onError = onError;
+    this.#onRecoverableError = onRecoverableError;
   }
 
   get canvas() {
@@ -363,6 +368,14 @@ export class RetainedExecutionWorkerClient {
             resolve(message);
             return;
           }
+          if (message.type === "recoverable_error") {
+            const error = new Error(
+              message.message || `${owner} mixed retained worker reported a recoverable error`,
+            );
+            error.diagnostic = message.diagnostic ?? null;
+            this.#notifyRecoverableError(error, owner);
+            return;
+          }
           if (message.type === "error") {
             const error = new Error(message.message || `${owner} mixed retained worker failed`);
             if (message.requestId === null || message.requestId === undefined) {
@@ -465,6 +478,14 @@ export class RetainedExecutionWorkerClient {
   #notifyError(error, owner) {
     this.#markFatalOwner(owner);
     this.#onError?.(error, owner);
+  }
+
+  #notifyRecoverableError(error, owner) {
+    if (this.#onRecoverableError !== null) {
+      this.#onRecoverableError(error, owner);
+      return;
+    }
+    console.warn(`[Noon retained execution] recoverable ${owner} error`, error);
   }
 
   #rememberPlaying(result) {


### PR DESCRIPTION
## Summary
- propagate real `wgpu::Device::on_uncaptured_error` diagnostics from both execution render workers to the host API
- use one bounded, generation-aware diagnostic mailbox across main-thread and worker renderers instead of separate error policies
- treat WebGPU validation errors as recoverable while preserving fatal priority for out-of-memory/internal failures
- keep `CurrentSurfaceTexture::Validation` retryable in both public renderers so the device callback owns the one-shot diagnostic instead of turning the same recoverable condition into a fatal worker exception
- prevent a fatal diagnostic consumed during the first presentation from being followed by a stale `ready` event for that renderer generation
- add structured worker diagnostic parsing and host callbacks for ordinary and retained execution clients
- reuse the shared WebGPU device-capture helper for both page and dedicated-worker targets
- add a real Chromium oracle that injects a validation error through the render worker's actual `GPUDevice`

## Architecture
`GpuDiagnosticMailbox` is a bounded, generation-aware handoff from asynchronous wgpu callbacks. A newer GPU generation replaces an older pending diagnostic, a fatal same-generation diagnostic replaces recoverable validation noise, and stale generations cannot overwrite current state.

The same mailbox owns uncaptured-error policy for `NoonCanvasPlayer`, `ExecutionCanvasRenderer`, and `RetainedExecutionCanvasRenderer`. Surface validation leaves the pending frame intact and returns a retryable no-present result; the device callback supplies the structured diagnostic exactly once.

Both render workers enter their running lifecycle before the first present and verify that `fail()` did not clear it before publishing `ready`, preventing a fatal+ready contradiction for one renderer generation.

## Validation
Exact head `72214a0a7a0762e4e0a06eeed286e1ec8fa68b9e` already passed:
- CI: Rust format, Clippy, workspace tests, Web package, WebGPU/WebGL rendering, browser authoring, reactive/editor
- Renderer recovery, including the real render-worker WebGPU validation oracle
- Playground cross-browser, lifecycle, resize, authoring recovery, and playback controls
- Test coverage, Manim differential, and Manim API coverage

This PR is a byte-identical non-draft replacement for #496 because the existing draft could not be transitioned through the current GitHub automation path. No implementation was replayed or modified for this replacement.

Related: #111, #496.