### PR TITLE
Expose common Mobject origin transforms through shared semantics

### DIFF
--- a/web/manim-mobject-transform-ownership.test.mjs
+++ b/web/manim-mobject-transform-ownership.test.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const adapterUrl = new URL("./python/_manim_mobject_transforms.py", import.meta.url);
+const modulesUrl = new URL("./python-compat-modules.js", import.meta.url);
+
+test("Mobject placement and origin rotation compose through shared semantics", async () => {
+  const [adapter, modules] = await Promise.all([
+    readFile(fileURLToPath(adapterUrl), "utf8"),
+    readFile(fileURLToPath(modulesUrl), "utf8"),
+  ]);
+
+  assert.match(adapter, /def _center\(/);
+  assert.match(adapter, /return self\.move_to\(_base\.ORIGIN\)/);
+  assert.match(adapter, /_base\.Mobject\.center = _center/);
+  assert.match(adapter, /_compat\.Group\.center = _center/);
+
+  assert.match(adapter, /def _rotate_about_origin\(/);
+  assert.match(
+    adapter,
+    /self\.rotate\(angle, axis=axis, about_point=_base\.ORIGIN, \*\*kwargs\)/,
+  );
+  assert.match(
+    adapter,
+    /_base\.Mobject\.rotate_about_origin = _rotate_about_origin/,
+  );
+  assert.match(
+    adapter,
+    /_compat\.Group\.rotate_about_origin = _rotate_about_origin/,
+  );
+
+  // These adapters are syntax-only: layout and transform math remain owned by
+  // the shared semantic handle paths behind move_to/rotate.
+  assert.doesNotMatch(adapter, /math\.(?:sin|cos)/);
+  assert.doesNotMatch(adapter, /transform\s*\[/);
+  assert.doesNotMatch(adapter, /get_center\(\)/);
+
+  const semanticIndex = modules.indexOf("python/_manim_semantic_handles.py");
+  const transformIndex = modules.indexOf("python/_manim_mobject_transforms.py");
+  assert.ok(semanticIndex >= 0, "semantic handle module must be registered");
+  assert.ok(
+    transformIndex > semanticIndex,
+    "transform adapters must load after shared semantic handles",
+  );
+});

--- a/web/python-compat-modules.js
+++ b/web/python-compat-modules.js
@@ -3,6 +3,7 @@ export const PYTHON_COMPAT_MODULES = Object.freeze([
   { sourcePath: "python/_noon_ir.py", runtimePath: "/tmp/_noon_ir.py", label: "Noon Python IR emitter" },
   { sourcePath: "python/_manim_compat.py", runtimePath: "/tmp/_manim_compat.py", label: "Noon Manim compatibility layer" },
   { sourcePath: "python/_manim_semantic_handles.py", runtimePath: "/tmp/_manim_semantic_handles.py", label: "Noon shared semantic handle layer" },
+  { sourcePath: "python/_manim_mobject_transforms.py", runtimePath: "/tmp/_manim_mobject_transforms.py", label: "Noon Manim Mobject transform adapters" },
   { sourcePath: "python/_manim_typst.py", runtimePath: "/tmp/_manim_typst.py", label: "Noon retained Typst compatibility layer" },
   { sourcePath: "python/_manim_retained_animate.py", runtimePath: "/tmp/_manim_retained_animate.py", label: "Noon retained text animation layer" },
   { sourcePath: "python/_manim_family_creation.py", runtimePath: "/tmp/_manim_family_creation.py", label: "Noon retained family creation-animation layer" },

--- a/web/python/_manim_mobject_transforms.py
+++ b/web/python/_manim_mobject_transforms.py
@@ -1,0 +1,41 @@
+"""Thin Manim Mobject transform adapters over shared Noon semantics."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import noon as _base
+import _manim_compat as _compat
+
+
+def _center(self: _base.Mobject) -> _base.Mobject:
+    """Pinned ManimCE v0.21 ``Mobject.center`` for Noon's 2D plane.
+
+    Centering is placement syntax, not a second geometry implementation. ``move_to``
+    already resolves the object's shared layout center and shifts through the common
+    semantic handle path, so keep this adapter as a zero-math composition.
+    """
+
+    return self.move_to(_base.ORIGIN)
+
+
+def _rotate_about_origin(
+    self: _base.Mobject,
+    angle: float,
+    axis: object = _compat.OUT,
+    **kwargs: Any,
+) -> _base.Mobject:
+    """Pinned ManimCE v0.21 ``Mobject.rotate_about_origin`` for Noon's 2D plane.
+
+    Keep the compatibility method as syntax-only composition. ``rotate`` already
+    delegates pivoted rotation to the shared Rust/WASM semantic handle, so this
+    adapter must not duplicate transform or pivot math in Python.
+    """
+
+    return self.rotate(angle, axis=axis, about_point=_base.ORIGIN, **kwargs)
+
+
+_base.Mobject.center = _center
+_compat.Group.center = _center
+_base.Mobject.rotate_about_origin = _rotate_about_origin
+_compat.Group.rotate_about_origin = _rotate_about_origin


### PR DESCRIPTION
Replaced by a normal non-draft current-master PR because the connected GitHub draft→ready mutation is still broken (`Repository.fullDatabaseId`).

The replacement uses the latest version of this work, not the earlier rotate-only snapshot: `Mobject.center` / `Group.center` compose through `move_to(ORIGIN)`, and `Mobject.rotate_about_origin` / `Group.rotate_about_origin` compose through the existing shared `rotate(..., about_point=ORIGIN)` semantic path. No Python-side layout, pivot, trigonometric, or transform-array math is introduced.

The three-file tree has been replayed onto master `04d4987c8835662fa0c3dd15a264af64cd7ae663` after #943 and #944, so its replacement can receive fresh qualification against the actual current repository state.

Closing only to replace the draft; the implementation continues unchanged in the current-master PR.