### PR TITLE
Support retained Text family identity

### DIFF
--- a/.github/workflows/retained-text-animation.yml
+++ b/.github/workflows/retained-text-animation.yml
@@ -3,6 +3,7 @@ name: Retained text animation
 on:
   pull_request:
     paths:
+      - "crates/noon-web/src/authoring_mobject.rs"
       - "crates/noon-web/src/retained_authoring_player.rs"
       - "crates/noon-web/src/retained_authoring_scene.rs"
       - "crates/noon-web/src/retained_authoring_tracks.rs"
@@ -12,15 +13,18 @@ on:
       - "web/python/_manim_animate.py"
       - "web/python/_manim_animation_options.py"
       - "web/python/_manim_retained_animate.py"
+      - "web/python/_manim_semantic_handles.py"
       - "web/python/_manim_typst.py"
       - "scripts/build-python-worker.mjs"
       - "scripts/retained-text-animation-smoke.mjs"
+      - "scripts/retained-text-family-identity-smoke.mjs"
       - "scripts/retained-text-scene-lifecycle-smoke.mjs"
       - ".github/workflows/retained-text-animation.yml"
   push:
     branches:
       - master
     paths:
+      - "crates/noon-web/src/authoring_mobject.rs"
       - "crates/noon-web/src/retained_authoring_player.rs"
       - "crates/noon-web/src/retained_authoring_scene.rs"
       - "crates/noon-web/src/retained_authoring_tracks.rs"
@@ -30,9 +34,11 @@ on:
       - "web/python/_manim_animate.py"
       - "web/python/_manim_animation_options.py"
       - "web/python/_manim_retained_animate.py"
+      - "web/python/_manim_semantic_handles.py"
       - "web/python/_manim_typst.py"
       - "scripts/build-python-worker.mjs"
       - "scripts/retained-text-animation-smoke.mjs"
+      - "scripts/retained-text-family-identity-smoke.mjs"
       - "scripts/retained-text-scene-lifecycle-smoke.mjs"
       - ".github/workflows/retained-text-animation.yml"
   workflow_dispatch:
@@ -100,6 +106,9 @@ jobs:
 
       - name: Test retained Text animation authoring
         run: node scripts/retained-text-animation-smoke.mjs
+
+      - name: Test retained Text family identity
+        run: node scripts/retained-text-family-identity-smoke.mjs
 
       - name: Test retained Text Scene lifecycle
         run: node scripts/retained-text-scene-lifecycle-smoke.mjs

--- a/crates/noon-web/src/authoring_mobject.rs
+++ b/crates/noon-web/src/authoring_mobject.rs
@@ -1495,6 +1495,14 @@ mod wasm {
         semantics: SharedSemanticStore,
     }
 
