### PR TITLE
Attach authored execution after render-owner preparation

### DIFF
--- a/web/execution-worker-client.js
+++ b/web/execution-worker-client.js
@@ -23,6 +23,7 @@ export class ExecutionWorkerClient {
   #candidateEngineWorker = null;
   #candidateEngineReject = null;
   #renderWorker = null;
+  #renderPrepared = null;
   #nextRequestIds = { engine: 0, render: 0 };
   #pending = new Map();
   #session = 0;
@@ -78,14 +79,72 @@ export class ExecutionWorkerClient {
     });
   }
 
-  async start(
-    sceneJson,
+  async prepare(
     {
-      loopDurationSeconds = 4,
       transportMode = selectExecutionTransportMode(),
       sharedSlotCapacity = DEFAULT_SHARED_SLOT_CAPACITY,
     } = {},
   ) {
+    if (this.#engineWorker !== null || this.#renderWorker !== null) {
+      throw new Error("ExecutionWorkerClient is already started or prepared");
+    }
+    validateTransportMode(transportMode);
+    if (
+      transportMode === EXECUTION_TRANSPORT_SHARED &&
+      selectExecutionTransportMode() !== EXECUTION_TRANSPORT_SHARED
+    ) {
+      throw new Error("shared execution transport requires cross-origin isolation");
+    }
+    if (typeof this.#canvas.transferControlToOffscreen !== "function") {
+      throw new Error("OffscreenCanvas transfer is unavailable in this browser");
+    }
+
+    this.#transportMode = transportMode;
+    this.#sharedSlotCapacity = validateSharedSlotCapacity(sharedSlotCapacity);
+    const { width, height } = this.#prepareCanvasDimensions();
+    const transferredCanvas = this.#canvas;
+
+    let canvasTransferred = false;
+    try {
+      const offscreen = this.#canvas.transferControlToOffscreen();
+      canvasTransferred = true;
+      this.#renderWorker = new Worker(new URL("./execution-render-worker.js", import.meta.url), {
+        type: "module",
+        name: "noon-render",
+      });
+      this.#attachCurrentWorkerEvents(this.#renderWorker, RENDER_CHANNEL, "render");
+      this.#renderPrepared = this.#request(
+        this.#renderWorker,
+        "render",
+        renderEnvelope,
+        "prepare",
+        {
+          canvas: offscreen,
+          transportMode,
+          width,
+          height,
+        },
+        [offscreen],
+      );
+      const render = await this.#renderPrepared;
+      this.#fatalOwner = null;
+      return { render, transportMode };
+    } catch (error) {
+      this.#rollbackFailedStart(
+        error,
+        canvasTransferred && this.#canvas === transferredCanvas,
+      );
+      throw error;
+    }
+  }
+
+  async start(sceneJson, options = {}) {
+    const loopDurationSeconds = options.loopDurationSeconds ?? 4;
+    const transportMode =
+      options.transportMode ?? this.#transportMode ?? selectExecutionTransportMode();
+    const sharedSlotCapacity =
+      options.sharedSlotCapacity ??
+      (this.#renderPrepared === null ? DEFAULT_SHARED_SLOT_CAPACITY : this.#sharedSlotCapacity);
     validateSceneJson(sceneJson);
     sceneJson = projectLegacyReactiveSceneJson(sceneJson);
     return this.#startMode(EXECUTION_MODE_LEGACY, sceneJson, null, {
@@ -95,15 +154,13 @@ export class ExecutionWorkerClient {
     });
   }
 
