### PR TITLE
Expose retained native Text authoring

### DIFF
--- a/crates/noon/Cargo.toml
+++ b/crates/noon/Cargo.toml
@@ -8,7 +8,10 @@ description = "Ergonomic language-neutral authoring facade for Noon"
 [dependencies]
 noon-compile = { path = "../noon-compile" }
 noon-core = { path = "../noon-core" }
+noon-text-native = { path = "../noon-text-native" }
 noon-typst = { path = "../noon-typst" }
+swash = "=0.2.10"
+typst-assets = { version = "=0.15.1", features = ["fonts"] }
 
 [dev-dependencies]
 noon-ir = { path = "../noon-ir" }

--- a/crates/noon/src/lib.rs
+++ b/crates/noon/src/lib.rs
@@ -41,9 +41,10 @@ pub mod prelude {
         MovingCameraScene, Polygon, Polygram, PolygramAuthoringError, ReactiveScene,
         ReactiveTimelineScene, RegularPolygon, RegularPolygram, RetainedMobject, RetainedScene,
         RoundedRectangle, RoundedRectangleAuthoringError, Sector, ShapeMatcherAuthoringError, Star,
-        SurroundingRectangle, TextAuthoringError, Triangle, Typst, Underline, ValueTracker,
+        SurroundingRectangle, Text, TextAuthoringError, Triangle, Typst, Underline, ValueTracker,
         VectorSignal, BACKGROUND_RECTANGLE_DEFAULT_FILL_OPACITY, DEFAULT_CROSS_SCALE_FACTOR,
-        DEFAULT_CROSS_STROKE_WIDTH, DEFAULT_DOT_RADIUS, DEFAULT_ROUNDED_RECTANGLE_CORNER_RADIUS,
+        DEFAULT_CROSS_STROKE_WIDTH, DEFAULT_DOT_RADIUS, DEFAULT_NATIVE_TEXT_FONT_FAMILY,
+        DEFAULT_NATIVE_TEXT_FONT_SIZE, DEFAULT_ROUNDED_RECTANGLE_CORNER_RADIUS,
         DEFAULT_UNDERLINE_BUFF, SURROUNDING_RECTANGLE_DEFAULT_COLOR,
     };
     pub use noon_core::{

--- a/crates/noon/src/text_authoring.rs
+++ b/crates/noon/src/text_authoring.rs
@@ -1,9 +1,9 @@
-//! Retained Typst / MathTypst authoring over Noon's text resource model.
+//! Retained native Text / Typst / MathTypst authoring over Noon's text resource model.
 //!
 //! This module is deliberately separate from the legacy geometry-only `Scene`.
-//! Typst-backed objects enter the retained compiler as `ObjectContentRef::Text`
-//! and keep their shaped glyph/vector resources in explicit arenas; no placeholder
-//! geometry or SVG payload is introduced at the public authoring boundary.
+//! Text-backed objects enter the retained compiler as `ObjectContentRef::Text` and
+//! keep shaped glyph/vector resources in explicit arenas; no placeholder geometry,
+//! SVG payload, or frontend-owned glyph state is introduced at the authoring boundary.
 
 use std::sync::Arc;
 
@@ -13,13 +13,22 @@ use noon_core::{
     RetainedObjectDefinition, SceneDefinition, Style, TextResource, TextResourceArena,
     TextResourceValidationError, TextSourceKind, TrackDefinition, Transform2D, Vec2, WHITE,
 };
+use noon_text_native::{
+    NativeFontFace, NativeTextCompiler, NativeTextError, NativeTextOptions,
+    NativeTextResourceArtifact,
+};
 use noon_typst::{compile_typst_resource, TypstBackendError, TypstMode, TypstResourceArtifact};
+use swash::{FontRef, StringId};
 
-/// Manim's public text APIs scale imported layout geometry by font points rather
-/// than changing the layout backend's source. Keeping this as an object transform
-/// also keeps glyph/cluster identity stable when font size changes geometrically.
+/// Typst's retained artifact is authored at 10pt, so its public Manim-style font size
+/// remains an object transform and does not alter glyph/cluster identity.
 pub const SCALE_FACTOR_PER_FONT_POINT: f32 = 1.0 / 960.0;
+/// Native text is shaped at its requested point size, so only the point-to-scene
+/// conversion belongs in the object transform.
+pub const NATIVE_POINT_TO_SCENE_SCALE: f32 = 1.0 / 96.0;
 pub const DEFAULT_TYPST_FONT_SIZE: f32 = 48.0;
+pub const DEFAULT_NATIVE_TEXT_FONT_SIZE: f32 = 48.0;
+pub const DEFAULT_NATIVE_TEXT_FONT_FAMILY: &str = "DejaVu Sans Mono";
 
 /// Stable handle to one semantic object in a [`RetainedScene`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -34,25 +43,23 @@ impl RetainedMobject {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-struct TypstSpec {
-    source: Arc<str>,
-    font_size: f32,
+struct TextPresentation {
     color: Color,
     opacity: f32,
     transform: Transform2D,
 }
 
-impl TypstSpec {
-    fn new(source: impl Into<Arc<str>>) -> Self {
+impl Default for TextPresentation {
+    fn default() -> Self {
         Self {
-            source: source.into(),
-            font_size: DEFAULT_TYPST_FONT_SIZE,
             color: WHITE,
             opacity: 1.0,
             transform: Transform2D::default(),
         }
     }
+}
 
+impl TextPresentation {
     fn style(&self) -> Style {
         Style {
             fill: Some(self.color),
@@ -63,8 +70,32 @@ impl TypstSpec {
         }
     }
 
+    fn validate(&self) -> Result<(), TextAuthoringError> {
+        if !self.opacity.is_finite() || !(0.0..=1.0).contains(&self.opacity) {
+            return Err(TextAuthoringError::InvalidOpacity(self.opacity));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct TypstSpec {
+    source: Arc<str>,
+    font_size: f32,
+    presentation: TextPresentation,
+}
+
+impl TypstSpec {
+    fn new(source: impl Into<Arc<str>>) -> Self {
+        Self {
+            source: source.into(),
+            font_size: DEFAULT_TYPST_FONT_SIZE,
+            presentation: TextPresentation::default(),
+        }
+    }
+
     fn authored_transform(&self) -> Transform2D {
-        let mut transform = self.transform;
+        let mut transform = self.presentation.transform;
         let font_scale = self.font_size * SCALE_FACTOR_PER_FONT_POINT;
         transform.scale = transform
             .scale
@@ -97,40 +128,41 @@ macro_rules! typst_object {
             }
 
             pub fn color(mut self, color: Color) -> Self {
-                self.0.color = color;
+                self.0.presentation.color = color;
                 self
             }
 
             pub fn set_opacity(mut self, opacity: f32) -> Self {
-                self.0.opacity = opacity;
+                self.0.presentation.opacity = opacity;
                 self
             }
 
             pub fn shift(mut self, offset: Vec2) -> Self {
-                self.0.transform.translation += offset;
+                self.0.presentation.transform.translation += offset;
                 self
             }
 
             pub fn move_to(mut self, point: Vec2) -> Self {
-                self.0.transform.translation = point;
+                self.0.presentation.transform.translation = point;
                 self
             }
 
             pub fn scale(mut self, factor: f32) -> Self {
-                self.0.transform.scale = Vec2::new(
-                    self.0.transform.scale.x * factor,
-                    self.0.transform.scale.y * factor,
+                self.0.presentation.transform.scale = Vec2::new(
+                    self.0.presentation.transform.scale.x * factor,
+                    self.0.presentation.transform.scale.y * factor,
                 );
                 self
             }
 
             pub fn scale_xy(mut self, factor: Vec2) -> Self {
-                self.0.transform.scale = self.0.transform.scale.component_mul(factor);
+                self.0.presentation.transform.scale =
+                    self.0.presentation.transform.scale.component_mul(factor);
                 self
             }
 
             pub fn rotate(mut self, angle: f32) -> Self {
-                self.0.transform.rotation += angle;
+                self.0.presentation.transform.rotation += angle;
                 self
             }
 
@@ -138,10 +170,7 @@ macro_rules! typst_object {
                 if !self.0.font_size.is_finite() || self.0.font_size <= 0.0 {
                     return Err(TextAuthoringError::InvalidFontSize(self.0.font_size));
                 }
-                if !self.0.opacity.is_finite() || !(0.0..=1.0).contains(&self.0.opacity) {
-                    return Err(TextAuthoringError::InvalidOpacity(self.0.opacity));
-                }
-                Ok(())
+                self.0.presentation.validate()
             }
 
             fn compile(
@@ -175,7 +204,7 @@ macro_rules! typst_object {
             ) -> RetainedObjectDefinition {
                 let mut object = RetainedObjectDefinition::text(id, handle);
                 object.transform = self.0.authored_transform();
-                object.style = self.0.style();
+                object.style = self.0.presentation.style();
                 object
             }
         }
@@ -185,15 +214,185 @@ macro_rules! typst_object {
 typst_object!(Typst, TypstMode::Markup, TextSourceKind::Typst);
 typst_object!(MathTypst, TypstMode::Math, TextSourceKind::MathTypst);
 
+/// Native plain text authored through the same retained resource contract as Typst.
+///
+/// This first public slice intentionally exposes deterministic plain/multiline text.
+/// Styled spans, fallback chains, bidi/script itemization, and MarkupText remain
+/// backend follow-ups rather than being approximated in frontend wrappers.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Text {
+    source: Arc<str>,
+    font_family: Arc<str>,
+    font_size: f32,
+    line_spacing: f32,
+    presentation: TextPresentation,
+}
+
+impl Text {
+    pub fn new(source: impl Into<Arc<str>>) -> Self {
+        Self {
+            source: source.into(),
+            font_family: Arc::from(DEFAULT_NATIVE_TEXT_FONT_FAMILY),
+            font_size: DEFAULT_NATIVE_TEXT_FONT_SIZE,
+            line_spacing: -1.0,
+            presentation: TextPresentation::default(),
+        }
+    }
+
+    pub fn source(&self) -> &str {
+        self.source.as_ref()
+    }
+
+    pub fn font_family(&self) -> &str {
+        self.font_family.as_ref()
+    }
+
+    pub const fn font_size(&self) -> f32 {
+        self.font_size
+    }
+
+    pub const fn line_spacing(&self) -> f32 {
+        self.line_spacing
+    }
+
+    pub fn with_font(mut self, family: impl Into<Arc<str>>) -> Self {
+        self.font_family = family.into();
+        self
+    }
+
+    pub fn with_font_size(mut self, font_size: f32) -> Self {
+        self.font_size = font_size;
+        self
+    }
+
+    pub fn with_line_spacing(mut self, line_spacing: f32) -> Self {
+        self.line_spacing = line_spacing;
+        self
+    }
+
+    pub fn color(mut self, color: Color) -> Self {
+        self.presentation.color = color;
+        self
+    }
+
+    pub fn set_opacity(mut self, opacity: f32) -> Self {
+        self.presentation.opacity = opacity;
+        self
+    }
+
+    pub fn shift(mut self, offset: Vec2) -> Self {
+        self.presentation.transform.translation += offset;
+        self
+    }
+
+    pub fn move_to(mut self, point: Vec2) -> Self {
+        self.presentation.transform.translation = point;
+        self
+    }
+
+    pub fn scale(mut self, factor: f32) -> Self {
+        self.presentation.transform.scale = Vec2::new(
+            self.presentation.transform.scale.x * factor,
+            self.presentation.transform.scale.y * factor,
+        );
+        self
+    }
+
+    pub fn scale_xy(mut self, factor: Vec2) -> Self {
+        self.presentation.transform.scale = self.presentation.transform.scale.component_mul(factor);
+        self
+    }
+
+    pub fn rotate(mut self, angle: f32) -> Self {
+        self.presentation.transform.rotation += angle;
+        self
+    }
+
+    fn validate(&self) -> Result<(), TextAuthoringError> {
+        if !self.font_size.is_finite() || self.font_size <= 0.0 {
+            return Err(TextAuthoringError::InvalidFontSize(self.font_size));
+        }
+        self.presentation.validate()
+    }
+
+    fn compile_artifact(&self) -> Result<NativeTextResourceArtifact, TextAuthoringError> {
+        self.validate()?;
+        let font = bundled_native_font(self.font_family.as_ref())?;
+        let mut options = NativeTextOptions::new(self.font_size);
+        options.line_spacing = self.line_spacing;
+        options.fill = Some(self.presentation.color);
+        let mut compiler = NativeTextCompiler::new();
+        let artifact = compiler.compile_plain(self.source.as_ref(), &font, &options)?;
+        debug_assert_eq!(artifact.resource.kind, TextSourceKind::Plain);
+        Ok(artifact)
+    }
+
+    fn compile(
+        self,
+        scene: &mut RetainedScene,
+    ) -> Result<RetainedObjectDefinition, TextAuthoringError> {
+        let artifact = self.compile_artifact()?;
+        let handle = scene.import_native_text_artifact(artifact)?;
+        let id = scene.allocate_object_id()?;
+        Ok(self.retained_definition(id, handle))
+    }
+
+    fn compile_with_id(
+        self,
+        scene: &mut RetainedScene,
+        id: ObjectId,
+    ) -> Result<RetainedObjectDefinition, TextAuthoringError> {
+        let artifact = self.compile_artifact()?;
+        let handle = scene.import_native_text_artifact(artifact)?;
+        Ok(self.retained_definition(id, handle))
+    }
+
+    fn retained_definition(
+        &self,
+        id: ObjectId,
+        handle: noon_core::TextResourceHandle,
+    ) -> RetainedObjectDefinition {
+        let mut object = RetainedObjectDefinition::text(id, handle);
+        object.transform = self.presentation.transform;
+        object.transform.scale = object.transform.scale.component_mul(Vec2::new(
+            NATIVE_POINT_TO_SCENE_SCALE,
+            NATIVE_POINT_TO_SCENE_SCALE,
+        ));
+        object.style = self.presentation.style();
+        object
+    }
+}
+
+fn bundled_native_font(family: &str) -> Result<NativeFontFace, TextAuthoringError> {
+    for data in typst_assets::fonts() {
+        let Some(font) = FontRef::from_index(data, 0) else {
+            continue;
+        };
+        let matches = font.localized_strings().any(|name| {
+            matches!(
+                name.id(),
+                StringId::Family | StringId::TypographicFamily | StringId::WwsFamily
+            ) && name.to_string().eq_ignore_ascii_case(family)
+        });
+        if matches {
+            return NativeFontFace::new(Arc::<str>::from(family), Arc::<[u8]>::from(data), 0)
+                .map_err(TextAuthoringError::NativeText);
+        }
+    }
+    Err(TextAuthoringError::FontUnavailable(Arc::from(family)))
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum TextAuthoringError {
     InvalidFontSize(f32),
     InvalidOpacity(f32),
+    FontUnavailable(Arc<str>),
     MissingGeometryResource,
     MissingFontResource,
     DuplicateObject(ObjectId),
     InvalidPainterOrder { order: usize, object_count: usize },
     ObjectIdSpaceExhausted,
+    NativeText(NativeTextError),
     Typst(TypstBackendError),
     Font(FontResourceError),
     Text(TextResourceValidationError),
@@ -203,13 +402,19 @@ pub enum TextAuthoringError {
 impl std::fmt::Display for TextAuthoringError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::InvalidFontSize(value) => write!(formatter, "invalid Typst font size {value}"),
-            Self::InvalidOpacity(value) => write!(formatter, "invalid Typst opacity {value}"),
+            Self::InvalidFontSize(value) => write!(formatter, "invalid text font size {value}"),
+            Self::InvalidOpacity(value) => write!(formatter, "invalid text opacity {value}"),
+            Self::FontUnavailable(family) => {
+                write!(
+                    formatter,
+                    "bundled native font family {family:?} is unavailable"
+                )
+            }
             Self::MissingGeometryResource => {
-                formatter.write_str("Typst artifact references missing vector geometry")
+                formatter.write_str("text artifact references missing vector geometry")
             }
             Self::MissingFontResource => {
-                formatter.write_str("Typst artifact references missing font data")
+                formatter.write_str("text artifact references missing font data")
             }
             Self::DuplicateObject(id) => {
                 write!(formatter, "duplicate retained object id {}", id.get())
@@ -224,6 +429,7 @@ impl std::fmt::Display for TextAuthoringError {
             Self::ObjectIdSpaceExhausted => {
                 formatter.write_str("retained object ID space is exhausted")
             }
+            Self::NativeText(error) => error.fmt(formatter),
             Self::Typst(error) => error.fmt(formatter),
             Self::Font(error) => error.fmt(formatter),
             Self::Text(error) => error.fmt(formatter),
@@ -233,6 +439,12 @@ impl std::fmt::Display for TextAuthoringError {
 }
 
 impl std::error::Error for TextAuthoringError {}
+
+impl From<NativeTextError> for TextAuthoringError {
+    fn from(value: NativeTextError) -> Self {
+        Self::NativeText(value)
+    }
+}
 
 impl From<TypstBackendError> for TextAuthoringError {
     fn from(value: TypstBackendError) -> Self {
@@ -259,10 +471,6 @@ impl From<RetainedCompileError> for TextAuthoringError {
 }
 
 /// Public retained authoring container for resource-backed text/math objects.
-///
-/// The legacy `Scene` remains available for the serialized geometry path. This
-/// retained scene is the resource-aware path consumed by the retained compiler and
-/// mixed GPU renderer, and is intentionally backend-neutral after object insertion.
 #[derive(Clone, Debug, Default)]
 pub struct RetainedScene {
     objects: Vec<RetainedObjectDefinition>,
@@ -279,10 +487,6 @@ impl RetainedScene {
     }
 
     /// Lift an existing geometry-only scene into the retained object domain.
-    ///
-    /// Object IDs, painter order, and tracks are preserved exactly. Resource-backed
-    /// text can then be inserted into explicit painter slots without changing the
-    /// legacy scene serialization or its track references.
     pub fn from_legacy(scene: &SceneDefinition) -> Result<Self, TextAuthoringError> {
         let objects = scene
             .objects()
@@ -308,6 +512,11 @@ impl RetainedScene {
         })
     }
 
+    pub fn add_text(&mut self, object: Text) -> Result<RetainedMobject, TextAuthoringError> {
+        let object = object.compile(self)?;
+        Ok(self.push_object(object))
+    }
+
     pub fn add_typst(&mut self, object: Typst) -> Result<RetainedMobject, TextAuthoringError> {
         let object = object.compile(self)?;
         Ok(self.push_object(object))
@@ -319,6 +528,16 @@ impl RetainedScene {
     ) -> Result<RetainedMobject, TextAuthoringError> {
         let object = object.compile(self)?;
         Ok(self.push_object(object))
+    }
+
+    /// Insert native Text at an exact global painter slot using a caller-owned semantic ID.
+    pub fn insert_native_text_at(
+        &mut self,
+        order: usize,
+        id: ObjectId,
+        object: Text,
+    ) -> Result<RetainedMobject, TextAuthoringError> {
+        self.insert_text_at(order, id, |scene| object.compile_with_id(scene, id))
     }
 
     /// Insert Typst at an exact global painter slot using a caller-owned semantic ID.
@@ -417,17 +636,19 @@ impl RetainedScene {
             .ok_or(TextAuthoringError::ObjectIdSpaceExhausted)
     }
 
+    fn import_native_text_artifact(
+        &mut self,
+        artifact: NativeTextResourceArtifact,
+    ) -> Result<noon_core::TextResourceHandle, TextAuthoringError> {
+        self.import_font_dependencies(&artifact.resource, &artifact.fonts)?;
+        Ok(self.texts.insert(artifact.resource)?)
+    }
+
     fn import_typst_artifact(
         &mut self,
         artifact: TypstResourceArtifact,
     ) -> Result<noon_core::TextResourceHandle, TextAuthoringError> {
-        for run in artifact.resource.runs.iter() {
-            let resource = artifact
-                .fonts
-                .get_for_face(&run.font)
-                .ok_or(TextAuthoringError::MissingFontResource)?;
-            self.fonts.intern_face(&run.font, resource.data.clone())?;
-        }
+        self.import_font_dependencies(&artifact.resource, &artifact.fonts)?;
 
         let mut resource: TextResource = artifact.resource;
         let mut vectors = Vec::with_capacity(resource.vector_items.len());
@@ -443,12 +664,73 @@ impl RetainedScene {
         resource.vector_items = vectors.into();
         Ok(self.texts.insert(resource)?)
     }
+
+    fn import_font_dependencies(
+        &mut self,
+        resource: &TextResource,
+        fonts: &FontResourceArena,
+    ) -> Result<(), TextAuthoringError> {
+        for run in resource.runs.iter() {
+            let font = fonts
+                .get_for_face(&run.font)
+                .ok_or(TextAuthoringError::MissingFontResource)?;
+            self.fonts.intern_face(&run.font, font.data.clone())?;
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use noon_core::{GeometryRef, ObjectContentRef, RateFunction, TrackTiming};
+
+    #[test]
+    fn native_text_authors_retained_plain_text_without_geometry_placeholder() {
+        let mut scene = RetainedScene::new();
+        let object = scene
+            .add_text(Text::new("Native Noon").color(noon_core::YELLOW))
+            .unwrap();
+
+        assert_eq!(scene.objects().len(), 1);
+        let ObjectContentRef::Text(handle) = &scene.objects()[0].content else {
+            panic!("Text must author retained text content");
+        };
+        assert_eq!(object.id(), scene.objects()[0].id);
+        let resource = scene.texts().get(*handle).unwrap();
+        assert_eq!(resource.kind, TextSourceKind::Plain);
+        assert_eq!(resource.source.as_ref(), "Native Noon");
+        assert!(!scene.fonts().is_empty());
+        assert!(scene.objects()[0].content.geometry().is_none());
+    }
+
+    #[test]
+    fn native_multiline_text_preserves_backend_runs_and_source_identity() {
+        let mut scene = RetainedScene::new();
+        scene
+            .add_text(Text::new("first\nsecond").with_line_spacing(0.5))
+            .unwrap();
+        let handle = scene.objects()[0].content.text().unwrap();
+        let resource = scene.texts().get(handle).unwrap();
+        assert_eq!(resource.kind, TextSourceKind::Plain);
+        assert_eq!(resource.runs.len(), 2);
+        assert_eq!(resource.source.as_ref(), "first\nsecond");
+    }
+
+    #[test]
+    fn unavailable_native_font_fails_without_consuming_scene_identity_or_resources() {
+        let mut scene = RetainedScene::new();
+        let error = scene
+            .add_text(Text::new("Noon").with_font("Definitely Missing Font"))
+            .unwrap_err();
+        assert!(matches!(error, TextAuthoringError::FontUnavailable(_)));
+        assert!(scene.objects().is_empty());
+        assert!(scene.texts().is_empty());
+        assert!(scene.fonts().is_empty());
+
+        let object = scene.add_text(Text::new("first valid object")).unwrap();
+        assert_eq!(object.id(), ObjectId::new(0));
+    }
 
     #[test]
     fn typst_authors_one_retained_text_object_without_geometry_placeholder() {
@@ -497,18 +779,19 @@ mod tests {
     #[test]
     fn retained_scene_compiles_text_handles_without_copying_resources() {
         let mut scene = RetainedScene::new();
+        scene.add_text(Text::new("Plain")).unwrap();
         scene.add_typst(Typst::new("Noon")).unwrap();
         scene
             .add_math_typst(MathTypst::new("sum_(k=1)^n k"))
             .unwrap();
 
         let compiled = scene.compile().unwrap();
-        assert_eq!(compiled.objects().len(), 2);
+        assert_eq!(compiled.objects().len(), 3);
         assert!(compiled
             .objects()
             .iter()
             .all(|object| object.text().is_some()));
-        assert_eq!(scene.texts().len(), 2);
+        assert_eq!(scene.texts().len(), 3);
     }
 
     #[test]
@@ -539,6 +822,34 @@ mod tests {
         assert_eq!(compiled.object_index(circle), Some(0));
         assert_eq!(compiled.object_index(square), Some(1));
         assert_eq!(compiled.track_count(), legacy.tracks().len());
+    }
+
+    #[test]
+    fn explicit_native_text_insertion_reconstructs_mixed_global_painter_order() {
+        let mut legacy = SceneDefinition::new();
+        let circle = legacy.add(GeometryRef::circle(0.25));
+        let square = legacy.add(GeometryRef::rectangle(0.5, 0.5));
+        let text_id = ObjectId::new(1_u64 << 52);
+
+        let mut retained = RetainedScene::from_legacy(&legacy).unwrap();
+        let text = retained
+            .insert_native_text_at(1, text_id, Text::new("middle"))
+            .unwrap();
+
+        assert_eq!(text.id(), text_id);
+        assert_eq!(
+            retained
+                .objects()
+                .iter()
+                .map(|object| object.id)
+                .collect::<Vec<_>>(),
+            vec![circle, text_id, square]
+        );
+        let handle = retained.objects()[1].content.text().unwrap();
+        assert_eq!(
+            retained.texts().get(handle).unwrap().kind,
+            TextSourceKind::Plain
+        );
     }
 
     #[test]
@@ -614,7 +925,7 @@ mod tests {
         assert!(retained.fonts().is_empty());
 
         let duplicate_error = retained
-            .insert_typst_at(1, existing, Typst::new("duplicate"))
+            .insert_native_text_at(1, existing, Text::new("duplicate"))
             .unwrap_err();
         assert_eq!(
             duplicate_error,
@@ -627,6 +938,13 @@ mod tests {
     #[test]
     fn invalid_font_size_is_rejected_before_resource_insertion() {
         let mut scene = RetainedScene::new();
+        let error = scene
+            .add_text(Text::new("bad").with_font_size(0.0))
+            .unwrap_err();
+        assert_eq!(error, TextAuthoringError::InvalidFontSize(0.0));
+        assert!(scene.objects().is_empty());
+        assert!(scene.texts().is_empty());
+
         let error = scene
             .add_typst(Typst::new("bad").with_font_size(0.0))
             .unwrap_err();


### PR DESCRIPTION
## Summary
- expose public retained `Text` authoring backed by `noon-text-native`
- select deterministic bundled fonts by actual OpenType family metadata rather than host discovery or asset position
- retain exact font bytes in the shared font arena and insert plain text into the same retained object/painter stream as Typst
- support the current deterministic plain/multiline surface: font family, font size, line spacing, color/opacity, and ordinary transforms
- keep unsupported font selection explicit and transactional
- preserve existing Typst/MathTypst behavior while sharing font dependency import logic

## Architecture
This is the public Rust authoring slice of #364. It does not add Python glyph/layout semantics, a special renderer, placeholder geometry, or a new scene model. Python/JS adapters remain a subsequent narrow slice over the retained source-level authoring channel.

## Tests
Adds retained plain-text coverage for:
- no geometry placeholder
- multiline/source identity
- deterministic missing-font failure
- mixed geometry/text painter order
- resource compilation alongside Typst/MathTypst
- transactional invalid input/insertion

Related: #364, #361