### PR TITLE
Move example gallery into an Examples browser

### DIFF
--- a/scripts/playground-browser-matrix-smoke.mjs
+++ b/scripts/playground-browser-matrix-smoke.mjs
@@ -298,6 +298,23 @@ async function assertDeferredRuntime(page) {
 }
 
 async function chooseDifferentExample(page) {
+  const trigger = page.locator("#example-browser-trigger");
+  await trigger.waitFor({ state: "visible" });
+  assert.equal(
+    await trigger.getAttribute("aria-expanded"),
+    "false",
+    `${browserName}/${profileName}: Examples browser should start closed`,
+  );
+  await trigger.click();
+
+  const browserLayer = page.locator(".example-browser-layer");
+  await browserLayer.waitFor({ state: "visible" });
+  assert.equal(
+    await trigger.getAttribute("aria-expanded"),
+    "true",
+    `${browserName}/${profileName}: Examples trigger did not enter expanded state`,
+  );
+
   const targetId = await page.evaluate(() => {
     const selected = document.querySelector(".example-card[aria-selected='true']")?.dataset.exampleId;
     return [...document.querySelectorAll(".example-card")]
@@ -306,6 +323,12 @@ async function chooseDifferentExample(page) {
   });
   assert.ok(targetId, `${browserName}/${profileName}: gallery must expose a second example`);
   await page.locator(`.example-card[data-example-id="${targetId}"]`).click();
+  await browserLayer.waitFor({ state: "hidden" });
+  assert.equal(
+    await trigger.getAttribute("aria-expanded"),
+    "false",
+    `${browserName}/${profileName}: Examples browser did not close after selection`,
+  );
   await waitForAppliedScene(page, targetId);
   return targetId;
 }

--- a/web/example-browser-ui.js
+++ b/web/example-browser-ui.js
@@ -1,0 +1,371 @@
+const INSTALL_MARKER = "noonExampleBrowserInstalled";
+const STYLE_ID = "noon-example-browser-style";
+
+if (typeof document !== "undefined") {
+  installExampleBrowser(document);
+}
+
+export function installExampleBrowser(documentLike = globalThis.document) {
+  if (
+    !documentLike?.documentElement?.dataset ||
+    typeof documentLike.createElement !== "function" ||
+    typeof MutationObserver !== "function"
+  ) {
+    return false;
+  }
+  if (documentLike.documentElement.dataset[INSTALL_MARKER] === "true") {
+    return false;
+  }
+  documentLike.documentElement.dataset[INSTALL_MARKER] = "true";
+
+  installStyles(documentLike);
+
+  const tryInstall = () => {
+    const gallery = documentLike.querySelector(".example-gallery");
+    const topbar = documentLike.querySelector(".topbar");
+    const workspace = documentLike.querySelector(".workspace");
+    if (!(gallery instanceof HTMLElement) || !(topbar instanceof HTMLElement) || !(workspace instanceof HTMLElement)) {
+      return false;
+    }
+    if (gallery.closest(".example-browser-layer") !== null) {
+      return true;
+    }
+    enhanceGallery(documentLike, gallery, topbar, workspace);
+    return true;
+  };
+
+  if (tryInstall()) return true;
+
+  const observer = new MutationObserver(() => {
+    if (tryInstall()) observer.disconnect();
+  });
+  observer.observe(documentLike.documentElement, { childList: true, subtree: true });
+  return true;
+}
+
+function enhanceGallery(documentLike, gallery, topbar, workspace) {
+  gallery.id = gallery.id || "example-browser-dialog";
+  gallery.setAttribute("role", "dialog");
+  gallery.setAttribute("aria-modal", "true");
+  gallery.setAttribute("aria-label", "Examples");
+
+  const layer = documentLike.createElement("div");
+  layer.className = "example-browser-layer";
+  layer.hidden = true;
+  layer.setAttribute("aria-hidden", "true");
+
+  const backdrop = documentLike.createElement("div");
+  backdrop.className = "example-browser-backdrop";
+  backdrop.setAttribute("aria-hidden", "true");
+
+  const trigger = documentLike.createElement("button");
+  trigger.id = "example-browser-trigger";
+  trigger.type = "button";
+  trigger.className = "example-browser-trigger";
+  trigger.setAttribute("aria-haspopup", "dialog");
+  trigger.setAttribute("aria-controls", gallery.id);
+  trigger.setAttribute("aria-expanded", "false");
+  trigger.innerHTML = `<span class="example-browser-trigger-label">Example</span><span class="example-browser-trigger-value">Choose example</span><span class="example-browser-trigger-chevron" aria-hidden="true">⌄</span>`;
+
+  const status = topbar.querySelector("#status");
+  topbar.insertBefore(trigger, status ?? null);
+
+  const galleryHead = gallery.querySelector(".gallery-head");
+  const galleryTitle = gallery.querySelector(".gallery-title strong");
+  const gallerySubtitle = gallery.querySelector(".gallery-title span");
+  const gallerySearch = gallery.querySelector('input[type="search"]');
+  const galleryControls = gallery.querySelector(".gallery-controls");
+  const paritySelect = gallery.querySelector('select[aria-label="Filter examples by parity status"]');
+
+  if (galleryTitle) galleryTitle.textContent = "Examples";
+  if (gallerySubtitle) gallerySubtitle.hidden = true;
+
+  if (galleryHead instanceof HTMLElement) {
+    const closeButton = documentLike.createElement("button");
+    closeButton.type = "button";
+    closeButton.className = "example-browser-close";
+    closeButton.setAttribute("aria-label", "Close examples");
+    closeButton.textContent = "×";
+    galleryHead.append(closeButton);
+    closeButton.addEventListener("click", () => closeBrowser({ restoreFocus: true }));
+  }
+
+  if (galleryControls instanceof HTMLElement && paritySelect instanceof HTMLSelectElement) {
+    const moreFilters = documentLike.createElement("details");
+    moreFilters.className = "example-browser-more-filters";
+    const summary = documentLike.createElement("summary");
+    summary.textContent = "More filters";
+    const content = documentLike.createElement("div");
+    content.className = "example-browser-more-filters-content";
+    content.append(paritySelect);
+    moreFilters.append(summary, content);
+    galleryControls.append(moreFilters);
+  }
+
+  layer.append(backdrop, gallery);
+  documentLike.body.append(layer);
+  workspace.tabIndex = -1;
+
+  const updateTriggerLabel = () => {
+    const selected = gallery.querySelector('.example-card[aria-selected="true"] .example-card-title');
+    const value = trigger.querySelector(".example-browser-trigger-value");
+    if (value) value.textContent = selected?.textContent?.trim() || "Choose example";
+  };
+
+  const selectionObserver = new MutationObserver(updateTriggerLabel);
+  selectionObserver.observe(gallery, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ["aria-selected"],
+  });
+  updateTriggerLabel();
+
+  let previouslyFocused = null;
+
+  function openBrowser() {
+    if (!layer.hidden) return;
+    previouslyFocused = documentLike.activeElement instanceof HTMLElement ? documentLike.activeElement : trigger;
+    layer.hidden = false;
+    layer.setAttribute("aria-hidden", "false");
+    trigger.setAttribute("aria-expanded", "true");
+    documentLike.body.classList.add("example-browser-open");
+    updateTriggerLabel();
+    requestAnimationFrame(() => {
+      if (gallerySearch instanceof HTMLElement) {
+        gallerySearch.focus();
+      } else {
+        gallery.querySelector("button, input, select, summary")?.focus();
+      }
+    });
+  }
+
+  function closeBrowser({ restoreFocus = true, focusWorkspace = false } = {}) {
+    if (layer.hidden) return;
+    layer.hidden = true;
+    layer.setAttribute("aria-hidden", "true");
+    trigger.setAttribute("aria-expanded", "false");
+    documentLike.body.classList.remove("example-browser-open");
+    if (focusWorkspace) {
+      requestAnimationFrame(() => workspace.focus());
+    } else if (restoreFocus) {
+      requestAnimationFrame(() => (previouslyFocused ?? trigger).focus());
+    }
+  }
+
+  trigger.addEventListener("click", () => {
+    if (layer.hidden) openBrowser();
+    else closeBrowser({ restoreFocus: true });
+  });
+  backdrop.addEventListener("click", () => closeBrowser({ restoreFocus: true }));
+
+  gallery.addEventListener("click", (event) => {
+    if (event.target instanceof Element && event.target.closest(".example-card")) {
+      closeBrowser({ restoreFocus: false, focusWorkspace: true });
+    }
+  });
+
+  layer.addEventListener("keydown", (event) => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      closeBrowser({ restoreFocus: true });
+      return;
+    }
+    if (event.key !== "Tab") return;
+    const focusable = [...gallery.querySelectorAll(
+      'button:not([disabled]), input:not([disabled]), select:not([disabled]), summary, [href], [tabindex]:not([tabindex="-1"])',
+    )].filter((element) => element instanceof HTMLElement && !element.hidden);
+    if (focusable.length === 0) return;
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (event.shiftKey && documentLike.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && documentLike.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  });
+
+  globalThis.__noonExampleBrowser = {
+    open: openBrowser,
+    close: closeBrowser,
+    get open() {
+      return !layer.hidden;
+    },
+  };
+}
+
+function installStyles(documentLike) {
+  if (documentLike.getElementById(STYLE_ID)) return;
+  const style = documentLike.createElement("style");
+  style.id = STYLE_ID;
+  style.textContent = `
+    body.example-browser-open { overflow: hidden; }
+
+    .example-browser-trigger {
+      display: grid;
+      grid-template-columns: auto minmax(0, 1fr) auto;
+      align-items: center;
+      gap: 0.42rem;
+      min-width: min(22rem, 38vw);
+      max-width: 32rem;
+      border: 1px solid var(--border);
+      border-radius: 0.62rem;
+      padding: 0.4rem 0.6rem;
+      background: #101621;
+      color: #dce3ef;
+      cursor: pointer;
+      text-align: left;
+    }
+    .example-browser-trigger:hover { border-color: var(--border-strong); background: #141b28; }
+    .example-browser-trigger:focus-visible {
+      outline: 2px solid var(--accent-strong);
+      outline-offset: 2px;
+    }
+    .example-browser-trigger-label {
+      color: var(--muted-2);
+      font-size: 0.64rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+    .example-browser-trigger-value {
+      overflow: hidden;
+      font-size: 0.74rem;
+      font-weight: 700;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .example-browser-trigger-chevron { color: var(--muted); }
+
+    .example-browser-layer {
+      position: fixed;
+      inset: 0;
+      z-index: 1000;
+      display: grid;
+      place-items: center;
+      padding: clamp(0.75rem, 3vw, 2rem);
+    }
+    .example-browser-backdrop {
+      position: absolute;
+      inset: 0;
+      background: rgb(3 5 9 / 76%);
+      backdrop-filter: blur(10px);
+    }
+    .example-browser-layer .example-gallery {
+      position: relative;
+      z-index: 1;
+      display: flex;
+      width: min(72rem, 100%);
+      max-height: min(86vh, 54rem);
+      margin: 0;
+      flex-direction: column;
+      overflow: hidden;
+      border: 1px solid var(--border-strong);
+      border-radius: 1rem;
+      background: #0b1019;
+      box-shadow: 0 2rem 7rem rgb(0 0 0 / 55%);
+    }
+    .example-browser-layer .gallery-head {
+      flex: none;
+      padding: 0.8rem 0.9rem;
+      background: #0d121c;
+    }
+    .example-browser-close {
+      appearance: none;
+      width: 2rem;
+      height: 2rem;
+      flex: none;
+      border: 1px solid var(--border);
+      border-radius: 0.55rem;
+      background: #141a26;
+      color: #cbd3e1;
+      cursor: pointer;
+      font-size: 1.1rem;
+      line-height: 1;
+    }
+    .example-browser-layer .gallery-controls { flex-wrap: wrap; }
+    .example-browser-layer .gallery-grid {
+      min-height: 0;
+      flex: 1;
+      overflow: auto;
+      grid-template-columns: repeat(auto-fill, minmax(11.5rem, 1fr));
+      overscroll-behavior: contain;
+    }
+    .example-browser-layer .example-parity { display: none; }
+    .example-browser-layer .example-card-meta { justify-content: flex-start; }
+    .example-browser-layer .gallery-pager { flex: none; }
+    .example-browser-more-filters { position: relative; }
+    .example-browser-more-filters > summary {
+      list-style: none;
+      border: 1px solid #303d58;
+      border-radius: 0.58rem;
+      padding: 0.48rem 0.62rem;
+      background: #111722;
+      color: #aeb9cc;
+      cursor: pointer;
+      font: 0.72rem ui-monospace, SFMono-Regular, Menlo, monospace;
+    }
+    .example-browser-more-filters > summary::-webkit-details-marker { display: none; }
+    .example-browser-more-filters-content {
+      position: absolute;
+      top: calc(100% + 0.4rem);
+      right: 0;
+      z-index: 3;
+      min-width: 12rem;
+      padding: 0.45rem;
+      border: 1px solid var(--border);
+      border-radius: 0.65rem;
+      background: #0d131e;
+      box-shadow: 0 1rem 2.5rem rgb(0 0 0 / 42%);
+    }
+    .example-browser-more-filters-content select { width: 100%; }
+
+    @media (max-width: 68rem) {
+      .example-browser-trigger { min-width: 0; max-width: 42vw; }
+      .example-browser-trigger-label { display: none; }
+      .example-browser-layer .gallery-controls { display: flex; }
+      .example-browser-layer .gallery-controls input { flex: 1 1 13rem; width: auto; }
+    }
+
+    @media (max-width: 44rem) {
+      .topbar { gap: 0.45rem; }
+      .topbar .brand h1 { display: none; }
+      .example-browser-trigger {
+        min-width: 0;
+        max-width: none;
+        flex: 1;
+      }
+      .example-browser-layer { padding: 0; }
+      .example-browser-layer .example-gallery {
+        width: 100%;
+        height: 100dvh;
+        max-height: none;
+        border: 0;
+        border-radius: 0;
+      }
+      .example-browser-layer .gallery-head { align-items: stretch; }
+      .example-browser-layer .gallery-controls {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) auto;
+      }
+      .example-browser-layer .gallery-controls input { grid-column: 1 / -1; width: 100%; }
+      .example-browser-layer .gallery-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 0.55rem;
+        padding: 0.6rem;
+      }
+      .example-browser-more-filters-content {
+        position: fixed;
+        right: 0.6rem;
+        left: 0.6rem;
+      }
+    }
+
+    @media (max-width: 28rem) {
+      .example-browser-layer .gallery-grid { grid-template-columns: 1fr; }
+    }
+  `;
+  documentLike.head?.append(style);
+}

