### PR TITLE
Ratchet exact geometry qualification evidence

### DIFF
--- a/parity/manim-v0.21/geometry-qualification.json
+++ b/parity/manim-v0.21/geometry-qualification.json
@@ -1,0 +1,18 @@
+{
+  "reference": {
+    "project": "Manim Community",
+    "version": "0.21.0",
+    "renderer": "cairo",
+    "tracking_issue": "#401"
+  },
+  "qualified": [
+    {
+      "symbol": "Dot",
+      "fixture": "dot-ellipse-parity"
+    },
+    {
+      "symbol": "Ellipse",
+      "fixture": "dot-ellipse-parity"
+    }
+  ]
+}

--- a/web/manim-geometry-qualification.test.mjs
+++ b/web/manim-geometry-qualification.test.mjs
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const qualificationUrl = new URL(
+  "../parity/manim-v0.21/geometry-qualification.json",
+  import.meta.url,
+);
+const rasterManifestUrl = new URL(
+  "../parity/manim-v0.21/manifest.json",
+  import.meta.url,
+);
+const sourceUrl = new URL("../parity/manim-v0.21/quickstart.py", import.meta.url);
+const coverageUrl = new URL("../compat/manim-v0.21.0.json", import.meta.url);
+
+async function readJson(url) {
+  return JSON.parse(await readFile(url, "utf8"));
+}
+
+test("qualified geometry is backed by a canonical raster/timeline fixture", async () => {
+  const [qualification, rasterManifest, coverage, source] = await Promise.all([
+    readJson(qualificationUrl),
+    readJson(rasterManifestUrl),
+    readJson(coverageUrl),
+    readFile(sourceUrl, "utf8"),
+  ]);
+
+  assert.equal(qualification.reference.project, "Manim Community");
+  assert.equal(qualification.reference.version, "0.21.0");
+  assert.equal(qualification.reference.renderer, "cairo");
+
+  const fixtures = new Map(
+    rasterManifest.fixtures.map((fixture) => [fixture.id, fixture]),
+  );
+  const seenSymbols = new Set();
+
+  for (const entry of qualification.qualified) {
+    assert.equal(
+      seenSymbols.has(entry.symbol),
+      false,
+      `duplicate geometry qualification for ${entry.symbol}`,
+    );
+    seenSymbols.add(entry.symbol);
+
+    const publicStatus = coverage.overrides[entry.symbol];
+    assert.ok(publicStatus, `missing compatibility entry for ${entry.symbol}`);
+    assert.equal(publicStatus.category, "geometry");
+    assert.equal(
+      publicStatus.status,
+      "supported",
+      `${entry.symbol} cannot be exact-output-qualified before it is public and supported`,
+    );
+
+    const fixture = fixtures.get(entry.fixture);
+    assert.ok(
+      fixture,
+      `${entry.symbol} qualification references unknown fixture ${entry.fixture}`,
+    );
+    assert.ok(
+      Number.isFinite(fixture.expected_duration) && fixture.expected_duration > 0,
+      `${entry.fixture} must participate in the timeline oracle`,
+    );
+    assert.match(
+      source,
+      new RegExp(`class\\s+${fixture.scene}\\s*\\(Scene\\):`),
+      `${entry.fixture} must resolve to canonical Manim source`,
+    );
+  }
+});
+
+test("canonical geometry support claims are recorded in the qualification ledger", async () => {
+  const [qualification, coverage] = await Promise.all([
+    readJson(qualificationUrl),
+    readJson(coverageUrl),
+  ]);
+  const qualified = new Set(qualification.qualified.map((entry) => entry.symbol));
+
+  for (const [symbol, status] of Object.entries(coverage.overrides)) {
+    if (
+      status.category === "geometry" &&
+      status.status === "supported" &&
+      String(status.evidence ?? "").toLowerCase().includes("canonical")
+    ) {
+      assert.ok(
+        qualified.has(symbol),
+        `${symbol} claims canonical exact-output evidence but has no #401 qualification record`,
+      );
+    }
+  }
+});


### PR DESCRIPTION
Tracks #401.

## Summary
- add a small machine-readable geometry qualification ledger for the #76 families that are already exact-output qualified on current master (`Dot` and `Ellipse`)
- tie each qualified public symbol to the canonical `dot-ellipse-parity` ManimCE v0.21 fixture rather than relying on prose-only evidence
- add an auto-discovered Node regression that verifies the symbol is publicly `supported`, the referenced raster/timeline fixture exists with a positive duration, and its scene resolves to the checked-in canonical Manim source
- fail if a geometry compatibility entry claims canonical evidence without a corresponding #401 qualification record

## Architecture
This is qualification infrastructure only. It does not add frontend geometry, renderer primitives, tolerances, or Noon-specific fixture tuning, and it deliberately does not touch the active #400 adapter PRs for the remaining geometry families.

## Why this slice
#401 requires exact-output evidence to remain attached to the public support claim. `Dot`/`Ellipse` are already qualified, but that relationship was encoded only as free-form text in the compatibility manifest. This makes the relationship structured and CI-ratcheted so later #400/#401 slices can append qualified families without inventing another coverage mechanism.

## Validation
PR Fast Gate should auto-discover `web/manim-geometry-qualification.test.mjs`. The full Manim raster workflow is currently red on master for the separately-owned palette regression (#864/#865), so this PR does not alter or relax that gate.

## Remaining #401 scope
Arc/sector/annulus, polygon/polygram/star, rounded/matcher geometry, mixed style/ordering, and animated path qualification remain independent follow-up slices as their public #400 adapters land.