### PR TITLE
Add retained Axes secant slope group geometry

### DIFF
--- a/scripts/build-web-demo.sh
+++ b/scripts/build-web-demo.sh
@@ -78,6 +78,7 @@ if [[ "${NOON_SKIP_WEB_PREFLIGHT:-0}" != "1" ]]; then
     web/python/_manim_phase_b.py \
     web/python/_manim_shared_geometry.py \
     web/python/_manim_axes.py \
+    web/python/_manim_axes_derived.py \
     web/python/_manim_animation_options.py \
     web/python/_manim_animate.py \
     web/python/_manim_rotate.py \

--- a/scripts/manim-axes-smoke.mjs
+++ b/scripts/manim-axes-smoke.mjs
@@ -97,6 +97,20 @@ def assert_corner_path(graph, expected_points):
     return snapshot
 
 
+def snapshot_for(mobject):
+    handle = _handles._handle_for(mobject)
+    assert handle is not None
+    return json.loads(str(handle.snapshotJson()))
+
+
+def assert_stroke_color(mobject, expected):
+    stroke = snapshot_for(mobject)["style"]["stroke"]
+    assert_close(stroke["red"], expected.red)
+    assert_close(stroke["green"], expected.green)
+    assert_close(stroke["blue"], expected.blue)
+    assert_close(stroke["alpha"], expected.alpha)
+
+
 class RetainedAxesPlot(Scene):
     def construct(self):
         axes = Axes(
@@ -264,6 +278,77 @@ class RetainedAxesPlot(Scene):
         assert isinstance(cos_graph, ParametricFunction)
         cos_point = axes.input_to_graph_point(0.25, cos_graph)
         assert_point_close(cos_point, axes.c2p(0.25, math.cos(0.25)))
+
+        cos_graph.set_color(MAROON)
+        secant_x = 0.25
+        secant_dx = 0.5
+        secant_p1 = axes.i2gp(secant_x, cos_graph)
+        secant_p2 = axes.i2gp(secant_x + secant_dx, cos_graph)
+        secant_interim = Vec2(secant_p2.x, secant_p1.y)
+        secant_group = axes.get_secant_slope_group(
+            secant_x,
+            cos_graph,
+            dx=secant_dx,
+            dx_line_color=PURE_GREEN,
+            secant_line_color=PURPLE,
+            secant_line_length=4.0,
+        )
+        assert isinstance(secant_group, VGroup)
+        assert len(secant_group) == 3
+        assert secant_group[0] is secant_group.dx_line
+        assert secant_group[1] is secant_group.df_line
+        assert secant_group[2] is secant_group.secant_line
+        assert_point_close(secant_group.dx_line.start, secant_p1)
+        assert_point_close(secant_group.dx_line.end, secant_interim)
+        assert_point_close(secant_group.df_line.start, secant_interim)
+        assert_point_close(secant_group.df_line.end, secant_p2)
+        assert_stroke_color(secant_group.dx_line, PURE_GREEN)
+        assert_stroke_color(secant_group.df_line, MAROON)
+        assert_stroke_color(secant_group.secant_line, PURPLE)
+        assert_point_close(
+            secant_group.secant_line.get_center(),
+            (secant_p1 + secant_p2) * 0.5,
+        )
+        raw_secant_length = (secant_p2 - secant_p1).length()
+        secant_snapshot = snapshot_for(secant_group.secant_line)
+        expected_secant_scale = 4.0 / raw_secant_length
+        assert_close(secant_snapshot["transform"]["scale"]["x"], expected_secant_scale)
+        assert_close(secant_snapshot["transform"]["scale"]["y"], expected_secant_scale)
+
+        default_dx = (axes.x_range[1] - axes.x_range[0]) / 10.0
+        default_secant = axes.get_secant_slope_group(
+            secant_x,
+            cos_graph,
+            dx=0.0,
+            include_secant_line=False,
+        )
+        assert len(default_secant) == 2
+        assert not hasattr(default_secant, "secant_line")
+        assert_point_close(
+            default_secant.df_line.end,
+            axes.i2gp(secant_x + default_dx, cos_graph),
+        )
+        assert_stroke_color(default_secant.dx_line, PURE_YELLOW)
+        assert_stroke_color(default_secant.df_line, MAROON)
+
+        negative_secant = axes.get_secant_slope_group(
+            secant_x,
+            cos_graph,
+            dx=-0.25,
+            include_secant_line=False,
+        )
+        assert len(negative_secant) == 2
+        assert_point_close(
+            negative_secant.df_line.end,
+            axes.i2gp(secant_x - 0.25, cos_graph),
+        )
+
+        for label_kwargs in ({"dx_label": "dx"}, {"dy_label": "dy"}):
+            try:
+                axes.get_secant_slope_group(secant_x, cos_graph, **label_kwargs)
+                raise AssertionError("secant labels must wait for exact retained text")
+            except NotImplementedError as error:
+                assert "MathTex/number labels" in str(error)
 
         parametric_calls = []
 
@@ -512,6 +597,7 @@ class RetainedAxesPlot(Scene):
             axes,
             sin_graph,
             cos_graph,
+            secant_group,
             parametric,
             direct_parametric,
             function_graph,
@@ -550,7 +636,7 @@ try {
     axesSource,
   );
   assert.equal(result.kind, "scene_document");
-  assert.equal(result.document.objects.length, 65);
+  assert.equal(result.document.objects.length, 68);
   assert.equal(result.document.tracks.length, 0);
 
   const geometryKinds = result.document.objects.map(
@@ -558,8 +644,8 @@ try {
   );
   assert.equal(
     geometryKinds.filter((kind) => kind === "line").length,
-    42,
-    "Axes, NumberPlane, and projection helpers must flatten to ordinary retained line geometry",
+    45,
+    "Axes, NumberPlane, projection helpers, and secant groups must flatten to ordinary retained line geometry",
   );
   assert.equal(
     geometryKinds.filter((kind) => kind === "vector_path").length,
@@ -578,7 +664,7 @@ try {
   );
   assert.deepEqual(errors, [], `browser errors while testing retained Axes:\n${errors.join("\n")}`);
   console.log(
-    "Retained Axes/NumberPlane smoke passed: transformed coordinates, retained grid families, direct/Axes parametric functions, FunctionGraph, authored/generic i2gp, line graphs, two-phase Riemann rectangles, and bounded area polygons.",
+    "Retained Axes/NumberPlane smoke passed: transformed coordinates, retained grid families, direct/Axes parametric functions, FunctionGraph, authored/generic i2gp, secant slope groups, line graphs, two-phase Riemann rectangles, and bounded area polygons.",
   );
 } finally {
   await browser?.close();

--- a/web/python-compat-modules.js
+++ b/web/python-compat-modules.js
@@ -12,6 +12,7 @@ export const PYTHON_COMPAT_MODULES = Object.freeze([
   { sourcePath: "python/_manim_geometry.py", runtimePath: "/tmp/_manim_geometry.py", label: "Noon Manim geometry layer" },
   { sourcePath: "python/_manim_shared_geometry.py", runtimePath: "/tmp/_manim_shared_geometry.py", label: "Noon shared Rust geometry adapter" },
   { sourcePath: "python/_manim_axes.py", runtimePath: "/tmp/_manim_axes.py", label: "Noon shared Axes adapter" },
+  { sourcePath: "python/_manim_axes_derived.py", runtimePath: "/tmp/_manim_axes_derived.py", label: "Noon derived Axes compatibility layer" },
   { sourcePath: "python/_manim_number_line.py", runtimePath: "/tmp/_manim_number_line.py", label: "Noon shared NumberLine adapter" },
   { sourcePath: "python/_manim_number_plane.py", runtimePath: "/tmp/_manim_number_plane.py", label: "Noon shared NumberPlane adapter" },
   { sourcePath: "python/_manim_polar_plane.py", runtimePath: "/tmp/_manim_polar_plane.py", label: "Noon shared PolarPlane adapter" },

--- a/web/python-worker.source.js
+++ b/web/python-worker.source.js
@@ -120,6 +120,8 @@ import _manim_shared_geometry
 _manim_shared_geometry.install()
 import _manim_axes
 _manim_axes.install()
+import _manim_axes_derived
+_manim_axes_derived.install()
 import _manim_number_plane
 _manim_number_plane.install()
 import _manim_polar_plane

--- a/web/python/_manim_axes_derived.py
+++ b/web/python/_manim_axes_derived.py
@@ -1,0 +1,104 @@
+"""Derived ManimCE v0.21 CoordinateSystem helpers over retained Axes primitives.
+
+This module owns authoring-only compositions that do not justify new Rust planners or
+renderer geometry. Static results remain ordinary retained primitives.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import noon as _base
+import _manim_axes as _axes
+import _manim_compat as _compat
+import _manim_semantic_handles as _shared
+
+_INSTALLED = False
+_DEFAULT_DX_LINE_COLOR = getattr(
+    _base, "PURE_YELLOW", _base.color_from_hex("#FFFF00")
+)
+
+
+def _current_stroke_color(mobject: object, helper_name: str) -> _base.Color:
+    """Read the current retained stroke color, including authoring-time recolors."""
+
+    handle = _shared._handle_for(mobject)
+    if handle is None or not hasattr(handle, "snapshotJson"):
+        raise NotImplementedError(f"{helper_name} requires current retained graph geometry")
+    snapshot = json.loads(str(handle.snapshotJson()))
+    stroke = snapshot.get("style", {}).get("stroke")
+    if not isinstance(stroke, dict):
+        raise NotImplementedError(f"{helper_name} requires a retained graph stroke color")
+    try:
+        return _base.Color(
+            float(stroke["red"]),
+            float(stroke["green"]),
+            float(stroke["blue"]),
+            float(stroke["alpha"]),
+        )
+    except (KeyError, TypeError, ValueError) as error:
+        raise TypeError("retained graph stroke color is malformed") from error
+
+
+def _get_secant_slope_group(
+    self: _axes.Axes,
+    x: float,
+    graph: _axes.ParametricFunction,
+    dx: float | None = None,
+    dx_line_color: object = _DEFAULT_DX_LINE_COLOR,
+    dy_line_color: object | None = None,
+    dx_label: object | None = None,
+    dy_label: object | None = None,
+    include_secant_line: bool = True,
+    secant_line_color: object = _base.GREEN,
+    secant_line_length: float = 10.0,
+) -> _compat.VGroup:
+    """Pinned v0.21 secant geometry using retained graph queries and Line leaves."""
+
+    if dx_label is not None or dy_label is not None:
+        raise NotImplementedError(
+            "get_secant_slope_group labels require retained MathTex/number labels"
+        )
+
+    resolved_dx = float(dx or (float(self.x_range[1]) - float(self.x_range[0])) / 10.0)
+    p1 = _compat._as_vec2(self.input_to_graph_point(float(x), graph))
+    p2 = _compat._as_vec2(self.input_to_graph_point(float(x) + resolved_dx, graph))
+    interim_point = _base.Vec2(float(p2.x), float(p1.y))
+
+    group = _compat.VGroup()
+    group.dx_line = _compat.Line(
+        p1,
+        interim_point,
+        color=_axes._color("dx_line_color", dx_line_color),
+    )
+    group.df_line = _compat.Line(
+        interim_point,
+        p2,
+        color=(
+            _current_stroke_color(graph, "get_secant_slope_group")
+            if dy_line_color is None
+            else _axes._color("dy_line_color", dy_line_color)
+        ),
+    )
+    group.add(group.dx_line, group.df_line)
+
+    if include_secant_line:
+        group.secant_line = _compat.Line(
+            p1,
+            p2,
+            color=_axes._color("secant_line_color", secant_line_color),
+        )
+        graph_delta = p2 - p1
+        group.secant_line.scale(float(secant_line_length) / graph_delta.length())
+        group.add(group.secant_line)
+
+    return group
+
+
+def install() -> None:
+    global _INSTALLED
+    if _INSTALLED:
+        return
+    _axes.Axes.get_secant_slope_group = _get_secant_slope_group
+    _INSTALLED = True

--- a/web/python/_manim_axes_derived.py
+++ b/web/python/_manim_axes_derived.py
@@ -7,7 +7,6 @@ renderer geometry. Static results remain ordinary retained primitives.
 from __future__ import annotations
 
 import json
-from typing import Any
 
 import noon as _base
 import _manim_axes as _axes

--- a/web/python/_manim_axes_derived.py
+++ b/web/python/_manim_axes_derived.py
@@ -40,6 +40,14 @@ def _current_stroke_color(mobject: object, helper_name: str) -> _base.Color:
         raise TypeError("retained graph stroke color is malformed") from error
 
 
+def _scale_about_center(mobject: _base.Mobject, factor: float) -> _base.Mobject:
+    """Compose Noon's origin-space scale into Manim's default center-pivot scale."""
+
+    center = mobject.get_center()
+    mobject.scale(float(factor))
+    return mobject.move_to(center)
+
+
 def _get_secant_slope_group(
     self: _axes.Axes,
     x: float,
@@ -89,7 +97,10 @@ def _get_secant_slope_group(
             color=_axes._color("secant_line_color", secant_line_color),
         )
         graph_delta = p2 - p1
-        group.secant_line.scale(float(secant_line_length) / graph_delta.length())
+        _scale_about_center(
+            group.secant_line,
+            float(secant_line_length) / graph_delta.length(),
+        )
         group.add(group.secant_line)
 
     return group


### PR DESCRIPTION
## Summary
Add ManimCE v0.21 `CoordinateSystem.get_secant_slope_group` for the exact unlabeled geometry path over Noon's existing retained Axes/Line/VGroup semantics.

- falsy `dx` resolves to one tenth of the Axes x range
- `p1`/`p2` come through the existing retained `input_to_graph_point` path
- `dx_line` is world-horizontal and `df_line` world-vertical exactly like v0.21
- default `dy_line_color` reads the graph's current retained stroke, including authoring-time recolors
- optional secant line preserves Manim's center-pivot scale semantics while using Noon's retained transform primitives
- returned `VGroup` exposes `dx_line`, `df_line`, and optional `secant_line`
- non-`None` `dx_label` / `dy_label` fail explicitly until #83 provides exact retained MathTex/number labels

## Architecture
Introduce `_manim_axes_derived.py` as the cohesive home for CoordinateSystem-derived authoring compositions that do not justify new engine planners. It is installed immediately after the authoritative Axes facade and included in the compatibility bundle/preflight compile ratchet.

No new Rust planner, renderer geometry kind, playback callback, or per-frame Python work is introduced. The result is ordinary retained Line geometry.

During acceptance this exposed a broader retained `Mobject.scale` pivot mismatch for off-origin geometry: Noon shared-handle scaling is origin-space, while pinned Manim defaults to the mobject center. That broader correction is recorded on #74. This slice composes scale + center restoration locally so the secant helper is exact without silently changing Noon's native transform contract.

## Acceptance
The existing real Pyodide/WASM Axes smoke covers:
- transformed Axes + nonlinear graph secant geometry
- explicit positive and negative `dx`
- v0.21 falsy/default `dx`
- current graph color inheritance after recoloring
- explicit line colors
- secant midpoint and scale-to-length behavior
- `include_secant_line=False`
- explicit text-label dependency failures
- ordinary retained line serialization and zero tracks

## Exact-head qualification
- exact head: `fefa935beafe2e91818170d8732df350c5f35192`
- PR Fast Gate: `33569208146` (#381)
- result: **green** across rustfmt + Clippy, workspace Rust unit tests, web static/unit checks, one-time WASM build, deterministic playback, Manim authoring, expanded retained Axes/secant acceptance, NumberLine, ComplexPlane, PolarPlane, lazy namespace dependencies, literal PlotExample, and primary WebGPU rendering

Independent base: exact-green #828 (`work/253-polar-plane`). Tracks #845 / #85.