### PR TITLE
Add shared semantic family bounds aggregation

### DIFF
--- a/crates/noon-web/src/family_bounds.rs
+++ b/crates/noon-web/src/family_bounds.rs
@@ -1,0 +1,220 @@
+use noon_core::{Bounds2D64, SemanticNodeId, SemanticNodeKind, SemanticStore};
+
+/// Aggregate layout bounds for a semantic family using authoritative shared leaf order.
+///
+/// Frontends may retain wrapper trees for language-level identity, but they must not
+/// recompute family geometry. This plan snapshots the semantic family's leaf order,
+/// validates every supplied leaf against that order, and performs the aggregate bounds
+/// union in Rust. Leaf bounds themselves remain owned by the existing shared mobject
+/// handle implementation.
+#[derive(Clone, Debug)]
+pub struct FrontendFamilyBoundsPlan {
+    leaves: Vec<SemanticNodeId>,
+    next_leaf: usize,
+    bounds: Option<Bounds2D64>,
+}
+
+impl FrontendFamilyBoundsPlan {
+    pub fn begin(store: &SemanticStore, family: SemanticNodeId) -> Result<Self, String> {
+        Ok(Self {
+            leaves: semantic_family_leaf_ids(store, family)?,
+            next_leaf: 0,
+            bounds: None,
+        })
+    }
+
+    pub fn leaf_count(&self) -> usize {
+        self.leaves.len()
+    }
+
+    pub fn accept_leaf_bounds(
+        &mut self,
+        leaf: SemanticNodeId,
+        bounds: Option<Bounds2D64>,
+    ) -> Result<(), String> {
+        let expected = self
+            .leaves
+            .get(self.next_leaf)
+            .copied()
+            .ok_or_else(|| "family bounds received too many leaves".to_owned())?;
+        if leaf != expected {
+            return Err(format!(
+                "family bounds leaf mismatch at index {}: expected {expected:?}, got {leaf:?}",
+                self.next_leaf
+            ));
+        }
+
+        if let Some(bounds) = bounds {
+            include_bounds(&mut self.bounds, bounds);
+        }
+        self.next_leaf += 1;
+        Ok(())
+    }
+
+    pub fn finish(&self) -> Result<Option<Bounds2D64>, String> {
+        if self.next_leaf != self.leaves.len() {
+            return Err(format!(
+                "family bounds is incomplete: accepted {} of {} leaves",
+                self.next_leaf,
+                self.leaves.len()
+            ));
+        }
+        Ok(self.bounds)
+    }
+}
+
+fn include_bounds(aggregate: &mut Option<Bounds2D64>, bounds: Bounds2D64) {
+    if let Some(aggregate) = aggregate {
+        aggregate.include(bounds.min_x, bounds.min_y);
+        aggregate.include(bounds.max_x, bounds.max_y);
+    } else {
+        *aggregate = Some(bounds);
+    }
+}
+
+fn semantic_family_leaf_ids(
+    store: &SemanticStore,
+    family: SemanticNodeId,
+) -> Result<Vec<SemanticNodeId>, String> {
+    fn collect(
+        store: &SemanticStore,
+        node_id: SemanticNodeId,
+        leaves: &mut Vec<SemanticNodeId>,
+    ) -> Result<(), String> {
+        let node = store
+            .node(node_id)
+            .ok_or_else(|| format!("unknown semantic family member {node_id:?}"))?;
+        match node.kind() {
+            SemanticNodeKind::AuthoringObject => {
+                leaves.push(node_id);
+                Ok(())
+            }
+            SemanticNodeKind::Family => {
+                for member in node.members() {
+                    collect(store, *member, leaves)?;
+                }
+                Ok(())
+            }
+            SemanticNodeKind::Object(_) => Err(format!(
+                "family bounds member {node_id:?} is not an authoring object"
+            )),
+        }
+    }
+
+    let root = store
+        .node(family)
+        .ok_or_else(|| format!("unknown family semantic node {family:?}"))?;
+    if !matches!(root.kind(), SemanticNodeKind::Family) {
+        return Err(format!("semantic node {family:?} is not a family"));
+    }
+
+    let mut leaves = Vec::new();
+    collect(store, family, &mut leaves)?;
+    Ok(leaves)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn nested_family() -> (
+        SemanticStore,
+        SemanticNodeId,
+        SemanticNodeId,
+        SemanticNodeId,
+        SemanticNodeId,
+    ) {
+        let mut store = SemanticStore::new();
+        let first = store.insert_authoring_object();
+        let second = store.insert_authoring_object();
+        let third = store.insert_authoring_object();
+        let nested = store.insert_family();
+        let root = store.insert_family();
+        store.add_member(nested, second).expect("nested second");
+        store.add_member(nested, third).expect("nested third");
+        store.add_member(root, first).expect("root first");
+        store.add_member(root, nested).expect("root nested");
+        (store, root, first, second, third)
+    }
+
+    #[test]
+    fn aggregates_nested_family_bounds_in_semantic_leaf_order() {
+        let (store, root, first, second, third) = nested_family();
+        let mut plan = FrontendFamilyBoundsPlan::begin(&store, root).expect("family bounds plan");
+        assert_eq!(plan.leaf_count(), 3);
+
+        plan.accept_leaf_bounds(
+            first,
+            Some(Bounds2D64 {
+                min_x: -2.0,
+                min_y: -1.0,
+                max_x: 0.0,
+                max_y: 1.0,
+            }),
+        )
+        .expect("first bounds");
+        plan.accept_leaf_bounds(
+            second,
+            Some(Bounds2D64 {
+                min_x: 3.0,
+                min_y: -4.0,
+                max_x: 5.0,
+                max_y: -2.0,
+            }),
+        )
+        .expect("second bounds");
+        plan.accept_leaf_bounds(third, None)
+            .expect("bounds-free leaf is still consumed");
+
+        assert_eq!(
+            plan.finish().expect("complete plan"),
+            Some(Bounds2D64 {
+                min_x: -2.0,
+                min_y: -4.0,
+                max_x: 5.0,
+                max_y: 1.0,
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_frontend_leaf_reordering_before_aggregation() {
+        let (store, root, first, second, _) = nested_family();
+        let mut plan = FrontendFamilyBoundsPlan::begin(&store, root).expect("family bounds plan");
+        let error = plan
+            .accept_leaf_bounds(second, Some(Bounds2D64::point(1.0, 2.0)))
+            .expect_err("out-of-order wrapper must fail");
+        assert!(error.contains("leaf mismatch"));
+
+        plan.accept_leaf_bounds(first, Some(Bounds2D64::point(0.0, 0.0)))
+            .expect("failed attempt must not advance plan");
+    }
+
+    #[test]
+    fn rejects_incomplete_family_traversal() {
+        let (store, root, first, _, _) = nested_family();
+        let mut plan = FrontendFamilyBoundsPlan::begin(&store, root).expect("family bounds plan");
+        plan.accept_leaf_bounds(first, Some(Bounds2D64::point(0.0, 0.0)))
+            .expect("first bounds");
+        let error = plan.finish().expect_err("partial family must fail closed");
+        assert!(error.contains("incomplete"));
+    }
+
+    #[test]
+    fn empty_family_has_no_aggregate_bounds() {
+        let mut store = SemanticStore::new();
+        let family = store.insert_family();
+        let plan = FrontendFamilyBoundsPlan::begin(&store, family).expect("empty family plan");
+        assert_eq!(plan.leaf_count(), 0);
+        assert_eq!(plan.finish().expect("empty family is complete"), None);
+    }
+
+    #[test]
+    fn rejects_non_family_roots() {
+        let mut store = SemanticStore::new();
+        let leaf = store.insert_authoring_object();
+        let error = FrontendFamilyBoundsPlan::begin(&store, leaf)
+            .expect_err("authoring object is not a family");
+        assert!(error.contains("is not a family"));
+    }
+}

--- a/crates/noon-web/src/lib.rs
+++ b/crates/noon-web/src/lib.rs
@@ -8,6 +8,7 @@ mod determinism;
 mod execution_canvas;
 mod execution_transport;
 mod execution_visibility;
+mod family_bounds;
 #[cfg(any(target_arch = "wasm32", test))]
 mod gpu_diagnostics;
 mod host_player;
@@ -44,6 +45,7 @@ pub use determinism::*;
 pub use execution_canvas::*;
 pub use execution_transport::*;
 pub use execution_visibility::*;
+pub use family_bounds::*;
 pub use host_player::*;
 pub use legacy::*;
 pub use lifecycle::*;


### PR DESCRIPTION
## Summary
- add `FrontendFamilyBoundsPlan` as the shared Rust owner for aggregate Group/VGroup layout bounds
- snapshot authoritative semantic leaf order from `SemanticStore`
- accept only leaf bounds supplied in that exact order and union them in Rust
- preserve nested-family traversal and bounds-free leaves
- fail closed on reordered, excess, incomplete, unknown, or non-family traversal

## Why
#400's `SurroundingRectangle` / `BackgroundRectangle` adapters can already delegate leaf matcher geometry to shared Rust, but Group/VGroup targets still lacked an aggregate-family-bounds boundary. Computing that union in Python would violate #61/#400's thin-wrapper architecture. This PR adds the missing reusable family-bounds primitive without exposing matcher-specific or frontend-owned geometry semantics.

## Tests
Focused Rust coverage pins nested-family aggregation, authoritative leaf ordering, failed-attempt rollback, incomplete traversal, empty families, and non-family roots.

## Scope / risk
This does not yet expose the public Python matcher adapters. It only establishes the reusable shared family-bounds contract they can consume. No renderer, execution, worker, geometry representation, or per-frame path changes are introduced.

## Qualification
The previous exact feature head `26bacb7373a78c3c3adaf5102ba4cc93ad4bdec3` completed the full PR workflow matrix successfully, including CI, coverage, Manim semantic/raster/API differential, cross-browser, platform/release, playback, resize, lifecycle, authoring, and renderer recovery.

Master then advanced by the unrelated retained-Text #710 merge. The exact same two-file feature was replayed directly onto current master `8c60732f6a9589899473a9efd6d23f5eebd36be9` as one clean commit:

`3b81c46e35666e375b5448ef54b0c61c6a2e1ad1`

Fresh exact-head CI is required before merge.

Tracks #400. Related #61, #76, #703.