### PR TITLE
Gate persistent render mode switching by PR risk

### DIFF
--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -223,6 +223,18 @@ jobs:
           echo "seconds=$SECONDS" >> "$GITHUB_OUTPUT"
           exit "$status"
 
+      - name: Check persistent render mode switching
+        if: steps.browser-risk.outputs.render_mode_switch == 'true'
+        id: render-mode-switch
+        run: |
+          SECONDS=0
+          set +e
+          timeout --signal=TERM 60s node scripts/authoring-render-mode-switch-smoke.mjs
+          status=$?
+          set -e
+          echo "seconds=$SECONDS" >> "$GITHUB_OUTPUT"
+          exit "$status"
+
       - name: Check primary WebGPU rendering
         id: webgpu-smoke
         env:
@@ -258,6 +270,8 @@ jobs:
           AUTHORING_SECONDS: ${{ steps.manim-authoring.outputs.seconds }}
           RETAINED_REQUIRED: ${{ steps.browser-risk.outputs.retained_execution }}
           RETAINED_SECONDS: ${{ steps.retained-execution.outputs.seconds }}
+          MODE_SWITCH_REQUIRED: ${{ steps.browser-risk.outputs.render_mode_switch }}
+          MODE_SWITCH_SECONDS: ${{ steps.render-mode-switch.outputs.seconds }}
           WEBGPU_SECONDS: ${{ steps.webgpu-smoke.outputs.seconds }}
           HOST_UPDATER_SECONDS: ${{ steps.host-updater-diagnostics.outputs.seconds }}
         run: |
@@ -279,6 +293,11 @@ jobs:
             retained_duration="$(display_seconds "$RETAINED_SECONDS")"
           fi
 
