### PR TITLE
Expose shared SurroundingRectangle family adapters

### DIFF
--- a/crates/noon-web/src/lib.rs
+++ b/crates/noon-web/src/lib.rs
@@ -20,6 +20,8 @@ mod manim_geometry_bridge;
 mod manim_path_query_bridge;
 mod manim_sector_bridge;
 mod manim_shape_matcher_bridge;
+#[cfg(any(target_arch = "wasm32", test))]
+mod manim_shape_matcher_handle_bridge;
 mod reactive_authoring_facade;
 mod reactive_player;
 mod retained_authoring;

--- a/crates/noon-web/src/manim_shape_matcher_handle_bridge.rs
+++ b/crates/noon-web/src/manim_shape_matcher_handle_bridge.rs
@@ -1,0 +1,230 @@
+use noon::{
+    BackgroundRectangle, IntoSnapshot, SurroundingRectangle, SURROUNDING_RECTANGLE_DEFAULT_COLOR,
+};
+use noon_core::{Rect, Vec2, BLACK};
+
+fn finite_f32(name: &str, value: f64) -> Result<f32, String> {
+    if !value.is_finite() || value.abs() > f64::from(f32::MAX) {
+        return Err(format!("{name} must be a finite f32-compatible number"));
+    }
+    Ok(value as f32)
+}
+
+fn rect_from_center_size(
+    center_x: f64,
+    center_y: f64,
+    width: f64,
+    height: f64,
+) -> Result<Rect, String> {
+    if !width.is_finite() || width < 0.0 {
+        return Err("family layout width must be finite and non-negative".to_owned());
+    }
+    if !height.is_finite() || height < 0.0 {
+        return Err("family layout height must be finite and non-negative".to_owned());
+    }
+    let half_width = width * 0.5;
+    let half_height = height * 0.5;
+    Ok(Rect::new(
+        Vec2::new(
+            finite_f32("family bounds min.x", center_x - half_width)?,
+            finite_f32("family bounds min.y", center_y - half_height)?,
+        ),
+        Vec2::new(
+            finite_f32("family bounds max.x", center_x + half_width)?,
+            finite_f32("family bounds max.y", center_y + half_height)?,
+        ),
+    ))
+}
+
+fn encode_snapshot(snapshot: noon_core::ObjectSnapshot) -> Result<String, String> {
+    serde_json::to_string(&snapshot)
+        .map_err(|error| format!("unable to serialize shape matcher snapshot: {error}"))
+}
+
+fn surrounding_from_bounds_json(
+    bounds: Rect,
+    buff_x: f64,
+    buff_y: f64,
+    corner_radius: f64,
+) -> Result<String, String> {
+    SurroundingRectangle::around_world_bounds(
+        bounds,
+        Vec2::new(finite_f32("buff.x", buff_x)?, finite_f32("buff.y", buff_y)?),
+        finite_f32("corner_radius", corner_radius)?,
+        SURROUNDING_RECTANGLE_DEFAULT_COLOR,
+    )
+    .map(IntoSnapshot::into_snapshot)
+    .map_err(|error| error.to_string())
+    .and_then(encode_snapshot)
+}
+
+fn background_from_bounds_json(
+    bounds: Rect,
+    buff_x: f64,
+    buff_y: f64,
+    corner_radius: f64,
+    fill_opacity: f64,
+) -> Result<String, String> {
+    BackgroundRectangle::around_world_bounds(
+        bounds,
+        Vec2::new(finite_f32("buff.x", buff_x)?, finite_f32("buff.y", buff_y)?),
+        finite_f32("corner_radius", corner_radius)?,
+        BLACK,
+        finite_f32("fill_opacity", fill_opacity)?,
+    )
+    .map(IntoSnapshot::into_snapshot)
+    .map_err(|error| error.to_string())
+    .and_then(encode_snapshot)
+}
+
+#[cfg(target_arch = "wasm32")]
+mod wasm {
+    use noon_core::Rect;
+    use wasm_bindgen::prelude::*;
+
+    use crate::{WasmAuthoringFamilyLayout, WasmAuthoringMobjectHandle};
+
+    use super::{background_from_bounds_json, rect_from_center_size, surrounding_from_bounds_json};
+
+    fn js_error(error: String) -> JsValue {
+        JsValue::from_str(&error)
+    }
+
+    fn family_bounds(layout: &WasmAuthoringFamilyLayout) -> Result<Rect, JsValue> {
+        rect_from_center_size(
+            layout.center_x()?,
+            layout.center_y()?,
+            layout.width()?,
+            layout.height()?,
+        )
+        .map_err(js_error)
+    }
+
+    #[wasm_bindgen]
+    impl WasmAuthoringMobjectHandle {
+        #[wasm_bindgen(js_name = surroundingRectangleSnapshotJson)]
+        pub fn surrounding_rectangle_snapshot_json(
+            &self,
+            buff_x: f64,
+            buff_y: f64,
+            corner_radius: f64,
+        ) -> Result<String, JsValue> {
+            crate::manim_shape_matcher_bridge::manim_surrounding_rectangle_snapshot_json(
+                &self.snapshot_json()?,
+                buff_x,
+                buff_y,
+                corner_radius,
+            )
+            .map_err(js_error)
+        }
+
+        #[wasm_bindgen(js_name = backgroundRectangleSnapshotJson)]
+        pub fn background_rectangle_snapshot_json(
+            &self,
+            buff_x: f64,
+            buff_y: f64,
+            corner_radius: f64,
+            fill_opacity: f64,
+        ) -> Result<String, JsValue> {
+            crate::manim_shape_matcher_bridge::manim_background_rectangle_snapshot_json(
+                &self.snapshot_json()?,
+                buff_x,
+                buff_y,
+                corner_radius,
+                fill_opacity,
+            )
+            .map_err(js_error)
+        }
+    }
+
+    #[wasm_bindgen]
+    impl WasmAuthoringFamilyLayout {
+        #[wasm_bindgen(js_name = surroundingRectangleSnapshotJson)]
+        pub fn surrounding_rectangle_snapshot_json(
+            &self,
+            buff_x: f64,
+            buff_y: f64,
+            corner_radius: f64,
+        ) -> Result<String, JsValue> {
+            surrounding_from_bounds_json(family_bounds(self)?, buff_x, buff_y, corner_radius)
+                .map_err(js_error)
+        }
+
+        #[wasm_bindgen(js_name = backgroundRectangleSnapshotJson)]
+        pub fn background_rectangle_snapshot_json(
+            &self,
+            buff_x: f64,
+            buff_y: f64,
+            corner_radius: f64,
+            fill_opacity: f64,
+        ) -> Result<String, JsValue> {
+            background_from_bounds_json(
+                family_bounds(self)?,
+                buff_x,
+                buff_y,
+                corner_radius,
+                fill_opacity,
+            )
+            .map_err(js_error)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use noon::BACKGROUND_RECTANGLE_DEFAULT_FILL_OPACITY;
+    use noon_core::{ObjectSnapshot, Vec2};
+
+    use super::*;
+
+    fn decode(value: &str) -> ObjectSnapshot {
+        serde_json::from_str(value).expect("valid matcher snapshot")
+    }
+
+    #[test]
+    fn family_center_size_lowers_to_exact_world_bounds() {
+        assert_eq!(
+            rect_from_center_size(1.0, -2.0, 8.0, 6.0).unwrap(),
+            Rect::new(Vec2::new(-3.0, -5.0), Vec2::new(5.0, 1.0))
+        );
+    }
+
+    #[test]
+    fn family_bounds_matcher_keeps_geometry_and_style_in_shared_rust() {
+        let bounds = rect_from_center_size(1.0, -2.0, 8.0, 6.0).unwrap();
+        let surrounding = decode(&surrounding_from_bounds_json(bounds, 0.25, 0.5, 0.1).unwrap());
+        let center = surrounding.center();
+        assert!((center.x - 1.0).abs() <= 1e-5);
+        assert!((center.y + 2.0).abs() <= 1e-5);
+        assert!((surrounding.width() - 8.5).abs() <= 1e-5);
+        assert!((surrounding.height() - 7.0).abs() <= 1e-5);
+        assert_eq!(
+            surrounding.style.stroke,
+            Some(SURROUNDING_RECTANGLE_DEFAULT_COLOR)
+        );
+
+        let background = decode(
+            &background_from_bounds_json(
+                bounds,
+                0.0,
+                0.0,
+                0.0,
+                f64::from(BACKGROUND_RECTANGLE_DEFAULT_FILL_OPACITY),
+            )
+            .unwrap(),
+        );
+        assert_eq!(background.style.stroke_width, 0.0);
+        assert!(
+            (background.style.fill.unwrap().alpha - BACKGROUND_RECTANGLE_DEFAULT_FILL_OPACITY)
+                .abs()
+                <= 1e-5
+        );
+    }
+
+    #[test]
+    fn invalid_family_extent_fails_closed() {
+        assert!(rect_from_center_size(0.0, 0.0, -1.0, 1.0).is_err());
+        assert!(rect_from_center_size(0.0, 0.0, 1.0, f64::NAN).is_err());
+        assert!(rect_from_center_size(f64::MAX, 0.0, 1.0, 1.0).is_err());
+    }
+}

--- a/web/python/_manim_shared_geometry.py
+++ b/web/python/_manim_shared_geometry.py
@@ -273,6 +273,117 @@ class RoundedRectangle(_compat.Rectangle):
             _set_shared_color(self, color)
 
 
+def _shape_matcher_buff(buff: object) -> tuple[float, float]:
+    if isinstance(buff, (int, float)) and not isinstance(buff, bool):
+        value = _shared._ir._finite_number("buff", buff)
+        return value, value
+    value = _compat._as_vec2(buff)
+    return (
+        _shared._ir._finite_number("buff.x", value.x),
+        _shared._ir._finite_number("buff.y", value.y),
+    )
+
+
+def _shape_matcher_target(target: object):
+    if not isinstance(target, _base.Mobject):
+        raise TypeError("shape matcher target must be a Mobject")
+    if isinstance(target, _compat.Group):
+        shared = _shared._shared_family_layout_session(target)
+        if shared is None:
+            raise NotImplementedError(
+                "shape matcher Group/VGroup targets require shared semantic family bounds"
+            )
+        return shared[0]
+    handle = _shared._handle_for(target)
+    if handle is None or not hasattr(handle, "snapshotJson"):
+        raise NotImplementedError(
+            "shape matcher target requires current shared semantic geometry"
+        )
+    return handle
+
+
+def _shape_matcher_handle(target: object, method: str, *args: float):
+    if _shared._create_handle is None:
+        raise RuntimeError("shape matchers require the shared browser geometry bridge")
+    source = _shape_matcher_target(target)
+    constructor = getattr(source, method, None)
+    if constructor is None:
+        raise NotImplementedError(
+            "shape matcher target bridge does not expose shared matcher construction"
+        )
+    return _shared._create_handle(constructor(*args))
+
+
+class SurroundingRectangle(RoundedRectangle):
+    """Manim SurroundingRectangle backed entirely by shared layout/matcher bounds."""
+
+    def __init__(
+        self,
+        mobject: _base.Mobject,
+        color: _base.Color = _geometry.PURE_YELLOW,
+        buff: object = _base.SMALL_BUFF,
+        corner_radius: float = 0.0,
+        **kwargs: Any,
+    ) -> None:
+        buff_x, buff_y = _shape_matcher_buff(buff)
+        radius = _shared._ir._finite_number("corner_radius", corner_radius)
+        _shared._attach_shared_handle(
+            self,
+            _shape_matcher_handle(
+                mobject,
+                "surroundingRectangleSnapshotJson",
+                buff_x,
+                buff_y,
+                radius,
+            ),
+        )
+        self.buff = buff
+        self.corner_radius = radius
+        _shared._apply_shared_constructor_kwargs(self, dict(kwargs))
+        if color is not None:
+            _set_shared_color(self, color)
+
+
+class BackgroundRectangle(SurroundingRectangle):
+    """Manim BackgroundRectangle using the same shared family-bounds matcher path."""
+
+    def __init__(
+        self,
+        mobject: _base.Mobject,
+        color: _base.Color = _base.BLACK,
+        stroke_width: float = 0.0,
+        stroke_opacity: float = 0.0,
+        fill_opacity: float = 0.75,
+        buff: object = 0.0,
+        **kwargs: Any,
+    ) -> None:
+        options = dict(kwargs)
+        corner_radius = _shared._ir._finite_number(
+            "corner_radius", options.pop("corner_radius", 0.0)
+        )
+        buff_x, buff_y = _shape_matcher_buff(buff)
+        fill_value = _shared._phase_b._opacity("fill_opacity", fill_opacity)
+        _shared._attach_shared_handle(
+            self,
+            _shape_matcher_handle(
+                mobject,
+                "backgroundRectangleSnapshotJson",
+                buff_x,
+                buff_y,
+                corner_radius,
+                fill_value,
+            ),
+        )
+        self.buff = buff
+        self.corner_radius = corner_radius
+        options["stroke_width"] = stroke_width
+        options["stroke_opacity"] = stroke_opacity
+        options["fill_opacity"] = fill_value
+        _shared._apply_shared_constructor_kwargs(self, options)
+        if color is not None:
+            _set_shared_color(self, color)
+
+
 class Underline(_compat.Line):
     """Manim Underline backed by the shared Rust line-matcher semantics."""
 
@@ -499,6 +610,8 @@ def install() -> None:
     public = {
         "Elbow": Elbow,
         "RoundedRectangle": RoundedRectangle,
+        "SurroundingRectangle": SurroundingRectangle,
+        "BackgroundRectangle": BackgroundRectangle,
         "Underline": Underline,
         "AnnularSector": AnnularSector,
         "Sector": Sector,

--- a/web/python/test_manim_shared_shape_matchers.py
+++ b/web/python/test_manim_shared_shape_matchers.py
@@ -1,0 +1,348 @@
+import os
+import subprocess
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+
+
+class ManimSharedShapeMatcherTests(unittest.TestCase):
+    def test_leaf_and_family_targets_stay_on_shared_matcher_path(self) -> None:
+        python_dir = Path(__file__).resolve().parent
+        env = os.environ.copy()
+        existing = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = (
+            str(python_dir)
+            if not existing
+            else os.pathsep.join((str(python_dir), existing))
+        )
+        source = textwrap.dedent(
+            r"""
+            import json
+
+            import _manim_compat
+            _manim_compat.install()
+            import _manim_phase_b
+            import _manim_geometry
+            import _manim_semantic_handles as handles
+
+            calls = []
+
+            def snapshot(cx, cy, width, height, *, background=False, fill_opacity=0.75):
+                return {
+                    "geometry": {"rectangle": {"size": {"x": float(width), "y": float(height)}}},
+                    "transform": {
+                        "translation": {"x": float(cx), "y": float(cy)},
+                        "rotation": 0.0,
+                        "scale": {"x": 1.0, "y": 1.0},
+                    },
+                    "style": {
+                        "fill": {
+                            "red": 0.0 if background else 1.0,
+                            "green": 0.0 if background else 1.0,
+                            "blue": 0.0,
+                            "alpha": float(fill_opacity) if background else 0.0,
+                        },
+                        "stroke": {
+                            "red": 0.0 if background else 1.0,
+                            "green": 0.0 if background else 1.0,
+                            "blue": 0.0,
+                            "alpha": 0.0 if background else 1.0,
+                        },
+                        "stroke_width": 0.0 if background else 0.04,
+                        "stroke_width_mode": "screen_space",
+                        "stroke_join": "miter",
+                        "stroke_cap": "butt",
+                        "opacity": 1.0,
+                    },
+                }
+
+            class FakeHandle:
+                def __init__(self, store, snapshot_json):
+                    self.store = store
+                    self.identity = store.allocate()
+                    self.snapshot = json.loads(snapshot_json)
+                    self._sync()
+
+                def _sync(self):
+                    transform = self.snapshot["transform"]
+                    self.wireTranslationX = float(transform["translation"]["x"])
+                    self.wireTranslationY = float(transform["translation"]["y"])
+                    self.wireScaleX = float(transform["scale"]["x"])
+                    self.wireScaleY = float(transform["scale"]["y"])
+                    self.wireRotation = float(transform["rotation"])
+                    fill = self.snapshot["style"]["fill"]
+                    stroke = self.snapshot["style"]["stroke"]
+                    self.wireHasFill = fill is not None
+                    self.wireFillRed = 0.0 if fill is None else float(fill["red"])
+                    self.wireFillGreen = 0.0 if fill is None else float(fill["green"])
+                    self.wireFillBlue = 0.0 if fill is None else float(fill["blue"])
+                    self.wireFillAlpha = 0.0 if fill is None else float(fill["alpha"])
+                    self.wireHasStroke = stroke is not None
+                    self.wireStrokeRed = 0.0 if stroke is None else float(stroke["red"])
+                    self.wireStrokeGreen = 0.0 if stroke is None else float(stroke["green"])
+                    self.wireStrokeBlue = 0.0 if stroke is None else float(stroke["blue"])
+                    self.wireStrokeAlpha = 0.0 if stroke is None else float(stroke["alpha"])
+                    self.wireStrokeWidth = float(self.snapshot["style"]["stroke_width"])
+                    self.wireObjectOpacity = float(self.snapshot["style"]["opacity"])
+
+                def snapshotJson(self):
+                    return json.dumps(self.snapshot, separators=(",", ":"))
+
+                @property
+                def centerX(self):
+                    return self.wireTranslationX
+
+                @property
+                def centerY(self):
+                    return self.wireTranslationY
+
+                @property
+                def width(self):
+                    return float(self.snapshot["geometry"]["rectangle"]["size"]["x"])
+
+                @property
+                def height(self):
+                    return float(self.snapshot["geometry"]["rectangle"]["size"]["y"])
+
+                @property
+                def fillOpacity(self):
+                    return self.wireFillAlpha
+
+                @property
+                def strokeOpacity(self):
+                    return self.wireStrokeAlpha
+
+                def criticalX(self, direction_x, direction_y):
+                    del direction_y
+                    edge = self.width * 0.5
+                    return self.centerX + (edge if direction_x > 0 else (-edge if direction_x < 0 else 0.0))
+
+                def criticalY(self, direction_x, direction_y):
+                    del direction_x
+                    edge = self.height * 0.5
+                    return self.centerY + (edge if direction_y > 0 else (-edge if direction_y < 0 else 0.0))
+
+                def shift(self, x, y):
+                    translation = self.snapshot["transform"]["translation"]
+                    translation["x"] += float(x)
+                    translation["y"] += float(y)
+                    self._sync()
+
+                def surroundingRectangleSnapshotJson(self, buff_x, buff_y, corner_radius):
+                    calls.append(("leaf-surround", float(buff_x), float(buff_y), float(corner_radius)))
+                    return json.dumps(snapshot(
+                        self.centerX,
+                        self.centerY,
+                        self.width + 2.0 * float(buff_x),
+                        self.height + 2.0 * float(buff_y),
+                    ))
+
+                def backgroundRectangleSnapshotJson(self, buff_x, buff_y, corner_radius, fill_opacity):
+                    calls.append(("leaf-background", float(buff_x), float(buff_y), float(corner_radius)))
+                    return json.dumps(snapshot(
+                        self.centerX,
+                        self.centerY,
+                        self.width + 2.0 * float(buff_x),
+                        self.height + 2.0 * float(buff_y),
+                        background=True,
+                        fill_opacity=float(fill_opacity),
+                    ))
+
+                def setStrokeWidth(self, value):
+                    self.snapshot["style"]["stroke_width"] = float(value)
+                    self._sync()
+
+                def setFillOpacity(self, value):
+                    self.snapshot["style"]["fill"]["alpha"] = float(value)
+                    self._sync()
+
+                def setStrokeOpacity(self, value):
+                    self.snapshot["style"]["stroke"]["alpha"] = float(value)
+                    self._sync()
+
+                def setFillColor(self, red, green, blue, alpha):
+                    del alpha
+                    current = self.snapshot["style"]["fill"]["alpha"]
+                    self.snapshot["style"]["fill"] = {
+                        "red": float(red), "green": float(green), "blue": float(blue), "alpha": current
+                    }
+                    self._sync()
+
+                def setStrokeColor(self, red, green, blue, alpha):
+                    del alpha
+                    current = self.snapshot["style"]["stroke"]["alpha"]
+                    self.snapshot["style"]["stroke"] = {
+                        "red": float(red), "green": float(green), "blue": float(blue), "alpha": current
+                    }
+                    self._sync()
+
+            class FakeLayoutSession:
+                def __init__(self):
+                    self.members = []
+
+                def includeMobject(self, member):
+                    self.members.append(member)
+
+                def _bounds(self):
+                    min_x = min(member.criticalX(-1.0, 0.0) for member in self.members)
+                    max_x = max(member.criticalX(1.0, 0.0) for member in self.members)
+                    min_y = min(member.criticalY(0.0, -1.0) for member in self.members)
+                    max_y = max(member.criticalY(0.0, 1.0) for member in self.members)
+                    return min_x, min_y, max_x, max_y
+
+                @property
+                def centerX(self):
+                    min_x, _, max_x, _ = self._bounds()
+                    return (min_x + max_x) * 0.5
+
+                @property
+                def centerY(self):
+                    _, min_y, _, max_y = self._bounds()
+                    return (min_y + max_y) * 0.5
+
+                @property
+                def width(self):
+                    min_x, _, max_x, _ = self._bounds()
+                    return max_x - min_x
+
+                @property
+                def height(self):
+                    _, min_y, _, max_y = self._bounds()
+                    return max_y - min_y
+
+                def surroundingRectangleSnapshotJson(self, buff_x, buff_y, corner_radius):
+                    calls.append(("family-surround", len(self.members), float(corner_radius)))
+                    return json.dumps(snapshot(
+                        self.centerX, self.centerY,
+                        self.width + 2.0 * float(buff_x), self.height + 2.0 * float(buff_y)
+                    ))
+
+                def backgroundRectangleSnapshotJson(self, buff_x, buff_y, corner_radius, fill_opacity):
+                    calls.append(("family-background", len(self.members), float(corner_radius)))
+                    return json.dumps(snapshot(
+                        self.centerX, self.centerY,
+                        self.width + 2.0 * float(buff_x), self.height + 2.0 * float(buff_y),
+                        background=True, fill_opacity=float(fill_opacity)
+                    ))
+
+            class FakeFamilyHandle:
+                def __init__(self, store):
+                    self.store = store
+                    self.identity = store.allocate()
+                    self.members = []
+
+                def layoutSession(self):
+                    return FakeLayoutSession()
+
+                @property
+                def memberCount(self):
+                    return len(self.members)
+
+                def addMobject(self, member):
+                    if member.identity in self.members:
+                        return False
+                    self.members.append(member.identity)
+                    return True
+
+                def addFamily(self, member):
+                    return self.addMobject(member)
+
+                def removeMobject(self, member):
+                    if member.identity not in self.members:
+                        return False
+                    self.members.remove(member.identity)
+                    return True
+
+                def removeFamily(self, member):
+                    return self.removeMobject(member)
+
+            class FakeStore:
+                def __init__(self):
+                    self.next_identity = 0
+
+                def allocate(self):
+                    value = self.next_identity
+                    self.next_identity += 1
+                    return value
+
+                def createMobject(self, snapshot_json):
+                    return FakeHandle(self, snapshot_json)
+
+                def createRectangle(self, width, height):
+                    return self.createMobject(json.dumps(snapshot(0.0, 0.0, width, height)))
+
+                def createFamily(self):
+                    return FakeFamilyHandle(self)
+
+            store = FakeStore()
+            handles._create_handle = store.createMobject
+            handles._create_rectangle_handle = store.createRectangle
+            handles._create_family_handle = store.createFamily
+            handles.install()
+
+            import noon as _base
+            _base._bounds = lambda *args, **kwargs: (_ for _ in ()).throw(
+                AssertionError("Python bounds computation was called")
+            )
+
+            import _manim_shared_geometry
+            _manim_shared_geometry.install()
+            from noon import BackgroundRectangle, BLUE, Rectangle, SurroundingRectangle, VGroup
+
+            leaf = Rectangle(width=4.0, height=2.0)
+            surround = SurroundingRectangle(leaf, buff=(0.25, 0.5), color=BLUE)
+            assert isinstance(surround, Rectangle)
+            assert calls[0][:3] == ("leaf-surround", 0.25, 0.5)
+            assert abs(surround.width - 4.5) < 1e-9
+            assert abs(surround.height - 3.0) < 1e-9
+
+            left = Rectangle(width=2.0, height=2.0).shift((-2.0, 0.0, 0.0))
+            right = Rectangle(width=4.0, height=1.0).shift((3.0, 2.0, 0.0))
+            family = VGroup(left, right)
+            grouped = SurroundingRectangle(family, buff=(0.25, 0.5))
+            assert calls[-1][0] == "family-surround"
+            assert calls[-1][1] == 2
+            assert abs(grouped.width - 8.5) < 1e-9
+            assert abs(grouped.height - 4.5) < 1e-9
+
+            background = BackgroundRectangle(family, fill_opacity=0.6)
+            assert calls[-1][0] == "family-background"
+            assert abs(background.get_fill_opacity() - 0.6) < 1e-9
+            assert abs(background.get_stroke_opacity()) < 1e-9
+            assert background.style["stroke_width"] == 0.0
+
+            family._semantic_family_handle = None
+            try:
+                SurroundingRectangle(family)
+            except NotImplementedError as error:
+                assert "shared semantic family bounds" in str(error)
+            else:
+                raise AssertionError("family matcher must not fall back to Python bounds")
+
+            leaf._semantic_handle_fresh = False
+            try:
+                BackgroundRectangle(leaf)
+            except NotImplementedError as error:
+                assert "shared semantic geometry" in str(error)
+            else:
+                raise AssertionError("stale leaf matcher must fail closed")
+            """
+        )
+        completed = subprocess.run(
+            [sys.executable, "-c", source],
+            cwd=python_dir,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(
+            completed.returncode,
+            0,
+            f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- expose public Python `SurroundingRectangle` and `BackgroundRectangle` on the shared semantic-handle path
- support both ordinary shared leaf mobjects and `Group` / `VGroup` targets
- add matcher-construction methods directly to the existing WASM mobject and completed family-layout handles
- register only the final Rust-produced matcher snapshot through the existing shared authoring store
- fail closed for stale/non-shared targets rather than falling back to Python bounds reconstruction

## Architecture
This completes the frontend seam unlocked by #712 and #727. Group/VGroup traversal, authoritative leaf order, and aggregate layout bounds stay owned by the existing Rust `WasmAuthoringFamilyLayout`; matcher geometry/style stays owned by `noon` through the bounds-native shape-matcher constructors.

Python only normalizes constructor arguments and selects the appropriate shared handle. It does not union bounds, decode transforms, serialize each family member, or synthesize a temporary aggregate scene object. No renderer primitive, execution protocol, worker lifecycle, or per-frame work is added.

## Focused coverage
- leaf targets use the shared mobject matcher method
- Group/VGroup targets use the shared completed family-layout session and union bounds
- `BackgroundRectangle` preserves fill/stroke defaults through the shared matcher path
- Python bounds fallback is explicitly forbidden in the regression
- stale/non-shared targets fail closed
- Rust coverage pins family center/size lowering, shared matcher geometry/style, and malformed extents

## Qualification
The exact feature tree previously passed all 13 legacy PR workflow families at `8405c24a580495701c9c1bf0e67a3f5e4422b08a`. Master then advanced through the shared family-animation refactor and CI consolidation, including changes to `family_bounds.rs` but none of this PR's four files. The exact same four feature blobs were replayed directly onto current master `d95ea11894db7e00b9e168b780b3b182d2d1b6a4` as one clean commit `95cf2737afce0f21100b78ac5a0e9b85ee5feba2`.

Only fresh exact-head validation for `95cf2737…` is valid for merge.

Tracks #400 / #76.