### PR TITLE
Reconcile pinned Manim references with canonical coverage

### DIFF
--- a/.github/workflows/manim-reference-inventory.yml
+++ b/.github/workflows/manim-reference-inventory.yml
@@ -5,20 +5,30 @@ on:
     paths:
       - '.github/workflows/manim-reference-inventory.yml'
       - 'compat/manim-v0.21.0-reference-inventory-lock.json'
+      - 'compat/manim-v0.21.0-reference-coverage-lock.json'
+      - 'parity/manim-v0.21/upstream-examples/**'
+      - 'web/python/examples/manim_tutorial_manifest.json'
       - 'scripts/manim-reference-inventory.mjs'
       - 'scripts/manim-reference-inventory.test.mjs'
       - 'scripts/manim-reference-ledger.mjs'
       - 'scripts/manim-reference-ledger.test.mjs'
+      - 'scripts/manim-reference-coverage.mjs'
+      - 'scripts/manim-reference-coverage.test.mjs'
   push:
     branches:
       - master
     paths:
       - '.github/workflows/manim-reference-inventory.yml'
       - 'compat/manim-v0.21.0-reference-inventory-lock.json'
+      - 'compat/manim-v0.21.0-reference-coverage-lock.json'
+      - 'parity/manim-v0.21/upstream-examples/**'
+      - 'web/python/examples/manim_tutorial_manifest.json'
       - 'scripts/manim-reference-inventory.mjs'
       - 'scripts/manim-reference-inventory.test.mjs'
       - 'scripts/manim-reference-ledger.mjs'
       - 'scripts/manim-reference-ledger.test.mjs'
+      - 'scripts/manim-reference-coverage.mjs'
+      - 'scripts/manim-reference-coverage.test.mjs'
   workflow_dispatch:
 
 permissions:
@@ -118,6 +128,28 @@ jobs:
           printf '\nReference inventory lock verified against the immutable extracted corpus.\n' \
             >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Reconcile canonical reference coverage
+        shell: bash
+        run: |
+          set -euo pipefail
+          node noon/scripts/manim-reference-coverage.mjs \
+            noon/artifacts/manim-v0.21.0-reference-inventory.json \
+            noon/web/python/examples/manim_tutorial_manifest.json \
+            noon/compat/manim-v0.21.0-reference-coverage-lock.json \
+            noon \
+            > noon/artifacts/manim-v0.21.0-reference-coverage.json
+          cat noon/artifacts/manim-v0.21.0-reference-coverage.json
+          node - <<'NODE'
+          const fs = require("node:fs");
+          const report = JSON.parse(
+            fs.readFileSync("noon/artifacts/manim-v0.21.0-reference-coverage.json", "utf8"),
+          );
+          fs.appendFileSync(
+            process.env.GITHUB_STEP_SUMMARY,
+            `\nReconciled ${report.reconciled_examples}/${report.inventory_examples} pinned reference directives with exact-source canonical manifest entries; ${report.unclassified_inventory_examples} remain to classify.\n`,
+          );
+          NODE
+
       - name: Upload reference inventory
         if: always()
         uses: actions/upload-artifact@v4
@@ -126,5 +158,6 @@ jobs:
           path: |
             noon/artifacts/manim-v0.21.0-reference-inventory.json
             noon/artifacts/manim-v0.21.0-reference-ledger-summary.json
+            noon/artifacts/manim-v0.21.0-reference-coverage.json
           if-no-files-found: error
           retention-days: 14

--- a/compat/manim-v0.21.0-reference-coverage-lock.json
+++ b/compat/manim-v0.21.0-reference-coverage-lock.json
@@ -1,0 +1,4 @@
+{
+  "schema_version": 1,
+  "minimum_reconciled_examples": 17
+}

--- a/compat/manim-v0.21.0-reference-inventory-lock.json
+++ b/compat/manim-v0.21.0-reference-inventory-lock.json
@@ -5,6 +5,6 @@
     "version": "v0.21.0",
     "revision": "861cd4849b17db1db3515b531ffe80b297848f93"
   },
-  "example_count": 472,
-  "provenance_sha256": "be552e1ac2b2671572224596ec04e6ac0025b48859e65a2c23146f3ae7acb1d8"
+  "example_count": 491,
+  "provenance_sha256": "5efd04cecacd1f24035f7cde0fb165a1438b0df7a2dc5aa9f8eb22076e70fd02"
 }

