### PR TITLE
Derive retained Text animation members from rendered glyphs

### DIFF
--- a/crates/noon-core/src/reactive.rs
+++ b/crates/noon-core/src/reactive.rs
@@ -44,6 +44,10 @@ pub use font_resources::*;
 mod text_resources;
 pub use text_resources::*;
 
+#[path = "text_animation_members.rs"]
+mod text_animation_members;
+pub use text_animation_members::*;
+
 #[path = "resource_mutation.rs"]
 mod resource_mutation;
 pub use resource_mutation::*;

--- a/crates/noon-core/src/text_animation_members.rs
+++ b/crates/noon-core/src/text_animation_members.rs
@@ -1,0 +1,298 @@
+use std::collections::BTreeMap;
+
+use crate::{TextRenderItem, TextResource, TextSourceKind, TextSourceSpan};
+
+/// Stable reference to one shaped glyph inside an immutable [`TextResource`].
+///
+/// This is internal retained-content identity, not a semantic scene object. A public
+/// `Text` remains one object while animation/render code can address the glyphs that
+/// form one rendered source cluster.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct TextAnimationGlyphRef {
+    pub run_index: u32,
+    pub glyph_index: u32,
+}
+
+/// One rendered plain-text animation member in shaped painter order.
+///
+/// Multiple glyphs may belong to the same source cluster. Whitespace/newlines
+/// naturally produce no member because the shaper emits no glyph for them.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TextAnimationMember {
+    pub source_span: TextSourceSpan,
+    pub glyphs: Vec<TextAnimationGlyphRef>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TextAnimationMemberError {
+    UnsupportedSourceKind(TextSourceKind),
+    VectorContent,
+    MissingRun(u32),
+    TooManyGlyphs,
+}
+
+impl std::fmt::Display for TextAnimationMemberError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnsupportedSourceKind(kind) => {
+                write!(
+                    formatter,
+                    "text animation members require plain Text, got {kind:?}"
+                )
+            }
+            Self::VectorContent => formatter
+                .write_str("plain Text animation members cannot contain backend vector items"),
+            Self::MissingRun(index) => {
+                write!(
+                    formatter,
+                    "text render stream references missing glyph run {index}"
+                )
+            }
+            Self::TooManyGlyphs => formatter.write_str(
+                "text animation member glyph index exceeds the retained u32 identity range",
+            ),
+        }
+    }
+}
+
+impl std::error::Error for TextAnimationMemberError {}
+
+/// Derive Manim-like rendered-character family identity from normalized native text.
+///
+/// Members are ordered by first appearance in the resource painter stream. Glyphs
+/// sharing the same UTF-8 source cluster span stay together even when the shaper emits
+/// multiple glyphs for that cluster. Source gaps such as spaces/newlines do not create
+/// fake members. This intentionally accepts only `Plain` resources; Typst/Tex family
+/// semantics must be defined by their own source model rather than inheriting plain-
+/// text assumptions.
+///
+/// The result is derived data. It must not be serialized into scene or authoring wire
+/// formats and must not create externally visible semantic object identities.
+pub fn plain_text_animation_members(
+    resource: &TextResource,
+) -> Result<Vec<TextAnimationMember>, TextAnimationMemberError> {
+    if resource.kind != TextSourceKind::Plain {
+        return Err(TextAnimationMemberError::UnsupportedSourceKind(
+            resource.kind,
+        ));
+    }
+    if !resource.vector_items.is_empty() {
+        return Err(TextAnimationMemberError::VectorContent);
+    }
+
+    let mut members = Vec::<TextAnimationMember>::new();
+    let mut by_span = BTreeMap::<TextSourceSpan, usize>::new();
+
+    for item in resource.render_items.iter() {
+        let TextRenderItem::GlyphRun(run_index) = *item else {
+            return Err(TextAnimationMemberError::VectorContent);
+        };
+        let run = resource
+            .runs
+            .get(run_index as usize)
+            .ok_or(TextAnimationMemberError::MissingRun(run_index))?;
+        for (glyph_index, glyph) in run.glyphs.iter().enumerate() {
+            let glyph_index =
+                u32::try_from(glyph_index).map_err(|_| TextAnimationMemberError::TooManyGlyphs)?;
+            let glyph_ref = TextAnimationGlyphRef {
+                run_index,
+                glyph_index,
+            };
+            let span = glyph.cluster.source_span;
+            if let Some(&member_index) = by_span.get(&span) {
+                members[member_index].glyphs.push(glyph_ref);
+            } else {
+                let member_index = members.len();
+                by_span.insert(span, member_index);
+                members.push(TextAnimationMember {
+                    source_span: span,
+                    glyphs: vec![glyph_ref],
+                });
+            }
+        }
+    }
+
+    Ok(members)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::{
+        FontFaceIdentity, GlyphRun, PositionedGlyph, Rect, TextAffineTransform,
+        TextClusterIdentity, TextDirection, TextLayoutArtifact, TextLayoutBackend,
+        TextLayoutBackendKind, Vec2,
+    };
+
+    fn glyph(span: TextSourceSpan, ordinal: u32, x: f32) -> PositionedGlyph {
+        PositionedGlyph {
+            glyph_id: ordinal + 1,
+            cluster: TextClusterIdentity {
+                source_span: span,
+                cluster_ordinal: ordinal,
+                semantic_key: None,
+            },
+            origin: Vec2::new(x, 0.0),
+            advance: Vec2::new(1.0, 0.0),
+            bounds: Rect::new(Vec2::new(x, 0.0), Vec2::new(x + 1.0, 1.0)),
+        }
+    }
+
+    fn run(glyphs: Vec<PositionedGlyph>) -> GlyphRun {
+        GlyphRun {
+            font: FontFaceIdentity {
+                family: Arc::from("Test"),
+                face_key: Arc::from("test-face"),
+                face_index: 0,
+                variation_key: Arc::from(""),
+            },
+            variations: Arc::from([]),
+            font_size: 24.0,
+            direction: TextDirection::LeftToRight,
+            fill: None,
+            stroke: None,
+            transform: TextAffineTransform::IDENTITY,
+            glyphs: glyphs.into(),
+        }
+    }
+
+    fn resource(
+        source: &str,
+        runs: Vec<GlyphRun>,
+        render_items: Vec<TextRenderItem>,
+    ) -> TextResource {
+        TextResource {
+            source: Arc::from(source),
+            kind: TextSourceKind::Plain,
+            runs: runs.into(),
+            vector_items: Arc::from([]),
+            render_items: render_items.into(),
+            parts: Arc::from([]),
+            bounds: Rect::new(Vec2::ZERO, Vec2::ONE),
+            baseline: 0.0,
+            layout_artifact: Some(TextLayoutArtifact {
+                backend: TextLayoutBackend {
+                    kind: TextLayoutBackendKind::NativeText,
+                    version: Arc::from("test"),
+                },
+                template_fingerprint: Arc::from("template"),
+                artifact_fingerprint: Arc::from("artifact"),
+                backend_payload_key: None,
+            }),
+        }
+    }
+
+    #[test]
+    fn whitespace_gaps_do_not_create_fake_animation_members() {
+        let text = resource(
+            "A B",
+            vec![run(vec![
+                glyph(TextSourceSpan::new(0, 1), 0, 0.0),
+                glyph(TextSourceSpan::new(2, 3), 1, 2.0),
+            ])],
+            vec![TextRenderItem::GlyphRun(0)],
+        );
+        let members = plain_text_animation_members(&text).unwrap();
+        assert_eq!(members.len(), 2);
+        assert_eq!(members[0].source_span, TextSourceSpan::new(0, 1));
+        assert_eq!(members[1].source_span, TextSourceSpan::new(2, 3));
+    }
+
+    #[test]
+    fn multiple_glyphs_in_one_source_cluster_remain_one_animation_member() {
+        let text = resource(
+            "fi",
+            vec![run(vec![
+                glyph(TextSourceSpan::new(0, 2), 0, 0.0),
+                glyph(TextSourceSpan::new(0, 2), 1, 0.5),
+            ])],
+            vec![TextRenderItem::GlyphRun(0)],
+        );
+        let members = plain_text_animation_members(&text).unwrap();
+        assert_eq!(members.len(), 1);
+        assert_eq!(members[0].source_span, TextSourceSpan::new(0, 2));
+        assert_eq!(
+            members[0].glyphs,
+            vec![
+                TextAnimationGlyphRef {
+                    run_index: 0,
+                    glyph_index: 0,
+                },
+                TextAnimationGlyphRef {
+                    run_index: 0,
+                    glyph_index: 1,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn first_painter_appearance_defines_member_order_across_runs() {
+        let text = resource(
+            "AB",
+            vec![
+                run(vec![glyph(TextSourceSpan::new(0, 1), 0, 0.0)]),
+                run(vec![glyph(TextSourceSpan::new(1, 2), 1, 1.0)]),
+            ],
+            vec![TextRenderItem::GlyphRun(1), TextRenderItem::GlyphRun(0)],
+        );
+        let members = plain_text_animation_members(&text).unwrap();
+        assert_eq!(
+            members
+                .iter()
+                .map(|member| member.source_span)
+                .collect::<Vec<_>>(),
+            vec![TextSourceSpan::new(1, 2), TextSourceSpan::new(0, 1)]
+        );
+    }
+
+    #[test]
+    fn repeated_source_span_is_aggregated_without_duplicate_family_identity() {
+        let span = TextSourceSpan::new(0, 2);
+        let text = resource(
+            "fi",
+            vec![
+                run(vec![glyph(span, 0, 0.0)]),
+                run(vec![glyph(span, 1, 1.0)]),
+            ],
+            vec![TextRenderItem::GlyphRun(0), TextRenderItem::GlyphRun(1)],
+        );
+        let members = plain_text_animation_members(&text).unwrap();
+        assert_eq!(members.len(), 1);
+        assert_eq!(members[0].glyphs.len(), 2);
+    }
+
+    #[test]
+    fn non_plain_and_vector_content_fail_closed() {
+        let mut text = resource(
+            "A",
+            vec![run(vec![glyph(TextSourceSpan::new(0, 1), 0, 0.0)])],
+            vec![TextRenderItem::GlyphRun(0)],
+        );
+        text.kind = TextSourceKind::Typst;
+        assert_eq!(
+            plain_text_animation_members(&text),
+            Err(TextAnimationMemberError::UnsupportedSourceKind(
+                TextSourceKind::Typst
+            ))
+        );
+
+        text.kind = TextSourceKind::Plain;
+        text.render_items = Arc::from([TextRenderItem::Vector(0)]);
+        assert_eq!(
+            plain_text_animation_members(&text),
+            Err(TextAnimationMemberError::VectorContent)
+        );
+    }
+
+    #[test]
+    fn malformed_render_run_reference_is_rejected() {
+        let text = resource("A", vec![], vec![TextRenderItem::GlyphRun(7)]);
+        assert_eq!(
+            plain_text_animation_members(&text),
+            Err(TextAnimationMemberError::MissingRun(7))
+        );
+    }
+}

--- a/crates/noon-core/src/text_animation_members.rs
+++ b/crates/noon-core/src/text_animation_members.rs
@@ -1,12 +1,10 @@
-use std::collections::BTreeMap;
-
 use crate::{TextRenderItem, TextResource, TextSourceKind, TextSourceSpan};
 
 /// Stable reference to one shaped glyph inside an immutable [`TextResource`].
 ///
 /// This is internal retained-content identity, not a semantic scene object. A public
-/// `Text` remains one object while animation/render code can address the glyphs that
-/// form one rendered source cluster.
+/// `Text` remains one object while animation/render code can address the rendered
+/// glyph members that Manim exposes through its SVG submobject family.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct TextAnimationGlyphRef {
     pub run_index: u32,
@@ -15,12 +13,14 @@ pub struct TextAnimationGlyphRef {
 
 /// One rendered plain-text animation member in shaped painter order.
 ///
-/// Multiple glyphs may belong to the same source cluster. Whitespace-only source
-/// clusters are excluded even when the shaper emits an advance glyph for them.
-#[derive(Clone, Debug, PartialEq, Eq)]
+/// ManimCE v0.21 Cairo animates `Text` through `family_members_with_points()`. Default
+/// `Text` builds that family from rendered SVG glyph submobjects; whitespace/newlines
+/// are stripped, ligatures naturally collapse to one rendered glyph, and a shaped
+/// source cluster that emits multiple visible glyphs remains multiple family members.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct TextAnimationMember {
     pub source_span: TextSourceSpan,
-    pub glyphs: Vec<TextAnimationGlyphRef>,
+    pub glyph: TextAnimationGlyphRef,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -63,17 +63,17 @@ impl std::fmt::Display for TextAnimationMemberError {
 
 impl std::error::Error for TextAnimationMemberError {}
 
-/// Derive Manim-like rendered-character family identity from normalized native text.
+/// Derive the rendered-glyph family that ManimCE v0.21 animates for default `Text`.
 ///
-/// Members are ordered by first appearance in the resource painter stream. Glyphs
-/// sharing the same UTF-8 source cluster span stay together even when the shaper emits
-/// multiple glyphs for that cluster. Whitespace-only source clusters are excluded
-/// explicitly because shaping backends may retain an advance glyph for them. This
-/// intentionally accepts only `Plain` resources; Typst/Tex family semantics must be
-/// defined by their own source model rather than inheriting plain-text assumptions.
+/// Members follow first painter-stream appearance. Each non-whitespace shaped glyph is
+/// one member, including multiple glyphs that share one source cluster span. A ligature
+/// produced as one shaped glyph therefore remains one member. Whitespace-only source
+/// spans are excluded explicitly because shaping backends may retain advance glyphs for
+/// them even though Manim strips whitespace from the SVG submobject family.
 ///
-/// The result is derived data. It must not be serialized into scene or authoring wire
-/// formats and must not create externally visible semantic object identities.
+/// This intentionally accepts only `Plain` resources; Typst/Tex family semantics must
+/// be defined by their own source model. The result is derived data and must not create
+/// externally visible semantic object identities or authoring-wire glyph IDs.
 pub fn plain_text_animation_members(
     resource: &TextResource,
 ) -> Result<Vec<TextAnimationMember>, TextAnimationMemberError> {
@@ -87,8 +87,6 @@ pub fn plain_text_animation_members(
     }
 
     let mut members = Vec::<TextAnimationMember>::new();
-    let mut by_span = BTreeMap::<TextSourceSpan, usize>::new();
-
     for item in resource.render_items.iter() {
         let TextRenderItem::GlyphRun(run_index) = *item else {
             return Err(TextAnimationMemberError::VectorContent);
@@ -104,20 +102,13 @@ pub fn plain_text_animation_members(
             }
             let glyph_index =
                 u32::try_from(glyph_index).map_err(|_| TextAnimationMemberError::TooManyGlyphs)?;
-            let glyph_ref = TextAnimationGlyphRef {
-                run_index,
-                glyph_index,
-            };
-            if let Some(&member_index) = by_span.get(&span) {
-                members[member_index].glyphs.push(glyph_ref);
-            } else {
-                let member_index = members.len();
-                by_span.insert(span, member_index);
-                members.push(TextAnimationMember {
-                    source_span: span,
-                    glyphs: vec![glyph_ref],
-                });
-            }
+            members.push(TextAnimationMember {
+                source_span: span,
+                glyph: TextAnimationGlyphRef {
+                    run_index,
+                    glyph_index,
+                },
+            });
         }
     }
 
@@ -220,35 +211,38 @@ mod tests {
         let members = plain_text_animation_members(&text).unwrap();
         assert_eq!(members.len(), 2);
         assert_eq!(members[0].source_span, TextSourceSpan::new(0, 1));
+        assert_eq!(members[0].glyph.glyph_index, 0);
         assert_eq!(members[1].source_span, TextSourceSpan::new(2, 3));
+        assert_eq!(members[1].glyph.glyph_index, 2);
     }
 
     #[test]
-    fn multiple_glyphs_in_one_source_cluster_remain_one_animation_member() {
+    fn multiple_glyphs_in_one_source_cluster_remain_distinct_animation_members() {
+        let span = TextSourceSpan::new(0, 2);
         let text = resource(
             "fi",
-            vec![run(vec![
-                glyph(TextSourceSpan::new(0, 2), 0, 0.0),
-                glyph(TextSourceSpan::new(0, 2), 1, 0.5),
-            ])],
+            vec![run(vec![glyph(span, 0, 0.0), glyph(span, 0, 0.5)])],
+            vec![TextRenderItem::GlyphRun(0)],
+        );
+        let members = plain_text_animation_members(&text).unwrap();
+        assert_eq!(members.len(), 2);
+        assert_eq!(members[0].source_span, span);
+        assert_eq!(members[1].source_span, span);
+        assert_eq!(members[0].glyph.glyph_index, 0);
+        assert_eq!(members[1].glyph.glyph_index, 1);
+    }
+
+    #[test]
+    fn one_ligature_glyph_spanning_multiple_source_characters_is_one_member() {
+        let span = TextSourceSpan::new(0, 2);
+        let text = resource(
+            "fi",
+            vec![run(vec![glyph(span, 0, 0.0)])],
             vec![TextRenderItem::GlyphRun(0)],
         );
         let members = plain_text_animation_members(&text).unwrap();
         assert_eq!(members.len(), 1);
-        assert_eq!(members[0].source_span, TextSourceSpan::new(0, 2));
-        assert_eq!(
-            members[0].glyphs,
-            vec![
-                TextAnimationGlyphRef {
-                    run_index: 0,
-                    glyph_index: 0,
-                },
-                TextAnimationGlyphRef {
-                    run_index: 0,
-                    glyph_index: 1,
-                },
-            ]
-        );
+        assert_eq!(members[0].source_span, span);
     }
 
     #[test]
@@ -272,19 +266,20 @@ mod tests {
     }
 
     #[test]
-    fn repeated_source_span_is_aggregated_without_duplicate_family_identity() {
+    fn repeated_source_span_across_runs_remains_distinct_rendered_members() {
         let span = TextSourceSpan::new(0, 2);
         let text = resource(
             "fi",
             vec![
                 run(vec![glyph(span, 0, 0.0)]),
-                run(vec![glyph(span, 1, 1.0)]),
+                run(vec![glyph(span, 0, 1.0)]),
             ],
             vec![TextRenderItem::GlyphRun(0), TextRenderItem::GlyphRun(1)],
         );
         let members = plain_text_animation_members(&text).unwrap();
-        assert_eq!(members.len(), 1);
-        assert_eq!(members[0].glyphs.len(), 2);
+        assert_eq!(members.len(), 2);
+        assert_eq!(members[0].glyph.run_index, 0);
+        assert_eq!(members[1].glyph.run_index, 1);
     }
 
     #[test]

--- a/crates/noon-core/src/text_animation_members.rs
+++ b/crates/noon-core/src/text_animation_members.rs
@@ -15,8 +15,8 @@ pub struct TextAnimationGlyphRef {
 
 /// One rendered plain-text animation member in shaped painter order.
 ///
-/// Multiple glyphs may belong to the same source cluster. Whitespace/newlines
-/// naturally produce no member because the shaper emits no glyph for them.
+/// Multiple glyphs may belong to the same source cluster. Whitespace-only source
+/// clusters are excluded even when the shaper emits an advance glyph for them.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TextAnimationMember {
     pub source_span: TextSourceSpan,
@@ -28,6 +28,7 @@ pub enum TextAnimationMemberError {
     UnsupportedSourceKind(TextSourceKind),
     VectorContent,
     MissingRun(u32),
+    InvalidSourceSpan(TextSourceSpan),
     TooManyGlyphs,
 }
 
@@ -48,6 +49,11 @@ impl std::fmt::Display for TextAnimationMemberError {
                     "text render stream references missing glyph run {index}"
                 )
             }
+            Self::InvalidSourceSpan(span) => write!(
+                formatter,
+                "text animation glyph source span {}..{} is outside the UTF-8 source",
+                span.start, span.end
+            ),
             Self::TooManyGlyphs => formatter.write_str(
                 "text animation member glyph index exceeds the retained u32 identity range",
             ),
@@ -61,10 +67,10 @@ impl std::error::Error for TextAnimationMemberError {}
 ///
 /// Members are ordered by first appearance in the resource painter stream. Glyphs
 /// sharing the same UTF-8 source cluster span stay together even when the shaper emits
-/// multiple glyphs for that cluster. Source gaps such as spaces/newlines do not create
-/// fake members. This intentionally accepts only `Plain` resources; Typst/Tex family
-/// semantics must be defined by their own source model rather than inheriting plain-
-/// text assumptions.
+/// multiple glyphs for that cluster. Whitespace-only source clusters are excluded
+/// explicitly because shaping backends may retain an advance glyph for them. This
+/// intentionally accepts only `Plain` resources; Typst/Tex family semantics must be
+/// defined by their own source model rather than inheriting plain-text assumptions.
 ///
 /// The result is derived data. It must not be serialized into scene or authoring wire
 /// formats and must not create externally visible semantic object identities.
@@ -92,13 +98,16 @@ pub fn plain_text_animation_members(
             .get(run_index as usize)
             .ok_or(TextAnimationMemberError::MissingRun(run_index))?;
         for (glyph_index, glyph) in run.glyphs.iter().enumerate() {
+            let span = glyph.cluster.source_span;
+            if source_span_is_whitespace(resource, span)? {
+                continue;
+            }
             let glyph_index =
                 u32::try_from(glyph_index).map_err(|_| TextAnimationMemberError::TooManyGlyphs)?;
             let glyph_ref = TextAnimationGlyphRef {
                 run_index,
                 glyph_index,
             };
-            let span = glyph.cluster.source_span;
             if let Some(&member_index) = by_span.get(&span) {
                 members[member_index].glyphs.push(glyph_ref);
             } else {
@@ -113,6 +122,19 @@ pub fn plain_text_animation_members(
     }
 
     Ok(members)
+}
+
+fn source_span_is_whitespace(
+    resource: &TextResource,
+    span: TextSourceSpan,
+) -> Result<bool, TextAnimationMemberError> {
+    let start = span.start as usize;
+    let end = span.end as usize;
+    let source = resource
+        .source
+        .get(start..end)
+        .ok_or(TextAnimationMemberError::InvalidSourceSpan(span))?;
+    Ok(!source.is_empty() && source.chars().all(char::is_whitespace))
 }
 
 #[cfg(test)]
@@ -185,12 +207,13 @@ mod tests {
     }
 
     #[test]
-    fn whitespace_gaps_do_not_create_fake_animation_members() {
+    fn whitespace_advance_glyphs_do_not_create_fake_animation_members() {
         let text = resource(
             "A B",
             vec![run(vec![
                 glyph(TextSourceSpan::new(0, 1), 0, 0.0),
-                glyph(TextSourceSpan::new(2, 3), 1, 2.0),
+                glyph(TextSourceSpan::new(1, 2), 1, 1.0),
+                glyph(TextSourceSpan::new(2, 3), 2, 2.0),
             ])],
             vec![TextRenderItem::GlyphRun(0)],
         );
@@ -265,7 +288,7 @@ mod tests {
     }
 
     #[test]
-    fn non_plain_and_vector_content_fail_closed() {
+    fn non_plain_vector_and_malformed_source_content_fail_closed() {
         let mut text = resource(
             "A",
             vec![run(vec![glyph(TextSourceSpan::new(0, 1), 0, 0.0)])],
@@ -284,6 +307,15 @@ mod tests {
         assert_eq!(
             plain_text_animation_members(&text),
             Err(TextAnimationMemberError::VectorContent)
+        );
+
+        text.render_items = Arc::from([TextRenderItem::GlyphRun(0)]);
+        text.runs = Arc::from([run(vec![glyph(TextSourceSpan::new(0, 2), 0, 0.0)])]);
+        assert_eq!(
+            plain_text_animation_members(&text),
+            Err(TextAnimationMemberError::InvalidSourceSpan(
+                TextSourceSpan::new(0, 2)
+            ))
         );
     }
 


### PR DESCRIPTION
Second #705 slice, stacked on #708's shared family timing primitive.

## What this adds
- renderer-independent `TextAnimationMember` derivation from immutable `TextResource`
- preserves one public retained `Text` semantic object while exposing internal rendered-glyph membership for animation/render preparation
- matches ManimCE v0.21 Cairo's `Animation.get_all_families_zipped()` / `family_members_with_points()` model: one rendered SVG glyph submobject is one default-Text animation member
- preserves first painter-stream appearance as family order across runs
- explicitly excludes whitespace-only source spans even when the shaping backend emits an advance glyph
- ligatures naturally remain one member when shaping emits one glyph spanning multiple source characters; multi-glyph combining clusters remain multiple rendered members
- fails closed for non-plain Text, backend vector content, malformed run references/source spans, and u32 glyph-index overflow
- keeps the result derived/non-serialized: no authoring-wire expansion, no Python-owned character IDs, and no fake scene objects

## Pinned Manim contract
ManimCE v0.21 `Animation.interpolate_mobject()` enumerates Cairo `family_members_with_points()`. Default `Text` sets `chars` from its rendered SVG `submobjects`; its own docs explicitly state whitespace/newlines never become submobjects. `disable_ligatures=True` is a separate mode that reconstructs source-character slots, so default Text animation must follow rendered glyphs rather than raw Unicode characters or shaped-cluster count.

#715 remains an independent metadata invariant cleanup because native shaping currently increments `TextClusterIdentity.cluster_ordinal` per glyph despite documenting it as cluster identity. Animation membership no longer relies on that ordinal.

Tracks #705. Depends on #708. Related: #700, #61, #89, #185, #715.