### PR TITLE
Add bounds-native shape matcher authoring

### DIFF
--- a/crates/noon-web/src/family_bounds.rs
+++ b/crates/noon-web/src/family_bounds.rs
@@ -1,4 +1,4 @@
-use noon_core::{Bounds2D64, SemanticNodeId, SemanticNodeKind, SemanticStore};
+use noon_core::{Bounds2D64, Rect, SemanticNodeId, SemanticNodeKind, SemanticStore, Vec2};
 
 /// Aggregate layout bounds for a semantic family using authoritative shared leaf order.
 ///
@@ -61,6 +61,34 @@ impl FrontendFamilyBoundsPlan {
         }
         Ok(self.bounds)
     }
+
+    /// Finish aggregation and explicitly lower the authoritative semantic bounds
+    /// to the compact world-bounds representation consumed by retained matcher
+    /// geometry. This keeps f64 -> f32 conversion in shared Rust rather than in a
+    /// Python/JS adapter and avoids fabricating a temporary aggregate scene object.
+    pub fn finish_world_bounds(&self) -> Result<Option<Rect>, String> {
+        self.finish()?
+            .map(|bounds| {
+                Ok(Rect::new(
+                    Vec2::new(
+                        lower_f32("family bounds min.x", bounds.min_x)?,
+                        lower_f32("family bounds min.y", bounds.min_y)?,
+                    ),
+                    Vec2::new(
+                        lower_f32("family bounds max.x", bounds.max_x)?,
+                        lower_f32("family bounds max.y", bounds.max_y)?,
+                    ),
+                ))
+            })
+            .transpose()
+    }
+}
+
+fn lower_f32(name: &str, value: f64) -> Result<f32, String> {
+    if !value.is_finite() || value.abs() > f64::from(f32::MAX) {
+        return Err(format!("{name} must be a finite f32-compatible number"));
+    }
+    Ok(value as f32)
 }
 
 fn include_bounds(aggregate: &mut Option<Bounds2D64>, bounds: Bounds2D64) {
@@ -175,6 +203,10 @@ mod tests {
                 max_y: 1.0,
             })
         );
+        assert_eq!(
+            plan.finish_world_bounds().expect("lowered bounds"),
+            Some(Rect::new(Vec2::new(-2.0, -4.0), Vec2::new(5.0, 1.0)))
+        );
     }
 
     #[test]
@@ -207,6 +239,7 @@ mod tests {
         let plan = FrontendFamilyBoundsPlan::begin(&store, family).expect("empty family plan");
         assert_eq!(plan.leaf_count(), 0);
         assert_eq!(plan.finish().expect("empty family is complete"), None);
+        assert_eq!(plan.finish_world_bounds().expect("empty lowered bounds"), None);
     }
 
     #[test]
@@ -216,5 +249,28 @@ mod tests {
         let error = FrontendFamilyBoundsPlan::begin(&store, leaf)
             .expect_err("authoring object is not a family");
         assert!(error.contains("is not a family"));
+    }
+
+    #[test]
+    fn world_bounds_lowering_rejects_values_outside_runtime_precision() {
+        let (store, root, first, second, third) = nested_family();
+        let mut plan = FrontendFamilyBoundsPlan::begin(&store, root).expect("family bounds plan");
+        plan.accept_leaf_bounds(
+            first,
+            Some(Bounds2D64 {
+                min_x: 0.0,
+                min_y: 0.0,
+                max_x: f64::from(f32::MAX) * 2.0,
+                max_y: 1.0,
+            }),
+        )
+        .expect("semantic f64 bounds remain valid");
+        plan.accept_leaf_bounds(second, None).expect("second leaf");
+        plan.accept_leaf_bounds(third, None).expect("third leaf");
+
+        let error = plan
+            .finish_world_bounds()
+            .expect_err("runtime lowering must be explicit and checked");
+        assert!(error.contains("f32-compatible"));
     }
 }

