### PR TITLE
Route Python Text through retained native resources

### DIFF
--- a/crates/noon-web/src/retained_authoring.rs
+++ b/crates/noon-web/src/retained_authoring.rs
@@ -7,14 +7,27 @@ use serde::{Deserialize, Serialize};
 ///
 /// This channel deliberately carries source-level retained text definitions rather
 /// than shaped glyphs, font bytes, SVG, or placeholder geometry. The receiving
-/// runtime compiles each definition once into the ordinary retained resource arenas.
+/// runtime selects the backend compiler and installs its normalized resources into
+/// the ordinary retained arenas.
 pub const RETAINED_AUTHORING_CHANNEL: &str = "noon.authoring.retained";
-pub const RETAINED_AUTHORING_VERSION: u32 = 1;
+pub const RETAINED_AUTHORING_VERSION: u32 = 2;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct RetainedTypstAuthoringSpec {
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum RetainedTextBackendSpec {
+    Native {
+        font_family: String,
+        line_spacing: f32,
+    },
+    Typst {
+        math: bool,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct RetainedTextAuthoringSpec {
     pub source: String,
-    pub math: bool,
+    pub backend: RetainedTextBackendSpec,
     pub font_size: f32,
     #[serde(default)]
     pub transform: Transform2D,
@@ -24,11 +37,39 @@ pub struct RetainedTypstAuthoringSpec {
     pub opacity: f32,
 }
 
-impl RetainedTypstAuthoringSpec {
+/// Source-compatible Rust alias retained while the browser sidecar migrates from
+/// its original Typst-only shape to the backend-neutral text wire.
+pub type RetainedTypstAuthoringSpec = RetainedTextAuthoringSpec;
+
+impl RetainedTextAuthoringSpec {
+    /// Construct a Typst/MathTypst source definition.
     pub fn new(source: impl Into<String>, math: bool, font_size: f32) -> Result<Self, String> {
         let spec = Self {
             source: source.into(),
-            math,
+            backend: RetainedTextBackendSpec::Typst { math },
+            font_size,
+            transform: Transform2D::default(),
+            color: WHITE,
+            opacity: 1.0,
+        };
+        spec.validate()?;
+        Ok(spec)
+    }
+
+    /// Construct a native plain-text definition. Font lookup and shaping remain
+    /// Rust-owned; the wire carries only deterministic source-level policy.
+    pub fn native(
+        source: impl Into<String>,
+        font_family: impl Into<String>,
+        font_size: f32,
+        line_spacing: f32,
+    ) -> Result<Self, String> {
+        let spec = Self {
+            source: source.into(),
+            backend: RetainedTextBackendSpec::Native {
+                font_family: font_family.into(),
+                line_spacing,
+            },
             font_size,
             transform: Transform2D::default(),
             color: WHITE,
@@ -39,14 +80,34 @@ impl RetainedTypstAuthoringSpec {
     }
 
     pub fn validate(&self) -> Result<(), String> {
-        if self.source.is_empty() {
-            return Err("retained Typst source must not be empty".to_owned());
-        }
         if !self.font_size.is_finite() || self.font_size <= 0.0 {
-            return Err("retained Typst font_size must be finite and positive".to_owned());
+            return Err("retained text font_size must be finite and positive".to_owned());
+        }
+        match &self.backend {
+            RetainedTextBackendSpec::Native {
+                font_family,
+                line_spacing,
+            } => {
+                if font_family.trim().is_empty() {
+                    return Err("retained native text font_family must not be empty".to_owned());
+                }
+                if !line_spacing.is_finite()
+                    || (*line_spacing != -1.0 && *line_spacing <= -1.0)
+                {
+                    return Err(
+                        "retained native text line_spacing must be -1 or greater than -1"
+                            .to_owned(),
+                    );
+                }
+            }
+            RetainedTextBackendSpec::Typst { .. } => {
+                if self.source.is_empty() {
+                    return Err("retained Typst source must not be empty".to_owned());
+                }
+            }
         }
         if !self.opacity.is_finite() || !(0.0..=1.0).contains(&self.opacity) {
-            return Err("retained Typst opacity must be finite and between 0 and 1".to_owned());
+            return Err("retained text opacity must be finite and between 0 and 1".to_owned());
         }
         let transform = self.transform;
         let values = [
@@ -61,14 +122,14 @@ impl RetainedTypstAuthoringSpec {
             self.color.alpha,
         ];
         if values.iter().any(|value| !value.is_finite()) {
-            return Err("retained Typst transform/color must be finite".to_owned());
+            return Err("retained text transform/color must be finite".to_owned());
         }
         Ok(())
     }
 
     pub fn shift(&mut self, offset: Vec2) -> Result<(), String> {
         if !offset.x.is_finite() || !offset.y.is_finite() {
-            return Err("retained Typst shift must be finite".to_owned());
+            return Err("retained text shift must be finite".to_owned());
         }
         self.transform.translation += offset;
         Ok(())
@@ -76,7 +137,7 @@ impl RetainedTypstAuthoringSpec {
 
     pub fn move_to(&mut self, point: Vec2) -> Result<(), String> {
         if !point.x.is_finite() || !point.y.is_finite() {
-            return Err("retained Typst position must be finite".to_owned());
+            return Err("retained text position must be finite".to_owned());
         }
         self.transform.translation = point;
         Ok(())
@@ -84,7 +145,7 @@ impl RetainedTypstAuthoringSpec {
 
     pub fn scale(&mut self, factor: f32) -> Result<(), String> {
         if !factor.is_finite() || factor <= 0.0 {
-            return Err("retained Typst scale factor must be finite and positive".to_owned());
+            return Err("retained text scale factor must be finite and positive".to_owned());
         }
         self.transform.scale = self
             .transform
@@ -95,7 +156,7 @@ impl RetainedTypstAuthoringSpec {
 
     pub fn rotate(&mut self, angle: f32) -> Result<(), String> {
         if !angle.is_finite() {
-            return Err("retained Typst rotation must be finite".to_owned());
+            return Err("retained text rotation must be finite".to_owned());
         }
         self.transform.rotation += angle;
         Ok(())
@@ -103,7 +164,7 @@ impl RetainedTypstAuthoringSpec {
 
     pub fn set_opacity(&mut self, opacity: f32) -> Result<(), String> {
         if !opacity.is_finite() || !(0.0..=1.0).contains(&opacity) {
-            return Err("retained Typst opacity must be finite and between 0 and 1".to_owned());
+            return Err("retained text opacity must be finite and between 0 and 1".to_owned());
         }
         self.opacity = opacity;
         Ok(())
@@ -114,7 +175,7 @@ impl RetainedTypstAuthoringSpec {
             .iter()
             .any(|value| !value.is_finite())
         {
-            return Err("retained Typst color must be finite".to_owned());
+            return Err("retained text color must be finite".to_owned());
         }
         self.color = color;
         Ok(())
@@ -123,11 +184,11 @@ impl RetainedTypstAuthoringSpec {
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct RetainedAuthoringTextObject {
-    /// Stable semantic identity. V1 keeps this independent of renderer-local slots.
+    /// Stable semantic identity, independent of renderer-local resource slots.
     pub object: ObjectId,
-    /// Global painter order shared with ordinary geometry at the eventual mixed lowering boundary.
+    /// Global painter order shared with ordinary geometry.
     pub order: u32,
-    pub text: RetainedTypstAuthoringSpec,
+    pub text: RetainedTextAuthoringSpec,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -209,13 +270,9 @@ mod wasm {
     use wasm_bindgen::prelude::*;
 
     /// Rust-owned semantic handle used by thin Python/JS Typst wrappers.
-    ///
-    /// Authoring mutations update this handle directly. `specJson()` is only the
-    /// cross-worker source definition; it never contains glyphs, font bytes, SVG,
-    /// vectorized glyph outlines, or renderer-local atlas state.
     #[wasm_bindgen(js_name = RetainedTypstAuthoringHandle)]
     pub struct WasmRetainedTypstAuthoringHandle {
-        inner: RetainedTypstAuthoringSpec,
+        inner: RetainedTextAuthoringSpec,
     }
 
     #[wasm_bindgen(js_class = RetainedTypstAuthoringHandle)]
@@ -223,8 +280,7 @@ mod wasm {
         #[wasm_bindgen(constructor)]
         pub fn new(source: &str, math: bool, font_size: f32) -> Result<Self, JsValue> {
             Ok(Self {
-                inner: RetainedTypstAuthoringSpec::new(source, math, font_size)
-                    .map_err(js_error)?,
+                inner: RetainedTextAuthoringSpec::new(source, math, font_size).map_err(js_error)?,
             })
         }
 
@@ -235,7 +291,106 @@ mod wasm {
 
         #[wasm_bindgen(getter)]
         pub fn math(&self) -> bool {
-            self.inner.math
+            match &self.inner.backend {
+                RetainedTextBackendSpec::Typst { math } => *math,
+                RetainedTextBackendSpec::Native { .. } => unreachable!("Typst handle backend"),
+            }
+        }
+
+        #[wasm_bindgen(getter, js_name = fontSize)]
+        pub fn font_size(&self) -> f32 {
+            self.inner.font_size
+        }
+
+        #[wasm_bindgen(js_name = shift)]
+        pub fn shift(&mut self, x: f32, y: f32) -> Result<(), JsValue> {
+            self.inner.shift(Vec2::new(x, y)).map_err(js_error)
+        }
+
+        #[wasm_bindgen(js_name = moveTo)]
+        pub fn move_to(&mut self, x: f32, y: f32) -> Result<(), JsValue> {
+            self.inner.move_to(Vec2::new(x, y)).map_err(js_error)
+        }
+
+        pub fn scale(&mut self, factor: f32) -> Result<(), JsValue> {
+            self.inner.scale(factor).map_err(js_error)
+        }
+
+        pub fn rotate(&mut self, angle: f32) -> Result<(), JsValue> {
+            self.inner.rotate(angle).map_err(js_error)
+        }
+
+        #[wasm_bindgen(js_name = setOpacity)]
+        pub fn set_opacity(&mut self, opacity: f32) -> Result<(), JsValue> {
+            self.inner.set_opacity(opacity).map_err(js_error)
+        }
+
+        #[wasm_bindgen(js_name = setColor)]
+        pub fn set_color(
+            &mut self,
+            red: f32,
+            green: f32,
+            blue: f32,
+            alpha: f32,
+        ) -> Result<(), JsValue> {
+            self.inner
+                .set_color(Color::rgba(red, green, blue, alpha))
+                .map_err(js_error)
+        }
+
+        #[wasm_bindgen(js_name = specJson)]
+        pub fn spec_json(&self) -> Result<String, JsValue> {
+            self.inner.validate().map_err(js_error)?;
+            serde_json::to_string(&self.inner).map_err(js_error)
+        }
+    }
+
+    /// Rust-owned source handle for native plain text. Font discovery, shaping,
+    /// exact font bytes, glyphs, and atlas state never cross into Python.
+    #[wasm_bindgen(js_name = RetainedNativeTextAuthoringHandle)]
+    pub struct WasmRetainedNativeTextAuthoringHandle {
+        inner: RetainedTextAuthoringSpec,
+    }
+
+    #[wasm_bindgen(js_class = RetainedNativeTextAuthoringHandle)]
+    impl WasmRetainedNativeTextAuthoringHandle {
+        #[wasm_bindgen(constructor)]
+        pub fn new(
+            source: &str,
+            font_family: &str,
+            font_size: f32,
+            line_spacing: f32,
+        ) -> Result<Self, JsValue> {
+            Ok(Self {
+                inner: RetainedTextAuthoringSpec::native(
+                    source,
+                    font_family,
+                    font_size,
+                    line_spacing,
+                )
+                .map_err(js_error)?,
+            })
+        }
+
+        #[wasm_bindgen(getter)]
+        pub fn source(&self) -> String {
+            self.inner.source.clone()
+        }
+
+        #[wasm_bindgen(getter, js_name = fontFamily)]
+        pub fn font_family(&self) -> String {
+            match &self.inner.backend {
+                RetainedTextBackendSpec::Native { font_family, .. } => font_family.clone(),
+                RetainedTextBackendSpec::Typst { .. } => unreachable!("native text handle backend"),
+            }
+        }
+
+        #[wasm_bindgen(getter, js_name = lineSpacing)]
+        pub fn line_spacing(&self) -> f32 {
+            match &self.inner.backend {
+                RetainedTextBackendSpec::Native { line_spacing, .. } => *line_spacing,
+                RetainedTextBackendSpec::Typst { .. } => unreachable!("native text handle backend"),
+            }
         }
 
         #[wasm_bindgen(getter, js_name = fontSize)]
@@ -306,54 +461,93 @@ mod tests {
     use super::*;
 
     #[test]
-    fn typst_handle_wire_spec_stays_source_level() {
-        let mut spec =
-            RetainedTypstAuthoringSpec::new("*Hello* from _Typst!_", false, 96.0).unwrap();
-        spec.shift(Vec2::new(1.0, -2.0)).unwrap();
-        let json = serde_json::to_string(&spec).unwrap();
-        assert!(json.contains("*Hello* from _Typst!_"));
-        assert!(!json.contains("glyph"));
-        assert!(!json.contains("font_bytes"));
-        assert!(!json.contains("svg"));
-        assert!(!json.contains("geometry"));
-        let round_trip: RetainedTypstAuthoringSpec = serde_json::from_str(&json).unwrap();
-        assert_eq!(round_trip, spec);
+    fn backend_neutral_wire_stays_source_level() {
+        let mut native = RetainedTextAuthoringSpec::native(
+            "Native Noon",
+            "DejaVu Sans Mono",
+            48.0,
+            -1.0,
+        )
+        .unwrap();
+        native.shift(Vec2::new(1.0, -2.0)).unwrap();
+        let typst = RetainedTextAuthoringSpec::new("*Hello* from _Typst!_", false, 96.0).unwrap();
+        for spec in [native, typst] {
+            let json = serde_json::to_string(&spec).unwrap();
+            assert!(!json.contains("glyph"));
+            assert!(!json.contains("font_bytes"));
+            assert!(!json.contains("svg"));
+            assert!(!json.contains("geometry"));
+            let round_trip: RetainedTextAuthoringSpec = serde_json::from_str(&json).unwrap();
+            assert_eq!(round_trip, spec);
+        }
     }
 
     #[test]
-    fn math_typst_identity_is_explicit_on_wire() {
-        let spec =
-            RetainedTypstAuthoringSpec::new("sum_(k=1)^n k = (n(n + 1)) / 2", true, 72.0).unwrap();
-        assert!(spec.math);
-        assert_eq!(spec.font_size, 72.0);
+    fn backend_identity_is_explicit_on_wire() {
+        let native = RetainedTextAuthoringSpec::native(
+            "Noon",
+            "DejaVu Sans Mono",
+            48.0,
+            0.3,
+        )
+        .unwrap();
+        assert!(matches!(
+            native.backend,
+            RetainedTextBackendSpec::Native {
+                ref font_family,
+                line_spacing: 0.3,
+            } if font_family == "DejaVu Sans Mono"
+        ));
+        let math =
+            RetainedTextAuthoringSpec::new("sum_(k=1)^n k = (n(n + 1)) / 2", true, 72.0)
+                .unwrap();
+        assert!(matches!(
+            math.backend,
+            RetainedTextBackendSpec::Typst { math: true }
+        ));
     }
 
     #[test]
-    fn document_preserves_semantic_identity_and_global_order() {
+    fn document_preserves_semantic_identity_global_order_and_backends() {
         let document = RetainedAuthoringDocument::new(vec![
             RetainedAuthoringTextObject {
                 object: ObjectId::new(9),
                 order: 1,
-                text: RetainedTypstAuthoringSpec::new("B", false, 48.0).unwrap(),
+                text: RetainedTextAuthoringSpec::native(
+                    "B",
+                    "DejaVu Sans Mono",
+                    48.0,
+                    -1.0,
+                )
+                .unwrap(),
             },
             RetainedAuthoringTextObject {
                 object: ObjectId::new(4),
                 order: 0,
-                text: RetainedTypstAuthoringSpec::new("A", false, 48.0).unwrap(),
+                text: RetainedTextAuthoringSpec::new("A", false, 48.0).unwrap(),
             },
         ])
         .unwrap();
+        assert_eq!(document.protocol_version, 2);
         let round_trip =
             RetainedAuthoringDocument::from_json(&document.to_json().unwrap()).unwrap();
         assert_eq!(round_trip.objects[0].object, ObjectId::new(9));
         assert_eq!(round_trip.objects[0].order, 1);
+        assert!(matches!(
+            round_trip.objects[0].text.backend,
+            RetainedTextBackendSpec::Native { .. }
+        ));
         assert_eq!(round_trip.objects[1].object, ObjectId::new(4));
         assert_eq!(round_trip.objects[1].order, 0);
+        assert!(matches!(
+            round_trip.objects[1].text.backend,
+            RetainedTextBackendSpec::Typst { math: false }
+        ));
     }
 
     #[test]
     fn duplicate_identity_or_order_is_rejected() {
-        let spec = RetainedTypstAuthoringSpec::new("A", false, 48.0).unwrap();
+        let spec = RetainedTextAuthoringSpec::new("A", false, 48.0).unwrap();
         assert!(RetainedAuthoringDocument::new(vec![
             RetainedAuthoringTextObject {
                 object: ObjectId::new(1),

--- a/crates/noon-web/src/retained_authoring.rs
+++ b/crates/noon-web/src/retained_authoring.rs
@@ -91,7 +91,7 @@ impl RetainedTextAuthoringSpec {
                 if font_family.trim().is_empty() {
                     return Err("retained native text font_family must not be empty".to_owned());
                 }
-                if !line_spacing.is_finite() || (*line_spacing != -1.0 && *line_spacing <= -1.0) {
+                if !line_spacing.is_finite() || *line_spacing < -1.0 {
                     return Err(
                         "retained native text line_spacing must be -1 or greater than -1"
                             .to_owned(),

--- a/crates/noon-web/src/retained_authoring.rs
+++ b/crates/noon-web/src/retained_authoring.rs
@@ -91,9 +91,7 @@ impl RetainedTextAuthoringSpec {
                 if font_family.trim().is_empty() {
                     return Err("retained native text font_family must not be empty".to_owned());
                 }
-                if !line_spacing.is_finite()
-                    || (*line_spacing != -1.0 && *line_spacing <= -1.0)
-                {
+                if !line_spacing.is_finite() || (*line_spacing != -1.0 && *line_spacing <= -1.0) {
                     return Err(
                         "retained native text line_spacing must be -1 or greater than -1"
                             .to_owned(),
@@ -462,13 +460,9 @@ mod tests {
 
     #[test]
     fn backend_neutral_wire_stays_source_level() {
-        let mut native = RetainedTextAuthoringSpec::native(
-            "Native Noon",
-            "DejaVu Sans Mono",
-            48.0,
-            -1.0,
-        )
-        .unwrap();
+        let mut native =
+            RetainedTextAuthoringSpec::native("Native Noon", "DejaVu Sans Mono", 48.0, -1.0)
+                .unwrap();
         native.shift(Vec2::new(1.0, -2.0)).unwrap();
         let typst = RetainedTextAuthoringSpec::new("*Hello* from _Typst!_", false, 96.0).unwrap();
         for spec in [native, typst] {
@@ -484,13 +478,8 @@ mod tests {
 
     #[test]
     fn backend_identity_is_explicit_on_wire() {
-        let native = RetainedTextAuthoringSpec::native(
-            "Noon",
-            "DejaVu Sans Mono",
-            48.0,
-            0.3,
-        )
-        .unwrap();
+        let native =
+            RetainedTextAuthoringSpec::native("Noon", "DejaVu Sans Mono", 48.0, 0.3).unwrap();
         assert!(matches!(
             native.backend,
             RetainedTextBackendSpec::Native {
@@ -499,8 +488,7 @@ mod tests {
             } if font_family == "DejaVu Sans Mono"
         ));
         let math =
-            RetainedTextAuthoringSpec::new("sum_(k=1)^n k = (n(n + 1)) / 2", true, 72.0)
-                .unwrap();
+            RetainedTextAuthoringSpec::new("sum_(k=1)^n k = (n(n + 1)) / 2", true, 72.0).unwrap();
         assert!(matches!(
             math.backend,
             RetainedTextBackendSpec::Typst { math: true }
@@ -513,13 +501,8 @@ mod tests {
             RetainedAuthoringTextObject {
                 object: ObjectId::new(9),
                 order: 1,
-                text: RetainedTextAuthoringSpec::native(
-                    "B",
-                    "DejaVu Sans Mono",
-                    48.0,
-                    -1.0,
-                )
-                .unwrap(),
+                text: RetainedTextAuthoringSpec::native("B", "DejaVu Sans Mono", 48.0, -1.0)
+                    .unwrap(),
             },
             RetainedAuthoringTextObject {
                 object: ObjectId::new(4),

--- a/crates/noon-web/src/retained_authoring_scene.rs
+++ b/crates/noon-web/src/retained_authoring_scene.rs
@@ -1,9 +1,12 @@
 use std::collections::HashSet;
 
-use noon::{MathTypst, RetainedScene, TextAuthoringError, Typst};
+use noon::{MathTypst, RetainedScene, Text as NativeText, TextAuthoringError, Typst};
 use noon_core::{ObjectId, SceneDefinition};
 
-use crate::{RetainedAuthoringDocument, RetainedAuthoringTextObject, RetainedTypstAuthoringSpec};
+use crate::{
+    RetainedAuthoringDocument, RetainedAuthoringTextObject, RetainedTextAuthoringSpec,
+    RetainedTextBackendSpec,
+};
 
 /// One resource-aware scene assembled from the legacy geometry document and the
 /// retained text sidecar emitted by Python authoring.
@@ -154,33 +157,54 @@ fn insert_text_object(
 ) -> Result<(), MixedRetainedAuthoringError> {
     let order = object.order as usize;
     let id = object.object;
-    let spec = object.text;
-    if spec.math {
-        scene.insert_math_typst_at(order, id, math_typst_from_spec(spec))?;
-    } else {
-        scene.insert_typst_at(order, id, typst_from_spec(spec))?;
+    let RetainedTextAuthoringSpec {
+        source,
+        backend,
+        font_size,
+        transform,
+        color,
+        opacity,
+    } = object.text;
+
+    match backend {
+        RetainedTextBackendSpec::Native {
+            font_family,
+            line_spacing,
+        } => {
+            let text = NativeText::new(source)
+                .with_font(font_family)
+                .with_font_size(font_size)
+                .with_line_spacing(line_spacing)
+                .color(color)
+                .set_opacity(opacity)
+                .move_to(transform.translation)
+                .scale_xy(transform.scale)
+                .rotate(transform.rotation);
+            scene.insert_native_text_at(order, id, text)?;
+        }
+        RetainedTextBackendSpec::Typst { math } => {
+            if math {
+                let text = MathTypst::new(source)
+                    .with_font_size(font_size)
+                    .color(color)
+                    .set_opacity(opacity)
+                    .move_to(transform.translation)
+                    .scale_xy(transform.scale)
+                    .rotate(transform.rotation);
+                scene.insert_math_typst_at(order, id, text)?;
+            } else {
+                let text = Typst::new(source)
+                    .with_font_size(font_size)
+                    .color(color)
+                    .set_opacity(opacity)
+                    .move_to(transform.translation)
+                    .scale_xy(transform.scale)
+                    .rotate(transform.rotation);
+                scene.insert_typst_at(order, id, text)?;
+            }
+        }
     }
     Ok(())
-}
-
-fn typst_from_spec(spec: RetainedTypstAuthoringSpec) -> Typst {
-    Typst::new(spec.source)
-        .with_font_size(spec.font_size)
-        .color(spec.color)
-        .set_opacity(spec.opacity)
-        .move_to(spec.transform.translation)
-        .scale_xy(spec.transform.scale)
-        .rotate(spec.transform.rotation)
-}
-
-fn math_typst_from_spec(spec: RetainedTypstAuthoringSpec) -> MathTypst {
-    MathTypst::new(spec.source)
-        .with_font_size(spec.font_size)
-        .color(spec.color)
-        .set_opacity(spec.opacity)
-        .move_to(spec.transform.translation)
-        .scale_xy(spec.transform.scale)
-        .rotate(spec.transform.rotation)
 }
 
 #[cfg(test)]
@@ -193,18 +217,28 @@ mod tests {
         RetainedAuthoringDocument::new(objects).unwrap()
     }
 
-    fn typst_spec(source: &str, math: bool, font_size: f32) -> RetainedTypstAuthoringSpec {
-        RetainedTypstAuthoringSpec::new(source, math, font_size).unwrap()
+    fn typst_spec(source: &str, math: bool, font_size: f32) -> RetainedTextAuthoringSpec {
+        RetainedTextAuthoringSpec::new(source, math, font_size).unwrap()
+    }
+
+    fn native_spec(source: &str, font_size: f32) -> RetainedTextAuthoringSpec {
+        RetainedTextAuthoringSpec::native(
+            source,
+            noon::DEFAULT_NATIVE_TEXT_FONT_FAMILY,
+            font_size,
+            -1.0,
+        )
+        .unwrap()
     }
 
     #[test]
-    fn text_only_authoring_decodes_into_one_retained_text_object() {
+    fn native_text_only_authoring_decodes_into_one_retained_plain_text_object() {
         let legacy = SceneDefinition::new();
         let text_id = ObjectId::new(1_u64 << 52);
         let retained = retained_document(vec![RetainedAuthoringTextObject {
             object: text_id,
             order: 0,
-            text: typst_spec("*Hello* from _Typst!_", false, 96.0),
+            text: native_spec("Native Noon", 48.0),
         }]);
 
         let mixed = MixedRetainedAuthoringScene::from_json(
@@ -215,14 +249,14 @@ mod tests {
         assert_eq!(mixed.scene().objects().len(), 1);
         assert_eq!(mixed.scene().objects()[0].id, text_id);
         let handle = mixed.scene().objects()[0].content.text().unwrap();
-        assert_eq!(
-            mixed.scene().texts().get(handle).unwrap().kind,
-            TextSourceKind::Typst
-        );
+        let resource = mixed.scene().texts().get(handle).unwrap();
+        assert_eq!(resource.kind, TextSourceKind::Plain);
+        assert_eq!(resource.source.as_ref(), "Native Noon");
+        assert!(!mixed.scene().fonts().is_empty());
     }
 
     #[test]
-    fn mixed_document_reconstructs_geometry_text_geometry_painter_order() {
+    fn mixed_document_reconstructs_geometry_native_text_geometry_painter_order() {
         let mut legacy = SceneDefinition::new();
         let circle = legacy.add(GeometryRef::circle(0.25));
         let square = legacy.add(GeometryRef::rectangle(0.5, 0.5));
@@ -230,7 +264,7 @@ mod tests {
         let retained = retained_document(vec![RetainedAuthoringTextObject {
             object: text_id,
             order: 1,
-            text: typst_spec("middle", false, 48.0),
+            text: native_spec("middle", 48.0),
         }]);
 
         let mixed = MixedRetainedAuthoringScene::from_parts(&legacy, retained).unwrap();
@@ -255,6 +289,11 @@ mod tests {
             mixed.scene().objects()[2].content,
             ObjectContentRef::Geometry(_)
         ));
+        let handle = mixed.scene().objects()[1].content.text().unwrap();
+        assert_eq!(
+            mixed.scene().texts().get(handle).unwrap().kind,
+            TextSourceKind::Plain
+        );
 
         let compiled = mixed.scene().compile().unwrap();
         assert_eq!(compiled.object_index(circle), Some(0));
@@ -312,7 +351,7 @@ mod tests {
         let retained = retained_document(vec![RetainedAuthoringTextObject {
             object: ObjectId::new(1_u64 << 52),
             order: 2,
-            text: typst_spec("outside", false, 48.0),
+            text: native_spec("outside", 48.0),
         }]);
 
         let error = MixedRetainedAuthoringScene::from_parts(&legacy, retained).unwrap_err();
@@ -332,7 +371,7 @@ mod tests {
         let retained = retained_document(vec![RetainedAuthoringTextObject {
             object: circle,
             order: 1,
-            text: typst_spec("collision", false, 48.0),
+            text: native_spec("collision", 48.0),
         }]);
 
         let error = MixedRetainedAuthoringScene::from_parts(&legacy, retained).unwrap_err();

--- a/scripts/authoring-execution-router-smoke.mjs
+++ b/scripts/authoring-execution-router-smoke.mjs
@@ -60,7 +60,7 @@ const mixedSource = `from noon import *
 class MixedRouterScene(Scene):
     def construct(self):
         self.add(Circle(radius=0.4))
-        self.add(Typst("middle", font_size=56))
+        self.add(Text("middle", font_size=56))
         self.add(Square(side_length=0.8))
 `;
 
@@ -125,6 +125,7 @@ try {
     const initialCanvas = execution.canvas;
 
     const mixed = await authoring.run(mixedSource, {});
+    const mixedRetainedBackend = mixed.retainedDocument.objects[0].text.backend.kind;
     const inFlightLegacyMetrics = execution.metrics();
     const mixedTransition = execution.reconcileScene(JSON.stringify(mixed.document), {
       retainedDocumentJson: JSON.stringify(mixed.retainedDocument),
@@ -234,6 +235,7 @@ try {
       retainedMode: AUTHORING_EXECUTION_RETAINED,
       initialReady,
       initialCanvasChanged: initialCanvas !== originalCanvas,
+      mixedRetainedBackend,
       legacyRaceModeBeforeMixed: preMixedRaceMetrics.executionMode,
       mixedMode: mixedResult.mode,
       mixedRebuilt: mixedResult.rebuilt,
@@ -298,6 +300,7 @@ try {
   assert.equal(result.initialCanvasChanged, false);
   assert.equal(result.initialReady.transportMode, "transferable");
   assert.equal(result.transportMode, "transferable");
+  assert.equal(result.mixedRetainedBackend, "native");
   assert.ok([result.initialMode, result.retainedMode].includes(result.legacyRaceModeBeforeMixed));
   assert.equal(result.mixedMode, result.retainedMode);
   assert.equal(result.mixedRebuilt, true);
@@ -391,7 +394,7 @@ try {
   assert.deepEqual(result.clientErrors, []);
   assert.deepEqual(browserErrors, []);
   console.log(
-    `✓ authoring execution router: persistent render ownership across retained/legacy on ${result.rendererBackend}`,
+    `✓ authoring execution router: native retained Text and persistent render ownership across retained/legacy on ${result.rendererBackend}`,
   );
 } finally {
   await browser?.close();

--- a/scripts/authoring-render-mode-switch-smoke.mjs
+++ b/scripts/authoring-render-mode-switch-smoke.mjs
@@ -70,14 +70,14 @@ const browserArgs = [
 
 const retainedScene = JSON.stringify({
   channel: "noon.authoring.retained",
-  protocol_version: 1,
+  protocol_version: 2,
   objects: [
     {
       object: 4503599627370496,
       order: 1,
       text: {
         source: "*Hello* from _Typst!_",
-        math: false,
+        backend: { kind: "typst", math: false },
         font_size: 64,
         transform: {
           translation: { x: 0, y: 1.1 },
@@ -93,7 +93,7 @@ const retainedScene = JSON.stringify({
       order: 4,
       text: {
         source: "frac(x, 2)",
-        math: true,
+        backend: { kind: "typst", math: true },
         font_size: 72,
         transform: {
           translation: { x: 0, y: -1 },

--- a/scripts/manim-typst-authoring-smoke.mjs
+++ b/scripts/manim-typst-authoring-smoke.mjs
@@ -32,11 +32,29 @@ async function waitForServer() {
     }
     await new Promise((resolve) => setTimeout(resolve, 100));
   }
-  throw new Error(`retained Typst authoring smoke server did not start: ${lastError}\n${serverOutput}`);
+  throw new Error(`retained text authoring smoke server did not start: ${lastError}\n${serverOutput}`);
 }
 
-// Pinned ManimCE v0.21 examples from parity/manim-v0.21/typst_scenes.py.
-// As with Noon's existing parity corpus, only the import is substituted.
+// Pinned ManimCE v0.21 Typst examples plus the native Text surface that replaces
+// Noon's temporary geometry-backed demo labels. Only the import is substituted.
+const helloTextSource = `from noon import *
+
+
+class HelloText(Scene):
+    def construct(self):
+        text = Text("Native Noon", font_size=48)
+        self.add(text)
+`;
+
+const multilineTextSource = `from noon import *
+
+
+class MultilineText(Scene):
+    def construct(self):
+        text = Text("first\\nsecond", font_size=36, line_spacing=0.5, color=YELLOW)
+        self.add(text)
+`;
+
 const helloTypstSource = `from noon import *
 
 
@@ -61,28 +79,41 @@ const mixedPainterSource = `from noon import *
 class MixedPainterOrder(Scene):
     def construct(self):
         self.add(Circle(radius=0.25))
-        self.add(Typst("middle", font_size=48))
+        self.add(Text("middle", font_size=48))
         self.add(Square(side_length=0.5))
 `;
 
-function assertSourceLevelSidecar(result, { source, math, fontSize, order }) {
+function retainedObject(result, { source, fontSize, order }) {
   assert.equal(result.kind, "scene_document");
   assert.ok(result.retained_document, "scene result must include a retained authoring document");
   assert.equal(result.retained_document.channel, "noon.authoring.retained");
-  assert.equal(result.retained_document.protocol_version, 1);
+  assert.equal(result.retained_document.protocol_version, 2);
   assert.equal(result.retained_document.objects.length, 1);
   const object = result.retained_document.objects[0];
   assert.ok(Number.isSafeInteger(object.object), "retained object identity must survive JSON exactly");
   assert.ok(object.object >= 2 ** 52 && object.object < Number.MAX_SAFE_INTEGER);
   assert.equal(object.order, order);
   assert.equal(object.text.source, source);
-  assert.equal(object.text.math, math);
   assert.equal(object.text.font_size, fontSize);
 
   const wire = JSON.stringify(result.retained_document);
   for (const forbidden of ["glyph", "font_bytes", "svg", "geometry", "atlas"]) {
     assert.ok(!wire.includes(forbidden), `retained authoring wire must not contain ${forbidden}`);
   }
+  return object;
+}
+
+function assertNativeText(result, expected) {
+  const object = retainedObject(result, expected);
+  assert.equal(object.text.backend.kind, "native");
+  assert.equal(object.text.backend.font_family, expected.fontFamily ?? "DejaVu Sans Mono");
+  assert.equal(object.text.backend.line_spacing, expected.lineSpacing ?? -1);
+}
+
+function assertTypst(result, expected) {
+  const object = retainedObject(result, expected);
+  assert.equal(object.text.backend.kind, "typst");
+  assert.equal(object.text.backend.math, expected.math);
 }
 
 let browser = null;
@@ -103,7 +134,7 @@ try {
   await page.goto(`${baseUrl}/web/`, { waitUntil: "load" });
   await page.evaluate(() => {
     const worker = new Worker(new URL("./python-worker.js", location.href), {
-      name: "noon-retained-typst-authoring-smoke",
+      name: "noon-retained-text-authoring-smoke",
       type: "module",
     });
     let nextRequestId = 0;
@@ -116,7 +147,7 @@ try {
     });
 
     worker.addEventListener("error", (event) => {
-      const error = new Error(event.message || "retained Typst worker crashed");
+      const error = new Error(event.message || "retained text worker crashed");
       rejectReady(error);
       for (const { reject } of pending.values()) reject(error);
       pending.clear();
@@ -124,7 +155,7 @@ try {
     worker.addEventListener("message", (event) => {
       const message = event.data;
       if (message?.channel !== "noon.authoring" || message?.protocolVersion !== 5) {
-        const error = new Error("invalid retained Typst worker envelope");
+        const error = new Error("invalid retained text worker envelope");
         rejectReady(error);
         for (const { reject } of pending.values()) reject(error);
         pending.clear();
@@ -135,7 +166,7 @@ try {
         return;
       }
       if (message.type === "error") {
-        const error = new Error(String(message.message || "retained Typst authoring failed"));
+        const error = new Error(String(message.message || "retained text authoring failed"));
         if (message.requestId === null) {
           rejectReady(error);
           for (const { reject } of pending.values()) reject(error);
@@ -157,7 +188,7 @@ try {
       }
     });
 
-    window.noonRetainedTypstSmoke = {
+    window.noonRetainedTextSmoke = {
       ready: () => ready,
       run: async (source) => {
         await ready;
@@ -176,14 +207,41 @@ try {
       stop: () => worker.terminate(),
     };
   });
-  await page.evaluate(() => window.noonRetainedTypstSmoke.ready());
+  await page.evaluate(() => window.noonRetainedTextSmoke.ready());
+
+  const helloText = await page.evaluate(
+    (source) => window.noonRetainedTextSmoke.run(source),
+    helloTextSource,
+  );
+  assert.equal(helloText.document.objects.length, 0, "Text must not create placeholder geometry");
+  assertNativeText(helloText, {
+    source: "Native Noon",
+    fontSize: 48,
+    order: 0,
+  });
+
+  const multilineText = await page.evaluate(
+    (source) => window.noonRetainedTextSmoke.run(source),
+    multilineTextSource,
+  );
+  assert.equal(
+    multilineText.document.objects.length,
+    0,
+    "multiline Text must not create placeholder geometry",
+  );
+  assertNativeText(multilineText, {
+    source: "first\nsecond",
+    fontSize: 36,
+    lineSpacing: 0.5,
+    order: 0,
+  });
 
   const helloTypst = await page.evaluate(
-    (source) => window.noonRetainedTypstSmoke.run(source),
+    (source) => window.noonRetainedTextSmoke.run(source),
     helloTypstSource,
   );
   assert.equal(helloTypst.document.objects.length, 0, "Typst must not create placeholder geometry");
-  assertSourceLevelSidecar(helloTypst, {
+  assertTypst(helloTypst, {
     source: "*Hello* from _Typst!_",
     math: false,
     fontSize: 96,
@@ -191,7 +249,7 @@ try {
   });
 
   const helloMathTypst = await page.evaluate(
-    (source) => window.noonRetainedTypstSmoke.run(source),
+    (source) => window.noonRetainedTextSmoke.run(source),
     helloMathTypstSource,
   );
   assert.equal(
@@ -199,7 +257,7 @@ try {
     0,
     "MathTypst must not create placeholder geometry",
   );
-  assertSourceLevelSidecar(helloMathTypst, {
+  assertTypst(helloMathTypst, {
     source: "sum_(k=1)^n k = (n(n + 1)) / 2",
     math: true,
     fontSize: 72,
@@ -207,23 +265,22 @@ try {
   });
 
   const mixed = await page.evaluate(
-    (source) => window.noonRetainedTypstSmoke.run(source),
+    (source) => window.noonRetainedTextSmoke.run(source),
     mixedPainterSource,
   );
   assert.equal(mixed.document.objects.length, 2, "only the circle and square belong to legacy geometry");
   assert.equal(mixed.document.objects[0].id, 0);
   assert.equal(mixed.document.objects[1].id, 1);
-  assertSourceLevelSidecar(mixed, {
+  assertNativeText(mixed, {
     source: "middle",
-    math: false,
     fontSize: 48,
     order: 1,
   });
 
-  await page.evaluate(() => window.noonRetainedTypstSmoke.stop());
-  assert.deepEqual(errors, [], `browser errors while testing retained Typst authoring:\n${errors.join("\n")}`);
+  await page.evaluate(() => window.noonRetainedTextSmoke.stop());
+  assert.deepEqual(errors, [], `browser errors while testing retained text authoring:\n${errors.join("\n")}`);
   console.log(
-    "Retained Typst authoring smoke passed: pinned Manim v0.21 Typst/MathTypst sources (import-only substitution) emit source-only retained sidecars, zero placeholder geometry, exact JS-safe identities, and deterministic mixed painter order.",
+    "Retained text authoring smoke passed: native Text and pinned Manim v0.21 Typst/MathTypst sources emit backend-neutral source-only sidecars, zero placeholder geometry, exact JS-safe identities, and deterministic mixed painter order.",
   );
 } finally {
   await browser?.close();

--- a/scripts/retained-execution-worker-smoke.mjs
+++ b/scripts/retained-execution-worker-smoke.mjs
@@ -72,14 +72,14 @@ const textA = 4503599627370496;
 const textB = 4503599627370497;
 const retainedScene = JSON.stringify({
   channel: "noon.authoring.retained",
-  protocol_version: 1,
+  protocol_version: 2,
   objects: [
     {
       object: textA,
       order: 1,
       text: {
         source: "*Hello* from _Typst!_",
-        math: false,
+        backend: { kind: "typst", math: false },
         font_size: 64,
         transform: {
           translation: { x: 0, y: 1.1 },
@@ -95,7 +95,7 @@ const retainedScene = JSON.stringify({
       order: 4,
       text: {
         source: "frac(x, 2)",
-        math: true,
+        backend: { kind: "typst", math: true },
         font_size: 72,
         transform: {
           translation: { x: 0, y: -1.0 },

--- a/web/authoring-client.js
+++ b/web/authoring-client.js
@@ -2,7 +2,7 @@ export const AUTHORING_CHANNEL = "noon.authoring";
 export const AUTHORING_PROTOCOL_VERSION = 5;
 export const NOON_IR_VERSION = 1;
 export const RETAINED_AUTHORING_CHANNEL = "noon.authoring.retained";
-export const RETAINED_AUTHORING_VERSION = 1;
+export const RETAINED_AUTHORING_VERSION = 2;
 
 export class PythonAuthoringClient {
   #worker;
@@ -319,26 +319,46 @@ export function validateRetainedAuthoringDocument(document) {
     }
     objectIds.add(object.object);
     orders.add(object.order);
-    validateRetainedTypstSpec(object.text);
+    validateRetainedTextSpec(object.text);
   }
   return document;
 }
 
-function validateRetainedTypstSpec(text) {
-  if (!isRecord(text) || typeof text.source !== "string" || text.source.length === 0) {
-    throw new Error("Python retained Typst source must be a non-empty string");
+function validateRetainedTextSpec(text) {
+  if (!isRecord(text) || typeof text.source !== "string") {
+    throw new Error("Python retained text source must be a string");
   }
-  if (typeof text.math !== "boolean") {
-    throw new Error("Python retained Typst math flag must be boolean");
+  if (!isRecord(text.backend) || typeof text.backend.kind !== "string") {
+    throw new Error("Python retained text backend is malformed");
+  }
+  if (text.backend.kind === "native") {
+    if (typeof text.backend.font_family !== "string" || text.backend.font_family.trim() === "") {
+      throw new Error("Python retained native text font family must be non-empty");
+    }
+    if (
+      !Number.isFinite(text.backend.line_spacing) ||
+      (text.backend.line_spacing !== -1 && text.backend.line_spacing <= -1)
+    ) {
+      throw new Error("Python retained native text line spacing must be -1 or greater than -1");
+    }
+  } else if (text.backend.kind === "typst") {
+    if (text.source.length === 0) {
+      throw new Error("Python retained Typst source must be a non-empty string");
+    }
+    if (typeof text.backend.math !== "boolean") {
+      throw new Error("Python retained Typst math flag must be boolean");
+    }
+  } else {
+    throw new Error(`Unsupported Python retained text backend ${text.backend.kind}`);
   }
   if (!Number.isFinite(text.font_size) || text.font_size <= 0) {
-    throw new Error("Python retained Typst font size must be finite and positive");
+    throw new Error("Python retained text font size must be finite and positive");
   }
   if (!Number.isFinite(text.opacity) || text.opacity < 0 || text.opacity > 1) {
-    throw new Error("Python retained Typst opacity must be between zero and one");
+    throw new Error("Python retained text opacity must be between zero and one");
   }
   if (!isRecord(text.transform) || !isRecord(text.transform.translation) || !isRecord(text.transform.scale)) {
-    throw new Error("Python retained Typst transform is malformed");
+    throw new Error("Python retained text transform is malformed");
   }
   for (const value of [
     text.transform.translation.x,
@@ -348,15 +368,15 @@ function validateRetainedTypstSpec(text) {
     text.transform.rotation,
   ]) {
     if (!Number.isFinite(value)) {
-      throw new Error("Python retained Typst transform must be finite");
+      throw new Error("Python retained text transform must be finite");
     }
   }
   if (!isRecord(text.color)) {
-    throw new Error("Python retained Typst color is malformed");
+    throw new Error("Python retained text color is malformed");
   }
   for (const value of [text.color.red, text.color.green, text.color.blue, text.color.alpha]) {
     if (!Number.isFinite(value)) {
-      throw new Error("Python retained Typst color must be finite");
+      throw new Error("Python retained text color must be finite");
     }
   }
 }

--- a/web/authoring-client.test.mjs
+++ b/web/authoring-client.test.mjs
@@ -49,17 +49,17 @@ function workerMessage(type, payload = {}) {
   };
 }
 
-function retainedDocument() {
+function retainedDocument(backend = { kind: "typst", math: false }) {
   return {
     channel: "noon.authoring.retained",
-    protocol_version: 1,
+    protocol_version: 2,
     objects: [
       {
         object: 2 ** 52,
         order: 1,
         text: {
-          source: "*Hello* from _Typst!_",
-          math: false,
+          source: backend.kind === "native" ? "Native Noon" : "*Hello* from _Typst!_",
+          backend,
           font_size: 96,
           transform: {
             translation: { x: 0, y: 0 },
@@ -153,18 +153,26 @@ test("older scene results without a retained sidecar remain compatible", () => {
   assert.equal("retainedDocument" in parsed, false);
 });
 
-test("validates retained Typst authoring documents and JS-safe identities", () => {
-  const retained = retainedDocument();
-  assert.equal(validateRetainedAuthoringDocument(retained), retained);
+test("validates retained native/Typst authoring documents and JS-safe identities", () => {
+  for (const retained of [
+    retainedDocument(),
+    retainedDocument({
+      kind: "native",
+      font_family: "DejaVu Sans Mono",
+      line_spacing: -1,
+    }),
+  ]) {
+    assert.equal(validateRetainedAuthoringDocument(retained), retained);
+  }
 
-  const unsafe = structuredClone(retained);
+  const unsafe = retainedDocument();
   unsafe.objects[0].object = Number.MAX_SAFE_INTEGER + 1;
   assert.throws(
     () => validateRetainedAuthoringDocument(unsafe),
     /invalid object ID/,
   );
 
-  const duplicateOrder = structuredClone(retained);
+  const duplicateOrder = retainedDocument();
   duplicateOrder.objects.push({
     ...structuredClone(duplicateOrder.objects[0]),
     object: 2 ** 52 + 1,
@@ -172,6 +180,12 @@ test("validates retained Typst authoring documents and JS-safe identities", () =
   assert.throws(
     () => validateRetainedAuthoringDocument(duplicateOrder),
     /duplicate painter orders/,
+  );
+
+  const invalidBackend = retainedDocument({ kind: "unknown" });
+  assert.throws(
+    () => validateRetainedAuthoringDocument(invalidBackend),
+    /Unsupported Python retained text backend/,
   );
 });
 

--- a/web/python-worker.source.js
+++ b/web/python-worker.source.js
@@ -1,4 +1,5 @@
 import initNoonWeb, {
+  RetainedNativeTextAuthoringHandle,
   RetainedTypstAuthoringHandle,
   WasmAuthoringStore,
   manimDotSnapshotJson,
@@ -54,6 +55,8 @@ async function initializePyodide() {
   self.noonCreateAuthoringLineHandle = (startX, startY, endX, endY) =>
     authoringStore.createManimLine(startX, startY, endX, endY);
   self.noonCreateAuthoringFamilyHandle = () => authoringStore.createFamily();
+  self.noonCreateRetainedNativeTextHandle = (source, fontFamily, fontSize, lineSpacing) =>
+    new RetainedNativeTextAuthoringHandle(source, fontFamily, fontSize, lineSpacing);
   self.noonCreateRetainedTypstHandle = (source, math, fontSize) =>
     new RetainedTypstAuthoringHandle(source, math, fontSize);
   self.noonResolveAnimationOptions = resolveAnimationOptionsPlain;

--- a/web/python/_manim_typst.py
+++ b/web/python/_manim_typst.py
@@ -1,9 +1,9 @@
-"""ManimCE Typst/MathTypst wrappers over Noon's retained authoring handle.
+"""ManimCE retained Text/Typst wrappers over Noon's source-level authoring handles.
 
-The wrappers are intentionally not geometry adapters. They never synthesize an
+These wrappers are intentionally not geometry adapters. They never synthesize an
 ``_ir.Mobject`` and ``Scene.add`` intercepts them before legacy geometry lowering.
-Only source-level Typst authoring state crosses the Python-worker boundary; shaping,
-fonts, vector decorations, and GPU glyph state remain Rust-owned retained resources.
+Only source-level text authoring state crosses the Python-worker boundary; shaping,
+font bytes, glyph/vector resources, and GPU atlas state remain Rust-owned.
 """
 
 from __future__ import annotations
@@ -16,14 +16,18 @@ import noon as _base
 import _manim_compat as _compat
 
 try:
-    from js import noonCreateRetainedTypstHandle as _create_retained_handle
-except ImportError:  # Native CPython tests use the source-level fallback below.
-    _create_retained_handle = None
+    from js import noonCreateRetainedNativeTextHandle as _create_native_text_handle
+    from js import noonCreateRetainedTypstHandle as _create_typst_handle
+except ImportError:  # Native CPython tests use the source-level fallbacks below.
+    _create_native_text_handle = None
+    _create_typst_handle = None
 
 
 # Reserve the upper half of JavaScript's exact-integer range for retained text IDs.
 # Legacy geometry IDs start at zero and no practical scene can approach 2^52 objects.
 _RETAINED_OBJECT_ID_BASE = 1 << 52
+_RETAINED_PROTOCOL_VERSION = 2
+_DEFAULT_NATIVE_FONT = "DejaVu Sans Mono"
 _INSTALLED = False
 _ORIGINAL_SCENE_ADD = _compat.Scene.add
 _ORIGINAL_SCENE_IS_PRESENT = _compat.Scene._is_present
@@ -38,22 +42,11 @@ def _color_dict(color: _base.Color) -> dict[str, float]:
     }
 
 
-class _FallbackRetainedTypstHandle:
+class _FallbackRetainedHandle:
     """CPython-only stand-in with the exact source-level WASM wire shape."""
 
-    def __init__(self, source: str, math_mode: bool, font_size: float) -> None:
-        self._spec = {
-            "source": str(source),
-            "math": bool(math_mode),
-            "font_size": float(font_size),
-            "transform": {
-                "translation": {"x": 0.0, "y": 0.0},
-                "scale": {"x": 1.0, "y": 1.0},
-                "rotation": 0.0,
-            },
-            "color": _color_dict(_base.WHITE),
-            "opacity": 1.0,
-        }
+    def __init__(self, spec: dict[str, Any]) -> None:
+        self._spec = spec
 
     def shift(self, x: float, y: float) -> None:
         self._spec["transform"]["translation"]["x"] += float(x)
@@ -84,40 +77,86 @@ class _FallbackRetainedTypstHandle:
         return json.dumps(self._spec, separators=(",", ":"), allow_nan=False)
 
 
-def _new_handle(source: str, math_mode: bool, font_size: float):
-    if not isinstance(source, str) or source == "":
-        raise ValueError("Typst source must be a non-empty string")
-    font_size = float(font_size)
+def _base_spec(source: str, backend: dict[str, Any], font_size: float) -> dict[str, Any]:
+    return {
+        "source": source,
+        "backend": backend,
+        "font_size": font_size,
+        "transform": {
+            "translation": {"x": 0.0, "y": 0.0},
+            "scale": {"x": 1.0, "y": 1.0},
+            "rotation": 0.0,
+        },
+        "color": _color_dict(_base.WHITE),
+        "opacity": 1.0,
+    }
+
+
+def _validated_font_size(value: float) -> float:
+    font_size = float(value)
     if not math.isfinite(font_size) or font_size <= 0.0:
         raise ValueError("font_size must be finite and positive")
-    if _create_retained_handle is None:
-        return _FallbackRetainedTypstHandle(source, math_mode, font_size)
-    return _create_retained_handle(source, bool(math_mode), font_size)
+    return font_size
+
+
+def _new_typst_handle(source: str, math_mode: bool, font_size: float):
+    if not isinstance(source, str) or source == "":
+        raise ValueError("Typst source must be a non-empty string")
+    font_size = _validated_font_size(font_size)
+    if _create_typst_handle is None:
+        return _FallbackRetainedHandle(
+            _base_spec(source, {"kind": "typst", "math": bool(math_mode)}, font_size)
+        )
+    return _create_typst_handle(source, bool(math_mode), font_size)
+
+
+def _new_native_text_handle(
+    source: str,
+    font_family: str,
+    font_size: float,
+    line_spacing: float,
+):
+    if not isinstance(source, str):
+        raise TypeError("Text source must be a string")
+    if not isinstance(font_family, str) or font_family.strip() == "":
+        raise ValueError("font must be a non-empty string")
+    font_size = _validated_font_size(font_size)
+    line_spacing = float(line_spacing)
+    if not math.isfinite(line_spacing) or (line_spacing != -1.0 and line_spacing <= -1.0):
+        raise ValueError("line_spacing must be -1 or a finite value greater than -1")
+    if _create_native_text_handle is None:
+        return _FallbackRetainedHandle(
+            _base_spec(
+                source,
+                {
+                    "kind": "native",
+                    "font_family": font_family,
+                    "line_spacing": line_spacing,
+                },
+                font_size,
+            )
+        )
+    return _create_native_text_handle(source, font_family, font_size, line_spacing)
 
 
 def _as_color(value: object) -> _base.Color:
     if isinstance(value, _base.Color):
         return value
-    raise TypeError("Typst color must be a Noon/Manim Color")
+    raise TypeError("retained text color must be a Noon/Manim Color")
 
 
-class _RetainedTypstMobject(_base.Mobject):
-    """Python semantic identity for one retained Typst resource-backed object."""
+class _RetainedTextMobject(_base.Mobject):
+    """Python semantic identity for one retained resource-backed text object."""
 
-    _math_mode = False
-
-    def __init__(
+    def _initialize_retained(
         self,
         source: str,
-        *,
-        font_size: float = 48.0,
-        color: _base.Color = _base.WHITE,
-        **kwargs: Any,
+        font_size: float,
+        handle: object,
+        color: _base.Color,
+        opacity: float,
     ) -> None:
-        opacity = float(kwargs.pop("opacity", 1.0))
-        if kwargs:
-            unsupported = ", ".join(sorted(kwargs))
-            raise NotImplementedError(f"unsupported Typst option(s): {unsupported}")
+        opacity = float(opacity)
         if not math.isfinite(opacity) or not 0.0 <= opacity <= 1.0:
             raise ValueError("opacity must be finite and between 0 and 1")
 
@@ -127,9 +166,9 @@ class _RetainedTypstMobject(_base.Mobject):
         self._object = None
         self._retained_object_id: int | None = None
         self._retained_order: int | None = None
-        self._source = str(source)
+        self._source = source
         self._font_size = float(font_size)
-        self._retained_handle = _new_handle(self._source, self._math_mode, self._font_size)
+        self._retained_handle = handle
         self.set_color(_as_color(color))
         self.set_opacity(opacity)
 
@@ -144,82 +183,84 @@ class _RetainedTypstMobject(_base.Mobject):
     @property
     def id(self) -> int:
         if self._retained_object_id is None:
-            raise AttributeError("detached retained Typst Mobject has no scene object id")
+            raise AttributeError("detached retained text Mobject has no scene object id")
         return self._retained_object_id
 
     def _current_raw(self):
-        raise TypeError("retained Typst objects do not have legacy geometry snapshots")
+        raise TypeError("retained text objects do not have legacy geometry snapshots")
 
     def _apply(self, raw):
         del raw
-        raise TypeError("retained Typst objects cannot be lowered through legacy geometry")
+        raise TypeError("retained text objects cannot be lowered through legacy geometry")
 
     def _bind_retained(self, scene: _compat.Scene, object_id: int, order: int) -> None:
         if self._scene is not None and self._scene is not scene:
-            raise ValueError("Typst Mobject already belongs to another Scene")
+            raise ValueError("retained text Mobject already belongs to another Scene")
         self._scene = scene
         self._retained_object_id = int(object_id)
         self._retained_order = int(order)
 
     def _retained_entry(self) -> dict[str, Any]:
         if self._retained_object_id is None or self._retained_order is None:
-            raise ValueError("retained Typst object must belong to a Scene before serialization")
+            raise ValueError("retained text object must belong to a Scene before serialization")
         return {
             "object": self._retained_object_id,
             "order": self._retained_order,
             "text": json.loads(str(self._retained_handle.specJson())),
         }
 
+    def _spec(self) -> dict[str, Any]:
+        return json.loads(str(self._retained_handle.specJson()))
+
     def get_center(self) -> _base.Vec2:
-        spec = json.loads(str(self._retained_handle.specJson()))
-        point = spec["transform"]["translation"]
+        point = self._spec()["transform"]["translation"]
         return _base.Vec2(float(point["x"]), float(point["y"]))
 
-    def shift(self, direction: object) -> _RetainedTypstMobject:
+    def shift(self, direction: object) -> _RetainedTextMobject:
         offset = _compat._as_vec2(direction)
         self._retained_handle.shift(float(offset.x), float(offset.y))
         return self
 
-    def move_to(self, point: object, *args: Any, **kwargs: Any) -> _RetainedTypstMobject:
+    def move_to(self, point: object, *args: Any, **kwargs: Any) -> _RetainedTextMobject:
         if args or kwargs:
-            raise NotImplementedError("retained Typst move_to currently supports point targets only")
+            raise NotImplementedError("retained text move_to currently supports point targets only")
         target = _compat._as_vec2(point)
         self._retained_handle.moveTo(float(target.x), float(target.y))
         return self
 
-    def center(self) -> _RetainedTypstMobject:
+    def center(self) -> _RetainedTextMobject:
         return self.move_to(_base.ORIGIN)
 
-    def set_x(self, x: float) -> _RetainedTypstMobject:
+    def set_x(self, x: float) -> _RetainedTextMobject:
         center = self.get_center()
         self._retained_handle.moveTo(float(x), float(center.y))
         return self
 
-    def set_y(self, y: float) -> _RetainedTypstMobject:
+    def set_y(self, y: float) -> _RetainedTextMobject:
         center = self.get_center()
         self._retained_handle.moveTo(float(center.x), float(y))
         return self
 
-    def scale(self, factor: float, **kwargs: Any) -> _RetainedTypstMobject:
+    def scale(self, factor: float, **kwargs: Any) -> _RetainedTextMobject:
         if kwargs:
             unsupported = ", ".join(sorted(kwargs))
-            raise NotImplementedError(f"unsupported retained Typst scale option(s): {unsupported}")
+            raise NotImplementedError(f"unsupported retained text scale option(s): {unsupported}")
         value = float(factor)
         if not math.isfinite(value) or value <= 0.0:
             raise ValueError("scale factor must be finite and positive")
         self._retained_handle.scale(value)
         return self
 
-    def rotate(self, angle: float, *args: Any, **kwargs: Any) -> _RetainedTypstMobject:
+    def rotate(self, angle: float, *args: Any, **kwargs: Any) -> _RetainedTextMobject:
         if args or kwargs:
-            raise NotImplementedError("retained Typst rotate currently supports angle only")
+            raise NotImplementedError("retained text rotate currently supports angle only")
         value = float(angle)
         if not math.isfinite(value):
             raise ValueError("rotation angle must be finite")
         self._retained_handle.rotate(value)
         return self
 
-    def set_color(self, color: _base.Color, family: bool = True) -> _RetainedTypstMobject:
+    def set_color(self, color: _base.Color, family: bool = True) -> _RetainedTextMobject:
         del family
         value = _as_color(color)
         self._retained_handle.setColor(
@@ -230,7 +271,7 @@ class _RetainedTypstMobject(_base.Mobject):
         )
         return self
 
-    def set_opacity(self, opacity: float, family: bool = True) -> _RetainedTypstMobject:
+    def set_opacity(self, opacity: float, family: bool = True) -> _RetainedTextMobject:
         del family
         value = float(opacity)
         if not math.isfinite(value) or not 0.0 <= value <= 1.0:
@@ -238,14 +279,17 @@ class _RetainedTypstMobject(_base.Mobject):
         self._retained_handle.setOpacity(value)
         return self
 
-    def copy(self) -> _RetainedTypstMobject:
-        spec = json.loads(str(self._retained_handle.specJson()))
-        clone = type(self)(self._source, font_size=self._font_size, color=_base.WHITE)
+    def _copy_constructor(self) -> _RetainedTextMobject:
+        raise NotImplementedError
+
+    def copy(self) -> _RetainedTextMobject:
+        spec = self._spec()
+        clone = self._copy_constructor()
         transform = spec["transform"]
         translation = transform["translation"]
         scale = transform["scale"]
         if not math.isclose(float(scale["x"]), float(scale["y"]), rel_tol=0.0, abs_tol=1e-12):
-            raise NotImplementedError("copy of non-uniform retained Typst scale is not implemented")
+            raise NotImplementedError("copy of non-uniform retained text scale is not implemented")
         clone._retained_handle.moveTo(float(translation["x"]), float(translation["y"]))
         clone._retained_handle.scale(float(scale["x"]))
         clone._retained_handle.rotate(float(transform["rotation"]))
@@ -260,12 +304,78 @@ class _RetainedTypstMobject(_base.Mobject):
         return clone
 
 
+class _RetainedTypstMobject(_RetainedTextMobject):
+    _math_mode = False
+
+    def __init__(
+        self,
+        source: str,
+        *,
+        font_size: float = 48.0,
+        color: _base.Color = _base.WHITE,
+        **kwargs: Any,
+    ) -> None:
+        opacity = float(kwargs.pop("opacity", 1.0))
+        if kwargs:
+            unsupported = ", ".join(sorted(kwargs))
+            raise NotImplementedError(f"unsupported Typst option(s): {unsupported}")
+        handle = _new_typst_handle(source, self._math_mode, font_size)
+        self._initialize_retained(str(source), float(font_size), handle, color, opacity)
+
+    def _copy_constructor(self) -> _RetainedTypstMobject:
+        return type(self)(self._source, font_size=self._font_size, color=_base.WHITE)
+
+
 class Typst(_RetainedTypstMobject):
     _math_mode = False
 
 
 class MathTypst(_RetainedTypstMobject):
     _math_mode = True
+
+
+class Text(_RetainedTextMobject):
+    """Deterministic native plain text compiled and rendered entirely by Rust."""
+
+    def __init__(
+        self,
+        text: str,
+        *,
+        font: str = _DEFAULT_NATIVE_FONT,
+        font_size: float = 48.0,
+        line_spacing: float = -1.0,
+        color: _base.Color = _base.WHITE,
+        **kwargs: Any,
+    ) -> None:
+        opacity = float(kwargs.pop("opacity", 1.0))
+        if kwargs:
+            unsupported = ", ".join(sorted(kwargs))
+            raise NotImplementedError(f"unsupported Text option(s): {unsupported}")
+        handle = _new_native_text_handle(text, font, font_size, line_spacing)
+        self._font = str(font)
+        self._line_spacing = float(line_spacing)
+        self._initialize_retained(str(text), float(font_size), handle, color, opacity)
+
+    @property
+    def text(self) -> str:
+        return self._source
+
+    @property
+    def font(self) -> str:
+        return self._font
+
+    @property
+    def line_spacing(self) -> float:
+        return self._line_spacing
+
+    def _copy_constructor(self) -> Text:
+        return type(self)(
+            self._source,
+            font=self._font,
+            font_size=self._font_size,
+            line_spacing=self._line_spacing,
+            color=_base.WHITE,
+        )
 
 
 def _ensure_scene_state(scene: _compat.Scene) -> None:
@@ -276,15 +386,15 @@ def _ensure_scene_state(scene: _compat.Scene) -> None:
         scene._retained_next_painter_order = len(scene._objects)
 
 
-def _add_retained(scene: _compat.Scene, mobject: _RetainedTypstMobject, key: str | None) -> None:
+def _add_retained(scene: _compat.Scene, mobject: _RetainedTextMobject, key: str | None) -> None:
     if key is not None:
-        raise NotImplementedError("explicit Scene.add keys for retained Typst are not implemented")
+        raise NotImplementedError("explicit Scene.add keys for retained text are not implemented")
     _ensure_scene_state(scene)
     if mobject._scene is scene:
         scene._register_top_level(mobject)
         return
     if mobject._scene is not None:
-        raise ValueError("Typst Mobject already belongs to another Scene")
+        raise ValueError("retained text Mobject already belongs to another Scene")
     object_id = int(scene._retained_next_object_id)
     order = int(scene._retained_next_painter_order)
     scene._retained_next_object_id += 1
@@ -303,7 +413,7 @@ def _scene_add(self: _compat.Scene, *mobjects: object, key: str | None = None):
 
     single_result: object = self
     for value in mobjects:
-        if isinstance(value, _RetainedTypstMobject):
+        if isinstance(value, _RetainedTextMobject):
             _add_retained(self, value, key)
             single_result = value
             continue
@@ -319,7 +429,7 @@ def _scene_add(self: _compat.Scene, *mobjects: object, key: str | None = None):
 
 
 def _scene_is_present(self: _compat.Scene, value: object) -> bool:
-    if isinstance(value, _RetainedTypstMobject):
+    if isinstance(value, _RetainedTextMobject):
         return value._scene is self
     return _ORIGINAL_SCENE_IS_PRESENT(self, value)
 
@@ -329,13 +439,13 @@ def _retained_document(self: _compat.Scene) -> dict[str, Any]:
     objects = [mobject._retained_entry() for mobject in self._retained_text_objects]
     return {
         "channel": "noon.authoring.retained",
-        "protocol_version": 1,
+        "protocol_version": _RETAINED_PROTOCOL_VERSION,
         "objects": objects,
     }
 
 
 def install() -> None:
-    """Install retained Typst authoring without changing legacy geometry lowering."""
+    """Install retained text authoring without changing legacy geometry lowering."""
 
     global _INSTALLED
     if _INSTALLED:
@@ -347,7 +457,7 @@ def install() -> None:
     _compat.Scene.retained_document = _retained_document
     _base.Scene = _compat.Scene
 
-    public = {"Typst": Typst, "MathTypst": MathTypst}
+    public = {"Text": Text, "Typst": Typst, "MathTypst": MathTypst}
     for name, value in public.items():
         setattr(_base, name, value)
     exports = list(_base.__all__)


### PR DESCRIPTION
## Summary
- generalize the retained Python/browser text sidecar from Typst-only v1 to backend-neutral v2
- add an explicit native backend source spec carrying only source, font policy, layout options, transform, and style
- lower native specs through the public Rust `Text` authoring path from #582
- expose a Rust-owned native Text authoring handle to Pyodide
- replace the Python `Text` surface with a retained source-only object that never creates legacy placeholder geometry
- update `PythonAuthoringClient` to validate the backend-neutral v2 contract
- extend browser authoring coverage across native Text, multiline Text, Typst/MathTypst, JS-safe identity, and mixed painter order
- route native `Text` through the real retained execution/resource-transfer/render path and require presented frames

## Architecture
Python never receives shaped glyphs, exact font bytes, SVG, geometry, or atlas state. Backend selection and compilation remain Rust-owned, while native Text and Typst share one semantic retained object stream and renderer/resource path.

The branch is restacked as one clean commit directly on the corrected #582 head. Retarget to `master` after #582 merges.

## Validation
- retained authoring wire smoke asserts zero placeholder geometry and forbids glyph/font-byte/SVG/atlas payloads
- authoring-client tests cover native + Typst protocol-v2 validation and malformed backend rejection
- execution-router smoke authors `Text("middle")`, verifies native backend selection, non-empty resource transfer, actual presented frames, restart/playback controls, and retained↔legacy mode transitions

Related: #364, #361, #582