### PR TITLE
Consume retained visibility candidates in execution renderer

### DIFF
--- a/crates/noon-render-wgpu/src/render_order.rs
+++ b/crates/noon-render-wgpu/src/render_order.rs
@@ -1,7 +1,7 @@
-use std::ops::Range;
+use std::{collections::HashSet, ops::Range};
 
-use crate::{FramePreparer, PreparedSlot};
-use noon_runtime::FrameState;
+use crate::{FramePreparer, PreparedFrame, PreparedSlot};
+use noon_runtime::{FrameChanges, FrameState};
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct RenderOrderKey {
@@ -58,6 +58,28 @@ impl std::fmt::Display for RenderOrderError {
 
 impl std::error::Error for RenderOrderError {}
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum VisibleRenderError {
+    ObjectIndexOutOfRange { index: usize, objects: usize },
+    DuplicateObjectIndex(usize),
+}
+
+impl std::fmt::Display for VisibleRenderError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ObjectIndexOutOfRange { index, objects } => write!(
+                formatter,
+                "visible render object index {index} is outside frame object count {objects}"
+            ),
+            Self::DuplicateObjectIndex(index) => {
+                write!(formatter, "duplicate visible render object index {index}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for VisibleRenderError {}
+
 impl FramePreparer {
     /// Install explicit semantic z/painter keys for subsequent preparations.
     ///
@@ -89,6 +111,53 @@ impl FramePreparer {
             self.render_order_keys.clear();
             self.initialized = false;
         }
+    }
+
+    /// Prepare one incremental frame while limiting ordered draw submission to the
+    /// supplied retained-visibility candidates.
+    ///
+    /// `visible_object_indices` must already be in back-to-front painter order, as
+    /// returned by the retained viewport query. The ordinary incremental preparation
+    /// still updates packed instance and mesh caches for dirty objects; this method
+    /// only rebuilds the lightweight ordered draw descriptors from visible slots, so
+    /// offscreen objects remain resident and can re-enter without a cache rebuild.
+    pub fn prepare_incremental_visible<'a>(
+        &'a mut self,
+        frame: &FrameState,
+        changes: &FrameChanges,
+        visible_object_indices: &[usize],
+    ) -> Result<PreparedFrame<'a>, VisibleRenderError> {
+        let mut seen = HashSet::with_capacity(visible_object_indices.len());
+        for &object_index in visible_object_indices {
+            if object_index >= frame.objects.len() {
+                return Err(VisibleRenderError::ObjectIndexOutOfRange {
+                    index: object_index,
+                    objects: frame.objects.len(),
+                });
+            }
+            if !seen.insert(object_index) {
+                return Err(VisibleRenderError::DuplicateObjectIndex(object_index));
+            }
+        }
+
+        let stats = self.prepare_incremental(frame, changes).stats;
+        self.render_batches.clear();
+        for &object_index in visible_object_indices {
+            push_slot_batches(&mut self.render_batches, self.slots[object_index]);
+        }
+        self.rebuild_mega_render_batches();
+
+        Ok(self.prepared_frame(
+            frame.time,
+            stats.capacity_growths,
+            stats.instances_repacked,
+            stats.geometry_cache_misses,
+            stats.path_vertices_repacked,
+            stats.path_indices_repacked,
+            stats.structural_slots_added,
+            stats.structural_slots_retired,
+            stats.full_rebuilds,
+        ))
     }
 
     pub(crate) fn append_ordered_render_slot(&mut self, slot: PreparedSlot) {
@@ -285,6 +354,86 @@ mod tests {
                 objects: 1,
                 keys: 0
             })
+        ));
+    }
+
+    #[test]
+    fn visible_preparation_filters_draw_batches_without_repacking_storage() {
+        let frame = frame(vec![
+            object(0, GeometryRef::circle(1.0)),
+            object(1, GeometryRef::rectangle(2.0, 2.0)),
+            object(2, GeometryRef::circle(0.5)),
+        ]);
+        let mut preparer = FramePreparer::new();
+        let prepared = preparer
+            .prepare_incremental_visible(&frame, &FrameChanges::all(), &[0, 2])
+            .unwrap();
+
+        assert_eq!(prepared.circles.len(), 2);
+        assert_eq!(prepared.rectangles.len(), 1);
+        assert_eq!(prepared.stats.instance_count, 3);
+        assert_eq!(prepared.stats.batch_count, 1);
+        assert_eq!(
+            prepared.render_batches,
+            &[OrderedRenderBatch {
+                primitive: RenderPrimitive::Circle,
+                instance_range: 0..2,
+            }]
+        );
+    }
+
+    #[test]
+    fn visible_preparation_preserves_candidate_painter_order() {
+        let frame = frame(vec![
+            object(0, GeometryRef::circle(1.0)),
+            object(1, GeometryRef::rectangle(2.0, 2.0)),
+            object(2, GeometryRef::circle(0.5)),
+        ]);
+        let mut preparer = FramePreparer::new();
+        let prepared = preparer
+            .prepare_incremental_visible(&frame, &FrameChanges::all(), &[1, 2])
+            .unwrap();
+
+        assert_eq!(prepared.render_batches.len(), 2);
+        assert_eq!(
+            prepared.render_batches[0].primitive,
+            RenderPrimitive::Rectangle
+        );
+        assert_eq!(prepared.render_batches[1].primitive, RenderPrimitive::Circle);
+        assert_eq!(prepared.render_batches[1].instance_range, 1..2);
+    }
+
+    #[test]
+    fn empty_visibility_keeps_packed_instances_but_submits_no_draws() {
+        let frame = frame(vec![
+            object(0, GeometryRef::circle(1.0)),
+            object(1, GeometryRef::rectangle(2.0, 2.0)),
+        ]);
+        let mut preparer = FramePreparer::new();
+        let prepared = preparer
+            .prepare_incremental_visible(&frame, &FrameChanges::all(), &[])
+            .unwrap();
+
+        assert_eq!(prepared.stats.instance_count, 2);
+        assert_eq!(prepared.stats.batch_count, 0);
+        assert!(prepared.render_batches.is_empty());
+    }
+
+    #[test]
+    fn invalid_visibility_is_rejected_before_preparation() {
+        let frame = frame(vec![object(0, GeometryRef::circle(1.0))]);
+        let mut preparer = FramePreparer::new();
+
+        assert!(matches!(
+            preparer.prepare_incremental_visible(&frame, &FrameChanges::all(), &[1]),
+            Err(VisibleRenderError::ObjectIndexOutOfRange {
+                index: 1,
+                objects: 1
+            })
+        ));
+        assert!(matches!(
+            preparer.prepare_incremental_visible(&frame, &FrameChanges::all(), &[0, 0]),
+            Err(VisibleRenderError::DuplicateObjectIndex(0))
         ));
     }
 }

