### PR TITLE
Classify pinned Manim references by provenance

### DIFF
--- a/compat/manim-v0.21.0-reference-coverage-lock.json
+++ b/compat/manim-v0.21.0-reference-coverage-lock.json
@@ -1,4 +1,5 @@
 {
-  "schema_version": 1,
-  "minimum_reconciled_examples": 20
+  "schema_version": 2,
+  "minimum_reconciled_examples": 20,
+  "minimum_classified_examples": 20
 }

--- a/scripts/manim-reference-coverage.mjs
+++ b/scripts/manim-reference-coverage.mjs
@@ -9,6 +9,7 @@ const CLASSIFIED_STATUSES = new Set([
   "deferred",
   "intentional-divergence",
 ]);
+const PROVENANCE_ONLY_STATUSES = new Set(["blocked", "deferred"]);
 const EXACT_SOURCE_REUSE = "source-equivalent-manim-v0.21";
 const MANIM_IMPORT_PRELUDE = "from manim import *";
 
@@ -50,6 +51,40 @@ function inventoryIdentity(example) {
   return `${example.source_path}:${example.directive_line}:${example.name ?? "<unnamed>"}`;
 }
 
+function validateProvenance(value, name) {
+  assertObject(value, name);
+  if (typeof value.source_path !== "string" || value.source_path.length === 0) {
+    throw new Error(`${name}.source_path must be a non-empty string`);
+  }
+  if (!Number.isInteger(value.directive_line) || value.directive_line < 1) {
+    throw new Error(`${name}.directive_line must be a positive integer`);
+  }
+  if (value.name !== null && typeof value.name !== "string") {
+    throw new Error(`${name}.name must be a string or null`);
+  }
+  if (typeof value.source_sha256 !== "string" || !/^[0-9a-f]{64}$/u.test(value.source_sha256)) {
+    throw new Error(`${name}.source_sha256 must be a lowercase SHA-256 digest`);
+  }
+}
+
+function provenanceKey(value) {
+  return JSON.stringify([
+    value.source_path,
+    value.directive_line,
+    value.name,
+    value.source_sha256,
+  ]);
+}
+
+function inventoryProjection(example) {
+  return {
+    source_path: example.source_path,
+    directive_line: example.directive_line,
+    name: example.name,
+    source_sha256: example.source_sha256,
+  };
+}
+
 function validateInputs(inventory, manifest, lock) {
   assertObject(inventory, "inventory");
   assertObject(manifest, "manifest");
@@ -60,11 +95,19 @@ function validateInputs(inventory, manifest, lock) {
   if (!Array.isArray(manifest.entries)) {
     throw new Error("manifest.entries must be an array");
   }
-  if (lock.schema_version !== 1) {
+  if (lock.schema_version !== 2) {
     throw new Error(`unsupported reference coverage lock schema ${lock.schema_version}`);
   }
   if (!Number.isInteger(lock.minimum_reconciled_examples) || lock.minimum_reconciled_examples < 0) {
     throw new Error("coverage lock minimum_reconciled_examples must be a non-negative integer");
+  }
+  if (!Number.isInteger(lock.minimum_classified_examples) || lock.minimum_classified_examples < 0) {
+    throw new Error("coverage lock minimum_classified_examples must be a non-negative integer");
+  }
+  if (lock.minimum_classified_examples < lock.minimum_reconciled_examples) {
+    throw new Error(
+      "coverage lock minimum_classified_examples must be at least minimum_reconciled_examples",
+    );
   }
 }
 
@@ -77,19 +120,32 @@ export async function reconcileReferenceCoverage(
   validateInputs(inventory, manifest, lock);
 
   const byHash = new Map();
+  const byProvenance = new Map();
   for (const [index, example] of inventory.examples.entries()) {
-    if (typeof example.source_sha256 !== "string" || !/^[0-9a-f]{64}$/u.test(example.source_sha256)) {
-      throw new Error(`inventory.examples[${index}].source_sha256 is invalid`);
-    }
+    validateProvenance(example, `inventory.examples[${index}]`);
     const matches = byHash.get(example.source_sha256) ?? [];
     matches.push({ index, example });
     byHash.set(example.source_sha256, matches);
+
+    const key = provenanceKey(example);
+    if (byProvenance.has(key)) {
+      throw new Error(`duplicate inventory provenance for ${inventoryIdentity(example)}`);
+    }
+    byProvenance.set(key, { index, example });
   }
 
   const referenceEntries = manifest.entries.filter(isReferenceEntry);
   const reconciled = [];
+  const provenanceClassified = [];
   const classifiedWithoutExactSource = [];
   const matchedInventoryIndices = new Set();
+
+  function claimInventory(index, example) {
+    if (matchedInventoryIndices.has(index)) {
+      throw new Error(`multiple manifest entries map to ${inventoryIdentity(example)}`);
+    }
+    matchedInventoryIndices.add(index);
+  }
 
   for (const entry of referenceEntries) {
     assertObject(entry, `manifest entry ${entry?.id ?? "<unknown>"}`);
@@ -99,14 +155,44 @@ export async function reconcileReferenceCoverage(
       );
     }
 
+    const hasProvenance = entry.reference_provenance !== undefined;
     if (entry.reuse !== EXACT_SOURCE_REUSE) {
-      classifiedWithoutExactSource.push({
+      if (!hasProvenance) {
+        classifiedWithoutExactSource.push({
+          id: entry.id,
+          title: entry.title ?? null,
+          status: entry.status,
+          upstream: entry.upstream,
+        });
+        continue;
+      }
+      if (!PROVENANCE_ONLY_STATUSES.has(entry.status)) {
+        throw new Error(
+          `provenance-only reference entry ${entry.id} must be blocked or deferred, got ${entry.status}`,
+        );
+      }
+      validateProvenance(entry.reference_provenance, `reference entry ${entry.id}.reference_provenance`);
+      const matched = byProvenance.get(provenanceKey(entry.reference_provenance));
+      if (matched === undefined) {
+        throw new Error(
+          `reference entry ${entry.id} provenance does not match one pinned directive`,
+        );
+      }
+      claimInventory(matched.index, matched.example);
+      provenanceClassified.push({
         id: entry.id,
         title: entry.title ?? null,
         status: entry.status,
         upstream: entry.upstream,
+        inventory: inventoryProjection(matched.example),
       });
       continue;
+    }
+
+    if (hasProvenance) {
+      throw new Error(
+        `exact-source reference entry ${entry.id} must not also set reference_provenance`,
+      );
     }
     if (typeof entry.upstream_source !== "string" || entry.upstream_source.length === 0) {
       throw new Error(`exact-source reference entry ${entry.id} is missing upstream_source`);
@@ -130,22 +216,14 @@ export async function reconcileReferenceCoverage(
     }
 
     const [{ index, example }] = matches;
-    if (matchedInventoryIndices.has(index)) {
-      throw new Error(`multiple manifest entries map to ${inventoryIdentity(example)}`);
-    }
-    matchedInventoryIndices.add(index);
+    claimInventory(index, example);
     reconciled.push({
       id: entry.id,
       title: entry.title ?? null,
       status: entry.status,
       upstream: entry.upstream,
       upstream_source: entry.upstream_source,
-      inventory: {
-        source_path: example.source_path,
-        directive_line: example.directive_line,
-        name: example.name,
-        source_sha256: example.source_sha256,
-      },
+      inventory: inventoryProjection(example),
     });
   }
 
@@ -154,15 +232,23 @@ export async function reconcileReferenceCoverage(
       `reference coverage regression: expected at least ${lock.minimum_reconciled_examples} reconciled examples, found ${reconciled.length}`,
     );
   }
+  if (matchedInventoryIndices.size < lock.minimum_classified_examples) {
+    throw new Error(
+      `reference classification regression: expected at least ${lock.minimum_classified_examples} classified examples, found ${matchedInventoryIndices.size}`,
+    );
+  }
 
   return {
-    schema_version: 1,
+    schema_version: 2,
     upstream: inventory.upstream,
     inventory_examples: inventory.examples.length,
     manifest_reference_entries: referenceEntries.length,
     reconciled_examples: reconciled.length,
+    provenance_classified_examples: provenanceClassified.length,
+    classified_examples: matchedInventoryIndices.size,
     classified_without_exact_source: classifiedWithoutExactSource,
     unclassified_inventory_examples: inventory.examples.length - matchedInventoryIndices.size,
+    provenance_classified: provenanceClassified,
     reconciled,
   };
 }

--- a/scripts/manim-reference-coverage.test.mjs
+++ b/scripts/manim-reference-coverage.test.mjs
@@ -22,7 +22,7 @@ function inventory(examples) {
 
 function example(name, source, line = 10) {
   return {
-    source_path: `docs/source/reference/${name}.py`,
+    source_path: `manim/example/${name}.py`,
     directive_line: line,
     name,
     source_sha256: normalizedSourceHash(source),
@@ -33,6 +33,14 @@ function manifest(entries) {
   return { entries };
 }
 
+function coverageLock(minimumReconciled = 0, minimumClassified = minimumReconciled) {
+  return {
+    schema_version: 2,
+    minimum_reconciled_examples: minimumReconciled,
+    minimum_classified_examples: minimumClassified,
+  };
+}
+
 function exactEntry(overrides = {}) {
   return {
     id: "dot-example",
@@ -41,6 +49,26 @@ function exactEntry(overrides = {}) {
     upstream: "reference/manim.mobject.geometry.arc.Dot.html",
     upstream_source: "fixtures/dot.py",
     reuse: "source-equivalent-manim-v0.21",
+    ...overrides,
+  };
+}
+
+function provenanceFor(value) {
+  return {
+    source_path: value.source_path,
+    directive_line: value.directive_line,
+    name: value.name,
+    source_sha256: value.source_sha256,
+  };
+}
+
+function classifiedEntry(value, overrides = {}) {
+  return {
+    id: "blocked-reference",
+    title: value.name,
+    status: "blocked",
+    upstream: `reference/manim.example.${value.name}.html`,
+    reference_provenance: provenanceFor(value),
     ...overrides,
   };
 }
@@ -75,13 +103,15 @@ test("reconciles exact-source reference entries by immutable source provenance",
       exactEntry(),
       { id: "quickstart", status: "ready", upstream: "tutorials/quickstart.html" },
     ]),
-    { schema_version: 1, minimum_reconciled_examples: 1 },
+    coverageLock(1, 1),
     { readSource: sourceReader({ "dot.py": FIXTURE_A }), repositoryRoot: "/repo" },
   );
 
   assert.equal(report.inventory_examples, 2);
   assert.equal(report.manifest_reference_entries, 1);
   assert.equal(report.reconciled_examples, 1);
+  assert.equal(report.provenance_classified_examples, 0);
+  assert.equal(report.classified_examples, 1);
   assert.equal(report.unclassified_inventory_examples, 1);
   assert.equal(report.reconciled[0].inventory.name, "DotExample");
 });
@@ -91,7 +121,7 @@ test("uses the manifest title to disambiguate identical directive source", async
   const report = await reconcileReferenceCoverage(
     inventory([example("DotExample", DIRECTIVE_A), duplicate]),
     manifest([exactEntry()]),
-    { schema_version: 1, minimum_reconciled_examples: 1 },
+    coverageLock(1, 1),
     { readSource: sourceReader({ "dot.py": FIXTURE_A }), repositoryRoot: "/repo" },
   );
 
@@ -103,7 +133,7 @@ test("fails when an exact-source fixture no longer identifies one pinned directi
     reconcileReferenceCoverage(
       inventory([example("OtherExample", DIRECTIVE_B)]),
       manifest([exactEntry()]),
-      { schema_version: 1, minimum_reconciled_examples: 0 },
+      coverageLock(),
       { readSource: sourceReader({ "dot.py": FIXTURE_A }), repositoryRoot: "/repo" },
     ),
     /matched no extracted directive/u,
@@ -115,14 +145,14 @@ test("ratchets the number of reconciled reference examples", async () => {
     reconcileReferenceCoverage(
       inventory([example("DotExample", DIRECTIVE_A)]),
       manifest([exactEntry()]),
-      { schema_version: 1, minimum_reconciled_examples: 2 },
+      coverageLock(2, 2),
       { readSource: sourceReader({ "dot.py": FIXTURE_A }), repositoryRoot: "/repo" },
     ),
     /reference coverage regression/u,
   );
 });
 
-test("keeps blocked/deferred reference classifications visible without inventing source provenance", async () => {
+test("keeps unprovenanced blocked/deferred reference entries visible but unclassified", async () => {
   const report = await reconcileReferenceCoverage(
     inventory([example("DotExample", DIRECTIVE_A)]),
     manifest([
@@ -134,11 +164,13 @@ test("keeps blocked/deferred reference classifications visible without inventing
         dependency: "#123",
       },
     ]),
-    { schema_version: 1, minimum_reconciled_examples: 0 },
+    coverageLock(),
     { readSource: sourceReader({}), repositoryRoot: "/repo" },
   );
 
   assert.equal(report.reconciled_examples, 0);
+  assert.equal(report.provenance_classified_examples, 0);
+  assert.equal(report.classified_examples, 0);
   assert.deepEqual(report.classified_without_exact_source, [
     {
       id: "blocked-reference",
@@ -147,4 +179,96 @@ test("keeps blocked/deferred reference classifications visible without inventing
       upstream: "reference/manim.example.BlockedReference.html",
     },
   ]);
+});
+
+test("classifies blocked/deferred reference entries by immutable inventory provenance", async () => {
+  const blocked = example("DashedLineExample", DIRECTIVE_A);
+  const deferred = example("TangentLineExample", DIRECTIVE_B, 20);
+  const report = await reconcileReferenceCoverage(
+    inventory([blocked, deferred]),
+    manifest([
+      classifiedEntry(blocked),
+      classifiedEntry(deferred, {
+        id: "deferred-reference",
+        status: "deferred",
+      }),
+    ]),
+    coverageLock(0, 2),
+    { readSource: sourceReader({}), repositoryRoot: "/repo" },
+  );
+
+  assert.equal(report.reconciled_examples, 0);
+  assert.equal(report.provenance_classified_examples, 2);
+  assert.equal(report.classified_examples, 2);
+  assert.equal(report.unclassified_inventory_examples, 0);
+  assert.deepEqual(
+    report.provenance_classified.map((entry) => entry.inventory.name),
+    ["DashedLineExample", "TangentLineExample"],
+  );
+});
+
+test("rejects provenance-only ready entries so supported examples keep exact-source proof", async () => {
+  const pinned = example("DotExample", DIRECTIVE_A);
+  await assert.rejects(
+    reconcileReferenceCoverage(
+      inventory([pinned]),
+      manifest([classifiedEntry(pinned, { status: "ready" })]),
+      coverageLock(),
+      { readSource: sourceReader({}), repositoryRoot: "/repo" },
+    ),
+    /must be blocked or deferred/u,
+  );
+});
+
+test("rejects stale provenance-only classifications", async () => {
+  const pinned = example("DashedLineExample", DIRECTIVE_A);
+  const stale = provenanceFor(pinned);
+  stale.directive_line += 1;
+  await assert.rejects(
+    reconcileReferenceCoverage(
+      inventory([pinned]),
+      manifest([classifiedEntry(pinned, { reference_provenance: stale })]),
+      coverageLock(),
+      { readSource: sourceReader({}), repositoryRoot: "/repo" },
+    ),
+    /does not match one pinned directive/u,
+  );
+});
+
+test("rejects duplicate claims across exact-source and provenance-only entries", async () => {
+  const pinned = example("DotExample", DIRECTIVE_A);
+  await assert.rejects(
+    reconcileReferenceCoverage(
+      inventory([pinned]),
+      manifest([exactEntry(), classifiedEntry(pinned)]),
+      coverageLock(1, 1),
+      { readSource: sourceReader({ "dot.py": FIXTURE_A }), repositoryRoot: "/repo" },
+    ),
+    /multiple manifest entries map/u,
+  );
+});
+
+test("ratchets total classified inventory independently from exact-source reconciliation", async () => {
+  const pinned = example("DashedLineExample", DIRECTIVE_A);
+  await assert.rejects(
+    reconcileReferenceCoverage(
+      inventory([pinned]),
+      manifest([classifiedEntry(pinned)]),
+      coverageLock(0, 2),
+      { readSource: sourceReader({}), repositoryRoot: "/repo" },
+    ),
+    /reference classification regression/u,
+  );
+});
+
+test("requires the classification ratchet to cover the exact-source ratchet", async () => {
+  await assert.rejects(
+    reconcileReferenceCoverage(
+      inventory([]),
+      manifest([]),
+      coverageLock(2, 1),
+      { readSource: sourceReader({}), repositoryRoot: "/repo" },
+    ),
+    /minimum_classified_examples must be at least minimum_reconciled_examples/u,
+  );
 });


### PR DESCRIPTION
## Summary
- extend the canonical pinned-Manim coverage reconciler with immutable provenance-only classification for blocked/deferred reference examples
- keep exact-source runnable reconciliation strict and independently ratcheted
- reject stale provenance, duplicate exact/provenance claims, and provenance-only `ready` entries
- add a separate total-classified ratchet without weakening the existing 20 exact-source examples on current master

## Architecture
This stays inside the existing `manim_tutorial_manifest.json` + extracted-inventory model. It does not introduce a second classification ledger. A future blocked/deferred manifest entry may carry `reference_provenance` (`source_path`, `directive_line`, `name`, `source_sha256`) and is counted only when that tuple exactly matches the immutable v0.21.0 inventory. Runnable/supported examples still require the existing exact-source fixture path and reuse contract.

The coverage report remains diagnostic about unprovenanced reference entries, while separately reporting exact reconciled, provenance-classified, total classified, and remaining unclassified counts.

## Validation
- focused Node suite: 13/13 passing before restack
- previous exact head was fully green across CI, coverage, semantic/raster differentials, and reference inventory
- restacked exact head `1a85611e296e0cba48a61717eb950addef4d0e8c` preserves current master’s 20-example exact-source ratchet; fresh exact-head GitHub CI is required before merge

## Follow-up
Pinned `DashedLineExample` (`manim/mobject/geometry/line.py:302`, SHA `313b8f…`) and `TangentLineExample` (`line.py:435`, SHA `a799c7…`) have been verified as suitable first blocked classifications under #77 once the canonical manifest is updated in a non-conflicting write.

Tracks #256.