### PR TITLE
Escalate renderer-critical PRs to WebGL smoke

### DIFF
--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -111,6 +111,12 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Classify PR risk
+        id: pr-risk
+        run: node scripts/classify-pr-risk.mjs "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}"
 
       - name: Use stable Rust and WASM target
         run: |
@@ -222,6 +228,21 @@ jobs:
           echo "seconds=$SECONDS" >> "$GITHUB_OUTPUT"
           exit "$status"
 
+      - name: Check WebGL rendering for renderer-critical changes
+        if: steps.pr-risk.outputs.renderer_critical == 'true'
+        id: webgl-smoke
+        env:
+          NOON_BROWSER_SMOKE_BACKEND: webgl
+          NOON_BROWSER_SMOKE_ARTIFACTS: browser-smoke-artifacts/webgl
+        run: |
+          SECONDS=0
+          set +e
+          node scripts/browser-smoke.mjs
+          status=$?
+          set -e
+          echo "seconds=$SECONDS" >> "$GITHUB_OUTPUT"
+          exit "$status"
+
       - name: Summarize browser timing
         if: always()
         env:
@@ -231,6 +252,9 @@ jobs:
           AUTHORING_SECONDS: ${{ steps.manim-authoring.outputs.seconds }}
           RETAINED_SECONDS: ${{ steps.retained-execution.outputs.seconds }}
           WEBGPU_SECONDS: ${{ steps.webgpu-smoke.outputs.seconds }}
+          WEBGL_SECONDS: ${{ steps.webgl-smoke.outputs.seconds }}
+          RENDERER_CRITICAL: ${{ steps.pr-risk.outputs.renderer_critical }}
+          RENDERER_CRITICAL_PATHS: ${{ steps.pr-risk.outputs.renderer_critical_paths }}
         run: |
           total=""
           if [[ "$START_EPOCH" =~ ^[0-9]+$ ]]; then
@@ -255,11 +279,22 @@ jobs:
             echo "| Manim authoring | $(display_seconds "$AUTHORING_SECONDS") |"
             echo "| Canonical retained execution | $(display_seconds "$RETAINED_SECONDS") |"
             echo "| WebGPU smoke | $(display_seconds "$WEBGPU_SECONDS") |"
+            if [[ "$RENDERER_CRITICAL" == "true" ]]; then
+              echo "| WebGL renderer-risk smoke | $(display_seconds "$WEBGL_SECONDS") |"
+            fi
             echo "| Measured browser path | $(display_seconds "$total") |"
             echo
+            if [[ "$RENDERER_CRITICAL" == "true" ]]; then
+              echo "Renderer-risk escalation: WebGL smoke enabled for: $RENDERER_CRITICAL_PATHS"
+              echo
+            fi
             echo "The measured browser path starts before checkout and ends after the renderer smoke. Hosted-runner queue time and post-job cleanup are intentionally excluded."
           } >> "$GITHUB_STEP_SUMMARY"
 
           if [[ "$total" =~ ^[0-9]+$ ]] && (( total >= 110 )); then
-            echo "::warning title=PR Fast Gate timing::Browser fast path reached ${total}s, leaving less than 10s of margin against the 120s target."
+            if [[ "$RENDERER_CRITICAL" == "true" ]]; then
+              echo "::notice title=PR Fast Gate timing::Renderer-critical escalation extended the browser path to ${total}s; low-risk PRs retain the 120s target."
+            else
+              echo "::warning title=PR Fast Gate timing::Browser fast path reached ${total}s, leaving less than 10s of margin against the 120s target."
+            fi
           fi

