### PR TITLE
Extract pinned Manim reference examples deterministically

### DIFF
--- a/scripts/build-web-demo.sh
+++ b/scripts/build-web-demo.sh
@@ -48,6 +48,7 @@ node --check scripts/browser-smoke.mjs
 node --check scripts/manim-raster-differential.mjs
 node --check scripts/manim-seek-playback-raster.mjs
 node --check scripts/manim-typst-authoring-smoke.mjs
+node --check scripts/manim-reference-inventory.mjs
 node --check scripts/perf-profile.mjs
 node --check scripts/authoring-perf.mjs
 node --check scripts/perf-device-run.mjs
@@ -64,6 +65,7 @@ node --check scripts/reactive-authoring-smoke.mjs
 node --check scripts/reactive-runtime-smoke.mjs
 node --check scripts/native-input-smoke.mjs
 node --check scripts/updater-callback-smoke.mjs
+node --test scripts/manim-reference-inventory.test.mjs
 node --test web/example-gallery.test.mjs
 node --test web/execution-transport.test.mjs
 node --test web/execution-worker-client.test.mjs

--- a/scripts/manim-reference-inventory.mjs
+++ b/scripts/manim-reference-inventory.mjs
@@ -1,0 +1,149 @@
+import { createHash } from "node:crypto";
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const SOURCE_EXTENSIONS = new Set([".py", ".rst"]);
+const INVENTORY_ROOTS = ["docs/source", "manim"];
+const IGNORED_DIRECTORIES = new Set([".git", ".venv", "__pycache__", "node_modules"]);
+
+function leadingWhitespace(line) {
+  return line.match(/^\s*/u)?.[0].length ?? 0;
+}
+
+function compareCodePoints(left, right) {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
+function dedent(lines) {
+  const nonBlank = lines.filter((line) => line.trim().length > 0);
+  if (nonBlank.length === 0) {
+    return "";
+  }
+  const indent = Math.min(...nonBlank.map(leadingWhitespace));
+  return lines
+    .map((line) => (line.trim().length === 0 ? "" : line.slice(indent)))
+    .join("\n")
+    .trimEnd();
+}
+
+function sourceHash(source) {
+  return createHash("sha256").update(source, "utf8").digest("hex");
+}
+
+export function extractManimDirectives(text, sourcePath) {
+  const lines = text.replace(/\r\n?/gu, "\n").split("\n");
+  const examples = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const match = lines[index].match(/^(\s*)\.\.\s+manim::(?:\s+(.*?))?\s*$/u);
+    if (!match) {
+      continue;
+    }
+
+    const directiveIndent = match[1].length;
+    const name = match[2]?.trim() || null;
+    const body = [];
+    let cursor = index + 1;
+    while (cursor < lines.length) {
+      const line = lines[cursor];
+      if (line.trim().length === 0) {
+        body.push(line);
+        cursor += 1;
+        continue;
+      }
+      if (leadingWhitespace(line) <= directiveIndent) {
+        break;
+      }
+      body.push(line);
+      cursor += 1;
+    }
+
+    const options = {};
+    const sourceLines = [];
+    let readingOptions = true;
+    for (const line of body) {
+      const trimmed = line.trim();
+      if (readingOptions && trimmed.length === 0) {
+        continue;
+      }
+      const option = readingOptions ? trimmed.match(/^:([\w-]+):(?:\s*(.*))?$/u) : null;
+      if (option) {
+        options[option[1]] = option[2]?.trim() || true;
+        continue;
+      }
+      readingOptions = false;
+      sourceLines.push(line);
+    }
+
+    while (sourceLines.length > 0 && sourceLines[0].trim().length === 0) {
+      sourceLines.shift();
+    }
+    const source = dedent(sourceLines);
+    examples.push({
+      name,
+      source_path: sourcePath,
+      directive_line: index + 1,
+      options,
+      source,
+      source_sha256: sourceHash(source),
+    });
+    index = cursor - 1;
+  }
+
+  return examples;
+}
+
+async function collectSourceFiles(repositoryRoot) {
+  const files = [];
+  async function visit(directory) {
+    const entries = await readdir(directory, { withFileTypes: true });
+    entries.sort((left, right) => compareCodePoints(left.name, right.name));
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        if (!IGNORED_DIRECTORIES.has(entry.name)) {
+          await visit(path.join(directory, entry.name));
+        }
+        continue;
+      }
+      if (entry.isFile() && SOURCE_EXTENSIONS.has(path.extname(entry.name))) {
+        files.push(path.join(directory, entry.name));
+      }
+    }
+  }
+  for (const relativeRoot of INVENTORY_ROOTS) {
+    await visit(path.join(repositoryRoot, relativeRoot));
+  }
+  return files;
+}
+
+export async function buildReferenceInventory(repositoryRoot) {
+  const absoluteRoot = path.resolve(repositoryRoot);
+  const examples = [];
+  for (const file of await collectSourceFiles(absoluteRoot)) {
+    const relativePath = path.relative(absoluteRoot, file).split(path.sep).join("/");
+    const text = await readFile(file, "utf8");
+    examples.push(...extractManimDirectives(text, relativePath));
+  }
+  examples.sort(
+    (left, right) =>
+      compareCodePoints(left.source_path, right.source_path) ||
+      left.directive_line - right.directive_line ||
+      compareCodePoints(left.name ?? "", right.name ?? ""),
+  );
+  return { schema_version: 1, scanned_roots: INVENTORY_ROOTS, examples };
+}
+
+async function main() {
+  const root = process.argv[2];
+  if (!root) {
+    throw new Error("usage: node scripts/manim-reference-inventory.mjs MANIM_REPOSITORY_ROOT");
+  }
+  process.stdout.write(`${JSON.stringify(await buildReferenceInventory(root), null, 2)}\n`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  await main();
+}

--- a/scripts/manim-reference-inventory.test.mjs
+++ b/scripts/manim-reference-inventory.test.mjs
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  buildReferenceInventory,
+  extractManimDirectives,
+} from "./manim-reference-inventory.mjs";
+
+test("extracts directive options and source from Python docstrings", () => {
+  const input = `class Arc:\n    \"\"\"Example.\n\n    .. manim:: ArcExample\n        :save_last_frame:\n        :quality: low_quality\n\n        class ArcExample(Scene):\n            def construct(self):\n                self.add(Arc(angle=PI))\n    \"\"\"\n`;
+  const examples = extractManimDirectives(input, "manim/mobject/geometry/arc.py");
+  assert.equal(examples.length, 1);
+  assert.deepEqual(examples[0], {
+    name: "ArcExample",
+    source_path: "manim/mobject/geometry/arc.py",
+    directive_line: 4,
+    options: { save_last_frame: true, quality: "low_quality" },
+    source: "class ArcExample(Scene):\n    def construct(self):\n        self.add(Arc(angle=PI))",
+    source_sha256: examples[0].source_sha256,
+  });
+  assert.match(examples[0].source_sha256, /^[0-9a-f]{64}$/u);
+});
+
+test("supports different directive indentation and multiple examples", () => {
+  const input = `.. manim:: First\n    :save_last_frame:\n\n    class First(Scene):\n        pass\n\nText between directives.\n\n    .. manim:: Second\n      class Second(Scene):\n          pass\n`;
+  const examples = extractManimDirectives(input, "docs/source/example.rst");
+  assert.deepEqual(
+    examples.map((example) => example.name),
+    ["First", "Second"],
+  );
+  assert.equal(examples[1].source, "class Second(Scene):\n    pass");
+});
+
+test("builds a deterministic code-point-ordered inventory across documentation sources", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "noon-manim-inventory-"));
+  await mkdir(path.join(root, "manim", "z"), { recursive: true });
+  await mkdir(path.join(root, "docs", "source"), { recursive: true });
+  await writeFile(
+    path.join(root, "manim", "z", "later.py"),
+    `\"\"\"Examples\n\n.. manim:: Later\n    class Later(Scene):\n        pass\n\"\"\"\n`,
+  );
+  await writeFile(
+    path.join(root, "docs", "source", "B.rst"),
+    `.. manim:: UppercaseFirst\n\n    class UppercaseFirst(Scene):\n        pass\n`,
+  );
+  await writeFile(
+    path.join(root, "docs", "source", "a.rst"),
+    `.. manim:: LowercaseSecond\n\n    class LowercaseSecond(Scene):\n        pass\n`,
+  );
+  await writeFile(
+    path.join(root, "docs", "source", "ignored.txt"),
+    ".. manim:: Ignored\n",
+  );
+
+  const inventory = await buildReferenceInventory(root);
+  assert.equal(inventory.schema_version, 1);
+  assert.deepEqual(inventory.scanned_roots, ["docs/source", "manim"]);
+  assert.deepEqual(
+    inventory.examples.map((example) => [example.source_path, example.name]),
+    [
+      ["docs/source/B.rst", "UppercaseFirst"],
+      ["docs/source/a.rst", "LowercaseSecond"],
+      ["manim/z/later.py", "Later"],
+    ],
+  );
+});


### PR DESCRIPTION
Clean integration of the exact #524 implementation onto current master after unrelated master movement.

The tree contains exactly the three validated #524 blobs:
- wire the extractor syntax/test into `scripts/build-web-demo.sh`
- add the deterministic `.. manim::` reference extractor
- add focused parser/root/order/provenance tests

Validation is inherited from the byte-identical #524 head `36a6db327672fa965080413cdd0b852480ee9924`: the optimized browser artifact explicitly ran all three new extractor tests successfully, then built/validated optimized WASM and passed deterministic browser replay. API, semantic differential, authoring/lifecycle/resize/playback, and coverage workflows were also green on that head.

Current master changes since #524's base do not overlap these three files.

Supersedes #524 integration-wise. Tracks #256.