### PR TITLE
Add shared generic Axes graph x lookup

### DIFF
--- a/crates/noon-web/src/manim_axes_query_bridge.rs
+++ b/crates/noon-web/src/manim_axes_query_bridge.rs
@@ -149,9 +149,9 @@ fn binary_search_graph_x(
     graph: &ObjectSnapshot,
     target: f64,
 ) -> Result<Option<f64>, ManimAxesQueryError> {
-    let mut left = 0.0;
-    let mut right = 1.0;
-    let mut middle = 0.5;
+    let mut left: f64 = 0.0;
+    let mut right: f64 = 1.0;
+    let mut middle: f64 = 0.5;
     while (right - left).abs() > MANIM_GRAPH_X_SEARCH_TOLERANCE {
         middle = (left + right) * 0.5;
         let left_x = graph_x_at_proportion(axes, graph, left)?;
@@ -512,8 +512,8 @@ mod tests {
             Err(ManimAxesQueryError::GraphXOutOfRange { .. })
         ));
 
-        let rectangle = serde_json::to_string(&ObjectSnapshot::new(GeometryRef::rectangle(1.0, 1.0)))
-            .unwrap();
+        let rectangle =
+            serde_json::to_string(&ObjectSnapshot::new(GeometryRef::rectangle(1.0, 1.0))).unwrap();
         assert!(matches!(
             plan.graph_point_for_x_json(0.0, &rectangle, &x_axis, &y_axis),
             Err(ManimAxesQueryError::GeometryProportion(

--- a/crates/noon-web/src/manim_axes_query_bridge.rs
+++ b/crates/noon-web/src/manim_axes_query_bridge.rs
@@ -3,7 +3,10 @@ use noon::{
     LineGraphAuthoringError, NumberRange, Path, TransformedAxes2DState,
 };
 use noon_core::{GeometryRef, ObjectSnapshot, Vec2};
+use noon_geometry::{point_from_geometry_proportion, GeometryProportionError};
 use serde::Deserialize;
+
+const MANIM_GRAPH_X_SEARCH_TOLERANCE: f64 = 1.0e-4;
 
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
@@ -72,6 +75,41 @@ impl AxesQueryPlan {
             .map_err(|error| ManimAxesQueryError::Serialization(error.to_string()))
     }
 
+    /// ManimCE v0.21 generic `input_to_graph_point` fallback for retained path-like graphs.
+    ///
+    /// The authored-function fast path remains frontend-visible because it calls the user's
+    /// callback directly. For generic VMobjects, however, path proportion, current graph
+    /// transform, current Axes transforms, and Manim's binary-search semantics all remain
+    /// inside Rust so the host does not repeatedly cross the WASM boundary.
+    pub fn graph_point_for_x_json(
+        &self,
+        x: f64,
+        graph_snapshot_json: &str,
+        x_axis_snapshot_json: &str,
+        y_axis_snapshot_json: &str,
+    ) -> Result<String, ManimAxesQueryError> {
+        if !x.is_finite() {
+            return Err(ManimAxesQueryError::NonFiniteGraphX(x));
+        }
+        let graph: ObjectSnapshot = serde_json::from_str(graph_snapshot_json)
+            .map_err(|error| ManimAxesQueryError::InvalidGraphSnapshot(error.to_string()))?;
+        let transformed = self.transformed_axes(x_axis_snapshot_json, y_axis_snapshot_json)?;
+        let alpha = binary_search_graph_x(&transformed, &graph, x)?;
+        if let Some(alpha) = alpha {
+            return serialize_pair(graph_point_from_proportion(&graph, alpha)?);
+        }
+
+        let start = graph_point_from_proportion(&graph, 0.0)?;
+        let end = graph_point_from_proportion(&graph, 1.0)?;
+        let start_x = transformed.point_to_coords(start)?.0;
+        let end_x = transformed.point_to_coords(end)?.0;
+        Err(ManimAxesQueryError::GraphXOutOfRange {
+            x,
+            start: start_x,
+            end: end_x,
+        })
+    }
+
     fn transformed_axes(
         &self,
         x_axis_snapshot_json: &str,
@@ -85,6 +123,60 @@ impl AxesQueryPlan {
             y_axis.transform,
         ))
     }
+}
+
+fn graph_point_from_proportion(
+    graph: &ObjectSnapshot,
+    alpha: f64,
+) -> Result<Vec2, ManimAxesQueryError> {
+    let local = point_from_geometry_proportion(&graph.geometry, alpha as f32)?;
+    Ok(graph.transform.transform_point(local))
+}
+
+fn graph_x_at_proportion(
+    axes: &TransformedAxes2DState,
+    graph: &ObjectSnapshot,
+    alpha: f64,
+) -> Result<f64, ManimAxesQueryError> {
+    Ok(axes
+        .point_to_coords(graph_point_from_proportion(graph, alpha)?)?
+        .0)
+}
+
+/// Exact control flow of ManimCE v0.21 `binary_search` for graph-x lookup.
+fn binary_search_graph_x(
+    axes: &TransformedAxes2DState,
+    graph: &ObjectSnapshot,
+    target: f64,
+) -> Result<Option<f64>, ManimAxesQueryError> {
+    let mut left = 0.0;
+    let mut right = 1.0;
+    let mut middle = 0.5;
+    while (right - left).abs() > MANIM_GRAPH_X_SEARCH_TOLERANCE {
+        middle = (left + right) * 0.5;
+        let left_x = graph_x_at_proportion(axes, graph, left)?;
+        let middle_x = graph_x_at_proportion(axes, graph, middle)?;
+        let right_x = graph_x_at_proportion(axes, graph, right)?;
+        if left_x == target {
+            return Ok(Some(left));
+        }
+        if right_x == target {
+            return Ok(Some(right));
+        }
+
+        if left_x <= target && target <= right_x {
+            if middle_x > target {
+                right = middle;
+            } else {
+                left = middle;
+            }
+        } else if left_x > target && target > right_x {
+            std::mem::swap(&mut left, &mut right);
+        } else {
+            return Ok(None);
+        }
+    }
+    Ok(Some(middle))
 }
 
 fn parse_axis_snapshot(
@@ -112,10 +204,14 @@ fn serialize_pair(point: Vec2) -> Result<String, ManimAxesQueryError> {
 pub enum ManimAxesQueryError {
     InvalidRequest(String),
     InvalidLineGraphValues(String),
+    InvalidGraphSnapshot(String),
     InvalidAxisSnapshot { axis: &'static str, error: String },
     InvalidAxisGeometry(&'static str),
+    NonFiniteGraphX(f64),
+    GraphXOutOfRange { x: f64, start: f64, end: f64 },
     Coordinates(CoordinateSystemError),
     LineGraph(LineGraphAuthoringError),
+    GeometryProportion(GeometryProportionError),
     Serialization(String),
 }
 
@@ -126,6 +222,9 @@ impl std::fmt::Display for ManimAxesQueryError {
             Self::InvalidLineGraphValues(error) => {
                 write!(formatter, "invalid Axes.plot_line_graph values: {error}")
             }
+            Self::InvalidGraphSnapshot(error) => {
+                write!(formatter, "invalid graph snapshot: {error}")
+            }
             Self::InvalidAxisSnapshot { axis, error } => {
                 write!(formatter, "invalid Axes {axis}-axis snapshot: {error}")
             }
@@ -135,8 +234,16 @@ impl std::fmt::Display for ManimAxesQueryError {
                     "Axes {axis}-axis snapshot must contain line geometry"
                 )
             }
+            Self::NonFiniteGraphX(x) => {
+                write!(formatter, "graph x lookup requires a finite value: {x}")
+            }
+            Self::GraphXOutOfRange { x, start, end } => write!(
+                formatter,
+                "x={x} not located in the range of the graph ([{start}, {end}])"
+            ),
             Self::Coordinates(error) => error.fmt(formatter),
             Self::LineGraph(error) => error.fmt(formatter),
+            Self::GeometryProportion(error) => error.fmt(formatter),
             Self::Serialization(error) => {
                 write!(formatter, "unable to serialize Axes query result: {error}")
             }
@@ -155,6 +262,12 @@ impl From<CoordinateSystemError> for ManimAxesQueryError {
 impl From<LineGraphAuthoringError> for ManimAxesQueryError {
     fn from(value: LineGraphAuthoringError) -> Self {
         Self::LineGraph(value)
+    }
+}
+
+impl From<GeometryProportionError> for ManimAxesQueryError {
+    fn from(value: GeometryProportionError) -> Self {
+        Self::GeometryProportion(value)
     }
 }
 
@@ -217,6 +330,24 @@ mod wasm {
                 .line_graph_snapshot_json(values_json, x_axis_snapshot_json, y_axis_snapshot_json)
                 .map_err(js_error)
         }
+
+        #[wasm_bindgen(js_name = graphPointForXJson)]
+        pub fn graph_point_for_x_json(
+            &self,
+            x: f64,
+            graph_snapshot_json: &str,
+            x_axis_snapshot_json: &str,
+            y_axis_snapshot_json: &str,
+        ) -> Result<String, JsValue> {
+            self.0
+                .graph_point_for_x_json(
+                    x,
+                    graph_snapshot_json,
+                    x_axis_snapshot_json,
+                    y_axis_snapshot_json,
+                )
+                .map_err(js_error)
+        }
     }
 }
 
@@ -237,6 +368,13 @@ mod tests {
         let mut snapshot = Line::new(axis.start(), axis.end()).into_snapshot();
         snapshot.transform = transform;
         serde_json::to_string(&snapshot).unwrap()
+    }
+
+    fn identity_axes(plan: &AxesQueryPlan) -> (String, String) {
+        (
+            axis_snapshot(plan.axes.x_axis(), Transform2D::IDENTITY),
+            axis_snapshot(plan.axes.y_axis(), Transform2D::IDENTITY),
+        )
     }
 
     #[test]
@@ -301,10 +439,93 @@ mod tests {
     }
 
     #[test]
+    fn generic_graph_lookup_matches_manim_binary_search_for_ascending_and_descending_x() {
+        let plan = AxesQueryPlan::from_json(request_json()).unwrap();
+        let (x_axis, y_axis) = identity_axes(&plan);
+
+        for values in [
+            "[[-1.0,0.0,1.0],[1.0,0.0,-1.0]]",
+            "[[1.0,0.0,-1.0],[1.0,0.0,-1.0]]",
+        ] {
+            let graph = plan
+                .line_graph_snapshot_json(values, &x_axis, &y_axis)
+                .unwrap();
+            let point: [f64; 2] = serde_json::from_str(
+                &plan
+                    .graph_point_for_x_json(0.5, &graph, &x_axis, &y_axis)
+                    .unwrap(),
+            )
+            .unwrap();
+            let coords: [f64; 2] = serde_json::from_str(
+                &plan
+                    .point_to_coords_json(point[0] as f32, point[1] as f32, &x_axis, &y_axis)
+                    .unwrap(),
+            )
+            .unwrap();
+            assert!((coords[0] - 0.5).abs() <= MANIM_GRAPH_X_SEARCH_TOLERANCE);
+        }
+    }
+
+    #[test]
+    fn generic_graph_lookup_uses_current_graph_and_axes_transforms() {
+        let plan = AxesQueryPlan::from_json(request_json()).unwrap();
+        let axes_transform = Transform2D {
+            translation: Vec2::new(2.0, -1.0),
+            rotation: 0.2,
+            scale: Vec2::new(1.1, 1.1),
+        };
+        let x_axis = axis_snapshot(plan.axes.x_axis(), axes_transform);
+        let y_axis = axis_snapshot(plan.axes.y_axis(), axes_transform);
+        let mut graph: ObjectSnapshot = serde_json::from_str(
+            &plan
+                .line_graph_snapshot_json("[[-1.0,0.0,1.0],[0.0,0.0,0.0]]", &x_axis, &y_axis)
+                .unwrap(),
+        )
+        .unwrap();
+        graph.transform.translation = Vec2::new(0.2, 0.0);
+        let point: [f64; 2] = serde_json::from_str(
+            &plan
+                .graph_point_for_x_json(
+                    0.5,
+                    &serde_json::to_string(&graph).unwrap(),
+                    &x_axis,
+                    &y_axis,
+                )
+                .unwrap(),
+        )
+        .unwrap();
+        let coords = TransformedAxes2DState::new(plan.axes, axes_transform, axes_transform)
+            .point_to_coords(Vec2::new(point[0] as f32, point[1] as f32))
+            .unwrap();
+        assert!((coords.0 - 0.5).abs() <= MANIM_GRAPH_X_SEARCH_TOLERANCE);
+    }
+
+    #[test]
+    fn generic_graph_lookup_rejects_out_of_range_and_non_path_geometry() {
+        let plan = AxesQueryPlan::from_json(request_json()).unwrap();
+        let (x_axis, y_axis) = identity_axes(&plan);
+        let graph = plan
+            .line_graph_snapshot_json("[[-1.0,0.0,1.0],[0.0,0.0,0.0]]", &x_axis, &y_axis)
+            .unwrap();
+        assert!(matches!(
+            plan.graph_point_for_x_json(3.0, &graph, &x_axis, &y_axis),
+            Err(ManimAxesQueryError::GraphXOutOfRange { .. })
+        ));
+
+        let rectangle = serde_json::to_string(&ObjectSnapshot::new(GeometryRef::rectangle(1.0, 1.0)))
+            .unwrap();
+        assert!(matches!(
+            plan.graph_point_for_x_json(0.0, &rectangle, &x_axis, &y_axis),
+            Err(ManimAxesQueryError::GeometryProportion(
+                GeometryProportionError::UnsupportedGeometry
+            ))
+        ));
+    }
+
+    #[test]
     fn malformed_and_mismatched_line_graph_values_fail_closed() {
         let plan = AxesQueryPlan::from_json(request_json()).unwrap();
-        let x_axis = axis_snapshot(plan.axes.x_axis(), Transform2D::IDENTITY);
-        let y_axis = axis_snapshot(plan.axes.y_axis(), Transform2D::IDENTITY);
+        let (x_axis, y_axis) = identity_axes(&plan);
         assert!(matches!(
             plan.line_graph_snapshot_json("not json", &x_axis, &y_axis),
             Err(ManimAxesQueryError::InvalidLineGraphValues(_))

--- a/scripts/manim-axes-smoke.mjs
+++ b/scripts/manim-axes-smoke.mjs
@@ -202,6 +202,21 @@ class RetainedAxesPlot(Scene):
         for dot, expected in zip(line_graph["vertex_dots"], expected_vertices):
             assert_point_close(dot.get_center(), expected)
 
+        lookup_line_graph = axes.plot_line_graph(
+            x_values=[-1.0, 0.0, 1.0],
+            y_values=[1.0, 0.0, 1.0],
+            add_vertex_dots=False,
+        )["line_graph"]
+        lookup_point = axes.input_to_graph_point(0.5, lookup_line_graph)
+        assert_point_close(lookup_point, axes.c2p(0.5, 0.5), tolerance=2e-4)
+        assert_point_close(axes.i2gp(0.5, lookup_line_graph), lookup_point, tolerance=2e-4)
+        try:
+            axes.input_to_graph_point(3.0, lookup_line_graph)
+            raise AssertionError("out-of-range generic graph lookup must fail")
+        except ValueError as error:
+            assert "x=3" in str(error)
+            assert "not located in the range of the graph" in str(error)
+
         no_dots = axes.plot_line_graph(
             x_values=[0, 1],
             y_values=[0, 1],
@@ -231,6 +246,8 @@ class RetainedAxesPlot(Scene):
         cos_graph = axes.plot(lambda x: math.cos(x), color=RED)
         assert isinstance(sin_graph, ParametricFunction)
         assert isinstance(cos_graph, ParametricFunction)
+        cos_point = axes.input_to_graph_point(0.25, cos_graph)
+        assert_point_close(cos_point, axes.c2p(0.25, math.cos(0.25)))
         self.add(axes, sin_graph, cos_graph, vertical, horizontal, line_graph)
 `;
 
@@ -281,7 +298,7 @@ try {
   );
   assert.deepEqual(errors, [], `browser errors while testing retained Axes:\n${errors.join("\n")}`);
   console.log(
-    "Retained Axes smoke passed: transformed c2p/p2c/i2gp, retained projections, plot curves, and VDict line graphs with shared corner-path geometry and optional retained dots.",
+    "Retained Axes smoke passed: transformed c2p/p2c, authored and generic i2gp, retained projections, plot curves, and VDict line graphs with shared corner-path geometry and optional retained dots.",
   );
 } finally {
   await browser?.close();

--- a/web/python/_manim_axes.py
+++ b/web/python/_manim_axes.py
@@ -394,20 +394,41 @@ class Axes(_compat.VGroup):
     def __rmatmul__(self, point: object) -> list[float]:
         return self.point_to_coords(point)
 
-    def input_to_graph_point(self, x: float, graph: ParametricFunction | _compat.VMobject) -> object:
+    def input_to_graph_point(
+        self, x: float, graph: ParametricFunction | _compat.VMobject
+    ) -> object:
         """Return the point on a graph corresponding to an axis x value.
 
-        ManimCE v0.21 directly evaluates authored function graphs through their
-        `function` callback. General VMobject lookup falls back to a path-space binary
-        search upstream; Noon fails closed on that broader case until generic
-        point-from-proportion semantics are shared.
+        Authored function graphs retain ManimCE v0.21's direct callback fast path.
+        Generic retained VMobjects delegate the complete path-proportion binary search
+        to the shared Rust query plan in one WASM call.
         """
 
+        value = float(x)
         if hasattr(graph, "underlying_function"):
-            return graph.function(float(x))
-        raise NotImplementedError(
-            "input_to_graph_point for generic VMobjects requires shared point-from-proportion semantics"
-        )
+            return graph.function(value)
+
+        handle = _shared._handle_for(graph)
+        if handle is None:
+            raise TypeError(
+                "input_to_graph_point requires an authored graph or retained VMobject"
+            )
+        try:
+            result = json.loads(
+                str(
+                    self._query_plan.graphPointForXJson(
+                        value,
+                        str(handle.snapshotJson()),
+                        self.x_axis._axis_snapshot_json(),
+                        self.y_axis._axis_snapshot_json(),
+                    )
+                )
+            )
+        except Exception as error:
+            # ManimCE surfaces generic graph lookup misses as ValueError. The shared
+            # Rust path already owns the exact diagnostic, including graph endpoints.
+            raise ValueError(str(error)) from None
+        return _base.Vec2(float(result[0]), float(result[1]))
 
     def input_to_graph_coords(
         self, x: float, graph: ParametricFunction
@@ -417,7 +438,9 @@ class Axes(_compat.VGroup):
     def i2gc(self, x: float, graph: ParametricFunction) -> tuple[float, float]:
         return self.input_to_graph_coords(x, graph)
 
-    def i2gp(self, x: float, graph: ParametricFunction) -> object:
+    def i2gp(
+        self, x: float, graph: ParametricFunction | _compat.VMobject
+    ) -> object:
         return self.input_to_graph_point(x, graph)
 
     def get_line_from_axis_to_point(


### PR DESCRIPTION
## Summary
- add ManimCE v0.21 generic `Axes.input_to_graph_point` / `i2gp` support for retained path-like graphs
- keep authored-function graphs on their existing direct callback fast path
- evaluate retained `point_from_geometry_proportion` in Rust, including the graph's current retained transform
- map every candidate through the current transformed Axes state
- reproduce ManimCE v0.21 `binary_search` control flow and `1e-4` tolerance in shared Rust
- expose one `WasmAxesQueryPlan.graphPointForXJson` call so Python never drives the binary-search loop across the WASM boundary
- pass the authoritative retained graph snapshot plus current x/y-axis snapshots from the Python facade and return a normal Manim-facing `Vec2`
- translate generic lookup failures to the Manim-facing `ValueError` surface while preserving the Rust-owned upstream-style diagnostic
- preserve Manim's descending-x search branch and explicit out-of-range diagnostic

## Focused tests
Rust bridge tests pin:
- ascending line-graph x lookup
- descending line-graph x lookup
- current graph + Axes transforms participate in the search
- out-of-range lookup fails explicitly
- non-path retained geometry fails closed through the shared geometry-proportion contract

Browser acceptance exercises the label-free upstream shape directly:
- a normal authored graph still resolves through the callback fast path
- a retained `plot_line_graph` resolves through the shared generic lookup
- `input_to_graph_point` and `i2gp` agree
- transformed Axes are respected
- out-of-range generic lookup raises `ValueError` with the upstream-style range diagnostic

## Exact-head qualification
Current head: `6f0e06895ade02c75960487227d4f726f1e1a68c`.

Single PR Fast Gate run `33505445229` completed successfully on this exact head. The gate includes Rust formatting/Clippy, Rust workspace library tests, web preflight/WASM build, deterministic playback, Manim-style browser authoring, retained Axes plotting (including the new authored + generic `i2gp` acceptance), lazy Manim namespace, literal pinned PlotExample, primary WebGPU rendering, and the aggregate Fast Gate.

## Architecture
This reuses `noon-geometry::point_from_geometry_proportion`; no path interpolation or binary-search math is copied into Python or JavaScript. Generic retained lookup crosses Python→WASM once per query, and Rust owns graph proportion evaluation plus current graph/Axes transforms for the entire search.

This is the label-independent Manim v0.21 acceptance slice needed before broader graph helpers. Exact `HeatDiagramPlot` gallery qualification remains separately blocked by #83 real Tex/axis-label rendering.

Stacked on #774.

Tracks #253 / #85.