### PR TITLE
Add initial shared Axes and plot browser facade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,9 @@ jobs:
       - name: Test Manim-style Python compatibility
         run: node scripts/manim-compat-smoke.mjs
 
+      - name: Test retained Axes plotting
+        run: node scripts/manim-axes-smoke.mjs
+
       - name: Test Manim composition authoring
         run: node scripts/composition-authoring-smoke.mjs
 

--- a/crates/noon-web/src/lib.rs
+++ b/crates/noon-web/src/lib.rs
@@ -14,6 +14,9 @@ mod host_player;
 #[path = "legacy.rs"]
 mod legacy;
 mod lifecycle;
+mod manim_axes_bridge;
+mod manim_axes_query_bridge;
+mod manim_axes_store_bridge;
 mod manim_elbow_bridge;
 mod manim_geometry_bridge;
 mod manim_path_query_bridge;
@@ -48,6 +51,8 @@ pub use execution_visibility::*;
 pub use host_player::*;
 pub use legacy::*;
 pub use lifecycle::*;
+pub use manim_axes_bridge::*;
+pub use manim_axes_query_bridge::*;
 pub use manim_elbow_bridge::*;
 pub use manim_geometry_bridge::*;
 pub use manim_path_query_bridge::*;

--- a/crates/noon-web/src/manim_axes_bridge.rs
+++ b/crates/noon-web/src/manim_axes_bridge.rs
@@ -1,0 +1,419 @@
+use noon::{
+    Axes2DState, AxisTickError, CoordinateSystemError, NumberLineGeometryPlan,
+    NumberLineTickOptions, NumberRange,
+};
+use noon_core::{Color, ObjectSnapshot};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+struct AxisGeometryRequest {
+    #[serde(default)]
+    include_tip: Option<bool>,
+    #[serde(default)]
+    include_ticks: Option<bool>,
+    #[serde(default)]
+    tick_size: Option<f64>,
+    #[serde(default)]
+    numbers_with_elongated_ticks: Option<Vec<f64>>,
+    #[serde(default)]
+    longer_tick_multiple: Option<usize>,
+    #[serde(default)]
+    exclude_origin_tick: Option<bool>,
+    #[serde(default)]
+    stroke_width: Option<f64>,
+    #[serde(default)]
+    color: Option<[f64; 4]>,
+}
+
+impl AxisGeometryRequest {
+    fn overlay(&mut self, other: Self) {
+        if other.include_tip.is_some() {
+            self.include_tip = other.include_tip;
+        }
+        if other.include_ticks.is_some() {
+            self.include_ticks = other.include_ticks;
+        }
+        if other.tick_size.is_some() {
+            self.tick_size = other.tick_size;
+        }
+        if other.numbers_with_elongated_ticks.is_some() {
+            self.numbers_with_elongated_ticks = other.numbers_with_elongated_ticks;
+        }
+        if other.longer_tick_multiple.is_some() {
+            self.longer_tick_multiple = other.longer_tick_multiple;
+        }
+        if other.exclude_origin_tick.is_some() {
+            self.exclude_origin_tick = other.exclude_origin_tick;
+        }
+        if other.stroke_width.is_some() {
+            self.stroke_width = other.stroke_width;
+        }
+        if other.color.is_some() {
+            self.color = other.color;
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+struct AxesAuthoringRequest {
+    x_range: [f64; 3],
+    y_range: [f64; 3],
+    x_length: f32,
+    y_length: f32,
+    #[serde(default = "default_true")]
+    tips: bool,
+    #[serde(default)]
+    axis_config: AxisGeometryRequest,
+    #[serde(default)]
+    x_axis_config: AxisGeometryRequest,
+    #[serde(default)]
+    y_axis_config: AxisGeometryRequest,
+}
+
+const fn default_true() -> bool {
+    true
+}
+
+#[derive(Serialize)]
+struct TickWire<'a> {
+    value: f64,
+    size: f64,
+    snapshot: &'a ObjectSnapshot,
+}
+
+#[derive(Serialize)]
+struct NumberLineGeometryWire<'a> {
+    line: &'a ObjectSnapshot,
+    ticks: Vec<TickWire<'a>>,
+}
+
+#[derive(Serialize)]
+struct AxesGeometryWire<'a> {
+    x_axis: NumberLineGeometryWire<'a>,
+    y_axis: NumberLineGeometryWire<'a>,
+}
+
+/// Shared semantic/geometry plan for the initial linear ManimCE v0.21 `Axes` subset.
+///
+/// This object owns the coordinate mapping and all retained line/tick geometry. Host
+/// frontends may serialize the resulting snapshots into their normal semantic-handle
+/// path, but they do not calculate axis placement, tick positions, tick orientation,
+/// config precedence, or coordinate conversion themselves.
+#[derive(Clone, Debug, PartialEq)]
+pub struct AxesAuthoringPlan {
+    axes: Axes2DState,
+    x_geometry: NumberLineGeometryPlan,
+    y_geometry: NumberLineGeometryPlan,
+}
+
+impl AxesAuthoringPlan {
+    pub fn from_json(request_json: &str) -> Result<Self, ManimAxesBridgeError> {
+        let request: AxesAuthoringRequest = serde_json::from_str(request_json)
+            .map_err(|error| ManimAxesBridgeError::InvalidRequest(error.to_string()))?;
+        Self::new(request)
+    }
+
+    fn new(request: AxesAuthoringRequest) -> Result<Self, ManimAxesBridgeError> {
+        let x_range = NumberRange::new(request.x_range[0], request.x_range[1], request.x_range[2])?;
+        let y_range = NumberRange::new(request.y_range[0], request.y_range[1], request.y_range[2])?;
+        let axes = Axes2DState::new(x_range, y_range, request.x_length, request.y_length)?;
+
+        let mut shared = AxisGeometryRequest {
+            include_tip: Some(request.tips),
+            ..AxisGeometryRequest::default()
+        };
+        shared.overlay(request.axis_config);
+
+        let mut x_request = shared.clone();
+        x_request.overlay(request.x_axis_config);
+        let mut y_request = shared;
+        y_request.overlay(request.y_axis_config);
+
+        let x_options = resolve_axis_options(x_request, Axis::X)?;
+        let y_options = resolve_axis_options(y_request, Axis::Y)?;
+        let x_geometry = NumberLineGeometryPlan::new(axes.x_axis(), &x_options)?;
+        let y_geometry = NumberLineGeometryPlan::new(axes.y_axis(), &y_options)?;
+
+        Ok(Self {
+            axes,
+            x_geometry,
+            y_geometry,
+        })
+    }
+
+    pub const fn axes(&self) -> Axes2DState {
+        self.axes
+    }
+
+    pub fn geometry_json(&self) -> Result<String, ManimAxesBridgeError> {
+        let wire = AxesGeometryWire {
+            x_axis: number_line_wire(&self.x_geometry),
+            y_axis: number_line_wire(&self.y_geometry),
+        };
+        serde_json::to_string(&wire)
+            .map_err(|error| ManimAxesBridgeError::Serialization(error.to_string()))
+    }
+
+    pub fn coords_to_point_json(&self, x: f64, y: f64) -> Result<String, ManimAxesBridgeError> {
+        let point = self.axes.coords_to_point(x, y)?;
+        serde_json::to_string(&[f64::from(point.x), f64::from(point.y)])
+            .map_err(|error| ManimAxesBridgeError::Serialization(error.to_string()))
+    }
+
+    pub fn point_to_coords_json(&self, x: f32, y: f32) -> Result<String, ManimAxesBridgeError> {
+        let (x, y) = self.axes.point_to_coords(noon_core::Vec2::new(x, y))?;
+        serde_json::to_string(&[x, y])
+            .map_err(|error| ManimAxesBridgeError::Serialization(error.to_string()))
+    }
+}
+
+fn number_line_wire(plan: &NumberLineGeometryPlan) -> NumberLineGeometryWire<'_> {
+    NumberLineGeometryWire {
+        line: plan.line(),
+        ticks: plan
+            .ticks()
+            .iter()
+            .map(|tick| TickWire {
+                value: tick.value(),
+                size: tick.size(),
+                snapshot: tick.snapshot(),
+            })
+            .collect(),
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Axis {
+    X,
+    Y,
+}
+
+fn resolve_axis_options(
+    request: AxisGeometryRequest,
+    axis: Axis,
+) -> Result<NumberLineTickOptions, ManimAxesBridgeError> {
+    if request.include_tip.unwrap_or(false) {
+        return Err(ManimAxesBridgeError::UnsupportedTips(match axis {
+            Axis::X => "x",
+            Axis::Y => "y",
+        }));
+    }
+
+    let mut options = NumberLineTickOptions::default();
+    if let Some(value) = request.include_ticks {
+        options.include_ticks = value;
+    }
+    if let Some(value) = request.tick_size {
+        options.tick_size = value;
+    }
+    if let Some(values) = request.numbers_with_elongated_ticks {
+        options.elongated_values = values;
+    }
+    if let Some(value) = request.longer_tick_multiple {
+        options.longer_tick_multiple = value;
+    }
+    if let Some(value) = request.stroke_width {
+        options.stroke_width = value;
+    }
+    if let Some(value) = request.color {
+        options.color = rgba(value)?;
+    }
+
+    // Manim's Axes constructor overwrites this after config merging for linear
+    // scaling. User-provided `exclude_origin_tick` therefore does not win here.
+    options.exclude_origin_tick = true;
+    Ok(options)
+}
+
+fn rgba(value: [f64; 4]) -> Result<Color, ManimAxesBridgeError> {
+    if value
+        .iter()
+        .any(|component| !component.is_finite() || !(0.0..=1.0).contains(component))
+    {
+        return Err(ManimAxesBridgeError::InvalidColor(value));
+    }
+    Ok(Color::rgba(
+        value[0] as f32,
+        value[1] as f32,
+        value[2] as f32,
+        value[3] as f32,
+    ))
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ManimAxesBridgeError {
+    InvalidRequest(String),
+    UnsupportedTips(&'static str),
+    InvalidColor([f64; 4]),
+    Coordinates(CoordinateSystemError),
+    Geometry(AxisTickError),
+    Serialization(String),
+}
+
+impl std::fmt::Display for ManimAxesBridgeError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidRequest(error) => write!(formatter, "invalid Axes request: {error}"),
+            Self::UnsupportedTips(axis) => write!(
+                formatter,
+                "Axes {axis}-axis tips are not yet supported by the retained geometry plan"
+            ),
+            Self::InvalidColor(value) => write!(
+                formatter,
+                "Axes color must contain finite RGBA components in [0, 1], got {value:?}"
+            ),
+            Self::Coordinates(error) => error.fmt(formatter),
+            Self::Geometry(error) => error.fmt(formatter),
+            Self::Serialization(error) => {
+                write!(formatter, "unable to serialize Axes state: {error}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ManimAxesBridgeError {}
+
+impl From<CoordinateSystemError> for ManimAxesBridgeError {
+    fn from(value: CoordinateSystemError) -> Self {
+        Self::Coordinates(value)
+    }
+}
+
+impl From<AxisTickError> for ManimAxesBridgeError {
+    fn from(value: AxisTickError) -> Self {
+        Self::Geometry(value)
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+mod wasm {
+    use wasm_bindgen::prelude::*;
+
+    use super::AxesAuthoringPlan;
+
+    fn js_error(error: impl std::fmt::Display) -> JsValue {
+        JsValue::from_str(&error.to_string())
+    }
+
+    #[wasm_bindgen]
+    pub struct WasmAxesAuthoringPlan(AxesAuthoringPlan);
+
+    #[wasm_bindgen]
+    impl WasmAxesAuthoringPlan {
+        #[wasm_bindgen(constructor)]
+        pub fn new(request_json: &str) -> Result<Self, JsValue> {
+            AxesAuthoringPlan::from_json(request_json)
+                .map(Self)
+                .map_err(js_error)
+        }
+
+        #[wasm_bindgen(js_name = geometryJson)]
+        pub fn geometry_json(&self) -> Result<String, JsValue> {
+            self.0.geometry_json().map_err(js_error)
+        }
+
+        #[wasm_bindgen(js_name = coordsToPointJson)]
+        pub fn coords_to_point_json(&self, x: f64, y: f64) -> Result<String, JsValue> {
+            self.0.coords_to_point_json(x, y).map_err(js_error)
+        }
+
+        #[wasm_bindgen(js_name = pointToCoordsJson)]
+        pub fn point_to_coords_json(&self, x: f32, y: f32) -> Result<String, JsValue> {
+            self.0.point_to_coords_json(x, y).map_err(js_error)
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub use wasm::WasmAxesAuthoringPlan;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+
+    fn request(extra: &str) -> String {
+        format!(
+            r#"{{"x_range":[-10.0,10.3,1.0],"y_range":[-1.5,1.5,1.0],"x_length":10.0,"y_length":6.0,"tips":false{extra}}}"#
+        )
+    }
+
+    #[test]
+    fn canonical_plot_axes_geometry_is_owned_by_shared_plan() {
+        let plan = AxesAuthoringPlan::from_json(&request(
+            r#", "axis_config":{"color":[0.0,1.0,0.0,1.0]}, "x_axis_config":{"numbers_with_elongated_ticks":[-10,-8,-6,-4,-2,0,2,4,6,8,10]}"#,
+        ))
+        .unwrap();
+        let geometry: Value = serde_json::from_str(&plan.geometry_json().unwrap()).unwrap();
+        let x_ticks = geometry["x_axis"]["ticks"].as_array().unwrap();
+        let y_ticks = geometry["y_axis"]["ticks"].as_array().unwrap();
+        assert_eq!(x_ticks.len(), 20);
+        assert_eq!(y_ticks.len(), 2);
+        assert!(x_ticks.iter().all(|tick| tick["value"] != 0.0));
+        let elongated = x_ticks.iter().find(|tick| tick["value"] == 2.0).unwrap();
+        assert_eq!(elongated["size"], 0.2);
+        assert_eq!(geometry["x_axis"]["line"]["style"]["stroke_width"], 0.02);
+    }
+
+    #[test]
+    fn axis_specific_config_overrides_shared_config() {
+        let plan = AxesAuthoringPlan::from_json(&request(
+            r#", "axis_config":{"tick_size":0.2}, "x_axis_config":{"tick_size":0.3}"#,
+        ))
+        .unwrap();
+        let geometry: Value = serde_json::from_str(&plan.geometry_json().unwrap()).unwrap();
+        assert_eq!(geometry["x_axis"]["ticks"][0]["size"], 0.3);
+        assert_eq!(geometry["y_axis"]["ticks"][0]["size"], 0.2);
+    }
+
+    #[test]
+    fn linear_axes_force_origin_tick_exclusion_after_config_merge() {
+        let plan = AxesAuthoringPlan::from_json(&request(
+            r#", "axis_config":{"exclude_origin_tick":false}"#,
+        ))
+        .unwrap();
+        let geometry: Value = serde_json::from_str(&plan.geometry_json().unwrap()).unwrap();
+        for axis in ["x_axis", "y_axis"] {
+            assert!(geometry[axis]["ticks"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .all(|tick| tick["value"] != 0.0));
+        }
+    }
+
+    #[test]
+    fn coordinate_queries_round_trip_through_same_axes_state() {
+        let plan = AxesAuthoringPlan::from_json(&request("")).unwrap();
+        let point: [f64; 2] =
+            serde_json::from_str(&plan.coords_to_point_json(2.0, 1.0).unwrap()).unwrap();
+        let coords: [f64; 2] = serde_json::from_str(
+            &plan
+                .point_to_coords_json(point[0] as f32, point[1] as f32)
+                .unwrap(),
+        )
+        .unwrap();
+        assert!((coords[0] - 2.0).abs() <= 1.0e-5);
+        assert!((coords[1] - 1.0).abs() <= 1.0e-5);
+    }
+
+    #[test]
+    fn tips_are_rejected_instead_of_silently_omitted() {
+        let request = r#"{"x_range":[-1,1,1],"y_range":[-1,1,1],"x_length":2,"y_length":2}"#;
+        assert!(matches!(
+            AxesAuthoringPlan::from_json(request),
+            Err(ManimAxesBridgeError::UnsupportedTips("x"))
+        ));
+    }
+
+    #[test]
+    fn unsupported_axis_config_keys_fail_closed() {
+        let error = AxesAuthoringPlan::from_json(&request(
+            r#", "x_axis_config":{"numbers_to_include":[-2,0,2]}"#,
+        ))
+        .unwrap_err();
+        assert!(matches!(error, ManimAxesBridgeError::InvalidRequest(_)));
+    }
+}

--- a/crates/noon-web/src/manim_axes_query_bridge.rs
+++ b/crates/noon-web/src/manim_axes_query_bridge.rs
@@ -1,0 +1,234 @@
+use noon::{Axes2DState, CoordinateSystemError, NumberRange, TransformedAxes2DState};
+use noon_core::{GeometryRef, ObjectSnapshot, Vec2};
+use serde::Deserialize;
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+struct AxesQueryRequest {
+    x_range: [f64; 3],
+    y_range: [f64; 3],
+    x_length: f32,
+    y_length: f32,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct AxesQueryPlan {
+    axes: Axes2DState,
+}
+
+impl AxesQueryPlan {
+    pub fn from_json(request_json: &str) -> Result<Self, ManimAxesQueryError> {
+        let request: AxesQueryRequest = serde_json::from_str(request_json)
+            .map_err(|error| ManimAxesQueryError::InvalidRequest(error.to_string()))?;
+        let x_range = NumberRange::new(request.x_range[0], request.x_range[1], request.x_range[2])?;
+        let y_range = NumberRange::new(request.y_range[0], request.y_range[1], request.y_range[2])?;
+        Ok(Self {
+            axes: Axes2DState::new(x_range, y_range, request.x_length, request.y_length)?,
+        })
+    }
+
+    pub fn coords_to_point_json(
+        &self,
+        x: f64,
+        y: f64,
+        x_axis_snapshot_json: &str,
+        y_axis_snapshot_json: &str,
+    ) -> Result<String, ManimAxesQueryError> {
+        let transformed = self.transformed_axes(x_axis_snapshot_json, y_axis_snapshot_json)?;
+        serialize_pair(transformed.coords_to_point(x, y)?)
+    }
+
+    pub fn point_to_coords_json(
+        &self,
+        x: f32,
+        y: f32,
+        x_axis_snapshot_json: &str,
+        y_axis_snapshot_json: &str,
+    ) -> Result<String, ManimAxesQueryError> {
+        let transformed = self.transformed_axes(x_axis_snapshot_json, y_axis_snapshot_json)?;
+        let (x, y) = transformed.point_to_coords(Vec2::new(x, y))?;
+        serde_json::to_string(&[x, y])
+            .map_err(|error| ManimAxesQueryError::Serialization(error.to_string()))
+    }
+
+    fn transformed_axes(
+        &self,
+        x_axis_snapshot_json: &str,
+        y_axis_snapshot_json: &str,
+    ) -> Result<TransformedAxes2DState, ManimAxesQueryError> {
+        let x_axis = parse_axis_snapshot(x_axis_snapshot_json, "x")?;
+        let y_axis = parse_axis_snapshot(y_axis_snapshot_json, "y")?;
+        Ok(TransformedAxes2DState::new(
+            self.axes,
+            x_axis.transform,
+            y_axis.transform,
+        ))
+    }
+}
+
+fn parse_axis_snapshot(
+    snapshot_json: &str,
+    axis: &'static str,
+) -> Result<ObjectSnapshot, ManimAxesQueryError> {
+    let snapshot: ObjectSnapshot = serde_json::from_str(snapshot_json).map_err(|error| {
+        ManimAxesQueryError::InvalidAxisSnapshot {
+            axis,
+            error: error.to_string(),
+        }
+    })?;
+    if !matches!(snapshot.geometry, GeometryRef::Line { .. }) {
+        return Err(ManimAxesQueryError::InvalidAxisGeometry(axis));
+    }
+    Ok(snapshot)
+}
+
+fn serialize_pair(point: Vec2) -> Result<String, ManimAxesQueryError> {
+    serde_json::to_string(&[f64::from(point.x), f64::from(point.y)])
+        .map_err(|error| ManimAxesQueryError::Serialization(error.to_string()))
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ManimAxesQueryError {
+    InvalidRequest(String),
+    InvalidAxisSnapshot { axis: &'static str, error: String },
+    InvalidAxisGeometry(&'static str),
+    Coordinates(CoordinateSystemError),
+    Serialization(String),
+}
+
+impl std::fmt::Display for ManimAxesQueryError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidRequest(error) => write!(formatter, "invalid Axes query request: {error}"),
+            Self::InvalidAxisSnapshot { axis, error } => {
+                write!(formatter, "invalid Axes {axis}-axis snapshot: {error}")
+            }
+            Self::InvalidAxisGeometry(axis) => {
+                write!(
+                    formatter,
+                    "Axes {axis}-axis snapshot must contain line geometry"
+                )
+            }
+            Self::Coordinates(error) => error.fmt(formatter),
+            Self::Serialization(error) => {
+                write!(formatter, "unable to serialize Axes query result: {error}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ManimAxesQueryError {}
+
+impl From<CoordinateSystemError> for ManimAxesQueryError {
+    fn from(value: CoordinateSystemError) -> Self {
+        Self::Coordinates(value)
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+mod wasm {
+    use wasm_bindgen::prelude::*;
+
+    use super::AxesQueryPlan;
+
+    fn js_error(error: impl std::fmt::Display) -> JsValue {
+        JsValue::from_str(&error.to_string())
+    }
+
+    #[wasm_bindgen]
+    pub struct WasmAxesQueryPlan(AxesQueryPlan);
+
+    #[wasm_bindgen]
+    impl WasmAxesQueryPlan {
+        #[wasm_bindgen(constructor)]
+        pub fn new(request_json: &str) -> Result<Self, JsValue> {
+            AxesQueryPlan::from_json(request_json)
+                .map(Self)
+                .map_err(js_error)
+        }
+
+        #[wasm_bindgen(js_name = coordsToPointJson)]
+        pub fn coords_to_point_json(
+            &self,
+            x: f64,
+            y: f64,
+            x_axis_snapshot_json: &str,
+            y_axis_snapshot_json: &str,
+        ) -> Result<String, JsValue> {
+            self.0
+                .coords_to_point_json(x, y, x_axis_snapshot_json, y_axis_snapshot_json)
+                .map_err(js_error)
+        }
+
+        #[wasm_bindgen(js_name = pointToCoordsJson)]
+        pub fn point_to_coords_json(
+            &self,
+            x: f32,
+            y: f32,
+            x_axis_snapshot_json: &str,
+            y_axis_snapshot_json: &str,
+        ) -> Result<String, JsValue> {
+            self.0
+                .point_to_coords_json(x, y, x_axis_snapshot_json, y_axis_snapshot_json)
+                .map_err(js_error)
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub use wasm::WasmAxesQueryPlan;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use noon::{IntoSnapshot, Line};
+    use noon_core::Transform2D;
+
+    fn request_json() -> &'static str {
+        r#"{"x_range":[-2,2,1],"y_range":[-2,2,1],"x_length":4,"y_length":4}"#
+    }
+
+    fn axis_snapshot(axis: noon::NumberLineState, transform: Transform2D) -> String {
+        let mut snapshot = Line::new(axis.start(), axis.end()).into_snapshot();
+        snapshot.transform = transform;
+        serde_json::to_string(&snapshot).unwrap()
+    }
+
+    #[test]
+    fn current_retained_transforms_drive_round_trip_queries() {
+        let plan = AxesQueryPlan::from_json(request_json()).unwrap();
+        let transform = Transform2D {
+            translation: Vec2::new(3.0, -2.0),
+            rotation: 0.45,
+            scale: Vec2::new(1.25, 1.25),
+        };
+        let x_axis = axis_snapshot(plan.axes.x_axis(), transform);
+        let y_axis = axis_snapshot(plan.axes.y_axis(), transform);
+        let point: [f64; 2] = serde_json::from_str(
+            &plan
+                .coords_to_point_json(1.0, -0.5, &x_axis, &y_axis)
+                .unwrap(),
+        )
+        .unwrap();
+        let coords: [f64; 2] = serde_json::from_str(
+            &plan
+                .point_to_coords_json(point[0] as f32, point[1] as f32, &x_axis, &y_axis)
+                .unwrap(),
+        )
+        .unwrap();
+        assert!((coords[0] - 1.0).abs() <= 1.0e-5);
+        assert!((coords[1] + 0.5).abs() <= 1.0e-5);
+    }
+
+    #[test]
+    fn non_line_snapshot_fails_closed() {
+        let plan = AxesQueryPlan::from_json(request_json()).unwrap();
+        let bad = serde_json::to_string(&ObjectSnapshot::new(GeometryRef::circle(1.0))).unwrap();
+        let good = axis_snapshot(plan.axes.y_axis(), Transform2D::IDENTITY);
+        assert_eq!(
+            plan.coords_to_point_json(0.0, 0.0, &bad, &good)
+                .unwrap_err(),
+            ManimAxesQueryError::InvalidAxisGeometry("x")
+        );
+    }
+}

--- a/crates/noon-web/src/manim_axes_store_bridge.rs
+++ b/crates/noon-web/src/manim_axes_store_bridge.rs
@@ -1,0 +1,35 @@
+#[cfg(target_arch = "wasm32")]
+mod wasm {
+    use wasm_bindgen::prelude::*;
+
+    use crate::{WasmAuthoringStore, WasmAxesAuthoringPlan, WasmAxesPlotPlan, WasmAxesQueryPlan};
+
+    /// Keep the browser worker coupled to one stable authoring-store import while
+    /// feature-specific plans remain separate Rust/WASM modules.
+    #[wasm_bindgen]
+    impl WasmAuthoringStore {
+        #[wasm_bindgen(js_name = createAxesAuthoringPlan)]
+        pub fn create_axes_authoring_plan(
+            &self,
+            request_json: &str,
+        ) -> Result<WasmAxesAuthoringPlan, JsValue> {
+            WasmAxesAuthoringPlan::new(request_json)
+        }
+
+        #[wasm_bindgen(js_name = createAxesQueryPlan)]
+        pub fn create_axes_query_plan(
+            &self,
+            request_json: &str,
+        ) -> Result<WasmAxesQueryPlan, JsValue> {
+            WasmAxesQueryPlan::new(request_json)
+        }
+
+        #[wasm_bindgen(js_name = createAxesPlotPlan)]
+        pub fn create_axes_plot_plan(
+            &self,
+            request_json: &str,
+        ) -> Result<WasmAxesPlotPlan, JsValue> {
+            WasmAxesPlotPlan::new(request_json)
+        }
+    }
+}

--- a/crates/noon-web/src/manim_plot_bridge.rs
+++ b/crates/noon-web/src/manim_plot_bridge.rs
@@ -1,9 +1,10 @@
 use noon::{
-    axes_sampled_values_vector_path, Axes2DState, CoordinateSystemError, IntoSnapshot, NumberRange,
-    ParametricSamplePlan, Path, PlotGeometryError, PlotRangeRequest, PlotSamplingError,
-    SampleRange, MANIM_DEFAULT_DISCONTINUITY_DT,
+    axes_sampled_values_vector_path, transformed_axes_sampled_values_vector_path, Axes2DState,
+    CoordinateSystemError, IntoSnapshot, NumberRange, ParametricSamplePlan, Path,
+    PlotGeometryError, PlotRangeRequest, PlotSamplingError, SampleRange, TransformedAxes2DState,
+    MANIM_DEFAULT_DISCONTINUITY_DT,
 };
-use noon_core::ObjectSnapshot;
+use noon_core::{GeometryRef, ObjectSnapshot};
 use serde::Deserialize;
 
 #[derive(Clone, Debug, Deserialize, PartialEq)]
@@ -103,13 +104,77 @@ impl AxesPlotAuthoringPlan {
         Ok(Path::new(path).into_snapshot())
     }
 
-    pub fn finish_snapshot_json(&self, values_json: &str) -> Result<String, ManimPlotBridgeError> {
-        let values: Vec<Vec<f64>> = serde_json::from_str(values_json)
-            .map_err(|error| ManimPlotBridgeError::InvalidCallbackValues(error.to_string()))?;
-        let snapshot = self.finish_values(&values)?;
-        serde_json::to_string(&snapshot)
-            .map_err(|error| ManimPlotBridgeError::Serialization(error.to_string()))
+    /// Finish against the current retained x/y-axis snapshots.
+    ///
+    /// Only each snapshot's affine transform participates in coordinate mapping;
+    /// the geometry kind is validated so callers cannot accidentally bind plotting
+    /// semantics to an unrelated retained mobject.
+    pub fn finish_values_with_axes(
+        &self,
+        values: &[Vec<f64>],
+        x_axis: &ObjectSnapshot,
+        y_axis: &ObjectSnapshot,
+    ) -> Result<ObjectSnapshot, ManimPlotBridgeError> {
+        ensure_axis_line(x_axis, "x")?;
+        ensure_axis_line(y_axis, "y")?;
+        let transformed =
+            TransformedAxes2DState::new(self.axes, x_axis.transform, y_axis.transform);
+        let path = transformed_axes_sampled_values_vector_path(
+            transformed,
+            &self.samples,
+            values,
+            self.use_smoothing,
+        )?;
+        Ok(Path::new(path).into_snapshot())
     }
+
+    pub fn finish_snapshot_json(&self, values_json: &str) -> Result<String, ManimPlotBridgeError> {
+        let values = parse_callback_values(values_json)?;
+        serialize_snapshot(&self.finish_values(&values)?)
+    }
+
+    pub fn finish_snapshot_json_with_axes(
+        &self,
+        values_json: &str,
+        x_axis_snapshot_json: &str,
+        y_axis_snapshot_json: &str,
+    ) -> Result<String, ManimPlotBridgeError> {
+        let values = parse_callback_values(values_json)?;
+        let x_axis = parse_axis_snapshot(x_axis_snapshot_json, "x")?;
+        let y_axis = parse_axis_snapshot(y_axis_snapshot_json, "y")?;
+        serialize_snapshot(&self.finish_values_with_axes(&values, &x_axis, &y_axis)?)
+    }
+}
+
+fn parse_callback_values(values_json: &str) -> Result<Vec<Vec<f64>>, ManimPlotBridgeError> {
+    serde_json::from_str(values_json)
+        .map_err(|error| ManimPlotBridgeError::InvalidCallbackValues(error.to_string()))
+}
+
+fn parse_axis_snapshot(
+    snapshot_json: &str,
+    axis: &'static str,
+) -> Result<ObjectSnapshot, ManimPlotBridgeError> {
+    serde_json::from_str(snapshot_json).map_err(|error| ManimPlotBridgeError::InvalidAxisSnapshot {
+        axis,
+        error: error.to_string(),
+    })
+}
+
+fn ensure_axis_line(
+    snapshot: &ObjectSnapshot,
+    axis: &'static str,
+) -> Result<(), ManimPlotBridgeError> {
+    if matches!(snapshot.geometry, GeometryRef::Line { .. }) {
+        Ok(())
+    } else {
+        Err(ManimPlotBridgeError::InvalidAxisGeometry(axis))
+    }
+}
+
+fn serialize_snapshot(snapshot: &ObjectSnapshot) -> Result<String, ManimPlotBridgeError> {
+    serde_json::to_string(snapshot)
+        .map_err(|error| ManimPlotBridgeError::Serialization(error.to_string()))
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -117,6 +182,8 @@ pub enum ManimPlotBridgeError {
     InvalidRequest(String),
     InvalidCallbackValues(String),
     InvalidPlotRangeLength(usize),
+    InvalidAxisSnapshot { axis: &'static str, error: String },
+    InvalidAxisGeometry(&'static str),
     Coordinates(CoordinateSystemError),
     Sampling(PlotSamplingError),
     Geometry(PlotGeometryError),
@@ -134,6 +201,15 @@ impl std::fmt::Display for ManimPlotBridgeError {
                 formatter,
                 "Axes.plot x_range must contain 2 or 3 values, got {length}"
             ),
+            Self::InvalidAxisSnapshot { axis, error } => {
+                write!(formatter, "invalid Axes.plot {axis}-axis snapshot: {error}")
+            }
+            Self::InvalidAxisGeometry(axis) => {
+                write!(
+                    formatter,
+                    "Axes.plot {axis}-axis snapshot must contain line geometry"
+                )
+            }
             Self::Coordinates(error) => error.fmt(formatter),
             Self::Sampling(error) => error.fmt(formatter),
             Self::Geometry(error) => error.fmt(formatter),
@@ -195,6 +271,22 @@ mod wasm {
         pub fn finish_snapshot_json(&self, values_json: &str) -> Result<String, JsValue> {
             self.0.finish_snapshot_json(values_json).map_err(js_error)
         }
+
+        #[wasm_bindgen(js_name = finishSnapshotJsonWithAxes)]
+        pub fn finish_snapshot_json_with_axes(
+            &self,
+            values_json: &str,
+            x_axis_snapshot_json: &str,
+            y_axis_snapshot_json: &str,
+        ) -> Result<String, JsValue> {
+            self.0
+                .finish_snapshot_json_with_axes(
+                    values_json,
+                    x_axis_snapshot_json,
+                    y_axis_snapshot_json,
+                )
+                .map_err(js_error)
+        }
     }
 }
 
@@ -204,12 +296,28 @@ pub use wasm::WasmAxesPlotPlan;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use noon_core::{GeometryRef, PathCommand};
+    use noon::Line;
+    use noon_core::{GeometryRef, PathCommand, Transform2D, Vec2};
 
     fn request_json(plot_range: &str, discontinuities: &str, use_smoothing: bool) -> String {
         format!(
             r#"{{"x_range":[-2.0,2.0,1.0],"y_range":[-2.0,2.0,1.0],"x_length":4.0,"y_length":4.0,"plot_range":{plot_range},"discontinuities":{discontinuities},"use_smoothing":{use_smoothing}}}"#
         )
+    }
+
+    fn axis_snapshot(
+        plan: &AxesPlotAuthoringPlan,
+        x_axis: bool,
+        transform: Transform2D,
+    ) -> ObjectSnapshot {
+        let axis = if x_axis {
+            plan.axes.x_axis()
+        } else {
+            plan.axes.y_axis()
+        };
+        let mut snapshot = Line::new(axis.start(), axis.end()).into_snapshot();
+        snapshot.transform = transform;
+        snapshot
     }
 
     #[test]
@@ -241,6 +349,52 @@ mod tests {
         assert!(matches!(path.commands()[0], PathCommand::MoveTo { .. }));
         assert!(matches!(path.commands()[1], PathCommand::CubicTo { .. }));
         assert!(matches!(path.commands()[2], PathCommand::CubicTo { .. }));
+    }
+
+    #[test]
+    fn current_axis_snapshots_drive_transformed_plot_geometry() {
+        let plan = AxesPlotAuthoringPlan::from_json(&request_json("[-1.0,1.0,1.0]", "null", false))
+            .unwrap();
+        let transform = Transform2D {
+            translation: Vec2::new(2.0, -1.0),
+            rotation: 0.4,
+            scale: Vec2::new(1.5, 1.5),
+        };
+        let x_axis = axis_snapshot(&plan, true, transform);
+        let y_axis = axis_snapshot(&plan, false, transform);
+        let snapshot = plan
+            .finish_values_with_axes(&[vec![1.0, 0.0, 1.0]], &x_axis, &y_axis)
+            .unwrap();
+        let GeometryRef::VectorPath(path) = snapshot.geometry else {
+            panic!("Axes.plot must lower to ordinary VectorPath geometry");
+        };
+        let expected = [
+            transform.transform_point(Vec2::new(-1.0, 1.0)),
+            transform.transform_point(Vec2::ZERO),
+            transform.transform_point(Vec2::new(1.0, 1.0)),
+        ];
+        for (command, expected) in path.commands().iter().zip(expected) {
+            match command {
+                PathCommand::MoveTo { to } | PathCommand::LineTo { to } => {
+                    assert!((*to - expected).length() <= 1.0e-5)
+                }
+                other => panic!("expected corner path command, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn non_line_axis_snapshot_is_rejected() {
+        let plan = AxesPlotAuthoringPlan::from_json(&request_json("[-1.0,1.0,1.0]", "null", false))
+            .unwrap();
+        let mut x_axis = axis_snapshot(&plan, true, Transform2D::IDENTITY);
+        x_axis.geometry = GeometryRef::circle(1.0);
+        let y_axis = axis_snapshot(&plan, false, Transform2D::IDENTITY);
+        assert_eq!(
+            plan.finish_values_with_axes(&[vec![1.0, 0.0, 1.0]], &x_axis, &y_axis)
+                .unwrap_err(),
+            ManimPlotBridgeError::InvalidAxisGeometry("x")
+        );
     }
 
     #[test]

--- a/crates/noon/src/axis_tick_authoring.rs
+++ b/crates/noon/src/axis_tick_authoring.rs
@@ -1,0 +1,195 @@
+use crate::{CoordinateSystemError, IntoSnapshot, Line, NumberLineState};
+use noon_core::{Color, ObjectSnapshot, Vec2, WHITE};
+
+const CAIRO_WIDTH_SCALE: f64 = 0.01;
+const IS_CLOSE_RTOL: f64 = 1.0e-5;
+const IS_CLOSE_ATOL: f64 = 1.0e-8;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct NumberLineTickOptions {
+    pub include_ticks: bool,
+    pub tick_size: f64,
+    pub elongated_values: Vec<f64>,
+    pub longer_tick_multiple: usize,
+    pub exclude_origin_tick: bool,
+    pub color: Color,
+    pub stroke_width: f64,
+}
+
+impl Default for NumberLineTickOptions {
+    fn default() -> Self {
+        Self {
+            include_ticks: true,
+            tick_size: 0.1,
+            elongated_values: Vec::new(),
+            longer_tick_multiple: 2,
+            exclude_origin_tick: false,
+            color: WHITE,
+            stroke_width: 2.0,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct NumberLineTick {
+    value: f64,
+    size: f64,
+    snapshot: ObjectSnapshot,
+}
+
+impl NumberLineTick {
+    pub const fn value(&self) -> f64 {
+        self.value
+    }
+
+    pub const fn size(&self) -> f64 {
+        self.size
+    }
+
+    pub fn snapshot(&self) -> &ObjectSnapshot {
+        &self.snapshot
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct NumberLineGeometryPlan {
+    line: ObjectSnapshot,
+    ticks: Vec<NumberLineTick>,
+}
+
+impl NumberLineGeometryPlan {
+    pub fn new(
+        state: NumberLineState,
+        options: &NumberLineTickOptions,
+    ) -> Result<Self, AxisTickError> {
+        validate_options(options)?;
+        let width = checked_f32(options.stroke_width * CAIRO_WIDTH_SCALE)?;
+        let line = styled_line(state.start(), state.end(), options.color, width);
+        let ticks = if options.include_ticks {
+            build_ticks(state, options, width)?
+        } else {
+            Vec::new()
+        };
+        Ok(Self { line, ticks })
+    }
+
+    pub fn line(&self) -> &ObjectSnapshot {
+        &self.line
+    }
+
+    pub fn ticks(&self) -> &[NumberLineTick] {
+        &self.ticks
+    }
+}
+
+fn build_ticks(
+    state: NumberLineState,
+    options: &NumberLineTickOptions,
+    width: f32,
+) -> Result<Vec<NumberLineTick>, AxisTickError> {
+    let delta = state.end() - state.start();
+    let length = delta.length();
+    if !length.is_finite() || length <= 0.0 {
+        return Err(CoordinateSystemError::DegenerateLine.into());
+    }
+    let tangent = delta / length;
+    let normal = Vec2::new(-tangent.y, tangent.x);
+    let range_min = state.range().min();
+
+    state
+        .tick_values(options.exclude_origin_tick)
+        .into_iter()
+        .map(|value| {
+            let elongated = options
+                .elongated_values
+                .iter()
+                .any(|candidate| is_close(value - range_min, *candidate - range_min));
+            let size = options.tick_size
+                * if elongated {
+                    options.longer_tick_multiple as f64
+                } else {
+                    1.0
+                };
+            let center = state.number_to_point(value)?;
+            let offset = normal * checked_f32(size)?;
+            Ok(NumberLineTick {
+                value,
+                size,
+                snapshot: styled_line(center - offset, center + offset, options.color, width),
+            })
+        })
+        .collect()
+}
+
+fn styled_line(start: Vec2, end: Vec2, color: Color, width: f32) -> ObjectSnapshot {
+    Line::new(start, end)
+        .color(color)
+        .set_stroke(Some(color), Some(width))
+        .into_snapshot()
+}
+
+fn validate_options(options: &NumberLineTickOptions) -> Result<(), AxisTickError> {
+    if !options.tick_size.is_finite() || options.tick_size < 0.0 {
+        return Err(AxisTickError::InvalidTickSize(options.tick_size));
+    }
+    if options.longer_tick_multiple == 0 {
+        return Err(AxisTickError::InvalidLongerTickMultiple);
+    }
+    if !options.stroke_width.is_finite() || options.stroke_width < 0.0 {
+        return Err(AxisTickError::InvalidStrokeWidth(options.stroke_width));
+    }
+    if options
+        .elongated_values
+        .iter()
+        .any(|value| !value.is_finite())
+    {
+        return Err(AxisTickError::NonFiniteElongatedValue);
+    }
+    Ok(())
+}
+
+fn is_close(lhs: f64, rhs: f64) -> bool {
+    (lhs - rhs).abs() <= IS_CLOSE_ATOL + IS_CLOSE_RTOL * rhs.abs()
+}
+
+fn checked_f32(value: f64) -> Result<f32, AxisTickError> {
+    let lowered = value as f32;
+    if lowered.is_finite() {
+        Ok(lowered)
+    } else {
+        Err(AxisTickError::Overflow(value))
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum AxisTickError {
+    Coordinates(CoordinateSystemError),
+    InvalidTickSize(f64),
+    InvalidLongerTickMultiple,
+    InvalidStrokeWidth(f64),
+    NonFiniteElongatedValue,
+    Overflow(f64),
+}
+
+impl From<CoordinateSystemError> for AxisTickError {
+    fn from(value: CoordinateSystemError) -> Self {
+        Self::Coordinates(value)
+    }
+}
+
+impl std::fmt::Display for AxisTickError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Coordinates(error) => error.fmt(f),
+            Self::InvalidTickSize(value) => write!(f, "invalid tick size: {value}"),
+            Self::InvalidLongerTickMultiple => f.write_str("longer tick multiple must be positive"),
+            Self::InvalidStrokeWidth(value) => write!(f, "invalid stroke width: {value}"),
+            Self::NonFiniteElongatedValue => f.write_str("elongated tick values must be finite"),
+            Self::Overflow(value) => {
+                write!(f, "tick geometry cannot be represented as f32: {value}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for AxisTickError {}

--- a/crates/noon/src/coordinate_transform_authoring.rs
+++ b/crates/noon/src/coordinate_transform_authoring.rs
@@ -1,0 +1,243 @@
+use crate::{Axes2DState, CoordinateSystemError, NumberLineState};
+use noon_core::{Transform2D, Vec2};
+
+/// A NumberLine coordinate view whose affine placement comes from the current
+/// retained mobject transform rather than from duplicated frontend state.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct TransformedNumberLineState {
+    line: NumberLineState,
+    transform: Transform2D,
+}
+
+impl TransformedNumberLineState {
+    pub const fn new(line: NumberLineState, transform: Transform2D) -> Self {
+        Self { line, transform }
+    }
+
+    pub const fn line(self) -> NumberLineState {
+        self.line
+    }
+
+    pub const fn transform(self) -> Transform2D {
+        self.transform
+    }
+
+    pub fn number_to_point(self, number: f64) -> Result<Vec2, CoordinateSystemError> {
+        let point = self
+            .transform
+            .transform_point(self.line.number_to_point(number)?);
+        if vec2_is_finite(point) {
+            Ok(point)
+        } else {
+            Err(CoordinateSystemError::NonFinitePoint(point))
+        }
+    }
+
+    pub fn point_to_number(self, point: Vec2) -> Result<f64, CoordinateSystemError> {
+        if !vec2_is_finite(point) {
+            return Err(CoordinateSystemError::NonFinitePoint(point));
+        }
+
+        let start = self.transform.transform_point(self.line.start());
+        let end = self.transform.transform_point(self.line.end());
+        if !vec2_is_finite(start) {
+            return Err(CoordinateSystemError::NonFinitePoint(start));
+        }
+        if !vec2_is_finite(end) {
+            return Err(CoordinateSystemError::NonFinitePoint(end));
+        }
+
+        let delta = end - start;
+        let length_squared =
+            f64::from(delta.x) * f64::from(delta.x) + f64::from(delta.y) * f64::from(delta.y);
+        if !length_squared.is_finite() || length_squared <= 0.0 {
+            return Err(CoordinateSystemError::DegenerateLine);
+        }
+
+        let from_start = point - start;
+        let projection = f64::from(from_start.x) * f64::from(delta.x)
+            + f64::from(from_start.y) * f64::from(delta.y);
+        let alpha = projection / length_squared;
+        let range = self.line.range();
+        Ok(range.min() + alpha * range.span())
+    }
+}
+
+/// Transform-aware view of the same two retained axis lines that render an Axes.
+///
+/// Manim composes coordinates vectorially: start from `x_axis.n2p(x)` and add
+/// `y_axis.n2p(y) - origin`, where origin is the x-axis origin-shift point. Keeping
+/// each current retained transform explicit makes c2p/p2c remain correct after
+/// group shifts, rotations, and scales without mirroring mutable coordinate state.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct TransformedAxes2DState {
+    axes: Axes2DState,
+    x_transform: Transform2D,
+    y_transform: Transform2D,
+}
+
+impl TransformedAxes2DState {
+    pub const fn new(
+        axes: Axes2DState,
+        x_transform: Transform2D,
+        y_transform: Transform2D,
+    ) -> Self {
+        Self {
+            axes,
+            x_transform,
+            y_transform,
+        }
+    }
+
+    pub const fn axes(self) -> Axes2DState {
+        self.axes
+    }
+
+    pub fn x_axis(self) -> TransformedNumberLineState {
+        TransformedNumberLineState::new(self.axes.x_axis(), self.x_transform)
+    }
+
+    pub fn y_axis(self) -> TransformedNumberLineState {
+        TransformedNumberLineState::new(self.axes.y_axis(), self.y_transform)
+    }
+
+    pub fn coords_to_point(self, x: f64, y: f64) -> Result<Vec2, CoordinateSystemError> {
+        let x_axis = self.x_axis();
+        let y_axis = self.y_axis();
+        let origin = x_axis.number_to_point(self.axes.x_axis().range().origin_shift())?;
+        let point = x_axis.number_to_point(x)? + y_axis.number_to_point(y)? - origin;
+        if vec2_is_finite(point) {
+            Ok(point)
+        } else {
+            Err(CoordinateSystemError::NonFinitePoint(point))
+        }
+    }
+
+    pub fn point_to_coords(self, point: Vec2) -> Result<(f64, f64), CoordinateSystemError> {
+        Ok((
+            self.x_axis().point_to_number(point)?,
+            self.y_axis().point_to_number(point)?,
+        ))
+    }
+
+    pub fn origin(self) -> Result<Vec2, CoordinateSystemError> {
+        self.coords_to_point(0.0, 0.0)
+    }
+}
+
+fn vec2_is_finite(value: Vec2) -> bool {
+    value.x.is_finite() && value.y.is_finite()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::NumberRange;
+
+    fn assert_close(actual: f64, expected: f64) {
+        assert!(
+            (actual - expected).abs() <= 1.0e-5,
+            "expected {expected}, got {actual}"
+        );
+    }
+
+    fn assert_point(actual: Vec2, expected: Vec2) {
+        assert_close(f64::from(actual.x), f64::from(expected.x));
+        assert_close(f64::from(actual.y), f64::from(expected.y));
+    }
+
+    #[test]
+    fn shared_affine_transform_preserves_vector_coordinate_composition() {
+        let axes = Axes2DState::new(
+            NumberRange::new(-2.0, 2.0, 1.0).unwrap(),
+            NumberRange::new(-2.0, 2.0, 1.0).unwrap(),
+            4.0,
+            4.0,
+        )
+        .unwrap();
+        let transform = Transform2D {
+            translation: Vec2::new(3.0, -1.0),
+            rotation: 0.6,
+            scale: Vec2::new(1.5, 1.5),
+        };
+        let transformed = TransformedAxes2DState::new(axes, transform, transform);
+
+        let expected = transform.transform_point(Vec2::new(1.0, -0.5));
+        let actual = transformed.coords_to_point(1.0, -0.5).unwrap();
+        assert_point(actual, expected);
+        let round_trip = transformed.point_to_coords(actual).unwrap();
+        assert_close(round_trip.0, 1.0);
+        assert_close(round_trip.1, -0.5);
+    }
+
+    #[test]
+    fn independent_axis_scales_use_each_retained_line_transform() {
+        let axes = Axes2DState::new(
+            NumberRange::new(-2.0, 2.0, 1.0).unwrap(),
+            NumberRange::new(-2.0, 2.0, 1.0).unwrap(),
+            4.0,
+            4.0,
+        )
+        .unwrap();
+        let x_transform = Transform2D {
+            translation: Vec2::new(2.0, 3.0),
+            rotation: 0.0,
+            scale: Vec2::new(2.0, 1.0),
+        };
+        let y_transform = Transform2D {
+            translation: Vec2::new(2.0, 3.0),
+            rotation: 0.0,
+            scale: Vec2::new(1.0, 3.0),
+        };
+        let transformed = TransformedAxes2DState::new(axes, x_transform, y_transform);
+
+        let point = transformed.coords_to_point(1.0, 1.0).unwrap();
+        assert_point(point, Vec2::new(4.0, 6.0));
+        let coords = transformed.point_to_coords(point).unwrap();
+        assert_close(coords.0, 1.0);
+        assert_close(coords.1, 1.0);
+    }
+
+    #[test]
+    fn positive_only_axis_origin_shift_matches_manim_after_transform() {
+        let axes = Axes2DState::new(
+            NumberRange::new(2.0, 6.0, 1.0).unwrap(),
+            NumberRange::new(-1.0, 3.0, 1.0).unwrap(),
+            8.0,
+            4.0,
+        )
+        .unwrap();
+        let transform = Transform2D {
+            translation: Vec2::new(-1.0, 2.0),
+            rotation: -0.3,
+            scale: Vec2::new(0.75, 0.75),
+        };
+        let transformed = TransformedAxes2DState::new(axes, transform, transform);
+        let base_point = axes.coords_to_point(4.0, 1.0).unwrap();
+        assert_point(
+            transformed.coords_to_point(4.0, 1.0).unwrap(),
+            transform.transform_point(base_point),
+        );
+    }
+
+    #[test]
+    fn collapsed_retained_axis_rejects_projection() {
+        let axes = Axes2DState::new(
+            NumberRange::new(-1.0, 1.0, 1.0).unwrap(),
+            NumberRange::new(-1.0, 1.0, 1.0).unwrap(),
+            2.0,
+            2.0,
+        )
+        .unwrap();
+        let collapsed = Transform2D {
+            translation: Vec2::ZERO,
+            rotation: 0.0,
+            scale: Vec2::ZERO,
+        };
+        let transformed = TransformedAxes2DState::new(axes, collapsed, Transform2D::IDENTITY);
+        assert_eq!(
+            transformed.point_to_coords(Vec2::ZERO),
+            Err(CoordinateSystemError::DegenerateLine)
+        );
+    }
+}

--- a/crates/noon/src/lib.rs
+++ b/crates/noon/src/lib.rs
@@ -8,8 +8,10 @@
 
 mod analytic_geometry_authoring;
 mod arc_authoring;
+mod axis_tick_authoring;
 mod camera_authoring;
 mod coordinate_system_authoring;
+mod coordinate_transform_authoring;
 mod elbow_authoring;
 mod geometry_authoring;
 mod legacy;
@@ -25,8 +27,10 @@ mod text_authoring;
 
 pub use analytic_geometry_authoring::*;
 pub use arc_authoring::*;
+pub use axis_tick_authoring::*;
 pub use camera_authoring::*;
 pub use coordinate_system_authoring::*;
+pub use coordinate_transform_authoring::*;
 pub use elbow_authoring::*;
 pub use geometry_authoring::*;
 pub use legacy::*;
@@ -44,16 +48,19 @@ pub use text_authoring::*;
 pub mod prelude {
     pub use crate::legacy::prelude::*;
     pub use crate::{
-        axes_function_vector_path, parametric_vector_path, AnnularSector, Annulus, Arc,
-        ArcAuthoringError, ArcBetweenPoints, Axes2DState, BackgroundRectangle,
+        axes_function_vector_path, parametric_vector_path, transformed_axes_function_vector_path,
+        transformed_axes_sampled_values_vector_path, AnnularSector, Annulus, Arc,
+        ArcAuthoringError, ArcBetweenPoints, Axes2DState, AxisTickError, BackgroundRectangle,
         CoordinateSystemError, Cross, Dot, Elbow, ElbowAuthoringError, Ellipse,
         GeometryAuthoringError, LineMatcherAuthoringError, MathTypst, MovingCameraScene,
-        NumberLineState, NumberRange, ParametricSamplePlan, PlotGeometryError, PlotRangeRequest,
-        PlotSamplingError, Polygon, Polygram, PolygramAuthoringError, ReactiveScene,
-        ReactiveTimelineScene, RegularPolygon, RegularPolygram, RetainedMobject, RetainedScene,
-        RoundedRectangle, RoundedRectangleAuthoringError, SampleRange, SampleSpan, Sector,
-        ShapeMatcherAuthoringError, Star, SurroundingRectangle, Text, TextAuthoringError, Triangle,
-        Typst, Underline, ValueTracker, VectorSignal, BACKGROUND_RECTANGLE_DEFAULT_FILL_OPACITY,
+        NumberLineGeometryPlan, NumberLineState, NumberLineTick, NumberLineTickOptions,
+        NumberRange, ParametricSamplePlan, PlotGeometryError, PlotRangeRequest, PlotSamplingError,
+        Polygon, Polygram, PolygramAuthoringError, ReactiveScene, ReactiveTimelineScene,
+        RegularPolygon, RegularPolygram, RetainedMobject, RetainedScene, RoundedRectangle,
+        RoundedRectangleAuthoringError, SampleRange, SampleSpan, Sector,
+        ShapeMatcherAuthoringError, Star, SurroundingRectangle, Text, TextAuthoringError,
+        TransformedAxes2DState, TransformedNumberLineState, Triangle, Typst, Underline,
+        ValueTracker, VectorSignal, BACKGROUND_RECTANGLE_DEFAULT_FILL_OPACITY,
         DEFAULT_CROSS_SCALE_FACTOR, DEFAULT_CROSS_STROKE_WIDTH, DEFAULT_DOT_RADIUS,
         DEFAULT_ELBOW_ANGLE, DEFAULT_ELBOW_WIDTH, DEFAULT_NATIVE_TEXT_FONT_FAMILY,
         DEFAULT_NATIVE_TEXT_FONT_SIZE, DEFAULT_ROUNDED_RECTANGLE_CORNER_RADIUS,

--- a/crates/noon/src/plot_geometry_authoring.rs
+++ b/crates/noon/src/plot_geometry_authoring.rs
@@ -1,4 +1,7 @@
-use crate::{Axes2DState, CoordinateSystemError, ParametricSamplePlan, PlotSamplingError};
+use crate::{
+    Axes2DState, CoordinateSystemError, ParametricSamplePlan, PlotSamplingError,
+    TransformedAxes2DState,
+};
 use noon_core::{Vec2, VectorPath};
 use noon_geometry::{smooth_cubic_path_from_subpaths, PathSmoothingError};
 
@@ -25,41 +28,91 @@ where
 }
 
 /// Compile the initial Manim-compatible `Axes.plot(function)` subset.
-///
-/// Parameters come from [`ParametricSamplePlan`], `function` is evaluated once
-/// per parameter, and [`Axes2DState`] owns the coordinate-to-scene mapping. With
-/// `use_smoothing=true`, the mapped anchors pass through the shared Manim cubic
-/// spline implementation in `noon-geometry`; otherwise they remain corners.
 pub fn axes_function_vector_path<F>(
     axes: Axes2DState,
     plan: &ParametricSamplePlan,
-    mut function: F,
+    function: F,
     use_smoothing: bool,
 ) -> Result<VectorPath, PlotGeometryError>
 where
     F: FnMut(f64) -> f64,
+{
+    axes_function_vector_path_with_mapper(plan, function, use_smoothing, |x, y| {
+        axes.coords_to_point(x, y)
+    })
+}
+
+/// Compile `Axes.plot(function)` against the current retained x/y-axis transforms.
+///
+/// This is the transform-safe path for an Axes family that has already been shifted,
+/// rotated, or scaled. Sampling and smoothing remain identical to the initial path;
+/// only coordinate mapping reads the current retained affine placement.
+pub fn transformed_axes_function_vector_path<F>(
+    axes: TransformedAxes2DState,
+    plan: &ParametricSamplePlan,
+    function: F,
+    use_smoothing: bool,
+) -> Result<VectorPath, PlotGeometryError>
+where
+    F: FnMut(f64) -> f64,
+{
+    axes_function_vector_path_with_mapper(plan, function, use_smoothing, |x, y| {
+        axes.coords_to_point(x, y)
+    })
+}
+
+fn axes_function_vector_path_with_mapper<F, M>(
+    plan: &ParametricSamplePlan,
+    mut function: F,
+    use_smoothing: bool,
+    mut coords_to_point: M,
+) -> Result<VectorPath, PlotGeometryError>
+where
+    F: FnMut(f64) -> f64,
+    M: FnMut(f64, f64) -> Result<Vec2, CoordinateSystemError>,
 {
     build_sampled_path(plan, use_smoothing, |parameter| {
         let value = function(parameter);
         if !value.is_finite() {
             return Err(PlotGeometryError::NonFiniteFunctionValue { parameter, value });
         }
-        Ok(axes.coords_to_point(parameter, value)?)
+        Ok(coords_to_point(parameter, value)?)
     })
 }
 
 /// Finish an `Axes.plot` after a host frontend evaluates the user callback.
-///
-/// Rust remains authoritative for parameter generation, sample cardinality,
-/// coordinate mapping, finite-value validation, smoothing, and final geometry.
-/// The host only supplies one scalar result for each parameter previously exposed
-/// by [`ParametricSamplePlan::parameter_subpaths`].
 pub fn axes_sampled_values_vector_path(
     axes: Axes2DState,
     plan: &ParametricSamplePlan,
     value_subpaths: &[Vec<f64>],
     use_smoothing: bool,
 ) -> Result<VectorPath, PlotGeometryError> {
+    axes_sampled_values_vector_path_with_mapper(plan, value_subpaths, use_smoothing, |x, y| {
+        axes.coords_to_point(x, y)
+    })
+}
+
+/// Finish host-evaluated plot samples against current retained Axes transforms.
+pub fn transformed_axes_sampled_values_vector_path(
+    axes: TransformedAxes2DState,
+    plan: &ParametricSamplePlan,
+    value_subpaths: &[Vec<f64>],
+    use_smoothing: bool,
+) -> Result<VectorPath, PlotGeometryError> {
+    axes_sampled_values_vector_path_with_mapper(plan, value_subpaths, use_smoothing, |x, y| {
+        axes.coords_to_point(x, y)
+    })
+}
+
+fn axes_sampled_values_vector_path_with_mapper<M>(
+    plan: &ParametricSamplePlan,
+    value_subpaths: &[Vec<f64>],
+    use_smoothing: bool,
+    mut coords_to_point: M,
+) -> Result<VectorPath, PlotGeometryError>
+where
+    M: FnMut(f64, f64) -> Result<Vec2, CoordinateSystemError>,
+{
     let parameter_subpaths = plan.parameter_subpaths()?;
     if value_subpaths.len() != parameter_subpaths.len() {
         return Err(PlotGeometryError::SampleSubpathCountMismatch {
@@ -84,7 +137,7 @@ pub fn axes_sampled_values_vector_path(
             if !value.is_finite() {
                 return Err(PlotGeometryError::NonFiniteFunctionValue { parameter, value });
             }
-            points.push(axes.coords_to_point(parameter, value)?);
+            points.push(coords_to_point(parameter, value)?);
         }
         point_subpaths.push(points);
     }
@@ -220,7 +273,7 @@ impl From<PathSmoothingError> for PlotGeometryError {
 mod tests {
     use super::*;
     use crate::{NumberRange, SampleRange};
-    use noon_core::PathCommand;
+    use noon_core::{PathCommand, Transform2D};
 
     fn assert_point(actual: Vec2, expected: Vec2) {
         assert!(
@@ -285,6 +338,67 @@ mod tests {
         assert!(matches!(path.commands()[0], PathCommand::MoveTo { .. }));
         assert!(matches!(path.commands()[1], PathCommand::CubicTo { .. }));
         assert!(matches!(path.commands()[2], PathCommand::CubicTo { .. }));
+    }
+
+    #[test]
+    fn transformed_host_samples_follow_current_axis_affine_state() {
+        let axes = test_axes();
+        let transform = Transform2D {
+            translation: Vec2::new(2.0, -1.0),
+            rotation: 0.5,
+            scale: Vec2::new(1.25, 1.25),
+        };
+        let transformed = TransformedAxes2DState::new(axes, transform, transform);
+        let plan = ParametricSamplePlan::without_discontinuities(
+            SampleRange::new(-1.0, 1.0, 1.0).unwrap(),
+        );
+        let path = transformed_axes_sampled_values_vector_path(
+            transformed,
+            &plan,
+            &[vec![1.0, 0.0, 1.0]],
+            false,
+        )
+        .unwrap();
+
+        let expected = [
+            transform.transform_point(Vec2::new(-1.0, 1.0)),
+            transform.transform_point(Vec2::ZERO),
+            transform.transform_point(Vec2::new(1.0, 1.0)),
+        ];
+        for (command, expected) in path.commands().iter().zip(expected) {
+            match command {
+                PathCommand::MoveTo { to } | PathCommand::LineTo { to } => {
+                    assert_point(*to, expected)
+                }
+                other => panic!("expected corner path command, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn transformed_direct_callback_is_evaluated_once_per_parameter() {
+        let axes = test_axes();
+        let transform = Transform2D {
+            translation: Vec2::new(-3.0, 2.0),
+            rotation: -0.35,
+            scale: Vec2::new(0.8, 0.8),
+        };
+        let transformed = TransformedAxes2DState::new(axes, transform, transform);
+        let plan = ParametricSamplePlan::without_discontinuities(
+            SampleRange::new(-1.0, 1.0, 1.0).unwrap(),
+        );
+        let mut calls = Vec::new();
+        transformed_axes_function_vector_path(
+            transformed,
+            &plan,
+            |x| {
+                calls.push(x);
+                x * x
+            },
+            true,
+        )
+        .unwrap();
+        assert_eq!(calls, vec![-1.0, 0.0, 1.0]);
     }
 
     #[test]

--- a/crates/noon/tests/axis_tick_authoring.rs
+++ b/crates/noon/tests/axis_tick_authoring.rs
@@ -1,0 +1,97 @@
+use noon::{
+    Axes2DState, NumberLineGeometryPlan, NumberLineState, NumberLineTickOptions, NumberRange,
+};
+use noon_core::{GeometryRef, Vec2, GREEN};
+
+fn endpoints(snapshot: &noon_core::ObjectSnapshot) -> (Vec2, Vec2) {
+    let GeometryRef::Line { start, end } = snapshot.geometry else {
+        panic!("expected retained line geometry");
+    };
+    (start, end)
+}
+
+#[test]
+fn default_ticks_are_independent_retained_lines() {
+    let state =
+        NumberLineState::centered(NumberRange::new(-2.0, 2.0, 1.0).unwrap(), 4.0, 0.0).unwrap();
+    let plan = NumberLineGeometryPlan::new(state, &NumberLineTickOptions::default()).unwrap();
+    assert_eq!(plan.ticks().len(), 5);
+    let origin = &plan.ticks()[2];
+    let (start, end) = endpoints(origin.snapshot());
+    assert_eq!(origin.value(), 0.0);
+    assert!((start.y + 0.1).abs() <= 1.0e-6);
+    assert!((end.y - 0.1).abs() <= 1.0e-6);
+}
+
+#[test]
+fn canonical_plot_axis_excludes_origin_and_elongates_requested_ticks() {
+    let axes = Axes2DState::new(
+        NumberRange::new(-10.0, 10.3, 1.0).unwrap(),
+        NumberRange::new(-1.5, 1.5, 1.0).unwrap(),
+        10.0,
+        6.0,
+    )
+    .unwrap();
+    let options = NumberLineTickOptions {
+        elongated_values: (-5..=5).map(|index| f64::from(index * 2)).collect(),
+        exclude_origin_tick: true,
+        color: GREEN,
+        ..NumberLineTickOptions::default()
+    };
+    let plan = NumberLineGeometryPlan::new(axes.x_axis(), &options).unwrap();
+    assert_eq!(plan.ticks().len(), 20);
+    assert!(plan.ticks().iter().all(|tick| tick.value() != 0.0));
+    assert_eq!(
+        plan.ticks()
+            .iter()
+            .find(|tick| tick.value() == 2.0)
+            .unwrap()
+            .size(),
+        0.2
+    );
+    assert_eq!(
+        plan.ticks()
+            .iter()
+            .find(|tick| tick.value() == 1.0)
+            .unwrap()
+            .size(),
+        0.1
+    );
+    assert!((plan.line().style.stroke_width - 0.02).abs() <= 1.0e-6);
+}
+
+#[test]
+fn vertical_axis_ticks_rotate_with_axis_geometry() {
+    let axes = Axes2DState::new(
+        NumberRange::new(-2.0, 2.0, 1.0).unwrap(),
+        NumberRange::new(-2.0, 2.0, 1.0).unwrap(),
+        4.0,
+        4.0,
+    )
+    .unwrap();
+    let options = NumberLineTickOptions {
+        exclude_origin_tick: true,
+        ..NumberLineTickOptions::default()
+    };
+    let plan = NumberLineGeometryPlan::new(axes.y_axis(), &options).unwrap();
+    let tick = plan
+        .ticks()
+        .iter()
+        .find(|tick| tick.value() == 1.0)
+        .unwrap();
+    let (start, end) = endpoints(tick.snapshot());
+    assert!((start.y - end.y).abs() <= 1.0e-6);
+    assert!(((end.x - start.x).abs() - 0.2).abs() <= 1.0e-6);
+}
+
+#[test]
+fn disabling_ticks_keeps_axis_line_without_hidden_tick_geometry() {
+    let state =
+        NumberLineState::centered(NumberRange::new(0.0, 2.0, 1.0).unwrap(), 2.0, 0.0).unwrap();
+    let options = NumberLineTickOptions {
+        include_ticks: false,
+        ..NumberLineTickOptions::default()
+    };
+    let plan = NumberLineGeometryPlan::new(state, &options).unwrap();
+    assert!(plan.ticks().is_empty());
+}

--- a/scripts/build-web-demo.sh
+++ b/scripts/build-web-demo.sh
@@ -49,6 +49,7 @@ node --check scripts/host-callback-perf.mjs
 node --check scripts/deterministic-replay-smoke.mjs
 node --check scripts/cross-language-parity.mjs
 node --check scripts/manim-compat-smoke.mjs
+node --check scripts/manim-axes-smoke.mjs
 node --check scripts/manim-tutorial-smoke.mjs
 node --check scripts/playground-layout-smoke.mjs
 node --check scripts/composition-authoring-smoke.mjs
@@ -72,6 +73,7 @@ PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile \
   web/python/_manim_rate_functions.py \
   web/python/_manim_phase_b.py \
   web/python/_manim_shared_geometry.py \
+  web/python/_manim_axes.py \
   web/python/_manim_animation_options.py \
   web/python/_manim_animate.py \
   web/python/_manim_rotate.py \

--- a/scripts/manim-axes-smoke.mjs
+++ b/scripts/manim-axes-smoke.mjs
@@ -1,0 +1,197 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import playwright from "playwright";
+
+const { chromium } = playwright;
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const port = 4185;
+const baseUrl = `http://127.0.0.1:${port}`;
+
+let serverOutput = "";
+const server = spawn(
+  "python3",
+  ["-m", "http.server", String(port), "--bind", "127.0.0.1", "--directory", repoRoot],
+  { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] },
+);
+server.stdout.on("data", (chunk) => (serverOutput += chunk));
+server.stderr.on("data", (chunk) => (serverOutput += chunk));
+
+async function waitForServer() {
+  let lastError = null;
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    try {
+      const response = await fetch(`${baseUrl}/web/manim-compat-smoke.html`);
+      if (response.ok) return;
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Axes smoke server did not start: ${lastError}\n${serverOutput}`);
+}
+
+const axesSource = `
+from noon import *
+import json
+import math
+import _manim_semantic_handles as _handles
+
+
+def assert_close(actual, expected, tolerance=1e-5):
+    assert abs(float(actual) - float(expected)) <= tolerance, (actual, expected)
+
+
+def assert_point_close(actual, expected, tolerance=1e-5):
+    assert_close(actual.x, expected.x, tolerance)
+    assert_close(actual.y, expected.y, tolerance)
+
+
+def assert_three_point_graph_matches_axes(axes, graph):
+    handle = _handles._handle_for(graph)
+    assert handle is not None
+    snapshot = json.loads(str(handle.snapshotJson()))
+    commands = snapshot["geometry"]["vector_path"]["commands"]
+    assert len(commands) == 3
+    expected_points = [axes.c2p(value, value) for value in (-1.0, 0.0, 1.0)]
+    for command, expected in zip(commands, expected_points):
+        payload = command.get("move_to") or command.get("line_to")
+        assert payload is not None, command
+        actual = payload["to"]
+        assert_close(actual["x"], expected.x)
+        assert_close(actual["y"], expected.y)
+
+
+class RetainedAxesPlot(Scene):
+    def construct(self):
+        axes = Axes(
+            x_range=[-10, 10.3, 1],
+            y_range=[-1.5, 1.5, 1],
+            x_length=10,
+            y_length=6,
+            axis_config={"color": GREEN},
+            x_axis_config={
+                "numbers_with_elongated_ticks": [-10, -8, -6, -4, -2, 0, 2, 4, 6, 8, 10],
+            },
+            tips=False,
+        )
+        assert isinstance(axes, VGroup)
+        assert len(axes.x_axis.ticks) == 20
+        assert len(axes.y_axis.ticks) == 2
+        assert len(axes.get_axes()) == 2
+        assert issubclass(FunctionGraph, ParametricFunction)
+
+        point = axes.c2p(3.25, -0.75)
+        recovered = axes.p2c(point)
+        assert_close(recovered[0], 3.25)
+        assert_close(recovered[1], -0.75)
+
+        probe_calls = []
+        axes.plot(
+            lambda x: (probe_calls.append(x), x * x)[1],
+            x_range=[-1, 1, 1],
+            use_smoothing=False,
+        )
+        assert probe_calls == [-1.0, 0.0, 1.0]
+
+        copied = axes.copy()
+        assert isinstance(copied, Axes)
+        assert copied is not axes
+        assert copied.x_axis is not axes.x_axis
+        assert copied.y_axis is not axes.y_axis
+        original_origin = axes.get_origin()
+        assert_point_close(copied.get_origin(), original_origin)
+        copied.to_corner(UL)
+        assert (copied.get_origin() - original_origin).length() > 0.25
+        assert_point_close(axes.get_origin(), original_origin)
+        copied_point = copied.c2p(3.25, -0.75)
+        copied_coords = copied.p2c(copied_point)
+        assert_close(copied_coords[0], 3.25)
+        assert_close(copied_coords[1], -0.75)
+        copied_identity = copied.plot(
+            lambda x: x,
+            x_range=[-1, 1, 1],
+            use_smoothing=False,
+        )
+        assert_three_point_graph_matches_axes(copied, copied_identity)
+
+        origin_before = axes.get_origin()
+        axes.shift(RIGHT * 1.25 + UP * 0.5)
+        axes.scale(0.8)
+        axes.rotate(0.35)
+        origin_after = axes.get_origin()
+        assert (origin_after - origin_before).length() > 0.25
+
+        transformed_point = axes.c2p(3.25, -0.75)
+        transformed_coords = axes.p2c(transformed_point)
+        assert_close(transformed_coords[0], 3.25)
+        assert_close(transformed_coords[1], -0.75)
+
+        identity_graph = axes.plot(
+            lambda x: x,
+            x_range=[-1, 1, 1],
+            use_smoothing=False,
+            color=YELLOW,
+        )
+        assert isinstance(identity_graph, ParametricFunction)
+        assert_three_point_graph_matches_axes(axes, identity_graph)
+
+        sin_graph = axes.plot(lambda x: math.sin(x), color=BLUE)
+        cos_graph = axes.plot(lambda x: math.cos(x), color=RED)
+        assert isinstance(sin_graph, ParametricFunction)
+        assert isinstance(cos_graph, ParametricFunction)
+        self.add(axes, sin_graph, cos_graph)
+`;
+
+let browser = null;
+try {
+  await waitForServer();
+  browser = await chromium.launch({
+    channel: "chromium",
+    headless: true,
+    args: ["--disable-dev-shm-usage"],
+  });
+  const page = await browser.newPage();
+  const errors = [];
+  page.on("pageerror", (error) => errors.push(`pageerror: ${error}`));
+  page.on("console", (message) => {
+    if (message.type() === "error") errors.push(`console: ${message.text()}`);
+  });
+
+  await page.goto(`${baseUrl}/web/manim-compat-smoke.html`, { waitUntil: "load" });
+  await page.waitForFunction(() => window.noonManimCompat, null, { timeout: 30_000 });
+  await page.evaluate(() => window.noonManimCompat.ready());
+
+  const result = await page.evaluate(
+    (pythonSource) => window.noonManimCompat.run(pythonSource),
+    axesSource,
+  );
+  assert.equal(result.kind, "scene_document");
+  assert.equal(result.document.objects.length, 26);
+  assert.equal(result.document.tracks.length, 0);
+
+  const geometryKinds = result.document.objects.map(
+    (object) => Object.keys(object.geometry)[0],
+  );
+  assert.equal(
+    geometryKinds.filter((kind) => kind === "line").length,
+    24,
+    "Axes must flatten to retained line/tick leaves",
+  );
+  assert.equal(
+    geometryKinds.filter((kind) => kind === "vector_path").length,
+    2,
+    "Axes.plot must lower to ordinary retained VectorPath curves",
+  );
+  assert.deepEqual(errors, [], `browser errors while testing retained Axes:\n${errors.join("\n")}`);
+  console.log(
+    "Retained Axes smoke passed: VGroup type, copy/placement independence, shared line/tick families, transform-safe c2p/p2c, exact transformed plot points, and ParametricFunction results.",
+  );
+} finally {
+  await browser?.close();
+  server.kill("SIGTERM");
+}

--- a/web/python-compat-modules.js
+++ b/web/python-compat-modules.js
@@ -9,6 +9,7 @@ export const PYTHON_COMPAT_MODULES = Object.freeze([
   { sourcePath: "python/_manim_phase_b.py", runtimePath: "/tmp/_manim_phase_b.py", label: "Noon Manim Phase B layer" },
   { sourcePath: "python/_manim_geometry.py", runtimePath: "/tmp/_manim_geometry.py", label: "Noon Manim geometry layer" },
   { sourcePath: "python/_manim_shared_geometry.py", runtimePath: "/tmp/_manim_shared_geometry.py", label: "Noon shared Rust geometry adapter" },
+  { sourcePath: "python/_manim_axes.py", runtimePath: "/tmp/_manim_axes.py", label: "Noon shared Axes adapter" },
   { sourcePath: "python/_manim_animation_options.py", runtimePath: "/tmp/_manim_animation_options.py", label: "Noon Manim animation options" },
   { sourcePath: "python/_manim_animate.py", runtimePath: "/tmp/_manim_animate.py", label: "Noon Manim animate layer" },
   { sourcePath: "python/_manim_rotate.py", runtimePath: "/tmp/_manim_rotate.py", label: "Noon Manim Rotate layer" },

--- a/web/python-worker.source.js
+++ b/web/python-worker.source.js
@@ -50,6 +50,12 @@ async function initializePyodide() {
   const authoringStore = new WasmAuthoringStore();
   self.noonCreateAuthoringMobjectHandle = (snapshotJson) =>
     authoringStore.createMobject(snapshotJson);
+  self.noonCreateAxesAuthoringPlan = (requestJson) =>
+    authoringStore.createAxesAuthoringPlan(requestJson);
+  self.noonCreateAxesQueryPlan = (requestJson) =>
+    authoringStore.createAxesQueryPlan(requestJson);
+  self.noonCreateAxesPlotPlan = (requestJson) =>
+    authoringStore.createAxesPlotPlan(requestJson);
   self.noonCreateAuthoringDotHandle = (pointX, pointY, radius) =>
     authoringStore.createMobject(manimDotSnapshotJson(pointX, pointY, radius));
   self.noonCreateAuthoringTriangleHandle = () =>
@@ -104,6 +110,8 @@ import _manim_semantic_handles
 _manim_semantic_handles.install()
 import _manim_shared_geometry
 _manim_shared_geometry.install()
+import _manim_axes
+_manim_axes.install()
 import _manim_animate
 import _manim_rotate
 _manim_rotate.install()

--- a/web/python/_manim_axes.py
+++ b/web/python/_manim_axes.py
@@ -1,0 +1,363 @@
+"""Initial ManimCE v0.21 linear Axes facade over shared Rust semantics.
+
+The supported subset deliberately excludes tips and text/number labels until those
+rendering paths are parity-qualified. Axis placement, ticks, coordinate queries,
+plot sampling, smoothing, and path construction remain Rust-owned.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from typing import Any, Callable, Sequence
+
+import noon as _base
+import _manim_compat as _compat
+import _manim_semantic_handles as _shared
+
+try:
+    from js import noonCreateAuthoringMobjectHandle as _create_mobject_handle
+    from js import noonCreateAxesAuthoringPlan as _create_axes_plan
+    from js import noonCreateAxesPlotPlan as _create_plot_plan
+    from js import noonCreateAxesQueryPlan as _create_query_plan
+except ImportError:
+    _create_mobject_handle = None
+    _create_axes_plan = None
+    _create_plot_plan = None
+    _create_query_plan = None
+
+_INSTALLED = False
+
+
+def _require_shared_axes() -> None:
+    if any(
+        factory is None
+        for factory in (
+            _create_mobject_handle,
+            _create_axes_plan,
+            _create_plot_plan,
+            _create_query_plan,
+        )
+    ):
+        raise RuntimeError("Axes requires Noon's browser shared-semantics runtime")
+
+
+def _range(value: Sequence[float] | None, default: tuple[float, float, float]) -> list[float]:
+    if value is None:
+        return list(default)
+    values = [float(component) for component in value]
+    if len(values) == 2:
+        values.append(1.0)
+    if len(values) != 3 or not all(math.isfinite(component) for component in values):
+        raise ValueError("Axes ranges must contain 2 or 3 finite values")
+    return values
+
+
+def _rgba(value: object) -> list[float]:
+    if not isinstance(value, _base.Color):
+        raise TypeError("axis color must be a Noon/Manim Color")
+    return [float(value.red), float(value.green), float(value.blue), float(value.alpha)]
+
+
+def _axis_config(value: dict[str, Any] | None) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise TypeError("axis configuration must be a dict or None")
+    result = dict(value)
+    if "color" in result:
+        result["color"] = _rgba(result["color"])
+    if "numbers_with_elongated_ticks" in result:
+        result["numbers_with_elongated_ticks"] = [
+            float(number) for number in result["numbers_with_elongated_ticks"]
+        ]
+    return result
+
+
+def _plain_copy(value: object) -> object:
+    """Clone JSON-safe facade metadata without touching any WASM proxy."""
+
+    return json.loads(json.dumps(value, separators=(",", ":"), allow_nan=False))
+
+
+def _snapshot_handle(snapshot: dict[str, Any]):
+    assert _create_mobject_handle is not None
+    return _create_mobject_handle(json.dumps(snapshot, separators=(",", ":"), allow_nan=False))
+
+
+def _mobject_from_snapshot(cls: type[_base.Mobject], snapshot: dict[str, Any]) -> _base.Mobject:
+    value = object.__new__(cls)
+    _shared._attach_shared_handle(value, _snapshot_handle(snapshot))
+    return value
+
+
+def _line_from_snapshot(snapshot: dict[str, Any]) -> _compat.Line:
+    value = _mobject_from_snapshot(_compat.Line, snapshot)
+    geometry = snapshot.get("geometry", {}).get("line")
+    if not isinstance(geometry, dict):
+        raise TypeError("shared Axes line snapshot is malformed")
+    start = geometry["start"]
+    end = geometry["end"]
+    value.start = _base.Vec2(float(start["x"]), float(start["y"]))
+    value.end = _base.Vec2(float(end["x"]), float(end["y"]))
+    return value
+
+
+class ParametricFunction(_compat.VMobject):
+    """Source-visible retained curve type produced by :meth:`Axes.plot`.
+
+    The current browser slice owns scalar Axes plots through the shared two-phase Rust
+    plan. Direct ParametricFunction authoring needs the more general vector-valued
+    callback plan and therefore fails explicitly rather than constructing a Python-only
+    geometry path.
+    """
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        del args, kwargs
+        raise NotImplementedError(
+            "direct ParametricFunction construction is not yet supported by the shared browser plan"
+        )
+
+    def get_function(self) -> Callable[[float], object]:
+        return self.function
+
+    def get_point_from_function(self, value: float) -> object:
+        return self.function(float(value))
+
+
+class FunctionGraph(ParametricFunction):
+    """Source-visible FunctionGraph type pending direct shared callback authoring."""
+
+
+class _NumberLineFamily(_compat.VGroup):
+    """Retained main line plus tick leaves for the initial NumberLine subset."""
+
+    def __init__(self, wire: dict[str, Any]) -> None:
+        self._line = _line_from_snapshot(wire["line"])
+        self.ticks = _compat.VGroup(
+            *(_line_from_snapshot(tick["snapshot"]) for tick in wire["ticks"])
+        )
+        super().__init__(self._line, self.ticks)
+
+    def get_start(self) -> _base.Vec2:
+        return self._line.get_start()
+
+    def get_end(self) -> _base.Vec2:
+        return self._line.get_end()
+
+    def _axis_snapshot_json(self) -> str:
+        handle = _shared._handle_for(self._line)
+        if handle is None:
+            raise RuntimeError("Axes main line no longer has an authoritative shared handle")
+        return str(handle.snapshotJson())
+
+
+class Axes(_compat.VGroup):
+    """Shared linear 2D Axes subset with transform-safe c2p/p2c and plotting."""
+
+    def __init__(
+        self,
+        x_range: Sequence[float] | None = None,
+        y_range: Sequence[float] | None = None,
+        x_length: float | None = 12.0,
+        y_length: float | None = 6.0,
+        axis_config: dict[str, Any] | None = None,
+        x_axis_config: dict[str, Any] | None = None,
+        y_axis_config: dict[str, Any] | None = None,
+        tips: bool = True,
+        **kwargs: Any,
+    ) -> None:
+        _require_shared_axes()
+        if kwargs:
+            unsupported = ", ".join(sorted(kwargs))
+            raise NotImplementedError(f"unsupported Axes option(s): {unsupported}")
+        if x_length is None or y_length is None:
+            raise NotImplementedError("automatic Axes length resolution is not yet supported")
+
+        self.x_range = _range(x_range, (-7.0, 7.0, 1.0))
+        self.y_range = _range(y_range, (-4.0, 4.0, 1.0))
+        self.x_length = float(x_length)
+        self.y_length = float(y_length)
+        self.axis_config = _axis_config(axis_config)
+        self.x_axis_config = _axis_config(x_axis_config)
+        self.y_axis_config = _axis_config(y_axis_config)
+        self._base_request = {
+            "x_range": self.x_range,
+            "y_range": self.y_range,
+            "x_length": self.x_length,
+            "y_length": self.y_length,
+        }
+        request = {
+            **self._base_request,
+            "tips": bool(tips),
+            "axis_config": self.axis_config,
+            "x_axis_config": self.x_axis_config,
+            "y_axis_config": self.y_axis_config,
+        }
+        assert _create_axes_plan is not None and _create_query_plan is not None
+        self._axes_plan = _create_axes_plan(json.dumps(request, separators=(",", ":")))
+        self._query_plan = _create_query_plan(
+            json.dumps(self._base_request, separators=(",", ":"))
+        )
+        wire = json.loads(str(self._axes_plan.geometryJson()))
+        self.x_axis = _NumberLineFamily(wire["x_axis"])
+        self.y_axis = _NumberLineFamily(wire["y_axis"])
+        self.axes = _compat.VGroup(self.x_axis, self.y_axis)
+        super().__init__(*self.axes)
+
+    def copy(self) -> Axes:
+        """Clone retained axis families while sharing immutable Rust plans.
+
+        Generic Group copying deep-copies subclass metadata. Pyodide WASM plans are
+        immutable JsProxy values and must not cross that host-language deepcopy path.
+        The copied leaves receive fresh shared semantic identities through their normal
+        Group/Mobject copy adapters, while both Axes wrappers may safely reference the
+        same immutable construction/query plans because every query supplies its own
+        current retained line snapshots.
+        """
+
+        clone = object.__new__(type(self))
+        clone.x_range = list(self.x_range)
+        clone.y_range = list(self.y_range)
+        clone.x_length = self.x_length
+        clone.y_length = self.y_length
+        clone.axis_config = _plain_copy(self.axis_config)
+        clone.x_axis_config = _plain_copy(self.x_axis_config)
+        clone.y_axis_config = _plain_copy(self.y_axis_config)
+        clone._base_request = _plain_copy(self._base_request)
+        clone._axes_plan = self._axes_plan
+        clone._query_plan = self._query_plan
+        clone.x_axis = self.x_axis.copy()
+        clone.y_axis = self.y_axis.copy()
+        clone.axes = _compat.VGroup(clone.x_axis, clone.y_axis)
+        _compat.VGroup.__init__(clone, clone.x_axis, clone.y_axis)
+        return clone
+
+    def get_axes(self) -> _compat.VGroup:
+        return self.axes
+
+    def get_axis(self, index: int) -> _NumberLineFamily:
+        return self.axes[index]
+
+    def get_x_axis(self) -> _NumberLineFamily:
+        return self.x_axis
+
+    def get_y_axis(self) -> _NumberLineFamily:
+        return self.y_axis
+
+    def coords_to_point(self, *coords: float) -> _base.Vec2:
+        if len(coords) < 2:
+            raise TypeError("Axes.coords_to_point requires x and y coordinates")
+        if len(coords) > 3 or (len(coords) == 3 and not math.isclose(float(coords[2]), 0.0)):
+            raise NotImplementedError("Noon Axes currently supports 2D coordinates only")
+        result = json.loads(
+            str(
+                self._query_plan.coordsToPointJson(
+                    float(coords[0]),
+                    float(coords[1]),
+                    self.x_axis._axis_snapshot_json(),
+                    self.y_axis._axis_snapshot_json(),
+                )
+            )
+        )
+        return _base.Vec2(float(result[0]), float(result[1]))
+
+    c2p = coords_to_point
+
+    def point_to_coords(self, point: object) -> list[float]:
+        value = _compat._as_vec2(point)
+        result = json.loads(
+            str(
+                self._query_plan.pointToCoordsJson(
+                    float(value.x),
+                    float(value.y),
+                    self.x_axis._axis_snapshot_json(),
+                    self.y_axis._axis_snapshot_json(),
+                )
+            )
+        )
+        return [float(result[0]), float(result[1])]
+
+    p2c = point_to_coords
+
+    def get_origin(self) -> _base.Vec2:
+        return self.coords_to_point(0.0, 0.0)
+
+    def __matmul__(self, coord: object) -> _base.Vec2:
+        if isinstance(coord, (_base.Mobject, _compat.Group)):
+            coord = coord.get_center()
+        try:
+            return self.coords_to_point(*coord)  # type: ignore[arg-type]
+        except TypeError as error:
+            raise TypeError("Axes @ value expects a coordinate sequence or Mobject") from error
+
+    def __rmatmul__(self, point: object) -> list[float]:
+        return self.point_to_coords(point)
+
+    def plot(
+        self,
+        function: Callable[[float], float],
+        x_range: Sequence[float] | None = None,
+        use_smoothing: bool = True,
+        discontinuities: Sequence[float] | None = None,
+        dt: float = 1.0e-8,
+        color: _base.Color | None = None,
+        **kwargs: Any,
+    ) -> ParametricFunction:
+        if kwargs:
+            unsupported = ", ".join(sorted(kwargs))
+            raise NotImplementedError(f"unsupported Axes.plot option(s): {unsupported}")
+        if not callable(function):
+            raise TypeError("Axes.plot function must be callable")
+        request = {
+            **self._base_request,
+            "plot_range": None if x_range is None else [float(value) for value in x_range],
+            "discontinuities": (
+                None
+                if discontinuities is None
+                else [float(value) for value in discontinuities]
+            ),
+            "discontinuity_dt": float(dt),
+            "use_smoothing": bool(use_smoothing),
+        }
+        assert _create_plot_plan is not None
+        plan = _create_plot_plan(json.dumps(request, separators=(",", ":"), allow_nan=False))
+        parameters = json.loads(str(plan.parametersJson()))
+        values = [
+            [float(function(float(parameter))) for parameter in subpath]
+            for subpath in parameters
+        ]
+        snapshot_json = str(
+            plan.finishSnapshotJsonWithAxes(
+                json.dumps(values, separators=(",", ":"), allow_nan=False),
+                self.x_axis._axis_snapshot_json(),
+                self.y_axis._axis_snapshot_json(),
+            )
+        )
+        graph = object.__new__(ParametricFunction)
+        assert _create_mobject_handle is not None
+        _shared._attach_shared_handle(graph, _create_mobject_handle(snapshot_json))
+        graph.function = lambda value: self.coords_to_point(float(value), function(float(value)))
+        graph.underlying_function = function
+        graph.x_range = self.x_range if x_range is None else list(x_range)
+        graph.axes = self
+        if color is not None:
+            graph.set_color(color)
+        return graph
+
+
+def install() -> None:
+    global _INSTALLED
+    if _INSTALLED:
+        return
+    public = {
+        "Axes": Axes,
+        "ParametricFunction": ParametricFunction,
+        "FunctionGraph": FunctionGraph,
+    }
+    for name, value in public.items():
+        setattr(_base, name, value)
+        setattr(_compat, name, value)
+        if name not in _base.__all__:
+            _base.__all__.append(name)
+    _INSTALLED = True


### PR DESCRIPTION
## Summary
- add the first public ManimCE-style `Axes` facade for the explicitly supported linear 2D subset
- preserve Manim-facing public shape: `Axes` is a `VGroup`, and `Axes.plot(...)` returns a `ParametricFunction`; `FunctionGraph` is source-visible while direct general callback construction remains explicitly unsupported
- materialize x/y axis lines and ticks from Rust `AxesAuthoringPlan` snapshots as ordinary shared semantic handles
- keep each axis as a retained family so axis and whole-Axes transforms move its ticks together
- route c2p/p2c through `WasmAxesQueryPlan` using the current retained main-line snapshots
- route `Axes.plot` through `WasmAxesPlotPlan`: Python only evaluates the user callback at Rust-provided parameters; Rust owns mapping, validation, smoothing, and final `VectorPath`
- preserve `Axes.copy()` without constructor replay: copied x/y retained families receive fresh semantic identities and named references are remapped, while immutable Rust/WASM authoring/query plans are shared rather than deep-copying JS proxies
- expose Axes/query/plot plans through small extensions on the existing `WasmAuthoringStore`, avoiding a second browser semantic store
- fail closed on tips, labels, unknown Axes options, and unsupported plot options rather than rendering incomplete parity
- add a required real Pyodide/WASM browser smoke covering callback cardinality, retained family shape, copy/placement independence, transformed c2p/p2c, and exact transformed plot endpoints

## Architecture
This branch is the transform-capable successor to the earlier #718/#720 path; those drafts are closed as superseded. The immutable-plan design from #718 and transform-blocking facade from #720 are replaced by #723 plus current-retained-snapshot query/plot plans.

It intentionally keeps text/numeric labels out: current compatibility `MathTex` is not parity-qualified, so labeled upstream gallery scenes remain blocked instead of receiving placeholder geometry.

Transforms remain single-owner: normal retained mobject/family handles own axis transforms. Query and plot calls feed the current main-line snapshots back into Rust, which derives `TransformedAxes2DState`; Python never decodes or mirrors transform state.

Copying likewise preserves ownership boundaries: retained leaf/family state is copied through the shared semantic-handle path, custom `Axes` child attributes are remapped to those copied families, and immutable semantic plans are reused. No copied Axes reconstructs coordinate semantics in Python.

## Supported first slice
- linear 2D Axes with explicit or default ranges/lengths
- `tips=False`
- normal/elongated retained ticks and supported axis style config
- `get_axes`, `get_axis`, `get_x_axis`, `get_y_axis`, c2p/p2c/get_origin
- static `Axes.plot` with x_range, smoothing, discontinuities/dt, and color
- shift/scale/rotate-safe coordinate queries and plots
- constructor-free `Axes.copy()` with independent retained family placement
- Manim-facing `VGroup` / `ParametricFunction` type relationships for this slice

## Browser validation
`node scripts/manim-axes-smoke.mjs` runs through the real Pyodide/WASM authoring worker and asserts:
- canonical label-free Axes flatten to 24 retained line/tick leaves
- explicit `[-1, 1, 1]` plot evaluation invokes the Python callback exactly at `[-1, 0, 1]`
- c2p/p2c round-trip before and after Axes shift/scale/rotate
- a copied Axes has independent retained families/named x/y references and can be placed independently (`to_corner`) without moving its source
- a three-point graph authored after those transforms has Rust-produced `VectorPath` endpoints equal to `axes.c2p(x, f(x))`
- visible sin/cos graphs are ordinary retained paths and public `ParametricFunction` instances

## Exact-head qualification
Current clean head: `ecce99f3390a3a11e774aa43b2d28c14a89e2c24` (one commit on #714 base).

All 15 workflows attached to this exact head are completed successfully: CI (Rust, package, browser authoring including retained Axes plotting, reactive/editor, WebGL, WebGPU, backend visual parity), test coverage, Manim API coverage, Manim semantic differential, Manim raster differential including direct-seek/incremental equivalence, playground cross-browser (Chromium/Firefox/WebKit), platform/release, renderer recovery, render-mode switching, retained Text/Typst, and playground authoring/lifecycle/playback/resize recovery.

The PR remains draft only because the connected GitHub `markPullRequestReadyForReview` mutation still fails before reaching the repository with an invalid GraphQL selection on `Repository.fullDatabaseId`. The code head itself is fully qualified; do not close/recreate the PR merely to bypass connector tooling.

## Deliberately unsupported
- tips
- numeric labels / `include_numbers`
- axis/graph labels and MathTex-dependent helpers
- non-linear scaling / 3D coordinate systems
- direct general `ParametricFunction` / `FunctionGraph` construction
- broad ParametricFunction kwargs not yet represented by shared semantics

Tracks #695 / #696 / parent #85. Stacked integration PR; prerequisites should merge independently before final flattening.