### PR TITLE
Validate legacy Scene semantic IDs

### DIFF
--- a/web/authoring-client.js
+++ b/web/authoring-client.js
@@ -285,6 +285,9 @@ export function validateSceneDocument(scene) {
   if (!Array.isArray(scene.tracks)) {
     throw new Error("Python Scene tracks must be an array");
   }
+
+  validateDefinitionIds("object", scene.objects);
+  validateDefinitionIds("track", scene.tracks);
   return scene;
 }
 
@@ -479,6 +482,23 @@ export function validateCallbackSession(callbacks, scene) {
     }
   }
   return callbacks;
+}
+
+function validateDefinitionIds(kind, definitions) {
+  const ids = new Set();
+  for (const definition of definitions) {
+    if (
+      !isRecord(definition) ||
+      !Number.isSafeInteger(definition.id) ||
+      definition.id < 0
+    ) {
+      throw new Error(`Python Scene has an invalid ${kind} ID`);
+    }
+    if (ids.has(definition.id)) {
+      throw new Error(`Python Scene has duplicate ${kind} IDs`);
+    }
+    ids.add(definition.id);
+  }
 }
 
 function validateIdentityEntries(kind, entries, definitions) {

--- a/web/authoring-scene-validation.test.mjs
+++ b/web/authoring-scene-validation.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { validateSceneDocument } from "./authoring-client.js";
+
+function scene({ objects = [], tracks = [] } = {}) {
+  return { version: 1, objects, tracks };
+}
+
+test("accepts unique JS-safe legacy Scene definition IDs", () => {
+  const document = scene({
+    objects: [{ id: 0 }, { id: 2 ** 52 }],
+    tracks: [{ id: 1 }, { id: 3 }],
+  });
+
+  assert.equal(validateSceneDocument(document), document);
+});
+
+test("rejects malformed legacy Scene definition IDs at the authoring boundary", () => {
+  for (const document of [
+    scene({ objects: [{}] }),
+    scene({ objects: [{ id: -1 }] }),
+    scene({ objects: [{ id: Number.MAX_SAFE_INTEGER + 1 }] }),
+    scene({ tracks: [null] }),
+    scene({ tracks: [{ id: -1 }] }),
+    scene({ tracks: [{ id: Number.MAX_SAFE_INTEGER + 1 }] }),
+  ]) {
+    assert.throws(() => validateSceneDocument(document), /invalid (object|track) ID/);
+  }
+});
+
+test("rejects duplicate legacy Scene object and track IDs", () => {
+  assert.throws(
+    () => validateSceneDocument(scene({ objects: [{ id: 4 }, { id: 4 }] })),
+    /duplicate object IDs/,
+  );
+  assert.throws(
+    () => validateSceneDocument(scene({ tracks: [{ id: 7 }, { id: 7 }] })),
+    /duplicate track IDs/,
+  );
+});


### PR DESCRIPTION
## Summary

Harden the legacy Python authoring `SceneDocument` boundary so malformed semantic identities cannot reach identity/callback reconciliation or Rust execution.

- validate every legacy object/track definition is a record with a non-negative JS-safe integer `id`;
- reject duplicate object and track IDs before downstream reconciliation;
- keep validation linear and allocation-bounded with one `Set` per definition family;
- add a focused standalone Node regression for valid high JS-safe IDs, malformed IDs, and duplicate IDs.

## Why this slice

The canonical `SceneSpec` path already validates object identity, while the still-supported legacy `SceneDocument` path only checked that `objects`/`tracks` were arrays. Downstream identity validation builds sets from those IDs, so duplicate definition IDs could collapse into an ambiguous semantic mapping rather than failing at the transport boundary.

This is deliberately independent of the active canonical SceneSpec worker migration in #791; that PR does not touch `web/authoring-client.js` or this new test.

## Validation

The repository's web test discovery runs top-level `web/*.test.mjs`, so the new regression participates in normal static/unit CI. PR Fast Gate should additionally cover the normal browser/Rust lanes.

## Risk

Low. Valid authoring output is unchanged. The only compatibility change is earlier rejection of malformed legacy documents that already violate semantic identity invariants.