### PR TITLE
Support retained Text opacity animate builders

### DIFF
--- a/scripts/retained-text-animation-smoke.mjs
+++ b/scripts/retained-text-animation-smoke.mjs
@@ -44,19 +44,26 @@ class RetainedAnimate(Scene):
         label = Text("Animate", font_size=48)
 
         self.play(
-            label.animate(run_time=2.0, rate_func=linear).scale(2.0).shift(RIGHT).rotate(PI / 2)
+            label.animate(run_time=2.0, rate_func=linear)
+                .scale(2.0)
+                .shift(RIGHT)
+                .rotate(PI / 2)
+                .set_opacity(0.25)
         )
-        self.play(label.animate.scale(0.5).shift(UP).rotate(-PI / 4), run_time=1.0)
+        self.play(
+            label.animate.scale(0.5).shift(UP).rotate(-PI / 4).set_opacity(0.75),
+            run_time=1.0,
+        )
         self.play(label.animate.move_to(2 * LEFT), run_time=1.0)
 
         assert label in self.mobjects
 
         unsupported = Text("Unsupported", font_size=36)
         try:
-            self.play(unsupported.animate.set_opacity(0.5), run_time=0.25)
-            raise AssertionError("unsupported retained animate.set_opacity must fail")
+            self.play(unsupported.animate.set_color(RED), run_time=0.25)
+            raise AssertionError("unsupported retained animate.set_color must fail")
         except NotImplementedError as error:
-            assert "animate.set_opacity" in str(error)
+            assert "animate.set_color" in str(error)
         assert unsupported not in self.mobjects
 `;
 
@@ -105,6 +112,7 @@ try {
   const scaleTracks = tracks.filter((track) => track.property === "scale");
   const positionTracks = tracks.filter((track) => track.property === "position");
   const rotationTracks = tracks.filter((track) => track.property === "rotation");
+  const opacityTracks = tracks.filter((track) => track.property === "opacity");
   assert.equal(scaleTracks.length, 2, "two scale calls must emit two retained scale tracks");
   assert.equal(
     positionTracks.length,
@@ -112,6 +120,7 @@ try {
     "two relative shifts and one absolute move_to must emit three retained position tracks",
   );
   assert.equal(rotationTracks.length, 2, "two rotate calls must emit two retained rotation tracks");
+  assert.equal(opacityTracks.length, 2, "two opacity calls must emit two retained opacity tracks");
 
   assert.deepEqual(scaleTracks[0].values.vec2, {
     from: { x: 1, y: 1 },
@@ -165,6 +174,19 @@ try {
   assert.equal(rotationTracks[1].timing.start_time, 2);
   assert.equal(rotationTracks[1].timing.duration, 1);
   assert.equal(rotationTracks[1].timing.easing, "smooth");
+
+  assertNear(opacityTracks[0].values.scalar.from, 1, "first opacity source");
+  assertNear(opacityTracks[0].values.scalar.to, 0.25, "first opacity target");
+  assert.equal(opacityTracks[0].timing.start_time, 0);
+  assert.equal(opacityTracks[0].timing.duration, 2);
+  assert.equal(opacityTracks[0].timing.easing, "linear");
+
+  assertNear(opacityTracks[1].values.scalar.from, 0.25, "second opacity source");
+  assertNear(opacityTracks[1].values.scalar.to, 0.75, "second opacity target");
+  assert.equal(opacityTracks[1].timing.start_time, 2);
+  assert.equal(opacityTracks[1].timing.duration, 1);
+  assert.equal(opacityTracks[1].timing.easing, "smooth");
+
   assert.equal(result.duration, 4);
 
   const wire = JSON.stringify(result.retainedDocument);
@@ -174,7 +196,7 @@ try {
   assert.deepEqual(errors, [], `browser errors while testing retained Text animation:\n${errors.join("\n")}`);
 
   console.log(
-    "Retained Text animation smoke passed: scale, position, and rotation builder methods lower to source-level retained tracks; relative operations compose against scheduler-owned state; absolute move_to remains absolute; timing options are preserved; and unsupported retained properties fail without legacy geometry.",
+    "Retained Text animation smoke passed: scale, position, rotation, and opacity builder methods lower to source-level retained tracks; relative operations compose against scheduler-owned state; absolute move_to/opacity targets remain absolute; timing options are preserved; and unsupported retained properties fail without legacy geometry.",
   );
 } finally {
   await browser?.close();

--- a/scripts/retained-text-animation-smoke.mjs
+++ b/scripts/retained-text-animation-smoke.mjs
@@ -10,6 +10,7 @@ const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, "..");
 const port = 4191;
 const baseUrl = `http://127.0.0.1:${port}`;
