### PR TITLE
Gate retained Text playback before merge

### DIFF
--- a/.github/workflows/retained-text-animation.yml
+++ b/.github/workflows/retained-text-animation.yml
@@ -28,6 +28,31 @@ on:
       - "scripts/retained-text-playback-smoke.mjs"
       - "scripts/retained-text-scene-lifecycle-smoke.mjs"
       - ".github/workflows/retained-text-animation.yml"
+  pull_request:
+    paths:
+      - "crates/noon-web/src/authoring_mobject.rs"
+      - "crates/noon-web/src/retained_authoring_player.rs"
+      - "crates/noon-web/src/retained_authoring_scene.rs"
+      - "crates/noon-web/src/retained_authoring_tracks.rs"
+      - "crates/noon-web/src/retained_authoring_wire_scene.rs"
+      - "web/authoring-render-worker.js"
+      - "web/python-worker.source.js"
+      - "web/python-compat-modules.js"
+      - "web/python/_manim_animate.py"
+      - "web/python/_manim_animation_options.py"
+      - "web/python/_manim_retained_animate.py"
+      - "web/python/_manim_retained_state.py"
+      - "web/python/_manim_semantic_handles.py"
+      - "web/python/_manim_typst.py"
+      - "scripts/build-python-worker.mjs"
+      - "scripts/retained-text-animation-smoke.mjs"
+      - "scripts/retained-text-canonical-state-smoke.mjs"
+      - "scripts/retained-text-family-identity-smoke.mjs"
+      - "scripts/retained-text-family-layout-smoke.mjs"
+      - "scripts/retained-text-family-fade-smoke.mjs"
+      - "scripts/retained-text-playback-smoke.mjs"
+      - "scripts/retained-text-scene-lifecycle-smoke.mjs"
+      - ".github/workflows/retained-text-animation.yml"
   workflow_dispatch:
 
 permissions:

--- a/scripts/build-web-demo.sh
+++ b/scripts/build-web-demo.sh
@@ -75,6 +75,7 @@ if [[ "$skip_web_preflight" != "1" ]]; then
   node --test scripts/manim-reference-coverage.test.mjs
   node --test scripts/manim-reference-classification-lock.test.mjs
   node --test scripts/pr-risk-classifier.test.mjs
+  node --test scripts/retained-text-workflow-policy.test.mjs
 
   for test_file in web/*.test.mjs; do
     node --test "$test_file"

--- a/scripts/retained-text-workflow-policy.test.mjs
+++ b/scripts/retained-text-workflow-policy.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const workflowPath = new URL("../.github/workflows/retained-text-animation.yml", import.meta.url);
+const workflow = readFileSync(workflowPath, "utf8");
+
+function triggerBlock(name) {
+  const lines = workflow.split(/\r?\n/);
+  const header = `  ${name}:`;
+  const start = lines.findIndex((line) => line === header);
+  assert.notEqual(start, -1, `retained Text workflow must define ${name}`);
+
+  const block = [];
+  for (let index = start + 1; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (/^  [A-Za-z_][A-Za-z0-9_-]*:/.test(line)) break;
+    block.push(line);
+  }
+  return block;
+}
+
+function pathsForTrigger(name) {
+  const block = triggerBlock(name);
+  const pathsIndex = block.findIndex((line) => line === "    paths:");
+  assert.notEqual(pathsIndex, -1, `${name} must define a retained Text path filter`);
+
+  const paths = [];
+  for (let index = pathsIndex + 1; index < block.length; index += 1) {
+    const match = block[index].match(/^      - ["'](.+)["']$/);
+    if (!match) break;
+    paths.push(match[1]);
+  }
+  return paths;
+}
+
+test("retained Text regressions gate matching pull-request and master paths", () => {
+  const pushPaths = pathsForTrigger("push");
+  const pullRequestPaths = pathsForTrigger("pull_request");
+
+  assert.ok(pushPaths.length > 0, "retained Text workflow must own at least one path");
+  assert.deepEqual(
+    pullRequestPaths,
+    pushPaths,
+    "pull requests and master pushes must exercise the same retained Text ownership boundary",
+  );
+
+  assert.ok(pushPaths.includes("scripts/retained-text-playback-smoke.mjs"));
+  assert.ok(pushPaths.includes("web/python/_manim_animate.py"));
+  assert.ok(pushPaths.includes(".github/workflows/retained-text-animation.yml"));
+});
+
+test("post-merge retained Text validation remains scoped to master", () => {
+  const push = triggerBlock("push").join("\n");
+  assert.match(push, /^    branches:\n      - master(?:\n|$)/m);
+});


### PR DESCRIPTION
## Summary
- run the dedicated retained Text animation workflow on pull requests touching the same owned paths already checked after master pushes
- preserve the post-merge master gate for direct/merge validation
- add a focused policy test requiring PR and master path filters to remain identical, including the retained playback regression and core Python animation owner
- run that policy test in the normal web preflight

## Why
Current master `54809da42fdec8ee3a1ff31c0b3d293b673f5bbb` fails the dedicated `Retained text animation` workflow at `Test retained Text animation playback` (run `33564244424`), while the preceding authoring/state/family checks pass. The merged PR #834 changed `crates/noon-web/src/retained_authoring_wire_scene.rs` and `web/python-compat-modules.js`, both already inside this workflow's path ownership, but the workflow previously ran only on pushes to `master`. The regression therefore could not be caught by this dedicated suite before merge.

This change does not alter retained Text implementation or relax the failing visual assertion. The active ShrinkToCenter/text fixes remain separate; this PR only moves the existing regression gate to the correct pre-merge boundary.

## Validation
Opening this PR intentionally exercises the new pull-request trigger because the workflow file itself is in the owned path list. Web preflight also runs `scripts/retained-text-workflow-policy.test.mjs` to prevent future trigger drift.

## Remaining risk / merge condition
The new retained Text PR check is expected to reproduce the currently known master playback failure until the active implementation fix lands. Keep this PR draft/blocked until that underlying regression is green; once fixed, the same suite becomes the pre-merge guard that would have caught #834.