### PR TITLE
Add Manim-compatible mixed-object stress demo

### DIFF
--- a/parity/manim-v0.21/manifest.json
+++ b/parity/manim-v0.21/manifest.json
@@ -309,6 +309,18 @@
       "id": "moving-camera-center",
       "scene": "MovingCameraCenter",
       "expected_duration": 2.6
+    },
+    {
+      "id": "mixed-object-parity-stress",
+      "scene": "MixedObjectParityStress",
+      "source": "parity/manim-v0.21/stress-examples/mixed_object_parity_stress.py",
+      "expected_duration": 5.0,
+      "stress": true,
+      "raster_tolerance": {
+        "max_bounds_delta_px": null,
+        "max_differing_ratio": 0.12,
+        "max_mean_absolute_channel_error": 8.0
+      }
     }
   ],
   "sample_fractions": [

--- a/parity/manim-v0.21/stress-examples/mixed_object_parity_stress.py
+++ b/parity/manim-v0.21/stress-examples/mixed_object_parity_stress.py
@@ -1,0 +1,132 @@
+from manim import *
+
+
+class MixedObjectParityStress(Scene):
+    def construct(self):
+        rows = 6
+        cols = 12
+        palette = [BLUE, TEAL, GREEN, YELLOW, ORANGE, RED, PINK, PURPLE]
+        font = "DejaVu Sans Mono"
+
+        title = Text(
+            "MANIM PARITY STRESS",
+            font=font,
+            font_size=34,
+            color=WHITE,
+        ).shift(3.25 * UP)
+        subtitle = Text(
+            "72 shapes | morph | rotate | color | text | lifecycle",
+            font=font,
+            font_size=17,
+            color=GRAY_B,
+        ).shift(2.72 * UP)
+
+        shapes = []
+        targets = []
+        x_spacing = 0.90
+        y_spacing = 0.72
+        x_origin = -0.5 * (cols - 1) * x_spacing
+        y_origin = 1.52
+
+        for row in range(rows):
+            for col in range(cols):
+                index = row * cols + col
+                color = palette[index % len(palette)]
+                target_color = palette[(index + 3) % len(palette)]
+                point = (x_origin + col * x_spacing) * RIGHT + (
+                    y_origin - row * y_spacing
+                ) * UP
+
+                if (row + col) % 2 == 0:
+                    shape = Square(
+                        side_length=0.42,
+                        fill_color=color,
+                        fill_opacity=0.58,
+                        stroke_color=color,
+                        stroke_width=2,
+                    )
+                    target = Circle(
+                        radius=0.23,
+                        fill_color=target_color,
+                        fill_opacity=0.88,
+                        stroke_color=target_color,
+                        stroke_width=2,
+                    )
+                else:
+                    shape = Circle(
+                        radius=0.21,
+                        fill_color=color,
+                        fill_opacity=0.58,
+                        stroke_color=color,
+                        stroke_width=2,
+                    )
+                    target = Square(
+                        side_length=0.46,
+                        fill_color=target_color,
+                        fill_opacity=0.88,
+                        stroke_color=target_color,
+                        stroke_width=2,
+                    ).rotate(PI / 4)
+
+                shape.move_to(point)
+                target.move_to(point + (0.07 if row % 2 == 0 else -0.07) * RIGHT)
+                shapes.append(shape)
+                targets.append(target)
+
+        self.play(
+            Create(title),
+            FadeIn(subtitle),
+            *[Create(shape) for shape in shapes],
+            run_time=1.0,
+        )
+
+        self.play(
+            *[
+                Transform(shape, target)
+                for shape, target in zip(shapes, targets)
+            ],
+            title.animate.set_color(YELLOW),
+            run_time=1.2,
+        )
+
+        motion = []
+        for index, shape in enumerate(shapes):
+            angle = PI / 2 if index % 2 == 0 else -PI / 2
+            direction = UP if (index // cols) % 2 == 0 else DOWN
+            color = palette[(index + 5) % len(palette)]
+            motion.append(
+                shape.animate.rotate(angle).shift(0.11 * direction).set_color(color)
+            )
+
+        self.play(
+            *motion,
+            title.animate.rotate(PI / 18).set_color(PINK),
+            subtitle.animate.set_color(TEAL),
+            run_time=1.2,
+        )
+
+        leaving = shapes[::2]
+        pulses = [
+            Circle(
+                radius=0.085,
+                fill_color=WHITE,
+                fill_opacity=1.0,
+                stroke_opacity=0.0,
+            ).move_to(shape.get_center())
+            for shape in leaving
+        ]
+
+        self.play(
+            *[FadeOut(shape, scale=0.35) for shape in leaving],
+            *[FadeIn(pulse, scale=0.2) for pulse in pulses],
+            FadeOut(subtitle),
+            run_time=0.8,
+        )
+
+        self.play(
+            *[FadeIn(shape, scale=0.35) for shape in leaving],
+            *[FadeOut(pulse, scale=1.8) for pulse in pulses],
+            FadeIn(subtitle),
+            title.animate.rotate(-PI / 18).set_color(WHITE),
+            run_time=0.8,
+        )

--- a/web/example-gallery.js
+++ b/web/example-gallery.js
@@ -1,6 +1,10 @@
 const MANIM_REUSE = "source-equivalent-manim-v0.21";
+const MANIM_PARITY_REUSE = "manim-compatible-parity-v0.21";
+const READY_REUSE = new Set([MANIM_REUSE, MANIM_PARITY_REUSE]);
 const READY_PARITY = new Set(["candidate", "parity-qualified"]);
 const THUMBNAIL_FALLBACK_MARKER = "noonThumbnailFallbackInstalled";
+const DEFAULT_GALLERY_MANIFEST = "./python/examples/manim_tutorial_manifest.json";
+const STRESS_GALLERY_MANIFEST = "./python/examples/manim_stress_manifest.json";
 
 if (typeof document !== "undefined") {
   installGalleryThumbnailFallback(document);
@@ -25,9 +29,9 @@ export function normalizeGalleryManifest(manifest) {
     if (entry.status !== "ready") {
       continue;
     }
-    if (entry.reuse !== MANIM_REUSE) {
+    if (!READY_REUSE.has(entry.reuse)) {
       throw new Error(
-        `${entry.id}: runnable gallery examples must be source-equivalent ManimCE v0.21 scenes`,
+        `${entry.id}: runnable gallery examples must be source-equivalent ManimCE v0.21 scenes or custom Manim-compatible parity workloads`,
       );
     }
     if (!READY_PARITY.has(entry.parity_status)) {
@@ -51,6 +55,7 @@ export function normalizeGalleryManifest(manifest) {
       category: entry.category ?? "manim",
       features: [...entry.features],
       upstream: entry.upstream ?? null,
+      reuse: entry.reuse,
       parityStatus: entry.parity_status,
       parityFixture: entry.parity_fixture ?? null,
       thumbnail: `./${entry.thumbnail}`,
@@ -67,18 +72,40 @@ export function normalizeGalleryManifest(manifest) {
   };
 }
 
+async function fetchGalleryManifest(url, fetchImpl) {
+  const response = await fetchImpl(url);
+  if (!response.ok) {
+    throw new Error(`Unable to load Manim example manifest ${url}: HTTP ${response.status}`);
+  }
+  return response.json();
+}
+
 export async function loadGalleryManifest(
-  url = "./python/examples/manim_tutorial_manifest.json",
+  url = DEFAULT_GALLERY_MANIFEST,
   fetchImpl = globalThis.fetch,
 ) {
   if (typeof fetchImpl !== "function") {
     throw new TypeError("loadGalleryManifest requires fetch");
   }
-  const response = await fetchImpl(url);
-  if (!response.ok) {
-    throw new Error(`Unable to load Manim example manifest: HTTP ${response.status}`);
+
+  const manifest = await fetchGalleryManifest(url, fetchImpl);
+  if (url !== DEFAULT_GALLERY_MANIFEST) {
+    return normalizeGalleryManifest(manifest);
   }
-  return normalizeGalleryManifest(await response.json());
+
+  const stressManifest = await fetchGalleryManifest(STRESS_GALLERY_MANIFEST, fetchImpl);
+  const referenceVersion = manifest.reference?.version ?? null;
+  const stressVersion = stressManifest.reference?.version ?? null;
+  if (stressVersion !== referenceVersion) {
+    throw new Error(
+      `Manim stress manifest version ${stressVersion ?? "unknown"} does not match gallery version ${referenceVersion ?? "unknown"}`,
+    );
+  }
+
+  return normalizeGalleryManifest({
+    ...manifest,
+    entries: [...manifest.entries, ...stressManifest.entries],
+  });
 }
 
 export function galleryCategories(examples) {

--- a/web/python/examples/manim_parity_stress_grid.py
+++ b/web/python/examples/manim_parity_stress_grid.py
@@ -1,0 +1,132 @@
+from noon import *
+
+
+class MixedObjectParityStress(Scene):
+    def construct(self):
+        rows = 6
+        cols = 12
+        palette = [BLUE, TEAL, GREEN, YELLOW, ORANGE, RED, PINK, PURPLE]
+        font = "DejaVu Sans Mono"
+
+        title = Text(
+            "MANIM PARITY STRESS",
+            font=font,
+            font_size=34,
+            color=WHITE,
+        ).shift(3.25 * UP)
+        subtitle = Text(
+            "72 shapes | morph | rotate | color | text | lifecycle",
+            font=font,
+            font_size=17,
+            color=GRAY_B,
+        ).shift(2.72 * UP)
+
+        shapes = []
+        targets = []
+        x_spacing = 0.90
+        y_spacing = 0.72
+        x_origin = -0.5 * (cols - 1) * x_spacing
+        y_origin = 1.52
+
+        for row in range(rows):
+            for col in range(cols):
+                index = row * cols + col
+                color = palette[index % len(palette)]
+                target_color = palette[(index + 3) % len(palette)]
+                point = (x_origin + col * x_spacing) * RIGHT + (
+                    y_origin - row * y_spacing
+                ) * UP
+
+                if (row + col) % 2 == 0:
+                    shape = Square(
+                        side_length=0.42,
+                        fill_color=color,
+                        fill_opacity=0.58,
+                        stroke_color=color,
+                        stroke_width=2,
+                    )
+                    target = Circle(
+                        radius=0.23,
+                        fill_color=target_color,
+                        fill_opacity=0.88,
+                        stroke_color=target_color,
+                        stroke_width=2,
+                    )
+                else:
+                    shape = Circle(
+                        radius=0.21,
+                        fill_color=color,
+                        fill_opacity=0.58,
+                        stroke_color=color,
+                        stroke_width=2,
+                    )
+                    target = Square(
+                        side_length=0.46,
+                        fill_color=target_color,
+                        fill_opacity=0.88,
+                        stroke_color=target_color,
+                        stroke_width=2,
+                    ).rotate(PI / 4)
+
+                shape.move_to(point)
+                target.move_to(point + (0.07 if row % 2 == 0 else -0.07) * RIGHT)
+                shapes.append(shape)
+                targets.append(target)
+
+        self.play(
+            Create(title),
+            FadeIn(subtitle),
+            *[Create(shape) for shape in shapes],
+            run_time=1.0,
+        )
+
+        self.play(
+            *[
+                Transform(shape, target)
+                for shape, target in zip(shapes, targets)
+            ],
+            title.animate.set_color(YELLOW),
+            run_time=1.2,
+        )
+
+        motion = []
+        for index, shape in enumerate(shapes):
+            angle = PI / 2 if index % 2 == 0 else -PI / 2
+            direction = UP if (index // cols) % 2 == 0 else DOWN
+            color = palette[(index + 5) % len(palette)]
+            motion.append(
+                shape.animate.rotate(angle).shift(0.11 * direction).set_color(color)
+            )
+
+        self.play(
+            *motion,
+            title.animate.rotate(PI / 18).set_color(PINK),
+            subtitle.animate.set_color(TEAL),
+            run_time=1.2,
+        )
+
+        leaving = shapes[::2]
+        pulses = [
+            Circle(
+                radius=0.085,
+                fill_color=WHITE,
+                fill_opacity=1.0,
+                stroke_opacity=0.0,
+            ).move_to(shape.get_center())
+            for shape in leaving
+        ]
+
+        self.play(
+            *[FadeOut(shape, scale=0.35) for shape in leaving],
+            *[FadeIn(pulse, scale=0.2) for pulse in pulses],
+            FadeOut(subtitle),
+            run_time=0.8,
+        )
+
+        self.play(
+            *[FadeIn(shape, scale=0.35) for shape in leaving],
+            *[FadeOut(pulse, scale=1.8) for pulse in pulses],
+            FadeIn(subtitle),
+            title.animate.rotate(-PI / 18).set_color(WHITE),
+            run_time=0.8,
+        )

--- a/web/python/examples/manim_stress_manifest.json
+++ b/web/python/examples/manim_stress_manifest.json
@@ -1,0 +1,41 @@
+{
+  "reference": {
+    "project": "Manim Community",
+    "version": "0.21.0",
+    "kind": "custom-parity-workload"
+  },
+  "policy": "Ready stress workloads are ordinary ManimCE v0.21-compatible scenes. Their browser source must match the canonical Manim source byte-for-byte after replacing exactly `from manim import *` with `from noon import *`; they are not represented as upstream Manim documentation examples.",
+  "entries": [
+    {
+      "id": "manim-parity-stress-grid",
+      "title": "Mixed Object Parity Stress",
+      "summary": "A 72-shape Manim-compatible stress scene combining retained Text, mass Create, square/circle morphs, chained rotation/translation/color animation, and lifecycle FadeIn/FadeOut transitions.",
+      "status": "ready",
+      "path": "python/examples/manim_parity_stress_grid.py",
+      "category": "stress",
+      "features": [
+        "72 shapes",
+        "Text",
+        "Create",
+        "Transform",
+        "animate",
+        "rotation",
+        "color",
+        "FadeIn",
+        "FadeOut",
+        "retained-text",
+        "stress",
+        "pixel-parity",
+        "time-parity"
+      ],
+      "reuse": "manim-compatible-parity-v0.21",
+      "parity_status": "candidate",
+      "parity_fixture": "mixed-object-parity-stress",
+      "parity_source": "parity/manim-v0.21/stress-examples/mixed_object_parity_stress.py",
+      "thumbnail": "thumbnails/manim/parity-stress-grid.svg",
+      "thumbnail_alt": "Dense multicolor grid of squares and circles under a MANIM PARITY STRESS title",
+      "thumbnail_time": 2.8,
+      "order": 55
+    }
+  ]
+}

--- a/web/python/test_manim_stress_example.py
+++ b/web/python/test_manim_stress_example.py
@@ -1,0 +1,74 @@
+import ast
+import json
+import unittest
+from pathlib import Path
+
+WEB_ROOT = Path(__file__).parents[1]
+REPO_ROOT = WEB_ROOT.parent
+STRESS_MANIFEST_PATH = WEB_ROOT / "python" / "examples" / "manim_stress_manifest.json"
+PARITY_MANIFEST_PATH = REPO_ROOT / "parity" / "manim-v0.21" / "manifest.json"
+
+
+def adapt_manim_source(source: str) -> str:
+    marker = "from manim import *"
+    if source.count(marker) != 1:
+        raise AssertionError("canonical stress source must contain exactly one Manim star import")
+    return source.replace(marker, "from noon import *", 1)
+
+
+class ManimStressExampleTests(unittest.TestCase):
+    def test_ready_stress_scene_is_import_only_manim_source(self) -> None:
+        manifest = json.loads(STRESS_MANIFEST_PATH.read_text(encoding="utf-8"))
+        self.assertEqual(manifest["reference"]["version"], "0.21.0")
+        ready = [entry for entry in manifest["entries"] if entry["status"] == "ready"]
+        self.assertEqual(len(ready), 1)
+        entry = ready[0]
+        self.assertEqual(entry["reuse"], "manim-compatible-parity-v0.21")
+        self.assertEqual(entry["parity_status"], "candidate")
+        self.assertEqual(entry["parity_fixture"], "mixed-object-parity-stress")
+
+        demo_path = WEB_ROOT / entry["path"]
+        canonical_path = REPO_ROOT / entry["parity_source"]
+        self.assertTrue(demo_path.is_file())
+        self.assertTrue(canonical_path.is_file())
+        self.assertTrue((WEB_ROOT / entry["thumbnail"]).is_file())
+
+        canonical_source = canonical_path.read_text(encoding="utf-8")
+        demo_source = demo_path.read_text(encoding="utf-8")
+        self.assertEqual(demo_source, adapt_manim_source(canonical_source))
+        compile(ast.parse(canonical_source, filename=str(canonical_path)), str(canonical_path), "exec")
+        compile(ast.parse(demo_source, filename=str(demo_path)), str(demo_path), "exec")
+
+        for token in (
+            "Text(",
+            "Create(",
+            "Transform(",
+            ".animate.rotate(",
+            ".set_color(",
+            "FadeIn(",
+            "FadeOut(",
+        ):
+            self.assertIn(token, canonical_source)
+        self.assertIn("rows = 6", canonical_source)
+        self.assertIn("cols = 12", canonical_source)
+        self.assertNotIn("VectorPath", canonical_source)
+        self.assertNotIn("context", canonical_source)
+        self.assertNotIn("result =", canonical_source)
+
+    def test_stress_scene_is_linked_to_canonical_raster_fixture(self) -> None:
+        stress_manifest = json.loads(STRESS_MANIFEST_PATH.read_text(encoding="utf-8"))
+        entry = next(item for item in stress_manifest["entries"] if item["status"] == "ready")
+        parity_manifest = json.loads(PARITY_MANIFEST_PATH.read_text(encoding="utf-8"))
+        fixture = next(
+            item
+            for item in parity_manifest["fixtures"]
+            if item["id"] == entry["parity_fixture"]
+        )
+
+        self.assertEqual(fixture["scene"], "MixedObjectParityStress")
+        self.assertEqual(fixture["source"], entry["parity_source"])
+        self.assertEqual(fixture["expected_duration"], 5.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/stress-gallery.test.mjs
+++ b/web/stress-gallery.test.mjs
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+import { loadGalleryManifest, normalizeGalleryManifest } from "./example-gallery.js";
+
+const stressManifest = JSON.parse(
+  await readFile(new URL("./python/examples/manim_stress_manifest.json", import.meta.url), "utf8"),
+);
+const stressGallery = normalizeGalleryManifest(stressManifest);
+
+assert.equal(stressManifest.reference.version, "0.21.0");
+assert.equal(stressGallery.examples.length, 1);
+const stress = stressGallery.examples[0];
+assert.equal(stress.id, "manim-parity-stress-grid");
+assert.equal(stress.reuse, "manim-compatible-parity-v0.21");
+assert.equal(stress.parityStatus, "candidate");
+assert.equal(stress.parityFixture, "mixed-object-parity-stress");
+assert.equal(stress.category, "stress");
+assert.ok(stress.features.includes("Text"));
+assert.ok(stress.features.includes("Transform"));
+assert.ok(stress.features.includes("FadeIn"));
+assert.ok(stress.features.includes("FadeOut"));
+assert.ok(stress.features.includes("pixel-parity"));
+assert.ok(stress.features.includes("time-parity"));
+
+const canonicalSource = await readFile(
+  new URL("../parity/manim-v0.21/stress-examples/mixed_object_parity_stress.py", import.meta.url),
+  "utf8",
+);
+const noonSource = await readFile(
+  new URL("./python/examples/manim_parity_stress_grid.py", import.meta.url),
+  "utf8",
+);
+assert.equal(
+  canonicalSource.match(/from manim import \*/g)?.length,
+  1,
+  "canonical stress scene must have exactly one Manim star import",
+);
+assert.equal(
+  noonSource,
+  canonicalSource.replace("from manim import *", "from noon import *"),
+  "Noon stress demo must differ from canonical Manim source by the import only",
+);
+
+const primaryManifest = {
+  reference: { version: "0.21.0" },
+  entries: [
+    {
+      id: "base-example",
+      title: "Base example",
+      status: "ready",
+      reuse: "source-equivalent-manim-v0.21",
+      path: "python/examples/manim_base.py",
+      thumbnail: "thumbnails/manim/base.svg",
+      features: ["Circle"],
+      parity_status: "candidate",
+      order: 10,
+    },
+  ],
+};
+const requests = [];
+const merged = await loadGalleryManifest(undefined, async (url) => {
+  requests.push(url);
+  const manifest = url.endsWith("manim_stress_manifest.json") ? stressManifest : primaryManifest;
+  return {
+    ok: true,
+    status: 200,
+    async json() {
+      return manifest;
+    },
+  };
+});
+assert.deepEqual(requests, [
+  "./python/examples/manim_tutorial_manifest.json",
+  "./python/examples/manim_stress_manifest.json",
+]);
+assert.deepEqual(
+  merged.examples.map((example) => example.id),
+  ["base-example", "manim-parity-stress-grid"],
+  "default gallery load must merge and order custom stress workloads with the Manim corpus",
+);
+
+console.log("✓ custom Manim parity stress gallery contract");

--- a/web/thumbnails/manim/parity-stress-grid.svg
+++ b/web/thumbnails/manim/parity-stress-grid.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">Mixed Object Parity Stress</title>
+  <desc id="desc">Dense multicolor squares and circles representing the Manim parity stress scene.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#080b12"/>
+      <stop offset="1" stop-color="#151024"/>
+    </linearGradient>
+    <pattern id="tiles" width="80" height="56" patternUnits="userSpaceOnUse">
+      <rect x="7" y="8" width="24" height="24" rx="3" fill="#58c4dd" fill-opacity=".82" stroke="#9cdceb" stroke-width="2"/>
+      <circle cx="59" cy="20" r="13" fill="#83c167" fill-opacity=".82" stroke="#a6cf8c" stroke-width="2"/>
+      <circle cx="19" cy="49" r="12" fill="#d147bd" fill-opacity=".82" stroke="#dc75cd" stroke-width="2"/>
+      <rect x="47" y="37" width="24" height="24" rx="3" transform="rotate(45 59 49)" fill="#f7d96f" fill-opacity=".82" stroke="#ffea94" stroke-width="2"/>
+    </pattern>
+    <radialGradient id="glow" cx="50%" cy="45%" r="60%">
+      <stop offset="0" stop-color="#8e7cff" stop-opacity=".18"/>
+      <stop offset="1" stop-color="#8e7cff" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="640" height="360" fill="url(#bg)"/>
+  <rect width="640" height="360" fill="url(#glow)"/>
+  <text x="320" y="53" text-anchor="middle" fill="#f1f4fb" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="28" font-weight="700">MANIM PARITY STRESS</text>
+  <text x="320" y="78" text-anchor="middle" fill="#9aa7be" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="13">72 shapes · morph · rotate · color · text · lifecycle</text>
+  <rect x="47" y="101" width="546" height="213" rx="14" fill="#0c111b" stroke="#27334b"/>
+  <rect x="58" y="112" width="524" height="191" rx="8" fill="url(#tiles)"/>
+  <path d="M58 208 H582" stroke="#8e7cff" stroke-opacity=".28" stroke-width="2" stroke-dasharray="6 7"/>
+  <text x="320" y="339" text-anchor="middle" fill="#7f8ca5" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="12">same scene body in ManimCE 0.21 and Noon</text>
+</svg>


### PR DESCRIPTION
## Summary
- add `MixedObjectParityStress`, a 5.0s custom ManimCE v0.21-compatible workload with 72 shapes plus retained Text
- exercise mass `Create`, square/circle `Transform`, chained rotation/translation/color animation, and `FadeIn`/`FadeOut` lifecycle transitions
- keep a canonical `from manim import *` source and a browser `from noon import *` mirror whose bodies must remain byte-for-byte identical
- expose the workload in the demo through a separate custom-parity manifest instead of weakening the provenance rules for verbatim upstream Manim examples
- register `mixed-object-parity-stress` in the existing raster differential manifest so Manim Cairo and Noon can be sampled on the same timeline

## Parity/provenance
This is deliberately **not** labeled as an upstream Manim documentation example. It is a custom parity workload written against ordinary ManimCE APIs. Tests enforce that the Noon demo differs from the canonical Manim source only by replacing exactly `from manim import *` with `from noon import *`.

The raster fixture starts as `candidate` with deliberately loose stress-scene tolerances; it should expose/runtime-check the full scene now without claiming pixel qualification before measured convergence.

## Coverage
- JS gallery contract verifies default loading merges the separate stress manifest and preserves parity metadata
- Python contract verifies source import-only equivalence, syntax, Manim API coverage, 6x12 workload size, and raster fixture linkage
- existing upstream tutorial manifest remains untouched and retains its source-equivalent-only policy
