### PR TITLE
Capture completed host callback frames atomically

### DIFF
--- a/web/manim-raster-host.js
+++ b/web/manim-raster-host.js
@@ -92,9 +92,10 @@ async function load(source, loopDurationSeconds) {
 
 async function advanceOneFrame(frameIndex, time) {
   const deterministicDelta = engine.tickDeltaJson(time * 1000);
-  await presentDelta(deterministicDelta);
 
-  if (host !== null) {
+  if (host === null) {
+    await presentDelta(deterministicDelta);
+  } else {
     host.advanceTo(time);
     const frame = JSON.parse(host.callbackFrameJson());
     if (Math.abs(Number(frame.time) - Number(time)) > 1e-9) {
@@ -106,9 +107,14 @@ async function advanceOneFrame(frameIndex, time) {
     const batch = await client.runCallbackPhase(callbackSessionId, frame, sequence);
     const batchJson = JSON.stringify(batch);
     host.commitPatchBatch(batchJson);
+    engine.applyHostPatchBatchDeltaJson(batchJson);
 
-    const hostDelta = engine.applyHostPatchBatchDeltaJson(batchJson);
-    await presentDelta(hostDelta);
+    // A Manim frame includes both deterministic timeline evaluation and its updater
+    // phase. Presenting the deterministic delta first exposes an intermediate state
+    // to the browser compositor; WebGL may screenshot that first present even after
+    // the callback present. A fresh transport snapshot is a supported sequence-gap
+    // resynchronization barrier, so capture only the completed logical frame.
+    await presentDelta(engine.snapshotDeltaJson());
   }
   currentFrameIndex = frameIndex;
   currentLogicalTime = time;


### PR DESCRIPTION
## Result: hypothesis disproven

This PR tested whether the WebGL-only `RotationUpdater` frame-90 failure came from exposing an intermediate deterministic presentation before the host updater presentation.

Focused phase diagnostics (#523) showed the failing frame has **no deterministic delta at all** (`applied=false`), so frame 90 already performs only one presentation: the host patch.

The unchanged #512 raster oracle was nevertheless stacked on this branch to test the stronger variant: present a full post-host execution snapshot instead of the incremental host delta. Exact #512 head: `d951d3755b9b5920ef9c2be9524cb353ea68b64e`.

Result:
- browser build passed
- canonical rendering passed
- WebGPU `rotation-updater/frame-0090` matched exactly in bounds (`0 px` delta)
- WebGL still collapsed at the same frame with `bounds_delta_px=55 > 2`
- WebGL frame-90 Noon bounds: y=268..271 vs reference y=268..326
- unchanged ratchet failed only at the known #513 boundary

Therefore neither intermediate presentation nor incremental-vs-full execution snapshots are the root cause. This PR is closed unmerged rather than carrying a harness workaround.

Current localization from #523 + merged #514: CPU host state is correct (`rotation≈0.966667`), packed line dirty identity is correct, and the remaining divergence is in the WebGL analytic-line GPU layout/draw/shader boundary.

Related: #513, #512, #523.