--- a/crates/noon-web/src/family_bounds.rs
+++ b/crates/noon-web/src/family_bounds.rs
@@ -239,7 +239,10 @@ mod tests {
         let plan = FrontendFamilyBoundsPlan::begin(&store, family).expect("empty family plan");
         assert_eq!(plan.leaf_count(), 0);
         assert_eq!(plan.finish().expect("empty family is complete"), None);
-        assert_eq!(plan.finish_world_bounds().expect("empty lowered bounds"), None);
+        assert_eq!(
+            plan.finish_world_bounds().expect("empty lowered bounds"),
+            None
+        );
     }
 
     #[test]

--- a/crates/noon/src/shape_matcher_authoring.rs
+++ b/crates/noon/src/shape_matcher_authoring.rs
@@ -227,7 +227,8 @@ impl BackgroundRectangle {
         color: Color,
         fill_opacity: f32,
     ) -> Result<Self, ShapeMatcherAuthoringError> {
-        let bounds = group_world_bounds(targets).ok_or(ShapeMatcherAuthoringError::NoBoundedTargets)?;
+        let bounds =
+            group_world_bounds(targets).ok_or(ShapeMatcherAuthoringError::NoBoundedTargets)?;
         Self::around_world_bounds(bounds, buff, corner_radius, color, fill_opacity)
     }
 
@@ -320,20 +321,12 @@ mod tests {
         let snapshots = [&left, &right];
         let bounds = group_world_bounds(snapshots).expect("union bounds");
 
-        let from_snapshots = SurroundingRectangle::around(
-            snapshots,
-            Vec2::new(0.25, 0.5),
-            0.2,
-            RED,
-        )
-        .expect("snapshot matcher");
-        let from_bounds = SurroundingRectangle::around_world_bounds(
-            bounds,
-            Vec2::new(0.25, 0.5),
-            0.2,
-            RED,
-        )
-        .expect("bounds matcher");
+        let from_snapshots =
+            SurroundingRectangle::around(snapshots, Vec2::new(0.25, 0.5), 0.2, RED)
+                .expect("snapshot matcher");
+        let from_bounds =
+            SurroundingRectangle::around_world_bounds(bounds, Vec2::new(0.25, 0.5), 0.2, RED)
+                .expect("bounds matcher");
 
         assert_eq!(from_bounds.snapshot(), from_snapshots.snapshot());
     }
