### PR TITLE
Avoid duplicate cold-start host callback reconciliation

### DIFF
--- a/web/authoring-execution-client.js
+++ b/web/authoring-execution-client.js
@@ -75,6 +75,8 @@ export class AuthoringExecutionClient {
       loopDurationSeconds = DEFAULT_LOOP_DURATION_SECONDS,
       transportMode = undefined,
       sharedSlotCapacity = DEFAULT_SHARED_SLOT_CAPACITY,
+      callbacks = null,
+      authoringClient = null,
     } = {},
   ) {
     if (this.#player !== null || this.#transition !== null) {
@@ -91,6 +93,9 @@ export class AuthoringExecutionClient {
       options.transportMode = transportMode;
     }
     const ready = await this.#startMode(AUTHORING_EXECUTION_LEGACY, sceneJson, options);
+    if (callbacks !== null && callbacks !== undefined) {
+      await this.#player.configureHostCallbacks(callbacks, authoringClient);
+    }
     this.#transportMode = ready.transportMode;
     return ready;
   }

--- a/web/main.js
+++ b/web/main.js
@@ -481,17 +481,12 @@ async function ensureRuntimeReady({
         ? await nextPlayer.startRetainedCanonical(sceneSpecJson, {
             loopDurationSeconds,
           })
-        : await nextPlayer.start(sceneJson, { loopDurationSeconds });
-      let initialState;
-      if (!startRetained && callbacks !== null && callbacks !== undefined) {
-        initialState = await nextPlayer.reconcileScene(sceneJson, {
-          callbacks,
-          authoringClient: client,
-          loopDurationSeconds,
-        });
-      } else {
-        initialState = await nextPlayer.state();
-      }
+        : await nextPlayer.start(sceneJson, {
+            loopDurationSeconds,
+            callbacks,
+            authoringClient: client,
+          });
+      const initialState = await nextPlayer.state();
 
       player = nextPlayer;
       playerNeedsRestart = false;

--- a/web/playground-cold-start-callbacks.test.mjs
+++ b/web/playground-cold-start-callbacks.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const mainSource = await readFile(new URL("./main.js", import.meta.url), "utf8");
+const executionSource = await readFile(
+  new URL("./authoring-execution-client.js", import.meta.url),
+  "utf8",
+);
+
+const runtimeStart = mainSource.indexOf("async function ensureRuntimeReady(");
+const runtimeEnd = mainSource.indexOf("\nasync function ensureExecutionReady()", runtimeStart);
+assert.ok(runtimeStart >= 0 && runtimeEnd > runtimeStart, "playground runtime startup boundary must exist");
+const runtimeReady = mainSource.slice(runtimeStart, runtimeEnd);
+
+assert.match(
+  runtimeReady,
+  /nextPlayer\.start\(sceneJson, \{[\s\S]*callbacks,[\s\S]*authoringClient: client,/u,
+  "legacy cold start must attach host callbacks through the initial startup",
+);
+assert.doesNotMatch(
+  runtimeReady,
+  /nextPlayer\.reconcileScene/u,
+  "legacy cold start must not reconcile the just-started scene only to attach callbacks",
+);
+
+const startMethod = executionSource.indexOf("  async start(");
+const retainedStart = executionSource.indexOf("\n  async startRetainedCanonical(", startMethod);
+assert.ok(startMethod >= 0 && retainedStart > startMethod, "legacy authoring startup method must exist");
+const legacyStart = executionSource.slice(startMethod, retainedStart);
+assert.match(legacyStart, /callbacks = null,/u);
+assert.match(legacyStart, /authoringClient = null,/u);
+assert.match(
+  legacyStart,
+  /configureHostCallbacks\(callbacks, authoringClient\)/u,
+  "legacy startup must reuse the shared host-callback configuration path",
+);
+
+console.log("✓ cold-start host callbacks attach without duplicate scene reconciliation");


### PR DESCRIPTION
## Summary
- let `AuthoringExecutionClient.start()` attach legacy host callbacks through the existing shared callback configuration path
- pass first-run playground callbacks and their authoring client through initial legacy startup
- remove the second reconciliation of the identical scene that was previously used only to install callbacks
- add a focused cold-start regression that keeps this startup path single-scene

## Why
The playground now correctly waits for Python authoring before choosing legacy vs retained execution, but first-run legacy scenes with host callbacks still did two engine scene operations: `start(scene)` followed immediately by `reconcileScene(scene)` for the same authored document. That adds avoidable cold-start work to the slow-path callback examples.

This keeps callback execution semantics where they already live: `ExecutionWorkerClient.configureHostCallbacks`. Retained+callback authoring remains rejected, and ordinary reruns still use normal scene reconciliation.

## Validation
The added `web/playground-cold-start-callbacks.test.mjs` is auto-discovered by the web test suite and asserts both sides of the boundary: the playground passes callbacks at startup, and the authoring execution client reuses the shared callback setup path without an immediate duplicate reconcile.

Tracks #642.

### Remaining risk
Callback attachment still occurs after the initial engine start, exactly as it did after the old first reconciliation; this change only removes the duplicate scene reconciliation. Browser/PR CI should verify the exact integrated worker startup path before merge.