### PR TITLE
Start cold playground runs in the authored engine mode

### DIFF
--- a/web/authoring-execution-client.js
+++ b/web/authoring-execution-client.js
@@ -89,7 +89,48 @@ export class AuthoringExecutionClient {
     if (transportMode !== undefined) {
       options.transportMode = transportMode;
     }
-    const ready = await this.#startLegacy(sceneJson, options);
+    const ready = await this.#startMode(
+      AUTHORING_EXECUTION_LEGACY,
+      sceneJson,
+      null,
+      options,
+    );
+    this.#transportMode = ready.transportMode;
+    return ready;
+  }
+
+  async startRetained(
+    sceneJson,
+    retainedDocumentJson,
+    {
+      loopDurationSeconds = DEFAULT_LOOP_DURATION_SECONDS,
+      transportMode = undefined,
+      sharedSlotCapacity = DEFAULT_SHARED_SLOT_CAPACITY,
+    } = {},
+  ) {
+    if (this.#player !== null || this.#transition !== null) {
+      throw new Error("AuthoringExecutionClient is already started");
+    }
+    validateSceneJson(sceneJson);
+    const retainedDocument = validateRetainedDocumentJson(retainedDocumentJson);
+    if (retainedDocument.objects.length === 0) {
+      throw new TypeError("retained startup requires at least one retained object");
+    }
+    this.#loopDurationSeconds = validateLoopDurationSeconds(loopDurationSeconds);
+    this.#sharedSlotCapacity = validateSharedSlotCapacity(sharedSlotCapacity);
+    const options = {
+      loopDurationSeconds: this.#loopDurationSeconds,
+      sharedSlotCapacity: this.#sharedSlotCapacity,
+    };
+    if (transportMode !== undefined) {
+      options.transportMode = transportMode;
+    }
+    const ready = await this.#startMode(
+      AUTHORING_EXECUTION_RETAINED,
+      sceneJson,
+      retainedDocumentJson,
+      options,
+    );
     this.#transportMode = ready.transportMode;
     return ready;
   }
@@ -242,7 +283,7 @@ export class AuthoringExecutionClient {
     this.#transportMode = null;
   }
 
-  async #startLegacy(sceneJson, options) {
+  async #startMode(mode, sceneJson, retainedDocumentJson, options) {
     const generation = this.#lifecycleGeneration;
     const player = new ExecutionWorkerClient(this.#canvas, {
       onError: this.#onError,
@@ -251,11 +292,14 @@ export class AuthoringExecutionClient {
     const terminateCandidate = createIdempotentTerminator(player);
     let published = false;
     try {
-      const ready = await player.start(sceneJson, options);
+      const ready =
+        mode === AUTHORING_EXECUTION_RETAINED
+          ? await player.startRetained(sceneJson, retainedDocumentJson, options)
+          : await player.start(sceneJson, options);
       this.#assertLifecycleCurrent(generation, terminateCandidate);
       this.#player = player;
       published = true;
-      this.#mode = AUTHORING_EXECUTION_LEGACY;
+      this.#mode = mode;
       this.#rendererBackend = ready.render.backend;
       this.#resizeCurrentCanvas();
       return ready;

--- a/web/execution-worker-client.js
+++ b/web/execution-worker-client.js
@@ -95,6 +95,24 @@ export class ExecutionWorkerClient {
     });
   }
 
+  async startRetained(
+    sceneJson,
+    retainedDocumentJson,
+    {
+      loopDurationSeconds = 4,
+      transportMode = selectExecutionTransportMode(),
+      sharedSlotCapacity = DEFAULT_SHARED_SLOT_CAPACITY,
+    } = {},
+  ) {
+    validateSceneJson(sceneJson);
+    validateRetainedDocumentJson(retainedDocumentJson);
+    return this.#startMode(EXECUTION_MODE_RETAINED, sceneJson, retainedDocumentJson, {
+      loopDurationSeconds,
+      transportMode,
+      sharedSlotCapacity,
+    });
+  }
+
   async #startMode(
     mode,
     sceneJson,