--- a/crates/noon-web/src/execution_canvas.rs
+++ b/crates/noon-web/src/execution_canvas.rs
@@ -1,4 +1,9 @@
 #[cfg(any(target_arch = "wasm32", test))]
+use crate::{
+    ExecutionFrameMirror, ExecutionVisibilityEnvelope, ExecutionVisibilityError, TransportSlotId,
+};
+
+#[cfg(any(target_arch = "wasm32", test))]
 const MANIM_DEFAULT_CAMERA_HEIGHT: f32 = 8.0;
 
 #[cfg(target_arch = "wasm32")]
@@ -9,10 +14,83 @@ const MANIM_DEFAULT_CLEAR_COLOR: wgpu::Color = wgpu::Color {
     a: 1.0,
 };
 
+#[cfg(any(target_arch = "wasm32", test))]
+#[derive(Clone, Debug, PartialEq)]
+enum ExecutionVisibilityResolveError {
+    Envelope(ExecutionVisibilityError),
+    MissingFrame,
+    FrameTimeMismatch { expected: f64, actual: f64 },
+    LiveCountMismatch { expected: usize, actual: usize },
+    UnknownSlot(TransportSlotId),
+}
+
+#[cfg(any(target_arch = "wasm32", test))]
+impl std::fmt::Display for ExecutionVisibilityResolveError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Envelope(error) => error.fmt(formatter),
+            Self::MissingFrame => formatter.write_str("execution visibility has no mirrored frame"),
+            Self::FrameTimeMismatch { expected, actual } => write!(
+                formatter,
+                "execution visibility frame time mismatch: expected {expected}, got {actual}",
+            ),
+            Self::LiveCountMismatch { expected, actual } => write!(
+                formatter,
+                "execution visibility live-count mismatch: expected {expected}, got {actual}",
+            ),
+            Self::UnknownSlot(slot) => write!(
+                formatter,
+                "execution visibility slot {}:{} is not present in the mirrored layout",
+                slot.slot, slot.generation,
+            ),
+        }
+    }
+}
+
+#[cfg(any(target_arch = "wasm32", test))]
+impl std::error::Error for ExecutionVisibilityResolveError {}
+
+#[cfg(any(target_arch = "wasm32", test))]
+fn resolve_visibility_indices(
+    mirror: &ExecutionFrameMirror,
+    json: &str,
+) -> Result<Vec<usize>, ExecutionVisibilityResolveError> {
+    let envelope = ExecutionVisibilityEnvelope::from_json(json)
+        .map_err(ExecutionVisibilityResolveError::Envelope)?;
+    envelope
+        .validate_layout_generation(mirror.layout_generation())
+        .map_err(ExecutionVisibilityResolveError::Envelope)?;
+    let frame = mirror
+        .frame()
+        .ok_or(ExecutionVisibilityResolveError::MissingFrame)?;
+    if envelope.time != frame.time {
+        return Err(ExecutionVisibilityResolveError::FrameTimeMismatch {
+            expected: frame.time,
+            actual: envelope.time,
+        });
+    }
+    let live_count = mirror.live_object_count();
+    if envelope.total_live != live_count {
+        return Err(ExecutionVisibilityResolveError::LiveCountMismatch {
+            expected: live_count,
+            actual: envelope.total_live,
+        });
+    }
+
+    envelope
+        .slots
+        .iter()
+        .copied()
+        .map(|slot| {
+            mirror
+                .frame_index_for_slot(slot)
+                .ok_or(ExecutionVisibilityResolveError::UnknownSlot(slot))
+        })
+        .collect()
+}
+
 #[cfg(target_arch = "wasm32")]
 mod wasm {
-    use std::mem;
-
     use noon_core::Vec2;
     use noon_render_wgpu::{Camera2D, FramePreparer, GpuRenderer};
     use noon_runtime::FrameChanges;
@@ -24,7 +102,9 @@ mod wasm {
         ExecutionFrameMirror, TransportApplyOutcome,
     };
 
-    use super::{MANIM_DEFAULT_CAMERA_HEIGHT, MANIM_DEFAULT_CLEAR_COLOR};
+    use super::{
+        resolve_visibility_indices, MANIM_DEFAULT_CAMERA_HEIGHT, MANIM_DEFAULT_CLEAR_COLOR,
+    };
 
     #[derive(Debug)]
     struct WebDisplaySource;
@@ -56,6 +136,7 @@ mod wasm {
         drawable: bool,
         mirror: ExecutionFrameMirror,
         pending_changes: FrameChanges,
+        pending_visible_indices: Option<Vec<usize>>,
         preparer: FramePreparer,
         renderer: GpuRenderer,
         camera_center: Vec2,
@@ -111,6 +192,7 @@ mod wasm {
                 drawable: true,
                 mirror,
                 pending_changes,
+                pending_visible_indices: None,
                 preparer: FramePreparer::new(),
                 renderer,
                 camera_center: camera.center,
@@ -144,10 +226,23 @@ mod wasm {
                         self.update_camera()?;
                     }
                     self.pending_changes = changes;
+                    self.pending_visible_indices = None;
                     Ok(true)
                 }
                 TransportApplyOutcome::DroppedStale => Ok(false),
             }
+        }
+
+        #[wasm_bindgen(js_name = applyVisibilityJson)]
+        pub fn apply_visibility_json(&mut self, json: &str) -> Result<(), JsValue> {
+            if self.pending_changes.is_empty() {
+                return Err(js_message(
+                    "execution visibility requires an unpresented execution frame",
+                ));
+            }
+            let visible_indices = resolve_visibility_indices(&self.mirror, json).map_err(js_error)?;
+            self.pending_visible_indices = Some(visible_indices);
+            Ok(())
         }
 
         pub fn render(&mut self) -> Result<bool, JsValue> {
@@ -176,12 +271,17 @@ mod wasm {
                     wgpu::CurrentSurfaceTexture::Validation => return Ok(false),
                 };
 
-            let changes = mem::take(&mut self.pending_changes);
             let frame = self
                 .mirror
                 .frame()
                 .ok_or_else(|| js_message("execution renderer has no frame snapshot"))?;
-            let prepared = self.preparer.prepare_incremental(frame, &changes);
+            let prepared = if let Some(visible_indices) = self.pending_visible_indices.as_deref() {
+                self.preparer
+                    .prepare_incremental_visible(frame, &self.pending_changes, visible_indices)
+                    .map_err(js_error)?
+            } else {
+                self.preparer.prepare_incremental(frame, &self.pending_changes)
+            };
             self.last_geometry_cache_misses = prepared.stats.geometry_cache_misses;
             let upload = self.renderer.upload(&self.device, &self.queue, &prepared);
             self.last_bytes_uploaded = upload.bytes_uploaded;
@@ -201,6 +301,8 @@ mod wasm {
             surface_texture.present();
             self.last_draw_calls = draw.draw_calls;
             self.last_instances_drawn = draw.instances_drawn;
+            self.pending_changes = FrameChanges::default();
+            self.pending_visible_indices = None;
             if reconfigure_after_present {
                 self.surface.configure(&self.device, &self.config);
             }
@@ -467,10 +569,132 @@ pub use wasm::*;
 
 #[cfg(test)]
 mod tests {
-    use super::MANIM_DEFAULT_CAMERA_HEIGHT;
+    use noon_core::{Camera2DState, GeometryRef, ObjectId, Style, Transform2D};
+
+    use crate::{
+        ExecutionDeltaEnvelope, ExecutionFrameMirror, ExecutionVisibilityEnvelope, TransportObjectState,
+        TransportSlotId, VisibilityQueryStats, EXECUTION_TRANSPORT_CHANNEL,
+        EXECUTION_TRANSPORT_VERSION, EXECUTION_VISIBILITY_CHANNEL, EXECUTION_VISIBILITY_VERSION,
+    };
+
+    use super::{
+        resolve_visibility_indices, ExecutionVisibilityResolveError, MANIM_DEFAULT_CAMERA_HEIGHT,
+    };
+
+    fn mirror() -> (ExecutionFrameMirror, TransportSlotId, TransportSlotId) {
+        let first = TransportSlotId {
+            slot: 4,
+            generation: 2,
+        };
+        let second = TransportSlotId {
+            slot: 9,
+            generation: 7,
+        };
+        let object = |slot: TransportSlotId, order: u32, id: u64| TransportObjectState {
+            slot,
+            order,
+            object: ObjectId::new(id),
+            geometry: GeometryRef::circle(1.0),
+            transform: Transform2D::IDENTITY,
+            style: Style::default(),
+            appearance: 1.0,
+            presence: true,
+            reveal: 1.0,
+            morph: 0.0,
+            render_geometry: None,
+        };
+        let delta = ExecutionDeltaEnvelope {
+            channel: EXECUTION_TRANSPORT_CHANNEL.to_owned(),
+            protocol_version: EXECUTION_TRANSPORT_VERSION,
+            session: 3,
+            sequence: 0,
+            snapshot: true,
+            time: 1.25,
+            layout_generation: 11,
+            camera: Camera2DState::default(),
+            removed: Vec::new(),
+            objects: vec![object(first, 0, 1), object(second, 1, 2)],
+        };
+        let mut mirror = ExecutionFrameMirror::default();
+        mirror.apply(delta).unwrap();
+        (mirror, first, second)
+    }
+
+    fn visibility_json(
+        slots: Vec<TransportSlotId>,
+        time: f64,
+        layout_generation: u64,
+        total_live: usize,
+    ) -> String {
+        ExecutionVisibilityEnvelope {
+            channel: EXECUTION_VISIBILITY_CHANNEL.to_owned(),
+            protocol_version: EXECUTION_VISIBILITY_VERSION,
+            time,
+            layout_generation,
+            total_live,
+            stats: VisibilityQueryStats {
+                cells_visited: 1,
+                candidates_tested: slots.len(),
+                results: slots.len(),
+                full_scan_fallbacks: 0,
+            },
+            slots,
+        }
+        .to_json()
+        .unwrap()
+    }
 
     #[test]
     fn default_camera_matches_manim_frame_height() {
         assert_eq!(MANIM_DEFAULT_CAMERA_HEIGHT, 8.0);
+    }
+
+    #[test]
+    fn visibility_slots_resolve_to_current_frame_rows_in_painter_order() {
+        let (mirror, first, second) = mirror();
+        let json = visibility_json(vec![second, first], 1.25, 11, 2);
+
+        assert_eq!(resolve_visibility_indices(&mirror, &json).unwrap(), vec![1, 0]);
+    }
+
+    #[test]
+    fn visibility_resolution_rejects_stale_or_mismatched_frame_metadata() {
+        let (mirror, first, _) = mirror();
+
+        assert!(matches!(
+            resolve_visibility_indices(&mirror, &visibility_json(vec![first], 1.25, 10, 2)),
+            Err(ExecutionVisibilityResolveError::Envelope(_))
+        ));
+        assert_eq!(
+            resolve_visibility_indices(&mirror, &visibility_json(vec![first], 2.0, 11, 2))
+                .unwrap_err(),
+            ExecutionVisibilityResolveError::FrameTimeMismatch {
+                expected: 1.25,
+                actual: 2.0,
+            }
+        );
+        assert_eq!(
+            resolve_visibility_indices(&mirror, &visibility_json(vec![first], 1.25, 11, 1))
+                .unwrap_err(),
+            ExecutionVisibilityResolveError::LiveCountMismatch {
+                expected: 2,
+                actual: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn visibility_resolution_rejects_unknown_generation_safe_slots() {
+        let (mirror, _, _) = mirror();
+        let unknown = TransportSlotId {
+            slot: 4,
+            generation: 3,
+        };
+        let json = visibility_json(vec![unknown], 1.25, 11, 2);
+
+        assert_eq!(
+            resolve_visibility_indices(&mirror, &json).unwrap_err(),
+            ExecutionVisibilityResolveError::UnknownSlot(unknown)
+        );
     }
 }

--- a/crates/noon-web/src/execution_transport.rs
+++ b/crates/noon-web/src/execution_transport.rs
@@ -50,6 +50,8 @@ pub struct ExecutionDeltaEnvelope {
     pub snapshot: bool,
     pub time: f64,
     #[serde(default)]
+    pub layout_generation: u64,
+    #[serde(default)]
     pub camera: Camera2DState,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub removed: Vec<TransportSlotId>,
@@ -210,6 +212,7 @@ pub struct ExecutionDeltaEncoder {
     slot_orders: HashMap<TransportSlotId, u32>,
     next_order: u32,
     camera_object: Option<ObjectId>,
+    layout_generation: u64,
 }
 
 impl ExecutionDeltaEncoder {
@@ -221,6 +224,7 @@ impl ExecutionDeltaEncoder {
             slot_orders: HashMap::new(),
             next_order: 0,
             camera_object: None,
+            layout_generation: 0,
         }
     }
 
@@ -242,6 +246,10 @@ impl ExecutionDeltaEncoder {
 
     pub fn set_camera_object(&mut self, camera_object: Option<ObjectId>) {
         self.camera_object = camera_object;
+    }
+
+    pub fn set_layout_generation(&mut self, layout_generation: u64) {
+        self.layout_generation = layout_generation;
     }
 
     pub fn contains_slot(&self, slot: ExecutionSlotId) -> bool {
@@ -281,6 +289,7 @@ impl ExecutionDeltaEncoder {
             sequence,
             snapshot: true,
             time: frame.time,
+            layout_generation: self.layout_generation,
             camera,
             removed: Vec::new(),
             objects,
@@ -351,6 +360,7 @@ impl ExecutionDeltaEncoder {
             sequence,
             snapshot: false,
             time: frame.time,
+            layout_generation: self.layout_generation,
             camera,
             removed,
             objects,
@@ -417,6 +427,7 @@ impl ExecutionDeltaEncoder {
 pub struct ExecutionFrameMirror {
     session: Option<u32>,
     next_sequence: u64,
+    layout_generation: u64,
     slots: Vec<TransportSlotId>,
     slot_indices: HashMap<TransportSlotId, usize>,
     object_slots: HashMap<ObjectId, TransportSlotId>,
@@ -439,6 +450,14 @@ impl ExecutionFrameMirror {
 
     pub const fn next_sequence(&self) -> u64 {
         self.next_sequence
+    }
+
+    pub const fn layout_generation(&self) -> u64 {
+        self.layout_generation
+    }
+
+    pub fn frame_index_for_slot(&self, slot: TransportSlotId) -> Option<usize> {
+        self.slot_indices.get(&slot).copied()
     }
 
     pub fn live_object_count(&self) -> usize {
@@ -489,6 +508,7 @@ impl ExecutionFrameMirror {
             self.apply_partial(&delta)?
         };
         self.camera = delta.camera;
+        self.layout_generation = delta.layout_generation;
         self.next_sequence = delta
             .sequence
             .checked_add(1)
@@ -526,6 +546,7 @@ impl ExecutionFrameMirror {
     fn reset_for_session(&mut self, session: u32) {
         self.session = Some(session);
         self.next_sequence = 0;
+        self.layout_generation = 0;
         self.slots.clear();
         self.slot_indices.clear();
         self.object_slots.clear();
@@ -688,6 +709,7 @@ fn encode_player_delta(
     player: &mut ScenePlayer,
     force_snapshot: bool,
 ) -> Result<Option<ExecutionDeltaEnvelope>, ExecutionTransportError> {
+    encoder.set_layout_generation(player.layout_generation());
     let changes = player.take_frame_changes();
     let execution_delta = player.take_execution_delta();
     if force_snapshot || !encoder.is_initialized() || changes.is_all() {
@@ -1085,9 +1107,11 @@ mod tests {
 
         let initial = encode_current(&mut encoder, &mut player);
         assert!(initial.snapshot);
+        assert_eq!(initial.layout_generation, player.layout_generation());
         let (outcome, changes) = mirror.apply(initial).unwrap();
         assert_eq!(outcome, TransportApplyOutcome::Applied);
         assert!(changes.is_all());
+        assert_eq!(mirror.layout_generation(), player.layout_generation());
         assert_eq!(mirror.frame().unwrap(), player.frame());
 
         player.advance_to(0.5).unwrap();
@@ -1144,6 +1168,7 @@ mod tests {
         assert_eq!(mirror.live_object_count(), 1);
         assert_eq!(mirror.frame().unwrap().objects.len(), 2);
         assert!(!mirror.frame().unwrap().presences[0]);
+        assert_eq!(mirror.frame_index_for_slot(surviving_slot), Some(1));
         assert_eq!(mirror.slots[1], surviving_slot);
     }
 
@@ -1178,6 +1203,7 @@ mod tests {
             sequence: 3,
             snapshot: false,
             time: 0.0,
+            layout_generation: 0,
             camera: Camera2DState::default(),
             removed: Vec::new(),
             objects: Vec::new(),
@@ -1267,6 +1293,7 @@ mod tests {
 
         let initial = encode_current(&mut encoder, &mut player);
         let surviving_slot = initial.objects[1].slot;
+        let initial_generation = initial.layout_generation;
         mirror.apply(initial.clone()).unwrap();
 
         let batch = PatchBatch::new(0, vec![ScenePatch::RemoveObject(ObjectId::new(0))]);
@@ -1278,19 +1305,24 @@ mod tests {
         mirror.apply(removal).unwrap();
         assert_eq!(mirror.frame().unwrap().objects.len(), 2);
         assert_eq!(mirror.live_object_count(), 1);
+        assert_eq!(mirror.frame_index_for_slot(surviving_slot), Some(1));
 
         let stats = player.compact_retired_slots().unwrap();
         assert_eq!(stats.frame_slots_reclaimed, 1);
         let compacted = encode_current(&mut encoder, &mut player);
         assert!(compacted.snapshot);
+        assert!(compacted.layout_generation > initial_generation);
+        assert_eq!(compacted.layout_generation, player.layout_generation());
         assert_eq!(compacted.objects.len(), 1);
         assert_eq!(compacted.objects[0].slot, surviving_slot);
         assert_eq!(compacted.objects[0].order, 0);
 
         let (_, changes) = mirror.apply(compacted).unwrap();
         assert!(changes.is_all());
+        assert_eq!(mirror.layout_generation(), player.layout_generation());
         assert_eq!(mirror.live_object_count(), 1);
         assert_eq!(mirror.frame().unwrap().objects.len(), 1);
+        assert_eq!(mirror.frame_index_for_slot(surviving_slot), Some(0));
         assert_eq!(mirror.slots, vec![surviving_slot]);
         assert_eq!(mirror.frame().unwrap(), player.frame());
     }

--- a/crates/noon-web/src/execution_visibility.rs
+++ b/crates/noon-web/src/execution_visibility.rs
@@ -1,0 +1,312 @@
+use std::collections::HashSet;
+
+use noon_core::{Rect, Vec2};
+use noon_runtime::SpatialQueryResult;
+use serde::{Deserialize, Serialize};
+
+use crate::{ScenePlayer, TransportSlotId};
+
+pub const EXECUTION_VISIBILITY_CHANNEL: &str = "noon.execution.visibility";
+pub const EXECUTION_VISIBILITY_VERSION: u32 = 1;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VisibilityQueryStats {
+    pub cells_visited: usize,
+    pub candidates_tested: usize,
+    pub results: usize,
+    pub full_scan_fallbacks: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ExecutionVisibilityEnvelope {
+    pub channel: String,
+    pub protocol_version: u32,
+    pub time: f64,
+    pub layout_generation: u64,
+    pub total_live: usize,
+    pub slots: Vec<TransportSlotId>,
+    pub stats: VisibilityQueryStats,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ExecutionVisibilityError {
+    Json(String),
+    InvalidChannel(String),
+    UnsupportedVersion(u32),
+    InvalidTime,
+    StaleLayout { expected: u64, actual: u64 },
+    DuplicateSlot(TransportSlotId),
+    InvalidResultCount { slots: usize, reported: usize },
+    ResultsExceedLiveSet { results: usize, total_live: usize },
+    CandidatesBelowResults { candidates: usize, results: usize },
+}
+
+impl std::fmt::Display for ExecutionVisibilityError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Json(message) => formatter.write_str(message),
+            Self::InvalidChannel(channel) => {
+                write!(formatter, "invalid execution visibility channel {channel:?}")
+            }
+            Self::UnsupportedVersion(version) => {
+                write!(formatter, "unsupported execution visibility version {version}")
+            }
+            Self::InvalidTime => formatter.write_str("invalid execution visibility time"),
+            Self::StaleLayout { expected, actual } => write!(
+                formatter,
+                "stale execution visibility layout generation: expected {expected}, got {actual}",
+            ),
+            Self::DuplicateSlot(slot) => write!(
+                formatter,
+                "duplicate execution visibility slot {}:{}",
+                slot.slot, slot.generation,
+            ),
+            Self::InvalidResultCount { slots, reported } => write!(
+                formatter,
+                "execution visibility reported {reported} results for {slots} slots",
+            ),
+            Self::ResultsExceedLiveSet {
+                results,
+                total_live,
+            } => write!(
+                formatter,
+                "execution visibility returned {results} results from {total_live} live objects",
+            ),
+            Self::CandidatesBelowResults {
+                candidates,
+                results,
+            } => write!(
+                formatter,
+                "execution visibility tested {candidates} candidates but returned {results} results",
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ExecutionVisibilityError {}
+
+impl ExecutionVisibilityEnvelope {
+    pub fn from_query(
+        time: f64,
+        layout_generation: u64,
+        total_live: usize,
+        query: SpatialQueryResult,
+    ) -> Self {
+        let stats = query.stats();
+        Self {
+            channel: EXECUTION_VISIBILITY_CHANNEL.to_owned(),
+            protocol_version: EXECUTION_VISIBILITY_VERSION,
+            time,
+            layout_generation,
+            total_live,
+            slots: query
+                .slots()
+                .iter()
+                .copied()
+                .map(TransportSlotId::from)
+                .collect(),
+            stats: VisibilityQueryStats {
+                cells_visited: stats.cells_visited,
+                candidates_tested: stats.candidates_tested,
+                results: stats.results,
+                full_scan_fallbacks: stats.full_scan_fallbacks,
+            },
+        }
+    }
+
+    pub fn to_json(&self) -> Result<String, ExecutionVisibilityError> {
+        self.validate()?;
+        serde_json::to_string(self)
+            .map_err(|error| ExecutionVisibilityError::Json(error.to_string()))
+    }
+
+    pub fn from_json(json: &str) -> Result<Self, ExecutionVisibilityError> {
+        let envelope: Self = serde_json::from_str(json)
+            .map_err(|error| ExecutionVisibilityError::Json(error.to_string()))?;
+        envelope.validate()?;
+        Ok(envelope)
+    }
+
+    pub fn validate_layout_generation(
+        &self,
+        expected: u64,
+    ) -> Result<(), ExecutionVisibilityError> {
+        if self.layout_generation == expected {
+            Ok(())
+        } else {
+            Err(ExecutionVisibilityError::StaleLayout {
+                expected,
+                actual: self.layout_generation,
+            })
+        }
+    }
+
+    pub fn validate(&self) -> Result<(), ExecutionVisibilityError> {
+        if self.channel != EXECUTION_VISIBILITY_CHANNEL {
+            return Err(ExecutionVisibilityError::InvalidChannel(
+                self.channel.clone(),
+            ));
+        }
+        if self.protocol_version != EXECUTION_VISIBILITY_VERSION {
+            return Err(ExecutionVisibilityError::UnsupportedVersion(
+                self.protocol_version,
+            ));
+        }
+        if !self.time.is_finite() {
+            return Err(ExecutionVisibilityError::InvalidTime);
+        }
+        if self.stats.results != self.slots.len() {
+            return Err(ExecutionVisibilityError::InvalidResultCount {
+                slots: self.slots.len(),
+                reported: self.stats.results,
+            });
+        }
+        if self.stats.results > self.total_live {
+            return Err(ExecutionVisibilityError::ResultsExceedLiveSet {
+                results: self.stats.results,
+                total_live: self.total_live,
+            });
+        }
+        if self.stats.candidates_tested < self.stats.results {
+            return Err(ExecutionVisibilityError::CandidatesBelowResults {
+                candidates: self.stats.candidates_tested,
+                results: self.stats.results,
+            });
+        }
+        let mut seen = HashSet::with_capacity(self.slots.len());
+        for &slot in &self.slots {
+            if !seen.insert(slot) {
+                return Err(ExecutionVisibilityError::DuplicateSlot(slot));
+            }
+        }
+        Ok(())
+    }
+}
+
+impl ScenePlayer {
+    pub fn viewport_visibility(
+        &self,
+        min_x: f32,
+        min_y: f32,
+        max_x: f32,
+        max_y: f32,
+    ) -> ExecutionVisibilityEnvelope {
+        let bounds = Rect::new(Vec2::new(min_x, min_y), Vec2::new(max_x, max_y));
+        ExecutionVisibilityEnvelope::from_query(
+            self.frame().time,
+            self.layout_generation(),
+            self.object_count(),
+            self.query_viewport(bounds),
+        )
+    }
+
+    pub fn viewport_visibility_json(
+        &self,
+        min_x: f32,
+        min_y: f32,
+        max_x: f32,
+        max_y: f32,
+    ) -> Result<String, ExecutionVisibilityError> {
+        self.viewport_visibility(min_x, min_y, max_x, max_y)
+            .to_json()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use noon_core::{GeometryRef, SceneDefinition, Transform2D};
+    use noon_ir::encode_scene;
+
+    use super::*;
+
+    fn player_with_overlapping_objects() -> ScenePlayer {
+        let mut scene = SceneDefinition::new();
+        scene.add(GeometryRef::circle(1.0));
+        scene.add(GeometryRef::rectangle(1.0, 1.0));
+        let json = encode_scene(&scene).unwrap();
+        ScenePlayer::from_scene_json(&json).unwrap()
+    }
+
+    #[test]
+    fn visibility_envelope_preserves_retained_painter_order_and_metrics() {
+        let mut player = player_with_overlapping_objects();
+        player.seek(1.25).unwrap();
+
+        let envelope = player.viewport_visibility(-0.25, -0.25, 0.25, 0.25);
+
+        assert_eq!(envelope.time, 1.25);
+        assert_eq!(envelope.layout_generation, 0);
+        assert_eq!(envelope.total_live, 2);
+        assert_eq!(envelope.slots.len(), 2);
+        assert_eq!(envelope.slots[0].slot, 0);
+        assert_eq!(envelope.slots[1].slot, 1);
+        assert_eq!(envelope.stats.results, 2);
+        assert_eq!(envelope.stats.full_scan_fallbacks, 0);
+        envelope.validate().unwrap();
+    }
+
+    #[test]
+    fn visibility_json_round_trip_keeps_generation_safe_identity() {
+        let player = player_with_overlapping_objects();
+        let json = player
+            .viewport_visibility_json(-0.25, -0.25, 0.25, 0.25)
+            .unwrap();
+        let decoded = ExecutionVisibilityEnvelope::from_json(&json).unwrap();
+
+        assert_eq!(
+            decoded.slots[0],
+            TransportSlotId {
+                slot: 0,
+                generation: 0
+            }
+        );
+        assert_eq!(
+            decoded.slots[1],
+            TransportSlotId {
+                slot: 1,
+                generation: 0
+            }
+        );
+        decoded.validate_layout_generation(0).unwrap();
+        assert!(matches!(
+            decoded.validate_layout_generation(1),
+            Err(ExecutionVisibilityError::StaleLayout {
+                expected: 1,
+                actual: 0,
+            })
+        ));
+    }
+
+    #[test]
+    fn large_offscreen_scene_reports_bounded_candidates_not_live_scan() {
+        let mut scene = SceneDefinition::new();
+        for index in 0..10_000 {
+            let object = scene.add(GeometryRef::circle(0.1));
+            scene.object_mut(object).unwrap().transform = Transform2D {
+                translation: Vec2::new(index as f32 * 4.0, 0.0),
+                ..Transform2D::IDENTITY
+            };
+        }
+        let json = encode_scene(&scene).unwrap();
+        let player = ScenePlayer::from_scene_json(&json).unwrap();
+
+        let envelope = player.viewport_visibility(-0.5, -0.5, 0.5, 0.5);
+
+        assert_eq!(envelope.total_live, 10_000);
+        assert_eq!(envelope.stats.full_scan_fallbacks, 0);
+        assert!(envelope.stats.results <= 1);
+        assert!(envelope.stats.candidates_tested < 16);
+    }
+
+    #[test]
+    fn malformed_visibility_metadata_is_rejected_transactionally() {
+        let player = player_with_overlapping_objects();
+        let mut envelope = player.viewport_visibility(-0.25, -0.25, 0.25, 0.25);
+        envelope.stats.results += 1;
+
+        assert!(matches!(
+            envelope.validate(),
+            Err(ExecutionVisibilityError::InvalidResultCount { .. })
+        ));
+    }
+}

--- a/crates/noon-web/src/lib.rs
+++ b/crates/noon-web/src/lib.rs
@@ -7,6 +7,7 @@ mod composition;
 mod determinism;
 mod execution_canvas;
 mod execution_transport;
+mod execution_visibility;
 #[cfg(any(target_arch = "wasm32", test))]
 mod gpu_diagnostics;
 mod host_player;
@@ -35,6 +36,7 @@ pub use determinism::*;
 #[cfg(target_arch = "wasm32")]
 pub use execution_canvas::*;
 pub use execution_transport::*;
+pub use execution_visibility::*;
 pub use host_player::*;
 pub use legacy::*;
 pub use lifecycle::*;


### PR DESCRIPTION
Superseded by the protocol-v2 restack after #596 advanced. The generation-safe visibility resolution boundary is now isolated in #601; renderer consumption is being replayed cleanly on top of that branch instead of carrying the stale protocol-v1 ancestry.

Original architectural intent remains unchanged: no renderer-owned spatial index, semantic-bounds scan, or duplicate slot map.