### PR TITLE
Add shared retained NumberLine tick geometry

### DIFF
--- a/crates/noon/src/axis_tick_authoring.rs
+++ b/crates/noon/src/axis_tick_authoring.rs
@@ -182,9 +182,7 @@ impl std::fmt::Display for AxisTickError {
         match self {
             Self::Coordinates(error) => error.fmt(f),
             Self::InvalidTickSize(value) => write!(f, "invalid tick size: {value}"),
-            Self::InvalidLongerTickMultiple => {
-                f.write_str("longer tick multiple must be positive")
-            }
+            Self::InvalidLongerTickMultiple => f.write_str("longer tick multiple must be positive"),
             Self::InvalidStrokeWidth(value) => write!(f, "invalid stroke width: {value}"),
             Self::NonFiniteElongatedValue => f.write_str("elongated tick values must be finite"),
             Self::Overflow(value) => {

--- a/crates/noon/src/axis_tick_authoring.rs
+++ b/crates/noon/src/axis_tick_authoring.rs
@@ -1,0 +1,197 @@
+use crate::{CoordinateSystemError, IntoSnapshot, Line, NumberLineState};
+use noon_core::{Color, ObjectSnapshot, Vec2, WHITE};
+
+const CAIRO_WIDTH_SCALE: f64 = 0.01;
+const IS_CLOSE_RTOL: f64 = 1.0e-5;
+const IS_CLOSE_ATOL: f64 = 1.0e-8;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct NumberLineTickOptions {
+    pub include_ticks: bool,
+    pub tick_size: f64,
+    pub elongated_values: Vec<f64>,
+    pub longer_tick_multiple: usize,
+    pub exclude_origin_tick: bool,
+    pub color: Color,
+    pub stroke_width: f64,
+}
+
+impl Default for NumberLineTickOptions {
+    fn default() -> Self {
+        Self {
+            include_ticks: true,
+            tick_size: 0.1,
+            elongated_values: Vec::new(),
+            longer_tick_multiple: 2,
+            exclude_origin_tick: false,
+            color: WHITE,
+            stroke_width: 2.0,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct NumberLineTick {
+    value: f64,
+    size: f64,
+    snapshot: ObjectSnapshot,
+}
+
+impl NumberLineTick {
+    pub const fn value(&self) -> f64 {
+        self.value
+    }
+
+    pub const fn size(&self) -> f64 {
+        self.size
+    }
+
+    pub fn snapshot(&self) -> &ObjectSnapshot {
+        &self.snapshot
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct NumberLineGeometryPlan {
+    line: ObjectSnapshot,
+    ticks: Vec<NumberLineTick>,
+}
+
+impl NumberLineGeometryPlan {
+    pub fn new(
+        state: NumberLineState,
+        options: &NumberLineTickOptions,
+    ) -> Result<Self, AxisTickError> {
+        validate_options(options)?;
+        let width = checked_f32(options.stroke_width * CAIRO_WIDTH_SCALE)?;
+        let line = styled_line(state.start(), state.end(), options.color, width);
+        let ticks = if options.include_ticks {
+            build_ticks(state, options, width)?
+        } else {
+            Vec::new()
+        };
+        Ok(Self { line, ticks })
+    }
+
+    pub fn line(&self) -> &ObjectSnapshot {
+        &self.line
+    }
+
+    pub fn ticks(&self) -> &[NumberLineTick] {
+        &self.ticks
+    }
+}
+
+fn build_ticks(
+    state: NumberLineState,
+    options: &NumberLineTickOptions,
+    width: f32,
+) -> Result<Vec<NumberLineTick>, AxisTickError> {
+    let delta = state.end() - state.start();
+    let length = delta.length();
+    if !length.is_finite() || length <= 0.0 {
+        return Err(CoordinateSystemError::DegenerateLine.into());
+    }
+    let tangent = delta / length;
+    let normal = Vec2::new(-tangent.y, tangent.x);
+    let range_min = state.range().min();
+
+    state
+        .tick_values(options.exclude_origin_tick)
+        .into_iter()
+        .map(|value| {
+            let elongated = options
+                .elongated_values
+                .iter()
+                .any(|candidate| is_close(value - range_min, *candidate - range_min));
+            let size = options.tick_size
+                * if elongated {
+                    options.longer_tick_multiple as f64
+                } else {
+                    1.0
+                };
+            let center = state.number_to_point(value)?;
+            let offset = normal * checked_f32(size)?;
+            Ok(NumberLineTick {
+                value,
+                size,
+                snapshot: styled_line(center - offset, center + offset, options.color, width),
+            })
+        })
+        .collect()
+}
+
+fn styled_line(start: Vec2, end: Vec2, color: Color, width: f32) -> ObjectSnapshot {
+    Line::new(start, end)
+        .color(color)
+        .set_stroke(Some(color), Some(width))
+        .into_snapshot()
+}
+
+fn validate_options(options: &NumberLineTickOptions) -> Result<(), AxisTickError> {
+    if !options.tick_size.is_finite() || options.tick_size < 0.0 {
+        return Err(AxisTickError::InvalidTickSize(options.tick_size));
+    }
+    if options.longer_tick_multiple == 0 {
+        return Err(AxisTickError::InvalidLongerTickMultiple);
+    }
+    if !options.stroke_width.is_finite() || options.stroke_width < 0.0 {
+        return Err(AxisTickError::InvalidStrokeWidth(options.stroke_width));
+    }
+    if options
+        .elongated_values
+        .iter()
+        .any(|value| !value.is_finite())
+    {
+        return Err(AxisTickError::NonFiniteElongatedValue);
+    }
+    Ok(())
+}
+
+fn is_close(lhs: f64, rhs: f64) -> bool {
+    (lhs - rhs).abs() <= IS_CLOSE_ATOL + IS_CLOSE_RTOL * rhs.abs()
+}
+
+fn checked_f32(value: f64) -> Result<f32, AxisTickError> {
+    let lowered = value as f32;
+    if lowered.is_finite() {
+        Ok(lowered)
+    } else {
+        Err(AxisTickError::Overflow(value))
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum AxisTickError {
+    Coordinates(CoordinateSystemError),
+    InvalidTickSize(f64),
+    InvalidLongerTickMultiple,
+    InvalidStrokeWidth(f64),
+    NonFiniteElongatedValue,
+    Overflow(f64),
+}
+
+impl From<CoordinateSystemError> for AxisTickError {
+    fn from(value: CoordinateSystemError) -> Self {
+        Self::Coordinates(value)
+    }
+}
+
+impl std::fmt::Display for AxisTickError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Coordinates(error) => error.fmt(f),
+            Self::InvalidTickSize(value) => write!(f, "invalid tick size: {value}"),
+            Self::InvalidLongerTickMultiple => {
+                f.write_str("longer tick multiple must be positive")
+            }
+            Self::InvalidStrokeWidth(value) => write!(f, "invalid stroke width: {value}"),
+            Self::NonFiniteElongatedValue => f.write_str("elongated tick values must be finite"),
+            Self::Overflow(value) => {
+                write!(f, "tick geometry cannot be represented as f32: {value}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for AxisTickError {}

--- a/crates/noon/src/lib.rs
+++ b/crates/noon/src/lib.rs
@@ -8,6 +8,7 @@
 
 mod analytic_geometry_authoring;
 mod arc_authoring;
+mod axis_tick_authoring;
 mod camera_authoring;
 mod coordinate_system_authoring;
 mod elbow_authoring;
@@ -23,6 +24,7 @@ mod text_authoring;
 
 pub use analytic_geometry_authoring::*;
 pub use arc_authoring::*;
+pub use axis_tick_authoring::*;
 pub use camera_authoring::*;
 pub use coordinate_system_authoring::*;
 pub use elbow_authoring::*;
@@ -41,17 +43,18 @@ pub mod prelude {
     pub use crate::legacy::prelude::*;
     pub use crate::{
         AnnularSector, Annulus, Arc, ArcAuthoringError, ArcBetweenPoints, Axes2DState,
-        BackgroundRectangle, CoordinateSystemError, Cross, Dot, Elbow, ElbowAuthoringError,
-        Ellipse, GeometryAuthoringError, LineMatcherAuthoringError, MathTypst, MovingCameraScene,
-        NumberLineState, NumberRange, Polygon, Polygram, PolygramAuthoringError, ReactiveScene,
-        ReactiveTimelineScene, RegularPolygon, RegularPolygram, RetainedMobject, RetainedScene,
-        RoundedRectangle, RoundedRectangleAuthoringError, Sector, ShapeMatcherAuthoringError, Star,
-        SurroundingRectangle, Text, TextAuthoringError, Triangle, Typst, Underline, ValueTracker,
-        VectorSignal, BACKGROUND_RECTANGLE_DEFAULT_FILL_OPACITY, DEFAULT_CROSS_SCALE_FACTOR,
-        DEFAULT_CROSS_STROKE_WIDTH, DEFAULT_DOT_RADIUS, DEFAULT_ELBOW_ANGLE, DEFAULT_ELBOW_WIDTH,
-        DEFAULT_NATIVE_TEXT_FONT_FAMILY, DEFAULT_NATIVE_TEXT_FONT_SIZE,
-        DEFAULT_ROUNDED_RECTANGLE_CORNER_RADIUS, DEFAULT_UNDERLINE_BUFF,
-        SURROUNDING_RECTANGLE_DEFAULT_COLOR,
+        AxisTickError, BackgroundRectangle, CoordinateSystemError, Cross, Dot, Elbow,
+        ElbowAuthoringError, Ellipse, GeometryAuthoringError, LineMatcherAuthoringError, MathTypst,
+        MovingCameraScene, NumberLineGeometryPlan, NumberLineState, NumberLineTick,
+        NumberLineTickOptions, NumberRange, Polygon, Polygram, PolygramAuthoringError,
+        ReactiveScene, ReactiveTimelineScene, RegularPolygon, RegularPolygram, RetainedMobject,
+        RetainedScene, RoundedRectangle, RoundedRectangleAuthoringError, Sector,
+        ShapeMatcherAuthoringError, Star, SurroundingRectangle, Text, TextAuthoringError, Triangle,
+        Typst, Underline, ValueTracker, VectorSignal, BACKGROUND_RECTANGLE_DEFAULT_FILL_OPACITY,
+        DEFAULT_CROSS_SCALE_FACTOR, DEFAULT_CROSS_STROKE_WIDTH, DEFAULT_DOT_RADIUS,
+        DEFAULT_ELBOW_ANGLE, DEFAULT_ELBOW_WIDTH, DEFAULT_NATIVE_TEXT_FONT_FAMILY,
+        DEFAULT_NATIVE_TEXT_FONT_SIZE, DEFAULT_ROUNDED_RECTANGLE_CORNER_RADIUS,
+        DEFAULT_UNDERLINE_BUFF, SURROUNDING_RECTANGLE_DEFAULT_COLOR,
     };
     pub use noon_core::{
         resolve_animation_options, resolve_composition_schedule, resolve_lifecycle_plan,

--- a/crates/noon/tests/axis_tick_authoring.rs
+++ b/crates/noon/tests/axis_tick_authoring.rs
@@ -12,12 +12,8 @@ fn endpoints(snapshot: &noon_core::ObjectSnapshot) -> (Vec2, Vec2) {
 
 #[test]
 fn default_ticks_are_independent_retained_lines() {
-    let state = NumberLineState::centered(
-        NumberRange::new(-2.0, 2.0, 1.0).unwrap(),
-        4.0,
-        0.0,
-    )
-    .unwrap();
+    let state =
+        NumberLineState::centered(NumberRange::new(-2.0, 2.0, 1.0).unwrap(), 4.0, 0.0).unwrap();
     let plan = NumberLineGeometryPlan::new(state, &NumberLineTickOptions::default()).unwrap();
     assert_eq!(plan.ticks().len(), 5);
     let origin = &plan.ticks()[2];
@@ -90,12 +86,8 @@ fn vertical_axis_ticks_rotate_with_axis_geometry() {
 
 #[test]
 fn disabling_ticks_keeps_axis_line_without_hidden_tick_geometry() {
-    let state = NumberLineState::centered(
-        NumberRange::new(0.0, 2.0, 1.0).unwrap(),
-        2.0,
-        0.0,
-    )
-    .unwrap();
+    let state =
+        NumberLineState::centered(NumberRange::new(0.0, 2.0, 1.0).unwrap(), 2.0, 0.0).unwrap();
     let options = NumberLineTickOptions {
         include_ticks: false,
         ..NumberLineTickOptions::default()

--- a/crates/noon/tests/axis_tick_authoring.rs
+++ b/crates/noon/tests/axis_tick_authoring.rs
@@ -1,0 +1,105 @@
+use noon::{
+    Axes2DState, NumberLineGeometryPlan, NumberLineState, NumberLineTickOptions, NumberRange,
+};
+use noon_core::{GeometryRef, Vec2, GREEN};
+
+fn endpoints(snapshot: &noon_core::ObjectSnapshot) -> (Vec2, Vec2) {
+    let GeometryRef::Line { start, end } = snapshot.geometry else {
+        panic!("expected retained line geometry");
+    };
+    (start, end)
+}
+
+#[test]
+fn default_ticks_are_independent_retained_lines() {
+    let state = NumberLineState::centered(
+        NumberRange::new(-2.0, 2.0, 1.0).unwrap(),
+        4.0,
+        0.0,
+    )
+    .unwrap();
+    let plan = NumberLineGeometryPlan::new(state, &NumberLineTickOptions::default()).unwrap();
+    assert_eq!(plan.ticks().len(), 5);
+    let origin = &plan.ticks()[2];
+    let (start, end) = endpoints(origin.snapshot());
+    assert_eq!(origin.value(), 0.0);
+    assert!((start.y + 0.1).abs() <= 1.0e-6);
+    assert!((end.y - 0.1).abs() <= 1.0e-6);
+}
+
+#[test]
+fn canonical_plot_axis_excludes_origin_and_elongates_requested_ticks() {
+    let axes = Axes2DState::new(
+        NumberRange::new(-10.0, 10.3, 1.0).unwrap(),
+        NumberRange::new(-1.5, 1.5, 1.0).unwrap(),
+        10.0,
+        6.0,
+    )
+    .unwrap();
+    let options = NumberLineTickOptions {
+        elongated_values: (-5..=5).map(|index| f64::from(index * 2)).collect(),
+        exclude_origin_tick: true,
+        color: GREEN,
+        ..NumberLineTickOptions::default()
+    };
+    let plan = NumberLineGeometryPlan::new(axes.x_axis(), &options).unwrap();
+    assert_eq!(plan.ticks().len(), 20);
+    assert!(plan.ticks().iter().all(|tick| tick.value() != 0.0));
+    assert_eq!(
+        plan.ticks()
+            .iter()
+            .find(|tick| tick.value() == 2.0)
+            .unwrap()
+            .size(),
+        0.2
+    );
+    assert_eq!(
+        plan.ticks()
+            .iter()
+            .find(|tick| tick.value() == 1.0)
+            .unwrap()
+            .size(),
+        0.1
+    );
+    assert!((plan.line().style.stroke_width - 0.02).abs() <= 1.0e-6);
+}
+
+#[test]
+fn vertical_axis_ticks_rotate_with_axis_geometry() {
+    let axes = Axes2DState::new(
+        NumberRange::new(-2.0, 2.0, 1.0).unwrap(),
+        NumberRange::new(-2.0, 2.0, 1.0).unwrap(),
+        4.0,
+        4.0,
+    )
+    .unwrap();
+    let options = NumberLineTickOptions {
+        exclude_origin_tick: true,
+        ..NumberLineTickOptions::default()
+    };
+    let plan = NumberLineGeometryPlan::new(axes.y_axis(), &options).unwrap();
+    let tick = plan
+        .ticks()
+        .iter()
+        .find(|tick| tick.value() == 1.0)
+        .unwrap();
+    let (start, end) = endpoints(tick.snapshot());
+    assert!((start.y - end.y).abs() <= 1.0e-6);
+    assert!(((end.x - start.x).abs() - 0.2).abs() <= 1.0e-6);
+}
+
+#[test]
+fn disabling_ticks_keeps_axis_line_without_hidden_tick_geometry() {
+    let state = NumberLineState::centered(
+        NumberRange::new(0.0, 2.0, 1.0).unwrap(),
+        2.0,
+        0.0,
+    )
+    .unwrap();
+    let options = NumberLineTickOptions {
+        include_ticks: false,
+        ..NumberLineTickOptions::default()
+    };
+    let plan = NumberLineGeometryPlan::new(state, &options).unwrap();
+    assert!(plan.ticks().is_empty());
+}


### PR DESCRIPTION
## Summary
- build NumberLine axis/tick geometry from the shared #701 `NumberLineState`
- keep the main axis and every tick as ordinary retained `Line` snapshots rather than an Axes renderer primitive
- reproduce ManimCE v0.21 normal tick size, elongated tick multiplier, zero-exclusion, axis-relative tick rotation, and elongated-value `isclose` matching
- centralize the Cairo/Manim NumberLine stroke-width conversion in Rust for this geometry path
- add focused integration coverage using the canonical `SinAndCosFunctionPlot` x-axis range and elongated tick values

## Architecture
This is geometry-only. Family composition, numbers/labels, tips, and helper methods stay separate. Python will compose the resulting line children through the existing semantic `Group`/`VGroup` family model; it will not calculate tick positions or rebuild line snapshots.

The slice is intentionally stacked only on #701 coordinate semantics and does not depend on plotting/smoothing or text work, so it can validate independently.

## Coverage
- default zero-inclusive ticks are independent line children
- canonical plotting x-axis excludes the origin and elongates requested even ticks
- vertical-axis ticks rotate with the shared NumberLine orientation
- `include_ticks=False` creates no hidden tick geometry

## Current head
One clean commit directly on #701:

`fde167243afcb7b3d5154afe5fc2905095f82327`

Tracks #695 / parent #85. Stacked on #701.