### PR TITLE
Stage render bootstrap before retiring active renderer

### DIFF
--- a/scripts/build-web-demo.sh
+++ b/scripts/build-web-demo.sh
@@ -19,6 +19,7 @@ node --check web/execution-transport.js
 node --check web/execution-canvas.js
 node --check web/execution-engine-worker.js
 node --check web/execution-render-worker.js
+node --check web/authoring-render-worker.js
 node --check web/render-gpu-diagnostics.js
 node --check web/execution-worker-client.js
 node --check web/retained-execution-engine-worker.js
@@ -70,6 +71,7 @@ node --test web/example-gallery.test.mjs
 node --test web/execution-transport.test.mjs
 node --test web/execution-worker-client.test.mjs
 node --test web/execution-worker-preflight.test.mjs
+node --test web/authoring-render-transition.test.mjs
 node --test web/render-gpu-diagnostics.test.mjs
 node --test web/execution-worker-startup.test.mjs
 node --test web/authoring-client.test.mjs

--- a/web/authoring-render-transition.test.mjs
+++ b/web/authoring-render-transition.test.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const source = readFileSync(
+  new URL("./authoring-render-worker.js", import.meta.url),
+  "utf8",
+);
+
+function functionSlice(name, nextName) {
+  const start = source.indexOf(`function ${name}`);
+  assert.notEqual(start, -1, `missing ${name}`);
+  const end = source.indexOf(`function ${nextName}`, start + 1);
+  assert.notEqual(end, -1, `missing ${nextName}`);
+  return source.slice(start, end);
+}
+
+test("renderer transition keeps the active renderer until replacement bootstrap arrives", () => {
+  const begin = functionSlice("beginRendererTransition", "resize");
+  assert.match(begin, /transitionMode = nextMode;/);
+  assert.doesNotMatch(begin, /disposeRenderer\(\)/);
+  assert.doesNotMatch(begin, /mode = nextMode;/);
+  assert.doesNotMatch(begin, /needsPresent = false;/);
+
+  const consume = functionSlice("consumeDelta", "commitRendererTransition");
+  assert.match(
+    consume,
+    /if \(transitionMode !== null\) \{\s*return commitRendererTransition\(json\);/s,
+  );
+
+  const commit = functionSlice("commitRendererTransition", "bootstrapRenderer");
+  const disposeIndex = commit.indexOf("disposeRenderer();");
+  const publishModeIndex = commit.indexOf("mode = nextMode;");
+  const bootstrapIndex = commit.indexOf("bootstrapPromise = bootstrapRenderer(initial);");
+  assert.ok(disposeIndex >= 0, "transition commit must retire the previous renderer");
+  assert.ok(
+    publishModeIndex > disposeIndex,
+    "next mode must not publish before the previous renderer is retired",
+  );
+  assert.ok(
+    bootstrapIndex > publishModeIndex,
+    "replacement renderer bootstrap must start only after commit state is published",
+  );
+});
+
+test("retained transition resources stage separately from the active renderer", () => {
+  const resources = functionSlice("handleRetainedResources", "drainTransport");
+  assert.match(resources, /if \(transitionMode !== null\)/);
+  assert.match(resources, /transitionMode !== MODE_RETAINED/);
+  assert.match(resources, /transitionResourceBytes = message\.bytes;/);
+
+  const commit = functionSlice("commitRendererTransition", "bootstrapRenderer");
+  assert.match(
+    commit,
+    /nextMode === MODE_RETAINED && transitionResourceBytes === null/,
+  );
+  assert.match(commit, /const nextResourceBytes = transitionResourceBytes;/);
+  assert.match(commit, /resourceBytes = nextResourceBytes;/);
+});
+
+test("transition state is observable without changing the presented mode", () => {
+  const metrics = functionSlice("currentMetrics", "disposeRenderer");
+  assert.match(metrics, /mode,/);
+  assert.match(metrics, /transitionMode,/);
+});

--- a/web/authoring-render-worker.js
+++ b/web/authoring-render-worker.js
@@ -34,6 +34,8 @@ let bootstrapQueue = [];
 let bootstrapPromise = null;
 let transitionRequestId = null;
 let transitionResponseType = null;
+let transitionMode = null;
+let transitionResourceBytes = null;
 let needsPresent = false;
 let running = false;
 let lastFrameTimestamp = null;
@@ -152,17 +154,19 @@ function rebuildEngine(message) {
 function beginRendererTransition(message, nextMode, responseType) {
   validateEnginePort(message.port, "authoring render engine transition");
   validateMatchingTransport(message.transportMode, "authoring render engine transition");
-  if (transitionRequestId !== null || bootstrapPromise !== null) {
+  if (
+    transitionRequestId !== null ||
+    transitionMode !== null ||
+    bootstrapPromise !== null
+  ) {
     throw new Error("authoring render engine transition is already in progress");
   }
 
   detachRenderPort();
-  disposeRenderer();
   resetTransportState();
-  resourceBytes = null;
   reconnectResourceBundlePending = false;
-  needsPresent = false;
-  mode = nextMode;
+  transitionMode = nextMode;
+  transitionResourceBytes = null;
   transitionRequestId = validateRequestId(message.requestId);
   transitionResponseType = responseType;
   attachRenderPort(message.port);
@@ -185,6 +189,8 @@ function resize(message) {
 function stop() {
   running = false;
   bootstrapQueue = [];
+  transitionMode = null;
+  transitionResourceBytes = null;
   detachRenderPort();
   disposeRenderer();
   self.close();
@@ -247,11 +253,23 @@ function handleEngineMessage(message) {
 
 function handleRetainedResources(message) {
   try {
-    if (mode !== MODE_RETAINED) {
-      throw new Error("legacy authoring render mode cannot accept retained resources");
-    }
     if (!(message.bytes instanceof Uint8Array) || message.bytes.byteLength === 0) {
       throw new Error("retained resource bundle must be a non-empty Uint8Array");
+    }
+    if (transitionMode !== null) {
+      if (transitionMode !== MODE_RETAINED) {
+        throw new Error("legacy authoring render transition cannot accept retained resources");
+      }
+      if (transitionResourceBytes !== null || bootstrapPromise !== null) {
+        throw new Error(
+          "retained transition resource bundle may be installed only once before the snapshot",
+        );
+      }
+      transitionResourceBytes = message.bytes;
+      return;
+    }
+    if (mode !== MODE_RETAINED) {
+      throw new Error("legacy authoring render mode cannot accept retained resources");
     }
     if (renderer !== null) {
       if (!reconnectResourceBundlePending) {
@@ -284,6 +302,9 @@ function drainTransport() {
 }
 
 function consumeDelta(json) {
+  if (transitionMode !== null) {
+    return commitRendererTransition(json);
+  }
   if (renderer === null) {
     if (mode === MODE_RETAINED && resourceBytes === null) {
       throw new Error("retained authoring snapshot arrived before its resource bundle");
@@ -311,6 +332,31 @@ function consumeDelta(json) {
   }
   needsPresent = true;
   tryPresent();
+  return true;
+}
+
+function commitRendererTransition(initial) {
+  const nextMode = transitionMode;
+  if (nextMode === null) {
+    throw new Error("authoring render transition has no pending mode");
+  }
+  if (nextMode === MODE_RETAINED && transitionResourceBytes === null) {
+    throw new Error("retained authoring transition snapshot arrived before its resource bundle");
+  }
+
+  const nextResourceBytes = transitionResourceBytes;
+  transitionMode = null;
+  transitionResourceBytes = null;
+
+  // The replacement engine has already queued a complete bootstrap payload.
+  // Retire the currently presenting renderer only once that payload reaches
+  // this worker; renderer/device construction is the only remaining blank-window seam.
+  disposeRenderer();
+  resourceBytes = nextResourceBytes;
+  reconnectResourceBundlePending = false;
+  needsPresent = false;
+  mode = nextMode;
+  bootstrapPromise = bootstrapRenderer(initial);
   return true;
 }
 
@@ -458,6 +504,7 @@ function currentMetrics() {
     presentedFrames,
     modeSwitches,
     rendererRebuilds,
+    transitionMode,
     lastFrameTimestamp,
     bufferedDeltas: bootstrapQueue.length + (transferableReceiver?.pendingCount() ?? 0),
     needsPresent,
@@ -549,6 +596,8 @@ function fail(error, requestId) {
   const effectiveRequestId = requestId ?? transitionRequestId;
   transitionRequestId = null;
   transitionResponseType = null;
+  transitionMode = null;
+  transitionResourceBytes = null;
   const message = String(error?.message ?? error);
   renderPort?.postMessage({ type: "render_error", message });
   postMain({ type: "error", requestId: effectiveRequestId, message });


### PR DESCRIPTION
## Summary
- keep the currently presenting authoring renderer alive after `switch_engine` / `rebuild_engine` begins
- stage the replacement mode separately from the committed/presented `mode`
- drain retained resources and the first replacement snapshot from the already-preflighted engine before retiring the old renderer
- use the first valid replacement snapshot as the renderer-transition commit point
- only then dispose the old renderer, publish the next mode, and begin replacement renderer creation
- expose `transitionMode` in metrics while `mode` continues to describe the renderer actually being presented
- clear transition staging on stop/failure
- directly syntax-check the permanent `authoring-render-worker.js` in the normal web build and add focused structural transition invariants

## Why
#517 preserved one HTML canvas/render worker across authoring mode changes, and #537 moved engine/WASM/resource/snapshot preparation ahead of render handoff. The render worker still disposed its live renderer as soon as the new engine port was attached, before the queued bootstrap payload actually reached the worker. That made port/transport/bootstrap-message latency part of the blank presentation window.

This slice removes that remaining avoidable latency without introducing a second renderer, GPU context, canvas, or frame-copy proxy. The existing renderer keeps presenting its last valid state while the replacement port drains. The first replacement snapshot is the explicit commit point.

## Invariants
- `beginRendererTransition()` does not dispose the active renderer, publish the next mode, or clear its pending presentation state
- retained transition resources are staged independently from the active retained/reconnect state
- a retained transition snapshot cannot commit before its resource bundle arrives
- renderer disposal happens only after a complete first replacement snapshot has reached the worker
- after commit, the existing renderer/bootstrap behavior and conservative full-surface recovery boundary remain unchanged
- shared and transferable transports use the same commit path
- exact HTML canvas and permanent render worker ownership remain unchanged

## Validation
New source-contract tests gate transition publication/disposal ordering and retained resource staging. The normal web build now syntax-checks `authoring-render-worker.js` directly instead of only checking its legacy import shim.

The existing dual-transport `Authoring render mode switch`, renderer recovery, lifecycle, playback, resize, and cross-browser browser suites remain the end-to-end gates.

## Remaining #492 seam
This does not pretend alternate renderer creation itself is atomic. Legacy and retained WASM renderer classes still independently own `wgpu::Instance`, `Surface`, `Device`, and `Queue`. After this lands, the remaining blank-window source is GPU renderer/device construction. The next sound architecture is one Rust GPU surface/device owner with mode-specific renderer state above it, not competing renderers on one `OffscreenCanvas`.

Tracks #492.