### PR TITLE
Skip unchanged retained Text spec serialization

### DIFF
--- a/crates/noon-web/src/retained_authoring.rs
+++ b/crates/noon-web/src/retained_authoring.rs
@@ -330,6 +330,13 @@ mod wasm {
     #[wasm_bindgen(js_name = RetainedTypstAuthoringHandle)]
     pub struct WasmRetainedTypstAuthoringHandle {
         inner: RetainedTextAuthoringSpec,
+        mutation_revision: u64,
+    }
+
+    impl WasmRetainedTypstAuthoringHandle {
+        fn mark_mutated(&mut self) {
+            self.mutation_revision = self.mutation_revision.saturating_add(1);
+        }
     }
 
     #[wasm_bindgen(js_class = RetainedTypstAuthoringHandle)]
@@ -338,6 +345,7 @@ mod wasm {
         pub fn new(source: &str, math: bool, font_size: f32) -> Result<Self, JsValue> {
             Ok(Self {
                 inner: RetainedTextAuthoringSpec::new(source, math, font_size).map_err(js_error)?,
+                mutation_revision: 0,
             })
         }
 
@@ -359,27 +367,42 @@ mod wasm {
             self.inner.font_size
         }
 
+        #[wasm_bindgen(getter, js_name = mutationRevision)]
+        pub fn mutation_revision(&self) -> u64 {
+            self.mutation_revision
+        }
+
         #[wasm_bindgen(js_name = shift)]
         pub fn shift(&mut self, x: f32, y: f32) -> Result<(), JsValue> {
-            self.inner.shift(Vec2::new(x, y)).map_err(js_error)
+            self.inner.shift(Vec2::new(x, y)).map_err(js_error)?;
+            self.mark_mutated();
+            Ok(())
         }
 
         #[wasm_bindgen(js_name = moveTo)]
         pub fn move_to(&mut self, x: f32, y: f32) -> Result<(), JsValue> {
-            self.inner.move_to(Vec2::new(x, y)).map_err(js_error)
+            self.inner.move_to(Vec2::new(x, y)).map_err(js_error)?;
+            self.mark_mutated();
+            Ok(())
         }
 
         pub fn scale(&mut self, factor: f32) -> Result<(), JsValue> {
-            self.inner.scale(factor).map_err(js_error)
+            self.inner.scale(factor).map_err(js_error)?;
+            self.mark_mutated();
+            Ok(())
         }
 
         pub fn rotate(&mut self, angle: f32) -> Result<(), JsValue> {
-            self.inner.rotate(angle).map_err(js_error)
+            self.inner.rotate(angle).map_err(js_error)?;
+            self.mark_mutated();
+            Ok(())
         }
 
         #[wasm_bindgen(js_name = setOpacity)]
         pub fn set_opacity(&mut self, opacity: f32) -> Result<(), JsValue> {
-            self.inner.set_opacity(opacity).map_err(js_error)
+            self.inner.set_opacity(opacity).map_err(js_error)?;
+            self.mark_mutated();
+            Ok(())
         }
 
         #[wasm_bindgen(js_name = setColor)]
@@ -392,7 +415,9 @@ mod wasm {
         ) -> Result<(), JsValue> {
             self.inner
                 .set_color(Color::rgba(red, green, blue, alpha))
-                .map_err(js_error)
+                .map_err(js_error)?;
+            self.mark_mutated();
+            Ok(())
         }
 
         #[wasm_bindgen(js_name = specJson)]
@@ -411,11 +436,16 @@ mod wasm {
         inner: RetainedTextAuthoringSpec,
         intrinsic_bounds: Rect,
         family_identity: Option<SemanticNodeId>,
+        mutation_revision: u64,
     }
 
     impl WasmRetainedNativeTextAuthoringHandle {
         fn bounds(&self) -> Rect {
             transformed_bounds(self.intrinsic_bounds, self.inner.transform)
+        }
+
+        fn mark_mutated(&mut self) {
+            self.mutation_revision = self.mutation_revision.saturating_add(1);
         }
 
         pub(crate) fn bind_family_identity(
@@ -466,7 +496,10 @@ mod wasm {
                     "retained native Text family translation must remain f32-compatible".to_owned(),
                 );
             }
-            self.inner.move_to(Vec2::new(next_x as f32, next_y as f32))
+            self.inner
+                .move_to(Vec2::new(next_x as f32, next_y as f32))?;
+            self.mark_mutated();
+            Ok(())
         }
     }
 
@@ -487,6 +520,7 @@ mod wasm {
                 inner,
                 intrinsic_bounds,
                 family_identity: None,
+                mutation_revision: 0,
             })
         }
 
