### PR TITLE
Gate shared sector geometry against ManimCE

### DIFF
--- a/.github/workflows/manim-differential.yml
+++ b/.github/workflows/manim-differential.yml
@@ -42,4 +42,5 @@ jobs:
         run: |
           python scripts/manim-differential.py
           python scripts/manim-dot-ellipse-differential.py
+          python scripts/manim-sector-differential.py
           python scripts/manim-frame-sampling-differential.py

--- a/crates/noon-web/examples/manim_sector_oracle.rs
+++ b/crates/noon-web/examples/manim_sector_oracle.rs
@@ -1,0 +1,80 @@
+use noon_core::ObjectSnapshot;
+use noon_web::{
+    manim_annular_sector_snapshot_json, manim_annulus_snapshot_json,
+    manim_sector_snapshot_json,
+};
+use serde_json::{json, Map, Value};
+
+fn decode(snapshot_json: String) -> ObjectSnapshot {
+    serde_json::from_str(&snapshot_json).expect("sector bridge must emit ObjectSnapshot JSON")
+}
+
+fn observation(snapshot: ObjectSnapshot) -> Value {
+    let center = snapshot.center();
+    json!({
+        "center": [center.x, center.y],
+        "width": snapshot.width(),
+        "height": snapshot.height(),
+    })
+}
+
+fn main() {
+    let mut observations = Map::new();
+
+    observations.insert(
+        "annular_default".to_owned(),
+        observation(decode(
+            manim_annular_sector_snapshot_json(
+                1.0,
+                2.0,
+                std::f64::consts::FRAC_PI_2,
+                0.0,
+                9,
+                0.0,
+                0.0,
+            )
+            .expect("default annular sector"),
+        )),
+    );
+    observations.insert(
+        "annular_signed_offset".to_owned(),
+        observation(decode(
+            manim_annular_sector_snapshot_json(
+                0.5,
+                2.25,
+                -std::f64::consts::FRAC_PI_3,
+                std::f64::consts::FRAC_PI_4,
+                9,
+                1.25,
+                -0.75,
+            )
+            .expect("signed offset annular sector"),
+        )),
+    );
+    observations.insert(
+        "sector_offset".to_owned(),
+        observation(decode(
+            manim_sector_snapshot_json(
+                2.0,
+                std::f64::consts::FRAC_PI_2,
+                -std::f64::consts::FRAC_PI_4,
+                9,
+                -1.5,
+                0.75,
+            )
+            .expect("offset sector"),
+        )),
+    );
+    observations.insert(
+        "annulus_offset".to_owned(),
+        observation(decode(
+            manim_annulus_snapshot_json(0.5, 1.75, 9, 0.8, -1.1)
+                .expect("offset annulus"),
+        )),
+    );
+
+    println!(
+        "{}",
+        serde_json::to_string(&Value::Object(observations)).expect("serialize observations")
+    );
+}

--- a/crates/noon-web/examples/manim_sector_oracle.rs
+++ b/crates/noon-web/examples/manim_sector_oracle.rs
@@ -1,7 +1,6 @@
 use noon_core::ObjectSnapshot;
 use noon_web::{
-    manim_annular_sector_snapshot_json, manim_annulus_snapshot_json,
-    manim_sector_snapshot_json,
+    manim_annular_sector_snapshot_json, manim_annulus_snapshot_json, manim_sector_snapshot_json,
 };
 use serde_json::{json, Map, Value};
 
