### PR TITLE
Restore retained Text after FadeOut cleanup

### DIFF
--- a/scripts/retained-text-animation-smoke.mjs
+++ b/scripts/retained-text-animation-smoke.mjs
@@ -91,6 +91,8 @@ class RetainedFade(Scene):
         assert label not in self.mobjects
 
         self.wait(0.5)
+        self.add(label)
+        assert label in self.mobjects
         self.play(label.animate.shift(UP), run_time=1.0)
         assert label in self.mobjects
 `;
@@ -288,10 +290,10 @@ try {
   assert.equal(fadeAppearance[1].timing.duration, 1);
   assert.equal(fadeAppearance[1].timing.easing, "smooth");
 
-  assertNear(fadeAppearance[2].values.scalar.from, 1, "reintroduced appearance source");
-  assertNear(fadeAppearance[2].values.scalar.to, 1, "reintroduced appearance target");
-  assert.equal(fadeAppearance[2].timing.start_time, 3);
-  assert.equal(fadeAppearance[2].timing.duration, 1);
+  assertNear(fadeAppearance[2].values.scalar.from, 0, "FadeOut cleanup appearance source");
+  assertNear(fadeAppearance[2].values.scalar.to, 1, "FadeOut cleanup appearance target");
+  assert.equal(fadeAppearance[2].timing.start_time, 2.5);
+  assert.equal(fadeAppearance[2].timing.duration, 0);
   assert.equal(fadeAppearance[2].timing.easing, "linear");
 
   assert.deepEqual(fadePosition[0].values.vec2, {
@@ -310,13 +312,22 @@ try {
   assert.equal(fadePosition[1].timing.duration, 1);
   assert.equal(fadePosition[1].timing.easing, "smooth");
 
+  assert.equal(fadePosition.length, 4);
   assert.deepEqual(fadePosition[2].values.vec2, {
+    from: { x: 1, y: 0 },
+    to: { x: -1, y: 0 },
+  });
+  assert.equal(fadePosition[2].timing.start_time, 2.5);
+  assert.equal(fadePosition[2].timing.duration, 0);
+  assert.equal(fadePosition[2].timing.easing, "linear");
+
+  assert.deepEqual(fadePosition[3].values.vec2, {
     from: { x: -1, y: 0 },
     to: { x: -1, y: 1 },
   });
-  assert.equal(fadePosition[2].timing.start_time, 3);
-  assert.equal(fadePosition[2].timing.duration, 1);
-  assert.equal(fadePosition[2].timing.easing, "smooth");
+  assert.equal(fadePosition[3].timing.start_time, 3);
+  assert.equal(fadePosition[3].timing.duration, 1);
+  assert.equal(fadePosition[3].timing.easing, "smooth");
 
   assert.deepEqual(fadeScale[0].values.vec2, {
     from: { x: 0.5, y: 0.5 },
@@ -335,11 +346,11 @@ try {
   assert.equal(fadeScale[1].timing.easing, "smooth");
 
   assert.deepEqual(fadeScale[2].values.vec2, {
-    from: { x: 1, y: 1 },
+    from: { x: 1.5, y: 1.5 },
     to: { x: 1, y: 1 },
   });
-  assert.equal(fadeScale[2].timing.start_time, 3);
-  assert.equal(fadeScale[2].timing.duration, 1);
+  assert.equal(fadeScale[2].timing.start_time, 2.5);
+  assert.equal(fadeScale[2].timing.duration, 0);
   assert.equal(fadeScale[2].timing.easing, "linear");
 
   assert.equal(fadeResult.duration, 4);
@@ -353,7 +364,7 @@ try {
   assert.deepEqual(errors, [], `browser errors while testing retained Text animation:\n${errors.join("\n")}`);
 
   console.log(
-    "Retained Text animation smoke passed: scale, position, rotation, opacity, and FadeIn/FadeOut lower to source-level retained tracks; lifecycle transitions use retained presence/appearance channels; fade shift/scale endpoints stay transient; reintroduction restores canonical state; and unsupported retained properties fail without legacy geometry.",
+    "Retained Text animation smoke passed: scale, position, rotation, opacity, and FadeIn/FadeOut lower to source-level retained tracks; FadeOut cleanup restores canonical appearance/position/scale at the removal timestamp; direct Scene.add reintroduces canonical state with Presence only; and unsupported retained properties fail without legacy geometry.",
   );
 } finally {
   await browser?.close();

--- a/web/python/_manim_retained_animate.py
+++ b/web/python/_manim_retained_animate.py
@@ -488,30 +488,6 @@ def _unique_retained_mobjects(
     return retained
 
 
-def _assert_direct_readd_runtime_is_canonical(
-    scene: _compat.Scene,
-    source: _typst._RetainedTextMobject,
-    plan: _lifecycle.LifecyclePlan,
-) -> None:
-    if not plan.show_now or source._scene is not scene or source._retained_object_id is None:
-        return
-    state = scene._retained_animation_state.get(int(source.id))
-    if state is None:
-        return
-    canonical_position = state["position"]
-    canonical_scale = state["scale"]
-    if (
-        not math.isclose(float(state["appearance"]), 1.0, abs_tol=1e-15)
-        or state["runtime_position"] != canonical_position
-        or state["runtime_scale"] != canonical_scale
-    ):
-        raise NotImplementedError(
-            "retained Text Scene.add cannot yet restore a transient FadeOut endpoint; "
-            "reintroduce it with FadeIn or .animate until instant retained state resets "
-            "are represented by the shared core timeline"
-        )
-
-
 def _retained_scene_add(
     self: _compat.Scene,
     *mobjects: object,
@@ -534,9 +510,6 @@ def _retained_scene_add(
         )
         for value in retained
     ]
-    for value, plan in plans:
-        _assert_direct_readd_runtime_is_canonical(self, value, plan)
-
     result = _ORIGINAL_SCENE_ADD(self, *mobjects, key=key)
     _ensure_animation_state(self)
     for value, plan in plans:
@@ -762,18 +735,55 @@ def _schedule_retained_fade(
         duration=duration,
         easing=easing,
     )
+    end_time = start_time + duration
     if lifecycle.hide_at_end:
         _append_presence_track(
             scene,
             object_id=object_id,
             current=True,
             target=False,
-            start_time=start_time + duration,
+            start_time=end_time,
         )
         state["presence"] = False
-    state["appearance"] = 0.0
-    state["runtime_position"] = copy.deepcopy(faded_position)
-    state["runtime_scale"] = copy.deepcopy(faded_scale)
+
+    # Manim FadeOut cleanup removes the object, then restores interpolation alpha 0.
+    # Keep that restoration in the ordinary property channels so direct seek and
+    # later Scene.add observe canonical state without Python-only repair state.
+    _append_scalar_track(
+        scene,
+        object_id=object_id,
+        property_name="appearance",
+        current=0.0,
+        target=1.0,
+        start_time=end_time,
+        duration=0.0,
+        easing="linear",
+    )
+    if faded_position != canonical_position:
+        _append_vec2_track(
+            scene,
+            object_id=object_id,
+            property_name="position",
+            current=faded_position,
+            target=canonical_position,
+            start_time=end_time,
+            duration=0.0,
+            easing="linear",
+        )
+    if faded_scale != canonical_scale:
+        _append_vec2_track(
+            scene,
+            object_id=object_id,
+            property_name="scale",
+            current=faded_scale,
+            target=canonical_scale,
+            start_time=end_time,
+            duration=0.0,
+            easing="linear",
+        )
+    state["appearance"] = 1.0
+    state["runtime_position"] = copy.deepcopy(canonical_position)
+    state["runtime_scale"] = copy.deepcopy(canonical_scale)
 
 
 def _schedule_retained_plan(


### PR DESCRIPTION
## Summary

- restore retained Text Appearance, Position, and Scale to canonical values at the exact `FadeOut` end timestamp using the shared zero-duration property-assignment primitive from #686
- keep Presence independently false after removal, matching Manim cleanup without coupling visibility to presentation-state reset
- remove the temporary direct-`Scene.add` rejection introduced in #680
- make direct `Scene.add(text)` after shifted/scaled `FadeOut` reintroduce the canonical retained object through Presence only
- preserve the retained Text resource/object identity and avoid legacy geometry or Python-only runtime repair state

## Semantics

Pinned ManimCE 0.21 `FadeOut.clean_up_from_scene()` removes the target and then restores interpolation alpha 0. Noon now represents that cleanup explicitly in the ordinary retained property channels at the same timestamp as the Presence hide:

- Appearance `0 -> 1`, duration 0
- shifted Position `faded -> canonical`, duration 0 when needed
- scaled Scale `faded -> canonical`, duration 0 when needed
- Presence remains `true -> false`, duration 0

A later direct `Scene.add()` only emits Presence `false -> true`; the object is already canonical in the shared timeline.

## Validation

The exact two-file implementation passed an assertion-guarded remote validation run on top of #686's exact core tree:

- full `scripts/build-web-demo.sh`
- real Chromium `scripts/retained-text-animation-smoke.mjs`
- exact retained source transform remains canonical
- no legacy placeholder geometry
- exact cleanup tracks occur at the FadeOut removal timestamp
- direct `Scene.add()` reintroduces the same retained Text object before a subsequent `.animate.shift(UP)`

This PR is a clean one-commit replay of those validated blobs directly onto merged master.

Follows #686. Resolves the direct FadeOut re-add limitation documented in #680 and #668.