### PR TITLE
Load optional Manim namespace packages lazily

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,8 @@ jobs:
         run: node scripts/deterministic-replay-smoke.mjs
       - name: Test Manim-style Python compatibility
         run: node scripts/manim-compat-smoke.mjs
+      - name: Test lazy Manim namespace dependencies
+        run: node scripts/manim-namespace-smoke.mjs
       - name: Test Manim composition authoring
         run: node scripts/composition-authoring-smoke.mjs
       - name: Test executable Manim tutorial corpus

--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -147,6 +147,9 @@ jobs:
       - name: Check Manim-style authoring
         run: node scripts/manim-compat-smoke.mjs
 
+      - name: Check lazy Manim namespace dependencies
+        run: node scripts/manim-namespace-smoke.mjs
+
       - name: Check primary WebGPU rendering
         env:
           NOON_BROWSER_SMOKE_BACKEND: webgpu

--- a/scripts/manim-namespace-smoke.mjs
+++ b/scripts/manim-namespace-smoke.mjs
@@ -1,0 +1,173 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import playwright from "playwright";
+
+const { chromium } = playwright;
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const port = 4191;
+const baseUrl = `http://127.0.0.1:${port}`;
+
+let serverOutput = "";
+const server = spawn(
+  "python3",
+  ["-m", "http.server", String(port), "--bind", "127.0.0.1", "--directory", repoRoot],
+  { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] },
+);
+server.stdout.on("data", (chunk) => (serverOutput += chunk));
+server.stderr.on("data", (chunk) => (serverOutput += chunk));
+
+async function waitForServer() {
+  let lastError = null;
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    try {
+      const response = await fetch(`${baseUrl}/web/`);
+      if (response.ok) return;
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`namespace smoke server did not start: ${lastError}\n${serverOutput}`);
+}
+
+const coldSource = `from noon import *
+import sys
+
+assert "numpy" not in sys.modules
+assert PURE_RED.red == 1.0 and PURE_RED.green == 0.0 and PURE_RED.blue == 0.0
+assert PURE_GREEN.red == 0.0 and PURE_GREEN.green == 1.0 and PURE_GREEN.blue == 0.0
+
+class ColdNamespace(Scene):
+    def construct(self):
+        self.add(Circle(radius=0.2, color=PURE_GREEN))
+`;
+
+const numpySource = `from noon import *
+import sys
+
+class LazyNumpyNamespace(Scene):
+    def construct(self):
+        assert np.__name__ == "numpy"
+        assert "numpy" in sys.modules
+        value = float(np.log(np.e))
+        assert abs(value - 1.0) < 1e-12
+        self.add(Circle(radius=0.2, color=PURE_RED).shift(RIGHT * value))
+`;
+
+let browser = null;
+try {
+  await waitForServer();
+  browser = await chromium.launch({
+    channel: "chromium",
+    headless: true,
+    args: ["--disable-dev-shm-usage"],
+  });
+  const page = await browser.newPage();
+  const errors = [];
+  page.on("pageerror", (error) => errors.push(`pageerror: ${error}`));
+  page.on("console", (message) => {
+    if (message.type() === "error") errors.push(`console: ${message.text()}`);
+  });
+
+  await page.goto(`${baseUrl}/web/`, { waitUntil: "load" });
+  await page.evaluate(() => {
+    const worker = new Worker(new URL("./python-worker.js", location.href), {
+      name: "noon-manim-namespace-smoke",
+      type: "module",
+    });
+    let nextRequestId = 0;
+    const pending = new Map();
+    let resolveReady;
+    let rejectReady;
+    const ready = new Promise((resolve, reject) => {
+      resolveReady = resolve;
+      rejectReady = reject;
+    });
+
+    worker.addEventListener("error", (event) => {
+      const error = new Error(event.message || "namespace worker crashed");
+      rejectReady(error);
+      for (const { reject } of pending.values()) reject(error);
+      pending.clear();
+    });
+    worker.addEventListener("message", (event) => {
+      const message = event.data;
+      if (message?.channel !== "noon.authoring" || message?.protocolVersion !== 5) {
+        const error = new Error("invalid namespace worker envelope");
+        rejectReady(error);
+        for (const { reject } of pending.values()) reject(error);
+        pending.clear();
+        return;
+      }
+      if (message.type === "ready") {
+        resolveReady();
+        return;
+      }
+      if (message.type === "error") {
+        const error = new Error(String(message.message || "namespace authoring failed"));
+        const request = pending.get(message.requestId);
+        if (request) {
+          pending.delete(message.requestId);
+          request.reject(error);
+        } else {
+          rejectReady(error);
+        }
+        return;
+      }
+      if (message.type === "result") {
+        const request = pending.get(message.requestId);
+        if (!request) return;
+        pending.delete(message.requestId);
+        request.resolve(JSON.parse(message.resultJson));
+      }
+    });
+
+    window.noonNamespaceSmoke = {
+      ready: () => ready,
+      run: async (source) => {
+        await ready;
+        const requestId = nextRequestId++;
+        const result = new Promise((resolve, reject) => pending.set(requestId, { resolve, reject }));
+        worker.postMessage({
+          channel: "noon.authoring",
+          protocolVersion: 5,
+          type: "run",
+          requestId,
+          source,
+          context: {},
+        });
+        return result;
+      },
+      stop: () => worker.terminate(),
+    };
+  });
+  await page.evaluate(() => window.noonNamespaceSmoke.ready());
+
+  const cold = await page.evaluate(
+    (source) => window.noonNamespaceSmoke.run(source),
+    coldSource,
+  );
+  assert.equal(cold.kind, "scene_document");
+  assert.equal(cold.document.objects.length, 1);
+
+  const numpy = await page.evaluate(
+    (source) => window.noonNamespaceSmoke.run(source),
+    numpySource,
+  );
+  assert.equal(numpy.kind, "scene_document");
+  assert.equal(numpy.document.objects.length, 1);
+
+  await page.evaluate(() => window.noonNamespaceSmoke.stop());
+  assert.deepEqual(errors, [], `browser errors while testing lazy namespace loading:\n${errors.join("\n")}`);
+  console.log(
+    "Manim namespace smoke passed: baseline authoring leaves NumPy unloaded, np resolves to real NumPy on demand, and pure-color aliases match the pinned namespace.",
+  );
+} finally {
+  await browser?.close();
+  server.kill("SIGTERM");
+}

