### PR TITLE
Route directional coordinate placement through shared Rust

### DIFF
--- a/web/python/_manim_shared_geometry.py
+++ b/web/python/_manim_shared_geometry.py
@@ -41,25 +41,68 @@ def _set_shared_color(self: _base.Mobject, color: object) -> None:
     _shared._set_color(self, parsed)
 
 
-def _set_x(self: _base.Mobject, x: float) -> _base.Mobject:
-    """Set the center x coordinate through Rust-owned ``move_to`` semantics."""
+def _coordinate_mask(dim: int) -> tuple[float, float, float]:
+    if isinstance(dim, bool) or not isinstance(dim, int):
+        raise TypeError("dim must be an integer")
+    if dim == 0:
+        return (1.0, 0.0, 0.0)
+    if dim == 1:
+        return (0.0, 1.0, 0.0)
+    raise NotImplementedError("Noon's shared 2D coordinate placement supports only x/y")
 
-    value = _shared._ir._finite_number("x", x)
+
+def _set_coord(
+    self: _base.Mobject,
+    value: float,
+    dim: int,
+    direction: object = _base.ORIGIN,
+) -> _base.Mobject:
+    """Set a directional coordinate through shared critical-point placement."""
+
+    coordinate = _shared._ir._finite_number("value", value)
+    mask = _coordinate_mask(dim)
+    point = _base.Vec2(coordinate if dim == 0 else 0.0, coordinate if dim == 1 else 0.0)
     return _shared._move_to(
         self,
-        _base.Vec2(value, 0.0),
-        coor_mask=(1.0, 0.0, 0.0),
+        point,
+        aligned_edge=direction,
+        coor_mask=mask,
     )
 
 
-def _set_y(self: _base.Mobject, y: float) -> _base.Mobject:
-    """Set the center y coordinate through Rust-owned ``move_to`` semantics."""
+def _set_x(
+    self: _base.Mobject,
+    x: float,
+    direction: object = _base.ORIGIN,
+) -> _base.Mobject:
+    """Set a directional x coordinate through shared ``set_coord`` semantics."""
 
-    value = _shared._ir._finite_number("y", y)
+    return _set_coord(self, x, 0, direction)
+
+
+def _set_y(
+    self: _base.Mobject,
+    y: float,
+    direction: object = _base.ORIGIN,
+) -> _base.Mobject:
+    """Set a directional y coordinate through shared ``set_coord`` semantics."""
+
+    return _set_coord(self, y, 1, direction)
+
+
+def _match_coord(
+    self: _base.Mobject,
+    mobject: _base.Mobject,
+    dim: int,
+    direction: object = _base.ORIGIN,
+) -> _base.Mobject:
+    """Match a directional coordinate through shared critical-point placement."""
+
     return _shared._move_to(
         self,
-        _base.Vec2(0.0, value),
-        coor_mask=(0.0, 1.0, 0.0),
+        mobject,
+        aligned_edge=direction,
+        coor_mask=_coordinate_mask(dim),
     )
 
 
@@ -68,14 +111,9 @@ def _match_x(
     mobject: _base.Mobject,
     direction: object = _base.ORIGIN,
 ) -> _base.Mobject:
-    """Match a directional x coordinate through shared ``move_to`` semantics."""
+    """Match a directional x coordinate through shared ``match_coord`` semantics."""
 
