### PR TITLE
Add shared Axes geometry and coordinate authoring plan

### DIFF
--- a/crates/noon-web/src/lib.rs
+++ b/crates/noon-web/src/lib.rs
@@ -14,6 +14,7 @@ mod host_player;
 #[path = "legacy.rs"]
 mod legacy;
 mod lifecycle;
+mod manim_axes_bridge;
 mod manim_elbow_bridge;
 mod manim_geometry_bridge;
 mod manim_path_query_bridge;
@@ -48,6 +49,7 @@ pub use execution_visibility::*;
 pub use host_player::*;
 pub use legacy::*;
 pub use lifecycle::*;
+pub use manim_axes_bridge::*;
 pub use manim_elbow_bridge::*;
 pub use manim_geometry_bridge::*;
 pub use manim_path_query_bridge::*;

--- a/crates/noon-web/src/manim_axes_bridge.rs
+++ b/crates/noon-web/src/manim_axes_bridge.rs
@@ -1,0 +1,430 @@
+use noon::{
+    Axes2DState, AxisTickError, CoordinateSystemError, NumberLineGeometryPlan,
+    NumberLineTickOptions, NumberRange,
+};
+use noon_core::{Color, ObjectSnapshot};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+struct AxisGeometryRequest {
+    #[serde(default)]
+    include_tip: Option<bool>,
+    #[serde(default)]
+    include_ticks: Option<bool>,
+    #[serde(default)]
+    tick_size: Option<f64>,
+    #[serde(default)]
+    numbers_with_elongated_ticks: Option<Vec<f64>>,
+    #[serde(default)]
+    longer_tick_multiple: Option<usize>,
+    #[serde(default)]
+    exclude_origin_tick: Option<bool>,
+    #[serde(default)]
+    stroke_width: Option<f64>,
+    #[serde(default)]
+    color: Option<[f64; 4]>,
+}
+
+impl AxisGeometryRequest {
+    fn overlay(&mut self, other: Self) {
+        if other.include_tip.is_some() {
+            self.include_tip = other.include_tip;
+        }
+        if other.include_ticks.is_some() {
+            self.include_ticks = other.include_ticks;
+        }
+        if other.tick_size.is_some() {
+            self.tick_size = other.tick_size;
+        }
+        if other.numbers_with_elongated_ticks.is_some() {
+            self.numbers_with_elongated_ticks = other.numbers_with_elongated_ticks;
+        }
+        if other.longer_tick_multiple.is_some() {
+            self.longer_tick_multiple = other.longer_tick_multiple;
+        }
+        if other.exclude_origin_tick.is_some() {
+            self.exclude_origin_tick = other.exclude_origin_tick;
+        }
+        if other.stroke_width.is_some() {
+            self.stroke_width = other.stroke_width;
+        }
+        if other.color.is_some() {
+            self.color = other.color;
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+struct AxesAuthoringRequest {
+    x_range: [f64; 3],
+    y_range: [f64; 3],
+    x_length: f32,
+    y_length: f32,
+    #[serde(default = "default_true")]
+    tips: bool,
+    #[serde(default)]
+    axis_config: AxisGeometryRequest,
+    #[serde(default)]
+    x_axis_config: AxisGeometryRequest,
+    #[serde(default)]
+    y_axis_config: AxisGeometryRequest,
+}
+
+const fn default_true() -> bool {
+    true
+}
+
+#[derive(Serialize)]
+struct TickWire<'a> {
+    value: f64,
+    size: f64,
+    snapshot: &'a ObjectSnapshot,
+}
+
+#[derive(Serialize)]
+struct NumberLineGeometryWire<'a> {
+    line: &'a ObjectSnapshot,
+    ticks: Vec<TickWire<'a>>,
+}
+
+#[derive(Serialize)]
+struct AxesGeometryWire<'a> {
+    x_axis: NumberLineGeometryWire<'a>,
+    y_axis: NumberLineGeometryWire<'a>,
+}
+
+/// Shared semantic/geometry plan for the initial linear ManimCE v0.21 `Axes` subset.
+///
+/// This object owns the coordinate mapping and all retained line/tick geometry. Host
+/// frontends may serialize the resulting snapshots into their normal semantic-handle
+/// path, but they do not calculate axis placement, tick positions, tick orientation,
+/// config precedence, or coordinate conversion themselves.
+#[derive(Clone, Debug, PartialEq)]
+pub struct AxesAuthoringPlan {
+    axes: Axes2DState,
+    x_geometry: NumberLineGeometryPlan,
+    y_geometry: NumberLineGeometryPlan,
+}
+
+impl AxesAuthoringPlan {
+    pub fn from_json(request_json: &str) -> Result<Self, ManimAxesBridgeError> {
+        let request: AxesAuthoringRequest = serde_json::from_str(request_json)
+            .map_err(|error| ManimAxesBridgeError::InvalidRequest(error.to_string()))?;
+        Self::new(request)
+    }
+
+    fn new(request: AxesAuthoringRequest) -> Result<Self, ManimAxesBridgeError> {
+        let x_range = NumberRange::new(request.x_range[0], request.x_range[1], request.x_range[2])?;
+        let y_range = NumberRange::new(request.y_range[0], request.y_range[1], request.y_range[2])?;
+        let axes = Axes2DState::new(x_range, y_range, request.x_length, request.y_length)?;
+
+        let mut shared = AxisGeometryRequest {
+            include_tip: Some(request.tips),
+            ..AxisGeometryRequest::default()
+        };
+        shared.overlay(request.axis_config);
+
+        let mut x_request = shared.clone();
+        x_request.overlay(request.x_axis_config);
+        let mut y_request = shared;
+        y_request.overlay(request.y_axis_config);
+
+        let x_options = resolve_axis_options(x_request, Axis::X)?;
+        let y_options = resolve_axis_options(y_request, Axis::Y)?;
+        let x_geometry = NumberLineGeometryPlan::new(axes.x_axis(), &x_options)?;
+        let y_geometry = NumberLineGeometryPlan::new(axes.y_axis(), &y_options)?;
+
+        Ok(Self {
+            axes,
+            x_geometry,
+            y_geometry,
+        })
+    }
+
+    pub const fn axes(&self) -> Axes2DState {
+        self.axes
+    }
+
+    pub fn geometry_json(&self) -> Result<String, ManimAxesBridgeError> {
+        let wire = AxesGeometryWire {
+            x_axis: number_line_wire(&self.x_geometry),
+            y_axis: number_line_wire(&self.y_geometry),
+        };
+        serde_json::to_string(&wire)
+            .map_err(|error| ManimAxesBridgeError::Serialization(error.to_string()))
+    }
+
+    pub fn coords_to_point_json(&self, x: f64, y: f64) -> Result<String, ManimAxesBridgeError> {
+        let point = self.axes.coords_to_point(x, y)?;
+        serde_json::to_string(&[f64::from(point.x), f64::from(point.y)])
+            .map_err(|error| ManimAxesBridgeError::Serialization(error.to_string()))
+    }
+
+    pub fn point_to_coords_json(
+        &self,
+        x: f32,
+        y: f32,
+    ) -> Result<String, ManimAxesBridgeError> {
+        let (x, y) = self.axes.point_to_coords(noon_core::Vec2::new(x, y))?;
+        serde_json::to_string(&[x, y])
+            .map_err(|error| ManimAxesBridgeError::Serialization(error.to_string()))
+    }
+}
+
+fn number_line_wire(plan: &NumberLineGeometryPlan) -> NumberLineGeometryWire<'_> {
+    NumberLineGeometryWire {
+        line: plan.line(),
+        ticks: plan
+            .ticks()
+            .iter()
+            .map(|tick| TickWire {
+                value: tick.value(),
+                size: tick.size(),
+                snapshot: tick.snapshot(),
+            })
+            .collect(),
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Axis {
+    X,
+    Y,
+}
+
+fn resolve_axis_options(
+    request: AxisGeometryRequest,
+    axis: Axis,
+) -> Result<NumberLineTickOptions, ManimAxesBridgeError> {
+    if request.include_tip.unwrap_or(false) {
+        return Err(ManimAxesBridgeError::UnsupportedTips(match axis {
+            Axis::X => "x",
+            Axis::Y => "y",
+        }));
+    }
+
+    let mut options = NumberLineTickOptions::default();
+    if let Some(value) = request.include_ticks {
+        options.include_ticks = value;
+    }
+    if let Some(value) = request.tick_size {
+        options.tick_size = value;
+    }
+    if let Some(values) = request.numbers_with_elongated_ticks {
+        options.elongated_values = values;
+    }
+    if let Some(value) = request.longer_tick_multiple {
+        options.longer_tick_multiple = value;
+    }
+    if let Some(value) = request.stroke_width {
+        options.stroke_width = value;
+    }
+    if let Some(value) = request.color {
+        options.color = rgba(value)?;
+    }
+
+    // Manim's Axes constructor overwrites this after config merging for linear
+    // scaling. User-provided `exclude_origin_tick` therefore does not win here.
+    options.exclude_origin_tick = true;
+    Ok(options)
+}
+
+fn rgba(value: [f64; 4]) -> Result<Color, ManimAxesBridgeError> {
+    if value
+        .iter()
+        .any(|component| !component.is_finite() || !(0.0..=1.0).contains(component))
+    {
+        return Err(ManimAxesBridgeError::InvalidColor(value));
+    }
+    Ok(Color::rgba(
+        value[0] as f32,
+        value[1] as f32,
+        value[2] as f32,
+        value[3] as f32,
+    ))
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ManimAxesBridgeError {
+    InvalidRequest(String),
+    UnsupportedTips(&'static str),
+    InvalidColor([f64; 4]),
+    Coordinates(CoordinateSystemError),
+    Geometry(AxisTickError),
+    Serialization(String),
+}
+
+impl std::fmt::Display for ManimAxesBridgeError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidRequest(error) => write!(formatter, "invalid Axes request: {error}"),
+            Self::UnsupportedTips(axis) => write!(
+                formatter,
+                "Axes {axis}-axis tips are not yet supported by the retained geometry plan"
+            ),
+            Self::InvalidColor(value) => write!(
+                formatter,
+                "Axes color must contain finite RGBA components in [0, 1], got {value:?}"
+            ),
+            Self::Coordinates(error) => error.fmt(formatter),
+            Self::Geometry(error) => error.fmt(formatter),
+            Self::Serialization(error) => {
+                write!(formatter, "unable to serialize Axes state: {error}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ManimAxesBridgeError {}
+
+impl From<CoordinateSystemError> for ManimAxesBridgeError {
+    fn from(value: CoordinateSystemError) -> Self {
+        Self::Coordinates(value)
+    }
+}
+
+impl From<AxisTickError> for ManimAxesBridgeError {
+    fn from(value: AxisTickError) -> Self {
+        Self::Geometry(value)
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+mod wasm {
+    use wasm_bindgen::prelude::*;
+
+    use super::AxesAuthoringPlan;
+
+    fn js_error(error: impl std::fmt::Display) -> JsValue {
+        JsValue::from_str(&error.to_string())
+    }
+
+    #[wasm_bindgen]
+    pub struct WasmAxesAuthoringPlan(AxesAuthoringPlan);
+
+    #[wasm_bindgen]
+    impl WasmAxesAuthoringPlan {
+        #[wasm_bindgen(constructor)]
+        pub fn new(request_json: &str) -> Result<Self, JsValue> {
+            AxesAuthoringPlan::from_json(request_json)
+                .map(Self)
+                .map_err(js_error)
+        }
+
+        #[wasm_bindgen(js_name = geometryJson)]
+        pub fn geometry_json(&self) -> Result<String, JsValue> {
+            self.0.geometry_json().map_err(js_error)
+        }
+
+        #[wasm_bindgen(js_name = coordsToPointJson)]
+        pub fn coords_to_point_json(&self, x: f64, y: f64) -> Result<String, JsValue> {
+            self.0.coords_to_point_json(x, y).map_err(js_error)
+        }
+
+        #[wasm_bindgen(js_name = pointToCoordsJson)]
+        pub fn point_to_coords_json(&self, x: f32, y: f32) -> Result<String, JsValue> {
+            self.0.point_to_coords_json(x, y).map_err(js_error)
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub use wasm::WasmAxesAuthoringPlan;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+
+    fn request(extra: &str) -> String {
+        format!(
+            r#"{{"x_range":[-10.0,10.3,1.0],"y_range":[-1.5,1.5,1.0],"x_length":10.0,"y_length":6.0,"tips":false{extra}}}"#
+        )
+    }
+
+    #[test]
+    fn canonical_plot_axes_geometry_is_owned_by_shared_plan() {
+        let plan = AxesAuthoringPlan::from_json(&request(
+            r#", "axis_config":{"color":[0.0,1.0,0.0,1.0]}, "x_axis_config":{"numbers_with_elongated_ticks":[-10,-8,-6,-4,-2,0,2,4,6,8,10]}"#,
+        ))
+        .unwrap();
+        let geometry: Value = serde_json::from_str(&plan.geometry_json().unwrap()).unwrap();
+        let x_ticks = geometry["x_axis"]["ticks"].as_array().unwrap();
+        let y_ticks = geometry["y_axis"]["ticks"].as_array().unwrap();
+        assert_eq!(x_ticks.len(), 20);
+        assert_eq!(y_ticks.len(), 2);
+        assert!(x_ticks.iter().all(|tick| tick["value"] != 0.0));
+        let elongated = x_ticks
+            .iter()
+            .find(|tick| tick["value"] == 2.0)
+            .unwrap();
+        assert_eq!(elongated["size"], 0.2);
+        assert_eq!(
+            geometry["x_axis"]["line"]["style"]["stroke_width"],
+            0.02
+        );
+    }
+
+    #[test]
+    fn axis_specific_config_overrides_shared_config() {
+        let plan = AxesAuthoringPlan::from_json(&request(
+            r#", "axis_config":{"tick_size":0.2}, "x_axis_config":{"tick_size":0.3}"#,
+        ))
+        .unwrap();
+        let geometry: Value = serde_json::from_str(&plan.geometry_json().unwrap()).unwrap();
+        assert_eq!(geometry["x_axis"]["ticks"][0]["size"], 0.3);
+        assert_eq!(geometry["y_axis"]["ticks"][0]["size"], 0.2);
+    }
+
+    #[test]
+    fn linear_axes_force_origin_tick_exclusion_after_config_merge() {
+        let plan = AxesAuthoringPlan::from_json(&request(
+            r#", "axis_config":{"exclude_origin_tick":false}"#,
+        ))
+        .unwrap();
+        let geometry: Value = serde_json::from_str(&plan.geometry_json().unwrap()).unwrap();
+        for axis in ["x_axis", "y_axis"] {
+            assert!(geometry[axis]["ticks"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .all(|tick| tick["value"] != 0.0));
+        }
+    }
+
+    #[test]
+    fn coordinate_queries_round_trip_through_same_axes_state() {
+        let plan = AxesAuthoringPlan::from_json(&request("")).unwrap();
+        let point: [f64; 2] =
+            serde_json::from_str(&plan.coords_to_point_json(2.0, 1.0).unwrap()).unwrap();
+        let coords: [f64; 2] = serde_json::from_str(
+            &plan
+                .point_to_coords_json(point[0] as f32, point[1] as f32)
+                .unwrap(),
+        )
+        .unwrap();
+        assert!((coords[0] - 2.0).abs() <= 1.0e-5);
+        assert!((coords[1] - 1.0).abs() <= 1.0e-5);
+    }
+
+    #[test]
+    fn tips_are_rejected_instead_of_silently_omitted() {
+        let request =
+            r#"{"x_range":[-1,1,1],"y_range":[-1,1,1],"x_length":2,"y_length":2}"#;
+        assert!(matches!(
+            AxesAuthoringPlan::from_json(request),
+            Err(ManimAxesBridgeError::UnsupportedTips("x"))
+        ));
+    }
+
+    #[test]
+    fn unsupported_axis_config_keys_fail_closed() {
+        let error = AxesAuthoringPlan::from_json(&request(
+            r#", "x_axis_config":{"numbers_to_include":[-2,0,2]}"#,
+        ))
+        .unwrap_err();
+        assert!(matches!(error, ManimAxesBridgeError::InvalidRequest(_)));
+    }
+}

--- a/crates/noon/src/axis_tick_authoring.rs
+++ b/crates/noon/src/axis_tick_authoring.rs
@@ -1,0 +1,195 @@
+use crate::{CoordinateSystemError, IntoSnapshot, Line, NumberLineState};
+use noon_core::{Color, ObjectSnapshot, Vec2, WHITE};
+
+const CAIRO_WIDTH_SCALE: f64 = 0.01;
+const IS_CLOSE_RTOL: f64 = 1.0e-5;
+const IS_CLOSE_ATOL: f64 = 1.0e-8;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct NumberLineTickOptions {
+    pub include_ticks: bool,
+    pub tick_size: f64,
+    pub elongated_values: Vec<f64>,
+    pub longer_tick_multiple: usize,
+    pub exclude_origin_tick: bool,
+    pub color: Color,
+    pub stroke_width: f64,
+}
+
+impl Default for NumberLineTickOptions {
+    fn default() -> Self {
+        Self {
+            include_ticks: true,
+            tick_size: 0.1,
+            elongated_values: Vec::new(),
+            longer_tick_multiple: 2,
+            exclude_origin_tick: false,
+            color: WHITE,
+            stroke_width: 2.0,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct NumberLineTick {
+    value: f64,
+    size: f64,
+    snapshot: ObjectSnapshot,
+}
+
+impl NumberLineTick {
+    pub const fn value(&self) -> f64 {
+        self.value
+    }
+
+    pub const fn size(&self) -> f64 {
+        self.size
+    }
+
+    pub fn snapshot(&self) -> &ObjectSnapshot {
+        &self.snapshot
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct NumberLineGeometryPlan {
+    line: ObjectSnapshot,
+    ticks: Vec<NumberLineTick>,
+}
+
+impl NumberLineGeometryPlan {
+    pub fn new(
+        state: NumberLineState,
+        options: &NumberLineTickOptions,
+    ) -> Result<Self, AxisTickError> {
+        validate_options(options)?;
+        let width = checked_f32(options.stroke_width * CAIRO_WIDTH_SCALE)?;
+        let line = styled_line(state.start(), state.end(), options.color, width);
+        let ticks = if options.include_ticks {
+            build_ticks(state, options, width)?
+        } else {
+            Vec::new()
+        };
+        Ok(Self { line, ticks })
+    }
+
+    pub fn line(&self) -> &ObjectSnapshot {
+        &self.line
+    }
+
+    pub fn ticks(&self) -> &[NumberLineTick] {
+        &self.ticks
+    }
+}
+
+fn build_ticks(
+    state: NumberLineState,
+    options: &NumberLineTickOptions,
+    width: f32,
+) -> Result<Vec<NumberLineTick>, AxisTickError> {
+    let delta = state.end() - state.start();
+    let length = delta.length();
+    if !length.is_finite() || length <= 0.0 {
+        return Err(CoordinateSystemError::DegenerateLine.into());
+    }
+    let tangent = delta / length;
+    let normal = Vec2::new(-tangent.y, tangent.x);
+    let range_min = state.range().min();
+
+    state
+        .tick_values(options.exclude_origin_tick)
+        .into_iter()
+        .map(|value| {
+            let elongated = options
+                .elongated_values
+                .iter()
+                .any(|candidate| is_close(value - range_min, *candidate - range_min));
+            let size = options.tick_size
+                * if elongated {
+                    options.longer_tick_multiple as f64
+                } else {
+                    1.0
+                };
+            let center = state.number_to_point(value)?;
+            let offset = normal * checked_f32(size)?;
+            Ok(NumberLineTick {
+                value,
+                size,
+                snapshot: styled_line(center - offset, center + offset, options.color, width),
+            })
+        })
+        .collect()
+}
+
+fn styled_line(start: Vec2, end: Vec2, color: Color, width: f32) -> ObjectSnapshot {
+    Line::new(start, end)
+        .color(color)
+        .set_stroke(Some(color), Some(width))
+        .into_snapshot()
+}
+
+fn validate_options(options: &NumberLineTickOptions) -> Result<(), AxisTickError> {
+    if !options.tick_size.is_finite() || options.tick_size < 0.0 {
+        return Err(AxisTickError::InvalidTickSize(options.tick_size));
+    }
+    if options.longer_tick_multiple == 0 {
+        return Err(AxisTickError::InvalidLongerTickMultiple);
+    }
+    if !options.stroke_width.is_finite() || options.stroke_width < 0.0 {
+        return Err(AxisTickError::InvalidStrokeWidth(options.stroke_width));
+    }
+    if options
+        .elongated_values
+        .iter()
+        .any(|value| !value.is_finite())
+    {
+        return Err(AxisTickError::NonFiniteElongatedValue);
+    }
+    Ok(())
+}
+
+fn is_close(lhs: f64, rhs: f64) -> bool {
+    (lhs - rhs).abs() <= IS_CLOSE_ATOL + IS_CLOSE_RTOL * rhs.abs()
+}
+
+fn checked_f32(value: f64) -> Result<f32, AxisTickError> {
+    let lowered = value as f32;
+    if lowered.is_finite() {
+        Ok(lowered)
+    } else {
+        Err(AxisTickError::Overflow(value))
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum AxisTickError {
+    Coordinates(CoordinateSystemError),
+    InvalidTickSize(f64),
+    InvalidLongerTickMultiple,
+    InvalidStrokeWidth(f64),
+    NonFiniteElongatedValue,
+    Overflow(f64),
+}
+
+impl From<CoordinateSystemError> for AxisTickError {
+    fn from(value: CoordinateSystemError) -> Self {
+        Self::Coordinates(value)
+    }
+}
+
+impl std::fmt::Display for AxisTickError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Coordinates(error) => error.fmt(f),
+            Self::InvalidTickSize(value) => write!(f, "invalid tick size: {value}"),
+            Self::InvalidLongerTickMultiple => f.write_str("longer tick multiple must be positive"),
+            Self::InvalidStrokeWidth(value) => write!(f, "invalid stroke width: {value}"),
+            Self::NonFiniteElongatedValue => f.write_str("elongated tick values must be finite"),
+            Self::Overflow(value) => {
+                write!(f, "tick geometry cannot be represented as f32: {value}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for AxisTickError {}

--- a/crates/noon/src/lib.rs
+++ b/crates/noon/src/lib.rs
@@ -8,6 +8,7 @@
 
 mod analytic_geometry_authoring;
 mod arc_authoring;
+mod axis_tick_authoring;
 mod camera_authoring;
 mod coordinate_system_authoring;
 mod elbow_authoring;
@@ -25,6 +26,7 @@ mod text_authoring;
 
 pub use analytic_geometry_authoring::*;
 pub use arc_authoring::*;
+pub use axis_tick_authoring::*;
 pub use camera_authoring::*;
 pub use coordinate_system_authoring::*;
 pub use elbow_authoring::*;
@@ -45,15 +47,16 @@ pub mod prelude {
     pub use crate::legacy::prelude::*;
     pub use crate::{
         axes_function_vector_path, parametric_vector_path, AnnularSector, Annulus, Arc,
-        ArcAuthoringError, ArcBetweenPoints, Axes2DState, BackgroundRectangle,
+        ArcAuthoringError, ArcBetweenPoints, Axes2DState, AxisTickError, BackgroundRectangle,
         CoordinateSystemError, Cross, Dot, Elbow, ElbowAuthoringError, Ellipse,
         GeometryAuthoringError, LineMatcherAuthoringError, MathTypst, MovingCameraScene,
-        NumberLineState, NumberRange, ParametricSamplePlan, PlotGeometryError, PlotRangeRequest,
-        PlotSamplingError, Polygon, Polygram, PolygramAuthoringError, ReactiveScene,
-        ReactiveTimelineScene, RegularPolygon, RegularPolygram, RetainedMobject, RetainedScene,
-        RoundedRectangle, RoundedRectangleAuthoringError, SampleRange, SampleSpan, Sector,
-        ShapeMatcherAuthoringError, Star, SurroundingRectangle, Text, TextAuthoringError, Triangle,
-        Typst, Underline, ValueTracker, VectorSignal, BACKGROUND_RECTANGLE_DEFAULT_FILL_OPACITY,
+        NumberLineGeometryPlan, NumberLineState, NumberLineTick, NumberLineTickOptions, NumberRange,
+        ParametricSamplePlan, PlotGeometryError, PlotRangeRequest, PlotSamplingError, Polygon,
+        Polygram, PolygramAuthoringError, ReactiveScene, ReactiveTimelineScene, RegularPolygon,
+        RegularPolygram, RetainedMobject, RetainedScene, RoundedRectangle,
+        RoundedRectangleAuthoringError, SampleRange, SampleSpan, Sector, ShapeMatcherAuthoringError,
+        Star, SurroundingRectangle, Text, TextAuthoringError, Triangle, Typst, Underline,
+        ValueTracker, VectorSignal, BACKGROUND_RECTANGLE_DEFAULT_FILL_OPACITY,
         DEFAULT_CROSS_SCALE_FACTOR, DEFAULT_CROSS_STROKE_WIDTH, DEFAULT_DOT_RADIUS,
         DEFAULT_ELBOW_ANGLE, DEFAULT_ELBOW_WIDTH, DEFAULT_NATIVE_TEXT_FONT_FAMILY,
         DEFAULT_NATIVE_TEXT_FONT_SIZE, DEFAULT_ROUNDED_RECTANGLE_CORNER_RADIUS,

--- a/crates/noon/tests/axis_tick_authoring.rs
+++ b/crates/noon/tests/axis_tick_authoring.rs
@@ -1,0 +1,97 @@
+use noon::{
+    Axes2DState, NumberLineGeometryPlan, NumberLineState, NumberLineTickOptions, NumberRange,
+};
+use noon_core::{GeometryRef, Vec2, GREEN};
+
+fn endpoints(snapshot: &noon_core::ObjectSnapshot) -> (Vec2, Vec2) {
+    let GeometryRef::Line { start, end } = snapshot.geometry else {
+        panic!("expected retained line geometry");
+    };
+    (start, end)
+}
+
+#[test]
+fn default_ticks_are_independent_retained_lines() {
+    let state =
+        NumberLineState::centered(NumberRange::new(-2.0, 2.0, 1.0).unwrap(), 4.0, 0.0).unwrap();
+    let plan = NumberLineGeometryPlan::new(state, &NumberLineTickOptions::default()).unwrap();
+    assert_eq!(plan.ticks().len(), 5);
+    let origin = &plan.ticks()[2];
+    let (start, end) = endpoints(origin.snapshot());
+    assert_eq!(origin.value(), 0.0);
+    assert!((start.y + 0.1).abs() <= 1.0e-6);
+    assert!((end.y - 0.1).abs() <= 1.0e-6);
+}
+
+#[test]
+fn canonical_plot_axis_excludes_origin_and_elongates_requested_ticks() {
+    let axes = Axes2DState::new(
+        NumberRange::new(-10.0, 10.3, 1.0).unwrap(),
+        NumberRange::new(-1.5, 1.5, 1.0).unwrap(),
+        10.0,
+        6.0,
+    )
+    .unwrap();
+    let options = NumberLineTickOptions {
+        elongated_values: (-5..=5).map(|index| f64::from(index * 2)).collect(),
+        exclude_origin_tick: true,
+        color: GREEN,
+        ..NumberLineTickOptions::default()
+    };
+    let plan = NumberLineGeometryPlan::new(axes.x_axis(), &options).unwrap();
+    assert_eq!(plan.ticks().len(), 20);
+    assert!(plan.ticks().iter().all(|tick| tick.value() != 0.0));
+    assert_eq!(
+        plan.ticks()
+            .iter()
+            .find(|tick| tick.value() == 2.0)
+            .unwrap()
+            .size(),
+        0.2
+    );
+    assert_eq!(
+        plan.ticks()
+            .iter()
+            .find(|tick| tick.value() == 1.0)
+            .unwrap()
+            .size(),
+        0.1
+    );
+    assert!((plan.line().style.stroke_width - 0.02).abs() <= 1.0e-6);
+}
+
+#[test]
+fn vertical_axis_ticks_rotate_with_axis_geometry() {
+    let axes = Axes2DState::new(
+        NumberRange::new(-2.0, 2.0, 1.0).unwrap(),
+        NumberRange::new(-2.0, 2.0, 1.0).unwrap(),
+        4.0,
+        4.0,
+    )
+    .unwrap();
+    let options = NumberLineTickOptions {
+        exclude_origin_tick: true,
+        ..NumberLineTickOptions::default()
+    };
+    let plan = NumberLineGeometryPlan::new(axes.y_axis(), &options).unwrap();
+    let tick = plan
+        .ticks()
+        .iter()
+        .find(|tick| tick.value() == 1.0)
+        .unwrap();
+    let (start, end) = endpoints(tick.snapshot());
+    assert!((start.y - end.y).abs() <= 1.0e-6);
+    assert!(((end.x - start.x).abs() - 0.2).abs() <= 1.0e-6);
+}
+
+#[test]
+fn disabling_ticks_keeps_axis_line_without_hidden_tick_geometry() {
+    let state =
+        NumberLineState::centered(NumberRange::new(0.0, 2.0, 1.0).unwrap(), 2.0, 0.0).unwrap();
+    let options = NumberLineTickOptions {
+        include_ticks: false,
+        ..NumberLineTickOptions::default()
+    };
+    let plan = NumberLineGeometryPlan::new(state, &options).unwrap();
+    assert!(plan.ticks().is_empty());
+}


### PR DESCRIPTION
## Summary
- combine the qualified coordinate, plot, and retained tick semantics needed for the first real Axes browser path
- add a shared Rust/WASM `AxesAuthoringPlan` that owns x/y axis construction, config precedence, retained line/tick snapshots, and c2p/p2c queries
- preserve ManimCE v0.21 linear-Axes origin-tick exclusion after config merging
- fail closed on unsupported tips and label-related config instead of silently rendering incomplete Axes
- serialize ordinary `ObjectSnapshot` line/tick children for the existing semantic-handle/family path

## Architecture
This is deliberately not the public Python `Axes` class yet. A public Group that can be shifted/scaled independently of the Rust coordinate state would create split semantic ownership. This PR establishes the single shared state/geometry boundary first; transform synchronization will be explicit before public export.

The branch contains the exact #717 retained-tick tree in addition to #714 because it is a CI union branch. Once prerequisites merge, this will be flattened to the minimal Axes-plan delta.

## Focused coverage
- canonical `SinAndCosFunctionPlot` axis ranges produce the expected retained tick counts and elongated tick sizing
- axis-specific config overrides shared axis config
- linear Axes force zero-tick exclusion after config merge
- c2p/p2c round-trip through the exact same `Axes2DState`
- default tips and unsupported numeric-label config are rejected rather than omitted

Tracks #695 / #696 / parent #85. Depends on #714 and #717.