--- a/scripts/classify-pr-risk.mjs
+++ b/scripts/classify-pr-risk.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const RENDERER_CRITICAL_PREFIXES = Object.freeze([
+  "crates/noon-render-wgpu/",
+  "crates/noon-text-render-wgpu/",
+  "crates/noon-web/",
+]);
+
+const RENDERER_CRITICAL_FILES = new Set([
+  "scripts/browser-smoke.mjs",
+  "web/authoring-render-worker.js",
+  "web/browser-smoke.html",
+  "web/browser-smoke.js",
+  "web/render-worker.js",
+]);
+
+export function classifyChangedPaths(paths) {
+  const normalized = paths
+    .map((path) => String(path).trim())
+    .filter(Boolean);
+
+  const rendererCriticalPaths = normalized.filter(
+    (path) =>
+      RENDERER_CRITICAL_FILES.has(path) ||
+      RENDERER_CRITICAL_PREFIXES.some((prefix) => path.startsWith(prefix)),
+  );
+
+  return {
+    rendererCritical: rendererCriticalPaths.length > 0,
+    rendererCriticalPaths,
+  };
+}
+
+export function changedPathsBetween(base, head) {
+  if (!base || !head) {
+    throw new Error("base and head refs are required");
+  }
+  const output = execFileSync(
+    "git",
+    ["diff", "--name-only", "--diff-filter=ACMRTUXB", `${base}...${head}`],
+    { encoding: "utf8" },
+  );
+  return output.split("\n").filter(Boolean);
+}
+
+function writeGithubOutput(path, classification) {
+  const lines = [
+    `renderer_critical=${classification.rendererCritical ? "true" : "false"}`,
+    `renderer_critical_paths=${classification.rendererCriticalPaths.join(",")}`,
+  ];
+  fs.appendFileSync(path, `${lines.join("\n")}\n`);
+}
+
+function main(argv) {
+  const [base, head] = argv;
+  const classification = classifyChangedPaths(changedPathsBetween(base, head));
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (outputPath) {
+    writeGithubOutput(outputPath, classification);
+  }
+  process.stdout.write(`${JSON.stringify(classification)}\n`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main(process.argv.slice(2));
+}

--- a/scripts/classify-pr-risk.mjs
+++ b/scripts/classify-pr-risk.mjs
@@ -11,6 +11,7 @@ const RENDERER_CRITICAL_PREFIXES = Object.freeze([
 ]);
 
 const RENDERER_CRITICAL_FILES = new Set([
+  ".github/workflows/pr-fast.yml",
   "scripts/browser-smoke.mjs",
   "web/authoring-render-worker.js",
   "web/browser-smoke.html",

--- a/scripts/classify-pr-risk.mjs
+++ b/scripts/classify-pr-risk.mjs
@@ -16,7 +16,9 @@ const RENDERER_CRITICAL_FILES = new Set([
   "web/authoring-render-worker.js",
   "web/browser-smoke.html",
   "web/browser-smoke.js",
-  "web/render-worker.js",
+  "web/execution-render-worker.js",
+  "web/render-gpu-diagnostics.js",
+  "web/retained-execution-render-worker.js",
 ]);
 
 export function classifyChangedPaths(paths) {

--- a/web/pr-risk-classification.test.mjs
+++ b/web/pr-risk-classification.test.mjs
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { classifyChangedPaths } from "../scripts/classify-pr-risk.mjs";
+
+{
+  const classification = classifyChangedPaths([
+    "README.md",
+    "crates/noon-core/src/lib.rs",
+    "web/example-gallery.js",
+  ]);
+  assert.equal(classification.rendererCritical, false);
+  assert.deepEqual(classification.rendererCriticalPaths, []);
+}
+
+{
+  const classification = classifyChangedPaths([
+    "crates/noon-render-wgpu/src/lib.rs",
+    "crates/noon-text-render-wgpu/src/glyph.rs",
+    "web/render-worker.js",
+  ]);
+  assert.equal(classification.rendererCritical, true);
+  assert.deepEqual(classification.rendererCriticalPaths, [
+    "crates/noon-render-wgpu/src/lib.rs",
+    "crates/noon-text-render-wgpu/src/glyph.rs",
+    "web/render-worker.js",
+  ]);
+}
+
+{
+  const classification = classifyChangedPaths([
+    "crates/noon-web/src/lib.rs",
+    "scripts/browser-smoke.mjs",
+    "web/browser-smoke.js",
+    "web/authoring-render-worker.js",
+  ]);
+  assert.equal(classification.rendererCritical, true);
+  assert.deepEqual(classification.rendererCriticalPaths, [
+    "crates/noon-web/src/lib.rs",
+    "scripts/browser-smoke.mjs",
+    "web/browser-smoke.js",
+    "web/authoring-render-worker.js",
+  ]);
+}
+
+{
+  const classification = classifyChangedPaths(["", "  ", "README.md"]);
+  assert.equal(classification.rendererCritical, false);
+}
+
+console.log("PR risk classification tests passed");

--- a/web/pr-risk-classification.test.mjs
+++ b/web/pr-risk-classification.test.mjs
@@ -15,29 +15,35 @@ import { classifyChangedPaths } from "../scripts/classify-pr-risk.mjs";
   const classification = classifyChangedPaths([
     "crates/noon-render-wgpu/src/lib.rs",
     "crates/noon-text-render-wgpu/src/glyph.rs",
-    "web/render-worker.js",
+    "web/execution-render-worker.js",
+    "web/retained-execution-render-worker.js",
   ]);
   assert.equal(classification.rendererCritical, true);
   assert.deepEqual(classification.rendererCriticalPaths, [
     "crates/noon-render-wgpu/src/lib.rs",
     "crates/noon-text-render-wgpu/src/glyph.rs",
-    "web/render-worker.js",
+    "web/execution-render-worker.js",
+    "web/retained-execution-render-worker.js",
   ]);
 }
 
 {
   const classification = classifyChangedPaths([
+    ".github/workflows/pr-fast.yml",
     "crates/noon-web/src/lib.rs",
     "scripts/browser-smoke.mjs",
     "web/browser-smoke.js",
     "web/authoring-render-worker.js",
+    "web/render-gpu-diagnostics.js",
   ]);
   assert.equal(classification.rendererCritical, true);
   assert.deepEqual(classification.rendererCriticalPaths, [
+    ".github/workflows/pr-fast.yml",
     "crates/noon-web/src/lib.rs",
     "scripts/browser-smoke.mjs",
     "web/browser-smoke.js",
     "web/authoring-render-worker.js",
+    "web/render-gpu-diagnostics.js",
   ]);
 }
 


### PR DESCRIPTION
## Summary
- add a deterministic, unit-tested PR change classifier for renderer-critical paths
- keep the normal fast gate WebGPU-only for low-risk changes
- run the existing browser smoke a second time with the WebGL backend only when renderer crates, renderer workers, browser smoke plumbing, or the fast-gate workflow itself changes
- report the classified paths and WebGL duration in the job summary so the extra cost is measurable rather than hidden

## Why
The PR fast gate currently prioritizes WebGPU, but backend-specific regressions such as the open WebGL updater failure can escape until broader validation. Running WebGL on every PR would work against #731's two-minute target. This adds the remaining change-aware escalation seam: pay the extra browser cost only when a change can plausibly affect rendering/backend behavior.

The active canonical-cache writer PR is independent (`ci.yml` + docs only); this slice does not alter cache ownership or publication.

## Validation
- `web/pr-risk-classification.test.mjs` covers low-risk paths, renderer crates, concrete browser renderer workers, diagnostics/smoke plumbing, and self-classification of `pr-fast.yml`
- this PR intentionally classifies itself as renderer-critical, so its PR Fast Gate exercises the conditional WebGL route end-to-end
- normal web preflight auto-discovers `web/*.test.mjs`

## Risk
The classification is intentionally conservative but explicit. New renderer entry points added outside the listed crates/files must be added to the classifier. The job summary exposes classified paths so false positives remain visible and cheap to tune.

Tracks #731.