### PR TITLE
Preserve f64 path proportions for shared tangent semantics

### DIFF
--- a/crates/noon-geometry/src/geometry_proportion.rs
+++ b/crates/noon-geometry/src/geometry_proportion.rs
@@ -1,6 +1,6 @@
-use noon_core::{GeometryRef, Vec2, TAU};
+use noon_core::{GeometryRef, SemanticLoweringError, SemanticVec3, Transform2D, Vec2, TAU};
 
-use crate::{point_from_proportion, PathProportionError};
+use crate::{point_from_proportion, point_from_proportion_f64, PathProportionError};
 
 const MANIM_CIRCLE_COMPONENTS: usize = 9;
 
@@ -39,7 +39,7 @@ pub fn point_from_geometry_proportion(
     geometry: &GeometryRef,
     alpha: f32,
 ) -> Result<Vec2, GeometryProportionError> {
-    validate_proportion(alpha)?;
+    validate_proportion_f32(alpha)?;
     match geometry {
         GeometryRef::Circle { radius } => Ok(circle_point_from_proportion(*radius, alpha)),
         GeometryRef::Line { start, end } => Ok(*start + (*end - *start) * alpha),
@@ -50,9 +50,164 @@ pub fn point_from_geometry_proportion(
     }
 }
 
-fn validate_proportion(alpha: f32) -> Result<(), GeometryProportionError> {
+/// High-precision authoring query for path-like retained geometry.
+///
+/// Retained coordinates remain renderer-facing f32, but the proportion,
+/// interpolation, analytic circle reconstruction, and downstream finite
+/// differences stay in f64. Vector paths reuse the same prepared sampled-length
+/// measure as [`point_from_geometry_proportion`] rather than maintaining another
+/// path-measure implementation.
+pub fn point_from_geometry_proportion_f64(
+    geometry: &GeometryRef,
+    alpha: f64,
+) -> Result<SemanticVec3, GeometryProportionError> {
+    validate_proportion_f64(alpha)?;
+    match geometry {
+        GeometryRef::Circle { radius } => {
+            Ok(circle_point_from_proportion_f64(f64::from(*radius), alpha))
+        }
+        GeometryRef::Line { start, end } => Ok(lerp_semantic(
+            SemanticVec3::from_vec2(*start),
+            SemanticVec3::from_vec2(*end),
+            alpha,
+        )),
+        GeometryRef::VectorPath(path) => Ok(point_from_proportion_f64(path, alpha)?),
+        GeometryRef::Rectangle { .. } | GeometryRef::External(_) => {
+            Err(GeometryProportionError::UnsupportedGeometry)
+        }
+    }
+}
+
+/// A retained world-space line segment produced from ManimCE-compatible tangent sampling.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct TangentSegment {
+    pub start: Vec2,
+    pub end: Vec2,
+}
+
+impl TangentSegment {
+    pub fn length(self) -> f32 {
+        (self.end - self.start).length()
+    }
+
+    pub fn center(self) -> Vec2 {
+        (self.start + self.end) * 0.5
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum TangentSegmentError {
+    Geometry(GeometryProportionError),
+    NonFiniteLength(f64),
+    InvalidDelta(f64),
+    DegenerateSample,
+    Lowering(SemanticLoweringError),
+}
+
+impl std::fmt::Display for TangentSegmentError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Geometry(error) => error.fmt(formatter),
+            Self::NonFiniteLength(length) => {
+                write!(formatter, "tangent length must be finite, got {length}")
+            }
+            Self::InvalidDelta(delta) => write!(
+                formatter,
+                "tangent sample delta must be finite and nonzero, got {delta}"
+            ),
+            Self::DegenerateSample => {
+                formatter.write_str("tangent sample points collapse to one world-space point")
+            }
+            Self::Lowering(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl std::error::Error for TangentSegmentError {}
+
+impl From<GeometryProportionError> for TangentSegmentError {
+    fn from(value: GeometryProportionError) -> Self {
+        Self::Geometry(value)
+    }
+}
+
+impl From<SemanticLoweringError> for TangentSegmentError {
+    fn from(value: SemanticLoweringError) -> Self {
+        Self::Lowering(value)
+    }
+}
+
+/// Sample and normalize a ManimCE v0.21 finite-difference tangent in world space.
+///
+/// Manim samples `alpha - d_alpha` and `alpha + d_alpha`, clipped to `[0, 1]`,
+/// creates an ordinary line between those points, then scales that line about its
+/// center to the requested length. This implementation preserves those operations
+/// in f64 through sampling, the current retained transform, and normalization,
+/// lowering only the final retained line endpoints to f32.
+///
+/// Sampling before normalization is required for non-uniformly transformed paths.
+/// Negative finite lengths and deltas retain Manim's ordinary line/scale behavior;
+/// zero `d_alpha` is rejected because it cannot define a tangent direction.
+pub fn tangent_segment_from_geometry_proportion(
+    geometry: &GeometryRef,
+    transform: Transform2D,
+    alpha: f64,
+    length: f64,
+    d_alpha: f64,
+) -> Result<TangentSegment, TangentSegmentError> {
+    validate_proportion_f64(alpha)?;
+    if !length.is_finite() {
+        return Err(TangentSegmentError::NonFiniteLength(length));
+    }
+    if !d_alpha.is_finite() || d_alpha == 0.0 {
+        return Err(TangentSegmentError::InvalidDelta(d_alpha));
+    }
+
+    let lower_alpha = (alpha - d_alpha).clamp(0.0, 1.0);
+    let upper_alpha = (alpha + d_alpha).clamp(0.0, 1.0);
+    let lower = transform_semantic_point(
+        transform,
+        point_from_geometry_proportion_f64(geometry, lower_alpha)?,
+    );
+    let upper = transform_semantic_point(
+        transform,
+        point_from_geometry_proportion_f64(geometry, upper_alpha)?,
+    );
+
+    let dx = upper.x - lower.x;
+    let dy = upper.y - lower.y;
+    let chord_length = dx.hypot(dy);
+    if !chord_length.is_finite() || chord_length == 0.0 {
+        return Err(TangentSegmentError::DegenerateSample);
+    }
+
+    let center = SemanticVec3::new(
+        (lower.x + upper.x) * 0.5,
+        (lower.y + upper.y) * 0.5,
+        (lower.z + upper.z) * 0.5,
+    );
+    let half_scale = length / chord_length * 0.5;
+    let half_x = dx * half_scale;
+    let half_y = dy * half_scale;
+    let start = SemanticVec3::new(center.x - half_x, center.y - half_y, center.z);
+    let end = SemanticVec3::new(center.x + half_x, center.y + half_y, center.z);
+
+    Ok(TangentSegment {
+        start: start.lower_xy_f32()?,
+        end: end.lower_xy_f32()?,
+    })
+}
+
+fn validate_proportion_f32(alpha: f32) -> Result<(), GeometryProportionError> {
     if !alpha.is_finite() || !(0.0..=1.0).contains(&alpha) {
         return Err(PathProportionError::InvalidProportion(alpha).into());
+    }
+    Ok(())
+}
+
+fn validate_proportion_f64(alpha: f64) -> Result<(), GeometryProportionError> {
+    if !alpha.is_finite() || !(0.0..=1.0).contains(&alpha) {
+        return Err(PathProportionError::InvalidProportion(alpha as f32).into());
     }
     Ok(())
 }
@@ -84,6 +239,53 @@ fn circle_point_from_proportion(radius: f32, alpha: f32) -> Vec2 {
     first + (second - first) * t
 }
 
+fn circle_point_from_proportion_f64(radius: f64, alpha: f64) -> SemanticVec3 {
+    if alpha == 1.0 {
+        return SemanticVec3::new(radius, 0.0, 0.0);
+    }
+
+    let component_count = MANIM_CIRCLE_COMPONENTS as f64;
+    let scaled = alpha * component_count;
+    let component = (scaled.floor() as usize).min(MANIM_CIRCLE_COMPONENTS - 1);
+    let t = scaled - component as f64;
+    let theta = std::f64::consts::TAU / component_count;
+    let start_angle = component as f64 * theta;
+    let end_angle = (component + 1) as f64 * theta;
+    let middle_angle = (start_angle + end_angle) * 0.5;
+    let control_radius = radius / (theta * 0.5).cos();
+
+    let start = SemanticVec3::new(start_angle.cos() * radius, start_angle.sin() * radius, 0.0);
+    let control = SemanticVec3::new(
+        middle_angle.cos() * control_radius,
+        middle_angle.sin() * control_radius,
+        0.0,
+    );
+    let end = SemanticVec3::new(end_angle.cos() * radius, end_angle.sin() * radius, 0.0);
+
+    let first = lerp_semantic(start, control, t);
+    let second = lerp_semantic(control, end, t);
+    lerp_semantic(first, second, t)
+}
+
+fn lerp_semantic(start: SemanticVec3, end: SemanticVec3, alpha: f64) -> SemanticVec3 {
+    SemanticVec3::new(
+        start.x + (end.x - start.x) * alpha,
+        start.y + (end.y - start.y) * alpha,
+        start.z + (end.z - start.z) * alpha,
+    )
+}
+
+fn transform_semantic_point(transform: Transform2D, point: SemanticVec3) -> SemanticVec3 {
+    let scaled_x = point.x * f64::from(transform.scale.x);
+    let scaled_y = point.y * f64::from(transform.scale.y);
+    let (sin, cos) = f64::from(transform.rotation).sin_cos();
+    SemanticVec3::new(
+        scaled_x * cos - scaled_y * sin + f64::from(transform.translation.x),
+        scaled_x * sin + scaled_y * cos + f64::from(transform.translation.y),
+        point.z,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use noon_core::VectorPath;
@@ -93,6 +295,15 @@ mod tests {
     fn assert_point(actual: Vec2, expected: Vec2) {
         assert!(
             (actual.x - expected.x).abs() <= 1.0e-5 && (actual.y - expected.y).abs() <= 1.0e-5,
+            "{actual:?} != {expected:?}"
+        );
+    }
+
+    fn assert_semantic(actual: SemanticVec3, expected: SemanticVec3, tolerance: f64) {
+        assert!(
+            (actual.x - expected.x).abs() <= tolerance
+                && (actual.y - expected.y).abs() <= tolerance
+                && (actual.z - expected.z).abs() <= tolerance,
             "{actual:?} != {expected:?}"
         );
     }
@@ -119,6 +330,24 @@ mod tests {
     }
 
     #[test]
+    fn precise_circle_query_preserves_default_tangent_sample_delta() {
+        let circle = GeometryRef::circle(2.0);
+        let lower = point_from_geometry_proportion_f64(&circle, 0.4 - 1.0e-6).unwrap();
+        let upper = point_from_geometry_proportion_f64(&circle, 0.4 + 1.0e-6).unwrap();
+
+        assert_semantic(
+            lower,
+            SemanticVec3::new(-1.6191706294001942, 1.1800713157856422, 0.0),
+            1.0e-12,
+        );
+        assert_semantic(
+            upper,
+            SemanticVec3::new(-1.6191850851338567, 1.1800512993440777, 0.0),
+            1.0e-12,
+        );
+    }
+
+    #[test]
     fn line_and_vector_path_keep_existing_shared_measures() {
         let line = GeometryRef::line(Vec2::new(-2.0, 1.0), Vec2::new(2.0, 1.0));
         assert_point(
@@ -135,6 +364,110 @@ mod tests {
             point_from_geometry_proportion(&path, 0.5).unwrap(),
             Vec2::new(1.0, 1.0),
         );
+        assert_semantic(
+            point_from_geometry_proportion_f64(&path, 0.5).unwrap(),
+            SemanticVec3::new(1.0, 1.0, 0.0),
+            1.0e-12,
+        );
+    }
+
+    #[test]
+    fn tangent_segment_matches_pinned_manim_circle_default_precision() {
+        let segment = tangent_segment_from_geometry_proportion(
+            &GeometryRef::circle(2.0),
+            Transform2D::IDENTITY,
+            0.4,
+            4.0,
+            1.0e-6,
+        )
+        .unwrap();
+
+        assert_point(segment.start, Vec2::new(-0.4482279, 2.8014424));
+        assert_point(segment.end, Vec2::new(-2.7901278, -0.44131964));
+        assert!((segment.length() - 4.0).abs() <= 1.0e-5);
+    }
+
+    #[test]
+    fn tangent_segment_normalizes_after_world_transform_and_clips_samples() {
+        let transform = Transform2D {
+            translation: Vec2::new(1.0, -1.0),
+            rotation: 0.3,
+            scale: Vec2::new(2.0, 0.5),
+        };
+        let transformed = tangent_segment_from_geometry_proportion(
+            &GeometryRef::circle(2.0),
+            transform,
+            0.4,
+            3.0,
+            1.0e-4,
+        )
+        .unwrap();
+        assert_point(transformed.start, Vec2::new(-1.058928, -0.50566184));
+        assert_point(transformed.end, Vec2::new(-3.4772415, -2.2809815));
+        assert!((transformed.length() - 3.0).abs() <= 1.0e-5);
+
+        let endpoint = tangent_segment_from_geometry_proportion(
+            &GeometryRef::circle(2.0),
+            Transform2D::IDENTITY,
+            0.0,
+            4.0,
+            1.0e-6,
+        )
+        .unwrap();
+        assert_point(endpoint.start, Vec2::new(2.0000057, -1.9999934));
+        assert_point(endpoint.end, Vec2::new(1.9999942, 2.0000067));
+    }
+
+    #[test]
+    fn tangent_segment_preserves_zero_negative_and_invalid_input_policy() {
+        let line = GeometryRef::line(Vec2::new(-1.0, 0.0), Vec2::new(1.0, 0.0));
+        let zero = tangent_segment_from_geometry_proportion(
+            &line,
+            Transform2D::IDENTITY,
+            0.5,
+            0.0,
+            1.0e-6,
+        )
+        .unwrap();
+        assert_point(zero.start, Vec2::ZERO);
+        assert_point(zero.end, Vec2::ZERO);
+
+        let negative = tangent_segment_from_geometry_proportion(
+            &line,
+            Transform2D::IDENTITY,
+            0.5,
+            -2.0,
+            1.0e-6,
+        )
+        .unwrap();
+        assert_point(negative.start, Vec2::new(1.0, 0.0));
+        assert_point(negative.end, Vec2::new(-1.0, 0.0));
+
+        let negative_delta = tangent_segment_from_geometry_proportion(
+            &line,
+            Transform2D::IDENTITY,
+            0.5,
+            2.0,
+            -1.0e-3,
+        )
+        .unwrap();
+        assert_point(negative_delta.start, Vec2::new(1.0, 0.0));
+        assert_point(negative_delta.end, Vec2::new(-1.0, 0.0));
+
+        assert!(matches!(
+            tangent_segment_from_geometry_proportion(&line, Transform2D::IDENTITY, 0.5, 1.0, 0.0,),
+            Err(TangentSegmentError::InvalidDelta(0.0))
+        ));
+        assert!(matches!(
+            tangent_segment_from_geometry_proportion(
+                &GeometryRef::circle(0.0),
+                Transform2D::IDENTITY,
+                0.5,
+                1.0,
+                1.0e-6,
+            ),
+            Err(TangentSegmentError::DegenerateSample)
+        ));
     }
 
     #[test]
@@ -142,6 +475,12 @@ mod tests {
         let circle = GeometryRef::circle(1.0);
         assert!(matches!(
             point_from_geometry_proportion(&circle, f32::NAN),
+            Err(GeometryProportionError::Path(
+                PathProportionError::InvalidProportion(_)
+            ))
+        ));
+        assert!(matches!(
+            point_from_geometry_proportion_f64(&circle, f64::NAN),
             Err(GeometryProportionError::Path(
                 PathProportionError::InvalidProportion(_)
             ))

--- a/crates/noon-geometry/src/partial.rs
+++ b/crates/noon-geometry/src/partial.rs
@@ -1,4 +1,4 @@
-use noon_core::{PathCommand, Vec2, VectorPath};
+use noon_core::{PathCommand, SemanticVec3, Vec2, VectorPath};
 
 const MANIM_LENGTH_SAMPLE_POINTS: usize = 10;
 
@@ -43,6 +43,13 @@ impl std::error::Error for PathProportionError {}
 fn validate_proportion(alpha: f32) -> Result<(), PathProportionError> {
     if !alpha.is_finite() || !(0.0..=1.0).contains(&alpha) {
         return Err(PathProportionError::InvalidProportion(alpha));
+    }
+    Ok(())
+}
+
+fn validate_proportion_f64(alpha: f64) -> Result<(), PathProportionError> {
+    if !alpha.is_finite() || !(0.0..=1.0).contains(&alpha) {
+        return Err(PathProportionError::InvalidProportion(alpha as f32));
     }
     Ok(())
 }
@@ -149,6 +156,72 @@ impl PathProportionPlan {
             .expect("path proportion plans are never empty")
             .to)
     }
+
+    /// Return a high-precision authoring point without quantizing `alpha` or
+    /// Bezier interpolation to the renderer's f32 coordinate type.
+    ///
+    /// The curve-selection measure is deliberately the same immutable sampled
+    /// measure prepared by [`Self::new`]. Only the proportion arithmetic and
+    /// point evaluation are lifted to f64, so there is one canonical Manim path
+    /// measure and precision-sensitive consumers do not need a second geometry
+    /// implementation.
+    pub fn point_f64(&self, alpha: f64) -> Result<SemanticVec3, PathProportionError> {
+        validate_proportion_f64(alpha)?;
+
+        if alpha == 1.0 {
+            return Ok(SemanticVec3::from_vec2(
+                self.curves
+                    .last()
+                    .expect("path proportion plans are never empty")
+                    .to,
+            ));
+        }
+
+        let total_length = f64::from(self.total_length);
+        let target_length = alpha * total_length;
+        if target_length.is_finite() {
+            let curve_index = self
+                .cumulative_lengths
+                .partition_point(|&end_length| f64::from(end_length) < target_length);
+            if curve_index < self.curves.len() {
+                let current_length = curve_index
+                    .checked_sub(1)
+                    .map_or(0.0, |index| f64::from(self.cumulative_lengths[index]));
+                let length = f64::from(self.lengths[curve_index]);
+                let residue = if length > 0.0 {
+                    ((target_length - current_length) / length).clamp(0.0, 1.0)
+                } else {
+                    0.0
+                };
+                return Ok(curve_point_f64(self.curves[curve_index], residue));
+            }
+        } else {
+            let mut current_length = 0.0_f64;
+            for (curve, length) in self
+                .curves
+                .iter()
+                .copied()
+                .zip(self.lengths.iter().copied().map(f64::from))
+            {
+                if current_length + length >= target_length {
+                    let residue = if length > 0.0 {
+                        ((target_length - current_length) / length).clamp(0.0, 1.0)
+                    } else {
+                        0.0
+                    };
+                    return Ok(curve_point_f64(curve, residue));
+                }
+                current_length += length;
+            }
+        }
+
+        Ok(SemanticVec3::from_vec2(
+            self.curves
+                .last()
+                .expect("path proportion plans are never empty")
+                .to,
+        ))
+    }
 }
 
 /// Return the point at `alpha` using ManimCE v0.21's `VMobject.point_from_proportion` measure.
@@ -164,6 +237,21 @@ impl PathProportionPlan {
 pub fn point_from_proportion(path: &VectorPath, alpha: f32) -> Result<Vec2, PathProportionError> {
     validate_proportion(alpha)?;
     PathProportionPlan::new(path)?.point(alpha)
+}
+
+/// High-precision authoring variant of [`point_from_proportion`].
+///
+/// This preserves f64 proportions and Bezier interpolation while reusing the
+/// exact same prepared Manim sampled-length measure. It is intended for
+/// precision-sensitive authoring operations such as finite-difference tangents;
+/// retained renderer geometry can be lowered to f32 after those semantic
+/// decisions are complete.
+pub fn point_from_proportion_f64(
+    path: &VectorPath,
+    alpha: f64,
+) -> Result<SemanticVec3, PathProportionError> {
+    validate_proportion_f64(alpha)?;
+    PathProportionPlan::new(path)?.point_f64(alpha)
 }
 
 /// Return the portion of a vector path whose global Bezier parameter lies in `[a, b]`.
@@ -334,6 +422,30 @@ fn curve_point(curve: Curve, t: f32) -> Vec2 {
     }
 }
 
+fn curve_point_f64(curve: Curve, t: f64) -> SemanticVec3 {
+    let from = SemanticVec3::from_vec2(curve.from);
+    let to = SemanticVec3::from_vec2(curve.to);
+    match curve.kind {
+        CurveKind::Line | CurveKind::Close => lerp_f64(from, to, t),
+        CurveKind::Quadratic { control } => {
+            let control = SemanticVec3::from_vec2(control);
+            let p01 = lerp_f64(from, control, t);
+            let p12 = lerp_f64(control, to, t);
+            lerp_f64(p01, p12, t)
+        }
+        CurveKind::Cubic { control1, control2 } => {
+            let control1 = SemanticVec3::from_vec2(control1);
+            let control2 = SemanticVec3::from_vec2(control2);
+            let p01 = lerp_f64(from, control1, t);
+            let p12 = lerp_f64(control1, control2, t);
+            let p23 = lerp_f64(control2, to, t);
+            let p012 = lerp_f64(p01, p12, t);
+            let p123 = lerp_f64(p12, p23, t);
+            lerp_f64(p012, p123, t)
+        }
+    }
+}
+
 fn partial_curve(curve: Curve, a: f32, b: f32) -> Curve {
     match curve.kind {
         CurveKind::Line | CurveKind::Close => Curve {
@@ -405,6 +517,14 @@ fn lerp(a: Vec2, b: Vec2, t: f32) -> Vec2 {
     a + (b - a) * t
 }
 
+fn lerp_f64(a: SemanticVec3, b: SemanticVec3, t: f64) -> SemanticVec3 {
+    SemanticVec3::new(
+        a.x + (b.x - a.x) * t,
+        a.y + (b.y - a.y) * t,
+        a.z + (b.z - a.z) * t,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -417,6 +537,15 @@ mod tests {
         assert!(
             (actual.y - expected.y).abs() < 1e-5,
             "y: {actual:?} != {expected:?}"
+        );
+    }
+
+    fn assert_semantic(actual: SemanticVec3, expected: SemanticVec3, tolerance: f64) {
+        assert!(
+            (actual.x - expected.x).abs() <= tolerance
+                && (actual.y - expected.y).abs() <= tolerance
+                && (actual.z - expected.z).abs() <= tolerance,
+            "{actual:?} != {expected:?}"
         );
     }
 
@@ -460,6 +589,25 @@ mod tests {
         assert_vec2(plan.point(0.25).unwrap(), Vec2::new(1.0, 0.0));
         assert_vec2(plan.point(0.5).unwrap(), Vec2::new(2.0, 0.0));
         assert_vec2(plan.point(0.875).unwrap(), Vec2::new(3.0, 0.5));
+    }
+
+    #[test]
+    fn precise_plan_reuses_measure_without_quantizing_alpha() {
+        let path = VectorPath::new()
+            .move_to(Vec2::ZERO)
+            .quadratic_to(Vec2::new(1.0, 2.0), Vec2::new(2.0, 0.0));
+        let plan = PathProportionPlan::new(&path).unwrap();
+        let lower_alpha = 0.4 - 1.0e-9;
+        let upper_alpha = 0.4 + 1.0e-9;
+
+        assert_eq!(lower_alpha as f32, upper_alpha as f32);
+        let lower = plan.point_f64(lower_alpha).unwrap();
+        let upper = plan.point_f64(upper_alpha).unwrap();
+        assert!((upper.x - lower.x).hypot(upper.y - lower.y) > 1.0e-9);
+
+        let ordinary = plan.point(0.4).unwrap();
+        let precise = plan.point_f64(0.4).unwrap();
+        assert_semantic(precise, SemanticVec3::from_vec2(ordinary), 2.0e-7);
     }
 
     #[test]
@@ -534,6 +682,10 @@ mod tests {
         );
         assert!(matches!(
             plan.point(f32::NAN),
+            Err(PathProportionError::InvalidProportion(alpha)) if alpha.is_nan()
+        ));
+        assert!(matches!(
+            plan.point_f64(f64::NAN),
             Err(PathProportionError::InvalidProportion(alpha)) if alpha.is_nan()
         ));
     }


### PR DESCRIPTION
Adds a precision-preserving shared path-proportion boundary and generic retained tangent-segment semantics. VectorPath queries reuse the existing ManimCE v0.21 PathProportionPlan; only proportion arithmetic and Bezier evaluation are lifted to f64. Analytic Circle uses the same pinned nine-component quadratic representation in f64. Tangent sampling, retained transform application, and normalization remain f64 until final retained endpoint lowering.

This resolves the real precision blocker documented in closed #655 without special-casing TangentLine in Python or the renderer. Focused tests cover sub-f32 alpha separation, Circle samples at 0.4 ± 1e-6, pinned TangentLine endpoints, transformed normalization, clipping, negative/zero lengths, and invalid inputs.

The DashedLine Python lane is already active in #755; plotting, retained-family animation, SceneSpec, Text transport, and CI work are also active, so this is an independent #78 prerequisite.

No renderer primitive, frontend tangent math, duplicate path measure, or new noon-to-noon-geometry dependency is introduced. Public WASM/Python TangentLine wiring and raster/demo qualification remain follow-up work.

Tracks #78 and unblocks #77 / #256.