### PR TITLE
Prototype retained Text Create/Uncreate — blocked on character-family parity

### DIFF
--- a/.github/workflows/retained-text-animation.yml
+++ b/.github/workflows/retained-text-animation.yml
@@ -18,6 +18,8 @@ on:
       - "web/python/_manim_typst.py"
       - "scripts/build-python-worker.mjs"
       - "scripts/retained-text-animation-smoke.mjs"
+      - "scripts/retained-text-creation-smoke.mjs"
+      - "scripts/retained-text-creation-playback-smoke.mjs"
       - "scripts/retained-text-family-identity-smoke.mjs"
       - "scripts/retained-text-playback-smoke.mjs"
       - "scripts/retained-text-scene-lifecycle-smoke.mjs"
@@ -41,6 +43,8 @@ on:
       - "web/python/_manim_typst.py"
       - "scripts/build-python-worker.mjs"
       - "scripts/retained-text-animation-smoke.mjs"
+      - "scripts/retained-text-creation-smoke.mjs"
+      - "scripts/retained-text-creation-playback-smoke.mjs"
       - "scripts/retained-text-family-identity-smoke.mjs"
       - "scripts/retained-text-playback-smoke.mjs"
       - "scripts/retained-text-scene-lifecycle-smoke.mjs"
@@ -111,11 +115,17 @@ jobs:
       - name: Test retained Text animation authoring
         run: node scripts/retained-text-animation-smoke.mjs
 
+      - name: Test retained Text creation authoring
+        run: node scripts/retained-text-creation-smoke.mjs
+
       - name: Test retained Text family identity
         run: node scripts/retained-text-family-identity-smoke.mjs
 
       - name: Test retained Text animation playback
         run: node scripts/retained-text-playback-smoke.mjs
+
+      - name: Test retained Text creation playback
+        run: node scripts/retained-text-creation-playback-smoke.mjs
 
       - name: Test retained Text Scene lifecycle
         run: node scripts/retained-text-scene-lifecycle-smoke.mjs

