### PR TITLE
Centralize semantic family leaf traversal

### DIFF
--- a/crates/noon-core/src/reactive.rs
+++ b/crates/noon-core/src/reactive.rs
@@ -28,6 +28,9 @@ pub use lifecycle::*;
 mod semantic_store;
 pub use semantic_store::*;
 
+#[path = "semantic_family.rs"]
+mod semantic_family;
+
 #[path = "semantic_model.rs"]
 mod semantic_model;
 pub use semantic_model::*;

--- a/crates/noon-core/src/semantic_family.rs
+++ b/crates/noon-core/src/semantic_family.rs
@@ -1,0 +1,138 @@
+use std::collections::HashSet;
+
+use crate::{SemanticNodeId, SemanticNodeKind, SemanticStore, SemanticStoreError};
+
+impl SemanticStore {
+    /// Return render/animation leaves below `root` in authoritative semantic order.
+    ///
+    /// A non-family object is its own leaf. Families are flattened depth-first in
+    /// member order. Shared descendants are emitted once at their first occurrence,
+    /// matching Manim's ordered family de-duplication instead of animating aliases
+    /// multiple times.
+    pub fn ordered_leaf_nodes(
+        &self,
+        root: SemanticNodeId,
+    ) -> Result<Vec<SemanticNodeId>, SemanticStoreError> {
+        fn collect(
+            store: &SemanticStore,
+            node_id: SemanticNodeId,
+            seen: &mut HashSet<SemanticNodeId>,
+            leaves: &mut Vec<SemanticNodeId>,
+        ) -> Result<(), SemanticStoreError> {
+            let node = store
+                .node(node_id)
+                .ok_or(SemanticStoreError::UnknownNode(node_id))?;
+            match node.kind() {
+                SemanticNodeKind::Object(_) | SemanticNodeKind::AuthoringObject => {
+                    if seen.insert(node_id) {
+                        leaves.push(node_id);
+                    }
+                }
+                SemanticNodeKind::Family => {
+                    for member in node.members() {
+                        collect(store, *member, seen, leaves)?;
+                    }
+                }
+            }
+            Ok(())
+        }
+
+        // Validate the root even when it is an empty family.
+        self.node(root)
+            .ok_or(SemanticStoreError::UnknownNode(root))?;
+
+        let mut leaves = Vec::new();
+        let mut seen = HashSet::new();
+        collect(self, root, &mut seen, &mut leaves)?;
+        Ok(leaves)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{GeometryRef, ObjectDefinition, ObjectId};
+
+    use super::*;
+
+    fn object(id: u64) -> ObjectDefinition {
+        ObjectDefinition::new(ObjectId::new(id), GeometryRef::circle(1.0))
+    }
+
+    #[test]
+    fn leaf_target_is_its_own_ordered_leaf_sequence() {
+        let mut store = SemanticStore::new();
+        let object = store.insert_object(object(1));
+        let authoring = store.insert_authoring_object();
+
+        assert_eq!(store.ordered_leaf_nodes(object).unwrap(), vec![object]);
+        assert_eq!(
+            store.ordered_leaf_nodes(authoring).unwrap(),
+            vec![authoring]
+        );
+    }
+
+    #[test]
+    fn nested_family_preserves_authoritative_depth_first_member_order() {
+        let mut store = SemanticStore::new();
+        let first = store.insert_authoring_object();
+        let second = store.insert_authoring_object();
+        let third = store.insert_authoring_object();
+        let nested = store.insert_family();
+        let root = store.insert_family();
+
+        store.add_member(nested, second).unwrap();
+        store.add_member(nested, third).unwrap();
+        store.add_member(root, first).unwrap();
+        store.add_member(root, nested).unwrap();
+
+        assert_eq!(
+            store.ordered_leaf_nodes(root).unwrap(),
+            vec![first, second, third]
+        );
+    }
+
+    #[test]
+    fn aliased_leaf_is_emitted_once_at_first_family_occurrence() {
+        let mut store = SemanticStore::new();
+        let shared = store.insert_authoring_object();
+        let second = store.insert_authoring_object();
+        let nested = store.insert_family();
+        let root = store.insert_family();
+
+        store.add_member(nested, second).unwrap();
+        store.add_member(nested, shared).unwrap();
+        store.add_member(root, shared).unwrap();
+        store.add_member(root, nested).unwrap();
+
+        assert_eq!(
+            store.ordered_leaf_nodes(root).unwrap(),
+            vec![shared, second]
+        );
+    }
+
+    #[test]
+    fn empty_family_has_no_leaves() {
+        let mut store = SemanticStore::new();
+        let family = store.insert_family();
+        assert!(store.ordered_leaf_nodes(family).unwrap().is_empty());
+    }
+
+    #[test]
+    fn stale_or_unknown_root_fails_closed() {
+        let mut store = SemanticStore::new();
+        let stale = store.insert_authoring_object();
+        store.remove_node(stale).unwrap();
+
+        assert_eq!(
+            store.ordered_leaf_nodes(stale),
+            Err(SemanticStoreError::UnknownNode(stale))
+        );
+        assert_eq!(
+            store.ordered_leaf_nodes(SemanticNodeId::new(u32::MAX, 0)),
+            Err(SemanticStoreError::UnknownNode(SemanticNodeId::new(
+                u32::MAX,
+                0
+            )))
+        );
+    }
+}

--- a/crates/noon-web/src/family_bounds.rs
+++ b/crates/noon-web/src/family_bounds.rs
@@ -104,31 +104,6 @@ fn semantic_family_leaf_ids(
     store: &SemanticStore,
     family: SemanticNodeId,
 ) -> Result<Vec<SemanticNodeId>, String> {
-    fn collect(
-        store: &SemanticStore,
-        node_id: SemanticNodeId,
-        leaves: &mut Vec<SemanticNodeId>,
-    ) -> Result<(), String> {
-        let node = store
-            .node(node_id)
-            .ok_or_else(|| format!("unknown semantic family member {node_id:?}"))?;
-        match node.kind() {
-            SemanticNodeKind::AuthoringObject => {
-                leaves.push(node_id);
-                Ok(())
-            }
-            SemanticNodeKind::Family => {
-                for member in node.members() {
-                    collect(store, *member, leaves)?;
-                }
-                Ok(())
-            }
-            SemanticNodeKind::Object(_) => Err(format!(
-                "family bounds member {node_id:?} is not an authoring object"
-            )),
-        }
-    }
-
     let root = store
         .node(family)
         .ok_or_else(|| format!("unknown family semantic node {family:?}"))?;
@@ -136,8 +111,19 @@ fn semantic_family_leaf_ids(
         return Err(format!("semantic node {family:?} is not a family"));
     }
 
-    let mut leaves = Vec::new();
-    collect(store, family, &mut leaves)?;
+    let leaves = store
+        .ordered_leaf_nodes(family)
+        .map_err(|error| error.to_string())?;
+    for leaf in &leaves {
+        let node = store
+            .node(*leaf)
+            .ok_or_else(|| format!("unknown semantic family member {leaf:?}"))?;
+        if !matches!(node.kind(), SemanticNodeKind::AuthoringObject) {
+            return Err(format!(
+                "family bounds member {leaf:?} is not an authoring object"
+            ));
+        }
+    }
     Ok(leaves)
 }
 
@@ -207,6 +193,25 @@ mod tests {
             plan.finish_world_bounds().expect("lowered bounds"),
             Some(Rect::new(Vec2::new(-2.0, -4.0), Vec2::new(5.0, 1.0)))
         );
+    }
+
+    #[test]
+    fn shared_alias_is_consumed_once_in_first_semantic_occurrence() {
+        let mut store = SemanticStore::new();
+        let shared = store.insert_authoring_object();
+        let second = store.insert_authoring_object();
+        let nested = store.insert_family();
+        let root = store.insert_family();
+        store.add_member(nested, second).unwrap();
+        store.add_member(nested, shared).unwrap();
+        store.add_member(root, shared).unwrap();
+        store.add_member(root, nested).unwrap();
+
+        let mut plan = FrontendFamilyBoundsPlan::begin(&store, root).unwrap();
+        assert_eq!(plan.leaf_count(), 2);
+        plan.accept_leaf_bounds(shared, None).unwrap();
+        plan.accept_leaf_bounds(second, None).unwrap();
+        assert_eq!(plan.finish().unwrap(), None);
     }
 
     #[test]


### PR DESCRIPTION
Part of #741.

Moves ordered semantic-family leaf traversal into shared `noon-core` semantics and makes the existing web family-bounds path consume that shared order.

Key properties:
- leaf objects are their own one-element sequence;
- nested families flatten depth-first in authoritative member order;
- aliased/shared descendants are emitted once at first occurrence, matching ManimCE v0.21 `extract_mobject_family_members` / `remove_list_redundancies` behavior;
- stale/unknown semantic identities fail closed;
- both legacy `Object` and shared `AuthoringObject` nodes are valid core leaves;
- the family-bounds adapter retains its stricter `AuthoringObject` requirement but no longer owns a second recursive traversal implementation;
- core and web tests cover nested order, alias de-duplication, empty families, stale roots, and frontend ordering enforcement.

This is deliberately the first binding slice of #741. It establishes the canonical semantic leaf sequence required before adding resource-local member spans and a global animation-member plan.