### PR TITLE
Ratchet canonical mixed authoring identities

### DIFF
--- a/web/authoring-scene-spec-result.test.mjs
+++ b/web/authoring-scene-spec-result.test.mjs
@@ -7,55 +7,24 @@ import {
   validateSceneSpec,
 } from "./authoring-client.js";
 
-function retainedDocument() {
-  return {
-    channel: "noon.authoring.retained",
-    protocol_version: 2,
-    objects: [
-      {
-        object: 2 ** 52,
-        order: 1,
-        text: {
-          source: "Canonical Noon",
-          backend: {
-            kind: "native",
-            font_family: "DejaVu Sans Mono",
-            line_spacing: -1,
-          },
-          font_size: 48,
-          transform: {
-            translation: { x: 0, y: 0 },
-            scale: { x: 1, y: 1 },
-            rotation: 0,
-          },
-          color: { red: 1, green: 1, blue: 1, alpha: 1 },
-          opacity: 1,
-        },
-      },
-    ],
-  };
-}
-
 function canonicalSceneSpec() {
   return {
     version: 1,
     objects: [
       { id: 0, content: { kind: "geometry" } },
-      { id: 2 ** 52, content: { kind: "text" } },
+      { id: 1, content: { kind: "text" } },
     ],
     tracks: [],
   };
 }
 
-test("retained scene results expose canonical SceneSpec beside the compatibility sidecar", () => {
+test("mixed scene results require only canonical SceneSpec at the authoring protocol boundary", () => {
   const document = { version: 1, objects: [{ id: 0 }], tracks: [] };
-  const retained = retainedDocument();
   const sceneSpec = canonicalSceneSpec();
   const parsed = parseAuthoringResult(
     JSON.stringify({
       kind: "scene_document",
       document,
-      retained_document: retained,
       scene_spec: sceneSpec,
       duration: 1.5,
       identities: { objects: [{ id: 0, key: "@object:0" }], tracks: [] },
@@ -64,22 +33,17 @@ test("retained scene results expose canonical SceneSpec beside the compatibility
   );
 
   assert.deepEqual(parsed.sceneSpec, sceneSpec);
-  assert.deepEqual(parsed.retainedDocument, retained);
-  assert.deepEqual(parsed.sceneSpec.objects.map(({ id }) => id), [0, 2 ** 52]);
+  assert.equal("retainedDocument" in parsed, false);
+  assert.deepEqual(parsed.sceneSpec.objects.map(({ id }) => id), [0, 1]);
 });
 
-test("geometry-only scene results carry canonical SceneSpec beside the empty compatibility sidecar", () => {
+test("geometry-only scene results require only canonical SceneSpec", () => {
   const document = { version: 1, objects: [], tracks: [] };
   const sceneSpec = { version: 1, objects: [], tracks: [] };
   const parsed = parseAuthoringResult(
     JSON.stringify({
       kind: "scene_document",
       document,
-      retained_document: {
-        channel: "noon.authoring.retained",
-        protocol_version: 2,
-        objects: [],
-      },
       scene_spec: sceneSpec,
       duration: 0,
       identities: { objects: [], tracks: [] },
@@ -88,7 +52,7 @@ test("geometry-only scene results carry canonical SceneSpec beside the empty com
   );
 
   assert.deepEqual(parsed.sceneSpec, sceneSpec);
-  assert.equal(parsed.retainedDocument.objects.length, 0);
+  assert.equal("retainedDocument" in parsed, false);
 });
 
 test("canonical SceneSpec result validation rejects duplicate identity and invalid camera references", () => {


### PR DESCRIPTION
Clean current-master replay of #867. Updates the focused authoring-result regression to the already-supported canonical contract: unified scene-global IDs and canonical `SceneSpec` without requiring the compatibility retained sidecar at the protocol boundary. Test-only; the existing internal retained-sidecar canonicalization adapter remains explicitly covered until the broader #367 migration removes it.

Supersedes #867.