### PR TITLE
Expose shared Axes area and Riemann helpers to Python

### DIFF
--- a/crates/noon-web/src/manim_axes_query_bridge.rs
+++ b/crates/noon-web/src/manim_axes_query_bridge.rs
@@ -39,6 +39,14 @@ struct AreaQueryRequest {
     x_range: Option<[f64; 2]>,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct AreaFinishInput<'a> {
+    graph_snapshot_json: &'a str,
+    bounded_graph_snapshot_json: &'a str,
+    graph_endpoint_y_values_json: &'a str,
+    bounded_graph_endpoint_y_values_json: &'a str,
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 struct RiemannSampleValues {
     graph: Vec<f64>,
@@ -213,28 +221,26 @@ impl AxesQueryPlan {
     }
 
     /// Finish one ManimCE v0.21 `Axes.get_area` retained polygon snapshot.
-    pub fn area_snapshot_json(
+    fn area_snapshot_json(
         &self,
         request_json: &str,
-        graph_snapshot_json: &str,
-        bounded_graph_snapshot_json: &str,
-        graph_endpoint_y_values_json: &str,
-        bounded_graph_endpoint_y_values_json: &str,
+        finish: AreaFinishInput<'_>,
         x_axis_snapshot_json: &str,
         y_axis_snapshot_json: &str,
     ) -> Result<String, ManimAxesQueryError> {
         let request = parse_area_request(request_json)?;
-        let graph = parse_graph_snapshot(graph_snapshot_json)?;
-        let bounded_graph = parse_optional_graph_snapshot(bounded_graph_snapshot_json)?;
+        let graph = parse_graph_snapshot(finish.graph_snapshot_json)?;
+        let bounded_graph = parse_optional_graph_snapshot(finish.bounded_graph_snapshot_json)?;
         validate_bounded_presence(
             request.bounded_graph_range.is_some(),
             bounded_graph.is_some(),
             "area",
         )?;
-        let graph_endpoint_y_values: [f64; 2] = serde_json::from_str(graph_endpoint_y_values_json)
-            .map_err(|error| ManimAxesQueryError::InvalidAreaValues(error.to_string()))?;
+        let graph_endpoint_y_values: [f64; 2] =
+            serde_json::from_str(finish.graph_endpoint_y_values_json)
+                .map_err(|error| ManimAxesQueryError::InvalidAreaValues(error.to_string()))?;
         let bounded_graph_endpoint_y_values: Option<[f64; 2]> =
-            parse_optional_json(bounded_graph_endpoint_y_values_json)
+            parse_optional_json(finish.bounded_graph_endpoint_y_values_json)
                 .map_err(|error| ManimAxesQueryError::InvalidAreaValues(error.to_string()))?;
         validate_bounded_presence(
             bounded_graph.is_some(),
@@ -508,7 +514,7 @@ impl From<AreaAuthoringError> for ManimAxesQueryError {
 mod wasm {
     use wasm_bindgen::prelude::*;
 
-    use super::AxesQueryPlan;
+    use super::{AreaFinishInput, AxesQueryPlan};
 
     fn js_error(error: impl std::fmt::Display) -> JsValue {
         JsValue::from_str(&error.to_string())
@@ -652,10 +658,12 @@ mod wasm {
             self.0
                 .area_snapshot_json(
                     request_json,
-                    graph_snapshot_json,
-                    bounded_graph_snapshot_json,
-                    graph_endpoint_y_values_json,
-                    bounded_graph_endpoint_y_values_json,
+                    AreaFinishInput {
+                        graph_snapshot_json,
+                        bounded_graph_snapshot_json,
+                        graph_endpoint_y_values_json,
+                        bounded_graph_endpoint_y_values_json,
+                    },
                     x_axis_snapshot_json,
                     y_axis_snapshot_json,
                 )
@@ -848,7 +856,17 @@ mod tests {
 
         let snapshot: ObjectSnapshot = serde_json::from_str(
             &plan
-                .area_snapshot_json(request, &graph, "", "[0.5,0.5]", "", &x_axis, &y_axis)
+                .area_snapshot_json(
+                    request,
+                    AreaFinishInput {
+                        graph_snapshot_json: &graph,
+                        bounded_graph_snapshot_json: "",
+                        graph_endpoint_y_values_json: "[0.5,0.5]",
+                        bounded_graph_endpoint_y_values_json: "",
+                    },
+                    &x_axis,
+                    &y_axis,
+                )
                 .unwrap(),
         )
         .unwrap();

--- a/crates/noon-web/src/manim_axes_query_bridge.rs
+++ b/crates/noon-web/src/manim_axes_query_bridge.rs
@@ -39,6 +39,7 @@ struct AreaQueryRequest {
     x_range: Option<[f64; 2]>,
 }
 
+#[cfg(any(target_arch = "wasm32", test))]
 #[derive(Clone, Copy, Debug, PartialEq)]
 struct AreaFinishInput<'a> {
     graph_snapshot_json: &'a str,
@@ -221,6 +222,7 @@ impl AxesQueryPlan {
     }
 
     /// Finish one ManimCE v0.21 `Axes.get_area` retained polygon snapshot.
+    #[cfg(any(target_arch = "wasm32", test))]
     fn area_snapshot_json(
         &self,
         request_json: &str,

--- a/crates/noon-web/src/manim_axes_query_bridge.rs
+++ b/crates/noon-web/src/manim_axes_query_bridge.rs
@@ -1,12 +1,11 @@
 use noon::{
-    transformed_axes_line_graph_vector_path, Axes2DState, CoordinateSystemError, IntoSnapshot,
-    LineGraphAuthoringError, NumberRange, Path, TransformedAxes2DState,
+    transformed_axes_line_graph_vector_path, transformed_graph_point_for_x, AreaAuthoringError,
+    AreaSamplePlan, Axes2DState, CoordinateSystemError, GraphParameterRange, GraphQueryError,
+    IntoSnapshot, LineGraphAuthoringError, NumberRange, Path, RiemannAuthoringError,
+    RiemannSamplePlan, RiemannSampleType, TransformedAxes2DState,
 };
 use noon_core::{GeometryRef, ObjectSnapshot, Vec2};
-use noon_geometry::{point_from_geometry_proportion, GeometryProportionError};
-use serde::Deserialize;
-
-const MANIM_GRAPH_X_SEARCH_TOLERANCE: f64 = 1.0e-4;
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
@@ -15,6 +14,42 @@ struct AxesQueryRequest {
     y_range: [f64; 3],
     x_length: f32,
     y_length: f32,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+struct RiemannQueryRequest {
+    graph_range: [f64; 2],
+    #[serde(default)]
+    bounded_graph_range: Option<[f64; 2]>,
+    #[serde(default)]
+    x_range: Option<[f64; 2]>,
+    dx: f64,
+    input_sample_type: String,
+    width_scale_factor: f64,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+struct AreaQueryRequest {
+    graph_range: [f64; 2],
+    #[serde(default)]
+    bounded_graph_range: Option<[f64; 2]>,
+    #[serde(default)]
+    x_range: Option<[f64; 2]>,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq)]
+struct RiemannSampleValues {
+    graph: Vec<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    bounded_graph: Option<Vec<f64>>,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq)]
+struct RiemannRectangleResult {
+    snapshot: ObjectSnapshot,
+    negative_signed_area: bool,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -78,9 +113,8 @@ impl AxesQueryPlan {
     /// ManimCE v0.21 generic `input_to_graph_point` fallback for retained path-like graphs.
     ///
     /// The authored-function fast path remains frontend-visible because it calls the user's
-    /// callback directly. For generic VMobjects, however, path proportion, current graph
-    /// transform, current Axes transforms, and Manim's binary-search semantics all remain
-    /// inside Rust so the host does not repeatedly cross the WASM boundary.
+    /// callback directly. Generic path proportion, graph/Axes transforms, and Manim's binary
+    /// search are delegated to the reusable shared `noon` semantic owner.
     pub fn graph_point_for_x_json(
         &self,
         x: f64,
@@ -88,26 +122,136 @@ impl AxesQueryPlan {
         x_axis_snapshot_json: &str,
         y_axis_snapshot_json: &str,
     ) -> Result<String, ManimAxesQueryError> {
-        if !x.is_finite() {
-            return Err(ManimAxesQueryError::NonFiniteGraphX(x));
-        }
-        let graph: ObjectSnapshot = serde_json::from_str(graph_snapshot_json)
-            .map_err(|error| ManimAxesQueryError::InvalidGraphSnapshot(error.to_string()))?;
+        let graph = parse_graph_snapshot(graph_snapshot_json)?;
         let transformed = self.transformed_axes(x_axis_snapshot_json, y_axis_snapshot_json)?;
-        let alpha = binary_search_graph_x(&transformed, &graph, x)?;
-        if let Some(alpha) = alpha {
-            return serialize_pair(graph_point_from_proportion(&graph, alpha)?);
+        serialize_pair(transformed_graph_point_for_x(transformed, &graph, x)?)
+    }
+
+    /// Phase one of ManimCE v0.21 `Axes.get_riemann_rectangles`.
+    ///
+    /// Rust resolves the half-open partition and returns only the x values at which the
+    /// Python authored callbacks must be evaluated. No geometry or coordinate loop is
+    /// owned by Python.
+    pub fn riemann_sample_values_json(
+        &self,
+        request_json: &str,
+        x_axis_snapshot_json: &str,
+        y_axis_snapshot_json: &str,
+    ) -> Result<String, ManimAxesQueryError> {
+        let request = parse_riemann_request(request_json)?;
+        let transformed = self.transformed_axes(x_axis_snapshot_json, y_axis_snapshot_json)?;
+        let plan = riemann_plan(transformed, &request)?;
+        serde_json::to_string(&RiemannSampleValues {
+            graph: plan.graph_sample_x_values(),
+            bounded_graph: request
+                .bounded_graph_range
+                .map(|_| plan.baseline_x_values()),
+        })
+        .map_err(|error| ManimAxesQueryError::Serialization(error.to_string()))
+    }
+
+    /// Phase two of ManimCE v0.21 `Axes.get_riemann_rectangles`.
+    ///
+    /// The frontend returns authored callback scalar values. Rust rebuilds the exact
+    /// deterministic plan, validates cardinality, and emits ordinary retained rectangles
+    /// plus signed-area metadata used only for Manim-facing color adaptation.
+    pub fn riemann_rectangles_json(
+        &self,
+        request_json: &str,
+        graph_y_values_json: &str,
+        bounded_graph_y_values_json: &str,
+        x_axis_snapshot_json: &str,
+        y_axis_snapshot_json: &str,
+    ) -> Result<String, ManimAxesQueryError> {
+        let request = parse_riemann_request(request_json)?;
+        let graph_y_values: Vec<f64> = serde_json::from_str(graph_y_values_json)
+            .map_err(|error| ManimAxesQueryError::InvalidRiemannValues(error.to_string()))?;
+        let bounded_graph_y_values: Option<Vec<f64>> =
+            parse_optional_json(bounded_graph_y_values_json).map_err(|error| {
+                ManimAxesQueryError::InvalidRiemannValues(error.to_string())
+            })?;
+        if request.bounded_graph_range.is_some() != bounded_graph_y_values.is_some() {
+            return Err(ManimAxesQueryError::InvalidRiemannRequest(
+                "bounded graph range/value presence must match".to_owned(),
+            ));
         }
 
-        let start = graph_point_from_proportion(&graph, 0.0)?;
-        let end = graph_point_from_proportion(&graph, 1.0)?;
-        let start_x = transformed.point_to_coords(start)?.0;
-        let end_x = transformed.point_to_coords(end)?.0;
-        Err(ManimAxesQueryError::GraphXOutOfRange {
-            x,
-            start: start_x,
-            end: end_x,
-        })
+        let transformed = self.transformed_axes(x_axis_snapshot_json, y_axis_snapshot_json)?;
+        let plan = riemann_plan(transformed, &request)?;
+        let rectangles = plan.finish(&graph_y_values, bounded_graph_y_values.as_deref())?;
+        let result: Vec<_> = rectangles
+            .into_iter()
+            .map(|rectangle| RiemannRectangleResult {
+                negative_signed_area: rectangle.is_negative_signed_area(),
+                snapshot: rectangle.into_snapshot(),
+            })
+            .collect();
+        serde_json::to_string(&result)
+            .map_err(|error| ManimAxesQueryError::Serialization(error.to_string()))
+    }
+
+    /// Resolve the clipped endpoint x values for ManimCE v0.21 `Axes.get_area`.
+    pub fn area_endpoint_x_values_json(
+        &self,
+        request_json: &str,
+        graph_snapshot_json: &str,
+        bounded_graph_snapshot_json: &str,
+        x_axis_snapshot_json: &str,
+        y_axis_snapshot_json: &str,
+    ) -> Result<String, ManimAxesQueryError> {
+        let request = parse_area_request(request_json)?;
+        let graph = parse_graph_snapshot(graph_snapshot_json)?;
+        let bounded_graph = parse_optional_graph_snapshot(bounded_graph_snapshot_json)?;
+        validate_bounded_presence(
+            request.bounded_graph_range.is_some(),
+            bounded_graph.is_some(),
+            "area",
+        )?;
+        let transformed = self.transformed_axes(x_axis_snapshot_json, y_axis_snapshot_json)?;
+        let plan = area_plan(transformed, &request, &graph, bounded_graph.as_ref())?;
+        serde_json::to_string(&plan.graph_endpoint_x_values())
+            .map_err(|error| ManimAxesQueryError::Serialization(error.to_string()))
+    }
+
+    /// Finish one ManimCE v0.21 `Axes.get_area` retained polygon snapshot.
+    pub fn area_snapshot_json(
+        &self,
+        request_json: &str,
+        graph_snapshot_json: &str,
+        bounded_graph_snapshot_json: &str,
+        graph_endpoint_y_values_json: &str,
+        bounded_graph_endpoint_y_values_json: &str,
+        x_axis_snapshot_json: &str,
+        y_axis_snapshot_json: &str,
+    ) -> Result<String, ManimAxesQueryError> {
+        let request = parse_area_request(request_json)?;
+        let graph = parse_graph_snapshot(graph_snapshot_json)?;
+        let bounded_graph = parse_optional_graph_snapshot(bounded_graph_snapshot_json)?;
+        validate_bounded_presence(
+            request.bounded_graph_range.is_some(),
+            bounded_graph.is_some(),
+            "area",
+        )?;
+        let graph_endpoint_y_values: [f64; 2] =
+            serde_json::from_str(graph_endpoint_y_values_json)
+                .map_err(|error| ManimAxesQueryError::InvalidAreaValues(error.to_string()))?;
+        let bounded_graph_endpoint_y_values: Option<[f64; 2]> =
+            parse_optional_json(bounded_graph_endpoint_y_values_json)
+                .map_err(|error| ManimAxesQueryError::InvalidAreaValues(error.to_string()))?;
+        validate_bounded_presence(
+            bounded_graph.is_some(),
+            bounded_graph_endpoint_y_values.is_some(),
+            "area endpoint values",
+        )?;
+
+        let transformed = self.transformed_axes(x_axis_snapshot_json, y_axis_snapshot_json)?;
+        let plan = area_plan(transformed, &request, &graph, bounded_graph.as_ref())?;
+        let snapshot = plan.finish(
+            graph_endpoint_y_values,
+            bounded_graph_endpoint_y_values,
+        )?;
+        serde_json::to_string(&snapshot)
+            .map_err(|error| ManimAxesQueryError::Serialization(error.to_string()))
     }
 
     fn transformed_axes(
@@ -125,58 +269,123 @@ impl AxesQueryPlan {
     }
 }
 
-fn graph_point_from_proportion(
-    graph: &ObjectSnapshot,
-    alpha: f64,
-) -> Result<Vec2, ManimAxesQueryError> {
-    let local = point_from_geometry_proportion(&graph.geometry, alpha as f32)?;
-    Ok(graph.transform.transform_point(local))
-}
-
-fn graph_x_at_proportion(
-    axes: &TransformedAxes2DState,
-    graph: &ObjectSnapshot,
-    alpha: f64,
-) -> Result<f64, ManimAxesQueryError> {
-    Ok(axes
-        .point_to_coords(graph_point_from_proportion(graph, alpha)?)?
-        .0)
-}
-
-/// Exact control flow of ManimCE v0.21 `binary_search` for graph-x lookup.
-fn binary_search_graph_x(
-    axes: &TransformedAxes2DState,
-    graph: &ObjectSnapshot,
-    target: f64,
-) -> Result<Option<f64>, ManimAxesQueryError> {
-    let mut left: f64 = 0.0;
-    let mut right: f64 = 1.0;
-    let mut middle: f64 = 0.5;
-    while (right - left).abs() > MANIM_GRAPH_X_SEARCH_TOLERANCE {
-        middle = (left + right) * 0.5;
-        let left_x = graph_x_at_proportion(axes, graph, left)?;
-        let middle_x = graph_x_at_proportion(axes, graph, middle)?;
-        let right_x = graph_x_at_proportion(axes, graph, right)?;
-        if left_x == target {
-            return Ok(Some(left));
-        }
-        if right_x == target {
-            return Ok(Some(right));
-        }
-
-        if left_x <= target && target <= right_x {
-            if middle_x > target {
-                right = middle;
-            } else {
-                left = middle;
-            }
-        } else if left_x > target && target > right_x {
-            std::mem::swap(&mut left, &mut right);
-        } else {
-            return Ok(None);
-        }
+fn parse_riemann_request(request_json: &str) -> Result<RiemannQueryRequest, ManimAxesQueryError> {
+    let request: RiemannQueryRequest = serde_json::from_str(request_json)
+        .map_err(|error| ManimAxesQueryError::InvalidRiemannRequest(error.to_string()))?;
+    validate_range(request.graph_range, "graph")?;
+    if let Some(range) = request.bounded_graph_range {
+        validate_range(range, "bounded graph")?;
     }
-    Ok(Some(middle))
+    if let Some(range) = request.x_range {
+        validate_range(range, "x_range")?;
+    }
+    Ok(request)
+}
+
+fn parse_area_request(request_json: &str) -> Result<AreaQueryRequest, ManimAxesQueryError> {
+    let request: AreaQueryRequest = serde_json::from_str(request_json)
+        .map_err(|error| ManimAxesQueryError::InvalidAreaRequest(error.to_string()))?;
+    validate_range(request.graph_range, "graph")?;
+    if let Some(range) = request.bounded_graph_range {
+        validate_range(range, "bounded graph")?;
+    }
+    if let Some(range) = request.x_range {
+        validate_range(range, "x_range")?;
+    }
+    Ok(request)
+}
+
+fn validate_range(range: [f64; 2], name: &str) -> Result<(), ManimAxesQueryError> {
+    if range.into_iter().all(f64::is_finite) {
+        Ok(())
+    } else {
+        Err(ManimAxesQueryError::InvalidCalculusRange(name.to_owned()))
+    }
+}
+
+fn riemann_plan(
+    axes: TransformedAxes2DState,
+    request: &RiemannQueryRequest,
+) -> Result<RiemannSamplePlan, ManimAxesQueryError> {
+    let [x_min, x_max] = request.x_range.unwrap_or_else(|| {
+        request.bounded_graph_range.map_or(request.graph_range, |bounded| {
+            [
+                request.graph_range[0].max(bounded[0]),
+                request.graph_range[1].min(bounded[1]),
+            ]
+        })
+    });
+    Ok(RiemannSamplePlan::new(
+        axes,
+        x_min,
+        x_max,
+        request.dx,
+        RiemannSampleType::try_from(request.input_sample_type.as_str())?,
+        request.width_scale_factor,
+    )?)
+}
+
+fn area_plan(
+    axes: TransformedAxes2DState,
+    request: &AreaQueryRequest,
+    graph: &ObjectSnapshot,
+    bounded_graph: Option<&ObjectSnapshot>,
+) -> Result<AreaSamplePlan, ManimAxesQueryError> {
+    let graph_range = GraphParameterRange::new(request.graph_range[0], request.graph_range[1])?;
+    let bounded = bounded_graph.zip(request.bounded_graph_range).map(|(graph, range)| {
+        GraphParameterRange::new(range[0], range[1]).map(|range| (graph, range))
+    });
+    let bounded = match bounded {
+        Some(result) => Some(result?),
+        None => None,
+    };
+    Ok(AreaSamplePlan::new(
+        axes,
+        graph,
+        graph_range,
+        request.x_range,
+        bounded,
+    )?)
+}
+
+fn parse_graph_snapshot(snapshot_json: &str) -> Result<ObjectSnapshot, ManimAxesQueryError> {
+    serde_json::from_str(snapshot_json)
+        .map_err(|error| ManimAxesQueryError::InvalidGraphSnapshot(error.to_string()))
+}
+
+fn parse_optional_graph_snapshot(
+    snapshot_json: &str,
+) -> Result<Option<ObjectSnapshot>, ManimAxesQueryError> {
+    if snapshot_json.is_empty() {
+        Ok(None)
+    } else {
+        parse_graph_snapshot(snapshot_json).map(Some)
+    }
+}
+
+fn parse_optional_json<T>(value: &str) -> Result<Option<T>, serde_json::Error>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    if value.is_empty() {
+        Ok(None)
+    } else {
+        serde_json::from_str(value).map(Some)
+    }
+}
+
+fn validate_bounded_presence(
+    expected: bool,
+    actual: bool,
+    context: &str,
+) -> Result<(), ManimAxesQueryError> {
+    if expected == actual {
+        Ok(())
+    } else {
+        Err(ManimAxesQueryError::InvalidAreaRequest(format!(
+            "{context} bounded graph presence must match request"
+        )))
+    }
 }
 
 fn parse_axis_snapshot(
@@ -205,13 +414,21 @@ pub enum ManimAxesQueryError {
     InvalidRequest(String),
     InvalidLineGraphValues(String),
     InvalidGraphSnapshot(String),
-    InvalidAxisSnapshot { axis: &'static str, error: String },
+    InvalidRiemannRequest(String),
+    InvalidRiemannValues(String),
+    InvalidAreaRequest(String),
+    InvalidAreaValues(String),
+    InvalidCalculusRange(String),
+    InvalidAxisSnapshot {
+        axis: &'static str,
+        error: String,
+    },
     InvalidAxisGeometry(&'static str),
-    NonFiniteGraphX(f64),
-    GraphXOutOfRange { x: f64, start: f64, end: f64 },
     Coordinates(CoordinateSystemError),
     LineGraph(LineGraphAuthoringError),
-    GeometryProportion(GeometryProportionError),
+    GraphQuery(GraphQueryError),
+    Riemann(RiemannAuthoringError),
+    Area(AreaAuthoringError),
     Serialization(String),
 }
 
@@ -225,25 +442,33 @@ impl std::fmt::Display for ManimAxesQueryError {
             Self::InvalidGraphSnapshot(error) => {
                 write!(formatter, "invalid graph snapshot: {error}")
             }
+            Self::InvalidRiemannRequest(error) => {
+                write!(formatter, "invalid Axes Riemann request: {error}")
+            }
+            Self::InvalidRiemannValues(error) => {
+                write!(formatter, "invalid Axes Riemann values: {error}")
+            }
+            Self::InvalidAreaRequest(error) => {
+                write!(formatter, "invalid Axes area request: {error}")
+            }
+            Self::InvalidAreaValues(error) => {
+                write!(formatter, "invalid Axes area values: {error}")
+            }
+            Self::InvalidCalculusRange(name) => {
+                write!(formatter, "Axes calculus {name} range must be finite")
+            }
             Self::InvalidAxisSnapshot { axis, error } => {
                 write!(formatter, "invalid Axes {axis}-axis snapshot: {error}")
             }
-            Self::InvalidAxisGeometry(axis) => {
-                write!(
-                    formatter,
-                    "Axes {axis}-axis snapshot must contain line geometry"
-                )
-            }
-            Self::NonFiniteGraphX(x) => {
-                write!(formatter, "graph x lookup requires a finite value: {x}")
-            }
-            Self::GraphXOutOfRange { x, start, end } => write!(
+            Self::InvalidAxisGeometry(axis) => write!(
                 formatter,
-                "x={x} not located in the range of the graph ([{start}, {end}])"
+                "Axes {axis}-axis snapshot must contain line geometry"
             ),
             Self::Coordinates(error) => error.fmt(formatter),
             Self::LineGraph(error) => error.fmt(formatter),
-            Self::GeometryProportion(error) => error.fmt(formatter),
+            Self::GraphQuery(error) => error.fmt(formatter),
+            Self::Riemann(error) => error.fmt(formatter),
+            Self::Area(error) => error.fmt(formatter),
             Self::Serialization(error) => {
                 write!(formatter, "unable to serialize Axes query result: {error}")
             }
@@ -265,9 +490,21 @@ impl From<LineGraphAuthoringError> for ManimAxesQueryError {
     }
 }
 
-impl From<GeometryProportionError> for ManimAxesQueryError {
-    fn from(value: GeometryProportionError) -> Self {
-        Self::GeometryProportion(value)
+impl From<GraphQueryError> for ManimAxesQueryError {
+    fn from(value: GraphQueryError) -> Self {
+        Self::GraphQuery(value)
+    }
+}
+
+impl From<RiemannAuthoringError> for ManimAxesQueryError {
+    fn from(value: RiemannAuthoringError) -> Self {
+        Self::Riemann(value)
+    }
+}
+
+impl From<AreaAuthoringError> for ManimAxesQueryError {
+    fn from(value: AreaAuthoringError) -> Self {
+        Self::Area(value)
     }
 }
 
@@ -343,6 +580,86 @@ mod wasm {
                 .graph_point_for_x_json(
                     x,
                     graph_snapshot_json,
+                    x_axis_snapshot_json,
+                    y_axis_snapshot_json,
+                )
+                .map_err(js_error)
+        }
+
+        #[wasm_bindgen(js_name = riemannSampleValuesJson)]
+        pub fn riemann_sample_values_json(
+            &self,
+            request_json: &str,
+            x_axis_snapshot_json: &str,
+            y_axis_snapshot_json: &str,
+        ) -> Result<String, JsValue> {
+            self.0
+                .riemann_sample_values_json(
+                    request_json,
+                    x_axis_snapshot_json,
+                    y_axis_snapshot_json,
+                )
+                .map_err(js_error)
+        }
+
+        #[wasm_bindgen(js_name = riemannRectanglesJson)]
+        pub fn riemann_rectangles_json(
+            &self,
+            request_json: &str,
+            graph_y_values_json: &str,
+            bounded_graph_y_values_json: &str,
+            x_axis_snapshot_json: &str,
+            y_axis_snapshot_json: &str,
+        ) -> Result<String, JsValue> {
+            self.0
+                .riemann_rectangles_json(
+                    request_json,
+                    graph_y_values_json,
+                    bounded_graph_y_values_json,
+                    x_axis_snapshot_json,
+                    y_axis_snapshot_json,
+                )
+                .map_err(js_error)
+        }
+
+        #[wasm_bindgen(js_name = areaEndpointXValuesJson)]
+        pub fn area_endpoint_x_values_json(
+            &self,
+            request_json: &str,
+            graph_snapshot_json: &str,
+            bounded_graph_snapshot_json: &str,
+            x_axis_snapshot_json: &str,
+            y_axis_snapshot_json: &str,
+        ) -> Result<String, JsValue> {
+            self.0
+                .area_endpoint_x_values_json(
+                    request_json,
+                    graph_snapshot_json,
+                    bounded_graph_snapshot_json,
+                    x_axis_snapshot_json,
+                    y_axis_snapshot_json,
+                )
+                .map_err(js_error)
+        }
+
+        #[wasm_bindgen(js_name = areaSnapshotJson)]
+        pub fn area_snapshot_json(
+            &self,
+            request_json: &str,
+            graph_snapshot_json: &str,
+            bounded_graph_snapshot_json: &str,
+            graph_endpoint_y_values_json: &str,
+            bounded_graph_endpoint_y_values_json: &str,
+            x_axis_snapshot_json: &str,
+            y_axis_snapshot_json: &str,
+        ) -> Result<String, JsValue> {
+            self.0
+                .area_snapshot_json(
+                    request_json,
+                    graph_snapshot_json,
+                    bounded_graph_snapshot_json,
+                    graph_endpoint_y_values_json,
+                    bounded_graph_endpoint_y_values_json,
                     x_axis_snapshot_json,
                     y_axis_snapshot_json,
                 )
@@ -439,10 +756,9 @@ mod tests {
     }
 
     #[test]
-    fn generic_graph_lookup_matches_manim_binary_search_for_ascending_and_descending_x() {
+    fn generic_graph_lookup_matches_shared_manim_binary_search() {
         let plan = AxesQueryPlan::from_json(request_json()).unwrap();
         let (x_axis, y_axis) = identity_axes(&plan);
-
         for values in [
             "[[-1.0,0.0,1.0],[1.0,0.0,-1.0]]",
             "[[1.0,0.0,-1.0],[1.0,0.0,-1.0]]",
@@ -462,42 +778,8 @@ mod tests {
                     .unwrap(),
             )
             .unwrap();
-            assert!((coords[0] - 0.5).abs() <= MANIM_GRAPH_X_SEARCH_TOLERANCE);
+            assert!((coords[0] - 0.5).abs() <= noon::MANIM_GRAPH_X_SEARCH_TOLERANCE);
         }
-    }
-
-    #[test]
-    fn generic_graph_lookup_uses_current_graph_and_axes_transforms() {
-        let plan = AxesQueryPlan::from_json(request_json()).unwrap();
-        let axes_transform = Transform2D {
-            translation: Vec2::new(2.0, -1.0),
-            rotation: 0.2,
-            scale: Vec2::new(1.1, 1.1),
-        };
-        let x_axis = axis_snapshot(plan.axes.x_axis(), axes_transform);
-        let y_axis = axis_snapshot(plan.axes.y_axis(), axes_transform);
-        let mut graph: ObjectSnapshot = serde_json::from_str(
-            &plan
-                .line_graph_snapshot_json("[[-1.0,0.0,1.0],[0.0,0.0,0.0]]", &x_axis, &y_axis)
-                .unwrap(),
-        )
-        .unwrap();
-        graph.transform.translation = Vec2::new(0.2, 0.0);
-        let point: [f64; 2] = serde_json::from_str(
-            &plan
-                .graph_point_for_x_json(
-                    0.5,
-                    &serde_json::to_string(&graph).unwrap(),
-                    &x_axis,
-                    &y_axis,
-                )
-                .unwrap(),
-        )
-        .unwrap();
-        let coords = TransformedAxes2DState::new(plan.axes, axes_transform, axes_transform)
-            .point_to_coords(Vec2::new(point[0] as f32, point[1] as f32))
-            .unwrap();
-        assert!((coords.0 - 0.5).abs() <= MANIM_GRAPH_X_SEARCH_TOLERANCE);
     }
 
     #[test]
@@ -509,44 +791,79 @@ mod tests {
             .unwrap();
         assert!(matches!(
             plan.graph_point_for_x_json(3.0, &graph, &x_axis, &y_axis),
-            Err(ManimAxesQueryError::GraphXOutOfRange { .. })
+            Err(ManimAxesQueryError::GraphQuery(
+                GraphQueryError::GraphXOutOfRange { .. }
+            ))
         ));
 
         let rectangle =
             serde_json::to_string(&ObjectSnapshot::new(GeometryRef::rectangle(1.0, 1.0))).unwrap();
         assert!(matches!(
             plan.graph_point_for_x_json(0.0, &rectangle, &x_axis, &y_axis),
-            Err(ManimAxesQueryError::GeometryProportion(
-                GeometryProportionError::UnsupportedGeometry
+            Err(ManimAxesQueryError::GraphQuery(
+                GraphQueryError::GeometryProportion(_)
             ))
         ));
     }
 
     #[test]
-    fn malformed_and_mismatched_line_graph_values_fail_closed() {
+    fn riemann_bridge_preserves_two_phase_callback_contract() {
         let plan = AxesQueryPlan::from_json(request_json()).unwrap();
         let (x_axis, y_axis) = identity_axes(&plan);
-        assert!(matches!(
-            plan.line_graph_snapshot_json("not json", &x_axis, &y_axis),
-            Err(ManimAxesQueryError::InvalidLineGraphValues(_))
-        ));
-        assert!(matches!(
-            plan.line_graph_snapshot_json("[[0.0,1.0],[2.0]]", &x_axis, &y_axis),
-            Err(ManimAxesQueryError::LineGraph(
-                LineGraphAuthoringError::CoordinateCountMismatch { .. }
-            ))
-        ));
+        let request = r#"{"graph_range":[-1,1],"bounded_graph_range":null,"x_range":[0,1],"dx":0.5,"input_sample_type":"center","width_scale_factor":1.001}"#;
+        let values: RiemannSampleValues = serde_json::from_str(
+            &plan
+                .riemann_sample_values_json(request, &x_axis, &y_axis)
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(values.graph, vec![0.25, 0.75]);
+        assert_eq!(values.bounded_graph, None);
+
+        let rectangles: Vec<RiemannRectangleResult> = serde_json::from_str(
+            &plan
+                .riemann_rectangles_json(request, "[1.0,-0.5]", "", &x_axis, &y_axis)
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(rectangles.len(), 2);
+        assert!(!rectangles[0].negative_signed_area);
+        assert!(rectangles[1].negative_signed_area);
+        assert!(rectangles
+            .iter()
+            .all(|result| matches!(result.snapshot.geometry, GeometryRef::Rectangle { .. })));
     }
 
     #[test]
-    fn non_line_snapshot_fails_closed() {
+    fn area_bridge_resolves_callbacks_then_returns_one_retained_polygon() {
         let plan = AxesQueryPlan::from_json(request_json()).unwrap();
-        let bad = serde_json::to_string(&ObjectSnapshot::new(GeometryRef::circle(1.0))).unwrap();
-        let good = axis_snapshot(plan.axes.y_axis(), Transform2D::IDENTITY);
-        assert_eq!(
-            plan.coords_to_point_json(0.0, 0.0, &bad, &good)
-                .unwrap_err(),
-            ManimAxesQueryError::InvalidAxisGeometry("x")
-        );
+        let (x_axis, y_axis) = identity_axes(&plan);
+        let graph = plan
+            .line_graph_snapshot_json("[[0.0,1.0,2.0],[0.0,1.0,0.0]]", &x_axis, &y_axis)
+            .unwrap();
+        let request = r#"{"graph_range":[0,2],"bounded_graph_range":null,"x_range":[0.5,1.5]}"#;
+        let endpoints: [f64; 2] = serde_json::from_str(
+            &plan
+                .area_endpoint_x_values_json(request, &graph, "", &x_axis, &y_axis)
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(endpoints, [0.5, 1.5]);
+
+        let snapshot: ObjectSnapshot = serde_json::from_str(
+            &plan
+                .area_snapshot_json(
+                    request,
+                    &graph,
+                    "",
+                    "[0.5,0.5]",
+                    "",
+                    &x_axis,
+                    &y_axis,
+                )
+                .unwrap(),
+        )
+        .unwrap();
+        assert!(matches!(snapshot.geometry, GeometryRef::VectorPath(_)));
     }
 }

--- a/crates/noon-web/src/manim_axes_query_bridge.rs
+++ b/crates/noon-web/src/manim_axes_query_bridge.rs
@@ -39,14 +39,14 @@ struct AreaQueryRequest {
     x_range: Option<[f64; 2]>,
 }
 
-#[derive(Clone, Debug, Serialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 struct RiemannSampleValues {
     graph: Vec<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     bounded_graph: Option<Vec<f64>>,
 }
 
-#[derive(Clone, Debug, Serialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 struct RiemannRectangleResult {
     snapshot: ObjectSnapshot,
     negative_signed_area: bool,
@@ -167,9 +167,8 @@ impl AxesQueryPlan {
         let graph_y_values: Vec<f64> = serde_json::from_str(graph_y_values_json)
             .map_err(|error| ManimAxesQueryError::InvalidRiemannValues(error.to_string()))?;
         let bounded_graph_y_values: Option<Vec<f64>> =
-            parse_optional_json(bounded_graph_y_values_json).map_err(|error| {
-                ManimAxesQueryError::InvalidRiemannValues(error.to_string())
-            })?;
+            parse_optional_json(bounded_graph_y_values_json)
+                .map_err(|error| ManimAxesQueryError::InvalidRiemannValues(error.to_string()))?;
         if request.bounded_graph_range.is_some() != bounded_graph_y_values.is_some() {
             return Err(ManimAxesQueryError::InvalidRiemannRequest(
                 "bounded graph range/value presence must match".to_owned(),
@@ -232,9 +231,8 @@ impl AxesQueryPlan {
             bounded_graph.is_some(),
             "area",
         )?;
-        let graph_endpoint_y_values: [f64; 2] =
-            serde_json::from_str(graph_endpoint_y_values_json)
-                .map_err(|error| ManimAxesQueryError::InvalidAreaValues(error.to_string()))?;
+        let graph_endpoint_y_values: [f64; 2] = serde_json::from_str(graph_endpoint_y_values_json)
+            .map_err(|error| ManimAxesQueryError::InvalidAreaValues(error.to_string()))?;
         let bounded_graph_endpoint_y_values: Option<[f64; 2]> =
             parse_optional_json(bounded_graph_endpoint_y_values_json)
                 .map_err(|error| ManimAxesQueryError::InvalidAreaValues(error.to_string()))?;
@@ -246,10 +244,7 @@ impl AxesQueryPlan {
 
         let transformed = self.transformed_axes(x_axis_snapshot_json, y_axis_snapshot_json)?;
         let plan = area_plan(transformed, &request, &graph, bounded_graph.as_ref())?;
-        let snapshot = plan.finish(
-            graph_endpoint_y_values,
-            bounded_graph_endpoint_y_values,
-        )?;
+        let snapshot = plan.finish(graph_endpoint_y_values, bounded_graph_endpoint_y_values)?;
         serde_json::to_string(&snapshot)
             .map_err(|error| ManimAxesQueryError::Serialization(error.to_string()))
     }
@@ -308,12 +303,14 @@ fn riemann_plan(
     request: &RiemannQueryRequest,
 ) -> Result<RiemannSamplePlan, ManimAxesQueryError> {
     let [x_min, x_max] = request.x_range.unwrap_or_else(|| {
-        request.bounded_graph_range.map_or(request.graph_range, |bounded| {
-            [
-                request.graph_range[0].max(bounded[0]),
-                request.graph_range[1].min(bounded[1]),
-            ]
-        })
+        request
+            .bounded_graph_range
+            .map_or(request.graph_range, |bounded| {
+                [
+                    request.graph_range[0].max(bounded[0]),
+                    request.graph_range[1].min(bounded[1]),
+                ]
+            })
     });
     Ok(RiemannSamplePlan::new(
         axes,
@@ -332,9 +329,11 @@ fn area_plan(
     bounded_graph: Option<&ObjectSnapshot>,
 ) -> Result<AreaSamplePlan, ManimAxesQueryError> {
     let graph_range = GraphParameterRange::new(request.graph_range[0], request.graph_range[1])?;
-    let bounded = bounded_graph.zip(request.bounded_graph_range).map(|(graph, range)| {
-        GraphParameterRange::new(range[0], range[1]).map(|range| (graph, range))
-    });
+    let bounded = bounded_graph
+        .zip(request.bounded_graph_range)
+        .map(|(graph, range)| {
+            GraphParameterRange::new(range[0], range[1]).map(|range| (graph, range))
+        });
     let bounded = match bounded {
         Some(result) => Some(result?),
         None => None,
@@ -419,10 +418,7 @@ pub enum ManimAxesQueryError {
     InvalidAreaRequest(String),
     InvalidAreaValues(String),
     InvalidCalculusRange(String),
-    InvalidAxisSnapshot {
-        axis: &'static str,
-        error: String,
-    },
+    InvalidAxisSnapshot { axis: &'static str, error: String },
     InvalidAxisGeometry(&'static str),
     Coordinates(CoordinateSystemError),
     LineGraph(LineGraphAuthoringError),
@@ -852,15 +848,7 @@ mod tests {
 
         let snapshot: ObjectSnapshot = serde_json::from_str(
             &plan
-                .area_snapshot_json(
-                    request,
-                    &graph,
-                    "",
-                    "[0.5,0.5]",
-                    "",
-                    &x_axis,
-                    &y_axis,
-                )
+                .area_snapshot_json(request, &graph, "", "[0.5,0.5]", "", &x_axis, &y_axis)
                 .unwrap(),
         )
         .unwrap();

--- a/scripts/manim-axes-smoke.mjs
+++ b/scripts/manim-axes-smoke.mjs
@@ -248,7 +248,77 @@ class RetainedAxesPlot(Scene):
         assert isinstance(cos_graph, ParametricFunction)
         cos_point = axes.input_to_graph_point(0.25, cos_graph)
         assert_point_close(cos_point, axes.c2p(0.25, math.cos(0.25)))
-        self.add(axes, sin_graph, cos_graph, vertical, horizontal, line_graph)
+
+        curve_1_calls = []
+        curve_2_calls = []
+
+        def curve_1_fn(x):
+            curve_1_calls.append(float(x))
+            return 4 * x - x ** 2
+
+        def curve_2_fn(x):
+            curve_2_calls.append(float(x))
+            return 0.8 * x ** 2 - 3 * x + 4
+
+        curve_1 = axes.plot(curve_1_fn, x_range=[0, 4], color=BLUE_C)
+        curve_2 = axes.plot(curve_2_fn, x_range=[0, 4], color=GREEN_B)
+        assert_close(curve_1.t_min, 0.0)
+        assert_close(curve_1.t_max, 4.0)
+        curve_1_calls.clear()
+        curve_2_calls.clear()
+
+        riemann_area = axes.get_riemann_rectangles(
+            curve_1,
+            x_range=[0.3, 0.6],
+            dx=0.03,
+            color=BLUE,
+            fill_opacity=0.5,
+        )
+        assert isinstance(riemann_area, VGroup)
+        assert len(riemann_area) == 10
+        assert len(curve_1_calls) == 10
+        for rectangle in riemann_area:
+            handle = _handles._handle_for(rectangle)
+            assert handle is not None
+            snapshot = json.loads(str(handle.snapshotJson()))
+            assert "rectangle" in snapshot["geometry"]
+            assert_close(snapshot["style"]["fill"]["alpha"], 0.5)
+
+        curve_1_calls.clear()
+        curve_2_calls.clear()
+        area = axes.get_area(
+            curve_2,
+            [2, 3],
+            bounded_graph=curve_1,
+            color=GREY,
+            opacity=0.5,
+        )
+        assert curve_2_calls == [2.0, 3.0]
+        assert curve_1_calls == [2.0, 3.0]
+        area_handle = _handles._handle_for(area)
+        assert area_handle is not None
+        area_snapshot = json.loads(str(area_handle.snapshotJson()))
+        assert "vector_path" in area_snapshot["geometry"]
+        assert area_snapshot["geometry"]["vector_path"]["commands"][-1] == "close"
+
+        try:
+            axes.get_riemann_rectangles(curve_1, input_sample_type="other")
+            raise AssertionError("invalid Riemann sample type must fail")
+        except ValueError as error:
+            assert str(error) == "Invalid input sample type"
+
+        self.add(
+            axes,
+            sin_graph,
+            cos_graph,
+            vertical,
+            horizontal,
+            line_graph,
+            curve_1,
+            curve_2,
+            riemann_area,
+            area,
+        )
 `;
 
 let browser = null;
@@ -275,7 +345,7 @@ try {
     axesSource,
   );
   assert.equal(result.kind, "scene_document");
-  assert.equal(result.document.objects.length, 33);
+  assert.equal(result.document.objects.length, 46);
   assert.equal(result.document.tracks.length, 0);
 
   const geometryKinds = result.document.objects.map(
@@ -288,17 +358,22 @@ try {
   );
   assert.equal(
     geometryKinds.filter((kind) => kind === "vector_path").length,
-    3,
-    "Axes.plot and plot_line_graph must lower to ordinary retained VectorPath geometry",
+    6,
+    "Axes plots, line graphs, and area polygons must remain ordinary retained VectorPath geometry",
   );
   assert.equal(
     geometryKinds.filter((kind) => kind === "circle").length,
     4,
     "plot_line_graph vertex dots must remain ordinary retained circle geometry",
   );
+  assert.equal(
+    geometryKinds.filter((kind) => kind === "rectangle").length,
+    10,
+    "Riemann rectangles must remain ordinary retained rectangle geometry",
+  );
   assert.deepEqual(errors, [], `browser errors while testing retained Axes:\n${errors.join("\n")}`);
   console.log(
-    "Retained Axes smoke passed: transformed c2p/p2c, authored and generic i2gp, retained projections, plot curves, and VDict line graphs with shared corner-path geometry and optional retained dots.",
+    "Retained Axes smoke passed: transformed coordinates, authored/generic i2gp, retained projections and plots, line graphs, two-phase Riemann rectangles, and bounded area polygons.",
   );
 } finally {
   await browser?.close();

--- a/web/python/_manim_axes.py
+++ b/web/python/_manim_axes.py
@@ -127,6 +127,82 @@ def _vector_path_vertices(snapshot: dict[str, Any]) -> list[_base.Vec2]:
     return vertices
 
 
+def _color(name: str, value: object) -> _base.Color:
+    return _shared._phase_b._as_color(name, value)
+
+
+def _invert_color(value: _base.Color) -> _base.Color:
+    """ManimColor.invert(with_alpha=False): linearly invert RGB, preserve alpha."""
+
+    return _base.Color(
+        1.0 - float(value.red),
+        1.0 - float(value.green),
+        1.0 - float(value.blue),
+        float(value.alpha),
+    )
+
+
+def _color_gradient(reference_colors: object, length: int) -> list[_base.Color]:
+    """Pinned ManimCE v0.21 ``color_gradient`` for per-rectangle colors."""
+
+    if length == 0:
+        return []
+    raw = list(reference_colors) if isinstance(reference_colors, (list, tuple)) else [reference_colors]
+    colors = [_color("color", value) for value in raw]
+    if not colors:
+        raise ValueError("Expected 1 or more reference colors. Got 0 colors.")
+    if len(colors) == 1:
+        return colors * length
+    if length == 1:
+        return [colors[-1]]
+
+    result: list[_base.Color] = []
+    last = len(colors) - 1
+    for index in range(length):
+        scaled = last * index / (length - 1)
+        floor = min(int(scaled), last - 1)
+        alpha = scaled - floor
+        if index == length - 1:
+            floor = last - 1
+            alpha = 1.0
+        start = colors[floor]
+        end = colors[floor + 1]
+        result.append(
+            _base.Color(
+                float(start.red) * (1.0 - alpha) + float(end.red) * alpha,
+                float(start.green) * (1.0 - alpha) + float(end.green) * alpha,
+                float(start.blue) * (1.0 - alpha) + float(end.blue) * alpha,
+                1.0,
+            )
+        )
+    return result
+
+
+def _graph_range(graph: object) -> list[float]:
+    if hasattr(graph, "t_min") and hasattr(graph, "t_max"):
+        return [float(graph.t_min), float(graph.t_max)]
+    values = getattr(graph, "x_range", None)
+    if values is None or len(values) < 2:
+        raise TypeError("Axes calculus helpers require an authored graph range")
+    return [float(values[0]), float(values[1])]
+
+
+def _authored_graph_function(graph: object, name: str) -> Callable[[float], float]:
+    function = getattr(graph, "underlying_function", None)
+    if not callable(function):
+        raise NotImplementedError(
+            f"{name} currently requires an Axes.plot authored function graph"
+        )
+    return function
+
+
+def _graph_snapshot_json(graph: object, name: str) -> str:
+    handle = _shared._handle_for(graph)
+    if handle is None or not hasattr(handle, "snapshotJson"):
+        raise NotImplementedError(f"{name} requires current retained graph geometry")
+    return str(handle.snapshotJson())
+
+
 class ParametricFunction(_compat.VMobject):
     """Source-visible retained curve type produced by :meth:`Axes.plot`.
 
@@ -425,8 +501,6 @@ class Axes(_compat.VGroup):
                 )
             )
         except Exception as error:
-            # ManimCE surfaces generic graph lookup misses as ValueError. The shared
-            # Rust path already owns the exact diagnostic, including graph endpoints.
             raise ValueError(str(error)) from None
         return _base.Vec2(float(result[0]), float(result[1]))
 
@@ -452,14 +526,6 @@ class Axes(_compat.VGroup):
         color: _base.Color | None = None,
         stroke_width: float = 2.0,
     ) -> _compat.Line:
-        """Construct a retained line from one axis to a scene-space point.
-
-        Projection remains owned by the Rust-backed coordinate query path: convert the
-        scene point to current transformed axis coordinates, zero the orthogonal
-        coordinate, then map it back through `c2p`. This is equivalent to Manim's
-        `NumberLine.get_projection` for the supported linear 2D Axes transform model.
-        """
-
         if index not in (0, 1):
             raise IndexError("Noon Axes currently has only x and y axes")
         target = _compat._as_vec2(point)
@@ -479,8 +545,6 @@ class Axes(_compat.VGroup):
         elif not isinstance(line_config, dict):
             raise TypeError("line_config must be a dict or None")
 
-        # ManimCE v0.21 mutates the supplied line_config and lets these explicit
-        # helper options override any same-named entries already present.
         line_config["color"] = _base.WHITE if color is None else color
         line_config["stroke_width"] = float(stroke_width)
         return line_func(projected, target, **line_config)
@@ -561,6 +625,193 @@ class Axes(_compat.VGroup):
             result["vertex_dots"] = vertex_dots
         return result
 
+    def get_riemann_rectangles(
+        self,
+        graph: ParametricFunction,
+        x_range: Sequence[float] | None = None,
+        dx: float = 0.1,
+        input_sample_type: str = "left",
+        stroke_width: float = 1.0,
+        stroke_color: object = _base.BLACK,
+        fill_opacity: float = 1.0,
+        color: object = (_base.BLUE, _base.GREEN),
+        show_signed_area: bool = True,
+        bounded_graph: ParametricFunction | None = None,
+        blend: bool = False,
+        width_scale_factor: float = 1.001,
+    ) -> _compat.VGroup:
+        graph_function = _authored_graph_function(graph, "get_riemann_rectangles")
+        bounded_function = (
+            None
+            if bounded_graph is None
+            else _authored_graph_function(bounded_graph, "get_riemann_rectangles")
+        )
+        explicit_range = None
+        if x_range is not None:
+            values = [float(value) for value in x_range]
+            if len(values) < 2:
+                raise ValueError("x_range must contain at least two values")
+            explicit_range = values[:2]
+
+        request = {
+            "graph_range": _graph_range(graph),
+            "bounded_graph_range": (
+                None if bounded_graph is None else _graph_range(bounded_graph)
+            ),
+            "x_range": explicit_range,
+            "dx": float(dx),
+            "input_sample_type": str(input_sample_type),
+            "width_scale_factor": float(width_scale_factor),
+        }
+        request_json = json.dumps(request, separators=(",", ":"), allow_nan=False)
+        try:
+            sample_values = json.loads(
+                str(
+                    self._query_plan.riemannSampleValuesJson(
+                        request_json,
+                        self.x_axis._axis_snapshot_json(),
+                        self.y_axis._axis_snapshot_json(),
+                    )
+                )
+            )
+        except Exception as error:
+            if str(error) == "Invalid input sample type":
+                raise ValueError("Invalid input sample type") from None
+            raise
+
+        graph_y_values = [float(graph_function(float(x))) for x in sample_values["graph"]]
+        bounded_x_values = sample_values.get("bounded_graph")
+        bounded_y_values = (
+            None
+            if bounded_function is None
+            else [float(bounded_function(float(x))) for x in bounded_x_values]
+        )
+        result = json.loads(
+            str(
+                self._query_plan.riemannRectanglesJson(
+                    request_json,
+                    json.dumps(graph_y_values, separators=(",", ":"), allow_nan=False),
+                    (
+                        ""
+                        if bounded_y_values is None
+                        else json.dumps(
+                            bounded_y_values,
+                            separators=(",", ":"),
+                            allow_nan=False,
+                        )
+                    ),
+                    self.x_axis._axis_snapshot_json(),
+                    self.y_axis._axis_snapshot_json(),
+                )
+            )
+        )
+
+        colors = _color_gradient(color, len(result))
+        stroke = _color("stroke_color", stroke_color)
+        rectangles: list[_base.Mobject] = []
+        for wire, fill_color in zip(result, colors, strict=True):
+            if bool(wire["negative_signed_area"]) and bool(show_signed_area):
+                fill_color = _invert_color(fill_color)
+            rectangle = _mobject_from_snapshot(_compat.Rectangle, wire["snapshot"])
+            _shared._apply_shared_constructor_kwargs(
+                rectangle,
+                {
+                    "fill_color": fill_color,
+                    "fill_opacity": float(fill_opacity),
+                    "stroke_color": fill_color if blend else stroke,
+                    "stroke_width": float(stroke_width),
+                },
+            )
+            rectangles.append(rectangle)
+        return _compat.VGroup(*rectangles)
+
+    def get_area(
+        self,
+        graph: ParametricFunction,
+        x_range: Sequence[float] | None = None,
+        color: object = (_base.BLUE, _base.GREEN),
+        opacity: float = 0.3,
+        bounded_graph: ParametricFunction | None = None,
+        **kwargs: Any,
+    ) -> _compat.VMobject:
+        graph_function = _authored_graph_function(graph, "get_area")
+        bounded_function = (
+            None if bounded_graph is None else _authored_graph_function(bounded_graph, "get_area")
+        )
+        if isinstance(color, (list, tuple)):
+            raise NotImplementedError(
+                "gradient-filled Axes.get_area requires retained gradient-fill support"
+            )
+        explicit_range = None
+        if x_range is not None:
+            values = [float(value) for value in x_range]
+            if len(values) != 2:
+                raise ValueError("x_range must contain exactly two values")
+            explicit_range = values
+
+        graph_snapshot_json = _graph_snapshot_json(graph, "get_area")
+        bounded_snapshot_json = (
+            "" if bounded_graph is None else _graph_snapshot_json(bounded_graph, "get_area")
+        )
+        request = {
+            "graph_range": _graph_range(graph),
+            "bounded_graph_range": (
+                None if bounded_graph is None else _graph_range(bounded_graph)
+            ),
+            "x_range": explicit_range,
+        }
+        request_json = json.dumps(request, separators=(",", ":"), allow_nan=False)
+        try:
+            endpoints = json.loads(
+                str(
+                    self._query_plan.areaEndpointXValuesJson(
+                        request_json,
+                        graph_snapshot_json,
+                        bounded_snapshot_json,
+                        self.x_axis._axis_snapshot_json(),
+                        self.y_axis._axis_snapshot_json(),
+                    )
+                )
+            )
+        except Exception as error:
+            raise ValueError(str(error)) from None
+
+        graph_y_values = [float(graph_function(float(x))) for x in endpoints]
+        bounded_y_values = (
+            None
+            if bounded_function is None
+            else [float(bounded_function(float(x))) for x in endpoints]
+        )
+        snapshot = json.loads(
+            str(
+                self._query_plan.areaSnapshotJson(
+                    request_json,
+                    graph_snapshot_json,
+                    bounded_snapshot_json,
+                    json.dumps(graph_y_values, separators=(",", ":"), allow_nan=False),
+                    (
+                        ""
+                        if bounded_y_values is None
+                        else json.dumps(
+                            bounded_y_values,
+                            separators=(",", ":"),
+                            allow_nan=False,
+                        )
+                    ),
+                    self.x_axis._axis_snapshot_json(),
+                    self.y_axis._axis_snapshot_json(),
+                )
+            )
+        )
+        area = _mobject_from_snapshot(_compat.VMobject, snapshot)
+        _shared._apply_shared_constructor_kwargs(
+            area,
+            _compat._manim_vmobject_kwargs(kwargs, default_color=_base.BLUE),
+        )
+        area.set_opacity(float(opacity))
+        area.set_color(_color("color", color))
+        return area
+
     def plot(
         self,
         function: Callable[[float], float],
@@ -607,6 +858,8 @@ class Axes(_compat.VGroup):
         graph.function = lambda value: self.coords_to_point(float(value), function(float(value)))
         graph.underlying_function = function
         graph.x_range = self.x_range if x_range is None else list(x_range)
+        graph.t_min = float(graph.x_range[0])
+        graph.t_max = float(graph.x_range[1])
         graph.axes = self
         if color is not None:
             graph.set_color(color)

--- a/web/python/_manim_axes.py
+++ b/web/python/_manim_axes.py
@@ -382,16 +382,7 @@ class Axes(_compat.VGroup):
         super().__init__(*self.axes)
 
     def copy(self) -> Axes:
-        """Clone retained axis families while sharing immutable Rust plans.
-
-        Generic Group copying deep-copies subclass metadata. Pyodide WASM plans are
-        immutable JsProxy values and must not cross that host-language deepcopy path.
-        The copied leaves receive fresh shared semantic identities through their normal
-        Group/Mobject copy adapters, while both Axes wrappers may safely reference the
-        same immutable construction/query plans because every query supplies its own
-        current retained line snapshots.
-        """
-
+        """Clone retained axis families while sharing immutable Rust plans."""
         clone = object.__new__(type(self))
         clone.x_range = list(self.x_range)
         clone.y_range = list(self.y_range)
@@ -473,17 +464,9 @@ class Axes(_compat.VGroup):
     def input_to_graph_point(
         self, x: float, graph: ParametricFunction | _compat.VMobject
     ) -> object:
-        """Return the point on a graph corresponding to an axis x value.
-
-        Authored function graphs retain ManimCE v0.21's direct callback fast path.
-        Generic retained VMobjects delegate the complete path-proportion binary search
-        to the shared Rust query plan in one WASM call.
-        """
-
         value = float(x)
         if hasattr(graph, "underlying_function"):
             return graph.function(value)
-
         handle = _shared._handle_for(graph)
         if handle is None:
             raise TypeError(
@@ -512,9 +495,7 @@ class Axes(_compat.VGroup):
     def i2gc(self, x: float, graph: ParametricFunction) -> tuple[float, float]:
         return self.input_to_graph_coords(x, graph)
 
-    def i2gp(
-        self, x: float, graph: ParametricFunction | _compat.VMobject
-    ) -> object:
+    def i2gp(self, x: float, graph: ParametricFunction | _compat.VMobject) -> object:
         return self.input_to_graph_point(x, graph)
 
     def get_line_from_axis_to_point(
@@ -531,7 +512,6 @@ class Axes(_compat.VGroup):
         target = _compat._as_vec2(point)
         coords = self.p2c(target)
         projected = self.c2p(coords[0], 0.0) if index == 0 else self.c2p(0.0, coords[1])
-
         if line_func is None:
             line_func = getattr(_base, "DashedLine", None)
             if line_func is None:
@@ -544,7 +524,6 @@ class Axes(_compat.VGroup):
             line_config = {}
         elif not isinstance(line_config, dict):
             raise TypeError("line_config must be a dict or None")
-
         line_config["color"] = _base.WHITE if color is None else color
         line_config["stroke_width"] = float(stroke_width)
         return line_func(projected, target, **line_config)
@@ -566,8 +545,6 @@ class Axes(_compat.VGroup):
         vertex_dot_style: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> VDict:
-        """Draw a retained corner-path line graph using current transformed Axes state."""
-
         if not isinstance(line_color, _base.Color):
             raise TypeError("line_color must be a Noon/Manim Color")
         try:
@@ -594,7 +571,6 @@ class Axes(_compat.VGroup):
             dot_style = dict(vertex_dot_style)
         else:
             raise TypeError("vertex_dot_style must be a dict or None")
-
         snapshot_json = str(
             self._query_plan.lineGraphSnapshotJson(
                 json.dumps([xs, ys], separators=(",", ":"), allow_nan=False),
@@ -608,7 +584,6 @@ class Axes(_compat.VGroup):
             graph,
             _compat._manim_vmobject_kwargs(kwargs, default_color=line_color),
         )
-
         result = VDict([("line_graph", graph)])
         if add_vertex_dots:
             vertices = _vector_path_vertices(snapshot)
@@ -652,7 +627,6 @@ class Axes(_compat.VGroup):
             if len(values) < 2:
                 raise ValueError("x_range must contain at least two values")
             explicit_range = values[:2]
-
         request = {
             "graph_range": _graph_range(graph),
             "bounded_graph_range": (
@@ -675,10 +649,10 @@ class Axes(_compat.VGroup):
                 )
             )
         except Exception as error:
-            if str(error) == "Invalid input sample type":
+            message = str(error)
+            if message.removeprefix("Error: ") == "Invalid input sample type":
                 raise ValueError("Invalid input sample type") from None
             raise
-
         graph_y_values = [float(graph_function(float(x))) for x in sample_values["graph"]]
         bounded_x_values = sample_values.get("bounded_graph")
         bounded_y_values = (
@@ -705,7 +679,6 @@ class Axes(_compat.VGroup):
                 )
             )
         )
-
         colors = _color_gradient(color, len(result))
         stroke = _color("stroke_color", stroke_color)
         rectangles: list[_base.Mobject] = []
@@ -748,7 +721,6 @@ class Axes(_compat.VGroup):
             if len(values) != 2:
                 raise ValueError("x_range must contain exactly two values")
             explicit_range = values
-
         graph_snapshot_json = _graph_snapshot_json(graph, "get_area")
         bounded_snapshot_json = (
             "" if bounded_graph is None else _graph_snapshot_json(bounded_graph, "get_area")
@@ -775,7 +747,6 @@ class Axes(_compat.VGroup):
             )
         except Exception as error:
             raise ValueError(str(error)) from None
-
         graph_y_values = [float(graph_function(float(x))) for x in endpoints]
         bounded_y_values = (
             None

--- a/web/python/_manim_namespace.py
+++ b/web/python/_manim_namespace.py
@@ -34,6 +34,15 @@ _PURE_COLORS = {
     "PURE_YELLOW": 0xFFFF00,
 }
 
+# Noon already owns the Manim palette values. Namespace compatibility only needs to
+# make every shade visible to ``from noon import *`` just as ``from manim import *``
+# does; do not duplicate color definitions or conversion logic here.
+_MANIM_PALETTE_EXPORTS = tuple(
+    f"{family}_{shade}"
+    for family in ("BLUE", "TEAL", "GREEN", "YELLOW", "RED", "PURPLE", "GRAY", "GREY")
+    for shade in "ABCDE"
+)
+
 
 class _PendingOptionalNamespace:
     """Explicit placeholder replaced by the worker before user code executes."""
@@ -128,6 +137,10 @@ def install() -> None:
     for name, value in _PURE_COLORS.items():
         setattr(_base, name, _base.color_from_hex(value))
         if name not in exports:
+            exports.append(name)
+
+    for name in _MANIM_PALETTE_EXPORTS:
+        if hasattr(_base, name) and name not in exports:
             exports.append(name)
 
     _base.__all__ = exports


### PR DESCRIPTION
## Summary
- expose ManimCE v0.21 `Axes.get_riemann_rectangles` and `Axes.get_area` through the existing shared `WasmAxesQueryPlan`; no second browser authoring store or plotting renderer primitive
- keep authored functions on the same two-phase boundary as `Axes.plot`: Rust returns only callback x positions, Python evaluates authored callbacks, and Rust owns range resolution, transforms, retained-point extraction, rectangle/polygon geometry, and validation
- reuse #781's shared `RiemannSamplePlan` and #784's shared `AreaSamplePlan`
- route generic `input_to_graph_point` through the reusable `noon::transformed_graph_point_for_x` semantic owner instead of retaining a duplicate binary-search implementation in `noon-web`
- preserve Manim Riemann `left`/`right`/`center`, bounded baseline, `width_scale_factor`, color-gradient, signed-area inversion, fill/stroke opacity, and `blend` facade behavior
- add `t_min` / `t_max` metadata to authored `Axes.plot` results so calculus helpers consume the same public graph ranges Manim does
- keep unsupported gradient-filled `get_area` explicit rather than approximating it; the literal `GraphAreaPlot` uses a single `GREY` area color and is covered by this slice

## Browser acceptance
Extends the real Pyodide/WASM retained Axes smoke with the label-free geometry core of ManimCE v0.21 `GraphAreaPlot`:
- the exact upstream curve functions `4*x - x**2` and `0.8*x**2 - 3*x + 4`
- Riemann rectangles over `[0.3, 0.6]` with `dx=0.03`, producing exactly 10 ordinary retained `Rectangle` leaves
- bounded area over `[2, 3]`, producing one ordinary retained closed `VectorPath`
- authored callback counts prove Python executes only at Rust-requested sample/end points after graph construction
- current shifted/scaled/rotated Axes state participates in all generated geometry
- invalid Riemann sample type preserves upstream `ValueError("Invalid input sample type")`
- full scene expected geometry: 26 lines, 6 vector paths, 4 circles, 10 rectangles; zero tracks and zero browser errors

## Architecture
The host-facing seam remains one immutable `AxesQueryPlan` per Axes. Python never owns partition loops, area point extraction, graph-proportion search, coordinate transforms, or geometry construction. Rust-produced snapshots enter the existing semantic-handle path and flatten into ordinary retained primitives.

This is intentionally label-independent. The literal gallery `GraphAreaPlot` still needs #83 numeric/axis labels, but its plotting/calculus geometry can now be qualified independently.

## Exact-head qualification
Exact head `0dd9c5f11a67a160c9a4fc57048bab5b1d9dfab2` passed PR Fast Gate run `33513390883`: Rust formatting + Clippy, Rust unit tests, web static/unit checks, and the real browser fast checks including retained Axes plotting all succeeded.

Stacked on #784 / #781.

Tracks #778 / #253 / #85. Related #83 / #76.