### PR TITLE
Clip browser jank metrics to measurement windows

### DIFF
--- a/web/browser-jank.js
+++ b/web/browser-jank.js
@@ -1,3 +1,23 @@
+function clipEntryToWindow(entry, measurementStartMs, measurementEndMs) {
+  const startTime = Number(entry.startTime);
+  const duration = Number(entry.duration);
+  if (!Number.isFinite(startTime) || !Number.isFinite(duration) || duration <= 0) {
+    return null;
+  }
+
+  const endTime = startTime + duration;
+  const clippedStart = Math.max(startTime, measurementStartMs);
+  const clippedEnd = Math.min(endTime, measurementEndMs);
+  if (!(clippedEnd > clippedStart)) {
+    return null;
+  }
+
+  return {
+    startTime: clippedStart,
+    duration: clippedEnd - clippedStart,
+  };
+}
+
 export class BrowserJankMonitor {
   #entries = [];
   #observer = null;
@@ -13,10 +33,12 @@ export class BrowserJankMonitor {
     }
     this.#observer = new PerformanceObserverClass((list) => {
       for (const entry of list.getEntries()) {
-        this.#entries.push({
-          startTime: Number(entry.startTime),
-          duration: Number(entry.duration),
-        });
+        const startTime = Number(entry.startTime);
+        const duration = Number(entry.duration);
+        if (!Number.isFinite(startTime) || !Number.isFinite(duration) || duration <= 0) {
+          continue;
+        }
+        this.#entries.push({ startTime, duration });
       }
     });
     this.#supported = true;
@@ -40,13 +62,17 @@ export class BrowserJankMonitor {
   }
 
   summary(measurementStartMs = -Infinity, measurementEndMs = Infinity) {
-    const entries = this.#entries.filter(
-      ({ startTime }) => startTime >= measurementStartMs && startTime <= measurementEndMs,
-    );
     if (!this.#supported) {
       return { supported: false };
     }
-    const durations = entries.map(({ duration }) => duration).filter(Number.isFinite);
+    if (!(measurementEndMs >= measurementStartMs)) {
+      throw new RangeError("measurementEndMs must be greater than or equal to measurementStartMs");
+    }
+
+    const entries = this.#entries
+      .map((entry) => clipEntryToWindow(entry, measurementStartMs, measurementEndMs))
+      .filter((entry) => entry !== null);
+    const durations = entries.map(({ duration }) => duration);
     return {
       supported: true,
       count: durations.length,

--- a/web/browser-jank.test.mjs
+++ b/web/browser-jank.test.mjs
@@ -27,7 +27,7 @@ class FakePerformanceObserver {
   }
 }
 
-test("collects long tasks within the requested measurement window", () => {
+test("clips overlapping long tasks to the requested measurement window", () => {
   const monitor = new BrowserJankMonitor(FakePerformanceObserver);
   assert.equal(monitor.start(), true);
   assert.deepEqual(FakePerformanceObserver.instance.observed, {
@@ -38,18 +38,43 @@ test("collects long tasks within the requested measurement window", () => {
   FakePerformanceObserver.instance.emit([
     { startTime: 10, duration: 55 },
     { startTime: 100, duration: 80 },
+    { startTime: 190, duration: 30 },
     { startTime: 300, duration: 120 },
   ]);
 
   assert.deepEqual(monitor.summary(50, 200), {
     supported: true,
-    count: 1,
-    totalMs: 80,
+    count: 3,
+    totalMs: 105,
     maxMs: 80,
-    entries: [{ startTime: 100, duration: 80 }],
+    entries: [
+      { startTime: 50, duration: 15 },
+      { startTime: 100, duration: 80 },
+      { startTime: 190, duration: 10 },
+    ],
   });
   monitor.stop();
   assert.equal(FakePerformanceObserver.instance.disconnected, true);
+});
+
+test("ignores malformed long-task entries and rejects inverted windows", () => {
+  const monitor = new BrowserJankMonitor(FakePerformanceObserver);
+  monitor.start();
+  FakePerformanceObserver.instance.emit([
+    { startTime: Number.NaN, duration: 60 },
+    { startTime: 20, duration: Number.POSITIVE_INFINITY },
+    { startTime: 30, duration: 0 },
+    { startTime: 40, duration: -1 },
+  ]);
+
+  assert.deepEqual(monitor.summary(), {
+    supported: true,
+    count: 0,
+    totalMs: 0,
+    maxMs: 0,
+    entries: [],
+  });
+  assert.throws(() => monitor.summary(200, 100), /measurementEndMs/);
 });
 
 test("reports unsupported environments without failing profiling", () => {


### PR DESCRIPTION
Clean current-master replay of #796. The affected files were unchanged since the original base, so this preserves the exact two-file fix and tests without stale ancestry.

Supersedes #796.