### PR TITLE
Generalize retained family animation semantics

### DIFF
--- a/crates/noon-core/src/family_animation.rs
+++ b/crates/noon-core/src/family_animation.rs
@@ -1,0 +1,369 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{FamilyAnimationProgressError, ObjectId, RateFunction, UniformFamilyAnimationPlan};
+
+/// Content-independent retained family animation operation.
+///
+/// Concrete resources decide how each operation is realized for one animation
+/// member; scheduling, lag mapping, reversal, and easing remain shared semantics.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FamilyAnimationMode {
+    Reveal,
+    DrawBorderThenFill,
+}
+
+/// One source-level retained animation over an authoritative semantic family.
+///
+/// The overall timeline stays object/family-level. Member decomposition is owned by
+/// the target content/resource, while this shared definition owns deterministic
+/// timing and ordering semantics for every content type.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+pub struct FamilyAnimationDefinition {
+    pub object: ObjectId,
+    pub mode: FamilyAnimationMode,
+    pub start_time: f64,
+    pub duration: f64,
+    pub lag_ratio: f64,
+    pub rate_function: RateFunction,
+    pub reverse_rate_function: bool,
+    pub reverse_member_order: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum FamilyAnimationError {
+    InvalidStartTime(f64),
+    InvalidDuration(f64),
+    InvalidEndTime(f64),
+    InvalidLagRatio(f64),
+    InvalidEvaluationTime(f64),
+    InvalidOverallProgress(f64),
+    FamilyProgress(FamilyAnimationProgressError),
+}
+
+impl std::fmt::Display for FamilyAnimationError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidStartTime(value) => {
+                write!(formatter, "invalid family animation start time {value}")
+            }
+            Self::InvalidDuration(value) => {
+                write!(formatter, "invalid family animation duration {value}")
+            }
+            Self::InvalidEndTime(value) => {
+                write!(formatter, "invalid family animation end time {value}")
+            }
+            Self::InvalidLagRatio(value) => {
+                write!(formatter, "invalid family animation lag ratio {value}")
+            }
+            Self::InvalidEvaluationTime(value) => {
+                write!(
+                    formatter,
+                    "invalid family animation evaluation time {value}"
+                )
+            }
+            Self::InvalidOverallProgress(value) => {
+                write!(formatter, "invalid family animation progress {value}")
+            }
+            Self::FamilyProgress(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl std::error::Error for FamilyAnimationError {}
+
+impl From<FamilyAnimationProgressError> for FamilyAnimationError {
+    fn from(value: FamilyAnimationProgressError) -> Self {
+        Self::FamilyProgress(value)
+    }
+}
+
+impl FamilyAnimationDefinition {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        object: ObjectId,
+        mode: FamilyAnimationMode,
+        start_time: f64,
+        duration: f64,
+        lag_ratio: f64,
+        rate_function: RateFunction,
+        reverse_rate_function: bool,
+        reverse_member_order: bool,
+    ) -> Result<Self, FamilyAnimationError> {
+        let definition = Self {
+            object,
+            mode,
+            start_time,
+            duration,
+            lag_ratio,
+            rate_function,
+            reverse_rate_function,
+            reverse_member_order,
+        };
+        definition.validate()?;
+        Ok(definition)
+    }
+
+    /// Revalidate a definition after any serialization boundary.
+    pub fn validate(self) -> Result<(), FamilyAnimationError> {
+        if !self.start_time.is_finite() {
+            return Err(FamilyAnimationError::InvalidStartTime(self.start_time));
+        }
+        if !self.duration.is_finite() || self.duration <= 0.0 {
+            return Err(FamilyAnimationError::InvalidDuration(self.duration));
+        }
+        let end_time = self.start_time + self.duration;
+        if !end_time.is_finite() {
+            return Err(FamilyAnimationError::InvalidEndTime(end_time));
+        }
+        if !self.lag_ratio.is_finite() || self.lag_ratio < 0.0 {
+            return Err(FamilyAnimationError::InvalidLagRatio(self.lag_ratio));
+        }
+        Ok(())
+    }
+
+    pub fn end_time(self) -> f64 {
+        self.start_time + self.duration
+    }
+
+    /// Evaluate only object/family-level timeline position. Per-member lag and
+    /// easing are preserved in the returned state and applied after the concrete
+    /// resource supplies the authoritative member count/order.
+    pub fn state_at(self, time: f64) -> Result<FamilyAnimationState, FamilyAnimationError> {
+        self.validate()?;
+        if !time.is_finite() {
+            return Err(FamilyAnimationError::InvalidEvaluationTime(time));
+        }
+        let overall_progress = ((time - self.start_time) / self.duration).clamp(0.0, 1.0);
+        Ok(FamilyAnimationState {
+            mode: self.mode,
+            overall_progress,
+            lag_ratio: self.lag_ratio,
+            rate_function: self.rate_function,
+            reverse_rate_function: self.reverse_rate_function,
+            reverse_member_order: self.reverse_member_order,
+        })
+    }
+}
+
+/// Evaluated content-independent frame state for one retained family animation.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+pub struct FamilyAnimationState {
+    pub mode: FamilyAnimationMode,
+    pub overall_progress: f64,
+    pub lag_ratio: f64,
+    pub rate_function: RateFunction,
+    pub reverse_rate_function: bool,
+    pub reverse_member_order: bool,
+}
+
+impl FamilyAnimationState {
+    /// Revalidate evaluated state after transport/deserialization.
+    pub fn validate(self) -> Result<(), FamilyAnimationError> {
+        if !self.overall_progress.is_finite() || !(0.0..=1.0).contains(&self.overall_progress) {
+            return Err(FamilyAnimationError::InvalidOverallProgress(
+                self.overall_progress,
+            ));
+        }
+        if !self.lag_ratio.is_finite() || self.lag_ratio < 0.0 {
+            return Err(FamilyAnimationError::InvalidLagRatio(self.lag_ratio));
+        }
+        Ok(())
+    }
+
+    pub fn member_progress(
+        self,
+        member_index: u32,
+        member_count: u32,
+    ) -> Result<f32, FamilyAnimationError> {
+        self.validate()?;
+        let scheduled_index = if self.reverse_member_order {
+            member_count
+                .checked_sub(1)
+                .and_then(|last| last.checked_sub(member_index))
+                .ok_or(FamilyAnimationProgressError::InvalidMemberIndex {
+                    index: member_index,
+                    member_count,
+                })?
+        } else {
+            member_index
+        };
+        let plan = UniformFamilyAnimationPlan::new(member_count, self.lag_ratio)?;
+        Ok(plan.member_progress(
+            self.overall_progress,
+            scheduled_index,
+            self.rate_function,
+            self.reverse_rate_function,
+        )?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn close(actual: f32, expected: f32) {
+        assert!(
+            (actual - expected).abs() <= 1e-6,
+            "expected {expected}, got {actual}"
+        );
+    }
+
+    fn definition(
+        reverse_rate_function: bool,
+        reverse_member_order: bool,
+    ) -> FamilyAnimationDefinition {
+        FamilyAnimationDefinition::new(
+            ObjectId::new(7),
+            FamilyAnimationMode::Reveal,
+            2.0,
+            4.0,
+            1.0,
+            RateFunction::Linear,
+            reverse_rate_function,
+            reverse_member_order,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn object_timeline_progress_is_clamped_but_not_eased() {
+        let animation = definition(false, false);
+        assert_eq!(animation.state_at(1.0).unwrap().overall_progress, 0.0);
+        assert_eq!(animation.state_at(4.0).unwrap().overall_progress, 0.5);
+        assert_eq!(animation.state_at(7.0).unwrap().overall_progress, 1.0);
+        assert_eq!(animation.end_time(), 6.0);
+    }
+
+    #[test]
+    fn lag_one_member_progress_is_content_independent() {
+        let state = definition(false, false).state_at(4.0).unwrap();
+        let values = (0..5)
+            .map(|index| state.member_progress(index, 5).unwrap())
+            .collect::<Vec<_>>();
+        for (actual, expected) in values.into_iter().zip([1.0, 1.0, 0.5, 0.0, 0.0]) {
+            close(actual, expected);
+        }
+    }
+
+    #[test]
+    fn rate_reversal_and_member_reversal_are_independent() {
+        let reversed_rate = definition(true, false).state_at(4.0).unwrap();
+        let rate_values = (0..5)
+            .map(|index| reversed_rate.member_progress(index, 5).unwrap())
+            .collect::<Vec<_>>();
+        for (actual, expected) in rate_values.into_iter().zip([0.0, 0.0, 0.5, 1.0, 1.0]) {
+            close(actual, expected);
+        }
+
+        let reversed_members = definition(false, true).state_at(2.8).unwrap();
+        close(reversed_members.member_progress(0, 5).unwrap(), 0.0);
+        close(reversed_members.member_progress(4, 5).unwrap(), 1.0);
+
+        let both = definition(true, true).state_at(2.8).unwrap();
+        close(both.member_progress(0, 5).unwrap(), 1.0);
+        close(both.member_progress(4, 5).unwrap(), 0.0);
+    }
+
+    #[test]
+    fn serialized_definition_and_state_are_revalidated() {
+        let mut invalid_definition = definition(false, false);
+        invalid_definition.duration = f64::INFINITY;
+        assert_eq!(
+            invalid_definition.validate(),
+            Err(FamilyAnimationError::InvalidDuration(f64::INFINITY))
+        );
+        assert_eq!(
+            invalid_definition.state_at(3.0),
+            Err(FamilyAnimationError::InvalidDuration(f64::INFINITY))
+        );
+
+        let mut invalid_state = definition(false, false).state_at(3.0).unwrap();
+        invalid_state.overall_progress = 1.5;
+        assert_eq!(
+            invalid_state.validate(),
+            Err(FamilyAnimationError::InvalidOverallProgress(1.5))
+        );
+        assert_eq!(
+            invalid_state.member_progress(0, 1),
+            Err(FamilyAnimationError::InvalidOverallProgress(1.5))
+        );
+    }
+
+    #[test]
+    fn invalid_timing_and_member_inputs_fail_closed() {
+        assert!(matches!(
+            FamilyAnimationDefinition::new(
+                ObjectId::new(1),
+                FamilyAnimationMode::Reveal,
+                f64::NAN,
+                1.0,
+                0.0,
+                RateFunction::Linear,
+                false,
+                false,
+            ),
+            Err(FamilyAnimationError::InvalidStartTime(value)) if value.is_nan()
+        ));
+        assert_eq!(
+            FamilyAnimationDefinition::new(
+                ObjectId::new(1),
+                FamilyAnimationMode::Reveal,
+                0.0,
+                0.0,
+                0.0,
+                RateFunction::Linear,
+                false,
+                false,
+            ),
+            Err(FamilyAnimationError::InvalidDuration(0.0))
+        );
+        assert_eq!(
+            FamilyAnimationDefinition::new(
+                ObjectId::new(1),
+                FamilyAnimationMode::Reveal,
+                f64::MAX,
+                f64::MAX,
+                0.0,
+                RateFunction::Linear,
+                false,
+                false,
+            ),
+            Err(FamilyAnimationError::InvalidEndTime(f64::INFINITY))
+        );
+        assert_eq!(
+            FamilyAnimationDefinition::new(
+                ObjectId::new(1),
+                FamilyAnimationMode::Reveal,
+                0.0,
+                1.0,
+                -0.1,
+                RateFunction::Linear,
+                false,
+                false,
+            ),
+            Err(FamilyAnimationError::InvalidLagRatio(-0.1))
+        );
+
+        let state = definition(false, false).state_at(3.0).unwrap();
+        assert!(matches!(
+            state.member_progress(0, 0),
+            Err(FamilyAnimationError::FamilyProgress(
+                FamilyAnimationProgressError::Composition(_)
+            ))
+        ));
+        assert!(matches!(
+            state.member_progress(5, 5),
+            Err(FamilyAnimationError::FamilyProgress(
+                FamilyAnimationProgressError::InvalidMemberIndex {
+                    index: 5,
+                    member_count: 5,
+                }
+            ))
+        ));
+        assert!(matches!(
+            definition(false, false).state_at(f64::INFINITY),
+            Err(FamilyAnimationError::InvalidEvaluationTime(value)) if value.is_infinite()
+        ));
+    }
+}

--- a/crates/noon-core/src/reactive.rs
+++ b/crates/noon-core/src/reactive.rs
@@ -48,6 +48,10 @@ pub use text_resources::*;
 mod text_animation_members;
 pub use text_animation_members::*;
 
+#[path = "family_animation.rs"]
+mod family_animation;
+pub use family_animation::*;
+
 #[path = "text_family_animation.rs"]
 mod text_family_animation;
 pub use text_family_animation::*;

--- a/crates/noon-core/src/text_family_animation.rs
+++ b/crates/noon-core/src/text_family_animation.rs
@@ -1,326 +1,42 @@
-use serde::{Deserialize, Serialize};
+use crate::{
+    FamilyAnimationDefinition, FamilyAnimationError, FamilyAnimationMode, FamilyAnimationState,
+};
 
-use crate::{FamilyAnimationProgressError, ObjectId, RateFunction, UniformFamilyAnimationPlan};
-
-/// Renderer-visible behavior for one retained Text family animation.
+/// Backward-compatible retained Text names.
 ///
-/// `Reveal` is the pointwise partial-path behavior used by Create/Uncreate.
-/// `DrawBorderThenFill` is intentionally distinct for Write/Unwrite; it must not be
-/// approximated by the same reveal mode merely because both animate family members.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum TextFamilyAnimationMode {
-    Reveal,
-    DrawBorderThenFill,
-}
-
-/// One source-level retained Text family animation.
-///
-/// The overall timeline remains object-level, while lag/easing are preserved until
-/// the renderer evaluates individual shaped members. This is required because Manim
-/// applies `rate_function` after per-member lag mapping rather than to one global
-/// reveal scalar.
-#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
-pub struct TextFamilyAnimationDefinition {
-    pub object: ObjectId,
-    pub mode: TextFamilyAnimationMode,
-    pub start_time: f64,
-    pub duration: f64,
-    pub lag_ratio: f64,
-    pub rate_function: RateFunction,
-    pub reverse_rate_function: bool,
-    pub reverse_member_order: bool,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub enum TextFamilyAnimationError {
-    InvalidStartTime(f64),
-    InvalidDuration(f64),
-    InvalidEndTime(f64),
-    InvalidLagRatio(f64),
-    InvalidEvaluationTime(f64),
-    InvalidOverallProgress(f64),
-    FamilyProgress(FamilyAnimationProgressError),
-}
-
-impl std::fmt::Display for TextFamilyAnimationError {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::InvalidStartTime(value) => {
-                write!(
-                    formatter,
-                    "invalid Text family animation start time {value}"
-                )
-            }
-            Self::InvalidDuration(value) => {
-                write!(formatter, "invalid Text family animation duration {value}")
-            }
-            Self::InvalidEndTime(value) => {
-                write!(formatter, "invalid Text family animation end time {value}")
-            }
-            Self::InvalidLagRatio(value) => {
-                write!(formatter, "invalid Text family animation lag ratio {value}")
-            }
-            Self::InvalidEvaluationTime(value) => {
-                write!(
-                    formatter,
-                    "invalid Text family animation evaluation time {value}"
-                )
-            }
-            Self::InvalidOverallProgress(value) => {
-                write!(formatter, "invalid Text family animation progress {value}")
-            }
-            Self::FamilyProgress(error) => error.fmt(formatter),
-        }
-    }
-}
-
-impl std::error::Error for TextFamilyAnimationError {}
-
-impl From<FamilyAnimationProgressError> for TextFamilyAnimationError {
-    fn from(value: FamilyAnimationProgressError) -> Self {
-        Self::FamilyProgress(value)
-    }
-}
-
-impl TextFamilyAnimationDefinition {
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        object: ObjectId,
-        mode: TextFamilyAnimationMode,
-        start_time: f64,
-        duration: f64,
-        lag_ratio: f64,
-        rate_function: RateFunction,
-        reverse_rate_function: bool,
-        reverse_member_order: bool,
-    ) -> Result<Self, TextFamilyAnimationError> {
-        let definition = Self {
-            object,
-            mode,
-            start_time,
-            duration,
-            lag_ratio,
-            rate_function,
-            reverse_rate_function,
-            reverse_member_order,
-        };
-        definition.validate()?;
-        Ok(definition)
-    }
-
-    /// Revalidate a definition after any serialization boundary.
-    pub fn validate(self) -> Result<(), TextFamilyAnimationError> {
-        if !self.start_time.is_finite() {
-            return Err(TextFamilyAnimationError::InvalidStartTime(self.start_time));
-        }
-        if !self.duration.is_finite() || self.duration <= 0.0 {
-            return Err(TextFamilyAnimationError::InvalidDuration(self.duration));
-        }
-        let end_time = self.start_time + self.duration;
-        if !end_time.is_finite() {
-            return Err(TextFamilyAnimationError::InvalidEndTime(end_time));
-        }
-        if !self.lag_ratio.is_finite() || self.lag_ratio < 0.0 {
-            return Err(TextFamilyAnimationError::InvalidLagRatio(self.lag_ratio));
-        }
-        Ok(())
-    }
-
-    pub fn end_time(self) -> f64 {
-        self.start_time + self.duration
-    }
-
-    /// Evaluate only the object-level timeline position. Per-member lag and easing
-    /// remain encoded in the returned state and are applied later against the shaped
-    /// resource's actual animation-member count.
-    pub fn state_at(self, time: f64) -> Result<TextFamilyAnimationState, TextFamilyAnimationError> {
-        self.validate()?;
-        if !time.is_finite() {
-            return Err(TextFamilyAnimationError::InvalidEvaluationTime(time));
-        }
-        let overall_progress = ((time - self.start_time) / self.duration).clamp(0.0, 1.0);
-        Ok(TextFamilyAnimationState {
-            mode: self.mode,
-            overall_progress,
-            lag_ratio: self.lag_ratio,
-            rate_function: self.rate_function,
-            reverse_rate_function: self.reverse_rate_function,
-            reverse_member_order: self.reverse_member_order,
-        })
-    }
-}
-
-/// Evaluated frame state for one retained Text family animation.
-///
-/// This structure is transport-friendly but contains no glyph IDs. The renderer
-/// combines it with derived [`crate::TextAnimationMember`] data from the immutable
-/// Text resource, preserving one semantic scene object and avoiding per-frame Python
-/// callbacks.
-#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
-pub struct TextFamilyAnimationState {
-    pub mode: TextFamilyAnimationMode,
-    pub overall_progress: f64,
-    pub lag_ratio: f64,
-    pub rate_function: RateFunction,
-    pub reverse_rate_function: bool,
-    pub reverse_member_order: bool,
-}
-
-impl TextFamilyAnimationState {
-    /// Revalidate evaluated state after transport/deserialization.
-    pub fn validate(self) -> Result<(), TextFamilyAnimationError> {
-        if !self.overall_progress.is_finite() || !(0.0..=1.0).contains(&self.overall_progress) {
-            return Err(TextFamilyAnimationError::InvalidOverallProgress(
-                self.overall_progress,
-            ));
-        }
-        if !self.lag_ratio.is_finite() || self.lag_ratio < 0.0 {
-            return Err(TextFamilyAnimationError::InvalidLagRatio(self.lag_ratio));
-        }
-        Ok(())
-    }
-
-    pub fn member_progress(
-        self,
-        member_index: u32,
-        member_count: u32,
-    ) -> Result<f32, TextFamilyAnimationError> {
-        self.validate()?;
-        let scheduled_index = if self.reverse_member_order {
-            member_count
-                .checked_sub(1)
-                .and_then(|last| last.checked_sub(member_index))
-                .ok_or(FamilyAnimationProgressError::InvalidMemberIndex {
-                    index: member_index,
-                    member_count,
-                })?
-        } else {
-            member_index
-        };
-        let plan = UniformFamilyAnimationPlan::new(member_count, self.lag_ratio)?;
-        Ok(plan.member_progress(
-            self.overall_progress,
-            scheduled_index,
-            self.rate_function,
-            self.reverse_rate_function,
-        )?)
-    }
-}
+/// Text is the first consumer of the generic family animation model. Keeping these
+/// aliases avoids churn at current compiler/runtime/renderer call sites while the
+/// shared abstraction is adopted by additional content types.
+pub type TextFamilyAnimationMode = FamilyAnimationMode;
+pub type TextFamilyAnimationDefinition = FamilyAnimationDefinition;
+pub type TextFamilyAnimationState = FamilyAnimationState;
+pub type TextFamilyAnimationError = FamilyAnimationError;
 
 #[cfg(test)]
 mod tests {
+    use crate::{ObjectId, RateFunction};
+
     use super::*;
 
-    fn close(actual: f32, expected: f32) {
-        assert!(
-            (actual - expected).abs() <= 1e-6,
-            "expected {expected}, got {actual}"
-        );
-    }
-
-    fn definition(
-        reverse_rate_function: bool,
-        reverse_member_order: bool,
-    ) -> TextFamilyAnimationDefinition {
-        TextFamilyAnimationDefinition::new(
-            ObjectId::new(7),
-            TextFamilyAnimationMode::Reveal,
+    #[test]
+    fn retained_text_aliases_preserve_the_existing_typed_api() {
+        let animation = TextFamilyAnimationDefinition::new(
+            ObjectId::new(9),
+            TextFamilyAnimationMode::DrawBorderThenFill,
+            0.0,
             2.0,
-            4.0,
-            1.0,
-            RateFunction::Linear,
-            reverse_rate_function,
-            reverse_member_order,
+            0.2,
+            RateFunction::Smooth,
+            false,
+            true,
         )
-        .unwrap()
-    }
-
-    #[test]
-    fn object_timeline_progress_is_clamped_but_not_eased() {
-        let animation = definition(false, false);
-        assert_eq!(animation.state_at(1.0).unwrap().overall_progress, 0.0);
-        assert_eq!(animation.state_at(4.0).unwrap().overall_progress, 0.5);
-        assert_eq!(animation.state_at(7.0).unwrap().overall_progress, 1.0);
-        assert_eq!(animation.end_time(), 6.0);
-    }
-
-    #[test]
-    fn create_member_progress_matches_manim_lag_one() {
-        let state = definition(false, false).state_at(4.0).unwrap();
-        let values = (0..5)
-            .map(|index| state.member_progress(index, 5).unwrap())
-            .collect::<Vec<_>>();
-        for (actual, expected) in values.into_iter().zip([1.0, 1.0, 0.5, 0.0, 0.0]) {
-            close(actual, expected);
-        }
-    }
-
-    #[test]
-    fn uncreate_reverses_rate_without_reversing_member_order() {
-        let state = definition(true, false).state_at(4.0).unwrap();
-        let values = (0..5)
-            .map(|index| state.member_progress(index, 5).unwrap())
-            .collect::<Vec<_>>();
-        for (actual, expected) in values.into_iter().zip([0.0, 0.0, 0.5, 1.0, 1.0]) {
-            close(actual, expected);
-        }
-    }
-
-    #[test]
-    fn reversed_write_order_is_independent_from_rate_reversal() {
-        let state = definition(false, true).state_at(2.8).unwrap();
-        close(state.member_progress(0, 5).unwrap(), 0.0);
-        close(state.member_progress(4, 5).unwrap(), 1.0);
-
-        let unwrite = definition(true, true).state_at(2.8).unwrap();
-        close(unwrite.member_progress(0, 5).unwrap(), 1.0);
-        close(unwrite.member_progress(4, 5).unwrap(), 0.0);
-    }
-
-    #[test]
-    fn serialized_definition_and_state_are_revalidated() {
-        let mut invalid_definition = definition(false, false);
-        invalid_definition.duration = f64::INFINITY;
-        assert_eq!(
-            invalid_definition.validate(),
-            Err(TextFamilyAnimationError::InvalidDuration(f64::INFINITY))
-        );
-        assert_eq!(
-            invalid_definition.state_at(3.0),
-            Err(TextFamilyAnimationError::InvalidDuration(f64::INFINITY))
-        );
-
-        let mut invalid_state = definition(false, false).state_at(3.0).unwrap();
-        invalid_state.overall_progress = 1.5;
-        assert_eq!(
-            invalid_state.validate(),
-            Err(TextFamilyAnimationError::InvalidOverallProgress(1.5))
-        );
-        assert_eq!(
-            invalid_state.member_progress(0, 1),
-            Err(TextFamilyAnimationError::InvalidOverallProgress(1.5))
-        );
-    }
-
-    #[test]
-    fn invalid_timing_and_member_inputs_fail_closed() {
+        .unwrap();
+        let state: TextFamilyAnimationState = animation.state_at(1.0).unwrap();
+        assert_eq!(state.mode, TextFamilyAnimationMode::DrawBorderThenFill);
+        assert_eq!(state.overall_progress, 0.5);
         assert!(matches!(
             TextFamilyAnimationDefinition::new(
-                ObjectId::new(1),
-                TextFamilyAnimationMode::Reveal,
-                f64::NAN,
-                1.0,
-                0.0,
-                RateFunction::Linear,
-                false,
-                false,
-            ),
-            Err(TextFamilyAnimationError::InvalidStartTime(value)) if value.is_nan()
-        ));
-        assert_eq!(
-            TextFamilyAnimationDefinition::new(
-                ObjectId::new(1),
+                ObjectId::new(9),
                 TextFamilyAnimationMode::Reveal,
                 0.0,
                 0.0,
@@ -330,53 +46,6 @@ mod tests {
                 false,
             ),
             Err(TextFamilyAnimationError::InvalidDuration(0.0))
-        );
-        assert_eq!(
-            TextFamilyAnimationDefinition::new(
-                ObjectId::new(1),
-                TextFamilyAnimationMode::Reveal,
-                f64::MAX,
-                f64::MAX,
-                0.0,
-                RateFunction::Linear,
-                false,
-                false,
-            ),
-            Err(TextFamilyAnimationError::InvalidEndTime(f64::INFINITY))
-        );
-        assert_eq!(
-            TextFamilyAnimationDefinition::new(
-                ObjectId::new(1),
-                TextFamilyAnimationMode::Reveal,
-                0.0,
-                1.0,
-                -0.1,
-                RateFunction::Linear,
-                false,
-                false,
-            ),
-            Err(TextFamilyAnimationError::InvalidLagRatio(-0.1))
-        );
-
-        let state = definition(false, false).state_at(3.0).unwrap();
-        assert!(matches!(
-            state.member_progress(0, 0),
-            Err(TextFamilyAnimationError::FamilyProgress(
-                FamilyAnimationProgressError::Composition(_)
-            ))
-        ));
-        assert!(matches!(
-            state.member_progress(5, 5),
-            Err(TextFamilyAnimationError::FamilyProgress(
-                FamilyAnimationProgressError::InvalidMemberIndex {
-                    index: 5,
-                    member_count: 5,
-                }
-            ))
-        ));
-        assert!(matches!(
-            definition(false, false).state_at(f64::INFINITY),
-            Err(TextFamilyAnimationError::InvalidEvaluationTime(value)) if value.is_infinite()
         ));
     }
 }

--- a/crates/noon-runtime/src/retained_text_family.rs
+++ b/crates/noon-runtime/src/retained_text_family.rs
@@ -1,10 +1,226 @@
 use noon_compile::RetainedCompiledScene;
 use noon_core::{
-    ObjectId, TextFamilyAnimationDefinition, TextFamilyAnimationError, TextFamilyAnimationState,
+    FamilyAnimationDefinition, FamilyAnimationError, FamilyAnimationState, ObjectId,
+    TextFamilyAnimationDefinition, TextFamilyAnimationError, TextFamilyAnimationState,
 };
 
 use crate::{EvaluationError, FrameChanges, RetainedFrameState, RetainedSceneInstance};
 
+/// Evaluated retained frame plus content-independent family animation state.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct RetainedFamilyFrame<'a> {
+    pub retained: &'a RetainedFrameState,
+    pub family_animations: &'a [Option<FamilyAnimationState>],
+}
+
+impl RetainedFamilyFrame<'_> {
+    pub fn family_animation(&self, object_index: usize) -> Option<FamilyAnimationState> {
+        self.family_animations.get(object_index).copied().flatten()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum RetainedFamilyRuntimeError {
+    Animation(FamilyAnimationError),
+    UnknownObject(ObjectId),
+    OverlappingAnimations {
+        object: ObjectId,
+        previous_start: f64,
+        previous_end: f64,
+        next_start: f64,
+    },
+    Evaluation(EvaluationError),
+}
+
+impl std::fmt::Display for RetainedFamilyRuntimeError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Animation(error) => error.fmt(formatter),
+            Self::UnknownObject(object) => write!(
+                formatter,
+                "family animation references unknown retained object {}",
+                object.get()
+            ),
+            Self::OverlappingAnimations {
+                object,
+                previous_start,
+                previous_end,
+                next_start,
+            } => write!(
+                formatter,
+                "family animations overlap for object {}: previous [{previous_start}, {previous_end}], next starts at {next_start}",
+                object.get()
+            ),
+            Self::Evaluation(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl std::error::Error for RetainedFamilyRuntimeError {}
+
+impl From<FamilyAnimationError> for RetainedFamilyRuntimeError {
+    fn from(value: FamilyAnimationError) -> Self {
+        Self::Animation(value)
+    }
+}
+
+impl From<EvaluationError> for RetainedFamilyRuntimeError {
+    fn from(value: EvaluationError) -> Self {
+        Self::Evaluation(value)
+    }
+}
+
+/// Additive retained runtime for content-independent family animations.
+///
+/// Ordinary retained object properties remain owned by [`RetainedSceneInstance`].
+/// This wrapper evaluates only family scheduling state. Concrete content/resource
+/// layers decide how a member realizes `Reveal`, `DrawBorderThenFill`, or future
+/// family operations; no content identity or host callback enters this scheduler.
+#[derive(Clone, Debug)]
+pub struct RetainedFamilySceneInstance {
+    inner: RetainedSceneInstance,
+    animations_by_object: Vec<Vec<FamilyAnimationDefinition>>,
+    states: Vec<Option<FamilyAnimationState>>,
+    family_changed_indices: Vec<usize>,
+}
+
+impl RetainedFamilySceneInstance {
+    pub fn new(
+        compiled: RetainedCompiledScene,
+        animations: Vec<FamilyAnimationDefinition>,
+    ) -> Result<Self, RetainedFamilyRuntimeError> {
+        let object_count = compiled.objects().len();
+        let mut animations_by_object = vec![Vec::new(); object_count];
+
+        for animation in animations {
+            animation.validate()?;
+            let object_index = compiled
+                .object_index(animation.object)
+                .ok_or(RetainedFamilyRuntimeError::UnknownObject(animation.object))?
+                as usize;
+            animations_by_object[object_index].push(animation);
+        }
+
+        for object_animations in &mut animations_by_object {
+            object_animations.sort_by(|left, right| left.start_time.total_cmp(&right.start_time));
+            for pair in object_animations.windows(2) {
+                let previous = pair[0];
+                let next = pair[1];
+                if next.start_time < previous.end_time() {
+                    return Err(RetainedFamilyRuntimeError::OverlappingAnimations {
+                        object: previous.object,
+                        previous_start: previous.start_time,
+                        previous_end: previous.end_time(),
+                        next_start: next.start_time,
+                    });
+                }
+            }
+        }
+
+        let inner = RetainedSceneInstance::new(compiled);
+        let states = evaluate_family_states(&animations_by_object, 0.0)?;
+        Ok(Self {
+            inner,
+            animations_by_object,
+            states,
+            family_changed_indices: Vec::new(),
+        })
+    }
+
+    pub fn frame(&self) -> RetainedFamilyFrame<'_> {
+        RetainedFamilyFrame {
+            retained: self.inner.frame(),
+            family_animations: &self.states,
+        }
+    }
+
+    pub fn evaluate(
+        &mut self,
+        time: f64,
+    ) -> Result<RetainedFamilyFrame<'_>, RetainedFamilyRuntimeError> {
+        self.inner.evaluate(time)?;
+        self.update_family_states(time)?;
+        Ok(self.frame())
+    }
+
+    pub fn seek(
+        &mut self,
+        time: f64,
+    ) -> Result<RetainedFamilyFrame<'_>, RetainedFamilyRuntimeError> {
+        self.inner.seek(time)?;
+        self.update_family_states(time)?;
+        Ok(self.frame())
+    }
+
+    pub fn advance_to(
+        &mut self,
+        time: f64,
+    ) -> Result<RetainedFamilyFrame<'_>, RetainedFamilyRuntimeError> {
+        self.inner.advance_to(time)?;
+        self.update_family_states(time)?;
+        Ok(self.frame())
+    }
+
+    pub fn take_frame_changes(&mut self) -> FrameChanges {
+        let base = self.inner.take_frame_changes();
+        if base.is_all() {
+            self.family_changed_indices.clear();
+            return FrameChanges::all();
+        }
+
+        let mut object_indices = base.object_indices().to_vec();
+        object_indices.append(&mut self.family_changed_indices);
+        object_indices.sort_unstable();
+        object_indices.dedup();
+        FrameChanges::with_structure(
+            object_indices,
+            base.added_indices().to_vec(),
+            base.removed_indices().to_vec(),
+        )
+    }
+
+    pub fn inner(&self) -> &RetainedSceneInstance {
+        &self.inner
+    }
+
+    fn update_family_states(&mut self, time: f64) -> Result<(), RetainedFamilyRuntimeError> {
+        let next = evaluate_family_states(&self.animations_by_object, time)?;
+        for (index, (previous, current)) in self.states.iter().zip(&next).enumerate() {
+            if previous != current {
+                self.family_changed_indices.push(index);
+            }
+        }
+        self.states = next;
+        Ok(())
+    }
+}
+
+fn evaluate_family_states(
+    animations_by_object: &[Vec<FamilyAnimationDefinition>],
+    time: f64,
+) -> Result<Vec<Option<FamilyAnimationState>>, RetainedFamilyRuntimeError> {
+    if !time.is_finite() {
+        return Err(RetainedFamilyRuntimeError::Evaluation(
+            EvaluationError::InvalidTime(time),
+        ));
+    }
+
+    animations_by_object
+        .iter()
+        .map(|animations| {
+            animations
+                .iter()
+                .rev()
+                .find(|animation| animation.start_time <= time && time <= animation.end_time())
+                .copied()
+                .map(|animation| animation.state_at(time))
+                .transpose()
+                .map_err(RetainedFamilyRuntimeError::from)
+        })
+        .collect()
+}
+
+/// Compatibility frame for the retained Text consumer.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RetainedTextFamilyFrame<'a> {
     pub retained: &'a RetainedFrameState,
@@ -65,30 +281,34 @@ impl std::fmt::Display for RetainedTextFamilyRuntimeError {
 
 impl std::error::Error for RetainedTextFamilyRuntimeError {}
 
-impl From<TextFamilyAnimationError> for RetainedTextFamilyRuntimeError {
-    fn from(value: TextFamilyAnimationError) -> Self {
-        Self::Animation(value)
+impl From<RetainedFamilyRuntimeError> for RetainedTextFamilyRuntimeError {
+    fn from(value: RetainedFamilyRuntimeError) -> Self {
+        match value {
+            RetainedFamilyRuntimeError::Animation(error) => Self::Animation(error),
+            RetainedFamilyRuntimeError::UnknownObject(object) => Self::UnknownObject(object),
+            RetainedFamilyRuntimeError::OverlappingAnimations {
+                object,
+                previous_start,
+                previous_end,
+                next_start,
+            } => Self::OverlappingAnimations {
+                object,
+                previous_start,
+                previous_end,
+                next_start,
+            },
+            RetainedFamilyRuntimeError::Evaluation(error) => Self::Evaluation(error),
+        }
     }
 }
 
-impl From<EvaluationError> for RetainedTextFamilyRuntimeError {
-    fn from(value: EvaluationError) -> Self {
-        Self::Evaluation(value)
-    }
-}
-
-/// Additive retained runtime for Text family animations.
+/// Retained Text compatibility adapter over the generic family scheduler.
 ///
-/// Ordinary retained object properties remain owned by [`RetainedSceneInstance`].
-/// This wrapper evaluates only content-specific Text family state, preserving raw
-/// animation progress until the renderer combines it with shaped resource members.
-/// No glyph identity or Python callback enters runtime state.
+/// Text-specific responsibility is now limited to validating that targets are
+/// retained Text objects and exposing the historical Text-named frame/error API.
 #[derive(Clone, Debug)]
 pub struct RetainedTextFamilySceneInstance {
-    inner: RetainedSceneInstance,
-    animations_by_object: Vec<Vec<TextFamilyAnimationDefinition>>,
-    states: Vec<Option<TextFamilyAnimationState>>,
-    family_changed_indices: Vec<usize>,
+    inner: RetainedFamilySceneInstance,
 }
 
 impl RetainedTextFamilySceneInstance {
@@ -96,11 +316,10 @@ impl RetainedTextFamilySceneInstance {
         compiled: RetainedCompiledScene,
         animations: Vec<TextFamilyAnimationDefinition>,
     ) -> Result<Self, RetainedTextFamilyRuntimeError> {
-        let object_count = compiled.objects().len();
-        let mut animations_by_object = vec![Vec::new(); object_count];
-
-        for animation in animations {
-            animation.validate()?;
+        for animation in &animations {
+            animation
+                .validate()
+                .map_err(RetainedTextFamilyRuntimeError::Animation)?;
             let object_index = compiled.object_index(animation.object).ok_or(
                 RetainedTextFamilyRuntimeError::UnknownObject(animation.object),
             )? as usize;
@@ -109,39 +328,19 @@ impl RetainedTextFamilySceneInstance {
                     animation.object,
                 ));
             }
-            animations_by_object[object_index].push(animation);
         }
 
-        for object_animations in &mut animations_by_object {
-            object_animations.sort_by(|left, right| left.start_time.total_cmp(&right.start_time));
-            for pair in object_animations.windows(2) {
-                let previous = pair[0];
-                let next = pair[1];
-                if next.start_time < previous.end_time() {
-                    return Err(RetainedTextFamilyRuntimeError::OverlappingAnimations {
-                        object: previous.object,
-                        previous_start: previous.start_time,
-                        previous_end: previous.end_time(),
-                        next_start: next.start_time,
-                    });
-                }
-            }
-        }
-
-        let inner = RetainedSceneInstance::new(compiled);
-        let states = evaluate_family_states(&animations_by_object, 0.0)?;
         Ok(Self {
-            inner,
-            animations_by_object,
-            states,
-            family_changed_indices: Vec::new(),
+            inner: RetainedFamilySceneInstance::new(compiled, animations)
+                .map_err(RetainedTextFamilyRuntimeError::from)?,
         })
     }
 
     pub fn frame(&self) -> RetainedTextFamilyFrame<'_> {
+        let frame = self.inner.frame();
         RetainedTextFamilyFrame {
-            retained: self.inner.frame(),
-            text_family_animations: &self.states,
+            retained: frame.retained,
+            text_family_animations: frame.family_animations,
         }
     }
 
@@ -149,8 +348,9 @@ impl RetainedTextFamilySceneInstance {
         &mut self,
         time: f64,
     ) -> Result<RetainedTextFamilyFrame<'_>, RetainedTextFamilyRuntimeError> {
-        self.inner.evaluate(time)?;
-        self.update_family_states(time)?;
+        self.inner
+            .evaluate(time)
+            .map_err(RetainedTextFamilyRuntimeError::from)?;
         Ok(self.frame())
     }
 
@@ -158,8 +358,9 @@ impl RetainedTextFamilySceneInstance {
         &mut self,
         time: f64,
     ) -> Result<RetainedTextFamilyFrame<'_>, RetainedTextFamilyRuntimeError> {
-        self.inner.seek(time)?;
-        self.update_family_states(time)?;
+        self.inner
+            .seek(time)
+            .map_err(RetainedTextFamilyRuntimeError::from)?;
         Ok(self.frame())
     }
 
@@ -167,75 +368,26 @@ impl RetainedTextFamilySceneInstance {
         &mut self,
         time: f64,
     ) -> Result<RetainedTextFamilyFrame<'_>, RetainedTextFamilyRuntimeError> {
-        self.inner.advance_to(time)?;
-        self.update_family_states(time)?;
+        self.inner
+            .advance_to(time)
+            .map_err(RetainedTextFamilyRuntimeError::from)?;
         Ok(self.frame())
     }
 
     pub fn take_frame_changes(&mut self) -> FrameChanges {
-        let base = self.inner.take_frame_changes();
-        if base.is_all() {
-            self.family_changed_indices.clear();
-            return FrameChanges::all();
-        }
-
-        let mut object_indices = base.object_indices().to_vec();
-        object_indices.append(&mut self.family_changed_indices);
-        object_indices.sort_unstable();
-        object_indices.dedup();
-        FrameChanges::with_structure(
-            object_indices,
-            base.added_indices().to_vec(),
-            base.removed_indices().to_vec(),
-        )
+        self.inner.take_frame_changes()
     }
 
     pub fn inner(&self) -> &RetainedSceneInstance {
-        &self.inner
+        self.inner.inner()
     }
