### PR TITLE
Guarantee bit-exact geometry morph endpoints

### DIFF
--- a/crates/noon-geometry/src/morph.rs
+++ b/crates/noon-geometry/src/morph.rs
@@ -591,6 +591,12 @@ fn squared_distance(a: Vec2, b: Vec2) -> f32 {
 }
 
 fn lerp_vec2(from: Vec2, to: Vec2, progress: f32) -> Vec2 {
+    if progress <= 0.0 {
+        return from;
+    }
+    if progress >= 1.0 {
+        return to;
+    }
     Vec2::new(
         from.x + (to.x - from.x) * progress,
         from.y + (to.y - from.y) * progress,

--- a/crates/noon-geometry/tests/morph_endpoints.rs
+++ b/crates/noon-geometry/tests/morph_endpoints.rs
@@ -1,0 +1,50 @@
+use noon_core::Vec2;
+use noon_geometry::{MorphContourPlan, MorphPlan};
+
+fn cancellation_prone_plan() -> MorphPlan {
+    MorphPlan {
+        contours: vec![MorphContourPlan {
+            source_points: vec![Vec2::new(7.579_909e25, -3.25)],
+            target_points: vec![Vec2::new(-1.104_579_8, 9.75)],
+            closed: false,
+        }],
+    }
+}
+
+#[test]
+fn interpolation_returns_bit_exact_planned_endpoints_after_clamping() {
+    let plan = cancellation_prone_plan();
+    let contour = &plan.contours[0];
+
+    for progress in [-10.0, 0.0] {
+        assert_eq!(
+            plan.interpolate(progress).contours[0].points,
+            contour.source_points,
+            "progress {progress} must return the stored source endpoint exactly"
+        );
+    }
+    for progress in [1.0, 10.0] {
+        assert_eq!(
+            plan.interpolate(progress).contours[0].points,
+            contour.target_points,
+            "progress {progress} must return the stored target endpoint exactly"
+        );
+    }
+}
+
+#[test]
+fn interior_interpolation_still_uses_finite_linear_arithmetic() {
+    let plan = cancellation_prone_plan();
+    let source = plan.contours[0].source_points[0];
+    let target = plan.contours[0].target_points[0];
+    let progress = 0.25;
+    let expected = Vec2::new(
+        source.x + (target.x - source.x) * progress,
+        source.y + (target.y - source.y) * progress,
+    );
+    let actual = plan.interpolate(progress).contours[0].points[0];
+
+    assert_eq!(actual, expected);
+    assert!(actual.x.is_finite());
+    assert!(actual.y.is_finite());
+}


### PR DESCRIPTION
Clean current-master integration of the exact validated #532 implementation.

- return stored source/target morph points directly at clamped boundaries
- keep interior linear interpolation unchanged
- add cancellation-prone finite-f32 regressions proving exact endpoint identity and ordinary interior arithmetic

The two blobs are byte-identical to #532 head `c128923168746e0e6f75dfb2590225dc0443fdef`. That exact head passed full Rust coverage/workspace execution, test inventory, Python/JS coverage, Manim API coverage, semantic differential, and raster differential. Current master has not touched these geometry files since #532's base.

This fixes the shared morph primitive once for ordinary and filled morph interpolation rather than adding renderer/animation handoff special cases.

Supersedes #532 integration-wise. Closes #529. Related #82/#185.