### PR TITLE
Avoid duplicate cold-start host callback reconciliation

### DIFF
--- a/web/authoring-execution-client.js
+++ b/web/authoring-execution-client.js
@@ -75,6 +75,8 @@ export class AuthoringExecutionClient {
       loopDurationSeconds = DEFAULT_LOOP_DURATION_SECONDS,
       transportMode = undefined,
       sharedSlotCapacity = DEFAULT_SHARED_SLOT_CAPACITY,
+      callbacks = null,
+      authoringClient = null,
     } = {},
   ) {
     if (this.#player !== null || this.#transition !== null) {
@@ -91,6 +93,9 @@ export class AuthoringExecutionClient {
       options.transportMode = transportMode;
     }
     const ready = await this.#startMode(AUTHORING_EXECUTION_LEGACY, sceneJson, options);
+    if (callbacks !== null && callbacks !== undefined) {
+      await this.#player.configureHostCallbacks(callbacks, authoringClient);
+    }
     this.#transportMode = ready.transportMode;
     return ready;
   }

--- a/web/main.js
+++ b/web/main.js
@@ -481,17 +481,12 @@ async function ensureRuntimeReady({
         ? await nextPlayer.startRetainedCanonical(sceneSpecJson, {
             loopDurationSeconds,
           })
-        : await nextPlayer.start(sceneJson, { loopDurationSeconds });
-      let initialState;
-      if (!startRetained && callbacks !== null && callbacks !== undefined) {
-        initialState = await nextPlayer.reconcileScene(sceneJson, {
-          callbacks,
-          authoringClient: client,
-          loopDurationSeconds,
-        });
-      } else {
-        initialState = await nextPlayer.state();
-      }
+        : await nextPlayer.start(sceneJson, {
+            loopDurationSeconds,
+            callbacks,
+            authoringClient: client,
+          });
+      const initialState = await nextPlayer.state();
 
       player = nextPlayer;
       playerNeedsRestart = false;

--- a/web/playground-cold-start-callbacks.test.mjs
+++ b/web/playground-cold-start-callbacks.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const mainSource = await readFile(new URL("./main.js", import.meta.url), "utf8");
+const executionSource = await readFile(
+  new URL("./authoring-execution-client.js", import.meta.url),
+  "utf8",
+);
+
+const runtimeStart = mainSource.indexOf("async function ensureRuntimeReady(");
+const runtimeEnd = mainSource.indexOf("\nasync function ensureExecutionReady()", runtimeStart);
+assert.ok(runtimeStart >= 0 && runtimeEnd > runtimeStart, "playground runtime startup boundary must exist");
+const runtimeReady = mainSource.slice(runtimeStart, runtimeEnd);
+
+assert.match(
+  runtimeReady,
+  /nextPlayer\.start\(sceneJson, \{[\s\S]*callbacks,[\s\S]*authoringClient: client,/u,
+  "legacy cold start must attach host callbacks through the initial startup",
+);
+assert.doesNotMatch(
+  runtimeReady,
+  /nextPlayer\.reconcileScene/u,
+  "legacy cold start must not reconcile the just-started scene only to attach callbacks",
+);
+
+const startMethod = executionSource.indexOf("  async start(");
+const retainedStart = executionSource.indexOf("\n  async startRetainedCanonical(", startMethod);
+assert.ok(startMethod >= 0 && retainedStart > startMethod, "legacy authoring startup method must exist");
+const legacyStart = executionSource.slice(startMethod, retainedStart);
+assert.match(legacyStart, /callbacks = null,/u);
+assert.match(legacyStart, /authoringClient = null,/u);
+assert.match(
+  legacyStart,
+  /configureHostCallbacks\(callbacks, authoringClient\)/u,
+  "legacy startup must reuse the shared host-callback configuration path",
+);
+
+console.log("✓ cold-start host callbacks attach without duplicate scene reconciliation");


### PR DESCRIPTION
Clean current-master three-way port of #854. Legacy playground startup now passes Python host callbacks into `AuthoringExecutionClient.start()`, which attaches them through the existing `ExecutionWorkerClient.configureHostCallbacks()` owner after the initial engine is ready. The former immediate `reconcileScene()` of the identical freshly-started scene is removed; retained+callback startup remains explicitly rejected before retained startup.

This preserves the current canonical mode-switch/lifecycle architecture and adds the focused cold-start regression from the original green PR.

Supersedes #854.