### PR TITLE
Resolve runtime object slots into family reveal members

### DIFF
--- a/crates/noon-render-wgpu/src/gpu/retained_family_reveal.rs
+++ b/crates/noon-render-wgpu/src/gpu/retained_family_reveal.rs
@@ -1,7 +1,8 @@
 use noon_core::{
     FamilyAnimationMode, ObjectId, RetainedAnimationMember, RetainedFamilyAnimationEvaluationError,
-    RetainedFamilyAnimationLeafFrame, TextAnimationGlyphRef,
+    RetainedFamilyAnimationLeafFrame, RetainedFamilyAnimationPlan, TextAnimationGlyphRef,
 };
+use noon_runtime::{RetainedFamilyFrame, RetainedFamilyFramePlanError};
 
 /// One renderer-facing reveal command derived from an already prepared family leaf.
 ///
@@ -25,6 +26,7 @@ pub enum RetainedFamilyRevealMember {
 pub enum RetainedFamilyRevealError {
     UnsupportedMode(FamilyAnimationMode),
     MissingPreparedMember { object: ObjectId, local_member: u32 },
+    FramePlan(RetainedFamilyFramePlanError),
     Evaluation(RetainedFamilyAnimationEvaluationError),
 }
 
@@ -45,12 +47,19 @@ impl std::fmt::Display for RetainedFamilyRevealError {
                 "retained object {} has no prepared family member {local_member}",
                 object.get()
             ),
+            Self::FramePlan(error) => error.fmt(formatter),
             Self::Evaluation(error) => error.fmt(formatter),
         }
     }
 }
 
 impl std::error::Error for RetainedFamilyRevealError {}
+
+impl From<RetainedFamilyFramePlanError> for RetainedFamilyRevealError {
+    fn from(value: RetainedFamilyFramePlanError) -> Self {
+        Self::FramePlan(value)
+    }
+}
 
 impl From<RetainedFamilyAnimationEvaluationError> for RetainedFamilyRevealError {
     fn from(value: RetainedFamilyAnimationEvaluationError) -> Self {
@@ -81,6 +90,23 @@ pub fn retained_family_reveal_members(
         frame,
         next_local_member: 0,
     })
+}
+
+/// Resolve one retained runtime object slot through the prepared family plan and expose
+/// its renderer-facing reveal members.
+///
+/// `Ok(None)` preserves the runtime bridge's distinction between an inactive slot and a
+/// slot owned by another prepared plan. No semantic traversal, resource lookup, lag
+/// mapping, easing, or member-order logic is repeated here.
+pub fn retained_family_reveal_members_for_object<'plan>(
+    frame: &RetainedFamilyFrame<'_>,
+    plan: &'plan RetainedFamilyAnimationPlan,
+    object_index: usize,
+) -> Result<Option<RetainedFamilyRevealMembers<'plan>>, RetainedFamilyRevealError> {
+    let Some(leaf) = frame.planned_family_leaf(plan, object_index)? else {
+        return Ok(None);
+    };
+    Ok(Some(retained_family_reveal_members(leaf)?))
 }
 
 impl Iterator for RetainedFamilyRevealMembers<'_> {
