### PR TITLE
Gate stale text resource identity after removal

### DIFF
--- a/crates/noon-core/tests/resource_churn.rs
+++ b/crates/noon-core/tests/resource_churn.rs
@@ -111,6 +111,35 @@ fn text_replacement_churn_keeps_one_live_resource_and_stable_accounting() {
 }
 
 #[test]
+fn text_remove_reinsert_does_not_alias_stale_identity() {
+    let mut arena = TextResourceArena::new();
+    let stale = arena
+        .insert(empty_text("old"))
+        .expect("initial text resource must insert");
+
+    arena
+        .remove(stale.id)
+        .expect("initial text resource must be removable");
+
+    let replacement = arena
+        .insert(empty_text("new"))
+        .expect("replacement text resource must insert");
+
+    assert_ne!(
+        replacement.id, stale.id,
+        "a removed bare TextResourceId must not alias a new occupant"
+    );
+    assert!(
+        arena.get(stale).is_none(),
+        "a stale handle must remain invalid after a new resource is inserted"
+    );
+    assert!(
+        arena.get(replacement).is_some(),
+        "the replacement handle must resolve independently"
+    );
+}
+
+#[test]
 fn repeated_font_interning_reuses_one_immutable_buffer() {
     let mut arena = FontResourceArena::new();
     let bytes: Arc<[u8]> = Arc::from([1_u8, 2, 3, 4]);


### PR DESCRIPTION
## Summary
- add a focused `TextResourceArena` lifecycle regression proving a removed text identity cannot alias a subsequently inserted resource
- keep the test at the core resource boundary, independent of renderer/worker/text-layout implementation
- document the follow-up bounded-slot design in #559 rather than enabling unsafe ID reuse as a shortcut

## Why this slice
`TextResourceArena` currently avoids stale aliasing by monotonically allocating IDs, but that leaves remove/create churn unbounded. Before introducing generation-aware slot reuse, the stale-identity invariant needs an explicit gate so memory work cannot regress correctness.

## Validation
The new test exercises insert -> remove -> insert and requires:
- replacement bare ID differs from the removed ID under the current implementation;
- stale handle remains unresolved;
- replacement handle resolves independently.

This is intentionally a small characterization/safety slice. The bounded generation-aware implementation remains #559 and should preserve the invariant while allowing physical slot reuse.

Tracks #559 and #114. No renderer, demo, protocol, or active text-upload files are touched.