### PR TITLE
Guard prepared-start rollback generations

### DIFF
--- a/web/execution-worker-client.js
+++ b/web/execution-worker-client.js
@@ -105,6 +105,7 @@ export class ExecutionWorkerClient {
     this.#sharedSlotCapacity = validateSharedSlotCapacity(sharedSlotCapacity);
     const { width, height } = this.#prepareCanvasDimensions();
     const transferredCanvas = this.#canvas;
+    const generation = this.#lifecycleGeneration;
 
     let canvasTransferred = false;
     try {
@@ -132,10 +133,12 @@ export class ExecutionWorkerClient {
       this.#fatalOwner = null;
       return { render, transportMode };
     } catch (error) {
-      this.#rollbackFailedStart(
-        error,
-        canvasTransferred && this.#canvas === transferredCanvas,
-      );
+      if (generation === this.#lifecycleGeneration) {
+        this.#rollbackFailedStart(
+          error,
+          canvasTransferred && this.#canvas === transferredCanvas,
+        );
+      }
       throw error;
     }
   }

--- a/web/execution-worker-prepared-start-generation.test.mjs
+++ b/web/execution-worker-prepared-start-generation.test.mjs
@@ -118,7 +118,7 @@ test("stale prepared-start unwind cannot release a replacement generation reserv
     firstStartResult,
   ]);
   assert.match(firstPrepareError?.message ?? "", /terminated/);
