### PR TITLE
Make canonical SceneSpec mandatory for authored scenes

### DIFF
--- a/compat/wire/v1/authoring-result-empty-scene.json
+++ b/compat/wire/v1/authoring-result-empty-scene.json
@@ -1,1 +1,1 @@
-{"kind":"scene_document","document":{"version":1,"objects":[],"tracks":[]},"duration":0.0,"identities":{"objects":[],"tracks":[]},"callbacks":null}
+{"kind":"scene_document","document":{"version":1,"objects":[],"tracks":[]},"scene_spec":{"version":1,"objects":[],"tracks":[]},"duration":0.0,"identities":{"objects":[],"tracks":[]},"callbacks":null}

--- a/web/authoring-client.js
+++ b/web/authoring-client.js
@@ -225,18 +225,19 @@ export function parseAuthoringResult(resultJson) {
     const document = validateSceneDocument(result.document);
     const retainedDocument = validateRetainedAuthoringDocument(result.retained_document);
     const sceneSpec = validateSceneSpec(result.scene_spec);
+    if (sceneSpec === null) {
+      throw new Error("Python Scene result must include canonical SceneSpec");
+    }
     const parsed = {
       kind: result.kind,
       document,
+      sceneSpec,
       duration: validateSceneDuration(result.duration),
       identities: validateSceneIdentities(result.identities, document),
       callbacks: validateCallbackSession(result.callbacks, document),
     };
     if (retainedDocument !== null) {
       parsed.retainedDocument = retainedDocument;
-    }
-    if (sceneSpec !== null) {
-      parsed.sceneSpec = sceneSpec;
     }
     return parsed;
   }

