### PR TITLE
Preserve retained text locality in mixed renderer

### DIFF
--- a/crates/noon-render-wgpu/Cargo.toml
+++ b/crates/noon-render-wgpu/Cargo.toml
@@ -38,3 +38,4 @@ wgpu = { version = "29.0.3", default-features = false, features = ["std", "wgsl"
 
 [dev-dependencies]
 noon-compile = { path = "../noon-compile" }
+noon-typst = { path = "../noon-typst" }

--- a/crates/noon-render-wgpu/src/gpu.rs
+++ b/crates/noon-render-wgpu/src/gpu.rs
@@ -20,3 +20,7 @@ pub use retained_family_reveal::*;
 #[path = "gpu/retained_family_draw_border_then_fill.rs"]
 mod retained_family_draw_border_then_fill;
 pub use retained_family_draw_border_then_fill::*;
+
+#[path = "gpu/retained_family_reveal_scene.rs"]
+mod retained_family_reveal_scene;
+pub use retained_family_reveal_scene::*;

--- a/crates/noon-render-wgpu/src/gpu/retained_family_draw_border_prepare.rs
+++ b/crates/noon-render-wgpu/src/gpu/retained_family_draw_border_prepare.rs
@@ -142,6 +142,10 @@ impl RetainedFramePreparer {
             &self.snapshot_text_items,
             &geometry,
         );
+        self.incremental_stats.mixed_order_rebuilds = self
+            .incremental_stats
+            .mixed_order_rebuilds
+            .saturating_add(1);
         let glyph_batches = self
             .render_items
             .iter()
@@ -172,6 +176,9 @@ impl RetainedFramePreparer {
             items: &self.snapshot_text_items,
             stats: self.snapshot_text_stats,
             atlas: self.text.atlas(),
+            partial_upload: false,
+            dirty_mask_ranges: &self.dirty_mask_ranges,
+            dirty_color_ranges: &self.dirty_color_ranges,
         };
         Ok(PreparedRetainedGpuFrame {
             geometry,

--- a/crates/noon-render-wgpu/src/gpu/retained_family_draw_border_prepare.rs
+++ b/crates/noon-render-wgpu/src/gpu/retained_family_draw_border_prepare.rs
@@ -176,7 +176,7 @@ impl RetainedFramePreparer {
             items: &self.snapshot_text_items,
             stats: self.snapshot_text_stats,
             atlas: self.text.atlas(),
-            partial_upload: false,
+            partial_upload_base_generation: None,
             dirty_mask_ranges: &self.dirty_mask_ranges,
             dirty_color_ranges: &self.dirty_color_ranges,
         };

--- a/crates/noon-render-wgpu/src/gpu/retained_family_plan_set_prepare.rs
+++ b/crates/noon-render-wgpu/src/gpu/retained_family_plan_set_prepare.rs
@@ -123,7 +123,7 @@ impl RetainedFramePreparer {
             items: &self.snapshot_text_items,
             stats: self.snapshot_text_stats,
             atlas: self.text.atlas(),
-            partial_upload: false,
+            partial_upload_base_generation: None,
             dirty_mask_ranges: &self.dirty_mask_ranges,
             dirty_color_ranges: &self.dirty_color_ranges,
         };

--- a/crates/noon-render-wgpu/src/gpu/retained_family_plan_set_prepare.rs
+++ b/crates/noon-render-wgpu/src/gpu/retained_family_plan_set_prepare.rs
@@ -92,6 +92,10 @@ impl RetainedFramePreparer {
             &self.snapshot_text_items,
             &geometry,
         );
+        self.incremental_stats.mixed_order_rebuilds = self
+            .incremental_stats
+            .mixed_order_rebuilds
+            .saturating_add(1);
         let glyph_batches = self
             .render_items
             .iter()
@@ -119,6 +123,9 @@ impl RetainedFramePreparer {
             items: &self.snapshot_text_items,
             stats: self.snapshot_text_stats,
             atlas: self.text.atlas(),
+            partial_upload: false,
+            dirty_mask_ranges: &self.dirty_mask_ranges,
+            dirty_color_ranges: &self.dirty_color_ranges,
         };
         Ok(PreparedRetainedGpuFrame {
             geometry,

--- a/crates/noon-render-wgpu/src/gpu/retained_family_prepare.rs
+++ b/crates/noon-render-wgpu/src/gpu/retained_family_prepare.rs
@@ -186,7 +186,7 @@ impl RetainedFramePreparer {
             items: &self.snapshot_text_items,
             stats: self.snapshot_text_stats,
             atlas: self.text.atlas(),
-            partial_upload: false,
+            partial_upload_base_generation: None,
             dirty_mask_ranges: &self.dirty_mask_ranges,
             dirty_color_ranges: &self.dirty_color_ranges,
         };

--- a/crates/noon-render-wgpu/src/gpu/retained_family_prepare.rs
+++ b/crates/noon-render-wgpu/src/gpu/retained_family_prepare.rs
@@ -151,6 +151,10 @@ impl RetainedFramePreparer {
             &self.snapshot_text_items,
             &geometry,
         );
+        self.incremental_stats.mixed_order_rebuilds = self
+            .incremental_stats
+            .mixed_order_rebuilds
+            .saturating_add(1);
         let glyph_batches = self
             .render_items
             .iter()
@@ -182,6 +186,9 @@ impl RetainedFramePreparer {
             items: &self.snapshot_text_items,
             stats: self.snapshot_text_stats,
             atlas: self.text.atlas(),
+            partial_upload: false,
+            dirty_mask_ranges: &self.dirty_mask_ranges,
+            dirty_color_ranges: &self.dirty_color_ranges,
         };
         Ok(PreparedRetainedGpuFrame {
             geometry,

--- a/crates/noon-render-wgpu/src/gpu/retained_family_reveal_scene.rs
+++ b/crates/noon-render-wgpu/src/gpu/retained_family_reveal_scene.rs
@@ -101,7 +101,8 @@ impl<'content> RetainedFamilyRevealSceneFrame<'_, '_, 'content> {
             .leaf_frame_for_object(state, object)
             .map_err(RetainedFamilyRevealSceneError::Evaluation)?;
         Ok(Some(
-            retained_family_reveal_members(frame).map_err(RetainedFamilyRevealSceneError::Reveal)?,
+            retained_family_reveal_members(frame)
+                .map_err(RetainedFamilyRevealSceneError::Reveal)?,
         ))
     }
 }
@@ -191,7 +192,10 @@ mod tests {
         ];
         let frame = scene.frame(&states).unwrap();
 
-        assert!(frame.members_for_object(ObjectId::new(99)).unwrap().is_none());
+        assert!(frame
+            .members_for_object(ObjectId::new(99))
+            .unwrap()
+            .is_none());
         let first_members = frame
             .members_for_object(ObjectId::new(10))
             .unwrap()
@@ -259,9 +263,7 @@ mod tests {
         assert!(matches!(
             frame.members_for_object(ObjectId::new(10)),
             Err(RetainedFamilyRevealSceneError::Reveal(
-                RetainedFamilyRevealError::UnsupportedMode(
-                    FamilyAnimationMode::DrawBorderThenFill
-                )
+                RetainedFamilyRevealError::UnsupportedMode(FamilyAnimationMode::DrawBorderThenFill)
             ))
         ));
     }

--- a/crates/noon-render-wgpu/src/gpu/retained_family_reveal_scene.rs
+++ b/crates/noon-render-wgpu/src/gpu/retained_family_reveal_scene.rs
@@ -1,0 +1,268 @@
+use std::collections::HashMap;
+
+use noon_core::{
+    FamilyAnimationState, ObjectId, RetainedFamilyAnimationEvaluationError,
+    RetainedFamilyAnimationPlan,
+};
+
+use super::{
+    retained_family_reveal_members, RetainedFamilyRevealError, RetainedFamilyRevealMembers,
+};
+
+/// Prepared scene-level binding for a set of concurrently active family animations.
+///
+/// This index is rebuilt only when the active animation set changes, not every frame.
+/// It maps each retained leaf to exactly one prepared family plan so the mixed retained
+/// renderer can resolve family realization in O(1) while it already walks objects in
+/// painter order. Family timing state intentionally stays out of this immutable index.
+#[derive(Clone, Debug)]
+pub struct RetainedFamilyRevealScenePlan<'a> {
+    plans: Vec<&'a RetainedFamilyAnimationPlan>,
+    plan_by_object: HashMap<ObjectId, usize>,
+}
+
+impl<'a> RetainedFamilyRevealScenePlan<'a> {
+    pub fn new(
+        plans: impl IntoIterator<Item = &'a RetainedFamilyAnimationPlan>,
+    ) -> Result<Self, RetainedFamilyRevealSceneError> {
+        let mut retained_plans = Vec::new();
+        let mut plan_by_object = HashMap::new();
+        for plan in plans {
+            let plan_index = retained_plans.len();
+            for leaf in plan.leaves() {
+                let object = leaf.span().object;
+                if let Some(&first_animation) = plan_by_object.get(&object) {
+                    return Err(RetainedFamilyRevealSceneError::OverlappingObject {
+                        object,
+                        first_animation,
+                        second_animation: plan_index,
+                    });
+                }
+                plan_by_object.insert(object, plan_index);
+            }
+            retained_plans.push(plan);
+        }
+        Ok(Self {
+            plans: retained_plans,
+            plan_by_object,
+        })
+    }
+
+    pub fn animation_count(&self) -> usize {
+        self.plans.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.plans.is_empty()
+    }
+
+    /// Borrow this immutable binding with the timing states for one frame.
+    ///
+    /// The state slice is parallel to the plan order supplied to [`Self::new`]. No map
+    /// or member metadata is rebuilt as progress advances.
+    pub fn frame<'plan, 'state>(
+        &'plan self,
+        states: &'state [FamilyAnimationState],
+    ) -> Result<RetainedFamilyRevealSceneFrame<'plan, 'state, 'a>, RetainedFamilyRevealSceneError>
+    {
+        if states.len() != self.plans.len() {
+            return Err(RetainedFamilyRevealSceneError::StateCountMismatch {
+                expected: self.plans.len(),
+                actual: states.len(),
+            });
+        }
+        Ok(RetainedFamilyRevealSceneFrame { plan: self, states })
+    }
+}
+
+/// Allocation-free frame view over an immutable active-family scene plan.
+#[derive(Clone, Copy, Debug)]
+pub struct RetainedFamilyRevealSceneFrame<'plan, 'state, 'content> {
+    plan: &'plan RetainedFamilyRevealScenePlan<'content>,
+    states: &'state [FamilyAnimationState],
+}
+
+impl<'content> RetainedFamilyRevealSceneFrame<'_, '_, 'content> {
+    /// Resolve already-prepared realization commands for one retained object.
+    ///
+    /// `None` means the object is outside every active family animation. A returned
+    /// iterator performs only leaf-local realization; global lag/easing/reversal was
+    /// evaluated by the shared family plan before this renderer boundary.
+    pub fn members_for_object(
+        &self,
+        object: ObjectId,
+    ) -> Result<Option<RetainedFamilyRevealMembers<'content>>, RetainedFamilyRevealSceneError> {
+        let Some(&plan_index) = self.plan.plan_by_object.get(&object) else {
+            return Ok(None);
+        };
+        let plan = self.plan.plans[plan_index];
+        let state = self.states[plan_index];
+        let frame = plan
+            .leaf_frame_for_object(state, object)
+            .map_err(RetainedFamilyRevealSceneError::Evaluation)?;
+        Ok(Some(
+            retained_family_reveal_members(frame).map_err(RetainedFamilyRevealSceneError::Reveal)?,
+        ))
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum RetainedFamilyRevealSceneError {
+    OverlappingObject {
+        object: ObjectId,
+        first_animation: usize,
+        second_animation: usize,
+    },
+    StateCountMismatch {
+        expected: usize,
+        actual: usize,
+    },
+    Evaluation(RetainedFamilyAnimationEvaluationError),
+    Reveal(RetainedFamilyRevealError),
+}
+
+impl std::fmt::Display for RetainedFamilyRevealSceneError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::OverlappingObject {
+                object,
+                first_animation,
+                second_animation,
+            } => write!(
+                formatter,
+                "family animations {first_animation} and {second_animation} both target retained object {}",
+                object.get()
+            ),
+            Self::StateCountMismatch { expected, actual } => write!(
+                formatter,
+                "retained family reveal scene expects {expected} animation states, got {actual}"
+            ),
+            Self::Evaluation(error) => error.fmt(formatter),
+            Self::Reveal(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl std::error::Error for RetainedFamilyRevealSceneError {}
+
+#[cfg(test)]
+mod tests {
+    use noon_core::{
+        FamilyAnimationMode, GeometryRef, RateFunction, RetainedFamilyAnimationPlanBuilder,
+        RetainedObjectDefinition, SemanticStore, TextResourceArena,
+    };
+
+    use super::*;
+    use crate::RetainedFamilyRevealMember;
+
+    fn state(mode: FamilyAnimationMode, progress: f64) -> FamilyAnimationState {
+        FamilyAnimationState {
+            mode,
+            overall_progress: progress,
+            lag_ratio: 0.0,
+            rate_function: RateFunction::Linear,
+            reverse_rate_function: false,
+            reverse_member_order: false,
+        }
+    }
+
+    fn geometry_plan(object: ObjectId) -> RetainedFamilyAnimationPlan {
+        let mut store = SemanticStore::new();
+        let leaf = store.insert_authoring_object();
+        let family = store.insert_family();
+        store.add_member(family, leaf).unwrap();
+
+        let object = RetainedObjectDefinition::geometry(object, GeometryRef::circle(1.0));
+        let mut builder = RetainedFamilyAnimationPlanBuilder::begin(&store, family).unwrap();
+        builder
+            .accept_leaf(leaf, &object, &TextResourceArena::new())
+            .unwrap();
+        builder.finish().unwrap()
+    }
+
+    #[test]
+    fn frame_lookup_is_object_addressable_across_distinct_plans() {
+        let first = geometry_plan(ObjectId::new(10));
+        let second = geometry_plan(ObjectId::new(20));
+        let scene = RetainedFamilyRevealScenePlan::new([&first, &second]).unwrap();
+        let states = [
+            state(FamilyAnimationMode::Reveal, 0.25),
+            state(FamilyAnimationMode::Reveal, 0.75),
+        ];
+        let frame = scene.frame(&states).unwrap();
+
+        assert!(frame.members_for_object(ObjectId::new(99)).unwrap().is_none());
+        let first_members = frame
+            .members_for_object(ObjectId::new(10))
+            .unwrap()
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        let second_members = frame
+            .members_for_object(ObjectId::new(20))
+            .unwrap()
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(
+            first_members,
+            vec![RetainedFamilyRevealMember::Geometry {
+                object: ObjectId::new(10),
+                reveal: 0.25,
+            }]
+        );
+        assert_eq!(
+            second_members,
+            vec![RetainedFamilyRevealMember::Geometry {
+                object: ObjectId::new(20),
+                reveal: 0.75,
+            }]
+        );
+    }
+
+    #[test]
+    fn overlapping_plan_ownership_fails_when_active_set_is_built() {
+        let first = geometry_plan(ObjectId::new(10));
+        let second = geometry_plan(ObjectId::new(10));
+        assert_eq!(
+            RetainedFamilyRevealScenePlan::new([&first, &second]).unwrap_err(),
+            RetainedFamilyRevealSceneError::OverlappingObject {
+                object: ObjectId::new(10),
+                first_animation: 0,
+                second_animation: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn frame_requires_one_state_per_prepared_plan() {
+        let first = geometry_plan(ObjectId::new(10));
+        let second = geometry_plan(ObjectId::new(20));
+        let scene = RetainedFamilyRevealScenePlan::new([&first, &second]).unwrap();
+        assert_eq!(
+            scene
+                .frame(&[state(FamilyAnimationMode::Reveal, 0.5)])
+                .unwrap_err(),
+            RetainedFamilyRevealSceneError::StateCountMismatch {
+                expected: 2,
+                actual: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn unsupported_operation_is_not_silently_treated_as_reveal() {
+        let plan = geometry_plan(ObjectId::new(10));
+        let scene = RetainedFamilyRevealScenePlan::new([&plan]).unwrap();
+        let states = [state(FamilyAnimationMode::DrawBorderThenFill, 0.5)];
+        let frame = scene.frame(&states).unwrap();
+        assert!(matches!(
+            frame.members_for_object(ObjectId::new(10)),
+            Err(RetainedFamilyRevealSceneError::Reveal(
+                RetainedFamilyRevealError::UnsupportedMode(
+                    FamilyAnimationMode::DrawBorderThenFill
+                )
+            ))
+        ));
+    }
+}

--- a/crates/noon-render-wgpu/src/gpu/retained_text.rs
+++ b/crates/noon-render-wgpu/src/gpu/retained_text.rs
@@ -69,12 +69,15 @@ pub struct RetainedPrepareStats {
 /// Cumulative counters for retained mixed-frame preparation locality.
 ///
 /// A scratch reuse means the semantic object/text/vector/outline walk was skipped.
-/// Mixed-order rebuilding and text snapshot copies remain separate follow-up costs
-/// and are intentionally not hidden by this counter.
+/// Text snapshot copies and mixed-order rebuilds are counted separately so a
+/// transform/opacity-only text update can prove that both parent-level scans stay
+/// out of the frame loop.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct RetainedFrameIncrementalStats {
     pub scratch_rebuilds: u64,
     pub scratch_reuses: u64,
+    pub text_snapshot_copies: u64,
+    pub mixed_order_rebuilds: u64,
 }
 
 pub struct PreparedRetainedTextSnapshot<'a> {
@@ -84,6 +87,9 @@ pub struct PreparedRetainedTextSnapshot<'a> {
     pub items: &'a [PreparedTextItem],
     pub stats: RetainedTextPrepareStats,
     pub atlas: &'a GpuGlyphAtlas,
+    pub partial_upload: bool,
+    pub dirty_mask_ranges: &'a [std::ops::Range<u32>],
+    pub dirty_color_ranges: &'a [std::ops::Range<u32>],
 }
 
 impl PreparedRetainedTextSnapshot<'_> {
@@ -546,6 +552,9 @@ pub struct RetainedFramePreparer {
     snapshot_color_quads: Vec<GlyphQuadInstance>,
     snapshot_text_items: Vec<PreparedTextItem>,
     snapshot_text_stats: RetainedTextPrepareStats,
+    text_item_ranges: Vec<std::ops::Range<usize>>,
+    dirty_mask_ranges: Vec<std::ops::Range<u32>>,
+    dirty_color_ranges: Vec<std::ops::Range<u32>>,
     snapshot_prepare_stats: RetainedPrepareStats,
     snapshot_metrics: Option<TextDeviceMetrics>,
     prepared_generation_ready: bool,
@@ -576,6 +585,9 @@ impl Default for RetainedFramePreparer {
             snapshot_color_quads: Vec::new(),
             snapshot_text_items: Vec::new(),
             snapshot_text_stats: RetainedTextPrepareStats::default(),
+            text_item_ranges: Vec::new(),
+            dirty_mask_ranges: Vec::new(),
+            dirty_color_ranges: Vec::new(),
             snapshot_prepare_stats: RetainedPrepareStats::default(),
             snapshot_metrics: None,
             prepared_generation_ready: false,
@@ -641,10 +653,24 @@ impl RetainedFramePreparer {
         geometries: &GeometryResourceArena,
         metrics: TextDeviceMetrics,
     ) -> Result<PreparedRetainedGpuFrame<'a>, RetainedPrepareError> {
+        let text_can_update_locally = if changes.is_empty() {
+            false
+        } else {
+            self.text.can_update_objects_locally(frame, changes, texts, metrics)?
+                && self.changes_are_fast_text_only(frame, changes)
+        };
         let scratch_reused =
-            self.prepare_scratch_with_changes(frame, changes, texts, fonts, geometries)?;
+            self.prepare_scratch_with_changes(
+                frame,
+                changes,
+                text_can_update_locally,
+                texts,
+                fonts,
+                geometries,
+            )?;
 
         if scratch_reused
+            && changes.is_empty()
             && self.prepared_generation_ready
             && self.snapshot_metrics == Some(metrics)
         {
@@ -654,15 +680,13 @@ impl RetainedFramePreparer {
             // Invalidate the parent generation first so any future fallible change in
             // that contract cannot expose stale snapshots.
             self.prepared_generation_ready = false;
-            {
-                let prepared = self
-                    .text
-                    .prepare_with_changes(device, queue, frame, changes, texts, fonts, metrics)?;
-                debug_assert_eq!(prepared.mask_quads.len(), self.snapshot_mask_quads.len());
-                debug_assert_eq!(prepared.color_quads.len(), self.snapshot_color_quads.len());
-                debug_assert_eq!(prepared.items.len(), self.snapshot_text_items.len());
-                debug_assert_eq!(prepared.stats, self.snapshot_text_stats);
-            }
+            let prepared = self
+                .text
+                .prepare_with_changes(device, queue, frame, changes, texts, fonts, metrics)?;
+            debug_assert_eq!(prepared.mask_quads.len(), self.snapshot_mask_quads.len());
+            debug_assert_eq!(prepared.color_quads.len(), self.snapshot_color_quads.len());
+            debug_assert_eq!(prepared.items.len(), self.snapshot_text_items.len());
+            debug_assert_eq!(prepared.stats, self.snapshot_text_stats);
 
             let no_changes = FrameChanges::default();
             let geometry = self
@@ -677,6 +701,54 @@ impl RetainedFramePreparer {
                 items: &self.snapshot_text_items,
                 stats: self.snapshot_text_stats,
                 atlas: self.text.atlas(),
+                partial_upload: false,
+                dirty_mask_ranges: &self.dirty_mask_ranges,
+                dirty_color_ranges: &self.dirty_color_ranges,
+            };
+            return Ok(PreparedRetainedGpuFrame {
+                geometry,
+                text_generation: self.text_generation,
+                text,
+                render_items: &self.render_items,
+                stats: self.snapshot_prepare_stats,
+            });
+        }
+
+        if text_can_update_locally {
+            self.prepared_generation_ready = false;
+            let prepared = self
+                .text
+                .prepare_with_changes(device, queue, frame, changes, texts, fonts, metrics)?;
+            copy_local_text_snapshot_updates(
+                &mut self.snapshot_mask_quads,
+                &mut self.snapshot_color_quads,
+                &self.text_item_ranges,
+                prepared.items,
+                prepared.mask_quads,
+                prepared.color_quads,
+                changes,
+                &mut self.dirty_mask_ranges,
+                &mut self.dirty_color_ranges,
+            );
+            self.text_generation = self
+                .text_generation
+                .checked_add(1)
+                .expect("retained text generation counter exhausted");
+            let no_changes = FrameChanges::default();
+            let geometry = self
+                .geometry
+                .prepare_incremental(&self.scratch, &no_changes);
+            self.prepared_generation_ready = true;
+            let text = PreparedRetainedTextSnapshot {
+                time: frame.time,
+                mask_quads: &self.snapshot_mask_quads,
+                color_quads: &self.snapshot_color_quads,
+                items: &self.snapshot_text_items,
+                stats: self.snapshot_text_stats,
+                atlas: self.text.atlas(),
+                partial_upload: true,
+                dirty_mask_ranges: &self.dirty_mask_ranges,
+                dirty_color_ranges: &self.dirty_color_ranges,
             };
             return Ok(PreparedRetainedGpuFrame {
                 geometry,
@@ -708,7 +780,14 @@ impl RetainedFramePreparer {
             self.snapshot_text_items.clear();
             self.snapshot_text_items.extend_from_slice(prepared.items);
             self.snapshot_text_stats = prepared.stats;
+            self.text_item_ranges = text_item_ranges(prepared.items, frame.objects.len());
         }
+        self.dirty_mask_ranges.clear();
+        self.dirty_color_ranges.clear();
+        self.incremental_stats.text_snapshot_copies = self
+            .incremental_stats
+            .text_snapshot_copies
+            .saturating_add(1);
         self.text_generation = self
             .text_generation
             .checked_add(1)
@@ -728,6 +807,10 @@ impl RetainedFramePreparer {
             &self.snapshot_text_items,
             &geometry,
         );
+        self.incremental_stats.mixed_order_rebuilds = self
+            .incremental_stats
+            .mixed_order_rebuilds
+            .saturating_add(1);
         let glyph_batches = self
             .render_items
             .iter()
@@ -753,6 +836,9 @@ impl RetainedFramePreparer {
             items: &self.snapshot_text_items,
             stats: self.snapshot_text_stats,
             atlas: self.text.atlas(),
+            partial_upload: false,
+            dirty_mask_ranges: &self.dirty_mask_ranges,
+            dirty_color_ranges: &self.dirty_color_ranges,
         };
         Ok(PreparedRetainedGpuFrame {
             geometry,
@@ -767,12 +853,13 @@ impl RetainedFramePreparer {
         &mut self,
         frame: &RetainedFrameState,
         changes: &FrameChanges,
+        text_only_local: bool,
         texts: &TextResourceArena,
         fonts: &FontResourceArena,
         geometries: &GeometryResourceArena,
     ) -> Result<bool, RetainedPrepareError> {
         if self.scratch_ready
-            && changes.is_empty()
+            && (changes.is_empty() || text_only_local)
             && frame.objects.len() == self.scratch_object_count
         {
             self.scratch.time = frame.time;
@@ -791,6 +878,28 @@ impl RetainedFramePreparer {
         self.incremental_stats.scratch_rebuilds =
             self.incremental_stats.scratch_rebuilds.saturating_add(1);
         Ok(false)
+    }
+
+    fn changes_are_fast_text_only(
+        &self,
+        frame: &RetainedFrameState,
+        changes: &FrameChanges,
+    ) -> bool {
+        if changes.is_all() || changes.is_structural() || changes.is_empty() {
+            return false;
+        }
+        changes.object_indices().iter().all(|&index| {
+            let Some(object) = frame.objects.get(index) else {
+                return false;
+            };
+            if !frame.is_present(index) || !matches!(&object.content, ObjectContentRef::Text(_)) {
+                return false;
+            }
+            self.sources.iter().filter(|source| match source {
+                SourceItem::FastGlyphRun { object_id, .. } => *object_id == object.id,
+                SourceItem::Geometry { object_id, .. } => *object_id == object.id,
+            }).all(|source| matches!(source, SourceItem::FastGlyphRun { .. }))
+        })
     }
 
     fn build_scratch_frame(
@@ -1026,6 +1135,80 @@ impl RetainedFramePreparer {
         }
         Ok(())
     }
+}
+
+fn text_item_ranges(
+    items: &[PreparedTextItem],
+    object_count: usize,
+) -> Vec<std::ops::Range<usize>> {
+    let mut ranges = vec![0..0; object_count];
+    for (item_index, item) in items.iter().enumerate() {
+        let object_index = item.object_index() as usize;
+        let Some(range) = ranges.get_mut(object_index) else {
+            continue;
+        };
+        if range.start == range.end {
+            range.start = item_index;
+        }
+        range.end = item_index + 1;
+    }
+    ranges
+}
+
+#[allow(clippy::too_many_arguments)]
+fn copy_local_text_snapshot_updates(
+    mask_destination: &mut [GlyphQuadInstance],
+    color_destination: &mut [GlyphQuadInstance],
+    item_ranges: &[std::ops::Range<usize>],
+    items: &[PreparedTextItem],
+    mask_source: &[GlyphQuadInstance],
+    color_source: &[GlyphQuadInstance],
+    changes: &FrameChanges,
+    dirty_mask_ranges: &mut Vec<std::ops::Range<u32>>,
+    dirty_color_ranges: &mut Vec<std::ops::Range<u32>>,
+) {
+    dirty_mask_ranges.clear();
+    dirty_color_ranges.clear();
+    for &object_index in changes.object_indices() {
+        let Some(item_range) = item_ranges.get(object_index) else {
+            continue;
+        };
+        for item in &items[item_range.clone()] {
+            let PreparedTextItem::GlyphBatch {
+                plane,
+                instance_range,
+                ..
+            } = item
+            else {
+                continue;
+            };
+            let start = instance_range.start as usize;
+            let end = instance_range.end as usize;
+            match plane {
+                noon_text_atlas::GlyphAtlasPlane::Mask => {
+                    mask_destination[start..end].copy_from_slice(&mask_source[start..end]);
+                    push_coalesced_range(dirty_mask_ranges, instance_range.clone());
+                }
+                noon_text_atlas::GlyphAtlasPlane::Color => {
+                    color_destination[start..end].copy_from_slice(&color_source[start..end]);
+                    push_coalesced_range(dirty_color_ranges, instance_range.clone());
+                }
+            }
+        }
+    }
+}
+
+fn push_coalesced_range(ranges: &mut Vec<std::ops::Range<u32>>, range: std::ops::Range<u32>) {
+    if range.start == range.end {
+        return;
+    }
+    if let Some(previous) = ranges.last_mut() {
+        if range.start <= previous.end {
+            previous.end = previous.end.max(range.end);
+            return;
+        }
+    }
+    ranges.push(range);
 }
 
 fn geometry_kind(geometry: &GeometryRef) -> ScratchGeometryKind {
@@ -1378,10 +1561,20 @@ impl GpuRenderer {
             prepared.text_generation,
         ) {
             let text_frame = prepared.text.as_prepared_frame();
-            let uploaded =
+            let uploaded = if prepared.text.partial_upload {
+                text_state.glyphs.upload_ranges(
+                    device,
+                    queue,
+                    &text_frame,
+                    prepared.text.atlas,
+                    prepared.text.dirty_mask_ranges,
+                    prepared.text.dirty_color_ranges,
+                )
+            } else {
                 text_state
                     .glyphs
-                    .upload(device, queue, &text_frame, prepared.text.atlas);
+                    .upload(device, queue, &text_frame, prepared.text.atlas)
+            };
             text_state.last_uploaded_generation = Some(prepared.text_generation);
             uploaded
         } else {
@@ -1723,6 +1916,8 @@ mod tests {
             RetainedFrameIncrementalStats {
                 scratch_rebuilds: 1,
                 scratch_reuses: 0,
+                text_snapshot_copies: 1,
+                mixed_order_rebuilds: 1,
             }
         );
         let outline_stats = preparer.outline_cache_stats();
@@ -1754,6 +1949,8 @@ mod tests {
             RetainedFrameIncrementalStats {
                 scratch_rebuilds: 1,
                 scratch_reuses: 1,
+                text_snapshot_copies: 1,
+                mixed_order_rebuilds: 1,
             }
         );
         assert_eq!(preparer.outline_cache_stats(), outline_stats);

--- a/crates/noon-render-wgpu/src/gpu/retained_text.rs
+++ b/crates/noon-render-wgpu/src/gpu/retained_text.rs
@@ -87,7 +87,9 @@ pub struct PreparedRetainedTextSnapshot<'a> {
     pub items: &'a [PreparedTextItem],
     pub stats: RetainedTextPrepareStats,
     pub atlas: &'a GpuGlyphAtlas,
-    pub partial_upload: bool,
+    /// The text generation whose GPU contents a partial update assumes are resident.
+    /// `None` means the snapshot requires the full-upload path.
+    pub partial_upload_base_generation: Option<u64>,
     pub dirty_mask_ranges: &'a [std::ops::Range<u32>],
     pub dirty_color_ranges: &'a [std::ops::Range<u32>],
 }
@@ -553,6 +555,7 @@ pub struct RetainedFramePreparer {
     snapshot_text_items: Vec<PreparedTextItem>,
     snapshot_text_stats: RetainedTextPrepareStats,
     text_item_ranges: Vec<std::ops::Range<usize>>,
+    fast_text_only: Vec<bool>,
     dirty_mask_ranges: Vec<std::ops::Range<u32>>,
     dirty_color_ranges: Vec<std::ops::Range<u32>>,
     snapshot_prepare_stats: RetainedPrepareStats,
@@ -586,6 +589,7 @@ impl Default for RetainedFramePreparer {
             snapshot_text_items: Vec::new(),
             snapshot_text_stats: RetainedTextPrepareStats::default(),
             text_item_ranges: Vec::new(),
+            fast_text_only: Vec::new(),
             dirty_mask_ranges: Vec::new(),
             dirty_color_ranges: Vec::new(),
             snapshot_prepare_stats: RetainedPrepareStats::default(),
@@ -701,7 +705,7 @@ impl RetainedFramePreparer {
                 items: &self.snapshot_text_items,
                 stats: self.snapshot_text_stats,
                 atlas: self.text.atlas(),
-                partial_upload: false,
+                partial_upload_base_generation: None,
                 dirty_mask_ranges: &self.dirty_mask_ranges,
                 dirty_color_ranges: &self.dirty_color_ranges,
             };
@@ -716,6 +720,7 @@ impl RetainedFramePreparer {
 
         if text_can_update_locally {
             self.prepared_generation_ready = false;
+            let partial_upload_base_generation = self.text_generation;
             let prepared = self
                 .text
                 .prepare_with_changes(device, queue, frame, changes, texts, fonts, metrics)?;
@@ -746,7 +751,7 @@ impl RetainedFramePreparer {
                 items: &self.snapshot_text_items,
                 stats: self.snapshot_text_stats,
                 atlas: self.text.atlas(),
-                partial_upload: true,
+                partial_upload_base_generation: Some(partial_upload_base_generation),
                 dirty_mask_ranges: &self.dirty_mask_ranges,
                 dirty_color_ranges: &self.dirty_color_ranges,
             };
@@ -836,7 +841,7 @@ impl RetainedFramePreparer {
             items: &self.snapshot_text_items,
             stats: self.snapshot_text_stats,
             atlas: self.text.atlas(),
-            partial_upload: false,
+            partial_upload_base_generation: None,
             dirty_mask_ranges: &self.dirty_mask_ranges,
             dirty_color_ranges: &self.dirty_color_ranges,
         };
@@ -885,7 +890,11 @@ impl RetainedFramePreparer {
         frame: &RetainedFrameState,
         changes: &FrameChanges,
     ) -> bool {
-        if changes.is_all() || changes.is_structural() || changes.is_empty() {
+        if !self.scratch_ready
+            || changes.is_all()
+            || changes.is_structural()
+            || changes.is_empty()
+        {
             return false;
         }
         changes.object_indices().iter().all(|&index| {
@@ -895,10 +904,7 @@ impl RetainedFramePreparer {
             if !frame.is_present(index) || !matches!(&object.content, ObjectContentRef::Text(_)) {
                 return false;
             }
-            self.sources.iter().filter(|source| match source {
-                SourceItem::FastGlyphRun { object_id, .. } => *object_id == object.id,
-                SourceItem::Geometry { object_id, .. } => *object_id == object.id,
-            }).all(|source| matches!(source, SourceItem::FastGlyphRun { .. }))
+            self.fast_text_only.get(index).copied().unwrap_or(false)
         })
     }
 
@@ -916,6 +922,8 @@ impl RetainedFramePreparer {
         self.scratch.morphs.clear();
         self.scratch.render_geometries.clear();
         self.sources.clear();
+        self.fast_text_only.clear();
+        self.fast_text_only.resize(frame.objects.len(), false);
 
         for (object_index, object) in frame.objects.iter().enumerate() {
             if !frame.is_present(object_index) {
@@ -935,6 +943,7 @@ impl RetainedFramePreparer {
                     );
                 }
                 ObjectContentRef::Text(handle) => {
+                    let mut fast_text_only = true;
                     let resource = texts
                         .get(*handle)
                         .ok_or(RetainedPrepareError::MissingTextResource)?;
@@ -947,6 +956,7 @@ impl RetainedFramePreparer {
                             TextRenderItem::GlyphRun(run_index) => {
                                 let run = &resource.runs[run_index as usize];
                                 if run.stroke.is_some() || reveal < 1.0 || morph != 0.0 {
+                                    fast_text_only = false;
                                     self.push_outline_run(
                                         object.id,
                                         object.transform,
@@ -966,6 +976,7 @@ impl RetainedFramePreparer {
                                 }
                             }
                             TextRenderItem::Vector(vector_index) => {
+                                fast_text_only = false;
                                 let vector = &resource.vector_items[vector_index as usize];
                                 self.push_text_vector(
                                     object.id,
@@ -980,6 +991,7 @@ impl RetainedFramePreparer {
                             }
                         }
                     }
+                    self.fast_text_only[object_index] = fast_text_only;
                 }
             }
         }
@@ -1561,7 +1573,10 @@ impl GpuRenderer {
             prepared.text_generation,
         ) {
             let text_frame = prepared.text.as_prepared_frame();
-            let uploaded = if prepared.text.partial_upload {
+            let uploaded = if prepared.text.partial_upload_base_generation.is_some()
+                && prepared.text.partial_upload_base_generation
+                    == text_state.last_uploaded_generation
+            {
                 text_state.glyphs.upload_ranges(
                     device,
                     queue,

--- a/crates/noon-render-wgpu/tests/retained_scratch_reuse.rs
+++ b/crates/noon-render-wgpu/tests/retained_scratch_reuse.rs
@@ -52,6 +52,8 @@ fn failed_scratch_rebuild_cannot_be_reused_by_empty_changes() {
         RetainedFrameIncrementalStats {
             scratch_rebuilds: 1,
             scratch_reuses: 0,
+            text_snapshot_copies: 1,
+            mixed_order_rebuilds: 1,
         }
     );
 
@@ -91,6 +93,8 @@ fn failed_scratch_rebuild_cannot_be_reused_by_empty_changes() {
         RetainedFrameIncrementalStats {
             scratch_rebuilds: 1,
             scratch_reuses: 0,
+            text_snapshot_copies: 1,
+            mixed_order_rebuilds: 1,
         }
     );
 }

--- a/crates/noon-render-wgpu/tests/retained_static_frame_locality.rs
+++ b/crates/noon-render-wgpu/tests/retained_static_frame_locality.rs
@@ -1,10 +1,11 @@
 use noon_core::{
     FontResourceArena, GeometryRef, GeometryResourceArena, ObjectContentRef, ObjectId, Style,
-    TextResourceArena, Transform2D,
+    TextResourceArena, Transform2D, Vec2,
 };
-use noon_render_wgpu::{RetainedFrameIncrementalStats, RetainedFramePreparer};
+use noon_render_wgpu::{GpuRenderer, RetainedFrameIncrementalStats, RetainedFramePreparer};
 use noon_runtime::{FrameChanges, RetainedFrameObjectState, RetainedFrameState};
 use noon_text_render_wgpu::TextDeviceMetrics;
+use noon_typst::{compile_typst_resource, TypstMode};
 
 const STATIC_OBJECTS: usize = 10_000;
 const STATIC_FRAMES: u64 = 128;
@@ -79,6 +80,89 @@ fn unchanged_large_retained_scene_reuses_preparation_scratch_after_warmup() {
         RetainedFrameIncrementalStats {
             scratch_rebuilds: 1,
             scratch_reuses: STATIC_FRAMES,
+            text_snapshot_copies: 1,
+            mixed_order_rebuilds: 1,
+        }
+    );
+}
+
+#[test]
+fn one_fast_text_update_reuses_parent_scratch_snapshot_and_order() {
+    let artifact = compile_typst_resource("A", TypstMode::Markup).unwrap();
+    let mut texts = TextResourceArena::new();
+    let text = texts.insert(artifact.resource).unwrap();
+    let mut frame = RetainedFrameState {
+        time: 0.0,
+        objects: (0..STATIC_OBJECTS)
+            .map(|index| RetainedFrameObjectState {
+                id: ObjectId::new(index as u64),
+                content: ObjectContentRef::Text(text),
+                transform: Transform2D::IDENTITY,
+                style: Style::default(),
+                appearance: 1.0,
+            })
+            .collect(),
+        presences: vec![true; STATIC_OBJECTS],
+        reveals: vec![1.0; STATIC_OBJECTS],
+        morphs: vec![0.0; STATIC_OBJECTS],
+        render_geometries: vec![None; STATIC_OBJECTS],
+    };
+    let fonts = artifact.fonts;
+    let geometries = GeometryResourceArena::new();
+    let metrics = TextDeviceMetrics::uniform(67.5).unwrap();
+    let (device, queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
+    let mut preparer = RetainedFramePreparer::new();
+
+    let mut renderer = GpuRenderer::new(&device, wgpu::TextureFormat::Rgba8Unorm);
+    let mut text_gpu = renderer.create_retained_text_state(&device, &queue);
+    let first_upload = {
+        let prepared = preparer
+            .prepare_with_changes(
+                &device,
+                &queue,
+                &frame,
+                &FrameChanges::all(),
+                &texts,
+                &fonts,
+                &geometries,
+                metrics,
+            )
+            .unwrap();
+        renderer.upload_retained(&device, &queue, &prepared, &mut text_gpu)
+    };
+    assert!(first_upload.text.bytes_uploaded > 0);
+
+    for frame_number in 1..=STATIC_FRAMES {
+        frame.time = frame_number as f64 / 60.0;
+        frame.objects[STATIC_OBJECTS / 2].transform.translation =
+            Vec2::new(frame_number as f32 * 0.01, -(frame_number as f32) * 0.005);
+        frame.objects[STATIC_OBJECTS / 2].style.opacity = 0.75;
+        let upload = {
+            let prepared = preparer
+                .prepare_with_changes(
+                    &device,
+                    &queue,
+                    &frame,
+                    &FrameChanges::objects(vec![STATIC_OBJECTS / 2]),
+                    &texts,
+                    &fonts,
+                    &geometries,
+                    metrics,
+                )
+                .unwrap();
+            renderer.upload_retained(&device, &queue, &prepared, &mut text_gpu)
+        };
+        assert!(upload.text.bytes_uploaded > 0);
+        assert!(upload.text.bytes_uploaded < first_upload.text.bytes_uploaded);
+    }
+
+    assert_eq!(
+        preparer.incremental_stats(),
+        RetainedFrameIncrementalStats {
+            scratch_rebuilds: 1,
+            scratch_reuses: STATIC_FRAMES,
+            text_snapshot_copies: 1,
+            mixed_order_rebuilds: 1,
         }
     );
 }

--- a/crates/noon-render-wgpu/tests/retained_static_frame_locality.rs
+++ b/crates/noon-render-wgpu/tests/retained_static_frame_locality.rs
@@ -132,7 +132,46 @@ fn one_fast_text_update_reuses_parent_scratch_snapshot_and_order() {
     };
     assert!(first_upload.text.bytes_uploaded > 0);
 
-    for frame_number in 1..=STATIC_FRAMES {
+    // Prepare one local generation without submitting it. The next local generation
+    // must not patch over the skipped generation's stale GPU ranges.
+    frame.time = 1.0 / 60.0;
+    frame.objects[STATIC_OBJECTS / 2].transform.translation = Vec2::new(0.01, -0.005);
+    preparer
+        .prepare_with_changes(
+            &device,
+            &queue,
+            &frame,
+            &FrameChanges::objects(vec![STATIC_OBJECTS / 2]),
+            &texts,
+            &fonts,
+            &geometries,
+            metrics,
+        )
+        .unwrap();
+
+    frame.time = 2.0 / 60.0;
+    frame.objects[STATIC_OBJECTS / 2 + 1].transform.translation = Vec2::new(0.02, -0.01);
+    let upload_after_skipped_generation = {
+        let prepared = preparer
+            .prepare_with_changes(
+                &device,
+                &queue,
+                &frame,
+                &FrameChanges::objects(vec![STATIC_OBJECTS / 2 + 1]),
+                &texts,
+                &fonts,
+                &geometries,
+                metrics,
+            )
+            .unwrap();
+        renderer.upload_retained(&device, &queue, &prepared, &mut text_gpu)
+    };
+    assert_eq!(
+        upload_after_skipped_generation.text.bytes_uploaded,
+        first_upload.text.bytes_uploaded
+    );
+
+    for frame_number in 3..=(STATIC_FRAMES + 2) {
         frame.time = frame_number as f64 / 60.0;
         frame.objects[STATIC_OBJECTS / 2].transform.translation =
             Vec2::new(frame_number as f32 * 0.01, -(frame_number as f32) * 0.005);
@@ -160,7 +199,7 @@ fn one_fast_text_update_reuses_parent_scratch_snapshot_and_order() {
         preparer.incremental_stats(),
         RetainedFrameIncrementalStats {
             scratch_rebuilds: 1,
-            scratch_reuses: STATIC_FRAMES,
+            scratch_reuses: STATIC_FRAMES + 2,
             text_snapshot_copies: 1,
             mixed_order_rebuilds: 1,
         }

--- a/crates/noon-text-render-wgpu/src/lib.rs
+++ b/crates/noon-text-render-wgpu/src/lib.rs
@@ -416,6 +416,22 @@ impl RetainedTextQuadPreparer {
         Ok(true)
     }
 
+    /// Report whether the current frame can update only existing text object records.
+    ///
+    /// This is exposed to the mixed renderer so it can avoid rebuilding its separate
+    /// geometry scratch frame before invoking the already-local text update path.
+    /// Prepared outline/vector items still require their owning mixed scratch records
+    /// to be updated by the caller; this method only describes the text quad state.
+    pub fn can_update_objects_locally(
+        &self,
+        frame: &RetainedFrameState,
+        changes: &FrameChanges,
+        texts: &TextResourceArena,
+        metrics: TextDeviceMetrics,
+    ) -> Result<bool, TextPrepareError> {
+        self.can_update_objects(frame, changes, texts, metrics)
+    }
+
     fn update_objects(
         &mut self,
         frame: &RetainedFrameState,


### PR DESCRIPTION
## Summary

- preserve parent retained scratch and mixed painter order for compatible text-only object changes
- retain per-object text item ranges and copy only changed glyph quad ranges into the parent snapshot
- route those ranges through the existing generation-safe GPU range uploader
- include the retained family reveal scene index prerequisite for O(1) active-family object lookup
- keep structural, metric, resource, lane-transition, and family-local realization changes on the conservative full-rebuild paths

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p noon-render-wgpu --all-targets -- -D warnings`
- `cargo test --workspace`

The focused 10,000-object regression covers 128 one-object translation/opacity updates and asserts smaller-than-initial GPU text uploads, one parent scratch rebuild, one text snapshot copy, and one mixed-order rebuild.

Related: #362 #835