### PR TITLE
Pin Manim reference inventory to v0.21.0

### DIFF
--- a/scripts/manim-reference-inventory.mjs
+++ b/scripts/manim-reference-inventory.mjs
@@ -1,11 +1,16 @@
 import { createHash } from "node:crypto";
+import { execFile } from "node:child_process";
 import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
+import { promisify } from "node:util";
 import { pathToFileURL } from "node:url";
 
 const SOURCE_EXTENSIONS = new Set([".py", ".rst"]);
 const INVENTORY_ROOTS = ["docs/source", "manim"];
 const IGNORED_DIRECTORIES = new Set([".git", ".venv", "__pycache__", "node_modules"]);
+export const PINNED_MANIM_VERSION = "v0.21.0";
+export const PINNED_MANIM_REVISION = "861cd4849b17db1db3515b531ffe80b297848f93";
+const execFileAsync = promisify(execFile);
 
 function leadingWhitespace(line) {
   return line.match(/^\s*/u)?.[0].length ?? 0;
@@ -119,8 +124,36 @@ async function collectSourceFiles(repositoryRoot) {
   return files;
 }
 
-export async function buildReferenceInventory(repositoryRoot) {
+export function validatePinnedRevision(revision) {
+  if (revision !== PINNED_MANIM_REVISION) {
+    throw new Error(
+      `Manim reference inventory requires ${PINNED_MANIM_VERSION} commit ${PINNED_MANIM_REVISION}, got ${revision || "an unknown revision"}`,
+    );
+  }
+  return revision;
+}
+
+async function resolvePinnedRevision(repositoryRoot) {
+  let stdout;
+  try {
+    ({ stdout } = await execFileAsync(
+      "git",
+      ["-C", repositoryRoot, "rev-parse", "HEAD"],
+      { encoding: "utf8" },
+    ));
+  } catch (error) {
+    throw new Error(
+      `Manim reference inventory requires a git checkout at ${PINNED_MANIM_VERSION} commit ${PINNED_MANIM_REVISION}`,
+      { cause: error },
+    );
+  }
+  return validatePinnedRevision(stdout.trim());
+}
+
+export async function buildReferenceInventory(repositoryRoot, { revision = null } = {}) {
   const absoluteRoot = path.resolve(repositoryRoot);
+  const pinnedRevision =
+    revision === null ? await resolvePinnedRevision(absoluteRoot) : validatePinnedRevision(revision);
   const examples = [];
   for (const file of await collectSourceFiles(absoluteRoot)) {
     const relativePath = path.relative(absoluteRoot, file).split(path.sep).join("/");
@@ -133,7 +166,16 @@ export async function buildReferenceInventory(repositoryRoot) {
       left.directive_line - right.directive_line ||
       compareCodePoints(left.name ?? "", right.name ?? ""),
   );
-  return { schema_version: 1, scanned_roots: INVENTORY_ROOTS, examples };
+  return {
+    schema_version: 1,
+    upstream: {
+      repository: "ManimCommunity/manim",
+      version: PINNED_MANIM_VERSION,
+      revision: pinnedRevision,
+    },
+    scanned_roots: INVENTORY_ROOTS,
+    examples,
+  };
 }
 
 async function main() {

--- a/scripts/manim-reference-inventory.test.mjs
+++ b/scripts/manim-reference-inventory.test.mjs
@@ -5,8 +5,11 @@ import path from "node:path";
 import test from "node:test";
 
 import {
+  PINNED_MANIM_REVISION,
+  PINNED_MANIM_VERSION,
   buildReferenceInventory,
   extractManimDirectives,
+  validatePinnedRevision,
 } from "./manim-reference-inventory.mjs";
 
 test("extracts directive options and source from Python docstrings", () => {
@@ -34,7 +37,7 @@ test("supports different directive indentation and multiple examples", () => {
   assert.equal(examples[1].source, "class Second(Scene):\n    pass");
 });
 
-test("builds a deterministic code-point-ordered inventory across documentation sources", async () => {
+test("builds a deterministic code-point-ordered inventory with pinned provenance", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "noon-manim-inventory-"));
   await mkdir(path.join(root, "manim", "z"), { recursive: true });
   await mkdir(path.join(root, "docs", "source"), { recursive: true });
@@ -55,8 +58,13 @@ test("builds a deterministic code-point-ordered inventory across documentation s
     ".. manim:: Ignored\n",
   );
 
-  const inventory = await buildReferenceInventory(root);
+  const inventory = await buildReferenceInventory(root, { revision: PINNED_MANIM_REVISION });
   assert.equal(inventory.schema_version, 1);
+  assert.deepEqual(inventory.upstream, {
+    repository: "ManimCommunity/manim",
+    version: "v0.21.0",
+    revision: PINNED_MANIM_REVISION,
+  });
   assert.deepEqual(inventory.scanned_roots, ["docs/source", "manim"]);
   assert.deepEqual(
     inventory.examples.map((example) => [example.source_path, example.name]),
@@ -65,5 +73,26 @@ test("builds a deterministic code-point-ordered inventory across documentation s
       ["docs/source/a.rst", "LowercaseSecond"],
       ["manim/z/later.py", "Later"],
     ],
+  );
+});
+
+test("rejects non-pinned Manim revisions", async () => {
+  assert.equal(PINNED_MANIM_VERSION, "v0.21.0");
+  assert.equal(validatePinnedRevision(PINNED_MANIM_REVISION), PINNED_MANIM_REVISION);
+  assert.throws(
+    () => validatePinnedRevision("main"),
+    /requires v0\.21\.0 commit .* got main/u,
+  );
+  assert.throws(
+    () => validatePinnedRevision("deadbeef"),
+    /requires v0\.21\.0 commit .* got deadbeef/u,
+  );
+
+  const root = await mkdtemp(path.join(tmpdir(), "noon-manim-wrong-revision-"));
+  await mkdir(path.join(root, "manim"), { recursive: true });
+  await mkdir(path.join(root, "docs", "source"), { recursive: true });
+  await assert.rejects(
+    buildReferenceInventory(root, { revision: "main" }),
+    /requires v0\.21\.0 commit .* got main/u,
   );
 });


### PR DESCRIPTION
## Summary
- make the existing reference-example inventory tool verify that its Manim checkout is exactly the immutable commit pinned for `v0.21.0`
- emit explicit `ManimCommunity/manim`, version, and revision provenance in the generated inventory instead of silently accepting whichever checkout is supplied
- preserve the existing deterministic directive parser/source hashing and add focused revision/provenance coverage

## Why
#256 is explicitly pinned to ManimCE v0.21.0, but `scripts/manim-reference-inventory.mjs` previously scanned any repository root without validating the upstream revision. Running it against `main` or another release could silently change the example corpus/provenance while still producing valid-looking JSON.

The CLI now resolves `git rev-parse HEAD` and requires the same immutable `861cd4849b17db1db3515b531ffe80b297848f93` commit already used by the dedicated inventory workflow. `buildReferenceInventory` keeps a narrow revision injection only for deterministic unit fixtures; injected revisions are validated against the same pin.

## Validation
- `node --test scripts/manim-reference-inventory.test.mjs` — 4/4 passing locally
- the focused test is already part of `scripts/build-web-demo.sh`
- `.github/workflows/manim-reference-inventory.yml` independently checks out and validates the same immutable upstream commit before extraction

Part of #256.