### PR TITLE
Fix native text descent bounds

### DIFF
--- a/crates/noon-text-native/src/lib.rs
+++ b/crates/noon-text-native/src/lib.rs
@@ -224,10 +224,10 @@ impl NativeTextCompiler {
                         },
                         origin,
                         advance,
-                        // Exact outlines remain lazy. The line-box bound is conservative
-                        // and sufficient for semantic layout until exact ink metrics land.
+                        // Swash reports descent as a positive distance below the baseline;
+                        // retained Y coordinates use negative values below the baseline.
                         bounds: Rect::new(
-                            Vec2::new(origin.x.min(right), metrics.descent),
+                            Vec2::new(origin.x.min(right), -metrics.descent),
                             Vec2::new(origin.x.max(right), metrics.ascent),
                         ),
                     });
@@ -241,7 +241,7 @@ impl NativeTextCompiler {
                 Rect::new(Vec2::ZERO, Vec2::ZERO)
             } else {
                 Rect::new(
-                    Vec2::new(0.0_f32.min(cursor_x), metrics.descent + baseline_y),
+                    Vec2::new(0.0_f32.min(cursor_x), -metrics.descent + baseline_y),
                     Vec2::new(0.0_f32.max(cursor_x), metrics.ascent + baseline_y),
                 )
             };

--- a/crates/noon-text-native/tests/metrics.rs
+++ b/crates/noon-text-native/tests/metrics.rs
@@ -1,0 +1,29 @@
+use std::sync::Arc;
+
+use noon_text_native::{NativeFontFace, NativeTextCompiler, NativeTextOptions};
+
+fn bundled_font() -> NativeFontFace {
+    let bytes = typst_assets::fonts()
+        .next()
+        .expect("Typst test assets include at least one font");
+    NativeFontFace::new("Bundled Test Font", Arc::<[u8]>::from(bytes), 0).unwrap()
+}
+
+#[test]
+fn conservative_native_glyph_bounds_extend_below_the_baseline() {
+    let font = bundled_font();
+    let mut compiler = NativeTextCompiler::new();
+    let artifact = compiler
+        .compile_plain("Hg", &font, &NativeTextOptions::new(48.0))
+        .unwrap();
+    let run = artifact.resource.runs.first().expect("one shaped line");
+
+    assert!(!run.glyphs.is_empty());
+    for glyph in run.glyphs.iter() {
+        assert!(
+            glyph.bounds.min.y < 0.0,
+            "descent is a positive metric distance but must map below the baseline"
+        );
+        assert!(glyph.bounds.max.y > 0.0);
+    }
+}


### PR DESCRIPTION
## Summary

Correct native-text conservative vertical bounds so Swash descent distances map below the retained baseline instead of above it.

## Changes

- map `metrics.descent` to negative retained Y for per-glyph conservative bounds;
- apply the same convention to line bounds;
- add a focused `Hg` regression test that requires every conservative glyph bound to extend below and above the baseline.

## Why this slice

While tracing the backend-independent `ShrinkToCenter(Text(...))` raster mismatch, the same text bounds discrepancy appears under both WebGPU and WebGL while the rectangle control passes. Current master still fed Swash's positive descent distance directly into retained Y coordinates, vertically inverting the lower line-box edge. This is independent of the active Axes, family-animation, SceneSpec, and CI-cache work.

The change is intentionally limited to the native text metric contract; it does not pull in the older diagnostic branch's font defaults, browser harness changes, worker instrumentation, or raster-threshold experiments.

## Validation

- branch is exactly one commit ahead of `be8d27c23416bea2a9edf3e2a0932602722dd552`;
- diff is limited to `crates/noon-text-native/src/lib.rs` and the focused `tests/metrics.rs` regression;
- the same isolated metric/test change previously compiled through the retained-text validation path far enough to reach browser raster checks.

## Remaining risk

This fixes the incorrect native text vertical-bounds convention. It may reduce the early-frame raster bounds mismatch, but the final `ShrinkToCenter(Text)` presence mismatch can still be a separate lifecycle/timing issue and is not claimed fixed here.