### PR TITLE
Lower canonical SceneSpec through retained runtime

### DIFF
--- a/crates/noon-web/src/lib.rs
+++ b/crates/noon-web/src/lib.rs
@@ -36,6 +36,7 @@ mod retained_execution_resources;
 mod retained_execution_transport;
 mod retained_resource_mutation_transport;
 mod retained_resource_transport;
+mod retained_scene_spec_runtime;
 mod retained_text_family_transport;
 mod retained_typst_canvas;
 mod semantic_snapshot;

--- a/crates/noon-web/src/retained_authoring_scene.rs
+++ b/crates/noon-web/src/retained_authoring_scene.rs
@@ -1,31 +1,39 @@
+#[cfg(test)]
 use std::collections::{BTreeMap, HashSet};
 
-use noon::{MathTypst, RetainedScene, Text as NativeText, TextAuthoringError, Typst};
-use noon_compile::{RetainedCompileError, RetainedCompiledScene};
-use noon_core::{ObjectId, SceneDefinition, TrackDefinition, Vec2};
+use noon::TextAuthoringError;
+#[cfg(test)]
+use noon::{MathTypst, RetainedScene, Text as NativeText, Typst};
+use noon_compile::RetainedCompileError;
+#[cfg(test)]
+use noon_compile::RetainedCompiledScene;
+use noon_core::ObjectId;
+#[cfg(test)]
+use noon_core::{SceneDefinition, TrackDefinition, Vec2};
 
+use crate::RetainedTrackMaterializationError;
+#[cfg(test)]
 use crate::{
     materialize_retained_tracks, RetainedAuthoringDocument, RetainedAuthoringTextObject,
     RetainedTextAuthoringSpec, RetainedTextBackendSpec, RetainedTrackAuthoringSpec,
-    RetainedTrackMaterializationError,
 };
 
-/// One resource-aware scene assembled from the legacy geometry document and the
-/// retained text sidecar emitted by Python authoring.
+/// Previous split-input retained lowerer, kept only as a migration oracle for #367.
 ///
-/// The merge happens before runtime compilation. Geometry and text therefore share
-/// one semantic object list, one painter order, and one retained runtime; the browser
-/// never needs a second scene model or overlay renderer.
+/// Production consumers now normalize through canonical `SceneSpec` before retained
+/// lowering. Keeping this implementation test-only lets equivalence coverage compare
+/// against the proven path without shipping two runtime architectures.
+#[cfg(test)]
 #[derive(Clone, Debug)]
