### PR TITLE
Keep prepared authoring execution unpublished until engine selection

### DIFF
--- a/web/authoring-execution-client.js
+++ b/web/authoring-execution-client.js
@@ -25,6 +25,7 @@ const EMPTY_HOST_METRICS = Object.freeze({
 export class AuthoringExecutionClient {
   #canvas;
   #player = null;
+  #preparedPlayer = null;
   #mode = null;
   #rendererBackend = "";
   #loopDurationSeconds = DEFAULT_LOOP_DURATION_SECONDS;
@@ -68,12 +69,52 @@ export class AuthoringExecutionClient {
     return this.#transportMode;
   }
 
+  async prepare(
+    {
+      transportMode = undefined,
+      sharedSlotCapacity = DEFAULT_SHARED_SLOT_CAPACITY,
+    } = {},
+  ) {
+    if (this.#player !== null || this.#preparedPlayer !== null || this.#transition !== null) {
+      throw new Error("AuthoringExecutionClient is already started or preparing");
+    }
+    this.#sharedSlotCapacity = validateSharedSlotCapacity(sharedSlotCapacity);
+    const options = { sharedSlotCapacity: this.#sharedSlotCapacity };
+    if (transportMode !== undefined) {
+      options.transportMode = transportMode;
+    }
+
+    const generation = this.#lifecycleGeneration;
+    const player = this.#createPlayer();
+    this.#preparedPlayer = player;
+    try {
+      const ready = await player.prepare(options);
+      this.#assertLifecycleCurrent(generation);
+      if (this.#preparedPlayer !== player && this.#player !== player) {
+        throw new Error(LIFECYCLE_CANCELLED_MESSAGE);
+      }
+      this.#transportMode = ready.transportMode;
+      return ready;
+    } catch (error) {
+      if (this.#preparedPlayer === player) {
+        this.#preparedPlayer = null;
+      }
+      if (generation === this.#lifecycleGeneration) {
+        this.#adoptPlayerCanvas(player);
+      }
+      if (generation !== this.#lifecycleGeneration) {
+        throw new Error(LIFECYCLE_CANCELLED_MESSAGE);
+      }
+      throw error;
+    }
+  }
+
   async start(
     sceneJson,
     {
       loopDurationSeconds = DEFAULT_LOOP_DURATION_SECONDS,
       transportMode = undefined,
-      sharedSlotCapacity = DEFAULT_SHARED_SLOT_CAPACITY,
+      sharedSlotCapacity = undefined,
     } = {},
   ) {
     if (this.#player !== null || this.#transition !== null) {
@@ -81,7 +122,7 @@ export class AuthoringExecutionClient {
     }
     validateSceneJson(sceneJson);
     this.#loopDurationSeconds = validateLoopDurationSeconds(loopDurationSeconds);
-    this.#sharedSlotCapacity = validateSharedSlotCapacity(sharedSlotCapacity);
+    this.#sharedSlotCapacity = this.#resolveStartupSharedSlotCapacity(sharedSlotCapacity);
     const options = {
       loopDurationSeconds: this.#loopDurationSeconds,
       sharedSlotCapacity: this.#sharedSlotCapacity,
@@ -105,7 +146,7 @@ export class AuthoringExecutionClient {
     {
       loopDurationSeconds = DEFAULT_LOOP_DURATION_SECONDS,
       transportMode = undefined,
-      sharedSlotCapacity = DEFAULT_SHARED_SLOT_CAPACITY,
+      sharedSlotCapacity = undefined,
     } = {},
   ) {
     if (this.#player !== null || this.#transition !== null) {
@@ -117,7 +158,7 @@ export class AuthoringExecutionClient {
       throw new TypeError("retained startup requires at least one retained object");
     }
     this.#loopDurationSeconds = validateLoopDurationSeconds(loopDurationSeconds);
-    this.#sharedSlotCapacity = validateSharedSlotCapacity(sharedSlotCapacity);
+    this.#sharedSlotCapacity = this.#resolveStartupSharedSlotCapacity(sharedSlotCapacity);
     const options = {
       loopDurationSeconds: this.#loopDurationSeconds,
       sharedSlotCapacity: this.#sharedSlotCapacity,
@@ -276,6 +317,12 @@ export class AuthoringExecutionClient {
     this.#lifecycleGeneration += 1;
     this.#resizeObserver?.disconnect();
     this.#resizeObserver = null;
+    const preparedPlayer = this.#preparedPlayer;
+    preparedPlayer?.terminate();
+    if (preparedPlayer !== null && this.#canvas !== preparedPlayer.canvas) {
+      this.#canvas = preparedPlayer.canvas;
+    }
+    this.#preparedPlayer = null;
     this.#player?.terminate();
     this.#player = null;
     this.#mode = null;
@@ -285,10 +332,7 @@ export class AuthoringExecutionClient {
 
   async #startMode(mode, sceneJson, retainedDocumentJson, options) {
     const generation = this.#lifecycleGeneration;
-    const player = new ExecutionWorkerClient(this.#canvas, {
-      onError: this.#onError,
-      onRecoverableError: this.#onRecoverableError,
-    });
+    const player = this.#preparedPlayer ?? this.#createPlayer();
     const terminateCandidate = createIdempotentTerminator(player);
     let published = false;
     try {
@@ -297,6 +341,9 @@ export class AuthoringExecutionClient {
           ? await player.startRetained(sceneJson, retainedDocumentJson, options)
           : await player.start(sceneJson, options);
       this.#assertLifecycleCurrent(generation, terminateCandidate);
+      if (this.#preparedPlayer === player) {
+        this.#preparedPlayer = null;
+      }
       this.#player = player;
       published = true;
       this.#mode = mode;
@@ -304,6 +351,9 @@ export class AuthoringExecutionClient {
       this.#resizeCurrentCanvas();
       return ready;
     } catch (error) {
+      if (this.#preparedPlayer === player) {
+        this.#preparedPlayer = null;
+      }
       if (!published || generation === this.#lifecycleGeneration) {
         terminateCandidate();
       }
@@ -315,6 +365,22 @@ export class AuthoringExecutionClient {
       }
       throw error;
     }
+  }
+
+  #createPlayer() {
+    return new ExecutionWorkerClient(this.#canvas, {
+      onError: this.#onError,
+      onRecoverableError: this.#onRecoverableError,
+    });
+  }
+
+  #resolveStartupSharedSlotCapacity(sharedSlotCapacity) {
+    if (sharedSlotCapacity !== undefined) {
+      return validateSharedSlotCapacity(sharedSlotCapacity);
+    }
+    return this.#preparedPlayer === null
+      ? DEFAULT_SHARED_SLOT_CAPACITY
+      : this.#sharedSlotCapacity;
   }
 
   async #switchRetained(sceneJson, retainedDocumentJson) {

--- a/web/authoring-execution-prepared-start.test.mjs
+++ b/web/authoring-execution-prepared-start.test.mjs
@@ -1,0 +1,217 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+class FakeCanvas {
+  clientWidth = 640;
+  clientHeight = 360;
+  width = 640;
+  height = 360;
+  replacement = null;
+  transferred = false;
+
+  transferControlToOffscreen() {
+    if (this.transferred) {
+      throw new Error("canvas was transferred twice");
+    }
+    this.transferred = true;
+    return { width: this.width, height: this.height };
+  }
+
+  cloneNode() {
+    const clone = new FakeCanvas();
+    clone.clientWidth = this.clientWidth;
+    clone.clientHeight = this.clientHeight;
+    clone.width = this.width;
+    clone.height = this.height;
+    return clone;
+  }
+
+  replaceWith(replacement) {
+    this.replacement = replacement;
+  }
+}
+
+class FakeWorker {
+  static instances = [];
+
+  listeners = new Map();
+  messages = [];
+  terminated = false;
+
+  constructor(url, options = {}) {
+    this.url = String(url);
+    this.name = options.name ?? "";
+    FakeWorker.instances.push(this);
+  }
+
+  addEventListener(type, listener) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  postMessage(message, transfer = []) {
+    this.messages.push({ message, transfer });
+  }
+
+  terminate() {
+    this.terminated = true;
+  }
+
+  emitMessage(message) {
+    for (const listener of this.listeners.get("message") ?? []) {
+      listener({ data: message });
+    }
+  }
+}
+
+globalThis.HTMLCanvasElement = FakeCanvas;
+globalThis.Worker = FakeWorker;
+globalThis.window = { devicePixelRatio: 1 };
+
+const { AuthoringExecutionClient } = await import("./authoring-execution-client.js");
+
+const SCENE_JSON = JSON.stringify({ version: 1, objects: [], tracks: [] });
+const RETAINED_DOCUMENT_JSON = JSON.stringify({
+  channel: "noon.authoring.retained",
+  objects: [{ id: 1 }],
+});
+const NON_DEFAULT_SHARED_SLOT_CAPACITY = 2 * 1024 * 1024;
+
+function envelope(channel, type, payload = {}) {
+  return { channel, protocolVersion: 1, type, ...payload };
+}
+
+function workerByName(offset, name) {
+  const worker = FakeWorker.instances.slice(offset).find((candidate) => candidate.name === name);
+  assert.ok(worker, `missing worker ${name}`);
+  return worker;
+}
+
+function requestMessage(worker, type) {
+  const entry = worker.messages.findLast(({ message }) => message.type === type);
+  assert.ok(entry, `missing ${worker.name} ${type} request`);
+  return entry.message;
+}
+
+function acknowledgePreparation(render) {
+  const request = requestMessage(render, "prepare");
+  render.emitMessage(
+    envelope("noon.render", "prepared", {
+      requestId: request.requestId,
+      transportMode: "transferable",
+      width: 640,
+      height: 360,
+    }),
+  );
+  return request;
+}
+
+function finishRetainedStart(render, engine) {
+  const startRequest = requestMessage(render, "start_engine");
+  engine.emitMessage(
+    envelope("noon.engine", "ready", {
+      transportMode: "transferable",
+      retained: true,
+      mixed: true,
+    }),
+  );
+  render.emitMessage(
+    envelope("noon.render", "engine_started", {
+      requestId: startRequest.requestId,
+      mode: "retained",
+      transportMode: "transferable",
+      backend: "WebGL2",
+    }),
+  );
+}
+
+test("prepared authoring execution stays unpublished until the authored engine is ready", async () => {
+  FakeWorker.instances.length = 0;
+  const client = new AuthoringExecutionClient(new FakeCanvas());
+  const preparation = client.prepare({ transportMode: "transferable" });
+  const render = workerByName(0, "noon-render");
+  const prepareRequest = requestMessage(render, "prepare");
+
+  assert.equal(client.mode, null, "mode must remain unpublished during render preparation");
+  await assert.rejects(
+    client.state(),
+    /AuthoringExecutionClient has not been started/,
+    "prepared resources must not make public execution state available",
+  );
+
+  const started = client.startRetained(SCENE_JSON, RETAINED_DOCUMENT_JSON);
+  assert.equal(client.mode, null, "mode must remain unpublished while preparation is pending");
+  assert.equal(
+    FakeWorker.instances.some(({ name }) => name === "noon-mixed-retained-engine"),
+    false,
+    "authored engine startup must wait for the render preparation barrier",
+  );
+
+  render.emitMessage(
+    envelope("noon.render", "prepared", {
+      requestId: prepareRequest.requestId,
+      transportMode: "transferable",
+      width: 640,
+      height: 360,
+    }),
+  );
+  await preparation;
+  await new Promise((resolve) => setImmediate(resolve));
+
+  const engine = workerByName(1, "noon-mixed-retained-engine");
+  finishRetainedStart(render, engine);
+
+  const ready = await started;
+  assert.equal(ready.session, 1);
+  assert.equal(client.mode, "retained");
+  assert.equal(client.rendererBackend, "WebGL2");
+  client.terminate();
+});
+
+test("prepared authoring startup inherits a non-default shared slot capacity", async () => {
+  FakeWorker.instances.length = 0;
+  const client = new AuthoringExecutionClient(new FakeCanvas());
+  const preparation = client.prepare({
+    transportMode: "transferable",
+    sharedSlotCapacity: NON_DEFAULT_SHARED_SLOT_CAPACITY,
+  });
+  const render = workerByName(0, "noon-render");
+  acknowledgePreparation(render);
+  await preparation;
+
+  const started = client.startRetained(SCENE_JSON, RETAINED_DOCUMENT_JSON);
+  await new Promise((resolve) => setImmediate(resolve));
+  const engine = workerByName(1, "noon-mixed-retained-engine");
+  const init = requestMessage(engine, "init");
+  assert.equal(
+    init.sharedSlotCapacity,
+    NON_DEFAULT_SHARED_SLOT_CAPACITY,
+    "authored startup must inherit the prepared transport capacity when no override is supplied",
+  );
+  finishRetainedStart(render, engine);
+  await started;
+  client.terminate();
+});
+
+test("terminating during render preparation cancels the unpublished candidate and adopts its fresh canvas", async () => {
+  FakeWorker.instances.length = 0;
+  const original = new FakeCanvas();
+  const client = new AuthoringExecutionClient(original);
+  const preparation = client.prepare({ transportMode: "transferable" });
+  const render = workerByName(0, "noon-render");
+
+  client.terminate();
+
+  await assert.rejects(
+    preparation,
+    /AuthoringExecutionClient was terminated during an asynchronous operation/,
+  );
+  assert.equal(render.terminated, true);
+  assert.equal(original.transferred, true);
+  assert.notEqual(client.canvas, original);
+  assert.equal(original.replacement, client.canvas);
+  assert.equal(client.canvas.transferred, false);
+  assert.equal(client.mode, null);
+  await assert.rejects(client.state(), /AuthoringExecutionClient has not been started/);
+});


### PR DESCRIPTION
Superseded by #941, merged as `a5824e4e8e9550b955ec3a6d1113d3bc5db08dc5`.

The original branch targeted the older split-retained startup API. #941 ports the same facade-level prepared-owner design onto current canonical `startRetainedCanonical(SceneSpec)` semantics, preserves later callback/mode-switch/lifecycle work, and depends on the generation-safe low-level rollback fixed in #931.

The merged replacement keeps render/WASM preparation unpublished until authored engine selection, reuses the prepared owner for legacy or canonical retained startup, inherits prepared shared-slot capacity when startup does not override it, and adopts the replacement canvas safely on cancellation.

Its exact head passed PR Fast Gate plus the dedicated playground authoring-recovery/stress workflow before merge. Closing this stale branch in favor of the current implementation.