### PR TITLE
Ratchet shared Mobject layout query ownership

### DIFF
--- a/web/manim-mobject-layout-ownership.test.mjs
+++ b/web/manim-mobject-layout-ownership.test.mjs
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const semanticHandlesSource = readFileSync(
+  new URL("./python/_manim_semantic_handles.py", import.meta.url),
+  "utf8",
+);
+const rustHandleSource = readFileSync(
+  new URL("../crates/noon-web/src/authoring_mobject.rs", import.meta.url),
+  "utf8",
+);
+
+function functionBody(source, name, nextName) {
+  const start = source.indexOf(`def ${name}(`);
+  assert.notEqual(start, -1, `missing Python function ${name}`);
+  const end = source.indexOf(`\ndef ${nextName}(`, start);
+  assert.notEqual(end, -1, `missing Python function boundary after ${name}`);
+  return source.slice(start, end);
+}
+
+test("detached Mobject layout queries stay owned by the shared semantic handle", () => {
+  const layoutCenter = functionBody(semanticHandlesSource, "_layout_center", "_init");
+  assert.match(layoutCenter, /_handle_for\(value\)/);
+  assert.match(layoutCenter, /handle\.centerX/);
+  assert.match(layoutCenter, /handle\.centerY/);
+
+  const getCenter = functionBody(semanticHandlesSource, "_get_center", "_width");
+  assert.match(getCenter, /_handle_for\(self\) is not None/);
+  assert.match(getCenter, /return _layout_center\(self\)/);
+
+  const width = functionBody(semanticHandlesSource, "_width", "_height");
+  assert.match(width, /handle\.width/);
+
+  const height = functionBody(semanticHandlesSource, "_height", "_set_width_property");
+  assert.match(height, /handle\.height/);
+
+  assert.match(
+    semanticHandlesSource,
+    /_base\.Mobject\.get_center = _get_center/,
+    "install() must keep get_center on the semantic-handle adapter",
+  );
+  assert.match(
+    semanticHandlesSource,
+    /_base\.Mobject\.width = property\(_width, _set_width_property\)/,
+    "install() must keep width on the semantic-handle adapter",
+  );
+  assert.match(
+    semanticHandlesSource,
+    /_base\.Mobject\.height = property\(_height, _set_height_property\)/,
+    "install() must keep height on the semantic-handle adapter",
+  );
+});
+
+test("Rust semantic handle remains the layout-query source of truth", () => {
+  assert.match(rustHandleSource, /pub fn layout_bounds\(&self\) -> Option<Bounds2D64>/);
+  assert.match(rustHandleSource, /pub fn center\(&self\) -> \(f64, f64\)/);
+  assert.match(rustHandleSource, /pub fn width\(&self\) -> f64/);
+  assert.match(rustHandleSource, /pub fn height\(&self\) -> f64/);
+  assert.match(
+    rustHandleSource,
+    /pub fn critical_point\(&self, direction_x: f64, direction_y: f64\) -> \(f64, f64\)/,
+  );
+
+  const centerStart = rustHandleSource.indexOf("pub fn center(&self)");
+  const widthStart = rustHandleSource.indexOf("pub fn width(&self)", centerStart);
+  assert.ok(centerStart >= 0 && widthStart > centerStart);
+  const centerBody = rustHandleSource.slice(centerStart, widthStart);
+  assert.match(centerBody, /self\.layout_bounds\(\)/);
+
+  const widthEnd = rustHandleSource.indexOf("pub fn height(&self)", widthStart);
+  const widthBody = rustHandleSource.slice(widthStart, widthEnd);
+  assert.match(widthBody, /self\.layout_bounds\(\)/);
+
+  const heightEnd = rustHandleSource.indexOf("pub fn critical_point", widthEnd);
+  const heightBody = rustHandleSource.slice(widthEnd, heightEnd);
+  assert.match(heightBody, /self\.layout_bounds\(\)/);
+});


### PR DESCRIPTION
## Summary
- add a focused architecture regression for #74's Mobject bounds/query tranche
- require detached/public `Mobject.get_center`, `width`, and `height` to continue routing through the shared semantic handle when available
- require the Rust `FrontendMobjectHandle` to remain the owner of layout bounds, center, width, height, and critical-point computation
- keep legacy snapshot math only as the explicit migration fallback for objects that cannot use a fresh shared handle

## Why
The current implementation already has the desired ownership split, but it was not directly ratcheted. A future compatibility refactor could silently move common layout queries back into Python-owned geometry/bounds math, increasing duplication and making downstream layout semantics diverge from the Rust semantic model.

This is intentionally test-only: it protects the existing high-leverage #74 O2 boundary without colliding with the active center-preserving scale work or family/layout stacks.

## Validation
`web/manim-mobject-layout-ownership.test.mjs` is auto-discovered by the normal web static/unit preflight. PR Fast Gate should validate the exact head.

## Risk
Low. There is no production behavior change. The test is structural by design: if the adapter is legitimately renamed/refactored, the ratchet should be updated together with equivalent proof that shared semantic ownership remains intact.

Tracks #74.