### PR TITLE
Expose shared polygon geometry through browser adapters

### DIFF
--- a/.github/workflows/manim-polygram-adapters.yml
+++ b/.github/workflows/manim-polygram-adapters.yml
@@ -1,0 +1,60 @@
+name: Manim polygon adapters
+
+on:
+  pull_request:
+    paths:
+      - "crates/noon/src/polygram_authoring.rs"
+      - "crates/noon-web/src/lib.rs"
+      - "crates/noon-web/src/manim_polygram_handle.rs"
+      - "web/python/_manim_shared_geometry.py"
+      - "web/python-worker.source.js"
+      - "scripts/check-polygram-web-package.mjs"
+      - "scripts/manim-polygram-adapters-smoke.mjs"
+      - ".github/workflows/manim-polygram-adapters.yml"
+  push:
+    branches:
+      - master
+    paths:
+      - "crates/noon/src/polygram_authoring.rs"
+      - "crates/noon-web/src/lib.rs"
+      - "crates/noon-web/src/manim_polygram_handle.rs"
+      - "web/python/_manim_shared_geometry.py"
+      - "web/python-worker.source.js"
+      - "scripts/check-polygram-web-package.mjs"
+      - "scripts/manim-polygram-adapters-smoke.mjs"
+      - ".github/workflows/manim-polygram-adapters.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  polygon-adapters:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@wasm-pack
+
+      - name: Build browser package and Python bundle
+        env:
+          NOON_SKIP_PLAYGROUND_TEST: "1"
+          NOON_WASM_SKIP_OPT: "1"
+        run: ./scripts/build-web-demo.sh
+
+      - name: Validate polygon package surface
+        run: node scripts/check-polygram-web-package.mjs
+
+      - name: Install Chromium smoke dependency
+        run: |
+          npm install --no-save --ignore-scripts playwright@1.62.1
+          npx playwright install chromium
+
+      - name: Test shared Python and JavaScript polygon adapters
+        run: node scripts/manim-polygram-adapters-smoke.mjs

--- a/crates/noon-web/src/authoring_facade.rs
+++ b/crates/noon-web/src/authoring_facade.rs
@@ -6,6 +6,11 @@ use noon::{
 };
 use noon_core::{Color, RateFunction, Vec2};
 
