### PR TITLE
Validate runnable gallery scalar metadata

### DIFF
--- a/web/example-gallery-validation.test.mjs
+++ b/web/example-gallery-validation.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+
+import { normalizeGalleryManifest } from "./example-gallery.js";
+
+function readyEntry(overrides = {}) {
+  return {
+    id: "valid-example",
+    title: "Valid example",
+    status: "ready",
+    reuse: "source-equivalent-manim-v0.21",
+    path: "python/examples/manim_valid_example.py",
+    thumbnail: "thumbnails/manim/valid-example.webp",
+    features: ["Circle"],
+    parity_status: "candidate",
+    ...overrides,
+  };
+}
+
+for (const title of [undefined, null, "", "   "]) {
+  assert.throws(
+    () => normalizeGalleryManifest({ entries: [readyEntry({ title })] }),
+    /requires a non-empty title/,
+    `ready gallery title ${String(title)} must fail at the manifest boundary`,
+  );
+}
+
+for (const order of [Number.NaN, Number.POSITIVE_INFINITY, "not-a-number"]) {
+  assert.throws(
+    () => normalizeGalleryManifest({ entries: [readyEntry({ order })] }),
+    /order must be finite/,
+    `ready gallery order ${String(order)} must fail before sorting`,
+  );
+}
+
+for (const thumbnailTime of [-0.1, Number.NaN, Number.POSITIVE_INFINITY, "not-a-number"]) {
+  assert.throws(
+    () =>
+      normalizeGalleryManifest({
+        entries: [readyEntry({ thumbnail_time: thumbnailTime })],
+      }),
+    /thumbnail_time must be a finite non-negative number/,
+    `thumbnail time ${String(thumbnailTime)} must fail before rendering`,
+  );
+}
+
+const normalized = normalizeGalleryManifest({
+  entries: [readyEntry({ order: "2", thumbnail_time: "0.5" })],
+}).examples[0];
+assert.equal(normalized.order, 2, "finite numeric order strings retain existing normalization semantics");
+assert.equal(
+  normalized.thumbnailTime,
+  0.5,
+  "finite numeric thumbnail-time strings retain existing normalization semantics",
+);
+
+console.log("✓ runnable gallery scalar metadata validation");

--- a/web/example-gallery.js
+++ b/web/example-gallery.js
@@ -39,6 +39,9 @@ export function normalizeGalleryManifest(manifest) {
     if (!READY_PARITY.has(entry.parity_status)) {
       throw new Error(`${entry.id}: runnable gallery example needs candidate/qualified parity status`);
     }
+    if (typeof entry.title !== "string" || entry.title.trim() === "") {
+      throw new TypeError(`${entry.id}: runnable gallery example requires a non-empty title`);
+    }
     if (typeof entry.path !== "string" || entry.path.trim() === "") {
       throw new Error(`${entry.id}: runnable gallery example requires a source path`);
     }
@@ -47,6 +50,17 @@ export function normalizeGalleryManifest(manifest) {
     }
     if (!Array.isArray(entry.features) || entry.features.length === 0) {
       throw new Error(`${entry.id}: runnable gallery example requires feature tags`);
+    }
+
+    const thumbnailTime = Number(entry.thumbnail_time ?? 0);
+    if (!Number.isFinite(thumbnailTime) || thumbnailTime < 0) {
+      throw new TypeError(
+        `${entry.id}: runnable gallery example thumbnail_time must be a finite non-negative number`,
+      );
+    }
+    const order = Number(entry.order ?? 0);
+    if (!Number.isFinite(order)) {
+      throw new TypeError(`${entry.id}: runnable gallery example order must be finite`);
     }
 
     examples.push({
@@ -62,8 +76,8 @@ export function normalizeGalleryManifest(manifest) {
       parityFixture: entry.parity_fixture ?? null,
       thumbnail: `./${entry.thumbnail}`,
       thumbnailAlt: entry.thumbnail_alt ?? `${entry.title} poster frame`,
-      thumbnailTime: Number(entry.thumbnail_time ?? 0),
-      order: Number(entry.order ?? 0),
+      thumbnailTime,
+      order,
     });
   }
 


### PR DESCRIPTION
Clean current-master port of #795 after the #887 Example Browser refactor. Keeps the new UI split intact and hardens the existing `normalizeGalleryManifest` boundary for non-empty titles, finite ordering, and finite non-negative thumbnail times, preserving numeric-string normalization.

Supersedes #795.