+const retainedScalarTolerance = 1e-6;
 
 let serverOutput = "";
 const server = spawn(
@@ -43,21 +44,28 @@ class RetainedAnimate(Scene):
         label = Text("Animate", font_size=48)
 
         self.play(
-            label.animate(run_time=2.0, rate_func=linear).scale(2.0).shift(RIGHT)
+            label.animate(run_time=2.0, rate_func=linear).scale(2.0).shift(RIGHT).rotate(PI / 2)
         )
-        self.play(label.animate.scale(0.5).shift(UP), run_time=1.0)
+        self.play(label.animate.scale(0.5).shift(UP).rotate(-PI / 4), run_time=1.0)
         self.play(label.animate.move_to(2 * LEFT), run_time=1.0)
 
         assert label in self.mobjects
 
         unsupported = Text("Unsupported", font_size=36)
         try:
-            self.play(unsupported.animate.rotate(0.25), run_time=0.25)
-            raise AssertionError("unsupported retained animate.rotate must fail")
+            self.play(unsupported.animate.set_opacity(0.5), run_time=0.25)
+            raise AssertionError("unsupported retained animate.set_opacity must fail")
         except NotImplementedError as error:
-            assert "animate.rotate" in str(error)
+            assert "animate.set_opacity" in str(error)
         assert unsupported not in self.mobjects
 `;
+
+function assertNear(actual, expected, message) {
+  assert.ok(
+    Math.abs(actual - expected) <= retainedScalarTolerance,
+    `${message}: expected ${expected}, got ${actual}`,
+  );
+}
 
 let browser = null;
 try {
@@ -96,12 +104,14 @@ try {
   const tracks = result.retainedDocument.tracks ?? [];
   const scaleTracks = tracks.filter((track) => track.property === "scale");
   const positionTracks = tracks.filter((track) => track.property === "position");
+  const rotationTracks = tracks.filter((track) => track.property === "rotation");
   assert.equal(scaleTracks.length, 2, "two scale calls must emit two retained scale tracks");
   assert.equal(
     positionTracks.length,
     3,
     "two relative shifts and one absolute move_to must emit three retained position tracks",
   );
+  assert.equal(rotationTracks.length, 2, "two rotate calls must emit two retained rotation tracks");
 
   assert.deepEqual(scaleTracks[0].values.vec2, {
     from: { x: 1, y: 1 },
@@ -142,6 +152,19 @@ try {
   assert.equal(positionTracks[2].timing.start_time, 3);
   assert.equal(positionTracks[2].timing.duration, 1);
   assert.equal(positionTracks[2].timing.easing, "smooth");
+
+  // Retained transform scalars are Rust f32 values serialized through the WASM handle.
+  assertNear(rotationTracks[0].values.scalar.from, 0, "first rotation source");
+  assertNear(rotationTracks[0].values.scalar.to, Math.PI / 2, "first rotation target");
+  assert.equal(rotationTracks[0].timing.start_time, 0);
+  assert.equal(rotationTracks[0].timing.duration, 2);
+  assert.equal(rotationTracks[0].timing.easing, "linear");
+
+  assertNear(rotationTracks[1].values.scalar.from, Math.PI / 2, "second rotation source");
+  assertNear(rotationTracks[1].values.scalar.to, Math.PI / 4, "second rotation target");
+  assert.equal(rotationTracks[1].timing.start_time, 2);
+  assert.equal(rotationTracks[1].timing.duration, 1);
+  assert.equal(rotationTracks[1].timing.easing, "smooth");
   assert.equal(result.duration, 4);
 
   const wire = JSON.stringify(result.retainedDocument);
@@ -151,7 +174,7 @@ try {
   assert.deepEqual(errors, [], `browser errors while testing retained Text animation:\n${errors.join("\n")}`);
 
   console.log(
-    "Retained Text animation smoke passed: scale and position builder methods lower to source-level retained tracks, relative shift composes against scheduler-owned state, absolute move_to remains absolute, timing options are preserved, and unsupported retained properties fail without legacy geometry.",
+    "Retained Text animation smoke passed: scale, position, and rotation builder methods lower to source-level retained tracks; relative operations compose against scheduler-owned state; absolute move_to remains absolute; timing options are preserved; and unsupported retained properties fail without legacy geometry.",
   );
 } finally {
   await browser?.close();

--- a/web/python/_manim_retained_animate.py
+++ b/web/python/_manim_retained_animate.py
@@ -55,6 +55,13 @@ def _finite_scalar(value: object, label: str) -> float:
     return result
 
 
+def _unit_scalar(value: object, label: str) -> float:
+    result = _finite_scalar(value, label)
+    if result < 0.0 or result > 1.0:
+        raise ValueError(f"retained text {label} state must be between zero and one")
+    return result
+
+
 def _transform(spec: dict[str, Any]) -> dict[str, Any]:
     transform = spec.get("transform")
     if not isinstance(transform, dict):
@@ -74,6 +81,22 @@ def _assert_only_transform_field_changed(
     if before_normalized != after_normalized:
         raise NotImplementedError(
             f"retained Text .animate.{field} changed unsupported retained state"
+        )
+
+
+def _assert_only_spec_field_changed(
+    before: dict[str, Any],
+    after: dict[str, Any],
+    field: str,
+    method: str,
+) -> None:
+    before_normalized = copy.deepcopy(before)
+    after_normalized = copy.deepcopy(after)
+    before_normalized[field] = None
+    after_normalized[field] = None
+    if before_normalized != after_normalized:
+        raise NotImplementedError(
+            f"retained Text .animate.{method} changed unsupported retained state"
         )
 
 
@@ -141,9 +164,13 @@ def _semantic_operation(
         after_rotation = _finite_scalar(_transform(after).get("rotation"), "rotation")
         return {"kind": "rotate_relative", "angle": after_rotation - before_rotation}
 
+    if name == "set_opacity":
+        _assert_only_spec_field_changed(before, after, "opacity", name)
+        return {"kind": "opacity_to", "opacity": _unit_scalar(after.get("opacity"), "opacity")}
+
     raise NotImplementedError(
         f"retained Text .animate.{name} is not supported yet; "
-        "position, rotation, and uniform scale animations are supported"
+        "position, rotation, opacity, and uniform scale animations are supported"
     )
 
 
@@ -207,8 +234,10 @@ def _bind_retained(scene: _compat.Scene, source: _typst._RetainedTextMobject) ->
 
 
 def _initial_animation_state(source: _typst._RetainedTextMobject) -> dict[str, Any]:
-    transform = _transform(source._spec())
+    spec = source._spec()
+    transform = _transform(spec)
     return {
+        "opacity": _unit_scalar(spec.get("opacity"), "opacity"),
         "position": _vec2(transform.get("translation"), "translation"),
         "rotation": _finite_scalar(transform.get("rotation"), "rotation"),
         "scale": _vec2(transform.get("scale"), "scale"),
@@ -287,9 +316,11 @@ def _schedule_retained_plan(
     state = scene._retained_animation_state.setdefault(
         object_id, _initial_animation_state(source)
     )
+    current_opacity = float(state["opacity"])
     current_position = copy.deepcopy(state["position"])
     current_rotation = float(state["rotation"])
     current_scale = copy.deepcopy(state["scale"])
+    target_opacity = current_opacity
     target_position = copy.deepcopy(current_position)
     target_rotation = current_rotation
     target_scale = copy.deepcopy(current_scale)
@@ -335,6 +366,11 @@ def _schedule_retained_plan(
                 touched.append("rotation")
             target_rotation += float(operation["angle"])
             continue
+        if kind == "opacity_to":
+            if "opacity" not in touched:
+                touched.append("opacity")
+            target_opacity = _unit_scalar(operation["opacity"], "opacity")
+            continue
         raise ValueError(f"unknown retained animation operation {kind!r}")
 
     for property_name in touched:
@@ -374,6 +410,18 @@ def _schedule_retained_plan(
                 easing=easing,
             )
             state["rotation"] = target_rotation
+        elif property_name == "opacity":
+            _append_scalar_track(
+                scene,
+                object_id=object_id,
+                property_name="opacity",
+                current=current_opacity,
+                target=target_opacity,
+                start_time=start_time,
+                duration=duration,
+                easing=easing,
+            )
+            state["opacity"] = target_opacity
 
 
 def _retained_document(self: _compat.Scene) -> dict[str, Any]:

--- a/web/python/_manim_retained_animate.py
+++ b/web/python/_manim_retained_animate.py
@@ -48,6 +48,13 @@ def _vec2(value: object, label: str) -> dict[str, float]:
     return {"x": x, "y": y}
 
 
+def _finite_scalar(value: object, label: str) -> float:
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError(f"retained text {label} state must be finite")
+    return result
+
+
 def _transform(spec: dict[str, Any]) -> dict[str, Any]:
     transform = spec.get("transform")
     if not isinstance(transform, dict):
@@ -128,9 +135,15 @@ def _semantic_operation(
         position = _vec2(_transform(after).get("translation"), "translation")
         return {"kind": "set_y", "y": position["y"]}
 
+    if name == "rotate":
+        _assert_only_transform_field_changed(before, after, "rotation")
+        before_rotation = _finite_scalar(_transform(before).get("rotation"), "rotation")
+        after_rotation = _finite_scalar(_transform(after).get("rotation"), "rotation")
+        return {"kind": "rotate_relative", "angle": after_rotation - before_rotation}
+
     raise NotImplementedError(
         f"retained Text .animate.{name} is not supported yet; "
-        "position and uniform scale animations are supported"
+        "position, rotation, and uniform scale animations are supported"
     )
 
 
@@ -197,6 +210,7 @@ def _initial_animation_state(source: _typst._RetainedTextMobject) -> dict[str, A
     transform = _transform(source._spec())
     return {
         "position": _vec2(transform.get("translation"), "translation"),
+        "rotation": _finite_scalar(transform.get("rotation"), "rotation"),
         "scale": _vec2(transform.get("scale"), "scale"),
     }
 
@@ -231,6 +245,31 @@ def _append_vec2_track(
     )
 
 
+def _append_scalar_track(
+    scene: _compat.Scene,
+    *,
+    object_id: int,
+    property_name: str,
+    current: float,
+    target: float,
+    start_time: float,
+    duration: float,
+    easing: str,
+) -> None:
+    scene._retained_animation_tracks.append(
+        {
+            "object": object_id,
+            "property": property_name,
+            "values": {"scalar": {"from": float(current), "to": float(target)}},
+            "timing": {
+                "start_time": float(start_time),
+                "duration": float(duration),
+                "easing": str(easing),
+            },
+        }
+    )
+
+
 def _schedule_retained_plan(
     scene: _compat.Scene,
     animation: object,
@@ -249,8 +288,10 @@ def _schedule_retained_plan(
         object_id, _initial_animation_state(source)
     )
     current_position = copy.deepcopy(state["position"])
+    current_rotation = float(state["rotation"])
     current_scale = copy.deepcopy(state["scale"])
     target_position = copy.deepcopy(current_position)
+    target_rotation = current_rotation
     target_scale = copy.deepcopy(current_scale)
     touched: list[str] = []
 
@@ -289,6 +330,11 @@ def _schedule_retained_plan(
                 touched.append("position")
             target_position["y"] = float(operation["y"])
             continue
+        if kind == "rotate_relative":
+            if "rotation" not in touched:
+                touched.append("rotation")
+            target_rotation += float(operation["angle"])
+            continue
         raise ValueError(f"unknown retained animation operation {kind!r}")
 
     for property_name in touched:
@@ -316,6 +362,18 @@ def _schedule_retained_plan(
                 easing=easing,
             )
             state["position"] = copy.deepcopy(target_position)
+        elif property_name == "rotation":
+            _append_scalar_track(
+                scene,
+                object_id=object_id,
+                property_name="rotation",
+                current=current_rotation,
+                target=target_rotation,
+                start_time=start_time,
+                duration=duration,
+                easing=easing,
+            )
+            state["rotation"] = target_rotation
 
 
 def _retained_document(self: _compat.Scene) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

Stack the next retained Text animation slice on #663 by lowering ordinary `Text.animate.set_opacity(value)` into the existing retained `opacity` scalar channel.

- keep the generic Manim builder and retained semantic-operation log authoritative;
- record `set_opacity(value)` as an absolute opacity target from the detached retained target;
- replay opacity against scheduler-owned current state so sequential opacity animations compose without mutating the source object;
- validate authored opacity as finite and within `[0, 1]` before scheduling;
- emit one scalar `opacity` track per play with the same timing/easing resolver used by scale, position, and rotation;
- allow scale + shift + rotation + opacity in one chained builder, producing independent simultaneous retained property tracks;
- keep color explicitly unsupported because the core retained `Property` model has no color channel;
- extend the dedicated Chromium smoke to prove `1 → 0.25 → 0.75` opacity composition alongside scale/position/rotation, timing preservation, and zero legacy placeholder geometry.

## Stack

This PR is intentionally based on `text/retained-animate-rotation-builder` / #663 while #663 finishes exact-head validation. It is not intended to merge to master in stacked form. After #663 lands, this PR will be restacked onto the resulting master and rerun on its new exact head before merge.

## Architecture

`Property::Opacity` is already a first-class retained runtime channel applied directly to retained object style, including text. This therefore remains an authoring-only slice with no renderer or alternate playback path.