### PR TITLE
Add retained PolarPlane geometry and mapping

### DIFF
--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -158,6 +158,9 @@ jobs:
       - name: Check retained ComplexPlane authoring
         run: node scripts/manim-complex-plane-smoke.mjs
 
+      - name: Check retained PolarPlane authoring
+        run: node scripts/manim-polar-plane-smoke.mjs
+
       - name: Check lazy Manim namespace dependencies
         run: node scripts/manim-namespace-smoke.mjs
 

--- a/crates/noon-web/src/lib.rs
+++ b/crates/noon-web/src/lib.rs
@@ -27,6 +27,7 @@ mod manim_number_plane_bridge;
 mod manim_parametric_bridge;
 mod manim_path_query_bridge;
 mod manim_plot_bridge;
+mod manim_polar_plane_bridge;
 mod manim_sector_bridge;
 mod manim_shape_matcher_bridge;
 #[cfg(any(target_arch = "wasm32", test))]
@@ -71,6 +72,7 @@ pub use manim_number_plane_bridge::*;
 pub use manim_parametric_bridge::*;
 pub use manim_path_query_bridge::*;
 pub use manim_plot_bridge::*;
+pub use manim_polar_plane_bridge::*;
 pub use manim_sector_bridge::*;
 pub use manim_shape_matcher_bridge::*;
 pub use reactive_authoring_facade::*;

--- a/crates/noon-web/src/manim_axes_store_bridge.rs
+++ b/crates/noon-web/src/manim_axes_store_bridge.rs
@@ -5,6 +5,7 @@ mod wasm {
     use crate::{
         WasmAuthoringStore, WasmAxesAuthoringPlan, WasmAxesPlotPlan, WasmAxesQueryPlan,
         WasmNumberLineAuthoringPlan, WasmNumberPlaneGridPlan, WasmParametricFunctionPlan,
+        WasmPolarPlaneGridPlan,
     };
 
     /// Keep the browser worker coupled to one stable authoring-store import while
@@ -57,6 +58,14 @@ mod wasm {
             request_json: &str,
         ) -> Result<WasmNumberPlaneGridPlan, JsValue> {
             WasmNumberPlaneGridPlan::new(request_json)
+        }
+
+        #[wasm_bindgen(js_name = createPolarPlaneGridPlan)]
+        pub fn create_polar_plane_grid_plan(
+            &self,
+            request_json: &str,
+        ) -> Result<WasmPolarPlaneGridPlan, JsValue> {
+            WasmPolarPlaneGridPlan::new(request_json)
         }
     }
 }

