### PR TITLE
Classify CI workflow topology

### DIFF
--- a/web/ci-workflow-topology.test.mjs
+++ b/web/ci-workflow-topology.test.mjs
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { readdir, readFile } from "node:fs/promises";
+
+const workflowDir = new URL("../.github/workflows/", import.meta.url);
+const workflowFiles = (await readdir(workflowDir))
+  .filter((name) => name.endsWith(".yml") || name.endsWith(".yaml"))
+  .sort();
+
+assert.ok(workflowFiles.length > 0, "CI workflow inventory must not be empty");
+
+const exactFamilies = new Map([
+  ["ci.yml", "main"],
+  ["test-coverage.yml", "coverage"],
+  ["platform-release.yml", "platform-release"],
+  ["pages.yml", "deployment"],
+  ["fuzz.yml", "fuzz"],
+]);
+
+function classifyWorkflow(name) {
+  if (exactFamilies.has(name)) return exactFamilies.get(name);
+  for (const [prefix, family] of [
+    ["manim-", "manim"],
+    ["playground-", "playground"],
+    ["renderer-", "renderer"],
+    ["authoring-", "authoring"],
+    ["perf-", "performance"],
+  ]) {
+    if (name.startsWith(prefix)) return family;
+  }
+  return null;
+}
+
+const classified = workflowFiles.map((name) => ({ name, family: classifyWorkflow(name) }));
+const unclassified = classified.filter(({ family }) => family === null).map(({ name }) => name);
+assert.deepEqual(
+  unclassified,
+  [],
+  `new workflow families must be classified explicitly: ${unclassified.join(", ")}`,
+);
+
+const requiredFamilies = new Set([
+  "main",
+  "coverage",
+  "platform-release",
+  "manim",
+  "playground",
+]);
+const presentFamilies = new Set(classified.map(({ family }) => family));
+for (const family of requiredFamilies) {
+  assert.ok(presentFamilies.has(family), `required CI family ${family} must remain represented`);
+}
+
+const ciDocs = await readFile(new URL("../docs/ci.md", import.meta.url), "utf8");
+for (const [needle, purpose] of [
+  [".github/workflows/ci.yml", "main CI"],
+  [".github/workflows/platform-release.yml", "platform/release validation"],
+  [".github/workflows/test-coverage.yml", "test observability"],
+  ["Manim compatibility workflows", "Manim validation family"],
+]) {
+  assert.match(ciDocs, new RegExp(needle.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")), `${purpose} must remain documented`);
+}
+
+const counts = Object.fromEntries(
+  [...presentFamilies].sort().map((family) => [
+    family,
+    classified.filter((entry) => entry.family === family).length,
+  ]),
+);
+console.log(`✓ classified ${workflowFiles.length} CI workflows: ${JSON.stringify(counts)}`);

--- a/web/ci-workflow-topology.test.mjs
+++ b/web/ci-workflow-topology.test.mjs
@@ -23,6 +23,7 @@ function classifyWorkflow(name) {
     ["playground-", "playground"],
     ["renderer-", "renderer"],
     ["authoring-", "authoring"],
+    ["retained-", "retained"],
     ["perf-", "performance"],
   ]) {
     if (name.startsWith(prefix)) return family;


### PR DESCRIPTION
## Summary
- add a self-registering Node regression that inventories every `.github/workflows/*.yml` file
- classify workflows into explicit architecture/testing families rather than letting new standalone lanes appear silently
- require the core main, coverage, platform/release, Manim, and playground families to remain represented
- keep `docs/ci.md` anchored to the core workflow documents it claims to describe

## Why
#116/#104 explicitly call out CI-topology/documentation drift. The repository has grown several dedicated playground/recovery/browser lanes beyond the older prose description. This slice adds a cheap mechanical ownership gate: adding a workflow with a new naming family now requires an explicit classification decision instead of silently expanding the CI surface.

The test is automatically syntax-checked and executed by `scripts/build-web-demo.sh` through the existing `web/*.test.mjs` discovery, so there is no duplicate test inventory to maintain.

## Scope / risk
Test/governance only; no production/runtime behavior changes. Prefix classification is deliberately coarse and architectural (Manim, playground, renderer, authoring, performance) rather than enumerating every workflow, so adding another workflow inside an existing family remains cheap.

Tracks #104 and #116.