### PR TITLE
Overlap first-run Python authoring and render preparation

### DIFF
--- a/scripts/playground-authoring-error-recovery-smoke.mjs
+++ b/scripts/playground-authoring-error-recovery-smoke.mjs
@@ -89,7 +89,7 @@ async function snapshot(page) {
   });
 }
 
-async function waitForInitialScene(page) {
+async function waitForDeferredEditor(page) {
   await page.waitForFunction(() => window.__noonExampleGallery !== undefined);
   const deferred = await snapshot(page);
   assert.equal(deferred.runtimeStartup, "deferred", "authoring runtime must stay deferred on page load");
@@ -97,6 +97,7 @@ async function waitForInitialScene(page) {
   assert.equal(deferred.presentedFrames, 0, "deferred authoring page must not render frames");
 
   const sourceTextarea = page.locator("#python-scene-source");
+  const initialSource = await sourceTextarea.inputValue();
   await sourceTextarea.focus();
   await page.waitForSelector("#scene-editor-panel .python-code-editor[data-editor-ready='true'] .cm-content", {
     timeout: 30_000,
@@ -104,21 +105,7 @@ async function waitForInitialScene(page) {
 
   const runButton = page.locator("#replace-scene");
   assert.equal(await runButton.isEnabled(), true, "Run must remain available after lazy editor startup");
-  await runButton.click();
-  await page.waitForFunction(
-    () => {
-      const status = document.querySelector("#status");
-      const patch = document.querySelector("#patch-status");
-      return (
-        status?.dataset.state === "running" &&
-        status?.dataset.rendererBackend === "WebGL2" &&
-        patch?.dataset.state === "applied" &&
-        !document.querySelector("#replace-scene")?.disabled
-      );
-    },
-    null,
-    { timeout: 60_000 },
-  );
+  return initialSource;
 }
 
 async function setEditorSource(page, source) {
@@ -204,19 +191,52 @@ try {
 
   diagnostics.browser = await browser.version();
   await page.goto(`${baseUrl}/web/index.html?example=parity-create-circle`, { waitUntil: "load" });
-  await waitForInitialScene(page);
-  await waitForObjectCount(page, 1);
-  page.on("framenavigated", (frame) => {
-    if (frame === page.mainFrame()) diagnostics.unexpectedNavigations += 1;
-  });
+  const initialSource = await waitForDeferredEditor(page);
 
-  phase = "baseline";
+  phase = "cold-syntax-error";
+  await setEditorSource(page, SOURCES.syntaxError);
+  await runAndWait(page, "error");
+  await page.waitForFunction(
+    () => document.querySelector("#status")?.dataset.runtimeStartup === "prepared-on-run",
+    null,
+    { timeout: 60_000 },
+  );
+  diagnostics.snapshots.coldSyntaxError = await snapshot(page);
+  assert.equal(
+    diagnostics.snapshots.coldSyntaxError.runtimeStartup,
+    "prepared-on-run",
+    "cold Python failure must leave the mode-free render owner prepared for retry",
+  );
+  assert.equal(
+    diagnostics.snapshots.coldSyntaxError.rendererBackend,
+    "",
+    "cold Python failure must not publish a renderer backend before engine selection",
+  );
+  assert.equal(
+    diagnostics.snapshots.coldSyntaxError.executionMode,
+    "",
+    "cold Python failure must not publish an execution mode",
+  );
+  assert.equal(
+    diagnostics.snapshots.coldSyntaxError.presentedFrames,
+    0,
+    "cold Python failure must not present a frame from a speculative engine",
+  );
+
+  phase = "cold-recovery";
+  await setEditorSource(page, initialSource);
+  await runAndWait(page, "applied");
+  await waitForObjectCount(page, 1);
   diagnostics.snapshots.baseline = await snapshot(page);
   assert.equal(diagnostics.snapshots.baseline.runtimeState, "running");
+  assert.equal(diagnostics.snapshots.baseline.runtimeStartup, "started-on-demand");
   assert.equal(diagnostics.snapshots.baseline.rendererBackend, "WebGL2");
   assert.equal(diagnostics.snapshots.baseline.exampleId, "parity-create-circle");
   assert.notEqual(diagnostics.snapshots.baseline.patchSequence, "");
   await page.screenshot({ path: path.join(artifactDir, "baseline.png"), fullPage: true });
+  page.on("framenavigated", (frame) => {
+    if (frame === page.mainFrame()) diagnostics.unexpectedNavigations += 1;
+  });
 
   phase = "syntax-error";
   await setEditorSource(page, SOURCES.syntaxError);
@@ -273,10 +293,20 @@ try {
   assert.equal(diagnostics.snapshots.runtimeRecovered.rendererBackend, "WebGL2");
   await page.screenshot({ path: path.join(artifactDir, "recovered.png"), fullPage: true });
 
+  const coldSyntaxConsole = diagnostics.consoleErrors.filter(
+    (entry) => entry.phase === "cold-syntax-error",
+  );
   const syntaxConsole = diagnostics.consoleErrors.filter((entry) => entry.phase === "syntax-error");
   const runtimeConsole = diagnostics.consoleErrors.filter((entry) => entry.phase === "runtime-error");
   const unexpectedConsole = diagnostics.consoleErrors.filter(
-    (entry) => entry.phase !== "syntax-error" && entry.phase !== "runtime-error",
+    (entry) =>
+      entry.phase !== "cold-syntax-error" &&
+      entry.phase !== "syntax-error" &&
+      entry.phase !== "runtime-error",
+  );
+  assert.ok(
+    coldSyntaxConsole.some((entry) => /SyntaxError|invalid syntax|expected ':'/i.test(entry.text)),
+    `cold syntax failure should be diagnostic in the console: ${JSON.stringify(coldSyntaxConsole)}`,
   );
   assert.ok(
     syntaxConsole.some((entry) => /SyntaxError|invalid syntax|expected ':'/i.test(entry.text)),
@@ -293,7 +323,7 @@ try {
   diagnostics.serverOutput = serverOutput;
   await writeFile(path.join(artifactDir, "diagnostics.json"), `${JSON.stringify(diagnostics, null, 2)}\n`);
   console.log(
-    `playground authoring recovery ok: ${diagnostics.snapshots.baseline.objectCount} -> ` +
+    `playground authoring recovery ok: cold failure -> ${diagnostics.snapshots.baseline.objectCount} -> ` +
       `${diagnostics.snapshots.syntaxRecovered.objectCount} -> ${diagnostics.snapshots.runtimeRecovered.objectCount} objects`,
   );
 } catch (error) {

--- a/web/authoring-execution-client.js
+++ b/web/authoring-execution-client.js
@@ -25,6 +25,7 @@ const EMPTY_HOST_METRICS = Object.freeze({
 export class AuthoringExecutionClient {
   #canvas;
   #player = null;
+  #preparedPlayer = null;
   #mode = null;
   #rendererBackend = "";
   #loopDurationSeconds = DEFAULT_LOOP_DURATION_SECONDS;
@@ -68,12 +69,52 @@ export class AuthoringExecutionClient {
     return this.#transportMode;
   }
 
+  async prepare(
+    {
+      transportMode = undefined,
+      sharedSlotCapacity = DEFAULT_SHARED_SLOT_CAPACITY,
+    } = {},
+  ) {
+    if (this.#player !== null || this.#preparedPlayer !== null || this.#transition !== null) {
+      throw new Error("AuthoringExecutionClient is already started or preparing");
+    }
+    this.#sharedSlotCapacity = validateSharedSlotCapacity(sharedSlotCapacity);
+    const options = { sharedSlotCapacity: this.#sharedSlotCapacity };
+    if (transportMode !== undefined) {
+      options.transportMode = transportMode;
+    }
+
+    const generation = this.#lifecycleGeneration;
+    const player = this.#createPlayer();
+    this.#preparedPlayer = player;
+    try {
+      const ready = await player.prepare(options);
+      this.#assertLifecycleCurrent(generation);
+      if (this.#preparedPlayer !== player && this.#player !== player) {
+        throw new Error(LIFECYCLE_CANCELLED_MESSAGE);
+      }
+      this.#transportMode = ready.transportMode;
+      return ready;
+    } catch (error) {
+      if (this.#preparedPlayer === player) {
+        this.#preparedPlayer = null;
+      }
+      if (generation === this.#lifecycleGeneration) {
+        this.#adoptPlayerCanvas(player);
+      }
+      if (generation !== this.#lifecycleGeneration) {
+        throw new Error(LIFECYCLE_CANCELLED_MESSAGE);
+      }
+      throw error;
+    }
+  }
+
   async start(
     sceneJson,
     {
       loopDurationSeconds = DEFAULT_LOOP_DURATION_SECONDS,
       transportMode = undefined,
-      sharedSlotCapacity = DEFAULT_SHARED_SLOT_CAPACITY,
+      sharedSlotCapacity = undefined,
     } = {},
   ) {
     if (this.#player !== null || this.#transition !== null) {
@@ -81,7 +122,7 @@ export class AuthoringExecutionClient {
     }
     validateSceneJson(sceneJson);
     this.#loopDurationSeconds = validateLoopDurationSeconds(loopDurationSeconds);
-    this.#sharedSlotCapacity = validateSharedSlotCapacity(sharedSlotCapacity);
+    this.#sharedSlotCapacity = this.#resolveStartupSharedSlotCapacity(sharedSlotCapacity);
     const options = {
       loopDurationSeconds: this.#loopDurationSeconds,
       sharedSlotCapacity: this.#sharedSlotCapacity,
@@ -105,7 +146,7 @@ export class AuthoringExecutionClient {
     {
       loopDurationSeconds = DEFAULT_LOOP_DURATION_SECONDS,
       transportMode = undefined,
-      sharedSlotCapacity = DEFAULT_SHARED_SLOT_CAPACITY,
+      sharedSlotCapacity = undefined,
     } = {},
   ) {
     if (this.#player !== null || this.#transition !== null) {
@@ -117,7 +158,7 @@ export class AuthoringExecutionClient {
       throw new TypeError("retained startup requires at least one retained object");
     }
     this.#loopDurationSeconds = validateLoopDurationSeconds(loopDurationSeconds);
-    this.#sharedSlotCapacity = validateSharedSlotCapacity(sharedSlotCapacity);
+    this.#sharedSlotCapacity = this.#resolveStartupSharedSlotCapacity(sharedSlotCapacity);
     const options = {
       loopDurationSeconds: this.#loopDurationSeconds,
       sharedSlotCapacity: this.#sharedSlotCapacity,
@@ -276,6 +317,12 @@ export class AuthoringExecutionClient {
     this.#lifecycleGeneration += 1;
     this.#resizeObserver?.disconnect();
     this.#resizeObserver = null;
+    const preparedPlayer = this.#preparedPlayer;
+    preparedPlayer?.terminate();
+    if (preparedPlayer !== null && this.#canvas !== preparedPlayer.canvas) {
+      this.#canvas = preparedPlayer.canvas;
+    }
+    this.#preparedPlayer = null;
     this.#player?.terminate();
     this.#player = null;
     this.#mode = null;
@@ -285,10 +332,7 @@ export class AuthoringExecutionClient {
 
   async #startMode(mode, sceneJson, retainedDocumentJson, options) {
     const generation = this.#lifecycleGeneration;
-    const player = new ExecutionWorkerClient(this.#canvas, {
-      onError: this.#onError,
-      onRecoverableError: this.#onRecoverableError,
-    });
+    const player = this.#preparedPlayer ?? this.#createPlayer();
     const terminateCandidate = createIdempotentTerminator(player);
     let published = false;
     try {
@@ -297,6 +341,9 @@ export class AuthoringExecutionClient {
           ? await player.startRetained(sceneJson, retainedDocumentJson, options)
           : await player.start(sceneJson, options);
       this.#assertLifecycleCurrent(generation, terminateCandidate);
+      if (this.#preparedPlayer === player) {
+        this.#preparedPlayer = null;
+      }
       this.#player = player;
       published = true;
       this.#mode = mode;
@@ -304,6 +351,9 @@ export class AuthoringExecutionClient {
       this.#resizeCurrentCanvas();
       return ready;
     } catch (error) {
+      if (this.#preparedPlayer === player) {
+        this.#preparedPlayer = null;
+      }
       if (!published || generation === this.#lifecycleGeneration) {
         terminateCandidate();
       }
@@ -315,6 +365,22 @@ export class AuthoringExecutionClient {
       }
       throw error;
     }
+  }
+
+  #createPlayer() {
+    return new ExecutionWorkerClient(this.#canvas, {
+      onError: this.#onError,
+      onRecoverableError: this.#onRecoverableError,
+    });
+  }
+
+  #resolveStartupSharedSlotCapacity(sharedSlotCapacity) {
+    if (sharedSlotCapacity !== undefined) {
+      return validateSharedSlotCapacity(sharedSlotCapacity);
+    }
+    return this.#preparedPlayer === null
+      ? DEFAULT_SHARED_SLOT_CAPACITY
+      : this.#sharedSlotCapacity;
   }
 
   async #switchRetained(sceneJson, retainedDocumentJson) {

--- a/web/authoring-execution-prepared-start.test.mjs
+++ b/web/authoring-execution-prepared-start.test.mjs
@@ -1,0 +1,217 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+class FakeCanvas {
+  clientWidth = 640;
+  clientHeight = 360;
+  width = 640;
+  height = 360;
+  replacement = null;
+  transferred = false;
+
+  transferControlToOffscreen() {
+    if (this.transferred) {
+      throw new Error("canvas was transferred twice");
+    }
+    this.transferred = true;
+    return { width: this.width, height: this.height };
+  }
+
+  cloneNode() {
+    const clone = new FakeCanvas();
+    clone.clientWidth = this.clientWidth;
+    clone.clientHeight = this.clientHeight;
+    clone.width = this.width;
+    clone.height = this.height;
+    return clone;
+  }
+
+  replaceWith(replacement) {
+    this.replacement = replacement;
+  }
+}
+
+class FakeWorker {
+  static instances = [];
+
+  listeners = new Map();
+  messages = [];
+  terminated = false;
+
+  constructor(url, options = {}) {
+    this.url = String(url);
+    this.name = options.name ?? "";
+    FakeWorker.instances.push(this);
+  }
+
+  addEventListener(type, listener) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  postMessage(message, transfer = []) {
+    this.messages.push({ message, transfer });
+  }
+
+  terminate() {
+    this.terminated = true;
+  }
+
+  emitMessage(message) {
+    for (const listener of this.listeners.get("message") ?? []) {
+      listener({ data: message });
+    }
+  }
+}
+
+globalThis.HTMLCanvasElement = FakeCanvas;
+globalThis.Worker = FakeWorker;
+globalThis.window = { devicePixelRatio: 1 };
+
+const { AuthoringExecutionClient } = await import("./authoring-execution-client.js");
+
+const SCENE_JSON = JSON.stringify({ version: 1, objects: [], tracks: [] });
+const RETAINED_DOCUMENT_JSON = JSON.stringify({
+  channel: "noon.authoring.retained",
+  objects: [{ id: 1 }],
+});
+const NON_DEFAULT_SHARED_SLOT_CAPACITY = 2 * 1024 * 1024;
+
+function envelope(channel, type, payload = {}) {
+  return { channel, protocolVersion: 1, type, ...payload };
+}
+
+function workerByName(offset, name) {
+  const worker = FakeWorker.instances.slice(offset).find((candidate) => candidate.name === name);
+  assert.ok(worker, `missing worker ${name}`);
+  return worker;
+}
+
+function requestMessage(worker, type) {
+  const entry = worker.messages.findLast(({ message }) => message.type === type);
+  assert.ok(entry, `missing ${worker.name} ${type} request`);
+  return entry.message;
+}
+
+function acknowledgePreparation(render) {
+  const request = requestMessage(render, "prepare");
+  render.emitMessage(
+    envelope("noon.render", "prepared", {
+      requestId: request.requestId,
+      transportMode: "transferable",
+      width: 640,
+      height: 360,
+    }),
+  );
+  return request;
+}
+
+function finishRetainedStart(render, engine) {
+  const startRequest = requestMessage(render, "start_engine");
+  engine.emitMessage(
+    envelope("noon.engine", "ready", {
+      transportMode: "transferable",
+      retained: true,
+      mixed: true,
+    }),
+  );
+  render.emitMessage(
+    envelope("noon.render", "engine_started", {
+      requestId: startRequest.requestId,
+      mode: "retained",
+      transportMode: "transferable",
+      backend: "WebGL2",
+    }),
+  );
+}
+
+test("prepared authoring execution stays unpublished until the authored engine is ready", async () => {
+  FakeWorker.instances.length = 0;
+  const client = new AuthoringExecutionClient(new FakeCanvas());
+  const preparation = client.prepare({ transportMode: "transferable" });
+  const render = workerByName(0, "noon-render");
+  const prepareRequest = requestMessage(render, "prepare");
+
+  assert.equal(client.mode, null, "mode must remain unpublished during render preparation");
+  await assert.rejects(
+    client.state(),
+    /AuthoringExecutionClient has not been started/,
+    "prepared resources must not make public execution state available",
+  );
+
+  const started = client.startRetained(SCENE_JSON, RETAINED_DOCUMENT_JSON);
+  assert.equal(client.mode, null, "mode must remain unpublished while preparation is pending");
+  assert.equal(
+    FakeWorker.instances.some(({ name }) => name === "noon-mixed-retained-engine"),
+    false,
+    "authored engine startup must wait for the render preparation barrier",
+  );
+
+  render.emitMessage(
+    envelope("noon.render", "prepared", {
+      requestId: prepareRequest.requestId,
+      transportMode: "transferable",
+      width: 640,
+      height: 360,
+    }),
+  );
+  await preparation;
+  await new Promise((resolve) => setImmediate(resolve));
+
+  const engine = workerByName(1, "noon-mixed-retained-engine");
+  finishRetainedStart(render, engine);
+
+  const ready = await started;
+  assert.equal(ready.session, 1);
+  assert.equal(client.mode, "retained");
+  assert.equal(client.rendererBackend, "WebGL2");
+  client.terminate();
+});
+
+test("prepared authoring startup inherits a non-default shared slot capacity", async () => {
+  FakeWorker.instances.length = 0;
+  const client = new AuthoringExecutionClient(new FakeCanvas());
+  const preparation = client.prepare({
+    transportMode: "transferable",
+    sharedSlotCapacity: NON_DEFAULT_SHARED_SLOT_CAPACITY,
+  });
+  const render = workerByName(0, "noon-render");
+  acknowledgePreparation(render);
+  await preparation;
+
+  const started = client.startRetained(SCENE_JSON, RETAINED_DOCUMENT_JSON);
+  await new Promise((resolve) => setImmediate(resolve));
+  const engine = workerByName(1, "noon-mixed-retained-engine");
+  const init = requestMessage(engine, "init");
+  assert.equal(
+    init.sharedSlotCapacity,
+    NON_DEFAULT_SHARED_SLOT_CAPACITY,
+    "authored startup must inherit the prepared transport capacity when no override is supplied",
+  );
+  finishRetainedStart(render, engine);
+  await started;
+  client.terminate();
+});
+
+test("terminating during render preparation cancels the unpublished candidate and adopts its fresh canvas", async () => {
+  FakeWorker.instances.length = 0;
+  const original = new FakeCanvas();
+  const client = new AuthoringExecutionClient(original);
+  const preparation = client.prepare({ transportMode: "transferable" });
+  const render = workerByName(0, "noon-render");
+
+  client.terminate();
+
+  await assert.rejects(
+    preparation,
+    /AuthoringExecutionClient was terminated during an asynchronous operation/,
+  );
+  assert.equal(render.terminated, true);
+  assert.equal(original.transferred, true);
+  assert.notEqual(client.canvas, original);
+  assert.equal(original.replacement, client.canvas);
+  assert.equal(client.canvas.transferred, false);
+  assert.equal(client.mode, null);
+  await assert.rejects(client.state(), /AuthoringExecutionClient has not been started/);
+});

--- a/web/main.js
+++ b/web/main.js
@@ -12,7 +12,7 @@ import {
   requestedExampleId,
 } from "./example-gallery.js";
 
-const canvas = document.querySelector("#scene");
+let canvas = document.querySelector("#scene");
 const status = document.querySelector("#status");
 const statusText = document.querySelector("#status-text");
 const sceneButton = document.querySelector("#replace-scene");
@@ -347,6 +347,7 @@ let playbackDurationSeconds = 4.0;
 let rendererBackend = "";
 let sceneRunPromise = null;
 let runtimeStartPromise = null;
+let runtimePreparation = null;
 let playerNeedsRestart = false;
 let busyDepth = 0;
 let galleryPage = 0;
@@ -444,7 +445,58 @@ function ensureAuthoringClient() {
   return authoringClient;
 }
 
+function adoptRuntimeCanvas(candidate) {
+  if (canvas !== candidate.canvas) {
+    canvas = candidate.canvas;
+  }
+}
+
+function createRuntimeClient() {
+  let candidate = null;
+  candidate = new AuthoringExecutionClient(canvas, {
+    onError(error) {
+      if (player !== candidate) return;
+      playerNeedsRestart = true;
+      showError(error);
+    },
+    onRecoverableError(error) {
+      showRecoverableSceneError(error);
+    },
+  });
+  return candidate;
+}
+
+function ensureRuntimePreparation() {
+  if (player !== null) return null;
+  if (runtimePreparation !== null) return runtimePreparation;
+
+  const candidate = createRuntimeClient();
+  const ready = candidate.prepare();
+  const preparation = { candidate, ready };
+  runtimePreparation = preparation;
+  status.dataset.runtimeStartup = "preparing-on-run";
+  status.dataset.executionTopology = "preparing-render-owner";
+
+  ready.then(
+    () => {
+      if (runtimePreparation === preparation) {
+        status.dataset.runtimeStartup = "prepared-on-run";
+        status.dataset.executionTopology = "prepared-render-owner";
+      }
+    },
+    (error) => {
+      adoptRuntimeCanvas(candidate);
+      if (runtimePreparation === preparation) {
+        runtimePreparation = null;
+      }
+      console.warn("Execution runtime preparation failed", error);
+    },
+  );
+  return preparation;
+}
+
 async function ensureRuntimeReady({
+  preparation = null,
   sceneJson,
   retainedDocumentJson,
   startRetained,
@@ -456,10 +508,6 @@ async function ensureRuntimeReady({
   if (player !== null) return null;
 
   const task = (async () => {
-    setRuntimeStatus("Starting execution runtime…", "running");
-    patchStatus.value = "Starting GPU execution runtime…";
-    patchStatus.dataset.state = "running";
-
     if (startRetained && callbacks !== null && callbacks !== undefined) {
       throw new Error(
         "retained authoring with Python host callbacks is not supported yet; " +
@@ -467,16 +515,17 @@ async function ensureRuntimeReady({
       );
     }
 
-    const nextPlayer = new AuthoringExecutionClient(canvas, {
-      onError(error) {
-        playerNeedsRestart = true;
-        showError(error);
-      },
-      onRecoverableError(error) {
-        showRecoverableSceneError(error);
-      },
-    });
+    const prepared = preparation ?? ensureRuntimePreparation();
+    if (prepared === null) {
+      throw new Error("execution runtime preparation is unavailable");
+    }
+    const nextPlayer = prepared.candidate;
     try {
+      await prepared.ready;
+      setRuntimeStatus("Starting authored execution engine…", "running");
+      patchStatus.value = "Starting authored GPU execution engine…";
+      patchStatus.dataset.state = "running";
+
       const ready = startRetained
         ? await nextPlayer.startRetained(sceneJson, retainedDocumentJson, {
             loopDurationSeconds,
@@ -494,6 +543,9 @@ async function ensureRuntimeReady({
       }
 
       player = nextPlayer;
+      if (runtimePreparation === prepared) {
+        runtimePreparation = null;
+      }
       playerNeedsRestart = false;
       rendererBackend = ready.render.backend;
       status.dataset.rendererBackend = rendererBackend;
@@ -523,7 +575,11 @@ async function ensureRuntimeReady({
         mode: nextPlayer.mode,
       };
     } catch (error) {
+      if (runtimePreparation === prepared) {
+        runtimePreparation = null;
+      }
       nextPlayer.terminate();
+      adoptRuntimeCanvas(nextPlayer);
       if (player === nextPlayer) {
         player = null;
         playbackControls?.destroy();
@@ -692,6 +748,7 @@ async function runScene() {
     try {
       patchStatus.value = `Building ${example.title} in the Python worker…`;
       patchStatus.dataset.state = "running";
+      const preparation = player === null ? ensureRuntimePreparation() : null;
       const client = ensureAuthoringClient();
       status.dataset.authoringWarmup = "started";
       let authored;
@@ -742,6 +799,7 @@ async function runScene() {
       let result;
       if (player === null) {
         result = await ensureRuntimeReady({
+          preparation,
           sceneJson,
           retainedDocumentJson,
           startRetained,
@@ -1058,6 +1116,9 @@ try {
       playbackControls = null;
       authoringClient?.terminate();
       authoringClient = null;
+      const preparation = runtimePreparation;
+      runtimePreparation = null;
+      preparation?.candidate.terminate();
       player?.terminate();
       player = null;
     },

--- a/web/playground-stability-boundary.test.mjs
+++ b/web/playground-stability-boundary.test.mjs
@@ -66,17 +66,37 @@ assert.match(
   "retained to legacy authoring must switch the persistent execution owner in place",
 );
 
-const runtimeReadyStart = main.indexOf("async function ensureRuntimeReady(");
-const runtimeReadyEnd = main.indexOf("async function ensureExecutionReady()", runtimeReadyStart);
-assert.ok(
-  runtimeReadyStart >= 0 && runtimeReadyEnd > runtimeReadyStart,
-  "playground must keep an explicit on-demand runtime boundary",
+assert.match(
+  main,
+  /let canvas = document\.querySelector\("#scene"\);/,
+  "playground must be able to adopt a replacement DOM canvas after prepared-owner rollback",
 );
-const runtimeReadyBody = main.slice(runtimeReadyStart, runtimeReadyEnd);
-const playgroundConstruction = runtimeReadyBody.match(
-  /const nextPlayer = new AuthoringExecutionClient\(canvas, \{([\s\S]*?)\n\s*\}\);/,
+const createRuntimeStart = main.indexOf("function createRuntimeClient()");
+const preparationStart = main.indexOf("function ensureRuntimePreparation()", createRuntimeStart);
+const runtimeReadyStart = main.indexOf("async function ensureRuntimeReady(", preparationStart);
+assert.ok(
+  createRuntimeStart >= 0 && preparationStart > createRuntimeStart && runtimeReadyStart > preparationStart,
+  "playground must separate client construction, mode-free preparation, and authored startup",
+);
+const createRuntimeBody = main.slice(createRuntimeStart, preparationStart);
+const preparationBody = main.slice(preparationStart, runtimeReadyStart);
+const playgroundConstruction = createRuntimeBody.match(
+  /candidate = new AuthoringExecutionClient\(canvas, \{([\s\S]*?)\n\s*\}\);/,
 )?.[1];
-assert.ok(playgroundConstruction, "deferred runtime must configure its authoring execution client");
+assert.ok(playgroundConstruction, "deferred runtime must configure its authoring execution client once");
+const fatalHandler = playgroundConstruction.match(
+  /onError\(error\) \{([\s\S]*?)\n\s*\}/,
+)?.[1];
+assert.match(
+  fatalHandler ?? "",
+  /if \(player !== candidate\) return;/,
+  "fatal callbacks from an unpublished preparation must not mark a nonexistent player for restart",
+);
+assert.match(
+  fatalHandler ?? "",
+  /playerNeedsRestart = true;/,
+  "fatal callbacks from the published player must still request worker restart",
+);
 assert.match(
   playgroundConstruction,
   /onRecoverableError\(error\) \{\s*showRecoverableSceneError\(error\);\s*\}/,
@@ -91,6 +111,21 @@ assert.doesNotMatch(
   "recoverable scene errors must not request worker restart",
 );
 assert.match(
+  preparationBody,
+  /if \(runtimePreparation !== null\) return runtimePreparation;/,
+  "a prepared unpublished owner must survive Python/stale retries instead of spawning duplicate owners",
+);
+assert.match(
+  preparationBody,
+  /adoptRuntimeCanvas\(candidate\);[\s\S]*runtimePreparation = null;/,
+  "failed render preparation must adopt the fresh replacement canvas before allowing retry",
+);
+assert.doesNotMatch(
+  preparationBody,
+  /showError\(error\)/,
+  "an unpublished preparation failure must not race Python authoring to publish a fatal UI state",
+);
+assert.match(
   main,
   /function showRecoverableSceneError\(error\) \{\s*console\.warn\([\s\S]*?patchStatus\.dataset\.state = "error";/,
   "recoverable callback errors must be visible without becoming fatal console errors",
@@ -101,4 +136,6 @@ assert.match(
   "superseded playground deployments must be cancelled",
 );
 
-console.log("✓ deferred playground runtime keeps recoverable scene errors outside fatal recovery");
+console.log(
+  "✓ overlapped playground preparation preserves unpublished ownership, canvas recovery, and recoverable scene-error boundaries",
+);

--- a/web/playground-startup.test.mjs
+++ b/web/playground-startup.test.mjs
@@ -4,13 +4,40 @@ import { readFile } from "node:fs/promises";
 const main = await readFile(new URL("./main.js", import.meta.url), "utf8");
 const worker = await readFile(new URL("./python-worker.source.js", import.meta.url), "utf8");
 
-const runtimeReadyStart = main.indexOf("async function ensureRuntimeReady({");
+const createRuntimeStart = main.indexOf("function createRuntimeClient()");
+const preparationStart = main.indexOf("function ensureRuntimePreparation()", createRuntimeStart);
+const runtimeReadyStart = main.indexOf("async function ensureRuntimeReady({", preparationStart);
 const executionReadyStart = main.indexOf("async function ensureExecutionReady()", runtimeReadyStart);
 assert.ok(
-  runtimeReadyStart >= 0 && executionReadyStart > runtimeReadyStart,
-  "on-demand runtime startup boundary must exist",
+  createRuntimeStart >= 0 &&
+    preparationStart > createRuntimeStart &&
+    runtimeReadyStart > preparationStart &&
+    executionReadyStart > runtimeReadyStart,
+  "on-demand preparation and authored-engine startup boundaries must exist in order",
 );
+const createRuntimeBody = main.slice(createRuntimeStart, preparationStart);
+const preparationBody = main.slice(preparationStart, runtimeReadyStart);
 const runtimeReadyBody = main.slice(runtimeReadyStart, executionReadyStart);
+assert.match(
+  createRuntimeBody,
+  /new AuthoringExecutionClient\(canvas,/,
+  "first Run must create the GPU execution owner on demand",
+);
+assert.match(
+  preparationBody,
+  /const ready = candidate\.prepare\(\);/,
+  "first Run must prepare the mode-free render owner before engine selection",
+);
+assert.doesNotMatch(
+  preparationBody,
+  /candidate\.start(?:Retained)?\(/,
+  "mode-free preparation must not speculate a legacy or retained engine",
+);
+assert.match(
+  preparationBody,
+  /if \(runtimePreparation !== null\) return runtimePreparation;/,
+  "failed or stale Python runs must be able to reuse an already prepared candidate",
+);
 assert.doesNotMatch(
   runtimeReadyBody,
   /warmAuthoringClient\(/,
@@ -18,18 +45,23 @@ assert.doesNotMatch(
 );
 assert.match(
   runtimeReadyBody,
-  /new AuthoringExecutionClient\(canvas,/,
-  "first authored scene must create the GPU execution owner on demand",
+  /const prepared = preparation \?\? ensureRuntimePreparation\(\);/,
+  "authored startup must consume the candidate prepared in parallel with Python",
+);
+assert.match(
+  runtimeReadyBody,
+  /await prepared\.ready;/,
+  "authored engine attachment must wait for render-owner preparation",
 );
 assert.match(
   runtimeReadyBody,
   /await nextPlayer\.startRetained\(sceneJson, retainedDocumentJson,/,
-  "retained first runs must start directly in retained mode",
+  "retained first runs must attach directly in retained mode",
 );
 assert.match(
   runtimeReadyBody,
   /await nextPlayer\.start\(sceneJson,/,
-  "geometry-only first runs must start their authored scene directly",
+  "geometry-only first runs must attach their authored scene directly",
 );
 assert.doesNotMatch(
   runtimeReadyBody,
@@ -51,6 +83,11 @@ assert.ok(
 );
 assert.match(
   runtimeReadyBody,
+  /if \(runtimePreparation === prepared\) \{\s*runtimePreparation = null;/,
+  "successful engine publication must consume the prepared candidate exactly once",
+);
+assert.match(
+  runtimeReadyBody,
   /playerNeedsRestart = false;/,
   "successful fresh runtime startup must clear stale restart state",
 );
@@ -64,14 +101,26 @@ const runSceneStart = main.indexOf("async function runScene()");
 const selectExampleStart = main.indexOf("async function selectExample(", runSceneStart);
 assert.ok(runSceneStart >= 0 && selectExampleStart > runSceneStart, "runScene boundary must exist");
 const runSceneBody = main.slice(runSceneStart, selectExampleStart);
+const preparationCall = runSceneBody.indexOf(
+  "const preparation = player === null ? ensureRuntimePreparation() : null;",
+);
 const authoringCall = runSceneBody.indexOf("authored = await client.run(source,");
 const ensureRuntimeCall = runSceneBody.indexOf("result = await ensureRuntimeReady({");
 const ensureExecutionCall = runSceneBody.indexOf("await ensureExecutionReady();");
 const reconcileCall = runSceneBody.indexOf("result = await player.reconcileScene(sceneJson,");
 assert.ok(authoringCall >= 0, "Run must author the selected Python source");
 assert.ok(
+  preparationCall >= 0 && preparationCall < authoringCall,
+  "cold Run must kick render/WASM preparation before awaiting Python authoring",
+);
+assert.ok(
   ensureRuntimeCall > authoringCall,
-  "cold execution startup must wait until authoring identifies the required engine mode",
+  "engine selection and attachment must still wait until authoring identifies the required mode",
+);
+assert.match(
+  runSceneBody,
+  /result = await ensureRuntimeReady\(\{\s*preparation,/,
+  "cold authored startup must consume the preparation kicked off before Python",
 );
 assert.ok(
   ensureExecutionCall > authoringCall && reconcileCall > ensureExecutionCall,
@@ -90,7 +139,7 @@ assert.ok(bootCatch > bootStart, "playground boot boundary must terminate cleanl
 const bootBody = main.slice(bootStart, bootCatch);
 assert.doesNotMatch(
   bootBody,
-  /ensureAuthoringClient\(|new AuthoringExecutionClient\(|\.start\(.*objects.*tracks/,
+  /ensureAuthoringClient\(|ensureRuntimePreparation\(|new AuthoringExecutionClient\(|\.start\(.*objects.*tracks/,
   "initial page boot must not create Python or GPU runtime resources",
 );
 assert.doesNotMatch(
@@ -169,8 +218,8 @@ assert.match(
 );
 assert.match(
   bootBody,
-  /pagehide[\s\S]*stopMetricsPolling\(\)[\s\S]*authoringClient\?\.terminate\(\)[\s\S]*player\?\.terminate\(\)/,
-  "page teardown must release metrics, Python, and execution resources",
+  /pagehide[\s\S]*stopMetricsPolling\(\)[\s\S]*authoringClient\?\.terminate\(\)[\s\S]*preparation\?\.candidate\.terminate\(\)[\s\S]*player\?\.terminate\(\)/,
+  "page teardown must release metrics, Python, unpublished preparation, and execution resources",
 );
 
 const initializeStart = worker.indexOf("async function initializePyodide()");
@@ -201,5 +250,5 @@ assert.match(
 );
 
 console.log(
-  "✓ playground defers heavyweight startup, starts the authored engine mode directly, bounds gallery residency, and preserves parallel Python bootstrap",
+  "✓ playground defers page-load work, overlaps first-Run Python/render preparation, and selects the authored engine only after authoring",
 );


### PR DESCRIPTION
Superseded by #944, merged as `04d4987c8835662fa0c3dd15a264af64cd7ae663`.

The original stacked branch targeted the older split-retained startup API. #944 ports the same first-Run overlap onto the current facade-level prepared-owner boundary from #941 and canonical `startRetainedCanonical(SceneSpec)` startup.

On cold Run, render/WASM preparation now begins before the Python await, while engine selection still waits for authored output. The prepared candidate stays unpublished until the chosen legacy/canonical-retained engine is ready, survives Python/stale failures for reuse, adopts the replacement canvas on preparation/attachment failure, and is released on page teardown.

The current-master port also updates the startup/stability ownership contracts rather than preserving stale assumptions about where the execution client is constructed. Its exact merge result passed PR Fast Gate plus authoring-error recovery, stress edit/rerun, and the newer mixed retained-family edit/rerun workflow.

Closing this stale branch in favor of the merged current implementation.