### PR TITLE
Serialize prepared execution startup

### DIFF
--- a/web/execution-worker-client.js
+++ b/web/execution-worker-client.js
@@ -24,6 +24,7 @@ export class ExecutionWorkerClient {
   #candidateEngineReject = null;
   #renderWorker = null;
   #renderPrepared = null;
+  #preparedStartReservation = null;
   #nextRequestIds = { engine: 0, render: 0 };
   #pending = new Map();
   #session = 0;
@@ -180,7 +181,7 @@ export class ExecutionWorkerClient {
       sharedSlotCapacity,
     },
   ) {
-    if (this.#engineWorker !== null) {
+    if (this.#engineWorker !== null || this.#preparedStartReservation !== null) {
       throw new Error("ExecutionWorkerClient is already started");
     }
     const preparedRender = this.#renderWorker !== null;
@@ -209,13 +210,21 @@ export class ExecutionWorkerClient {
       if (slotCapacity !== this.#sharedSlotCapacity) {
         throw new Error("prepared shared slot capacity does not match execution startup");
       }
-      await this.#renderPrepared;
-      return this.#startPreparedMode(
-        mode,
-        sceneJson,
-        retainedDocumentJson,
-        loopDurationSeconds,
-      );
+      const reservation = {};
+      this.#preparedStartReservation = reservation;
+      try {
+        await this.#renderPrepared;
+        return await this.#startPreparedMode(
+          mode,
+          sceneJson,
+          retainedDocumentJson,
+          loopDurationSeconds,
+        );
+      } finally {
+        if (this.#preparedStartReservation === reservation) {
+          this.#preparedStartReservation = null;
+        }
+      }
     }
 
     if (typeof this.#canvas.transferControlToOffscreen !== "function") {
@@ -840,6 +849,7 @@ export class ExecutionWorkerClient {
     this.#engineWorker = null;
     this.#renderWorker = null;
     this.#renderPrepared = null;
+    this.#preparedStartReservation = null;
     this.#ready = null;
     const error = new Error("execution worker client terminated");
     for (const pending of this.#pending.values()) {

--- a/web/execution-worker-prepared-start.test.mjs
+++ b/web/execution-worker-prepared-start.test.mjs
@@ -203,6 +203,51 @@ test("prepared render owner waits for preparation before starting the authored r
   client.terminate();
 });
 
+test("prepared render owner admits only one authored start while preparation is pending", async () => {
+  resetWorkers();
+  const client = new ExecutionWorkerClient(new FakeCanvas());
+
+  const preparePromise = client.prepare({ transportMode: "transferable" });
+  const render = workerByName(0, "noon-render");
+  const retainedStart = client.startRetained(SCENE_JSON, RETAINED_DOCUMENT_JSON);
+  let competingError = null;
+  const competingStart = client.start(SCENE_JSON).catch((error) => {
+    competingError = error;
+  });
+
+  acknowledgePreparation(render);
+  await preparePromise;
+  await new Promise((resolve) => setImmediate(resolve));
+
+  const engineWorkers = FakeWorker.instances.filter(({ name }) => name.includes("engine"));
+  assert.equal(
+    engineWorkers.length,
+    1,
+    "one prepared render owner must never attach two competing engines",
+  );
+  assert.equal(engineWorkers[0].name, "noon-mixed-retained-engine");
+  assert.match(competingError?.message ?? "", /already started/);
+  await competingStart;
+
+  const retainedEngine = engineWorkers[0];
+  const startRequest = requestMessage(render, "start_engine");
+  assert.equal(startRequest.mode, "retained");
+  retainedEngine.emitMessage(engineMessage("ready", { transportMode: "transferable" }));
+  render.emitMessage(
+    renderMessage("engine_started", {
+      requestId: startRequest.requestId,
+      mode: "retained",
+      transportMode: "transferable",
+      backend: "WebGL2",
+    }),
+  );
+
+  const ready = await retainedStart;
+  assert.equal(ready.session, 1);
+  assert.equal(client.mode, "retained");
+  client.terminate();
+});
+
 test("failed prepared engine attachment replaces the transferred canvas and remains retryable", async () => {
   resetWorkers();
   const original = new FakeCanvas();


### PR DESCRIPTION
## Summary
- fix the prepared-start race introduced by #650 where two `start()` / `startRetained()` calls could await the same mode-free render preparation and then attach competing engines
- reserve the prepared-start slot before awaiting the render `prepared` acknowledgement
- keep the reservation identity-scoped so an older async unwind cannot clear a newer generation after `terminate()`
- release the reservation immediately on termination so a replacement session can start without waiting for stale work to unwind
- add a regression that races retained and legacy startup against the same prepared render owner and requires exactly one engine attachment

## Why
#650 merged with `#engineWorker === null` as the only startup guard. Before the render `prepared` acknowledgement, `#engineWorker` is intentionally still null, so multiple callers could pass the guard, await the same preparation promise, and each enter `#startPreparedMode`. The later caller could overwrite the authoritative engine worker and send a second `start_engine` to the same render owner.

## Architecture
This remains a single-owner lifecycle fix. No queue, second execution state machine, renderer protocol change, or speculative engine is introduced. The existing prepared render owner still transitions exactly once to the authored engine; the new token only reserves that transition across the asynchronous preparation barrier.

## Validation
The focused fake-worker regression proves a pending retained start rejects a competing legacy start before either engine exists, then completes with one retained engine and session 1. Full exact-head browser/worker CI is required before merge.

Hotfixes #650. Related #642.