### PR TITLE
Expose shared Manim DashedLine through Python

### DIFF
--- a/web/python-compat-modules.js
+++ b/web/python-compat-modules.js
@@ -11,6 +11,7 @@ export const PYTHON_COMPAT_MODULES = Object.freeze([
   { sourcePath: "python/_manim_phase_b.py", runtimePath: "/tmp/_manim_phase_b.py", label: "Noon Manim Phase B layer" },
   { sourcePath: "python/_manim_geometry.py", runtimePath: "/tmp/_manim_geometry.py", label: "Noon Manim geometry layer" },
   { sourcePath: "python/_manim_shared_geometry.py", runtimePath: "/tmp/_manim_shared_geometry.py", label: "Noon shared Rust geometry adapter" },
+  { sourcePath: "python/_manim_dashed_line.py", runtimePath: "/tmp/_manim_dashed_line.py", label: "Noon shared DashedLine adapter" },
   { sourcePath: "python/_manim_animation_options.py", runtimePath: "/tmp/_manim_animation_options.py", label: "Noon Manim animation options" },
   { sourcePath: "python/_manim_animate.py", runtimePath: "/tmp/_manim_animate.py", label: "Noon Manim animate layer" },
   { sourcePath: "python/_manim_rotate.py", runtimePath: "/tmp/_manim_rotate.py", label: "Noon Manim Rotate layer" },

--- a/web/python-worker.source.js
+++ b/web/python-worker.source.js
@@ -6,6 +6,7 @@ import initNoonWeb, {
   canonicalRetainedSceneSpecJson,
   manimAnnularSectorSnapshotJson,
   manimAnnulusSnapshotJson,
+  manimDashedLineSnapshotJson,
   manimDotSnapshotJson,
   manimElbowSnapshotJson,
   manimRoundedRectangleSnapshotJson,
@@ -67,6 +68,8 @@ async function initializePyodide() {
     authoringStore.createMobject(manimSectorSnapshotJson(...args));
   self.noonCreateAuthoringAnnulusHandle = (...args) =>
     authoringStore.createMobject(manimAnnulusSnapshotJson(...args));
+  self.noonCreateAuthoringDashedLineHandle = (...args) =>
+    authoringStore.createMobject(manimDashedLineSnapshotJson(...args));
   self.noonCreateAuthoringUnderlineHandle = (targetHandle, buff) =>
     authoringStore.createMobject(manimUnderlineSnapshotJson(targetHandle.snapshotJson(), buff));
   self.noonCreateAuthoringCircleHandle = (radius) => authoringStore.createManimCircle(radius);
@@ -108,6 +111,8 @@ import _manim_semantic_handles
 _manim_semantic_handles.install()
 import _manim_shared_geometry
 _manim_shared_geometry.install()
+import _manim_dashed_line
+_manim_dashed_line.install()
 import _manim_animate
 import _manim_rotate
 _manim_rotate.install()

--- a/web/python/_manim_dashed_line.py
+++ b/web/python/_manim_dashed_line.py
@@ -1,0 +1,72 @@
+"""Thin Manim DashedLine adapter backed by shared Rust geometry."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import noon as _base
+import _manim_compat as _compat
+import _manim_semantic_handles as _shared
+
+try:
+    from js import noonCreateAuthoringDashedLineHandle as _create_dashed_line_handle
+except ImportError:
+    _create_dashed_line_handle = None
+
+_INSTALLED = False
+
+
+class DashedLine(_compat.Line):
+    """Straight Manim DashedLine whose dash geometry is authored in shared Rust."""
+
+    def __init__(
+        self,
+        start: object = _base.LEFT,
+        end: object = _base.RIGHT,
+        dash_length: float = 0.05,
+        dashed_ratio: float = 0.5,
+        **kwargs: Any,
+    ) -> None:
+        if _create_dashed_line_handle is None:
+            raise RuntimeError("DashedLine requires the shared browser geometry bridge")
+
+        start_value = _compat._as_vec2(start)
+        end_value = _compat._as_vec2(end)
+        dash_length_value = _shared._ir._positive_number("dash_length", dash_length)
+        dashed_ratio_value = _shared._ir._finite_number("dashed_ratio", dashed_ratio)
+        if not 0.0 <= dashed_ratio_value <= 1.0:
+            raise ValueError("dashed_ratio must be within [0, 1]")
+
+        options = dict(kwargs)
+        color = options.pop("color", None)
+        _shared._attach_shared_handle(
+            self,
+            _create_dashed_line_handle(
+                start_value.x,
+                start_value.y,
+                end_value.x,
+                end_value.y,
+                dash_length_value,
+                dashed_ratio_value,
+            ),
+        )
+        self.dash_length = dash_length_value
+        self.dashed_ratio = dashed_ratio_value
+        _shared._apply_shared_constructor_kwargs(self, options)
+        if color is not None:
+            parsed = _shared._phase_b._as_color("color", color)
+            _shared._set_color(self, parsed)
+
+
+def install() -> None:
+    global _INSTALLED
+    if _INSTALLED:
+        return
+    _INSTALLED = True
+    _base.DashedLine = DashedLine
+    _compat.DashedLine = DashedLine
+    if "DashedLine" not in _base.__all__:
+        _base.__all__.append("DashedLine")
+
+
+install()

--- a/web/python/test_manim_shared_dashed_line.py
+++ b/web/python/test_manim_shared_dashed_line.py
@@ -1,0 +1,97 @@
+import os
+import subprocess
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+
+
+class ManimSharedDashedLineTests(unittest.TestCase):
+    def test_constructor_stays_on_shared_rust_geometry(self) -> None:
+        python_dir = Path(__file__).resolve().parent
+        env = os.environ.copy()
+        existing = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = str(python_dir) if not existing else os.pathsep.join((str(python_dir), existing))
+        source = textwrap.dedent(
+            r"""
+            import json
+            import sys
+            import types
+
+            fake_js = types.ModuleType("js")
+            calls = []
+
+            class FakeHandle:
+                wireTranslationX = 0.0
+                wireTranslationY = 0.0
+                wireScaleX = 1.0
+                wireScaleY = 1.0
+                wireRotation = 0.0
+                wireHasFill = True
+                wireFillRed = wireFillGreen = wireFillBlue = 1.0
+                wireFillAlpha = 0.0
+                wireHasStroke = True
+                wireStrokeRed = wireStrokeGreen = wireStrokeBlue = 1.0
+                wireStrokeAlpha = 1.0
+                wireStrokeWidth = 0.04
+                wireObjectOpacity = 1.0
+
+                def __init__(self, snapshot):
+                    self.snapshot = snapshot
+
+                def snapshotJson(self):
+                    return json.dumps(self.snapshot)
+
+            def generic_handle(snapshot_json):
+                return FakeHandle(json.loads(snapshot_json))
+
+            def dashed_line(sx, sy, ex, ey, dash_length, dashed_ratio):
+                calls.append((float(sx), float(sy), float(ex), float(ey), float(dash_length), float(dashed_ratio)))
+                return FakeHandle({
+                    "geometry": {"vector_path": {"commands": [
+                        {"move_to": {"to": {"x": float(sx), "y": float(sy)}}},
+                        {"line_to": {"to": {"x": float(ex), "y": float(ey)}}},
+                    ]}},
+                    "transform": {"translation": {"x": 0.0, "y": 0.0}, "rotation": 0.0, "scale": {"x": 1.0, "y": 1.0}},
+                    "style": {"fill": {"red": 1.0, "green": 1.0, "blue": 1.0, "alpha": 0.0}, "stroke": {"red": 1.0, "green": 1.0, "blue": 1.0, "alpha": 1.0}, "stroke_width": 0.04, "stroke_width_mode": "screen_space", "stroke_join": "miter", "stroke_cap": "butt", "opacity": 1.0},
+                })
+
+            fake_js.noonCreateAuthoringMobjectHandle = generic_handle
+            fake_js.noonCreateAuthoringDashedLineHandle = dashed_line
+            sys.modules["js"] = fake_js
+
+            import _manim_compat
+            _manim_compat.install()
+            import _manim_phase_b
+            import _manim_geometry
+            import _manim_semantic_handles as handles
+            handles.install()
+
+            _manim_compat._ir.Path = lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("Python path reconstruction was called"))
+
+            import _manim_dashed_line
+            _manim_dashed_line.install()
+            from noon import DashedLine, Line
+
+            line = DashedLine(start=(-2, 1), end=(3, -1), dash_length=0.2, dashed_ratio=0.25)
+            assert isinstance(line, Line)
+            assert calls == [(-2.0, 1.0, 3.0, -1.0, 0.2, 0.25)]
+            assert "vector_path" in line.geometry
+
+            before = list(calls)
+            for kwargs in ({"dash_length": 0.0}, {"dashed_ratio": -0.1}, {"dashed_ratio": 1.1}):
+                try:
+                    DashedLine(**kwargs)
+                except ValueError:
+                    pass
+                else:
+                    raise AssertionError("invalid dash parameters must fail before bridge dispatch")
+            assert calls == before
+            """
+        )
+        completed = subprocess.run([sys.executable, "-c", source], cwd=python_dir, env=env, capture_output=True, text=True, check=False)
+        self.assertEqual(completed.returncode, 0, f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Clean current-master port of #755 on top of the Rust-owned canonical authoring context. Exposes the already-existing shared `manimDashedLineSnapshotJson` WASM bridge through the authoring store, installs the thin Python `DashedLine(Line)` facade before the final canonical SceneSpec wrapper, and keeps dash count/segmentation/path construction owned entirely by shared Rust.

The original native regression is retained and still fails if Python reconstructs dash geometry or dispatches invalid dash parameters across the bridge.

Supersedes #755.