--- a/web/example-browser-ui.js
+++ b/web/example-browser-ui.js
@@ -174,7 +174,12 @@ function enhanceGallery(documentLike, gallery, topbar, workspace) {
     if (event.key !== "Tab") return;
     const focusable = [...gallery.querySelectorAll(
       'button:not([disabled]), input:not([disabled]), select:not([disabled]), summary, [href], [tabindex]:not([tabindex="-1"])',
-    )].filter((element) => element instanceof HTMLElement && !element.hidden);
+    )].filter(
+      (element) =>
+        element instanceof HTMLElement &&
+        !element.hidden &&
+        element.getClientRects().length > 0,
+    );
     if (focusable.length === 0) return;
     const first = focusable[0];
     const last = focusable[focusable.length - 1];
@@ -188,9 +193,9 @@ function enhanceGallery(documentLike, gallery, topbar, workspace) {
   });
 
   globalThis.__noonExampleBrowser = {
-    open: openBrowser,
-    close: closeBrowser,
-    get open() {
+    show: openBrowser,
+    hide: closeBrowser,
+    get isOpen() {
       return !layer.hidden;
     },
   };

--- a/web/example-gallery.js
+++ b/web/example-gallery.js
@@ -1,3 +1,5 @@
+import "./example-browser-ui.js";
+
 const MANIM_REUSE = "source-equivalent-manim-v0.21";
 const MANIM_PARITY_REUSE = "manim-compatible-parity-v0.21";
 const READY_REUSE = new Set([MANIM_REUSE, MANIM_PARITY_REUSE]);

--- a/web/index.html
+++ b/web/index.html
@@ -5,10 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="Noon Playground: author mathematical animation in Python and run it in a persistent Rust/WASM GPU runtime with WebGPU and WebGL2 fallback."
+      content="Noon Playground: author mathematical animation in Python and preview it in the browser."
     />
     <link rel="icon" href="data:," />
-    <title>Noon Playground · Python + GPU</title>
+    <title>Noon Playground</title>
     <style>
       :root {
         color-scheme: dark;
@@ -35,12 +35,16 @@
         box-sizing: border-box;
       }
 
+      [hidden] {
+        display: none !important;
+      }
+
       body {
         min-height: 100vh;
         margin: 0;
         background:
-          radial-gradient(circle at 14% -10%, rgb(83 68 178 / 25%), transparent 32rem),
-          radial-gradient(circle at 88% 6%, rgb(35 113 143 / 16%), transparent 28rem),
+          radial-gradient(circle at 14% -10%, rgb(83 68 178 / 22%), transparent 32rem),
+          radial-gradient(circle at 88% 6%, rgb(35 113 143 / 14%), transparent 28rem),
           #07090f;
       }
 
@@ -50,7 +54,8 @@
       }
 
       button:focus-visible,