@@ -68,8 +67,7 @@ fn main() {
     observations.insert(
         "annulus_offset".to_owned(),
         observation(decode(
-            manim_annulus_snapshot_json(0.5, 1.75, 9, 0.8, -1.1)
-                .expect("offset annulus"),
+            manim_annulus_snapshot_json(0.5, 1.75, 9, 0.8, -1.1).expect("offset annulus"),
         )),
     );
 

--- a/scripts/manim-sector-differential.py
+++ b/scripts/manim-sector-differential.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Compare shared Rust sector geometry against pinned ManimCE semantics.
+
+This probe deliberately bypasses the still-in-progress Python adapter.  It compares
+renderer-independent bounds from the existing shared Rust/WASM sector bridge with
+ManimCE 0.21.0, so frontend work can reuse an already-qualified geometry oracle.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import subprocess
+from pathlib import Path
+
+import manim
+
+ROOT = Path(__file__).resolve().parents[1]
+PINNED_MANIM_VERSION = "0.21.0"
+TOLERANCE = 2e-5
+
+
+def observe(obj):
+    center = obj.get_center()
+    return {
+        "center": [float(center[0]), float(center[1])],
+        "width": float(obj.width),
+        "height": float(obj.height),
+    }
+
+
+def manim_observations():
+    annular_default = manim.AnnularSector()
+    annular_signed_offset = manim.AnnularSector(
+        inner_radius=0.5,
+        outer_radius=2.25,
+        angle=-math.pi / 3,
+        start_angle=math.pi / 4,
+        num_components=9,
+        arc_center=[1.25, -0.75, 0.0],
+    )
+    sector_offset = manim.Sector(
+        radius=2.0,
+        angle=math.pi / 2,
+        start_angle=-math.pi / 4,
+        num_components=9,
+        arc_center=[-1.5, 0.75, 0.0],
+    )
+    annulus_offset = manim.Annulus(inner_radius=0.5, outer_radius=1.75).shift(
+        [0.8, -1.1, 0.0]
+    )
+    return {
+        "annular_default": observe(annular_default),
+        "annular_signed_offset": observe(annular_signed_offset),
+        "sector_offset": observe(sector_offset),
+        "annulus_offset": observe(annulus_offset),
+    }
+
+
+def noon_observations():
+    result = subprocess.run(
+        [
+            "cargo",
+            "run",
+            "--quiet",
+            "-p",
+            "noon-web",
+            "--example",
+            "manim_sector_oracle",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def compare(path, actual, expected, failures):
+    if isinstance(expected, dict):
+        if set(actual) != set(expected):
+            failures.append(
+                f"{path}: keys differ: Noon={sorted(actual)}, Manim={sorted(expected)}"
+            )
+            return
+        for key in expected:
+            compare(f"{path}.{key}", actual[key], expected[key], failures)
+        return
+    if isinstance(expected, list):
+        if len(actual) != len(expected):
+            failures.append(
+                f"{path}: length differs: Noon={len(actual)}, Manim={len(expected)}"
+            )
+            return
+        for index, (actual_item, expected_item) in enumerate(zip(actual, expected)):
+            compare(f"{path}[{index}]", actual_item, expected_item, failures)
+        return
+    if not math.isclose(float(actual), float(expected), rel_tol=0.0, abs_tol=TOLERANCE):
+        failures.append(f"{path}: Noon={actual!r}, Manim={expected!r}")
+
+
+def main():
+    if manim.__version__ != PINNED_MANIM_VERSION:
+        raise SystemExit(
+            f"expected ManimCE {PINNED_MANIM_VERSION}, got {manim.__version__}"
+        )
+
+    noon = noon_observations()
+    reference = manim_observations()
+    failures = []
+    compare("sector", noon, reference, failures)
+    if failures:
+        print("[FAIL] shared Rust sector geometry diverges from ManimCE")
+        for failure in failures:
+            print(f"  {failure}")
+        raise SystemExit(1)
+
+    print(
+        f"[PASS] {len(reference)} shared Rust sector fixtures match "
+        f"ManimCE {manim.__version__} within {TOLERANCE:g}"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a focused native probe for the existing shared Rust `AnnularSector` / `Sector` / `Annulus` browser bridge
- compare renderer-independent center/width/height semantics directly against pinned ManimCE 0.21.0
- cover defaults, signed-angle + translated annular geometry, translated sector geometry, and translated annulus geometry
- run the new probe in the existing blocking Manim semantic differential workflow

## Architecture
This deliberately does not add or approximate the still-missing Python/JS sector adapters. The reference path consumes the existing shared Rust bridge directly, so geometry remains Rust-owned and there is no frontend geometry reconstruction or JSON mutation/query loop. It provides the #401 oracle lane that can proceed independently while #400 adapter work is active.

I considered the `SurroundingRectangle` / `BackgroundRectangle` public adapter next, but the clean implementation needs direct access through the existing WASM authoring-handle/store boundary. A separate module would otherwise be forced to serialize snapshots or duplicate bounds semantics, so I left that seam untouched rather than introduce transitional debt.

## Validation
CI runs the probe with the same pinned ManimCE 0.21.0 installation as the existing differential suite. Numerical tolerance is `2e-5`, only to account for Noon's retained f32 geometry versus Manim's numpy f64 observations; there are no raster/timing tolerance changes.

Tracks #401 and #400.