### PR TITLE
Compile static plot samples into retained vector paths

### DIFF
--- a/crates/noon-geometry/src/lib.rs
+++ b/crates/noon-geometry/src/lib.rs
@@ -5,9 +5,11 @@
 mod morph;
 mod outline;
 mod partial;
+mod smoothing;
 mod tessellation;
 
 pub use morph::*;
 pub use outline::*;
 pub use partial::*;
+pub use smoothing::*;
 pub use tessellation::*;

--- a/crates/noon-geometry/src/smoothing.rs
+++ b/crates/noon-geometry/src/smoothing.rs
@@ -1,0 +1,404 @@
+use noon_core::{Vec2, VectorPath};
+
+const MANIM_CLOSE_RTOL: f64 = 1.0e-5;
+const MANIM_CLOSE_ATOL: f64 = 1.0e-8;
+
+/// Errors produced while converting sampled/corner anchors into Manim-compatible
+/// smooth cubic Bezier geometry.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum PathSmoothingError {
+    NonFiniteAnchor { index: usize, point: Vec2 },
+    CoordinateOverflow { x: f64, y: f64 },
+}
+
+impl std::fmt::Display for PathSmoothingError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match *self {
+            Self::NonFiniteAnchor { index, point } => write!(
+                formatter,
+                "smooth path anchor {index} must be finite: ({}, {})",
+                point.x, point.y
+            ),
+            Self::CoordinateOverflow { x, y } => write!(
+                formatter,
+                "smooth path control point cannot be represented as f32: ({x}, {y})"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for PathSmoothingError {}
+
+/// Compute the first/second cubic Bezier handles used by ManimCE v0.21
+/// `get_smooth_cubic_bezier_handle_points` for one 2D anchor sequence.
+///
+/// This is a semantic geometry operation, not a renderer interpolation. The
+/// solve is performed in f64 and lowered to Noon's current f32 `Vec2` path
+/// representation only after the complete spline has been solved.
+pub fn smooth_cubic_bezier_handles(
+    anchors: &[Vec2],
+) -> Result<(Vec<Vec2>, Vec<Vec2>), PathSmoothingError> {
+    validate_anchors(anchors)?;
+    if anchors.len() < 2 {
+        return Ok((Vec::new(), Vec::new()));
+    }
+
+    let anchors64 = anchors.iter().copied().map(Vec2d::from).collect::<Vec<_>>();
+    let (first, second) = if anchors64.len() == 2 {
+        straight_handles(anchors64[0], anchors64[1])
+    } else if manim_anchors_are_closed(anchors) {
+        smooth_closed_handles(&anchors64)
+    } else {
+        smooth_open_handles(&anchors64)
+    };
+
+    Ok((lower_points(&first)?, lower_points(&second)?))
+}
+
+/// Convert independent corner/sample subpaths into one retained cubic `VectorPath`
+/// using ManimCE v0.21 `VMobject.make_smooth()` handle semantics.
+///
+/// Each input slice is one explicit subpath. Empty subpaths are ignored and a
+/// one-anchor subpath is retained as a `MoveTo`. Multiple subpaths therefore
+/// stay disconnected, which is required for plotting discontinuities.
+///
+/// A closed anchor sequence already contains its final cubic back to the first
+/// anchor. No extra `Close` command is appended: in Noon's path model `Close`
+/// is itself a drawable segment and would create a spurious extra curve.
+pub fn smooth_cubic_path_from_subpaths(
+    subpaths: &[Vec<Vec2>],
+) -> Result<VectorPath, PathSmoothingError> {
+    let mut path = VectorPath::new();
+    for anchors in subpaths {
+        validate_anchors(anchors)?;
+        let Some(&first_anchor) = anchors.first() else {
+            continue;
+        };
+
+        path = path.move_to(first_anchor);
+        if anchors.len() < 2 {
+            continue;
+        }
+
+        let (first_handles, second_handles) = smooth_cubic_bezier_handles(anchors)?;
+        debug_assert_eq!(first_handles.len(), anchors.len() - 1);
+        debug_assert_eq!(second_handles.len(), anchors.len() - 1);
+        for index in 0..anchors.len() - 1 {
+            path = path.cubic_to(
+                first_handles[index],
+                second_handles[index],
+                anchors[index + 1],
+            );
+        }
+    }
+    Ok(path)
+}
+
+fn validate_anchors(anchors: &[Vec2]) -> Result<(), PathSmoothingError> {
+    for (index, &point) in anchors.iter().enumerate() {
+        if !point.x.is_finite() || !point.y.is_finite() {
+            return Err(PathSmoothingError::NonFiniteAnchor { index, point });
+        }
+    }
+    Ok(())
+}
+
+/// Match Manim v0.21's `utils.bezier.is_closed` test for the 2D coordinates
+/// supported by the current retained vector path.
+fn manim_anchors_are_closed(anchors: &[Vec2]) -> bool {
+    let Some((&start, &end)) = anchors.first().zip(anchors.last()) else {
+        return false;
+    };
+    let tolerance_x = MANIM_CLOSE_ATOL + MANIM_CLOSE_RTOL * f64::from(start.x);
+    if (f64::from(end.x) - f64::from(start.x)).abs() > tolerance_x {
+        return false;
+    }
+    let tolerance_y = MANIM_CLOSE_ATOL + MANIM_CLOSE_RTOL * f64::from(start.y);
+    (f64::from(end.y) - f64::from(start.y)).abs() <= tolerance_y
+}
+
+fn straight_handles(start: Vec2d, end: Vec2d) -> (Vec<Vec2d>, Vec<Vec2d>) {
+    let delta = end.sub(start);
+    (
+        vec![start.add(delta.scale(1.0 / 3.0))],
+        vec![start.add(delta.scale(2.0 / 3.0))],
+    )
+}
+
+/// Manim's open-spline tridiagonal solve (`get_smooth_open_cubic_bezier_handle_points`).
+fn smooth_open_handles(anchors: &[Vec2d]) -> (Vec<Vec2d>, Vec<Vec2d>) {
+    let curve_count = anchors.len() - 1;
+    debug_assert!(curve_count >= 2);
+
+    let mut c_prime = vec![0.0_f64; curve_count - 1];
+    c_prime[0] = 0.5;
+    for index in 1..curve_count - 1 {
+        c_prime[index] = 1.0 / (4.0 - c_prime[index - 1]);
+    }
+
+    let mut d_prime = vec![Vec2d::ZERO; curve_count];
+    d_prime[0] = anchors[0].scale(0.5).add(anchors[1]);
+    for index in 1..curve_count - 1 {
+        let rhs = anchors[index]
+            .scale(4.0)
+            .add(anchors[index + 1].scale(2.0))
+            .sub(d_prime[index - 1]);
+        d_prime[index] = rhs.scale(c_prime[index]);
+    }
+
+    let last = curve_count - 1;
+    let last_factor = 1.0 / (7.0 - 2.0 * c_prime[last - 1]);
+    d_prime[last] = anchors[last]
+        .scale(8.0)
+        .add(anchors[last + 1])
+        .sub(d_prime[last - 1].scale(2.0))
+        .scale(last_factor);
+
+    let mut first_handles = d_prime;
+    for index in (0..last).rev() {
+        first_handles[index] =
+            first_handles[index].sub(first_handles[index + 1].scale(c_prime[index]));
+    }
+
+    let mut second_handles = vec![Vec2d::ZERO; curve_count];
+    for index in 0..last {
+        second_handles[index] = anchors[index + 1].scale(2.0).sub(first_handles[index + 1]);
+    }
+    second_handles[last] = anchors[last + 1].add(first_handles[last]).scale(0.5);
+
+    (first_handles, second_handles)
+}
+
+/// Manim's closed-spline cyclic tridiagonal solve
+/// (`get_smooth_closed_cubic_bezier_handle_points`).
+fn smooth_closed_handles(anchors: &[Vec2d]) -> (Vec<Vec2d>, Vec<Vec2d>) {
+    let curve_count = anchors.len() - 1;
+    debug_assert!(curve_count >= 2);
+
+    let mut c_prime = vec![0.0_f64; curve_count - 1];
+    let mut u_prime = vec![0.0_f64; curve_count - 1];
+    c_prime[0] = 1.0 / 3.0;
+    u_prime[0] = 1.0 / 3.0;
+    for index in 1..curve_count - 1 {
+        c_prime[index] = 1.0 / (4.0 - c_prime[index - 1]);
+        u_prime[index] = -c_prime[index] * u_prime[index - 1];
+    }
+
+    let last = curve_count - 1;
+    let last_division = 1.0 / (3.0 - c_prime[last - 1]);
+    let u_last = last_division * (1.0 - u_prime[last - 1]);
+
+    let mut q = vec![0.0_f64; curve_count];
+    q[last] = u_last;
+    for index in (0..last).rev() {
+        q[index] = u_prime[index] - c_prime[index] * q[index + 1];
+    }
+
+    let mut d_prime = vec![Vec2d::ZERO; curve_count];
+    d_prime[0] = anchors[0]
+        .scale(4.0)
+        .add(anchors[1].scale(2.0))
+        .scale(1.0 / 3.0);
+    for index in 1..last {
+        let rhs = anchors[index]
+            .scale(4.0)
+            .add(anchors[index + 1].scale(2.0))
+            .sub(d_prime[index - 1]);
+        d_prime[index] = rhs.scale(c_prime[index]);
+    }
+    d_prime[last] = anchors[last]
+        .scale(4.0)
+        .add(anchors[last + 1].scale(2.0))
+        .sub(d_prime[last - 1])
+        .scale(last_division);
+
+    let mut y = d_prime.clone();
+    for index in (0..last).rev() {
+        y[index] = d_prime[index].sub(y[index + 1].scale(c_prime[index]));
+    }
+
+    let endpoint_sum = y[0].add(y[last]);
+    let correction_scale = 1.0 / (1.0 + q[0] + q[last]);
+    let mut first_handles = vec![Vec2d::ZERO; curve_count];
+    for index in 0..curve_count {
+        first_handles[index] = y[index].sub(endpoint_sum.scale(correction_scale * q[index]));
+    }
+
+    let mut second_handles = vec![Vec2d::ZERO; curve_count];
+    for index in 0..last {
+        second_handles[index] = anchors[index + 1].scale(2.0).sub(first_handles[index + 1]);
+    }
+    second_handles[last] = anchors[last + 1].scale(2.0).sub(first_handles[0]);
+
+    (first_handles, second_handles)
+}
+
+fn lower_points(points: &[Vec2d]) -> Result<Vec<Vec2>, PathSmoothingError> {
+    points.iter().copied().map(Vec2d::lower).collect()
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct Vec2d {
+    x: f64,
+    y: f64,
+}
+
+impl Vec2d {
+    const ZERO: Self = Self { x: 0.0, y: 0.0 };
+
+    fn add(self, other: Self) -> Self {
+        Self {
+            x: self.x + other.x,
+            y: self.y + other.y,
+        }
+    }
+
+    fn sub(self, other: Self) -> Self {
+        Self {
+            x: self.x - other.x,
+            y: self.y - other.y,
+        }
+    }
+
+    fn scale(self, factor: f64) -> Self {
+        Self {
+            x: self.x * factor,
+            y: self.y * factor,
+        }
+    }
+
+    fn lower(self) -> Result<Vec2, PathSmoothingError> {
+        if !self.x.is_finite()
+            || !self.y.is_finite()
+            || self.x.abs() > f64::from(f32::MAX)
+            || self.y.abs() > f64::from(f32::MAX)
+        {
+            return Err(PathSmoothingError::CoordinateOverflow {
+                x: self.x,
+                y: self.y,
+            });
+        }
+        Ok(Vec2::new(self.x as f32, self.y as f32))
+    }
+}
+
+impl From<Vec2> for Vec2d {
+    fn from(value: Vec2) -> Self {
+        Self {
+            x: f64::from(value.x),
+            y: f64::from(value.y),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use noon_core::PathCommand;
+
+    fn assert_point(actual: Vec2, expected: Vec2) {
+        assert!(
+            (actual - expected).length() <= 1.0e-5,
+            "expected {expected:?}, got {actual:?}"
+        );
+    }
+
+    #[test]
+    fn two_anchors_keep_straight_line_handles() {
+        let (first, second) =
+            smooth_cubic_bezier_handles(&[Vec2::new(0.0, 0.0), Vec2::new(3.0, 0.0)]).unwrap();
+        assert_eq!(first.len(), 1);
+        assert_eq!(second.len(), 1);
+        assert_point(first[0], Vec2::new(1.0, 0.0));
+        assert_point(second[0], Vec2::new(2.0, 0.0));
+    }
+
+    #[test]
+    fn open_three_anchor_handles_match_manim_v021_oracle() {
+        let (first, second) = smooth_cubic_bezier_handles(&[
+            Vec2::new(0.0, 0.0),
+            Vec2::new(1.0, 1.0),
+            Vec2::new(2.0, 0.0),
+        ])
+        .unwrap();
+
+        assert_point(first[0], Vec2::new(1.0 / 3.0, 0.5));
+        assert_point(second[0], Vec2::new(2.0 / 3.0, 1.0));
+        assert_point(first[1], Vec2::new(4.0 / 3.0, 1.0));
+        assert_point(second[1], Vec2::new(5.0 / 3.0, 0.5));
+    }
+
+    #[test]
+    fn closed_square_handles_match_manim_v021_oracle() {
+        let (first, second) = smooth_cubic_bezier_handles(&[
+            Vec2::new(0.0, 0.0),
+            Vec2::new(1.0, 0.0),
+            Vec2::new(1.0, 1.0),
+            Vec2::new(0.0, 1.0),
+            Vec2::new(0.0, 0.0),
+        ])
+        .unwrap();
+
+        let expected_first = [
+            Vec2::new(0.25, -0.25),
+            Vec2::new(1.25, 0.25),
+            Vec2::new(0.75, 1.25),
+            Vec2::new(-0.25, 0.75),
+        ];
+        let expected_second = [
+            Vec2::new(0.75, -0.25),
+            Vec2::new(1.25, 0.75),
+            Vec2::new(0.25, 1.25),
+            Vec2::new(-0.25, 0.25),
+        ];
+        for index in 0..4 {
+            assert_point(first[index], expected_first[index]);
+            assert_point(second[index], expected_second[index]);
+        }
+    }
+
+    #[test]
+    fn smoothing_keeps_disconnected_subpaths_disconnected() {
+        let path = smooth_cubic_path_from_subpaths(&[
+            vec![
+                Vec2::new(0.0, 0.0),
+                Vec2::new(1.0, 1.0),
+                Vec2::new(2.0, 0.0),
+            ],
+            vec![Vec2::new(3.0, 0.0), Vec2::new(4.0, 0.0)],
+        ])
+        .unwrap();
+
+        assert_eq!(path.commands().len(), 5);
+        assert!(matches!(path.commands()[0], PathCommand::MoveTo { .. }));
+        assert!(matches!(path.commands()[1], PathCommand::CubicTo { .. }));
+        assert!(matches!(path.commands()[2], PathCommand::CubicTo { .. }));
+        assert!(matches!(path.commands()[3], PathCommand::MoveTo { .. }));
+        assert!(matches!(path.commands()[4], PathCommand::CubicTo { .. }));
+    }
+
+    #[test]
+    fn one_anchor_subpath_remains_a_move_only_path() {
+        let path = smooth_cubic_path_from_subpaths(&[vec![Vec2::new(2.0, -1.0)]]).unwrap();
+        assert_eq!(
+            path.commands(),
+            &[PathCommand::MoveTo {
+                to: Vec2::new(2.0, -1.0)
+            }]
+        );
+    }
+
+    #[test]
+    fn non_finite_anchor_is_rejected_before_solve() {
+        let anchors = [Vec2::ZERO, Vec2::new(f32::NAN, 1.0)];
+        let error = smooth_cubic_bezier_handles(&anchors).unwrap_err();
+        match error {
+            PathSmoothingError::NonFiniteAnchor { index, point } => {
+                assert_eq!(index, 1);
+                assert!(point.x.is_nan());
+                assert_eq!(point.y, 1.0);
+            }
+            other => panic!("expected non-finite anchor error, got {other:?}"),
+        }
+    }
+}

--- a/crates/noon/Cargo.toml
+++ b/crates/noon/Cargo.toml
@@ -8,6 +8,7 @@ description = "Ergonomic language-neutral authoring facade for Noon"
 [dependencies]
 noon-compile = { path = "../noon-compile" }
 noon-core = { path = "../noon-core" }
+noon-geometry = { path = "../noon-geometry" }
 noon-text-native = { path = "../noon-text-native" }
 noon-typst = { path = "../noon-typst" }
 swash = "=0.2.10"

--- a/crates/noon/src/lib.rs
+++ b/crates/noon/src/lib.rs
@@ -14,6 +14,7 @@ mod elbow_authoring;
 mod geometry_authoring;
 mod legacy;
 mod line_matcher_authoring;
+mod plot_geometry_authoring;
 mod plot_sampling_authoring;
 mod polygram_authoring;
 mod reactive_authoring;
@@ -30,6 +31,7 @@ pub use elbow_authoring::*;
 pub use geometry_authoring::*;
 pub use legacy::*;
 pub use line_matcher_authoring::*;
+pub use plot_geometry_authoring::*;
 pub use plot_sampling_authoring::*;
 pub use polygram_authoring::*;
 pub use reactive_authoring::*;
@@ -42,13 +44,14 @@ pub use text_authoring::*;
 pub mod prelude {
     pub use crate::legacy::prelude::*;
     pub use crate::{
-        AnnularSector, Annulus, Arc, ArcAuthoringError, ArcBetweenPoints, Axes2DState,
-        BackgroundRectangle, CoordinateSystemError, Cross, Dot, Elbow, ElbowAuthoringError,
-        Ellipse, GeometryAuthoringError, LineMatcherAuthoringError, MathTypst, MovingCameraScene,
-        NumberLineState, NumberRange, ParametricSamplePlan, PlotRangeRequest, PlotSamplingError,
-        Polygon, Polygram, PolygramAuthoringError, ReactiveScene, ReactiveTimelineScene,
-        RegularPolygon, RegularPolygram, RetainedMobject, RetainedScene, RoundedRectangle,
-        RoundedRectangleAuthoringError, SampleRange, SampleSpan, Sector,
+        axes_function_vector_path, parametric_vector_path, AnnularSector, Annulus, Arc,
+        ArcAuthoringError, ArcBetweenPoints, Axes2DState, BackgroundRectangle,
+        CoordinateSystemError, Cross, Dot, Elbow, ElbowAuthoringError, Ellipse,
+        GeometryAuthoringError, LineMatcherAuthoringError, MathTypst, MovingCameraScene,
+        NumberLineState, NumberRange, ParametricSamplePlan, PlotGeometryError, PlotRangeRequest,
+        PlotSamplingError, Polygon, Polygram, PolygramAuthoringError, ReactiveScene,
+        ReactiveTimelineScene, RegularPolygon, RegularPolygram, RetainedMobject, RetainedScene,
+        RoundedRectangle, RoundedRectangleAuthoringError, SampleRange, SampleSpan, Sector,
         ShapeMatcherAuthoringError, Star, SurroundingRectangle, Text, TextAuthoringError, Triangle,
         Typst, Underline, ValueTracker, VectorSignal, BACKGROUND_RECTANGLE_DEFAULT_FILL_OPACITY,
         DEFAULT_CROSS_SCALE_FACTOR, DEFAULT_CROSS_STROKE_WIDTH, DEFAULT_DOT_RADIUS,

--- a/crates/noon/src/plot_geometry_authoring.rs
+++ b/crates/noon/src/plot_geometry_authoring.rs
@@ -194,18 +194,12 @@ mod tests {
 
     #[test]
     fn unsmoothed_discontinuities_remain_separate_corner_subpaths() {
-        let plan = ParametricSamplePlan::new(
-            SampleRange::new(-2.0, 2.0, 1.0).unwrap(),
-            &[0.0],
-            0.1,
-        )
-        .unwrap();
-        let path = parametric_vector_path(
-            &plan,
-            |parameter| Vec2::new(parameter as f32, 0.0),
-            false,
-        )
-        .unwrap();
+        let plan =
+            ParametricSamplePlan::new(SampleRange::new(-2.0, 2.0, 1.0).unwrap(), &[0.0], 0.1)
+                .unwrap();
+        let path =
+            parametric_vector_path(&plan, |parameter| Vec2::new(parameter as f32, 0.0), false)
+                .unwrap();
 
         let move_count = path
             .commands()
@@ -228,9 +222,8 @@ mod tests {
             2.0,
         )
         .unwrap();
-        let plan = ParametricSamplePlan::without_discontinuities(
-            SampleRange::new(0.0, 1.0, 1.0).unwrap(),
-        );
+        let plan =
+            ParametricSamplePlan::without_discontinuities(SampleRange::new(0.0, 1.0, 1.0).unwrap());
         let error = axes_function_vector_path(axes, &plan, |_| f64::INFINITY, true).unwrap_err();
         match error {
             PlotGeometryError::NonFiniteFunctionValue { parameter, value } => {
@@ -243,9 +236,8 @@ mod tests {
 
     #[test]
     fn non_finite_parametric_point_fails_before_geometry_creation() {
-        let plan = ParametricSamplePlan::without_discontinuities(
-            SampleRange::new(0.0, 1.0, 1.0).unwrap(),
-        );
+        let plan =
+            ParametricSamplePlan::without_discontinuities(SampleRange::new(0.0, 1.0, 1.0).unwrap());
         let error = parametric_vector_path(&plan, |_| Vec2::new(f32::NAN, 0.0), false).unwrap_err();
         match error {
             PlotGeometryError::NonFinitePoint { parameter, point } => {

--- a/crates/noon/src/plot_geometry_authoring.rs
+++ b/crates/noon/src/plot_geometry_authoring.rs
@@ -1,0 +1,259 @@
+use crate::{Axes2DState, CoordinateSystemError, ParametricSamplePlan, PlotSamplingError};
+use noon_core::{Vec2, VectorPath};
+use noon_geometry::{smooth_cubic_path_from_subpaths, PathSmoothingError};
+
+/// Compile sampled scene-space points into one ordinary retained `VectorPath`.
+///
+/// Function evaluation is authoring-time work. The returned path contains only
+/// immutable geometry, so playback/seek never calls the source function again.
+pub fn parametric_vector_path<F>(
+    plan: &ParametricSamplePlan,
+    mut point_from_parameter: F,
+    use_smoothing: bool,
+) -> Result<VectorPath, PlotGeometryError>
+where
+    F: FnMut(f64) -> Vec2,
+{
+    build_sampled_path(plan, use_smoothing, |parameter| {
+        let point = point_from_parameter(parameter);
+        if vec2_is_finite(point) {
+            Ok(point)
+        } else {
+            Err(PlotGeometryError::NonFinitePoint { parameter, point })
+        }
+    })
+}
+
+/// Compile the initial Manim-compatible `Axes.plot(function)` subset.
+///
+/// Parameters come from [`ParametricSamplePlan`], `function` is evaluated once
+/// per parameter, and [`Axes2DState`] owns the coordinate-to-scene mapping. With
+/// `use_smoothing=true`, the mapped anchors pass through the shared Manim cubic
+/// spline implementation in `noon-geometry`; otherwise they remain corners.
+pub fn axes_function_vector_path<F>(
+    axes: Axes2DState,
+    plan: &ParametricSamplePlan,
+    mut function: F,
+    use_smoothing: bool,
+) -> Result<VectorPath, PlotGeometryError>
+where
+    F: FnMut(f64) -> f64,
+{
+    build_sampled_path(plan, use_smoothing, |parameter| {
+        let value = function(parameter);
+        if !value.is_finite() {
+            return Err(PlotGeometryError::NonFiniteFunctionValue { parameter, value });
+        }
+        Ok(axes.coords_to_point(parameter, value)?)
+    })
+}
+
+fn build_sampled_path<F>(
+    plan: &ParametricSamplePlan,
+    use_smoothing: bool,
+    mut point_from_parameter: F,
+) -> Result<VectorPath, PlotGeometryError>
+where
+    F: FnMut(f64) -> Result<Vec2, PlotGeometryError>,
+{
+    let parameter_subpaths = plan.parameter_subpaths()?;
+    let mut point_subpaths = Vec::with_capacity(parameter_subpaths.len());
+    for parameters in parameter_subpaths {
+        let mut points = Vec::with_capacity(parameters.len());
+        for parameter in parameters {
+            points.push(point_from_parameter(parameter)?);
+        }
+        point_subpaths.push(points);
+    }
+
+    if use_smoothing {
+        Ok(smooth_cubic_path_from_subpaths(&point_subpaths)?)
+    } else {
+        Ok(corner_path_from_subpaths(&point_subpaths))
+    }
+}
+
+fn corner_path_from_subpaths(subpaths: &[Vec<Vec2>]) -> VectorPath {
+    let mut path = VectorPath::new();
+    for points in subpaths {
+        let Some((&first, rest)) = points.split_first() else {
+            continue;
+        };
+        path = path.move_to(first);
+        for &point in rest {
+            path = path.line_to(point);
+        }
+    }
+    path
+}
+
+fn vec2_is_finite(point: Vec2) -> bool {
+    point.x.is_finite() && point.y.is_finite()
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum PlotGeometryError {
+    Sampling(PlotSamplingError),
+    Coordinates(CoordinateSystemError),
+    Smoothing(PathSmoothingError),
+    NonFiniteFunctionValue { parameter: f64, value: f64 },
+    NonFinitePoint { parameter: f64, point: Vec2 },
+}
+
+impl std::fmt::Display for PlotGeometryError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Sampling(error) => error.fmt(formatter),
+            Self::Coordinates(error) => error.fmt(formatter),
+            Self::Smoothing(error) => error.fmt(formatter),
+            Self::NonFiniteFunctionValue { parameter, value } => write!(
+                formatter,
+                "plot function must return a finite value at {parameter}: {value}"
+            ),
+            Self::NonFinitePoint { parameter, point } => write!(
+                formatter,
+                "parametric function must return a finite point at {parameter}: ({}, {})",
+                point.x, point.y
+            ),
+        }
+    }
+}
+
+impl std::error::Error for PlotGeometryError {}
+
+impl From<PlotSamplingError> for PlotGeometryError {
+    fn from(value: PlotSamplingError) -> Self {
+        Self::Sampling(value)
+    }
+}
+
+impl From<CoordinateSystemError> for PlotGeometryError {
+    fn from(value: CoordinateSystemError) -> Self {
+        Self::Coordinates(value)
+    }
+}
+
+impl From<PathSmoothingError> for PlotGeometryError {
+    fn from(value: PathSmoothingError) -> Self {
+        Self::Smoothing(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{NumberRange, SampleRange};
+    use noon_core::PathCommand;
+
+    fn assert_point(actual: Vec2, expected: Vec2) {
+        assert!(
+            (actual - expected).length() <= 1.0e-5,
+            "expected {expected:?}, got {actual:?}"
+        );
+    }
+
+    #[test]
+    fn axes_function_maps_each_parameter_once_before_smoothing() {
+        let axes = Axes2DState::new(
+            NumberRange::new(-2.0, 2.0, 1.0).unwrap(),
+            NumberRange::new(-2.0, 2.0, 1.0).unwrap(),
+            4.0,
+            4.0,
+        )
+        .unwrap();
+        let plan = ParametricSamplePlan::without_discontinuities(
+            SampleRange::new(-1.0, 1.0, 1.0).unwrap(),
+        );
+        let mut calls = Vec::new();
+        let path = axes_function_vector_path(
+            axes,
+            &plan,
+            |x| {
+                calls.push(x);
+                x * x
+            },
+            true,
+        )
+        .unwrap();
+
+        assert_eq!(calls, vec![-1.0, 0.0, 1.0]);
+        assert_eq!(path.commands().len(), 3);
+        match path.commands()[0] {
+            PathCommand::MoveTo { to } => assert_point(to, Vec2::new(-1.0, 1.0)),
+            ref other => panic!("expected MoveTo, got {other:?}"),
+        }
+        match path.commands()[1] {
+            PathCommand::CubicTo { to, .. } => assert_point(to, Vec2::ZERO),
+            ref other => panic!("expected CubicTo, got {other:?}"),
+        }
+        match path.commands()[2] {
+            PathCommand::CubicTo { to, .. } => assert_point(to, Vec2::new(1.0, 1.0)),
+            ref other => panic!("expected CubicTo, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unsmoothed_discontinuities_remain_separate_corner_subpaths() {
+        let plan = ParametricSamplePlan::new(
+            SampleRange::new(-2.0, 2.0, 1.0).unwrap(),
+            &[0.0],
+            0.1,
+        )
+        .unwrap();
+        let path = parametric_vector_path(
+            &plan,
+            |parameter| Vec2::new(parameter as f32, 0.0),
+            false,
+        )
+        .unwrap();
+
+        let move_count = path
+            .commands()
+            .iter()
+            .filter(|command| matches!(command, PathCommand::MoveTo { .. }))
+            .count();
+        assert_eq!(move_count, 2);
+        assert!(path
+            .commands()
+            .iter()
+            .all(|command| matches!(command, PathCommand::MoveTo { .. } | PathCommand::LineTo { .. })));
+    }
+
+    #[test]
+    fn non_finite_function_value_fails_before_coordinate_mapping() {
+        let axes = Axes2DState::new(
+            NumberRange::new(-1.0, 1.0, 1.0).unwrap(),
+            NumberRange::new(-1.0, 1.0, 1.0).unwrap(),
+            2.0,
+            2.0,
+        )
+        .unwrap();
+        let plan = ParametricSamplePlan::without_discontinuities(
+            SampleRange::new(0.0, 1.0, 1.0).unwrap(),
+        );
+        let error = axes_function_vector_path(axes, &plan, |_| f64::INFINITY, true).unwrap_err();
+        assert!(matches!(
+            error,
+            PlotGeometryError::NonFiniteFunctionValue {
+                parameter: 0.0,
+                value: f64::INFINITY
+            }
+        ));
+    }
+
+    #[test]
+    fn non_finite_parametric_point_fails_before_geometry_creation() {
+        let plan = ParametricSamplePlan::without_discontinuities(
+            SampleRange::new(0.0, 1.0, 1.0).unwrap(),
+        );
+        let error = parametric_vector_path(&plan, |_| Vec2::new(f32::NAN, 0.0), false).unwrap_err();
+        match error {
+            PlotGeometryError::NonFinitePoint { parameter, point } => {
+                assert_eq!(parameter, 0.0);
+                assert!(point.x.is_nan());
+                assert_eq!(point.y, 0.0);
+            }
+            other => panic!("expected non-finite point error, got {other:?}"),
+        }
+    }
+}

--- a/crates/noon/src/plot_geometry_authoring.rs
+++ b/crates/noon/src/plot_geometry_authoring.rs
@@ -213,10 +213,10 @@ mod tests {
             .filter(|command| matches!(command, PathCommand::MoveTo { .. }))
             .count();
         assert_eq!(move_count, 2);
-        assert!(path
-            .commands()
-            .iter()
-            .all(|command| matches!(command, PathCommand::MoveTo { .. } | PathCommand::LineTo { .. })));
+        assert!(path.commands().iter().all(|command| matches!(
+            command,
+            PathCommand::MoveTo { .. } | PathCommand::LineTo { .. }
+        )));
     }
 
     #[test]
@@ -232,13 +232,13 @@ mod tests {
             SampleRange::new(0.0, 1.0, 1.0).unwrap(),
         );
         let error = axes_function_vector_path(axes, &plan, |_| f64::INFINITY, true).unwrap_err();
-        assert!(matches!(
-            error,
-            PlotGeometryError::NonFiniteFunctionValue {
-                parameter: 0.0,
-                value: f64::INFINITY
+        match error {
+            PlotGeometryError::NonFiniteFunctionValue { parameter, value } => {
+                assert_eq!(parameter, 0.0);
+                assert!(value.is_infinite() && value.is_sign_positive());
             }
-        ));
+            other => panic!("expected non-finite function value error, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- connect the shared #696 sampling plan to ordinary immutable `VectorPath` geometry
- evaluate static parametric/axes functions exactly once per sampled parameter at authoring time
- map `Axes.plot` samples through the shared `Axes2DState` coordinate semantics
- delegate default `use_smoothing=True` to the shared Manim cubic spline implementation from #706
- preserve discontinuities as independent subpaths; `use_smoothing=False` emits only corner segments
- reject non-finite function values/points before retained geometry creation

## Architecture
There is no `Graph`/`Axes` renderer primitive and no per-frame function callback. Both `parametric_vector_path` and `axes_function_vector_path` return the same `noon_core::VectorPath` consumed by existing geometry/render pipelines. The `noon` facade takes an explicit dependency on `noon-geometry` because path smoothing is an authoring-time geometry transform.

The branch currently has merge ancestry from the clean #704 sampling head and clean #706 smoothing head so CI can validate the complete dependency union before those drafts are merged. It will be flattened/rebased once prerequisites land.

## Focused coverage
- `Axes.plot` sample evaluation occurs once per parameter before smoothing
- mapped anchors become cubic segments with default smoothing
- explicit discontinuities remain separate `MoveTo` subpaths when unsmoothed
- non-finite scalar and parametric outputs fail before geometry creation

Tracks #696 / parent #85. Depends on #701 and #706.