--- a/scripts/retained-text-creation-playback-smoke.mjs
+++ b/scripts/retained-text-creation-playback-smoke.mjs
@@ -1,0 +1,220 @@
+import assert from "node:assert/strict";
+import { createReadStream } from "node:fs";
+import { stat } from "node:fs/promises";
+import { createServer } from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import playwright from "playwright";
+import pngjs from "pngjs";
+
+import { foregroundMask } from "./browser-visual-parity-lib.mjs";
+
+const { chromium } = playwright;
+const { PNG } = pngjs;
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const port = Number(process.env.NOON_RETAINED_TEXT_CREATION_PLAYBACK_PORT ?? "4198");
+const baseUrl = `http://127.0.0.1:${port}`;
+
+const contentTypes = new Map([
+  [".html", "text/html; charset=utf-8"],
+  [".js", "text/javascript; charset=utf-8"],
+  [".mjs", "text/javascript; charset=utf-8"],
+  [".wasm", "application/wasm"],
+  [".json", "application/json; charset=utf-8"],
+  [".py", "text/x-python; charset=utf-8"],
+]);
+
+const server = createServer(async (request, response) => {
+  try {
+    const url = new URL(request.url, baseUrl);
+    const relative = decodeURIComponent(url.pathname).replace(/^\/+/, "");
+    const resolved = path.resolve(repoRoot, relative || "web/execution-worker-smoke.html");
+    if (resolved !== repoRoot && !resolved.startsWith(`${repoRoot}${path.sep}`)) {
+      response.writeHead(403).end("forbidden");
+      return;
+    }
+    const info = await stat(resolved);
+    if (!info.isFile()) {
+      response.writeHead(404).end("not found");
+      return;
+    }
+    response.setHeader("Cross-Origin-Opener-Policy", "same-origin");
+    response.setHeader("Cross-Origin-Embedder-Policy", "require-corp");
+    response.setHeader("Cross-Origin-Resource-Policy", "same-origin");
+    response.setHeader("Cache-Control", "no-store");
+    response.setHeader(
+      "Content-Type",
+      contentTypes.get(path.extname(resolved)) ?? "application/octet-stream",
+    );
+    response.writeHead(200);
+    createReadStream(resolved).pipe(response);
+  } catch (error) {
+    response.writeHead(error?.code === "ENOENT" ? 404 : 500).end(String(error));
+  }
+});
+await new Promise((resolve, reject) => {
+  server.once("error", reject);
+  server.listen(port, "127.0.0.1", resolve);
+});
+
+const source = `from noon import *
+
+class RetainedTextCreationPlayback(Scene):
+    def construct(self):
+        label = Text("Create / Uncreate", font_size=96)
+        self.play(Create(label), run_time=1.0, rate_func=linear)
+        self.play(Uncreate(label), run_time=1.0, rate_func=linear)
+`;
+
+const browserArgs = [
+  "--enable-unsafe-webgpu",
+  "--enable-unsafe-swiftshader",
+  "--use-webgpu-adapter=swiftshader",
+  "--use-gpu-in-tests",
+  "--ignore-gpu-blocklist",
+  "--enable-features=Vulkan",
+  "--use-gl=angle",
+  "--use-angle=swiftshader",
+  "--use-vulkan=swiftshader",
+  "--disable-gpu-sandbox",
+  "--disable-dev-shm-usage",
+];
+
+function foregroundPixels(buffer) {
+  const image = PNG.sync.read(buffer);
+  return foregroundMask(image, 32).count;
+}
+
+async function seekAndWait(page, time, previousPresentedFrames) {
+  return page.evaluate(
+    async ({ time, previousPresentedFrames }) => {
+      const execution = globalThis.__noonRetainedCreationExecution;
+      const seek = await execution.seek(time);
+      let lastReport = null;
+      for (let attempt = 0; attempt < 100; attempt += 1) {
+        const report = await execution.metrics();
+        lastReport = report;
+        if (report.metrics.presentedFrames > previousPresentedFrames) {
+          return { seek, state: await execution.state(), report };
+        }
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      const state = await execution.state();
+      const diagnosticJson = (value) =>
+        JSON.stringify(value, (_key, nested) =>
+          typeof nested === "bigint" ? `${nested}n` : nested,
+        );
+      throw new Error(
+        `retained renderer did not present seek to ${time}s; ` +
+          `state=${diagnosticJson(state)}; metrics=${diagnosticJson(lastReport)}`,
+      );
+    },
+    { time, previousPresentedFrames },
+  );
+}
+
+let browser = null;
+try {
+  browser = await chromium.launch({ channel: "chromium", headless: true, args: browserArgs });
+  const page = await browser.newPage({ viewport: { width: 900, height: 520 } });
+  const errors = [];
+  page.on("pageerror", (error) => errors.push(`pageerror: ${error}`));
+  page.on("console", (message) => {
+    if (message.type() === "error") errors.push(`console: ${message.text()}`);
+  });
+  await page.goto(`${baseUrl}/web/execution-worker-smoke.html`, { waitUntil: "load" });
+
+  const started = await page.evaluate(async (sourceText) => {
+    const { PythonAuthoringClient } = await import("./authoring-client.js");
+    const { AuthoringExecutionClient, AUTHORING_EXECUTION_RETAINED } = await import(
+      "./authoring-execution-client.js"
+    );
+    const authoring = new PythonAuthoringClient();
+    const execution = new AuthoringExecutionClient(document.querySelector("#scene"));
+    const authored = await authoring.run(sourceText, {});
+    const reveals = (authored.retainedDocument?.tracks ?? []).filter(
+      (track) => track.property === "reveal" && track.timing.duration > 0,
+    );
+    if (authored.duration !== 2 || reveals.length !== 2) {
+      throw new Error(
+        `Create/Uncreate authored unexpected duration/tracks: duration=${authored.duration} reveals=${reveals.length}`,
+      );
+    }
+    if ((authored.document?.objects?.length ?? 0) !== 0) {
+      throw new Error("Create/Uncreate(Text) must remain retained-only");
+    }
+    const ready = await execution.startRetained(
+      JSON.stringify(authored.document),
+      JSON.stringify(authored.retainedDocument),
+      { loopDurationSeconds: authored.duration, transportMode: "transferable" },
+    );
+    await execution.pause();
+    globalThis.__noonRetainedCreationExecution = execution;
+    globalThis.__noonRetainedCreationAuthoring = authoring;
+    const metrics = await execution.metrics();
+    return {
+      mode: execution.mode,
+      expectedMode: AUTHORING_EXECUTION_RETAINED,
+      ready,
+      reveals,
+      presentedFrames: metrics.metrics.presentedFrames,
+    };
+  }, source);
+
+  assert.equal(started.mode, started.expectedMode);
+  assert.deepEqual(started.reveals[0].values.scalar, { from: 0, to: 1 });
+  assert.deepEqual(started.reveals[1].values.scalar, { from: 1, to: 0 });
+
+  const createEarly = await seekAndWait(page, 0.2, started.presentedFrames);
+  const createEarlyPixels = foregroundPixels(await page.locator("#scene").screenshot());
+  const createLate = await seekAndWait(
+    page,
+    0.8,
+    createEarly.report.metrics.presentedFrames,
+  );
+  const createLatePixels = foregroundPixels(await page.locator("#scene").screenshot());
+  assert.ok(
+    createLatePixels > createEarlyPixels * 1.35,
+    `Create(Text) must visibly reveal more ink: early=${createEarlyPixels} late=${createLatePixels}`,
+  );
+
+  const uncreateEarly = await seekAndWait(
+    page,
+    1.2,
+    createLate.report.metrics.presentedFrames,
+  );
+  const uncreateEarlyPixels = foregroundPixels(await page.locator("#scene").screenshot());
+  const uncreateLate = await seekAndWait(
+    page,
+    1.8,
+    uncreateEarly.report.metrics.presentedFrames,
+  );
+  const uncreateLatePixels = foregroundPixels(await page.locator("#scene").screenshot());
+  assert.ok(
+    uncreateLatePixels < uncreateEarlyPixels * 0.75,
+    `Uncreate(Text) must visibly remove ink: early=${uncreateEarlyPixels} late=${uncreateLatePixels}`,
+  );
+
+  assert.equal(createEarly.state.playing, false);
+  assert.equal(createLate.state.playing, false);
+  assert.equal(uncreateEarly.state.playing, false);
+  assert.equal(uncreateLate.state.playing, false);
+  assert.deepEqual(errors, [], `browser errors during retained creation playback:\n${errors.join("\n")}`);
+
+  await page.evaluate(() => {
+    globalThis.__noonRetainedCreationExecution?.terminate();
+    globalThis.__noonRetainedCreationAuthoring?.terminate();
+    delete globalThis.__noonRetainedCreationExecution;
+    delete globalThis.__noonRetainedCreationAuthoring;
+  });
+
+  console.log(
+    `Retained Text creation playback passed: Create ${createEarlyPixels}->${createLatePixels}, ` +
+      `Uncreate ${uncreateEarlyPixels}->${uncreateLatePixels} foreground pixels.`,
+  );
+} finally {
+  await browser?.close();
+  await new Promise((resolve) => server.close(resolve));
+}

--- a/scripts/retained-text-creation-smoke.mjs
+++ b/scripts/retained-text-creation-smoke.mjs
@@ -130,6 +130,10 @@ try {
     presence.map((track) => ({ values: track.values.bool, timing: track.timing })),
     [
       {
+        values: { from: false, to: true },
+        timing: { start_time: 0, duration: 0, easing: "linear" },
+      },
+      {
         values: { from: true, to: false },
         timing: { start_time: 2, duration: 0, easing: "linear" },
       },
@@ -138,7 +142,7 @@ try {
         timing: { start_time: 2, duration: 0, easing: "linear" },
       },
     ],
-    "Uncreate removes at the exact end and Scene.add reintroduces the canonical Text",
+    "Create introduces at its start; Uncreate removes at the exact end; Scene.add reintroduces canonical Text",
   );
 
   const forwardResult = await page.evaluate(

--- a/scripts/retained-text-creation-smoke.mjs
+++ b/scripts/retained-text-creation-smoke.mjs
@@ -1,0 +1,169 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import playwright from "playwright";
+
+const { chromium } = playwright;
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const port = 4197;
+const baseUrl = `http://127.0.0.1:${port}`;
+
+let serverOutput = "";
+const server = spawn(
+  "python3",
+  ["-m", "http.server", String(port), "--bind", "127.0.0.1", "--directory", repoRoot],
+  { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] },
+);
+server.stdout.on("data", (chunk) => (serverOutput += chunk));
+server.stderr.on("data", (chunk) => (serverOutput += chunk));
+
+async function waitForServer() {
+  let lastError = null;
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    try {
+      const response = await fetch(`${baseUrl}/web/manim-compat-smoke.html`);
+      if (response.ok) return;
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`retained text creation smoke server did not start: ${lastError}\n${serverOutput}`);
+}
+
+const createUncreateSource = `
+from noon import *
+
+class RetainedCreateUncreate(Scene):
+    def construct(self):
+        label = Text("Create / Uncreate", font_size=72)
+        assert label not in self.mobjects
+
+        self.play(Create(label), run_time=1.0, rate_func=linear)
+        assert label in self.mobjects
+
+        self.play(Uncreate(label), run_time=1.0, rate_func=linear)
+        assert label not in self.mobjects
+
+        self.add(label)
+        assert label in self.mobjects
+`;
+
+const forwardUncreateSource = `
+from noon import *
+
+class RetainedForwardUncreate(Scene):
+    def construct(self):
+        label = Text("Forward Uncreate", font_size=72)
+        self.add(label)
+        self.play(
+            Uncreate(label, reverse_rate_function=False, remover=False),
+            run_time=1.0,
+            rate_func=linear,
+        )
+        assert label in self.mobjects
+`;
+
+function scalarTracks(result, propertyName) {
+  return (result.retainedDocument?.tracks ?? []).filter(
+    (track) => track.property === propertyName,
+  );
+}
+
+let browser = null;
+try {
+  await waitForServer();
+  browser = await chromium.launch({
+    channel: "chromium",
+    headless: true,
+    args: ["--disable-dev-shm-usage"],
+  });
+  const page = await browser.newPage();
+  const errors = [];
+  page.on("pageerror", (error) => errors.push(`pageerror: ${error}`));
+  page.on("console", (message) => {
+    if (message.type() === "error") errors.push(`console: ${message.text()}`);
+  });
+
+  await page.goto(`${baseUrl}/web/manim-compat-smoke.html`, { waitUntil: "load" });
+  await page.waitForFunction(() => window.noonManimCompat, null, { timeout: 30_000 });
+  await page.evaluate(() => window.noonManimCompat.ready());
+
+  const result = await page.evaluate(
+    (source) => window.noonManimCompat.run(source),
+    createUncreateSource,
+  );
+  assert.equal(result.kind, "scene_document");
+  assert.equal(result.document.objects.length, 0, "Text creation must remain retained-only");
+  assert.equal(result.retainedDocument.objects.length, 1);
+  assert.equal(result.retainedDocument.objects[0].text.source, "Create / Uncreate");
+  assert.equal(result.duration, 2);
+
+  const reveals = scalarTracks(result, "reveal");
+  assert.equal(reveals.length, 3, "Create, Uncreate, and removal cleanup must author reveal tracks");
+  assert.deepEqual(
+    reveals.map((track) => ({ values: track.values.scalar, timing: track.timing })),
+    [
+      {
+        values: { from: 0, to: 1 },
+        timing: { start_time: 0, duration: 1, easing: "linear" },
+      },
+      {
+        values: { from: 1, to: 0 },
+        timing: { start_time: 1, duration: 1, easing: "linear" },
+      },
+      {
+        values: { from: 0, to: 1 },
+        timing: { start_time: 2, duration: 0, easing: "linear" },
+      },
+    ],
+  );
+
+  const presence = (result.retainedDocument.tracks ?? []).filter(
+    (track) => track.property === "presence",
+  );
+  assert.deepEqual(
+    presence.map((track) => ({ values: track.values.bool, timing: track.timing })),
+    [
+      {
+        values: { from: true, to: false },
+        timing: { start_time: 2, duration: 0, easing: "linear" },
+      },
+      {
+        values: { from: false, to: true },
+        timing: { start_time: 2, duration: 0, easing: "linear" },
+      },
+    ],
+    "Uncreate removes at the exact end and Scene.add reintroduces the canonical Text",
+  );
+
+  const forwardResult = await page.evaluate(
+    (source) => window.noonManimCompat.run(source),
+    forwardUncreateSource,
+  );
+  const forwardReveal = scalarTracks(forwardResult, "reveal");
+  assert.equal(forwardReveal.length, 1);
+  assert.deepEqual(forwardReveal[0].values.scalar, { from: 0, to: 1 });
+  assert.deepEqual(forwardReveal[0].timing, {
+    start_time: 0,
+    duration: 1,
+    easing: "linear",
+  });
+  assert.equal(
+    (forwardResult.retainedDocument.tracks ?? []).filter(
+      (track) => track.property === "presence",
+    ).length,
+    0,
+    "remover=False must keep the retained Text present",
+  );
+
+  assert.deepEqual(errors, []);
+  console.log("retained Text Create/Uncreate authoring smoke passed");
+} finally {
+  await browser?.close();
+  server.kill("SIGTERM");
+}

--- a/web/python/_manim_retained_animate.py
+++ b/web/python/_manim_retained_animate.py
@@ -205,7 +205,10 @@ def _retained_animation_source(
 ) -> _typst._RetainedTextMobject | None:
     if isinstance(animation, _animate._AlignedAnimationBuilder):
         source = getattr(animation, "source", None)
-    elif isinstance(animation, (_animate.FadeIn, _animate.FadeOut)):
+    elif isinstance(
+        animation,
+        (_animate.Create, _animate.Uncreate, _animate.FadeIn, _animate.FadeOut),
+    ):
         source = getattr(animation, "target", None)
     else:
         return None
@@ -218,6 +221,18 @@ def _retained_animation_plan(animation: object) -> list[dict[str, Any]] | None:
     source = _retained_animation_source(animation)
     if source is None:
         return None
+
+    if isinstance(animation, _animate.Uncreate):
+        return [
+            {
+                "kind": "uncreate",
+                "reverse_rate_function": bool(animation.reverse_rate_function),
+                "remover": bool(animation.remover),
+            }
+        ]
+
+    if isinstance(animation, _animate.Create):
+        return [{"kind": "create"}]
 
     if isinstance(animation, (_animate.FadeIn, _animate.FadeOut)):
         shift = _compat._as_vec2(animation._fade_shift_vector)
@@ -272,6 +287,7 @@ def _initial_animation_state(source: _typst._RetainedTextMobject) -> dict[str, A
         "opacity": _unit_scalar(spec.get("opacity"), "opacity"),
         "position": _vec2(transform.get("translation"), "translation"),
         "presence": True,
+        "reveal": 1.0,
         "rotation": _finite_scalar(transform.get("rotation"), "rotation"),
         "scale": _vec2(transform.get("scale"), "scale"),
         "runtime_position": _vec2(transform.get("translation"), "translation"),
@@ -279,15 +295,23 @@ def _initial_animation_state(source: _typst._RetainedTextMobject) -> dict[str, A
     }
 
 
-def _retained_presence_tracks(
+def _retained_property_tracks(
     scene: _compat.Scene,
     object_id: int,
+    property_name: str,
 ) -> list[dict[str, Any]]:
     return [
         track
         for track in getattr(scene, "_retained_animation_tracks", [])
-        if int(track["object"]) == object_id and track["property"] == "presence"
+        if int(track["object"]) == object_id and track["property"] == property_name
     ]
+
+
+def _retained_presence_tracks(
+    scene: _compat.Scene,
+    object_id: int,
+) -> list[dict[str, Any]]:
+    return _retained_property_tracks(scene, object_id, "presence")
 
 
 def _resolve_retained_lifecycle(
@@ -598,6 +622,115 @@ def _scale_vec2(value: dict[str, float], factor: float) -> dict[str, float]:
     }
 
 
+def _ensure_reveal_interval_available(
+    scene: _compat.Scene,
+    *,
+    object_id: int,
+    start_time: float,
+    duration: float,
+) -> None:
+    end_time = start_time + duration
+    for track in _retained_property_tracks(scene, object_id, "reveal"):
+        track_start = float(track["timing"]["start_time"])
+        track_end = track_start + float(track["timing"]["duration"])
+        if track_start < end_time and start_time < track_end:
+            raise ValueError("Create/Uncreate reveal animations for one retained object must not overlap")
+
+
+def _schedule_retained_creation(
+    scene: _compat.Scene,
+    *,
+    object_id: int,
+    state: dict[str, Any],
+    operation: dict[str, Any],
+    lifecycle: _lifecycle.LifecyclePlan,
+    start_time: float,
+    duration: float,
+    easing: str,
+) -> None:
+    """Lower Create/Uncreate to the shared retained reveal and presence channels."""
+
+    _ensure_reveal_interval_available(
+        scene,
+        object_id=object_id,
+        start_time=start_time,
+        duration=duration,
+    )
+    kind = operation["kind"]
+    end_time = start_time + duration
+
+    if kind == "create":
+        if lifecycle.show_at_start:
+            state["presence"] = False
+            _append_presence_track(
+                scene,
+                object_id=object_id,
+                current=False,
+                target=True,
+                start_time=start_time,
+            )
+        _append_scalar_track(
+            scene,
+            object_id=object_id,
+            property_name="reveal",
+            current=0.0,
+            target=1.0,
+            start_time=start_time,
+            duration=duration,
+            easing=easing,
+        )
+        state["presence"] = True
+        state["reveal"] = 1.0
+        return
+
+    if kind != "uncreate":
+        raise ValueError(f"unknown retained creation operation {kind!r}")
+
+    track_easing, reverse_track = _animate._uncreate_track_settings(
+        easing,
+        bool(operation["reverse_rate_function"]),
+    )
+    from_reveal = 1.0 if reverse_track else 0.0
+    to_reveal = 0.0 if reverse_track else 1.0
+    _append_scalar_track(
+        scene,
+        object_id=object_id,
+        property_name="reveal",
+        current=from_reveal,
+        target=to_reveal,
+        start_time=start_time,
+        duration=duration,
+        easing=track_easing,
+    )
+    state["reveal"] = to_reveal
+
+    if bool(operation["remover"]) and lifecycle.hide_at_end:
+        _append_presence_track(
+            scene,
+            object_id=object_id,
+            current=True,
+            target=False,
+            start_time=end_time,
+        )
+        state["presence"] = False
+
+        # Manim removes the animated mobject but leaves its canonical geometry
+        # reusable. Restore reveal while absent so a later Scene.add or Create uses
+        # the original retained Text instead of inheriting Uncreate's partial frame.
+        if not math.isclose(to_reveal, 1.0, abs_tol=1e-15):
+            _append_scalar_track(
+                scene,
+                object_id=object_id,
+                property_name="reveal",
+                current=to_reveal,
+                target=1.0,
+                start_time=end_time,
+                duration=0.0,
+                easing="linear",
+            )
+            state["reveal"] = 1.0
+
+
 def _schedule_retained_fade(
     scene: _compat.Scene,
     *,
@@ -799,13 +932,21 @@ def _schedule_retained_plan(
     if source is None:
         raise TypeError("retained animation lost its retained Text source")
 
-    fade_kind = (
-        operations[0]["kind"]
-        if len(operations) == 1 and operations[0]["kind"] in {"fade_in", "fade_out"}
-        else None
-    )
+    operation_kind = operations[0]["kind"] if len(operations) == 1 else None
+    fade_kind = operation_kind if operation_kind in {"fade_in", "fade_out"} else None
+    creation_kind = operation_kind if operation_kind in {"create", "uncreate"} else None
 
-    if fade_kind == "fade_in":
+    if creation_kind == "create":
+        lifecycle = _resolve_retained_lifecycle(
+            scene, source, "introduce", start_time, "Create target"
+        )
+        _bind_retained(scene, source)
+    elif creation_kind == "uncreate":
+        add_plan = _resolve_retained_lifecycle(
+            scene, source, "add", start_time, "animated Uncreate target"
+        )
+        _bind_retained(scene, source)
+    elif fade_kind == "fade_in":
         lifecycle = _resolve_retained_lifecycle(
             scene, source, "introduce", start_time, "fade target"
         )
@@ -826,6 +967,50 @@ def _schedule_retained_plan(
     state = scene._retained_animation_state.setdefault(
         object_id, _initial_animation_state(source)
     )
+
+    if creation_kind == "uncreate":
+        if add_plan.show_now:
+            state["presence"] = False
+            _append_presence_track(
+                scene,
+                object_id=object_id,
+                current=False,
+                target=True,
+                start_time=start_time,
+            )
+            state["presence"] = True
+            state["reveal"] = 1.0
+        lifecycle = (
+            _resolve_retained_lifecycle(
+                scene, source, "remove_after_animation", start_time, "Uncreate target"
+            )
+            if bool(operations[0]["remover"])
+            else add_plan
+        )
+        _schedule_retained_creation(
+            scene,
+            object_id=object_id,
+            state=state,
+            operation=operations[0],
+            lifecycle=lifecycle,
+            start_time=start_time,
+            duration=duration,
+            easing=easing,
+        )
+        return
+
+    if creation_kind == "create":
+        _schedule_retained_creation(
+            scene,
+            object_id=object_id,
+            state=state,
+            operation=operations[0],
+            lifecycle=lifecycle,
+            start_time=start_time,
+            duration=duration,
+            easing=easing,
+        )
+        return
 
     if fade_kind == "fade_out":
         if add_plan.show_now:


### PR DESCRIPTION
## Status: do not merge yet

The first retained implementation proved the lifecycle wiring, but its real browser gate exposed an architectural parity gap rather than a threshold problem.

Observed on the exact PR head:
- retained authoring/lifecycle tracks pass;
- existing ShrinkToCenter retained playback passes;
- `Create(Text("Create / Uncreate"), rate_func=linear)` changes foreground mass only `5188 -> 5670` from 0.2s to 0.8s and fails the new playback gate.

Root cause: this PR currently lowers Create/Uncreate to one object-wide `Reveal` scalar. The renderer converts the whole glyph run to one combined outline path and reveals that path globally. ManimCE v0.21 instead animates `Text.family_members_with_points()` independently using `Animation.get_sub_alpha`; `Create` defaults to `lag_ratio=1.0`, and `Uncreate` reverses each subanimation's rate function while preserving family order.

Therefore the current implementation is visibly animated but **not Manim-compatible enough to merge**. The browser assertion will not be relaxed to make it pass.

The shared fix is tracked in #705: add retained Text character-family animation state while preserving one retained semantic object/resource, then rework this PR onto it. That same primitive is the prerequisite for accurate `Write` / `Unwrite` and letter-by-letter demos.

Existing useful work in this branch remains:
- lifecycle planning for introduction/removal/re-add;
- regression source and browser playback harness;
- proof that no legacy placeholder geometry is needed.

Do not add gallery/parity labels until #705's intermediate-frame Manim Cairo gates pass.

Related: #61, #89, #185, #705.