@@ -138,12 +164,14 @@ mod tests {
     use std::sync::Arc;
 
     use noon_core::{
-        FamilyAnimationState, FontFaceIdentity, GeometryRef, GlyphRun, ObjectId, PositionedGlyph,
-        RateFunction, Rect, RetainedFamilyAnimationPlan, RetainedFamilyAnimationPlanBuilder,
-        RetainedObjectDefinition, SemanticNodeId, SemanticStore, TextAffineTransform,
-        TextClusterIdentity, TextDirection, TextRenderItem, TextResource, TextResourceArena,
-        TextSourceKind, TextSourceSpan, Vec2,
+        FamilyAnimationState, FontFaceIdentity, GeometryRef, GlyphRun, ObjectContentRef, ObjectId,
+        PositionedGlyph, RateFunction, Rect, RetainedFamilyAnimationPlan,
+        RetainedFamilyAnimationPlanBuilder, RetainedObjectDefinition, SemanticNodeId,
+        SemanticStore, Style, TextAffineTransform, TextClusterIdentity, TextDirection,
+        TextRenderItem, TextResource, TextResourceArena, TextSourceKind, TextSourceSpan,
+        Transform2D, Vec2,
     };
+    use noon_runtime::{RetainedFrameObjectState, RetainedFrameState};
 
     use super::*;
 
@@ -211,6 +239,55 @@ mod tests {
         (builder.finish().unwrap(), text_leaf, circle_leaf)
     }
 
+    fn geometry_runtime_fixture() -> (
+        RetainedFamilyAnimationPlan,
+        RetainedFrameState,
+        Vec<Option<FamilyAnimationState>>,
+    ) {
+        let mut store = SemanticStore::new();
+        let first = store.insert_authoring_object();
+        let second = store.insert_authoring_object();
+        let family = store.insert_family();
+        store.add_member(family, first).unwrap();
+        store.add_member(family, second).unwrap();
+
+        let first_object =
+            RetainedObjectDefinition::geometry(ObjectId::new(20), GeometryRef::circle(1.0));
+        let second_object =
+            RetainedObjectDefinition::geometry(ObjectId::new(21), GeometryRef::circle(2.0));
+        let texts = TextResourceArena::new();
+        let mut builder = RetainedFamilyAnimationPlanBuilder::begin(&store, family).unwrap();
+        builder.accept_leaf(first, &first_object, &texts).unwrap();
+        builder.accept_leaf(second, &second_object, &texts).unwrap();
+        let plan = builder.finish().unwrap();
+
+        let frame = RetainedFrameState {
+            time: 1.0,
+            objects: vec![
+                RetainedFrameObjectState {
+                    id: ObjectId::new(20),
+                    content: ObjectContentRef::Geometry(GeometryRef::circle(1.0)),
+                    transform: Transform2D::IDENTITY,
+                    style: Style::default(),
+                    appearance: 1.0,
+                },
+                RetainedFrameObjectState {
+                    id: ObjectId::new(21),
+                    content: ObjectContentRef::Geometry(GeometryRef::circle(2.0)),
+                    transform: Transform2D::IDENTITY,
+                    style: Style::default(),
+                    appearance: 1.0,
+                },
+            ],
+            presences: vec![true, true],
+            reveals: vec![1.0, 1.0],
+            morphs: vec![0.0, 0.0],
+            render_geometries: vec![None, None],
+        };
+        let animation = state(false);
+        (plan, frame, vec![Some(animation), Some(animation)])
+    }
+
     fn state(reverse_member_order: bool) -> FamilyAnimationState {
         FamilyAnimationState {
             mode: FamilyAnimationMode::Reveal,
@@ -250,6 +327,53 @@ mod tests {
                 reveal: 0.0,
             }]
         );
+    }
+
+    #[test]
+    fn runtime_object_helper_composes_plan_binding_and_reveal_realization() {
+        let (plan, frame, states) = geometry_runtime_fixture();
+        let family = RetainedFamilyFrame {
+            retained: &frame,
+            family_animations: &states,
+        };
+        let first = retained_family_reveal_members_for_object(&family, &plan, 0)
+            .unwrap()
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        let second = retained_family_reveal_members_for_object(&family, &plan, 1)
+            .unwrap()
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+
+        assert_eq!(
+            first,
+            vec![RetainedFamilyRevealMember::Geometry {
+                object: ObjectId::new(20),
+                reveal: 1.0,
+            }]
+        );
+        assert_eq!(
+            second,
+            vec![RetainedFamilyRevealMember::Geometry {
+                object: ObjectId::new(21),
+                reveal: 0.0,
+            }]
+        );
+    }
+
+    #[test]
+    fn runtime_object_helper_preserves_inactive_slots() {
+        let (plan, frame, mut states) = geometry_runtime_fixture();
+        states[0] = None;
+        let family = RetainedFamilyFrame {
+            retained: &frame,
+            family_animations: &states,
+        };
+        assert!(retained_family_reveal_members_for_object(&family, &plan, 0)
+            .unwrap()
+            .is_none());
     }
 
     #[test]


### PR DESCRIPTION
Part of #741. Stacked on #761.

Composes the runtime-to-plan binding with the renderer-side reveal realization so `RetainedFramePreparer` can consume one retained object slot through a single zero-allocation helper.

### What lands
- `retained_family_reveal_members_for_object(...)` resolves an object-local runtime family state through the prepared global member plan and returns the existing renderer reveal iterator;
- inactive slots and objects owned by another prepared plan remain `None` rather than becoming false errors;
- `RetainedFamilyRevealError` now carries runtime-plan binding failures without flattening them into renderer timing logic;
- the helper performs no semantic traversal, resource lookup, easing, lag mapping, or member-order recomputation.

### Proof
A two-geometry family at the midpoint resolves object slot 0 to reveal `1.0` and slot 1 to `0.0` through one shared global timeline. Existing mixed `Text("AB") + Circle` tests continue to prove glyph-local `1.0, 0.5` followed by geometry `0.0`, including global reversal.

This leaves the final consumer patch very small conceptually: inside the retained preparer object walk, call this helper; geometry member 0 overrides the legacy scalar reveal, while Text glyph members are materialized individually through the existing outline/path cache lane.