--- a/web/python-compat-modules.js
+++ b/web/python-compat-modules.js
@@ -2,6 +2,7 @@ export const PYTHON_COMPAT_MODULES = Object.freeze([
   { sourcePath: "python/noon.py", runtimePath: "/tmp/noon.py", label: "Noon Python API" },
   { sourcePath: "python/_noon_ir.py", runtimePath: "/tmp/_noon_ir.py", label: "Noon Python IR emitter" },
   { sourcePath: "python/_manim_compat.py", runtimePath: "/tmp/_manim_compat.py", label: "Noon Manim compatibility layer" },
+  { sourcePath: "python/_manim_namespace.py", runtimePath: "/tmp/_manim_namespace.py", label: "Noon Manim namespace compatibility layer" },
   { sourcePath: "python/_manim_semantic_handles.py", runtimePath: "/tmp/_manim_semantic_handles.py", label: "Noon shared semantic handle layer" },
   { sourcePath: "python/_manim_typst.py", runtimePath: "/tmp/_manim_typst.py", label: "Noon retained Typst compatibility layer" },
   { sourcePath: "python/_manim_retained_animate.py", runtimePath: "/tmp/_manim_retained_animate.py", label: "Noon retained text animation layer" },

--- a/web/python-worker.source.js
+++ b/web/python-worker.source.js
@@ -96,6 +96,8 @@ import sys
 sys.path.insert(0, "/tmp")
 import _manim_compat
 _manim_compat.install()
+import _manim_namespace
+_manim_namespace.install()
 import _manim_rate_functions
 _manim_rate_functions.install()
 import _manim_phase_b
@@ -302,7 +304,52 @@ async function handleHostRequest(request) {
   }
 }
 
+async function prepareAuthoringDependencies(pyodide, source) {
+  // Explicit user imports use Pyodide's normal package resolver. Local/stdlib imports
+  // remain cheap, while packages present in the Pyodide lockfile load only on demand.
+  await pyodide.loadPackagesFromImports(source);
+
+  const dictConstructor = pyodide.globals.get("dict");
+  const globals = dictConstructor();
+  dictConstructor.destroy();
+  globals.set("__noon_dependency_source", source);
+  try {
+    const requiredJson = pyodide.runPython(
+      `
+import _manim_namespace
+_manim_namespace.required_packages_json(__noon_dependency_source)
+`,
+      { globals },
+    );
+    const requiredPackages = JSON.parse(requiredJson);
+    if (requiredPackages.length === 0) return;
+
+    const requiredPackagesJson = JSON.stringify(requiredPackages);
+    globals.set("__noon_required_packages_json", requiredPackagesJson);
+    const missingJson = pyodide.runPython(
+      `
+_manim_namespace.missing_packages_json(__noon_required_packages_json)
+`,
+      { globals },
+    );
+    const missingPackages = JSON.parse(missingJson);
+    if (missingPackages.length > 0) {
+      await pyodide.loadPackage(missingPackages);
+    }
+    pyodide.runPython(
+      `
+_manim_namespace.bind_loaded_packages_json(__noon_required_packages_json)
+`,
+      { globals },
+    );
+  } finally {
+    globals.destroy();
+  }
+}
+
 async function runAuthoringSource(pyodide, source, context) {
+  await prepareAuthoringDependencies(pyodide, source);
+
   const dictConstructor = pyodide.globals.get("dict");
   const globals = dictConstructor();
   dictConstructor.destroy();

--- a/web/python/_manim_namespace.py
+++ b/web/python/_manim_namespace.py
@@ -1,0 +1,133 @@
+"""ManimCE top-level namespace parity with lazy browser dependencies.
+
+Manim exposes a few names from ``from manim import *`` that are not ordinary Manim
+objects. In particular, its package ``__init__`` imports NumPy as ``np``. Loading NumPy
+unconditionally in Pyodide would put a large optional dependency on every authoring
+startup, so this module separates namespace identity from asynchronous package loading.
+
+The JavaScript worker asks :func:`required_packages_json` before executing user source,
+loads only the returned Pyodide packages, then calls :func:`bind_loaded_packages_json`.
+Python never substitutes a partial implementation for an optional dependency.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import importlib.util
+import json
+from typing import Any
+
+import noon as _base
+
+
+_OPTIONAL_NAMESPACE_PACKAGES = {
+    "np": "numpy",
+}
+
+_PURE_COLORS = {
+    "PURE_RED": 0xFF0000,
+    "PURE_GREEN": 0x00FF00,
+    "PURE_BLUE": 0x0000FF,
+    "PURE_CYAN": 0x00FFFF,
+    "PURE_MAGENTA": 0xFF00FF,
+    "PURE_YELLOW": 0xFFFF00,
+}
+
+
+class _PendingOptionalNamespace:
+    """Explicit placeholder replaced by the worker before user code executes."""
+
+    __slots__ = ("alias", "package")
+
+    def __init__(self, alias: str, package: str) -> None:
+        self.alias = alias
+        self.package = package
+
+    def __getattr__(self, name: str) -> Any:
+        raise RuntimeError(
+            f"Manim namespace alias {self.alias!r} requires optional package "
+            f"{self.package!r}; the browser authoring worker did not load it before access"
+        )
+
+    def __repr__(self) -> str:
+        return f"<pending Manim namespace {self.alias!r} -> {self.package!r}>"
+
+
+def _loaded_names(source: str) -> set[str]:
+    """Return identifier names read by the source using only the stdlib AST parser."""
+
+    tree = ast.parse(source, mode="exec")
+    return {
+        node.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load)
+    }
+
+
+def required_packages(source: str) -> tuple[str, ...]:
+    """Return optional packages required by implicit Manim namespace aliases."""
+
+    names = _loaded_names(source)
+    return tuple(
+        package
+        for alias, package in _OPTIONAL_NAMESPACE_PACKAGES.items()
+        if alias in names
+    )
+
+
+def required_packages_json(source: str) -> str:
+    return json.dumps(required_packages(source), separators=(",", ":"))
+
+
+def missing_packages(packages: list[str] | tuple[str, ...]) -> tuple[str, ...]:
+    """Return requested packages that are not already importable in this interpreter."""
+
+    return tuple(
+        package
+        for package in packages
+        if importlib.util.find_spec(package) is None
+    )
+
+
+def missing_packages_json(packages_json: str) -> str:
+    value = json.loads(packages_json)
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise TypeError("optional package list must be a JSON string array")
+    return json.dumps(missing_packages(value), separators=(",", ":"))
+
+
+def bind_loaded_packages(packages: list[str] | tuple[str, ...]) -> None:
+    """Bind real imported modules for aliases whose Pyodide packages are loaded."""
+
+    requested = set(packages)
+    for alias, package in _OPTIONAL_NAMESPACE_PACKAGES.items():
+        if package not in requested:
+            continue
+        module = importlib.import_module(package)
+        setattr(_base, alias, module)
+
+
+def bind_loaded_packages_json(packages_json: str) -> None:
+    value = json.loads(packages_json)
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise TypeError("loaded optional package list must be a JSON string array")
+    bind_loaded_packages(value)
+
+
+def install() -> None:
+    """Install lightweight namespace names without importing optional packages."""
+
+    exports = list(_base.__all__)
+    for alias, package in _OPTIONAL_NAMESPACE_PACKAGES.items():
+        if not hasattr(_base, alias):
+            setattr(_base, alias, _PendingOptionalNamespace(alias, package))
+        if alias not in exports:
+            exports.append(alias)
+
+    for name, value in _PURE_COLORS.items():
+        setattr(_base, name, _base.color_from_hex(value))
+        if name not in exports:
+            exports.append(name)
+
+    _base.__all__ = exports

--- a/web/python/test_manim_namespace.py
+++ b/web/python/test_manim_namespace.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import unittest
+
+import noon as _base
+import _manim_namespace as namespace
+
+
+class ManimNamespaceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        namespace.install()
+
+    def test_optional_alias_detection_uses_python_syntax(self) -> None:
+        self.assertEqual(
+            namespace.required_packages(
+                "from noon import *\nclass Example(Scene):\n    def construct(self):\n        value = np.log(2.0)\n"
+            ),
+            ("numpy",),
+        )
+        self.assertEqual(
+            namespace.required_packages(
+                "from noon import *\nclass Example(Scene):\n    def construct(self):\n        self.add(Circle())\n"
+            ),
+            (),
+        )
+        self.assertEqual(
+            namespace.required_packages("message = 'np.log is only text here'\n"),
+            (),
+        )
+
+    def test_install_exposes_pending_alias_without_importing_numpy(self) -> None:
+        self.assertIn("np", _base.__all__)
+        pending = _base.np
+        if type(pending).__name__ == "_PendingOptionalNamespace":
+            with self.assertRaisesRegex(RuntimeError, "requires optional package 'numpy'"):
+                pending.log
+
+    def test_pure_colors_match_manim_v021(self) -> None:
+        expected = {
+            "PURE_RED": (1.0, 0.0, 0.0),
+            "PURE_GREEN": (0.0, 1.0, 0.0),
+            "PURE_BLUE": (0.0, 0.0, 1.0),
+            "PURE_CYAN": (0.0, 1.0, 1.0),
+            "PURE_MAGENTA": (1.0, 0.0, 1.0),
+            "PURE_YELLOW": (1.0, 1.0, 0.0),
+        }
+        for name, rgb in expected.items():
+            color = getattr(_base, name)
+            self.assertEqual((color.red, color.green, color.blue), rgb)
+            self.assertIn(name, _base.__all__)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a small `_manim_namespace` compatibility layer for ManimCE v0.21 top-level names that are not ordinary Noon objects
- expose the pinned pure-color constants used by upstream plotting/reference examples
- preserve Manim's `np` namespace alias without eagerly importing NumPy during normal browser startup
- inspect source with Python's stdlib AST to identify implicit namespace dependencies
- use Pyodide's normal `loadPackagesFromImports` path for explicit imports, then load only still-missing implicit packages and bind the real module before executing user source
- keep all package resolution on the authoring path; no package/import work enters playback or rendering
- add native namespace tests plus a real worker/browser smoke that first proves NumPy is absent on cold authoring, then proves `np.log` resolves to the real NumPy module on demand
- gate the smoke in both the new PR Fast Gate browser lane and exhaustive master CI

## Architecture
This is intentionally a declared namespace/dependency boundary rather than a fake compatibility implementation. `np` is a placeholder only until the asynchronous worker resolves its declared `numpy` package; once needed, the actual package is imported and installed into Noon's exported namespace.

Baseline scenes that do not reference optional aliases do not request NumPy. Repeated scenes reuse the interpreter/package state already present in Pyodide. Explicit user imports and implicit Manim aliases converge at one package-resolution boundary before authoring execution.

## Exact-head qualification
Current clean head: `8c1de048052e81289c5563c59e24c16d5e787f64`, one commit directly on master `3481beadb233509e803aa5419a3de95293cede8d`.

The master advancement from #738 touches only retained-family Rust modules and has zero overlap with this namespace implementation, so the seven feature/integration blobs are unchanged from the previous green head.

On this exact head, the single `PR Fast Gate` is fully green: Rust format/Clippy, Rust library tests, web static/unit preflight, one-time WASM build, deterministic playback, Manim-style authoring, `Check lazy Manim namespace dependencies`, primary WebGPU rendering, and the aggregate `PR Fast Gate` status all completed successfully. The real browser smoke proves cold authoring leaves NumPy unloaded and a later unchanged `np.log(np.e)` scene loads and binds the real NumPy module.

The validation topology is intentionally adapted to #734: `manim-namespace-smoke.mjs` runs in `.github/workflows/pr-fast.yml` for PR feedback and remains in exhaustive `.github/workflows/ci.yml` for master/manual validation.

The PR remains draft only because the connected GitHub `markPullRequestReadyForReview` mutation still fails before reaching the repository with an invalid GraphQL selection on `Repository.fullDatabaseId`. Do not close/recreate the PR merely to bypass connector tooling.

Closes #735. Related: #73, #91, #93, #253, #695, #696. Kept independent of #730 so Axes qualification is not reset by this package-loading work.