### PR TITLE
Diagnose WebGL host raster submission visibility

### DIFF
--- a/web/manim-raster-host.js
+++ b/web/manim-raster-host.js
@@ -25,6 +25,18 @@ function waitForPaint() {
   });
 }
 
+function finishWebGlDiagnosticSubmission() {
+  if (renderer?.rendererBackend() !== "WebGL2") return;
+  const gl = offscreen.getContext("webgl2");
+  if (gl === null) {
+    throw new Error("host raster WebGL diagnostic could not recover the owned WebGL2 context");
+  }
+  // Diagnostic only: prove whether the failing host-updater sample is caused by
+  // screenshot visibility racing the final WebGL submission. This direct context
+  // fence must be replaced by a renderer-owned completion contract before merge.
+  gl.finish();
+}
+
 async function presentDelta(deltaJson) {
   if (deltaJson === undefined || deltaJson === null) return false;
   const applied = renderer.applyDeltaJson(deltaJson);
@@ -36,6 +48,7 @@ async function presentDelta(deltaJson) {
   if (!presented) {
     throw new Error("host raster renderer could not present an applied execution delta");
   }
+  finishWebGlDiagnosticSubmission();
   await waitForPaint();
   return true;
 }
@@ -79,6 +92,7 @@ async function load(source, loopDurationSeconds) {
   if (!presented) {
     throw new Error("host raster renderer could not present its initial snapshot");
   }
+  finishWebGlDiagnosticSubmission();
   await waitForPaint();
 
   return {


### PR DESCRIPTION
## Diagnostic scope

Tracks #513. This is an intentionally disposable A/B test, **not the final architecture**.

- after each host-raster `ExecutionCanvasRenderer.render()` on the WebGL2 backend, recover the already-owned WebGL2 context and call `finish()` before the existing compositor paint wait
- leave WebGPU untouched
- leave production engine/render worker callback ordering untouched
- do not change raster tolerances, uploads, snapshots, or callback deadlines

## Question this answers

The #512 artifact shows frame 90 as an effectively missing moving line only on WebGL while WebGPU is correct, and #514 proves runtime -> `FramePreparer` locality. If this branch clears the exact frame-90 raster failure, the root seam is submission visibility/completion rather than semantic/preparation data.

If confirmed, this direct context fence will be replaced before merge by a renderer-owned explicit completion method using wgpu's submission/poll contract. This draft must not merge with the raw GL call.

Related: #513, #512, #514.