### PR TITLE
Add transform-safe Axes graph projection helpers

### DIFF
--- a/scripts/manim-axes-smoke.mjs
+++ b/scripts/manim-axes-smoke.mjs
@@ -140,11 +140,38 @@ class RetainedAxesPlot(Scene):
         assert isinstance(identity_graph, ParametricFunction)
         assert_three_point_graph_matches_axes(axes, identity_graph)
 
+        graph_point = axes.i2gp(0.75, identity_graph)
+        assert_point_close(graph_point, axes.c2p(0.75, 0.75))
+        graph_coords = axes.i2gc(0.75, identity_graph)
+        assert_close(graph_coords[0], 0.75)
+        assert_close(graph_coords[1], 0.75)
+
+        vertical_config = {}
+        vertical = axes.get_vertical_line(
+            graph_point,
+            line_func=Line,
+            line_config=vertical_config,
+            color=PURE_GREEN,
+            stroke_width=3,
+        )
+        assert_close(vertical_config["stroke_width"], 3)
+        assert vertical_config["color"] == PURE_GREEN
+        assert_point_close(vertical.start, axes.c2p(0.75, 0.0))
+        assert_point_close(vertical.end, graph_point)
+
+        horizontal = axes.get_horizontal_line(
+            graph_point,
+            line_func=Line,
+            color=ORANGE,
+        )
+        assert_point_close(horizontal.start, axes.c2p(0.0, 0.75))
+        assert_point_close(horizontal.end, graph_point)
+
         sin_graph = axes.plot(lambda x: math.sin(x), color=BLUE)
         cos_graph = axes.plot(lambda x: math.cos(x), color=RED)
         assert isinstance(sin_graph, ParametricFunction)
         assert isinstance(cos_graph, ParametricFunction)
