### PR TITLE
Restore canonical retained browser smoke coverage

### DIFF
--- a/scripts/authoring-execution-router-smoke.mjs
+++ b/scripts/authoring-execution-router-smoke.mjs
@@ -126,11 +126,10 @@ try {
 
     const mixed = await authoring.run(mixedSource, {});
     const mixedRetainedBackend = mixed.retainedDocument.objects[0].text.backend.kind;
+    const mixedSceneSpecJson = JSON.stringify(mixed.sceneSpec);
     const inFlightLegacyMetrics = execution.metrics();
     const mixedTransition = execution.reconcileScene(JSON.stringify(mixed.document), {
-      retainedDocumentJson: JSON.stringify(mixed.retainedDocument),
-      callbacks: mixed.callbacks,
-      authoringClient: authoring,
+      sceneSpecJson: mixedSceneSpecJson,
       loopDurationSeconds: mixed.duration > 0 ? mixed.duration : null,
     });
     const mixedTransitionMetrics = execution.metrics();
@@ -146,9 +145,7 @@ try {
     const mixedCanvas = execution.canvas;
 
     const secondMixed = await execution.reconcileScene(JSON.stringify(mixed.document), {
-      retainedDocumentJson: JSON.stringify(mixed.retainedDocument),
-      callbacks: mixed.callbacks,
-      authoringClient: authoring,
+      sceneSpecJson: mixedSceneSpecJson,
       loopDurationSeconds: mixed.duration > 0 ? mixed.duration : null,
     });
     await new Promise((resolve) => setTimeout(resolve, 250));
@@ -177,7 +174,7 @@ try {
     let callbackError = null;
     try {
       await execution.reconcileScene(JSON.stringify(mixed.document), {
-        retainedDocumentJson: JSON.stringify(mixed.retainedDocument),
+        sceneSpecJson: mixedSceneSpecJson,
         callbacks: { session_id: 1, slots: [{}] },
         authoringClient: authoring,
       });
@@ -189,7 +186,6 @@ try {
     const legacyRetainedObjectCount = legacy.retainedDocument?.objects?.length ?? -1;
     const inFlightRetainedMetrics = execution.metrics();
     const legacyTransition = execution.reconcileScene(JSON.stringify(legacy.document), {
-      retainedDocumentJson: JSON.stringify(legacy.retainedDocument),
       callbacks: legacy.callbacks,
       authoringClient: authoring,
       loopDurationSeconds: legacy.duration > 0 ? legacy.duration : null,
@@ -221,7 +217,6 @@ try {
     const legacyPlaybackRestartState = await execution.state();
 
     const secondLegacy = await execution.reconcileScene(JSON.stringify(legacy.document), {
-      retainedDocumentJson: JSON.stringify(legacy.retainedDocument),
       callbacks: legacy.callbacks,
       authoringClient: authoring,
     });
@@ -230,6 +225,8 @@ try {
     const legacyRestartMetrics = await execution.metrics();
 
     const state = await execution.state();
+    const mixedRaceSceneSpec = JSON.parse(mixedRaceState.sceneSpecJson);
+    const mixedRestartSceneSpec = JSON.parse(mixedRestartState.sceneSpecJson);
     const summary = {
       initialMode: AUTHORING_EXECUTION_LEGACY,
       retainedMode: AUTHORING_EXECUTION_RETAINED,
@@ -241,7 +238,8 @@ try {
       mixedRebuilt: mixedResult.rebuilt,
       mixedCanvasChanged: mixedCanvas !== initialCanvas,
       mixedRaceMode: mixedRaceMetrics.executionMode,
-      mixedRaceRetainedChannel: JSON.parse(mixedRaceState.retainedDocumentJson).channel,
+      mixedRaceSceneSpecVersion: mixedRaceSceneSpec.version,
+      mixedRaceSceneSpecObjectCount: mixedRaceSceneSpec.objects.length,
       mixedMetrics,
       secondMixedMode: secondMixed.mode,
       secondMixedRebuilt: secondMixed.rebuilt,
@@ -261,7 +259,8 @@ try {
       mixedRestartMode: mixedRestartReady.mode,
       mixedRestartCanvasChanged: mixedRestartCanvas !== mixedCanvas,
       mixedRestartObjectCount: mixedRestartMetrics.metrics.objectCount,
-      mixedRestartRetainedChannel: JSON.parse(mixedRestartState.retainedDocumentJson).channel,
+      mixedRestartSceneSpecVersion: mixedRestartSceneSpec.version,
+      mixedRestartSceneSpecObjectCount: mixedRestartSceneSpec.objects.length,
       callbackError,
       legacyRetainedObjectCount,
       retainedRaceModeBeforeLegacy: retainedRaceMetrics.executionMode,
@@ -306,7 +305,8 @@ try {
   assert.equal(result.mixedRebuilt, true);
   assert.equal(result.mixedCanvasChanged, false);
   assert.equal(result.mixedRaceMode, result.retainedMode);
-  assert.equal(result.mixedRaceRetainedChannel, "noon.authoring.retained");
+  assert.equal(result.mixedRaceSceneSpecVersion, 1);
+  assert.equal(result.mixedRaceSceneSpecObjectCount, 3);
   assert.equal(result.mixedMetrics.executionMode, result.retainedMode);
   assert.equal(result.mixedMetrics.metrics.ready, true);
   assert.equal(result.mixedMetrics.metrics.objectCount, 3);
@@ -349,7 +349,8 @@ try {
   assert.equal(result.mixedRestartMode, result.retainedMode);
   assert.equal(result.mixedRestartCanvasChanged, true);
   assert.equal(result.mixedRestartObjectCount, 3);
-  assert.equal(result.mixedRestartRetainedChannel, "noon.authoring.retained");
+  assert.equal(result.mixedRestartSceneSpecVersion, 1);
+  assert.equal(result.mixedRestartSceneSpecObjectCount, 3);
   assert.match(result.callbackError, /retained authoring with Python host callbacks is not supported yet/);
 
   assert.equal(result.legacyRetainedObjectCount, 0, "geometry-only authoring should emit an empty sidecar");

--- a/scripts/authoring-render-mode-switch-smoke.mjs
+++ b/scripts/authoring-render-mode-switch-smoke.mjs
@@ -122,6 +122,7 @@ async function runMode(browser, transportMode) {
     const wasm = await import("./pkg/noon_web.js");
     await wasm.default();
     const sceneJson = wasm.demoSceneJson();
+    const sceneSpecJson = wasm.canonicalRetainedSceneSpecJson(sceneJson, retainedDocumentJson);
     const originalCanvas = document.querySelector("#scene");
     const devicePixelRatio = window.devicePixelRatio || 1;
     const width = Math.max(1, Math.round(originalCanvas.clientWidth * devicePixelRatio));
@@ -252,8 +253,7 @@ async function runMode(browser, transportMode) {
           protocolVersion: 1,
           type: "init",
           port,
-          sceneJson,
-          ...(retained ? { retainedDocumentJson } : {}),
+          ...(retained ? { sceneSpecJson } : { sceneJson }),
           loopDurationSeconds: 4,
           transportMode: mode,
           sharedSlotCapacity: 1024 * 1024,

--- a/scripts/authoring-render-prepare-smoke.mjs
+++ b/scripts/authoring-render-prepare-smoke.mjs
@@ -107,6 +107,9 @@ async function runMode(browser, transportMode) {
 
   const result = await page.evaluate(
     async ({ transportMode: mode, retainedDocumentJson: retained, sceneJson: scene }) => {
+      const wasm = await import("./pkg/noon_web.js");
+      await wasm.default();
+      const sceneSpecJson = wasm.canonicalRetainedSceneSpecJson(scene, retained);
       const canvas = document.querySelector("#scene");
       const devicePixelRatio = window.devicePixelRatio || 1;
       const width = Math.max(1, Math.round(canvas.clientWidth * devicePixelRatio));
@@ -225,8 +228,7 @@ async function runMode(browser, transportMode) {
           protocolVersion: 1,
           type: "init",
           port: channel.port1,
-          sceneJson: scene,
-          retainedDocumentJson: retained,
+          sceneSpecJson,
           loopDurationSeconds: 4,
           transportMode: mode,
           sharedSlotCapacity: 1024 * 1024,


### PR DESCRIPTION
## Summary
- repair the two master workflows that regressed after #815 retired split retained browser initialization/reconciliation
- migrate the Python authoring execution router smoke to consume the canonical `sceneSpec` emitted by Python authoring for retained scenes
- keep geometry-only authoring on the legacy `sceneJson` path without passing an empty retained sidecar
- migrate prepared-render and persistent render-owner smoke workers to derive one canonical `sceneSpecJson` through the existing Rust/WASM `canonicalRetainedSceneSpecJson` bridge
- make low-level retained engine init send only `sceneSpecJson`; legacy engine init continues to send only `sceneJson`

## Why
Current master `6b8daf09669b224e62c2deb7a000f8fd97e33a8d` is red in both `CI` and `Authoring render mode switch`. The failures are deterministic harness drift from #815, not a production compatibility gap:
- authoring router: `split retained reconciliation is retired; provide canonical sceneSpecJson instead`
- prepared retained owner: `retained execution init accepts only canonical sceneSpecJson`

The dedicated mode-switch smoke had the same stale retained init shape in its next skipped step, so this updates all three contract consumers together instead of fixing failures one at a time.

## Architecture
No production API or compatibility fallback is restored. Canonicalization remains owned by the existing authoring/Rust-WASM boundary, and retained workers continue to accept only canonical SceneSpec. Existing race, lifecycle, pause/resume/seek/restart, transport, persistent-canvas, and renderer-switch assertions remain intact; retained state assertions now inspect canonical `sceneSpecJson` instead of the retired sidecar.

## Validation
PR Fast Gate validates web/static syntax, Rust format/lint/tests, deterministic playback, Manim authoring, the browser package, and primary WebGPU rendering. Its optional canonical-retained step is not classified for these script-only paths and is skipped. The two exact regression workflows are `push: master`/`workflow_dispatch` only; the connected GitHub surface does not expose workflow dispatch. After merge, both rerun automatically because the changed script paths are explicit workflow triggers, and their results should be treated as the final regression qualification.