### PR TITLE
Guarantee bit-exact geometry morph endpoints

### DIFF
--- a/crates/noon-geometry/src/morph.rs
+++ b/crates/noon-geometry/src/morph.rs
@@ -591,6 +591,12 @@ fn squared_distance(a: Vec2, b: Vec2) -> f32 {
 }
 
 fn lerp_vec2(from: Vec2, to: Vec2, progress: f32) -> Vec2 {
+    if progress <= 0.0 {
+        return from;
+    }
+    if progress >= 1.0 {
+        return to;
+    }
     Vec2::new(
         from.x + (to.x - from.x) * progress,
         from.y + (to.y - from.y) * progress,

--- a/crates/noon-geometry/tests/morph_endpoints.rs
+++ b/crates/noon-geometry/tests/morph_endpoints.rs
@@ -1,0 +1,50 @@
+use noon_core::Vec2;
+use noon_geometry::{MorphContourPlan, MorphPlan};
+
+fn cancellation_prone_plan() -> MorphPlan {
+    MorphPlan {
+        contours: vec![MorphContourPlan {
+            source_points: vec![Vec2::new(7.579_909e25, -3.25)],
+            target_points: vec![Vec2::new(-1.104_579_8, 9.75)],
+            closed: false,
+        }],
+    }
+}
+
+#[test]
+fn interpolation_returns_bit_exact_planned_endpoints_after_clamping() {
+    let plan = cancellation_prone_plan();
+    let contour = &plan.contours[0];
+
+    for progress in [-10.0, 0.0] {
+        assert_eq!(
+            plan.interpolate(progress).contours[0].points,
+            contour.source_points,
+            "progress {progress} must return the stored source endpoint exactly"
+        );
+    }
+    for progress in [1.0, 10.0] {
+        assert_eq!(
+            plan.interpolate(progress).contours[0].points,
+            contour.target_points,
+            "progress {progress} must return the stored target endpoint exactly"
+        );
+    }
+}
+
+#[test]
+fn interior_interpolation_still_uses_finite_linear_arithmetic() {
+    let plan = cancellation_prone_plan();
+    let source = plan.contours[0].source_points[0];
+    let target = plan.contours[0].target_points[0];
+    let progress = 0.25;
+    let expected = Vec2::new(
+        source.x + (target.x - source.x) * progress,
+        source.y + (target.y - source.y) * progress,
+    );
+    let actual = plan.interpolate(progress).contours[0].points[0];
+
+    assert_eq!(actual, expected);
+    assert!(actual.x.is_finite());
+    assert!(actual.y.is_finite());
+}


### PR DESCRIPTION
## Summary
- make `lerp_vec2` return the stored source/target point directly at clamped morph boundaries
- preserve ordinary linear interpolation unchanged for interior progress
- add focused regression coverage using cancellation-prone finite `f32` coordinates so the test fails if endpoint arithmetic is recomputed instead of returning the stored plan
- cover negative/>1 clamping and finite interior interpolation

## Why
`MorphPlan::interpolate()` already clamps progress to `[0, 1]`, but arithmetic interpolation at exactly `1.0` can lose target bits for large/cancellation-prone finite coordinates. Transform handoff and direct-seek boundaries should be able to rely on exact planned endpoint identity.

The helper is shared by ordinary and filled morph interpolation, so this fixes the invariant once at the geometry primitive boundary without animation- or renderer-specific special cases.

## Scope
Two geometry files only: six implementation lines plus focused tests. No renderer, browser worker, authoring, parity manifest, or active demo/CI work is touched.

## Validation
- branch is directly based on current master `f779a141`
- reviewed master comparison: only `crates/noon-geometry/src/morph.rs` (+6) and `crates/noon-geometry/tests/morph_endpoints.rs` (+50)
- the regression uses values where `from + (to - from)` is not guaranteed bit-identical to `to`, and separately verifies interior arithmetic remains finite and unchanged
- GitHub CI is the end-to-end validation authority for this branch

Closes #529. Related: #82, #185.