### PR TITLE
Gate authoritative frontend family leaf order

### DIFF
--- a/crates/noon-web/tests/family_leaf_order_contract.rs
+++ b/crates/noon-web/tests/family_leaf_order_contract.rs
@@ -1,0 +1,62 @@
+use noon_core::SemanticStore;
+use noon_web::{FrontendFamilyTranslation, FrontendMobjectHandle};
+
+fn nested_family() -> (
+    SemanticStore,
+    noon_core::SemanticNodeId,
+    [noon_core::SemanticNodeId; 3],
+) {
+    let mut store = SemanticStore::new();
+    let first = store.insert_authoring_object();
+    let second = store.insert_authoring_object();
+    let third = store.insert_authoring_object();
+    let nested = store.insert_family();
+    let root = store.insert_family();
+
+    store.add_member(nested, second).unwrap();
+    store.add_member(nested, third).unwrap();
+    store.add_member(root, first).unwrap();
+    store.add_member(root, nested).unwrap();
+
+    (store, root, [first, second, third])
+}
+
+#[test]
+fn nested_family_translation_uses_authoritative_semantic_leaf_order() {
+    let (store, root, [first, second, third]) = nested_family();
+    let mut translation = FrontendFamilyTranslation::begin(&store, root, 0.25, -0.5).unwrap();
+    let mut first_handle = FrontendMobjectHandle::manim_square(1.0).unwrap();
+    let mut second_handle = FrontendMobjectHandle::manim_square(1.0).unwrap();
+    let mut third_handle = FrontendMobjectHandle::manim_square(1.0).unwrap();
+
+    translation.apply(first, &mut first_handle).unwrap();
+    assert_eq!(first_handle.wire_translation(), (0.25, -0.5));
+
+    let second_before = second_handle.wire_translation();
+    let error = translation
+        .apply(third, &mut second_handle)
+        .expect_err("frontend wrapper order must not override semantic family order");
+    assert!(error.contains("leaf mismatch"));
+    assert_eq!(second_handle.wire_translation(), second_before);
+
+    translation.apply(second, &mut second_handle).unwrap();
+    translation.apply(third, &mut third_handle).unwrap();
+    translation.finish().unwrap();
+
+    assert_eq!(second_handle.wire_translation(), (0.25, -0.5));
+    assert_eq!(third_handle.wire_translation(), (0.25, -0.5));
+}
+
+#[test]
+fn family_translation_refuses_incomplete_leaf_traversal() {
+    let (store, root, [first, _, _]) = nested_family();
+    let mut translation = FrontendFamilyTranslation::begin(&store, root, 1.0, 0.0).unwrap();
+    let mut handle = FrontendMobjectHandle::manim_square(1.0).unwrap();
+
+    translation.apply(first, &mut handle).unwrap();
+    let error = translation
+        .finish()
+        .expect_err("partially traversed semantic families must fail closed");
+
+    assert!(error.contains("applied 1 of 3 leaves"));
+}


### PR DESCRIPTION
Part of #61 and supports the remaining family-aware adapter work under #400.

Shared `SemanticStore` family identity is the authority for nested leaf traversal. This adds an external `noon-web` integration regression proving that frontend family operations:

- flatten nested families in shared semantic order rather than host-wrapper order;
- reject an out-of-order wrapper leaf before mutating its handle;
- fail closed when traversal is incomplete.

This is intentionally test-only. It does not add Python-side family bounds, synthetic aggregate snapshots, renderer changes, or another geometry representation. That keeps the contract needed by future `SurroundingRectangle` / `BackgroundRectangle` Group/VGroup support explicit without prematurely exposing a leaf-only compatibility surface.

Also audited the previously reported playground deploy failure (#689): archived logs show a transient Binaryen/`wasm-opt` HTTP 502, followed by a successful unchanged deploy, so #689 was closed without adding retry/bypass code.

Remaining risk: this gates traversal/mutation order, not aggregate family bounds. Matcher adapters still need a shared family-bounds API before Group/VGroup targets can be exposed without frontend geometry reconstruction.