### PR TITLE
Preserve f64 path proportions for finite-difference authoring

### DIFF
--- a/crates/noon-geometry/src/geometry_proportion.rs
+++ b/crates/noon-geometry/src/geometry_proportion.rs
@@ -1,12 +1,15 @@
-use noon_core::{GeometryRef, Vec2, TAU};
+use noon_core::{GeometryRef, PathCommand, Vec2, VectorPath, TAU};
 
 use crate::{point_from_proportion, PathProportionError};
 
 const MANIM_CIRCLE_COMPONENTS: usize = 9;
+const MANIM_LENGTH_SAMPLE_POINTS: usize = 10;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum GeometryProportionError {
     Path(PathProportionError),
+    InvalidHighPrecisionProportion(f64),
+    EmptyPath,
     UnsupportedGeometry,
 }
 
@@ -14,6 +17,11 @@ impl std::fmt::Display for GeometryProportionError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Path(error) => error.fmt(formatter),
+            Self::InvalidHighPrecisionProportion(alpha) => write!(
+                formatter,
+                "path proportion must be finite and between 0 and 1: {alpha}"
+            ),
+            Self::EmptyPath => formatter.write_str("path has no drawable curves"),
             Self::UnsupportedGeometry => formatter.write_str(
                 "point_from_proportion requires retained circle, line, or vector-path geometry",
             ),
