### PR TITLE
Gate retained ShrinkToCenter visual playback

### DIFF
--- a/.github/workflows/manim-raster-differential.yml
+++ b/.github/workflows/manim-raster-differential.yml
@@ -52,6 +52,22 @@ jobs:
       - name: Install pinned ManimCE reference
         run: python -m pip install --disable-pip-version-check "manim[typst]==0.21.0" "typst==0.15.0"
 
+      - name: Report Manim default text oracle
+        run: |
+          fc-match sans-serif
+          python - <<'PY'
+          from manim import Text
+
+          text = Text("Hello World!")
+          center = text.get_center()
+          print(
+              "Manim Text('Hello World!'): "
+              f"font={text.font!r} font_size={text.font_size} "
+              f"width={text.width:.9f} height={text.height:.9f} "
+              f"center=({center[0]:.9f},{center[1]:.9f})"
+          )
+          PY
+
       - name: Use stable Rust
         run: |
           rustup default stable

--- a/.github/workflows/manim-raster-differential.yml
+++ b/.github/workflows/manim-raster-differential.yml
@@ -135,6 +135,12 @@ jobs:
           NOON_MANIM_RASTER_ARTIFACTS: manim-raster-artifacts
         run: node scripts/manim-seek-playback-raster.mjs
 
+      - name: Verify retained direct seek and incremental playback at Manim frame times
+        env:
+          NOON_MANIM_RASTER_BACKENDS: webgpu,webgl
+          NOON_MANIM_RASTER_ARTIFACTS: manim-raster-artifacts
+        run: node scripts/manim-retained-seek-playback-raster.mjs
+
       - name: Upload Manim/Noon/diff artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/retained-text-animation.yml
+++ b/.github/workflows/retained-text-animation.yml
@@ -16,6 +16,7 @@ on:
       - "scripts/build-python-worker.mjs"
       - "scripts/retained-text-animation-smoke.mjs"
       - "scripts/retained-text-playback-smoke.mjs"
+      - "scripts/retained-text-scene-lifecycle-smoke.mjs"
       - ".github/workflows/retained-text-animation.yml"
   push:
     branches:
@@ -34,6 +35,7 @@ on:
       - "scripts/build-python-worker.mjs"
       - "scripts/retained-text-animation-smoke.mjs"
       - "scripts/retained-text-playback-smoke.mjs"
+      - "scripts/retained-text-scene-lifecycle-smoke.mjs"
       - ".github/workflows/retained-text-animation.yml"
   workflow_dispatch:
 
@@ -103,3 +105,6 @@ jobs:
 
       - name: Test retained Text animation playback
         run: node scripts/retained-text-playback-smoke.mjs
+
+      - name: Test retained Text Scene lifecycle
+        run: node scripts/retained-text-scene-lifecycle-smoke.mjs

--- a/.github/workflows/retained-text-animation.yml
+++ b/.github/workflows/retained-text-animation.yml
@@ -15,6 +15,7 @@ on:
       - "web/python/_manim_typst.py"
       - "scripts/build-python-worker.mjs"
       - "scripts/retained-text-animation-smoke.mjs"
+      - "scripts/retained-text-playback-smoke.mjs"
       - ".github/workflows/retained-text-animation.yml"
   push:
     branches:
@@ -32,6 +33,7 @@ on:
       - "web/python/_manim_typst.py"
       - "scripts/build-python-worker.mjs"
       - "scripts/retained-text-animation-smoke.mjs"
+      - "scripts/retained-text-playback-smoke.mjs"
       - ".github/workflows/retained-text-animation.yml"
   workflow_dispatch:
 
@@ -98,3 +100,6 @@ jobs:
 
       - name: Test retained Text animation authoring
         run: node scripts/retained-text-animation-smoke.mjs
+
+      - name: Test retained Text animation playback
+        run: node scripts/retained-text-playback-smoke.mjs

--- a/crates/noon-text-native/src/lib.rs
+++ b/crates/noon-text-native/src/lib.rs
@@ -224,10 +224,10 @@ impl NativeTextCompiler {
                         },
                         origin,
                         advance,
-                        // Exact outlines remain lazy. The line-box bound is conservative
-                        // and sufficient for semantic layout until exact ink metrics land.
+                        // Swash reports descent as a positive distance below the baseline;
+                        // retained Y coordinates use negative values below the baseline.
                         bounds: Rect::new(
-                            Vec2::new(origin.x.min(right), metrics.descent),
+                            Vec2::new(origin.x.min(right), -metrics.descent),
                             Vec2::new(origin.x.max(right), metrics.ascent),
                         ),
                     });
@@ -241,7 +241,7 @@ impl NativeTextCompiler {
                 Rect::new(Vec2::ZERO, Vec2::ZERO)
             } else {
                 Rect::new(
-                    Vec2::new(0.0_f32.min(cursor_x), metrics.descent + baseline_y),
+                    Vec2::new(0.0_f32.min(cursor_x), -metrics.descent + baseline_y),
                     Vec2::new(0.0_f32.max(cursor_x), metrics.ascent + baseline_y),
                 )
             };

--- a/crates/noon-text-native/tests/metrics.rs
+++ b/crates/noon-text-native/tests/metrics.rs
@@ -1,0 +1,29 @@
+use std::sync::Arc;
+
+use noon_text_native::{NativeFontFace, NativeTextCompiler, NativeTextOptions};
+
+fn bundled_font() -> NativeFontFace {
+    let bytes = typst_assets::fonts()
+        .next()
+        .expect("Typst test assets include at least one font");
+    NativeFontFace::new("Bundled Test Font", Arc::<[u8]>::from(bytes), 0).unwrap()
+}
+
+#[test]
+fn conservative_native_glyph_bounds_extend_below_the_baseline() {
+    let font = bundled_font();
+    let mut compiler = NativeTextCompiler::new();
+    let artifact = compiler
+        .compile_plain("Hg", &font, &NativeTextOptions::new(48.0))
+        .unwrap();
+    let run = artifact.resource.runs.first().expect("one shaped line");
+
+    assert!(!run.glyphs.is_empty());
+    for glyph in run.glyphs.iter() {
+        assert!(
+            glyph.bounds.min.y < 0.0,
+            "descent is a positive metric distance but must map below the baseline"
+        );
+        assert!(glyph.bounds.max.y > 0.0);
+    }
+}

