### PR TITLE
Support instant timeline property assignments

### DIFF
--- a/crates/noon-core/src/timeline.rs
+++ b/crates/noon-core/src/timeline.rs
@@ -248,6 +248,10 @@ impl TrackTiming {
     pub const fn instant(start_time: f64) -> Self {
         Self::new(start_time, 0.0, RateFunction::Linear)
     }
+
+    pub const fn is_instant(self) -> bool {
+        self.duration == 0.0
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -359,7 +363,7 @@ pub(crate) fn validate_track_timing(
                 duration: timing.duration,
             });
         }
-    } else if timing.duration <= 0.0 {
+    } else if timing.duration < 0.0 {
         return Err(TimelineError::InvalidDuration(timing.duration));
     }
     Ok(())
@@ -379,7 +383,7 @@ pub fn validate_track_definition(track: &TrackDefinition) -> Result<(), Timeline
     track
         .values
         .validate_numeric_values(track.object, track.property)?;
-    if track.property.is_instant() && !track.time_map.is_identity() {
+    if track.timing.is_instant() && !track.time_map.is_identity() {
         return Err(TimelineError::InstantTrackCannotUseTimeMap(track.property));
     }
     track
@@ -668,7 +672,7 @@ mod tests {
     }
 
     #[test]
-    fn presence_rejects_nonzero_duration_and_other_tracks_reject_zero_duration() {
+    fn presence_requires_zero_duration_and_other_tracks_allow_instant_assignments() {
         let mut scene = SceneDefinition::new();
         let object = scene.add(GeometryRef::circle(1.0));
         assert!(matches!(
@@ -686,16 +690,16 @@ mod tests {
                 ..
             })
         ));
-        assert!(matches!(
-            scene.animate_scalar(
+        let track = scene
+            .animate_scalar(
                 object,
                 Property::Opacity,
                 1.0,
                 0.0,
                 TrackTiming::instant(1.0),
-            ),
-            Err(TimelineError::InvalidDuration(0.0))
-        ));
+            )
+            .expect("ordinary properties may be assigned at an exact timestamp");
+        assert_eq!(track, TrackId::new(0));
     }
 
     #[test]
@@ -781,7 +785,7 @@ mod tests {
     fn invalid_timing_is_rejected() {
         let mut scene = SceneDefinition::new();
         let object = scene.add(GeometryRef::circle(1.0));
-        for duration in [0.0, -1.0, f64::NAN, f64::INFINITY] {
+        for duration in [-1.0, f64::NAN, f64::INFINITY] {
             let error = scene
                 .animate_position(
                     object,

--- a/crates/noon-ir/src/mixed.rs
+++ b/crates/noon-ir/src/mixed.rs
@@ -602,7 +602,7 @@ mod tests {
         let scene = scene_with_position_track();
         let object = scene.objects()[0].id;
         let mut track = scene.tracks()[0].clone();
-        track.timing.duration = 0.0;
+        track.timing.duration = -1.0;
         let spec = SceneSpec {
             version: SCENE_SPEC_VERSION,
             objects: vec![ObjectSpec::geometry(object, GeometryRef::circle(1.0))],
@@ -614,7 +614,7 @@ mod tests {
             spec.validate(),
             Err(SceneSpecError::InvalidTrack {
                 track: id,
-                error: TimelineError::InvalidDuration(0.0),
+                error: TimelineError::InvalidDuration(-1.0),
             }) if id == track.id
         ));
 
@@ -623,7 +623,7 @@ mod tests {
             SceneSpec::from_json(&json),
             Err(SceneSpecError::InvalidTrack {
                 track: id,
-                error: TimelineError::InvalidDuration(0.0),
+                error: TimelineError::InvalidDuration(-1.0),
             }) if id == track.id
         ));
     }

--- a/crates/noon-runtime/src/lib.rs
+++ b/crates/noon-runtime/src/lib.rs
@@ -1295,15 +1295,19 @@ fn interpolate_color(from: Color, to: Color, progress: f32) -> Color {
 }
 
 fn track_progress(track: &CompiledTrack, time: f64) -> f32 {
-    debug_assert!(!track.property.is_instant());
+    if track.timing.is_instant() {
+        return 1.0;
+    }
     let raw = ((time - track.timing.start_time) / track.timing.duration).clamp(0.0, 1.0) as f32;
     track.timing.easing.evaluate(raw)
 }
 
 fn mapped_track_progress(track: &CompiledTrack, time: f64) -> Option<f32> {
-    debug_assert!(!track.property.is_instant());
     if time < track.timing.start_time {
         return None;
+    }
+    if track.timing.is_instant() {
+        return Some(1.0);
     }
     let end = track.timing.start_time + track.timing.duration;
     // Scene state is defined after animation finish/cleanup at the exact endpoint.

--- a/crates/noon-runtime/src/reactive/timeline_scheduler.rs
+++ b/crates/noon-runtime/src/reactive/timeline_scheduler.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use noon_compile::{CompiledChannelKey, CompiledScene, CompiledTrack};
-use noon_core::{Property, TrackId};
+use noon_core::TrackId;
 
 use crate::SceneInstance;
 
@@ -191,7 +191,7 @@ impl TimelineEventScheduler {
 
         let mut inserted = 0;
         for track in tracks {
-            if track.property == Property::Presence {
+            if track.timing.is_instant() {
                 inserted +=
                     self.insert_event(group, track.id, track.timing.start_time, EventKind::Instant);
             } else {
@@ -332,7 +332,7 @@ impl TimelineEventScheduler {
         let count = tracks
             .iter()
             .filter(|track| {
-                track.property != Property::Presence
+                !track.timing.is_instant()
                     && track.timing.start_time <= self.time
                     && self.time < track.timing.start_time + track.timing.duration
             })

--- a/crates/noon-runtime/tests/instant_property_assignment.rs
+++ b/crates/noon-runtime/tests/instant_property_assignment.rs
@@ -1,0 +1,360 @@
+use noon_compile::{CompiledScene, RetainedCompiledScene};
+use noon_core::{
+    CompositionTimeMap, CompositionTimeMapStep, GeometryRef, ObjectId, Property, RateFunction,
+    RetainedObjectDefinition, SceneDefinition, TextResourceHandle, TextResourceId, TimelineError,
+    TrackDefinition, TrackId, TrackTiming, TrackValues, Vec2,
+};
+use noon_runtime::{RetainedSceneInstance, SceneInstance};
+
+fn text_handle() -> TextResourceHandle {
+    TextResourceHandle {
+        id: TextResourceId::new(41),
+        version: 7,
+    }
+}
+
+fn track(
+    id: u64,
+    object: ObjectId,
+    property: Property,
+    values: TrackValues,
+    start_time: f64,
+    duration: f64,
+) -> TrackDefinition {
+    TrackDefinition {
+        id: TrackId::new(id),
+        object,
+        property,
+        values,
+        timing: TrackTiming::new(start_time, duration, RateFunction::Linear),
+        time_map: CompositionTimeMap::identity(),
+    }
+}
+
+#[test]
+fn ordinary_properties_accept_exact_instant_assignments() {
+    let mut scene = SceneDefinition::new();
+    let object = scene.add(GeometryRef::circle(1.0));
+
+    scene
+        .add_track(
+            object,
+            Property::Position,
+            TrackValues::Vec2 {
+                from: Vec2::new(4.0, -2.0),
+                to: Vec2::ZERO,
+            },
+            TrackTiming::instant(1.0),
+        )
+        .expect("ordinary property assignments must support an exact timestamp");
+
+    let negative = scene
+        .add_track(
+            object,
+            Property::Scale,
+            TrackValues::Vec2 {
+                from: Vec2::ONE,
+                to: Vec2::ONE,
+            },
+            TrackTiming::new(2.0, -1.0, RateFunction::Linear),
+        )
+        .expect_err("negative-duration assignments must remain invalid");
+    assert!(matches!(negative, TimelineError::InvalidDuration(value) if value == -1.0));
+
+    let mapped_instant = scene
+        .add_track_with_time_map(
+            object,
+            Property::Scale,
+            TrackValues::Vec2 {
+                from: Vec2::new(0.5, 0.5),
+                to: Vec2::ONE,
+            },
+            TrackTiming::instant(2.0),
+            CompositionTimeMap::from_steps(vec![CompositionTimeMapStep::new(
+                0.0,
+                1.0,
+                RateFunction::Linear,
+            )]),
+        )
+        .expect_err("instant assignments cannot carry a composition time map");
+    assert!(matches!(
+        mapped_instant,
+        TimelineError::InstantTrackCannotUseTimeMap(Property::Scale)
+    ));
+
+    let positive_presence = scene
+        .add_track(
+            object,
+            Property::Presence,
+            TrackValues::Bool {
+                from: true,
+                to: false,
+            },
+            TrackTiming::new(3.0, 0.5, RateFunction::Linear),
+        )
+        .expect_err("Presence remains a discrete zero-duration channel");
+    assert!(matches!(
+        positive_presence,
+        TimelineError::InvalidInstantDuration {
+            property: Property::Presence,
+            duration: 0.5,
+        }
+    ));
+}
+
+#[test]
+fn legacy_cleanup_assignments_restore_canonical_state_at_the_hide_boundary() {
+    let mut scene = SceneDefinition::new();
+    let object = scene.add(GeometryRef::circle(1.0));
+    let faded_position = Vec2::new(2.0, -1.0);
+    let faded_scale = Vec2::new(0.5, 0.5);
+
+    scene
+        .animate_position(
+            object,
+            Vec2::ZERO,
+            faded_position,
+            TrackTiming::new(0.0, 1.0, RateFunction::Linear),
+        )
+        .unwrap();
+    scene
+        .animate_scale(
+            object,
+            Vec2::ONE,
+            faded_scale,
+            TrackTiming::new(0.0, 1.0, RateFunction::Linear),
+        )
+        .unwrap();
+    scene
+        .animate_appearance(
+            object,
+            1.0,
+            0.0,
+            TrackTiming::new(0.0, 1.0, RateFunction::Linear),
+        )
+        .unwrap();
+
+    scene
+        .add_track(
+            object,
+            Property::Position,
+            TrackValues::Vec2 {
+                from: faded_position,
+                to: Vec2::ZERO,
+            },
+            TrackTiming::instant(1.0),
+        )
+        .unwrap();
+    scene
+        .add_track(
+            object,
+            Property::Scale,
+            TrackValues::Vec2 {
+                from: faded_scale,
+                to: Vec2::ONE,
+            },
+            TrackTiming::instant(1.0),
+        )
+        .unwrap();
+    scene
+        .add_track(
+            object,
+            Property::Appearance,
+            TrackValues::Scalar { from: 0.0, to: 1.0 },
+            TrackTiming::instant(1.0),
+        )
+        .unwrap();
+    scene.set_presence_at(object, true, false, 1.0).unwrap();
+    scene.set_presence_at(object, false, true, 2.0).unwrap();
+
+    let compiled = CompiledScene::compile(&scene).unwrap();
+    let mut direct = SceneInstance::new(compiled.clone());
+    let mut sequential = SceneInstance::new(compiled);
+
+    let before = direct.seek(0.999).unwrap();
+    assert!(before.objects[0].transform.translation.x > 1.99);
+    assert!(before.objects[0].transform.scale.x < 0.501);
+    assert!(before.appearance(0) < 0.0011);
+    assert!(before.is_present(0));
+
+    let hidden = direct.seek(1.0).unwrap();
+    assert!(!hidden.is_present(0));
+    assert_eq!(hidden.objects[0].transform.translation, Vec2::ZERO);
+    assert_eq!(hidden.objects[0].transform.scale, Vec2::ONE);
+    assert_eq!(hidden.appearance(0), 1.0);
+
+    let shown = direct.seek(2.0).unwrap();
+    assert!(shown.is_present(0));
+    assert_eq!(shown.objects[0].transform.translation, Vec2::ZERO);
+    assert_eq!(shown.objects[0].transform.scale, Vec2::ONE);
+    assert_eq!(shown.appearance(0), 1.0);
+
+    for step in 1..=20 {
+        sequential.advance_to(f64::from(step) * 0.1).unwrap();
+    }
+    assert_eq!(sequential.frame(), direct.frame());
+}
+
+#[test]
+fn retained_text_cleanup_assignments_are_seekable_and_preserve_resource_identity() {
+    let object = ObjectId::new(3);
+    let handle = text_handle();
+    let objects = [RetainedObjectDefinition::text(object, handle)];
+    let faded_position = Vec2::new(-3.0, 1.5);
+    let faded_scale = Vec2::new(0.25, 0.25);
+    let tracks = [
+        track(
+            0,
+            object,
+            Property::Position,
+            TrackValues::Vec2 {
+                from: Vec2::ZERO,
+                to: faded_position,
+            },
+            0.0,
+            1.0,
+        ),
+        track(
+            1,
+            object,
+            Property::Scale,
+            TrackValues::Vec2 {
+                from: Vec2::ONE,
+                to: faded_scale,
+            },
+            0.0,
+            1.0,
+        ),
+        track(
+            2,
+            object,
+            Property::Appearance,
+            TrackValues::Scalar { from: 1.0, to: 0.0 },
+            0.0,
+            1.0,
+        ),
+        track(
+            3,
+            object,
+            Property::Position,
+            TrackValues::Vec2 {
+                from: faded_position,
+                to: Vec2::ZERO,
+            },
+            1.0,
+            0.0,
+        ),
+        track(
+            4,
+            object,
+            Property::Scale,
+            TrackValues::Vec2 {
+                from: faded_scale,
+                to: Vec2::ONE,
+            },
+            1.0,
+            0.0,
+        ),
+        track(
+            5,
+            object,
+            Property::Appearance,
+            TrackValues::Scalar { from: 0.0, to: 1.0 },
+            1.0,
+            0.0,
+        ),
+        track(
+            6,
+            object,
+            Property::Presence,
+            TrackValues::Bool {
+                from: true,
+                to: false,
+            },
+            1.0,
+            0.0,
+        ),
+        track(
+            7,
+            object,
+            Property::Presence,
+            TrackValues::Bool {
+                from: false,
+                to: true,
+            },
+            2.0,
+            0.0,
+        ),
+    ];
+
+    let compiled = RetainedCompiledScene::compile(&objects, &tracks).unwrap();
+    let mut direct = RetainedSceneInstance::new(compiled.clone());
+    let mut sequential = RetainedSceneInstance::new(compiled);
+
+    let hidden = direct.seek(1.0).unwrap();
+    assert!(!hidden.is_present(0));
+    assert_eq!(hidden.objects[0].transform.translation, Vec2::ZERO);
+    assert_eq!(hidden.objects[0].transform.scale, Vec2::ONE);
+    assert_eq!(hidden.appearance(0), 1.0);
+    assert_eq!(hidden.text(0), Some(handle));
+    assert_eq!(hidden.render_geometry(0), None);
+
+    let shown = direct.seek(2.0).unwrap();
+    assert!(shown.is_present(0));
+    assert_eq!(shown.objects[0].transform.translation, Vec2::ZERO);
+    assert_eq!(shown.objects[0].transform.scale, Vec2::ONE);
+    assert_eq!(shown.appearance(0), 1.0);
+    assert_eq!(shown.text(0), Some(handle));
+
+    for step in 1..=20 {
+        sequential.advance_to(f64::from(step) * 0.1).unwrap();
+    }
+    assert_eq!(sequential.frame(), direct.frame());
+}
+
+#[test]
+fn instant_assignment_wins_in_a_channel_that_also_has_a_composition_map() {
+    let mut scene = SceneDefinition::new();
+    let object = scene.add(GeometryRef::circle(1.0));
+
+    scene
+        .add_track_with_time_map(
+            object,
+            Property::Position,
+            TrackValues::Vec2 {
+                from: Vec2::ZERO,
+                to: Vec2::new(4.0, 0.0),
+            },
+            TrackTiming::new(0.0, 2.0, RateFunction::Linear),
+            CompositionTimeMap::from_steps(vec![CompositionTimeMapStep::new(
+                0.0,
+                1.0,
+                RateFunction::Smooth,
+            )]),
+        )
+        .unwrap();
+    scene
+        .add_track(
+            object,
+            Property::Position,
+            TrackValues::Vec2 {
+                from: Vec2::new(4.0, 0.0),
+                to: Vec2::ZERO,
+            },
+            TrackTiming::instant(2.0),
+        )
+        .unwrap();
+
+    let compiled = CompiledScene::compile(&scene).unwrap();
+    let mut direct = SceneInstance::new(compiled.clone());
+    let mut sequential = SceneInstance::new(compiled);
+
+    assert_eq!(
+        direct.seek(2.0).unwrap().objects[0].transform.translation,
+        Vec2::ZERO
+    );
+    for step in 1..=20 {
+        sequential.advance_to(f64::from(step) * 0.1).unwrap();
+    }
+    assert_eq!(sequential.frame(), direct.frame());
+}


### PR DESCRIPTION
## Summary

- allow ordinary timeline properties to use `duration == 0` as exact timestamp assignments while continuing to reject negative and non-finite durations
- keep `Presence` as the property that requires zero duration, and reject composition time maps on any zero-duration track
- classify every zero-duration track as an instant scheduler event so it never enters active-group accounting
- evaluate ordinary instant assignments as their exact `to` value in both normal and composition-mapped channels through the shared runtime evaluator
- preserve the existing per-property channel model; no Presence-coupled reset, cross-channel reset event, epsilon-duration track, or step-function workaround
- update the canonical mixed-IR validation regression to use a genuinely invalid negative duration under the new shared contract

## Validation

Exact head `a406b011e86d2ed4cb063d6b9315d20bd79d1dfa` already passed the complete required matrix unchanged: CI, Test coverage, Manim differential, Manim API coverage, Playground cross-browser, Platform/release validation, and Manim raster differential including direct-seek/incremental-playback equivalence.

This PR replaces draft wrapper #683 because the connected GitHub ready-for-review mutation currently fails on an upstream GraphQL field mismatch; no commit or tree content changed.

Closes #682. Related: #680, #668.