### PR TITLE
Gate persistent render mode switches by PR risk

### DIFF
--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -223,6 +223,18 @@ jobs:
           echo "seconds=$SECONDS" >> "$GITHUB_OUTPUT"
           exit "$status"
 
+      - name: Check persistent render mode switching
+        if: steps.browser-risk.outputs.render_mode_switch == 'true'
+        id: render-mode-switch
+        run: |
+          SECONDS=0
+          set +e
+          timeout --signal=TERM 60s node scripts/authoring-render-mode-switch-smoke.mjs
+          status=$?
+          set -e
+          echo "seconds=$SECONDS" >> "$GITHUB_OUTPUT"
+          exit "$status"
+
       - name: Check primary WebGPU rendering
         id: webgpu-smoke
         env:
@@ -246,6 +258,8 @@ jobs:
           AUTHORING_SECONDS: ${{ steps.manim-authoring.outputs.seconds }}
           RETAINED_REQUIRED: ${{ steps.browser-risk.outputs.retained_execution }}
           RETAINED_SECONDS: ${{ steps.retained-execution.outputs.seconds }}
+          MODE_SWITCH_REQUIRED: ${{ steps.browser-risk.outputs.render_mode_switch }}
+          MODE_SWITCH_SECONDS: ${{ steps.render-mode-switch.outputs.seconds }}
           WEBGPU_SECONDS: ${{ steps.webgpu-smoke.outputs.seconds }}
         run: |
           total=""
@@ -266,6 +280,11 @@ jobs:
             retained_duration="$(display_seconds "$RETAINED_SECONDS")"
           fi
 