@@ -381,16 +374,14 @@ mod tests {
     #[test]
     fn bounds_native_background_preserves_style_contract() {
         let bounds = Rect::new(Vec2::new(-2.0, -1.0), Vec2::new(3.0, 4.0));
-        let background = BackgroundRectangle::around_world_bounds(
-            bounds,
-            Vec2::new(0.2, 0.3),
-            0.1,
-            WHITE,
-            0.2,
-        )
-        .expect("bounds background");
+        let background =
+            BackgroundRectangle::around_world_bounds(bounds, Vec2::new(0.2, 0.3), 0.1, WHITE, 0.2)
+                .expect("bounds background");
 
-        assert_eq!(background.snapshot().center(), bounds.center());
+        let center = background.snapshot().center();
+        let expected_center = bounds.center();
+        assert_close(center.x, expected_center.x);
+        assert_close(center.y, expected_center.y);
         assert_close(background.snapshot().width(), 5.4);
         assert_close(background.snapshot().height(), 5.6);
         assert_eq!(

--- a/crates/noon/src/shape_matcher_authoring.rs
+++ b/crates/noon/src/shape_matcher_authoring.rs
@@ -16,6 +16,7 @@ pub const BACKGROUND_RECTANGLE_DEFAULT_FILL_OPACITY: f32 = 0.75;
 #[derive(Clone, Debug, PartialEq)]
 pub enum ShapeMatcherAuthoringError {
     NoBoundedTargets,
+    NonFiniteBounds,
     NonFiniteBuffer(Vec2),
     RoundedRectangle(RoundedRectangleAuthoringError),
 }
@@ -26,6 +27,7 @@ impl std::fmt::Display for ShapeMatcherAuthoringError {
             Self::NoBoundedTargets => {
                 formatter.write_str("shape matcher requires at least one target with world bounds")
             }
+            Self::NonFiniteBounds => formatter.write_str("shape matcher bounds must be finite"),
             Self::NonFiniteBuffer(value) => write!(
                 formatter,
                 "shape matcher buffer must be finite, got ({}, {})",
@@ -120,14 +122,25 @@ fn validate_buffer(buff: Vec2) -> Result<(), ShapeMatcherAuthoringError> {
     Ok(())
 }
 
-fn surrounding_snapshot<'a>(
-    targets: impl IntoIterator<Item = &'a ObjectSnapshot>,
+fn validate_bounds(bounds: Rect) -> Result<(), ShapeMatcherAuthoringError> {
+    if !bounds.min.x.is_finite()
+        || !bounds.min.y.is_finite()
+        || !bounds.max.x.is_finite()
+        || !bounds.max.y.is_finite()
+    {
+        return Err(ShapeMatcherAuthoringError::NonFiniteBounds);
+    }
+    Ok(())
+}
+
+fn surrounding_snapshot_from_bounds(
+    bounds: Rect,
     buff: Vec2,
     corner_radius: f32,
     color: Color,
 ) -> Result<ObjectSnapshot, ShapeMatcherAuthoringError> {
+    validate_bounds(bounds)?;
     validate_buffer(buff)?;
-    let bounds = group_world_bounds(targets).ok_or(ShapeMatcherAuthoringError::NoBoundedTargets)?;
     let width = bounds.width() + 2.0 * buff.x;
     let height = bounds.height() + 2.0 * buff.y;
 
@@ -140,6 +153,16 @@ fn surrounding_snapshot<'a>(
         .move_to(bounds.center())
         .into_snapshot();
     Ok(snapshot)
+}
+
+fn surrounding_snapshot<'a>(
+    targets: impl IntoIterator<Item = &'a ObjectSnapshot>,
+    buff: Vec2,
+    corner_radius: f32,
+    color: Color,
+) -> Result<ObjectSnapshot, ShapeMatcherAuthoringError> {
+    let bounds = group_world_bounds(targets).ok_or(ShapeMatcherAuthoringError::NoBoundedTargets)?;
+    surrounding_snapshot_from_bounds(bounds, buff, corner_radius, color)
 }
 
 impl SurroundingRectangle {
@@ -165,6 +188,25 @@ impl SurroundingRectangle {
             color,
         )?))
     }
+
+    /// Construct directly from authoritative shared world bounds.
+    ///
+    /// This keeps aggregate-family adapters from fabricating temporary scene
+    /// objects merely to reuse matcher geometry. Snapshot-based construction and
+    /// bounds-based construction share the same implementation below this seam.
+    pub fn around_world_bounds(
+        bounds: Rect,
+        buff: Vec2,
+        corner_radius: f32,
+        color: Color,
+    ) -> Result<Self, ShapeMatcherAuthoringError> {
+        Ok(Self(surrounding_snapshot_from_bounds(
+            bounds,
+            buff,
+            corner_radius,
+            color,
+        )?))
+    }
 }
 
 impl BackgroundRectangle {
@@ -185,7 +227,19 @@ impl BackgroundRectangle {
         color: Color,
         fill_opacity: f32,
     ) -> Result<Self, ShapeMatcherAuthoringError> {
-        let mut snapshot = surrounding_snapshot(targets, buff, corner_radius, color)?;
+        let bounds = group_world_bounds(targets).ok_or(ShapeMatcherAuthoringError::NoBoundedTargets)?;
+        Self::around_world_bounds(bounds, buff, corner_radius, color, fill_opacity)
+    }
+
+    /// Construct directly from authoritative shared world bounds.
+    pub fn around_world_bounds(
+        bounds: Rect,
+        buff: Vec2,
+        corner_radius: f32,
+        color: Color,
+        fill_opacity: f32,
+    ) -> Result<Self, ShapeMatcherAuthoringError> {
+        let mut snapshot = surrounding_snapshot_from_bounds(bounds, buff, corner_radius, color)?;
         snapshot = snapshot.set_fill(Some(color), Some(fill_opacity));
 
         // Manim defaults BackgroundRectangle to `stroke_width=0` and
@@ -258,6 +312,33 @@ mod tests {
     }
 
     #[test]
+    fn bounds_native_matcher_matches_snapshot_union_without_temporary_geometry() {
+        let left = Circle::new(1.0).shift(Vec2::new(-2.0, 0.0)).into_snapshot();
+        let right = Rectangle::new(2.0, 4.0)
+            .shift(Vec2::new(3.0, 1.0))
+            .into_snapshot();
+        let snapshots = [&left, &right];
+        let bounds = group_world_bounds(snapshots).expect("union bounds");
+
+        let from_snapshots = SurroundingRectangle::around(
+            snapshots,
+            Vec2::new(0.25, 0.5),
+            0.2,
+            RED,
+        )
+        .expect("snapshot matcher");
+        let from_bounds = SurroundingRectangle::around_world_bounds(
+            bounds,
+            Vec2::new(0.25, 0.5),
+            0.2,
+            RED,
+        )
+        .expect("bounds matcher");
+
+        assert_eq!(from_bounds.snapshot(), from_snapshots.snapshot());
+    }
+
+    #[test]
     fn background_rectangle_matches_default_geometry_and_style() {
         let target = Circle::new(1.5).into_snapshot();
         let background = BackgroundRectangle::new(&target).expect("bounded target");
@@ -295,5 +376,41 @@ mod tests {
         );
         assert_close(background.snapshot().width(), 2.2);
         assert_close(background.snapshot().height(), 1.4);
+    }
+
+    #[test]
+    fn bounds_native_background_preserves_style_contract() {
+        let bounds = Rect::new(Vec2::new(-2.0, -1.0), Vec2::new(3.0, 4.0));
+        let background = BackgroundRectangle::around_world_bounds(
+            bounds,
+            Vec2::new(0.2, 0.3),
+            0.1,
+            WHITE,
+            0.2,
+        )
+        .expect("bounds background");
+
+        assert_eq!(background.snapshot().center(), bounds.center());
+        assert_close(background.snapshot().width(), 5.4);
+        assert_close(background.snapshot().height(), 5.6);
+        assert_eq!(
+            background.snapshot().style.fill.map(|color| color.alpha),
+            Some(0.2)
+        );
+        assert_eq!(
+            background.snapshot().style.stroke.map(|color| color.alpha),
+            Some(0.0)
+        );
+        assert_close(background.snapshot().style.stroke_width, 0.0);
+    }
+
+    #[test]
+    fn bounds_native_matchers_reject_non_finite_bounds() {
+        let invalid = Rect::new(Vec2::new(f32::NAN, 0.0), Vec2::new(1.0, 1.0));
+        assert_eq!(
+            SurroundingRectangle::around_world_bounds(invalid, Vec2::ZERO, 0.0, RED)
+                .expect_err("non-finite bounds must fail"),
+            ShapeMatcherAuthoringError::NonFiniteBounds
+        );
     }
 }


### PR DESCRIPTION
## Summary
- add direct `Rect`-based construction for shared `SurroundingRectangle` and `BackgroundRectangle`
- keep snapshot-based matcher construction routed through the same implementation
- add explicit checked f64 semantic-family-bounds -> f32 world-bounds lowering in `FrontendFamilyBoundsPlan`
- avoid requiring Python/JS adapters to fabricate temporary aggregate scene objects just to construct a matcher

## Architecture
This is the missing seam between the shared semantic family-bounds work from #712 and the existing shared matcher geometry from #675. Family traversal/order and bounds aggregation remain Rust-owned; compact runtime lowering is explicit; matcher geometry/style remains owned by `noon`.

No Python geometry, renderer primitive, worker protocol, or per-frame behavior is introduced.

## Focused coverage
- bounds-native `SurroundingRectangle` is exactly equivalent to the existing snapshot-union path
- bounds-native `BackgroundRectangle` preserves its fill/stroke contract
- non-finite direct bounds fail closed
- semantic family bounds lower only after complete authoritative traversal and reject values outside f32 runtime precision

Tracks #400 / #76.