+#[cfg(any(target_arch = "wasm32", test))]
+use crate::{
+    polygon_snapshot, polygram_snapshot, regular_polygon_snapshot, regular_polygram_snapshot,
+    star_snapshot, triangle_snapshot,
+};
 use crate::FrontendMobjectHandle;
 
 fn finite_f32(name: &str, value: f64) -> Result<f32, String> {
@@ -92,6 +97,53 @@ impl FrontendDetachedMobject {
         Ok(Self::from_snapshot(
             Line::new(vec2("start", start_x, start_y)?, vec2("end", end_x, end_y)?).into_snapshot(),
         ))
+    }
+
+    #[cfg(any(target_arch = "wasm32", test))]
+    pub fn polygon(coordinates: &[f64]) -> Result<Self, String> {
+        polygon_snapshot(coordinates).map(Self::from_snapshot)
+    }
+
+    #[cfg(any(target_arch = "wasm32", test))]
+    pub fn polygram(coordinates: &[f64], group_lengths: &[u32]) -> Result<Self, String> {
+        polygram_snapshot(coordinates, group_lengths).map(Self::from_snapshot)
+    }
+
+    #[cfg(any(target_arch = "wasm32", test))]
+    pub fn regular_polygon(
+        num_vertices: u32,
+        radius: f64,
+        start_angle: Option<f64>,
+    ) -> Result<Self, String> {
+        regular_polygon_snapshot(num_vertices, radius, start_angle).map(Self::from_snapshot)
+    }
+
+    #[cfg(any(target_arch = "wasm32", test))]
+    pub fn regular_polygram(
+        num_vertices: u32,
+        density: u32,
+        radius: f64,
+        start_angle: Option<f64>,
+    ) -> Result<Self, String> {
+        regular_polygram_snapshot(num_vertices, density, radius, start_angle)
+            .map(Self::from_snapshot)
+    }
+
+    #[cfg(any(target_arch = "wasm32", test))]
+    pub fn triangle() -> Self {
+        Self::from_snapshot(triangle_snapshot())
+    }
+
+    #[cfg(any(target_arch = "wasm32", test))]
+    pub fn star(
+        points: u32,
+        outer_radius: f64,
+        inner_radius: Option<f64>,
+        density: u32,
+        start_angle: Option<f64>,
+    ) -> Result<Self, String> {
+        star_snapshot(points, outer_radius, inner_radius, density, start_angle)
+            .map(Self::from_snapshot)
     }
 
     pub fn shift(&mut self, x: f64, y: f64) -> Result<&mut Self, String> {
@@ -493,6 +545,8 @@ impl FrontendAuthoringScene {
 mod wasm {
     use wasm_bindgen::prelude::*;
 
+    use crate::WasmPolygramVertexGroups;
+
     use super::{
         FrontendAnimate, FrontendAuthoringScene, FrontendDetachedMobject, FrontendPlayBatch,
     };
@@ -575,6 +629,11 @@ mod wasm {
                 .map_err(js_error)
         }
 
+        #[wasm_bindgen(js_name = manimVertexGroups)]
+        pub fn manim_vertex_groups(&self) -> Result<WasmPolygramVertexGroups, JsValue> {
+            WasmPolygramVertexGroups::from_snapshot(self.0.handle.snapshot()).map_err(js_error)
+        }
+
         #[wasm_bindgen(getter, js_name = centerX)]
         pub fn center_x(&self) -> f64 {
             self.0.center().0
@@ -627,6 +686,70 @@ mod wasm {
         FrontendDetachedMobject::line(start_x, start_y, end_x, end_y)
             .map(DetachedMobjectCore)
             .map_err(js_error)
+    }
+
+    #[wasm_bindgen(js_name = authoringPolygon)]
+    pub fn authoring_polygon(coordinates: &[f64]) -> Result<DetachedMobjectCore, JsValue> {
+        FrontendDetachedMobject::polygon(coordinates)
+            .map(DetachedMobjectCore)
+            .map_err(js_error)
+    }
+
+    #[wasm_bindgen(js_name = authoringPolygram)]
+    pub fn authoring_polygram(
+        coordinates: &[f64],
+        group_lengths: &[u32],
+    ) -> Result<DetachedMobjectCore, JsValue> {
+        FrontendDetachedMobject::polygram(coordinates, group_lengths)
+            .map(DetachedMobjectCore)
+            .map_err(js_error)
+    }
+
+    #[wasm_bindgen(js_name = authoringRegularPolygon)]
+    pub fn authoring_regular_polygon(
+        num_vertices: u32,
+        radius: f64,
+        start_angle: Option<f64>,
+    ) -> Result<DetachedMobjectCore, JsValue> {
+        FrontendDetachedMobject::regular_polygon(num_vertices, radius, start_angle)
+            .map(DetachedMobjectCore)
+            .map_err(js_error)
+    }
+
+    #[wasm_bindgen(js_name = authoringRegularPolygram)]
+    pub fn authoring_regular_polygram(
+        num_vertices: u32,
+        density: u32,
+        radius: f64,
+        start_angle: Option<f64>,
+    ) -> Result<DetachedMobjectCore, JsValue> {
+        FrontendDetachedMobject::regular_polygram(num_vertices, density, radius, start_angle)
+            .map(DetachedMobjectCore)
+            .map_err(js_error)
+    }
+
+    #[wasm_bindgen(js_name = authoringTriangle)]
+    pub fn authoring_triangle() -> DetachedMobjectCore {
+        DetachedMobjectCore(FrontendDetachedMobject::triangle())
+    }
+
+    #[wasm_bindgen(js_name = authoringStar)]
+    pub fn authoring_star(
+        points: u32,
+        outer_radius: f64,
+        inner_radius: Option<f64>,
+        density: u32,
+        start_angle: Option<f64>,
+    ) -> Result<DetachedMobjectCore, JsValue> {
+        FrontendDetachedMobject::star(
+            points,
+            outer_radius,
+            inner_radius,
+            density,
+            start_angle,
+        )
+        .map(DetachedMobjectCore)
+        .map_err(js_error)
     }
 
     #[wasm_bindgen]
@@ -850,6 +973,7 @@ pub use wasm::*;
 
 #[cfg(test)]
 mod tests {
+    use noon::polygram_vertex_groups;
     use noon_core::{Property, RateFunction};
 
     use super::*;
@@ -869,6 +993,35 @@ mod tests {
         let gap = square_snapshot.world_bounds().unwrap().min.x
             - circle_snapshot.world_bounds().unwrap().max.x;
         assert!((gap - 0.25).abs() < 1e-6);
+    }
+
+    #[test]
+    fn browser_facade_polygon_family_reuses_shared_geometry_queries() {
+        let mut polygon =
+            FrontendDetachedMobject::polygon(&[-1.0, -1.0, 2.0, -1.0, 0.0, 3.0]).unwrap();
+        polygon.shift(1.0, 0.0).unwrap();
+        let groups = polygram_vertex_groups(polygon.handle.snapshot());
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0], vec![Vec2::new(0.0, -1.0), Vec2::new(3.0, -1.0), Vec2::new(1.0, 3.0)]);
+
+        let disconnected = FrontendDetachedMobject::regular_polygram(6, 2, 1.0, None).unwrap();
+        let groups = polygram_vertex_groups(disconnected.handle.snapshot());
+        assert_eq!(groups.iter().map(Vec::len).collect::<Vec<_>>(), vec![3, 3]);
+
+        assert_eq!(
+            polygram_vertex_groups(FrontendDetachedMobject::triangle().handle.snapshot())[0].len(),
+            3
+        );
+        assert_eq!(
+            polygram_vertex_groups(
+                FrontendDetachedMobject::star(5, 1.0, None, 2, Some(std::f64::consts::FRAC_PI_2))
+                    .unwrap()
+                    .handle
+                    .snapshot()
+            )[0]
+            .len(),
+            10
+        );
     }
 
     #[test]

--- a/crates/noon-web/src/lib.rs
+++ b/crates/noon-web/src/lib.rs
@@ -14,6 +14,7 @@ mod host_player;
 mod legacy;
 mod lifecycle;
 mod manim_geometry_bridge;
+mod manim_polygram_handle;
 mod reactive_authoring_facade;
 mod reactive_player;
 mod retained_authoring;
@@ -38,6 +39,8 @@ pub use host_player::*;
 pub use legacy::*;
 pub use lifecycle::*;
 pub use manim_geometry_bridge::*;
+#[cfg(target_arch = "wasm32")]
+pub use manim_polygram_handle::*;
 pub use reactive_authoring_facade::*;
 pub use reactive_player::*;
 pub use retained_authoring::*;

--- a/crates/noon-web/src/lib.rs
+++ b/crates/noon-web/src/lib.rs
@@ -14,6 +14,7 @@ mod host_player;
 mod legacy;
 mod lifecycle;
 mod manim_geometry_bridge;
+#[cfg(any(target_arch = "wasm32", test))]
 mod manim_polygram_handle;
 mod reactive_authoring_facade;
 mod reactive_player;

--- a/crates/noon-web/src/manim_polygram_handle.rs
+++ b/crates/noon-web/src/manim_polygram_handle.rs
@@ -20,7 +20,7 @@ fn positive_f32(name: &str, value: f64) -> Result<f32, String> {
 }
 
 fn vertices_from_flat(name: &str, coordinates: &[f64]) -> Result<Vec<Vec2>, String> {
-    if !coordinates.len().is_multiple_of(2) {
+    if coordinates.len() % 2 != 0 {
         return Err(format!("{name} must contain x/y coordinate pairs"));
     }
     coordinates

--- a/crates/noon-web/src/manim_polygram_handle.rs
+++ b/crates/noon-web/src/manim_polygram_handle.rs
@@ -344,14 +344,22 @@ mod tests {
     }
 
     #[test]
-    fn regular_polygon_defaults_and_explicit_rotation_stay_shared() {
+    fn regular_polygon_default_even_orientation_matches_zero_angle() {
         let default = regular_polygon_snapshot(4, 1.0, None).unwrap();
-        let rotated = regular_polygon_snapshot(4, 1.0, Some(0.0)).unwrap();
+        let zero_angle = regular_polygon_snapshot(4, 1.0, Some(0.0)).unwrap();
+        let quarter_turn =
+            regular_polygon_snapshot(4, 1.0, Some(f64::from(FRAC_PI_2))).unwrap();
+
         let default_vertices = encode_vertex_groups(&default).unwrap().coordinates;
-        let rotated_vertices = encode_vertex_groups(&rotated).unwrap().coordinates;
-        assert_ne!(default_vertices, rotated_vertices);
-        assert!((default_vertices[1] - 1.0).abs() < 1e-6);
-        assert!((rotated_vertices[0] - 1.0).abs() < 1e-6);
+        let zero_vertices = encode_vertex_groups(&zero_angle).unwrap().coordinates;
+        let quarter_vertices = encode_vertex_groups(&quarter_turn).unwrap().coordinates;
+
+        assert_eq!(default_vertices, zero_vertices);
+        assert_ne!(default_vertices, quarter_vertices);
+        assert!((default_vertices[0] - 1.0).abs() < 1e-6);
+        assert!(default_vertices[1].abs() < 1e-6);
+        assert!(quarter_vertices[0].abs() < 1e-6);
+        assert!((quarter_vertices[1] - 1.0).abs() < 1e-6);
     }
 
     #[test]

--- a/crates/noon-web/src/manim_polygram_handle.rs
+++ b/crates/noon-web/src/manim_polygram_handle.rs
@@ -72,11 +72,11 @@ fn optional_angle(name: &str, value: Option<f64>) -> Result<Option<f32>, String>
     value.map(|value| finite_f32(name, value)).transpose()
 }
 
-fn polygon_snapshot(coordinates: &[f64]) -> Result<ObjectSnapshot, String> {
+pub(crate) fn polygon_snapshot(coordinates: &[f64]) -> Result<ObjectSnapshot, String> {
     Ok(Polygon::new(vertices_from_flat("vertices", coordinates)?).into_snapshot())
 }
 
-fn polygram_snapshot(
+pub(crate) fn polygram_snapshot(
     coordinates: &[f64],
     group_lengths: &[u32],
 ) -> Result<ObjectSnapshot, String> {
@@ -85,7 +85,7 @@ fn polygram_snapshot(
         .map_err(|error| error.to_string())
 }
 
-fn regular_polygon_snapshot(
+pub(crate) fn regular_polygon_snapshot(
     num_vertices: u32,
     radius: f64,
     start_angle: Option<f64>,
@@ -99,7 +99,7 @@ fn regular_polygon_snapshot(
     .map_err(|error| error.to_string())
 }
 
-fn regular_polygram_snapshot(
+pub(crate) fn regular_polygram_snapshot(
     num_vertices: u32,
     density: u32,
     radius: f64,
@@ -115,7 +115,7 @@ fn regular_polygram_snapshot(
     .map_err(|error| error.to_string())
 }
 
-fn star_snapshot(
+pub(crate) fn star_snapshot(
     points: u32,
     outer_radius: f64,
     inner_radius: Option<f64>,
@@ -135,17 +135,19 @@ fn star_snapshot(
     .map_err(|error| error.to_string())
 }
 
-fn triangle_snapshot() -> ObjectSnapshot {
+pub(crate) fn triangle_snapshot() -> ObjectSnapshot {
     Triangle::new().into_snapshot()
 }
 
 #[derive(Clone, Debug, PartialEq)]
-struct EncodedVertexGroups {
+pub(crate) struct EncodedVertexGroups {
     coordinates: Vec<f64>,
     group_lengths: Vec<u32>,
 }
 
-fn encode_vertex_groups(snapshot: &ObjectSnapshot) -> Result<EncodedVertexGroups, String> {
+pub(crate) fn encode_vertex_groups(
+    snapshot: &ObjectSnapshot,
+) -> Result<EncodedVertexGroups, String> {
     let groups = polygram_vertex_groups(snapshot);
     let mut coordinates = Vec::new();
     let mut group_lengths = Vec::with_capacity(groups.len());
@@ -203,6 +205,12 @@ mod wasm {
 
     #[wasm_bindgen]
     pub struct WasmPolygramVertexGroups(EncodedVertexGroups);
+
+    impl WasmPolygramVertexGroups {
+        pub(crate) fn from_snapshot(snapshot: &noon_core::ObjectSnapshot) -> Result<Self, String> {
+            encode_vertex_groups(snapshot).map(Self)
+        }
+    }
 
     #[wasm_bindgen]
     impl WasmPolygramVertexGroups {
@@ -294,9 +302,7 @@ mod wasm {
         #[wasm_bindgen(js_name = manimVertexGroups)]
         pub fn manim_vertex_groups(&self) -> Result<WasmPolygramVertexGroups, JsValue> {
             let snapshot = snapshot_from_handle(self)?;
-            encode_vertex_groups(&snapshot)
-                .map(WasmPolygramVertexGroups)
-                .map_err(js_error)
+            WasmPolygramVertexGroups::from_snapshot(&snapshot).map_err(js_error)
         }
     }
 }

--- a/crates/noon-web/src/manim_polygram_handle.rs
+++ b/crates/noon-web/src/manim_polygram_handle.rs
@@ -323,17 +323,16 @@ mod tests {
         let snapshot = polygon_snapshot(&[-1.0, -1.0, 2.0, -1.0, 0.0, 3.0]).unwrap();
         let encoded = encode_vertex_groups(&snapshot).unwrap();
         assert_eq!(encoded.group_lengths, vec![3]);
-        assert_eq!(
-            encoded.coordinates,
-            vec![-1.0, -1.0, 2.0, -1.0, 0.0, 3.0]
-        );
+        assert_eq!(encoded.coordinates, vec![-1.0, -1.0, 2.0, -1.0, 0.0, 3.0]);
         assert!(matches!(snapshot.geometry, GeometryRef::VectorPath(_)));
     }
 
     #[test]
     fn polygram_bridge_preserves_disconnected_groups() {
         let snapshot = polygram_snapshot(
-            &[0.0, 2.0, -1.0, -1.0, 1.0, -1.0, 0.0, -2.0, -1.0, 1.0, 1.0, 1.0],
+            &[
+                0.0, 2.0, -1.0, -1.0, 1.0, -1.0, 0.0, -2.0, -1.0, 1.0, 1.0, 1.0,
+            ],
             &[3, 3],
         )
         .unwrap();

--- a/crates/noon-web/src/manim_polygram_handle.rs
+++ b/crates/noon-web/src/manim_polygram_handle.rs
@@ -1,0 +1,364 @@
+use noon::{
+    polygram_vertex_groups, IntoSnapshot, Polygon, Polygram, RegularPolygon, RegularPolygram, Star,
+    Triangle,
+};
+use noon_core::{ObjectSnapshot, Vec2};
+
+fn finite_f32(name: &str, value: f64) -> Result<f32, String> {
+    if !value.is_finite() || value.abs() > f64::from(f32::MAX) {
+        return Err(format!("{name} must be a finite f32-compatible number"));
+    }
+    Ok(value as f32)
+}
+
+fn positive_f32(name: &str, value: f64) -> Result<f32, String> {
+    let value = finite_f32(name, value)?;
+    if value <= 0.0 {
+        return Err(format!("{name} must be positive"));
+    }
+    Ok(value)
+}
+
+fn vertices_from_flat(name: &str, coordinates: &[f64]) -> Result<Vec<Vec2>, String> {
+    if !coordinates.len().is_multiple_of(2) {
+        return Err(format!("{name} must contain x/y coordinate pairs"));
+    }
+    coordinates
+        .chunks_exact(2)
+        .enumerate()
+        .map(|(index, pair)| {
+            Ok(Vec2::new(
+                finite_f32(&format!("{name}[{index}].x"), pair[0])?,
+                finite_f32(&format!("{name}[{index}].y"), pair[1])?,
+            ))
+        })
+        .collect()
+}
+
+fn vertex_groups_from_flat(
+    coordinates: &[f64],
+    group_lengths: &[u32],
+) -> Result<Vec<Vec<Vec2>>, String> {
+    let vertices = vertices_from_flat("vertices", coordinates)?;
+    let expected = group_lengths.iter().try_fold(0usize, |total, length| {
+        total
+            .checked_add(*length as usize)
+            .ok_or_else(|| "polygram vertex count overflow".to_owned())
+    })?;
+    if expected != vertices.len() {
+        return Err(format!(
+            "polygram group lengths describe {expected} vertices but {} were supplied",
+            vertices.len()
+        ));
+    }
+
+    let mut groups = Vec::with_capacity(group_lengths.len());
+    let mut start = 0usize;
+    for (group_index, length) in group_lengths.iter().copied().enumerate() {
+        let length = length as usize;
+        if length == 0 {
+            return Err(format!(
+                "polygram vertex group {group_index} must contain at least one vertex"
+            ));
+        }
+        let end = start + length;
+        groups.push(vertices[start..end].to_vec());
+        start = end;
+    }
+    Ok(groups)
+}
+
+fn optional_angle(name: &str, value: Option<f64>) -> Result<Option<f32>, String> {
+    value.map(|value| finite_f32(name, value)).transpose()
+}
+
+fn polygon_snapshot(coordinates: &[f64]) -> Result<ObjectSnapshot, String> {
+    Ok(Polygon::new(vertices_from_flat("vertices", coordinates)?).into_snapshot())
+}
+
+fn polygram_snapshot(
+    coordinates: &[f64],
+    group_lengths: &[u32],
+) -> Result<ObjectSnapshot, String> {
+    Polygram::new(vertex_groups_from_flat(coordinates, group_lengths)?)
+        .map(IntoSnapshot::into_snapshot)
+        .map_err(|error| error.to_string())
+}
+
+fn regular_polygon_snapshot(
+    num_vertices: u32,
+    radius: f64,
+    start_angle: Option<f64>,
+) -> Result<ObjectSnapshot, String> {
+    RegularPolygon::with_options(
+        num_vertices as usize,
+        positive_f32("radius", radius)?,
+        optional_angle("start_angle", start_angle)?,
+    )
+    .map(IntoSnapshot::into_snapshot)
+    .map_err(|error| error.to_string())
+}
+
+fn regular_polygram_snapshot(
+    num_vertices: u32,
+    density: u32,
+    radius: f64,
+    start_angle: Option<f64>,
+) -> Result<ObjectSnapshot, String> {
+    RegularPolygram::with_options(
+        num_vertices as usize,
+        density as usize,
+        positive_f32("radius", radius)?,
+        optional_angle("start_angle", start_angle)?,
+    )
+    .map(IntoSnapshot::into_snapshot)
+    .map_err(|error| error.to_string())
+}
+
+fn star_snapshot(
+    points: u32,
+    outer_radius: f64,
+    inner_radius: Option<f64>,
+    density: u32,
+    start_angle: Option<f64>,
+) -> Result<ObjectSnapshot, String> {
+    Star::with_options(
+        points as usize,
+        positive_f32("outer_radius", outer_radius)?,
+        inner_radius
+            .map(|value| positive_f32("inner_radius", value))
+            .transpose()?,
+        density as usize,
+        optional_angle("start_angle", start_angle)?,
+    )
+    .map(IntoSnapshot::into_snapshot)
+    .map_err(|error| error.to_string())
+}
+
+fn triangle_snapshot() -> ObjectSnapshot {
+    Triangle::new().into_snapshot()
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct EncodedVertexGroups {
+    coordinates: Vec<f64>,
+    group_lengths: Vec<u32>,
+}
+
+fn encode_vertex_groups(snapshot: &ObjectSnapshot) -> Result<EncodedVertexGroups, String> {
+    let groups = polygram_vertex_groups(snapshot);
+    let mut coordinates = Vec::new();
+    let mut group_lengths = Vec::with_capacity(groups.len());
+    for group in groups {
+        group_lengths.push(
+            u32::try_from(group.len())
+                .map_err(|_| "polygram vertex group exceeds JS index range".to_owned())?,
+        );
+        coordinates.reserve(group.len() * 2);
+        for vertex in group {
+            coordinates.push(f64::from(vertex.x));
+            coordinates.push(f64::from(vertex.y));
+        }
+    }
+    Ok(EncodedVertexGroups {
+        coordinates,
+        group_lengths,
+    })
+}
+
+#[cfg(target_arch = "wasm32")]
+mod wasm {
+    use wasm_bindgen::prelude::*;
+
+    use crate::{WasmAuthoringMobjectHandle, WasmAuthoringStore};
+
+    use super::{
+        encode_vertex_groups, polygon_snapshot, polygram_snapshot, regular_polygon_snapshot,
+        regular_polygram_snapshot, star_snapshot, triangle_snapshot, EncodedVertexGroups,
+    };
+
+    fn js_error(error: String) -> JsValue {
+        JsValue::from_str(&error)
+    }
+
+    fn attach_snapshot(
+        store: &WasmAuthoringStore,
+        snapshot: noon_core::ObjectSnapshot,
+    ) -> Result<WasmAuthoringMobjectHandle, JsValue> {
+        // The public host boundary remains typed. This serialization is contained
+        // inside Rust only because the established WASM store intentionally keeps
+        // its semantic arena private; no snapshot crosses Python/JS for construction.
+        let json = serde_json::to_string(&snapshot).map_err(|error| js_error(error.to_string()))?;
+        store.create_mobject(&json)
+    }
+
+    fn snapshot_from_handle(
+        handle: &WasmAuthoringMobjectHandle,
+    ) -> Result<noon_core::ObjectSnapshot, JsValue> {
+        // Likewise, query results cross the host boundary as typed numeric arrays.
+        // Geometry/path traversal and transforms remain owned by shared Rust.
+        let json = handle.snapshot_json()?;
+        serde_json::from_str(&json).map_err(|error| js_error(error.to_string()))
+    }
+
+    #[wasm_bindgen]
+    pub struct WasmPolygramVertexGroups(EncodedVertexGroups);
+
+    #[wasm_bindgen]
+    impl WasmPolygramVertexGroups {
+        #[wasm_bindgen(js_name = coordinates)]
+        pub fn coordinates(&self) -> Box<[f64]> {
+            self.0.coordinates.clone().into_boxed_slice()
+        }
+
+        #[wasm_bindgen(js_name = groupLengths)]
+        pub fn group_lengths(&self) -> Box<[u32]> {
+            self.0.group_lengths.clone().into_boxed_slice()
+        }
+    }
+
+    #[wasm_bindgen]
+    impl WasmAuthoringStore {
+        #[wasm_bindgen(js_name = createManimPolygon)]
+        pub fn create_manim_polygon(
+            &self,
+            coordinates: &[f64],
+        ) -> Result<WasmAuthoringMobjectHandle, JsValue> {
+            attach_snapshot(self, polygon_snapshot(coordinates).map_err(js_error)?)
+        }
+
+        #[wasm_bindgen(js_name = createManimPolygram)]
+        pub fn create_manim_polygram(
+            &self,
+            coordinates: &[f64],
+            group_lengths: &[u32],
+        ) -> Result<WasmAuthoringMobjectHandle, JsValue> {
+            attach_snapshot(
+                self,
+                polygram_snapshot(coordinates, group_lengths).map_err(js_error)?,
+            )
+        }
+
+        #[wasm_bindgen(js_name = createManimRegularPolygon)]
+        pub fn create_manim_regular_polygon(
+            &self,
+            num_vertices: u32,
+            radius: f64,
+            start_angle: Option<f64>,
+        ) -> Result<WasmAuthoringMobjectHandle, JsValue> {
+            attach_snapshot(
+                self,
+                regular_polygon_snapshot(num_vertices, radius, start_angle).map_err(js_error)?,
+            )
+        }
+
+        #[wasm_bindgen(js_name = createManimRegularPolygram)]
+        pub fn create_manim_regular_polygram(
+            &self,
+            num_vertices: u32,
+            density: u32,
+            radius: f64,
+            start_angle: Option<f64>,
+        ) -> Result<WasmAuthoringMobjectHandle, JsValue> {
+            attach_snapshot(
+                self,
+                regular_polygram_snapshot(num_vertices, density, radius, start_angle)
+                    .map_err(js_error)?,
+            )
+        }
+
+        #[wasm_bindgen(js_name = createManimTriangle)]
+        pub fn create_manim_triangle(&self) -> Result<WasmAuthoringMobjectHandle, JsValue> {
+            attach_snapshot(self, triangle_snapshot())
+        }
+
+        #[wasm_bindgen(js_name = createManimStar)]
+        pub fn create_manim_star(
+            &self,
+            points: u32,
+            outer_radius: f64,
+            inner_radius: Option<f64>,
+            density: u32,
+            start_angle: Option<f64>,
+        ) -> Result<WasmAuthoringMobjectHandle, JsValue> {
+            attach_snapshot(
+                self,
+                star_snapshot(points, outer_radius, inner_radius, density, start_angle)
+                    .map_err(js_error)?,
+            )
+        }
+    }
+
+    #[wasm_bindgen]
+    impl WasmAuthoringMobjectHandle {
+        #[wasm_bindgen(js_name = manimVertexGroups)]
+        pub fn manim_vertex_groups(&self) -> Result<WasmPolygramVertexGroups, JsValue> {
+            let snapshot = snapshot_from_handle(self)?;
+            encode_vertex_groups(&snapshot)
+                .map(WasmPolygramVertexGroups)
+                .map_err(js_error)
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub use wasm::*;
+
+#[cfg(test)]
+mod tests {
+    use std::f32::consts::FRAC_PI_2;
+
+    use noon_core::GeometryRef;
+
+    use super::*;
+
+    #[test]
+    fn polygon_bridge_uses_shared_constructor_and_query_order() {
+        let snapshot = polygon_snapshot(&[-1.0, -1.0, 2.0, -1.0, 0.0, 3.0]).unwrap();
+        let encoded = encode_vertex_groups(&snapshot).unwrap();
+        assert_eq!(encoded.group_lengths, vec![3]);
+        assert_eq!(
+            encoded.coordinates,
+            vec![-1.0, -1.0, 2.0, -1.0, 0.0, 3.0]
+        );
+        assert!(matches!(snapshot.geometry, GeometryRef::VectorPath(_)));
+    }
+
+    #[test]
+    fn polygram_bridge_preserves_disconnected_groups() {
+        let snapshot = polygram_snapshot(
+            &[0.0, 2.0, -1.0, -1.0, 1.0, -1.0, 0.0, -2.0, -1.0, 1.0, 1.0, 1.0],
+            &[3, 3],
+        )
+        .unwrap();
+        let encoded = encode_vertex_groups(&snapshot).unwrap();
+        assert_eq!(encoded.group_lengths, vec![3, 3]);
+        assert_eq!(encoded.coordinates.len(), 12);
+    }
+
+    #[test]
+    fn regular_polygon_defaults_and_explicit_rotation_stay_shared() {
+        let default = regular_polygon_snapshot(4, 1.0, None).unwrap();
+        let rotated = regular_polygon_snapshot(4, 1.0, Some(0.0)).unwrap();
+        let default_vertices = encode_vertex_groups(&default).unwrap().coordinates;
+        let rotated_vertices = encode_vertex_groups(&rotated).unwrap().coordinates;
+        assert_ne!(default_vertices, rotated_vertices);
+        assert!((default_vertices[1] - 1.0).abs() < 1e-6);
+        assert!((rotated_vertices[0] - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn regular_polygram_and_star_delegate_density_validation() {
+        assert!(regular_polygram_snapshot(6, 2, 1.0, None).is_ok());
+        assert!(regular_polygram_snapshot(5, 0, 1.0, None).is_err());
+        assert!(star_snapshot(7, 2.0, None, 3, Some(f64::from(FRAC_PI_2))).is_ok());
+        assert!(star_snapshot(5, 1.0, None, 3, None).is_err());
+    }
+
+    #[test]
+    fn malformed_flat_inputs_are_rejected_before_shared_construction() {
+        assert!(polygon_snapshot(&[0.0, 1.0, 2.0]).is_err());
+        assert!(polygram_snapshot(&[0.0, 0.0, 1.0, 0.0], &[3]).is_err());
+        assert!(polygram_snapshot(&[0.0, 0.0], &[0, 1]).is_err());
+    }
+}

--- a/crates/noon-web/src/manim_polygram_handle.rs
+++ b/crates/noon-web/src/manim_polygram_handle.rs
@@ -20,11 +20,13 @@ fn positive_f32(name: &str, value: f64) -> Result<f32, String> {
 }
 
 fn vertices_from_flat(name: &str, coordinates: &[f64]) -> Result<Vec<Vec2>, String> {
-    if coordinates.len() % 2 != 0 {
+    if !coordinates.len().is_multiple_of(2) {
         return Err(format!("{name} must contain x/y coordinate pairs"));
     }
     coordinates
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .enumerate()
         .map(|(index, pair)| {
             Ok(Vec2::new(
@@ -358,6 +360,14 @@ mod tests {
         assert!(regular_polygram_snapshot(5, 0, 1.0, None).is_err());
         assert!(star_snapshot(7, 2.0, None, 3, Some(f64::from(FRAC_PI_2))).is_ok());
         assert!(star_snapshot(5, 1.0, None, 3, None).is_err());
+    }
+
+    #[test]
+    fn triangle_bridge_uses_shared_triangle_constructor() {
+        let snapshot = triangle_snapshot();
+        let encoded = encode_vertex_groups(&snapshot).unwrap();
+        assert_eq!(encoded.group_lengths, vec![3]);
+        assert_eq!(encoded.coordinates.len(), 6);
     }
 
     #[test]

--- a/crates/noon/src/polygram_authoring.rs
+++ b/crates/noon/src/polygram_authoring.rs
@@ -122,14 +122,11 @@ impl Polygram {
     }
 
     pub fn get_vertices(&self) -> Vec<Vec2> {
-        snapshot_vertex_groups(&self.0)
-            .into_iter()
-            .flatten()
-            .collect()
+        polygram_vertices(&self.0)
     }
 
     pub fn get_vertex_groups(&self) -> Vec<Vec<Vec2>> {
-        snapshot_vertex_groups(&self.0)
+        polygram_vertex_groups(&self.0)
     }
 }
 
@@ -139,7 +136,11 @@ impl IntoSnapshot for Polygram {
     }
 }
 
-fn snapshot_vertex_groups(snapshot: &ObjectSnapshot) -> Vec<Vec<Vec2>> {
+/// Return transformed world-space vertex groups for any retained polygon/polygram snapshot.
+///
+/// This is the shared frontend query boundary: adapters should call this instead of
+/// reconstructing retained path commands or transform math in their host language.
+pub fn polygram_vertex_groups(snapshot: &ObjectSnapshot) -> Vec<Vec<Vec2>> {
     let GeometryRef::VectorPath(path) = &snapshot.geometry else {
         return Vec::new();
     };
@@ -172,19 +173,24 @@ fn snapshot_vertex_groups(snapshot: &ObjectSnapshot) -> Vec<Vec<Vec2>> {
     groups
 }
 
+/// Return transformed world-space vertices flattened in retained group order.
+pub fn polygram_vertices(snapshot: &ObjectSnapshot) -> Vec<Vec2> {
+    polygram_vertex_groups(snapshot)
+        .into_iter()
+        .flatten()
+        .collect()
+}
+
 macro_rules! impl_polygram_queries {
     ($($shape:ty),+ $(,)?) => {
         $(
             impl $shape {
                 pub fn get_vertices(&self) -> Vec<Vec2> {
-                    snapshot_vertex_groups(self.snapshot())
-                        .into_iter()
-                        .flatten()
-                        .collect()
+                    polygram_vertices(self.snapshot())
                 }
 
                 pub fn get_vertex_groups(&self) -> Vec<Vec<Vec2>> {
-                    snapshot_vertex_groups(self.snapshot())
+                    polygram_vertex_groups(self.snapshot())
                 }
             }
         )+
@@ -277,6 +283,21 @@ mod tests {
             ]
         );
         assert_eq!(polygram.get_vertex_groups().len(), 1);
+    }
+
+    #[test]
+    fn shared_query_functions_match_shape_methods() {
+        let polygon = Polygon::new([
+            Vec2::new(-1.0, -1.0),
+            Vec2::new(2.0, -1.0),
+            Vec2::new(0.0, 3.0),
+        ])
+        .shift(Vec2::new(4.0, 2.0));
+        assert_eq!(polygram_vertices(polygon.snapshot()), polygon.get_vertices());
+        assert_eq!(
+            polygram_vertex_groups(polygon.snapshot()),
+            polygon.get_vertex_groups()
+        );
     }
 
     #[test]

--- a/crates/noon/src/polygram_authoring.rs
+++ b/crates/noon/src/polygram_authoring.rs
@@ -293,7 +293,10 @@ mod tests {
             Vec2::new(0.0, 3.0),
         ])
         .shift(Vec2::new(4.0, 2.0));
-        assert_eq!(polygram_vertices(polygon.snapshot()), polygon.get_vertices());
+        assert_eq!(
+            polygram_vertices(polygon.snapshot()),
+            polygon.get_vertices()
+        );
         assert_eq!(
             polygram_vertex_groups(polygon.snapshot()),
             polygon.get_vertex_groups()

--- a/scripts/check-polygram-web-package.mjs
+++ b/scripts/check-polygram-web-package.mjs
@@ -1,0 +1,47 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+const packageDirectory = path.join(process.cwd(), "web", "pkg");
+const [javascript, declarations] = await Promise.all([
+  readFile(path.join(packageDirectory, "noon_web.js"), "utf8"),
+  readFile(path.join(packageDirectory, "noon_web.d.ts"), "utf8"),
+]);
+
+const javascriptSurface = [
+  "export class WasmPolygramVertexGroups",
+  "createManimPolygon(",
+  "createManimPolygram(",
+  "createManimRegularPolygon(",
+  "createManimRegularPolygram(",
+  "createManimTriangle(",
+  "createManimStar(",
+  "manimVertexGroups(",
+  "coordinates(",
+  "groupLengths(",
+];
+
+const declarationSurface = [
+  "export class WasmPolygramVertexGroups",
+  "createManimPolygon(",
+  "createManimPolygram(",
+  "createManimRegularPolygon(",
+  "createManimRegularPolygram(",
+  "createManimTriangle(",
+  "createManimStar(",
+  "manimVertexGroups(): WasmPolygramVertexGroups",
+  "coordinates(): Float64Array",
+  "groupLengths(): Uint32Array",
+];
+
+for (const fragment of javascriptSurface) {
+  if (!javascript.includes(fragment)) {
+    throw new Error(`Generated JavaScript is missing polygon adapter surface: ${fragment}`);
+  }
+}
+for (const fragment of declarationSurface) {
+  if (!declarations.includes(fragment)) {
+    throw new Error(`Generated declarations are missing polygon adapter surface: ${fragment}`);
+  }
+}
+
+console.log("Validated shared polygon/polygram browser package surface");

--- a/scripts/manim-polygram-adapters-smoke.mjs
+++ b/scripts/manim-polygram-adapters-smoke.mjs
@@ -1,0 +1,174 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import playwright from "playwright";
+
+const { chromium } = playwright;
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const port = 4186;
+const baseUrl = `http://127.0.0.1:${port}`;
+
+const pythonSource = `
+from noon import *
+
+class PolygramAdapters(Scene):
+    def construct(self):
+        polygon = Polygon((-1.0, -1.0, 0.0), (2.0, -1.0, 0.0), (0.0, 3.0, 0.0)).shift(RIGHT)
+        vertices = polygon.get_vertices()
+        assert len(vertices) == 3
+        assert abs(vertices[0][0] - 0.0) < 1e-6
+        assert abs(vertices[0][1] + 1.0) < 1e-6
+        assert abs(vertices[2][0] - 1.0) < 1e-6
+        assert abs(vertices[2][1] - 3.0) < 1e-6
+
+        regular = RegularPolygon(4, radius=2.0, start_angle=0.0)
+        regular_vertices = regular.get_vertices()
+        assert len(regular_vertices) == 4
+        assert abs(regular_vertices[0][0] - 2.0) < 1e-6
+        assert abs(regular_vertices[0][1]) < 1e-6
+
+        disconnected = RegularPolygram(6, density=2)
+        groups = disconnected.get_vertex_groups()
+        assert [len(group) for group in groups] == [3, 3]
+
+        triangle = Triangle()
+        assert len(triangle.get_vertices()) == 3
+        assert isinstance(triangle, RegularPolygon)
+        assert isinstance(triangle, Polygram)
+
+        star = Star(n=5, outer_radius=1.5, density=2)
+        assert len(star.get_vertices()) == 10
+        assert isinstance(star, Polygon)
+
+        explicit = Polygram(
+            ((0.0, 2.0, 0.0), (-1.0, -1.0, 0.0), (1.0, -1.0, 0.0)),
+            ((0.0, -2.0, 0.0), (-1.0, 1.0, 0.0), (1.0, 1.0, 0.0)),
+        )
+        assert [len(group) for group in explicit.get_vertex_groups()] == [3, 3]
+
+        self.add(polygon, regular, disconnected, triangle, star, explicit)
+`;
+
+let serverOutput = "";
+const server = spawn(
+  "python3",
+  ["-m", "http.server", String(port), "--bind", "127.0.0.1", "--directory", repoRoot],
+  { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] },
+);
+server.stdout.on("data", (chunk) => (serverOutput += chunk));
+server.stderr.on("data", (chunk) => (serverOutput += chunk));
+
+async function waitForServer() {
+  let lastError = null;
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    try {
+      const response = await fetch(`${baseUrl}/web/manim-compat-smoke.html`);
+      if (response.ok) return;
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Polygon adapter smoke server did not start: ${lastError}\n${serverOutput}`);
+}
+
+function assertClose(actual, expected, message) {
+  assert.ok(Math.abs(actual - expected) <= 1e-6, `${message}: ${actual} != ${expected}`);
+}
+
+let browser = null;
+try {
+  await waitForServer();
+  browser = await chromium.launch({
+    channel: "chromium",
+    headless: true,
+    args: ["--disable-dev-shm-usage"],
+  });
+  const page = await browser.newPage();
+  const errors = [];
+  page.on("pageerror", (error) => errors.push(`pageerror: ${error}`));
+  page.on("console", (message) => {
+    if (message.type() === "error") errors.push(`console: ${message.text()}`);
+  });
+
+  await page.goto(`${baseUrl}/web/manim-compat-smoke.html`, { waitUntil: "load" });
+  await page.waitForFunction(() => window.noonManimCompat, null, { timeout: 30_000 });
+  await page.evaluate(() => window.noonManimCompat.ready());
+
+  const python = await page.evaluate(
+    (source) => window.noonManimCompat.run(source),
+    pythonSource,
+  );
+  assert.equal(python.kind, "scene_document");
+  assert.equal(python.document.objects.length, 6);
+
+  const javascript = await page.evaluate(async () => {
+    const wasm = await import("/web/pkg/noon_web.js");
+    await wasm.default();
+    const store = new wasm.WasmAuthoringStore();
+
+    const readGroups = (handle) => {
+      const encoded = handle.manimVertexGroups();
+      try {
+        return {
+          coordinates: Array.from(encoded.coordinates()),
+          lengths: Array.from(encoded.groupLengths()),
+        };
+      } finally {
+        encoded.free();
+      }
+    };
+
+    const polygon = store.createManimPolygon(
+      new Float64Array([-1, -1, 2, -1, 0, 3]),
+    );
+    polygon.shift(1, 0);
+
+    const regular = store.createManimRegularPolygon(4, 2, 0);
+    const disconnected = store.createManimRegularPolygram(6, 2, 1, undefined);
+    const triangle = store.createManimTriangle();
+    const star = store.createManimStar(5, 1.5, undefined, 2, Math.PI / 2);
+    const explicit = store.createManimPolygram(
+      new Float64Array([0, 2, -1, -1, 1, -1, 0, -2, -1, 1, 1, 1]),
+      new Uint32Array([3, 3]),
+    );
+
+    let rejectedInvalidDensity = false;
+    try {
+      store.createManimRegularPolygram(5, 0, 1, undefined);
+    } catch {
+      rejectedInvalidDensity = true;
+    }
+
+    return {
+      polygon: readGroups(polygon),
+      regular: readGroups(regular),
+      disconnected: readGroups(disconnected),
+      triangle: readGroups(triangle),
+      star: readGroups(star),
+      explicit: readGroups(explicit),
+      rejectedInvalidDensity,
+    };
+  });
+
+  assert.deepEqual(javascript.polygon.lengths, [3]);
+  assert.deepEqual(javascript.polygon.coordinates, [0, -1, 3, -1, 1, 3]);
+  assert.deepEqual(javascript.regular.lengths, [4]);
+  assertClose(javascript.regular.coordinates[0], 2, "regular polygon first x");
+  assertClose(javascript.regular.coordinates[1], 0, "regular polygon first y");
+  assert.deepEqual(javascript.disconnected.lengths, [3, 3]);
+  assert.deepEqual(javascript.triangle.lengths, [3]);
+  assert.deepEqual(javascript.star.lengths, [10]);
+  assert.deepEqual(javascript.explicit.lengths, [3, 3]);
+  assert.equal(javascript.rejectedInvalidDensity, true);
+  assert.equal(errors.length, 0, errors.join("\n"));
+
+  console.log("Shared Python/JavaScript polygon and polygram adapter smoke passed");
+} finally {
+  if (browser !== null) await browser.close();
+  server.kill("SIGTERM");
+}

--- a/web/python-worker.source.js
+++ b/web/python-worker.source.js
@@ -2,7 +2,6 @@ import initNoonWeb, {
   RetainedTypstAuthoringHandle,
   WasmAuthoringStore,
   manimDotSnapshotJson,
-  manimTriangleSnapshotJson,
   resolveAnimationOptions,
   resolveCompositionSchedule,
   resolveLifecyclePlan,
@@ -30,6 +29,10 @@ self.addEventListener("message", (event) => {
   requestQueue = requestQueue.then(() => handleRequest(event.data));
 });
 
+function optionalNumber(value) {
+  return value == null ? undefined : Number(value);
+}
+
 async function initializePyodide() {
   const noonWebReady = initNoonWeb();
   const pyodideReady = loadPyodide();
@@ -45,14 +48,52 @@ async function initializePyodide() {
     authoringStore.createMobject(snapshotJson);
   self.noonCreateAuthoringDotHandle = (pointX, pointY, radius) =>
     authoringStore.createMobject(manimDotSnapshotJson(pointX, pointY, radius));
-  self.noonCreateAuthoringTriangleHandle = () =>
-    authoringStore.createMobject(manimTriangleSnapshotJson());
+  self.noonCreateAuthoringTriangleHandle = () => authoringStore.createManimTriangle();
   self.noonCreateAuthoringCircleHandle = (radius) => authoringStore.createManimCircle(radius);
   self.noonCreateAuthoringSquareHandle = (sideLength) => authoringStore.createManimSquare(sideLength);
   self.noonCreateAuthoringRectangleHandle = (width, height) =>
     authoringStore.createManimRectangle(width, height);
   self.noonCreateAuthoringLineHandle = (startX, startY, endX, endY) =>
     authoringStore.createManimLine(startX, startY, endX, endY);
+  self.noonCreateAuthoringPolygonHandle = (coordinates) =>
+    authoringStore.createManimPolygon(Float64Array.from(coordinates));
+  self.noonCreateAuthoringPolygramHandle = (coordinates, groupLengths) =>
+    authoringStore.createManimPolygram(
+      Float64Array.from(coordinates),
+      Uint32Array.from(groupLengths),
+    );
+  self.noonCreateAuthoringRegularPolygonHandle = (numVertices, radius, startAngle) =>
+    authoringStore.createManimRegularPolygon(
+      Number(numVertices),
+      Number(radius),
+      optionalNumber(startAngle),
+    );
+  self.noonCreateAuthoringRegularPolygramHandle = (
+    numVertices,
+    density,
+    radius,
+    startAngle,
+  ) =>
+    authoringStore.createManimRegularPolygram(
+      Number(numVertices),
+      Number(density),
+      Number(radius),
+      optionalNumber(startAngle),
+    );
+  self.noonCreateAuthoringStarHandle = (
+    points,
+    outerRadius,
+    innerRadius,
+    density,
+    startAngle,
+  ) =>
+    authoringStore.createManimStar(
+      Number(points),
+      Number(outerRadius),
+      optionalNumber(innerRadius),
+      Number(density),
+      optionalNumber(startAngle),
+    );
   self.noonCreateAuthoringFamilyHandle = () => authoringStore.createFamily();
   self.noonCreateRetainedTypstHandle = (source, math, fontSize) =>
     new RetainedTypstAuthoringHandle(source, math, fontSize);

--- a/web/python/_manim_shared_geometry.py
+++ b/web/python/_manim_shared_geometry.py
@@ -1,7 +1,8 @@
 """Thin Manim geometry constructor adapters backed by shared Rust semantics.
 
-This module intentionally patches only constructors whose full observable geometry/layout
-contract is already owned by Rust.  Class identity and inheritance remain unchanged.
+This module intentionally patches only constructors whose observable geometry/layout
+contract is already owned by Rust. Class identity and inheritance stay Python-facing,
+while path construction, winding, defaults, transforms and vertex queries stay shared.
 """
 
 from __future__ import annotations
@@ -23,19 +24,34 @@ try:
 except ImportError:  # Native CPython tests keep the existing Python constructor.
     _create_triangle_handle = None
 
+try:
+    from js import noonCreateAuthoringPolygonHandle as _create_polygon_handle
+except ImportError:
+    _create_polygon_handle = None
+try:
+    from js import noonCreateAuthoringPolygramHandle as _create_polygram_handle
+except ImportError:
+    _create_polygram_handle = None
+try:
+    from js import noonCreateAuthoringRegularPolygonHandle as _create_regular_polygon_handle
+except ImportError:
+    _create_regular_polygon_handle = None
+try:
+    from js import noonCreateAuthoringRegularPolygramHandle as _create_regular_polygram_handle
+except ImportError:
+    _create_regular_polygram_handle = None
+try:
+    from js import noonCreateAuthoringStarHandle as _create_star_handle
+except ImportError:
+    _create_star_handle = None
+
 _ORIGINAL_DOT_INIT = _geometry.Dot.__init__
 _ORIGINAL_TRIANGLE_INIT = _geometry.Triangle.__init__
 _INSTALLED = False
 
 
 def _set_shared_color(self: _base.Mobject, color: object) -> None:
-    """Apply Manim ``color`` through the shared semantic handle.
-
-    The generic Phase-B setter rebuilds a Python snapshot before handing it back to
-    Rust.  Shared constructors must not re-enter that compatibility path: parse the
-    host color once, then use the semantic-handle mutation that preserves each
-    channel's existing opacity.
-    """
+    """Apply Manim ``color`` through the shared semantic handle."""
 
     parsed = _shared._phase_b._as_color("color", color)
     _shared._set_color(self, parsed)
@@ -79,6 +95,8 @@ def _dot_init(
 
 
 def _triangle_init(self: _geometry.Triangle, **kwargs: Any) -> None:
+    """Compatibility path for bridges that expose Triangle but not the full family."""
+
     if _create_triangle_handle is None:
         _ORIGINAL_TRIANGLE_INIT(self, **kwargs)
         return
@@ -91,6 +109,219 @@ def _triangle_init(self: _geometry.Triangle, **kwargs: Any) -> None:
         _set_shared_color(self, color)
 
 
+def _vertex2(value: object) -> _base.Vec2:
+    return _compat._as_vec2(value)
+
+
+def _flatten_vertices(vertices: tuple[object, ...]) -> list[float]:
+    flat: list[float] = []
+    for vertex in vertices:
+        point = _vertex2(vertex)
+        flat.extend((float(point.x), float(point.y)))
+    return flat
+
+
+def _flatten_vertex_groups(vertex_groups: tuple[object, ...]) -> tuple[list[float], list[int]]:
+    flat: list[float] = []
+    lengths: list[int] = []
+    for group in vertex_groups:
+        try:
+            vertices = tuple(group)  # type: ignore[arg-type]
+        except TypeError as error:
+            raise TypeError("Polygram vertex groups must be iterable") from error
+        lengths.append(len(vertices))
+        flat.extend(_flatten_vertices(vertices))
+    return flat, lengths
+
+
+def _constructor_options(kwargs: dict[str, Any]) -> tuple[object | None, dict[str, Any]]:
+    options = dict(kwargs)
+    color = options.pop("color", None)
+    return color, options
+
+
+def _attach_constructed(
+    self: _base.Mobject,
+    handle: object,
+    color: object | None,
+    options: dict[str, Any],
+) -> None:
+    _shared._attach_shared_handle(self, handle)
+    _shared._apply_shared_constructor_kwargs(self, options)
+    if color is not None:
+        _set_shared_color(self, color)
+
+
+def _decode_vertex_groups(self: _base.Mobject) -> list[list[tuple[float, float, float]]]:
+    handle = _shared._handle_for(self)
+    if handle is None or not hasattr(handle, "manimVertexGroups"):
+        raise RuntimeError("polygram vertex queries require a current shared semantic handle")
+    encoded = handle.manimVertexGroups()
+    try:
+        coordinates = [float(value) for value in encoded.coordinates()]
+        lengths = [int(value) for value in encoded.groupLengths()]
+    finally:
+        encoded.free()
+
+    groups: list[list[tuple[float, float, float]]] = []
+    cursor = 0
+    for length in lengths:
+        group: list[tuple[float, float, float]] = []
+        for _ in range(length):
+            group.append((coordinates[cursor], coordinates[cursor + 1], 0.0))
+            cursor += 2
+        groups.append(group)
+    if cursor != len(coordinates):
+        raise RuntimeError("shared polygram vertex query returned inconsistent group lengths")
+    return groups
+
+
+class Polygram(_compat.VMobject):
+    def __init__(
+        self,
+        *vertex_groups: object,
+        color: _base.Color = _base.BLUE,
+        **kwargs: Any,
+    ) -> None:
+        if _create_polygram_handle is None:
+            raise RuntimeError("shared Polygram authoring bridge is unavailable")
+        coordinates, lengths = _flatten_vertex_groups(vertex_groups)
+        _attach_constructed(
+            self,
+            _create_polygram_handle(coordinates, lengths),
+            color,
+            dict(kwargs),
+        )
+
+    def get_vertex_groups(self) -> list[list[tuple[float, float, float]]]:
+        return _decode_vertex_groups(self)
+
+    def get_vertices(self) -> list[tuple[float, float, float]]:
+        return [vertex for group in self.get_vertex_groups() for vertex in group]
+
+
+class Polygon(Polygram):
+    def __init__(self, *vertices: object, **kwargs: Any) -> None:
+        if _create_polygon_handle is None:
+            raise RuntimeError("shared Polygon authoring bridge is unavailable")
+        color, options = _constructor_options(kwargs)
+        _attach_constructed(
+            self,
+            _create_polygon_handle(_flatten_vertices(vertices)),
+            color,
+            options,
+        )
+
+
+class RegularPolygram(Polygram):
+    def __init__(
+        self,
+        num_vertices: int,
+        *,
+        density: int = 2,
+        radius: float = 1.0,
+        start_angle: float | None = None,
+        **kwargs: Any,
+    ) -> None:
+        if _create_regular_polygram_handle is None:
+            raise RuntimeError("shared RegularPolygram authoring bridge is unavailable")
+        color, options = _constructor_options(kwargs)
+        _attach_constructed(
+            self,
+            _create_regular_polygram_handle(
+                int(num_vertices),
+                int(density),
+                float(radius),
+                start_angle,
+            ),
+            color,
+            options,
+        )
+        self.num_vertices = int(num_vertices)
+        self.density = int(density)
+        self.radius = float(radius)
+        self.start_angle = start_angle
+
+
+class RegularPolygon(RegularPolygram):
+    def __init__(self, n: int = 6, **kwargs: Any) -> None:
+        if _create_regular_polygon_handle is None:
+            raise RuntimeError("shared RegularPolygon authoring bridge is unavailable")
+        options = dict(kwargs)
+        radius = float(options.pop("radius", 1.0))
+        start_angle = options.pop("start_angle", None)
+        color, options = _constructor_options(options)
+        _attach_constructed(
+            self,
+            _create_regular_polygon_handle(int(n), radius, start_angle),
+            color,
+            options,
+        )
+        self.num_vertices = int(n)
+        self.density = 1
+        self.radius = radius
+        self.start_angle = start_angle
+
+
+class Triangle(RegularPolygon):
+    def __init__(self, **kwargs: Any) -> None:
+        if _create_triangle_handle is None:
+            raise RuntimeError("shared Triangle authoring bridge is unavailable")
+        color, options = _constructor_options(kwargs)
+        _attach_constructed(self, _create_triangle_handle(), color, options)
+        self.num_vertices = 3
+        self.density = 1
+        self.radius = 1.0
+        self.start_angle = None
+
+
+class Star(Polygon):
+    def __init__(
+        self,
+        n: int = 5,
+        *,
+        outer_radius: float = 1.0,
+        inner_radius: float | None = None,
+        density: int = 2,
+        start_angle: float = _base.PI / 2,
+        **kwargs: Any,
+    ) -> None:
+        if _create_star_handle is None:
+            raise RuntimeError("shared Star authoring bridge is unavailable")
+        color, options = _constructor_options(kwargs)
+        _attach_constructed(
+            self,
+            _create_star_handle(
+                int(n),
+                float(outer_radius),
+                inner_radius,
+                int(density),
+                float(start_angle),
+            ),
+            color,
+            options,
+        )
+        self.num_vertices = int(n)
+        self.outer_radius = float(outer_radius)
+        self.inner_radius = inner_radius
+        self.density = int(density)
+        self.start_angle = float(start_angle)
+
+
+def _polygram_bridge_available() -> bool:
+    return all(
+        value is not None
+        for value in (
+            _create_polygon_handle,
+            _create_polygram_handle,
+            _create_regular_polygon_handle,
+            _create_regular_polygram_handle,
+            _create_triangle_handle,
+            _create_star_handle,
+        )
+    )
+
+
 def install() -> None:
     global _INSTALLED
     if _INSTALLED:
@@ -98,7 +329,26 @@ def install() -> None:
     _INSTALLED = True
     if _create_dot_handle is not None:
         _geometry.Dot.__init__ = _dot_init
-    if _create_triangle_handle is not None:
+
+    if _polygram_bridge_available():
+        public = {
+            "Polygram": Polygram,
+            "Polygon": Polygon,
+            "RegularPolygram": RegularPolygram,
+            "RegularPolygon": RegularPolygon,
+            "Triangle": Triangle,
+            "Star": Star,
+        }
+        for name, value in public.items():
+            setattr(_base, name, value)
+            setattr(_compat, name, value)
+            setattr(_geometry, name, value)
+        exports = list(_base.__all__)
+        for name in public:
+            if name not in exports:
+                exports.append(name)
+        _base.__all__ = exports
+    elif _create_triangle_handle is not None:
         _geometry.Triangle.__init__ = _triangle_init
 
 


### PR DESCRIPTION
Part of #400.

This slice exposes the shared Rust polygon/polygram family through thin browser adapters without frontend geometry reconstruction.

Included:
- world-space Polygon/Polygram vertex and vertex-group queries owned by shared Rust
- typed WASM constructors for Polygon, Polygram, RegularPolygon, RegularPolygram, Triangle, and Star
- Python Manim-compatible classes backed by shared semantic handles
- Python worker typed-array bridge
- generated browser package contract checks
- focused Chromium Python + JavaScript parity smoke
- Rust validation for grouping, defaults, density, transforms, and malformed inputs

No renderer, execution-worker, text/font, or scene-model changes.

#400 remains open for the remaining geometry families.