### PR TITLE
Escalate renderer-critical PRs to WebGL smoke

### DIFF
--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -249,6 +249,21 @@ jobs:
           echo "seconds=$SECONDS" >> "$GITHUB_OUTPUT"
           exit "$status"
 
+      - name: Check WebGL rendering for renderer-critical changes
+        if: steps.browser-risk.outputs.renderer_critical == 'true'
+        id: webgl-smoke
+        env:
+          NOON_BROWSER_SMOKE_BACKEND: webgl
+          NOON_BROWSER_SMOKE_ARTIFACTS: browser-smoke-artifacts/webgl
+        run: |
+          SECONDS=0
+          set +e
+          node scripts/browser-smoke.mjs
+          status=$?
+          set -e
+          echo "seconds=$SECONDS" >> "$GITHUB_OUTPUT"
+          exit "$status"
+
       - name: Check host-updater diagnostics on WebGL and WebGPU
         if: steps.browser-risk.outputs.host_updater_diagnostics == 'true'
         id: host-updater-diagnostics
@@ -273,6 +288,9 @@ jobs:
           MODE_SWITCH_REQUIRED: ${{ steps.browser-risk.outputs.render_mode_switch }}
           MODE_SWITCH_SECONDS: ${{ steps.render-mode-switch.outputs.seconds }}
           WEBGPU_SECONDS: ${{ steps.webgpu-smoke.outputs.seconds }}
+          WEBGL_SECONDS: ${{ steps.webgl-smoke.outputs.seconds }}
+          RENDERER_CRITICAL: ${{ steps.browser-risk.outputs.renderer_critical }}
+          RENDERER_CRITICAL_PATHS: ${{ steps.browser-risk.outputs.renderer_critical_paths }}
           HOST_UPDATER_SECONDS: ${{ steps.host-updater-diagnostics.outputs.seconds }}
         run: |
           total=""
@@ -298,6 +316,11 @@ jobs:
             mode_switch_duration="$(display_seconds "$MODE_SWITCH_SECONDS")"
           fi
 
+          webgl_duration="skipped"
+          if [[ "$RENDERER_CRITICAL" == "true" ]]; then
+            webgl_duration="$(display_seconds "$WEBGL_SECONDS")"
+          fi
+
           {
             echo "### Browser fast checks timing"
             echo
@@ -309,15 +332,24 @@ jobs:
             echo "| Canonical retained execution | $retained_duration |"
             echo "| Persistent render mode switching | $mode_switch_duration |"
             echo "| WebGPU smoke | $(display_seconds "$WEBGPU_SECONDS") |"
+            echo "| WebGL renderer-risk smoke | $webgl_duration |"
             echo "| Host-updater diagnostics | $(display_seconds "$HOST_UPDATER_SECONDS") |"
             echo "| Measured browser path | $(display_seconds "$total") |"
             echo
             echo "Retained execution escalation required: ${RETAINED_REQUIRED:-unknown}."
             echo "Render mode-switch escalation required: ${MODE_SWITCH_REQUIRED:-unknown}."
+            echo "Renderer-critical WebGL escalation required: ${RENDERER_CRITICAL:-unknown}."
+            if [[ "$RENDERER_CRITICAL" == "true" ]]; then
+              echo "Renderer-critical paths: ${RENDERER_CRITICAL_PATHS:-unknown}."
+            fi
             echo
             echo "The measured browser path starts before checkout and ends after the renderer smoke. Hosted-runner queue time and post-job cleanup are intentionally excluded."
           } >> "$GITHUB_STEP_SUMMARY"
 
           if [[ "$total" =~ ^[0-9]+$ ]] && (( total >= 110 )); then
-            echo "::warning title=PR Fast Gate timing::Browser fast path reached ${total}s, leaving less than 10s of margin against the 120s target."
+            if [[ "$RENDERER_CRITICAL" == "true" ]]; then
+              echo "::notice title=PR Fast Gate timing::Renderer-critical escalation extended the browser path to ${total}s; low-risk PRs retain the 120s target."
+            else
+              echo "::warning title=PR Fast Gate timing::Browser fast path reached ${total}s, leaving less than 10s of margin against the 120s target."
+            fi
           fi

