### PR TITLE
Author concurrent retained family animations in one Scene.play

### DIFF
--- a/scripts/manim-compat-smoke.mjs
+++ b/scripts/manim-compat-smoke.mjs
@@ -300,6 +300,25 @@ class SharedRateFunctions(Scene):
         self.play(circle.animate.shift(LEFT), run_time=0.2, rate_func=there_and_back)
 `;
 
+const concurrentFamilySource = `
+from noon import *
+
+class ConcurrentRetainedFamilies(Scene):
+    def construct(self):
+        short = Text("AB")
+        long = Text("ABCDEFGHIJKLMNOPQRST")
+        self.play(Write(short), Write(long), rate_func=linear)
+`;
+
+const overlappingFamilySource = `
+from noon import *
+
+class OverlappingRetainedFamilies(Scene):
+    def construct(self):
+        text = Text("AB")
+        self.play(Write(text), Unwrite(text), rate_func=linear)
+`;
+
 let browser = null;
 try {
   await waitForServer();
@@ -466,6 +485,108 @@ try {
     "known Python callables should lower directly to shared Rust semantic IDs",
   );
 
+  const concurrent = await page.evaluate(
+    (pythonSource) => window.noonManimCompat.run(pythonSource),
+    concurrentFamilySource,
+  );
+  assert.equal(concurrent.kind, "scene_document");
+  assert.equal(concurrent.retainedDocument.objects.length, 2);
+  assert.equal(concurrent.retainedDocument.family_animations.length, 2);
+  assert.equal(concurrent.sceneSpec.family_animations.length, 2);
+  assert.equal(concurrent.duration, 2, "Scene.play duration must be the maximum child duration");
+  const concurrentRequests = concurrent.sceneSpec.family_animations;
+  assert.deepEqual(
+    concurrentRequests.map((request) => request.spec.start_time),
+    [0, 0],
+    "concurrent family requests must share the play start time",
+  );
+  assert.deepEqual(
+    concurrentRequests.map((request) => request.spec.duration),
+    [1, 2],
+    "each Write must retain its independently Rust-derived default duration",
+  );
+  assert.ok(
+    concurrentRequests.every((request) => request.spec.mode === "draw_border_then_fill"),
+  );
+  const concurrentSerialized = JSON.stringify(concurrentRequests);
+  for (const forbidden of ["glyph_id", "atlas_id", "font_bytes"]) {
+    assert.equal(concurrentSerialized.includes(forbidden), false, `concurrent requests leaked ${forbidden}`);
+  }
+
+  const concurrentRender = await page.evaluate(async (sceneSpec) => {
+    const { ExecutionWorkerClient } = await import("./execution-worker-client.js");
+    const canvas = document.createElement("canvas");
+    canvas.width = 640;
+    canvas.height = 360;
+    document.body.appendChild(canvas);
+    const errors = [];
+    const execution = new ExecutionWorkerClient(canvas, {
+      onError(error, owner) {
+        errors.push(`${owner}: ${error}`);
+      },
+    });
+    async function renderedAt(time) {
+      await execution.seek(time);
+      let latest = null;
+      for (let attempt = 0; attempt < 100; attempt += 1) {
+        latest = await execution.metrics();
+        if (errors.length !== 0) throw new Error(errors.join("; "));
+        if (
+          Math.abs(Number(latest.metrics.time) - time) <= 1e-6 &&
+          latest.metrics.objectCount === 2 &&
+          latest.metrics.presentedFrames >= 1
+        ) {
+          return latest;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      }
+      throw new Error(`concurrent family render did not converge at t=${time}: ${JSON.stringify(latest)}`);
+    }
+    try {
+      await execution.startRetainedCanonical(JSON.stringify(sceneSpec), {
+        loopDurationSeconds: 2,
+        transportMode: "transferable",
+      });
+      await execution.pause();
+      const first = await renderedAt(0.5);
+      const presented = first.metrics.presentedFrames;
+      const second = await renderedAt(1.5);
+      if (!first.engineMetrics.canonical || !second.engineMetrics.canonical) {
+        throw new Error("concurrent family render bypassed canonical retained execution");
+      }
+      if (second.metrics.presentedFrames <= presented) {
+        throw new Error("second concurrent-family seek did not present a new frame");
+      }
+      return {
+        firstTime: first.metrics.time,
+        secondTime: second.metrics.time,
+        objectCount: second.metrics.objectCount,
+        presentedFrames: second.metrics.presentedFrames,
+      };
+    } finally {
+      execution.terminate();
+      canvas.remove();
+    }
+  }, concurrent.sceneSpec);
+  assert.equal(concurrentRender.firstTime, 0.5);
+  assert.equal(concurrentRender.secondTime, 1.5);
+  assert.equal(concurrentRender.objectCount, 2);
+
+  let overlapError = null;
+  try {
+    await page.evaluate(
+      (pythonSource) => window.noonManimCompat.run(pythonSource),
+      overlappingFamilySource,
+    );
+  } catch (error) {
+    overlapError = String(error);
+  }
+  assert.match(
+    overlapError ?? "",
+    /disjoint family leaves/,
+    "same-leaf concurrent family ownership must fail before lifecycle mutation",
+  );
+
   let zError = null;
   try {
     await page.evaluate(
@@ -479,7 +600,7 @@ try {
 
   assert.deepEqual(errors, [], `browser errors while testing Manim compatibility:\n${errors.join("\n")}`);
   console.log(
-    "Manim compatibility smoke passed: construct discovery, shape classes, scene/group semantics, callable and chained animate builders, detached animate auto-add, per-animation timing, play overrides, independent fill/stroke opacity, shared detached query/dimension transforms, z=0 vectors, and shared deterministic Manim rate-function lowering.",
+    "Manim compatibility smoke passed: construct discovery, shape classes, scene/group semantics, callable and chained animate builders, detached animate auto-add, per-animation timing, play overrides, concurrent retained-family play, independent fill/stroke opacity, shared detached query/dimension transforms, z=0 vectors, and shared deterministic Manim rate-function lowering.",
   );
 } finally {
   await browser?.close();

--- a/web/family-animation-authoring.test.mjs
+++ b/web/family-animation-authoring.test.mjs
@@ -42,6 +42,20 @@ test("Python appends family requests without owning the scene-wide scheduler lim
   );
 });
 
+test("one Scene.play can author concurrent disjoint retained families", () => {
+  assert.doesNotMatch(
+    pythonSource,
+    /must currently be the only animation in Scene\.play/,
+  );
+  assert.match(
+    pythonSource,
+    /cannot currently be mixed with[\s\S]*ordinary animations/,
+  );
+  assert.match(pythonSource, /must target disjoint family leaves/);
+  assert.match(pythonSource, /base_start \+ actual_run_time/);
+  assert.match(pythonSource, /play_end = max\(/);
+});
+
 test("Python does not serialize semantic family order or retained resource identity", () => {
   for (const forbidden of [
     "memberSlot(",

--- a/web/python/_manim_family_creation.py
+++ b/web/python/_manim_family_creation.py
@@ -142,7 +142,11 @@ def _family_candidate(animation: object):
         synthetic = True
 
     family_handle = getattr(family, "_semantic_family_handle", None)
-    method = "familyWriteAnimationRequest" if _is_write_animation(animation) else "familyAnimationRequest"
+    method = (
+        "familyWriteAnimationRequest"
+        if _is_write_animation(animation)
+        else "familyAnimationRequest"
+    )
     if family_handle is None or not hasattr(family_handle, method):
         raise RuntimeError(f"family {label} requires the shared Rust authoring family handle")
     return target, family, leaves, synthetic
@@ -414,9 +418,13 @@ def _write_request_inputs(
     elif play_rate_func is not None:
         rate_id = _compat._easing_from_rate_func(play_rate_func)
     else:
-        rate_id = _compat._easing_from_rate_func(args.get("rate_func", _rate_functions.linear))
+        rate_id = _compat._easing_from_rate_func(
+            args.get("rate_func", _rate_functions.linear)
+        )
 
-    reverse_rate = bool(args.get("reverse_rate_function", animation.reverse_rate_function))
+    reverse_rate = bool(
+        args.get("reverse_rate_function", animation.reverse_rate_function)
+    )
     reverse_members = bool(animation.reverse)
     return run_time_override, lag_override, str(rate_id), reverse_rate, reverse_members
 
@@ -470,7 +478,8 @@ def _family_scene_play(
     **kwargs: Any,
 ) -> _compat.Scene:
     candidates = [_family_candidate(animation) for animation in animations]
-    if not any(candidate is not None for candidate in candidates):
+    family_count = sum(candidate is not None for candidate in candidates)
+    if family_count == 0:
         assert _ORIGINAL_SCENE_PLAY is not None
         return _ORIGINAL_SCENE_PLAY(
             self,
@@ -483,9 +492,10 @@ def _family_scene_play(
             lag_ratio=lag_ratio,
             **kwargs,
         )
-    if len(animations) != 1 or candidates[0] is None:
+    if family_count != len(animations):
         raise NotImplementedError(
-            "canonical retained family creation animation must currently be the only animation in Scene.play"
+            "canonical retained family animations cannot currently be mixed with "
+            "ordinary animations in the same Scene.play"
         )
     if duration is not None and run_time is not None:
         raise ValueError("use either duration or run_time, not both")
@@ -495,8 +505,19 @@ def _family_scene_play(
         unsupported = ", ".join(sorted(kwargs))
         raise NotImplementedError(f"unsupported Manim Scene.play option(s): {unsupported}")
 
-    animation = animations[0]
-    target, family, leaves, _synthetic = candidates[0]
+    family_candidates = [candidate for candidate in candidates if candidate is not None]
+    leaf_owners: dict[int, int] = {}
+    for animation_index, candidate in enumerate(family_candidates):
+        _target, _family, leaves, _synthetic = candidate
+        for member in leaves:
+            previous = leaf_owners.get(id(member))
+            if previous is not None:
+                raise ValueError(
+                    "concurrent retained family animations must target disjoint family leaves; "
+                    f"animations {previous} and {animation_index} share one target"
+                )
+            leaf_owners[id(member)] = animation_index
+
     play_run_time = run_time if run_time is not None else duration
     if play_run_time is not None:
         play_run_time = float(play_run_time)
@@ -511,91 +532,112 @@ def _family_scene_play(
     retained_objects_before = list(getattr(self, "_retained_text_objects", []))
     next_object_id_before = getattr(self, "_retained_next_object_id", None)
     next_order_before = getattr(self, "_retained_next_painter_order", None)
-    retained_tracks_before = copy.deepcopy(getattr(self, "_retained_animation_tracks", []))
-    retained_state_before = copy.deepcopy(getattr(self, "_retained_animation_state", {}))
-    family_requests_before = copy.deepcopy(getattr(self, "_retained_family_animations", []))
+    retained_tracks_before = copy.deepcopy(
+        getattr(self, "_retained_animation_tracks", [])
+    )
+    retained_state_before = copy.deepcopy(
+        getattr(self, "_retained_animation_state", {})
+    )
+    family_requests_before = copy.deepcopy(
+        getattr(self, "_retained_family_animations", [])
+    )
 
     geometry_states: dict[int, tuple[_base.Mobject, object, object]] = {}
-    retained_states: dict[int, tuple[_typst._RetainedTextMobject, object, object, object]] = {}
-    for member in leaves:
-        if _native_text(member):
-            retained_states[id(member)] = (
-                member,
-                member._scene,
-                member._retained_object_id,
-                member._retained_order,
-            )
-        else:
-            _animate._record_wrapper_state(member, geometry_states)
+    retained_states: dict[
+        int, tuple[_typst._RetainedTextMobject, object, object, object]
+    ] = {}
+    for candidate in family_candidates:
+        _target, _family, leaves, _synthetic = candidate
+        for member in leaves:
+            if _native_text(member):
+                retained_states[id(member)] = (
+                    member,
+                    member._scene,
+                    member._retained_object_id,
+                    member._retained_order,
+                )
+            else:
+                _animate._record_wrapper_state(member, geometry_states)
 
     try:
-        lifecycle_plans = _begin_family_lifecycle(
-            self,
-            animation,
-            target,
-            leaves,
-            start_time=base_start,
-        )
-
-        if _is_write_animation(animation):
-            assert isinstance(animation, Write)
-            (
-                duration_override,
-                lag_override,
-                rate_id,
-                reverse_rate,
-                reverse_members,
-            ) = _write_request_inputs(
-                animation,
-                play_run_time=play_run_time,
-                play_easing=easing,
-                play_rate_func=rate_func,
-                play_lag_ratio=play_lag_ratio,
-            )
-            actual_run_time, _actual_lag = _append_write_request(
+        completed: list[tuple[object, object, list[tuple[_base.Mobject, object]], float]] = []
+        for animation, candidate in zip(animations, family_candidates, strict=True):
+            target, family, leaves, _synthetic = candidate
+            lifecycle_plans = _begin_family_lifecycle(
                 self,
                 animation,
-                family,
+                target,
                 leaves,
                 start_time=base_start,
-                duration_override=duration_override,
-                lag_ratio_override=lag_override,
-                rate_function=rate_id,
-                reverse_rate_function=reverse_rate,
-                reverse_member_order=reverse_members,
-            )
-        else:
-            resolved = _options.resolve(
-                builder_args=_options.builder_args(animation),
-                default_lag_ratio=1.0,
-                play_run_time=play_run_time,
-                play_easing=easing,
-                play_rate_func=rate_func,
-                play_lag_ratio=play_lag_ratio,
-            )
-            if not math.isclose(resolved.path_arc, 0.0, abs_tol=1e-15):
-                raise NotImplementedError("family Create/Uncreate does not support path_arc")
-            actual_run_time = resolved.run_time
-            _append_reveal_request(
-                self,
-                animation,
-                family,
-                leaves,
-                start_time=base_start,
-                duration=resolved.run_time,
-                lag_ratio=resolved.lag_ratio,
-                rate_function=resolved.rate_func,
             )
 
-        end_time = base_start + actual_run_time
-        _finish_family_lifecycle(
-            self,
-            animation,
-            target,
-            lifecycle_plans,
-            end_time=end_time,
-        )
-        self._cursor = max(cursor_before, end_time)
+            if _is_write_animation(animation):
+                assert isinstance(animation, Write)
+                (
+                    duration_override,
+                    lag_override,
+                    rate_id,
+                    reverse_rate,
+                    reverse_members,
+                ) = _write_request_inputs(
+                    animation,
+                    play_run_time=play_run_time,
+                    play_easing=easing,
+                    play_rate_func=rate_func,
+                    play_lag_ratio=play_lag_ratio,
+                )
+                actual_run_time, _actual_lag = _append_write_request(
+                    self,
+                    animation,
+                    family,
+                    leaves,
+                    start_time=base_start,
+                    duration_override=duration_override,
+                    lag_ratio_override=lag_override,
+                    rate_function=rate_id,
+                    reverse_rate_function=reverse_rate,
+                    reverse_member_order=reverse_members,
+                )
+            else:
+                resolved = _options.resolve(
+                    builder_args=_options.builder_args(animation),
+                    default_lag_ratio=1.0,
+                    play_run_time=play_run_time,
+                    play_easing=easing,
+                    play_rate_func=rate_func,
+                    play_lag_ratio=play_lag_ratio,
+                )
+                if not math.isclose(resolved.path_arc, 0.0, abs_tol=1e-15):
+                    raise NotImplementedError(
+                        "family Create/Uncreate does not support path_arc"
+                    )
+                actual_run_time = resolved.run_time
+                _append_reveal_request(
+                    self,
+                    animation,
+                    family,
+                    leaves,
+                    start_time=base_start,
+                    duration=resolved.run_time,
+                    lag_ratio=resolved.lag_ratio,
+                    rate_function=resolved.rate_func,
+                )
+
+            completed.append(
+                (animation, target, lifecycle_plans, base_start + actual_run_time)
+            )
+
+        for animation, target, lifecycle_plans, end_time in completed:
+            _finish_family_lifecycle(
+                self,
+                animation,
+                target,
+                lifecycle_plans,
+                end_time=end_time,
+            )
+
+        play_end = max(end_time for _animation, _target, _plans, end_time in completed)
+        self._cursor = max(cursor_before, play_end)
         return self
     except Exception:
         self._restore_authoring_checkpoint(checkpoint)

--- a/web/stress-runtime-contract.test.mjs
+++ b/web/stress-runtime-contract.test.mjs
@@ -58,10 +58,20 @@ assert.match(
   /mixing retained Text animations with legacy animations in one Scene\.play /,
   "contract should track the retained-vs-geometry mixed-play capability boundary",
 );
+assert.doesNotMatch(
+  familyCreation,
+  /must currently be the only animation in Scene\.play/,
+  "disjoint retained family animations should no longer be artificially single-animation-only",
+);
 assert.match(
   familyCreation,
-  /canonical retained family creation animation must currently be the only animation in Scene\.play/,
-  "contract should track the retained family mixed-play capability boundary",
+  /cannot currently be mixed with[\s\S]*ordinary animations in the same Scene\.play/,
+  "contract should retain the family-vs-ordinary mixed-play capability boundary",
+);
+assert.match(
+  familyCreation,
+  /concurrent retained family animations must target disjoint family leaves/,
+  "contract should reject ambiguous same-leaf concurrent family ownership",
 );
 assert.match(browserSmoke, /manim_parity_stress_grid\.py/);
 assert.match(browserSmoke, /stressResult\.duration\) - 5\.0/);


### PR DESCRIPTION
## Summary
- allow multiple retained family animations in one `Scene.play(...)` when every animation is a retained-family candidate and their flattened leaves are disjoint
- keep all requests on one shared play start time while preserving each animation's independently resolved duration/lag/rate semantics
- advance the scene cursor by ManimCE's `max(animation.run_time)` rule rather than forcing equal durations
- keep the whole multi-animation authoring step transactional: a later failure restores the earlier lifecycle/request mutations
- reject mixed retained-family + ordinary animations in the same `play` for now instead of pretending the general composition surface is qualified
- reject same-leaf concurrent ownership before lifecycle mutation, matching the plural Rust runtime's overlap invariant

## ManimCE v0.21 timing
`Scene.compile_animations` applies `play(...)` kwargs to each animation individually, and `Scene.get_run_time` returns the maximum animation run time. The adapter follows that rule: a play-level `run_time=` overrides every child, while otherwise each `Write` keeps its Rust-derived family-length default.

## Acceptance
The Manim browser smoke authors two disjoint native `Text` writes in one call:

```python
self.play(Write(Text("AB")), Write(Text("ABCDEFGHIJKLMNOPQRST")), rate_func=linear)
```

It verifies:
- two canonical family requests, both starting at `t=0`
- independent Rust-derived durations `[1, 2]`
- scene duration `2`
- no glyph/font/atlas identity leakage
- one canonical retained execution worker renders both active plans at `t=0.5` and the surviving long plan at `t=1.5`
- `Write(text), Unwrite(text)` in the same play fails explicitly because the plans share a leaf

## Validation
Exact head `35f0a3ca41c00179f5724a42f176ab4c790f14fb` passed PR Fast Gate #513 (`33650274540`):
- Rust formatting + Clippy
- Rust unit tests
- web static/unit checks, including the updated capability-boundary ratchet
- browser WASM build
- deterministic playback
- Manim/Pyodide authoring with real concurrent retained-family rendering
- primary WebGPU rendering

The base advanced afterward only in playground/replay workflow and editor files; `cdfa7a45... -> 4e75b1cb...` has no overlap with this PR's four changed files or retained-family/runtime paths.

Tracks #741 / #705.