--- a/web/execution-worker-retained-start.test.mjs
+++ b/web/execution-worker-retained-start.test.mjs
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+class FakeCanvas {
+  clientWidth = 640;
+  clientHeight = 360;
+  width = 640;
+  height = 360;
+
+  transferControlToOffscreen() {
+    return { width: this.width, height: this.height };
+  }
+}
+
+class FakeWorker {
+  static instances = [];
+
+  listeners = new Map();
+  messages = [];
+
+  constructor(url, options = {}) {
+    this.url = String(url);
+    this.name = options.name ?? "";
+    FakeWorker.instances.push(this);
+  }
+
+  addEventListener(type, listener) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  postMessage(message, transfer = []) {
+    this.messages.push({ message, transfer });
+  }
+
+  terminate() {}
+
+  emitMessage(message) {
+    for (const listener of this.listeners.get("message") ?? []) {
+      listener({ data: message });
+    }
+  }
+}
+
+globalThis.HTMLCanvasElement = FakeCanvas;
+globalThis.Worker = FakeWorker;
+globalThis.window = { devicePixelRatio: 1 };
+
+const { AuthoringExecutionClient } = await import("./authoring-execution-client.js");
+
+const SCENE_JSON = JSON.stringify({ version: 1, objects: [], tracks: [] });
+const RETAINED_DOCUMENT_JSON = JSON.stringify({
+  channel: "noon.authoring.retained",
+  objects: [{ id: 1 }],
+});
+
+function engineReady() {
+  return {
+    channel: "noon.engine",
+    protocolVersion: 1,
+    type: "ready",
+    transportMode: "transferable",
+  };
+}
+
+function renderReady() {
+  return {
+    channel: "noon.render",
+    protocolVersion: 1,
+    type: "ready",
+    transportMode: "transferable",
+    backend: "WebGL2",
+  };
+}
+
+test("retained first start boots the retained engine directly", async () => {
+  FakeWorker.instances.length = 0;
+  const client = new AuthoringExecutionClient(new FakeCanvas());
+  const readyPromise = client.startRetained(SCENE_JSON, RETAINED_DOCUMENT_JSON, {
+    transportMode: "transferable",
+  });
+
+  const retainedEngine = FakeWorker.instances.find(
+    ({ name }) => name === "noon-mixed-retained-engine",
+  );
+  const legacyEngine = FakeWorker.instances.find(({ name }) => name === "noon-engine");
+  const render = FakeWorker.instances.find(({ name }) => name === "noon-render");
+
+  assert.ok(retainedEngine, "retained startup must create the retained engine");
+  assert.equal(legacyEngine, undefined, "retained startup must not create a legacy engine");
+  assert.ok(render, "retained startup must create the shared render owner");
+  assert.match(retainedEngine.url, /retained-execution-engine-worker\.js$/);
+
+  const engineInit = retainedEngine.messages.find(({ message }) => message.type === "init")?.message;
+  const renderInit = render.messages.find(({ message }) => message.type === "init")?.message;
+  assert.equal(engineInit?.retainedDocumentJson, RETAINED_DOCUMENT_JSON);
+  assert.equal(renderInit?.mode, "retained");
+
+  retainedEngine.emitMessage(engineReady());
+  render.emitMessage(renderReady());
+  const ready = await readyPromise;
+
+  assert.equal(ready.session, 1);
+  assert.equal(client.mode, "retained");
+  client.terminate();
+});

--- a/web/execution-worker-startup.test.mjs
+++ b/web/execution-worker-startup.test.mjs
@@ -127,6 +127,27 @@ function emitLegacyReady(offset) {
   return { engine, render };
 }
 