--- a/scripts/build-web-demo.sh
+++ b/scripts/build-web-demo.sh
@@ -32,6 +32,7 @@ node --check scripts/manim-seek-playback-raster.mjs
 node --check scripts/manim-typst-authoring-smoke.mjs
 node --check scripts/manim-reference-inventory.mjs
 node --check scripts/manim-reference-ledger.mjs
+node --check scripts/manim-reference-coverage.mjs
 node --check scripts/perf-profile.mjs
 node --check scripts/authoring-perf.mjs
 node --check scripts/perf-device-run.mjs
@@ -51,6 +52,7 @@ node --check scripts/updater-callback-smoke.mjs
 node --test scripts/browser-visual-parity-lib.test.mjs
 node --test scripts/manim-reference-inventory.test.mjs
 node --test scripts/manim-reference-ledger.test.mjs
+node --test scripts/manim-reference-coverage.test.mjs
 
 for test_file in web/*.test.mjs; do
   node --test "$test_file"

--- a/scripts/manim-reference-coverage.mjs
+++ b/scripts/manim-reference-coverage.mjs
@@ -10,6 +10,7 @@ const CLASSIFIED_STATUSES = new Set([
   "intentional-divergence",
 ]);
 const EXACT_SOURCE_REUSE = "source-equivalent-manim-v0.21";
+const MANIM_IMPORT_PRELUDE = "from manim import *";
 
 function assertObject(value, name) {
   if (value === null || typeof value !== "object" || Array.isArray(value)) {
@@ -17,13 +18,28 @@ function assertObject(value, name) {
   }
 }
 
-export function normalizedSourceHash(source) {
+function normalizeSource(source) {
   if (typeof source !== "string") {
     throw new Error("source must be a string");
   }
-  return createHash("sha256")
-    .update(source.replace(/\r\n?/gu, "\n").trimEnd(), "utf8")
-    .digest("hex");
+  return source.replace(/\r\n?/gu, "\n").trimEnd();
+}
+
+export function normalizedSourceHash(source) {
+  return createHash("sha256").update(normalizeSource(source), "utf8").digest("hex");
+}
+
+export function directiveSourceFromFixture(source) {
+  const normalized = normalizeSource(source);
+  const lines = normalized.split("\n");
+  if (lines[0]?.trim() !== MANIM_IMPORT_PRELUDE) {
+    return normalized;
+  }
+  lines.shift();
+  while (lines[0]?.trim() === "") {
+    lines.shift();
+  }
+  return lines.join("\n").trimEnd();
 }
 
 function isReferenceEntry(entry) {
@@ -98,7 +114,7 @@ export async function reconcileReferenceCoverage(
 
     const fixturePath = path.resolve(repositoryRoot, entry.upstream_source);
     const fixtureSource = await readSource(fixturePath, "utf8");
-    const fixtureHash = normalizedSourceHash(fixtureSource);
+    const fixtureHash = normalizedSourceHash(directiveSourceFromFixture(fixtureSource));
     let matches = byHash.get(fixtureHash) ?? [];
     if (matches.length > 1 && typeof entry.title === "string") {
       const named = matches.filter(({ example }) => example.name === entry.title);

--- a/scripts/manim-reference-coverage.mjs
+++ b/scripts/manim-reference-coverage.mjs
@@ -1,0 +1,172 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const CLASSIFIED_STATUSES = new Set([
+  "ready",
+  "blocked",
+  "deferred",
+  "intentional-divergence",
+]);
+const EXACT_SOURCE_REUSE = "source-equivalent-manim-v0.21";
+
+function assertObject(value, name) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${name} must be an object`);
+  }
+}
+
+export function normalizedSourceHash(source) {
+  if (typeof source !== "string") {
+    throw new Error("source must be a string");
+  }
+  return createHash("sha256")
+    .update(source.replace(/\r\n?/gu, "\n").trimEnd(), "utf8")
+    .digest("hex");
+}
+
+function isReferenceEntry(entry) {
+  return typeof entry.upstream === "string" && entry.upstream.startsWith("reference/");
+}
+
+function inventoryIdentity(example) {
+  return `${example.source_path}:${example.directive_line}:${example.name ?? "<unnamed>"}`;
+}
+
+function validateInputs(inventory, manifest, lock) {
+  assertObject(inventory, "inventory");
+  assertObject(manifest, "manifest");
+  assertObject(lock, "coverage lock");
+  if (inventory.schema_version !== 1 || !Array.isArray(inventory.examples)) {
+    throw new Error("reference inventory must use schema 1 with an examples array");
+  }
+  if (!Array.isArray(manifest.entries)) {
+    throw new Error("manifest.entries must be an array");
+  }
+  if (lock.schema_version !== 1) {
+    throw new Error(`unsupported reference coverage lock schema ${lock.schema_version}`);
+  }
+  if (!Number.isInteger(lock.minimum_reconciled_examples) || lock.minimum_reconciled_examples < 0) {
+    throw new Error("coverage lock minimum_reconciled_examples must be a non-negative integer");
+  }
+}
+
+export async function reconcileReferenceCoverage(
+  inventory,
+  manifest,
+  lock,
+  { readSource = readFile, repositoryRoot = process.cwd() } = {},
+) {
+  validateInputs(inventory, manifest, lock);
+
+  const byHash = new Map();
+  for (const [index, example] of inventory.examples.entries()) {
+    if (typeof example.source_sha256 !== "string" || !/^[0-9a-f]{64}$/u.test(example.source_sha256)) {
+      throw new Error(`inventory.examples[${index}].source_sha256 is invalid`);
+    }
+    const matches = byHash.get(example.source_sha256) ?? [];
+    matches.push({ index, example });
+    byHash.set(example.source_sha256, matches);
+  }
+
+  const referenceEntries = manifest.entries.filter(isReferenceEntry);
+  const reconciled = [];
+  const classifiedWithoutExactSource = [];
+  const matchedInventoryIndices = new Set();
+
+  for (const entry of referenceEntries) {
+    assertObject(entry, `manifest entry ${entry?.id ?? "<unknown>"}`);
+    if (!CLASSIFIED_STATUSES.has(entry.status)) {
+      throw new Error(
+        `reference manifest entry ${entry.id ?? "<unknown>"} has unsupported status ${entry.status ?? "<missing>"}`,
+      );
+    }
+
+    if (entry.reuse !== EXACT_SOURCE_REUSE) {
+      classifiedWithoutExactSource.push({
+        id: entry.id,
+        title: entry.title ?? null,
+        status: entry.status,
+        upstream: entry.upstream,
+      });
+      continue;
+    }
+    if (typeof entry.upstream_source !== "string" || entry.upstream_source.length === 0) {
+      throw new Error(`exact-source reference entry ${entry.id} is missing upstream_source`);
+    }
+
+    const fixturePath = path.resolve(repositoryRoot, entry.upstream_source);
+    const fixtureSource = await readSource(fixturePath, "utf8");
+    const fixtureHash = normalizedSourceHash(fixtureSource);
+    let matches = byHash.get(fixtureHash) ?? [];
+    if (matches.length > 1 && typeof entry.title === "string") {
+      const named = matches.filter(({ example }) => example.name === entry.title);
+      if (named.length === 1) {
+        matches = named;
+      }
+    }
+    if (matches.length !== 1) {
+      const detail = matches.length === 0 ? "no extracted directive" : `${matches.length} extracted directives`;
+      throw new Error(
+        `reference entry ${entry.id} fixture ${entry.upstream_source} matched ${detail} by source provenance`,
+      );
+    }
+
+    const [{ index, example }] = matches;
+    if (matchedInventoryIndices.has(index)) {
+      throw new Error(`multiple manifest entries map to ${inventoryIdentity(example)}`);
+    }
+    matchedInventoryIndices.add(index);
+    reconciled.push({
+      id: entry.id,
+      title: entry.title ?? null,
+      status: entry.status,
+      upstream: entry.upstream,
+      upstream_source: entry.upstream_source,
+      inventory: {
+        source_path: example.source_path,
+        directive_line: example.directive_line,
+        name: example.name,
+        source_sha256: example.source_sha256,
+      },
+    });
+  }
+
+  if (reconciled.length < lock.minimum_reconciled_examples) {
+    throw new Error(
+      `reference coverage regression: expected at least ${lock.minimum_reconciled_examples} reconciled examples, found ${reconciled.length}`,
+    );
+  }
+
+  return {
+    schema_version: 1,
+    upstream: inventory.upstream,
+    inventory_examples: inventory.examples.length,
+    manifest_reference_entries: referenceEntries.length,
+    reconciled_examples: reconciled.length,
+    classified_without_exact_source: classifiedWithoutExactSource,
+    unclassified_inventory_examples: inventory.examples.length - matchedInventoryIndices.size,
+    reconciled,
+  };
+}
+
+async function main() {
+  const [inventoryPath, manifestPath, lockPath, repositoryRoot = "."] = process.argv.slice(2);
+  if (!inventoryPath || !manifestPath || !lockPath) {
+    throw new Error(
+      "usage: node scripts/manim-reference-coverage.mjs INVENTORY_JSON MANIFEST_JSON COVERAGE_LOCK_JSON [REPOSITORY_ROOT]",
+    );
+  }
+  const [inventory, manifest, lock] = await Promise.all(
+    [inventoryPath, manifestPath, lockPath].map(async (file) => JSON.parse(await readFile(file, "utf8"))),
+  );
+  const report = await reconcileReferenceCoverage(inventory, manifest, lock, {
+    repositoryRoot: path.resolve(repositoryRoot),
+  });
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  await main();
+}

--- a/scripts/manim-reference-coverage.test.mjs
+++ b/scripts/manim-reference-coverage.test.mjs
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  normalizedSourceHash,
+  reconcileReferenceCoverage,
+} from "./manim-reference-coverage.mjs";
+
+const SOURCE_A = "from manim import *\n\nclass DotExample(Scene):\n    pass\n";
+const SOURCE_B = "from manim import *\n\nclass OtherExample(Scene):\n    pass\n";
+
+function inventory(examples) {
+  return {
+    schema_version: 1,
+    upstream: { repository: "ManimCommunity/manim", version: "v0.21.0", revision: "abc" },
+    examples,
+  };
+}
+
+function example(name, source, line = 10) {
+  return {
+    source_path: `docs/source/reference/${name}.py`,
+    directive_line: line,
+    name,
+    source_sha256: normalizedSourceHash(source),
+  };
+}
+
+function manifest(entries) {
+  return { entries };
+}
+
+function exactEntry(overrides = {}) {
+  return {
+    id: "dot-example",
+    title: "DotExample",
+    status: "ready",
+    upstream: "reference/manim.mobject.geometry.arc.Dot.html",
+    upstream_source: "fixtures/dot.py",
+    reuse: "source-equivalent-manim-v0.21",
+    ...overrides,
+  };
+}
+
+function sourceReader(sources) {
+  return async (file) => {
+    const key = file.replaceAll("\\", "/").split("/").at(-1);
+    if (!(key in sources)) {
+      throw new Error(`missing fixture ${key}`);
+    }
+    return sources[key];
+  };
+}
+
+test("normalizes line endings and trailing whitespace before provenance hashing", () => {
+  assert.equal(normalizedSourceHash("a\r\nb\r\n"), normalizedSourceHash("a\nb"));
+});
+
+test("reconciles exact-source reference entries by immutable source provenance", async () => {
+  const report = await reconcileReferenceCoverage(
+    inventory([example("DotExample", SOURCE_A), example("OtherExample", SOURCE_B, 20)]),
+    manifest([
+      exactEntry(),
+      { id: "quickstart", status: "ready", upstream: "tutorials/quickstart.html" },
+    ]),
+    { schema_version: 1, minimum_reconciled_examples: 1 },
+    { readSource: sourceReader({ "dot.py": SOURCE_A }), repositoryRoot: "/repo" },
+  );
+
+  assert.equal(report.inventory_examples, 2);
+  assert.equal(report.manifest_reference_entries, 1);
+  assert.equal(report.reconciled_examples, 1);
+  assert.equal(report.unclassified_inventory_examples, 1);
+  assert.equal(report.reconciled[0].inventory.name, "DotExample");
+});
+
+test("uses the manifest title to disambiguate identical directive source", async () => {
+  const duplicate = example("OtherName", SOURCE_A, 30);
+  const report = await reconcileReferenceCoverage(
+    inventory([example("DotExample", SOURCE_A), duplicate]),
+    manifest([exactEntry()]),
+    { schema_version: 1, minimum_reconciled_examples: 1 },
+    { readSource: sourceReader({ "dot.py": SOURCE_A }), repositoryRoot: "/repo" },
+  );
+
+  assert.equal(report.reconciled[0].inventory.name, "DotExample");
+});
+
+test("fails when an exact-source fixture no longer identifies one pinned directive", async () => {
+  await assert.rejects(
+    reconcileReferenceCoverage(
+      inventory([example("OtherExample", SOURCE_B)]),
+      manifest([exactEntry()]),
+      { schema_version: 1, minimum_reconciled_examples: 0 },
+      { readSource: sourceReader({ "dot.py": SOURCE_A }), repositoryRoot: "/repo" },
+    ),
+    /matched no extracted directive/u,
+  );
+});
+
+test("ratchets the number of reconciled reference examples", async () => {
+  await assert.rejects(
+    reconcileReferenceCoverage(
+      inventory([example("DotExample", SOURCE_A)]),
+      manifest([exactEntry()]),
+      { schema_version: 1, minimum_reconciled_examples: 2 },
+      { readSource: sourceReader({ "dot.py": SOURCE_A }), repositoryRoot: "/repo" },
+    ),
+    /reference coverage regression/u,
+  );
+});
+
+test("keeps blocked/deferred reference classifications visible without inventing source provenance", async () => {
+  const report = await reconcileReferenceCoverage(
+    inventory([example("DotExample", SOURCE_A)]),
+    manifest([
+      {
+        id: "blocked-reference",
+        title: "BlockedReference",
+        status: "blocked",
+        upstream: "reference/manim.example.BlockedReference.html",
+        dependency: "#123",
+      },
+    ]),
+    { schema_version: 1, minimum_reconciled_examples: 0 },
+    { readSource: sourceReader({}), repositoryRoot: "/repo" },
+  );
+
+  assert.equal(report.reconciled_examples, 0);
+  assert.deepEqual(report.classified_without_exact_source, [
+    {
+      id: "blocked-reference",
+      title: "BlockedReference",
+      status: "blocked",
+      upstream: "reference/manim.example.BlockedReference.html",
+    },
+  ]);
+});

--- a/scripts/manim-reference-coverage.test.mjs
+++ b/scripts/manim-reference-coverage.test.mjs
@@ -2,12 +2,15 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  directiveSourceFromFixture,
   normalizedSourceHash,
   reconcileReferenceCoverage,
 } from "./manim-reference-coverage.mjs";
 
-const SOURCE_A = "from manim import *\n\nclass DotExample(Scene):\n    pass\n";
-const SOURCE_B = "from manim import *\n\nclass OtherExample(Scene):\n    pass\n";
+const DIRECTIVE_A = "class DotExample(Scene):\n    pass";
+const DIRECTIVE_B = "class OtherExample(Scene):\n    pass";
+const FIXTURE_A = `from manim import *\n\n${DIRECTIVE_A}\n`;
+const FIXTURE_B = `from manim import *\n\n${DIRECTIVE_B}\n`;
 
 function inventory(examples) {
   return {
@@ -56,15 +59,24 @@ test("normalizes line endings and trailing whitespace before provenance hashing"
   assert.equal(normalizedSourceHash("a\r\nb\r\n"), normalizedSourceHash("a\nb"));
 });
 
+test("removes only the runnable Manim import prelude before directive matching", () => {
+  assert.equal(directiveSourceFromFixture(FIXTURE_A), DIRECTIVE_A);
+  assert.equal(directiveSourceFromFixture(DIRECTIVE_A), DIRECTIVE_A);
+  assert.equal(
+    directiveSourceFromFixture(`import math\n\n${DIRECTIVE_A}\n`),
+    `import math\n\n${DIRECTIVE_A}`,
+  );
+});
+
 test("reconciles exact-source reference entries by immutable source provenance", async () => {
   const report = await reconcileReferenceCoverage(
-    inventory([example("DotExample", SOURCE_A), example("OtherExample", SOURCE_B, 20)]),
+    inventory([example("DotExample", DIRECTIVE_A), example("OtherExample", DIRECTIVE_B, 20)]),
     manifest([
       exactEntry(),
       { id: "quickstart", status: "ready", upstream: "tutorials/quickstart.html" },
     ]),
     { schema_version: 1, minimum_reconciled_examples: 1 },
-    { readSource: sourceReader({ "dot.py": SOURCE_A }), repositoryRoot: "/repo" },
+    { readSource: sourceReader({ "dot.py": FIXTURE_A }), repositoryRoot: "/repo" },
   );
 
   assert.equal(report.inventory_examples, 2);
@@ -75,12 +87,12 @@ test("reconciles exact-source reference entries by immutable source provenance",
 });
 
 test("uses the manifest title to disambiguate identical directive source", async () => {
-  const duplicate = example("OtherName", SOURCE_A, 30);
+  const duplicate = example("OtherName", DIRECTIVE_A, 30);
   const report = await reconcileReferenceCoverage(
-    inventory([example("DotExample", SOURCE_A), duplicate]),
+    inventory([example("DotExample", DIRECTIVE_A), duplicate]),
     manifest([exactEntry()]),
     { schema_version: 1, minimum_reconciled_examples: 1 },
-    { readSource: sourceReader({ "dot.py": SOURCE_A }), repositoryRoot: "/repo" },
+    { readSource: sourceReader({ "dot.py": FIXTURE_A }), repositoryRoot: "/repo" },
   );
 
   assert.equal(report.reconciled[0].inventory.name, "DotExample");
@@ -89,10 +101,10 @@ test("uses the manifest title to disambiguate identical directive source", async
 test("fails when an exact-source fixture no longer identifies one pinned directive", async () => {
   await assert.rejects(
     reconcileReferenceCoverage(
-      inventory([example("OtherExample", SOURCE_B)]),
+      inventory([example("OtherExample", DIRECTIVE_B)]),
       manifest([exactEntry()]),
       { schema_version: 1, minimum_reconciled_examples: 0 },
-      { readSource: sourceReader({ "dot.py": SOURCE_A }), repositoryRoot: "/repo" },
+      { readSource: sourceReader({ "dot.py": FIXTURE_A }), repositoryRoot: "/repo" },
     ),
     /matched no extracted directive/u,
   );
@@ -101,10 +113,10 @@ test("fails when an exact-source fixture no longer identifies one pinned directi
 test("ratchets the number of reconciled reference examples", async () => {
   await assert.rejects(
     reconcileReferenceCoverage(
-      inventory([example("DotExample", SOURCE_A)]),
+      inventory([example("DotExample", DIRECTIVE_A)]),
       manifest([exactEntry()]),
       { schema_version: 1, minimum_reconciled_examples: 2 },
-      { readSource: sourceReader({ "dot.py": SOURCE_A }), repositoryRoot: "/repo" },
+      { readSource: sourceReader({ "dot.py": FIXTURE_A }), repositoryRoot: "/repo" },
     ),
     /reference coverage regression/u,
   );
@@ -112,7 +124,7 @@ test("ratchets the number of reconciled reference examples", async () => {
 
 test("keeps blocked/deferred reference classifications visible without inventing source provenance", async () => {
   const report = await reconcileReferenceCoverage(
-    inventory([example("DotExample", SOURCE_A)]),
+    inventory([example("DotExample", DIRECTIVE_A)]),
     manifest([
       {
         id: "blocked-reference",

--- a/scripts/manim-reference-inventory.mjs
+++ b/scripts/manim-reference-inventory.mjs
@@ -43,7 +43,7 @@ export function extractManimDirectives(text, sourcePath) {
   const examples = [];
 
   for (let index = 0; index < lines.length; index += 1) {
-    const match = lines[index].match(/^(\s*)\.\.\s+manim::(?:\s+(.*?))?\s*$/u);
+    const match = lines[index].match(/^(\s*)\.\.\s+manim\s*::(?:\s+(.*?))?\s*$/u);
     if (!match) {
       continue;
     }

--- a/scripts/manim-reference-inventory.test.mjs
+++ b/scripts/manim-reference-inventory.test.mjs
@@ -27,6 +27,16 @@ test("extracts directive options and source from Python docstrings", () => {
   assert.match(examples[0].source_sha256, /^[0-9a-f]{64}$/u);
 });
 
+test("accepts the spaced manim directive spelling used by pinned ManimCE", () => {
+  const examples = extractManimDirectives(
+    `.. manim :: GrowFromPointExample\n\n    class GrowFromPointExample(Scene):\n        pass\n`,
+    "manim/animation/growing.py",
+  );
+  assert.equal(examples.length, 1);
+  assert.equal(examples[0].name, "GrowFromPointExample");
+  assert.equal(examples[0].source, "class GrowFromPointExample(Scene):\n    pass");
+});
+
 test("supports different directive indentation and multiple examples", () => {
   const input = `.. manim:: First\n    :save_last_frame:\n\n    class First(Scene):\n        pass\n\nText between directives.\n\n    .. manim:: Second\n      class Second(Scene):\n          pass\n`;
   const examples = extractManimDirectives(input, "docs/source/example.rst");

--- a/scripts/manim-reference-ledger.mjs
+++ b/scripts/manim-reference-ledger.mjs
@@ -62,16 +62,14 @@ export function validateReferenceLedger(inventory, ledger) {
   if (!Array.isArray(inventory.examples)) {
     throw new Error("inventory.examples must be an array");
   }
-  if (inventory.examples.length !== ledger.example_count) {
-    throw new Error(
-      `reference example count drift: expected ${ledger.example_count}, extracted ${inventory.examples.length}`,
-    );
-  }
 
   const fingerprint = referenceInventoryFingerprint(inventory.examples);
-  if (fingerprint !== ledger.provenance_sha256) {
+  if (
+    inventory.examples.length !== ledger.example_count ||
+    fingerprint !== ledger.provenance_sha256
+  ) {
     throw new Error(
-      `reference inventory provenance drift: expected ${ledger.provenance_sha256}, extracted ${fingerprint}`,
+      `reference inventory drift: expected count ${ledger.example_count} / ${ledger.provenance_sha256}, extracted count ${inventory.examples.length} / ${fingerprint}`,
     );
   }
 

--- a/scripts/manim-reference-ledger.test.mjs
+++ b/scripts/manim-reference-ledger.test.mjs
@@ -47,12 +47,16 @@ test("accepts an exact pinned reference inventory lock", () => {
   });
 });
 
-test("rejects added or removed pinned examples", () => {
+test("reports count and fingerprint together for added or removed examples", () => {
   const { inventory, ledger } = fixture();
   inventory.examples.pop();
+  const actualFingerprint = referenceInventoryFingerprint(inventory.examples);
   assert.throws(
     () => validateReferenceLedger(inventory, ledger),
-    /reference example count drift: expected 2, extracted 1/u,
+    new RegExp(
+      `reference inventory drift: expected count 2 / ${ledger.provenance_sha256}, extracted count 1 / ${actualFingerprint}`,
+      "u",
+    ),
   );
 });
 
@@ -66,7 +70,7 @@ test("rejects moved, renamed, or source-changed reference examples", () => {
     inventory.examples[0] = mutation(inventory.examples[0]);
     assert.throws(
       () => validateReferenceLedger(inventory, ledger),
-      /reference inventory provenance drift/u,
+      /reference inventory drift/u,
     );
   }
 });


### PR DESCRIPTION
## Summary
- fix the pinned ManimCE v0.21.0 reference extractor to accept both directive spellings used upstream: `.. manim::` and `.. manim ::`
- ratchet the immutable corpus from the previously incomplete 472 directives to the complete 491-directive set and lock its new provenance fingerprint
- reconcile promoted reference-manual examples in the canonical demo manifest with that immutable directive inventory by exact normalized source hash
- normalize only the runnable fixture prelude (`from manim import *`) before matching directive bodies
- reject missing/ambiguous provenance and duplicate manifest mappings rather than relying on brittle HTML-path heuristics
- report reconciled and still-unclassified inventory counts as a CI artifact/step summary
- improve inventory-lock drift diagnostics to report expected/actual count and fingerprint together

## Architecture
The extracted inventory remains the provenance source of truth and `manim_tutorial_manifest.json` remains the canonical coverage/status model. This adds only a join/ratchet between them; it does not create a parallel hand-maintained example ledger.

Exact-source promoted entries are joined using their checked-in `upstream_source` bytes. Runnable fixture line endings/trailing whitespace are normalized and the exact leading `from manim import *` prelude is removed because the upstream `.. manim::` directive stores only the directive body. The resulting body is SHA-256 matched to the pinned corpus; manifest title is used only to disambiguate genuinely duplicate source blobs.

The extractor correction is intentionally part of this PR because the real reconciliation exposed that 19 pinned examples used Manim's valid spaced `manim ::` spelling and had never entered the old lock.

Blocked/deferred reference entries without an exact checked-in fixture remain visible in the report but are not assigned invented provenance. A later #256 tranche can add explicit stable inventory identities as those examples are classified.

## Validation
Fresh exact-head CI is required. The dedicated Manim reference workflow is the acceptance gate because it checks out immutable commit `861cd4849b17db1db3515b531ffe80b297848f93`, verifies the 491-example lock, and performs the real reconciliation.

Tracks #256.