### PR TITLE
Fix retained Text playback smoke canonical startup

### DIFF
--- a/scripts/retained-text-playback-smoke.mjs
+++ b/scripts/retained-text-playback-smoke.mjs
@@ -155,6 +155,9 @@ try {
     if ((authored.retainedDocument?.objects?.length ?? 0) !== 1) {
       throw new Error("ShrinkToCenter must author exactly one retained Text object");
     }
+    if (!authored.sceneSpec) {
+      throw new Error("ShrinkToCenter retained playback requires canonical SceneSpec output");
+    }
     const retainedObject = authored.retainedDocument.objects[0];
     const tracks = authored.retainedDocument?.tracks ?? [];
     const scales = tracks.filter((track) => track.property === "scale");
@@ -162,9 +165,8 @@ try {
       throw new Error(`ShrinkToCenter must author one scale track, got ${scales.length}`);
     }
     const positions = tracks.filter((track) => track.property === "position");
-    const ready = await execution.startRetained(
-      JSON.stringify(authored.document),
-      JSON.stringify(authored.retainedDocument),
+    const ready = await execution.startRetainedCanonical(
+      JSON.stringify(authored.sceneSpec),
       { loopDurationSeconds: authored.duration, transportMode: "transferable" },
     );
     await execution.pause();


### PR DESCRIPTION
## Summary
- migrate the retained Text `ShrinkToCenter` playback smoke from the retired split `startRetained(...)` API to `startRetainedCanonical(...)`
- require the Python authoring result to expose canonical `sceneSpec` before starting retained execution
- keep the retained compatibility document assertions for source-level Text/track authoring, while execution consumes only canonical `SceneSpec`
- leave every visual shrink, foreground-mass, seek/presentation, and center invariant unchanged

## Root cause
Master `54809da42fdec8ee3a1ff31c0b3d293b673f5bbb` failed `Retained text animation` run `33564244424` at `Test retained Text animation playback` with:

```
TypeError: execution.startRetained is not a function
```

The canonical-only execution migration had already retired the split retained startup API. The smoke therefore failed before it reached any renderer or Text visual assertion; the preceding retained animation/state/family checks were green.

## Architecture
This is a test-harness boundary repair only. The production path remains:

```text
Python authoring -> canonical SceneSpec -> AuthoringExecutionClient.startRetainedCanonical -> retained engine/render worker
```

No compatibility fallback is reintroduced and no visual tolerance is relaxed.

## Validation
- normal PR Fast Gate validates the changed JS syntax/integration surface
- because `scripts/retained-text-playback-smoke.mjs` is already an owned path of the dedicated retained-text workflow, the merged master commit will re-run the full retained Text suite and, crucially, reach the existing end-to-end visual assertions
- #838 independently moves that dedicated suite to the pre-merge boundary so this stale-harness class of failure is caught before future merges