### PR TITLE
Make dynamic load stress demo substantially more complex

### DIFF
--- a/parity/manim-v0.21/stress-examples/mixed_object_parity_stress.py
+++ b/parity/manim-v0.21/stress-examples/mixed_object_parity_stress.py
@@ -1,7 +1,7 @@
 from manim import *
 
 
-class MixedObjectParityStress(Scene):
+class DynamicLoadStress(Scene):
     def construct(self):
         rows = 20
         cols = 30
@@ -10,17 +10,33 @@ class MixedObjectParityStress(Scene):
 
         shape_count = rows * cols
         title = Text(
-            "MANIM PARITY STRESS",
+            "NOON DYNAMIC LOAD",
             font=font,
             font_size=30,
             color=WHITE,
         ).shift(3.45 * UP)
         subtitle = Text(
-            f"{shape_count} shapes | 200 churn | repeated morph + motion + color",
+            f"{shape_count} GEOMETRY  ·  24 TEXT STREAMS  ·  STAGGERED TRANSFORMS",
             font=font,
-            font_size=14,
+            font_size=13,
             color=GRAY,
         ).shift(3.02 * UP)
+
+        labels = []
+        for index in range(24):
+            slot = index % 12
+            side = -1 if index < 12 else 1
+            label = Text(
+                f"S{index:02d} {((index * 73 + 19) % 997):03d}",
+                font=font,
+                font_size=9,
+                color=palette[(index * 3 + 2) % len(palette)],
+            )
+            label.shift(
+                (6.32 * side) * RIGHT
+                + (2.58 - slot * 0.47) * UP
+            )
+            labels.append(label)
 
         shapes = []
         targets_a = []
@@ -93,7 +109,12 @@ class MixedObjectParityStress(Scene):
                 targets_a.append(target_a)
                 targets_b.append(target_b)
 
-        self.play(FadeIn(title), FadeIn(subtitle), run_time=0.25)
+        self.play(
+            FadeIn(title),
+            FadeIn(subtitle),
+            *[FadeIn(label) for label in labels],
+            run_time=0.35,
+        )
         self.play(*[Create(shape) for shape in shapes], run_time=0.55)
 
         self.play(
@@ -101,46 +122,91 @@ class MixedObjectParityStress(Scene):
                 Transform(shape, target)
                 for shape, target in zip(shapes, targets_a)
             ],
-            run_time=0.75,
+            run_time=0.65,
         )
 
-        motion_a = []
-        for index, shape in enumerate(shapes):
-            row = index // cols
-            angle = PI / 3 if index % 2 == 0 else -PI / 3
-            x_direction = RIGHT if row % 2 == 0 else LEFT
-            y_direction = UP if index % 3 == 0 else DOWN
-            color = palette[(index + 5) % len(palette)]
-            motion_a.append(
-                shape.animate.rotate(angle)
-                .shift(0.035 * x_direction + 0.025 * y_direction)
-                .set_color(color)
-            )
-        self.play(*motion_a, run_time=0.55)
-        self.play(title.animate.rotate(PI / 24), run_time=0.10)
+        for wave in range(6):
+            wave_motion = []
+            for index, shape in enumerate(shapes):
+                row = index // cols
+                col = index % cols
+                bucket = (index * 37 + row * 11 + col * 7) % 6
+                if bucket != wave:
+                    continue
+                scale_factor = 0.84 + 0.04 * ((index * 13 + row) % 9)
+                angle = (((index * 19 + col) % 11) - 5) * (PI / 36)
+                dx = (((index * 17 + row) % 9) - 4) * 0.027
+                dy = (((index * 29 + col) % 7) - 3) * 0.023
+                color = palette[(index + wave + 3) % len(palette)]
+                wave_motion.append(
+                    shape.animate.scale(scale_factor)
+                    .rotate(angle)
+                    .shift(dx * RIGHT + dy * UP)
+                    .set_color(color)
+                )
+            self.play(*wave_motion, run_time=0.12)
+
+        label_specs = []
+        for index in range(len(labels)):
+            factor = 0.90 + 0.04 * ((index * 5 + 1) % 6)
+            angle = (((index * 7) % 9) - 4) * (PI / 72)
+            dx = (((index * 11) % 5) - 2) * 0.045
+            dy = (((index * 13) % 5) - 2) * 0.025
+            opacity = 0.62 + 0.09 * (index % 5)
+            label_specs.append((factor, angle, dx, dy, opacity))
+
+        for wave in range(4):
+            text_motion = []
+            for index, label in enumerate(labels):
+                if index % 4 != wave:
+                    continue
+                factor, angle, dx, dy, opacity = label_specs[index]
+                text_motion.append(
+                    label.animate.scale(factor)
+                    .rotate(angle)
+                    .shift(dx * RIGHT + dy * UP)
+                    .set_opacity(opacity)
+                )
+            self.play(*text_motion, run_time=0.08)
 
         self.play(
             *[
                 Transform(shape, target)
                 for shape, target in zip(shapes, targets_b)
             ],
-            run_time=0.75,
+            run_time=0.65,
         )
 
-        motion_b = []
+        turbulence = []
         for index, shape in enumerate(shapes):
             row = index // cols
