### PR TITLE
Gate semantic store generation reuse

### DIFF
--- a/crates/noon-core/tests/semantic_store_generation_reuse.rs
+++ b/crates/noon-core/tests/semantic_store_generation_reuse.rs
@@ -1,0 +1,68 @@
+use noon_core::{
+    GeometryRef, ObjectDefinition, ObjectId, SemanticStore, SemanticStoreError, SourceIdentity,
+};
+
+const REUSE_CYCLES: u32 = 1_000;
+
+fn object(generation: u32) -> ObjectDefinition {
+    ObjectDefinition::new(
+        ObjectId::new(u64::from(generation)),
+        GeometryRef::circle(1.0),
+    )
+}
+
+fn source(generation: u32) -> SourceIdentity {
+    SourceIdentity::ExplicitKey(format!("semantic-reuse-{generation}"))
+}
+
+#[test]
+fn semantic_slot_reuse_stays_bounded_and_never_aliases_stale_identity() {
+    let mut store = SemanticStore::new();
+    let mut current = store.insert_object(object(0));
+    let mut current_source = source(0);
+    store
+        .set_source_identity(current, Some(current_source.clone()))
+        .expect("initial source identity must install");
+
+    assert_eq!(store.len(), 1);
+    assert_eq!(store.slot_capacity(), 1);
+
+    for generation in 1..=REUSE_CYCLES {
+        let stale = current;
+        let stale_object = ObjectId::new(u64::from(generation - 1));
+        let stale_source = current_source;
+
+        store
+            .remove_node(stale)
+            .expect("live semantic node must remove exactly once");
+        assert!(store.node(stale).is_none());
+        assert_eq!(store.node_for_object(stale_object), None);
+        assert_eq!(store.node_for_source(&stale_source), None);
+        assert!(matches!(
+            store.remove_node(stale),
+            Err(SemanticStoreError::UnknownNode(id)) if id == stale
+        ));
+
+        current = store.insert_object(object(generation));
+        current_source = source(generation);
+        store
+            .set_source_identity(current, Some(current_source.clone()))
+            .expect("replacement source identity must install");
+
+        assert_eq!(current.slot(), stale.slot());
+        assert_eq!(current.generation(), generation);
+        assert_ne!(current, stale);
+        assert_eq!(store.len(), 1);
+        assert_eq!(store.slot_capacity(), 1);
+        assert_eq!(
+            store.node_for_object(ObjectId::new(u64::from(generation))),
+            Some(current)
+        );
+        assert_eq!(store.node_for_source(&current_source), Some(current));
+        assert_eq!(store.node_for_source(&stale_source), None);
+    }
+
+    assert_eq!(current.generation(), REUSE_CYCLES);
+    assert_eq!(store.len(), 1);
+    assert_eq!(store.slot_capacity(), 1);
+}


### PR DESCRIPTION
## Summary
- add a public-API `noon-core` integration regression for long-running `SemanticStore` slot reuse
- recycle one physical semantic slot through 1,000 generations
- require every retired `SemanticNodeId` to stay stale after the slot is reused
- require removed object/source lookup entries to disappear before the replacement is installed
- require the replacement object/source identities to resolve only to the current generation
- require live node count and slot capacity to remain at exactly one throughout

## Why
Hot reload/reconciliation relies on source identity and stable generation-tagged semantic handles. Short unit tests cover ordinary removal/reuse, but there was no sustained gate proving repeated edit churn cannot grow the semantic slot table or leave stale object/source lookup aliases behind.

## Architecture
Test-only and public-API-only. This exercises the existing `SemanticStore`, generation-tagged `SemanticNodeId`, object/source indexes, and free-list reuse policy. No new tombstone table, compaction pass, GC behavior, or production mutation policy is added.

One commit / one new integration-test file directly on current master `6610dc8f`.

Tracks #64 and #114. Related #51/#68.