### PR TITLE
Expose retained Axes parametric curves through shared sampling

### DIFF
--- a/crates/noon-web/src/manim_plot_bridge.rs
+++ b/crates/noon-web/src/manim_plot_bridge.rs
@@ -206,11 +206,7 @@ impl AxesPlotAuthoringPlan {
         let values = parse_parametric_callback_values(values_json)?;
         let x_axis = parse_axis_snapshot(x_axis_snapshot_json, "x")?;
         let y_axis = parse_axis_snapshot(y_axis_snapshot_json, "y")?;
-        serialize_snapshot(&self.finish_parametric_values_with_axes(
-            &values,
-            &x_axis,
-            &y_axis,
-        )?)
+        serialize_snapshot(&self.finish_parametric_values_with_axes(&values, &x_axis, &y_axis)?)
     }
 
     fn transformed_axes(

--- a/crates/noon-web/src/manim_plot_bridge.rs
+++ b/crates/noon-web/src/manim_plot_bridge.rs
@@ -1,10 +1,10 @@
 use noon::{
-    axes_sampled_values_vector_path, transformed_axes_sampled_values_vector_path, Axes2DState,
-    CoordinateSystemError, IntoSnapshot, NumberRange, ParametricSamplePlan, Path,
-    PlotGeometryError, PlotRangeRequest, PlotSamplingError, SampleRange, TransformedAxes2DState,
-    MANIM_DEFAULT_DISCONTINUITY_DT,
+    axes_sampled_values_vector_path, parametric_vector_path,
+    transformed_axes_sampled_values_vector_path, Axes2DState, CoordinateSystemError, IntoSnapshot,
+    NumberRange, ParametricSamplePlan, Path, PlotGeometryError, PlotRangeRequest,
+    PlotSamplingError, SampleRange, TransformedAxes2DState, MANIM_DEFAULT_DISCONTINUITY_DT,
 };
-use noon_core::{GeometryRef, ObjectSnapshot};
+use noon_core::{GeometryRef, ObjectSnapshot, Vec2};
 use serde::Deserialize;
 
 #[derive(Clone, Debug, Deserialize, PartialEq)]
@@ -31,13 +31,13 @@ const fn default_true() -> bool {
     true
 }
 
-/// Two-phase browser authoring plan for ManimCE v0.21 `Axes.plot`.
+/// Two-phase browser authoring plan for ManimCE v0.21 Axes graphing.
 ///
-/// Rust owns every deterministic semantic rule: axis construction, plot-range
+/// Rust owns every deterministic semantic rule: axis construction, parameter-range
 /// interpretation, parameter generation, discontinuity splitting, callback-result
 /// cardinality, coordinate mapping, smoothing, and final `ObjectSnapshot` creation.
-/// The host language receives only the parameter values it must pass to the user's
-/// callback and returns exactly one scalar result per parameter.
+/// The host receives only parameters to evaluate and returns either one scalar y value
+/// (`Axes.plot`) or one axis-coordinate pair (`Axes.plot_parametric_curve`) per parameter.
 #[derive(Clone, Debug, PartialEq)]
 pub struct AxesPlotAuthoringPlan {
     axes: Axes2DState,
@@ -104,27 +104,79 @@ impl AxesPlotAuthoringPlan {
         Ok(Path::new(path).into_snapshot())
     }
 
-    /// Finish against the current retained x/y-axis snapshots.
-    ///
-    /// Only each snapshot's affine transform participates in coordinate mapping;
-    /// the geometry kind is validated so callers cannot accidentally bind plotting
-    /// semantics to an unrelated retained mobject.
+    /// Finish scalar `Axes.plot` callback values against current retained axis state.
     pub fn finish_values_with_axes(
         &self,
         values: &[Vec<f64>],
         x_axis: &ObjectSnapshot,
         y_axis: &ObjectSnapshot,
     ) -> Result<ObjectSnapshot, ManimPlotBridgeError> {
-        ensure_axis_line(x_axis, "x")?;
-        ensure_axis_line(y_axis, "y")?;
-        let transformed =
-            TransformedAxes2DState::new(self.axes, x_axis.transform, y_axis.transform);
+        let transformed = self.transformed_axes(x_axis, y_axis)?;
         let path = transformed_axes_sampled_values_vector_path(
             transformed,
             &self.samples,
             values,
             self.use_smoothing,
         )?;
+        Ok(Path::new(path).into_snapshot())
+    }
+
+    /// Finish vector-valued parametric callback samples against current Axes state.
+    pub fn finish_parametric_values_with_axes(
+        &self,
+        values: &[Vec<[f64; 2]>],
+        x_axis: &ObjectSnapshot,
+        y_axis: &ObjectSnapshot,
+    ) -> Result<ObjectSnapshot, ManimPlotBridgeError> {
+        let transformed = self.transformed_axes(x_axis, y_axis)?;
+        let parameter_subpaths = self.samples.parameter_subpaths()?;
+        if values.len() != parameter_subpaths.len() {
+            return Err(PlotGeometryError::SampleSubpathCountMismatch {
+                expected: parameter_subpaths.len(),
+                actual: values.len(),
+            }
+            .into());
+        }
+
+        let mut scene_subpaths = Vec::with_capacity(parameter_subpaths.len());
+        for (subpath, (parameters, coordinates)) in
+            parameter_subpaths.iter().zip(values).enumerate()
+        {
+            if coordinates.len() != parameters.len() {
+                return Err(PlotGeometryError::SampleValueCountMismatch {
+                    subpath,
+                    expected: parameters.len(),
+                    actual: coordinates.len(),
+                }
+                .into());
+            }
+            let mut scene_points = Vec::with_capacity(parameters.len());
+            for (&parameter, &[x, y]) in parameters.iter().zip(coordinates) {
+                if !x.is_finite() || !y.is_finite() {
+                    return Err(PlotGeometryError::NonFinitePoint {
+                        parameter,
+                        point: Vec2::new(x as f32, y as f32),
+                    }
+                    .into());
+                }
+                scene_points.push(transformed.coords_to_point(x, y)?);
+            }
+            scene_subpaths.push(scene_points);
+        }
+
+        // `parametric_vector_path` remains the single shared owner of subpath construction
+        // and smoothing. Cardinality is validated above, so this iterator is exact by design.
+        let mut scene_points = scene_subpaths.iter().flatten().copied();
+        let path = parametric_vector_path(
+            &self.samples,
+            |_| {
+                scene_points
+                    .next()
+                    .expect("validated parametric callback cardinality")
+            },
+            self.use_smoothing,
+        )?;
+        debug_assert!(scene_points.next().is_none());
         Ok(Path::new(path).into_snapshot())
     }
 
@@ -144,9 +196,46 @@ impl AxesPlotAuthoringPlan {
         let y_axis = parse_axis_snapshot(y_axis_snapshot_json, "y")?;
         serialize_snapshot(&self.finish_values_with_axes(&values, &x_axis, &y_axis)?)
     }
+
+    pub fn finish_parametric_snapshot_json_with_axes(
+        &self,
+        values_json: &str,
+        x_axis_snapshot_json: &str,
+        y_axis_snapshot_json: &str,
+    ) -> Result<String, ManimPlotBridgeError> {
+        let values = parse_parametric_callback_values(values_json)?;
+        let x_axis = parse_axis_snapshot(x_axis_snapshot_json, "x")?;
+        let y_axis = parse_axis_snapshot(y_axis_snapshot_json, "y")?;
+        serialize_snapshot(&self.finish_parametric_values_with_axes(
+            &values,
+            &x_axis,
+            &y_axis,
+        )?)
+    }
+
+    fn transformed_axes(
+        &self,
+        x_axis: &ObjectSnapshot,
+        y_axis: &ObjectSnapshot,
+    ) -> Result<TransformedAxes2DState, ManimPlotBridgeError> {
+        ensure_axis_line(x_axis, "x")?;
+        ensure_axis_line(y_axis, "y")?;
+        Ok(TransformedAxes2DState::new(
+            self.axes,
+            x_axis.transform,
+            y_axis.transform,
+        ))
+    }
 }
 
 fn parse_callback_values(values_json: &str) -> Result<Vec<Vec<f64>>, ManimPlotBridgeError> {
+    serde_json::from_str(values_json)
+        .map_err(|error| ManimPlotBridgeError::InvalidCallbackValues(error.to_string()))
+}
+
+fn parse_parametric_callback_values(
+    values_json: &str,
+) -> Result<Vec<Vec<[f64; 2]>>, ManimPlotBridgeError> {
     serde_json::from_str(values_json)
         .map_err(|error| ManimPlotBridgeError::InvalidCallbackValues(error.to_string()))
 }
@@ -193,28 +282,28 @@ pub enum ManimPlotBridgeError {
 impl std::fmt::Display for ManimPlotBridgeError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::InvalidRequest(error) => write!(formatter, "invalid Axes.plot request: {error}"),
+            Self::InvalidRequest(error) => write!(formatter, "invalid Axes plot request: {error}"),
             Self::InvalidCallbackValues(error) => {
-                write!(formatter, "invalid Axes.plot callback values: {error}")
+                write!(formatter, "invalid Axes plot callback values: {error}")
             }
             Self::InvalidPlotRangeLength(length) => write!(
                 formatter,
-                "Axes.plot x_range must contain 2 or 3 values, got {length}"
+                "Axes plot range must contain 2 or 3 values, got {length}"
             ),
             Self::InvalidAxisSnapshot { axis, error } => {
-                write!(formatter, "invalid Axes.plot {axis}-axis snapshot: {error}")
+                write!(formatter, "invalid Axes plot {axis}-axis snapshot: {error}")
             }
             Self::InvalidAxisGeometry(axis) => {
                 write!(
                     formatter,
-                    "Axes.plot {axis}-axis snapshot must contain line geometry"
+                    "Axes plot {axis}-axis snapshot must contain line geometry"
                 )
             }
             Self::Coordinates(error) => error.fmt(formatter),
             Self::Sampling(error) => error.fmt(formatter),
             Self::Geometry(error) => error.fmt(formatter),
             Self::Serialization(error) => {
-                write!(formatter, "unable to serialize Axes.plot state: {error}")
+                write!(formatter, "unable to serialize Axes plot state: {error}")
             }
         }
     }
