### PR TITLE
Restore PR WASM cache from trusted master archives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,12 +59,14 @@ jobs:
   web-build:
     name: Web package
     runs-on: ubuntu-latest
-    needs: rust
     env:
       CARGO_INCREMENTAL: "0"
       CARGO_PROFILE_DEV_DEBUG: "0"
       RUSTC_WRAPPER: sccache
-      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_GHA_ENABLED: "false"
+      SCCACHE_DIR: /home/runner/.cache/noon-sccache-wasm
+      SCCACHE_CACHE_SIZE: "1G"
+      SCCACHE_LOCAL_RW_MODE: "READ_ONLY"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -83,6 +85,14 @@ jobs:
           key: ${{ runner.os }}-cargo-sources-${{ hashFiles('Cargo.toml', 'crates/**/Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-sources-
+
+      - name: Restore WASM compiler cache
+        uses: actions/cache/restore@v4
+        with:
+          path: /home/runner/.cache/noon-sccache-wasm
+          key: ${{ runner.os }}-sccache-wasm-v1-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-sccache-wasm-v1-
 
       - name: Use sccache
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11

--- a/.github/workflows/compiler-cache-seed.yml
+++ b/.github/workflows/compiler-cache-seed.yml
@@ -1,0 +1,80 @@
+name: Compiler Cache Seed
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "Cargo.toml"
+      - "crates/**"
+      - "scripts/build-web-demo.sh"
+      - ".github/workflows/compiler-cache-seed.yml"
+      - ".github/workflows/pr-fast.yml"
+      - ".github/workflows/ci.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: compiler-cache-seed-master
+  cancel-in-progress: false
+
+jobs:
+  wasm:
+    name: Seed dev WASM compiler cache
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    env:
+      CARGO_INCREMENTAL: "0"
+      CARGO_PROFILE_DEV_DEBUG: "0"
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "false"
+      SCCACHE_DIR: /home/runner/.cache/noon-sccache-wasm
+      SCCACHE_CACHE_SIZE: "1G"
+      SCCACHE_LOCAL_RW_MODE: "READ_WRITE"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use stable Rust and WASM target
+        run: |
+          rustup default stable
+          rustup target add wasm32-unknown-unknown
+
+      - name: Cache Cargo sources
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-sources-${{ hashFiles('Cargo.toml', 'crates/**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-sources-
+
+      - name: Restore and publish WASM compiler cache
+        uses: actions/cache@v4
+        with:
+          path: /home/runner/.cache/noon-sccache-wasm
+          key: ${{ runner.os }}-sccache-wasm-v1-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-sccache-wasm-v1-
+
+      - name: Use sccache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+        with:
+          version: v0.16.0
+
+      - name: Install pinned wasm-pack
+        uses: taiki-e/install-action@13608cbb45b01feb47ef444ab1a42dc41ad56f1a # v2.79.11
+        with:
+          tool: wasm-pack@0.15.0
+          fallback: none
+
+      - name: Seed browser compile artifacts
+        env:
+          NOON_SKIP_WEB_PREFLIGHT: "1"
+          NOON_SKIP_PLAYGROUND_TEST: "1"
+          NOON_WASM_PROFILE: "dev"
+          NOON_WASM_SKIP_OPT: "1"
+        run: bash scripts/build-web-demo.sh

--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -96,6 +96,11 @@ jobs:
   web-fast:
     name: Browser fast checks
     runs-on: ubuntu-latest
+    env:
+      SCCACHE_GHA_ENABLED: "false"
+      SCCACHE_DIR: /home/runner/.cache/noon-sccache-wasm
+      SCCACHE_CACHE_SIZE: "1G"
+      SCCACHE_LOCAL_RW_MODE: "READ_ONLY"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -114,6 +119,14 @@ jobs:
           key: ${{ runner.os }}-cargo-sources-${{ hashFiles('Cargo.toml', 'crates/**/Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-sources-
+
+      - name: Restore trusted WASM compiler cache
+        uses: actions/cache/restore@v4
+        with:
+          path: /home/runner/.cache/noon-sccache-wasm
+          key: ${{ runner.os }}-sccache-wasm-v1-${{ github.event.pull_request.base.sha }}
+          restore-keys: |
+            ${{ runner.os }}-sccache-wasm-v1-
 
       - name: Use sccache
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -19,13 +19,25 @@ The four real lane results are the PR validation signals; there is deliberately 
 
 Deterministic replay keeps the full workload in the PR gate: the same playground corpus, all authored objects including the 1,000-object morph stress scene, every direct-seek target and rewind check, and 32 incremental forward samples per target. The browser harness calls one Rust verifier per scene. That verifier decodes and compiles the scene once, keeps independent direct/forward/rewind runtime instances resident, and compares renderer-observable `FrameState` values in Rust. This preserves the exact determinism contract while avoiding repeated scene compilation and large normalized-frame JSON serialization across the WASM boundary solely for equality checks.
 
-Cargo source downloads and Rust compilations use the shared cache/sccache setup. PR jobs consume the GitHub Actions sccache backend in `READ_ONLY` mode: review iterations should benefit from trusted default-branch compiler artifacts without creating hundreds of branch-local cache entries or competing for the repository upload-rate budget. The master CI workflow owns compiler-cache population. Its native writer uses the same symbol-free `dev`/`test` profile overrides as the PR Rust lanes, and its browser writer uses the same symbol-free dev WASM profile as the PR browser lane. The two master writers are serialized so they do not compete for cache uploads. Debug assertions and overflow checks remain those of the ordinary profiles; only debugger symbols are omitted. Production release behavior and optimized browser artifacts remain exercised separately by platform/release validation.
+## Compiler caches
+
+Native and WASM compilation use different cache transports because measurements showed different behavior.
+
+The Rust lint/test lanes continue to consume the GitHub Actions sccache backend in `READ_ONLY` mode. Native PR measurements already show high hit rates and remain under the two-minute budget, so adding large archive restores to both Rust jobs would increase bandwidth without solving the current critical path. Main CI remains the trusted native GHA-cache writer.
+
+The browser lane uses a local sccache directory restored through `actions/cache/restore`. `.github/workflows/compiler-cache-seed.yml` is the only workflow allowed to publish that WASM archive. Relevant pushes to `master` restore the latest trusted archive, compile the same symbol-free dev WASM profile used by PRs, and save an immutable archive keyed by the master SHA. PRs request the archive for their exact base SHA and may fall back to the latest default-branch seed. Because PRs use the restore-only action and `SCCACHE_LOCAL_RW_MODE=READ_ONLY`, they cannot publish branch-local compiler archives.
+
+This archive boundary is intentional. The per-object GHA backend successfully reused native objects, but an exact-master WASM build could see 315/315 hits while a source-neutral PR saw 0/315. Packaging the local sccache directory into one default-branch cache entry gives the WASM path an explicit master-to-PR restore contract and avoids hundreds of per-object cache uploads.
+
+The WASM archive is capped at 1 GiB. Seed runs are non-cancelling so rapid master merges cannot abort the only archive writer in progress; newer relevant master pushes may queue another seed. Main CI and specialized validators are consumers rather than WASM archive owners.
 
 ## Main CI workflow
 
 `.github/workflows/ci.yml` runs on pushes to `master` and manual dispatch. It is the full Linux integration workflow rather than the pull-request inner loop.
 
-Its Rust lane runs formatting, full workspace Clippy, and the complete workspace test set while seeding the native compiler cache used by PRs. Its browser build follows that native writer, produces the same dev-profile integration package used by the PR fast path, seeds the WASM compiler cache, and uploads one reusable package artifact that fans out to authoring, reactive/editor, WebGPU, WebGL, and backend-parity jobs.
+Its Rust lane runs formatting, full workspace Clippy, and the complete workspace test set while maintaining the native compiler cache. Its browser build runs independently, restores the latest trusted WASM archive read-only, produces the same dev-profile integration package used by the PR fast path, and uploads one reusable package artifact that fans out to authoring, reactive/editor, WebGPU, WebGL, and backend-parity jobs.
+
+The browser build no longer waits for the Rust lane merely to serialize compiler-cache writes: native still uses the GHA backend, while WASM uses a separate archive owned by the seed workflow. This removes an unnecessary post-merge dependency and prevents the browser cache from being starved by cancellation before it starts.
 
 This workflow is intentionally broader than the PR fast gate. A failure after merge is still a correctness failure to fix immediately, but expensive validation and cache population do not delay every review iteration.
 

--- a/web/ci-workflow-topology.test.mjs
+++ b/web/ci-workflow-topology.test.mjs
@@ -11,6 +11,7 @@ assert.ok(workflowFiles.length > 0, "CI workflow inventory must not be empty");
 const exactFamilies = new Map([
   ["pr-fast.yml", "pr-fast"],
   ["ci.yml", "main"],
+  ["compiler-cache-seed.yml", "cache-seed"],
   ["test-coverage.yml", "coverage"],
   ["platform-release.yml", "platform-release"],
   ["pages.yml", "deployment"],
@@ -43,6 +44,7 @@ assert.deepEqual(
 const requiredFamilies = new Set([
   "pr-fast",
   "main",
+  "cache-seed",
   "coverage",
   "platform-release",
   "manim",
@@ -57,6 +59,7 @@ const ciDocs = await readFile(new URL("../docs/ci.md", import.meta.url), "utf8")
 for (const [needle, purpose] of [
   [".github/workflows/pr-fast.yml", "pull-request fast gate"],
   [".github/workflows/ci.yml", "main CI"],
+  [".github/workflows/compiler-cache-seed.yml", "compiler-cache seed"],
   [".github/workflows/platform-release.yml", "platform/release validation"],
   [".github/workflows/test-coverage.yml", "test observability"],
   ["Manim compatibility workflows", "Manim validation family"],


### PR DESCRIPTION
## Summary
- move the PR-critical WASM compiler cache off sccache's per-object GHA backend and onto an explicit local sccache directory restored with `actions/cache/restore`
- add `Compiler Cache Seed` as the sole writer of immutable master-scoped WASM cache archives
- keep PR browser jobs strictly read-only; they request their exact base-SHA seed and fall back to the latest default-branch archive
- let main CI's browser package build run independently from native Rust again, since the two lanes no longer compete for the same writable backend
- keep native lint/test caching unchanged because measured PR hit rates are already 87–99% and under budget
- document and topology-ratchet the new cache ownership contract

## Why
The latest source-neutral probe isolated the remaining browser bottleneck:

- exact-master dev-WASM build: **315/315 sccache hits**, Rust compile **34.99s**, wasm-pack package build **53.88s**
- source-neutral PR on the same compiler/profile family: **0/315 sccache hits**

So the compiler objects themselves are reusable, but the PR merge ref cannot reliably consume the master's per-object GHA namespace. Retrying or adding more writers cannot fix that visibility contract.

This slice packages the local sccache directory into one default-branch cache archive. GitHub's cache restore semantics explicitly allow PRs to consume caches from the default branch, while `actions/cache/restore` prevents PRs from publishing branch-local archives. It also reduces a cold WASM seed from hundreds of cache-entry uploads to one archive publication.

## Cache policy
- Native: existing GHA sccache backend; PRs read-only, main CI writes.
- WASM: local sccache disk cache, 1 GiB cap.
- `.github/workflows/compiler-cache-seed.yml`: only WASM archive writer.
- Seed runs do not cancel an in-progress writer.
- PR Fast Gate and main CI browser jobs only restore/read the archive.

## Validation plan
The first PR run is expected to be cold because no default-branch archive exists yet. It must still pass correctness. After merge, the first master seed will publish the archive; a source-neutral follow-up probe will measure actual default-branch → PR restoration and browser-lane wall time.

Tracks #731. Supersedes the WASM-writer motivation in #780.