### PR TITLE
Profile stable camera command submission

### DIFF
--- a/scripts/authoring-perf.mjs
+++ b/scripts/authoring-perf.mjs
@@ -15,6 +15,10 @@ const baseUrl = `http://127.0.0.1:${port}`;
 const counts = integerList(process.env.NOON_AUTHORING_PERF_COUNTS ?? "1000,10000,100000");
 const samples = positiveInteger(process.env.NOON_AUTHORING_PERF_SAMPLES ?? "3", "samples");
 const scrubs = positiveInteger(process.env.NOON_AUTHORING_PERF_SCRUBS ?? "20", "scrubs");
+const cameraSamples = positiveInteger(
+  process.env.NOON_AUTHORING_PERF_CAMERA_SAMPLES ?? "30",
+  "camera samples",
+);
 const backend = process.env.NOON_AUTHORING_PERF_BACKEND ?? "webgpu";
 assert.ok(backend === "webgpu" || backend === "webgl", `unknown backend: ${backend}`);
 const artifactPath = path.resolve(
@@ -54,6 +58,7 @@ try {
       objects: String(objects),
       samples: String(samples),
       scrubs: String(scrubs),
+      camera_samples: String(cameraSamples),
     });
     process.stdout.write(`Authoring ${backend} ${objects.toLocaleString()} objects… `);
     await page.goto(`${baseUrl}/web/authoring-perf.html?${query}`, { waitUntil: "load" });
@@ -69,12 +74,14 @@ try {
     }
     const report = await page.evaluate(() => window.__NOON_AUTHORING_PERF__);
     assert.equal(report.workload.objects, objects);
+    assert.equal(report.workload.cameraSamples, cameraSamples);
     cases.push(report);
     console.log(
       `cold ${format(report.cold.timeToVisibleMs)} ms, ` +
         `unchanged p95 ${format(report.warmUnchanged.timeToVisibleMs?.p95)} ms, ` +
         `local edit p95 ${format(report.oneObjectEdit.timeToVisibleMs?.p95)} ms, ` +
-        `scrub p95 ${format(report.scrub.timeToVisibleMs?.p95)} ms`,
+        `scrub p95 ${format(report.scrub.timeToVisibleMs?.p95)} ms, ` +
+        `camera encode/submit p95 ${format(report.stableCamera.encodeSubmitMs?.p95)} ms`,
     );
     await page.close();
   }
@@ -93,7 +100,7 @@ try {
       totalMemoryBytes: os.totalmem(),
       node: process.version,
     },
-    configuration: { backend, counts, samples, scrubs },
+    configuration: { backend, counts, samples, scrubs, cameraSamples },
     cases,
   };
   await mkdir(path.dirname(artifactPath), { recursive: true });

--- a/web/authoring-perf-scenarios.js
+++ b/web/authoring-perf-scenarios.js
@@ -1,0 +1,60 @@
+import { summarizeSamples } from "./frame-metrics.js";
+
+export function stableCameraSweepTargets(sampleCount, cameraHeight) {
+  if (!Number.isSafeInteger(sampleCount) || sampleCount <= 0) {
+    throw new Error("sampleCount must be a positive integer");
+  }
+  if (!Number.isFinite(cameraHeight) || cameraHeight <= 0) {
+    throw new Error("cameraHeight must be positive and finite");
+  }
+
+  // Keep the motion deliberately small so the benchmark changes only camera
+  // uniforms while preserving the same visible candidate/painter topology.
+  const xAmplitude = cameraHeight * 0.01;
+  const yAmplitude = cameraHeight * 0.006;
+  return Array.from({ length: sampleCount }, (_, index) => {
+    const phase = (index / sampleCount) * Math.PI * 2;
+    return {
+      x: Math.cos(phase) * xAmplitude,
+      y: Math.sin(phase) * yAmplitude,
+    };
+  });
+}
+
+export function summarizeStableCameraProfile(samples) {
+  if (!Array.isArray(samples) || samples.length === 0) {
+    throw new Error("camera profile requires at least one sample");
+  }
+
+  const drawCalls = uniqueFiniteMetric(samples, "drawCalls");
+  const instances = uniqueFiniteMetric(samples, "instances");
+  if (drawCalls.size !== 1 || instances.size !== 1) {
+    throw new Error(
+      "camera profile changed visible draw topology; increase camera margin or inspect culling",
+    );
+  }
+
+  return {
+    samples: samples.length,
+    stableDrawCalls: [...drawCalls][0],
+    stableInstances: [...instances][0],
+    timeToVisibleMs: summarizeSamples(samples.map(({ timeToVisibleMs }) => timeToVisibleMs)),
+    runtimeMs: summarizeSamples(samples.map(({ frame }) => frame.runtimeMs)),
+    prepareMs: summarizeSamples(samples.map(({ frame }) => frame.prepareMs)),
+    uploadMs: summarizeSamples(samples.map(({ frame }) => frame.uploadMs)),
+    encodeSubmitMs: summarizeSamples(samples.map(({ frame }) => frame.encodeSubmitMs)),
+    uploadBytes: summarizeSamples(samples.map(({ frame }) => frame.uploadBytes)),
+  };
+}
+
+function uniqueFiniteMetric(samples, name) {
+  const values = new Set();
+  for (const { frame } of samples) {
+    const value = frame?.[name];
+    if (!Number.isFinite(value) || value < 0) {
+      throw new Error(`camera profile sample has invalid ${name}`);
+    }
+    values.add(value);
+  }
+  return values;
+}

