### PR TITLE
Scale Manim parity stress demo to 600 active shapes

### DIFF
--- a/parity/manim-v0.21/stress-examples/mixed_object_parity_stress.py
+++ b/parity/manim-v0.21/stress-examples/mixed_object_parity_stress.py
@@ -116,7 +116,8 @@ class MixedObjectParityStress(Scene):
                 .shift(0.035 * x_direction + 0.025 * y_direction)
                 .set_color(color)
             )
-        self.play(*motion_a, title.animate.rotate(PI / 24), run_time=0.65)
+        self.play(*motion_a, run_time=0.55)
+        self.play(title.animate.rotate(PI / 24), run_time=0.10)
 
         self.play(
             *[
@@ -138,7 +139,8 @@ class MixedObjectParityStress(Scene):
                 .shift(0.055 * x_direction + 0.035 * y_direction)
                 .set_color(color)
             )
-        self.play(*motion_b, title.animate.rotate(-PI / 12), run_time=0.65)
+        self.play(*motion_b, run_time=0.55)
+        self.play(title.animate.rotate(-PI / 12), run_time=0.10)
 
         leaving = shapes[::3]
         pulses = [
@@ -158,13 +160,10 @@ class MixedObjectParityStress(Scene):
             run_time=0.50,
         )
 
-        self.play(
-            FadeIn(subtitle),
-            title.animate.rotate(PI / 24),
-            run_time=0.10,
-        )
+        self.play(title.animate.rotate(PI / 24), run_time=0.10)
+        self.play(FadeIn(subtitle), run_time=0.10)
         self.play(
             *[FadeIn(shape, scale=0.25) for shape in leaving],
             *[FadeOut(pulse, scale=2.0) for pulse in pulses],
-            run_time=0.70,
+            run_time=0.60,
         )

--- a/parity/manim-v0.21/stress-examples/mixed_object_parity_stress.py
+++ b/parity/manim-v0.21/stress-examples/mixed_object_parity_stress.py
@@ -3,103 +3,147 @@ from manim import *
 
 class MixedObjectParityStress(Scene):
     def construct(self):
-        rows = 6
-        cols = 12
+        rows = 20
+        cols = 30
         palette = [BLUE, TEAL, GREEN, YELLOW, ORANGE, RED, PINK, PURPLE]
         font = "DejaVu Sans Mono"
 
+        shape_count = rows * cols
         title = Text(
             "MANIM PARITY STRESS",
             font=font,
-            font_size=34,
+            font_size=30,
             color=WHITE,
-        ).shift(3.25 * UP)
+        ).shift(3.45 * UP)
         subtitle = Text(
-            "72 shapes | morph | rotate | color | text | lifecycle",
+            f"{shape_count} shapes | 200 churn | repeated morph + motion + color",
             font=font,
-            font_size=17,
+            font_size=14,
             color=GRAY,
-        ).shift(2.72 * UP)
+        ).shift(3.02 * UP)
 
         shapes = []
-        targets = []
-        x_spacing = 0.90
-        y_spacing = 0.72
+        targets_a = []
+        targets_b = []
+        x_spacing = 0.38
+        y_spacing = 0.255
         x_origin = -0.5 * (cols - 1) * x_spacing
-        y_origin = 1.52
+        y_origin = 2.40
 
         for row in range(rows):
             for col in range(cols):
                 index = row * cols + col
                 color = palette[index % len(palette)]
-                target_color = palette[(index + 3) % len(palette)]
+                color_a = palette[(index + 3) % len(palette)]
+                color_b = palette[(index + 6) % len(palette)]
                 point = (x_origin + col * x_spacing) * RIGHT + (
                     y_origin - row * y_spacing
                 ) * UP
 
                 if (row + col) % 2 == 0:
                     shape = Square(
-                        side_length=0.42,
+                        side_length=0.18,
                         fill_color=color,
                         fill_opacity=0.58,
                         stroke_color=color,
-                        stroke_width=2,
+                        stroke_width=1,
                     )
