### PR TITLE
Expose shared retained Axes and plotting to Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,9 @@ jobs:
       - name: Test Manim-style Python compatibility
         run: node scripts/manim-compat-smoke.mjs
 
+      - name: Test retained Axes plotting
+        run: node scripts/manim-axes-smoke.mjs
+
       - name: Test Manim composition authoring
         run: node scripts/composition-authoring-smoke.mjs
 

--- a/crates/noon-web/src/manim_axes_bridge.rs
+++ b/crates/noon-web/src/manim_axes_bridge.rs
@@ -113,6 +113,7 @@ pub struct AxesAuthoringPlan {
     axes: Axes2DState,
     x_range: NumberRange,
     children: Vec<ObjectSnapshot>,
+    x_child_count: usize,
 }
 
 impl AxesAuthoringPlan {
@@ -139,17 +140,23 @@ impl AxesAuthoringPlan {
 
         let x_geometry = NumberLineGeometryPlan::new(axes.x_axis(), &x_visuals.ticks)?;
         let y_geometry = NumberLineGeometryPlan::new(axes.y_axis(), &y_visuals.ticks)?;
+        let x_child_count = 1 + x_geometry.ticks().len();
         let children = flatten_axis_children(&x_geometry, &y_geometry);
 
         Ok(Self {
             axes,
             x_range,
             children,
+            x_child_count,
         })
     }
 
     pub fn children(&self) -> &[ObjectSnapshot] {
         &self.children
+    }
+
+    pub const fn x_child_count(&self) -> usize {
+        self.x_child_count
     }
 
     pub fn children_json(&self) -> Result<String, ManimAxesBridgeError> {
@@ -345,6 +352,11 @@ mod wasm {
                 .map_err(js_error)
         }
 
+        #[wasm_bindgen(getter, js_name = xChildCount)]
+        pub fn x_child_count(&self) -> usize {
+            self.0.x_child_count()
+        }
+
         #[wasm_bindgen(js_name = childrenJson)]
         pub fn children_json(&self) -> Result<String, JsValue> {
             self.0.children_json().map_err(js_error)
@@ -399,6 +411,7 @@ mod tests {
         );
         let plan = AxesAuthoringPlan::from_json(&request).unwrap();
         assert_eq!(plan.children().len(), 24);
+        assert_eq!(plan.x_child_count(), 21);
         assert!(plan
             .children()
             .iter()

--- a/scripts/build-web-demo.sh
+++ b/scripts/build-web-demo.sh
@@ -49,6 +49,7 @@ node --check scripts/host-callback-perf.mjs
 node --check scripts/deterministic-replay-smoke.mjs
 node --check scripts/cross-language-parity.mjs
 node --check scripts/manim-compat-smoke.mjs
+node --check scripts/manim-axes-smoke.mjs
 node --check scripts/manim-tutorial-smoke.mjs
 node --check scripts/playground-layout-smoke.mjs
 node --check scripts/composition-authoring-smoke.mjs
@@ -72,6 +73,7 @@ PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile \
   web/python/_manim_rate_functions.py \
   web/python/_manim_phase_b.py \
   web/python/_manim_shared_geometry.py \
+  web/python/_manim_axes.py \
   web/python/_manim_animation_options.py \
   web/python/_manim_animate.py \
   web/python/_manim_rotate.py \

--- a/scripts/manim-axes-smoke.mjs
+++ b/scripts/manim-axes-smoke.mjs
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import playwright from "playwright";
+
+const { chromium } = playwright;
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const port = 4185;
+const baseUrl = `http://127.0.0.1:${port}`;
+
+let serverOutput = "";
+const server = spawn(
+  "python3",
+  ["-m", "http.server", String(port), "--bind", "127.0.0.1", "--directory", repoRoot],
+  { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] },
+);
+server.stdout.on("data", (chunk) => (serverOutput += chunk));
+server.stderr.on("data", (chunk) => (serverOutput += chunk));
+
+async function waitForServer() {
+  let lastError = null;
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    try {
+      const response = await fetch(`${baseUrl}/web/manim-compat-smoke.html`);
+      if (response.ok) return;
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Axes smoke server did not start: ${lastError}\n${serverOutput}`);
+}
+
+const axesSource = `
+from noon import *
+import math
+
+class RetainedAxesPlot(Scene):
+    def construct(self):
+        axes = Axes(
+            x_range=[-10, 10.3, 1],
+            y_range=[-1.5, 1.5, 1],
+            x_length=10,
+            y_length=6,
+            axis_config={"color": GREEN},
+            x_axis_config={
+                "numbers_with_elongated_ticks": [-10, -8, -6, -4, -2, 0, 2, 4, 6, 8, 10],
+            },
+            tips=False,
+        )
+        assert len(axes.x_axis) == 21
+        assert len(axes.y_axis) == 3
+        assert len(axes.get_axes()) == 2
+
+        point = axes.c2p(3.25, -0.75)
+        recovered = axes.p2c(point)
+        assert abs(recovered[0] - 3.25) < 1e-5
+        assert abs(recovered[1] + 0.75) < 1e-5
+
+        probe_calls = []
+        axes.plot(
+            lambda x: (probe_calls.append(x), x * x)[1],
+            x_range=[-1, 1, 1],
+            use_smoothing=False,
+        )
+        assert probe_calls == [-1.0, 0.0, 1.0]
+
+        sin_graph = axes.plot(lambda x: math.sin(x), color=BLUE)
+        cos_graph = axes.plot(lambda x: math.cos(x), color=RED)
+        assert isinstance(sin_graph, ParametricFunction)
+        assert isinstance(cos_graph, ParametricFunction)
+
+        try:
+            axes.shift(RIGHT)
+        except NotImplementedError as error:
+            assert "shared affine coordinate-state synchronization" in str(error)
+        else:
+            raise AssertionError("Axes.shift must not desynchronize c2p from visible geometry")
+
+        self.add(axes, sin_graph, cos_graph)
+`;
+
+let browser = null;
+try {
+  await waitForServer();
+  browser = await chromium.launch({
+    channel: "chromium",
+    headless: true,
+    args: ["--disable-dev-shm-usage"],
+  });
+  const page = await browser.newPage();
+  const errors = [];
+  page.on("pageerror", (error) => errors.push(`pageerror: ${error}`));
+  page.on("console", (message) => {
+    if (message.type() === "error") errors.push(`console: ${message.text()}`);
+  });
+
+  await page.goto(`${baseUrl}/web/manim-compat-smoke.html`, { waitUntil: "load" });
+  await page.waitForFunction(() => window.noonManimCompat, null, { timeout: 30_000 });
+  await page.evaluate(() => window.noonManimCompat.ready());
+
+  const result = await page.evaluate(
+    (pythonSource) => window.noonManimCompat.run(pythonSource),
+    axesSource,
+  );
+  assert.equal(result.kind, "scene_document");
+  assert.equal(result.document.objects.length, 26);
+  assert.equal(result.document.tracks.length, 0);
+
+  const geometryKinds = result.document.objects.map(
+    (object) => Object.keys(object.geometry)[0],
+  );
+  assert.equal(
+    geometryKinds.filter((kind) => kind === "line").length,
+    24,
+    "Axes must flatten to retained line/tick children",
+  );
+  assert.equal(
+    geometryKinds.filter((kind) => kind === "vector_path").length,
+    2,
+    "Axes.plot must lower to ordinary retained VectorPath curves",
+  );
+  assert.deepEqual(errors, [], `browser errors while testing retained Axes:\n${errors.join("\n")}`);
+  console.log(
+    "Retained Axes smoke passed: shared line/tick family, c2p/p2c, one host evaluation per Rust sample, VectorPath plots, and explicit transform boundary.",
+  );
+} finally {
+  await browser?.close();
+  server.kill("SIGTERM");
+}

--- a/web/python-compat-modules.js
+++ b/web/python-compat-modules.js
@@ -9,6 +9,7 @@ export const PYTHON_COMPAT_MODULES = Object.freeze([
   { sourcePath: "python/_manim_phase_b.py", runtimePath: "/tmp/_manim_phase_b.py", label: "Noon Manim Phase B layer" },
   { sourcePath: "python/_manim_geometry.py", runtimePath: "/tmp/_manim_geometry.py", label: "Noon Manim geometry layer" },
   { sourcePath: "python/_manim_shared_geometry.py", runtimePath: "/tmp/_manim_shared_geometry.py", label: "Noon shared Rust geometry adapter" },
+  { sourcePath: "python/_manim_axes.py", runtimePath: "/tmp/_manim_axes.py", label: "Noon shared Axes compatibility layer" },
   { sourcePath: "python/_manim_animation_options.py", runtimePath: "/tmp/_manim_animation_options.py", label: "Noon Manim animation options" },
   { sourcePath: "python/_manim_animate.py", runtimePath: "/tmp/_manim_animate.py", label: "Noon Manim animate layer" },
   { sourcePath: "python/_manim_rotate.py", runtimePath: "/tmp/_manim_rotate.py", label: "Noon Manim Rotate layer" },

--- a/web/python-worker.source.js
+++ b/web/python-worker.source.js
@@ -2,6 +2,7 @@ import initNoonWeb, {
   RetainedNativeTextAuthoringHandle,
   RetainedTypstAuthoringHandle,
   WasmAuthoringStore,
+  WasmAxesAuthoringPlan,
   manimAnnularSectorSnapshotJson,
   manimAnnulusSnapshotJson,
   manimDotSnapshotJson,
@@ -48,6 +49,8 @@ async function initializePyodide() {
   ]);
   const [, pyodide, compatibilityModules] = await startupResourcesReady;
   const authoringStore = new WasmAuthoringStore();
+  self.noonCreateAxesAuthoringPlan = (requestJson) =>
+    new WasmAxesAuthoringPlan(requestJson);
   self.noonCreateAuthoringMobjectHandle = (snapshotJson) =>
     authoringStore.createMobject(snapshotJson);
   self.noonCreateAuthoringDotHandle = (pointX, pointY, radius) =>
@@ -104,6 +107,8 @@ import _manim_semantic_handles
 _manim_semantic_handles.install()
 import _manim_shared_geometry
 _manim_shared_geometry.install()
+import _manim_axes
+_manim_axes.install()
 import _manim_animate
 import _manim_rotate
 _manim_rotate.install()

--- a/web/python/_manim_axes.py
+++ b/web/python/_manim_axes.py
@@ -1,0 +1,335 @@
+"""Thin ManimCE v0.21 Axes facade over shared Rust/WASM authoring state.
+
+Python owns only host-type coercion and unavoidable user-function evaluation. Axis
+placement, tick geometry, coordinate conversion, sampling, discontinuities, smoothing,
+and final plot geometry remain in the shared Rust plans.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Iterable
+from typing import Any, Callable
+
+import noon as _base
+import _manim_compat as _compat
+import _manim_semantic_handles as _shared
+
+try:
+    from js import noonCreateAxesAuthoringPlan as _create_axes_plan
+except ImportError:  # Native CPython has no WASM authoring plan.
+    _create_axes_plan = None
+
+
+_DEFAULT_X_RANGE = (-7.0, 7.0, 1.0)
+_DEFAULT_Y_RANGE = (-4.0, 4.0, 1.0)
+_DEFAULT_X_LENGTH = 12.0
+_DEFAULT_Y_LENGTH = 6.0
+_DEFAULT_PLOT_COLOR = _base.color_from_hex("#FFFF00")
+_DEFAULT_DISCONTINUITY_DT = 1.0e-8
+
+_SUPPORTED_AXIS_OPTIONS = {
+    "include_ticks",
+    "tick_size",
+    "numbers_with_elongated_ticks",
+    "longer_tick_multiple",
+    "stroke_width",
+    "color",
+    "include_tip",
+    "include_numbers",
+    "numbers_to_include",
+}
+
+
+def _finite(name: str, value: object) -> float:
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError(f"{name} must be finite")
+    return result
+
+
+def _range3(name: str, value: object | None, default: tuple[float, float, float]) -> list[float]:
+    if value is None:
+        return list(default)
+    try:
+        values = list(value)  # type: ignore[arg-type]
+    except TypeError as error:
+        raise TypeError(f"{name} must contain 2 or 3 numeric values") from error
+    if len(values) == 2:
+        values.append(1.0)
+    if len(values) != 3:
+        raise ValueError(f"{name} must contain 2 or 3 values")
+    return [_finite(f"{name}[{index}]", item) for index, item in enumerate(values)]
+
+
+def _float_list(name: str, value: object) -> list[float]:
+    try:
+        values = list(value)  # type: ignore[arg-type]
+    except TypeError as error:
+        raise TypeError(f"{name} must be an iterable of numbers") from error
+    return [_finite(f"{name}[{index}]", item) for index, item in enumerate(values)]
+
+
+def _color_payload(value: object) -> list[float]:
+    color = _shared._phase_b._as_color("color", value)
+    return [float(color.red), float(color.green), float(color.blue), float(color.alpha)]
+
+
+def _axis_config(name: str, value: dict[str, object] | None) -> dict[str, object]:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise TypeError(f"{name} must be a dict or None")
+    unknown = sorted(set(value) - _SUPPORTED_AXIS_OPTIONS)
+    if unknown:
+        raise NotImplementedError(
+            f"unsupported retained Axes {name} option(s): {', '.join(unknown)}"
+        )
+
+    result: dict[str, object] = {}
+    for key, item in value.items():
+        if key == "color":
+            result[key] = _color_payload(item)
+        elif key in {"numbers_with_elongated_ticks", "numbers_to_include"}:
+            result[key] = _float_list(f"{name}.{key}", item)
+        elif key in {"tick_size", "stroke_width"}:
+            result[key] = _finite(f"{name}.{key}", item)
+        elif key == "longer_tick_multiple":
+            if isinstance(item, bool):
+                raise TypeError(f"{name}.{key} must be an integer")
+            result[key] = int(item)
+        elif key in {"include_ticks", "include_tip", "include_numbers"}:
+            if not isinstance(item, bool):
+                raise TypeError(f"{name}.{key} must be a bool")
+            result[key] = item
+    return result
+
+
+def _snapshot_line(snapshot: object) -> _compat.Line:
+    if _shared._create_handle is None:
+        raise RuntimeError("shared Mobject handles are unavailable")
+    line = object.__new__(_compat.Line)
+    snapshot_json = json.dumps(snapshot, separators=(",", ":"), allow_nan=False)
+    _shared._attach_shared_handle(line, _shared._create_handle(snapshot_json))
+    return line
+
+
+def _snapshot_curve(snapshot_json: str) -> ParametricFunction:
+    if _shared._create_handle is None:
+        raise RuntimeError("shared Mobject handles are unavailable")
+    curve = object.__new__(ParametricFunction)
+    _shared._attach_shared_handle(curve, _shared._create_handle(snapshot_json))
+    return curve
+
+
+def _blocked_axes_transform(name: str):
+    def blocked(self: Axes, *args: object, **kwargs: object):
+        del self, args, kwargs
+        raise NotImplementedError(
+            f"Axes.{name} requires shared affine coordinate-state synchronization"
+        )
+
+    blocked.__name__ = name
+    return blocked
+
+
+class ParametricFunction(_compat.VMobject):
+    """Retained curve produced by shared plot authoring.
+
+    Direct host-callback construction remains separate; the initial source-compatible
+    surface is created through :meth:`Axes.plot` so the curve shares its Axes state.
+    """
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        del args, kwargs
+        raise NotImplementedError(
+            "direct ParametricFunction construction is not implemented in the shared browser subset"
+        )
+
+
+class FunctionGraph(ParametricFunction):
+    """Source-visible FunctionGraph type pending its direct shared callback plan."""
+
+
+class Axes(_compat.VGroup):
+    """Initial retained linear Axes subset backed by one shared Rust/WASM plan."""
+
+    def __init__(
+        self,
+        x_range: object | None = None,
+        y_range: object | None = None,
+        x_length: float | None = _DEFAULT_X_LENGTH,
+        y_length: float | None = _DEFAULT_Y_LENGTH,
+        axis_config: dict[str, object] | None = None,
+        x_axis_config: dict[str, object] | None = None,
+        y_axis_config: dict[str, object] | None = None,
+        tips: bool = True,
+        **kwargs: Any,
+    ) -> None:
+        if kwargs:
+            unsupported = ", ".join(sorted(kwargs))
+            raise NotImplementedError(f"unsupported retained Axes option(s): {unsupported}")
+        if _create_axes_plan is None:
+            raise RuntimeError("shared Axes authoring is available only in the browser WASM frontend")
+        if x_length is None or y_length is None:
+            raise NotImplementedError("automatic Axes lengths are not implemented")
+        if not isinstance(tips, bool):
+            raise TypeError("tips must be a bool")
+
+        self.x_range = _range3("x_range", x_range, _DEFAULT_X_RANGE)
+        self.y_range = _range3("y_range", y_range, _DEFAULT_Y_RANGE)
+        self.x_length = _finite("x_length", x_length)
+        self.y_length = _finite("y_length", y_length)
+        request = {
+            "x_range": self.x_range,
+            "y_range": self.y_range,
+            "x_length": self.x_length,
+            "y_length": self.y_length,
+            "tips": tips,
+            "axis_config": _axis_config("axis_config", axis_config),
+            "x_axis_config": _axis_config("x_axis_config", x_axis_config),
+            "y_axis_config": _axis_config("y_axis_config", y_axis_config),
+        }
+        self._axes_plan = _create_axes_plan(
+            json.dumps(request, separators=(",", ":"), allow_nan=False)
+        )
+
+        snapshots = json.loads(str(self._axes_plan.childrenJson()))
+        split = int(self._axes_plan.xChildCount)
+        if split <= 0 or split >= len(snapshots):
+            raise RuntimeError("shared Axes plan returned an invalid family boundary")
+        x_members = [_snapshot_line(snapshot) for snapshot in snapshots[:split]]
+        y_members = [_snapshot_line(snapshot) for snapshot in snapshots[split:]]
+        self.x_axis = _compat.VGroup(*x_members)
+        self.y_axis = _compat.VGroup(*y_members)
+        self.axes = _compat.VGroup(self.x_axis, self.y_axis)
+        super().__init__(self.x_axis, self.y_axis)
+
+    def coords_to_point(self, *coords: object) -> _base.Vec2:
+        if len(coords) not in (2, 3):
+            raise TypeError("Axes.coords_to_point expects x, y, and optional zero z")
+        x = _finite("x", coords[0])
+        y = _finite("y", coords[1])
+        if len(coords) == 3 and not math.isclose(_finite("z", coords[2]), 0.0, abs_tol=1.0e-12):
+            raise NotImplementedError("retained Axes currently supports only z=0")
+        point = json.loads(str(self._axes_plan.coordsToPointJson(x, y)))
+        return _base.Vec2(float(point[0]), float(point[1]))
+
+    c2p = coords_to_point
+
+    def point_to_coords(self, point: object) -> tuple[float, float]:
+        value = _compat._as_vec2(point)
+        coords = json.loads(str(self._axes_plan.pointToCoordsJson(value.x, value.y)))
+        return float(coords[0]), float(coords[1])
+
+    p2c = point_to_coords
+
+    def get_origin(self) -> _base.Vec2:
+        return self.coords_to_point(0.0, 0.0)
+
+    def get_axes(self) -> _compat.VGroup:
+        return self.axes
+
+    def get_all_ranges(self) -> list[list[float]]:
+        return [list(self.x_range), list(self.y_range)]
+
+    def plot(
+        self,
+        function: Callable[[float], object],
+        x_range: object | None = None,
+        *,
+        color: object = _DEFAULT_PLOT_COLOR,
+        use_smoothing: bool = True,
+        discontinuities: Iterable[float] | None = None,
+        dt: float = _DEFAULT_DISCONTINUITY_DT,
+        **kwargs: Any,
+    ) -> ParametricFunction:
+        if kwargs:
+            unsupported = ", ".join(sorted(kwargs))
+            raise NotImplementedError(f"unsupported retained Axes.plot option(s): {unsupported}")
+        if not callable(function):
+            raise TypeError("Axes.plot function must be callable")
+        if not isinstance(use_smoothing, bool):
+            raise TypeError("use_smoothing must be a bool")
+
+        plot_range = None if x_range is None else _range3("x_range", x_range, tuple(self.x_range))
+        if x_range is not None:
+            try:
+                original_length = len(x_range)  # type: ignore[arg-type]
+            except TypeError:
+                original_length = 3
+            if original_length == 2:
+                plot_range = plot_range[:2]
+        discontinuity_values = (
+            None
+            if discontinuities is None
+            else _float_list("discontinuities", discontinuities)
+        )
+        plot_request = {
+            "plot_range": plot_range,
+            "discontinuities": discontinuity_values,
+            "discontinuity_dt": _finite("dt", dt),
+            "use_smoothing": use_smoothing,
+        }
+        request_json = json.dumps(plot_request, separators=(",", ":"), allow_nan=False)
+        parameter_subpaths = json.loads(str(self._axes_plan.plotParametersJson(request_json)))
+        value_subpaths: list[list[float]] = []
+        for parameters in parameter_subpaths:
+            values: list[float] = []
+            for parameter in parameters:
+                parameter_value = float(parameter)
+                result = float(function(parameter_value))
+                if not math.isfinite(result):
+                    raise ValueError(
+                        f"Axes.plot function returned a non-finite value at {parameter_value}: {result}"
+                    )
+                values.append(result)
+            value_subpaths.append(values)
+
+        snapshot_json = str(
+            self._axes_plan.finishPlotSnapshotJson(
+                request_json,
+                json.dumps(value_subpaths, separators=(",", ":"), allow_nan=False),
+            )
+        )
+        graph = _snapshot_curve(snapshot_json)
+        graph.function = function
+        graph.underlying_function = function
+        graph.x_range = list(self.x_range if x_range is None else plot_range)
+        graph.set_color(color)
+        return graph
+
+    # A Python-only family transform would move visible lines while leaving c2p/p2c
+    # and subsequently-created plots on stale shared coordinates. Fail explicitly
+    # until the shared plan owns affine Axes placement too.
+    shift = _blocked_axes_transform("shift")
+    move_to = _blocked_axes_transform("move_to")
+    center = _blocked_axes_transform("center")
+    set_x = _blocked_axes_transform("set_x")
+    set_y = _blocked_axes_transform("set_y")
+    scale = _blocked_axes_transform("scale")
+    rotate = _blocked_axes_transform("rotate")
+    next_to = _blocked_axes_transform("next_to")
+    align_to = _blocked_axes_transform("align_to")
+    copy = _blocked_axes_transform("copy")
+
+
+_INSTALLED = False
+
+
+def install() -> None:
+    global _INSTALLED
+    if _INSTALLED:
+        return
+    _INSTALLED = True
+    public = {
+        "Axes": Axes,
+        "ParametricFunction": ParametricFunction,
+        "FunctionGraph": FunctionGraph,
+    }
+    for name, value in public.items():
+        setattr(_base, name, value)
+        setattr(_compat, name, value)
+        if name not in _base.__all__:
+            _base.__all__.append(name)


### PR DESCRIPTION
## Summary
- expose the shared `WasmAxesAuthoringPlan` to Pyodide through one worker constructor
- add a thin `_manim_axes.py` source-compatibility layer for the initial linear `Axes` subset
- construct `x_axis` / `y_axis` as ordinary retained `VGroup` families from Rust-produced line/tick snapshots, using the Rust-provided family boundary
- delegate `c2p` / `p2c` and all `Axes.plot` sampling/mapping/smoothing/final geometry back to the same shared plan
- evaluate the user function exactly once per Rust-provided sample parameter and return only scalar results to Rust
- expose `Axes`, `ParametricFunction`, and `FunctionGraph` names; direct ParametricFunction/FunctionGraph construction remains explicitly unsupported in this slice
- explicitly reject Axes family transforms until shared affine coordinate-state synchronization lands, preventing visible geometry from drifting from c2p/p2c
- add a browser smoke that verifies 24 retained axis/tick Lines, two retained VectorPath curves, c2p/p2c round-trip, callback cardinality, and the transform safety boundary

## Architecture
Python does not own tick positions, axis crossing/origin rules, plot range interpretation, sample density, discontinuity splitting, coordinate mapping, spline controls, or path construction. It only coerces host call shapes/config values and evaluates the user callback when Rust asks for each parameter.

The public Axes family is composed through the existing shared `VGroup` semantic-family path. The initial source-compatible subset intentionally rejects tips and numeric labels because those visible retained implementations are not ready; it does not substitute placeholder geometry.

## Validation added
`node scripts/manim-axes-smoke.mjs` runs through the real Pyodide/WASM authoring worker and asserts:
- canonical label-free Sin/Cos-style Axes => 24 retained `Line` objects
- sin/cos plots => two ordinary retained `VectorPath` objects
- `c2p` -> `p2c` round trip
- explicit three-sample plot callback executes exactly at `[-1, 0, 1]`
- Axes shift fails explicitly until shared affine state is implemented

The smoke is a required `browser-authoring` CI step.

Tracks #695 and #696 / parent #85. Stacked on #718; prerequisites include #701, #709, #714, and #717.