+function emitUnifiedRetainedReady(offset) {
+  const engine = workerByName(offset, "noon-mixed-retained-engine");
+  const render = workerByName(offset, "noon-render");
+  engine.emitMessage(
+    envelope("noon.engine", "ready", {
+      transportMode: "transferable",
+      retained: true,
+      mixed: true,
+    }),
+  );
+  render.emitMessage(
+    envelope("noon.render", "ready", {
+      transportMode: "transferable",
+      backend: "WebGL2",
+      retained: true,
+      mixed: true,
+    }),
+  );
+  return { engine, render };
+}
+
 function emitRetainedReady(offset) {
   const engine = workerByName(offset, "noon-mixed-retained-engine");
   const render = workerByName(offset, "noon-mixed-retained-render");
@@ -163,6 +184,48 @@ test("legacy constructor failure rolls back transferred canvas and retry succeed
   emitLegacyReady(retryOffset);
   const ready = await retry;
   assert.equal(ready.session, 2, "failed startup generation must not be reused");
+  client.terminate();
+});
+
+test("direct retained startup failure rolls back transferred canvas and retry succeeds", async () => {
+  const original = new FakeCanvas();
+  const errors = [];
+  const client = new ExecutionWorkerClient(original, {
+    onError(error, owner) {
+      errors.push(`${owner}: ${error.message}`);
+    },
+  });
+  const offset = FakeWorker.instances.length;
+  const started = client.startRetained(SCENE_JSON, RETAINED_JSON, {
+    transportMode: "transferable",
+  });
+  const engine = workerByName(offset, "noon-mixed-retained-engine");
+  const render = workerByName(offset, "noon-render");
+  engine.emitMessage(
+    envelope("noon.engine", "ready", {
+      transportMode: "transferable",
+      retained: true,
+      mixed: true,
+    }),
+  );
+  render.emitError("direct retained render startup crashed");
+
+  await assert.rejects(started, /direct retained render startup crashed/);
+  assert.equal(engine.terminated, true);
+  assert.equal(render.terminated, true);
+  assert.equal(original.transferred, true);
+  assert.notEqual(client.canvas, original);
+  assert.equal(original.replacement, client.canvas);
+  assert.equal(client.canvas.transferred, false);
+  assert.deepEqual(errors, ["render: direct retained render startup crashed"]);
+
+  const retryOffset = FakeWorker.instances.length;
+  const retry = client.startRetained(SCENE_JSON, RETAINED_JSON, {
+    transportMode: "transferable",
+  });
+  emitUnifiedRetainedReady(retryOffset);
+  const ready = await retry;
+  assert.equal(ready.session, 2, "failed retained startup generation must not be reused");
   client.terminate();
 });
 

