### PR TITLE
Gate path cache under long-running churn

### DIFF
--- a/crates/noon-render-wgpu/tests/path_cache_lifecycle.rs
+++ b/crates/noon-render-wgpu/tests/path_cache_lifecycle.rs
@@ -87,3 +87,68 @@ fn active_frame_geometry_can_exceed_retention_budget_without_retessellation() {
     );
     assert_eq!(preparer.cached_path_mesh_count(), 2);
 }
+
+#[test]
+fn transient_path_churn_reaches_a_bounded_cache_plateau() {
+    const EDIT_COUNT: usize = 1_000;
+    const CACHE_LIMIT: usize = 32;
+
+    let mut preparer = FramePreparer::new();
+    preparer.set_path_mesh_cache_limit(CACHE_LIMIT);
+    let mut most_recent = None;
+
+    for edit in 0..EDIT_COUNT {
+        let current = path(edit as f32 * 10.0);
+        let scene = path_scene(std::slice::from_ref(&current));
+        let prepared = preparer.prepare(scene.frame());
+
+        assert_eq!(prepared.stats.geometry_cache_misses, 1);
+        assert!(
+            preparer.cached_path_mesh_count() <= CACHE_LIMIT + 1,
+            "transient unique geometry must plateau at the retention budget plus the pinned incoming mesh"
+        );
+        most_recent = Some(current);
+    }
+
+    let most_recent = most_recent.expect("churn creates at least one path");
+    let scene = path_scene(std::slice::from_ref(&most_recent));
+    let prepared = preparer.prepare(scene.frame());
+    assert_eq!(
+        prepared.stats.geometry_cache_misses, 0,
+        "the most recent working set should remain reusable after long-running churn"
+    );
+    assert!(preparer.cached_path_mesh_count() <= CACHE_LIMIT);
+}
+
+#[test]
+fn large_temporary_path_scene_does_not_remain_pinned_after_contraction() {
+    const CACHE_LIMIT: usize = 16;
+    const TEMPORARY_PATH_COUNT: usize = 128;
+
+    let mut preparer = FramePreparer::new();
+    preparer.set_path_mesh_cache_limit(CACHE_LIMIT);
+    let temporary_paths = (0..TEMPORARY_PATH_COUNT)
+        .map(|index| path(index as f32 * 10.0))
+        .collect::<Vec<_>>();
+
+    let large_scene = path_scene(&temporary_paths);
+    let prepared = preparer.prepare(large_scene.frame());
+    assert_eq!(prepared.path_ids.len(), TEMPORARY_PATH_COUNT);
+    assert_eq!(prepared.stats.geometry_cache_misses, TEMPORARY_PATH_COUNT);
+    assert_eq!(preparer.cached_path_mesh_count(), TEMPORARY_PATH_COUNT);
+
+    let small_path = path(10_000.0);
+    let small_scene = path_scene(std::slice::from_ref(&small_path));
+    let prepared = preparer.prepare(small_scene.frame());
+    assert_eq!(prepared.path_ids.len(), 1);
+    assert_eq!(prepared.stats.geometry_cache_misses, 1);
+    assert!(
+        preparer.cached_path_mesh_count() <= CACHE_LIMIT + 1,
+        "temporary active geometry must be released back to the bounded retention plateau"
+    );
+
+    let small_scene = path_scene(std::slice::from_ref(&small_path));
+    let prepared = preparer.prepare(small_scene.frame());
+    assert_eq!(prepared.stats.geometry_cache_misses, 0);
+    assert!(preparer.cached_path_mesh_count() <= CACHE_LIMIT);
+}


### PR DESCRIPTION
## Summary
- extend the existing renderer path-cache lifecycle suite with 1,000 unique transient path scenes
- assert retained path meshes plateau at the configured cache budget plus the currently pinned incoming mesh
- verify the most recent working set remains reusable after churn
- cover a 128-path temporary scene contracting back to one path and prove the temporary geometry is not permanently retained

## Why
#114 requires deterministic resource-lifecycle gates for long-running edit/reload/churn patterns. The renderer already had a small LRU correctness test, but it did not prove bounded steady-state behavior under sustained unique geometry churn or after a large temporary scene. Those are the failure modes most likely to reintroduce memory pressure during long demo/editor sessions.

## Scope
Test-only, entirely in `noon-render-wgpu`. No renderer algorithm, GPU upload path, browser worker, demo lifecycle, text/cache residency, or active authoring-mode/raster work is changed.

## Acceptance
- 1,000 transient unique path preparations never grow retained cache beyond the documented budget + pinned incoming frame allowance
- recent working-set reuse still hits the cache
- a large temporary active set can exceed the retention budget while live, but contracts back to the bounded plateau on the following small scene

Tracks #114.