### PR TITLE
Gate WebGPU/WebGL browser visual coverage parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,3 +262,42 @@ jobs:
           path: browser-smoke-artifacts
           if-no-files-found: ignore
           retention-days: 7
+
+  browser-rendering-parity:
+    name: Browser rendering parity
+    runs-on: ubuntu-latest
+    needs: browser-rendering
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install visual diff dependency
+        run: npm install --no-save --ignore-scripts pngjs@7.0.0
+
+      - name: Download WebGPU screenshots
+        uses: actions/download-artifact@v4
+        with:
+          name: browser-smoke-screenshots-webgpu
+          path: browser-backend-parity
+
+      - name: Download WebGL screenshots
+        uses: actions/download-artifact@v4
+        with:
+          name: browser-smoke-screenshots-webgl
+          path: browser-backend-parity
+
+      - name: Compare WebGPU and WebGL foreground coverage
+        run: |
+          node scripts/browser-backend-visual-parity.mjs \
+            browser-backend-parity/webgpu \
+            browser-backend-parity/webgl \
+            browser-backend-parity-report
+
+      - name: Upload backend visual parity report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: browser-backend-visual-parity
+          path: browser-backend-parity-report
+          if-no-files-found: error
+          retention-days: 7

--- a/scripts/browser-backend-visual-parity.mjs
+++ b/scripts/browser-backend-visual-parity.mjs
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import pngjs from "pngjs";
+
+import {
+  compareForegroundCoverage,
+  foregroundMismatchMask,
+} from "./browser-visual-parity-lib.mjs";
+
+const { PNG } = pngjs;
+
+const [webgpuDir, webglDir, outputDir] = process.argv.slice(2);
+if (!webgpuDir || !webglDir || !outputDir) {
+  throw new Error(
+    "usage: node scripts/browser-backend-visual-parity.mjs <webgpu-dir> <webgl-dir> <output-dir>",
+  );
+}
+
+function finiteEnv(name, fallback) {
+  const raw = process.env[name];
+  if (raw === undefined) {
+    return fallback;
+  }
+  const value = Number(raw);
+  if (!Number.isFinite(value)) {
+    throw new Error(`${name} must be finite, got ${raw}`);
+  }
+  return value;
+}
+
+const tolerances = {
+  backgroundDistance: finiteEnv("NOON_BACKEND_PARITY_BACKGROUND_DISTANCE", 32),
+  neighborRadius: finiteEnv("NOON_BACKEND_PARITY_NEIGHBOR_RADIUS", 1),
+  maxMismatchFraction: finiteEnv("NOON_BACKEND_PARITY_MAX_MISMATCH_FRACTION", 0.02),
+  maxBoundsDelta: finiteEnv("NOON_BACKEND_PARITY_MAX_BOUNDS_DELTA", 2),
+};
+assert.ok(Number.isInteger(tolerances.neighborRadius) && tolerances.neighborRadius >= 0);
+
+async function pngNames(directory) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".png"))
+    .map((entry) => entry.name)
+    .sort();
+}
+
+function mismatchPng(width, height, mask) {
+  const diff = new PNG({ width, height });
+  for (let pixel = 0; pixel < mask.length; pixel += 1) {
+    const offset = pixel * 4;
+    const value = mask[pixel] === 0 ? 0 : 255;
+    diff.data[offset] = value;
+    diff.data[offset + 1] = value;
+    diff.data[offset + 2] = value;
+    diff.data[offset + 3] = mask[pixel] === 0 ? 0 : 255;
+  }
+  return PNG.sync.write(diff);
+}
+
+await mkdir(outputDir, { recursive: true });
+
+const webgpuNames = await pngNames(webgpuDir);
+const webglNames = await pngNames(webglDir);
+assert.ok(webgpuNames.length > 0, `no browser-smoke PNGs found in ${webgpuDir}`);
+assert.deepEqual(
+  webglNames,
+  webgpuNames,
+  "WebGPU and WebGL browser-smoke artifact sets must contain the same deterministic checkpoints",
+);
+
+const results = [];
+for (const name of webgpuNames) {
+  const [webgpuBuffer, webglBuffer] = await Promise.all([
+    readFile(path.join(webgpuDir, name)),
+    readFile(path.join(webglDir, name)),
+  ]);
+  const webgpu = PNG.sync.read(webgpuBuffer);
+  const webgl = PNG.sync.read(webglBuffer);
+  const comparison = compareForegroundCoverage(webgpu, webgl, tolerances);
+  results.push({ name, ...comparison });
+
+  const marker = comparison.pass ? "✓" : "✗";
+  console.log(
+    `${marker} ${name}: ${(comparison.mismatchFraction * 100).toFixed(3)}% unmatched foreground, ` +
+      `${comparison.boundsDelta}px bounds delta`,
+  );
+
+  if (!comparison.pass) {
+    const mask = foregroundMismatchMask(webgpu, webgl, tolerances);
+    await writeFile(
+      path.join(outputDir, name.replace(/\.png$/u, "-coverage-diff.png")),
+      mismatchPng(webgpu.width, webgpu.height, mask),
+    );
+  }
+}
+
+const failed = results.filter((result) => !result.pass);
+const report = {
+  schemaVersion: 1,
+  comparison: "foreground-coverage",
+  rationale:
+    "Compare renderer geometry/coverage while deliberately ignoring backend color-transfer differences tracked separately.",
+  tolerances,
+  compared: results.length,
+  failed: failed.length,
+  results,
+};
+await writeFile(
+  path.join(outputDir, "browser-backend-visual-parity.json"),
+  `${JSON.stringify(report, null, 2)}\n`,
+);
+
+assert.deepEqual(
+  failed.map((result) => result.name),
+  [],
+  `WebGPU/WebGL foreground coverage diverged for ${failed.length}/${results.length} checkpoints; see ${outputDir}`,
+);
+
+console.log(
+  `Browser backend visual parity passed for ${results.length} deterministic screenshots ` +
+    `(<= ${(tolerances.maxMismatchFraction * 100).toFixed(2)}% unmatched foreground, ` +
+    `<= ${tolerances.maxBoundsDelta}px bounds delta).`,
+);

