### PR TITLE
Route retained execution workers through canonical SceneSpec

### DIFF
--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -197,6 +197,17 @@ jobs:
           echo "seconds=$SECONDS" >> "$GITHUB_OUTPUT"
           exit "$status"
 
+      - name: Check canonical retained execution
+        id: retained-execution
+        run: |
+          SECONDS=0
+          set +e
+          timeout --signal=TERM 60s node scripts/retained-execution-worker-smoke.mjs
+          status=$?
+          set -e
+          echo "seconds=$SECONDS" >> "$GITHUB_OUTPUT"
+          exit "$status"
+
       - name: Check primary WebGPU rendering
         id: webgpu-smoke
         env:
@@ -218,6 +229,7 @@ jobs:
           PACKAGE_SECONDS: ${{ steps.browser-package.outputs.seconds }}
           REPLAY_SECONDS: ${{ steps.deterministic-replay.outputs.seconds }}
           AUTHORING_SECONDS: ${{ steps.manim-authoring.outputs.seconds }}
+          RETAINED_SECONDS: ${{ steps.retained-execution.outputs.seconds }}
           WEBGPU_SECONDS: ${{ steps.webgpu-smoke.outputs.seconds }}
         run: |
           total=""
@@ -241,6 +253,7 @@ jobs:
             echo "| Browser package | $(display_seconds "$PACKAGE_SECONDS") |"
             echo "| Deterministic replay | $(display_seconds "$REPLAY_SECONDS") |"
             echo "| Manim authoring | $(display_seconds "$AUTHORING_SECONDS") |"
+            echo "| Canonical retained execution | $(display_seconds "$RETAINED_SECONDS") |"
             echo "| WebGPU smoke | $(display_seconds "$WEBGPU_SECONDS") |"
             echo "| Measured browser path | $(display_seconds "$total") |"
             echo

--- a/crates/noon-web/src/retained_execution_resources.rs
+++ b/crates/noon-web/src/retained_execution_resources.rs
@@ -159,7 +159,7 @@ impl InstalledRetainedExecutionMirror {
         &self,
         delta: &RetainedExecutionDeltaEnvelope,
     ) -> Result<RetainedFrameState, InstalledExecutionError> {
-        let mut wire = RetainedExecutionFrameMirror::default();
+        let mut wire = self.wire.clone();
         let (outcome, _) = wire.apply(delta.clone())?;
         debug_assert_eq!(outcome, RetainedTransportApplyOutcome::Applied);
         let frame = wire
@@ -424,6 +424,28 @@ mod tests {
             mirror.family_frame().unwrap().unwrap().family_animation(0),
             Some(family_state(0.5))
         );
+    }
+
+    #[test]
+    fn later_family_snapshot_previews_against_live_wire_sequence() {
+        let mut engine = engine();
+        let mut mirror =
+            InstalledRetainedExecutionMirror::from_bundle_bytes(engine.resource_bundle_bytes())
+                .unwrap();
+        let initial: RetainedExecutionDeltaEnvelope =
+            serde_json::from_str(&engine.initial_delta_json().unwrap()).unwrap();
+        mirror
+            .apply_family(family_snapshot(initial.clone()))
+            .unwrap();
+
+        let mut later = initial;
+        later.sequence = 1;
+        later.time = 0.5;
+        let (outcome, changes) = mirror.apply_family(family_snapshot(later)).unwrap();
+        assert_eq!(outcome, RetainedTransportApplyOutcome::Applied);
+        assert!(changes.is_all());
+        assert_eq!(mirror.frame().unwrap().time, 0.5);
+        assert!(mirror.family_plan().unwrap().is_some());
     }
 
     #[test]

--- a/scripts/retained-execution-worker-smoke.mjs
+++ b/scripts/retained-execution-worker-smoke.mjs
@@ -135,7 +135,11 @@ async function runMode(browser, transportMode) {
     });
     window.retainedExecutionSmoke = { client, errors };
     const sceneJson = wasm.demoSceneJson();
