### PR TITLE
Use compact morph stress in PR replay smoke

### DIFF
--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -191,6 +191,8 @@ jobs:
 
       - name: Check deterministic playback
         id: deterministic-replay
+        env:
+          NOON_DETERMINISM_MORPH_STRESS_COUNT: "96"
         run: |
           SECONDS=0
           set +e

--- a/crates/noon-web/tests/playground_examples.rs
+++ b/crates/noon-web/tests/playground_examples.rs
@@ -1,17 +1,24 @@
 use noon_web::ScenePlayer;
-use std::{fs, path::PathBuf, process::Command};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
 
-#[test]
-fn every_playground_scene_executes_and_compiles() {
+fn generate_playground_scenes(extra_args: &[&str]) -> (PathBuf, String) {
     let repository_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
-    let output_dir =
-        std::env::temp_dir().join(format!("noon-playground-scenes-{}", std::process::id()));
+    let output_dir = std::env::temp_dir().join(format!(
+        "noon-playground-scenes-{}-{}",
+        std::process::id(),
+        extra_args.join("-").replace("--", "")
+    ));
     let _ = fs::remove_dir_all(&output_dir);
     fs::create_dir_all(&output_dir).expect("temporary playground scene directory is writable");
 
     let output = Command::new("python3")
         .arg(repository_root.join("web/python/playground_examples.py"))
         .arg(&output_dir)
+        .args(extra_args)
         .current_dir(&repository_root)
         .env("PYTHONDONTWRITEBYTECODE", "1")
         // Exercise the manifest producer under a hostile inherited encoding.
@@ -28,6 +35,10 @@ fn every_playground_scene_executes_and_compiles() {
     }
 
     let manifest = String::from_utf8(output.stdout).expect("playground manifest is UTF-8");
+    (output_dir, manifest)
+}
+
+fn assert_manifest_compiles(output_dir: &Path, manifest: &str) {
     let registered = manifest
         .lines()
         .filter(|line| !line.trim().is_empty())
@@ -57,5 +68,21 @@ fn every_playground_scene_executes_and_compiles() {
         compiled, registered,
         "every registered playground scene was compiled"
     );
-    fs::remove_dir_all(&output_dir).expect("temporary playground scene directory is removable");
+    fs::remove_dir_all(output_dir).expect("temporary playground scene directory is removable");
+}
+
+#[test]
+fn every_playground_scene_executes_and_compiles() {
+    let (output_dir, manifest) = generate_playground_scenes(&[]);
+    assert_manifest_compiles(&output_dir, &manifest);
+}
+
+#[test]
+fn compact_morph_stress_scene_executes_and_compiles() {
+    let (output_dir, manifest) = generate_playground_scenes(&["--morph-stress-count", "96"]);
+    assert!(
+        manifest.contains("Morph stress · 1,000"),
+        "compact generation keeps the canonical gallery corpus"
+    );
+    assert_manifest_compiles(&output_dir, &manifest);
 }

--- a/scripts/deterministic-replay-smoke.mjs
+++ b/scripts/deterministic-replay-smoke.mjs
@@ -14,16 +14,20 @@ const sceneDir = await mkdtemp(path.join(tmpdir(), "noon-determinism-scenes-"));
 const port = Number(process.env.NOON_DETERMINISM_PORT ?? "4183");
 const baseUrl = `http://127.0.0.1:${port}`;
 const forwardSampleCount = 32;
+const morphStressCount = process.env.NOON_DETERMINISM_MORPH_STRESS_COUNT;
+const generatorArgs = ["web/python/playground_examples.py", sceneDir];
+if (morphStressCount !== undefined) {
+  if (!/^\d+$/.test(morphStressCount) || Number(morphStressCount) < 12) {
+    throw new Error("NOON_DETERMINISM_MORPH_STRESS_COUNT must be an integer >= 12");
+  }
+  generatorArgs.push("--morph-stress-count", morphStressCount);
+}
 
-const generated = spawnSync(
-  "python3",
-  ["web/python/playground_examples.py", sceneDir],
-  {
-    cwd: repoRoot,
-    encoding: "utf8",
-    env: { ...process.env, PYTHONDONTWRITEBYTECODE: "1" },
-  },
-);
+const generated = spawnSync("python3", generatorArgs, {
+  cwd: repoRoot,
+  encoding: "utf8",
+  env: { ...process.env, PYTHONDONTWRITEBYTECODE: "1" },
+});
 if (generated.status !== 0) {
   throw new Error(`Unable to generate deterministic scenes:\n${generated.stdout}\n${generated.stderr}`);
 }
@@ -91,9 +95,8 @@ try {
     const sceneJson = await readFile(example.file, "utf8");
     const document = JSON.parse(sceneJson);
     const end = sceneEnd(document);
-    const targets = end > 0
-      ? [0, end * 0.125, end * 0.5, end * 0.875, end, end + 0.75]
-      : [0, 0.5];
+    const targets =
+      end > 0 ? [0, end * 0.125, end * 0.5, end * 0.875, end, end + 0.75] : [0, 0.5];
 
     await page.evaluate(
       ({ json, targetTimes, sampleCount }) => {

--- a/web/python/playground_examples.py
+++ b/web/python/playground_examples.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import argparse
 import sys
 from pathlib import Path
 
 from noon import PatchBatch, Scene
 
 WEB_ROOT = Path(__file__).parents[1]
+MORPH_STRESS_NAME = "Morph stress · 1,000"
 
 # Ordered from basic authoring toward specialized renderer/performance behavior.
 # Each picker entry has one primary teaching purpose and one source file.
@@ -20,7 +22,7 @@ PLAYGROUND_SCENE_EXAMPLES = (
     ("Filled path Transform", "python/examples/filled_path_transform.py", {}),
     ("Staggered timing", "python/examples/staggered_choreography.py", {}),
     ("Instanced field · 180", "python/examples/instanced_field.py", {}),
-    ("Morph stress · 1,000", "python/examples/morph_stress_test.py", {"object_count": 1000}),
+    (MORPH_STRESS_NAME, "python/examples/morph_stress_test.py", {"object_count": 1000}),
 )
 
 PLAYGROUND_PATCH_EXAMPLES = (
@@ -38,6 +40,19 @@ PLAYGROUND_PATCH_EXAMPLES = (
     ),
     ("Transform remix", "python/examples/transform_patch.py", {"sequence": 0}),
 )
+
+
+def scene_examples(*, morph_stress_count: int | None = None):
+    if morph_stress_count is not None and morph_stress_count < 12:
+        raise ValueError("morph_stress_count must be at least 12")
+
+    examples = []
+    for name, relative_path, context in PLAYGROUND_SCENE_EXAMPLES:
+        effective_context = dict(context)
+        if name == MORPH_STRESS_NAME and morph_stress_count is not None:
+            effective_context["object_count"] = morph_stress_count
+        examples.append((name, relative_path, effective_context))
+    return tuple(examples)
 
 
 def _execute_source(relative_path: str, context: dict[str, object]) -> object:
@@ -68,9 +83,11 @@ def run_patch_example(relative_path: str, context: dict[str, object]) -> PatchBa
     return result
 
 
-def emit_scene_documents(output_dir: Path) -> None:
+def emit_scene_documents(output_dir: Path, *, morph_stress_count: int | None = None) -> None:
     output_dir.mkdir(parents=True, exist_ok=True)
-    for index, (name, relative_path, context) in enumerate(PLAYGROUND_SCENE_EXAMPLES):
+    for index, (name, relative_path, context) in enumerate(
+        scene_examples(morph_stress_count=morph_stress_count)
+    ):
         scene = run_scene_example(relative_path, context)
         output_path = output_dir / f"scene-{index:02d}.json"
         output_path.write_text(scene.to_json(), encoding="utf-8")
@@ -85,8 +102,16 @@ def _configure_manifest_stdout() -> None:
         reconfigure(encoding="utf-8")
 
 
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("output_dir", type=Path)
+    parser.add_argument("--morph-stress-count", type=int)
+    return parser.parse_args()
+
+
 if __name__ == "__main__":
-    if len(sys.argv) != 2:
-        raise SystemExit("usage: playground_examples.py OUTPUT_DIR")
+    args = _parse_args()
     _configure_manifest_stdout()
-    emit_scene_documents(Path(sys.argv[1]).resolve())
+    emit_scene_documents(
+        args.output_dir.resolve(), morph_stress_count=args.morph_stress_count
+    )


### PR DESCRIPTION
Clean current-master replay of #783. Keeps the canonical playground/gallery and default validation corpus at the 1,000-object morph workload, adds an explicit generator override with regression coverage, and sets only PR Fast Gate deterministic replay to 96 objects. This reduces redundant per-PR morph cost without weakening the default/full corpus.

The current retained-execution, mode-switch, renderer-critical WebGL, and host-updater risk gates are preserved unchanged.

Supersedes #783.