### PR TITLE
Gate spatial index slot-generation reuse

### DIFF
--- a/crates/noon-runtime/tests/spatial_slot_generation_reuse.rs
+++ b/crates/noon-runtime/tests/spatial_slot_generation_reuse.rs
@@ -1,0 +1,38 @@
+use noon_core::{ObjectId, Rect, Vec2};
+use noon_runtime::{ExecutionSlotId, ExecutionSpatialIndex};
+
+const REUSE_CYCLES: u32 = 1_000;
+const PHYSICAL_SLOT: u32 = 7;
+
+#[test]
+fn stale_slot_generations_cannot_remove_or_alias_the_reused_spatial_leaf() {
+    let mut index = ExecutionSpatialIndex::default();
+    let bounds = Rect::new(Vec2::new(-0.5, -0.5), Vec2::new(0.5, 0.5));
+    let mut current = ExecutionSlotId::new(PHYSICAL_SLOT, 0);
+
+    index.upsert_bounds(current, ObjectId::new(0), bounds, 0);
+
+    for generation in 1..=REUSE_CYCLES {
+        let stale = current;
+        let removed = index.remove_slot(stale);
+        assert_eq!(removed.leaves_removed, 1);
+
+        current = ExecutionSlotId::new(PHYSICAL_SLOT, generation);
+        let inserted = index.upsert_bounds(
+            current,
+            ObjectId::new(u64::from(generation)),
+            bounds,
+            u64::from(generation),
+        );
+        assert_eq!(inserted.leaves_upserted, 1);
+
+        assert_eq!(index.remove_slot(stale).leaves_removed, 0);
+        assert!(!index.contains_slot(stale));
+        assert!(index.contains_slot(current));
+        assert_eq!(index.len(), 1);
+
+        let hit = index.hit_test(Vec2::ZERO);
+        assert_eq!(hit.slots(), &[current]);
+        assert_eq!(hit.stats().full_scan_fallbacks, 0);
+    }
+}


### PR DESCRIPTION
## Summary
- add a public-API `noon-runtime` integration regression for execution-slot generation reuse in `ExecutionSpatialIndex`
- recycle one physical slot through 1,000 generations
- after each replacement, issue a stale removal for the retired generation and require it to be a no-op
- require the current generation to remain the only live spatial leaf and the only hit-test result
- require point queries to stay on the indexed path with zero full-scan fallbacks

## Why
The retained spatial index already provides 100k-object query locality and local leaf updates, but its existing tests do not directly gate the stable-handle invariant across execution-slot reuse. Long-running editing can recycle physical execution slots; a stale generation must never delete or alias the replacement spatial entry.

## Architecture
Test-only. This exercises the existing `ExecutionSlotId` generation identity and `ExecutionSpatialIndex` public API. No second index, tombstone map, runtime hook, timing threshold, or production behavior is added.

One commit / one new integration-test file directly on current master `ba94ef5a`.

Tracks #66 and #114.