### PR TITLE
Reuse unpinned glyph atlas pages by generation

### DIFF
--- a/crates/noon-text-atlas/src/lib.rs
+++ b/crates/noon-text-atlas/src/lib.rs
@@ -759,13 +759,8 @@ impl GpuGlyphAtlas {
         for _ in 0..missing {
             let next_page = u32::try_from(self.page_count(plane))
                 .map_err(|_| GlyphAtlasError::DimensionOverflow)?;
-            let state = AtlasPlaneState::new(
-                device,
-                plane,
-                self.extent,
-                next_page,
-                self.generation,
-            );
+            let state =
+                AtlasPlaneState::new(device, plane, self.extent, next_page, self.generation);
             match plane {
                 GlyphAtlasPlane::Mask => self.mask_pages.push(state),
                 GlyphAtlasPlane::Color => self.color_pages.push(state),

--- a/crates/noon-text-atlas/src/lib.rs
+++ b/crates/noon-text-atlas/src/lib.rs
@@ -67,6 +67,9 @@ pub struct GlyphAtlasStats {
     pub bytes_uploaded: usize,
     pub hits: u64,
     pub misses: u64,
+    pub page_evictions: u64,
+    pub page_reuses: u64,
+    pub image_entries_evicted: u64,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -293,6 +296,15 @@ impl GlyphAtlasPageAllocator {
         self.pages.push(page);
         page_allocation(page_index, allocation)
     }
+
+    fn reset_page(&mut self, page_index: usize) -> Result<(), GlyphAtlasError> {
+        let page = self
+            .pages
+            .get_mut(page_index)
+            .ok_or(GlyphAtlasError::DimensionOverflow)?;
+        *page = ShelfPacker::new(self.extent)?;
+        Ok(())
+    }
 }
 
 fn page_allocation(
@@ -311,10 +323,18 @@ fn page_allocation(
 struct AtlasPlaneState {
     texture: wgpu::Texture,
     view: wgpu::TextureView,
+    last_used_generation: u64,
+    keys: Vec<GlyphRasterKey>,
 }
 
 impl AtlasPlaneState {
-    fn new(device: &wgpu::Device, plane: GlyphAtlasPlane, extent: u32, page: u32) -> Self {
+    fn new(
+        device: &wgpu::Device,
+        plane: GlyphAtlasPlane,
+        extent: u32,
+        page: u32,
+        generation: u64,
+    ) -> Self {
         let label = match plane {
             GlyphAtlasPlane::Mask => format!("Noon glyph mask atlas page {page}"),
             GlyphAtlasPlane::Color => format!("Noon glyph color atlas page {page}"),
@@ -334,7 +354,12 @@ impl AtlasPlaneState {
             view_formats: &[],
         });
         let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
-        Self { texture, view }
+        Self {
+            texture,
+            view,
+            last_used_generation: generation,
+            keys: Vec::new(),
+        }
     }
 }
 
@@ -346,8 +371,10 @@ impl AtlasPlaneState {
 /// cached without consuming GPU space.
 ///
 /// `GpuGlyphAtlas::new` preserves the historical one-page-per-plane policy. Callers
-/// must opt into a larger bounded budget with `with_page_limit`; eviction/reuse is a
-/// separate residency policy layered on top of this structural page ownership.
+/// must opt into a larger bounded budget with `with_page_limit`. Page reuse is also
+/// explicit: callers advance preparation generations with `begin_generation`, and
+/// only pages untouched in the current generation are eligible for deterministic
+/// oldest-page reuse.
 pub struct GpuGlyphAtlas {
     extent: u32,
     mask_allocator: GlyphAtlasPageAllocator,
@@ -356,6 +383,7 @@ pub struct GpuGlyphAtlas {
     color_pages: Vec<AtlasPlaneState>,
     entries: HashMap<GlyphRasterKey, GlyphAtlasEntry>,
     stats: GlyphAtlasStats,
+    generation: u64,
 }
 
 impl GpuGlyphAtlas {
@@ -375,6 +403,7 @@ impl GpuGlyphAtlas {
             color_pages: Vec::new(),
             entries: HashMap::new(),
             stats: GlyphAtlasStats::default(),
+            generation: 1,
         })
     }
 
@@ -390,6 +419,29 @@ impl GpuGlyphAtlas {
         self.stats
     }
 
+    pub const fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    /// Advance the residency generation used to pin pages referenced by one
+    /// preparation pass. Pages touched by `insert` during this generation cannot be
+    /// recycled until a later generation begins.
+    pub fn begin_generation(&mut self) -> u64 {
+        if self.generation == u64::MAX {
+            self.generation = 1;
+            for state in self
+                .mask_pages
+                .iter_mut()
+                .chain(self.color_pages.iter_mut())
+            {
+                state.last_used_generation = 0;
+            }
+        } else {
+            self.generation += 1;
+        }
+        self.generation
+    }
+
     pub fn len(&self) -> usize {
         self.entries.len()
     }
@@ -403,10 +455,7 @@ impl GpuGlyphAtlas {
     }
 
     pub fn page_count(&self, plane: GlyphAtlasPlane) -> usize {
-        match plane {
-            GlyphAtlasPlane::Mask => self.mask_pages.len(),
-            GlyphAtlasPlane::Color => self.color_pages.len(),
-        }
+        self.page_states(plane).len()
     }
 
     /// Compatibility accessor for page zero of a plane.
@@ -420,10 +469,7 @@ impl GpuGlyphAtlas {
         page: u32,
     ) -> Option<&wgpu::TextureView> {
         let page = usize::try_from(page).ok()?;
-        match plane {
-            GlyphAtlasPlane::Mask => self.mask_pages.get(page).map(|state| &state.view),
-            GlyphAtlasPlane::Color => self.color_pages.get(page).map(|state| &state.view),
-        }
+        self.page_states(plane).get(page).map(|state| &state.view)
     }
 
     pub fn get(&self, key: GlyphRasterKey) -> Option<GlyphAtlasEntry> {
@@ -444,6 +490,7 @@ impl GpuGlyphAtlas {
     ) -> Result<GlyphAtlasEntry, GlyphAtlasError> {
         if let Some(entry) = self.entries.get(&key).copied() {
             self.stats.hits = self.stats.hits.saturating_add(1);
+            self.touch_entry(entry);
             return Ok(entry);
         }
         self.stats.misses = self.stats.misses.saturating_add(1);
@@ -554,6 +601,7 @@ impl GpuGlyphAtlas {
                 (origin[1] + size[1]) as f32 / extent as f32,
             ],
         };
+        self.record_page_key(plane, allocation.page, key)?;
         let entry = GlyphAtlasEntry::Image(atlas_image);
         self.entries.insert(key, entry);
         self.stats.entries = self.entries.len();
@@ -575,9 +623,125 @@ impl GpuGlyphAtlas {
         width: u32,
         height: u32,
     ) -> Result<GlyphAtlasPageAllocation, GlyphAtlasError> {
+        match self.allocate_without_reuse(plane, width, height) {
+            Err(error @ GlyphAtlasError::Full { .. }) => {
+                let Some(victim) = self.eviction_victim(plane) else {
+                    return Err(error);
+                };
+                self.recycle_page(plane, victim)?;
+                self.allocate_without_reuse(plane, width, height)
+            }
+            result => result,
+        }
+    }
+
+    fn allocate_without_reuse(
+        &mut self,
+        plane: GlyphAtlasPlane,
+        width: u32,
+        height: u32,
+    ) -> Result<GlyphAtlasPageAllocation, GlyphAtlasError> {
         match plane {
             GlyphAtlasPlane::Mask => self.mask_allocator.allocate(plane, width, height),
             GlyphAtlasPlane::Color => self.color_allocator.allocate(plane, width, height),
+        }
+    }
+
+    fn eviction_victim(&self, plane: GlyphAtlasPlane) -> Option<usize> {
+        self.page_states(plane)
+            .iter()
+            .enumerate()
+            .filter(|(_, state)| state.last_used_generation != self.generation)
+            .min_by_key(|(page_index, state)| (state.last_used_generation, *page_index))
+            .map(|(page_index, _)| page_index)
+    }
+
+    fn recycle_page(
+        &mut self,
+        plane: GlyphAtlasPlane,
+        page_index: usize,
+    ) -> Result<(), GlyphAtlasError> {
+        match plane {
+            GlyphAtlasPlane::Mask => self.mask_allocator.reset_page(page_index)?,
+            GlyphAtlasPlane::Color => self.color_allocator.reset_page(page_index)?,
+        }
+
+        let generation = self.generation;
+        let keys = {
+            let state = self
+                .page_states_mut(plane)
+                .get_mut(page_index)
+                .ok_or(GlyphAtlasError::DimensionOverflow)?;
+            state.last_used_generation = generation;
+            std::mem::take(&mut state.keys)
+        };
+        let removed = keys
+            .iter()
+            .filter(|key| self.entries.remove(key).is_some())
+            .count();
+        debug_assert_eq!(removed, keys.len());
+        self.stats.entries = self.entries.len();
+        match plane {
+            GlyphAtlasPlane::Mask => {
+                self.stats.mask_entries = self.stats.mask_entries.saturating_sub(removed)
+            }
+            GlyphAtlasPlane::Color => {
+                self.stats.color_entries = self.stats.color_entries.saturating_sub(removed)
+            }
+        }
+        self.stats.page_evictions = self.stats.page_evictions.saturating_add(1);
+        self.stats.page_reuses = self.stats.page_reuses.saturating_add(1);
+        self.stats.image_entries_evicted = self
+            .stats
+            .image_entries_evicted
+            .saturating_add(removed as u64);
+        Ok(())
+    }
+
+    fn touch_entry(&mut self, entry: GlyphAtlasEntry) {
+        let GlyphAtlasEntry::Image(image) = entry else {
+            return;
+        };
+        let Ok(page_index) = usize::try_from(image.page) else {
+            debug_assert!(false, "cached glyph atlas page must fit usize");
+            return;
+        };
+        let generation = self.generation;
+        if let Some(state) = self.page_states_mut(image.plane).get_mut(page_index) {
+            state.last_used_generation = generation;
+        } else {
+            debug_assert!(false, "cached glyph atlas page must remain resident");
+        }
+    }
+
+    fn record_page_key(
+        &mut self,
+        plane: GlyphAtlasPlane,
+        page: u32,
+        key: GlyphRasterKey,
+    ) -> Result<(), GlyphAtlasError> {
+        let page_index = usize::try_from(page).map_err(|_| GlyphAtlasError::DimensionOverflow)?;
+        let generation = self.generation;
+        let state = self
+            .page_states_mut(plane)
+            .get_mut(page_index)
+            .ok_or(GlyphAtlasError::DimensionOverflow)?;
+        state.last_used_generation = generation;
+        state.keys.push(key);
+        Ok(())
+    }
+
+    fn page_states(&self, plane: GlyphAtlasPlane) -> &[AtlasPlaneState] {
+        match plane {
+            GlyphAtlasPlane::Mask => &self.mask_pages,
+            GlyphAtlasPlane::Color => &self.color_pages,
+        }
+    }
+
+    fn page_states_mut(&mut self, plane: GlyphAtlasPlane) -> &mut [AtlasPlaneState] {
+        match plane {
+            GlyphAtlasPlane::Mask => &mut self.mask_pages,
+            GlyphAtlasPlane::Color => &mut self.color_pages,
         }
     }
 
@@ -595,7 +759,13 @@ impl GpuGlyphAtlas {
         for _ in 0..missing {
             let next_page = u32::try_from(self.page_count(plane))
                 .map_err(|_| GlyphAtlasError::DimensionOverflow)?;
-            let state = AtlasPlaneState::new(device, plane, self.extent, next_page);
+            let state = AtlasPlaneState::new(
+                device,
+                plane,
+                self.extent,
+                next_page,
+                self.generation,
+            );
             match plane {
                 GlyphAtlasPlane::Mask => self.mask_pages.push(state),
                 GlyphAtlasPlane::Color => self.color_pages.push(state),
@@ -752,6 +922,14 @@ mod tests {
         assert_eq!(atlas.max_pages_per_plane(), 1);
         assert_eq!(atlas.page_count(GlyphAtlasPlane::Mask), 0);
         assert_eq!(atlas.page_count(GlyphAtlasPlane::Color), 0);
+        assert_eq!(atlas.generation(), 1);
+    }
+
+    #[test]
+    fn generation_wrap_releases_old_page_pins() {
+        let mut atlas = GpuGlyphAtlas::new(8).unwrap();
+        atlas.generation = u64::MAX;
+        assert_eq!(atlas.begin_generation(), 1);
     }
 
     #[test]

--- a/crates/noon-text-atlas/tests/gpu_upload.rs
+++ b/crates/noon-text-atlas/tests/gpu_upload.rs
@@ -178,12 +178,7 @@ fn noop_device_reuses_oldest_unpinned_page_without_reallocating_texture() {
 
     for glyph_id in 1..=4 {
         let GlyphAtlasEntry::Image(image) = atlas
-            .insert(
-                &device,
-                &queue,
-                glyph_key(glyph_id),
-                &full_page_raster,
-            )
+            .insert(&device, &queue, glyph_key(glyph_id), &full_page_raster)
             .unwrap()
         else {
             panic!("visible mask glyph must occupy the atlas");

--- a/crates/noon-text-atlas/tests/gpu_upload.rs
+++ b/crates/noon-text-atlas/tests/gpu_upload.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use noon_core::{FontResourceHandle, FontResourceId};
-use noon_text_atlas::{GlyphAtlasEntry, GlyphAtlasPlane, GpuGlyphAtlas};
+use noon_text_atlas::{GlyphAtlasEntry, GlyphAtlasError, GlyphAtlasPlane, GpuGlyphAtlas};
 use noon_text_raster::{
     GlyphRaster, GlyphRasterFormat, GlyphRasterImage, GlyphRasterKey, GlyphRasterPlacement,
 };
@@ -138,4 +138,86 @@ fn noop_device_allocates_live_pages_within_explicit_budget() {
         .texture_view_for_page(GlyphAtlasPlane::Mask, 2)
         .is_none());
     assert_eq!(atlas.stats().texture_allocations, 2);
+}
+
+#[test]
+fn noop_device_keeps_current_generation_pages_pinned() {
+    let (device, queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
+    let mut atlas = GpuGlyphAtlas::with_page_limit(8, 1).unwrap();
+    let raster = mask_raster(4, 2, 200);
+
+    for glyph_id in 1..=2 {
+        atlas
+            .insert(&device, &queue, glyph_key(glyph_id), &raster)
+            .unwrap();
+    }
+    assert_eq!(atlas.stats().texture_allocations, 1);
+
+    let error = atlas
+        .insert(&device, &queue, glyph_key(3), &mask_raster(1, 1, 255))
+        .unwrap_err();
+    assert_eq!(
+        error,
+        GlyphAtlasError::Full {
+            plane: GlyphAtlasPlane::Mask,
+            extent: 8,
+        }
+    );
+    assert_eq!(atlas.stats().page_evictions, 0);
+    assert_eq!(atlas.stats().page_reuses, 0);
+    assert_eq!(atlas.stats().texture_allocations, 1);
+    assert!(atlas.get(glyph_key(1)).is_some());
+    assert!(atlas.get(glyph_key(2)).is_some());
+}
+
+#[test]
+fn noop_device_reuses_oldest_unpinned_page_without_reallocating_texture() {
+    let (device, queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
+    let mut atlas = GpuGlyphAtlas::with_page_limit(8, 2).unwrap();
+    let full_page_raster = mask_raster(4, 2, 180);
+
+    for glyph_id in 1..=4 {
+        let GlyphAtlasEntry::Image(image) = atlas
+            .insert(
+                &device,
+                &queue,
+                glyph_key(glyph_id),
+                &full_page_raster,
+            )
+            .unwrap()
+        else {
+            panic!("visible mask glyph must occupy the atlas");
+        };
+        assert_eq!(image.page, u32::from(glyph_id > 2));
+    }
+    assert_eq!(atlas.page_count(GlyphAtlasPlane::Mask), 2);
+    assert_eq!(atlas.stats().texture_allocations, 2);
+
+    assert_eq!(atlas.begin_generation(), 2);
+    atlas
+        .insert(&device, &queue, glyph_key(4), &full_page_raster)
+        .unwrap();
+
+    let GlyphAtlasEntry::Image(reused) = atlas
+        .insert(&device, &queue, glyph_key(5), &mask_raster(1, 1, 255))
+        .unwrap()
+    else {
+        panic!("visible mask glyph must occupy the atlas");
+    };
+    assert_eq!(reused.page, 0);
+    assert_eq!(reused.origin, [1, 1]);
+
+    assert_eq!(atlas.get(glyph_key(1)), None);
+    assert_eq!(atlas.get(glyph_key(2)), None);
+    assert!(atlas.get(glyph_key(3)).is_some());
+    assert!(atlas.get(glyph_key(4)).is_some());
+    assert!(atlas.get(glyph_key(5)).is_some());
+
+    let stats = atlas.stats();
+    assert_eq!(stats.entries, 3);
+    assert_eq!(stats.mask_entries, 3);
+    assert_eq!(stats.texture_allocations, 2);
+    assert_eq!(stats.page_evictions, 1);
+    assert_eq!(stats.page_reuses, 1);
+    assert_eq!(stats.image_entries_evicted, 2);
 }


### PR DESCRIPTION
## Summary
- add explicit atlas residency generations; page hits and uploads pin the referenced page for the current generation
- when a bounded plane is full, deterministically reuse the oldest unpinned page by `(last_used_generation, page_index)`
- reset only the selected shelf packer while reusing the existing GPU texture/view
- track exact per-page glyph-key ownership so eviction removes stale atlas entries atomically
- add cumulative page-eviction/reuse and image-entry-eviction counters
- add noop-GPU coverage for same-generation pin protection and cross-generation page reuse without new texture allocation

## Compatibility
- callers that never call `begin_generation()` retain the existing behavior: once all configured pages are full, insertion returns `GlyphAtlasError::Full`
- this PR intentionally does not yet wire `RetainedTextQuadPreparer` to advance generations; that is the next small integration slice after the residency primitive is validated
- empty-glyph metadata remains a separate bounded-LRU follow-up because it has no page ownership

Tracks #363.