### PR TITLE
Guard persistent canvas identity across authoring mode switches

### DIFF
--- a/web/authoring-render-transition.test.mjs
+++ b/web/authoring-render-transition.test.mjs
@@ -6,6 +6,10 @@ const source = readFileSync(
   new URL("./authoring-render-worker.js", import.meta.url),
   "utf8",
 );
+const executionClientSource = readFileSync(
+  new URL("./authoring-execution-client.js", import.meta.url),
+  "utf8",
+);
 
 function functionSlice(name, nextName) {
   const start = source.indexOf(`function ${name}`);
@@ -13,6 +17,14 @@ function functionSlice(name, nextName) {
   const end = source.indexOf(`function ${nextName}`, start + 1);
   assert.notEqual(end, -1, `missing ${nextName}`);
   return source.slice(start, end);
+}
+
+function executionMethodSlice(name, nextName) {
+  const start = executionClientSource.indexOf(`async #${name}`);
+  assert.notEqual(start, -1, `missing AuthoringExecutionClient.#${name}`);
+  const end = executionClientSource.indexOf(`async #${nextName}`, start + 1);
+  assert.notEqual(end, -1, `missing AuthoringExecutionClient.#${nextName}`);
+  return executionClientSource.slice(start, end);
 }
 
 test("renderer transition keeps the active renderer until replacement bootstrap arrives", () => {
@@ -62,4 +74,32 @@ test("transition state is observable without changing the presented mode", () =>
   const metrics = functionSlice("currentMetrics", "disposeRenderer");
   assert.match(metrics, /mode,/);
   assert.match(metrics, /transitionMode,/);
+});
+
+test("authoring mode switches keep the same canvas-owning execution client", () => {
+  const retained = executionMethodSlice(
+    "switchRetainedCanonical",
+    "rebuildRetainedCanonical",
+  );
+  const legacy = executionMethodSlice("switchLegacy", "runTransition");
+
+  for (const [mode, method] of [
+    ["retained", retained],
+    ["legacy", legacy],
+  ]) {
+    assert.match(method, /const player = this\.#player;/);
+    assert.doesNotMatch(
+      method,
+      /new ExecutionWorkerClient|cloneNode|replaceWith|replaceChild|transferControlToOffscreen/,
+      `${mode} transition must reuse the existing canvas-owning execution client`,
+    );
+    assert.doesNotMatch(
+      method,
+      /this\.#canvas\s*=/,
+      `${mode} transition must not replace the HTML canvas`,
+    );
+  }
+
+  assert.match(retained, /player\.switchToRetainedCanonical\(/);
+  assert.match(legacy, /player\.switchToLegacy\(/);
 });


### PR DESCRIPTION
## Summary
- add a focused structural regression for the persistent render-surface contract already implemented on master
- require retained/legacy authoring mode switches to reuse the existing `ExecutionWorkerClient`
- reject reintroduction of DOM canvas replacement, cloning, or a second `transferControlToOffscreen()` inside mode-transition methods
- preserve the existing renderer transition staging/resource tests unchanged

## Why
#492's core architecture is already present on current master: `AuthoringExecutionClient` owns one `ExecutionWorkerClient`, and mode changes call `switchToRetainedCanonical` / `switchToLegacy` on that same canvas-owning client. The issue remains open, but the acceptance contract was not directly ratcheted at this ownership boundary. A future refactor could therefore reintroduce canvas replacement without failing the existing render-worker transition tests.

This is deliberately a test-only hardening slice. It does not redesign the renderer or add another surface abstraction.

## Validation
The changed test is auto-discovered by the normal web static/unit preflight. PR Fast Gate should validate the exact branch head.

## Remaining risk
This guards the ownership path structurally; a separate full browser smoke can still add repeated geometry ↔ retained switching and assert DOM object identity end-to-end if that coverage is not already provided elsewhere.

Tracks #492.