### PR TITLE
Fix blank examples browser on iOS WebKit

### DIFF
--- a/web/example-browser-ui.js
+++ b/web/example-browser-ui.js
@@ -298,6 +298,10 @@ function installStyles(documentLike) {
       grid-template-columns: repeat(auto-fill, minmax(11.5rem, 1fr));
       overscroll-behavior: contain;
     }
+    .example-browser-layer .example-card {
+      content-visibility: visible;
+      contain-intrinsic-size: none;
+    }
     .example-browser-layer .example-parity { display: none; }
     .example-browser-layer .example-card-meta { justify-content: flex-start; }
     .example-browser-layer .gallery-pager { flex: none; }


### PR DESCRIPTION
## Summary

Fixes the Examples browser rendering blank on iPhone Chrome/Safari after #887.

### Root cause

The example cards inherit `content-visibility: auto` from the gallery card style. The Examples browser initially lives under a hidden overlay and is then revealed. Current WebKit/iOS 26 has known rendering issues where `content-visibility: auto` content revealed inside a scrolling container can remain skipped/blank until another layout is forced.

Because the gallery is already paginated to 18 cards, this optimization is unnecessary in the modal/sheet.

### Fix

Inside the Examples browser only, force normal painting:

- `content-visibility: visible`
- `contain-intrinsic-size: none`

This keeps the optimization scoped away from the overlay and avoids WebKit's skipped-content path.

Related: #887, #880.