### PR TITLE
Format font resource churn regression

### DIFF
--- a/crates/noon-core/src/font_resources.rs
+++ b/crates/noon-core/src/font_resources.rs
@@ -320,18 +320,17 @@ mod tests {
         let baseline = arena.stats();
 
         for attempt in 0..ATTEMPTS {
-            let conflicting = Arc::<[u8]>::from([
-                9,
-                (attempt & 0xff) as u8,
-                ((attempt >> 8) & 0xff) as u8,
-                7,
-            ]);
+            let conflicting =
+                Arc::<[u8]>::from([9, (attempt & 0xff) as u8, ((attempt >> 8) & 0xff) as u8, 7]);
             assert!(matches!(
                 arena.intern_face(&stable_face, conflicting),
                 Err(FontResourceError::ConflictingResource(_))
             ));
             assert_eq!(arena.stats(), baseline);
-            assert_eq!(arena.get(stable_handle).unwrap().data.as_ref(), &[1, 2, 3, 4]);
+            assert_eq!(
+                arena.get(stable_handle).unwrap().data.as_ref(),
+                &[1, 2, 3, 4]
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary
- apply the exact `cargo fmt` output required by current master in `crates/noon-core/src/font_resources.rs`
- change formatting only; no logic, assertions, constants, or resource semantics change

## Why
Current master inherited an unformatted font-resource churn test from #543. As a result, unrelated PRs fail the umbrella Rust CI immediately at `cargo fmt --all -- --check` before clippy/tests run. #546 exposed this through its synthetic merge even though #546 has no Rust changes.

## Validation
The diff is one file and matches the formatting reported by the failing Rust CI job exactly. Normal Rust CI is the acceptance gate.

This is intentionally separate from runtime/render work so ownership and review remain clean.