### PR TITLE
Track Manim Basic Concepts gallery blockers

### DIFF
--- a/web/example-gallery.test.mjs
+++ b/web/example-gallery.test.mjs
@@ -54,6 +54,22 @@ assert.ok(
   "every public example must point to its canonical upstream source fixture",
 );
 
+const basicConceptCases = new Map([
+  ["ManimCELogo", "#83/#76/#74/#177/#180"],
+  ["BraceAnnotation", "#84/#83"],
+  ["VectorArrow", "#77/#85/#83"],
+  ["GradientImageFromArray", "#79/#76"],
+  ["BooleanOperations", "#78/#83/#74"],
+]);
+for (const [title, dependency] of basicConceptCases) {
+  const entry = manifest.entries.find((candidate) => candidate.title === title);
+  assert.ok(entry, `${title}: Manim Basic Concepts gallery case must remain explicitly tracked`);
+  assert.equal(entry.status, "blocked", `${title}: unsupported gallery case must remain explicit`);
+  assert.equal(entry.category, "gallery/basic-concepts", `${title}: gallery section must remain stable`);
+  assert.equal(entry.upstream, "examples.html#basic-concepts", `${title}: upstream provenance must remain explicit`);
+  assert.equal(entry.dependency, dependency, `${title}: owning implementation issues must remain explicit`);
+}
+
 function assertQualifiedFixture(entryId, fixtureId, message) {
   const entry = readyEntries.find((candidate) => candidate.id === entryId);
   assert.equal(entry?.parity_status, "parity-qualified", message);

--- a/web/python/examples/manim_tutorial_manifest.json
+++ b/web/python/examples/manim_tutorial_manifest.json
@@ -624,6 +624,85 @@
       "order": 230
     },
     {
+      "id": "gallery-basic-manim-ce-logo",
+      "title": "ManimCELogo",
+      "summary": "ManimCE v0.21 Basic Concepts gallery case; blocked until MathTex, Triangle, retained VGroup layout, and exact camera/background parity are complete.",
+      "status": "blocked",
+      "category": "gallery/basic-concepts",
+      "features": [
+        "MathTex",
+        "Triangle",
+        "VGroup",
+        "arrange",
+        "camera-background"
+      ],
+      "upstream": "examples.html#basic-concepts",
+      "dependency": "#83/#76/#74/#177/#180"
+    },
+    {
+      "id": "gallery-basic-brace-annotation",
+      "title": "BraceAnnotation",
+      "summary": "ManimCE v0.21 Basic Concepts gallery case; blocked until Brace/get_text/get_tex layout and text/math support are complete.",
+      "status": "blocked",
+      "category": "gallery/basic-concepts",
+      "features": [
+        "Brace",
+        "get_text",
+        "get_tex",
+        "Line",
+        "Dot"
+      ],
+      "upstream": "examples.html#basic-concepts",
+      "dependency": "#84/#83"
+    },
+    {
+      "id": "gallery-basic-vector-arrow",
+      "title": "VectorArrow",
+      "summary": "ManimCE v0.21 Basic Concepts gallery case; blocked until Arrow, NumberPlane, native Text, and endpoint/layout parity are complete.",
+      "status": "blocked",
+      "category": "gallery/basic-concepts",
+      "features": [
+        "Arrow",
+        "NumberPlane",
+        "Text",
+        "layout"
+      ],
+      "upstream": "examples.html#basic-concepts",
+      "dependency": "#77/#85/#83"
+    },
+    {
+      "id": "gallery-basic-gradient-image-from-array",
+      "title": "GradientImageFromArray",
+      "summary": "ManimCE v0.21 Basic Concepts gallery case; blocked until array-backed ImageMobject and SurroundingRectangle parity are complete.",
+      "status": "blocked",
+      "category": "gallery/basic-concepts",
+      "features": [
+        "ImageMobject",
+        "SurroundingRectangle",
+        "array-image",
+        "filtering"
+      ],
+      "upstream": "examples.html#basic-concepts",
+      "dependency": "#79/#76"
+    },
+    {
+      "id": "gallery-basic-boolean-operations",
+      "title": "BooleanOperations",
+      "summary": "ManimCE v0.21 Basic Concepts gallery case; blocked until boolean geometry, text/markup, and retained group/layout parity are complete.",
+      "status": "blocked",
+      "category": "gallery/basic-concepts",
+      "features": [
+        "Intersection",
+        "Union",
+        "Exclusion",
+        "Difference",
+        "MarkupText",
+        "VGroup"
+      ],
+      "upstream": "examples.html#basic-concepts",
+      "dependency": "#78/#83/#74"
+    },
+    {
       "id": "text-and-math",
       "title": "Full text and mathematical notation parity",
       "status": "blocked",


### PR DESCRIPTION
## Summary
- add all five ManimCE v0.21 Basic Concepts gallery cases to the canonical tutorial/example manifest
- keep currently unsupported cases explicit as `blocked` rather than silently absent
- record the exact upstream gallery section and owning implementation issues for each case
- add a manifest regression so the five named cases cannot disappear or lose blocker ownership unnoticed

## Cases
- `ManimCELogo` → #83/#76/#74/#177/#180
- `BraceAnnotation` → #84/#83
- `VectorArrow` → #77/#85/#83
- `GradientImageFromArray` → #79/#76
- `BooleanOperations` → #78/#83/#74

## Why
#251 explicitly requires every Basic Concepts example to exist in the canonical manifest even before its dependencies are implemented. The manifest previously had generic feature blockers but none of these five named upstream cases, so coverage could improve by omission.

Blocked entries remain excluded from the public ready gallery by the existing `normalizeGalleryManifest` contract. This change does not add placeholder scenes, thumbnails, renderer behavior, or Python compatibility approximations.

## Scope
Two manifest/test files only. No renderer, browser smoke, authoring worker, text backend, geometry implementation, or active #513/#517/#522/#524 work is changed.

## Validation
The existing `web/example-gallery.test.mjs` is part of the normal web build and now asserts exact Basic Concepts case presence, status, section provenance, and blocker ownership. GitHub CI is the end-to-end validation authority for this branch.

Tracks #251. Parent: #91.