### PR TITLE
Add shared center-preserving Manim scale semantics

### DIFF
--- a/crates/noon-web/src/lib.rs
+++ b/crates/noon-web/src/lib.rs
@@ -23,6 +23,7 @@ mod manim_dashed_line_bridge;
 mod manim_elbow_bridge;
 mod manim_geometry_bridge;
 mod manim_path_query_bridge;
+mod manim_scale_bridge;
 mod manim_sector_bridge;
 mod manim_shape_matcher_bridge;
 #[cfg(any(target_arch = "wasm32", test))]

--- a/crates/noon-web/src/manim_scale_bridge.rs
+++ b/crates/noon-web/src/manim_scale_bridge.rs
@@ -1,0 +1,76 @@
+use crate::FrontendMobjectHandle;
+
+impl FrontendMobjectHandle {
+    /// Apply relative Manim scaling while preserving the mobject's world-space center.
+    ///
+    /// Noon's lower-level `scale` operation intentionally remains origin-space. Manim's
+    /// `Mobject.scale` instead uses the current mobject center as its default pivot, so
+    /// off-origin geometry needs a compensating translation after the relative scale.
+    /// Keeping that pivot rule here gives every frontend one shared semantic operation
+    /// without baking Manim behavior into the native transform primitive.
+    pub fn manim_scale(&mut self, x: f64, y: f64) -> Result<(), String> {
+        let center = self.center();
+        self.scale(x, y)?;
+        let scaled_center = self.center();
+        self.shift(center.0 - scaled_center.0, center.1 - scaled_center.1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const EPSILON: f64 = 1.0e-6;
+
+    fn assert_close(actual: f64, expected: f64) {
+        assert!(
+            (actual - expected).abs() <= EPSILON,
+            "expected {expected}, got {actual}"
+        );
+    }
+
+    #[test]
+    fn manim_scale_preserves_center_for_off_origin_rotated_geometry() {
+        let mut line = FrontendMobjectHandle::manim_line(1.0, 2.0, 5.0, 4.0).unwrap();
+        line.shift(0.75, -1.25).unwrap();
+        line.rotate(0.37).unwrap();
+
+        let center = line.center();
+        let width = line.width();
+        let height = line.height();
+
+        line.manim_scale(1.75, 1.75).unwrap();
+
+        let scaled_center = line.center();
+        assert_close(scaled_center.0, center.0);
+        assert_close(scaled_center.1, center.1);
+        assert_close(line.width(), width * 1.75);
+        assert_close(line.height(), height * 1.75);
+    }
+
+    #[test]
+    fn manim_scale_preserves_center_for_non_uniform_scale() {
+        let mut line = FrontendMobjectHandle::manim_line(-2.0, 1.0, 3.0, 5.0).unwrap();
+        line.shift(-0.5, 0.25).unwrap();
+        line.rotate(-0.2).unwrap();
+        let center = line.center();
+
+        line.manim_scale(2.0, 0.5).unwrap();
+
+        let scaled_center = line.center();
+        assert_close(scaled_center.0, center.0);
+        assert_close(scaled_center.1, center.1);
+    }
+
+    #[test]
+    fn native_relative_scale_keeps_origin_space_contract() {
+        let mut line = FrontendMobjectHandle::manim_line(1.0, 2.0, 5.0, 4.0).unwrap();
+        let center = line.center();
+
+        line.scale(2.0, 2.0).unwrap();
+
+        let scaled_center = line.center();
+        assert!((scaled_center.0 - center.0).abs() > EPSILON);
+        assert!((scaled_center.1 - center.1).abs() > EPSILON);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a shared Rust semantic operation for Manim-compatible relative scaling without changing Noon's native origin-space transform contract.

`FrontendMobjectHandle::manim_scale(x, y)` captures the current world-space layout center, applies the existing relative scale primitive, then restores that center. This fixes the architectural gap behind off-origin geometry such as `Line`, where Manim's default `Mobject.scale()` pivot is the mobject center but Noon's lower-level relative scale is intentionally origin-space.

## Why this slice

The current plotting/retained-family/text/Typst lanes are actively owned by open PRs. The latest master still has a Retained Typst authoring failure, but #851 is already handling that lane. PR #850 independently exposed this shared scale-pivot mismatch and had to compensate locally for secant geometry. This PR takes the reusable shared-semantic portion without modifying #850's active branch or changing native transform behavior.

## Tests

Focused Rust tests cover:
- uniform scaling of shifted + rotated off-origin line geometry preserves world center and scales extents;
- non-uniform scaling also preserves world center;
- the existing native `scale` primitive remains origin-space, preventing an accidental contract change.

Exact-head PR Fast Gate (`d283b15bdefdc9539d26aba66258b5139012ad78`):
- web static/unit preflight: green;
- Rust format/lint: green;
- fast Rust tests (including these new regressions): green;
- browser fast checks: still running at last validation check.

## Remaining integration / risk

The browser Manim facade still calls the lower-level `scale` handle directly. A follow-up can route that adapter to `manim_scale` (and then remove feature-local center-restoration workarounds) once this shared semantic boundary is accepted. I intentionally did not change the large active facade surface in this PR to keep the unit independent and low-conflict.

The implementation uses existing relative scale plus one compensating translation, so it does not clone retained geometry or add per-vertex work. The only remaining behavioral integration risk is adapter routing, not the shared center-preservation primitive itself.

Related: #74, #61, #850