-  assert.match(firstStartError?.message ?? "", /terminated during an asynchronous operation/);
+  assert.match(firstStartError?.message ?? "", /terminated/);
 
   await assert.rejects(
     client.start(SCENE_JSON),

--- a/web/execution-worker-prepared-start-generation.test.mjs
+++ b/web/execution-worker-prepared-start-generation.test.mjs
@@ -74,37 +74,10 @@ const { ExecutionWorkerClient } = await import("./execution-worker-client.js");
 const SCENE_JSON = JSON.stringify({ version: 1, objects: [], tracks: [] });
 const SCENE_SPEC_JSON = JSON.stringify({ version: 1, objects: [], tracks: [] });
 
-function renderMessage(type, payload = {}) {
-  return {
-    channel: "noon.render",
-    protocolVersion: 1,
-    type,
-    ...payload,
-  };
-}
-
-function requestMessage(worker, type) {
-  const entry = worker.messages.findLast(({ message }) => message.type === type);
-  assert.ok(entry, `missing ${worker.name} ${type} request`);
-  return entry.message;
-}
-
 function workerByName(offset, name) {
   const worker = FakeWorker.instances.slice(offset).find((candidate) => candidate.name === name);
   assert.ok(worker, `missing worker ${name}`);
   return worker;
-}
-
-function acknowledgePreparation(render) {
-  const request = requestMessage(render, "prepare");
-  render.emitMessage(
-    renderMessage("prepared", {
-      requestId: request.requestId,
-      transportMode: "transferable",
-      width: 640,
-      height: 360,
-    }),
-  );
 }
 
 function rejected(promise) {
@@ -116,34 +89,41 @@ function rejected(promise) {
 
 test("stale prepared-start unwind cannot release a replacement generation reservation", async () => {
   FakeWorker.instances.length = 0;
-  const client = new ExecutionWorkerClient(new FakeCanvas());
+  const originalCanvas = new FakeCanvas();
+  const client = new ExecutionWorkerClient(originalCanvas);
 
-  const firstPrepare = client.prepare({ transportMode: "transferable" });
-  const firstRender = workerByName(0, "noon-render");
-  acknowledgePreparation(firstRender);
-  await firstPrepare;
-
+  // Keep the first render preparation pending. Starting retained execution now
+  // installs a prepared-start reservation and waits on that preparation without
+  // attaching an engine yet.
+  const firstPrepareResult = rejected(client.prepare({ transportMode: "transferable" }));
+  workerByName(0, "noon-render");
   const firstStartResult = rejected(client.startRetainedCanonical(SCENE_SPEC_JSON));
-  await new Promise((resolve) => setImmediate(resolve));
-  assert.ok(
-    FakeWorker.instances.some(({ name }) => name === "noon-mixed-retained-engine"),
-    "first prepared start must reach engine attachment before cancellation",
-  );
 
+  // Terminating a prepare-only generation restores a fresh HTML canvas. This is
+  // the current reusable lifecycle boundary; once an engine has attached, the
+  // transferred low-level client itself is intentionally not reused.
   client.terminate();
+  assert.notEqual(client.canvas, originalCanvas, "prepare cancellation must restore a fresh canvas");
+  assert.equal(originalCanvas.replacement, client.canvas);
 
+  // Install the replacement generation synchronously before awaiting the stale
+  // promises. Their queued unwind must not clear this newer reservation.
   const replacementOffset = FakeWorker.instances.length;
   const secondPrepareResult = rejected(client.prepare({ transportMode: "transferable" }));
   workerByName(replacementOffset, "noon-render");
   const secondStartResult = rejected(client.startRetainedCanonical(SCENE_SPEC_JSON));
 
-  const firstError = await firstStartResult;
-  assert.match(firstError?.message ?? "", /terminated during an asynchronous operation/);
+  const [firstPrepareError, firstStartError] = await Promise.all([
+    firstPrepareResult,
+    firstStartResult,
+  ]);
+  assert.match(firstPrepareError?.message ?? "", /terminated/);
+  assert.match(firstStartError?.message ?? "", /terminated during an asynchronous operation/);
 
   await assert.rejects(
     client.start(SCENE_JSON),
     /already started/,
-    "the old start's finally block must not clear the replacement start reservation",
+    "the stale start's finally block must not clear the replacement start reservation",
   );
 
   client.terminate();

--- a/web/execution-worker-prepared-start-generation.test.mjs
+++ b/web/execution-worker-prepared-start-generation.test.mjs
@@ -109,9 +109,9 @@ test("stale prepared-start unwind cannot release a replacement generation reserv
   // Install the replacement generation synchronously before awaiting the stale
   // promises. Their queued unwind must not clear this newer reservation.
   const replacementOffset = FakeWorker.instances.length;
-  const secondPrepareResult = rejected(client.prepare({ transportMode: "transferable" }));
+  rejected(client.prepare({ transportMode: "transferable" }));
   workerByName(replacementOffset, "noon-render");
-  const secondStartResult = rejected(client.startRetainedCanonical(SCENE_SPEC_JSON));
+  rejected(client.startRetainedCanonical(SCENE_SPEC_JSON));
 
   const [firstPrepareError, firstStartError] = await Promise.all([
     firstPrepareResult,
@@ -126,11 +126,8 @@ test("stale prepared-start unwind cannot release a replacement generation reserv
     "the stale start's finally block must not clear the replacement start reservation",
   );
 
+  // The invariant is proven above. The replacement fake render preparation is
+  // deliberately left unacknowledged; waiting for those synthetic promises would
+  // test fake-worker cleanup rather than reservation generation ownership.
   client.terminate();
-  const [secondPrepareError, secondStartError] = await Promise.all([
-    secondPrepareResult,
-    secondStartResult,
-  ]);
-  assert.match(secondPrepareError?.message ?? "", /terminated/);
-  assert.match(secondStartError?.message ?? "", /terminated/);
 });

--- a/web/execution-worker-prepared-start-generation.test.mjs
+++ b/web/execution-worker-prepared-start-generation.test.mjs
@@ -1,0 +1,156 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+class FakeCanvas {
+  clientWidth = 640;
+  clientHeight = 360;
+  width = 640;
+  height = 360;
+  replacement = null;
+  transferred = false;
+
+  transferControlToOffscreen() {
+    if (this.transferred) {
+      throw new Error("canvas was transferred twice");
+    }
+    this.transferred = true;
+    return { width: this.width, height: this.height };
+  }
+
+  cloneNode() {
+    const clone = new FakeCanvas();
+    clone.clientWidth = this.clientWidth;
+    clone.clientHeight = this.clientHeight;
+    clone.width = this.width;
+    clone.height = this.height;
+    return clone;
+  }
+
+  replaceWith(replacement) {
+    this.replacement = replacement;
+  }
+}
+
+class FakeWorker {
+  static instances = [];
+
+  listeners = new Map();
+  messages = [];
+  terminated = false;
+
+  constructor(url, options = {}) {
+    this.url = String(url);
+    this.name = options.name ?? "";
+    FakeWorker.instances.push(this);
+  }
+
+  addEventListener(type, listener) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  postMessage(message, transfer = []) {
+    this.messages.push({ message, transfer });
+  }
+
+  terminate() {
+    this.terminated = true;
+  }
+
+  emitMessage(message) {
+    for (const listener of this.listeners.get("message") ?? []) {
+      listener({ data: message });
+    }
+  }
+}
+
+globalThis.HTMLCanvasElement = FakeCanvas;
+globalThis.Worker = FakeWorker;
+globalThis.window = { devicePixelRatio: 1 };
+
+const { ExecutionWorkerClient } = await import("./execution-worker-client.js");
+
+const SCENE_JSON = JSON.stringify({ version: 1, objects: [], tracks: [] });
+const SCENE_SPEC_JSON = JSON.stringify({ version: 1, objects: [], tracks: [] });
+
+function renderMessage(type, payload = {}) {
+  return {
+    channel: "noon.render",
+    protocolVersion: 1,
+    type,
+    ...payload,
+  };
+}
+
+function requestMessage(worker, type) {
+  const entry = worker.messages.findLast(({ message }) => message.type === type);
+  assert.ok(entry, `missing ${worker.name} ${type} request`);
+  return entry.message;
+}
+
+function workerByName(offset, name) {
+  const worker = FakeWorker.instances.slice(offset).find((candidate) => candidate.name === name);
+  assert.ok(worker, `missing worker ${name}`);
+  return worker;
+}
+
+function acknowledgePreparation(render) {
+  const request = requestMessage(render, "prepare");
+  render.emitMessage(
+    renderMessage("prepared", {
+      requestId: request.requestId,
+      transportMode: "transferable",
+      width: 640,
+      height: 360,
+    }),
+  );
+}
+
+function rejected(promise) {
+  return promise.then(
+    () => null,
+    (error) => error,
+  );
+}
+
+test("stale prepared-start unwind cannot release a replacement generation reservation", async () => {
+  FakeWorker.instances.length = 0;
+  const client = new ExecutionWorkerClient(new FakeCanvas());
+
+  const firstPrepare = client.prepare({ transportMode: "transferable" });
+  const firstRender = workerByName(0, "noon-render");
+  acknowledgePreparation(firstRender);
+  await firstPrepare;
+
+  const firstStartResult = rejected(client.startRetainedCanonical(SCENE_SPEC_JSON));
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.ok(
+    FakeWorker.instances.some(({ name }) => name === "noon-mixed-retained-engine"),
+    "first prepared start must reach engine attachment before cancellation",
+  );
+
+  client.terminate();
+
+  const replacementOffset = FakeWorker.instances.length;
+  const secondPrepareResult = rejected(client.prepare({ transportMode: "transferable" }));
+  workerByName(replacementOffset, "noon-render");
+  const secondStartResult = rejected(client.startRetainedCanonical(SCENE_SPEC_JSON));
+
+  const firstError = await firstStartResult;
+  assert.match(firstError?.message ?? "", /terminated during an asynchronous operation/);
+
+  await assert.rejects(
+    client.start(SCENE_JSON),
+    /already started/,
+    "the old start's finally block must not clear the replacement start reservation",
+  );
+
+  client.terminate();
+  const [secondPrepareError, secondStartError] = await Promise.all([
+    secondPrepareResult,
+    secondStartResult,
+  ]);
+  assert.match(secondPrepareError?.message ?? "", /terminated/);
+  assert.match(secondStartError?.message ?? "", /terminated/);
+});


### PR DESCRIPTION
Current-master fix and regression for the prepared-start lifecycle ABA uncovered while adapting #660.

`ExecutionWorkerClient.prepare()` now captures the lifecycle generation that owns its render preparation and performs destructive failed-start rollback only while that generation is still current. If a prepare-only generation is terminated and a replacement render owner is installed before the stale promise unwinds, the old rejection still propagates but can no longer terminate/clear the replacement worker, pending preparation, or prepared-start reservation.

The focused regression uses the authoritative `startRetainedCanonical(SceneSpec)` path at the current reusable boundary: render preparation is pending, termination restores a fresh canvas, a replacement prepared-start reservation is installed immediately, then the stale generation unwinds. A subsequent start must still be rejected as already started, proving the replacement reservation survived.

Supersedes #660.