### PR TITLE
Expose Rust-owned native Text layout queries

### DIFF
--- a/crates/noon-web/src/retained_authoring.rs
+++ b/crates/noon-web/src/retained_authoring.rs
@@ -1,5 +1,7 @@
 use std::collections::HashSet;
 
+#[cfg(any(target_arch = "wasm32", test))]
+use noon_core::Rect;
 use noon_core::{Color, ObjectId, Transform2D, Vec2, WHITE};
 use serde::{Deserialize, Serialize};
 
@@ -262,6 +264,61 @@ const fn default_opacity() -> f32 {
     1.0
 }
 
+#[cfg(any(target_arch = "wasm32", test))]
+fn native_text_intrinsic_bounds(spec: &RetainedTextAuthoringSpec) -> Result<Rect, String> {
+    let RetainedTextBackendSpec::Native {
+        font_family,
+        line_spacing,
+    } = &spec.backend
+    else {
+        return Err("native text bounds require the native backend".to_owned());
+    };
+
+    let mut scene = noon::RetainedScene::new();
+    scene
+        .add_text(
+            noon::Text::new(spec.source.clone())
+                .with_font(font_family.clone())
+                .with_font_size(spec.font_size)
+                .with_line_spacing(*line_spacing),
+        )
+        .map_err(|error| error.to_string())?;
+    let object = scene
+        .objects()
+        .first()
+        .ok_or_else(|| "native text measurement produced no retained object".to_owned())?;
+    let handle = object
+        .content
+        .text()
+        .ok_or_else(|| "native text measurement produced no text resource".to_owned())?;
+    let resource = scene
+        .texts()
+        .get(handle)
+        .ok_or_else(|| "native text measurement lost its text resource".to_owned())?;
+    let scale = object.transform.scale;
+    Ok(Rect::new(
+        Vec2::new(
+            resource.bounds.min.x * scale.x,
+            resource.bounds.min.y * scale.y,
+        ),
+        Vec2::new(
+            resource.bounds.max.x * scale.x,
+            resource.bounds.max.y * scale.y,
+        ),
+    ))
+}
+
+#[cfg(any(target_arch = "wasm32", test))]
+fn transformed_bounds(bounds: Rect, transform: Transform2D) -> Rect {
+    Rect::from_points([
+        transform.transform_point(bounds.min),
+        transform.transform_point(Vec2::new(bounds.min.x, bounds.max.y)),
+        transform.transform_point(Vec2::new(bounds.max.x, bounds.min.y)),
+        transform.transform_point(bounds.max),
+    ])
+    .expect("four transformed text bounds corners are never empty")
+}
+
 #[cfg(target_arch = "wasm32")]
 mod wasm {
     use super::*;
@@ -344,10 +401,19 @@ mod wasm {
     }
 
     /// Rust-owned source handle for native plain text. Font discovery, shaping,
-    /// exact font bytes, glyphs, and atlas state never cross into Python.
+    /// exact font bytes, glyphs, and atlas state never cross into Python. The
+    /// canonical native compiler is also used once at construction to cache only
+    /// the scene-space layout bounds required by authoring-time placement queries.
     #[wasm_bindgen(js_name = RetainedNativeTextAuthoringHandle)]
     pub struct WasmRetainedNativeTextAuthoringHandle {
         inner: RetainedTextAuthoringSpec,
+        intrinsic_bounds: Rect,
+    }
+
+    impl WasmRetainedNativeTextAuthoringHandle {
+        fn bounds(&self) -> Rect {
+            transformed_bounds(self.intrinsic_bounds, self.inner.transform)
+        }
     }
 
     #[wasm_bindgen(js_class = RetainedNativeTextAuthoringHandle)]
@@ -359,14 +425,13 @@ mod wasm {
             font_size: f32,
             line_spacing: f32,
         ) -> Result<Self, JsValue> {
+            let inner =
+                RetainedTextAuthoringSpec::native(source, font_family, font_size, line_spacing)
+                    .map_err(js_error)?;
+            let intrinsic_bounds = native_text_intrinsic_bounds(&inner).map_err(js_error)?;
             Ok(Self {
-                inner: RetainedTextAuthoringSpec::native(
-                    source,
-                    font_family,
-                    font_size,
-                    line_spacing,
-                )
-                .map_err(js_error)?,
+                inner,
+                intrinsic_bounds,
             })
         }
 
@@ -394,6 +459,42 @@ mod wasm {
         #[wasm_bindgen(getter, js_name = fontSize)]
         pub fn font_size(&self) -> f32 {
             self.inner.font_size
+        }
+
+        #[wasm_bindgen(getter, js_name = centerX)]
+        pub fn center_x(&self) -> f64 {
+            f64::from(self.bounds().center().x)
+        }
+
+        #[wasm_bindgen(getter, js_name = centerY)]
+        pub fn center_y(&self) -> f64 {
+            f64::from(self.bounds().center().y)
+        }
+
+        #[wasm_bindgen(getter)]
+        pub fn width(&self) -> f64 {
+            f64::from(self.bounds().width())
+        }
+
+        #[wasm_bindgen(getter)]
+        pub fn height(&self) -> f64 {
+            f64::from(self.bounds().height())
+        }
+
+        #[wasm_bindgen(js_name = criticalX)]
+        pub fn critical_x(&self, direction_x: f64, direction_y: f64) -> f64 {
+            let point = self
+                .bounds()
+                .critical_point(Vec2::new(direction_x as f32, direction_y as f32));
+            f64::from(point.x)
+        }
+
+        #[wasm_bindgen(js_name = criticalY)]
+        pub fn critical_y(&self, direction_x: f64, direction_y: f64) -> f64 {
+            let point = self
+                .bounds()
+                .critical_point(Vec2::new(direction_x as f32, direction_y as f32));
+            f64::from(point.y)
         }
 
         #[wasm_bindgen(js_name = shift)]
@@ -474,6 +575,39 @@ mod tests {
             let round_trip: RetainedTextAuthoringSpec = serde_json::from_str(&json).unwrap();
             assert_eq!(round_trip, spec);
         }
+    }
+
+    #[test]
+    fn native_layout_bounds_reuse_canonical_text_authoring() {
+        let spec = RetainedTextAuthoringSpec::native(
+            "Native Noon",
+            noon::DEFAULT_NATIVE_TEXT_FONT_FAMILY,
+            48.0,
+            -1.0,
+        )
+        .unwrap();
+        let bounds = native_text_intrinsic_bounds(&spec).unwrap();
+        assert!(bounds.width() > 0.0);
+        assert!(bounds.height() > 0.0);
+        assert!(bounds.center().x.abs() < 1.0e-5);
+        assert!(bounds.center().y.abs() < 1.0e-5);
+    }
+
+    #[test]
+    fn retained_layout_transform_produces_world_space_aabb() {
+        let bounds = Rect::new(Vec2::new(-1.0, -0.5), Vec2::new(1.0, 0.5));
+        let transformed = transformed_bounds(
+            bounds,
+            Transform2D {
+                translation: Vec2::new(3.0, -2.0),
+                scale: Vec2::new(2.0, 1.0),
+                rotation: std::f32::consts::FRAC_PI_2,
+            },
+        );
+        assert!((transformed.center().x - 3.0).abs() < 1.0e-6);
+        assert!((transformed.center().y + 2.0).abs() < 1.0e-6);
+        assert!((transformed.width() - 1.0).abs() < 1.0e-5);
+        assert!((transformed.height() - 4.0).abs() < 1.0e-5);
     }
 
     #[test]

--- a/scripts/manim-typst-authoring-smoke.mjs
+++ b/scripts/manim-typst-authoring-smoke.mjs
@@ -55,6 +55,20 @@ class MultilineText(Scene):
         self.add(text)
 `;
 
+const nativeTextLayoutSource = `from noon import *
+
+
+class NativeTextLayout(Scene):
+    def construct(self):
+        box = Square(side_length=2)
+        label = Text("Native Noon", font_size=48)
+        if label.width <= 0 or label.height <= 0:
+            raise RuntimeError("native Text layout metrics must be positive")
+        label.width = 2
+        label.next_to(box, RIGHT, buff=0.25)
+        self.add(box, label)
+`;
+
 const helloTypstSource = `from noon import *
 
 
@@ -108,6 +122,7 @@ function assertNativeText(result, expected) {
   assert.equal(object.text.backend.kind, "native");
   assert.equal(object.text.backend.font_family, expected.fontFamily ?? "DejaVu Sans Mono");
   assert.equal(object.text.backend.line_spacing, expected.lineSpacing ?? -1);
+  return object;
 }
 
 function assertTypst(result, expected) {
@@ -236,6 +251,25 @@ try {
     order: 0,
   });
 
+  const nativeLayout = await page.evaluate(
+    (source) => window.noonRetainedTextSmoke.run(source),
+    nativeTextLayoutSource,
+  );
+  assert.equal(nativeLayout.document.objects.length, 1, "layout scene must retain only the Square as geometry");
+  assert.equal(nativeLayout.document.objects[0].id, 0);
+  const nativeLayoutText = assertNativeText(nativeLayout, {
+    source: "Native Noon",
+    fontSize: 48,
+    order: 1,
+  });
+  assert.ok(
+    Math.abs(nativeLayoutText.text.transform.translation.x - 2.25) < 1e-4,
+    "Text.next_to must use Rust-owned width/critical-point metrics",
+  );
+  assert.ok(Math.abs(nativeLayoutText.text.transform.translation.y) < 1e-5);
+  assert.ok(Math.abs(nativeLayoutText.text.transform.scale.x - nativeLayoutText.text.transform.scale.y) < 1e-6);
+  assert.ok(nativeLayoutText.text.transform.scale.x > 0);
+
   const helloTypst = await page.evaluate(
     (source) => window.noonRetainedTextSmoke.run(source),
     helloTypstSource,
@@ -280,7 +314,7 @@ try {
   await page.evaluate(() => window.noonRetainedTextSmoke.stop());
   assert.deepEqual(errors, [], `browser errors while testing retained text authoring:\n${errors.join("\n")}`);
   console.log(
-    "Retained text authoring smoke passed: native Text and pinned Manim v0.21 Typst/MathTypst sources emit backend-neutral source-only sidecars, zero placeholder geometry, exact JS-safe identities, and deterministic mixed painter order.",
+    "Retained text authoring smoke passed: native Text layout/placement and pinned Manim v0.21 Typst/MathTypst sources emit backend-neutral source-only sidecars, zero placeholder geometry, exact JS-safe identities, and deterministic mixed painter order.",
   );
 } finally {
   await browser?.close();

--- a/web/python/_manim_typst.py
+++ b/web/python/_manim_typst.py
@@ -145,6 +145,15 @@ def _as_color(value: object) -> _base.Color:
     raise TypeError("retained text color must be a Noon/Manim Color")
 
 
+def _native_layout_handle(handle: object):
+    required = ("centerX", "centerY", "width", "height", "criticalX", "criticalY")
+    if not all(hasattr(handle, name) for name in required):
+        raise NotImplementedError(
+            "native Text layout queries require the Rust/WASM retained authoring handle"
+        )
+    return handle
+
+
 class _RetainedTextMobject(_base.Mobject):
     """Python semantic identity for one retained resource-backed text object."""
 
@@ -367,6 +376,46 @@ class Text(_RetainedTextMobject):
     @property
     def line_spacing(self) -> float:
         return self._line_spacing
+
+    def get_center(self) -> _base.Vec2:
+        handle = _native_layout_handle(self._retained_handle)
+        return _base.Vec2(float(handle.centerX), float(handle.centerY))
+
+    @property
+    def width(self) -> float:
+        return float(_native_layout_handle(self._retained_handle).width)
+
+    @width.setter
+    def width(self, value: float) -> None:
+        target = float(value)
+        current = self.width
+        if not math.isfinite(target) or target <= 0.0:
+            raise ValueError("Text width must be finite and positive")
+        if current <= 0.0:
+            raise ValueError("cannot set width of zero-width Text")
+        self.scale(target / current)
+
+    @property
+    def height(self) -> float:
+        return float(_native_layout_handle(self._retained_handle).height)
+
+    @height.setter
+    def height(self, value: float) -> None:
+        target = float(value)
+        current = self.height
+        if not math.isfinite(target) or target <= 0.0:
+            raise ValueError("Text height must be finite and positive")
+        if current <= 0.0:
+            raise ValueError("cannot set height of zero-height Text")
+        self.scale(target / current)
+
+    def get_critical_point(self, direction: object) -> _base.Vec2:
+        axis = _compat._as_vec2(direction)
+        handle = _native_layout_handle(self._retained_handle)
+        return _base.Vec2(
+            float(handle.criticalX(float(axis.x), float(axis.y))),
+            float(handle.criticalY(float(axis.x), float(axis.y))),
+        )
 
     def _copy_constructor(self) -> Text:
         return type(self)(


### PR DESCRIPTION
## Summary
- derive native `Text` authoring bounds from the canonical Rust `noon::Text` compiler/font policy rather than reimplementing measurement in Python
- cache only the intrinsic scene-space `Rect` on the WASM source handle; shaped glyphs, font bytes, SVG, geometry, and atlas state remain Rust-owned and absent from the authoring wire
- expose center/width/height/critical-point scalar queries that update from ordinary retained transforms without reshaping
- wire Python `Text.width`, `Text.height`, `get_center`, and `get_critical_point` to those Rust-owned queries
- exercise Manim-style `Text.next_to(...)` and width scaling in the browser authoring smoke

## Architecture
The measurement path deliberately authors one temporary native `Text` through the same public Rust path introduced by #582, reads its normalized `TextResource.bounds`, converts to scene units, and drops the temporary resource arenas. Python never measures text or receives glyph/font resources.

#586 is merged. This branch has been replayed as one commit directly on current master because none of its three target files changed across the intervening 29 commits. The browser/Python blobs are byte-identical to the previously qualified implementation. The only Rust adjustment cfg-gates the layout helpers and `Rect` import to `wasm32 || test`, fixing the native-library Clippy dead-code failure without suppressing lints.

## Validation
The browser smoke creates `Square(2)` plus `Text("Native Noon")`, asserts positive native metrics, sets `label.width = 2`, then uses `label.next_to(box, RIGHT, buff=0.25)` and requires the retained text center to land at x=2.25 with zero placeholder text geometry.

Fresh exact-head CI is required before merge.

Related: #364, #361, #582, #586