### PR TITLE
Gate playground cold-start WASM topology

### DIFF
--- a/web/playground-cold-start-topology.test.mjs
+++ b/web/playground-cold-start-topology.test.mjs
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+class FakeCanvas {
+  clientWidth = 640;
+  clientHeight = 360;
+  width = 640;
+  height = 360;
+
+  transferControlToOffscreen() {
+    return { width: this.width, height: this.height };
+  }
+}
+
+class FakeMessageChannel {
+  constructor() {
+    this.port1 = {};
+    this.port2 = {};
+  }
+}
+
+class FakeWorker {
+  static instances = [];
+
+  constructor(url, options = {}) {
+    this.url = String(url);
+    this.name = options.name ?? "";
+    FakeWorker.instances.push(this);
+  }
+
+  addEventListener() {}
+  postMessage() {}
+  terminate() {}
+}
+
+globalThis.HTMLCanvasElement = FakeCanvas;
+globalThis.MessageChannel = FakeMessageChannel;
+globalThis.Worker = FakeWorker;
+globalThis.window = { devicePixelRatio: 1 };
+
+const [{ PythonAuthoringClient }, { AuthoringExecutionClient }] = await Promise.all([
+  import("./authoring-client.js"),
+  import("./authoring-execution-client.js"),
+]);
+
+const authoring = new PythonAuthoringClient();
+authoring.ready().catch(() => {});
+const execution = new AuthoringExecutionClient(new FakeCanvas());
+execution
+  .start(JSON.stringify({ version: 1, objects: [], tracks: [] }), {
+    transportMode: "transferable",
+  })
+  .catch(() => {});
+
+const coldWorkers = FakeWorker.instances.map(({ url, name }) => ({
+  url: new URL(url),
+  name,
+}));
+
+assert.ok(coldWorkers.length > 0, "cold Run must create at least one worker owner");
+assert.ok(
+  coldWorkers.length <= 3,
+  `cold Run must not grow beyond the current three worker owners: ${coldWorkers
+    .map(({ name, url }) => `${name || "<unnamed>"}=${url.pathname.split("/").at(-1)}`)
+    .join(", ")}`,
+);
+
+const STATIC_IMPORT = /\b(?:import|export)\s+(?:[^"'()]*?\s+from\s*)?["'](\.[^"']+)["']/gu;
+const DYNAMIC_IMPORT = /\bimport\s*\(\s*["'](\.[^"']+)["']\s*\)/gu;
+const NOON_WASM_PATH = "/pkg/noon_web.js";
+
+async function readWorkerSource(moduleUrl) {
+  try {
+    return await readFile(moduleUrl, "utf8");
+  } catch (error) {
+    if (error?.code !== "ENOENT" || !moduleUrl.pathname.endsWith("/python-worker.js")) {
+      throw error;
+    }
+    return readFile(new URL("./python-worker.source.js", moduleUrl), "utf8");
+  }
+}
+
+async function workerDependencyReport(entryUrl) {
+  const visited = new Set();
+  let sourceBytes = 0;
+  let ownsNoonWasm = false;
+
+  async function visit(moduleUrl) {
+    if (visited.has(moduleUrl.href)) {
+      return;
+    }
+    visited.add(moduleUrl.href);
+    const source = await readWorkerSource(moduleUrl);
+    sourceBytes += Buffer.byteLength(source, "utf8");
+
+    const imports = [
+      ...source.matchAll(STATIC_IMPORT),
+      ...source.matchAll(DYNAMIC_IMPORT),
+    ].map((match) => new URL(match[1], moduleUrl));
+    for (const dependency of imports) {
+      if (dependency.pathname.endsWith(NOON_WASM_PATH)) {
+        ownsNoonWasm = true;
+        continue;
+      }
+      if (/\.(?:m?js)$/u.test(dependency.pathname)) {
+        await visit(dependency);
+      }
+    }
+  }
+
+  await visit(entryUrl);
+  return {
+    entry: entryUrl.pathname.split("/").at(-1),
+    sourceBytes,
+    ownsNoonWasm,
+  };
+}
+
+const workerReports = await Promise.all(
+  coldWorkers.map(async ({ url, name }) => ({
+    name,
+    ...(await workerDependencyReport(url)),
+  })),
+);
+const noonWasmOwners = workerReports.filter(({ ownsNoonWasm }) => ownsNoonWasm);
+
+assert.ok(
+  noonWasmOwners.length <= 3,
+  `cold Run must not grow beyond the current three monolithic Noon WASM owners: ${noonWasmOwners
+    .map(({ entry }) => entry)
+    .join(", ")}`,
+);
+
+const report = {
+  workerCount: workerReports.length,
+  workerEntries: workerReports.map(({ entry }) => entry),
+  noonWasmOwnerCount: noonWasmOwners.length,
+  noonWasmOwners: noonWasmOwners.map(({ entry }) => entry),
+  workerReachableSourceBytes: workerReports.reduce((total, { sourceBytes }) => total + sourceBytes, 0),
+};
+
+assert.ok(
+  report.workerReachableSourceBytes > 0,
+  "cold-start topology report must include reachable worker source bytes",
+);
+
+console.log(`✓ cold-start topology ${JSON.stringify(report)}`);


### PR DESCRIPTION
## Summary
- add a self-registering web regression that observes the workers actually constructed by the first-Run authoring/execution path
- recursively follow each worker entrypoint's local JS imports to identify independent monolithic `noon_web.js` owners, including compatibility entrypoints such as `execution-render-worker.js -> authoring-render-worker.js`
- report worker count/entrypoints, monolithic Noon WASM owner count/names, and reachable worker source bytes in deterministic CI output
- prevent cold startup from growing beyond the current three workers / three independent monolithic WASM owners while allowing future consolidation to reduce either count

## Why this slice
#642 identifies duplicate worker/WASM startup as a major remaining cold-start cost. Before changing orchestration or splitting WASM surfaces, this gives the existing web build a cheap structural baseline that future startup work can ratchet downward without a wall-clock threshold or per-frame metrics loop.

## Design
The test instantiates the real `PythonAuthoringClient` and `AuthoringExecutionClient` under fake browser primitives and records `new Worker(...)` calls from the production startup path. WASM ownership is then derived from each observed worker's reachable local module graph, so a newly introduced worker cannot hide behind a hard-coded filename inventory.

`python-worker.js` is generated by `scripts/build-web-demo.sh`, but the generic JavaScript coverage workflow executes `web/*.test.mjs` directly from a clean checkout. The guard therefore still observes the production `python-worker.js` Worker URL, while static dependency inspection falls back to the checked-in `python-worker.source.js` only when that generated file is absent. Other missing worker modules remain hard failures.

The guard deliberately does not require any worker to keep importing the monolithic `noon_web.js` package. A future split into specialized authoring/engine/renderer WASM surfaces may legitimately drive the monolithic-owner count to zero.

## Current baseline
The generated-worker Web-package run on head `95d0493a…` measured:
- 3 first-Run workers: `python-worker.js`, `execution-engine-worker.js`, `execution-render-worker.js`
- 3 monolithic `noon_web.js` owners
- 84,318 reachable worker JS bytes

## Validation
- generated-worker Web package passed with the topology guard above
- previous coverage failure was isolated to missing generated `web/python-worker.js`; fixed at head `7c6e06f0d77a004c359d79a18471b9c0b65861e9`
- fresh exact-head CI is required before merge

## Scope / risk
Test-only; no runtime behavior changes. This deliberately does **not** lock in the legacy-first startup sequence or require exactly three workers/WASM owners: worker consolidation to two/one and monolithic-WASM consolidation/splitting down to zero owners remain compatible.

Tracks #642.