--- a/crates/noon-web/src/manim_shape_matcher_bridge.rs
+++ b/crates/noon-web/src/manim_shape_matcher_bridge.rs
@@ -236,12 +236,8 @@ mod tests {
     use super::*;
 
     fn rectangle_json(width: f32, height: f32, center: Vec2) -> String {
-        serde_json::to_string(
-            &Rectangle::new(width, height)
-                .shift(center)
-                .into_snapshot(),
-        )
-        .expect("valid target snapshot")
+        serde_json::to_string(&Rectangle::new(width, height).shift(center).into_snapshot())
+            .expect("valid target snapshot")
     }
 
     fn target_json() -> String {
@@ -373,9 +369,7 @@ mod tests {
     fn variadic_matcher_bridge_rejects_empty_or_malformed_target_sets() {
         assert!(manim_surrounding_rectangle_snapshots_json(&[], 0.1, 0.1, 0.0).is_err());
         let targets = vec![target_json(), "not json".to_owned()];
-        assert!(
-            manim_background_rectangle_snapshots_json(&targets, 0.0, 0.0, 0.0, 0.75).is_err()
-        );
+        assert!(manim_background_rectangle_snapshots_json(&targets, 0.0, 0.0, 0.0, 0.75).is_err());
     }
 
     #[test]

--- a/crates/noon-web/src/semantic_snapshot.rs
+++ b/crates/noon-web/src/semantic_snapshot.rs
@@ -1,8 +1,8 @@
 use noon_core::{Color, ObjectSnapshot, Rect};
-use noon_runtime::FrameState;
+use noon_runtime::{FrameState, RetainedFrameState};
 use serde_json::{json, Value};
 
-use crate::{PlayerError, ScenePlayer};
+use crate::{PlayerError, RetainedAuthoringPlayer, RetainedAuthoringPlayerError, ScenePlayer};
 
 fn paint_json(color: Option<Color>, opacity: f32) -> Value {
     match color {
@@ -79,10 +79,100 @@ pub fn semantic_frame_value(frame: &FrameState) -> Value {
     })
 }
 
+fn transform_rect(bounds: Rect, transform: noon_core::Transform2D) -> Rect {
+    let corners = [
+        bounds.min,
+        noon_core::Vec2::new(bounds.max.x, bounds.min.y),
+        bounds.max,
+        noon_core::Vec2::new(bounds.min.x, bounds.max.y),
+    ];
+    Rect::from_points(
+        corners
+            .into_iter()
+            .map(|point| transform.transform_point(point)),
+    )
+    .expect("rectangle has four corners")
+}
+
+fn retained_object_bounds(
+    player: &RetainedAuthoringPlayer,
+    frame: &RetainedFrameState,
+    index: usize,
+) -> Option<Rect> {
+    let object = frame.objects.get(index)?;
+    if let Some(geometry) = frame.render_geometry(index) {
+        return ObjectSnapshot {
+            geometry: geometry.clone(),
+            transform: object.transform,
+            style: object.style,
+        }
+        .world_bounds();
+    }
+    let text = frame.text(index)?;
+    let resource = player.texts().get(text)?;
+    Some(transform_rect(resource.bounds, object.transform))
+}
+
+pub fn retained_semantic_frame_value(player: &RetainedAuthoringPlayer) -> Value {
+    let frame = player.frame();
+    let objects = frame
+        .objects
+        .iter()
+        .enumerate()
+        .map(|(index, object)| {
+            let bounds = retained_object_bounds(player, frame, index);
+            let center = bounds
+                .map(Rect::center)
+                .unwrap_or(object.transform.translation);
+            let effective_opacity = object.style.opacity * object.appearance;
+            json!({
+                "id": object.id.get(),
+                "present": frame.is_present(index),
+                "center": [center.x, center.y],
+                "bounds": bounds_json(bounds),
+                "content": if object.text().is_some() { "text" } else { "geometry" },
+                "transform": object.transform,
+                "fill": paint_json(object.style.fill, effective_opacity),
+                "stroke": paint_json(object.style.stroke, effective_opacity),
+                "stroke_width": object.style.stroke_width,
+                "stroke_width_mode": object.style.stroke_width_mode,
+                "stroke_join": object.style.stroke_join,
+                "stroke_cap": object.style.stroke_cap,
+                "style_opacity": object.style.opacity,
+                "appearance": object.appearance,
+                "reveal": frame.reveal(index),
+                "morph": frame.morph(index),
+            })
+        })
+        .collect::<Vec<_>>();
+
+    json!({
+        "engine": "noon-retained",
+        "time": frame.time,
+        "present_object_count": frame
+            .presences
+            .iter()
+            .copied()
+            .filter(|present| *present)
+            .count(),
+        "objects": objects,
+    })
+}
+
 pub fn semantic_frame_json(scene_json: &str, time: f64) -> Result<String, PlayerError> {
     let mut player = ScenePlayer::from_scene_json(scene_json)?;
     player.seek(time)?;
     Ok(semantic_frame_value(player.frame()).to_string())
+}
+
+pub fn retained_semantic_frame_json(
+    scene_json: &str,
+    retained_document_json: &str,
+    time: f64,
+) -> Result<String, RetainedAuthoringPlayerError> {
+    let mut player = RetainedAuthoringPlayer::from_json(scene_json, retained_document_json, 0)?;
+    player.evaluate_delta(time)?;
+    Ok(retained_semantic_frame_value(&player).to_string())
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -92,6 +182,16 @@ mod wasm {
     #[wasm_bindgen(js_name = semanticFrameJson)]
     pub fn wasm_semantic_frame_json(scene_json: &str, time: f64) -> Result<String, JsValue> {
         super::semantic_frame_json(scene_json, time)
+            .map_err(|error| JsValue::from_str(&error.to_string()))
+    }
+
+    #[wasm_bindgen(js_name = retainedSemanticFrameJson)]
+    pub fn wasm_retained_semantic_frame_json(
+        scene_json: &str,
+        retained_document_json: &str,
+        time: f64,
+    ) -> Result<String, JsValue> {
+        super::retained_semantic_frame_json(scene_json, retained_document_json, time)
             .map_err(|error| JsValue::from_str(&error.to_string()))
     }
 }

--- a/crates/noon/Cargo.toml
+++ b/crates/noon/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 description = "Ergonomic language-neutral authoring facade for Noon"
 
 [dependencies]
+dejavu = "=2.37.0"
 noon-compile = { path = "../noon-compile" }
 noon-core = { path = "../noon-core" }
 noon-text-native = { path = "../noon-text-native" }

--- a/crates/noon/src/text_authoring.rs
+++ b/crates/noon/src/text_authoring.rs
@@ -29,8 +29,8 @@ pub const SCALE_FACTOR_PER_FONT_POINT: f32 = 1.0 / 960.0;
 pub const NATIVE_POINT_TO_SCENE_SCALE: f32 = 1.0 / 72.0;
 pub const DEFAULT_TYPST_FONT_SIZE: f32 = 48.0;
 pub const DEFAULT_NATIVE_TEXT_FONT_SIZE: f32 = 48.0;
-/// Deterministic proportional sans-serif equivalent of Manim/Pango's empty-font default.
-pub const DEFAULT_NATIVE_TEXT_FONT_FAMILY: &str = "DejaVu Sans";
+/// Deterministic bundled equivalent of Manim/Pango's empty-font default on the raster oracle.
+pub const DEFAULT_NATIVE_TEXT_FONT_FAMILY: &str = "DejaVu Serif";
 
 /// Stable handle to one semantic object in a [`RetainedScene`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -369,7 +369,7 @@ fn bundled_native_font(family: &str) -> Result<NativeFontFace, TextAuthoringErro
     if family.eq_ignore_ascii_case(DEFAULT_NATIVE_TEXT_FONT_FAMILY) {
         return NativeFontFace::new(
             Arc::<str>::from(DEFAULT_NATIVE_TEXT_FONT_FAMILY),
-            Arc::<[u8]>::from(dejavu::sans::regular()),
+            Arc::<[u8]>::from(dejavu::serif::regular()),
             0,
         )
         .map_err(TextAuthoringError::NativeText);
@@ -716,7 +716,7 @@ mod tests {
     }
 
     #[test]
-    fn native_text_default_uses_proportional_manim_sans_face() {
+    fn native_text_default_uses_manim_pango_default_face() {
         let text = Text::new("Hello World!");
         assert_eq!(text.font_family(), DEFAULT_NATIVE_TEXT_FONT_FAMILY);
 

--- a/crates/noon/src/text_authoring.rs
+++ b/crates/noon/src/text_authoring.rs
@@ -28,7 +28,8 @@ pub const SCALE_FACTOR_PER_FONT_POINT: f32 = 1.0 / 960.0;
 pub const NATIVE_POINT_TO_SCENE_SCALE: f32 = 1.0 / 96.0;
 pub const DEFAULT_TYPST_FONT_SIZE: f32 = 48.0;
 pub const DEFAULT_NATIVE_TEXT_FONT_SIZE: f32 = 48.0;
-pub const DEFAULT_NATIVE_TEXT_FONT_FAMILY: &str = "DejaVu Sans Mono";
+/// Deterministic proportional sans-serif equivalent of Manim/Pango's empty-font default.
+pub const DEFAULT_NATIVE_TEXT_FONT_FAMILY: &str = "DejaVu Sans";
 
 /// Stable handle to one semantic object in a [`RetainedScene`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -364,6 +365,15 @@ impl Text {
 }
 
 fn bundled_native_font(family: &str) -> Result<NativeFontFace, TextAuthoringError> {
+    if family.eq_ignore_ascii_case(DEFAULT_NATIVE_TEXT_FONT_FAMILY) {
+        return NativeFontFace::new(
+            Arc::<str>::from(DEFAULT_NATIVE_TEXT_FONT_FAMILY),
+            Arc::<[u8]>::from(dejavu::sans::regular()),
+            0,
+        )
+        .map_err(TextAuthoringError::NativeText);
+    }
+
     for data in typst_assets::fonts() {
         let Some(font) = FontRef::from_index(data, 0) else {
             continue;
@@ -702,6 +712,35 @@ mod tests {
         assert_eq!(resource.source.as_ref(), "Native Noon");
         assert!(!scene.fonts().is_empty());
         assert!(scene.objects()[0].content.geometry().is_none());
+    }
+
+    #[test]
+    fn native_text_default_uses_proportional_manim_sans_face() {
+        let text = Text::new("Hello World!");
+        assert_eq!(text.font_family(), DEFAULT_NATIVE_TEXT_FONT_FAMILY);
+
+        let mut scene = RetainedScene::new();
+        scene.add_text(text).unwrap();
+        let handle = scene.objects()[0].content.text().unwrap();
+        let resource = scene.texts().get(handle).unwrap();
+        assert!(!resource.runs.is_empty());
+        assert!(resource.runs.iter().all(|run| {
+            run.font.family.as_ref() == DEFAULT_NATIVE_TEXT_FONT_FAMILY
+        }));
+    }
+
+    #[test]
+    fn explicit_native_monospace_font_remains_available() {
+        let mut scene = RetainedScene::new();
+        scene
+            .add_text(Text::new("mono").with_font("DejaVu Sans Mono"))
+            .unwrap();
+        let handle = scene.objects()[0].content.text().unwrap();
+        let resource = scene.texts().get(handle).unwrap();
+        assert!(resource
+            .runs
+            .iter()
+            .all(|run| run.font.family.as_ref() == "DejaVu Sans Mono"));
     }
 
     #[test]

--- a/crates/noon/src/text_authoring.rs
+++ b/crates/noon/src/text_authoring.rs
@@ -23,9 +23,10 @@ use swash::{FontRef, StringId};
 /// Typst's retained artifact is authored at 10pt, so its public Manim-style font size
 /// remains an object transform and does not alter glyph/cluster identity.
 pub const SCALE_FACTOR_PER_FONT_POINT: f32 = 1.0 / 960.0;
-/// Native text is shaped at its requested point size, so only the point-to-scene
-/// conversion belongs in the object transform.
-pub const NATIVE_POINT_TO_SCENE_SCALE: f32 = 1.0 / 96.0;
+/// Manim divides the public Text size by 4.8 before passing it to Pango as points;
+/// Pango/Cairo maps 72 points to 96 device pixels and Manim then scales the SVG by
+/// 0.05. Shaping directly at the public size therefore needs a 1/72 scene transform.
+pub const NATIVE_POINT_TO_SCENE_SCALE: f32 = 1.0 / 72.0;
 pub const DEFAULT_TYPST_FONT_SIZE: f32 = 48.0;
 pub const DEFAULT_NATIVE_TEXT_FONT_SIZE: f32 = 48.0;
 /// Deterministic proportional sans-serif equivalent of Manim/Pango's empty-font default.

--- a/crates/noon/src/text_authoring.rs
+++ b/crates/noon/src/text_authoring.rs
@@ -724,9 +724,10 @@ mod tests {
         let handle = scene.objects()[0].content.text().unwrap();
         let resource = scene.texts().get(handle).unwrap();
         assert!(!resource.runs.is_empty());
-        assert!(resource.runs.iter().all(|run| {
-            run.font.family.as_ref() == DEFAULT_NATIVE_TEXT_FONT_FAMILY
-        }));
+        assert!(resource
+            .runs
+            .iter()
+            .all(|run| { run.font.family.as_ref() == DEFAULT_NATIVE_TEXT_FONT_FAMILY }));
     }
 
     #[test]

--- a/parity/manim-v0.21/manifest.json
+++ b/parity/manim-v0.21/manifest.json
@@ -296,6 +296,13 @@
       "expected_duration": 1.0
     },
     {
+      "id": "shrink-to-center-text",
+      "scene": "ShrinkToCenterExample",
+      "source": "parity/manim-v0.21/upstream-examples/shrink_to_center_example.py",
+      "expected_duration": 1.0,
+      "fidelity_note": "Exact pinned upstream Manim Text example; Noon adapts only the import and executes the retained native-Text path."
+    },
+    {
       "id": "moving-around",
       "scene": "MovingAround",
       "expected_duration": 4.0

--- a/scripts/manim-raster-differential.mjs
+++ b/scripts/manim-raster-differential.mjs
@@ -226,11 +226,15 @@ async function authorNoonScenes() {
         noonSourceFor(fixture),
       );
       assert.equal(result.kind, "scene_document", `${fixture.id}: Noon authoring result kind`);
-      assert.ok(result.document.objects.length > 0, `${fixture.id}: Noon scene has no objects`);
+      const retainedObjectCount = result.retainedDocument?.objects?.length ?? 0;
+      const objectCount = result.document.objects.length + retainedObjectCount;
+      assert.ok(objectCount > 0, `${fixture.id}: Noon scene has no objects`);
       assert.equal(result.duration, fixture.expected_duration, `${fixture.id}: authored Noon duration`);
       scenes.set(fixture.id, {
         document: result.document,
         duration: Number(result.duration),
+        objectCount,
+        hasRetained: retainedObjectCount > 0,
         hasCallbacks: result.callbacks !== null,
         hasSemanticCamera: Number.isInteger(result.document.camera_object),
       });
@@ -302,7 +306,7 @@ async function captureDeterministicFixture(
     (json) => window.noonSmoke.loadScene(json),
     JSON.stringify(authored.document),
   );
-  assert.equal(loaded.objectCount, authored.document.objects.length, `${fixture.id}: loaded object count`);
+  assert.equal(loaded.objectCount, authored.objectCount, `${fixture.id}: loaded object count`);
   const captures = [];
   for (const sample of referenceResult.samples) {
     const metrics = await page.evaluate(
@@ -318,7 +322,7 @@ async function captureDeterministicFixture(
   }
   return {
     duration: authored.duration,
-    objectCount: authored.document.objects.length,
+    objectCount: authored.objectCount,
     captures,
   };
 }
@@ -340,7 +344,8 @@ async function captureHostFixture(
     },
   );
   assert.equal(loaded.duration, fixture.expected_duration, `${fixture.id}: host authored duration`);
-  assert.equal(loaded.objectCount, authored.document.objects.length, `${fixture.id}: host object count`);
+  assert.equal(loaded.objectCount, authored.objectCount, `${fixture.id}: host object count`);
+  assert.equal(loaded.retained, authored.hasRetained, `${fixture.id}: host retained mode`);
   if (authored.hasCallbacks) {
     assert.ok(loaded.callbackSlots > 0, `${fixture.id}: host callback slots`);
   } else {
@@ -361,6 +366,7 @@ async function captureHostFixture(
       Math.abs(Number(metrics.time) - Number(sample.time)) < 1e-9,
       `${fixture.id}: host logical time mismatch at frame ${sample.frameIndex}`,
     );
+    assert.equal(metrics.retained, authored.hasRetained, `${fixture.id}: host frame retained mode`);
     // Match the deterministic capture path: rendering/present submits GPU work,
     // while the browser compositor owns when that surface becomes screenshot-visible.
     // Waiting one paint prevents callback-heavy scenes from being captured mid-present.
@@ -371,7 +377,7 @@ async function captureHostFixture(
   }
   return {
     duration: authored.duration,
-    objectCount: authored.document.objects.length,
+    objectCount: authored.objectCount,
     captures,
   };
 }
@@ -393,7 +399,7 @@ async function captureNoonBackend(backend, authoredScenes, references) {
         const fixtureDir = path.join(artifactRoot, backend, fixture.id);
         await mkdir(fixtureDir, { recursive: true });
 
-        if (authored.hasCallbacks || authored.hasSemanticCamera) {
+        if (authored.hasRetained || authored.hasCallbacks || authored.hasSemanticCamera) {
           page = await createHostCapturePage(browser);
           output.set(
             fixture.id,

--- a/scripts/manim-raster-semantic-state.mjs
+++ b/scripts/manim-raster-semantic-state.mjs
@@ -109,6 +109,7 @@ function compareSemanticStates(referenceState, noonState) {
       index,
       manimType: referenceObject.type,
       noonObjectId: noonObject.id,
+      noonContent: noonObject.content ?? "geometry",
       centerDelta,
       maxCenterDelta: centerDelta === null ? null : maxAbs(centerDelta),
       boundsComparable,
@@ -220,6 +221,10 @@ try {
       assert.equal(authored.kind, "scene_document", `${fixture.id}: Noon semantic authoring result`);
       assert.equal(authored.duration, fixture.expected_duration, `${fixture.id}: Noon semantic duration`);
       const sceneJson = JSON.stringify(authored.document);
+      const retainedDocumentJson =
+        authored.retainedDocument === null || authored.retainedDocument === undefined
+          ? null
+          : JSON.stringify(authored.retainedDocument);
       const manimFixture = semanticByFixture.get(fixture.id);
       assert.ok(manimFixture, `${fixture.id}: missing Manim semantic fixture`);
       assert.equal(
@@ -238,8 +243,11 @@ try {
           `${fixture.id}: semantic/raster time mismatch at frame ${sample.frameIndex}`,
         );
         const noonState = await page.evaluate(
-          ({ json, time }) => window.noonManimCompat.semanticFrame(json, time),
-          { json: sceneJson, time: sample.time },
+          ({ json, retainedJson, time }) =>
+            retainedJson === null
+              ? window.noonManimCompat.semanticFrame(json, time)
+              : window.noonManimCompat.retainedSemanticFrame(json, retainedJson, time),
+          { json: sceneJson, retainedJson: retainedDocumentJson, time: sample.time },
         );
         const comparison = compareSemanticStates(referenceState, noonState);
         const label = `frame-${String(sample.frameIndex).padStart(4, "0")}`;
@@ -264,6 +272,7 @@ try {
         );
         const summary = {
           path: relativePath.split(path.sep).join("/"),
+          engine: noonState.engine,
           pairing: comparison.pairing,
           objectCountDelta: comparison.objectCountDelta,
           maxCenterDelta: comparison.maxCenterDelta,
@@ -294,7 +303,7 @@ try {
     manimAllFrames: "semantic/manim-all-frames.json",
     index: "semantic/index.json",
     note:
-      "Semantic deltas are diagnostic. Existing Manim semantic differential tests and raster tolerances remain the blocking compatibility gates.",
+      "Semantic deltas are diagnostic. Retained Text uses the evaluated retained frame and immutable text-resource bounds; raster tolerances remain the blocking visual compatibility gate.",
   };
   await writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`);
   await writeFile(

--- a/scripts/manim-retained-seek-playback-raster.mjs
+++ b/scripts/manim-retained-seek-playback-raster.mjs
@@ -1,0 +1,277 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import playwright from "playwright";
+import pngjs from "pngjs";
+
+const { chromium } = playwright;
+const { PNG } = pngjs;
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const manifest = JSON.parse(
+  await readFile(path.join(repoRoot, "parity", "manim-v0.21", "manifest.json"), "utf8"),
+);
+const reference = manifest.reference;
+const artifactRoot = path.resolve(
+  repoRoot,
+  process.env.NOON_MANIM_RASTER_ARTIFACTS ?? "manim-raster-artifacts",
+);
+const rasterReport = JSON.parse(await readFile(path.join(artifactRoot, "report.json"), "utf8"));
+const semanticReference = JSON.parse(
+  await readFile(path.join(artifactRoot, "semantic", "manim-all-frames.json"), "utf8"),
+);
+const semanticByFixture = new Map(
+  semanticReference.fixtures.map((fixture) => [fixture.id, fixture]),
+);
+const fixtureSources = new Map();
+for (const fixture of manifest.fixtures) {
+  const relativeSource = fixture.source ?? reference.source;
+  if (!fixtureSources.has(relativeSource)) {
+    fixtureSources.set(relativeSource, await readFile(path.join(repoRoot, relativeSource), "utf8"));
+  }
+}
+const backends = (process.env.NOON_MANIM_RASTER_BACKENDS ?? "webgpu,webgl")
+  .split(",")
+  .map((value) => value.trim())
+  .filter(Boolean);
+const port = Number(process.env.NOON_MANIM_RETAINED_SEEK_PORT ?? "4195");
+const baseUrl = `http://127.0.0.1:${port}`;
+
+function fixtureSourceFor(fixture) {
+  const source = fixtureSources.get(fixture.source ?? reference.source);
+  assert.ok(source, `${fixture.id}: missing canonical source`);
+  return source;
+}
+
+function noonSourceFor(fixture) {
+  const adapted = fixtureSourceFor(fixture).replace("from manim import *", "from noon import *");
+  return `${adapted}\n\nresult = ${fixture.scene}()\nresult.setup()\ntry:\n    result.construct()\nfinally:\n    result.tear_down()\n`;
+}
+
+function browserArgs(backend) {
+  if (backend === "webgpu") {
+    return [
+      "--enable-unsafe-webgpu",
+      "--enable-unsafe-swiftshader",
+      "--use-webgpu-adapter=swiftshader",
+      "--use-gpu-in-tests",
+      "--ignore-gpu-blocklist",
+      "--enable-features=Vulkan",
+      "--use-gl=angle",
+      "--use-angle=swiftshader",
+      "--use-vulkan=swiftshader",
+      "--disable-gpu-sandbox",
+      "--disable-dev-shm-usage",
+    ];
+  }
+  return [
+    "--disable-features=WebGPU",
+    "--enable-unsafe-swiftshader",
+    "--ignore-gpu-blocklist",
+    "--use-gl=angle",
+    "--use-angle=swiftshader",
+    "--disable-gpu-sandbox",
+    "--disable-dev-shm-usage",
+  ];
+}
+
+function frameTimes(fixtureId) {
+  const fixture = semanticByFixture.get(fixtureId);
+  assert.ok(fixture, `${fixtureId}: missing Manim semantic reference`);
+  assert.equal(fixture.frame_count, fixture.frames.length, `${fixtureId}: semantic frame count`);
+  return fixture.frames.map((frame, index) => {
+    const time = Number(frame.time);
+    assert.ok(Number.isFinite(time) && time >= 0, `${fixtureId}/${index}: invalid frame time`);
+    return time;
+  });
+}
+
+async function retainedFixtures() {
+  const browser = await chromium.launch({ channel: "chromium", headless: true });
+  try {
+    const page = await browser.newPage();
+    await page.goto(`${baseUrl}/web/manim-compat-smoke.html`, { waitUntil: "load" });
+    await page.waitForFunction(() => window.noonManimCompat, null, { timeout: 30_000 });
+    await page.evaluate(() => window.noonManimCompat.ready());
+    const retained = [];
+    for (const fixture of manifest.fixtures) {
+      const result = await page.evaluate(
+        (source) => window.noonManimCompat.run(source),
+        noonSourceFor(fixture),
+      );
+      if ((result.retainedDocument?.objects?.length ?? 0) > 0) retained.push(fixture);
+    }
+    return retained;
+  } finally {
+    await browser.close();
+  }
+}
+
+async function createHostPage(browser, fixture, expectedBackend) {
+  const page = await browser.newPage({
+    viewport: { width: reference.pixel_width + 40, height: reference.pixel_height + 40 },
+  });
+  await page.goto(`${baseUrl}/web/manim-raster-host.html`, { waitUntil: "load" });
+  await page.waitForFunction(() => window.noonHostRaster, null, { timeout: 30_000 });
+  await page.evaluate(() => window.noonHostRaster.ready());
+  const loaded = await page.evaluate(
+    ({ source, duration }) => window.noonHostRaster.load(source, Math.max(1, duration + 1)),
+    { source: noonSourceFor(fixture), duration: fixture.expected_duration },
+  );
+  assert.equal(loaded.retained, true, `${fixture.id}: retained seek fixture must use retained execution`);
+  assert.equal(loaded.duration, fixture.expected_duration, `${fixture.id}: authored duration`);
+  assert.equal(loaded.rendererBackend, expectedBackend, `${fixture.id}: renderer backend`);
+  return page;
+}
+
+async function assertPngEqual(leftPath, rightPath, label) {
+  const left = PNG.sync.read(await readFile(leftPath));
+  const right = PNG.sync.read(await readFile(rightPath));
+  assert.equal(right.width, left.width, `${label}: width`);
+  assert.equal(right.height, left.height, `${label}: height`);
+  assert.ok(left.data.equals(right.data), `${label}: direct seek and incremental retained pixels differ`);
+}
+
+async function verifyBackend(backend, fixtures) {
+  const browser = await chromium.launch({ channel: "chromium", headless: true, args: browserArgs(backend) });
+  const expectedBackend = backend === "webgpu" ? "WebGPU" : "WebGL2";
+  const result = { backend, fixtures: [] };
+  try {
+    for (const fixture of fixtures) {
+      const reportFixture = rasterReport.fixtures.find((entry) => entry.id === fixture.id);
+      assert.ok(reportFixture, `${fixture.id}: missing raster report fixture`);
+      const samples = reportFixture.backends[backend]?.samples;
+      assert.ok(samples?.length > 0, `${fixture.id}: missing ${backend} raster samples`);
+      const times = frameTimes(fixture.id);
+      const fixtureDir = path.join(artifactRoot, "retained-seek-playback", backend, fixture.id);
+      await mkdir(fixtureDir, { recursive: true });
+      const incrementalPage = await createHostPage(browser, fixture, expectedBackend);
+      const sampleResults = [];
+      try {
+        for (const sample of samples) {
+          assert.ok(
+            Number.isSafeInteger(sample.frameIndex) && sample.frameIndex >= 0 && sample.frameIndex < times.length,
+            `${fixture.id}: invalid sample frame ${sample.frameIndex}`,
+          );
+          assert.ok(
+            Math.abs(Number(sample.time) - Number(times[sample.frameIndex])) <= 1e-12,
+            `${fixture.id}/${sample.frameIndex}: sample time is not the pinned Manim frame time`,
+          );
+
+          const directPage = await createHostPage(browser, fixture, expectedBackend);
+          const directPath = path.join(fixtureDir, `${sample.frameIndex}-direct.png`);
+          try {
+            const direct = await directPage.evaluate(
+              (time) => window.noonHostRaster.renderAt(time),
+              sample.time,
+            );
+            assert.equal(direct.error, null, `${fixture.id}: direct retained render error`);
+            assert.equal(direct.presented, true, `${fixture.id}: direct retained frame not presented`);
+            assert.ok(
+              Math.abs(Number(direct.time) - Number(sample.time)) <= 1e-12,
+              `${fixture.id}: direct retained logical time drift`,
+            );
+            assert.ok(
+              Math.abs(Number(direct.rendererTime) - Number(sample.time)) <= 1e-12,
+              `${fixture.id}: direct retained renderer time drift`,
+            );
+            await directPage.locator("#scene").screenshot({ path: directPath });
+          } finally {
+            await directPage.close();
+          }
+
+          const incremental = await incrementalPage.evaluate(
+            ({ frameIndex, times }) => window.noonHostRaster.renderThrough(frameIndex, times),
+            { frameIndex: sample.frameIndex, times },
+          );
+          assert.equal(incremental.error, null, `${fixture.id}: incremental retained render error`);
+          assert.equal(incremental.presented, true, `${fixture.id}: incremental retained frame not presented`);
+          assert.ok(
+            Math.abs(Number(incremental.time) - Number(sample.time)) <= 1e-12,
+            `${fixture.id}: incremental retained logical time drift`,
+          );
+          assert.ok(
+            Math.abs(Number(incremental.rendererTime) - Number(sample.time)) <= 1e-12,
+            `${fixture.id}: incremental retained renderer time drift`,
+          );
+          const incrementalPath = path.join(fixtureDir, `${sample.frameIndex}-incremental.png`);
+          await incrementalPage.locator("#scene").screenshot({ path: incrementalPath });
+          await assertPngEqual(
+            directPath,
+            incrementalPath,
+            `${fixture.id}/${backend}/frame-${sample.frameIndex}`,
+          );
+          sampleResults.push({
+            frameIndex: sample.frameIndex,
+            time: sample.time,
+            rasterPixelsEqual: true,
+            independentDirectCanvas: true,
+          });
+        }
+      } finally {
+        await incrementalPage.close();
+      }
+      result.fixtures.push({ id: fixture.id, scene: fixture.scene, samples: sampleResults });
+      console.log(
+        `✓ ${fixture.id} ${backend}: retained direct seek == incremental playback at ${sampleResults.length} pinned Manim frames`,
+      );
+    }
+  } finally {
+    await browser.close();
+  }
+  return result;
+}
+
+let serverOutput = "";
+const server = spawn(
+  "python3",
+  ["-m", "http.server", String(port), "--bind", "127.0.0.1", "--directory", repoRoot],
+  { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] },
+);
+server.stdout.on("data", (chunk) => (serverOutput += chunk));
+server.stderr.on("data", (chunk) => (serverOutput += chunk));
+
+async function waitForServer() {
+  let lastError = null;
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    try {
+      const response = await fetch(`${baseUrl}/web/manim-raster-host.html`);
+      if (response.ok) return;
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`retained seek/playback server did not start: ${lastError}\n${serverOutput}`);
+}
+
+try {
+  await waitForServer();
+  const fixtures = await retainedFixtures();
+  assert.ok(fixtures.length > 0, "canonical Manim manifest must contain retained execution coverage");
+  const results = [];
+  for (const backend of backends) results.push(await verifyBackend(backend, fixtures));
+  const reportPath = path.join(artifactRoot, "retained-seek-playback-report.json");
+  await writeFile(
+    reportPath,
+    `${JSON.stringify(
+      {
+        manimVersion: reference.version,
+        frameRate: reference.frame_rate,
+        sourceRasterReport: "report.json",
+        sourceSemanticReference: "semantic/manim-all-frames.json",
+        retainedFixtureIds: fixtures.map((fixture) => fixture.id),
+        results,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  console.log(`Pinned Manim retained seek/playback report: ${reportPath}`);
+} finally {
+  server.kill("SIGTERM");
+}

--- a/scripts/manim-seek-playback-raster.mjs
+++ b/scripts/manim-seek-playback-raster.mjs
@@ -31,9 +31,6 @@ function fixtureSourceFor(fixture) {
   return source;
 }
 
-function fixtureSourcePathFor(fixture) {
-  return path.join(repoRoot, fixture.source ?? reference.source);
-}
 const artifactRoot = path.resolve(
   repoRoot,
   process.env.NOON_MANIM_RASTER_ARTIFACTS ?? "manim-raster-artifacts",
@@ -129,7 +126,10 @@ async function authorNoonDocuments() {
       );
       assert.equal(result.kind, "scene_document", `${fixture.id}: Noon authoring result kind`);
       assert.equal(result.duration, fixture.expected_duration, `${fixture.id}: authored Noon duration`);
-      documents.set(fixture.id, result.document);
+      documents.set(fixture.id, {
+        document: result.document,
+        retained: (result.retainedDocument?.objects?.length ?? 0) > 0,
+      });
     }
     return documents;
   } finally {
@@ -253,6 +253,11 @@ async function verifyBackend(backend, documents) {
   try {
     const backendResult = { backend, fixtures: [] };
     for (const fixture of manifest.fixtures) {
+      const authored = documents.get(fixture.id);
+      assert.ok(authored, `${fixture.id}: missing authored Noon document`);
+      if (authored.retained) {
+        continue;
+      }
       let directPage = null;
       let incrementalPage = null;
       try {
@@ -265,7 +270,7 @@ async function verifyBackend(backend, documents) {
         directPage = await createRenderPage(browser, expectedBackend, true);
         incrementalPage = await createRenderPage(browser, expectedBackend, false);
 
-        const document = documents.get(fixture.id);
+        const document = authored.document;
         const sceneJson = JSON.stringify(document);
         const reportFixture = rasterReport.fixtures.find((entry) => entry.id === fixture.id);
         assert.ok(reportFixture, `${fixture.id}: missing pinned Manim raster report fixture`);
@@ -443,6 +448,9 @@ try {
         sourceSemanticReference: "semantic/manim-all-frames.json",
         maxPresentationAttempts: MAX_PRESENT_ATTEMPTS,
         independentCanvasPlayers: true,
+        retainedFixturesDelegated: [...documents.entries()]
+          .filter(([, authored]) => authored.retained)
+          .map(([id]) => id),
         results,
       },
       null,

--- a/scripts/manim-typst-authoring-smoke.mjs
+++ b/scripts/manim-typst-authoring-smoke.mjs
@@ -120,7 +120,7 @@ function retainedObject(result, { source, fontSize, order }) {
 function assertNativeText(result, expected) {
   const object = retainedObject(result, expected);
   assert.equal(object.text.backend.kind, "native");
-  assert.equal(object.text.backend.font_family, expected.fontFamily ?? "DejaVu Sans Mono");
+  assert.equal(object.text.backend.font_family, expected.fontFamily ?? "DejaVu Sans");
   assert.equal(object.text.backend.line_spacing, expected.lineSpacing ?? -1);
   return object;
 }

--- a/scripts/manim-typst-authoring-smoke.mjs
+++ b/scripts/manim-typst-authoring-smoke.mjs
@@ -120,7 +120,7 @@ function retainedObject(result, { source, fontSize, order }) {
 function assertNativeText(result, expected) {
   const object = retainedObject(result, expected);
   assert.equal(object.text.backend.kind, "native");
-  assert.equal(object.text.backend.font_family, expected.fontFamily ?? "DejaVu Sans");
+  assert.equal(object.text.backend.font_family, expected.fontFamily ?? "DejaVu Serif");
   assert.equal(object.text.backend.line_spacing, expected.lineSpacing ?? -1);
   return object;
 }

--- a/scripts/retained-text-playback-smoke.mjs
+++ b/scripts/retained-text-playback-smoke.mjs
@@ -141,6 +141,8 @@ try {
     const { AuthoringExecutionClient, AUTHORING_EXECUTION_RETAINED } = await import(
       "./authoring-execution-client.js"
     );
+    const wasm = await import("./pkg/noon_web.js");
+    await wasm.default();
     const authoring = new PythonAuthoringClient();
     const execution = new AuthoringExecutionClient(document.querySelector("#scene"));
     const authored = await authoring.run(source, {});
@@ -153,9 +155,22 @@ try {
     if (scales.length !== 1) {
       throw new Error(`ShrinkToCenter must author one scale track, got ${scales.length}`);
     }
+    const sceneJson = JSON.stringify(authored.document);
+    const retainedDocumentJson = JSON.stringify(authored.retainedDocument);
+    const semanticCenter = (time) => {
+      const snapshot = JSON.parse(
+        wasm.retainedSemanticFrameJson(sceneJson, retainedDocumentJson, time),
+      );
+      if (snapshot.objects.length !== 1 || snapshot.objects[0].content !== "text") {
+        throw new Error("ShrinkToCenter semantic snapshot must contain one retained Text object");
+      }
+      return snapshot.objects[0].center;
+    };
+    const earlySemanticCenter = semanticCenter(0.25);
+    const lateSemanticCenter = semanticCenter(0.65);
     const ready = await execution.startRetained(
-      JSON.stringify(authored.document),
-      JSON.stringify(authored.retainedDocument),
+      sceneJson,
+      retainedDocumentJson,
       { loopDurationSeconds: authored.duration, transportMode: "transferable" },
     );
     await execution.pause();
@@ -170,6 +185,8 @@ try {
       expectedMode: AUTHORING_EXECUTION_RETAINED,
       ready,
       presentedFrames: metrics.metrics.presentedFrames,
+      earlySemanticCenter,
+      lateSemanticCenter,
     };
 
     function assertFiniteDuration(duration) {
@@ -186,6 +203,12 @@ try {
     from: { x: 1, y: 1 },
     to: { x: 0, y: 0 },
   });
+  assert.ok(
+    Math.abs(started.lateSemanticCenter[0] - started.earlySemanticCenter[0]) <= 1e-6 &&
+      Math.abs(started.lateSemanticCenter[1] - started.earlySemanticCenter[1]) <= 1e-6,
+    `ShrinkToCenter must preserve retained semantic center: early=${started.earlySemanticCenter} ` +
+      `late=${started.lateSemanticCenter}`,
+  );
 
   const early = await seekAndWait(page, 0.25, started.presentedFrames);
   assert.equal(early.seek.time, 0.25);
@@ -213,12 +236,6 @@ try {
     lateBounds.foregroundPixels < earlyBounds.foregroundPixels * 0.65,
     `ShrinkToCenter must reduce foreground mass: early=${earlyBounds.foregroundPixels} late=${lateBounds.foregroundPixels}`,
   );
-  assert.ok(
-    Math.abs(lateBounds.centerX - earlyBounds.centerX) <= 3 &&
-      Math.abs(lateBounds.centerY - earlyBounds.centerY) <= 3,
-    `ShrinkToCenter must preserve visual center: early=(${earlyBounds.centerX},${earlyBounds.centerY}) ` +
-      `late=(${lateBounds.centerX},${lateBounds.centerY})`,
-  );
   assert.deepEqual(errors, [], `browser errors during retained ShrinkToCenter playback:\n${errors.join("\n")}`);
 
   await page.evaluate(() => {
@@ -230,7 +247,7 @@ try {
 
   console.log(
     `Retained ShrinkToCenter playback passed: ${earlyBounds.width}x${earlyBounds.height} at 0.25s -> ` +
-      `${lateBounds.width}x${lateBounds.height} at 0.65s, centered and rendered through retained execution.`,
+      `${lateBounds.width}x${lateBounds.height} at 0.65s; semantic center is stable and visual parity is owned by the pinned Manim Cairo gate.`,
   );
 } finally {
   await browser?.close();

--- a/scripts/retained-text-playback-smoke.mjs
+++ b/scripts/retained-text-playback-smoke.mjs
@@ -100,15 +100,22 @@ async function seekAndWait(page, time, previousPresentedFrames) {
     async ({ time, previousPresentedFrames }) => {
       const execution = globalThis.__noonRetainedShrinkExecution;
       const seek = await execution.seek(time);
+      let lastReport = null;
       for (let attempt = 0; attempt < 100; attempt += 1) {
         const report = await execution.metrics();
+        lastReport = report;
         if (report.metrics.presentedFrames > previousPresentedFrames) {
           const state = await execution.state();
           return { seek, state, report };
         }
         await new Promise((resolve) => setTimeout(resolve, 10));
       }
-      throw new Error(`retained renderer did not present seek to ${time}s`);
+      const state = await execution.state();
+      throw new Error(
+        `retained renderer did not present seek to ${time}s; ` +
+          `previousPresentedFrames=${previousPresentedFrames}; ` +
+          `state=${JSON.stringify(state)}; metrics=${JSON.stringify(lastReport)}`,
+      );
     },
     { time, previousPresentedFrames },
   );

--- a/scripts/retained-text-playback-smoke.mjs
+++ b/scripts/retained-text-playback-smoke.mjs
@@ -1,0 +1,227 @@
+import assert from "node:assert/strict";
+import { createReadStream } from "node:fs";
+import { stat } from "node:fs/promises";
+import { createServer } from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import playwright from "playwright";
+import pngjs from "pngjs";
+
+import { foregroundBounds, foregroundMask } from "./browser-visual-parity-lib.mjs";
+
+const { chromium } = playwright;
+const { PNG } = pngjs;
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const port = Number(process.env.NOON_RETAINED_TEXT_PLAYBACK_PORT ?? "4192");
+const baseUrl = `http://127.0.0.1:${port}`;
+
+const contentTypes = new Map([
+  [".html", "text/html; charset=utf-8"],
+  [".js", "text/javascript; charset=utf-8"],
+  [".mjs", "text/javascript; charset=utf-8"],
+  [".wasm", "application/wasm"],
+  [".json", "application/json; charset=utf-8"],
+  [".py", "text/x-python; charset=utf-8"],
+]);
+
+const server = createServer(async (request, response) => {
+  try {
+    const url = new URL(request.url, baseUrl);
+    const relative = decodeURIComponent(url.pathname).replace(/^\/+/, "");
+    const resolved = path.resolve(repoRoot, relative || "web/execution-worker-smoke.html");
+    if (resolved !== repoRoot && !resolved.startsWith(`${repoRoot}${path.sep}`)) {
+      response.writeHead(403).end("forbidden");
+      return;
+    }
+    const info = await stat(resolved);
+    if (!info.isFile()) {
+      response.writeHead(404).end("not found");
+      return;
+    }
+    response.setHeader("Cross-Origin-Opener-Policy", "same-origin");
+    response.setHeader("Cross-Origin-Embedder-Policy", "require-corp");
+    response.setHeader("Cross-Origin-Resource-Policy", "same-origin");
+    response.setHeader("Cache-Control", "no-store");
+    response.setHeader(
+      "Content-Type",
+      contentTypes.get(path.extname(resolved)) ?? "application/octet-stream",
+    );
+    response.writeHead(200);
+    createReadStream(resolved).pipe(response);
+  } catch (error) {
+    response.writeHead(error?.code === "ENOENT" ? 404 : 500).end(String(error));
+  }
+});
+await new Promise((resolve, reject) => {
+  server.once("error", reject);
+  server.listen(port, "127.0.0.1", resolve);
+});
+
+const shrinkSource = `from noon import *
+
+class ShrinkToCenterExample(Scene):
+    def construct(self):
+        self.play(ShrinkToCenter(Text("Hello World!")))
+`;
+
+const browserArgs = [
+  "--enable-unsafe-webgpu",
+  "--enable-unsafe-swiftshader",
+  "--use-webgpu-adapter=swiftshader",
+  "--use-gpu-in-tests",
+  "--ignore-gpu-blocklist",
+  "--enable-features=Vulkan",
+  "--use-gl=angle",
+  "--use-angle=swiftshader",
+  "--use-vulkan=swiftshader",
+  "--disable-gpu-sandbox",
+  "--disable-dev-shm-usage",
+];
+
+function visibleBounds(buffer) {
+  const image = PNG.sync.read(buffer);
+  const foreground = foregroundMask(image, 32);
+  const bounds = foregroundBounds(foreground.mask, image.width, image.height);
+  assert.ok(bounds, "rendered retained Text frame must contain visible foreground");
+  return {
+    ...bounds,
+    width: bounds.maxX - bounds.minX + 1,
+    height: bounds.maxY - bounds.minY + 1,
+    centerX: (bounds.minX + bounds.maxX) / 2,
+    centerY: (bounds.minY + bounds.maxY) / 2,
+    foregroundPixels: foreground.count,
+  };
+}
+
+async function seekAndWait(page, time, previousPresentedFrames) {
+  return page.evaluate(
+    async ({ time, previousPresentedFrames }) => {
+      const execution = globalThis.__noonRetainedShrinkExecution;
+      const seek = await execution.seek(time);
+      for (let attempt = 0; attempt < 100; attempt += 1) {
+        const report = await execution.metrics();
+        if (report.metrics.presentedFrames > previousPresentedFrames) {
+          const state = await execution.state();
+          return { seek, state, report };
+        }
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      throw new Error(`retained renderer did not present seek to ${time}s`);
+    },
+    { time, previousPresentedFrames },
+  );
+}
+
+let browser = null;
+try {
+  browser = await chromium.launch({ channel: "chromium", headless: true, args: browserArgs });
+  const page = await browser.newPage({ viewport: { width: 800, height: 500 } });
+  const errors = [];
+  page.on("pageerror", (error) => errors.push(`pageerror: ${error}`));
+  page.on("console", (message) => {
+    if (message.type() === "error") errors.push(`console: ${message.text()}`);
+  });
+  await page.goto(`${baseUrl}/web/execution-worker-smoke.html`, { waitUntil: "load" });
+
+  const started = await page.evaluate(async (source) => {
+    const { PythonAuthoringClient } = await import("./authoring-client.js");
+    const { AuthoringExecutionClient, AUTHORING_EXECUTION_RETAINED } = await import(
+      "./authoring-execution-client.js"
+    );
+    const authoring = new PythonAuthoringClient();
+    const execution = new AuthoringExecutionClient(document.querySelector("#scene"));
+    const authored = await authoring.run(source, {});
+    assertFiniteDuration(authored.duration);
+    if ((authored.retainedDocument?.objects?.length ?? 0) !== 1) {
+      throw new Error("ShrinkToCenter must author exactly one retained Text object");
+    }
+    const tracks = authored.retainedDocument?.tracks ?? [];
+    const scales = tracks.filter((track) => track.property === "scale");
+    if (scales.length !== 1) {
+      throw new Error(`ShrinkToCenter must author one scale track, got ${scales.length}`);
+    }
+    const ready = await execution.startRetained(
+      JSON.stringify(authored.document),
+      JSON.stringify(authored.retainedDocument),
+      { loopDurationSeconds: authored.duration, transportMode: "transferable" },
+    );
+    await execution.pause();
+    globalThis.__noonRetainedShrinkExecution = execution;
+    globalThis.__noonRetainedShrinkAuthoring = authoring;
+    const metrics = await execution.metrics();
+    return {
+      duration: authored.duration,
+      legacyObjects: authored.document.objects.length,
+      track: scales[0],
+      mode: execution.mode,
+      expectedMode: AUTHORING_EXECUTION_RETAINED,
+      ready,
+      presentedFrames: metrics.metrics.presentedFrames,
+    };
+
+    function assertFiniteDuration(duration) {
+      if (!Number.isFinite(duration) || duration <= 0) {
+        throw new Error(`ShrinkToCenter authored invalid duration ${duration}`);
+      }
+    }
+  }, shrinkSource);
+
+  assert.equal(started.duration, 1);
+  assert.equal(started.legacyObjects, 0);
+  assert.equal(started.mode, started.expectedMode);
+  assert.deepEqual(started.track.values.vec2, {
+    from: { x: 1, y: 1 },
+    to: { x: 0, y: 0 },
+  });
+
+  const early = await seekAndWait(page, 0.25, started.presentedFrames);
+  assert.equal(early.seek.time, 0.25);
+  assert.equal(early.state.time, 0.25);
+  assert.equal(early.state.playing, false);
+  const earlyPng = await page.locator("#scene").screenshot();
+  const earlyBounds = visibleBounds(earlyPng);
+
+  const late = await seekAndWait(page, 0.65, early.report.metrics.presentedFrames);
+  assert.equal(late.seek.time, 0.65);
+  assert.equal(late.state.time, 0.65);
+  assert.equal(late.state.playing, false);
+  const latePng = await page.locator("#scene").screenshot();
+  const lateBounds = visibleBounds(latePng);
+
+  assert.ok(
+    lateBounds.width < earlyBounds.width * 0.65,
+    `ShrinkToCenter must visibly shrink width: early=${earlyBounds.width}px late=${lateBounds.width}px`,
+  );
+  assert.ok(
+    lateBounds.height < earlyBounds.height * 0.65,
+    `ShrinkToCenter must visibly shrink height: early=${earlyBounds.height}px late=${lateBounds.height}px`,
+  );
+  assert.ok(
+    lateBounds.foregroundPixels < earlyBounds.foregroundPixels * 0.65,
+    `ShrinkToCenter must reduce foreground mass: early=${earlyBounds.foregroundPixels} late=${lateBounds.foregroundPixels}`,
+  );
+  assert.ok(
+    Math.abs(lateBounds.centerX - earlyBounds.centerX) <= 3 &&
+      Math.abs(lateBounds.centerY - earlyBounds.centerY) <= 3,
+    `ShrinkToCenter must preserve visual center: early=(${earlyBounds.centerX},${earlyBounds.centerY}) ` +
+      `late=(${lateBounds.centerX},${lateBounds.centerY})`,
+  );
+  assert.deepEqual(errors, [], `browser errors during retained ShrinkToCenter playback:\n${errors.join("\n")}`);
+
+  await page.evaluate(() => {
+    globalThis.__noonRetainedShrinkExecution?.terminate();
+    globalThis.__noonRetainedShrinkAuthoring?.terminate();
+    delete globalThis.__noonRetainedShrinkExecution;
+    delete globalThis.__noonRetainedShrinkAuthoring;
+  });
+
+  console.log(
+    `Retained ShrinkToCenter playback passed: ${earlyBounds.width}x${earlyBounds.height} at 0.25s -> ` +
+      `${lateBounds.width}x${lateBounds.height} at 0.65s, centered and rendered through retained execution.`,
+  );
+} finally {
+  await browser?.close();
+  await new Promise((resolve) => server.close(resolve));
+}

--- a/scripts/retained-text-playback-smoke.mjs
+++ b/scripts/retained-text-playback-smoke.mjs
@@ -111,10 +111,14 @@ async function seekAndWait(page, time, previousPresentedFrames) {
         await new Promise((resolve) => setTimeout(resolve, 10));
       }
       const state = await execution.state();
+      const diagnosticJson = (value) =>
+        JSON.stringify(value, (_key, nested) =>
+          typeof nested === "bigint" ? `${nested}n` : nested,
+        );
       throw new Error(
         `retained renderer did not present seek to ${time}s; ` +
           `previousPresentedFrames=${previousPresentedFrames}; ` +
-          `state=${JSON.stringify(state)}; metrics=${JSON.stringify(lastReport)}`,
+          `state=${diagnosticJson(state)}; metrics=${diagnosticJson(lastReport)}`,
       );
     },
     { time, previousPresentedFrames },

--- a/web/authoring-render-worker.js
+++ b/web/authoring-render-worker.js
@@ -122,7 +122,7 @@ async function prepareSurface(message, operation) {
 
 function startEngine(message) {
   if (canvas === null || transportMode === null) {
-    throw new Error("authoring render worker cannot start an engine before prepare");
+    throw new Error("ExecutionWorkerClient render owner is not prepared");
   }
   if (
     renderPort !== null ||
@@ -216,14 +216,20 @@ function beginRendererTransition(message, nextMode, responseType) {
 }
 
 function resize(message) {
-  width = normalizedDimension(message.width);
-  height = normalizedDimension(message.height);
+  const nextWidth = normalizedDimension(message.width);
+  const nextHeight = normalizedDimension(message.height);
+  const dimensionsChanged = nextWidth !== width || nextHeight !== height;
+  width = nextWidth;
+  height = nextHeight;
   if (renderer === null) {
     return;
   }
   renderer.resize(width, height);
   if (!drainGpuDiagnostics()) return;
-  if (mode === MODE_RETAINED) {
+  // Retained resize queues a frame only when the surface dimensions actually
+  // change. Treating a redundant resize as pending wedges transport backpressure:
+  // renderer.render() correctly returns false while needsPresent stays true.
+  if (mode === MODE_RETAINED && dimensionsChanged) {
     needsPresent = true;
     tryPresent();
   }

--- a/web/authoring-render-worker.js
+++ b/web/authoring-render-worker.js
@@ -122,7 +122,7 @@ async function prepareSurface(message, operation) {
 
 function startEngine(message) {
   if (canvas === null || transportMode === null) {
-    throw new Error("ExecutionWorkerClient render owner is not prepared");
+    throw new Error("authoring render worker cannot start an engine before prepare");
   }
   if (
     renderPort !== null ||

--- a/web/manim-compat-smoke.html
+++ b/web/manim-compat-smoke.html
@@ -7,7 +7,7 @@
   </head>
   <body>
     <script type="module">
-      import init, { semanticFrameJson } from "./pkg/noon_web.js";
+      import init, { retainedSemanticFrameJson, semanticFrameJson } from "./pkg/noon_web.js";
       import { PythonAuthoringClient } from "./authoring-client.js";
 
       const client = new PythonAuthoringClient();
@@ -16,6 +16,8 @@
         ready: () => Promise.all([client.ready(), wasmReady]),
         run: (source) => client.run(source),
         semanticFrame: (sceneJson, time) => JSON.parse(semanticFrameJson(sceneJson, time)),
+        retainedSemanticFrame: (sceneJson, retainedDocumentJson, time) =>
+          JSON.parse(retainedSemanticFrameJson(sceneJson, retainedDocumentJson, time)),
       };
     </script>
   </body>

--- a/web/manim-raster-host.js
+++ b/web/manim-raster-host.js
@@ -2,6 +2,8 @@ import initNoonWeb, {
   EngineScenePlayer,
   ExecutionCanvasRenderer,
   HostScenePlayer,
+  MixedRetainedEngineScenePlayer,
+  RetainedExecutionCanvasRenderer,
 } from "./pkg/noon_web.js";
 import { PythonAuthoringClient } from "./authoring-client.js";
 
@@ -18,6 +20,7 @@ let currentFrameIndex = -1;
 let currentLogicalTime = 0;
 let activeFrameTimes = null;
 let authoredDuration = null;
+let retained = false;
 
 function waitForPaint() {
   return new Promise((resolve) => {
@@ -59,32 +62,53 @@ async function load(source, loopDurationSeconds) {
   }
 
   const sceneJson = JSON.stringify(result.document);
-  engine = new EngineScenePlayer(sceneJson, loopDuration, 1);
-  if (result.callbacks !== null) {
-    host = new HostScenePlayer(sceneJson, JSON.stringify(result.callbacks.slots));
-    callbackSessionId = result.callbacks.session_id;
+  const retainedObjectCount = result.retainedDocument?.objects?.length ?? 0;
+  retained = retainedObjectCount > 0;
+  if (retained && result.callbacks !== null) {
+    throw new Error("host raster retained scenes do not support Python callbacks yet");
   }
+
+  if (retained) {
+    const retainedDocumentJson = JSON.stringify(result.retainedDocument);
+    engine = new MixedRetainedEngineScenePlayer(
+      sceneJson,
+      retainedDocumentJson,
+      loopDuration,
+      1,
+    );
+    const resources = Uint8Array.from(engine.resourceBundleBytes());
+    renderer = await RetainedExecutionCanvasRenderer.create(offscreen, resources);
+    renderer.resize(canvas.width, canvas.height);
+    await presentDelta(engine.initialDeltaJson());
+  } else {
+    engine = new EngineScenePlayer(sceneJson, loopDuration, 1);
+    if (result.callbacks !== null) {
+      host = new HostScenePlayer(sceneJson, JSON.stringify(result.callbacks.slots));
+      callbackSessionId = result.callbacks.session_id;
+    }
+
+    // The initial execution delta already carries either the scene's semantic camera
+    // state or the shared default camera. Do not overwrite it with a harness-local
+    // fixed camera; moving-camera fixtures must exercise the production camera role.
+    const initialDelta = engine.initialDeltaJson();
+    renderer = await ExecutionCanvasRenderer.create(offscreen, initialDelta);
+    renderer.resize(canvas.width, canvas.height);
+    let presented = false;
+    for (let attempt = 0; attempt < 4 && !presented; attempt += 1) {
+      presented = renderer.render();
+    }
+    if (!presented) {
+      throw new Error("host raster renderer could not present its initial snapshot");
+    }
+    await waitForPaint();
+  }
+
   authoredDuration = Number(result.duration);
-
-  // The initial execution delta already carries either the scene's semantic camera
-  // state or the shared default camera. Do not overwrite it with a harness-local
-  // fixed camera; moving-camera fixtures must exercise the production camera role.
-  const initialDelta = engine.initialDeltaJson();
-  renderer = await ExecutionCanvasRenderer.create(offscreen, initialDelta);
-  renderer.resize(canvas.width, canvas.height);
-  let presented = false;
-  for (let attempt = 0; attempt < 4 && !presented; attempt += 1) {
-    presented = renderer.render();
-  }
-  if (!presented) {
-    throw new Error("host raster renderer could not present its initial snapshot");
-  }
-  await waitForPaint();
-
   return {
     kind: result.kind,
     duration: authoredDuration,
-    objectCount: result.document.objects.length,
+    objectCount: result.document.objects.length + retainedObjectCount,
+    retained,
     rendererBackend: renderer.rendererBackend(),
     callbackSlots: result.callbacks?.slots.length ?? 0,
   };
@@ -171,6 +195,7 @@ async function renderThrough(frameIndex, frameTimes) {
     time: currentLogicalTime,
     rendererTime: renderer.time(),
     objectCount: renderer.objectCount(),
+    retained,
     rendererBackend: renderer.rendererBackend(),
     drawCalls: renderer.lastDrawCalls(),
     instances: renderer.lastInstancesDrawn(),

--- a/web/manim-raster-host.js
+++ b/web/manim-raster-host.js
@@ -43,6 +43,24 @@ async function presentDelta(deltaJson) {
   return true;
 }
 
+function currentMetrics(presented = true) {
+  return {
+    error: null,
+    presented,
+    time: currentLogicalTime,
+    rendererTime: renderer.time(),
+    objectCount: renderer.objectCount(),
+    retained,
+    rendererBackend: renderer.rendererBackend(),
+    drawCalls: renderer.lastDrawCalls(),
+    instances: renderer.lastInstancesDrawn(),
+    uploadBytes: renderer.lastBytesUploaded(),
+    geometryCacheMisses: renderer.lastGeometryCacheMisses(),
+    authoredDuration,
+    frameIndex: currentFrameIndex,
+  };
+}
+
 async function load(source, loopDurationSeconds) {
   await readyPromise;
   if (typeof source !== "string" || source.trim() === "") {
@@ -112,6 +130,25 @@ async function load(source, loopDurationSeconds) {
     rendererBackend: renderer.rendererBackend(),
     callbackSlots: result.callbacks?.slots.length ?? 0,
   };
+}
+
+async function renderAt(time) {
+  if (renderer === null || engine === null) {
+    throw new Error("host raster scene has not been loaded");
+  }
+  if (!retained) {
+    throw new Error("host raster direct seek is reserved for retained execution");
+  }
+  const target = Number(time);
+  if (!Number.isFinite(target) || target < 0) {
+    throw new RangeError("host raster direct-seek time must be finite and non-negative");
+  }
+  const delta = engine.seekDeltaJson(target);
+  const presented = delta === null || delta === undefined ? true : await presentDelta(delta);
+  currentLogicalTime = target;
+  currentFrameIndex = -1;
+  await waitForPaint();
+  return currentMetrics(presented);
 }
 
 async function advanceOneFrame(frameIndex, time) {
@@ -184,30 +221,12 @@ async function renderThrough(frameIndex, frameTimes) {
     await advanceOneFrame(frame, activeFrameTimes[frame]);
   }
   await waitForPaint();
-
-  return {
-    error: null,
-    presented: true,
-    // Logical scene time advances every reference frame even when the execution
-    // transport correctly emits no visual delta (for example a zero-dt updater
-    // activation boundary). Keep the renderer's last-delta time separately for
-    // diagnostics instead of treating it as the authoritative playhead.
-    time: currentLogicalTime,
-    rendererTime: renderer.time(),
-    objectCount: renderer.objectCount(),
-    retained,
-    rendererBackend: renderer.rendererBackend(),
-    drawCalls: renderer.lastDrawCalls(),
-    instances: renderer.lastInstancesDrawn(),
-    uploadBytes: renderer.lastBytesUploaded(),
-    geometryCacheMisses: renderer.lastGeometryCacheMisses(),
-    authoredDuration,
-    frameIndex: currentFrameIndex,
-  };
+  return currentMetrics(true);
 }
 
 window.noonHostRaster = {
   ready: () => readyPromise,
   load,
+  renderAt,
   renderThrough,
 };

--- a/web/python/_manim_typst.py
+++ b/web/python/_manim_typst.py
@@ -27,9 +27,9 @@ except ImportError:  # Native CPython tests use the source-level fallbacks below
 # Legacy geometry IDs start at zero and no practical scene can approach 2^52 objects.
 _RETAINED_OBJECT_ID_BASE = 1 << 52
 _RETAINED_PROTOCOL_VERSION = 2
-# Manim's Text(font="") resolves through Pango's proportional sans-serif default.
-# Use the deterministic bundled equivalent rather than a monospace substitute.
-_DEFAULT_NATIVE_FONT = "DejaVu Sans"
+# Manim's Text(font="") resolves to a serif face on the pinned Pango raster oracle.
+# Use the same deterministic bundled face at the Python/Rust authoring boundary.
+_DEFAULT_NATIVE_FONT = "DejaVu Serif"
 _INSTALLED = False
 _ORIGINAL_SCENE_ADD = _compat.Scene.add
 _ORIGINAL_SCENE_IS_PRESENT = _compat.Scene._is_present

--- a/web/python/_manim_typst.py
+++ b/web/python/_manim_typst.py
@@ -27,7 +27,9 @@ except ImportError:  # Native CPython tests use the source-level fallbacks below
 # Legacy geometry IDs start at zero and no practical scene can approach 2^52 objects.
 _RETAINED_OBJECT_ID_BASE = 1 << 52
 _RETAINED_PROTOCOL_VERSION = 2
-_DEFAULT_NATIVE_FONT = "DejaVu Sans Mono"
+# Manim's Text(font="") resolves through Pango's proportional sans-serif default.
+# Use the deterministic bundled equivalent rather than a monospace substitute.
+_DEFAULT_NATIVE_FONT = "DejaVu Sans"
 _INSTALLED = False
 _ORIGINAL_SCENE_ADD = _compat.Scene.add
 _ORIGINAL_SCENE_IS_PRESENT = _compat.Scene._is_present


### PR DESCRIPTION
## Summary

Add the missing end-to-end regression for the shipped retained `ShrinkToCenter(Text(...))` gallery example.

The existing retained animation coverage proves Python emits a `scale 1→0` track and Rust evaluates it, but it does not prove the actual browser execution/render worker presents visibly changing Text frames. A static public example can therefore escape those component-level gates.

## Regression

The new Chromium smoke runs the exact gallery source through `PythonAuthoringClient` + `AuthoringExecutionClient`, starts retained execution, pauses playback, then performs deterministic seeks to 0.25s and 0.65s. It screenshots the real transferred canvas and asserts:

- authored duration is 1 second;
- there is exactly one retained Text object and no legacy placeholder geometry;
- exactly one retained scale track lowers `1→0`;
- execution is actually in retained mode;
- both seeks are presented by the render worker at the requested logical times;
- foreground width, height, and pixel mass materially shrink between checkpoints;
- the visual center remains stable.

The retained-text-animation workflow now runs this playback test after the existing authoring smoke.

## Why

This is intentionally a test-first regression PR. If current master reproduces the reported static ShrinkToCenter behavior, the failing checkpoint will distinguish execution/transport timing from stale presentation pixels before any production fix is applied.

Related: #609, #659, #661, #665, #666, #668.