### PR TITLE
Support retained Text family fades

### DIFF
--- a/.github/workflows/retained-text-animation.yml
+++ b/.github/workflows/retained-text-animation.yml
@@ -19,6 +19,7 @@ on:
       - "scripts/build-python-worker.mjs"
       - "scripts/retained-text-animation-smoke.mjs"
       - "scripts/retained-text-family-identity-smoke.mjs"
+      - "scripts/retained-text-family-fade-smoke.mjs"
       - "scripts/retained-text-playback-smoke.mjs"
       - "scripts/retained-text-scene-lifecycle-smoke.mjs"
       - ".github/workflows/retained-text-animation.yml"
@@ -42,6 +43,7 @@ on:
       - "scripts/build-python-worker.mjs"
       - "scripts/retained-text-animation-smoke.mjs"
       - "scripts/retained-text-family-identity-smoke.mjs"
+      - "scripts/retained-text-family-fade-smoke.mjs"
       - "scripts/retained-text-playback-smoke.mjs"
       - "scripts/retained-text-scene-lifecycle-smoke.mjs"
       - ".github/workflows/retained-text-animation.yml"
@@ -113,6 +115,9 @@ jobs:
 
       - name: Test retained Text family identity
         run: node scripts/retained-text-family-identity-smoke.mjs
+
+      - name: Test retained Text family fades
+        run: node scripts/retained-text-family-fade-smoke.mjs
 
       - name: Test retained Text animation playback
         run: node scripts/retained-text-playback-smoke.mjs

