### PR TITLE
Support retained Text rotation animate builders

### DIFF
--- a/scripts/retained-text-animation-smoke.mjs
+++ b/scripts/retained-text-animation-smoke.mjs
@@ -10,6 +10,7 @@ const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, "..");
 const port = 4191;
 const baseUrl = `http://127.0.0.1:${port}`;
+const retainedScalarTolerance = 1e-6;
 
 let serverOutput = "";
 const server = spawn(
@@ -43,21 +44,28 @@ class RetainedAnimate(Scene):
         label = Text("Animate", font_size=48)
 
         self.play(
-            label.animate(run_time=2.0, rate_func=linear).scale(2.0).shift(RIGHT)
+            label.animate(run_time=2.0, rate_func=linear).scale(2.0).shift(RIGHT).rotate(PI / 2)
         )
-        self.play(label.animate.scale(0.5).shift(UP), run_time=1.0)
+        self.play(label.animate.scale(0.5).shift(UP).rotate(-PI / 4), run_time=1.0)
         self.play(label.animate.move_to(2 * LEFT), run_time=1.0)
 
         assert label in self.mobjects
 
         unsupported = Text("Unsupported", font_size=36)
         try:
-            self.play(unsupported.animate.rotate(0.25), run_time=0.25)
-            raise AssertionError("unsupported retained animate.rotate must fail")
+            self.play(unsupported.animate.set_opacity(0.5), run_time=0.25)
+            raise AssertionError("unsupported retained animate.set_opacity must fail")
         except NotImplementedError as error:
-            assert "animate.rotate" in str(error)
+            assert "animate.set_opacity" in str(error)
         assert unsupported not in self.mobjects
 `;
+
+function assertNear(actual, expected, message) {
+  assert.ok(
+    Math.abs(actual - expected) <= retainedScalarTolerance,
+    `${message}: expected ${expected}, got ${actual}`,
+  );
+}
 
 let browser = null;
 try {
@@ -96,12 +104,14 @@ try {
   const tracks = result.retainedDocument.tracks ?? [];
   const scaleTracks = tracks.filter((track) => track.property === "scale");
   const positionTracks = tracks.filter((track) => track.property === "position");
+  const rotationTracks = tracks.filter((track) => track.property === "rotation");
   assert.equal(scaleTracks.length, 2, "two scale calls must emit two retained scale tracks");
   assert.equal(
     positionTracks.length,
     3,
     "two relative shifts and one absolute move_to must emit three retained position tracks",
   );
+  assert.equal(rotationTracks.length, 2, "two rotate calls must emit two retained rotation tracks");
 
   assert.deepEqual(scaleTracks[0].values.vec2, {
     from: { x: 1, y: 1 },
@@ -142,6 +152,19 @@ try {
   assert.equal(positionTracks[2].timing.start_time, 3);
   assert.equal(positionTracks[2].timing.duration, 1);
   assert.equal(positionTracks[2].timing.easing, "smooth");
+
+  // Retained transform scalars are Rust f32 values serialized through the WASM handle.
+  assertNear(rotationTracks[0].values.scalar.from, 0, "first rotation source");
+  assertNear(rotationTracks[0].values.scalar.to, Math.PI / 2, "first rotation target");
+  assert.equal(rotationTracks[0].timing.start_time, 0);
+  assert.equal(rotationTracks[0].timing.duration, 2);
+  assert.equal(rotationTracks[0].timing.easing, "linear");
+
+  assertNear(rotationTracks[1].values.scalar.from, Math.PI / 2, "second rotation source");
+  assertNear(rotationTracks[1].values.scalar.to, Math.PI / 4, "second rotation target");
+  assert.equal(rotationTracks[1].timing.start_time, 2);
+  assert.equal(rotationTracks[1].timing.duration, 1);
+  assert.equal(rotationTracks[1].timing.easing, "smooth");
   assert.equal(result.duration, 4);
 
   const wire = JSON.stringify(result.retainedDocument);
@@ -151,7 +174,7 @@ try {
   assert.deepEqual(errors, [], `browser errors while testing retained Text animation:\n${errors.join("\n")}`);
 
   console.log(
-    "Retained Text animation smoke passed: scale and position builder methods lower to source-level retained tracks, relative shift composes against scheduler-owned state, absolute move_to remains absolute, timing options are preserved, and unsupported retained properties fail without legacy geometry.",
+    "Retained Text animation smoke passed: scale, position, and rotation builder methods lower to source-level retained tracks; relative operations compose against scheduler-owned state; absolute move_to remains absolute; timing options are preserved; and unsupported retained properties fail without legacy geometry.",
   );
 } finally {
   await browser?.close();

--- a/web/python/_manim_retained_animate.py
+++ b/web/python/_manim_retained_animate.py
@@ -48,6 +48,13 @@ def _vec2(value: object, label: str) -> dict[str, float]:
     return {"x": x, "y": y}
 
 
+def _finite_scalar(value: object, label: str) -> float:
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError(f"retained text {label} state must be finite")
+    return result
+
+
 def _transform(spec: dict[str, Any]) -> dict[str, Any]:
     transform = spec.get("transform")
     if not isinstance(transform, dict):
@@ -128,9 +135,15 @@ def _semantic_operation(
         position = _vec2(_transform(after).get("translation"), "translation")
         return {"kind": "set_y", "y": position["y"]}
 
+    if name == "rotate":
+        _assert_only_transform_field_changed(before, after, "rotation")
+        before_rotation = _finite_scalar(_transform(before).get("rotation"), "rotation")
+        after_rotation = _finite_scalar(_transform(after).get("rotation"), "rotation")
+        return {"kind": "rotate_relative", "angle": after_rotation - before_rotation}
+
     raise NotImplementedError(
         f"retained Text .animate.{name} is not supported yet; "
-        "position and uniform scale animations are supported"
+        "position, rotation, and uniform scale animations are supported"
     )
 
 
@@ -197,6 +210,7 @@ def _initial_animation_state(source: _typst._RetainedTextMobject) -> dict[str, A
     transform = _transform(source._spec())
     return {
         "position": _vec2(transform.get("translation"), "translation"),
+        "rotation": _finite_scalar(transform.get("rotation"), "rotation"),
         "scale": _vec2(transform.get("scale"), "scale"),
     }
 
@@ -231,6 +245,31 @@ def _append_vec2_track(
     )
 
 
+def _append_scalar_track(
+    scene: _compat.Scene,
+    *,
+    object_id: int,
+    property_name: str,
+    current: float,
+    target: float,
+    start_time: float,
+    duration: float,
+    easing: str,
+) -> None:
+    scene._retained_animation_tracks.append(
+        {
+            "object": object_id,
+            "property": property_name,
+            "values": {"scalar": {"from": float(current), "to": float(target)}},
+            "timing": {
+                "start_time": float(start_time),
+                "duration": float(duration),
+                "easing": str(easing),
+            },
+        }
+    )
+
+
 def _schedule_retained_plan(
     scene: _compat.Scene,
     animation: object,
@@ -249,8 +288,10 @@ def _schedule_retained_plan(
         object_id, _initial_animation_state(source)
     )
     current_position = copy.deepcopy(state["position"])
+    current_rotation = float(state["rotation"])
     current_scale = copy.deepcopy(state["scale"])
     target_position = copy.deepcopy(current_position)
+    target_rotation = current_rotation
     target_scale = copy.deepcopy(current_scale)
     touched: list[str] = []
 
@@ -289,6 +330,11 @@ def _schedule_retained_plan(
                 touched.append("position")
             target_position["y"] = float(operation["y"])
             continue
+        if kind == "rotate_relative":
+            if "rotation" not in touched:
+                touched.append("rotation")
+            target_rotation += float(operation["angle"])
+            continue
         raise ValueError(f"unknown retained animation operation {kind!r}")
 
     for property_name in touched:
@@ -316,6 +362,18 @@ def _schedule_retained_plan(
                 easing=easing,
             )
             state["position"] = copy.deepcopy(target_position)
+        elif property_name == "rotation":
+            _append_scalar_track(
+                scene,
+                object_id=object_id,
+                property_name="rotation",
+                current=current_rotation,
+                target=target_rotation,
+                start_time=start_time,
+                duration=duration,
+                easing=easing,
+            )
+            state["rotation"] = target_rotation
 
 
 def _retained_document(self: _compat.Scene) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

Lower ordinary `Text.animate.rotate(angle)` into the existing retained `rotation` scalar channel.

- keep the generic Manim builder and retained semantic-operation log authoritative;
- record `rotate(angle)` as a relative angular delta from the detached retained target;
- replay rotation against scheduler-owned current state so sequential relative rotations compose without mutating the source object;
- emit one scalar `rotation` track per play with the same timing/easing resolver used by scale and position;
- allow scale + shift + rotation in one chained builder, producing independent simultaneous retained property tracks;
- keep unsupported properties explicit and transactional; the focused smoke now uses `set_opacity` as the next unsupported property;
- extend the dedicated Chromium smoke to prove `0 → π/2 → π/4` rotation composition alongside scale/position assertions and zero legacy placeholder geometry;
- assert rotation using an explicit `1e-6` tolerance because retained transform scalars cross the Rust/WASM boundary as `f32` values.

## Architecture

`Property::Rotation` is already a first-class scalar retained runtime channel, so this is an authoring-only slice. No renderer or alternate playback path is introduced. The semantic operation log preserves relative intent instead of inferring later from an accumulated target state.

Color remains a separate follow-up because the core property model has no `Color` channel.

Follows #661, #659, and #609.