### PR TITLE
Preflight authoring engines before renderer handoff

### DIFF
--- a/scripts/build-web-demo.sh
+++ b/scripts/build-web-demo.sh
@@ -69,6 +69,7 @@ node --test scripts/manim-reference-inventory.test.mjs
 node --test web/example-gallery.test.mjs
 node --test web/execution-transport.test.mjs
 node --test web/execution-worker-client.test.mjs
+node --test web/execution-worker-preflight.test.mjs
 node --test web/render-gpu-diagnostics.test.mjs
 node --test web/execution-worker-startup.test.mjs
 node --test web/authoring-client.test.mjs

--- a/web/execution-worker-client.js
+++ b/web/execution-worker-client.js
@@ -20,6 +20,8 @@ const LIFECYCLE_CANCELLED_MESSAGE =
 export class ExecutionWorkerClient {
   #canvas;
   #engineWorker = null;
+  #candidateEngineWorker = null;
+  #candidateEngineReject = null;
   #renderWorker = null;
   #nextRequestIds = { engine: 0, render: 0 };
   #pending = new Map();
@@ -316,13 +318,53 @@ export class ExecutionWorkerClient {
     const previousMode = this.#mode;
     const wasPlaying = this.#playing;
     const duration = loopDurationSeconds ?? this.#loopDurationSeconds;
+    const oldEngine = this.#engineWorker;
+    const nextSession = checkedNextSession(this.#session);
+    const channel = new MessageChannel();
+    const candidate = this.#createEngineWorker(nextMode);
+    this.#candidateEngineWorker = candidate;
+
+    let candidateReady;
+    try {
+      const candidateReadyPromise = this.#candidateWorkerReady(candidate);
+      this.#postEngineInit(
+        candidate,
+        channel.port1,
+        nextMode,
+        sceneJson,
+        retainedDocumentJson,
+        duration,
+        nextSession,
+      );
+      candidateReady = await candidateReadyPromise;
+      this.#assertLifecycleCurrent(generation);
+    } catch (error) {
+      if (this.#candidateEngineWorker === candidate) {
+        this.#candidateEngineWorker = null;
+        candidate.terminate();
+      }
+      channel.port2.close?.();
+      if (generation !== this.#lifecycleGeneration) {
+        throw new Error(LIFECYCLE_CANCELLED_MESSAGE);
+      }
+      // Candidate initialization failed before the render owner was touched.
+      // Keep the existing engine, renderer, mode, and recovery state authoritative.
+      throw error;
+    }
+
+    // Candidate readiness is emitted only after its immutable resources/transport
+    // setup and first complete snapshot have been queued on the MessageChannel.
+    // Commit ownership only now, so engine/WASM bootstrap latency cannot blank the
+    // live surface and preflight failure leaves the old session untouched.
     const reconnectError = new Error(`execution engine transitioning to ${nextMode}`);
-    this.#engineWorker?.terminate();
-    this.#engineWorker = null;
+    this.#candidateEngineWorker = null;
+    this.#engineWorker = candidate;
+    this.#attachCurrentWorkerEvents(candidate, ENGINE_CHANNEL, "engine");
+    this.#session = nextSession;
+    oldEngine?.terminate();
     this.#rejectOwner("engine", reconnectError);
 
     try {
-      const channel = new MessageChannel();
       const renderSwitched = this.#request(
         this.#renderWorker,
         "render",
@@ -338,25 +380,13 @@ export class ExecutionWorkerClient {
         this.#markFatalOwner("render");
         throw error;
       });
-
-      this.#session = checkedNextSession(this.#session);
-      this.#engineWorker = this.#createEngineWorker(nextMode);
-      const engineReady = this.#workerReady(this.#engineWorker, ENGINE_CHANNEL, "engine");
-      const nextReady = Promise.all([engineReady, renderSwitched]).then(([engine, render]) => ({
-        engine,
+      const nextReady = renderSwitched.then((render) => ({
+        engine: candidateReady,
         render,
         transportMode: this.#transportMode,
         session: this.#session,
       }));
       this.#ready = nextReady;
-      this.#postEngineInit(
-        this.#engineWorker,
-        channel.port1,
-        nextMode,
-        sceneJson,
-        retainedDocumentJson,
-        duration,
-      );
 
       const ready = await nextReady;
       this.#assertLifecycleCurrent(generation);
@@ -391,9 +421,9 @@ export class ExecutionWorkerClient {
       if (generation !== this.#lifecycleGeneration) {
         throw new Error(LIFECYCLE_CANCELLED_MESSAGE);
       }
-      // A failed renderer transition can leave the live render worker between
-      // renderer generations. Force a full-surface recovery on the next restart
-      // rather than trying to infer partial render ownership.
+      // Once the render transition begins, a failure can leave the live render
+      // worker between renderer generations. Keep the conservative full-surface
+      // recovery policy for this post-preflight failure boundary.
       this.#fatalOwner = "render";
       this.#mode = previousMode;
       throw error;
@@ -622,6 +652,11 @@ export class ExecutionWorkerClient {
 
   terminate({ preserveHostConfiguration = false } = {}) {
     this.#lifecycleGeneration += 1;
+    const cancellation = new Error(LIFECYCLE_CANCELLED_MESSAGE);
+    this.#candidateEngineReject?.(cancellation);
+    this.#candidateEngineReject = null;
+    this.#candidateEngineWorker?.terminate();
+    this.#candidateEngineWorker = null;
     this.#engineWorker?.terminate();
     this.#renderWorker?.terminate();
     this.#engineWorker = null;
@@ -680,77 +715,142 @@ export class ExecutionWorkerClient {
   #workerReady(worker, channel, owner) {
     validateWorkerOwner(owner);
     return new Promise((resolve, reject) => {
-      const onMessage = (event) => {
-        if (!this.#isCurrentWorker(owner, worker)) {
-          this.#recordStaleWorkerEvent(owner);
+      this.#attachCurrentWorkerEvents(worker, channel, owner, {
+        resolveReady: resolve,
+        rejectReady: reject,
+      });
+    });
+  }
+
+  #attachCurrentWorkerEvents(
+    worker,
+    channel,
+    owner,
+    { resolveReady = null, rejectReady = null } = {},
+  ) {
+    validateWorkerOwner(owner);
+    const rejectInitial = (error) => rejectReady?.(error);
+    const onMessage = (event) => {
+      if (!this.#isCurrentWorker(owner, worker)) {
+        this.#recordStaleWorkerEvent(owner);
+        return;
+      }
+      const message = event.data;
+      try {
+        validateWorkerEnvelope(message, channel);
+        if (message.type === "ready") {
+          resolveReady?.(message);
           return;
         }
-        const message = event.data;
+        if (message.type === "host_callback_error") {
+          this.#notifyRecoverableError(
+            new Error(message.message || "host callback failed"),
+            "host",
+          );
+          return;
+        }
+        if (message.type === "recoverable_error") {
+          const error = new Error(
+            message.message || `${owner} worker reported a recoverable error`,
+          );
+          error.diagnostic = message.diagnostic ?? null;
+          this.#notifyRecoverableError(error, owner);
+          return;
+        }
+        if (message.type === "error") {
+          const error = new Error(message.message || `${owner} worker failed`);
+          if (message.requestId === null || message.requestId === undefined) {
+            rejectInitial(error);
+            this.#rejectOwner(owner, error);
+            this.#notifyError(error, owner);
+            return;
+          }
+          this.#settle(owner, message.requestId, ({ reject: rejectPending }) => {
+            rejectPending(error);
+          });
+          return;
+        }
+        if (message.requestId !== undefined) {
+          this.#settle(owner, message.requestId, ({ resolve: resolvePending }) => {
+            resolvePending(message);
+          });
+        }
+      } catch (error) {
+        rejectInitial(error);
+        this.#rejectOwner(owner, error);
+        this.#notifyError(error, owner);
+      }
+    };
+    worker.addEventListener("message", onMessage);
+    worker.addEventListener("error", (event) => {
+      if (!this.#isCurrentWorker(owner, worker)) {
+        this.#recordStaleWorkerEvent(owner);
+        return;
+      }
+      const error = new Error(event.message || `${owner} worker crashed`);
+      rejectInitial(error);
+      this.#rejectOwner(owner, error);
+      this.#notifyError(error, owner);
+    });
+    worker.addEventListener("messageerror", () => {
+      if (!this.#isCurrentWorker(owner, worker)) {
+        this.#recordStaleWorkerEvent(owner);
+        return;
+      }
+      const error = new Error(`${owner} worker message could not be decoded`);
+      rejectInitial(error);
+      this.#rejectOwner(owner, error);
+      this.#notifyError(error, owner);
+    });
+  }
+
+  #candidateWorkerReady(worker) {
+    return new Promise((resolve, reject) => {
+      let settled = false;
+      const settle = (callback, value) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        if (this.#candidateEngineReject === cancel) {
+          this.#candidateEngineReject = null;
+        }
+        callback(value);
+      };
+      const cancel = (error) => settle(reject, error);
+      this.#candidateEngineReject = cancel;
+
+      worker.addEventListener("message", (event) => {
+        if (this.#candidateEngineWorker !== worker) {
+          return;
+        }
         try {
-          validateWorkerEnvelope(message, channel);
+          const message = event.data;
+          validateWorkerEnvelope(message, ENGINE_CHANNEL);
           if (message.type === "ready") {
-            resolve(message);
-            return;
-          }
-          if (message.type === "host_callback_error") {
-            this.#notifyRecoverableError(
-              new Error(message.message || "host callback failed"),
-              "host",
-            );
-            return;
-          }
-          if (message.type === "recoverable_error") {
-            const error = new Error(
-              message.message || `${owner} worker reported a recoverable error`,
-            );
-            error.diagnostic = message.diagnostic ?? null;
-            this.#notifyRecoverableError(error, owner);
+            settle(resolve, message);
             return;
           }
           if (message.type === "error") {
-            const error = new Error(message.message || `${owner} worker failed`);
-            if (message.requestId === null || message.requestId === undefined) {
-              reject(error);
-              this.#rejectOwner(owner, error);
-              this.#notifyError(error, owner);
-              return;
-            }
-            this.#settle(owner, message.requestId, ({ reject: rejectPending }) => {
-              rejectPending(error);
-            });
+            settle(reject, new Error(message.message || "candidate engine worker failed"));
             return;
           }
-          if (message.requestId !== undefined) {
-            this.#settle(owner, message.requestId, ({ resolve: resolvePending }) => {
-              resolvePending(message);
-            });
-          }
+          throw new Error(
+            `candidate engine emitted unexpected ${message.type ?? "message"} before ready`,
+          );
         } catch (error) {
-          reject(error);
-          this.#rejectOwner(owner, error);
-          this.#notifyError(error, owner);
+          settle(reject, error);
         }
