### PR TITLE
Fix playground editor startup and stress-scene reruns

### DIFF
--- a/.github/workflows/playground-authoring-recovery.yml
+++ b/.github/workflows/playground-authoring-recovery.yml
@@ -10,6 +10,16 @@ on:
       - "crates/noon-web/**"
       - "scripts/build-web-demo.sh"
       - "scripts/playground-authoring-error-recovery-smoke.mjs"
+      - "scripts/playground-stress-edit-smoke.mjs"
+      - "web/**"
+  pull_request:
+    paths:
+      - ".github/workflows/playground-authoring-recovery.yml"
+      - "crates/noon-render-wgpu/**"
+      - "crates/noon-web/**"
+      - "scripts/build-web-demo.sh"
+      - "scripts/playground-authoring-error-recovery-smoke.mjs"
+      - "scripts/playground-stress-edit-smoke.mjs"
       - "web/**"
   workflow_dispatch:
 
@@ -72,11 +82,17 @@ jobs:
         env:
           NOON_PLAYGROUND_AUTHORING_RECOVERY_ARTIFACTS: browser-smoke-artifacts/playground-authoring-recovery
         run: node scripts/playground-authoring-error-recovery-smoke.mjs
+      - name: Test stress edit and rerun
+        env:
+          NOON_PLAYGROUND_STRESS_EDIT_ARTIFACTS: browser-smoke-artifacts/playground-stress-edit
+        run: node scripts/playground-stress-edit-smoke.mjs
       - name: Upload authoring recovery diagnostics
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: playground-authoring-recovery
-          path: browser-smoke-artifacts/playground-authoring-recovery
+          path: |
+            browser-smoke-artifacts/playground-authoring-recovery
+            browser-smoke-artifacts/playground-stress-edit
           if-no-files-found: error
           retention-days: 7

