### PR TITLE
Restore lazy Python editor after playground tab cleanup

### DIFF
--- a/web/python-editor.js
+++ b/web/python-editor.js
@@ -29,9 +29,7 @@ if (typeof document !== "undefined") {
 }
 
 function isVisiblePythonTextarea(textarea) {
-  if (!textarea || textarea.hidden) return false;
-  const editorPanel = textarea.closest(".editor-panel");
-  return editorPanel === null || editorPanel.dataset.active === "true";
+  return textarea !== null && textarea.closest("[hidden]") === null;
 }
 
 async function enhancePythonEditors() {


### PR DESCRIPTION
## Summary

The latest master CI fails in `Browser reactive and editor` while waiting for the lazy CodeMirror editor to become ready after focusing `#python-scene-source`.

#885 removed the public scene/patch tab state, but `python-editor.js` still used `editorPanel.dataset.active === "true"` to decide whether a textarea was eligible for enhancement. The now-tabless public scene panel has no `data-active`, so the lazy enhancer selected zero editors and silently returned.

This change removes that obsolete coupling and derives eligibility from the actual DOM visibility contract: a Python textarea is enhanceable only when it is not inside a `[hidden]` subtree. That keeps the internal patch textarea excluded while allowing the public scene editor to enhance normally, independent of any tab implementation.

## Validation

The existing `scripts/playground-layout-smoke.mjs` is already a focused end-to-end regression for this behavior: it focuses the public textarea and requires `#scene-editor-panel .python-code-editor[data-editor-ready='true']`. That exact assertion is what fails on current master, so no duplicate test was added.

The branch is one commit directly on failing master `ac91583d7cb3ea93d71f01bbe78086f60769f57e`, with a production diff of +1/-3 in one file. PR Fast Gate will validate the exact head; I am leaving this draft until checks report back.

## Risk

Low. The predicate now follows native hidden-subtree semantics rather than legacy playground tab state. A future visible secondary Python editor would also become eligible by design; hidden compatibility editors remain excluded.