### PR TITLE
Ratchet analytic line CPU-GPU vertex ABI

### DIFF
--- a/crates/noon-render-wgpu/tests/line_instance_vertex_abi.rs
+++ b/crates/noon-render-wgpu/tests/line_instance_vertex_abi.rs
@@ -76,6 +76,7 @@ fn line_instance_vertex_layout_matches_packed_cpu_abi() {
 #[test]
 fn line_instance_partial_upload_stride_is_four_byte_aligned() {
     let stride = size_of::<LineInstance>();
+    let second_line_offset = stride;
 
     assert_eq!(
         stride, 88,
@@ -83,8 +84,7 @@ fn line_instance_partial_upload_stride_is_four_byte_aligned() {
     );
     assert_eq!(stride % wgpu::COPY_BUFFER_ALIGNMENT as usize, 0);
     assert_eq!(
-        stride * 1,
-        88,
+        second_line_offset, 88,
         "the second packed line starts at the frame-90 diagnostic offset"
     );
 }

--- a/crates/noon-render-wgpu/tests/line_instance_vertex_abi.rs
+++ b/crates/noon-render-wgpu/tests/line_instance_vertex_abi.rs
@@ -1,8 +1,6 @@
 use std::mem::{offset_of, size_of};
 
-use noon_render_wgpu::{
-    line_instance_layout, LineInstance, PackedStyle, PackedTransform,
-};
+use noon_render_wgpu::{line_instance_layout, LineInstance, PackedStyle, PackedTransform};
 
 #[test]
 fn line_instance_vertex_layout_matches_packed_cpu_abi() {
@@ -79,7 +77,14 @@ fn line_instance_vertex_layout_matches_packed_cpu_abi() {
 fn line_instance_partial_upload_stride_is_four_byte_aligned() {
     let stride = size_of::<LineInstance>();
 
-    assert_eq!(stride, 88, "changing the line ABI requires updating GPU layout and diagnostics");
+    assert_eq!(
+        stride, 88,
+        "changing the line ABI requires updating GPU layout and diagnostics"
+    );
     assert_eq!(stride % wgpu::COPY_BUFFER_ALIGNMENT as usize, 0);
-    assert_eq!(stride * 1, 88, "the second packed line starts at the frame-90 diagnostic offset");
+    assert_eq!(
+        stride * 1,
+        88,
+        "the second packed line starts at the frame-90 diagnostic offset"
+    );
 }

--- a/crates/noon-render-wgpu/tests/line_instance_vertex_abi.rs
+++ b/crates/noon-render-wgpu/tests/line_instance_vertex_abi.rs
@@ -1,0 +1,85 @@
+use std::mem::{offset_of, size_of};
+
+use noon_render_wgpu::{
+    line_instance_layout, LineInstance, PackedStyle, PackedTransform,
+};
+
+#[test]
+fn line_instance_vertex_layout_matches_packed_cpu_abi() {
+    let layout = line_instance_layout();
+    let attributes = layout.attributes;
+
+    assert_eq!(layout.array_stride as usize, size_of::<LineInstance>());
+    assert_eq!(layout.step_mode, wgpu::VertexStepMode::Instance);
+    assert_eq!(attributes.len(), 10);
+
+    let transform = offset_of!(LineInstance, transform);
+    let style = offset_of!(LineInstance, style);
+    let expected = [
+        (
+            transform + offset_of!(PackedTransform, translation),
+            1,
+            wgpu::VertexFormat::Float32x2,
+        ),
+        (
+            transform + offset_of!(PackedTransform, scale),
+            2,
+            wgpu::VertexFormat::Float32x2,
+        ),
+        (
+            transform + offset_of!(PackedTransform, rotation),
+            3,
+            wgpu::VertexFormat::Float32,
+        ),
+        (
+            offset_of!(LineInstance, start),
+            4,
+            wgpu::VertexFormat::Float32x2,
+        ),
+        (
+            style + offset_of!(PackedStyle, fill),
+            5,
+            wgpu::VertexFormat::Float32x4,
+        ),
+        (
+            style + offset_of!(PackedStyle, stroke),
+            6,
+            wgpu::VertexFormat::Float32x4,
+        ),
+        (
+            style + offset_of!(PackedStyle, stroke_width),
+            7,
+            wgpu::VertexFormat::Float32x2,
+        ),
+        (
+            style + offset_of!(PackedStyle, fill_enabled),
+            8,
+            wgpu::VertexFormat::Uint32x2,
+        ),
+        (
+            offset_of!(LineInstance, end),
+            9,
+            wgpu::VertexFormat::Float32x2,
+        ),
+        (
+            transform + offset_of!(PackedTransform, padding),
+            10,
+            wgpu::VertexFormat::Float32,
+        ),
+    ];
+
+    for (attribute, (offset, shader_location, format)) in attributes.iter().zip(expected) {
+        assert_eq!(attribute.offset as usize, offset);
+        assert_eq!(attribute.shader_location, shader_location);
+        assert_eq!(attribute.format, format);
+    }
+}
+
+#[test]
+fn line_instance_partial_upload_stride_is_four_byte_aligned() {
+    let stride = size_of::<LineInstance>();
+
+    assert_eq!(stride, 88, "changing the line ABI requires updating GPU layout and diagnostics");
+    assert_eq!(stride % wgpu::COPY_BUFFER_ALIGNMENT as usize, 0);
+    assert_eq!(stride * 1, 88, "the second packed line starts at the frame-90 diagnostic offset");
+}


### PR DESCRIPTION
Current-master non-draft replacement for #914, which could not be promoted because the connected GitHub draft→ready mutation is currently broken.

This remains test-only. It adds a focused `noon-render-wgpu` integration regression for the packed analytic `LineInstance` CPU↔GPU vertex ABI: array stride, instance step mode, shader locations/formats, and every asserted byte offset are derived from the actual Rust `repr(C)` fields with `offset_of!`. It also ratchets the current 88-byte partial-upload stride used by the WebGL RotationUpdater diagnostic.

The earlier head already passed Rust tests, web preflight, and browser checks; its only red job was rustfmt. The exact rustfmt output has been applied on the current branch. No renderer behavior, upload path, or backend policy changes.

Supersedes #914. Tracks #513.