### PR TITLE
Add bounded live glyph atlas pages

### DIFF
--- a/crates/noon-text-atlas/src/lib.rs
+++ b/crates/noon-text-atlas/src/lib.rs
@@ -508,11 +508,7 @@ impl GpuGlyphAtlas {
             image.placement.height,
             bytes_per_pixel,
         )?;
-        let allocation = self.allocate(
-            plane,
-            image.placement.width,
-            image.placement.height,
-        )?;
+        let allocation = self.allocate(plane, image.placement.width, image.placement.height)?;
         let extent = self.extent;
         let state = self.ensure_page(device, plane, allocation.page)?;
         let bytes_per_row = allocation.outer_size[0]

--- a/crates/noon-text-atlas/src/lib.rs
+++ b/crates/noon-text-atlas/src/lib.rs
@@ -41,9 +41,7 @@ impl GlyphAtlasPlane {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GlyphAtlasImage {
     pub plane: GlyphAtlasPlane,
-    /// Texture page containing this image. The current live GPU atlas emits page
-    /// zero only; keeping page identity in the retained entry lets multi-page GPU
-    /// residency land without changing glyph/quad identity again.
+    /// Texture page containing this image.
     pub page: u32,
     /// Top-left texel containing visible glyph pixels, excluding the transparent gutter.
     pub origin: [u32; 2],
@@ -313,20 +311,16 @@ fn page_allocation(
 struct AtlasPlaneState {
     texture: wgpu::Texture,
     view: wgpu::TextureView,
-    packer: ShelfPacker,
 }
 
 impl AtlasPlaneState {
-    fn new(
-        device: &wgpu::Device,
-        plane: GlyphAtlasPlane,
-        extent: u32,
-    ) -> Result<Self, GlyphAtlasError> {
+    fn new(device: &wgpu::Device, plane: GlyphAtlasPlane, extent: u32, page: u32) -> Self {
+        let label = match plane {
+            GlyphAtlasPlane::Mask => format!("Noon glyph mask atlas page {page}"),
+            GlyphAtlasPlane::Color => format!("Noon glyph color atlas page {page}"),
+        };
         let texture = device.create_texture(&wgpu::TextureDescriptor {
-            label: Some(match plane {
-                GlyphAtlasPlane::Mask => "Noon glyph mask atlas",
-                GlyphAtlasPlane::Color => "Noon glyph color atlas",
-            }),
+            label: Some(&label),
             size: wgpu::Extent3d {
                 width: extent,
                 height: extent,
@@ -340,39 +334,45 @@ impl AtlasPlaneState {
             view_formats: &[],
         });
         let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
-        Ok(Self {
-            texture,
-            view,
-            packer: ShelfPacker::new(extent)?,
-        })
+        Self { texture, view }
     }
 }
 
-/// Lazily allocated two-plane glyph atlas.
+/// Lazily allocated two-plane glyph atlas with an explicit bounded page budget.
 ///
-/// Alpha-mask and color glyphs use independent textures because they have different
-/// formats and shader semantics. Neither texture is allocated until the first image
-/// for that plane is uploaded. Empty glyphs are cached without consuming GPU space.
+/// Alpha-mask and color glyphs use independent page vectors because they have
+/// different formats and shader semantics. Textures remain lazy: a plane allocates
+/// only the pages actually reached by deterministic shelf packing. Empty glyphs are
+/// cached without consuming GPU space.
 ///
-/// The live GPU implementation intentionally remains one page per plane in this
-/// foundation slice. Entries already carry page identity and the pure page allocator
-/// above defines deterministic rollover; subsequent work can move texture ownership
-/// to page vectors without another retained-entry format change.
+/// `GpuGlyphAtlas::new` preserves the historical one-page-per-plane policy. Callers
+/// must opt into a larger bounded budget with `with_page_limit`; eviction/reuse is a
+/// separate residency policy layered on top of this structural page ownership.
 pub struct GpuGlyphAtlas {
     extent: u32,
-    mask: Option<AtlasPlaneState>,
-    color: Option<AtlasPlaneState>,
+    mask_allocator: GlyphAtlasPageAllocator,
+    color_allocator: GlyphAtlasPageAllocator,
+    mask_pages: Vec<AtlasPlaneState>,
+    color_pages: Vec<AtlasPlaneState>,
     entries: HashMap<GlyphRasterKey, GlyphAtlasEntry>,
     stats: GlyphAtlasStats,
 }
 
 impl GpuGlyphAtlas {
     pub fn new(extent: u32) -> Result<Self, GlyphAtlasError> {
-        ShelfPacker::new(extent)?;
+        Self::with_page_limit(extent, 1)
+    }
+
+    pub fn with_page_limit(
+        extent: u32,
+        max_pages_per_plane: usize,
+    ) -> Result<Self, GlyphAtlasError> {
         Ok(Self {
             extent,
-            mask: None,
-            color: None,
+            mask_allocator: GlyphAtlasPageAllocator::new(extent, max_pages_per_plane)?,
+            color_allocator: GlyphAtlasPageAllocator::new(extent, max_pages_per_plane)?,
+            mask_pages: Vec::new(),
+            color_pages: Vec::new(),
             entries: HashMap::new(),
             stats: GlyphAtlasStats::default(),
         })
@@ -398,10 +398,31 @@ impl GpuGlyphAtlas {
         self.entries.is_empty()
     }
 
-    pub fn texture_view(&self, plane: GlyphAtlasPlane) -> Option<&wgpu::TextureView> {
+    pub fn max_pages_per_plane(&self) -> usize {
+        self.mask_allocator.max_pages()
+    }
+
+    pub fn page_count(&self, plane: GlyphAtlasPlane) -> usize {
         match plane {
-            GlyphAtlasPlane::Mask => self.mask.as_ref().map(|state| &state.view),
-            GlyphAtlasPlane::Color => self.color.as_ref().map(|state| &state.view),
+            GlyphAtlasPlane::Mask => self.mask_pages.len(),
+            GlyphAtlasPlane::Color => self.color_pages.len(),
+        }
+    }
+
+    /// Compatibility accessor for page zero of a plane.
+    pub fn texture_view(&self, plane: GlyphAtlasPlane) -> Option<&wgpu::TextureView> {
+        self.texture_view_for_page(plane, 0)
+    }
+
+    pub fn texture_view_for_page(
+        &self,
+        plane: GlyphAtlasPlane,
+        page: u32,
+    ) -> Option<&wgpu::TextureView> {
+        let page = usize::try_from(page).ok()?;
+        match plane {
+            GlyphAtlasPlane::Mask => self.mask_pages.get(page).map(|state| &state.view),
+            GlyphAtlasPlane::Color => self.color_pages.get(page).map(|state| &state.view),
         }
     }
 
@@ -457,7 +478,7 @@ impl GpuGlyphAtlas {
             });
         }
 
-        // Reject impossible images before lazily allocating the GPU plane.
+        // Reject impossible images before mutating allocator state or allocating a GPU page.
         let gutter_twice = GLYPH_ATLAS_GUTTER
             .checked_mul(2)
             .ok_or(GlyphAtlasError::DimensionOverflow)?;
@@ -481,18 +502,19 @@ impl GpuGlyphAtlas {
             });
         }
 
-        let extent = self.extent;
-        let state = self.ensure_plane(device, plane)?;
-        let allocation =
-            state
-                .packer
-                .allocate(plane, image.placement.width, image.placement.height)?;
         let upload = padded_upload(
             &image.data,
             image.placement.width,
             image.placement.height,
             bytes_per_pixel,
         )?;
+        let allocation = self.allocate(
+            plane,
+            image.placement.width,
+            image.placement.height,
+        )?;
+        let extent = self.extent;
+        let state = self.ensure_page(device, plane, allocation.page)?;
         let bytes_per_row = allocation.outer_size[0]
             .checked_mul(bytes_per_pixel as u32)
             .ok_or(GlyphAtlasError::DimensionOverflow)?;
@@ -524,7 +546,7 @@ impl GpuGlyphAtlas {
         let size = [image.placement.width, image.placement.height];
         let atlas_image = GlyphAtlasImage {
             plane,
-            page: 0,
+            page: allocation.page,
             origin,
             size,
             uv_min: [
@@ -551,29 +573,44 @@ impl GpuGlyphAtlas {
         Ok(entry)
     }
 
-    fn ensure_plane(
+    fn allocate(
+        &mut self,
+        plane: GlyphAtlasPlane,
+        width: u32,
+        height: u32,
+    ) -> Result<GlyphAtlasPageAllocation, GlyphAtlasError> {
+        match plane {
+            GlyphAtlasPlane::Mask => self.mask_allocator.allocate(plane, width, height),
+            GlyphAtlasPlane::Color => self.color_allocator.allocate(plane, width, height),
+        }
+    }
+
+    fn ensure_page(
         &mut self,
         device: &wgpu::Device,
         plane: GlyphAtlasPlane,
+        page: u32,
     ) -> Result<&mut AtlasPlaneState, GlyphAtlasError> {
-        match plane {
-            GlyphAtlasPlane::Mask => {
-                if self.mask.is_none() {
-                    self.mask = Some(AtlasPlaneState::new(device, plane, self.extent)?);
-                    self.stats.texture_allocations =
-                        self.stats.texture_allocations.saturating_add(1);
-                }
-                Ok(self.mask.as_mut().expect("mask atlas was initialized"))
+        let page_index = usize::try_from(page).map_err(|_| GlyphAtlasError::DimensionOverflow)?;
+        let required = page_index
+            .checked_add(1)
+            .ok_or(GlyphAtlasError::DimensionOverflow)?;
+        let missing = required.saturating_sub(self.page_count(plane));
+        for _ in 0..missing {
+            let next_page = u32::try_from(self.page_count(plane))
+                .map_err(|_| GlyphAtlasError::DimensionOverflow)?;
+            let state = AtlasPlaneState::new(device, plane, self.extent, next_page);
+            match plane {
+                GlyphAtlasPlane::Mask => self.mask_pages.push(state),
+                GlyphAtlasPlane::Color => self.color_pages.push(state),
             }
-            GlyphAtlasPlane::Color => {
-                if self.color.is_none() {
-                    self.color = Some(AtlasPlaneState::new(device, plane, self.extent)?);
-                    self.stats.texture_allocations =
-                        self.stats.texture_allocations.saturating_add(1);
-                }
-                Ok(self.color.as_mut().expect("color atlas was initialized"))
-            }
+            self.stats.texture_allocations = self.stats.texture_allocations.saturating_add(1);
         }
+        match plane {
+            GlyphAtlasPlane::Mask => self.mask_pages.get_mut(page_index),
+            GlyphAtlasPlane::Color => self.color_pages.get_mut(page_index),
+        }
+        .ok_or(GlyphAtlasError::DimensionOverflow)
     }
 }
 
@@ -707,6 +744,18 @@ mod tests {
             GlyphAtlasPageAllocator::new(8, 0).unwrap_err(),
             GlyphAtlasError::InvalidPageCount
         );
+        assert!(matches!(
+            GpuGlyphAtlas::with_page_limit(8, 0),
+            Err(GlyphAtlasError::InvalidPageCount)
+        ));
+    }
+
+    #[test]
+    fn default_gpu_atlas_page_budget_stays_one() {
+        let atlas = GpuGlyphAtlas::new(8).unwrap();
+        assert_eq!(atlas.max_pages_per_plane(), 1);
+        assert_eq!(atlas.page_count(GlyphAtlasPlane::Mask), 0);
+        assert_eq!(atlas.page_count(GlyphAtlasPlane::Color), 0);
     }
 
     #[test]

--- a/crates/noon-text-atlas/tests/gpu_upload.rs
+++ b/crates/noon-text-atlas/tests/gpu_upload.rs
@@ -20,6 +20,19 @@ fn glyph_key(glyph_id: u16) -> GlyphRasterKey {
     }
 }
 
+fn mask_raster(width: u32, height: u32, value: u8) -> GlyphRaster {
+    GlyphRaster::Image(GlyphRasterImage {
+        format: GlyphRasterFormat::Alpha8,
+        placement: GlyphRasterPlacement {
+            left: 0,
+            top: height as i32,
+            width,
+            height,
+        },
+        data: Arc::from(vec![value; (width * height) as usize]),
+    })
+}
+
 #[test]
 fn noop_device_validates_lazy_mask_and_color_uploads() {
     let (device, queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
@@ -44,6 +57,7 @@ fn noop_device_validates_lazy_mask_and_color_uploads() {
         panic!("visible mask glyph must occupy the atlas");
     };
     assert_eq!(mask_image.plane, GlyphAtlasPlane::Mask);
+    assert_eq!(mask_image.page, 0);
     assert_eq!(mask_image.origin, [1, 1]);
     assert_eq!(mask_image.size, [2, 2]);
     assert!(atlas.texture_view(GlyphAtlasPlane::Mask).is_some());
@@ -70,6 +84,7 @@ fn noop_device_validates_lazy_mask_and_color_uploads() {
         panic!("visible color glyph must occupy the atlas");
     };
     assert_eq!(color_image.plane, GlyphAtlasPlane::Color);
+    assert_eq!(color_image.page, 0);
     assert_eq!(color_image.origin, [1, 1]);
     assert_eq!(color_image.size, [1, 1]);
     assert!(atlas.texture_view(GlyphAtlasPlane::Color).is_some());
@@ -83,4 +98,44 @@ fn noop_device_validates_lazy_mask_and_color_uploads() {
     assert_eq!(stats.misses, 2);
     assert_eq!(atlas.get(mask_key), Some(mask_entry));
     assert_eq!(atlas.get(color_key), Some(color_entry));
+}
+
+#[test]
+fn noop_device_allocates_live_pages_within_explicit_budget() {
+    let (device, queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
+    let mut atlas = GpuGlyphAtlas::with_page_limit(8, 2).unwrap();
+
+    for glyph_id in 1..=2 {
+        let GlyphAtlasEntry::Image(image) = atlas
+            .insert(
+                &device,
+                &queue,
+                glyph_key(glyph_id),
+                &mask_raster(4, 2, 100 + glyph_id as u8),
+            )
+            .unwrap()
+        else {
+            panic!("visible mask glyph must occupy the atlas");
+        };
+        assert_eq!(image.page, 0);
+    }
+
+    let GlyphAtlasEntry::Image(page_one) = atlas
+        .insert(&device, &queue, glyph_key(3), &mask_raster(1, 1, 255))
+        .unwrap()
+    else {
+        panic!("visible mask glyph must occupy the atlas");
+    };
+    assert_eq!(page_one.page, 1);
+    assert_eq!(page_one.origin, [1, 1]);
+    assert_eq!(atlas.page_count(GlyphAtlasPlane::Mask), 2);
+    assert_eq!(atlas.page_count(GlyphAtlasPlane::Color), 0);
+    assert!(atlas.texture_view(GlyphAtlasPlane::Mask).is_some());
+    assert!(atlas
+        .texture_view_for_page(GlyphAtlasPlane::Mask, 1)
+        .is_some());
+    assert!(atlas
+        .texture_view_for_page(GlyphAtlasPlane::Mask, 2)
+        .is_none());
+    assert_eq!(atlas.stats().texture_allocations, 2);
 }

--- a/crates/noon-text-render-wgpu/src/gpu.rs
+++ b/crates/noon-text-render-wgpu/src/gpu.rs
@@ -130,6 +130,12 @@ impl std::ops::AddAssign for TextGpuDrawStats {
 pub enum TextGpuDrawError {
     UnsupportedSampleCount(u32),
     MissingAtlasPlane(GlyphAtlasPlane),
+    MissingAtlasPage {
+        plane: GlyphAtlasPlane,
+        page: u32,
+    },
+    /// Retained for compatibility with callers compiled against the page-identity
+    /// foundation. Live page-aware bindings no longer emit this error.
     UnsupportedAtlasPage {
         plane: GlyphAtlasPlane,
         page: u32,
@@ -149,6 +155,9 @@ impl std::fmt::Display for TextGpuDrawError {
             }
             Self::MissingAtlasPlane(plane) => {
                 write!(formatter, "{plane:?} glyph atlas texture is not resident")
+            }
+            Self::MissingAtlasPage { plane, page } => {
+                write!(formatter, "{plane:?} glyph atlas page {page} is not resident")
             }
             Self::UnsupportedAtlasPage { plane, page } => write!(
                 formatter,
@@ -182,8 +191,8 @@ pub struct TextGlyphGpuRenderer {
     camera_bind_group: wgpu::BindGroup,
     atlas_layout: wgpu::BindGroupLayout,
     sampler: wgpu::Sampler,
-    mask_bind_group: Option<wgpu::BindGroup>,
-    color_bind_group: Option<wgpu::BindGroup>,
+    mask_bind_groups: Vec<wgpu::BindGroup>,
+    color_bind_groups: Vec<wgpu::BindGroup>,
     mask_buffer: wgpu::Buffer,
     color_buffer: wgpu::Buffer,
     mask_capacity_bytes: usize,
@@ -313,8 +322,8 @@ impl TextGlyphGpuRenderer {
             camera_bind_group,
             atlas_layout,
             sampler,
-            mask_bind_group: None,
-            color_bind_group: None,
+            mask_bind_groups: Vec::new(),
+            color_bind_groups: Vec::new(),
             mask_buffer: empty_instance_buffer(device, "Noon text mask glyph instances"),
             color_buffer: empty_instance_buffer(device, "Noon text color glyph instances"),
             mask_capacity_bytes: 0,
@@ -340,8 +349,8 @@ impl TextGlyphGpuRenderer {
 
     /// Drop texture bind groups when switching to a different persistent atlas.
     pub fn reset_atlas_bindings(&mut self) {
-        self.mask_bind_group = None;
-        self.color_bind_group = None;
+        self.mask_bind_groups.clear();
+        self.color_bind_groups.clear();
     }
 
     pub fn upload(
@@ -392,28 +401,24 @@ impl TextGlyphGpuRenderer {
     }
 
     fn refresh_atlas_bind_groups(&mut self, device: &wgpu::Device, atlas: &GpuGlyphAtlas) {
-        if self.mask_bind_group.is_none() {
-            if let Some(view) = atlas.texture_view(GlyphAtlasPlane::Mask) {
-                self.mask_bind_group = Some(create_atlas_bind_group(
-                    device,
-                    &self.atlas_layout,
-                    &self.sampler,
-                    view,
-                    "Noon mask glyph atlas bind group",
-                ));
-            }
-        }
-        if self.color_bind_group.is_none() {
-            if let Some(view) = atlas.texture_view(GlyphAtlasPlane::Color) {
-                self.color_bind_group = Some(create_atlas_bind_group(
-                    device,
-                    &self.atlas_layout,
-                    &self.sampler,
-                    view,
-                    "Noon color glyph atlas bind group",
-                ));
-            }
-        }
+        refresh_plane_bind_groups(
+            device,
+            &self.atlas_layout,
+            &self.sampler,
+            &mut self.mask_bind_groups,
+            atlas,
+            GlyphAtlasPlane::Mask,
+            "Noon mask glyph atlas bind group",
+        );
+        refresh_plane_bind_groups(
+            device,
+            &self.atlas_layout,
+            &self.sampler,
+            &mut self.color_bind_groups,
+            atlas,
+            GlyphAtlasPlane::Color,
+            "Noon color glyph atlas bind group",
+        );
     }
 
     pub fn draw_item<'a>(
@@ -437,26 +442,35 @@ impl TextGlyphGpuRenderer {
         if instance_range.is_empty() {
             return Ok(TextGpuDrawStats::default());
         }
-        validate_atlas_page(*plane, *page)?;
 
-        let (buffer, bind_group, available, pipeline) = match plane {
+        let (buffer, bind_groups, available, pipeline) = match plane {
             GlyphAtlasPlane::Mask => (
                 &self.mask_buffer,
-                self.mask_bind_group
-                    .as_ref()
-                    .ok_or(TextGpuDrawError::MissingAtlasPlane(*plane))?,
+                &self.mask_bind_groups,
                 self.mask_instances,
                 self.pipeline(GlyphAtlasPlane::Mask, sample_count)?,
             ),
             GlyphAtlasPlane::Color => (
                 &self.color_buffer,
-                self.color_bind_group
-                    .as_ref()
-                    .ok_or(TextGpuDrawError::MissingAtlasPlane(*plane))?,
+                &self.color_bind_groups,
                 self.color_instances,
                 self.pipeline(GlyphAtlasPlane::Color, sample_count)?,
             ),
         };
+        let page_index = usize::try_from(*page).map_err(|_| TextGpuDrawError::MissingAtlasPage {
+            plane: *plane,
+            page: *page,
+        })?;
+        let bind_group = bind_groups.get(page_index).ok_or_else(|| {
+            if *page == 0 && bind_groups.is_empty() {
+                TextGpuDrawError::MissingAtlasPlane(*plane)
+            } else {
+                TextGpuDrawError::MissingAtlasPage {
+                    plane: *plane,
+                    page: *page,
+                }
+            }
+        })?;
         if instance_range.end > available {
             return Err(TextGpuDrawError::InstanceRangeOutOfBounds {
                 plane: *plane,
@@ -513,11 +527,25 @@ impl TextGlyphGpuRenderer {
     }
 }
 
-fn validate_atlas_page(plane: GlyphAtlasPlane, page: u32) -> Result<(), TextGpuDrawError> {
-    if page == 0 {
-        Ok(())
-    } else {
-        Err(TextGpuDrawError::UnsupportedAtlasPage { plane, page })
+fn refresh_plane_bind_groups(
+    device: &wgpu::Device,
+    layout: &wgpu::BindGroupLayout,
+    sampler: &wgpu::Sampler,
+    bind_groups: &mut Vec<wgpu::BindGroup>,
+    atlas: &GpuGlyphAtlas,
+    plane: GlyphAtlasPlane,
+    label: &'static str,
+) {
+    let page_count = atlas.page_count(plane);
+    if bind_groups.len() > page_count {
+        bind_groups.truncate(page_count);
+    }
+    while bind_groups.len() < page_count {
+        let page = u32::try_from(bind_groups.len()).expect("glyph atlas page count exceeds u32");
+        let view = atlas
+            .texture_view_for_page(plane, page)
+            .expect("resident glyph atlas page must expose its texture view");
+        bind_groups.push(create_atlas_bind_group(device, layout, sampler, view, label));
     }
 }
 
@@ -648,6 +676,19 @@ mod tests {
         }
     }
 
+    fn mask_raster(width: u32, height: u32, value: u8) -> GlyphRaster {
+        GlyphRaster::Image(GlyphRasterImage {
+            format: GlyphRasterFormat::Alpha8,
+            placement: GlyphRasterPlacement {
+                left: 0,
+                top: height as i32,
+                width,
+                height,
+            },
+            data: Arc::from(vec![value; (width * height) as usize]),
+        })
+    }
+
     fn prepared_mask_frame<'a>(
         quads: &'a [GlyphQuadInstance],
         items: &'a [PreparedTextItem],
@@ -666,6 +707,28 @@ mod tests {
             id: TextResourceId::new(0),
             version: 0,
         }
+    }
+
+    fn noop_target(
+        device: &wgpu::Device,
+        label: &'static str,
+    ) -> (wgpu::Texture, wgpu::TextureView) {
+        let target = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some(label),
+            size: wgpu::Extent3d {
+                width: 16,
+                height: 16,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Rgba8Unorm,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            view_formats: &[],
+        });
+        let view = target.create_view(&wgpu::TextureViewDescriptor::default());
+        (target, view)
     }
 
     #[test]
@@ -714,21 +777,7 @@ mod tests {
         assert_eq!(upload.bytes_uploaded, size_of::<GlyphQuadInstance>());
         assert_eq!(upload.buffer_reallocations, 1);
 
-        let target = device.create_texture(&wgpu::TextureDescriptor {
-            label: Some("Noon text glyph noop render target"),
-            size: wgpu::Extent3d {
-                width: 16,
-                height: 16,
-                depth_or_array_layers: 1,
-            },
-            mip_level_count: 1,
-            sample_count: 1,
-            dimension: wgpu::TextureDimension::D2,
-            format: wgpu::TextureFormat::Rgba8Unorm,
-            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-            view_formats: &[],
-        });
-        let view = target.create_view(&wgpu::TextureViewDescriptor::default());
+        let (_target, view) = noop_target(&device, "Noon text glyph noop render target");
         let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
             label: Some("Noon text glyph noop encoder"),
         });
@@ -758,6 +807,83 @@ mod tests {
         assert_eq!(stats.draw_calls, 1);
         assert_eq!(stats.instances_drawn, 1);
         assert_eq!(stats.deferred_items, 0);
+    }
+
+    #[test]
+    fn noop_device_draws_from_nonzero_atlas_page() {
+        let (device, queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
+        let mut atlas = GpuGlyphAtlas::with_page_limit(8, 2).unwrap();
+        for glyph_id in 1..=2 {
+            let image = mask_raster(4, 2, 100 + glyph_id as u8);
+            let GlyphAtlasEntry::Image(entry) = atlas
+                .insert(&device, &queue, raster_key(glyph_id), &image)
+                .unwrap()
+            else {
+                panic!("visible mask glyph must allocate an atlas image");
+            };
+            assert_eq!(entry.page, 0);
+        }
+        let raster = mask_raster(1, 1, 255);
+        let GlyphAtlasEntry::Image(page_one) = atlas
+            .insert(&device, &queue, raster_key(3), &raster)
+            .unwrap()
+        else {
+            panic!("visible mask glyph must allocate an atlas image");
+        };
+        assert_eq!(page_one.page, 1);
+        assert_eq!(atlas.page_count(GlyphAtlasPlane::Mask), 2);
+
+        let quads = [GlyphQuadInstance {
+            origin: [-0.5, -0.5],
+            axis_x: [1.0, 0.0],
+            axis_y: [0.0, 1.0],
+            uv_min: page_one.uv_min,
+            uv_max: page_one.uv_max,
+            color: [1.0; 4],
+        }];
+        let items = [PreparedTextItem::GlyphBatch {
+            object_index: 0,
+            text: text_handle(),
+            run_index: 0,
+            plane: GlyphAtlasPlane::Mask,
+            page: page_one.page,
+            instance_range: 0..1,
+        }];
+        let prepared = prepared_mask_frame(&quads, &items);
+        let mut renderer = TextGlyphGpuRenderer::new(
+            &device,
+            &queue,
+            wgpu::TextureFormat::Rgba8Unorm,
+            TextCamera2D::DEFAULT,
+        );
+        renderer.upload(&device, &queue, &prepared, &atlas);
+        assert_eq!(renderer.mask_bind_groups.len(), 2);
+
+        let (_target, view) = noop_target(&device, "Noon text page-one noop target");
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+        let attachments = [Some(wgpu::RenderPassColorAttachment {
+            view: &view,
+            depth_slice: None,
+            resolve_target: None,
+            ops: wgpu::Operations {
+                load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                store: wgpu::StoreOp::Store,
+            },
+        })];
+        let stats = {
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("Noon text page-one noop pass"),
+                color_attachments: &attachments,
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+                multiview_mask: None,
+            });
+            renderer.draw_item(&mut pass, &items[0], 1).unwrap()
+        };
+        queue.submit(Some(encoder.finish()));
+        assert_eq!(stats.draw_calls, 1);
+        assert_eq!(stats.instances_drawn, 1);
     }
 
     #[test]
@@ -833,21 +959,7 @@ mod tests {
             morph: 0.0,
         };
 
-        let target = device.create_texture(&wgpu::TextureDescriptor {
-            label: Some("Noon text deferred noop render target"),
-            size: wgpu::Extent3d {
-                width: 4,
-                height: 4,
-                depth_or_array_layers: 1,
-            },
-            mip_level_count: 1,
-            sample_count: 1,
-            dimension: wgpu::TextureDimension::D2,
-            format: wgpu::TextureFormat::Rgba8Unorm,
-            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-            view_formats: &[],
-        });
-        let view = target.create_view(&wgpu::TextureViewDescriptor::default());
+        let (_target, view) = noop_target(&device, "Noon text deferred noop render target");
         let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
         let attachments = [Some(wgpu::RenderPassColorAttachment {
             view: &view,
@@ -871,18 +983,6 @@ mod tests {
         };
         assert_eq!(stats.draw_calls, 0);
         assert_eq!(stats.deferred_items, 1);
-    }
-
-    #[test]
-    fn nonzero_atlas_page_is_rejected_before_draw() {
-        assert_eq!(validate_atlas_page(GlyphAtlasPlane::Mask, 0), Ok(()));
-        assert_eq!(
-            validate_atlas_page(GlyphAtlasPlane::Color, 3),
-            Err(TextGpuDrawError::UnsupportedAtlasPage {
-                plane: GlyphAtlasPlane::Color,
-                page: 3,
-            })
-        );
     }
 
     #[test]

--- a/crates/noon-text-render-wgpu/src/gpu.rs
+++ b/crates/noon-text-render-wgpu/src/gpu.rs
@@ -462,7 +462,7 @@ impl TextGlyphGpuRenderer {
                 plane: *plane,
                 page: *page,
             })?;
-        let bind_group = bind_groups.get(page_index).ok_or_else(|| {
+        let bind_group = bind_groups.get(page_index).ok_or({
             if *page == 0 && bind_groups.is_empty() {
                 TextGpuDrawError::MissingAtlasPlane(*plane)
             } else {

--- a/crates/noon-text-render-wgpu/src/gpu.rs
+++ b/crates/noon-text-render-wgpu/src/gpu.rs
@@ -457,10 +457,11 @@ impl TextGlyphGpuRenderer {
                 self.pipeline(GlyphAtlasPlane::Color, sample_count)?,
             ),
         };
-        let page_index = usize::try_from(*page).map_err(|_| TextGpuDrawError::MissingAtlasPage {
-            plane: *plane,
-            page: *page,
-        })?;
+        let page_index =
+            usize::try_from(*page).map_err(|_| TextGpuDrawError::MissingAtlasPage {
+                plane: *plane,
+                page: *page,
+            })?;
         let bind_group = bind_groups.get(page_index).ok_or_else(|| {
             if *page == 0 && bind_groups.is_empty() {
                 TextGpuDrawError::MissingAtlasPlane(*plane)
@@ -545,7 +546,9 @@ fn refresh_plane_bind_groups(
         let view = atlas
             .texture_view_for_page(plane, page)
             .expect("resident glyph atlas page must expose its texture view");
-        bind_groups.push(create_atlas_bind_group(device, layout, sampler, view, label));
+        bind_groups.push(create_atlas_bind_group(
+            device, layout, sampler, view, label,
+        ));
     }
 }
 

--- a/crates/noon-text-render-wgpu/tests/live_atlas_pages.rs
+++ b/crates/noon-text-render-wgpu/tests/live_atlas_pages.rs
@@ -2,9 +2,7 @@
 
 use std::{mem::size_of, sync::Arc};
 
-use noon_core::{
-    FontResourceHandle, FontResourceId, TextResourceHandle, TextResourceId,
-};
+use noon_core::{FontResourceHandle, FontResourceId, TextResourceHandle, TextResourceId};
 use noon_text_atlas::{GlyphAtlasEntry, GlyphAtlasPlane, GpuGlyphAtlas};
 use noon_text_raster::{
     GlyphRaster, GlyphRasterFormat, GlyphRasterImage, GlyphRasterKey, GlyphRasterPlacement,

--- a/crates/noon-text-render-wgpu/tests/live_atlas_pages.rs
+++ b/crates/noon-text-render-wgpu/tests/live_atlas_pages.rs
@@ -1,0 +1,174 @@
+#![cfg(feature = "ci-noop")]
+
+use std::{mem::size_of, sync::Arc};
+
+use noon_core::{
+    FontResourceHandle, FontResourceId, TextResourceHandle, TextResourceId,
+};
+use noon_text_atlas::{GlyphAtlasEntry, GlyphAtlasPlane, GpuGlyphAtlas};
+use noon_text_raster::{
+    GlyphRaster, GlyphRasterFormat, GlyphRasterImage, GlyphRasterKey, GlyphRasterPlacement,
+};
+use noon_text_render_wgpu::{
+    GlyphQuadInstance, PreparedRetainedTextFrame, PreparedTextItem, TextCamera2D,
+    TextGlyphGpuRenderer,
+};
+
+fn raster_key(glyph_id: u16) -> GlyphRasterKey {
+    GlyphRasterKey {
+        font: FontResourceHandle {
+            id: FontResourceId::new(0),
+            version: 0,
+        },
+        glyph_id,
+        pixel_size_bits: 32.0f32.to_bits(),
+        variation_fingerprint: 0,
+    }
+}
+
+fn text_handle() -> TextResourceHandle {
+    TextResourceHandle {
+        id: TextResourceId::new(0),
+        version: 0,
+    }
+}
+
+fn mask_raster(width: u32, height: u32, value: u8) -> GlyphRaster {
+    GlyphRaster::Image(GlyphRasterImage {
+        format: GlyphRasterFormat::Alpha8,
+        placement: GlyphRasterPlacement {
+            left: 0,
+            top: height as i32,
+            width,
+            height,
+        },
+        data: Arc::from(vec![value; (width * height) as usize]),
+    })
+}
+
+fn quad(image: noon_text_atlas::GlyphAtlasImage) -> GlyphQuadInstance {
+    GlyphQuadInstance {
+        origin: [-0.5, -0.5],
+        axis_x: [1.0, 0.0],
+        axis_y: [0.0, 1.0],
+        uv_min: image.uv_min,
+        uv_max: image.uv_max,
+        color: [1.0; 4],
+    }
+}
+
+fn prepared_mask_frame<'a>(
+    quads: &'a [GlyphQuadInstance],
+    items: &'a [PreparedTextItem],
+) -> PreparedRetainedTextFrame<'a> {
+    PreparedRetainedTextFrame {
+        time: 0.0,
+        mask_quads: quads,
+        color_quads: &[],
+        items,
+        stats: Default::default(),
+    }
+}
+
+#[test]
+fn renderer_extends_bindings_when_persistent_atlas_grows() {
+    let (device, queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
+    let mut atlas = GpuGlyphAtlas::with_page_limit(8, 2).unwrap();
+
+    let GlyphAtlasEntry::Image(page_zero) = atlas
+        .insert(&device, &queue, raster_key(1), &mask_raster(4, 2, 101))
+        .unwrap()
+    else {
+        panic!("visible glyph must allocate an atlas image");
+    };
+    assert_eq!(page_zero.page, 0);
+
+    let first_quads = [quad(page_zero)];
+    let first_items = [PreparedTextItem::GlyphBatch {
+        object_index: 0,
+        text: text_handle(),
+        run_index: 0,
+        plane: GlyphAtlasPlane::Mask,
+        page: page_zero.page,
+        instance_range: 0..1,
+    }];
+    let first = prepared_mask_frame(&first_quads, &first_items);
+    let mut renderer = TextGlyphGpuRenderer::new(
+        &device,
+        &queue,
+        wgpu::TextureFormat::Rgba8Unorm,
+        TextCamera2D::DEFAULT,
+    );
+    let first_upload = renderer.upload(&device, &queue, &first, &atlas);
+    assert_eq!(first_upload.bytes_uploaded, size_of::<GlyphQuadInstance>());
+
+    let GlyphAtlasEntry::Image(page_zero_second) = atlas
+        .insert(&device, &queue, raster_key(2), &mask_raster(4, 2, 102))
+        .unwrap()
+    else {
+        panic!("visible glyph must allocate an atlas image");
+    };
+    assert_eq!(page_zero_second.page, 0);
+
+    let GlyphAtlasEntry::Image(page_one) = atlas
+        .insert(&device, &queue, raster_key(3), &mask_raster(1, 1, 255))
+        .unwrap()
+    else {
+        panic!("visible glyph must allocate an atlas image");
+    };
+    assert_eq!(page_one.page, 1);
+    assert_eq!(atlas.page_count(GlyphAtlasPlane::Mask), 2);
+
+    let second_quads = [quad(page_one)];
+    let second_items = [PreparedTextItem::GlyphBatch {
+        object_index: 0,
+        text: text_handle(),
+        run_index: 0,
+        plane: GlyphAtlasPlane::Mask,
+        page: page_one.page,
+        instance_range: 0..1,
+    }];
+    let second = prepared_mask_frame(&second_quads, &second_items);
+    renderer.upload(&device, &queue, &second, &atlas);
+
+    let target = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("Noon growing glyph atlas integration target"),
+        size: wgpu::Extent3d {
+            width: 16,
+            height: 16,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Rgba8Unorm,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+        view_formats: &[],
+    });
+    let view = target.create_view(&wgpu::TextureViewDescriptor::default());
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+    let attachments = [Some(wgpu::RenderPassColorAttachment {
+        view: &view,
+        depth_slice: None,
+        resolve_target: None,
+        ops: wgpu::Operations {
+            load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+            store: wgpu::StoreOp::Store,
+        },
+    })];
+    let stats = {
+        let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("Noon growing glyph atlas integration pass"),
+            color_attachments: &attachments,
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        });
+        renderer.draw_item(&mut pass, &second_items[0], 1).unwrap()
+    };
+    queue.submit(Some(encoder.finish()));
+
+    assert_eq!(stats.draw_calls, 1);
+    assert_eq!(stats.instances_drawn, 1);
+}


### PR DESCRIPTION
## Summary
- move live `GpuGlyphAtlas` ownership from one texture per plane to bounded page vectors backed by the existing deterministic page allocator
- preserve `GpuGlyphAtlas::new(extent)` as the existing one-page-per-plane policy
- add explicit `with_page_limit(extent, max_pages_per_plane)` opt-in without changing the retained renderer's default GPU memory budget
- preserve `texture_view(plane)` as page-0 compatibility and add page-aware view lookup/counts
- make retained text GPU bind groups page-aware and select the bind group from `PreparedTextItem::GlyphBatch.page`
- add noop-GPU regressions that force page 1 allocation and submit a draw using that page

## Invariants
- default production behavior still allocates at most one texture per plane
- page allocation remains deterministic and bounded; no eviction/reuse policy is introduced here
- textures remain lazy and are allocated only when a page is reached
- nonzero pages can no longer be rejected merely because the renderer has a single bind group
- current-frame pinning/eviction, metadata plateau counters, and product multi-page defaults remain the next isolated #363 slice

Tracks #363. Built directly on merged #562 (`bc1a8986`).