### PR TITLE
Fix retained ShrinkToCenter center regression check

### DIFF
--- a/scripts/retained-text-playback-smoke.mjs
+++ b/scripts/retained-text-playback-smoke.mjs
@@ -87,6 +87,8 @@ function visibleBounds(buffer) {
   assert.ok(bounds, "rendered retained Text frame must contain visible foreground");
   return {
     ...bounds,
+    imageWidth: image.width,
+    imageHeight: image.height,
     width: bounds.maxX - bounds.minX + 1,
     height: bounds.maxY - bounds.minY + 1,
     centerX: (bounds.minX + bounds.maxX) / 2,
@@ -153,11 +155,13 @@ try {
     if ((authored.retainedDocument?.objects?.length ?? 0) !== 1) {
       throw new Error("ShrinkToCenter must author exactly one retained Text object");
     }
+    const retainedObject = authored.retainedDocument.objects[0];
     const tracks = authored.retainedDocument?.tracks ?? [];
     const scales = tracks.filter((track) => track.property === "scale");
     if (scales.length !== 1) {
       throw new Error(`ShrinkToCenter must author one scale track, got ${scales.length}`);
     }
+    const positions = tracks.filter((track) => track.property === "position");
     const ready = await execution.startRetained(
       JSON.stringify(authored.document),
       JSON.stringify(authored.retainedDocument),
@@ -170,6 +174,8 @@ try {
     return {
       duration: authored.duration,
       track: scales[0],
+      baseTranslation: retainedObject.text.transform.translation,
+      positionTrackCount: positions.length,
       mode: execution.mode,
       expectedMode: AUTHORING_EXECUTION_RETAINED,
       ready,
@@ -179,6 +185,8 @@ try {
 
   assert.equal(started.duration, 1);
   assert.equal(started.mode, started.expectedMode);
+  assert.deepEqual(started.baseTranslation, { x: 0, y: 0 });
+  assert.equal(started.positionTrackCount, 0, "ShrinkToCenter must keep the semantic center fixed");
   assert.deepEqual(started.track.values.vec2, {
     from: { x: 1, y: 1 },
     to: { x: 0, y: 0 },
@@ -208,16 +216,26 @@ try {
     lateBounds.foregroundPixels < earlyBounds.foregroundPixels * 0.65,
     `ShrinkToCenter must reduce foreground mass: early=${earlyBounds.foregroundPixels} late=${lateBounds.foregroundPixels}`,
   );
-  // Foreground-mask bounds can move by a few pixels as glyph stems cross the
-  // threshold at different scales. This still rejects meaningful translation
-  // while avoiding false failures caused purely by rasterization/antialiasing.
-  const centerTolerancePx = 5;
+  assert.equal(lateBounds.imageWidth, earlyBounds.imageWidth);
+  assert.equal(lateBounds.imageHeight, earlyBounds.imageHeight);
+
+  // Text ink is not symmetric around its semantic origin. Under a uniform scale about
+  // the fixed scene origin, the ink-bounds center therefore contracts toward that
+  // origin instead of remaining numerically fixed. Compare against that transformed
+  // center and reserve only two pixels for raster edge quantization.
+  const anchorX = earlyBounds.imageWidth / 2;
+  const anchorY = earlyBounds.imageHeight / 2;
+  const widthRatio = lateBounds.width / earlyBounds.width;
+  const heightRatio = lateBounds.height / earlyBounds.height;
+  const expectedLateCenterX = anchorX + (earlyBounds.centerX - anchorX) * widthRatio;
+  const expectedLateCenterY = anchorY + (earlyBounds.centerY - anchorY) * heightRatio;
   assert.ok(
-    Math.abs(lateBounds.centerX - earlyBounds.centerX) <= centerTolerancePx &&
-      Math.abs(lateBounds.centerY - earlyBounds.centerY) <= centerTolerancePx,
-    `ShrinkToCenter must remain visually centered within ${centerTolerancePx}px: ` +
-      `early=(${earlyBounds.centerX},${earlyBounds.centerY}) ` +
-      `late=(${lateBounds.centerX},${lateBounds.centerY})`,
+    Math.abs(lateBounds.centerX - expectedLateCenterX) <= 2 &&
+      Math.abs(lateBounds.centerY - expectedLateCenterY) <= 2,
+    `ShrinkToCenter must scale ink bounds about the fixed scene center: ` +
+      `anchor=(${anchorX},${anchorY}) early=(${earlyBounds.centerX},${earlyBounds.centerY}) ` +
+      `late=(${lateBounds.centerX},${lateBounds.centerY}) ` +
+      `expectedLate=(${expectedLateCenterX},${expectedLateCenterY})`,
   );
   assert.deepEqual(errors, [], `browser errors during retained ShrinkToCenter playback:\n${errors.join("\n")}`);
 


### PR DESCRIPTION
## Summary
- replace #693's fixed 5 px `ShrinkToCenter(Text(...))` center tolerance with a scale-aware invariant derived from uniform scaling about the scene origin
- assert the retained Text semantic translation stays exactly at the origin and that ShrinkToCenter authors no position track
- keep the end-to-end render-worker checks for material width, height, and foreground-mass shrink

## Why the fixed-center checks are wrong
The exact #691 PR head failed its own new playback smoke with:

```
early=(317.5,184) late=(319,180.5)
```

on a 640×360 canvas whose semantic origin is `(320,180)`. #693 stabilized that by widening the allowed early/late center difference to 5 px.

But retained text ink is asymmetric around the semantic object origin. Under uniform scaling about that fixed origin, the ink-bounds center mathematically contracts toward the origin; it is not supposed to remain at the same pixel coordinate. A fixed early/late delta tolerance therefore checks the wrong invariant even when widened.

## New invariant
For each axis, predict the late ink-bounds center by scaling the early center's offset from the scene origin by the observed rendered width/height ratio:

```
late_center ≈ origin + (early_center - origin) * rendered_scale_ratio
```

The comparison allows only 2 px for raster-edge quantization. Separately, the authored retained document must have base translation `{x: 0, y: 0}` and zero position tracks, so semantic centering cannot silently regress.

This remains an end-to-end Chromium/render-worker regression and does not relax the existing visible-shrink requirements.

This repair remains intentionally separate from #692 retained family fades.

Exact head: `1e8943ff0c95398c6816eace9ea1d1d810ecae01`, based directly on #693 merge `e9c7134d914020de6043d217bd28627e2afd5feb`.