### PR TITLE
Add retained Axes calculus and graph-line helpers

### DIFF
--- a/scripts/manim-axes-smoke.mjs
+++ b/scripts/manim-axes-smoke.mjs
@@ -199,6 +199,18 @@ class RetainedAxesPlot(Scene):
         assert_point_close(horizontal.start, axes.c2p(0.0, 0.75))
         assert_point_close(horizontal.end, graph_point)
 
+        point_lines = axes.get_lines_to_point(
+            graph_point,
+            line_func=Line,
+            color=GREY,
+        )
+        assert isinstance(point_lines, VGroup)
+        assert len(point_lines) == 2
+        assert_point_close(point_lines[0].start, axes.c2p(0.0, 0.75))
+        assert_point_close(point_lines[0].end, graph_point)
+        assert_point_close(point_lines[1].start, axes.c2p(0.75, 0.0))
+        assert_point_close(point_lines[1].end, graph_point)
+
         x_values = [0.0, 1.0, 1.0, 2.0]
         y_values = [0.5, 1.0, -0.5, 0.0]
         line_graph = axes.plot_line_graph(
@@ -264,6 +276,73 @@ class RetainedAxesPlot(Scene):
         assert isinstance(cos_graph, ParametricFunction)
         cos_point = axes.input_to_graph_point(0.25, cos_graph)
         assert_point_close(cos_point, axes.c2p(0.25, math.cos(0.25)))
+
+        calculus_graph = axes.plot(
+            lambda x: x * x,
+            x_range=[-2.0, 2.0, 1.0],
+            use_smoothing=False,
+            color=PURPLE,
+        )
+        custom_dx = 0.25
+        expected_angle = math.atan2((2.0 + custom_dx) ** 2 - 4.0, custom_dx)
+        assert_close(
+            axes.angle_of_tangent(2.0, calculus_graph, dx=custom_dx),
+            expected_angle,
+        )
+        assert_close(axes.slope_of_tangent(2.0, calculus_graph, dx=custom_dx), 4.25)
+
+        derivative_graph = axes.plot_derivative_graph(
+            calculus_graph,
+            x_range=[-1.0, 1.0, 1.0],
+            use_smoothing=False,
+            color=GREEN,
+        )
+        derivative_x = [-1.0, 0.0, 1.0]
+        derivative_y = [derivative_graph.underlying_function(x) for x in derivative_x]
+        assert_line_graph_matches_axes(axes, derivative_graph, derivative_x, derivative_y)
+        expected_derivative = ((0.5 + 1.0e-8) ** 2 - 0.25) / 1.0e-8
+        assert_close(derivative_graph.underlying_function(0.5), expected_derivative)
+
+        antiderivative_graph = axes.plot_antiderivative_graph(
+            calculus_graph,
+            y_intercept=2.0,
+            samples=5,
+            x_range=[-1.0, 1.0, 1.0],
+            use_smoothing=False,
+            color=BLUE,
+        )
+        antiderivative_x = [-1.0, 0.0, 1.0]
+        antiderivative_y = [1.65625, 2.0, 2.34375]
+        for x, expected in zip(antiderivative_x, antiderivative_y):
+            assert_close(antiderivative_graph.underlying_function(x), expected)
+        assert_line_graph_matches_axes(
+            axes, antiderivative_graph, antiderivative_x, antiderivative_y
+        )
+
+        vertical_graph_lines = axes.get_vertical_lines_to_graph(
+            calculus_graph,
+            x_range=[-1.0, 1.0],
+            num_lines=3,
+            line_func=Line,
+            color=TEAL,
+            stroke_width=1.5,
+        )
+        assert isinstance(vertical_graph_lines, VGroup)
+        assert len(vertical_graph_lines) == 3
+        for line, x in zip(vertical_graph_lines, [-1.0, 0.0, 1.0]):
+            assert_point_close(line.start, axes.c2p(x, 0.0))
+            assert_point_close(line.end, axes.c2p(x, x * x))
+
+        try:
+            axes.plot(lambda x: x, use_vectorized=True)
+            raise AssertionError("vectorized scalar plot callbacks must fail explicitly")
+        except NotImplementedError:
+            pass
+        try:
+            axes.plot_antiderivative_graph(calculus_graph, use_vectorized=True)
+            raise AssertionError("vectorized antiderivative callbacks must fail explicitly")
+        except NotImplementedError:
+            pass
 
         parametric_calls = []
 
@@ -512,6 +591,10 @@ class RetainedAxesPlot(Scene):
             axes,
             sin_graph,
             cos_graph,
+            calculus_graph,
+            derivative_graph,
+            antiderivative_graph,
+            vertical_graph_lines,
             parametric,
             direct_parametric,
             function_graph,
@@ -550,7 +633,7 @@ try {
     axesSource,
   );
   assert.equal(result.kind, "scene_document");
-  assert.equal(result.document.objects.length, 65);
+  assert.equal(result.document.objects.length, 71);
   assert.equal(result.document.tracks.length, 0);
 
   const geometryKinds = result.document.objects.map(
@@ -558,13 +641,13 @@ try {
   );
   assert.equal(
     geometryKinds.filter((kind) => kind === "line").length,
-    42,
-    "Axes, NumberPlane, and projection helpers must flatten to ordinary retained line geometry",
+    45,
+    "Axes, NumberPlane, projection, and graph-line helpers must flatten to ordinary retained line geometry",
   );
   assert.equal(
     geometryKinds.filter((kind) => kind === "vector_path").length,
-    9,
-    "Axes/direct scalar and parametric plots, line graphs, and area polygons must remain ordinary retained VectorPath geometry",
+    12,
+    "Axes/direct/calculus plots, line graphs, and area polygons must remain ordinary retained VectorPath geometry",
   );
   assert.equal(
     geometryKinds.filter((kind) => kind === "circle").length,
@@ -578,7 +661,7 @@ try {
   );
   assert.deepEqual(errors, [], `browser errors while testing retained Axes:\n${errors.join("\n")}`);
   console.log(
-    "Retained Axes/NumberPlane smoke passed: transformed coordinates, retained grid families, direct/Axes parametric functions, FunctionGraph, authored/generic i2gp, line graphs, two-phase Riemann rectangles, and bounded area polygons.",
+    "Retained Axes/NumberPlane smoke passed: transformed coordinates, graph queries/line families, calculus graphs, retained grid families, direct/Axes parametric functions, FunctionGraph, line graphs, two-phase Riemann rectangles, and bounded area polygons.",
   );
 } finally {
   await browser?.close();

--- a/web/python/_manim_axes.py
+++ b/web/python/_manim_axes.py
@@ -257,6 +257,44 @@ def _graph_snapshot_json(graph: object, name: str) -> str:
     return str(handle.snapshotJson())
 
 
+def _inclusive_linspace(start: float, end: float, count: object, name: str) -> list[float]:
+    """Small authoring-only equivalent of NumPy linspace for pinned helper semantics."""
+
+    try:
+        resolved = int(count)
+    except (TypeError, ValueError, OverflowError) as error:
+        raise TypeError(f"{name} must be an integer") from error
+    try:
+        if resolved != count:
+            raise TypeError(f"{name} must be an integer")
+    except TypeError:
+        raise TypeError(f"{name} must be an integer") from None
+    if resolved < 0:
+        raise ValueError(f"{name} must be non-negative")
+    if resolved == 0:
+        return []
+    first = float(start)
+    if resolved == 1:
+        return [first]
+    step = (float(end) - first) / float(resolved - 1)
+    return [first + step * index for index in range(resolved)]
+
+
+def _trapezoid_integral(
+    function: Callable[[float], float], end: float, samples: object
+) -> float:
+    x_values = _inclusive_linspace(0.0, float(end), samples, "samples")
+    if len(x_values) < 2:
+        return 0.0
+    y_values = [float(function(x)) for x in x_values]
+    return sum(
+        0.5 * (y0 + y1) * (x1 - x0)
+        for x0, x1, y0, y1 in zip(
+            x_values, x_values[1:], y_values, y_values[1:], strict=True
+        )
+    )
+
+
 class ParametricFunction(_compat.VMobject):
     """Retained ManimCE v0.21 scene-space parametric curve for the 2D renderer."""
 
@@ -679,6 +717,12 @@ class Axes(_compat.VGroup):
     def get_horizontal_line(self, point: object, **kwargs: Any) -> _compat.Line:
         return self.get_line_from_axis_to_point(1, point, **kwargs)
 
+    def get_lines_to_point(self, point: object, **kwargs: Any) -> _compat.VGroup:
+        return _compat.VGroup(
+            self.get_horizontal_line(point, **kwargs),
+            self.get_vertical_line(point, **kwargs),
+        )
+
     def plot_line_graph(
         self,
         x_values: object,
@@ -928,6 +972,74 @@ class Axes(_compat.VGroup):
         area.set_color(_color("color", color))
         return area
 
+    def angle_of_tangent(
+        self,
+        x: float,
+        graph: ParametricFunction,
+        dx: float = 1.0e-8,
+    ) -> float:
+        p0 = self.input_to_graph_coords(float(x), graph)
+        p1 = self.input_to_graph_coords(float(x) + float(dx), graph)
+        return math.atan2(p1[1] - p0[1], p1[0] - p0[0])
+
+    def slope_of_tangent(
+        self, x: float, graph: ParametricFunction, **kwargs: Any
+    ) -> float:
+        return math.tan(self.angle_of_tangent(float(x), graph, **kwargs))
+
+    def plot_derivative_graph(
+        self,
+        graph: ParametricFunction,
+        color: object = _base.GREEN,
+        **kwargs: Any,
+    ) -> ParametricFunction:
+        _authored_graph_function(graph, "plot_derivative_graph")
+
+        def derivative(x: float) -> float:
+            return self.slope_of_tangent(x, graph)
+
+        return self.plot(derivative, color=_color("color", color), **kwargs)
+
+    def plot_antiderivative_graph(
+        self,
+        graph: ParametricFunction,
+        y_intercept: float = 0.0,
+        samples: int = 50,
+        use_vectorized: bool = False,
+        **kwargs: Any,
+    ) -> ParametricFunction:
+        function = _authored_graph_function(graph, "plot_antiderivative_graph")
+        if use_vectorized:
+            raise NotImplementedError(
+                "Axes.plot_antiderivative_graph(use_vectorized=True) requires vectorized callback transport"
+            )
+        intercept = float(y_intercept)
+        _inclusive_linspace(0.0, 0.0, samples, "samples")
+
+        def antiderivative(x: float) -> float:
+            return _trapezoid_integral(function, float(x), samples) + intercept
+
+        return self.plot(
+            antiderivative,
+            use_vectorized=False,
+            **kwargs,
+        )
+
+    def get_vertical_lines_to_graph(
+        self,
+        graph: ParametricFunction,
+        x_range: Sequence[float] | None = None,
+        num_lines: int = 20,
+        **kwargs: Any,
+    ) -> _compat.VGroup:
+        values = self.x_range if x_range is None else [float(value) for value in x_range]
+        if len(values) < 2:
+            raise ValueError("x_range must contain at least two values")
+        samples = _inclusive_linspace(values[0], values[1], num_lines, "num_lines")
+        return _compat.VGroup(
+            *(self.get_vertical_line(self.i2gp(x, graph), **kwargs) for x in samples)
+        )
+
     def plot_parametric_curve(
         self,
         function: Callable[[float], object],
@@ -994,6 +1106,7 @@ class Axes(_compat.VGroup):
         self,
         function: Callable[[float], float],
         x_range: Sequence[float] | None = None,
+        use_vectorized: bool = False,
         use_smoothing: bool = True,
         discontinuities: Sequence[float] | None = None,
         dt: float = 1.0e-8,
@@ -1005,6 +1118,10 @@ class Axes(_compat.VGroup):
             raise NotImplementedError(f"unsupported Axes.plot option(s): {unsupported}")
         if not callable(function):
             raise TypeError("Axes.plot function must be callable")
+        if use_vectorized:
+            raise NotImplementedError(
+                "Axes.plot(use_vectorized=True) requires vectorized callback transport"
+            )
         request = {
             **self._base_request,
             "plot_range": None if x_range is None else [float(value) for value in x_range],
@@ -1039,6 +1156,7 @@ class Axes(_compat.VGroup):
         graph.t_min = float(graph.x_range[0])
         graph.t_max = float(graph.x_range[1])
         graph.axes = self
+        graph.use_vectorized = False
         if color is not None:
             graph.set_color(color)
         return graph

--- a/web/python/_manim_axes.py
+++ b/web/python/_manim_axes.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import math
+import operator
 from typing import Any, Callable, Sequence
 
 import noon as _base
@@ -261,14 +262,9 @@ def _inclusive_linspace(start: float, end: float, count: object, name: str) -> l
     """Small authoring-only equivalent of NumPy linspace for pinned helper semantics."""
 
     try:
-        resolved = int(count)
-    except (TypeError, ValueError, OverflowError) as error:
+        resolved = operator.index(count)
+    except TypeError as error:
         raise TypeError(f"{name} must be an integer") from error
-    try:
-        if resolved != count:
-            raise TypeError(f"{name} must be an integer")
-    except TypeError:
-        raise TypeError(f"{name} must be an integer") from None
     if resolved < 0:
         raise ValueError(f"{name} must be non-negative")
     if resolved == 0:
@@ -288,10 +284,10 @@ def _trapezoid_integral(
         return 0.0
     y_values = [float(function(x)) for x in x_values]
     return sum(
-        0.5 * (y0 + y1) * (x1 - x0)
-        for x0, x1, y0, y1 in zip(
-            x_values, x_values[1:], y_values, y_values[1:], strict=True
-        )
+        0.5
+        * (y_values[index] + y_values[index + 1])
+        * (x_values[index + 1] - x_values[index])
+        for index in range(len(x_values) - 1)
     )
 
 


### PR DESCRIPTION
## Summary
Add the unblocked ManimCE v0.21 CoordinateSystem calculus/query helpers over the existing retained Axes/plot substrate:

- `get_lines_to_point`
- `angle_of_tangent`
- `slope_of_tangent`
- `plot_derivative_graph`
- `plot_antiderivative_graph`
- `get_vertical_lines_to_graph`
- explicit `Axes.plot(..., use_vectorized=False)` keyword parity; `True` remains an explicit unsupported callback-transport boundary

## Architecture
These stay authoring-level compositions. Tangent queries use authored logical graph coordinates, derivative/antiderivative functions feed back through the existing retained `Axes.plot`, and line families compose `i2gp` with ordinary retained line construction. No new Rust planner, geometry kind, renderer path, or playback callback is introduced.

The antiderivative uses the pinned v0.21 evenly spaced sampling + trapezoidal integration convention without importing a second numerical stack into the facade. The helper is authoring-only; its result is compiled to immutable retained `VectorPath` geometry.

`get_secant_slope_group` remains outside this slice because its optional exact labels depend on #83; no placeholder label geometry is introduced.

## Acceptance
The existing real Pyodide/WASM Axes smoke covers transformed-coordinate tangent queries, custom `dx`, derivative path samples, positive/negative antiderivative integration with custom intercept/sample count, explicit vectorized failures, `get_lines_to_point`, inclusive transformed vertical graph-line families, ordinary retained Line/VectorPath output, and zero tracks.

## Exact-head qualification
- exact head: `40a15eb8e9e2b4ad59fddac7dbb1153fc37e5882`
- PR Fast Gate: `33566838215` (#375)
- result: **green** across rustfmt + Clippy, workspace Rust unit tests, web static/unit checks, one-time WASM build, deterministic playback, Manim authoring, expanded retained Axes calculus/graph-line acceptance, NumberLine, ComplexPlane, PolarPlane, lazy namespace dependencies, literal PlotExample, and primary WebGPU rendering

Independent base: exact-green #828 (`work/253-polar-plane`). Tracks #843 / #85.