--- a/web/authoring-perf-scenarios.test.mjs
+++ b/web/authoring-perf-scenarios.test.mjs
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  stableCameraSweepTargets,
+  summarizeStableCameraProfile,
+} from "./authoring-perf-scenarios.js";
+
+test("stable camera sweep is deterministic, bounded, and closes one orbit", () => {
+  const targets = stableCameraSweepTargets(4, 10);
+  assert.equal(targets.length, 4);
+  assert.deepEqual(targets[0], { x: 0.1, y: 0 });
+  assert.ok(Math.abs(targets[1].x) < 1e-12);
+  assert.equal(targets[1].y, 0.06);
+  assert.equal(targets[2].x, -0.1);
+  assert.ok(Math.abs(targets[2].y) < 1e-12);
+  assert.ok(Math.abs(targets[3].x) < 1e-12);
+  assert.equal(targets[3].y, -0.06);
+});
+
+test("stable camera profile summarizes command work without hiding topology changes", () => {
+  const sample = (encodeSubmitMs, uploadBytes) => ({
+    timeToVisibleMs: encodeSubmitMs + 1,
+    frame: {
+      runtimeMs: 0.1,
+      prepareMs: 0.2,
+      uploadMs: 0.3,
+      encodeSubmitMs,
+      uploadBytes,
+      drawCalls: 2,
+      instances: 1000,
+    },
+  });
+
+  const summary = summarizeStableCameraProfile([sample(0.4, 64), sample(0.6, 128)]);
+  assert.equal(summary.samples, 2);
+  assert.equal(summary.stableDrawCalls, 2);
+  assert.equal(summary.stableInstances, 1000);
+  assert.equal(summary.encodeSubmitMs.min, 0.4);
+  assert.equal(summary.encodeSubmitMs.max, 0.6);
+  assert.equal(summary.uploadBytes.min, 64);
+  assert.equal(summary.uploadBytes.max, 128);
+
+  assert.throws(
+    () =>
+      summarizeStableCameraProfile([
+        sample(0.4, 64),
+        {
+          ...sample(0.5, 64),
+          frame: { ...sample(0.5, 64).frame, drawCalls: 3 },
+        },
+      ]),
+    /changed visible draw topology/,
+  );
+});
+
+test("stable camera helpers reject invalid benchmark inputs", () => {
+  assert.throws(() => stableCameraSweepTargets(0, 10), /positive integer/);
+  assert.throws(() => stableCameraSweepTargets(4, Number.NaN), /positive and finite/);
+  assert.throws(() => summarizeStableCameraProfile([]), /at least one sample/);
+  assert.throws(
+    () =>
+      summarizeStableCameraProfile([
+        {
+          timeToVisibleMs: 1,
+          frame: {
+            runtimeMs: 0,
+            prepareMs: 0,
+            uploadMs: 0,
+            encodeSubmitMs: 0,
+            uploadBytes: 0,
+            drawCalls: Number.NaN,
+            instances: 1,
+          },
+        },
+      ]),
+    /invalid drawCalls/,
+  );
+});

--- a/web/authoring-perf.js
+++ b/web/authoring-perf.js
@@ -1,6 +1,10 @@
 import init, { NoonCanvasPlayer } from "./pkg/noon_web.js";
 import { PythonAuthoringClient } from "./authoring-client.js";
 import { BrowserJankMonitor } from "./browser-jank.js";
+import {
+  stableCameraSweepTargets,
+  summarizeStableCameraProfile,
+} from "./authoring-perf-scenarios.js";
 import { summarizeSamples } from "./frame-metrics.js";
 import { SceneIdentityMap } from "./scene-identity.js";
 
@@ -8,6 +12,7 @@ const parameters = new URLSearchParams(location.search);
 const objectCount = positiveInteger("objects", 1_000);
 const samples = positiveInteger("samples", 5);
 const scrubSamples = positiveInteger("scrubs", 20);
