### PR TITLE
Fix playback smoke restart control lookup

### DIFF
--- a/scripts/playground-playback-controls-smoke.mjs
+++ b/scripts/playground-playback-controls-smoke.mjs
@@ -100,9 +100,7 @@ async function playbackSnapshot(page) {
   return page.evaluate(() => {
     const controls = document.querySelector(".playback-controls");
     const play = document.querySelector(".playback-toggle");
-    const restart = [...document.querySelectorAll(".playback-button")].find(
-      (button) => button.textContent === "Restart",
-    );
+    const restart = document.querySelector(".playback-restart");
     const scrubber = document.querySelector(".playback-scrubber");
     const time = document.querySelector(".playback-time");
     const canvas = document.querySelector("#scene");


### PR DESCRIPTION
Restores the currently failing master `Playground playback controls` gate.

The browser diagnostic shows the runtime itself is healthy (`playing=true`, `busy=false`, retained WebGL2, one persistent canvas), but the smoke reports `restartDisabled=true`. The snapshot helper was locating restart by visible text `Restart`; the control intentionally renders the compact `↺` glyph and exposes its stable semantic hook as `.playback-restart` plus an accessible name. As a result, the helper found no element and defaulted `restartDisabled` to `true` before exercising the rest of the playback contract.

This changes only the diagnostic lookup to the dedicated `.playback-restart` class. It does not alter playback behavior, timing, rendering, or UI copy, and keeps the smoke independent of presentation text.

Validation target: PR Fast Gate plus the dedicated `Playground playback controls` browser workflow. Remaining risk is limited to CI/browser flakiness unrelated to this selector; the failing master artifact has no page or console errors and points directly at this assertion.