### PR TITLE
Migrate authoring lifecycle smoke to canonical SceneSpec

### DIFF
--- a/scripts/authoring-execution-lifecycle-smoke.mjs
+++ b/scripts/authoring-execution-lifecycle-smoke.mjs
@@ -126,6 +126,7 @@ try {
     const authoring = new PythonAuthoringClient();
     const emptySceneJson = '{"version":1,"objects":[],"tracks":[]}';
     const mixed = await authoring.run(mixedSource, {});
+    const mixedSceneSpecJson = JSON.stringify(mixed.sceneSpec);
     const legacy = await authoring.run(legacySource, {});
 
     function freshCanvas() {
@@ -183,9 +184,7 @@ try {
     });
     const toRetained = await expectTerminated(retainedExecution, () =>
       retainedExecution.reconcileScene(JSON.stringify(mixed.document), {
-        retainedDocumentJson: JSON.stringify(mixed.retainedDocument),
-        callbacks: mixed.callbacks,
-        authoringClient: authoring,
+        sceneSpecJson: mixedSceneSpecJson,
         loopDurationSeconds: mixed.duration > 0 ? mixed.duration : null,
       }),
     );
@@ -196,14 +195,11 @@ try {
       transportMode: "transferable",
     });
     const retainedReady = await legacyExecution.reconcileScene(JSON.stringify(mixed.document), {
-      retainedDocumentJson: JSON.stringify(mixed.retainedDocument),
-      callbacks: mixed.callbacks,
-      authoringClient: authoring,
+      sceneSpecJson: mixedSceneSpecJson,
       loopDurationSeconds: mixed.duration > 0 ? mixed.duration : null,
     });
     const toLegacy = await expectTerminated(legacyExecution, () =>
       legacyExecution.reconcileScene(JSON.stringify(legacy.document), {
-        retainedDocumentJson: JSON.stringify(legacy.retainedDocument),
         callbacks: legacy.callbacks,
         authoringClient: authoring,
         loopDurationSeconds: legacy.duration > 0 ? legacy.duration : null,


### PR DESCRIPTION
## Summary
- migrate the remaining authoring execution lifecycle/termination smoke from retired split retained reconciliation to canonical `sceneSpecJson`
- preserve the existing startup, retained-transition, retained→legacy transition, immediate termination, unpublished-worker invalidation, and at-most-once worker termination assertions
- keep the legacy transition on `sceneJson` only; no compatibility sidecar is reintroduced

## Why
After #820 fixed the original post-#815 regressions, master CI advanced past `Test Python authoring execution routing` successfully and exposed the next stale harness in `authoring-execution-lifecycle-smoke.mjs`: `split retained reconciliation is retired; provide canonical sceneSpecJson instead`.

This is the same harness-migration boundary, not a production API defect. Restoring `retainedDocumentJson` support would reverse #815's canonical-only architecture.

## Architecture
The mixed Python authoring result already contains authoritative `sceneSpec`; the lifecycle smoke serializes that once and reuses it for both retained transition scenarios. The legacy transition remains legacy and continues to carry callback configuration through the existing path. No production files or worker protocols change.

## Validation
The current master run already proves #820's authoring router smoke and dedicated prepared/mode-switch retained smoke pass. This PR is one focused smoke-file migration; PR Fast Gate will validate static/browser integration before merge. The exact lifecycle race smoke runs in master `CI`, so its post-merge result is the final regression qualification.