### PR TITLE
Guard retained first-run engine selection

### DIFF
--- a/web/playground-retained-first-run-mode.test.mjs
+++ b/web/playground-retained-first-run-mode.test.mjs
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const mainSource = await readFile(new URL("./main.js", import.meta.url), "utf8");
+
+function sourceBetween(source, startMarker, endMarker) {
+  const start = source.indexOf(startMarker);
+  const end = source.indexOf(endMarker, start + startMarker.length);
+  assert.ok(start >= 0 && end > start, `expected source boundary ${startMarker}`);
+  return source.slice(start, end);
+}
+
+const runScene = sourceBetween(
+  mainSource,
+  "async function runScene()",
+  "\nasync function selectExample(",
+);
+const runtimeReady = sourceBetween(
+  mainSource,
+  "async function ensureRuntimeReady(",
+  "\nasync function ensureExecutionReady()",
+);
+
+const authoring = runScene.indexOf("authored = await client.run(source");
+const runtimeStart = runScene.indexOf("result = await ensureRuntimeReady({");
+assert.ok(authoring >= 0, "first run must author the selected source");
+assert.ok(runtimeStart > authoring, "execution startup must not serialize source authoring behind an empty runtime");
+
+assert.match(
+  runScene,
+  /const startRetained = sceneSpecJson !== null;/u,
+  "the authored canonical SceneSpec must select retained startup",
+);
+assert.match(
+  runScene,
+  /ensureRuntimeReady\(\{[\s\S]*sceneJson,[\s\S]*sceneSpecJson,[\s\S]*startRetained,/u,
+  "first-run mode selection must be passed into runtime startup",
+);
+
+const retainedBranch = runtimeReady.match(
+  /const ready = startRetained\s*\?([\s\S]*?)\s*:\s*await nextPlayer\.start\(sceneJson/u,
+);
+assert.ok(retainedBranch, "runtime startup must branch between retained and legacy modes");
+assert.match(
+  retainedBranch[1],
+  /await nextPlayer\.startRetainedCanonical\(sceneSpecJson,/u,
+  "a retained first run must start the retained engine directly from the canonical SceneSpec",
+);
+assert.doesNotMatch(
+  retainedBranch[1],
+  /nextPlayer\.start\(sceneJson/u,
+  "a retained first run must not bootstrap a legacy engine before retained startup",
+);
+
+console.log("✓ retained first run authors before startup and boots only the retained engine");


### PR DESCRIPTION
## Summary

Add a focused cold-start architecture regression for #642.

The playground already has the desired first-run topology on current `master`: it authors the selected Python source before constructing the execution runtime, derives `startRetained` from the canonical `SceneSpec`, and starts retained scenes directly with `startRetainedCanonical(...)` rather than booting an empty legacy engine first.

This PR ratchets that contract so later startup refactors cannot silently reintroduce the duplicate/wrong-engine cold path.

## Coverage

The new auto-discovered Node test verifies:
- selected-source authoring precedes first execution-runtime startup;
- canonical `SceneSpec` presence selects retained mode;
- the mode decision is carried into `ensureRuntimeReady`;
- retained first run invokes `startRetainedCanonical(sceneSpecJson, ...)` directly;
- the retained branch cannot invoke legacy `start(sceneJson, ...)` first.

No runtime behavior or renderer code changes are included, so this stays independent of active #854 callback-startup work and the current retained text/raster lanes.

## Remaining #642 work

This closes only the explicit regression gate for the already-landed author-before-runtime / correct-first-engine topology. WASM package duplication, phase timing/measurement, and further worker-startup reduction remain separate performance work and should be driven by measurement rather than preload hacks.