-
-    fn update_family_states(&mut self, time: f64) -> Result<(), RetainedTextFamilyRuntimeError> {
-        let next = evaluate_family_states(&self.animations_by_object, time)?;
-        for (index, (previous, current)) in self.states.iter().zip(&next).enumerate() {
-            if previous != current {
-                self.family_changed_indices.push(index);
-            }
-        }
-        self.states = next;
-        Ok(())
-    }
-}
-
-fn evaluate_family_states(
-    animations_by_object: &[Vec<TextFamilyAnimationDefinition>],
-    time: f64,
-) -> Result<Vec<Option<TextFamilyAnimationState>>, RetainedTextFamilyRuntimeError> {
-    if !time.is_finite() {
-        return Err(RetainedTextFamilyRuntimeError::Evaluation(
-            EvaluationError::InvalidTime(time),
-        ));
-    }
-
-    animations_by_object
-        .iter()
-        .map(|animations| {
-            animations
-                .iter()
-                .rev()
-                .find(|animation| animation.start_time <= time && time <= animation.end_time())
-                .copied()
-                .map(|animation| animation.state_at(time))
-                .transpose()
-                .map_err(Into::into)
-        })
-        .collect()
 }
 
 #[cfg(test)]
 mod tests {
     use noon_core::{
-        GeometryRef, RateFunction, RetainedObjectDefinition, TextFamilyAnimationMode,
-        TextResourceHandle, TextResourceId,
+        FamilyAnimationMode, GeometryRef, RateFunction, RetainedObjectDefinition,
+        TextFamilyAnimationMode, TextResourceHandle, TextResourceId,
     };
 
     use super::*;
@@ -250,6 +402,17 @@ mod tests {
     fn compiled_text(object: ObjectId) -> RetainedCompiledScene {
         RetainedCompiledScene::compile(
             &[RetainedObjectDefinition::text(object, text_handle())],
+            &[],
+        )
+        .unwrap()
+    }
+
+    fn compiled_geometry(object: ObjectId) -> RetainedCompiledScene {
+        RetainedCompiledScene::compile(
+            &[RetainedObjectDefinition::geometry(
+                object,
+                GeometryRef::circle(1.0),
+            )],
             &[],
         )
         .unwrap()
@@ -273,6 +436,33 @@ mod tests {
             reverse_member_order,
         )
         .unwrap()
+    }
+
+    #[test]
+    fn generic_family_runtime_accepts_non_text_retained_objects() {
+        let object = ObjectId::new(5);
+        let definition = FamilyAnimationDefinition::new(
+            object,
+            FamilyAnimationMode::Reveal,
+            0.0,
+            2.0,
+            0.0,
+            RateFunction::Linear,
+            false,
+            false,
+        )
+        .unwrap();
+        let mut instance =
+            RetainedFamilySceneInstance::new(compiled_geometry(object), vec![definition]).unwrap();
+        instance.seek(1.0).unwrap();
+        assert_eq!(
+            instance
+                .frame()
+                .family_animation(0)
+                .unwrap()
+                .overall_progress,
+            0.5
+        );
     }
 
     #[test]
@@ -348,7 +538,7 @@ mod tests {
     }
 
     #[test]
-    fn overlapping_animations_on_one_text_object_fail_before_runtime_start() {
+    fn overlapping_animations_on_one_text_object_keep_compatibility_error() {
         let object = ObjectId::new(7);
         let error = RetainedTextFamilySceneInstance::new(
             compiled_text(object),
@@ -370,7 +560,7 @@ mod tests {
     }
 
     #[test]
-    fn unknown_and_non_text_targets_fail_closed() {
+    fn unknown_and_non_text_text_targets_fail_closed() {
         let text = ObjectId::new(7);
         assert_eq!(
             RetainedTextFamilySceneInstance::new(
@@ -382,17 +572,9 @@ mod tests {
         );
 
         let geometry = ObjectId::new(8);
-        let compiled = RetainedCompiledScene::compile(
-            &[RetainedObjectDefinition::geometry(
-                geometry,
-                GeometryRef::circle(1.0),
-            )],
-            &[],
-        )
-        .unwrap();
         assert_eq!(
             RetainedTextFamilySceneInstance::new(
-                compiled,
+                compiled_geometry(geometry),
                 vec![animation(geometry, 0.0, 1.0, false, false)],
             )
             .unwrap_err(),


### PR DESCRIPTION
Part of #737. Follow-up binding work is tracked in #741.

Generalizes the retained family-animation timing/runtime seam across core and runtime while preserving current retained Text behavior as a compatibility/content adapter.

### Core
- adds content-independent `FamilyAnimationMode`, `FamilyAnimationDefinition`, `FamilyAnimationState`, and `FamilyAnimationError` in a dedicated `family_animation` module;
- owns member scheduling, lag mapping, easing, rate reversal, member-order reversal, validation, and timeline state without referencing Text/glyph resources;
- keeps `TextFamilyAnimation*` as compatibility aliases, so current compiler/runtime/renderer call sites and serialized field/variant shapes do not need a migration in this PR.

### Runtime
- adds `RetainedFamilySceneInstance` / `RetainedFamilyFrame` as content-independent scheduling/runtime state;
- proves the generic runtime accepts a geometry retained object, so the scheduler is no longer inherently Text-only;
- reduces `RetainedTextFamilySceneInstance` to Text target validation plus compatibility frame/error names over the generic scheduler;
- preserves existing Text unknown-target, non-Text-target, overlap, seek/advance, and dirty-index behavior.

### Deliberate boundary
This PR extracts the shared scheduler only. It does **not** claim to solve composite semantic-family binding by itself. #741 owns the required global animation-member plan that flattens semantic family leaves and resource-local members (for example Text glyphs) into one Manim-compatible ordered timeline.

No public Manim feature is newly claimed supported by this refactor.