### PR TITLE
Surface mixed-object stress demo near top of gallery

### DIFF
--- a/web/python/examples/manim_stress_manifest.json
+++ b/web/python/examples/manim_stress_manifest.json
@@ -35,7 +35,7 @@
       "thumbnail": "thumbnails/manim/parity-stress-grid.svg",
       "thumbnail_alt": "Dense multicolor grid of squares and circles under a MANIM PARITY STRESS title",
       "thumbnail_time": 2.8,
-      "order": 55
+      "order": 15
     }
   ]
 }

--- a/web/stress-gallery.test.mjs
+++ b/web/stress-gallery.test.mjs
@@ -16,6 +16,7 @@ assert.equal(stress.reuse, "manim-compatible-parity-v0.21");
 assert.equal(stress.parityStatus, "candidate");
 assert.equal(stress.parityFixture, "mixed-object-parity-stress");
 assert.equal(stress.category, "stress");
+assert.equal(stress.order, 15, "stress workload should sit directly behind the default example");
 assert.ok(stress.features.includes("Text"));
 assert.ok(stress.features.includes("Transform"));
 assert.ok(stress.features.includes("FadeIn"));


### PR DESCRIPTION
The stress demo was deployed successfully but was easy to miss in the mobile gallery because it appeared after five other cards. Move `Mixed Object Parity Stress` directly behind the default example while keeping `CreateCircle` as the landing/default scene. Add a contract assertion for the placement so future ordering changes do not bury the stress workload again.