### PR TITLE
Unify scene object binding across retained content

### DIFF
--- a/web/python/_manim_compat.py
+++ b/web/python/_manim_compat.py
@@ -590,12 +590,7 @@ class Scene(_BaseScene):
         leaves = _leaf_mobjects(value)
         if not leaves:
             return False
-        return any(
-            member._scene is self
-            and member._object is not None
-            and self._presence_at(member._object, self._cursor)
-            for member in leaves
-        )
+        return any(member._is_present_in_scene(self, self._cursor) for member in leaves)
 
     @property
     def mobjects(self) -> list[object]:
@@ -611,10 +606,7 @@ class Scene(_BaseScene):
         for index, member in enumerate(leaves):
             newly_bound = member._scene is None
             if newly_bound:
-                raw_object = _ir.Scene.add(
-                    self, member._current_raw(), key=key if index == 0 else None
-                )
-                member._bind(self, raw_object)
+                member._bind_to_scene(self, key=key if index == 0 else None)
             elif member._scene is not self:
                 raise ValueError("Mobject already belongs to another Scene")
 
@@ -693,16 +685,14 @@ class Scene(_BaseScene):
         if isinstance(target, Group):
             for member in _leaf_mobjects(target):
                 if member._scene is None:
-                    raw_object = super().add(member._current_raw())
-                    member._bind(self, raw_object)
+                    member._bind_to_scene(self)
                 elif member._scene is not self:
                     raise ValueError("Mobject already belongs to another Scene")
             self._register_top_level(target)
             return
         if isinstance(target, _BaseMobject):
             if target._scene is None:
-                raw_object = super().add(target._current_raw())
-                target._bind(self, raw_object)
+                target._bind_to_scene(self)
             elif target._scene is not self:
                 raise ValueError("Mobject already belongs to another Scene")
             self._register_top_level(target)

--- a/web/python/_manim_lifecycle.py
+++ b/web/python/_manim_lifecycle.py
@@ -135,8 +135,7 @@ def _resolve_wrapper(
             at_time_zero=math.isclose(time, 0.0, abs_tol=1e-12),
             label=label,
         )
