### PR TITLE
Expose shared Manim Underline through Python

### DIFF
--- a/web/python-worker.source.js
+++ b/web/python-worker.source.js
@@ -8,6 +8,7 @@ import initNoonWeb, {
   manimRoundedRectangleSnapshotJson,
   manimSectorSnapshotJson,
   manimTriangleSnapshotJson,
+  manimUnderlineSnapshotJson,
   resolveAnimationOptions,
   resolveCompositionSchedule,
   resolveLifecyclePlan,
@@ -60,6 +61,8 @@ async function initializePyodide() {
     authoringStore.createMobject(manimSectorSnapshotJson(...args));
   self.noonCreateAuthoringAnnulusHandle = (...args) =>
     authoringStore.createMobject(manimAnnulusSnapshotJson(...args));
+  self.noonCreateAuthoringUnderlineHandle = (targetHandle, buff) =>
+    authoringStore.createMobject(manimUnderlineSnapshotJson(targetHandle.snapshotJson(), buff));
   self.noonCreateAuthoringCircleHandle = (radius) => authoringStore.createManimCircle(radius);
   self.noonCreateAuthoringSquareHandle = (sideLength) => authoringStore.createManimSquare(sideLength);
   self.noonCreateAuthoringRectangleHandle = (width, height) =>

--- a/web/python/_manim_shared_geometry.py
+++ b/web/python/_manim_shared_geometry.py
@@ -31,6 +31,11 @@ except ImportError:
     _create_rounded_rectangle_handle = None
 
 try:
+    from js import noonCreateAuthoringUnderlineHandle as _create_underline_handle
+except ImportError:
+    _create_underline_handle = None
+
+try:
     from js import noonCreateAuthoringAnnularSectorHandle as _create_annular_sector_handle
 except ImportError:
     _create_annular_sector_handle = None
@@ -243,6 +248,38 @@ class RoundedRectangle(_compat.Rectangle):
             _set_shared_color(self, color)
 
 
+class Underline(_compat.Line):
+    """Manim Underline backed by the shared Rust line-matcher semantics."""
+
+    def __init__(
+        self,
+        mobject: _base.Mobject,
+        buff: float = _base.SMALL_BUFF,
+        **kwargs: Any,
+    ) -> None:
+        if _create_underline_handle is None:
+            raise RuntimeError("Underline requires the shared browser shape-matcher bridge")
+        if not isinstance(mobject, _base.Mobject):
+            raise TypeError("Underline target must be a Mobject")
+        target_handle = _shared._handle_for(mobject)
+        if target_handle is None or not hasattr(target_handle, "snapshotJson"):
+            raise NotImplementedError(
+                "Underline currently requires a target with shared semantic geometry"
+            )
+
+        buff_value = _shared._ir._finite_number("buff", buff)
+        options = dict(kwargs)
+        color = options.pop("color", None)
+        _shared._attach_shared_handle(
+            self,
+            _create_underline_handle(target_handle, buff_value),
+        )
+        self.buff = buff_value
+        _shared._apply_shared_constructor_kwargs(self, options)
+        if color is not None:
+            _set_shared_color(self, color)
+
+
 def _sector_component_count(value: object) -> int:
     if isinstance(value, bool):
         raise TypeError("num_components must be an integer")
@@ -436,6 +473,7 @@ def install() -> None:
 
     public = {
         "RoundedRectangle": RoundedRectangle,
+        "Underline": Underline,
         "AnnularSector": AnnularSector,
         "Sector": Sector,
         "Annulus": Annulus,

--- a/web/python/test_manim_shared_underline.py
+++ b/web/python/test_manim_shared_underline.py
@@ -1,0 +1,210 @@
+import os
+import subprocess
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+
+
+class ManimSharedUnderlineTests(unittest.TestCase):
+    def test_constructor_uses_target_semantic_handle_and_shared_matcher(self) -> None:
+        python_dir = Path(__file__).resolve().parent
+        env = os.environ.copy()
+        existing = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = (
+            str(python_dir)
+            if not existing
+            else os.pathsep.join((str(python_dir), existing))
+        )
+        source = textwrap.dedent(
+            r"""
+            import json
+            import sys
+            import types
+
+            fake_js = types.ModuleType("js")
+            calls = []
+
+            def style():
+                return {
+                    "fill": {"red": 1.0, "green": 1.0, "blue": 1.0, "alpha": 0.0},
+                    "stroke": {"red": 1.0, "green": 1.0, "blue": 1.0, "alpha": 1.0},
+                    "stroke_width": 0.04,
+                    "stroke_width_mode": "screen_space",
+                    "stroke_join": "miter",
+                    "stroke_cap": "butt",
+                    "opacity": 1.0,
+                }
+
+            class FakeHandle:
+                def __init__(self, snapshot):
+                    self.snapshot = snapshot
+                    self.wireTranslationX = 0.0
+                    self.wireTranslationY = 0.0
+                    self.wireScaleX = 1.0
+                    self.wireScaleY = 1.0
+                    self.wireRotation = 0.0
+                    self.wireHasFill = True
+                    self.wireFillRed = 1.0
+                    self.wireFillGreen = 1.0
+                    self.wireFillBlue = 1.0
+                    self.wireFillAlpha = 0.0
+                    self.wireHasStroke = True
+                    self.wireStrokeRed = 1.0
+                    self.wireStrokeGreen = 1.0
+                    self.wireStrokeBlue = 1.0
+                    self.wireStrokeAlpha = 1.0
+                    self.wireStrokeWidth = float(snapshot["style"]["stroke_width"])
+                    self.wireObjectOpacity = 1.0
+
+                def snapshotJson(self):
+                    return json.dumps(self.snapshot)
+
+                def setStrokeWidth(self, value):
+                    self.snapshot["style"]["stroke_width"] = float(value)
+                    self.wireStrokeWidth = float(value)
+
+                def setFillColor(self, red, green, blue, alpha):
+                    current_alpha = self.snapshot["style"]["fill"]["alpha"]
+                    self.snapshot["style"]["fill"] = {
+                        "red": float(red),
+                        "green": float(green),
+                        "blue": float(blue),
+                        "alpha": current_alpha,
+                    }
+                    self.wireFillRed = float(red)
+                    self.wireFillGreen = float(green)
+                    self.wireFillBlue = float(blue)
+
+                def setStrokeColor(self, red, green, blue, alpha):
+                    current_alpha = self.snapshot["style"]["stroke"]["alpha"]
+                    self.snapshot["style"]["stroke"] = {
+                        "red": float(red),
+                        "green": float(green),
+                        "blue": float(blue),
+                        "alpha": current_alpha,
+                    }
+                    self.wireStrokeRed = float(red)
+                    self.wireStrokeGreen = float(green)
+                    self.wireStrokeBlue = float(blue)
+
+            def rectangle_handle(width, height):
+                return FakeHandle({
+                    "geometry": {"rectangle": {"size": {"x": float(width), "y": float(height)}}},
+                    "transform": {
+                        "translation": {"x": 0.0, "y": 0.0},
+                        "rotation": 0.0,
+                        "scale": {"x": 1.0, "y": 1.0},
+                    },
+                    "style": style(),
+                })
+
+            def generic_handle(snapshot_json):
+                return FakeHandle(json.loads(snapshot_json))
+
+            def underline_handle(target_handle, buff):
+                calls.append((target_handle, float(buff)))
+                target = target_handle.snapshot
+                size = target["geometry"]["rectangle"]["size"]
+                center = target["transform"]["translation"]
+                half_width = float(size["x"]) / 2.0
+                half_height = float(size["y"]) / 2.0
+                y = float(center["y"]) - half_height - float(buff)
+                return FakeHandle({
+                    "geometry": {"line": {
+                        "start": {"x": float(center["x"]) - half_width, "y": y},
+                        "end": {"x": float(center["x"]) + half_width, "y": y},
+                    }},
+                    "transform": {
+                        "translation": {"x": 0.0, "y": 0.0},
+                        "rotation": 0.0,
+                        "scale": {"x": 1.0, "y": 1.0},
+                    },
+                    "style": style(),
+                })
+
+            fake_js.noonCreateAuthoringMobjectHandle = generic_handle
+            fake_js.noonCreateAuthoringRectangleHandle = rectangle_handle
+            fake_js.noonCreateAuthoringUnderlineHandle = underline_handle
+            sys.modules["js"] = fake_js
+
+            import _manim_compat
+            _manim_compat.install()
+            import _manim_phase_b
+            import _manim_geometry
+            import _manim_semantic_handles as handles
+            handles.install()
+
+            # Underline geometry and placement must stay below the Python facade.
+            _manim_compat._ir.Line = lambda *args, **kwargs: (_ for _ in ()).throw(
+                AssertionError("Python Line geometry constructor was called")
+            )
+            import noon as _base
+            _base._bounds = lambda *args, **kwargs: (_ for _ in ()).throw(
+                AssertionError("Python bounds computation was called")
+            )
+
+            import _manim_shared_geometry
+            _manim_shared_geometry.install()
+            from noon import BLUE, Line, Rectangle, Underline
+
+            target = Rectangle(width=4.0, height=2.0)
+            target_handle = target._semantic_handle
+            underline = Underline(
+                target,
+                buff=0.25,
+                color=BLUE,
+                stroke_width=2.0,
+            )
+
+            assert isinstance(underline, Line)
+            assert len(calls) == 1
+            assert calls[0][0] is target_handle
+            assert calls[0][1] == 0.25
+            assert underline.buff == 0.25
+            assert underline.geometry["line"] == {
+                "start": {"x": -2.0, "y": -1.25},
+                "end": {"x": 2.0, "y": -1.25},
+            }
+            assert underline.style["stroke_width"] == 0.02
+            assert underline.style["stroke"]["red"] == BLUE.red
+            assert underline.style["stroke"]["green"] == BLUE.green
+            assert underline.style["stroke"]["blue"] == BLUE.blue
+
+            before = len(calls)
+            target._semantic_handle_fresh = False
+            try:
+                Underline(target)
+            except NotImplementedError as error:
+                assert "shared semantic geometry" in str(error)
+            else:
+                raise AssertionError("stale/non-shared targets must not use Python bounds fallback")
+            assert len(calls) == before
+
+            target._semantic_handle_fresh = True
+            try:
+                Underline(target, buff=float("nan"))
+            except ValueError as error:
+                assert "buff" in str(error)
+            else:
+                raise AssertionError("non-finite buff must be rejected before bridge dispatch")
+            assert len(calls) == before
+            """
+        )
+        completed = subprocess.run(
+            [sys.executable, "-c", source],
+            cwd=python_dir,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(
+            completed.returncode,
+            0,
+            f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- expose ManimCE v0.21 `Underline` through the Python compatibility facade
- keep target bounds/placement in the existing shared Rust `Underline` matcher instead of reconstructing line geometry in Python
- pass the authoritative semantic target handle directly across the Python/JS boundary, serializing only at the existing Rust matcher bridge
- preserve `Line` inheritance, `buff`, ordinary shared constructor styling, and explicit finite-input validation
- reject targets whose current geometry is not owned by a usable shared semantic handle rather than silently falling back to Python bounds math

## Architecture
This is deliberately a thin adapter over the already-implemented `noon::Underline` and `manimUnderlineSnapshotJson` semantics. It adds no renderer primitive, second geometry representation, Python layout calculation, or runtime callback.

The worker helper accepts the target semantic handle rather than target snapshot JSON from Python. That keeps Python out of serialization/layout ownership and lets the existing WASM/Rust boundary remain authoritative.

## Focused regression
`test_manim_shared_underline.py` installs a deterministic fake authoring handle/bridge and makes both Python `Line` construction and Python bounds calculation throw. The test verifies:
- `Underline` receives the exact target semantic handle;
- default/shared matcher geometry is used;
- `buff`, shared color, and stroke-width authoring options are preserved;
- stale/non-shared targets fail explicitly;
- non-finite `buff` fails before bridge dispatch.

## Cross boundary
I audited adjacent `Cross` at the same time but intentionally did not expose it. ManimCE v0.21 `Cross` is a `VGroup` with two observable `Line` children; Noon's current shared Rust `Cross` is one multi-subpath `VectorPath`. Publishing that as a Python `Cross` would either fake `VGroup` family identity or silently change indexing/family semantics. That should be resolved at the shared semantic-family layer before a public adapter is added.

Tracks #400 and #76.