### PR TITLE
Fix WebGL analytic line host-updater raster divergence

### DIFF
--- a/crates/noon-render-wgpu/src/analytic.wgsl
+++ b/crates/noon-render-wgpu/src/analytic.wgsl
@@ -43,6 +43,7 @@ struct VertexOutput {
     @location(4) metrics: vec2<f32>,
     @location(5) flags: vec2<f32>,
     @location(6) object_scale: vec2<f32>,
+    @location(7) line_stroke_enabled: f32,
 };
 
 fn rotate_vector(local: vec2<f32>, rotation: f32) -> vec2<f32> {
@@ -132,6 +133,7 @@ fn make_output(input: VertexInput, local: vec2<f32>) -> VertexOutput {
     output.metrics = input.metrics;
     output.flags = vec2<f32>(f32(input.flags.x), f32(input.flags.y));
     output.object_scale = input.scale;
+    output.line_stroke_enabled = 0.0;
     return output;
 }
 
@@ -236,6 +238,7 @@ fn vs_line(input: LineVertexInput) -> VertexOutput {
     output.stroke = input.stroke;
     output.metrics = input.metrics;
     output.flags = vec2<f32>(f32(input.flags.x), f32(input.flags.y));
+    output.line_stroke_enabled = select(0.0, 1.0, stroke_is_enabled(input.flags));
     return output;
 }
 
@@ -330,7 +333,7 @@ fn styled_shape_color(
 
 fn styled_line_color(input: VertexOutput, signed_distance: f32) -> vec4<f32> {
     let coverage = inside_coverage(signed_distance);
-    if (u32(input.flags.y) & 1u) != 0u {
+    if input.line_stroke_enabled >= 0.5 {
         return covered_color(input.stroke, input.metrics.y, coverage);
     }
     if input.flags.x > 0.5 {

--- a/crates/noon-render-wgpu/tests/analytic_line_caps.rs
+++ b/crates/noon-render-wgpu/tests/analytic_line_caps.rs
@@ -75,3 +75,17 @@ fn analytic_shader_has_distinct_round_butt_and_square_cap_sdfs() {
     assert!(shader.contains("else if cap_mode == 2u"));
     assert!(shader.contains("vec2<f32>(half_length + radius, radius)"));
 }
+
+#[test]
+fn analytic_line_fragment_passes_stroke_enablement_as_a_scalar_varying() {
+    let shader = include_str!("../src/analytic.wgsl");
+    assert!(shader.contains("@location(7) line_stroke_enabled: f32"));
+    assert!(shader.contains("output.line_stroke_enabled = select(0.0, 1.0, stroke_is_enabled(input.flags));"));
+    let styled_line_color = shader
+        .split_once("fn styled_line_color")
+        .and_then(|(_, remainder)| remainder.split_once("fn rectangle_signed_distance"))
+        .map(|(body, _)| body)
+        .expect("styled_line_color and the following helper must remain in the shader");
+    assert!(styled_line_color.contains("input.line_stroke_enabled >= 0.5"));
+    assert!(!styled_line_color.contains("(u32(input.flags.y) & 1u)"));
+}

--- a/crates/noon-render-wgpu/tests/analytic_line_caps.rs
+++ b/crates/noon-render-wgpu/tests/analytic_line_caps.rs
@@ -80,7 +80,9 @@ fn analytic_shader_has_distinct_round_butt_and_square_cap_sdfs() {
 fn analytic_line_fragment_passes_stroke_enablement_as_a_scalar_varying() {
     let shader = include_str!("../src/analytic.wgsl");
     assert!(shader.contains("@location(7) line_stroke_enabled: f32"));
-    assert!(shader.contains("output.line_stroke_enabled = select(0.0, 1.0, stroke_is_enabled(input.flags));"));
+    assert!(shader.contains(
+        "output.line_stroke_enabled = select(0.0, 1.0, stroke_is_enabled(input.flags));"
+    ));
     let styled_line_color = shader
         .split_once("fn styled_line_color")
         .and_then(|(_, remainder)| remainder.split_once("fn rectangle_signed_distance"))

--- a/scripts/manim-host-updater-diagnostics.mjs
+++ b/scripts/manim-host-updater-diagnostics.mjs
@@ -5,8 +5,12 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import playwright from "playwright";
+import pngjs from "pngjs";
+
+import { compareForegroundCoverage } from "./browser-visual-parity-lib.mjs";
 
 const { chromium } = playwright;
+const { PNG } = pngjs;
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const port = Number(process.env.NOON_MANIM_HOST_DIAGNOSTICS_PORT ?? "4194");
 const baseUrl = `http://127.0.0.1:${port}`;
@@ -14,6 +18,12 @@ const targetObject = 2;
 const targetFrame = 90;
 const targetTime = 3.0;
 const frameTimes = Array.from({ length: targetFrame + 1 }, (_, index) => index / 30);
+const rasterTolerances = {
+  backgroundDistance: 32,
+  neighborRadius: 1,
+  maxMismatchFraction: 0.02,
+  maxBoundsDelta: 2,
+};
 const source = await readFile(
   path.join(repoRoot, "web/python/examples/manim_host_updater_mixed_primitive.py"),
   "utf8",
@@ -135,9 +145,10 @@ function assertDiagnostic(diagnostic, backend) {
   assert.equal(diagnostic.draw_plan.submission_membership, true);
   assert.ok(
     diagnostic.draw_plan.batches.some(
-      (batch) => batch.primitive === "line"
-        && batch.instance_range.start <= lineInstanceIndex
-        && batch.instance_range.end > lineInstanceIndex,
+      (batch) =>
+        batch.primitive === "line" &&
+        batch.instance_range.start <= lineInstanceIndex &&
+        batch.instance_range.end > lineInstanceIndex,
     ),
     `${backend}: target is absent from draw plan`,
   );
@@ -177,7 +188,8 @@ async function runBackend(browser, backend) {
     assertNear(result.time, targetTime, `${backend}: logical frame time`);
     assertDiagnostic(result.diagnostic, backend);
     assert.deepEqual(errors, [], `${backend}: browser errors`);
-    return result.diagnostic;
+    const screenshot = await page.locator("#scene").screenshot();
+    return { diagnostic: result.diagnostic, screenshot };
   } finally {
     await page.close();
   }
@@ -191,26 +203,50 @@ try {
     headless: true,
     args: browserArgs("webgl"),
   });
-  const webglDiagnostic = await runBackend(browser, "webgl");
+  const webgl = await runBackend(browser, "webgl");
   await browser.close();
   browser = await chromium.launch({
     channel: "chromium",
     headless: true,
     args: browserArgs("webgpu"),
   });
-  const webgpuDiagnostic = await runBackend(browser, "webgpu");
+  const webgpu = await runBackend(browser, "webgpu");
 
   for (const field of ["committed", "prepared", "upload", "draw_plan"]) {
     assert.deepEqual(
-      webglDiagnostic[field],
-      webgpuDiagnostic[field],
+      webgl.diagnostic[field],
+      webgpu.diagnostic[field],
       `WebGL2/WebGPU ${field} diagnostic state diverged`,
     );
   }
-  assert.deepEqual(webglDiagnostic.present_call.submit_called, webgpuDiagnostic.present_call.submit_called);
-  assert.deepEqual(webglDiagnostic.present_call.present_called, webgpuDiagnostic.present_call.present_called);
+  assert.deepEqual(
+    webgl.diagnostic.present_call.submit_called,
+    webgpu.diagnostic.present_call.submit_called,
+  );
+  assert.deepEqual(
+    webgl.diagnostic.present_call.present_called,
+    webgpu.diagnostic.present_call.present_called,
+  );
+
+  const rasterComparison = compareForegroundCoverage(
+    PNG.sync.read(webgpu.screenshot),
+    PNG.sync.read(webgl.screenshot),
+    rasterTolerances,
+  );
+  assert.equal(
+    rasterComparison.pass,
+    true,
+    `WebGL2/WebGPU frame-90 foreground coverage diverged: ` +
+      `${(rasterComparison.mismatchFraction * 100).toFixed(3)}% unmatched foreground, ` +
+      `${rasterComparison.boundsDelta}px bounds delta`,
+  );
   console.log(
-    "✓ RotationUpdater frame 90 / t=3.0s: committed, prepared, uploaded, drawn, and presented state agree on WebGL2 and WebGPU",
+    `✓ RotationUpdater frame 90 raster parity: ` +
+      `${(rasterComparison.mismatchFraction * 100).toFixed(3)}% unmatched foreground, ` +
+      `${rasterComparison.boundsDelta}px bounds delta`,
+  );
+  console.log(
+    "✓ RotationUpdater frame 90 / t=3.0s: committed, prepared, uploaded, drawn, presented, and raster-visible state agree on WebGL2 and WebGPU",
   );
 } finally {
   await browser?.close();


### PR DESCRIPTION
## Summary

- Fix WebGL/ANGLE fragment evaluation for analytic line stroke flags.
- Compute the packed stroke-enabled bit in the vertex stage and pass it as a scalar float varying to the fragment stage.
- Preserve the existing 88-byte `LineInstance` ABI and partial dirty-range uploads.
- Add a shader contract regression test.

The WebGL host-updater path was receiving the correct updated line instance and upload range, but `fs_line` tested the interpolated `flags.y` by converting it to `u32` and applying a bitwise operation. ANGLE produced stale/incorrect fragment coverage for that expression after the partial update. The integer bit test now remains on the vertex input, and the fragment shader performs only a scalar comparison.

Closes #513

## Validation

- `cargo test -p noon-render-wgpu --all-targets`
- `NOON_SKIP_WEB_PREFLIGHT=1 NOON_WASM_PROFILE=dev bash scripts/build-web-demo.sh`
- `node scripts/manim-host-updater-diagnostics.mjs`
- Focused Chromium WebGL frame-90 raster probe: rotated line restored, no browser errors

The full Cairo differential remains unavailable in this local environment because Python Manim is not installed.
