### PR TITLE
Support retained Text Scene lifecycle

### DIFF
--- a/.github/workflows/retained-text-animation.yml
+++ b/.github/workflows/retained-text-animation.yml
@@ -15,6 +15,7 @@ on:
       - "web/python/_manim_typst.py"
       - "scripts/build-python-worker.mjs"
       - "scripts/retained-text-animation-smoke.mjs"
+      - "scripts/retained-text-scene-lifecycle-smoke.mjs"
       - ".github/workflows/retained-text-animation.yml"
   push:
     branches:
@@ -32,6 +33,7 @@ on:
       - "web/python/_manim_typst.py"
       - "scripts/build-python-worker.mjs"
       - "scripts/retained-text-animation-smoke.mjs"
+      - "scripts/retained-text-scene-lifecycle-smoke.mjs"
       - ".github/workflows/retained-text-animation.yml"
   workflow_dispatch:
 
@@ -98,3 +100,6 @@ jobs:
 
       - name: Test retained Text animation authoring
         run: node scripts/retained-text-animation-smoke.mjs
+
+      - name: Test retained Text Scene lifecycle
+        run: node scripts/retained-text-scene-lifecycle-smoke.mjs

--- a/scripts/retained-text-scene-lifecycle-smoke.mjs
+++ b/scripts/retained-text-scene-lifecycle-smoke.mjs
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import playwright from "playwright";
+
+const { chromium } = playwright;
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const port = 4192;
+const baseUrl = `http://127.0.0.1:${port}`;
+
+let serverOutput = "";
+const server = spawn(
+  "python3",
+  ["-m", "http.server", String(port), "--bind", "127.0.0.1", "--directory", repoRoot],
+  { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] },
+);
+server.stdout.on("data", (chunk) => (serverOutput += chunk));
+server.stderr.on("data", (chunk) => (serverOutput += chunk));
+
+async function waitForServer() {
+  let lastError = null;
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    try {
+      const response = await fetch(`${baseUrl}/web/manim-compat-smoke.html`);
+      if (response.ok) return;
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`retained Text lifecycle smoke server did not start: ${lastError}\n${serverOutput}`);
+}
+
+const lifecycleSource = `
+from noon import *
+
+class RetainedSceneLifecycle(Scene):
+    def construct(self):
+        label = Text("Lifecycle", font_size=48)
+
+        self.wait(0.5)
+        assert label not in self.mobjects
+        self.add(label)
+        assert label in self.mobjects
+
+        self.wait(0.5)
+        self.remove(label)
+        assert label not in self.mobjects
+
+        self.wait(0.5)
+        self.add(label)
+        assert label in self.mobjects
+
+        self.wait(0.5)
+        self.clear()
+        assert label not in self.mobjects
+
+        self.wait(0.5)
+        self.play(label.animate.shift(UP), run_time=0.5)
+        assert label in self.mobjects
+`;
+
+let browser = null;
+try {
+  await waitForServer();
+  browser = await chromium.launch({
+    channel: "chromium",
+    headless: true,
+    args: ["--disable-dev-shm-usage"],
+  });
+  const page = await browser.newPage();
+  const errors = [];
+  page.on("pageerror", (error) => errors.push(`pageerror: ${error}`));
+  page.on("console", (message) => {
+    if (message.type() === "error") errors.push(`console: ${message.text()}`);
+  });
+
+  await page.goto(`${baseUrl}/web/manim-compat-smoke.html`, { waitUntil: "load" });
+  await page.waitForFunction(() => window.noonManimCompat, null, { timeout: 30_000 });
+  await page.evaluate(() => window.noonManimCompat.ready());
+
+  const result = await page.evaluate(
+    (source) => window.noonManimCompat.run(source),
+    lifecycleSource,
+  );
+  assert.equal(result.kind, "scene_document");
+  assert.equal(
+    result.document.objects.length,
+    0,
+    "retained Scene lifecycle must not synthesize legacy placeholder geometry",
+  );
+  assert.ok(result.retainedDocument, "retained Scene lifecycle must emit a retained document");
+  assert.equal(result.retainedDocument.objects.length, 1);
+  assert.equal(result.retainedDocument.objects[0].text.source, "Lifecycle");
+  assert.deepEqual(result.retainedDocument.objects[0].text.transform.translation, {
+    x: 0,
+    y: 0,
+  });
+
+  const tracks = result.retainedDocument.tracks ?? [];
+  const presence = tracks.filter((track) => track.property === "presence");
+  const position = tracks.filter((track) => track.property === "position");
+
+  assert.deepEqual(
+    presence.map((track) => ({
+      values: track.values.bool,
+      start: track.timing.start_time,
+      duration: track.timing.duration,
+      easing: track.timing.easing,
+    })),
+    [
+      { values: { from: false, to: true }, start: 0.5, duration: 0, easing: "linear" },
+      { values: { from: true, to: false }, start: 1, duration: 0, easing: "linear" },
+      { values: { from: false, to: true }, start: 1.5, duration: 0, easing: "linear" },
+      { values: { from: true, to: false }, start: 2, duration: 0, easing: "linear" },
+      { values: { from: false, to: true }, start: 2.5, duration: 0, easing: "linear" },
+    ],
+    "direct add/remove/clear and animate reintroduction must share one Presence timeline",
+  );
+
+  assert.equal(position.length, 1);
+  assert.deepEqual(position[0].values.vec2, {
+    from: { x: 0, y: 0 },
+    to: { x: 0, y: 1 },
+  });
+  assert.equal(position[0].timing.start_time, 2.5);
+  assert.equal(position[0].timing.duration, 0.5);
+  assert.equal(position[0].timing.easing, "smooth");
+
+  assert.equal(result.duration, 3);
+  const wire = JSON.stringify(result.retainedDocument);
+  for (const forbidden of ["glyph", "font_bytes", "svg", "geometry", "atlas"]) {
+    assert.ok(!wire.includes(forbidden), `retained lifecycle wire must not contain ${forbidden}`);
+  }
+  assert.deepEqual(errors, [], `browser errors while testing retained Text lifecycle:\n${errors.join("\n")}`);
+
+  console.log(
+    "Retained Text Scene lifecycle smoke passed: delayed add, remove, re-add, clear, and animate reintroduction share retained Presence state without placeholder geometry.",
+  );
+} finally {
+  await browser?.close();
+  server.kill("SIGTERM");
+}

