### PR TITLE
Restore lazy Python editor after playground tab cleanup

### DIFF
--- a/web/python-editor.js
+++ b/web/python-editor.js
@@ -29,9 +29,7 @@ if (typeof document !== "undefined") {
 }
 
 function isVisiblePythonTextarea(textarea) {
-  if (!textarea || textarea.hidden) return false;
-  const editorPanel = textarea.closest(".editor-panel");
-  return editorPanel === null || editorPanel.dataset.active === "true";
+  return textarea !== null && textarea.closest("[hidden]") === null;
 }
 
 async function enhancePythonEditors() {


### PR DESCRIPTION
Clean current-master replay of #890. Keeps only the intended `web/python-editor.js` visibility fix: enhance visible textareas based on native `[hidden]` ancestry rather than the removed `data-active` tab state.

Supersedes #890.