### PR TITLE
Carry glyph atlas page identity into GPU draws

### DIFF
--- a/crates/noon-text-render-wgpu/src/gpu.rs
+++ b/crates/noon-text-render-wgpu/src/gpu.rs
@@ -130,6 +130,10 @@ impl std::ops::AddAssign for TextGpuDrawStats {
 pub enum TextGpuDrawError {
     UnsupportedSampleCount(u32),
     MissingAtlasPlane(GlyphAtlasPlane),
+    UnsupportedAtlasPage {
+        plane: GlyphAtlasPlane,
+        page: u32,
+    },
     InstanceRangeOutOfBounds {
         plane: GlyphAtlasPlane,
         end: u32,
@@ -146,6 +150,10 @@ impl std::fmt::Display for TextGpuDrawError {
             Self::MissingAtlasPlane(plane) => {
                 write!(formatter, "{plane:?} glyph atlas texture is not resident")
             }
+            Self::UnsupportedAtlasPage { plane, page } => write!(
+                formatter,
+                "{plane:?} glyph atlas page {page} is not supported by the current GPU binding model"
+            ),
             Self::InstanceRangeOutOfBounds {
                 plane,
                 end,
@@ -416,6 +424,7 @@ impl TextGlyphGpuRenderer {
     ) -> Result<TextGpuDrawStats, TextGpuDrawError> {
         let PreparedTextItem::GlyphBatch {
             plane,
+            page,
             instance_range,
             ..
         } = item
@@ -428,6 +437,7 @@ impl TextGlyphGpuRenderer {
         if instance_range.is_empty() {
             return Ok(TextGpuDrawStats::default());
         }
+        validate_atlas_page(*plane, *page)?;
 
         let (buffer, bind_group, available, pipeline) = match plane {
             GlyphAtlasPlane::Mask => (
@@ -500,6 +510,14 @@ impl TextGlyphGpuRenderer {
             (GlyphAtlasPlane::Color, TEXT_MSAA_SAMPLE_COUNT) => Ok(&self.color_pipeline_msaa),
             (_, count) => Err(TextGpuDrawError::UnsupportedSampleCount(count)),
         }
+    }
+}
+
+fn validate_atlas_page(plane: GlyphAtlasPlane, page: u32) -> Result<(), TextGpuDrawError> {
+    if page == 0 {
+        Ok(())
+    } else {
+        Err(TextGpuDrawError::UnsupportedAtlasPage { plane, page })
     }
 }
 
@@ -682,6 +700,7 @@ mod tests {
             text: text_handle(),
             run_index: 0,
             plane: GlyphAtlasPlane::Mask,
+            page: image.page,
             instance_range: 0..1,
         }];
         let prepared = prepared_mask_frame(&quads, &items);
@@ -773,6 +792,7 @@ mod tests {
             text: text_handle(),
             run_index: 0,
             plane: GlyphAtlasPlane::Mask,
+            page: image.page,
             instance_range: 0..1,
         }];
         let prepared = prepared_mask_frame(&quads, &items);
@@ -851,6 +871,18 @@ mod tests {
         };
         assert_eq!(stats.draw_calls, 0);
         assert_eq!(stats.deferred_items, 1);
+    }
+
+    #[test]
+    fn nonzero_atlas_page_is_rejected_before_draw() {
+        assert_eq!(validate_atlas_page(GlyphAtlasPlane::Mask, 0), Ok(()));
+        assert_eq!(
+            validate_atlas_page(GlyphAtlasPlane::Color, 3),
+            Err(TextGpuDrawError::UnsupportedAtlasPage {
+                plane: GlyphAtlasPlane::Color,
+                page: 3,
+            })
+        );
     }
 
     #[test]

--- a/crates/noon-text-render-wgpu/src/lib.rs
+++ b/crates/noon-text-render-wgpu/src/lib.rs
@@ -97,6 +97,7 @@ pub enum PreparedTextItem {
         text: TextResourceHandle,
         run_index: u32,
         plane: GlyphAtlasPlane,
+        page: u32,
         instance_range: Range<u32>,
     },
     Vector {
@@ -639,6 +640,7 @@ impl RetainedTextQuadPreparer {
                 text_handle,
                 run_index,
                 atlas_image.plane,
+                atlas_image.page,
                 instance_index,
             );
         }
@@ -651,6 +653,7 @@ impl RetainedTextQuadPreparer {
         text: TextResourceHandle,
         run_index: u32,
         plane: GlyphAtlasPlane,
+        page: u32,
         instance_index: usize,
     ) {
         let start = u32::try_from(instance_index).expect("text quad count exceeds u32 draw limits");
@@ -662,6 +665,7 @@ impl RetainedTextQuadPreparer {
             text: last_text,
             run_index: last_run,
             plane: last_plane,
+            page: last_page,
             instance_range,
         }) = self.items.last_mut()
         {
@@ -669,6 +673,7 @@ impl RetainedTextQuadPreparer {
                 && *last_text == text
                 && *last_run == run_index
                 && *last_plane == plane
+                && *last_page == page
                 && instance_range.end == start
             {
                 instance_range.end = end;
@@ -680,6 +685,7 @@ impl RetainedTextQuadPreparer {
             text,
             run_index,
             plane,
+            page,
             instance_range: start..end,
         });
     }


### PR DESCRIPTION
## Summary
- carry `GlyphAtlasImage.page` into prepared glyph-batch identity
- stop coalescing adjacent glyphs across different atlas pages
- reject nonzero atlas pages explicitly in the current GPU binding path until page-specific bind groups exist
- add a focused regression proving page>0 cannot silently sample page 0

## Why
#373 established page identity in atlas allocation, but prepared glyph batches still dropped it. Enabling live multi-page residency before this propagation would allow page>0 glyphs to sample page 0 silently.

## Invariants
- current live atlas allocation still emits page 0 only
- this PR does not enable multi-page allocation
- page 0 rendering remains unchanged
- future nonzero-page states fail explicitly rather than rendering from the wrong texture

## Integration provenance
The two parent blobs in `noon-text-render-wgpu` are byte-identical between the previously reviewed #475 parent and current master after #558. This branch therefore reuses the exact #475 final blobs for only those two files; no stale retained-renderer parent changes are replayed.

One commit / two files / +38, directly on current master `be42c2f2`.

Supersedes #475 integration-wise. Tracks #363; architecture parent #361.