--- a/scripts/retained-text-family-fade-smoke.mjs
+++ b/scripts/retained-text-family-fade-smoke.mjs
@@ -1,0 +1,169 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import playwright from "playwright";
+
+const { chromium } = playwright;
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const port = 4193;
+const baseUrl = `http://127.0.0.1:${port}`;
+
+let serverOutput = "";
+const server = spawn(
+  "python3",
+  ["-m", "http.server", String(port), "--bind", "127.0.0.1", "--directory", repoRoot],
+  { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] },
+);
+server.stdout.on("data", (chunk) => (serverOutput += chunk));
+server.stderr.on("data", (chunk) => (serverOutput += chunk));
+
+async function waitForServer() {
+  let lastError = null;
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    try {
+      const response = await fetch(`${baseUrl}/web/manim-compat-smoke.html`);
+      if (response.ok) return;
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`retained family fade smoke server did not start: ${lastError}\n${serverOutput}`);
+}
+
+const source = `
+from noon import *
+
+class RetainedFamilyFade(Scene):
+    def construct(self):
+        first = Text("Family A", font_size=40).shift(LEFT)
+        second = Text("Family B", font_size=40).shift(RIGHT)
+        family = VGroup(first, VGroup(second))
+
+        mirror = family.copy()
+        assert len(mirror) == 2
+
+        detached = Text("Detached", font_size=32)
+        holder = VGroup(detached)
+        holder.remove(detached)
+        holder.add(detached)
+
+        self.wait(0.25)
+        assert family not in self.mobjects
+
+        self.play(FadeIn(family), run_time=0.75, rate_func=linear)
+        assert family in self.mobjects
+        assert first not in self.mobjects
+        assert second not in self.mobjects
+
+        self.play(FadeOut(family), run_time=0.5)
+        assert family not in self.mobjects
+        assert first not in self.mobjects
+        assert second not in self.mobjects
+
+        unsupported = VGroup(
+            Text("Unsupported A", font_size=32),
+            Text("Unsupported B", font_size=32),
+        )
+        try:
+            self.play(FadeIn(unsupported, shift=UP), run_time=0.25)
+            raise AssertionError("shifted retained family FadeIn must fail")
+        except NotImplementedError as error:
+            assert "shared retained family layout semantics" in str(error)
+        assert unsupported not in self.mobjects
+`;
+
+let browser = null;
+try {
+  await waitForServer();
+  browser = await chromium.launch({
+    channel: "chromium",
+    headless: true,
+    args: ["--disable-dev-shm-usage"],
+  });
+  const page = await browser.newPage();
+  const errors = [];
+  page.on("pageerror", (error) => errors.push(`pageerror: ${error}`));
+  page.on("console", (message) => {
+    if (message.type() === "error") errors.push(`console: ${message.text()}`);
+  });
+
+  await page.goto(`${baseUrl}/web/manim-compat-smoke.html`, { waitUntil: "load" });
+  await page.waitForFunction(() => window.noonManimCompat, null, { timeout: 30_000 });
+  await page.evaluate(() => window.noonManimCompat.ready());
+
+  const result = await page.evaluate((python) => window.noonManimCompat.run(python), source);
+  assert.equal(result.kind, "scene_document");
+  assert.equal(
+    result.document.objects.length,
+    0,
+    "retained Text family fades must not create legacy placeholder geometry",
+  );
+  assert.ok(result.retainedDocument, "family fade must emit retained authoring state");
+  assert.deepEqual(
+    result.retainedDocument.objects.map((object) => object.text.source),
+    ["Family A", "Family B"],
+  );
+
+  const tracks = result.retainedDocument.tracks ?? [];
+  assert.equal(
+    tracks.filter((track) => track.property === "position").length,
+    0,
+    "default family fades must not synthesize position tracks",
+  );
+  assert.equal(
+    tracks.filter((track) => track.property === "scale").length,
+    0,
+    "default family fades must not synthesize scale tracks",
+  );
+
+  for (const object of result.retainedDocument.objects) {
+    const objectTracks = tracks.filter((track) => track.object === object.object);
+    const presence = objectTracks.filter((track) => track.property === "presence");
+    const appearance = objectTracks.filter((track) => track.property === "appearance");
+    assert.deepEqual(
+      presence.map((track) => ({
+        values: track.values.bool,
+        start: track.timing.start_time,
+        duration: track.timing.duration,
+        easing: track.timing.easing,
+      })),
+      [
+        { values: { from: false, to: true }, start: 0.25, duration: 0, easing: "linear" },
+        { values: { from: true, to: false }, start: 1.5, duration: 0, easing: "linear" },
+      ],
+      `${object.text.source} must use leaf Presence lifecycle`,
+    );
+    assert.deepEqual(
+      appearance.map((track) => ({
+        values: track.values.scalar,
+        start: track.timing.start_time,
+        duration: track.timing.duration,
+        easing: track.timing.easing,
+      })),
+      [
+        { values: { from: 0, to: 1 }, start: 0.25, duration: 0.75, easing: "linear" },
+        { values: { from: 1, to: 0 }, start: 1, duration: 0.5, easing: "smooth" },
+        { values: { from: 0, to: 1 }, start: 1.5, duration: 0, easing: "linear" },
+      ],
+      `${object.text.source} must use leaf Appearance fade plus cleanup`,
+    );
+  }
+
+  assert.equal(result.duration, 1.5);
+  const wire = JSON.stringify(result.retainedDocument);
+  for (const forbidden of ["glyph", "font_bytes", "svg", "geometry", "atlas"]) {
+    assert.ok(!wire.includes(forbidden), `retained family fade wire must not contain ${forbidden}`);
+  }
+  assert.deepEqual(errors, [], `browser errors while testing retained family fades:\n${errors.join("\n")}`);
+  console.log(
+    "Retained Text family fade smoke passed: nested VGroup identity is shared, default FadeIn/FadeOut lower to leaf Presence/Appearance tracks, wrapper identity stays top-level, and unsupported family layout endpoints fail before mutation.",
+  );
+} finally {
+  await browser?.close();
+  server.kill("SIGTERM");
+}

--- a/web/python/_manim_retained_animate.py
+++ b/web/python/_manim_retained_animate.py
@@ -252,6 +252,82 @@ def _retained_animation_plan(animation: object) -> list[dict[str, Any]] | None:
     return copy.deepcopy(operations)
 
 
