### PR TITLE
Add shared implicit contour request semantics

### DIFF
--- a/crates/noon/src/implicit_contour_authoring.rs
+++ b/crates/noon/src/implicit_contour_authoring.rs
@@ -1,0 +1,211 @@
+/// ManimCE v0.21 `ImplicitFunction` defaults.
+pub const MANIM_DEFAULT_IMPLICIT_MIN_DEPTH: u32 = 5;
+pub const MANIM_DEFAULT_IMPLICIT_MAX_QUADS: usize = 1500;
+pub const MANIM_DEFAULT_IMPLICIT_TOLERANCE_DIVISOR: f64 = 1000.0;
+
+/// Finite, non-degenerate authoring domain for one implicit contour extraction.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ImplicitContourDomain {
+    x_min: f64,
+    x_max: f64,
+    y_min: f64,
+    y_max: f64,
+}
+
+impl ImplicitContourDomain {
+    pub fn new(
+        x_min: f64,
+        x_max: f64,
+        y_min: f64,
+        y_max: f64,
+    ) -> Result<Self, ImplicitContourError> {
+        if [x_min, x_max, y_min, y_max]
+            .into_iter()
+            .any(|value| !value.is_finite())
+        {
+            return Err(ImplicitContourError::NonFiniteDomain);
+        }
+        if x_min >= x_max || y_min >= y_max {
+            return Err(ImplicitContourError::InvalidDomain {
+                x_min,
+                x_max,
+                y_min,
+                y_max,
+            });
+        }
+        Ok(Self {
+            x_min,
+            x_max,
+            y_min,
+            y_max,
+        })
+    }
+
+    pub const fn x_min(self) -> f64 {
+        self.x_min
+    }
+
+    pub const fn x_max(self) -> f64 {
+        self.x_max
+    }
+
+    pub const fn y_min(self) -> f64 {
+        self.y_min
+    }
+
+    pub const fn y_max(self) -> f64 {
+        self.y_max
+    }
+
+    /// Default per-axis isoline tolerance used by the pinned isosurfaces behavior.
+    pub fn default_tolerance(self) -> [f64; 2] {
+        [
+            (self.x_max - self.x_min) / MANIM_DEFAULT_IMPLICIT_TOLERANCE_DIVISOR,
+            (self.y_max - self.y_min) / MANIM_DEFAULT_IMPLICIT_TOLERANCE_DIVISOR,
+        ]
+    }
+}
+
+/// Renderer-independent request metadata for adaptive implicit contour extraction.
+///
+/// This deliberately contains no callback or generated geometry. Rust chooses
+/// evaluation coordinates in the contour session that consumes this request;
+/// host-language functions are authoring-time evaluators only.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ImplicitContourRequest {
+    domain: ImplicitContourDomain,
+    min_depth: u32,
+    max_quads: usize,
+    use_smoothing: bool,
+}
+
+impl ImplicitContourRequest {
+    pub fn new(
+        domain: ImplicitContourDomain,
+        min_depth: u32,
+        max_quads: usize,
+        use_smoothing: bool,
+    ) -> Result<Self, ImplicitContourError> {
+        if max_quads == 0 {
+            return Err(ImplicitContourError::InvalidMaxQuads(max_quads));
+        }
+        Ok(Self {
+            domain,
+            min_depth,
+            max_quads,
+            use_smoothing,
+        })
+    }
+
+    pub fn manim_default(domain: ImplicitContourDomain) -> Self {
+        Self {
+            domain,
+            min_depth: MANIM_DEFAULT_IMPLICIT_MIN_DEPTH,
+            max_quads: MANIM_DEFAULT_IMPLICIT_MAX_QUADS,
+            use_smoothing: true,
+        }
+    }
+
+    pub const fn domain(self) -> ImplicitContourDomain {
+        self.domain
+    }
+
+    pub const fn min_depth(self) -> u32 {
+        self.min_depth
+    }
+
+    pub const fn max_quads(self) -> usize {
+        self.max_quads
+    }
+
+    pub const fn use_smoothing(self) -> bool {
+        self.use_smoothing
+    }
+
+    pub fn tolerance(self) -> [f64; 2] {
+        self.domain.default_tolerance()
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ImplicitContourError {
+    NonFiniteDomain,
+    InvalidDomain {
+        x_min: f64,
+        x_max: f64,
+        y_min: f64,
+        y_max: f64,
+    },
+    InvalidMaxQuads(usize),
+}
+
+impl std::fmt::Display for ImplicitContourError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match *self {
+            Self::NonFiniteDomain => formatter.write_str("implicit contour domain must be finite"),
+            Self::InvalidDomain {
+                x_min,
+                x_max,
+                y_min,
+                y_max,
+            } => write!(
+                formatter,
+                "implicit contour bounds must be strictly increasing: x=[{x_min}, {x_max}], y=[{y_min}, {y_max}]"
+            ),
+            Self::InvalidMaxQuads(max_quads) => {
+                write!(formatter, "implicit contour max_quads must be non-zero: {max_quads}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ImplicitContourError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn manim_defaults_are_explicit_and_domain_scaled() {
+        let domain = ImplicitContourDomain::new(-7.0, 7.0, -4.0, 4.0).unwrap();
+        let request = ImplicitContourRequest::manim_default(domain);
+        assert_eq!(request.min_depth(), 5);
+        assert_eq!(request.max_quads(), 1500);
+        assert!(request.use_smoothing());
+        assert_eq!(request.tolerance(), [0.014, 0.008]);
+    }
+
+    #[test]
+    fn min_depth_is_independent_of_max_quad_budget() {
+        let domain = ImplicitContourDomain::new(-1.0, 1.0, -1.0, 1.0).unwrap();
+        let request = ImplicitContourRequest::new(domain, 8, 1, false).unwrap();
+        assert_eq!(request.min_depth(), 8);
+        assert_eq!(request.max_quads(), 1);
+        assert!(!request.use_smoothing());
+    }
+
+    #[test]
+    fn rejects_nonfinite_degenerate_and_reversed_domains() {
+        assert_eq!(
+            ImplicitContourDomain::new(f64::NAN, 1.0, -1.0, 1.0),
+            Err(ImplicitContourError::NonFiniteDomain)
+        );
+        assert!(matches!(
+            ImplicitContourDomain::new(1.0, 1.0, -1.0, 1.0),
+            Err(ImplicitContourError::InvalidDomain { .. })
+        ));
+        assert!(matches!(
+            ImplicitContourDomain::new(-1.0, 1.0, 2.0, -2.0),
+            Err(ImplicitContourError::InvalidDomain { .. })
+        ));
+    }
+
+    #[test]
+    fn zero_quad_budget_is_rejected_before_evaluation() {
+        let domain = ImplicitContourDomain::new(-1.0, 1.0, -1.0, 1.0).unwrap();
+        assert_eq!(
+            ImplicitContourRequest::new(domain, 5, 0, true),
+            Err(ImplicitContourError::InvalidMaxQuads(0))
+        );
+    }
+}

--- a/crates/noon/src/lib.rs
+++ b/crates/noon/src/lib.rs
@@ -17,6 +17,7 @@ mod dashed_line_authoring;
 mod elbow_authoring;
 mod geometry_authoring;
 mod graph_query_authoring;
+mod implicit_contour_authoring;
 mod legacy;
 mod line_graph_authoring;
 mod line_matcher_authoring;
@@ -42,6 +43,7 @@ pub use dashed_line_authoring::*;
 pub use elbow_authoring::*;
 pub use geometry_authoring::*;
 pub use graph_query_authoring::*;
+pub use implicit_contour_authoring::*;
 pub use legacy::*;
 pub use line_graph_authoring::*;
 pub use line_matcher_authoring::*;
@@ -67,22 +69,25 @@ pub mod prelude {
         ArcBetweenPoints, AreaAuthoringError, AreaSamplePlan, Axes2DState, AxisTickError,
         BackgroundRectangle, CoordinateSystemError, Cross, DashedLine, DashedLineAuthoringError,
         Dot, Elbow, ElbowAuthoringError, Ellipse, GeometryAuthoringError, GraphParameterRange,
-        GraphQueryError, LineGraphAuthoringError, LineMatcherAuthoringError, MathTypst,
-        MovingCameraScene, NumberLineGeometryPlan, NumberLineState, NumberLineTick,
-        NumberLineTickOptions, NumberPlaneAuthoringError, NumberPlaneGridLine, NumberPlaneGridPlan,
-        NumberPlaneLineStyle, NumberRange, ParametricSamplePlan, PlotGeometryError,
-        PlotRangeRequest, PlotSamplingError, Polygon, Polygram, PolygramAuthoringError,
-        ReactiveScene, ReactiveTimelineScene, RegularPolygon, RegularPolygram, RetainedMobject,
-        RetainedScene, RiemannAuthoringError, RiemannRectangleGeometry, RiemannSample,
-        RiemannSamplePlan, RiemannSampleType, RoundedRectangle, RoundedRectangleAuthoringError,
-        SampleRange, SampleSpan, Sector, ShapeMatcherAuthoringError, Star, SurroundingRectangle,
-        Text, TextAuthoringError, TransformedAxes2DState, TransformedNumberLineState, Triangle,
-        Typst, Underline, ValueTracker, VectorSignal, BACKGROUND_RECTANGLE_DEFAULT_FILL_OPACITY,
+        GraphQueryError, ImplicitContourDomain, ImplicitContourError, ImplicitContourRequest,
+        LineGraphAuthoringError, LineMatcherAuthoringError, MathTypst, MovingCameraScene,
+        NumberLineGeometryPlan, NumberLineState, NumberLineTick, NumberLineTickOptions,
+        NumberPlaneAuthoringError, NumberPlaneGridLine, NumberPlaneGridPlan, NumberPlaneLineStyle,
+        NumberRange, ParametricSamplePlan, PlotGeometryError, PlotRangeRequest, PlotSamplingError,
+        Polygon, Polygram, PolygramAuthoringError, ReactiveScene, ReactiveTimelineScene,
+        RegularPolygon, RegularPolygram, RetainedMobject, RetainedScene, RiemannAuthoringError,
+        RiemannRectangleGeometry, RiemannSample, RiemannSamplePlan, RiemannSampleType,
+        RoundedRectangle, RoundedRectangleAuthoringError, SampleRange, SampleSpan, Sector,
+        ShapeMatcherAuthoringError, Star, SurroundingRectangle, Text, TextAuthoringError,
+        TransformedAxes2DState, TransformedNumberLineState, Triangle, Typst, Underline,
+        ValueTracker, VectorSignal, BACKGROUND_RECTANGLE_DEFAULT_FILL_OPACITY,
         DEFAULT_CROSS_SCALE_FACTOR, DEFAULT_CROSS_STROKE_WIDTH, DEFAULT_DASHED_RATIO,
         DEFAULT_DASH_LENGTH, DEFAULT_DOT_RADIUS, DEFAULT_ELBOW_ANGLE, DEFAULT_ELBOW_WIDTH,
         DEFAULT_NATIVE_TEXT_FONT_FAMILY, DEFAULT_NATIVE_TEXT_FONT_SIZE,
         DEFAULT_ROUNDED_RECTANGLE_CORNER_RADIUS, DEFAULT_UNDERLINE_BUFF,
-        MANIM_DEFAULT_DISCONTINUITY_DT, MANIM_DEFAULT_PARAMETRIC_STEP, MANIM_DEFAULT_RIEMANN_DX,
+        MANIM_DEFAULT_DISCONTINUITY_DT, MANIM_DEFAULT_IMPLICIT_MAX_QUADS,
+        MANIM_DEFAULT_IMPLICIT_MIN_DEPTH, MANIM_DEFAULT_IMPLICIT_TOLERANCE_DIVISOR,
+        MANIM_DEFAULT_PARAMETRIC_STEP, MANIM_DEFAULT_RIEMANN_DX,
         MANIM_DEFAULT_RIEMANN_WIDTH_SCALE_FACTOR, MANIM_GRAPH_X_SEARCH_TOLERANCE,
         MANIM_SAMPLED_GRAPH_POINTS_PER_TICK, SURROUNDING_RECTANGLE_DEFAULT_COLOR,
     };


### PR DESCRIPTION
First architecture slice for #830, stacked on exact-green #821.

## What changes
- add a renderer-independent `ImplicitContourDomain` with finite, strictly increasing x/y bounds
- add `ImplicitContourRequest` owning the pinned ManimCE v0.21 defaults: `min_depth=5`, `max_quads=1500`, `use_smoothing=true`
- centralize the pinned isosurfaces default per-axis tolerance `(pmax-pmin)/1000`
- preserve the important contract that `min_depth` is independent of the adaptive `max_quads` budget
- reject malformed domains and a zero adaptive budget before any host callback evaluation
- export the new shared authoring types through the normal Noon facade/prelude
- add focused unit tests for defaults, tolerance scaling, min-depth precedence, and invalid inputs

## Architecture
This intentionally contains no Python callback, contour extraction, or renderer geometry. Rust-owned adaptive contour evaluation can consume this validated request next and choose every evaluation coordinate; host functions remain authoring-time evaluators only. The eventual output remains ordinary retained `VectorPath` geometry.

## Scope / remaining work
This does not claim `ImplicitFunction` support. Follow-up work under #830 still owns adaptive quadtree/simplicial sampling, NaN/discontinuity handling, zero refinement/asymptote rejection, curve tracing/orientation, shared smoothing, the authoring callback session, Axes mapping, WASM/Python facade, and browser parity.

Base: #821 (`work/253-complex-plane`).