### PR TITLE
Retry transient Binaryen download failures

### DIFF
--- a/.github/workflows/platform-release.yml
+++ b/.github/workflows/platform-release.yml
@@ -131,7 +131,7 @@ jobs:
         run: |
           archive="binaryen-version_${BINARYEN_VERSION}-x86_64-linux.tar.gz"
           url="https://github.com/WebAssembly/binaryen/releases/download/version_${BINARYEN_VERSION}/${archive}"
-          curl --fail --location --retry 3 --output "$RUNNER_TEMP/$archive" "$url"
+          curl --fail --location --retry 3 --retry-all-errors --output "$RUNNER_TEMP/$archive" "$url"
           echo "${BINARYEN_LINUX_SHA256}  $RUNNER_TEMP/$archive" | sha256sum --check --strict
           tar -xzf "$RUNNER_TEMP/$archive" -C "$RUNNER_TEMP"
           binaryen_dir="$RUNNER_TEMP/binaryen-version_${BINARYEN_VERSION}"


### PR DESCRIPTION
## Summary
- make the pinned Binaryen/wasm-opt download retry connection-reset and other transient curl errors
- keep the existing pinned Binaryen version and SHA-256 verification unchanged

## Rationale
#605's optimized browser artifact failed before build with `curl: (35) Recv failure: Connection reset by peer`. `--retry 3` alone does not retry every transient transport error; `--retry-all-errors` preserves fail-fast checksum validation while avoiding false-red release validation from transient GitHub release download failures.