+          mode_switch_duration="skipped"
+          if [[ "$MODE_SWITCH_REQUIRED" == "true" ]]; then
+            mode_switch_duration="$(display_seconds "$MODE_SWITCH_SECONDS")"
+          fi
+
           {
             echo "### Browser fast checks timing"
             echo
@@ -288,11 +307,13 @@ jobs:
             echo "| Deterministic replay | $(display_seconds "$REPLAY_SECONDS") |"
             echo "| Manim authoring | $(display_seconds "$AUTHORING_SECONDS") |"
             echo "| Canonical retained execution | $retained_duration |"
+            echo "| Persistent render mode switching | $mode_switch_duration |"
             echo "| WebGPU smoke | $(display_seconds "$WEBGPU_SECONDS") |"
             echo "| Host-updater diagnostics | $(display_seconds "$HOST_UPDATER_SECONDS") |"
             echo "| Measured browser path | $(display_seconds "$total") |"
             echo
             echo "Retained execution escalation required: ${RETAINED_REQUIRED:-unknown}."
+            echo "Render mode-switch escalation required: ${MODE_SWITCH_REQUIRED:-unknown}."
             echo
             echo "The measured browser path starts before checkout and ends after the renderer smoke. Hosted-runner queue time and post-job cleanup are intentionally excluded."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/pr-risk-classifier.mjs
+++ b/scripts/pr-risk-classifier.mjs
@@ -20,6 +20,20 @@ const retainedExecutionRustPaths = new Set([
   "crates/noon-web/src/lib.rs",
 ]);
 
+const renderModeSwitchPaths = new Set([
+  "scripts/authoring-render-mode-switch-smoke.mjs",
+  // Policy changes must exercise the oracle they decide whether to run.
+  "scripts/pr-risk-classifier.mjs",
+  "web/authoring-execution-client.js",
+  "web/authoring-render-worker.js",
+  "web/execution-engine-worker.js",
+  "web/execution-render-worker.js",
+  "web/execution-transport.js",
+  "web/execution-worker-client.js",
+  "web/execution-worker-smoke.html",
+  "web/retained-execution-engine-worker.js",
+]);
+
 const hostUpdaterDiagnosticPaths = new Set([
   ".github/workflows/pr-fast.yml",
   "crates/noon-render-wgpu/src/gpu_geometry.rs",
@@ -45,28 +59,27 @@ export function requiresRetainedExecutionSmoke(path) {
   return normalized.startsWith("crates/") && /(^|\/)[^/]*retained[^/]*(\/|$)/.test(normalized);
 }
 
+export function requiresRenderModeSwitchSmoke(path) {
+  const normalized = normalizeRepositoryPath(path);
+  return normalized !== "" && renderModeSwitchPaths.has(normalized);
+}
+
 export function requiresHostUpdaterDiagnostic(path) {
   const normalized = normalizeRepositoryPath(path);
   return hostUpdaterDiagnosticPaths.has(normalized);
 }
 
 export function classifyPrRisk(paths) {
-  const retainedExecutionPaths = [...new Set(
-    paths
-      .map(normalizeRepositoryPath)
-      .filter(Boolean)
-      .filter(requiresRetainedExecutionSmoke),
-  )].sort();
-  const hostUpdaterDiagnosticPathsChanged = [...new Set(
-    paths
-      .map(normalizeRepositoryPath)
-      .filter(Boolean)
-      .filter(requiresHostUpdaterDiagnostic),
-  )].sort();
+  const normalizedPaths = [...new Set(paths.map(normalizeRepositoryPath).filter(Boolean))];
+  const retainedExecutionPaths = normalizedPaths.filter(requiresRetainedExecutionSmoke).sort();
+  const renderModeSwitchPathsChanged = normalizedPaths.filter(requiresRenderModeSwitchSmoke).sort();
+  const hostUpdaterDiagnosticPathsChanged = normalizedPaths.filter(requiresHostUpdaterDiagnostic).sort();
 
   return Object.freeze({
     retainedExecution: retainedExecutionPaths.length > 0,
     retainedExecutionPaths: Object.freeze(retainedExecutionPaths),
+    renderModeSwitch: renderModeSwitchPathsChanged.length > 0,
+    renderModeSwitchPaths: Object.freeze(renderModeSwitchPathsChanged),
     hostUpdaterDiagnostics: hostUpdaterDiagnosticPathsChanged.length > 0,
     hostUpdaterDiagnosticPaths: Object.freeze(hostUpdaterDiagnosticPathsChanged),
   });
@@ -76,12 +89,21 @@ function runCli() {
   const paths = readFileSync(0, "utf8").split(/\r?\n/);
   const risk = classifyPrRisk(paths);
   process.stdout.write(`retained_execution=${risk.retainedExecution}\n`);
+  process.stdout.write(`render_mode_switch=${risk.renderModeSwitch}\n`);
   process.stdout.write(`host_updater_diagnostics=${risk.hostUpdaterDiagnostics}\n`);
 
-  const detail = risk.retainedExecution
+  const retainedDetail = risk.retainedExecution
     ? risk.retainedExecutionPaths.join(", ")
     : "none";
-  process.stderr.write(`retained execution risk paths: ${detail}\n`);
+  const modeSwitchDetail = risk.renderModeSwitch
+    ? risk.renderModeSwitchPaths.join(", ")
+    : "none";
+  const hostUpdaterDetail = risk.hostUpdaterDiagnostics
+    ? risk.hostUpdaterDiagnosticPaths.join(", ")
+    : "none";
+  process.stderr.write(`retained execution risk paths: ${retainedDetail}\n`);
+  process.stderr.write(`render mode-switch risk paths: ${modeSwitchDetail}\n`);
+  process.stderr.write(`host-updater diagnostic risk paths: ${hostUpdaterDetail}\n`);
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/scripts/pr-risk-classifier.test.mjs
+++ b/scripts/pr-risk-classifier.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   classifyPrRisk,
   requiresHostUpdaterDiagnostic,
+  requiresRenderModeSwitchSmoke,
   requiresRetainedExecutionSmoke,
 } from "./pr-risk-classifier.mjs";
 
@@ -24,13 +25,22 @@ const retainedRuntimeChanges = [
   "crates/noon-web/src/lib.rs",
 ];
 
-const ordinaryChanges = [
-  ".github/workflows/pr-fast.yml",
-  "docs/ci.md",
+const renderModeSwitchChanges = [
   "scripts/pr-risk-classifier.mjs",
+  "web/authoring-execution-client.js",
+  "web/authoring-render-worker.js",
+  "web/execution-engine-worker.js",
+  "web/execution-render-worker.js",
+  "web/execution-transport.js",
+  "web/execution-worker-client.js",
+  "web/execution-worker-smoke.html",
+  "web/retained-execution-engine-worker.js",
+];
+
+const ordinaryChanges = [
+  "docs/ci.md",
   "web/main.js",
   "web/playground-gallery.js",
-  "web/execution-engine-worker.js",
   "crates/noon-geometry/src/lib.rs",
   "crates/noon-web/src/manim_geometry_bridge.rs",
 ];
@@ -47,10 +57,23 @@ test("retained engine, shared render, and Rust ownership boundaries escalate", (
   }
 });
 
-test("ordinary CI, docs, demo, legacy engine, geometry, and Manim bridge changes stay fast", () => {
+test("render-owner, transition, and risk-policy changes escalate the mode-switch smoke", () => {
+  const risk = classifyPrRisk(renderModeSwitchChanges);
+  assert.equal(risk.renderModeSwitch, true);
+  assert.deepEqual(risk.renderModeSwitchPaths, renderModeSwitchChanges.slice().sort());
+  for (const path of renderModeSwitchChanges) {
+    assert.equal(requiresRenderModeSwitchSmoke(path), true, path);
+  }
+});
+
+test("ordinary docs, demo, geometry, and Manim bridge changes stay on the base fast path", () => {
   const risk = classifyPrRisk(ordinaryChanges);
   assert.equal(risk.retainedExecution, false);
   assert.deepEqual(risk.retainedExecutionPaths, []);
+  assert.equal(risk.renderModeSwitch, false);
+  assert.deepEqual(risk.renderModeSwitchPaths, []);
+  assert.equal(risk.hostUpdaterDiagnostics, false);
+  assert.deepEqual(risk.hostUpdaterDiagnosticPaths, []);
 });
 
 test("classifier normalizes diff-style paths and de-duplicates triggers", () => {
@@ -61,6 +84,7 @@ test("classifier normalizes diff-style paths and de-duplicates triggers", () => 
     "",
   ]);
   assert.deepEqual(risk.retainedExecutionPaths, ["web/authoring-render-worker.js"]);
+  assert.deepEqual(risk.renderModeSwitchPaths, ["web/authoring-render-worker.js"]);
 });
 
 test("host-updater changes escalate the backend diagnostic harness", () => {


### PR DESCRIPTION
Clean current-master consolidation of #888 on top of the newer #884 risk classifier. Adds a third independent browser-risk dimension for persistent retained↔legacy render-mode switching, keeps the existing retained-execution and host-updater diagnostic gates intact, and runs `scripts/authoring-render-mode-switch-smoke.mjs` only for transition/owner/policy changes that can break persistent worker mode switching.

The classifier tests cover overlap, normalization/de-duplication, and ordinary low-risk paths.

Supersedes #888.