### PR TITLE
Keep empty glyphs out of GPU atlas residency

### DIFF
--- a/crates/noon-text-atlas/src/lib.rs
+++ b/crates/noon-text-atlas/src/lib.rs
@@ -368,7 +368,8 @@ impl AtlasPlaneState {
 /// Alpha-mask and color glyphs use independent page vectors because they have
 /// different formats and shader semantics. Textures remain lazy: a plane allocates
 /// only the pages actually reached by deterministic shelf packing. Empty glyphs are
-/// cached without consuming GPU space.
+/// returned without GPU-side residency; the bounded CPU raster cache owns their
+/// identity.
 ///
 /// `GpuGlyphAtlas::new` preserves the historical one-page-per-plane policy. Callers
 /// must opt into a larger bounded budget with `with_page_limit`. Page reuse is also
@@ -496,15 +497,9 @@ impl GpuGlyphAtlas {
         self.stats.misses = self.stats.misses.saturating_add(1);
 
         let GlyphRaster::Image(image) = raster else {
-            self.entries.insert(key, GlyphAtlasEntry::Empty);
-            self.stats.entries = self.entries.len();
-            self.stats.empty_entries = self.stats.empty_entries.saturating_add(1);
             return Ok(GlyphAtlasEntry::Empty);
         };
         if image.placement.width == 0 || image.placement.height == 0 {
-            self.entries.insert(key, GlyphAtlasEntry::Empty);
-            self.stats.entries = self.entries.len();
-            self.stats.empty_entries = self.stats.empty_entries.saturating_add(1);
             return Ok(GlyphAtlasEntry::Empty);
         }
 

--- a/crates/noon-text-render-wgpu/tests/live_atlas_pages.rs
+++ b/crates/noon-text-render-wgpu/tests/live_atlas_pages.rs
@@ -81,6 +81,12 @@ fn empty_glyphs_do_not_accumulate_gpu_atlas_metadata() {
             GlyphAtlasEntry::Empty
         );
     }
+    assert_eq!(
+        atlas
+            .insert(&device, &queue, raster_key(2_000), &mask_raster(0, 3, 255))
+            .unwrap(),
+        GlyphAtlasEntry::Empty
+    );
 
     assert!(atlas.is_empty());
     assert_eq!(atlas.len(), 0);
@@ -92,7 +98,7 @@ fn empty_glyphs_do_not_accumulate_gpu_atlas_metadata() {
     assert_eq!(atlas.stats().empty_entries, 0);
     assert_eq!(atlas.stats().texture_allocations, 0);
     assert_eq!(atlas.stats().hits, 0);
-    assert_eq!(atlas.stats().misses, 1_024);
+    assert_eq!(atlas.stats().misses, 1_025);
 }
 
 #[test]

--- a/crates/noon-text-render-wgpu/tests/live_atlas_pages.rs
+++ b/crates/noon-text-render-wgpu/tests/live_atlas_pages.rs
@@ -69,6 +69,33 @@ fn prepared_mask_frame<'a>(
 }
 
 #[test]
+fn empty_glyphs_do_not_accumulate_gpu_atlas_metadata() {
+    let (device, queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
+    let mut atlas = GpuGlyphAtlas::with_page_limit(8, 2).unwrap();
+
+    for glyph_id in 1..=1_024_u16 {
+        assert_eq!(
+            atlas
+                .insert(&device, &queue, raster_key(glyph_id), &GlyphRaster::Empty)
+                .unwrap(),
+            GlyphAtlasEntry::Empty
+        );
+    }
+
+    assert!(atlas.is_empty());
+    assert_eq!(atlas.len(), 0);
+    assert_eq!(atlas.page_count(GlyphAtlasPlane::Mask), 0);
+    assert_eq!(atlas.page_count(GlyphAtlasPlane::Color), 0);
+    assert_eq!(atlas.stats().entries, 0);
+    assert_eq!(atlas.stats().mask_entries, 0);
+    assert_eq!(atlas.stats().color_entries, 0);
+    assert_eq!(atlas.stats().empty_entries, 0);
+    assert_eq!(atlas.stats().texture_allocations, 0);
+    assert_eq!(atlas.stats().hits, 0);
+    assert_eq!(atlas.stats().misses, 1_024);
+}
+
+#[test]
 fn renderer_extends_bindings_when_persistent_atlas_grows() {
     let (device, queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
     let mut atlas = GpuGlyphAtlas::with_page_limit(8, 2).unwrap();


### PR DESCRIPTION
Superseded by clean one-commit PR #599. #599 carries the same production change plus the strengthened zero-sized-image acceptance case.