### PR TITLE
Make Axes plot bridge transform-aware

### DIFF
--- a/crates/noon-web/src/manim_plot_bridge.rs
+++ b/crates/noon-web/src/manim_plot_bridge.rs
@@ -1,9 +1,10 @@
 use noon::{
-    axes_sampled_values_vector_path, Axes2DState, CoordinateSystemError, IntoSnapshot, NumberRange,
-    ParametricSamplePlan, Path, PlotGeometryError, PlotRangeRequest, PlotSamplingError,
-    SampleRange, MANIM_DEFAULT_DISCONTINUITY_DT,
+    axes_sampled_values_vector_path, transformed_axes_sampled_values_vector_path, Axes2DState,
+    CoordinateSystemError, IntoSnapshot, NumberRange, ParametricSamplePlan, Path,
+    PlotGeometryError, PlotRangeRequest, PlotSamplingError, SampleRange, TransformedAxes2DState,
+    MANIM_DEFAULT_DISCONTINUITY_DT,
 };
-use noon_core::ObjectSnapshot;
+use noon_core::{GeometryRef, ObjectSnapshot};
 use serde::Deserialize;
 
 #[derive(Clone, Debug, Deserialize, PartialEq)]
@@ -103,13 +104,78 @@ impl AxesPlotAuthoringPlan {
         Ok(Path::new(path).into_snapshot())
     }
 
