### PR TITLE
Classify pinned Manim line reference examples

### DIFF
--- a/compat/manim-v0.21.0-reference-coverage-lock.json
+++ b/compat/manim-v0.21.0-reference-coverage-lock.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 2,
   "minimum_reconciled_examples": 20,
-  "minimum_classified_examples": 20
+  "minimum_classified_examples": 22
 }

--- a/web/python/examples/manim_tutorial_manifest.json
+++ b/web/python/examples/manim_tutorial_manifest.json
@@ -520,6 +520,38 @@
       "order": 260
     },
     {
+      "id": "manim-dashed-line-reference",
+      "title": "DashedLineExample",
+      "summary": "ManimCE v0.21 DashedLine reference example; tracked by exact pinned provenance and blocked until DashedLine parity lands.",
+      "status": "blocked",
+      "category": "geometry/line",
+      "features": ["DashedLine", "dash_length", "dashed_ratio", "Scene.add"],
+      "upstream": "reference/manim.mobject.geometry.line.DashedLine.html",
+      "dependency": "#77",
+      "reference_provenance": {
+        "source_path": "manim/mobject/geometry/line.py",
+        "directive_line": 302,
+        "name": "DashedLineExample",
+        "source_sha256": "313b8f0b5bf505f3cdaf3a20b870ba38c472501790fe56c550ccc6436d26a288"
+      }
+    },
+    {
+      "id": "manim-tangent-line-reference",
+      "title": "TangentLineExample",
+      "summary": "ManimCE v0.21 TangentLine reference example; tracked by exact pinned provenance and blocked until TangentLine parity lands.",
+      "status": "blocked",
+      "category": "geometry/line",
+      "features": ["TangentLine", "Circle", "alpha", "length", "Scene.add"],
+      "upstream": "reference/manim.mobject.geometry.line.TangentLine.html",
+      "dependency": "#77",
+      "reference_provenance": {
+        "source_path": "manim/mobject/geometry/line.py",
+        "directive_line": 435,
+        "name": "TangentLineExample",
+        "source_sha256": "a799c7449429bea841efc326f23b661e5d2913405f8c6078c37f0146e25fb130"
+      }
+    },
+    {
       "id": "gallery-basic-manim-ce-logo",
       "title": "ManimCELogo",
       "summary": "ManimCE v0.21 Basic Concepts gallery case; blocked until MathTex, Triangle, retained VGroup layout, and exact camera/background parity are complete.",


### PR DESCRIPTION
## Summary
- classify pinned `DashedLineExample` and `TangentLineExample` as blocked reference-manual examples using immutable ManimCE v0.21.0 provenance
- point both examples at the existing #77 line/arrow implementation lane rather than rewriting or silently omitting them
- ratchet total classified reference coverage from 20 to 22 while keeping the exact-source runnable ratchet at 20

## Provenance
Both tuples come from the immutable extracted inventory at ManimCE commit `861cd4849b17db1db3515b531ffe80b297848f93`:
- `DashedLineExample`: `manim/mobject/geometry/line.py:302`, SHA-256 `313b8f0b5bf505f3cdaf3a20b870ba38c472501790fe56c550ccc6436d26a288`
- `TangentLineExample`: `manim/mobject/geometry/line.py:435`, SHA-256 `a799c7449429bea841efc326f23b661e5d2913405f8c6078c37f0146e25fb130`

The public reference paths were also verified against the ManimCE v0.21.0 docs.

## Expected coverage
- inventory: 491
- exact-source reconciled: 20
- provenance-only classified: 2
- total classified: 22
- remaining unclassified: 469

The `Manim reference inventory` workflow is the authoritative validation: it re-extracts the pinned upstream corpus and rejects stale/mismatched provenance or duplicate claims.

Tracks #256 and #77.