-    const ready = await client.start(sceneJson, retainedDocumentJson, {
+    const sceneSpecJson = wasm.canonicalRetainedSceneSpecJson(
+      sceneJson,
+      retainedDocumentJson,
+    );
+    const ready = await client.startCanonical(sceneSpecJson, {
       loopDurationSeconds: 4,
       transportMode: mode,
       sharedSlotCapacity: 1024 * 1024,
@@ -143,6 +147,7 @@ async function runMode(browser, transportMode) {
     return {
       ready,
       legacyObjectCount: JSON.parse(sceneJson).objects.length,
+      canonicalObjectCount: JSON.parse(sceneSpecJson).objects.length,
       crossOriginIsolated: window.crossOriginIsolated,
       hasSharedArrayBuffer: typeof SharedArrayBuffer === "function",
     };
@@ -151,9 +156,11 @@ async function runMode(browser, transportMode) {
   assert.equal(started.crossOriginIsolated, true);
   assert.equal(started.hasSharedArrayBuffer, true);
   assert.equal(started.legacyObjectCount, 4);
+  assert.equal(started.canonicalObjectCount, 6);
   assert.equal(started.ready.transportMode, transportMode);
   assert.equal(started.ready.engine.retained, true);
   assert.equal(started.ready.engine.mixed, true);
+  assert.equal(started.ready.engine.canonical, true);
   assert.equal(started.ready.render.retained, true);
   assert.equal(started.ready.render.mixed, true);
   assert.match(started.ready.render.backend, /WebGPU|WebGL2/);
@@ -170,38 +177,60 @@ async function runMode(browser, transportMode) {
   assert.ok(before.metrics.bytesUploaded > 0, `${transportMode}: mixed retained scene uploaded no GPU data`);
   assert.equal(before.engineMetrics.retained, true);
   assert.equal(before.engineMetrics.mixed, true);
+  assert.equal(before.engineMetrics.canonical, true);
   assert.equal(before.engineMetrics.resourceBundleTransfers, 1);
   assert.ok(before.engineMetrics.resourceBundleBytes > 0);
   assert.ok(before.engineMetrics.time > 0, `${transportMode}: mixed retained engine playhead did not advance`);
 
   const state = await page.evaluate(() => window.retainedExecutionSmoke.client.state());
-  const legacyDocument = JSON.parse(state.sceneJson);
-  const retainedDocument = JSON.parse(state.retainedDocumentJson);
-  assert.equal(legacyDocument.objects.length, 4);
-  assert.equal(retainedDocument.channel, "noon.authoring.retained");
-  assert.deepEqual(retainedDocument.objects.map((object) => object.object), [textA, textB]);
-  assert.deepEqual(retainedDocument.objects.map((object) => object.order), [1, 4]);
+  assert.equal("sceneJson" in state, false);
+  assert.equal("retainedDocumentJson" in state, false);
+  const sceneSpec = JSON.parse(state.sceneSpecJson);
+  assert.equal(sceneSpec.objects.length, 6);
+  assert.equal(sceneSpec.objects[1].id, textA);
+  assert.equal(sceneSpec.objects[4].id, textB);
   assert.equal(state.nextPatchSequence, "0");
 
   const retimed = await page.evaluate(() =>
     window.retainedExecutionSmoke.client.setLoopDurationSeconds(0.9),
   );
   assert.equal(retimed.nextPatchSequence, "0");
+  assert.equal("sceneSpecJson" in retimed, true);
   await page.waitForTimeout(1050);
   const afterRetime = await page.evaluate(() => window.retainedExecutionSmoke.client.metrics());
   assert.ok(afterRetime.engineMetrics.time >= 0 && afterRetime.engineMetrics.time < 0.9);
   assert.equal(afterRetime.engineMetrics.resourceBundleTransfers, 1);
+  assert.equal(afterRetime.engineMetrics.canonical, true);
   assert.equal(afterRetime.metrics.objectCount, 6);
 
   const reconnected = await page.evaluate(async () => {
+    async function bounded(label, operation, timeoutMs = 5_000) {
+      let timer = null;
+      try {
+        return await Promise.race([
+          Promise.resolve().then(operation),
+          new Promise((_, reject) => {
+            timer = setTimeout(
+              () => reject(new Error(`retained reconnect timed out during ${label}`)),
+              timeoutMs,
+            );
+          }),
+        ]);
+      } finally {
+        if (timer !== null) {
+          clearTimeout(timer);
+        }
+      }
+    }
+
     const client = window.retainedExecutionSmoke.client;
     const canvas = client.canvas;
-    const paused = await client.pause();
-    const beforeReconnect = await client.metrics();
-    const ready = await client.restart({ failedOwner: "engine" });
+    const paused = await bounded("pause", () => client.pause());
+    const beforeReconnect = await bounded("pre-reconnect metrics", () => client.metrics());
+    const ready = await bounded("engine restart", () => client.restart({ failedOwner: "engine" }));
     await new Promise((resolve) => setTimeout(resolve, 350));
-    const afterReconnect = await client.metrics();
-    const state = await client.state();
+    const afterReconnect = await bounded("post-reconnect metrics", () => client.metrics());
+    const state = await bounded("post-reconnect state", () => client.state());
     return {
       ready,
       paused,
@@ -215,6 +244,7 @@ async function runMode(browser, transportMode) {
   });
   assert.equal(reconnected.ready.session, 2);
   assert.equal(reconnected.ready.transportMode, transportMode);
+  assert.equal(reconnected.ready.engine.canonical, true);
   assert.equal(reconnected.ready.render.retained, true);
   assert.equal(reconnected.ready.render.mixed, true);
   assert.equal(reconnected.paused.playing, false);
@@ -223,6 +253,9 @@ async function runMode(browser, transportMode) {
     false,
     `${transportMode}: retained engine reconnect lost paused mode`,
   );
+  assert.equal("sceneJson" in reconnected.state, false);
+  assert.equal("retainedDocumentJson" in reconnected.state, false);
+  assert.equal(JSON.parse(reconnected.state.sceneSpecJson).objects.length, 6);
   assert.equal(reconnected.sameCanvas, true, `${transportMode}: retained engine reconnect replaced canvas`);
   assert.ok(
     reconnected.presentedAfter >= reconnected.presentedBefore,
@@ -231,6 +264,7 @@ async function runMode(browser, transportMode) {
   assert.equal(reconnected.metrics.ready, true);
   assert.equal(reconnected.metrics.objectCount, 6);
   assert.equal(reconnected.metrics.resourceBundlePending, false);
+  assert.equal(reconnected.engineMetrics.canonical, true);
   assert.equal(reconnected.engineMetrics.resourceBundleTransfers, 1);
   assert.ok(reconnected.engineMetrics.resourceBundleBytes > 0);
   assert.ok(
@@ -239,15 +273,70 @@ async function runMode(browser, transportMode) {
   );
   await page.evaluate(() => window.retainedExecutionSmoke.client.resume());
 
+  const recovered = await page.evaluate(async () => {
+    const client = window.retainedExecutionSmoke.client;
+    const canvas = client.canvas;
+    const ready = await client.restart({ failedOwner: "render" });
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    const state = await client.state();
+    const metrics = await client.metrics();
+    return {
+      ready,
+      state,
+      canvasReplaced: client.canvas !== canvas,
+      metrics: metrics.metrics,
+      engineMetrics: metrics.engineMetrics,
+    };
+  });
+  assert.equal(recovered.ready.session, 3);
+  assert.equal(recovered.ready.engine.canonical, true);
+  assert.equal(recovered.canvasReplaced, true);
+  assert.equal("sceneJson" in recovered.state, false);
+  assert.equal("retainedDocumentJson" in recovered.state, false);
+  assert.equal(JSON.parse(recovered.state.sceneSpecJson).objects.length, 6);
+  assert.equal(recovered.metrics.objectCount, 6);
+  assert.equal(recovered.engineMetrics.canonical, true);
+  assert.equal(recovered.engineMetrics.resourceBundleTransfers, 1);
+
   const clientErrors = await page.evaluate(() => window.retainedExecutionSmoke.errors.slice());
   assert.deepEqual(clientErrors, []);
   assert.deepEqual(browserErrors, []);
   await page.evaluate(() => window.retainedExecutionSmoke.client.terminate());
   await page.close();
   console.log(
-    `✓ mixed retained execution workers ${transportMode}: ${before.metrics.backend}, ` +
-      `${reconnected.presentedAfter} frames with canvas-preserving engine reconnect`,
+    `✓ canonical retained execution workers ${transportMode}: ${before.metrics.backend}, ` +
+      `${reconnected.presentedAfter} frames with canonical engine/render recovery`,
   );
+}
+
+async function runCompatibilityFallback(browser) {
+  const page = await browser.newPage({ viewport: { width: 480, height: 320 } });
+  await page.goto(`${baseUrl}/web/execution-worker-smoke.html`, { waitUntil: "load" });
+  const result = await page.evaluate(async (retainedDocumentJson) => {
+    const wasm = await import("./pkg/noon_web.js");
+    await wasm.default();
+    const { RetainedExecutionWorkerClient } = await import(
+      "./retained-execution-worker-client.js"
+    );
+    const client = new RetainedExecutionWorkerClient(document.querySelector("#scene"));
+    const sceneJson = wasm.demoSceneJson();
+    const ready = await client.start(sceneJson, retainedDocumentJson, {
+      loopDurationSeconds: 1,
+      transportMode: "transferable",
+    });
+    const state = await client.state();
+    const metrics = await client.metrics();
+    client.terminate();
+    return { ready, state, engineMetrics: metrics.engineMetrics };
+  }, retainedScene);
+
+  assert.equal(result.ready.engine.canonical, false);
+  assert.equal(result.engineMetrics.canonical, false);
+  assert.equal(typeof result.state.sceneJson, "string");
+  assert.equal(typeof result.state.retainedDocumentJson, "string");
+  assert.equal("sceneSpecJson" in result.state, false);
+  await page.close();
+  console.log("✓ split retained compatibility startup remains available");
 }
 
 let browser = null;
@@ -259,6 +348,7 @@ try {
   });
   await runMode(browser, "transferable");
   await runMode(browser, "shared");
+  await runCompatibilityFallback(browser);
 } finally {
   await browser?.close();
   await new Promise((resolve) => server.close(resolve));

--- a/web/execution-worker-preflight.test.mjs
+++ b/web/execution-worker-preflight.test.mjs
@@ -15,9 +15,7 @@ test("engine ready is emitted only after the complete initial render bootstrap i
 
   const retainedResources = retained.indexOf('type: "retained_resources"');
   const retainedSnapshot = retained.indexOf("sendDeltaOrThrow(player.initialDeltaJson())");
-  const retainedReady = retained.indexOf(
-    'postMain({ type: "ready", transportMode, retained: true, mixed: true })',
-  );
+  const retainedReady = retained.indexOf('type: "ready"', retainedSnapshot);
   assert.ok(retainedResources >= 0);
   assert.ok(retainedSnapshot > retainedResources);
   assert.ok(retainedReady > retainedSnapshot);

--- a/web/execution-worker-startup.test.mjs
+++ b/web/execution-worker-startup.test.mjs
@@ -149,7 +149,7 @@ function emitUnifiedRetainedReady(offset) {
 }
 
 function emitRetainedReady(offset) {
-  const engine = workerByName(offset, "noon-mixed-retained-engine");
+  const engine = workerByName(offset, "noon-retained-engine");
   const render = workerByName(offset, "noon-mixed-retained-render");
   engine.emitMessage(envelope("noon.engine", "ready", { transportMode: "transferable" }));
   render.emitMessage(
@@ -239,7 +239,7 @@ test("retained pre-ready crash rolls back transferred canvas and retry succeeds"
   });
   const offset = FakeWorker.instances.length;
   const started = client.start(SCENE_JSON, RETAINED_JSON, { transportMode: "transferable" });
-  const engine = workerByName(offset, "noon-mixed-retained-engine");
+  const engine = workerByName(offset, "noon-retained-engine");
   const render = workerByName(offset, "noon-mixed-retained-render");
   engine.emitMessage(envelope("noon.engine", "ready", { transportMode: "transferable" }));
   render.emitError("retained render startup crashed");

--- a/web/retained-execution-engine-worker.js
+++ b/web/retained-execution-engine-worker.js
@@ -1,4 +1,7 @@
-import init, { MixedRetainedEngineScenePlayer } from "./pkg/noon_web.js";
+import init, {
+  CanonicalRetainedEngineScenePlayer,
+  MixedRetainedEngineScenePlayer,
+} from "./pkg/noon_web.js";
 import {
   EXECUTION_TRANSPORT_SHARED,
   EXECUTION_TRANSPORT_TRANSFERABLE,
@@ -9,15 +12,19 @@ import {
 
 const ENGINE_CHANNEL = "noon.engine";
 const ENGINE_PROTOCOL_VERSION = 1;
+const AUTHORING_CANONICAL = "canonical";
+const AUTHORING_COMPATIBILITY = "compatibility";
 
 let renderPort = null;
 let transportMode = null;
 let transport = null;
 let player = null;
+let authoringKind = null;
 let latestTick = null;
 let controlQueue = [];
 let initialized = false;
 let stopped = false;
+let fatalErrorMessage = null;
 let resourceBundleBytes = 0;
 
 self.addEventListener("message", (event) => {
@@ -40,14 +47,7 @@ async function handleMainMessage(message) {
         return;
       case "state":
         requireInitialized();
-        respond(message.requestId, {
-          type: "state",
-          time: player.time(),
-          playing: player.isPlaying(),
-          nextPatchSequence: "0",
-          sceneJson: player.legacySceneJson(),
-          retainedDocumentJson: player.retainedDocumentJson(),
-        });
+        respond(message.requestId, runtimeState("state"));
         return;
       case "metrics":
         requireInitialized();
@@ -56,8 +56,11 @@ async function handleMainMessage(message) {
           metrics: {
             retained: true,
             mixed: true,
+            canonical: authoringKind === AUTHORING_CANONICAL,
             time: player.time(),
             playing: player.isPlaying(),
+            stopped,
+            fatalErrorMessage,
             resourceBundleBytes,
             resourceBundleTransfers: 1,
           },
@@ -69,7 +72,7 @@ async function handleMainMessage(message) {
       case "configure_callbacks":
       case "attach_host_port":
         throw new Error(
-          `${message.type} is not supported by mixed retained execution yet; rebuild the scene instead`,
+          `${message.type} is not supported by retained execution yet; rebuild the scene instead`,
         );
       case "stop":
         stopped = true;
@@ -79,7 +82,7 @@ async function handleMainMessage(message) {
         self.close();
         return;
       default:
-        throw new Error(`unknown mixed retained engine command ${message.type}`);
+        throw new Error(`unknown retained engine command ${message.type}`);
     }
   } catch (error) {
     fail(error, message?.requestId ?? null);
@@ -88,42 +91,30 @@ async function handleMainMessage(message) {
 
 async function initialize(message) {
   if (initialized) {
-    throw new Error("mixed retained execution engine worker is already initialized");
+    throw new Error("retained execution engine worker is already initialized");
   }
   if (!(message.port instanceof MessagePort)) {
-    throw new Error("mixed retained execution engine init requires a render MessagePort");
+    throw new Error("retained execution engine init requires a render MessagePort");
   }
-  if (typeof message.sceneJson !== "string" || message.sceneJson.trim() === "") {
-    throw new Error("mixed retained execution engine init requires legacy scene JSON");
-  }
-  if (
-    typeof message.retainedDocumentJson !== "string" ||
-    message.retainedDocumentJson.trim() === ""
-  ) {
-    throw new Error("mixed retained execution engine init requires retained document JSON");
-  }
+  const authoring = validateAuthoringInput(message);
   validateLoopDuration(message.loopDurationSeconds);
   if (!Number.isSafeInteger(message.session) || message.session < 0) {
-    throw new Error("mixed retained execution session must be a non-negative safe integer");
+    throw new Error("retained execution session must be a non-negative safe integer");
   }
   if (
     message.transportMode !== EXECUTION_TRANSPORT_SHARED &&
     message.transportMode !== EXECUTION_TRANSPORT_TRANSFERABLE
   ) {
-    throw new Error(`unsupported mixed retained execution transport mode ${message.transportMode}`);
+    throw new Error(`unsupported retained execution transport mode ${message.transportMode}`);
   }
 
   renderPort = message.port;
   renderPort.addEventListener("message", (event) => handleRenderMessage(event.data));
   renderPort.start();
   transportMode = message.transportMode;
+  authoringKind = authoring.kind;
   await init();
-  player = new MixedRetainedEngineScenePlayer(
-    message.sceneJson,
-    message.retainedDocumentJson,
-    message.loopDurationSeconds,
-    message.session,
-  );
+  player = createPlayer(authoring, message.loopDurationSeconds, message.session);
 
   // wasm-bindgen returns a view/copy for Vec<u8>; make an independently owned
   // transferable buffer so detaching it cannot affect WebAssembly memory.
@@ -151,8 +142,30 @@ async function initialize(message) {
 
   sendDeltaOrThrow(player.initialDeltaJson());
   initialized = true;
-  postMain({ type: "ready", transportMode, retained: true, mixed: true });
+  postMain({
+    type: "ready",
+    transportMode,
+    retained: true,
+    mixed: true,
+    canonical: authoringKind === AUTHORING_CANONICAL,
+  });
   drainWork();
+}
+
+function createPlayer(authoring, loopDurationSeconds, session) {
+  if (authoring.kind === AUTHORING_CANONICAL) {
+    return new CanonicalRetainedEngineScenePlayer(
+      authoring.sceneSpecJson,
+      loopDurationSeconds,
+      session,
+    );
+  }
+  return new MixedRetainedEngineScenePlayer(
+    authoring.sceneJson,
+    authoring.retainedDocumentJson,
+    loopDurationSeconds,
+    session,
+  );
 }
 
 function handleRenderMessage(message) {
@@ -173,14 +186,21 @@ function handleRenderMessage(message) {
     return;
   }
   if (message.type === "render_error") {
-    fail(new Error(`mixed retained render worker failed: ${message.message}`), null);
+    fail(new Error(`retained render worker failed: ${message.message}`), null);
   }
 }
 
 function enqueueControl(message) {
   requireInitialized();
   if (!Number.isSafeInteger(message.requestId) || message.requestId < 0) {
-    throw new Error("mixed retained engine request ID must be a non-negative safe integer");
+    throw new Error("retained engine request ID must be a non-negative safe integer");
+  }
+  if (stopped) {
+    throw new Error(
+      fatalErrorMessage === null
+        ? "retained execution engine is stopped"
+        : `retained execution engine is stopped after: ${fatalErrorMessage}`,
+    );
   }
   controlQueue.push(message);
   drainWork();
@@ -191,17 +211,18 @@ function drainWork() {
     return;
   }
 
-  while (controlQueue.length > 0 && transportCanSend()) {
-    const message = controlQueue.shift();
+  while (controlQueue.length > 0) {
+    const message = controlQueue[0];
+    if (controlRequiresTransport(message) && !transportCanSend()) {
+      return;
+    }
+    controlQueue.shift();
     try {
       executeControl(message);
     } catch (error) {
       fail(error, message.requestId);
       return;
     }
-  }
-  if (controlQueue.length > 0) {
-    return;
   }
 
   if (latestTick === null || !transportCanSend()) {
@@ -219,22 +240,26 @@ function drainWork() {
   }
 }
 
+function controlRequiresTransport(message) {
+  return message.type === "seek" || message.type === "restart_playback";
+}
+
 function executeControl(message) {
   switch (message.type) {
     case "set_loop_duration":
       validateLoopDuration(message.loopDurationSeconds);
       player.setLoopDurationSeconds(message.loopDurationSeconds);
-      respond(message.requestId, runtimeResult("set_loop_duration"));
+      respond(message.requestId, runtimeState("result", "set_loop_duration"));
       return;
     case "pause":
       player.pause();
       latestTick = null;
-      respond(message.requestId, runtimeResult("pause"));
+      respond(message.requestId, runtimeState("result", "pause"));
       return;
     case "resume":
       player.resume();
       latestTick = null;
-      respond(message.requestId, runtimeResult("resume"));
+      respond(message.requestId, runtimeState("result", "resume"));
       return;
     case "seek": {
       const delta = player.seekDeltaJson(message.time);
@@ -242,7 +267,7 @@ function executeControl(message) {
       if (delta !== undefined && delta !== null) {
         sendDeltaOrThrow(delta);
       }
-      respond(message.requestId, runtimeResult("seek"));
+      respond(message.requestId, runtimeState("result", "seek"));
       return;
     }
     case "restart_playback": {
@@ -251,11 +276,11 @@ function executeControl(message) {
       if (delta !== undefined && delta !== null) {
         sendDeltaOrThrow(delta);
       }
-      respond(message.requestId, runtimeResult("restart_playback"));
+      respond(message.requestId, runtimeState("result", "restart_playback"));
       return;
     }
     default:
-      throw new Error(`unknown mixed retained queued engine command ${message.type}`);
+      throw new Error(`unknown retained queued engine command ${message.type}`);
   }
 }
 
@@ -277,35 +302,77 @@ function sendDeltaOrThrow(json) {
     return;
   }
   if (!transport.send(json)) {
-    throw new Error("mixed retained execution transport became backpressured after work was admitted");
+    throw new Error("retained execution transport became backpressured after work was admitted");
   }
   if (transportMode === EXECUTION_TRANSPORT_SHARED) {
     renderPort.postMessage({ type: "shared_delta" });
   }
 }
 
-function runtimeResult(operation) {
-  return {
-    type: "result",
-    operation,
+function runtimeState(type, operation = undefined) {
+  const state = {
+    type,
     time: player.time(),
     playing: player.isPlaying(),
     nextPatchSequence: "0",
+    ...authoringState(),
+  };
+  if (operation !== undefined) {
+    state.operation = operation;
+  }
+  return state;
+}
+
+function authoringState() {
+  if (authoringKind === AUTHORING_CANONICAL) {
+    return { sceneSpecJson: player.sceneSpecJson() };
+  }
+  return {
     sceneJson: player.legacySceneJson(),
     retainedDocumentJson: player.retainedDocumentJson(),
   };
 }
 
+function validateAuthoringInput(message) {
+  const hasCanonical =
+    typeof message.sceneSpecJson === "string" && message.sceneSpecJson.trim() !== "";
+  const hasLegacyScene =
+    typeof message.sceneJson === "string" && message.sceneJson.trim() !== "";
+  const hasRetainedDocument =
+    typeof message.retainedDocumentJson === "string" &&
+    message.retainedDocumentJson.trim() !== "";
+
+  if (hasCanonical) {
+    if (message.sceneJson !== undefined || message.retainedDocumentJson !== undefined) {
+      throw new Error("retained execution init must not mix canonical and compatibility inputs");
+    }
+    return { kind: AUTHORING_CANONICAL, sceneSpecJson: message.sceneSpecJson };
+  }
+  if (hasLegacyScene && hasRetainedDocument) {
+    return {
+      kind: AUTHORING_COMPATIBILITY,
+      sceneJson: message.sceneJson,
+      retainedDocumentJson: message.retainedDocumentJson,
+    };
+  }
+  throw new Error(
+    "retained execution init requires sceneSpecJson or the complete legacy scene + retained document pair",
+  );
+}
+
 function respond(requestId, payload) {
   if (!Number.isSafeInteger(requestId) || requestId < 0) {
-    throw new Error("mixed retained engine request ID must be a non-negative safe integer");
+    throw new Error("retained engine request ID must be a non-negative safe integer");
   }
   postMain({ requestId, ...payload });
 }
 
 function fail(error, requestId) {
-  stopped = true;
   const message = String(error?.message ?? error);
+  if (fatalErrorMessage === null) {
+    fatalErrorMessage = message;
+  }
+  stopped = true;
   renderPort?.postMessage({ type: "render_error", message });
   postMain({ type: "error", requestId, message });
 }
@@ -325,18 +392,18 @@ function validateMainMessage(message) {
     message.channel !== ENGINE_CHANNEL ||
     message.protocolVersion !== ENGINE_PROTOCOL_VERSION
   ) {
-    throw new Error("invalid mixed retained execution engine control envelope");
+    throw new Error("invalid retained execution engine control envelope");
   }
 }
 
 function validateLoopDuration(duration) {
   if (!Number.isFinite(duration) || duration <= 0) {
-    throw new Error("mixed retained execution loop duration must be positive and finite");
+    throw new Error("retained execution loop duration must be positive and finite");
   }
 }
 
 function requireInitialized() {
   if (!initialized || player === null) {
-    throw new Error("mixed retained execution engine worker is not initialized");
+    throw new Error("retained execution engine worker is not initialized");
   }
 }

--- a/web/retained-execution-worker-client.js
+++ b/web/retained-execution-worker-client.js
@@ -10,6 +10,9 @@ const ENGINE_PROTOCOL_VERSION = 1;
 const RENDER_CHANNEL = "noon.render";
 const RENDER_PROTOCOL_VERSION = 1;
 const RETAINED_AUTHORING_CHANNEL = "noon.authoring.retained";
+const SCENE_SPEC_VERSION = 1;
+const AUTHORING_CANONICAL = "canonical";
+const AUTHORING_COMPATIBILITY = "compatibility";
 const DEFAULT_SHARED_SLOT_CAPACITY = 1024 * 1024;
 
 export class RetainedExecutionWorkerClient {
@@ -19,8 +22,7 @@ export class RetainedExecutionWorkerClient {
   #nextRequestId = 0;
   #pending = new Map();
   #session = 0;
-  #sceneJson = null;
-  #retainedDocumentJson = null;
+  #authoring = null;
   #loopDurationSeconds = 4;
   #transportMode = null;
   #sharedSlotCapacity = DEFAULT_SHARED_SLOT_CAPACITY;
@@ -57,13 +59,36 @@ export class RetainedExecutionWorkerClient {
   get diagnostics() {
     return Object.freeze({
       session: this.#session,
+      authoring: this.#authoring?.kind ?? null,
       staleWorkerEvents: Object.freeze({ ...this.#staleWorkerEvents }),
     });
   }
 
-  async start(
-    sceneJson,
-    retainedDocumentJson,
+  /// Compatibility entry point for the transitional split authoring payload.
+  async start(sceneJson, retainedDocumentJson, options = {}) {
+    validateLegacySceneJson(sceneJson);
+    validateRetainedDocumentJson(retainedDocumentJson);
+    return this.#startAuthoring(
+      Object.freeze({
+        kind: AUTHORING_COMPATIBILITY,
+        sceneJson,
+        retainedDocumentJson,
+      }),
+      options,
+    );
+  }
+
+  /// Canonical retained startup. Browser execution after #367 should use this path.
+  async startCanonical(sceneSpecJson, options = {}) {
+    validateSceneSpecJson(sceneSpecJson);
+    return this.#startAuthoring(
+      Object.freeze({ kind: AUTHORING_CANONICAL, sceneSpecJson }),
+      options,
+    );
+  }
+
+  async #startAuthoring(
+    authoring,
     {
       loopDurationSeconds = 4,
       transportMode = selectExecutionTransportMode(),
@@ -73,9 +98,9 @@ export class RetainedExecutionWorkerClient {
     if (this.#engineWorker !== null || this.#renderWorker !== null) {
       throw new Error("RetainedExecutionWorkerClient is already started");
     }
-    validateLegacySceneJson(sceneJson);
-    validateRetainedDocumentJson(retainedDocumentJson);
+    validateAuthoringPayload(authoring);
     validateLoopDurationSeconds(loopDurationSeconds);
+    validateSharedSlotCapacity(sharedSlotCapacity);
     if (
       transportMode !== EXECUTION_TRANSPORT_SHARED &&
       transportMode !== EXECUTION_TRANSPORT_TRANSFERABLE
@@ -92,8 +117,7 @@ export class RetainedExecutionWorkerClient {
       throw new Error("OffscreenCanvas transfer is unavailable in this browser");
     }
 
-    this.#sceneJson = sceneJson;
-    this.#retainedDocumentJson = retainedDocumentJson;
+    this.#authoring = authoring;
     this.#loopDurationSeconds = loopDurationSeconds;
     this.#transportMode = transportMode;
     this.#sharedSlotCapacity = sharedSlotCapacity;
@@ -112,7 +136,7 @@ export class RetainedExecutionWorkerClient {
       canvasTransferred = true;
       this.#engineWorker = new Worker(
         new URL("./retained-execution-engine-worker.js", import.meta.url),
-        { type: "module", name: "noon-mixed-retained-engine" },
+        { type: "module", name: "noon-retained-engine" },
       );
       this.#renderWorker = new Worker(
         new URL("./retained-execution-render-worker.js", import.meta.url),
@@ -138,18 +162,7 @@ export class RetainedExecutionWorkerClient {
         }),
         [offscreen, channel.port2],
       );
-      this.#engineWorker.postMessage(
-        engineEnvelope("init", {
-          port: channel.port1,
-          sceneJson,
-          retainedDocumentJson,
-          loopDurationSeconds,
-          transportMode,
-          sharedSlotCapacity,
-          session: this.#session,
-        }),
-        [channel.port1],
-      );
+      this.#postEngineInit(this.#engineWorker, channel.port1);
       const ready = await this.#ready;
       this.#playing = true;
       this.#fatalOwner = null;
@@ -227,11 +240,7 @@ export class RetainedExecutionWorkerClient {
   }
 
   async restart({ failedOwner = this.#fatalOwner } = {}) {
-    if (
-      this.#sceneJson === null ||
-      this.#retainedDocumentJson === null ||
-      this.#transportMode === null
-    ) {
+    if (this.#authoring === null || this.#transportMode === null) {
       throw new Error("RetainedExecutionWorkerClient has not been started");
     }
     if (failedOwner !== null && failedOwner !== "engine" && failedOwner !== "render") {
@@ -265,7 +274,7 @@ export class RetainedExecutionWorkerClient {
     this.#session = checkedNext(this.#session, "mixed retained execution session");
     this.#engineWorker = new Worker(
       new URL("./retained-execution-engine-worker.js", import.meta.url),
-      { type: "module", name: "noon-mixed-retained-engine" },
+      { type: "module", name: "noon-retained-engine" },
     );
     const engineReady = this.#workerReady(this.#engineWorker, ENGINE_CHANNEL, "engine");
     const nextReady = Promise.all([engineReady, renderAttached]).then(([engine, render]) => ({
@@ -275,18 +284,7 @@ export class RetainedExecutionWorkerClient {
       session: this.#session,
     }));
     this.#ready = nextReady;
-    this.#engineWorker.postMessage(
-      engineEnvelope("init", {
-        port: channel.port1,
-        sceneJson: this.#sceneJson,
-        retainedDocumentJson: this.#retainedDocumentJson,
-        loopDurationSeconds: this.#loopDurationSeconds,
-        transportMode: this.#transportMode,
-        sharedSlotCapacity: this.#sharedSlotCapacity,
-        session: this.#session,
-      }),
-      [channel.port1],
-    );
+    this.#postEngineInit(this.#engineWorker, channel.port1);
 
     const ready = await nextReady;
     this.#playing = true;
@@ -298,8 +296,7 @@ export class RetainedExecutionWorkerClient {
   }
 
   async #restartAll() {
-    const sceneJson = this.#sceneJson;
-    const retainedDocumentJson = this.#retainedDocumentJson;
+    const authoring = this.#authoring;
     const loopDurationSeconds = this.#loopDurationSeconds;
     const transportMode = this.#transportMode;
     const sharedSlotCapacity = this.#sharedSlotCapacity;
@@ -308,7 +305,7 @@ export class RetainedExecutionWorkerClient {
       this.terminate();
       this.#canvas = replaceExecutionCanvas(this.#canvas);
     }
-    const ready = await this.start(sceneJson, retainedDocumentJson, {
+    const ready = await this.#startAuthoring(authoring, {
       loopDurationSeconds,
       transportMode,
       sharedSlotCapacity,
@@ -332,6 +329,23 @@ export class RetainedExecutionWorkerClient {
     }
     this.#pending.clear();
     this.#fatalOwner = null;
+  }
+
+  #postEngineInit(worker, port) {
+    if (this.#authoring === null) {
+      throw new Error("retained execution authoring payload is unavailable");
+    }
+    worker.postMessage(
+      engineEnvelope("init", {
+        port,
+        ...authoringWirePayload(this.#authoring),
+        loopDurationSeconds: this.#loopDurationSeconds,
+        transportMode: this.#transportMode,
+        sharedSlotCapacity: this.#sharedSlotCapacity,
+        session: this.#session,
+      }),
+      [port],
+    );
   }
 
   async #requestEngine(type, payload, transfer = []) {
@@ -531,6 +545,50 @@ function validateWorkerEnvelope(message, channel) {
   }
 }
 
+function validateAuthoringPayload(authoring) {
+  if (authoring?.kind === AUTHORING_CANONICAL) {
+    validateSceneSpecJson(authoring.sceneSpecJson);
+    return;
+  }
+  if (authoring?.kind === AUTHORING_COMPATIBILITY) {
+    validateLegacySceneJson(authoring.sceneJson);
+    validateRetainedDocumentJson(authoring.retainedDocumentJson);
+    return;
+  }
+  throw new TypeError("unsupported retained execution authoring payload");
+}
+
+function authoringWirePayload(authoring) {
+  if (authoring.kind === AUTHORING_CANONICAL) {
+    return { sceneSpecJson: authoring.sceneSpecJson };
+  }
+  return {
+    sceneJson: authoring.sceneJson,
+    retainedDocumentJson: authoring.retainedDocumentJson,
+  };
+}
+
+function validateSceneSpecJson(sceneSpecJson) {
+  if (typeof sceneSpecJson !== "string" || sceneSpecJson.trim() === "") {
+    throw new TypeError("canonical SceneSpec must be non-empty JSON text");
+  }
+  let document;
+  try {
+    document = JSON.parse(sceneSpecJson);
+  } catch (error) {
+    throw new TypeError(`canonical SceneSpec must be valid JSON: ${error}`);
+  }
+  if (!document || typeof document !== "object" || Array.isArray(document)) {
+    throw new TypeError("canonical SceneSpec must decode to an object");
+  }
+  if (document.version !== SCENE_SPEC_VERSION) {
+    throw new TypeError(`unsupported canonical SceneSpec version ${document.version}`);
+  }
+  if (!Array.isArray(document.objects) || !Array.isArray(document.tracks)) {
+    throw new TypeError("canonical SceneSpec must contain objects and tracks arrays");
+  }
+}
+
 function validateLegacySceneJson(sceneJson) {
   if (typeof sceneJson !== "string" || sceneJson.trim() === "") {
     throw new TypeError("legacy scene must be non-empty JSON text");
@@ -566,6 +624,13 @@ function validateLoopDurationSeconds(loopDurationSeconds) {
     throw new TypeError("mixed retained loop duration must be positive and finite");
   }
   return loopDurationSeconds;
+}
+
+function validateSharedSlotCapacity(sharedSlotCapacity) {
+  if (!Number.isSafeInteger(sharedSlotCapacity) || sharedSlotCapacity <= 0) {
+    throw new TypeError("mixed retained shared slot capacity must be a positive safe integer");
+  }
+  return sharedSlotCapacity;
 }
 
 function validateSeekTimeSeconds(timeSeconds, loopDurationSeconds) {


### PR DESCRIPTION
## Summary

- add canonical `RetainedExecutionWorkerClient.startCanonical(sceneSpecJson, ...)` while keeping the old split `start(sceneJson, retainedDocumentJson, ...)` as an explicit compatibility entry point
- store one immutable authoring descriptor so initial startup, engine-only reconnect, and full render recovery share the same lifecycle path
- make `retained-execution-engine-worker.js` instantiate `CanonicalRetainedEngineScenePlayer` for canonical sessions and reject ambiguous mixed payloads
- return only `sceneSpecJson` from canonical worker state/control results; the legacy scene + retained sidecar pair remains confined to compatibility sessions
- migrate the retained worker smoke to canonical startup across transferable/shared transports, engine reconnect, and full render recovery, while retaining one lightweight split-payload compatibility check
- add that retained worker smoke to PR Fast Gate so this transport boundary is exercised end-to-end on every PR

## Architecture

```text
canonical authoring
    sceneSpecJson
         |
         v
RetainedExecutionWorkerClient
  immutable authoring descriptor
         |
         v
retained engine worker
         |
CanonicalRetainedEngineScenePlayer
         |
 retained resources + frame deltas
```

The compatibility path is deliberately isolated rather than propagated through recovery logic. The next #367 slice can switch the general `ExecutionWorkerClient` / `AuthoringExecutionClient` / playground routing to `sceneSpec`, after which normal browser authoring no longer needs `retainedDocument` and the split worker/player entry points can be retired.

Tracks #367. Follows #785.