### PR TITLE
Keep prepared authoring execution unpublished until engine selection

### DIFF
--- a/web/authoring-execution-client.js
+++ b/web/authoring-execution-client.js
@@ -26,6 +26,7 @@ const EMPTY_HOST_METRICS = Object.freeze({
 export class AuthoringExecutionClient {
   #canvas;
   #player = null;
+  #preparedPlayer = null;
   #mode = null;
   #rendererBackend = "";
   #loopDurationSeconds = DEFAULT_LOOP_DURATION_SECONDS;
@@ -69,12 +70,52 @@ export class AuthoringExecutionClient {
     return this.#transportMode;
   }
 
+  async prepare(
+    {
+      transportMode = undefined,
+      sharedSlotCapacity = DEFAULT_SHARED_SLOT_CAPACITY,
+    } = {},
+  ) {
+    if (this.#player !== null || this.#preparedPlayer !== null || this.#transition !== null) {
+      throw new Error("AuthoringExecutionClient is already started or preparing");
+    }
+    this.#sharedSlotCapacity = validateSharedSlotCapacity(sharedSlotCapacity);
+    const options = { sharedSlotCapacity: this.#sharedSlotCapacity };
+    if (transportMode !== undefined) {
+      options.transportMode = transportMode;
+    }
+
+    const generation = this.#lifecycleGeneration;
+    const player = this.#createPlayer();
+    this.#preparedPlayer = player;
+    try {
+      const ready = await player.prepare(options);
+      this.#assertLifecycleCurrent(generation);
+      if (this.#preparedPlayer !== player && this.#player !== player) {
+        throw new Error(LIFECYCLE_CANCELLED_MESSAGE);
+      }
+      this.#transportMode = ready.transportMode;
+      return ready;
+    } catch (error) {
+      if (this.#preparedPlayer === player) {
+        this.#preparedPlayer = null;
+      }
+      if (generation === this.#lifecycleGeneration) {
+        this.#adoptPlayerCanvas(player);
+      }
+      if (generation !== this.#lifecycleGeneration) {
+        throw new Error(LIFECYCLE_CANCELLED_MESSAGE);
+      }
+      throw error;
+    }
+  }
+
   async start(
     sceneJson,
     {
       loopDurationSeconds = DEFAULT_LOOP_DURATION_SECONDS,
       transportMode = undefined,
-      sharedSlotCapacity = DEFAULT_SHARED_SLOT_CAPACITY,
+      sharedSlotCapacity = undefined,
       callbacks = null,
       authoringClient = null,
     } = {},
@@ -84,7 +125,7 @@ export class AuthoringExecutionClient {
     }
     validateSceneJson(sceneJson);
     this.#loopDurationSeconds = validateLoopDurationSeconds(loopDurationSeconds);
-    this.#sharedSlotCapacity = validateSharedSlotCapacity(sharedSlotCapacity);
+    this.#sharedSlotCapacity = this.#resolveStartupSharedSlotCapacity(sharedSlotCapacity);
     const options = {
       loopDurationSeconds: this.#loopDurationSeconds,
       sharedSlotCapacity: this.#sharedSlotCapacity,
@@ -105,7 +146,7 @@ export class AuthoringExecutionClient {
     {
       loopDurationSeconds = DEFAULT_LOOP_DURATION_SECONDS,
       transportMode = undefined,
-      sharedSlotCapacity = DEFAULT_SHARED_SLOT_CAPACITY,
+      sharedSlotCapacity = undefined,
     } = {},
   ) {
     if (this.#player !== null || this.#transition !== null) {
@@ -113,7 +154,7 @@ export class AuthoringExecutionClient {
     }
     validateSceneSpecJson(sceneSpecJson);
     this.#loopDurationSeconds = validateLoopDurationSeconds(loopDurationSeconds);
-    this.#sharedSlotCapacity = validateSharedSlotCapacity(sharedSlotCapacity);
+    this.#sharedSlotCapacity = this.#resolveStartupSharedSlotCapacity(sharedSlotCapacity);
     const options = {
       loopDurationSeconds: this.#loopDurationSeconds,
       sharedSlotCapacity: this.#sharedSlotCapacity,
@@ -271,6 +312,12 @@ export class AuthoringExecutionClient {
     this.#lifecycleGeneration += 1;
     this.#resizeObserver?.disconnect();
     this.#resizeObserver = null;
+    const preparedPlayer = this.#preparedPlayer;
+    preparedPlayer?.terminate();
+    if (preparedPlayer !== null && this.#canvas !== preparedPlayer.canvas) {
+      this.#canvas = preparedPlayer.canvas;
+    }
+    this.#preparedPlayer = null;
     this.#player?.terminate();
     this.#player = null;
     this.#mode = null;
@@ -280,10 +327,7 @@ export class AuthoringExecutionClient {
 
   async #startMode(mode, sceneJson, options, sceneSpecJson = null) {
     const generation = this.#lifecycleGeneration;
-    const player = new ExecutionWorkerClient(this.#canvas, {
-      onError: this.#onError,
-      onRecoverableError: this.#onRecoverableError,
-    });
+    const player = this.#preparedPlayer ?? this.#createPlayer();
     const terminateCandidate = createIdempotentTerminator(player);
     let published = false;
     try {
@@ -292,6 +336,9 @@ export class AuthoringExecutionClient {
           ? await player.startRetainedCanonical(sceneSpecJson, options)
           : await player.start(sceneJson, options);
       this.#assertLifecycleCurrent(generation, terminateCandidate);
+      if (this.#preparedPlayer === player) {
+        this.#preparedPlayer = null;
+      }
       this.#player = player;
       published = true;
       this.#mode = mode;
@@ -299,6 +346,9 @@ export class AuthoringExecutionClient {
       this.#resizeCurrentCanvas();
       return ready;
     } catch (error) {
+      if (this.#preparedPlayer === player) {
+        this.#preparedPlayer = null;
+      }
       if (!published || generation === this.#lifecycleGeneration) {
         terminateCandidate();
       }
@@ -310,6 +360,22 @@ export class AuthoringExecutionClient {
       }
       throw error;
     }
+  }
+
+  #createPlayer() {
+    return new ExecutionWorkerClient(this.#canvas, {
+      onError: this.#onError,
+      onRecoverableError: this.#onRecoverableError,
+    });
+  }
+
+  #resolveStartupSharedSlotCapacity(sharedSlotCapacity) {
+    if (sharedSlotCapacity !== undefined) {
+      return validateSharedSlotCapacity(sharedSlotCapacity);
+    }
+    return this.#preparedPlayer === null
+      ? DEFAULT_SHARED_SLOT_CAPACITY
+      : this.#sharedSlotCapacity;
   }
 
   async #switchRetainedCanonical(sceneSpecJson) {

--- a/web/authoring-execution-prepared-start.test.mjs
+++ b/web/authoring-execution-prepared-start.test.mjs
@@ -1,0 +1,217 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+class FakeCanvas {
+  clientWidth = 640;
+  clientHeight = 360;
+  width = 640;
+  height = 360;
+  replacement = null;
+  transferred = false;
+
+  transferControlToOffscreen() {
+    if (this.transferred) {
+      throw new Error("canvas was transferred twice");
+    }
+    this.transferred = true;
+    return { width: this.width, height: this.height };
+  }
+
+  cloneNode() {
+    const clone = new FakeCanvas();
+    clone.clientWidth = this.clientWidth;
+    clone.clientHeight = this.clientHeight;
+    clone.width = this.width;
+    clone.height = this.height;
+    return clone;
+  }
+
+  replaceWith(replacement) {
+    this.replacement = replacement;
+  }
+}
+
+class FakeWorker {
+  static instances = [];
+
+  listeners = new Map();
+  messages = [];
+  terminated = false;
+
+  constructor(url, options = {}) {
+    this.url = String(url);
+    this.name = options.name ?? "";
+    FakeWorker.instances.push(this);
+  }
+
+  addEventListener(type, listener) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  postMessage(message, transfer = []) {
+    this.messages.push({ message, transfer });
+  }
+
+  terminate() {
+    this.terminated = true;
+  }
+
+  emitMessage(message) {
+    for (const listener of this.listeners.get("message") ?? []) {
+      listener({ data: message });
+    }
+  }
+}
+
+globalThis.HTMLCanvasElement = FakeCanvas;
+globalThis.Worker = FakeWorker;
+globalThis.window = { devicePixelRatio: 1 };
+
+const { AuthoringExecutionClient } = await import("./authoring-execution-client.js");
+
+const SCENE_SPEC_JSON = JSON.stringify({
+  version: 1,
+  objects: [{ id: 1 }],
+  tracks: [],
+});
+const NON_DEFAULT_SHARED_SLOT_CAPACITY = 2 * 1024 * 1024;
+
+function envelope(channel, type, payload = {}) {
+  return { channel, protocolVersion: 1, type, ...payload };
+}
+
+function workerByName(offset, name) {
+  const worker = FakeWorker.instances.slice(offset).find((candidate) => candidate.name === name);
+  assert.ok(worker, `missing worker ${name}`);
+  return worker;
+}
+
+function requestMessage(worker, type) {
+  const entry = worker.messages.findLast(({ message }) => message.type === type);
+  assert.ok(entry, `missing ${worker.name} ${type} request`);
+  return entry.message;
+}
+
+function acknowledgePreparation(render) {
+  const request = requestMessage(render, "prepare");
+  render.emitMessage(
+    envelope("noon.render", "prepared", {
+      requestId: request.requestId,
+      transportMode: "transferable",
+      width: 640,
+      height: 360,
+    }),
+  );
+  return request;
+}
+
+function finishRetainedStart(render, engine) {
+  const startRequest = requestMessage(render, "start_engine");
+  engine.emitMessage(
+    envelope("noon.engine", "ready", {
+      transportMode: "transferable",
+      retained: true,
+      mixed: true,
+    }),
+  );
+  render.emitMessage(
+    envelope("noon.render", "engine_started", {
+      requestId: startRequest.requestId,
+      mode: "retained",
+      transportMode: "transferable",
+      backend: "WebGL2",
+    }),
+  );
+}
+
+test("prepared authoring execution stays unpublished until the canonical retained engine is ready", async () => {
+  FakeWorker.instances.length = 0;
+  const client = new AuthoringExecutionClient(new FakeCanvas());
+  const preparation = client.prepare({ transportMode: "transferable" });
+  const render = workerByName(0, "noon-render");
+  const prepareRequest = requestMessage(render, "prepare");
+
+  assert.equal(client.mode, null, "mode must remain unpublished during render preparation");
+  await assert.rejects(
+    client.state(),
+    /AuthoringExecutionClient has not been started/,
+    "prepared resources must not make public execution state available",
+  );
+
+  const started = client.startRetainedCanonical(SCENE_SPEC_JSON);
+  assert.equal(client.mode, null, "mode must remain unpublished while preparation is pending");
+  assert.equal(
+    FakeWorker.instances.some(({ name }) => name === "noon-mixed-retained-engine"),
+    false,
+    "canonical authored engine startup must wait for the render preparation barrier",
+  );
+
+  render.emitMessage(
+    envelope("noon.render", "prepared", {
+      requestId: prepareRequest.requestId,
+      transportMode: "transferable",
+      width: 640,
+      height: 360,
+    }),
+  );
+  await preparation;
+  await new Promise((resolve) => setImmediate(resolve));
+
+  const engine = workerByName(1, "noon-mixed-retained-engine");
+  finishRetainedStart(render, engine);
+
+  const ready = await started;
+  assert.equal(ready.session, 1);
+  assert.equal(client.mode, "retained");
+  assert.equal(client.rendererBackend, "WebGL2");
+  client.terminate();
+});
+
+test("prepared canonical startup inherits a non-default shared slot capacity", async () => {
+  FakeWorker.instances.length = 0;
+  const client = new AuthoringExecutionClient(new FakeCanvas());
+  const preparation = client.prepare({
+    transportMode: "transferable",
+    sharedSlotCapacity: NON_DEFAULT_SHARED_SLOT_CAPACITY,
+  });
+  const render = workerByName(0, "noon-render");
+  acknowledgePreparation(render);
+  await preparation;
+
+  const started = client.startRetainedCanonical(SCENE_SPEC_JSON);
+  await new Promise((resolve) => setImmediate(resolve));
+  const engine = workerByName(1, "noon-mixed-retained-engine");
+  const init = requestMessage(engine, "init");
+  assert.equal(
+    init.sharedSlotCapacity,
+    NON_DEFAULT_SHARED_SLOT_CAPACITY,
+    "canonical startup must inherit prepared transport capacity without an explicit override",
+  );
+  finishRetainedStart(render, engine);
+  await started;
+  client.terminate();
+});
+
+test("terminating during render preparation cancels the unpublished candidate and adopts its fresh canvas", async () => {
+  FakeWorker.instances.length = 0;
+  const original = new FakeCanvas();
+  const client = new AuthoringExecutionClient(original);
+  const preparation = client.prepare({ transportMode: "transferable" });
+  const render = workerByName(0, "noon-render");
+
+  client.terminate();
+
+  await assert.rejects(
+    preparation,
+    /AuthoringExecutionClient was terminated during an asynchronous operation/,
+  );
+  assert.equal(render.terminated, true);
+  assert.equal(original.transferred, true);
+  assert.notEqual(client.canvas, original);
+  assert.equal(original.replacement, client.canvas);
+  assert.equal(client.canvas.transferred, false);
+  assert.equal(client.mode, null);
+  await assert.rejects(client.state(), /AuthoringExecutionClient has not been started/);
+});


### PR DESCRIPTION
Current-master canonical-SceneSpec replacement for #654.

`AuthoringExecutionClient` can now own a mode-free prepared low-level execution candidate without publishing an execution mode or exposing state/metrics/playback until the authored engine is genuinely ready.

What changed:
- add facade-level `prepare()` backed by an unpublished `ExecutionWorkerClient` candidate;
- keep `mode`, public state, and active-player semantics unavailable while only render/WASM preparation exists;
- finalize that same candidate through current `start()` or `startRetainedCanonical(SceneSpec)` after authoring selects the engine mode;
- publish the candidate only after the low-level ready boundary succeeds;
- inherit a non-default prepared shared-slot capacity when final startup omits an explicit override;
- preserve explicit capacity/transport mismatch validation in the low-level owner;
- on preparation cancellation, adopt the replacement canvas so the facade never retains a detached transferred element.

The focused Node regression uses only the current canonical retained startup API and covers unpublished preparation, no speculative retained engine before the preparation barrier, prepared capacity inheritance, and termination/canvas adoption. The low-level stale-generation rollback that this lifecycle depends on is now fixed by merged #931.

Supersedes #654. Tracks #642.