### PR TITLE
Expose shared RoundedRectangle through Python

### DIFF
--- a/web/python-worker.source.js
+++ b/web/python-worker.source.js
@@ -5,6 +5,7 @@ import initNoonWeb, {
   manimAnnularSectorSnapshotJson,
   manimAnnulusSnapshotJson,
   manimDotSnapshotJson,
+  manimRoundedRectangleSnapshotJson,
   manimSectorSnapshotJson,
   manimTriangleSnapshotJson,
   resolveAnimationOptions,
@@ -51,6 +52,8 @@ async function initializePyodide() {
     authoringStore.createMobject(manimDotSnapshotJson(pointX, pointY, radius));
   self.noonCreateAuthoringTriangleHandle = () =>
     authoringStore.createMobject(manimTriangleSnapshotJson());
+  self.noonCreateAuthoringRoundedRectangleHandle = (...args) =>
+    authoringStore.createMobject(manimRoundedRectangleSnapshotJson(...args));
   self.noonCreateAuthoringAnnularSectorHandle = (...args) =>
     authoringStore.createMobject(manimAnnularSectorSnapshotJson(...args));
   self.noonCreateAuthoringSectorHandle = (...args) =>

--- a/web/python/_manim_shared_geometry.py
+++ b/web/python/_manim_shared_geometry.py
@@ -26,6 +26,11 @@ except ImportError:  # Native CPython tests keep the existing Python constructor
     _create_triangle_handle = None
 
 try:
+    from js import noonCreateAuthoringRoundedRectangleHandle as _create_rounded_rectangle_handle
+except ImportError:
+    _create_rounded_rectangle_handle = None
+
+try:
     from js import noonCreateAuthoringAnnularSectorHandle as _create_annular_sector_handle
 except ImportError:
     _create_annular_sector_handle = None
@@ -208,6 +213,34 @@ def _triangle_init(self: _geometry.Triangle, **kwargs: Any) -> None:
     _shared._apply_shared_constructor_kwargs(self, options)
     if color is not None:
         _set_shared_color(self, color)
+
+
+class RoundedRectangle(_compat.Rectangle):
+    """Scalar-radius Manim RoundedRectangle backed by shared Rust geometry."""
+
+    def __init__(self, corner_radius: float = 0.5, **kwargs: Any) -> None:
+        if _create_rounded_rectangle_handle is None:
+            raise RuntimeError("RoundedRectangle requires the shared browser geometry bridge")
+        if isinstance(corner_radius, (list, tuple)):
+            raise NotImplementedError(
+                "per-corner RoundedRectangle radii are not exposed by the browser bridge yet"
+            )
+
+        options = dict(kwargs)
+        width = _shared._ir._positive_number("width", options.pop("width", 4.0))
+        height = _shared._ir._positive_number("height", options.pop("height", 2.0))
+        radius = _shared._ir._finite_number("corner_radius", corner_radius)
+        color = options.pop("color", None)
+        _shared._attach_shared_handle(
+            self,
+            _create_rounded_rectangle_handle(width, height, radius),
+        )
+        self.width_value = width
+        self.height_value = height
+        self.corner_radius = radius
+        _shared._apply_shared_constructor_kwargs(self, options)
+        if color is not None:
+            _set_shared_color(self, color)
 
 
 def _sector_component_count(value: object) -> int:
@@ -402,6 +435,7 @@ def install() -> None:
         _geometry.Triangle.__init__ = _triangle_init
 
     public = {
+        "RoundedRectangle": RoundedRectangle,
         "AnnularSector": AnnularSector,
         "Sector": Sector,
         "Annulus": Annulus,

--- a/web/python/test_manim_shared_rounded_rectangle.py
+++ b/web/python/test_manim_shared_rounded_rectangle.py
@@ -1,0 +1,151 @@
+import os
+import subprocess
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+
+
+class ManimSharedRoundedRectangleTests(unittest.TestCase):
+    def test_scalar_radius_constructor_stays_on_shared_rust_geometry(self) -> None:
+        python_dir = Path(__file__).resolve().parent
+        env = os.environ.copy()
+        existing = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = (
+            str(python_dir)
+            if not existing
+            else os.pathsep.join((str(python_dir), existing))
+        )
+        source = textwrap.dedent(
+            r"""
+            import json
+            import sys
+            import types
+
+            fake_js = types.ModuleType("js")
+            calls = []
+
+            class FakeHandle:
+                def __init__(self, snapshot):
+                    self.snapshot = snapshot
+                def snapshotJson(self):
+                    return json.dumps(self.snapshot)
+                def setStrokeWidth(self, value):
+                    self.snapshot["style"]["stroke_width"] = float(value)
+                def setFillOpacity(self, value):
+                    self.snapshot["style"]["fill"]["alpha"] = float(value)
+                def setFillColor(self, r, g, b, a):
+                    alpha = self.snapshot["style"]["fill"]["alpha"]
+                    self.snapshot["style"]["fill"] = {
+                        "red": float(r), "green": float(g), "blue": float(b), "alpha": alpha
+                    }
+                def setStrokeColor(self, r, g, b, a):
+                    alpha = self.snapshot["style"]["stroke"]["alpha"]
+                    self.snapshot["style"]["stroke"] = {
+                        "red": float(r), "green": float(g), "blue": float(b), "alpha": alpha
+                    }
+
+            def style():
+                return {
+                    "fill": {"red": 1.0, "green": 1.0, "blue": 1.0, "alpha": 0.0},
+                    "stroke": {"red": 1.0, "green": 1.0, "blue": 1.0, "alpha": 1.0},
+                    "stroke_width": 0.04,
+                    "stroke_width_mode": "screen_space",
+                    "stroke_join": "miter",
+                    "stroke_cap": "butt",
+                    "opacity": 1.0,
+                }
+
+            def rounded_rectangle(width, height, corner_radius):
+                calls.append((
+                    "rounded_rectangle",
+                    float(width),
+                    float(height),
+                    float(corner_radius),
+                ))
+                return FakeHandle({
+                    "geometry": {"vector_path": {"commands": [
+                        {"move_to": {"to": {"x": float(width) / 2.0, "y": 0.0}}},
+                        "close",
+                    ]}},
+                    "transform": {
+                        "translation": {"x": 0.0, "y": 0.0},
+                        "rotation": 0.0,
+                        "scale": {"x": 1.0, "y": 1.0},
+                    },
+                    "style": style(),
+                })
+
+            fake_js.noonCreateAuthoringRoundedRectangleHandle = rounded_rectangle
+            sys.modules["js"] = fake_js
+
+            import _manim_compat
+            _manim_compat.install()
+            import _manim_phase_b
+            import _manim_geometry
+            import _manim_semantic_handles as handles
+            handles.install()
+
+            # Any Python-side path construction would violate the shared-geometry boundary.
+            _manim_compat._ir.Path = lambda *args, **kwargs: (_ for _ in ()).throw(
+                AssertionError("Python Path geometry constructor was called")
+            )
+
+            import _manim_shared_geometry
+            _manim_shared_geometry.install()
+            from noon import BLUE, Rectangle, RoundedRectangle
+
+            rect = RoundedRectangle(
+                corner_radius=0.25,
+                width=6.0,
+                height=3.0,
+                color=BLUE,
+                stroke_width=2.0,
+            )
+
+            assert isinstance(rect, Rectangle)
+            assert calls == [("rounded_rectangle", 6.0, 3.0, 0.25)]
+            assert rect.width_value == 6.0
+            assert rect.height_value == 3.0
+            assert rect.corner_radius == 0.25
+            assert "vector_path" in rect.geometry
+            assert rect.style["stroke_width"] == 2.0
+            assert rect.style["stroke"]["red"] == BLUE.red
+            assert rect.style["stroke"]["green"] == BLUE.green
+            assert rect.style["stroke"]["blue"] == BLUE.blue
+
+            before = list(calls)
+            try:
+                RoundedRectangle(corner_radius=[0.1, 0.2, 0.3, 0.4])
+            except NotImplementedError as error:
+                assert "per-corner" in str(error)
+            else:
+                raise AssertionError("per-corner radii must remain explicitly unsupported")
+            assert calls == before
+
+            try:
+                RoundedRectangle(width=0.0)
+            except ValueError as error:
+                assert "width" in str(error)
+            else:
+                raise AssertionError("non-positive width must be rejected before bridge dispatch")
+            assert calls == before
+            """
+        )
+        completed = subprocess.run(
+            [sys.executable, "-c", source],
+            cwd=python_dir,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(
+            completed.returncode,
+            0,
+            f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/python/test_manim_shared_rounded_rectangle.py
+++ b/web/python/test_manim_shared_rounded_rectangle.py
@@ -83,6 +83,9 @@ class ManimSharedRoundedRectangleTests(unittest.TestCase):
                     "opacity": 1.0,
                 }
 
+            def generic_handle(snapshot_json):
+                return FakeHandle(json.loads(snapshot_json))
+
             def rounded_rectangle(width, height, corner_radius):
                 calls.append((
                     "rounded_rectangle",
@@ -103,6 +106,7 @@ class ManimSharedRoundedRectangleTests(unittest.TestCase):
                     "style": style(),
                 })
 
+            fake_js.noonCreateAuthoringMobjectHandle = generic_handle
             fake_js.noonCreateAuthoringRoundedRectangleHandle = rounded_rectangle
             sys.modules["js"] = fake_js
 

--- a/web/python/test_manim_shared_rounded_rectangle.py
+++ b/web/python/test_manim_shared_rounded_rectangle.py
@@ -140,7 +140,9 @@ class ManimSharedRoundedRectangleTests(unittest.TestCase):
             assert rect.height_value == 3.0
             assert rect.corner_radius == 0.25
             assert "vector_path" in rect.geometry
-            assert rect.style["stroke_width"] == 2.0
+            # Shared VMobject styling keeps the established Manim Cairo conversion:
+            # authored width 2.0 is 0.02 scene units in the retained snapshot.
+            assert rect.style["stroke_width"] == 0.02
             assert rect.style["stroke"]["red"] == BLUE.red
             assert rect.style["stroke"]["green"] == BLUE.green
             assert rect.style["stroke"]["blue"] == BLUE.blue

--- a/web/python/test_manim_shared_rounded_rectangle.py
+++ b/web/python/test_manim_shared_rounded_rectangle.py
@@ -28,22 +28,49 @@ class ManimSharedRoundedRectangleTests(unittest.TestCase):
             class FakeHandle:
                 def __init__(self, snapshot):
                     self.snapshot = snapshot
+                    # Mirror the real FrontendMobjectHandle wire projection so
+                    # semantic style mutation stays on the same no-JSON fast path.
+                    self.wireTranslationX = 0.0
+                    self.wireTranslationY = 0.0
+                    self.wireScaleX = 1.0
+                    self.wireScaleY = 1.0
+                    self.wireRotation = 0.0
+                    self.wireHasFill = True
+                    self.wireFillRed = 1.0
+                    self.wireFillGreen = 1.0
+                    self.wireFillBlue = 1.0
+                    self.wireFillAlpha = 0.0
+                    self.wireHasStroke = True
+                    self.wireStrokeRed = 1.0
+                    self.wireStrokeGreen = 1.0
+                    self.wireStrokeBlue = 1.0
+                    self.wireStrokeAlpha = 1.0
+                    self.wireStrokeWidth = 0.04
+                    self.wireObjectOpacity = 1.0
                 def snapshotJson(self):
                     return json.dumps(self.snapshot)
                 def setStrokeWidth(self, value):
                     self.snapshot["style"]["stroke_width"] = float(value)
+                    self.wireStrokeWidth = float(value)
                 def setFillOpacity(self, value):
                     self.snapshot["style"]["fill"]["alpha"] = float(value)
+                    self.wireFillAlpha = float(value)
                 def setFillColor(self, r, g, b, a):
                     alpha = self.snapshot["style"]["fill"]["alpha"]
                     self.snapshot["style"]["fill"] = {
                         "red": float(r), "green": float(g), "blue": float(b), "alpha": alpha
                     }
+                    self.wireFillRed = float(r)
+                    self.wireFillGreen = float(g)
+                    self.wireFillBlue = float(b)
                 def setStrokeColor(self, r, g, b, a):
                     alpha = self.snapshot["style"]["stroke"]["alpha"]
                     self.snapshot["style"]["stroke"] = {
                         "red": float(r), "green": float(g), "blue": float(b), "alpha": alpha
                     }
+                    self.wireStrokeRed = float(r)
+                    self.wireStrokeGreen = float(g)
+                    self.wireStrokeBlue = float(b)
 
             def style():
                 return {


### PR DESCRIPTION
## Summary
- expose Manim `RoundedRectangle` through the existing shared Rust/WASM geometry constructor
- keep the Python facade thin: validate scalar authoring values, attach the ordinary semantic handle, and delegate style/mutation behavior to the existing shared handle path
- preserve `Rectangle` inheritance and Manim defaults (`width=4`, `height=2`, `corner_radius=0.5`)
- explicitly reject per-corner radius sequences rather than approximating them, because the Rust core supports them but the current browser bridge only carries one scalar radius
- add a focused Python regression proving the constructor calls the shared bridge and never reconstructs a Python `Path`

## Architecture
No renderer primitive, Python geometry math, persistent duplicate snapshot, or new mutation path is introduced. The WASM bridge already produces the canonical retained `VectorPath`; Python only selects constructor arguments and attaches the same `FrontendMobjectHandle` used by other migrated geometry.

## Scope / remaining risk
This intentionally does not expose `SurroundingRectangle` / `BackgroundRectangle` yet. Their Rust semantics are variadic, while the current WASM bridge accepts one target snapshot; exposing them now would silently narrow Manim behavior. A follow-up should carry a target collection through the bridge first. Per-corner `RoundedRectangle(corner_radius=[...])` likewise remains explicit `NotImplementedError` until that existing Rust `[f32; 4]` contract is bridged.

Tracks #400 and #76.