### PR TITLE
Gate semantic ownership inventory in required CI

### DIFF
--- a/scripts/build-web-demo.sh
+++ b/scripts/build-web-demo.sh
@@ -7,6 +7,12 @@ cd "$noon_root"
 
 node scripts/build-python-worker.mjs
 
+# The #61 ownership inventory is an architecture ratchet, not passive documentation.
+# Validate both the checked-in inventory and the validator's ownership-class invariants
+# in the required web build so contradictory or growing Python semantic debt cannot land.
+PYTHONDONTWRITEBYTECODE=1 python3 scripts/semantic_ownership_check.py
+PYTHONDONTWRITEBYTECODE=1 python3 scripts/test_semantic_ownership_check.py
+
 # Keep top-level browser modules and tests self-registering with the required web build.
 # This prevents a new JavaScript file or regression test from silently escaping syntax
 # validation / execution because this script's hand-maintained inventory was not updated.

--- a/scripts/semantic_ownership_check.py
+++ b/scripts/semantic_ownership_check.py
@@ -134,7 +134,12 @@ def validate_inventory(document: Any) -> list[str]:
         if classification == "shared-rust" and owner_language != "rust":
             errors.append(f"{label} shared-rust entries must be Rust-owned")
         if (
-            classification in {"python-adapter-only", "host-language-required"}
+            classification
+            in {
+                "python-adapter-only",
+                "python-semantic-duplicate",
+                "host-language-required",
+            }
             and owner_language != "python"
         ):
             errors.append(f"{label} {classification} entries must be Python-owned")
@@ -157,7 +162,15 @@ def validate_inventory(document: Any) -> list[str]:
                     f"{label} unexplained python-semantic-duplicate; "
                     f"missing {', '.join(missing)}"
                 )
-            _location(operation.get("shared_owner"), f"{label}.shared_owner", errors)
+            shared_owner = operation.get("shared_owner")
+            _location(shared_owner, f"{label}.shared_owner", errors)
+            shared_owner_language = (
+                shared_owner.get("language") if isinstance(shared_owner, dict) else None
+            )
+            if shared_owner_language != "rust":
+                errors.append(
+                    f"{label} python-semantic-duplicate shared_owner must be Rust-owned"
+                )
             if operation.get("migration_issue") != "#61":
                 errors.append(f"{label}.migration_issue must be #61")
         if (

--- a/scripts/test_semantic_ownership_check.py
+++ b/scripts/test_semantic_ownership_check.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Focused regressions for the semantic ownership inventory validator."""
+
+from __future__ import annotations
+
+import copy
+import unittest
+
+import semantic_ownership_check as ownership
+
+
+class SemanticOwnershipCheckTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.inventory = ownership.load_inventory()
+
+    def duplicate_operation(self) -> dict:
+        return next(
+            operation
+            for operation in copy.deepcopy(self.inventory["operations"])
+            if operation["classification"] == "python-semantic-duplicate"
+        )
+
+    def inventory_with_only(self, operation: dict) -> dict:
+        document = copy.deepcopy(self.inventory)
+        document["operations"] = [operation]
+        return document
+
+    def test_checked_in_inventory_is_valid(self) -> None:
+        self.assertEqual(ownership.validate_inventory(copy.deepcopy(self.inventory)), [])
+
+    def test_python_semantic_duplicate_must_be_python_owned(self) -> None:
+        operation = self.duplicate_operation()
+        operation["owner"]["language"] = "rust"
+
+        errors = ownership.validate_inventory(self.inventory_with_only(operation))
+
+        self.assertTrue(
+            any("python-semantic-duplicate entries must be Python-owned" in error for error in errors),
+            errors,
+        )
+
+    def test_python_semantic_duplicate_shared_owner_must_be_rust_owned(self) -> None:
+        operation = self.duplicate_operation()
+        operation["shared_owner"]["language"] = "python"
+
+        errors = ownership.validate_inventory(self.inventory_with_only(operation))
+
+        self.assertTrue(
+            any(
+                "python-semantic-duplicate shared_owner must be Rust-owned" in error
+                for error in errors
+            ),
+            errors,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- run the #61 semantic ownership inventory validator from the required web-package build
- require `python-semantic-duplicate` entries to be Python-owned
- require each duplicate's declared shared replacement owner to be Rust-owned
- add focused validator regressions, including validation of the checked-in inventory

## Why
`compat/semantic-ownership-v1.json` is intended to prevent new Python-owned semantic duplication, but its validator was not called by `scripts/build-web-demo.sh`, which is the required CI web-package gate. The validator also allowed internally contradictory duplicate ownership metadata.

This keeps the ownership audit as an executable architecture ratchet rather than passive documentation. The change is test/governance-only and does not touch production runtime, rendering, startup, spatial indexing, or active compatibility feature implementation.

## Validation
The required web package job now executes both the checked-in inventory check and focused validator tests before the rest of the web build. Fresh exact-head CI is required before merge.

Tracks #61.