-            angle = -PI / 2 if index % 2 == 0 else PI / 2
-            x_direction = LEFT if row % 2 == 0 else RIGHT
-            y_direction = DOWN if index % 3 == 0 else UP
-            color = palette[(index + 1) % len(palette)]
-            motion_b.append(
-                shape.animate.rotate(angle)
-                .shift(0.055 * x_direction + 0.035 * y_direction)
+            col = index % cols
+            factor = 0.92 + 0.02 * ((index * 7 + col) % 9)
+            angle = (PI / 3) if (index + row) % 2 == 0 else (-PI / 3)
+            dx = (((index * 23 + col) % 7) - 3) * 0.022
+            dy = (((index * 31 + row) % 7) - 3) * 0.020
+            color = palette[(index * 5 + 1) % len(palette)]
+            turbulence.append(
+                shape.animate.scale(factor)
+                .rotate(angle)
+                .shift(dx * RIGHT + dy * UP)
                 .set_color(color)
             )
-        self.play(*motion_b, run_time=0.55)
-        self.play(title.animate.rotate(-PI / 12), run_time=0.10)
+        self.play(*turbulence, run_time=0.55)
+
+        for wave in range(4):
+            text_motion = []
+            for index, label in enumerate(labels):
+                if index % 4 != wave:
+                    continue
+                factor, angle, dx, dy, _ = label_specs[index]
+                text_motion.append(
+                    label.animate.scale(1.0 / factor)
+                    .rotate(-angle)
+                    .shift(-dx * RIGHT - dy * UP)
+                    .set_opacity(1.0)
+                )
+            self.play(*text_motion, run_time=0.08)
 
         leaving = shapes[::3]
         pulses = [
@@ -152,18 +218,47 @@ class MixedObjectParityStress(Scene):
             ).move_to(shape.get_center())
             for shape in leaving
         ]
+        blinking_labels = labels[::3]
 
-        self.play(FadeOut(subtitle), run_time=0.10)
+        self.play(
+            FadeOut(subtitle),
+            *[FadeOut(label) for label in blinking_labels],
+            run_time=0.15,
+        )
         self.play(
             *[FadeOut(shape, scale=0.25) for shape in leaving],
             *[FadeIn(pulse, scale=0.15) for pulse in pulses],
             run_time=0.50,
         )
 
-        self.play(title.animate.rotate(PI / 24), run_time=0.10)
-        self.play(FadeIn(subtitle), run_time=0.10)
+        self.play(
+            FadeIn(subtitle),
+            *[FadeIn(label) for label in blinking_labels],
+            run_time=0.15,
+        )
         self.play(
             *[FadeIn(shape, scale=0.25) for shape in leaving],
             *[FadeOut(pulse, scale=2.0) for pulse in pulses],
-            run_time=0.60,
+            run_time=0.55,
         )
+
+        for wave in range(6):
+            wave_motion = []
+            for index, shape in enumerate(shapes):
+                row = index // cols
+                col = index % cols
+                bucket = (index * 17 + row * 5 + col * 13) % 6
+                if bucket != wave:
+                    continue
+                scale_factor = 0.90 + 0.025 * ((index * 11 + col) % 9)
+                angle = (((index * 5 + row) % 13) - 6) * (PI / 48)
+                dx = (((index * 41 + col) % 11) - 5) * 0.020
+                dy = (((index * 43 + row) % 9) - 4) * 0.018
+                color = palette[(index + 2 * wave + 5) % len(palette)]
+                wave_motion.append(
+                    shape.animate.scale(scale_factor)
+                    .rotate(angle)
+                    .shift(dx * RIGHT + dy * UP)
+                    .set_color(color)
+                )
+            self.play(*wave_motion, run_time=0.10)

--- a/parity/manim-v0.21/stress-examples/mixed_object_parity_stress.py
+++ b/parity/manim-v0.21/stress-examples/mixed_object_parity_stress.py
@@ -1,7 +1,7 @@
 from manim import *
 
 
-class DynamicLoadStress(Scene):
+class MixedObjectParityStress(Scene):
     def construct(self):
         rows = 20
         cols = 30
@@ -122,7 +122,7 @@ class DynamicLoadStress(Scene):
                 Transform(shape, target)
                 for shape, target in zip(shapes, targets_a)
             ],
-            run_time=0.65,
+            run_time=0.55,
         )
 
         for wave in range(6):
@@ -144,7 +144,7 @@ class DynamicLoadStress(Scene):
                     .shift(dx * RIGHT + dy * UP)
                     .set_color(color)
                 )
-            self.play(*wave_motion, run_time=0.12)
+            self.play(*wave_motion, run_time=0.08)
 
         label_specs = []
         for index in range(len(labels)):
@@ -167,14 +167,14 @@ class DynamicLoadStress(Scene):
                     .shift(dx * RIGHT + dy * UP)
                     .set_opacity(opacity)
                 )
-            self.play(*text_motion, run_time=0.08)
+            self.play(*text_motion, run_time=0.06)
 
         self.play(
             *[
                 Transform(shape, target)
                 for shape, target in zip(shapes, targets_b)
             ],
-            run_time=0.65,
+            run_time=0.55,
         )
 
         turbulence = []
@@ -192,7 +192,7 @@ class DynamicLoadStress(Scene):
                 .shift(dx * RIGHT + dy * UP)
                 .set_color(color)
             )
-        self.play(*turbulence, run_time=0.55)
+        self.play(*turbulence, run_time=0.45)
 
         for wave in range(4):
             text_motion = []
@@ -206,7 +206,7 @@ class DynamicLoadStress(Scene):
                     .shift(-dx * RIGHT - dy * UP)
                     .set_opacity(1.0)
                 )
-            self.play(*text_motion, run_time=0.08)
+            self.play(*text_motion, run_time=0.06)
 
         leaving = shapes[::3]
         pulses = [
@@ -223,23 +223,23 @@ class DynamicLoadStress(Scene):
         self.play(
             FadeOut(subtitle),
             *[FadeOut(label) for label in blinking_labels],
-            run_time=0.15,
+            run_time=0.10,
         )
         self.play(
             *[FadeOut(shape, scale=0.25) for shape in leaving],
             *[FadeIn(pulse, scale=0.15) for pulse in pulses],
-            run_time=0.50,
+            run_time=0.40,
         )
 
         self.play(
             FadeIn(subtitle),
             *[FadeIn(label) for label in blinking_labels],
-            run_time=0.15,
+            run_time=0.10,
         )
         self.play(
             *[FadeIn(shape, scale=0.25) for shape in leaving],
             *[FadeOut(pulse, scale=2.0) for pulse in pulses],
-            run_time=0.55,
+            run_time=0.45,
         )
 
         for wave in range(6):
@@ -261,4 +261,4 @@ class DynamicLoadStress(Scene):
                     .shift(dx * RIGHT + dy * UP)
                     .set_color(color)
                 )
