### PR TITLE
Compose retained family and Text property animations

### DIFF
--- a/.github/workflows/playground-authoring-recovery.yml
+++ b/.github/workflows/playground-authoring-recovery.yml
@@ -11,6 +11,7 @@ on:
       - "scripts/build-web-demo.sh"
       - "scripts/playground-authoring-error-recovery-smoke.mjs"
       - "scripts/playground-stress-edit-smoke.mjs"
+      - "scripts/mixed-family-retained-text-smoke.mjs"
       - "web/**"
   pull_request:
     paths:
@@ -20,6 +21,7 @@ on:
       - "scripts/build-web-demo.sh"
       - "scripts/playground-authoring-error-recovery-smoke.mjs"
       - "scripts/playground-stress-edit-smoke.mjs"
+      - "scripts/mixed-family-retained-text-smoke.mjs"
       - "web/**"
   workflow_dispatch:
 
@@ -86,6 +88,8 @@ jobs:
         env:
           NOON_PLAYGROUND_STRESS_EDIT_ARTIFACTS: browser-smoke-artifacts/playground-stress-edit
         run: node scripts/playground-stress-edit-smoke.mjs
+      - name: Test mixed retained family edit and rerun
+        run: node scripts/mixed-family-retained-text-smoke.mjs
       - name: Upload authoring recovery diagnostics
         if: always()
         uses: actions/upload-artifact@v4

