### PR TITLE
Normalize native wheel input to CSS pixels

### DIFF
--- a/web/native-inputs.js
+++ b/web/native-inputs.js
@@ -20,12 +20,14 @@ function wheelLinePixels(canvas) {
   throw new TypeError("canvas must have a positive CSS line-height or font-size");
 }
 
-function wheelDeltaCssPixels(canvas, event, linePixels) {
+function wheelDeltaCssPixels(canvas, event, resolveLinePixels) {
   switch (event.deltaMode) {
     case 0:
       return { x: event.deltaX, y: event.deltaY };
-    case 1:
+    case 1: {
+      const linePixels = resolveLinePixels();
       return { x: event.deltaX * linePixels, y: event.deltaY * linePixels };
+    }
     case 2: {
       const rect = canvas.getBoundingClientRect();
       return { x: event.deltaX * rect.width, y: event.deltaY * rect.height };
@@ -63,10 +65,14 @@ export function attachNativeInputs(
   };
   const keyDown = (event) => player.dispatchKey(event.code, true);
   const keyUp = (event) => player.dispatchKey(event.code, false);
-  const linePixels = wheelLinePixels(canvas);
+  let cachedLinePixels = null;
+  const resolveLinePixels = () => {
+    cachedLinePixels ??= wheelLinePixels(canvas);
+    return cachedLinePixels;
+  };
   const wheel = (event) => {
     if (preventWheelDefault) event.preventDefault();
-    const delta = wheelDeltaCssPixels(canvas, event, linePixels);
+    const delta = wheelDeltaCssPixels(canvas, event, resolveLinePixels);
     player.dispatchWheel(delta.x, delta.y);
   };
 

--- a/web/native-inputs.js
+++ b/web/native-inputs.js
@@ -7,6 +7,34 @@ function normalizedPointer(canvas, event) {
   };
 }
 
+function wheelLinePixels(canvas) {
+  const view = canvas.ownerDocument?.defaultView;
+  if (typeof view?.getComputedStyle !== "function") {
+    throw new TypeError("canvas must provide computed style for line-mode wheel input");
+  }
+  const style = view.getComputedStyle(canvas);
+  const lineHeight = Number.parseFloat(style.lineHeight);
+  if (Number.isFinite(lineHeight) && lineHeight > 0) return lineHeight;
+  const fontSize = Number.parseFloat(style.fontSize);
+  if (Number.isFinite(fontSize) && fontSize > 0) return fontSize;
+  throw new TypeError("canvas must have a positive CSS line-height or font-size");
+}
+
+function wheelDeltaCssPixels(canvas, event, linePixels) {
+  switch (event.deltaMode) {
+    case 0:
+      return { x: event.deltaX, y: event.deltaY };
+    case 1:
+      return { x: event.deltaX * linePixels, y: event.deltaY * linePixels };
+    case 2: {
+      const rect = canvas.getBoundingClientRect();
+      return { x: event.deltaX * rect.width, y: event.deltaY * rect.height };
+    }
+    default:
+      throw new RangeError(`unsupported WheelEvent.deltaMode ${event.deltaMode}`);
+  }
+}
+
 /**
  * Attach browser pointer/keyboard/wheel input to a ReactiveCanvasPlayer.
  *
@@ -35,9 +63,11 @@ export function attachNativeInputs(
   };
   const keyDown = (event) => player.dispatchKey(event.code, true);
   const keyUp = (event) => player.dispatchKey(event.code, false);
+  const linePixels = wheelLinePixels(canvas);
   const wheel = (event) => {
     if (preventWheelDefault) event.preventDefault();
-    player.dispatchWheel(event.deltaX, event.deltaY);
+    const delta = wheelDeltaCssPixels(canvas, event, linePixels);
+    player.dispatchWheel(delta.x, delta.y);
   };
 
   canvas.addEventListener("pointermove", pointerMove);

--- a/web/native-inputs.test.mjs
+++ b/web/native-inputs.test.mjs
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { attachNativeInputs } from "./native-inputs.js";
+
+class FakeTarget {
+  listeners = new Map();
+
+  addEventListener(type, listener) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type, listener) {
+    const listeners = this.listeners.get(type) ?? [];
+    this.listeners.set(
+      type,
+      listeners.filter((candidate) => candidate !== listener),
+    );
+  }
+
+  dispatch(type, event) {
+    for (const listener of this.listeners.get(type) ?? []) listener(event);
+  }
+}
+
+class FakeCanvas extends FakeTarget {
+  constructor({ lineHeight = "20px", fontSize = "16px" } = {}) {
+    super();
+    this.style = { lineHeight, fontSize };
+    this.ownerDocument = {
+      defaultView: {
+        getComputedStyle: () => this.style,
+      },
+    };
+  }
+
+  getBoundingClientRect() {
+    return { left: 0, top: 0, width: 640, height: 360 };
+  }
+}
+
+function wheelEvent(deltaX, deltaY, deltaMode) {
+  return {
+    deltaX,
+    deltaY,
+    deltaMode,
+    defaultPrevented: false,
+    preventDefault() {
+      this.defaultPrevented = true;
+    },
+  };
+}
+
+function recordingPlayer() {
+  const wheel = [];
+  return {
+    wheel,
+    dispatchPointerPosition() {},
+    dispatchPointerButton() {},
+    dispatchKey() {},
+    dispatchWheel(x, y) {
+      wheel.push([x, y]);
+    },
+  };
+}
+
+test("native wheel input normalizes browser delta modes to CSS pixels", () => {
+  const canvas = new FakeCanvas();
+  const keyboardTarget = new FakeTarget();
+  const player = recordingPlayer();
+  const detach = attachNativeInputs(player, canvas, {
+    keyboardTarget,
+    preventWheelDefault: true,
+  });
+
+  const pixels = wheelEvent(2, -3, 0);
+  canvas.dispatch("wheel", pixels);
+  assert.equal(pixels.defaultPrevented, true);
+
+  const lines = wheelEvent(2, -3, 1);
+  canvas.dispatch("wheel", lines);
+
+  const pages = wheelEvent(0.5, -0.25, 2);
+  canvas.dispatch("wheel", pages);
+
+  assert.deepEqual(player.wheel, [
+    [2, -3],
+    [40, -60],
+    [320, -90],
+  ]);
+
+  detach();
+  canvas.dispatch("wheel", wheelEvent(1, 1, 0));
+  assert.equal(player.wheel.length, 3, "detached collectors must stop forwarding wheel input");
+});
+
+test("line-mode wheel input falls back to computed font size for normal line-height", () => {
+  const canvas = new FakeCanvas({ lineHeight: "normal", fontSize: "18px" });
+  const player = recordingPlayer();
+  const detach = attachNativeInputs(player, canvas, {
+    keyboardTarget: new FakeTarget(),
+  });
+
+  canvas.dispatch("wheel", wheelEvent(1.5, -2, 1));
+  assert.deepEqual(player.wheel, [[27, -36]]);
+  detach();
+});
+
+test("unknown browser wheel delta modes fail instead of silently changing units", () => {
+  const canvas = new FakeCanvas();
+  const player = recordingPlayer();
+  const detach = attachNativeInputs(player, canvas, {
+    keyboardTarget: new FakeTarget(),
+  });
+
+  assert.throws(
+    () => canvas.dispatch("wheel", wheelEvent(1, 1, 9)),
+    /unsupported WheelEvent\.deltaMode 9/,
+  );
+  assert.deepEqual(player.wheel, []);
+  detach();
+});


### PR DESCRIPTION
## Summary
- honor `WheelEvent.deltaMode` at the existing browser-native input boundary
- keep the established `NativeStateSource::WheelDelta` contract in canvas CSS-pixel units
- pass pixel-mode deltas through unchanged
- convert line-mode deltas using the canvas computed line height, falling back to computed font size when CSS reports `normal`
- convert page-mode deltas using the current canvas CSS width/height
- reject unknown delta modes rather than silently assigning the wrong units

## Why
`noon-core` already specifies that wheel deltas use canvas CSS-pixel units, but `web/native-inputs.js` forwarded raw `deltaX`/`deltaY` and discarded `WheelEvent.deltaMode`. On devices/browsers that report line- or page-mode wheel input, identical numbers therefore represented different physical magnitudes while Noon interpreted them as pixels.

The fix stays at the DOM collection boundary, where CSS metrics exist. No reactive schema, WASM API, runtime router, renderer, or Python callback path changes are introduced.

## Tests
A focused auto-discovered `web/*.test.mjs` regression covers:
- pixel, line, and page delta modes
- CSS `line-height: normal` fallback to computed font size
- `preventDefault` behavior
- listener teardown
- fail-closed handling for an invalid delta mode

The existing full browser native-input smoke continues to exercise the production `attachNativeInputs -> ReactiveCanvasPlayer` route.

Tracks #69.