### PR TITLE
Make native Text cluster ordinals cluster-scoped

### DIFF
--- a/crates/noon-text-native/src/lib.rs
+++ b/crates/noon-text-native/src/lib.rs
@@ -211,6 +211,7 @@ impl NativeTextCompiler {
                     line.start.saturating_add(cluster.source.start),
                     line.start.saturating_add(cluster.source.end),
                 );
+                let shaped_cluster_ordinal = cluster_ordinal;
                 for glyph in cluster.glyphs {
                     let origin = Vec2::new(cursor_x + glyph.x, glyph.y);
                     let advance = Vec2::new(glyph.advance, 0.0);
@@ -219,7 +220,7 @@ impl NativeTextCompiler {
                         glyph_id: u32::from(glyph.id),
                         cluster: TextClusterIdentity {
                             source_span,
-                            cluster_ordinal,
+                            cluster_ordinal: shaped_cluster_ordinal,
                             semantic_key: None,
                         },
                         origin,
@@ -231,8 +232,8 @@ impl NativeTextCompiler {
                             Vec2::new(origin.x.max(right), metrics.ascent),
                         ),
                     });
-                    cluster_ordinal = cluster_ordinal.saturating_add(1);
                 }
+                cluster_ordinal = cluster_ordinal.saturating_add(1);
                 cursor_x += cluster.advance();
             });
 
@@ -417,6 +418,8 @@ fn fingerprint_u64(bytes: &[u8]) -> u64 {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use super::*;
 
     fn bundled_font() -> NativeFontFace {
@@ -472,6 +475,39 @@ mod tests {
             assert!("café".is_char_boundary(glyph.cluster.source_span.start as usize));
             assert!("café".is_char_boundary(glyph.cluster.source_span.end as usize));
         }
+    }
+
+    #[test]
+    fn glyphs_from_one_shaped_cluster_share_one_cluster_ordinal() {
+        let source = "a\u{0301}b";
+        let font = bundled_font();
+        let mut compiler = NativeTextCompiler::new();
+        let artifact = compiler
+            .compile_plain(source, &font, &NativeTextOptions::new(24.0))
+            .unwrap();
+
+        let mut by_span = BTreeMap::<TextSourceSpan, Vec<u32>>::new();
+        for glyph in artifact.resource.runs[0].glyphs.iter() {
+            by_span
+                .entry(glyph.cluster.source_span)
+                .or_default()
+                .push(glyph.cluster.cluster_ordinal);
+        }
+        let multi_glyph_cluster = by_span
+            .values()
+            .find(|ordinals| ordinals.len() > 1)
+            .expect("combining-mark fixture must shape at least one multi-glyph cluster");
+        assert!(multi_glyph_cluster
+            .iter()
+            .all(|ordinal| *ordinal == multi_glyph_cluster[0]));
+
+        let mut first_ordinals = by_span
+            .values()
+            .map(|ordinals| ordinals[0])
+            .collect::<Vec<_>>();
+        first_ordinals.sort_unstable();
+        first_ordinals.dedup();
+        assert_eq!(first_ordinals, (0..first_ordinals.len() as u32).collect::<Vec<_>>());
     }
 
     #[test]


### PR DESCRIPTION
Superseded by #907, the clean current-master port now merged as `a6abc3d0162a331818cf9a38744b14a924755a7d`.

The production invariant is unchanged: every glyph emitted from one Swash shaped cluster shares a single `TextClusterIdentity.cluster_ordinal`, and the ordinal advances once per shaped cluster rather than once per glyph. #907 also composes this correctly with the later native-text descent fix already on master.

The original decomposed `a + combining acute` regression was not deterministic with the CI font/shaper because it may compose to a single precomposed glyph. The replacement uses `q + combining acute`, which has no precomposed Unicode form, and its exact-head Fast Gate passed Rust unit tests, rustfmt/Clippy, web preflight, retained/mode-switch browser checks, and rendering.

Closing this stale branch in favor of the merged current-master implementation.