### PR TITLE
Ratchet Examples browser WebKit paint workaround

### DIFF
--- a/web/example-browser-webkit-paint.test.mjs
+++ b/web/example-browser-webkit-paint.test.mjs
@@ -27,11 +27,10 @@ test("Examples browser cards bypass deferred painting inside the revealable over
 });
 
 test("WebKit paint workaround stays scoped to the Examples browser", () => {
-  const selector = ".example-browser-layer .example-card";
-  const occurrences = source.split(selector).length - 1;
+  const occurrences = source.match(/\.example-browser-layer\s+\.example-card\s*\{/g) ?? [];
 
   assert.equal(
-    occurrences,
+    occurrences.length,
     1,
     "keep the eager-paint override scoped to the paginated Examples overlay instead of disabling gallery virtualization globally",
   );

--- a/web/example-browser-webkit-paint.test.mjs
+++ b/web/example-browser-webkit-paint.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const source = await readFile(new URL("./example-browser-ui.js", import.meta.url), "utf8");
+
+function cssRuleBody(selector) {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = source.match(new RegExp(`${escaped}\\s*\\{([^}]*)\\}`, "m"));
+  assert.ok(match, `missing CSS rule for ${selector}`);
+  return match[1];
+}
+
+test("Examples browser cards bypass deferred painting inside the revealable overlay", () => {
+  const body = cssRuleBody(".example-browser-layer .example-card");
+
+  assert.match(
+    body,
+    /content-visibility\s*:\s*visible\s*;/,
+    "overlay cards must opt out of content-visibility:auto so WebKit paints them immediately after reveal",
+  );
+  assert.match(
+    body,
+    /contain-intrinsic-size\s*:\s*none\s*;/,
+    "overlay cards must not retain the intrinsic-size placeholder used by deferred gallery cards",
+  );
+});
+
+test("WebKit paint workaround stays scoped to the Examples browser", () => {
+  const selector = ".example-browser-layer .example-card";
+  const occurrences = source.split(selector).length - 1;
+
+  assert.equal(
+    occurrences,
+    1,
+    "keep the eager-paint override scoped to the paginated Examples overlay instead of disabling gallery virtualization globally",
+  );
+});


### PR DESCRIPTION
## Summary

Add focused regression coverage for the iOS/WebKit blank Examples-browser fix merged in #929.

- require `.example-browser-layer .example-card` to override deferred painting with `content-visibility: visible`
- require `contain-intrinsic-size: none` so revealed cards do not retain the gallery virtualization placeholder
- require the override to stay scoped to the Examples overlay rather than disabling gallery-card virtualization globally

## Why this slice

The underlying user-visible regression was fixed directly on master in #929, but the four-line CSS compatibility boundary had no focused regression. The larger playground UX lane (#880), playback failure (#935), retained Text locality (#936), and raster diagnostics are already actively owned, so this is an independent hardening slice that protects a freshly regressed mobile path without touching runtime/rendering architecture.

## Validation

`web/*.test.mjs` is auto-discovered by the normal web static/unit preflight and PR Fast Gate. The test is source-structural because the failure is a WebKit painting heuristic that Chromium cannot faithfully reproduce; it ratchets the exact CSS boundary that avoids that heuristic without introducing browser-specific runtime code.

## Risk

Low. Test-only; no production behavior changes. The regression does not substitute for eventual WebKit E2E coverage under #110.