### PR TITLE
Consume retained viewport visibility in web renderer

### DIFF
--- a/crates/noon-web/src/execution_canvas.rs
+++ b/crates/noon-web/src/execution_canvas.rs
@@ -14,14 +14,14 @@ mod wasm {
     use std::mem;
 
     use noon_core::Vec2;
-    use noon_render_wgpu::{Camera2D, FramePreparer, GpuRenderer};
+    use noon_render_wgpu::{Camera2D, GpuRenderer, VisibilityFramePreparer};
     use noon_runtime::FrameChanges;
     use wasm_bindgen::prelude::*;
     use web_sys::OffscreenCanvas;
 
     use crate::{
         gpu_diagnostics::{install_wgpu_error_handler, GpuDiagnosticMailbox},
-        ExecutionFrameMirror, TransportApplyOutcome,
+        ExecutionFrameMirror, ExecutionVisibilityEnvelope, TransportApplyOutcome,
     };
 
     use super::{MANIM_DEFAULT_CAMERA_HEIGHT, MANIM_DEFAULT_CLEAR_COLOR};
@@ -44,6 +44,13 @@ mod wasm {
         config: wgpu::SurfaceConfiguration,
     }
 
+    #[derive(Debug)]
+    struct PendingVisibility {
+        rows: Vec<usize>,
+        candidates_tested: usize,
+        total_live: usize,
+    }
+
     #[wasm_bindgen(js_name = ExecutionCanvasRenderer)]
     pub struct WasmExecutionCanvasRenderer {
         instance: wgpu::Instance,
@@ -56,7 +63,8 @@ mod wasm {
         drawable: bool,
         mirror: ExecutionFrameMirror,
         pending_changes: FrameChanges,
-        preparer: FramePreparer,
+        pending_visibility: Option<PendingVisibility>,
+        preparer: VisibilityFramePreparer,
         renderer: GpuRenderer,
         camera_center: Vec2,
         camera_height: f32,
@@ -65,6 +73,9 @@ mod wasm {
         last_instances_drawn: usize,
         last_bytes_uploaded: usize,
         last_geometry_cache_misses: usize,
+        last_visibility_candidates_tested: usize,
+        last_visibility_results: usize,
+        last_visibility_total_live: usize,
         gpu_generation: u32,
         gpu_diagnostics: GpuDiagnosticMailbox,
     }
@@ -111,7 +122,8 @@ mod wasm {
                 drawable: true,
                 mirror,
                 pending_changes,
-                preparer: FramePreparer::new(),
+                pending_visibility: None,
+                preparer: VisibilityFramePreparer::new(),
                 renderer,
                 camera_center: camera.center,
                 camera_height: camera.height,
@@ -120,6 +132,9 @@ mod wasm {
                 last_instances_drawn: 0,
                 last_bytes_uploaded: 0,
                 last_geometry_cache_misses: 0,
+                last_visibility_candidates_tested: 0,
+                last_visibility_results: 0,
+                last_visibility_total_live: 0,
                 gpu_generation,
                 gpu_diagnostics,
             };
@@ -129,9 +144,9 @@ mod wasm {
 
         #[wasm_bindgen(js_name = applyDeltaJson)]
         pub fn apply_delta_json(&mut self, json: &str) -> Result<bool, JsValue> {
-            if !self.pending_changes.is_empty() {
+            if !self.pending_changes.is_empty() || self.pending_visibility.is_some() {
                 return Err(js_message(
-                    "render worker must present the applied execution delta before accepting another",
+                    "render worker must present the pending execution frame before accepting another delta",
                 ));
             }
             let (outcome, changes) = self.mirror.apply_json(json).map_err(js_error)?;
@@ -150,8 +165,29 @@ mod wasm {
             }
         }
 
+        #[wasm_bindgen(js_name = applyVisibilityJson)]
+        pub fn apply_visibility_json(&mut self, json: &str) -> Result<(), JsValue> {
+            if self.pending_visibility.is_some() {
+                return Err(js_message(
+                    "render worker must present pending execution visibility before accepting another",
+                ));
+            }
+            let visibility = ExecutionVisibilityEnvelope::from_json(json).map_err(js_error)?;
+            let rows = visibility
+                .resolve_for_mirror(&self.mirror)
+                .map_err(js_error)?;
+            self.pending_visibility = Some(PendingVisibility {
+                rows,
+                candidates_tested: visibility.stats.candidates_tested,
+                total_live: visibility.total_live,
+            });
+            Ok(())
+        }
+
         pub fn render(&mut self) -> Result<bool, JsValue> {
-            if !self.drawable || self.pending_changes.is_empty() {
+            if !self.drawable
+                || (self.pending_changes.is_empty() && self.pending_visibility.is_none())
+            {
                 return Ok(false);
             }
 
@@ -177,11 +213,21 @@ mod wasm {
                 };
 
             let changes = mem::take(&mut self.pending_changes);
+            let visibility = self.pending_visibility.take();
             let frame = self
                 .mirror
                 .frame()
                 .ok_or_else(|| js_message("execution renderer has no frame snapshot"))?;
-            let prepared = self.preparer.prepare_incremental(frame, &changes);
+            let prepared = if let Some(visibility) = visibility {
+                self.last_visibility_candidates_tested = visibility.candidates_tested;
+                self.last_visibility_results = visibility.rows.len();
+                self.last_visibility_total_live = visibility.total_live;
+                self.preparer
+                    .prepare_incremental_visible(frame, &changes, &visibility.rows)
+                    .map_err(js_error)?
+            } else {
+                self.preparer.prepare_incremental(frame, &changes)
+            };
             self.last_geometry_cache_misses = prepared.stats.geometry_cache_misses;
             let upload = self.renderer.upload(&self.device, &self.queue, &prepared);
             self.last_bytes_uploaded = upload.bytes_uploaded;
@@ -288,6 +334,21 @@ mod wasm {
         #[wasm_bindgen(js_name = lastGeometryCacheMisses)]
         pub fn last_geometry_cache_misses(&self) -> usize {
             self.last_geometry_cache_misses
+        }
+
+        #[wasm_bindgen(js_name = lastVisibilityCandidatesTested)]
+        pub fn last_visibility_candidates_tested(&self) -> usize {
+            self.last_visibility_candidates_tested
+        }
+
+        #[wasm_bindgen(js_name = lastVisibilityResults)]
+        pub fn last_visibility_results(&self) -> usize {
+            self.last_visibility_results
+        }
+
+        #[wasm_bindgen(js_name = lastVisibilityTotalLive)]
+        pub fn last_visibility_total_live(&self) -> usize {
+            self.last_visibility_total_live
         }
     }
 

--- a/web/authoring-render-worker.js
+++ b/web/authoring-render-worker.js
@@ -11,6 +11,7 @@ import {
   EXECUTION_TRANSPORT_TRANSFERABLE,
   SharedExecutionDeltaReader,
   TransferableExecutionDeltaReceiver,
+  executionDeltaMetadata,
 } from "./execution-transport.js";
 
 const RENDER_CHANNEL = "noon.render";
@@ -25,11 +26,13 @@ let mode = null;
 let sharedReader = null;
 let transferableReceiver = null;
 let renderer = null;
+let executionMetadata = null;
 let resourceBytes = null;
 let reconnectResourceBundlePending = false;
 let canvas = null;
 let width = 1;
 let height = 1;
+let resizePending = false;
 let bootstrapQueue = [];
 let bootstrapPromise = null;
 let transitionRequestId = null;
@@ -37,6 +40,10 @@ let transitionResponseType = null;
 let transitionMode = null;
 let transitionResourceBytes = null;
 let needsPresent = false;
+let visibilityActive = false;
+let visibilityActivationPending = false;
+let awaitingVisibility = false;
+let visibilityReady = false;
 let running = false;
 let lastFrameTimestamp = null;
 let presentedFrames = 0;
@@ -178,6 +185,21 @@ function resize(message) {
   if (renderer === null) {
     return;
   }
+  if (
+    mode === MODE_LEGACY &&
+    (visibilityActivationPending || awaitingVisibility || needsPresent)
+  ) {
+    resizePending = true;
+    return;
+  }
+  applyRendererResize();
+}
+
+function applyRendererResize() {
+  if (renderer === null) {
+    return;
+  }
+  resizePending = false;
   renderer.resize(width, height);
   if (!drainGpuDiagnostics()) return;
   if (mode === MODE_RETAINED) {
@@ -223,10 +245,23 @@ function resetTransportState() {
   transferableReceiver = null;
   bootstrapQueue = [];
   bootstrapPromise = null;
+  executionMetadata = null;
+  visibilityActive = false;
+  visibilityActivationPending = false;
+  awaitingVisibility = false;
+  visibilityReady = false;
 }
 
 function handleEngineMessage(message) {
   if (!message || typeof message !== "object") {
+    return;
+  }
+  if (message.type === "visibility_active") {
+    handleVisibilityActivation();
+    return;
+  }
+  if (message.type === "visibility") {
+    handleVisibility(message);
     return;
   }
   if (message.type === "retained_resources") {
@@ -248,6 +283,46 @@ function handleEngineMessage(message) {
   }
   if (message.type === "shared_delta") {
     drainTransport();
+  }
+}
+
+function handleVisibilityActivation() {
+  if (mode !== MODE_LEGACY || !visibilityActivationPending || visibilityActive) {
+    fail(new Error("authoring render worker received unexpected visibility activation"), null);
+    return;
+  }
+  visibilityActivationPending = false;
+  visibilityActive = true;
+}
+
+function handleVisibility(message) {
+  try {
+    if (mode !== MODE_LEGACY || !visibilityActive) {
+      throw new Error("authoring render worker received visibility outside active legacy mode");
+    }
+    if (renderer === null) {
+      throw new Error("authoring render worker received visibility before renderer bootstrap");
+    }
+    if (typeof message.json !== "string") {
+      throw new Error("authoring render visibility requires a JSON payload");
+    }
+    if (
+      executionMetadata === null ||
+      message.session !== executionMetadata.session ||
+      message.sequence !== executionMetadata.sequence
+    ) {
+      throw new Error("authoring render visibility does not match the applied execution frame");
+    }
+    renderer.applyVisibilityJson(message.json);
+    awaitingVisibility = false;
+    visibilityReady = true;
+    needsPresent = true;
+    if (tryPresent()) {
+      flushBootstrapQueue();
+      drainTransport();
+    }
+  } catch (error) {
+    fail(error, null);
   }
 }
 
@@ -326,12 +401,17 @@ function consumeDelta(json) {
   if (needsPresent) {
     return false;
   }
+  const metadata = executionDeltaMetadata(json);
   const applied = renderer.applyDeltaJson(json);
   if (!applied) {
     return true;
   }
+  executionMetadata = metadata;
   needsPresent = true;
-  tryPresent();
+  visibilityReady = false;
+  if (mode === MODE_RETAINED || !visibilityActive) {
+    tryPresent();
+  }
   return true;
 }
 
@@ -355,6 +435,7 @@ function commitRendererTransition(initial) {
   resourceBytes = nextResourceBytes;
   reconnectResourceBundlePending = false;
   needsPresent = false;
+  visibilityReady = false;
   mode = nextMode;
   bootstrapPromise = bootstrapRenderer(initial);
   return true;
@@ -363,6 +444,7 @@ function commitRendererTransition(initial) {
 async function bootstrapRenderer(initial) {
   const wasRunning = running;
   try {
+    const initialMetadata = executionDeltaMetadata(initial);
     if (mode === MODE_RETAINED) {
       renderer = await RetainedExecutionCanvasRenderer.create(canvas, resourceBytes);
       resourceBytes = null;
@@ -373,7 +455,9 @@ async function bootstrapRenderer(initial) {
     } else {
       renderer = await ExecutionCanvasRenderer.create(canvas, initial);
     }
+    executionMetadata = initialMetadata;
     renderer.resize(width, height);
+    resizePending = false;
     if (!drainGpuDiagnostics()) return;
     needsPresent = true;
     running = true;
@@ -416,12 +500,19 @@ function tryPresent() {
   if (renderer === null || !needsPresent || !drainGpuDiagnostics()) {
     return false;
   }
+  if (mode === MODE_LEGACY && visibilityActive && !visibilityReady) {
+    return false;
+  }
   if (!renderer.render()) {
     drainGpuDiagnostics();
     return false;
   }
   needsPresent = false;
+  visibilityReady = false;
   presentedFrames += 1;
+  if (resizePending) {
+    applyRendererResize();
+  }
   return drainGpuDiagnostics();
 }
 
@@ -431,10 +522,12 @@ function flushBootstrapQueue() {
   }
   while (!needsPresent && bootstrapQueue.length > 0) {
     const json = bootstrapQueue.shift();
+    const metadata = executionDeltaMetadata(json);
     const applied = renderer.applyDeltaJson(json);
     if (!applied) {
       continue;
     }
+    executionMetadata = metadata;
     needsPresent = true;
     if (!tryPresent()) {
       break;
@@ -469,7 +562,23 @@ function frame(timestamp) {
   if (!running || !drainGpuDiagnostics()) {
     return;
   }
-  renderPort?.postMessage({ type: "tick", timestamp });
+  if (transitionMode !== null || bootstrapPromise !== null || renderer === null) {
+    scheduleFrame();
+    return;
+  }
+  if (mode === MODE_LEGACY) {
+    if (!visibilityActivationPending && !awaitingVisibility && !needsPresent) {
+      visibilityActivationPending = !visibilityActive;
+      awaitingVisibility = true;
+      renderPort?.postMessage({
+        type: "tick",
+        timestamp,
+        aspect: width / height,
+      });
+    }
+  } else {
+    renderPort?.postMessage({ type: "tick", timestamp });
+  }
   scheduleFrame();
 }
 
@@ -508,6 +617,10 @@ function currentMetrics() {
     lastFrameTimestamp,
     bufferedDeltas: bootstrapQueue.length + (transferableReceiver?.pendingCount() ?? 0),
     needsPresent,
+    resizePending,
+    visibilityActive,
+    visibilityActivationPending,
+    awaitingVisibility,
   };
   if (renderer === null) {
     return {
@@ -529,6 +642,10 @@ function currentMetrics() {
   if (mode === MODE_RETAINED) {
     metrics.outlineCacheMisses = renderer.lastOutlineCacheMisses();
     metrics.resourceBundlePending = reconnectResourceBundlePending;
+  } else {
+    metrics.visibilityCandidatesTested = renderer.lastVisibilityCandidatesTested();
+    metrics.visibilityResults = renderer.lastVisibilityResults();
+    metrics.visibilityTotalLive = renderer.lastVisibilityTotalLive();
   }
   return metrics;
 }

--- a/web/execution-engine-worker.js
+++ b/web/execution-engine-worker.js
@@ -5,6 +5,7 @@ import {
   SharedExecutionDeltaWriter,
   TransferableExecutionDeltaSender,
   createSharedExecutionMailbox,
+  executionDeltaMetadata,
 } from "./execution-transport.js";
 
 const ENGINE_CHANNEL = "noon.engine";
@@ -17,6 +18,9 @@ let transportMode = null;
 let transport = null;
 let player = null;
 let latestTick = null;
+let viewportAspect = null;
+let pendingVisibility = null;
+let lastVisibility = null;
 let controlQueue = [];
 let initialized = false;
 let stopped = false;
@@ -81,6 +85,9 @@ async function handleMainMessage(message) {
         stopped = true;
         controlQueue = [];
         latestTick = null;
+        viewportAspect = null;
+        pendingVisibility = null;
+        lastVisibility = null;
         clearHostCallbacks();
         hostPort?.close?.();
         hostPort = null;
@@ -139,8 +146,8 @@ async function initialize(message) {
     });
   } else {
     transport = new TransferableExecutionDeltaSender(renderPort, {
-      maxInFlight: 2,
-      onWritable: drainWork,
+      maxInFlight: 1,
+      onWritable: handleTransportWritable,
     });
   }
 
@@ -160,21 +167,45 @@ function handleRenderMessage(message) {
       fail(new Error("render worker sent a non-finite frame timestamp"), null);
       return;
     }
+    const requestsVisibility = message.aspect !== undefined && message.aspect !== null;
+    if (requestsVisibility && (!Number.isFinite(message.aspect) || message.aspect <= 0)) {
+      fail(new Error("render worker sent an invalid viewport aspect"), null);
+      return;
+    }
     if (hostInFlight !== null && message.timestamp > hostInFlight.presentationTimestamp) {
       hostInFlight.late = true;
       hostMetrics.missedDeadlines += 1;
     }
-    latestTick = message.timestamp;
+    if (requestsVisibility) {
+      const activatingVisibility = viewportAspect === null;
+      viewportAspect = message.aspect;
+      if (activatingVisibility) {
+        renderPort.postMessage({ type: "visibility_active" });
+      }
+    }
+    latestTick = {
+      timestamp: message.timestamp,
+      aspect: requestsVisibility ? message.aspect : null,
+    };
     drainWork();
     return;
   }
   if (message.type === "transport_writable") {
-    drainWork();
+    handleTransportWritable();
     return;
   }
   if (message.type === "render_error") {
     fail(new Error(`render worker failed: ${message.message}`), null);
   }
+}
+
+function handleTransportWritable() {
+  if (pendingVisibility !== null) {
+    sendVisibilityOrThrow(pendingVisibility);
+    lastVisibility = pendingVisibility;
+    pendingVisibility = null;
+  }
+  drainWork();
 }
 
 function attachHostPort(message) {
@@ -290,14 +321,26 @@ function drainWork() {
     return;
   }
 
-  const timestamp = latestTick;
+  const tick = latestTick;
   latestTick = null;
+  if (tick.aspect !== null) {
+    viewportAspect = tick.aspect;
+  }
   try {
-    const delta = player.tickDeltaJson(timestamp);
+    const delta = player.tickDeltaJson(tick.timestamp);
     if (delta !== undefined && delta !== null) {
       sendDeltaOrThrow(delta);
+    } else if (tick.aspect === null) {
+      // Ordinary execution ticks do not participate in viewport visibility culling.
+    } else if (lastVisibility !== null && Object.is(lastVisibility.aspect, viewportAspect)) {
+      sendVisibilityOrThrow(lastVisibility);
+    } else {
+      // The mirror must advance to the same semantic frame before accepting a new
+      // visibility envelope. A complete snapshot is needed only for first activation
+      // or an aspect change when evaluation produced no object delta.
+      sendDeltaOrThrow(player.snapshotDeltaJson());
     }
-    maybeRequestHostCallback(timestamp);
+    maybeRequestHostCallback(tick.timestamp);
   } catch (error) {
     fail(error, null);
   }
@@ -603,14 +646,14 @@ function applyHostMirror(delta) {
 }
 
 function transportCanSend() {
-  if (transport === null) {
+  if (transport === null || pendingVisibility !== null) {
     return false;
   }
   if (typeof transport.canSend === "function") {
     return transport.canSend();
   }
   if (typeof transport.inFlight === "function") {
-    return transport.inFlight() < 2;
+    return transport.inFlight() < 1;
   }
   return true;
 }
@@ -619,6 +662,7 @@ function sendDeltaOrThrow(json) {
   if (json === undefined || json === null) {
     return;
   }
+  const metadata = executionDeltaMetadata(json);
   const decoded = hostCallbacks === null ? null : JSON.parse(json);
   if (!transport.send(json)) {
     throw new Error("execution transport became backpressured after work was admitted");
@@ -629,10 +673,37 @@ function sendDeltaOrThrow(json) {
   if (transportMode === EXECUTION_TRANSPORT_SHARED) {
     renderPort.postMessage({ type: "shared_delta" });
   }
+  if (viewportAspect !== null) {
+    pendingVisibility = {
+      session: metadata.session,
+      sequence: metadata.sequence,
+      aspect: viewportAspect,
+      json: player.viewportVisibilityJson(viewportAspect),
+    };
+  }
+}
+
+function sendVisibilityOrThrow(visibility) {
+  if (visibility === null) {
+    return;
+  }
+  renderPort.postMessage({
+    type: "visibility",
+    session: visibility.session,
+    sequence: visibility.sequence,
+    json: visibility.json,
+  });
 }
 
 function currentEngineMetrics() {
   return {
+    visibility: {
+      active: viewportAspect !== null,
+      aspect: viewportAspect,
+      pending: pendingVisibility !== null,
+      lastSession: lastVisibility?.session ?? null,
+      lastSequence: lastVisibility?.sequence ?? null,
+    },
     host: {
       enabled: hostCallbacks !== null,
       inFlight: hostInFlight !== null,

--- a/web/execution-visibility-protocol.test.mjs
+++ b/web/execution-visibility-protocol.test.mjs
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const engineUrl = new URL("./execution-engine-worker.js", import.meta.url);
+const renderUrl = new URL("./authoring-render-worker.js", import.meta.url);
+
+async function workerSources() {
+  return Promise.all([readFile(engineUrl, "utf8"), readFile(renderUrl, "utf8")]);
+}
+
+test("legacy execution activates visibility before paired frame delivery", async () => {
+  const [engine, render] = await workerSources();
+
+  const activation = engine.indexOf('renderPort.postMessage({ type: "visibility_active" })');
+  const tickDrain = engine.indexOf("drainWork();", activation);
+  assert.ok(activation >= 0, "engine must acknowledge visibility activation");
+  assert.ok(tickDrain > activation, "activation must be queued before tick work is drained");
+
+  assert.match(engine, /const requestsVisibility = message\.aspect !== undefined && message\.aspect !== null/);
+  assert.match(engine, /requestsVisibility && \(!Number\.isFinite\(message\.aspect\) \|\| message\.aspect <= 0\)/);
+  assert.match(engine, /aspect: requestsVisibility \? message\.aspect : null/);
+  assert.match(engine, /executionDeltaMetadata\(json\)/);
+  assert.match(engine, /pendingVisibility = \{[\s\S]*?session: metadata\.session,[\s\S]*?sequence: metadata\.sequence/);
+  assert.match(engine, /maxInFlight: 1/);
+  assert.match(
+    engine,
+    /function handleTransportWritable\(\)[\s\S]*?sendVisibilityOrThrow\(pendingVisibility\)[\s\S]*?pendingVisibility = null/,
+    "visibility must be published only after the paired execution delta is acknowledged",
+  );
+  assert.match(engine, /player\.viewportVisibilityJson\(viewportAspect\)/);
+
+  assert.match(render, /message\.type === "visibility_active"/);
+  assert.match(render, /message\.type === "visibility"/);
+  assert.match(render, /renderer\.applyVisibilityJson\(message\.json\)/);
+});
+
+test("retained execution ticks omit aspect and bypass viewport visibility", async () => {
+  const [engine, render] = await workerSources();
+
+  assert.match(
+    render,
+    /else \{\s*renderPort\?\.postMessage\(\{ type: "tick", timestamp \}\);\s*\}/,
+    "retained mode must request ordinary execution without activating viewport culling",
+  );
+  assert.match(
+    engine,
+    /else if \(tick\.aspect === null\) \{[\s\S]*?Ordinary execution ticks do not participate in viewport visibility culling/,
+  );
+});
+
+test("renderer transitions drain transport without issuing premature engine ticks", async () => {
+  const [, render] = await workerSources();
+
+  const frameStart = render.indexOf("function frame(timestamp)");
+  const transportDrain = render.indexOf("drainTransport();", frameStart);
+  const transitionGate = render.indexOf(
+    "transitionMode !== null || bootstrapPromise !== null || renderer === null",
+    transportDrain,
+  );
+  const legacyTick = render.indexOf("if (mode === MODE_LEGACY)", transitionGate);
+  assert.ok(transportDrain >= 0, "frame loop must continue draining replacement transport");
+  assert.ok(transitionGate > transportDrain, "transition gate must run after transport draining");
+  assert.ok(legacyTick > transitionGate, "no engine tick may be emitted before transition bootstrap settles");
+  assert.match(
+    render,
+    /transitionMode !== null \|\| bootstrapPromise !== null \|\| renderer === null[\s\S]*?scheduleFrame\(\);[\s\S]*?return;/,
+    "transition gating must keep the existing RAF loop alive without issuing work",
+  );
+});
+
+test("legacy visibility is bound to the exact applied execution envelope", async () => {
+  const [, render] = await workerSources();
+
+  assert.match(render, /executionDeltaMetadata\(json\)/);
+  assert.match(render, /executionMetadata = metadata/);
+  assert.match(render, /message\.session !== executionMetadata\.session/);
+  assert.match(render, /message\.sequence !== executionMetadata\.sequence/);
+  assert.match(
+    render,
+    /executionMetadata = null;[\s\S]*?visibilityActive = false;/,
+    "engine reconnect or transition must invalidate old execution pairing metadata",
+  );
+});
+
+test("legacy no-change ticks preserve a mirror-compatible visibility frame", async () => {
+  const [engine] = await workerSources();
+
+  assert.match(
+    engine,
+    /lastVisibility !== null && Object\.is\(lastVisibility\.aspect, viewportAspect\)[\s\S]*?sendVisibilityOrThrow\(lastVisibility\)/,
+    "unchanged ticks should reuse visibility already resolved against the current mirror frame",
+  );
+  assert.match(
+    engine,
+    /sendDeltaOrThrow\(player\.snapshotDeltaJson\(\)\)/,
+    "first activation or an aspect change must synchronize the mirror before new visibility",
+  );
+});
+
+test("legacy render ticks carry aspect and wait for matching visibility", async () => {
+  const [, render] = await workerSources();
+
+  assert.match(render, /aspect: width \/ height/);
+  assert.match(
+    render,
+    /mode === MODE_LEGACY && visibilityActive && !visibilityReady[\s\S]*?return false;/,
+  );
+  assert.match(
+    render,
+    /!visibilityActivationPending && !awaitingVisibility && !needsPresent/,
+  );
+  assert.match(
+    render,
+    /visibilityActivationPending \|\| awaitingVisibility \|\| needsPresent/,
+    "resize must defer while an old-aspect frame is pending",
+  );
+});


### PR DESCRIPTION
## Summary
- pair legacy execution deltas with authoritative retained `noon.execution.visibility` packets after visibility activation
- carry render aspect from the render worker to the engine so viewport queries use the post-evaluation semantic camera
- resolve visibility through `ExecutionFrameMirror` and submit only the ordered rows through #591 while keeping packed GPU caches resident
- gate presentation after activation until matching visibility arrives, including control/host-callback deltas and no-delta resize ticks
- bind visibility delivery to the existing execution `{session, sequence}` identity, publish it only after the paired delta is acknowledged, and reject visibility whose pair does not match the last execution envelope actually accepted by the renderer
- serialize visibility-bearing execution frames to one in flight so shared and transferable transports have the same ordering contract
- reuse the last mirror-compatible visibility on unchanged ticks; first activation or an aspect change with no object delta synchronizes one snapshot before computing new visibility
- defer surface resize while an old-aspect visibility frame is in flight so candidate bounds and GPU projection cannot mix
- expose candidate/result/live-set renderer metrics and add focused worker protocol regressions

## Architecture
The execution engine remains the only spatial-index owner. The render worker supplies only aspect and consumes generation-safe candidate identity; it does not scan bounds or build another index.

Correctness does not rely on MessagePort/FIFO timing across the execution transport and visibility messages. The engine admits one visibility-bearing frame at a time, derives the existing execution session/sequence from that delta, waits for the render transport acknowledgement, then publishes visibility for the now-current mirror frame. The render worker independently tracks metadata from the execution envelope it actually applied and requires an exact pair match before accepting visibility. Reconnects/transitions clear that pairing state. This is frame pairing, not protocol-version negotiation; Rust and JS still share one current application schema.

The initial bootstrap frame remains uncullled so renderer construction does not depend on a second bootstrap payload. After activation, legacy presentation is visibility-gated and never falls back to ordinary preparation for a pending execution frame.

Stacked on #604. Tracks #569 and #66.