### PR TITLE
Expose shared sector geometry through Python adapters

### DIFF
--- a/web/python-worker-source.test.mjs
+++ b/web/python-worker-source.test.mjs
@@ -10,3 +10,12 @@ test("Python authoring worker keeps request validation helper", () => {
   assert.match(source, /function\s+isRecord\s*\(value\)\s*\{/);
   assert.match(source, /if\s*\(!isRecord\(request\)\s*\|\|\s*request\.channel\s*!==\s*AUTHORING_CHANNEL\)/);
 });
+
+test("Python authoring worker keeps shared sector constructors", () => {
+  assert.match(source, /manimAnnularSectorSnapshotJson/);
+  assert.match(source, /manimSectorSnapshotJson/);
+  assert.match(source, /manimAnnulusSnapshotJson/);
+  assert.match(source, /noonCreateAuthoringAnnularSectorHandle/);
+  assert.match(source, /noonCreateAuthoringSectorHandle/);
+  assert.match(source, /noonCreateAuthoringAnnulusHandle/);
+});

--- a/web/python-worker.source.js
+++ b/web/python-worker.source.js
@@ -2,7 +2,10 @@ import initNoonWeb, {
   RetainedNativeTextAuthoringHandle,
   RetainedTypstAuthoringHandle,
   WasmAuthoringStore,
+  manimAnnularSectorSnapshotJson,
+  manimAnnulusSnapshotJson,
   manimDotSnapshotJson,
+  manimSectorSnapshotJson,
   manimTriangleSnapshotJson,
   resolveAnimationOptions,
   resolveCompositionSchedule,
@@ -48,6 +51,12 @@ async function initializePyodide() {
     authoringStore.createMobject(manimDotSnapshotJson(pointX, pointY, radius));
   self.noonCreateAuthoringTriangleHandle = () =>
     authoringStore.createMobject(manimTriangleSnapshotJson());
+  self.noonCreateAuthoringAnnularSectorHandle = (...args) =>
+    authoringStore.createMobject(manimAnnularSectorSnapshotJson(...args));
+  self.noonCreateAuthoringSectorHandle = (...args) =>
+    authoringStore.createMobject(manimSectorSnapshotJson(...args));
+  self.noonCreateAuthoringAnnulusHandle = (...args) =>
+    authoringStore.createMobject(manimAnnulusSnapshotJson(...args));
   self.noonCreateAuthoringCircleHandle = (radius) => authoringStore.createManimCircle(radius);
   self.noonCreateAuthoringSquareHandle = (sideLength) => authoringStore.createManimSquare(sideLength);
   self.noonCreateAuthoringRectangleHandle = (width, height) =>

--- a/web/python/_manim_shared_geometry.py
+++ b/web/python/_manim_shared_geometry.py
@@ -1,11 +1,13 @@
 """Thin Manim geometry adapters backed by shared Rust semantics.
 
 This module patches only operations whose full observable geometry/layout contract is
-already owned by Rust. Class identity and inheritance remain unchanged.
+already owned by Rust. Class identity and inheritance remain unchanged where an
+established compatibility class already exists.
 """
 
 from __future__ import annotations
 
+import operator
 from typing import Any
 
 import noon as _base
@@ -22,6 +24,21 @@ try:
     from js import noonCreateAuthoringTriangleHandle as _create_triangle_handle
 except ImportError:  # Native CPython tests keep the existing Python constructor.
     _create_triangle_handle = None
+
+try:
+    from js import noonCreateAuthoringAnnularSectorHandle as _create_annular_sector_handle
+except ImportError:
+    _create_annular_sector_handle = None
+
+try:
+    from js import noonCreateAuthoringSectorHandle as _create_sector_handle
+except ImportError:
+    _create_sector_handle = None
+
+try:
+    from js import noonCreateAuthoringAnnulusHandle as _create_annulus_handle
+except ImportError:
+    _create_annulus_handle = None
 
 _ORIGINAL_DOT_INIT = _geometry.Dot.__init__
 _ORIGINAL_TRIANGLE_INIT = _geometry.Triangle.__init__
@@ -193,6 +210,180 @@ def _triangle_init(self: _geometry.Triangle, **kwargs: Any) -> None:
         _set_shared_color(self, color)
 
 
+def _sector_component_count(value: object) -> int:
+    if isinstance(value, bool):
+        raise TypeError("num_components must be an integer")
+    try:
+        result = operator.index(value)
+    except TypeError as error:
+        raise TypeError("num_components must be an integer") from error
+    if result < 2:
+        raise ValueError("num_components must be at least 2")
+    if result > 0xFFFFFFFF:
+        raise ValueError("num_components is too large")
+    return int(result)
+
+
+def _sector_options(
+    kwargs: dict[str, Any],
+) -> tuple[dict[str, Any], int, _base.Vec2]:
+    options = dict(kwargs)
+    component_count = _sector_component_count(options.pop("num_components", 9))
+    center = _compat._as_vec2(options.pop("arc_center", _base.ORIGIN))
+    return options, component_count, center
+
+
+def _finish_sector_style(
+    self: _base.Mobject,
+    kwargs: dict[str, Any],
+    *,
+    fill_opacity: float,
+    stroke_width: float,
+    color: object,
+) -> None:
+    options = dict(kwargs)
+    options["fill_opacity"] = fill_opacity
+    options["stroke_width"] = stroke_width
+    _shared._apply_shared_constructor_kwargs(self, options)
+    if color is not None:
+        _set_shared_color(self, color)
+
+
+class AnnularSector(_compat.VMobject):
+    """Manim-compatible annular sector backed by the shared Rust constructor."""
+
+    def __init__(
+        self,
+        inner_radius: float = 1.0,
+        outer_radius: float = 2.0,
+        angle: float = _base.TAU / 4.0,
+        start_angle: float = 0.0,
+        fill_opacity: float = 1.0,
+        stroke_width: float = 0.0,
+        color: _base.Color = _base.WHITE,
+        **kwargs: Any,
+    ) -> None:
+        if _create_annular_sector_handle is None:
+            raise RuntimeError("AnnularSector requires the shared browser geometry bridge")
+
+        options, component_count, center = _sector_options(kwargs)
+        inner = _shared._ir._finite_number("inner_radius", inner_radius)
+        outer = _shared._ir._finite_number("outer_radius", outer_radius)
+        angle_value = _shared._ir._finite_number("angle", angle)
+        start_value = _shared._ir._finite_number("start_angle", start_angle)
+        _shared._attach_shared_handle(
+            self,
+            _create_annular_sector_handle(
+                inner,
+                outer,
+                angle_value,
+                start_value,
+                component_count,
+                center.x,
+                center.y,
+            ),
+        )
+        self.inner_radius = inner
+        self.outer_radius = outer
+        self.angle = angle_value
+        self.start_angle = start_value
+        self.num_components = component_count
+        self.arc_center = center
+        _finish_sector_style(
+            self,
+            options,
+            fill_opacity=fill_opacity,
+            stroke_width=stroke_width,
+            color=color,
+        )
+
+
+class Sector(AnnularSector):
+    """Manim-compatible circle sector backed by the shared Rust constructor."""
+
+    def __init__(self, radius: float = 1.0, **kwargs: Any) -> None:
+        if _create_sector_handle is None:
+            raise RuntimeError("Sector requires the shared browser geometry bridge")
+
+        options = dict(kwargs)
+        fill_opacity = options.pop("fill_opacity", 1.0)
+        stroke_width = options.pop("stroke_width", 0.0)
+        color = options.pop("color", _base.WHITE)
+        start_angle = options.pop("start_angle", 0.0)
+        angle = options.pop("angle", _base.TAU / 4.0)
+        options, component_count, center = _sector_options(options)
+        radius_value = _shared._ir._finite_number("radius", radius)
+        angle_value = _shared._ir._finite_number("angle", angle)
+        start_value = _shared._ir._finite_number("start_angle", start_angle)
+        _shared._attach_shared_handle(
+            self,
+            _create_sector_handle(
+                radius_value,
+                angle_value,
+                start_value,
+                component_count,
+                center.x,
+                center.y,
+            ),
+        )
+        self.inner_radius = 0.0
+        self.outer_radius = radius_value
+        self.angle = angle_value
+        self.start_angle = start_value
+        self.num_components = component_count
+        self.arc_center = center
+        _finish_sector_style(
+            self,
+            options,
+            fill_opacity=fill_opacity,
+            stroke_width=stroke_width,
+            color=color,
+        )
+
+
+class Annulus(_compat.VMobject):
+    """Manim-compatible annulus backed by the shared Rust constructor."""
+
+    def __init__(
+        self,
+        inner_radius: float = 1.0,
+        outer_radius: float = 2.0,
+        fill_opacity: float = 1.0,
+        stroke_width: float = 0.0,
+        color: _base.Color = _base.WHITE,
+        mark_paths_closed: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        if _create_annulus_handle is None:
+            raise RuntimeError("Annulus requires the shared browser geometry bridge")
+
+        options, component_count, center = _sector_options(kwargs)
+        inner = _shared._ir._finite_number("inner_radius", inner_radius)
+        outer = _shared._ir._finite_number("outer_radius", outer_radius)
+        _shared._attach_shared_handle(
+            self,
+            _create_annulus_handle(
+                inner,
+                outer,
+                component_count,
+                center.x,
+                center.y,
+            ),
+        )
+        self.inner_radius = inner
+        self.outer_radius = outer
+        self.mark_paths_closed = bool(mark_paths_closed)
+        self.num_components = component_count
+        self.arc_center = center
+        _finish_sector_style(
+            self,
+            options,
+            fill_opacity=fill_opacity,
+            stroke_width=stroke_width,
+            color=color,
+        )
+
+
 def install() -> None:
     global _INSTALLED
     if _INSTALLED:
@@ -209,6 +400,17 @@ def install() -> None:
         _geometry.Dot.__init__ = _dot_init
     if _create_triangle_handle is not None:
         _geometry.Triangle.__init__ = _triangle_init
+
+    public = {
+        "AnnularSector": AnnularSector,
+        "Sector": Sector,
+        "Annulus": Annulus,
+    }
+    for name, value in public.items():
+        setattr(_base, name, value)
+        setattr(_compat, name, value)
+        if name not in _base.__all__:
+            _base.__all__.append(name)
 
 
 install()

--- a/web/python/test_manim_shared_sectors.py
+++ b/web/python/test_manim_shared_sectors.py
@@ -1,0 +1,196 @@
+import os
+import subprocess
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+
+
+class ManimSharedSectorTests(unittest.TestCase):
+    def test_sector_family_uses_shared_rust_constructors(self) -> None:
+        python_dir = Path(__file__).resolve().parent
+        env = os.environ.copy()
+        existing = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = (
+            str(python_dir)
+            if not existing
+            else os.pathsep.join((str(python_dir), existing))
+        )
+        source = textwrap.dedent(
+            r"""
+            import json
+            import math
+            import sys
+            import types
+
+            fake_js = types.ModuleType("js")
+            calls = []
+
+            WHITE = (1.0, 1.0, 1.0)
+
+            def style():
+                return {
+                    "fill": {"red": 1.0, "green": 1.0, "blue": 1.0, "alpha": 1.0},
+                    "stroke": {"red": 1.0, "green": 1.0, "blue": 1.0, "alpha": 1.0},
+                    "stroke_width": 0.0,
+                    "stroke_width_mode": "screen_space",
+                    "stroke_join": "miter",
+                    "stroke_cap": "butt",
+                    "opacity": 1.0,
+                }
+
+            def snapshot(tag):
+                return {
+                    "geometry": {"vector_path": {"commands": [
+                        {"move_to": {"to": {"x": 1.0, "y": 0.0}}},
+                        {"line_to": {"to": {"x": 0.0, "y": 1.0}}},
+                        "close",
+                    ]}},
+                    "transform": {
+                        "translation": {"x": 0.0, "y": 0.0},
+                        "rotation": 0.0,
+                        "scale": {"x": 1.0, "y": 1.0},
+                    },
+                    "style": style(),
+                    "debug_tag": tag,
+                }
+
+            class FakeHandle:
+                def __init__(self, value):
+                    self.snapshot = value
+                def snapshotJson(self):
+                    value = dict(self.snapshot)
+                    value.pop("debug_tag", None)
+                    return json.dumps(value)
+                def setStrokeWidth(self, value):
+                    self.snapshot["style"]["stroke_width"] = float(value)
+                def setFillOpacity(self, value):
+                    self.snapshot["style"]["fill"]["alpha"] = float(value)
+                def setStrokeOpacity(self, value):
+                    self.snapshot["style"]["stroke"]["alpha"] = float(value)
+                def setFillColor(self, r, g, b, a):
+                    alpha = self.snapshot["style"]["fill"]["alpha"]
+                    self.snapshot["style"]["fill"] = {
+                        "red": float(r), "green": float(g), "blue": float(b), "alpha": alpha,
+                    }
+                def setStrokeColor(self, r, g, b, a):
+                    alpha = self.snapshot["style"]["stroke"]["alpha"]
+                    self.snapshot["style"]["stroke"] = {
+                        "red": float(r), "green": float(g), "blue": float(b), "alpha": alpha,
+                    }
+
+            def generic_snapshot(value):
+                return FakeHandle(json.loads(value))
+
+            def annular_sector(inner, outer, angle, start, components, cx, cy):
+                calls.append((
+                    "annular_sector", float(inner), float(outer), float(angle), float(start),
+                    int(components), float(cx), float(cy),
+                ))
+                return FakeHandle(snapshot("annular_sector"))
+
+            def sector(radius, angle, start, components, cx, cy):
+                calls.append((
+                    "sector", float(radius), float(angle), float(start), int(components),
+                    float(cx), float(cy),
+                ))
+                return FakeHandle(snapshot("sector"))
+
+            def annulus(inner, outer, components, cx, cy):
+                calls.append((
+                    "annulus", float(inner), float(outer), int(components), float(cx), float(cy),
+                ))
+                return FakeHandle(snapshot("annulus"))
+
+            fake_js.noonCreateAuthoringMobjectHandle = generic_snapshot
+            fake_js.noonCreateAuthoringAnnularSectorHandle = annular_sector
+            fake_js.noonCreateAuthoringSectorHandle = sector
+            fake_js.noonCreateAuthoringAnnulusHandle = annulus
+            sys.modules["js"] = fake_js
+
+            import _manim_compat
+            _manim_compat.install()
+            import _manim_phase_b
+            import _manim_geometry
+            import _manim_semantic_handles as handles
+            handles.install()
+
+            _manim_compat._ir.Path = lambda *args, **kwargs: (_ for _ in ()).throw(
+                AssertionError("Python Path geometry constructor was called")
+            )
+
+            import _manim_shared_geometry
+            _manim_shared_geometry.install()
+            from noon import AnnularSector, Annulus, BLUE, Sector
+
+            annular = AnnularSector(
+                inner_radius=0.5,
+                outer_radius=1.75,
+                angle=1.2,
+                start_angle=0.3,
+                fill_opacity=0.4,
+                stroke_width=2.0,
+                color=BLUE,
+                num_components=7,
+                arc_center=(2.0, -1.0, 0.0),
+            )
+            circle_sector = Sector(
+                radius=2.5,
+                angle=0.8,
+                start_angle=0.1,
+                num_components=6,
+                arc_center=(-1.0, 2.0, 0.0),
+            )
+            ring = Annulus(
+                inner_radius=0.75,
+                outer_radius=1.5,
+                num_components=10,
+                arc_center=(3.0, 4.0, 0.0),
+                mark_paths_closed=True,
+            )
+
+            assert calls == [
+                ("annular_sector", 0.5, 1.75, 1.2, 0.3, 7, 2.0, -1.0),
+                ("sector", 2.5, 0.8, 0.1, 6, -1.0, 2.0),
+                ("annulus", 0.75, 1.5, 10, 3.0, 4.0),
+            ]
+            assert annular.inner_radius == 0.5
+            assert annular.outer_radius == 1.75
+            assert annular.num_components == 7
+            assert annular.arc_center.x == 2.0 and annular.arc_center.y == -1.0
+            assert math.isclose(annular.style["fill"]["alpha"], 0.4)
+            assert annular.style["stroke_width"] == 2.0
+            assert math.isclose(annular.style["fill"]["red"], BLUE.red)
+            assert math.isclose(annular.style["stroke"]["blue"], BLUE.blue)
+            assert circle_sector.inner_radius == 0.0
+            assert circle_sector.outer_radius == 2.5
+            assert ring.mark_paths_closed is True
+            assert "vector_path" in annular.geometry
+            assert "vector_path" in circle_sector.geometry
+            assert "vector_path" in ring.geometry
+
+            try:
+                AnnularSector(num_components=1)
+            except ValueError as error:
+                assert "at least 2" in str(error)
+            else:
+                raise AssertionError("invalid num_components was accepted")
+            """
+        )
+        completed = subprocess.run(
+            [sys.executable, "-c", source],
+            cwd=python_dir,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(
+            completed.returncode,
+            0,
+            f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/python/test_manim_shared_sectors.py
+++ b/web/python/test_manim_shared_sectors.py
@@ -160,8 +160,9 @@ class ManimSharedSectorTests(unittest.TestCase):
             assert annular.arc_center.x == 2.0 and annular.arc_center.y == -1.0
             assert math.isclose(annular.style["fill"]["alpha"], 0.4)
             assert annular.style["stroke_width"] == 2.0
-            assert math.isclose(annular.style["fill"]["red"], BLUE.red)
-            assert math.isclose(annular.style["stroke"]["blue"], BLUE.blue)
+            parsed_blue = _manim_phase_b._as_color("color", BLUE)
+            assert math.isclose(annular.style["fill"]["red"], parsed_blue.red)
+            assert math.isclose(annular.style["stroke"]["blue"], parsed_blue.blue)
             assert circle_sector.inner_radius == 0.0
             assert circle_sector.outer_radius == 2.5
             assert ring.mark_paths_closed is True

--- a/web/python/test_manim_shared_sectors.py
+++ b/web/python/test_manim_shared_sectors.py
@@ -159,7 +159,7 @@ class ManimSharedSectorTests(unittest.TestCase):
             assert annular.num_components == 7
             assert annular.arc_center.x == 2.0 and annular.arc_center.y == -1.0
             assert math.isclose(annular.style["fill"]["alpha"], 0.4)
-            assert annular.style["stroke_width"] == 2.0
+            assert math.isclose(annular.style["stroke_width"], 0.02)
             parsed_blue = _manim_phase_b._as_color("color", BLUE)
             assert math.isclose(annular.style["fill"]["red"], parsed_blue.red)
             assert math.isclose(annular.style["stroke"]["blue"], parsed_blue.blue)


### PR DESCRIPTION
## Summary
- expose ManimCE v0.21 `AnnularSector`, `Sector`, and `Annulus` through thin Python compatibility classes backed by the existing shared Rust sector constructors
- wire the already-landed WASM snapshot bridge into the Python authoring worker and immediately install each snapshot into the ordinary semantic mobject store
- preserve Manim constructor defaults and observable metadata while keeping `num_components` / `arc_center` in the existing Arc-compatible kwargs path
- apply style options through the shared semantic-handle mutation helpers; Python never reconstructs sector paths
- add focused Python coverage that makes Python path construction fail if these adapters regress away from Rust, plus worker-source wiring guards

## Architecture
The shared Rust `AnnularSector` / `Sector` / `Annulus` implementations and `manim_sector_bridge` remain the sole geometry owners. The browser worker only turns their serialized `ObjectSnapshot` into the existing `WasmAuthoringStore` handle, matching the current Dot/Triangle migration pattern. No renderer primitive, frontend geometry math, execution protocol, or duplicate sector representation is introduced.

This is intentionally independent of the active text, culling, resource-mutation, renderer-recovery, and raster-parity lanes.

## Validation
Fresh exact-head CI is requested by this PR. Focused regressions cover constructor argument forwarding, semantic-handle styling, public exports, invalid component counts, and absence of Python path construction. The web-package source test covers all three worker bridge functions.

## Remaining boundary
This exposes the shared-authoring surface but does not by itself promote the sector family to full Manim raster-parity qualification; that remains subject to the canonical differential/raster gates tracked by #76/#400/#185.

Tracks #76 and #400.