+          mode_switch_duration="skipped"
+          if [[ "$MODE_SWITCH_REQUIRED" == "true" ]]; then
+            mode_switch_duration="$(display_seconds "$MODE_SWITCH_SECONDS")"
+          fi
+
           {
             echo "### Browser fast checks timing"
             echo
@@ -275,10 +294,12 @@ jobs:
             echo "| Deterministic replay | $(display_seconds "$REPLAY_SECONDS") |"
             echo "| Manim authoring | $(display_seconds "$AUTHORING_SECONDS") |"
             echo "| Canonical retained execution | $retained_duration |"
+            echo "| Persistent render mode switching | $mode_switch_duration |"
             echo "| WebGPU smoke | $(display_seconds "$WEBGPU_SECONDS") |"
             echo "| Measured browser path | $(display_seconds "$total") |"
             echo
             echo "Retained execution escalation required: ${RETAINED_REQUIRED:-unknown}."
+            echo "Render mode-switch escalation required: ${MODE_SWITCH_REQUIRED:-unknown}."
             echo
             echo "The measured browser path starts before checkout and ends after the renderer smoke. Hosted-runner queue time and post-job cleanup are intentionally excluded."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/pr-risk-classifier.mjs
+++ b/scripts/pr-risk-classifier.mjs
@@ -20,6 +20,18 @@ const retainedExecutionRustPaths = new Set([
   "crates/noon-web/src/lib.rs",
 ]);
 
+const renderModeSwitchPaths = new Set([
+  "scripts/authoring-render-mode-switch-smoke.mjs",
+  "web/authoring-execution-client.js",
+  "web/authoring-render-worker.js",
+  "web/execution-engine-worker.js",
+  "web/execution-render-worker.js",
+  "web/execution-transport.js",
+  "web/execution-worker-client.js",
+  "web/execution-worker-smoke.html",
+  "web/retained-execution-engine-worker.js",
+]);
+
 function normalizeRepositoryPath(path) {
   return path.trim().replaceAll("\\", "/").replace(/^\.\//, "");
 }
@@ -36,17 +48,21 @@ export function requiresRetainedExecutionSmoke(path) {
   return normalized.startsWith("crates/") && /(^|\/)[^/]*retained[^/]*(\/|$)/.test(normalized);
 }
 
+export function requiresRenderModeSwitchSmoke(path) {
+  const normalized = normalizeRepositoryPath(path);
+  return normalized !== "" && renderModeSwitchPaths.has(normalized);
+}
+
 export function classifyPrRisk(paths) {
-  const retainedExecutionPaths = [...new Set(
-    paths
-      .map(normalizeRepositoryPath)
-      .filter(Boolean)
-      .filter(requiresRetainedExecutionSmoke),
-  )].sort();
+  const normalizedPaths = [...new Set(paths.map(normalizeRepositoryPath).filter(Boolean))];
+  const retainedExecutionPaths = normalizedPaths.filter(requiresRetainedExecutionSmoke).sort();
+  const renderModeSwitchPaths = normalizedPaths.filter(requiresRenderModeSwitchSmoke).sort();
 
   return Object.freeze({
     retainedExecution: retainedExecutionPaths.length > 0,
     retainedExecutionPaths: Object.freeze(retainedExecutionPaths),
+    renderModeSwitch: renderModeSwitchPaths.length > 0,
+    renderModeSwitchPaths: Object.freeze(renderModeSwitchPaths),
   });
 }
 
@@ -54,11 +70,16 @@ function runCli() {
   const paths = readFileSync(0, "utf8").split(/\r?\n/);
   const risk = classifyPrRisk(paths);
   process.stdout.write(`retained_execution=${risk.retainedExecution}\n`);
+  process.stdout.write(`render_mode_switch=${risk.renderModeSwitch}\n`);
 
-  const detail = risk.retainedExecution
+  const retainedDetail = risk.retainedExecution
     ? risk.retainedExecutionPaths.join(", ")
     : "none";
-  process.stderr.write(`retained execution risk paths: ${detail}\n`);
+  const modeSwitchDetail = risk.renderModeSwitch
+    ? risk.renderModeSwitchPaths.join(", ")
+    : "none";
+  process.stderr.write(`retained execution risk paths: ${retainedDetail}\n`);
+  process.stderr.write(`render mode-switch risk paths: ${modeSwitchDetail}\n`);
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/scripts/pr-risk-classifier.mjs
+++ b/scripts/pr-risk-classifier.mjs
@@ -22,6 +22,8 @@ const retainedExecutionRustPaths = new Set([
 
 const renderModeSwitchPaths = new Set([
   "scripts/authoring-render-mode-switch-smoke.mjs",
+  // Policy changes must exercise the oracle they decide whether to run.
+  "scripts/pr-risk-classifier.mjs",
   "web/authoring-execution-client.js",
   "web/authoring-render-worker.js",
   "web/execution-engine-worker.js",

--- a/scripts/pr-risk-classifier.test.mjs
+++ b/scripts/pr-risk-classifier.test.mjs
@@ -25,6 +25,7 @@ const retainedRuntimeChanges = [
 ];
 
 const renderModeSwitchChanges = [
+  "scripts/pr-risk-classifier.mjs",
   "web/authoring-execution-client.js",
   "web/authoring-render-worker.js",
   "web/execution-engine-worker.js",
@@ -38,7 +39,6 @@ const renderModeSwitchChanges = [
 const ordinaryChanges = [
   ".github/workflows/pr-fast.yml",
   "docs/ci.md",
-  "scripts/pr-risk-classifier.mjs",
   "web/main.js",
   "web/playground-gallery.js",
   "crates/noon-geometry/src/lib.rs",
@@ -57,7 +57,7 @@ test("retained engine, shared render, and Rust ownership boundaries escalate", (
   }
 });
 
-test("render-owner and engine transition boundaries escalate the mode-switch smoke", () => {
+test("render-owner, transition, and risk-policy changes escalate the mode-switch smoke", () => {
   const risk = classifyPrRisk(renderModeSwitchChanges);
   assert.equal(risk.renderModeSwitch, true);
   assert.deepEqual(risk.renderModeSwitchPaths, renderModeSwitchChanges.slice().sort());

--- a/scripts/pr-risk-classifier.test.mjs
+++ b/scripts/pr-risk-classifier.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   classifyPrRisk,
+  requiresRenderModeSwitchSmoke,
   requiresRetainedExecutionSmoke,
 } from "./pr-risk-classifier.mjs";
 
@@ -23,13 +24,23 @@ const retainedRuntimeChanges = [
   "crates/noon-web/src/lib.rs",
 ];
 
+const renderModeSwitchChanges = [
+  "web/authoring-execution-client.js",
+  "web/authoring-render-worker.js",
+  "web/execution-engine-worker.js",
+  "web/execution-render-worker.js",
+  "web/execution-transport.js",
+  "web/execution-worker-client.js",
+  "web/execution-worker-smoke.html",
+  "web/retained-execution-engine-worker.js",
+];
+
 const ordinaryChanges = [
   ".github/workflows/pr-fast.yml",
   "docs/ci.md",
   "scripts/pr-risk-classifier.mjs",
   "web/main.js",
   "web/playground-gallery.js",
-  "web/execution-engine-worker.js",
   "crates/noon-geometry/src/lib.rs",
   "crates/noon-web/src/manim_geometry_bridge.rs",
 ];
@@ -46,10 +57,21 @@ test("retained engine, shared render, and Rust ownership boundaries escalate", (
   }
 });
 
-test("ordinary CI, docs, demo, legacy engine, geometry, and Manim bridge changes stay fast", () => {
+test("render-owner and engine transition boundaries escalate the mode-switch smoke", () => {
+  const risk = classifyPrRisk(renderModeSwitchChanges);
+  assert.equal(risk.renderModeSwitch, true);
+  assert.deepEqual(risk.renderModeSwitchPaths, renderModeSwitchChanges.slice().sort());
+  for (const path of renderModeSwitchChanges) {
+    assert.equal(requiresRenderModeSwitchSmoke(path), true, path);
+  }
+});
+
+test("ordinary CI, docs, demo, geometry, and Manim bridge changes stay fast", () => {
   const risk = classifyPrRisk(ordinaryChanges);
   assert.equal(risk.retainedExecution, false);
   assert.deepEqual(risk.retainedExecutionPaths, []);
+  assert.equal(risk.renderModeSwitch, false);
+  assert.deepEqual(risk.renderModeSwitchPaths, []);
 });
 
 test("classifier normalizes diff-style paths and de-duplicates triggers", () => {
@@ -60,4 +82,5 @@ test("classifier normalizes diff-style paths and de-duplicates triggers", () => 
     "",
   ]);
   assert.deepEqual(risk.retainedExecutionPaths, ["web/authoring-render-worker.js"]);
+  assert.deepEqual(risk.renderModeSwitchPaths, ["web/authoring-render-worker.js"]);
 });


### PR DESCRIPTION
## Summary
- extend the existing PR risk classifier with a focused `render_mode_switch` escalation for browser/render-worker ownership files that can break legacy ↔ retained transitions
- run the already-existing `authoring-render-mode-switch-smoke.mjs` only when those boundaries change
- self-gate classifier changes so edits to the policy exercise the browser oracle they control
- keep ordinary demo/docs/geometry PRs on the fast path
- add classifier coverage for escalation, normalization, de-duplication, and non-trigger cases
- include mode-switch timing in the existing browser Fast Gate summary

## Why
#492 already has a real browser smoke that exercises both transferable and shared transports, switches legacy → retained → legacy, asserts the same HTML canvas object is preserved, and verifies presentation counters continue across mode switches. That oracle was not run by PR Fast Gate, so changes to the render owner or engine-switch boundaries could regress the exact architecture without pre-merge coverage.

This reuses the existing oracle instead of creating a duplicate test or broad always-on browser cost. The gate is path-risk based and deliberately limited to the cross-mode ownership/protocol files plus the classifier policy itself.

## Validation
The focused risk-policy test is auto-discovered by web preflight. Because this PR changes `scripts/pr-risk-classifier.mjs`, the new self-gating rule also makes this exact PR run the persistent render mode-switch browser smoke, validating the conditional workflow path end-to-end rather than only its static policy.

## Remaining risk
The smoke adds browser time only for mode-switch-sensitive PRs. If exact-head CI shows that it consistently pushes the risk path beyond the existing Fast Gate timing budget, the next step should be to reduce duplicated setup or move the smoke into a parallel risk job—not weaken its assertions.

Tracks #492.