@@ -281,6 +370,22 @@ mod wasm {
         ) -> Result<String, JsValue> {
             self.0
                 .finish_snapshot_json_with_axes(
+                    values_json,
+                    x_axis_snapshot_json,
+                    y_axis_snapshot_json,
+                )
+                .map_err(js_error)
+        }
+
+        #[wasm_bindgen(js_name = finishParametricSnapshotJsonWithAxes)]
+        pub fn finish_parametric_snapshot_json_with_axes(
+            &self,
+            values_json: &str,
+            x_axis_snapshot_json: &str,
+            y_axis_snapshot_json: &str,
+        ) -> Result<String, JsValue> {
+            self.0
+                .finish_parametric_snapshot_json_with_axes(
                     values_json,
                     x_axis_snapshot_json,
                     y_axis_snapshot_json,
@@ -384,6 +489,42 @@ mod tests {
     }
 
     #[test]
+    fn parametric_callback_values_use_current_axis_state() {
+        let plan = AxesPlotAuthoringPlan::from_json(&request_json("[-1.0,1.0,1.0]", "null", false))
+            .unwrap();
+        let transform = Transform2D {
+            translation: Vec2::new(-1.5, 2.0),
+            rotation: -0.25,
+            scale: Vec2::new(0.75, 0.75),
+        };
+        let x_axis = axis_snapshot(&plan, true, transform);
+        let y_axis = axis_snapshot(&plan, false, transform);
+        let snapshot = plan
+            .finish_parametric_values_with_axes(
+                &[vec![[-1.0, 0.5], [0.0, -0.5], [1.0, 0.5]]],
+                &x_axis,
+                &y_axis,
+            )
+            .unwrap();
+        let GeometryRef::VectorPath(path) = snapshot.geometry else {
+            panic!("Axes.plot_parametric_curve must lower to ordinary VectorPath geometry");
+        };
+        let expected = [
+            transform.transform_point(Vec2::new(-1.0, 0.5)),
+            transform.transform_point(Vec2::new(0.0, -0.5)),
+            transform.transform_point(Vec2::new(1.0, 0.5)),
+        ];
+        for (command, expected) in path.commands().iter().zip(expected) {
+            match command {
+                PathCommand::MoveTo { to } | PathCommand::LineTo { to } => {
+                    assert!((*to - expected).length() <= 1.0e-5)
+                }
+                other => panic!("expected corner path command, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
     fn non_line_axis_snapshot_is_rejected() {
         let plan = AxesPlotAuthoringPlan::from_json(&request_json("[-1.0,1.0,1.0]", "null", false))
             .unwrap();
@@ -402,6 +543,21 @@ mod tests {
         let plan = AxesPlotAuthoringPlan::from_json(&request_json("[-1.0,1.0,1.0]", "null", false))
             .unwrap();
         let error = plan.finish_values(&[vec![0.0]]).unwrap_err();
+        assert!(matches!(
+            error,
+            ManimPlotBridgeError::Geometry(PlotGeometryError::SampleValueCountMismatch {
+                subpath: 0,
+                expected: 3,
+                actual: 1,
+            })
+        ));
+        let error = plan
+            .finish_parametric_values_with_axes(
+                &[vec![[0.0, 0.0]]],
+                &axis_snapshot(&plan, true, Transform2D::IDENTITY),
+                &axis_snapshot(&plan, false, Transform2D::IDENTITY),
+            )
+            .unwrap_err();
         assert!(matches!(
             error,
             ManimPlotBridgeError::Geometry(PlotGeometryError::SampleValueCountMismatch {

--- a/scripts/manim-axes-smoke.mjs
+++ b/scripts/manim-axes-smoke.mjs
@@ -249,6 +249,54 @@ class RetainedAxesPlot(Scene):
         cos_point = axes.input_to_graph_point(0.25, cos_graph)
         assert_point_close(cos_point, axes.c2p(0.25, math.cos(0.25)))
 
+        parametric_calls = []
+
+        def parametric_fn(t):
+            parametric_calls.append(float(t))
+            return [math.cos(t), math.sin(t), 42.0]
+
+        parametric = axes.plot_parametric_curve(
+            parametric_fn,
+            t_range=[0.0, math.pi, math.pi / 2.0],
+            use_smoothing=False,
+            color=PURPLE,
+        )
+        assert isinstance(parametric, ParametricFunction)
+        assert len(parametric_calls) == 3
+        for actual, expected in zip(
+            parametric_calls, [0.0, math.pi / 2.0, math.pi]
+        ):
+            assert_close(actual, expected)
+        assert_close(parametric.t_min, 0.0)
+        assert_close(parametric.t_max, math.pi)
+        parametric_handle = _handles._handle_for(parametric)
+        assert parametric_handle is not None
+        parametric_snapshot = json.loads(str(parametric_handle.snapshotJson()))
+        parametric_commands = parametric_snapshot["geometry"]["vector_path"]["commands"]
+        assert len(parametric_commands) == 3
+        parametric_expected = [
+            axes.c2p(1.0, 0.0),
+            axes.c2p(0.0, 1.0),
+            axes.c2p(-1.0, 0.0),
+        ]
+        for command, expected in zip(parametric_commands, parametric_expected):
+            payload = command.get("move_to") or command.get("line_to")
+            assert payload is not None, command
+            actual = payload["to"]
+            assert_close(actual["x"], expected.x)
+            assert_close(actual["y"], expected.y)
+        parametric_calls.clear()
+        assert_point_close(
+            parametric.get_point_from_function(math.pi / 2.0),
+            axes.c2p(0.0, 1.0),
+        )
+        assert len(parametric_calls) == 1
+        try:
+            axes.plot_parametric_curve(parametric_fn, use_vectorized=True)
+            raise AssertionError("vectorized parametric callbacks must fail explicitly")
+        except NotImplementedError:
+            pass
+
         curve_1_calls = []
         curve_2_calls = []
 
@@ -311,6 +359,7 @@ class RetainedAxesPlot(Scene):
             axes,
             sin_graph,
             cos_graph,
+            parametric,
             vertical,
             horizontal,
             line_graph,
@@ -345,7 +394,7 @@ try {
     axesSource,
   );
   assert.equal(result.kind, "scene_document");
-  assert.equal(result.document.objects.length, 46);
+  assert.equal(result.document.objects.length, 47);
   assert.equal(result.document.tracks.length, 0);
 
   const geometryKinds = result.document.objects.map(
@@ -358,8 +407,8 @@ try {
   );
   assert.equal(
     geometryKinds.filter((kind) => kind === "vector_path").length,
-    6,
-    "Axes plots, line graphs, and area polygons must remain ordinary retained VectorPath geometry",
+    7,
+    "Axes scalar/parametric plots, line graphs, and area polygons must remain ordinary retained VectorPath geometry",
   );
   assert.equal(
     geometryKinds.filter((kind) => kind === "circle").length,
@@ -373,7 +422,7 @@ try {
   );
   assert.deepEqual(errors, [], `browser errors while testing retained Axes:\n${errors.join("\n")}`);
   console.log(
-    "Retained Axes smoke passed: transformed coordinates, authored/generic i2gp, retained projections and plots, line graphs, two-phase Riemann rectangles, and bounded area polygons.",
+    "Retained Axes smoke passed: transformed coordinates, authored/generic i2gp, scalar and parametric plots, line graphs, two-phase Riemann rectangles, and bounded area polygons.",
   );
 } finally {
   await browser?.close();

--- a/web/python/_manim_axes.py
+++ b/web/python/_manim_axes.py
@@ -57,6 +57,26 @@ def _range(value: Sequence[float] | None, default: tuple[float, float, float]) -
     return values
 
 
+def _parametric_range(value: Sequence[float] | None) -> list[float]:
+    values = [0.0, 1.0, 0.01] if value is None else [float(component) for component in value]
+    if len(values) == 2:
+        values.append(0.01)
+    if len(values) != 3 or not all(math.isfinite(component) for component in values):
+        raise ValueError("t_range must contain 2 or 3 finite values")
+    return values
+
+
+def _parametric_coordinates(function: Callable[[float], object], parameter: float) -> list[float]:
+    value = function(float(parameter))
+    try:
+        coordinates = value[:2]  # type: ignore[index]
+    except (TypeError, IndexError) as error:
+        raise TypeError("parametric function must return at least two coordinates") from error
+    if len(coordinates) < 2:
+        raise ValueError("parametric function must return at least two coordinates")
+    return [float(coordinates[0]), float(coordinates[1])]
+
+
 def _rgba(value: object) -> list[float]:
     if not isinstance(value, _base.Color):
         raise TypeError("axis color must be a Noon/Manim Color")
@@ -204,12 +224,10 @@ def _graph_snapshot_json(graph: object, name: str) -> str:
 
 
 class ParametricFunction(_compat.VMobject):
-    """Source-visible retained curve type produced by :meth:`Axes.plot`.
+    """Source-visible retained curve type produced by Axes graphing helpers.
 
-    The current browser slice owns scalar Axes plots through the shared two-phase Rust
-    plan. Direct ParametricFunction authoring needs the more general vector-valued
-    callback plan and therefore fails explicitly rather than constructing a Python-only
-    geometry path.
+    Direct `ParametricFunction` construction remains a separate scene-space callback
+    surface. Axes-owned graphing uses the shared two-phase Rust plan below.
     """
 
     def __init__(self, *args: object, **kwargs: object) -> None:
@@ -782,6 +800,68 @@ class Axes(_compat.VGroup):
         area.set_opacity(float(opacity))
         area.set_color(_color("color", color))
         return area
+
+    def plot_parametric_curve(
+        self,
+        function: Callable[[float], object],
+        use_vectorized: bool = False,
+        **kwargs: Any,
+    ) -> ParametricFunction:
+        if not callable(function):
+            raise TypeError("Axes.plot_parametric_curve function must be callable")
+        if use_vectorized:
+            raise NotImplementedError(
+                "Axes.plot_parametric_curve(use_vectorized=True) requires vectorized callback transport"
+            )
+        t_range = _parametric_range(kwargs.pop("t_range", None))
+        discontinuities = kwargs.pop("discontinuities", None)
+        dt = float(kwargs.pop("dt", 1.0e-8))
+        use_smoothing = bool(kwargs.pop("use_smoothing", True))
+        color = kwargs.pop("color", None)
+        if kwargs:
+            unsupported = ", ".join(sorted(kwargs))
+            raise NotImplementedError(
+                f"unsupported Axes.plot_parametric_curve option(s): {unsupported}"
+            )
+        request = {
+            **self._base_request,
+            "plot_range": t_range,
+            "discontinuities": (
+                None
+                if discontinuities is None
+                else [float(value) for value in discontinuities]
+            ),
+            "discontinuity_dt": dt,
+            "use_smoothing": use_smoothing,
+        }
+        assert _create_plot_plan is not None
+        plan = _create_plot_plan(json.dumps(request, separators=(",", ":"), allow_nan=False))
+        parameters = json.loads(str(plan.parametersJson()))
+        values = [
+            [_parametric_coordinates(function, parameter) for parameter in subpath]
+            for subpath in parameters
+        ]
+        snapshot_json = str(
+            plan.finishParametricSnapshotJsonWithAxes(
+                json.dumps(values, separators=(",", ":"), allow_nan=False),
+                self.x_axis._axis_snapshot_json(),
+                self.y_axis._axis_snapshot_json(),
+            )
+        )
+        graph = object.__new__(ParametricFunction)
+        assert _create_mobject_handle is not None
+        _shared._attach_shared_handle(graph, _create_mobject_handle(snapshot_json))
+        graph.function = lambda value: self.coords_to_point(
+            *_parametric_coordinates(function, float(value))
+        )
+        graph.underlying_function = function
+        graph.t_range = list(t_range)
+        graph.t_min = float(t_range[0])
+        graph.t_max = float(t_range[1])
+        graph.axes = self
+        if color is not None:
+            graph.set_color(_color("color", color))
+        return graph
 
     def plot(
         self,


### PR DESCRIPTION
## Summary
- expose ManimCE v0.21 `Axes.plot_parametric_curve` through the existing shared `AxesPlotAuthoringPlan`; no second sampler, browser authoring store, or renderer primitive
- reuse the exact Rust `ParametricSamplePlan` range/discontinuity/endpoint semantics already qualified by `Axes.plot`
- add one vector-valued finish shape to the existing WASM plan: Python returns only authored `[x, y]` callback values at Rust-requested parameters, then Rust owns current Axes transforms, cardinality validation, smoothing, and retained VectorPath construction
- preserve 2D Axes semantics by consuming only `function(t)[:2]`; additional callback components are ignored as in ManimCE v0.21
- return the same retained `ParametricFunction` family used by `Axes.plot`, with `underlying_function`, `t_range`, `t_min`, and `t_max` metadata
- keep direct `ParametricFunction(...)` construction separate; this slice is specifically the Axes-owned coordinate-mapping path
- keep `use_vectorized=True` explicit/unsupported until vectorized callback transport exists rather than silently emulating different callback semantics

## Browser acceptance
Extends the real transformed-Axes Pyodide/WASM smoke with a three-sample parametric curve:
- authored callback returns `[cos(t), sin(t), 42]`; the third component is deliberately nonzero to prove 2D Axes slices it away
- explicit `t_range=[0, pi, pi/2]` produces exactly three callback evaluations at `0`, `pi/2`, and `pi`
- retained path points match `axes.c2p(1,0)`, `axes.c2p(0,1)`, and `axes.c2p(-1,0)` after the Axes family has already been shifted, scaled, and rotated
- `get_point_from_function` still uses the authored callback and current Axes mapping
- `use_vectorized=True` fails explicitly
- scene remains ordinary retained geometry: 26 lines, 7 vector paths, 4 circles, 10 rectangles; zero tracks

## Architecture
`AxesPlotAuthoringPlan` remains the single deterministic plot sampler. The frontend is a two-phase arbitrary-callback adapter only: Rust emits parameter subpaths, Python evaluates user code, and Rust consumes the values to build canonical retained geometry. There is no Python sampling loop independent of the Rust plan and no parametric-curve-specific renderer state.

## Exact-head qualification
Exact head `6c3729c6e70871a0be394a11d09f569daf032469` passed PR Fast Gate run `33525549720`: Rust formatting + Clippy, Rust unit tests, web static/unit checks, and all browser fast checks succeeded, including retained Axes plotting, lazy namespace dependencies, literal PlotExample, and primary WebGPU rendering.

Stacked on #789.

Tracks #85 / #253.