### PR TITLE
Add shared retained Axes browser authoring plan

### DIFF
--- a/crates/noon-web/src/lib.rs
+++ b/crates/noon-web/src/lib.rs
@@ -14,6 +14,7 @@ mod host_player;
 #[path = "legacy.rs"]
 mod legacy;
 mod lifecycle;
+mod manim_axes_bridge;
 mod manim_elbow_bridge;
 mod manim_geometry_bridge;
 mod manim_path_query_bridge;
@@ -48,6 +49,7 @@ pub use execution_visibility::*;
 pub use host_player::*;
 pub use legacy::*;
 pub use lifecycle::*;
+pub use manim_axes_bridge::*;
 pub use manim_elbow_bridge::*;
 pub use manim_geometry_bridge::*;
 pub use manim_path_query_bridge::*;

--- a/crates/noon-web/src/manim_axes_bridge.rs
+++ b/crates/noon-web/src/manim_axes_bridge.rs
@@ -1,0 +1,458 @@
+use noon::{
+    Axes2DState, AxisTickError, CoordinateSystemError, NumberLineGeometryPlan,
+    NumberLineTickOptions, NumberRange,
+};
+use noon_core::{Color, ObjectSnapshot, Vec2};
+use serde::Deserialize;
+
+use crate::{AxesPlotAuthoringPlan, ManimPlotBridgeError};
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+struct AxesAuthoringRequest {
+    x_range: [f64; 3],
+    y_range: [f64; 3],
+    x_length: f32,
+    y_length: f32,
+    #[serde(default = "default_true")]
+    tips: bool,
+    #[serde(default)]
+    axis_config: AxisVisualOverride,
+    #[serde(default)]
+    x_axis_config: AxisVisualOverride,
+    #[serde(default)]
+    y_axis_config: AxisVisualOverride,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+struct AxisVisualOverride {
+    include_ticks: Option<bool>,
+    tick_size: Option<f64>,
+    numbers_with_elongated_ticks: Option<Vec<f64>>,
+    longer_tick_multiple: Option<usize>,
+    stroke_width: Option<f64>,
+    color: Option<[f64; 4]>,
+    include_tip: Option<bool>,
+    include_numbers: Option<bool>,
+    numbers_to_include: Option<Vec<f64>>,
+}
+
+const fn default_true() -> bool {
+    true
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct ResolvedAxisVisuals {
+    ticks: NumberLineTickOptions,
+    include_tip: bool,
+    include_numbers: bool,
+    numbers_to_include: Option<Vec<f64>>,
+}
+
+impl ResolvedAxisVisuals {
+    fn new(tips: bool) -> Self {
+        Self {
+            ticks: NumberLineTickOptions {
+                exclude_origin_tick: true,
+                ..NumberLineTickOptions::default()
+            },
+            include_tip: tips,
+            include_numbers: false,
+            numbers_to_include: None,
+        }
+    }
+
+    fn apply(&mut self, overrides: &AxisVisualOverride) -> Result<(), ManimAxesBridgeError> {
+        if let Some(value) = overrides.include_ticks {
+            self.ticks.include_ticks = value;
+        }
+        if let Some(value) = overrides.tick_size {
+            self.ticks.tick_size = value;
+        }
+        if let Some(values) = &overrides.numbers_with_elongated_ticks {
+            self.ticks.elongated_values = values.clone();
+        }
+        if let Some(value) = overrides.longer_tick_multiple {
+            self.ticks.longer_tick_multiple = value;
+        }
+        if let Some(value) = overrides.stroke_width {
+            self.ticks.stroke_width = value;
+        }
+        if let Some(value) = overrides.color {
+            self.ticks.color = decode_color(value)?;
+        }
+        if let Some(value) = overrides.include_tip {
+            self.include_tip = value;
+        }
+        if let Some(value) = overrides.include_numbers {
+            self.include_numbers = value;
+        }
+        if let Some(values) = &overrides.numbers_to_include {
+            self.numbers_to_include = Some(values.clone());
+        }
+        Ok(())
+    }
+
+    fn validate_supported(&self) -> Result<(), ManimAxesBridgeError> {
+        if self.include_tip {
+            return Err(ManimAxesBridgeError::UnsupportedTips);
+        }
+        if self.include_numbers || self.numbers_to_include.is_some() {
+            return Err(ManimAxesBridgeError::UnsupportedNumbers);
+        }
+        Ok(())
+    }
+}
+
+/// Shared browser plan for the initial linear ManimCE v0.21 `Axes` subset.
+///
+/// One retained `Axes2DState` owns coordinate conversion, axis placement, tick
+/// geometry, and all plots created from this plan. Frontends only coerce host
+/// values and compose the returned ordinary retained line/path snapshots.
+#[derive(Clone, Debug, PartialEq)]
+pub struct AxesAuthoringPlan {
+    axes: Axes2DState,
+    x_range: NumberRange,
+    children: Vec<ObjectSnapshot>,
+}
+
+impl AxesAuthoringPlan {
+    pub fn from_json(request_json: &str) -> Result<Self, ManimAxesBridgeError> {
+        let request: AxesAuthoringRequest = serde_json::from_str(request_json)
+            .map_err(|error| ManimAxesBridgeError::InvalidRequest(error.to_string()))?;
+        Self::new(request)
+    }
+
+    fn new(request: AxesAuthoringRequest) -> Result<Self, ManimAxesBridgeError> {
+        let x_range = NumberRange::new(request.x_range[0], request.x_range[1], request.x_range[2])?;
+        let y_range = NumberRange::new(request.y_range[0], request.y_range[1], request.y_range[2])?;
+        let axes = Axes2DState::new(x_range, y_range, request.x_length, request.y_length)?;
+
+        let mut x_visuals = ResolvedAxisVisuals::new(request.tips);
+        x_visuals.apply(&request.axis_config)?;
+        x_visuals.apply(&request.x_axis_config)?;
+        x_visuals.validate_supported()?;
+
+        let mut y_visuals = ResolvedAxisVisuals::new(request.tips);
+        y_visuals.apply(&request.axis_config)?;
+        y_visuals.apply(&request.y_axis_config)?;
+        y_visuals.validate_supported()?;
+
+        let x_geometry = NumberLineGeometryPlan::new(axes.x_axis(), &x_visuals.ticks)?;
+        let y_geometry = NumberLineGeometryPlan::new(axes.y_axis(), &y_visuals.ticks)?;
+        let children = flatten_axis_children(&x_geometry, &y_geometry);
+
+        Ok(Self {
+            axes,
+            x_range,
+            children,
+        })
+    }
+
+    pub fn children(&self) -> &[ObjectSnapshot] {
+        &self.children
+    }
+
+    pub fn children_json(&self) -> Result<String, ManimAxesBridgeError> {
+        serde_json::to_string(&self.children)
+            .map_err(|error| ManimAxesBridgeError::Serialization(error.to_string()))
+    }
+
+    pub fn coords_to_point(&self, x: f64, y: f64) -> Result<Vec2, ManimAxesBridgeError> {
+        Ok(self.axes.coords_to_point(x, y)?)
+    }
+
+    pub fn point_to_coords(&self, point: Vec2) -> Result<(f64, f64), ManimAxesBridgeError> {
+        Ok(self.axes.point_to_coords(point)?)
+    }
+
+    pub fn coords_to_point_json(&self, x: f64, y: f64) -> Result<String, ManimAxesBridgeError> {
+        let point = self.coords_to_point(x, y)?;
+        serde_json::to_string(&[f64::from(point.x), f64::from(point.y)])
+            .map_err(|error| ManimAxesBridgeError::Serialization(error.to_string()))
+    }
+
+    pub fn point_to_coords_json(&self, x: f64, y: f64) -> Result<String, ManimAxesBridgeError> {
+        let point = Vec2::new(checked_f32("point.x", x)?, checked_f32("point.y", y)?);
+        let (x, y) = self.point_to_coords(point)?;
+        serde_json::to_string(&[x, y])
+            .map_err(|error| ManimAxesBridgeError::Serialization(error.to_string()))
+    }
+
+    pub fn plot_parameters_json(&self, request_json: &str) -> Result<String, ManimAxesBridgeError> {
+        Ok(self.plot_plan(request_json)?.parameters_json()?)
+    }
+
+    pub fn finish_plot_snapshot_json(
+        &self,
+        request_json: &str,
+        values_json: &str,
+    ) -> Result<String, ManimAxesBridgeError> {
+        Ok(self
+            .plot_plan(request_json)?
+            .finish_snapshot_json(values_json)?)
+    }
+
+    fn plot_plan(&self, request_json: &str) -> Result<AxesPlotAuthoringPlan, ManimAxesBridgeError> {
+        Ok(AxesPlotAuthoringPlan::from_axes_json(
+            self.axes,
+            self.x_range,
+            request_json,
+        )?)
+    }
+}
+
+fn flatten_axis_children(
+    x_geometry: &NumberLineGeometryPlan,
+    y_geometry: &NumberLineGeometryPlan,
+) -> Vec<ObjectSnapshot> {
+    let mut children = Vec::with_capacity(2 + x_geometry.ticks().len() + y_geometry.ticks().len());
+    children.push(x_geometry.line().clone());
+    children.extend(
+        x_geometry
+            .ticks()
+            .iter()
+            .map(|tick| tick.snapshot().clone()),
+    );
+    children.push(y_geometry.line().clone());
+    children.extend(
+        y_geometry
+            .ticks()
+            .iter()
+            .map(|tick| tick.snapshot().clone()),
+    );
+    children
+}
+
+fn decode_color(value: [f64; 4]) -> Result<Color, ManimAxesBridgeError> {
+    let [red, green, blue, alpha] = value;
+    for (name, channel) in [
+        ("red", red),
+        ("green", green),
+        ("blue", blue),
+        ("alpha", alpha),
+    ] {
+        if !channel.is_finite() || !(0.0..=1.0).contains(&channel) {
+            return Err(ManimAxesBridgeError::InvalidColorChannel {
+                name,
+                value: channel,
+            });
+        }
+    }
+    Ok(Color::rgba(
+        red as f32,
+        green as f32,
+        blue as f32,
+        alpha as f32,
+    ))
+}
+
+fn checked_f32(name: &'static str, value: f64) -> Result<f32, ManimAxesBridgeError> {
+    let lowered = value as f32;
+    if value.is_finite() && lowered.is_finite() {
+        Ok(lowered)
+    } else {
+        Err(ManimAxesBridgeError::InvalidPoint { name, value })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ManimAxesBridgeError {
+    InvalidRequest(String),
+    Coordinates(CoordinateSystemError),
+    Ticks(AxisTickError),
+    Plot(ManimPlotBridgeError),
+    UnsupportedTips,
+    UnsupportedNumbers,
+    InvalidColorChannel { name: &'static str, value: f64 },
+    InvalidPoint { name: &'static str, value: f64 },
+    Serialization(String),
+}
+
+impl std::fmt::Display for ManimAxesBridgeError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidRequest(error) => write!(formatter, "invalid Axes request: {error}"),
+            Self::Coordinates(error) => error.fmt(formatter),
+            Self::Ticks(error) => error.fmt(formatter),
+            Self::Plot(error) => error.fmt(formatter),
+            Self::UnsupportedTips => formatter.write_str(
+                "Axes tips are not implemented in the retained 2D Axes subset; pass tips=False",
+            ),
+            Self::UnsupportedNumbers => formatter.write_str(
+                "Axes numeric labels are not implemented in the retained 2D Axes subset",
+            ),
+            Self::InvalidColorChannel { name, value } => {
+                write!(
+                    formatter,
+                    "Axes color {name} must be in [0, 1], got {value}"
+                )
+            }
+            Self::InvalidPoint { name, value } => {
+                write!(
+                    formatter,
+                    "Axes {name} must be a finite f32-compatible number: {value}"
+                )
+            }
+            Self::Serialization(error) => {
+                write!(
+                    formatter,
+                    "unable to serialize Axes authoring state: {error}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for ManimAxesBridgeError {}
+
+impl From<CoordinateSystemError> for ManimAxesBridgeError {
+    fn from(value: CoordinateSystemError) -> Self {
+        Self::Coordinates(value)
+    }
+}
+
+impl From<AxisTickError> for ManimAxesBridgeError {
+    fn from(value: AxisTickError) -> Self {
+        Self::Ticks(value)
+    }
+}
+
+impl From<ManimPlotBridgeError> for ManimAxesBridgeError {
+    fn from(value: ManimPlotBridgeError) -> Self {
+        Self::Plot(value)
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+mod wasm {
+    use wasm_bindgen::prelude::*;
+
+    use super::AxesAuthoringPlan;
+
+    fn js_error(error: impl std::fmt::Display) -> JsValue {
+        JsValue::from_str(&error.to_string())
+    }
+
+    #[wasm_bindgen]
+    pub struct WasmAxesAuthoringPlan(AxesAuthoringPlan);
+
+    #[wasm_bindgen]
+    impl WasmAxesAuthoringPlan {
+        #[wasm_bindgen(constructor)]
+        pub fn new(request_json: &str) -> Result<Self, JsValue> {
+            AxesAuthoringPlan::from_json(request_json)
+                .map(Self)
+                .map_err(js_error)
+        }
+
+        #[wasm_bindgen(js_name = childrenJson)]
+        pub fn children_json(&self) -> Result<String, JsValue> {
+            self.0.children_json().map_err(js_error)
+        }
+
+        #[wasm_bindgen(js_name = coordsToPointJson)]
+        pub fn coords_to_point_json(&self, x: f64, y: f64) -> Result<String, JsValue> {
+            self.0.coords_to_point_json(x, y).map_err(js_error)
+        }
+
+        #[wasm_bindgen(js_name = pointToCoordsJson)]
+        pub fn point_to_coords_json(&self, x: f64, y: f64) -> Result<String, JsValue> {
+            self.0.point_to_coords_json(x, y).map_err(js_error)
+        }
+
+        #[wasm_bindgen(js_name = plotParametersJson)]
+        pub fn plot_parameters_json(&self, request_json: &str) -> Result<String, JsValue> {
+            self.0.plot_parameters_json(request_json).map_err(js_error)
+        }
+
+        #[wasm_bindgen(js_name = finishPlotSnapshotJson)]
+        pub fn finish_plot_snapshot_json(
+            &self,
+            request_json: &str,
+            values_json: &str,
+        ) -> Result<String, JsValue> {
+            self.0
+                .finish_plot_snapshot_json(request_json, values_json)
+                .map_err(js_error)
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub use wasm::WasmAxesAuthoringPlan;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use noon_core::{GeometryRef, PathCommand};
+
+    fn request_json(extra: &str) -> String {
+        format!(
+            r#"{{"x_range":[-10.0,10.3,1.0],"y_range":[-1.5,1.5,1.0],"x_length":10.0,"y_length":6.0,"tips":false{extra}}}"#
+        )
+    }
+
+    #[test]
+    fn canonical_label_free_axes_build_real_retained_line_children() {
+        let request = request_json(
+            r#", "axis_config":{"color":[0.1,0.2,0.3,1.0]}, "x_axis_config":{"numbers_with_elongated_ticks":[-10,-8,-6,-4,-2,0,2,4,6,8,10]}"#,
+        );
+        let plan = AxesAuthoringPlan::from_json(&request).unwrap();
+        assert_eq!(plan.children().len(), 24);
+        assert!(plan
+            .children()
+            .iter()
+            .all(|snapshot| matches!(&snapshot.geometry, GeometryRef::Line { .. })));
+        let red = plan.children()[0].style.stroke.unwrap().red;
+        assert!((red - 0.1_f32).abs() <= f32::EPSILON);
+    }
+
+    #[test]
+    fn coordinate_round_trip_uses_the_same_stored_axes_state() {
+        let plan = AxesAuthoringPlan::from_json(&request_json("")).unwrap();
+        let point = plan.coords_to_point(3.25, -0.75).unwrap();
+        let (x, y) = plan.point_to_coords(point).unwrap();
+        assert!((x - 3.25).abs() <= 1.0e-5);
+        assert!((y + 0.75).abs() <= 1.0e-5);
+    }
+
+    #[test]
+    fn plot_plan_reuses_axes_state_and_lowers_to_vector_path() {
+        let plan = AxesAuthoringPlan::from_json(&request_json("")).unwrap();
+        let plot_request = r#"{"plot_range":[-1.0,1.0,1.0],"use_smoothing":false}"#;
+        assert_eq!(
+            plan.plot_parameters_json(plot_request).unwrap(),
+            "[[-1.0,0.0,1.0]]"
+        );
+        let snapshot: ObjectSnapshot = serde_json::from_str(
+            &plan
+                .finish_plot_snapshot_json(plot_request, "[[0.0,1.0,0.0]]")
+                .unwrap(),
+        )
+        .unwrap();
+        let GeometryRef::VectorPath(path) = snapshot.geometry else {
+            panic!("plot must remain ordinary retained VectorPath geometry");
+        };
+        assert!(matches!(path.commands()[0], PathCommand::MoveTo { .. }));
+        assert!(matches!(path.commands()[1], PathCommand::LineTo { .. }));
+        assert!(matches!(path.commands()[2], PathCommand::LineTo { .. }));
+    }
+
+    #[test]
+    fn unsupported_visible_features_fail_instead_of_rendering_placeholders() {
+        assert!(matches!(
+            AxesAuthoringPlan::from_json(
+                r#"{"x_range":[-1,1,1],"y_range":[-1,1,1],"x_length":2,"y_length":2}"#,
+            )
+            .unwrap_err(),
+            ManimAxesBridgeError::UnsupportedTips
+        ));
+        assert!(matches!(
+            AxesAuthoringPlan::from_json(&request_json(
+                r#", "x_axis_config":{"numbers_to_include":[-1,0,1]}"#,
+            ))
+            .unwrap_err(),
+            ManimAxesBridgeError::UnsupportedNumbers
+        ));
+    }
+}

--- a/crates/noon-web/src/manim_plot_bridge.rs
+++ b/crates/noon-web/src/manim_plot_bridge.rs
@@ -12,6 +12,12 @@ struct AxesPlotPlanRequest {
     y_range: [f64; 3],
     x_length: f32,
     y_length: f32,
+    #[serde(flatten)]
+    curve: AxesPlotCurveRequest,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+struct AxesPlotCurveRequest {
     #[serde(default)]
     plot_range: Option<Vec<f64>>,
     #[serde(default)]
@@ -48,13 +54,27 @@ impl AxesPlotAuthoringPlan {
     pub fn from_json(request_json: &str) -> Result<Self, ManimPlotBridgeError> {
         let request: AxesPlotPlanRequest = serde_json::from_str(request_json)
             .map_err(|error| ManimPlotBridgeError::InvalidRequest(error.to_string()))?;
-        Self::new(request)
-    }
-
-    fn new(request: AxesPlotPlanRequest) -> Result<Self, ManimPlotBridgeError> {
         let x_range = NumberRange::new(request.x_range[0], request.x_range[1], request.x_range[2])?;
         let y_range = NumberRange::new(request.y_range[0], request.y_range[1], request.y_range[2])?;
         let axes = Axes2DState::new(x_range, y_range, request.x_length, request.y_length)?;
+        Self::from_axes_curve(axes, x_range, request.curve)
+    }
+
+    pub(crate) fn from_axes_json(
+        axes: Axes2DState,
+        x_range: NumberRange,
+        request_json: &str,
+    ) -> Result<Self, ManimPlotBridgeError> {
+        let request: AxesPlotCurveRequest = serde_json::from_str(request_json)
+            .map_err(|error| ManimPlotBridgeError::InvalidRequest(error.to_string()))?;
+        Self::from_axes_curve(axes, x_range, request)
+    }
+
+    fn from_axes_curve(
+        axes: Axes2DState,
+        x_range: NumberRange,
+        request: AxesPlotCurveRequest,
+    ) -> Result<Self, ManimPlotBridgeError> {
         let range_request = match request.plot_range.as_deref() {
             None => PlotRangeRequest::AxisDefault,
             Some([min, max]) => PlotRangeRequest::Bounds {
@@ -256,5 +276,22 @@ mod tests {
                 actual: 1,
             })
         ));
+    }
+
+    #[test]
+    fn existing_axes_state_can_seed_the_same_plot_plan() {
+        let x_range = NumberRange::new(-2.0, 2.0, 1.0).unwrap();
+        let y_range = NumberRange::new(-1.0, 1.0, 1.0).unwrap();
+        let axes = Axes2DState::new(x_range, y_range, 4.0, 2.0).unwrap();
+        let plan = AxesPlotAuthoringPlan::from_axes_json(
+            axes,
+            x_range,
+            r#"{"plot_range":[-1.0,1.0,1.0],"use_smoothing":false}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            plan.parameter_subpaths().unwrap(),
+            vec![vec![-1.0, 0.0, 1.0]]
+        );
     }
 }

--- a/crates/noon/src/axis_tick_authoring.rs
+++ b/crates/noon/src/axis_tick_authoring.rs
@@ -1,0 +1,195 @@
+use crate::{CoordinateSystemError, IntoSnapshot, Line, NumberLineState};
+use noon_core::{Color, ObjectSnapshot, Vec2, WHITE};
+
+const CAIRO_WIDTH_SCALE: f64 = 0.01;
+const IS_CLOSE_RTOL: f64 = 1.0e-5;
+const IS_CLOSE_ATOL: f64 = 1.0e-8;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct NumberLineTickOptions {
+    pub include_ticks: bool,
+    pub tick_size: f64,
+    pub elongated_values: Vec<f64>,
+    pub longer_tick_multiple: usize,
+    pub exclude_origin_tick: bool,
+    pub color: Color,
+    pub stroke_width: f64,
+}
+
+impl Default for NumberLineTickOptions {
+    fn default() -> Self {
+        Self {
+            include_ticks: true,
+            tick_size: 0.1,
+            elongated_values: Vec::new(),
+            longer_tick_multiple: 2,
+            exclude_origin_tick: false,
+            color: WHITE,
+            stroke_width: 2.0,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct NumberLineTick {
+    value: f64,
+    size: f64,
+    snapshot: ObjectSnapshot,
+}
+
+impl NumberLineTick {
+    pub const fn value(&self) -> f64 {
+        self.value
+    }
+
+    pub const fn size(&self) -> f64 {
+        self.size
+    }
+
+    pub fn snapshot(&self) -> &ObjectSnapshot {
+        &self.snapshot
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct NumberLineGeometryPlan {
+    line: ObjectSnapshot,
+    ticks: Vec<NumberLineTick>,
+}
+
+impl NumberLineGeometryPlan {
+    pub fn new(
+        state: NumberLineState,
+        options: &NumberLineTickOptions,
+    ) -> Result<Self, AxisTickError> {
+        validate_options(options)?;
+        let width = checked_f32(options.stroke_width * CAIRO_WIDTH_SCALE)?;
+        let line = styled_line(state.start(), state.end(), options.color, width);
+        let ticks = if options.include_ticks {
+            build_ticks(state, options, width)?
+        } else {
+            Vec::new()
+        };
+        Ok(Self { line, ticks })
+    }
+
+    pub fn line(&self) -> &ObjectSnapshot {
+        &self.line
+    }
+
+    pub fn ticks(&self) -> &[NumberLineTick] {
+        &self.ticks
+    }
+}
+
+fn build_ticks(
+    state: NumberLineState,
+    options: &NumberLineTickOptions,
+    width: f32,
+) -> Result<Vec<NumberLineTick>, AxisTickError> {
+    let delta = state.end() - state.start();
+    let length = delta.length();
+    if !length.is_finite() || length <= 0.0 {
+        return Err(CoordinateSystemError::DegenerateLine.into());
+    }
+    let tangent = delta / length;
+    let normal = Vec2::new(-tangent.y, tangent.x);
+    let range_min = state.range().min();
+
+    state
+        .tick_values(options.exclude_origin_tick)
+        .into_iter()
+        .map(|value| {
+            let elongated = options
+                .elongated_values
+                .iter()
+                .any(|candidate| is_close(value - range_min, *candidate - range_min));
+            let size = options.tick_size
+                * if elongated {
+                    options.longer_tick_multiple as f64
+                } else {
+                    1.0
+                };
+            let center = state.number_to_point(value)?;
+            let offset = normal * checked_f32(size)?;
+            Ok(NumberLineTick {
+                value,
+                size,
+                snapshot: styled_line(center - offset, center + offset, options.color, width),
+            })
+        })
+        .collect()
+}
+
+fn styled_line(start: Vec2, end: Vec2, color: Color, width: f32) -> ObjectSnapshot {
+    Line::new(start, end)
+        .color(color)
+        .set_stroke(Some(color), Some(width))
+        .into_snapshot()
+}
+
+fn validate_options(options: &NumberLineTickOptions) -> Result<(), AxisTickError> {
+    if !options.tick_size.is_finite() || options.tick_size < 0.0 {
+        return Err(AxisTickError::InvalidTickSize(options.tick_size));
+    }
+    if options.longer_tick_multiple == 0 {
+        return Err(AxisTickError::InvalidLongerTickMultiple);
+    }
+    if !options.stroke_width.is_finite() || options.stroke_width < 0.0 {
+        return Err(AxisTickError::InvalidStrokeWidth(options.stroke_width));
+    }
+    if options
+        .elongated_values
+        .iter()
+        .any(|value| !value.is_finite())
+    {
+        return Err(AxisTickError::NonFiniteElongatedValue);
+    }
+    Ok(())
+}
+
+fn is_close(lhs: f64, rhs: f64) -> bool {
+    (lhs - rhs).abs() <= IS_CLOSE_ATOL + IS_CLOSE_RTOL * rhs.abs()
+}
+
+fn checked_f32(value: f64) -> Result<f32, AxisTickError> {
+    let lowered = value as f32;
+    if lowered.is_finite() {
+        Ok(lowered)
+    } else {
+        Err(AxisTickError::Overflow(value))
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum AxisTickError {
+    Coordinates(CoordinateSystemError),
+    InvalidTickSize(f64),
+    InvalidLongerTickMultiple,
+    InvalidStrokeWidth(f64),
+    NonFiniteElongatedValue,
+    Overflow(f64),
+}
+
+impl From<CoordinateSystemError> for AxisTickError {
+    fn from(value: CoordinateSystemError) -> Self {
+        Self::Coordinates(value)
+    }
+}
+
+impl std::fmt::Display for AxisTickError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Coordinates(error) => error.fmt(f),
+            Self::InvalidTickSize(value) => write!(f, "invalid tick size: {value}"),
+            Self::InvalidLongerTickMultiple => f.write_str("longer tick multiple must be positive"),
+            Self::InvalidStrokeWidth(value) => write!(f, "invalid stroke width: {value}"),
+            Self::NonFiniteElongatedValue => f.write_str("elongated tick values must be finite"),
+            Self::Overflow(value) => {
+                write!(f, "tick geometry cannot be represented as f32: {value}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for AxisTickError {}

--- a/crates/noon/src/lib.rs
+++ b/crates/noon/src/lib.rs
@@ -8,6 +8,7 @@
 
 mod analytic_geometry_authoring;
 mod arc_authoring;
+mod axis_tick_authoring;
 mod camera_authoring;
 mod coordinate_system_authoring;
 mod elbow_authoring;
@@ -25,6 +26,7 @@ mod text_authoring;
 
 pub use analytic_geometry_authoring::*;
 pub use arc_authoring::*;
+pub use axis_tick_authoring::*;
 pub use camera_authoring::*;
 pub use coordinate_system_authoring::*;
 pub use elbow_authoring::*;
@@ -44,20 +46,22 @@ pub use text_authoring::*;
 pub mod prelude {
     pub use crate::legacy::prelude::*;
     pub use crate::{
-        axes_function_vector_path, parametric_vector_path, AnnularSector, Annulus, Arc,
-        ArcAuthoringError, ArcBetweenPoints, Axes2DState, BackgroundRectangle,
-        CoordinateSystemError, Cross, Dot, Elbow, ElbowAuthoringError, Ellipse,
-        GeometryAuthoringError, LineMatcherAuthoringError, MathTypst, MovingCameraScene,
-        NumberLineState, NumberRange, ParametricSamplePlan, PlotGeometryError, PlotRangeRequest,
-        PlotSamplingError, Polygon, Polygram, PolygramAuthoringError, ReactiveScene,
-        ReactiveTimelineScene, RegularPolygon, RegularPolygram, RetainedMobject, RetainedScene,
-        RoundedRectangle, RoundedRectangleAuthoringError, SampleRange, SampleSpan, Sector,
-        ShapeMatcherAuthoringError, Star, SurroundingRectangle, Text, TextAuthoringError, Triangle,
-        Typst, Underline, ValueTracker, VectorSignal, BACKGROUND_RECTANGLE_DEFAULT_FILL_OPACITY,
-        DEFAULT_CROSS_SCALE_FACTOR, DEFAULT_CROSS_STROKE_WIDTH, DEFAULT_DOT_RADIUS,
-        DEFAULT_ELBOW_ANGLE, DEFAULT_ELBOW_WIDTH, DEFAULT_NATIVE_TEXT_FONT_FAMILY,
-        DEFAULT_NATIVE_TEXT_FONT_SIZE, DEFAULT_ROUNDED_RECTANGLE_CORNER_RADIUS,
-        DEFAULT_UNDERLINE_BUFF, MANIM_DEFAULT_DISCONTINUITY_DT, MANIM_DEFAULT_PARAMETRIC_STEP,
+        axes_function_vector_path, axes_sampled_values_vector_path, parametric_vector_path,
+        AnnularSector, Annulus, Arc, ArcAuthoringError, ArcBetweenPoints, Axes2DState,
+        AxisTickError, BackgroundRectangle, CoordinateSystemError, Cross, Dot, Elbow,
+        ElbowAuthoringError, Ellipse, GeometryAuthoringError, LineMatcherAuthoringError, MathTypst,
+        MovingCameraScene, NumberLineGeometryPlan, NumberLineState, NumberLineTick,
+        NumberLineTickOptions, NumberRange, ParametricSamplePlan, PlotGeometryError,
+        PlotRangeRequest, PlotSamplingError, Polygon, Polygram, PolygramAuthoringError,
+        ReactiveScene, ReactiveTimelineScene, RegularPolygon, RegularPolygram, RetainedMobject,
+        RetainedScene, RoundedRectangle, RoundedRectangleAuthoringError, SampleRange, SampleSpan,
+        Sector, ShapeMatcherAuthoringError, Star, SurroundingRectangle, Text, TextAuthoringError,
+        Triangle, Typst, Underline, ValueTracker, VectorSignal,
+        BACKGROUND_RECTANGLE_DEFAULT_FILL_OPACITY, DEFAULT_CROSS_SCALE_FACTOR,
+        DEFAULT_CROSS_STROKE_WIDTH, DEFAULT_DOT_RADIUS, DEFAULT_ELBOW_ANGLE, DEFAULT_ELBOW_WIDTH,
+        DEFAULT_NATIVE_TEXT_FONT_FAMILY, DEFAULT_NATIVE_TEXT_FONT_SIZE,
+        DEFAULT_ROUNDED_RECTANGLE_CORNER_RADIUS, DEFAULT_UNDERLINE_BUFF,
+        MANIM_DEFAULT_DISCONTINUITY_DT, MANIM_DEFAULT_PARAMETRIC_STEP,
         MANIM_SAMPLED_GRAPH_POINTS_PER_TICK, SURROUNDING_RECTANGLE_DEFAULT_COLOR,
     };
     pub use noon_core::{

--- a/crates/noon/tests/axis_tick_authoring.rs
+++ b/crates/noon/tests/axis_tick_authoring.rs
@@ -1,0 +1,97 @@
+use noon::{
+    Axes2DState, NumberLineGeometryPlan, NumberLineState, NumberLineTickOptions, NumberRange,
+};
+use noon_core::{GeometryRef, Vec2, GREEN};
+
+fn endpoints(snapshot: &noon_core::ObjectSnapshot) -> (Vec2, Vec2) {
+    let GeometryRef::Line { start, end } = snapshot.geometry else {
+        panic!("expected retained line geometry");
+    };
+    (start, end)
+}
+
+#[test]
+fn default_ticks_are_independent_retained_lines() {
+    let state =
+        NumberLineState::centered(NumberRange::new(-2.0, 2.0, 1.0).unwrap(), 4.0, 0.0).unwrap();
+    let plan = NumberLineGeometryPlan::new(state, &NumberLineTickOptions::default()).unwrap();
+    assert_eq!(plan.ticks().len(), 5);
+    let origin = &plan.ticks()[2];
+    let (start, end) = endpoints(origin.snapshot());
+    assert_eq!(origin.value(), 0.0);
+    assert!((start.y + 0.1).abs() <= 1.0e-6);
+    assert!((end.y - 0.1).abs() <= 1.0e-6);
+}
+
+#[test]
+fn canonical_plot_axis_excludes_origin_and_elongates_requested_ticks() {
+    let axes = Axes2DState::new(
+        NumberRange::new(-10.0, 10.3, 1.0).unwrap(),
+        NumberRange::new(-1.5, 1.5, 1.0).unwrap(),
+        10.0,
+        6.0,
+    )
+    .unwrap();
+    let options = NumberLineTickOptions {
+        elongated_values: (-5..=5).map(|index| f64::from(index * 2)).collect(),
+        exclude_origin_tick: true,
+        color: GREEN,
+        ..NumberLineTickOptions::default()
+    };
+    let plan = NumberLineGeometryPlan::new(axes.x_axis(), &options).unwrap();
+    assert_eq!(plan.ticks().len(), 20);
+    assert!(plan.ticks().iter().all(|tick| tick.value() != 0.0));
+    assert_eq!(
+        plan.ticks()
+            .iter()
+            .find(|tick| tick.value() == 2.0)
+            .unwrap()
+            .size(),
+        0.2
+    );
+    assert_eq!(
+        plan.ticks()
+            .iter()
+            .find(|tick| tick.value() == 1.0)
+            .unwrap()
+            .size(),
+        0.1
+    );
+    assert!((plan.line().style.stroke_width - 0.02).abs() <= 1.0e-6);
+}
+
+#[test]
+fn vertical_axis_ticks_rotate_with_axis_geometry() {
+    let axes = Axes2DState::new(
+        NumberRange::new(-2.0, 2.0, 1.0).unwrap(),
+        NumberRange::new(-2.0, 2.0, 1.0).unwrap(),
+        4.0,
+        4.0,
+    )
+    .unwrap();
+    let options = NumberLineTickOptions {
+        exclude_origin_tick: true,
+        ..NumberLineTickOptions::default()
+    };
+    let plan = NumberLineGeometryPlan::new(axes.y_axis(), &options).unwrap();
+    let tick = plan
+        .ticks()
+        .iter()
+        .find(|tick| tick.value() == 1.0)
+        .unwrap();
+    let (start, end) = endpoints(tick.snapshot());
+    assert!((start.y - end.y).abs() <= 1.0e-6);
+    assert!(((end.x - start.x).abs() - 0.2).abs() <= 1.0e-6);
+}
+
+#[test]
+fn disabling_ticks_keeps_axis_line_without_hidden_tick_geometry() {
+    let state =
+        NumberLineState::centered(NumberRange::new(0.0, 2.0, 1.0).unwrap(), 2.0, 0.0).unwrap();
+    let options = NumberLineTickOptions {
+        include_ticks: false,
+        ..NumberLineTickOptions::default()
+    };
+    let plan = NumberLineGeometryPlan::new(state, &options).unwrap();
+    assert!(plan.ticks().is_empty());
+}


### PR DESCRIPTION
## Summary
- combine the qualified retained NumberLine/tick geometry lane with the shared two-phase Axes.plot lane
- add one browser-facing `AxesAuthoringPlan` whose single stored `Axes2DState` owns axis placement, c2p/p2c, tick children, and every plot created from the Axes
- resolve common `axis_config` followed by per-axis overrides in Rust
- flatten the initial Axes family to ordinary retained `Line` snapshots; no Axes renderer primitive is introduced
- expose WASM methods for children, c2p/p2c, plot parameter generation, and final plot snapshot creation
- explicitly reject tips and numeric labels until their retained implementations exist instead of rendering compatibility placeholders

## Architecture
The host language never calculates tick positions, coordinate conversion, sample spacing, discontinuities, smoothing, or path geometry. `AxesAuthoringPlan` stores one canonical `Axes2DState`; `AxesPlotAuthoringPlan::from_axes_json` reuses that exact state for plot construction. This prevents the visible axis family and plotted curves from drifting semantically.

This branch is stacked on #714 and includes #717's retained tick-geometry delta. Once the prerequisites land it can be flattened to only the Axes integration layer.

## Focused coverage
- canonical label-free Sin/Cos-style Axes range produces only real retained Line children
- common color and elongated x-ticks are applied through shared Rust geometry
- c2p -> p2c round trip uses the stored Axes state
- plot parameters and final VectorPath reuse the same state
- unsupported tips/numeric labels fail explicitly rather than silently substituting placeholders

Tracks #695 and #696 / parent #85. Depends on #701, #709, #714, and #717.