### PR TITLE
Ratchet Manim palette star-import exports

### DIFF
--- a/web/manim-palette-star-import.test.mjs
+++ b/web/manim-palette-star-import.test.mjs
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./python/noon.py", import.meta.url), "utf8");
+const allMatch = source.match(/__all__\s*=\s*\[(?<body>[\s\S]*?)\]\s*$/m);
+assert.ok(allMatch?.groups?.body, "noon.py must define a public __all__ export list");
+
+const exported = new Set(
+  [...allMatch.groups.body.matchAll(/"([A-Z][A-Z0-9_]*)"/g)].map((match) => match[1]),
+);
+
+const manimPaletteNames = [
+  "WHITE",
+  "BLACK",
+  "BLUE_A",
+  "BLUE_B",
+  "BLUE_C",
+  "BLUE_D",
+  "BLUE_E",
+  "BLUE",
+  "TEAL_A",
+  "TEAL_B",
+  "TEAL_C",
+  "TEAL_D",
+  "TEAL_E",
+  "TEAL",
+  "GREEN_A",
+  "GREEN_B",
+  "GREEN_C",
+  "GREEN_D",
+  "GREEN_E",
+  "GREEN",
+  "YELLOW_A",
+  "YELLOW_B",
+  "YELLOW_C",
+  "YELLOW_D",
+  "YELLOW_E",
+  "YELLOW",
+  "GOLD",
+  "RED_A",
+  "RED_B",
+  "RED_C",
+  "RED_D",
+  "RED_E",
+  "RED",
+  "MAROON",
+  "PURPLE_A",
+  "PURPLE_B",
+  "PURPLE_C",
+  "PURPLE_D",
+  "PURPLE_E",
+  "PURPLE",
+  "ORANGE",
+  "PINK",
+  "LIGHT_PINK",
+  "GRAY_A",
+  "GRAY_B",
+  "GRAY_C",
+  "GRAY_D",
+  "GRAY_E",
+  "GRAY",
+  "GREY_A",
+  "GREY_B",
+  "GREY_C",
+  "GREY_D",
+  "GREY_E",
+  "GREY",
+];
+
+const missing = manimPaletteNames.filter((name) => !exported.has(name));
+assert.deepEqual(
+  missing,
+  [],
+  `from noon import * would omit defined Manim palette names: ${missing.join(", ")}`,
+);


### PR DESCRIPTION
Current-master replacement for draft #927, which could not be promoted because the connected GitHub draft→ready mutation is currently broken.

This is the same focused #879 regression contract, rebased onto current master. It adds one auto-discovered web unit test that reads the canonical `web/python/noon.py` `__all__` and requires every currently defined Manim palette name/shade—including gray/grey aliases and A–E shade families—to remain exported by `from noon import *`.

No runtime behavior, color table, or frontend semantics are added. The production palette exports already exist; this PR only makes that public compatibility surface durable.

Supersedes #927. Closes #879 once qualified and merged.