### PR TITLE
Fix duplicate Python editor in playground

### DIFF
--- a/web/python-editor.js
+++ b/web/python-editor.js
@@ -86,7 +86,6 @@ async function enhancePythonEditors() {
     const host = document.createElement("div");
     host.className = "python-code-editor";
     textarea.before(host);
-    textarea.hidden = true;
 
     const view = new EditorView({
       doc: textarea.value,
@@ -101,6 +100,14 @@ async function enhancePythonEditors() {
         EditorView.lineWrapping,
       ],
     });
+
+    // Only hide the native fallback after CodeMirror has been constructed
+    // successfully. `index.html` gives all textareas `display: block`, which can
+    // override the HTML `hidden` presentational hint in author CSS. Set an
+    // explicit inline display value as well so the enhanced editor never leaves
+    // a second plain-text copy stacked underneath it.
+    textarea.hidden = true;
+    textarea.style.display = "none";
 
     // Keep the hidden textarea as the stable integration surface for the
     // playground. Programmatic .value writes are projected into CodeMirror,
@@ -146,6 +153,7 @@ async function enhancePythonEditors() {
     }
     .python-code-editor .cm-editor { height: 100%; }
     .python-code-editor .cm-focused { outline: 2px solid #aa9cff; outline-offset: -2px; }
+    .python-code-editor + textarea[hidden] { display: none !important; }
     @media (max-width: 44rem) {
       .python-code-editor { min-height: 25rem; }
       .python-code-editor .cm-editor { font-size: 0.76rem; }


### PR DESCRIPTION
## Summary

Fixes the playground showing both the syntax-highlighted CodeMirror editor and the native textarea stacked vertically.

The enhanced editor already set the textarea's `hidden` attribute, but the playground's author CSS gives all `textarea` elements `display: block`, so the hidden fallback could remain in layout depending on CSS handling.

This change:

- constructs CodeMirror before hiding the fallback so progressive enhancement still fails safely;
- sets both `hidden` and an explicit inline `display: none` after CodeMirror mounts;
- adds a defensive adjacent-sibling CSS rule with `!important` so future textarea styling cannot re-expose the hidden fallback.

This is the first P0 cleanup slice from #880.

Closes the duplicate-editor visual bug reported while working on #880.

Related: #880, #403.