### PR TITLE
Support clipped-edge visual golden comparisons

### DIFF
--- a/scripts/browser-visual-parity-lib.mjs
+++ b/scripts/browser-visual-parity-lib.mjs
@@ -10,6 +10,19 @@ function assertImage(image, name) {
   }
 }
 
+function normalizedBackground(background) {
+  if (background === undefined || background === null) {
+    return null;
+  }
+  if (!Array.isArray(background) || background.length !== 4) {
+    throw new RangeError("background must be an RGBA array with four byte values");
+  }
+  if (!background.every((value) => Number.isInteger(value) && value >= 0 && value <= 255)) {
+    throw new RangeError("background RGBA values must be integers within [0, 255]");
+  }
+  return [...background];
+}
+
 function colorDistance(data, offset, background) {
   return (
     Math.abs(data[offset] - background[0]) +
@@ -19,17 +32,19 @@ function colorDistance(data, offset, background) {
   );
 }
 
-export function foregroundMask(image, backgroundDistance = 32) {
+export function foregroundMask(image, backgroundDistance = 32, background = null) {
   assertImage(image, "image");
   if (!Number.isFinite(backgroundDistance) || backgroundDistance < 0) {
     throw new RangeError("backgroundDistance must be a non-negative finite number");
   }
 
-  const background = [image.data[0], image.data[1], image.data[2], image.data[3]];
+  const explicitBackground = normalizedBackground(background);
+  const resolvedBackground =
+    explicitBackground ?? [image.data[0], image.data[1], image.data[2], image.data[3]];
   const mask = new Uint8Array(image.width * image.height);
   let count = 0;
   for (let pixel = 0; pixel < mask.length; pixel += 1) {
-    if (colorDistance(image.data, pixel * 4, background) >= backgroundDistance) {
+    if (colorDistance(image.data, pixel * 4, resolvedBackground) >= backgroundDistance) {
       mask[pixel] = 1;
       count += 1;
     }
@@ -110,7 +125,11 @@ function normalizedOptions(options = {}) {
   const neighborRadius = options.neighborRadius ?? 1;
   const maxMismatchFraction = options.maxMismatchFraction ?? 0.02;
   const maxBoundsDelta = options.maxBoundsDelta ?? 2;
+  const background = normalizedBackground(options.background);
 
+  if (!Number.isFinite(backgroundDistance) || backgroundDistance < 0) {
+    throw new RangeError("backgroundDistance must be a non-negative finite number");
+  }
   if (!Number.isInteger(neighborRadius) || neighborRadius < 0) {
     throw new RangeError("neighborRadius must be a non-negative integer");
   }
@@ -120,7 +139,7 @@ function normalizedOptions(options = {}) {
   if (!Number.isFinite(maxBoundsDelta) || maxBoundsDelta < 0) {
     throw new RangeError("maxBoundsDelta must be a non-negative finite number");
   }
-  return { backgroundDistance, neighborRadius, maxMismatchFraction, maxBoundsDelta };
+  return { backgroundDistance, neighborRadius, maxMismatchFraction, maxBoundsDelta, background };
 }
 
 export function compareForegroundCoverage(left, right, options = {}) {
@@ -133,8 +152,16 @@ export function compareForegroundCoverage(left, right, options = {}) {
   }
 
   const normalized = normalizedOptions(options);
-  const leftForeground = foregroundMask(left, normalized.backgroundDistance);
-  const rightForeground = foregroundMask(right, normalized.backgroundDistance);
+  const leftForeground = foregroundMask(
+    left,
+    normalized.backgroundDistance,
+    normalized.background,
+  );
+  const rightForeground = foregroundMask(
+    right,
+    normalized.backgroundDistance,
+    normalized.background,
+  );
   const leftUnmatched = unmatchedForegroundMask(
     leftForeground.mask,
     rightForeground.mask,
@@ -184,8 +211,16 @@ export function foregroundMismatchMask(left, right, options = {}) {
   }
 
   const normalized = normalizedOptions(options);
-  const leftForeground = foregroundMask(left, normalized.backgroundDistance);
-  const rightForeground = foregroundMask(right, normalized.backgroundDistance);
+  const leftForeground = foregroundMask(
+    left,
+    normalized.backgroundDistance,
+    normalized.background,
+  );
+  const rightForeground = foregroundMask(
+    right,
+    normalized.backgroundDistance,
+    normalized.background,
+  );
   const leftUnmatched = unmatchedForegroundMask(
     leftForeground.mask,
     rightForeground.mask,

--- a/scripts/browser-visual-parity-lib.test.mjs
+++ b/scripts/browser-visual-parity-lib.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { compareForegroundCoverage } from "./browser-visual-parity-lib.mjs";
+import {
+  compareForegroundCoverage,
+  foregroundMask,
+} from "./browser-visual-parity-lib.mjs";
 
 function image(width, height, foreground, colors = {}) {
   const background = colors.background ?? [20, 20, 20, 255];
@@ -64,6 +67,47 @@ test("color-transfer differences do not masquerade as geometry differences", () 
 
   assert.equal(result.pass, true);
   assert.equal(result.mismatchFraction, 0);
+});
+
+test("explicit background preserves foreground that reaches the top-left canvas edge", () => {
+  const background = [20, 20, 20, 255];
+  const clipped = image(5, 4, [
+    [0, 0],
+    [1, 0],
+    [0, 1],
+  ], { background });
+
+  const inferred = foregroundMask(clipped);
+  assert.equal(
+    inferred.count,
+    17,
+    "corner inference treats the clipped foreground color as the background",
+  );
+
+  const explicit = foregroundMask(clipped, 32, background);
+  assert.equal(explicit.count, 3);
+  assert.deepEqual([...explicit.mask.slice(0, 7)], [1, 1, 0, 0, 0, 1, 0]);
+
+  const result = compareForegroundCoverage(clipped, clipped, {
+    background,
+    maxMismatchFraction: 0,
+    maxBoundsDelta: 0,
+  });
+  assert.equal(result.pass, true);
+  assert.equal(result.leftForegroundPixels, 3);
+  assert.deepEqual(result.leftBounds, { minX: 0, minY: 0, maxX: 1, maxY: 1 });
+});
+
+test("explicit backgrounds reject malformed RGBA contracts", () => {
+  const sample = image(4, 4, [[1, 1]]);
+  assert.throws(
+    () => compareForegroundCoverage(sample, sample, { background: [0, 0, 0] }),
+    /RGBA array with four byte values/,
+  );
+  assert.throws(
+    () => compareForegroundCoverage(sample, sample, { background: [0, 0, 0, 300] }),
+    /integers within \[0, 255\]/,
+  );
 });
 
 test("missing visible geometry fails the parity gate", () => {


### PR DESCRIPTION
## Summary
- let the shared browser visual-parity comparator accept an explicit canonical RGBA background
- preserve the existing per-image top-left inference when no background is supplied, so current WebGPU/WebGL coverage ratchets remain unchanged
- validate the explicit background contract before comparison
- add focused regressions for foreground touching the top-left canvas edge and malformed background values

## Why
#109 requires deterministic golden fixtures for clipping/canvas edges. The reusable comparator currently infers each image's background from pixel `(0, 0)`. A valid fixture whose foreground reaches that corner therefore inverts foreground/background classification and cannot be trusted as a golden oracle.

This fixes the comparator boundary rather than adding fixture-specific margins or a second screenshot-diff implementation. Future canonical goldens can pass their pinned background explicitly, while existing backend parity continues using its current color-transfer-tolerant inference.

## Validation
`scripts/browser-visual-parity-lib.test.mjs` is already executed by the required web build. The added regression demonstrates both the old corner-inference failure mode and the explicit-background result/bounds.

Tracks #109.