### PR TITLE
Document interactive runtime, live authoring, and renderer locality

### DIFF
--- a/docs/interactive-runtime-and-live-authoring.md
+++ b/docs/interactive-runtime-and-live-authoring.md
@@ -1,0 +1,415 @@
+# Interactive runtime and live authoring
+
+## Purpose
+
+Noon should combine three different upstream strengths rather than copy one Manim implementation wholesale:
+
+- use **ManimCE v0.21** as the semantic/API and visual/timing compatibility reference for supported Manim behavior;
+- use **current 3b1b/manim (ManimGL)** as an interaction and live-authoring capability reference;
+- preserve Noon's own retained, language-neutral, worker-isolated execution architecture and stronger `O(active + dirty + visible)` scalability goals.
+
+The key design conclusion is:
+
+> Borrow ManimGL's interaction affordances and live-authoring immediacy, but do not borrow its mutable-Python-object ownership model.
+
+This document separates interactive runtime behavior from live authoring, defines the additional session-state layer Noon needs, and records renderer lessons from current ManimGL.
+
+Related trackers: #56, #64, #68, #69, #70, #569, #835, #846, #847.
+
+## Upstream architecture comparison
+
+### Current 3b1b/manim
+
+Current ManimGL is best understood as a **live mutable Python graphics runtime with a retained/versioned GPU backend**.
+
+Its `Scene` owns live Python `Mobject` instances. Interaction, animations and updaters mutate those same objects directly. The interactive loop repeatedly advances scene time, updates all scene mobjects, and captures the current scene. Mouse/camera state is represented by live mobjects as well.
+
+That ownership model makes interactive code extremely direct:
+
+```text
+window event
+    |
+    v
+Python Scene handler / updater
+    |
+    v
+mutate live Mobject graph
+    |
+    v
+renderer resolves current graph
+```
+
+There is no semantic/runtime/renderer ownership boundary to cross. That is a major reason features such as camera dragging, object grabbing, live updaters and embedded interactive authoring can feel immediate.
+
+The current ManimGL renderer is nevertheless substantially retained:
+
+- each drawable mobject maps to a persistent renderer-side `Drawing`;
+- CPU structured arrays carry versions so unchanged data is not recopied unnecessarily;
+- compatible consecutive drawings are merged into runs;
+- shared GPU buffers are reused;
+- once the draw topology remains stable for a small number of frames, the renderer can capture it in a WebGPU render bundle;
+- the bundle keeps draw order/pipeline/buffer ranges while reading current buffer contents when replayed, so transform/color/camera data can keep changing without rebuilding command topology.
+
+This is a useful separation of **stable draw topology** from **mutable data**, even though the Python scene graph is still resolved each frame.
+
+### Manim Community Edition
+
+ManimCE preserves the same broad Python-mutable object heritage but is designed primarily as a general animation/video authoring framework.
+
+Its scene update path still calls mobject updaters from the Python scene graph. Its OpenGL renderer updates a frame by walking the current scene mobjects and rendering each eligible object. CE also has interactive OpenGL support, queued interaction actions, file-triggered reruns and callbacks, but interactivity is less central to the architecture than in 3b1b/manim.
+
+For Noon, CE should remain the compatibility oracle because its public behavior/version can be pinned and differentially tested. It should not be treated as the target realtime execution architecture.
+
+### Noon
+
+Noon intentionally separates:
+
+```text
+language authoring
+      |
+      v
+canonical semantic scene
+      |
+      v
+lowered retained execution
+  /          |          \
+ timeline  reactive VM  host slots
+      \       |         /
+          atomic deltas
+              |
+              v
+       retained renderer
+```
+
+This is more complex than mutating a live Python graph, but it gives Noon important properties that Manim's direct-mutation model cannot guarantee cheaply:
+
+- deterministic direct seek for native/seekable behavior;
+- language-neutral semantics shared by Python/Rust/JavaScript;
+- worker isolation and a renderer that does not synchronously depend on arbitrary Python;
+- local runtime mutation and dirty propagation;
+- retained spatial queries;
+- `O(active + dirty + visible)` as an explicit scaling target;
+- immutable shared resource ownership rather than repeated geometry/text transport.
+
+Noon should not weaken these properties to imitate ManimGL's implementation.
+
+## Two distinct interaction requirements
+
+### Interactive runtime
+
+A finished scene reacts to live input while it is running.
+
+Examples:
+
+- pointer-following objects;
+- drag constraints;
+- hover/click behavior;
+- keyboard-controlled state;
+- sliders and controls;
+- camera pan/zoom;
+- interactive graph/geometry manipulation.
+
+This is primarily the domain of #69 plus the reactive VM, spatial index and host-callback fallback.
+
+### Live authoring
+
+The author edits and explores a scene while preserving useful current state.
+
+Examples:
+
+- pause at a frame and inspect objects;
+- select an object by clicking it;
+- move or resize it directly;
+- move the camera without advancing animation time;
+- modify source and rerun a block/scene;
+- preserve compatible playhead/control/selection state after re-execution;
+- undo a direct manipulation or semantic edit;
+- inspect coordinates, bounds and identity;
+- execute additional authoring commands against the current semantic scene.
+
+This is not merely another native input source. It requires explicit **session state** above the semantic scene. #846 owns that contract.
+
+## Interactive session state
+
+Noon should introduce a conceptual `InteractiveSession` layer. Exact type/module names may differ.
+
+It owns ephemeral interaction/editor state that should not become persistent semantic scene content:
+
+```text
+InteractiveSession
+  selection
+  hover target
+  pointer capture
+  active tool / manipulation mode
+  drag origin / reference transform
+  camera-navigation gesture state
+  temporary property drivers
+  undo/transaction grouping
+  inspector state
+  editor overlay projection
+```
+
+The semantic scene remains authoritative for authored content. Selection rectangles, grab handles, crosshairs and inspector labels should normally be editor overlays, not semantic mobjects inserted into the user's scene.
+
+This differs deliberately from current ManimGL `InteractiveScene`, where selection/highlight/helper graphics are ordinary mobjects and are updated through the same mutable scene.
+
+## Input, event and frame ordering
+
+#69 already distinguishes sampled state from discrete events. The full interaction scheduler should make the ordering explicit.
+
+Recommended shape:
+
+```text
+DOM/native collection
+      |
+normalize coordinates and units
+      |
+      +-- sampled state -> coalesce to latest applicable sample
+      |
+      `-- discrete events -> preserve ordered occurrences
+      |
+      v
+pointer capture / hit-test / session state machine
+      |
+      v
+native reactive dependency closure
+      |
+      v
+property-driver arbitration
+      |
+      v
+host callback phase when required
+      |
+      v
+atomic semantic/runtime commit
+      |
+      v
+bounds/culling update
+      |
+      v
+presentation
+```
+
+Sampled pointer movement may be coalesced when intermediate positions have no semantic significance. Pointer/key press and release, commits and other discrete events may not be silently lost.
+
+## Time model
+
+Interactive authoring needs more than one notion of time.
+
+At minimum distinguish:
+
+- **timeline time**: position in the authored animation;
+- **presentation/wall time**: realtime pacing and deadlines;
+- **input event ordering/time**: ordering of external interaction relative to a committed frame.
+
+A paused timeline must still allow:
+
+- camera movement;
+- pointer/hover/selection changes;
+- direct manipulation;
+- inspector/overlay changes;
+- source edits and semantic transactions;
+- reactive control changes whose semantics are defined to operate while paused.
+
+These actions must not implicitly advance the animation timeline merely because frames are presented.
+
+## Direct manipulation and property ownership
+
+A direct manipulation can conflict with an animation, reactive binding or host updater already driving the same property.
+
+A mutable-Python system often resolves this implicitly through execution order. Noon requires an explicit contract.
+
+Conceptually, manipulation should acquire a temporary interaction driver/lease over the affected property set. The public contract must define what happens on release. Useful policies include:
+
+- cancel and restore the pre-drag driven value;
+- commit a new semantic/base value and let the existing driver continue from its defined model;
+- replace/remove the previous driver;
+- rebase the remaining animation where the animation type explicitly supports that operation.
+
+Do not choose one global implicit "last writer wins" rule for all of these cases.
+
+The generic multi-driver phase semantics remain owned by #56. #846 defines the user-facing acquisition/release semantics for direct manipulation on top of that foundation.
+
+## Hit testing and selection
+
+Interaction should consume the existing retained spatial index rather than scan semantic or renderer objects.
+
+Recommended flow:
+
+```text
+pointer position
+      |
+      v
+ExecutionSpatialIndex broad phase
+      |
+ordered candidates
+      |
+optional precise geometry hit test
+      |
+      v
+session hover / selection target
+```
+
+Selection order should preserve painter order. The interaction layer must not introduce another bounds tree.
+
+## Live source re-execution
+
+ManimGL achieves live authoring cheaply because an embedded interpreter directly sees and mutates the live Python scene.
+
+Noon should provide similar ergonomics through **semantic reconciliation**, not shared mutable Python authority:
+
+```text
+edited source / authoring command
+       |
+       v
+new draft semantic generation
+       |
+       v
+stable-source-identity reconciliation (#64)
+       |
+       v
+local semantic mutation transaction
+       |
+       v
+localized execution relowering / state migration
+```
+
+Compatible state should be migrated deliberately, including as applicable:
+
+- timeline playhead;
+- user controls/signals;
+- session selection/hover when identities remain valid;
+- editor camera/navigation state;
+- compatible execution slots;
+- host state according to its declared replay/migration class.
+
+Stale or ambiguous selection/interaction identity should be cleared or surfaced explicitly rather than rebound heuristically to the wrong object.
+
+## Demand-driven paused presentation
+
+When the timeline is paused and there is no scene, input, session-overlay, camera or renderer dirtiness, Noon should not keep doing meaningful frame work merely because a browser `requestAnimationFrame` callback fires.
+
+Target behavior:
+
+```text
+paused + no dirty work
+    -> engine sleeps / no evaluation
+    -> no GPU presentation required
+
+event / edit / camera change / timeline resume
+    -> wake affected execution path
+    -> present resulting frame
+```
+
+This strengthens the existing `static frame CPU work ~ O(0)` invariant into a product-level interaction requirement.
+
+## Renderer lesson from current ManimGL
+
+The most transferable renderer idea is **stable draw-topology reuse**.
+
+Current ManimGL can bundle a stable draw sequence while still updating the contents of buffers read by that bundle. Noon should benchmark the analogous design instead of assuming it is either necessary or useless. #847 owns the measurement/decision gate.
+
+Potential Noon model:
+
+```text
+resident renderer state
+      |
+      v
+visible ordered draw plan
+      |
+      +-- topology/pipeline/binding/layout identity -> reusable command plan
+      |
+      `-- transforms/style/reveal/camera -> mutable buffers only
+```
+
+A reusable WebGPU command/bundle plan should not be invalidated by ordinary value changes when all referenced buffers/bindings/ranges remain valid. It should be invalidated by changes such as:
+
+- visible/painter topology changes;
+- pipeline/material binding changes;
+- buffer relocation/layout generation changes;
+- renderer/device generation changes;
+- draw-count/range changes baked into the command sequence.
+
+WebGL2 remains on the normal draw path.
+
+Because Noon already has analytic batching, mega meshes and retained draw preparation, this is a **measurement question first**, not a mandatory redesign.
+
+## Preview versus output quality
+
+Interactive presentation resolution is a renderer/presentation policy, not semantic state.
+
+The editor may render at current canvas size/DPR/MSAA policy while offline/high-quality export renders at the requested output resolution. Changing preview resolution must not alter semantic geometry, timeline state or object identity.
+
+Future video export should similarly pipeline GPU readback/encoding where possible rather than impose a synchronous readback stall on every frame.
+
+## Product/reference policy
+
+Use the upstream projects for different purposes:
+
+```text
+ManimCE v0.21
+    -> semantic/API/visual/timing compatibility oracle
+
+current 3b1b/manim
+    -> interaction and live-authoring capability reference
+    -> renderer optimization ideas to benchmark
+
+Noon
+    -> authoritative implementation architecture
+    -> deterministic retained execution
+    -> language neutrality
+    -> browser-native interaction
+    -> worker isolation
+    -> O(active + dirty + visible)
+```
+
+Noon does **not** target source-level compatibility with current ManimGL's experimental interactive APIs unless an API is separately adopted as a Noon feature.
+
+## Required capability gates
+
+### Native runtime interaction
+
+- pointer/keyboard/wheel/control behavior can update a scene with zero Python frame callbacks when expressible through native signals/reactivity;
+- high-frequency sampled input reevaluates only its dependency closure;
+- discrete input ordering is deterministic and tested;
+- hit testing uses the retained spatial index;
+- arbitrary host interaction remains available through the host callback protocol without blocking renderer deadlines.
+
+### Direct manipulation/session state
+
+- hover/selection/pointer capture are session state, not user-scene mobjects;
+- drag begins from an explicit hit/capture decision and ends transactionally;
+- property conflicts with timeline/reactive/host drivers use explicit arbitration semantics;
+- undo groups one manipulation gesture as one user action;
+- paused direct manipulation does not advance timeline time;
+- editor overlays do not pollute semantic painter/family identity.
+
+### Live re-execution
+
+- local source changes reconcile by stable identity rather than whole-scene replacement on the normal path;
+- compatible playhead/control/session state survives re-execution;
+- stale/ambiguous identities fail predictably;
+- unchanged semantic/execution/resource identities remain resident;
+- static deterministic playback still requires no Python participation after authoring.
+
+### Demand-driven rendering
+
+- paused, clean scenes perform no meaningful runtime/render work;
+- camera/input/editor-overlay changes wake only the necessary path;
+- renderer presentation can occur without advancing timeline time.
+
+### Draw-plan reuse benchmark
+
+- benchmark stable large scenes under transform/style/camera-only changes;
+- measure CPU command encoding/submission separately from runtime/preparation/upload cost;
+- compare ordinary WebGPU encoding against stable draw-plan/render-bundle reuse;
+- verify exact painter/render equivalence and correct invalidation;
+- adopt the optimization only when the measurements justify its complexity.
+
+## Architectural invariant
+
+A useful review question for interaction work is:
+
+> Is this state part of the authored scene, part of executable scene behavior, or only part of the current editor/interaction session?
+
+Those are three distinct ownership classes and should not be collapsed merely because a mutable Python implementation can represent all three as `Mobject`s.

--- a/docs/renderer-locality-and-caching.md
+++ b/docs/renderer-locality-and-caching.md
@@ -1,0 +1,321 @@
+# Renderer locality and caching
+
+## Purpose
+
+Noon should borrow the **work-avoidance principles** used by high-performance retained/cached drawing systems without copying Canvas-specific implementation choices.
+
+The architectural goal is simple:
+
+> Keep expensive renderable representations resident, and make ordinary animation update only the smallest mutable presentation state that actually changed.
+
+For Noon, that means preserving vector/glyph/resource fidelity while driving frame cost toward visible and dirty work rather than total scene complexity.
+
+This document records the current architecture, the remaining gaps, and the design rules that should guide renderer work.
+
+Related trackers: #68, #362, #569, #737, #741, #835, #847.
+
+## Current foundation
+
+Noon already implements most of the retained-resource side of this model.
+
+### Geometry
+
+`FramePreparer` retains packed analytic/path state across frames and already supports:
+
+- packed primitive instance records;
+- dirty instance ranges;
+- bounded tessellated-path caching;
+- incremental unique-path replacement;
+- retained path vertex/index arenas with free-range reuse;
+- painter-order batching and packed mega-mesh submission;
+- explicit full rebuild/compaction barriers rather than routine repacking.
+
+A transform/style/reveal change therefore does not inherently require regenerating unrelated path geometry.
+
+### Text
+
+The retained text renderer already separates steady-state glyph rendering from path-level behavior:
+
+- ordinary glyphs use a GPU glyph atlas;
+- glyph outlines are extracted lazily;
+- outline and stroked-outline paths are cached;
+- outline residency is bounded and instrumented;
+- text resources/font resources remain immutable renderer-resolved inputs;
+- glyph/vector items share the same semantic `ObjectId` painter stream.
+
+This is preferable to generic per-text bitmap caching because it preserves resolution-independent geometry and reuses glyph-level resources.
+
+### Runtime locality
+
+Runtime execution already carries local change information and stable execution identity. `ExecutionSpatialIndex` provides incrementally maintained conservative bounds, painter-ordered viewport queries, and point-query candidates.
+
+The retained-renderer target is therefore not to invent more caches or another spatial tree. It is to **consume the locality that already exists all the way through preparation, upload, and draw submission**.
+
+## Target complexity
+
+After warmup, the intended cost model is:
+
+```text
+static frame CPU work           ~ O(0)
+runtime/timeline work           ~ O(active or crossed work)
+render preparation              ~ O(changed + visible projection)
+GPU upload                      ~ O(changed instance/resource ranges)
+draw submission                 ~ O(visible batches/instances)
+spatial query                   ~ O(index query + candidates)
+resource regeneration           ~ O(actual content/resource changes)
+```
+
+The important distinction is between **resident state** and **submitted state**:
+
+- packed geometry/text resources may stay resident even while off-screen;
+- viewport culling should filter draw projection/submission without destroying resident cache state;
+- becoming visible again should normally not require resource reconstruction.
+
+## Design rules
+
+### 1. Animation properties must not invalidate unrelated resources
+
+The renderer should preserve semantic invalidation boundaries through to GPU work.
+
+Preferred behavior:
+
+```text
+transform / opacity / simple paint
+    -> instance records only
+
+reveal progress
+    -> reveal/member progress state only when representation is unchanged
+
+text position
+    -> glyph instance ranges only
+
+content / font / shaping input
+    -> text resource + dependent residency
+
+path topology / geometry replacement
+    -> affected mesh/resource ranges
+
+structural insertion/removal
+    -> local arena/order updates or explicit maintenance barrier
+```
+
+Do not collapse all of these into “object changed”.
+
+### 2. Cache the expensive representation, animate cheap state
+
+If an immutable glyph outline, tessellated path, text layout, geometry resource, or GPU mesh is already known, animation should reference that representation rather than recreate an equivalent transient object each frame.
+
+The canonical pattern is:
+
+```text
+immutable resource
+      |
+      v
+resident renderer resource / mesh / atlas entry
+      |
+      v
+small mutable instance state
+(transform, style, opacity, reveal, morph/member progress)
+```
+
+### 3. Viewport culling is a projection, not a second scene
+
+The execution runtime owns the spatial broad phase. Renderer culling must consume ordered candidates from that authority rather than:
+
+- scanning semantic bounds in JavaScript;
+- constructing a renderer-specific BVH/R-tree;
+- rebuilding a visible-only scene;
+- evicting otherwise healthy packed resources merely because an object left the viewport.
+
+Candidate filtering should preserve canonical painter order and keep the ordinary all-live resident state intact.
+
+### 4. Family animation must remain retained
+
+Family scheduling is now content-independent, but renderer realization must also preserve locality.
+
+A partial Text family reveal should not repeatedly turn cached glyph outlines into new transient `VectorPath` geometry and then force a fresh family scratch preparation when only per-member reveal progress changed.
+
+Target model:
+
+```text
+TextResource / glyph identity
+        |
+        v
+cached outline / resident path representation
+        |
+        v
+stable family-member render binding
+        |
+        v
+member instance state
+(reveal / border-fill phase / visibility)
+```
+
+The same rule should apply to future VMobject/SVG/graph/mesh family members: family timing changes mutable member state; immutable content stays resident.
+
+### 5. Separate canonical resident state from frame-specific projection
+
+Visibility, family-member filtering, and similar frame-local projections must not mutate the canonical retained preparation state in ways that leak into later uncullled/ordinary frames.
+
+Use separate candidate/projection scratch where necessary while keeping the packed all-live state authoritative.
+
+### 6. Prefer vector/GPU retention over generic bitmap caches
+
+Do **not** make per-object bitmap caching the normal architecture.
+
+Noon already has better primitives for most content:
+
+- analytic GPU primitives;
+- packed vector meshes;
+- glyph atlases;
+- lazy cached outlines;
+- immutable shared geometry resources.
+
+Rasterized subtree caching may be added later as an optional rendering strategy for demonstrably expensive, immutable subtrees, but it must remain an optimization over canonical vector/resource state rather than become source truth.
+
+### 7. Static/dynamic partitioning should be draw-plan level, not DOM/canvas topology
+
+Current 3b1b/manim provides useful evidence for this direction: its WebGPU renderer keeps mutable buffer contents separate from stable draw topology and can reuse a render bundle after the draw sequence settles.
+
+Noon should benchmark an analogous retained visible draw plan through #847 before adopting it. The likely reusable identity is draw topology/pipelines/bindings/ranges and renderer layout generation; ordinary transform/style/reveal/camera buffer changes should not invalidate it when those references remain valid.
+
+Do not introduce extra canvases merely to imitate immediate-mode systems. Do not commit to render bundles until profiling proves command encoding/submission is a material cost after Noon's existing analytic batching and mega-mesh work.
+
+## Current gaps
+
+### Viewport consumption
+
+The retained spatial-query stack exists, and #569 owns its end-to-end consumption. The desired renderer behavior is:
+
+```text
+ExecutionSpatialIndex
+       |
+query_viewport(camera bounds)
+       |
+ordered execution candidates
+       |
+map to resident renderer rows
+       |
+candidate-sized draw projection
+       |
+GPU
+```
+
+The renderer must retain all-live packed/cache state while reducing preparation/submission work to visible candidates. The prerequisite Rust/mirror pieces are already tracked in #569; the remaining web integration is represented by #605 and should be replayed on current master rather than replaced with another culling architecture.
+
+### Retained text dirty ranges
+
+#362 already owns the broader dirty-object text/mixed-renderer migration. Ordinary transform/paint/opacity locality has progressed substantially, but remaining work includes preserving dirty GPU instance ranges, localized prepared-structure transitions, and avoiding parent-level global work.
+
+Family-animation realization must satisfy the same invariant rather than becoming a parallel whole-frame path.
+
+### Family Text reveal realization
+
+The current family renderer can reuse the cached source glyph outline, but it still materializes transformed transient path geometry for partial glyphs and rebuilds family-local scratch/painter state. This is correct but not the desired steady-state performance architecture.
+
+#835 owns making family-member render bindings resident and proving that progressing one family animation does not regenerate immutable glyph/path resources or rebuild unrelated mixed-frame state.
+
+## Required performance gates
+
+Performance claims should be deterministic and structural rather than based only on wall-clock timing.
+
+### Large mostly-static viewport
+
+Use a scene with at least 100k resident objects where a small fraction is visible.
+
+After warmup, assert:
+
+- spatial query candidate count is proportional to visible objects;
+- renderer draw projection walks/submits candidates rather than all live objects;
+- off-screen packed resources remain resident;
+- panning objects into view does not cause geometry/text resource cache misses when content is unchanged;
+- painter order remains exact.
+
+### Text-heavy one-object change
+
+Use 10k+ visible/static text objects and mutate exactly one object per frame.
+
+Assert:
+
+- no global text-object/glyph scan on compatible frames;
+- GPU text upload bytes are proportional to that object's dirty instance ranges;
+- no atlas/raster/outline misses after warmup when effective resource identity is unchanged;
+- mixed painter order is not rebuilt for non-structural changes.
+
+### Family animation locality
+
+Use a mixed semantic family such as:
+
+```text
+VGroup
+├── Text("AB")
+└── Circle
+```
+
+with many unrelated static objects around it.
+
+After warmup, advance Create/Uncreate/Write-like family progress and assert:
+
+- family scheduling uses the authoritative global member plan;
+- immutable glyph outlines/path geometry are reused;
+- no unrelated object/resource preparation occurs;
+- changed GPU bytes/ranges are proportional to affected family-member state;
+- direct seek and incremental playback produce identical render state;
+- WebGPU and WebGL paths preserve the same semantics.
+
+### Stable draw-plan command reuse
+
+#847 owns the experiment. Measure a large stable visible scene under transform/style/camera-only changes and separate:
+
+- runtime evaluation cost;
+- retained frame preparation cost;
+- GPU upload cost;
+- command encoding/submission cost;
+- GPU execution cost where measurable.
+
+Compare the normal WebGPU path against an experimental stable draw-plan/render-bundle path. The experiment must preserve exact painter order and invalidate correctly for topology/pipeline/binding/range/layout changes. WebGL2 is the control path and does not require equivalent command-bundle machinery.
+
+A benchmark result showing negligible benefit is a valid outcome and should close the experiment without adding permanent complexity.
+
+## Optional future optimization: rasterized subtree cache
+
+A rasterized subtree cache can be useful for exceptionally expensive immutable content such as a complex static equation, imported illustration, or effect-heavy group.
+
+If introduced, keep the architecture explicit:
+
+```text
+canonical retained vector/resources
+          |
+          v
+render strategy selection
+      /          \
+ vector/GPU     cached subtree texture
+```
+
+Requirements:
+
+- vector/resources remain canonical;
+- cache key includes all visual inputs that affect the raster result;
+- viewport/scale policy prevents visible undersampling;
+- memory residency is bounded;
+- export/high-quality paths may bypass the raster cache;
+- rasterization is never required for ordinary transforms of already efficient vector/glyph content.
+
+No implementation issue should be opened for this until profiling demonstrates a real bottleneck.
+
+## Sequencing
+
+1. Complete the #569 viewport-consumer path without introducing duplicate spatial ownership.
+2. Continue #362 until text/mixed preparation and uploads are truly dirty-range local.
+3. Implement #835 so family-animation render realization is resident and incremental.
+4. Add/maintain structural benchmarks proving `O(visible + dirty)` behavior.
+5. Run #847 before deciding whether stable draw-plan/render-bundle reuse belongs in the production architecture.
+6. Consider optional rasterized subtree caching only from measured workloads.
+
+## Architectural invariant
+
+A useful review question for every renderer change is:
+
+> Did this frame regenerate, traverse, upload, encode, or submit anything whose semantic/render inputs did not change and which did not need to be visible?
+
+If the answer is yes, the burden is on the implementation to show why that work is unavoidable.


### PR DESCRIPTION
## Summary
- add `docs/interactive-runtime-and-live-authoring.md`
- define the reference split: ManimCE v0.21 for semantic/API/visual/timing compatibility, current 3b1b/manim for interaction/live-authoring capability reference, Noon for the retained execution architecture
- separate interactive runtime input from live-authoring/session state
- define the `InteractiveSession` ownership layer for selection, hover, pointer capture, direct manipulation, undo grouping, inspector state and editor overlays
- require explicit sampled-state coalescing vs discrete-event ordering, paused interaction without timeline advancement, and direct-manipulation property-driver arbitration
- document hot-reload/state migration through stable semantic reconciliation rather than a shared mutable Python scene
- carry forward the renderer locality/caching document from #836 and refine it with the current ManimGL stable draw-topology/render-bundle lesson
- keep render-bundle reuse measurement-driven through #847 rather than making it a production requirement

## Tracker triage
- #68 updated with the upstream reference policy, `O(active + dirty + visible)`/paused-clean requirements, #846 and #847
- #69 narrowed to native input/event delivery and reactive binding; session/editor state is explicitly #846
- #64 expanded to live-authoring reconciliation and runtime/session-state migration
- #70 clarified as the shared geometry/structural mutation vocabulary usable by host callbacks and native editor tools
- #846 opened for interactive session/direct manipulation/live-authoring state
- #847 opened as a benchmark/decision gate for stable visible draw-plan/WebGPU render-bundle reuse
- #93 annotated to keep ManimCE as the sole pinned compatibility oracle

Documentation only; no runtime behavior changes.