+const cameraSamples = positiveInteger("camera_samples", 30);
 const canvas = document.querySelector("#scene");
 const status = document.querySelector("#status");
 const output = document.querySelector("#json");
@@ -40,6 +45,9 @@ try {
   status.value = `Scrub/seek profile · ${scrubSamples} samples…`;
   const scrubs = profileScrubs(scrubSamples);
 
+  status.value = `Stable camera profile · ${cameraSamples} samples…`;
+  const cameraSweep = profileStableCamera(cameraSamples);
+
   const report = {
     schemaVersion: 1,
     benchmark: "Noon interactive authoring time-to-visible profile",
@@ -55,20 +63,24 @@ try {
       objects: objectCount,
       warmSamples: samples,
       scrubSamples,
+      cameraSamples,
       source: "python/examples/authoring_perf_scene.py",
       localEdit: "one stable-identity circle changes fill color",
+      stableCamera: "camera center moves while visible draw topology remains unchanged",
     },
     cold,
     warmUnchanged: summarizeOperations(unchanged),
     oneObjectEdit: summarizeOperations(localEdit),
     scrub: summarizeScrubs(scrubs),
+    stableCamera: summarizeStableCameraProfile(cameraSweep),
   };
 
   window.__NOON_AUTHORING_PERF__ = report;
   output.textContent = JSON.stringify(report, null, 2);
   status.value =
     `Complete · unchanged visible p95 ${format(report.warmUnchanged.timeToVisibleMs?.p95)} ms · ` +
-    `one-object edit p95 ${format(report.oneObjectEdit.timeToVisibleMs?.p95)} ms`;
+    `one-object edit p95 ${format(report.oneObjectEdit.timeToVisibleMs?.p95)} ms · ` +
+    `camera encode/submit p95 ${format(report.stableCamera.encodeSubmitMs?.p95)} ms`;
   status.dataset.state = "complete";
   console.log("NOON_AUTHORING_PERF", report);
 } catch (error) {
@@ -207,6 +219,38 @@ function profileScrubs(count) {
       frame: frameSnapshot(elapsed),
     });
   }
+  return results;
+}
+
+function profileStableCamera(count) {
+  const results = [];
+  const normalHeight = cameraHeight(objectCount);
+  const benchmarkHeight = normalHeight * 1.2;
+  const targets = stableCameraSweepTargets(count, benchmarkHeight);
+
+  player.resetClock();
+  player.setCamera(0, 0, benchmarkHeight);
+  if (!player.renderFrame(0)) {
+    throw new Error("camera benchmark bootstrap frame was not presented");
+  }
+
+  for (const target of targets) {
+    const started = performance.now();
+    player.setCamera(target.x, target.y, benchmarkHeight);
+    const presented = player.renderFrame(0);
+    const elapsed = performance.now() - started;
+    if (!presented) {
+      throw new Error("camera update did not present a frame");
+    }
+    results.push({
+      center: [target.x, target.y],
+      timeToVisibleMs: elapsed,
+      frame: frameSnapshot(elapsed),
+    });
+  }
+
+  player.setCamera(0, 0, normalHeight);
+  player.renderFrame(0);
   return results;
 }
 


### PR DESCRIPTION
## Summary
- extend the existing authoring performance harness with the semantic-camera scenario required by #847
- move the camera over a large retained analytic scene while holding camera height and scene content stable
- use extra framing margin and fail the benchmark if draw-call or instance counts change, so the sample cannot silently turn into a culling/topology benchmark
- record time-to-visible, runtime evaluation, frame preparation, upload work/bytes, and CPU encode/submit time from the existing renderer metrics
- expose camera sample count through the existing CLI/environment-driven benchmark runner and JSON artifact

## Architecture
This is deliberately measurement-only. It does not add render-bundle production state, a speculative draw-plan cache, renderer-owned visibility state, or WebGL behavior. The benchmark consumes existing `NoonCanvasPlayer` metrics and keeps the new scenario logic in a small reusable module.

## Focused tests
`web/authoring-perf-scenarios.test.mjs` covers deterministic bounded camera targets, metric summarization, fail-closed topology changes, and malformed inputs. The test is auto-discovered by the normal web preflight.

## Scope / remaining work
This completes one of #847's required benchmark scenarios: semantic-camera movement over otherwise unchanged visible topology. The transform-only, unique-path/mega-mesh, text-heavy, mixed painter-order, deliberate visibility-invalidation, and small-scene bookkeeping scenarios remain before an adopt/defer decision can be made.

Exact head: `719f83eb865643b82140a9d093b08ba86291d97c` (one commit directly on current master at branch creation).

Tracks #847.