+    /// Content-agnostic semantic identity for authoring objects whose mutable
+    /// presentation state is owned by another retained/resource-specific handle.
+    #[wasm_bindgen]
+    pub struct WasmAuthoringFamilyMemberHandle {
+        semantics: SharedSemanticStore,
+        id: SemanticNodeId,
+    }
+
     impl WasmAuthoringStore {
         fn attach_handle(&self, handle: FrontendMobjectHandle) -> WasmAuthoringMobjectHandle {
             let id = self.semantics.borrow_mut().insert_authoring_object();
@@ -1564,6 +1572,16 @@ mod wasm {
                 .map_err(js_error)
         }
 
+        /// Allocate stable semantic identity for a non-geometry authoring object.
+        #[wasm_bindgen(js_name = createFamilyMember)]
+        pub fn create_family_member(&self) -> WasmAuthoringFamilyMemberHandle {
+            let id = self.semantics.borrow_mut().insert_authoring_object();
+            WasmAuthoringFamilyMemberHandle {
+                semantics: Rc::clone(&self.semantics),
+                id,
+            }
+        }
+
         #[wasm_bindgen(js_name = createFamily)]
         pub fn create_family(&self) -> WasmAuthoringFamilyHandle {
             let id = self.semantics.borrow_mut().insert_family();
@@ -1571,6 +1589,19 @@ mod wasm {
                 semantics: Rc::clone(&self.semantics),
                 id,
             }
+        }
+    }
+
+    #[wasm_bindgen]
+    impl WasmAuthoringFamilyMemberHandle {
+        #[wasm_bindgen(getter, js_name = semanticSlot)]
+        pub fn semantic_slot(&self) -> u32 {
+            self.id.slot()
+        }
+
+        #[wasm_bindgen(getter, js_name = semanticGeneration)]
+        pub fn semantic_generation(&self) -> u32 {
+            self.id.generation()
         }
     }
 
@@ -2142,6 +2173,18 @@ mod wasm {
                 .ok_or_else(|| JsValue::from_str("mobject has no semantic identity"))
         }
 
+        fn identity_member_id(
+            &self,
+            member: &WasmAuthoringFamilyMemberHandle,
+        ) -> Result<SemanticNodeId, JsValue> {
+            if !Rc::ptr_eq(&self.semantics, &member.semantics) {
+                return Err(JsValue::from_str(
+                    "family target editor and member belong to different authoring stores",
+                ));
+            }
+            Ok(member.id)
+        }
+
         fn family_member_id(
             &self,
             member: &WasmAuthoringFamilyHandle,
@@ -2165,6 +2208,19 @@ mod wasm {
         ) -> Result<(), JsValue> {
             let source_id = self.mobject_member_id(source)?;
             let target_id = self.mobject_member_id(target)?;
+            self.editor
+                .accept_member(&mut self.semantics.borrow_mut(), source_id, target_id)
+                .map_err(js_error)
+        }
+
+        #[wasm_bindgen(js_name = acceptMember)]
+        pub fn accept_member_identity(
+            &mut self,
+            source: &WasmAuthoringFamilyMemberHandle,
+            target: &WasmAuthoringFamilyMemberHandle,
+        ) -> Result<(), JsValue> {
+            let source_id = self.identity_member_id(source)?;
+            let target_id = self.identity_member_id(target)?;
             self.editor
                 .accept_member(&mut self.semantics.borrow_mut(), source_id, target_id)
                 .map_err(js_error)
@@ -2208,6 +2264,18 @@ mod wasm {
             member
                 .2
                 .ok_or_else(|| JsValue::from_str("mobject has no semantic identity"))
+        }
+
+        fn identity_member_id(
+            &self,
+            member: &WasmAuthoringFamilyMemberHandle,
+        ) -> Result<SemanticNodeId, JsValue> {
+            if !Rc::ptr_eq(&self.semantics, &member.semantics) {
+                return Err(JsValue::from_str(
+                    "family and member belong to different authoring stores",
+                ));
+            }
+            Ok(member.id)
         }
 
         fn family_member_id(
@@ -2363,6 +2431,15 @@ mod wasm {
             self.add_id(id)
         }
 
+        #[wasm_bindgen(js_name = addMember)]
+        pub fn add_member_identity(
+            &mut self,
+            member: &WasmAuthoringFamilyMemberHandle,
+        ) -> Result<bool, JsValue> {
+            let id = self.identity_member_id(member)?;
+            self.add_id(id)
+        }
+
         #[wasm_bindgen(js_name = addFamily)]
         pub fn add_family(&mut self, member: &WasmAuthoringFamilyHandle) -> Result<bool, JsValue> {
             let id = self.family_member_id(member)?;
@@ -2375,6 +2452,15 @@ mod wasm {
             member: &WasmAuthoringMobjectHandle,
         ) -> Result<bool, JsValue> {
             let id = self.object_member_id(member)?;
+            self.remove_id(id)
+        }
+
+        #[wasm_bindgen(js_name = removeMember)]
+        pub fn remove_member_identity(
+            &mut self,
+            member: &WasmAuthoringFamilyMemberHandle,
+        ) -> Result<bool, JsValue> {
+            let id = self.identity_member_id(member)?;
             self.remove_id(id)
         }
 

--- a/scripts/retained-text-family-identity-smoke.mjs
+++ b/scripts/retained-text-family-identity-smoke.mjs
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import playwright from "playwright";
+
+const { chromium } = playwright;
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const port = 4193;
+const baseUrl = `http://127.0.0.1:${port}`;
+
+let serverOutput = "";
+const server = spawn(
+  "python3",
+  ["-m", "http.server", String(port), "--bind", "127.0.0.1", "--directory", repoRoot],
+  { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] },
+);
+server.stdout.on("data", (chunk) => (serverOutput += chunk));
+server.stderr.on("data", (chunk) => (serverOutput += chunk));
+
+async function waitForServer() {
+  let lastError = null;
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    try {
+      const response = await fetch(`${baseUrl}/web/manim-compat-smoke.html`);
+      if (response.ok) return;
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`retained family identity smoke server did not start: ${lastError}\n${serverOutput}`);
+}
+
+const source = `
+from noon import *
+
+class RetainedFamilyIdentity(Scene):
+    def construct(self):
+        first = Text("Family A", font_size=40)
+        second = Text("Family B", font_size=40)
+        nested = VGroup(first, VGroup(second))
+
+        assert len(nested) == 2
+        assert nested[0] is first
+        assert len(nested[1]) == 1
+        assert nested[1][0] is second
+
+        clone = nested.copy()
+        assert len(clone) == 2
+        assert clone is not nested
+        assert clone[0] is not first
+        assert clone[1] is not nested[1]
+        assert clone[1][0] is not second
+
+        holder = VGroup(first)
+        holder.remove(first)
+        assert len(holder) == 0
+        holder.add(first)
+        assert len(holder) == 1
+        assert holder[0] is first
+`;
+
+let browser = null;
+try {
+  await waitForServer();
+  browser = await chromium.launch({
+    channel: "chromium",
+    headless: true,
+    args: ["--disable-dev-shm-usage"],
+  });
+  const page = await browser.newPage();
+  const errors = [];
+  page.on("pageerror", (error) => errors.push(`pageerror: ${error}`));
+  page.on("console", (message) => {
+    if (message.type() === "error") errors.push(`console: ${message.text()}`);
+  });
+
+  await page.goto(`${baseUrl}/web/manim-compat-smoke.html`, { waitUntil: "load" });
+  await page.waitForFunction(() => window.noonManimCompat, null, { timeout: 30_000 });
+  await page.evaluate(() => window.noonManimCompat.ready());
+
+  const result = await page.evaluate((python) => window.noonManimCompat.run(python), source);
+  assert.equal(result.kind, "scene_document");
+  assert.equal(
+    result.document.objects.length,
+    0,
+    "detached retained family identity must not synthesize legacy geometry",
+  );
+  assert.deepEqual(
+    errors,
+    [],
+    `browser errors while testing retained Text family identity:\n${errors.join("\n")}`,
+  );
+  console.log(
+    "Retained Text family identity smoke passed: nested VGroup construction, copy, remove, and re-add use shared semantic membership without legacy geometry.",
+  );
+} finally {
+  await browser?.close();
+  server.kill("SIGTERM");
+}

--- a/web/python-worker.source.js
+++ b/web/python-worker.source.js
@@ -73,6 +73,8 @@ async function initializePyodide() {
   self.noonCreateAuthoringLineHandle = (startX, startY, endX, endY) =>
     authoringStore.createManimLine(startX, startY, endX, endY);
   self.noonCreateAuthoringFamilyHandle = () => authoringStore.createFamily();
+  self.noonCreateAuthoringFamilyMemberHandle = () =>
+    authoringStore.createFamilyMember();
   self.noonCreateRetainedNativeTextHandle = (source, fontFamily, fontSize, lineSpacing) =>
     new RetainedNativeTextAuthoringHandle(source, fontFamily, fontSize, lineSpacing);
   self.noonCreateRetainedTypstHandle = (source, math, fontSize) =>

--- a/web/python/_manim_semantic_handles.py
+++ b/web/python/_manim_semantic_handles.py
@@ -1405,6 +1405,9 @@ def _family_member_handle(value: object) -> tuple[str | None, object | None]:
     if isinstance(value, _compat.Group):
         return "family", getattr(value, "_semantic_family_handle", None)
     if isinstance(value, _base.Mobject):
+        retained_identity = getattr(value, "_semantic_family_member_handle", None)
+        if retained_identity is not None:
+            return "member", retained_identity
         # Family identity survives scene binding even though ordinary detached-state
         # mutations stop using this handle after binding.
         return "mobject", getattr(value, "_semantic_handle", None)
@@ -1417,6 +1420,8 @@ def _family_add_handle(family_handle: object, value: object) -> bool:
         raise RuntimeError("family member has no shared semantic identity")
     if kind == "family":
         return bool(family_handle.addFamily(handle))
+    if kind == "member":
+        return bool(family_handle.addMember(handle))
     return bool(family_handle.addMobject(handle))
 
 
@@ -1426,6 +1431,8 @@ def _family_remove_handle(family_handle: object, value: object) -> bool:
         raise RuntimeError("family member has no shared semantic identity")
     if kind == "family":
         return bool(family_handle.removeFamily(handle))
+    if kind == "member":
+        return bool(family_handle.removeMember(handle))
     return bool(family_handle.removeMobject(handle))
 
 
@@ -1466,6 +1473,8 @@ def _family_target_accept(editor: object, source: object, target: object) -> Non
         raise RuntimeError("Group target wrapper mirror diverged from shared family membership")
     if source_kind == "family":
         editor.acceptFamily(source_handle, target_handle)
+    elif source_kind == "member":
+        editor.acceptMember(source_handle, target_handle)
     elif source_kind == "mobject":
         editor.acceptMobject(source_handle, target_handle)
     else:

--- a/web/python/_manim_typst.py
+++ b/web/python/_manim_typst.py
@@ -22,6 +22,11 @@ except ImportError:  # Native CPython tests use the source-level fallbacks below
     _create_native_text_handle = None
     _create_typst_handle = None
 
+try:
+    from js import noonCreateAuthoringFamilyMemberHandle as _create_family_member_handle
+except ImportError:  # Shared semantic handles are browser-only.
+    _create_family_member_handle = None
+
 
 # Reserve the upper half of JavaScript's exact-integer range for retained text IDs.
 # Legacy geometry IDs start at zero and no practical scene can approach 2^52 objects.
@@ -178,6 +183,11 @@ class _RetainedTextMobject(_base.Mobject):
         self._source = source
         self._font_size = float(font_size)
         self._retained_handle = handle
+        self._semantic_family_member_handle = (
+            None
+            if _create_family_member_handle is None
+            else _create_family_member_handle()
+        )
         self.set_color(_as_color(color))
         self.set_opacity(opacity)
 


### PR DESCRIPTION
## Summary
- give retained Text/Typst objects a content-agnostic semantic identity in the existing shared Rust `SemanticStore`
- let Group/VGroup membership, removal, and target-copy accept that identity without synthesizing legacy geometry or merging retained text state into geometry handles
- keep the retained resource handle authoritative for text presentation while the shared family-member handle owns only family identity/membership
- add a focused Chromium regression for nested `VGroup(Text(...))` construction, copy, remove, and re-add
- make the retained-text workflow watch the shared authoring/family-handle files that this path depends on

## Architecture
This extends the existing #61 `group-family` ownership model rather than introducing a Python fallback. Rust still owns stable family identity, direct-member order, duplicate suppression, and target-family membership through `SemanticStore`; Python mirrors only host-language wrapper identity.

The new identity-only handle intentionally exposes no layout or mutation surface. Retained text transforms/layout remain owned by their resource-specific retained handle until generic retained family layout semantics are shared.

## Validation
Validated on current master `505796bed88fc0c10e88638174d60fbd299c11e4` before replaying this exact one-commit tree:
- full Rust/WASM + web package build
- semantic ownership inventory gate: 39 operations, 24 shared-rust, unchanged debt budgets
- retained Text family identity Chromium smoke
- existing retained Text animation Chromium smoke
- existing retained Text Scene lifecycle Chromium smoke

This is the prerequisite for default retained `FadeIn/FadeOut(Group/VGroup(Text...))`; that consumer remains a separate follow-up PR.