### PR TITLE
Support retained native Text family layout

### DIFF
--- a/.github/workflows/retained-text-animation.yml
+++ b/.github/workflows/retained-text-animation.yml
@@ -19,6 +19,7 @@ on:
       - "scripts/build-python-worker.mjs"
       - "scripts/retained-text-animation-smoke.mjs"
       - "scripts/retained-text-family-identity-smoke.mjs"
+      - "scripts/retained-text-family-layout-smoke.mjs"
       - "scripts/retained-text-family-fade-smoke.mjs"
       - "scripts/retained-text-playback-smoke.mjs"
       - "scripts/retained-text-scene-lifecycle-smoke.mjs"
@@ -43,6 +44,7 @@ on:
       - "scripts/build-python-worker.mjs"
       - "scripts/retained-text-animation-smoke.mjs"
       - "scripts/retained-text-family-identity-smoke.mjs"
+      - "scripts/retained-text-family-layout-smoke.mjs"
       - "scripts/retained-text-family-fade-smoke.mjs"
       - "scripts/retained-text-playback-smoke.mjs"
       - "scripts/retained-text-scene-lifecycle-smoke.mjs"
@@ -115,6 +117,9 @@ jobs:
 
       - name: Test retained Text family identity
         run: node scripts/retained-text-family-identity-smoke.mjs
+
+      - name: Test retained Text family layout
+        run: node scripts/retained-text-family-layout-smoke.mjs
 
       - name: Test retained Text family fades
         run: node scripts/retained-text-family-fade-smoke.mjs

--- a/crates/noon-web/src/authoring_mobject.rs
+++ b/crates/noon-web/src/authoring_mobject.rs
@@ -875,11 +875,10 @@ impl FrontendFamilyTranslation {
         })
     }
 
-    pub fn apply(
-        &mut self,
-        source_member: SemanticNodeId,
-        member: &mut FrontendMobjectHandle,
-    ) -> Result<(), String> {
+    fn apply_with<F>(&mut self, source_member: SemanticNodeId, apply: F) -> Result<(), String>
+    where
+        F: FnOnce((f64, f64)) -> Result<(), String>,
+    {
         let expected = self
             .source_members
             .get(self.next_index)
@@ -891,9 +890,17 @@ impl FrontendFamilyTranslation {
                 self.next_index
             ));
         }
-        member.shift(self.delta.0, self.delta.1)?;
+        apply(self.delta)?;
         self.next_index += 1;
         Ok(())