-            self.play(*wave_motion, run_time=0.10)
+            self.play(*wave_motion, run_time=0.09)

--- a/web/main.js
+++ b/web/main.js
@@ -30,8 +30,8 @@ const metricTime = document.querySelector("#metric-time");
 const workspace = document.querySelector(".workspace");
 const toolbarActions = document.querySelector(".actions");
 
-// The public demo is a Manim compatibility surface. Noon-native patch templates and
-// implementation/stress examples remain repository fixtures, but are not user-facing examples.
+// The public demo is a source-compatible Python authoring surface. Noon-native patch
+// templates and implementation fixtures remain repository assets, not user-facing examples.
 patchButton.hidden = true;
 patchTab.hidden = true;
 patchPanel.hidden = true;
@@ -258,23 +258,23 @@ document.head.append(galleryStyle);
 const galleryManifest = await loadGalleryManifest();
 const SCENE_EXAMPLES = galleryManifest.examples;
 if (SCENE_EXAMPLES.length === 0) {
-  throw new Error("No source-equivalent ManimCE examples are ready for the gallery");
+  throw new Error("No runnable examples are ready for the gallery");
 }
 
 const gallerySection = document.createElement("section");
 gallerySection.className = "example-gallery";
-gallerySection.setAttribute("aria-label", "Manim compatible scene examples");
+gallerySection.setAttribute("aria-label", "Animation scene examples");
 const galleryHead = document.createElement("div");
 galleryHead.className = "gallery-head";
 const galleryTitle = document.createElement("div");
 galleryTitle.className = "gallery-title";
-galleryTitle.innerHTML = `<strong>ManimCE examples</strong><span>Source-equivalent v${galleryManifest.reference?.version ?? "0.21.0"} scenes</span>`;
+galleryTitle.innerHTML = `<strong>Examples</strong><span>Python-authored animation scenes</span>`;
 const galleryControls = document.createElement("div");
 galleryControls.className = "gallery-controls";
 const gallerySearch = document.createElement("input");
 gallerySearch.type = "search";
 gallerySearch.placeholder = "Search examples";
-gallerySearch.setAttribute("aria-label", "Search Manim examples");
+gallerySearch.setAttribute("aria-label", "Search examples");
 const categorySelect = document.createElement("select");
 categorySelect.setAttribute("aria-label", "Filter examples by category");
 categorySelect.append(new Option("All categories", "all"));
