### PR TITLE
Scope retained native Text identity by authoring store

### DIFF
--- a/crates/noon-web/src/authoring_mobject.rs
+++ b/crates/noon-web/src/authoring_mobject.rs
@@ -1484,7 +1484,7 @@ mod wasm {
 
     use wasm_bindgen::prelude::*;
 
-    use crate::WasmRetainedNativeTextAuthoringHandle;
+    use crate::{AuthoringSemanticIdentity, WasmRetainedNativeTextAuthoringHandle};
 
     use super::{
         manim_family_align_to_delta, manim_family_next_to_delta, render_f64,
@@ -1510,7 +1510,11 @@ mod wasm {
                 "{context} and retained member belong to different authoring stores"
             )));
         }
-        if text.family_identity() != Some(member.id) {
+        let member_identity = member.authoring_identity();
+        if !text
+            .family_identity()
+            .is_some_and(|identity| identity.matches(&member_identity))
+        {
             return Err(JsValue::from_str(&format!(
                 "{context} retained member identity does not match retained native Text handle"
             )));
@@ -1556,6 +1560,12 @@ mod wasm {
     pub struct WasmAuthoringFamilyMemberHandle {
         semantics: SharedSemanticStore,
         id: SemanticNodeId,
+    }
+
+    impl WasmAuthoringFamilyMemberHandle {
+        pub(crate) fn authoring_identity(&self) -> AuthoringSemanticIdentity {
+            AuthoringSemanticIdentity::from_shared_store(&self.semantics, self.id)
+        }
     }
 
     impl WasmAuthoringStore {
@@ -1664,7 +1674,8 @@ mod wasm {
             &self,
             text: &mut WasmRetainedNativeTextAuthoringHandle,
         ) -> Result<(), JsValue> {
-            text.bind_family_identity(self.id).map_err(js_error)
+            let identity = self.authoring_identity();
+            text.bind_family_identity(&identity).map_err(js_error)
         }
     }
 

--- a/crates/noon-web/src/authoring_semantics.rs
+++ b/crates/noon-web/src/authoring_semantics.rs
@@ -81,6 +81,19 @@ pub struct AuthoringSemanticIdentity {
 }
 
 impl AuthoringSemanticIdentity {
+    #[cfg(target_arch = "wasm32")]
+    pub(crate) fn from_shared_store(
+        store: &Rc<RefCell<SemanticStore>>,
+        node: SemanticNodeId,
+    ) -> Self {
+        Self::new(
+            AuthoringSemanticStore {
+                inner: Rc::clone(store),
+            },
+            node,
+        )
+    }
+
     fn new(store: AuthoringSemanticStore, node: SemanticNodeId) -> Self {
         Self { store, node }
     }

--- a/crates/noon-web/src/retained_authoring.rs
+++ b/crates/noon-web/src/retained_authoring.rs
@@ -1,9 +1,11 @@
 use std::collections::HashSet;
 
 #[cfg(any(target_arch = "wasm32", test))]
-use noon_core::Rect;
+use crate::AuthoringSemanticIdentity;
 #[cfg(target_arch = "wasm32")]
-use noon_core::{Bounds2D64, SemanticNodeId};
+use noon_core::Bounds2D64;
+#[cfg(any(target_arch = "wasm32", test))]
+use noon_core::Rect;
 use noon_core::{Color, ObjectId, Transform2D, Vec2, WHITE};
 use serde::{Deserialize, Serialize};
 
@@ -321,6 +323,32 @@ fn transformed_bounds(bounds: Rect, transform: Transform2D) -> Rect {
     .expect("four transformed text bounds corners are never empty")
 }
 
+#[cfg(any(target_arch = "wasm32", test))]
+#[derive(Clone, Debug, Default)]
+struct RetainedFamilyIdentityBinding {
+    identity: Option<AuthoringSemanticIdentity>,
+}
+
+#[cfg(any(target_arch = "wasm32", test))]
+impl RetainedFamilyIdentityBinding {
+    fn bind(&mut self, identity: &AuthoringSemanticIdentity) -> Result<(), String> {
+        if let Some(existing) = &self.identity {
+            if !existing.matches(identity) {
+                return Err(
+                    "retained native Text is already bound to another family identity".to_owned(),
+                );
+            }
+            return Ok(());
+        }
+        self.identity = Some(identity.clone());
+        Ok(())
+    }
+
+    fn identity(&self) -> Option<&AuthoringSemanticIdentity> {
+        self.identity.as_ref()
+    }
+}
+
 #[cfg(target_arch = "wasm32")]
 mod wasm {
     use super::*;
@@ -435,7 +463,7 @@ mod wasm {
     pub struct WasmRetainedNativeTextAuthoringHandle {
         inner: RetainedTextAuthoringSpec,
         intrinsic_bounds: Rect,
-        family_identity: Option<SemanticNodeId>,
+        family_identity: RetainedFamilyIdentityBinding,
         mutation_revision: u64,
     }
 
@@ -450,23 +478,13 @@ mod wasm {
 
         pub(crate) fn bind_family_identity(
             &mut self,
-            identity: SemanticNodeId,
+            identity: &AuthoringSemanticIdentity,
         ) -> Result<(), String> {
-            if let Some(existing) = self.family_identity {
-                if existing != identity {
-                    return Err(
-                        "retained native Text is already bound to another family identity"
-                            .to_owned(),
-                    );
-                }
-                return Ok(());
-            }
-            self.family_identity = Some(identity);
-            Ok(())
+            self.family_identity.bind(identity)
         }
 
-        pub(crate) fn family_identity(&self) -> Option<SemanticNodeId> {
-            self.family_identity
+        pub(crate) fn family_identity(&self) -> Option<&AuthoringSemanticIdentity> {
+            self.family_identity.identity()
         }
 
         pub(crate) fn family_layout_bounds(&self) -> Bounds2D64 {
@@ -519,7 +537,7 @@ mod wasm {
             Ok(Self {
                 inner,
                 intrinsic_bounds,
-                family_identity: None,
+                family_identity: RetainedFamilyIdentityBinding::default(),
                 mutation_revision: 0,
             })
         }
@@ -664,6 +682,24 @@ pub use wasm::*;
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn retained_family_identity_binding_rejects_cross_store_numeric_collision() {
+        let first_store = crate::AuthoringSemanticStore::new();
+        let second_store = crate::AuthoringSemanticStore::new();
+        let first = first_store.insert_object();
+        let second = second_store.insert_object();
+
+        assert_eq!(first.node_id(), second.node_id());
+
+        let mut binding = RetainedFamilyIdentityBinding::default();
+        binding.bind(&first).unwrap();
+        binding.bind(&first).unwrap();
+        assert!(binding.bind(&second).is_err());
+        assert!(binding
+            .identity()
+            .is_some_and(|identity| identity.matches(&first)));
+    }
 
     #[test]
     fn backend_neutral_wire_stays_source_level() {


### PR DESCRIPTION
Advances #741 through the live WASM authoring identity boundary after #816.

## What changes

- `AuthoringSemanticIdentity` gains a crate-private WASM bridge that wraps the existing shared semantic-store owner plus node ID without exposing either as a new frontend-controlled token.
- `WasmAuthoringFamilyMemberHandle` derives that opaque store-scoped identity from the shared Rust store it already owns.
- `RetainedNativeTextAuthoringHandle` now retains the full store-scoped identity rather than only a numeric `SemanticNodeId`.
- retained Text family/layout/arrange validation compares both semantic node and originating authoring store.
- rebinding the exact same identity remains idempotent; an equal numeric node ID allocated by another store is rejected.

## Architecture

No JS/Python or renderer-wire shape changes. Store ownership stays represented by Rust `Rc` identity and never crosses the frontend boundary. Existing family/layout sessions continue to validate their member handles with Rust store pointer identity; retained native Text now carries the same ownership invariant instead of trusting slot/generation alone.

This deliberately stops before introducing the final retained `ObjectId` materialization binding session. With Text identity now safe, the next #741 slice can bind live Mobject/Text handles to individual retained `ObjectId`s and feed `RetainedFamilyAuthoringLoweringSession` without ever sending ordered family member IDs through JavaScript.

## Tests

Adds a regression that constructs two independent authoring stores which allocate identical numeric node IDs, binds Text identity to the first, verifies same-identity rebinding is idempotent, and rejects the colliding identity from the second store.