### PR TITLE
Run multiple canonical family animations in one retained scene

### DIFF
--- a/crates/noon-render-wgpu/src/gpu.rs
+++ b/crates/noon-render-wgpu/src/gpu.rs
@@ -7,6 +7,7 @@ mod retained_text {
         include!("gpu/retained_family_prepare.rs");
         include!("gpu/retained_family_draw_border_prepare.rs");
         include!("gpu/retained_family_animation_prepare.rs");
+        include!("gpu/retained_family_plan_set_prepare.rs");
     }
     pub use family_prepare::*;
 }

--- a/crates/noon-render-wgpu/src/gpu/retained_family_plan_set_prepare.rs
+++ b/crates/noon-render-wgpu/src/gpu/retained_family_plan_set_prepare.rs
@@ -143,7 +143,7 @@ impl RetainedFramePreparer {
         }
 
         let family_frame = frame.as_family_frame();
-        let baseline_sources = mem::take(&mut self.sources);
+        let baseline_sources = std::mem::take(&mut self.sources);
         self.sources.reserve(baseline_sources.len());
 
         for source in baseline_sources {
@@ -169,7 +169,7 @@ impl RetainedFramePreparer {
                     };
 
                     match state.mode {
-                        FamilyAnimationMode::Reveal => {
+                        noon_core::FamilyAnimationMode::Reveal => {
                             if let Some(reveal) = self.family_geometry_reveal(
                                 &family_frame,
                                 plan,
@@ -190,10 +190,13 @@ impl RetainedFramePreparer {
                                 kind,
                             });
                         }
-                        FamilyAnimationMode::DrawBorderThenFill => {
-                            return Err(RetainedFamilyDrawBorderPrepareError::
-                                UnsupportedTextOutlineBaseline(object_id)
-                                .into());
+                        noon_core::FamilyAnimationMode::DrawBorderThenFill => {
+                            return Err(
+                                RetainedFamilyDrawBorderPrepareError::UnsupportedTextOutlineBaseline(
+                                    object_id,
+                                )
+                                .into(),
+                            );
                         }
                     }
                 }
@@ -215,7 +218,7 @@ impl RetainedFramePreparer {
                     };
 
                     match state.mode {
-                        FamilyAnimationMode::Reveal => {
+                        noon_core::FamilyAnimationMode::Reveal => {
                             if self.family_text_run_needs_outline(
                                 &family_frame,
                                 plan,
@@ -240,7 +243,7 @@ impl RetainedFramePreparer {
                                 });
                             }
                         }
-                        FamilyAnimationMode::DrawBorderThenFill => {
+                        noon_core::FamilyAnimationMode::DrawBorderThenFill => {
                             if self.family_text_run_needs_draw_border_paths(
                                 &family_frame,
                                 plan,
@@ -277,8 +280,13 @@ fn selected_family_plan<'a>(
     frame: &RetainedPlannedFamilyFrame<'_>,
     plans: &'a [RetainedFamilyAnimationPlan],
     object_index: usize,
-) -> Result<Option<(FamilyAnimationState, &'a RetainedFamilyAnimationPlan)>, RetainedPlannedFamilyFrameError>
-{
+) -> Result<
+    Option<(
+        noon_core::FamilyAnimationState,
+        &'a RetainedFamilyAnimationPlan,
+    )>,
+    RetainedPlannedFamilyFrameError,
+> {
     let Some(state) = frame.family_animation(object_index) else {
         return Ok(None);
     };
@@ -286,7 +294,9 @@ fn selected_family_plan<'a>(
         .retained
         .objects
         .get(object_index)
-        .ok_or(RetainedPlannedFamilyFrameError::InvalidObjectIndex(object_index))?;
+        .ok_or(RetainedPlannedFamilyFrameError::InvalidObjectIndex(
+            object_index,
+        ))?;
     let plan_index = frame
         .family_plan_index(object_index)
         .ok_or(RetainedPlannedFamilyFrameError::MissingPlanIndex(object.id))?;

--- a/crates/noon-render-wgpu/src/gpu/retained_family_plan_set_prepare.rs
+++ b/crates/noon-render-wgpu/src/gpu/retained_family_plan_set_prepare.rs
@@ -1,0 +1,307 @@
+use noon_runtime::{RetainedPlannedFamilyFrame, RetainedPlannedFamilyFrameError};
+
+/// Failure while realizing multiple concurrently installed family plans.
+#[derive(Clone, Debug, PartialEq)]
+pub enum RetainedFamilyPlanSetPrepareError {
+    Retained(RetainedPrepareError),
+    PlannedFrame(RetainedPlannedFamilyFrameError),
+    Reveal(RetainedFamilyPrepareError),
+    DrawBorderThenFill(RetainedFamilyDrawBorderPrepareError),
+}
+
+impl std::fmt::Display for RetainedFamilyPlanSetPrepareError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Retained(error) => error.fmt(formatter),
+            Self::PlannedFrame(error) => error.fmt(formatter),
+            Self::Reveal(error) => error.fmt(formatter),
+            Self::DrawBorderThenFill(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl std::error::Error for RetainedFamilyPlanSetPrepareError {}
+
+impl From<RetainedPrepareError> for RetainedFamilyPlanSetPrepareError {
+    fn from(value: RetainedPrepareError) -> Self {
+        Self::Retained(value)
+    }
+}
+
+impl From<RetainedPlannedFamilyFrameError> for RetainedFamilyPlanSetPrepareError {
+    fn from(value: RetainedPlannedFamilyFrameError) -> Self {
+        Self::PlannedFrame(value)
+    }
+}
+
+impl From<RetainedFamilyPrepareError> for RetainedFamilyPlanSetPrepareError {
+    fn from(value: RetainedFamilyPrepareError) -> Self {
+        Self::Reveal(value)
+    }
+}
+
+impl From<RetainedFamilyDrawBorderPrepareError> for RetainedFamilyPlanSetPrepareError {
+    fn from(value: RetainedFamilyDrawBorderPrepareError) -> Self {
+        Self::DrawBorderThenFill(value)
+    }
+}
+
+impl RetainedFramePreparer {
+    /// Prepare a frame with any number of immutable family plans in one renderer pass.
+    ///
+    /// Runtime plan identity is selected per object, so disjoint active requests may
+    /// use different family operations concurrently. Sequential requests on the same
+    /// object likewise select their exact plan at each time. Existing reveal and
+    /// DrawBorderThenFill content realizers are reused; no scheduling semantics move
+    /// into the renderer.
+    #[allow(clippy::too_many_arguments)]
+    pub fn prepare_family_plan_set_with_changes<'a>(
+        &'a mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        frame: &RetainedPlannedFamilyFrame<'_>,
+        plans: &[RetainedFamilyAnimationPlan],
+        changes: &FrameChanges,
+        texts: &TextResourceArena,
+        fonts: &FontResourceArena,
+        geometries: &GeometryResourceArena,
+        metrics: TextDeviceMetrics,
+    ) -> Result<PreparedRetainedGpuFrame<'a>, RetainedFamilyPlanSetPrepareError> {
+        self.prepare_with_changes(
+            device,
+            queue,
+            frame.retained,
+            changes,
+            texts,
+            fonts,
+            geometries,
+            metrics,
+        )?;
+
+        self.prepared_generation_ready = false;
+        if let Err(error) = self.apply_family_plan_set_to_scratch(frame, plans, texts, fonts) {
+            self.scratch_ready = false;
+            return Err(error);
+        }
+
+        let geometry = self.geometry.prepare(&self.scratch);
+        self.render_items.clear();
+        rebuild_mixed_order(
+            &mut self.render_items,
+            &self.sources,
+            &self.snapshot_text_items,
+            &geometry,
+        );
+        let glyph_batches = self
+            .render_items
+            .iter()
+            .filter(|item| matches!(item, RetainedRenderItem::Glyph { .. }))
+            .count();
+        let outline_cache = self.outlines.stats();
+        let stats = RetainedPrepareStats {
+            semantic_objects: frame.retained.objects.len(),
+            geometry_slots: self.scratch.objects.len(),
+            glyph_batches,
+            vector_items: self.snapshot_text_stats.vector_items,
+            outline_runs: self.snapshot_text_stats.outline_runs,
+            outline_cache_hits: outline_cache.hits,
+            outline_cache_misses: outline_cache.misses,
+        };
+        self.snapshot_prepare_stats = stats;
+        self.snapshot_metrics = Some(metrics);
+        self.prepared_generation_ready = true;
+        self.scratch_ready = false;
+
+        let text = PreparedRetainedTextSnapshot {
+            time: frame.retained.time,
+            mask_quads: &self.snapshot_mask_quads,
+            color_quads: &self.snapshot_color_quads,
+            items: &self.snapshot_text_items,
+            stats: self.snapshot_text_stats,
+            atlas: self.text.atlas(),
+        };
+        Ok(PreparedRetainedGpuFrame {
+            geometry,
+            text_generation: self.text_generation,
+            text,
+            render_items: &self.render_items,
+            stats,
+        })
+    }
+
+    fn apply_family_plan_set_to_scratch(
+        &mut self,
+        frame: &RetainedPlannedFamilyFrame<'_>,
+        plans: &[RetainedFamilyAnimationPlan],
+        texts: &TextResourceArena,
+        fonts: &FontResourceArena,
+    ) -> Result<(), RetainedFamilyPlanSetPrepareError> {
+        if frame.family_animations.len() != frame.retained.objects.len()
+            || frame.family_plan_indices.len() != frame.retained.objects.len()
+        {
+            return Err(RetainedPlannedFamilyFrameError::FrameShapeMismatch.into());
+        }
+
+        let family_frame = frame.as_family_frame();
+        let baseline_sources = mem::take(&mut self.sources);
+        self.sources.reserve(baseline_sources.len());
+
+        for source in baseline_sources {
+            match source {
+                SourceItem::Geometry {
+                    object_id,
+                    scratch_id,
+                    kind,
+                } => {
+                    let object_index = frame
+                        .retained
+                        .objects
+                        .iter()
+                        .position(|object| object.id == object_id)
+                        .ok_or(RetainedFamilyPrepareError::MissingSourceObject(object_id))?;
+                    let Some((state, plan)) = selected_family_plan(frame, plans, object_index)? else {
+                        self.sources.push(SourceItem::Geometry {
+                            object_id,
+                            scratch_id,
+                            kind,
+                        });
+                        continue;
+                    };
+
+                    match state.mode {
+                        FamilyAnimationMode::Reveal => {
+                            if let Some(reveal) = self.family_geometry_reveal(
+                                &family_frame,
+                                plan,
+                                object_index,
+                                object_id,
+                            )? {
+                                let scratch_index = usize::try_from(scratch_id.get()).map_err(|_| {
+                                    RetainedFamilyPrepareError::MissingScratchObject(scratch_id)
+                                })?;
+                                let target = self.scratch.reveals.get_mut(scratch_index).ok_or(
+                                    RetainedFamilyPrepareError::MissingScratchObject(scratch_id),
+                                )?;
+                                *target = reveal;
+                            }
+                            self.sources.push(SourceItem::Geometry {
+                                object_id,
+                                scratch_id,
+                                kind,
+                            });
+                        }
+                        FamilyAnimationMode::DrawBorderThenFill => {
+                            return Err(RetainedFamilyDrawBorderPrepareError::
+                                UnsupportedTextOutlineBaseline(object_id)
+                                .into());
+                        }
+                    }
+                }
+                SourceItem::FastGlyphRun {
+                    object_id,
+                    object_index,
+                    run_index,
+                } => {
+                    let object_index_usize = object_index as usize;
+                    let Some((state, plan)) =
+                        selected_family_plan(frame, plans, object_index_usize)?
+                    else {
+                        self.sources.push(SourceItem::FastGlyphRun {
+                            object_id,
+                            object_index,
+                            run_index,
+                        });
+                        continue;
+                    };
+
+                    match state.mode {
+                        FamilyAnimationMode::Reveal => {
+                            if self.family_text_run_needs_outline(
+                                &family_frame,
+                                plan,
+                                object_index_usize,
+                                object_id,
+                                run_index,
+                            )? {
+                                self.push_family_glyph_run(
+                                    &family_frame,
+                                    plan,
+                                    object_index_usize,
+                                    object_id,
+                                    run_index,
+                                    texts,
+                                    fonts,
+                                )?;
+                            } else {
+                                self.sources.push(SourceItem::FastGlyphRun {
+                                    object_id,
+                                    object_index,
+                                    run_index,
+                                });
+                            }
+                        }
+                        FamilyAnimationMode::DrawBorderThenFill => {
+                            if self.family_text_run_needs_draw_border_paths(
+                                &family_frame,
+                                plan,
+                                object_index_usize,
+                                object_id,
+                                run_index,
+                            )? {
+                                self.push_family_draw_border_glyph_run(
+                                    &family_frame,
+                                    plan,
+                                    object_index_usize,
+                                    object_id,
+                                    run_index,
+                                    texts,
+                                    fonts,
+                                )?;
+                            } else {
+                                self.sources.push(SourceItem::FastGlyphRun {
+                                    object_id,
+                                    object_index,
+                                    run_index,
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+fn selected_family_plan<'a>(
+    frame: &RetainedPlannedFamilyFrame<'_>,
+    plans: &'a [RetainedFamilyAnimationPlan],
+    object_index: usize,
+) -> Result<Option<(FamilyAnimationState, &'a RetainedFamilyAnimationPlan)>, RetainedPlannedFamilyFrameError>
+{
+    let Some(state) = frame.family_animation(object_index) else {
+        return Ok(None);
+    };
+    let object = frame
+        .retained
+        .objects
+        .get(object_index)
+        .ok_or(RetainedPlannedFamilyFrameError::InvalidObjectIndex(object_index))?;
+    let plan_index = frame
+        .family_plan_index(object_index)
+        .ok_or(RetainedPlannedFamilyFrameError::MissingPlanIndex(object.id))?;
+    let plan = plans.get(plan_index as usize).ok_or(
+        RetainedPlannedFamilyFrameError::InvalidPlanIndex {
+            object: object.id,
+            plan_index,
+            plan_count: plans.len(),
+        },
+    )?;
+    if plan.leaf_for_object(object.id).is_none() {
+        return Err(RetainedPlannedFamilyFrameError::PlanDoesNotOwnObject {
+            object: object.id,
+            plan_index,
+        });
+    }
+    Ok(Some((state, plan)))
+}

--- a/crates/noon-runtime/src/reactive.rs
+++ b/crates/noon-runtime/src/reactive.rs
@@ -28,6 +28,14 @@ pub use retained_text_family::*;
 mod retained_family_plan_frame;
 pub use retained_family_plan_frame::*;
 
+#[path = "retained_family_plan_set_frame.rs"]
+mod retained_family_plan_set_frame;
+pub use retained_family_plan_set_frame::*;
+
 #[path = "retained_family_plan_runtime.rs"]
 mod retained_family_plan_runtime;
 pub use retained_family_plan_runtime::*;
+
+#[path = "retained_family_plan_set_runtime.rs"]
+mod retained_family_plan_set_runtime;
+pub use retained_family_plan_set_runtime::*;

--- a/crates/noon-runtime/src/retained_family_plan_set_frame.rs
+++ b/crates/noon-runtime/src/retained_family_plan_set_frame.rs
@@ -1,0 +1,130 @@
+use noon_core::{
+    FamilyAnimationState, RetainedFamilyAnimationPlan, RetainedFamilyLeafFrame,
+};
+
+use crate::{RetainedFamilyFrame, RetainedFamilyFramePlanError, RetainedFrameState};
+
+/// Retained family frame with explicit immutable-plan ownership per active object.
+///
+/// Multiple family requests may reference the same retained object at different times.
+/// The evaluated family state alone therefore cannot identify which immutable member
+/// plan owns that state. `family_plan_indices` carries the snapshot-installed plan
+/// index selected by the runtime for each object. Renderer code never guesses plan
+/// identity from object membership.
+#[derive(Clone, Copy, Debug)]
+pub struct RetainedPlannedFamilyFrame<'a> {
+    pub retained: &'a RetainedFrameState,
+    pub family_animations: &'a [Option<FamilyAnimationState>],
+    pub family_plan_indices: &'a [Option<u32>],
+}
+
+impl RetainedPlannedFamilyFrame<'_> {
+    pub fn family_animation(&self, object_index: usize) -> Option<FamilyAnimationState> {
+        self.family_animations.get(object_index).copied().flatten()
+    }
+
+    pub fn family_plan_index(&self, object_index: usize) -> Option<u32> {
+        self.family_plan_indices.get(object_index).copied().flatten()
+    }
+
+    pub fn as_family_frame(&self) -> RetainedFamilyFrame<'_> {
+        RetainedFamilyFrame {
+            retained: self.retained,
+            family_animations: self.family_animations,
+        }
+    }
+
+    pub fn planned_family_leaf(
+        &self,
+        plans: &[RetainedFamilyAnimationPlan],
+        object_index: usize,
+    ) -> Result<Option<RetainedFamilyLeafFrame>, RetainedPlannedFamilyFrameError> {
+        if self.family_animations.len() != self.retained.objects.len()
+            || self.family_plan_indices.len() != self.retained.objects.len()
+        {
+            return Err(RetainedPlannedFamilyFrameError::FrameShapeMismatch);
+        }
+        let Some(state) = self.family_animation(object_index) else {
+            return Ok(None);
+        };
+        let object = self.retained.objects.get(object_index).ok_or(
+            RetainedPlannedFamilyFrameError::InvalidObjectIndex(object_index),
+        )?;
+        let plan_index = self.family_plan_index(object_index).ok_or(
+            RetainedPlannedFamilyFrameError::MissingPlanIndex(object.id),
+        )?;
+        let plan = plans.get(plan_index as usize).ok_or(
+            RetainedPlannedFamilyFrameError::InvalidPlanIndex {
+                object: object.id,
+                plan_index,
+                plan_count: plans.len(),
+            },
+        )?;
+        if plan.leaf_for_object(object.id).is_none() {
+            return Err(RetainedPlannedFamilyFrameError::PlanDoesNotOwnObject {
+                object: object.id,
+                plan_index,
+            });
+        }
+        plan.leaf_frame_for_object(state, object.id)
+            .map_err(RetainedPlannedFamilyFrameError::Plan)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum RetainedPlannedFamilyFrameError {
+    FrameShapeMismatch,
+    InvalidObjectIndex(usize),
+    MissingPlanIndex(noon_core::ObjectId),
+    InvalidPlanIndex {
+        object: noon_core::ObjectId,
+        plan_index: u32,
+        plan_count: usize,
+    },
+    PlanDoesNotOwnObject {
+        object: noon_core::ObjectId,
+        plan_index: u32,
+    },
+    Plan(RetainedFamilyFramePlanError),
+}
+
+impl std::fmt::Display for RetainedPlannedFamilyFrameError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::FrameShapeMismatch => formatter.write_str(
+                "retained planned-family state shape does not match retained frame objects",
+            ),
+            Self::InvalidObjectIndex(index) => {
+                write!(formatter, "invalid retained planned-family object index {index}")
+            }
+            Self::MissingPlanIndex(object) => write!(
+                formatter,
+                "active retained family state for object {} has no plan index",
+                object.get()
+            ),
+            Self::InvalidPlanIndex {
+                object,
+                plan_index,
+                plan_count,
+            } => write!(
+                formatter,
+                "retained family object {} references plan index {plan_index}, but only {plan_count} plans are installed",
+                object.get()
+            ),
+            Self::PlanDoesNotOwnObject { object, plan_index } => write!(
+                formatter,
+                "retained family plan {plan_index} does not own object {}",
+                object.get()
+            ),
+            Self::Plan(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl std::error::Error for RetainedPlannedFamilyFrameError {}
+
+impl From<RetainedFamilyFramePlanError> for RetainedPlannedFamilyFrameError {
+    fn from(value: RetainedFamilyFramePlanError) -> Self {
+        Self::Plan(value)
+    }
+}

--- a/crates/noon-runtime/src/retained_family_plan_set_frame.rs
+++ b/crates/noon-runtime/src/retained_family_plan_set_frame.rs
@@ -37,11 +37,11 @@ impl RetainedPlannedFamilyFrame<'_> {
         }
     }
 
-    pub fn planned_family_leaf(
+    pub fn planned_family_leaf<'plan>(
         &self,
-        plans: &[RetainedFamilyAnimationPlan],
+        plans: &'plan [RetainedFamilyAnimationPlan],
         object_index: usize,
-    ) -> Result<Option<RetainedFamilyAnimationLeafFrame<'_>>, RetainedPlannedFamilyFrameError> {
+    ) -> Result<Option<RetainedFamilyAnimationLeafFrame<'plan>>, RetainedPlannedFamilyFrameError> {
         if self.family_animations.len() != self.retained.objects.len()
             || self.family_plan_indices.len() != self.retained.objects.len()
         {

--- a/crates/noon-runtime/src/retained_family_plan_set_frame.rs
+++ b/crates/noon-runtime/src/retained_family_plan_set_frame.rs
@@ -1,5 +1,5 @@
 use noon_core::{
-    FamilyAnimationState, RetainedFamilyAnimationPlan, RetainedFamilyLeafFrame,
+    FamilyAnimationState, RetainedFamilyAnimationLeafFrame, RetainedFamilyAnimationPlan,
 };
 
 use crate::{RetainedFamilyFrame, RetainedFamilyFramePlanError, RetainedFrameState};
@@ -24,7 +24,10 @@ impl RetainedPlannedFamilyFrame<'_> {
     }
 
     pub fn family_plan_index(&self, object_index: usize) -> Option<u32> {
-        self.family_plan_indices.get(object_index).copied().flatten()
+        self.family_plan_indices
+            .get(object_index)
+            .copied()
+            .flatten()
     }
 
     pub fn as_family_frame(&self) -> RetainedFamilyFrame<'_> {
@@ -38,7 +41,7 @@ impl RetainedPlannedFamilyFrame<'_> {
         &self,
         plans: &[RetainedFamilyAnimationPlan],
         object_index: usize,
-    ) -> Result<Option<RetainedFamilyLeafFrame>, RetainedPlannedFamilyFrameError> {
+    ) -> Result<Option<RetainedFamilyAnimationLeafFrame<'_>>, RetainedPlannedFamilyFrameError> {
         if self.family_animations.len() != self.retained.objects.len()
             || self.family_plan_indices.len() != self.retained.objects.len()
         {
@@ -50,9 +53,9 @@ impl RetainedPlannedFamilyFrame<'_> {
         let object = self.retained.objects.get(object_index).ok_or(
             RetainedPlannedFamilyFrameError::InvalidObjectIndex(object_index),
         )?;
-        let plan_index = self.family_plan_index(object_index).ok_or(
-            RetainedPlannedFamilyFrameError::MissingPlanIndex(object.id),
-        )?;
+        let plan_index = self
+            .family_plan_index(object_index)
+            .ok_or(RetainedPlannedFamilyFrameError::MissingPlanIndex(object.id))?;
         let plan = plans.get(plan_index as usize).ok_or(
             RetainedPlannedFamilyFrameError::InvalidPlanIndex {
                 object: object.id,
@@ -67,7 +70,12 @@ impl RetainedPlannedFamilyFrame<'_> {
             });
         }
         plan.leaf_frame_for_object(state, object.id)
-            .map_err(RetainedPlannedFamilyFrameError::Plan)
+            .map(Some)
+            .map_err(|error| {
+                RetainedPlannedFamilyFrameError::Plan(RetainedFamilyFramePlanError::Evaluation(
+                    error,
+                ))
+            })
     }
 }
 

--- a/crates/noon-runtime/src/retained_family_plan_set_frame.rs
+++ b/crates/noon-runtime/src/retained_family_plan_set_frame.rs
@@ -41,7 +41,8 @@ impl RetainedPlannedFamilyFrame<'_> {
         &self,
         plans: &'plan [RetainedFamilyAnimationPlan],
         object_index: usize,
-    ) -> Result<Option<RetainedFamilyAnimationLeafFrame<'plan>>, RetainedPlannedFamilyFrameError> {
+    ) -> Result<Option<RetainedFamilyAnimationLeafFrame<'plan>>, RetainedPlannedFamilyFrameError>
+    {
         if self.family_animations.len() != self.retained.objects.len()
             || self.family_plan_indices.len() != self.retained.objects.len()
         {

--- a/crates/noon-runtime/src/retained_family_plan_set_runtime.rs
+++ b/crates/noon-runtime/src/retained_family_plan_set_runtime.rs
@@ -4,9 +4,7 @@ use noon_core::{
     RetainedFamilyAnimationPlan,
 };
 
-use crate::{
-    EvaluationError, FrameChanges, RetainedFrameState, RetainedPlannedFamilyFrame,
-};
+use crate::{EvaluationError, FrameChanges, RetainedPlannedFamilyFrame};
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 struct PlannedFamilyInterval {
@@ -225,14 +223,7 @@ impl RetainedFamilyPlanSetSceneInstance {
         )
     }
 
-    fn update_family_state(
-        &mut self,
-        time: f64,
-    ) -> Result<(), RetainedFamilyPlanSetRuntimeError> {
-        if !time.is_finite() {
-            return Err(EvaluationError::InvalidTime(time).into());
-        }
-
+    fn update_family_state(&mut self, time: f64) -> Result<(), RetainedFamilyPlanSetRuntimeError> {
         let animation_states = self
             .specs
             .iter()
@@ -247,8 +238,7 @@ impl RetainedFamilyPlanSetSceneInstance {
                 .map(|index| schedule[index])
                 .filter(|interval| time <= interval.end_time);
             let next_plan_index = selected.map(|interval| interval.plan_index);
-            let next_state = next_plan_index
-                .and_then(|index| animation_states[index as usize]);
+            let next_state = next_plan_index.and_then(|index| animation_states[index as usize]);
 
             if self.states[object_index] != next_state
                 || self.plan_indices[object_index] != next_plan_index
@@ -309,10 +299,14 @@ mod tests {
 
     #[test]
     fn sequential_same_object_selects_exact_plan_and_next_wins_touching_boundary() {
-        let object = RetainedObjectDefinition::geometry(ObjectId::new(10), GeometryRef::circle(1.0));
+        let object =
+            RetainedObjectDefinition::geometry(ObjectId::new(10), GeometryRef::circle(1.0));
         let compiled = RetainedCompiledScene::compile(std::slice::from_ref(&object), &[]).unwrap();
         let animations = vec![
-            (plan_for(object.clone()), spec(0.0, 1.0, FamilyAnimationMode::Reveal)),
+            (
+                plan_for(object.clone()),
+                spec(0.0, 1.0, FamilyAnimationMode::Reveal),
+            ),
             (
                 plan_for(object),
                 spec(1.0, 1.0, FamilyAnimationMode::DrawBorderThenFill),
@@ -322,7 +316,10 @@ mod tests {
 
         let first = runtime.seek(0.5).unwrap();
         assert_eq!(first.family_plan_index(0), Some(0));
-        assert_eq!(first.family_animation(0).unwrap().mode, FamilyAnimationMode::Reveal);
+        assert_eq!(
+            first.family_animation(0).unwrap().mode,
+            FamilyAnimationMode::Reveal
+        );
 
         let boundary = runtime.seek(1.0).unwrap();
         assert_eq!(boundary.family_plan_index(0), Some(1));
@@ -338,13 +335,20 @@ mod tests {
 
     #[test]
     fn overlapping_same_object_fails_before_playback() {
-        let object = RetainedObjectDefinition::geometry(ObjectId::new(10), GeometryRef::circle(1.0));
+        let object =
+            RetainedObjectDefinition::geometry(ObjectId::new(10), GeometryRef::circle(1.0));
         let compiled = RetainedCompiledScene::compile(std::slice::from_ref(&object), &[]).unwrap();
         let error = RetainedFamilyPlanSetSceneInstance::new(
             compiled,
             vec![
-                (plan_for(object.clone()), spec(0.0, 1.0, FamilyAnimationMode::Reveal)),
-                (plan_for(object), spec(0.5, 1.0, FamilyAnimationMode::Reveal)),
+                (
+                    plan_for(object.clone()),
+                    spec(0.0, 1.0, FamilyAnimationMode::Reveal),
+                ),
+                (
+                    plan_for(object),
+                    spec(0.5, 1.0, FamilyAnimationMode::Reveal),
+                ),
             ],
         )
         .unwrap_err();
@@ -358,12 +362,17 @@ mod tests {
     #[test]
     fn concurrent_disjoint_plans_can_use_different_modes() {
         let first = RetainedObjectDefinition::geometry(ObjectId::new(10), GeometryRef::circle(1.0));
-        let second = RetainedObjectDefinition::geometry(ObjectId::new(11), GeometryRef::circle(2.0));
-        let compiled = RetainedCompiledScene::compile(&[first.clone(), second.clone()], &[]).unwrap();
+        let second =
+            RetainedObjectDefinition::geometry(ObjectId::new(11), GeometryRef::circle(2.0));
+        let compiled =
+            RetainedCompiledScene::compile(&[first.clone(), second.clone()], &[]).unwrap();
         let mut runtime = RetainedFamilyPlanSetSceneInstance::new(
             compiled,
             vec![
-                (plan_for(first), spec(0.0, 2.0, FamilyAnimationMode::Reveal)),
+                (
+                    plan_for(first),
+                    spec(0.0, 2.0, FamilyAnimationMode::Reveal),
+                ),
                 (
                     plan_for(second),
                     spec(0.0, 2.0, FamilyAnimationMode::DrawBorderThenFill),
@@ -374,7 +383,10 @@ mod tests {
         let frame = runtime.seek(1.0).unwrap();
         assert_eq!(frame.family_plan_index(0), Some(0));
         assert_eq!(frame.family_plan_index(1), Some(1));
-        assert_eq!(frame.family_animation(0).unwrap().mode, FamilyAnimationMode::Reveal);
+        assert_eq!(
+            frame.family_animation(0).unwrap().mode,
+            FamilyAnimationMode::Reveal
+        );
         assert_eq!(
             frame.family_animation(1).unwrap().mode,
             FamilyAnimationMode::DrawBorderThenFill
@@ -383,13 +395,21 @@ mod tests {
 
     #[test]
     fn direct_seek_matches_forward_playback_for_state_and_plan_identity() {
-        let object = RetainedObjectDefinition::geometry(ObjectId::new(10), GeometryRef::circle(1.0));
+        let object =
+            RetainedObjectDefinition::geometry(ObjectId::new(10), GeometryRef::circle(1.0));
         let compiled = RetainedCompiledScene::compile(std::slice::from_ref(&object), &[]).unwrap();
         let animations = vec![
-            (plan_for(object.clone()), spec(0.0, 1.0, FamilyAnimationMode::Reveal)),
-            (plan_for(object), spec(1.0, 1.0, FamilyAnimationMode::Reveal)),
+            (
+                plan_for(object.clone()),
+                spec(0.0, 1.0, FamilyAnimationMode::Reveal),
+            ),
+            (
+                plan_for(object),
+                spec(1.0, 1.0, FamilyAnimationMode::Reveal),
+            ),
         ];
-        let mut forward = RetainedFamilyPlanSetSceneInstance::new(compiled.clone(), animations.clone()).unwrap();
+        let mut forward =
+            RetainedFamilyPlanSetSceneInstance::new(compiled.clone(), animations.clone()).unwrap();
         forward.advance_to(0.5).unwrap();
         let forward_frame = forward.advance_to(1.5).unwrap();
         let forward_state = forward_frame.family_animation(0);

--- a/crates/noon-runtime/src/retained_family_plan_set_runtime.rs
+++ b/crates/noon-runtime/src/retained_family_plan_set_runtime.rs
@@ -1,0 +1,404 @@
+use noon_compile::RetainedCompiledScene;
+use noon_core::{
+    FamilyAnimationError, FamilyAnimationSpec, FamilyAnimationState, ObjectId,
+    RetainedFamilyAnimationPlan,
+};
+
+use crate::{
+    EvaluationError, FrameChanges, RetainedFrameState, RetainedPlannedFamilyFrame,
+};
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct PlannedFamilyInterval {
+    plan_index: u32,
+    start_time: f64,
+    end_time: f64,
+}
+
+/// Failure while binding multiple immutable family plans to one retained scene.
+#[derive(Clone, Debug, PartialEq)]
+pub enum RetainedFamilyPlanSetRuntimeError {
+    Animation(FamilyAnimationError),
+    Evaluation(EvaluationError),
+    UnknownObject(ObjectId),
+    TooManyPlans(usize),
+    OverlappingAnimations {
+        object: ObjectId,
+        previous_plan: u32,
+        previous_start: f64,
+        previous_end: f64,
+        next_plan: u32,
+        next_start: f64,
+    },
+}
+
+impl std::fmt::Display for RetainedFamilyPlanSetRuntimeError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Animation(error) => error.fmt(formatter),
+            Self::Evaluation(error) => error.fmt(formatter),
+            Self::UnknownObject(object) => write!(
+                formatter,
+                "retained family plan set references unknown compiled object {}",
+                object.get()
+            ),
+            Self::TooManyPlans(count) => write!(
+                formatter,
+                "retained family plan set has {count} plans, exceeding the u32 plan-index domain"
+            ),
+            Self::OverlappingAnimations {
+                object,
+                previous_plan,
+                previous_start,
+                previous_end,
+                next_plan,
+                next_start,
+            } => write!(
+                formatter,
+                "retained family plans overlap on object {}: plan {previous_plan} [{previous_start}, {previous_end}] overlaps plan {next_plan} starting at {next_start}",
+                object.get()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for RetainedFamilyPlanSetRuntimeError {}
+
+impl From<FamilyAnimationError> for RetainedFamilyPlanSetRuntimeError {
+    fn from(value: FamilyAnimationError) -> Self {
+        Self::Animation(value)
+    }
+}
+
+impl From<EvaluationError> for RetainedFamilyPlanSetRuntimeError {
+    fn from(value: EvaluationError) -> Self {
+        Self::Evaluation(value)
+    }
+}
+
+/// Deterministic retained runtime for any number of immutable semantic-family plans.
+///
+/// Plans are installed in canonical request order and retain that index for transport.
+/// Multiple plans may run concurrently when their object sets are disjoint. Reusing an
+/// object is allowed when intervals are sequential; overlapping ownership of the same
+/// object is rejected before playback because one retained object can realize only one
+/// family operation at a time.
+#[derive(Clone, Debug)]
+pub struct RetainedFamilyPlanSetSceneInstance {
+    inner: crate::RetainedSceneInstance,
+    plans: Vec<RetainedFamilyAnimationPlan>,
+    specs: Vec<FamilyAnimationSpec>,
+    object_schedules: Vec<Vec<PlannedFamilyInterval>>,
+    states: Vec<Option<FamilyAnimationState>>,
+    plan_indices: Vec<Option<u32>>,
+    family_changed_indices: Vec<usize>,
+}
+
+impl RetainedFamilyPlanSetSceneInstance {
+    pub fn new(
+        compiled: RetainedCompiledScene,
+        animations: Vec<(RetainedFamilyAnimationPlan, FamilyAnimationSpec)>,
+    ) -> Result<Self, RetainedFamilyPlanSetRuntimeError> {
+        if animations.len() > u32::MAX as usize {
+            return Err(RetainedFamilyPlanSetRuntimeError::TooManyPlans(
+                animations.len(),
+            ));
+        }
+
+        let object_count = compiled.objects().len();
+        let mut object_schedules = vec![Vec::new(); object_count];
+        let mut plans = Vec::with_capacity(animations.len());
+        let mut specs = Vec::with_capacity(animations.len());
+
+        for (animation_index, (plan, spec)) in animations.into_iter().enumerate() {
+            spec.validate()?;
+            let plan_index = animation_index as u32;
+            for leaf in plan.leaves() {
+                let object = leaf.span().object;
+                let object_index = compiled
+                    .object_index(object)
+                    .map(|index| index as usize)
+                    .ok_or(RetainedFamilyPlanSetRuntimeError::UnknownObject(object))?;
+                object_schedules[object_index].push(PlannedFamilyInterval {
+                    plan_index,
+                    start_time: spec.start_time,
+                    end_time: spec.end_time(),
+                });
+            }
+            plans.push(plan);
+            specs.push(spec);
+        }
+
+        for (object_index, schedule) in object_schedules.iter_mut().enumerate() {
+            schedule.sort_by(|left, right| {
+                left.start_time
+                    .total_cmp(&right.start_time)
+                    .then_with(|| left.plan_index.cmp(&right.plan_index))
+            });
+            for pair in schedule.windows(2) {
+                let previous = pair[0];
+                let next = pair[1];
+                if next.start_time < previous.end_time {
+                    return Err(RetainedFamilyPlanSetRuntimeError::OverlappingAnimations {
+                        object: compiled.objects()[object_index].id,
+                        previous_plan: previous.plan_index,
+                        previous_start: previous.start_time,
+                        previous_end: previous.end_time,
+                        next_plan: next.plan_index,
+                        next_start: next.start_time,
+                    });
+                }
+            }
+        }
+
+        Ok(Self {
+            inner: crate::RetainedSceneInstance::new(compiled),
+            plans,
+            specs,
+            object_schedules,
+            states: vec![None; object_count],
+            plan_indices: vec![None; object_count],
+            family_changed_indices: Vec::new(),
+        })
+    }
+
+    pub fn frame(&self) -> RetainedPlannedFamilyFrame<'_> {
+        RetainedPlannedFamilyFrame {
+            retained: self.inner.frame(),
+            family_animations: &self.states,
+            family_plan_indices: &self.plan_indices,
+        }
+    }
+
+    pub fn plans(&self) -> &[RetainedFamilyAnimationPlan] {
+        &self.plans
+    }
+
+    pub fn specs(&self) -> &[FamilyAnimationSpec] {
+        &self.specs
+    }
+
+    pub fn inner(&self) -> &crate::RetainedSceneInstance {
+        &self.inner
+    }
+
+    pub fn evaluate(
+        &mut self,
+        time: f64,
+    ) -> Result<RetainedPlannedFamilyFrame<'_>, RetainedFamilyPlanSetRuntimeError> {
+        self.inner.evaluate(time)?;
+        self.update_family_state(time)?;
+        Ok(self.frame())
+    }
+
+    pub fn seek(
+        &mut self,
+        time: f64,
+    ) -> Result<RetainedPlannedFamilyFrame<'_>, RetainedFamilyPlanSetRuntimeError> {
+        self.inner.seek(time)?;
+        self.update_family_state(time)?;
+        Ok(self.frame())
+    }
+
+    pub fn advance_to(
+        &mut self,
+        time: f64,
+    ) -> Result<RetainedPlannedFamilyFrame<'_>, RetainedFamilyPlanSetRuntimeError> {
+        self.inner.advance_to(time)?;
+        self.update_family_state(time)?;
+        Ok(self.frame())
+    }
+
+    pub fn take_frame_changes(&mut self) -> FrameChanges {
+        let base = self.inner.take_frame_changes();
+        if base.is_all() {
+            self.family_changed_indices.clear();
+            return FrameChanges::all();
+        }
+
+        let mut object_indices = base.object_indices().to_vec();
+        object_indices.append(&mut self.family_changed_indices);
+        FrameChanges::with_structure(
+            object_indices,
+            base.added_indices().to_vec(),
+            base.removed_indices().to_vec(),
+        )
+    }
+
+    fn update_family_state(
+        &mut self,
+        time: f64,
+    ) -> Result<(), RetainedFamilyPlanSetRuntimeError> {
+        if !time.is_finite() {
+            return Err(EvaluationError::InvalidTime(time).into());
+        }
+
+        let animation_states = self
+            .specs
+            .iter()
+            .copied()
+            .map(|spec| active_state_at(spec, time))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        for (object_index, schedule) in self.object_schedules.iter().enumerate() {
+            let selected = schedule
+                .partition_point(|interval| interval.start_time <= time)
+                .checked_sub(1)
+                .map(|index| schedule[index])
+                .filter(|interval| time <= interval.end_time);
+            let next_plan_index = selected.map(|interval| interval.plan_index);
+            let next_state = next_plan_index
+                .and_then(|index| animation_states[index as usize]);
+
+            if self.states[object_index] != next_state
+                || self.plan_indices[object_index] != next_plan_index
+            {
+                self.states[object_index] = next_state;
+                self.plan_indices[object_index] = next_plan_index;
+                self.family_changed_indices.push(object_index);
+            }
+        }
+        Ok(())
+    }
+}
+
+fn active_state_at(
+    spec: FamilyAnimationSpec,
+    time: f64,
+) -> Result<Option<FamilyAnimationState>, FamilyAnimationError> {
+    if time < spec.start_time || time > spec.end_time() {
+        if !time.is_finite() {
+            spec.state_at(time)?;
+        }
+        return Ok(None);
+    }
+    Ok(Some(spec.state_at(time)?))
+}
+
+#[cfg(test)]
+mod tests {
+    use noon_core::{
+        FamilyAnimationMode, GeometryRef, RateFunction, RetainedFamilyAnimationPlanBuilder,
+        RetainedObjectDefinition, SemanticStore, TextResourceArena,
+    };
+
+    use super::*;
+
+    fn plan_for(object: RetainedObjectDefinition) -> RetainedFamilyAnimationPlan {
+        let mut semantics = SemanticStore::new();
+        let leaf = semantics.insert_authoring_object();
+        let mut builder = RetainedFamilyAnimationPlanBuilder::begin(&semantics, leaf).unwrap();
+        builder
+            .accept_leaf(leaf, &object, &TextResourceArena::new())
+            .unwrap();
+        builder.finish().unwrap()
+    }
+
+    fn spec(start: f64, duration: f64, mode: FamilyAnimationMode) -> FamilyAnimationSpec {
+        FamilyAnimationSpec::new(
+            mode,
+            start,
+            duration,
+            0.0,
+            RateFunction::Linear,
+            false,
+            false,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn sequential_same_object_selects_exact_plan_and_next_wins_touching_boundary() {
+        let object = RetainedObjectDefinition::geometry(ObjectId::new(10), GeometryRef::circle(1.0));
+        let compiled = RetainedCompiledScene::compile(std::slice::from_ref(&object), &[]).unwrap();
+        let animations = vec![
+            (plan_for(object.clone()), spec(0.0, 1.0, FamilyAnimationMode::Reveal)),
+            (
+                plan_for(object),
+                spec(1.0, 1.0, FamilyAnimationMode::DrawBorderThenFill),
+            ),
+        ];
+        let mut runtime = RetainedFamilyPlanSetSceneInstance::new(compiled, animations).unwrap();
+
+        let first = runtime.seek(0.5).unwrap();
+        assert_eq!(first.family_plan_index(0), Some(0));
+        assert_eq!(first.family_animation(0).unwrap().mode, FamilyAnimationMode::Reveal);
+
+        let boundary = runtime.seek(1.0).unwrap();
+        assert_eq!(boundary.family_plan_index(0), Some(1));
+        assert_eq!(
+            boundary.family_animation(0).unwrap().mode,
+            FamilyAnimationMode::DrawBorderThenFill
+        );
+
+        let second = runtime.seek(1.5).unwrap();
+        assert_eq!(second.family_plan_index(0), Some(1));
+        assert_eq!(runtime.seek(2.1).unwrap().family_plan_index(0), None);
+    }
+
+    #[test]
+    fn overlapping_same_object_fails_before_playback() {
+        let object = RetainedObjectDefinition::geometry(ObjectId::new(10), GeometryRef::circle(1.0));
+        let compiled = RetainedCompiledScene::compile(std::slice::from_ref(&object), &[]).unwrap();
+        let error = RetainedFamilyPlanSetSceneInstance::new(
+            compiled,
+            vec![
+                (plan_for(object.clone()), spec(0.0, 1.0, FamilyAnimationMode::Reveal)),
+                (plan_for(object), spec(0.5, 1.0, FamilyAnimationMode::Reveal)),
+            ],
+        )
+        .unwrap_err();
+        assert!(matches!(
+            error,
+            RetainedFamilyPlanSetRuntimeError::OverlappingAnimations { object, .. }
+                if object == ObjectId::new(10)
+        ));
+    }
+
+    #[test]
+    fn concurrent_disjoint_plans_can_use_different_modes() {
+        let first = RetainedObjectDefinition::geometry(ObjectId::new(10), GeometryRef::circle(1.0));
+        let second = RetainedObjectDefinition::geometry(ObjectId::new(11), GeometryRef::circle(2.0));
+        let compiled = RetainedCompiledScene::compile(&[first.clone(), second.clone()], &[]).unwrap();
+        let mut runtime = RetainedFamilyPlanSetSceneInstance::new(
+            compiled,
+            vec![
+                (plan_for(first), spec(0.0, 2.0, FamilyAnimationMode::Reveal)),
+                (
+                    plan_for(second),
+                    spec(0.0, 2.0, FamilyAnimationMode::DrawBorderThenFill),
+                ),
+            ],
+        )
+        .unwrap();
+        let frame = runtime.seek(1.0).unwrap();
+        assert_eq!(frame.family_plan_index(0), Some(0));
+        assert_eq!(frame.family_plan_index(1), Some(1));
+        assert_eq!(frame.family_animation(0).unwrap().mode, FamilyAnimationMode::Reveal);
+        assert_eq!(
+            frame.family_animation(1).unwrap().mode,
+            FamilyAnimationMode::DrawBorderThenFill
+        );
+    }
+
+    #[test]
+    fn direct_seek_matches_forward_playback_for_state_and_plan_identity() {
+        let object = RetainedObjectDefinition::geometry(ObjectId::new(10), GeometryRef::circle(1.0));
+        let compiled = RetainedCompiledScene::compile(std::slice::from_ref(&object), &[]).unwrap();
+        let animations = vec![
+            (plan_for(object.clone()), spec(0.0, 1.0, FamilyAnimationMode::Reveal)),
+            (plan_for(object), spec(1.0, 1.0, FamilyAnimationMode::Reveal)),
+        ];
+        let mut forward = RetainedFamilyPlanSetSceneInstance::new(compiled.clone(), animations.clone()).unwrap();
+        forward.advance_to(0.5).unwrap();
+        let forward_frame = forward.advance_to(1.5).unwrap();
+        let forward_state = forward_frame.family_animation(0);
+        let forward_plan = forward_frame.family_plan_index(0);
+
+        let mut direct = RetainedFamilyPlanSetSceneInstance::new(compiled, animations).unwrap();
+        let direct_frame = direct.seek(1.5).unwrap();
+        assert_eq!(direct_frame.family_animation(0), forward_state);
+        assert_eq!(direct_frame.family_plan_index(0), forward_plan);
+        assert!(direct.take_frame_changes().is_all());
+    }
+}

--- a/crates/noon-runtime/src/retained_family_plan_set_runtime.rs
+++ b/crates/noon-runtime/src/retained_family_plan_set_runtime.rs
@@ -369,10 +369,7 @@ mod tests {
         let mut runtime = RetainedFamilyPlanSetSceneInstance::new(
             compiled,
             vec![
-                (
-                    plan_for(first),
-                    spec(0.0, 2.0, FamilyAnimationMode::Reveal),
-                ),
+                (plan_for(first), spec(0.0, 2.0, FamilyAnimationMode::Reveal)),
                 (
                     plan_for(second),
                     spec(0.0, 2.0, FamilyAnimationMode::DrawBorderThenFill),

--- a/crates/noon-web/src/canonical_retained_engine_player.rs
+++ b/crates/noon-web/src/canonical_retained_engine_player.rs
@@ -73,35 +73,25 @@ impl CanonicalRetainedEnginePlayer {
         loop_duration_seconds: f64,
         session: u32,
     ) -> Result<Self, CanonicalRetainedEnginePlayerError> {
-        let family_animation_count = scene_spec.family_animations.len();
-        if family_animation_count > 1 {
-            return Err(
-                CanonicalRetainedEnginePlayerError::MultipleFamilyAnimationsUnsupported(
-                    family_animation_count,
-                ),
-            );
-        }
-
+        let has_family_animations = !scene_spec.family_animations.is_empty();
         let scene_spec_json = scene_spec.to_json()?;
-        let player = if family_animation_count == 0 {
+        let player = if !has_family_animations {
             let mixed = MixedRetainedAuthoringScene::from_scene_spec(scene_spec)?;
             CanonicalRetainedExecutionPlayer::Ordinary(RetainedAuthoringPlayer::new(
                 mixed, session,
             )?)
         } else {
             let lowered = CanonicalRetainedFamilyAnimationScene::from_scene_spec(scene_spec)?;
-            let (scene, tracks, camera_object, mut animations) = lowered.into_parts();
-            let animation = animations
-                .pop()
-                .expect("one canonical family request must lower to one animation");
-            debug_assert!(animations.is_empty());
-            let (plan, spec) = animation.into_parts();
+            let (scene, tracks, camera_object, animations) = lowered.into_parts();
+            let animations = animations
+                .into_iter()
+                .map(|animation| animation.into_parts())
+                .collect();
             CanonicalRetainedExecutionPlayer::Family(
-                RetainedFamilyExecutionPlayer::new_with_tracks(
+                RetainedFamilyExecutionPlayer::new_many_with_tracks(
                     scene,
                     &tracks,
-                    plan,
-                    spec,
+                    animations,
                     camera_object,
                     session,
                 )?,
@@ -192,7 +182,6 @@ pub enum CanonicalRetainedEnginePlayerError {
     Player(RetainedAuthoringPlayerError),
     FamilyScene(CanonicalRetainedFamilyAnimationSceneError),
     FamilyPlayer(RetainedFamilyExecutionPlayerError),
-    MultipleFamilyAnimationsUnsupported(usize),
     MissingInitialSnapshot,
     Clock(ClockError),
     Json(serde_json::Error),
@@ -206,10 +195,6 @@ impl std::fmt::Display for CanonicalRetainedEnginePlayerError {
             Self::Player(error) => error.fmt(formatter),
             Self::FamilyScene(error) => error.fmt(formatter),
             Self::FamilyPlayer(error) => error.fmt(formatter),
-            Self::MultipleFamilyAnimationsUnsupported(count) => write!(
-                formatter,
-                "canonical retained execution currently supports at most one family animation; received {count}"
-            ),
             Self::MissingInitialSnapshot => {
                 formatter.write_str("canonical retained execution did not emit its initial snapshot")
             }
@@ -435,6 +420,29 @@ mod tests {
         (scene_spec, text_id, circle_id)
     }
 
+    fn append_family_request(
+        scene_spec: &mut SceneSpec,
+        start_time: f64,
+        duration: f64,
+        mode: FamilyAnimationMode,
+    ) {
+        let first = &scene_spec.family_animations[0];
+        let spec = FamilyAnimationSpec::new(
+            mode,
+            start_time,
+            duration,
+            first.spec().lag_ratio,
+            RateFunction::Linear,
+            false,
+            false,
+        )
+        .unwrap();
+        scene_spec.family_animations.push(
+            FamilyAnimationRequest::new(first.target(), first.bindings().to_vec(), spec).unwrap(),
+        );
+        scene_spec.validate().unwrap();
+    }
+
     fn assert_family_midpoint(
         mirror: &InstalledRetainedExecutionMirror,
         text_id: ObjectId,
@@ -444,11 +452,6 @@ mod tests {
         assert_eq!(plan.leaves()[0].span().object, text_id);
         assert_eq!(plan.leaves()[1].span().object, circle_id);
 
-        // Canonical painter/materialization order is intentionally Circle -> Text for
-        // this fixture, while semantic family order is Text -> Circle. Renderer family
-        // lookup takes a retained runtime object slot, so resolve those slots by stable
-        // ObjectId rather than accidentally treating semantic-plan indices as painter
-        // indices. This directly proves the two ordering domains stay independent.
         let retained = mirror.frame().unwrap();
         let text_index = retained
             .objects
@@ -618,15 +621,55 @@ mod tests {
     }
 
     #[test]
-    fn canonical_engine_rejects_multiple_family_animations_explicitly() {
+    fn canonical_engine_runs_sequential_family_requests_with_exact_plan_identity() {
+        let (mut scene_spec, text_id, circle_id) = family_scene_spec();
+        append_family_request(&mut scene_spec, 3.0, 1.0, FamilyAnimationMode::Reveal);
+        let mut engine = CanonicalRetainedEnginePlayer::new(scene_spec, 5.0, 71).unwrap();
+        let mut mirror =
+            InstalledRetainedExecutionMirror::from_bundle_bytes(engine.resource_bundle_bytes())
+                .unwrap();
+
+        let initial = engine.initial_delta_json().unwrap();
+        let initial_delta: RetainedFamilyExecutionDeltaEnvelope =
+            serde_json::from_str(&initial).unwrap();
+        assert_eq!(initial_delta.family_plans.len(), 2);
+        mirror.apply_json(&initial).unwrap();
+        assert_eq!(mirror.family_plans().len(), 2);
+
+        let first = engine
+            .seek_delta_json(2.0)
+            .unwrap()
+            .expect("first family request state");
+        mirror.apply_json(&first).unwrap();
+        let retained = mirror.frame().unwrap();
+        let text_index = retained.objects.iter().position(|object| object.id == text_id).unwrap();
+        let circle_index = retained.objects.iter().position(|object| object.id == circle_id).unwrap();
+        let first_frame = mirror.planned_family_frame().unwrap().unwrap();
+        assert_eq!(first_frame.family_plan_index(text_index), Some(0));
+        assert_eq!(first_frame.family_plan_index(circle_index), Some(0));
+
+        let second = engine
+            .seek_delta_json(3.5)
+            .unwrap()
+            .expect("second family request state");
+        mirror.apply_json(&second).unwrap();
+        let second_frame = mirror.planned_family_frame().unwrap().unwrap();
+        assert_eq!(second_frame.family_plan_index(text_index), Some(1));
+        assert_eq!(second_frame.family_plan_index(circle_index), Some(1));
+    }
+
+    #[test]
+    fn canonical_engine_rejects_overlapping_family_ownership_on_same_object() {
         let (mut scene_spec, _, _) = family_scene_spec();
-        scene_spec
-            .family_animations
-            .push(scene_spec.family_animations[0].clone());
-        let error = CanonicalRetainedEnginePlayer::new(scene_spec, 4.0, 71).unwrap_err();
+        append_family_request(&mut scene_spec, 2.5, 1.0, FamilyAnimationMode::Reveal);
+        let error = CanonicalRetainedEnginePlayer::new(scene_spec, 4.0, 72).unwrap_err();
         assert!(matches!(
             error,
-            CanonicalRetainedEnginePlayerError::MultipleFamilyAnimationsUnsupported(2)
+            CanonicalRetainedEnginePlayerError::FamilyPlayer(
+                RetainedFamilyExecutionPlayerError::Runtime(
+                    noon_runtime::RetainedFamilyPlanSetRuntimeError::OverlappingAnimations { .. }
+                )
+            )
         ));
     }
 

--- a/crates/noon-web/src/canonical_retained_engine_player.rs
+++ b/crates/noon-web/src/canonical_retained_engine_player.rs
@@ -195,9 +195,8 @@ impl std::fmt::Display for CanonicalRetainedEnginePlayerError {
             Self::Player(error) => error.fmt(formatter),
             Self::FamilyScene(error) => error.fmt(formatter),
             Self::FamilyPlayer(error) => error.fmt(formatter),
-            Self::MissingInitialSnapshot => {
-                formatter.write_str("canonical retained execution did not emit its initial snapshot")
-            }
+            Self::MissingInitialSnapshot => formatter
+                .write_str("canonical retained execution did not emit its initial snapshot"),
             Self::Clock(error) => error.fmt(formatter),
             Self::Json(error) => error.fmt(formatter),
         }
@@ -642,8 +641,16 @@ mod tests {
             .expect("first family request state");
         mirror.apply_json(&first).unwrap();
         let retained = mirror.frame().unwrap();
-        let text_index = retained.objects.iter().position(|object| object.id == text_id).unwrap();
-        let circle_index = retained.objects.iter().position(|object| object.id == circle_id).unwrap();
+        let text_index = retained
+            .objects
+            .iter()
+            .position(|object| object.id == text_id)
+            .unwrap();
+        let circle_index = retained
+            .objects
+            .iter()
+            .position(|object| object.id == circle_id)
+            .unwrap();
         let first_frame = mirror.planned_family_frame().unwrap().unwrap();
         assert_eq!(first_frame.family_plan_index(text_index), Some(0));
         assert_eq!(first_frame.family_plan_index(circle_index), Some(0));

--- a/crates/noon-web/src/retained_execution_canvas.rs
+++ b/crates/noon-web/src/retained_execution_canvas.rs
@@ -190,9 +190,6 @@ mod wasm {
                         self.surface.configure(&self.device, &self.config);
                         return Ok(false);
                     }
-                    // The device error callback owns validation diagnostics. Keep
-                    // the retained frame pending so a recoverable validation can
-                    // be reported once and presentation retried unchanged.
                     wgpu::CurrentSurfaceTexture::Validation => return Ok(false),
                 };
 
@@ -203,31 +200,8 @@ mod wasm {
                 self.config.height as f32 / camera.world_size.y,
             ))
             .map_err(js_error)?;
-            let family_plan = self.mirror.family_plan().map_err(js_error)?;
-            let prepared = if let Some(plan) = family_plan {
-                let family_frame = self
-                    .mirror
-                    .family_frame()
-                    .map_err(js_error)?
-                    .ok_or_else(|| {
-                        js_message(
-                            "retained family execution has a plan without an evaluated family frame",
-                        )
-                    })?;
-                self.preparer
-                    .prepare_family_animation_with_changes(
-                        &self.device,
-                        &self.queue,
-                        &family_frame,
-                        plan,
-                        &self.pending_changes,
-                        resources.texts(),
-                        resources.fonts(),
-                        resources.geometries(),
-                        metrics,
-                    )
-                    .map_err(js_error)?
-            } else {
+            let plans = self.mirror.family_plans();
+            let prepared = if plans.is_empty() {
                 let frame = self.mirror.frame().ok_or_else(|| {
                     js_message("retained execution renderer has no frame snapshot")
                 })?;
@@ -236,6 +210,29 @@ mod wasm {
                         &self.device,
                         &self.queue,
                         frame,
+                        &self.pending_changes,
+                        resources.texts(),
+                        resources.fonts(),
+                        resources.geometries(),
+                        metrics,
+                    )
+                    .map_err(js_error)?
+            } else {
+                let family_frame = self
+                    .mirror
+                    .planned_family_frame()
+                    .map_err(js_error)?
+                    .ok_or_else(|| {
+                        js_message(
+                            "retained family execution has plans without an evaluated family frame",
+                        )
+                    })?;
+                self.preparer
+                    .prepare_family_plan_set_with_changes(
+                        &self.device,
+                        &self.queue,
+                        &family_frame,
+                        plans,
                         &self.pending_changes,
                         resources.texts(),
                         resources.fonts(),

--- a/crates/noon-web/src/retained_execution_resources.rs
+++ b/crates/noon-web/src/retained_execution_resources.rs
@@ -1,5 +1,7 @@
 use noon_core::{Camera2DState, ObjectContentRef, RetainedFamilyAnimationPlan};
-use noon_runtime::{FrameChanges, RetainedFamilyFrame, RetainedFrameState};
+use noon_runtime::{
+    FrameChanges, RetainedFamilyFrame, RetainedFrameState, RetainedPlannedFamilyFrame,
+};
 
 use crate::{
     InstalledRetainedFamilyExecutionState, InstalledRetainedResources,
@@ -52,6 +54,23 @@ impl InstalledRetainedExecutionMirror {
             .as_ref()
             .ok_or(InstalledExecutionError::MissingResolvedFrame)?;
         Ok(Some(self.family.frame(frame)?))
+    }
+
+    pub fn planned_family_frame(
+        &self,
+    ) -> Result<Option<RetainedPlannedFamilyFrame<'_>>, InstalledExecutionError> {
+        if self.family.plans().is_empty() {
+            return Ok(None);
+        }
+        let frame = self
+            .resolved
+            .as_ref()
+            .ok_or(InstalledExecutionError::MissingResolvedFrame)?;
+        Ok(Some(self.family.planned_frame(frame)?))
+    }
+
+    pub fn family_plans(&self) -> &[RetainedFamilyAnimationPlan] {
+        self.family.plans()
     }
 
     pub fn family_plan(
@@ -419,9 +438,18 @@ mod tests {
         assert_eq!(outcome, RetainedTransportApplyOutcome::Applied);
         assert!(changes.is_all());
         assert!(mirror.family_plan().unwrap().is_some());
+        assert_eq!(mirror.family_plans().len(), 1);
         assert_eq!(
             mirror.family_frame().unwrap().unwrap().family_animation(0),
             Some(family_state(0.5))
+        );
+        assert_eq!(
+            mirror
+                .planned_family_frame()
+                .unwrap()
+                .unwrap()
+                .family_plan_index(0),
+            Some(0)
         );
     }
 

--- a/crates/noon-web/src/retained_family_execution_encoder.rs
+++ b/crates/noon-web/src/retained_family_execution_encoder.rs
@@ -1,5 +1,5 @@
 use noon_core::{Camera2DState, RetainedFamilyAnimationPlan};
-use noon_runtime::{FrameChanges, RetainedFamilyFrame};
+use noon_runtime::{FrameChanges, RetainedFamilyFrame, RetainedPlannedFamilyFrame};
 
 use crate::{
     RetainedExecutionDeltaEncoder, RetainedExecutionTransportError,
@@ -36,6 +36,18 @@ impl RetainedFamilyExecutionDeltaEncoder {
         )?)
     }
 
+    pub fn encode_planned_snapshot(
+        &mut self,
+        frame: &RetainedPlannedFamilyFrame<'_>,
+        plans: &[RetainedFamilyAnimationPlan],
+        camera: Camera2DState,
+    ) -> Result<RetainedFamilyExecutionDeltaEnvelope, RetainedFamilyExecutionEncodeError> {
+        let retained = self.retained.encode_snapshot(frame.retained, camera)?;
+        Ok(RetainedFamilyExecutionDeltaEnvelope::planned_snapshot(
+            retained, frame, plans,
+        )?)
+    }
+
     /// Encode one sparse family-aware retained update.
     ///
     /// `plans` are normally used only by the initial snapshot. They are supplied here
@@ -60,6 +72,29 @@ impl RetainedFamilyExecutionDeltaEncoder {
             RetainedFamilyExecutionDeltaEnvelope::snapshot(retained, frame, plans)?
         } else {
             RetainedFamilyExecutionDeltaEnvelope::incremental(retained, frame, changes)?
+        };
+        Ok(Some(envelope))
+    }
+
+    pub fn encode_planned_incremental(
+        &mut self,
+        frame: &RetainedPlannedFamilyFrame<'_>,
+        plans: &[RetainedFamilyAnimationPlan],
+        changes: &FrameChanges,
+        camera: Camera2DState,
+    ) -> Result<Option<RetainedFamilyExecutionDeltaEnvelope>, RetainedFamilyExecutionEncodeError>
+    {
+        let Some(retained) = self
+            .retained
+            .encode_incremental(frame.retained, changes, camera)?
+        else {
+            return Ok(None);
+        };
+
+        let envelope = if retained.snapshot {
+            RetainedFamilyExecutionDeltaEnvelope::planned_snapshot(retained, frame, plans)?
+        } else {
+            RetainedFamilyExecutionDeltaEnvelope::planned_incremental(retained, frame, changes)?
         };
         Ok(Some(envelope))
     }
@@ -197,6 +232,39 @@ mod tests {
         assert!(incremental.family_plans.is_empty());
         assert_eq!(incremental.family_states.len(), 1);
         assert_eq!(incremental.family_states[0].object, ObjectId::new(11));
+    }
+
+    #[test]
+    fn planned_encoder_carries_sparse_plan_identity() {
+        let (plan, frame, states) = fixture();
+        let plan_indices = [Some(0), Some(0)];
+        let family = RetainedPlannedFamilyFrame {
+            retained: &frame,
+            family_animations: &states,
+            family_plan_indices: &plan_indices,
+        };
+        let mut encoder = RetainedFamilyExecutionDeltaEncoder::new(19);
+        let snapshot = encoder
+            .encode_planned_snapshot(
+                &family,
+                std::slice::from_ref(&plan),
+                Camera2DState::default(),
+            )
+            .unwrap();
+        assert_eq!(snapshot.family_states[0].family_plan_index, Some(0));
+        assert_eq!(snapshot.family_states[1].family_plan_index, Some(0));
+
+        let incremental = encoder
+            .encode_planned_incremental(
+                &family,
+                std::slice::from_ref(&plan),
+                &FrameChanges::objects(vec![1]),
+                Camera2DState::default(),
+            )
+            .unwrap()
+            .unwrap();
+        assert_eq!(incremental.family_states.len(), 1);
+        assert_eq!(incremental.family_states[0].family_plan_index, Some(0));
     }
 
     #[test]

--- a/crates/noon-web/src/retained_family_execution_player.rs
+++ b/crates/noon-web/src/retained_family_execution_player.rs
@@ -4,8 +4,8 @@ use noon_core::{
     Camera2DState, FamilyAnimationSpec, ObjectId, RetainedFamilyAnimationPlan, TrackDefinition,
 };
 use noon_runtime::{
-    RetainedFamilyFrame, RetainedFamilyPlanRuntimeError, RetainedFamilyPlanSceneInstance,
-    RetainedFrameState,
+    RetainedFamilyPlanSetRuntimeError, RetainedFamilyPlanSetSceneInstance, RetainedFrameState,
+    RetainedPlannedFamilyFrame,
 };
 
 use crate::{
@@ -13,18 +13,16 @@ use crate::{
     RetainedFamilyExecutionEncodeError, RetainedResourceBundle, RetainedResourceTransportError,
 };
 
-/// Production owner for one prepared retained semantic-family animation.
+/// Production owner for prepared retained semantic-family animations.
 ///
-/// Authoring and semantic lowering end before this boundary. The player receives the
-/// authoritative retained scene plus one prepared family plan/spec, compiles the
-/// ordinary retained timeline once, captures renderer resources once, and then drives
-/// the shared family runtime directly into the family-aware retained transport.
-/// Object identity, resource identity, camera state, and transport sequencing therefore
-/// stay on the same path as ordinary retained playback.
+/// The ordinary retained scene is compiled once and resources are captured once. Any
+/// number of immutable family plans then share one deterministic runtime. Plan indices
+/// are stable in canonical request order and are carried with active per-object state,
+/// allowing sequential reuse of an object without exposing glyph/resource identity.
 #[derive(Clone, Debug)]
 pub struct RetainedFamilyExecutionPlayer {
     scene: RetainedScene,
-    runtime: RetainedFamilyPlanSceneInstance,
+    runtime: RetainedFamilyPlanSetSceneInstance,
     encoder: RetainedFamilyExecutionDeltaEncoder,
     resource_bundle: Vec<u8>,
     camera_object: Option<ObjectId>,
@@ -43,19 +41,33 @@ impl RetainedFamilyExecutionPlayer {
         Self::new_with_tracks(scene, &tracks, plan, spec, camera_object, session)
     }
 
-    /// Construct from a retained materialization whose validated timeline is carried
-    /// separately from its resource/object arena.
-    ///
-    /// Canonical mixed SceneSpec lowering currently materializes geometry first and
-    /// therefore cannot install text-targeting tracks into that temporary seed scene.
-    /// The canonical handoff nevertheless validates one exact track set after all
-    /// objects exist. Accept it here explicitly so family-aware execution cannot drop
-    /// ordinary transform/style/lifecycle animation while switching schedulers.
+    /// Single-plan compatibility constructor over the plural production owner.
     pub fn new_with_tracks(
         scene: RetainedScene,
         tracks: &[TrackDefinition],
         plan: RetainedFamilyAnimationPlan,
         spec: FamilyAnimationSpec,
+        camera_object: Option<ObjectId>,
+        session: u32,
+    ) -> Result<Self, RetainedFamilyExecutionPlayerError> {
+        Self::new_many_with_tracks(
+            scene,
+            tracks,
+            vec![(plan, spec)],
+            camera_object,
+            session,
+        )
+    }
+
+    /// Construct the production family player from all canonical family requests.
+    ///
+    /// The runtime validates same-object overlap before playback. Concurrent requests
+    /// targeting disjoint objects are allowed, as are touching/sequential requests on
+    /// the same object.
+    pub fn new_many_with_tracks(
+        scene: RetainedScene,
+        tracks: &[TrackDefinition],
+        animations: Vec<(RetainedFamilyAnimationPlan, FamilyAnimationSpec)>,
         camera_object: Option<ObjectId>,
         session: u32,
     ) -> Result<Self, RetainedFamilyExecutionPlayerError> {
@@ -70,7 +82,7 @@ impl RetainedFamilyExecutionPlayer {
             scene.fonts(),
         )?;
         let resource_bundle = bundle.encode_binary()?;
-        let runtime = RetainedFamilyPlanSceneInstance::new(compiled, plan, spec)?;
+        let runtime = RetainedFamilyPlanSetSceneInstance::new(compiled, animations)?;
         Ok(Self {
             scene,
             runtime,
@@ -81,7 +93,7 @@ impl RetainedFamilyExecutionPlayer {
         })
     }
 
-    /// Enter production execution directly from the Rust-owned authoring lowering result.
+    /// Enter production execution directly from one Rust-owned authoring lowering result.
     pub fn from_lowered(
         scene: RetainedScene,
         lowered: LoweredRetainedFamilyAnimation,
@@ -100,16 +112,29 @@ impl RetainedFamilyExecutionPlayer {
         self.runtime.inner().frame()
     }
 
-    pub fn family_frame(&self) -> RetainedFamilyFrame<'_> {
+    pub fn planned_family_frame(&self) -> RetainedPlannedFamilyFrame<'_> {
         self.runtime.frame()
     }
 
-    pub fn plan(&self) -> &RetainedFamilyAnimationPlan {
-        self.runtime.plan()
+    pub fn plans(&self) -> &[RetainedFamilyAnimationPlan] {
+        self.runtime.plans()
     }
 
-    pub const fn spec(&self) -> FamilyAnimationSpec {
-        self.runtime.spec()
+    /// Compatibility accessor for players constructed through the single-plan API.
+    pub fn plan(&self) -> &RetainedFamilyAnimationPlan {
+        self.runtime
+            .plans()
+            .first()
+            .expect("single-plan compatibility player must contain one plan")
+    }
+
+    /// Compatibility accessor for players constructed through the single-plan API.
+    pub fn spec(&self) -> FamilyAnimationSpec {
+        *self
+            .runtime
+            .specs()
+            .first()
+            .expect("single-plan compatibility player must contain one spec")
     }
 
     pub const fn camera_object(&self) -> Option<ObjectId> {
@@ -122,10 +147,9 @@ impl RetainedFamilyExecutionPlayer {
 
     /// Evaluate one absolute scene time and encode the renderer-facing family delta.
     ///
-    /// The first call is always an authoritative snapshot carrying the immutable plan.
-    /// Later calls are sparse: ordinary retained dirtiness and family-state changes are
-    /// merged by the shared runtime before the shared retained encoder assigns sequence.
-    /// A backward seek naturally promotes to a complete snapshot through `FrameChanges`.
+    /// The first call is an authoritative snapshot carrying every immutable plan.
+    /// Later calls remain sparse. A backward seek naturally promotes to a complete
+    /// snapshot through `FrameChanges`, reinstalling the same stable plan ordering.
     pub fn evaluate_delta(
         &mut self,
         time: f64,
@@ -135,17 +159,19 @@ impl RetainedFamilyExecutionPlayer {
         let camera = self.camera_state()?;
         let changes = self.runtime.take_frame_changes();
         let frame = self.runtime.frame();
-        let plans = std::slice::from_ref(self.runtime.plan());
+        let plans = self.runtime.plans();
 
         if !self.snapshot_sent {
-            let delta = self.encoder.encode_snapshot(&frame, plans, camera)?;
+            let delta = self
+                .encoder
+                .encode_planned_snapshot(&frame, plans, camera)?;
             self.snapshot_sent = true;
             return Ok(Some(delta));
         }
 
         Ok(self
             .encoder
-            .encode_incremental(&frame, plans, &changes, camera)?)
+            .encode_planned_incremental(&frame, plans, &changes, camera)?)
     }
 
     fn camera_state(&self) -> Result<Camera2DState, RetainedFamilyExecutionPlayerError> {
@@ -162,12 +188,11 @@ impl RetainedFamilyExecutionPlayer {
             .ok_or(RetainedFamilyExecutionPlayerError::InvalidCameraObject(
                 camera_object,
             ))?;
-        let geometry =
-            object
-                .geometry()
-                .ok_or(RetainedFamilyExecutionPlayerError::InvalidCameraObject(
-                    camera_object,
-                ))?;
+        let geometry = object
+            .geometry()
+            .ok_or(RetainedFamilyExecutionPlayerError::InvalidCameraObject(
+                camera_object,
+            ))?;
         Camera2DState::from_frame_object(geometry, object.transform).ok_or(
             RetainedFamilyExecutionPlayerError::InvalidCameraObject(camera_object),
         )
@@ -178,7 +203,7 @@ impl RetainedFamilyExecutionPlayer {
 pub enum RetainedFamilyExecutionPlayerError {
     Compile(RetainedCompileError),
     Resource(RetainedResourceTransportError),
-    Runtime(RetainedFamilyPlanRuntimeError),
+    Runtime(RetainedFamilyPlanSetRuntimeError),
     Transport(RetainedFamilyExecutionEncodeError),
     InvalidCameraObject(ObjectId),
 }
@@ -213,8 +238,8 @@ impl From<RetainedResourceTransportError> for RetainedFamilyExecutionPlayerError
     }
 }
 
-impl From<RetainedFamilyPlanRuntimeError> for RetainedFamilyExecutionPlayerError {
-    fn from(value: RetainedFamilyPlanRuntimeError) -> Self {
+impl From<RetainedFamilyPlanSetRuntimeError> for RetainedFamilyExecutionPlayerError {
+    fn from(value: RetainedFamilyPlanSetRuntimeError) -> Self {
         Self::Runtime(value)
     }
 }
@@ -266,7 +291,6 @@ mod tests {
         .unwrap();
         let mut lowering =
             RetainedFamilyAnimationLoweringSession::begin(&semantics, family, spec).unwrap();
-        // Retained materialization order must never become semantic animation order.
         lowering.bind_leaf(circle_leaf, circle_id).unwrap();
         lowering.bind_leaf(text_leaf, text_id).unwrap();
         let lowered = lowering.finish(&scene).unwrap();
@@ -292,6 +316,10 @@ mod tests {
         assert_eq!(midpoint.retained.sequence, 1);
         assert!(midpoint.family_plans.is_empty());
         assert_eq!(midpoint.family_states.len(), 2);
+        assert!(midpoint
+            .family_states
+            .iter()
+            .all(|state| state.family_plan_index == Some(0)));
         let midpoint_json = serde_json::to_string(&midpoint).unwrap();
         assert!(!midpoint_json.contains("glyph"));
         let (outcome, changes) = mirror.apply_json(&midpoint_json).unwrap();

--- a/crates/noon-web/src/retained_family_execution_player.rs
+++ b/crates/noon-web/src/retained_family_execution_player.rs
@@ -50,13 +50,7 @@ impl RetainedFamilyExecutionPlayer {
         camera_object: Option<ObjectId>,
         session: u32,
     ) -> Result<Self, RetainedFamilyExecutionPlayerError> {
-        Self::new_many_with_tracks(
-            scene,
-            tracks,
-            vec![(plan, spec)],
-            camera_object,
-            session,
-        )
+        Self::new_many_with_tracks(scene, tracks, vec![(plan, spec)], camera_object, session)
     }
 
     /// Construct the production family player from all canonical family requests.
@@ -188,11 +182,12 @@ impl RetainedFamilyExecutionPlayer {
             .ok_or(RetainedFamilyExecutionPlayerError::InvalidCameraObject(
                 camera_object,
             ))?;
-        let geometry = object
-            .geometry()
-            .ok_or(RetainedFamilyExecutionPlayerError::InvalidCameraObject(
-                camera_object,
-            ))?;
+        let geometry =
+            object
+                .geometry()
+                .ok_or(RetainedFamilyExecutionPlayerError::InvalidCameraObject(
+                    camera_object,
+                ))?;
         Camera2DState::from_frame_object(geometry, object.transform).ok_or(
             RetainedFamilyExecutionPlayerError::InvalidCameraObject(camera_object),
         )

--- a/crates/noon-web/src/retained_family_execution_transport.rs
+++ b/crates/noon-web/src/retained_family_execution_transport.rs
@@ -11,6 +11,8 @@ use crate::{
     RetainedFamilyTransportState,
 };
 
+type ValidatedFamilyStateUpdate = (usize, Option<FamilyAnimationState>, Option<u32>);
+
 /// Sparse per-object family scheduler state carried alongside an ordinary retained delta.
 ///
 /// `family_plan_index` identifies the immutable snapshot-installed plan that owns an
@@ -347,10 +349,7 @@ fn validated_state_updates(
     frame: &RetainedFrameState,
     plans: &[RetainedFamilyAnimationPlan],
     entries: &[RetainedFamilyExecutionObjectState],
-) -> Result<
-    Vec<(usize, Option<FamilyAnimationState>, Option<u32>)>,
-    RetainedFamilyExecutionTransportError,
-> {
+) -> Result<Vec<ValidatedFamilyStateUpdate>, RetainedFamilyExecutionTransportError> {
     entries
         .iter()
         .map(|entry| {

--- a/crates/noon-web/src/retained_family_execution_transport.rs
+++ b/crates/noon-web/src/retained_family_execution_transport.rs
@@ -1,7 +1,9 @@
 use std::collections::HashSet;
 
 use noon_core::{FamilyAnimationState, ObjectId, RetainedFamilyAnimationPlan, TextResourceArena};
-use noon_runtime::{FrameChanges, RetainedFamilyFrame, RetainedFrameState};
+use noon_runtime::{
+    FrameChanges, RetainedFamilyFrame, RetainedFrameState, RetainedPlannedFamilyFrame,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -11,16 +13,20 @@ use crate::{
 
 /// Sparse per-object family scheduler state carried alongside an ordinary retained delta.
 ///
-/// An entry with `family_animation: None` is meaningful on incrementals: it clears a
-/// previously active family animation after its interval ends.
+/// `family_plan_index` identifies the immutable snapshot-installed plan that owns an
+/// active state. It is omitted for inactive states and remains optional on decode so
+/// pre-multi-plan single-family snapshots remain readable.
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 pub struct RetainedFamilyExecutionObjectState {
     pub object: ObjectId,
     #[serde(flatten)]
     pub state: RetainedFamilyTransportState,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub family_plan_index: Option<u32>,
 }
 
 impl RetainedFamilyExecutionObjectState {
+    /// Compatibility constructor for the original single-plan transport shape.
     pub fn new(
         object: ObjectId,
         family_animation: Option<FamilyAnimationState>,
@@ -28,15 +34,40 @@ impl RetainedFamilyExecutionObjectState {
         Ok(Self {
             object,
             state: RetainedFamilyTransportState::new(family_animation)?,
+            family_plan_index: None,
         })
+    }
+
+    /// Construct an explicitly planned state for plural family execution.
+    pub fn planned(
+        object: ObjectId,
+        family_animation: Option<FamilyAnimationState>,
+        family_plan_index: Option<u32>,
+    ) -> Result<Self, RetainedFamilyExecutionTransportError> {
+        let result = Self {
+            object,
+            state: RetainedFamilyTransportState::new(family_animation)?,
+            family_plan_index,
+        };
+        result.validate_plan_identity()?;
+        Ok(result)
+    }
+
+    fn validate_plan_identity(&self) -> Result<(), RetainedFamilyExecutionTransportError> {
+        if self.state.family_animation.is_none() && self.family_plan_index.is_some() {
+            return Err(RetainedFamilyExecutionTransportError::PlanIndexWithoutState(
+                self.object,
+            ));
+        }
+        Ok(())
     }
 }
 
 /// Additive family-animation envelope over the stable retained execution transport.
 ///
-/// Serde flattening preserves the existing retained v1 JSON shape. Family-aware
-/// producers add only sparse evaluated scheduler state and snapshot-only immutable
-/// plan descriptors; glyph IDs and renderer payloads remain renderer-local.
+/// Family-aware producers add sparse evaluated scheduler state plus snapshot-only
+/// immutable plan descriptors. Plan indices refer only to this snapshot plan vector;
+/// glyph IDs and renderer payloads remain renderer-local.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct RetainedFamilyExecutionDeltaEnvelope {
     #[serde(flatten)]
@@ -48,6 +79,7 @@ pub struct RetainedFamilyExecutionDeltaEnvelope {
 }
 
 impl RetainedFamilyExecutionDeltaEnvelope {
+    /// Compatibility snapshot for one family plan.
     pub fn snapshot(
         retained: RetainedExecutionDeltaEnvelope,
         frame: &RetainedFamilyFrame<'_>,
@@ -68,6 +100,31 @@ impl RetainedFamilyExecutionDeltaEnvelope {
         Ok(envelope)
     }
 
+    /// Snapshot with explicit active-plan ownership for plural family execution.
+    pub fn planned_snapshot(
+        retained: RetainedExecutionDeltaEnvelope,
+        frame: &RetainedPlannedFamilyFrame<'_>,
+        plans: &[RetainedFamilyAnimationPlan],
+    ) -> Result<Self, RetainedFamilyExecutionTransportError> {
+        if !retained.snapshot {
+            return Err(RetainedFamilyExecutionTransportError::ExpectedSnapshot);
+        }
+        let envelope = Self {
+            family_states: planned_family_states_for_indices(
+                frame,
+                0..frame.retained.objects.len(),
+            )?,
+            family_plans: plans
+                .iter()
+                .map(RetainedFamilyPlanTransport::from_plan)
+                .collect(),
+            retained,
+        };
+        envelope.validate()?;
+        Ok(envelope)
+    }
+
+    /// Compatibility incremental for one family plan.
     pub fn incremental(
         retained: RetainedExecutionDeltaEnvelope,
         frame: &RetainedFamilyFrame<'_>,
@@ -78,6 +135,27 @@ impl RetainedFamilyExecutionDeltaEnvelope {
         }
         let envelope = Self {
             family_states: family_states_for_indices(
+                frame,
+                changes.object_indices().iter().copied(),
+            )?,
+            family_plans: Vec::new(),
+            retained,
+        };
+        envelope.validate()?;
+        Ok(envelope)
+    }
+
+    /// Sparse plural-family incremental. Plan identity is sent only for changed objects.
+    pub fn planned_incremental(
+        retained: RetainedExecutionDeltaEnvelope,
+        frame: &RetainedPlannedFamilyFrame<'_>,
+        changes: &FrameChanges,
+    ) -> Result<Self, RetainedFamilyExecutionTransportError> {
+        if retained.snapshot {
+            return Err(RetainedFamilyExecutionTransportError::ExpectedIncremental);
+        }
+        let envelope = Self {
+            family_states: planned_family_states_for_indices(
                 frame,
                 changes.object_indices().iter().copied(),
             )?,
@@ -101,6 +179,7 @@ impl RetainedFamilyExecutionDeltaEnvelope {
                 ));
             }
             entry.state.validate()?;
+            entry.validate_plan_identity()?;
         }
         for plan in &self.family_plans {
             plan.validate()?;
@@ -127,6 +206,30 @@ fn family_states_for_indices(
         .collect()
 }
 
+fn planned_family_states_for_indices(
+    frame: &RetainedPlannedFamilyFrame<'_>,
+    indices: impl IntoIterator<Item = usize>,
+) -> Result<Vec<RetainedFamilyExecutionObjectState>, RetainedFamilyExecutionTransportError> {
+    if frame.family_animations.len() != frame.retained.objects.len()
+        || frame.family_plan_indices.len() != frame.retained.objects.len()
+    {
+        return Err(RetainedFamilyExecutionTransportError::FrameShapeMismatch);
+    }
+    indices
+        .into_iter()
+        .map(|index| {
+            let object = frame.retained.objects.get(index).ok_or(
+                RetainedFamilyExecutionTransportError::InvalidObjectIndex(index),
+            )?;
+            RetainedFamilyExecutionObjectState::planned(
+                object.id,
+                frame.family_animation(index),
+                frame.family_plan_index(index),
+            )
+        })
+        .collect()
+}
+
 /// Renderer-side family state paired with a resolved retained execution frame.
 ///
 /// Snapshots replace plans/state only after the complete replacement validates.
@@ -134,6 +237,7 @@ fn family_states_for_indices(
 #[derive(Clone, Debug, Default)]
 pub struct InstalledRetainedFamilyExecutionState {
     states: Vec<Option<FamilyAnimationState>>,
+    plan_indices: Vec<Option<u32>>,
     plans: Vec<RetainedFamilyAnimationPlan>,
     initialized: bool,
 }
@@ -154,10 +258,15 @@ impl InstalledRetainedFamilyExecutionState {
                 .map(|plan| plan.install(frame, texts))
                 .collect::<Result<Vec<_>, _>>()?;
             let mut states = vec![None; frame.objects.len()];
-            for (index, state) in validated_state_updates(frame, &plans, &delta.family_states)? {
+            let mut plan_indices = vec![None; frame.objects.len()];
+            for (index, state, plan_index) in
+                validated_state_updates(frame, &plans, &delta.family_states)?
+            {
                 states[index] = state;
+                plan_indices[index] = plan_index;
             }
             self.states = states;
+            self.plan_indices = plan_indices;
             self.plans = plans;
             self.initialized = true;
             return Ok(());
@@ -166,13 +275,16 @@ impl InstalledRetainedFamilyExecutionState {
         if !self.initialized {
             return Err(RetainedFamilyExecutionTransportError::IncrementalBeforeSnapshot);
         }
-        if self.states.len() != frame.objects.len() {
+        if self.states.len() != frame.objects.len()
+            || self.plan_indices.len() != frame.objects.len()
+        {
             return Err(RetainedFamilyExecutionTransportError::FrameShapeMismatch);
         }
 
         let updates = validated_state_updates(frame, &self.plans, &delta.family_states)?;
-        for (index, state) in updates {
+        for (index, state, plan_index) in updates {
             self.states[index] = state;
+            self.plan_indices[index] = plan_index;
         }
         Ok(())
     }
@@ -181,15 +293,22 @@ impl InstalledRetainedFamilyExecutionState {
         &'a self,
         retained: &'a RetainedFrameState,
     ) -> Result<RetainedFamilyFrame<'a>, RetainedFamilyExecutionTransportError> {
-        if !self.initialized {
-            return Err(RetainedFamilyExecutionTransportError::MissingSnapshot);
-        }
-        if self.states.len() != retained.objects.len() {
-            return Err(RetainedFamilyExecutionTransportError::FrameShapeMismatch);
-        }
+        self.validate_frame_shape(retained)?;
         Ok(RetainedFamilyFrame {
             retained,
             family_animations: &self.states,
+        })
+    }
+
+    pub fn planned_frame<'a>(
+        &'a self,
+        retained: &'a RetainedFrameState,
+    ) -> Result<RetainedPlannedFamilyFrame<'a>, RetainedFamilyExecutionTransportError> {
+        self.validate_frame_shape(retained)?;
+        Ok(RetainedPlannedFamilyFrame {
+            retained,
+            family_animations: &self.states,
+            family_plan_indices: &self.plan_indices,
         })
     }
 
@@ -197,16 +316,32 @@ impl InstalledRetainedFamilyExecutionState {
         &self.plans
     }
 
+    /// Legacy convenience for callers that deliberately operate on one plan only.
     pub fn single_plan(
         &self,
     ) -> Result<Option<&RetainedFamilyAnimationPlan>, RetainedFamilyExecutionTransportError> {
         match self.plans.as_slice() {
             [] => Ok(None),
             [plan] => Ok(Some(plan)),
-            plans => {
-                Err(RetainedFamilyExecutionTransportError::MultiplePlansUnsupported(plans.len()))
-            }
+            plans => Err(RetainedFamilyExecutionTransportError::MultiplePlansUnsupported(
+                plans.len(),
+            )),
         }
+    }
+
+    fn validate_frame_shape(
+        &self,
+        retained: &RetainedFrameState,
+    ) -> Result<(), RetainedFamilyExecutionTransportError> {
+        if !self.initialized {
+            return Err(RetainedFamilyExecutionTransportError::MissingSnapshot);
+        }
+        if self.states.len() != retained.objects.len()
+            || self.plan_indices.len() != retained.objects.len()
+        {
+            return Err(RetainedFamilyExecutionTransportError::FrameShapeMismatch);
+        }
+        Ok(())
     }
 }
 
@@ -214,7 +349,10 @@ fn validated_state_updates(
     frame: &RetainedFrameState,
     plans: &[RetainedFamilyAnimationPlan],
     entries: &[RetainedFamilyExecutionObjectState],
-) -> Result<Vec<(usize, Option<FamilyAnimationState>)>, RetainedFamilyExecutionTransportError> {
+) -> Result<
+    Vec<(usize, Option<FamilyAnimationState>, Option<u32>)>,
+    RetainedFamilyExecutionTransportError,
+> {
     entries
         .iter()
         .map(|entry| {
@@ -225,16 +363,38 @@ fn validated_state_updates(
                 .ok_or(RetainedFamilyExecutionTransportError::UnknownObject(
                     entry.object,
                 ))?;
-            if entry.state.family_animation.is_some()
-                && !plans
-                    .iter()
-                    .any(|plan| plan.leaf_for_object(entry.object).is_some())
-            {
+            let state = entry.state.family_animation;
+            let plan_index = match (state, entry.family_plan_index) {
+                (None, _) => None,
+                (Some(_), Some(plan_index)) => Some(plan_index),
+                (Some(_), None) if plans.len() == 1 => Some(0),
+                (Some(_), None) => {
+                    return Err(RetainedFamilyExecutionTransportError::MissingPlanIndex(
+                        entry.object,
+                    ));
+                }
+            };
+
+            if let Some(plan_index) = plan_index {
+                let plan = plans.get(plan_index as usize).ok_or(
+                    RetainedFamilyExecutionTransportError::InvalidPlanIndex {
+                        object: entry.object,
+                        plan_index,
+                        plan_count: plans.len(),
+                    },
+                )?;
+                if plan.leaf_for_object(entry.object).is_none() {
+                    return Err(RetainedFamilyExecutionTransportError::PlanDoesNotOwnObject {
+                        object: entry.object,
+                        plan_index,
+                    });
+                }
+            } else if state.is_some() {
                 return Err(RetainedFamilyExecutionTransportError::StateWithoutPlan(
                     entry.object,
                 ));
             }
-            Ok((index, entry.state.family_animation))
+            Ok((index, state, plan_index))
         })
         .collect()
 }
@@ -252,6 +412,17 @@ pub enum RetainedFamilyExecutionTransportError {
     DuplicateStateObject(ObjectId),
     UnknownObject(ObjectId),
     StateWithoutPlan(ObjectId),
+    PlanIndexWithoutState(ObjectId),
+    MissingPlanIndex(ObjectId),
+    InvalidPlanIndex {
+        object: ObjectId,
+        plan_index: u32,
+        plan_count: usize,
+    },
+    PlanDoesNotOwnObject {
+        object: ObjectId,
+        plan_index: u32,
+    },
     MultiplePlansUnsupported(usize),
 }
 
@@ -291,9 +462,33 @@ impl std::fmt::Display for RetainedFamilyExecutionTransportError {
                 "retained family state for object {} has no installed member plan",
                 object.get()
             ),
+            Self::PlanIndexWithoutState(object) => write!(
+                formatter,
+                "retained family object {} has a plan index without an active state",
+                object.get()
+            ),
+            Self::MissingPlanIndex(object) => write!(
+                formatter,
+                "active retained family state for object {} does not identify an installed plan",
+                object.get()
+            ),
+            Self::InvalidPlanIndex {
+                object,
+                plan_index,
+                plan_count,
+            } => write!(
+                formatter,
+                "retained family object {} references plan index {plan_index}, but only {plan_count} plans are installed",
+                object.get()
+            ),
+            Self::PlanDoesNotOwnObject { object, plan_index } => write!(
+                formatter,
+                "retained family plan {plan_index} does not own object {}",
+                object.get()
+            ),
             Self::MultiplePlansUnsupported(count) => write!(
                 formatter,
-                "retained family renderer currently requires one active plan, got {count}"
+                "single-plan compatibility helper received {count} retained family plans"
             ),
         }
     }
@@ -357,7 +552,7 @@ mod tests {
             sequence,
             snapshot,
             time: 0.0,
-            camera: Camera2DState::default(),
+            camera: noon_core::Camera2DState::default(),
             objects: vec![RetainedTransportObjectState {
                 slot: TransportSlotId {
                     slot: 0,
@@ -436,6 +631,14 @@ mod tests {
                 .family_animation(0),
             Some(family_state(0.5))
         );
+        assert_eq!(
+            installed
+                .planned_frame(&retained_frame)
+                .unwrap()
+                .family_plan_index(0),
+            Some(0),
+            "legacy single-plan state receives deterministic compatibility index zero",
+        );
 
         let cleared = [None];
         let cleared_frame = RetainedFamilyFrame {
@@ -452,11 +655,61 @@ mod tests {
             .apply(&incremental, &retained_frame, &TextResourceArena::new())
             .unwrap();
         assert_eq!(
-            installed
-                .frame(&retained_frame)
-                .unwrap()
-                .family_animation(0),
+            installed.frame(&retained_frame).unwrap().family_animation(0),
             None
+        );
+        assert_eq!(
+            installed
+                .planned_frame(&retained_frame)
+                .unwrap()
+                .family_plan_index(0),
+            None
+        );
+    }
+
+    #[test]
+    fn plural_state_requires_and_validates_exact_plan_identity() {
+        let retained_frame = frame();
+        let plan = geometry_plan();
+        let snapshot = RetainedFamilyExecutionDeltaEnvelope {
+            retained: retained(true, 0),
+            family_states: vec![RetainedFamilyExecutionObjectState::planned(
+                ObjectId::new(7),
+                Some(family_state(0.5)),
+                Some(1),
+            )
+            .unwrap()],
+            family_plans: vec![
+                RetainedFamilyPlanTransport::from_plan(&plan),
+                RetainedFamilyPlanTransport::from_plan(&plan),
+            ],
+        };
+        let mut installed = InstalledRetainedFamilyExecutionState::default();
+        installed
+            .apply(&snapshot, &retained_frame, &TextResourceArena::new())
+            .unwrap();
+        assert_eq!(
+            installed
+                .planned_frame(&retained_frame)
+                .unwrap()
+                .family_plan_index(0),
+            Some(1)
+        );
+
+        let missing = RetainedFamilyExecutionDeltaEnvelope {
+            retained: retained(false, 1),
+            family_states: vec![RetainedFamilyExecutionObjectState::new(
+                ObjectId::new(7),
+                Some(family_state(0.25)),
+            )
+            .unwrap()],
+            family_plans: Vec::new(),
+        };
+        assert_eq!(
+            installed
+                .apply(&missing, &retained_frame, &TextResourceArena::new())
+                .unwrap_err(),
+            RetainedFamilyExecutionTransportError::MissingPlanIndex(ObjectId::new(7))
         );
     }
 
@@ -493,7 +746,7 @@ mod tests {
             installed
                 .apply(&bad, &frame(), &TextResourceArena::new())
                 .unwrap_err(),
-            RetainedFamilyExecutionTransportError::StateWithoutPlan(ObjectId::new(7))
+            RetainedFamilyExecutionTransportError::MissingPlanIndex(ObjectId::new(7))
         );
     }
 
@@ -522,7 +775,7 @@ mod tests {
             installed
                 .apply(&invalid, &retained_frame, &TextResourceArena::new())
                 .unwrap_err(),
-            RetainedFamilyExecutionTransportError::StateWithoutPlan(ObjectId::new(7))
+            RetainedFamilyExecutionTransportError::MissingPlanIndex(ObjectId::new(7))
         );
         assert!(installed.single_plan().unwrap().is_some());
         assert_eq!(

--- a/crates/noon-web/src/retained_family_execution_transport.rs
+++ b/crates/noon-web/src/retained_family_execution_transport.rs
@@ -55,9 +55,7 @@ impl RetainedFamilyExecutionObjectState {
 
     fn validate_plan_identity(&self) -> Result<(), RetainedFamilyExecutionTransportError> {
         if self.state.family_animation.is_none() && self.family_plan_index.is_some() {
-            return Err(RetainedFamilyExecutionTransportError::PlanIndexWithoutState(
-                self.object,
-            ));
+            return Err(RetainedFamilyExecutionTransportError::PlanIndexWithoutState(self.object));
         }
         Ok(())
     }
@@ -323,9 +321,9 @@ impl InstalledRetainedFamilyExecutionState {
         match self.plans.as_slice() {
             [] => Ok(None),
             [plan] => Ok(Some(plan)),
-            plans => Err(RetainedFamilyExecutionTransportError::MultiplePlansUnsupported(
-                plans.len(),
-            )),
+            plans => {
+                Err(RetainedFamilyExecutionTransportError::MultiplePlansUnsupported(plans.len()))
+            }
         }
     }
 
@@ -384,10 +382,12 @@ fn validated_state_updates(
                     },
                 )?;
                 if plan.leaf_for_object(entry.object).is_none() {
-                    return Err(RetainedFamilyExecutionTransportError::PlanDoesNotOwnObject {
-                        object: entry.object,
-                        plan_index,
-                    });
+                    return Err(
+                        RetainedFamilyExecutionTransportError::PlanDoesNotOwnObject {
+                            object: entry.object,
+                            plan_index,
+                        },
+                    );
                 }
             } else if state.is_some() {
                 return Err(RetainedFamilyExecutionTransportError::StateWithoutPlan(
@@ -552,7 +552,7 @@ mod tests {
             sequence,
             snapshot,
             time: 0.0,
-            camera: noon_core::Camera2DState::default(),
+            camera: Camera2DState::default(),
             objects: vec![RetainedTransportObjectState {
                 slot: TransportSlotId {
                     slot: 0,
@@ -655,7 +655,10 @@ mod tests {
             .apply(&incremental, &retained_frame, &TextResourceArena::new())
             .unwrap();
         assert_eq!(
-            installed.frame(&retained_frame).unwrap().family_animation(0),
+            installed
+                .frame(&retained_frame)
+                .unwrap()
+                .family_animation(0),
             None
         );
         assert_eq!(

--- a/web/family-animation-authoring.test.mjs
+++ b/web/family-animation-authoring.test.mjs
@@ -31,6 +31,17 @@ test("retained family creation-animation module is valid Python and bundled", ()
   assert.match(pythonSource, /bindRetainedNativeText/);
 });
 
+test("Python appends family requests without owning the scene-wide scheduler limit", () => {
+  assert.doesNotMatch(
+    pythonSource,
+    /supports one family animation request per scene/,
+  );
+  assert.match(
+    pythonSource,
+    /Rust owns plural-plan validation/,
+  );
+});
+
 test("Python does not serialize semantic family order or retained resource identity", () => {
   for (const forbidden of [
     "memberSlot(",

--- a/web/manim-compat-smoke.html
+++ b/web/manim-compat-smoke.html
@@ -7,6 +7,7 @@
   </head>
   <body>
     <canvas id="retained-write-smoke" width="640" height="360"></canvas>
+    <canvas id="retained-stress-smoke" width="640" height="360"></canvas>
     <script type="module">
       import init, { semanticFrameJson } from "./pkg/noon_web.js";
       import { PythonAuthoringClient } from "./authoring-client.js";
@@ -54,6 +55,8 @@ class RetainedSequentialFamilySmoke(Scene):
       let writeResult = null;
       let sequentialResult = null;
       let writeRenderResult = null;
+      let stressResult = null;
+      let stressRenderResult = null;
 
       function oneFamilyRequest(result, label) {
         if (result.kind !== "scene_document") {
@@ -104,7 +107,97 @@ class RetainedSequentialFamilySmoke(Scene):
         return requests;
       }
 
-      async function renderWriteMidpoint() {
+      async function waitForRenderedState(
+        execution,
+        { label, seekTime, expectedObjectCount, errors },
+      ) {
+        let latest = null;
+        for (let attempt = 0; attempt < 100; attempt += 1) {
+          latest = await execution.metrics();
+          if (errors.length !== 0) {
+            throw new Error(`${label} retained execution reported errors: ${errors.join("; ")}`);
+          }
+          const renderTime = Number(latest.metrics.time);
+          if (
+            Math.abs(renderTime - seekTime) <= 1e-6 &&
+            latest.metrics.objectCount === expectedObjectCount
+          ) {
+            return latest;
+          }
+          await new Promise((resolve) => setTimeout(resolve, 20));
+        }
+        const renderTime = latest == null ? "unavailable" : latest.metrics.time;
+        const objectCount = latest == null ? "unavailable" : latest.metrics.objectCount;
+        throw new Error(
+          `${label} renderer did not converge to t=${seekTime} with ${expectedObjectCount} visible objects; ` +
+            `last state was t=${renderTime}, objects=${objectCount}`,
+        );
+      }
+
+      function assertCanonicalRenderedState(metrics, label, seekTime) {
+        if (!metrics.metrics.ready || !metrics.metrics.retained || !metrics.engineMetrics.canonical) {
+          throw new Error(`${label} did not run through canonical retained execution`);
+        }
+        if (metrics.metrics.presentedFrames < 1 || metrics.metrics.drawCalls < 1 || metrics.metrics.instancesDrawn < 1) {
+          throw new Error(`${label} did not produce a presented retained render frame`);
+        }
+        if (Math.abs(Number(metrics.engineMetrics.time) - seekTime) > 1e-6) {
+          throw new Error(`${label} deterministic seek drifted to ${metrics.engineMetrics.time}`);
+        }
+      }
+
+      async function renderCanonicalMidpoint({
+        result,
+        canvasSelector,
+        label,
+        loopDurationSeconds,
+        seekTime,
+        expectedObjectCount,
+      }) {
+        if (result == null) {
+          throw new Error(`${label} authoring result is unavailable`);
+        }
+
+        const canvas = document.querySelector(canvasSelector);
+        const errors = [];
+        const execution = new ExecutionWorkerClient(canvas, {
+          onError(error, owner) {
+            errors.push(`${owner}: ${error}`);
+          },
+        });
+        try {
+          const readyState = await execution.startRetainedCanonical(
+            JSON.stringify(result.sceneSpec),
+            {
+              loopDurationSeconds,
+              transportMode: "transferable",
+            },
+          );
+          await execution.pause();
+          await execution.seek(seekTime);
+          const metrics = await waitForRenderedState(execution, {
+            label,
+            seekTime,
+            expectedObjectCount,
+            errors,
+          });
+          assertCanonicalRenderedState(metrics, `${label} midpoint`, seekTime);
+          return {
+            backend: metrics.metrics.backend,
+            presentedFrames: metrics.metrics.presentedFrames,
+            drawCalls: metrics.metrics.drawCalls,
+            instancesDrawn: metrics.metrics.instancesDrawn,
+            engineTime: metrics.engineMetrics.time,
+            renderTime: metrics.metrics.time,
+            objectCount: metrics.metrics.objectCount,
+            readyState,
+          };
+        } finally {
+          execution.terminate();
+        }
+      }
+
+      async function renderSequentialFamilySwitch() {
         if (sequentialResult == null) {
           throw new Error("sequential family authoring result is unavailable");
         }
@@ -125,44 +218,37 @@ class RetainedSequentialFamilySmoke(Scene):
             },
           );
           await execution.pause();
+
           await execution.seek(0.5);
-          await new Promise((resolve) => setTimeout(resolve, 120));
-          const first = await execution.metrics();
-          if (!first.metrics.ready || !first.metrics.retained || !first.engineMetrics.canonical) {
-            throw new Error("first family request did not run through canonical retained execution");
-          }
-          if (first.metrics.objectCount !== 1) {
-            throw new Error(`first family request expected one object, got ${first.metrics.objectCount}`);
-          }
-          if (first.metrics.presentedFrames < 1 || first.metrics.drawCalls < 1 || first.metrics.instancesDrawn < 1) {
-            throw new Error("first family request did not produce a retained render frame");
-          }
-          if (Math.abs(Number(first.engineMetrics.time) - 0.5) > 1e-6) {
-            throw new Error(`first family request deterministic seek drifted to ${first.engineMetrics.time}`);
+          const first = await waitForRenderedState(execution, {
+            label: "sequential family first plan",
+            seekTime: 0.5,
+            expectedObjectCount: 1,
+            errors,
+          });
+          assertCanonicalRenderedState(first, "sequential family first plan", 0.5);
+          const presentedAfterFirst = first.metrics.presentedFrames;
+
+          await execution.seek(1.5);
+          const second = await waitForRenderedState(execution, {
+            label: "sequential family second plan",
+            seekTime: 1.5,
+            expectedObjectCount: 1,
+            errors,
+          });
+          assertCanonicalRenderedState(second, "sequential family second plan", 1.5);
+          if (second.metrics.presentedFrames <= presentedAfterFirst) {
+            throw new Error("sequential family second plan did not present a new retained frame");
           }
 
-          const presentedAfterFirst = first.metrics.presentedFrames;
-          await execution.seek(1.5);
-          await new Promise((resolve) => setTimeout(resolve, 120));
-          const second = await execution.metrics();
-          if (second.metrics.objectCount !== 1) {
-            throw new Error(`second family request expected one object, got ${second.metrics.objectCount}`);
-          }
-          if (second.metrics.presentedFrames <= presentedAfterFirst || second.metrics.drawCalls < 1 || second.metrics.instancesDrawn < 1) {
-            throw new Error("second family request did not switch plans and present a retained frame");
-          }
-          if (Math.abs(Number(second.engineMetrics.time) - 1.5) > 1e-6) {
-            throw new Error(`second family request deterministic seek drifted to ${second.engineMetrics.time}`);
-          }
-          if (errors.length !== 0) {
-            throw new Error(`sequential family retained execution reported errors: ${errors.join("; ")}`);
-          }
           return {
             backend: second.metrics.backend,
             presentedFrames: second.metrics.presentedFrames,
             drawCalls: second.metrics.drawCalls,
             instancesDrawn: second.metrics.instancesDrawn,
             engineTime: second.engineMetrics.time,
+            renderTime: second.metrics.time,
+            objectCount: second.metrics.objectCount,
             readyState,
           };
         } finally {
@@ -236,16 +322,58 @@ class RetainedSequentialFamilySmoke(Scene):
               throw new Error(`sequential family scene cursor drifted to ${sequentialResult.duration}`);
             }
 
-            // One worker execution crosses the exact touching boundary and renders both
-            // immutable plans. This catches browser-side plan-selection regressions that
-            // authoring-only JSON and native Rust tests cannot see.
-            writeRenderResult = await renderWriteMidpoint();
+            // One canonical worker crosses the touching boundary and renders both plans.
+            writeRenderResult = await renderSequentialFamilySwitch();
+
+            const stressResponse = await fetch("./python/examples/manim_parity_stress_grid.py");
+            if (!stressResponse.ok) {
+              throw new Error(`stress source fetch failed with HTTP ${stressResponse.status}`);
+            }
+            const stressSource = await stressResponse.text();
+            stressResult = await client.run(stressSource);
+            if (stressResult.kind !== "scene_document") {
+              throw new Error(`stress smoke returned ${stressResult.kind}`);
+            }
+            if (Math.abs(Number(stressResult.duration) - 5.0) > 1e-12) {
+              throw new Error(`stress scene duration drifted to ${stressResult.duration}`);
+            }
+            if (!stressResult.sceneSpec) {
+              throw new Error("stress scene did not produce canonical SceneSpec");
+            }
+            if (stressResult.document.objects.length !== 108) {
+              throw new Error(
+                `stress scene expected 108 geometry objects, got ${stressResult.document.objects.length}`,
+              );
+            }
+            if (stressResult.retainedDocument?.objects?.length !== 2) {
+              throw new Error(
+                `stress scene expected two retained Text objects, got ${stressResult.retainedDocument?.objects?.length}`,
+              );
+            }
+            if (stressResult.sceneSpec.objects.length !== 110) {
+              throw new Error(
+                `stress canonical SceneSpec expected 110 mixed objects, got ${stressResult.sceneSpec.objects.length}`,
+              );
+            }
+            stressRenderResult = await renderCanonicalMidpoint({
+              result: stressResult,
+              canvasSelector: "#retained-stress-smoke",
+              label: "mixed-object parity stress",
+              loopDurationSeconds: 5.0,
+              seekTime: 2.8,
+              // At t=2.8 the 72 original shapes and two retained Text objects are
+              // present. The 36 pulse circles are authored but do not enter until 3.6s.
+              expectedObjectCount: 74,
+            });
+
             return {
               create,
               write: writeResult,
               unwrite,
               sequential: sequentialResult,
               writeRender: writeRenderResult,
+              stress: stressResult,
+              stressRender: stressRenderResult,
             };
           })();
         }
@@ -257,6 +385,10 @@ class RetainedSequentialFamilySmoke(Scene):
         renderRetainedWriteMidpoint: async () => {
           await ready();
           return writeRenderResult;
+        },
+        renderStressMidpoint: async () => {
+          await ready();
+          return stressRenderResult;
         },
         run: (source) => client.run(source),
         semanticFrame: (sceneJson, time) => JSON.parse(semanticFrameJson(sceneJson, time)),

--- a/web/manim-compat-smoke.html
+++ b/web/manim-compat-smoke.html
@@ -40,9 +40,19 @@ class RetainedFamilyUnwriteSmoke(Scene):
         self.add(text)
         self.play(Unwrite(text))
 `;
+      const sequentialFamilySource = `
+from noon import *
+
+class RetainedSequentialFamilySmoke(Scene):
+    def construct(self):
+        text = Text("AB")
+        self.play(Write(text), run_time=1.0, rate_func=linear)
+        self.play(Unwrite(text), run_time=1.0, rate_func=linear)
+`;
 
       let readyPromise = null;
       let writeResult = null;
+      let sequentialResult = null;
       let writeRenderResult = null;
 
       function oneFamilyRequest(result, label) {
@@ -70,9 +80,33 @@ class RetainedFamilyUnwriteSmoke(Scene):
         return request;
       }
 
+      function sequentialFamilyRequests(result) {
+        if (result.kind !== "scene_document") {
+          throw new Error(`sequential family smoke returned ${result.kind}`);
+        }
+        const retained = result.retainedDocument;
+        if (!retained || retained.objects.length !== 1) {
+          throw new Error("sequential family smoke expected one retained Text object");
+        }
+        if (!Array.isArray(retained.family_animations) || retained.family_animations.length !== 2) {
+          throw new Error("sequential family smoke did not author two retained family requests");
+        }
+        const requests = result.sceneSpec?.family_animations;
+        if (!Array.isArray(requests) || requests.length !== 2) {
+          throw new Error("sequential family smoke did not reach two canonical family requests");
+        }
+        const serialized = JSON.stringify(requests);
+        for (const forbidden of ["glyph_id", "atlas_id", "font_bytes"]) {
+          if (serialized.includes(forbidden)) {
+            throw new Error(`sequential family requests leaked ${forbidden}`);
+          }
+        }
+        return requests;
+      }
+
       async function renderWriteMidpoint() {
-        if (writeResult == null) {
-          throw new Error("family Write authoring result is unavailable");
+        if (sequentialResult == null) {
+          throw new Error("sequential family authoring result is unavailable");
         }
 
         const canvas = document.querySelector("#retained-write-smoke");
@@ -84,37 +118,51 @@ class RetainedFamilyUnwriteSmoke(Scene):
         });
         try {
           const readyState = await execution.startRetainedCanonical(
-            JSON.stringify(writeResult.sceneSpec),
+            JSON.stringify(sequentialResult.sceneSpec),
             {
-              loopDurationSeconds: 1.0,
+              loopDurationSeconds: 2.0,
               transportMode: "transferable",
             },
           );
           await execution.pause();
           await execution.seek(0.5);
           await new Promise((resolve) => setTimeout(resolve, 120));
-          const metrics = await execution.metrics();
-          if (!metrics.metrics.ready || !metrics.metrics.retained || !metrics.engineMetrics.canonical) {
-            throw new Error("family Write midpoint did not run through canonical retained execution");
+          const first = await execution.metrics();
+          if (!first.metrics.ready || !first.metrics.retained || !first.engineMetrics.canonical) {
+            throw new Error("first family request did not run through canonical retained execution");
           }
-          if (metrics.metrics.objectCount !== 1) {
-            throw new Error(`family Write renderer expected one object, got ${metrics.metrics.objectCount}`);
+          if (first.metrics.objectCount !== 1) {
+            throw new Error(`first family request expected one object, got ${first.metrics.objectCount}`);
           }
-          if (metrics.metrics.presentedFrames < 1 || metrics.metrics.drawCalls < 1 || metrics.metrics.instancesDrawn < 1) {
-            throw new Error("family Write midpoint did not produce a presented retained render frame");
+          if (first.metrics.presentedFrames < 1 || first.metrics.drawCalls < 1 || first.metrics.instancesDrawn < 1) {
+            throw new Error("first family request did not produce a retained render frame");
           }
-          if (Math.abs(Number(metrics.engineMetrics.time) - 0.5) > 1e-6) {
-            throw new Error(`family Write deterministic seek drifted to ${metrics.engineMetrics.time}`);
+          if (Math.abs(Number(first.engineMetrics.time) - 0.5) > 1e-6) {
+            throw new Error(`first family request deterministic seek drifted to ${first.engineMetrics.time}`);
+          }
+
+          const presentedAfterFirst = first.metrics.presentedFrames;
+          await execution.seek(1.5);
+          await new Promise((resolve) => setTimeout(resolve, 120));
+          const second = await execution.metrics();
+          if (second.metrics.objectCount !== 1) {
+            throw new Error(`second family request expected one object, got ${second.metrics.objectCount}`);
+          }
+          if (second.metrics.presentedFrames <= presentedAfterFirst || second.metrics.drawCalls < 1 || second.metrics.instancesDrawn < 1) {
+            throw new Error("second family request did not switch plans and present a retained frame");
+          }
+          if (Math.abs(Number(second.engineMetrics.time) - 1.5) > 1e-6) {
+            throw new Error(`second family request deterministic seek drifted to ${second.engineMetrics.time}`);
           }
           if (errors.length !== 0) {
-            throw new Error(`family Write retained execution reported errors: ${errors.join("; ")}`);
+            throw new Error(`sequential family retained execution reported errors: ${errors.join("; ")}`);
           }
           return {
-            backend: metrics.metrics.backend,
-            presentedFrames: metrics.metrics.presentedFrames,
-            drawCalls: metrics.metrics.drawCalls,
-            instancesDrawn: metrics.metrics.instancesDrawn,
-            engineTime: metrics.engineMetrics.time,
+            backend: second.metrics.backend,
+            presentedFrames: second.metrics.presentedFrames,
+            drawCalls: second.metrics.drawCalls,
+            instancesDrawn: second.metrics.instancesDrawn,
+            engineTime: second.engineMetrics.time,
             readyState,
           };
         } finally {
@@ -170,11 +218,35 @@ class RetainedFamilyUnwriteSmoke(Scene):
               throw new Error("default Unwrite must reverse both per-member rate and semantic member order");
             }
 
-            // Reuse this already-loaded browser/Pyodide smoke for one real execution
-            // frame. A midpoint seek forces DrawBorderThenFill through the canonical
-            // family runtime and retained renderer instead of only checking authoring JSON.
+            sequentialResult = await client.run(sequentialFamilySource);
+            const sequential = sequentialFamilyRequests(sequentialResult);
+            if (Math.abs(Number(sequential[0].spec.start_time) - 0.0) > 1e-12 || Math.abs(Number(sequential[0].spec.duration) - 1.0) > 1e-12) {
+              throw new Error("sequential Write did not retain its [0, 1] canonical interval");
+            }
+            if (Math.abs(Number(sequential[1].spec.start_time) - 1.0) > 1e-12 || Math.abs(Number(sequential[1].spec.duration) - 1.0) > 1e-12) {
+              throw new Error("sequential Unwrite did not retain its [1, 2] canonical interval");
+            }
+            if (sequential[0].spec.reverse_rate_function || sequential[0].spec.reverse_member_order) {
+              throw new Error("sequential Write unexpectedly reversed rate or member order");
+            }
+            if (!sequential[1].spec.reverse_rate_function || !sequential[1].spec.reverse_member_order) {
+              throw new Error("sequential Unwrite did not retain reverse rate/member semantics");
+            }
+            if (Math.abs(Number(sequentialResult.duration) - 2.0) > 1e-12) {
+              throw new Error(`sequential family scene cursor drifted to ${sequentialResult.duration}`);
+            }
+
+            // One worker execution crosses the exact touching boundary and renders both
+            // immutable plans. This catches browser-side plan-selection regressions that
+            // authoring-only JSON and native Rust tests cannot see.
             writeRenderResult = await renderWriteMidpoint();
-            return { create, write: writeResult, unwrite, writeRender: writeRenderResult };
+            return {
+              create,
+              write: writeResult,
+              unwrite,
+              sequential: sequentialResult,
+              writeRender: writeRenderResult,
+            };
           })();
         }
         return readyPromise;

--- a/web/manim-compat-smoke.html
+++ b/web/manim-compat-smoke.html
@@ -340,9 +340,9 @@ class RetainedSequentialFamilySmoke(Scene):
             if (!stressResult.sceneSpec) {
               throw new Error("stress scene did not produce canonical SceneSpec");
             }
-            if (stressResult.document.objects.length !== 108) {
+            if (stressResult.document.objects.length !== 800) {
               throw new Error(
-                `stress scene expected 108 geometry objects, got ${stressResult.document.objects.length}`,
+                `stress scene expected 800 geometry objects, got ${stressResult.document.objects.length}`,
               );
             }
             if (stressResult.retainedDocument?.objects?.length !== 2) {
@@ -350,9 +350,9 @@ class RetainedSequentialFamilySmoke(Scene):
                 `stress scene expected two retained Text objects, got ${stressResult.retainedDocument?.objects?.length}`,
               );
             }
-            if (stressResult.sceneSpec.objects.length !== 110) {
+            if (stressResult.sceneSpec.objects.length !== 802) {
               throw new Error(
-                `stress canonical SceneSpec expected 110 mixed objects, got ${stressResult.sceneSpec.objects.length}`,
+                `stress canonical SceneSpec expected 802 mixed objects, got ${stressResult.sceneSpec.objects.length}`,
               );
             }
             stressRenderResult = await renderCanonicalMidpoint({
@@ -361,9 +361,9 @@ class RetainedSequentialFamilySmoke(Scene):
               label: "mixed-object parity stress",
               loopDurationSeconds: 5.0,
               seekTime: 2.8,
-              // At t=2.8 the 72 original shapes and two retained Text objects are
-              // present. The 36 pulse circles are authored but do not enter until 3.6s.
-              expectedObjectCount: 74,
+              // At t=2.8 all 600 primary shapes and both retained Text objects are
+              // present. The 200 pulse circles are authored but do not enter until 3.7s.
+              expectedObjectCount: 602,
             });
 
             return {

--- a/web/python/_manim_family_creation.py
+++ b/web/python/_manim_family_creation.py
@@ -335,10 +335,8 @@ def _request_list(scene: _compat.Scene) -> list[dict[str, Any]]:
     if requests is None:
         requests = []
         scene._retained_family_animations = requests
-    if requests:
-        raise NotImplementedError(
-            "canonical retained execution currently supports one family animation request per scene"
-        )
+    # Preserve source play order. Rust owns plural-plan validation, including rejecting
+    # time-overlapping ownership of the same retained object before playback starts.
     return requests
 
 


### PR DESCRIPTION
## Summary
- replace the single-family retained runtime owner with a plural immutable-plan runtime
- preserve canonical request order as stable plan indices
- allow sequential same-object family requests and concurrent disjoint requests
- reject only time-overlapping family ownership of the same retained object
- carry active plan identity explicitly per object through the additive retained execution envelope
- keep existing single-plan transport JSON readable by resolving legacy active state to plan index 0
- prepare mixed active family operations in one renderer pass by reusing the existing Reveal and DrawBorderThenFill realizers
- remove the canonical engine's blanket multiple-family-request rejection
- allow Python to append sequential canonical family requests while keeping one family animation per `Scene.play` call

## Architecture
The renderer never guesses which immutable plan owns an active object. Runtime evaluation emits a per-object plan index referring to the snapshot-installed `family_plans` vector. Glyph/resource identity remains renderer-local and the family wire remains glyph-free.

Touching intervals are allowed; at a shared boundary the later-starting request owns the object. This matches the existing retained family scheduler policy while making ownership deterministic.

## Current-master integration
The branch incorporates master `fafc2622c5d23b5eeffca8a8499fe9ea8a617abf` as a merge parent. The only overlapping file was `web/manim-compat-smoke.html`; the resolution preserves both the plural-family `Write -> Unwrite` acceptance and #891's 600-active-shape stress ratchet (800 geometry objects, 802 canonical mixed objects, 602 visible objects at t=2.8). A master-to-head comparison reports `behind_by = 0` and exactly the intended 14 PR files differ.

## Validation
Exact head `877035fe35b2770c57b5e531714f792d636a4842` passed PR Fast Gate run #468 (`33641785292`):
- Rust formatting + Clippy
- Rust unit tests
- web static/unit checks
- browser WASM build
- deterministic playback
- Manim/Pyodide authoring
- canonical retained execution
- primary WebGPU rendering

Browser acceptance authors one retained `Text("AB")`, executes `Write(text)` on `[0, 1]`, then `Unwrite(text)` on `[1, 2]`, verifies two canonical family requests without glyph/font/atlas leakage, and seeks the same canonical retained/WebGPU worker across both plan intervals. The same browser gate also retains the current 600-shape mixed-object stress acceptance from master.

Tracks #741 / #705.