### PR TITLE
Add fast pull request CI gate

### DIFF
--- a/.github/workflows/authoring-render-mode-switch.yml
+++ b/.github/workflows/authoring-render-mode-switch.yml
@@ -1,19 +1,6 @@
 name: Authoring render mode switch
 
 on:
-  pull_request:
-    paths:
-      - ".github/workflows/authoring-render-mode-switch.yml"
-      - "crates/noon-render-wgpu/**"
-      - "crates/noon-text-render-wgpu/**"
-      - "crates/noon-web/**"
-      - "scripts/authoring-render-mode-switch-smoke.mjs"
-      - "scripts/authoring-render-prepare-smoke.mjs"
-      - "scripts/build-web-demo.sh"
-      - "web/authoring-render-worker.js"
-      - "web/execution-engine-worker.js"
-      - "web/retained-execution-engine-worker.js"
-      - "web/execution-transport.js"
   push:
     branches:
       - master
@@ -49,12 +36,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Use stable Rust
         run: |
           rustup default stable
           rustup target add wasm32-unknown-unknown
-
       - name: Cache Cargo sources
         uses: actions/cache@v4
         with:
@@ -64,43 +49,35 @@ jobs:
           key: ${{ runner.os }}-cargo-sources-${{ hashFiles('Cargo.toml', 'crates/**/Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-sources-
-
       - name: Use sccache
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
           version: v0.16.0
-
       - name: Install pinned wasm-pack
         uses: taiki-e/install-action@13608cbb45b01feb47ef444ab1a42dc41ad56f1a # v2.79.11
         with:
           tool: wasm-pack@0.15.0
           fallback: none
-
       - name: Validate mode-switch sources
         run: |
           node --check web/authoring-render-worker.js
           node --check scripts/authoring-render-mode-switch-smoke.mjs
           node --check scripts/authoring-render-prepare-smoke.mjs
-
       - name: Build browser package
         env:
           NOON_SKIP_PLAYGROUND_TEST: "1"
           NOON_WASM_SKIP_OPT: "1"
         run: bash scripts/build-web-demo.sh
-
       - name: Cache Playwright Chromium
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-chromium-1.62.1
-
       - name: Install Playwright Chromium
         run: |
           npm install --no-save --ignore-scripts playwright@1.62.1
           npx playwright install chromium
-
       - name: Prepare one retained render owner before engine selection
         run: node scripts/authoring-render-prepare-smoke.mjs
-
       - name: Switch legacy retained legacy on one render owner
         run: node scripts/authoring-render-mode-switch-smoke.mjs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 
 on:
-  pull_request:
   push:
     branches:
       - master
@@ -116,36 +115,28 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Download browser package
         uses: actions/download-artifact@v4
         with:
           name: web-pkg
           path: web
-
       - name: Cache Playwright Chromium
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-chromium-1.62.1
-
       - name: Install browser smoke dependencies
         run: |
           npm install --no-save --ignore-scripts playwright@1.62.1 pngjs@7.0.0
           npx playwright install chromium
-
       - name: Test Rust/Python semantic parity
         run: node scripts/cross-language-parity.mjs
-
       - name: Test deterministic seek/playback/rewind in WASM
         run: node scripts/deterministic-replay-smoke.mjs
-
       - name: Test Manim-style Python compatibility
         run: node scripts/manim-compat-smoke.mjs
-
       - name: Test Manim composition authoring
         run: node scripts/composition-authoring-smoke.mjs
-
       - name: Test executable Manim tutorial corpus
         run: node scripts/manim-tutorial-smoke.mjs
 
@@ -156,54 +147,40 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Download browser package
         uses: actions/download-artifact@v4
         with:
           name: web-pkg
           path: web
-
       - name: Cache Playwright Chromium
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-chromium-1.62.1
-
       - name: Install browser smoke dependencies
         run: |
           npm install --no-save --ignore-scripts playwright@1.62.1 pngjs@7.0.0
           npx playwright install chromium
-
       - name: Test playground viewport layout
         run: node scripts/playground-layout-smoke.mjs
-
       - name: Test native reactive Python authoring
         run: node scripts/reactive-authoring-smoke.mjs
-
       - name: Test native reactive browser runtime
         run: node scripts/reactive-runtime-smoke.mjs
-
       - name: Test native browser input signals
         run: node scripts/native-input-smoke.mjs
-
       - name: Test Python updater callback bridge
         run: node scripts/updater-callback-smoke.mjs
-
       - name: Test engine/render worker transports
         run: node scripts/execution-worker-smoke.mjs
-
       - name: Test mixed retained worker transports
         run: node scripts/retained-execution-worker-smoke.mjs
-
       - name: Test Python authoring execution routing
         run: node scripts/authoring-execution-router-smoke.mjs
-
       - name: Test authoring execution termination races
         run: node scripts/authoring-execution-lifecycle-smoke.mjs
-
       - name: Test slow Python callbacks do not block rendering
         run: node scripts/execution-worker-host-smoke.mjs
-
       - name: Test Python editor highlighting and linting
         run: node scripts/python-editor-smoke.mjs
 
@@ -220,40 +197,33 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Download browser package
         uses: actions/download-artifact@v4
         with:
           name: web-pkg
           path: web
-
       - name: Cache Playwright Chromium
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-chromium-1.62.1
-
       - name: Install browser smoke dependencies
         run: |
           npm install --no-save --ignore-scripts playwright@1.62.1 pngjs@7.0.0
           npx playwright install chromium
-
       - name: Test browser rendering
         env:
           NOON_BROWSER_SMOKE_BACKEND: ${{ matrix.backend }}
           NOON_BROWSER_SMOKE_ARTIFACTS: browser-smoke-artifacts/${{ matrix.backend }}
         run: node scripts/browser-smoke.mjs
-
       - name: Test camera backing-density invariance
         env:
           NOON_BROWSER_SMOKE_BACKEND: ${{ matrix.backend }}
           NOON_CAMERA_DENSITY_ARTIFACTS: browser-smoke-artifacts/${{ matrix.backend }}/camera-density
         run: node scripts/camera-density-smoke.mjs
-
       - name: Test mixed painter order in WebGPU
         if: matrix.backend == 'webgpu'
         run: node scripts/painter-order-browser-smoke.mjs
-
       - name: Upload browser smoke screenshots
         if: always()
         uses: actions/upload-artifact@v4
@@ -270,29 +240,24 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Install visual diff dependency
         run: npm install --no-save --ignore-scripts pngjs@7.0.0
-
       - name: Download WebGPU screenshots
         uses: actions/download-artifact@v4
         with:
           name: browser-smoke-screenshots-webgpu
           path: browser-backend-parity
-
       - name: Download WebGL screenshots
         uses: actions/download-artifact@v4
         with:
           name: browser-smoke-screenshots-webgl
           path: browser-backend-parity
-
       - name: Compare WebGPU and WebGL foreground coverage
         run: |
           node scripts/browser-backend-visual-parity.mjs \
             browser-backend-parity/webgpu \
             browser-backend-parity/webgl \
             browser-backend-parity-report
-
       - name: Upload backend visual parity report
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,10 +1,6 @@
 name: Fuzz
 
 on:
-  pull_request:
-    paths:
-      - "fuzz/**"
-      - ".github/workflows/fuzz.yml"
   workflow_dispatch:
   schedule:
     - cron: "23 4 * * 0"
@@ -13,29 +9,8 @@ permissions:
   contents: read
 
 jobs:
-  build:
-    name: Build fuzz targets
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Use nightly Rust
-        run: |
-          rustup toolchain install nightly --profile minimal
-          rustup default nightly
-      - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz --locked
-      - name: Compile all fuzz targets
-        run: |
-          cd fuzz
-          cargo fuzz build scene_decode
-          cargo fuzz build patch_transaction
-          cargo fuzz build tessellation
-          cargo fuzz build morph
-
   fuzz:
     name: ${{ matrix.target }}
-    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/manim-api-coverage.yml
+++ b/.github/workflows/manim-api-coverage.yml
@@ -1,7 +1,9 @@
 name: Manim API coverage
 
 on:
-  pull_request:
+  push:
+    branches:
+      - master
     paths-ignore:
       - "crates/**/tests/**"
   workflow_dispatch:

--- a/.github/workflows/manim-differential.yml
+++ b/.github/workflows/manim-differential.yml
@@ -1,7 +1,9 @@
 name: Manim differential
 
 on:
-  pull_request:
+  push:
+    branches:
+      - master
     paths-ignore:
       - "crates/**/tests/**"
   workflow_dispatch:
@@ -20,12 +22,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-
       - name: Install Manim system dependencies
         run: |
           sudo apt-get update
@@ -34,10 +34,8 @@ jobs:
             libcairo2-dev \
             libpango1.0-dev \
             pkg-config
-
       - name: Install pinned ManimCE reference
         run: python -m pip install --disable-pip-version-check "manim==0.21.0"
-
       - name: Compare supported Noon semantics with ManimCE
         run: |
           python scripts/manim-differential.py

--- a/.github/workflows/manim-raster-differential.yml
+++ b/.github/workflows/manim-raster-differential.yml
@@ -1,9 +1,6 @@
 name: Manim raster differential
 
 on:
-  pull_request:
-    paths-ignore:
-      - "crates/**/tests/**"
   push:
     branches:
       - master
@@ -16,7 +13,7 @@ permissions:
 
 concurrency:
   group: manim-raster-differential-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: true
 
 jobs:
   raster:
@@ -31,15 +28,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Validate raster ratchet policy
         run: node scripts/manim-raster-policy.test.mjs
-
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-
       - name: Install Manim system dependencies
         run: |
           sudo apt-get update
@@ -48,15 +42,12 @@ jobs:
             libcairo2-dev \
             libpango1.0-dev \
             pkg-config
-
       - name: Install pinned ManimCE reference
         run: python -m pip install --disable-pip-version-check "manim[typst]==0.21.0" "typst==0.15.0"
-
       - name: Use stable Rust
         run: |
           rustup default stable
           rustup target add wasm32-unknown-unknown
-
       - name: Cache Cargo sources
         uses: actions/cache@v4
         with:
@@ -66,44 +57,36 @@ jobs:
           key: ${{ runner.os }}-cargo-sources-${{ hashFiles('Cargo.toml', 'crates/**/Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-sources-
-
       - name: Use sccache
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
           version: v0.16.0
-
       - name: Install pinned wasm-pack
         uses: taiki-e/install-action@13608cbb45b01feb47ef444ab1a42dc41ad56f1a # v2.79.11
         with:
           tool: wasm-pack@0.15.0
           fallback: none
-
       - name: Build browser package
         run: bash scripts/build-web-demo.sh
-
       - name: Cache Playwright Chromium
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-chromium-1.62.1
-
       - name: Install raster harness dependencies
         run: |
           npm install --no-save --ignore-scripts playwright@1.62.1 pngjs@7.0.0
           npx playwright install chromium
-
       - name: Render and compare retained Typst fixtures
         env:
           NOON_MANIM_TYPST_RASTER_BACKENDS: webgpu,webgl
           NOON_MANIM_TYPST_RASTER_ARTIFACTS: manim-raster-artifacts/retained-typst
         run: node scripts/manim-typst-raster-differential.mjs
-
       - name: Enforce retained Typst raster ratchets
         env:
           NOON_MANIM_TYPST_RASTER_BACKENDS: webgpu,webgl
           NOON_MANIM_TYPST_RASTER_ARTIFACTS: manim-raster-artifacts/retained-typst
         run: node scripts/manim-typst-raster-enforce.mjs
-
       - name: Upload retained Typst measurement artifacts
         if: always()
         uses: actions/upload-artifact@v4
@@ -112,29 +95,24 @@ jobs:
           path: manim-raster-artifacts/retained-typst
           if-no-files-found: warn
           retention-days: 14
-
       - name: Render and compare canonical Manim scenes
         env:
           NOON_MANIM_RASTER_BACKENDS: webgpu,webgl
           NOON_MANIM_RASTER_ARTIFACTS: manim-raster-artifacts
         run: node scripts/manim-raster-differential.mjs
-
       - name: Capture semantic state at raster frame times
         env:
           NOON_MANIM_RASTER_ARTIFACTS: manim-raster-artifacts
         run: node scripts/manim-raster-semantic-state.mjs
-
       - name: Enforce per-fixture raster ratchet
         env:
           NOON_MANIM_RASTER_ARTIFACTS: manim-raster-artifacts
         run: node scripts/manim-raster-enforce.mjs
-
       - name: Verify direct seek and incremental playback at Manim frame times
         env:
           NOON_MANIM_RASTER_BACKENDS: webgpu,webgl
           NOON_MANIM_RASTER_ARTIFACTS: manim-raster-artifacts
         run: node scripts/manim-seek-playback-raster.mjs
-
       - name: Upload Manim/Noon/diff artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/manim-reference-inventory.yml
+++ b/.github/workflows/manim-reference-inventory.yml
@@ -1,21 +1,6 @@
 name: Manim reference inventory
 
 on:
-  pull_request:
-    paths:
-      - '.github/workflows/manim-reference-inventory.yml'
-      - 'compat/manim-v0.21.0-reference-inventory-lock.json'
-      - 'compat/manim-v0.21.0-reference-coverage-lock.json'
-      - 'parity/manim-v0.21/upstream-examples/**'
-      - 'web/python/examples/manim_tutorial_manifest.json'
-      - 'scripts/manim-reference-inventory.mjs'
-      - 'scripts/manim-reference-inventory.test.mjs'
-      - 'scripts/manim-reference-ledger.mjs'
-      - 'scripts/manim-reference-ledger.test.mjs'
-      - 'scripts/manim-reference-coverage.mjs'
-      - 'scripts/manim-reference-coverage.test.mjs'
-      - 'scripts/manim-reference-classification-lock.mjs'
-      - 'scripts/manim-reference-classification-lock.test.mjs'
   push:
     branches:
       - master
@@ -54,7 +39,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: noon
-
       - name: Checkout pinned ManimCE source
         uses: actions/checkout@v4
         with:
@@ -62,64 +46,35 @@ jobs:
           ref: ${{ env.MANIM_REFERENCE_SHA }}
           path: manim-v0.21.0
           persist-credentials: false
-
       - name: Extract and validate reference inventory
         shell: bash
         run: |
           set -euo pipefail
           actual_sha="$(git -C manim-v0.21.0 rev-parse HEAD)"
           test "$actual_sha" = "$MANIM_REFERENCE_SHA"
-
           mkdir -p noon/artifacts
           node noon/scripts/manim-reference-inventory.mjs manim-v0.21.0 \
             > noon/artifacts/manim-v0.21.0-reference-inventory.json
-
           node - <<'NODE'
           const fs = require("node:fs");
           const path = "noon/artifacts/manim-v0.21.0-reference-inventory.json";
           const inventory = JSON.parse(fs.readFileSync(path, "utf8"));
           const expectedRoots = ["docs/source", "manim"];
-
-          if (inventory.schema_version !== 1) {
-            throw new Error(`unexpected reference inventory schema: ${inventory.schema_version}`);
-          }
-          if (JSON.stringify(inventory.scanned_roots) !== JSON.stringify(expectedRoots)) {
-            throw new Error(`unexpected scanned roots: ${JSON.stringify(inventory.scanned_roots)}`);
-          }
-          if (!Array.isArray(inventory.examples) || inventory.examples.length === 0) {
-            throw new Error("pinned Manim source produced no reference examples");
-          }
-
+          if (inventory.schema_version !== 1) throw new Error(`unexpected reference inventory schema: ${inventory.schema_version}`);
+          if (JSON.stringify(inventory.scanned_roots) !== JSON.stringify(expectedRoots)) throw new Error(`unexpected scanned roots: ${JSON.stringify(inventory.scanned_roots)}`);
+          if (!Array.isArray(inventory.examples) || inventory.examples.length === 0) throw new Error("pinned Manim source produced no reference examples");
           const locations = new Set();
           for (const example of inventory.examples) {
-            if (!Number.isInteger(example.directive_line) || example.directive_line < 1) {
-              throw new Error(`invalid directive line for ${example.source_path}`);
-            }
-            if (
-              typeof example.source_path !== "string" ||
-              !expectedRoots.some(
-                (root) => example.source_path === root || example.source_path.startsWith(`${root}/`),
-              )
-            ) {
-              throw new Error(`example escaped pinned source roots: ${example.source_path}`);
-            }
-            if (typeof example.source_sha256 !== "string" || !/^[0-9a-f]{64}$/u.test(example.source_sha256)) {
-              throw new Error(`invalid source provenance hash at ${example.source_path}:${example.directive_line}`);
-            }
+            if (!Number.isInteger(example.directive_line) || example.directive_line < 1) throw new Error(`invalid directive line for ${example.source_path}`);
+            if (typeof example.source_path !== "string" || !expectedRoots.some((root) => example.source_path === root || example.source_path.startsWith(`${root}/`))) throw new Error(`example escaped pinned source roots: ${example.source_path}`);
+            if (typeof example.source_sha256 !== "string" || !/^[0-9a-f]{64}$/u.test(example.source_sha256)) throw new Error(`invalid source provenance hash at ${example.source_path}:${example.directive_line}`);
             const location = `${example.source_path}:${example.directive_line}`;
-            if (locations.has(location)) {
-              throw new Error(`duplicate reference directive location: ${location}`);
-            }
+            if (locations.has(location)) throw new Error(`duplicate reference directive location: ${location}`);
             locations.add(location);
           }
-
-          fs.appendFileSync(
-            process.env.GITHUB_STEP_SUMMARY,
-            `Extracted ${inventory.examples.length} ManimCE v0.21.0 reference examples from immutable source commit ${process.env.MANIM_REFERENCE_SHA}.\n`,
-          );
+          fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `Extracted ${inventory.examples.length} ManimCE v0.21.0 reference examples from immutable source commit ${process.env.MANIM_REFERENCE_SHA}.\n`);
           console.log(`Validated ${inventory.examples.length} pinned Manim reference examples.`);
           NODE
-
       - name: Verify checked-in reference inventory lock
         shell: bash
         run: |
@@ -129,9 +84,7 @@ jobs:
             noon/compat/manim-v0.21.0-reference-inventory-lock.json \
             > noon/artifacts/manim-v0.21.0-reference-ledger-summary.json
           cat noon/artifacts/manim-v0.21.0-reference-ledger-summary.json
-          printf '\nReference inventory lock verified against the immutable extracted corpus.\n' \
-            >> "$GITHUB_STEP_SUMMARY"
-
+          printf '\nReference inventory lock verified against the immutable extracted corpus.\n' >> "$GITHUB_STEP_SUMMARY"
       - name: Verify classified reference identities
         shell: bash
         run: |
@@ -141,9 +94,7 @@ jobs:
             noon/compat/manim-v0.21.0-reference-coverage-lock.json \
             > noon/artifacts/manim-v0.21.0-reference-classification-lock.json
           cat noon/artifacts/manim-v0.21.0-reference-classification-lock.json
-          printf '\nReference classification identities verified against the checked-in ratchet.\n' \
-            >> "$GITHUB_STEP_SUMMARY"
-
+          printf '\nReference classification identities verified against the checked-in ratchet.\n' >> "$GITHUB_STEP_SUMMARY"
       - name: Reconcile canonical reference coverage
         shell: bash
         run: |
@@ -157,15 +108,9 @@ jobs:
           cat noon/artifacts/manim-v0.21.0-reference-coverage.json
           node - <<'NODE'
           const fs = require("node:fs");
-          const report = JSON.parse(
-            fs.readFileSync("noon/artifacts/manim-v0.21.0-reference-coverage.json", "utf8"),
-          );
-          fs.appendFileSync(
-            process.env.GITHUB_STEP_SUMMARY,
-            `\nReconciled ${report.reconciled_examples}/${report.inventory_examples} pinned reference directives with exact-source canonical manifest entries; ${report.unclassified_inventory_examples} remain to classify.\n`,
-          );
+          const report = JSON.parse(fs.readFileSync("noon/artifacts/manim-v0.21.0-reference-coverage.json", "utf8"));
+          fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\nReconciled ${report.reconciled_examples}/${report.inventory_examples} pinned reference directives with exact-source canonical manifest entries; ${report.unclassified_inventory_examples} remain to classify.\n`);
           NODE
-
       - name: Upload reference inventory
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/platform-release.yml
+++ b/.github/workflows/platform-release.yml
@@ -1,18 +1,6 @@
 name: Platform and release validation
 
 on:
-  pull_request:
-    paths:
-      - Cargo.toml
-      - Cargo.lock
-      - 'crates/**'
-      - '!crates/**/tests/**'
-      - 'scripts/build-web-demo.sh'
-      - 'scripts/build-python-worker.mjs'
-      - 'scripts/check-web-package.mjs'
-      - 'scripts/deterministic-replay-smoke.mjs'
-      - 'web/**'
-      - '.github/workflows/platform-release.yml'
   push:
     branches:
       - master
@@ -52,10 +40,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Use stable Rust
         run: rustup default stable
-
       - name: Cache Cargo sources
         uses: actions/cache@v4
         with:
@@ -65,7 +51,6 @@ jobs:
           key: ${{ runner.os }}-platform-cargo-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'crates/**/Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-platform-cargo-
-
       - name: Compile and test native workspace
         run: cargo test --workspace --all-features --lib --tests
 
@@ -77,10 +62,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Use stable Rust
         run: rustup default stable
-
       - name: Cache Cargo sources
         uses: actions/cache@v4
         with:
@@ -90,7 +73,6 @@ jobs:
           key: release-cargo-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'crates/**/Cargo.toml') }}
           restore-keys: |
             release-cargo-
-
       - name: Test core execution crates in release mode
         run: cargo test --release -p noon-core -p noon-geometry -p noon-runtime --all-features
 
@@ -104,12 +86,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Use stable Rust and WASM target
         run: |
           rustup default stable
           rustup target add wasm32-unknown-unknown
-
       - name: Cache Cargo sources
         uses: actions/cache@v4
         with:
@@ -119,13 +99,11 @@ jobs:
           key: optimized-wasm-cargo-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'crates/**/Cargo.toml') }}
           restore-keys: |
             optimized-wasm-cargo-
-
       - name: Install pinned wasm-pack
         uses: taiki-e/install-action@13608cbb45b01feb47ef444ab1a42dc41ad56f1a # v2.79.11
         with:
           tool: wasm-pack@0.15.0
           fallback: none
-
       - name: Install pinned wasm-opt
         shell: bash
         run: |
@@ -137,12 +115,10 @@ jobs:
           binaryen_dir="$RUNNER_TEMP/binaryen-version_${BINARYEN_VERSION}"
           echo "$binaryen_dir/bin" >> "$GITHUB_PATH"
           "$binaryen_dir/bin/wasm-opt" --version
-
       - name: Build and validate optimized browser package
         env:
           NOON_SKIP_PLAYGROUND_TEST: '1'
         run: bash scripts/build-web-demo.sh
-
       - name: Record optimized WASM size
         shell: bash
         run: |
@@ -156,15 +132,12 @@ jobs:
             echo '- wasm-pack: 0.15.0'
             echo "- Binaryen/wasm-opt: version ${BINARYEN_VERSION}"
           } >> "$GITHUB_STEP_SUMMARY"
-
       - name: Install Chromium smoke dependency
         run: |
           npm install --no-save --ignore-scripts playwright@1.62.1
           npx playwright install chromium
-
       - name: Exercise optimized WASM in Chromium
         run: node scripts/deterministic-replay-smoke.mjs
-
       - name: Upload optimized browser package
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/playground-authoring-recovery.yml
+++ b/.github/workflows/playground-authoring-recovery.yml
@@ -1,14 +1,6 @@
 name: Playground authoring recovery
 
 on:
-  pull_request:
-    paths:
-      - ".github/workflows/playground-authoring-recovery.yml"
-      - "crates/noon-render-wgpu/**"
-      - "crates/noon-web/**"
-      - "scripts/build-web-demo.sh"
-      - "scripts/playground-authoring-error-recovery-smoke.mjs"
-      - "web/**"
   push:
     branches:
       - master
@@ -39,12 +31,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Use stable Rust
         run: |
           rustup default stable
           rustup target add wasm32-unknown-unknown
-
       - name: Cache Cargo sources
         uses: actions/cache@v4
         with:
@@ -54,40 +44,33 @@ jobs:
           key: ${{ runner.os }}-cargo-sources-${{ hashFiles('Cargo.toml', 'crates/**/Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-sources-
-
       - name: Use sccache
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
           version: v0.16.0
-
       - name: Install pinned wasm-pack
         uses: taiki-e/install-action@13608cbb45b01feb47ef444ab1a42dc41ad56f1a # v2.79.11
         with:
           tool: wasm-pack@0.15.0
           fallback: none
-
       - name: Build browser package
         env:
           NOON_SKIP_PLAYGROUND_TEST: "1"
           NOON_WASM_SKIP_OPT: "1"
         run: bash scripts/build-web-demo.sh
-
       - name: Cache Playwright Chromium
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-chromium-1.62.1
-
       - name: Install Playwright Chromium
         run: |
           npm install --no-save --ignore-scripts playwright@1.62.1
           npx playwright install chromium
-
       - name: Test authoring error recovery
         env:
           NOON_PLAYGROUND_AUTHORING_RECOVERY_ARTIFACTS: browser-smoke-artifacts/playground-authoring-recovery
         run: node scripts/playground-authoring-error-recovery-smoke.mjs
-
       - name: Upload authoring recovery diagnostics
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playground-cross-browser.yml
+++ b/.github/workflows/playground-cross-browser.yml
@@ -1,17 +1,6 @@
 name: Playground cross-browser matrix
 
 on:
-  pull_request:
-    paths:
-      - ".github/workflows/playground-cross-browser.yml"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "crates/**"
-      - "!crates/**/tests/**"
-      - "scripts/build-web-demo.sh"
-      - "scripts/build-python-worker.mjs"
-      - "scripts/playground-browser-matrix-smoke.mjs"
-      - "web/**"
   push:
     branches:
       - master
@@ -45,12 +34,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Use stable Rust
         run: |
           rustup default stable
           rustup target add wasm32-unknown-unknown
-
       - name: Cache Cargo sources
         uses: actions/cache@v4
         with:
@@ -60,24 +47,20 @@ jobs:
           key: ${{ runner.os }}-cargo-sources-${{ hashFiles('Cargo.toml', 'crates/**/Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-sources-
-
       - name: Use sccache
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
           version: v0.16.0
-
       - name: Install pinned wasm-pack
         uses: taiki-e/install-action@13608cbb45b01feb47ef444ab1a42dc41ad56f1a # v2.79.11
         with:
           tool: wasm-pack@0.15.0
           fallback: none
-
       - name: Build browser package
         env:
           NOON_SKIP_PLAYGROUND_TEST: "1"
           NOON_WASM_SKIP_OPT: "1"
         run: bash scripts/build-web-demo.sh
-
       - name: Upload browser runtime assets
         uses: actions/upload-artifact@v4
         with:
@@ -106,31 +89,26 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Download browser runtime assets
         uses: actions/download-artifact@v4
         with:
           name: playground-cross-browser-web-runtime
           path: web
-
       - name: Cache Playwright browser
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ matrix.browser }}-1.62.1
-
       - name: Install browser E2E dependencies
         run: |
           npm install --no-save --ignore-scripts playwright@1.62.1
           npx playwright install --with-deps ${{ matrix.browser }}
-
       - name: Test public playground workflow
         env:
           NOON_PLAYGROUND_BROWSER: ${{ matrix.browser }}
           NOON_PLAYGROUND_PROFILE: ${{ matrix.profile }}
           NOON_PLAYGROUND_MATRIX_ARTIFACTS: browser-smoke-artifacts/playground-matrix/${{ matrix.browser }}-${{ matrix.profile }}
         run: node scripts/playground-browser-matrix-smoke.mjs
-
       - name: Upload playground diagnostics
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playground-lifecycle-recovery.yml
+++ b/.github/workflows/playground-lifecycle-recovery.yml
@@ -1,14 +1,6 @@
 name: Playground lifecycle recovery
 
 on:
-  pull_request:
-    paths:
-      - ".github/workflows/playground-lifecycle-recovery.yml"
-      - "crates/noon-render-wgpu/**"
-      - "crates/noon-web/**"
-      - "scripts/build-web-demo.sh"
-      - "scripts/playground-lifecycle-smoke.mjs"
-      - "web/**"
   push:
     branches:
       - master
@@ -39,12 +31,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Use stable Rust
         run: |
           rustup default stable
           rustup target add wasm32-unknown-unknown
-
       - name: Cache Cargo sources
         uses: actions/cache@v4
         with:
@@ -54,40 +44,33 @@ jobs:
           key: ${{ runner.os }}-cargo-sources-${{ hashFiles('Cargo.toml', 'crates/**/Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-sources-
-
       - name: Use sccache
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
           version: v0.16.0
-
       - name: Install pinned wasm-pack
         uses: taiki-e/install-action@13608cbb45b01feb47ef444ab1a42dc41ad56f1a # v2.79.11
         with:
           tool: wasm-pack@0.15.0
           fallback: none
-
       - name: Build browser package
         env:
           NOON_SKIP_PLAYGROUND_TEST: "1"
           NOON_WASM_SKIP_OPT: "1"
         run: bash scripts/build-web-demo.sh
-
       - name: Cache Playwright Chromium
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-chromium-1.62.1
-
       - name: Install Playwright Chromium
         run: |
           npm install --no-save --ignore-scripts playwright@1.62.1
           npx playwright install chromium
-
       - name: Test playground lifecycle recovery
         env:
           NOON_PLAYGROUND_LIFECYCLE_ARTIFACTS: browser-smoke-artifacts/playground-lifecycle
         run: node scripts/playground-lifecycle-smoke.mjs
-
       - name: Upload lifecycle diagnostics
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playground-playback-controls.yml
+++ b/.github/workflows/playground-playback-controls.yml
@@ -1,15 +1,6 @@
 name: Playground playback controls
 
 on:
-  pull_request:
-    paths:
-      - ".github/workflows/playground-playback-controls.yml"
-      - "crates/noon-render-wgpu/**"
-      - "crates/noon-web/**"
-      - "scripts/build-web-demo.sh"
-      - "scripts/playground-playback-controls-smoke.mjs"
-      - "scripts/playground-playback-rerun-stress.mjs"
-      - "web/**"
   push:
     branches:
       - master
@@ -41,12 +32,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Use stable Rust
         run: |
           rustup default stable
           rustup target add wasm32-unknown-unknown
-
       - name: Cache Cargo sources
         uses: actions/cache@v4
         with:
@@ -56,45 +45,37 @@ jobs:
           key: ${{ runner.os }}-cargo-sources-${{ hashFiles('Cargo.toml', 'crates/**/Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-sources-
-
       - name: Use sccache
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
           version: v0.16.0
-
       - name: Install pinned wasm-pack
         uses: taiki-e/install-action@13608cbb45b01feb47ef444ab1a42dc41ad56f1a # v2.79.11
         with:
           tool: wasm-pack@0.15.0
           fallback: none
-
       - name: Build browser package
         env:
           NOON_SKIP_PLAYGROUND_TEST: "1"
           NOON_WASM_SKIP_OPT: "1"
         run: bash scripts/build-web-demo.sh
-
       - name: Cache Playwright Chromium
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-chromium-1.62.1
-
       - name: Install Playwright Chromium
         run: |
           npm install --no-save --ignore-scripts playwright@1.62.1
           npx playwright install chromium
-
       - name: Test public playback controls
         env:
           NOON_PLAYGROUND_PLAYBACK_ARTIFACTS: browser-smoke-artifacts/playground-playback-controls
         run: node scripts/playground-playback-controls-smoke.mjs
-
       - name: Stress reruns across playback states
         env:
           NOON_PLAYGROUND_RERUN_STRESS_ARTIFACTS: browser-smoke-artifacts/playground-playback-rerun-stress
         run: node scripts/playground-playback-rerun-stress.mjs
-
       - name: Upload playback diagnostics
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playground-resize-recovery.yml
+++ b/.github/workflows/playground-resize-recovery.yml
@@ -1,14 +1,6 @@
 name: Playground resize recovery
 
 on:
-  pull_request:
-    paths:
-      - ".github/workflows/playground-resize-recovery.yml"
-      - "crates/noon-render-wgpu/**"
-      - "crates/noon-web/**"
-      - "scripts/build-web-demo.sh"
-      - "scripts/playground-zero-size-smoke.mjs"
-      - "web/**"
   push:
     branches:
       - master
@@ -39,12 +31,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Use stable Rust
         run: |
           rustup default stable
           rustup target add wasm32-unknown-unknown
-
       - name: Cache Cargo sources
         uses: actions/cache@v4
         with:
@@ -54,40 +44,33 @@ jobs:
           key: ${{ runner.os }}-cargo-sources-${{ hashFiles('Cargo.toml', 'crates/**/Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-sources-
-
       - name: Use sccache
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
           version: v0.16.0
-
       - name: Install pinned wasm-pack
         uses: taiki-e/install-action@13608cbb45b01feb47ef444ab1a42dc41ad56f1a # v2.79.11
         with:
           tool: wasm-pack@0.15.0
           fallback: none
-
       - name: Build browser package
         env:
           NOON_SKIP_PLAYGROUND_TEST: "1"
           NOON_WASM_SKIP_OPT: "1"
         run: bash scripts/build-web-demo.sh
-
       - name: Cache Playwright Chromium
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-chromium-1.62.1
-
       - name: Install Playwright Chromium
         run: |
           npm install --no-save --ignore-scripts playwright@1.62.1
           npx playwright install chromium
-
       - name: Test playground zero-size recovery
         env:
           NOON_PLAYGROUND_ZERO_SIZE_ARTIFACTS: browser-smoke-artifacts/playground-zero-size
         run: node scripts/playground-zero-size-smoke.mjs
-
       - name: Upload resize diagnostics
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -1,0 +1,176 @@
+name: PR Fast Gate
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-fast-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  CARGO_INCREMENTAL: "0"
+  RUSTC_WRAPPER: sccache
+  SCCACHE_GHA_ENABLED: "true"
+
+jobs:
+  rust-lint:
+    name: Rust format and lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use stable Rust
+        run: |
+          rustup default stable
+          rustup component add rustfmt clippy
+
+      - name: Cache Cargo sources
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-sources-${{ hashFiles('Cargo.toml', 'crates/**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-sources-
+
+      - name: Use sccache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+        with:
+          version: v0.16.0
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Lint workspace
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+  rust-test:
+    name: Rust unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use stable Rust
+        run: rustup default stable
+
+      - name: Cache Cargo sources
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-sources-${{ hashFiles('Cargo.toml', 'crates/**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-sources-
+
+      - name: Use sccache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+        with:
+          version: v0.16.0
+
+      - name: Run fast Rust tests
+        run: cargo test --workspace --all-features --lib
+
+  web-preflight:
+    name: Web static and unit checks
+    runs-on: ubuntu-latest
+    env:
+      NOON_SKIP_PLAYGROUND_TEST: "1"
+      NOON_WEB_PREFLIGHT_ONLY: "1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run web preflight
+        run: bash scripts/build-web-demo.sh
+
+  web-fast:
+    name: Browser fast checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use stable Rust and WASM target
+        run: |
+          rustup default stable
+          rustup target add wasm32-unknown-unknown
+
+      - name: Cache Cargo sources
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-sources-${{ hashFiles('Cargo.toml', 'crates/**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-sources-
+
+      - name: Use sccache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+        with:
+          version: v0.16.0
+
+      - name: Install pinned wasm-pack
+        uses: taiki-e/install-action@13608cbb45b01feb47ef444ab1a42dc41ad56f1a # v2.79.11
+        with:
+          tool: wasm-pack@0.15.0
+          fallback: none
+
+      - name: Build browser package once
+        env:
+          NOON_SKIP_WEB_PREFLIGHT: "1"
+          NOON_SKIP_PLAYGROUND_TEST: "1"
+          NOON_WASM_SKIP_OPT: "1"
+        run: bash scripts/build-web-demo.sh
+
+      - name: Cache Playwright Chromium
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-chromium-1.62.1
+
+      - name: Install browser smoke dependencies
+        run: |
+          npm install --no-save --ignore-scripts playwright@1.62.1 pngjs@7.0.0
+          npx playwright install chromium
+
+      - name: Check deterministic playback
+        run: node scripts/deterministic-replay-smoke.mjs
+
+      - name: Check Manim-style authoring
+        run: node scripts/manim-compat-smoke.mjs
+
+      - name: Check primary WebGPU rendering
+        env:
+          NOON_BROWSER_SMOKE_BACKEND: webgpu
+          NOON_BROWSER_SMOKE_ARTIFACTS: browser-smoke-artifacts/webgpu
+        run: node scripts/browser-smoke.mjs
+
+  fast-gate:
+    name: PR Fast Gate
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - rust-lint
+      - rust-test
+      - web-preflight
+      - web-fast
+    steps:
+      - name: Require fast checks
+        env:
+          LINT_RESULT: ${{ needs.rust-lint.result }}
+          TEST_RESULT: ${{ needs.rust-test.result }}
+          WEB_PREFLIGHT_RESULT: ${{ needs.web-preflight.result }}
+          WEB_RESULT: ${{ needs.web-fast.result }}
+        run: |
+          test "$LINT_RESULT" = success
+          test "$TEST_RESULT" = success
+          test "$WEB_PREFLIGHT_RESULT" = success
+          test "$WEB_RESULT" = success

--- a/.github/workflows/renderer-recovery.yml
+++ b/.github/workflows/renderer-recovery.yml
@@ -1,27 +1,6 @@
 name: Renderer recovery
 
 on:
-  pull_request:
-    paths:
-      - ".github/workflows/renderer-recovery.yml"
-      - "crates/noon-web/**"
-      - "crates/noon-render-wgpu/**"
-      - "scripts/renderer-init-failure-smoke.mjs"
-      - "scripts/renderer-webgl-context-loss-smoke.mjs"
-      - "scripts/renderer-webgpu-device-loss-smoke.mjs"
-      - "scripts/renderer-webgpu-validation-error-smoke.mjs"
-      - "scripts/renderer-worker-webgpu-validation-error-smoke.mjs"
-      - "scripts/webgpu-device-capture.mjs"
-      - "web/browser-smoke.html"
-      - "web/browser-smoke.js"
-      - "web/execution-renderer-smoke.html"
-      - "web/execution-renderer-smoke.js"
-      - "web/execution-render-worker.js"
-      - "web/retained-execution-render-worker.js"
-      - "web/execution-worker-client.js"
-      - "web/retained-execution-worker-client.js"
-      - "web/authoring-execution-client.js"
-      - "web/render-gpu-diagnostics.js"
   push:
     branches:
       - master
@@ -65,12 +44,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Use stable Rust
         run: |
           rustup default stable
           rustup target add wasm32-unknown-unknown
-
       - name: Cache Cargo sources
         uses: actions/cache@v4
         with:
@@ -80,64 +57,53 @@ jobs:
           key: ${{ runner.os }}-cargo-sources-${{ hashFiles('Cargo.toml', 'crates/**/Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-sources-
-
       - name: Use sccache
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
           version: v0.16.0
-
       - name: Install pinned wasm-pack
         uses: taiki-e/install-action@13608cbb45b01feb47ef444ab1a42dc41ad56f1a # v2.79.11
         with:
           tool: wasm-pack@0.15.0
           fallback: none
-
       - name: Build browser package
         env:
           NOON_SKIP_PLAYGROUND_TEST: "1"
           NOON_WASM_SKIP_OPT: "1"
         run: bash scripts/build-web-demo.sh
-
       - name: Cache Playwright Chromium
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-chromium-1.62.1
-
       - name: Install browser smoke dependencies
         run: |
           npm install --no-save --ignore-scripts playwright@1.62.1 pngjs@7.0.0
           npx playwright install chromium
-
       - name: Test renderer initialization and fallback
         env:
           NOON_RENDERER_FAILURE_ARTIFACTS: browser-smoke-artifacts/renderer-init-failure
         run: node scripts/renderer-init-failure-smoke.mjs
-
       - name: Test WebGL context loss and recovery
         id: webgl_context_loss
         env:
           NOON_RENDERER_CONTEXT_LOSS_ARTIFACTS: browser-smoke-artifacts/renderer-context-loss
         run: node scripts/renderer-webgl-context-loss-smoke.mjs
-
       - name: Test WebGPU device loss and recovery
         id: webgpu_device_loss
         env:
           NOON_RENDERER_DEVICE_LOSS_ARTIFACTS: browser-smoke-artifacts/renderer-device-loss
         run: node scripts/renderer-webgpu-device-loss-smoke.mjs
-
       - name: Test WebGPU validation-error propagation
         id: webgpu_validation_error
         env:
           NOON_RENDERER_VALIDATION_ERROR_ARTIFACTS: browser-smoke-artifacts/renderer-validation-error
         run: node scripts/renderer-webgpu-validation-error-smoke.mjs
-
       - name: Test render-worker WebGPU validation propagation
         id: worker_webgpu_validation_error
         env:
           NOON_RENDERER_VALIDATION_ARTIFACTS: browser-smoke-artifacts/render-worker-validation-error
         run: node scripts/renderer-worker-webgpu-validation-error-smoke.mjs
-
       - name: Upload renderer initialization diagnostics
         if: always()
         uses: actions/upload-artifact@v4
@@ -146,7 +112,6 @@ jobs:
           path: browser-smoke-artifacts/renderer-init-failure
           if-no-files-found: error
           retention-days: 7
-
       - name: Upload WebGL recovery diagnostics
         if: always() && steps.webgl_context_loss.outcome != 'skipped'
         uses: actions/upload-artifact@v4
@@ -155,7 +120,6 @@ jobs:
           path: browser-smoke-artifacts/renderer-context-loss
           if-no-files-found: error
           retention-days: 7
-
       - name: Upload WebGPU recovery diagnostics
         if: always() && steps.webgpu_device_loss.outcome != 'skipped'
         uses: actions/upload-artifact@v4
@@ -164,7 +128,6 @@ jobs:
           path: browser-smoke-artifacts/renderer-device-loss
           if-no-files-found: error
           retention-days: 7
-
       - name: Upload WebGPU validation-error diagnostics
         if: always() && steps.webgpu_validation_error.outcome != 'skipped'
         uses: actions/upload-artifact@v4
@@ -173,7 +136,6 @@ jobs:
           path: browser-smoke-artifacts/renderer-validation-error
           if-no-files-found: error
           retention-days: 7
-
       - name: Upload render-worker WebGPU validation diagnostics
         if: always() && steps.worker_webgpu_validation_error.outcome != 'skipped'
         uses: actions/upload-artifact@v4

--- a/.github/workflows/retained-text-animation.yml
+++ b/.github/workflows/retained-text-animation.yml
@@ -1,31 +1,6 @@
 name: Retained text animation
 
 on:
-  pull_request:
-    paths:
-      - "crates/noon-web/src/authoring_mobject.rs"
-      - "crates/noon-web/src/retained_authoring_player.rs"
-      - "crates/noon-web/src/retained_authoring_scene.rs"
-      - "crates/noon-web/src/retained_authoring_tracks.rs"
-      - "crates/noon-web/src/retained_authoring_wire_scene.rs"
-      - "web/authoring-render-worker.js"
-      - "web/python-worker.source.js"
-      - "web/python-compat-modules.js"
-      - "web/python/_manim_animate.py"
-      - "web/python/_manim_animation_options.py"
-      - "web/python/_manim_retained_animate.py"
-      - "web/python/_manim_retained_state.py"
-      - "web/python/_manim_semantic_handles.py"
-      - "web/python/_manim_typst.py"
-      - "scripts/build-python-worker.mjs"
-      - "scripts/retained-text-animation-smoke.mjs"
-      - "scripts/retained-text-canonical-state-smoke.mjs"
-      - "scripts/retained-text-family-identity-smoke.mjs"
-      - "scripts/retained-text-family-layout-smoke.mjs"
-      - "scripts/retained-text-family-fade-smoke.mjs"
-      - "scripts/retained-text-playback-smoke.mjs"
-      - "scripts/retained-text-scene-lifecycle-smoke.mjs"
-      - ".github/workflows/retained-text-animation.yml"
   push:
     branches:
       - master
@@ -75,12 +50,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Use stable Rust
         run: |
           rustup default stable
           rustup target add wasm32-unknown-unknown
-
       - name: Cache Cargo sources
         uses: actions/cache@v4
         with:
@@ -90,49 +63,37 @@ jobs:
           key: ${{ runner.os }}-cargo-sources-${{ hashFiles('Cargo.toml', 'crates/**/Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-sources-
-
       - name: Use sccache
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
           version: v0.16.0
-
       - name: Install pinned wasm-pack
         uses: taiki-e/install-action@13608cbb45b01feb47ef444ab1a42dc41ad56f1a
         with:
           tool: wasm-pack@0.15.0
           fallback: none
-
       - name: Build browser package
         run: bash scripts/build-web-demo.sh
-
       - name: Cache Playwright Chromium
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-chromium-1.62.1
-
       - name: Install browser smoke dependencies
         run: |
           npm install --no-save --ignore-scripts playwright@1.62.1 pngjs@7.0.0
           npx playwright install chromium
-
       - name: Test retained Text animation authoring
         run: node scripts/retained-text-animation-smoke.mjs
-
       - name: Test retained Text canonical authoring state
         run: node scripts/retained-text-canonical-state-smoke.mjs
-
       - name: Test retained Text family identity
         run: node scripts/retained-text-family-identity-smoke.mjs
-
       - name: Test retained Text family layout
         run: node scripts/retained-text-family-layout-smoke.mjs
-
       - name: Test retained Text family fades
         run: node scripts/retained-text-family-fade-smoke.mjs
-
       - name: Test retained Text animation playback
         run: node scripts/retained-text-playback-smoke.mjs
-
       - name: Test retained Text Scene lifecycle
         run: node scripts/retained-text-scene-lifecycle-smoke.mjs

--- a/.github/workflows/retained-typst-authoring.yml
+++ b/.github/workflows/retained-typst-authoring.yml
@@ -1,15 +1,6 @@
 name: Retained Typst authoring
 
 on:
-  pull_request:
-    paths:
-      - "crates/noon-web/src/retained_authoring.rs"
-      - "web/python-worker.source.js"
-      - "web/python-compat-modules.js"
-      - "web/python/_manim_typst.py"
-      - "scripts/build-python-worker.mjs"
-      - "scripts/manim-typst-authoring-smoke.mjs"
-      - ".github/workflows/retained-typst-authoring.yml"
   push:
     branches:
       - master
@@ -41,12 +32,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Use stable Rust
         run: |
           rustup default stable
           rustup target add wasm32-unknown-unknown
-
       - name: Cache Cargo sources
         uses: actions/cache@v4
         with:
@@ -56,26 +45,21 @@ jobs:
           key: ${{ runner.os }}-cargo-sources-${{ hashFiles('Cargo.toml', 'crates/**/Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-sources-
-
       - name: Install pinned wasm-pack
         uses: taiki-e/install-action@13608cbb45b01feb47ef444ab1a42dc41ad56f1a
         with:
           tool: wasm-pack@0.15.0
           fallback: none
-
       - name: Build browser package
         run: bash scripts/build-web-demo.sh
-
       - name: Cache Playwright Chromium
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-chromium-1.62.1
-
       - name: Install browser smoke dependencies
         run: |
           npm install --no-save --ignore-scripts playwright@1.62.1 pngjs@7.0.0
           npx playwright install chromium
-
       - name: Test retained Typst Python authoring
         run: node scripts/manim-typst-authoring-smoke.mjs

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -1,13 +1,6 @@
 name: Test coverage
 
 on:
-  pull_request:
-    paths:
-      - "crates/**"
-      - "web/**"
-      - "scripts/**"
-      - "compat/**"
-      - ".github/workflows/test-coverage.yml"
   push:
     branches:
       - master
@@ -33,17 +26,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Generate inventory
         run: |
           python3 scripts/test-inventory.py \
             --check \
             --json test-artifacts/test-inventory.json \
             --markdown test-artifacts/test-inventory.md
-
       - name: Validate semantic ownership inventory
         run: python3 scripts/semantic_ownership_check.py
-
       - name: Upload inventory
         uses: actions/upload-artifact@v4
         with:
@@ -58,22 +48,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Use stable Rust
         run: rustup default stable
-
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@13608cbb45b01feb47ef444ab1a42dc41ad56f1a
         with:
           tool: cargo-llvm-cov
           fallback: none
-
       - name: Generate Rust coverage
         run: |
           mkdir -p test-artifacts
           cargo llvm-cov --workspace --all-features \
             --lcov --output-path test-artifacts/rust.lcov
-
       - name: Upload Rust coverage
         uses: actions/upload-artifact@v4
         with:
@@ -88,12 +74,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-
       - name: Python coverage
         run: |
           python -m pip install --disable-pip-version-check "coverage==7.6.12"
@@ -103,7 +87,6 @@ jobs:
           coverage json -o test-artifacts/python-coverage.json
           coverage report > test-artifacts/python-coverage.txt
           cat test-artifacts/python-coverage.txt
-
       - name: JavaScript coverage
         run: |
           npm install --no-save --ignore-scripts c8@10.1.3
@@ -112,7 +95,6 @@ jobs:
             --reporter=text \
             --report-dir=test-artifacts/js \
             node --test web/*.test.mjs
-
       - name: Upload scripting coverage
         uses: actions/upload-artifact@v4
         with:

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,109 +1,79 @@
 # Continuous integration policy
 
-Noon uses CI as a correctness gate, but not as the inner development loop. The required workflow is split by subsystem so expensive browser work fans out after one reusable WASM build instead of rebuilding the package in every job.
+Noon separates fast pull-request feedback from exhaustive post-merge validation. Pull requests should get one high-signal result quickly; broader compatibility, recovery, coverage, release, and cross-browser matrices remain available without forcing every change to pay their startup cost.
+
+## Pull-request fast gate
+
+`.github/workflows/pr-fast.yml` is the only workflow triggered for every pull request. It is the intended branch-protection check and targets a warm-run wall clock of at most two minutes.
+
+The workflow runs four independent lanes in parallel:
+
+- **Rust format and lint:** `cargo fmt --all -- --check` and workspace Clippy with all targets/features;
+- **Rust unit tests:** `cargo test --workspace --all-features --lib`;
+- **Web static and unit checks:** ownership ratchets, JavaScript syntax/unit tests, and Python compile/unit tests;
+- **Browser fast checks:** one unoptimized WASM/browser package build followed by deterministic replay, Manim-style authoring, and primary WebGPU smoke coverage.
+
+A small aggregate `PR Fast Gate` job succeeds only when all four lanes succeed. Rust lint and unit-test compilation are deliberately separate jobs because Clippy and the test profile cannot reuse enough artifacts to justify serializing roughly independent compile work on the critical path. The web preflight is similarly independent of the WASM build and browser runtime, so it runs beside rather than ahead of that work.
+
+`scripts/build-web-demo.sh` remains the canonical full web validation entry point. `NOON_WEB_PREFLIGHT_ONLY=1` runs only its static/unit preflight, while `NOON_SKIP_WEB_PREFLIGHT=1` skips that preflight and proceeds directly to the package build. The full master/release invocation sets neither flag and therefore preserves the original all-in-one behavior.
+
+Cargo source downloads and Rust compilations use the shared cache/sccache setup. The browser lane builds the package once and keeps `wasm-opt` out of the pull-request path.
 
 ## Main CI workflow
 
-`.github/workflows/ci.yml` runs on pull requests, pushes to `master`, and manual dispatch.
+`.github/workflows/ci.yml` runs on pushes to `master` and manual dispatch. It is the full Linux integration workflow rather than the pull-request inner loop.
 
-### Rust
+Its Rust lane runs formatting, full workspace Clippy, and the complete workspace test set. Its browser build produces one reusable package artifact that fans out to authoring, reactive/editor, WebGPU, WebGL, and backend-parity jobs.
 
-The Rust job runs on Ubuntu and requires:
+This workflow is intentionally broader than the PR fast gate. A failure after merge is still a correctness failure to fix immediately, but expensive validation does not delay every review iteration.
 
-- `cargo fmt --all -- --check`;
-- `cargo clippy --workspace --all-targets --all-features -- -D warnings`;
-- `cargo test --workspace --all-features`.
+## Specialized validation
 
-Cargo sources and compiled Rust work are accelerated with sccache. The workspace is treated as one current architecture; there is no separate legacy compatibility gate.
+Feature-specific workflows under `.github/workflows/` do not independently cold-start on every pull request. They run on their documented `master`, scheduled, or manual triggers.
 
-### Browser package build
-
-The web-build job:
-
-- syntax-checks the checked-in JavaScript harnesses;
-- runs Node unit tests;
-- compiles/checks the Python compatibility modules and examples;
-- runs the Python unittest suite;
-- builds `noon-web` for `wasm32-unknown-unknown` with pinned `wasm-pack`;
-- validates the generated JavaScript/TypeScript/WASM package surface;
-- uploads the package once for downstream browser jobs.
-
-PR CI intentionally skips `wasm-opt` in this fast package build. The production-optimized artifact is validated separately by the release/platform testing lane rather than making every browser job pay the optimization cost.
-
-### Browser authoring
-
-The authoring job consumes the shared browser package and runs:
-
-- Rust/Python semantic parity;
-- Manim-style Python compatibility;
-- composition authoring;
-- the executable Manim tutorial corpus.
-
-### Browser reactive/editor
-
-The reactive/editor job runs:
-
-- native reactive Python authoring;
-- native reactive browser runtime;
-- Python updater callback bridge;
-- Python editor syntax-highlighting/linting smoke coverage.
-
-### Browser rendering
-
-Rendering is a two-entry matrix over WebGPU and WebGL2 fallback. Both run the deterministic playground/browser smoke corpus and upload screenshots on success or failure. The required Linux browser path uses Playwright Chromium/SwiftShader so it is repeatable on hosted runners.
-
-### Test-only trigger policy
-
-A change whose crate paths are exclusively integration tests under `crates/**/tests/**` remains covered by normal CI and test coverage, but does not start the separate Manim semantic/API/raster, cross-browser, or platform/release matrices. Those product-validation workflows run unchanged as soon as the same change set includes any non-test crate path, Cargo metadata, browser/authoring source, workflow definition, or other path already owned by that workflow. This keeps new deterministic Rust regressions cheap to add without weakening validation of production changes.
+This keeps their focused contracts intact while avoiding repeated checkout, Rust/WASM setup, browser installation, and `build-web-demo.sh` invocations for the same PR head. If a future class of change proves too risky to defer, add measured change-aware escalation to the fast workflow instead of adding another unconditional PR workflow.
 
 ## Platform and release validation
 
-`.github/workflows/platform-release.yml` is the compact portability and production-artifact lane. It runs when native/browser production paths or their build generators change, on pushes to `master`, and by manual dispatch.
+`.github/workflows/platform-release.yml` is the portability and production-artifact lane. It runs on relevant pushes to `master` and by manual dispatch.
 
-The workflow deliberately stays separate from fast main CI and provides three contracts:
+It provides three distinct contracts:
 
-- **native platform matrix:** Linux, macOS, and Windows compile and run the workspace library/integration test set with stable Rust;
-- **release-mode native check:** `noon-core`, `noon-geometry`, and `noon-runtime` run their tests with release optimizations enabled to catch optimization-sensitive failures without tripling the cost across every OS;
-- **optimized browser artifact:** pinned `wasm-pack` 0.15.0 and Binaryen/`wasm-opt` version 132 build the real release package, including generated Python-worker assets; the normal package-surface validation runs, the optimized WASM is loaded/evaluated through deterministic Chromium replay, and the resulting package is retained as a short-lived artifact.
+- Linux, macOS, and Windows native workspace validation;
+- release-mode testing for core execution crates;
+- a production browser artifact built with pinned `wasm-pack` and Binaryen/`wasm-opt`, then exercised in Chromium.
 
-The supported Rust policy for this lane is current stable Rust plus `wasm32-unknown-unknown`. If a minimum supported Rust version becomes a product requirement, add it as a separate explicit matrix entry rather than relying on whatever a hosted runner happens to contain. Binaryen is downloaded from its versioned release artifact and checksum-verified before adding its `wasm-opt` to `PATH`; this prevents wasm-pack's default "latest" optimizer download from making release output silently drift.
-
-The optimized job records `noon_web_bg.wasm` byte size in the workflow summary as diagnostic trend data. Size is not yet a required budget; establish a stable baseline before adding a ratchet.
-
-Machine-readable subprocess protocols used by the platform matrix must define their encoding rather than inherit a host locale. In particular, the playground scene manifest is explicitly UTF-8 and its integration test forces a hostile inherited Python encoding so the contract is deterministic on every runner.
-
-This matrix is intentionally compact. Add another operating system, browser, toolchain, or backend only when it proves a distinct product contract or catches a demonstrated class of failure. Browser-engine/DPR/UI variation belongs to the separate #110 lane rather than expanding this workflow combinatorially.
+The optimized job records WASM size as diagnostic trend data. Size should become a ratchet only after a stable baseline exists.
 
 ## Manim compatibility workflows
 
-Manim API-surface and semantic compatibility are separate workflows because they require a pinned ManimCE/Python environment. Manim Community v0.21.0 is the reference version. API inventory and semantic differential tests should remain separate: surface presence does not prove behavior, and behavioral fixtures should not become a second API manifest.
+Manim compatibility workflows validate Noon against the pinned Manim Community reference independently of the fast PR loop. API inventory, semantic differential, raster differential, and reference-inventory checks remain separate because surface presence, semantic behavior, rendered output, and corpus provenance are different contracts.
+
+The expensive reference environment belongs on `master` or manual validation unless a measured change classifier explicitly escalates a PR.
 
 ## Test inventory and coverage
 
-`.github/workflows/test-coverage.yml` is the observability workflow introduced by #104. It runs in parallel with normal CI when production/test files change and produces:
+`.github/workflows/test-coverage.yml` is the test-observability workflow. On `master` and manual runs it produces:
 
-- a generated machine-readable/Markdown test inventory;
-- Rust LCOV data from `cargo llvm-cov`;
-- Python coverage from the normal unit suite;
-- V8/c8 coverage for browser JavaScript unit modules.
+- generated test inventory data;
+- Rust LCOV coverage;
+- Python coverage;
+- JavaScript/V8 coverage.
 
-The inventory has a small required ratchet now: every production module must belong to an explicit test strategy. Line coverage is initially diagnostic. After a stable baseline is established, use changed-code or per-layer non-regression ratchets rather than an arbitrary global percentage.
+Coverage is not duplicated in the required fast gate. Prefer changed-code or per-layer non-regression ratchets over an arbitrary repository-wide percentage.
 
 See `docs/testing.md` for the verification hierarchy and local commands.
 
+## Fuzzing and recovery
+
+Fuzzing remains scheduled/manual, and recovery/cross-browser workflows remain post-merge/manual validation. Their purpose is to exercise failure and environment matrices that are valuable but structurally unsuitable for a two-minute review loop.
+
 ## Performance policy
 
-Shared GitHub runners are too noisy for small wall-clock regressions to be a reliable correctness gate. Required CI should prefer deterministic structural invariants such as:
+Shared hosted runners are noisy, so correctness tests should prefer deterministic structural invariants over tiny wall-clock thresholds. CI architecture itself is different: the PR feedback budget is a developer-productivity contract, so workflow wall time should be measured and regressions in the critical path should be visible.
 
-- objects/tracks/reactive nodes visited;
-- dirty slots and instances repacked;
-- upload bytes;
-- geometry/cache misses and rebuild counts;
-- host callback slots/payload size;
-- retained resource counts.
-
-Named-machine p50/p95 measurements remain useful diagnostic/release evidence and are documented in `docs/performance.md`.
+Useful runtime invariants include objects/tracks visited, dirty slots, upload bytes, cache misses, callback payload sizes, and retained resource counts. Named-machine p50/p95 measurements remain diagnostic/release evidence and are documented in `docs/performance.md`.
 
 ## Development cadence
 
-Use local focused tests as the inner loop and update branches in coherent batches. A change should run the cheapest relevant subsystem tests first; the full required CI is the integration gate before merge. Avoid serializing tiny formatting/lint-only commits solely to trigger Actions repeatedly.
+Use local focused tests as the inner loop, `PR Fast Gate` as the pre-merge integration signal, and the exhaustive master workflows as the full correctness matrix. Extend CI by adding tests to existing ownership lanes or change-aware escalation; avoid introducing another independently bootstrapped unconditional pull-request workflow.

--- a/scripts/build-web-demo.sh
+++ b/scripts/build-web-demo.sh
@@ -7,86 +7,92 @@ cd "$noon_root"
 
 node scripts/build-python-worker.mjs
 
-# The #61 ownership inventory is an architecture ratchet, not passive documentation.
-# Validate both the checked-in inventory and the validator's ownership-class invariants
-# in the required web build so contradictory or growing Python semantic debt cannot land.
-PYTHONDONTWRITEBYTECODE=1 python3 scripts/semantic_ownership_check.py
-PYTHONDONTWRITEBYTECODE=1 python3 scripts/test_semantic_ownership_check.py
+if [[ "${NOON_SKIP_WEB_PREFLIGHT:-0}" != "1" ]]; then
+  # The #61 ownership inventory is an architecture ratchet, not passive documentation.
+  # Validate both the checked-in inventory and the validator's ownership-class invariants
+  # in the required web build so contradictory or growing Python semantic debt cannot land.
+  PYTHONDONTWRITEBYTECODE=1 python3 scripts/semantic_ownership_check.py
+  PYTHONDONTWRITEBYTECODE=1 python3 scripts/test_semantic_ownership_check.py
 
-# Keep top-level browser modules and tests self-registering with the required web build.
-# This prevents a new JavaScript file or regression test from silently escaping syntax
-# validation / execution because this script's hand-maintained inventory was not updated.
-while IFS= read -r source; do
-  node --check "$source"
-done < <(find web -maxdepth 1 -type f \( -name '*.js' -o -name '*.mjs' \) -print | sort)
+  # Keep top-level browser modules and tests self-registering with the required web build.
+  # This prevents a new JavaScript file or regression test from silently escaping syntax
+  # validation / execution because this script's hand-maintained inventory was not updated.
+  while IFS= read -r source; do
+    node --check "$source"
+  done < <(find web -maxdepth 1 -type f \( -name '*.js' -o -name '*.mjs' \) -print | sort)
 
-while IFS= read -r source; do
-  node --check "$source"
-done < <(find web/js -type f -name '*.js' -print | sort)
+  while IFS= read -r source; do
+    node --check "$source"
+  done < <(find web/js -type f -name '*.js' -print | sort)
 
-node --check scripts/build-python-worker.mjs
-node --check scripts/execution-worker-smoke.mjs
-node --check scripts/execution-worker-host-smoke.mjs
-node --check scripts/retained-execution-worker-smoke.mjs
-node --check scripts/authoring-execution-router-smoke.mjs
-node --check scripts/authoring-execution-lifecycle-smoke.mjs
-node --check scripts/browser-smoke.mjs
-node --check scripts/browser-backend-visual-parity.mjs
-node --check scripts/browser-visual-parity-lib.mjs
-node --check scripts/manim-raster-differential.mjs
-node --check scripts/manim-seek-playback-raster.mjs
-node --check scripts/manim-typst-authoring-smoke.mjs
-node --check scripts/manim-reference-inventory.mjs
-node --check scripts/manim-reference-ledger.mjs
-node --check scripts/manim-reference-coverage.mjs
-node --check scripts/manim-reference-classification-lock.mjs
-node --check scripts/perf-profile.mjs
-node --check scripts/authoring-perf.mjs
-node --check scripts/perf-device-run.mjs
-node --check scripts/perf-compare.mjs
-node --check scripts/perf-corpus.mjs
-node --check scripts/host-callback-perf.mjs
-node --check scripts/deterministic-replay-smoke.mjs
-node --check scripts/cross-language-parity.mjs
-node --check scripts/manim-compat-smoke.mjs
-node --check scripts/manim-tutorial-smoke.mjs
-node --check scripts/playground-layout-smoke.mjs
-node --check scripts/composition-authoring-smoke.mjs
-node --check scripts/reactive-authoring-smoke.mjs
-node --check scripts/reactive-runtime-smoke.mjs
-node --check scripts/native-input-smoke.mjs
-node --check scripts/updater-callback-smoke.mjs
-node --test scripts/browser-visual-parity-lib.test.mjs
-node --test scripts/manim-reference-inventory.test.mjs
-node --test scripts/manim-reference-ledger.test.mjs
-node --test scripts/manim-reference-coverage.test.mjs
-node --test scripts/manim-reference-classification-lock.test.mjs
+  node --check scripts/build-python-worker.mjs
+  node --check scripts/execution-worker-smoke.mjs
+  node --check scripts/execution-worker-host-smoke.mjs
+  node --check scripts/retained-execution-worker-smoke.mjs
+  node --check scripts/authoring-execution-router-smoke.mjs
+  node --check scripts/authoring-execution-lifecycle-smoke.mjs
+  node --check scripts/browser-smoke.mjs
+  node --check scripts/browser-backend-visual-parity.mjs
+  node --check scripts/browser-visual-parity-lib.mjs
+  node --check scripts/manim-raster-differential.mjs
+  node --check scripts/manim-seek-playback-raster.mjs
+  node --check scripts/manim-typst-authoring-smoke.mjs
+  node --check scripts/manim-reference-inventory.mjs
+  node --check scripts/manim-reference-ledger.mjs
+  node --check scripts/manim-reference-coverage.mjs
+  node --check scripts/manim-reference-classification-lock.mjs
+  node --check scripts/perf-profile.mjs
+  node --check scripts/authoring-perf.mjs
+  node --check scripts/perf-device-run.mjs
+  node --check scripts/perf-compare.mjs
+  node --check scripts/perf-corpus.mjs
+  node --check scripts/host-callback-perf.mjs
+  node --check scripts/deterministic-replay-smoke.mjs
+  node --check scripts/cross-language-parity.mjs
+  node --check scripts/manim-compat-smoke.mjs
+  node --check scripts/manim-tutorial-smoke.mjs
+  node --check scripts/playground-layout-smoke.mjs
+  node --check scripts/composition-authoring-smoke.mjs
+  node --check scripts/reactive-authoring-smoke.mjs
+  node --check scripts/reactive-runtime-smoke.mjs
+  node --check scripts/native-input-smoke.mjs
+  node --check scripts/updater-callback-smoke.mjs
+  node --test scripts/browser-visual-parity-lib.test.mjs
+  node --test scripts/manim-reference-inventory.test.mjs
+  node --test scripts/manim-reference-ledger.test.mjs
+  node --test scripts/manim-reference-coverage.test.mjs
+  node --test scripts/manim-reference-classification-lock.test.mjs
 
-for test_file in web/*.test.mjs; do
-  node --test "$test_file"
-done
+  for test_file in web/*.test.mjs; do
+    node --test "$test_file"
+  done
 
-PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile \
-  web/python/_manim_compat.py \
-  web/python/_manim_typst.py \
-  web/python/_manim_rate_functions.py \
-  web/python/_manim_phase_b.py \
-  web/python/_manim_shared_geometry.py \
-  web/python/_manim_animation_options.py \
-  web/python/_manim_animate.py \
-  web/python/_manim_rotate.py \
-  web/python/_manim_composition.py \
-  web/python/_manim_frame_sampling.py \
-  web/python/_manim_lifecycle.py \
-  web/python/_manim_growing.py \
-  web/python/_manim_draw_border_then_fill.py \
-  web/python/_manim_reactive.py \
-  web/python/_manim_updaters.py
-PYTHONDONTWRITEBYTECODE=1 python3 -m compileall -q web/python/examples
-PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s web/python -p 'test_*.py'
+  PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile \
+    web/python/_manim_compat.py \
+    web/python/_manim_typst.py \
+    web/python/_manim_rate_functions.py \
+    web/python/_manim_phase_b.py \
+    web/python/_manim_shared_geometry.py \
+    web/python/_manim_animation_options.py \
+    web/python/_manim_animate.py \
+    web/python/_manim_rotate.py \
+    web/python/_manim_composition.py \
+    web/python/_manim_frame_sampling.py \
+    web/python/_manim_lifecycle.py \
+    web/python/_manim_growing.py \
+    web/python/_manim_draw_border_then_fill.py \
+    web/python/_manim_reactive.py \
+    web/python/_manim_updaters.py
+  PYTHONDONTWRITEBYTECODE=1 python3 -m compileall -q web/python/examples
+  PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s web/python -p 'test_*.py'
 
-if [[ "${NOON_SKIP_PLAYGROUND_TEST:-0}" != "1" ]]; then
-  cargo test -p noon-web --test playground_examples
+  if [[ "${NOON_SKIP_PLAYGROUND_TEST:-0}" != "1" ]]; then
+    cargo test -p noon-web --test playground_examples
+  fi
+fi
+
+if [[ "${NOON_WEB_PREFLIGHT_ONLY:-0}" == "1" ]]; then
+  exit 0
 fi
 
 wasm_pack_args=(build crates/noon-web --target web --out-dir ../../web/pkg --release)

--- a/web/ci-workflow-topology.test.mjs
+++ b/web/ci-workflow-topology.test.mjs
@@ -9,6 +9,7 @@ const workflowFiles = (await readdir(workflowDir))
 assert.ok(workflowFiles.length > 0, "CI workflow inventory must not be empty");
 
 const exactFamilies = new Map([
+  ["pr-fast.yml", "pr-fast"],
   ["ci.yml", "main"],
   ["test-coverage.yml", "coverage"],
   ["platform-release.yml", "platform-release"],
@@ -40,6 +41,7 @@ assert.deepEqual(
 );
 
 const requiredFamilies = new Set([
+  "pr-fast",
   "main",
   "coverage",
   "platform-release",
@@ -53,6 +55,7 @@ for (const family of requiredFamilies) {
 
 const ciDocs = await readFile(new URL("../docs/ci.md", import.meta.url), "utf8");
 for (const [needle, purpose] of [
+  [".github/workflows/pr-fast.yml", "pull-request fast gate"],
   [".github/workflows/ci.yml", "main CI"],
   [".github/workflows/platform-release.yml", "platform/release validation"],
   [".github/workflows/test-coverage.yml", "test observability"],


### PR DESCRIPTION
## Summary
- add a dedicated `PR Fast Gate` as the sole unconditional pull-request workflow
- remove `pull_request` triggers from broad and feature-specific workflows while preserving exhaustive validation on `master`, manual dispatch, or scheduled runs
- keep Manim semantic/API validation by adding `master` triggers where those workflows previously existed only on PR/manual execution
- split independent Rust Clippy and unit-test compilation into parallel jobs
- split the web static/unit preflight from the WASM/browser build so they run in parallel while preserving the full `build-web-demo.sh` contract for master/release
- update CI topology/documentation so future workflows cannot silently bypass the architecture

## Fast-gate lanes
Four jobs run in parallel and feed one aggregate `PR Fast Gate` status:

1. **Rust format and lint**
   - rustfmt
   - workspace Clippy, all targets/features
2. **Rust unit tests**
   - workspace library tests, all features
3. **Web static and unit checks**
   - semantic-ownership ratchets
   - JavaScript syntax/unit tests
   - Python compile/unit tests
4. **Browser fast checks**
   - one unoptimized WASM/browser package build
   - deterministic replay
   - Manim-style authoring
   - primary WebGPU rendering smoke

## Measured bottleneck
The first warm Rust run before the split took about 94 s: roughly 37 s in Clippy followed by roughly 41 s compiling the separate test profile, while actual test execution was only a few seconds. sccache was already hitting cacheable compilation requests, so serial orchestration was the main problem. Those compile-heavy lanes now run concurrently.

The first browser attempt also exposed that `build-web-demo.sh` serialized the complete JS/Python preflight ahead of the WASM build. It now supports preflight-only and skip-preflight modes for PR parallelism; normal master/release invocation sets neither and retains the original complete behavior.

## Validation state
- representative source-heavy PR fan-out reduced from about 15 workflows to one `PR Fast Gate` workflow
- CI topology ratchet updated to classify and require `pr-fast.yml`
- branch rebased onto current `master` and kept as one commit
- final green wall-clock measurement still needed before declaring the <=120 s target achieved

Tracks #731.

## Follow-ups
- measure the final warm/cold lane timings
- consolidate Playwright/browser startup if browser runtime remains the critical path
- evaluate `cargo-nextest` only if measured test execution, rather than compilation, remains meaningful
- add non-flaky timing telemetry/budget regression visibility
- add change-aware escalation only for demonstrated high-risk paths