### PR TITLE
Stabilize playground deployments and verify live revision

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -13,7 +13,9 @@ permissions:
 
 concurrency:
   group: pages
-  cancel-in-progress: true
+  # Production deployments must finish even when master is moving quickly.
+  # New pushes queue behind the in-flight deployment instead of starving Pages.
+  cancel-in-progress: false
 
 jobs:
   build:
@@ -57,6 +59,9 @@ jobs:
       - name: Build and validate playground
         run: bash scripts/build-web-demo.sh
 
+      - name: Stamp deployed revision
+        run: printf '{"commit":"%s"}\n' "$GITHUB_SHA" > web/build-info.json
+
       - name: Configure Pages
         uses: actions/configure-pages@v5
 
@@ -76,3 +81,24 @@ jobs:
       - name: Deploy
         id: deployment
         uses: actions/deploy-pages@v4
+
+      - name: Verify deployed revision
+        env:
+          PAGE_URL: ${{ steps.deployment.outputs.page_url }}
+          EXPECTED_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          url="${PAGE_URL%/}/build-info.json?sha=${EXPECTED_SHA}"
+          for attempt in {1..20}; do
+            body="$(curl --fail --silent --show-error \
+              -H 'Cache-Control: no-cache' \
+              "$url" 2>/dev/null || true)"
+            if [[ "$body" == *"\"commit\":\"${EXPECTED_SHA}\""* ]]; then
+              echo "Verified live playground revision ${EXPECTED_SHA}"
+              exit 0
+            fi
+            echo "Waiting for Pages to serve ${EXPECTED_SHA} (attempt ${attempt}/20)"
+            sleep 5
+          done
+          echo "Pages never served expected revision ${EXPECTED_SHA}" >&2
+          exit 1

--- a/web/playground-stability-boundary.test.mjs
+++ b/web/playground-stability-boundary.test.mjs
@@ -97,8 +97,18 @@ assert.match(
 );
 assert.match(
   pagesWorkflow,
-  /concurrency:\s*\n\s*group: pages\s*\n\s*cancel-in-progress: true/,
-  "superseded playground deployments must be cancelled",
+  /concurrency:\s*\n\s*group: pages[\s\S]*?cancel-in-progress: false/,
+  "playground deployments must queue instead of starving an in-flight production release",
+);
+assert.match(
+  pagesWorkflow,
+  /name: Stamp deployed revision[\s\S]*?GITHUB_SHA[\s\S]*?web\/build-info\.json/,
+  "the Pages artifact must carry the exact source revision",
+);
+assert.match(
+  pagesWorkflow,
+  /name: Verify deployed revision[\s\S]*?EXPECTED_SHA: \$\{\{ github\.sha \}\}[\s\S]*?build-info\.json/,
+  "the deployment must verify the public Pages site serves the expected revision",
 );
 
 console.log("✓ deferred playground runtime keeps recoverable scene errors outside fatal recovery");


### PR DESCRIPTION
## Summary
- stop cancelling an in-flight production Pages deployment when master advances
- stamp the deployed web artifact with the exact Git commit SHA
- verify the public Pages URL serves that SHA after deployment, with cache-busting retries

This fixes deployment starvation during rapid merges and gives an end-to-end signal that the live playground actually updated.