### PR TITLE
Use retained family state in execution canvas

### DIFF
--- a/crates/noon-web/src/retained_execution_canvas.rs
+++ b/crates/noon-web/src/retained_execution_canvas.rs
@@ -196,10 +196,6 @@ mod wasm {
                     wgpu::CurrentSurfaceTexture::Validation => return Ok(false),
                 };
 
-            let frame = self
-                .mirror
-                .frame()
-                .ok_or_else(|| js_message("retained execution renderer has no frame snapshot"))?;
             let resources = self.mirror.resources();
             let camera = self.renderer.camera();
             let metrics = TextDeviceMetrics::new(Vec2::new(
@@ -207,19 +203,47 @@ mod wasm {
                 self.config.height as f32 / camera.world_size.y,
             ))
             .map_err(js_error)?;
-            let prepared = self
-                .preparer
-                .prepare_with_changes(
-                    &self.device,
-                    &self.queue,
-                    frame,
-                    &self.pending_changes,
-                    resources.texts(),
-                    resources.fonts(),
-                    resources.geometries(),
-                    metrics,
-                )
-                .map_err(js_error)?;
+            let family_plan = self.mirror.family_plan().map_err(js_error)?;
+            let prepared = if let Some(plan) = family_plan {
+                let family_frame = self
+                    .mirror
+                    .family_frame()
+                    .map_err(js_error)?
+                    .ok_or_else(|| {
+                        js_message(
+                            "retained family execution has a plan without an evaluated family frame",
+                        )
+                    })?;
+                self.preparer
+                    .prepare_family_with_changes(
+                        &self.device,
+                        &self.queue,
+                        &family_frame,
+                        plan,
+                        &self.pending_changes,
+                        resources.texts(),
+                        resources.fonts(),
+                        resources.geometries(),
+                        metrics,
+                    )
+                    .map_err(js_error)?
+            } else {
+                let frame = self.mirror.frame().ok_or_else(|| {
+                    js_message("retained execution renderer has no frame snapshot")
+                })?;
+                self.preparer
+                    .prepare_with_changes(
+                        &self.device,
+                        &self.queue,
+                        frame,
+                        &self.pending_changes,
+                        resources.texts(),
+                        resources.fonts(),
+                        resources.geometries(),
+                        metrics,
+                    )
+                    .map_err(js_error)?
+            };
             self.last_geometry_cache_misses = prepared.geometry_stats().geometry_cache_misses;
             self.last_outline_cache_misses = prepared.stats.outline_cache_misses;
             let upload = self.renderer.upload_retained(


### PR DESCRIPTION
Part of #741.

Wires the validated retained-family execution mirror into the WASM execution canvas without adding scheduler or semantic traversal logic to the renderer.

### What lands
- ordinary retained execution keeps the existing `prepare_with_changes` path unchanged;
- when the mirror has one installed family plan, the canvas obtains the matching evaluated `RetainedFamilyFrame` and calls #769's `prepare_family_with_changes`;
- the same pending `FrameChanges`, installed Text/font/geometry arenas, and device metrics are reused for both paths;
- an impossible plan-without-family-frame state fails explicitly rather than silently falling back to object-level reveal semantics;
- no family timing, member indexing, glyph identity, or resource reconstruction is performed in the canvas.

This is intentionally a one-file worker/render binding slice, now directly based on the merged render mirror. The next work is the producer owner that evaluates one target-independent `FamilyAnimationSpec` and projects the same state onto the prepared plan leaves, followed by the mixed Text+geometry direct-seek browser fixture.