### PR TITLE
Keep empty glyphs out of GPU atlas residency

### DIFF
--- a/crates/noon-text-atlas/src/lib.rs
+++ b/crates/noon-text-atlas/src/lib.rs
@@ -368,7 +368,8 @@ impl AtlasPlaneState {
 /// Alpha-mask and color glyphs use independent page vectors because they have
 /// different formats and shader semantics. Textures remain lazy: a plane allocates
 /// only the pages actually reached by deterministic shelf packing. Empty glyphs are
-/// cached without consuming GPU space.
+/// returned without GPU-side residency; the bounded CPU raster cache owns their
+/// identity.
 ///
 /// `GpuGlyphAtlas::new` preserves the historical one-page-per-plane policy. Callers
 /// must opt into a larger bounded budget with `with_page_limit`. Page reuse is also
@@ -496,15 +497,9 @@ impl GpuGlyphAtlas {
         self.stats.misses = self.stats.misses.saturating_add(1);
 
         let GlyphRaster::Image(image) = raster else {
-            self.entries.insert(key, GlyphAtlasEntry::Empty);
-            self.stats.entries = self.entries.len();
-            self.stats.empty_entries = self.stats.empty_entries.saturating_add(1);
             return Ok(GlyphAtlasEntry::Empty);
         };
         if image.placement.width == 0 || image.placement.height == 0 {
-            self.entries.insert(key, GlyphAtlasEntry::Empty);
-            self.stats.entries = self.entries.len();
-            self.stats.empty_entries = self.stats.empty_entries.saturating_add(1);
             return Ok(GlyphAtlasEntry::Empty);
         }
 

--- a/crates/noon-text-render-wgpu/tests/live_atlas_pages.rs
+++ b/crates/noon-text-render-wgpu/tests/live_atlas_pages.rs
@@ -69,6 +69,39 @@ fn prepared_mask_frame<'a>(
 }
 
 #[test]
+fn empty_glyphs_do_not_accumulate_gpu_atlas_metadata() {
+    let (device, queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
+    let mut atlas = GpuGlyphAtlas::with_page_limit(8, 2).unwrap();
+
+    for glyph_id in 1..=1_024_u16 {
+        assert_eq!(
+            atlas
+                .insert(&device, &queue, raster_key(glyph_id), &GlyphRaster::Empty)
+                .unwrap(),
+            GlyphAtlasEntry::Empty
+        );
+    }
+    assert_eq!(
+        atlas
+            .insert(&device, &queue, raster_key(2_000), &mask_raster(0, 3, 255))
+            .unwrap(),
+        GlyphAtlasEntry::Empty
+    );
+
+    assert!(atlas.is_empty());
+    assert_eq!(atlas.len(), 0);
+    assert_eq!(atlas.page_count(GlyphAtlasPlane::Mask), 0);
+    assert_eq!(atlas.page_count(GlyphAtlasPlane::Color), 0);
+    assert_eq!(atlas.stats().entries, 0);
+    assert_eq!(atlas.stats().mask_entries, 0);
+    assert_eq!(atlas.stats().color_entries, 0);
+    assert_eq!(atlas.stats().empty_entries, 0);
+    assert_eq!(atlas.stats().texture_allocations, 0);
+    assert_eq!(atlas.stats().hits, 0);
+    assert_eq!(atlas.stats().misses, 1_025);
+}
+
+#[test]
 fn renderer_extends_bindings_when_persistent_atlas_grows() {
     let (device, queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
     let mut atlas = GpuGlyphAtlas::with_page_limit(8, 2).unwrap();


### PR DESCRIPTION
## Summary
- keep `GlyphAtlasEntry::Empty` as a transient API result while removing empty glyph keys from GPU atlas residency
- let the already-bounded CPU raster cache remain the sole owner of empty-glyph identity
- preserve image atlas caching, page generation pinning, and all public atlas types
- add a noop-GPU regression covering 1,024 distinct `GlyphRaster::Empty` keys plus a zero-sized image and proving atlas entries, pages, texture allocations, and hits remain zero

## Why
Empty glyphs consume no GPU texture space but previously accumulated indefinitely in the GPU atlas `HashMap`, creating a separate unbounded metadata path despite the bounded CPU raster cache. Removing duplicate GPU-side retention eliminates that growth by construction instead of adding another LRU/budget.

Clean one-commit replacement for #598 after strengthening the zero-sized-image acceptance case.

Tracks #363.