### PR TITLE
Support retained Text animate scale builders

### DIFF
--- a/.github/workflows/retained-text-animation.yml
+++ b/.github/workflows/retained-text-animation.yml
@@ -1,0 +1,100 @@
+name: Retained text animation
+
+on:
+  pull_request:
+    paths:
+      - "crates/noon-web/src/retained_authoring_player.rs"
+      - "crates/noon-web/src/retained_authoring_scene.rs"
+      - "crates/noon-web/src/retained_authoring_tracks.rs"
+      - "crates/noon-web/src/retained_authoring_wire_scene.rs"
+      - "web/python-worker.source.js"
+      - "web/python-compat-modules.js"
+      - "web/python/_manim_animate.py"
+      - "web/python/_manim_animation_options.py"
+      - "web/python/_manim_retained_animate.py"
+      - "web/python/_manim_typst.py"
+      - "scripts/build-python-worker.mjs"
+      - "scripts/retained-text-animation-smoke.mjs"
+      - ".github/workflows/retained-text-animation.yml"
+  push:
+    branches:
+      - master
+    paths:
+      - "crates/noon-web/src/retained_authoring_player.rs"
+      - "crates/noon-web/src/retained_authoring_scene.rs"
+      - "crates/noon-web/src/retained_authoring_tracks.rs"
+      - "crates/noon-web/src/retained_authoring_wire_scene.rs"
+      - "web/python-worker.source.js"
+      - "web/python-compat-modules.js"
+      - "web/python/_manim_animate.py"
+      - "web/python/_manim_animation_options.py"
+      - "web/python/_manim_retained_animate.py"
+      - "web/python/_manim_typst.py"
+      - "scripts/build-python-worker.mjs"
+      - "scripts/retained-text-animation-smoke.mjs"
+      - ".github/workflows/retained-text-animation.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: retained-text-animation-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  browser-authoring:
+    name: Python retained Text animation
+    runs-on: ubuntu-latest
+    env:
+      CARGO_INCREMENTAL: "0"
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+      NOON_SKIP_PLAYGROUND_TEST: "1"
+      NOON_WASM_SKIP_OPT: "1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use stable Rust
+        run: |
+          rustup default stable
+          rustup target add wasm32-unknown-unknown
+
+      - name: Cache Cargo sources
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-sources-${{ hashFiles('Cargo.toml', 'crates/**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-sources-
+
+      - name: Use sccache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+        with:
+          version: v0.16.0
+
+      - name: Install pinned wasm-pack
+        uses: taiki-e/install-action@13608cbb45b01feb47ef444ab1a42dc41ad56f1a
+        with:
+          tool: wasm-pack@0.15.0
+          fallback: none
+
+      - name: Build browser package
+        run: bash scripts/build-web-demo.sh
+
+      - name: Cache Playwright Chromium
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-chromium-1.62.1
+
+      - name: Install browser smoke dependencies
+        run: |
+          npm install --no-save --ignore-scripts playwright@1.62.1 pngjs@7.0.0
+          npx playwright install chromium
+
+      - name: Test retained Text animation authoring
+        run: node scripts/retained-text-animation-smoke.mjs

--- a/scripts/retained-text-animation-smoke.mjs
+++ b/scripts/retained-text-animation-smoke.mjs
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import playwright from "playwright";
+
+const { chromium } = playwright;
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const port = 4191;
+const baseUrl = `http://127.0.0.1:${port}`;
+
+let serverOutput = "";
+const server = spawn(
+  "python3",
+  ["-m", "http.server", String(port), "--bind", "127.0.0.1", "--directory", repoRoot],
+  { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] },
+);
+server.stdout.on("data", (chunk) => (serverOutput += chunk));
+server.stderr.on("data", (chunk) => (serverOutput += chunk));
+
+async function waitForServer() {
+  let lastError = null;
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    try {
+      const response = await fetch(`${baseUrl}/web/manim-compat-smoke.html`);
+      if (response.ok) return;
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`retained text animation smoke server did not start: ${lastError}\n${serverOutput}`);
+}
+
+const retainedAnimateScaleSource = `
+from noon import *
+
+class RetainedAnimateScale(Scene):
+    def construct(self):
+        label = Text("Animate", font_size=48)
+
+        self.play(
+            label.animate(run_time=2.0, rate_func=linear).scale(2.0)
+        )
+        self.play(label.animate.scale(0.5), run_time=1.0)
+
+        assert label in self.mobjects
+
+        unsupported = Text("Unsupported", font_size=36)
+        try:
+            self.play(unsupported.animate.shift(RIGHT), run_time=0.25)
+            raise AssertionError("unsupported retained animate.shift must fail")
+        except NotImplementedError as error:
+            assert "uniform scale only" in str(error)
+        assert unsupported not in self.mobjects
+`;
+
+let browser = null;
+try {
+  await waitForServer();
+  browser = await chromium.launch({
+    channel: "chromium",
+    headless: true,
+    args: ["--disable-dev-shm-usage"],
+  });
+  const page = await browser.newPage();
+  const errors = [];
+  page.on("pageerror", (error) => errors.push(`pageerror: ${error}`));
+  page.on("console", (message) => {
+    if (message.type() === "error") errors.push(`console: ${message.text()}`);
+  });
+
+  await page.goto(`${baseUrl}/web/manim-compat-smoke.html`, { waitUntil: "load" });
+  await page.waitForFunction(() => window.noonManimCompat, null, { timeout: 30_000 });
+  await page.evaluate(() => window.noonManimCompat.ready());
+
+  const result = await page.evaluate(
+    (source) => window.noonManimCompat.run(source),
+    retainedAnimateScaleSource,
+  );
+
+  assert.equal(result.kind, "scene_document");
+  assert.equal(
+    result.document.objects.length,
+    0,
+    "retained Text.animate.scale must not create legacy placeholder geometry",
+  );
+  assert.ok(result.retainedDocument, "retained animation must emit a retained authoring document");
+  assert.equal(result.retainedDocument.objects.length, 1);
+  assert.equal(result.retainedDocument.objects[0].text.source, "Animate");
+
+  const tracks = result.retainedDocument.tracks ?? [];
+  assert.equal(tracks.length, 2, "two sequential animate.scale calls must emit two retained tracks");
+  assert.ok(tracks.every((track) => track.property === "scale"));
+
+  assert.deepEqual(tracks[0].values.vec2, {
+    from: { x: 1, y: 1 },
+    to: { x: 2, y: 2 },
+  });
+  assert.equal(tracks[0].timing.start_time, 0);
+  assert.equal(tracks[0].timing.duration, 2);
+  assert.equal(tracks[0].timing.easing, "linear");
+
+  assert.deepEqual(tracks[1].values.vec2, {
+    from: { x: 2, y: 2 },
+    to: { x: 1, y: 1 },
+  });
+  assert.equal(tracks[1].timing.start_time, 2);
+  assert.equal(tracks[1].timing.duration, 1);
+  assert.equal(tracks[1].timing.easing, "smooth");
+  assert.equal(result.duration, 3);
+
+  const wire = JSON.stringify(result.retainedDocument);
+  for (const forbidden of ["glyph", "font_bytes", "svg", "geometry", "atlas"]) {
+    assert.ok(!wire.includes(forbidden), `retained animation wire must not contain ${forbidden}`);
+  }
+  assert.deepEqual(errors, [], `browser errors while testing retained Text animation:\n${errors.join("\n")}`);
+
+  console.log(
+    "Retained Text animation smoke passed: native Text.animate.scale lowers to source-level retained scale tracks, composes sequential relative scales, preserves timing options, and rejects unsupported retained target-state properties without legacy geometry.",
+  );
+} finally {
+  await browser?.close();
+  server.kill("SIGTERM");
+}

--- a/web/python/_manim_retained_animate.py
+++ b/web/python/_manim_retained_animate.py
@@ -22,6 +22,14 @@ _ORIGINAL_SCENE_PLAY = _compat.Scene.play
 _ORIGINAL_RETAINED_DOCUMENT = _compat.Scene.retained_document
 
 
+def _retained_copy_for_animate_target(
+    self: _typst._RetainedTextMobject,
+) -> _typst._RetainedTextMobject:
+    """Clone a retained animation target without entering geometry-only cloning."""
+
+    return self.copy()
+
+
 def _ensure_animation_state(scene: _compat.Scene) -> None:
     _typst._ensure_scene_state(scene)
     if not hasattr(scene, "_retained_animation_tracks"):
@@ -29,20 +37,91 @@ def _ensure_animation_state(scene: _compat.Scene) -> None:
         scene._retained_animation_state = {}
 
 
+def _normal_builder_scale_factor(
+    animation: _animate._AlignedAnimationBuilder,
+    source: _typst._RetainedTextMobject,
+) -> float:
+    """Extract one uniform relative scale from a normal ``mobject.animate`` builder.
+
+    The generic Manim builder mutates a detached target copy. Retained playback owns
+    the semantic current state separately, so the only frontend value we need is the
+    source-to-target scale ratio. Applying that ratio to the retained state makes
+    sequential calls such as ``scale(2)`` then ``scale(0.5)`` compose correctly without
+    mutating the source object or reconstructing a legacy geometry snapshot.
+    """
+
+    target = animation.target
+    if type(target) is not type(source):
+        raise NotImplementedError(
+            "retained Text .animate currently requires a target of the same retained text type"
+        )
+
+    source_spec = source._spec()
+    target_spec = target._spec()
+    source_transform = source_spec.get("transform")
+    target_transform = target_spec.get("transform")
+    if not isinstance(source_transform, dict) or not isinstance(target_transform, dict):
+        raise ValueError("retained text authoring spec is missing transform state")
+
+    source_scale = source_transform.get("scale")
+    target_scale = target_transform.get("scale")
+    if not isinstance(source_scale, dict) or not isinstance(target_scale, dict):
+        raise ValueError("retained text authoring spec is missing scale state")
+
+    source_without_scale = copy.deepcopy(source_spec)
+    target_without_scale = copy.deepcopy(target_spec)
+    source_without_scale["transform"]["scale"] = None
+    target_without_scale["transform"]["scale"] = None
+    if source_without_scale != target_without_scale:
+        raise NotImplementedError(
+            "retained Text .animate currently supports uniform scale only; "
+            "position, rotation, color, and opacity animation remain separate slices"
+        )
+
+    source_x = float(source_scale["x"])
+    source_y = float(source_scale["y"])
+    target_x = float(target_scale["x"])
+    target_y = float(target_scale["y"])
+    if not all(math.isfinite(value) for value in (source_x, source_y, target_x, target_y)):
+        raise ValueError("retained text scale state must be finite")
+    if math.isclose(source_x, 0.0, abs_tol=1e-15) or math.isclose(
+        source_y, 0.0, abs_tol=1e-15
+    ):
+        raise ValueError("retained Text .animate cannot derive scale from a zero-scale source")
+
+    factor_x = target_x / source_x
+    factor_y = target_y / source_y
+    if not math.isclose(factor_x, factor_y, rel_tol=1e-12, abs_tol=1e-12):
+        raise NotImplementedError(
+            "retained Text .animate currently supports uniform scale only"
+        )
+    factor = (factor_x + factor_y) / 2.0
+    if not math.isfinite(factor) or factor <= 0.0:
+        raise ValueError("retained Text .animate scale factor must be finite and positive")
+    return factor
+
+
 def _retained_scale_factor(animation: object) -> float | None:
-    """Return a deferred retained scale factor, or ``None`` for another animation."""
+    """Return a retained relative scale factor, or ``None`` for another animation."""
 
     if not isinstance(animation, _animate._AlignedAnimationBuilder):
         return None
     source = getattr(animation, "source", None)
     if not isinstance(source, _typst._RetainedTextMobject):
         return None
-    if not hasattr(animation, "scale_factor"):
-        return None
-    factor = float(animation.scale_factor)
-    if not math.isfinite(factor):
-        raise ValueError("retained text scale factor must be finite")
-    return factor
+
+    # ScaleInPlace/ShrinkToCenter use a deferred builder because Manim creates their
+    # target at play-begin time. Keep that zero-scale-capable path independent of the
+    # normal .animate target copy, whose retained ``scale`` mutator intentionally
+    # accepts positive factors only.
+    deferred_factor = vars(animation).get("scale_factor")
+    if deferred_factor is not None:
+        factor = float(deferred_factor)
+        if not math.isfinite(factor):
+            raise ValueError("retained text scale factor must be finite")
+        return factor
+
+    return _normal_builder_scale_factor(animation, source)
 
 
 def _bind_retained(scene: _compat.Scene, source: _typst._RetainedTextMobject) -> None:
@@ -222,5 +301,9 @@ def install() -> None:
     if _INSTALLED:
         return
     _INSTALLED = True
+    # The generic semantic-handle target cloner is geometry-backed. Retained Text/Typst
+    # instead owns source-level resource state, so its normal `.animate` target must clone
+    # through the retained handle before any target-state mutator is applied.
+    _typst._RetainedTextMobject._copy_for_animate_target = _retained_copy_for_animate_target
     _compat.Scene.play = _retained_scene_play
     _compat.Scene.retained_document = _retained_document


### PR DESCRIPTION
## Summary

Extend the retained Text/Typst animation scheduler so ordinary Manim-style `mobject.animate.scale(...)` lowers to the same source-level retained `scale` tracks introduced by #609.

- recognize normal `_AlignedAnimationBuilder` instances whose source is retained Text/Typst;
- derive only the uniform source→target scale ratio from the detached builder target;
- apply that ratio to the scheduler-owned retained semantic state, so sequential relative scales compose correctly without mutating the source object;
- preserve the deferred zero-scale path used by `ScaleInPlace` / `ShrinkToCenter`;
- reject position/rotation/color/opacity target-state changes explicitly instead of falling through to legacy geometry;
- add a dedicated Chromium smoke proving `Text.animate.scale(2)` followed by `Text.animate.scale(0.5)` emits `1→2` then `2→1` retained tracks with no placeholder geometry and preserves animation timing options.

## Architecture

The generic `.animate` builder remains the Manim syntax adapter. Retained Text does not get a second builder or playback engine. The retained scheduler reads the builder's relative scale intent and applies it to its own semantic current state; Rust remains responsible for materializing backend intrinsic scale and compiling/evaluating the resulting retained tracks.

This deliberately keeps Position/Rotation/Opacity/Color as separate follow-up slices. A chained retained builder that changes one of those properties fails clearly and transactionally rather than entering the geometry-only Transform path.

Related: #609, #364, #83.