-    pub fn finish_snapshot_json(&self, values_json: &str) -> Result<String, ManimPlotBridgeError> {
-        let values: Vec<Vec<f64>> = serde_json::from_str(values_json)
-            .map_err(|error| ManimPlotBridgeError::InvalidCallbackValues(error.to_string()))?;
-        let snapshot = self.finish_values(&values)?;
-        serde_json::to_string(&snapshot)
-            .map_err(|error| ManimPlotBridgeError::Serialization(error.to_string()))
+    /// Finish against the current retained x/y-axis snapshots.
+    ///
+    /// Only each snapshot's affine transform participates in coordinate mapping;
+    /// the geometry kind is validated so callers cannot accidentally bind plotting
+    /// semantics to an unrelated retained mobject.
+    pub fn finish_values_with_axes(
+        &self,
+        values: &[Vec<f64>],
+        x_axis: &ObjectSnapshot,
+        y_axis: &ObjectSnapshot,
+    ) -> Result<ObjectSnapshot, ManimPlotBridgeError> {
+        ensure_axis_line(x_axis, "x")?;
+        ensure_axis_line(y_axis, "y")?;
+        let transformed =
+            TransformedAxes2DState::new(self.axes, x_axis.transform, y_axis.transform);
+        let path = transformed_axes_sampled_values_vector_path(
+            transformed,
+            &self.samples,
+            values,
+            self.use_smoothing,
+        )?;
+        Ok(Path::new(path).into_snapshot())
     }
+
+    pub fn finish_snapshot_json(&self, values_json: &str) -> Result<String, ManimPlotBridgeError> {
+        let values = parse_callback_values(values_json)?;
+        serialize_snapshot(&self.finish_values(&values)?)
+    }
+
+    pub fn finish_snapshot_json_with_axes(
+        &self,
+        values_json: &str,
+        x_axis_snapshot_json: &str,
+        y_axis_snapshot_json: &str,
+    ) -> Result<String, ManimPlotBridgeError> {
+        let values = parse_callback_values(values_json)?;
+        let x_axis = parse_axis_snapshot(x_axis_snapshot_json, "x")?;
+        let y_axis = parse_axis_snapshot(y_axis_snapshot_json, "y")?;
+        serialize_snapshot(&self.finish_values_with_axes(&values, &x_axis, &y_axis)?)
+    }
+}
+
+fn parse_callback_values(values_json: &str) -> Result<Vec<Vec<f64>>, ManimPlotBridgeError> {
+    serde_json::from_str(values_json)
+        .map_err(|error| ManimPlotBridgeError::InvalidCallbackValues(error.to_string()))
+}
+
+fn parse_axis_snapshot(
+    snapshot_json: &str,
+    axis: &'static str,
+) -> Result<ObjectSnapshot, ManimPlotBridgeError> {
+    serde_json::from_str(snapshot_json)
+        .map_err(|error| ManimPlotBridgeError::InvalidAxisSnapshot {
+            axis,
+            error: error.to_string(),
+        })
+}
+
+fn ensure_axis_line(
+    snapshot: &ObjectSnapshot,
+    axis: &'static str,
+) -> Result<(), ManimPlotBridgeError> {
+    if matches!(snapshot.geometry, GeometryRef::Line { .. }) {
+        Ok(())
+    } else {
+        Err(ManimPlotBridgeError::InvalidAxisGeometry(axis))
+    }
+}
+
+fn serialize_snapshot(snapshot: &ObjectSnapshot) -> Result<String, ManimPlotBridgeError> {
+    serde_json::to_string(snapshot)
+        .map_err(|error| ManimPlotBridgeError::Serialization(error.to_string()))
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -117,6 +183,8 @@ pub enum ManimPlotBridgeError {
     InvalidRequest(String),
     InvalidCallbackValues(String),
     InvalidPlotRangeLength(usize),
+    InvalidAxisSnapshot { axis: &'static str, error: String },
+    InvalidAxisGeometry(&'static str),
     Coordinates(CoordinateSystemError),
     Sampling(PlotSamplingError),
     Geometry(PlotGeometryError),
@@ -134,6 +202,12 @@ impl std::fmt::Display for ManimPlotBridgeError {
                 formatter,
                 "Axes.plot x_range must contain 2 or 3 values, got {length}"
             ),
+            Self::InvalidAxisSnapshot { axis, error } => {
+                write!(formatter, "invalid Axes.plot {axis}-axis snapshot: {error}")
+            }
+            Self::InvalidAxisGeometry(axis) => {
+                write!(formatter, "Axes.plot {axis}-axis snapshot must contain line geometry")
+            }
             Self::Coordinates(error) => error.fmt(formatter),
             Self::Sampling(error) => error.fmt(formatter),
             Self::Geometry(error) => error.fmt(formatter),
@@ -195,6 +269,22 @@ mod wasm {
         pub fn finish_snapshot_json(&self, values_json: &str) -> Result<String, JsValue> {
             self.0.finish_snapshot_json(values_json).map_err(js_error)
         }
+
+        #[wasm_bindgen(js_name = finishSnapshotJsonWithAxes)]
+        pub fn finish_snapshot_json_with_axes(
+            &self,
+            values_json: &str,
+            x_axis_snapshot_json: &str,
+            y_axis_snapshot_json: &str,
+        ) -> Result<String, JsValue> {
+            self.0
+                .finish_snapshot_json_with_axes(
+                    values_json,
+                    x_axis_snapshot_json,
+                    y_axis_snapshot_json,
+                )
+                .map_err(js_error)
+        }
     }
 }
 
@@ -204,12 +294,24 @@ pub use wasm::WasmAxesPlotPlan;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use noon_core::{GeometryRef, PathCommand};
+    use noon::Line;
+    use noon_core::{GeometryRef, PathCommand, Transform2D, Vec2};
 
     fn request_json(plot_range: &str, discontinuities: &str, use_smoothing: bool) -> String {
         format!(
             r#"{{"x_range":[-2.0,2.0,1.0],"y_range":[-2.0,2.0,1.0],"x_length":4.0,"y_length":4.0,"plot_range":{plot_range},"discontinuities":{discontinuities},"use_smoothing":{use_smoothing}}}"#
         )
+    }
+
+    fn axis_snapshot(plan: &AxesPlotAuthoringPlan, x_axis: bool, transform: Transform2D) -> ObjectSnapshot {
+        let axis = if x_axis {
+            plan.axes.x_axis()
+        } else {
+            plan.axes.y_axis()
+        };
+        let mut snapshot = Line::new(axis.start(), axis.end()).into_snapshot();
+        snapshot.transform = transform;
+        snapshot
     }
 
     #[test]
@@ -241,6 +343,52 @@ mod tests {
         assert!(matches!(path.commands()[0], PathCommand::MoveTo { .. }));
         assert!(matches!(path.commands()[1], PathCommand::CubicTo { .. }));
         assert!(matches!(path.commands()[2], PathCommand::CubicTo { .. }));
+    }
+
+    #[test]
+    fn current_axis_snapshots_drive_transformed_plot_geometry() {
+        let plan = AxesPlotAuthoringPlan::from_json(&request_json("[-1.0,1.0,1.0]", "null", false))
+            .unwrap();
+        let transform = Transform2D {
+            translation: Vec2::new(2.0, -1.0),
+            rotation: 0.4,
+            scale: Vec2::new(1.5, 1.5),
+        };
+        let x_axis = axis_snapshot(&plan, true, transform);
+        let y_axis = axis_snapshot(&plan, false, transform);
+        let snapshot = plan
+            .finish_values_with_axes(&[vec![1.0, 0.0, 1.0]], &x_axis, &y_axis)
+            .unwrap();
+        let GeometryRef::VectorPath(path) = snapshot.geometry else {
+            panic!("Axes.plot must lower to ordinary VectorPath geometry");
+        };
+        let expected = [
+            transform.transform_point(Vec2::new(-1.0, 1.0)),
+            transform.transform_point(Vec2::ZERO),
+            transform.transform_point(Vec2::new(1.0, 1.0)),
+        ];
+        for (command, expected) in path.commands().iter().zip(expected) {
+            match command {
+                PathCommand::MoveTo { to } | PathCommand::LineTo { to } => {
+                    assert!((*to - expected).length() <= 1.0e-5)
+                }
+                other => panic!("expected corner path command, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn non_line_axis_snapshot_is_rejected() {
+        let plan = AxesPlotAuthoringPlan::from_json(&request_json("[-1.0,1.0,1.0]", "null", false))
+            .unwrap();
+        let mut x_axis = axis_snapshot(&plan, true, Transform2D::IDENTITY);
+        x_axis.geometry = GeometryRef::circle(1.0);
+        let y_axis = axis_snapshot(&plan, false, Transform2D::IDENTITY);
+        assert_eq!(
+            plan.finish_values_with_axes(&[vec![1.0, 0.0, 1.0]], &x_axis, &y_axis)
+                .unwrap_err(),
+            ManimPlotBridgeError::InvalidAxisGeometry("x")
+        );
     }
 
     #[test]

--- a/crates/noon/src/coordinate_transform_authoring.rs
+++ b/crates/noon/src/coordinate_transform_authoring.rs
@@ -1,0 +1,241 @@
+use crate::{Axes2DState, CoordinateSystemError, NumberLineState};
+use noon_core::{Transform2D, Vec2};
+
+/// A NumberLine coordinate view whose affine placement comes from the current
+/// retained mobject transform rather than from duplicated frontend state.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct TransformedNumberLineState {
+    line: NumberLineState,
+    transform: Transform2D,
+}
+
+impl TransformedNumberLineState {
+    pub const fn new(line: NumberLineState, transform: Transform2D) -> Self {
+        Self { line, transform }
+    }
+
+    pub const fn line(self) -> NumberLineState {
+        self.line
+    }
+
+    pub const fn transform(self) -> Transform2D {
+        self.transform
+    }
+
+    pub fn number_to_point(self, number: f64) -> Result<Vec2, CoordinateSystemError> {
+        let point = self.transform.transform_point(self.line.number_to_point(number)?);
+        if vec2_is_finite(point) {
+            Ok(point)
+        } else {
+            Err(CoordinateSystemError::NonFinitePoint(point))
+        }
+    }
+
+    pub fn point_to_number(self, point: Vec2) -> Result<f64, CoordinateSystemError> {
+        if !vec2_is_finite(point) {
+            return Err(CoordinateSystemError::NonFinitePoint(point));
+        }
+
+        let start = self.transform.transform_point(self.line.start());
+        let end = self.transform.transform_point(self.line.end());
+        if !vec2_is_finite(start) {
+            return Err(CoordinateSystemError::NonFinitePoint(start));
+        }
+        if !vec2_is_finite(end) {
+            return Err(CoordinateSystemError::NonFinitePoint(end));
+        }
+
+        let delta = end - start;
+        let length_squared =
+            f64::from(delta.x) * f64::from(delta.x) + f64::from(delta.y) * f64::from(delta.y);
+        if !length_squared.is_finite() || length_squared <= 0.0 {
+            return Err(CoordinateSystemError::DegenerateLine);
+        }
+
+        let from_start = point - start;
+        let projection = f64::from(from_start.x) * f64::from(delta.x)
+            + f64::from(from_start.y) * f64::from(delta.y);
+        let alpha = projection / length_squared;
+        let range = self.line.range();
+        Ok(range.min() + alpha * range.span())
+    }
+}
+
+/// Transform-aware view of the same two retained axis lines that render an Axes.
+///
+/// Manim composes coordinates vectorially: start from `x_axis.n2p(x)` and add
+/// `y_axis.n2p(y) - origin`, where origin is the x-axis origin-shift point. Keeping
+/// each current retained transform explicit makes c2p/p2c remain correct after
+/// group shifts, rotations, and scales without mirroring mutable coordinate state.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct TransformedAxes2DState {
+    axes: Axes2DState,
+    x_transform: Transform2D,
+    y_transform: Transform2D,
+}
+
+impl TransformedAxes2DState {
+    pub const fn new(
+        axes: Axes2DState,
+        x_transform: Transform2D,
+        y_transform: Transform2D,
+    ) -> Self {
+        Self {
+            axes,
+            x_transform,
+            y_transform,
+        }
+    }
+
+    pub const fn axes(self) -> Axes2DState {
+        self.axes
+    }
+
+    pub fn x_axis(self) -> TransformedNumberLineState {
+        TransformedNumberLineState::new(self.axes.x_axis(), self.x_transform)
+    }
+
+    pub fn y_axis(self) -> TransformedNumberLineState {
+        TransformedNumberLineState::new(self.axes.y_axis(), self.y_transform)
+    }
+
+    pub fn coords_to_point(self, x: f64, y: f64) -> Result<Vec2, CoordinateSystemError> {
+        let x_axis = self.x_axis();
+        let y_axis = self.y_axis();
+        let origin = x_axis.number_to_point(self.axes.x_axis().range().origin_shift())?;
+        let point = x_axis.number_to_point(x)? + y_axis.number_to_point(y)? - origin;
+        if vec2_is_finite(point) {
+            Ok(point)
+        } else {
+            Err(CoordinateSystemError::NonFinitePoint(point))
+        }
+    }
+
+    pub fn point_to_coords(self, point: Vec2) -> Result<(f64, f64), CoordinateSystemError> {
+        Ok((
+            self.x_axis().point_to_number(point)?,
+            self.y_axis().point_to_number(point)?,
+        ))
+    }
+
+    pub fn origin(self) -> Result<Vec2, CoordinateSystemError> {
+        self.coords_to_point(0.0, 0.0)
+    }
+}
+
+fn vec2_is_finite(value: Vec2) -> bool {
+    value.x.is_finite() && value.y.is_finite()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::NumberRange;
+
+    fn assert_close(actual: f64, expected: f64) {
+        assert!(
+            (actual - expected).abs() <= 1.0e-5,
+            "expected {expected}, got {actual}"
+        );
+    }
+
+    fn assert_point(actual: Vec2, expected: Vec2) {
+        assert_close(f64::from(actual.x), f64::from(expected.x));
+        assert_close(f64::from(actual.y), f64::from(expected.y));
+    }
+
+    #[test]
+    fn shared_affine_transform_preserves_vector_coordinate_composition() {
+        let axes = Axes2DState::new(
+            NumberRange::new(-2.0, 2.0, 1.0).unwrap(),
+            NumberRange::new(-2.0, 2.0, 1.0).unwrap(),
+            4.0,
+            4.0,
+        )
+        .unwrap();
+        let transform = Transform2D {
+            translation: Vec2::new(3.0, -1.0),
+            rotation: 0.6,
+            scale: Vec2::new(1.5, 1.5),
+        };
+        let transformed = TransformedAxes2DState::new(axes, transform, transform);
+
+        let expected = transform.transform_point(Vec2::new(1.0, -0.5));
+        let actual = transformed.coords_to_point(1.0, -0.5).unwrap();
+        assert_point(actual, expected);
+        let round_trip = transformed.point_to_coords(actual).unwrap();
+        assert_close(round_trip.0, 1.0);
+        assert_close(round_trip.1, -0.5);
+    }
+
+    #[test]
+    fn independent_axis_scales_use_each_retained_line_transform() {
+        let axes = Axes2DState::new(
+            NumberRange::new(-2.0, 2.0, 1.0).unwrap(),
+            NumberRange::new(-2.0, 2.0, 1.0).unwrap(),
+            4.0,
+            4.0,
+        )
+        .unwrap();
+        let x_transform = Transform2D {
+            translation: Vec2::new(2.0, 3.0),
+            rotation: 0.0,
+            scale: Vec2::new(2.0, 1.0),
+        };
+        let y_transform = Transform2D {
+            translation: Vec2::new(2.0, 3.0),
+            rotation: 0.0,
+            scale: Vec2::new(1.0, 3.0),
+        };
+        let transformed = TransformedAxes2DState::new(axes, x_transform, y_transform);
+
+        let point = transformed.coords_to_point(1.0, 1.0).unwrap();
+        assert_point(point, Vec2::new(4.0, 6.0));
+        let coords = transformed.point_to_coords(point).unwrap();
+        assert_close(coords.0, 1.0);
+        assert_close(coords.1, 1.0);
+    }
+
+    #[test]
+    fn positive_only_axis_origin_shift_matches_manim_after_transform() {
+        let axes = Axes2DState::new(
+            NumberRange::new(2.0, 6.0, 1.0).unwrap(),
+            NumberRange::new(-1.0, 3.0, 1.0).unwrap(),
+            8.0,
+            4.0,
+        )
+        .unwrap();
+        let transform = Transform2D {
+            translation: Vec2::new(-1.0, 2.0),
+            rotation: -0.3,
+            scale: Vec2::new(0.75, 0.75),
+        };
+        let transformed = TransformedAxes2DState::new(axes, transform, transform);
+        let base_point = axes.coords_to_point(4.0, 1.0).unwrap();
+        assert_point(
+            transformed.coords_to_point(4.0, 1.0).unwrap(),
+            transform.transform_point(base_point),
+        );
+    }
+
+    #[test]
+    fn collapsed_retained_axis_rejects_projection() {
+        let axes = Axes2DState::new(
+            NumberRange::new(-1.0, 1.0, 1.0).unwrap(),
+            NumberRange::new(-1.0, 1.0, 1.0).unwrap(),
+            2.0,
+            2.0,
+        )
+        .unwrap();
+        let collapsed = Transform2D {
+            translation: Vec2::ZERO,
+            rotation: 0.0,
+            scale: Vec2::ZERO,
+        };
+        let transformed = TransformedAxes2DState::new(axes, collapsed, Transform2D::IDENTITY);
+        assert_eq!(
+            transformed.point_to_coords(Vec2::ZERO),
+            Err(CoordinateSystemError::DegenerateLine)
+        );
+    }
+}

--- a/crates/noon/src/lib.rs
+++ b/crates/noon/src/lib.rs
@@ -10,6 +10,7 @@ mod analytic_geometry_authoring;
 mod arc_authoring;
 mod camera_authoring;
 mod coordinate_system_authoring;
+mod coordinate_transform_authoring;
 mod elbow_authoring;
 mod geometry_authoring;
 mod legacy;
@@ -27,6 +28,7 @@ pub use analytic_geometry_authoring::*;
 pub use arc_authoring::*;
 pub use camera_authoring::*;
 pub use coordinate_system_authoring::*;
+pub use coordinate_transform_authoring::*;
 pub use elbow_authoring::*;
 pub use geometry_authoring::*;
 pub use legacy::*;
@@ -52,8 +54,9 @@ pub mod prelude {
         PlotSamplingError, Polygon, Polygram, PolygramAuthoringError, ReactiveScene,
         ReactiveTimelineScene, RegularPolygon, RegularPolygram, RetainedMobject, RetainedScene,
         RoundedRectangle, RoundedRectangleAuthoringError, SampleRange, SampleSpan, Sector,
-        ShapeMatcherAuthoringError, Star, SurroundingRectangle, Text, TextAuthoringError, Triangle,
-        Typst, Underline, ValueTracker, VectorSignal, BACKGROUND_RECTANGLE_DEFAULT_FILL_OPACITY,
+        ShapeMatcherAuthoringError, Star, SurroundingRectangle, Text, TextAuthoringError,
+        TransformedAxes2DState, TransformedNumberLineState, Triangle, Typst, Underline,
+        ValueTracker, VectorSignal, BACKGROUND_RECTANGLE_DEFAULT_FILL_OPACITY,
         DEFAULT_CROSS_SCALE_FACTOR, DEFAULT_CROSS_STROKE_WIDTH, DEFAULT_DOT_RADIUS,
         DEFAULT_ELBOW_ANGLE, DEFAULT_ELBOW_WIDTH, DEFAULT_NATIVE_TEXT_FONT_FAMILY,
         DEFAULT_NATIVE_TEXT_FONT_SIZE, DEFAULT_ROUNDED_RECTANGLE_CORNER_RADIUS,

--- a/crates/noon/src/plot_geometry_authoring.rs
+++ b/crates/noon/src/plot_geometry_authoring.rs
@@ -1,4 +1,7 @@
-use crate::{Axes2DState, CoordinateSystemError, ParametricSamplePlan, PlotSamplingError};
+use crate::{
+    Axes2DState, CoordinateSystemError, ParametricSamplePlan, PlotSamplingError,
+    TransformedAxes2DState,
+};
 use noon_core::{Vec2, VectorPath};
 use noon_geometry::{smooth_cubic_path_from_subpaths, PathSmoothingError};
 
@@ -25,41 +28,103 @@ where
 }
 
 /// Compile the initial Manim-compatible `Axes.plot(function)` subset.
-///
-/// Parameters come from [`ParametricSamplePlan`], `function` is evaluated once
-/// per parameter, and [`Axes2DState`] owns the coordinate-to-scene mapping. With
-/// `use_smoothing=true`, the mapped anchors pass through the shared Manim cubic
-/// spline implementation in `noon-geometry`; otherwise they remain corners.
 pub fn axes_function_vector_path<F>(
     axes: Axes2DState,
     plan: &ParametricSamplePlan,
-    mut function: F,
+    function: F,
     use_smoothing: bool,
 ) -> Result<VectorPath, PlotGeometryError>
 where
     F: FnMut(f64) -> f64,
+{
+    axes_function_vector_path_with_mapper(
+        plan,
+        function,
+        use_smoothing,
+        |x, y| axes.coords_to_point(x, y),
+    )
+}
+
+/// Compile `Axes.plot(function)` against the current retained x/y-axis transforms.
+///
+/// This is the transform-safe path for an Axes family that has already been shifted,
+/// rotated, or scaled. Sampling and smoothing remain identical to the initial path;
+/// only coordinate mapping reads the current retained affine placement.
+pub fn transformed_axes_function_vector_path<F>(
+    axes: TransformedAxes2DState,
+    plan: &ParametricSamplePlan,
+    function: F,
+    use_smoothing: bool,
+) -> Result<VectorPath, PlotGeometryError>
+where
+    F: FnMut(f64) -> f64,
+{
+    axes_function_vector_path_with_mapper(
+        plan,
+        function,
+        use_smoothing,
+        |x, y| axes.coords_to_point(x, y),
+    )
+}
+
+fn axes_function_vector_path_with_mapper<F, M>(
+    plan: &ParametricSamplePlan,
+    mut function: F,
+    use_smoothing: bool,
+    mut coords_to_point: M,
+) -> Result<VectorPath, PlotGeometryError>
+where
+    F: FnMut(f64) -> f64,
+    M: FnMut(f64, f64) -> Result<Vec2, CoordinateSystemError>,
 {
     build_sampled_path(plan, use_smoothing, |parameter| {
         let value = function(parameter);
         if !value.is_finite() {
             return Err(PlotGeometryError::NonFiniteFunctionValue { parameter, value });
         }
-        Ok(axes.coords_to_point(parameter, value)?)
+        Ok(coords_to_point(parameter, value)?)
     })
 }
 
 /// Finish an `Axes.plot` after a host frontend evaluates the user callback.
-///
-/// Rust remains authoritative for parameter generation, sample cardinality,
-/// coordinate mapping, finite-value validation, smoothing, and final geometry.
-/// The host only supplies one scalar result for each parameter previously exposed
-/// by [`ParametricSamplePlan::parameter_subpaths`].
 pub fn axes_sampled_values_vector_path(
     axes: Axes2DState,
     plan: &ParametricSamplePlan,
     value_subpaths: &[Vec<f64>],
     use_smoothing: bool,
 ) -> Result<VectorPath, PlotGeometryError> {
+    axes_sampled_values_vector_path_with_mapper(
+        plan,
+        value_subpaths,
+        use_smoothing,
+        |x, y| axes.coords_to_point(x, y),
+    )
+}
+
+/// Finish host-evaluated plot samples against current retained Axes transforms.
+pub fn transformed_axes_sampled_values_vector_path(
+    axes: TransformedAxes2DState,
+    plan: &ParametricSamplePlan,
+    value_subpaths: &[Vec<f64>],
+    use_smoothing: bool,
+) -> Result<VectorPath, PlotGeometryError> {
+    axes_sampled_values_vector_path_with_mapper(
+        plan,
+        value_subpaths,
+        use_smoothing,
+        |x, y| axes.coords_to_point(x, y),
+    )
+}
+
+fn axes_sampled_values_vector_path_with_mapper<M>(
+    plan: &ParametricSamplePlan,
+    value_subpaths: &[Vec<f64>],
+    use_smoothing: bool,
+    mut coords_to_point: M,
+) -> Result<VectorPath, PlotGeometryError>
+where
+    M: FnMut(f64, f64) -> Result<Vec2, CoordinateSystemError>,
+{
     let parameter_subpaths = plan.parameter_subpaths()?;
     if value_subpaths.len() != parameter_subpaths.len() {
         return Err(PlotGeometryError::SampleSubpathCountMismatch {
@@ -84,7 +149,7 @@ pub fn axes_sampled_values_vector_path(
             if !value.is_finite() {
                 return Err(PlotGeometryError::NonFiniteFunctionValue { parameter, value });
             }
-            points.push(axes.coords_to_point(parameter, value)?);
+            points.push(coords_to_point(parameter, value)?);
         }
         point_subpaths.push(points);
     }
@@ -220,7 +285,7 @@ impl From<PathSmoothingError> for PlotGeometryError {
 mod tests {
     use super::*;
     use crate::{NumberRange, SampleRange};
-    use noon_core::PathCommand;
+    use noon_core::{PathCommand, Transform2D};
 
     fn assert_point(actual: Vec2, expected: Vec2) {
         assert!(
@@ -285,6 +350,67 @@ mod tests {
         assert!(matches!(path.commands()[0], PathCommand::MoveTo { .. }));
         assert!(matches!(path.commands()[1], PathCommand::CubicTo { .. }));
         assert!(matches!(path.commands()[2], PathCommand::CubicTo { .. }));
+    }
+
+    #[test]
+    fn transformed_host_samples_follow_current_axis_affine_state() {
+        let axes = test_axes();
+        let transform = Transform2D {
+            translation: Vec2::new(2.0, -1.0),
+            rotation: 0.5,
+            scale: Vec2::new(1.25, 1.25),
+        };
+        let transformed = TransformedAxes2DState::new(axes, transform, transform);
+        let plan = ParametricSamplePlan::without_discontinuities(
+            SampleRange::new(-1.0, 1.0, 1.0).unwrap(),
+        );
+        let path = transformed_axes_sampled_values_vector_path(
+            transformed,
+            &plan,
+            &[vec![1.0, 0.0, 1.0]],
+            false,
+        )
+        .unwrap();
+
+        let expected = [
+            transform.transform_point(Vec2::new(-1.0, 1.0)),
+            transform.transform_point(Vec2::ZERO),
+            transform.transform_point(Vec2::new(1.0, 1.0)),
+        ];
+        for (command, expected) in path.commands().iter().zip(expected) {
+            match command {
+                PathCommand::MoveTo { to } | PathCommand::LineTo { to } => {
+                    assert_point(*to, expected)
+                }
+                other => panic!("expected corner path command, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn transformed_direct_callback_is_evaluated_once_per_parameter() {
+        let axes = test_axes();
+        let transform = Transform2D {
+            translation: Vec2::new(-3.0, 2.0),
+            rotation: -0.35,
+            scale: Vec2::new(0.8, 0.8),
+        };
+        let transformed = TransformedAxes2DState::new(axes, transform, transform);
+        let plan = ParametricSamplePlan::without_discontinuities(
+            SampleRange::new(-1.0, 1.0, 1.0).unwrap(),
+        );
+        let mut calls = Vec::new();
+        transformed_axes_function_vector_path(
+            transformed,
+            &plan,
+            |x| {
+                calls.push(x);
+                x * x
+            },
+            true,
+        )
+        .unwrap();
+        assert_eq!(calls, vec![-1.0, 0.0, 1.0]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- extend `WasmAxesPlotPlan` with a transform-aware finish path
- accept the current retained x/y-axis snapshots instead of loose frontend transform numbers
- validate both snapshots contain line geometry before using their retained `Transform2D`s
- finish host-evaluated callback values through the shared transformed Axes plot compiler
- preserve the existing identity/untransformed finish path for callers that have not transformed the Axes family

## Architecture
Python/JS still owns only unavoidable user-function evaluation. It does not decode transforms, calculate c2p, validate sample cardinality, smooth paths, or construct geometry. The current rendered axis placement returns to Rust as ordinary semantic snapshots, and Rust derives the transformed coordinate view from those snapshots.

This stacks the transform-aware coordinate/plot helpers onto #714. Once prerequisites merge, the branch can be flattened to the bridge-only delta.

## Focused coverage
- current retained axis transforms drive final plot geometry
- non-Line axis snapshots fail closed
- existing sample cardinality validation remains in Rust
- output remains an ordinary `VectorPath` snapshot

Tracks #696 / parent #85. Depends on #714, #725, and #726.