### PR TITLE
Expose canonical retained family Create/Uncreate to Python

### DIFF
--- a/crates/noon-web/src/family_animation_authoring.rs
+++ b/crates/noon-web/src/family_animation_authoring.rs
@@ -7,9 +7,8 @@ mod wasm {
     use wasm_bindgen::prelude::*;
 
     use crate::{
-        WasmAuthoringFamilyHandle, WasmAuthoringFamilyLayout,
-        WasmAuthoringFamilyMemberHandle, WasmAuthoringMobjectHandle,
-        WasmRetainedNativeTextAuthoringHandle,
+        WasmAuthoringFamilyHandle, WasmAuthoringFamilyLayout, WasmAuthoringFamilyMemberHandle,
+        WasmAuthoringMobjectHandle, WasmRetainedNativeTextAuthoringHandle,
     };
 
     const MAX_JS_SAFE_INTEGER: f64 = 9_007_199_254_740_991.0;
@@ -19,10 +18,7 @@ mod wasm {
     }
 
     fn object_id(value: f64) -> Result<ObjectId, JsValue> {
-        if !value.is_finite()
-            || value < 0.0
-            || value > MAX_JS_SAFE_INTEGER
-            || value.fract() != 0.0
+        if !value.is_finite() || value < 0.0 || value > MAX_JS_SAFE_INTEGER || value.fract() != 0.0
         {
             return Err(JsValue::from_str(
                 "family animation object ID must be a non-negative JavaScript-safe integer",
@@ -105,10 +101,8 @@ mod wasm {
             final_object_id: f64,
         ) -> Result<(), JsValue> {
             self.layout.include_mobject(member)?;
-            let semantic_leaf = SemanticNodeId::new(
-                member.semantic_slot()?,
-                member.semantic_generation()?,
-            );
+            let semantic_leaf =
+                SemanticNodeId::new(member.semantic_slot()?, member.semantic_generation()?);
             self.bindings.push(FamilyAnimationLeafBinding::new(
                 semantic_leaf,
                 object_id(final_object_id)?,

--- a/crates/noon-web/src/family_animation_authoring.rs
+++ b/crates/noon-web/src/family_animation_authoring.rs
@@ -1,0 +1,153 @@
+#[cfg(target_arch = "wasm32")]
+mod wasm {
+    use noon_core::{
+        FamilyAnimationLeafBinding, FamilyAnimationMode, FamilyAnimationRequest,
+        FamilyAnimationSpec, ObjectId, RateFunction, SemanticNodeId,
+    };
+    use wasm_bindgen::prelude::*;
+
+    use crate::{
+        WasmAuthoringFamilyHandle, WasmAuthoringFamilyLayout,
+        WasmAuthoringFamilyMemberHandle, WasmAuthoringMobjectHandle,
+        WasmRetainedNativeTextAuthoringHandle,
+    };
+
+    const MAX_JS_SAFE_INTEGER: f64 = 9_007_199_254_740_991.0;
+
+    fn js_error(message: impl ToString) -> JsValue {
+        JsValue::from_str(&message.to_string())
+    }
+
+    fn object_id(value: f64) -> Result<ObjectId, JsValue> {
+        if !value.is_finite()
+            || value < 0.0
+            || value > MAX_JS_SAFE_INTEGER
+            || value.fract() != 0.0
+        {
+            return Err(JsValue::from_str(
+                "family animation object ID must be a non-negative JavaScript-safe integer",
+            ));
+        }
+        Ok(ObjectId::new(value as u64))
+    }
+
+    fn animation_mode(value: &str) -> Result<FamilyAnimationMode, JsValue> {
+        match value {
+            "reveal" => Ok(FamilyAnimationMode::Reveal),
+            _ => Err(JsValue::from_str(&format!(
+                "unsupported family animation mode {value:?}; public authoring currently supports reveal"
+            ))),
+        }
+    }
+
+    fn rate_function(value: &str) -> Result<RateFunction, JsValue> {
+        RateFunction::from_semantic_id(value).ok_or_else(|| {
+            JsValue::from_str(&format!(
+                "unsupported family animation rate function semantic ID {value:?}"
+            ))
+        })
+    }
+
+    /// Rust-owned builder for one canonical semantic-family animation request.
+    ///
+    /// The embedded family-layout session is used only as an authoritative ordered-leaf
+    /// validator. Frontends report each already-materialized leaf and final ObjectId;
+    /// they never serialize or reconstruct semantic family order themselves.
+    #[wasm_bindgen]
+    pub struct WasmFamilyAnimationRequestSession {
+        target: SemanticNodeId,
+        layout: WasmAuthoringFamilyLayout,
+        spec: FamilyAnimationSpec,
+        bindings: Vec<FamilyAnimationLeafBinding>,
+    }
+
+    #[wasm_bindgen]
+    impl WasmAuthoringFamilyHandle {
+        #[wasm_bindgen(js_name = familyAnimationRequest)]
+        #[allow(clippy::too_many_arguments)]
+        pub fn family_animation_request(
+            &self,
+            mode: &str,
+            start_time: f64,
+            duration: f64,
+            lag_ratio: f64,
+            rate_function_id: &str,
+            reverse_rate_function: bool,
+            reverse_member_order: bool,
+        ) -> Result<WasmFamilyAnimationRequestSession, JsValue> {
+            let target = SemanticNodeId::new(self.semantic_slot(), self.semantic_generation());
+            let spec = FamilyAnimationSpec::new(
+                animation_mode(mode)?,
+                start_time,
+                duration,
+                lag_ratio,
+                rate_function(rate_function_id)?,
+                reverse_rate_function,
+                reverse_member_order,
+            )
+            .map_err(js_error)?;
+            Ok(WasmFamilyAnimationRequestSession {
+                target,
+                layout: self.layout_session()?,
+                spec,
+                bindings: Vec::new(),
+            })
+        }
+    }
+
+    #[wasm_bindgen]
+    impl WasmFamilyAnimationRequestSession {
+        /// Bind one ordinary semantic Mobject leaf in authoritative family order.
+        #[wasm_bindgen(js_name = bindMobject)]
+        pub fn bind_mobject(
+            &mut self,
+            member: &WasmAuthoringMobjectHandle,
+            final_object_id: f64,
+        ) -> Result<(), JsValue> {
+            self.layout.include_mobject(member)?;
+            let semantic_leaf = SemanticNodeId::new(
+                member.semantic_slot()?,
+                member.semantic_generation()?,
+            );
+            self.bindings.push(FamilyAnimationLeafBinding::new(
+                semantic_leaf,
+                object_id(final_object_id)?,
+            ));
+            Ok(())
+        }
+
+        /// Bind one retained native Text leaf without exposing its shaped members.
+        #[wasm_bindgen(js_name = bindRetainedNativeText)]
+        pub fn bind_retained_native_text(
+            &mut self,
+            member: &WasmAuthoringFamilyMemberHandle,
+            text: &WasmRetainedNativeTextAuthoringHandle,
+            final_object_id: f64,
+        ) -> Result<(), JsValue> {
+            self.layout.include_retained_native_text(member, text)?;
+            let semantic_leaf =
+                SemanticNodeId::new(member.semantic_slot(), member.semantic_generation());
+            self.bindings.push(FamilyAnimationLeafBinding::new(
+                semantic_leaf,
+                object_id(final_object_id)?,
+            ));
+            Ok(())
+        }
+
+        /// Finish only after every authoritative semantic leaf has been accepted.
+        #[wasm_bindgen(js_name = finishJson)]
+        pub fn finish_json(&self) -> Result<String, JsValue> {
+            // Every public layout query first checks that all authoritative leaves were
+            // consumed. Use width only as a zero-allocation completion gate; bounds are
+            // intentionally absent from the canonical family-animation request.
+            let _ = self.layout.width()?;
+            let request =
+                FamilyAnimationRequest::new(self.target, self.bindings.clone(), self.spec)
+                    .map_err(js_error)?;
+            serde_json::to_string(&request).map_err(js_error)
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub use wasm::*;

--- a/crates/noon-web/src/lib.rs
+++ b/crates/noon-web/src/lib.rs
@@ -11,6 +11,7 @@ mod determinism;
 mod execution_canvas;
 mod execution_transport;
 mod execution_visibility;
+mod family_animation_authoring;
 mod family_bounds;
 #[cfg(any(target_arch = "wasm32", test))]
 mod gpu_diagnostics;
@@ -61,6 +62,8 @@ pub use determinism::*;
 pub use execution_canvas::*;
 pub use execution_transport::*;
 pub use execution_visibility::*;
+#[cfg(target_arch = "wasm32")]
+pub use family_animation_authoring::*;
 pub use family_bounds::*;
 pub use host_player::*;
 pub use legacy::*;

--- a/crates/noon-web/src/retained_authoring_wire_scene.rs
+++ b/crates/noon-web/src/retained_authoring_wire_scene.rs
@@ -1,6 +1,6 @@
 use noon::RetainedScene;
 use noon_compile::RetainedCompiledScene;
-use noon_core::{ObjectId, SceneDefinition, TrackDefinition};
+use noon_core::{FamilyAnimationRequest, ObjectId, SceneDefinition, TrackDefinition};
 use noon_ir::{SceneSpec, SceneSpecError};
 use serde::Deserialize;
 
@@ -12,14 +12,16 @@ use crate::{
 /// One protocol-v2 retained payload.
 ///
 /// The established object document remains the compatibility source-level text schema;
-/// animation tracks are an additive wire field. The two inputs are normalized into one
-/// canonical `SceneSpec` before any retained/runtime lowering.
+/// animation tracks and semantic-family animations are additive wire fields. Inputs are
+/// normalized into one canonical `SceneSpec` before any retained/runtime lowering.
 #[derive(Debug, Deserialize)]
 struct RetainedAuthoringWireDocument {
     #[serde(flatten)]
     document: RetainedAuthoringDocument,
     #[serde(default)]
     tracks: Vec<RetainedTrackAuthoringSpec>,
+    #[serde(default)]
+    family_animations: Vec<FamilyAnimationRequest>,
 }
 
 /// Normalize the current browser compatibility pair into one canonical mixed scene JSON.
@@ -48,8 +50,11 @@ fn retained_authoring_scene_spec_from_json(
                 "invalid retained authoring document: {error}"
             ))
         })?;
-    retained_authoring_scene_spec(&legacy, wire.document, wire.tracks)
-        .map_err(map_scene_spec_adapter_error)
+    let mut spec = retained_authoring_scene_spec(&legacy, wire.document, wire.tracks)
+        .map_err(map_scene_spec_adapter_error)?;
+    spec.family_animations = wire.family_animations;
+    spec.validate().map_err(map_scene_spec_error)?;
+    Ok(spec)
 }
 
 /// Wire-facing mixed retained scene.
@@ -179,7 +184,10 @@ pub use wasm::*;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use noon_core::{GeometryRef, Property, RateFunction, TrackTiming, TrackValues, Vec2};
+    use noon_core::{
+        FamilyAnimationLeafBinding, FamilyAnimationMode, FamilyAnimationSpec, GeometryRef,
+        Property, RateFunction, SemanticNodeId, TrackTiming, TrackValues, Vec2,
+    };
     use noon_ir::{encode_scene, ObjectSpecContent};
     use serde_json::json;
 
@@ -309,6 +317,41 @@ mod tests {
             spec.objects[1].content,
             ObjectSpecContent::Text(_)
         ));
+    }
+
+    #[test]
+    fn browser_normalizer_carries_family_animation_requests_into_scene_spec() {
+        let legacy = SceneDefinition::new();
+        let object = ObjectId::new(1_u64 << 52);
+        let document = retained_document(object);
+        let mut wire = serde_json::to_value(document).unwrap();
+        let target = SemanticNodeId::new(7, 0);
+        let leaf = SemanticNodeId::new(8, 0);
+        let animation = FamilyAnimationRequest::new(
+            target,
+            vec![FamilyAnimationLeafBinding::new(leaf, object)],
+            FamilyAnimationSpec::new(
+                FamilyAnimationMode::Reveal,
+                0.0,
+                1.0,
+                1.0,
+                RateFunction::Smooth,
+                false,
+                false,
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        wire["family_animations"] = json!([animation]);
+
+        let json = canonical_retained_scene_spec_json(
+            &encode_scene(&legacy).unwrap(),
+            &serde_json::to_string(&wire).unwrap(),
+        )
+        .unwrap();
+        let spec = SceneSpec::from_json(&json).unwrap();
+        assert_eq!(spec.family_animations.len(), 1);
+        assert_eq!(spec.family_animations[0], animation);
     }
 
     #[test]

--- a/web/family-animation-authoring.test.mjs
+++ b/web/family-animation-authoring.test.mjs
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { test } from "node:test";
+
+const pythonPath = "web/python/_manim_family_create.py";
+const pythonSource = readFileSync(pythonPath, "utf8");
+const moduleManifest = readFileSync("web/python-compat-modules.js", "utf8");
+const rustBridge = readFileSync(
+  "crates/noon-web/src/family_animation_authoring.rs",
+  "utf8",
+);
+const canonicalWire = readFileSync(
+  "crates/noon-web/src/retained_authoring_wire_scene.rs",
+  "utf8",
+);
+
+test("retained family Create authoring module is valid Python and bundled", () => {
+  const result = spawnSync("python3", ["-m", "py_compile", pythonPath], {
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(moduleManifest, /python\/_manim_family_create\.py/);
+  assert.match(pythonSource, /familyAnimationRequest/);
+  assert.match(pythonSource, /bindRetainedNativeText/);
+});
+
+test("Python does not serialize semantic family order or retained resource identity", () => {
+  for (const forbidden of [
+    "memberSlot(",
+    "memberGeneration(",
+    "glyph",
+    "atlas",
+    "font_bytes",
+  ]) {
+    assert.equal(
+      pythonSource.includes(forbidden),
+      false,
+      `Python family authoring must not contain ${forbidden}`,
+    );
+  }
+  assert.match(rustBridge, /layout\.include_mobject/);
+  assert.match(rustBridge, /layout\.include_retained_native_text/);
+  assert.match(rustBridge, /FamilyAnimationRequest::new/);
+});
+
+test("canonical retained normalization owns family animation transport", () => {
+  assert.match(canonicalWire, /family_animations: Vec<FamilyAnimationRequest>/);
+  assert.match(canonicalWire, /spec\.family_animations = wire\.family_animations/);
+  assert.match(canonicalWire, /spec\.validate\(\)/);
+});

--- a/web/family-animation-authoring.test.mjs
+++ b/web/family-animation-authoring.test.mjs
@@ -29,8 +29,9 @@ test("Python does not serialize semantic family order or retained resource ident
   for (const forbidden of [
     "memberSlot(",
     "memberGeneration(",
-    "glyph",
-    "atlas",
+    "glyph_id",
+    "glyphIds",
+    "atlas_id",
     "font_bytes",
   ]) {
     assert.equal(

--- a/web/manim-compat-smoke.html
+++ b/web/manim-compat-smoke.html
@@ -42,7 +42,11 @@ class RetainedFamilyCreateSmoke(Scene):
             if (!Array.isArray(retained.family_animations) || retained.family_animations.length !== 1) {
               throw new Error("family Create smoke did not author exactly one family animation request");
             }
-            const serialized = JSON.stringify(retained.family_animations[0]);
+            const sceneSpec = result.sceneSpec;
+            if (!sceneSpec || !Array.isArray(sceneSpec.family_animations) || sceneSpec.family_animations.length !== 1) {
+              throw new Error("family Create smoke did not reach canonical SceneSpec family animations");
+            }
+            const serialized = JSON.stringify(sceneSpec.family_animations[0]);
             for (const forbidden of ["glyph_id", "atlas_id", "font_bytes"]) {
               if (serialized.includes(forbidden)) {
                 throw new Error(`family Create request leaked ${forbidden}`);

--- a/web/manim-compat-smoke.html
+++ b/web/manim-compat-smoke.html
@@ -12,8 +12,50 @@
 
       const client = new PythonAuthoringClient();
       const wasmReady = init();
+      const familyCreateSource = `
+from noon import *
+
+class RetainedFamilyCreateSmoke(Scene):
+    def construct(self):
+        family = VGroup(Text("AB"), Circle(radius=0.25))
+        self.play(Create(family), run_time=1.0, rate_func=linear)
+`;
+
+      let readyPromise = null;
+      async function ready() {
+        if (readyPromise == null) {
+          readyPromise = (async () => {
+            await Promise.all([client.ready(), wasmReady]);
+            const result = await client.run(familyCreateSource);
+            if (result.kind !== "scene_document") {
+              throw new Error(`family Create smoke returned ${result.kind}`);
+            }
+            if (result.document.objects.length !== 1) {
+              throw new Error(
+                `family Create smoke expected one geometry leaf, got ${result.document.objects.length}`,
+              );
+            }
+            const retained = result.retainedDocument;
+            if (!retained || retained.objects.length !== 1) {
+              throw new Error("family Create smoke expected one retained native Text leaf");
+            }
+            if (!Array.isArray(retained.family_animations) || retained.family_animations.length !== 1) {
+              throw new Error("family Create smoke did not author exactly one family animation request");
+            }
+            const serialized = JSON.stringify(retained.family_animations[0]);
+            for (const forbidden of ["glyph_id", "atlas_id", "font_bytes"]) {
+              if (serialized.includes(forbidden)) {
+                throw new Error(`family Create request leaked ${forbidden}`);
+              }
+            }
+            return result;
+          })();
+        }
+        return readyPromise;
+      }
+
       window.noonManimCompat = {
-        ready: () => Promise.all([client.ready(), wasmReady]),
+        ready,
         run: (source) => client.run(source),
         semanticFrame: (sceneJson, time) => JSON.parse(semanticFrameJson(sceneJson, time)),
       };

--- a/web/python-compat-modules.js
+++ b/web/python-compat-modules.js
@@ -5,6 +5,7 @@ export const PYTHON_COMPAT_MODULES = Object.freeze([
   { sourcePath: "python/_manim_semantic_handles.py", runtimePath: "/tmp/_manim_semantic_handles.py", label: "Noon shared semantic handle layer" },
   { sourcePath: "python/_manim_typst.py", runtimePath: "/tmp/_manim_typst.py", label: "Noon retained Typst compatibility layer" },
   { sourcePath: "python/_manim_retained_animate.py", runtimePath: "/tmp/_manim_retained_animate.py", label: "Noon retained text animation layer" },
+  { sourcePath: "python/_manim_family_create.py", runtimePath: "/tmp/_manim_family_create.py", label: "Noon retained family Create/Uncreate layer" },
   { sourcePath: "python/_manim_retained_state.py", runtimePath: "/tmp/_manim_retained_state.py", label: "Noon retained text canonical state layer" },
   { sourcePath: "python/_manim_rate_functions.py", runtimePath: "/tmp/_manim_rate_functions.py", label: "Noon Manim rate functions" },
   { sourcePath: "python/_manim_phase_b.py", runtimePath: "/tmp/_manim_phase_b.py", label: "Noon Manim Phase B layer" },

--- a/web/python/_manim_camera.py
+++ b/web/python/_manim_camera.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import noon as _base
 import _manim_compat as _compat
+import _manim_family_create as _family_create
 import _manim_phase_b as _phase_b
 
 
@@ -51,8 +52,12 @@ class MovingCameraScene(_compat.Scene):
 
 
 def install() -> None:
-    """Expose the Manim name through ``from noon import *``."""
+    """Install final authoring wrappers and expose the moving-camera name."""
 
+    # Camera is the final compatibility module installed by the browser bootstrap.
+    # Install family Create/Uncreate here so it wraps every existing Scene.play layer
+    # and delegates all unrelated animations unchanged.
+    _family_create.install()
     _base.MovingCameraScene = MovingCameraScene
     if "MovingCameraScene" not in _base.__all__:
         _base.__all__.append("MovingCameraScene")

--- a/web/python/_manim_family_create.py
+++ b/web/python/_manim_family_create.py
@@ -1,0 +1,413 @@
+"""Canonical retained family Create/Uncreate authoring.
+
+This is a thin Manim-compatible syntax layer over the Rust-owned semantic-family
+animation request builder. Python reports already-bound leaf ObjectIds in its normal
+wrapper traversal; Rust validates those leaves against authoritative SemanticStore order
+and serializes one glyph/resource-free FamilyAnimationRequest into canonical SceneSpec.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import math
+from typing import Any
+
+import noon as _base
+import _manim_animation_options as _options
+import _manim_animate as _animate
+import _manim_compat as _compat
+import _manim_lifecycle as _lifecycle
+import _manim_phase_b as _phase_b
+import _manim_retained_animate as _retained
+import _manim_semantic_handles as _semantic_handles
+import _manim_typst as _typst
+
+
+_INSTALLED = False
+_ORIGINAL_SCENE_PLAY = None
+_ORIGINAL_RETAINED_DOCUMENT = None
+
+
+def _native_text(value: object) -> bool:
+    return isinstance(value, _typst.Text)
+
+
+def _family_candidate(animation: object):
+    if not isinstance(animation, (_animate.Create, _animate.Uncreate)):
+        return None
+    target = animation.target
+    leaves = _compat._leaf_mobjects(target)
+    if not leaves or not any(_native_text(member) for member in leaves):
+        return None
+
+    for member in leaves:
+        if isinstance(member, _typst._RetainedTextMobject) and not _native_text(member):
+            raise NotImplementedError(
+                "canonical family Create/Uncreate currently supports native Text; "
+                "Typst and MathTypst need their retained family identity bound to the same contract"
+            )
+        if not isinstance(member, _base.Mobject):
+            raise TypeError("family Create/Uncreate target contains a non-Mobject leaf")
+
+    if isinstance(target, _compat.Group):
+        family = target
+        synthetic = False
+    else:
+        # A single native Text is still a Manim family of rendered members. Build an
+        # authoring-only one-member semantic family; it is never inserted into scene
+        # membership or serialized as a renderer object.
+        family = _compat.Group(target)
+        synthetic = True
+    family_handle = getattr(family, "_semantic_family_handle", None)
+    if family_handle is None or not hasattr(family_handle, "familyAnimationRequest"):
+        raise RuntimeError("family Create/Uncreate requires the shared Rust authoring family handle")
+    return target, family, leaves, synthetic
+
+
+def _geometry_lifecycle(
+    scene: _compat.Scene,
+    member: _base.Mobject,
+    intent: str,
+    start_time: float,
+    label: str,
+):
+    plan = _lifecycle._resolve_wrapper(scene, member, intent, start_time, label)
+    if plan.bind:
+        _phase_b._bind_raw(scene, member)
+    if member._object is None:
+        raise RuntimeError("family animation geometry leaf did not bind to a scene object")
+    return plan
+
+
+def _text_lifecycle(
+    scene: _compat.Scene,
+    member: _typst.Text,
+    intent: str,
+    start_time: float,
+    label: str,
+):
+    plan = _retained._resolve_retained_lifecycle(scene, member, intent, start_time, label)
+    if plan.bind:
+        _retained._bind_retained(scene, member)
+    if member._retained_object_id is None:
+        raise RuntimeError("family animation Text leaf did not bind to a retained scene object")
+    _retained._ensure_animation_state(scene)
+    scene._retained_animation_state.setdefault(
+        int(member.id), _retained._initial_animation_state(member)
+    )
+    return plan
+
+
+def _show_at_start(
+    scene: _compat.Scene,
+    member: _base.Mobject,
+    plan: object,
+    start_time: float,
+) -> None:
+    if not bool(getattr(plan, "show_at_start", False)):
+        return
+    if _native_text(member):
+        state = scene._retained_animation_state[int(member.id)]
+        state["presence"] = False
+        _retained._append_presence_track(
+            scene,
+            object_id=int(member.id),
+            current=False,
+            target=True,
+            start_time=start_time,
+        )
+        state["presence"] = True
+        return
+    assert member._object is not None
+    scene._add_presence_track(
+        member._object,
+        False,
+        True,
+        start_time,
+        key=f"@family-create:{member._object.id}:{start_time:g}.show",
+    )
+
+
+def _hide_at_end(
+    scene: _compat.Scene,
+    member: _base.Mobject,
+    plan: object,
+    end_time: float,
+) -> None:
+    if not bool(getattr(plan, "hide_at_end", False)):
+        return
+    if _native_text(member):
+        state = scene._retained_animation_state[int(member.id)]
+        _retained._append_presence_track(
+            scene,
+            object_id=int(member.id),
+            current=True,
+            target=False,
+            start_time=end_time,
+        )
+        state["presence"] = False
+        return
+    assert member._object is not None
+    scene._add_presence_track(
+        member._object,
+        True,
+        False,
+        end_time,
+        key=f"@family-uncreate:{member._object.id}:{end_time:g}.hide",
+    )
+
+
+def _bind_family(
+    scene: _compat.Scene,
+    animation: object,
+    target: object,
+    leaves: list[_base.Mobject],
+    *,
+    start_time: float,
+    duration: float,
+) -> None:
+    uncreate = isinstance(animation, _animate.Uncreate)
+    end_time = start_time + duration
+    lifecycle_plans: list[tuple[_base.Mobject, object]] = []
+
+    for member in leaves:
+        if uncreate:
+            # Match Scene.play's implicit-add behavior first, then apply the remover
+            # lifecycle only when this Uncreate instance owns cleanup.
+            if _native_text(member):
+                add_plan = _text_lifecycle(
+                    scene, member, "add", start_time, "animated Uncreate target"
+                )
+            else:
+                add_plan = _geometry_lifecycle(
+                    scene, member, "add", start_time, "animated Uncreate target"
+                )
+            if bool(getattr(add_plan, "show_now", False)):
+                _show_at_start(scene, member, type("Plan", (), {"show_at_start": True})(), start_time)
+            intent = "remove_after_animation" if bool(animation.remover) else "require_present"
+        else:
+            intent = "introduce"
+
+        plan = (
+            _text_lifecycle(scene, member, intent, start_time, "family animation target")
+            if _native_text(member)
+            else _geometry_lifecycle(scene, member, intent, start_time, "family animation target")
+        )
+        lifecycle_plans.append((member, plan))
+        if not uncreate:
+            _show_at_start(scene, member, plan, start_time)
+
+    # Scene membership is represented by the source-level family wrapper, not by the
+    # flattened leaves used for runtime materialization.
+    leaf_ids = {id(member) for member in leaves}
+    scene._compat_top_level = [
+        value for value in scene._compat_top_level if id(value) not in leaf_ids
+    ]
+    scene._register_top_level(target)
+
+    if uncreate and bool(animation.remover):
+        for member, plan in lifecycle_plans:
+            _hide_at_end(scene, member, plan, end_time)
+        scene._compat_top_level = [
+            value for value in scene._compat_top_level if value is not target
+        ]
+
+
+def _append_request(
+    scene: _compat.Scene,
+    animation: object,
+    family: _compat.Group,
+    leaves: list[_base.Mobject],
+    *,
+    start_time: float,
+    duration: float,
+    lag_ratio: float,
+    rate_function: str,
+) -> None:
+    requests = getattr(scene, "_retained_family_animations", None)
+    if requests is None:
+        requests = []
+        scene._retained_family_animations = requests
+    if requests:
+        raise NotImplementedError(
+            "canonical retained execution currently supports one family animation request per scene"
+        )
+
+    reverse_rate = bool(animation.reverse_rate_function) if isinstance(
+        animation, _animate.Uncreate
+    ) else False
+    session = family._semantic_family_handle.familyAnimationRequest(
+        "reveal",
+        float(start_time),
+        float(duration),
+        float(lag_ratio),
+        str(rate_function),
+        reverse_rate,
+        False,
+    )
+    for member in leaves:
+        if _native_text(member):
+            identity = member._semantic_family_member_handle
+            if identity is None:
+                raise RuntimeError("native Text has no shared semantic family identity")
+            session.bindRetainedNativeText(
+                identity,
+                member._retained_handle,
+                float(member.id),
+            )
+            continue
+        handle = _semantic_handles._handle_for(member)
+        if handle is None:
+            raise RuntimeError(
+                "family animation geometry leaf has no current shared semantic handle"
+            )
+        session.bindMobject(handle, float(member.id))
+
+    requests.append(json.loads(str(session.finishJson())))
+
+
+def _family_scene_play(
+    self: _compat.Scene,
+    *animations: Any,
+    duration: float | None = None,
+    run_time: float | None = None,
+    start_time: float | None = None,
+    easing: str | None = None,
+    rate_func: object | None = None,
+    lag_ratio: float | None = None,
+    **kwargs: Any,
+) -> _compat.Scene:
+    candidates = [_family_candidate(animation) for animation in animations]
+    if not any(candidate is not None for candidate in candidates):
+        assert _ORIGINAL_SCENE_PLAY is not None
+        return _ORIGINAL_SCENE_PLAY(
+            self,
+            *animations,
+            duration=duration,
+            run_time=run_time,
+            start_time=start_time,
+            easing=easing,
+            rate_func=rate_func,
+            lag_ratio=lag_ratio,
+            **kwargs,
+        )
+    if len(animations) != 1 or candidates[0] is None:
+        raise NotImplementedError(
+            "canonical family Create/Uncreate must currently be the only animation in Scene.play"
+        )
+    if duration is not None and run_time is not None:
+        raise ValueError("use either duration or run_time, not both")
+    if easing is not None and rate_func is not None:
+        raise ValueError("use either rate_func or the low-level easing alias, not both")
+    if kwargs:
+        unsupported = ", ".join(sorted(kwargs))
+        raise NotImplementedError(f"unsupported Manim Scene.play option(s): {unsupported}")
+
+    animation = animations[0]
+    target, family, leaves, _synthetic = candidates[0]
+    play_run_time = run_time if run_time is not None else duration
+    if play_run_time is not None:
+        play_run_time = float(play_run_time)
+    play_lag_ratio = None if lag_ratio is None else float(lag_ratio)
+    base_start = self._cursor if start_time is None else float(start_time)
+    if not math.isfinite(base_start) or base_start < 0.0:
+        raise ValueError("start_time must be finite and non-negative")
+
+    resolved = _options.resolve(
+        builder_args=_options.builder_args(animation),
+        default_lag_ratio=1.0,
+        play_run_time=play_run_time,
+        play_easing=easing,
+        play_rate_func=rate_func,
+        play_lag_ratio=play_lag_ratio,
+    )
+    if not math.isclose(resolved.path_arc, 0.0, abs_tol=1e-15):
+        raise NotImplementedError("family Create/Uncreate does not support path_arc")
+
+    checkpoint = self._authoring_checkpoint()
+    cursor_before = self._cursor
+    top_level_before = list(self._compat_top_level)
+    retained_objects_before = list(getattr(self, "_retained_text_objects", []))
+    next_object_id_before = getattr(self, "_retained_next_object_id", None)
+    next_order_before = getattr(self, "_retained_next_painter_order", None)
+    retained_tracks_before = copy.deepcopy(getattr(self, "_retained_animation_tracks", []))
+    retained_state_before = copy.deepcopy(getattr(self, "_retained_animation_state", {}))
+    family_requests_before = copy.deepcopy(getattr(self, "_retained_family_animations", []))
+
+    geometry_states: dict[int, tuple[_base.Mobject, object, object]] = {}
+    retained_states: dict[int, tuple[_typst._RetainedTextMobject, object, object, object]] = {}
+    for member in leaves:
+        if _native_text(member):
+            retained_states[id(member)] = (
+                member,
+                member._scene,
+                member._retained_object_id,
+                member._retained_order,
+            )
+        else:
+            _animate._record_wrapper_state(member, geometry_states)
+
+    try:
+        _bind_family(
+            self,
+            animation,
+            target,
+            leaves,
+            start_time=base_start,
+            duration=resolved.run_time,
+        )
+        _append_request(
+            self,
+            animation,
+            family,
+            leaves,
+            start_time=base_start,
+            duration=resolved.run_time,
+            lag_ratio=resolved.lag_ratio,
+            rate_function=resolved.rate_func,
+        )
+        self._cursor = max(cursor_before, base_start + resolved.run_time)
+        return self
+    except Exception:
+        self._restore_authoring_checkpoint(checkpoint)
+        self._cursor = cursor_before
+        self._compat_top_level = top_level_before
+        self._retained_text_objects = retained_objects_before
+        if next_object_id_before is not None:
+            self._retained_next_object_id = next_object_id_before
+        if next_order_before is not None:
+            self._retained_next_painter_order = next_order_before
+        self._retained_animation_tracks = retained_tracks_before
+        self._retained_animation_state = retained_state_before
+        self._retained_family_animations = family_requests_before
+        for member, old_scene, old_object in geometry_states.values():
+            member._scene = old_scene
+            member._object = old_object
+        for member, old_scene, old_object_id, old_order in retained_states.values():
+            member._scene = old_scene
+            member._retained_object_id = old_object_id
+            member._retained_order = old_order
+        raise
+
+
+def _retained_document(self: _compat.Scene) -> dict[str, Any]:
+    assert _ORIGINAL_RETAINED_DOCUMENT is not None
+    document = _ORIGINAL_RETAINED_DOCUMENT(self)
+    requests = getattr(self, "_retained_family_animations", None)
+    if requests:
+        document["family_animations"] = copy.deepcopy(requests)
+    return document
+
+
+def install() -> None:
+    """Install after the ordinary retained and DrawBorderThenFill Scene.play wrappers."""
+
+    global _INSTALLED, _ORIGINAL_SCENE_PLAY, _ORIGINAL_RETAINED_DOCUMENT
+    if _INSTALLED:
+        return
+    _INSTALLED = True
+    _ORIGINAL_SCENE_PLAY = _compat.Scene.play
+    _ORIGINAL_RETAINED_DOCUMENT = _compat.Scene.retained_document
+    _compat.Scene.play = _family_scene_play
+    _compat.Scene.retained_document = _retained_document


### PR DESCRIPTION
## Summary
- expose a Rust-owned WASM authoring session that converts a live semantic family plus final retained ObjectId bindings into one canonical `FamilyAnimationRequest`
- validate reported leaves against authoritative `SemanticStore` order through the existing family-layout session; Python never serializes semantic order or glyph/resource identity
- lower public Python `Create` / `Uncreate` for native `Text`, including mixed `VGroup(Text(...), geometry)`, through `SceneSpec.family_animations`
- carry family animation requests through the existing retained authoring compatibility wire into canonical `SceneSpec`
- preserve ordinary lifecycle/presence tracks for introduction/removal while family member reveal timing stays in the shared retained family runtime
- fail explicitly on Typst/MathTypst family Create and on a second family-animation request because the current canonical engine intentionally supports one request per scene

## Architecture
```text
Python Create/Uncreate syntax
  -> live Group/Text/geometry shared handles
  -> Rust familyAnimationRequest session
       existing authoritative family-layout traversal validates leaf order
       frontend reports leaf -> final ObjectId only
  -> FamilyAnimationRequest
  -> retained authoring normalization
  -> SceneSpec.family_animations
  -> CanonicalRetainedEngineScenePlayer
  -> existing RetainedFamilyExecutionPlayer
```

No glyph IDs, font resources, atlas state, source-derived family ordering, or renderer-specific payload is added to Python or the canonical request.

## Validation
- native Rust regression proves `family_animations` survives retained compatibility normalization into canonical SceneSpec
- auto-discovered web contract test syntax-checks the new Python module, requires bundle registration, and ratchets ownership away from Python family-order/resource serialization
- normal PR Fast Gate is the compile/WASM/browser authority for the exact head

## Current intentional boundary
Canonical retained engine selection currently accepts exactly one family animation request. This PR mirrors that boundary rather than adding a second scheduler or silently flattening multiple requests. `Write`/`Unwrite` remain the next operation-mode consumer after Create/Uncreate is qualified.

Tracks #741 and #705.