### PR TITLE
Validate legacy Scene semantic IDs

### DIFF
--- a/web/authoring-client.js
+++ b/web/authoring-client.js
@@ -286,6 +286,9 @@ export function validateSceneDocument(scene) {
   if (!Array.isArray(scene.tracks)) {
     throw new Error("Python Scene tracks must be an array");
   }
+
+  validateDefinitionIds("object", scene.objects);
+  validateDefinitionIds("track", scene.tracks);
   return scene;
 }
 
@@ -480,6 +483,23 @@ export function validateCallbackSession(callbacks, scene) {
     }
   }
   return callbacks;
+}
+
+function validateDefinitionIds(kind, definitions) {
+  const ids = new Set();
+  for (const definition of definitions) {
+    if (
+      !isRecord(definition) ||
+      !Number.isSafeInteger(definition.id) ||
+      definition.id < 0
+    ) {
+      throw new Error(`Python Scene has an invalid ${kind} ID`);
+    }
+    if (ids.has(definition.id)) {
+      throw new Error(`Python Scene has duplicate ${kind} IDs`);
+    }
+    ids.add(definition.id);
+  }
 }
 
 function validateIdentityEntries(kind, entries, definitions) {

--- a/web/authoring-scene-validation.test.mjs
+++ b/web/authoring-scene-validation.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { validateSceneDocument } from "./authoring-client.js";
+
+function scene({ objects = [], tracks = [] } = {}) {
+  return { version: 1, objects, tracks };
+}
+
+test("accepts unique JS-safe legacy Scene definition IDs", () => {
+  const document = scene({
+    objects: [{ id: 0 }, { id: 2 ** 52 }],
+    tracks: [{ id: 1 }, { id: 3 }],
+  });
+
+  assert.equal(validateSceneDocument(document), document);
+});
+
+test("rejects malformed legacy Scene definition IDs at the authoring boundary", () => {
+  for (const document of [
+    scene({ objects: [{}] }),
+    scene({ objects: [{ id: -1 }] }),
+    scene({ objects: [{ id: Number.MAX_SAFE_INTEGER + 1 }] }),
+    scene({ tracks: [null] }),
+    scene({ tracks: [{ id: -1 }] }),
+    scene({ tracks: [{ id: Number.MAX_SAFE_INTEGER + 1 }] }),
+  ]) {
+    assert.throws(() => validateSceneDocument(document), /invalid (object|track) ID/);
+  }
+});
+
+test("rejects duplicate legacy Scene object and track IDs", () => {
+  assert.throws(
+    () => validateSceneDocument(scene({ objects: [{ id: 4 }, { id: 4 }] })),
+    /duplicate object IDs/,
+  );
+  assert.throws(
+    () => validateSceneDocument(scene({ tracks: [{ id: 7 }, { id: 7 }] })),
+    /duplicate track IDs/,
+  );
+});


### PR DESCRIPTION
Clean current-master port of #802. Keeps canonical SceneSpec validation unchanged and hardens the still-supported legacy `SceneDocument` boundary against malformed or duplicate object/track IDs, with focused auto-discovered Node coverage.

Supersedes #802.