### PR TITLE
Adapt retained authoring into canonical SceneSpec

### DIFF
--- a/crates/noon-ir/src/mixed.rs
+++ b/crates/noon-ir/src/mixed.rs
@@ -45,6 +45,27 @@ pub enum TextSpecKind {
     MathTex,
 }
 
+/// Backend-specific source/layout options that participate in text compilation identity.
+///
+/// Presentation remains on `ObjectSpec`; this enum carries only source/layout policy
+/// that must survive the canonical authoring boundary.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TextSpecOptions {
+    #[default]
+    Default,
+    NativePlain {
+        font_family: String,
+        line_spacing: f32,
+    },
+}
+
+impl TextSpecOptions {
+    fn is_default(&self) -> bool {
+        matches!(self, Self::Default)
+    }
+}
+
 /// Backend-source text definition before compilation into immutable retained resources.
 ///
 /// Presentation is deliberately absent. Transform, color, opacity and painter order
@@ -55,6 +76,8 @@ pub struct TextSpec {
     pub kind: TextSpecKind,
     pub source: String,
     pub font_size: f32,
+    #[serde(default, skip_serializing_if = "TextSpecOptions::is_default")]
+    pub options: TextSpecOptions,
 }
 
 impl TextSpec {
@@ -63,6 +86,24 @@ impl TextSpec {
             kind,
             source: source.into(),
             font_size,
+            options: TextSpecOptions::Default,
+        }
+    }
+
+    pub fn native_plain(
+        source: impl Into<String>,
+        font_family: impl Into<String>,
+        font_size: f32,
+        line_spacing: f32,
+    ) -> Self {
+        Self {
+            kind: TextSpecKind::Plain,
+            source: source.into(),
+            font_size,
+            options: TextSpecOptions::NativePlain {
+                font_family: font_family.into(),
+                line_spacing,
+            },
         }
     }
 
