### PR TITLE
Validate canonical SceneSpec identity before worker startup

### DIFF
--- a/web/authoring-execution-client.js
+++ b/web/authoring-execution-client.js
@@ -527,6 +527,31 @@ function validateSceneSpecJson(sceneSpecJson) {
   if (!Array.isArray(sceneSpec.objects) || !Array.isArray(sceneSpec.tracks)) {
     throw new TypeError("canonical SceneSpec must contain object and track arrays");
   }
+  const objectIds = new Set();
+  for (const object of sceneSpec.objects) {
+    if (
+      !object ||
+      typeof object !== "object" ||
+      Array.isArray(object) ||
+      !Number.isSafeInteger(object.id) ||
+      object.id < 0
+    ) {
+      throw new TypeError("canonical SceneSpec object has an invalid object ID");
+    }
+    if (objectIds.has(object.id)) {
+      throw new TypeError("canonical SceneSpec has duplicate object IDs");
+    }
+    objectIds.add(object.id);
+  }
+  if (
+    sceneSpec.camera_object !== null &&
+    sceneSpec.camera_object !== undefined &&
+    (!Number.isSafeInteger(sceneSpec.camera_object) ||
+      sceneSpec.camera_object < 0 ||
+      !objectIds.has(sceneSpec.camera_object))
+  ) {
+    throw new TypeError("canonical SceneSpec has an invalid camera object");
+  }
   return sceneSpec;
 }
 

--- a/web/authoring-execution-scene-spec-validation.test.mjs
+++ b/web/authoring-execution-scene-spec-validation.test.mjs
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { AuthoringExecutionClient } from "./authoring-execution-client.js";
+
+class TestCanvas {
+  clientWidth = 640;
+  clientHeight = 360;
+}
+
+globalThis.HTMLCanvasElement = TestCanvas;
+
+function createClient() {
+  return new AuthoringExecutionClient(new TestCanvas());
+}
+
+function sceneSpec(objects, cameraObject = undefined) {
+  const spec = { version: 1, objects, tracks: [] };
+  if (cameraObject !== undefined) {
+    spec.camera_object = cameraObject;
+  }
+  return JSON.stringify(spec);
+}
+
+test("canonical retained startup rejects invalid object IDs before worker startup", async () => {
+  const invalidObjects = [
+    {},
+    { id: -1 },
+    { id: Number.MAX_SAFE_INTEGER + 1 },
+    { id: "1" },
+  ];
+
+  for (const object of invalidObjects) {
+    await assert.rejects(
+      createClient().startRetainedCanonical(sceneSpec([object])),
+      /invalid object ID/,
+    );
+  }
+});
+
+test("canonical retained startup rejects duplicate object IDs before worker startup", async () => {
+  await assert.rejects(
+    createClient().startRetainedCanonical(sceneSpec([{ id: 7 }, { id: 7 }])),
+    /duplicate object IDs/,
+  );
+});
+
+test("canonical retained startup rejects invalid camera references before worker startup", async () => {
+  for (const cameraObject of [-1, 2, Number.MAX_SAFE_INTEGER + 1, "1"]) {
+    await assert.rejects(
+      createClient().startRetainedCanonical(sceneSpec([{ id: 1 }], cameraObject)),
+      /invalid camera object/,
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- reject malformed canonical retained object IDs at the `AuthoringExecutionClient` ingress before creating or switching execution workers
- reject duplicate object IDs and invalid `camera_object` references using the same identity invariants already enforced by the lower execution client
- add focused Node coverage proving malformed canonical specs fail before worker startup

## Why
#815 made retained browser execution canonical-only. That left the top-level authoring execution facade validating only SceneSpec JSON shape/version while the lower execution client and authoring-result boundary already validate semantic identity. Malformed canonical identity could therefore cross the facade and fail only after entering worker-transition machinery.

This keeps failure at the ownership boundary and avoids partial/needless worker startup. Validation is O(number of objects) with one temporary `Set`; no frame-path behavior changes.

## Validation
- branch is exactly one commit on current master `6b8daf09669b224e62c2deb7a000f8fd97e33a8d`
- diff: 2 files, +80/-0
- focused tests cover invalid, duplicate, and unsafe object IDs plus invalid camera references
- full PR Fast Gate requested by normal CI

## Risk
Low. Valid SceneSpecs are unchanged. Inputs that were already rejected by the lower execution boundary are now rejected earlier by `AuthoringExecutionClient` with the same invariant.