-    return _shared._move_to(
-        self,
-        mobject,
-        aligned_edge=direction,
-        coor_mask=(1.0, 0.0, 0.0),
-    )
+    return _match_coord(self, mobject, 0, direction)
 
 
 def _match_y(
@@ -83,14 +121,9 @@ def _match_y(
     mobject: _base.Mobject,
     direction: object = _base.ORIGIN,
 ) -> _base.Mobject:
-    """Match a directional y coordinate through shared ``move_to`` semantics."""
+    """Match a directional y coordinate through shared ``match_coord`` semantics."""
 
-    return _shared._move_to(
-        self,
-        mobject,
-        aligned_edge=direction,
-        coor_mask=(0.0, 1.0, 0.0),
-    )
+    return _match_coord(self, mobject, 1, direction)
 
 
 def _rotate_about_origin(
@@ -165,8 +198,10 @@ def install() -> None:
     if _INSTALLED:
         return
     _INSTALLED = True
+    _base.Mobject.set_coord = _set_coord
     _base.Mobject.set_x = _set_x
     _base.Mobject.set_y = _set_y
+    _base.Mobject.match_coord = _match_coord
     _base.Mobject.match_x = _match_x
     _base.Mobject.match_y = _match_y
     _base.Mobject.rotate_about_origin = _rotate_about_origin

--- a/web/python/test_manim_shared_coordinate_placement.py
+++ b/web/python/test_manim_shared_coordinate_placement.py
@@ -1,0 +1,141 @@
+import os
+import subprocess
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+
+
+class ManimSharedCoordinatePlacementTests(unittest.TestCase):
+    def test_directional_set_and_match_coord_use_shared_placement(self) -> None:
+        python_dir = Path(__file__).resolve().parent
+        env = os.environ.copy()
+        existing = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = (
+            str(python_dir)
+            if not existing
+            else os.pathsep.join((str(python_dir), existing))
+        )
+        source = textwrap.dedent(
+            r"""
+            import json
+            import sys
+            import types
+
+            fake_js = types.ModuleType("js")
+            point_calls = []
+            handle_calls = []
+
+            class FakeHandle:
+                def __init__(self, snapshot):
+                    self.snapshot = snapshot
+                def snapshotJson(self):
+                    return json.dumps(self.snapshot)
+                def setFillOpacity(self, value):
+                    if self.snapshot["style"]["fill"] is not None:
+                        self.snapshot["style"]["fill"]["alpha"] = float(value)
+                def setStrokeOpacity(self, value):
+                    if self.snapshot["style"]["stroke"] is not None:
+                        self.snapshot["style"]["stroke"]["alpha"] = float(value)
+                def shift(self, x, y):
+                    translation = self.snapshot["transform"]["translation"]
+                    translation["x"] += float(x)
+                    translation["y"] += float(y)
+                def _critical(self, edge_x, edge_y):
+                    translation = self.snapshot["transform"]["translation"]
+                    geometry = self.snapshot["geometry"]
+                    radius = float(geometry.get("circle", {}).get("radius", 0.0))
+                    return (
+                        float(translation["x"]) + (radius if edge_x > 0 else -radius if edge_x < 0 else 0.0),
+                        float(translation["y"]) + (radius if edge_y > 0 else -radius if edge_y < 0 else 0.0),
+                    )
+                def manimMoveToPoint(self, x, y, edge_x, edge_y, mask_x, mask_y):
+                    point_calls.append((
+                        float(x), float(y), float(edge_x), float(edge_y),
+                        float(mask_x), float(mask_y),
+                    ))
+                    current_x, current_y = self._critical(edge_x, edge_y)
+                    translation = self.snapshot["transform"]["translation"]
+                    if mask_x:
+                        translation["x"] += float(x) - current_x
+                    if mask_y:
+                        translation["y"] += float(y) - current_y
+                def manimMoveToHandle(self, other, edge_x, edge_y, mask_x, mask_y):
+                    handle_calls.append((
+                        float(edge_x), float(edge_y), float(mask_x), float(mask_y),
+                    ))
+                    current_x, current_y = self._critical(edge_x, edge_y)
+                    target_x, target_y = other._critical(edge_x, edge_y)
+                    translation = self.snapshot["transform"]["translation"]
+                    if mask_x:
+                        translation["x"] += target_x - current_x
+                    if mask_y:
+                        translation["y"] += target_y - current_y
+
+            def generic_snapshot(value):
+                return FakeHandle(json.loads(value))
+
+            fake_js.noonCreateAuthoringMobjectHandle = generic_snapshot
+            sys.modules["js"] = fake_js
+
+            import _manim_compat
+            _manim_compat.install()
+            import _manim_phase_b
+            import _manim_geometry
+            import _manim_semantic_handles as handles
+            handles.install()
+            import _manim_shared_geometry
+            _manim_shared_geometry.install()
+
+            from noon import Circle, RIGHT, UP
+
+            source = Circle(1.0).shift((-2.0, -1.0))
+            target = Circle(1.0).shift((4.0, 3.0))
+            fail = lambda *args, **kwargs: (_ for _ in ()).throw(
+                AssertionError("Python coordinate/critical-point placement was used")
+            )
+            source.get_critical_point = fail
+            target.get_critical_point = fail
+            source.get_coord = fail
+            target.get_coord = fail
+
+            assert source.set_x(5.0, RIGHT) is source
+            assert source.set_y(-4.0, UP) is source
+            assert source.match_coord(target, 0, RIGHT) is source
+            assert source.match_coord(target, 1, UP) is source
+
+            assert point_calls == [
+                (5.0, 0.0, 1.0, 0.0, 1.0, 0.0),
+                (0.0, -4.0, 0.0, 1.0, 0.0, 1.0),
+            ]
+            assert handle_calls == [
+                (1.0, 0.0, 1.0, 0.0),
+                (0.0, 1.0, 0.0, 1.0),
+            ]
+            assert source.transform["translation"] == {"x": 4.0, "y": 3.0}
+
+            try:
+                source.set_coord(1.0, 2)
+            except NotImplementedError as error:
+                assert "only x/y" in str(error)
+            else:
+                raise AssertionError("2D set_coord unexpectedly accepted z")
+            """
+        )
+        completed = subprocess.run(
+            [sys.executable, "-c", source],
+            cwd=python_dir,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(
+            completed.returncode,
+            0,
+            f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add Manim-compatible `Mobject.set_coord` and `match_coord` for the supported 2D axes
- restore the upstream `direction` parameter on `set_x` / `set_y`
- make `match_x` / `match_y` delegate through the same shared coordinate adapter
- reuse the existing Rust-owned `manim_move_to_point` / `manim_move_to_handle` critical-point placement; no Python bounds or coordinate math
- add a fake-WASM regression that makes Python `get_coord` / `get_critical_point` fatal and verifies exact directional point/handle calls

## Semantics
Manim v0.21 implements `set_coord(value, dim, direction)` as an axis-only shift from `get_coord(dim, direction)`. For x/y this is exactly equivalent to shared `move_to(point, aligned_edge=direction, coor_mask=axis_mask)`. `match_coord` is the same operation with another mobject as the target.

Noon remains explicitly 2D here: `dim=2` fails with a clear `NotImplementedError` rather than pretending to support z placement.

Replayed as one clean commit directly on current master `bbe68907` after #571 merged. The two file blobs are identical to the previously fully-green head; fresh exact-head CI is required before merge.

Tracks #74 and #61.