### PR TITLE
Bind execution visibility to transport frame identity

### DIFF
--- a/web/execution-visibility-transport.js
+++ b/web/execution-visibility-transport.js
@@ -1,0 +1,94 @@
+export const EXECUTION_VISIBILITY_CHANNEL = "noon.execution.visibility";
+export const EXECUTION_VISIBILITY_VERSION = 1;
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+export function executionVisibilityMetadata(json) {
+  if (typeof json !== "string") {
+    throw new TypeError("execution visibility must be a JSON string");
+  }
+
+  let visibility;
+  try {
+    visibility = JSON.parse(json);
+  } catch (error) {
+    throw new Error(`execution visibility is invalid JSON: ${error.message}`);
+  }
+
+  if (!isRecord(visibility) || visibility.channel !== EXECUTION_VISIBILITY_CHANNEL) {
+    throw new Error("execution visibility has an invalid channel");
+  }
+  if (visibility.protocol_version !== EXECUTION_VISIBILITY_VERSION) {
+    throw new Error(`unsupported execution visibility version ${visibility.protocol_version}`);
+  }
+  if (!Number.isFinite(visibility.time)) {
+    throw new Error("execution visibility has an invalid time");
+  }
+  if (!Number.isSafeInteger(visibility.layout_generation) || visibility.layout_generation < 0) {
+    throw new Error("execution visibility has an invalid layout generation");
+  }
+  if (!Number.isSafeInteger(visibility.total_live) || visibility.total_live < 0) {
+    throw new Error("execution visibility has an invalid live-object count");
+  }
+  if (!Array.isArray(visibility.slots)) {
+    throw new Error("execution visibility slots must be an array");
+  }
+
+  return {
+    time: visibility.time,
+    layoutGeneration: visibility.layout_generation,
+    totalLive: visibility.total_live,
+  };
+}
+
+export function encodeTransferableExecutionVisibility({ session, sequence }, json) {
+  validateFrameIdentity(session, sequence);
+  executionVisibilityMetadata(json);
+  const payload = encoder.encode(json);
+  const buffer = payload.buffer.slice(payload.byteOffset, payload.byteOffset + payload.byteLength);
+  return {
+    message: {
+      type: "execution_visibility",
+      session,
+      sequence,
+      buffer,
+    },
+    transfer: [buffer],
+  };
+}
+
+export function decodeTransferableExecutionVisibility(message) {
+  if (!isRecord(message) || message.type !== "execution_visibility") {
+    throw new Error("execution visibility message must be an execution_visibility envelope");
+  }
+  validateFrameIdentity(message.session, message.sequence);
+  if (!(message.buffer instanceof ArrayBuffer)) {
+    throw new Error("execution visibility payload must be an ArrayBuffer");
+  }
+
+  const json = decoder.decode(new Uint8Array(message.buffer));
+  return {
+    json,
+    frame: { session: message.session, sequence: message.sequence },
+    visibility: executionVisibilityMetadata(json),
+  };
+}
+
+export function executionFrameKey({ session, sequence }) {
+  validateFrameIdentity(session, sequence);
+  return `${session}:${sequence}`;
+}
+
+function validateFrameIdentity(session, sequence) {
+  if (!Number.isSafeInteger(session) || session < 0) {
+    throw new Error("execution visibility has an invalid session");
+  }
+  if (!Number.isSafeInteger(sequence) || sequence < 0) {
+    throw new Error("execution visibility has an invalid sequence");
+  }
+}
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/web/execution-visibility-transport.test.mjs
+++ b/web/execution-visibility-transport.test.mjs
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  decodeTransferableExecutionVisibility,
+  encodeTransferableExecutionVisibility,
+  executionFrameKey,
+  executionVisibilityMetadata,
+} from "./execution-visibility-transport.js";
+
+function visibility(overrides = {}) {
+  return JSON.stringify({
+    channel: "noon.execution.visibility",
+    protocol_version: 1,
+    time: 0.5,
+    layout_generation: 7,
+    total_live: 2,
+    slots: [
+      { slot: 4, generation: 1 },
+      { slot: 9, generation: 3 },
+    ],
+    stats: { candidates: 2, results: 2, full_scan_fallbacks: 0 },
+    ...overrides,
+  });
+}
+
+test("visibility metadata validates the retained-query transport envelope", () => {
+  assert.deepEqual(executionVisibilityMetadata(visibility()), {
+    time: 0.5,
+    layoutGeneration: 7,
+    totalLive: 2,
+  });
+
+  assert.throws(
+    () => executionVisibilityMetadata(visibility({ channel: "noon.execution" })),
+    /invalid channel/,
+  );
+  assert.throws(
+    () => executionVisibilityMetadata(visibility({ protocol_version: 2 })),
+    /unsupported execution visibility version 2/,
+  );
+  assert.throws(
+    () => executionVisibilityMetadata(visibility({ layout_generation: -1 })),
+    /invalid layout generation/,
+  );
+});
+
+test("transferable visibility keeps the candidate set bound to one execution frame", () => {
+  const encoded = encodeTransferableExecutionVisibility(
+    { session: 12, sequence: 41 },
+    visibility(),
+  );
+  assert.equal(encoded.transfer.length, 1);
+  assert.equal(encoded.transfer[0], encoded.message.buffer);
+
+  const decoded = decodeTransferableExecutionVisibility(encoded.message);
+  assert.equal(decoded.json, visibility());
+  assert.deepEqual(decoded.frame, { session: 12, sequence: 41 });
+  assert.deepEqual(decoded.visibility, {
+    time: 0.5,
+    layoutGeneration: 7,
+    totalLive: 2,
+  });
+  assert.equal(executionFrameKey(decoded.frame), "12:41");
+});
+
+test("frame identity rejects malformed or unsafe pairing metadata", () => {
+  assert.throws(
+    () => encodeTransferableExecutionVisibility({ session: -1, sequence: 0 }, visibility()),
+    /invalid session/,
+  );
+  assert.throws(
+    () => encodeTransferableExecutionVisibility({ session: 1, sequence: 1.5 }, visibility()),
+    /invalid sequence/,
+  );
+  assert.throws(
+    () => executionFrameKey({ session: 1, sequence: Number.MAX_SAFE_INTEGER + 1 }),
+    /invalid sequence/,
+  );
+});
+
+test("decoder rejects non-transferable visibility payloads before pairing", () => {
+  assert.throws(
+    () =>
+      decodeTransferableExecutionVisibility({
+        type: "execution_visibility",
+        session: 1,
+        sequence: 0,
+        buffer: "not-a-buffer",
+      }),
+    /must be an ArrayBuffer/,
+  );
+});


### PR DESCRIPTION
Superseded by #605. The integrated worker path already pairs visibility with the execution flow and does not need a separate protocol-version/pairing transport layer. Closing this redundant slice.