@@ -27,6 +35,52 @@ impl From<PathProportionError> for GeometryProportionError {
     fn from(value: PathProportionError) -> Self {
         Self::Path(value)
     }
+}
+
+/// High-precision local-space point used by derivative-like authoring queries.
+///
+/// Retained geometry is still stored in the renderer-facing f32 representation,
+/// but proportion arithmetic and Bezier evaluation can remain f64 until the final
+/// authored result is lowered. This matters for Manim operations such as
+/// `TangentLine`, whose default finite difference is only `1e-6` in path progress.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct GeometryPoint64 {
+    pub x: f64,
+    pub y: f64,
+}
+
+impl GeometryPoint64 {
+    const fn new(x: f64, y: f64) -> Self {
+        Self { x, y }
+    }
+
+    fn from_vec2(point: Vec2) -> Self {
+        Self::new(f64::from(point.x), f64::from(point.y))
+    }
+
+    fn distance(self, other: Self) -> f64 {
+        (other.x - self.x).hypot(other.y - self.y)
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum CurveKind64 {
+    Line,
+    Quadratic {
+        control: GeometryPoint64,
+    },
+    Cubic {
+        control1: GeometryPoint64,
+        control2: GeometryPoint64,
+    },
+    Close,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Curve64 {
+    from: GeometryPoint64,
+    to: GeometryPoint64,
+    kind: CurveKind64,
 }
 
 /// Return the local-space point at `alpha` for path-like retained geometry.
@@ -50,9 +104,56 @@ pub fn point_from_geometry_proportion(
     }
 }
 
+/// Evaluate two path proportions with f64 arithmetic through the same shared measure.
+///
+/// This is the precision-preserving boundary for finite-difference authoring
+/// operations. It intentionally evaluates both samples from one prepared path
+/// measure so callers such as `TangentLine` do not rebuild path lengths twice and
+/// do not downcast `alpha ± d_alpha` before subtracting nearly coincident points.
+/// The retained geometry itself remains unchanged and no renderer state is added.
+pub fn point_pair_from_geometry_proportion_f64(
+    geometry: &GeometryRef,
+    first_alpha: f64,
+    second_alpha: f64,
+) -> Result<(GeometryPoint64, GeometryPoint64), GeometryProportionError> {
+    validate_high_precision_proportion(first_alpha)?;
+    validate_high_precision_proportion(second_alpha)?;
+
+    match geometry {
+        GeometryRef::Circle { radius } => Ok((
+            circle_point_from_proportion_f64(f64::from(*radius), first_alpha),
+            circle_point_from_proportion_f64(f64::from(*radius), second_alpha),
+        )),
+        GeometryRef::Line { start, end } => {
+            let start = GeometryPoint64::from_vec2(*start);
+            let end = GeometryPoint64::from_vec2(*end);
+            Ok((
+                lerp64(start, end, first_alpha),
+                lerp64(start, end, second_alpha),
+            ))
+        }
+        GeometryRef::VectorPath(path) => {
+            let plan = GeometryProportionPlan64::new(path)?;
+            Ok((plan.point(first_alpha), plan.point(second_alpha)))
+        }
+        GeometryRef::Rectangle { .. } | GeometryRef::External(_) => {
+            Err(GeometryProportionError::UnsupportedGeometry)
+        }
+    }
+}
+
 fn validate_proportion(alpha: f32) -> Result<(), GeometryProportionError> {
     if !alpha.is_finite() || !(0.0..=1.0).contains(&alpha) {
         return Err(PathProportionError::InvalidProportion(alpha).into());
+    }
+    Ok(())
+}
+
+fn validate_high_precision_proportion(alpha: f64) -> Result<(), GeometryProportionError> {
+    if !alpha.is_finite() || !(0.0..=1.0).contains(&alpha) {
+        return Err(GeometryProportionError::InvalidHighPrecisionProportion(
+            alpha,
+        ));
     }
     Ok(())
 }
@@ -84,6 +185,213 @@ fn circle_point_from_proportion(radius: f32, alpha: f32) -> Vec2 {
     first + (second - first) * t
 }
 
+fn circle_point_from_proportion_f64(radius: f64, alpha: f64) -> GeometryPoint64 {
+    if alpha == 1.0 {
+        return GeometryPoint64::new(radius, 0.0);
+    }
+
+    let component_count = MANIM_CIRCLE_COMPONENTS as f64;
+    let scaled = alpha * component_count;
+    let component = (scaled.floor() as usize).min(MANIM_CIRCLE_COMPONENTS - 1);
+    let t = scaled - component as f64;
+    let theta = std::f64::consts::TAU / component_count;
+    let start_angle = component as f64 * theta;
+    let end_angle = (component + 1) as f64 * theta;
+    let middle_angle = (start_angle + end_angle) * 0.5;
+    let control_radius = radius / (theta * 0.5).cos();
+
+    let start = GeometryPoint64::new(start_angle.cos() * radius, start_angle.sin() * radius);
+    let control = GeometryPoint64::new(
+        middle_angle.cos() * control_radius,
+        middle_angle.sin() * control_radius,
+    );
+    let end = GeometryPoint64::new(end_angle.cos() * radius, end_angle.sin() * radius);
+
+    let first = lerp64(start, control, t);
+    let second = lerp64(control, end, t);
+    lerp64(first, second, t)
+}
+
+#[derive(Clone, Debug)]
+struct GeometryProportionPlan64 {
+    curves: Vec<Curve64>,
+    lengths: Vec<f64>,
+    cumulative_lengths: Vec<f64>,
+    total_length: f64,
+}
+
+impl GeometryProportionPlan64 {
+    fn new(path: &VectorPath) -> Result<Self, GeometryProportionError> {
+        let curves = collect_curves64(path);
+        if curves.is_empty() {
+            return Err(GeometryProportionError::EmptyPath);
+        }
+
+        let lengths = curves
+            .iter()
+            .copied()
+            .map(sampled_curve_length64)
+            .collect::<Vec<_>>();
+        let mut cumulative_lengths = Vec::with_capacity(lengths.len());
+        let mut total_length = 0.0_f64;
+        for &length in &lengths {
+            total_length += length;
+            cumulative_lengths.push(total_length);
+        }
+
+        Ok(Self {
+            curves,
+            lengths,
+            cumulative_lengths,
+            total_length,
+        })
+    }
+
+    fn point(&self, alpha: f64) -> GeometryPoint64 {
+        if alpha == 1.0 {
+            return self
+                .curves
+                .last()
+                .expect("high-precision path proportion plans are never empty")
+                .to;
+        }
+
+        let target_length = alpha * self.total_length;
+        if target_length.is_finite() {
+            let curve_index = self
+                .cumulative_lengths
+                .partition_point(|&end_length| end_length < target_length);
+            if curve_index < self.curves.len() {
+                let current_length = curve_index
+                    .checked_sub(1)
+                    .map_or(0.0, |index| self.cumulative_lengths[index]);
+                let length = self.lengths[curve_index];
+                let residue = if length > 0.0 {
+                    ((target_length - current_length) / length).clamp(0.0, 1.0)
+                } else {
+                    0.0
+                };
+                return curve_point64(self.curves[curve_index], residue);
+            }
+        }
+
+        self.curves
+            .last()
+            .expect("high-precision path proportion plans are never empty")
+            .to
+    }
+}
+
+fn collect_curves64(path: &VectorPath) -> Vec<Curve64> {
+    let mut curves = Vec::new();
+    let mut current = None;
+    let mut subpath_start = None;
+
+    for command in path.commands() {
+        match *command {
+            PathCommand::MoveTo { to } => {
+                let to = GeometryPoint64::from_vec2(to);
+                current = Some(to);
+                subpath_start = Some(to);
+            }
+            PathCommand::LineTo { to } => {
+                let to = GeometryPoint64::from_vec2(to);
+                if let Some(from) = current {
+                    curves.push(Curve64 {
+                        from,
+                        to,
+                        kind: CurveKind64::Line,
+                    });
+                }
+                current = Some(to);
+            }
+            PathCommand::QuadraticTo { control, to } => {
+                let to = GeometryPoint64::from_vec2(to);
+                if let Some(from) = current {
+                    curves.push(Curve64 {
+                        from,
+                        to,
+                        kind: CurveKind64::Quadratic {
+                            control: GeometryPoint64::from_vec2(control),
+                        },
+                    });
+                }
+                current = Some(to);
+            }
+            PathCommand::CubicTo {
+                control1,
+                control2,
+                to,
+            } => {
+                let to = GeometryPoint64::from_vec2(to);
+                if let Some(from) = current {
+                    curves.push(Curve64 {
+                        from,
+                        to,
+                        kind: CurveKind64::Cubic {
+                            control1: GeometryPoint64::from_vec2(control1),
+                            control2: GeometryPoint64::from_vec2(control2),
+                        },
+                    });
+                }
+                current = Some(to);
+            }
+            PathCommand::Close => {
+                if let (Some(from), Some(to)) = (current, subpath_start) {
+                    if from.distance(to) > f64::from(f32::EPSILON) {
+                        curves.push(Curve64 {
+                            from,
+                            to,
+                            kind: CurveKind64::Close,
+                        });
+                    }
+                    current = Some(to);
+                }
+            }
+        }
+    }
+
+    curves
+}
+
+fn sampled_curve_length64(curve: Curve64) -> f64 {
+    let denominator = (MANIM_LENGTH_SAMPLE_POINTS - 1) as f64;
+    let mut previous = curve_point64(curve, 0.0);
+    let mut length = 0.0_f64;
+    for sample in 1..MANIM_LENGTH_SAMPLE_POINTS {
+        let point = curve_point64(curve, sample as f64 / denominator);
+        length += previous.distance(point);
+        previous = point;
+    }
+    length
+}
+
+fn curve_point64(curve: Curve64, t: f64) -> GeometryPoint64 {
+    match curve.kind {
+        CurveKind64::Line | CurveKind64::Close => lerp64(curve.from, curve.to, t),
+        CurveKind64::Quadratic { control } => {
+            let first = lerp64(curve.from, control, t);
+            let second = lerp64(control, curve.to, t);
+            lerp64(first, second, t)
+        }
+        CurveKind64::Cubic { control1, control2 } => {
+            let p01 = lerp64(curve.from, control1, t);
+            let p12 = lerp64(control1, control2, t);
+            let p23 = lerp64(control2, curve.to, t);
+            let p012 = lerp64(p01, p12, t);
+            let p123 = lerp64(p12, p23, t);
+            lerp64(p012, p123, t)
+        }
+    }
+}
+
+fn lerp64(start: GeometryPoint64, end: GeometryPoint64, t: f64) -> GeometryPoint64 {
+    GeometryPoint64::new(
+        start.x + (end.x - start.x) * t,
+        start.y + (end.y - start.y) * t,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use noon_core::VectorPath;
@@ -93,6 +401,14 @@ mod tests {
     fn assert_point(actual: Vec2, expected: Vec2) {
         assert!(
             (actual.x - expected.x).abs() <= 1.0e-5 && (actual.y - expected.y).abs() <= 1.0e-5,
+            "{actual:?} != {expected:?}"
+        );
+    }
+
+    fn assert_point64(actual: GeometryPoint64, expected: GeometryPoint64, tolerance: f64) {
+        assert!(
+            (actual.x - expected.x).abs() <= tolerance
+                && (actual.y - expected.y).abs() <= tolerance,
             "{actual:?} != {expected:?}"
         );
     }
@@ -138,6 +454,65 @@ mod tests {
     }
 
     #[test]
+    fn high_precision_pair_preserves_manim_default_tangent_delta() {
+        let (first, second) = point_pair_from_geometry_proportion_f64(
+            &GeometryRef::circle(2.0),
+            0.4 - 1.0e-6,
+            0.4 + 1.0e-6,
+        )
+        .unwrap();
+
+        assert_point64(
+            first,
+            GeometryPoint64::new(-1.6191706294001942, 1.1800713157856422),
+            1.0e-12,
+        );
+        assert_point64(
+            second,
+            GeometryPoint64::new(-1.6191850851338567, 1.1800512993440777),
+            1.0e-12,
+        );
+
+        let dx = second.x - first.x;
+        let dy = second.y - first.y;
+        let sample_length = dx.hypot(dy);
+        let center = GeometryPoint64::new((first.x + second.x) * 0.5, (first.y + second.y) * 0.5);
+        let half_x = dx / sample_length * 2.0;
+        let half_y = dy / sample_length * 2.0;
+        assert_point64(
+            GeometryPoint64::new(center.x - half_x, center.y - half_y),
+            GeometryPoint64::new(-0.448227905248914, 2.80144226522681),
+            1.0e-10,
+        );
+        assert_point64(
+            GeometryPoint64::new(center.x + half_x, center.y + half_y),
+            GeometryPoint64::new(-2.7901278092851367, -0.4413196500970902),
+            1.0e-10,
+        );
+    }
+
+    #[test]
+    fn high_precision_vector_path_pair_reuses_manim_sampled_measure() {
+        let path = GeometryRef::VectorPath(
+            VectorPath::new()
+                .move_to(Vec2::ZERO)
+                .quadratic_to(Vec2::new(1.0, 2.0), Vec2::new(2.0, 0.0)),
+        );
+        let (first, second) =
+            point_pair_from_geometry_proportion_f64(&path, 0.5 - 1.0e-6, 0.5 + 1.0e-6).unwrap();
+
+        assert!(first.x < 1.0 && second.x > 1.0);
+        assert!(first.distance(second) > 1.0e-6);
+        assert_point64(
+            point_pair_from_geometry_proportion_f64(&path, 0.5, 0.5)
+                .unwrap()
+                .0,
+            GeometryPoint64::new(1.0, 1.0),
+            1.0e-12,
+        );
+    }
+
+    #[test]
     fn invalid_proportion_and_non_path_geometry_are_rejected() {
         let circle = GeometryRef::circle(1.0);
         assert!(matches!(
@@ -146,8 +521,16 @@ mod tests {
                 PathProportionError::InvalidProportion(_)
             ))
         ));
+        assert!(matches!(
+            point_pair_from_geometry_proportion_f64(&circle, f64::NAN, 0.5),
+            Err(GeometryProportionError::InvalidHighPrecisionProportion(value)) if value.is_nan()
+        ));
         assert_eq!(
             point_from_geometry_proportion(&GeometryRef::rectangle(1.0, 1.0), 0.5),
+            Err(GeometryProportionError::UnsupportedGeometry)
+        );
+        assert_eq!(
+            point_pair_from_geometry_proportion_f64(&GeometryRef::rectangle(1.0, 1.0), 0.25, 0.75,),
             Err(GeometryProportionError::UnsupportedGeometry)
         );
     }


### PR DESCRIPTION
## Summary
- add a shared f64 two-sample proportion boundary for retained Circle, Line, and VectorPath geometry
- keep ManimCE v0.21's existing nine-component Circle measure and ten-sample Bezier length measure
- prepare VectorPath lengths once and evaluate both proportions from the same immutable measure
- preserve retained/render geometry as f32 and lower only later consumers' final authored result
- add focused regressions for the exact `alpha=0.4 ± 1e-6` Circle samples underlying pinned `TangentLineExample`, generic quadratic VectorPath sampling, and invalid/unsupported inputs

## Why
Closed prototype #655 demonstrated that `TangentLine` itself is architecturally straightforward but unsafe while `alpha ± d_alpha` is downcast to f32 before finite differencing. With Manim's default `d_alpha=1e-6`, the normalized 4-unit tangent shifts by roughly 0.003 in the pinned Circle case. Relaxing tolerance or special-casing Circle would hide the actual shared-geometry precision defect.

This PR fixes the prerequisite only. `TangentLine` can now consume the shared pair, apply the retained transform, normalize/scale in f64, and lower its final ordinary Line endpoints once.

## Architecture
No renderer primitive, frontend tangent math, path mutation, worker protocol, or per-frame work is introduced. Existing f32 public path queries remain unchanged for compatibility; derivative-like authoring queries get an explicit precision-preserving boundary.

## Qualification
The feature blob on `dbf42691a4435549ce44ccc06153fd4d1db49a9c` passed the complete PR Fast Gate: formatting, Clippy, Rust tests, web preflight, WASM/browser build, deterministic playback, Manim-style authoring, and primary WebGPU rendering.

Master then advanced only through disjoint retained-family work. The exact qualified feature blob was replayed as one commit directly onto current master `6cc14be87c4cd0db7e7c29a3df760442cc88a1e8`; current head is `7b6ba775681340d9639c86236e3971501a4a16e4`, one commit / one file and mergeable. Fresh exact-integration PR Fast Gate run #135 is queued; do not merge until that current-head run is green.

Tracks #78. Unblocks #77 / #256 and supersedes the precision blocker documented in #655.