### PR TITLE
Expose shared Manim Elbow through WASM

### DIFF
--- a/crates/noon-web/src/lib.rs
+++ b/crates/noon-web/src/lib.rs
@@ -14,6 +14,7 @@ mod host_player;
 #[path = "legacy.rs"]
 mod legacy;
 mod lifecycle;
+mod manim_elbow_bridge;
 mod manim_geometry_bridge;
 mod manim_path_query_bridge;
 mod manim_sector_bridge;
@@ -44,6 +45,7 @@ pub use execution_visibility::*;
 pub use host_player::*;
 pub use legacy::*;
 pub use lifecycle::*;
+pub use manim_elbow_bridge::*;
 pub use manim_geometry_bridge::*;
 pub use manim_path_query_bridge::*;
 pub use manim_sector_bridge::*;

--- a/crates/noon-web/src/manim_elbow_bridge.rs
+++ b/crates/noon-web/src/manim_elbow_bridge.rs
@@ -1,0 +1,112 @@
+use noon::{Elbow, IntoSnapshot};
+use noon_core::ObjectSnapshot;
+
+fn finite_f32(name: &str, value: f64) -> Result<f32, String> {
+    if !value.is_finite() || value.abs() > f64::from(f32::MAX) {
+        return Err(format!("{name} must be a finite f32-compatible number"));
+    }
+    Ok(value as f32)
+}
+
+fn snapshot_json(snapshot: ObjectSnapshot) -> Result<String, String> {
+    serde_json::to_string(&snapshot)
+        .map_err(|error| format!("unable to serialize Manim Elbow snapshot: {error}"))
+}
+
+pub fn manim_elbow_snapshot_json(width: f64, angle: f64) -> Result<String, String> {
+    let elbow = Elbow::with_options(finite_f32("width", width)?, finite_f32("angle", angle)?)
+        .map_err(|error| error.to_string())?;
+    snapshot_json(elbow.into_snapshot())
+}
+
+#[cfg(target_arch = "wasm32")]
+mod wasm {
+    use wasm_bindgen::prelude::*;
+
+    use super::manim_elbow_snapshot_json;
+
+    #[wasm_bindgen(js_name = manimElbowSnapshotJson)]
+    pub fn manim_elbow_snapshot(width: f64, angle: f64) -> Result<String, JsValue> {
+        manim_elbow_snapshot_json(width, angle).map_err(|error| JsValue::from_str(&error))
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub use wasm::*;
+
+#[cfg(test)]
+mod tests {
+    use noon_core::{
+        GeometryRef, PathCommand, StrokeCap, StrokeJoin, StrokeWidthMode, Vec2, WHITE,
+    };
+
+    use super::*;
+
+    fn decode(value: &str) -> ObjectSnapshot {
+        serde_json::from_str(value).expect("valid ObjectSnapshot JSON")
+    }
+
+    fn assert_close(actual: f32, expected: f32) {
+        assert!(
+            (actual - expected).abs() <= 1.0e-5,
+            "{actual} != {expected}"
+        );
+    }
+
+    #[test]
+    fn elbow_bridge_preserves_shared_path_and_style_defaults() {
+        let snapshot = decode(&manim_elbow_snapshot_json(0.2, 0.0).expect("valid Elbow"));
+        let GeometryRef::VectorPath(path) = &snapshot.geometry else {
+            panic!("Elbow bridge must preserve retained VectorPath geometry")
+        };
+        assert_eq!(
+            path.commands(),
+            &[
+                PathCommand::MoveTo {
+                    to: Vec2::new(0.0, 0.2),
+                },
+                PathCommand::LineTo {
+                    to: Vec2::new(0.2, 0.2),
+                },
+                PathCommand::LineTo {
+                    to: Vec2::new(0.2, 0.0),
+                },
+            ]
+        );
+        assert_eq!(snapshot.style.stroke, Some(WHITE));
+        assert_eq!(snapshot.style.fill.map(|color| color.alpha), Some(0.0));
+        assert_eq!(snapshot.style.stroke_width, 0.04);
+        assert_eq!(
+            snapshot.style.stroke_width_mode,
+            StrokeWidthMode::ScreenSpace
+        );
+        assert_eq!(snapshot.style.stroke_join, StrokeJoin::Miter);
+        assert_eq!(snapshot.style.stroke_cap, StrokeCap::Butt);
+    }
+
+    #[test]
+    fn elbow_bridge_preserves_constructor_rotated_public_geometry() {
+        let angle = 5.0 * std::f64::consts::PI / 4.0;
+        let snapshot = decode(&manim_elbow_snapshot_json(2.0, angle).expect("valid Elbow"));
+        let root_two = 2.0_f32.sqrt();
+
+        assert_eq!(snapshot.transform.rotation, 0.0);
+        assert_close(snapshot.center().x, 0.0);
+        assert_close(snapshot.center().y, -1.5 * root_two);
+        assert_close(snapshot.width(), 2.0 * root_two);
+        assert_close(snapshot.height(), root_two);
+    }
+
+    #[test]
+    fn elbow_bridge_preserves_zero_and_negative_widths() {
+        assert!(manim_elbow_snapshot_json(0.0, 0.0).is_ok());
+        assert!(manim_elbow_snapshot_json(-0.5, 0.0).is_ok());
+    }
+
+    #[test]
+    fn elbow_bridge_rejects_non_renderable_inputs() {
+        assert!(manim_elbow_snapshot_json(f64::NAN, 0.0).is_err());
+        assert!(manim_elbow_snapshot_json(0.2, f64::INFINITY).is_err());
+        assert!(manim_elbow_snapshot_json(f64::MAX, 0.0).is_err());
+    }
+}


### PR DESCRIPTION
## Summary
- expose the newly-landed shared Rust `Elbow` semantics through a focused `noon-web` WASM bridge
- serialize the ordinary retained `ObjectSnapshot`; frontend callers do not reconstruct the three-corner path or rotation
- validate JS numeric inputs at the bridge boundary and preserve Manim-compatible zero/negative widths
- add focused native tests for exact retained path/style defaults, edge-case widths, and invalid numeric inputs

## Architecture
This follows the existing sector/geometry bridge pattern. `noon::Elbow` remains the sole owner of observable geometry and Manim defaults; `noon-web` only validates f64→f32 compatibility, serializes the snapshot, and exposes `manimElbowSnapshotJson`. No renderer primitive, worker protocol, Python path math, or persistent Elbow-specific state is introduced.

## Dependency
#630 identified and fixes a real shared-Rust constructor representation bug: Manim rotates Elbow points during construction, while the previous Noon implementation stored the constructor angle in `ObjectSnapshot.transform.rotation`, producing incorrect canonical bounds. This bridge must not merge before #630 lands. After that merge, this branch will be refreshed and its old internal transform-rotation assertion replaced with public rotated path/bounds observations.

## Validation
Fresh exact-head CI is required after the #630 refresh. The normal Rust/web-package jobs will exercise native tests plus wasm-bindgen export generation.

## Remaining boundary
This establishes the browser semantic bridge only. Thin Python/JS compatibility adapters and exact Manim raster/demo qualification can follow independently without adding geometry semantics.

Tracks #77 and #400.