### PR TITLE
Lock pinned Manim reference example inventory

### DIFF
--- a/.github/workflows/manim-reference-inventory.yml
+++ b/.github/workflows/manim-reference-inventory.yml
@@ -4,15 +4,21 @@ on:
   pull_request:
     paths:
       - '.github/workflows/manim-reference-inventory.yml'
+      - 'compat/manim-v0.21.0-reference-inventory-lock.json'
       - 'scripts/manim-reference-inventory.mjs'
       - 'scripts/manim-reference-inventory.test.mjs'
+      - 'scripts/manim-reference-ledger.mjs'
+      - 'scripts/manim-reference-ledger.test.mjs'
   push:
     branches:
       - master
     paths:
       - '.github/workflows/manim-reference-inventory.yml'
+      - 'compat/manim-v0.21.0-reference-inventory-lock.json'
       - 'scripts/manim-reference-inventory.mjs'
       - 'scripts/manim-reference-inventory.test.mjs'
+      - 'scripts/manim-reference-ledger.mjs'
+      - 'scripts/manim-reference-ledger.test.mjs'
   workflow_dispatch:
 
 permissions:
@@ -100,11 +106,25 @@ jobs:
           console.log(`Validated ${inventory.examples.length} pinned Manim reference examples.`);
           NODE
 
+      - name: Verify checked-in reference inventory lock
+        shell: bash
+        run: |
+          set -euo pipefail
+          node noon/scripts/manim-reference-ledger.mjs \
+            noon/artifacts/manim-v0.21.0-reference-inventory.json \
+            noon/compat/manim-v0.21.0-reference-inventory-lock.json \
+            > noon/artifacts/manim-v0.21.0-reference-ledger-summary.json
+          cat noon/artifacts/manim-v0.21.0-reference-ledger-summary.json
+          printf '\nReference inventory lock verified against the immutable extracted corpus.\n' \
+            >> "$GITHUB_STEP_SUMMARY"
+
       - name: Upload reference inventory
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: manim-v0.21.0-reference-inventory
-          path: noon/artifacts/manim-v0.21.0-reference-inventory.json
+          path: |
+            noon/artifacts/manim-v0.21.0-reference-inventory.json
+            noon/artifacts/manim-v0.21.0-reference-ledger-summary.json
           if-no-files-found: error
           retention-days: 14

--- a/compat/manim-v0.21.0-reference-inventory-lock.json
+++ b/compat/manim-v0.21.0-reference-inventory-lock.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 1,
+  "upstream": {
+    "repository": "ManimCommunity/manim",
+    "version": "v0.21.0",
+    "revision": "861cd4849b17db1db3515b531ffe80b297848f93"
+  },
+  "example_count": 472,
+  "provenance_sha256": "be552e1ac2b2671572224596ec04e6ac0025b48859e65a2c23146f3ae7acb1d8"
+}

--- a/scripts/build-web-demo.sh
+++ b/scripts/build-web-demo.sh
@@ -29,6 +29,7 @@ node --check scripts/manim-raster-differential.mjs
 node --check scripts/manim-seek-playback-raster.mjs
 node --check scripts/manim-typst-authoring-smoke.mjs
 node --check scripts/manim-reference-inventory.mjs
+node --check scripts/manim-reference-ledger.mjs
 node --check scripts/perf-profile.mjs
 node --check scripts/authoring-perf.mjs
 node --check scripts/perf-device-run.mjs
@@ -46,6 +47,7 @@ node --check scripts/reactive-runtime-smoke.mjs
 node --check scripts/native-input-smoke.mjs
 node --check scripts/updater-callback-smoke.mjs
 node --test scripts/manim-reference-inventory.test.mjs