--- a/crates/noon-web/src/manim_polar_plane_bridge.rs
+++ b/crates/noon-web/src/manim_polar_plane_bridge.rs
@@ -1,0 +1,241 @@
+use noon::{
+    Axes2DState, CoordinateSystemError, NumberPlaneLineStyle, NumberRange,
+    PolarPlaneAuthoringError, PolarPlaneGridPlan, PolarPlaneRadialLine, PolarPlaneRadiusCircle,
+};
+use noon_core::{Color, ObjectSnapshot};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+struct GridStyleRequest {
+    color: [f64; 4],
+    stroke_width: f64,
+    stroke_opacity: f64,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+struct PolarPlaneGridRequest {
+    radius_max: f64,
+    radius_step: f64,
+    size: f32,
+    azimuth_step: f64,
+    azimuth_offset: f64,
+    faded_line_ratio: usize,
+    background_style: GridStyleRequest,
+    faded_style: GridStyleRequest,
+}
+
+#[derive(Serialize)]
+struct RadialLineWire<'a> {
+    angle: f64,
+    snapshot: &'a ObjectSnapshot,
+}
+
+#[derive(Serialize)]
+struct RadiusCircleWire<'a> {
+    radius: f64,
+    snapshot: &'a ObjectSnapshot,
+}
+
+#[derive(Serialize)]
+struct PolarPlaneGridWire<'a> {
+    radial_lines: Vec<RadialLineWire<'a>>,
+    circles: Vec<RadiusCircleWire<'a>>,
+    faded_radial_lines: Vec<RadialLineWire<'a>>,
+    faded_circles: Vec<RadiusCircleWire<'a>>,
+}
+
+/// Thin serialization adapter over the shared retained PolarPlane grid planner.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PolarPlaneGridAuthoringPlan {
+    grid: PolarPlaneGridPlan,
+}
+
+impl PolarPlaneGridAuthoringPlan {
+    pub fn from_json(request_json: &str) -> Result<Self, ManimPolarPlaneBridgeError> {
+        let request: PolarPlaneGridRequest = serde_json::from_str(request_json)
+            .map_err(|error| ManimPolarPlaneBridgeError::InvalidRequest(error.to_string()))?;
+        let range = NumberRange::new(
+            -request.radius_max,
+            request.radius_max,
+            request.radius_step,
+        )?;
+        let axes = Axes2DState::new(range, range, request.size, request.size)?;
+        let grid = PolarPlaneGridPlan::new(
+            axes,
+            request.azimuth_step,
+            request.azimuth_offset,
+            request.faded_line_ratio,
+            line_style(request.background_style)?,
+            line_style(request.faded_style)?,
+        )?;
+        Ok(Self { grid })
+    }
+
+    pub fn geometry_json(&self) -> Result<String, ManimPolarPlaneBridgeError> {
+        let wire = PolarPlaneGridWire {
+            radial_lines: radial_lines_wire(self.grid.radial_lines()),
+            circles: radius_circles_wire(self.grid.circles()),
+            faded_radial_lines: radial_lines_wire(self.grid.faded_radial_lines()),
+            faded_circles: radius_circles_wire(self.grid.faded_circles()),
+        };
+        serde_json::to_string(&wire)
+            .map_err(|error| ManimPolarPlaneBridgeError::Serialization(error.to_string()))
+    }
+}
+
+fn radial_lines_wire(lines: &[PolarPlaneRadialLine]) -> Vec<RadialLineWire<'_>> {
+    lines
+        .iter()
+        .map(|line| RadialLineWire {
+            angle: line.angle(),
+            snapshot: line.snapshot(),
+        })
+        .collect()
+}
+
+fn radius_circles_wire(circles: &[PolarPlaneRadiusCircle]) -> Vec<RadiusCircleWire<'_>> {
+    circles
+        .iter()
+        .map(|circle| RadiusCircleWire {
+            radius: circle.radius(),
+            snapshot: circle.snapshot(),
+        })
+        .collect()
+}
+
+fn line_style(
+    request: GridStyleRequest,
+) -> Result<NumberPlaneLineStyle, ManimPolarPlaneBridgeError> {
+    Ok(NumberPlaneLineStyle::new(
+        rgba(request.color)?,
+        request.stroke_width,
+        request.stroke_opacity,
+    ))
+}
+
+fn rgba(value: [f64; 4]) -> Result<Color, ManimPolarPlaneBridgeError> {
+    if value
+        .iter()
+        .any(|component| !component.is_finite() || !(0.0..=1.0).contains(component))
+    {
+        return Err(ManimPolarPlaneBridgeError::InvalidColor(value));
+    }
+    Ok(Color::rgba(
+        value[0] as f32,
+        value[1] as f32,
+        value[2] as f32,
+        value[3] as f32,
+    ))
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ManimPolarPlaneBridgeError {
+    InvalidRequest(String),
+    InvalidColor([f64; 4]),
+    Coordinates(CoordinateSystemError),
+    Geometry(PolarPlaneAuthoringError),
+    Serialization(String),
+}
+
+impl std::fmt::Display for ManimPolarPlaneBridgeError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidRequest(error) => {
+                write!(formatter, "invalid PolarPlane request: {error}")
+            }
+            Self::InvalidColor(value) => write!(
+                formatter,
+                "PolarPlane color must contain finite RGBA components in [0, 1], got {value:?}"
+            ),
+            Self::Coordinates(error) => error.fmt(formatter),
+            Self::Geometry(error) => error.fmt(formatter),
+            Self::Serialization(error) => {
+                write!(formatter, "unable to serialize PolarPlane grid: {error}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ManimPolarPlaneBridgeError {}
+
+impl From<CoordinateSystemError> for ManimPolarPlaneBridgeError {
+    fn from(value: CoordinateSystemError) -> Self {
+        Self::Coordinates(value)
+    }
+}
+
+impl From<PolarPlaneAuthoringError> for ManimPolarPlaneBridgeError {
+    fn from(value: PolarPlaneAuthoringError) -> Self {
+        Self::Geometry(value)
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+mod wasm {
+    use wasm_bindgen::prelude::*;
+
+    use super::PolarPlaneGridAuthoringPlan;
+
+    fn js_error(error: impl std::fmt::Display) -> JsValue {
+        JsValue::from_str(&error.to_string())
+    }
+
+    #[wasm_bindgen]
+    pub struct WasmPolarPlaneGridPlan(PolarPlaneGridAuthoringPlan);
+
+    #[wasm_bindgen]
+    impl WasmPolarPlaneGridPlan {
+        #[wasm_bindgen(constructor)]
+        pub fn new(request_json: &str) -> Result<Self, JsValue> {
+            PolarPlaneGridAuthoringPlan::from_json(request_json)
+                .map(Self)
+                .map_err(js_error)
+        }
+
+        #[wasm_bindgen(js_name = geometryJson)]
+        pub fn geometry_json(&self) -> Result<String, JsValue> {
+            self.0.geometry_json().map_err(js_error)
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub use wasm::WasmPolarPlaneGridPlan;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+
+    fn request(ratio: usize) -> String {
+        format!(
+            r#"{{"radius_max":2.0,"radius_step":1.0,"size":4.0,"azimuth_step":4.0,"azimuth_offset":0.0,"faded_line_ratio":{ratio},"background_style":{{"color":[0.1,0.2,0.3,1.0],"stroke_width":2.0,"stroke_opacity":1.0}},"faded_style":{{"color":[0.1,0.2,0.3,1.0],"stroke_width":1.0,"stroke_opacity":0.5}}}}"#
+        )
+    }
+
+    #[test]
+    fn bridge_serializes_shared_polar_families_without_recomputing_geometry() {
+        let plan = PolarPlaneGridAuthoringPlan::from_json(&request(2)).unwrap();
+        let wire: Value = serde_json::from_str(&plan.geometry_json().unwrap()).unwrap();
+        assert_eq!(wire["radial_lines"].as_array().unwrap().len(), 4);
+        assert_eq!(wire["circles"].as_array().unwrap().len(), 3);
+        assert_eq!(wire["faded_radial_lines"].as_array().unwrap().len(), 4);
+        assert_eq!(wire["faded_circles"].as_array().unwrap().len(), 2);
+        assert_eq!(wire["circles"][1]["radius"], 1.0);
+        assert_eq!(
+            wire["faded_radial_lines"][0]["snapshot"]["style"]["stroke_width"],
+            0.01
+        );
+    }
+
+    #[test]
+    fn bridge_rejects_non_rgba_style_inputs() {
+        let invalid = request(1).replace("[0.1,0.2,0.3,1.0]", "[2.0,0.2,0.3,1.0]");
+        assert!(matches!(
+            PolarPlaneGridAuthoringPlan::from_json(&invalid),
+            Err(ManimPolarPlaneBridgeError::InvalidColor(_))
+        ));
+    }
+}

--- a/crates/noon-web/src/manim_polar_plane_bridge.rs
+++ b/crates/noon-web/src/manim_polar_plane_bridge.rs
@@ -56,11 +56,7 @@ impl PolarPlaneGridAuthoringPlan {
     pub fn from_json(request_json: &str) -> Result<Self, ManimPolarPlaneBridgeError> {
         let request: PolarPlaneGridRequest = serde_json::from_str(request_json)
             .map_err(|error| ManimPolarPlaneBridgeError::InvalidRequest(error.to_string()))?;
-        let range = NumberRange::new(
-            -request.radius_max,
-            request.radius_max,
-            request.radius_step,
-        )?;
+        let range = NumberRange::new(-request.radius_max, request.radius_max, request.radius_step)?;
         let axes = Axes2DState::new(range, range, request.size, request.size)?;
         let grid = PolarPlaneGridPlan::new(
             axes,

--- a/crates/noon/src/lib.rs
+++ b/crates/noon/src/lib.rs
@@ -23,6 +23,7 @@ mod line_matcher_authoring;
 mod number_plane_authoring;
 mod plot_geometry_authoring;
 mod plot_sampling_authoring;
+mod polar_plane_authoring;
 mod polygram_authoring;
 mod reactive_authoring;
 mod riemann_authoring;
@@ -48,6 +49,7 @@ pub use line_matcher_authoring::*;
 pub use number_plane_authoring::*;
 pub use plot_geometry_authoring::*;
 pub use plot_sampling_authoring::*;
+pub use polar_plane_authoring::*;
 pub use polygram_authoring::*;
 pub use reactive_authoring::*;
 pub use riemann_authoring::*;
@@ -71,7 +73,8 @@ pub mod prelude {
         MovingCameraScene, NumberLineGeometryPlan, NumberLineState, NumberLineTick,
         NumberLineTickOptions, NumberPlaneAuthoringError, NumberPlaneGridLine, NumberPlaneGridPlan,
         NumberPlaneLineStyle, NumberRange, ParametricSamplePlan, PlotGeometryError,
-        PlotRangeRequest, PlotSamplingError, Polygon, Polygram, PolygramAuthoringError,
+        PlotRangeRequest, PlotSamplingError, PolarPlaneAuthoringError, PolarPlaneGridPlan,
+        PolarPlaneRadialLine, PolarPlaneRadiusCircle, Polygon, Polygram, PolygramAuthoringError,
         ReactiveScene, ReactiveTimelineScene, RegularPolygon, RegularPolygram, RetainedMobject,
         RetainedScene, RiemannAuthoringError, RiemannRectangleGeometry, RiemannSample,
         RiemannSamplePlan, RiemannSampleType, RoundedRectangle, RoundedRectangleAuthoringError,

--- a/crates/noon/src/polar_plane_authoring.rs
+++ b/crates/noon/src/polar_plane_authoring.rs
@@ -1,0 +1,451 @@
+use crate::{Axes2DState, Circle, IntoSnapshot, Line, NumberPlaneLineStyle};
+use noon_core::{ObjectSnapshot, Vec2, TAU};
+
+const CAIRO_WIDTH_SCALE: f64 = 0.01;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct PolarPlaneRadialLine {
+    angle: f64,
+    snapshot: ObjectSnapshot,
+}
+
+impl PolarPlaneRadialLine {
+    pub const fn angle(&self) -> f64 {
+        self.angle
+    }
+
+    pub fn snapshot(&self) -> &ObjectSnapshot {
+        &self.snapshot
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct PolarPlaneRadiusCircle {
+    radius: f64,
+    snapshot: ObjectSnapshot,
+}
+
+impl PolarPlaneRadiusCircle {
+    pub const fn radius(&self) -> f64 {
+        self.radius
+    }
+
+    pub fn snapshot(&self) -> &ObjectSnapshot {
+        &self.snapshot
+    }
+}
+
+/// Renderer-independent ManimCE v0.21 PolarPlane background geometry.
+///
+/// The plan stores ordinary retained `Line` and `Circle` snapshots. Axes geometry
+/// remains owned by the existing `Axes2DState`; this type owns only the polar
+/// background subdivision, faded classification, style, and upstream family order.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PolarPlaneGridPlan {
+    radial_lines: Vec<PolarPlaneRadialLine>,
+    circles: Vec<PolarPlaneRadiusCircle>,
+    faded_radial_lines: Vec<PolarPlaneRadialLine>,
+    faded_circles: Vec<PolarPlaneRadiusCircle>,
+}
+
+impl PolarPlaneGridPlan {
+    pub fn new(
+        axes: Axes2DState,
+        azimuth_step: f64,
+        azimuth_offset: f64,
+        faded_line_ratio: usize,
+        background_style: NumberPlaneLineStyle,
+        faded_style: NumberPlaneLineStyle,
+    ) -> Result<Self, PolarPlaneAuthoringError> {
+        validate_style(background_style)?;
+        validate_style(faded_style)?;
+        if !azimuth_step.is_finite() || azimuth_step <= 0.0 {
+            return Err(PolarPlaneAuthoringError::InvalidAzimuthStep(azimuth_step));
+        }
+        if !azimuth_offset.is_finite() {
+            return Err(PolarPlaneAuthoringError::InvalidAzimuthOffset(
+                azimuth_offset,
+            ));
+        }
+
+        let x_axis = axes.x_axis();
+        let range = x_axis.range();
+        if (range.min() + range.max()).abs() > 1.0e-9 {
+            return Err(PolarPlaneAuthoringError::AsymmetricRadiusRange {
+                min: range.min(),
+                max: range.max(),
+            });
+        }
+
+        let ratio = faded_line_ratio.max(1);
+        let radius_step = range.step() / ratio as f64;
+        let azimuth_increment = f64::from(TAU) / azimuth_step / ratio as f64;
+        if !radius_step.is_finite() || radius_step <= 0.0 {
+            return Err(PolarPlaneAuthoringError::InvalidRadiusStep(radius_step));
+        }
+        if !azimuth_increment.is_finite() || azimuth_increment <= 0.0 {
+            return Err(PolarPlaneAuthoringError::InvalidAzimuthStep(azimuth_step));
+        }
+
+        let unit_size = x_axis.unit_size();
+        if !unit_size.is_finite() || unit_size <= 0.0 {
+            return Err(PolarPlaneAuthoringError::InvalidUnitSize(unit_size));
+        }
+        let center = axes.origin()?;
+        let radial_end = x_axis.end();
+        let radial_vector = radial_end - center;
+
+        let mut circles = Vec::new();
+        let mut faded_circles = Vec::new();
+        let radius_stop = range.max() + radius_step;
+        let mut logical_radius = 0.0;
+        let mut index = 0_usize;
+        while logical_radius < radius_stop {
+            let circle = PolarPlaneRadiusCircle {
+                radius: logical_radius,
+                snapshot: styled_circle(logical_radius * unit_size, background_style)?,
+            };
+            if index.is_multiple_of(ratio) {
+                circles.push(circle);
+            } else {
+                faded_circles.push(PolarPlaneRadiusCircle {
+                    radius: logical_radius,
+                    snapshot: styled_circle(logical_radius * unit_size, faded_style)?,
+                });
+            }
+            logical_radius += radius_step;
+            index += 1;
+        }
+
+        let mut radial_lines = Vec::new();
+        let mut faded_radial_lines = Vec::new();
+        let mut angle = 0.0;
+        index = 0;
+        while angle < f64::from(TAU) {
+            let final_angle = angle + azimuth_offset;
+            let end = center + rotate(radial_vector, final_angle)?;
+            let line = PolarPlaneRadialLine {
+                angle: final_angle,
+                snapshot: styled_line(center, end, background_style)?,
+            };
+            if index.is_multiple_of(ratio) {
+                radial_lines.push(line);
+            } else {
+                faded_radial_lines.push(PolarPlaneRadialLine {
+                    angle: final_angle,
+                    snapshot: styled_line(center, end, faded_style)?,
+                });
+            }
+            angle += azimuth_increment;
+            index += 1;
+        }
+
+        Ok(Self {
+            radial_lines,
+            circles,
+            faded_radial_lines,
+            faded_circles,
+        })
+    }
+
+    /// Non-faded radial lines. These precede circles in Manim's background family.
+    pub fn radial_lines(&self) -> &[PolarPlaneRadialLine] {
+        &self.radial_lines
+    }
+
+    /// Non-faded concentric circles, following radial lines upstream.
+    pub fn circles(&self) -> &[PolarPlaneRadiusCircle] {
+        &self.circles
+    }
+
+    pub fn faded_radial_lines(&self) -> &[PolarPlaneRadialLine] {
+        &self.faded_radial_lines
+    }
+
+    pub fn faded_circles(&self) -> &[PolarPlaneRadiusCircle] {
+        &self.faded_circles
+    }
+}
+
+fn styled_line(
+    start: Vec2,
+    end: Vec2,
+    style: NumberPlaneLineStyle,
+) -> Result<ObjectSnapshot, PolarPlaneAuthoringError> {
+    let (color, width) = resolved_style(style)?;
+    Ok(Line::new(start, end)
+        .color(color)
+        .set_stroke(Some(color), Some(width))
+        .into_snapshot())
+}
+
+fn styled_circle(
+    radius: f64,
+    style: NumberPlaneLineStyle,
+) -> Result<ObjectSnapshot, PolarPlaneAuthoringError> {
+    let radius = checked_f32(radius)?;
+    let (color, width) = resolved_style(style)?;
+    Ok(Circle::new(radius)
+        .color(color)
+        .set_stroke(Some(color), Some(width))
+        .into_snapshot())
+}
+
+fn resolved_style(
+    style: NumberPlaneLineStyle,
+) -> Result<(noon_core::Color, f32), PolarPlaneAuthoringError> {
+    validate_style(style)?;
+    let width = checked_f32(style.stroke_width * CAIRO_WIDTH_SCALE)?;
+    let mut color = style.color;
+    color.alpha *= checked_f32(style.stroke_opacity)?;
+    Ok((color, width))
+}
+
+fn validate_style(style: NumberPlaneLineStyle) -> Result<(), PolarPlaneAuthoringError> {
+    if !style.stroke_width.is_finite() || style.stroke_width < 0.0 {
+        return Err(PolarPlaneAuthoringError::InvalidStrokeWidth(
+            style.stroke_width,
+        ));
+    }
+    if !style.stroke_opacity.is_finite() || !(0.0..=1.0).contains(&style.stroke_opacity) {
+        return Err(PolarPlaneAuthoringError::InvalidStrokeOpacity(
+            style.stroke_opacity,
+        ));
+    }
+    if [
+        style.color.red,
+        style.color.green,
+        style.color.blue,
+        style.color.alpha,
+    ]
+    .iter()
+    .any(|component| !component.is_finite())
+    {
+        return Err(PolarPlaneAuthoringError::NonFiniteColor);
+    }
+    Ok(())
+}
+
+fn rotate(vector: Vec2, angle: f64) -> Result<Vec2, PolarPlaneAuthoringError> {
+    let cosine = checked_f32(angle.cos())?;
+    let sine = checked_f32(angle.sin())?;
+    Ok(Vec2::new(
+        vector.x * cosine - vector.y * sine,
+        vector.x * sine + vector.y * cosine,
+    ))
+}
+
+fn checked_f32(value: f64) -> Result<f32, PolarPlaneAuthoringError> {
+    let lowered = value as f32;
+    if lowered.is_finite() {
+        Ok(lowered)
+    } else {
+        Err(PolarPlaneAuthoringError::Overflow(value))
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum PolarPlaneAuthoringError {
+    InvalidAzimuthStep(f64),
+    InvalidAzimuthOffset(f64),
+    InvalidRadiusStep(f64),
+    InvalidUnitSize(f64),
+    InvalidStrokeWidth(f64),
+    InvalidStrokeOpacity(f64),
+    NonFiniteColor,
+    AsymmetricRadiusRange { min: f64, max: f64 },
+    Coordinates(crate::CoordinateSystemError),
+    Overflow(f64),
+}
+
+impl std::fmt::Display for PolarPlaneAuthoringError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match *self {
+            Self::InvalidAzimuthStep(value) => {
+                write!(formatter, "invalid PolarPlane azimuth step: {value}")
+            }
+            Self::InvalidAzimuthOffset(value) => {
+                write!(formatter, "invalid PolarPlane azimuth offset: {value}")
+            }
+            Self::InvalidRadiusStep(value) => {
+                write!(formatter, "invalid PolarPlane radius step: {value}")
+            }
+            Self::InvalidUnitSize(value) => {
+                write!(formatter, "invalid PolarPlane unit size: {value}")
+            }
+            Self::InvalidStrokeWidth(value) => {
+                write!(formatter, "invalid PolarPlane stroke width: {value}")
+            }
+            Self::InvalidStrokeOpacity(value) => {
+                write!(formatter, "invalid PolarPlane stroke opacity: {value}")
+            }
+            Self::NonFiniteColor => formatter.write_str("PolarPlane grid color must be finite"),
+            Self::AsymmetricRadiusRange { min, max } => write!(
+                formatter,
+                "PolarPlane radius range must be symmetric around zero: [{min}, {max}]"
+            ),
+            Self::Coordinates(ref error) => error.fmt(formatter),
+            Self::Overflow(value) => write!(
+                formatter,
+                "PolarPlane geometry cannot be represented as f32: {value}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for PolarPlaneAuthoringError {}
+
+impl From<crate::CoordinateSystemError> for PolarPlaneAuthoringError {
+    fn from(value: crate::CoordinateSystemError) -> Self {
+        Self::Coordinates(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::NumberRange;
+    use noon_core::{GeometryRef, BLUE_D};
+
+    fn axes(radius_max: f64, radius_step: f64, size: f32) -> Axes2DState {
+        let range = NumberRange::new(-radius_max, radius_max, radius_step).unwrap();
+        Axes2DState::new(range, range, size, size).unwrap()
+    }
+
+    fn style(width: f64, opacity: f64) -> NumberPlaneLineStyle {
+        NumberPlaneLineStyle::new(BLUE_D, width, opacity)
+    }
+
+    fn assert_close(actual: f64, expected: f64) {
+        assert!(
+            (actual - expected).abs() <= 1.0e-5,
+            "expected {expected}, got {actual}"
+        );
+    }
+
+    #[test]
+    fn ratio_one_matches_upstream_radius_and_azimuth_families() {
+        let plan = PolarPlaneGridPlan::new(
+            axes(2.0, 1.0, 4.0),
+            4.0,
+            0.0,
+            1,
+            style(2.0, 1.0),
+            style(1.0, 0.5),
+        )
+        .unwrap();
+        assert_eq!(
+            plan.circles()
+                .iter()
+                .map(PolarPlaneRadiusCircle::radius)
+                .collect::<Vec<_>>(),
+            vec![0.0, 1.0, 2.0]
+        );
+        assert_eq!(plan.radial_lines().len(), 4);
+        assert!(plan.faded_circles().is_empty());
+        assert!(plan.faded_radial_lines().is_empty());
+        for (actual, expected) in plan
+            .radial_lines()
+            .iter()
+            .map(PolarPlaneRadialLine::angle)
+            .zip([0.0, std::f64::consts::FRAC_PI_2, std::f64::consts::PI, 3.0 * std::f64::consts::FRAC_PI_2])
+        {
+            assert_close(actual, expected);
+        }
+    }
+
+    #[test]
+    fn ratio_two_classifies_radius_and_azimuth_indices_independently() {
+        let plan = PolarPlaneGridPlan::new(
+            axes(2.0, 1.0, 4.0),
+            4.0,
+            0.0,
+            2,
+            style(2.0, 1.0),
+            style(1.0, 0.5),
+        )
+        .unwrap();
+        assert_eq!(
+            plan.circles()
+                .iter()
+                .map(PolarPlaneRadiusCircle::radius)
+                .collect::<Vec<_>>(),
+            vec![0.0, 1.0, 2.0]
+        );
+        assert_eq!(
+            plan.faded_circles()
+                .iter()
+                .map(PolarPlaneRadiusCircle::radius)
+                .collect::<Vec<_>>(),
+            vec![0.5, 1.5]
+        );
+        assert_eq!(plan.radial_lines().len(), 4);
+        assert_eq!(plan.faded_radial_lines().len(), 4);
+    }
+
+    #[test]
+    fn ratio_zero_matches_ratio_one() {
+        let axes = axes(2.0, 1.0, 4.0);
+        let background = style(2.0, 1.0);
+        let faded = style(1.0, 0.5);
+        assert_eq!(
+            PolarPlaneGridPlan::new(axes, 4.0, 0.0, 0, background, faded).unwrap(),
+            PolarPlaneGridPlan::new(axes, 4.0, 0.0, 1, background, faded).unwrap()
+        );
+    }
+
+    #[test]
+    fn non_integer_azimuth_divisions_keep_the_partial_final_division() {
+        let plan = PolarPlaneGridPlan::new(
+            axes(2.0, 1.0, 4.0),
+            2.5,
+            0.0,
+            1,
+            style(2.0, 1.0),
+            style(1.0, 0.5),
+        )
+        .unwrap();
+        assert_eq!(plan.radial_lines().len(), 3);
+        assert_close(plan.radial_lines()[2].angle(), 1.6 * std::f64::consts::PI);
+    }
+
+    #[test]
+    fn custom_size_scales_circle_radius_and_radial_endpoint() {
+        let plan = PolarPlaneGridPlan::new(
+            axes(2.0, 1.0, 8.0),
+            4.0,
+            0.0,
+            1,
+            style(2.0, 1.0),
+            style(1.0, 0.5),
+        )
+        .unwrap();
+        let GeometryRef::Circle { radius } = &plan.circles()[1].snapshot().geometry else {
+            panic!("PolarPlane circles must remain retained Circle geometry")
+        };
+        assert_close(f64::from(*radius), 2.0);
+        let GeometryRef::Line { start, end } = &plan.radial_lines()[0].snapshot().geometry else {
+            panic!("PolarPlane radial lines must remain retained Line geometry")
+        };
+        assert_close(f64::from(start.x), 0.0);
+        assert_close(f64::from(end.x), 4.0);
+    }
+
+    #[test]
+    fn azimuth_offset_rotates_retained_radial_endpoints() {
+        let plan = PolarPlaneGridPlan::new(
+            axes(2.0, 1.0, 4.0),
+            4.0,
+            std::f64::consts::FRAC_PI_2,
+            1,
+            style(2.0, 1.0),
+            style(1.0, 0.5),
+        )
+        .unwrap();
+        let GeometryRef::Line { end, .. } = &plan.radial_lines()[0].snapshot().geometry else {
+            panic!("PolarPlane radial lines must remain retained Line geometry")
+        };
+        assert_close(f64::from(end.x), 0.0);
+        assert_close(f64::from(end.y), 2.0);
+    }
+}

--- a/crates/noon/src/polar_plane_authoring.rs
+++ b/crates/noon/src/polar_plane_authoring.rs
@@ -1,5 +1,5 @@
 use crate::{Axes2DState, Circle, IntoSnapshot, Line, NumberPlaneLineStyle};
-use noon_core::{ObjectSnapshot, Vec2, TAU};
+use noon_core::{ObjectSnapshot, Vec2};
 
 const CAIRO_WIDTH_SCALE: f64 = 0.01;
 
@@ -79,7 +79,7 @@ impl PolarPlaneGridPlan {
 
         let ratio = faded_line_ratio.max(1);
         let radius_step = range.step() / ratio as f64;
-        let azimuth_increment = f64::from(TAU) / azimuth_step / ratio as f64;
+        let azimuth_increment = std::f64::consts::TAU / azimuth_step / ratio as f64;
         if !radius_step.is_finite() || radius_step <= 0.0 {
             return Err(PolarPlaneAuthoringError::InvalidRadiusStep(radius_step));
         }
@@ -92,8 +92,7 @@ impl PolarPlaneGridPlan {
             return Err(PolarPlaneAuthoringError::InvalidUnitSize(unit_size));
         }
         let center = axes.origin()?;
-        let radial_end = x_axis.end();
-        let radial_vector = radial_end - center;
+        let radial_vector = x_axis.end() - center;
 
         let mut circles = Vec::new();
         let mut faded_circles = Vec::new();
@@ -101,17 +100,20 @@ impl PolarPlaneGridPlan {
         let mut logical_radius = 0.0;
         let mut index = 0_usize;
         while logical_radius < radius_stop {
+            let is_background = index.is_multiple_of(ratio);
+            let style = if is_background {
+                background_style
+            } else {
+                faded_style
+            };
             let circle = PolarPlaneRadiusCircle {
                 radius: logical_radius,
-                snapshot: styled_circle(logical_radius * unit_size, background_style)?,
+                snapshot: styled_circle(logical_radius * unit_size, style)?,
             };
-            if index.is_multiple_of(ratio) {
+            if is_background {
                 circles.push(circle);
             } else {
-                faded_circles.push(PolarPlaneRadiusCircle {
-                    radius: logical_radius,
-                    snapshot: styled_circle(logical_radius * unit_size, faded_style)?,
-                });
+                faded_circles.push(circle);
             }
             logical_radius += radius_step;
             index += 1;
@@ -121,20 +123,23 @@ impl PolarPlaneGridPlan {
         let mut faded_radial_lines = Vec::new();
         let mut angle = 0.0;
         index = 0;
-        while angle < f64::from(TAU) {
+        while angle < std::f64::consts::TAU {
             let final_angle = angle + azimuth_offset;
             let end = center + rotate(radial_vector, final_angle)?;
+            let is_background = index.is_multiple_of(ratio);
+            let style = if is_background {
+                background_style
+            } else {
+                faded_style
+            };
             let line = PolarPlaneRadialLine {
                 angle: final_angle,
-                snapshot: styled_line(center, end, background_style)?,
+                snapshot: styled_line(center, end, style)?,
             };
-            if index.is_multiple_of(ratio) {
+            if is_background {
                 radial_lines.push(line);
             } else {
-                faded_radial_lines.push(PolarPlaneRadialLine {
-                    angle: final_angle,
-                    snapshot: styled_line(center, end, faded_style)?,
-                });
+                faded_radial_lines.push(line);
             }
             angle += azimuth_increment;
             index += 1;
@@ -344,12 +349,12 @@ mod tests {
         assert_eq!(plan.radial_lines().len(), 4);
         assert!(plan.faded_circles().is_empty());
         assert!(plan.faded_radial_lines().is_empty());
-        for (actual, expected) in plan
-            .radial_lines()
-            .iter()
-            .map(PolarPlaneRadialLine::angle)
-            .zip([0.0, std::f64::consts::FRAC_PI_2, std::f64::consts::PI, 3.0 * std::f64::consts::FRAC_PI_2])
-        {
+        for (actual, expected) in plan.radial_lines().iter().map(PolarPlaneRadialLine::angle).zip([
+            0.0,
+            std::f64::consts::FRAC_PI_2,
+            std::f64::consts::PI,
+            3.0 * std::f64::consts::FRAC_PI_2,
+        ]) {
             assert_close(actual, expected);
         }
     }
@@ -406,7 +411,10 @@ mod tests {
         )
         .unwrap();
         assert_eq!(plan.radial_lines().len(), 3);
-        assert_close(plan.radial_lines()[2].angle(), 1.6 * std::f64::consts::PI);
+        assert_close(
+            plan.radial_lines()[2].angle(),
+            1.6 * std::f64::consts::PI,
+        );
     }
 
     #[test]

--- a/crates/noon/src/polar_plane_authoring.rs
+++ b/crates/noon/src/polar_plane_authoring.rs
@@ -349,12 +349,17 @@ mod tests {
         assert_eq!(plan.radial_lines().len(), 4);
         assert!(plan.faded_circles().is_empty());
         assert!(plan.faded_radial_lines().is_empty());
-        for (actual, expected) in plan.radial_lines().iter().map(PolarPlaneRadialLine::angle).zip([
-            0.0,
-            std::f64::consts::FRAC_PI_2,
-            std::f64::consts::PI,
-            3.0 * std::f64::consts::FRAC_PI_2,
-        ]) {
+        for (actual, expected) in plan
+            .radial_lines()
+            .iter()
+            .map(PolarPlaneRadialLine::angle)
+            .zip([
+                0.0,
+                std::f64::consts::FRAC_PI_2,
+                std::f64::consts::PI,
+                3.0 * std::f64::consts::FRAC_PI_2,
+            ])
+        {
             assert_close(actual, expected);
         }
     }
@@ -411,10 +416,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(plan.radial_lines().len(), 3);
-        assert_close(
-            plan.radial_lines()[2].angle(),
-            1.6 * std::f64::consts::PI,
-        );
+        assert_close(plan.radial_lines()[2].angle(), 1.6 * std::f64::consts::PI);
     }
 
     #[test]

--- a/scripts/manim-polar-plane-smoke.mjs
+++ b/scripts/manim-polar-plane-smoke.mjs
@@ -1,0 +1,203 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import playwright from "playwright";
+
+const { chromium } = playwright;
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const port = 4188;
+const baseUrl = `http://127.0.0.1:${port}`;
+
+let serverOutput = "";
+const server = spawn(
+  "python3",
+  ["-m", "http.server", String(port), "--bind", "127.0.0.1", "--directory", repoRoot],
+  { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] },
+);
+server.stdout.on("data", (chunk) => (serverOutput += chunk));
+server.stderr.on("data", (chunk) => (serverOutput += chunk));
+
+async function waitForServer() {
+  let lastError = null;
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    try {
+      const response = await fetch(`${baseUrl}/web/manim-compat-smoke.html`);
+      if (response.ok) return;
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`PolarPlane smoke server did not start: ${lastError}\n${serverOutput}`);
+}
+
+const source = `
+from noon import *
+import math
+
+
+def assert_close(actual, expected, tolerance=1e-5):
+    assert abs(float(actual) - float(expected)) <= tolerance, (actual, expected)
+
+
+def assert_point_close(actual, expected, tolerance=1e-5):
+    assert_close(actual.x, expected.x, tolerance)
+    assert_close(actual.y, expected.y, tolerance)
+
+
+def assert_polar_close(actual, expected, tolerance=1e-5):
+    assert_close(actual[0], expected[0], tolerance)
+    delta = math.atan2(
+        math.sin(float(actual[1]) - float(expected[1])),
+        math.cos(float(actual[1]) - float(expected[1])),
+    )
+    assert_close(delta, 0.0, tolerance)
+
+
+class RetainedPolarPlaneScene(Scene):
+    def construct(self):
+        plane = PolarPlane(
+            radius_max=2,
+            size=8,
+            radius_step=1,
+            azimuth_step=4,
+            azimuth_offset=0.25,
+            faded_line_ratio=2,
+        )
+
+        assert isinstance(plane, Axes)
+        assert type(plane) is PolarPlane
+        assert len(plane.axes) == 2
+        assert len(plane._radial_lines) == 4
+        assert len(plane._circles) == 3
+        assert len(plane._faded_radial_lines) == 4
+        assert len(plane._faded_circles) == 2
+        assert len(plane.background_lines) == 7
+        assert len(plane.faded_lines) == 6
+        assert len(plane.submobjects) == 4
+
+        # size=8 over logical [-2, 2] means two scene units per radius unit.
+        expected_background_radii = [0.0, 2.0, 4.0]
+        expected_faded_radii = [1.0, 3.0]
+        for circle, expected in zip(plane._circles, expected_background_radii):
+            assert_close(circle.radius, expected)
+        for circle, expected in zip(plane._faded_circles, expected_faded_radii):
+            assert_close(circle.radius, expected)
+
+        origin = plane.get_origin()
+        first_radial = plane._radial_lines[0]
+        assert_point_close(first_radial.get_start(), origin)
+        radial_delta = first_radial.get_end() - origin
+        assert_close(radial_delta.length(), 4.0)
+        assert_close(math.atan2(radial_delta.y, radial_delta.x), 0.25)
+
+        # The shared polar helpers are CoordinateSystem behavior, not PolarPlane-only math.
+        axes = Axes(
+            x_range=[-3, 3, 1],
+            y_range=[-3, 3, 1],
+            x_length=6,
+            y_length=6,
+            tips=False,
+        )
+        assert_point_close(axes.pr2pt(2.0, math.pi / 3.0), axes.c2p(1.0, math.sqrt(3.0)))
+        assert_polar_close(axes.pt2pr(axes.pr2pt(1.5, -0.4)), (1.5, -0.4))
+
+        plane.shift(LEFT * 0.6 + UP * 0.4)
+        plane.scale(0.8)
+        plane.rotate(0.3)
+        target = (1.25, -0.7)
+        transformed = plane.pr2pt(*target)
+        assert_polar_close(plane.pt2pr(transformed), target)
+
+        copied = plane.copy()
+        assert type(copied) is PolarPlane
+        assert copied is not plane
+        assert len(copied._radial_lines) == len(plane._radial_lines)
+        assert len(copied._circles) == len(plane._circles)
+        assert_point_close(copied.pr2pt(*target), transformed)
+        copied.shift(RIGHT)
+        assert (copied.pr2pt(*target) - plane.pr2pt(*target)).length() > 0.5
+        assert_polar_close(copied.pt2pr(copied.pr2pt(*target)), target)
+
+        no_fade = PolarPlane(radius_max=1, size=2, azimuth_step=4, faded_line_ratio=0)
+        ratio_one = PolarPlane(radius_max=1, size=2, azimuth_step=4, faded_line_ratio=1)
+        assert len(no_fade._faded_radial_lines) == 0
+        assert len(no_fade._faded_circles) == 0
+        assert len(no_fade._radial_lines) == len(ratio_one._radial_lines) == 4
+        assert len(no_fade._circles) == len(ratio_one._circles) == 2
+
+        partial = PolarPlane(radius_max=1, size=2, azimuth_step=2.5)
+        assert len(partial._radial_lines) == 3
+
+        try:
+            PolarPlane(azimuth_units="turns")
+            raise AssertionError("invalid azimuth units unexpectedly succeeded")
+        except ValueError as error:
+            assert "Invalid azimuth units" in str(error)
+
+        try:
+            PolarPlane(azimuth_direction="SIDEWAYS")
+            raise AssertionError("invalid azimuth direction unexpectedly succeeded")
+        except ValueError as error:
+            assert "CW, CCW" in str(error)
+
+        for operation in (plane.get_coordinate_labels, plane.add_coordinates):
+            try:
+                operation()
+                raise AssertionError("PolarPlane label API unexpectedly succeeded")
+            except NotImplementedError as error:
+                assert "number/MathTex labels" in str(error)
+
+        self.add(plane)
+`;
+
+let browser = null;
+try {
+  await waitForServer();
+  browser = await chromium.launch({
+    channel: "chromium",
+    headless: true,
+    args: ["--disable-dev-shm-usage"],
+  });
+  const page = await browser.newPage();
+  const errors = [];
+  page.on("pageerror", (error) => errors.push(`pageerror: ${error}`));
+  page.on("console", (message) => {
+    if (message.type() === "error") errors.push(`console: ${message.text()}`);
+  });
+
+  await page.goto(`${baseUrl}/web/manim-compat-smoke.html`, { waitUntil: "load" });
+  await page.waitForFunction(() => window.noonManimCompat, null, { timeout: 30_000 });
+  await page.evaluate(() => window.noonManimCompat.ready());
+  const result = await page.evaluate(
+    (pythonSource) => window.noonManimCompat.run(pythonSource),
+    source,
+  );
+
+  assert.equal(result.kind, "scene_document");
+  assert.equal(result.document.tracks.length, 0);
+  assert.equal(result.document.objects.length, 15);
+  const kinds = result.document.objects.map((object) => Object.keys(object.geometry)[0]);
+  assert.deepEqual(kinds, [
+    "line", "line", "line", "line",
+    "circle", "circle",
+    "line", "line", "line", "line",
+    "circle", "circle", "circle",
+    "line", "line",
+  ]);
+  assert.ok(
+    kinds.every((kind) => kind === "line" || kind === "circle"),
+    "PolarPlane must lower only to existing retained Line/Circle geometry",
+  );
+  assert.deepEqual(errors, [], `browser errors while testing retained PolarPlane:\n${errors.join("\n")}`);
+  console.log(
+    "Retained PolarPlane smoke passed: exact radial/circle subdivision and order, unit-size scaling, transform-safe polar round trips, copy independence, explicit label deferral, and ordinary retained Line/Circle geometry.",
+  );
+} finally {
+  await browser?.close();
+  server.kill("SIGTERM");
+}

--- a/web/python-compat-modules.js
+++ b/web/python-compat-modules.js
@@ -14,6 +14,7 @@ export const PYTHON_COMPAT_MODULES = Object.freeze([
   { sourcePath: "python/_manim_axes.py", runtimePath: "/tmp/_manim_axes.py", label: "Noon shared Axes adapter" },
   { sourcePath: "python/_manim_number_line.py", runtimePath: "/tmp/_manim_number_line.py", label: "Noon shared NumberLine adapter" },
   { sourcePath: "python/_manim_number_plane.py", runtimePath: "/tmp/_manim_number_plane.py", label: "Noon shared NumberPlane adapter" },
+  { sourcePath: "python/_manim_polar_plane.py", runtimePath: "/tmp/_manim_polar_plane.py", label: "Noon shared PolarPlane adapter" },
   { sourcePath: "python/_manim_animation_options.py", runtimePath: "/tmp/_manim_animation_options.py", label: "Noon Manim animation options" },
   { sourcePath: "python/_manim_animate.py", runtimePath: "/tmp/_manim_animate.py", label: "Noon Manim animate layer" },
   { sourcePath: "python/_manim_rotate.py", runtimePath: "/tmp/_manim_rotate.py", label: "Noon Manim Rotate layer" },

--- a/web/python-worker.source.js
+++ b/web/python-worker.source.js
@@ -60,6 +60,8 @@ async function initializePyodide() {
     authoringStore.createParametricFunctionPlan(requestJson);
   self.noonCreateNumberPlaneGridPlan = (requestJson) =>
     authoringStore.createNumberPlaneGridPlan(requestJson);
+  self.noonCreatePolarPlaneGridPlan = (requestJson) =>
+    authoringStore.createPolarPlaneGridPlan(requestJson);
   self.noonCreateAuthoringDotHandle = (pointX, pointY, radius) =>
     authoringStore.createMobject(manimDotSnapshotJson(pointX, pointY, radius));
   self.noonCreateAuthoringTriangleHandle = () =>
@@ -120,6 +122,8 @@ import _manim_axes
 _manim_axes.install()
 import _manim_number_plane
 _manim_number_plane.install()
+import _manim_polar_plane
+_manim_polar_plane.install()
 import _manim_animate
 import _manim_rotate
 _manim_rotate.install()

--- a/web/python/_manim_polar_plane.py
+++ b/web/python/_manim_polar_plane.py
@@ -1,0 +1,300 @@
+"""ManimCE v0.21 PolarPlane facade over shared retained radial geometry.
+
+Radius/azimuth subdivision and retained Circle/Line construction remain Rust-owned.
+This module resolves public defaults, composes the ordinary retained family, and keeps
+text/nonlinear surfaces explicit until their shared substrates are qualified.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from typing import Any
+
+import noon as _base
+import _manim_axes as _axes
+import _manim_compat as _compat
+import _manim_number_plane as _number_plane
+
+try:
+    from js import noonCreatePolarPlaneGridPlan as _create_polar_grid_plan
+except ImportError:
+    _create_polar_grid_plan = None
+
+_INSTALLED = False
+_FRAME_Y_RADIUS = float(getattr(_base, "DEFAULT_FRAME_HEIGHT", 8.0)) / 2.0
+_DEFAULT_AZIMUTH_STEPS = {
+    "PI radians": 20.0,
+    "TAU radians": 20.0,
+    "degrees": 36.0,
+    "gradians": 40.0,
+    None: 1.0,
+}
+
+
+def _require_shared_polar_plane() -> None:
+    if _create_polar_grid_plan is None:
+        raise RuntimeError("PolarPlane requires Noon's browser shared-semantics runtime")
+
+
+def _finite(name: str, value: object) -> float:
+    try:
+        result = float(value)
+    except (TypeError, ValueError) as error:
+        raise TypeError(f"{name} must be a finite number") from error
+    if not math.isfinite(result):
+        raise ValueError(f"{name} must be finite")
+    return result
+
+
+def _positive(name: str, value: object) -> float:
+    result = _finite(name, value)
+    if result <= 0.0:
+        raise ValueError(f"{name} must be positive")
+    return result
+
+
+def _circle_from_snapshot(snapshot: dict[str, Any]) -> _compat.Circle:
+    value = _axes._mobject_from_snapshot(_compat.Circle, snapshot)
+    geometry = snapshot.get("geometry", {}).get("circle")
+    if not isinstance(geometry, dict):
+        raise TypeError("shared PolarPlane circle snapshot is malformed")
+    value.radius = float(geometry["radius"])
+    return value
+
+
+def _line_group(wire: list[dict[str, Any]]) -> _compat.VGroup:
+    return _compat.VGroup(*(_axes._line_from_snapshot(item["snapshot"]) for item in wire))
+
+
+def _circle_group(wire: list[dict[str, Any]]) -> _compat.VGroup:
+    return _compat.VGroup(*(_circle_from_snapshot(item["snapshot"]) for item in wire))
+
+
+class PolarPlane(_axes.Axes):
+    """Static retained PolarPlane with ManimCE v0.21 radial grid semantics."""
+
+    def __init__(
+        self,
+        radius_max: float = _FRAME_Y_RADIUS,
+        size: float | None = None,
+        radius_step: float = 1.0,
+        azimuth_step: float | None = None,
+        azimuth_units: str | None = "PI radians",
+        azimuth_compact_fraction: bool = True,
+        azimuth_offset: float = 0.0,
+        azimuth_direction: str = "CCW",
+        azimuth_label_buff: float = float(getattr(_base, "SMALL_BUFF", 0.1)),
+        azimuth_label_font_size: float = 24.0,
+        radius_config: dict[str, Any] | None = None,
+        background_line_style: dict[str, Any] | None = None,
+        faded_line_style: dict[str, Any] | None = None,
+        faded_line_ratio: int = 1,
+        make_smooth_after_applying_functions: bool = True,
+        **kwargs: Any,
+    ) -> None:
+        _require_shared_polar_plane()
+        if azimuth_units not in _DEFAULT_AZIMUTH_STEPS:
+            raise ValueError(
+                "Invalid azimuth units. Expected one of: PI radians, TAU radians, degrees, gradians or None."
+            )
+        if azimuth_direction not in ("CW", "CCW"):
+            raise ValueError("Invalid azimuth units. Expected one of: CW, CCW.")
+        if kwargs:
+            unsupported = ", ".join(sorted(kwargs))
+            raise NotImplementedError(f"unsupported PolarPlane option(s): {unsupported}")
+
+        resolved_radius_max = _positive("PolarPlane radius_max", radius_max)
+        resolved_radius_step = _positive("PolarPlane radius_step", radius_step)
+        resolved_size = (
+            2.0 * resolved_radius_max
+            if size is None
+            else _positive("PolarPlane size", size)
+        )
+        resolved_azimuth_step = (
+            _DEFAULT_AZIMUTH_STEPS[azimuth_units]
+            if azimuth_step is None
+            else _positive("PolarPlane azimuth_step", azimuth_step)
+        )
+        resolved_azimuth_offset = _finite("PolarPlane azimuth_offset", azimuth_offset)
+        resolved_label_buff = _finite("PolarPlane azimuth_label_buff", azimuth_label_buff)
+        resolved_label_font_size = _positive(
+            "PolarPlane azimuth_label_font_size", azimuth_label_font_size
+        )
+        ratio = _number_plane._faded_line_ratio(faded_line_ratio)
+
+        radius_axis_config: dict[str, Any] = {
+            "stroke_width": 2.0,
+            "include_ticks": False,
+            "include_tip": False,
+            "line_to_number_buff": float(getattr(_base, "SMALL_BUFF", 0.1)),
+            "label_direction": _base.DL,
+            "font_size": 24.0,
+        }
+        radius_axis_config.update(
+            _number_plane._axis_metadata(radius_config, "radius_config")
+        )
+        background = _number_plane._grid_style(
+            background_line_style,
+            {
+                "stroke_color": _base.BLUE_D,
+                "stroke_width": 2.0,
+                "stroke_opacity": 1.0,
+            },
+            "background_line_style",
+        )
+        faded = (
+            _number_plane._faded_style(background)
+            if faded_line_style is None
+            else _number_plane._grid_style(
+                faded_line_style,
+                _number_plane._DEFAULT_GRID_LINE_STYLE,
+                "faded_line_style",
+            )
+        )
+
+        radius_range = [
+            -resolved_radius_max,
+            resolved_radius_max,
+            resolved_radius_step,
+        ]
+        super().__init__(
+            x_range=radius_range,
+            y_range=radius_range,
+            x_length=resolved_size,
+            y_length=resolved_size,
+            axis_config=_number_plane._axis_geometry(radius_axis_config),
+            tips=False,
+        )
+
+        request = {
+            "radius_max": resolved_radius_max,
+            "radius_step": resolved_radius_step,
+            "size": resolved_size,
+            "azimuth_step": resolved_azimuth_step,
+            "azimuth_offset": resolved_azimuth_offset,
+            "faded_line_ratio": ratio,
+            "background_style": _number_plane._style_wire(background),
+            "faded_style": _number_plane._style_wire(faded),
+        }
+        assert _create_polar_grid_plan is not None
+        plan = _create_polar_grid_plan(
+            json.dumps(request, separators=(",", ":"), allow_nan=False)
+        )
+        wire = json.loads(str(plan.geometryJson()))
+
+        self._radial_lines = _line_group(wire["radial_lines"])
+        self._circles = _circle_group(wire["circles"])
+        self._faded_radial_lines = _line_group(wire["faded_radial_lines"])
+        self._faded_circles = _circle_group(wire["faded_circles"])
+        self.background_lines = _compat.VGroup(*self._radial_lines, *self._circles)
+        self.faded_lines = _compat.VGroup(
+            *self._faded_radial_lines, *self._faded_circles
+        )
+
+        self.remove(self.x_axis, self.y_axis)
+        self.add(self.faded_lines, self.background_lines, self.x_axis, self.y_axis)
+
+        self.radius_max = resolved_radius_max
+        self.size = resolved_size
+        self.radius_step = resolved_radius_step
+        self.azimuth_step = resolved_azimuth_step
+        self.azimuth_units = azimuth_units
+        self.azimuth_compact_fraction = bool(azimuth_compact_fraction)
+        self.azimuth_offset = resolved_azimuth_offset
+        self.azimuth_direction = azimuth_direction
+        self.azimuth_label_buff = resolved_label_buff
+        self.azimuth_label_font_size = resolved_label_font_size
+        self.radius_config = radius_axis_config
+        self.background_line_style = background
+        self.faded_line_style = faded
+        self.faded_line_ratio = ratio
+        self.make_smooth_after_applying_functions = bool(
+            make_smooth_after_applying_functions
+        )
+        self._polar_plane_grid_plan = plan
+
+    def copy(self) -> PolarPlane:
+        clone = object.__new__(type(self))
+        clone.x_range = list(self.x_range)
+        clone.y_range = list(self.y_range)
+        clone.x_length = self.x_length
+        clone.y_length = self.y_length
+        clone.axis_config = _axes._plain_copy(self.axis_config)
+        clone.x_axis_config = _axes._plain_copy(self.x_axis_config)
+        clone.y_axis_config = _axes._plain_copy(self.y_axis_config)
+        clone._base_request = _axes._plain_copy(self._base_request)
+        clone._axes_plan = self._axes_plan
+        clone._query_plan = self._query_plan
+        clone.radius_max = self.radius_max
+        clone.size = self.size
+        clone.radius_step = self.radius_step
+        clone.azimuth_step = self.azimuth_step
+        clone.azimuth_units = self.azimuth_units
+        clone.azimuth_compact_fraction = self.azimuth_compact_fraction
+        clone.azimuth_offset = self.azimuth_offset
+        clone.azimuth_direction = self.azimuth_direction
+        clone.azimuth_label_buff = self.azimuth_label_buff
+        clone.azimuth_label_font_size = self.azimuth_label_font_size
+        clone.radius_config = _axes._plain_copy(self.radius_config)
+        clone.background_line_style = dict(self.background_line_style)
+        clone.faded_line_style = dict(self.faded_line_style)
+        clone.faded_line_ratio = self.faded_line_ratio
+        clone.make_smooth_after_applying_functions = self.make_smooth_after_applying_functions
+        clone._polar_plane_grid_plan = self._polar_plane_grid_plan
+
+        clone.x_axis = self.x_axis.copy()
+        clone.y_axis = self.y_axis.copy()
+        clone.axes = _compat.VGroup(clone.x_axis, clone.y_axis)
+        clone._radial_lines = self._radial_lines.copy()
+        clone._circles = self._circles.copy()
+        clone._faded_radial_lines = self._faded_radial_lines.copy()
+        clone._faded_circles = self._faded_circles.copy()
+        clone.background_lines = _compat.VGroup(*clone._radial_lines, *clone._circles)
+        clone.faded_lines = _compat.VGroup(
+            *clone._faded_radial_lines, *clone._faded_circles
+        )
+        _compat.VGroup.__init__(
+            clone,
+            clone.faded_lines,
+            clone.background_lines,
+            clone.x_axis,
+            clone.y_axis,
+        )
+        return clone
+
+    def get_coordinate_labels(self, *args: object, **kwargs: Any):
+        del args, kwargs
+        raise NotImplementedError(
+            "PolarPlane coordinate labels require retained number/MathTex labels"
+        )
+
+    def add_coordinates(self, *args: object, **kwargs: Any):
+        del args, kwargs
+        raise NotImplementedError(
+            "PolarPlane.add_coordinates requires retained number/MathTex labels"
+        )
+
+    def get_vector(self, coords: object, **kwargs: Any):
+        del coords, kwargs
+        raise NotImplementedError(
+            "PolarPlane.get_vector requires the retained Arrow compatibility surface"
+        )
+
+    def prepare_for_nonlinear_transform(self, num_inserted_curves: int = 50) -> PolarPlane:
+        del num_inserted_curves
+        raise NotImplementedError(
+            "PolarPlane.prepare_for_nonlinear_transform requires retained pointwise nonlinear deformation"
+        )
+
+
+def install() -> None:
+    global _INSTALLED
+    if _INSTALLED:
+        return
+    _number_plane.install()
+    setattr(_base, "PolarPlane", PolarPlane)
+    setattr(_compat, "PolarPlane", PolarPlane)
+    if "PolarPlane" not in _base.__all__:
+        _base.__all__.append("PolarPlane")
+    _INSTALLED = True

--- a/web/python/_manim_polar_plane.py
+++ b/web/python/_manim_polar_plane.py
@@ -54,6 +54,32 @@ def _positive(name: str, value: object) -> float:
     return result
 
 
+def _polar_to_point(self: _axes.Axes, radius: float, azimuth: float) -> _base.Vec2:
+    """Shared v0.21 CoordinateSystem polar projection over retained c2p."""
+
+    resolved_radius = _finite("radius", radius)
+    resolved_azimuth = _finite("azimuth", azimuth)
+    return self.coords_to_point(
+        resolved_radius * math.cos(resolved_azimuth),
+        resolved_radius * math.sin(resolved_azimuth),
+    )
+
+
+def _point_to_polar(self: _axes.Axes, point: object) -> tuple[float, float]:
+    """Shared v0.21 CoordinateSystem polar inverse over retained p2c."""
+
+    x, y = self.point_to_coords(point)
+    return math.hypot(x, y), math.atan2(y, x)
+
+
+def _pr2pt(self: _axes.Axes, radius: float, azimuth: float) -> _base.Vec2:
+    return _polar_to_point(self, radius, azimuth)
+
+
+def _pt2pr(self: _axes.Axes, point: object) -> tuple[float, float]:
+    return _point_to_polar(self, point)
+
+
 def _circle_from_snapshot(snapshot: dict[str, Any]) -> _compat.Circle:
     value = _axes._mobject_from_snapshot(_compat.Circle, snapshot)
     geometry = snapshot.get("geometry", {}).get("circle")
@@ -293,6 +319,10 @@ def install() -> None:
     if _INSTALLED:
         return
     _number_plane.install()
+    _axes.Axes.polar_to_point = _polar_to_point
+    _axes.Axes.point_to_polar = _point_to_polar
+    _axes.Axes.pr2pt = _pr2pt
+    _axes.Axes.pt2pr = _pt2pr
     setattr(_base, "PolarPlane", PolarPlane)
     setattr(_compat, "PolarPlane", PolarPlane)
     if "PolarPlane" not in _base.__all__:


### PR DESCRIPTION
## Summary
- add a shared Rust `PolarPlaneGridPlan` for pinned ManimCE v0.21 concentric-circle and radial-line subdivision
- reuse existing retained `Circle` / `Line` geometry and the qualified `Axes2DState` / NumberLine unit-size substrate; no renderer geometry kind is added
- expose a thin WASM serialization bridge and stable authoring-store factory
- add the Python `PolarPlane` facade with exact public defaults/validation for radius, size, azimuth units/steps/offset/direction, background/faded styles, and family composition
- add shared `polar_to_point`, `point_to_polar`, `pr2pt`, and `pt2pr` helpers over authoritative transform-safe `c2p` / `p2c`
- keep coordinate labels and nonlinear deformation explicitly deferred to their retained substrates
- add a dedicated real Pyodide/WASM browser smoke and Fast Gate step

## Architecture
The Rust plan owns subdivision, style validation, retained primitive construction, background/faded classification, and upstream family ordering. Python owns only public option normalization and facade composition. Static output remains ordinary retained Line/Circle leaves with zero tracks.

## Browser acceptance
The dedicated fixture checks:
- exact background/faded radial and circle counts for `radius_max=2`, `size=8`, `radius_step=1`, `azimuth_step=4`, `faded_line_ratio=2`
- upstream family order in the serialized scene
- custom-size NumberLine unit scaling
- azimuth offset geometry
- shared polar helpers on both Axes and PolarPlane
- transform-safe polar round trips
- subclass-preserving independent copy
- ratio-0 behavior and non-integer azimuth divisions
- invalid azimuth units/direction
- explicit label deferral
- Line/Circle-only retained scene output with zero tracks

## Exact-head qualification
- exact head: `85ebaa57849a39e3bbd42409a13aa405947fac49`
- PR Fast Gate run: `33556842406` (#340)
- result: **green** across Rust formatting + Clippy, Rust unit tests, web static/unit checks, one-time WASM build, deterministic playback, Manim authoring, retained Axes plotting, retained NumberLine authoring, retained ComplexPlane authoring, dedicated retained PolarPlane acceptance, lazy namespace dependencies, literal PlotExample, and primary WebGPU rendering

Stacked on exact-green #821.

Tracks #824 / #85. Related label work: #83.