### PR TITLE
Expose canonical SceneSpec from Python authoring

### DIFF
--- a/web/authoring-client.js
+++ b/web/authoring-client.js
@@ -1,6 +1,7 @@
 export const AUTHORING_CHANNEL = "noon.authoring";
 export const AUTHORING_PROTOCOL_VERSION = 5;
 export const NOON_IR_VERSION = 1;
+export const SCENE_SPEC_VERSION = 1;
 export const RETAINED_AUTHORING_CHANNEL = "noon.authoring.retained";
 export const RETAINED_AUTHORING_VERSION = 2;
 
@@ -223,6 +224,7 @@ export function parseAuthoringResult(resultJson) {
   if (result.kind === "scene_document") {
     const document = validateSceneDocument(result.document);
     const retainedDocument = validateRetainedAuthoringDocument(result.retained_document);
+    const sceneSpec = validateSceneSpec(result.scene_spec);
     const parsed = {
       kind: result.kind,
       document,
@@ -232,6 +234,9 @@ export function parseAuthoringResult(resultJson) {
     };
     if (retainedDocument !== null) {
       parsed.retainedDocument = retainedDocument;
+    }
+    if (sceneSpec !== null) {
+      parsed.sceneSpec = sceneSpec;
     }
     return parsed;
   }
@@ -281,6 +286,45 @@ export function validateSceneDocument(scene) {
     throw new Error("Python Scene tracks must be an array");
   }
   return scene;
+}
+
+export function validateSceneSpec(sceneSpec) {
+  if (sceneSpec === null || sceneSpec === undefined) {
+    return null;
+  }
+  if (!isRecord(sceneSpec)) {
+    throw new Error("Python canonical SceneSpec result must be an object");
+  }
+  if (sceneSpec.version !== SCENE_SPEC_VERSION) {
+    throw new Error(`Unsupported canonical SceneSpec version ${sceneSpec.version}`);
+  }
+  if (!Array.isArray(sceneSpec.objects)) {
+    throw new Error("Python canonical SceneSpec objects must be an array");
+  }
+  if (!Array.isArray(sceneSpec.tracks)) {
+    throw new Error("Python canonical SceneSpec tracks must be an array");
+  }
+
+  const objectIds = new Set();
+  for (const object of sceneSpec.objects) {
+    if (!isRecord(object) || !Number.isSafeInteger(object.id) || object.id < 0) {
+      throw new Error("Python canonical SceneSpec object has an invalid object ID");
+    }
+    if (objectIds.has(object.id)) {
+      throw new Error("Python canonical SceneSpec has duplicate object IDs");
+    }
+    objectIds.add(object.id);
+  }
+  if (
+    sceneSpec.camera_object !== null &&
+    sceneSpec.camera_object !== undefined &&
+    (!Number.isSafeInteger(sceneSpec.camera_object) ||
+      sceneSpec.camera_object < 0 ||
+      !objectIds.has(sceneSpec.camera_object))
+  ) {
+    throw new Error("Python canonical SceneSpec has an invalid camera object");
+  }
+  return sceneSpec;
 }
 
 export function validateRetainedAuthoringDocument(document) {

--- a/web/authoring-scene-spec-result.test.mjs
+++ b/web/authoring-scene-spec-result.test.mjs
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import {
+  parseAuthoringResult,
+  validateSceneSpec,
+} from "./authoring-client.js";
+
+function retainedDocument() {
+  return {
+    channel: "noon.authoring.retained",
+    protocol_version: 2,
+    objects: [
+      {
+        object: 2 ** 52,
+        order: 1,
+        text: {
+          source: "Canonical Noon",
+          backend: {
+            kind: "native",
+            font_family: "DejaVu Sans Mono",
+            line_spacing: -1,
+          },
+          font_size: 48,
+          transform: {
+            translation: { x: 0, y: 0 },
+            scale: { x: 1, y: 1 },
+            rotation: 0,
+          },
+          color: { red: 1, green: 1, blue: 1, alpha: 1 },
+          opacity: 1,
+        },
+      },
+    ],
+  };
+}
+
+function canonicalSceneSpec() {
+  return {
+    version: 1,
+    objects: [
+      { id: 0, content: { kind: "geometry" } },
+      { id: 2 ** 52, content: { kind: "text" } },
+    ],
+    tracks: [],
+  };
+}
+
+test("retained scene results expose canonical SceneSpec beside the compatibility sidecar", () => {
+  const document = { version: 1, objects: [{ id: 0 }], tracks: [] };
+  const retained = retainedDocument();
+  const sceneSpec = canonicalSceneSpec();
+  const parsed = parseAuthoringResult(
+    JSON.stringify({
+      kind: "scene_document",
+      document,
+      retained_document: retained,
+      scene_spec: sceneSpec,
+      duration: 1.5,
+      identities: { objects: [{ id: 0, key: "@object:0" }], tracks: [] },
+      callbacks: null,
+    }),
+  );
+
+  assert.deepEqual(parsed.sceneSpec, sceneSpec);
+  assert.deepEqual(parsed.retainedDocument, retained);
+  assert.deepEqual(parsed.sceneSpec.objects.map(({ id }) => id), [0, 2 ** 52]);
+});
+
+test("geometry-only scene results remain unchanged while the SceneSpec migration is retained-only", () => {
+  const document = { version: 1, objects: [], tracks: [] };
+  const parsed = parseAuthoringResult(
+    JSON.stringify({
+      kind: "scene_document",
+      document,
+      retained_document: {
+        channel: "noon.authoring.retained",
+        protocol_version: 2,
+        objects: [],
+      },
+      duration: 0,
+      identities: { objects: [], tracks: [] },
+      callbacks: null,
+    }),
+  );
+
+  assert.equal("sceneSpec" in parsed, false);
+  assert.equal(parsed.retainedDocument.objects.length, 0);
+});
+
+test("canonical SceneSpec result validation rejects duplicate identity and invalid camera references", () => {
+  const duplicate = canonicalSceneSpec();
+  duplicate.objects[1].id = 0;
+  assert.throws(() => validateSceneSpec(duplicate), /duplicate object IDs/);
+
+  const invalidCamera = canonicalSceneSpec();
+  invalidCamera.camera_object = 99;
+  assert.throws(() => validateSceneSpec(invalidCamera), /invalid camera object/);
+
+  assert.throws(
+    () => validateSceneSpec({ version: 99, objects: [], tracks: [] }),
+    /Unsupported canonical SceneSpec version/,
+  );
+});
+
+test("Python worker canonicalizes retained output through the Rust WASM bridge", async () => {
+  const source = await readFile(new URL("./python-worker.source.js", import.meta.url), "utf8");
+  assert.match(source, /canonicalRetainedSceneSpecJson/);
+  assert.match(source, /result\.scene_spec\s*=\s*JSON\.parse/);
+  assert.match(
+    source,
+    /canonicalRetainedSceneSpecJson\(JSON\.stringify\(result\.document\), retainedDocumentJson\)/,
+  );
+});

--- a/web/python-worker.source.js
+++ b/web/python-worker.source.js
@@ -2,6 +2,7 @@ import initNoonWeb, {
   RetainedNativeTextAuthoringHandle,
   RetainedTypstAuthoringHandle,
   WasmAuthoringStore,
+  canonicalRetainedSceneSpecJson,
   manimAnnularSectorSnapshotJson,
   manimAnnulusSnapshotJson,
   manimDotSnapshotJson,
@@ -381,9 +382,15 @@ json.dumps(
     );
     const result = JSON.parse(resultJson);
     if (result.retained_document !== null) {
-      validateRetainedAuthoringDocumentJson(JSON.stringify(result.retained_document));
+      const retainedDocumentJson = JSON.stringify(result.retained_document);
+      validateRetainedAuthoringDocumentJson(retainedDocumentJson);
+      if (result.retained_document.objects.length > 0) {
+        result.scene_spec = JSON.parse(
+          canonicalRetainedSceneSpecJson(JSON.stringify(result.document), retainedDocumentJson),
+        );
+      }
     }
-    return resultJson;
+    return JSON.stringify(result);
   } finally {
     globals.destroy();
   }


### PR DESCRIPTION
## Summary

- make the Python authoring worker normalize retained scenes through the Rust/WASM `canonicalRetainedSceneSpecJson` bridge immediately after validating the compatibility sidecar
- expose that full mixed scene from `PythonAuthoringClient` as `sceneSpec`
- keep `retainedDocument` temporarily as a compatibility field until retained execution startup is switched to consume `SceneSpec` directly
- leave geometry-only authoring results unchanged
- add a web ratchet covering SceneSpec result parsing/validation and the worker’s Rust-owned normalization call

## Architecture

```text
Python compatibility internals
  legacy document + retained sidecar
                |
                v
        Python authoring worker
                |
    Rust/WASM canonical normalizer
                |
                v
          sceneSpec (primary)
          retainedDocument
        (temporary compatibility)
```

This avoids reconstructing the mixed scene in JavaScript. The next #367 slice can switch retained execution startup to `sceneSpec`, after which the compatibility sidecar can be removed from the normal browser result.

Tracks #367. Follows #777.