+def _retained_family_fade_expansion(
+    animation: object,
+) -> tuple[_compat.Group, list[_typst._RetainedTextMobject], list[object]] | None:
+    """Expand one default retained family fade through the shared leaf traversal."""
+
+    if not isinstance(animation, (_animate.FadeIn, _animate.FadeOut)):
+        return None
+    target = getattr(animation, "target", None)
+    if not isinstance(target, _compat.Group):
+        return None
+
+    leaves = _compat._leaf_mobjects(target)
+    retained = [
+        member for member in leaves if isinstance(member, _typst._RetainedTextMobject)
+    ]
+    if not retained:
+        return None
+    if len(retained) != len(leaves):
+        raise NotImplementedError(
+            "mixing retained Text and legacy Mobjects in one Group/VGroup fade is not supported"
+        )
+
+    shift = _compat._as_vec2(animation._fade_shift_vector)
+    scale_factor = float(animation._fade_scale_factor)
+    if not math.isfinite(scale_factor):
+        raise ValueError("retained text family fade scale must be finite")
+    default_endpoint = (
+        math.isclose(float(shift.x), 0.0, abs_tol=1e-15)
+        and math.isclose(float(shift.y), 0.0, abs_tol=1e-15)
+        and math.isclose(scale_factor, 1.0, rel_tol=0.0, abs_tol=1e-15)
+        and not bool(animation._fade_point_target)
+    )
+    if not default_endpoint:
+        raise NotImplementedError(
+            "retained Text Group/VGroup fades with shift, scale, or target_position "
+            "require shared retained family layout semantics"
+        )
+
+    animation_args = _options.builder_args(animation)
+    family_lag_ratio = float(animation_args.get("lag_ratio", 0.0))
+    if not math.isfinite(family_lag_ratio):
+        raise ValueError("retained text family fade lag_ratio must be finite")
+    if not math.isclose(family_lag_ratio, 0.0, rel_tol=0.0, abs_tol=1e-15):
+        raise NotImplementedError(
+            "retained Text Group/VGroup fade lag_ratio requires shared retained family scheduling"
+        )
+
+    children: list[object] = []
+    for index, member in enumerate(retained):
+        child = type(animation)(
+            member,
+            None if animation.key is None else f"{animation.key}.{index}",
+        )
+        object.__setattr__(child, "anim_args", copy.deepcopy(animation_args))
+        children.append(child)
+    return target, retained, children
+
+
+def _normalize_retained_family_top_level(
+    scene: _compat.Scene,
+    families: list[tuple[_compat.Group, list[_typst._RetainedTextMobject]]],
+    top_level_before: list[object],
+) -> None:
+    """Keep Manim family wrappers top-level while retained leaves own runtime state."""
+
+    previous = {id(value) for value in top_level_before}
+    family_leaves = {id(member) for _, leaves in families for member in leaves}
+    scene._compat_top_level = [
+        value
+        for value in scene._compat_top_level
+        if id(value) not in family_leaves or id(value) in previous
+    ]
+    for family, _ in families:
+        scene._register_top_level(family)
+
+
 def _bind_retained(
     scene: _compat.Scene,
     source: _typst._RetainedTextMobject,
@@ -996,6 +1072,12 @@ def _schedule_retained_plan(
 
 
 def _retained_scene_is_present(self: _compat.Scene, value: object) -> bool:
+    if isinstance(value, _compat.Group):
+        leaves = _compat._leaf_mobjects(value)
+        if leaves and all(
+            isinstance(member, _typst._RetainedTextMobject) for member in leaves
+        ):
+            return any(_retained_scene_is_present(self, member) for member in leaves)
     if not isinstance(value, _typst._RetainedTextMobject):
         return _ORIGINAL_SCENE_IS_PRESENT(self, value)
     if value._scene is not self or value._retained_object_id is None:
@@ -1023,6 +1105,29 @@ def _retained_scene_play(
     lag_ratio: float | None = None,
     **kwargs: Any,
 ) -> _compat.Scene:
+    expanded: list[object] = []
+    retained_families: list[
+        tuple[_compat.Group, list[_typst._RetainedTextMobject]]
+    ] = []
+    for animation in animations:
+        family = _retained_family_fade_expansion(animation)
+        if family is None:
+            expanded.append(animation)
+            continue
+        target, leaves, children = family
+        retained_families.append((target, leaves))
+        expanded.extend(children)
+    animations = tuple(expanded)
+
+    if retained_families and lag_ratio is not None:
+        play_family_lag_ratio = float(lag_ratio)
+        if not math.isfinite(play_family_lag_ratio):
+            raise ValueError("retained text family fade lag_ratio must be finite")
+        if not math.isclose(play_family_lag_ratio, 0.0, rel_tol=0.0, abs_tol=1e-15):
+            raise NotImplementedError(
+                "retained Text Group/VGroup Scene.play lag_ratio requires shared retained family scheduling"
+            )
+
     retained_plans = [_retained_animation_plan(animation) for animation in animations]
     if not any(plan is not None for plan in retained_plans):
         return _ORIGINAL_SCENE_PLAY(
@@ -1106,6 +1211,7 @@ def _retained_scene_play(
             )
             max_end = max(max_end, base_start + resolved.run_time)
 
+        _normalize_retained_family_top_level(self, retained_families, top_level_before)
         self._cursor = max(cursor_before, max_end)
         return self
     except Exception:


### PR DESCRIPTION
## Summary
- support default `FadeIn` / `FadeOut` for homogeneous retained `Group` / `VGroup` trees containing retained Text/Typst leaves
- expand family fades through the existing shared recursive leaf traversal while keeping the Group/VGroup wrapper as the scene-level identity
- lower each retained leaf to the existing retained Presence/Appearance lifecycle without synthesizing legacy geometry, position tracks, or scale tracks
- keep mixed retained/legacy families and non-default family endpoints explicit rather than approximating unsupported semantics
- add a focused Chromium regression and make the retained-text workflow run it

## Architecture
This consumer builds on #690’s shared Rust family identity. Family membership/identity remains owned by `SemanticStore`; retained leaf presentation and lifecycle remain owned by the retained source-level timeline.

The adapter only expands a homogeneous retained family into leaf fades after validating that no family-level layout/scheduling semantics are required. After lowering, top-level wrapper membership is normalized so `scene.mobjects` exposes the original Group/VGroup identity rather than promoted retained leaves.

## Supported boundary
Supported:
- `FadeIn(Group/VGroup(retained Text/Typst leaves))`
- `FadeOut(Group/VGroup(retained Text/Typst leaves))`
- nested retained Group/VGroup trees
- default family endpoint (`shift=0`, `scale=1`, no `target_position`)
- zero family/play `lag_ratio`

Explicitly unsupported until shared retained-family semantics exist:
- mixed retained Text + legacy geometry families
- family fade `shift`, `scale`, or `target_position`
- nonzero family or `Scene.play` lag ratio for retained family fades

## Validation
The implementation and focused smoke were originally qualified stacked on #690 and then on the post-#691 master. #691's retained `ShrinkToCenter` playback gate exposed an independent incorrect raster-center invariant; that gate was repaired in #694 before this PR was replayed.

After #694 merged, both shared base blobs used by this PR were verified byte-for-byte unchanged from the last qualified #692 base:
- `.github/workflows/retained-text-animation.yml`: `37b74464fa74a2decf216d0590417e79cb625461`
- `web/python/_manim_retained_animate.py`: `ddcc430113fa6ef4b9a8ef362896c3daea0dfeec`

The same three previously validated feature blobs were then replayed without reconstruction directly on #694 merge `dc17df09237eae4b7122ee6556e939e49a540fdd`.

Pre-replay targeted qualification passed:
- full Rust/WASM + web package build
- semantic ownership inventory gate
- retained Text family identity Chromium smoke
- retained Text family fade Chromium smoke
- existing retained Text animation Chromium smoke
- existing retained Text Scene lifecycle Chromium smoke

The focused family-fade smoke verifies nested `VGroup` identity/copy semantics, exact leaf Presence/Appearance tracks, no legacy placeholder geometry, no position/scale synthesis for default fades, top-level wrapper membership, and failure-before-mutation for unsupported shifted family fades.

Current exact head: `630591948af13f811c7643450cc0fc2ca1e78fd9`. It is one commit / three files / +280, directly parented on #694. Merge only after this exact head's fresh matrix is green, including family-fade and corrected retained ShrinkToCenter playback smokes.