### PR TITLE
Gate retained outline object locality

### DIFF
--- a/crates/noon-text-render-wgpu/tests/retained_object_update_locality.rs
+++ b/crates/noon-text-render-wgpu/tests/retained_object_update_locality.rs
@@ -1,7 +1,7 @@
 use noon_core::{ObjectContentRef, ObjectId, Style, TextResourceArena, Transform2D, Vec2};
 use noon_runtime::{FrameChanges, RetainedFrameObjectState, RetainedFrameState};
 use noon_text_render_wgpu::{
-    RetainedTextIncrementalStats, RetainedTextQuadPreparer, TextDeviceMetrics,
+    PreparedTextItem, RetainedTextIncrementalStats, RetainedTextQuadPreparer, TextDeviceMetrics,
 };
 use noon_typst::{compile_typst_resource, TypstMode};
 
@@ -77,6 +77,79 @@ fn one_changed_text_object_stays_object_local_after_warmup() {
                 metrics,
             )
             .unwrap();
+    }
+
+    assert_eq!(preparer.raster_stats(), raster_after_warmup);
+    assert_eq!(preparer.atlas_stats(), atlas_after_warmup);
+    assert_eq!(
+        preparer.incremental_stats(),
+        RetainedTextIncrementalStats {
+            rebuild_attempts: 1,
+            reused_frames: 0,
+            object_update_frames: UPDATE_FRAMES as u64,
+            objects_updated: UPDATE_FRAMES as u64,
+            fallback_rebuilds: 0,
+        }
+    );
+}
+
+#[test]
+fn one_resident_outline_object_stays_local_among_static_glyphs() {
+    let artifact = compile_typst_resource("A", TypstMode::Markup).unwrap();
+    let mut texts = TextResourceArena::new();
+    let text = texts.insert(artifact.resource).unwrap();
+    let mut frame = large_text_frame(text);
+    frame.reveals[CHANGED_INDEX] = 0.5;
+
+    let metrics = TextDeviceMetrics::uniform(67.5).unwrap();
+    let (device, queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
+    let mut preparer = RetainedTextQuadPreparer::new(256).unwrap();
+
+    let prepared = preparer
+        .prepare_with_changes(
+            &device,
+            &queue,
+            &frame,
+            &FrameChanges::all(),
+            &texts,
+            &artifact.fonts,
+            metrics,
+        )
+        .unwrap();
+    assert_eq!(prepared.stats.text_objects, OBJECT_COUNT);
+    assert_eq!(prepared.stats.outline_runs, 1);
+    assert!(prepared.items.iter().any(|item| matches!(
+        item,
+        PreparedTextItem::OutlineRun {
+            object_index,
+            reveal,
+            ..
+        } if *object_index as usize == CHANGED_INDEX && *reveal == 0.5
+    )));
+    assert!(!prepared.mask_quads.is_empty());
+
+    let raster_after_warmup = preparer.raster_stats();
+    let atlas_after_warmup = preparer.atlas_stats();
+
+    for frame_index in 1..=UPDATE_FRAMES {
+        frame.time = frame_index as f64 / 60.0;
+        frame.objects[CHANGED_INDEX].transform.translation =
+            Vec2::new(-(frame_index as f32) * 0.01, frame_index as f32 * 0.004);
+        frame.objects[CHANGED_INDEX].style.opacity =
+            1.0 - (frame_index as f32 / UPDATE_FRAMES as f32) * 0.2;
+
+        let prepared = preparer
+            .prepare_with_changes(
+                &device,
+                &queue,
+                &frame,
+                &FrameChanges::objects(vec![CHANGED_INDEX]),
+                &texts,
+                &artifact.fonts,
+                metrics,
+            )
+            .unwrap();
+        assert_eq!(prepared.stats.outline_runs, 1);
     }
 
     assert_eq!(preparer.raster_stats(), raster_after_warmup);


### PR DESCRIPTION
## Summary
- extend the existing #362 large-scene text locality gate with the remaining resident outline-path case
- warm 10,000 retained text objects sharing one immutable Typst resource, with exactly one object already in the outline lane via partial reveal
- update only that outline object's translation/opacity for 128 logical frames
- require exactly one outline run throughout, one object-local update per frame, zero fallback rebuilds, and bit-for-bit unchanged raster/atlas accounting after warmup

## Architecture
This is a deterministic structural regression only. It does not add renderer behavior, timing thresholds, cache policy, worker transport, or backend-specific tolerances. It specifically protects the already-supported case where an object remains resident in the outline lane while presentation state changes.

Changing `reveal`/`morph` so an object crosses glyph ↔ outline lane is still structurally incompatible with `RetainedTextQuadPreparer::can_update_objects` and intentionally falls back today; that remains substantive #362 work rather than being hidden by this gate.

Tracks #362 and #68.