-        self.add(axes, sin_graph, cos_graph)
+        self.add(axes, sin_graph, cos_graph, vertical, horizontal)
 `;
 
 let browser = null;
@@ -171,7 +198,7 @@ try {
     axesSource,
   );
   assert.equal(result.kind, "scene_document");
-  assert.equal(result.document.objects.length, 26);
+  assert.equal(result.document.objects.length, 28);
   assert.equal(result.document.tracks.length, 0);
 
   const geometryKinds = result.document.objects.map(
@@ -179,8 +206,8 @@ try {
   );
   assert.equal(
     geometryKinds.filter((kind) => kind === "line").length,
-    24,
-    "Axes must flatten to retained line/tick leaves",
+    26,
+    "Axes and projection helpers must flatten to ordinary retained line geometry",
   );
   assert.equal(
     geometryKinds.filter((kind) => kind === "vector_path").length,
@@ -189,7 +216,7 @@ try {
   );
   assert.deepEqual(errors, [], `browser errors while testing retained Axes:\n${errors.join("\n")}`);
   console.log(
-    "Retained Axes smoke passed: VGroup type, copy/placement independence, shared line/tick families, transform-safe c2p/p2c, exact transformed plot points, and ParametricFunction results.",
+    "Retained Axes smoke passed: VGroup type, copy/placement independence, shared line/tick families, transform-safe c2p/p2c/i2gp, retained axis projections, exact transformed plot points, and ParametricFunction results.",
   );
 } finally {
   await browser?.close();

--- a/web/python/_manim_axes.py
+++ b/web/python/_manim_axes.py
@@ -294,6 +294,80 @@ class Axes(_compat.VGroup):
     def __rmatmul__(self, point: object) -> list[float]:
         return self.point_to_coords(point)
 
+    def input_to_graph_point(self, x: float, graph: ParametricFunction | _compat.VMobject) -> object:
+        """Return the point on a graph corresponding to an axis x value.
+
+        ManimCE v0.21 directly evaluates authored function graphs through their
+        `function` callback. General VMobject lookup falls back to a path-space binary
+        search upstream; Noon fails closed on that broader case until generic
+        point-from-proportion semantics are shared.
+        """
+
+        if hasattr(graph, "underlying_function"):
+            return graph.function(float(x))
+        raise NotImplementedError(
+            "input_to_graph_point for generic VMobjects requires shared point-from-proportion semantics"
+        )
+
+    def input_to_graph_coords(
+        self, x: float, graph: ParametricFunction
+    ) -> tuple[float, float]:
+        return float(x), float(graph.underlying_function(float(x)))
+
+    def i2gc(self, x: float, graph: ParametricFunction) -> tuple[float, float]:
+        return self.input_to_graph_coords(x, graph)
+
+    def i2gp(self, x: float, graph: ParametricFunction) -> object:
+        return self.input_to_graph_point(x, graph)
+
+    def get_line_from_axis_to_point(
+        self,
+        index: int,
+        point: object,
+        line_func: Callable[..., _compat.Line] | None = None,
+        line_config: dict[str, Any] | None = None,
+        color: _base.Color | None = None,
+        stroke_width: float = 2.0,
+    ) -> _compat.Line:
+        """Construct a retained line from one axis to a scene-space point.
+
+        Projection remains owned by the Rust-backed coordinate query path: convert the
+        scene point to current transformed axis coordinates, zero the orthogonal
+        coordinate, then map it back through `c2p`. This is equivalent to Manim's
+        `NumberLine.get_projection` for the supported linear 2D Axes transform model.
+        """
+
+        if index not in (0, 1):
+            raise IndexError("Noon Axes currently has only x and y axes")
+        target = _compat._as_vec2(point)
+        coords = self.p2c(target)
+        projected = self.c2p(coords[0], 0.0) if index == 0 else self.c2p(0.0, coords[1])
+
+        if line_func is None:
+            line_func = getattr(_base, "DashedLine", None)
+            if line_func is None:
+                raise NotImplementedError(
+                    "default dashed axis helper lines require the public DashedLine facade"
+                )
+        if not callable(line_func):
+            raise TypeError("line_func must construct a Line-compatible mobject")
+        if line_config is None:
+            line_config = {}
+        elif not isinstance(line_config, dict):
+            raise TypeError("line_config must be a dict or None")
+
+        # ManimCE v0.21 mutates the supplied line_config and lets these explicit
+        # helper options override any same-named entries already present.
+        line_config["color"] = _base.WHITE if color is None else color
+        line_config["stroke_width"] = float(stroke_width)
+        return line_func(projected, target, **line_config)
+
+    def get_vertical_line(self, point: object, **kwargs: Any) -> _compat.Line:
+        return self.get_line_from_axis_to_point(0, point, **kwargs)
+
+    def get_horizontal_line(self, point: object, **kwargs: Any) -> _compat.Line:
+        return self.get_line_from_axis_to_point(1, point, **kwargs)
+
     def plot(
         self,
         function: Callable[[float], float],


### PR DESCRIPTION
## Summary
- add ManimCE v0.21 `input_to_graph_point` / `i2gp` for retained `Axes.plot` results
- add `input_to_graph_coords` / `i2gc`
- add shared-state `get_line_from_axis_to_point`, `get_vertical_line`, and `get_horizontal_line`
- keep graph lookup exact for authored function graphs: `i2gp` evaluates the graph's existing Manim-facing `function` callback, which already routes through the Rust-backed current Axes coordinate mapping
- keep axis projection free of duplicated Python geometry math: convert the scene point through Rust-backed `p2c`, zero the orthogonal coordinate, and map back through Rust-backed `c2p`
- preserve ManimCE v0.21 helper option behavior for `line_config`, `color`, and `stroke_width`
- fail closed for generic VMobject graph lookup until shared point-from-proportion wiring is exposed to Python
- fail closed for the upstream default dashed helper when a public Python `DashedLine` facade is unavailable; #755 owns that facade, while explicit `line_func=Line` (used by `SinAndCosFunctionPlot`) is supported here

## Browser coverage
Extends the existing retained Axes smoke after shifting, scaling, and rotating the Axes. It asserts:
- `i2gp(0.75, graph) == axes.c2p(0.75, f(0.75))`
- `i2gc` returns axis-space graph coordinates
- transformed vertical projection begins at `axes.c2p(x, 0)` and ends at the graph point
- transformed horizontal projection begins at `axes.c2p(0, y)` and ends at the graph point
- helper lines remain ordinary retained line geometry
- Manim's mutation/override behavior for the supplied `line_config` is preserved

## Exact-head qualification
Current head: `f00a2b3ad66feee6e9d0c98d1d3a3d85a3bcd517`.

Single Fast Gate run `33500878427` is fully green on this exact head:
- Rust formatting + Clippy: success
- Rust workspace library tests: success
- web static/unit preflight: success
- one-time WASM build: success
- deterministic playback: success
- Manim-style authoring: success
- **retained Axes plotting + transformed projection helpers: success**
- lazy Manim namespace: success
- literal pinned ManimCE v0.21 `PlotExample`: success
- primary WebGPU rendering: success
- aggregate PR Fast Gate: success

## Architecture
This is deliberately label-independent. It advances the first remaining `SinAndCosFunctionPlot` geometry/helper slice without creating placeholder `MathTex`/number labels; label ownership remains #83.

Stacked on the exact-green #759 PlotExample acceptance head so that proof remains frozen and independently inspectable.

Tracks #253 / #85. Related #83 / #755.