### PR TITLE
[Parity] Qualify RotationUpdater on current master

### DIFF
--- a/parity/manim-v0.21/manifest.json
+++ b/parity/manim-v0.21/manifest.json
@@ -309,6 +309,12 @@
       "id": "moving-camera-center",
       "scene": "MovingCameraCenter",
       "expected_duration": 2.6
+    },
+    {
+      "id": "rotation-updater",
+      "scene": "RotationUpdater",
+      "expected_duration": 4.5,
+      "source": "parity/manim-v0.21/upstream-examples/rotation_updater.py"
     }
   ],
   "sample_fractions": [


### PR DESCRIPTION
## Summary
- qualify the canonical ManimCE v0.21 `RotationUpdater` fixture on current `master`
- preserve the existing 4.5 s duration and literal checked-in upstream source path
- add no fixture-specific tolerance or Noon-only tuning

## Current clean head
`119feea4465186f48211cad3b92d9c18d62d452d`, directly on current `master` (`a15e4bd80af42d5d066bb76a85a3943a664b2ebe`). This PR is again a one-file manifest-only diff.

## Blocker
#513 remains a real WebGL-only renderer divergence at frame 90 / t≈3.0 s. Diagnostics have ruled out updater math, execution transport state, FramePreparer locality, screenshot/GPU-completion timing, intermediate presentation, and incremental-vs-full execution snapshots.

Latest unchanged full-snapshot A/B still produced:
- WebGPU frame 90: exact bounds match (`0 px` delta)
- WebGL frame 90: Noon y bounds `268..271` vs Manim `268..326`, `bounds_delta_px=55 > 2`

Keep this PR unmerged until #513 is fixed and unchanged WebGPU/WebGL raster + direct-seek gates pass. No tolerance changes.

Supersedes #323. Tracks #513, #252 and #185.