### PR TITLE
Add cross-platform and optimized release validation

### DIFF
--- a/.github/workflows/platform-release-validation.yml
+++ b/.github/workflows/platform-release-validation.yml
@@ -1,0 +1,161 @@
+name: Platform and release validation
+
+on:
+  pull_request:
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "crates/**"
+      - "scripts/build-web-demo.sh"
+      - "scripts/check-web-package.mjs"
+      - "scripts/browser-smoke.mjs"
+      - "web/**"
+      - ".github/workflows/platform-release-validation.yml"
+  push:
+    branches:
+      - master
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "crates/**"
+      - "scripts/build-web-demo.sh"
+      - "scripts/check-web-package.mjs"
+      - "scripts/browser-smoke.mjs"
+      - "web/**"
+      - ".github/workflows/platform-release-validation.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: platform-release-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  native-platforms:
+    name: Native tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 35
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - windows-latest
+    env:
+      CARGO_INCREMENTAL: "0"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use stable Rust
+        run: rustup default stable
+
+      - name: Cache Cargo sources and target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-native-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'crates/**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-native-
+
+      - name: Test workspace libraries and integration tests
+        run: cargo test --workspace --all-features --lib --tests
+
+  native-release:
+    name: Native release semantics
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      CARGO_INCREMENTAL: "0"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use stable Rust
+        run: rustup default stable
+
+      - name: Cache Cargo sources and target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: release-native-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'crates/**/Cargo.toml') }}
+          restore-keys: |
+            release-native-
+
+      - name: Test core deterministic layers in release mode
+        run: cargo test --release --all-features -p noon-core -p noon-geometry -p noon-runtime
+
+  optimized-web:
+    name: Optimized browser artifact
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    env:
+      CARGO_INCREMENTAL: "0"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use stable Rust with WASM target
+        run: |
+          rustup default stable
+          rustup target add wasm32-unknown-unknown
+
+      - name: Cache Cargo sources and target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: optimized-web-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'crates/**/Cargo.toml') }}
+          restore-keys: |
+            optimized-web-
+
+      - name: Install pinned wasm-pack
+        uses: taiki-e/install-action@13608cbb45b01feb47ef444ab1a42dc41ad56f1a # v2.79.11
+        with:
+          tool: wasm-pack@0.15.0
+          fallback: none
+
+      - name: Build production-optimized browser package
+        env:
+          NOON_SKIP_PLAYGROUND_TEST: "1"
+        run: bash scripts/build-web-demo.sh
+
+      - name: Record optimized artifact size
+        shell: bash
+        run: |
+          test -s web/pkg/noon_web_bg.wasm
+          bytes=$(wc -c < web/pkg/noon_web_bg.wasm)
+          echo "Optimized WASM bytes: ${bytes}"
+          echo "### Optimized WebAssembly artifact" >> "$GITHUB_STEP_SUMMARY"
+          echo "- noon_web_bg.wasm: ${bytes} bytes" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Install Chromium smoke dependency
+        run: |
+          npm install --no-save --ignore-scripts playwright@1.62.1 pngjs@7.0.0
+          npx playwright install chromium
+
+      - name: Smoke optimized artifact in browser
+        env:
+          NOON_BROWSER_SMOKE_BACKEND: webgl
+          NOON_BROWSER_SMOKE_EXAMPLE: parity-create-circle
+          NOON_BROWSER_SMOKE_ARTIFACTS: browser-smoke-artifacts/optimized-webgl
+        run: node scripts/browser-smoke.mjs
+
+      - name: Upload optimized smoke artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: optimized-web-smoke
+          path: browser-smoke-artifacts/optimized-webgl
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/platform-release-validation.yml
+++ b/.github/workflows/platform-release-validation.yml
@@ -147,7 +147,6 @@ jobs:
       - name: Smoke optimized artifact in browser
         env:
           NOON_BROWSER_SMOKE_BACKEND: webgl
-          NOON_BROWSER_SMOKE_EXAMPLE: parity-create-circle
           NOON_BROWSER_SMOKE_ARTIFACTS: browser-smoke-artifacts/optimized-webgl
         run: node scripts/browser-smoke.mjs
 


### PR DESCRIPTION
## Summary
- add macOS and Windows workspace library/integration test lanes so platform-specific compile/test failures are no longer Linux-only blind spots
- add a focused Ubuntu release-mode semantic test for `noon-core`, `noon-geometry`, and `noon-runtime`
- build the browser package through the production optimized WASM path (no `NOON_WASM_SKIP_OPT`), record the optimized artifact size, and run the existing WebGL browser smoke against that artifact
- keep the workflow path-filtered and independently cancellable so this extra validation does not run for documentation-only changes

## Why this slice
The current active failures and PRs are concentrated in viewport culling, retained text, geometry adapters, and WebGL updater parity. This change deliberately avoids those implementation files and addresses the independent #115 verification gap instead.

## Validation
The workflow itself is the validation unit. It reuses existing workspace tests, the pinned wasm-pack version from primary CI, the production build script, and the existing browser smoke rather than introducing a second test harness.

## Remaining risk
The first macOS/Windows run may expose existing platform assumptions rather than workflow defects. Those should be fixed in focused follow-ups instead of weakening the matrix. The optimized browser job intentionally uses the existing full browser smoke until a dedicated minimal optimized-artifact smoke exists.

Tracks #115.