### PR TITLE
Align PR WASM cache keys with master seed

### DIFF
--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -13,7 +13,6 @@ concurrency:
 env:
   CARGO_INCREMENTAL: "0"
   CARGO_PROFILE_DEV_DEBUG: "0"
-  CARGO_PROFILE_TEST_DEBUG: "0"
   RUSTC_WRAPPER: sccache
   SCCACHE_GHA_ENABLED: "true"
   SCCACHE_GHA_RW_MODE: "READ_ONLY"
@@ -22,6 +21,8 @@ jobs:
   rust-lint:
     name: Rust format and lint
     runs-on: ubuntu-latest
+    env:
+      CARGO_PROFILE_TEST_DEBUG: "0"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -55,6 +56,8 @@ jobs:
   rust-test:
     name: Rust unit tests
     runs-on: ubuntu-latest
+    env:
+      CARGO_PROFILE_TEST_DEBUG: "0"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -31,6 +31,8 @@ This archive boundary is intentional. The per-object GHA backend successfully re
 
 The WASM archive is capped at 1 GiB. Seed runs are non-cancelling so rapid master merges cannot abort the only archive writer in progress; newer relevant master pushes may queue another seed. Main CI and specialized validators are consumers rather than WASM archive owners.
 
+When changing compiler-cache policy, validate it with a source-neutral pull request after a default-branch seed has completed so cache transport behavior is measured independently from source invalidation.
+
 ## Main CI workflow
 
 `.github/workflows/ci.yml` runs on pushes to `master` and manual dispatch. It is the full Linux integration workflow rather than the pull-request inner loop.


### PR DESCRIPTION
## Summary
- keep `CARGO_PROFILE_TEST_DEBUG=0` scoped to the Rust lint/test jobs that actually need the test-profile override
- remove that irrelevant `CARGO_*` variable from the browser job so its sccache key environment exactly matches the master WASM seed
- retain the source-neutral CI-policy note documenting how compiler-cache changes should be measured

## Root cause
#787 fixed archive transport: the PR restored the exact ~297 MiB master archive in ~2 s. But the first source-neutral probe still saw **0/315** compiler hits.

A control rerun of the exact same master seed on the exact same SHA restored the same archive and got **315/315 hits (100%)**, reducing Rust WASM compilation to ~26 s. Comparing job environments exposed the mismatch: PR Fast Gate globally set `CARGO_PROFILE_TEST_DEBUG=0`, while the WASM seed did not. sccache hashes `CARGO_*` environment variables into Rust cache keys, so a test-only setting was invalidating every browser compiler object.

The clean fix is to scope the test-profile override to the Rust jobs rather than teaching the browser/seed lanes about an unrelated test setting.

## Validation
The updated PR remains Rust-source-neutral and is based on the seeded master archive. The decisive signal is the browser lane: restore the exact default-branch archive, report high/complete sccache hits, and measure total wall time against the <=120 s target.

Tracks #731.