### PR TITLE
Ratchet classified Manim reference identities

### DIFF
--- a/.github/workflows/manim-reference-inventory.yml
+++ b/.github/workflows/manim-reference-inventory.yml
@@ -14,6 +14,8 @@ on:
       - 'scripts/manim-reference-ledger.test.mjs'
       - 'scripts/manim-reference-coverage.mjs'
       - 'scripts/manim-reference-coverage.test.mjs'
+      - 'scripts/manim-reference-classification-lock.mjs'
+      - 'scripts/manim-reference-classification-lock.test.mjs'
   push:
     branches:
       - master
@@ -29,6 +31,8 @@ on:
       - 'scripts/manim-reference-ledger.test.mjs'
       - 'scripts/manim-reference-coverage.mjs'
       - 'scripts/manim-reference-coverage.test.mjs'
+      - 'scripts/manim-reference-classification-lock.mjs'
+      - 'scripts/manim-reference-classification-lock.test.mjs'
   workflow_dispatch:
 
 permissions:
@@ -128,6 +132,18 @@ jobs:
           printf '\nReference inventory lock verified against the immutable extracted corpus.\n' \
             >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Verify classified reference identities
+        shell: bash
+        run: |
+          set -euo pipefail
+          node noon/scripts/manim-reference-classification-lock.mjs \
+            noon/web/python/examples/manim_tutorial_manifest.json \
+            noon/compat/manim-v0.21.0-reference-coverage-lock.json \
+            > noon/artifacts/manim-v0.21.0-reference-classification-lock.json
+          cat noon/artifacts/manim-v0.21.0-reference-classification-lock.json
+          printf '\nReference classification identities verified against the checked-in ratchet.\n' \
+            >> "$GITHUB_STEP_SUMMARY"
+
       - name: Reconcile canonical reference coverage
         shell: bash
         run: |
@@ -158,6 +174,7 @@ jobs:
           path: |
             noon/artifacts/manim-v0.21.0-reference-inventory.json
             noon/artifacts/manim-v0.21.0-reference-ledger-summary.json
+            noon/artifacts/manim-v0.21.0-reference-classification-lock.json
             noon/artifacts/manim-v0.21.0-reference-coverage.json
           if-no-files-found: error
           retention-days: 14

--- a/compat/manim-v0.21.0-reference-coverage-lock.json
+++ b/compat/manim-v0.21.0-reference-coverage-lock.json
@@ -1,5 +1,30 @@
 {
   "schema_version": 2,
   "minimum_reconciled_examples": 21,
-  "minimum_classified_examples": 23
+  "minimum_classified_examples": 23,
+  "required_classified_entry_ids": [
+    "manim-dot-example",
+    "manim-ellipse-example",
+    "manim-show-uncreate",
+    "parity-draw-border-then-fill-styled-square",
+    "manim-show-increasing-subsets",
+    "manim-add-with-run-time",
+    "manim-succession-example",
+    "manim-grow-from-point",
+    "manim-grow-from-center",
+    "manim-grow-from-edge",
+    "manim-spin-in-from-nothing",
+    "manim-rotating-demo",
+    "manim-using-focus-on",
+    "manim-using-indicate",
+    "manim-lagged-start-map",
+    "manim-move-to-target",
+    "manim-moving-camera-center",
+    "manim-example1-text",
+    "manim-typst-text-reference",
+    "manim-math-typst-reference",
+    "manim-shrink-to-center-text",
+    "manim-dashed-line-reference",
+    "manim-tangent-line-reference"
+  ]
 }

--- a/scripts/build-web-demo.sh
+++ b/scripts/build-web-demo.sh
@@ -33,6 +33,7 @@ node --check scripts/manim-typst-authoring-smoke.mjs
 node --check scripts/manim-reference-inventory.mjs
 node --check scripts/manim-reference-ledger.mjs
 node --check scripts/manim-reference-coverage.mjs
+node --check scripts/manim-reference-classification-lock.mjs
 node --check scripts/perf-profile.mjs
 node --check scripts/authoring-perf.mjs
 node --check scripts/perf-device-run.mjs
@@ -53,6 +54,7 @@ node --test scripts/browser-visual-parity-lib.test.mjs
 node --test scripts/manim-reference-inventory.test.mjs
 node --test scripts/manim-reference-ledger.test.mjs
 node --test scripts/manim-reference-coverage.test.mjs