-                    target = Circle(
-                        radius=0.23,
-                        fill_color=target_color,
-                        fill_opacity=0.88,
-                        stroke_color=target_color,
-                        stroke_width=2,
+                    target_a = Circle(
+                        radius=0.105,
+                        fill_color=color_a,
+                        fill_opacity=0.90,
+                        stroke_color=color_a,
+                        stroke_width=1,
                     )
+                    target_b = Square(
+                        side_length=0.20,
+                        fill_color=color_b,
+                        fill_opacity=0.72,
+                        stroke_color=color_b,
+                        stroke_width=1,
+                    ).rotate(PI / 4)
                 else:
                     shape = Circle(
-                        radius=0.21,
+                        radius=0.09,
                         fill_color=color,
                         fill_opacity=0.58,
                         stroke_color=color,
-                        stroke_width=2,
+                        stroke_width=1,
                     )
-                    target = Square(
-                        side_length=0.46,
-                        fill_color=target_color,
-                        fill_opacity=0.88,
-                        stroke_color=target_color,
-                        stroke_width=2,
+                    target_a = Square(
+                        side_length=0.20,
+                        fill_color=color_a,
+                        fill_opacity=0.90,
+                        stroke_color=color_a,
+                        stroke_width=1,
                     ).rotate(PI / 4)
+                    target_b = Circle(
+                        radius=0.105,
+                        fill_color=color_b,
+                        fill_opacity=0.72,
+                        stroke_color=color_b,
+                        stroke_width=1,
+                    )
 
+                offset = 0.025 if row % 2 == 0 else -0.025
                 shape.move_to(point)
-                target.move_to(point + (0.07 if row % 2 == 0 else -0.07) * RIGHT)
+                target_a.move_to(point + offset * RIGHT)
+                target_b.move_to(point - offset * RIGHT)
                 shapes.append(shape)
-                targets.append(target)
+                targets_a.append(target_a)
+                targets_b.append(target_b)
 
-        self.play(FadeIn(title), FadeIn(subtitle), run_time=0.4)
-        self.play(*[Create(shape) for shape in shapes], run_time=0.6)
+        self.play(FadeIn(title), FadeIn(subtitle), run_time=0.30)
+        self.play(*[Create(shape) for shape in shapes], run_time=0.70)
 
         self.play(
             *[
                 Transform(shape, target)
-                for shape, target in zip(shapes, targets)
+                for shape, target in zip(shapes, targets_a)
             ],
-            run_time=1.2,
+            run_time=0.90,
         )
 
-        motion = []
+        motion_a = []
         for index, shape in enumerate(shapes):
-            angle = PI / 2 if index % 2 == 0 else -PI / 2
-            direction = UP if (index // cols) % 2 == 0 else DOWN
+            row = index // cols
+            angle = PI / 3 if index % 2 == 0 else -PI / 3
+            x_direction = RIGHT if row % 2 == 0 else LEFT
+            y_direction = UP if index % 3 == 0 else DOWN
             color = palette[(index + 5) % len(palette)]
-            motion.append(
-                shape.animate.rotate(angle).shift(0.11 * direction).set_color(color)
+            motion_a.append(
+                shape.animate.rotate(angle)
+                .shift(0.035 * x_direction + 0.025 * y_direction)
+                .set_color(color)
             )
+        self.play(*motion_a, title.animate.rotate(PI / 24), run_time=0.85)
 
-        self.play(title.animate.rotate(PI / 18), run_time=0.2)
-        self.play(*motion, run_time=1.0)
+        self.play(
+            *[
+                Transform(shape, target)
+                for shape, target in zip(shapes, targets_b)
+            ],
+            run_time=0.90,
+        )
 
-        leaving = shapes[::2]
+        motion_b = []
+        for index, shape in enumerate(shapes):
+            row = index // cols
+            angle = -PI / 2 if index % 2 == 0 else PI / 2
+            x_direction = LEFT if row % 2 == 0 else RIGHT
+            y_direction = DOWN if index % 3 == 0 else UP
+            color = palette[(index + 1) % len(palette)]
+            motion_b.append(
+                shape.animate.rotate(angle)
+                .shift(0.055 * x_direction + 0.035 * y_direction)
+                .set_color(color)
+            )
+        self.play(*motion_b, title.animate.rotate(-PI / 12), run_time=0.85)
+
+        leaving = shapes[::3]
         pulses = [
             Circle(
-                radius=0.085,
+                radius=0.045,
                 fill_color=WHITE,
                 fill_opacity=1.0,
                 stroke_opacity=0.0,
@@ -107,20 +151,20 @@ class MixedObjectParityStress(Scene):
             for shape in leaving
         ]
 
-        self.play(FadeOut(subtitle), run_time=0.2)
+        self.play(FadeOut(subtitle), run_time=0.15)
         self.play(
-            *[FadeOut(shape, scale=0.35) for shape in leaving],
-            *[FadeIn(pulse, scale=0.2) for pulse in pulses],
-            run_time=0.6,
+            *[FadeOut(shape, scale=0.25) for shape in leaving],
+            *[FadeIn(pulse, scale=0.15) for pulse in pulses],
+            run_time=0.55,
         )
 
         self.play(
             FadeIn(subtitle),
-            title.animate.rotate(-PI / 18),
-            run_time=0.2,
+            title.animate.rotate(PI / 24),
+            run_time=0.15,
         )
         self.play(
-            *[FadeIn(shape, scale=0.35) for shape in leaving],
-            *[FadeOut(pulse, scale=1.8) for pulse in pulses],
-            run_time=0.6,
+            *[FadeIn(shape, scale=0.25) for shape in leaving],
+            *[FadeOut(pulse, scale=2.0) for pulse in pulses],
+            run_time=0.55,
         )

--- a/parity/manim-v0.21/stress-examples/mixed_object_parity_stress.py
+++ b/parity/manim-v0.21/stress-examples/mixed_object_parity_stress.py
@@ -93,15 +93,15 @@ class MixedObjectParityStress(Scene):
                 targets_a.append(target_a)
                 targets_b.append(target_b)
 
-        self.play(FadeIn(title), FadeIn(subtitle), run_time=0.30)
-        self.play(*[Create(shape) for shape in shapes], run_time=0.70)
+        self.play(FadeIn(title), FadeIn(subtitle), run_time=0.25)
+        self.play(*[Create(shape) for shape in shapes], run_time=0.55)
 
         self.play(
             *[
                 Transform(shape, target)
                 for shape, target in zip(shapes, targets_a)
             ],
-            run_time=0.90,
+            run_time=0.75,
         )
 
         motion_a = []
@@ -116,14 +116,14 @@ class MixedObjectParityStress(Scene):
                 .shift(0.035 * x_direction + 0.025 * y_direction)
                 .set_color(color)
             )
-        self.play(*motion_a, title.animate.rotate(PI / 24), run_time=0.85)
+        self.play(*motion_a, title.animate.rotate(PI / 24), run_time=0.65)
 
         self.play(
             *[
                 Transform(shape, target)
                 for shape, target in zip(shapes, targets_b)
             ],
-            run_time=0.90,
+            run_time=0.75,
         )
 
         motion_b = []
@@ -138,7 +138,7 @@ class MixedObjectParityStress(Scene):
                 .shift(0.055 * x_direction + 0.035 * y_direction)
                 .set_color(color)
             )
-        self.play(*motion_b, title.animate.rotate(-PI / 12), run_time=0.85)
+        self.play(*motion_b, title.animate.rotate(-PI / 12), run_time=0.65)
 
         leaving = shapes[::3]
         pulses = [
@@ -151,20 +151,20 @@ class MixedObjectParityStress(Scene):
             for shape in leaving
         ]
 
-        self.play(FadeOut(subtitle), run_time=0.15)
+        self.play(FadeOut(subtitle), run_time=0.10)
         self.play(
             *[FadeOut(shape, scale=0.25) for shape in leaving],
             *[FadeIn(pulse, scale=0.15) for pulse in pulses],
-            run_time=0.55,
+            run_time=0.50,
         )
 
         self.play(
             FadeIn(subtitle),
             title.animate.rotate(PI / 24),
-            run_time=0.15,
+            run_time=0.10,
         )
         self.play(
             *[FadeIn(shape, scale=0.25) for shape in leaving],
             *[FadeOut(pulse, scale=2.0) for pulse in pulses],
-            run_time=0.55,
+            run_time=0.70,
         )

--- a/web/manim-compat-smoke.html
+++ b/web/manim-compat-smoke.html
@@ -231,9 +231,9 @@ class RetainedFamilyUnwriteSmoke(Scene):
             if (!stressResult.sceneSpec) {
               throw new Error("stress scene did not produce canonical SceneSpec");
             }
-            if (stressResult.document.objects.length !== 108) {
+            if (stressResult.document.objects.length !== 800) {
               throw new Error(
-                `stress scene expected 108 geometry objects, got ${stressResult.document.objects.length}`,
+                `stress scene expected 800 geometry objects, got ${stressResult.document.objects.length}`,
               );
             }
             if (stressResult.retainedDocument?.objects?.length !== 2) {
@@ -241,9 +241,9 @@ class RetainedFamilyUnwriteSmoke(Scene):
                 `stress scene expected two retained Text objects, got ${stressResult.retainedDocument?.objects?.length}`,
               );
             }
-            if (stressResult.sceneSpec.objects.length !== 110) {
+            if (stressResult.sceneSpec.objects.length !== 802) {
               throw new Error(
-                `stress canonical SceneSpec expected 110 mixed objects, got ${stressResult.sceneSpec.objects.length}`,
+                `stress canonical SceneSpec expected 802 mixed objects, got ${stressResult.sceneSpec.objects.length}`,
               );
             }
             stressRenderResult = await renderCanonicalMidpoint({
@@ -252,9 +252,9 @@ class RetainedFamilyUnwriteSmoke(Scene):
               label: "mixed-object parity stress",
               loopDurationSeconds: 5.0,
               seekTime: 2.8,
-              // At t=2.8 the 72 original shapes and two retained Text objects are
-              // present. The 36 pulse circles are authored but do not enter until 3.6s.
-              expectedObjectCount: 74,
+              // At t=2.8 all 600 primary shapes and both retained Text objects are
+              // present. The 200 pulse circles are authored but do not enter until 3.7s.
+              expectedObjectCount: 602,
             });
 
             return {

--- a/web/python/examples/manim_parity_stress_grid.py
+++ b/web/python/examples/manim_parity_stress_grid.py
@@ -116,7 +116,8 @@ class MixedObjectParityStress(Scene):
                 .shift(0.035 * x_direction + 0.025 * y_direction)
                 .set_color(color)
             )
-        self.play(*motion_a, title.animate.rotate(PI / 24), run_time=0.65)
+        self.play(*motion_a, run_time=0.55)
+        self.play(title.animate.rotate(PI / 24), run_time=0.10)
 
         self.play(
             *[
@@ -138,7 +139,8 @@ class MixedObjectParityStress(Scene):
                 .shift(0.055 * x_direction + 0.035 * y_direction)
                 .set_color(color)
             )
-        self.play(*motion_b, title.animate.rotate(-PI / 12), run_time=0.65)
+        self.play(*motion_b, run_time=0.55)
+        self.play(title.animate.rotate(-PI / 12), run_time=0.10)
 
         leaving = shapes[::3]
         pulses = [
@@ -158,13 +160,10 @@ class MixedObjectParityStress(Scene):
             run_time=0.50,
         )
 
-        self.play(
-            FadeIn(subtitle),
-            title.animate.rotate(PI / 24),
-            run_time=0.10,
-        )
+        self.play(title.animate.rotate(PI / 24), run_time=0.10)
+        self.play(FadeIn(subtitle), run_time=0.10)
         self.play(
             *[FadeIn(shape, scale=0.25) for shape in leaving],
             *[FadeOut(pulse, scale=2.0) for pulse in pulses],
-            run_time=0.70,
+            run_time=0.60,
         )

--- a/web/python/examples/manim_parity_stress_grid.py
+++ b/web/python/examples/manim_parity_stress_grid.py
@@ -93,15 +93,15 @@ class MixedObjectParityStress(Scene):
                 targets_a.append(target_a)
                 targets_b.append(target_b)
 
-        self.play(FadeIn(title), FadeIn(subtitle), run_time=0.30)
-        self.play(*[Create(shape) for shape in shapes], run_time=0.70)
+        self.play(FadeIn(title), FadeIn(subtitle), run_time=0.25)
+        self.play(*[Create(shape) for shape in shapes], run_time=0.55)
 
         self.play(
             *[
                 Transform(shape, target)
                 for shape, target in zip(shapes, targets_a)
             ],
-            run_time=0.90,
+            run_time=0.75,
         )
 
         motion_a = []
@@ -116,14 +116,14 @@ class MixedObjectParityStress(Scene):
                 .shift(0.035 * x_direction + 0.025 * y_direction)
                 .set_color(color)
             )
-        self.play(*motion_a, title.animate.rotate(PI / 24), run_time=0.85)
+        self.play(*motion_a, title.animate.rotate(PI / 24), run_time=0.65)
 
         self.play(
             *[
                 Transform(shape, target)
                 for shape, target in zip(shapes, targets_b)
             ],
-            run_time=0.90,
+            run_time=0.75,
         )
 
         motion_b = []
@@ -138,7 +138,7 @@ class MixedObjectParityStress(Scene):
                 .shift(0.055 * x_direction + 0.035 * y_direction)
                 .set_color(color)
             )
-        self.play(*motion_b, title.animate.rotate(-PI / 12), run_time=0.85)
+        self.play(*motion_b, title.animate.rotate(-PI / 12), run_time=0.65)
 
         leaving = shapes[::3]
         pulses = [
@@ -151,20 +151,20 @@ class MixedObjectParityStress(Scene):
             for shape in leaving
         ]
 
-        self.play(FadeOut(subtitle), run_time=0.15)
+        self.play(FadeOut(subtitle), run_time=0.10)
         self.play(
             *[FadeOut(shape, scale=0.25) for shape in leaving],
             *[FadeIn(pulse, scale=0.15) for pulse in pulses],
-            run_time=0.55,
+            run_time=0.50,
         )
 
         self.play(
             FadeIn(subtitle),
             title.animate.rotate(PI / 24),
-            run_time=0.15,
+            run_time=0.10,
         )
         self.play(
             *[FadeIn(shape, scale=0.25) for shape in leaving],
             *[FadeOut(pulse, scale=2.0) for pulse in pulses],
-            run_time=0.55,
+            run_time=0.70,
         )

--- a/web/python/examples/manim_parity_stress_grid.py
+++ b/web/python/examples/manim_parity_stress_grid.py
@@ -3,103 +3,147 @@ from noon import *
 
 class MixedObjectParityStress(Scene):
     def construct(self):
-        rows = 6
-        cols = 12
+        rows = 20
+        cols = 30
         palette = [BLUE, TEAL, GREEN, YELLOW, ORANGE, RED, PINK, PURPLE]
         font = "DejaVu Sans Mono"
 
+        shape_count = rows * cols
         title = Text(
             "MANIM PARITY STRESS",
             font=font,
-            font_size=34,
+            font_size=30,
             color=WHITE,
-        ).shift(3.25 * UP)
+        ).shift(3.45 * UP)
         subtitle = Text(
-            "72 shapes | morph | rotate | color | text | lifecycle",
+            f"{shape_count} shapes | 200 churn | repeated morph + motion + color",
             font=font,
-            font_size=17,
+            font_size=14,
             color=GRAY,
-        ).shift(2.72 * UP)
+        ).shift(3.02 * UP)
 
         shapes = []
-        targets = []
-        x_spacing = 0.90
-        y_spacing = 0.72
+        targets_a = []
+        targets_b = []
+        x_spacing = 0.38
+        y_spacing = 0.255
         x_origin = -0.5 * (cols - 1) * x_spacing
-        y_origin = 1.52
+        y_origin = 2.40
 
         for row in range(rows):
             for col in range(cols):
                 index = row * cols + col
                 color = palette[index % len(palette)]
-                target_color = palette[(index + 3) % len(palette)]
+                color_a = palette[(index + 3) % len(palette)]
+                color_b = palette[(index + 6) % len(palette)]
                 point = (x_origin + col * x_spacing) * RIGHT + (
                     y_origin - row * y_spacing
                 ) * UP
 
                 if (row + col) % 2 == 0:
                     shape = Square(
-                        side_length=0.42,
+                        side_length=0.18,
                         fill_color=color,
                         fill_opacity=0.58,
                         stroke_color=color,
-                        stroke_width=2,
+                        stroke_width=1,
                     )
-                    target = Circle(
-                        radius=0.23,
-                        fill_color=target_color,
-                        fill_opacity=0.88,
-                        stroke_color=target_color,
-                        stroke_width=2,
+                    target_a = Circle(
+                        radius=0.105,
+                        fill_color=color_a,
+                        fill_opacity=0.90,
+                        stroke_color=color_a,
+                        stroke_width=1,
                     )
+                    target_b = Square(
+                        side_length=0.20,
+                        fill_color=color_b,
+                        fill_opacity=0.72,
+                        stroke_color=color_b,
+                        stroke_width=1,
+                    ).rotate(PI / 4)
                 else:
                     shape = Circle(
-                        radius=0.21,
+                        radius=0.09,
                         fill_color=color,
                         fill_opacity=0.58,
                         stroke_color=color,
-                        stroke_width=2,
+                        stroke_width=1,
                     )
-                    target = Square(
-                        side_length=0.46,
-                        fill_color=target_color,
-                        fill_opacity=0.88,
-                        stroke_color=target_color,
-                        stroke_width=2,
+                    target_a = Square(
+                        side_length=0.20,
+                        fill_color=color_a,
+                        fill_opacity=0.90,
+                        stroke_color=color_a,
+                        stroke_width=1,
                     ).rotate(PI / 4)
+                    target_b = Circle(
+                        radius=0.105,
+                        fill_color=color_b,
+                        fill_opacity=0.72,
+                        stroke_color=color_b,
+                        stroke_width=1,
+                    )
 
+                offset = 0.025 if row % 2 == 0 else -0.025
                 shape.move_to(point)
-                target.move_to(point + (0.07 if row % 2 == 0 else -0.07) * RIGHT)
+                target_a.move_to(point + offset * RIGHT)
+                target_b.move_to(point - offset * RIGHT)
                 shapes.append(shape)
-                targets.append(target)
+                targets_a.append(target_a)
+                targets_b.append(target_b)
 
-        self.play(FadeIn(title), FadeIn(subtitle), run_time=0.4)
-        self.play(*[Create(shape) for shape in shapes], run_time=0.6)
+        self.play(FadeIn(title), FadeIn(subtitle), run_time=0.30)
+        self.play(*[Create(shape) for shape in shapes], run_time=0.70)
 
         self.play(
             *[
                 Transform(shape, target)
-                for shape, target in zip(shapes, targets)
+                for shape, target in zip(shapes, targets_a)
             ],
-            run_time=1.2,
+            run_time=0.90,
         )
 
-        motion = []
+        motion_a = []
         for index, shape in enumerate(shapes):
-            angle = PI / 2 if index % 2 == 0 else -PI / 2
-            direction = UP if (index // cols) % 2 == 0 else DOWN
+            row = index // cols
+            angle = PI / 3 if index % 2 == 0 else -PI / 3
+            x_direction = RIGHT if row % 2 == 0 else LEFT
+            y_direction = UP if index % 3 == 0 else DOWN
             color = palette[(index + 5) % len(palette)]
-            motion.append(
-                shape.animate.rotate(angle).shift(0.11 * direction).set_color(color)
+            motion_a.append(
+                shape.animate.rotate(angle)
+                .shift(0.035 * x_direction + 0.025 * y_direction)
+                .set_color(color)
             )
+        self.play(*motion_a, title.animate.rotate(PI / 24), run_time=0.85)
 
-        self.play(title.animate.rotate(PI / 18), run_time=0.2)
-        self.play(*motion, run_time=1.0)
+        self.play(
+            *[
+                Transform(shape, target)
+                for shape, target in zip(shapes, targets_b)
+            ],
+            run_time=0.90,
+        )
 
-        leaving = shapes[::2]
+        motion_b = []
+        for index, shape in enumerate(shapes):
+            row = index // cols
+            angle = -PI / 2 if index % 2 == 0 else PI / 2
+            x_direction = LEFT if row % 2 == 0 else RIGHT
+            y_direction = DOWN if index % 3 == 0 else UP
+            color = palette[(index + 1) % len(palette)]
+            motion_b.append(
+                shape.animate.rotate(angle)
+                .shift(0.055 * x_direction + 0.035 * y_direction)
+                .set_color(color)
+            )
+        self.play(*motion_b, title.animate.rotate(-PI / 12), run_time=0.85)
+
+        leaving = shapes[::3]
         pulses = [
             Circle(
-                radius=0.085,
+                radius=0.045,
                 fill_color=WHITE,
                 fill_opacity=1.0,
                 stroke_opacity=0.0,
@@ -107,20 +151,20 @@ class MixedObjectParityStress(Scene):
             for shape in leaving
         ]
 
-        self.play(FadeOut(subtitle), run_time=0.2)
+        self.play(FadeOut(subtitle), run_time=0.15)
         self.play(
-            *[FadeOut(shape, scale=0.35) for shape in leaving],
-            *[FadeIn(pulse, scale=0.2) for pulse in pulses],
-            run_time=0.6,
+            *[FadeOut(shape, scale=0.25) for shape in leaving],
+            *[FadeIn(pulse, scale=0.15) for pulse in pulses],
+            run_time=0.55,
         )
 
         self.play(
             FadeIn(subtitle),
-            title.animate.rotate(-PI / 18),
-            run_time=0.2,
+            title.animate.rotate(PI / 24),
+            run_time=0.15,
         )
         self.play(
-            *[FadeIn(shape, scale=0.35) for shape in leaving],
-            *[FadeOut(pulse, scale=1.8) for pulse in pulses],
-            run_time=0.6,
+            *[FadeIn(shape, scale=0.25) for shape in leaving],
+            *[FadeOut(pulse, scale=2.0) for pulse in pulses],
+            run_time=0.55,
         )

--- a/web/python/examples/manim_stress_manifest.json
+++ b/web/python/examples/manim_stress_manifest.json
@@ -9,17 +9,20 @@
     {
       "id": "manim-parity-stress-grid",
       "title": "Mixed Object Parity Stress",
-      "summary": "A 72-shape Manim-compatible stress scene combining retained Text, mass Create, square/circle morphs, chained rotation/translation/color animation, and lifecycle FadeIn/FadeOut transitions.",
+      "summary": "A 600-shape Manim-compatible stress scene with two full-grid geometry morph waves, two simultaneous rotation/translation/color waves, retained Text, and 200-object lifecycle churn.",
       "status": "ready",
       "path": "python/examples/manim_parity_stress_grid.py",
       "category": "stress",
       "features": [
-        "72 shapes",
+        "600 shapes",
+        "200 lifecycle churn",
         "Text",
         "Create",
         "Transform",
+        "repeated Transform",
         "animate",
         "rotation",
+        "translation",
         "color",
         "FadeIn",
         "FadeOut",
@@ -33,7 +36,7 @@
       "parity_fixture": "mixed-object-parity-stress",
       "parity_source": "parity/manim-v0.21/stress-examples/mixed_object_parity_stress.py",
       "thumbnail": "thumbnails/manim/parity-stress-grid.svg",
-      "thumbnail_alt": "Dense multicolor grid of squares and circles under a MANIM PARITY STRESS title",
+      "thumbnail_alt": "Dense multicolor grid of hundreds of squares and circles under a MANIM PARITY STRESS title",
       "thumbnail_time": 2.8,
       "order": 15
     }

--- a/web/python/test_manim_stress_example.py
+++ b/web/python/test_manim_stress_example.py
@@ -26,6 +26,8 @@ class ManimStressExampleTests(unittest.TestCase):
         self.assertEqual(entry["reuse"], "manim-compatible-parity-v0.21")
         self.assertEqual(entry["parity_status"], "candidate")
         self.assertEqual(entry["parity_fixture"], "mixed-object-parity-stress")
+        self.assertIn("600 shapes", entry["features"])
+        self.assertIn("200 lifecycle churn", entry["features"])
 
         demo_path = WEB_ROOT / entry["path"]
         canonical_path = REPO_ROOT / entry["parity_source"]
@@ -49,8 +51,11 @@ class ManimStressExampleTests(unittest.TestCase):
             "FadeOut(",
         ):
             self.assertIn(token, canonical_source)
-        self.assertIn("rows = 6", canonical_source)
-        self.assertIn("cols = 12", canonical_source)
+        self.assertIn("rows = 20", canonical_source)
+        self.assertIn("cols = 30", canonical_source)
+        self.assertIn("targets_a = []", canonical_source)
+        self.assertIn("targets_b = []", canonical_source)
+        self.assertIn("leaving = shapes[::3]", canonical_source)
         self.assertNotIn("VectorPath", canonical_source)
         self.assertNotIn("context", canonical_source)
         self.assertNotIn("result =", canonical_source)

--- a/web/stress-runtime-contract.test.mjs
+++ b/web/stress-runtime-contract.test.mjs
@@ -24,16 +24,23 @@ assert.equal(
   canonical.replace("from manim import *", "from noon import *"),
   "stress source must remain import-only Manim compatible",
 );
-assert.match(noon, /self\.play\(FadeIn\(title\), FadeIn\(subtitle\), run_time=0\.4\)/);
-assert.match(noon, /self\.play\(\*\[Create\(shape\) for shape in shapes\], run_time=0\.6\)/);
+assert.match(noon, /rows = 20/);
+assert.match(noon, /cols = 30/);
+assert.match(noon, /shape_count = rows \* cols/);
+assert.match(noon, /self\.play\(FadeIn\(title\), FadeIn\(subtitle\), run_time=0\.25\)/);
+assert.match(noon, /self\.play\(\*\[Create\(shape\) for shape in shapes\], run_time=0\.55\)/);
 assert.doesNotMatch(
   noon,
   /Create\(title\)/,
   "retained family Create cannot share the stress scene's mass mixed-animation play yet",
 );
-assert.match(noon, /shape\.animate\.rotate\(angle\)\.shift\(0\.11 \* direction\)\.set_color\(color\)/);
-assert.match(noon, /self\.play\(title\.animate\.rotate\(PI \/ 18\), run_time=0\.2\)/);
-assert.match(noon, /title\.animate\.rotate\(-PI \/ 18\)/);
+assert.match(noon, /for shape, target in zip\(shapes, targets_a\)/);
+assert.match(noon, /for shape, target in zip\(shapes, targets_b\)/);
+assert.match(noon, /motion_a = \[\]/);
+assert.match(noon, /motion_b = \[\]/);
+assert.match(noon, /leaving = shapes\[::3\]/);
+assert.match(noon, /title\.animate\.rotate\(PI \/ 24\)/);
+assert.match(noon, /title\.animate\.rotate\(-PI \/ 12\)/);
 assert.doesNotMatch(
   noon,
   /(?:title|subtitle)\.animate[^\n]*set_color/,
@@ -55,8 +62,9 @@ assert.match(
   "contract should track the retained family mixed-play capability boundary",
 );
 assert.match(browserSmoke, /manim_parity_stress_grid\.py/);
-assert.match(browserSmoke, /stressResult\.sceneSpec\.objects\.length !== 110/);
-assert.match(browserSmoke, /expectedObjectCount: 74/);
+assert.match(browserSmoke, /stressResult\.document\.objects\.length !== 800/);
+assert.match(browserSmoke, /stressResult\.sceneSpec\.objects\.length !== 802/);
+assert.match(browserSmoke, /expectedObjectCount: 602/);
 assert.match(browserSmoke, /waitForRenderedState/);
 assert.match(browserSmoke, /seekTime: 2\.8/);
 


### PR DESCRIPTION
## Summary
- scale the Manim-compatible parity stress scene from 72 to 600 simultaneously animated primary shapes
- add a second full-grid square/circle morph wave and a second full-grid rotate/shift/color wave
- churn 200 additional pulse objects through FadeOut/FadeIn lifecycle transitions
- keep the scene at exactly 5.0 seconds and preserve import-only canonical Manim/Noon source parity
- strengthen the browser smoke to require 800 geometry objects + 2 retained Text objects and 602 visible objects at t=2.8s

## Why
The previous 72-shape scene validated correctness but was too light to expose realistic browser/runtime throughput limits. This workload is roughly an order of magnitude heavier and repeatedly updates the same large active set instead of only stressing initial creation.

Parity status remains `candidate`; this does not claim pixel qualification.