--- a/web/python/_manim_retained_animate.py
+++ b/web/python/_manim_retained_animate.py
@@ -19,6 +19,8 @@ import _manim_typst as _typst
 
 
 _INSTALLED = False
+_ORIGINAL_SCENE_ADD = _compat.Scene.add
+_ORIGINAL_SCENE_REMOVE = _compat.Scene.remove
 _ORIGINAL_SCENE_PLAY = _compat.Scene.play
 _ORIGINAL_SCENE_IS_PRESENT = _compat.Scene._is_present
 _ORIGINAL_RETAINED_DOCUMENT = _compat.Scene.retained_document
@@ -422,6 +424,189 @@ def _append_presence_track(
     )
 
 
+def _restore_reintroduced_runtime_state(
+    scene: _compat.Scene,
+    *,
+    object_id: int,
+    state: dict[str, Any],
+    start_time: float,
+    duration: float,
+    touched: tuple[str, ...] | list[str] = (),
+) -> None:
+    """Restore transient fade endpoints while a reintroduction animation runs."""
+
+    current_position = copy.deepcopy(state["position"])
+    current_scale = copy.deepcopy(state["scale"])
+    if not math.isclose(float(state["appearance"]), 1.0, abs_tol=1e-15):
+        _append_scalar_track(
+            scene,
+            object_id=object_id,
+            property_name="appearance",
+            current=1.0,
+            target=1.0,
+            start_time=start_time,
+            duration=duration,
+            easing="linear",
+        )
+    if state["runtime_position"] != current_position and "position" not in touched:
+        _append_vec2_track(
+            scene,
+            object_id=object_id,
+            property_name="position",
+            current=current_position,
+            target=current_position,
+            start_time=start_time,
+            duration=duration,
+            easing="linear",
+        )
+    if state["runtime_scale"] != current_scale and "scale" not in touched:
+        _append_vec2_track(
+            scene,
+            object_id=object_id,
+            property_name="scale",
+            current=current_scale,
+            target=current_scale,
+            start_time=start_time,
+            duration=duration,
+            easing="linear",
+        )
+    state["appearance"] = 1.0
+    state["runtime_position"] = copy.deepcopy(current_position)
+    state["runtime_scale"] = copy.deepcopy(current_scale)
+
+
+def _unique_retained_mobjects(
+    mobjects: tuple[object, ...],
+) -> list[_typst._RetainedTextMobject]:
+    retained: list[_typst._RetainedTextMobject] = []
+    identities: set[int] = set()
+    for value in mobjects:
+        if not isinstance(value, _typst._RetainedTextMobject) or id(value) in identities:
+            continue
+        identities.add(id(value))
+        retained.append(value)
+    return retained
+
+
+def _assert_direct_readd_runtime_is_canonical(
+    scene: _compat.Scene,
+    source: _typst._RetainedTextMobject,
+    plan: _lifecycle.LifecyclePlan,
+) -> None:
+    if not plan.show_now or source._scene is not scene or source._retained_object_id is None:
+        return
+    state = scene._retained_animation_state.get(int(source.id))
+    if state is None:
+        return
+    canonical_position = state["position"]
+    canonical_scale = state["scale"]
+    if (
+        not math.isclose(float(state["appearance"]), 1.0, abs_tol=1e-15)
+        or state["runtime_position"] != canonical_position
+        or state["runtime_scale"] != canonical_scale
+    ):
+        raise NotImplementedError(
+            "retained Text Scene.add cannot yet restore a transient FadeOut endpoint; "
+            "reintroduce it with FadeIn or .animate until instant retained state resets "
+            "are represented by the shared core timeline"
+        )
+
+
+def _retained_scene_add(
+    self: _compat.Scene,
+    *mobjects: object,
+    key: str | None = None,
+):
+    retained = _unique_retained_mobjects(mobjects)
+    if not retained:
+        return _ORIGINAL_SCENE_ADD(self, *mobjects, key=key)
+
+    plans = [
+        (
+            value,
+            _resolve_retained_lifecycle(
+                self,
+                value,
+                "add",
+                self._cursor,
+                "Scene.add target",
+            ),
+        )
+        for value in retained
+    ]
+    for value, plan in plans:
+        _assert_direct_readd_runtime_is_canonical(self, value, plan)
+
+    result = _ORIGINAL_SCENE_ADD(self, *mobjects, key=key)
+    _ensure_animation_state(self)
+    for value, plan in plans:
+        object_id = int(value.id)
+        state = self._retained_animation_state.setdefault(
+            object_id, _initial_animation_state(value)
+        )
+        if plan.show_now:
+            state["presence"] = False
+            _append_presence_track(
+                self,
+                object_id=object_id,
+                current=False,
+                target=True,
+                start_time=self._cursor,
+            )
+            state["presence"] = True
+        else:
+            state["presence"] = True
+    return result
+
+
+def _retained_scene_remove(self: _compat.Scene, *mobjects: object) -> _compat.Scene:
+    retained = _unique_retained_mobjects(mobjects)
+    if not retained:
+        return _ORIGINAL_SCENE_REMOVE(self, *mobjects)
+
+    plans = [
+        (
+            value,
+            _resolve_retained_lifecycle(
+                self,
+                value,
+                "remove",
+                self._cursor,
+                "Scene.remove target",
+            ),
+        )
+        for value in retained
+    ]
+    _ensure_animation_state(self)
+    for value, plan in plans:
+        if value._scene is not self or value._retained_object_id is None:
+            continue
+        object_id = int(value.id)
+        state = self._retained_animation_state.setdefault(
+            object_id, _initial_animation_state(value)
+        )
+        if plan.hide_now:
+            _append_presence_track(
+                self,
+                object_id=object_id,
+                current=True,
+                target=False,
+                start_time=self._cursor,
+            )
+            state["presence"] = False
+
+    legacy = tuple(
+        value for value in mobjects if not isinstance(value, _typst._RetainedTextMobject)
+    )
+    if legacy:
+        _ORIGINAL_SCENE_REMOVE(self, *legacy)
+    retained_identities = {id(value) for value in retained}
+    self._compat_top_level = [
+        value for value in self._compat_top_level if id(value) not in retained_identities
+    ]
+    return self
+
+
 def _offset_vec2(
     value: dict[str, float],
     delta: dict[str, float],
@@ -738,42 +923,14 @@ def _schedule_retained_plan(
         raise ValueError(f"unknown retained animation operation {kind!r}")
 
     if reintroducing:
-        if not math.isclose(float(state["appearance"]), 1.0, abs_tol=1e-15):
-            _append_scalar_track(
-                scene,
-                object_id=object_id,
-                property_name="appearance",
-                current=1.0,
-                target=1.0,
-                start_time=start_time,
-                duration=duration,
-                easing="linear",
-            )
-        if state["runtime_position"] != current_position and "position" not in touched:
-            _append_vec2_track(
-                scene,
-                object_id=object_id,
-                property_name="position",
-                current=current_position,
-                target=current_position,
-                start_time=start_time,
-                duration=duration,
-                easing="linear",
-            )
-        if state["runtime_scale"] != current_scale and "scale" not in touched:
-            _append_vec2_track(
-                scene,
-                object_id=object_id,
-                property_name="scale",
-                current=current_scale,
-                target=current_scale,
-                start_time=start_time,
-                duration=duration,
-                easing="linear",
-            )
-        state["appearance"] = 1.0
-        state["runtime_position"] = copy.deepcopy(current_position)
-        state["runtime_scale"] = copy.deepcopy(current_scale)
+        _restore_reintroduced_runtime_state(
+            scene,
+            object_id=object_id,
+            state=state,
+            start_time=start_time,
+            duration=duration,
+            touched=touched,
+        )
 
     for property_name in touched:
         if property_name == "scale":
@@ -965,6 +1122,8 @@ def install() -> None:
     _INSTALLED = True
     _typst._RetainedTextMobject._copy_for_animate_target = _retained_copy_for_animate_target
     _animate._AlignedAnimationBuilder.__getattr__ = _retained_builder_getattr
+    _compat.Scene.add = _retained_scene_add
+    _compat.Scene.remove = _retained_scene_remove
     _compat.Scene._is_present = _retained_scene_is_present
     _compat.Scene.play = _retained_scene_play
     _compat.Scene.retained_document = _retained_document


### PR DESCRIPTION
## Summary

- lower direct retained `Text` / `Typst` `Scene.add` and `Scene.remove` through the same shared Rust lifecycle planner used by legacy geometry and retained animations
- keep resource binding, stable object identity, and painter ordering in the existing retained-text layer while authoring explicit retained `Presence` transitions for delayed add, remove, re-add, and `Scene.clear()`
- keep `scene.mobjects` derived from retained presence state instead of Python-only membership
- extract the existing animated reintroduction restoration into one helper so `.animate` continues to restore canonical state after transient fades without duplicating lifecycle rules
- reject direct `Scene.add` before mutation when a prior `FadeOut` left transient appearance/shift/scale runtime endpoints that cannot yet be represented as an instant reset; Noon core intentionally permits zero-duration tracks only for `Presence`, while `FadeIn` / `.animate` reintroduction remains supported

## Browser validation

Adds an exact Chromium regression for:

`wait` → delayed `add(Text)` → `remove` → re-add → `clear` → `.animate.shift(UP)` reintroduction

The smoke asserts:

- exact `Presence` transitions at 0.5 / 1.0 / 1.5 / 2.0 / 2.5 seconds
- the exact positive-duration `Position` track for the final reintroduction
- `scene.mobjects` membership after every lifecycle operation
- zero legacy placeholder geometry and no glyph/font/SVG/atlas payload leakage

This follows #668 and advances the retained Text lifecycle/API unification tracked by #61 / #89.