### PR TITLE
Make canonical scene identity stabilization collision-safe

### DIFF
--- a/scripts/playground-stress-edit-smoke.mjs
+++ b/scripts/playground-stress-edit-smoke.mjs
@@ -164,40 +164,51 @@ try {
     () => document.querySelector("#python-scene-source")?.value ?? "",
   );
   assert.match(source, /rows = 20/);
-  const editedSource = source.replace("rows = 20", "rows = 5");
-  assert.notEqual(editedSource, source);
+  let editedSource = source;
+  for (const rows of [5, 7, 20]) {
+    const nextSource = editedSource.replace(/rows = \d+/, `rows = ${rows}`);
+    assert.notEqual(nextSource, editedSource);
 
-  // Use the real CodeMirror input path so the hidden textarea/draft bridge is exercised.
-  await editor.click();
-  await page.keyboard.press("Control+A");
-  await page.keyboard.insertText(editedSource);
-  await page.waitForFunction(
-    (expected) => document.querySelector("#python-scene-source")?.value === expected,
-    editedSource,
-    { timeout: 15_000 },
-  );
-  diagnostics.snapshots.edited = await snapshot(page);
-  assert.ok(
-    Math.abs(diagnostics.snapshots.edited.editorHeight - diagnostics.snapshots.loaded.editorHeight) <= 2,
-    "editing the long source must not grow the editor pane",
-  );
+    // Use the real CodeMirror input path on every edit so identity stabilization is
+    // exercised across consecutive authoring results, not just one structural rerun.
+    await editor.click();
+    await page.keyboard.press("Control+A");
+    await page.keyboard.insertText(nextSource);
+    await page.waitForFunction(
+      (expected) => document.querySelector("#python-scene-source")?.value === expected,
+      nextSource,
+      { timeout: 15_000 },
+    );
+    diagnostics.snapshots[`rows${rows}Edited`] = await snapshot(page);
+    assert.ok(
+      Math.abs(
+        diagnostics.snapshots[`rows${rows}Edited`].editorHeight -
+          diagnostics.snapshots.loaded.editorHeight,
+      ) <= 2,
+      "editing the long source must not grow the editor pane",
+    );
 
-  diagnostics.snapshots.rerun = await runAndWait(page);
-  assert.equal(diagnostics.snapshots.rerun.executionMode, "retained");
-  assert.match(diagnostics.snapshots.rerun.patchText, /Scene rebuilt atomically/);
+    diagnostics.snapshots[`rows${rows}Rerun`] = await runAndWait(page);
+    assert.equal(diagnostics.snapshots[`rows${rows}Rerun`].executionMode, "retained");
+    assert.match(
+      diagnostics.snapshots[`rows${rows}Rerun`].patchText,
+      /Scene rebuilt atomically/,
+    );
+    editedSource = nextSource;
+  }
 
   assert.deepEqual(diagnostics.pageErrors, [], `unhandled page errors: ${diagnostics.pageErrors.join("\n")}`);
   assert.deepEqual(
     diagnostics.consoleErrors,
     [],
-    `valid structural stress edit/rerun emitted console errors: ${diagnostics.consoleErrors.join("\n")}`,
+    `valid repeated structural stress edits emitted console errors: ${diagnostics.consoleErrors.join("\n")}`,
   );
 
   diagnostics.serverOutput = serverOutput;
   await page.screenshot({ path: path.join(artifactDir, "stress-edited.png"), fullPage: true });
   await writeFile(path.join(artifactDir, "diagnostics.json"), `${JSON.stringify(diagnostics, null, 2)}\n`);
   console.log(
-    `playground structural stress edit ok: ${diagnostics.snapshots.loaded.editorHeight}px editor, rows=5 rerun applied`,
+    `playground repeated structural stress edits ok: ${diagnostics.snapshots.loaded.editorHeight}px editor, rows=5 -> 7 -> 20 applied`,
   );
 } catch (error) {
   diagnostics.failure = error instanceof Error ? error.stack ?? error.message : String(error);

--- a/web/scene-identity-canonical-collision.test.mjs
+++ b/web/scene-identity-canonical-collision.test.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { SceneIdentityMap } from "./scene-identity.js";
+
+function canonicalScene(keys) {
+  const textId = keys.length;
+  return {
+    sceneSpec: {
+      version: 1,
+      objects: [
+        ...keys.map((key, id) => ({ id, content: { kind: "geometry", key } })),
+        { id: textId, content: { kind: "text" } },
+      ],
+      tracks: [
+        ...keys.map((key, id) => ({ id, object: id, key })),
+        { id: textId, object: textId },
+      ],
+      family_animations: [
+        {
+          target: 100,
+          bindings: [{ semantic_leaf: 101, object: textId }],
+          spec: {},
+        },
+      ],
+      camera_object: keys.length === 0 ? null : 0,
+    },
+    identities: {
+      objects: keys.map((key, id) => ({ id, key: `object:${key}` })),
+      tracks: keys.map((key, id) => ({ id, key: `track:${key}` })),
+    },
+  };
+}
+
+function assertUnique(values) {
+  assert.equal(new Set(values).size, values.length);
+}
+
+test("canonical mixed identities stay unique across repeated topology edits", () => {
+  const identities = new SceneIdentityMap();
+  const sequence = [
+    { keys: ["a", "b"], stable: [0, 1] },
+    { keys: ["b"], stable: [1] },
+    { keys: ["c", "b"], stable: [2, 1] },
+    { keys: ["b", "d", "c"], stable: [1, 3, 2] },
+    { keys: ["a", "b"], stable: [0, 1] },
+  ];
+
+  const results = [];
+  for (const { keys, stable } of sequence) {
+    const { sceneSpec, identities: authoredIdentities } = canonicalScene(keys);
+    const result = identities.stabilizeSceneSpec(sceneSpec, authoredIdentities);
+    results.push(result);
+
+    assert.deepEqual(result.objects.slice(0, keys.length).map(({ id }) => id), stable);
+    assert.deepEqual(result.tracks.slice(0, keys.length).map(({ id }) => id), stable);
+    assertUnique(result.objects.map(({ id }) => id));
+    assertUnique(result.tracks.map(({ id }) => id));
+
+    const textObject = result.objects.at(-1).id;
+    const textTrack = result.tracks.at(-1).id;
+    assert.equal(result.tracks.at(-1).object, textObject);
+    assert.equal(result.family_animations[0].bindings[0].object, textObject);
+    assert.ok(!stable.includes(textObject));
+    assert.ok(!stable.includes(textTrack));
+  }
+
+  // c and d own stable IDs 2 and 3 even while absent from the final scene. The
+  // canonical-only Text source ID is 2 in that final rerun and must not steal c's
+  // historical semantic identity.
+  assert.ok(![0, 1, 2, 3].includes(results.at(-1).objects.at(-1).id));
+  assert.ok(![0, 1, 2, 3].includes(results.at(-1).tracks.at(-1).id));
+});

--- a/web/scene-identity.js
+++ b/web/scene-identity.js
@@ -38,17 +38,25 @@ export class SceneIdentityMap {
 
   /// Apply the same semantic identity map to the canonical mixed scene.
   ///
-  /// Python identity metadata currently describes the legacy geometry objects/tracks
-  /// that feed SceneSpec construction. Canonical-only objects such as retained text
-  /// are intentionally absent from that metadata and therefore keep their source IDs.
-  /// Painter order stays structural while geometry track/camera references follow the
-  /// remapped stable object IDs.
+  /// Python identity metadata currently describes only the geometry objects/tracks
+  /// that feed SceneSpec construction. Canonical-only identities, such as retained
+  /// Text tracks, are therefore provisional local IDs rather than stable semantic
+  /// claims. Keyed semantic identities permanently own their stable IDs. Unkeyed
+  /// canonical identities keep their source IDs when collision-free and are moved to
+  /// a temporary free ID when a topology edit would otherwise alias a stable claim.
+  /// This preserves one scene-global numeric domain without relying on disjoint ranges.
   stabilizeSceneSpec(sceneSpec, identities) {
     if (sceneSpec === null || sceneSpec === undefined) {
       return sceneSpec;
     }
-    const objectIds = this.#objects.resolve(identities.objects);
-    const trackIds = this.#tracks.resolve(identities.tracks);
+    const objectIds = this.#objects.resolveCanonical(
+      identities.objects,
+      sceneSpec.objects.map(({ id }) => id),
+    );
+    const trackIds = this.#tracks.resolveCanonical(
+      identities.tracks,
+      sceneSpec.tracks.map(({ id }) => id),
+    );
     if (objectIds === null && trackIds === null) {
       return sceneSpec;
     }
@@ -70,6 +78,7 @@ export class SceneIdentityMap {
               ? track
               : { ...track, id, object };
           });