--- a/scripts/mixed-family-retained-text-smoke.mjs
+++ b/scripts/mixed-family-retained-text-smoke.mjs
@@ -1,0 +1,286 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import playwright from "playwright";
+
+const { chromium } = playwright;
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const port = 4198;
+const baseUrl = `http://127.0.0.1:${port}`;
+
+let serverOutput = "";
+const server = spawn(
+  "python3",
+  ["-m", "http.server", String(port), "--bind", "127.0.0.1", "--directory", repoRoot],
+  { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] },
+);
+server.stdout.on("data", (chunk) => (serverOutput += chunk));
+server.stderr.on("data", (chunk) => (serverOutput += chunk));
+
+async function waitForServer() {
+  let lastError = null;
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    try {
+      const response = await fetch(`${baseUrl}/web/manim-compat-smoke.html`);
+      if (response.ok) return;
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`mixed retained family smoke server did not start: ${lastError}\n${serverOutput}`);
+}
+
+const propertyFirstSource = `
+from noon import *
+
+class MixedRetainedPropertyFirst(Scene):
+    def construct(self):
+        moving = Text("MOVE")
+        writing = Text("WRITE")
+        self.play(
+            moving.animate.shift(RIGHT),
+            Write(writing),
+            run_time=1.0,
+            rate_func=linear,
+        )
+`;
+
+const editedFamilyFirstSource = `
+from noon import *
+
+class MixedRetainedFamilyFirst(Scene):
+    def construct(self):
+        writing = Text("EDITED")
+        moving = Text("SHIFT")
+        appearing = Text("FADE")
+        self.play(
+            Write(writing),
+            moving.animate.shift(UP),
+            FadeIn(appearing),
+            run_time=1.0,
+            rate_func=linear,
+        )
+`;
+
+const sameLeafSource = `
+from noon import *
+
+class MixedRetainedSameLeaf(Scene):
+    def construct(self):
+        label = Text("ONE")
+        try:
+            self.play(
+                Write(label),
+                label.animate.shift(RIGHT),
+                run_time=0.25,
+            )
+            raise AssertionError("same-leaf family/property ownership must fail")
+        except ValueError as error:
+            assert "disjoint scene leaves" in str(error)
+        assert label._scene is None
+        assert label._object is None
+        assert label._retained_object_id is None
+        self.play(Write(label), run_time=0.25, rate_func=linear)
+`;
+
+const rollbackSource = `
+from noon import *
+
+class MixedRetainedRollback(Scene):
+    def construct(self):
+        writing = Text("ROLLBACK")
+        moving = Text("MOVE")
+        try:
+            self.play(
+                Write(writing),
+                moving.animate(run_time=-1.0).shift(RIGHT),
+            )
+            raise AssertionError("negative retained run_time must fail")
+        except ValueError:
+            pass
+        assert writing._scene is None
+        assert writing._object is None
+        assert writing._retained_object_id is None
+        assert moving._scene is None
+        assert moving._object is None
+        assert moving._retained_object_id is None
+        self.play(
+            Write(writing),
+            moving.animate.shift(RIGHT),
+            run_time=0.5,
+            rate_func=linear,
+        )
+`;
+
+function retainedSources(result) {
+  return (result.retainedDocument?.objects ?? []).map((object) => object.text.source);
+}
+
+function tracksFor(result, property) {
+  return (result.retainedDocument?.tracks ?? []).filter((track) => track.property === property);
+}
+
+let browser = null;
+try {
+  await waitForServer();
+  browser = await chromium.launch({
+    channel: "chromium",
+    headless: true,
+    args: ["--disable-dev-shm-usage"],
+  });
+  const page = await browser.newPage();
+  const errors = [];
+  page.on("pageerror", (error) => errors.push(`pageerror: ${error}`));
+  page.on("console", (message) => {
+    if (message.type() === "error") errors.push(`console: ${message.text()}`);
+  });
+
+  await page.goto(`${baseUrl}/web/manim-compat-smoke.html`, { waitUntil: "load" });
+  await page.waitForFunction(() => window.noonManimCompat, null, { timeout: 30_000 });
+  await page.evaluate(() => window.noonManimCompat.ready());
+
+  // Both source versions run through the same Pyodide authoring worker. Object order
+  // must follow source binding order even though both objects use retained execution.
+  const propertyFirst = await page.evaluate(
+    (source) => window.noonManimCompat.run(source),
+    propertyFirstSource,
+  );
+  assert.equal(propertyFirst.kind, "scene_document");
+  assert.equal(propertyFirst.document.objects.length, 0);
+  assert.deepEqual(retainedSources(propertyFirst), ["MOVE", "WRITE"]);
+  assert.equal(propertyFirst.sceneSpec.objects.length, 2);
+  assert.equal(propertyFirst.sceneSpec.family_animations.length, 1);
+  assert.equal(propertyFirst.retainedDocument.family_animations.length, 1);
+  assert.equal(propertyFirst.duration, 1);
+  const firstPositions = tracksFor(propertyFirst, "position");
+  assert.equal(firstPositions.length, 1);
+  assert.equal(firstPositions[0].object, 0, "property-first Text must own the first retained object slot");
+  assert.deepEqual(firstPositions[0].values.vec2, {
+    from: { x: 0, y: 0 },
+    to: { x: 1, y: 0 },
+  });
+  assert.equal(firstPositions[0].timing.start_time, 0);
+  assert.equal(firstPositions[0].timing.duration, 1);
+  assert.equal(firstPositions[0].timing.easing, "linear");
+
+  const edited = await page.evaluate(
+    (source) => window.noonManimCompat.run(source),
+    editedFamilyFirstSource,
+  );
+  assert.equal(edited.kind, "scene_document");
+  assert.equal(edited.document.objects.length, 0);
+  assert.deepEqual(retainedSources(edited), ["EDITED", "SHIFT", "FADE"]);
+  assert.equal(edited.sceneSpec.objects.length, 3);
+  assert.equal(edited.sceneSpec.family_animations.length, 1);
+  assert.equal(edited.retainedDocument.family_animations.length, 1);
+  assert.equal(edited.duration, 1);
+  const editedPositions = tracksFor(edited, "position");
+  assert.equal(editedPositions.length, 1);
+  assert.equal(editedPositions[0].object, 1, "family-first source order must remain canonical painter order");
+  assert.deepEqual(editedPositions[0].values.vec2, {
+    from: { x: 0, y: 0 },
+    to: { x: 0, y: 1 },
+  });
+  const editedPresence = tracksFor(edited, "presence");
+  const editedAppearance = tracksFor(edited, "appearance");
+  assert.ok(
+    editedPresence.some((track) => track.object === 2 && track.values.bool?.from === false && track.values.bool?.to === true),
+    "mixed retained FadeIn must keep retained lifecycle ownership",
+  );
+  assert.ok(
+    editedAppearance.some((track) => track.object === 2 && track.values.scalar?.from === 0 && track.values.scalar?.to === 1),
+    "mixed retained FadeIn must keep retained appearance-track ownership",
+  );
+
+  const sameLeaf = await page.evaluate(
+    (source) => window.noonManimCompat.run(source),
+    sameLeafSource,
+  );
+  assert.deepEqual(retainedSources(sameLeaf), ["ONE"]);
+  assert.equal(sameLeaf.sceneSpec.objects.length, 1);
+  assert.equal(sameLeaf.sceneSpec.family_animations.length, 1);
+  assert.equal(tracksFor(sameLeaf, "position").length, 0, "rejected same-leaf play must not leak a retained track");
+
+  const rollback = await page.evaluate(
+    (source) => window.noonManimCompat.run(source),
+    rollbackSource,
+  );
+  assert.deepEqual(retainedSources(rollback), ["ROLLBACK", "MOVE"]);
+  assert.equal(rollback.sceneSpec.objects.length, 2);
+  assert.equal(rollback.sceneSpec.family_animations.length, 1, "failed family request must be rolled back before retry");
+  assert.equal(tracksFor(rollback, "position").length, 1, "failed retained property track must not survive retry");
+
+  // Edit -> rerun uses the same browser execution owner. Rebuilding from A to B must
+  // replace the canonical object/request set rather than accumulate the first run.
+  const rebuild = await page.evaluate(async ({ first, second }) => {
+    const { AuthoringExecutionClient } = await import("./authoring-execution-client.js");
+    const canvas = document.createElement("canvas");
+    canvas.width = 640;
+    canvas.height = 360;
+    document.body.appendChild(canvas);
+    const errors = [];
+    const execution = new AuthoringExecutionClient(canvas, {
+      onError(error) {
+        errors.push(String(error));
+      },
+    });
+
+    async function waitForObjectCount(expected) {
+      let latest = null;
+      for (let attempt = 0; attempt < 100; attempt += 1) {
+        latest = await execution.metrics();
+        if (errors.length !== 0) throw new Error(errors.join("; "));
+        if (latest.metrics?.objectCount === expected) return latest;
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      }
+      throw new Error(`retained object count did not converge to ${expected}: ${JSON.stringify(latest)}`);
+    }
+
+    try {
+      await execution.startRetainedCanonical(JSON.stringify(first.sceneSpec), {
+        loopDurationSeconds: first.duration,
+        transportMode: "transferable",
+      });
+      const persistentCanvas = execution.canvas;
+      const before = await waitForObjectCount(2);
+      const reconciled = await execution.reconcileScene(JSON.stringify(second.document), {
+        sceneSpecJson: JSON.stringify(second.sceneSpec),
+        loopDurationSeconds: second.duration,
+      });
+      const after = await waitForObjectCount(3);
+      return {
+        beforeCount: before.metrics.objectCount,
+        afterCount: after.metrics.objectCount,
+        beforeCanonical: Boolean(before.engineMetrics?.canonical),
+        afterCanonical: Boolean(after.engineMetrics?.canonical),
+        rebuilt: reconciled.rebuilt,
+        mode: reconciled.mode,
+        sameCanvas: execution.canvas === persistentCanvas,
+      };
+    } finally {
+      execution.terminate();
+      execution.canvas?.remove();
+    }
+  }, { first: propertyFirst, second: edited });
+
+  assert.deepEqual(rebuild, {
+    beforeCount: 2,
+    afterCount: 3,
+    beforeCanonical: true,
+    afterCanonical: true,
+    rebuilt: true,
+    mode: "retained",
+    sameCanvas: true,
+  });
+
+  assert.deepEqual(errors, [], `browser errors while testing mixed retained family composition:\n${errors.join("\n")}`);
+  console.log("Mixed retained family/property animation smoke passed, including edit -> rerun rebuild.");
+} finally {
+  await browser?.close();
+  server.kill("SIGTERM");
+}