--- a/web/main.js
+++ b/web/main.js
@@ -504,7 +504,7 @@ async function ensureRuntimeReady({
         nextPlayer,
         document.querySelector(".preview-pane"),
         {
-          durationSeconds: playbackDurationSeconds,
+          durationSeconds: loopDurationSeconds,
           onError: showPlaybackError,
         },
       );
@@ -513,7 +513,7 @@ async function ensureRuntimeReady({
       playbackControls.sync({
         time: initialState.time,
         playing: initialState.playing,
-        durationSeconds: playbackDurationSeconds,
+        durationSeconds: loopDurationSeconds,
       });
       startMetricsPolling();
       return {
@@ -731,9 +731,6 @@ async function runScene() {
         authored.retainedDocument === null ? null : JSON.stringify(authored.retainedDocument);
       const startRetained = (authored.retainedDocument?.objects?.length ?? 0) > 0;
       const loopDurationSeconds = authored.duration > 0 ? authored.duration : playbackDurationSeconds;
-      if (authored.duration > 0) {
-        playbackDurationSeconds = authored.duration;
-      }
 
       await runPlaygroundTestHook("beforeReconcile", {
         exampleId: example.id,
@@ -765,6 +762,9 @@ async function runScene() {
         if (!isCurrentRun(runToken)) return recordStale(runToken, "after-reconcile");
       }
 
+      if (authored.duration > 0) {
+        playbackDurationSeconds = authored.duration;
+      }
       playbackControls?.sync({
         time: result.time,
         playing: result.playing,

--- a/web/main.js
+++ b/web/main.js
@@ -444,35 +444,28 @@ function ensureAuthoringClient() {
   return authoringClient;
 }
 
-function warmAuthoringClient() {
-  const client = ensureAuthoringClient();
-  status.dataset.authoringWarmup = "started";
-  void client.ready().then(
-    () => {
-      if (authoringClient === client) {
-        status.dataset.authoringWarmup = "ready";
-      }
-    },
-    () => {
-      if (authoringClient !== client) return;
-      if (client.terminated) {
-        authoringClient = null;
-      }
-      status.dataset.authoringWarmup = "failed";
-    },
-  );
-  return client;
-}
-
-async function ensureRuntimeReady() {
+async function ensureRuntimeReady({
+  sceneJson,
+  retainedDocumentJson,
+  startRetained,
+  callbacks,
+  authoringClient: client,
+  loopDurationSeconds,
+}) {
   if (runtimeStartPromise !== null) return runtimeStartPromise;
-  if (player !== null) return;
+  if (player !== null) return null;
 
   const task = (async () => {
-    setRuntimeStatus("Starting runtime on demand…", "running");
-    patchStatus.value = "Starting Python + GPU runtime…";
+    setRuntimeStatus("Starting execution runtime…", "running");
+    patchStatus.value = "Starting GPU execution runtime…";
     patchStatus.dataset.state = "running";
-    warmAuthoringClient();
+
+    if (startRetained && callbacks !== null && callbacks !== undefined) {
+      throw new Error(
+        "retained authoring with Python host callbacks is not supported yet; " +
+          "split the callback work from retained text instead of silently dropping either",
+      );
+    }
 
     const nextPlayer = new AuthoringExecutionClient(canvas, {
       onError(error) {
@@ -483,11 +476,24 @@ async function ensureRuntimeReady() {
         showRecoverableSceneError(error);
       },
     });
-    player = nextPlayer;
     try {
-      const ready = await nextPlayer.start('{"version":1,"objects":[],"tracks":[]}', {
-        loopDurationSeconds: 4.0,
-      });
+      const ready = startRetained
+        ? await nextPlayer.startRetained(sceneJson, retainedDocumentJson, {
+            loopDurationSeconds,
+          })
+        : await nextPlayer.start(sceneJson, { loopDurationSeconds });
+      let initialState;
+      if (!startRetained && callbacks !== null && callbacks !== undefined) {
+        initialState = await nextPlayer.reconcileScene(sceneJson, {
+          callbacks,
+          authoringClient: client,
+          loopDurationSeconds,
+        });
+      } else {
+        initialState = await nextPlayer.state();
+      }
+
+      player = nextPlayer;
       playerNeedsRestart = false;
       rendererBackend = ready.render.backend;
       status.dataset.rendererBackend = rendererBackend;
@@ -503,7 +509,6 @@ async function ensureRuntimeReady() {
         },
       );
 
-      const initialState = await nextPlayer.state();
       patchStatus.dataset.sequence = String(initialState.nextPatchSequence);
       playbackControls.sync({
         time: initialState.time,
@@ -511,6 +516,12 @@ async function ensureRuntimeReady() {
         durationSeconds: playbackDurationSeconds,
       });
       startMetricsPolling();
+      return {
+        ...initialState,
+        incremental: false,
+        rebuilt: true,
+        mode: nextPlayer.mode,
+      };
     } catch (error) {
       nextPlayer.terminate();
       if (player === nextPlayer) {
@@ -524,7 +535,7 @@ async function ensureRuntimeReady() {
 
   runtimeStartPromise = task;
   try {
-    await task;
+    return await task;
   } finally {
     if (runtimeStartPromise === task) {
       runtimeStartPromise = null;
@@ -679,14 +690,10 @@ async function runScene() {
   const releaseBusy = beginBusy();
   const task = (async () => {
     try {
-      await ensureRuntimeReady();
-      if (!isCurrentRun(runToken)) return recordStale(runToken, "after-runtime-start");
-      await ensureExecutionReady();
-      if (!isCurrentRun(runToken)) return recordStale(runToken, "after-restart");
-
       patchStatus.value = `Building ${example.title} in the Python worker…`;
       patchStatus.dataset.state = "running";
       const client = ensureAuthoringClient();
+      status.dataset.authoringWarmup = "started";
       let authored;
       try {
         authored = await client.run(source, {
@@ -696,7 +703,9 @@ async function runScene() {
             run_generation: runToken.runGeneration,
           },
         });
+        status.dataset.authoringWarmup = "ready";
       } catch (error) {
+        status.dataset.authoringWarmup = "failed";
         if (client.terminated && authoringClient === client) {
           authoringClient = null;
         }
@@ -717,6 +726,15 @@ async function runScene() {
         authored.callbacks === null
           ? sceneIdentities.stabilize(authored.document, authored.identities)
           : authored.document;
+      const sceneJson = JSON.stringify(runtimeDocument);
+      const retainedDocumentJson =
+        authored.retainedDocument === null ? null : JSON.stringify(authored.retainedDocument);
+      const startRetained = (authored.retainedDocument?.objects?.length ?? 0) > 0;
+      const loopDurationSeconds = authored.duration > 0 ? authored.duration : playbackDurationSeconds;
+      if (authored.duration > 0) {
+        playbackDurationSeconds = authored.duration;
+      }
+
       await runPlaygroundTestHook("beforeReconcile", {
         exampleId: example.id,
         selectionGeneration: runToken.selectionGeneration,
@@ -724,18 +742,29 @@ async function runScene() {
       });
       if (!isCurrentRun(runToken)) return recordStale(runToken, "before-reconcile");
 
-      const result = await player.reconcileScene(JSON.stringify(runtimeDocument), {
-        retainedDocumentJson:
-          authored.retainedDocument === null ? null : JSON.stringify(authored.retainedDocument),
-        callbacks: authored.callbacks,
-        authoringClient: client,
-        loopDurationSeconds: authored.duration > 0 ? authored.duration : null,
-      });
-      if (!isCurrentRun(runToken)) return recordStale(runToken, "after-reconcile");
-
-      if (authored.duration > 0) {
-        playbackDurationSeconds = authored.duration;
+      let result;
+      if (player === null) {
+        result = await ensureRuntimeReady({
+          sceneJson,
+          retainedDocumentJson,
+          startRetained,
+          callbacks: authored.callbacks,
+          authoringClient: client,
+          loopDurationSeconds,
+        });
+        if (!isCurrentRun(runToken)) return recordStale(runToken, "after-runtime-start");
+      } else {
+        await ensureExecutionReady();
+        if (!isCurrentRun(runToken)) return recordStale(runToken, "after-restart");
+        result = await player.reconcileScene(sceneJson, {
+          retainedDocumentJson,
+          callbacks: authored.callbacks,
+          authoringClient: client,
+          loopDurationSeconds: authored.duration > 0 ? authored.duration : null,
+        });
+        if (!isCurrentRun(runToken)) return recordStale(runToken, "after-reconcile");
       }
+
       playbackControls?.sync({
         time: result.time,
         playing: result.playing,

--- a/web/playground-duration-commit.test.mjs
+++ b/web/playground-duration-commit.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const main = await readFile(new URL("./main.js", import.meta.url), "utf8");
+
+const runtimeStart = main.indexOf("async function ensureRuntimeReady(");
+const runtimeEnd = main.indexOf("async function ensureExecutionReady()", runtimeStart);
+assert.ok(runtimeStart >= 0 && runtimeEnd > runtimeStart, "runtime startup boundary must exist");
+const runtimeBody = main.slice(runtimeStart, runtimeEnd);
+assert.match(
+  runtimeBody,
+  /new PlaygroundPlaybackControls\([\s\S]*?durationSeconds: loopDurationSeconds,/,
+  "cold playback controls must use the authored duration without publishing global scene state early",
+);
+assert.match(
+  runtimeBody,
+  /playbackControls\.sync\(\{[\s\S]*?durationSeconds: loopDurationSeconds,/,
+  "cold playback sync must use the startup-local authored duration",
+);
+
+const runStart = main.indexOf("async function runScene()");
+const runEnd = main.indexOf("async function selectExample(", runStart);
+assert.ok(runStart >= 0 && runEnd > runStart, "runScene boundary must exist");
+const runBody = main.slice(runStart, runEnd);
+
+const beforeReconcileCheck = runBody.indexOf(
+  'if (!isCurrentRun(runToken)) return recordStale(runToken, "before-reconcile");',
+);
+const coldCommitCheck = runBody.indexOf(
+  'if (!isCurrentRun(runToken)) return recordStale(runToken, "after-runtime-start");',
+);
+const warmCommitCheck = runBody.indexOf(
+  'if (!isCurrentRun(runToken)) return recordStale(runToken, "after-reconcile");',
+);
+const durationCommit = runBody.indexOf("playbackDurationSeconds = authored.duration;");
+
+assert.ok(beforeReconcileCheck >= 0, "run must reject stale authored results before execution commit");
+assert.ok(coldCommitCheck > beforeReconcileCheck, "cold startup must have a post-start freshness check");
+assert.ok(warmCommitCheck > coldCommitCheck, "warm reconciliation must have a post-reconcile freshness check");
+assert.ok(
+  durationCommit > coldCommitCheck && durationCommit > warmCommitCheck,
+  "global playback duration must commit only after the current scene has committed successfully",
+);
+assert.equal(
+  runBody.split("playbackDurationSeconds = authored.duration;").length - 1,
+  1,
+  "runScene must have exactly one transactional playback-duration commit",
+);
+
+console.log("✓ playback duration commits only with the current authored scene");

--- a/web/playground-stability-boundary.test.mjs
+++ b/web/playground-stability-boundary.test.mjs
@@ -66,7 +66,7 @@ assert.match(
   "retained to legacy authoring must switch the persistent execution owner in place",
 );
 
-const runtimeReadyStart = main.indexOf("async function ensureRuntimeReady()");
+const runtimeReadyStart = main.indexOf("async function ensureRuntimeReady(");
 const runtimeReadyEnd = main.indexOf("async function ensureExecutionReady()", runtimeReadyStart);
 assert.ok(
   runtimeReadyStart >= 0 && runtimeReadyEnd > runtimeReadyStart,

--- a/web/playground-startup.test.mjs
+++ b/web/playground-startup.test.mjs
@@ -4,33 +4,50 @@ import { readFile } from "node:fs/promises";
 const main = await readFile(new URL("./main.js", import.meta.url), "utf8");
 const worker = await readFile(new URL("./python-worker.source.js", import.meta.url), "utf8");
 
-const runtimeReadyStart = main.indexOf("async function ensureRuntimeReady()");
+const runtimeReadyStart = main.indexOf("async function ensureRuntimeReady({");
 const executionReadyStart = main.indexOf("async function ensureExecutionReady()", runtimeReadyStart);
 assert.ok(
   runtimeReadyStart >= 0 && executionReadyStart > runtimeReadyStart,
   "on-demand runtime startup boundary must exist",
 );
 const runtimeReadyBody = main.slice(runtimeReadyStart, executionReadyStart);
-assert.match(
+assert.doesNotMatch(
   runtimeReadyBody,
-  /warmAuthoringClient\(\);/,
-  "first runtime request must begin Python warmup",
+  /warmAuthoringClient\(/,
+  "execution startup must not bootstrap Python after the authored scene is already available",
 );
 assert.match(
   runtimeReadyBody,
   /new AuthoringExecutionClient\(canvas,/,
-  "first runtime request must create the GPU execution owner",
+  "first authored scene must create the GPU execution owner on demand",
 );
 assert.match(
   runtimeReadyBody,
-  /await nextPlayer\.start\(/,
-  "on-demand startup must await execution readiness before publishing controls",
+  /await nextPlayer\.startRetained\(sceneJson, retainedDocumentJson,/,
+  "retained first runs must start directly in retained mode",
+);
+assert.match(
+  runtimeReadyBody,
+  /await nextPlayer\.start\(sceneJson,/,
+  "geometry-only first runs must start their authored scene directly",
+);
+assert.doesNotMatch(
+  runtimeReadyBody,
+  /\{\\"version\\":1,\\"objects\\":\[\],\\"tracks\\":\[\]\}/,
+  "cold startup must not boot a throwaway empty legacy scene",
 );
 const inFlightGuard = runtimeReadyBody.indexOf("if (runtimeStartPromise !== null)");
 const livePlayerGuard = runtimeReadyBody.indexOf("if (player !== null)");
 assert.ok(
   inFlightGuard >= 0 && livePlayerGuard > inFlightGuard,
   "concurrent startup callers must await the in-flight startup before observing the published player",
+);
+const playerPublish = runtimeReadyBody.indexOf("player = nextPlayer;");
+const retainedStart = runtimeReadyBody.indexOf("await nextPlayer.startRetained");
+const legacyStart = runtimeReadyBody.indexOf("await nextPlayer.start(sceneJson");
+assert.ok(
+  playerPublish > retainedStart && playerPublish > legacyStart,
+  "the execution owner must publish only after the selected engine mode is ready",
 );
 assert.match(
   runtimeReadyBody,
@@ -47,12 +64,23 @@ const runSceneStart = main.indexOf("async function runScene()");
 const selectExampleStart = main.indexOf("async function selectExample(", runSceneStart);
 assert.ok(runSceneStart >= 0 && selectExampleStart > runSceneStart, "runScene boundary must exist");
 const runSceneBody = main.slice(runSceneStart, selectExampleStart);
-const ensureRuntimeCall = runSceneBody.indexOf("await ensureRuntimeReady();");
+const authoringCall = runSceneBody.indexOf("authored = await client.run(source,");
+const ensureRuntimeCall = runSceneBody.indexOf("result = await ensureRuntimeReady({");
 const ensureExecutionCall = runSceneBody.indexOf("await ensureExecutionReady();");
-assert.ok(ensureRuntimeCall >= 0, "Run must start the deferred runtime");
+const reconcileCall = runSceneBody.indexOf("result = await player.reconcileScene(sceneJson,");
+assert.ok(authoringCall >= 0, "Run must author the selected Python source");
 assert.ok(
-  ensureExecutionCall > ensureRuntimeCall,
-  "runtime startup must complete before execution recovery/reconciliation",
+  ensureRuntimeCall > authoringCall,
+  "cold execution startup must wait until authoring identifies the required engine mode",
+);
+assert.ok(
+  ensureExecutionCall > authoringCall && reconcileCall > ensureExecutionCall,
+  "warm runs must preserve recovery before incremental reconciliation",
+);
+assert.match(
+  runSceneBody,
+  /const startRetained = \(authored\.retainedDocument\?\.objects\?\.length \?\? 0\) > 0;/,
+  "first-run engine selection must derive from the authored retained sidecar",
 );
 
 const bootStart = main.indexOf("try {\n  const requested = requestedExampleId();");
@@ -62,7 +90,7 @@ assert.ok(bootCatch > bootStart, "playground boot boundary must terminate cleanl
 const bootBody = main.slice(bootStart, bootCatch);
 assert.doesNotMatch(
   bootBody,
-  /warmAuthoringClient\(|new AuthoringExecutionClient\(|\.start\(.*objects.*tracks/,
+  /ensureAuthoringClient\(|new AuthoringExecutionClient\(|\.start\(.*objects.*tracks/,
   "initial page boot must not create Python or GPU runtime resources",
 );
 assert.doesNotMatch(
@@ -173,5 +201,5 @@ assert.match(
 );
 
 console.log(
-  "✓ playground defers heavyweight startup, bounds gallery residency, and preserves parallel Python bootstrap",
+  "✓ playground defers heavyweight startup, starts the authored engine mode directly, bounds gallery residency, and preserves parallel Python bootstrap",
 );


### PR DESCRIPTION
## Summary

Take the first behavior-changing slice of #642 by removing the throwaway execution mode from the playground's cold first Run.

Today `runScene()` starts an empty legacy execution runtime before Python authoring has identified whether the scene needs retained execution. A retained Text/Typst result therefore pays for a legacy engine startup and then immediately replaces it with the retained engine.

This PR changes the cold path to author first, then bootstrap execution once in the mode required by that authored result.

## What changed

- add direct retained startup to `ExecutionWorkerClient`, reusing the existing private mode-aware startup path;
- expose retained-first startup through `AuthoringExecutionClient` with the same lifecycle/canvas ownership guarantees as legacy startup;
- move cold execution bootstrap in `runScene()` after Python authoring identifies the retained sidecar;
- start geometry-only cold scenes directly with their authored scene instead of an empty placeholder;
- start retained cold scenes directly with `retained-execution-engine-worker.js`, avoiding the legacy -> retained engine transition;
- preserve the existing warm-run `reconcileScene()` path and runtime-recovery path;
- preserve deferred initial-page startup: opening the gallery still creates neither Python nor GPU runtime resources;
- keep the existing retained+host-callback rejection explicit rather than silently dropping either behavior;
- keep authored playback duration local to cold startup until the scene passes its post-start/post-reconcile freshness check, preventing superseded runs from leaking duration state.

## Tests

- add a fake-worker regression through `AuthoringExecutionClient` proving retained first startup creates the retained engine and render owner, and never creates the legacy engine;
- exercise failed direct `ExecutionWorkerClient.startRetained()` startup on the unified production path and prove it terminates both workers, replaces the transferred canvas, and retries on a new session;
- update the playground startup contract test to require authoring before cold execution startup, authored-scene startup rather than an empty placeholder, and retained mode selection from the retained sidecar;
- keep the deferred-runtime stability guard implementation-agnostic so it pins the on-demand boundary rather than one obsolete function signature;
- add a playback-duration commit regression requiring cold controls to use startup-local duration while the global duration commits only after current-scene execution succeeds;
- the web build automatically syntax-checks all top-level web modules and executes every `web/*.test.mjs` file.

## Scope

This deliberately does **not** claim to finish all of #642. It removes the wrong-engine/double-engine cold bootstrap and the empty-scene first reconcile. Follow-up work can overlap Python/Pyodide startup with #645's mode-free render-owner preparation, then attack remaining duplicate WASM ownership without coupling those architectural changes into this focused slice.

Tracks #642.