### PR TITLE
Add geometry-independent scale timeline channel

### DIFF
--- a/crates/noon-compile/src/lib.rs
+++ b/crates/noon-compile/src/lib.rs
@@ -18,6 +18,7 @@ pub struct DynamicProperties {
     pub transform: bool,
     pub position: bool,
     pub rotation: bool,
+    pub scale: bool,
     pub opacity: bool,
     pub appearance: bool,
     pub reveal: bool,
@@ -31,6 +32,7 @@ impl DynamicProperties {
             Property::Transform => self.transform = true,
             Property::Position => self.position = true,
             Property::Rotation => self.rotation = true,
+            Property::Scale => self.scale = true,
             Property::Opacity => self.opacity = true,
             Property::Appearance => self.appearance = true,
             Property::Reveal => self.reveal = true,
@@ -43,6 +45,7 @@ impl DynamicProperties {
             || self.transform
             || self.position
             || self.rotation
+            || self.scale
             || self.opacity
             || self.appearance
             || self.reveal
@@ -1151,10 +1154,11 @@ const fn property_rank(property: Property) -> u8 {
         Property::Transform => 1,
         Property::Position => 2,
         Property::Rotation => 3,
-        Property::Opacity => 4,
-        Property::Appearance => 5,
-        Property::Reveal => 6,
-        Property::Morph => 7,
+        Property::Scale => 4,
+        Property::Opacity => 5,
+        Property::Appearance => 6,
+        Property::Reveal => 7,
+        Property::Morph => 8,
     }
 }
 
@@ -1344,6 +1348,7 @@ mod tests {
                 transform: false,
                 position: false,
                 rotation: false,
+                scale: false,
                 opacity: true,
                 appearance: false,
                 reveal: false,
@@ -1351,6 +1356,28 @@ mod tests {
             }
         );
         assert!(!compiled.objects()[static_index].dynamic.any());
+    }
+
+    #[test]
+    fn scale_tracks_mark_only_scale_dynamic() {
+        let mut scene = SceneDefinition::new();
+        let object = scene.add(GeometryRef::circle(1.0));
+        scene
+            .animate_scale(
+                object,
+                Vec2::ONE,
+                Vec2::new(2.0, 0.5),
+                TrackTiming::new(0.0, 1.0, Easing::Linear),
+            )
+            .expect("valid scale track");
+        let compiled = CompiledScene::compile(&scene).expect("scene must compile");
+        assert_eq!(
+            compiled.objects()[0].dynamic,
+            DynamicProperties {
+                scale: true,
+                ..DynamicProperties::default()
+            }
+        );
     }
 
     #[test]
@@ -1489,6 +1516,7 @@ mod tests {
                 transform: false,
                 position: false,
                 rotation: false,
+                scale: false,
                 opacity: false,
                 appearance: false,
                 reveal: true,

--- a/crates/noon-core/src/timeline.rs
+++ b/crates/noon-core/src/timeline.rs
@@ -88,6 +88,7 @@ pub enum Property {
     Transform,
     Position,
     Rotation,
+    Scale,
     Opacity,
     Appearance,
     Reveal,
@@ -107,7 +108,7 @@ impl Property {
         match self {
             Self::Presence => ValueKind::Bool,
             Self::Transform => ValueKind::Object,
-            Self::Position => ValueKind::Vec2,
+            Self::Position | Self::Scale => ValueKind::Vec2,
             Self::Rotation | Self::Opacity | Self::Appearance | Self::Reveal | Self::Morph => {
                 ValueKind::Scalar
             }
@@ -478,6 +479,21 @@ impl SceneDefinition {
         )
     }
 
+    pub fn animate_scale(
+        &mut self,
+        object: ObjectId,
+        from: Vec2,
+        to: Vec2,
+        timing: TrackTiming,
+    ) -> Result<TrackId, TimelineError> {
+        self.add_track(
+            object,
+            Property::Scale,
+            TrackValues::Vec2 { from, to },
+            timing,
+        )
+    }
+
     pub fn animate_scalar(
         &mut self,
         object: ObjectId,
@@ -680,6 +696,24 @@ mod tests {
             ),
             Err(TimelineError::InvalidDuration(0.0))
         ));
+    }
+
+    #[test]
+    fn scale_is_a_vec2_timeline_property() {
+        let mut scene = SceneDefinition::new();
+        let object = scene.add(GeometryRef::circle(1.0));
+        let track = scene
+            .animate_scale(object, Vec2::ONE, Vec2::new(2.0, 0.5), timing())
+            .expect("valid scale track");
+        assert_eq!(track, TrackId::new(0));
+        assert_eq!(scene.tracks()[0].property, Property::Scale);
+        assert_eq!(
+            scene.tracks()[0].values,
+            TrackValues::Vec2 {
+                from: Vec2::ONE,
+                to: Vec2::new(2.0, 0.5)
+            }
+        );
     }
 
     #[test]

--- a/crates/noon-runtime/src/lib.rs
+++ b/crates/noon-runtime/src/lib.rs
@@ -523,7 +523,12 @@ impl SceneInstance {
                 self.frame.objects[index].transform = *transform;
                 self.reapply_properties(
                     index,
-                    &[Property::Transform, Property::Position, Property::Rotation],
+                    &[
+                        Property::Transform,
+                        Property::Position,
+                        Property::Rotation,
+                        Property::Scale,
+                    ],
                 );
             }
             ScenePatch::SetStyle { style, .. } => {
@@ -696,11 +701,12 @@ fn initial_scalar_property(
     values
 }
 
-const PROPERTY_ORDER: [Property; 8] = [
+const PROPERTY_ORDER: [Property; 9] = [
     Property::Presence,
     Property::Transform,
     Property::Position,
     Property::Rotation,
+    Property::Scale,
     Property::Opacity,
     Property::Appearance,
     Property::Reveal,
@@ -927,6 +933,12 @@ fn apply_evaluated_value(
             let object = &mut frame.objects[object_index];
             let changed = object.transform.rotation != value;
             object.transform.rotation = value;
+            changed
+        }
+        (Property::Scale, EvaluatedValue::Vec2(value)) => {
+            let object = &mut frame.objects[object_index];
+            let changed = object.transform.scale != value;
+            object.transform.scale = value;
             changed
         }
         (Property::Opacity, EvaluatedValue::Scalar(value)) => {
@@ -1380,6 +1392,40 @@ mod tests {
                 .transform
                 .translation,
             Vec2::new(10.0, 0.0)
+        );
+    }
+
+    #[test]
+    fn scale_timeline_endpoints_and_midpoint_are_exact() {
+        let mut scene = SceneDefinition::new();
+        let object = scene.add(GeometryRef::circle(1.0));
+        scene
+            .animate_scale(
+                object,
+                Vec2::ONE,
+                Vec2::new(3.0, 2.0),
+                TrackTiming::new(1.0, 2.0, Easing::Linear),
+            )
+            .expect("valid scale track");
+        let mut instance =
+            SceneInstance::new(CompiledScene::compile(&scene).expect("scene must compile"));
+        assert_eq!(
+            instance.seek(1.0).expect("valid time").objects[0]
+                .transform
+                .scale,
+            Vec2::ONE
+        );
+        assert_eq!(
+            instance.seek(2.0).expect("valid time").objects[0]
+                .transform
+                .scale,
+            Vec2::new(2.0, 1.5)
+        );
+        assert_eq!(
+            instance.seek(3.0).expect("valid time").objects[0]
+                .transform
+                .scale,
+            Vec2::new(3.0, 2.0)
         );
     }
 

--- a/crates/noon-runtime/src/reactive_impl.rs
+++ b/crates/noon-runtime/src/reactive_impl.rs
@@ -107,11 +107,12 @@ impl ReactiveRuntime {
     }
 
     fn rebind_object(&mut self, object: ObjectId, object_index: usize) {
-        const PROPERTIES: [Property; 8] = [
+        const PROPERTIES: [Property; 9] = [
             Property::Presence,
             Property::Transform,
             Property::Position,
             Property::Rotation,
+            Property::Scale,
             Property::Opacity,
             Property::Appearance,
             Property::Reveal,
@@ -286,10 +287,11 @@ const fn property_slot(property: Property) -> u8 {
         Property::Transform => 1,
         Property::Position => 2,
         Property::Rotation => 3,
-        Property::Opacity => 4,
-        Property::Appearance => 5,
-        Property::Reveal => 6,
-        Property::Morph => 7,
+        Property::Scale => 4,
+        Property::Opacity => 5,
+        Property::Appearance => 6,
+        Property::Reveal => 7,
+        Property::Morph => 8,
     }
 }
 
@@ -315,6 +317,12 @@ fn apply_reactive_value(
             let object = &mut frame.objects[object_index];
             let changed = object.transform.rotation != *value;
             object.transform.rotation = *value;
+            changed
+        }
+        (Property::Scale, ReactiveValue::Vec2(value)) => {
+            let object = &mut frame.objects[object_index];
+            let changed = object.transform.scale != *value;
+            object.transform.scale = *value;
             changed
         }
         (Property::Opacity, ReactiveValue::Scalar(value)) => {
@@ -367,6 +375,28 @@ mod tests {
             instance.frame().objects[0].transform.translation,
             Vec2::new(3.0, -2.0)
         );
+    }
+
+    #[test]
+    fn reactive_scale_updates_transform_without_touching_geometry() {
+        let mut scene = SemanticScene::new();
+        let object = scene.add(GeometryRef::circle(1.0));
+        let scale = scene.add_input(Vec2::ONE);
+        scene.bind(scale, object, Property::Scale);
+
+        let mut instance =
+            SceneInstance::from_semantic(&scene).expect("semantic scene must compile");
+        assert_eq!(instance.frame().objects[0].transform.scale, Vec2::ONE);
+        assert_eq!(instance.frame().objects[0].geometry, GeometryRef::circle(1.0));
+
+        instance
+            .set_reactive_input(scale, Vec2::new(0.25, 2.0))
+            .expect("scale input update must work");
+        assert_eq!(
+            instance.frame().objects[0].transform.scale,
+            Vec2::new(0.25, 2.0)
+        );
+        assert_eq!(instance.frame().objects[0].geometry, GeometryRef::circle(1.0));
     }
 
     #[test]
@@ -514,5 +544,4 @@ mod tests {
         assert!(!instance.frame().presences[1]);
         assert_eq!(instance.last_reactive_stats().dense_targets_applied, 1);
     }
-
 }

--- a/crates/noon-runtime/src/retained.rs
+++ b/crates/noon-runtime/src/retained.rs
@@ -373,6 +373,11 @@ fn retained_apply_evaluated_value(
             frame.objects[index].transform.rotation = value;
             changed
         }
+        (Property::Scale, EvaluatedValue::Vec2(value)) => {
+            let changed = frame.objects[index].transform.scale != value;
+            frame.objects[index].transform.scale = value;
+            changed
+        }
         (Property::Opacity, EvaluatedValue::Scalar(value)) => {
             let changed = frame.objects[index].style.opacity != value;
             frame.objects[index].style.opacity = value;
@@ -539,6 +544,36 @@ mod tests {
         assert!((frame.objects[0].style.opacity - 0.6).abs() < 1e-6);
         assert_eq!(frame.appearance(0), 0.5);
         assert_eq!(frame.text(0), Some(text_handle()));
+    }
+
+    #[test]
+    fn retained_text_scale_track_preserves_resource_identity() {
+        let object = ObjectId::new(3);
+        let handle = text_handle();
+        let objects = [RetainedObjectDefinition::text(object, handle)];
+        let tracks = [text_track(
+            0,
+            object,
+            Property::Scale,
+            TrackValues::Vec2 {
+                from: Vec2::ONE,
+                to: Vec2::new(0.0, 0.0),
+            },
+            0.0,
+            2.0,
+        )];
+        let compiled = RetainedCompiledScene::compile(&objects, &tracks).unwrap();
+        let mut runtime = RetainedSceneInstance::new(compiled);
+
+        let midpoint = runtime.seek(1.0).unwrap();
+        assert_eq!(midpoint.objects[0].transform.scale, Vec2::new(0.5, 0.5));
+        assert_eq!(midpoint.text(0), Some(handle));
+        assert_eq!(midpoint.render_geometry(0), None);
+
+        let end = runtime.seek(2.0).unwrap();
+        assert_eq!(end.objects[0].transform.scale, Vec2::ZERO);
+        assert_eq!(end.text(0), Some(handle));
+        assert_eq!(end.render_geometry(0), None);
     }
 
     #[test]


### PR DESCRIPTION
Adds a first-class, geometry-independent `Scale` `Vec2` timeline property for retained and legacy objects.

This keeps legacy geometry-morph `Transform` semantics unchanged while allowing resource-backed objects such as native retained `Text` to animate scale without geometry-bearing `ObjectSnapshot`s or placeholder geometry.

Included:
- core `Property::Scale` type/validation and `animate_scale` authoring helper;
- compiler dynamic-property tracking and deterministic channel ordering;
- legacy and retained runtime evaluation;
- reactive runtime propagation for the same typed scale channel;
- retained-text regression proving scale-to-zero preserves the exact `TextResourceHandle` and never creates render geometry;
- deterministic endpoint/midpoint and reactive-scale tests.

This is the shared runtime prerequisite for restoring animations such as Manim's `ShrinkToCenter(Text("Hello World!"))` without a Text-specific animation path.