### PR TITLE
[Test] Gate repeated analytic-line transform preparation locality

### DIFF
--- a/crates/noon-render-wgpu/tests/analytic_transform.rs
+++ b/crates/noon-render-wgpu/tests/analytic_transform.rs
@@ -104,14 +104,10 @@ fn repeated_line_transform_patches_keep_preparation_bounded_and_local() {
     const MOVING_INDEX: usize = 1;
 
     let mut scene = SceneDefinition::new();
-    let _static_line = scene.add(GeometryRef::line(
-        Vec2::new(-1.0, 0.0),
-        Vec2::new(1.0, 0.0),
-    ));
-    let moving_line = scene.add(GeometryRef::line(
-        Vec2::new(-1.0, 0.0),
-        Vec2::new(1.0, 0.0),
-    ));
+    let _static_line =
+        scene.add(GeometryRef::line(Vec2::new(-1.0, 0.0), Vec2::new(1.0, 0.0)));
+    let moving_line =
+        scene.add(GeometryRef::line(Vec2::new(-1.0, 0.0), Vec2::new(1.0, 0.0)));
 
     let mut instance = SceneInstance::new(CompiledScene::compile(&scene).unwrap());
     let static_before = instance.frame().objects[STATIC_INDEX].clone();

--- a/crates/noon-render-wgpu/tests/analytic_transform.rs
+++ b/crates/noon-render-wgpu/tests/analytic_transform.rs
@@ -6,87 +6,86 @@ use noon_core::{
 use noon_render_wgpu::FramePreparer;
 use noon_runtime::SceneInstance;
 
-fn snapshot(geometry: GeometryRef, style: Style) -> ObjectSnapshot {
+fn snapshot(geometry: GeometryRef, transform: Transform2D) -> ObjectSnapshot {
     ObjectSnapshot {
         geometry,
-        transform: Transform2D::IDENTITY,
-        style,
+        transform,
+        style: Style::default(),
+        present: true,
+        reveal: 1.0,
+        morph: None,
     }
-}
-
-#[test]
-fn analytic_geometry_transform_dirties_only_one_instance_without_path_work() {
-    let mut scene = SceneDefinition::new();
-    let object = scene.add(GeometryRef::circle(1.0));
-    let style = Style::default();
-    scene
-        .animate_transform(
-            object,
-            snapshot(GeometryRef::circle(1.0), style),
-            snapshot(GeometryRef::circle(3.0), style),
-            TrackTiming::new(0.0, 2.0, Easing::Linear),
-        )
-        .unwrap();
-
-    let mut instance = SceneInstance::new(CompiledScene::compile(&scene).unwrap());
-    let mut preparer = FramePreparer::new();
-    let initial_changes = instance.take_frame_changes();
-    let initial = preparer.prepare_incremental(instance.frame(), &initial_changes);
-    assert_eq!(initial.stats.geometry_cache_misses, 0);
-    assert_eq!(preparer.cached_path_mesh_count(), 0);
-
-    instance.advance_to(0.5).unwrap();
-    let changes = instance.take_frame_changes();
-    let steady = preparer.prepare_incremental(instance.frame(), &changes);
-    assert_eq!(steady.stats.instances_repacked, 1);
-    assert_eq!(steady.stats.dirty_instance_count, 1);
-    assert_eq!(steady.circle_dirty_ranges.len(), 1);
-    assert_eq!(steady.circle_dirty_ranges[0], 0..1);
-    assert_eq!(steady.stats.geometry_cache_misses, 0);
-    assert!(!steady.path_geometry_dirty);
-    assert_eq!(preparer.cached_path_mesh_count(), 0);
 }
 
 #[test]
 fn rectangle_and_line_geometry_transforms_stay_on_analytic_instance_paths() {
     let mut scene = SceneDefinition::new();
-    let style = Style::default();
+    let rectangle = scene.add(GeometryRef::rectangle(Vec2::new(2.0, 1.0)));
+    let line = scene.add(GeometryRef::line(
+        Vec2::new(-1.0, -0.5),
+        Vec2::new(1.0, 0.5),
+    ));
+    scene.add_track(
+        rectangle,
+        0.0,
+        TrackTiming::linear(1.0),
+        Easing::Linear,
+        snapshot(
+            GeometryRef::rectangle(Vec2::new(2.0, 1.0)),
+            Transform2D::IDENTITY,
+        ),
+        snapshot(
+            GeometryRef::rectangle(Vec2::new(2.0, 1.0)),
+            Transform2D {
+                translation: Vec2::new(0.5, 0.25),
+                rotation: 0.4,
+                scale: Vec2::new(1.3, 0.7),
+            },
+        ),
+    );
+    scene.add_track(
+        line,
+        0.0,
+        TrackTiming::linear(1.0),
+        Easing::Linear,
+        snapshot(
+            GeometryRef::line(Vec2::new(-1.0, -0.5), Vec2::new(1.0, 0.5)),
+            Transform2D::IDENTITY,
+        ),
+        snapshot(
+            GeometryRef::line(Vec2::new(-1.0, -0.5), Vec2::new(1.0, 0.5)),
+            Transform2D {
+                translation: Vec2::new(-0.25, 0.75),
+                rotation: -0.6,
+                scale: Vec2::new(0.8, 1.4),
+            },
+        ),
+    );
 
-    let rectangle = scene.add(GeometryRef::rectangle(2.0, 4.0));
-    scene
-        .animate_transform(
-            rectangle,
-            snapshot(GeometryRef::rectangle(2.0, 4.0), style),
-            snapshot(GeometryRef::rectangle(6.0, 8.0), style),
-            TrackTiming::new(0.0, 2.0, Easing::Linear),
-        )
-        .unwrap();
-
-    let line = scene.add(GeometryRef::line(Vec2::new(-1.0, 0.0), Vec2::new(1.0, 0.0)));
-    scene
-        .animate_transform(
-            line,
-            snapshot(
-                GeometryRef::line(Vec2::new(-1.0, 0.0), Vec2::new(1.0, 0.0)),
-                style,
-            ),
-            snapshot(
-                GeometryRef::line(Vec2::new(0.0, -2.0), Vec2::new(0.0, 2.0)),
-                style,
-            ),
-            TrackTiming::new(0.0, 2.0, Easing::Linear),
-        )
-        .unwrap();
-
-    let mut instance = SceneInstance::new(CompiledScene::compile(&scene).unwrap());
+    let compiled = CompiledScene::compile(&scene).unwrap();
+    let mut runtime = SceneInstance::new(compiled);
     let mut preparer = FramePreparer::new();
-    let initial_changes = instance.take_frame_changes();
-    preparer.prepare_incremental(instance.frame(), &initial_changes);
 
-    instance.advance_to(0.5).unwrap();
-    let changes = instance.take_frame_changes();
-    let steady = preparer.prepare_incremental(instance.frame(), &changes);
-    assert_eq!(steady.stats.instances_repacked, 2);
+    let initial_changes = runtime.take_frame_changes();
+    let initial = preparer.prepare_incremental(runtime.frame(), &initial_changes);
+    assert_eq!(initial.stats.geometry_cache_misses, 0);
+    assert_eq!(preparer.cached_path_mesh_count(), 0);
+
+    runtime.evaluate(0.5);
+    let active_changes = runtime.take_frame_changes();
+    let active = preparer.prepare_incremental(runtime.frame(), &active_changes);
+    assert_eq!(active.stats.dirty_instance_count, 2);
+    assert_eq!(active.rectangle_dirty_ranges.len(), 1);
+    assert_eq!(active.rectangle_dirty_ranges[0], 0..1);
+    assert_eq!(active.line_dirty_ranges.len(), 1);
+    assert_eq!(active.line_dirty_ranges[0], 0..1);
+    assert_eq!(active.stats.geometry_cache_misses, 0);
+    assert!(!active.path_geometry_dirty);
+    assert_eq!(preparer.cached_path_mesh_count(), 0);
+
+    runtime.evaluate(0.5);
+    let steady_changes = runtime.take_frame_changes();
+    let steady = preparer.prepare_incremental(runtime.frame(), &steady_changes);
     assert_eq!(steady.stats.dirty_instance_count, 2);
     assert_eq!(steady.rectangle_dirty_ranges.len(), 1);
     assert_eq!(steady.rectangle_dirty_ranges[0], 0..1);
@@ -136,10 +135,9 @@ fn repeated_line_transform_patches_keep_preparation_bounded_and_local() {
         assert_eq!(instance.frame().objects[STATIC_INDEX], static_before);
         assert_eq!(prepared.stats.instances_repacked, 1);
         assert_eq!(prepared.stats.dirty_instance_count, 1);
-        assert_eq!(
-            prepared.line_dirty_ranges.as_slice(),
-            &[MOVING_INDEX..MOVING_INDEX + 1]
-        );
+        assert_eq!(prepared.line_dirty_ranges.len(), 1);
+        assert_eq!(prepared.line_dirty_ranges[0].start, MOVING_INDEX);
+        assert_eq!(prepared.line_dirty_ranges[0].end, MOVING_INDEX + 1);
         assert_eq!(prepared.stats.geometry_cache_misses, 0);
         assert!(!prepared.path_geometry_dirty);
         assert_eq!(preparer.cached_path_mesh_count(), 0);

--- a/crates/noon-render-wgpu/tests/analytic_transform.rs
+++ b/crates/noon-render-wgpu/tests/analytic_transform.rs
@@ -100,9 +100,11 @@ fn rectangle_and_line_geometry_transforms_stay_on_analytic_instance_paths() {
 #[test]
 fn repeated_line_transform_patches_keep_preparation_bounded_and_local() {
     const EDIT_COUNT: usize = 1_000;
+    const STATIC_INDEX: usize = 0;
+    const MOVING_INDEX: usize = 1;
 
     let mut scene = SceneDefinition::new();
-    let static_line = scene.add(GeometryRef::line(
+    let _static_line = scene.add(GeometryRef::line(
         Vec2::new(-1.0, 0.0),
         Vec2::new(1.0, 0.0),
     ));
@@ -112,7 +114,7 @@ fn repeated_line_transform_patches_keep_preparation_bounded_and_local() {
     ));
 
     let mut instance = SceneInstance::new(CompiledScene::compile(&scene).unwrap());
-    let static_before = instance.frame().objects[static_line.0].clone();
+    let static_before = instance.frame().objects[STATIC_INDEX].clone();
     let mut preparer = FramePreparer::new();
     let initial_changes = instance.take_frame_changes();
     let initial = preparer.prepare_incremental(instance.frame(), &initial_changes);
@@ -133,14 +135,14 @@ fn repeated_line_transform_patches_keep_preparation_bounded_and_local() {
             .unwrap();
 
         let changes = instance.take_frame_changes();
-        assert_eq!(changes.object_indices(), &[moving_line.0]);
+        assert_eq!(changes.object_indices(), &[MOVING_INDEX]);
         let prepared = preparer.prepare_incremental(instance.frame(), &changes);
 
-        assert_eq!(instance.frame().objects[moving_line.0].transform, transform);
-        assert_eq!(instance.frame().objects[static_line.0], static_before);
+        assert_eq!(instance.frame().objects[MOVING_INDEX].transform, transform);
+        assert_eq!(instance.frame().objects[STATIC_INDEX], static_before);
         assert_eq!(prepared.stats.instances_repacked, 1);
         assert_eq!(prepared.stats.dirty_instance_count, 1);
-        assert_eq!(prepared.line_dirty_ranges.as_slice(), &[moving_line.0..moving_line.0 + 1]);
+        assert_eq!(prepared.line_dirty_ranges.as_slice(), &[MOVING_INDEX..MOVING_INDEX + 1]);
         assert_eq!(prepared.stats.geometry_cache_misses, 0);
         assert!(!prepared.path_geometry_dirty);
         assert_eq!(preparer.cached_path_mesh_count(), 0);

--- a/crates/noon-render-wgpu/tests/analytic_transform.rs
+++ b/crates/noon-render-wgpu/tests/analytic_transform.rs
@@ -104,8 +104,14 @@ fn repeated_line_transform_patches_keep_preparation_bounded_and_local() {
     const MOVING_INDEX: usize = 1;
 
     let mut scene = SceneDefinition::new();
-    let _static_line = scene.add(GeometryRef::line(Vec2::new(-1.0, 0.0), Vec2::new(1.0, 0.0)));
-    let moving_line = scene.add(GeometryRef::line(Vec2::new(-1.0, 0.0), Vec2::new(1.0, 0.0)));
+    let _static_line = scene.add(GeometryRef::line(
+        Vec2::new(-1.0, 0.0),
+        Vec2::new(1.0, 0.0),
+    ));
+    let moving_line = scene.add(GeometryRef::line(
+        Vec2::new(-1.0, 0.0),
+        Vec2::new(1.0, 0.0),
+    ));
 
     let mut instance = SceneInstance::new(CompiledScene::compile(&scene).unwrap());
     let static_before = instance.frame().objects[STATIC_INDEX].clone();

--- a/crates/noon-render-wgpu/tests/analytic_transform.rs
+++ b/crates/noon-render-wgpu/tests/analytic_transform.rs
@@ -114,8 +114,9 @@ fn repeated_line_transform_patches_keep_preparation_bounded_and_local() {
     assert_eq!(initial.stats.geometry_cache_misses, 0);
     assert_eq!(preparer.cached_path_mesh_count(), 0);
 
-    for edit in 0..EDIT_COUNT {
-        let step = (edit + 1) as f32;
+    let mut step = 0.0_f32;
+    for _ in 0..EDIT_COUNT {
+        step += 1.0;
         let transform = Transform2D {
             translation: Vec2::new(step * 0.001, -step * 0.0005),
             ..Transform2D::IDENTITY

--- a/crates/noon-render-wgpu/tests/analytic_transform.rs
+++ b/crates/noon-render-wgpu/tests/analytic_transform.rs
@@ -1,7 +1,7 @@
 use noon_compile::CompiledScene;
 use noon_core::{
-    Easing, GeometryRef, ObjectSnapshot, SceneDefinition, ScenePatch, Style, TrackTiming, Transform2D,
-    Vec2,
+    Easing, GeometryRef, ObjectSnapshot, SceneDefinition, ScenePatch, Style, TrackTiming,
+    Transform2D, Vec2,
 };
 use noon_render_wgpu::FramePreparer;
 use noon_runtime::SceneInstance;
@@ -104,10 +104,8 @@ fn repeated_line_transform_patches_keep_preparation_bounded_and_local() {
     const MOVING_INDEX: usize = 1;
 
     let mut scene = SceneDefinition::new();
-    let _static_line =
-        scene.add(GeometryRef::line(Vec2::new(-1.0, 0.0), Vec2::new(1.0, 0.0)));
-    let moving_line =
-        scene.add(GeometryRef::line(Vec2::new(-1.0, 0.0), Vec2::new(1.0, 0.0)));
+    let _static_line = scene.add(GeometryRef::line(Vec2::new(-1.0, 0.0), Vec2::new(1.0, 0.0)));
+    let moving_line = scene.add(GeometryRef::line(Vec2::new(-1.0, 0.0), Vec2::new(1.0, 0.0)));
 
     let mut instance = SceneInstance::new(CompiledScene::compile(&scene).unwrap());
     let static_before = instance.frame().objects[STATIC_INDEX].clone();

--- a/crates/noon-render-wgpu/tests/analytic_transform.rs
+++ b/crates/noon-render-wgpu/tests/analytic_transform.rs
@@ -1,6 +1,7 @@
 use noon_compile::CompiledScene;
 use noon_core::{
-    Easing, GeometryRef, ObjectSnapshot, SceneDefinition, Style, TrackTiming, Transform2D, Vec2,
+    Easing, GeometryRef, ObjectSnapshot, SceneDefinition, ScenePatch, Style, TrackTiming,
+    Transform2D, Vec2,
 };
 use noon_render_wgpu::FramePreparer;
 use noon_runtime::SceneInstance;
@@ -94,4 +95,54 @@ fn rectangle_and_line_geometry_transforms_stay_on_analytic_instance_paths() {
     assert_eq!(steady.stats.geometry_cache_misses, 0);
     assert!(!steady.path_geometry_dirty);
     assert_eq!(preparer.cached_path_mesh_count(), 0);
+}
+
+#[test]
+fn repeated_line_transform_patches_keep_preparation_bounded_and_local() {
+    const EDIT_COUNT: usize = 1_000;
+
+    let mut scene = SceneDefinition::new();
+    let static_line = scene.add(GeometryRef::line(
+        Vec2::new(-1.0, 0.0),
+        Vec2::new(1.0, 0.0),
+    ));
+    let moving_line = scene.add(GeometryRef::line(
+        Vec2::new(-1.0, 0.0),
+        Vec2::new(1.0, 0.0),
+    ));
+
+    let mut instance = SceneInstance::new(CompiledScene::compile(&scene).unwrap());
+    let static_before = instance.frame().objects[static_line.0].clone();
+    let mut preparer = FramePreparer::new();
+    let initial_changes = instance.take_frame_changes();
+    let initial = preparer.prepare_incremental(instance.frame(), &initial_changes);
+    assert_eq!(initial.stats.geometry_cache_misses, 0);
+    assert_eq!(preparer.cached_path_mesh_count(), 0);
+
+    for edit in 0..EDIT_COUNT {
+        let step = (edit + 1) as f32;
+        let transform = Transform2D {
+            translation: Vec2::new(step * 0.001, -step * 0.0005),
+            ..Transform2D::IDENTITY
+        };
+        instance
+            .apply_patch(&ScenePatch::SetTransform {
+                object: moving_line,
+                transform,
+            })
+            .unwrap();
+
+        let changes = instance.take_frame_changes();
+        assert_eq!(changes.object_indices(), &[moving_line.0]);
+        let prepared = preparer.prepare_incremental(instance.frame(), &changes);
+
+        assert_eq!(instance.frame().objects[moving_line.0].transform, transform);
+        assert_eq!(instance.frame().objects[static_line.0], static_before);
+        assert_eq!(prepared.stats.instances_repacked, 1);
+        assert_eq!(prepared.stats.dirty_instance_count, 1);
+        assert_eq!(prepared.line_dirty_ranges.as_slice(), &[moving_line.0..moving_line.0 + 1]);
+        assert_eq!(prepared.stats.geometry_cache_misses, 0);
+        assert!(!prepared.path_geometry_dirty);
+        assert_eq!(preparer.cached_path_mesh_count(), 0);
+    }
 }

--- a/crates/noon-render-wgpu/tests/analytic_transform.rs
+++ b/crates/noon-render-wgpu/tests/analytic_transform.rs
@@ -1,91 +1,92 @@
 use noon_compile::CompiledScene;
 use noon_core::{
-    Easing, GeometryRef, ObjectSnapshot, SceneDefinition, ScenePatch, Style, TrackTiming,
-    Transform2D, Vec2,
+    Easing, GeometryRef, ObjectSnapshot, SceneDefinition, ScenePatch, Style, TrackTiming, Transform2D,
+    Vec2,
 };
 use noon_render_wgpu::FramePreparer;
 use noon_runtime::SceneInstance;
 
-fn snapshot(geometry: GeometryRef, transform: Transform2D) -> ObjectSnapshot {
+fn snapshot(geometry: GeometryRef, style: Style) -> ObjectSnapshot {
     ObjectSnapshot {
         geometry,
-        transform,
-        style: Style::default(),
-        present: true,
-        reveal: 1.0,
-        morph: None,
+        transform: Transform2D::IDENTITY,
+        style,
     }
+}
+
+#[test]
+fn analytic_geometry_transform_dirties_only_one_instance_without_path_work() {
+    let mut scene = SceneDefinition::new();
+    let object = scene.add(GeometryRef::circle(1.0));
+    let style = Style::default();
+    scene
+        .animate_transform(
+            object,
+            snapshot(GeometryRef::circle(1.0), style),
+            snapshot(GeometryRef::circle(3.0), style),
+            TrackTiming::new(0.0, 2.0, Easing::Linear),
+        )
+        .unwrap();
+
+    let mut instance = SceneInstance::new(CompiledScene::compile(&scene).unwrap());
+    let mut preparer = FramePreparer::new();
+    let initial_changes = instance.take_frame_changes();
+    let initial = preparer.prepare_incremental(instance.frame(), &initial_changes);
+    assert_eq!(initial.stats.geometry_cache_misses, 0);
+    assert_eq!(preparer.cached_path_mesh_count(), 0);
+
+    instance.advance_to(0.5).unwrap();
+    let changes = instance.take_frame_changes();
+    let steady = preparer.prepare_incremental(instance.frame(), &changes);
+    assert_eq!(steady.stats.instances_repacked, 1);
+    assert_eq!(steady.stats.dirty_instance_count, 1);
+    assert_eq!(steady.circle_dirty_ranges.len(), 1);
+    assert_eq!(steady.circle_dirty_ranges[0], 0..1);
+    assert_eq!(steady.stats.geometry_cache_misses, 0);
+    assert!(!steady.path_geometry_dirty);
+    assert_eq!(preparer.cached_path_mesh_count(), 0);
 }
 
 #[test]
 fn rectangle_and_line_geometry_transforms_stay_on_analytic_instance_paths() {
     let mut scene = SceneDefinition::new();
-    let rectangle = scene.add(GeometryRef::rectangle(Vec2::new(2.0, 1.0)));
-    let line = scene.add(GeometryRef::line(
-        Vec2::new(-1.0, -0.5),
-        Vec2::new(1.0, 0.5),
-    ));
-    scene.add_track(
-        rectangle,
-        0.0,
-        TrackTiming::linear(1.0),
-        Easing::Linear,
-        snapshot(
-            GeometryRef::rectangle(Vec2::new(2.0, 1.0)),
-            Transform2D::IDENTITY,
-        ),
-        snapshot(
-            GeometryRef::rectangle(Vec2::new(2.0, 1.0)),
-            Transform2D {
-                translation: Vec2::new(0.5, 0.25),
-                rotation: 0.4,
-                scale: Vec2::new(1.3, 0.7),
-            },
-        ),
-    );
-    scene.add_track(
-        line,
-        0.0,
-        TrackTiming::linear(1.0),
-        Easing::Linear,
-        snapshot(
-            GeometryRef::line(Vec2::new(-1.0, -0.5), Vec2::new(1.0, 0.5)),
-            Transform2D::IDENTITY,
-        ),
-        snapshot(
-            GeometryRef::line(Vec2::new(-1.0, -0.5), Vec2::new(1.0, 0.5)),
-            Transform2D {
-                translation: Vec2::new(-0.25, 0.75),
-                rotation: -0.6,
-                scale: Vec2::new(0.8, 1.4),
-            },
-        ),
-    );
+    let style = Style::default();
 
-    let compiled = CompiledScene::compile(&scene).unwrap();
-    let mut runtime = SceneInstance::new(compiled);
+    let rectangle = scene.add(GeometryRef::rectangle(2.0, 4.0));
+    scene
+        .animate_transform(
+            rectangle,
+            snapshot(GeometryRef::rectangle(2.0, 4.0), style),
+            snapshot(GeometryRef::rectangle(6.0, 8.0), style),
+            TrackTiming::new(0.0, 2.0, Easing::Linear),
+        )
+        .unwrap();
+
+    let line = scene.add(GeometryRef::line(Vec2::new(-1.0, 0.0), Vec2::new(1.0, 0.0)));
+    scene
+        .animate_transform(
+            line,
+            snapshot(
+                GeometryRef::line(Vec2::new(-1.0, 0.0), Vec2::new(1.0, 0.0)),
+                style,
+            ),
+            snapshot(
+                GeometryRef::line(Vec2::new(0.0, -2.0), Vec2::new(0.0, 2.0)),
+                style,
+            ),
+            TrackTiming::new(0.0, 2.0, Easing::Linear),
+        )
+        .unwrap();
+
+    let mut instance = SceneInstance::new(CompiledScene::compile(&scene).unwrap());
     let mut preparer = FramePreparer::new();
+    let initial_changes = instance.take_frame_changes();
+    preparer.prepare_incremental(instance.frame(), &initial_changes);
 
-    let initial_changes = runtime.take_frame_changes();
-    let initial = preparer.prepare_incremental(runtime.frame(), &initial_changes);
-    assert_eq!(initial.stats.geometry_cache_misses, 0);
-    assert_eq!(preparer.cached_path_mesh_count(), 0);
-
-    runtime.evaluate(0.5);
-    let active_changes = runtime.take_frame_changes();
-    let active = preparer.prepare_incremental(runtime.frame(), &active_changes);
-    assert_eq!(active.stats.dirty_instance_count, 2);
-    assert_eq!(active.rectangle_dirty_ranges.len(), 1);
-    assert_eq!(active.rectangle_dirty_ranges[0], 0..1);
-    assert_eq!(active.line_dirty_ranges.len(), 1);
-    assert_eq!(active.line_dirty_ranges[0], 0..1);
-    assert_eq!(active.stats.geometry_cache_misses, 0);
-    assert!(!active.path_geometry_dirty);
-    assert_eq!(preparer.cached_path_mesh_count(), 0);
-
-    runtime.evaluate(0.5);
-    let steady_changes = runtime.take_frame_changes();
-    let steady = preparer.prepare_incremental(runtime.frame(), &steady_changes);
+    instance.advance_to(0.5).unwrap();
+    let changes = instance.take_frame_changes();
+    let steady = preparer.prepare_incremental(instance.frame(), &changes);
+    assert_eq!(steady.stats.instances_repacked, 2);
     assert_eq!(steady.stats.dirty_instance_count, 2);
     assert_eq!(steady.rectangle_dirty_ranges.len(), 1);
     assert_eq!(steady.rectangle_dirty_ranges[0], 0..1);

--- a/crates/noon-render-wgpu/tests/analytic_transform.rs
+++ b/crates/noon-render-wgpu/tests/analytic_transform.rs
@@ -104,14 +104,8 @@ fn repeated_line_transform_patches_keep_preparation_bounded_and_local() {
     const MOVING_INDEX: usize = 1;
 
     let mut scene = SceneDefinition::new();
-    let _static_line = scene.add(GeometryRef::line(
-        Vec2::new(-1.0, 0.0),
-        Vec2::new(1.0, 0.0),
-    ));
-    let moving_line = scene.add(GeometryRef::line(
-        Vec2::new(-1.0, 0.0),
-        Vec2::new(1.0, 0.0),
-    ));
+    let _static_line = scene.add(GeometryRef::line(Vec2::new(-1.0, 0.0), Vec2::new(1.0, 0.0)));
+    let moving_line = scene.add(GeometryRef::line(Vec2::new(-1.0, 0.0), Vec2::new(1.0, 0.0)));
 
     let mut instance = SceneInstance::new(CompiledScene::compile(&scene).unwrap());
     let static_before = instance.frame().objects[STATIC_INDEX].clone();
@@ -142,7 +136,10 @@ fn repeated_line_transform_patches_keep_preparation_bounded_and_local() {
         assert_eq!(instance.frame().objects[STATIC_INDEX], static_before);
         assert_eq!(prepared.stats.instances_repacked, 1);
         assert_eq!(prepared.stats.dirty_instance_count, 1);
-        assert_eq!(prepared.line_dirty_ranges.as_slice(), &[MOVING_INDEX..MOVING_INDEX + 1]);
+        assert_eq!(
+            prepared.line_dirty_ranges.as_slice(),
+            &[MOVING_INDEX..MOVING_INDEX + 1]
+        );
         assert_eq!(prepared.stats.geometry_cache_misses, 0);
         assert!(!prepared.path_geometry_dirty);
         assert_eq!(preparer.cached_path_mesh_count(), 0);


### PR DESCRIPTION
## Summary
- add a 1,000-edit renderer-preparation churn regression for a two-line scene
- repeatedly patch only the moving line through the real `SceneInstance` property-patch path
- require each edit to publish exactly one dirty execution object and exactly one analytic line dirty range
- require one repacked instance, zero path-geometry invalidation/cache misses, a constant empty path-mesh cache, and byte-for-byte stable state for the untouched reference line

## Why this slice
The `RotationUpdater` raster qualification in #512 exposed a WebGL-only divergence at one sample and is now tracked as #513. That issue still needs backend-specific isolation and should not be papered over with tolerance changes or full-scene uploads.

This regression is an independent, deterministic boundary check below the browser backend: it exercises sustained runtime property mutation -> `FrameChanges` -> `FramePreparer` and proves that ordinary analytic-line updates remain local and do not drift into path work over long churn. It strengthens #114/#109 and narrows #513 investigation toward the GPU upload/draw/presentation side if this gate stays green.

## Validation
CI should run this automatically as part of the `noon-render-wgpu` integration-test suite. No production path or tolerance is changed.

Related: #513, #114, #109.