### PR TITLE
Route browser authoring through canonical SceneSpec

### DIFF
--- a/web/authoring-execution-client.js
+++ b/web/authoring-execution-client.js
@@ -3,6 +3,7 @@ import { ExecutionWorkerClient } from "./execution-worker-client.js";
 export const AUTHORING_EXECUTION_LEGACY = "legacy";
 export const AUTHORING_EXECUTION_RETAINED = "retained";
 
+const SCENE_SPEC_VERSION = 1;
 const DEFAULT_LOOP_DURATION_SECONDS = 4;
 const DEFAULT_SHARED_SLOT_CAPACITY = 1024 * 1024;
 const LIFECYCLE_CANCELLED_MESSAGE =
@@ -17,11 +18,12 @@ const EMPTY_HOST_METRICS = Object.freeze({
 ///
 /// The execution client owns one render worker and one transferred OffscreenCanvas
 /// for its lifetime. Geometry-only results keep a legacy engine attached to that
-/// owner. Results with retained objects switch only the engine type and renderer
-/// implementation at an authoring boundary; the render worker, HTML canvas, and
-/// OffscreenCanvas ownership remain stable. Empty retained sidecars stay on legacy
-/// execution. Retained edits still rebuild engine state at authoring boundaries;
-/// playback itself remains retained with no per-frame Python/source work.
+/// owner. Results with canonical retained SceneSpec output switch only the engine
+/// type and renderer implementation at an authoring boundary; the render worker,
+/// HTML canvas, and OffscreenCanvas ownership remain stable. The split legacy scene
+/// plus retained sidecar API remains an explicit compatibility path. Retained edits
+/// rebuild engine state at authoring boundaries; playback itself remains retained
+/// with no per-frame Python/source work.
 export class AuthoringExecutionClient {
   #canvas;
   #player = null;
@@ -99,6 +101,7 @@ export class AuthoringExecutionClient {
     return ready;
   }
 
+  /// Compatibility startup for the transitional split retained payload.
   async startRetained(
     sceneJson,
     retainedDocumentJson,
@@ -135,9 +138,43 @@ export class AuthoringExecutionClient {
     return ready;
   }
 
+  /// Canonical retained startup used by normal Python authoring.
+  async startRetainedCanonical(
+    sceneSpecJson,
+    {
+      loopDurationSeconds = DEFAULT_LOOP_DURATION_SECONDS,
+      transportMode = undefined,
+      sharedSlotCapacity = DEFAULT_SHARED_SLOT_CAPACITY,
+    } = {},
+  ) {
+    if (this.#player !== null || this.#transition !== null) {
+      throw new Error("AuthoringExecutionClient is already started");
+    }
+    validateSceneSpecJson(sceneSpecJson);
+    this.#loopDurationSeconds = validateLoopDurationSeconds(loopDurationSeconds);
+    this.#sharedSlotCapacity = validateSharedSlotCapacity(sharedSlotCapacity);
+    const options = {
+      loopDurationSeconds: this.#loopDurationSeconds,
+      sharedSlotCapacity: this.#sharedSlotCapacity,
+    };
+    if (transportMode !== undefined) {
+      options.transportMode = transportMode;
+    }
+    const ready = await this.#startMode(
+      AUTHORING_EXECUTION_RETAINED,
+      null,
+      null,
+      options,
+      sceneSpecJson,
+    );
+    this.#transportMode = ready.transportMode;
+    return ready;
+  }
+
   async reconcileScene(
     sceneJson,
     {
+      sceneSpecJson = null,
       retainedDocumentJson = null,
       callbacks = null,
       authoringClient = null,
@@ -152,6 +189,29 @@ export class AuthoringExecutionClient {
     const duration = validateOptionalLoopDurationSeconds(loopDurationSeconds);
     if (duration !== null) {
       this.#loopDurationSeconds = duration;
+    }
+
+    if (
+      sceneSpecJson !== null &&
+      sceneSpecJson !== undefined &&
+      retainedDocumentJson !== null &&
+      retainedDocumentJson !== undefined
+    ) {
+      throw new Error("authoring reconciliation must not mix canonical and compatibility retained inputs");
+    }
+
+    if (sceneSpecJson !== null && sceneSpecJson !== undefined) {
+      validateSceneSpecJson(sceneSpecJson);
+      if (callbacks !== null && callbacks !== undefined) {
+        throw new Error(
+          "retained authoring with Python host callbacks is not supported yet; " +
+            "split the callback work from retained text instead of silently dropping either",
+        );
+      }
+      if (this.#mode === AUTHORING_EXECUTION_RETAINED) {
+        return this.#runTransition(() => this.#rebuildRetainedCanonical(sceneSpecJson));
+      }
+      return this.#runTransition(() => this.#switchRetainedCanonical(sceneSpecJson));
     }
 
     let retainedDocument = null;
@@ -283,7 +343,7 @@ export class AuthoringExecutionClient {
     this.#transportMode = null;
   }
 
-  async #startMode(mode, sceneJson, retainedDocumentJson, options) {
+  async #startMode(mode, sceneJson, retainedDocumentJson, options, sceneSpecJson = null) {
     const generation = this.#lifecycleGeneration;
     const player = new ExecutionWorkerClient(this.#canvas, {
       onError: this.#onError,
@@ -292,10 +352,15 @@ export class AuthoringExecutionClient {
     const terminateCandidate = createIdempotentTerminator(player);
     let published = false;
     try {
-      const ready =
-        mode === AUTHORING_EXECUTION_RETAINED
-          ? await player.startRetained(sceneJson, retainedDocumentJson, options)
-          : await player.start(sceneJson, options);
+      let ready;
+      if (mode === AUTHORING_EXECUTION_RETAINED) {
+        ready =
+          sceneSpecJson !== null
+            ? await player.startRetainedCanonical(sceneSpecJson, options)
+            : await player.startRetained(sceneJson, retainedDocumentJson, options);
+      } else {
+        ready = await player.start(sceneJson, options);
+      }
       this.#assertLifecycleCurrent(generation, terminateCandidate);
       this.#player = player;
       published = true;
@@ -313,6 +378,68 @@ export class AuthoringExecutionClient {
       if (generation !== this.#lifecycleGeneration) {
         throw new Error(LIFECYCLE_CANCELLED_MESSAGE);
       }
+      throw error;
+    }
+  }
+
+  async #switchRetainedCanonical(sceneSpecJson) {
+    const generation = this.#lifecycleGeneration;
+    const player = this.#player;
+    try {
+      const ready = await player.switchToRetainedCanonical(sceneSpecJson, {
+        loopDurationSeconds: this.#loopDurationSeconds,
+      });
+      this.#assertLifecycleCurrent(generation);
+      this.#mode = AUTHORING_EXECUTION_RETAINED;
+      this.#rendererBackend = ready.render.backend;
+      this.#resizeCurrentCanvas();
+      const state = await player.state();
+      this.#assertLifecycleCurrent(generation);
+      return {
+        type: "result",
+        operation: "rebuild_retained_scene",
+        incremental: false,
+        rebuilt: true,
+        mode: this.#mode,
+        ready,
+        ...state,
+      };
+    } catch (error) {
+      if (generation !== this.#lifecycleGeneration) {
+        throw new Error(LIFECYCLE_CANCELLED_MESSAGE);
+      }
+      this.#adoptPlayerCanvas(player);
+      throw error;
+    }
+  }
+
+  async #rebuildRetainedCanonical(sceneSpecJson) {
+    const generation = this.#lifecycleGeneration;
+    const player = this.#player;
+    try {
+      const ready = await player.rebuildRetainedCanonical(sceneSpecJson, {
+        loopDurationSeconds: this.#loopDurationSeconds,
+      });
+      this.#assertLifecycleCurrent(generation);
+      this.#mode = AUTHORING_EXECUTION_RETAINED;
+      this.#rendererBackend = ready.render.backend;
+      this.#resizeCurrentCanvas();
+      const state = await player.state();
+      this.#assertLifecycleCurrent(generation);
+      return {
+        type: "result",
+        operation: "rebuild_retained_scene",
+        incremental: false,
+        rebuilt: true,
+        mode: this.#mode,
+        ready,
+        ...state,
+      };
+    } catch (error) {
+      if (generation !== this.#lifecycleGeneration) {
+        throw new Error(LIFECYCLE_CANCELLED_MESSAGE);
+      }
+      this.#adoptPlayerCanvas(player);
       throw error;
     }
   }
@@ -516,6 +643,28 @@ function validateSceneJson(sceneJson) {
   if (typeof sceneJson !== "string" || sceneJson.trim() === "") {
     throw new TypeError("scene must be non-empty JSON text");
   }
+}
+
+function validateSceneSpecJson(sceneSpecJson) {
+  if (typeof sceneSpecJson !== "string" || sceneSpecJson.trim() === "") {
+    throw new TypeError("canonical SceneSpec must be non-empty JSON text");
+  }
+  let sceneSpec;
+  try {
+    sceneSpec = JSON.parse(sceneSpecJson);
+  } catch (error) {
+    throw new TypeError(`canonical SceneSpec must be valid JSON: ${error}`);
+  }
+  if (!sceneSpec || typeof sceneSpec !== "object" || Array.isArray(sceneSpec)) {
+    throw new TypeError("canonical SceneSpec must be an object");
+  }
+  if (sceneSpec.version !== SCENE_SPEC_VERSION) {
+    throw new TypeError(`unsupported canonical SceneSpec version ${sceneSpec.version}`);
+  }
+  if (!Array.isArray(sceneSpec.objects) || !Array.isArray(sceneSpec.tracks)) {
+    throw new TypeError("canonical SceneSpec must contain object and track arrays");
+  }
+  return sceneSpec;
 }
 
 function validateRetainedDocumentJson(retainedDocumentJson) {

--- a/web/execution-worker-canonical-retained.test.mjs
+++ b/web/execution-worker-canonical-retained.test.mjs
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+class FakeCanvas {
+  clientWidth = 640;
+  clientHeight = 360;
+  width = 640;
+  height = 360;
+  transferred = false;
+  replacement = null;
+
+  transferControlToOffscreen() {
+    if (this.transferred) {
+      throw new Error("canvas was transferred twice");
+    }
+    this.transferred = true;
+    return { width: this.width, height: this.height };
+  }
+
+  cloneNode() {
+    const clone = new FakeCanvas();
+    clone.clientWidth = this.clientWidth;
+    clone.clientHeight = this.clientHeight;
+    clone.width = this.width;
+    clone.height = this.height;
+    return clone;
+  }
+
+  replaceWith(replacement) {
+    this.replacement = replacement;
+  }
+}
+
+class FakeWorker {
+  static instances = [];
+
+  listeners = new Map();
+  messages = [];
+  terminated = false;
+
+  constructor(_url, options = {}) {
+    this.name = options.name ?? "";
+    FakeWorker.instances.push(this);
+  }
+
+  addEventListener(type, listener) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  postMessage(message, transfer = []) {
+    this.messages.push({ message, transfer });
+  }
+
+  terminate() {
+    this.terminated = true;
+  }
+
+  emitMessage(message) {
+    for (const listener of this.listeners.get("message") ?? []) {
+      listener({ data: message });
+    }
+  }
+}
+
+globalThis.HTMLCanvasElement = FakeCanvas;
+globalThis.Worker = FakeWorker;
+globalThis.window = { devicePixelRatio: 1 };
+
+const { ExecutionWorkerClient } = await import("./execution-worker-client.js");
+
+const SCENE_SPEC_JSON = JSON.stringify({
+  version: 1,
+  camera_object: null,
+  objects: [{ id: 7, content: { kind: "text", text: {} } }],
+  tracks: [],
+});
+
+function engineMessage(type, payload = {}) {
+  return {
+    channel: "noon.engine",
+    protocolVersion: 1,
+    type,
+    ...payload,
+  };
+}
+
+function renderMessage(type, payload = {}) {
+  return {
+    channel: "noon.render",
+    protocolVersion: 1,
+    type,
+    ...payload,
+  };
+}
+
+function retainedEngines() {
+  return FakeWorker.instances.filter(({ name }) => name === "noon-mixed-retained-engine");
+}
+
+function latestRender() {
+  return FakeWorker.instances.findLast(({ name }) => name === "noon-render");
+}
+
+function latestMessage(worker, type) {
+  return worker.messages.findLast(({ message }) => message.type === type)?.message;
+}
+
+function emitReady(engine, render) {
+  engine.emitMessage(
+    engineMessage("ready", {
+      transportMode: "transferable",
+      retained: true,
+      mixed: true,
+      canonical: true,
+    }),
+  );
+  render.emitMessage(
+    renderMessage("ready", {
+      transportMode: "transferable",
+      backend: "WebGL2",
+      retained: true,
+      mixed: true,
+    }),
+  );
+}
+
+test("canonical retained authoring survives engine-only and full recovery", async () => {
+  FakeWorker.instances.length = 0;
+  const client = new ExecutionWorkerClient(new FakeCanvas());
+  const started = client.startRetainedCanonical(SCENE_SPEC_JSON, {
+    transportMode: "transferable",
+  });
+  const firstEngine = retainedEngines()[0];
+  const firstRender = latestRender();
+  const firstInit = latestMessage(firstEngine, "init");
+  assert.equal(firstInit.sceneSpecJson, SCENE_SPEC_JSON);
+  assert.equal("sceneJson" in firstInit, false);
+  assert.equal("retainedDocumentJson" in firstInit, false);
+  emitReady(firstEngine, firstRender);
+  assert.equal((await started).session, 1);
+
+  const engineRestart = client.restart({ failedOwner: "engine" });
+  const secondEngine = retainedEngines()[1];
+  const attach = latestMessage(firstRender, "attach_engine");
+  const secondInit = latestMessage(secondEngine, "init");
+  assert.equal(secondInit.sceneSpecJson, SCENE_SPEC_JSON);
+  assert.equal("sceneJson" in secondInit, false);
+  assert.equal("retainedDocumentJson" in secondInit, false);
+  secondEngine.emitMessage(
+    engineMessage("ready", {
+      transportMode: "transferable",
+      retained: true,
+      mixed: true,
+      canonical: true,
+    }),
+  );
+  firstRender.emitMessage(
+    renderMessage("engine_attached", {
+      requestId: attach.requestId,
+      transportMode: "transferable",
+      backend: "WebGL2",
+      retained: true,
+      mixed: true,
+    }),
+  );
+  const reconnected = await engineRestart;
+  assert.equal(reconnected.session, 2);
+  assert.equal(reconnected.engine.canonical, true);
+
+  const beforeFullRecoveryCanvas = client.canvas;
+  const fullRestart = client.restart({ failedOwner: "render" });
+  const thirdEngine = retainedEngines()[2];
+  const secondRender = latestRender();
+  const thirdInit = latestMessage(thirdEngine, "init");
+  assert.notEqual(client.canvas, beforeFullRecoveryCanvas);
+  assert.equal(thirdInit.sceneSpecJson, SCENE_SPEC_JSON);
+  assert.equal("sceneJson" in thirdInit, false);
+  assert.equal("retainedDocumentJson" in thirdInit, false);
+  emitReady(thirdEngine, secondRender);
+  const recovered = await fullRestart;
+  assert.equal(recovered.session, 3);
+  assert.equal(recovered.engine.canonical, true);
+
+  client.terminate();
+});

--- a/web/execution-worker-client.js
+++ b/web/execution-worker-client.js
@@ -13,6 +13,7 @@ const RENDER_PROTOCOL_VERSION = 1;
 const WORKER_OWNERS = Object.freeze(["engine", "render"]);
 const EXECUTION_MODE_LEGACY = "legacy";
 const EXECUTION_MODE_RETAINED = "retained";
+const SCENE_SPEC_VERSION = 1;
 const DEFAULT_SHARED_SLOT_CAPACITY = 1024 * 1024;
 const LIFECYCLE_CANCELLED_MESSAGE =
   "execution worker client was terminated during an asynchronous operation";
@@ -31,6 +32,7 @@ export class ExecutionWorkerClient {
   #mode = EXECUTION_MODE_LEGACY;
   #sceneJson = null;
   #retainedDocumentJson = null;
+  #sceneSpecJson = null;
   #loopDurationSeconds = 4;
   #transportMode = null;
   #sharedSlotCapacity = DEFAULT_SHARED_SLOT_CAPACITY;
@@ -155,6 +157,7 @@ export class ExecutionWorkerClient {
     });
   }
 
+  /// Compatibility entry point for the transitional split retained payload.
   async startRetained(sceneJson, retainedDocumentJson, options = {}) {
     const loopDurationSeconds = options.loopDurationSeconds ?? 4;
     const transportMode =
@@ -171,6 +174,24 @@ export class ExecutionWorkerClient {
     });
   }
 
+  /// Canonical retained startup. Normal authoring should use this path.
+  async startRetainedCanonical(sceneSpecJson, options = {}) {
+    const loopDurationSeconds = options.loopDurationSeconds ?? 4;
+    const transportMode =
+      options.transportMode ?? this.#transportMode ?? selectExecutionTransportMode();
+    const sharedSlotCapacity =
+      options.sharedSlotCapacity ??
+      (this.#renderPrepared === null ? DEFAULT_SHARED_SLOT_CAPACITY : this.#sharedSlotCapacity);
+    validateSceneSpecJson(sceneSpecJson);
+    return this.#startMode(
+      EXECUTION_MODE_RETAINED,
+      null,
+      null,
+      { loopDurationSeconds, transportMode, sharedSlotCapacity },
+      sceneSpecJson,
+    );
+  }
+
   async #startMode(
     mode,
     sceneJson,
@@ -180,6 +201,7 @@ export class ExecutionWorkerClient {
       transportMode,
       sharedSlotCapacity,
     },
+    sceneSpecJson = null,
   ) {
     if (this.#engineWorker !== null || this.#preparedStartReservation !== null) {
       throw new Error("ExecutionWorkerClient is already started");
@@ -189,8 +211,18 @@ export class ExecutionWorkerClient {
       throw new Error("ExecutionWorkerClient render owner is not in a prepared state");
     }
     validateExecutionMode(mode);
-    validateSceneJson(sceneJson);
-    if (mode === EXECUTION_MODE_RETAINED) {
+    if (mode === EXECUTION_MODE_LEGACY) {
+      validateSceneJson(sceneJson);
+      if (sceneSpecJson !== null || retainedDocumentJson !== null) {
+        throw new Error("legacy execution must not include retained authoring payloads");
+      }
+    } else if (sceneSpecJson !== null) {
+      validateSceneSpecJson(sceneSpecJson);
+      if (sceneJson !== null || retainedDocumentJson !== null) {
+        throw new Error("retained execution must not mix canonical and compatibility inputs");
+      }
+    } else {
+      validateSceneJson(sceneJson);
       validateRetainedDocumentJson(retainedDocumentJson);
     }
     validateLoopDurationSeconds(loopDurationSeconds);
@@ -219,6 +251,7 @@ export class ExecutionWorkerClient {
           sceneJson,
           retainedDocumentJson,
           loopDurationSeconds,
+          sceneSpecJson,
         );
       } finally {
         if (this.#preparedStartReservation === reservation) {
@@ -238,6 +271,7 @@ export class ExecutionWorkerClient {
       loopDurationSeconds,
       transportMode,
       slotCapacity,
+      sceneSpecJson,
     );
     const { width: initialWidth, height: initialHeight } = this.#prepareCanvasDimensions();
 
@@ -279,6 +313,8 @@ export class ExecutionWorkerClient {
         sceneJson,
         retainedDocumentJson,
         loopDurationSeconds,
+        this.#session,
+        sceneSpecJson,
       );
       const ready = await this.#ready;
       this.#playing = true;
@@ -294,7 +330,13 @@ export class ExecutionWorkerClient {
     }
   }
 
-  async #startPreparedMode(mode, sceneJson, retainedDocumentJson, loopDurationSeconds) {
+  async #startPreparedMode(
+    mode,
+    sceneJson,
+    retainedDocumentJson,
+    loopDurationSeconds,
+    sceneSpecJson = null,
+  ) {
     this.#configureStart(
       mode,
       sceneJson,
@@ -302,6 +344,7 @@ export class ExecutionWorkerClient {
       loopDurationSeconds,
       this.#transportMode,
       this.#sharedSlotCapacity,
+      sceneSpecJson,
     );
     try {
       const channel = new MessageChannel();
@@ -332,6 +375,8 @@ export class ExecutionWorkerClient {
         sceneJson,
         retainedDocumentJson,
         loopDurationSeconds,
+        this.#session,
+        sceneSpecJson,
       );
       const ready = await this.#ready;
       this.#renderPrepared = null;
@@ -356,11 +401,13 @@ export class ExecutionWorkerClient {
     loopDurationSeconds,
     transportMode,
     sharedSlotCapacity,
+    sceneSpecJson = null,
   ) {
     this.#mode = mode;
     this.#sceneJson = sceneJson;
     this.#retainedDocumentJson =
       mode === EXECUTION_MODE_RETAINED ? retainedDocumentJson : null;
+    this.#sceneSpecJson = mode === EXECUTION_MODE_RETAINED ? sceneSpecJson : null;
     this.#loopDurationSeconds = loopDurationSeconds;
     this.#transportMode = transportMode;
     this.#sharedSlotCapacity = sharedSlotCapacity;
@@ -425,6 +472,7 @@ export class ExecutionWorkerClient {
     return result;
   }
 
+  /// Compatibility transition for the split retained payload.
   async switchToRetained(
     sceneJson,
     retainedDocumentJson,
@@ -440,6 +488,19 @@ export class ExecutionWorkerClient {
     });
   }
 
+  /// Canonical retained transition used by normal browser authoring.
+  async switchToRetainedCanonical(sceneSpecJson, { loopDurationSeconds = null } = {}) {
+    validateSceneSpecJson(sceneSpecJson);
+    return this.#transitionEngine(EXECUTION_MODE_RETAINED, null, null, {
+      loopDurationSeconds: validateOptionalLoopDurationSeconds(loopDurationSeconds),
+      callbacks: null,
+      authoringClient: null,
+      renderCommand: "switch_engine",
+      sceneSpecJson,
+    });
+  }
+
+  /// Compatibility rebuild for the split retained payload.
   async rebuildRetained(
     sceneJson,
     retainedDocumentJson,
@@ -452,6 +513,18 @@ export class ExecutionWorkerClient {
       callbacks: null,
       authoringClient: null,
       renderCommand: "rebuild_engine",
+    });
+  }
+
+  /// Canonical retained rebuild used by normal browser authoring.
+  async rebuildRetainedCanonical(sceneSpecJson, { loopDurationSeconds = null } = {}) {
+    validateSceneSpecJson(sceneSpecJson);
+    return this.#transitionEngine(EXECUTION_MODE_RETAINED, null, null, {
+      loopDurationSeconds: validateOptionalLoopDurationSeconds(loopDurationSeconds),
+      callbacks: null,
+      authoringClient: null,
+      renderCommand: "rebuild_engine",
+      sceneSpecJson,
     });
   }
 
@@ -481,10 +554,26 @@ export class ExecutionWorkerClient {
     nextMode,
     sceneJson,
     retainedDocumentJson,
-    { loopDurationSeconds, callbacks, authoringClient, renderCommand },
+    { loopDurationSeconds, callbacks, authoringClient, renderCommand, sceneSpecJson = null },
   ) {
     this.#requireStarted();
     validateExecutionMode(nextMode);
+    if (nextMode === EXECUTION_MODE_RETAINED) {
+      if (sceneSpecJson !== null) {
+        validateSceneSpecJson(sceneSpecJson);
+        if (sceneJson !== null || retainedDocumentJson !== null) {
+          throw new Error("retained execution must not mix canonical and compatibility inputs");
+        }
+      } else {
+        validateSceneJson(sceneJson);
+        validateRetainedDocumentJson(retainedDocumentJson);
+      }
+    } else {
+      validateSceneJson(sceneJson);
+      if (sceneSpecJson !== null || retainedDocumentJson !== null) {
+        throw new Error("legacy execution must not include retained authoring payloads");
+      }
+    }
     if (renderCommand === "switch_engine" && nextMode === this.#mode) {
       throw new Error(`execution worker client is already in ${nextMode} mode`);
     }
@@ -518,6 +607,7 @@ export class ExecutionWorkerClient {
         retainedDocumentJson,
         duration,
         nextSession,
+        sceneSpecJson,
       );
       candidateReady = await candidateReadyPromise;
       this.#assertLifecycleCurrent(generation);
@@ -597,6 +687,7 @@ export class ExecutionWorkerClient {
       this.#sceneJson = sceneJson;
       this.#retainedDocumentJson =
         nextMode === EXECUTION_MODE_RETAINED ? retainedDocumentJson : null;
+      this.#sceneSpecJson = nextMode === EXECUTION_MODE_RETAINED ? sceneSpecJson : null;
       this.#loopDurationSeconds = duration;
       this.#fatalOwner = null;
       return ready;
@@ -714,7 +805,12 @@ export class ExecutionWorkerClient {
   }
 
   async restart({ failedOwner = this.#fatalOwner } = {}) {
-    if (this.#sceneJson === null || this.#transportMode === null) {
+    const hasAuthoring =
+      this.#mode === EXECUTION_MODE_LEGACY
+        ? this.#sceneJson !== null
+        : this.#sceneSpecJson !== null ||
+          (this.#sceneJson !== null && this.#retainedDocumentJson !== null);
+    if (!hasAuthoring || this.#transportMode === null) {
       throw new Error("ExecutionWorkerClient has not been started");
     }
     if (failedOwner !== null && failedOwner !== "engine" && failedOwner !== "render") {
@@ -772,6 +868,8 @@ export class ExecutionWorkerClient {
         this.#sceneJson,
         this.#retainedDocumentJson,
         this.#loopDurationSeconds,
+        this.#session,
+        this.#sceneSpecJson,
       );
 
       const ready = await nextReady;
@@ -803,6 +901,7 @@ export class ExecutionWorkerClient {
     const mode = this.#mode;
     const sceneJson = this.#sceneJson;
     const retainedDocumentJson = this.#retainedDocumentJson;
+    const sceneSpecJson = this.#sceneSpecJson;
     const loopDurationSeconds = this.#loopDurationSeconds;
     const transportMode = this.#transportMode;
     const sharedSlotCapacity = this.#sharedSlotCapacity;
@@ -816,11 +915,13 @@ export class ExecutionWorkerClient {
       this.#canvas = replaceExecutionCanvas(this.#canvas);
     }
 
-    const ready = await this.#startMode(mode, sceneJson, retainedDocumentJson, {
-      loopDurationSeconds,
-      transportMode,
-      sharedSlotCapacity,
-    });
+    const ready = await this.#startMode(
+      mode,
+      sceneJson,
+      retainedDocumentJson,
+      { loopDurationSeconds, transportMode, sharedSlotCapacity },
+      sceneSpecJson,
+    );
     if (!wasPlaying) {
       const paused = await this.#requestEngine("pause", {});
       this.#rememberPlaying(paused);
@@ -1113,17 +1214,22 @@ export class ExecutionWorkerClient {
     retainedDocumentJson,
     loopDurationSeconds,
     session = this.#session,
+    sceneSpecJson = null,
   ) {
     const payload = {
       port,
-      sceneJson,
       loopDurationSeconds,
       transportMode: this.#transportMode,
       sharedSlotCapacity: this.#sharedSlotCapacity,
       session,
     };
-    if (mode === EXECUTION_MODE_RETAINED) {
-      payload.retainedDocumentJson = retainedDocumentJson;
+    if (mode === EXECUTION_MODE_RETAINED && sceneSpecJson !== null) {
+      payload.sceneSpecJson = sceneSpecJson;
+    } else {
+      payload.sceneJson = sceneJson;
+      if (mode === EXECUTION_MODE_RETAINED) {
+        payload.retainedDocumentJson = retainedDocumentJson;
+      }
     }
     worker.postMessage(engineEnvelope("init", payload), [port]);
   }
@@ -1253,6 +1359,53 @@ function validateSceneJson(sceneJson) {
   if (typeof sceneJson !== "string" || sceneJson.trim() === "") {
     throw new TypeError("scene must be non-empty JSON text");
   }
+}
+
+function validateSceneSpecJson(sceneSpecJson) {
+  if (typeof sceneSpecJson !== "string" || sceneSpecJson.trim() === "") {
+    throw new TypeError("canonical SceneSpec must be non-empty JSON text");
+  }
+  let sceneSpec;
+  try {
+    sceneSpec = JSON.parse(sceneSpecJson);
+  } catch (error) {
+    throw new TypeError(`canonical SceneSpec must be valid JSON: ${error}`);
+  }
+  if (!sceneSpec || typeof sceneSpec !== "object" || Array.isArray(sceneSpec)) {
+    throw new TypeError("canonical SceneSpec must be an object");
+  }
+  if (sceneSpec.version !== SCENE_SPEC_VERSION) {
+    throw new TypeError(`unsupported canonical SceneSpec version ${sceneSpec.version}`);
+  }
+  if (!Array.isArray(sceneSpec.objects) || !Array.isArray(sceneSpec.tracks)) {
+    throw new TypeError("canonical SceneSpec must contain object and track arrays");
+  }
+  const objectIds = new Set();
+  for (const object of sceneSpec.objects) {
+    if (
+      !object ||
+      typeof object !== "object" ||
+      Array.isArray(object) ||
+      !Number.isSafeInteger(object.id) ||
+      object.id < 0
+    ) {
+      throw new TypeError("canonical SceneSpec object has an invalid object ID");
+    }
+    if (objectIds.has(object.id)) {
+      throw new TypeError("canonical SceneSpec has duplicate object IDs");
+    }
+    objectIds.add(object.id);
+  }
+  if (
+    sceneSpec.camera_object !== null &&
+    sceneSpec.camera_object !== undefined &&
+    (!Number.isSafeInteger(sceneSpec.camera_object) ||
+      sceneSpec.camera_object < 0 ||
+      !objectIds.has(sceneSpec.camera_object))
+  ) {
+    throw new TypeError("canonical SceneSpec has an invalid camera object");
+  }
+  return sceneSpec;
 }
 
 function validateRetainedDocumentJson(retainedDocumentJson) {

--- a/web/execution-worker-retained-start.test.mjs
+++ b/web/execution-worker-retained-start.test.mjs
@@ -50,17 +50,26 @@ globalThis.window = { devicePixelRatio: 1 };
 const { AuthoringExecutionClient } = await import("./authoring-execution-client.js");
 
 const SCENE_JSON = JSON.stringify({ version: 1, objects: [], tracks: [] });
+const SCENE_SPEC_JSON = JSON.stringify({
+  version: 1,
+  camera_object: null,
+  objects: [{ id: 7, content: { kind: "text", text: {} } }],
+  tracks: [],
+});
 const RETAINED_DOCUMENT_JSON = JSON.stringify({
   channel: "noon.authoring.retained",
   objects: [{ id: 1 }],
 });
 
-function engineReady() {
+function engineReady({ canonical = false } = {}) {
   return {
     channel: "noon.engine",
     protocolVersion: 1,
     type: "ready",
     transportMode: "transferable",
+    retained: true,
+    mixed: true,
+    canonical,
   };
 }
 
@@ -74,10 +83,10 @@ function renderReady() {
   };
 }
 
-test("retained first start boots the retained engine directly", async () => {
+test("canonical retained first start sends only SceneSpec to the retained engine", async () => {
   FakeWorker.instances.length = 0;
   const client = new AuthoringExecutionClient(new FakeCanvas());
-  const readyPromise = client.startRetained(SCENE_JSON, RETAINED_DOCUMENT_JSON, {
+  const readyPromise = client.startRetainedCanonical(SCENE_SPEC_JSON, {
     transportMode: "transferable",
   });
 
@@ -94,13 +103,40 @@ test("retained first start boots the retained engine directly", async () => {
 
   const engineInit = retainedEngine.messages.find(({ message }) => message.type === "init")?.message;
   const renderInit = render.messages.find(({ message }) => message.type === "init")?.message;
-  assert.equal(engineInit?.retainedDocumentJson, RETAINED_DOCUMENT_JSON);
+  assert.equal(engineInit?.sceneSpecJson, SCENE_SPEC_JSON);
+  assert.equal("sceneJson" in engineInit, false);
+  assert.equal("retainedDocumentJson" in engineInit, false);
   assert.equal(renderInit?.mode, "retained");
+
+  retainedEngine.emitMessage(engineReady({ canonical: true }));
+  render.emitMessage(renderReady());
+  const ready = await readyPromise;
+
+  assert.equal(ready.session, 1);
+  assert.equal(ready.engine.canonical, true);
+  assert.equal(client.mode, "retained");
+  client.terminate();
+});
+
+test("split retained startup remains an explicit compatibility path", async () => {
+  FakeWorker.instances.length = 0;
+  const client = new AuthoringExecutionClient(new FakeCanvas());
+  const readyPromise = client.startRetained(SCENE_JSON, RETAINED_DOCUMENT_JSON, {
+    transportMode: "transferable",
+  });
+
+  const retainedEngine = FakeWorker.instances.find(
+    ({ name }) => name === "noon-mixed-retained-engine",
+  );
+  const render = FakeWorker.instances.find(({ name }) => name === "noon-render");
+  const engineInit = retainedEngine.messages.find(({ message }) => message.type === "init")?.message;
+  assert.equal(engineInit?.sceneJson, SCENE_JSON);
+  assert.equal(engineInit?.retainedDocumentJson, RETAINED_DOCUMENT_JSON);
+  assert.equal("sceneSpecJson" in engineInit, false);
 
   retainedEngine.emitMessage(engineReady());
   render.emitMessage(renderReady());
   const ready = await readyPromise;
-
   assert.equal(ready.session, 1);
   assert.equal(client.mode, "retained");
   client.terminate();

--- a/web/main.js
+++ b/web/main.js
@@ -446,7 +446,7 @@ function ensureAuthoringClient() {
 
 async function ensureRuntimeReady({
   sceneJson,
-  retainedDocumentJson,
+  sceneSpecJson,
   startRetained,
   callbacks,
   authoringClient: client,
@@ -478,7 +478,7 @@ async function ensureRuntimeReady({
     });
     try {
       const ready = startRetained
-        ? await nextPlayer.startRetained(sceneJson, retainedDocumentJson, {
+        ? await nextPlayer.startRetainedCanonical(sceneSpecJson, {
             loopDurationSeconds,
           })
         : await nextPlayer.start(sceneJson, { loopDurationSeconds });
@@ -726,10 +726,13 @@ async function runScene() {
         authored.callbacks === null
           ? sceneIdentities.stabilize(authored.document, authored.identities)
           : authored.document;
+      const runtimeSceneSpec =
+        authored.sceneSpec === null || authored.sceneSpec === undefined
+          ? null
+          : sceneIdentities.stabilizeSceneSpec(authored.sceneSpec, authored.identities);
       const sceneJson = JSON.stringify(runtimeDocument);
-      const retainedDocumentJson =
-        authored.retainedDocument === null ? null : JSON.stringify(authored.retainedDocument);
-      const startRetained = (authored.retainedDocument?.objects?.length ?? 0) > 0;
+      const sceneSpecJson = runtimeSceneSpec === null ? null : JSON.stringify(runtimeSceneSpec);
+      const startRetained = sceneSpecJson !== null;
       const loopDurationSeconds = authored.duration > 0 ? authored.duration : playbackDurationSeconds;
 
       await runPlaygroundTestHook("beforeReconcile", {
@@ -743,7 +746,7 @@ async function runScene() {
       if (player === null) {
         result = await ensureRuntimeReady({
           sceneJson,
-          retainedDocumentJson,
+          sceneSpecJson,
           startRetained,
           callbacks: authored.callbacks,
           authoringClient: client,
@@ -754,7 +757,7 @@ async function runScene() {
         await ensureExecutionReady();
         if (!isCurrentRun(runToken)) return recordStale(runToken, "after-restart");
         result = await player.reconcileScene(sceneJson, {
-          retainedDocumentJson,
+          sceneSpecJson,
           callbacks: authored.callbacks,
           authoringClient: client,
           loopDurationSeconds: authored.duration > 0 ? authored.duration : null,

--- a/web/playground-scene-spec-routing.test.mjs
+++ b/web/playground-scene-spec-routing.test.mjs
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const mainSource = await readFile(new URL("./main.js", import.meta.url), "utf8");
+
+test("playground routes retained Python output through canonical SceneSpec", () => {
+  assert.match(mainSource, /authored\.sceneSpec/);
+  assert.match(mainSource, /startRetainedCanonical\(sceneSpecJson/);
+  assert.match(mainSource, /reconcileScene\(sceneJson, \{\s*sceneSpecJson,/s);
+  assert.doesNotMatch(mainSource, /authored\.retainedDocument/);
+  assert.doesNotMatch(mainSource, /retainedDocumentJson/);
+});

--- a/web/playground-startup.test.mjs
+++ b/web/playground-startup.test.mjs
@@ -23,8 +23,13 @@ assert.match(
 );
 assert.match(
   runtimeReadyBody,
-  /await nextPlayer\.startRetained\(sceneJson, retainedDocumentJson,/,
-  "retained first runs must start directly in retained mode",
+  /await nextPlayer\.startRetainedCanonical\(sceneSpecJson,/,
+  "retained first runs must start directly from canonical SceneSpec",
+);
+assert.doesNotMatch(
+  runtimeReadyBody,
+  /startRetained\(sceneJson, retainedDocumentJson/,
+  "normal retained startup must not reconstruct the transitional split payload",
 );
 assert.match(
   runtimeReadyBody,
@@ -43,7 +48,7 @@ assert.ok(
   "concurrent startup callers must await the in-flight startup before observing the published player",
 );
 const playerPublish = runtimeReadyBody.indexOf("player = nextPlayer;");
-const retainedStart = runtimeReadyBody.indexOf("await nextPlayer.startRetained");
+const retainedStart = runtimeReadyBody.indexOf("await nextPlayer.startRetainedCanonical");
 const legacyStart = runtimeReadyBody.indexOf("await nextPlayer.start(sceneJson");
 assert.ok(
   playerPublish > retainedStart && playerPublish > legacyStart,
@@ -79,8 +84,13 @@ assert.ok(
 );
 assert.match(
   runSceneBody,
-  /const startRetained = \(authored\.retainedDocument\?\.objects\?\.length \?\? 0\) > 0;/,
-  "first-run engine selection must derive from the authored retained sidecar",
+  /const startRetained = sceneSpecJson !== null;/,
+  "first-run retained engine selection must derive from canonical SceneSpec availability",
+);
+assert.doesNotMatch(
+  runSceneBody,
+  /authored\.retainedDocument|retainedDocumentJson/,
+  "normal playground routing must not depend on the transitional retained sidecar",
 );
 
 const bootStart = main.indexOf("try {\n  const requested = requestedExampleId();");

--- a/web/scene-identity.js
+++ b/web/scene-identity.js
@@ -35,6 +35,52 @@ export class SceneIdentityMap {
       ? document
       : { ...document, objects, tracks, ...(reactive === undefined ? {} : { reactive }) };
   }
+
+  /// Apply the same semantic identity map to the canonical mixed scene.
+  ///
+  /// Python identity metadata currently describes the legacy geometry objects/tracks
+  /// that feed SceneSpec construction. Canonical-only objects such as retained text
+  /// are intentionally absent from that metadata and therefore keep their source IDs.
+  /// Painter order stays structural while geometry track/camera references follow the
+  /// remapped stable object IDs.
+  stabilizeSceneSpec(sceneSpec, identities) {
+    if (sceneSpec === null || sceneSpec === undefined) {
+      return sceneSpec;
+    }
+    const objectIds = this.#objects.resolve(identities.objects);
+    const trackIds = this.#tracks.resolve(identities.tracks);
+    if (objectIds === null && trackIds === null) {
+      return sceneSpec;
+    }
+
+    const objects =
+      objectIds === null
+        ? sceneSpec.objects
+        : sceneSpec.objects.map((object) => {
+            const id = optionalId(objectIds, object.id);
+            return id === object.id ? object : { ...object, id };
+          });
+    const tracks =
+      objectIds === null && trackIds === null
+        ? sceneSpec.tracks
+        : sceneSpec.tracks.map((track) => {
+            const id = trackIds === null ? track.id : optionalId(trackIds, track.id);
+            const object = objectIds === null ? track.object : optionalId(objectIds, track.object);
+            return id === track.id && object === track.object
+              ? track
+              : { ...track, id, object };
+          });
+    const cameraObject =
+      objectIds === null || sceneSpec.camera_object === null || sceneSpec.camera_object === undefined
+        ? sceneSpec.camera_object
+        : optionalId(objectIds, sceneSpec.camera_object);
+
+    return objects === sceneSpec.objects &&
+      tracks === sceneSpec.tracks &&
+      cameraObject === sceneSpec.camera_object
+      ? sceneSpec
+      : { ...sceneSpec, objects, tracks, camera_object: cameraObject };
+  }
 }
 
 function remapReactiveObjects(reactive, objectIds) {
@@ -116,4 +162,8 @@ function requiredId(ids, localId, kind) {
     throw new Error(`Scene ${kind} ${localId} has no authoring identity`);
   }
   return stableId;
+}
+
+function optionalId(ids, localId) {
+  return ids.get(localId) ?? localId;
 }

--- a/web/scene-identity.test.mjs
+++ b/web/scene-identity.test.mjs
@@ -87,6 +87,60 @@ test("rewrites track IDs and object references by stable keys", () => {
   ]);
 });
 
+test("canonical SceneSpec stabilizes geometry identities without renumbering retained text", () => {
+  const identities = new SceneIdentityMap();
+  const textId = 4503599627370496;
+  const firstKeys = {
+    objects: [{ id: 0, key: "hero" }],
+    tracks: [{ id: 0, key: "hero.move" }],
+  };
+  identities.stabilizeSceneSpec(
+    {
+      version: 1,
+      objects: [
+        { id: 0, content: { kind: "geometry" } },
+        { id: textId, content: { kind: "text" } },
+      ],
+      tracks: [{ id: 0, object: 0 }],
+      camera_object: 0,
+    },
+    firstKeys,
+  );
+
+  const second = identities.stabilizeSceneSpec(
+    {
+      version: 1,
+      objects: [
+        { id: textId, content: { kind: "text" } },
+        { id: 0, content: { kind: "geometry" } },
+        { id: 1, content: { kind: "geometry" } },
+      ],
+      tracks: [
+        { id: 0, object: 1 },
+        { id: 1, object: 0 },
+      ],
+      camera_object: 1,
+    },
+    {
+      objects: [
+        { id: 0, key: "other" },
+        { id: 1, key: "hero" },
+      ],
+      tracks: [
+        { id: 0, key: "hero.move" },
+        { id: 1, key: "other.move" },
+      ],
+    },
+  );
+
+  assert.deepEqual(second.objects.map(({ id }) => id), [textId, 1, 0]);
+  assert.deepEqual(second.tracks, [
+    { id: 0, object: 0 },
+    { id: 1, object: 1 },
+  ]);
+  assert.equal(second.camera_object, 0);
+});
+
 function keyedScene(count) {
   return {
     document: {


### PR DESCRIPTION
## Summary

- add canonical retained start/switch/rebuild entry points to the general `ExecutionWorkerClient` while preserving the split scene + retained-document methods as explicit compatibility APIs
- persist canonical `sceneSpecJson` across engine-only reconnect and full render recovery so retained authoring has one immutable recovery descriptor
- route `AuthoringExecutionClient` through canonical retained operations whenever Python provides `sceneSpec`
- stop the playground from serializing or forwarding `retainedDocument`; normal retained Python authoring now sends the validated canonical `SceneSpec` directly to the retained engine worker
- extend `SceneIdentityMap` to stabilize geometry object IDs, track IDs/references, and the camera inside canonical mixed scenes while leaving canonical-only retained text IDs and painter order untouched
- keep geometry-only legacy execution and Python host-callback routing unchanged
- add focused startup/recovery, identity, and playground topology tests that reject accidental fallback to the split payload

## Architecture

```text
Python authoring worker
      sceneSpec
         |
         v
SceneIdentityMap
 canonical graph IDs
         |
         v
playground / AuthoringExecutionClient
         |
         v
ExecutionWorkerClient
  immutable canonical retained descriptor
         |
         v
retained execution engine
```

The old split retained APIs remain only for compatibility callers. This removes the duplicated retained sidecar from the normal browser authoring path without giving up stable geometry/track identity across re-authoring, and advances #367 toward retiring the split worker/player entry points entirely.

Tracks #367. Follows #791.