### PR TITLE
Overlap Python authoring with cold runtime startup

### DIFF
--- a/scripts/playground-playback-controls-smoke.mjs
+++ b/scripts/playground-playback-controls-smoke.mjs
@@ -279,13 +279,34 @@ try {
       .find((id) => id && id !== selected);
   });
   assert.ok(targetExampleId, "gallery must expose another example");
+  await page.evaluate(() => {
+    let releaseSwitch;
+    const switchGate = new Promise((resolve) => {
+      releaseSwitch = resolve;
+    });
+    globalThis.__NOON_PLAYGROUND_TEST_HOOKS__ ??= {};
+    globalThis.__NOON_PLAYGROUND_TEST_HOOKS__.beforeReconcile = async () => {
+      document.documentElement.dataset.playbackSwitchGate = "reached";
+      await switchGate;
+    };
+    globalThis.__NOON_RELEASE_PLAYBACK_SWITCH__ = releaseSwitch;
+  });
   await page.locator(`.example-card[data-example-id="${targetExampleId}"]`).click();
-  await page.waitForFunction(() => document.querySelector(".playback-controls")?.dataset.busy === "true");
+  await page.waitForFunction(
+    () => document.documentElement.dataset.playbackSwitchGate === "reached",
+  );
   const busy = await playbackSnapshot(page);
   diagnostics.busy = busy;
+  assert.equal(busy.busy, "true");
   assert.equal(busy.playDisabled, true);
   assert.equal(busy.restartDisabled, true);
   assert.equal(busy.scrubberDisabled, true);
+  await page.evaluate(() => {
+    globalThis.__NOON_RELEASE_PLAYBACK_SWITCH__?.();
+    delete globalThis.__NOON_RELEASE_PLAYBACK_SWITCH__;
+    delete globalThis.__NOON_PLAYGROUND_TEST_HOOKS__?.beforeReconcile;
+    delete document.documentElement.dataset.playbackSwitchGate;
+  });
   await waitForAppliedScene(page, targetExampleId);
   await page.waitForFunction(() => document.querySelector(".playback-controls")?.dataset.busy === "false");
   const switched = await playbackSnapshot(page);

