### PR TITLE
Expose shared Manim Elbow through Python

### DIFF
--- a/web/python-worker.source.js
+++ b/web/python-worker.source.js
@@ -5,6 +5,7 @@ import initNoonWeb, {
   manimAnnularSectorSnapshotJson,
   manimAnnulusSnapshotJson,
   manimDotSnapshotJson,
+  manimElbowSnapshotJson,
   manimRoundedRectangleSnapshotJson,
   manimSectorSnapshotJson,
   manimTriangleSnapshotJson,
@@ -53,6 +54,8 @@ async function initializePyodide() {
     authoringStore.createMobject(manimDotSnapshotJson(pointX, pointY, radius));
   self.noonCreateAuthoringTriangleHandle = () =>
     authoringStore.createMobject(manimTriangleSnapshotJson());
+  self.noonCreateAuthoringElbowHandle = (...args) =>
+    authoringStore.createMobject(manimElbowSnapshotJson(...args));
   self.noonCreateAuthoringRoundedRectangleHandle = (...args) =>
     authoringStore.createMobject(manimRoundedRectangleSnapshotJson(...args));
   self.noonCreateAuthoringAnnularSectorHandle = (...args) =>

--- a/web/python/_manim_shared_geometry.py
+++ b/web/python/_manim_shared_geometry.py
@@ -26,6 +26,11 @@ except ImportError:  # Native CPython tests keep the existing Python constructor
     _create_triangle_handle = None
 
 try:
+    from js import noonCreateAuthoringElbowHandle as _create_elbow_handle
+except ImportError:
+    _create_elbow_handle = None
+
+try:
     from js import noonCreateAuthoringRoundedRectangleHandle as _create_rounded_rectangle_handle
 except ImportError:
     _create_rounded_rectangle_handle = None
@@ -218,6 +223,26 @@ def _triangle_init(self: _geometry.Triangle, **kwargs: Any) -> None:
     _shared._apply_shared_constructor_kwargs(self, options)
     if color is not None:
         _set_shared_color(self, color)
+
+
+class Elbow(_compat.VMobject):
+    """Manim-compatible Elbow backed by shared Rust geometry."""
+
+    def __init__(self, width: float = 0.2, angle: float = 0.0, **kwargs: Any) -> None:
+        if _create_elbow_handle is None:
+            raise RuntimeError("Elbow requires the shared browser geometry bridge")
+
+        width_value = _shared._ir._finite_number("width", width)
+        angle_value = _shared._ir._finite_number("angle", angle)
+        options = dict(kwargs)
+        color = options.pop("color", None)
+        _shared._attach_shared_handle(
+            self,
+            _create_elbow_handle(width_value, angle_value),
+        )
+        _shared._apply_shared_constructor_kwargs(self, options)
+        if color is not None:
+            _set_shared_color(self, color)
 
 
 class RoundedRectangle(_compat.Rectangle):
@@ -472,6 +497,7 @@ def install() -> None:
         _geometry.Triangle.__init__ = _triangle_init
 
     public = {
+        "Elbow": Elbow,
         "RoundedRectangle": RoundedRectangle,
         "Underline": Underline,
         "AnnularSector": AnnularSector,

--- a/web/python/test_manim_shared_elbow.py
+++ b/web/python/test_manim_shared_elbow.py
@@ -1,0 +1,167 @@
+import os
+import subprocess
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+
+
+class ManimSharedElbowTests(unittest.TestCase):
+    def test_constructor_stays_on_shared_rust_geometry(self) -> None:
+        python_dir = Path(__file__).resolve().parent
+        env = os.environ.copy()
+        existing = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = (
+            str(python_dir)
+            if not existing
+            else os.pathsep.join((str(python_dir), existing))
+        )
+        source = textwrap.dedent(
+            r"""
+            import json
+            import math
+            import sys
+            import types
+
+            fake_js = types.ModuleType("js")
+            calls = []
+
+            class FakeHandle:
+                def __init__(self, snapshot):
+                    self.snapshot = snapshot
+                    self.wireTranslationX = 0.0
+                    self.wireTranslationY = 0.0
+                    self.wireScaleX = 1.0
+                    self.wireScaleY = 1.0
+                    self.wireRotation = 0.0
+                    self.wireHasFill = True
+                    self.wireFillRed = 1.0
+                    self.wireFillGreen = 1.0
+                    self.wireFillBlue = 1.0
+                    self.wireFillAlpha = 0.0
+                    self.wireHasStroke = True
+                    self.wireStrokeRed = 1.0
+                    self.wireStrokeGreen = 1.0
+                    self.wireStrokeBlue = 1.0
+                    self.wireStrokeAlpha = 1.0
+                    self.wireStrokeWidth = 0.04
+                    self.wireObjectOpacity = 1.0
+
+                def snapshotJson(self):
+                    return json.dumps(self.snapshot)
+
+                def setStrokeWidth(self, value):
+                    self.snapshot["style"]["stroke_width"] = float(value)
+                    self.wireStrokeWidth = float(value)
+
+                def setFillColor(self, r, g, b, a):
+                    alpha = self.snapshot["style"]["fill"]["alpha"]
+                    self.snapshot["style"]["fill"] = {
+                        "red": float(r), "green": float(g), "blue": float(b), "alpha": alpha
+                    }
+                    self.wireFillRed = float(r)
+                    self.wireFillGreen = float(g)
+                    self.wireFillBlue = float(b)
+
+                def setStrokeColor(self, r, g, b, a):
+                    alpha = self.snapshot["style"]["stroke"]["alpha"]
+                    self.snapshot["style"]["stroke"] = {
+                        "red": float(r), "green": float(g), "blue": float(b), "alpha": alpha
+                    }
+                    self.wireStrokeRed = float(r)
+                    self.wireStrokeGreen = float(g)
+                    self.wireStrokeBlue = float(b)
+
+            def style():
+                return {
+                    "fill": {"red": 1.0, "green": 1.0, "blue": 1.0, "alpha": 0.0},
+                    "stroke": {"red": 1.0, "green": 1.0, "blue": 1.0, "alpha": 1.0},
+                    "stroke_width": 0.04,
+                    "stroke_width_mode": "screen_space",
+                    "stroke_join": "miter",
+                    "stroke_cap": "butt",
+                    "opacity": 1.0,
+                }
+
+            def generic_handle(snapshot_json):
+                return FakeHandle(json.loads(snapshot_json))
+
+            def elbow(width, angle):
+                calls.append(("elbow", float(width), float(angle)))
+                return FakeHandle({
+                    "geometry": {"vector_path": {"commands": [
+                        {"move_to": {"to": {"x": 0.0, "y": float(width)}}},
+                        {"line_to": {"to": {"x": float(width), "y": float(width)}}},
+                        {"line_to": {"to": {"x": float(width), "y": 0.0}}},
+                    ]}},
+                    "transform": {
+                        "translation": {"x": 0.0, "y": 0.0},
+                        "rotation": 0.0,
+                        "scale": {"x": 1.0, "y": 1.0},
+                    },
+                    "style": style(),
+                })
+
+            fake_js.noonCreateAuthoringMobjectHandle = generic_handle
+            fake_js.noonCreateAuthoringElbowHandle = elbow
+            sys.modules["js"] = fake_js
+
+            import _manim_compat
+            _manim_compat.install()
+            import _manim_phase_b
+            import _manim_geometry
+            import _manim_semantic_handles as handles
+            handles.install()
+
+            _manim_compat._ir.Path = lambda *args, **kwargs: (_ for _ in ()).throw(
+                AssertionError("Python Path geometry constructor was called")
+            )
+
+            import _manim_shared_geometry
+            _manim_shared_geometry.install()
+            from noon import BLUE, Elbow, VMobject
+
+            shape = Elbow(width=-0.5, angle=math.pi / 3.0, color=BLUE, stroke_width=2.0)
+            assert isinstance(shape, VMobject)
+            assert calls == [("elbow", -0.5, math.pi / 3.0)]
+            assert "vector_path" in shape.geometry
+            assert shape.style["stroke_width"] == 0.02
+            assert shape.style["stroke"]["red"] == BLUE.red
+            assert shape.style["stroke"]["green"] == BLUE.green
+            assert shape.style["stroke"]["blue"] == BLUE.blue
+
+            before = list(calls)
+            try:
+                Elbow(width=float("nan"))
+            except ValueError as error:
+                assert "width" in str(error)
+            else:
+                raise AssertionError("non-finite width must be rejected before bridge dispatch")
+            assert calls == before
+
+            try:
+                Elbow(angle=float("inf"))
+            except ValueError as error:
+                assert "angle" in str(error)
+            else:
+                raise AssertionError("non-finite angle must be rejected before bridge dispatch")
+            assert calls == before
+            """
+        )
+        completed = subprocess.run(
+            [sys.executable, "-c", source],
+            cwd=python_dir,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(
+            completed.returncode,
+            0,
+            f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes the remaining thin-adapter gap for the already-qualified shared `Elbow` geometry under #77.

## What changed
- expose the existing `manimElbowSnapshotJson` WASM constructor through the Python authoring store;
- add a thin `Elbow(VMobject)` Python facade with Manim defaults (`width=0.2`, `angle=0`) and finite-input validation;
- keep zero/negative widths supported by routing directly to the existing Rust constructor rather than imposing frontend positivity semantics;
- reuse the ordinary shared semantic handle/style path; no Python path construction or renderer special case;
- add a focused regression that makes Python `Path` construction fail, proving the adapter stays on shared Rust geometry, and checks style dispatch plus invalid-input preflight.

## Architecture
Rust remains the single geometry authority. The Python layer only coerces host values, obtains the existing shared handle, and applies the established shared constructor/style mutations.

## Validation
The branch is based directly on current master `1485e9f6808b61db32fabb8599cbdb1bb7ce8185`. The focused test is included automatically by the existing Python unittest discovery in the web-package CI. Fresh GitHub Actions validation is expected on this PR.

## Remaining risk
This does not address `TangentLine`/path-proportion precision, `DashedLine`, or `Cross` family identity; those remain separate architectural/parity lanes.