@@ -632,7 +632,7 @@ function renderGallery({ keepSelectedVisible = false } = {}) {
   if (visible.length === 0) {
     const empty = document.createElement("div");
     empty.className = "gallery-empty";
-    empty.textContent = "No Manim examples match these filters.";
+    empty.textContent = "No examples match these filters.";
     galleryGrid.append(empty);
     return;
   }
@@ -817,7 +817,7 @@ async function selectExample(
 ) {
   const example = SCENE_EXAMPLES.find((candidate) => candidate.id === id);
   if (!example) {
-    throw new Error(`Unknown Manim example ${id}`);
+    throw new Error(`Unknown example ${id}`);
   }
 
   const requestToken = generations.beginSelectionRequest(id);
@@ -915,7 +915,7 @@ resetButton.addEventListener("click", async () => {
   canonicalSource = await loadDemoAuthoringSource(example.path);
   sceneSourceEditor.value = canonicalSource;
   resetButton.disabled = true;
-  patchStatus.value = `${example.title} reset to canonical Manim source`;
+  patchStatus.value = `${example.title} reset to canonical source`;
   patchStatus.dataset.state = "ready";
 });
 sceneSourceEditor.addEventListener(

--- a/web/manim-compat-smoke.html
+++ b/web/manim-compat-smoke.html
@@ -225,7 +225,7 @@ class RetainedFamilyUnwriteSmoke(Scene):
             if (stressResult.kind !== "scene_document") {
               throw new Error(`stress smoke returned ${stressResult.kind}`);
             }
-            if (Math.abs(Number(stressResult.duration) - 6.06) > 1e-12) {
+            if (Math.abs(Number(stressResult.duration) - 5.0) > 1e-12) {
               throw new Error(`stress scene duration drifted to ${stressResult.duration}`);
             }
             if (!stressResult.sceneSpec) {
@@ -250,9 +250,9 @@ class RetainedFamilyUnwriteSmoke(Scene):
               result: stressResult,
               canvasSelector: "#retained-stress-smoke",
               label: "dynamic load stress",
-              loopDurationSeconds: 6.06,
-              seekTime: 3.6,
-              // At t=3.6 all 600 primary shapes and all 26 retained Text objects
+              loopDurationSeconds: 5.0,
+              seekTime: 3.0,
+              // At t=3.0 all 600 primary shapes and all 26 retained Text objects
               // are present. The 200 pulse circles are authored but enter later.
               expectedObjectCount: 626,
             });

--- a/web/manim-compat-smoke.html
+++ b/web/manim-compat-smoke.html
@@ -225,7 +225,7 @@ class RetainedFamilyUnwriteSmoke(Scene):
             if (stressResult.kind !== "scene_document") {
               throw new Error(`stress smoke returned ${stressResult.kind}`);
             }
-            if (Math.abs(Number(stressResult.duration) - 5.0) > 1e-12) {
+            if (Math.abs(Number(stressResult.duration) - 6.06) > 1e-12) {
               throw new Error(`stress scene duration drifted to ${stressResult.duration}`);
             }
             if (!stressResult.sceneSpec) {
@@ -236,25 +236,25 @@ class RetainedFamilyUnwriteSmoke(Scene):
                 `stress scene expected 800 geometry objects, got ${stressResult.document.objects.length}`,
               );
             }
-            if (stressResult.retainedDocument?.objects?.length !== 2) {
+            if (stressResult.retainedDocument?.objects?.length !== 26) {
               throw new Error(
-                `stress scene expected two retained Text objects, got ${stressResult.retainedDocument?.objects?.length}`,
+                `stress scene expected 26 retained Text objects, got ${stressResult.retainedDocument?.objects?.length}`,
               );
             }
-            if (stressResult.sceneSpec.objects.length !== 802) {
+            if (stressResult.sceneSpec.objects.length !== 826) {
               throw new Error(
-                `stress canonical SceneSpec expected 802 mixed objects, got ${stressResult.sceneSpec.objects.length}`,
+                `stress canonical SceneSpec expected 826 mixed objects, got ${stressResult.sceneSpec.objects.length}`,
               );
             }
             stressRenderResult = await renderCanonicalMidpoint({
               result: stressResult,
               canvasSelector: "#retained-stress-smoke",
-              label: "mixed-object parity stress",
-              loopDurationSeconds: 5.0,
-              seekTime: 2.8,
-              // At t=2.8 all 600 primary shapes and both retained Text objects are
-              // present. The 200 pulse circles are authored but do not enter until 3.7s.
-              expectedObjectCount: 602,
+              label: "dynamic load stress",
+              loopDurationSeconds: 6.06,
+              seekTime: 3.6,
+              // At t=3.6 all 600 primary shapes and all 26 retained Text objects
+              // are present. The 200 pulse circles are authored but enter later.
+              expectedObjectCount: 626,
             });
 
             return {

--- a/web/python/examples/manim_parity_stress_grid.py
+++ b/web/python/examples/manim_parity_stress_grid.py
@@ -1,7 +1,7 @@
 from noon import *
 
 
-class MixedObjectParityStress(Scene):
+class DynamicLoadStress(Scene):
     def construct(self):
         rows = 20
         cols = 30
@@ -10,17 +10,33 @@ class MixedObjectParityStress(Scene):
 
         shape_count = rows * cols
         title = Text(
-            "MANIM PARITY STRESS",
+            "NOON DYNAMIC LOAD",
             font=font,
             font_size=30,
             color=WHITE,
         ).shift(3.45 * UP)
         subtitle = Text(
-            f"{shape_count} shapes | 200 churn | repeated morph + motion + color",
+            f"{shape_count} GEOMETRY  ·  24 TEXT STREAMS  ·  STAGGERED TRANSFORMS",
             font=font,
-            font_size=14,
+            font_size=13,
             color=GRAY,
         ).shift(3.02 * UP)
+
+        labels = []
+        for index in range(24):
+            slot = index % 12
+            side = -1 if index < 12 else 1
+            label = Text(
+                f"S{index:02d} {((index * 73 + 19) % 997):03d}",
+                font=font,
+                font_size=9,
+                color=palette[(index * 3 + 2) % len(palette)],
+            )
+            label.shift(
+                (6.32 * side) * RIGHT
+                + (2.58 - slot * 0.47) * UP
+            )
+            labels.append(label)
 
         shapes = []
         targets_a = []
@@ -93,7 +109,12 @@ class MixedObjectParityStress(Scene):
                 targets_a.append(target_a)
                 targets_b.append(target_b)
 
-        self.play(FadeIn(title), FadeIn(subtitle), run_time=0.25)
+        self.play(
+            FadeIn(title),
+            FadeIn(subtitle),
+            *[FadeIn(label) for label in labels],
+            run_time=0.35,
+        )
         self.play(*[Create(shape) for shape in shapes], run_time=0.55)
 
         self.play(
@@ -101,46 +122,91 @@ class MixedObjectParityStress(Scene):
                 Transform(shape, target)
                 for shape, target in zip(shapes, targets_a)
             ],
-            run_time=0.75,
+            run_time=0.65,
         )
 
-        motion_a = []
-        for index, shape in enumerate(shapes):
-            row = index // cols
-            angle = PI / 3 if index % 2 == 0 else -PI / 3
-            x_direction = RIGHT if row % 2 == 0 else LEFT
-            y_direction = UP if index % 3 == 0 else DOWN
-            color = palette[(index + 5) % len(palette)]
-            motion_a.append(
-                shape.animate.rotate(angle)
-                .shift(0.035 * x_direction + 0.025 * y_direction)
-                .set_color(color)
-            )
-        self.play(*motion_a, run_time=0.55)
-        self.play(title.animate.rotate(PI / 24), run_time=0.10)
+        for wave in range(6):
+            wave_motion = []
+            for index, shape in enumerate(shapes):
+                row = index // cols
+                col = index % cols
+                bucket = (index * 37 + row * 11 + col * 7) % 6
+                if bucket != wave:
+                    continue
+                scale_factor = 0.84 + 0.04 * ((index * 13 + row) % 9)
+                angle = (((index * 19 + col) % 11) - 5) * (PI / 36)
+                dx = (((index * 17 + row) % 9) - 4) * 0.027
+                dy = (((index * 29 + col) % 7) - 3) * 0.023
+                color = palette[(index + wave + 3) % len(palette)]
+                wave_motion.append(
+                    shape.animate.scale(scale_factor)
+                    .rotate(angle)
+                    .shift(dx * RIGHT + dy * UP)
+                    .set_color(color)
+                )
+            self.play(*wave_motion, run_time=0.12)
+
+        label_specs = []
+        for index in range(len(labels)):
+            factor = 0.90 + 0.04 * ((index * 5 + 1) % 6)
+            angle = (((index * 7) % 9) - 4) * (PI / 72)
+            dx = (((index * 11) % 5) - 2) * 0.045
+            dy = (((index * 13) % 5) - 2) * 0.025
+            opacity = 0.62 + 0.09 * (index % 5)
+            label_specs.append((factor, angle, dx, dy, opacity))
+
+        for wave in range(4):
+            text_motion = []
+            for index, label in enumerate(labels):
+                if index % 4 != wave:
+                    continue
+                factor, angle, dx, dy, opacity = label_specs[index]
+                text_motion.append(
+                    label.animate.scale(factor)
+                    .rotate(angle)
+                    .shift(dx * RIGHT + dy * UP)
+                    .set_opacity(opacity)
+                )
+            self.play(*text_motion, run_time=0.08)
 
         self.play(
             *[
                 Transform(shape, target)
                 for shape, target in zip(shapes, targets_b)
             ],
-            run_time=0.75,
+            run_time=0.65,
         )
 
-        motion_b = []
+        turbulence = []
         for index, shape in enumerate(shapes):
             row = index // cols
-            angle = -PI / 2 if index % 2 == 0 else PI / 2
-            x_direction = LEFT if row % 2 == 0 else RIGHT
-            y_direction = DOWN if index % 3 == 0 else UP
-            color = palette[(index + 1) % len(palette)]
-            motion_b.append(
-                shape.animate.rotate(angle)
-                .shift(0.055 * x_direction + 0.035 * y_direction)
+            col = index % cols
+            factor = 0.92 + 0.02 * ((index * 7 + col) % 9)
+            angle = (PI / 3) if (index + row) % 2 == 0 else (-PI / 3)
+            dx = (((index * 23 + col) % 7) - 3) * 0.022
+            dy = (((index * 31 + row) % 7) - 3) * 0.020
+            color = palette[(index * 5 + 1) % len(palette)]
+            turbulence.append(
+                shape.animate.scale(factor)
+                .rotate(angle)
+                .shift(dx * RIGHT + dy * UP)
                 .set_color(color)
             )
-        self.play(*motion_b, run_time=0.55)
-        self.play(title.animate.rotate(-PI / 12), run_time=0.10)
+        self.play(*turbulence, run_time=0.55)
+
+        for wave in range(4):
+            text_motion = []
+            for index, label in enumerate(labels):
+                if index % 4 != wave:
+                    continue
+                factor, angle, dx, dy, _ = label_specs[index]
+                text_motion.append(
+                    label.animate.scale(1.0 / factor)
+                    .rotate(-angle)
+                    .shift(-dx * RIGHT - dy * UP)
+                    .set_opacity(1.0)
+                )
+            self.play(*text_motion, run_time=0.08)
 
         leaving = shapes[::3]
         pulses = [
@@ -152,18 +218,47 @@ class MixedObjectParityStress(Scene):
             ).move_to(shape.get_center())
             for shape in leaving
         ]
+        blinking_labels = labels[::3]
 
-        self.play(FadeOut(subtitle), run_time=0.10)
+        self.play(
+            FadeOut(subtitle),
+            *[FadeOut(label) for label in blinking_labels],
+            run_time=0.15,
+        )
         self.play(
             *[FadeOut(shape, scale=0.25) for shape in leaving],
             *[FadeIn(pulse, scale=0.15) for pulse in pulses],
             run_time=0.50,
         )
 
-        self.play(title.animate.rotate(PI / 24), run_time=0.10)
-        self.play(FadeIn(subtitle), run_time=0.10)
+        self.play(
+            FadeIn(subtitle),
+            *[FadeIn(label) for label in blinking_labels],
+            run_time=0.15,
+        )
         self.play(
             *[FadeIn(shape, scale=0.25) for shape in leaving],
             *[FadeOut(pulse, scale=2.0) for pulse in pulses],
-            run_time=0.60,
+            run_time=0.55,
         )
+
+        for wave in range(6):
+            wave_motion = []
+            for index, shape in enumerate(shapes):
+                row = index // cols
+                col = index % cols
+                bucket = (index * 17 + row * 5 + col * 13) % 6
+                if bucket != wave:
+                    continue
+                scale_factor = 0.90 + 0.025 * ((index * 11 + col) % 9)
+                angle = (((index * 5 + row) % 13) - 6) * (PI / 48)
+                dx = (((index * 41 + col) % 11) - 5) * 0.020
+                dy = (((index * 43 + row) % 9) - 4) * 0.018
+                color = palette[(index + 2 * wave + 5) % len(palette)]
+                wave_motion.append(
+                    shape.animate.scale(scale_factor)
+                    .rotate(angle)
+                    .shift(dx * RIGHT + dy * UP)
+                    .set_color(color)
+                )
+            self.play(*wave_motion, run_time=0.10)

--- a/web/python/examples/manim_parity_stress_grid.py
+++ b/web/python/examples/manim_parity_stress_grid.py
@@ -1,7 +1,7 @@
 from noon import *
 
 
-class DynamicLoadStress(Scene):
+class MixedObjectParityStress(Scene):
     def construct(self):
         rows = 20
         cols = 30
@@ -122,7 +122,7 @@ class DynamicLoadStress(Scene):
                 Transform(shape, target)
                 for shape, target in zip(shapes, targets_a)
             ],
-            run_time=0.65,
+            run_time=0.55,
         )
 
         for wave in range(6):
@@ -144,7 +144,7 @@ class DynamicLoadStress(Scene):
                     .shift(dx * RIGHT + dy * UP)
                     .set_color(color)
                 )
-            self.play(*wave_motion, run_time=0.12)
+            self.play(*wave_motion, run_time=0.08)
 
         label_specs = []
         for index in range(len(labels)):
@@ -167,14 +167,14 @@ class DynamicLoadStress(Scene):
                     .shift(dx * RIGHT + dy * UP)
                     .set_opacity(opacity)
                 )
-            self.play(*text_motion, run_time=0.08)
+            self.play(*text_motion, run_time=0.06)
 
         self.play(
             *[
                 Transform(shape, target)
                 for shape, target in zip(shapes, targets_b)
             ],
-            run_time=0.65,
+            run_time=0.55,
         )
 
         turbulence = []
@@ -192,7 +192,7 @@ class DynamicLoadStress(Scene):
                 .shift(dx * RIGHT + dy * UP)
                 .set_color(color)
             )
