### PR TITLE
Batch native input bursts without losing discrete events

### DIFF
--- a/crates/noon-core/src/reactive/native_input_runtime.rs
+++ b/crates/noon-core/src/reactive/native_input_runtime.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 
 use crate::{NativeEventSource, NativeStateSource, ValueKind, Vec2};
@@ -75,6 +77,88 @@ pub struct NativeEventOccurrence {
 impl NativeEventOccurrence {
     pub const fn new(sequence: u64, source: NativeEventSource) -> Self {
         Self { sequence, source }
+    }
+}
+
+/// Accounting for one pending native-input batch.
+///
+/// `state_received` counts every sampled update accepted by the batch while
+/// `state_coalesced` counts samples superseded by a newer value for the same
+/// exact source. Discrete events are never coalesced.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct NativeInputBatchStats {
+    pub state_received: u64,
+    pub state_coalesced: u64,
+    pub events_received: u64,
+}
+
+/// Pending normalized native input awaiting one runtime dispatch boundary.
+///
+/// Sampled state is stored once per exact source so high-frequency pointer,
+/// viewport, wheel, gesture, and control updates have memory proportional to the
+/// number of active sources rather than the number of browser samples. Discrete
+/// events remain an insertion-ordered `Vec` because press/release/commit
+/// occurrences must not disappear. This type deliberately does not define when
+/// state versus events are applied relative to timeline/reactive/commit phases;
+/// the runtime dispatcher owns that ordering contract.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct NativeInputBatch {
+    states: BTreeMap<NativeStateSource, NativeStateUpdate>,
+    events: Vec<NativeEventOccurrence>,
+    stats: NativeInputBatchStats,
+}
+
+impl NativeInputBatch {
+    pub const fn new() -> Self {
+        Self {
+            states: BTreeMap::new(),
+            events: Vec::new(),
+            stats: NativeInputBatchStats {
+                state_received: 0,
+                state_coalesced: 0,
+                events_received: 0,
+            },
+        }
+    }
+
+    /// Retains the newest sampled value for this exact source.
+    ///
+    /// Returns `true` when an older pending sample was coalesced away.
+    pub fn push_state(&mut self, update: NativeStateUpdate) -> bool {
+        self.stats.state_received = self.stats.state_received.saturating_add(1);
+        let replaced = self.states.insert(update.source.clone(), update).is_some();
+        if replaced {
+            self.stats.state_coalesced = self.stats.state_coalesced.saturating_add(1);
+        }
+        replaced
+    }
+
+    /// Appends a discrete occurrence without coalescing or reordering it.
+    pub fn push_event(&mut self, occurrence: NativeEventOccurrence) {
+        self.stats.events_received = self.stats.events_received.saturating_add(1);
+        self.events.push(occurrence);
+    }
+
+    pub fn states(&self) -> impl ExactSizeIterator<Item = &NativeStateUpdate> {
+        self.states.values()
+    }
+
+    pub fn events(&self) -> &[NativeEventOccurrence] {
+        &self.events
+    }
+
+    pub const fn stats(&self) -> NativeInputBatchStats {
+        self.stats
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.states.is_empty() && self.events.is_empty()
+    }
+
+    pub fn clear(&mut self) {
+        self.states.clear();
+        self.events.clear();
+        self.stats = NativeInputBatchStats::default();
     }
 }
 
@@ -178,5 +262,91 @@ mod tests {
 
         assert!(down.sequence < up.sequence);
         assert_ne!(down.source, up.source);
+    }
+
+    #[test]
+    fn burst_batch_coalesces_sampled_state_to_latest_exact_source() {
+        let mut batch = NativeInputBatch::new();
+        for sample in 0..10_000 {
+            let update = NativeStateUpdate::new(
+                NativeStateSource::PointerPosition,
+                NativeInputValue::Vec2(Vec2::new(sample as f32, -(sample as f32))),
+            )
+            .unwrap();
+            batch.push_state(update);
+        }
+        batch.push_state(
+            NativeStateUpdate::new(
+                NativeStateSource::Key {
+                    code: "Space".to_owned(),
+                },
+                NativeInputValue::Bool(true),
+            )
+            .unwrap(),
+        );
+
+        let states: Vec<_> = batch.states().collect();
+        assert_eq!(states.len(), 2);
+        let pointer = states
+            .iter()
+            .find(|update| update.source == NativeStateSource::PointerPosition)
+            .unwrap();
+        assert_eq!(
+            pointer.value,
+            NativeInputValue::Vec2(Vec2::new(9_999.0, -9_999.0))
+        );
+        assert_eq!(
+            batch.stats(),
+            NativeInputBatchStats {
+                state_received: 10_001,
+                state_coalesced: 9_999,
+                events_received: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn burst_batch_never_coalesces_or_reorders_discrete_events() {
+        let mut batch = NativeInputBatch::new();
+        for sequence in 0..4_096 {
+            let source = if sequence % 2 == 0 {
+                NativeEventSource::PointerDown { button: 0 }
+            } else {
+                NativeEventSource::PointerUp { button: 0 }
+            };
+            batch.push_event(NativeEventOccurrence::new(sequence, source));
+        }
+
+        assert_eq!(batch.events().len(), 4_096);
+        assert!(batch
+            .events()
+            .iter()
+            .enumerate()
+            .all(|(index, event)| event.sequence == index as u64));
+        assert_eq!(batch.stats().events_received, 4_096);
+    }
+
+    #[test]
+    fn clearing_batch_resets_pending_input_and_accounting() {
+        let mut batch = NativeInputBatch::new();
+        batch.push_event(NativeEventOccurrence::new(
+            3,
+            NativeEventSource::ControlCommit {
+                name: "gain".to_owned(),
+            },
+        ));
+        batch.push_state(
+            NativeStateUpdate::new(
+                NativeStateSource::Control {
+                    name: "gain".to_owned(),
+                },
+                NativeInputValue::Scalar(0.5),
+            )
+            .unwrap(),
+        );
+
+        batch.clear();
+        assert!(batch.is_empty());
+        assert_eq!(batch.stats(), NativeInputBatchStats::default());
     }
 }


### PR DESCRIPTION
## Summary

Advance #69 with a renderer/browser-agnostic pending-input batch in `noon-core`.

- coalesce sampled state by exact `NativeStateSource`, retaining only the newest pending sample
- preserve every discrete `NativeEventOccurrence` in ingress order
- expose batch-local received/coalesced counters for later runtime instrumentation
- keep timeline/reactive/commit phase ordering outside this container so the runtime dispatcher remains the single owner of execution semantics
- bound sampled-state memory by active source count instead of browser sample count, without imposing an unsafe drop policy on discrete events

## Tests

Focused Rust coverage exercises a 10,000-sample pointer burst, exact-source separation, 4,096 alternating pointer down/up events with no loss or reordering, and batch reset/accounting.

## Scope / remaining risk

This deliberately does not choose cross-phase dispatch ordering or a discrete-event overflow/drop policy: #69 explicitly requires discrete occurrences not to disappear. Browser normalization, worker transport, application into the reactive graph, and paused-scene wakeup remain follow-up slices.

Closes no issue; contributes to #69.