### PR TITLE
Gate retained text object-update locality

### DIFF
--- a/crates/noon-text-render-wgpu/tests/retained_object_update_locality.rs
+++ b/crates/noon-text-render-wgpu/tests/retained_object_update_locality.rs
@@ -1,0 +1,96 @@
+use noon_core::{
+    ObjectContentRef, ObjectId, Style, TextResourceArena, Transform2D, Vec2,
+};
+use noon_runtime::{FrameChanges, RetainedFrameObjectState, RetainedFrameState};
+use noon_text_render_wgpu::{
+    RetainedTextIncrementalStats, RetainedTextQuadPreparer, TextDeviceMetrics,
+};
+use noon_typst::{compile_typst_resource, TypstMode};
+
+const OBJECT_COUNT: usize = 10_000;
+const UPDATE_FRAMES: usize = 128;
+const CHANGED_INDEX: usize = OBJECT_COUNT / 2;
+
+fn large_text_frame(text: noon_core::TextResourceHandle) -> RetainedFrameState {
+    let transform = Transform2D {
+        scale: Vec2::new(0.05, 0.05),
+        ..Transform2D::IDENTITY
+    };
+    RetainedFrameState {
+        time: 0.0,
+        objects: (0..OBJECT_COUNT)
+            .map(|index| RetainedFrameObjectState {
+                id: ObjectId::new(index as u64),
+                content: ObjectContentRef::Text(text),
+                transform,
+                style: Style::default(),
+                appearance: 1.0,
+            })
+            .collect(),
+        presences: vec![true; OBJECT_COUNT],
+        reveals: vec![1.0; OBJECT_COUNT],
+        morphs: vec![0.0; OBJECT_COUNT],
+        render_geometries: vec![None; OBJECT_COUNT],
+    }
+}
+
+#[test]
+fn one_changed_text_object_stays_object_local_after_warmup() {
+    let artifact = compile_typst_resource("A", TypstMode::Markup).unwrap();
+    let mut texts = TextResourceArena::new();
+    let text = texts.insert(artifact.resource).unwrap();
+    let mut frame = large_text_frame(text);
+    let metrics = TextDeviceMetrics::uniform(67.5).unwrap();
+    let (device, queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
+    let mut preparer = RetainedTextQuadPreparer::new(256).unwrap();
+
+    let prepared = preparer
+        .prepare_with_changes(
+            &device,
+            &queue,
+            &frame,
+            &FrameChanges::all(),
+            &texts,
+            &artifact.fonts,
+            metrics,
+        )
+        .unwrap();
+    assert_eq!(prepared.stats.text_objects, OBJECT_COUNT);
+    assert!(!prepared.mask_quads.is_empty());
+
+    let raster_after_warmup = preparer.raster_stats();
+    let atlas_after_warmup = preparer.atlas_stats();
+
+    for frame_index in 1..=UPDATE_FRAMES {
+        frame.time = frame_index as f64 / 60.0;
+        frame.objects[CHANGED_INDEX].transform.translation =
+            Vec2::new(frame_index as f32 * 0.01, -(frame_index as f32) * 0.005);
+        frame.objects[CHANGED_INDEX].style.opacity =
+            1.0 - (frame_index as f32 / UPDATE_FRAMES as f32) * 0.25;
+
+        preparer
+            .prepare_with_changes(
+                &device,
+                &queue,
+                &frame,
+                &FrameChanges::objects(vec![CHANGED_INDEX]),
+                &texts,
+                &artifact.fonts,
+                metrics,
+            )
+            .unwrap();
+    }
+
+    assert_eq!(preparer.raster_stats(), raster_after_warmup);
+    assert_eq!(preparer.atlas_stats(), atlas_after_warmup);
+    assert_eq!(
+        preparer.incremental_stats(),
+        RetainedTextIncrementalStats {
+            rebuild_attempts: 1,
+            reused_frames: 0,
+            object_update_frames: UPDATE_FRAMES as u64,
+            objects_updated: UPDATE_FRAMES as u64,
+            fallback_rebuilds: 0,
+        }
+    );
+}

--- a/crates/noon-text-render-wgpu/tests/retained_object_update_locality.rs
+++ b/crates/noon-text-render-wgpu/tests/retained_object_update_locality.rs
@@ -1,6 +1,4 @@
-use noon_core::{
-    ObjectContentRef, ObjectId, Style, TextResourceArena, Transform2D, Vec2,
-};
+use noon_core::{ObjectContentRef, ObjectId, Style, TextResourceArena, Transform2D, Vec2};
 use noon_runtime::{FrameChanges, RetainedFrameObjectState, RetainedFrameState};
 use noon_text_render_wgpu::{
     RetainedTextIncrementalStats, RetainedTextQuadPreparer, TextDeviceMetrics,


### PR DESCRIPTION
## Summary
- add a deterministic large-scene regression for the object-local path already implemented by `RetainedTextQuadPreparer`
- warm 10,000 retained text objects sharing one immutable text resource
- change exactly one object's translation/opacity for 128 logical frames
- require one initial rebuild, 128 object-local update frames, 128 total objects updated, and zero fallback rebuilds
- require raster/atlas stats to remain bit-for-bit unchanged after warmup

## Why this slice
#362's parent mixed renderer still has additional whole-frame work to remove, but the child text preparer already has an important O(dirty objects) contract. This gate makes that contract non-regressible before the parent scratch/order/upload layers are migrated incrementally.

The test uses deterministic operation/cache counters rather than wall-clock thresholds and introduces no production behavior or tolerance changes.

## Remaining #362 work
- preserve object-locality through the parent mixed scratch preparation path
- avoid global mixed painter-order reconstruction for non-structural changes
- upload only dirty GPU instance ranges
- add the reveal/outline-among-static-glyphs gate

Tracks #362 and #68.