-        self.play(*turbulence, run_time=0.55)
+        self.play(*turbulence, run_time=0.45)
 
         for wave in range(4):
             text_motion = []
@@ -206,7 +206,7 @@ class DynamicLoadStress(Scene):
                     .shift(-dx * RIGHT - dy * UP)
                     .set_opacity(1.0)
                 )
-            self.play(*text_motion, run_time=0.08)
+            self.play(*text_motion, run_time=0.06)
 
         leaving = shapes[::3]
         pulses = [
@@ -223,23 +223,23 @@ class DynamicLoadStress(Scene):
         self.play(
             FadeOut(subtitle),
             *[FadeOut(label) for label in blinking_labels],
-            run_time=0.15,
+            run_time=0.10,
         )
         self.play(
             *[FadeOut(shape, scale=0.25) for shape in leaving],
             *[FadeIn(pulse, scale=0.15) for pulse in pulses],
-            run_time=0.50,
+            run_time=0.40,
         )
 
         self.play(
             FadeIn(subtitle),
             *[FadeIn(label) for label in blinking_labels],
-            run_time=0.15,
+            run_time=0.10,
         )
         self.play(
             *[FadeIn(shape, scale=0.25) for shape in leaving],
             *[FadeOut(pulse, scale=2.0) for pulse in pulses],
-            run_time=0.55,
+            run_time=0.45,
         )
 
         for wave in range(6):
@@ -261,4 +261,4 @@ class DynamicLoadStress(Scene):
                     .shift(dx * RIGHT + dy * UP)
                     .set_color(color)
                 )
