### PR TITLE
Share analytic circle path-proportion queries

### DIFF
--- a/crates/noon-geometry/src/geometry_proportion.rs
+++ b/crates/noon-geometry/src/geometry_proportion.rs
@@ -143,9 +143,7 @@ mod tests {
         let circle = GeometryRef::circle(1.0);
         assert!(matches!(
             point_from_geometry_proportion(&circle, f32::NAN),
-            Err(GeometryProportionError::Path(
-                PathProportionError::InvalidProportion(_)
-            ))
+            Err(GeometryProportionError::Path(PathProportionError::InvalidProportion(_)))
         ));
         assert_eq!(
             point_from_geometry_proportion(&GeometryRef::rectangle(1.0, 1.0), 0.5),

--- a/crates/noon-geometry/src/geometry_proportion.rs
+++ b/crates/noon-geometry/src/geometry_proportion.rs
@@ -92,8 +92,7 @@ mod tests {
 
     fn assert_point(actual: Vec2, expected: Vec2) {
         assert!(
-            (actual.x - expected.x).abs() <= 1.0e-5
-                && (actual.y - expected.y).abs() <= 1.0e-5,
+            (actual.x - expected.x).abs() <= 1.0e-5 && (actual.y - expected.y).abs() <= 1.0e-5,
             "{actual:?} != {expected:?}"
         );
     }

--- a/crates/noon-geometry/src/geometry_proportion.rs
+++ b/crates/noon-geometry/src/geometry_proportion.rs
@@ -1,6 +1,6 @@
-use noon_core::{GeometryRef, Vec2, TAU};
+use noon_core::{GeometryRef, TAU, Vec2};
 
-use crate::{point_from_proportion, PathProportionError};
+use crate::{PathProportionError, point_from_proportion};
 
 const MANIM_CIRCLE_COMPONENTS: usize = 9;
 

--- a/crates/noon-geometry/src/geometry_proportion.rs
+++ b/crates/noon-geometry/src/geometry_proportion.rs
@@ -1,6 +1,6 @@
-use noon_core::{GeometryRef, TAU, Vec2};
+use noon_core::{GeometryRef, Vec2, TAU};
 
-use crate::{PathProportionError, point_from_proportion};
+use crate::{point_from_proportion, PathProportionError};
 
 const MANIM_CIRCLE_COMPONENTS: usize = 9;
 
@@ -142,7 +142,9 @@ mod tests {
         let circle = GeometryRef::circle(1.0);
         assert!(matches!(
             point_from_geometry_proportion(&circle, f32::NAN),
-            Err(GeometryProportionError::Path(PathProportionError::InvalidProportion(_)))
+            Err(GeometryProportionError::Path(
+                PathProportionError::InvalidProportion(_)
+            ))
         ));
         assert_eq!(
             point_from_geometry_proportion(&GeometryRef::rectangle(1.0, 1.0), 0.5),

--- a/crates/noon-geometry/src/geometry_proportion.rs
+++ b/crates/noon-geometry/src/geometry_proportion.rs
@@ -1,0 +1,155 @@
+use noon_core::{GeometryRef, Vec2, TAU};
+
+use crate::{point_from_proportion, PathProportionError};
+
+const MANIM_CIRCLE_COMPONENTS: usize = 9;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum GeometryProportionError {
+    Path(PathProportionError),
+    UnsupportedGeometry,
+}
+
+impl std::fmt::Display for GeometryProportionError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Path(error) => error.fmt(formatter),
+            Self::UnsupportedGeometry => formatter.write_str(
+                "point_from_proportion requires retained circle, line, or vector-path geometry",
+            ),
+        }
+    }
+}
+
+impl std::error::Error for GeometryProportionError {}
+
+impl From<PathProportionError> for GeometryProportionError {
+    fn from(value: PathProportionError) -> Self {
+        Self::Path(value)
+    }
+}
+
+/// Return the local-space point at `alpha` for path-like retained geometry.
+///
+/// Vector paths reuse [`point_from_proportion`]. Lines remain exact analytic
+/// segments. Circles reproduce ManimCE v0.21's nine-component quadratic-Bezier
+/// `Arc(TAU)` representation rather than substituting an ideal trigonometric
+/// circle, so downstream tangent/path queries observe the same authored curve.
+pub fn point_from_geometry_proportion(
+    geometry: &GeometryRef,
+    alpha: f32,
+) -> Result<Vec2, GeometryProportionError> {
+    validate_proportion(alpha)?;
+    match geometry {
+        GeometryRef::Circle { radius } => Ok(circle_point_from_proportion(*radius, alpha)),
+        GeometryRef::Line { start, end } => Ok(*start + (*end - *start) * alpha),
+        GeometryRef::VectorPath(path) => Ok(point_from_proportion(path, alpha)?),
+        GeometryRef::Rectangle { .. } | GeometryRef::External(_) => {
+            Err(GeometryProportionError::UnsupportedGeometry)
+        }
+    }
+}
+
+fn validate_proportion(alpha: f32) -> Result<(), GeometryProportionError> {
+    if !alpha.is_finite() || !(0.0..=1.0).contains(&alpha) {
+        return Err(PathProportionError::InvalidProportion(alpha).into());
+    }
+    Ok(())
+}
+
+fn circle_point_from_proportion(radius: f32, alpha: f32) -> Vec2 {
+    if alpha == 1.0 {
+        return Vec2::new(radius, 0.0);
+    }
+
+    let component_count = MANIM_CIRCLE_COMPONENTS as f32;
+    let scaled = alpha * component_count;
+    let component = (scaled.floor() as usize).min(MANIM_CIRCLE_COMPONENTS - 1);
+    let t = scaled - component as f32;
+    let theta = TAU / component_count;
+    let start_angle = component as f32 * theta;
+    let end_angle = (component + 1) as f32 * theta;
+    let middle_angle = (start_angle + end_angle) * 0.5;
+    let control_radius = radius / (theta * 0.5).cos();
+
+    let start = Vec2::new(start_angle.cos() * radius, start_angle.sin() * radius);
+    let control = Vec2::new(
+        middle_angle.cos() * control_radius,
+        middle_angle.sin() * control_radius,
+    );
+    let end = Vec2::new(end_angle.cos() * radius, end_angle.sin() * radius);
+
+    let first = start + (control - start) * t;
+    let second = control + (end - control) * t;
+    first + (second - first) * t
+}
+
+#[cfg(test)]
+mod tests {
+    use noon_core::VectorPath;
+
+    use super::*;
+
+    fn assert_point(actual: Vec2, expected: Vec2) {
+        assert!(
+            (actual.x - expected.x).abs() <= 1.0e-5
+                && (actual.y - expected.y).abs() <= 1.0e-5,
+            "{actual:?} != {expected:?}"
+        );
+    }
+
+    #[test]
+    fn circle_matches_manim_quadratic_arc_proportion_samples() {
+        let circle = GeometryRef::circle(2.0);
+        assert_point(
+            point_from_geometry_proportion(&circle, 0.0).unwrap(),
+            Vec2::new(2.0, 0.0),
+        );
+        assert_point(
+            point_from_geometry_proportion(&circle, 0.25).unwrap(),
+            Vec2::new(-0.0057401983, 2.0021698),
+        );
+        assert_point(
+            point_from_geometry_proportion(&circle, 0.4).unwrap(),
+            Vec2::new(-1.6191778, 1.1800613),
+        );
+        assert_point(
+            point_from_geometry_proportion(&circle, 1.0).unwrap(),
+            Vec2::new(2.0, 0.0),
+        );
+    }
+
+    #[test]
+    fn line_and_vector_path_keep_existing_shared_measures() {
+        let line = GeometryRef::line(Vec2::new(-2.0, 1.0), Vec2::new(2.0, 1.0));
+        assert_point(
+            point_from_geometry_proportion(&line, 0.75).unwrap(),
+            Vec2::new(1.0, 1.0),
+        );
+
+        let path = GeometryRef::VectorPath(
+            VectorPath::new()
+                .move_to(Vec2::ZERO)
+                .quadratic_to(Vec2::new(1.0, 2.0), Vec2::new(2.0, 0.0)),
+        );
+        assert_point(
+            point_from_geometry_proportion(&path, 0.5).unwrap(),
+            Vec2::new(1.0, 1.0),
+        );
+    }
+
+    #[test]
+    fn invalid_proportion_and_non_path_geometry_are_rejected() {
+        let circle = GeometryRef::circle(1.0);
+        assert!(matches!(
+            point_from_geometry_proportion(&circle, f32::NAN),
+            Err(GeometryProportionError::Path(
+                PathProportionError::InvalidProportion(_)
+            ))
+        ));
+        assert_eq!(
+            point_from_geometry_proportion(&GeometryRef::rectangle(1.0, 1.0), 0.5),
+            Err(GeometryProportionError::UnsupportedGeometry)
+        );
+    }
+}

--- a/crates/noon-geometry/src/lib.rs
+++ b/crates/noon-geometry/src/lib.rs
@@ -2,11 +2,13 @@
 
 #![forbid(unsafe_code)]
 
+mod geometry_proportion;
 mod morph;
 mod outline;
 mod partial;
 mod tessellation;
 
+pub use geometry_proportion::*;
 pub use morph::*;
 pub use outline::*;
 pub use partial::*;

--- a/crates/noon-web/src/manim_path_query_bridge.rs
+++ b/crates/noon-web/src/manim_path_query_bridge.rs
@@ -1,5 +1,5 @@
-use noon_core::{GeometryRef, ObjectSnapshot, Vec2};
-use noon_geometry::point_from_proportion;
+use noon_core::{ObjectSnapshot, Vec2};
+use noon_geometry::point_from_geometry_proportion;
 
 fn validate_alpha(alpha: f64) -> Result<f32, String> {
     if !alpha.is_finite() || !(0.0..=1.0).contains(&alpha) {
@@ -10,39 +10,19 @@ fn validate_alpha(alpha: f64) -> Result<f32, String> {
     Ok(alpha as f32)
 }
 
-fn transform_point(snapshot: &ObjectSnapshot, point: Vec2) -> Vec2 {
-    let transform = snapshot.transform;
-    let scaled = Vec2::new(point.x * transform.scale.x, point.y * transform.scale.y);
-    let sine = transform.rotation.sin();
-    let cosine = transform.rotation.cos();
-    Vec2::new(
-        scaled.x * cosine - scaled.y * sine + transform.translation.x,
-        scaled.x * sine + scaled.y * cosine + transform.translation.y,
-    )
-}
-
 /// Query ManimCE v0.21-compatible path position from an ordinary retained snapshot.
 ///
-/// Vector paths use the shared `noon-geometry` ten-sample Bezier length measure.
-/// Analytic lines stay analytic and use exact linear interpolation. The returned point
-/// is transformed into world space from the snapshot's current retained transform.
+/// Path-like geometry resolution is owned by `noon-geometry`: vector paths use
+/// Manim's sampled Bezier length measure, lines remain analytic, and circles use
+/// Manim's nine-component quadratic Arc representation. This bridge only decodes
+/// the snapshot and applies its current retained transform into world space.
 pub fn manim_point_from_proportion(snapshot_json: &str, alpha: f64) -> Result<Vec2, String> {
     let alpha = validate_alpha(alpha)?;
     let snapshot: ObjectSnapshot = serde_json::from_str(snapshot_json)
         .map_err(|error| format!("invalid path query snapshot: {error}"))?;
-
-    let local = match &snapshot.geometry {
-        GeometryRef::Line { start, end } => *start + (*end - *start) * alpha,
-        GeometryRef::VectorPath(path) => {
-            point_from_proportion(path, alpha).map_err(|error| error.to_string())?
-        }
-        _ => {
-            return Err(
-                "point_from_proportion requires retained line or vector-path geometry".to_owned(),
-            )
-        }
-    };
-    Ok(transform_point(&snapshot, local))
+    let local = point_from_geometry_proportion(&snapshot.geometry, alpha)
+        .map_err(|error| error.to_string())?;
+    Ok(snapshot.transform.transform_point(local))
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -153,11 +133,24 @@ mod tests {
     }
 
     #[test]
+    fn query_circle_matches_manim_arc_measure_then_applies_transform() {
+        let snapshot = ObjectSnapshot::new(GeometryRef::circle(2.0))
+            .scale_xy(Vec2::new(0.5, 2.0))
+            .shift(Vec2::new(3.0, -1.0));
+
+        assert_point(
+            manim_point_from_proportion(&encode(&snapshot), 0.4).expect("circle query"),
+            Vec2::new(2.190411, 1.3601226),
+        );
+    }
+
+    #[test]
     fn query_rejects_invalid_alpha_snapshot_and_unsupported_geometry() {
         let circle = encode(&ObjectSnapshot::new(GeometryRef::circle(1.0)));
+        let rectangle = encode(&ObjectSnapshot::new(GeometryRef::rectangle(1.0, 1.0)));
         assert!(manim_point_from_proportion(&circle, -0.1).is_err());
         assert!(manim_point_from_proportion(&circle, f64::NAN).is_err());
         assert!(manim_point_from_proportion("not json", 0.5).is_err());
-        assert!(manim_point_from_proportion(&circle, 0.5).is_err());
+        assert!(manim_point_from_proportion(&rectangle, 0.5).is_err());
     }
 }


### PR DESCRIPTION
## Summary
- add a renderer-independent `point_from_geometry_proportion` boundary in `noon-geometry`
- preserve the existing ManimCE v0.21 sampled measure for `VectorPath` and exact interpolation for retained `Line`
- support analytic retained `Circle` without converting it into persistent path geometry
- reproduce ManimCE v0.21 `Circle` query semantics from its nine-component quadratic `Arc(TAU)` representation rather than using an ideal trig circle
- route the existing WASM/browser `manimPointFromProportion` bridge through the shared geometry authority and use `Transform2D::transform_point` for world-space adaptation

## Current integration
The feature is based directly on current master `9496b36b92c53eedec81f3c6cef164251215b688` after the old branch had fallen far behind. On replay head `c4a4aec626e067811e8ec863a176ad177fa9b061`, Rust unit tests, web static/unit checks, the one-time WASM build, deterministic playback, Manim authoring, and primary WebGPU rendering all passed; the sole fast-gate failure was `cargo fmt --check` in the new nested error-pattern assertion.

That formatting defect is corrected on current head `e02de0336488c2226430333cbff6f7d028bf1478` without changing behavior or tolerances. Fresh exact-head qualification is running.

## Architecture
Path semantics remain in `noon-geometry`; the browser bridge only decodes a retained snapshot and applies its retained transform. Circle support remains analytic in scene storage and only reproduces Manim's quadratic Arc measure for the query itself. No frontend geometry reconstruction, renderer primitive, or per-frame work is introduced.

## Focused coverage
- pinned Manim-compatible Circle samples at alpha 0, 0.25, 0.4, and 1
- existing Line and quadratic VectorPath measures remain unchanged
- browser bridge applies retained nonuniform scale/translation after the shared Circle query
- invalid proportions and unsupported geometry fail explicitly

Tracks #78 and unblocks #77/#256.