+node --test scripts/manim-reference-classification-lock.test.mjs
 
 for test_file in web/*.test.mjs; do
   node --test "$test_file"

--- a/scripts/manim-reference-classification-lock.mjs
+++ b/scripts/manim-reference-classification-lock.mjs
@@ -1,0 +1,131 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const CLASSIFIED_STATUSES = new Set([
+  "ready",
+  "blocked",
+  "deferred",
+  "intentional-divergence",
+]);
+const PROVENANCE_ONLY_STATUSES = new Set(["blocked", "deferred"]);
+const EXACT_SOURCE_REUSE = "source-equivalent-manim-v0.21";
+
+function assertObject(value, name) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${name} must be an object`);
+  }
+}
+
+function isReferenceEntry(entry) {
+  return typeof entry.upstream === "string" && entry.upstream.startsWith("reference/");
+}
+
+function hasExactSourceEvidence(entry) {
+  return (
+    entry.reuse === EXACT_SOURCE_REUSE &&
+    typeof entry.upstream_source === "string" &&
+    entry.upstream_source.length > 0 &&
+    entry.reference_provenance === undefined
+  );
+}
+
+function hasProvenanceEvidence(entry) {
+  if (!PROVENANCE_ONLY_STATUSES.has(entry.status)) {
+    return false;
+  }
+  const provenance = entry.reference_provenance;
+  return (
+    provenance !== null &&
+    typeof provenance === "object" &&
+    !Array.isArray(provenance) &&
+    typeof provenance.source_path === "string" &&
+    provenance.source_path.length > 0 &&
+    Number.isInteger(provenance.directive_line) &&
+    provenance.directive_line > 0 &&
+    (provenance.name === null || typeof provenance.name === "string") &&
+    typeof provenance.source_sha256 === "string" &&
+    /^[0-9a-f]{64}$/u.test(provenance.source_sha256)
+  );
+}
+
+export function validateReferenceClassificationLock(manifest, lock) {
+  assertObject(manifest, "manifest");
+  assertObject(lock, "coverage lock");
+  if (!Array.isArray(manifest.entries)) {
+    throw new Error("manifest.entries must be an array");
+  }
+  if (lock.schema_version !== 2) {
+    throw new Error(`unsupported reference coverage lock schema ${lock.schema_version}`);
+  }
+  if (!Number.isInteger(lock.minimum_classified_examples) || lock.minimum_classified_examples < 0) {
+    throw new Error("coverage lock minimum_classified_examples must be a non-negative integer");
+  }
+  if (!Array.isArray(lock.required_classified_entry_ids)) {
+    throw new Error("coverage lock required_classified_entry_ids must be an array");
+  }
+
+  const requiredIds = new Set();
+  for (const [index, id] of lock.required_classified_entry_ids.entries()) {
+    if (typeof id !== "string" || id.length === 0) {
+      throw new Error(`coverage lock required_classified_entry_ids[${index}] must be a non-empty string`);
+    }
+    if (requiredIds.has(id)) {
+      throw new Error(`coverage lock contains duplicate required classified entry id ${id}`);
+    }
+    requiredIds.add(id);
+  }
+  if (requiredIds.size !== lock.minimum_classified_examples) {
+    throw new Error(
+      `coverage lock must name exactly ${lock.minimum_classified_examples} required classified entry ids, found ${requiredIds.size}`,
+    );
+  }
+
+  const referenceById = new Map();
+  for (const entry of manifest.entries.filter(isReferenceEntry)) {
+    assertObject(entry, `manifest entry ${entry?.id ?? "<unknown>"}`);
+    if (typeof entry.id !== "string" || entry.id.length === 0) {
+      throw new Error("reference manifest entry id must be a non-empty string");
+    }
+    if (referenceById.has(entry.id)) {
+      throw new Error(`duplicate reference manifest entry id ${entry.id}`);
+    }
+    referenceById.set(entry.id, entry);
+  }
+
+  for (const id of requiredIds) {
+    const entry = referenceById.get(id);
+    if (entry === undefined) {
+      throw new Error(`required classified reference entry ${id} is missing`);
+    }
+    if (!CLASSIFIED_STATUSES.has(entry.status)) {
+      throw new Error(`required classified reference entry ${id} has unsupported status ${entry.status ?? "<missing>"}`);
+    }
+    if (!hasExactSourceEvidence(entry) && !hasProvenanceEvidence(entry)) {
+      throw new Error(`required classified reference entry ${id} no longer carries pinned classification evidence`);
+    }
+  }
+
+  return {
+    schema_version: 1,
+    required_classified_entries: requiredIds.size,
+  };
+}
+
+async function main() {
+  const [manifestPath, lockPath] = process.argv.slice(2);
+  if (!manifestPath || !lockPath) {
+    throw new Error(
+      "usage: node scripts/manim-reference-classification-lock.mjs MANIFEST_JSON COVERAGE_LOCK_JSON",
+    );
+  }
+  const [manifest, lock] = await Promise.all(
+    [manifestPath, lockPath].map(async (file) => JSON.parse(await readFile(file, "utf8"))),
+  );
+  const report = validateReferenceClassificationLock(manifest, lock);
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  await main();
+}

--- a/scripts/manim-reference-classification-lock.test.mjs
+++ b/scripts/manim-reference-classification-lock.test.mjs
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { validateReferenceClassificationLock } from "./manim-reference-classification-lock.mjs";
+
+const HASH = "a".repeat(64);
+
+function lock(ids) {
+  return {
+    schema_version: 2,
+    minimum_reconciled_examples: 0,
+    minimum_classified_examples: ids.length,
+    required_classified_entry_ids: ids,
+  };
+}
+
+function exactEntry(id = "exact") {
+  return {
+    id,
+    status: "ready",
+    upstream: `reference/${id}.html`,
+    upstream_source: `fixtures/${id}.py`,
+    reuse: "source-equivalent-manim-v0.21",
+  };
+}
+
+function provenanceEntry(id = "blocked") {
+  return {
+    id,
+    status: "blocked",
+    upstream: `reference/${id}.html`,
+    reference_provenance: {
+      source_path: "manim/example.py",
+      directive_line: 10,
+      name: "Example",
+      source_sha256: HASH,
+    },
+  };
+}
+
+test("preserves exact-source and provenance-classified reference identities", () => {
+  const report = validateReferenceClassificationLock(
+    { entries: [exactEntry(), provenanceEntry()] },
+    lock(["exact", "blocked"]),
+  );
+  assert.equal(report.required_classified_entries, 2);
+});
+
+test("fails if one locked classification disappears even when total coverage can be replaced", () => {
+  assert.throws(
+    () =>
+      validateReferenceClassificationLock(
+        { entries: [exactEntry("replacement"), provenanceEntry()] },
+        lock(["exact", "blocked"]),
+      ),
+    /required classified reference entry exact is missing/u,
+  );
+});
+
+test("does not let an unprovenanced blocked stub satisfy a locked classification", () => {
+  assert.throws(
+    () =>
+      validateReferenceClassificationLock(
+        {
+          entries: [
+            {
+              id: "blocked",
+              status: "blocked",
+              upstream: "reference/blocked.html",
+              dependency: "#123",
+            },
+          ],
+        },
+        lock(["blocked"]),
+      ),
+    /no longer carries pinned classification evidence/u,
+  );
+});
+
+test("requires every count-ratcheted classification to have a locked identity", () => {
+  assert.throws(
+    () =>
+      validateReferenceClassificationLock(
+        { entries: [exactEntry()] },
+        {
+          ...lock(["exact"]),
+          minimum_classified_examples: 2,
+        },
+      ),
+    /must name exactly 2 required classified entry ids/u,
+  );
+});
+
+test("rejects duplicate locked ids", () => {
+  assert.throws(
+    () =>
+      validateReferenceClassificationLock(
+        { entries: [exactEntry()] },
+        {
+          ...lock(["exact"]),
+          minimum_classified_examples: 2,
+          required_classified_entry_ids: ["exact", "exact"],
+        },
+      ),
+    /duplicate required classified entry id exact/u,
+  );
+});


### PR DESCRIPTION
## Summary
- lock the stable manifest IDs of all 23 currently proven ManimCE v0.21 reference classifications, not just their aggregate count
- add a small validator that requires every locked ID to remain a reference entry with exact-source or pinned-provenance evidence
- require the identity lock size to equal the existing classification count ratchet, so future count increases must name the newly protected classifications
- run focused validator tests in the required web build and enforce the lock in the dedicated pinned-Manim reference workflow
- retain the existing provenance/source reconciler as the authority that proves each classification still maps to the immutable upstream corpus

## Why
The current #256 coverage lock only stores `minimum_classified_examples: 23`. A classified reference example can therefore disappear while a different example is classified in its place, and CI still passes as long as the total stays at least 23. That weakens the inventory into a count metric rather than a monotonic coverage contract.

This change composes two independent checks instead of duplicating extraction logic: the new validator preserves *which* manifest classifications are required; `manim-reference-coverage.mjs` continues proving their source/provenance against the pinned Manim checkout.

## Validation
- focused Node tests cover successful exact/provenance identities, same-count replacement regression, unprovenanced blocked stubs, missing identity ratchet entries, and duplicate IDs
- normal web CI syntax-checks and executes the new tests
- the Manim reference inventory workflow validates the identity lock before reconciling the canonical pinned corpus

Tracks #256.