### PR TITLE
Fence host raster capture on GPU submission completion

### DIFF
--- a/crates/noon-web/src/execution_canvas.rs
+++ b/crates/noon-web/src/execution_canvas.rs
@@ -11,7 +11,13 @@ const MANIM_DEFAULT_CLEAR_COLOR: wgpu::Color = wgpu::Color {
 
 #[cfg(target_arch = "wasm32")]
 mod wasm {
-    use std::mem;
+    use std::{
+        mem,
+        sync::{
+            atomic::{AtomicU32, Ordering},
+            Arc,
+        },
+    };
 
     use noon_core::Vec2;
     use noon_render_wgpu::{Camera2D, FramePreparer, GpuRenderer};
@@ -65,6 +71,8 @@ mod wasm {
         last_instances_drawn: usize,
         last_bytes_uploaded: usize,
         last_geometry_cache_misses: usize,
+        submission_generation: u32,
+        completed_submission_generation: Arc<AtomicU32>,
         gpu_generation: u32,
         gpu_diagnostics: GpuDiagnosticMailbox,
     }
@@ -120,6 +128,8 @@ mod wasm {
                 last_instances_drawn: 0,
                 last_bytes_uploaded: 0,
                 last_geometry_cache_misses: 0,
+                submission_generation: 0,
+                completed_submission_generation: Arc::new(AtomicU32::new(0)),
                 gpu_generation,
                 gpu_diagnostics,
             };
@@ -155,6 +165,10 @@ mod wasm {
                 return Ok(false);
             }
 
+            let submission_generation = self
+                .submission_generation
+                .checked_add(1)
+                .ok_or_else(|| js_message("execution renderer submission generation exhausted"))?;
             let (surface_texture, reconfigure_after_present) =
                 match self.surface.get_current_texture() {
                     wgpu::CurrentSurfaceTexture::Success(texture) => (texture, false),
@@ -198,6 +212,11 @@ mod wasm {
                 .renderer
                 .encode(&mut encoder, &view, &prepared, self.clear_color);
             self.queue.submit(Some(encoder.finish()));
+            self.submission_generation = submission_generation;
+            let completed_submission_generation = Arc::clone(&self.completed_submission_generation);
+            self.queue.on_submitted_work_done(move || {
+                completed_submission_generation.fetch_max(submission_generation, Ordering::Release);
+            });
             surface_texture.present();
             self.last_draw_calls = draw.draw_calls;
             self.last_instances_drawn = draw.instances_drawn;
@@ -205,6 +224,23 @@ mod wasm {
                 self.surface.configure(&self.device, &self.config);
             }
             Ok(true)
+        }
+
+        #[wasm_bindgen(js_name = pollSubmissionComplete)]
+        pub fn poll_submission_complete(&self) -> Result<bool, JsValue> {
+            self.device.poll(wgpu::PollType::Poll).map_err(js_error)?;
+            Ok(self.completed_submission_generation.load(Ordering::Acquire)
+                >= self.submission_generation)
+        }
+
+        #[wasm_bindgen(js_name = submissionGeneration)]
+        pub fn submission_generation(&self) -> u32 {
+            self.submission_generation
+        }
+
+        #[wasm_bindgen(js_name = completedSubmissionGeneration)]
+        pub fn completed_submission_generation(&self) -> u32 {
+            self.completed_submission_generation.load(Ordering::Acquire)
         }
 
         pub fn resize(&mut self, width: u32, height: u32) -> Result<(), JsValue> {

--- a/web/manim-raster-host.js
+++ b/web/manim-raster-host.js
@@ -19,10 +19,21 @@ let currentLogicalTime = 0;
 let activeFrameTimes = null;
 let authoredDuration = null;
 
+function waitForAnimationFrame() {
+  return new Promise((resolve) => requestAnimationFrame(resolve));
+}
+
 function waitForPaint() {
   return new Promise((resolve) => {
     requestAnimationFrame(() => requestAnimationFrame(resolve));
   });
+}
+
+async function waitForSubmittedFrame() {
+  while (!renderer.pollSubmissionComplete()) {
+    await waitForAnimationFrame();
+  }
+  await waitForPaint();
 }
 
 async function presentDelta(deltaJson) {
@@ -36,7 +47,7 @@ async function presentDelta(deltaJson) {
   if (!presented) {
     throw new Error("host raster renderer could not present an applied execution delta");
   }
-  await waitForPaint();
+  await waitForSubmittedFrame();
   return true;
 }
 
@@ -79,7 +90,7 @@ async function load(source, loopDurationSeconds) {
   if (!presented) {
     throw new Error("host raster renderer could not present its initial snapshot");
   }
-  await waitForPaint();
+  await waitForSubmittedFrame();
 
   return {
     kind: result.kind,
@@ -176,6 +187,8 @@ async function renderThrough(frameIndex, frameTimes) {
     instances: renderer.lastInstancesDrawn(),
     uploadBytes: renderer.lastBytesUploaded(),
     geometryCacheMisses: renderer.lastGeometryCacheMisses(),
+    submissionGeneration: renderer.submissionGeneration(),
+    completedSubmissionGeneration: renderer.completedSubmissionGeneration(),
     authoredDuration,
     frameIndex: currentFrameIndex,
   };


### PR DESCRIPTION
## Result: hypothesis disproven

This PR tested whether #513 was caused by the raster harness treating `surface_texture.present()` plus animation-frame boundaries as sufficient proof that the latest GPU submission was screenshot-visible.

It added explicit queue-submission completion tracking via `wgpu::Queue::on_submitted_work_done` and made only the capture harness poll that completion before its paint boundary. Production rendering remained non-blocking.

The exact `RotationUpdater` acceptance oracle was then run with #512 stacked on this PR at head `6524e9bf1be90d17bd0ece1439399d974b498222`.

Result:
- WASM/browser build passed
- canonical rendering passed
- semantic-state capture passed
- WebGPU `rotation-updater` passed
- WebGL still failed at exactly frame 90 with `bounds_delta_px=55 > 2`
- all other raster fixtures passed on both backends

Therefore explicit GPU submission completion does **not** fix #513. This PR is closed rather than merging unnecessary renderer/capture API surface.

The next boundary is WebGL-specific instance upload/draw state downstream of the runtime/FramePreparer locality gate in merged #514.

Related: #513, #512, #514.