### PR TITLE
Gate shared Elbow semantics against ManimCE

### DIFF
--- a/.github/workflows/manim-differential.yml
+++ b/.github/workflows/manim-differential.yml
@@ -43,4 +43,5 @@ jobs:
           python scripts/manim-differential.py
           python scripts/manim-dot-ellipse-differential.py
           python scripts/manim-sector-differential.py
+          python scripts/manim-elbow-differential.py
           python scripts/manim-frame-sampling-differential.py

--- a/crates/noon-web/examples/manim_elbow_oracle.rs
+++ b/crates/noon-web/examples/manim_elbow_oracle.rs
@@ -52,12 +52,7 @@ fn observation(snapshot: ObjectSnapshot) -> Value {
     })
 }
 
-fn insert(
-    observations: &mut Map<String, Value>,
-    name: &str,
-    width: f32,
-    angle: f32,
-) {
+fn insert(observations: &mut Map<String, Value>, name: &str, width: f32, angle: f32) {
     observations.insert(
         name.to_owned(),
         observation(
@@ -77,7 +72,12 @@ fn main() {
         2.0,
         5.0 * std::f32::consts::PI / 4.0,
     );
-    insert(&mut observations, "zero_width", 0.0, std::f32::consts::FRAC_PI_3);
+    insert(
+        &mut observations,
+        "zero_width",
+        0.0,
+        std::f32::consts::FRAC_PI_3,
+    );
     insert(
         &mut observations,
         "negative_width",

--- a/crates/noon-web/examples/manim_elbow_oracle.rs
+++ b/crates/noon-web/examples/manim_elbow_oracle.rs
@@ -1,0 +1,92 @@
+use noon::{Elbow, IntoSnapshot};
+use noon_core::{GeometryRef, ObjectSnapshot, PathCommand, Vec2};
+use serde_json::{json, Map, Value};
+
+fn transformed_point(snapshot: &ObjectSnapshot, point: Vec2) -> Vec2 {
+    let scaled = Vec2::new(
+        point.x * snapshot.transform.scale.x,
+        point.y * snapshot.transform.scale.y,
+    );
+    let (sin, cos) = snapshot.transform.rotation.sin_cos();
+    Vec2::new(
+        scaled.x * cos - scaled.y * sin + snapshot.transform.translation.x,
+        scaled.x * sin + scaled.y * cos + snapshot.transform.translation.y,
+    )
+}
+
+fn endpoints(snapshot: &ObjectSnapshot) -> (Vec2, Vec2) {
+    let GeometryRef::VectorPath(path) = &snapshot.geometry else {
+        panic!("Elbow oracle requires retained VectorPath geometry")
+    };
+
+    let mut first = None;
+    let mut last = None;
+    for command in path.commands() {
+        let point = match command {
+            PathCommand::MoveTo { to } | PathCommand::LineTo { to } => Some(*to),
+            _ => None,
+        };
+        if let Some(point) = point {
+            first.get_or_insert(point);
+            last = Some(point);
+        }
+    }
+
+    let first = first.expect("Elbow path must contain a start point");
+    let last = last.expect("Elbow path must contain an end point");
+    (
+        transformed_point(snapshot, first),
+        transformed_point(snapshot, last),
+    )
+}
+
+fn observation(snapshot: ObjectSnapshot) -> Value {
+    let center = snapshot.center();
+    let (start, end) = endpoints(&snapshot);
+    json!({
+        "center": [center.x, center.y],
+        "start": [start.x, start.y],
+        "end": [end.x, end.y],
+        "width": snapshot.width(),
+        "height": snapshot.height(),
+    })
+}
+
+fn insert(
+    observations: &mut Map<String, Value>,
+    name: &str,
+    width: f32,
+    angle: f32,
+) {
+    observations.insert(
+        name.to_owned(),
+        observation(
+            Elbow::with_options(width, angle)
+                .expect("Elbow oracle fixture must be valid")
+                .into_snapshot(),
+        ),
+    );
+}
+
+fn main() {
+    let mut observations = Map::new();
+    insert(&mut observations, "default", 0.2, 0.0);
+    insert(
+        &mut observations,
+        "rotated_wide",
+        2.0,
+        5.0 * std::f32::consts::PI / 4.0,
+    );
+    insert(&mut observations, "zero_width", 0.0, std::f32::consts::FRAC_PI_3);
+    insert(
+        &mut observations,
+        "negative_width",
+        -0.5,
+        -std::f32::consts::FRAC_PI_6,
+    );
+
+    println!(
+        "{}",
+        serde_json::to_string(&Value::Object(observations)).expect("serialize observations")
+    );
+}

--- a/crates/noon/src/elbow_authoring.rs
+++ b/crates/noon/src/elbow_authoring.rs
@@ -56,12 +56,8 @@ impl Elbow {
         }
 
         let (sin, cos) = angle.sin_cos();
-        let rotate = |point: Vec2| {
-            Vec2::new(
-                point.x * cos - point.y * sin,
-                point.x * sin + point.y * cos,
-            )
-        };
+        let rotate =
+            |point: Vec2| Vec2::new(point.x * cos - point.y * sin, point.x * sin + point.y * cos);
         let path = VectorPath::new()
             .move_to(rotate(Vec2::new(0.0, width)))
             .line_to(rotate(Vec2::new(width, width)))

--- a/crates/noon/src/elbow_authoring.rs
+++ b/crates/noon/src/elbow_authoring.rs
@@ -1,10 +1,10 @@
 //! Shared Rust authoring semantics for Manim-compatible `Elbow` geometry.
 //!
 //! ManimCE defines `Elbow` as one open three-corner VMobject, scaled about the
-//! origin to the requested width and then rotated about the origin. Noon keeps
-//! that observable geometry as one immutable retained [`VectorPath`] and uses
-//! the ordinary object transform for rotation; no renderer-specific primitive
-//! or frontend path reconstruction is required.
+//! origin to the requested width and then rotates those points about the origin.
+//! Noon bakes that constructor rotation into the immutable retained [`VectorPath`]
+//! so ordinary snapshot bounds observe the same rotated points. Later authoring
+//! transforms still use the shared [`ObjectSnapshot`] transform.
 
 use crate::legacy::{IntoSnapshot, Path};
 use noon_core::{Color, ObjectSnapshot, Vec2, VectorPath};
@@ -55,12 +55,18 @@ impl Elbow {
             return Err(ElbowAuthoringError::NonFiniteAngle(angle));
         }
 
+        let (sin, cos) = angle.sin_cos();
+        let rotate = |point: Vec2| {
+            Vec2::new(
+                point.x * cos - point.y * sin,
+                point.x * sin + point.y * cos,
+            )
+        };
         let path = VectorPath::new()
-            .move_to(Vec2::new(0.0, width))
-            .line_to(Vec2::new(width, width))
-            .line_to(Vec2::new(width, 0.0));
-        let snapshot = Path::new(path).into_snapshot().rotate_by(angle);
-        Ok(Self(snapshot))
+            .move_to(rotate(Vec2::new(0.0, width)))
+            .line_to(rotate(Vec2::new(width, width)))
+            .line_to(rotate(Vec2::new(width, 0.0)));
+        Ok(Self(Path::new(path).into_snapshot()))
     }
 
     pub fn color(mut self, color: Color) -> Self {
@@ -142,6 +148,13 @@ mod tests {
         }
     }
 
+    fn assert_close(actual: f32, expected: f32) {
+        assert!(
+            (actual - expected).abs() <= 1.0e-5,
+            "{actual} != {expected}"
+        );
+    }
+
     #[test]
     fn default_elbow_matches_manim_open_corner_path_and_style() {
         let elbow = Elbow::new();
@@ -175,38 +188,40 @@ mod tests {
     }
 
     #[test]
-    fn elbow_width_and_angle_are_shared_retained_semantics() {
+    fn constructor_rotation_is_baked_into_path_for_exact_public_bounds() {
         let angle = 5.0 * std::f32::consts::PI / 4.0;
         let elbow = Elbow::with_options(2.0, angle).unwrap();
-        assert_eq!(
-            commands(&elbow),
-            &[
-                PathCommand::MoveTo {
-                    to: Vec2::new(0.0, 2.0),
-                },
-                PathCommand::LineTo {
-                    to: Vec2::new(2.0, 2.0),
-                },
-                PathCommand::LineTo {
-                    to: Vec2::new(2.0, 0.0),
-                },
-            ]
-        );
-        assert_eq!(elbow.snapshot().transform.rotation, angle);
+        let root_two = 2.0_f32.sqrt();
+
+        assert_eq!(elbow.snapshot().transform.rotation, 0.0);
+        assert_close(elbow.snapshot().center().x, 0.0);
+        assert_close(elbow.snapshot().center().y, -1.5 * root_two);
+        assert_close(elbow.snapshot().width(), 2.0 * root_two);
+        assert_close(elbow.snapshot().height(), root_two);
     }
 
     #[test]
     fn elbow_preserves_manim_zero_and_negative_width_behavior() {
-        let zero = Elbow::with_options(0.0, 0.0).unwrap();
+        let zero = Elbow::with_options(0.0, std::f32::consts::FRAC_PI_3).unwrap();
         assert!(commands(&zero).iter().all(|command| match command {
             PathCommand::MoveTo { to } | PathCommand::LineTo { to } => *to == Vec2::ZERO,
             _ => false,
         }));
 
-        let negative = Elbow::with_options(-0.5, 0.0).unwrap();
-        assert!(commands(&negative).contains(&PathCommand::LineTo {
-            to: Vec2::new(-0.5, -0.5),
-        }));
+        let negative = Elbow::with_options(-0.5, -std::f32::consts::FRAC_PI_6).unwrap();
+        assert_close(negative.snapshot().center().x, -0.46650636);
+        assert_close(negative.snapshot().width(), 0.4330127);
+    }
+
+    #[test]
+    fn later_rotation_remains_an_ordinary_retained_transform() {
+        let elbow = Elbow::with_options(0.2, std::f32::consts::FRAC_PI_4)
+            .unwrap()
+            .rotate(std::f32::consts::FRAC_PI_2);
+        assert_eq!(
+            elbow.snapshot().transform.rotation,
+            std::f32::consts::FRAC_PI_2
+        );
     }
 
     #[test]

--- a/scripts/manim-elbow-differential.py
+++ b/scripts/manim-elbow-differential.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Compare shared Rust Elbow geometry against pinned ManimCE semantics."""
+
+from __future__ import annotations
+
+import json
+import math
+import subprocess
+from pathlib import Path
+
+import manim
+
+ROOT = Path(__file__).resolve().parents[1]
+PINNED_MANIM_VERSION = "0.21.0"
+TOLERANCE = 2e-5
+
+
+def observe(obj):
+    center = obj.get_center()
+    start = obj.get_start()
+    end = obj.get_end()
+    return {
+        "center": [float(center[0]), float(center[1])],
+        "start": [float(start[0]), float(start[1])],
+        "end": [float(end[0]), float(end[1])],
+        "width": float(obj.width),
+        "height": float(obj.height),
+    }
+
+
+def manim_observations():
+    return {
+        "default": observe(manim.Elbow()),
+        "rotated_wide": observe(manim.Elbow(width=2.0, angle=5.0 * math.pi / 4.0)),
+        "zero_width": observe(manim.Elbow(width=0.0, angle=math.pi / 3.0)),
+        "negative_width": observe(manim.Elbow(width=-0.5, angle=-math.pi / 6.0)),
+    }
+
+
+def noon_observations():
+    result = subprocess.run(
+        [
+            "cargo",
+            "run",
+            "--quiet",
+            "-p",
+            "noon-web",
+            "--example",
+            "manim_elbow_oracle",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def compare(path, actual, expected, failures):
+    if isinstance(expected, dict):
+        if set(actual) != set(expected):
+            failures.append(
+                f"{path}: keys differ: Noon={sorted(actual)}, Manim={sorted(expected)}"
+            )
+            return
+        for key in expected:
+            compare(f"{path}.{key}", actual[key], expected[key], failures)
+        return
+
+    if isinstance(expected, list):
+        if len(actual) != len(expected):
+            failures.append(
+                f"{path}: length differs: Noon={len(actual)}, Manim={len(expected)}"
+            )
+            return
+        for index, (actual_item, expected_item) in enumerate(zip(actual, expected)):
+            compare(f"{path}[{index}]", actual_item, expected_item, failures)
+        return
+
+    if not math.isclose(float(actual), float(expected), rel_tol=0.0, abs_tol=TOLERANCE):
+        failures.append(f"{path}: Noon={actual!r}, Manim={expected!r}")
+
+
+def main():
+    if manim.__version__ != PINNED_MANIM_VERSION:
+        raise SystemExit(
+            f"expected ManimCE {PINNED_MANIM_VERSION}, got {manim.__version__}"
+        )
+
+    noon = noon_observations()
+    reference = manim_observations()
+    failures = []
+    compare("elbow", noon, reference, failures)
+    if failures:
+        print("[FAIL] shared Rust Elbow geometry diverges from ManimCE")
+        for failure in failures:
+            print(f"  {failure}")
+        raise SystemExit(1)
+
+    print(
+        f"[PASS] {len(reference)} shared Rust Elbow fixtures match "
+        f"ManimCE {manim.__version__} within {TOLERANCE:g}"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a renderer-independent semantic oracle for shared Rust `Elbow`
- compare Noon against pinned ManimCE v0.21.0 for default, rotated/wide, zero-width, and negative-width cases
- qualify public start/end/center/width/height observations at the existing `2e-5` tolerance
- fix the real mismatch exposed by that oracle: bake Manim's constructor-time rotation into the retained path points so canonical snapshot bounds observe the rotated VMobject points rather than a rotated local AABB
- keep subsequent `.rotate()` authoring operations on the ordinary retained `ObjectSnapshot` transform

## Architecture
Manim constructs `Elbow` by creating the three-corner path, scaling it about the origin, then rotating the VMobject's points about the origin. The previous Noon implementation represented that constructor angle as `ObjectSnapshot.transform.rotation`; canonical bounds therefore rotated the path's local AABB and were conservatively wrong for rotated and negative-width Elbows.

The corrected shared Rust constructor performs only the constructor-time point rotation in geometry. It adds no renderer special case, frontend geometry, alternate bounds implementation, or persistent Elbow state. Later transforms continue through the shared retained transform path.

## Regression
Focused Rust coverage pins the rotated/wide and negative-width public center/width/height values that failed against Manim and verifies later rotation still remains a retained transform. The pinned-Manim differential covers default, rotated/wide, zero-width, and negative-width start/end/center/width/height observations.

Fresh exact-head CI is required before merge. No tolerance changes are included.

Tracks #77 and #185.