-            self.play(*wave_motion, run_time=0.10)
+            self.play(*wave_motion, run_time=0.09)

--- a/web/python/examples/manim_stress_manifest.json
+++ b/web/python/examples/manim_stress_manifest.json
@@ -8,25 +8,29 @@
   "entries": [
     {
       "id": "manim-parity-stress-grid",
-      "title": "Mixed Object Parity Stress",
-      "summary": "A 600-shape Manim-compatible stress scene with two full-grid geometry morph waves, two simultaneous rotation/translation/color waves, retained Text, and 200-object lifecycle churn.",
+      "title": "Dynamic Load Stress",
+      "summary": "A dense dynamic scene with 600 geometry objects, 24 animated text streams, staggered pseudo-random transform waves, repeated morphs, full-grid turbulence, and 200-object lifecycle churn.",
       "status": "ready",
       "path": "python/examples/manim_parity_stress_grid.py",
       "category": "stress",
       "features": [
-        "600 shapes",
-        "200 lifecycle churn",
+        "600 geometry objects",
+        "24 text streams",
+        "staggered motion",
+        "pseudo-random transforms",
+        "scale",
+        "rotation",
+        "translation",
+        "opacity",
+        "color",
         "Text",
         "Create",
         "Transform",
         "repeated Transform",
         "animate",
-        "rotation",
-        "translation",
-        "color",
         "FadeIn",
         "FadeOut",
-        "retained-text",
+        "200 lifecycle churn",
         "stress",
         "pixel-parity",
         "time-parity"
@@ -36,8 +40,8 @@
       "parity_fixture": "mixed-object-parity-stress",
       "parity_source": "parity/manim-v0.21/stress-examples/mixed_object_parity_stress.py",
       "thumbnail": "thumbnails/manim/parity-stress-grid.svg",
-      "thumbnail_alt": "Dense multicolor grid of hundreds of squares and circles under a MANIM PARITY STRESS title",
-      "thumbnail_time": 2.8,
+      "thumbnail_alt": "Dense dynamic grid of hundreds of colorful shapes with telemetry-style text streams around the edges",
+      "thumbnail_time": 3.6,
       "order": 15
     }
   ]

--- a/web/python/examples/manim_stress_manifest.json
+++ b/web/python/examples/manim_stress_manifest.json
@@ -31,6 +31,7 @@
         "FadeIn",
         "FadeOut",
         "200 lifecycle churn",
+        "600 shapes",
         "stress",
         "pixel-parity",
         "time-parity"
@@ -41,7 +42,7 @@
       "parity_source": "parity/manim-v0.21/stress-examples/mixed_object_parity_stress.py",
       "thumbnail": "thumbnails/manim/parity-stress-grid.svg",
       "thumbnail_alt": "Dense dynamic grid of hundreds of colorful shapes with telemetry-style text streams around the edges",
-      "thumbnail_time": 3.6,
+      "thumbnail_time": 3.0,
       "order": 15
     }
   ]

--- a/web/python/test_manim_stress_example.py
+++ b/web/python/test_manim_stress_example.py
@@ -26,7 +26,9 @@ class ManimStressExampleTests(unittest.TestCase):
         self.assertEqual(entry["reuse"], "manim-compatible-parity-v0.21")
         self.assertEqual(entry["parity_status"], "candidate")
         self.assertEqual(entry["parity_fixture"], "mixed-object-parity-stress")
-        self.assertIn("600 shapes", entry["features"])
+        self.assertIn("600 geometry objects", entry["features"])
+        self.assertIn("24 text streams", entry["features"])
+        self.assertIn("staggered motion", entry["features"])
         self.assertIn("200 lifecycle churn", entry["features"])
 
         demo_path = WEB_ROOT / entry["path"]
@@ -45,17 +47,24 @@ class ManimStressExampleTests(unittest.TestCase):
             "Text(",
             "Create(",
             "Transform(",
-            ".animate.rotate(",
+            ".animate.scale(",
+            ".rotate(",
+            ".shift(",
             ".set_color(",
+            ".set_opacity(",
             "FadeIn(",
             "FadeOut(",
         ):
             self.assertIn(token, canonical_source)
         self.assertIn("rows = 20", canonical_source)
         self.assertIn("cols = 30", canonical_source)
+        self.assertIn("for index in range(24)", canonical_source)
+        self.assertIn("for wave in range(6)", canonical_source)
         self.assertIn("targets_a = []", canonical_source)
         self.assertIn("targets_b = []", canonical_source)