-      textarea:focus-visible {
+      textarea:focus-visible,
+      a:focus-visible {
         outline: 2px solid var(--accent-strong);
         outline-offset: 2px;
       }
@@ -58,83 +63,74 @@
       .shell {
         width: min(100% - 2rem, 92rem);
         margin: 0 auto;
-        padding: 1.4rem 0 2.5rem;
+        padding: 1rem 0 2rem;
       }
 
       .topbar {
         display: flex;
+        min-height: 3rem;
         align-items: center;
         justify-content: space-between;
         gap: 1rem;
-        margin-bottom: 1.1rem;
+        margin-bottom: 0.75rem;
       }
 
       .brand {
         display: flex;
+        min-width: 0;
         align-items: center;
-        gap: 0.8rem;
+        gap: 0.65rem;
       }
 
       .mark {
         display: grid;
-        width: 2.25rem;
-        height: 2.25rem;
+        width: 2rem;
+        height: 2rem;
+        flex: none;
         place-items: center;
         border: 1px solid #514691;
-        border-radius: 0.75rem;
+        border-radius: 0.65rem;
         background: linear-gradient(145deg, #2a2351, #171426);
         color: #d7d0ff;
         font-weight: 800;
         letter-spacing: -0.08em;
       }
 
-      h1,
-      h2,
-      p {
-        margin: 0;
-      }
-
       h1 {
-        font-size: 1.05rem;
+        margin: 0;
+        overflow: hidden;
+        font-size: 1rem;
         letter-spacing: -0.02em;
-      }
-
-      .subtitle {
-        margin-top: 0.16rem;
-        color: var(--muted);
-        font-size: 0.78rem;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
 
       .runtime-status {
         display: flex;
-        align-items: center;
-        gap: 0.5rem;
         min-width: 0;
-        padding: 0.5rem 0.72rem;
-        border: 1px solid var(--border);
-        border-radius: 999px;
-        background: rgb(8 11 18 / 72%);
-        color: #bdc7da;
-        font: 0.76rem ui-monospace, SFMono-Regular, Menlo, monospace;
+        align-items: center;
+        gap: 0.42rem;
+        padding: 0.35rem 0.5rem;
+        border: 0;
+        background: transparent;
+        color: var(--muted);
+        font-size: 0.72rem;
       }
 
       .status-dot {
-        width: 0.48rem;
-        height: 0.48rem;
+        width: 0.42rem;
+        height: 0.42rem;
         flex: none;
         border-radius: 50%;
         background: #71809c;
-        box-shadow: 0 0 0 0.2rem rgb(113 128 156 / 10%);
       }
 
       .runtime-status[data-state="running"] .status-dot {
         background: var(--success);
-        box-shadow: 0 0 0 0.2rem rgb(117 215 176 / 12%);
       }
 
       .runtime-status[data-state="error"] .status-dot {
         background: var(--danger);
-        box-shadow: 0 0 0 0.2rem rgb(255 143 157 / 12%);
       }
 
       .workspace {
@@ -143,9 +139,9 @@
         min-height: 38rem;
         overflow: hidden;
         border: 1px solid var(--border);
-        border-radius: 1.1rem;
+        border-radius: 1rem;
         background: rgb(7 10 16 / 78%);
-        box-shadow: 0 1.5rem 5rem rgb(0 0 0 / 30%);
+        box-shadow: 0 1.5rem 5rem rgb(0 0 0 / 28%);
       }
 
       .editor-pane,
@@ -161,9 +157,10 @@
         background: var(--panel-strong);
       }
 
-      .pane-toolbar {
+      .pane-toolbar,
+      .preview-head {
         display: flex;
-        min-height: 3.1rem;
+        min-height: 3rem;
         align-items: center;
         justify-content: space-between;
         gap: 0.8rem;
@@ -171,39 +168,26 @@
         border-bottom: 1px solid var(--border);
       }
 
-      .tabs,
+      .file-label,
+      .preview-title {
+        color: #d5dbea;
+        font-size: 0.78rem;
+        font-weight: 700;
+      }
+
       .actions {
         display: flex;
         align-items: center;
         gap: 0.38rem;
       }
 
-      .tab,
       .secondary-button,
       .primary-button {
         appearance: none;
-        border-radius: 0.58rem;
-        cursor: pointer;
-      }
-
-      .tab {
-        border: 0;
-        padding: 0.46rem 0.62rem;
-        background: transparent;
-        color: var(--muted);
-        font-size: 0.78rem;
-        font-weight: 650;
-      }
-
-      .tab[aria-selected="true"] {
-        background: #1c2332;
-        color: #f3f5fb;
-      }
-
-      .secondary-button,
-      .primary-button {
         border: 1px solid var(--border-strong);
-        padding: 0.48rem 0.68rem;
+        border-radius: 0.58rem;
+        padding: 0.46rem 0.68rem;
+        cursor: pointer;
         font-size: 0.76rem;
         font-weight: 700;
       }
@@ -232,20 +216,15 @@
         opacity: 0.48;
       }
 
-      .editor-stack {
-        position: relative;
+      .editor-stack,
+      .editor-panel {
         display: flex;
         min-height: 0;
         flex: 1;
       }
 
       .editor-panel {
-        display: none;
         width: 100%;
-      }
-
-      .editor-panel[data-active="true"] {
-        display: flex;
         flex-direction: column;
       }
 
@@ -269,14 +248,12 @@
 
       .editor-footer {
         display: flex;
-        min-height: 2.65rem;
+        min-height: 2.35rem;
         align-items: center;
-        justify-content: space-between;
-        gap: 1rem;
-        padding: 0.58rem 0.8rem;
+        padding: 0.48rem 0.8rem;
         border-top: 1px solid var(--border);
         color: var(--muted-2);
-        font-size: 0.72rem;
+        font-size: 0.7rem;
       }
 
       #patch-status {
@@ -295,11 +272,6 @@
         color: var(--danger);
       }
 
-      .shortcut {
-        flex: none;
-        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-      }
-
       .preview-pane {
         display: flex;
         min-height: 38rem;
@@ -307,36 +279,6 @@
         background:
           radial-gradient(circle at 50% 42%, rgb(62 70 100 / 16%), transparent 22rem),
           #090c13;
-      }
-
-      .preview-head {
-        display: flex;
-        min-height: 3.1rem;
-        align-items: center;
-        justify-content: space-between;
-        gap: 1rem;
-        padding: 0 0.9rem;
-        border-bottom: 1px solid var(--border);
-      }
-
-      .preview-title {
-        color: #d5dbea;
-        font-size: 0.78rem;
-        font-weight: 700;
-      }
-
-      .badges {
-        display: flex;
-        gap: 0.38rem;
-      }
-
-      .badge {
-        padding: 0.25rem 0.45rem;
-        border: 1px solid #2c3850;
-        border-radius: 999px;
-        background: #111722;
-        color: #8f9db5;
-        font: 0.66rem ui-monospace, SFMono-Regular, Menlo, monospace;
       }
 
       .canvas-wrap {
@@ -373,39 +315,17 @@
         box-shadow: inset 0 0 0 1px rgb(255 255 255 / 2%);
       }
 
-      .metrics {
-        display: grid;
-        grid-template-columns: repeat(4, minmax(0, 1fr));
-        border-top: 1px solid var(--border);
-        background: rgb(10 13 21 / 86%);
-      }
-
-      .metric {
-        min-width: 0;
-        padding: 0.72rem 0.85rem 0.78rem;
-        border-right: 1px solid var(--border);
-      }
-
-      .metric:last-child {
-        border-right: 0;
-      }
-
-      .metric-label {
-        display: block;
-        margin-bottom: 0.22rem;
-        color: var(--muted-2);
-        font-size: 0.66rem;
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-      }
-
-      .metric-value {
-        display: block;
-        overflow: hidden;
-        color: #dce3f1;
-        font: 0.78rem ui-monospace, SFMono-Regular, Menlo, monospace;
-        text-overflow: ellipsis;
-        white-space: nowrap;
+      /*
+       * These surfaces are still produced/updated by the current runtime JS for
+       * diagnostics and compatibility, but they are deliberately not part of
+       * the default public playground chrome. Follow-up #880 work removes the
+       * legacy DOM hooks once the UI/runtime state split is complete.
+       */
+      .selected-example,
+      .badges,
+      .metrics,
+      .shortcut {
+        display: none !important;
       }
 
       @media (max-width: 68rem) {
@@ -427,36 +347,35 @@
       @media (max-width: 44rem) {
         .shell {
           width: min(100% - 1rem, 92rem);
-          padding-top: 0.75rem;
+          padding-top: 0.6rem;
         }
 
         .topbar {
-          align-items: flex-start;
-          flex-direction: column;
+          min-height: 2.6rem;
+          margin-bottom: 0.55rem;
         }
 
         .runtime-status {
-          max-width: 100%;
+          max-width: 48%;
+          overflow: hidden;
+        }
+
+        #status-text {
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
         }
 
         .workspace {
-          border-radius: 0.85rem;
+          border-radius: 0.8rem;
         }
 
         .pane-toolbar {
-          min-height: auto;
-          align-items: stretch;
-          flex-direction: column;
-          padding: 0.62rem;
-        }
-
-        .tabs,
-        .actions {
-          justify-content: space-between;
+          padding: 0 0.6rem;
         }
 
         .actions button {
-          flex: 1;
+          min-width: 4.5rem;
         }
 
         textarea {
@@ -470,29 +389,12 @@
           min-height: 25rem;
         }
 
-        .badges {
-          display: none;
-        }
-
         .canvas-wrap {
           padding: 0.55rem;
         }
 
         .canvas-frame::before {
           padding-top: 75%;
-        }
-
-        .metrics,
-        .perf-metrics {
-          grid-template-columns: repeat(2, 1fr);
-        }
-
-        .metric:nth-child(2) {
-          border-right: 0;
-        }
-
-        .metric:nth-child(-n + 2) {
-          border-bottom: 1px solid var(--border);
         }
       }
     </style>
@@ -502,66 +404,30 @@
       <header class="topbar">
         <div class="brand">
           <div class="mark" aria-hidden="true">N</div>
-          <div>
-            <h1>Noon Playground</h1>
-            <p class="subtitle">Write Python. Keep the animation loop in Rust + GPU.</p>
-          </div>
+          <h1>Noon Playground</h1>
         </div>
         <output id="status" class="runtime-status" aria-live="polite">
           <span class="status-dot" aria-hidden="true"></span>
-          <span id="status-text">Starting GPU renderer…</span>
+          <span id="status-text">Loading…</span>
         </output>
       </header>
 
       <section class="workspace" aria-label="Noon interactive playground">
         <section class="editor-pane" aria-label="Python editor">
           <div class="pane-toolbar">
-            <div class="tabs" role="tablist" aria-label="Python source type">
-              <button
-                id="scene-tab"
-                class="tab"
-                type="button"
-                role="tab"
-                aria-selected="true"
-                aria-controls="scene-editor-panel"
-              >
-                scene.py
-              </button>
-              <button
-                id="patch-tab"
-                class="tab"
-                type="button"
-                role="tab"
-                aria-selected="false"
-                aria-controls="patch-editor-panel"
-              >
-                patch.py
-              </button>
-            </div>
+            <span class="file-label">main.py</span>
             <div class="actions">
-              <button id="apply-patch" class="secondary-button" type="button" disabled>
-                Apply patch
-              </button>
               <button id="replace-scene" class="primary-button" type="button" disabled>
-                Run scene
+                Run
               </button>
             </div>
           </div>
 
           <div class="editor-stack">
-            <div id="scene-editor-panel" class="editor-panel" data-active="true" role="tabpanel">
+            <div id="scene-editor-panel" class="editor-panel">
               <textarea
                 id="python-scene-source"
                 aria-label="Python scene source"
-                autocomplete="off"
-                autocorrect="off"
-                spellcheck="false"
-              ></textarea>
-            </div>
-            <div id="patch-editor-panel" class="editor-panel" data-active="false" role="tabpanel">
-              <textarea
-                id="python-source"
-                aria-label="Python patch source"
                 autocomplete="off"
                 autocorrect="off"
                 spellcheck="false"
@@ -571,45 +437,41 @@
 
           <footer class="editor-footer">
             <output id="patch-status" aria-live="polite">Loading Python examples…</output>
-            <span class="shortcut">⌘/Ctrl + Enter</span>
           </footer>
+
+          <!--
+            Temporary internal compatibility hooks for main.js. They are not public UI.
+            Remove with the #880 JS/state cleanup once patch-era references are deleted.
+          -->
+          <div hidden aria-hidden="true">
+            <button id="scene-tab" type="button"></button>
+            <button id="patch-tab" type="button"></button>
+            <button id="apply-patch" type="button" disabled></button>
+            <div id="patch-editor-panel">
+              <textarea id="python-source" aria-label="Internal Python patch source"></textarea>
+            </div>
+          </div>
         </section>
 
-        <section class="preview-pane" aria-label="GPU preview">
+        <section class="preview-pane" aria-label="Animation preview">
           <div class="preview-head">
-            <span class="preview-title">Live preview</span>
-            <div class="badges" aria-label="Runtime technologies">
-              <span class="badge">Pyodide worker</span>
-              <span class="badge">Rust/WASM</span>
-              <span class="badge">WebGPU / WebGL2</span>
-            </div>
+            <span class="preview-title">Preview</span>
           </div>
           <div class="canvas-wrap">
             <div class="canvas-frame">
               <canvas id="scene" aria-label="Animated Noon scene"></canvas>
             </div>
           </div>
-          <div class="metrics" aria-label="Runtime metrics">
-            <div class="metric">
-              <span class="metric-label">Objects</span>
-              <output id="metric-objects" class="metric-value">—</output>
-            </div>
-            <div class="metric">
-              <span class="metric-label">Draw calls</span>
-              <output id="metric-draws" class="metric-value">—</output>
-            </div>
-            <div class="metric">
-              <span class="metric-label">GPU upload</span>
-              <output id="metric-upload" class="metric-value">—</output>
-            </div>
-            <div class="metric">
-              <span class="metric-label">Playhead</span>
-              <output id="metric-time" class="metric-value">—</output>
-            </div>
+
+          <!-- Runtime metrics remain available to the current JS but are not default chrome. -->
+          <div class="metrics" hidden aria-hidden="true">
+            <output id="metric-objects">—</output>
+            <output id="metric-draws">—</output>
+            <output id="metric-upload">—</output>
+            <output id="metric-time">—</output>
           </div>
         </section>
       </section>
-
     </main>
 
     <script type="module" src="./main.js"></script>

--- a/web/playground-playback-controls.js
+++ b/web/playground-playback-controls.js
@@ -1,5 +1,9 @@
 const STYLE_ID = "noon-playground-playback-controls-style";
 
+if (typeof document !== "undefined") {
+  ensurePlaybackSlot();
+}
+
 export class PlaygroundPlaybackControls {
   #player;
   #onError;
@@ -35,9 +39,14 @@ export class PlaygroundPlaybackControls {
 
     installStyles();
 
-    this.#root = document.createElement("section");
+    this.#root = previewPane.querySelector(".playback-slot");
+    if (!(this.#root instanceof HTMLElement)) {
+      this.#root = document.createElement("section");
+      previewPane.append(this.#root);
+    }
     this.#root.className = "playback-controls";
     this.#root.setAttribute("aria-label", "Animation playback controls");
+    this.#root.replaceChildren();
 
     this.#playButton = document.createElement("button");
     this.#playButton.type = "button";
@@ -46,16 +55,14 @@ export class PlaygroundPlaybackControls {
 
     this.#restartButton = document.createElement("button");
     this.#restartButton.type = "button";
-    this.#restartButton.className = "playback-button";
-    this.#restartButton.textContent = "Restart";
+    this.#restartButton.className = "playback-button playback-restart";
+    this.#restartButton.textContent = "↺";
     this.#restartButton.setAttribute("aria-label", "Restart animation from the beginning");
+    this.#restartButton.title = "Restart";
     this.#restartButton.addEventListener("click", this.#handleRestart);
 
     const timeline = document.createElement("label");
     timeline.className = "playback-timeline";
-    const timelineLabel = document.createElement("span");
-    timelineLabel.className = "playback-label";
-    timelineLabel.textContent = "Timeline";
 
     this.#scrubber = document.createElement("input");
     this.#scrubber.type = "range";
@@ -64,7 +71,7 @@ export class PlaygroundPlaybackControls {
     this.#scrubber.step = "0.001";
     this.#scrubber.setAttribute("aria-label", "Animation playhead");
     this.#scrubber.addEventListener("input", this.#handleSeekInput);
-    timeline.append(timelineLabel, this.#scrubber);
+    timeline.append(this.#scrubber);
 
     this.#timeOutput = document.createElement("output");
     this.#timeOutput.className = "playback-time";
@@ -72,12 +79,6 @@ export class PlaygroundPlaybackControls {
     this.#timeOutput.setAttribute("aria-label", "Animation time");
 
     this.#root.append(this.#playButton, this.#restartButton, timeline, this.#timeOutput);
-    const metrics = previewPane.querySelector(".metrics");
-    if (metrics !== null) {
-      previewPane.insertBefore(this.#root, metrics);
-    } else {
-      previewPane.append(this.#root);
-    }
     this.#render();
   }
 
@@ -135,7 +136,7 @@ export class PlaygroundPlaybackControls {
     this.#playButton.removeEventListener("click", this.#handleToggle);
     this.#restartButton.removeEventListener("click", this.#handleRestart);
     this.#scrubber.removeEventListener("input", this.#handleSeekInput);
-    this.#root.remove();
+    renderPlaybackPlaceholder(this.#root);
   }
 
   #handleToggle = () => {
@@ -227,9 +228,9 @@ export class PlaygroundPlaybackControls {
     this.#scrubber.value = String(clampedTime);
     this.#scrubber.setAttribute(
       "aria-valuetext",
-      `${formatTime(clampedTime)} of ${formatTime(this.#durationSeconds)}`,
+      `${formatTime(clampedTime)} seconds of ${formatTime(this.#durationSeconds)} seconds`,
     );
-    this.#timeOutput.value = `${formatTime(clampedTime)} / ${formatTime(this.#durationSeconds)}`;
+    this.#timeOutput.value = `${formatTime(clampedTime)} / ${formatTime(this.#durationSeconds)} s`;
   }
 
   #renderDisabled() {
@@ -243,33 +244,90 @@ export class PlaygroundPlaybackControls {
   }
 }
 
+function ensurePlaybackSlot() {
+  installStyles();
+  const previewPane = document.querySelector(".preview-pane");
+  if (!(previewPane instanceof HTMLElement)) return null;
+  const existing = previewPane.querySelector(".playback-slot, .playback-controls");
+  if (existing instanceof HTMLElement) return existing;
+  const root = document.createElement("section");
+  renderPlaybackPlaceholder(root);
+  previewPane.append(root);
+  return root;
+}
+
+function renderPlaybackPlaceholder(root) {
+  root.className = "playback-slot";
+  root.removeAttribute("aria-busy");
+  root.removeAttribute("data-busy");
+  root.removeAttribute("data-playing");
+  root.setAttribute("aria-label", "Animation playback controls");
+
+  const playButton = document.createElement("button");
+  playButton.type = "button";
+  playButton.className = "playback-button playback-toggle";
+  playButton.textContent = "Play";
+  playButton.disabled = true;
+  playButton.setAttribute("aria-label", "Run the example to enable playback");
+
+  const restartButton = document.createElement("button");
+  restartButton.type = "button";
+  restartButton.className = "playback-button playback-restart";
+  restartButton.textContent = "↺";
+  restartButton.disabled = true;
+  restartButton.setAttribute("aria-label", "Run the example to enable restart");
+  restartButton.title = "Restart";
+
+  const timeline = document.createElement("label");
+  timeline.className = "playback-timeline";
+  const scrubber = document.createElement("input");
+  scrubber.type = "range";
+  scrubber.className = "playback-scrubber";
+  scrubber.min = "0";
+  scrubber.max = "1";
+  scrubber.value = "0";
+  scrubber.disabled = true;
+  scrubber.setAttribute("aria-label", "Animation playhead unavailable until Run");
+  timeline.append(scrubber);
+
+  const timeOutput = document.createElement("output");
+  timeOutput.className = "playback-time";
+  timeOutput.setAttribute("aria-live", "off");
+  timeOutput.setAttribute("aria-label", "Animation time unavailable until Run");
+  timeOutput.value = "0.00 / —";
+
+  root.replaceChildren(playButton, restartButton, timeline, timeOutput);
+}
+
 function installStyles() {
   if (document.getElementById(STYLE_ID) !== null) return;
   const style = document.createElement("style");
   style.id = STYLE_ID;
   style.textContent = `
+    .playback-slot,
     .playback-controls {
       display: grid;
-      grid-template-columns: auto auto minmax(8rem, 1fr) auto;
+      grid-template-columns: auto auto minmax(4rem, 1fr) auto;
       align-items: center;
-      gap: 0.55rem;
-      min-height: 3.15rem;
-      padding: 0.55rem 0.85rem;
+      gap: 0.45rem;
+      min-height: 3rem;
+      padding: 0.5rem 0.75rem;
       border-top: 1px solid var(--border);
       background: rgb(9 12 19 / 94%);
     }
     .playback-button {
       appearance: none;
-      min-width: 4.5rem;
       border: 1px solid var(--border-strong);
       border-radius: 0.55rem;
-      padding: 0.42rem 0.6rem;
+      padding: 0.4rem 0.56rem;
       background: #171d2a;
       color: #d9deeb;
       cursor: pointer;
-      font-size: 0.72rem;
+      font-size: 0.7rem;
       font-weight: 700;
     }
+    .playback-toggle { min-width: 4.1rem; }
+    .playback-restart { min-width: 2.25rem; }
     .playback-button:hover:not(:disabled) { background: #20283a; }
     .playback-button:focus-visible,
     .playback-scrubber:focus-visible {
@@ -277,17 +335,8 @@ function installStyles() {
       outline-offset: 2px;
     }
     .playback-timeline {
-      display: grid;
-      grid-template-columns: auto minmax(0, 1fr);
-      align-items: center;
-      gap: 0.5rem;
+      display: block;
       min-width: 0;
-    }
-    .playback-label {
-      color: var(--muted-2);
-      font-size: 0.66rem;
-      text-transform: uppercase;
-      letter-spacing: 0.06em;
     }
     .playback-scrubber {
       width: 100%;
@@ -296,29 +345,40 @@ function installStyles() {
       cursor: pointer;
     }
     .playback-time {
-      min-width: 7.2rem;
+      min-width: 6.2rem;
       color: #b9c3d6;
-      font: 0.7rem ui-monospace, SFMono-Regular, Menlo, monospace;
+      font: 0.68rem ui-monospace, SFMono-Regular, Menlo, monospace;
       text-align: right;
       white-space: nowrap;
     }
+    .playback-slot button:disabled,
+    .playback-slot input:disabled,
     .playback-controls button:disabled,
     .playback-controls input:disabled {
+      cursor: default;
+      opacity: 0.42;
+    }
+    .playback-controls[data-busy="true"] button:disabled,
+    .playback-controls[data-busy="true"] input:disabled {
       cursor: wait;
-      opacity: 0.48;
     }
     @media (max-width: 44rem) {
+      .playback-slot,
       .playback-controls {
-        grid-template-columns: 1fr 1fr;
-        gap: 0.45rem;
-        padding: 0.55rem;
+        grid-template-columns: auto auto minmax(3rem, 1fr) auto;
+        gap: 0.32rem;
+        min-height: 2.75rem;
+        padding: 0.42rem 0.5rem;
       }
-      .playback-button { width: 100%; }
-      .playback-timeline { grid-column: 1 / -1; }
+      .playback-button {
+        padding: 0.36rem 0.45rem;
+        font-size: 0.66rem;
+      }
+      .playback-toggle { min-width: 3.6rem; }
+      .playback-restart { min-width: 2rem; }
       .playback-time {
-        grid-column: 1 / -1;
-        min-width: 0;
-        text-align: center;
+        min-width: 5.25rem;
+        font-size: 0.62rem;
       }
     }
   `;
@@ -326,7 +386,7 @@ function installStyles() {
 }
 
 function formatTime(seconds) {
-  return `${seconds.toFixed(2)} s`;
+  return seconds.toFixed(2);
 }
 
 function validateDuration(durationSeconds) {


### PR DESCRIPTION
## Summary

P2 slice for #880.

This removes the permanent gallery from normal page flow and turns it into a focused Examples picker while preserving the existing manifest, thumbnails, search, categories, filters, deep links, pagination, draft handling, and current selection behavior.

### What changes

- moves the existing `.example-gallery` into a modal-style Examples browser;
- adds a compact header trigger showing the currently selected example;
- focuses search when the browser opens;
- closes on card selection, Escape, close button, or backdrop click;
- traps keyboard focus inside the open browser;
- moves parity filtering behind `More filters`;
- removes parity text from default example cards while keeping category metadata;
- uses a full-screen Examples sheet on mobile;
- locks background scrolling while open;
- keeps the current selection semantics for this PR: selecting an example still auto-runs it;
- extends the existing cross-browser Playwright smoke test to open the picker, select a different example, and verify the picker closes.

### Scope

This PR intentionally does **not** yet separate example selection from execution. That is the next #880 interaction slice so this change stays presentation-focused and existing runtime behavior remains stable.

This PR is stacked on #886 (`ux/880-p1-stable-playback`). After #886 lands it can be retargeted to `master`.

Related: #880, #886, #241, #91, #256.