--- a/scripts/pr-risk-classifier.mjs
+++ b/scripts/pr-risk-classifier.mjs
@@ -43,6 +43,24 @@ const hostUpdaterDiagnosticPaths = new Set([
   "web/manim-raster-host.js",
 ]);
 
+const rendererCriticalPrefixes = Object.freeze([
+  "crates/noon-render-wgpu/",
+  "crates/noon-text-render-wgpu/",
+  "crates/noon-web/",
+]);
+
+const rendererCriticalFiles = new Set([
+  ".github/workflows/pr-fast.yml",
+  "scripts/browser-smoke.mjs",
+  // Classifier policy changes must exercise the WebGL oracle they decide whether to run.
+  "scripts/pr-risk-classifier.mjs",
+  "web/authoring-render-worker.js",
+  "web/browser-smoke.html",
+  "web/browser-smoke.js",
+  "web/execution-render-worker.js",
+  "web/render-gpu-diagnostics.js",
+]);
+
 function normalizeRepositoryPath(path) {
   return path.trim().replaceAll("\\", "/").replace(/^\.\//, "");
 }
@@ -69,11 +87,19 @@ export function requiresHostUpdaterDiagnostic(path) {
   return hostUpdaterDiagnosticPaths.has(normalized);
 }
 
+export function requiresRendererCriticalWebglSmoke(path) {
+  const normalized = normalizeRepositoryPath(path);
+  if (normalized === "") return false;
+  if (rendererCriticalFiles.has(normalized)) return true;
+  return rendererCriticalPrefixes.some((prefix) => normalized.startsWith(prefix));
+}
+
 export function classifyPrRisk(paths) {
   const normalizedPaths = [...new Set(paths.map(normalizeRepositoryPath).filter(Boolean))];
   const retainedExecutionPaths = normalizedPaths.filter(requiresRetainedExecutionSmoke).sort();
   const renderModeSwitchPathsChanged = normalizedPaths.filter(requiresRenderModeSwitchSmoke).sort();
   const hostUpdaterDiagnosticPathsChanged = normalizedPaths.filter(requiresHostUpdaterDiagnostic).sort();
+  const rendererCriticalPaths = normalizedPaths.filter(requiresRendererCriticalWebglSmoke).sort();
 
   return Object.freeze({
     retainedExecution: retainedExecutionPaths.length > 0,
@@ -82,6 +108,8 @@ export function classifyPrRisk(paths) {
     renderModeSwitchPaths: Object.freeze(renderModeSwitchPathsChanged),
     hostUpdaterDiagnostics: hostUpdaterDiagnosticPathsChanged.length > 0,
     hostUpdaterDiagnosticPaths: Object.freeze(hostUpdaterDiagnosticPathsChanged),
+    rendererCritical: rendererCriticalPaths.length > 0,
+    rendererCriticalPaths: Object.freeze(rendererCriticalPaths),
   });
 }
 
@@ -91,6 +119,8 @@ function runCli() {
   process.stdout.write(`retained_execution=${risk.retainedExecution}\n`);
   process.stdout.write(`render_mode_switch=${risk.renderModeSwitch}\n`);
   process.stdout.write(`host_updater_diagnostics=${risk.hostUpdaterDiagnostics}\n`);
+  process.stdout.write(`renderer_critical=${risk.rendererCritical}\n`);
+  process.stdout.write(`renderer_critical_paths=${risk.rendererCriticalPaths.join(",")}\n`);
 
   const retainedDetail = risk.retainedExecution
     ? risk.retainedExecutionPaths.join(", ")
@@ -101,9 +131,13 @@ function runCli() {
   const hostUpdaterDetail = risk.hostUpdaterDiagnostics
     ? risk.hostUpdaterDiagnosticPaths.join(", ")
     : "none";
+  const rendererDetail = risk.rendererCritical
+    ? risk.rendererCriticalPaths.join(", ")
+    : "none";
   process.stderr.write(`retained execution risk paths: ${retainedDetail}\n`);
   process.stderr.write(`render mode-switch risk paths: ${modeSwitchDetail}\n`);
   process.stderr.write(`host-updater diagnostic risk paths: ${hostUpdaterDetail}\n`);
+  process.stderr.write(`renderer-critical WebGL risk paths: ${rendererDetail}\n`);
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/scripts/pr-risk-classifier.test.mjs
+++ b/scripts/pr-risk-classifier.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   classifyPrRisk,
   requiresHostUpdaterDiagnostic,
+  requiresRendererCriticalWebglSmoke,
   requiresRenderModeSwitchSmoke,
   requiresRetainedExecutionSmoke,
 } from "./pr-risk-classifier.mjs";
@@ -37,12 +38,26 @@ const renderModeSwitchChanges = [
   "web/retained-execution-engine-worker.js",
 ];
 
+const rendererCriticalChanges = [
+  ".github/workflows/pr-fast.yml",
+  "scripts/browser-smoke.mjs",
+  "scripts/pr-risk-classifier.mjs",
+  "web/authoring-render-worker.js",
+  "web/browser-smoke.html",
+  "web/browser-smoke.js",
+  "web/execution-render-worker.js",
+  "web/render-gpu-diagnostics.js",
+  "crates/noon-render-wgpu/src/lib.rs",
+  "crates/noon-text-render-wgpu/src/glyph.rs",
+  "crates/noon-web/src/lib.rs",
+];
+
 const ordinaryChanges = [
   "docs/ci.md",
   "web/main.js",
   "web/playground-gallery.js",
+  "crates/noon-core/src/lib.rs",
   "crates/noon-geometry/src/lib.rs",
-  "crates/noon-web/src/manim_geometry_bridge.rs",
 ];
 
 test("canonical retained routing changes escalate the retained worker smoke", () => {
@@ -66,7 +81,17 @@ test("render-owner, transition, and risk-policy changes escalate the mode-switch
   }
 });
 
-test("ordinary docs, demo, geometry, and Manim bridge changes stay on the base fast path", () => {
+test("renderer crates, browser render owners, smoke plumbing, and policy escalate WebGL", () => {
+  const risk = classifyPrRisk(rendererCriticalChanges);
+  assert.equal(risk.rendererCritical, true);
+  assert.deepEqual(risk.rendererCriticalPaths, rendererCriticalChanges.slice().sort());
+  for (const path of rendererCriticalChanges) {
+    assert.equal(requiresRendererCriticalWebglSmoke(path), true, path);
+  }
+  assert.equal(requiresRendererCriticalWebglSmoke("README.md"), false);
+});
+
+test("ordinary docs, demo, core, and geometry changes stay on the base fast path", () => {
   const risk = classifyPrRisk(ordinaryChanges);
   assert.equal(risk.retainedExecution, false);
   assert.deepEqual(risk.retainedExecutionPaths, []);
@@ -74,6 +99,8 @@ test("ordinary docs, demo, geometry, and Manim bridge changes stay on the base f
   assert.deepEqual(risk.renderModeSwitchPaths, []);
   assert.equal(risk.hostUpdaterDiagnostics, false);
   assert.deepEqual(risk.hostUpdaterDiagnosticPaths, []);
+  assert.equal(risk.rendererCritical, false);
+  assert.deepEqual(risk.rendererCriticalPaths, []);
 });
 
 test("classifier normalizes diff-style paths and de-duplicates triggers", () => {
@@ -85,6 +112,7 @@ test("classifier normalizes diff-style paths and de-duplicates triggers", () => 
   ]);
   assert.deepEqual(risk.retainedExecutionPaths, ["web/authoring-render-worker.js"]);
   assert.deepEqual(risk.renderModeSwitchPaths, ["web/authoring-render-worker.js"]);
+  assert.deepEqual(risk.rendererCriticalPaths, ["web/authoring-render-worker.js"]);
 });
 
 test("host-updater changes escalate the backend diagnostic harness", () => {


### PR DESCRIPTION
Clean current-master consolidation of #807 on top of the unified risk classifier from #915. Adds `rendererCritical` as a fourth independent browser-risk dimension covering renderer crates, browser render owners, smoke plumbing, and classifier/workflow policy. Renderer-critical PRs run the existing browser smoke on WebGL in addition to the always-on WebGPU path, while ordinary docs/demo/core/geometry changes remain on the base fast path.

This deliberately reuses `scripts/pr-risk-classifier.mjs` and its tests instead of restoring the obsolete parallel `classify-pr-risk.mjs` implementation.

Supersedes #807.