+    const familyAnimations = remapFamilyAnimationObjects(sceneSpec.family_animations, objectIds);
     const cameraObject =
       objectIds === null || sceneSpec.camera_object === null || sceneSpec.camera_object === undefined
         ? sceneSpec.camera_object
@@ -77,9 +86,18 @@ export class SceneIdentityMap {
 
     return objects === sceneSpec.objects &&
       tracks === sceneSpec.tracks &&
+      familyAnimations === sceneSpec.family_animations &&
       cameraObject === sceneSpec.camera_object
       ? sceneSpec
-      : { ...sceneSpec, objects, tracks, camera_object: cameraObject };
+      : {
+          ...sceneSpec,
+          objects,
+          tracks,
+          ...(familyAnimations === sceneSpec.family_animations
+            ? {}
+            : { family_animations: familyAnimations }),
+          camera_object: cameraObject,
+        };
   }
 }
 
@@ -102,6 +120,33 @@ function remapReactiveObjects(reactive, objectIds) {
   return changed ? { ...reactive, bindings } : reactive;
 }
 
+function remapFamilyAnimationObjects(familyAnimations, objectIds) {
+  if (objectIds === null || !Array.isArray(familyAnimations)) {
+    return familyAnimations;
+  }
+  let changed = false;
+  const remapped = familyAnimations.map((animation) => {
+    if (!Array.isArray(animation.bindings)) {
+      return animation;
+    }
+    let animationChanged = false;
+    const bindings = animation.bindings.map((binding) => {
+      const object = optionalId(objectIds, binding.object);
+      if (object === binding.object) {
+        return binding;
+      }
+      animationChanged = true;
+      return { ...binding, object };
+    });
+    if (!animationChanged) {
+      return animation;
+    }
+    changed = true;
+    return { ...animation, bindings };
+  });
+  return changed ? remapped : familyAnimations;
+}
+
 class IdentityNamespace {
   #kind;
   #keyToId = new Map();
@@ -113,27 +158,54 @@ class IdentityNamespace {
   }
 
   resolve(entries) {
-    let localToStable = null;
+    const localToStable = this.#resolveSemantic(entries);
+    for (const { id: localId } of entries) {
+      if (localToStable.get(localId) !== localId) {
+        return localToStable;
+      }
+    }
+    return null;
+  }
+
+  /// Resolve a canonical mixed ID domain containing both keyed semantic entries and
+  /// unkeyed canonical-only entries. Stable keyed claims win permanently; unkeyed
+  /// entries are displaced only when necessary and their temporary IDs are not
+  /// persisted as semantic claims.
+  resolveCanonical(entries, localIds) {
+    const localToStable = this.#resolveSemantic(entries);
+    let changed = false;
+    for (const { id: localId } of entries) {
+      if (localToStable.get(localId) !== localId) {
+        changed = true;
+      }
+    }
+
+    const currentLocalIds = new Set(localIds);
+    const usedIds = new Set(localToStable.values());
+    for (const localId of localIds) {
+      if (localToStable.has(localId)) {
+        continue;
+      }
+      let stableId = localId;
+      if (this.#idToKey.has(stableId) || usedIds.has(stableId)) {
+        stableId = this.#temporaryId(currentLocalIds, usedIds);
+        changed = true;
+      }
+      localToStable.set(localId, stableId);
+      usedIds.add(stableId);
+    }
+
+    return changed ? localToStable : null;
+  }
+
+  #resolveSemantic(entries) {
+    const localToStable = new Map();
     for (const { id: localId, key } of entries) {
       let stableId = this.#keyToId.get(key);
       if (stableId === undefined) {
         stableId = this.#claim(localId, key);
       }
-      if (stableId !== localId) {
-        localToStable ??= new Map();
-      }
-      localToStable?.set(localId, stableId);
-    }
-    if (localToStable === null) {
-      return null;
-    }
-
-    // Once one entry needs remapping, callers still need identity mappings for
-    // every other local ID referenced by the same document.
-    for (const { id: localId, key } of entries) {
-      if (!localToStable.has(localId)) {
-        localToStable.set(localId, this.#keyToId.get(key));
-      }
+      localToStable.set(localId, stableId);
     }
     return localToStable;
   }
@@ -146,13 +218,26 @@ class IdentityNamespace {
         id += 1;
       }
     }