+node --test scripts/manim-reference-ledger.test.mjs
 
 for test_file in web/*.test.mjs; do
   node --test "$test_file"

--- a/scripts/manim-reference-ledger.mjs
+++ b/scripts/manim-reference-ledger.mjs
@@ -1,0 +1,99 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+function locationKey(example) {
+  return `${example.source_path}:${example.directive_line}`;
+}
+
+function assertObject(value, name) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${name} must be an object`);
+  }
+}
+
+function validateExampleShape(example, name) {
+  assertObject(example, name);
+  if (typeof example.source_path !== "string" || example.source_path.length === 0) {
+    throw new Error(`${name}.source_path must be a non-empty string`);
+  }
+  if (!Number.isInteger(example.directive_line) || example.directive_line < 1) {
+    throw new Error(`${name}.directive_line must be a positive integer`);
+  }
+  if (example.name !== null && typeof example.name !== "string") {
+    throw new Error(`${name}.name must be a string or null`);
+  }
+  if (typeof example.source_sha256 !== "string" || !/^[0-9a-f]{64}$/u.test(example.source_sha256)) {
+    throw new Error(`${name}.source_sha256 must be a lowercase SHA-256 digest`);
+  }
+}
+
+export function validateReferenceLedger(inventory, ledger) {
+  assertObject(inventory, "inventory");
+  assertObject(ledger, "ledger");
+  if (inventory.schema_version !== 1) {
+    throw new Error(`unsupported inventory schema ${inventory.schema_version}`);
+  }
+  if (ledger.schema_version !== 1) {
+    throw new Error(`unsupported ledger schema ${ledger.schema_version}`);
+  }
+  if (JSON.stringify(ledger.upstream) !== JSON.stringify(inventory.upstream)) {
+    throw new Error("ledger upstream provenance does not match extracted inventory");
+  }
+  if (!Array.isArray(inventory.examples) || !Array.isArray(ledger.entries)) {
+    throw new Error("inventory.examples and ledger.entries must be arrays");
+  }
+
+  const extracted = new Map();
+  for (const [index, example] of inventory.examples.entries()) {
+    validateExampleShape(example, `inventory.examples[${index}]`);
+    const key = locationKey(example);
+    if (extracted.has(key)) {
+      throw new Error(`duplicate extracted reference location ${key}`);
+    }
+    extracted.set(key, example);
+  }
+
+  const tracked = new Set();
+  for (const [index, entry] of ledger.entries.entries()) {
+    validateExampleShape(entry, `ledger.entries[${index}]`);
+    const key = locationKey(entry);
+    if (tracked.has(key)) {
+      throw new Error(`duplicate ledger reference location ${key}`);
+    }
+    tracked.add(key);
+    const example = extracted.get(key);
+    if (!example) {
+      throw new Error(`ledger contains reference absent from pinned inventory: ${key}`);
+    }
+    if (entry.name !== example.name || entry.source_sha256 !== example.source_sha256) {
+      throw new Error(`ledger provenance drift at ${key}`);
+    }
+  }
+
+  const missing = [...extracted.keys()].filter((key) => !tracked.has(key));
+  if (missing.length > 0) {
+    throw new Error(`ledger is missing ${missing.length} pinned reference example(s): ${missing.slice(0, 5).join(", ")}`);
+  }
+
+  return {
+    schema_version: 1,
+    upstream: inventory.upstream,
+    tracked_examples: tracked.size,
+  };
+}
+
+async function main() {
+  const [inventoryPath, ledgerPath] = process.argv.slice(2);
+  if (!inventoryPath || !ledgerPath) {
+    throw new Error("usage: node scripts/manim-reference-ledger.mjs INVENTORY_JSON LEDGER_JSON");
+  }
+  const [inventory, ledger] = await Promise.all(
+    [inventoryPath, ledgerPath].map(async (file) => JSON.parse(await readFile(file, "utf8"))),
+  );
+  process.stdout.write(`${JSON.stringify(validateReferenceLedger(inventory, ledger), null, 2)}\n`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  await main();
+}

--- a/scripts/manim-reference-ledger.mjs
+++ b/scripts/manim-reference-ledger.mjs
@@ -1,10 +1,7 @@
+import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-
-function locationKey(example) {
-  return `${example.source_path}:${example.directive_line}`;
-}
 
 function assertObject(value, name) {
   if (value === null || typeof value !== "object" || Array.isArray(value)) {
@@ -28,6 +25,22 @@ function validateExampleShape(example, name) {
   }
 }
 
+export function referenceInventoryFingerprint(examples) {
+  if (!Array.isArray(examples)) {
+    throw new Error("inventory.examples must be an array");
+  }
+  const projection = examples.map((example, index) => {
+    validateExampleShape(example, `inventory.examples[${index}]`);
+    return {
+      source_path: example.source_path,
+      directive_line: example.directive_line,
+      name: example.name,
+      source_sha256: example.source_sha256,
+    };
+  });
+  return createHash("sha256").update(JSON.stringify(projection), "utf8").digest("hex");
+}
+
 export function validateReferenceLedger(inventory, ledger) {
   assertObject(inventory, "inventory");
   assertObject(ledger, "ledger");
@@ -40,46 +53,33 @@ export function validateReferenceLedger(inventory, ledger) {
   if (JSON.stringify(ledger.upstream) !== JSON.stringify(inventory.upstream)) {
     throw new Error("ledger upstream provenance does not match extracted inventory");
   }
-  if (!Array.isArray(inventory.examples) || !Array.isArray(ledger.entries)) {
-    throw new Error("inventory.examples and ledger.entries must be arrays");
+  if (!Number.isInteger(ledger.example_count) || ledger.example_count < 0) {
+    throw new Error("ledger.example_count must be a non-negative integer");
+  }
+  if (typeof ledger.provenance_sha256 !== "string" || !/^[0-9a-f]{64}$/u.test(ledger.provenance_sha256)) {
+    throw new Error("ledger.provenance_sha256 must be a lowercase SHA-256 digest");
+  }
+  if (!Array.isArray(inventory.examples)) {
+    throw new Error("inventory.examples must be an array");
+  }
+  if (inventory.examples.length !== ledger.example_count) {
+    throw new Error(
+      `reference example count drift: expected ${ledger.example_count}, extracted ${inventory.examples.length}`,
+    );
   }
 
-  const extracted = new Map();
-  for (const [index, example] of inventory.examples.entries()) {
-    validateExampleShape(example, `inventory.examples[${index}]`);
-    const key = locationKey(example);
-    if (extracted.has(key)) {
-      throw new Error(`duplicate extracted reference location ${key}`);
-    }
-    extracted.set(key, example);
-  }
-
-  const tracked = new Set();
-  for (const [index, entry] of ledger.entries.entries()) {
-    validateExampleShape(entry, `ledger.entries[${index}]`);
-    const key = locationKey(entry);
-    if (tracked.has(key)) {
-      throw new Error(`duplicate ledger reference location ${key}`);
-    }
-    tracked.add(key);
-    const example = extracted.get(key);
-    if (!example) {
-      throw new Error(`ledger contains reference absent from pinned inventory: ${key}`);
-    }
-    if (entry.name !== example.name || entry.source_sha256 !== example.source_sha256) {
-      throw new Error(`ledger provenance drift at ${key}`);
-    }
-  }
-
-  const missing = [...extracted.keys()].filter((key) => !tracked.has(key));
-  if (missing.length > 0) {
-    throw new Error(`ledger is missing ${missing.length} pinned reference example(s): ${missing.slice(0, 5).join(", ")}`);
+  const fingerprint = referenceInventoryFingerprint(inventory.examples);
+  if (fingerprint !== ledger.provenance_sha256) {
+    throw new Error(
+      `reference inventory provenance drift: expected ${ledger.provenance_sha256}, extracted ${fingerprint}`,
+    );
   }
 
   return {
     schema_version: 1,
     upstream: inventory.upstream,
-    tracked_examples: tracked.size,
+    tracked_examples: inventory.examples.length,
+    provenance_sha256: fingerprint,
   };
 }
 

--- a/scripts/manim-reference-ledger.test.mjs
+++ b/scripts/manim-reference-ledger.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { validateReferenceLedger } from "./manim-reference-ledger.mjs";
+import {
+  referenceInventoryFingerprint,
+  validateReferenceLedger,
+} from "./manim-reference-ledger.mjs";
 
 const upstream = {
   repository: "ManimCommunity/manim",
@@ -19,55 +22,64 @@ function example(sourcePath, directiveLine, name, hashByte) {
 }
 
 function fixture() {
-  const first = example("docs/source/a.rst", 10, "First", "a");
-  const second = example("manim/mobject/b.py", 20, null, "b");
+  const examples = [
+    example("docs/source/a.rst", 10, "First", "a"),
+    example("manim/mobject/b.py", 20, null, "b"),
+  ];
   return {
-    inventory: { schema_version: 1, upstream, examples: [first, second] },
-    ledger: { schema_version: 1, upstream, entries: [first, second] },
+    inventory: { schema_version: 1, upstream, examples },
+    ledger: {
+      schema_version: 1,
+      upstream,
+      example_count: examples.length,
+      provenance_sha256: referenceInventoryFingerprint(examples),
+    },
   };
 }
 
-test("accepts an exact pinned reference ledger", () => {
+test("accepts an exact pinned reference inventory lock", () => {
   const { inventory, ledger } = fixture();
   assert.deepEqual(validateReferenceLedger(inventory, ledger), {
     schema_version: 1,
     upstream,
     tracked_examples: 2,
+    provenance_sha256: ledger.provenance_sha256,
   });
 });
 
-test("rejects silently missing pinned examples", () => {
+test("rejects added or removed pinned examples", () => {
   const { inventory, ledger } = fixture();
-  ledger.entries.pop();
+  inventory.examples.pop();
   assert.throws(
     () => validateReferenceLedger(inventory, ledger),
-    /ledger is missing 1 pinned reference example/u,
+    /reference example count drift: expected 2, extracted 1/u,
   );
 });
 
-test("rejects stale source provenance at the same directive location", () => {
-  const { inventory, ledger } = fixture();
-  ledger.entries[0] = { ...ledger.entries[0], source_sha256: "c".repeat(64) };
-  assert.throws(
-    () => validateReferenceLedger(inventory, ledger),
-    /ledger provenance drift at docs\/source\/a\.rst:10/u,
-  );
+test("rejects moved, renamed, or source-changed reference examples", () => {
+  for (const mutation of [
+    (exampleValue) => ({ ...exampleValue, source_path: "docs/source/moved.rst" }),
+    (exampleValue) => ({ ...exampleValue, name: "Renamed" }),
+    (exampleValue) => ({ ...exampleValue, source_sha256: "c".repeat(64) }),
+  ]) {
+    const { inventory, ledger } = fixture();
+    inventory.examples[0] = mutation(inventory.examples[0]);
+    assert.throws(
+      () => validateReferenceLedger(inventory, ledger),
+      /reference inventory provenance drift/u,
+    );
+  }
 });
 
-test("rejects extra and duplicate ledger locations", () => {
-  const { inventory, ledger } = fixture();
-  ledger.entries.push(example("docs/source/extra.rst", 30, "Extra", "d"));
-  assert.throws(
-    () => validateReferenceLedger(inventory, ledger),
-    /ledger contains reference absent from pinned inventory/u,
-  );
-
-  const duplicate = fixture();
-  duplicate.ledger.entries.push({ ...duplicate.ledger.entries[0] });
-  assert.throws(
-    () => validateReferenceLedger(duplicate.inventory, duplicate.ledger),
-    /duplicate ledger reference location/u,
-  );
+test("fingerprint ignores directive options and extracted source payload", () => {
+  const { inventory } = fixture();
+  const baseline = referenceInventoryFingerprint(inventory.examples);
+  inventory.examples[0] = {
+    ...inventory.examples[0],
+    options: { save_last_frame: true },
+    source: "class First(Scene): pass",
+  };
+  assert.equal(referenceInventoryFingerprint(inventory.examples), baseline);
 });
 
 test("rejects upstream revision drift", () => {

--- a/scripts/manim-reference-ledger.test.mjs
+++ b/scripts/manim-reference-ledger.test.mjs
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { validateReferenceLedger } from "./manim-reference-ledger.mjs";
+
+const upstream = {
+  repository: "ManimCommunity/manim",
+  version: "v0.21.0",
+  revision: "861cd4849b17db1db3515b531ffe80b297848f93",
+};
+
+function example(sourcePath, directiveLine, name, hashByte) {
+  return {
+    source_path: sourcePath,
+    directive_line: directiveLine,
+    name,
+    source_sha256: hashByte.repeat(64),
+  };
+}
+
+function fixture() {
+  const first = example("docs/source/a.rst", 10, "First", "a");
+  const second = example("manim/mobject/b.py", 20, null, "b");
+  return {
+    inventory: { schema_version: 1, upstream, examples: [first, second] },
+    ledger: { schema_version: 1, upstream, entries: [first, second] },
+  };
+}
+
+test("accepts an exact pinned reference ledger", () => {
+  const { inventory, ledger } = fixture();
+  assert.deepEqual(validateReferenceLedger(inventory, ledger), {
+    schema_version: 1,
+    upstream,
+    tracked_examples: 2,
+  });
+});
+
+test("rejects silently missing pinned examples", () => {
+  const { inventory, ledger } = fixture();
+  ledger.entries.pop();
+  assert.throws(
+    () => validateReferenceLedger(inventory, ledger),
+    /ledger is missing 1 pinned reference example/u,
+  );
+});
+
+test("rejects stale source provenance at the same directive location", () => {
+  const { inventory, ledger } = fixture();
+  ledger.entries[0] = { ...ledger.entries[0], source_sha256: "c".repeat(64) };
+  assert.throws(
+    () => validateReferenceLedger(inventory, ledger),
+    /ledger provenance drift at docs\/source\/a\.rst:10/u,
+  );
+});
+
+test("rejects extra and duplicate ledger locations", () => {
+  const { inventory, ledger } = fixture();
+  ledger.entries.push(example("docs/source/extra.rst", 30, "Extra", "d"));
+  assert.throws(
+    () => validateReferenceLedger(inventory, ledger),
+    /ledger contains reference absent from pinned inventory/u,
+  );
+
+  const duplicate = fixture();
+  duplicate.ledger.entries.push({ ...duplicate.ledger.entries[0] });
+  assert.throws(
+    () => validateReferenceLedger(duplicate.inventory, duplicate.ledger),
+    /duplicate ledger reference location/u,
+  );
+});
+
+test("rejects upstream revision drift", () => {
+  const { inventory, ledger } = fixture();
+  ledger.upstream = { ...upstream, revision: "deadbeef" };
+  assert.throws(
+    () => validateReferenceLedger(inventory, ledger),
+    /ledger upstream provenance does not match extracted inventory/u,
+  );
+});


### PR DESCRIPTION
## Summary
- record a compact checked-in lock for the exact ManimCE v0.21.0 reference-example corpus extracted by the existing pinned inventory tool
- verify the immutable corpus by exact example count plus a canonical SHA-256 over `{source_path, directive_line, name, source_sha256}` for every extracted directive
- fail the dedicated inventory workflow if an example is added, removed, moved, renamed, or its source provenance changes without an explicit lock update
- add focused validator tests and register them in the normal web-package build
- keep the detailed 472-example inventory generated as a CI artifact instead of duplicating that large derived dataset in the repository

## Why
#620 made the extractor deterministic and pinned it to the exact ManimCE v0.21.0 commit, but the resulting reference corpus remained an ephemeral artifact. A parser regression or future intentional extraction change could therefore silently change which reference examples Noon believes exist. This adds a small provenance ratchet around that boundary.

The lock currently represents 472 `.. manim::` directives from immutable upstream commit `861cd4849b17db1db3515b531ffe80b297848f93`.

## Architecture
This is coverage/tooling only. It does not create a second example manifest and does not copy generated reference examples into source control. The extractor remains the source of detailed upstream inventory; the checked-in lock only commits to its exact immutable corpus identity.

## Remaining boundary
This does not yet classify all 472 reference examples as ready/blocked/deferred/intentional-divergence or merge those classifications into the public gallery manifest. That remains the next #256 coverage-model tranche.

Tracks #256.