### PR TITLE
Bound parsed font faces with raster residency

### DIFF
--- a/crates/noon-text-raster/src/lib.rs
+++ b/crates/noon-text-raster/src/lib.rs
@@ -256,6 +256,7 @@ impl GlyphRasterCache {
 
     pub fn clear_images(&mut self) {
         self.entries.clear();
+        self.faces.clear();
         self.image_bytes = 0;
         self.access_clock = 0;
         self.hits = 0;
@@ -340,6 +341,7 @@ impl GlyphRasterCache {
         }
 
         self.image_bytes = self.image_bytes.saturating_add(image_bytes);
+        self.faces.entry(font_handle).or_insert(face);
         self.entries.insert(
             key,
             CachedGlyphRaster {
@@ -375,11 +377,14 @@ impl GlyphRasterCache {
                 .expect("selected glyph raster cache entry must still exist");
             self.image_bytes = self.image_bytes.saturating_sub(removed.image_bytes);
             self.evictions = self.evictions.saturating_add(1);
+            if !self.entries.keys().any(|key| key.font == oldest_key.font) {
+                self.faces.remove(&oldest_key.font);
+            }
         }
     }
 
     fn swash_face(
-        &mut self,
+        &self,
         handle: FontResourceHandle,
         resource: &FontResource,
     ) -> Result<SwashFace, GlyphRasterError> {
@@ -388,12 +393,10 @@ impl GlyphRasterCache {
         }
         let font = FontRef::from_index(resource.data.as_ref(), resource.key.face_index as usize)
             .ok_or(GlyphRasterError::InvalidFontData(handle))?;
-        let face = SwashFace {
+        Ok(SwashFace {
             offset: font.offset,
             key: font.key,
-        };
-        self.faces.insert(handle, face);
-        Ok(face)
+        })
     }
 
     fn rasterize(
@@ -543,6 +546,7 @@ mod tests {
         assert_eq!(stats.evictions, 1);
         assert_eq!(stats.hits, 1);
         assert_eq!(stats.misses, 3);
+        assert!(stats.font_faces <= stats.entries);
 
         cache
             .get_or_rasterize(&artifact.fonts, run, b, 48.0)
@@ -567,13 +571,32 @@ mod tests {
         assert!(image.data.len() > 1);
         assert_eq!(cache.stats().entries, 0);
         assert_eq!(cache.stats().image_bytes, 0);
+        assert_eq!(cache.stats().font_faces, 0);
         assert_eq!(cache.stats().rejected_admissions, 1);
 
         cache
             .get_or_rasterize(&artifact.fonts, run, glyph.glyph_id, 64.0)
             .unwrap();
         assert_eq!(cache.stats().misses, 2);
+        assert_eq!(cache.stats().font_faces, 0);
         assert_eq!(cache.stats().rejected_admissions, 2);
+    }
+
+    #[test]
+    fn clearing_images_releases_cached_font_faces() {
+        let artifact = compile_typst_resource("A", TypstMode::Markup).unwrap();
+        let run = artifact.resource.runs.first().unwrap();
+        let glyph = run.glyphs.first().unwrap();
+        let mut cache = GlyphRasterCache::new();
+
+        cache
+            .get_or_rasterize(&artifact.fonts, run, glyph.glyph_id, 48.0)
+            .unwrap();
+        assert_eq!(cache.stats().font_faces, 1);
+
+        cache.clear_images();
+        assert_eq!(cache.stats().entries, 0);
+        assert_eq!(cache.stats().font_faces, 0);
     }
 
     #[test]
@@ -590,6 +613,7 @@ mod tests {
 
         cache.set_limits(GlyphRasterCacheLimits::new(1, usize::MAX));
         assert_eq!(cache.stats().entries, 1);
+        assert!(cache.stats().font_faces <= cache.stats().entries);
         assert!(cache.stats().evictions >= 1);
     }
 


### PR DESCRIPTION
## Summary

Close an independent CPU residency hole under #363 / #114.

`GlyphRasterCache` already bounds raster entries and retained image bytes, but its parsed Swash `faces` map was independent of those limits. Font handle/version churn could therefore keep `entries` and `image_bytes` bounded while `font_faces` grew monotonically.

This change ties parsed-face residency directly to admitted raster residency:
- rejected raster admissions do not retain parsed face metadata;
- evicting the last raster for a font retires that cached face;
- `clear_images()` clears parsed faces as part of the same residency reset;
- focused tests assert rejected admissions stay at zero resident faces and that face count remains bounded by raster entries.

This deliberately does not add a second face-cache policy or change shaping/font-resource ownership. Parsed metadata is an implementation cache of resident raster content, while immutable font bytes remain owned by the retained font arena.

## Validation

CI requested on exact head `1fa1a1af105877a539803b7f28b4d38f48c3188a`.

Closes one bounded-residency sub-slice of #363; #363 remains open for paged GPU atlas residency, scale bucketing, outline residency, and broader churn policy.