### PR TITLE
Share transformed tangent-segment semantics

### DIFF
--- a/crates/noon-geometry/src/geometry_proportion.rs
+++ b/crates/noon-geometry/src/geometry_proportion.rs
@@ -1,4 +1,4 @@
-use noon_core::{GeometryRef, Vec2, TAU};
+use noon_core::{GeometryRef, Transform2D, Vec2, TAU};
 
 use crate::{point_from_proportion, PathProportionError};
 
@@ -50,6 +50,100 @@ pub fn point_from_geometry_proportion(
     }
 }
 
+/// A world-space finite-difference tangent segment sampled from retained geometry.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct TangentSegment {
+    pub start: Vec2,
+    pub end: Vec2,
+}
+
+impl TangentSegment {
+    pub fn length(self) -> f32 {
+        (self.end - self.start).length()
+    }
+
+    pub fn center(self) -> Vec2 {
+        (self.start + self.end) * 0.5
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum TangentSegmentError {
+    Geometry(GeometryProportionError),
+    NonFiniteLength(f32),
+    InvalidDelta(f32),
+    DegenerateSample,
+}
+
+impl std::fmt::Display for TangentSegmentError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Geometry(error) => error.fmt(formatter),
+            Self::NonFiniteLength(length) => {
+                write!(formatter, "tangent length must be finite, got {length}")
+            }
+            Self::InvalidDelta(delta) => write!(
+                formatter,
+                "tangent sample delta must be finite and greater than zero, got {delta}"
+            ),
+            Self::DegenerateSample => {
+                formatter.write_str("tangent sample points collapse to one world-space point")
+            }
+        }
+    }
+}
+
+impl std::error::Error for TangentSegmentError {}
+
+impl From<GeometryProportionError> for TangentSegmentError {
+    fn from(value: GeometryProportionError) -> Self {
+        Self::Geometry(value)
+    }
+}
+
+/// Sample and normalize a finite-difference tangent in world space.
+///
+/// This mirrors the geometry kernel used by ManimCE v0.21 `TangentLine`: sample
+/// `alpha - d_alpha` and `alpha + d_alpha` after clipping to `[0, 1]`, construct
+/// the chord between those current transformed points, then scale that chord about
+/// its center to `length`. Sampling before normalization is important for
+/// non-uniformly transformed paths because their world-space tangent differs from
+/// the local tangent transformed after normalization.
+///
+/// Negative finite lengths are intentionally supported and reverse the segment,
+/// matching a negative scale factor. A zero length collapses both endpoints to the
+/// sampled chord center.
+pub fn tangent_segment_from_geometry_proportion(
+    geometry: &GeometryRef,
+    transform: Transform2D,
+    alpha: f32,
+    length: f32,
+    d_alpha: f32,
+) -> Result<TangentSegment, TangentSegmentError> {
+    validate_proportion(alpha)?;
+    if !length.is_finite() {
+        return Err(TangentSegmentError::NonFiniteLength(length));
+    }
+    if !d_alpha.is_finite() || d_alpha <= 0.0 {
+        return Err(TangentSegmentError::InvalidDelta(d_alpha));
+    }
+
+    let lower = (alpha - d_alpha).clamp(0.0, 1.0);
+    let upper = (alpha + d_alpha).clamp(0.0, 1.0);
+    let lower = transform.transform_point(point_from_geometry_proportion(geometry, lower)?);
+    let upper = transform.transform_point(point_from_geometry_proportion(geometry, upper)?);
+    let direction = (upper - lower)
+        .normalized()
+        .ok_or(TangentSegmentError::DegenerateSample)?;
+    let center = (lower + upper) * 0.5;
+    let half = direction * (length * 0.5);
+
+    Ok(TangentSegment {
+        start: center - half,
+        end: center + half,
+    })
+}
+
 fn validate_proportion(alpha: f32) -> Result<(), GeometryProportionError> {
     if !alpha.is_finite() || !(0.0..=1.0).contains(&alpha) {
         return Err(PathProportionError::InvalidProportion(alpha).into());
@@ -97,6 +191,13 @@ mod tests {
         );
     }
 
+    fn assert_point_loose(actual: Vec2, expected: Vec2) {
+        assert!(
+            (actual.x - expected.x).abs() <= 2.0e-4 && (actual.y - expected.y).abs() <= 2.0e-4,
+            "{actual:?} != {expected:?}"
+        );
+    }
+
     #[test]
     fn circle_matches_manim_quadratic_arc_proportion_samples() {
         let circle = GeometryRef::circle(2.0);
@@ -135,6 +236,100 @@ mod tests {
             point_from_geometry_proportion(&path, 0.5).unwrap(),
             Vec2::new(1.0, 1.0),
         );
+    }
+
+    #[test]
+    fn tangent_segment_matches_manim_circle_finite_difference() {
+        let segment = tangent_segment_from_geometry_proportion(
+            &GeometryRef::circle(2.0),
+            Transform2D::IDENTITY,
+            0.4,
+            4.0,
+            1.0e-6,
+        )
+        .unwrap();
+
+        assert_point_loose(segment.start, Vec2::new(-0.4482279, 2.8014423));
+        assert_point_loose(segment.end, Vec2::new(-2.7901278, -0.44131965));
+        assert!((segment.length() - 4.0).abs() <= 2.0e-4);
+    }
+
+    #[test]
+    fn tangent_segment_normalizes_after_world_transform_and_clips_endpoint_samples() {
+        let transform = Transform2D {
+            translation: Vec2::new(1.0, -1.0),
+            rotation: 0.3,
+            scale: Vec2::new(2.0, 0.5),
+        };
+        let transformed = tangent_segment_from_geometry_proportion(
+            &GeometryRef::circle(2.0),
+            transform,
+            0.4,
+            3.0,
+            1.0e-4,
+        )
+        .unwrap();
+        assert_point_loose(transformed.start, Vec2::new(-1.058928, -0.50566184));
+        assert_point_loose(transformed.end, Vec2::new(-3.4772415, -2.2809815));
+        assert!((transformed.length() - 3.0).abs() <= 2.0e-4);
+
+        let endpoint = tangent_segment_from_geometry_proportion(
+            &GeometryRef::circle(2.0),
+            Transform2D::IDENTITY,
+            0.0,
+            4.0,
+            1.0e-6,
+        )
+        .unwrap();
+        assert_point_loose(endpoint.start, Vec2::new(2.0000057, -1.9999934));
+        assert_point_loose(endpoint.end, Vec2::new(1.9999942, 2.0000067));
+    }
+
+    #[test]
+    fn tangent_segment_preserves_zero_negative_and_invalid_input_policy() {
+        let line = GeometryRef::line(Vec2::new(-1.0, 0.0), Vec2::new(1.0, 0.0));
+        let zero = tangent_segment_from_geometry_proportion(
+            &line,
+            Transform2D::IDENTITY,
+            0.5,
+            0.0,
+            1.0e-6,
+        )
+        .unwrap();
+        assert_point(zero.start, Vec2::ZERO);
+        assert_point(zero.end, Vec2::ZERO);
+
+        let negative = tangent_segment_from_geometry_proportion(
+            &line,
+            Transform2D::IDENTITY,
+            0.5,
+            -2.0,
+            1.0e-6,
+        )
+        .unwrap();
+        assert_point(negative.start, Vec2::new(1.0, 0.0));
+        assert_point(negative.end, Vec2::new(-1.0, 0.0));
+
+        assert!(matches!(
+            tangent_segment_from_geometry_proportion(
+                &line,
+                Transform2D::IDENTITY,
+                0.5,
+                1.0,
+                0.0,
+            ),
+            Err(TangentSegmentError::InvalidDelta(0.0))
+        ));
+        assert!(matches!(
+            tangent_segment_from_geometry_proportion(
+                &GeometryRef::circle(0.0),
+                Transform2D::IDENTITY,
+                0.5,
+                1.0,
+                1.0e-6,
+            ),
+            Err(TangentSegmentError::DegenerateSample)
+        ));
     }
 
     #[test]

--- a/crates/noon-geometry/src/geometry_proportion.rs
+++ b/crates/noon-geometry/src/geometry_proportion.rs
@@ -84,7 +84,7 @@ impl std::fmt::Display for TangentSegmentError {
             }
             Self::InvalidDelta(delta) => write!(
                 formatter,
-                "tangent sample delta must be finite and greater than zero, got {delta}"
+                "tangent sample delta must be finite and nonzero, got {delta}"
             ),
             Self::DegenerateSample => {
                 formatter.write_str("tangent sample points collapse to one world-space point")
@@ -111,8 +111,9 @@ impl From<GeometryProportionError> for TangentSegmentError {
 /// the local tangent transformed after normalization.
 ///
 /// Negative finite lengths are intentionally supported and reverse the segment,
-/// matching a negative scale factor. A zero length collapses both endpoints to the
-/// sampled chord center.
+/// matching a negative scale factor. Negative finite sample deltas are also kept:
+/// they reverse the sampled chord just as Manim does. A zero length collapses both
+/// endpoints to the sampled chord center.
 pub fn tangent_segment_from_geometry_proportion(
     geometry: &GeometryRef,
     transform: Transform2D,
@@ -124,7 +125,7 @@ pub fn tangent_segment_from_geometry_proportion(
     if !length.is_finite() {
         return Err(TangentSegmentError::NonFiniteLength(length));
     }
-    if !d_alpha.is_finite() || d_alpha <= 0.0 {
+    if !d_alpha.is_finite() || d_alpha == 0.0 {
         return Err(TangentSegmentError::InvalidDelta(d_alpha));
     }
 
@@ -310,14 +311,19 @@ mod tests {
         assert_point(negative.start, Vec2::new(1.0, 0.0));
         assert_point(negative.end, Vec2::new(-1.0, 0.0));
 
+        let negative_delta = tangent_segment_from_geometry_proportion(
+            &line,
+            Transform2D::IDENTITY,
+            0.5,
+            2.0,
+            -1.0e-3,
+        )
+        .unwrap();
+        assert_point(negative_delta.start, Vec2::new(1.0, 0.0));
+        assert_point(negative_delta.end, Vec2::new(-1.0, 0.0));
+
         assert!(matches!(
-            tangent_segment_from_geometry_proportion(
-                &line,
-                Transform2D::IDENTITY,
-                0.5,
-                1.0,
-                0.0,
-            ),
+            tangent_segment_from_geometry_proportion(&line, Transform2D::IDENTITY, 0.5, 1.0, 0.0,),
             Err(TangentSegmentError::InvalidDelta(0.0))
         ));
         assert!(matches!(


### PR DESCRIPTION
## Status: closed after precision review

The architectural split is still correct, but validation exposed a prerequisite that makes this implementation unsafe to merge.

ManimCE v0.21 `TangentLine` samples `point_from_proportion(alpha ± d_alpha)` with the default `d_alpha=1e-6` in NumPy/f64. Noon's current shared proportion boundary (#652 and the existing browser bridge) evaluates/downcasts the proportion and path arithmetic in f32. For the pinned `Circle(radius=2), alpha=0.4, length=4` case, that tiny finite difference suffers enough f32 cancellation to shift the normalized 4-unit tangent endpoints by roughly 0.003 compared with the f64 Manim construction. Loosening the test would hide a real semantic mismatch.

A sound `TangentLine` implementation therefore needs a precision-preserving shared path-query/tangent boundary first: either f64 internal sampling/evaluation (without duplicating the path-measure implementation) or another mathematically equivalent shared representation proven against corner/curve-boundary semantics. Special-casing Circle or using an analytic derivative only for this example would violate the shared-geometry architecture and would not cover generic VMobjects.

The branch demonstrated the intended ownership boundary—sample transformed points before normalization, keep renderer/frontends out of tangent math—but should not become authoritative until #78 resolves the precision seam. No production code from this PR should be merged.

Related: #77, #78, #256. #653 remains independent and unaffected.