### PR TITLE
Carry retained Text family state over execution transport

### DIFF
--- a/crates/noon-core/src/reactive.rs
+++ b/crates/noon-core/src/reactive.rs
@@ -48,6 +48,10 @@ pub use text_resources::*;
 mod text_animation_members;
 pub use text_animation_members::*;
 
+#[path = "text_family_animation.rs"]
+mod text_family_animation;
+pub use text_family_animation::*;
+
 #[path = "resource_mutation.rs"]
 mod resource_mutation;
 pub use resource_mutation::*;

--- a/crates/noon-core/src/text_family_animation.rs
+++ b/crates/noon-core/src/text_family_animation.rs
@@ -1,0 +1,382 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{FamilyAnimationProgressError, ObjectId, RateFunction, UniformFamilyAnimationPlan};
+
+/// Renderer-visible behavior for one retained Text family animation.
+///
+/// `Reveal` is the pointwise partial-path behavior used by Create/Uncreate.
+/// `DrawBorderThenFill` is intentionally distinct for Write/Unwrite; it must not be
+/// approximated by the same reveal mode merely because both animate family members.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TextFamilyAnimationMode {
+    Reveal,
+    DrawBorderThenFill,
+}
+
+/// One source-level retained Text family animation.
+///
+/// The overall timeline remains object-level, while lag/easing are preserved until
+/// the renderer evaluates individual shaped members. This is required because Manim
+/// applies `rate_function` after per-member lag mapping rather than to one global
+/// reveal scalar.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+pub struct TextFamilyAnimationDefinition {
+    pub object: ObjectId,
+    pub mode: TextFamilyAnimationMode,
+    pub start_time: f64,
+    pub duration: f64,
+    pub lag_ratio: f64,
+    pub rate_function: RateFunction,
+    pub reverse_rate_function: bool,
+    pub reverse_member_order: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum TextFamilyAnimationError {
+    InvalidStartTime(f64),
+    InvalidDuration(f64),
+    InvalidEndTime(f64),
+    InvalidLagRatio(f64),
+    InvalidEvaluationTime(f64),
+    InvalidOverallProgress(f64),
+    FamilyProgress(FamilyAnimationProgressError),
+}
+
+impl std::fmt::Display for TextFamilyAnimationError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidStartTime(value) => {
+                write!(
+                    formatter,
+                    "invalid Text family animation start time {value}"
+                )
+            }
+            Self::InvalidDuration(value) => {
+                write!(formatter, "invalid Text family animation duration {value}")
+            }
+            Self::InvalidEndTime(value) => {
+                write!(formatter, "invalid Text family animation end time {value}")
+            }
+            Self::InvalidLagRatio(value) => {
+                write!(formatter, "invalid Text family animation lag ratio {value}")
+            }
+            Self::InvalidEvaluationTime(value) => {
+                write!(
+                    formatter,
+                    "invalid Text family animation evaluation time {value}"
+                )
+            }
+            Self::InvalidOverallProgress(value) => {
+                write!(formatter, "invalid Text family animation progress {value}")
+            }
+            Self::FamilyProgress(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl std::error::Error for TextFamilyAnimationError {}
+
+impl From<FamilyAnimationProgressError> for TextFamilyAnimationError {
+    fn from(value: FamilyAnimationProgressError) -> Self {
+        Self::FamilyProgress(value)
+    }
+}
+
+impl TextFamilyAnimationDefinition {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        object: ObjectId,
+        mode: TextFamilyAnimationMode,
+        start_time: f64,
+        duration: f64,
+        lag_ratio: f64,
+        rate_function: RateFunction,
+        reverse_rate_function: bool,
+        reverse_member_order: bool,
+    ) -> Result<Self, TextFamilyAnimationError> {
+        let definition = Self {
+            object,
+            mode,
+            start_time,
+            duration,
+            lag_ratio,
+            rate_function,
+            reverse_rate_function,
+            reverse_member_order,
+        };
+        definition.validate()?;
+        Ok(definition)
+    }
+
+    /// Revalidate a definition after any serialization boundary.
+    pub fn validate(self) -> Result<(), TextFamilyAnimationError> {
+        if !self.start_time.is_finite() {
+            return Err(TextFamilyAnimationError::InvalidStartTime(self.start_time));
+        }
+        if !self.duration.is_finite() || self.duration <= 0.0 {
+            return Err(TextFamilyAnimationError::InvalidDuration(self.duration));
+        }
+        let end_time = self.start_time + self.duration;
+        if !end_time.is_finite() {
+            return Err(TextFamilyAnimationError::InvalidEndTime(end_time));
+        }
+        if !self.lag_ratio.is_finite() || self.lag_ratio < 0.0 {
+            return Err(TextFamilyAnimationError::InvalidLagRatio(self.lag_ratio));
+        }
+        Ok(())
+    }
+
+    pub fn end_time(self) -> f64 {
+        self.start_time + self.duration
+    }
+
+    /// Evaluate only the object-level timeline position. Per-member lag and easing
+    /// remain encoded in the returned state and are applied later against the shaped
+    /// resource's actual animation-member count.
+    pub fn state_at(self, time: f64) -> Result<TextFamilyAnimationState, TextFamilyAnimationError> {
+        self.validate()?;
+        if !time.is_finite() {
+            return Err(TextFamilyAnimationError::InvalidEvaluationTime(time));
+        }
+        let overall_progress = ((time - self.start_time) / self.duration).clamp(0.0, 1.0);
+        Ok(TextFamilyAnimationState {
+            mode: self.mode,
+            overall_progress,
+            lag_ratio: self.lag_ratio,
+            rate_function: self.rate_function,
+            reverse_rate_function: self.reverse_rate_function,
+            reverse_member_order: self.reverse_member_order,
+        })
+    }
+}
+
+/// Evaluated frame state for one retained Text family animation.
+///
+/// This structure is transport-friendly but contains no glyph IDs. The renderer
+/// combines it with derived [`crate::TextAnimationMember`] data from the immutable
+/// Text resource, preserving one semantic scene object and avoiding per-frame Python
+/// callbacks.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+pub struct TextFamilyAnimationState {
+    pub mode: TextFamilyAnimationMode,
+    pub overall_progress: f64,
+    pub lag_ratio: f64,
+    pub rate_function: RateFunction,
+    pub reverse_rate_function: bool,
+    pub reverse_member_order: bool,
+}
+
+impl TextFamilyAnimationState {
+    /// Revalidate evaluated state after transport/deserialization.
+    pub fn validate(self) -> Result<(), TextFamilyAnimationError> {
+        if !self.overall_progress.is_finite() || !(0.0..=1.0).contains(&self.overall_progress) {
+            return Err(TextFamilyAnimationError::InvalidOverallProgress(
+                self.overall_progress,
+            ));
+        }
+        if !self.lag_ratio.is_finite() || self.lag_ratio < 0.0 {
+            return Err(TextFamilyAnimationError::InvalidLagRatio(self.lag_ratio));
+        }
+        Ok(())
+    }
+
+    pub fn member_progress(
+        self,
+        member_index: u32,
+        member_count: u32,
+    ) -> Result<f32, TextFamilyAnimationError> {
+        self.validate()?;
+        let scheduled_index = if self.reverse_member_order {
+            member_count
+                .checked_sub(1)
+                .and_then(|last| last.checked_sub(member_index))
+                .ok_or(FamilyAnimationProgressError::InvalidMemberIndex {
+                    index: member_index,
+                    member_count,
+                })?
+        } else {
+            member_index
+        };
+        let plan = UniformFamilyAnimationPlan::new(member_count, self.lag_ratio)?;
+        Ok(plan.member_progress(
+            self.overall_progress,
+            scheduled_index,
+            self.rate_function,
+            self.reverse_rate_function,
+        )?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn close(actual: f32, expected: f32) {
+        assert!(
+            (actual - expected).abs() <= 1e-6,
+            "expected {expected}, got {actual}"
+        );
+    }
+
+    fn definition(
+        reverse_rate_function: bool,
+        reverse_member_order: bool,
+    ) -> TextFamilyAnimationDefinition {
+        TextFamilyAnimationDefinition::new(
+            ObjectId::new(7),
+            TextFamilyAnimationMode::Reveal,
+            2.0,
+            4.0,
+            1.0,
+            RateFunction::Linear,
+            reverse_rate_function,
+            reverse_member_order,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn object_timeline_progress_is_clamped_but_not_eased() {
+        let animation = definition(false, false);
+        assert_eq!(animation.state_at(1.0).unwrap().overall_progress, 0.0);
+        assert_eq!(animation.state_at(4.0).unwrap().overall_progress, 0.5);
+        assert_eq!(animation.state_at(7.0).unwrap().overall_progress, 1.0);
+        assert_eq!(animation.end_time(), 6.0);
+    }
+
+    #[test]
+    fn create_member_progress_matches_manim_lag_one() {
+        let state = definition(false, false).state_at(4.0).unwrap();
+        let values = (0..5)
+            .map(|index| state.member_progress(index, 5).unwrap())
+            .collect::<Vec<_>>();
+        for (actual, expected) in values.into_iter().zip([1.0, 1.0, 0.5, 0.0, 0.0]) {
+            close(actual, expected);
+        }
+    }
+
+    #[test]
+    fn uncreate_reverses_rate_without_reversing_member_order() {
+        let state = definition(true, false).state_at(4.0).unwrap();
+        let values = (0..5)
+            .map(|index| state.member_progress(index, 5).unwrap())
+            .collect::<Vec<_>>();
+        for (actual, expected) in values.into_iter().zip([0.0, 0.0, 0.5, 1.0, 1.0]) {
+            close(actual, expected);
+        }
+    }
+
+    #[test]
+    fn reversed_write_order_is_independent_from_rate_reversal() {
+        let state = definition(false, true).state_at(2.8).unwrap();
+        close(state.member_progress(0, 5).unwrap(), 0.0);
+        close(state.member_progress(4, 5).unwrap(), 1.0);
+
+        let unwrite = definition(true, true).state_at(2.8).unwrap();
+        close(unwrite.member_progress(0, 5).unwrap(), 1.0);
+        close(unwrite.member_progress(4, 5).unwrap(), 0.0);
+    }
+
+    #[test]
+    fn serialized_definition_and_state_are_revalidated() {
+        let mut invalid_definition = definition(false, false);
+        invalid_definition.duration = f64::INFINITY;
+        assert_eq!(
+            invalid_definition.validate(),
+            Err(TextFamilyAnimationError::InvalidDuration(f64::INFINITY))
+        );
+        assert_eq!(
+            invalid_definition.state_at(3.0),
+            Err(TextFamilyAnimationError::InvalidDuration(f64::INFINITY))
+        );
+
+        let mut invalid_state = definition(false, false).state_at(3.0).unwrap();
+        invalid_state.overall_progress = 1.5;
+        assert_eq!(
+            invalid_state.validate(),
+            Err(TextFamilyAnimationError::InvalidOverallProgress(1.5))
+        );
+        assert_eq!(
+            invalid_state.member_progress(0, 1),
+            Err(TextFamilyAnimationError::InvalidOverallProgress(1.5))
+        );
+    }
+
+    #[test]
+    fn invalid_timing_and_member_inputs_fail_closed() {
+        assert!(matches!(
+            TextFamilyAnimationDefinition::new(
+                ObjectId::new(1),
+                TextFamilyAnimationMode::Reveal,
+                f64::NAN,
+                1.0,
+                0.0,
+                RateFunction::Linear,
+                false,
+                false,
+            ),
+            Err(TextFamilyAnimationError::InvalidStartTime(value)) if value.is_nan()
+        ));
+        assert_eq!(
+            TextFamilyAnimationDefinition::new(
+                ObjectId::new(1),
+                TextFamilyAnimationMode::Reveal,
+                0.0,
+                0.0,
+                0.0,
+                RateFunction::Linear,
+                false,
+                false,
+            ),
+            Err(TextFamilyAnimationError::InvalidDuration(0.0))
+        );
+        assert_eq!(
+            TextFamilyAnimationDefinition::new(
+                ObjectId::new(1),
+                TextFamilyAnimationMode::Reveal,
+                f64::MAX,
+                f64::MAX,
+                0.0,
+                RateFunction::Linear,
+                false,
+                false,
+            ),
+            Err(TextFamilyAnimationError::InvalidEndTime(f64::INFINITY))
+        );
+        assert_eq!(
+            TextFamilyAnimationDefinition::new(
+                ObjectId::new(1),
+                TextFamilyAnimationMode::Reveal,
+                0.0,
+                1.0,
+                -0.1,
+                RateFunction::Linear,
+                false,
+                false,
+            ),
+            Err(TextFamilyAnimationError::InvalidLagRatio(-0.1))
+        );
+
+        let state = definition(false, false).state_at(3.0).unwrap();
+        assert!(matches!(
+            state.member_progress(0, 0),
+            Err(TextFamilyAnimationError::FamilyProgress(
+                FamilyAnimationProgressError::Composition(_)
+            ))
+        ));
+        assert!(matches!(
+            state.member_progress(5, 5),
+            Err(TextFamilyAnimationError::FamilyProgress(
+                FamilyAnimationProgressError::InvalidMemberIndex {
+                    index: 5,
+                    member_count: 5,
+                }
+            ))
+        ));
+        assert!(matches!(
+            definition(false, false).state_at(f64::INFINITY),
+            Err(TextFamilyAnimationError::InvalidEvaluationTime(value)) if value.is_infinite()
+        ));
+    }
+}

--- a/crates/noon-runtime/src/reactive.rs
+++ b/crates/noon-runtime/src/reactive.rs
@@ -19,3 +19,6 @@ pub use timeline_scheduler::*;
 #[path = "retained.rs"]
 mod retained_runtime;
 pub use retained_runtime::*;
+
+mod retained_text_family;
+pub use retained_text_family::*;

--- a/crates/noon-runtime/src/retained_text_family.rs
+++ b/crates/noon-runtime/src/retained_text_family.rs
@@ -1,0 +1,402 @@
+use noon_compile::RetainedCompiledScene;
+use noon_core::{
+    ObjectId, TextFamilyAnimationDefinition, TextFamilyAnimationError, TextFamilyAnimationState,
+};
+
+use crate::{EvaluationError, FrameChanges, RetainedFrameState, RetainedSceneInstance};
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct RetainedTextFamilyFrame<'a> {
+    pub retained: &'a RetainedFrameState,
+    pub text_family_animations: &'a [Option<TextFamilyAnimationState>],
+}
+
+impl RetainedTextFamilyFrame<'_> {
+    pub fn text_family_animation(&self, object_index: usize) -> Option<TextFamilyAnimationState> {
+        self.text_family_animations
+            .get(object_index)
+            .copied()
+            .flatten()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum RetainedTextFamilyRuntimeError {
+    Animation(TextFamilyAnimationError),
+    UnknownObject(ObjectId),
+    NonTextObject(ObjectId),
+    OverlappingAnimations {
+        object: ObjectId,
+        previous_start: f64,
+        previous_end: f64,
+        next_start: f64,
+    },
+    Evaluation(EvaluationError),
+}
+
+impl std::fmt::Display for RetainedTextFamilyRuntimeError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Animation(error) => error.fmt(formatter),
+            Self::UnknownObject(object) => write!(
+                formatter,
+                "Text family animation references unknown retained object {}",
+                object.get()
+            ),
+            Self::NonTextObject(object) => write!(
+                formatter,
+                "Text family animation targets non-text retained object {}",
+                object.get()
+            ),
+            Self::OverlappingAnimations {
+                object,
+                previous_start,
+                previous_end,
+                next_start,
+            } => write!(
+                formatter,
+                "Text family animations overlap for object {}: previous [{previous_start}, {previous_end}], next starts at {next_start}",
+                object.get()
+            ),
+            Self::Evaluation(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl std::error::Error for RetainedTextFamilyRuntimeError {}
+
+impl From<TextFamilyAnimationError> for RetainedTextFamilyRuntimeError {
+    fn from(value: TextFamilyAnimationError) -> Self {
+        Self::Animation(value)
+    }
+}
+
+impl From<EvaluationError> for RetainedTextFamilyRuntimeError {
+    fn from(value: EvaluationError) -> Self {
+        Self::Evaluation(value)
+    }
+}
+
+/// Additive retained runtime for Text family animations.
+///
+/// Ordinary retained object properties remain owned by [`RetainedSceneInstance`].
+/// This wrapper evaluates only content-specific Text family state, preserving raw
+/// animation progress until the renderer combines it with shaped resource members.
+/// No glyph identity or Python callback enters runtime state.
+#[derive(Clone, Debug)]
+pub struct RetainedTextFamilySceneInstance {
+    inner: RetainedSceneInstance,
+    animations_by_object: Vec<Vec<TextFamilyAnimationDefinition>>,
+    states: Vec<Option<TextFamilyAnimationState>>,
+    family_changed_indices: Vec<usize>,
+}
+
+impl RetainedTextFamilySceneInstance {
+    pub fn new(
+        compiled: RetainedCompiledScene,
+        animations: Vec<TextFamilyAnimationDefinition>,
+    ) -> Result<Self, RetainedTextFamilyRuntimeError> {
+        let object_count = compiled.objects().len();
+        let mut animations_by_object = vec![Vec::new(); object_count];
+
+        for animation in animations {
+            animation.validate()?;
+            let object_index = compiled.object_index(animation.object).ok_or(
+                RetainedTextFamilyRuntimeError::UnknownObject(animation.object),
+            )? as usize;
+            if compiled.objects()[object_index].text().is_none() {
+                return Err(RetainedTextFamilyRuntimeError::NonTextObject(
+                    animation.object,
+                ));
+            }
+            animations_by_object[object_index].push(animation);
+        }
+
+        for object_animations in &mut animations_by_object {
+            object_animations.sort_by(|left, right| left.start_time.total_cmp(&right.start_time));
+            for pair in object_animations.windows(2) {
+                let previous = pair[0];
+                let next = pair[1];
+                if next.start_time < previous.end_time() {
+                    return Err(RetainedTextFamilyRuntimeError::OverlappingAnimations {
+                        object: previous.object,
+                        previous_start: previous.start_time,
+                        previous_end: previous.end_time(),
+                        next_start: next.start_time,
+                    });
+                }
+            }
+        }
+
+        let inner = RetainedSceneInstance::new(compiled);
+        let states = evaluate_family_states(&animations_by_object, 0.0)?;
+        Ok(Self {
+            inner,
+            animations_by_object,
+            states,
+            family_changed_indices: Vec::new(),
+        })
+    }
+
+    pub fn frame(&self) -> RetainedTextFamilyFrame<'_> {
+        RetainedTextFamilyFrame {
+            retained: self.inner.frame(),
+            text_family_animations: &self.states,
+        }
+    }
+
+    pub fn evaluate(
+        &mut self,
+        time: f64,
+    ) -> Result<RetainedTextFamilyFrame<'_>, RetainedTextFamilyRuntimeError> {
+        self.inner.evaluate(time)?;
+        self.update_family_states(time)?;
+        Ok(self.frame())
+    }
+
+    pub fn seek(
+        &mut self,
+        time: f64,
+    ) -> Result<RetainedTextFamilyFrame<'_>, RetainedTextFamilyRuntimeError> {
+        self.inner.seek(time)?;
+        self.update_family_states(time)?;
+        Ok(self.frame())
+    }
+
+    pub fn advance_to(
+        &mut self,
+        time: f64,
+    ) -> Result<RetainedTextFamilyFrame<'_>, RetainedTextFamilyRuntimeError> {
+        self.inner.advance_to(time)?;
+        self.update_family_states(time)?;
+        Ok(self.frame())
+    }
+
+    pub fn take_frame_changes(&mut self) -> FrameChanges {
+        let base = self.inner.take_frame_changes();
+        if base.is_all() {
+            self.family_changed_indices.clear();
+            return FrameChanges::all();
+        }
+
+        let mut object_indices = base.object_indices().to_vec();
+        object_indices.append(&mut self.family_changed_indices);
+        object_indices.sort_unstable();
+        object_indices.dedup();
+        FrameChanges::with_structure(
+            object_indices,
+            base.added_indices().to_vec(),
+            base.removed_indices().to_vec(),
+        )
+    }
+
+    pub fn inner(&self) -> &RetainedSceneInstance {
+        &self.inner
+    }
+
+    fn update_family_states(&mut self, time: f64) -> Result<(), RetainedTextFamilyRuntimeError> {
+        let next = evaluate_family_states(&self.animations_by_object, time)?;
+        for (index, (previous, current)) in self.states.iter().zip(&next).enumerate() {
+            if previous != current {
+                self.family_changed_indices.push(index);
+            }
+        }
+        self.states = next;
+        Ok(())
+    }
+}
+
+fn evaluate_family_states(
+    animations_by_object: &[Vec<TextFamilyAnimationDefinition>],
+    time: f64,
+) -> Result<Vec<Option<TextFamilyAnimationState>>, RetainedTextFamilyRuntimeError> {
+    if !time.is_finite() {
+        return Err(RetainedTextFamilyRuntimeError::Evaluation(
+            EvaluationError::InvalidTime(time),
+        ));
+    }
+
+    animations_by_object
+        .iter()
+        .map(|animations| {
+            animations
+                .iter()
+                .rev()
+                .find(|animation| animation.start_time <= time && time <= animation.end_time())
+                .copied()
+                .map(|animation| animation.state_at(time))
+                .transpose()
+                .map_err(Into::into)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use noon_core::{
+        GeometryRef, RateFunction, RetainedObjectDefinition, TextFamilyAnimationMode,
+        TextResourceHandle, TextResourceId,
+    };
+
+    use super::*;
+
+    fn text_handle() -> TextResourceHandle {
+        TextResourceHandle {
+            id: TextResourceId::new(11),
+            version: 0,
+        }
+    }
+
+    fn compiled_text(object: ObjectId) -> RetainedCompiledScene {
+        RetainedCompiledScene::compile(
+            &[RetainedObjectDefinition::text(object, text_handle())],
+            &[],
+        )
+        .unwrap()
+    }
+
+    fn animation(
+        object: ObjectId,
+        start_time: f64,
+        duration: f64,
+        reverse_rate_function: bool,
+        reverse_member_order: bool,
+    ) -> TextFamilyAnimationDefinition {
+        TextFamilyAnimationDefinition::new(
+            object,
+            TextFamilyAnimationMode::Reveal,
+            start_time,
+            duration,
+            1.0,
+            RateFunction::Linear,
+            reverse_rate_function,
+            reverse_member_order,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn direct_seek_and_incremental_advance_produce_identical_family_state() {
+        let object = ObjectId::new(7);
+        let definitions = vec![animation(object, 1.0, 2.0, false, false)];
+        let mut incremental =
+            RetainedTextFamilySceneInstance::new(compiled_text(object), definitions.clone())
+                .unwrap();
+        incremental.take_frame_changes();
+        incremental.advance_to(1.25).unwrap();
+        incremental.advance_to(2.0).unwrap();
+        let incremental_state = incremental.frame().text_family_animation(0).unwrap();
+
+        let mut direct =
+            RetainedTextFamilySceneInstance::new(compiled_text(object), definitions).unwrap();
+        direct.seek(2.0).unwrap();
+        let direct_state = direct.frame().text_family_animation(0).unwrap();
+
+        assert_eq!(incremental_state, direct_state);
+        assert_eq!(direct_state.overall_progress, 0.5);
+        assert_eq!(
+            (0..5)
+                .map(|index| direct_state.member_progress(index, 5).unwrap())
+                .collect::<Vec<_>>(),
+            vec![1.0, 1.0, 0.5, 0.0, 0.0]
+        );
+    }
+
+    #[test]
+    fn family_state_changes_mark_only_the_target_object_dirty() {
+        let first = ObjectId::new(7);
+        let second = ObjectId::new(8);
+        let compiled = RetainedCompiledScene::compile(
+            &[
+                RetainedObjectDefinition::text(first, text_handle()),
+                RetainedObjectDefinition::text(second, text_handle()),
+            ],
+            &[],
+        )
+        .unwrap();
+        let mut instance = RetainedTextFamilySceneInstance::new(
+            compiled,
+            vec![animation(second, 1.0, 1.0, false, false)],
+        )
+        .unwrap();
+        assert!(instance.take_frame_changes().is_all());
+
+        instance.evaluate(0.5).unwrap();
+        assert!(instance.take_frame_changes().is_empty());
+
+        instance.evaluate(1.0).unwrap();
+        assert_eq!(instance.take_frame_changes().object_indices(), &[1]);
+        instance.evaluate(1.5).unwrap();
+        assert_eq!(instance.take_frame_changes().object_indices(), &[1]);
+        instance.evaluate(2.1).unwrap();
+        assert_eq!(instance.take_frame_changes().object_indices(), &[1]);
+    }
+
+    #[test]
+    fn adjacent_animations_are_allowed_and_later_start_wins_at_boundary() {
+        let object = ObjectId::new(7);
+        let first = animation(object, 0.0, 1.0, false, false);
+        let second = animation(object, 1.0, 1.0, true, true);
+        let mut instance =
+            RetainedTextFamilySceneInstance::new(compiled_text(object), vec![first, second])
+                .unwrap();
+        instance.seek(1.0).unwrap();
+        let state = instance.frame().text_family_animation(0).unwrap();
+        assert_eq!(state.overall_progress, 0.0);
+        assert!(state.reverse_rate_function);
+        assert!(state.reverse_member_order);
+    }
+
+    #[test]
+    fn overlapping_animations_on_one_text_object_fail_before_runtime_start() {
+        let object = ObjectId::new(7);
+        let error = RetainedTextFamilySceneInstance::new(
+            compiled_text(object),
+            vec![
+                animation(object, 0.0, 2.0, false, false),
+                animation(object, 1.0, 1.0, false, false),
+            ],
+        )
+        .unwrap_err();
+        assert!(matches!(
+            error,
+            RetainedTextFamilyRuntimeError::OverlappingAnimations {
+                object: actual,
+                previous_start: 0.0,
+                previous_end: 2.0,
+                next_start: 1.0,
+            } if actual == object
+        ));
+    }
+
+    #[test]
+    fn unknown_and_non_text_targets_fail_closed() {
+        let text = ObjectId::new(7);
+        assert_eq!(
+            RetainedTextFamilySceneInstance::new(
+                compiled_text(text),
+                vec![animation(ObjectId::new(99), 0.0, 1.0, false, false)],
+            )
+            .unwrap_err(),
+            RetainedTextFamilyRuntimeError::UnknownObject(ObjectId::new(99))
+        );
+
+        let geometry = ObjectId::new(8);
+        let compiled = RetainedCompiledScene::compile(
+            &[RetainedObjectDefinition::geometry(
+                geometry,
+                GeometryRef::circle(1.0),
+            )],
+            &[],
+        )
+        .unwrap();
+        assert_eq!(
+            RetainedTextFamilySceneInstance::new(
+                compiled,
+                vec![animation(geometry, 0.0, 1.0, false, false)],
+            )
+            .unwrap_err(),
+            RetainedTextFamilyRuntimeError::NonTextObject(geometry)
+        );
+    }
+}

--- a/crates/noon-web/src/lib.rs
+++ b/crates/noon-web/src/lib.rs
@@ -31,6 +31,7 @@ mod retained_execution_resources;
 mod retained_execution_transport;
 mod retained_resource_mutation_transport;
 mod retained_resource_transport;
+mod retained_text_family_transport;
 mod retained_typst_canvas;
 mod semantic_snapshot;
 mod spatial_query;
@@ -65,6 +66,7 @@ pub use retained_execution_resources::*;
 pub use retained_execution_transport::*;
 pub use retained_resource_mutation_transport::*;
 pub use retained_resource_transport::*;
+pub use retained_text_family_transport::*;
 #[cfg(target_arch = "wasm32")]
 pub use retained_typst_canvas::*;
 pub use semantic_snapshot::*;

--- a/crates/noon-web/src/retained_text_family_transport.rs
+++ b/crates/noon-web/src/retained_text_family_transport.rs
@@ -1,0 +1,487 @@
+use noon_core::{
+    ObjectId, TextFamilyAnimationError, TextFamilyAnimationState,
+};
+use noon_runtime::{
+    FrameChanges, RetainedFrameState, RetainedTextFamilyFrame,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    RetainedExecutionDeltaEncoder, RetainedExecutionDeltaEnvelope,
+    RetainedExecutionFrameMirror, RetainedExecutionTransportError,
+    RetainedTransportApplyOutcome, TransportObjectContent,
+    RETAINED_EXECUTION_TRANSPORT_CHANNEL, RETAINED_EXECUTION_TRANSPORT_VERSION,
+};
+
+/// Retained execution protocol carrying object-local Text family animation state.
+///
+/// Version 2 deliberately reuses the v1 object/session/sequence protocol internally,
+/// but old consumers must reject it rather than silently dropping animation state.
+pub const RETAINED_TEXT_FAMILY_TRANSPORT_VERSION: u32 = 2;
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct RetainedTextFamilyExecutionDeltaEnvelope {
+    #[serde(flatten)]
+    pub retained: RetainedExecutionDeltaEnvelope,
+    pub text_family_animations: Vec<Option<TextFamilyAnimationState>>,
+}
+
+#[derive(Debug)]
+pub enum RetainedTextFamilyTransportError {
+    Base(RetainedExecutionTransportError),
+    UnsupportedVersion(u32),
+    StateShapeMismatch {
+        objects: usize,
+        states: usize,
+    },
+    InvalidObjectOrder(u32),
+    NonTextAnimation(ObjectId),
+    Animation(TextFamilyAnimationError),
+    MissingFrameSnapshot,
+}
+
+impl std::fmt::Display for RetainedTextFamilyTransportError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Base(error) => error.fmt(formatter),
+            Self::UnsupportedVersion(version) => write!(
+                formatter,
+                "unsupported retained Text family transport version {version}"
+            ),
+            Self::StateShapeMismatch { objects, states } => write!(
+                formatter,
+                "retained Text family transport carries {states} animation states for {objects} objects"
+            ),
+            Self::InvalidObjectOrder(order) => {
+                write!(formatter, "invalid retained Text family object order {order}")
+            }
+            Self::NonTextAnimation(object) => write!(
+                formatter,
+                "retained Text family animation targets non-text object {}",
+                object.get()
+            ),
+            Self::Animation(error) => error.fmt(formatter),
+            Self::MissingFrameSnapshot => formatter
+                .write_str("retained Text family transport has no installed frame snapshot"),
+        }
+    }
+}
+
+impl std::error::Error for RetainedTextFamilyTransportError {}
+
+impl From<RetainedExecutionTransportError> for RetainedTextFamilyTransportError {
+    fn from(value: RetainedExecutionTransportError) -> Self {
+        Self::Base(value)
+    }
+}
+
+impl From<TextFamilyAnimationError> for RetainedTextFamilyTransportError {
+    fn from(value: TextFamilyAnimationError) -> Self {
+        Self::Animation(value)
+    }
+}
+
+/// Version-2 encoder that delegates all base retained sequencing to the existing
+/// v1 encoder, then attaches the animation state for exactly the transmitted slots.
+#[derive(Clone, Debug)]
+pub struct RetainedTextFamilyDeltaEncoder {
+    base: RetainedExecutionDeltaEncoder,
+}
+
+impl RetainedTextFamilyDeltaEncoder {
+    pub const fn new(session: u32) -> Self {
+        Self {
+            base: RetainedExecutionDeltaEncoder::new(session),
+        }
+    }
+
+    pub fn encode_snapshot(
+        &mut self,
+        frame: RetainedTextFamilyFrame<'_>,
+        camera: noon_core::Camera2DState,
+    ) -> Result<RetainedTextFamilyExecutionDeltaEnvelope, RetainedTextFamilyTransportError> {
+        let delta = self.base.encode_snapshot(frame.retained, camera)?;
+        upgrade_delta(frame, delta)
+    }
+
+    pub fn encode_incremental(
+        &mut self,
+        frame: RetainedTextFamilyFrame<'_>,
+        changes: &FrameChanges,
+        camera: noon_core::Camera2DState,
+    ) -> Result<Option<RetainedTextFamilyExecutionDeltaEnvelope>, RetainedTextFamilyTransportError>
+    {
+        self.base
+            .encode_incremental(frame.retained, changes, camera)?
+            .map(|delta| upgrade_delta(frame, delta))
+            .transpose()
+    }
+}
+
+fn upgrade_delta(
+    frame: RetainedTextFamilyFrame<'_>,
+    mut retained: RetainedExecutionDeltaEnvelope,
+) -> Result<RetainedTextFamilyExecutionDeltaEnvelope, RetainedTextFamilyTransportError> {
+    let mut states = Vec::with_capacity(retained.objects.len());
+    for object in &retained.objects {
+        let index = usize::try_from(object.order)
+            .map_err(|_| RetainedTextFamilyTransportError::InvalidObjectOrder(object.order))?;
+        let state = frame
+            .text_family_animations
+            .get(index)
+            .copied()
+            .ok_or(RetainedTextFamilyTransportError::InvalidObjectOrder(
+                object.order,
+            ))?;
+        validate_object_animation(object.object, &object.content, state)?;
+        states.push(state);
+    }
+    retained.protocol_version = RETAINED_TEXT_FAMILY_TRANSPORT_VERSION;
+    Ok(RetainedTextFamilyExecutionDeltaEnvelope {
+        retained,
+        text_family_animations: states,
+    })
+}
+
+fn validate_object_animation(
+    object: ObjectId,
+    content: &TransportObjectContent,
+    state: Option<TextFamilyAnimationState>,
+) -> Result<(), RetainedTextFamilyTransportError> {
+    let Some(state) = state else {
+        return Ok(());
+    };
+    state.validate()?;
+    if !matches!(content, TransportObjectContent::Text { .. }) {
+        return Err(RetainedTextFamilyTransportError::NonTextAnimation(object));
+    }
+    Ok(())
+}
+
+/// Transactional v2 mirror. The v1 mirror remains the authority for session,
+/// sequence, slot identity, content identity, camera, and retained frame state.
+/// Animation state is committed only after both layers validate successfully.
+#[derive(Clone, Debug, Default)]
+pub struct RetainedTextFamilyExecutionFrameMirror {
+    base: RetainedExecutionFrameMirror,
+    text_family_animations: Vec<Option<TextFamilyAnimationState>>,
+}
+
+impl RetainedTextFamilyExecutionFrameMirror {
+    pub fn frame(&self) -> Option<&RetainedFrameState> {
+        self.base.frame()
+    }
+
+    pub const fn camera(&self) -> noon_core::Camera2DState {
+        self.base.camera()
+    }
+
+    pub fn text_family_animations(&self) -> &[Option<TextFamilyAnimationState>] {
+        &self.text_family_animations
+    }
+
+    pub fn text_family_animation(
+        &self,
+        object_index: usize,
+    ) -> Option<TextFamilyAnimationState> {
+        self.text_family_animations
+            .get(object_index)
+            .copied()
+            .flatten()
+    }
+
+    pub fn apply(
+        &mut self,
+        delta: RetainedTextFamilyExecutionDeltaEnvelope,
+    ) -> Result<(RetainedTransportApplyOutcome, FrameChanges), RetainedTextFamilyTransportError>
+    {
+        if delta.retained.channel != RETAINED_EXECUTION_TRANSPORT_CHANNEL {
+            let mut base = delta.retained.clone();
+            base.protocol_version = RETAINED_EXECUTION_TRANSPORT_VERSION;
+            return Err(RetainedTextFamilyTransportError::Base(
+                RetainedExecutionFrameMirror::default()
+                    .apply(base)
+                    .expect_err("invalid channel must be rejected by base transport"),
+            ));
+        }
+        if delta.retained.protocol_version != RETAINED_TEXT_FAMILY_TRANSPORT_VERSION {
+            return Err(RetainedTextFamilyTransportError::UnsupportedVersion(
+                delta.retained.protocol_version,
+            ));
+        }
+        if delta.retained.objects.len() != delta.text_family_animations.len() {
+            return Err(RetainedTextFamilyTransportError::StateShapeMismatch {
+                objects: delta.retained.objects.len(),
+                states: delta.text_family_animations.len(),
+            });
+        }
+
+        let mut candidate_base = self.base.clone();
+        let mut base_delta = delta.retained.clone();
+        base_delta.protocol_version = RETAINED_EXECUTION_TRANSPORT_VERSION;
+        let (outcome, changes) = candidate_base.apply(base_delta)?;
+        if outcome == RetainedTransportApplyOutcome::DroppedStale {
+            return Ok((outcome, changes));
+        }
+
+        for (object, state) in delta
+            .retained
+            .objects
+            .iter()
+            .zip(&delta.text_family_animations)
+        {
+            validate_object_animation(object.object, &object.content, *state)?;
+        }
+
+        let frame = candidate_base
+            .frame()
+            .ok_or(RetainedTextFamilyTransportError::MissingFrameSnapshot)?;
+        let mut candidate_states = if delta.retained.snapshot {
+            vec![None; frame.objects.len()]
+        } else {
+            if self.text_family_animations.len() != frame.objects.len() {
+                return Err(RetainedTextFamilyTransportError::StateShapeMismatch {
+                    objects: frame.objects.len(),
+                    states: self.text_family_animations.len(),
+                });
+            }
+            self.text_family_animations.clone()
+        };
+
+        for (object, state) in delta
+            .retained
+            .objects
+            .iter()
+            .zip(delta.text_family_animations.iter().copied())
+        {
+            let index = usize::try_from(object.order)
+                .map_err(|_| RetainedTextFamilyTransportError::InvalidObjectOrder(object.order))?;
+            let destination = candidate_states
+                .get_mut(index)
+                .ok_or(RetainedTextFamilyTransportError::InvalidObjectOrder(
+                    object.order,
+                ))?;
+            *destination = state;
+        }
+
+        self.base = candidate_base;
+        self.text_family_animations = candidate_states;
+        Ok((outcome, changes))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use noon_core::{
+        Camera2DState, GeometryRef, ObjectContentRef, RateFunction, Style,
+        TextFamilyAnimationDefinition, TextFamilyAnimationMode, TextResourceHandle,
+        TextResourceId, Transform2D,
+    };
+    use noon_runtime::RetainedFrameObjectState;
+
+    use super::*;
+
+    fn mixed_frame(time: f64) -> RetainedFrameState {
+        let text = TextResourceHandle {
+            id: TextResourceId::new(7),
+            version: 3,
+        };
+        RetainedFrameState {
+            time,
+            objects: vec![
+                RetainedFrameObjectState {
+                    id: ObjectId::new(11),
+                    content: ObjectContentRef::Geometry(GeometryRef::circle(1.0)),
+                    transform: Transform2D::IDENTITY,
+                    style: Style::default(),
+                    appearance: 1.0,
+                },
+                RetainedFrameObjectState {
+                    id: ObjectId::new(12),
+                    content: ObjectContentRef::Text(text),
+                    transform: Transform2D::IDENTITY,
+                    style: Style::default(),
+                    appearance: 1.0,
+                },
+            ],
+            presences: vec![true, true],
+            reveals: vec![1.0, 1.0],
+            morphs: vec![0.0, 0.0],
+            render_geometries: vec![None, None],
+        }
+    }
+
+    fn family_state(progress_time: f64) -> TextFamilyAnimationState {
+        TextFamilyAnimationDefinition::new(
+            ObjectId::new(12),
+            TextFamilyAnimationMode::Reveal,
+            0.0,
+            1.0,
+            1.0,
+            RateFunction::Linear,
+            false,
+            false,
+        )
+        .unwrap()
+        .state_at(progress_time)
+        .unwrap()
+    }
+
+    #[test]
+    fn v2_snapshot_round_trips_text_family_state() {
+        let frame = mixed_frame(0.5);
+        let states = vec![None, Some(family_state(0.5))];
+        let family_frame = RetainedTextFamilyFrame {
+            retained: &frame,
+            text_family_animations: &states,
+        };
+        let mut encoder = RetainedTextFamilyDeltaEncoder::new(4);
+        let delta = encoder
+            .encode_snapshot(family_frame, Camera2DState::default())
+            .unwrap();
+        assert_eq!(
+            delta.retained.protocol_version,
+            RETAINED_TEXT_FAMILY_TRANSPORT_VERSION
+        );
+
+        let json = serde_json::to_string(&delta).unwrap();
+        let decoded: RetainedTextFamilyExecutionDeltaEnvelope =
+            serde_json::from_str(&json).unwrap();
+        let mut mirror = RetainedTextFamilyExecutionFrameMirror::default();
+        let (outcome, changes) = mirror.apply(decoded).unwrap();
+        assert_eq!(outcome, RetainedTransportApplyOutcome::Applied);
+        assert!(changes.is_all());
+        assert_eq!(mirror.frame().unwrap(), &frame);
+        assert_eq!(mirror.text_family_animation(0), None);
+        assert_eq!(mirror.text_family_animation(1), Some(family_state(0.5)));
+    }
+
+    #[test]
+    fn incremental_updates_only_transmitted_family_slot() {
+        let initial = mixed_frame(0.0);
+        let initial_states = vec![None, Some(family_state(0.0))];
+        let mut encoder = RetainedTextFamilyDeltaEncoder::new(7);
+        let snapshot = encoder
+            .encode_snapshot(
+                RetainedTextFamilyFrame {
+                    retained: &initial,
+                    text_family_animations: &initial_states,
+                },
+                Camera2DState::default(),
+            )
+            .unwrap();
+        let mut mirror = RetainedTextFamilyExecutionFrameMirror::default();
+        mirror.apply(snapshot).unwrap();
+
+        let updated = mixed_frame(0.5);
+        let updated_states = vec![None, Some(family_state(0.5))];
+        let delta = encoder
+            .encode_incremental(
+                RetainedTextFamilyFrame {
+                    retained: &updated,
+                    text_family_animations: &updated_states,
+                },
+                &FrameChanges::objects(vec![1]),
+                Camera2DState::default(),
+            )
+            .unwrap()
+            .unwrap();
+        assert_eq!(delta.retained.objects.len(), 1);
+        assert_eq!(delta.text_family_animations, vec![Some(family_state(0.5))]);
+
+        let (_, changes) = mirror.apply(delta).unwrap();
+        assert_eq!(changes.object_indices(), &[1]);
+        assert_eq!(mirror.frame().unwrap().time, 0.5);
+        assert_eq!(mirror.text_family_animation(1), Some(family_state(0.5)));
+    }
+
+    #[test]
+    fn encoder_rejects_family_animation_on_geometry() {
+        let frame = mixed_frame(0.5);
+        let states = vec![Some(family_state(0.5)), None];
+        let mut encoder = RetainedTextFamilyDeltaEncoder::new(11);
+        let error = encoder
+            .encode_snapshot(
+                RetainedTextFamilyFrame {
+                    retained: &frame,
+                    text_family_animations: &states,
+                },
+                Camera2DState::default(),
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            RetainedTextFamilyTransportError::NonTextAnimation(ObjectId::new(11))
+        ));
+    }
+
+    #[test]
+    fn invalid_family_state_does_not_partially_mutate_mirror() {
+        let frame = mixed_frame(0.0);
+        let states = vec![None, Some(family_state(0.0))];
+        let mut encoder = RetainedTextFamilyDeltaEncoder::new(13);
+        let snapshot = encoder
+            .encode_snapshot(
+                RetainedTextFamilyFrame {
+                    retained: &frame,
+                    text_family_animations: &states,
+                },
+                Camera2DState::default(),
+            )
+            .unwrap();
+        let mut mirror = RetainedTextFamilyExecutionFrameMirror::default();
+        mirror.apply(snapshot).unwrap();
+
+        let updated = mixed_frame(0.5);
+        let updated_states = vec![None, Some(family_state(0.5))];
+        let mut delta = encoder
+            .encode_incremental(
+                RetainedTextFamilyFrame {
+                    retained: &updated,
+                    text_family_animations: &updated_states,
+                },
+                &FrameChanges::objects(vec![1]),
+                Camera2DState::default(),
+            )
+            .unwrap()
+            .unwrap();
+        delta.text_family_animations[0]
+            .as_mut()
+            .unwrap()
+            .overall_progress = 2.0;
+
+        assert!(matches!(
+            mirror.apply(delta),
+            Err(RetainedTextFamilyTransportError::Animation(
+                TextFamilyAnimationError::InvalidOverallProgress(2.0)
+            ))
+        ));
+        assert_eq!(mirror.frame().unwrap().time, 0.0);
+        assert_eq!(mirror.text_family_animation(1), Some(family_state(0.0)));
+    }
+
+    #[test]
+    fn v1_payload_is_rejected_by_v2_mirror() {
+        let frame = mixed_frame(0.0);
+        let states = vec![None, Some(family_state(0.0))];
+        let mut encoder = RetainedTextFamilyDeltaEncoder::new(17);
+        let mut delta = encoder
+            .encode_snapshot(
+                RetainedTextFamilyFrame {
+                    retained: &frame,
+                    text_family_animations: &states,
+                },
+                Camera2DState::default(),
+            )
+            .unwrap();
+        delta.retained.protocol_version = RETAINED_EXECUTION_TRANSPORT_VERSION;
+
+        let mut mirror = RetainedTextFamilyExecutionFrameMirror::default();
+        assert!(matches!(
+            mirror.apply(delta),
+            Err(RetainedTextFamilyTransportError::UnsupportedVersion(
+                RETAINED_EXECUTION_TRANSPORT_VERSION
+            ))
+        ));
+    }
+}


### PR DESCRIPTION
Superseded by the current retained execution architecture on master.

This PR introduced a separate version-2 retained Text-family execution envelope/mirror layered over the old v1 retained transport. Current master no longer uses that ownership split: `RetainedTextFamilyTransportState` embeds the optional validated Text-family state directly in the existing retained object transport (with no glyph IDs), while the runtime has generalized scheduling to content-independent `FamilyAnimationState` and multi-plan retained family runtime/frame sets.

Replaying this branch would restore a second protocol-version/encoder/mirror owner beside the canonical mixed retained transport. The intended invariants—validated Text-only state, sparse object-local transport, no glyph identity on the wire, and transactional retained execution ownership—are already represented in the newer architecture. Closing as absorbed/superseded by the later #705/#741 canonical retained family work.