--- a/scripts/playground-stress-edit-smoke.mjs
+++ b/scripts/playground-stress-edit-smoke.mjs
@@ -1,0 +1,214 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import playwright from "playwright";
+
+const { chromium } = playwright;
+const port = Number(process.env.NOON_PLAYGROUND_STRESS_EDIT_PORT ?? "4191");
+const baseUrl = `http://127.0.0.1:${port}`;
+const artifactDir = path.resolve(
+  process.env.NOON_PLAYGROUND_STRESS_EDIT_ARTIFACTS ??
+    "browser-smoke-artifacts/playground-stress-edit",
+);
+
+await mkdir(artifactDir, { recursive: true });
+
+let serverOutput = "";
+const server = spawn(
+  "python3",
+  ["-m", "http.server", String(port), "--bind", "127.0.0.1", "--directory", "."],
+  { stdio: ["ignore", "pipe", "pipe"] },
+);
+server.stdout.on("data", (chunk) => (serverOutput += chunk));
+server.stderr.on("data", (chunk) => (serverOutput += chunk));
+
+async function waitForServer() {
+  let lastError = null;
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    try {
+      const response = await fetch(`${baseUrl}/web/index.html`);
+      if (response.ok) return;
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Playground server did not start: ${lastError}\n${serverOutput}`);
+}
+
+async function snapshot(page) {
+  return page.evaluate(() => {
+    const status = document.querySelector("#status");
+    const patch = document.querySelector("#patch-status");
+    const pane = document.querySelector(".editor-pane");
+    const scroller = document.querySelector("#scene-editor-panel .cm-scroller");
+    return {
+      runtimeState: status?.dataset.state ?? "",
+      rendererBackend: status?.dataset.rendererBackend ?? "",
+      executionMode: status?.dataset.executionMode ?? "",
+      patchState: patch?.dataset.state ?? "",
+      patchText: patch?.value ?? patch?.textContent ?? "",
+      exampleId: patch?.dataset.exampleId ?? "",
+      objectCount: document.querySelector("#metric-objects")?.value ?? "",
+      editorHeight: pane?.getBoundingClientRect().height ?? 0,
+      bodyHeight: document.body.scrollHeight,
+      editorScrollHeight: scroller?.scrollHeight ?? 0,
+      editorClientHeight: scroller?.clientHeight ?? 0,
+      enhanced: document.querySelector("#scene-editor-panel .python-code-editor[data-editor-ready='true']") !== null,
+      textareaHidden: document.querySelector("#python-scene-source")?.hidden ?? false,
+    };
+  });
+}
+
+async function runAndWait(page) {
+  const button = page.locator("#replace-scene");
+  assert.equal(await button.isEnabled(), true, "Run must be enabled before stress-scene execution");
+  await button.click();
+  await page.waitForFunction(
+    () => {
+      const patch = document.querySelector("#patch-status");
+      const run = document.querySelector("#replace-scene");
+      return (patch?.dataset.state === "applied" || patch?.dataset.state === "error") && !run?.disabled;
+    },
+    null,
+    { timeout: 120_000 },
+  );
+  const state = await snapshot(page);
+  assert.equal(state.patchState, "applied", `stress scene must run successfully: ${state.patchText}`);
+  return state;
+}
+
+const diagnostics = {
+  browser: null,
+  viewport: { width: 1280, height: 820 },
+  pageErrors: [],
+  consoleErrors: [],
+  snapshots: {},
+  serverOutput: "",
+};
+
+let browser = null;
+let context = null;
+let page = null;
+try {
+  await waitForServer();
+  browser = await chromium.launch({
+    channel: "chromium",
+    headless: true,
+    args: [
+      "--disable-features=WebGPU",
+      "--enable-unsafe-swiftshader",
+      "--ignore-gpu-blocklist",
+      "--use-gl=angle",
+      "--use-angle=swiftshader",
+      "--disable-gpu-sandbox",
+      "--disable-dev-shm-usage",
+    ],
+  });
+  context = await browser.newContext({ viewport: diagnostics.viewport, deviceScaleFactor: 1 });
+  page = await context.newPage();
+  page.on("pageerror", (error) => diagnostics.pageErrors.push(String(error)));
+  page.on("console", (message) => {
+    if (message.type() === "error") diagnostics.consoleErrors.push(message.text());
+  });
+  diagnostics.browser = await browser.version();
+
+  await page.goto(`${baseUrl}/web/index.html?example=manim-parity-stress-grid`, {
+    waitUntil: "load",
+  });
+  await page.waitForFunction(
+    () => window.__noonExampleGallery?.selectedExampleId === "manim-parity-stress-grid",
+    null,
+    { timeout: 30_000 },
+  );
+
+  // Highlighting must arrive without requiring the user to focus/click the source first.
+  await page.waitForSelector(
+    "#scene-editor-panel .python-code-editor[data-editor-ready='true'] .cm-content",
+    { timeout: 30_000 },
+  );
+  diagnostics.snapshots.loaded = await snapshot(page);
+  assert.equal(diagnostics.snapshots.loaded.enhanced, true);
+  assert.equal(diagnostics.snapshots.loaded.textareaHidden, true);
+  assert.ok(
+    diagnostics.snapshots.loaded.editorHeight >= 500 && diagnostics.snapshots.loaded.editorHeight <= 650,
+    `desktop editor pane must stay viewport-bounded, got ${diagnostics.snapshots.loaded.editorHeight}px`,
+  );
+  assert.ok(
+    diagnostics.snapshots.loaded.editorScrollHeight > diagnostics.snapshots.loaded.editorClientHeight,
+    "long Python source must scroll inside the editor rather than expanding the workspace",
+  );
+
+  const editor = page.locator("#scene-editor-panel .cm-content");
+  await editor.click();
+  const focused = await snapshot(page);
+  assert.ok(
+    Math.abs(focused.editorHeight - diagnostics.snapshots.loaded.editorHeight) <= 2,
+    `focusing CodeMirror must not expand the editor pane (${diagnostics.snapshots.loaded.editorHeight} -> ${focused.editorHeight})`,
+  );
+
+  diagnostics.snapshots.baseline = await runAndWait(page);
+  assert.equal(diagnostics.snapshots.baseline.exampleId, "manim-parity-stress-grid");
+  assert.equal(diagnostics.snapshots.baseline.executionMode, "retained");
+
+  const source = await page.evaluate(
+    () => document.querySelector("#python-scene-source")?.value ?? "",
+  );
+  assert.match(source, /NOON DYNAMIC LOAD/);
+  const editedSource = source.replace("NOON DYNAMIC LOAD", "NOON EDITED LOAD");
+  assert.notEqual(editedSource, source);
+
+  // Use the real CodeMirror input path so the hidden textarea/draft bridge is exercised.
+  await editor.click();
+  await page.keyboard.press("Control+A");
+  await page.keyboard.insertText(editedSource);
+  await page.waitForFunction(
+    (expected) => document.querySelector("#python-scene-source")?.value === expected,
+    editedSource,
+    { timeout: 15_000 },
+  );
+  diagnostics.snapshots.edited = await snapshot(page);
+  assert.ok(
+    Math.abs(diagnostics.snapshots.edited.editorHeight - diagnostics.snapshots.loaded.editorHeight) <= 2,
+    "editing the long source must not grow the editor pane",
+  );
+
+  diagnostics.snapshots.rerun = await runAndWait(page);
+  assert.equal(diagnostics.snapshots.rerun.executionMode, "retained");
+  assert.match(diagnostics.snapshots.rerun.patchText, /Scene rebuilt atomically/);
+
+  assert.deepEqual(diagnostics.pageErrors, [], `unhandled page errors: ${diagnostics.pageErrors.join("\n")}`);
+  assert.deepEqual(
+    diagnostics.consoleErrors,
+    [],
+    `valid stress edit/rerun emitted console errors: ${diagnostics.consoleErrors.join("\n")}`,
+  );
+
+  diagnostics.serverOutput = serverOutput;
+  await page.screenshot({ path: path.join(artifactDir, "stress-edited.png"), fullPage: true });
+  await writeFile(path.join(artifactDir, "diagnostics.json"), `${JSON.stringify(diagnostics, null, 2)}\n`);
+  console.log(
+    `playground stress edit ok: ${diagnostics.snapshots.loaded.editorHeight}px editor, ` +
+      `${diagnostics.snapshots.rerun.objectCount} objects after retained rerun`,
+  );
+} catch (error) {
+  diagnostics.failure = error instanceof Error ? error.stack ?? error.message : String(error);
+  diagnostics.serverOutput = serverOutput;
+  if (page !== null) {
+    try {
+      diagnostics.snapshots.failure = await snapshot(page);
+      await page.screenshot({ path: path.join(artifactDir, "failure.png"), fullPage: true });
+    } catch (screenshotError) {
+      diagnostics.screenshotFailure = String(screenshotError);
+    }
+  }
+  await writeFile(path.join(artifactDir, "diagnostics.json"), `${JSON.stringify(diagnostics, null, 2)}\n`);
+  throw error;
+} finally {
+  await context?.close().catch(() => {});
+  await browser?.close().catch(() => {});
+  server.kill("SIGTERM");
+}

--- a/web/editor-runtime-boundary.test.mjs
+++ b/web/editor-runtime-boundary.test.mjs
@@ -6,26 +6,39 @@ const authoringClient = await readFile(
   "utf8",
 );
 const playgroundEntry = await readFile(new URL("./main.js", import.meta.url), "utf8");
+const editorBootstrap = await readFile(
+  new URL("./python-editor-bootstrap.js", import.meta.url),
+  "utf8",
+);
+const playgroundHtml = await readFile(new URL("./index.html", import.meta.url), "utf8");
 
 assert.doesNotMatch(
   authoringClient,
   /python-editor\.js/,
   "runtime authoring client must not depend on presentation/editor enhancement",
 );
-assert.doesNotMatch(
-  playgroundEntry,
-  /^void import\(["']\.\/python-editor\.js["']\)/m,
-  "playground startup must not eagerly load editor enhancement",
+assert.match(
+  editorBootstrap,
+  /void import\(["']\.\/python-editor\.js["']\)\.catch\(/,
+  "presentation bootstrap must begin fail-soft editor enhancement without waiting for focus",
+);
+assert.match(
+  playgroundHtml,
+  /<script type="module" src="\.\/python-editor-bootstrap\.js"><\/script>[\s\S]*?<script type="module" src="\.\/main\.js"><\/script>/,
+  "editor enhancement must start independently before the playground runtime entrypoint",
 );
 assert.match(
   playgroundEntry,
   /function loadEnhancedPythonEditor\(\)[\s\S]*?import\(["']\.\/python-editor\.js["']\)\.catch\(/,
-  "playground entrypoint must own editor enhancement through a fail-soft lazy dynamic import",
+  "playground entrypoint must retain a fail-soft focus fallback for editor enhancement",
 );
 assert.match(
   playgroundEntry,
   /sceneSourceEditor\.addEventListener\([\s\S]*?["']focus["'][\s\S]*?loadEnhancedPythonEditor\(\)[\s\S]*?\{ once: true \}/,
-  "editor enhancement must begin only on the first source-editor focus",
+  "focus path must remain a fallback if bootstrap enhancement was delayed or failed",
 );
+assert.match(playgroundHtml, /\.workspace \{[\s\S]*?height: 38rem;[\s\S]*?min-height: 0;/);
+assert.match(playgroundHtml, /\.editor-pane \{[\s\S]*?height: 100%;[\s\S]*?overflow: hidden;/);
+assert.match(playgroundHtml, /\.editor-stack,[\s\S]*?\.editor-panel \{[\s\S]*?overflow: hidden;/);
 
-console.log("✓ lazy editor enhancement stays outside the runtime authoring dependency graph");
+console.log("✓ editor highlighting starts before focus while runtime startup stays decoupled and bounded");

--- a/web/index.html
+++ b/web/index.html
@@ -136,7 +136,8 @@
       .workspace {
         display: grid;
         grid-template-columns: minmax(24rem, 1fr) minmax(0, 1.15fr);
-        min-height: 38rem;
+        height: 38rem;
+        min-height: 0;
         overflow: hidden;
         border: 1px solid var(--border);
         border-radius: 1rem;
@@ -151,7 +152,9 @@
 
       .editor-pane {
         display: flex;
-        min-height: 38rem;
+        height: 100%;
+        min-height: 0;
+        overflow: hidden;
         flex-direction: column;
         border-right: 1px solid var(--border);
         background: var(--panel-strong);
@@ -221,6 +224,7 @@
         display: flex;
         min-height: 0;
         flex: 1;
+        overflow: hidden;
       }
 
       .editor-panel {
@@ -274,7 +278,8 @@
 
       .preview-pane {
         display: flex;
-        min-height: 38rem;
+        height: 100%;
+        min-height: 0;
         flex-direction: column;
         background:
           radial-gradient(circle at 50% 42%, rgb(62 70 100 / 16%), transparent 22rem),
@@ -330,17 +335,21 @@
 
       @media (max-width: 68rem) {
         .workspace {
+          height: auto;
+          min-height: 0;
           grid-template-columns: 1fr;
         }
 
         .editor-pane {
-          min-height: 31rem;
+          height: 31rem;
+          min-height: 0;
           border-right: 0;
           border-bottom: 1px solid var(--border);
         }
 
         .preview-pane {
-          min-height: 30rem;
+          height: 30rem;
+          min-height: 0;
         }
       }
 
@@ -386,6 +395,7 @@
         }
 
         .preview-pane {
+          height: 25rem;
           min-height: 25rem;
         }
 
@@ -474,6 +484,7 @@
       </section>
     </main>
 
+    <script type="module" src="./python-editor-bootstrap.js"></script>
     <script type="module" src="./main.js"></script>
   </body>
 </html>

--- a/web/python-editor-bootstrap.js
+++ b/web/python-editor-bootstrap.js
@@ -1,0 +1,6 @@
+// Start the presentation-only editor enhancement as soon as the playground DOM is ready.
+// The Python authoring/runtime clients remain independent and still start only on Run.
+// Ruff's WASM linter remains lazy until the first real editor input.
+void import("./python-editor.js").catch((error) => {
+  console.warn("Optional Python editor unavailable; using textarea fallback", error);
+});


### PR DESCRIPTION
Fixes the public playground regressions where Python highlighting only appeared after focus, the long source editor expanded the workspace to its full document height, and edited stress-scene reruns could fail without dedicated regression coverage.

Changes:
- start CodeMirror enhancement immediately as presentation-only progressive enhancement while keeping Python/render runtime startup deferred
- bound the desktop and responsive editor panes so long source scrolls internally
- retain the existing focus loader as a fail-soft fallback
- add a real browser regression for Dynamic Load Stress that verifies highlighting before click, bounded layout, a valid title edit through CodeMirror, and a retained rerun
- run authoring recovery on relevant PRs so the exact traceback is captured before merge