### PR TITLE
Defer Ruff until Python source editing

### DIFF
--- a/scripts/python-editor-smoke.mjs
+++ b/scripts/python-editor-smoke.mjs
@@ -104,9 +104,13 @@ try {
 
   const page = await browser.newPage({ viewport: { width: 1400, height: 900 } });
   const errors = [];
+  const ruffRequests = [];
   page.on("pageerror", (error) => errors.push(`pageerror: ${error}`));
   page.on("console", (message) => {
     if (message.type() === "error") errors.push(`console: ${message.text()}`);
+  });
+  page.on("request", (request) => {
+    if (request.url().includes("ruff-wasm")) ruffRequests.push(request.url());
   });
 
   await page.goto(`${baseUrl}/web/index.html`, { waitUntil: "load" });
@@ -145,12 +149,23 @@ try {
   });
   assert.equal(
     await page.locator(".python-code-editor[data-editor-ready='true']").count(),
-    2,
-    "both Python textareas should be enhanced after the first editor focus",
+    1,
+    "only the visible Python source textarea should be enhanced after focus",
+  );
+  assert.equal(
+    await page.locator("#patch-editor-panel .python-code-editor").count(),
+    0,
+    "the hidden patch editor must not allocate a CodeMirror instance",
   );
 
   const highlightedSpans = await page.locator("#scene-editor-panel .cm-line span").count();
   assert.ok(highlightedSpans > 0, "Python source should contain syntax-highlighted spans");
+  await page.waitForTimeout(750);
+  assert.equal(
+    ruffRequests.length,
+    0,
+    "Ruff WASM must stay unloaded while the user only inspects highlighted source",
+  );
 
   await page.locator("#replace-scene").click();
   await waitForRuntime(page, errors, "enhanced editor");
@@ -199,15 +214,15 @@ try {
     `desktop preview should remain horizontally centered; ${JSON.stringify(layout)}`,
   );
 
-  await page.evaluate(() => {
-    document.querySelector("#python-scene-source").value =
-      "import os\n\ndef broken():\n    return missing_name\n";
-  });
+  await page.locator("#scene-editor-panel .cm-content").fill(
+    "import os\n\ndef broken():\n    return missing_name\n",
+  );
   await page.waitForSelector("#scene-editor-panel .cm-lintRange-warning", {
     timeout: 30_000,
   });
   const lintRanges = await page.locator("#scene-editor-panel .cm-lintRange-warning").count();
-  assert.ok(lintRanges >= 1, "Ruff should report inline Python diagnostics");
+  assert.ok(lintRanges >= 1, "Ruff should report inline Python diagnostics after real editor input");
+  assert.ok(ruffRequests.length >= 1, "the first real editor input should load Ruff on demand");
 
   assert.deepEqual(errors, [], `browser errors while loading Python editor:\n${errors.join("\n")}`);
   await page.close();
@@ -290,7 +305,7 @@ try {
   await fallbackContext.close();
 
   console.log(
-    `Python editor smoke passed: deferred startup + enhanced editor + ${lintRanges} Ruff diagnostic(s) + CDN-blocked textarea fallback with a fresh two-object render.`,
+    `Python editor smoke passed: deferred startup + one visible CodeMirror + deferred Ruff (${lintRanges} diagnostic(s)) + CDN-blocked textarea fallback with a fresh two-object render.`,
   );
 } finally {
   await browser?.close();

--- a/web/python-editor.js
+++ b/web/python-editor.js
@@ -17,6 +17,7 @@ export const PYTHON_RUFF_SETTINGS = {
 };
 
 let ruffWorkspacePromise = null;
+const ruffEnabledViews = new WeakSet();
 
 if (typeof document !== "undefined") {
   // CodeMirror/Ruff are progressive enhancement. A transient CDN, CSP, or WASM
@@ -31,12 +32,12 @@ async function enhancePythonEditors() {
   const textareas = [
     document.querySelector("#python-scene-source"),
     document.querySelector("#python-source"),
-  ].filter(Boolean);
+  ].filter((textarea) => textarea && !textarea.hidden);
   if (textareas.length === 0) {
     return;
   }
 
-  const [{ EditorView, basicSetup }, { python }, { linter, lintGutter }, { oneDark }] =
+  const [{ EditorView, basicSetup }, { python }, { linter, lintGutter, forceLinting }, { oneDark }] =
     await Promise.all([
       import(CODEMIRROR_URL),
       import(PYTHON_URL),
@@ -98,8 +99,12 @@ async function enhancePythonEditors() {
     // Keep the hidden textarea as the stable integration surface for the
     // playground. Programmatic .value writes are projected into CodeMirror,
     // while real user edits emit the textarea input event expected by gallery
-    // draft/reset state and any other existing consumers.
+    // draft/reset state and any other existing consumers. Ruff is intentionally
+    // activated by the first real editor input so merely inspecting source does
+    // not allocate its additional WASM runtime.
     view.contentDOM.addEventListener("input", () => {
+      ruffEnabledViews.add(view);
+      forceLinting(view);
       textarea.dispatchEvent(new Event("input", { bubbles: true }));
     });
 
@@ -144,6 +149,9 @@ async function enhancePythonEditors() {
 }
 
 async function runRuff(view) {
+  if (!ruffEnabledViews.has(view)) {
+    return [];
+  }
   try {
     const workspace = await getRuffWorkspace();
     const diagnostics = workspace.check(view.state.doc.toString());

--- a/web/python-editor.js
+++ b/web/python-editor.js
@@ -28,11 +28,17 @@ if (typeof document !== "undefined") {
   });
 }
 
+function isVisiblePythonTextarea(textarea) {
+  if (!textarea || textarea.hidden) return false;
+  const editorPanel = textarea.closest(".editor-panel");
+  return editorPanel === null || editorPanel.dataset.active === "true";
+}
+
 async function enhancePythonEditors() {
   const textareas = [
     document.querySelector("#python-scene-source"),
     document.querySelector("#python-source"),
-  ].filter((textarea) => textarea && !textarea.hidden);
+  ].filter(isVisiblePythonTextarea);
   if (textareas.length === 0) {
     return;
   }


### PR DESCRIPTION
## Summary
- keep CodeMirror deferred until the existing first source-editor focus boundary
- enhance only visible Python textareas, avoiding a hidden patch-editor CodeMirror allocation in the public demo
- keep Ruff WASM uninitialized while users only inspect highlighted source
- activate Ruff on the first real CodeMirror input and preserve inline diagnostics thereafter
- extend the browser smoke to prove one visible editor, no pre-edit Ruff request, on-demand linting, and the existing fail-soft textarea fallback

## Why
#491 removed the large eager startup costs, but focusing the source editor still enhanced the hidden patch textarea and CodeMirror's linter could initialize Ruff shortly after editor creation. This keeps the presentation upgrade progressive: syntax highlighting is available on focus, while the heavier lint WASM is paid for only when editing actually begins.

## Scope
Editor/presentation only. No authoring worker, execution runtime, renderer, geometry, or active #513/#517 seams are changed.