### PR TITLE
Route set_x and set_y through shared placement

### DIFF
--- a/web/python/_manim_shared_geometry.py
+++ b/web/python/_manim_shared_geometry.py
@@ -1,7 +1,7 @@
-"""Thin Manim geometry constructor adapters backed by shared Rust semantics.
+"""Thin Manim geometry adapters backed by shared Rust semantics.
 
-This module intentionally patches only constructors whose full observable geometry/layout
-contract is already owned by Rust.  Class identity and inheritance remain unchanged.
+This module patches only operations whose full observable geometry/layout contract is
+already owned by Rust. Class identity and inheritance remain unchanged.
 """
 
 from __future__ import annotations
@@ -32,13 +32,35 @@ def _set_shared_color(self: _base.Mobject, color: object) -> None:
     """Apply Manim ``color`` through the shared semantic handle.
 
     The generic Phase-B setter rebuilds a Python snapshot before handing it back to
-    Rust.  Shared constructors must not re-enter that compatibility path: parse the
+    Rust. Shared constructors must not re-enter that compatibility path: parse the
     host color once, then use the semantic-handle mutation that preserves each
     channel's existing opacity.
     """
 
     parsed = _shared._phase_b._as_color("color", color)
     _shared._set_color(self, parsed)
+
+
+def _set_x(self: _base.Mobject, x: float) -> _base.Mobject:
+    """Set the center x coordinate through Rust-owned ``move_to`` semantics."""
+
+    value = _shared._ir._finite_number("x", x)
+    return _shared._move_to(
+        self,
+        _base.Vec2(value, 0.0),
+        coor_mask=(1.0, 0.0, 0.0),
+    )
+
+
+def _set_y(self: _base.Mobject, y: float) -> _base.Mobject:
+    """Set the center y coordinate through Rust-owned ``move_to`` semantics."""
+
+    value = _shared._ir._finite_number("y", y)
+    return _shared._move_to(
+        self,
+        _base.Vec2(0.0, value),
+        coor_mask=(0.0, 1.0, 0.0),
+    )
 
 
 def _dot_init(
@@ -96,6 +118,8 @@ def install() -> None:
     if _INSTALLED:
         return
     _INSTALLED = True
+    _base.Mobject.set_x = _set_x
+    _base.Mobject.set_y = _set_y
     if _create_dot_handle is not None:
         _geometry.Dot.__init__ = _dot_init
     if _create_triangle_handle is not None:

--- a/web/python/test_manim_shared_geometry.py
+++ b/web/python/test_manim_shared_geometry.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 
 class ManimSharedGeometryTests(unittest.TestCase):
-    def test_dot_and_triangle_bypass_python_geometry_construction(self) -> None:
+    def test_dot_triangle_and_axis_placement_bypass_python_geometry_semantics(self) -> None:
         python_dir = Path(__file__).resolve().parent
         env = os.environ.copy()
         existing = env.get("PYTHONPATH")
@@ -24,6 +24,7 @@ class ManimSharedGeometryTests(unittest.TestCase):
 
             fake_js = types.ModuleType("js")
             calls = []
+            placement_calls = []
 
             class FakeHandle:
                 def __init__(self, snapshot):
@@ -37,6 +38,16 @@ class ManimSharedGeometryTests(unittest.TestCase):
                 def setStrokeColor(self, r, g, b, a):
                     alpha = self.snapshot["style"]["stroke"]["alpha"]
                     self.snapshot["style"]["stroke"] = {"red": float(r), "green": float(g), "blue": float(b), "alpha": alpha}
+                def manimMoveToPoint(self, x, y, edge_x, edge_y, mask_x, mask_y):
+                    placement_calls.append((
+                        float(x), float(y), float(edge_x), float(edge_y),
+                        float(mask_x), float(mask_y),
+                    ))
+                    translation = self.snapshot["transform"]["translation"]
+                    if mask_x:
+                        translation["x"] = float(x)
+                    if mask_y:
+                        translation["y"] = float(y)
 
             def base_style(color, *, fill_alpha=0.0, stroke_width=0.04):
                 return {
@@ -121,6 +132,19 @@ class ManimSharedGeometryTests(unittest.TestCase):
             assert dot_obj.style["stroke_width"] == 0.0
             assert triangle_obj.style["stroke"]["red"] == BLUE[0]
             assert "vector_path" in triangle_obj.geometry
+
+            # set_x/set_y must delegate axis placement to the shared Rust move-to
+            # contract rather than reading the center and calculating a Python delta.
+            dot_obj.get_center = lambda: (_ for _ in ()).throw(
+                AssertionError("Python center math was used by set_x/set_y")
+            )
+            assert dot_obj.set_x(5.0) is dot_obj
+            assert dot_obj.set_y(4.0) is dot_obj
+            assert placement_calls == [
+                (5.0, 0.0, 0.0, 0.0, 1.0, 0.0),
+                (0.0, 4.0, 0.0, 0.0, 0.0, 1.0),
+            ]
+            assert dot_obj.transform["translation"] == {"x": 5.0, "y": 4.0}
             """
         )
         completed = subprocess.run(


### PR DESCRIPTION
## Summary
- route leaf `Mobject.set_x` and `Mobject.set_y` through the existing shared Rust `manimMoveToPoint` placement contract
- use coordinate masks so Rust owns center/critical-point placement math while Python only validates/coerces the requested scalar
- preserve the existing fallback path when a shared semantic handle is unavailable
- add a focused fake-WASM regression that makes Python `get_center` fail if either axis setter tries to compute its own delta

## Why
#74 and the pinned `MovingDots` gallery case require `set_x`/`set_y`. The methods already existed, but their center-to-delta calculation lived in `web/python/noon.py`, leaving observable placement semantics duplicated in Python even after `move_to` migrated to shared Rust.

No new Rust/WASM API is needed: `FrontendMobjectHandle::manim_move_to_point` already owns the exact coordinate-mask semantics and bound-state synchronization used here.

## Architecture
This is a thin-wrapper migration only. No renderer/runtime/timeline behavior, geometry representation, snapshot transport, or Python frame loop is added. Objects without an eligible shared handle continue through the existing compatibility fallback.

One commit / two small Python files directly on current master `9816fd4e`.

Tracks #61 and #74. Helps unblock #252 `MovingDots`.