-    if (!Number.isSafeInteger(id)) {
-      throw new Error(`No safe ${this.#kind} identity IDs remain`);
-    }
+    this.#assertSafeId(id);
     this.#keyToId.set(key, id);
     this.#idToKey.set(id, key);
     this.#nextId = Math.max(this.#nextId, id + 1);
     return id;
+  }
+
+  #temporaryId(currentLocalIds, usedIds) {
+    let id = this.#nextId;
+    while (this.#idToKey.has(id) || currentLocalIds.has(id) || usedIds.has(id)) {
+      id += 1;
+    }
+    this.#assertSafeId(id);
+    return id;
+  }
+
+  #assertSafeId(id) {
+    if (!Number.isSafeInteger(id)) {
+      throw new Error(`No safe ${this.#kind} identity IDs remain`);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Fix repeated structural playground reruns at the canonical identity boundary instead of special-casing the stress demo.

### Root cause
`SceneIdentityMap` persistently stabilizes keyed geometry object/track IDs across authoring reruns, while canonical-only IDs such as retained Text objects/tracks were left at their current source-local IDs. After a topology change, a surviving keyed identity could remap onto one of those unkeyed IDs, producing duplicate canonical SceneSpec identities (for example the observed duplicate track 9900).

### Architecture fix
- keep one scene-global numeric ID domain; do not reintroduce disjoint retained ranges
- treat keyed semantic IDs as permanent claims
- treat canonical-only IDs as provisional local IDs
- preserve a canonical-only source ID when collision-free
- move only the canonical-only ID that collides with a stable semantic claim to a temporary free ID
- do not persist that temporary ID as a semantic claim
- remap every affected object reference, including ordinary tracks, camera identity, and family-animation bindings
- preserve strict duplicate-ID validation downstream

### Regression coverage
- add a focused identity test that runs five consecutive topology shapes and verifies surviving semantic IDs remain stable while object/track IDs stay globally unique
- verify historical semantic claims cannot be stolen while their object is temporarily absent
- verify retained-track targets and family-animation bindings follow any displaced canonical-only object ID
- extend the real CodeMirror playground smoke from one structural edit to `rows=20 -> 5 -> 7 -> 20`, requiring every retained rebuild to complete without page/console errors

This is intentionally an identity-ownership fix, not a workload-specific workaround.