### PR TITLE
Fix native text descent bounds

### DIFF
--- a/crates/noon-text-native/src/lib.rs
+++ b/crates/noon-text-native/src/lib.rs
@@ -224,10 +224,10 @@ impl NativeTextCompiler {
                         },
                         origin,
                         advance,
-                        // Exact outlines remain lazy. The line-box bound is conservative
-                        // and sufficient for semantic layout until exact ink metrics land.
+                        // Swash reports descent as a positive distance below the baseline;
+                        // retained Y coordinates use negative values below the baseline.
                         bounds: Rect::new(
-                            Vec2::new(origin.x.min(right), metrics.descent),
+                            Vec2::new(origin.x.min(right), -metrics.descent),
                             Vec2::new(origin.x.max(right), metrics.ascent),
                         ),
                     });
@@ -241,7 +241,7 @@ impl NativeTextCompiler {
                 Rect::new(Vec2::ZERO, Vec2::ZERO)
             } else {
                 Rect::new(
-                    Vec2::new(0.0_f32.min(cursor_x), metrics.descent + baseline_y),
+                    Vec2::new(0.0_f32.min(cursor_x), -metrics.descent + baseline_y),
                     Vec2::new(0.0_f32.max(cursor_x), metrics.ascent + baseline_y),
                 )
             };

--- a/crates/noon-text-native/tests/metrics.rs
+++ b/crates/noon-text-native/tests/metrics.rs
@@ -1,0 +1,29 @@
+use std::sync::Arc;
+
+use noon_text_native::{NativeFontFace, NativeTextCompiler, NativeTextOptions};
+
+fn bundled_font() -> NativeFontFace {
+    let bytes = typst_assets::fonts()
+        .next()
+        .expect("Typst test assets include at least one font");
+    NativeFontFace::new("Bundled Test Font", Arc::<[u8]>::from(bytes), 0).unwrap()
+}
+
+#[test]
+fn conservative_native_glyph_bounds_extend_below_the_baseline() {
+    let font = bundled_font();
+    let mut compiler = NativeTextCompiler::new();
+    let artifact = compiler
+        .compile_plain("Hg", &font, &NativeTextOptions::new(48.0))
+        .unwrap();
+    let run = artifact.resource.runs.first().expect("one shaped line");
+
+    assert!(!run.glyphs.is_empty());
+    for glyph in run.glyphs.iter() {
+        assert!(
+            glyph.bounds.min.y < 0.0,
+            "descent is a positive metric distance but must map below the baseline"
+        );
+        assert!(glyph.bounds.max.y > 0.0);
+    }
+}


### PR DESCRIPTION
Clean current-master replay of #794. The production file was unchanged since the original base, so this preserves the exact native-text descent sign correction and focused metrics regression.

Supersedes #794.