### PR TITLE
Diagnose WebGL host-patch frame phases

### DIFF
--- a/.github/workflows/webgl-host-phase-diagnostic.yml
+++ b/.github/workflows/webgl-host-phase-diagnostic.yml
@@ -1,0 +1,71 @@
+name: WebGL host phase diagnostic
+
+on:
+  pull_request:
+    paths:
+      - "web/manim-raster-host.js"
+      - "scripts/webgl-host-phase-diagnostic.mjs"
+      - ".github/workflows/webgl-host-phase-diagnostic.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  diagnose:
+    name: RotationUpdater frame 90 phases
+    runs-on: ubuntu-latest
+    env:
+      CARGO_INCREMENTAL: "0"
+      NOON_WASM_SKIP_OPT: "1"
+      NOON_SKIP_PLAYGROUND_TEST: "1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use stable Rust
+        run: |
+          rustup default stable
+          rustup target add wasm32-unknown-unknown
+
+      - name: Cache Cargo sources
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-sources-${{ hashFiles('Cargo.toml', 'crates/**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-sources-
+
+      - name: Install pinned wasm-pack
+        uses: taiki-e/install-action@13608cbb45b01feb47ef444ab1a42dc41ad56f1a # v2.79.11
+        with:
+          tool: wasm-pack@0.15.0
+          fallback: none
+
+      - name: Build browser package
+        run: bash scripts/build-web-demo.sh
+
+      - name: Cache Playwright Chromium
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-chromium-1.62.1
+
+      - name: Install diagnostic dependencies
+        run: |
+          npm install --no-save --ignore-scripts playwright@1.62.1
+          npx playwright install chromium
+
+      - name: Capture frame 90 phase metrics
+        run: node scripts/webgl-host-phase-diagnostic.mjs
+
+      - name: Upload phase diagnostic
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: webgl-host-phase-diagnostic
+          path: webgl-host-phase-diagnostic
+          if-no-files-found: warn
+          retention-days: 3

--- a/scripts/webgl-host-phase-diagnostic.mjs
+++ b/scripts/webgl-host-phase-diagnostic.mjs
@@ -26,6 +26,10 @@ function noonRotationUpdaterSource() {
   });
 }
 
+function staticRotationSource() {
+  return `from noon import *\n\nclass StaticRotation(Scene):\n    def construct(self):\n        line_reference = Line(ORIGIN, LEFT).set_color(WHITE)\n        line_moving = Line(ORIGIN, LEFT).set_color(YELLOW)\n        line_moving.rotate_about_origin(0.9666666666666667)\n        self.add(line_reference, line_moving)\n        self.wait(0.5)\n\nresult = StaticRotation()\nresult.setup()\ntry:\n    result.construct()\nfinally:\n    result.tear_down()\n`;
+}
+
 function referenceFrameTimes(frameCount) {
   const times = [0];
   let time = 0;
@@ -50,6 +54,14 @@ async function waitForServer() {
   throw new Error("timed out waiting for diagnostic web server");
 }
 
+async function createHostPage(browser) {
+  const page = await browser.newPage({ viewport: { width: 1000, height: 580 } });
+  await page.goto(`${baseUrl}/web/manim-raster-host.html`, { waitUntil: "load" });
+  await page.waitForFunction(() => window.noonHostRaster, null, { timeout: 30_000 });
+  await page.evaluate(() => window.noonHostRaster.ready());
+  return page;
+}
+
 const server = spawn("python3", ["-m", "http.server", String(port), "--bind", "127.0.0.1"], {
   cwd: repoRoot,
   stdio: ["ignore", "ignore", "inherit"],
@@ -72,13 +84,10 @@ try {
       "--disable-dev-shm-usage",
     ],
   });
-  const page = await browser.newPage({ viewport: { width: 1000, height: 580 } });
-  await page.goto(`${baseUrl}/web/manim-raster-host.html`, { waitUntil: "load" });
-  await page.waitForFunction(() => window.noonHostRaster, null, { timeout: 30_000 });
-  await page.evaluate(() => window.noonHostRaster.ready());
 
+  const updaterPage = await createHostPage(browser);
   const source = await noonRotationUpdaterSource();
-  const loaded = await page.evaluate(
+  const loaded = await updaterPage.evaluate(
     ({ sourceText, loopDuration }) => window.noonHostRaster.load(sourceText, loopDuration),
     { sourceText: source, loopDuration: 5.5 },
   );
@@ -87,7 +96,7 @@ try {
   assert.ok(loaded.callbackSlots > 0, "RotationUpdater must use host callbacks");
 
   const frameTimes = referenceFrameTimes(121);
-  const metrics = await page.evaluate(
+  const metrics = await updaterPage.evaluate(
     ({ targetFrame, times }) => window.noonHostRaster.renderThrough(targetFrame, times),
     { targetFrame: 90, times: frameTimes },
   );
@@ -96,11 +105,26 @@ try {
   assert.ok(metrics.phases, "frame 90 phase metrics");
   assert.equal(metrics.phases.frameIndex, 90, "phase metrics frame index");
   assert.ok(metrics.phases.hostPatch, "frame 90 host patch phase");
+  await updaterPage.locator("#scene").screenshot({
+    path: path.join(artifactDir, "frame-0090-updater.png"),
+  });
+  await updaterPage.close();
 
-  const reportPath = path.join(artifactDir, "frame-0090.json");
-  await writeFile(reportPath, `${JSON.stringify({ loaded, metrics }, null, 2)}\n`);
-  await page.locator("#scene").screenshot({ path: path.join(artifactDir, "frame-0090.png") });
-  console.log(JSON.stringify({ loaded, metrics }, null, 2));
+  const staticPage = await createHostPage(browser);
+  const staticLoaded = await staticPage.evaluate(
+    ({ sourceText, loopDuration }) => window.noonHostRaster.load(sourceText, loopDuration),
+    { sourceText: staticRotationSource(), loopDuration: 1.5 },
+  );
+  assert.equal(staticLoaded.rendererBackend, "WebGL2", "static diagnostic must exercise WebGL2");
+  assert.equal(staticLoaded.callbackSlots, 0, "static rotation must not use host callbacks");
+  await staticPage.locator("#scene").screenshot({
+    path: path.join(artifactDir, "frame-static-rotation.png"),
+  });
+  await staticPage.close();
+
+  const report = { loaded, metrics, staticLoaded, staticRotation: 0.9666666666666667 };
+  await writeFile(path.join(artifactDir, "frame-0090.json"), `${JSON.stringify(report, null, 2)}\n`);
+  console.log(JSON.stringify(report, null, 2));
 } finally {
   await browser?.close();
   server.kill("SIGTERM");

--- a/scripts/webgl-host-phase-diagnostic.mjs
+++ b/scripts/webgl-host-phase-diagnostic.mjs
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import playwright from "playwright";
+
+const { chromium } = playwright;
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const port = Number(process.env.NOON_WEBGL_HOST_DIAGNOSTIC_PORT ?? "4197");
+const baseUrl = `http://127.0.0.1:${port}`;
+const artifactDir = path.resolve(
+  repoRoot,
+  process.env.NOON_WEBGL_HOST_DIAGNOSTIC_ARTIFACTS ?? "webgl-host-phase-diagnostic",
+);
+
+function noonRotationUpdaterSource() {
+  return readFile(
+    path.join(repoRoot, "parity", "manim-v0.21", "upstream-examples", "rotation_updater.py"),
+    "utf8",
+  ).then((source) => {
+    const adapted = source.replace("from manim import *", "from noon import *");
+    return `${adapted}\n\nresult = RotationUpdater()\nresult.setup()\ntry:\n    result.construct()\nfinally:\n    result.tear_down()\n`;
+  });
+}
+
+function referenceFrameTimes(frameCount) {
+  const times = [0];
+  let time = 0;
+  for (let frame = 1; frame < frameCount; frame += 1) {
+    time += 1 / 30;
+    times.push(time);
+  }
+  return times;
+}
+
+async function waitForServer() {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`${baseUrl}/web/manim-raster-host.html`);
+      if (response.ok) return;
+    } catch {
+      // Server is still starting.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error("timed out waiting for diagnostic web server");
+}
+
+const server = spawn("python3", ["-m", "http.server", String(port), "--bind", "127.0.0.1"], {
+  cwd: repoRoot,
+  stdio: ["ignore", "ignore", "inherit"],
+});
+
+let browser = null;
+try {
+  await waitForServer();
+  await mkdir(artifactDir, { recursive: true });
+  browser = await chromium.launch({
+    channel: "chromium",
+    headless: true,
+    args: [
+      "--disable-features=WebGPU",
+      "--enable-unsafe-swiftshader",
+      "--ignore-gpu-blocklist",
+      "--use-gl=angle",
+      "--use-angle=swiftshader",
+      "--disable-gpu-sandbox",
+      "--disable-dev-shm-usage",
+    ],
+  });
+  const page = await browser.newPage({ viewport: { width: 1000, height: 580 } });
+  await page.goto(`${baseUrl}/web/manim-raster-host.html`, { waitUntil: "load" });
+  await page.waitForFunction(() => window.noonHostRaster, null, { timeout: 30_000 });
+  await page.evaluate(() => window.noonHostRaster.ready());
+
+  const source = await noonRotationUpdaterSource();
+  const loaded = await page.evaluate(
+    ({ sourceText, loopDuration }) => window.noonHostRaster.load(sourceText, loopDuration),
+    { sourceText: source, loopDuration: 5.5 },
+  );
+  assert.equal(loaded.rendererBackend, "WebGL2", "diagnostic must exercise WebGL2 fallback");
+  assert.equal(loaded.duration, 4.5, "RotationUpdater authored duration");
+  assert.ok(loaded.callbackSlots > 0, "RotationUpdater must use host callbacks");
+
+  const frameTimes = referenceFrameTimes(121);
+  const metrics = await page.evaluate(
+    ({ targetFrame, times }) => window.noonHostRaster.renderThrough(targetFrame, times),
+    { targetFrame: 90, times: frameTimes },
+  );
+  assert.equal(metrics.error, null, "frame 90 render error");
+  assert.equal(metrics.frameIndex, 90, "frame 90 diagnostic target");
+  assert.ok(metrics.phases, "frame 90 phase metrics");
+  assert.equal(metrics.phases.frameIndex, 90, "phase metrics frame index");
+  assert.ok(metrics.phases.hostPatch, "frame 90 host patch phase");
+
+  const reportPath = path.join(artifactDir, "frame-0090.json");
+  await writeFile(reportPath, `${JSON.stringify({ loaded, metrics }, null, 2)}\n`);
+  await page.locator("#scene").screenshot({ path: path.join(artifactDir, "frame-0090.png") });
+  console.log(JSON.stringify({ loaded, metrics }, null, 2));
+} finally {
+  await browser?.close();
+  server.kill("SIGTERM");
+}

--- a/web/manim-raster-host.js
+++ b/web/manim-raster-host.js
@@ -52,7 +52,7 @@ async function presentDelta(deltaJson) {
     throw new Error("host raster renderer could not present an applied execution delta");
   }
   await waitForPaint();
-  return true;
+  return renderMetrics(true, true);
 }
 
 async function load(source, loopDurationSeconds) {

--- a/web/manim-raster-host.js
+++ b/web/manim-raster-host.js
@@ -18,6 +18,7 @@ let currentFrameIndex = -1;
 let currentLogicalTime = 0;
 let activeFrameTimes = null;
 let authoredDuration = null;
+let lastFramePhases = null;
 
 function waitForPaint() {
   return new Promise((resolve) => {
@@ -25,10 +26,24 @@ function waitForPaint() {
   });
 }
 
+function renderMetrics(applied, presented) {
+  return {
+    applied,
+    presented,
+    rendererTime: renderer.time(),
+    drawCalls: renderer.lastDrawCalls(),
+    instances: renderer.lastInstancesDrawn(),
+    uploadBytes: renderer.lastBytesUploaded(),
+    geometryCacheMisses: renderer.lastGeometryCacheMisses(),
+  };
+}
+
 async function presentDelta(deltaJson) {
-  if (deltaJson === undefined || deltaJson === null) return false;
+  if (deltaJson === undefined || deltaJson === null) {
+    return renderMetrics(false, false);
+  }
   const applied = renderer.applyDeltaJson(deltaJson);
-  if (!applied) return false;
+  if (!applied) return renderMetrics(false, false);
   let presented = false;
   for (let attempt = 0; attempt < 4 && !presented; attempt += 1) {
     presented = renderer.render();
@@ -37,7 +52,7 @@ async function presentDelta(deltaJson) {
     throw new Error("host raster renderer could not present an applied execution delta");
   }
   await waitForPaint();
-  return true;
+  return renderMetrics(true, true);
 }
 
 async function load(source, loopDurationSeconds) {
@@ -92,7 +107,8 @@ async function load(source, loopDurationSeconds) {
 
 async function advanceOneFrame(frameIndex, time) {
   const deterministicDelta = engine.tickDeltaJson(time * 1000);
-  await presentDelta(deterministicDelta);
+  const deterministic = await presentDelta(deterministicDelta);
+  let hostPatch = null;
 
   if (host !== null) {
     host.advanceTo(time);
@@ -108,8 +124,14 @@ async function advanceOneFrame(frameIndex, time) {
     host.commitPatchBatch(batchJson);
 
     const hostDelta = engine.applyHostPatchBatchDeltaJson(batchJson);
-    await presentDelta(hostDelta);
+    hostPatch = await presentDelta(hostDelta);
   }
+  lastFramePhases = {
+    frameIndex,
+    time,
+    deterministic,
+    hostPatch,
+  };
   currentFrameIndex = frameIndex;
   currentLogicalTime = time;
 }
@@ -176,6 +198,7 @@ async function renderThrough(frameIndex, frameTimes) {
     instances: renderer.lastInstancesDrawn(),
     uploadBytes: renderer.lastBytesUploaded(),
     geometryCacheMisses: renderer.lastGeometryCacheMisses(),
+    phases: lastFramePhases,
     authoredDuration,
     frameIndex: currentFrameIndex,
   };

--- a/web/manim-raster-host.js
+++ b/web/manim-raster-host.js
@@ -109,6 +109,7 @@ async function advanceOneFrame(frameIndex, time) {
   const deterministicDelta = engine.tickDeltaJson(time * 1000);
   const deterministic = await presentDelta(deterministicDelta);
   let hostPatch = null;
+  let hostSnapshot = null;
 
   if (host !== null) {
     host.advanceTo(time);
@@ -125,12 +126,16 @@ async function advanceOneFrame(frameIndex, time) {
 
     const hostDelta = engine.applyHostPatchBatchDeltaJson(batchJson);
     hostPatch = await presentDelta(hostDelta);
+    if (frameIndex === 90) {
+      hostSnapshot = JSON.parse(engine.snapshotDeltaJson());
+    }
   }
   lastFramePhases = {
     frameIndex,
     time,
     deterministic,
     hostPatch,
+    hostSnapshot,
   };
   currentFrameIndex = frameIndex;
   currentLogicalTime = time;

--- a/web/manim-raster-host.js
+++ b/web/manim-raster-host.js
@@ -52,7 +52,7 @@ async function presentDelta(deltaJson) {
     throw new Error("host raster renderer could not present an applied execution delta");
   }
   await waitForPaint();
-  return renderMetrics(true, true);
+  return true;
 }
 
 async function load(source, loopDurationSeconds) {
@@ -125,9 +125,12 @@ async function advanceOneFrame(frameIndex, time) {
     host.commitPatchBatch(batchJson);
 
     const hostDelta = engine.applyHostPatchBatchDeltaJson(batchJson);
-    hostPatch = await presentDelta(hostDelta);
     if (frameIndex === 90) {
-      hostSnapshot = JSON.parse(engine.snapshotDeltaJson());
+      const snapshotJson = engine.snapshotDeltaJson();
+      hostSnapshot = JSON.parse(snapshotJson);
+      hostPatch = await presentDelta(snapshotJson);
+    } else {
+      hostPatch = await presentDelta(hostDelta);
     }
   }
   lastFramePhases = {


### PR DESCRIPTION
## Purpose
Temporary focused diagnostic for #513; not a product fix.

- expose per-logical-frame deterministic vs host-patch render metrics from the existing Manim raster host harness
- run the literal `RotationUpdater` source through WebGL to frame 90
- record whether each phase applied/presented and its upload bytes, draw calls, instance count, renderer time, and geometry-cache misses
- upload the exact frame-90 screenshot + metrics JSON

This should distinguish a missing host dirty/upload from a host upload/draw that WebGL nevertheless fails to reflect. No renderer production API, tolerance, callback scheduling, or scene semantics are changed.

This PR will be closed after the first divergent layer is identified unless the generic harness diagnostics prove worth retaining.

Related: #513, #512, #514.