@@ -514,6 +548,11 @@ mod wasm {
         #[wasm_bindgen(getter, js_name = fontSize)]
         pub fn font_size(&self) -> f32 {
             self.inner.font_size
+        }
+
+        #[wasm_bindgen(getter, js_name = mutationRevision)]
+        pub fn mutation_revision(&self) -> u64 {
+            self.mutation_revision
         }
 
         #[wasm_bindgen(getter, js_name = centerX)]
@@ -554,25 +593,35 @@ mod wasm {
 
         #[wasm_bindgen(js_name = shift)]
         pub fn shift(&mut self, x: f32, y: f32) -> Result<(), JsValue> {
-            self.inner.shift(Vec2::new(x, y)).map_err(js_error)
+            self.inner.shift(Vec2::new(x, y)).map_err(js_error)?;
+            self.mark_mutated();
+            Ok(())
         }
 
         #[wasm_bindgen(js_name = moveTo)]
         pub fn move_to(&mut self, x: f32, y: f32) -> Result<(), JsValue> {
-            self.inner.move_to(Vec2::new(x, y)).map_err(js_error)
+            self.inner.move_to(Vec2::new(x, y)).map_err(js_error)?;
+            self.mark_mutated();
+            Ok(())
         }
 
         pub fn scale(&mut self, factor: f32) -> Result<(), JsValue> {
-            self.inner.scale(factor).map_err(js_error)
+            self.inner.scale(factor).map_err(js_error)?;
+            self.mark_mutated();
+            Ok(())
         }
 
         pub fn rotate(&mut self, angle: f32) -> Result<(), JsValue> {
-            self.inner.rotate(angle).map_err(js_error)
+            self.inner.rotate(angle).map_err(js_error)?;
+            self.mark_mutated();
+            Ok(())
         }
 
         #[wasm_bindgen(js_name = setOpacity)]
         pub fn set_opacity(&mut self, opacity: f32) -> Result<(), JsValue> {
-            self.inner.set_opacity(opacity).map_err(js_error)
+            self.inner.set_opacity(opacity).map_err(js_error)?;
+            self.mark_mutated();
+            Ok(())
         }
 
         #[wasm_bindgen(js_name = setColor)]
@@ -585,7 +634,9 @@ mod wasm {
         ) -> Result<(), JsValue> {
             self.inner
                 .set_color(Color::rgba(red, green, blue, alpha))
-                .map_err(js_error)
+                .map_err(js_error)?;
+            self.mark_mutated();
+            Ok(())
         }
 
         #[wasm_bindgen(js_name = specJson)]

--- a/scripts/retained-text-canonical-state-smoke.mjs
+++ b/scripts/retained-text-canonical-state-smoke.mjs
@@ -64,6 +64,11 @@ class RetainedCanonicalState(Scene):
         label.rotate(PI / 4)
         label.set_opacity(0.4)
         self.wait(0.25)
+
+        reads_after_mutation = label._retained_state_spec_reads
+        self.wait(0.1)
+        self.wait(0.1)
+        assert label._retained_state_spec_reads == reads_after_mutation
 `;
 
 let browser = null;
@@ -143,7 +148,7 @@ try {
   assert.equal(opacity[0].timing.start_time, 1);
   assert.equal(opacity[0].timing.duration, 0);
 
-  assert.equal(result.duration, 1.25);
+  assertNear(result.duration, 1.45, "scene duration");
   assert.deepEqual(errors, []);
   console.log("retained Text canonical authoring state smoke passed");
 } finally {

--- a/web/python/_manim_retained_state.py
+++ b/web/python/_manim_retained_state.py
@@ -38,17 +38,29 @@ def _bound_sources(scene: _compat.Scene) -> list[_typst._RetainedTextMobject]:
     ]
 
 
+def _source_revision(source: _typst._RetainedTextMobject) -> int:
+    return int(source._retained_handle.mutationRevision)
+
+
+def _read_source_spec(source: _typst._RetainedTextMobject) -> dict[str, Any]:
+    source._retained_state_spec_reads = (
+        int(getattr(source, "_retained_state_spec_reads", 0)) + 1
+    )
+    return source._spec()
+
+
 def _freeze_base(source: _typst._RetainedTextMobject) -> dict[str, Any]:
     base = getattr(source, "_retained_timeline_base_spec", None)
     if base is None:
-        base = copy.deepcopy(source._spec())
+        base = copy.deepcopy(_read_source_spec(source))
         source._retained_timeline_base_spec = base
     return base
 
 
 def _observe_source(source: _typst._RetainedTextMobject) -> dict[str, Any]:
-    observed = copy.deepcopy(source._spec())
+    observed = copy.deepcopy(_read_source_spec(source))
     source._retained_observed_spec = observed
+    source._retained_observed_revision = _source_revision(source)
     return observed
 
 
@@ -57,6 +69,7 @@ def _observed_source(source: _typst._RetainedTextMobject) -> dict[str, Any]:
     if observed is None:
         observed = copy.deepcopy(_freeze_base(source))
         source._retained_observed_spec = observed
+        source._retained_observed_revision = _source_revision(source)
     return observed
 
 
@@ -163,12 +176,15 @@ def _sync_source(
     if source._scene is not scene or source._retained_object_id is None:
         return
 
+    previous = _observed_source(source)
+    current_revision = _source_revision(source)
+    if current_revision == int(source._retained_observed_revision):
+        return
+
     object_id = int(source.id)
     base = _freeze_base(source)
-    previous = copy.deepcopy(_observed_source(source))
-    current = source._spec()
-    if current == previous:
-        return
+    previous = copy.deepcopy(previous)
+    current = _read_source_spec(source)
     _validate_static_source_contract(base, current)
 
     state = _state_for(scene, source)
@@ -178,6 +194,7 @@ def _sync_source(
         source._retained_timeline_base_spec = copy.deepcopy(current)
         _update_state_from_spec(state, current)
         source._retained_observed_spec = copy.deepcopy(current)
+        source._retained_observed_revision = current_revision
         return
 
     previous_transform = _retained._transform(previous)
@@ -256,6 +273,7 @@ def _sync_source(
 
     _update_state_from_spec(state, current)
     source._retained_observed_spec = copy.deepcopy(current)
+    source._retained_observed_revision = current_revision
 
 
 def _sync_all(scene: _compat.Scene) -> None:


### PR DESCRIPTION
## Summary

- expose a Rust-owned monotonic mutation revision on retained native/Typst authoring handles
- increment the revision only after successful source-spec mutations, including retained family translation
- use the revision in the retained canonical-state adapter to return before `specJson()` when the source handle has not changed
- keep changed-source reconciliation exact: one source snapshot still lowers direct edits to zero-duration property assignments
- add an executable bridge-cost regression: repeated unchanged `Scene.wait()` boundaries must not increase retained-state spec reads

## Architecture

This is a bounded #61 performance slice. Mutation detection lives with the authoritative Rust handle rather than in Python dirty flags, so family mutations cannot bypass it. The revision is handle-local and never enters the retained authoring wire/document.

The sidecar adapter remains transitional per #367; this change reduces its normal-path bridge cost without expanding its semantic ownership.

## Regression

The existing canonical retained Text smoke still verifies `animate -> direct edit -> animate` track semantics and now additionally asserts that two idle `wait()` boundaries after reconciliation perform zero additional retained-state spec reads.

Related: #61, #367