### PR TITLE
Make retained browser execution protocol canonical-only

### DIFF
--- a/web/authoring-execution-client.js
+++ b/web/authoring-execution-client.js
@@ -20,10 +20,9 @@ const EMPTY_HOST_METRICS = Object.freeze({
 /// for its lifetime. Geometry-only results keep a legacy engine attached to that
 /// owner. Results with canonical retained SceneSpec output switch only the engine
 /// type and renderer implementation at an authoring boundary; the render worker,
-/// HTML canvas, and OffscreenCanvas ownership remain stable. The split legacy scene
-/// plus retained sidecar API remains an explicit compatibility path. Retained edits
-/// rebuild engine state at authoring boundaries; playback itself remains retained
-/// with no per-frame Python/source work.
+/// HTML canvas, and OffscreenCanvas ownership remain stable. Retained edits rebuild
+/// engine state at authoring boundaries; playback itself remains retained with no
+/// per-frame Python/source work.
 export class AuthoringExecutionClient {
   #canvas;
   #player = null;
@@ -91,54 +90,11 @@ export class AuthoringExecutionClient {
     if (transportMode !== undefined) {
       options.transportMode = transportMode;
     }
-    const ready = await this.#startMode(
-      AUTHORING_EXECUTION_LEGACY,
-      sceneJson,
-      null,
-      options,
-    );
+    const ready = await this.#startMode(AUTHORING_EXECUTION_LEGACY, sceneJson, options);
     this.#transportMode = ready.transportMode;
     return ready;
   }
 
-  /// Compatibility startup for the transitional split retained payload.
-  async startRetained(
-    sceneJson,
-    retainedDocumentJson,
-    {
-      loopDurationSeconds = DEFAULT_LOOP_DURATION_SECONDS,
-      transportMode = undefined,
-      sharedSlotCapacity = DEFAULT_SHARED_SLOT_CAPACITY,
-    } = {},
-  ) {
-    if (this.#player !== null || this.#transition !== null) {
-      throw new Error("AuthoringExecutionClient is already started");
-    }
-    validateSceneJson(sceneJson);
-    const retainedDocument = validateRetainedDocumentJson(retainedDocumentJson);
-    if (retainedDocument.objects.length === 0) {
-      throw new TypeError("retained startup requires at least one retained object");
-    }
-    this.#loopDurationSeconds = validateLoopDurationSeconds(loopDurationSeconds);
-    this.#sharedSlotCapacity = validateSharedSlotCapacity(sharedSlotCapacity);
-    const options = {
-      loopDurationSeconds: this.#loopDurationSeconds,
-      sharedSlotCapacity: this.#sharedSlotCapacity,
-    };
-    if (transportMode !== undefined) {
-      options.transportMode = transportMode;
-    }
-    const ready = await this.#startMode(
-      AUTHORING_EXECUTION_RETAINED,
-      sceneJson,
-      retainedDocumentJson,
-      options,
-    );
-    this.#transportMode = ready.transportMode;
-    return ready;
-  }
-
-  /// Canonical retained startup used by normal Python authoring.
   async startRetainedCanonical(
     sceneSpecJson,
     {
@@ -163,7 +119,6 @@ export class AuthoringExecutionClient {
     const ready = await this.#startMode(
       AUTHORING_EXECUTION_RETAINED,
       null,
-      null,
       options,
       sceneSpecJson,
     );
@@ -186,18 +141,14 @@ export class AuthoringExecutionClient {
     }
     this.#requireStarted();
     validateSceneJson(sceneJson);
+    if (retainedDocumentJson !== null && retainedDocumentJson !== undefined) {
+      throw new Error(
+        "split retained reconciliation is retired; provide canonical sceneSpecJson instead",
+      );
+    }
     const duration = validateOptionalLoopDurationSeconds(loopDurationSeconds);
     if (duration !== null) {
       this.#loopDurationSeconds = duration;
-    }
-
-    if (
-      sceneSpecJson !== null &&
-      sceneSpecJson !== undefined &&
-      retainedDocumentJson !== null &&
-      retainedDocumentJson !== undefined
-    ) {
-      throw new Error("authoring reconciliation must not mix canonical and compatibility retained inputs");
     }
 
     if (sceneSpecJson !== null && sceneSpecJson !== undefined) {
@@ -212,27 +163,6 @@ export class AuthoringExecutionClient {
         return this.#runTransition(() => this.#rebuildRetainedCanonical(sceneSpecJson));
       }
       return this.#runTransition(() => this.#switchRetainedCanonical(sceneSpecJson));
-    }
-
-    let retainedDocument = null;
-    if (retainedDocumentJson !== null && retainedDocumentJson !== undefined) {
-      retainedDocument = validateRetainedDocumentJson(retainedDocumentJson);
-    }
-    if (retainedDocument !== null && retainedDocument.objects.length > 0) {
-      if (callbacks !== null && callbacks !== undefined) {
-        throw new Error(
-          "retained authoring with Python host callbacks is not supported yet; " +
-            "split the callback work from retained text instead of silently dropping either",
-        );
-      }
-      if (this.#mode === AUTHORING_EXECUTION_RETAINED) {
-        return this.#runTransition(() =>
-          this.#rebuildRetained(sceneJson, retainedDocumentJson),
-        );
-      }
-      return this.#runTransition(() =>
-        this.#switchRetained(sceneJson, retainedDocumentJson),
-      );
     }
 
     if (this.#mode === AUTHORING_EXECUTION_LEGACY) {
@@ -343,7 +273,7 @@ export class AuthoringExecutionClient {
     this.#transportMode = null;
   }
 
-  async #startMode(mode, sceneJson, retainedDocumentJson, options, sceneSpecJson = null) {
+  async #startMode(mode, sceneJson, options, sceneSpecJson = null) {
     const generation = this.#lifecycleGeneration;
     const player = new ExecutionWorkerClient(this.#canvas, {
       onError: this.#onError,
@@ -352,15 +282,10 @@ export class AuthoringExecutionClient {
     const terminateCandidate = createIdempotentTerminator(player);
     let published = false;
     try {
-      let ready;
-      if (mode === AUTHORING_EXECUTION_RETAINED) {
-        ready =
-          sceneSpecJson !== null
-            ? await player.startRetainedCanonical(sceneSpecJson, options)
-            : await player.startRetained(sceneJson, retainedDocumentJson, options);
-      } else {
-        ready = await player.start(sceneJson, options);
-      }
+      const ready =
+        mode === AUTHORING_EXECUTION_RETAINED
+          ? await player.startRetainedCanonical(sceneSpecJson, options)
+          : await player.start(sceneJson, options);
       this.#assertLifecycleCurrent(generation, terminateCandidate);
       this.#player = player;
       published = true;
@@ -418,68 +343,6 @@ export class AuthoringExecutionClient {
     const player = this.#player;
     try {
       const ready = await player.rebuildRetainedCanonical(sceneSpecJson, {
-        loopDurationSeconds: this.#loopDurationSeconds,
-      });
-      this.#assertLifecycleCurrent(generation);
-      this.#mode = AUTHORING_EXECUTION_RETAINED;
-      this.#rendererBackend = ready.render.backend;
-      this.#resizeCurrentCanvas();
-      const state = await player.state();
-      this.#assertLifecycleCurrent(generation);
-      return {
-        type: "result",
-        operation: "rebuild_retained_scene",
-        incremental: false,
-        rebuilt: true,
-        mode: this.#mode,
-        ready,
-        ...state,
-      };
-    } catch (error) {
-      if (generation !== this.#lifecycleGeneration) {
-        throw new Error(LIFECYCLE_CANCELLED_MESSAGE);
-      }
-      this.#adoptPlayerCanvas(player);
-      throw error;
-    }
-  }
-
-  async #switchRetained(sceneJson, retainedDocumentJson) {
-    const generation = this.#lifecycleGeneration;
-    const player = this.#player;
-    try {
-      const ready = await player.switchToRetained(sceneJson, retainedDocumentJson, {
-        loopDurationSeconds: this.#loopDurationSeconds,
-      });
-      this.#assertLifecycleCurrent(generation);
-      this.#mode = AUTHORING_EXECUTION_RETAINED;
-      this.#rendererBackend = ready.render.backend;
-      this.#resizeCurrentCanvas();
-      const state = await player.state();
-      this.#assertLifecycleCurrent(generation);
-      return {
-        type: "result",
-        operation: "rebuild_retained_scene",
-        incremental: false,
-        rebuilt: true,
-        mode: this.#mode,
-        ready,
-        ...state,
-      };
-    } catch (error) {
-      if (generation !== this.#lifecycleGeneration) {
-        throw new Error(LIFECYCLE_CANCELLED_MESSAGE);
-      }
-      this.#adoptPlayerCanvas(player);
-      throw error;
-    }
-  }
-
-  async #rebuildRetained(sceneJson, retainedDocumentJson) {
-    const generation = this.#lifecycleGeneration;
-    const player = this.#player;
-    try {
-      const ready = await player.rebuildRetained(sceneJson, retainedDocumentJson, {
         loopDurationSeconds: this.#loopDurationSeconds,
       });
       this.#assertLifecycleCurrent(generation);
@@ -665,25 +528,6 @@ function validateSceneSpecJson(sceneSpecJson) {
     throw new TypeError("canonical SceneSpec must contain object and track arrays");
   }
   return sceneSpec;
-}
-
-function validateRetainedDocumentJson(retainedDocumentJson) {
-  if (typeof retainedDocumentJson !== "string" || retainedDocumentJson.trim() === "") {
-    throw new TypeError("retained document must be non-empty JSON text");
-  }
-  let document;
-  try {
-    document = JSON.parse(retainedDocumentJson);
-  } catch (error) {
-    throw new TypeError(`retained document must be valid JSON: ${error}`);
-  }
-  if (document?.channel !== "noon.authoring.retained") {
-    throw new TypeError("retained document must use noon.authoring.retained");
-  }
-  if (!Array.isArray(document.objects)) {
-    throw new TypeError("retained document objects must be an array");
-  }
-  return document;
 }
 
 function validateLoopDurationSeconds(loopDurationSeconds) {

--- a/web/execution-worker-client.js
+++ b/web/execution-worker-client.js
@@ -31,7 +31,6 @@ export class ExecutionWorkerClient {
   #session = 0;
   #mode = EXECUTION_MODE_LEGACY;
   #sceneJson = null;
-  #retainedDocumentJson = null;
   #sceneSpecJson = null;
   #loopDurationSeconds = 4;
   #transportMode = null;
@@ -150,31 +149,13 @@ export class ExecutionWorkerClient {
       (this.#renderPrepared === null ? DEFAULT_SHARED_SLOT_CAPACITY : this.#sharedSlotCapacity);
     validateSceneJson(sceneJson);
     sceneJson = projectLegacyReactiveSceneJson(sceneJson);
-    return this.#startMode(EXECUTION_MODE_LEGACY, sceneJson, null, {
+    return this.#startMode(EXECUTION_MODE_LEGACY, sceneJson, {
       loopDurationSeconds,
       transportMode,
       sharedSlotCapacity,
     });
   }
 
-  /// Compatibility entry point for the transitional split retained payload.
-  async startRetained(sceneJson, retainedDocumentJson, options = {}) {
-    const loopDurationSeconds = options.loopDurationSeconds ?? 4;
-    const transportMode =
-      options.transportMode ?? this.#transportMode ?? selectExecutionTransportMode();
-    const sharedSlotCapacity =
-      options.sharedSlotCapacity ??
-      (this.#renderPrepared === null ? DEFAULT_SHARED_SLOT_CAPACITY : this.#sharedSlotCapacity);
-    validateSceneJson(sceneJson);
-    validateRetainedDocumentJson(retainedDocumentJson);
-    return this.#startMode(EXECUTION_MODE_RETAINED, sceneJson, retainedDocumentJson, {
-      loopDurationSeconds,
-      transportMode,
-      sharedSlotCapacity,
-    });
-  }
-
-  /// Canonical retained startup. Normal authoring should use this path.
   async startRetainedCanonical(sceneSpecJson, options = {}) {
     const loopDurationSeconds = options.loopDurationSeconds ?? 4;
     const transportMode =
@@ -186,7 +167,6 @@ export class ExecutionWorkerClient {
     return this.#startMode(
       EXECUTION_MODE_RETAINED,
       null,
-      null,
       { loopDurationSeconds, transportMode, sharedSlotCapacity },
       sceneSpecJson,
     );
@@ -195,7 +175,6 @@ export class ExecutionWorkerClient {
   async #startMode(
     mode,
     sceneJson,
-    retainedDocumentJson,
     {
       loopDurationSeconds,
       transportMode,
@@ -213,17 +192,14 @@ export class ExecutionWorkerClient {
     validateExecutionMode(mode);
     if (mode === EXECUTION_MODE_LEGACY) {
       validateSceneJson(sceneJson);
-      if (sceneSpecJson !== null || retainedDocumentJson !== null) {
-        throw new Error("legacy execution must not include retained authoring payloads");
-      }
-    } else if (sceneSpecJson !== null) {
-      validateSceneSpecJson(sceneSpecJson);
-      if (sceneJson !== null || retainedDocumentJson !== null) {
-        throw new Error("retained execution must not mix canonical and compatibility inputs");
+      if (sceneSpecJson !== null) {
+        throw new Error("legacy execution must not include canonical retained authoring");
       }
     } else {
-      validateSceneJson(sceneJson);
-      validateRetainedDocumentJson(retainedDocumentJson);
+      validateSceneSpecJson(sceneSpecJson);
+      if (sceneJson !== null) {
+        throw new Error("retained execution accepts only canonical SceneSpec authoring");
+      }
     }
     validateLoopDurationSeconds(loopDurationSeconds);
     validateTransportMode(transportMode);
@@ -249,7 +225,6 @@ export class ExecutionWorkerClient {
         return await this.#startPreparedMode(
           mode,
           sceneJson,
-          retainedDocumentJson,
           loopDurationSeconds,
           sceneSpecJson,
         );
@@ -267,7 +242,6 @@ export class ExecutionWorkerClient {
     this.#configureStart(
       mode,
       sceneJson,
-      retainedDocumentJson,
       loopDurationSeconds,
       transportMode,
       slotCapacity,
@@ -311,7 +285,6 @@ export class ExecutionWorkerClient {
         channel.port1,
         mode,
         sceneJson,
-        retainedDocumentJson,
         loopDurationSeconds,
         this.#session,
         sceneSpecJson,
@@ -333,14 +306,12 @@ export class ExecutionWorkerClient {
   async #startPreparedMode(
     mode,
     sceneJson,
-    retainedDocumentJson,
     loopDurationSeconds,
     sceneSpecJson = null,
   ) {
     this.#configureStart(
       mode,
       sceneJson,
-      retainedDocumentJson,
       loopDurationSeconds,
       this.#transportMode,
       this.#sharedSlotCapacity,
@@ -373,7 +344,6 @@ export class ExecutionWorkerClient {
         channel.port1,
         mode,
         sceneJson,
-        retainedDocumentJson,
         loopDurationSeconds,
         this.#session,
         sceneSpecJson,
@@ -397,7 +367,6 @@ export class ExecutionWorkerClient {
   #configureStart(
     mode,
     sceneJson,
-    retainedDocumentJson,
     loopDurationSeconds,
     transportMode,
     sharedSlotCapacity,
@@ -405,8 +374,6 @@ export class ExecutionWorkerClient {
   ) {
     this.#mode = mode;
     this.#sceneJson = sceneJson;
-    this.#retainedDocumentJson =
-      mode === EXECUTION_MODE_RETAINED ? retainedDocumentJson : null;
     this.#sceneSpecJson = mode === EXECUTION_MODE_RETAINED ? sceneSpecJson : null;
     this.#loopDurationSeconds = loopDurationSeconds;
     this.#transportMode = transportMode;
@@ -472,26 +439,9 @@ export class ExecutionWorkerClient {
     return result;
   }
 
-  /// Compatibility transition for the split retained payload.
-  async switchToRetained(
-    sceneJson,
-    retainedDocumentJson,
-    { loopDurationSeconds = null } = {},
-  ) {
-    validateSceneJson(sceneJson);
-    validateRetainedDocumentJson(retainedDocumentJson);
-    return this.#transitionEngine(EXECUTION_MODE_RETAINED, sceneJson, retainedDocumentJson, {
-      loopDurationSeconds: validateOptionalLoopDurationSeconds(loopDurationSeconds),
-      callbacks: null,
-      authoringClient: null,
-      renderCommand: "switch_engine",
-    });
-  }
-
-  /// Canonical retained transition used by normal browser authoring.
   async switchToRetainedCanonical(sceneSpecJson, { loopDurationSeconds = null } = {}) {
     validateSceneSpecJson(sceneSpecJson);
-    return this.#transitionEngine(EXECUTION_MODE_RETAINED, null, null, {
+    return this.#transitionEngine(EXECUTION_MODE_RETAINED, null, {
       loopDurationSeconds: validateOptionalLoopDurationSeconds(loopDurationSeconds),
       callbacks: null,
       authoringClient: null,
@@ -500,26 +450,9 @@ export class ExecutionWorkerClient {
     });
   }
 
-  /// Compatibility rebuild for the split retained payload.
-  async rebuildRetained(
-    sceneJson,
-    retainedDocumentJson,
-    { loopDurationSeconds = null } = {},
-  ) {
-    validateSceneJson(sceneJson);
-    validateRetainedDocumentJson(retainedDocumentJson);
-    return this.#transitionEngine(EXECUTION_MODE_RETAINED, sceneJson, retainedDocumentJson, {
-      loopDurationSeconds: validateOptionalLoopDurationSeconds(loopDurationSeconds),
-      callbacks: null,
-      authoringClient: null,
-      renderCommand: "rebuild_engine",
-    });
-  }
-
-  /// Canonical retained rebuild used by normal browser authoring.
   async rebuildRetainedCanonical(sceneSpecJson, { loopDurationSeconds = null } = {}) {
     validateSceneSpecJson(sceneSpecJson);
-    return this.#transitionEngine(EXECUTION_MODE_RETAINED, null, null, {
+    return this.#transitionEngine(EXECUTION_MODE_RETAINED, null, {
       loopDurationSeconds: validateOptionalLoopDurationSeconds(loopDurationSeconds),
       callbacks: null,
       authoringClient: null,
@@ -542,7 +475,7 @@ export class ExecutionWorkerClient {
       validateCallbacks(callbacks);
       validateAuthoringClient(authoringClient);
     }
-    return this.#transitionEngine(EXECUTION_MODE_LEGACY, sceneJson, null, {
+    return this.#transitionEngine(EXECUTION_MODE_LEGACY, sceneJson, {
       loopDurationSeconds: validateOptionalLoopDurationSeconds(loopDurationSeconds),
       callbacks,
       authoringClient,
@@ -553,25 +486,19 @@ export class ExecutionWorkerClient {
   async #transitionEngine(
     nextMode,
     sceneJson,
-    retainedDocumentJson,
     { loopDurationSeconds, callbacks, authoringClient, renderCommand, sceneSpecJson = null },
   ) {
     this.#requireStarted();
     validateExecutionMode(nextMode);
     if (nextMode === EXECUTION_MODE_RETAINED) {
-      if (sceneSpecJson !== null) {
-        validateSceneSpecJson(sceneSpecJson);
-        if (sceneJson !== null || retainedDocumentJson !== null) {
-          throw new Error("retained execution must not mix canonical and compatibility inputs");
-        }
-      } else {
-        validateSceneJson(sceneJson);
-        validateRetainedDocumentJson(retainedDocumentJson);
+      validateSceneSpecJson(sceneSpecJson);
+      if (sceneJson !== null) {
+        throw new Error("retained execution accepts only canonical SceneSpec authoring");
       }
     } else {
       validateSceneJson(sceneJson);
-      if (sceneSpecJson !== null || retainedDocumentJson !== null) {
-        throw new Error("legacy execution must not include retained authoring payloads");
+      if (sceneSpecJson !== null) {
+        throw new Error("legacy execution must not include canonical retained authoring");
       }
     }
     if (renderCommand === "switch_engine" && nextMode === this.#mode) {
@@ -604,7 +531,6 @@ export class ExecutionWorkerClient {
         channel.port1,
         nextMode,
         sceneJson,
-        retainedDocumentJson,
         duration,
         nextSession,
         sceneSpecJson,
@@ -685,8 +611,6 @@ export class ExecutionWorkerClient {
 
       this.#mode = nextMode;
       this.#sceneJson = sceneJson;
-      this.#retainedDocumentJson =
-        nextMode === EXECUTION_MODE_RETAINED ? retainedDocumentJson : null;
       this.#sceneSpecJson = nextMode === EXECUTION_MODE_RETAINED ? sceneSpecJson : null;
       this.#loopDurationSeconds = duration;
       this.#fatalOwner = null;
@@ -808,8 +732,7 @@ export class ExecutionWorkerClient {
     const hasAuthoring =
       this.#mode === EXECUTION_MODE_LEGACY
         ? this.#sceneJson !== null
-        : this.#sceneSpecJson !== null ||
-          (this.#sceneJson !== null && this.#retainedDocumentJson !== null);
+        : this.#sceneSpecJson !== null;
     if (!hasAuthoring || this.#transportMode === null) {
       throw new Error("ExecutionWorkerClient has not been started");
     }
@@ -866,7 +789,6 @@ export class ExecutionWorkerClient {
         channel.port1,
         mode,
         this.#sceneJson,
-        this.#retainedDocumentJson,
         this.#loopDurationSeconds,
         this.#session,
         this.#sceneSpecJson,
@@ -900,7 +822,6 @@ export class ExecutionWorkerClient {
   async #restartAll() {
     const mode = this.#mode;
     const sceneJson = this.#sceneJson;
-    const retainedDocumentJson = this.#retainedDocumentJson;
     const sceneSpecJson = this.#sceneSpecJson;
     const loopDurationSeconds = this.#loopDurationSeconds;
     const transportMode = this.#transportMode;
@@ -918,7 +839,6 @@ export class ExecutionWorkerClient {
     const ready = await this.#startMode(
       mode,
       sceneJson,
-      retainedDocumentJson,
       { loopDurationSeconds, transportMode, sharedSlotCapacity },
       sceneSpecJson,
     );
@@ -1211,7 +1131,6 @@ export class ExecutionWorkerClient {
     port,
     mode,
     sceneJson,
-    retainedDocumentJson,
     loopDurationSeconds,
     session = this.#session,
     sceneSpecJson = null,
@@ -1223,13 +1142,12 @@ export class ExecutionWorkerClient {
       sharedSlotCapacity: this.#sharedSlotCapacity,
       session,
     };
-    if (mode === EXECUTION_MODE_RETAINED && sceneSpecJson !== null) {
+    if (mode === EXECUTION_MODE_RETAINED) {
+      validateSceneSpecJson(sceneSpecJson);
       payload.sceneSpecJson = sceneSpecJson;
     } else {
+      validateSceneJson(sceneJson);
       payload.sceneJson = sceneJson;
-      if (mode === EXECUTION_MODE_RETAINED) {
-        payload.retainedDocumentJson = retainedDocumentJson;
-      }
     }
     worker.postMessage(engineEnvelope("init", payload), [port]);
   }
@@ -1406,24 +1324,6 @@ function validateSceneSpecJson(sceneSpecJson) {
     throw new TypeError("canonical SceneSpec has an invalid camera object");
   }
   return sceneSpec;
-}
-
-function validateRetainedDocumentJson(retainedDocumentJson) {
-  if (typeof retainedDocumentJson !== "string" || retainedDocumentJson.trim() === "") {
-    throw new TypeError("retained document must be non-empty JSON text");
-  }
-  let document;
-  try {
-    document = JSON.parse(retainedDocumentJson);
-  } catch (error) {
-    throw new TypeError(`retained document must be valid JSON: ${error}`);
-  }
-  if (document?.channel !== "noon.authoring.retained") {
-    throw new TypeError("retained document must use noon.authoring.retained");
-  }
-  if (!Array.isArray(document.objects) || document.objects.length === 0) {
-    throw new TypeError("retained document must contain objects");
-  }
 }
 
 function validateLoopDurationSeconds(loopDurationSeconds) {

--- a/web/execution-worker-preflight.test.mjs
+++ b/web/execution-worker-preflight.test.mjs
@@ -84,10 +84,11 @@ globalThis.window = { devicePixelRatio: 1 };
 const { ExecutionWorkerClient } = await import("./execution-worker-client.js");
 
 const SCENE_JSON = JSON.stringify({ version: 1, objects: [], tracks: [] });
-const RETAINED_JSON = JSON.stringify({
-  channel: "noon.authoring.retained",
+const SCENE_SPEC_JSON = JSON.stringify({
   version: 1,
-  objects: [{ id: 1, kind: "typst" }],
+  camera_object: null,
+  objects: [{ id: 1, content: { kind: "text", text: {} } }],
+  tracks: [],
 });
 
 function engineMessage(type, payload = {}) {
@@ -142,7 +143,7 @@ test("mode transition preflights the candidate before touching the live render o
   const { client, engine: oldEngine, render } = await startLegacyClient();
   const canvas = client.canvas;
 
-  const transition = client.switchToRetained(SCENE_JSON, RETAINED_JSON);
+  const transition = client.switchToRetainedCanonical(SCENE_SPEC_JSON);
   await flush();
   const candidate = latestWorker("noon-mixed-retained-engine");
   assert.ok(candidate, "retained candidate must be created during preflight");
@@ -154,6 +155,9 @@ test("mode transition preflights the candidate before touching the live render o
   );
   const init = requestMessage(candidate, "init");
   assert.equal(init.session, 2, "candidate may reserve the next session without publishing it");
+  assert.equal(init.sceneSpecJson, SCENE_SPEC_JSON);
+  assert.equal("sceneJson" in init, false);
+  assert.equal("retainedDocumentJson" in init, false);
 
   const oldStatePromise = client.state();
   await flush();
@@ -170,7 +174,12 @@ test("mode transition preflights the candidate before touching the live render o
   assert.equal((await oldStatePromise).sceneJson, SCENE_JSON);
 
   candidate.emitMessage(
-    engineMessage("ready", { transportMode: "transferable", retained: true, mixed: true }),
+    engineMessage("ready", {
+      transportMode: "transferable",
+      retained: true,
+      mixed: true,
+      canonical: true,
+    }),
   );
   await flush();
 
@@ -199,7 +208,7 @@ test("candidate failure before readiness leaves the old engine and renderer auth
   const { client, engine: oldEngine, render } = await startLegacyClient();
   const canvas = client.canvas;
 
-  const transition = client.switchToRetained(SCENE_JSON, RETAINED_JSON);
+  const transition = client.switchToRetainedCanonical(SCENE_SPEC_JSON);
   await flush();
   const candidate = latestWorker("noon-mixed-retained-engine");
   candidate.emitMessage(engineMessage("error", { message: "candidate bootstrap rejected" }));
@@ -235,7 +244,7 @@ test("candidate failure before readiness leaves the old engine and renderer auth
 test("terminate cancels an unpublished candidate without resurrecting either generation", async () => {
   const { client, engine: oldEngine, render } = await startLegacyClient();
 
-  const transition = client.switchToRetained(SCENE_JSON, RETAINED_JSON);
+  const transition = client.switchToRetainedCanonical(SCENE_SPEC_JSON);
   await flush();
   const candidate = latestWorker("noon-mixed-retained-engine");
   assert.ok(candidate);

--- a/web/execution-worker-prepared-start.test.mjs
+++ b/web/execution-worker-prepared-start.test.mjs
@@ -85,9 +85,11 @@ globalThis.window = { devicePixelRatio: 1 };
 const { ExecutionWorkerClient } = await import("./execution-worker-client.js");
 
 const SCENE_JSON = JSON.stringify({ version: 1, objects: [], tracks: [] });
-const RETAINED_DOCUMENT_JSON = JSON.stringify({
-  channel: "noon.authoring.retained",
-  objects: [{ id: 1 }],
+const SCENE_SPEC_JSON = JSON.stringify({
+  version: 1,
+  camera_object: null,
+  objects: [{ id: 1, content: { kind: "text", text: {} } }],
+  tracks: [],
 });
 
 function engineMessage(type, payload = {}) {
@@ -158,7 +160,7 @@ test("prepared render owner waits for preparation before starting the authored r
   const prepareRequest = requestMessage(render, "prepare");
   assert.equal(prepareRequest.mode, undefined, "render preparation must remain mode-free");
 
-  const startPromise = client.startRetained(SCENE_JSON, RETAINED_DOCUMENT_JSON);
+  const startPromise = client.startRetainedCanonical(SCENE_SPEC_JSON);
   assert.equal(
     FakeWorker.instances.length,
     1,
@@ -180,11 +182,14 @@ test("prepared render owner waits for preparation before starting the authored r
   assert.equal(startRequest.mode, "retained");
   assert.equal(startRequest.transportMode, "transferable");
   const engineInit = requestMessage(retainedEngine, "init");
-  assert.equal(engineInit.retainedDocumentJson, RETAINED_DOCUMENT_JSON);
+  assert.equal(engineInit.sceneSpecJson, SCENE_SPEC_JSON);
+  assert.equal("sceneJson" in engineInit, false);
+  assert.equal("retainedDocumentJson" in engineInit, false);
 
   retainedEngine.emitMessage(
     engineMessage("ready", {
       transportMode: "transferable",
+      canonical: true,
     }),
   );
   render.emitMessage(
@@ -209,7 +214,7 @@ test("prepared render owner admits only one authored start while preparation is 
 
   const preparePromise = client.prepare({ transportMode: "transferable" });
   const render = workerByName(0, "noon-render");
-  const retainedStart = client.startRetained(SCENE_JSON, RETAINED_DOCUMENT_JSON);
+  const retainedStart = client.startRetainedCanonical(SCENE_SPEC_JSON);
   let competingError = null;
   const competingStart = client.start(SCENE_JSON).catch((error) => {
     competingError = error;
@@ -232,7 +237,9 @@ test("prepared render owner admits only one authored start while preparation is 
   const retainedEngine = engineWorkers[0];
   const startRequest = requestMessage(render, "start_engine");
   assert.equal(startRequest.mode, "retained");
-  retainedEngine.emitMessage(engineMessage("ready", { transportMode: "transferable" }));
+  retainedEngine.emitMessage(
+    engineMessage("ready", { transportMode: "transferable", canonical: true }),
+  );
   render.emitMessage(
     renderMessage("engine_started", {
       requestId: startRequest.requestId,
@@ -258,7 +265,7 @@ test("failed prepared engine attachment replaces the transferred canvas and rema
   acknowledgePreparation(render);
   await preparePromise;
 
-  const started = client.startRetained(SCENE_JSON, RETAINED_DOCUMENT_JSON);
+  const started = client.startRetainedCanonical(SCENE_SPEC_JSON);
   await new Promise((resolve) => setImmediate(resolve));
   const engine = workerByName(1, "noon-mixed-retained-engine");
   requestMessage(render, "start_engine");
@@ -273,12 +280,14 @@ test("failed prepared engine attachment replaces the transferred canvas and rema
   assert.equal(client.canvas.transferred, false);
 
   const retryOffset = FakeWorker.instances.length;
-  const retry = client.startRetained(SCENE_JSON, RETAINED_DOCUMENT_JSON, {
+  const retry = client.startRetainedCanonical(SCENE_SPEC_JSON, {
     transportMode: "transferable",
   });
   const retryEngine = workerByName(retryOffset, "noon-mixed-retained-engine");
   const retryRender = workerByName(retryOffset, "noon-render");
-  retryEngine.emitMessage(engineMessage("ready", { transportMode: "transferable" }));
+  retryEngine.emitMessage(
+    engineMessage("ready", { transportMode: "transferable", canonical: true }),
+  );
   retryRender.emitMessage(
     renderMessage("ready", {
       transportMode: "transferable",
@@ -339,12 +348,14 @@ test("abandoning preparation restores the transferred canvas before any engine s
   assert.equal(client.canvas.transferred, false);
 
   const retryOffset = FakeWorker.instances.length;
-  const retry = client.startRetained(SCENE_JSON, RETAINED_DOCUMENT_JSON, {
+  const retry = client.startRetainedCanonical(SCENE_SPEC_JSON, {
     transportMode: "transferable",
   });
   const retryEngine = workerByName(retryOffset, "noon-mixed-retained-engine");
   const retryRender = workerByName(retryOffset, "noon-render");
-  retryEngine.emitMessage(engineMessage("ready", { transportMode: "transferable" }));
+  retryEngine.emitMessage(
+    engineMessage("ready", { transportMode: "transferable", canonical: true }),
+  );
   retryRender.emitMessage(
     renderMessage("ready", {
       transportMode: "transferable",

--- a/web/execution-worker-retained-start.test.mjs
+++ b/web/execution-worker-retained-start.test.mjs
@@ -48,20 +48,16 @@ globalThis.Worker = FakeWorker;
 globalThis.window = { devicePixelRatio: 1 };
 
 const { AuthoringExecutionClient } = await import("./authoring-execution-client.js");
+const { ExecutionWorkerClient } = await import("./execution-worker-client.js");
 
-const SCENE_JSON = JSON.stringify({ version: 1, objects: [], tracks: [] });
 const SCENE_SPEC_JSON = JSON.stringify({
   version: 1,
   camera_object: null,
   objects: [{ id: 7, content: { kind: "text", text: {} } }],
   tracks: [],
 });
-const RETAINED_DOCUMENT_JSON = JSON.stringify({
-  channel: "noon.authoring.retained",
-  objects: [{ id: 1 }],
-});
 
-function engineReady({ canonical = false } = {}) {
+function engineReady() {
   return {
     channel: "noon.engine",
     protocolVersion: 1,
@@ -69,7 +65,7 @@ function engineReady({ canonical = false } = {}) {
     transportMode: "transferable",
     retained: true,
     mixed: true,
-    canonical,
+    canonical: true,
   };
 }
 
@@ -108,7 +104,7 @@ test("canonical retained first start sends only SceneSpec to the retained engine
   assert.equal("retainedDocumentJson" in engineInit, false);
   assert.equal(renderInit?.mode, "retained");
 
-  retainedEngine.emitMessage(engineReady({ canonical: true }));
+  retainedEngine.emitMessage(engineReady());
   render.emitMessage(renderReady());
   const ready = await readyPromise;
 
@@ -118,26 +114,22 @@ test("canonical retained first start sends only SceneSpec to the retained engine
   client.terminate();
 });
 
-test("split retained startup remains an explicit compatibility path", async () => {
-  FakeWorker.instances.length = 0;
-  const client = new AuthoringExecutionClient(new FakeCanvas());
-  const readyPromise = client.startRetained(SCENE_JSON, RETAINED_DOCUMENT_JSON, {
-    transportMode: "transferable",
-  });
-
-  const retainedEngine = FakeWorker.instances.find(
-    ({ name }) => name === "noon-mixed-retained-engine",
-  );
-  const render = FakeWorker.instances.find(({ name }) => name === "noon-render");
-  const engineInit = retainedEngine.messages.find(({ message }) => message.type === "init")?.message;
-  assert.equal(engineInit?.sceneJson, SCENE_JSON);
-  assert.equal(engineInit?.retainedDocumentJson, RETAINED_DOCUMENT_JSON);
-  assert.equal("sceneSpecJson" in engineInit, false);
-
-  retainedEngine.emitMessage(engineReady());
-  render.emitMessage(renderReady());
-  const ready = await readyPromise;
-  assert.equal(ready.session, 1);
-  assert.equal(client.mode, "retained");
-  client.terminate();
+test("split retained startup and transition APIs stay retired", () => {
+  for (const [owner, prototype] of [
+    ["authoring", AuthoringExecutionClient.prototype],
+    ["execution", ExecutionWorkerClient.prototype],
+  ]) {
+    assert.equal(
+      Object.prototype.hasOwnProperty.call(prototype, "startRetained"),
+      false,
+      `${owner} client must not expose split retained startup`,
+    );
+  }
+  for (const method of ["switchToRetained", "rebuildRetained"]) {
+    assert.equal(
+      Object.prototype.hasOwnProperty.call(ExecutionWorkerClient.prototype, method),
+      false,
+      `execution client must not expose ${method}`,
+    );
+  }
 });

--- a/web/playground-stability-boundary.test.mjs
+++ b/web/playground-stability-boundary.test.mjs
@@ -52,13 +52,13 @@ assert.doesNotMatch(
 );
 assert.match(
   authoringExecutionClient,
-  /player\.switchToRetained\(/,
-  "legacy to retained authoring must switch the persistent execution owner in place",
+  /player\.switchToRetainedCanonical\(/,
+  "legacy to retained authoring must switch the persistent execution owner in place using canonical SceneSpec",
 );
 assert.match(
   authoringExecutionClient,
-  /player\.rebuildRetained\(/,
-  "retained authoring edits must rebuild on the persistent execution owner",
+  /player\.rebuildRetainedCanonical\(/,
+  "retained authoring edits must rebuild on the persistent execution owner using canonical SceneSpec",
 );
 assert.match(
   authoringExecutionClient,

--- a/web/retained-execution-engine-worker.js
+++ b/web/retained-execution-engine-worker.js
@@ -1,7 +1,4 @@
-import init, {
-  CanonicalRetainedEngineScenePlayer,
-  MixedRetainedEngineScenePlayer,
-} from "./pkg/noon_web.js";
+import init, { CanonicalRetainedEngineScenePlayer } from "./pkg/noon_web.js";
 import {
   EXECUTION_TRANSPORT_SHARED,
   EXECUTION_TRANSPORT_TRANSFERABLE,
@@ -12,14 +9,11 @@ import {
 
 const ENGINE_CHANNEL = "noon.engine";
 const ENGINE_PROTOCOL_VERSION = 1;
-const AUTHORING_CANONICAL = "canonical";
-const AUTHORING_COMPATIBILITY = "compatibility";
 
 let renderPort = null;
 let transportMode = null;
 let transport = null;
 let player = null;
-let authoringKind = null;
 let latestTick = null;
 let controlQueue = [];
 let initialized = false;
@@ -56,7 +50,7 @@ async function handleMainMessage(message) {
           metrics: {
             retained: true,
             mixed: true,
-            canonical: authoringKind === AUTHORING_CANONICAL,
+            canonical: true,
             time: player.time(),
             playing: player.isPlaying(),
             stopped,
@@ -96,7 +90,7 @@ async function initialize(message) {
   if (!(message.port instanceof MessagePort)) {
     throw new Error("retained execution engine init requires a render MessagePort");
   }
-  const authoring = validateAuthoringInput(message);
+  const sceneSpecJson = validateSceneSpecInput(message);
   validateLoopDuration(message.loopDurationSeconds);
   if (!Number.isSafeInteger(message.session) || message.session < 0) {
     throw new Error("retained execution session must be a non-negative safe integer");
@@ -112,9 +106,12 @@ async function initialize(message) {
   renderPort.addEventListener("message", (event) => handleRenderMessage(event.data));
   renderPort.start();
   transportMode = message.transportMode;
-  authoringKind = authoring.kind;
   await init();
-  player = createPlayer(authoring, message.loopDurationSeconds, message.session);
+  player = new CanonicalRetainedEngineScenePlayer(
+    sceneSpecJson,
+    message.loopDurationSeconds,
+    message.session,
+  );
 
   // wasm-bindgen returns a view/copy for Vec<u8>; make an independently owned
   // transferable buffer so detaching it cannot affect WebAssembly memory.
@@ -147,25 +144,9 @@ async function initialize(message) {
     transportMode,
     retained: true,
     mixed: true,
-    canonical: authoringKind === AUTHORING_CANONICAL,
+    canonical: true,
   });
   drainWork();
-}
-
-function createPlayer(authoring, loopDurationSeconds, session) {
-  if (authoring.kind === AUTHORING_CANONICAL) {
-    return new CanonicalRetainedEngineScenePlayer(
-      authoring.sceneSpecJson,
-      loopDurationSeconds,
-      session,
-    );
-  }
-  return new MixedRetainedEngineScenePlayer(
-    authoring.sceneJson,
-    authoring.retainedDocumentJson,
-    loopDurationSeconds,
-    session,
-  );
 }
 
 function handleRenderMessage(message) {
@@ -315,7 +296,7 @@ function runtimeState(type, operation = undefined) {
     time: player.time(),
     playing: player.isPlaying(),
     nextPatchSequence: "0",
-    ...authoringState(),
+    sceneSpecJson: player.sceneSpecJson(),
   };
   if (operation !== undefined) {
     state.operation = operation;
@@ -323,41 +304,14 @@ function runtimeState(type, operation = undefined) {
   return state;
 }
 
-function authoringState() {
-  if (authoringKind === AUTHORING_CANONICAL) {
-    return { sceneSpecJson: player.sceneSpecJson() };
+function validateSceneSpecInput(message) {
+  if (message.sceneJson !== undefined || message.retainedDocumentJson !== undefined) {
+    throw new Error("retained execution init accepts only canonical sceneSpecJson");
   }
-  return {
-    sceneJson: player.legacySceneJson(),
-    retainedDocumentJson: player.retainedDocumentJson(),
-  };
-}
-
-function validateAuthoringInput(message) {
-  const hasCanonical =
-    typeof message.sceneSpecJson === "string" && message.sceneSpecJson.trim() !== "";
-  const hasLegacyScene =
-    typeof message.sceneJson === "string" && message.sceneJson.trim() !== "";
-  const hasRetainedDocument =
-    typeof message.retainedDocumentJson === "string" &&
-    message.retainedDocumentJson.trim() !== "";
-
-  if (hasCanonical) {
-    if (message.sceneJson !== undefined || message.retainedDocumentJson !== undefined) {
-      throw new Error("retained execution init must not mix canonical and compatibility inputs");
-    }
-    return { kind: AUTHORING_CANONICAL, sceneSpecJson: message.sceneSpecJson };
+  if (typeof message.sceneSpecJson !== "string" || message.sceneSpecJson.trim() === "") {
+    throw new Error("retained execution init requires canonical sceneSpecJson");
   }
-  if (hasLegacyScene && hasRetainedDocument) {
-    return {
-      kind: AUTHORING_COMPATIBILITY,
-      sceneJson: message.sceneJson,
-      retainedDocumentJson: message.retainedDocumentJson,
-    };
-  }
-  throw new Error(
-    "retained execution init requires sceneSpecJson or the complete legacy scene + retained document pair",
-  );
+  return message.sceneSpecJson;
 }
 
 function respond(requestId, payload) {

--- a/web/retained-execution-topology.test.mjs
+++ b/web/retained-execution-topology.test.mjs
@@ -6,6 +6,14 @@ const smoke = await readFile(
   "utf8",
 );
 const generalClient = await readFile(new URL("./execution-worker-client.js", import.meta.url), "utf8");
+const authoringClient = await readFile(
+  new URL("./authoring-execution-client.js", import.meta.url),
+  "utf8",
+);
+const retainedEngine = await readFile(
+  new URL("./retained-execution-engine-worker.js", import.meta.url),
+  "utf8",
+);
 const renderEntry = await readFile(new URL("./execution-render-worker.js", import.meta.url), "utf8");
 
 await assert.rejects(
@@ -39,10 +47,42 @@ assert.match(
   /new URL\("\.\/retained-execution-engine-worker\.js", import\.meta\.url\)/,
   "the shared execution client remains the retained engine owner",
 );
+for (const [surface, source] of [
+  ["execution client", generalClient],
+  ["authoring client", authoringClient],
+]) {
+  assert.doesNotMatch(
+    source,
+    /async startRetained\(/,
+    `${surface} must not expose split retained startup`,
+  );
+}
+for (const method of ["switchToRetained", "rebuildRetained"]) {
+  assert.doesNotMatch(
+    generalClient,
+    new RegExp(`async ${method}\\(`),
+    `execution client must not expose split ${method}`,
+  );
+}
+assert.match(
+  retainedEngine,
+  /CanonicalRetainedEngineScenePlayer/,
+  "retained engine must lower canonical SceneSpec",
+);
+assert.doesNotMatch(
+  retainedEngine,
+  /MixedRetainedEngineScenePlayer|AUTHORING_COMPATIBILITY/,
+  "retained engine must not retain split authoring execution",
+);
+assert.match(
+  retainedEngine,
+  /retained execution init accepts only canonical sceneSpecJson/,
+  "retained engine must reject legacy split wire fields",
+);
 assert.match(
   renderEntry,
   /import "\.\/authoring-render-worker\.js";/,
   "legacy and retained execution must share the permanent authoring render owner",
 );
 
-console.log("✓ retained browser execution has one client and one render-owner topology");
+console.log("✓ retained browser execution has one canonical client/engine/render topology");


### PR DESCRIPTION
## Summary

- remove split retained startup/switch/rebuild APIs from `AuthoringExecutionClient` and `ExecutionWorkerClient`
- retain geometry-only `sceneJson` execution, but require canonical `sceneSpecJson` for every retained start, transition, rebuild, and recovery
- make `retained-execution-engine-worker.js` instantiate only `CanonicalRetainedEngineScenePlayer`
- reject legacy `sceneJson` / `retainedDocumentJson` fields at the retained engine boundary
- replace the compatibility startup test with API-retirement assertions and extend the retained topology ratchet

## Architecture

Retained browser execution now has one authoring contract end to end:

```text
Python/browser authoring
  -> canonical SceneSpec
  -> AuthoringExecutionClient
  -> ExecutionWorkerClient
  -> retained execution engine
  -> CanonicalRetainedEngineScenePlayer
  -> shared authoring render owner
```

`SceneDocument`/`sceneJson` remains the geometry-only legacy execution contract. It is no longer accepted as half of a retained execution payload.

This intentionally does not yet remove the Rust/WASM `MixedRetainedEngineScenePlayer` compatibility adapter or the Python retained sidecar producer; those become independently removable once this browser boundary is proven green.

Tracks #367. Follows #811 and #812.