--- a/web/main.js
+++ b/web/main.js
@@ -679,29 +679,49 @@ async function runScene() {
   const releaseBusy = beginBusy();
   const task = (async () => {
     try {
-      await ensureRuntimeReady();
-      if (!isCurrentRun(runToken)) return recordStale(runToken, "after-runtime-start");
-      await ensureExecutionReady();
-      if (!isCurrentRun(runToken)) return recordStale(runToken, "after-restart");
+      const runtimeTask = (async () => {
+        await ensureRuntimeReady();
+        if (!isCurrentRun(runToken)) return "after-runtime-start";
+        await ensureExecutionReady();
+        if (!isCurrentRun(runToken)) return "after-restart";
+        return null;
+      })();
 
       patchStatus.value = `Building ${example.title} in the Python worker…`;
       patchStatus.dataset.state = "running";
       const client = ensureAuthoringClient();
-      let authored;
-      try {
-        authored = await client.run(source, {
+      const authoringTask = client
+        .run(source, {
           playground: {
             example_id: example.id,
             selection_generation: runToken.selectionGeneration,
             run_generation: runToken.runGeneration,
           },
+        })
+        .catch((error) => {
+          if (client.terminated && authoringClient === client) {
+            authoringClient = null;
+          }
+          throw error;
         });
-      } catch (error) {
-        if (client.terminated && authoringClient === client) {
-          authoringClient = null;
-        }
-        throw error;
+
+      // Source authoring and the GPU/execution startup are independent until
+      // reconciliation. Keep both in flight on a cold Run, but wait for both
+      // to settle so a failure cannot leave an unobserved sibling task behind.
+      const [runtimeOutcome, authoringOutcome] = await Promise.allSettled([
+        runtimeTask,
+        authoringTask,
+      ]);
+      if (runtimeOutcome.status === "rejected") {
+        throw runtimeOutcome.reason;
       }
+      if (runtimeOutcome.value !== null) {
+        return recordStale(runToken, runtimeOutcome.value);
+      }
+      if (authoringOutcome.status === "rejected") {
+        throw authoringOutcome.reason;
+      }
+      const authored = authoringOutcome.value;
 
       await runPlaygroundTestHook("afterAuthoring", {
         exampleId: example.id,

--- a/web/playground-first-run-overlap.test.mjs
+++ b/web/playground-first-run-overlap.test.mjs
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const main = await readFile(new URL("./main.js", import.meta.url), "utf8");
+const runSceneStart = main.indexOf("async function runScene()");
+const selectExampleStart = main.indexOf("async function selectExample(", runSceneStart);
+assert.ok(runSceneStart >= 0 && selectExampleStart > runSceneStart, "runScene boundary must exist");
+const runSceneBody = main.slice(runSceneStart, selectExampleStart);
+
+const runtimeTaskStart = runSceneBody.indexOf("const runtimeTask = (async () => {");
+const runtimeReady = runSceneBody.indexOf("await ensureRuntimeReady();", runtimeTaskStart);
+const executionReady = runSceneBody.indexOf("await ensureExecutionReady();", runtimeReady);
+const runtimeTaskEnd = runSceneBody.indexOf("})();", executionReady);
+const authoringTaskStart = runSceneBody.indexOf("const authoringTask = client", runtimeTaskEnd);
+const authoringRun = runSceneBody.indexOf(".run(source,", authoringTaskStart);
+const joinBarrier = runSceneBody.indexOf("await Promise.allSettled([", authoringRun);
+
+assert.ok(runtimeTaskStart >= 0, "Run must create an execution-startup task");
+assert.ok(runtimeReady > runtimeTaskStart, "execution-startup task must start the deferred runtime");
+assert.ok(
+  executionReady > runtimeReady && executionReady < runtimeTaskEnd,
+  "execution recovery must remain sequenced after runtime startup inside the execution task",
+);
+assert.ok(
+  authoringTaskStart > runtimeTaskEnd && authoringRun > authoringTaskStart,
+  "Run must start source authoring as a sibling task after execution startup has been kicked off",
+);
+assert.ok(
+  joinBarrier > authoringRun,
+  "Run must not wait for execution startup before submitting source authoring",
+);
+
+const joinBody = runSceneBody.slice(joinBarrier, runSceneBody.indexOf("]);", joinBarrier) + 3);
+assert.match(joinBody, /runtimeTask,\s*authoringTask,/, "reconciliation barrier must join both startup tasks");
+assert.doesNotMatch(
+  runSceneBody.slice(runtimeTaskEnd, authoringTaskStart),
+  /await\s+(?:runtimeTask|ensureRuntimeReady\(\)|ensureExecutionReady\(\))/,
+  "source authoring must not be serialized behind execution readiness",
+);
+assert.ok(
+  runSceneBody.indexOf("player.reconcileScene(", joinBarrier) > joinBarrier,
+  "scene reconciliation must remain after the joined startup barrier",
+);
+
+console.log("✓ playground overlaps Python source authoring with cold execution startup");


### PR DESCRIPTION
## Superseded by #646 + #645

This PR proved that Python authoring can safely overlap execution startup, but its concrete cold path overlaps authoring with the existing speculative empty **legacy** engine bootstrap. #646 removes that wrong-engine bootstrap entirely, which is the stronger architectural step and avoids retained first-run legacy -> retained churn.

The useful overlap objective remains part of #642 and will be recovered after #646 using #645's mode-free persistent render-owner preparation, so we can overlap Python/Pyodide work with only mode-independent GPU/WASM preparation rather than booting an engine before the authored mode is known.

The deterministic playback-control smoke fix discovered here remains available on the branch if the direct-mode path exposes the same timing edge.

Original implementation details:
- start selected Python authoring while deferred execution startup proceeds
- join both siblings with `Promise.allSettled`
- preserve stale-generation checks and reconciliation ordering
- deterministic playback busy assertion via the existing `beforeReconcile` test hook

Closed without merge in favor of the cleaner #646 -> #645 -> mode-free overlap sequence. Tracks #642.