### PR TITLE
Gate canonical Manim raster differential before merge

### DIFF
--- a/.github/workflows/manim-raster-differential.yml
+++ b/.github/workflows/manim-raster-differential.yml
@@ -6,6 +6,11 @@ on:
       - master
     paths-ignore:
       - "crates/**/tests/**"
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - "crates/**/tests/**"
   workflow_dispatch:
 
 permissions:
@@ -29,6 +34,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Validate raster workflow trigger policy
+        run: node scripts/manim-raster-workflow-policy.test.mjs
       - name: Validate raster ratchet policy
         run: node scripts/manim-raster-policy.test.mjs
       - name: Set up Python

--- a/scripts/manim-raster-workflow-policy.test.mjs
+++ b/scripts/manim-raster-workflow-policy.test.mjs
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const workflowUrl = new URL(
+  "../.github/workflows/manim-raster-differential.yml",
+  import.meta.url,
+);
+const workflow = fs.readFileSync(workflowUrl, "utf8");
+const lines = workflow.split(/\r?\n/);
+
+function eventBlock(name) {
+  const marker = `  ${name}:`;
+  const start = lines.findIndex((line) => line === marker);
+  assert.notEqual(start, -1, `missing ${name} workflow trigger`);
+
+  let end = start + 1;
+  while (end < lines.length) {
+    const line = lines[end];
+    if (/^  [A-Za-z_][A-Za-z0-9_-]*:\s*$/.test(line)) {
+      break;
+    }
+    if (/^[A-Za-z_][A-Za-z0-9_-]*:\s*$/.test(line)) {
+      break;
+    }
+    end += 1;
+  }
+  return lines.slice(start + 1, end);
+}
+
+function listValues(block, key) {
+  const marker = `    ${key}:`;
+  const start = block.findIndex((line) => line === marker);
+  assert.notEqual(start, -1, `missing ${key} in workflow trigger`);
+
+  const values = [];
+  for (let index = start + 1; index < block.length; index += 1) {
+    const line = block[index];
+    if (/^    [A-Za-z_][A-Za-z0-9_-]*:\s*$/.test(line)) {
+      break;
+    }
+    const match = line.match(/^      -\s+["']?(.+?)["']?\s*$/);
+    if (match) {
+      values.push(match[1]);
+    }
+  }
+  return values;
+}
+
+const push = eventBlock("push");
+const pullRequest = eventBlock("pull_request");
+
+assert.deepEqual(
+  listValues(pullRequest, "branches"),
+  listValues(push, "branches"),
+  "push and pull_request branch filters must stay identical",
+);
+assert.deepEqual(
+  listValues(pullRequest, "paths-ignore"),
+  listValues(push, "paths-ignore"),
+  "push and pull_request path filters must stay identical",
+);
+assert.deepEqual(listValues(push, "branches"), ["master"]);
+assert.deepEqual(listValues(push, "paths-ignore"), ["crates/**/tests/**"]);
+assert.ok(
+  lines.includes("  workflow_dispatch:"),
+  "manual raster validation must remain available",
+);
+
+console.log("Manim raster workflow trigger policy is valid");


### PR DESCRIPTION
## Summary
- run the full canonical Manim raster differential on pull requests targeting `master`, in addition to the existing post-merge master run
- keep pull-request and push branch/path filters identical so the pre-merge oracle covers exactly the same source surface
- add a focused trigger-policy regression that fails if those filters drift or manual dispatch disappears
- leave every raster tolerance, fixture, backend, semantic-state capture, and direct-seek assertion unchanged

## Why
Current master `37d30f0b96c94079cfe6e631d75111d9543e613c` has a failing `Manim raster differential` run (`33590776739`) while the ordinary Manim semantic differential is green. #864 owns the immediate `GRAY_B` public-export defect, but the architectural CI gap is independent: `.github/workflows/manim-raster-differential.yml` only runs after pushes to `master` (or manual dispatch), so the exact oracle that found the regression could not prevent it from merging.

This PR moves that existing correctness boundary to PR time rather than weakening or duplicating the oracle. It is intentionally restricted to PRs targeting `master`; stacked feature PRs can continue using the fast gate until their final integration targets master.

## Validation
Opening this PR should itself trigger the new pull-request raster workflow because the workflow file is part of the change. The first step runs `scripts/manim-raster-workflow-policy.test.mjs`, which requires push/PR branch filters and `paths-ignore` filters to remain identical and preserves `workflow_dispatch`.

## Remaining risk / merge condition
The new raster job may reproduce the already-known master failure until #864 lands. Keep this PR draft while that known defect is active. Once #864 is merged, the unchanged raster oracle should become a true pre-merge gate for future canonical pixel/time regressions.

Related: #109, #116, #864.