### PR TITLE
Carry execution layout generation into renderer mirror

### DIFF
--- a/crates/noon-web/src/execution_transport.rs
+++ b/crates/noon-web/src/execution_transport.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use crate::{ClockError, PlaybackClock, PlayerError, ReconcileOutcome, ScenePlayer};
 
 pub const EXECUTION_TRANSPORT_CHANNEL: &str = "noon.execution";
-pub const EXECUTION_TRANSPORT_VERSION: u32 = 1;
+pub const EXECUTION_TRANSPORT_VERSION: u32 = 2;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct TransportSlotId {
@@ -49,6 +49,7 @@ pub struct ExecutionDeltaEnvelope {
     pub sequence: u64,
     pub snapshot: bool,
     pub time: f64,
+    pub layout_generation: u64,
     #[serde(default)]
     pub camera: Camera2DState,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -210,6 +211,7 @@ pub struct ExecutionDeltaEncoder {
     slot_orders: HashMap<TransportSlotId, u32>,
     next_order: u32,
     camera_object: Option<ObjectId>,
+    layout_generation: u64,
 }
 
 impl ExecutionDeltaEncoder {
@@ -221,6 +223,7 @@ impl ExecutionDeltaEncoder {
             slot_orders: HashMap::new(),
             next_order: 0,
             camera_object: None,
+            layout_generation: 0,
         }
     }
 
@@ -242,6 +245,10 @@ impl ExecutionDeltaEncoder {
 
     pub fn set_camera_object(&mut self, camera_object: Option<ObjectId>) {
         self.camera_object = camera_object;
+    }
+
+    pub fn set_layout_generation(&mut self, layout_generation: u64) {
+        self.layout_generation = layout_generation;
     }
 
     pub fn contains_slot(&self, slot: ExecutionSlotId) -> bool {
@@ -281,6 +288,7 @@ impl ExecutionDeltaEncoder {
             sequence,
             snapshot: true,
             time: frame.time,
+            layout_generation: self.layout_generation,
             camera,
             removed: Vec::new(),
             objects,
@@ -351,6 +359,7 @@ impl ExecutionDeltaEncoder {
             sequence,
             snapshot: false,
             time: frame.time,
+            layout_generation: self.layout_generation,
             camera,
             removed,
             objects,
@@ -417,6 +426,7 @@ impl ExecutionDeltaEncoder {
 pub struct ExecutionFrameMirror {
     session: Option<u32>,
     next_sequence: u64,
+    layout_generation: u64,
     slots: Vec<TransportSlotId>,
     slot_indices: HashMap<TransportSlotId, usize>,
     object_slots: HashMap<ObjectId, TransportSlotId>,
@@ -439,6 +449,14 @@ impl ExecutionFrameMirror {
 
     pub const fn next_sequence(&self) -> u64 {
         self.next_sequence
+    }
+
+    pub const fn layout_generation(&self) -> u64 {
+        self.layout_generation
+    }
+
+    pub fn frame_index_for_slot(&self, slot: TransportSlotId) -> Option<usize> {
+        self.slot_indices.get(&slot).copied()
     }
 
     pub fn live_object_count(&self) -> usize {
@@ -489,6 +507,7 @@ impl ExecutionFrameMirror {
             self.apply_partial(&delta)?
         };
         self.camera = delta.camera;
+        self.layout_generation = delta.layout_generation;
         self.next_sequence = delta
             .sequence
             .checked_add(1)
@@ -526,6 +545,7 @@ impl ExecutionFrameMirror {
     fn reset_for_session(&mut self, session: u32) {
         self.session = Some(session);
         self.next_sequence = 0;
+        self.layout_generation = 0;
         self.slots.clear();
         self.slot_indices.clear();
         self.object_slots.clear();
@@ -688,6 +708,7 @@ fn encode_player_delta(
     player: &mut ScenePlayer,
     force_snapshot: bool,
 ) -> Result<Option<ExecutionDeltaEnvelope>, ExecutionTransportError> {
+    encoder.set_layout_generation(player.layout_generation());
     let changes = player.take_frame_changes();
     let execution_delta = player.take_execution_delta();
     if force_snapshot || !encoder.is_initialized() || changes.is_all() {
@@ -1085,9 +1106,12 @@ mod tests {
 
         let initial = encode_current(&mut encoder, &mut player);
         assert!(initial.snapshot);
+        assert_eq!(initial.protocol_version, 2);
+        assert_eq!(initial.layout_generation, player.layout_generation());
         let (outcome, changes) = mirror.apply(initial).unwrap();
         assert_eq!(outcome, TransportApplyOutcome::Applied);
         assert!(changes.is_all());
+        assert_eq!(mirror.layout_generation(), player.layout_generation());
         assert_eq!(mirror.frame().unwrap(), player.frame());
 
         player.advance_to(0.5).unwrap();
@@ -1098,6 +1122,17 @@ mod tests {
         assert_eq!(outcome, TransportApplyOutcome::Applied);
         assert_eq!(changes.object_indices(), &[0]);
         assert_eq!(mirror.frame().unwrap(), player.frame());
+    }
+
+    #[test]
+    fn layout_generation_is_required_on_wire() {
+        let mut player = ScenePlayer::from_scene_json(&scene_json()).unwrap();
+        let mut encoder = ExecutionDeltaEncoder::new(31);
+        let initial = encode_current(&mut encoder, &mut player);
+        let mut value = serde_json::to_value(initial).unwrap();
+        value.as_object_mut().unwrap().remove("layout_generation");
+
+        assert!(serde_json::from_value::<ExecutionDeltaEnvelope>(value).is_err());
     }
 
     #[test]
@@ -1144,6 +1179,7 @@ mod tests {
         assert_eq!(mirror.live_object_count(), 1);
         assert_eq!(mirror.frame().unwrap().objects.len(), 2);
         assert!(!mirror.frame().unwrap().presences[0]);
+        assert_eq!(mirror.frame_index_for_slot(surviving_slot), Some(1));
         assert_eq!(mirror.slots[1], surviving_slot);
     }
 
@@ -1178,6 +1214,7 @@ mod tests {
             sequence: 3,
             snapshot: false,
             time: 0.0,
+            layout_generation: 0,
             camera: Camera2DState::default(),
             removed: Vec::new(),
             objects: Vec::new(),
@@ -1267,6 +1304,7 @@ mod tests {
 
         let initial = encode_current(&mut encoder, &mut player);
         let surviving_slot = initial.objects[1].slot;
+        let initial_generation = initial.layout_generation;
         mirror.apply(initial.clone()).unwrap();
 
         let batch = PatchBatch::new(0, vec![ScenePatch::RemoveObject(ObjectId::new(0))]);
@@ -1278,19 +1316,24 @@ mod tests {
         mirror.apply(removal).unwrap();
         assert_eq!(mirror.frame().unwrap().objects.len(), 2);
         assert_eq!(mirror.live_object_count(), 1);
+        assert_eq!(mirror.frame_index_for_slot(surviving_slot), Some(1));
 
         let stats = player.compact_retired_slots().unwrap();
         assert_eq!(stats.frame_slots_reclaimed, 1);
         let compacted = encode_current(&mut encoder, &mut player);
         assert!(compacted.snapshot);
+        assert!(compacted.layout_generation > initial_generation);
+        assert_eq!(compacted.layout_generation, player.layout_generation());
         assert_eq!(compacted.objects.len(), 1);
         assert_eq!(compacted.objects[0].slot, surviving_slot);
         assert_eq!(compacted.objects[0].order, 0);
 
         let (_, changes) = mirror.apply(compacted).unwrap();
         assert!(changes.is_all());
+        assert_eq!(mirror.layout_generation(), player.layout_generation());
         assert_eq!(mirror.live_object_count(), 1);
         assert_eq!(mirror.frame().unwrap().objects.len(), 1);
+        assert_eq!(mirror.frame_index_for_slot(surviving_slot), Some(0));
         assert_eq!(mirror.slots, vec![surviving_slot]);
         assert_eq!(mirror.frame().unwrap(), player.frame());
     }

--- a/web/execution-transport.js
+++ b/web/execution-transport.js
@@ -1,6 +1,5 @@
 export const EXECUTION_TRANSPORT_CHANNEL = "noon.execution";
 export const RETAINED_EXECUTION_TRANSPORT_CHANNEL = "noon.execution.retained";
-export const EXECUTION_TRANSPORT_VERSION = 1;
 export const EXECUTION_TRANSPORT_SHARED = "shared";
 export const EXECUTION_TRANSPORT_TRANSFERABLE = "transferable";
 
@@ -40,9 +39,6 @@ export function executionDeltaMetadata(json) {
   }
   if (!isRecord(delta) || !EXECUTION_TRANSPORT_CHANNELS.has(delta.channel)) {
     throw new Error("execution delta has an invalid channel");
-  }
-  if (delta.protocol_version !== EXECUTION_TRANSPORT_VERSION) {
-    throw new Error(`unsupported execution transport version ${delta.protocol_version}`);
   }
   if (!Number.isSafeInteger(delta.session) || delta.session < 0) {
     throw new Error("execution delta has an invalid session");

--- a/web/execution-transport.test.mjs
+++ b/web/execution-transport.test.mjs
@@ -19,7 +19,6 @@ import {
 function delta(sequence, { session = 1, snapshot = sequence === 0, channel = "noon.execution" } = {}) {
   return JSON.stringify({
     channel,
-    protocol_version: 1,
     session,
     sequence,
     snapshot,
@@ -189,7 +188,8 @@ test("transferable envelope metadata must match encoded payload", () => {
   );
 });
 
-test("metadata accepts only known execution channels and rejects future protocols", () => {
+test("metadata validates the current execution schema directly", () => {
+  assert.equal(executionDeltaMetadata(delta(0)).sequence, 0);
   assert.equal(
     executionDeltaMetadata(delta(0, { channel: RETAINED_EXECUTION_TRANSPORT_CHANNEL })).sequence,
     0,
@@ -200,13 +200,6 @@ test("metadata accepts only known execution channels and rejects future protocol
   assert.throws(
     () => executionDeltaMetadata(JSON.stringify(unrelated)),
     /invalid channel/,
-  );
-
-  const future = JSON.parse(delta(0));
-  future.protocol_version = 2;
-  assert.throws(
-    () => executionDeltaMetadata(JSON.stringify(future)),
-    /unsupported execution transport version 2/,
   );
 
   const unsafe = JSON.parse(delta(0));


### PR DESCRIPTION
## Summary
- carry authoritative `layout_generation` on ordinary execution envelopes
- stamp snapshots and incremental deltas from `ScenePlayer::layout_generation()`
- retain the current generation in `ExecutionFrameMirror`
- expose a narrow generation-safe `TransportSlotId -> frame row` resolver through the mirror's existing slot table
- reject execution envelopes that omit layout generation instead of silently treating them as generation zero
- verify compaction preserves execution-slot identity while remapping the surviving object from row 1 to row 0 and advancing layout generation
- validate the current JS execution schema directly by channel/session/sequence instead of negotiating separate v1/v2 protocol numbers between Rust and JS

## Architecture
This is the correctness prerequisite for consuming retained visibility in the renderer. Layout generation is real state needed to reject stale post-compaction visibility. Protocol-version negotiation is not: the Rust engine and JS renderer ship as one app and are updated together.

The render worker can compare visibility layout generation with its current execution mirror and resolve candidates through the already-owned slot map. No second spatial index, semantic-bounds scan, duplicate slot map, or compatibility layer is introduced.

Stacked on #591. Tracks #569 and #66.