-    assert member._object is not None
-    has_tracks, present, has_future = _presence_state(scene, member._object, time)
+    has_tracks, present, has_future = member._scene_lifecycle_state(scene, time)
     return _resolve(
         intent,
         binding="this_scene",
@@ -165,8 +164,8 @@ def _scene_add(
             _phase_b._bind_raw(self, member, key=key if index == 0 else None)
         assert member._object is not None
         if plan.show_now:
-            self._add_presence_track(
-                member._object,
+            member._record_scene_presence(
+                self,
                 False,
                 True,
                 self._cursor,
@@ -184,8 +183,8 @@ def _scene_remove(self: _compat.Scene, *mobjects: object) -> _compat.Scene:
         plan = _resolve_wrapper(self, member, "remove", self._cursor, "Scene.remove target")
         if plan.hide_now:
             assert member._object is not None
-            self._add_presence_track(
-                member._object,
+            member._record_scene_presence(
+                self,
                 True,
                 False,
                 self._cursor,
@@ -231,8 +230,8 @@ def _bind_for_animation(
             _phase_b._bind_raw(scene, member)
         assert member._object is not None
         if plan.show_now:
-            scene._add_presence_track(
-                member._object,
+            member._record_scene_presence(
+                scene,
                 False,
                 True,
                 start_time,

--- a/web/python/_manim_phase_b.py
+++ b/web/python/_manim_phase_b.py
@@ -283,16 +283,8 @@ def _manim_layout_bounds(raw: _base._ir.Mobject) -> tuple[_base.Vec2, _base.Vec2
 _base._bounds = _manim_layout_bounds
 
 
-def _bind_raw(
-    scene: _compat.Scene,
-    member: _base.Mobject,
-    *,
-    key: str | None = None,
-) -> None:
-    """Bind one public wrapper using the canonical low-level Scene emitter."""
-
-    raw_object = _base._ir.Scene.add(scene, member._current_raw(), key=key)
-    member._bind(scene, raw_object)
+def _bind_raw(scene: _compat.Scene, member: _base.Mobject, *, key: str | None = None) -> None:
+    member._bind_to_scene(scene, key=key)
 
 
 def _scene_add(

--- a/web/python/_manim_retained_animate.py
+++ b/web/python/_manim_retained_animate.py
@@ -15,14 +15,12 @@ import _manim_animate as _animate
 import _manim_animation_options as _options
 import _manim_compat as _compat
 import _manim_lifecycle as _lifecycle
+import _manim_phase_b as _phase_b
 import _manim_typst as _typst
 
 
 _INSTALLED = False
-_ORIGINAL_SCENE_ADD = _compat.Scene.add
-_ORIGINAL_SCENE_REMOVE = _compat.Scene.remove
 _ORIGINAL_SCENE_PLAY = _compat.Scene.play
-_ORIGINAL_SCENE_IS_PRESENT = _compat.Scene._is_present
 _ORIGINAL_RETAINED_DOCUMENT = _compat.Scene.retained_document
 _ORIGINAL_BUILDER_GETATTR = _animate._AlignedAnimationBuilder.__getattr__
 
@@ -37,9 +35,6 @@ def _retained_copy_for_animate_target(
 
 def _ensure_animation_state(scene: _compat.Scene) -> None:
     _typst._ensure_scene_state(scene)
-    if not hasattr(scene, "_retained_animation_tracks"):
-        scene._retained_animation_tracks = []
-        scene._retained_animation_state = {}
 
 
 def _vec2(value: object, label: str) -> dict[str, float]:
@@ -329,41 +324,25 @@ def _normalize_retained_family_top_level(
 
 
 def _bind_retained(
-    scene: _compat.Scene,
-    source: _typst._RetainedTextMobject,
+    scene: _compat.Scene, source: _typst._RetainedTextMobject
 ) -> None:
     if source._scene is None:
-        _typst._add_retained(scene, source, None)
+        _phase_b._bind_raw(scene, source)
     elif source._scene is not scene:
-        raise ValueError("retained text Mobject already belongs to another Scene")
-    else:
-        scene._register_top_level(source)
+        raise ValueError("retained Text already belongs to another Scene")
+    scene._register_top_level(source)
 
 
-def _initial_animation_state(source: _typst._RetainedTextMobject) -> dict[str, Any]:
-    spec = source._spec()
-    transform = _transform(spec)
-    return {
-        "appearance": 1.0,
-        "opacity": _unit_scalar(spec.get("opacity"), "opacity"),
-        "position": _vec2(transform.get("translation"), "translation"),
-        "presence": True,
-        "rotation": _finite_scalar(transform.get("rotation"), "rotation"),
-        "scale": _vec2(transform.get("scale"), "scale"),
-        "runtime_position": _vec2(transform.get("translation"), "translation"),
-        "runtime_scale": _vec2(transform.get("scale"), "scale"),
-    }
+def _initial_animation_state(
+    source: _typst._RetainedTextMobject,
+) -> dict[str, Any]:
+    return source._initial_scene_animation_state()
 
 
 def _retained_presence_tracks(
-    scene: _compat.Scene,
-    object_id: int,
+    scene: _compat.Scene, object_id: int
 ) -> list[dict[str, Any]]:
-    return [
-        track
-        for track in getattr(scene, "_retained_animation_tracks", [])
-        if int(track["object"]) == object_id and track["property"] == "presence"
-    ]
+    return _typst._retained_presence_tracks(scene, object_id)
 
 
 def _resolve_retained_lifecycle(
@@ -373,42 +352,7 @@ def _resolve_retained_lifecycle(
     time: float,
     label: str,
 ) -> _lifecycle.LifecyclePlan:
-    _ensure_animation_state(scene)
-    if source._scene is None:
-        return _lifecycle._resolve(
-            intent,
-            binding="detached",
-            has_presence_timeline=False,
-            present=True,
-            has_future_event=False,
-            at_time_zero=math.isclose(time, 0.0, abs_tol=1e-12),
-            label=label,
-        )
-    if source._scene is not scene:
-        return _lifecycle._resolve(
-            intent,
-            binding="other_scene",
-            has_presence_timeline=False,
-            present=True,
-            has_future_event=False,
-            at_time_zero=math.isclose(time, 0.0, abs_tol=1e-12),
-            label=label,
-        )
-
-    object_id = int(source.id)
-    tracks = _retained_presence_tracks(scene, object_id)
-    state = scene._retained_animation_state.get(object_id)
-    present = True if state is None else bool(state["presence"])
-    has_future = any(float(track["timing"]["start_time"]) > time for track in tracks)
-    return _lifecycle._resolve(
-        intent,
-        binding="this_scene",
-        has_presence_timeline=bool(tracks),
-        present=present,
-        has_future_event=has_future,
-        at_time_zero=math.isclose(time, 0.0, abs_tol=1e-12),
-        label=label,
-    )
+    return _lifecycle._resolve_wrapper(scene, source, intent, time, label)
 
 
 def _append_vec2_track(
@@ -474,29 +418,12 @@ def _append_presence_track(
     target: bool,
     start_time: float,
 ) -> None:
-    existing = _retained_presence_tracks(scene, object_id)
-    previous = existing[-1] if existing else None
-    result = _lifecycle._validate_shared_presence_transition(
-        previous is not None,
-        0.0 if previous is None else float(previous["timing"]["start_time"]),
-        False if previous is None else bool(previous["values"]["bool"]["to"]),
-        float(start_time),
-        bool(current),
-    )
-    if not bool(result.ok):
-        raise ValueError(str(result.message))
-
-    scene._retained_animation_tracks.append(
-        {
-            "object": object_id,
-            "property": "presence",
-            "values": {"bool": {"from": bool(current), "to": bool(target)}},
-            "timing": {
-                "start_time": float(start_time),
-                "duration": 0.0,
-                "easing": "linear",
-            },
-        }
+    _typst._append_retained_presence_track(
+        scene,
+        object_id=object_id,
+        current=current,
+        target=target,
+        start_time=start_time,
     )
 
 
@@ -549,111 +476,6 @@ def _restore_reintroduced_runtime_state(
     state["appearance"] = 1.0
     state["runtime_position"] = copy.deepcopy(current_position)
     state["runtime_scale"] = copy.deepcopy(current_scale)
-
-
-def _unique_retained_mobjects(
-    mobjects: tuple[object, ...],
-) -> list[_typst._RetainedTextMobject]:
-    retained: list[_typst._RetainedTextMobject] = []
-    identities: set[int] = set()
-    for value in mobjects:
-        if not isinstance(value, _typst._RetainedTextMobject) or id(value) in identities:
-            continue
-        identities.add(id(value))
-        retained.append(value)
-    return retained
-
-
-def _retained_scene_add(
-    self: _compat.Scene,
-    *mobjects: object,
-    key: str | None = None,
-):
-    retained = _unique_retained_mobjects(mobjects)
-    if not retained:
-        return _ORIGINAL_SCENE_ADD(self, *mobjects, key=key)
-
-    plans = [
-        (
-            value,
-            _resolve_retained_lifecycle(
-                self,
-                value,
-                "add",
-                self._cursor,
-                "Scene.add target",
-            ),
-        )
-        for value in retained
-    ]
-    result = _ORIGINAL_SCENE_ADD(self, *mobjects, key=key)
-    _ensure_animation_state(self)
-    for value, plan in plans:
-        object_id = int(value.id)
-        state = self._retained_animation_state.setdefault(
-            object_id, _initial_animation_state(value)
-        )
-        if plan.show_now:
-            state["presence"] = False
-            _append_presence_track(
-                self,
-                object_id=object_id,
-                current=False,
-                target=True,
-                start_time=self._cursor,
-            )
-            state["presence"] = True
-        else:
-            state["presence"] = True
-    return result
-
-
-def _retained_scene_remove(self: _compat.Scene, *mobjects: object) -> _compat.Scene:
-    retained = _unique_retained_mobjects(mobjects)
-    if not retained:
-        return _ORIGINAL_SCENE_REMOVE(self, *mobjects)
-
-    plans = [
-        (
-            value,
-            _resolve_retained_lifecycle(
-                self,
-                value,
-                "remove",
-                self._cursor,
-                "Scene.remove target",
-            ),
-        )
-        for value in retained
-    ]
-    _ensure_animation_state(self)
-    for value, plan in plans:
-        if value._scene is not self or value._retained_object_id is None:
-            continue
-        object_id = int(value.id)
-        state = self._retained_animation_state.setdefault(
-            object_id, _initial_animation_state(value)
-        )
-        if plan.hide_now:
-            _append_presence_track(
-                self,
-                object_id=object_id,
-                current=True,
-                target=False,
-                start_time=self._cursor,
-            )
-            state["presence"] = False
-
-    legacy = tuple(
-        value for value in mobjects if not isinstance(value, _typst._RetainedTextMobject)
-    )
-    if legacy:
-        _ORIGINAL_SCENE_REMOVE(self, *legacy)
-    retained_identities = {id(value) for value in retained}
-    self._compat_top_level = [
-        value for value in self._compat_top_level if id(value) not in retained_identities
-    ]
-    return self
 
 
 def _offset_vec2(
@@ -1071,21 +893,6 @@ def _schedule_retained_plan(
             state["opacity"] = target_opacity
 
 
-def _retained_scene_is_present(self: _compat.Scene, value: object) -> bool:
-    if isinstance(value, _compat.Group):
-        leaves = _compat._leaf_mobjects(value)
-        if leaves and all(
-            isinstance(member, _typst._RetainedTextMobject) for member in leaves
-        ):
-            return any(_retained_scene_is_present(self, member) for member in leaves)
-    if not isinstance(value, _typst._RetainedTextMobject):
-        return _ORIGINAL_SCENE_IS_PRESENT(self, value)
-    if value._scene is not self or value._retained_object_id is None:
-        return False
-    state = getattr(self, "_retained_animation_state", {}).get(int(value._retained_object_id))
-    return True if state is None else bool(state["presence"])
-
-
 def _retained_document(self: _compat.Scene) -> dict[str, Any]:
     document = _ORIGINAL_RETAINED_DOCUMENT(self)
     tracks = getattr(self, "_retained_animation_tracks", None)
@@ -1169,9 +976,8 @@ def _retained_scene_play(
     _ensure_animation_state(self)
     cursor_before = self._cursor
     top_level_before = list(self._compat_top_level)
+    authoring_checkpoint = self._authoring_checkpoint()
     retained_objects_before = list(self._retained_text_objects)
-    next_object_id_before = self._retained_next_object_id
-    next_order_before = self._retained_next_painter_order
     tracks_before = copy.deepcopy(self._retained_animation_tracks)
     state_before = copy.deepcopy(self._retained_animation_state)
     retained_sources = [
@@ -1183,6 +989,7 @@ def _retained_scene_play(
         id(source): (
             source,
             source._scene,
+            source._object,
             source._retained_object_id,
             source._retained_order,
         )
@@ -1215,22 +1022,22 @@ def _retained_scene_play(
         self._cursor = max(cursor_before, max_end)
         return self
     except Exception:
+        self._restore_authoring_checkpoint(authoring_checkpoint)
         self._cursor = cursor_before
         self._compat_top_level = top_level_before
         self._retained_text_objects = retained_objects_before
-        self._retained_next_object_id = next_object_id_before
-        self._retained_next_painter_order = next_order_before
         self._retained_animation_tracks = tracks_before
         self._retained_animation_state = state_before
-        for source, old_scene, old_object_id, old_order in wrapper_states.values():
+        for source, old_scene, old_object, old_object_id, old_order in wrapper_states.values():
             source._scene = old_scene
+            source._object = old_object
             source._retained_object_id = old_object_id
             source._retained_order = old_order
         raise
 
 
 def install() -> None:
-    """Install retained animation scheduling after retained Text Scene hooks."""
+    """Install retained animation scheduling without taking over Scene lifecycle."""
 
     global _INSTALLED
     if _INSTALLED:
@@ -1238,8 +1045,5 @@ def install() -> None:
     _INSTALLED = True
     _typst._RetainedTextMobject._copy_for_animate_target = _retained_copy_for_animate_target
     _animate._AlignedAnimationBuilder.__getattr__ = _retained_builder_getattr
-    _compat.Scene.add = _retained_scene_add
-    _compat.Scene.remove = _retained_scene_remove
-    _compat.Scene._is_present = _retained_scene_is_present
     _compat.Scene.play = _retained_scene_play
     _compat.Scene.retained_document = _retained_document

--- a/web/python/_manim_typst.py
+++ b/web/python/_manim_typst.py
@@ -1,9 +1,9 @@
-"""ManimCE retained Text/Typst wrappers over Noon's source-level authoring handles.
+"""ManimCE Text/Typst wrappers over Noon's retained source authoring handles.
 
-These wrappers are intentionally not geometry adapters. They never synthesize an
-``_ir.Mobject`` and ``Scene.add`` intercepts them before legacy geometry lowering.
-Only source-level text authoring state crosses the Python-worker boundary; shaping,
-font bytes, glyph/vector resources, and GPU atlas state remain Rust-owned.
+Text is a normal scene object at the lifecycle/identity boundary and specializes only
+its content binding and retained-resource realization. It never synthesizes fake
+geometry; shaping, font bytes, glyph/vector resources, and GPU atlas state remain
+Rust-owned.
 """
 
 from __future__ import annotations
@@ -28,14 +28,9 @@ except ImportError:  # Shared semantic handles are browser-only.
     _create_family_member_handle = None
 
 
-# Reserve the upper half of JavaScript's exact-integer range for retained text IDs.
-# Legacy geometry IDs start at zero and no practical scene can approach 2^52 objects.
-_RETAINED_OBJECT_ID_BASE = 1 << 52
 _RETAINED_PROTOCOL_VERSION = 2
 _DEFAULT_NATIVE_FONT = "DejaVu Sans Mono"
 _INSTALLED = False
-_ORIGINAL_SCENE_ADD = _compat.Scene.add
-_ORIGINAL_SCENE_IS_PRESENT = _compat.Scene._is_present
 
 
 def _color_dict(color: _base.Color) -> dict[str, float]:
@@ -212,12 +207,89 @@ class _RetainedTextMobject(_base.Mobject):
         del raw
         raise TypeError("retained text objects cannot be lowered through legacy geometry")
 
-    def _bind_retained(self, scene: _compat.Scene, object_id: int, order: int) -> None:
+    def _bind_retained(
+        self, scene: _compat.Scene, obj: object, order: int
+    ) -> None:
         if self._scene is not None and self._scene is not scene:
             raise ValueError("retained text Mobject already belongs to another Scene")
         self._scene = scene
-        self._retained_object_id = int(object_id)
+        self._object = obj
+        self._retained_object_id = int(obj.id)
         self._retained_order = int(order)
+
+    def _bind_to_scene(
+        self, scene: _compat.Scene, *, key: str | None = None
+    ) -> object:
+        if self._scene is scene and self._object is not None:
+            return self._object
+        if self._scene is not None:
+            raise ValueError("retained text Mobject already belongs to another Scene")
+        _ensure_scene_state(scene)
+        obj, order = scene._allocate_object(key)
+        self._bind_retained(scene, obj, order)
+        scene._retained_text_objects.append(self)
+        return obj
+
+    def _initial_scene_animation_state(self) -> dict[str, Any]:
+        spec = self._spec()
+        transform = spec["transform"]
+        translation = transform["translation"]
+        scale = transform["scale"]
+        return {
+            "appearance": 1.0,
+            "opacity": float(spec["opacity"]),
+            "position": {"x": float(translation["x"]), "y": float(translation["y"])},
+            "presence": True,
+            "rotation": float(transform["rotation"]),
+            "scale": {"x": float(scale["x"]), "y": float(scale["y"])},
+            "runtime_position": {
+                "x": float(translation["x"]),
+                "y": float(translation["y"]),
+            },
+            "runtime_scale": {"x": float(scale["x"]), "y": float(scale["y"])},
+        }
+
+    def _scene_lifecycle_state(
+        self, scene: _compat.Scene, time: float
+    ) -> tuple[bool, bool, bool]:
+        if self._scene is not scene or self._object is None:
+            raise ValueError("retained text Mobject must belong to this Scene")
+        _ensure_scene_state(scene)
+        object_id = int(self._object.id)
+        tracks = _retained_presence_tracks(scene, object_id)
+        state = scene._retained_animation_state.get(object_id)
+        present = True if state is None else bool(state["presence"])
+        has_future = any(float(track["timing"]["start_time"]) > time for track in tracks)
+        return bool(tracks), present, has_future
+
+    def _record_scene_presence(
+        self,
+        scene: _compat.Scene,
+        from_: bool,
+        to: bool,
+        time: float,
+        *,
+        key: str | None = None,
+    ) -> None:
+        del key
+        if self._scene is not scene or self._object is None:
+            raise ValueError("retained text Mobject must belong to this Scene")
+        _append_retained_presence_track(
+            scene,
+            object_id=int(self._object.id),
+            current=from_,
+            target=to,
+            start_time=time,
+        )
+        state = scene._retained_animation_state.setdefault(
+            int(self._object.id), self._initial_scene_animation_state()
+        )
+        state["presence"] = bool(to)
+
+    def _is_present_in_scene(self, scene: _compat.Scene, time: float) -> bool:
+        if self._scene is not scene or self._object is None:
+            return False
+        return self._scene_lifecycle_state(scene, time)[1]
 
     def _retained_entry(self) -> dict[str, Any]:
         if self._retained_object_id is None or self._retained_order is None:
@@ -442,57 +514,57 @@ class Text(_RetainedTextMobject):
 def _ensure_scene_state(scene: _compat.Scene) -> None:
     if not hasattr(scene, "_retained_text_objects"):
         scene._retained_text_objects = []
-        scene._retained_next_object_id = _RETAINED_OBJECT_ID_BASE
-        # Existing geometry objects already occupy the leading global painter slots.
-        scene._retained_next_painter_order = len(scene._objects)
+    if not hasattr(scene, "_retained_animation_tracks"):
+        scene._retained_animation_tracks = []
+    if not hasattr(scene, "_retained_animation_state"):
+        scene._retained_animation_state = {}
 
 
-def _add_retained(scene: _compat.Scene, mobject: _RetainedTextMobject, key: str | None) -> None:
-    if key is not None:
-        raise NotImplementedError("explicit Scene.add keys for retained text are not implemented")
+def _retained_presence_tracks(
+    scene: _compat.Scene, object_id: int
+) -> list[dict[str, Any]]:
     _ensure_scene_state(scene)
-    if mobject._scene is scene:
-        scene._register_top_level(mobject)
-        return
-    if mobject._scene is not None:
-        raise ValueError("retained text Mobject already belongs to another Scene")
-    object_id = int(scene._retained_next_object_id)
-    order = int(scene._retained_next_painter_order)
-    scene._retained_next_object_id += 1
-    scene._retained_next_painter_order += 1
-    mobject._bind_retained(scene, object_id, order)
-    scene._retained_text_objects.append(mobject)
-    scene._register_top_level(mobject)
+    return [
+        track
+        for track in scene._retained_animation_tracks
+        if track["object"] == object_id and track["property"] == "presence"
+    ]
 
 
-def _scene_add(self: _compat.Scene, *mobjects: object, key: str | None = None):
-    if not mobjects:
-        return self
-    if key is not None and len(mobjects) != 1:
-        raise ValueError("an explicit key can only be used when adding one Mobject")
-    _ensure_scene_state(self)
+def _append_retained_presence_track(
+    scene: _compat.Scene,
+    *,
+    object_id: int,
+    current: bool,
+    target: bool,
+    start_time: float,
+) -> None:
+    _ensure_scene_state(scene)
+    tracks = _retained_presence_tracks(scene, object_id)
+    previous = tracks[-1] if tracks else None
+    from _manim_lifecycle import _validate_shared_presence_transition
 
-    single_result: object = self
-    for value in mobjects:
-        if isinstance(value, _RetainedTextMobject):
-            _add_retained(self, value, key)
-            single_result = value
-            continue
-
-        before = len(self._objects)
-        result = _ORIGINAL_SCENE_ADD(self, value, key=key)
-        added = len(self._objects) - before
-        if added > 0:
-            self._retained_next_painter_order += added
-        single_result = result
-
-    return single_result if len(mobjects) == 1 else self
-
-
-def _scene_is_present(self: _compat.Scene, value: object) -> bool:
-    if isinstance(value, _RetainedTextMobject):
-        return value._scene is self
-    return _ORIGINAL_SCENE_IS_PRESENT(self, value)
+    result = _validate_shared_presence_transition(
+        previous is not None,
+        0.0 if previous is None else float(previous["timing"]["start_time"]),
+        False if previous is None else bool(previous["values"]["bool"]["to"]),
+        float(start_time),
+        bool(current),
+    )
+    if not bool(result.ok):
+        raise ValueError(str(result.message))
+    scene._retained_animation_tracks.append(
+        {
+            "object": int(object_id),
+            "property": "presence",
+            "values": {"bool": {"from": bool(current), "to": bool(target)}},
+            "timing": {
+                "start_time": float(start_time),
+                "duration": 0.0,
+                "easing": "linear",
+            },
+        }
+    )
 
 
 def _retained_document(self: _compat.Scene) -> dict[str, Any]:
@@ -513,8 +585,6 @@ def install() -> None:
         return
     _INSTALLED = True
 
-    _compat.Scene.add = _scene_add
-    _compat.Scene._is_present = _scene_is_present
     _compat.Scene.retained_document = _retained_document
     _base.Scene = _compat.Scene
 

--- a/web/python/_noon_ir.py
+++ b/web/python/_noon_ir.py
@@ -370,10 +370,29 @@ class Scene:
         self._objects: list[dict[str, Any]] = []
         self._tracks: list[dict[str, Any]] = []
         self._object_keys: dict[int, str] = {}
+        self._object_positions: dict[int, int] = {}
         self._track_keys: dict[int, str] = {}
+        self._next_object_id = 0
+        self._next_painter_order = 0
         self._scheduled_transform_targets: dict[int, dict[str, Any]] = {}
         self._scheduled_transform_ends: dict[int, float] = {}
         self._scheduled_fade_ends: dict[int, float] = {}
+
+    def _allocate_object(self, key: str | None = None) -> tuple[Object, int]:
+        """Allocate one scene-global object identity and painter slot.
+
+        Content backends may store their payloads in different authoring projections,
+        but identity/order are scene concerns and therefore come from this one allocator.
+        """
+        object_id = self._next_object_id
+        painter_order = self._next_painter_order
+        authoring_key = _authoring_key("key", key, f"@object:{object_id}")
+        if authoring_key in self._object_keys.values():
+            raise ValueError(f"duplicate object key: {authoring_key}")
+        self._object_keys[object_id] = authoring_key
+        self._next_object_id += 1
+        self._next_painter_order += 1
+        return Object(object_id, self._owner), painter_order
 
     def add(self, mobject: Mobject, *, key: str | None = None) -> Object:
         if not isinstance(mobject, Mobject):
@@ -583,6 +602,11 @@ class Scene:
         return (
             len(self._objects),
             len(self._tracks),
+            self._next_object_id,
+            self._next_painter_order,
+            dict(self._object_keys),
+            dict(self._object_positions),
+            dict(self._track_keys),
             dict(self._scheduled_transform_targets),
             dict(self._scheduled_transform_ends),
             dict(self._scheduled_fade_ends),
@@ -592,16 +616,22 @@ class Scene:
         (
             object_count,
             track_count,
+            next_object_id,
+            next_painter_order,
+            object_keys,
+            object_positions,
+            track_keys,
             scheduled_transform_targets,
             scheduled_transform_ends,
             scheduled_fade_ends,
         ) = checkpoint
-        for object_id in range(object_count, len(self._objects)):
-            self._object_keys.pop(object_id, None)
-        for track_id in range(track_count, len(self._tracks)):
-            self._track_keys.pop(track_id, None)
         del self._objects[object_count:]
         del self._tracks[track_count:]
+        self._next_object_id = next_object_id
+        self._next_painter_order = next_painter_order
+        self._object_keys = object_keys
+        self._object_positions = object_positions
+        self._track_keys = track_keys
         self._scheduled_transform_targets = scheduled_transform_targets
         self._scheduled_transform_ends = scheduled_transform_ends
         self._scheduled_fade_ends = scheduled_fade_ends
@@ -1152,7 +1182,12 @@ class Scene:
         )
 
     def _snapshot_for_object(self, obj: Object) -> dict[str, Any]:
-        stored = self._objects[obj.id]
+        if not isinstance(obj, Object) or obj._owner is not self._owner:
+            raise ValueError("object must belong to this Scene")
+        position = self._object_positions.get(obj.id)
+        if position is None:
+            raise ValueError(f"object {obj.id} is not geometry-backed")
+        stored = self._objects[position]
         return {
             "geometry": copy.deepcopy(stored["geometry"]),
             "transform": copy.deepcopy(stored["transform"]),
@@ -1248,15 +1283,12 @@ class Scene:
     def _append_snapshot(
         self, snapshot: dict[str, Any], key: str | None
     ) -> Object:
-        object_id = len(self._objects)
-        authoring_key = _authoring_key("key", key, f"@object:{object_id}")
-        if authoring_key in self._object_keys.values():
-            raise ValueError(f"duplicate object key: {authoring_key}")
-        self._object_keys[object_id] = authoring_key
+        obj, _ = self._allocate_object(key)
         stored = copy.deepcopy(snapshot)
-        stored["id"] = object_id
+        stored["id"] = obj.id
+        self._object_positions[obj.id] = len(self._objects)
         self._objects.append(stored)
-        return Object(object_id, self._owner)
+        return obj
 
     def _add_object(
         self,
@@ -1383,6 +1415,7 @@ class Scene:
             "objects": [
                 {"id": object_id, "key": key}
                 for object_id, key in self._object_keys.items()
+                if object_id in self._object_positions
             ],
             "tracks": [
                 {"id": track_id, "key": key}

--- a/web/python/noon.py
+++ b/web/python/noon.py
@@ -332,6 +332,38 @@ class Mobject:
         self._scene = scene
         self._object = obj
 
+    def _bind_to_scene(self, scene: Scene, *, key: str | None = None) -> _ir.Object:
+        obj = _ir.Scene.add(scene, self._current_raw(), key=key)
+        self._bind(scene, obj)
+        return obj
+
+    def _scene_lifecycle_state(
+        self, scene: Scene, time: float
+    ) -> tuple[bool, bool, bool]:
+        if self._scene is not scene or self._object is None:
+            raise ValueError("Mobject must belong to this Scene")
+        tracks = scene._presence_tracks(self._object)
+        has_future = any(float(track["timing"]["start_time"]) > time for track in tracks)
+        return bool(tracks), scene._presence_at(self._object, time), has_future
+
+    def _record_scene_presence(
+        self,
+        scene: Scene,
+        from_: bool,
+        to: bool,
+        time: float,
+        *,
+        key: str | None = None,
+    ) -> None:
+        if self._scene is not scene or self._object is None:
+            raise ValueError("Mobject must belong to this Scene")
+        scene._add_presence_track(self._object, from_, to, time, key=key)
+
+    def _is_present_in_scene(self, scene: Scene, time: float) -> bool:
+        if self._scene is not scene or self._object is None:
+            return False
+        return self._scene_lifecycle_state(scene, time)[1]
+
     def _current_raw(self) -> _ir.Mobject:
         if self._scene is None or self._object is None:
             return self._raw
@@ -762,7 +794,10 @@ class Scene(_ir.Scene):
             raise ValueError(
                 "direct Mobject mutation after animation authoring is ambiguous; use mobject.animate"
             )
-        stored = self._objects[obj.id]
+        position = self._object_positions.get(obj.id)
+        if position is None:
+            raise ValueError(f"object {obj.id} is not geometry-backed")
+        stored = self._objects[position]
         stored["geometry"] = copy.deepcopy(raw.geometry)
         stored["transform"] = copy.deepcopy(raw.transform)
         stored["style"] = copy.deepcopy(raw.style)
@@ -783,8 +818,7 @@ class Scene(_ir.Scene):
         for index, mobject in enumerate(flattened):
             if mobject._scene is self:
                 continue
-            raw_object = super().add(mobject._current_raw(), key=key if index == 0 else None)
-            mobject._bind(self, raw_object)
+            mobject._bind_to_scene(self, key=key if index == 0 else None)
         return flattened[0] if len(flattened) == 1 else self
 
     def circle(self, radius: float, *, key: str | None = None, **kwargs: Any) -> Mobject:

--- a/web/python/test_unified_scene_binding.py
+++ b/web/python/test_unified_scene_binding.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+
+import _noon_ir as _ir
+import _manim_compat as _compat
+import _manim_typst as _typst
+import noon as _base
+
+
+def test_scene_allocator_is_shared_across_content_projections():
+    scene = _ir.Scene()
+    first = scene.add(_ir.Circle(1.0))
+    retained, retained_order = scene._allocate_object()
+    third = scene.add(_ir.Circle(2.0))
+
+    assert (first.id, retained.id, third.id) == (0, 1, 2)
+    assert retained_order == 1
+    assert [obj["id"] for obj in scene.to_document()["objects"]] == [0, 2]
+    assert [entry["id"] for entry in scene.identity_document()["objects"]] == [0, 2]
+
+
+def test_retained_content_modules_do_not_own_scene_lifecycle():
+    root = Path(__file__).parent
+    typst = (root / "_manim_typst.py").read_text()
+    retained_animation = (root / "_manim_retained_animate.py").read_text()
+
+    forbidden = (
+        "_compat.Scene.add =",
+        "_compat.Scene.remove =",
+        "_compat.Scene._is_present =",
+    )
+    for source in (typst, retained_animation):
+        for assignment in forbidden:
+            assert assignment not in source
+
+
+def test_phase_b_binding_is_content_polymorphic():
+    source = (Path(__file__).parent / "_manim_phase_b.py").read_text()
+    assert "member._bind_to_scene(scene, key=key)" in source
+    assert "_base.Scene.add(scene, raw" not in source
+
+
+def test_mixed_geometry_and_text_share_public_scene_identity_and_order():
+    _compat.install()
+    _typst.install()
+
+    scene = _compat.Scene()
+    first = _base.Circle(1.0)
+    text = _typst.Text("AB")
+    third = _base.Circle(2.0)
+
+    scene.add(first)
+    scene.add(text)
+    scene.add(third)
+
+    assert (first.id, text.id, third.id) == (0, 1, 2)
+    retained = scene.retained_document()["objects"]
+    assert len(retained) == 1
+    assert retained[0]["object"] == 1
+    assert retained[0]["order"] == 1
+    assert [obj["id"] for obj in scene.to_document()["objects"]] == [0, 2]
+    assert [entry["id"] for entry in scene.identity_document()["objects"]] == [0, 2]


### PR DESCRIPTION
## Summary
- give the Python Scene one scene-global object-ID and painter-order allocator shared by geometry and retained content
- make object binding and lifecycle state content-polymorphic instead of routing retained Text through a second Scene.add/remove interception path
- remove the retained Text high-ID namespace and derive retained painter order from the same Scene allocation stream as geometry
- keep retained Text resource-backed; this does not synthesize geometry or expose glyph/resource identity to Python
- collapse retained presence scheduling onto the shared lifecycle owner and delete the duplicate retained animation lifecycle hooks
- add a mixed Circle -> Text("AB") -> Circle regression proving scene IDs/order 0,1,2 while transitional geometry/retained serializers continue to project their respective content subsets

## Architecture
```text
Scene.add / shared lifecycle owner
  -> Mobject._bind_to_scene(...)
       geometry -> shared Scene allocator -> geometry projection
       Text     -> shared Scene allocator -> retained resource/object projection

one ObjectId domain
one painter-order domain
one lifecycle owner
content-specific materialization below that boundary
```

This is intentionally a producer/lifecycle cleanup rather than another family-animation special case. The transitional geometry and retained serializers remain separate projections for now, but they no longer own separate identity, order, or Scene lifecycle semantics.

The canonical family Create/Uncreate path merged in #834 remains downstream of final ObjectId binding and does not need to reconstruct ordering in Python.

## Validation
- current-master replay against #834/#840 topology
- `python -m compileall -q web/python`
- `PYTHONPATH=web/python python -m pytest -q web/python/test_*.py`
- `node scripts/build-python-worker.mjs`
- `git diff --check`
- current-master regeneration produced no additional tracked artifact delta

Tracks #367. This also removes a transitional prerequisite before continuing #741 family/materialization work.

## Next boundary
Move the remaining split producer serialization toward direct canonical SceneSpec construction, while retaining the unified scene identity/lifecycle boundary introduced here.