+        self.assertIn("turbulence = []", canonical_source)
         self.assertIn("leaving = shapes[::3]", canonical_source)
+        self.assertIn("blinking_labels = labels[::3]", canonical_source)
         self.assertNotIn("VectorPath", canonical_source)
         self.assertNotIn("context", canonical_source)
         self.assertNotIn("result =", canonical_source)

--- a/web/stress-runtime-contract.test.mjs
+++ b/web/stress-runtime-contract.test.mjs
@@ -22,29 +22,31 @@ const browserSmoke = await readFile(new URL("./manim-compat-smoke.html", import.
 assert.equal(
   noon,
   canonical.replace("from manim import *", "from noon import *"),
-  "stress source must remain import-only Manim compatible",
+  "stress source must remain import-only source compatible",
 );
+assert.match(noon, /class DynamicLoadStress\(Scene\)/);
 assert.match(noon, /rows = 20/);
 assert.match(noon, /cols = 30/);
 assert.match(noon, /shape_count = rows \* cols/);
-assert.match(noon, /self\.play\(FadeIn\(title\), FadeIn\(subtitle\), run_time=0\.25\)/);
-assert.match(noon, /self\.play\(\*\[Create\(shape\) for shape in shapes\], run_time=0\.55\)/);
-assert.doesNotMatch(
-  noon,
-  /Create\(title\)/,
-  "retained family Create cannot share the stress scene's mass mixed-animation play yet",
-);
-assert.match(noon, /for shape, target in zip\(shapes, targets_a\)/);
-assert.match(noon, /for shape, target in zip\(shapes, targets_b\)/);
-assert.match(noon, /motion_a = \[\]/);
-assert.match(noon, /motion_b = \[\]/);
+assert.match(noon, /for index in range\(24\)/);
+assert.match(noon, /\*\[FadeIn\(label\) for label in labels\]/);
+assert.match(noon, /for wave in range\(6\)/);
+assert.match(noon, /bucket = \(index \* 37 \+ row \* 11 \+ col \* 7\) % 6/);
+assert.match(noon, /shape\.animate\.scale\(scale_factor\)/);
+assert.match(noon, /\.rotate\(angle\)/);
+assert.match(noon, /\.shift\(dx \* RIGHT \+ dy \* UP\)/);
+assert.match(noon, /\.set_color\(color\)/);
+assert.match(noon, /label\.animate\.scale\(factor\)/);
+assert.match(noon, /\.set_opacity\(opacity\)/);
+assert.match(noon, /\.set_opacity\(1\.0\)/);
+assert.match(noon, /turbulence = \[\]/);
 assert.match(noon, /leaving = shapes\[::3\]/);
-assert.match(noon, /title\.animate\.rotate\(PI \/ 24\)/);
-assert.match(noon, /title\.animate\.rotate\(-PI \/ 12\)/);
+assert.match(noon, /blinking_labels = labels\[::3\]/);
+assert.doesNotMatch(noon, /MANIM/i, "public stress scene copy must not expose compatibility branding");
 assert.doesNotMatch(
   noon,
-  /(?:title|subtitle)\.animate[^\n]*set_color/,
-  "public stress scene must not claim retained Text color animation before a color track exists",
+  /(?:title|subtitle|label)\.animate[^\n]*set_color/,
+  "retained Text color animation must not be claimed before a color track exists",
 );
 assert.match(
   retainedAnimate,
@@ -62,10 +64,12 @@ assert.match(
   "contract should track the retained family mixed-play capability boundary",
 );
 assert.match(browserSmoke, /manim_parity_stress_grid\.py/);
+assert.match(browserSmoke, /stressResult\.duration\) - 6\.06/);
 assert.match(browserSmoke, /stressResult\.document\.objects\.length !== 800/);
-assert.match(browserSmoke, /stressResult\.sceneSpec\.objects\.length !== 802/);
-assert.match(browserSmoke, /expectedObjectCount: 602/);
+assert.match(browserSmoke, /stressResult\.retainedDocument\?\.objects\?\.length !== 26/);
+assert.match(browserSmoke, /stressResult\.sceneSpec\.objects\.length !== 826/);
+assert.match(browserSmoke, /expectedObjectCount: 626/);
 assert.match(browserSmoke, /waitForRenderedState/);
-assert.match(browserSmoke, /seekTime: 2\.8/);
+assert.match(browserSmoke, /seekTime: 3\.6/);
 
 console.log("✓ stress runtime capability and browser-execution contract");

--- a/web/stress-runtime-contract.test.mjs
+++ b/web/stress-runtime-contract.test.mjs
@@ -24,7 +24,7 @@ assert.equal(
   canonical.replace("from manim import *", "from noon import *"),
   "stress source must remain import-only source compatible",
 );
-assert.match(noon, /class DynamicLoadStress\(Scene\)/);
+assert.match(noon, /class MixedObjectParityStress\(Scene\)/);
 assert.match(noon, /rows = 20/);
 assert.match(noon, /cols = 30/);
 assert.match(noon, /shape_count = rows \* cols/);
@@ -64,12 +64,12 @@ assert.match(
   "contract should track the retained family mixed-play capability boundary",
 );
 assert.match(browserSmoke, /manim_parity_stress_grid\.py/);
-assert.match(browserSmoke, /stressResult\.duration\) - 6\.06/);
+assert.match(browserSmoke, /stressResult\.duration\) - 5\.0/);
 assert.match(browserSmoke, /stressResult\.document\.objects\.length !== 800/);
 assert.match(browserSmoke, /stressResult\.retainedDocument\?\.objects\?\.length !== 26/);
 assert.match(browserSmoke, /stressResult\.sceneSpec\.objects\.length !== 826/);
 assert.match(browserSmoke, /expectedObjectCount: 626/);
 assert.match(browserSmoke, /waitForRenderedState/);
-assert.match(browserSmoke, /seekTime: 3\.6/);
+assert.match(browserSmoke, /seekTime: 3\.0/);
 
 console.log("✓ stress runtime capability and browser-execution contract");