-      };
-      worker.addEventListener("message", onMessage);
+      });
       worker.addEventListener("error", (event) => {
-        if (!this.#isCurrentWorker(owner, worker)) {
-          this.#recordStaleWorkerEvent(owner);
-          return;
+        if (this.#candidateEngineWorker === worker) {
+          settle(reject, new Error(event.message || "candidate engine worker crashed"));
         }
-        const error = new Error(event.message || `${owner} worker crashed`);
-        reject(error);
-        this.#rejectOwner(owner, error);
-        this.#notifyError(error, owner);
       });
       worker.addEventListener("messageerror", () => {
-        if (!this.#isCurrentWorker(owner, worker)) {
-          this.#recordStaleWorkerEvent(owner);
-          return;
+        if (this.#candidateEngineWorker === worker) {
+          settle(reject, new Error("candidate engine worker message could not be decoded"));
         }
-        const error = new Error(`${owner} worker message could not be decoded`);
-        reject(error);
-        this.#rejectOwner(owner, error);
-        this.#notifyError(error, owner);
       });
     });
   }
@@ -819,6 +919,7 @@ export class ExecutionWorkerClient {
     sceneJson,
     retainedDocumentJson,
     loopDurationSeconds,
+    session = this.#session,
   ) {
     const payload = {
       port,
@@ -826,7 +927,7 @@ export class ExecutionWorkerClient {
       loopDurationSeconds,
       transportMode: this.#transportMode,
       sharedSlotCapacity: this.#sharedSlotCapacity,
-      session: this.#session,
+      session,
     };
     if (mode === EXECUTION_MODE_RETAINED) {
       payload.retainedDocumentJson = retainedDocumentJson;

--- a/web/execution-worker-preflight.test.mjs
+++ b/web/execution-worker-preflight.test.mjs
@@ -1,0 +1,254 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+test("engine ready is emitted only after the complete initial render bootstrap is queued", async () => {
+  const legacy = await readFile(new URL("./execution-engine-worker.js", import.meta.url), "utf8");
+  const retained = await readFile(
+    new URL("./retained-execution-engine-worker.js", import.meta.url),
+    "utf8",
+  );
+
+  const legacySnapshot = legacy.indexOf("sendDeltaOrThrow(initial)");
+  const legacyReady = legacy.indexOf('postMain({ type: "ready", transportMode })');
+  assert.ok(legacySnapshot >= 0 && legacyReady > legacySnapshot);
+
+  const retainedResources = retained.indexOf('type: "retained_resources"');
+  const retainedSnapshot = retained.indexOf("sendDeltaOrThrow(player.initialDeltaJson())");
+  const retainedReady = retained.indexOf(
+    'postMain({ type: "ready", transportMode, retained: true, mixed: true })',
+  );
+  assert.ok(retainedResources >= 0);
+  assert.ok(retainedSnapshot > retainedResources);
+  assert.ok(retainedReady > retainedSnapshot);
+});
+
+class FakeCanvas {
+  clientWidth = 640;
+  clientHeight = 360;
+  width = 640;
+  height = 360;
+
+  transferControlToOffscreen() {
+    return { width: this.width, height: this.height };
+  }
+
+  cloneNode() {
+    return new FakeCanvas();
+  }
+
+  replaceWith() {}
+}
+
+class FakeWorker {
+  static instances = [];
+
+  listeners = new Map();
+  messages = [];
+  terminated = false;
+
+  constructor(_url, options = {}) {
+    this.name = options.name ?? "";
+    FakeWorker.instances.push(this);
+  }
+
+  addEventListener(type, listener) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  postMessage(message, transfer = []) {
+    this.messages.push({ message, transfer });
+  }
+
+  terminate() {
+    this.terminated = true;
+  }
+
+  emitMessage(message) {
+    for (const listener of this.listeners.get("message") ?? []) {
+      listener({ data: message });
+    }
+  }
+
+  emitError(message = "worker crashed") {
+    for (const listener of this.listeners.get("error") ?? []) {
+      listener({ message });
+    }
+  }
+}
+
+globalThis.HTMLCanvasElement = FakeCanvas;
+globalThis.Worker = FakeWorker;
+globalThis.window = { devicePixelRatio: 1 };
+
+const { ExecutionWorkerClient } = await import("./execution-worker-client.js");
+
+const SCENE_JSON = JSON.stringify({ version: 1, objects: [], tracks: [] });
+const RETAINED_JSON = JSON.stringify({
+  channel: "noon.authoring.retained",
+  version: 1,
+  objects: [{ id: 1, kind: "typst" }],
+});
+
+function engineMessage(type, payload = {}) {
+  return {
+    channel: "noon.engine",
+    protocolVersion: 1,
+    type,
+    ...payload,
+  };
+}
+
+function renderMessage(type, payload = {}) {
+  return {
+    channel: "noon.render",
+    protocolVersion: 1,
+    type,
+    ...payload,
+  };
+}
+
+function latestWorker(name) {
+  return FakeWorker.instances.findLast((worker) => worker.name === name);
+}
+
+function requestMessage(worker, type) {
+  const entry = worker.messages.findLast(({ message }) => message.type === type);
+  assert.ok(entry, `missing ${worker.name} ${type} request`);
+  return entry.message;
+}
+
+async function flush() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+async function startLegacyClient() {
+  const client = new ExecutionWorkerClient(new FakeCanvas());
+  const readyPromise = client.start(SCENE_JSON, { transportMode: "transferable" });
+  const engine = latestWorker("noon-engine");
+  const render = latestWorker("noon-render");
+  assert.ok(engine);
+  assert.ok(render);
+  engine.emitMessage(engineMessage("ready", { transportMode: "transferable" }));
+  render.emitMessage(
+    renderMessage("ready", { transportMode: "transferable", backend: "WebGL2" }),
+  );
+  await readyPromise;
+  return { client, engine, render };
+}
+
+test("mode transition preflights the candidate before touching the live render owner", async () => {
+  const { client, engine: oldEngine, render } = await startLegacyClient();
+  const canvas = client.canvas;
+
+  const transition = client.switchToRetained(SCENE_JSON, RETAINED_JSON);
+  await flush();
+  const candidate = latestWorker("noon-mixed-retained-engine");
+  assert.ok(candidate, "retained candidate must be created during preflight");
+  assert.equal(oldEngine.terminated, false, "old engine must stay live during candidate preflight");
+  assert.equal(
+    render.messages.some(({ message }) => message.type === "switch_engine"),
+    false,
+    "render owner must not switch before candidate readiness",
+  );
+  const init = requestMessage(candidate, "init");
+  assert.equal(init.session, 2, "candidate may reserve the next session without publishing it");
+
+  const oldStatePromise = client.state();
+  await flush();
+  const oldState = requestMessage(oldEngine, "state");
+  oldEngine.emitMessage(
+    engineMessage("state", {
+      requestId: oldState.requestId,
+      time: 0,
+      playing: true,
+      nextPatchSequence: "0",
+      sceneJson: SCENE_JSON,
+    }),
+  );
+  assert.equal((await oldStatePromise).sceneJson, SCENE_JSON);
+
+  candidate.emitMessage(
+    engineMessage("ready", { transportMode: "transferable", retained: true, mixed: true }),
+  );
+  await flush();
+
+  assert.equal(oldEngine.terminated, true, "old engine retires only after candidate readiness");
+  const renderSwitch = requestMessage(render, "switch_engine");
+  assert.equal(renderSwitch.mode, "retained");
+  render.emitMessage(
+    renderMessage("mode_switched", {
+      requestId: renderSwitch.requestId,
+      mode: "retained",
+      retained: true,
+      mixed: true,
+      transportMode: "transferable",
+      backend: "WebGL2",
+    }),
+  );
+
+  const ready = await transition;
+  assert.equal(ready.session, 2);
+  assert.equal(client.mode, "retained");
+  assert.equal(client.canvas, canvas);
+  client.terminate();
+});
+
+test("candidate failure before readiness leaves the old engine and renderer authoritative", async () => {
+  const { client, engine: oldEngine, render } = await startLegacyClient();
+  const canvas = client.canvas;
+
+  const transition = client.switchToRetained(SCENE_JSON, RETAINED_JSON);
+  await flush();
+  const candidate = latestWorker("noon-mixed-retained-engine");
+  candidate.emitMessage(engineMessage("error", { message: "candidate bootstrap rejected" }));
+
+  await assert.rejects(transition, /candidate bootstrap rejected/);
+  assert.equal(candidate.terminated, true);
+  assert.equal(oldEngine.terminated, false);
+  assert.equal(render.terminated, false);
+  assert.equal(client.mode, "legacy");
+  assert.equal(client.canvas, canvas);
+  assert.equal(
+    render.messages.some(({ message }) => message.type === "switch_engine"),
+    false,
+    "failed preflight must not mutate the render owner",
+  );
+
+  const statePromise = client.state();
+  await flush();
+  const state = requestMessage(oldEngine, "state");
+  oldEngine.emitMessage(
+    engineMessage("state", {
+      requestId: state.requestId,
+      time: 0,
+      playing: true,
+      nextPatchSequence: "0",
+      sceneJson: SCENE_JSON,
+    }),
+  );
+  assert.equal((await statePromise).sceneJson, SCENE_JSON);
+  client.terminate();
+});
+
+test("terminate cancels an unpublished candidate without resurrecting either generation", async () => {
+  const { client, engine: oldEngine, render } = await startLegacyClient();
+
+  const transition = client.switchToRetained(SCENE_JSON, RETAINED_JSON);
+  await flush();
+  const candidate = latestWorker("noon-mixed-retained-engine");
+  assert.ok(candidate);
+
+  client.terminate();
+  await assert.rejects(
+    transition,
+    /execution worker client was terminated during an asynchronous operation/,
+  );
+  assert.equal(candidate.terminated, true);
+  assert.equal(oldEngine.terminated, true);
+  assert.equal(render.terminated, true);
+  await assert.rejects(client.state(), /ExecutionWorkerClient has not been started/);
+});


### PR DESCRIPTION
## Summary
- stage the next legacy/retained engine against an unattached `MessageChannel` before mutating the live render owner
- wait for candidate engine readiness, which both engine implementations emit only after their initial transport/resources/snapshot have been queued
- keep the old engine and renderer fully authoritative during that preflight window, including serving in-flight state/metrics requests
- only after successful preflight publish the candidate engine, retire the old engine, and send `switch_engine` / `rebuild_engine` to the persistent render worker
- if candidate initialization fails before handoff, terminate only the candidate and leave the old engine, renderer, mode, canvas, session, and recovery state intact
- keep the existing conservative full-surface recovery boundary once renderer handoff has actually begun
- cancel unpublished candidates through the existing lifecycle generation on `terminate()` without double-terminating workers

## Why
#517 removed DOM canvas/render-worker replacement from normal legacy ↔ retained authoring transitions, but it still retired the active engine/renderer before replacement engine bootstrap completed. This removes engine/WASM/resource/snapshot preparation from that presentation-risk window and adds a real rollback boundary before the renderer is touched.

The staging mechanism uses the browser's existing `MessageChannel` queue rather than a second render transport or frame proxy. For retained execution, `retained_resources`, optional shared `transport_setup`, and the first complete snapshot are posted before the engine's main-thread `ready` message. Legacy execution likewise posts its initial snapshot before `ready`.

## Validation contract
New deterministic worker-client tests prove:
- the render worker receives no `switch_engine` before candidate readiness
- the old engine remains live and can answer requests during candidate preflight
- old engine retirement happens only after candidate readiness
- a candidate bootstrap failure leaves old engine/render/canvas/mode authoritative and usable
- `terminate()` cancels the unpublished candidate and does not resurrect either generation

The existing real dual-transport authoring mode-switch browser oracle, authoring router/lifecycle races, renderer recovery, playback, resize, and cross-browser suites remain the end-to-end gates.

Tracks #492.