### PR TITLE
Pin Manim reference inventory generation

### DIFF
--- a/.github/workflows/manim-reference-inventory.yml
+++ b/.github/workflows/manim-reference-inventory.yml
@@ -1,0 +1,110 @@
+name: Manim reference inventory
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/manim-reference-inventory.yml'
+      - 'scripts/manim-reference-inventory.mjs'
+      - 'scripts/manim-reference-inventory.test.mjs'
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/manim-reference-inventory.yml'
+      - 'scripts/manim-reference-inventory.mjs'
+      - 'scripts/manim-reference-inventory.test.mjs'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: manim-reference-inventory-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  MANIM_REFERENCE_SHA: 861cd4849b17db1db3515b531ffe80b297848f93
+
+jobs:
+  inventory:
+    name: ManimCE 0.21.0 reference examples
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Noon
+        uses: actions/checkout@v4
+        with:
+          path: noon
+
+      - name: Checkout pinned ManimCE source
+        uses: actions/checkout@v4
+        with:
+          repository: ManimCommunity/manim
+          ref: ${{ env.MANIM_REFERENCE_SHA }}
+          path: manim-v0.21.0
+          persist-credentials: false
+
+      - name: Extract and validate reference inventory
+        shell: bash
+        run: |
+          set -euo pipefail
+          actual_sha="$(git -C manim-v0.21.0 rev-parse HEAD)"
+          test "$actual_sha" = "$MANIM_REFERENCE_SHA"
+
+          mkdir -p noon/artifacts
+          node noon/scripts/manim-reference-inventory.mjs manim-v0.21.0 \
+            > noon/artifacts/manim-v0.21.0-reference-inventory.json
+
+          node - <<'NODE'
+          const fs = require("node:fs");
+          const path = "noon/artifacts/manim-v0.21.0-reference-inventory.json";
+          const inventory = JSON.parse(fs.readFileSync(path, "utf8"));
+          const expectedRoots = ["docs/source", "manim"];
+
+          if (inventory.schema_version !== 1) {
+            throw new Error(`unexpected reference inventory schema: ${inventory.schema_version}`);
+          }
+          if (JSON.stringify(inventory.scanned_roots) !== JSON.stringify(expectedRoots)) {
+            throw new Error(`unexpected scanned roots: ${JSON.stringify(inventory.scanned_roots)}`);
+          }
+          if (!Array.isArray(inventory.examples) || inventory.examples.length === 0) {
+            throw new Error("pinned Manim source produced no reference examples");
+          }
+
+          const locations = new Set();
+          for (const example of inventory.examples) {
+            if (!Number.isInteger(example.directive_line) || example.directive_line < 1) {
+              throw new Error(`invalid directive line for ${example.source_path}`);
+            }
+            if (
+              typeof example.source_path !== "string" ||
+              !expectedRoots.some(
+                (root) => example.source_path === root || example.source_path.startsWith(`${root}/`),
+              )
+            ) {
+              throw new Error(`example escaped pinned source roots: ${example.source_path}`);
+            }
+            if (typeof example.source_sha256 !== "string" || !/^[0-9a-f]{64}$/u.test(example.source_sha256)) {
+              throw new Error(`invalid source provenance hash at ${example.source_path}:${example.directive_line}`);
+            }
+            const location = `${example.source_path}:${example.directive_line}`;
+            if (locations.has(location)) {
+              throw new Error(`duplicate reference directive location: ${location}`);
+            }
+            locations.add(location);
+          }
+
+          fs.appendFileSync(
+            process.env.GITHUB_STEP_SUMMARY,
+            `Extracted ${inventory.examples.length} ManimCE v0.21.0 reference examples from immutable source commit ${process.env.MANIM_REFERENCE_SHA}.\n`,
+          );
+          console.log(`Validated ${inventory.examples.length} pinned Manim reference examples.`);
+          NODE
+
+      - name: Upload reference inventory
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: manim-v0.21.0-reference-inventory
+          path: noon/artifacts/manim-v0.21.0-reference-inventory.json
+          if-no-files-found: error
+          retention-days: 14


### PR DESCRIPTION
## Summary
- add a dedicated deterministic Manim reference-inventory workflow for #256
- pin ManimCE v0.21.0 to immutable upstream commit `861cd4849b17db1db3515b531ffe80b297848f93`
- check out that exact source tree and run the merged `manim-reference-inventory.mjs` extractor
- validate schema version, exact source roots, non-empty output, source-root containment, directive-location uniqueness, and SHA-256 provenance
- publish the generated JSON as a 14-day CI artifact and report the extracted count in the workflow summary

## Architecture
This is intentionally only the reproducible extraction boundary. It does **not** classify entries, mutate the public gallery, or claim reference-manual coverage. The next #256 slice can consume this pinned artifact to check in/classify the inventory and add a classification ratchet without mixing upstream discovery with support policy.

The upstream `v0.21.0` tag resolves to commit `861cd4849b17db1db3515b531ffe80b297848f93`; the workflow pins the commit rather than trusting tag movement.

## Validation
This PR's own new `Manim reference inventory` workflow is the acceptance gate: it must successfully check out the external pinned source, extract real upstream directives, validate the artifact, and upload it before merge.

Tracks #256.