--- a/scripts/browser-visual-parity-lib.mjs
+++ b/scripts/browser-visual-parity-lib.mjs
@@ -1,0 +1,208 @@
+function assertImage(image, name) {
+  if (!image || !Number.isInteger(image.width) || !Number.isInteger(image.height)) {
+    throw new TypeError(`${name} must provide integer width and height`);
+  }
+  if (image.width <= 0 || image.height <= 0) {
+    throw new RangeError(`${name} dimensions must be positive`);
+  }
+  if (!image.data || image.data.length !== image.width * image.height * 4) {
+    throw new RangeError(`${name} must provide exactly width * height * 4 RGBA bytes`);
+  }
+}
+
+function colorDistance(data, offset, background) {
+  return (
+    Math.abs(data[offset] - background[0]) +
+    Math.abs(data[offset + 1] - background[1]) +
+    Math.abs(data[offset + 2] - background[2]) +
+    Math.abs(data[offset + 3] - background[3])
+  );
+}
+
+export function foregroundMask(image, backgroundDistance = 32) {
+  assertImage(image, "image");
+  if (!Number.isFinite(backgroundDistance) || backgroundDistance < 0) {
+    throw new RangeError("backgroundDistance must be a non-negative finite number");
+  }
+
+  const background = [image.data[0], image.data[1], image.data[2], image.data[3]];
+  const mask = new Uint8Array(image.width * image.height);
+  let count = 0;
+  for (let pixel = 0; pixel < mask.length; pixel += 1) {
+    if (colorDistance(image.data, pixel * 4, background) >= backgroundDistance) {
+      mask[pixel] = 1;
+      count += 1;
+    }
+  }
+  return { mask, count };
+}
+
+export function foregroundBounds(mask, width, height) {
+  if (!(mask instanceof Uint8Array) || mask.length !== width * height) {
+    throw new RangeError("foreground mask dimensions do not match image dimensions");
+  }
+
+  let minX = width;
+  let minY = height;
+  let maxX = -1;
+  let maxY = -1;
+  for (let pixel = 0; pixel < mask.length; pixel += 1) {
+    if (mask[pixel] === 0) {
+      continue;
+    }
+    const x = pixel % width;
+    const y = Math.floor(pixel / width);
+    minX = Math.min(minX, x);
+    minY = Math.min(minY, y);
+    maxX = Math.max(maxX, x);
+    maxY = Math.max(maxY, y);
+  }
+  return maxX < 0 ? null : { minX, minY, maxX, maxY };
+}
+
+function hasForegroundNear(mask, width, height, x, y, radius) {
+  const minX = Math.max(0, x - radius);
+  const maxX = Math.min(width - 1, x + radius);
+  const minY = Math.max(0, y - radius);
+  const maxY = Math.min(height - 1, y + radius);
+  for (let candidateY = minY; candidateY <= maxY; candidateY += 1) {
+    const row = candidateY * width;
+    for (let candidateX = minX; candidateX <= maxX; candidateX += 1) {
+      if (mask[row + candidateX] !== 0) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function unmatchedForegroundMask(source, target, width, height, radius) {
+  const unmatched = new Uint8Array(source.length);
+  let count = 0;
+  for (let pixel = 0; pixel < source.length; pixel += 1) {
+    if (source[pixel] === 0) {
+      continue;
+    }
+    const x = pixel % width;
+    const y = Math.floor(pixel / width);
+    if (!hasForegroundNear(target, width, height, x, y, radius)) {
+      unmatched[pixel] = 1;
+      count += 1;
+    }
+  }
+  return { mask: unmatched, count };
+}
+
+function maxBoundsDelta(left, right) {
+  if (left === null || right === null) {
+    return left === right ? 0 : Number.POSITIVE_INFINITY;
+  }
+  return Math.max(
+    Math.abs(left.minX - right.minX),
+    Math.abs(left.minY - right.minY),
+    Math.abs(left.maxX - right.maxX),
+    Math.abs(left.maxY - right.maxY),
+  );
+}
+
+function normalizedOptions(options = {}) {
+  const backgroundDistance = options.backgroundDistance ?? 32;
+  const neighborRadius = options.neighborRadius ?? 1;
+  const maxMismatchFraction = options.maxMismatchFraction ?? 0.02;
+  const maxBoundsDelta = options.maxBoundsDelta ?? 2;
+
+  if (!Number.isInteger(neighborRadius) || neighborRadius < 0) {
+    throw new RangeError("neighborRadius must be a non-negative integer");
+  }
+  if (!Number.isFinite(maxMismatchFraction) || maxMismatchFraction < 0 || maxMismatchFraction > 1) {
+    throw new RangeError("maxMismatchFraction must be within [0, 1]");
+  }
+  if (!Number.isFinite(maxBoundsDelta) || maxBoundsDelta < 0) {
+    throw new RangeError("maxBoundsDelta must be a non-negative finite number");
+  }
+  return { backgroundDistance, neighborRadius, maxMismatchFraction, maxBoundsDelta };
+}
+
+export function compareForegroundCoverage(left, right, options = {}) {
+  assertImage(left, "left image");
+  assertImage(right, "right image");
+  if (left.width !== right.width || left.height !== right.height) {
+    throw new RangeError(
+      `visual parity dimensions differ: ${left.width}x${left.height} vs ${right.width}x${right.height}`,
+    );
+  }
+
+  const normalized = normalizedOptions(options);
+  const leftForeground = foregroundMask(left, normalized.backgroundDistance);
+  const rightForeground = foregroundMask(right, normalized.backgroundDistance);
+  const leftUnmatched = unmatchedForegroundMask(
+    leftForeground.mask,
+    rightForeground.mask,
+    left.width,
+    left.height,
+    normalized.neighborRadius,
+  );
+  const rightUnmatched = unmatchedForegroundMask(
+    rightForeground.mask,
+    leftForeground.mask,
+    left.width,
+    left.height,
+    normalized.neighborRadius,
+  );
+  const foregroundMass = leftForeground.count + rightForeground.count;
+  const unmatchedPixels = leftUnmatched.count + rightUnmatched.count;
+  const mismatchFraction = foregroundMass === 0 ? 0 : unmatchedPixels / foregroundMass;
+  const leftBounds = foregroundBounds(leftForeground.mask, left.width, left.height);
+  const rightBounds = foregroundBounds(rightForeground.mask, right.width, right.height);
+  const boundsDelta = maxBoundsDelta(leftBounds, rightBounds);
+  const hasVisibleContent = leftForeground.count > 0 && rightForeground.count > 0;
+
+  return {
+    width: left.width,
+    height: left.height,
+    leftForegroundPixels: leftForeground.count,
+    rightForegroundPixels: rightForeground.count,
+    unmatchedPixels,
+    mismatchFraction,
+    leftBounds,
+    rightBounds,
+    boundsDelta,
+    hasVisibleContent,
+    pass:
+      hasVisibleContent &&
+      mismatchFraction <= normalized.maxMismatchFraction &&
+      boundsDelta <= normalized.maxBoundsDelta,
+    tolerances: normalized,
+  };
+}
+
+export function foregroundMismatchMask(left, right, options = {}) {
+  assertImage(left, "left image");
+  assertImage(right, "right image");
+  if (left.width !== right.width || left.height !== right.height) {
+    throw new RangeError("cannot build a mismatch mask for images with different dimensions");
+  }
+
+  const normalized = normalizedOptions(options);
+  const leftForeground = foregroundMask(left, normalized.backgroundDistance);
+  const rightForeground = foregroundMask(right, normalized.backgroundDistance);
+  const leftUnmatched = unmatchedForegroundMask(
+    leftForeground.mask,
+    rightForeground.mask,
+    left.width,
+    left.height,
+    normalized.neighborRadius,
+  );
+  const rightUnmatched = unmatchedForegroundMask(
+    rightForeground.mask,
+    leftForeground.mask,
+    left.width,
+    left.height,
+    normalized.neighborRadius,
+  );
+  const mask = new Uint8Array(left.width * left.height);
+  for (let pixel = 0; pixel < mask.length; pixel += 1) {
+    mask[pixel] = leftUnmatched.mask[pixel] || rightUnmatched.mask[pixel] ? 1 : 0;
+  }
+  return mask;
+}

--- a/scripts/browser-visual-parity-lib.test.mjs
+++ b/scripts/browser-visual-parity-lib.test.mjs
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { compareForegroundCoverage } from "./browser-visual-parity-lib.mjs";
+
+function image(width, height, foreground, colors = {}) {
+  const background = colors.background ?? [20, 20, 20, 255];
+  const ink = colors.ink ?? [220, 80, 60, 255];
+  const data = new Uint8Array(width * height * 4);
+  for (let pixel = 0; pixel < width * height; pixel += 1) {
+    data.set(background, pixel * 4);
+  }
+  for (const [x, y] of foreground) {
+    data.set(ink, (y * width + x) * 4);
+  }
+  return { width, height, data };
+}
+
+function rectangle(minX, minY, maxX, maxY) {
+  const pixels = [];
+  for (let y = minY; y <= maxY; y += 1) {
+    for (let x = minX; x <= maxX; x += 1) {
+      pixels.push([x, y]);
+    }
+  }
+  return pixels;
+}
+
+test("identical foreground coverage passes exactly", () => {
+  const pixels = rectangle(2, 2, 5, 5);
+  const result = compareForegroundCoverage(image(8, 8, pixels), image(8, 8, pixels));
+
+  assert.equal(result.pass, true);
+  assert.equal(result.unmatchedPixels, 0);
+  assert.equal(result.mismatchFraction, 0);
+  assert.equal(result.boundsDelta, 0);
+});
+
+test("one-pixel raster edge movement is absorbed by the neighborhood tolerance", () => {
+  const left = image(12, 8, rectangle(2, 2, 5, 5));
+  const right = image(12, 8, rectangle(3, 2, 6, 5));
+  const result = compareForegroundCoverage(left, right, {
+    neighborRadius: 1,
+    maxMismatchFraction: 0,
+    maxBoundsDelta: 1,
+  });
+
+  assert.equal(result.pass, true);
+  assert.equal(result.unmatchedPixels, 0);
+  assert.equal(result.boundsDelta, 1);
+});
+
+test("color-transfer differences do not masquerade as geometry differences", () => {
+  const pixels = rectangle(2, 2, 6, 6);
+  const left = image(10, 10, pixels, {
+    background: [18, 18, 18, 255],
+    ink: [235, 80, 65, 255],
+  });
+  const right = image(10, 10, pixels, {
+    background: [24, 24, 24, 255],
+    ink: [190, 104, 92, 255],
+  });
+  const result = compareForegroundCoverage(left, right);
+
+  assert.equal(result.pass, true);
+  assert.equal(result.mismatchFraction, 0);
+});
+
+test("missing visible geometry fails the parity gate", () => {
+  const shared = rectangle(1, 1, 4, 4);
+  const missingBar = rectangle(7, 1, 8, 6);
+  const left = image(10, 8, [...shared, ...missingBar]);
+  const right = image(10, 8, shared);
+  const result = compareForegroundCoverage(left, right, {
+    neighborRadius: 1,
+    maxMismatchFraction: 0.02,
+    maxBoundsDelta: 2,
+  });
+
+  assert.equal(result.pass, false);
+  assert.ok(result.mismatchFraction > 0.02);
+  assert.ok(result.boundsDelta > 2);
+});
+
+test("dimension mismatch is rejected before comparison", () => {
+  assert.throws(
+    () => compareForegroundCoverage(image(4, 4, [[1, 1]]), image(5, 4, [[1, 1]])),
+    /dimensions differ/,
+  );
+});

--- a/scripts/build-web-demo.sh
+++ b/scripts/build-web-demo.sh
@@ -25,6 +25,8 @@ node --check scripts/retained-execution-worker-smoke.mjs
 node --check scripts/authoring-execution-router-smoke.mjs
 node --check scripts/authoring-execution-lifecycle-smoke.mjs
 node --check scripts/browser-smoke.mjs
+node --check scripts/browser-backend-visual-parity.mjs
+node --check scripts/browser-visual-parity-lib.mjs
 node --check scripts/manim-raster-differential.mjs
 node --check scripts/manim-seek-playback-raster.mjs
 node --check scripts/manim-typst-authoring-smoke.mjs
@@ -45,6 +47,7 @@ node --check scripts/reactive-authoring-smoke.mjs
 node --check scripts/reactive-runtime-smoke.mjs
 node --check scripts/native-input-smoke.mjs
 node --check scripts/updater-callback-smoke.mjs
+node --test scripts/browser-visual-parity-lib.test.mjs
 node --test scripts/manim-reference-inventory.test.mjs
 
 for test_file in web/*.test.mjs; do


### PR DESCRIPTION
## Summary
- add a reusable foreground-coverage comparator for deterministic renderer screenshots
- compare every root browser-smoke screenshot produced by the existing WebGPU and WebGL CI matrix after both backend jobs complete
- tolerate one-pixel raster-edge variation while failing structural coverage differences above 2% or visible-bounds differences above 2 px
- deliberately compare geometry/coverage rather than RGB values so the known #149 backend color-transfer issue cannot create noise or be hidden by a loose color tolerance
- emit a machine-readable JSON report and per-checkpoint coverage-diff PNGs on failure
- register focused comparator tests and syntax checks in the normal web-package build

## Why
#109 notes that most browser-smoke screenshots are currently uploaded as artifacts but never compared. Both required renderer backends already render the same deterministic scene/checkpoint corpus, so a post-matrix comparison is a low-coupling first visual-regression gate that reuses existing work instead of adding another renderer harness.

This catches backend-only missing geometry, transform/coverage drift, gross stroke/path differences, and visible-bounds divergence without touching renderer implementation or active retained-text/culling work.

## Validation
- branch is one commit directly on master `58e834884d333ede175bba07e0989628aa82dcf9`
- focused unit cases cover exact equality, one-pixel edge movement, backend color-transfer differences, missing geometry, and dimension mismatch
- `scripts/build-web-demo.sh` now runs the focused test and syntax-checks the new tooling
- exact-head GitHub CI will exercise the new post-matrix artifact comparison against real WebGPU/WebGL screenshots

## Remaining scope / risk
This is the backend-parity tranche of #109, not a replacement for reviewed expected-image goldens. A later independent tranche should add committed/generated canonical baselines for renderer-visible behavior. The initial 2%/2 px structural tolerances are explicit and should only be tightened from observed deterministic CI data, not loosened to mask regressions.

Tracks #109. Related #149.