+    }
+
+    pub fn apply(
+        &mut self,
+        source_member: SemanticNodeId,
+        member: &mut FrontendMobjectHandle,
+    ) -> Result<(), String> {
+        self.apply_with(source_member, |delta| member.shift(delta.0, delta.1))
     }
 
     pub fn finish(&self) -> Result<(), String> {
@@ -1477,6 +1484,8 @@ mod wasm {
 
     use wasm_bindgen::prelude::*;
 
+    use crate::WasmRetainedNativeTextAuthoringHandle;
+
     use super::{
         manim_family_align_to_delta, manim_family_next_to_delta, render_f64,
         semantic_family_leaf_ids, semantic_xy_f64, Bounds2D64, FrontendFamilyArrangePlan,
@@ -1489,6 +1498,52 @@ mod wasm {
     }
 
     type SharedSemanticStore = Rc<RefCell<SemanticStore>>;
+
+    fn retained_native_member_id(
+        semantics: &SharedSemanticStore,
+        member: &WasmAuthoringFamilyMemberHandle,
+        text: &WasmRetainedNativeTextAuthoringHandle,
+        context: &str,
+    ) -> Result<SemanticNodeId, JsValue> {
+        if !Rc::ptr_eq(semantics, &member.semantics) {
+            return Err(JsValue::from_str(&format!(
+                "{context} and retained member belong to different authoring stores"
+            )));
+        }
+        if text.family_identity() != Some(member.id) {
+            return Err(JsValue::from_str(&format!(
+                "{context} retained member identity does not match retained native Text handle"
+            )));
+        }
+        Ok(member.id)
+    }
+
+    fn retained_native_critical_point(
+        text: &WasmRetainedNativeTextAuthoringHandle,
+        direction: (f64, f64),
+    ) -> (f64, f64) {
+        let bounds = text.family_layout_bounds();
+        let center = (
+            (bounds.min_x + bounds.max_x) * 0.5,
+            (bounds.min_y + bounds.max_y) * 0.5,
+        );
+        (
+            if direction.0 < 0.0 {
+                bounds.min_x
+            } else if direction.0 > 0.0 {
+                bounds.max_x
+            } else {
+                center.0
+            },
+            if direction.1 < 0.0 {
+                bounds.min_y
+            } else if direction.1 > 0.0 {
+                bounds.max_y
+            } else {
+                center.1
+            },
+        )
+    }
 
     #[wasm_bindgen]
     pub struct WasmAuthoringStore {
@@ -1603,6 +1658,14 @@ mod wasm {
         pub fn semantic_generation(&self) -> u32 {
             self.id.generation()
         }
+
+        #[wasm_bindgen(js_name = bindRetainedNativeText)]
+        pub fn bind_retained_native_text(
+            &self,
+            text: &mut WasmRetainedNativeTextAuthoringHandle,
+        ) -> Result<(), JsValue> {
+            text.bind_family_identity(self.id).map_err(js_error)
+        }
     }
 
     #[wasm_bindgen]
@@ -1682,6 +1745,18 @@ mod wasm {
                 .map_err(js_error)
         }
 
+        #[wasm_bindgen(js_name = includeRetainedNativeText)]
+        pub fn include_retained_native_text(
+            &mut self,
+            member: &WasmAuthoringFamilyMemberHandle,
+            text: &WasmRetainedNativeTextAuthoringHandle,
+        ) -> Result<(), JsValue> {
+            let id = retained_native_member_id(&self.semantics, member, text, "family arrange")?;
+            self.plan
+                .accept_member_bounds(id, Some(text.family_layout_bounds()))
+                .map_err(js_error)
+        }
+
         #[wasm_bindgen(js_name = includeFamily)]
         pub fn include_family(
             &mut self,
@@ -1729,6 +1804,29 @@ mod wasm {
     }
 
     impl WasmAuthoringFamilyLayout {
+        fn include_leaf_bounds(
+            &mut self,
+            id: SemanticNodeId,
+            bounds: Option<Bounds2D64>,
+        ) -> Result<(), JsValue> {
+            let expected = self
+                .expected_leaves
+                .get(self.next_leaf)
+                .copied()
+                .ok_or_else(|| JsValue::from_str("family layout received too many leaves"))?;
+            if id != expected {
+                return Err(JsValue::from_str(&format!(
+                    "family layout leaf mismatch at index {}: expected {expected:?}, got {id:?}",
+                    self.next_leaf
+                )));
+            }
+            if let Some(bounds) = bounds {
+                self.include_bounds(bounds);
+            }
+            self.next_leaf += 1;
+            Ok(())
+        }
+
         fn ensure_complete(&self) -> Result<(), JsValue> {
             if self.next_leaf != self.expected_leaves.len() {
                 return Err(JsValue::from_str(&format!(
@@ -1820,22 +1918,17 @@ mod wasm {
             let id = member.2.ok_or_else(|| {
                 JsValue::from_str("family layout member has no semantic identity")
             })?;
-            let expected = self
-                .expected_leaves
-                .get(self.next_leaf)
-                .copied()
-                .ok_or_else(|| JsValue::from_str("family layout received too many leaves"))?;
-            if id != expected {
-                return Err(JsValue::from_str(&format!(
-                    "family layout leaf mismatch at index {}: expected {expected:?}, got {id:?}",
-                    self.next_leaf
-                )));
-            }
-            if let Some(bounds) = member.0.layout_bounds() {
-                self.include_bounds(bounds);
-            }
-            self.next_leaf += 1;
-            Ok(())
+            self.include_leaf_bounds(id, member.0.layout_bounds())
+        }
+
+        #[wasm_bindgen(js_name = includeRetainedNativeText)]
+        pub fn include_retained_native_text(
+            &mut self,
+            member: &WasmAuthoringFamilyMemberHandle,
+            text: &WasmRetainedNativeTextAuthoringHandle,
+        ) -> Result<(), JsValue> {
+            let id = retained_native_member_id(&self.semantics, member, text, "family layout")?;
+            self.include_leaf_bounds(id, Some(text.family_layout_bounds()))
         }
 
         #[wasm_bindgen(getter, js_name = centerX)]
@@ -1909,6 +2002,34 @@ mod wasm {
             let source_x = self.critical_x(edge.x, edge.y)?;
             let source_y = self.critical_y(edge.x, edge.y)?;
             let target_point = target.0.critical_point(edge.x, edge.y);
+            self.translation(
+                (target_point.0 - source_x) * mask.x,
+                (target_point.1 - source_y) * mask.y,
+            )
+        }
+
+        #[wasm_bindgen(js_name = moveToRetainedNativeText)]
+        pub fn move_to_retained_native_text(
+            &self,
+            target_member: &WasmAuthoringFamilyMemberHandle,
+            target: &WasmRetainedNativeTextAuthoringHandle,
+            aligned_edge_x: f64,
+            aligned_edge_y: f64,
+            mask_x: f64,
+            mask_y: f64,
+        ) -> Result<WasmAuthoringFamilyTranslation, JsValue> {
+            self.ensure_complete()?;
+            retained_native_member_id(
+                &self.semantics,
+                target_member,
+                target,
+                "family placement target",
+            )?;
+            let edge = semantic_xy_f64(aligned_edge_x, aligned_edge_y).map_err(js_error)?;
+            let mask = semantic_xy_f64(mask_x, mask_y).map_err(js_error)?;
+            let source_x = self.critical_x(edge.x, edge.y)?;
+            let source_y = self.critical_y(edge.x, edge.y)?;
+            let target_point = retained_native_critical_point(target, (edge.x, edge.y));
             self.translation(
                 (target_point.0 - source_x) * mask.x,
                 (target_point.1 - source_y) * mask.y,
@@ -2010,6 +2131,48 @@ mod wasm {
             self.translation(delta.0, delta.1)
         }
 
+        #[wasm_bindgen(js_name = nextToRetainedNativeText)]
+        #[allow(clippy::too_many_arguments)]
+        pub fn next_to_retained_native_text(
+            &self,
+            target_member: &WasmAuthoringFamilyMemberHandle,
+            target: &WasmRetainedNativeTextAuthoringHandle,
+            direction_x: f64,
+            direction_y: f64,
+            buff: f64,
+            aligned_edge_x: f64,
+            aligned_edge_y: f64,
+            mask_x: f64,
+            mask_y: f64,
+        ) -> Result<WasmAuthoringFamilyTranslation, JsValue> {
+            self.ensure_complete()?;
+            retained_native_member_id(
+                &self.semantics,
+                target_member,
+                target,
+                "family placement target",
+            )?;
+            let direction = semantic_xy_f64(direction_x, direction_y).map_err(js_error)?;
+            let edge = semantic_xy_f64(aligned_edge_x, aligned_edge_y).map_err(js_error)?;
+            let source = (
+                self.critical_x(edge.x - direction.x, edge.y - direction.y)?,
+                self.critical_y(edge.x - direction.x, edge.y - direction.y)?,
+            );
+            let target_point = retained_native_critical_point(
+                target,
+                (edge.x + direction.x, edge.y + direction.y),
+            );
+            let delta = manim_family_next_to_delta(
+                source,
+                target_point,
+                (direction.x, direction.y),
+                buff,
+                (mask_x, mask_y),
+            )
+            .map_err(js_error)?;
+            self.translation(delta.0, delta.1)
+        }
+
         #[wasm_bindgen(js_name = nextToFamily)]
         #[allow(clippy::too_many_arguments)]
         pub fn next_to_family(
@@ -2085,6 +2248,32 @@ mod wasm {
                 self.critical_y(axis.x, axis.y)?,
             );
             let target_point = target.0.critical_point(axis.x, axis.y);
+            let delta = manim_family_align_to_delta(source, target_point, (axis.x, axis.y))
+                .map_err(js_error)?;
+            self.translation(delta.0, delta.1)
+        }
+
+        #[wasm_bindgen(js_name = alignToRetainedNativeText)]
+        pub fn align_to_retained_native_text(
+            &self,
+            target_member: &WasmAuthoringFamilyMemberHandle,
+            target: &WasmRetainedNativeTextAuthoringHandle,
+            axis_x: f64,
+            axis_y: f64,
+        ) -> Result<WasmAuthoringFamilyTranslation, JsValue> {
+            self.ensure_complete()?;
+            retained_native_member_id(
+                &self.semantics,
+                target_member,
+                target,
+                "family placement target",
+            )?;
+            let axis = semantic_xy_f64(axis_x, axis_y).map_err(js_error)?;
+            let source = (
+                self.critical_x(axis.x, axis.y)?,
+                self.critical_y(axis.x, axis.y)?,
+            );
+            let target_point = retained_native_critical_point(target, (axis.x, axis.y));
             let delta = manim_family_align_to_delta(source, target_point, (axis.x, axis.y))
                 .map_err(js_error)?;
             self.translation(delta.0, delta.1)
@@ -2328,6 +2517,19 @@ mod wasm {
                 JsValue::from_str("family translation member has no semantic identity")
             })?;
             self.translation.apply(id, &mut member.0).map_err(js_error)
+        }
+
+        #[wasm_bindgen(js_name = applyRetainedNativeText)]
+        pub fn apply_retained_native_text(
+            &mut self,
+            member: &WasmAuthoringFamilyMemberHandle,
+            text: &mut WasmRetainedNativeTextAuthoringHandle,
+        ) -> Result<(), JsValue> {
+            let id =
+                retained_native_member_id(&self.semantics, member, text, "family translation")?;
+            self.translation
+                .apply_with(id, |delta| text.apply_family_translation(delta.0, delta.1))
+                .map_err(js_error)
         }
 
         pub fn finish(&self) -> Result<(), JsValue> {

--- a/crates/noon-web/src/retained_authoring.rs
+++ b/crates/noon-web/src/retained_authoring.rs
@@ -2,6 +2,8 @@ use std::collections::HashSet;
 
 #[cfg(any(target_arch = "wasm32", test))]
 use noon_core::Rect;
+#[cfg(target_arch = "wasm32")]
+use noon_core::{Bounds2D64, SemanticNodeId};
 use noon_core::{Color, ObjectId, Transform2D, Vec2, WHITE};
 use serde::{Deserialize, Serialize};
 
@@ -408,11 +410,63 @@ mod wasm {
     pub struct WasmRetainedNativeTextAuthoringHandle {
         inner: RetainedTextAuthoringSpec,
         intrinsic_bounds: Rect,
+        family_identity: Option<SemanticNodeId>,
     }
 
     impl WasmRetainedNativeTextAuthoringHandle {
         fn bounds(&self) -> Rect {
             transformed_bounds(self.intrinsic_bounds, self.inner.transform)
+        }
+
+        pub(crate) fn bind_family_identity(
+            &mut self,
+            identity: SemanticNodeId,
+        ) -> Result<(), String> {
+            if let Some(existing) = self.family_identity {
+                if existing != identity {
+                    return Err(
+                        "retained native Text is already bound to another family identity"
+                            .to_owned(),
+                    );
+                }
+                return Ok(());
+            }
+            self.family_identity = Some(identity);
+            Ok(())
+        }
+
+        pub(crate) fn family_identity(&self) -> Option<SemanticNodeId> {
+            self.family_identity
+        }
+
+        pub(crate) fn family_layout_bounds(&self) -> Bounds2D64 {
+            let bounds = self.bounds();
+            Bounds2D64 {
+                min_x: f64::from(bounds.min.x),
+                min_y: f64::from(bounds.min.y),
+                max_x: f64::from(bounds.max.x),
+                max_y: f64::from(bounds.max.y),
+            }
+        }
+
+        pub(crate) fn apply_family_translation(
+            &mut self,
+            delta_x: f64,
+            delta_y: f64,
+        ) -> Result<(), String> {
+            let current = self.inner.transform.translation;
+            let next_x = f64::from(current.x) + delta_x;
+            let next_y = f64::from(current.y) + delta_y;
+            if !next_x.is_finite()
+                || !next_y.is_finite()
+                || next_x.abs() > f64::from(f32::MAX)
+                || next_y.abs() > f64::from(f32::MAX)
+            {
+                return Err(
+                    "retained native Text family translation must remain f32-compatible".to_owned(),
+                );
+            }
+            self.inner.move_to(Vec2::new(next_x as f32, next_y as f32))
         }
     }
 
@@ -432,6 +486,7 @@ mod wasm {
             Ok(Self {
                 inner,
                 intrinsic_bounds,
+                family_identity: None,
             })
         }
 

--- a/scripts/retained-text-family-layout-smoke.mjs
+++ b/scripts/retained-text-family-layout-smoke.mjs
@@ -1,0 +1,183 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import playwright from "playwright";
+
+const { chromium } = playwright;
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const port = 4194;
+const baseUrl = `http://127.0.0.1:${port}`;
+
+let serverOutput = "";
+const server = spawn(
+  "python3",
+  ["-m", "http.server", String(port), "--bind", "127.0.0.1", "--directory", repoRoot],
+  { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] },
+);
+server.stdout.on("data", (chunk) => (serverOutput += chunk));
+server.stderr.on("data", (chunk) => (serverOutput += chunk));
+
+async function waitForServer() {
+  let lastError = null;
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    try {
+      const response = await fetch(`${baseUrl}/web/manim-compat-smoke.html`);
+      if (response.ok) return;
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`retained family layout smoke server did not start: ${lastError}\n${serverOutput}`);
+}
+
+const source = `
+from noon import *
+
+
+def close(actual, expected, label, tolerance=1e-5):
+    assert abs(float(actual) - float(expected)) <= tolerance, f"{label}: {actual} != {expected}"
+
+
+def union_bounds(*members):
+    return (
+        min(member.get_critical_point(LEFT).x for member in members),
+        min(member.get_critical_point(DOWN).y for member in members),
+        max(member.get_critical_point(RIGHT).x for member in members),
+        max(member.get_critical_point(UP).y for member in members),
+    )
+
+
+class RetainedFamilyLayout(Scene):
+    def construct(self):
+        first = Text("Layout A", font_size=40).shift(LEFT * 1.75 + UP * 0.4)
+        second = Text("Layout BBB", font_size=32).shift(RIGHT * 1.25 + DOWN * 0.3)
+        family = VGroup(first, VGroup(second))
+
+        min_x, min_y, max_x, max_y = union_bounds(first, second)
+        close(family.width, max_x - min_x, "nested retained family width")
+        close(family.height, max_y - min_y, "nested retained family height")
+        center = family.get_center()
+        close(center.x, (min_x + max_x) * 0.5, "nested retained family center x")
+        close(center.y, (min_y + max_y) * 0.5, "nested retained family center y")
+
+        first_before = first.get_center()
+        second_before = second.get_center()
+        delta = RIGHT * 0.75 + UP * 0.55
+        family.shift(delta)
+        close(first.get_center().x, first_before.x + delta.x, "family shift first x")
+        close(first.get_center().y, first_before.y + delta.y, "family shift first y")
+        close(second.get_center().x, second_before.x + delta.x, "family shift second x")
+        close(second.get_center().y, second_before.y + delta.y, "family shift second y")
+
+        family.center()
+        centered = family.get_center()
+        close(centered.x, 0.0, "family center x")
+        close(centered.y, 0.0, "family center y")
+
+        arranged_a = Text("A", font_size=36)
+        arranged_b = Text("BBBB", font_size=36)
+        arranged = VGroup(arranged_a, VGroup(arranged_b))
+        arranged.arrange(RIGHT, buff=0.375, center=True)
+        gap = arranged_b.get_critical_point(LEFT).x - arranged_a.get_critical_point(RIGHT).x
+        close(gap, 0.375, "nested retained arrange gap")
+        arranged_center = arranged.get_center()
+        close(arranged_center.x, 0.0, "arranged family center x")
+        close(arranged_center.y, 0.0, "arranged family center y")
+
+        square = Square(side_length=1.25).shift(LEFT * 0.9)
+        mixed_text = Text("Mixed", font_size=30).shift(RIGHT * 0.8)
+        mixed = VGroup(square, mixed_text)
+        min_x, min_y, max_x, max_y = union_bounds(square, mixed_text)
+        close(mixed.width, max_x - min_x, "mixed family width")
+        close(mixed.height, max_y - min_y, "mixed family height")
+        mixed_center = mixed.get_center()
+        close(mixed_center.x, (min_x + max_x) * 0.5, "mixed family center x")
+        close(mixed_center.y, (min_y + max_y) * 0.5, "mixed family center y")
+
+        square_before = square.get_center()
+        mixed_text_before = mixed_text.get_center()
+        mixed.shift(DOWN * 0.6)
+        close(square.get_center().y, square_before.y - 0.6, "mixed family square shift")
+        close(mixed_text.get_center().y, mixed_text_before.y - 0.6, "mixed family text shift")
+
+        placement_target = Text("Target", font_size=34).shift(RIGHT * 2.5 + UP * 0.8)
+        placement_a = Text("P", font_size=30)
+        placement_b = Text("QQ", font_size=30).shift(RIGHT * 0.8)
+        placement = VGroup(placement_a, placement_b)
+        placement.move_to(placement_target)
+        close(placement.get_center().x, placement_target.get_center().x, "move_to retained target x")
+        close(placement.get_center().y, placement_target.get_center().y, "move_to retained target y")
+        placement.next_to(placement_target, RIGHT, buff=0.25)
+        placement_left = placement.get_center().x - placement.width * 0.5
+        gap = placement_left - placement_target.get_critical_point(RIGHT).x
+        close(gap, 0.25, "next_to retained target gap")
+        placement.align_to(placement_target, UP)
+        placement_top = placement.get_center().y + placement.height * 0.5
+        close(
+            placement_top,
+            placement_target.get_critical_point(UP).y,
+            "align_to retained target top",
+        )
+
+        typst_family = VGroup(Typst("*Typst*", font_size=36))
+        try:
+            _ = typst_family.width
+            raise AssertionError("Typst family layout must remain explicit until Rust-owned Typst bounds exist")
+        except NotImplementedError as error:
+            assert "Typst/MathTypst family layout" in str(error)
+
+        self.add(first, second, arranged_a, arranged_b, mixed_text)
+`;
+
+let browser = null;
+try {
+  await waitForServer();
+  browser = await chromium.launch({
+    channel: "chromium",
+    headless: true,
+    args: ["--disable-dev-shm-usage"],
+  });
+  const page = await browser.newPage();
+  const errors = [];
+  page.on("pageerror", (error) => errors.push(`pageerror: ${error}`));
+  page.on("console", (message) => {
+    if (message.type() === "error") errors.push(`console: ${message.text()}`);
+  });
+
+  await page.goto(`${baseUrl}/web/manim-compat-smoke.html`, { waitUntil: "load" });
+  await page.waitForFunction(() => window.noonManimCompat, null, { timeout: 30_000 });
+  await page.evaluate(() => window.noonManimCompat.ready());
+
+  const result = await page.evaluate((python) => window.noonManimCompat.run(python), source);
+  assert.equal(result.kind, "scene_document");
+  assert.equal(
+    result.document.objects.length,
+    0,
+    "retained family layout must not synthesize legacy placeholder geometry",
+  );
+  assert.ok(result.retainedDocument, "retained family layout scene must emit retained state");
+  assert.deepEqual(
+    result.retainedDocument.objects.map((object) => object.text.source),
+    ["Layout A", "Layout BBB", "A", "BBBB", "Mixed"],
+  );
+  const wire = JSON.stringify(result.retainedDocument);
+  for (const forbidden of ["glyph", "font_bytes", "svg", "geometry", "atlas"]) {
+    assert.ok(!wire.includes(forbidden), `retained family layout wire must not contain ${forbidden}`);
+  }
+  assert.deepEqual(
+    errors,
+    [],
+    `browser errors while testing retained Text family layout:\n${errors.join("\n")}`,
+  );
+  console.log(
+    "Retained Text family layout smoke passed: shared Rust family bounds, nested arrange, mixed geometry/Text translation, and explicit Typst layout debt all hold without legacy Text geometry.",
+  );
+} finally {
+  await browser?.close();
+  server.kill("SIGTERM");
+}

--- a/web/python/_manim_semantic_handles.py
+++ b/web/python/_manim_semantic_handles.py
@@ -1080,6 +1080,29 @@ def _get_stroke_opacity(self: _compat.VMobject) -> float:
 
 
 
+def _retained_family_layout_handles(value: object):
+    identity = getattr(value, "_semantic_family_member_handle", None)
+    retained = getattr(value, "_retained_handle", None)
+    if identity is None or retained is None:
+        return None
+    if not _has_shared_layout_queries(retained):
+        raise NotImplementedError(
+            "Typst/MathTypst family layout requires Rust-owned retained layout bounds"
+        )
+    return identity, retained
+
+
+def _family_layout_leaf_adapter(value: object, *, mutation: bool = False):
+    resolver = _mutation_handle_for if mutation else _handle_for
+    handle = resolver(value)
+    if handle is not None:
+        return "mobject", handle
+    retained = _retained_family_layout_handles(value)
+    if retained is not None:
+        return "retained_native_text", retained
+    return None
+
+
 def _shared_family_layout_session(value: object, *, mutation: bool = False):
     if not isinstance(value, _compat.Group):
         return None
@@ -1087,25 +1110,37 @@ def _shared_family_layout_session(value: object, *, mutation: bool = False):
     if family_handle is None or not hasattr(family_handle, "layoutSession"):
         return None
     leaves = _compat._leaf_mobjects(value)
-    resolver = _mutation_handle_for if mutation else _handle_for
-    leaf_handles = [resolver(member) for member in leaves]
-    if not all(handle is not None for handle in leaf_handles):
+    leaf_adapters = [
+        _family_layout_leaf_adapter(member, mutation=mutation) for member in leaves
+    ]
+    if not all(adapter is not None for adapter in leaf_adapters):
         return None
     session = family_handle.layoutSession()
-    for handle in leaf_handles:
-        session.includeMobject(handle)
-    return session, leaves, leaf_handles
+    for adapter in leaf_adapters:
+        assert adapter is not None
+        kind, payload = adapter
+        if kind == "mobject":
+            session.includeMobject(payload)
+        else:
+            identity, retained = payload
+            session.includeRetainedNativeText(identity, retained)
+    return session, leaves, leaf_adapters
 
 
 def _apply_family_translation(
     self: _compat.Group,
     translation: object,
     leaves: list[_base.Mobject],
-    leaf_handles: list[object],
+    leaf_adapters: list[object],
 ) -> _compat.Group:
-    for member, handle in zip(leaves, leaf_handles):
-        translation.applyMobject(handle)
-        _sync_bound_transform(member, handle)
+    for member, adapter in zip(leaves, leaf_adapters):
+        kind, payload = adapter
+        if kind == "mobject":
+            translation.applyMobject(payload)
+            _sync_bound_transform(member, payload)
+        else:
+            identity, retained = payload
+            translation.applyRetainedNativeText(identity, retained)
     translation.finish()
     return self
 
@@ -1144,11 +1179,20 @@ def _group_move_to(
                 target_session, edge.x, edge.y, mask.x, mask.y
             )
     elif _alignment_is_mobject(point_or_mobject):
-        target_handle = _handle_for(point_or_mobject)
-        if target_handle is not None and hasattr(session, "moveToMobject"):
-            translation = session.moveToMobject(
-                target_handle, edge.x, edge.y, mask.x, mask.y
-            )
+        target_adapter = _family_layout_leaf_adapter(point_or_mobject)
+        if target_adapter is not None:
+            kind, payload = target_adapter
+            if kind == "mobject" and hasattr(session, "moveToMobject"):
+                translation = session.moveToMobject(
+                    payload, edge.x, edge.y, mask.x, mask.y
+                )
+            elif kind == "retained_native_text" and hasattr(
+                session, "moveToRetainedNativeText"
+            ):
+                identity, retained = payload
+                translation = session.moveToRetainedNativeText(
+                    identity, retained, edge.x, edge.y, mask.x, mask.y
+                )
     elif hasattr(session, "moveToPoint"):
         point = _base._as_vec2(point_or_mobject)
         translation = session.moveToPoint(
@@ -1217,18 +1261,35 @@ def _group_next_to(
                 mask.y,
             )
     elif _alignment_is_mobject(mobject_or_point):
-        target_handle = _handle_for(mobject_or_point)
-        if target_handle is not None and hasattr(session, "nextToMobject"):
-            translation = session.nextToMobject(
-                target_handle,
-                vector.x,
-                vector.y,
-                float(buff),
-                edge.x,
-                edge.y,
-                mask.x,
-                mask.y,
-            )
+        target_adapter = _family_layout_leaf_adapter(mobject_or_point)
+        if target_adapter is not None:
+            kind, payload = target_adapter
+            if kind == "mobject" and hasattr(session, "nextToMobject"):
+                translation = session.nextToMobject(
+                    payload,
+                    vector.x,
+                    vector.y,
+                    float(buff),
+                    edge.x,
+                    edge.y,
+                    mask.x,
+                    mask.y,
+                )
+            elif kind == "retained_native_text" and hasattr(
+                session, "nextToRetainedNativeText"
+            ):
+                identity, retained = payload
+                translation = session.nextToRetainedNativeText(
+                    identity,
+                    retained,
+                    vector.x,
+                    vector.y,
+                    float(buff),
+                    edge.x,
+                    edge.y,
+                    mask.x,
+                    mask.y,
+                )
     elif hasattr(session, "nextToPoint"):
         point = _base._as_vec2(mobject_or_point)
         translation = session.nextToPoint(
@@ -1274,9 +1335,18 @@ def _group_align_to(
         if target_shared is not None and hasattr(session, "alignToFamily"):
             translation = session.alignToFamily(target_shared[0], axis.x, axis.y)
     elif _alignment_is_mobject(mobject_or_point):
-        target_handle = _handle_for(mobject_or_point)
-        if target_handle is not None and hasattr(session, "alignToMobject"):
-            translation = session.alignToMobject(target_handle, axis.x, axis.y)
+        target_adapter = _family_layout_leaf_adapter(mobject_or_point)
+        if target_adapter is not None:
+            kind, payload = target_adapter
+            if kind == "mobject" and hasattr(session, "alignToMobject"):
+                translation = session.alignToMobject(payload, axis.x, axis.y)
+            elif kind == "retained_native_text" and hasattr(
+                session, "alignToRetainedNativeText"
+            ):
+                identity, retained = payload
+                translation = session.alignToRetainedNativeText(
+                    identity, retained, axis.x, axis.y
+                )
     elif hasattr(session, "alignToPoint"):
         point = _base._as_vec2(mobject_or_point)
         translation = session.alignToPoint(point.x, point.y, axis.x, axis.y)
@@ -1325,25 +1395,24 @@ def _group_arrange(
             arrangement.includeFamily(shared[0])
             prepared.append((member, shared[1], shared[2]))
         elif isinstance(member, _base.Mobject):
-            handle = _mutation_handle_for(member)
-            if handle is None or not hasattr(arrangement, "includeMobject"):
+            adapter = _family_layout_leaf_adapter(member, mutation=True)
+            if adapter is None:
                 return _ORIGINAL_GROUP_ARRANGE(
                     self, direction=direction, buff=buff, center=center
                 )
-            arrangement.includeMobject(handle)
-            prepared.append((member, [member], [handle]))
+            kind, payload = adapter
+            if kind == "mobject":
+                arrangement.includeMobject(payload)
+            else:
+                identity, retained = payload
+                arrangement.includeRetainedNativeText(identity, retained)
+            prepared.append((member, [member], [adapter]))
         else:
             return _ORIGINAL_GROUP_ARRANGE(self, direction=direction, buff=buff, center=center)
 
-    for member, leaves, leaf_handles in prepared:
+    for member, leaves, leaf_adapters in prepared:
         translation = arrangement.nextTranslation()
-        if isinstance(member, _compat.Group):
-            _apply_family_translation(member, translation, leaves, leaf_handles)
-        else:
-            handle = leaf_handles[0]
-            translation.applyMobject(handle)
-            _sync_bound_transform(member, handle)
-            translation.finish()
+        _apply_family_translation(member, translation, leaves, leaf_adapters)
     arrangement.finish()
     return self
 
@@ -1355,16 +1424,9 @@ def _compat_bounds_for(value: object) -> tuple[_base.Vec2, _base.Vec2] | None:
     # family graph independently derives the expected recursive leaf sequence and
     # rejects any wrapper divergence. Rust owns the actual aggregate bounds math.
     if isinstance(value, _compat.Group):
-        family_handle = getattr(value, "_semantic_family_handle", None)
-        leaf_handles = [_handle_for(member) for member in leaves]
-        if (
-            family_handle is not None
-            and hasattr(family_handle, "layoutSession")
-            and all(handle is not None for handle in leaf_handles)
-        ):
-            session = family_handle.layoutSession()
-            for handle in leaf_handles:
-                session.includeMobject(handle)
+        shared = _shared_family_layout_session(value)
+        if shared is not None:
+            session = shared[0]
             return (
                 _base.Vec2(
                     float(session.criticalX(-1.0, 0.0)),
@@ -1381,11 +1443,25 @@ def _compat_bounds_for(value: object) -> tuple[_base.Vec2, _base.Vec2] | None:
     # not execute this aggregation path.
     present: list[tuple[_base.Vec2, _base.Vec2]] = []
     for member in leaves:
-        bounds = (
-            _layout_bounds(member)
-            if _handle_for(member) is not None
-            else _base._bounds(member._current_raw())
-        )
+        handle = _handle_for(member)
+        if handle is not None:
+            bounds = _layout_bounds(member)
+        else:
+            retained = _retained_family_layout_handles(member)
+            if retained is not None:
+                retained_handle = retained[1]
+                bounds = (
+                    _base.Vec2(
+                        float(retained_handle.criticalX(-1.0, 0.0)),
+                        float(retained_handle.criticalY(0.0, -1.0)),
+                    ),
+                    _base.Vec2(
+                        float(retained_handle.criticalX(1.0, 0.0)),
+                        float(retained_handle.criticalY(0.0, 1.0)),
+                    ),
+                )
+            else:
+                bounds = _base._bounds(member._current_raw())
         if bounds is not None:
             present.append(bounds)
     if not present:

--- a/web/python/_manim_typst.py
+++ b/web/python/_manim_typst.py
@@ -374,6 +374,8 @@ class Text(_RetainedTextMobject):
         self._font = str(font)
         self._line_spacing = float(line_spacing)
         self._initialize_retained(str(text), float(font_size), handle, color, opacity)
+        if self._semantic_family_member_handle is not None:
+            self._semantic_family_member_handle.bindRetainedNativeText(self._retained_handle)
 
     @property
     def text(self) -> str:


### PR DESCRIPTION
## Summary

- extend the shared Rust family layout / arrange / translation bridge to retained native `Text` without synthesizing legacy geometry
- pair retained resource-specific authoring state with the existing shared semantic family identity so Rust validates authoritative leaf order before reading bounds or mutating presentation
- keep nested all-Text and mixed geometry + retained-Text family bounds, shift, arrange, and Group placement math in Rust
- route Group `move_to`, `next_to`, and `align_to` against standalone retained native `Text` through the shared family placement path
- keep Typst / MathTypst family layout explicit until those retained handles expose authoritative authoring-time bounds
- add a focused retained family-layout Chromium smoke to the permanent retained-text workflow

## Architecture

The Python wrapper only selects the appropriate shared handle variant. It does not own aggregate bounds, family deltas, leaf ordering, or retained Text geometry. Native Text continues to use its resource-aware retained Rust handle, while `WasmAuthoringFamilyMemberHandle` supplies stable family identity/order validation. The shared Rust family planner remains authoritative for traversal and layout math.

This intentionally does **not** implement family fade shift/scale endpoints or lag scheduling. Those remain separate #61 / #63 seams.

## Validation

The exact staged patch passed:

- assertion-based exact patch application
- `cargo fmt`
- `cargo clippy -p noon-web`
- `cargo test -p noon-web`
- full WASM/browser package build
- retained native Text family-layout Chromium smoke
- existing retained Text family identity, family fade, and Scene lifecycle browser regressions

The production branch is one clean commit based on current master and reuses the exact formatted validated Rust/Python/test blobs.