@@ -75,11 +116,28 @@ impl TextSpec {
     }
 
     pub fn validate(&self) -> Result<(), SceneSpecError> {
-        if self.source.is_empty() {
+        if self.source.is_empty() && self.kind != TextSpecKind::Plain {
             return Err(SceneSpecError::EmptyTextSource);
         }
         if !self.font_size.is_finite() || self.font_size <= 0.0 {
             return Err(SceneSpecError::InvalidTextFontSize(self.font_size));
+        }
+        match &self.options {
+            TextSpecOptions::Default => {}
+            TextSpecOptions::NativePlain {
+                font_family,
+                line_spacing,
+            } => {
+                if self.kind != TextSpecKind::Plain {
+                    return Err(SceneSpecError::NativeTextOptionsRequirePlain(self.kind));
+                }
+                if font_family.trim().is_empty() {
+                    return Err(SceneSpecError::EmptyNativeTextFontFamily);
+                }
+                if !line_spacing.is_finite() || *line_spacing < -1.0 {
+                    return Err(SceneSpecError::InvalidNativeTextLineSpacing(*line_spacing));
+                }
+            }
         }
         Ok(())
     }
@@ -332,6 +390,9 @@ pub enum SceneSpecError {
     UnsupportedVersion(u32),
     EmptyTextSource,
     InvalidTextFontSize(f32),
+    NativeTextOptionsRequirePlain(TextSpecKind),
+    EmptyNativeTextFontFamily,
+    InvalidNativeTextLineSpacing(f32),
     DuplicateObject(ObjectId),
     DuplicatePainterOrder(u32),
     PainterOrderOutOfRange {
@@ -364,6 +425,17 @@ impl std::fmt::Display for SceneSpecError {
             Self::InvalidTextFontSize(size) => {
                 write!(formatter, "text font_size must be finite and positive, got {size}")
             }
+            Self::NativeTextOptionsRequirePlain(kind) => write!(
+                formatter,
+                "native plain-text options require plain text content, got {kind:?}"
+            ),
+            Self::EmptyNativeTextFontFamily => {
+                formatter.write_str("native plain-text font family must not be empty")
+            }
+            Self::InvalidNativeTextLineSpacing(value) => write!(
+                formatter,
+                "native plain-text line spacing must be finite and at least -1, got {value}"
+            ),
             Self::DuplicateObject(object) => {
                 write!(formatter, "duplicate SceneSpec object {}", object.get())
             }
@@ -682,6 +754,57 @@ mod tests {
         let decoded = SceneSpec::from_json(&json).unwrap();
         assert_eq!(decoded, mixed);
         assert_eq!(decoded.objects[1].id, ObjectId::new(100));
+    }
+
+    #[test]
+    fn native_plain_options_round_trip_without_changing_scene_spec_version() {
+        let text = TextSpec::native_plain("A\nB", "DejaVu Sans Mono", 48.0, 0.5);
+        let spec = SceneSpec::new(
+            vec![ObjectSpec::text(ObjectId::new(100), text.clone())],
+            Vec::new(),
+        )
+        .unwrap();
+        let decoded = SceneSpec::from_json(&spec.to_json().unwrap()).unwrap();
+        assert_eq!(decoded.version, SCENE_SPEC_VERSION);
+        let ObjectSpecContent::Text(decoded_text) = &decoded.objects[0].content else {
+            panic!("native text must remain source-level text");
+        };
+        assert_eq!(decoded_text, &text);
+        assert!(matches!(
+            &decoded_text.options,
+            TextSpecOptions::NativePlain { font_family, line_spacing }
+                if font_family == "DejaVu Sans Mono" && *line_spacing == 0.5
+        ));
+    }
+
+    #[test]
+    fn native_plain_allows_empty_source_but_validates_layout_options() {
+        TextSpec::native_plain("", "DejaVu Sans Mono", 48.0, -1.0)
+            .validate()
+            .unwrap();
+        assert!(matches!(
+            TextSpec::native_plain("x", "", 48.0, -1.0).validate(),
+            Err(SceneSpecError::EmptyNativeTextFontFamily)
+        ));
+        assert!(matches!(
+            TextSpec::native_plain("x", "DejaVu Sans Mono", 48.0, -1.5).validate(),
+            Err(SceneSpecError::InvalidNativeTextLineSpacing(-1.5))
+        ));
+        let mut typst = TextSpec::typst("x", 48.0);
+        typst.options = TextSpecOptions::NativePlain {
+            font_family: "DejaVu Sans Mono".to_owned(),
+            line_spacing: -1.0,
+        };
+        assert!(matches!(
+            typst.validate(),
+            Err(SceneSpecError::NativeTextOptionsRequirePlain(
+                TextSpecKind::Typst
+            ))
+        ));
+        assert!(matches!(
+            TextSpec::typst("", 48.0).validate(),
+            Err(SceneSpecError::EmptyTextSource)
+        ));
     }
 
     #[test]

--- a/crates/noon-web/src/lib.rs
+++ b/crates/noon-web/src/lib.rs
@@ -25,6 +25,7 @@ mod reactive_player;
 mod retained_authoring;
 mod retained_authoring_player;
 mod retained_authoring_scene;
+mod retained_authoring_scene_spec;
 mod retained_authoring_tracks;
 mod retained_authoring_wire_scene;
 mod retained_execution_canvas;
@@ -59,6 +60,7 @@ pub use reactive_player::*;
 pub use retained_authoring::*;
 pub use retained_authoring_player::*;
 pub use retained_authoring_scene::MixedRetainedAuthoringError;
+pub use retained_authoring_scene_spec::*;
 pub use retained_authoring_tracks::*;
 pub use retained_authoring_wire_scene::MixedRetainedAuthoringScene;
 #[cfg(target_arch = "wasm32")]

--- a/crates/noon-web/src/retained_authoring_scene_spec.rs
+++ b/crates/noon-web/src/retained_authoring_scene_spec.rs
@@ -1,0 +1,301 @@
+use std::collections::BTreeMap;
+
+use noon_core::{ObjectId, SceneDefinition, Style, Vec2};
+use noon_ir::{
+    ObjectSpec, OrderedTextObjectSpec, SceneDocument, SceneSpec, SceneSpecError, TextSpec,
+};
+
+use crate::{
+    materialize_retained_tracks, RetainedAuthoringDocument, RetainedAuthoringTextObject,
+    RetainedTextAuthoringSpec, RetainedTextBackendSpec, RetainedTrackAuthoringSpec,
+    RetainedTrackMaterializationError,
+};
+
+/// Adapt the current geometry document + retained-text sidecar into the canonical
+/// `noon_ir::SceneSpec` established by #391.
+///
+/// The compatibility-only text `order` field is consumed here and disappears into
+/// `SceneSpec::objects`; transform/style move onto the ordinary `ObjectSpec` and
+/// retained animation tracks join the ordinary `TrackDefinition` domain. Existing
+/// producers and the old mixed retained runtime remain supported while #367 migrates
+/// consumers incrementally.
+pub fn retained_authoring_scene_spec(
+    legacy: &SceneDefinition,
+    retained: RetainedAuthoringDocument,
+    retained_tracks: Vec<RetainedTrackAuthoringSpec>,
+) -> Result<SceneSpec, RetainedAuthoringSceneSpecError> {
+    retained
+        .validate()
+        .map_err(RetainedAuthoringSceneSpecError::RetainedDocument)?;
+
+    let scale_factors = retained_scale_factors(&retained.objects);
+    let tracks = materialize_retained_tracks(legacy.tracks(), retained_tracks, &scale_factors)?;
+    let ordered_text = retained
+        .objects
+        .into_iter()
+        .map(ordered_text_object)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let legacy = SceneDocument::from_scene(legacy);
+    let mut spec = SceneSpec::from_legacy_with_ordered_text(&legacy, ordered_text)?;
+    spec.tracks = tracks;
+    spec.validate()?;
+    Ok(spec)
+}
+
+#[derive(Debug)]
+pub enum RetainedAuthoringSceneSpecError {
+    RetainedDocument(String),
+    TrackMaterialization(RetainedTrackMaterializationError),
+    SceneSpec(SceneSpecError),
+}
+
+impl std::fmt::Display for RetainedAuthoringSceneSpecError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::RetainedDocument(error) => formatter.write_str(error),
+            Self::TrackMaterialization(error) => error.fmt(formatter),
+            Self::SceneSpec(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl std::error::Error for RetainedAuthoringSceneSpecError {}
+
+impl From<RetainedTrackMaterializationError> for RetainedAuthoringSceneSpecError {
+    fn from(value: RetainedTrackMaterializationError) -> Self {
+        Self::TrackMaterialization(value)
+    }
+}
+
+impl From<SceneSpecError> for RetainedAuthoringSceneSpecError {
+    fn from(value: SceneSpecError) -> Self {
+        Self::SceneSpec(value)
+    }
+}
+
+fn ordered_text_object(
+    object: RetainedAuthoringTextObject,
+) -> Result<OrderedTextObjectSpec, SceneSpecError> {
+    let RetainedAuthoringTextObject {
+        object: id,
+        order,
+        text,
+    } = object;
+    let RetainedTextAuthoringSpec {
+        source,
+        backend,
+        font_size,
+        transform,
+        color,
+        opacity,
+    } = text;
+
+    let text = match backend {
+        RetainedTextBackendSpec::Native {
+            font_family,
+            line_spacing,
+        } => TextSpec::native_plain(source, font_family, font_size, line_spacing),
+        RetainedTextBackendSpec::Typst { math: false } => TextSpec::typst(source, font_size),
+        RetainedTextBackendSpec::Typst { math: true } => TextSpec::math_typst(source, font_size),
+    };
+    let mut object = ObjectSpec::text(id, text);
+    object.transform = transform;
+    object.style = Style {
+        fill: Some(color),
+        stroke: None,
+        stroke_width: 0.0,
+        opacity,
+        ..Style::default()
+    };
+    OrderedTextObjectSpec::new(order, object)
+}
+
+fn retained_scale_factors(objects: &[RetainedAuthoringTextObject]) -> BTreeMap<ObjectId, Vec2> {
+    objects
+        .iter()
+        .map(|object| {
+            let factor = match &object.text.backend {
+                RetainedTextBackendSpec::Native { .. } => noon::NATIVE_POINT_TO_SCENE_SCALE,
+                RetainedTextBackendSpec::Typst { .. } => {
+                    object.text.font_size * noon::SCALE_FACTOR_PER_FONT_POINT
+                }
+            };
+            (object.object, Vec2::new(factor, factor))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use noon_core::{
+        Color, GeometryRef, ObjectId, Property, RateFunction, TrackTiming, TrackValues,
+        Transform2D, Vec2,
+    };
+    use noon_ir::{ObjectSpecContent, TextSpecKind, TextSpecOptions};
+
+    use super::*;
+    use crate::MixedRetainedAuthoringScene;
+
+    fn native_spec(source: &str) -> RetainedTextAuthoringSpec {
+        RetainedTextAuthoringSpec::native(source, "DejaVu Sans Mono", 48.0, 0.5).unwrap()
+    }
+
+    fn retained_document(
+        object: ObjectId,
+        order: u32,
+        text: RetainedTextAuthoringSpec,
+    ) -> RetainedAuthoringDocument {
+        RetainedAuthoringDocument::new(vec![RetainedAuthoringTextObject {
+            object,
+            order,
+            text,
+        }])
+        .unwrap()
+    }
+
+    #[test]
+    fn retained_native_text_adapts_into_existing_scene_spec_contract() {
+        let mut legacy = SceneDefinition::new();
+        let circle = legacy.add(GeometryRef::circle(0.25));
+        let square = legacy.add(GeometryRef::rectangle(0.5, 0.5));
+        let text_id = ObjectId::new(1_u64 << 52);
+        let mut text = native_spec("A\nB");
+        text.transform = Transform2D {
+            translation: Vec2::new(1.0, -2.0),
+            rotation: 0.25,
+            scale: Vec2::new(1.5, 0.75),
+        };
+        text.set_color(Color::rgba(0.2, 0.4, 0.8, 1.0)).unwrap();
+        text.set_opacity(0.6).unwrap();
+
+        let spec =
+            retained_authoring_scene_spec(&legacy, retained_document(text_id, 1, text), Vec::new())
+                .unwrap();
+
+        assert_eq!(
+            spec.objects
+                .iter()
+                .map(|object| object.id)
+                .collect::<Vec<_>>(),
+            vec![circle, text_id, square]
+        );
+        let ObjectSpecContent::Text(text) = &spec.objects[1].content else {
+            panic!("middle object must be canonical source-level text");
+        };
+        assert_eq!(text.kind, TextSpecKind::Plain);
+        assert_eq!(text.source, "A\nB");
+        assert!(matches!(
+            &text.options,
+            TextSpecOptions::NativePlain { font_family, line_spacing }
+                if font_family == "DejaVu Sans Mono" && *line_spacing == 0.5
+        ));
+        assert_eq!(spec.objects[1].transform.translation, Vec2::new(1.0, -2.0));
+        assert_eq!(spec.objects[1].transform.rotation, 0.25);
+        assert_eq!(spec.objects[1].transform.scale, Vec2::new(1.5, 0.75));
+        assert_eq!(
+            spec.objects[1].style.fill,
+            Some(Color::rgba(0.2, 0.4, 0.8, 1.0))
+        );
+        assert_eq!(spec.objects[1].style.opacity, 0.6);
+    }
+
+    #[test]
+    fn retained_tracks_join_canonical_track_domain_with_existing_normalization() {
+        let legacy = SceneDefinition::new();
+        let text_id = ObjectId::new(1_u64 << 52);
+        let retained = retained_document(text_id, 0, native_spec("Shrink"));
+        let track = RetainedTrackAuthoringSpec::new(
+            text_id,
+            Property::Scale,
+            TrackValues::Vec2 {
+                from: Vec2::ONE,
+                to: Vec2::ZERO,
+            },
+            TrackTiming::new(0.0, 1.0, RateFunction::Linear),
+        );
+
+        let spec = retained_authoring_scene_spec(&legacy, retained, vec![track]).unwrap();
+        assert_eq!(spec.tracks.len(), 1);
+        assert_eq!(spec.tracks[0].object, text_id);
+        assert_eq!(
+            spec.tracks[0].values,
+            TrackValues::Vec2 {
+                from: Vec2::new(
+                    noon::NATIVE_POINT_TO_SCENE_SCALE,
+                    noon::NATIVE_POINT_TO_SCENE_SCALE,
+                ),
+                to: Vec2::ZERO,
+            }
+        );
+    }
+
+    #[test]
+    fn scene_spec_adapter_matches_current_split_path_identity_tracks_and_camera() {
+        let mut legacy = SceneDefinition::new();
+        let camera = legacy.add(GeometryRef::rectangle(14.0, 8.0));
+        let geometry = legacy.add(GeometryRef::circle(0.5));
+        assert!(legacy.set_camera_object(camera));
+        let text_id = ObjectId::new(1_u64 << 52);
+        let retained = retained_document(text_id, 1, native_spec("middle"));
+        let track = RetainedTrackAuthoringSpec::new(
+            text_id,
+            Property::Opacity,
+            TrackValues::Scalar {
+                from: 1.0,
+                to: 0.25,
+            },
+            TrackTiming::new(0.0, 0.5, RateFunction::Linear),
+        );
+
+        let canonical =
+            retained_authoring_scene_spec(&legacy, retained.clone(), vec![track.clone()]).unwrap();
+        let current =
+            MixedRetainedAuthoringScene::from_parts_with_tracks(&legacy, retained, vec![track])
+                .unwrap();
+
+        assert_eq!(
+            canonical
+                .objects
+                .iter()
+                .map(|object| object.id)
+                .collect::<Vec<_>>(),
+            current
+                .scene()
+                .objects()
+                .iter()
+                .map(|object| object.id)
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(canonical.tracks, current.tracks());
+        assert_eq!(canonical.camera_object, current.camera_object());
+        assert_eq!(canonical.objects[0].id, camera);
+        assert_eq!(canonical.objects[2].id, geometry);
+    }
+
+    #[test]
+    fn typst_backends_map_without_backend_specific_payloads() {
+        let legacy = SceneDefinition::new();
+        for (math, kind) in [
+            (false, TextSpecKind::Typst),
+            (true, TextSpecKind::MathTypst),
+        ] {
+            let id = ObjectId::new((1_u64 << 52) + u64::from(math));
+            let retained = retained_document(
+                id,
+                0,
+                RetainedTextAuthoringSpec::new("x^2", math, 72.0).unwrap(),
+            );
+            let spec = retained_authoring_scene_spec(&legacy, retained, Vec::new()).unwrap();
+            let ObjectSpecContent::Text(text) = &spec.objects[0].content else {
+                panic!("retained Typst must remain source-level text");
+            };
+            assert_eq!(text.kind, kind);
+            assert!(matches!(text.options, TextSpecOptions::Default));
+            let json = spec.to_json().unwrap();
+            for forbidden in ["glyph", "font_bytes", "svg", "atlas"] {
+                assert!(!json.contains(forbidden));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- reuse the existing canonical `noon_ir::SceneSpec` / `ObjectSpec` contract from #391 rather than introducing a second mixed scene model
- add lossless native plain-text source/layout options to `TextSpec` for `font_family` and `line_spacing`, while keeping transform/style on `ObjectSpec`
- adapt the current `SceneDefinition + RetainedAuthoringDocument + retained tracks` inputs into `SceneSpec`
- consume transitional retained `order` at the adapter boundary so `SceneSpec::objects` remains the sole painter-order stream
- materialize retained tracks into the ordinary `TrackDefinition` domain and preserve camera identity
- keep the existing `MixedRetainedAuthoringScene` runtime path unchanged for the next migration step

## Architecture

This is migration step 2 of #367, building on #391. There is exactly one canonical mixed authoring representation: `noon_ir::SceneSpec`.

The current split producer shape remains a compatibility input:

```text
SceneDefinition + RetainedAuthoringDocument + retained tracks
                         |
                         v
                 noon_ir::SceneSpec
       Vec<ObjectSpec> = sole painter order
       Geometry | source-level TextSpec
       one ObjectId / TrackDefinition domain
```

Native Text options are content/layout inputs and therefore live in typed `TextSpecOptions::NativePlain`. Presentation-only transform/color/opacity remain on the owning `ObjectSpec`, preserving compile/cache identity boundaries.

JSON remains transport/debug/export; no glyph arrays, font bytes, SVG, vectorized outlines, atlas state, fake `GeometryRef::Text`, or overlay renderer are introduced.

## Validation

Focused pre-commit qualification passed:
- `cargo fmt --all`
- `cargo test -p noon-ir --lib`
- `cargo test -p noon-web --lib`
- `cargo clippy -p noon-ir -p noon-web --all-targets --all-features -- -D warnings`

Regression coverage includes:
- geometry -> native Text -> geometry in the canonical object vector
- native `font_family` / `line_spacing` SceneSpec round-trip and validation
- empty native plain Text support matching the native compiler
- common ObjectSpec transform/style preservation
- retained scale-track normalization into ordinary tracks
- identity/track/camera equivalence with the current split retained runtime path
- Typst/MathTypst source-level mapping with no renderer payloads

## Scope boundary

This PR does **not** switch the worker/runtime compiler to consume `SceneSpec` directly and does not remove the retained sidecar or special text-ID allocator yet. Those remain the next bounded #367 steps after this adapter is qualified.

Tracks #367. Related #61.