--- a/web/authoring-client.test.mjs
+++ b/web/authoring-client.test.mjs
@@ -114,6 +114,14 @@ test("correlates a Python request with Scene callback, retained, and duration me
   const identities = { objects: [{ id: 0, key: "@object:0" }], tracks: [] };
   const callbacks = { session_id: 3, slots: [{ id: 0, objects: [0] }] };
   const retained = retainedDocument();
+  const sceneSpec = {
+    version: 1,
+    objects: [
+      { id: 0, content: { kind: "geometry" } },
+      { id: 2 ** 52, content: { kind: "text" } },
+    ],
+    tracks: [],
+  };
   worker.emit(
     "message",
     workerMessage("result", {
@@ -122,6 +130,7 @@ test("correlates a Python request with Scene callback, retained, and duration me
         kind: "scene_document",
         document: scene,
         retained_document: retained,
+        scene_spec: sceneSpec,
         duration: 2.75,
         identities,
         callbacks,
@@ -132,6 +141,7 @@ test("correlates a Python request with Scene callback, retained, and duration me
   assert.deepEqual(await resultPromise, {
     kind: "scene_document",
     document: scene,
+    sceneSpec,
     retainedDocument: retained,
     duration: 2.75,
     identities,
@@ -139,18 +149,21 @@ test("correlates a Python request with Scene callback, retained, and duration me
   });
 });
 
-test("older scene results without a retained sidecar remain compatible", () => {
+test("scene results without canonical SceneSpec are rejected at the current protocol boundary", () => {
   const scene = { version: 1, objects: [], tracks: [] };
-  const parsed = parseAuthoringResult(
-    JSON.stringify({
-      kind: "scene_document",
-      document: scene,
-      duration: 0,
-      identities: { objects: [], tracks: [] },
-      callbacks: null,
-    }),
+  assert.throws(
+    () =>
+      parseAuthoringResult(
+        JSON.stringify({
+          kind: "scene_document",
+          document: scene,
+          duration: 0,
+          identities: { objects: [], tracks: [] },
+          callbacks: null,
+        }),
+      ),
+    /must include canonical SceneSpec/,
   );
-  assert.equal("retainedDocument" in parsed, false);
 });
 
 test("validates retained native/Typst authoring documents and JS-safe identities", () => {
@@ -200,6 +213,7 @@ test("Scene duration accepts zero and rejects missing, negative, or non-finite v
   const sceneResult = {
     kind: "scene_document",
     document: { version: 1, objects: [], tracks: [] },
+    scene_spec: { version: 1, objects: [], tracks: [] },
     identities: { objects: [], tracks: [] },
     callbacks: null,
   };

--- a/web/authoring-out-of-order-races.test.mjs
+++ b/web/authoring-out-of-order-races.test.mjs
@@ -47,6 +47,11 @@ function sceneResultJson(objectId) {
   return JSON.stringify({
     kind: "scene_document",
     document: { version: 1, objects: [{ id: objectId }], tracks: [] },
+    scene_spec: {
+      version: 1,
+      objects: [{ id: objectId, content: { kind: "geometry" } }],
+      tracks: [],
+    },
     duration: 0,
     identities: {
       objects: [{ id: objectId, key: `@object:${objectId}` }],

--- a/web/authoring-scene-spec-result.test.mjs
+++ b/web/authoring-scene-spec-result.test.mjs
@@ -68,8 +68,9 @@ test("retained scene results expose canonical SceneSpec beside the compatibility
   assert.deepEqual(parsed.sceneSpec.objects.map(({ id }) => id), [0, 2 ** 52]);
 });
 
-test("geometry-only scene results remain unchanged while the SceneSpec migration is retained-only", () => {
+test("geometry-only scene results carry canonical SceneSpec beside the empty compatibility sidecar", () => {
   const document = { version: 1, objects: [], tracks: [] };
+  const sceneSpec = { version: 1, objects: [], tracks: [] };
   const parsed = parseAuthoringResult(
     JSON.stringify({
       kind: "scene_document",
@@ -79,13 +80,14 @@ test("geometry-only scene results remain unchanged while the SceneSpec migration
         protocol_version: 2,
         objects: [],
       },
+      scene_spec: sceneSpec,
       duration: 0,
       identities: { objects: [], tracks: [] },
       callbacks: null,
     }),
   );
 
-  assert.equal("sceneSpec" in parsed, false);
+  assert.deepEqual(parsed.sceneSpec, sceneSpec);
   assert.equal(parsed.retainedDocument.objects.length, 0);
 });
 
@@ -112,4 +114,5 @@ test("Python worker canonicalizes retained output through the Rust WASM bridge",
     source,
     /canonicalRetainedSceneSpecJson\(JSON\.stringify\(result\.document\), retainedDocumentJson\)/,
   );
+  assert.doesNotMatch(source, /retained_document\.objects\.length/);
 });

--- a/web/python-worker.source.js
+++ b/web/python-worker.source.js
@@ -384,11 +384,9 @@ json.dumps(
     if (result.retained_document !== null) {
       const retainedDocumentJson = JSON.stringify(result.retained_document);
       validateRetainedAuthoringDocumentJson(retainedDocumentJson);
-      if (result.retained_document.objects.length > 0) {
-        result.scene_spec = JSON.parse(
-          canonicalRetainedSceneSpecJson(JSON.stringify(result.document), retainedDocumentJson),
-        );
-      }
+      result.scene_spec = JSON.parse(
+        canonicalRetainedSceneSpecJson(JSON.stringify(result.document), retainedDocumentJson),
+      );
     }
     return JSON.stringify(result);
   } finally {

--- a/web/wire-contracts.test.mjs
+++ b/web/wire-contracts.test.mjs
@@ -21,7 +21,11 @@ test("canonical scene, patch, and authoring result fixtures are accepted", async
   const patch = await fixture("v1/patch-empty.json");
   assert.equal(validatePatchBatch(patch), patch);
   const result = await fixture("v1/authoring-result-empty-scene.json");
-  assert.deepEqual(parseAuthoringResult(JSON.stringify(result)), result);
+  const { scene_spec: sceneSpec, ...compatibilityResult } = result;
+  assert.deepEqual(parseAuthoringResult(JSON.stringify(result)), {
+    ...compatibilityResult,
+    sceneSpec,
+  });
 });
 
 test("future IR fixtures fail with explicit version diagnostics in JS", async () => {


### PR DESCRIPTION
## Summary
- canonicalize every Python-authored `Scene` through the existing Rust `SceneSpec` adapter, including geometry-only scenes
- make canonical `SceneSpec` a required result at the current authoring protocol boundary instead of an optional retained-text-only attachment
- keep legacy `SceneDocument` and retained sidecar payloads as compatibility projections during #367 migration
- preserve the existing Rust-owned geometry/text merge, text-source normalization, retained-track materialization, and family-animation lowering; no new frontend IR is introduced

## Why this slice
After #841, geometry and retained Text already share one object-ID, painter-order, and lifecycle domain, but the worker still emitted canonical `SceneSpec` only when retained text objects were present. That left canonical transport conditional on content kind. This PR removes that content-kind branch before producer ownership moves fully to `SceneSpec`.

## Validation
- focused authoring client + SceneSpec result tests
- generated worker rebuild
- `git diff --check`

Tracks #367.

## Next boundary
Move Python producer ownership from the split legacy document + retained compatibility sidecar into direct canonical `SceneSpec` object construction, while deriving the old payloads only as compatibility projections until their consumers are retired.