### PR TITLE
Make Scene own canonical SceneSpec production

### DIFF
--- a/web/authoring-scene-spec-result.test.mjs
+++ b/web/authoring-scene-spec-result.test.mjs
@@ -106,13 +106,20 @@ test("canonical SceneSpec result validation rejects duplicate identity and inval
   );
 });
 
-test("Python worker canonicalizes retained output through the Rust WASM bridge", async () => {
-  const source = await readFile(new URL("./python-worker.source.js", import.meta.url), "utf8");
-  assert.match(source, /canonicalRetainedSceneSpecJson/);
-  assert.match(source, /result\.scene_spec\s*=\s*JSON\.parse/);
-  assert.match(
-    source,
-    /canonicalRetainedSceneSpecJson\(JSON\.stringify\(result\.document\), retainedDocumentJson\)/,
-  );
-  assert.doesNotMatch(source, /retained_document\.objects\.length/);
+test("Scene producer owns canonical SceneSpec finalization through the Rust WASM bridge", async () => {
+  const [workerSource, pythonSource] = await Promise.all([
+    readFile(new URL("./python-worker.source.js", import.meta.url), "utf8"),
+    readFile(new URL("./python/noon.py", import.meta.url), "utf8"),
+  ]);
+
+  assert.match(workerSource, /self\.noonCanonicalSceneSpecJson = canonicalRetainedSceneSpecJson/);
+  assert.match(workerSource, /__noon_scene_spec = __noon_result\.to_scene_spec\(\)/);
+  assert.match(workerSource, /"scene_spec": __noon_scene_spec/);
+  assert.doesNotMatch(workerSource, /result\.scene_spec\s*=/);
+  assert.doesNotMatch(workerSource, /validateRetainedAuthoringDocumentJson/);
+
+  assert.match(pythonSource, /def to_scene_spec\(self\)/);
+  assert.match(pythonSource, /from js import noonCanonicalSceneSpecJson as canonicalize/);
+  assert.match(pythonSource, /retained_document = getattr\(self, "retained_document", None\)/);
+  assert.match(pythonSource, /canonicalize\(legacy_json, retained_json\)/);
 });

--- a/web/python-worker.source.js
+++ b/web/python-worker.source.js
@@ -16,7 +16,6 @@ import initNoonWeb, {
   resolveLifecyclePlan,
   resolveUniformCompositionSchedule,
   validatePresenceTransition,
-  validateRetainedAuthoringDocumentJson,
 } from "./pkg/noon_web.js";
 import { PYTHON_COMPAT_MODULES } from "./python-compat-modules.js";
 import { loadPyodide } from "https://cdn.jsdelivr.net/pyodide/v314.0.5/full/pyodide.mjs";
@@ -85,6 +84,7 @@ async function initializePyodide() {
   self.noonResolveUniformCompositionSchedule = resolveUniformCompositionSchedulePlain;
   self.noonResolveLifecyclePlan = resolveLifecyclePlanPlain;
   self.noonValidatePresenceTransition = validatePresenceTransitionPlain;
+  self.noonCanonicalSceneSpecJson = canonicalRetainedSceneSpecJson;
 
   for (const [index, descriptor] of PYTHON_COMPAT_MODULES.entries()) {
     pyodide.FS.writeFile(descriptor.runtimePath, compatibilityModules[index].source, {
@@ -111,8 +111,8 @@ _manim_rotate.install()
 import _manim_composition
 _manim_composition.install()
 import _manim_lifecycle
-# Retained text must wrap the final lifecycle-aware Scene.add implementation so
-# it is intercepted before any legacy geometry binding occurs.
+# Retained Text specializes content binding below the lifecycle-owned Scene.add path;
+# it must not replace or intercept scene membership semantics.
 import _manim_typst
 _manim_typst.install()
 # Install retained animation before later Scene.play adapters capture their
@@ -353,23 +353,28 @@ else:
 
 if isinstance(__noon_result, Scene):
     __noon_kind = "scene_document"
+    __noon_scene_spec = __noon_result.to_scene_spec()
+    __noon_document = __noon_result.to_document()
+    __noon_retained = __noon_result.retained_document()
     __noon_duration = float(__noon_result.time)
     __noon_identities = __noon_result.identity_document()
     __noon_callbacks = _manim_updaters.register_scene(__noon_result)
-    __noon_retained = __noon_result.retained_document()
 elif isinstance(__noon_result, PatchBatch):
     __noon_kind = "patch_batch"
+    __noon_scene_spec = None
+    __noon_document = __noon_result.to_document()
+    __noon_retained = None
     __noon_duration = None
     __noon_identities = None
     __noon_callbacks = None
-    __noon_retained = None
 else:
     raise TypeError("Python authoring result must be a noon.Scene or noon.PatchBatch")
 json.dumps(
     {
         "kind": __noon_kind,
-        "document": __noon_result.to_document(),
+        "document": __noon_document,
         "retained_document": __noon_retained,
+        "scene_spec": __noon_scene_spec,
         "duration": __noon_duration,
         "identities": __noon_identities,
         "callbacks": __noon_callbacks,
@@ -380,15 +385,7 @@ json.dumps(
 `,
       { globals },
     );
-    const result = JSON.parse(resultJson);
-    if (result.retained_document !== null) {
-      const retainedDocumentJson = JSON.stringify(result.retained_document);
-      validateRetainedAuthoringDocumentJson(retainedDocumentJson);
-      result.scene_spec = JSON.parse(
-        canonicalRetainedSceneSpecJson(JSON.stringify(result.document), retainedDocumentJson),
-      );
-    }
-    return JSON.stringify(result);
+    return resultJson;
   } finally {
     globals.destroy();
   }

--- a/web/python/noon.py
+++ b/web/python/noon.py
@@ -1,13 +1,14 @@
 """Public Noon authoring API.
 
-The public surface favors Manim-like semantic vocabulary while the internal
-``_noon_ir`` module remains a thin emitter for Noon's single SceneDocument IR.
-No separate authoring document or frontend-specific scene model is introduced.
+The public surface favors Manim-like semantic vocabulary while ``SceneSpec`` is the
+canonical mixed-content producer contract. Legacy geometry and retained-text documents
+remain bounded compatibility projections while #367 retires the split authoring path.
 """
 
 from __future__ import annotations
 
 import copy
+import json
 import math
 from dataclasses import dataclass
 from typing import Any, Iterable, Iterator
@@ -759,7 +760,7 @@ class _AnimationBuilder:
 
 
 class Scene(_ir.Scene):
-    """High-level scene facade that still emits the canonical SceneDocument."""
+    """High-level scene facade whose authoritative mixed output is ``SceneSpec``."""
 
     def __init__(self) -> None:
         super().__init__()
@@ -768,6 +769,34 @@ class Scene(_ir.Scene):
     @property
     def time(self) -> float:
         return self._cursor
+
+    def to_scene_spec(self) -> dict[str, Any]:
+        """Finalize this authored scene through Rust's canonical mixed-scene adapter.
+
+        Content adapters may still maintain legacy projections during #367 migration,
+        but callers consume one validated ``SceneSpec``. The Rust adapter remains the
+        authority for geometry/text ordering, text source lowering, retained tracks,
+        and family-animation transport.
+        """
+        try:
+            from js import noonCanonicalSceneSpecJson as canonicalize
+        except ImportError as error:
+            raise RuntimeError(
+                "canonical SceneSpec finalization requires the Noon browser Rust bridge"
+            ) from error
+
+        retained_document = getattr(self, "retained_document", None)
+        if retained_document is None:
+            raise RuntimeError(
+                "canonical SceneSpec finalization requires retained authoring compatibility"
+            )
+        legacy_json = json.dumps(
+            self.to_document(), separators=(",", ":"), allow_nan=False
+        )
+        retained_json = json.dumps(
+            retained_document(), separators=(",", ":"), allow_nan=False
+        )
+        return json.loads(str(canonicalize(legacy_json, retained_json)))
 
     def _raw_object(self, value: Mobject | _ir.Object) -> _ir.Object:
         if isinstance(value, _ir.Object):


### PR DESCRIPTION
## Summary
- make `Scene.to_scene_spec()` the canonical producer boundary for Python-authored mixed scenes
- keep Rust authoritative for legacy-geometry + retained-text normalization, ordering, retained tracks, and family-animation transport
- reduce the Python worker to transport: it exposes the Rust finalizer bridge but no longer validates/inspects retained sidecars or constructs `scene_spec` after Python returns
- correct the stale worker comment that still described retained Text as a `Scene.add` interceptor
- keep legacy `SceneDocument` and retained payloads available as bounded compatibility projections during #367 migration

## Architecture
This is a producer-ownership slice, not a new frontend IR. `Scene.add` remains lifecycle-owned and content-independent. `Scene.to_scene_spec()` delegates to the existing Rust `canonicalRetainedSceneSpecJson` boundary, so Python does not reconstruct mixed ordering or text semantics.

## Validation
- rebuilt generated Python authoring assets successfully
- `node --test web/authoring-scene-spec-result.test.mjs`
- `node --test web/python-compat-bundle.test.mjs`
- `git diff --check`

Tracks #367.

## Next boundary
Move the canonical producer below the remaining split compatibility projections by registering geometry/Text source objects directly into one Rust-backed scene-authoring context. The compatibility `document`/`retained_document` views can then be derived or retired without changing the worker transport contract.