--- a/web/family-animation-authoring.test.mjs
+++ b/web/family-animation-authoring.test.mjs
@@ -6,6 +6,7 @@ import { test } from "node:test";
 const pythonPath = "web/python/_manim_family_creation.py";
 const pythonSource = readFileSync(pythonPath, "utf8");
 const ordinaryPythonSource = readFileSync("web/python/_manim_animate.py", "utf8");
+const retainedPythonSource = readFileSync("web/python/_manim_retained_animate.py", "utf8");
 const moduleManifest = readFileSync("web/python-compat-modules.js", "utf8");
 const genericRustBridge = readFileSync(
   "crates/noon-web/src/family_animation_authoring.rs",
@@ -43,33 +44,44 @@ test("Python appends family requests without owning the scene-wide scheduler lim
   );
 });
 
-test("one Scene.play composes disjoint retained families with ordinary geometry", () => {
+test("one Scene.play composes disjoint family, retained Text, and geometry animation domains", () => {
   assert.doesNotMatch(
     pythonSource,
     /must currently be the only animation in Scene\.play/,
   );
   assert.doesNotMatch(
     pythonSource,
-    /family animations cannot currently be mixed with[\s\S]*ordinary animations/,
+    /retained Text property animations in the same Scene\.play still require/,
   );
-  assert.match(pythonSource, /retained family animations can mix with ordinary geometry animations/);
-  assert.match(pythonSource, /must target disjoint family leaves/);
-  assert.match(pythonSource, /family and ordinary animations must target[\s\S]*disjoint scene leaves/);
-  assert.match(pythonSource, /Bind in exact source order/);
+  assert.match(pythonSource, /_retained_ordinary_plan/);
+  assert.match(pythonSource, /_retained\._schedule_retained_plan/);
   assert.match(pythonSource, /_prepare_aligned_animation_binding/);
   assert.match(pythonSource, /_schedule_aligned_bound_animations/);
   assert.match(pythonSource, /_commit_semantic_targets/);
-  assert.match(pythonSource, /base_start \+ actual_run_time/);
+  assert.match(pythonSource, /must target disjoint family leaves/);
+  assert.match(pythonSource, /family and ordinary animations must target[\s\S]*disjoint scene leaves/);
+  assert.match(pythonSource, /one source-ordered transaction/);
+  assert.match(pythonSource, /retained_ordinary_end/);
   assert.match(pythonSource, /play_end = max\(/);
 });
 
-test("ordinary play exposes bind/schedule/commit phases for one outer transaction", () => {
+test("mixed family play reuses the retained property scheduler instead of duplicating it", () => {
+  assert.match(retainedPythonSource, /def _schedule_retained_plan\(/);
+  assert.match(pythonSource, /_retained\._retained_animation_plan\(animation\)/);
+  assert.match(pythonSource, /_retained\._schedule_retained_plan\(/);
+  assert.doesNotMatch(pythonSource, /def _append_vec2_track\(/);
+  assert.doesNotMatch(pythonSource, /def _append_scalar_track\(/);
+  assert.match(pythonSource, /checkpoint = self\._authoring_checkpoint\(\)/);
+  assert.match(pythonSource, /self\._restore_authoring_checkpoint\(checkpoint\)/);
+  assert.match(pythonSource, /source\._object/);
+  assert.match(pythonSource, /member\._object = old_object/);
+});
+
+test("ordinary geometry still exposes bind/schedule/commit phases for the outer transaction", () => {
   assert.match(ordinaryPythonSource, /def _prepare_aligned_animation_binding\(/);
   assert.match(ordinaryPythonSource, /def _schedule_aligned_bound_animations\(/);
   assert.match(ordinaryPythonSource, /without committing semantic targets/);
   assert.match(ordinaryPythonSource, /def _commit_semantic_targets\(/);
-  assert.match(pythonSource, /checkpoint = self\._authoring_checkpoint\(\)/);
-  assert.match(pythonSource, /self\._restore_authoring_checkpoint\(checkpoint\)/);
 
   const scheduleIndex = pythonSource.lastIndexOf("_schedule_aligned_bound_animations(");
   const commitIndex = pythonSource.lastIndexOf("_commit_semantic_targets(");

--- a/web/python/_manim_family_creation.py
+++ b/web/python/_manim_family_creation.py
@@ -164,7 +164,7 @@ def _value_contains_retained_text(value: object) -> bool:
 
 
 def _ordinary_requires_retained_scheduler(animation: object) -> bool:
-    """Keep retained Text property-track composition on its existing scheduler."""
+    """Return whether an ordinary animation touches retained Text content."""
 
     values = (
         _animate._builder_source(animation),
@@ -172,6 +172,21 @@ def _ordinary_requires_retained_scheduler(animation: object) -> bool:
         getattr(animation, "target", None),
     )
     return any(_value_contains_retained_text(value) for value in values if value is not None)
+
+
+def _retained_ordinary_plan(animation: object) -> list[dict[str, Any]] | None:
+    """Classify one non-family animation without inventing a second retained scheduler."""
+
+    plan = _retained._retained_animation_plan(animation)
+    if plan is not None:
+        return plan
+    if _ordinary_requires_retained_scheduler(animation):
+        raise NotImplementedError(
+            "retained family animations can currently compose with direct retained Text "
+            "property animations and fades; retained Group/VGroup property scheduling "
+            "must first use the shared retained family scheduler"
+        )
+    return None
 
 
 def _ordinary_scene_leaves(animation: object) -> list[_base.Mobject]:
@@ -550,17 +565,14 @@ def _family_scene_play(
         unsupported = ", ".join(sorted(kwargs))
         raise NotImplementedError(f"unsupported Manim Scene.play option(s): {unsupported}")
 
-    ordinary_animations = [
-        animation
+    # Resolve retained-property intent before any Scene mutation. Direct retained Text
+    # animations reuse the existing retained scheduler; geometry remains on the aligned
+    # scheduler. A retained Group/VGroup that has not joined the shared retained-family
+    # scheduler still fails explicitly rather than falling through to legacy geometry.
+    retained_ordinary_plans = [
+        None if candidate is not None else _retained_ordinary_plan(animation)
         for animation, candidate in zip(animations, candidates, strict=True)
-        if candidate is None
     ]
-    if any(_ordinary_requires_retained_scheduler(animation) for animation in ordinary_animations):
-        raise NotImplementedError(
-            "retained family animations can mix with ordinary geometry animations, but "
-            "retained Text property animations in the same Scene.play still require "
-            "unified retained-track scheduling"
-        )
 
     leaf_owners: dict[int, int] = {}
     for animation_index, candidate in enumerate(candidates):
@@ -576,6 +588,9 @@ def _family_scene_play(
                 )
             leaf_owners[id(member)] = animation_index
 
+    # This check runs before lifecycle binding, retained track emission, or canonical
+    # family request creation. Same-leaf ownership is therefore rejected transactionally
+    # instead of depending on whichever scheduler happens to run first.
     for animation_index, (animation, candidate) in enumerate(
         zip(animations, candidates, strict=True)
     ):
@@ -616,11 +631,25 @@ def _family_scene_play(
 
     geometry_states: dict[int, tuple[_base.Mobject, object, object]] = {}
     retained_states: dict[
-        int, tuple[_typst._RetainedTextMobject, object, object, object]
+        int, tuple[_typst._RetainedTextMobject, object, object, object, object]
     ] = {}
-    for animation, candidate in zip(animations, candidates, strict=True):
+    for animation, candidate, retained_plan in zip(
+        animations, candidates, retained_ordinary_plans, strict=True
+    ):
         if candidate is None:
-            _animate._record_animation_wrapper_state(animation, geometry_states)
+            if retained_plan is not None:
+                source = _retained._retained_animation_source(animation)
+                if source is None:
+                    raise RuntimeError("retained animation classification lost its source")
+                retained_states[id(source)] = (
+                    source,
+                    source._scene,
+                    source._object,
+                    source._retained_object_id,
+                    source._retained_order,
+                )
+            else:
+                _animate._record_animation_wrapper_state(animation, geometry_states)
             continue
         _target, _family, leaves, _synthetic = candidate
         for member in leaves:
@@ -628,6 +657,7 @@ def _family_scene_play(
                 retained_states[id(member)] = (
                     member,
                     member._scene,
+                    member._object,
                     member._retained_object_id,
                     member._retained_order,
                 )
@@ -636,16 +666,42 @@ def _family_scene_play(
 
     try:
         completed: list[tuple[object, object, list[tuple[_base.Mobject, object]], float]] = []
-        bound_ordinary: list[object] = []
+        bound_geometry: list[object] = []
+        retained_ordinary_end = base_start
 
-        # Bind in exact source order so canonical object/painter order is independent
-        # of whether one sibling uses family realization or ordinary geometry tracks.
-        for animation, candidate in zip(animations, candidates, strict=True):
+        # Participate in one source-ordered transaction. Family lifecycle/request
+        # authoring and direct retained Text property scheduling both own their existing
+        # semantics; this layer only coordinates ownership/order and the commit boundary.
+        # Geometry semantic-handle commits remain deferred until every sibling succeeds.
+        for animation, candidate, retained_plan in zip(
+            animations, candidates, retained_ordinary_plans, strict=True
+        ):
             if candidate is None:
-                _animate._prepare_aligned_animation_binding(
-                    self, animation, start_time=base_start
-                )
-                bound_ordinary.append(animation)
+                if retained_plan is not None:
+                    resolved = _options.resolve(
+                        builder_args=_options.builder_args(animation),
+                        default_lag_ratio=0.0,
+                        play_run_time=play_run_time,
+                        play_easing=easing,
+                        play_rate_func=rate_func,
+                        play_lag_ratio=play_lag_ratio,
+                    )
+                    _retained._schedule_retained_plan(
+                        self,
+                        animation,
+                        retained_plan,
+                        start_time=base_start,
+                        duration=resolved.run_time,
+                        easing=resolved.rate_func,
+                    )
+                    retained_ordinary_end = max(
+                        retained_ordinary_end, base_start + resolved.run_time
+                    )
+                else:
+                    _animate._prepare_aligned_animation_binding(
+                        self, animation, start_time=base_start
+                    )
+                    bound_geometry.append(animation)
                 continue
 
             target, family, leaves, _synthetic = candidate
@@ -722,9 +778,9 @@ def _family_scene_play(
                 end_time=end_time,
             )
 
-        ordinary_end, semantic_targets = _animate._schedule_aligned_bound_animations(
+        geometry_end, semantic_targets = _animate._schedule_aligned_bound_animations(
             self,
-            bound_ordinary,
+            bound_geometry,
             base_start=base_start,
             play_run_time=play_run_time,
             play_easing=easing,
@@ -732,19 +788,19 @@ def _family_scene_play(
             play_lag_ratio=play_lag_ratio,
         )
         play_end = max(
-            [ordinary_end]
+            [geometry_end, retained_ordinary_end]
             + [end_time for _animation, _target, _plans, end_time in completed]
         )
         self._cursor = max(cursor_before, play_end)
 
-        # This is deliberately the final authoring mutation. No family/runtime work
-        # follows a semantic-handle commit, so a failed sibling cannot leak target
-        # state into a subsequent source edit/rerun.
+        # Deliberately last: neither family requests nor retained Text tracks can fail
+        # after ordinary semantic handles are committed. A source edit/rerun therefore
+        # starts from its fresh Scene/context rather than leaked target state.
         _animate._commit_semantic_targets(semantic_targets)
         return self
     except Exception:
-        # #882's Scene checkpoint also restores the Rust-owned canonical authoring
-        # context, so an edit/rerun never inherits objects or requests from a failed play.
+        # #882's Scene checkpoint restores the Rust-owned canonical authoring context;
+        # the sidecar/wrapper restoration below covers the retained compatibility views.
         self._restore_authoring_checkpoint(checkpoint)
         self._cursor = cursor_before
         self._compat_top_level = top_level_before
@@ -759,8 +815,15 @@ def _family_scene_play(
         for member, old_scene, old_object in geometry_states.values():
             member._scene = old_scene
             member._object = old_object
-        for member, old_scene, old_object_id, old_order in retained_states.values():
+        for (
+            member,
+            old_scene,
+            old_object,
+            old_object_id,
+            old_order,
+        ) in retained_states.values():
             member._scene = old_scene
+            member._object = old_object
             member._retained_object_id = old_object_id
             member._retained_order = old_order
         raise

--- a/web/stress-runtime-contract.test.mjs
+++ b/web/stress-runtime-contract.test.mjs
@@ -56,7 +56,7 @@ assert.match(
 assert.match(
   retainedAnimate,
   /mixing retained Text animations with legacy animations in one Scene\.play /,
-  "contract should track the retained-vs-geometry property-animation mixed-play boundary",
+  "standalone retained-vs-geometry property animation remains a separate composition boundary",
 );
 assert.doesNotMatch(
   familyCreation,
@@ -65,13 +65,13 @@ assert.doesNotMatch(
 );
 assert.doesNotMatch(
   familyCreation,
-  /family animations cannot currently be mixed with[\s\S]*ordinary animations/,
-  "retained family animations should compose with ordinary geometry animations",
+  /retained Text property animations in the same Scene\.play still require/,
+  "family composition should now admit direct retained Text property animations",
 );
 assert.match(
   familyCreation,
-  /retained family animations can mix with ordinary geometry animations/,
-  "contract should retain the narrower retained-property-track composition boundary",
+  /_retained\._schedule_retained_plan/,
+  "family composition must reuse the retained property-track scheduler",
 );
 assert.match(
   familyCreation,


### PR DESCRIPTION
## Summary
- allow a retained family animation such as `Write(title)` to share one `Scene.play(...)` with direct retained Text property animations/fades on disjoint Text objects
- reuse the existing retained property-track scheduler instead of duplicating transform/opacity/fade semantics in the family layer
- keep family requests, retained property tracks, and ordinary geometry under the existing outer canonical authoring transaction
- preserve source-order retained object/painter binding whether the property animation or family animation appears first
- reject family/property ownership of the same scene leaf before any lifecycle or canonical mutation
- keep retained Group/VGroup property scheduling explicit until it joins the shared retained-family scheduler

## Transaction / rerun design
The family composition wrapper classifies retained-property intent before mutation, records retained wrapper state including the canonical `_object` binding, and runs direct retained Text scheduling in source order inside the same checkpoint already used for family and geometry composition. Ordinary geometry semantic handles still commit only after every sibling succeeds. On failure, the Rust-owned Scene authoring checkpoint plus retained sidecar/wrapper snapshots restore the pre-play state.

Each source rerun still constructs a fresh Rust-owned per-Scene canonical authoring context (#882). Browser acceptance additionally starts source A in one persistent `AuthoringExecutionClient`, authors edited source B through the same Pyodide worker, then reconciles B onto the same canvas and requires the canonical object count to change exactly 2 -> 3 with `rebuilt=true` and retained execution.

## Browser acceptance
`scripts/mixed-family-retained-text-smoke.mjs` covers:
- `Text.animate` first, then `Write(Text)` -> retained object order `MOVE`, `WRITE`
- `Write(Text)` first, then another Text `.animate` plus retained `FadeIn` -> `EDITED`, `SHIFT`, `FADE`
- exact retained position/lifecycle/appearance tracks and one family request
- same-leaf `Write(text)` + `text.animate...` rejection with no leaked track/request
- failure after the family request has been authored (negative sibling run_time), followed by a successful retry proving full rollback
- persistent edit -> rerun rebuild on the same execution canvas without object/request accumulation

The smoke is added to the existing Playground authoring recovery workflow so no additional browser-package build is introduced.

Tracks #741 / #705 / #367.