-pub struct MixedRetainedAuthoringScene {
+pub(crate) struct MixedRetainedAuthoringScene {
     scene: RetainedScene,
     tracks: Vec<TrackDefinition>,
     camera_object: Option<ObjectId>,
 }
 
+#[cfg(test)]
 impl MixedRetainedAuthoringScene {
-    #[cfg(test)]
-    pub fn from_json(
+    pub(crate) fn from_json(
         legacy_scene_json: &str,
         retained_document_json: &str,
     ) -> Result<Self, MixedRetainedAuthoringError> {
@@ -35,7 +43,7 @@ impl MixedRetainedAuthoringScene {
         Self::from_parts(&legacy, retained)
     }
 
-    pub fn from_parts(
+    pub(crate) fn from_parts(
         legacy: &SceneDefinition,
         retained: RetainedAuthoringDocument,
     ) -> Result<Self, MixedRetainedAuthoringError> {
@@ -49,7 +57,7 @@ impl MixedRetainedAuthoringScene {
     /// the legacy range, then the exact object/track set is compiled before this
     /// constructor commits a mixed scene. Invalid or text-incompatible tracks therefore
     /// fail transactionally without introducing a second animation validator.
-    pub fn from_parts_with_tracks(
+    pub(crate) fn from_parts_with_tracks(
         legacy: &SceneDefinition,
         retained: RetainedAuthoringDocument,
         retained_tracks: Vec<RetainedTrackAuthoringSpec>,
@@ -79,26 +87,22 @@ impl MixedRetainedAuthoringScene {
         })
     }
 
-    pub const fn scene(&self) -> &RetainedScene {
+    pub(crate) const fn scene(&self) -> &RetainedScene {
         &self.scene
     }
 
-    pub fn tracks(&self) -> &[TrackDefinition] {
+    pub(crate) fn tracks(&self) -> &[TrackDefinition] {
         &self.tracks
     }
 
-    pub fn compile(&self) -> Result<RetainedCompiledScene, MixedRetainedAuthoringError> {
+    pub(crate) fn compile(&self) -> Result<RetainedCompiledScene, MixedRetainedAuthoringError> {
         Ok(RetainedCompiledScene::compile(
             self.scene.objects(),
             &self.tracks,
         )?)
     }
 
-    pub fn into_scene(self) -> RetainedScene {
-        self.scene
-    }
-
-    pub const fn camera_object(&self) -> Option<ObjectId> {
+    pub(crate) const fn camera_object(&self) -> Option<ObjectId> {
         self.camera_object
     }
 }
@@ -168,6 +172,7 @@ impl From<RetainedCompileError> for MixedRetainedAuthoringError {
     }
 }
 
+#[cfg(test)]
 fn preflight_merge(
     legacy: &SceneDefinition,
     retained: &RetainedAuthoringDocument,
@@ -203,6 +208,7 @@ fn preflight_merge(
     Ok(())
 }
 
+#[cfg(test)]
 fn retained_scale_factors(objects: &[RetainedAuthoringTextObject]) -> BTreeMap<ObjectId, Vec2> {
     objects
         .iter()
@@ -218,6 +224,7 @@ fn retained_scale_factors(objects: &[RetainedAuthoringTextObject]) -> BTreeMap<O
         .collect()
 }
 
+#[cfg(test)]
 fn insert_text_object(
     scene: &mut RetainedScene,
     object: RetainedAuthoringTextObject,

--- a/crates/noon-web/src/retained_authoring_wire_scene.rs
+++ b/crates/noon-web/src/retained_authoring_wire_scene.rs
@@ -1,19 +1,19 @@
 use noon::RetainedScene;
 use noon_compile::RetainedCompiledScene;
 use noon_core::{ObjectId, SceneDefinition, TrackDefinition};
+use noon_ir::{SceneSpec, SceneSpecError};
 use serde::Deserialize;
 
 use crate::{
-    retained_authoring_scene, MixedRetainedAuthoringError, RetainedAuthoringDocument,
-    RetainedTrackAuthoringSpec,
+    retained_authoring_scene_spec, retained_scene_spec_runtime, MixedRetainedAuthoringError,
+    RetainedAuthoringDocument, RetainedAuthoringSceneSpecError, RetainedTrackAuthoringSpec,
 };
 
 /// One protocol-v2 retained payload.
 ///
-/// The established object document remains the canonical source-level text schema;
-/// animation tracks are an additive wire field. Flattening the object document here
-/// lets the complete payload deserialize exactly once while preserving backwards
-/// compatibility with object-only v2 JSON.
+/// The established object document remains the compatibility source-level text schema;
+/// animation tracks are an additive wire field. The two inputs are normalized into one
+/// canonical `SceneSpec` before any retained/runtime lowering.
 #[derive(Debug, Deserialize)]
 struct RetainedAuthoringWireDocument {
     #[serde(flatten)]
@@ -24,13 +24,14 @@ struct RetainedAuthoringWireDocument {
 
 /// Wire-facing mixed retained scene.
 ///
-/// Protocol v2 remains backwards-compatible with object-only retained documents while
-/// allowing an additive `tracks` field. Object validation stays source-level; track
-/// semantics are compiled only after legacy geometry and retained text share one object
-/// domain.
+/// Protocol v2 remains backwards-compatible while the consumer path is canonical:
+///
+/// `legacy geometry + retained sidecar -> SceneSpec -> RetainedScene -> compiler`.
+///
+/// The old split lowerer remains only as an equivalence oracle during #367 migration.
 #[derive(Clone, Debug)]
 pub struct MixedRetainedAuthoringScene {
-    inner: retained_authoring_scene::MixedRetainedAuthoringScene,
+    inner: retained_scene_spec_runtime::CanonicalRetainedAuthoringScene,
 }
 
 impl MixedRetainedAuthoringScene {
@@ -45,9 +46,6 @@ impl MixedRetainedAuthoringScene {
                     "invalid retained authoring document: {error}"
                 ))
             })?;
-        wire.document
-            .validate()
-            .map_err(MixedRetainedAuthoringError::RetainedDocument)?;
         Self::from_parts_with_tracks(&legacy, wire.document, wire.tracks)
     }
 
@@ -55,11 +53,7 @@ impl MixedRetainedAuthoringScene {
         legacy: &SceneDefinition,
         retained: RetainedAuthoringDocument,
     ) -> Result<Self, MixedRetainedAuthoringError> {
-        Ok(Self {
-            inner: retained_authoring_scene::MixedRetainedAuthoringScene::from_parts(
-                legacy, retained,
-            )?,
-        })
+        Self::from_parts_with_tracks(legacy, retained, Vec::new())
     }
 
     pub fn from_parts_with_tracks(
@@ -67,11 +61,20 @@ impl MixedRetainedAuthoringScene {
         retained: RetainedAuthoringDocument,
         retained_tracks: Vec<RetainedTrackAuthoringSpec>,
     ) -> Result<Self, MixedRetainedAuthoringError> {
+        let spec = retained_authoring_scene_spec(legacy, retained, retained_tracks)
+            .map_err(map_scene_spec_adapter_error)?;
+        Self::from_scene_spec(spec)
+    }
+
+    /// Consume the canonical mixed authoring document directly.
+    ///
+    /// This is the target consumer boundary for future Rust/Python/JavaScript producer
+    /// migration. Source-level text is still compiled by the existing shared Rust
+    /// backends and enters the ordinary retained resource/runtime path.
+    pub fn from_scene_spec(spec: SceneSpec) -> Result<Self, MixedRetainedAuthoringError> {
         Ok(Self {
-            inner: retained_authoring_scene::MixedRetainedAuthoringScene::from_parts_with_tracks(
-                legacy,
-                retained,
-                retained_tracks,
+            inner: retained_scene_spec_runtime::CanonicalRetainedAuthoringScene::from_scene_spec(
+                spec,
             )?,
         })
     }
@@ -97,10 +100,41 @@ impl MixedRetainedAuthoringScene {
     }
 }
 
+fn map_scene_spec_adapter_error(
+    error: RetainedAuthoringSceneSpecError,
+) -> MixedRetainedAuthoringError {
+    match error {
+        RetainedAuthoringSceneSpecError::RetainedDocument(error) => {
+            MixedRetainedAuthoringError::RetainedDocument(error)
+        }
+        RetainedAuthoringSceneSpecError::TrackMaterialization(error) => {
+            MixedRetainedAuthoringError::TrackMaterialization(error)
+        }
+        RetainedAuthoringSceneSpecError::SceneSpec(SceneSpecError::PainterOrderOutOfRange {
+            order,
+            object_count,
+        }) => MixedRetainedAuthoringError::PainterOrderOutOfRange {
+            order,
+            object_count,
+        },
+        RetainedAuthoringSceneSpecError::SceneSpec(SceneSpecError::ObjectCountOverflow) => {
+            MixedRetainedAuthoringError::ObjectCountOverflow
+        }
+        RetainedAuthoringSceneSpecError::SceneSpec(SceneSpecError::DuplicateObject(object)) => {
+            MixedRetainedAuthoringError::ObjectIdentityCollision(object)
+        }
+        RetainedAuthoringSceneSpecError::SceneSpec(error) => {
+            MixedRetainedAuthoringError::RetainedDocument(format!(
+                "invalid canonical mixed SceneSpec: {error}"
+            ))
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use noon_core::{Property, RateFunction, TrackTiming, TrackValues, Vec2};
+    use noon_core::{GeometryRef, Property, RateFunction, TrackTiming, TrackValues, Vec2};
     use noon_ir::encode_scene;
     use serde_json::json;
 
@@ -136,10 +170,22 @@ mod tests {
     }
 
     #[test]
-    fn protocol_v2_track_field_reaches_unified_retained_compiler() {
-        let legacy = SceneDefinition::new();
+    fn protocol_v2_normalizes_geometry_text_and_tracks_through_scene_spec() {
+        let mut legacy = SceneDefinition::new();
+        let geometry = legacy.add(GeometryRef::circle(0.5));
         let object = ObjectId::new(1_u64 << 52);
-        let document = retained_document(object);
+        let document = RetainedAuthoringDocument::new(vec![RetainedAuthoringTextObject {
+            object,
+            order: 1,
+            text: RetainedTextAuthoringSpec::native(
+                "Animated Noon",
+                noon::DEFAULT_NATIVE_TEXT_FONT_FAMILY,
+                48.0,
+                -1.0,
+            )
+            .unwrap(),
+        }])
+        .unwrap();
         let mut wire = serde_json::to_value(document).unwrap();
         wire["tracks"] = json!([RetainedTrackAuthoringSpec::new(
             object,
@@ -156,6 +202,15 @@ mod tests {
             &serde_json::to_string(&wire).unwrap(),
         )
         .unwrap();
+        assert_eq!(
+            mixed
+                .scene()
+                .objects()
+                .iter()
+                .map(|object| object.id)
+                .collect::<Vec<_>>(),
+            vec![geometry, object]
+        );
         assert_eq!(mixed.tracks().len(), 1);
         assert_eq!(mixed.tracks()[0].property, Property::Scale);
         assert_eq!(mixed.tracks()[0].object, object);
@@ -169,10 +224,11 @@ mod tests {
                 to: Vec2::ZERO,
             }
         );
+        assert_eq!(mixed.compile().unwrap().object_index(object), Some(1));
     }
 
     #[test]
-    fn invalid_object_document_is_rejected_before_track_materialization() {
+    fn invalid_object_document_is_rejected_before_canonical_lowering() {
         let legacy = SceneDefinition::new();
         let object = ObjectId::new(1_u64 << 52);
         let document = retained_document(object);

--- a/crates/noon-web/src/retained_scene_spec_runtime.rs
+++ b/crates/noon-web/src/retained_scene_spec_runtime.rs
@@ -1,0 +1,334 @@
+use noon::{MathTypst, RetainedScene, Text as NativeText, Typst};
+use noon_compile::RetainedCompiledScene;
+use noon_core::{
+    Color, ObjectDefinition, ObjectId, SceneDefinition, Style, TrackDefinition, Transform2D,
+};
+use noon_ir::{ObjectSpec, ObjectSpecContent, SceneSpec, TextSpec, TextSpecKind, TextSpecOptions};
+
+use crate::retained_authoring_scene::MixedRetainedAuthoringError;
+
+/// Canonical `SceneSpec` lowered into the existing retained runtime/resource model.
+///
+/// This is the consumer-side convergence point for #367. Geometry and source-level
+/// text arrive in one painter-ordered object vector, while compilation still reuses
+/// the existing native/Typst text authoring, resource arenas, retained compiler, and
+/// renderer. No frontend payload or renderer representation is introduced here.
+#[derive(Clone, Debug)]
+pub(crate) struct CanonicalRetainedAuthoringScene {
+    scene: RetainedScene,
+    tracks: Vec<TrackDefinition>,
+    camera_object: Option<ObjectId>,
+}
+
+impl CanonicalRetainedAuthoringScene {
+    pub(crate) fn from_scene_spec(spec: SceneSpec) -> Result<Self, MixedRetainedAuthoringError> {
+        spec.validate().map_err(invalid_scene_spec)?;
+
+        let SceneSpec {
+            objects,
+            tracks,
+            camera_object,
+            ..
+        } = spec;
+
+        // `RetainedScene` already owns the correct resource-backed text insertion
+        // APIs. Seed it with only the geometry subset, preserving relative geometry
+        // order, then insert text at its structural global painter slots.
+        let geometry_objects = objects
+            .iter()
+            .filter_map(|object| {
+                let ObjectSpecContent::Geometry(geometry) = &object.content else {
+                    return None;
+                };
+                Some(ObjectDefinition {
+                    id: object.id,
+                    geometry: geometry.clone(),
+                    transform: object.transform,
+                    style: object.style,
+                })
+            })
+            .collect::<Vec<_>>();
+        let geometry_scene = SceneDefinition::from_parts(geometry_objects, Vec::new())
+            .map_err(|error| invalid_scene_spec(error.to_string()))?;
+        let mut scene = RetainedScene::from_legacy(&geometry_scene)?;
+
+        for (order, object) in objects.into_iter().enumerate() {
+            let ObjectSpec {
+                id,
+                content,
+                transform,
+                style,
+            } = object;
+            if let ObjectSpecContent::Text(text) = content {
+                insert_text_object(&mut scene, order, id, text, transform, style)?;
+            }
+        }
+
+        // Keep the mature retained compiler as the semantic/timeline validator.
+        // This also proves every canonical object ID and normalized track reaches the
+        // same dense runtime domain before the scene is committed.
+        RetainedCompiledScene::compile(scene.objects(), &tracks)?;
+
+        Ok(Self {
+            scene,
+            tracks,
+            camera_object,
+        })
+    }
+
+    pub(crate) const fn scene(&self) -> &RetainedScene {
+        &self.scene
+    }
+
+    pub(crate) fn tracks(&self) -> &[TrackDefinition] {
+        &self.tracks
+    }
+
+    pub(crate) fn compile(&self) -> Result<RetainedCompiledScene, MixedRetainedAuthoringError> {
+        Ok(RetainedCompiledScene::compile(
+            self.scene.objects(),
+            &self.tracks,
+        )?)
+    }
+
+    pub(crate) fn into_scene(self) -> RetainedScene {
+        self.scene
+    }
+
+    pub(crate) const fn camera_object(&self) -> Option<ObjectId> {
+        self.camera_object
+    }
+}
+
+fn insert_text_object(
+    scene: &mut RetainedScene,
+    order: usize,
+    id: ObjectId,
+    text: TextSpec,
+    transform: Transform2D,
+    style: Style,
+) -> Result<(), MixedRetainedAuthoringError> {
+    let color = canonical_text_color(id, transform, style)?;
+    let TextSpec {
+        kind,
+        source,
+        font_size,
+        options,
+    } = text;
+
+    match kind {
+        TextSpecKind::Plain => {
+            let (font_family, line_spacing) = match options {
+                TextSpecOptions::Default => {
+                    (noon::DEFAULT_NATIVE_TEXT_FONT_FAMILY.to_owned(), -1.0)
+                }
+                TextSpecOptions::NativePlain {
+                    font_family,
+                    line_spacing,
+                } => (font_family, line_spacing),
+            };
+            let text = NativeText::new(source)
+                .with_font(font_family)
+                .with_font_size(font_size)
+                .with_line_spacing(line_spacing)
+                .color(color)
+                .set_opacity(style.opacity)
+                .move_to(transform.translation)
+                .scale_xy(transform.scale)
+                .rotate(transform.rotation);
+            scene.insert_native_text_at(order, id, text)?;
+        }
+        TextSpecKind::Typst | TextSpecKind::MathTypst => {
+            debug_assert!(matches!(options, TextSpecOptions::Default));
+            if kind == TextSpecKind::MathTypst {
+                let text = MathTypst::new(source)
+                    .with_font_size(font_size)
+                    .color(color)
+                    .set_opacity(style.opacity)
+                    .move_to(transform.translation)
+                    .scale_xy(transform.scale)
+                    .rotate(transform.rotation);
+                scene.insert_math_typst_at(order, id, text)?;
+            } else {
+                let text = Typst::new(source)
+                    .with_font_size(font_size)
+                    .color(color)
+                    .set_opacity(style.opacity)
+                    .move_to(transform.translation)
+                    .scale_xy(transform.scale)
+                    .rotate(transform.rotation);
+                scene.insert_typst_at(order, id, text)?;
+            }
+        }
+        TextSpecKind::Markup | TextSpecKind::Tex | TextSpecKind::MathTex => {
+            return Err(invalid_scene_spec(format!(
+                "text object {} uses unsupported source kind {kind:?}",
+                id.get()
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+fn canonical_text_color(
+    id: ObjectId,
+    transform: Transform2D,
+    style: Style,
+) -> Result<Color, MixedRetainedAuthoringError> {
+    let Some(color) = style.fill else {
+        return Err(invalid_scene_spec(format!(
+            "text object {} has no fill color",
+            id.get()
+        )));
+    };
+    if style.stroke.is_some() {
+        return Err(invalid_scene_spec(format!(
+            "text object {} requests text stroke before canonical stroke lowering is available",
+            id.get()
+        )));
+    }
+    if !style.opacity.is_finite() || !(0.0..=1.0).contains(&style.opacity) {
+        return Err(invalid_scene_spec(format!(
+            "text object {} has invalid opacity {}",
+            id.get(),
+            style.opacity
+        )));
+    }
+
+    let values = [
+        transform.translation.x,
+        transform.translation.y,
+        transform.scale.x,
+        transform.scale.y,
+        transform.rotation,
+        color.red,
+        color.green,
+        color.blue,
+        color.alpha,
+    ];
+    if values.iter().any(|value| !value.is_finite()) {
+        return Err(invalid_scene_spec(format!(
+            "text object {} has non-finite transform/color state",
+            id.get()
+        )));
+    }
+    Ok(color)
+}
+
+fn invalid_scene_spec(error: impl std::fmt::Display) -> MixedRetainedAuthoringError {
+    MixedRetainedAuthoringError::RetainedDocument(format!(
+        "invalid canonical mixed SceneSpec: {error}"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use noon_core::{
+        Color, GeometryRef, ObjectContentRef, Property, RateFunction, TrackTiming, TrackValues,
+        Transform2D, Vec2,
+    };
+
+    use super::*;
+    use crate::{
+        retained_authoring_scene, retained_authoring_scene_spec, RetainedAuthoringDocument,
+        RetainedAuthoringTextObject, RetainedTextAuthoringSpec, RetainedTrackAuthoringSpec,
+    };
+
+    #[test]
+    fn canonical_lowering_matches_split_runtime_and_compiled_output() {
+        let mut legacy = SceneDefinition::new();
+        let camera = legacy.add(GeometryRef::rectangle(14.0, 8.0));
+        let circle = legacy.add(GeometryRef::circle(0.5));
+        assert!(legacy.set_camera_object(camera));
+
+        let text_id = ObjectId::new(1_u64 << 52);
+        let mut text = RetainedTextAuthoringSpec::native(
+            "Canonical Noon",
+            noon::DEFAULT_NATIVE_TEXT_FONT_FAMILY,
+            48.0,
+            -1.0,
+        )
+        .unwrap();
+        text.transform = Transform2D {
+            translation: Vec2::new(1.25, -0.5),
+            rotation: 0.2,
+            scale: Vec2::new(1.5, 0.75),
+        };
+        text.set_color(Color::rgba(0.2, 0.5, 0.8, 0.9)).unwrap();
+        text.set_opacity(0.65).unwrap();
+
+        let retained = RetainedAuthoringDocument::new(vec![RetainedAuthoringTextObject {
+            object: text_id,
+            order: 1,
+            text,
+        }])
+        .unwrap();
+        let track = RetainedTrackAuthoringSpec::new(
+            text_id,
+            Property::Scale,
+            TrackValues::Vec2 {
+                from: Vec2::ONE,
+                to: Vec2::ZERO,
+            },
+            TrackTiming::new(0.0, 1.0, RateFunction::Smooth),
+        );
+
+        let canonical_spec =
+            retained_authoring_scene_spec(&legacy, retained.clone(), vec![track.clone()]).unwrap();
+        let canonical = CanonicalRetainedAuthoringScene::from_scene_spec(canonical_spec).unwrap();
+        let split = retained_authoring_scene::MixedRetainedAuthoringScene::from_parts_with_tracks(
+            &legacy,
+            retained,
+            vec![track],
+        )
+        .unwrap();
+
+        assert_eq!(
+            canonical
+                .scene()
+                .objects()
+                .iter()
+                .map(|object| object.id)
+                .collect::<Vec<_>>(),
+            vec![camera, text_id, circle]
+        );
+        assert_eq!(canonical.scene().objects(), split.scene().objects());
+        assert_eq!(canonical.tracks(), split.tracks());
+        assert_eq!(canonical.camera_object(), split.camera_object());
+        assert_eq!(canonical.compile().unwrap(), split.compile().unwrap());
+
+        let canonical_handle = canonical.scene().objects()[1].content.text().unwrap();
+        let split_handle = split.scene().objects()[1].content.text().unwrap();
+        assert_eq!(
+            canonical.scene().texts().get(canonical_handle),
+            split.scene().texts().get(split_handle)
+        );
+        assert!(matches!(
+            canonical.scene().objects()[0].content,
+            ObjectContentRef::Geometry(_)
+        ));
+        assert!(matches!(
+            canonical.scene().objects()[1].content,
+            ObjectContentRef::Text(_)
+        ));
+    }
+
+    #[test]
+    fn direct_scene_spec_rejects_unimplemented_text_backends_without_fallback() {
+        let object = ObjectId::new(7);
+        let spec = SceneSpec::new(
+            vec![ObjectSpec::text(
+                object,
+                TextSpec::new(TextSpecKind::Tex, "x^2", 48.0),
+            )],
+            Vec::new(),
+        )
+        .unwrap();
+
+        let error = CanonicalRetainedAuthoringScene::from_scene_spec(spec).unwrap_err();
+        let message = error.to_string();
+        assert!(message.contains("unsupported source kind Tex"));
+        assert!(message.contains("7"));
+    }
+}


### PR DESCRIPTION
## Summary

- add the consumer-side `SceneSpec -> RetainedScene` lowering boundary for #367
- normalize existing protocol-v2 `legacy geometry + retained text sidecar + retained tracks` into the canonical `SceneSpec` before runtime compilation
- reuse the existing native Text / Typst / MathTypst compilers, resource arenas, retained compiler, and renderer unchanged
- expose `MixedRetainedAuthoringScene::from_scene_spec` as the direct canonical consumer entry for later producer migration
- keep the previous split lowerer only under `cfg(test)` as an equivalence oracle, so production ships one retained consumer path

## Architecture

```text
protocol-v2 compatibility inputs
  legacy geometry + retained sidecar + tracks
                    |
                    v
             noon_ir::SceneSpec
       one ordered object/track domain
                    |
                    v
       canonical retained lowerer
       /                    \
 geometry subset       source TextSpec
       |                    |
       |              existing Native/Typst
       |                 compilers/arenas
       \____________________/
                    |
              RetainedScene
                    |
           RetainedCompiledScene
                    |
            existing renderer
```

No glyph arrays, font bytes, SVG, fake geometry, overlay renderer, or renderer/runtime semantic fork is introduced.

## Equivalence coverage

The new regression compares the canonical lowerer against the previous split lowerer for:
- geometry -> text -> geometry painter order
- exact retained object definitions
- normalized tracks
- camera identity
- compiled retained scene output including dense object indices/dynamic flags
- compiled text resource content

The previous split lowerer is test-only during this migration step; compatibility protocol decoding remains supported, but production no longer has two retained lowerers.

## Scope boundary

This PR does **not** switch Python/JS producers to emit `SceneSpec` directly, remove the retained sidecar, or retire the special text-ID range. Those are subsequent #367 slices after the canonical consumer path is qualified.

Tracks #367. Follows #748.