--- a/web/thumbnails/manim/parity-stress-grid.svg
+++ b/web/thumbnails/manim/parity-stress-grid.svg
@@ -1,28 +1,32 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
-  <title id="title">Mixed Object Parity Stress</title>
-  <desc id="desc">Dense multicolor squares and circles representing the Manim parity stress scene.</desc>
+  <title id="title">Dynamic Load Stress</title>
+  <desc id="desc">Dense animated-load scene with hundreds of colorful shapes and telemetry-style text streams.</desc>
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#080b12"/>
       <stop offset="1" stop-color="#151024"/>
     </linearGradient>
-    <pattern id="tiles" width="80" height="56" patternUnits="userSpaceOnUse">
-      <rect x="7" y="8" width="24" height="24" rx="3" fill="#58c4dd" fill-opacity=".82" stroke="#9cdceb" stroke-width="2"/>
-      <circle cx="59" cy="20" r="13" fill="#83c167" fill-opacity=".82" stroke="#a6cf8c" stroke-width="2"/>
-      <circle cx="19" cy="49" r="12" fill="#d147bd" fill-opacity=".82" stroke="#dc75cd" stroke-width="2"/>
-      <rect x="47" y="37" width="24" height="24" rx="3" transform="rotate(45 59 49)" fill="#f7d96f" fill-opacity=".82" stroke="#ffea94" stroke-width="2"/>
+    <pattern id="tiles" width="54" height="38" patternUnits="userSpaceOnUse">
+      <rect x="5" y="5" width="15" height="15" rx="2" fill="#58c4dd" fill-opacity=".86" stroke="#9cdceb" stroke-width="1.3"/>
+      <circle cx="39" cy="12" r="8" fill="#83c167" fill-opacity=".86" stroke="#a6cf8c" stroke-width="1.3"/>
+      <circle cx="14" cy="32" r="7" fill="#d147bd" fill-opacity=".84" stroke="#dc75cd" stroke-width="1.2"/>
+      <rect x="32" y="24" width="14" height="14" rx="2" transform="rotate(45 39 31)" fill="#f7d96f" fill-opacity=".84" stroke="#ffea94" stroke-width="1.2"/>
     </pattern>
     <radialGradient id="glow" cx="50%" cy="45%" r="60%">
-      <stop offset="0" stop-color="#8e7cff" stop-opacity=".18"/>
+      <stop offset="0" stop-color="#8e7cff" stop-opacity=".20"/>
       <stop offset="1" stop-color="#8e7cff" stop-opacity="0"/>
     </radialGradient>
   </defs>
   <rect width="640" height="360" fill="url(#bg)"/>
   <rect width="640" height="360" fill="url(#glow)"/>
-  <text x="320" y="53" text-anchor="middle" fill="#f1f4fb" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="28" font-weight="700">MANIM PARITY STRESS</text>
-  <text x="320" y="78" text-anchor="middle" fill="#9aa7be" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="13">72 shapes · morph · rotate · color · text · lifecycle</text>
-  <rect x="47" y="101" width="546" height="213" rx="14" fill="#0c111b" stroke="#27334b"/>
-  <rect x="58" y="112" width="524" height="191" rx="8" fill="url(#tiles)"/>
-  <path d="M58 208 H582" stroke="#8e7cff" stroke-opacity=".28" stroke-width="2" stroke-dasharray="6 7"/>
-  <text x="320" y="339" text-anchor="middle" fill="#7f8ca5" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="12">same scene body in ManimCE 0.21 and Noon</text>
+  <text x="320" y="49" text-anchor="middle" fill="#f1f4fb" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="27" font-weight="700">DYNAMIC LOAD STRESS</text>
+  <text x="320" y="73" text-anchor="middle" fill="#9aa7be" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="12">600 geometry · 24 text streams · stagger · morph · churn</text>
+  <rect x="63" y="94" width="514" height="220" rx="14" fill="#0c111b" stroke="#27334b"/>
+  <rect x="88" y="107" width="464" height="194" rx="8" fill="url(#tiles)"/>
+  <path d="M88 205 H552" stroke="#8e7cff" stroke-opacity=".34" stroke-width="2" stroke-dasharray="5 6"/>
+  <g fill="#8998b2" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="7">
+    <text x="68" y="120">S00 019</text><text x="68" y="138">S01 092</text><text x="68" y="156">S02 165</text><text x="68" y="174">S03 238</text><text x="68" y="192">S04 311</text><text x="68" y="210">S05 384</text><text x="68" y="228">S06 457</text><text x="68" y="246">S07 530</text><text x="68" y="264">S08 603</text><text x="68" y="282">S09 676</text>
+    <text x="553" y="120">S14 044</text><text x="553" y="138">S15 117</text><text x="553" y="156">S16 190</text><text x="553" y="174">S17 263</text><text x="553" y="192">S18 336</text><text x="553" y="210">S19 409</text><text x="553" y="228">S20 482</text><text x="553" y="246">S21 555</text><text x="553" y="264">S22 628</text><text x="553" y="282">S23 701</text>
+  </g>
+  <text x="320" y="340" text-anchor="middle" fill="#7f8ca5" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="12">translation · scale · rotation · opacity · color · lifecycle</text>
 </svg>


### PR DESCRIPTION
## Summary
- keep 600 primary geometry objects while adding 24 retained text streams
- add six-wave deterministic staggered translation/scale/rotation/color motion before and after the main morph phases
- add text scale/rotation/translation/opacity waves in retained-only plays
- retain two geometry morph phases, full-grid turbulence, and 200-object lifecycle churn
- rename the public scene/card copy to `Dynamic Load Stress` and remove compatibility branding from the public scene/gallery copy
- update the browser regression to require 800 geometry objects + 26 retained text objects = 826 canonical objects and 626 simultaneously visible objects at t=3.0s

The pseudo-random motion is deterministic so authoring and direct-seek runtime checks remain reproducible.