-  async startRetained(
-    sceneJson,
-    retainedDocumentJson,
-    {
-      loopDurationSeconds = 4,
-      transportMode = selectExecutionTransportMode(),
-      sharedSlotCapacity = DEFAULT_SHARED_SLOT_CAPACITY,
-    } = {},
-  ) {
+  async startRetained(sceneJson, retainedDocumentJson, options = {}) {
+    const loopDurationSeconds = options.loopDurationSeconds ?? 4;
+    const transportMode =
+      options.transportMode ?? this.#transportMode ?? selectExecutionTransportMode();
+    const sharedSlotCapacity =
+      options.sharedSlotCapacity ??
+      (this.#renderPrepared === null ? DEFAULT_SHARED_SLOT_CAPACITY : this.#sharedSlotCapacity);
     validateSceneJson(sceneJson);
     validateRetainedDocumentJson(retainedDocumentJson);
     return this.#startMode(EXECUTION_MODE_RETAINED, sceneJson, retainedDocumentJson, {
@@ -123,8 +180,12 @@ export class ExecutionWorkerClient {
       sharedSlotCapacity,
     },
   ) {
-    if (this.#engineWorker !== null || this.#renderWorker !== null) {
+    if (this.#engineWorker !== null) {
       throw new Error("ExecutionWorkerClient is already started");
+    }
+    const preparedRender = this.#renderWorker !== null;
+    if (preparedRender && this.#renderPrepared === null) {
+      throw new Error("ExecutionWorkerClient render owner is not in a prepared state");
     }
     validateExecutionMode(mode);
     validateSceneJson(sceneJson);
@@ -133,30 +194,43 @@ export class ExecutionWorkerClient {
     }
     validateLoopDurationSeconds(loopDurationSeconds);
     validateTransportMode(transportMode);
+    const slotCapacity = validateSharedSlotCapacity(sharedSlotCapacity);
     if (
       transportMode === EXECUTION_TRANSPORT_SHARED &&
       selectExecutionTransportMode() !== EXECUTION_TRANSPORT_SHARED
     ) {
       throw new Error("shared execution transport requires cross-origin isolation");
     }
+
+    if (preparedRender) {
+      if (transportMode !== this.#transportMode) {
+        throw new Error("prepared render transport mode does not match execution startup");
+      }
+      if (slotCapacity !== this.#sharedSlotCapacity) {
+        throw new Error("prepared shared slot capacity does not match execution startup");
+      }
+      await this.#renderPrepared;
+      return this.#startPreparedMode(
+        mode,
+        sceneJson,
+        retainedDocumentJson,
+        loopDurationSeconds,
+      );
+    }
+
     if (typeof this.#canvas.transferControlToOffscreen !== "function") {
       throw new Error("OffscreenCanvas transfer is unavailable in this browser");
     }
 
-    this.#mode = mode;
-    this.#sceneJson = sceneJson;
-    this.#retainedDocumentJson =
-      mode === EXECUTION_MODE_RETAINED ? retainedDocumentJson : null;
-    this.#loopDurationSeconds = loopDurationSeconds;
-    this.#transportMode = transportMode;
-    this.#sharedSlotCapacity = validateSharedSlotCapacity(sharedSlotCapacity);
-    this.#session = checkedNextSession(this.#session);
-
-    const devicePixelRatio = window.devicePixelRatio || 1;
-    const initialWidth = Math.max(1, Math.round(this.#canvas.clientWidth * devicePixelRatio));
-    const initialHeight = Math.max(1, Math.round(this.#canvas.clientHeight * devicePixelRatio));
-    this.#canvas.width = initialWidth;
-    this.#canvas.height = initialHeight;
+    this.#configureStart(
+      mode,
+      sceneJson,
+      retainedDocumentJson,
+      loopDurationSeconds,
+      transportMode,
+      slotCapacity,
+    );
+    const { width: initialWidth, height: initialHeight } = this.#prepareCanvasDimensions();
 
     let canvasTransferred = false;
     try {
@@ -209,6 +283,88 @@ export class ExecutionWorkerClient {
       this.#rollbackFailedStart(error, canvasTransferred);
       throw error;
     }
+  }
+
+  async #startPreparedMode(mode, sceneJson, retainedDocumentJson, loopDurationSeconds) {
+    this.#configureStart(
+      mode,
+      sceneJson,
+      retainedDocumentJson,
+      loopDurationSeconds,
+      this.#transportMode,
+      this.#sharedSlotCapacity,
+    );
+    try {
+      const channel = new MessageChannel();
+      this.#engineWorker = this.#createEngineWorker(mode);
+      const engineReady = this.#workerReady(this.#engineWorker, ENGINE_CHANNEL, "engine");
+      const renderReady = this.#request(
+        this.#renderWorker,
+        "render",
+        renderEnvelope,
+        "start_engine",
+        {
+          port: channel.port2,
+          transportMode: this.#transportMode,
+          mode,
+        },
+        [channel.port2],
+      );
+      this.#ready = Promise.all([engineReady, renderReady]).then(([engine, render]) => ({
+        engine,
+        render,
+        transportMode: this.#transportMode,
+        session: this.#session,
+      }));
+      this.#postEngineInit(
+        this.#engineWorker,
+        channel.port1,
+        mode,
+        sceneJson,
+        retainedDocumentJson,
+        loopDurationSeconds,
+      );
+      const ready = await this.#ready;
+      this.#renderPrepared = null;
+      this.#playing = true;
+      this.#fatalOwner = null;
+      if (mode === EXECUTION_MODE_RETAINED) {
+        this.#hostAuthoringClient = null;
+        this.#hostCallbacks = null;
+      }
+      return ready;
+    } catch (error) {
+      this.#renderPrepared = null;
+      this.#rollbackFailedStart(error, true);
+      throw error;
+    }
+  }
+
+  #configureStart(
+    mode,
+    sceneJson,
+    retainedDocumentJson,
+    loopDurationSeconds,
+    transportMode,
+    sharedSlotCapacity,
+  ) {
+    this.#mode = mode;
+    this.#sceneJson = sceneJson;
+    this.#retainedDocumentJson =
+      mode === EXECUTION_MODE_RETAINED ? retainedDocumentJson : null;
+    this.#loopDurationSeconds = loopDurationSeconds;
+    this.#transportMode = transportMode;
+    this.#sharedSlotCapacity = sharedSlotCapacity;
+    this.#session = checkedNextSession(this.#session);
+  }
+
+  #prepareCanvasDimensions() {
+    const devicePixelRatio = window.devicePixelRatio || 1;
+    const width = Math.max(1, Math.round(this.#canvas.clientWidth * devicePixelRatio));
+    const height = Math.max(1, Math.round(this.#canvas.clientHeight * devicePixelRatio));
+    this.#canvas.width = width;
+    this.#canvas.height = height;
+    return { width, height };
   }
 
   ready() {
@@ -669,6 +825,10 @@ export class ExecutionWorkerClient {
   }
 
   terminate({ preserveHostConfiguration = false } = {}) {
+    const restorePreparedCanvas =
+      this.#engineWorker === null &&
+      this.#renderWorker !== null &&
+      this.#renderPrepared !== null;
     this.#lifecycleGeneration += 1;
     const cancellation = new Error(LIFECYCLE_CANCELLED_MESSAGE);
     this.#candidateEngineReject?.(cancellation);
@@ -679,12 +839,16 @@ export class ExecutionWorkerClient {
     this.#renderWorker?.terminate();
     this.#engineWorker = null;
     this.#renderWorker = null;
+    this.#renderPrepared = null;
     this.#ready = null;
     const error = new Error("execution worker client terminated");
     for (const pending of this.#pending.values()) {
       pending.reject(error);
     }
     this.#pending.clear();
+    if (restorePreparedCanvas) {
+      this.#canvas = replaceExecutionCanvas(this.#canvas);
+    }
     if (!preserveHostConfiguration) {
       this.#hostAuthoringClient = null;
       this.#hostCallbacks = null;
@@ -906,6 +1070,7 @@ export class ExecutionWorkerClient {
     this.#renderWorker?.terminate();
     this.#engineWorker = null;
     this.#renderWorker = null;
+    this.#renderPrepared = null;
     this.#ready = null;
     for (const pending of this.#pending.values()) {
       pending.reject(error);

--- a/web/execution-worker-prepared-start.test.mjs
+++ b/web/execution-worker-prepared-start.test.mjs
@@ -1,0 +1,313 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+class FakeCanvas {
+  clientWidth = 640;
+  clientHeight = 360;
+  width = 640;
+  height = 360;
+  replacement = null;
+  transferred = false;
+
+  transferControlToOffscreen() {
+    if (this.transferred) {
+      throw new Error("canvas was transferred twice");
+    }
+    this.transferred = true;
+    return { width: this.width, height: this.height };
+  }
+
+  cloneNode() {
+    const clone = new FakeCanvas();
+    clone.clientWidth = this.clientWidth;
+    clone.clientHeight = this.clientHeight;
+    clone.width = this.width;
+    clone.height = this.height;
+    return clone;
+  }
+
+  replaceWith(replacement) {
+    this.replacement = replacement;
+  }
+}
+
+class FakeWorker {
+  static instances = [];
+  static failNextName = null;
+
+  listeners = new Map();
+  messages = [];
+  terminated = false;
+
+  constructor(url, options = {}) {
+    this.url = String(url);
+    this.name = options.name ?? "";
+    if (FakeWorker.failNextName === this.name) {
+      FakeWorker.failNextName = null;
+      throw new Error(`${this.name} constructor failed`);
+    }
+    FakeWorker.instances.push(this);
+  }
+
+  addEventListener(type, listener) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  postMessage(message, transfer = []) {
+    this.messages.push({ message, transfer });
+  }
+
+  terminate() {
+    this.terminated = true;
+  }
+
+  emitMessage(message) {
+    this.#emit("message", { data: message });
+  }
+
+  emitError(message = "worker crashed") {
+    this.#emit("error", { message });
+  }
+
+  #emit(type, event) {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+}
+
+globalThis.HTMLCanvasElement = FakeCanvas;
+globalThis.Worker = FakeWorker;
+globalThis.window = { devicePixelRatio: 1 };
+
+const { ExecutionWorkerClient } = await import("./execution-worker-client.js");
+
+const SCENE_JSON = JSON.stringify({ version: 1, objects: [], tracks: [] });
+const RETAINED_DOCUMENT_JSON = JSON.stringify({
+  channel: "noon.authoring.retained",
+  objects: [{ id: 1 }],
+});
+
+function engineMessage(type, payload = {}) {
+  return {
+    channel: "noon.engine",
+    protocolVersion: 1,
+    type,
+    ...payload,
+  };
+}
+
+function renderMessage(type, payload = {}) {
+  return {
+    channel: "noon.render",
+    protocolVersion: 1,
+    type,
+    ...payload,
+  };
+}
+
+function requestMessage(worker, type) {
+  const entry = worker.messages.findLast(({ message }) => message.type === type);
+  assert.ok(entry, `missing ${worker.name} ${type} request`);
+  return entry.message;
+}
+
+function workerByName(offset, name) {
+  const worker = FakeWorker.instances.slice(offset).find((candidate) => candidate.name === name);
+  assert.ok(worker, `missing worker ${name}`);
+  return worker;
+}
+
+function acknowledgePreparation(render) {
+  const request = requestMessage(render, "prepare");
+  render.emitMessage(
+    renderMessage("prepared", {
+      requestId: request.requestId,
+      transportMode: "transferable",
+      width: 640,
+      height: 360,
+    }),
+  );
+  return request;
+}
+
+function resetWorkers() {
+  FakeWorker.instances.length = 0;
+  FakeWorker.failNextName = null;
+}
+
+test("prepared render owner waits for preparation before starting the authored retained engine", async () => {
+  resetWorkers();
+  const client = new ExecutionWorkerClient(new FakeCanvas());
+
+  const preparePromise = client.prepare({ transportMode: "transferable" });
+  const render = workerByName(0, "noon-render");
+  assert.equal(
+    FakeWorker.instances.some(({ name }) => name === "noon-engine"),
+    false,
+    "prepare must not speculate a legacy engine",
+  );
+  assert.equal(
+    FakeWorker.instances.some(({ name }) => name === "noon-mixed-retained-engine"),
+    false,
+    "prepare must not select retained mode before authoring completes",
+  );
+
+  const prepareRequest = requestMessage(render, "prepare");
+  assert.equal(prepareRequest.mode, undefined, "render preparation must remain mode-free");
+
+  const startPromise = client.startRetained(SCENE_JSON, RETAINED_DOCUMENT_JSON);
+  assert.equal(
+    FakeWorker.instances.length,
+    1,
+    "engine startup must wait if authoring wins the race with render preparation",
+  );
+
+  acknowledgePreparation(render);
+  await preparePromise;
+  await new Promise((resolve) => setImmediate(resolve));
+
+  const retainedEngine = workerByName(1, "noon-mixed-retained-engine");
+  assert.equal(
+    FakeWorker.instances.some(({ name }) => name === "noon-engine"),
+    false,
+    "prepared retained startup must never create a legacy engine",
+  );
+
+  const startRequest = requestMessage(render, "start_engine");
+  assert.equal(startRequest.mode, "retained");
+  assert.equal(startRequest.transportMode, "transferable");
+  const engineInit = requestMessage(retainedEngine, "init");
+  assert.equal(engineInit.retainedDocumentJson, RETAINED_DOCUMENT_JSON);
+
+  retainedEngine.emitMessage(
+    engineMessage("ready", {
+      transportMode: "transferable",
+    }),
+  );
+  render.emitMessage(
+    renderMessage("engine_started", {
+      requestId: startRequest.requestId,
+      mode: "retained",
+      transportMode: "transferable",
+      backend: "WebGL2",
+    }),
+  );
+
+  const ready = await startPromise;
+  assert.equal(ready.session, 1);
+  assert.equal(ready.render.type, "engine_started");
+  assert.equal(client.mode, "retained");
+  client.terminate();
+});
+
+test("failed prepared engine attachment replaces the transferred canvas and remains retryable", async () => {
+  resetWorkers();
+  const original = new FakeCanvas();
+  const client = new ExecutionWorkerClient(original);
+
+  const preparePromise = client.prepare({ transportMode: "transferable" });
+  const render = workerByName(0, "noon-render");
+  acknowledgePreparation(render);
+  await preparePromise;
+
+  const started = client.startRetained(SCENE_JSON, RETAINED_DOCUMENT_JSON);
+  await new Promise((resolve) => setImmediate(resolve));
+  const engine = workerByName(1, "noon-mixed-retained-engine");
+  requestMessage(render, "start_engine");
+  engine.emitError("prepared retained engine crashed");
+
+  await assert.rejects(started, /prepared retained engine crashed/);
+  assert.equal(engine.terminated, true);
+  assert.equal(render.terminated, true);
+  assert.equal(original.transferred, true);
+  assert.notEqual(client.canvas, original);
+  assert.equal(original.replacement, client.canvas);
+  assert.equal(client.canvas.transferred, false);
+
+  const retryOffset = FakeWorker.instances.length;
+  const retry = client.startRetained(SCENE_JSON, RETAINED_DOCUMENT_JSON, {
+    transportMode: "transferable",
+  });
+  const retryEngine = workerByName(retryOffset, "noon-mixed-retained-engine");
+  const retryRender = workerByName(retryOffset, "noon-render");
+  retryEngine.emitMessage(engineMessage("ready", { transportMode: "transferable" }));
+  retryRender.emitMessage(
+    renderMessage("ready", {
+      transportMode: "transferable",
+      backend: "WebGL2",
+    }),
+  );
+
+  const ready = await retry;
+  assert.equal(ready.session, 2, "failed prepared startup generation must not be reused");
+  client.terminate();
+});
+
+test("prepare constructor failure restores the transferred canvas and remains retryable", async () => {
+  resetWorkers();
+  const original = new FakeCanvas();
+  const client = new ExecutionWorkerClient(original);
+  FakeWorker.failNextName = "noon-render";
+
+  await assert.rejects(
+    client.prepare({ transportMode: "transferable" }),
+    /noon-render constructor failed/,
+  );
+
+  assert.equal(original.transferred, true);
+  assert.notEqual(client.canvas, original);
+  assert.equal(original.replacement, client.canvas);
+  assert.equal(client.canvas.transferred, false);
+
+  const retryOffset = FakeWorker.instances.length;
+  const prepared = client.prepare({ transportMode: "transferable" });
+  const render = workerByName(retryOffset, "noon-render");
+  acknowledgePreparation(render);
+  await prepared;
+  client.terminate();
+});
+
+test("abandoning preparation restores the transferred canvas before any engine starts", async () => {
+  resetWorkers();
+  const original = new FakeCanvas();
+  const client = new ExecutionWorkerClient(original);
+
+  const prepared = client.prepare({ transportMode: "transferable" });
+  const render = workerByName(0, "noon-render");
+  acknowledgePreparation(render);
+  await prepared;
+
+  assert.equal(
+    FakeWorker.instances.some(({ name }) => name.includes("engine")),
+    false,
+    "abandonment coverage must remain before engine selection",
+  );
+  client.terminate();
+
+  assert.equal(render.terminated, true);
+  assert.equal(original.transferred, true);
+  assert.notEqual(client.canvas, original);
+  assert.equal(original.replacement, client.canvas);
+  assert.equal(client.canvas.transferred, false);
+
+  const retryOffset = FakeWorker.instances.length;
+  const retry = client.startRetained(SCENE_JSON, RETAINED_DOCUMENT_JSON, {
+    transportMode: "transferable",
+  });
+  const retryEngine = workerByName(retryOffset, "noon-mixed-retained-engine");
+  const retryRender = workerByName(retryOffset, "noon-render");
+  retryEngine.emitMessage(engineMessage("ready", { transportMode: "transferable" }));
+  retryRender.emitMessage(
+    renderMessage("ready", {
+      transportMode: "transferable",
+      backend: "WebGL2",
+    }),
+  );
+
+  const ready = await retry;
+  assert.equal(ready.session, 1, "pre-engine preparation must not consume a session generation");
+  client.terminate();
+});


### PR DESCRIPTION
## Summary

Build the production-client handoff on top of #645's now-merged mode-free render-owner preparation protocol.

This tranche teaches `ExecutionWorkerClient` to prepare the permanent render/WASM owner before an authored engine mode is known, then attach exactly one legacy or retained engine once authoring has selected the mode. It deliberately does **not** change playground orchestration yet; that remains the next #642 slice after this client boundary is qualified.

## What changed

- add `ExecutionWorkerClient.prepare()` to transfer the canvas and initialize only the persistent render owner;
- keep preparation mode-free: no legacy or retained engine is created and no renderer/backend is selected;
- allow existing `start()` / `startRetained()` to finalize an already-prepared owner;
- validate that prepared transport/shared-slot configuration matches final engine startup;
- if authoring finishes before render preparation, engine creation waits for the prepare barrier rather than speculating a mode;
- use #645 `start_engine` for the initial authored engine and preserve `ready()` semantics through the render worker's `engine_started` acknowledgement;
- preserve the existing one-shot startup path unchanged for current callers;
- restore a fresh DOM canvas if a prepared render owner is abandoned before any engine starts, so failed/stale authoring cannot poison the next Run;
- preserve canvas recovery when the render-worker constructor fails after OffscreenCanvas transfer, while avoiding double replacement if preparation is concurrently terminated;
- preserve transferred-canvas rollback/retry semantics when prepared engine attachment fails.

## Tests

- race regression: call retained startup before the render `prepared` acknowledgement and prove no engine exists until preparation completes;
- assert preparation creates neither legacy nor retained engine and carries no mode;
- assert the first attached engine is retained and no legacy engine is ever created;
- assert `ready()` resolves from `engine_started` only after the render handoff;
- failure regression: crash the first prepared retained engine, require both workers to be torn down, replace the transferred canvas, and successfully retry with the next session generation;
- constructor regression: fail render-worker construction after canvas transfer, require canvas restoration, then successfully prepare again;
- abandonment regression: prepare successfully, terminate before engine selection, require the transferred canvas to be replaced, then successfully start retained execution on the same client without consuming a phantom session.

## Validation

#645 merged fully green as `304e67b25af934dfd799f63c1f94a3f070b9f527`. Master later advanced only through disjoint #649 manifest/reference-lock files. The exact two-file #650 tree was replayed byte-for-byte onto current master `c8e69581df882a74c18469983bf83b562f2f0412` as one commit `011220a2edf842e06356f745cde7cfe36d278d9e`. Only fresh exact-head validation for `011220a2…` is valid for merge.

Tracks #642.