### PR TITLE
Set retained glyph atlas product budget

### DIFF
--- a/crates/noon-text-atlas/tests/gpu_residency_churn.rs
+++ b/crates/noon-text-atlas/tests/gpu_residency_churn.rs
@@ -1,0 +1,88 @@
+#![cfg(feature = "ci-noop")]
+
+use std::sync::Arc;
+
+use noon_core::{FontResourceHandle, FontResourceId};
+use noon_text_atlas::{GlyphAtlasEntry, GlyphAtlasPlane, GpuGlyphAtlas};
+use noon_text_raster::{
+    GlyphRaster, GlyphRasterFormat, GlyphRasterImage, GlyphRasterKey, GlyphRasterPlacement,
+};
+
+fn glyph_key(glyph_id: u16) -> GlyphRasterKey {
+    GlyphRasterKey {
+        font: FontResourceHandle {
+            id: FontResourceId::new(0),
+            version: 0,
+        },
+        glyph_id,
+        pixel_size_bits: 16.0f32.to_bits(),
+        variation_fingerprint: 0,
+    }
+}
+
+fn mask_raster(value: u8) -> GlyphRaster {
+    const WIDTH: u32 = 4;
+    const HEIGHT: u32 = 2;
+    GlyphRaster::Image(GlyphRasterImage {
+        format: GlyphRasterFormat::Alpha8,
+        placement: GlyphRasterPlacement {
+            left: 0,
+            top: HEIGHT as i32,
+            width: WIDTH,
+            height: HEIGHT,
+        },
+        data: Arc::from(vec![value; (WIDTH * HEIGHT) as usize]),
+    })
+}
+
+#[test]
+fn two_page_atlas_churn_plateaus_without_texture_reallocation() {
+    const GENERATIONS: u16 = 1_000;
+
+    let (device, queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
+    let mut atlas = GpuGlyphAtlas::with_page_limit(8, 2).unwrap();
+    let raster = mask_raster(180);
+
+    for glyph_id in 1..=4 {
+        let GlyphAtlasEntry::Image(_) = atlas
+            .insert(&device, &queue, glyph_key(glyph_id), &raster)
+            .unwrap()
+        else {
+            panic!("visible mask glyph must occupy the atlas");
+        };
+    }
+
+    assert_eq!(atlas.page_count(GlyphAtlasPlane::Mask), 2);
+    assert_eq!(atlas.page_count(GlyphAtlasPlane::Color), 0);
+    assert_eq!(atlas.stats().texture_allocations, 2);
+    assert_eq!(atlas.stats().entries, 4);
+
+    for generation in 0..GENERATIONS {
+        atlas.begin_generation();
+        let first = 5 + generation * 2;
+        for glyph_id in first..=first + 1 {
+            let GlyphAtlasEntry::Image(_) = atlas
+                .insert(&device, &queue, glyph_key(glyph_id), &raster)
+                .unwrap()
+            else {
+                panic!("visible mask glyph must occupy the atlas");
+            };
+        }
+
+        let stats = atlas.stats();
+        assert_eq!(atlas.page_count(GlyphAtlasPlane::Mask), 2);
+        assert_eq!(atlas.page_count(GlyphAtlasPlane::Color), 0);
+        assert_eq!(stats.texture_allocations, 2);
+        assert_eq!(stats.entries, 4);
+        assert_eq!(stats.mask_entries, 4);
+        assert_eq!(stats.color_entries, 0);
+    }
+
+    let stats = atlas.stats();
+    assert_eq!(stats.page_evictions, u64::from(GENERATIONS));
+    assert_eq!(stats.page_reuses, u64::from(GENERATIONS));
+    assert_eq!(
+        stats.image_entries_evicted,
+        u64::from(GENERATIONS) * 2
+    );
+}

--- a/crates/noon-text-atlas/tests/gpu_residency_churn.rs
+++ b/crates/noon-text-atlas/tests/gpu_residency_churn.rs
@@ -81,8 +81,5 @@ fn two_page_atlas_churn_plateaus_without_texture_reallocation() {
     let stats = atlas.stats();
     assert_eq!(stats.page_evictions, u64::from(GENERATIONS));
     assert_eq!(stats.page_reuses, u64::from(GENERATIONS));
-    assert_eq!(
-        stats.image_entries_evicted,
-        u64::from(GENERATIONS) * 2
-    );
+    assert_eq!(stats.image_entries_evicted, u64::from(GENERATIONS) * 2);
 }

--- a/crates/noon-text-render-wgpu/src/lib.rs
+++ b/crates/noon-text-render-wgpu/src/lib.rs
@@ -24,6 +24,7 @@ use noon_text_raster::{
     GlyphRasterStats,
 };
 
+pub const DEFAULT_GLYPH_ATLAS_MAX_PAGES_PER_PLANE: usize = 2;
 pub const DEFAULT_GLYPH_RASTER_CACHE_MAX_ENTRIES: usize = 8_192;
 pub const DEFAULT_GLYPH_RASTER_CACHE_MAX_IMAGE_BYTES: usize = 64 * 1024 * 1024;
 pub const GLYPH_RASTER_SIZE_BUCKET_RATIO: f32 = 1.125;
@@ -246,7 +247,10 @@ impl RetainedTextQuadPreparer {
     ) -> Result<Self, GlyphAtlasError> {
         Ok(Self {
             raster_cache: GlyphRasterCache::with_limits(raster_limits),
-            atlas: GpuGlyphAtlas::new(atlas_extent)?,
+            atlas: GpuGlyphAtlas::with_page_limit(
+                atlas_extent,
+                DEFAULT_GLYPH_ATLAS_MAX_PAGES_PER_PLANE,
+            )?,
             mask_quads: Vec::new(),
             color_quads: Vec::new(),
             items: Vec::new(),
@@ -276,6 +280,15 @@ impl RetainedTextQuadPreparer {
 
     pub const fn atlas_stats(&self) -> GlyphAtlasStats {
         self.atlas.stats()
+    }
+
+    /// GPU texture bytes currently resident in lazily allocated atlas pages.
+    pub fn atlas_resident_texture_bytes(&self) -> u64 {
+        atlas_texture_bytes(
+            self.atlas.extent(),
+            self.atlas.page_count(GlyphAtlasPlane::Mask),
+            self.atlas.page_count(GlyphAtlasPlane::Color),
+        )
     }
 
     pub const fn incremental_stats(&self) -> RetainedTextIncrementalStats {
@@ -698,6 +711,15 @@ impl Default for RetainedTextQuadPreparer {
     }
 }
 
+fn atlas_texture_bytes(extent: u32, mask_pages: usize, color_pages: usize) -> u64 {
+    let extent = u64::from(extent);
+    let page_texels = extent.saturating_mul(extent);
+    let mask_pages = u64::try_from(mask_pages).unwrap_or(u64::MAX);
+    let color_pages = u64::try_from(color_pages).unwrap_or(u64::MAX);
+    let weighted_pages = mask_pages.saturating_add(color_pages.saturating_mul(4));
+    page_texels.saturating_mul(weighted_pages)
+}
+
 fn raster_pixel_size(
     run: &GlyphRun,
     object_transform: Transform2D,
@@ -881,7 +903,7 @@ mod tests {
     }
 
     #[test]
-    fn renderer_uses_finite_default_raster_cache_limits() {
+    fn renderer_uses_finite_default_residency_limits() {
         let preparer = RetainedTextQuadPreparer::new(128).unwrap();
         assert_eq!(
             preparer.raster_cache_limits(),
@@ -889,6 +911,23 @@ mod tests {
         );
         assert!(preparer.raster_cache_limits().max_entries < usize::MAX);
         assert!(preparer.raster_cache_limits().max_image_bytes < usize::MAX);
+        assert_eq!(
+            preparer.atlas().max_pages_per_plane(),
+            DEFAULT_GLYPH_ATLAS_MAX_PAGES_PER_PLANE
+        );
+        assert_eq!(preparer.atlas_resident_texture_bytes(), 0);
+    }
+
+    #[test]
+    fn default_atlas_policy_caps_texture_residency_at_forty_mib() {
+        assert_eq!(
+            atlas_texture_bytes(
+                DEFAULT_GLYPH_ATLAS_EXTENT,
+                DEFAULT_GLYPH_ATLAS_MAX_PAGES_PER_PLANE,
+                DEFAULT_GLYPH_ATLAS_MAX_PAGES_PER_PLANE,
+            ),
+            40 * 1024 * 1024
+        );
     }
 
     #[test]
@@ -950,6 +989,9 @@ mod tests {
             .atlas()
             .texture_view(GlyphAtlasPlane::Color)
             .is_none());
+        assert_eq!(preparer.atlas().page_count(GlyphAtlasPlane::Mask), 1);
+        assert_eq!(preparer.atlas().page_count(GlyphAtlasPlane::Color), 0);
+        assert_eq!(preparer.atlas_resident_texture_bytes(), 128 * 128);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- keep low-level `GpuGlyphAtlas::new(extent)` at its one-page-per-plane compatibility policy
- make the retained text product owner explicitly opt into a lazy two-page-per-plane atlas budget
- expose current retained atlas texture residency in bytes using actual lazily allocated page counts
- document and test the 2048² default worst-case texture plateau at 40 MiB (2 × R8 mask pages + 2 × RGBA8 color pages)
- add a deterministic 1,000-generation noop-GPU churn regression proving page count, live entries, and texture allocations plateau while page eviction/reuse counters advance exactly

## Architecture
The memory policy belongs at `RetainedTextQuadPreparer`, the product owner, rather than changing the low-level atlas compatibility default. Typical mask-only text remains lazy: one allocated 2048² R8 page is 4 MiB; the 40 MiB value is only the configured worst case when both planes consume both pages.

This completes the remaining #363 product-policy boundary after #589 generation-pinned page reuse, #594 retained rebuild generation wiring, and #599 empty-glyph metadata cleanup.

Tracks #363 and #114.