### PR TITLE
Overlap first-run Python authoring and render preparation

### DIFF
--- a/web/main.js
+++ b/web/main.js
@@ -12,7 +12,7 @@ import {
   requestedExampleId,
 } from "./example-gallery.js";
 
-const canvas = document.querySelector("#scene");
+let canvas = document.querySelector("#scene");
 const status = document.querySelector("#status");
 const statusText = document.querySelector("#status-text");
 const sceneButton = document.querySelector("#replace-scene");
@@ -326,7 +326,6 @@ const selectedTags = document.createElement("div");
 selectedTags.className = "selected-tags";
 selectedExampleStrip.append(selectedCopy, selectedTags);
 workspace.before(selectedExampleStrip);
-
 const resetButton = document.createElement("button");
 resetButton.type = "button";
 resetButton.className = "secondary-button reset-example";
@@ -347,6 +346,7 @@ let playbackDurationSeconds = 4.0;
 let rendererBackend = "";
 let sceneRunPromise = null;
 let runtimeStartPromise = null;
+let runtimePreparation = null;
 let playerNeedsRestart = false;
 let busyDepth = 0;
 let galleryPage = 0;
@@ -444,7 +444,58 @@ function ensureAuthoringClient() {
   return authoringClient;
 }
 
+function adoptRuntimeCanvas(candidate) {
+  if (canvas !== candidate.canvas) {
+    canvas = candidate.canvas;
+  }
+}
+
+function createRuntimeClient() {
+  let candidate = null;
+  candidate = new AuthoringExecutionClient(canvas, {
+    onError(error) {
+      if (player !== candidate) return;
+      playerNeedsRestart = true;
+      showError(error);
+    },
+    onRecoverableError(error) {
+      showRecoverableSceneError(error);
+    },
+  });
+  return candidate;
+}
+
+function ensureRuntimePreparation() {
+  if (player !== null) return null;
+  if (runtimePreparation !== null) return runtimePreparation;
+
+  const candidate = createRuntimeClient();
+  const ready = candidate.prepare();
+  const preparation = { candidate, ready };
+  runtimePreparation = preparation;
+  status.dataset.runtimeStartup = "preparing-on-run";
+  status.dataset.executionTopology = "preparing-render-owner";
+
+  ready.then(
+    () => {
+      if (runtimePreparation === preparation) {
+        status.dataset.runtimeStartup = "prepared-on-run";
+        status.dataset.executionTopology = "prepared-render-owner";
+      }
+    },
+    (error) => {
+      adoptRuntimeCanvas(candidate);
+      if (runtimePreparation === preparation) {
+        runtimePreparation = null;
+      }
+      console.warn("Execution runtime preparation failed", error);
+    },
+  );
+  return preparation;
+}
+
 async function ensureRuntimeReady({
+  preparation = null,
   sceneJson,
   sceneSpecJson,
   startRetained,
@@ -456,10 +507,6 @@ async function ensureRuntimeReady({
   if (player !== null) return null;
 
   const task = (async () => {
-    setRuntimeStatus("Starting execution runtime…", "running");
-    patchStatus.value = "Starting GPU execution runtime…";
-    patchStatus.dataset.state = "running";
-
     if (startRetained && callbacks !== null && callbacks !== undefined) {
       throw new Error(
         "retained authoring with Python host callbacks is not supported yet; " +
@@ -467,16 +514,17 @@ async function ensureRuntimeReady({
       );
     }
 
-    const nextPlayer = new AuthoringExecutionClient(canvas, {
-      onError(error) {
-        playerNeedsRestart = true;
-        showError(error);
-      },
-      onRecoverableError(error) {
-        showRecoverableSceneError(error);
-      },
-    });
+    const prepared = preparation ?? ensureRuntimePreparation();
+    if (prepared === null) {
+      throw new Error("execution runtime preparation is unavailable");
+    }
+    const nextPlayer = prepared.candidate;
     try {
+      await prepared.ready;
+      setRuntimeStatus("Starting authored execution engine…", "running");
+      patchStatus.value = "Starting authored GPU execution engine…";
+      patchStatus.dataset.state = "running";
+
       const ready = startRetained
         ? await nextPlayer.startRetainedCanonical(sceneSpecJson, {
             loopDurationSeconds,
@@ -489,6 +537,9 @@ async function ensureRuntimeReady({
       const initialState = await nextPlayer.state();
 
       player = nextPlayer;
+      if (runtimePreparation === prepared) {
+        runtimePreparation = null;
+      }
       playerNeedsRestart = false;
       rendererBackend = ready.render.backend;
       status.dataset.rendererBackend = rendererBackend;
@@ -518,7 +569,11 @@ async function ensureRuntimeReady({
         mode: nextPlayer.mode,
       };
     } catch (error) {
+      if (runtimePreparation === prepared) {
+        runtimePreparation = null;
+      }
       nextPlayer.terminate();
+      adoptRuntimeCanvas(nextPlayer);
       if (player === nextPlayer) {
         player = null;
         playbackControls?.destroy();
@@ -687,6 +742,7 @@ async function runScene() {
     try {
       patchStatus.value = `Building ${example.title} in the Python worker…`;
       patchStatus.dataset.state = "running";
+      const preparation = player === null ? ensureRuntimePreparation() : null;
       const client = ensureAuthoringClient();
       status.dataset.authoringWarmup = "started";
       let authored;
@@ -740,6 +796,7 @@ async function runScene() {
       let result;
       if (player === null) {
         result = await ensureRuntimeReady({
+          preparation,
           sceneJson,
           sceneSpecJson,
           startRetained,
@@ -1056,6 +1113,9 @@ try {
       playbackControls = null;
       authoringClient?.terminate();
       authoringClient = null;
+      const preparation = runtimePreparation;
+      runtimePreparation = null;
+      preparation?.candidate.terminate();
       player?.terminate();
       player = null;
     },

--- a/web/playground-first-run-preparation.test.mjs
+++ b/web/playground-first-run-preparation.test.mjs
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const main = await readFile(new URL("./main.js", import.meta.url), "utf8");
+
+assert.match(
+  main,
+  /let canvas = document\.querySelector\("#scene"\);/,
+  "the playground must be able to adopt a replacement canvas from an unpublished prepared owner",
+);
+
+const createRuntimeStart = main.indexOf("function createRuntimeClient()");
+const preparationStart = main.indexOf("function ensureRuntimePreparation()", createRuntimeStart);
+const runtimeReadyStart = main.indexOf("async function ensureRuntimeReady({", preparationStart);
+const executionReadyStart = main.indexOf("async function ensureExecutionReady()", runtimeReadyStart);
+assert.ok(
+  createRuntimeStart >= 0 &&
+    preparationStart > createRuntimeStart &&
+    runtimeReadyStart > preparationStart &&
+    executionReadyStart > runtimeReadyStart,
+  "prepared-owner creation and authored-engine startup boundaries must exist in order",
+);
+
+const createRuntimeBody = main.slice(createRuntimeStart, preparationStart);
+const preparationBody = main.slice(preparationStart, runtimeReadyStart);
+const runtimeReadyBody = main.slice(runtimeReadyStart, executionReadyStart);
+
+assert.match(
+  createRuntimeBody,
+  /new AuthoringExecutionClient\(canvas,/,
+  "first Run must create one execution facade candidate on demand",
+);
+assert.match(
+  createRuntimeBody,
+  /if \(player !== candidate\) return;/,
+  "fatal callbacks from an unpublished candidate must not mark a public player for restart",
+);
+assert.match(
+  preparationBody,
+  /if \(runtimePreparation !== null\) return runtimePreparation;/,
+  "Python or stale-run failures must be able to reuse an already prepared candidate",
+);
+assert.match(
+  preparationBody,
+  /const ready = candidate\.prepare\(\);/,
+  "first Run must prepare the mode-free render owner",
+);
+assert.doesNotMatch(
+  preparationBody,
+  /candidate\.start(?:RetainedCanonical)?\(/,
+  "mode-free preparation must not speculate a legacy or retained engine",
+);
+assert.match(
+  preparationBody,
+  /adoptRuntimeCanvas\(candidate\);[\s\S]*runtimePreparation = null;/,
+  "failed render preparation must adopt the replacement canvas and release the failed candidate",
+);
+
+assert.match(
+  runtimeReadyBody,
+  /const prepared = preparation \?\? ensureRuntimePreparation\(\);/,
+  "authored startup must consume the candidate prepared in parallel with Python",
+);
+assert.match(
+  runtimeReadyBody,
+  /await prepared\.ready;/,
+  "engine attachment must wait for mode-free render preparation",
+);
+assert.match(
+  runtimeReadyBody,
+  /await nextPlayer\.startRetainedCanonical\(sceneSpecJson,/,
+  "canonical retained first runs must attach directly after authoring selects retained mode",
+);
+assert.match(
+  runtimeReadyBody,
+  /await nextPlayer\.start\(sceneJson,/,
+  "legacy first runs must attach directly after authoring selects legacy mode",
+);
+const retainedStart = runtimeReadyBody.indexOf("await nextPlayer.startRetainedCanonical(sceneSpecJson,");
+const legacyStart = runtimeReadyBody.indexOf("await nextPlayer.start(sceneJson,");
+const playerPublish = runtimeReadyBody.indexOf("player = nextPlayer;");
+assert.ok(
+  retainedStart >= 0 && legacyStart >= 0 && playerPublish > retainedStart && playerPublish > legacyStart,
+  "the prepared candidate must remain unpublished until the selected authored engine is ready",
+);
+assert.match(
+  runtimeReadyBody,
+  /if \(runtimePreparation === prepared\) \{\s*runtimePreparation = null;/,
+  "successful publication must consume the prepared candidate exactly once",
+);
+assert.match(
+  runtimeReadyBody,
+  /nextPlayer\.terminate\(\);\s*adoptRuntimeCanvas\(nextPlayer\);/,
+  "failed engine attachment must terminate the candidate and adopt its fresh canvas",
+);
+
+const runSceneStart = main.indexOf("async function runScene()");
+const selectExampleStart = main.indexOf("async function selectExample(", runSceneStart);
+assert.ok(runSceneStart >= 0 && selectExampleStart > runSceneStart, "runScene boundary must exist");
+const runSceneBody = main.slice(runSceneStart, selectExampleStart);
+const preparationCall = runSceneBody.indexOf(
+  "const preparation = player === null ? ensureRuntimePreparation() : null;",
+);
+const authoringCall = runSceneBody.indexOf("authored = await client.run(source,");
+const runtimeCall = runSceneBody.indexOf("result = await ensureRuntimeReady({");
+assert.ok(
+  preparationCall >= 0 && preparationCall < authoringCall,
+  "cold Run must kick render/WASM preparation before awaiting Python authoring",
+);
+assert.ok(
+  runtimeCall > authoringCall,
+  "engine selection and attachment must still wait for authored output",
+);
+assert.match(
+  runSceneBody,
+  /result = await ensureRuntimeReady\(\{\s*preparation,/,
+  "cold authored startup must consume the preparation started before the Python await",
+);
+
+const bootStart = main.indexOf("try {\n  const requested = requestedExampleId();");
+const bootCatch = main.indexOf("} catch (error) {\n  showError(error);", bootStart);
+assert.ok(bootStart >= 0 && bootCatch > bootStart, "playground boot boundary must exist");
+const bootBody = main.slice(bootStart, bootCatch);
+assert.doesNotMatch(
+  bootBody.slice(0, bootBody.indexOf("window.__noonExampleGallery")),
+  /ensureRuntimePreparation\(|new AuthoringExecutionClient\(/,
+  "page boot must remain fully deferred until an explicit Run",
+);
+assert.match(
+  bootBody,
+  /pagehide[\s\S]*const preparation = runtimePreparation;[\s\S]*runtimePreparation = null;[\s\S]*preparation\?\.candidate\.terminate\(\);[\s\S]*player\?\.terminate\(\);/,
+  "page teardown must release an unpublished prepared owner before the published player",
+);
+
+console.log(
+  "✓ first Run overlaps Python authoring with mode-free render preparation and publishes only the authored engine",
+);

--- a/web/playground-stability-boundary.test.mjs
+++ b/web/playground-stability-boundary.test.mjs
@@ -66,17 +66,37 @@ assert.match(
   "retained to legacy authoring must switch the persistent execution owner in place",
 );
 
-const runtimeReadyStart = main.indexOf("async function ensureRuntimeReady(");
-const runtimeReadyEnd = main.indexOf("async function ensureExecutionReady()", runtimeReadyStart);
-assert.ok(
-  runtimeReadyStart >= 0 && runtimeReadyEnd > runtimeReadyStart,
-  "playground must keep an explicit on-demand runtime boundary",
+assert.match(
+  main,
+  /let canvas = document\.querySelector\("#scene"\);/,
+  "playground must be able to adopt a replacement DOM canvas after prepared-owner rollback",
 );
-const runtimeReadyBody = main.slice(runtimeReadyStart, runtimeReadyEnd);
-const playgroundConstruction = runtimeReadyBody.match(
-  /const nextPlayer = new AuthoringExecutionClient\(canvas, \{([\s\S]*?)\n\s*\}\);/,
+const createRuntimeStart = main.indexOf("function createRuntimeClient()");
+const preparationStart = main.indexOf("function ensureRuntimePreparation()", createRuntimeStart);
+const runtimeReadyStart = main.indexOf("async function ensureRuntimeReady(", preparationStart);
+assert.ok(
+  createRuntimeStart >= 0 && preparationStart > createRuntimeStart && runtimeReadyStart > preparationStart,
+  "playground must separate client construction, mode-free preparation, and authored startup",
+);
+const createRuntimeBody = main.slice(createRuntimeStart, preparationStart);
+const preparationBody = main.slice(preparationStart, runtimeReadyStart);
+const playgroundConstruction = createRuntimeBody.match(
+  /candidate = new AuthoringExecutionClient\(canvas, \{([\s\S]*?)\n\s*\}\);/,
 )?.[1];
-assert.ok(playgroundConstruction, "deferred runtime must configure its authoring execution client");
+assert.ok(playgroundConstruction, "deferred runtime must configure its authoring execution client once");
+const fatalHandler = playgroundConstruction.match(
+  /onError\(error\) \{([\s\S]*?)\n\s*\}/,
+)?.[1];
+assert.match(
+  fatalHandler ?? "",
+  /if \(player !== candidate\) return;/,
+  "fatal callbacks from an unpublished preparation must not mark a nonexistent player for restart",
+);
+assert.match(
+  fatalHandler ?? "",
+  /playerNeedsRestart = true;/,
+  "fatal callbacks from the published player must still request worker restart",
+);
 assert.match(
   playgroundConstruction,
   /onRecoverableError\(error\) \{\s*showRecoverableSceneError\(error\);\s*\}/,
@@ -89,6 +109,21 @@ assert.doesNotMatch(
   recoverableHandler ?? "",
   /playerNeedsRestart\s*=\s*true/,
   "recoverable scene errors must not request worker restart",
+);
+assert.match(
+  preparationBody,
+  /if \(runtimePreparation !== null\) return runtimePreparation;/,
+  "a prepared unpublished owner must survive Python/stale retries instead of spawning duplicate owners",
+);
+assert.match(
+  preparationBody,
+  /adoptRuntimeCanvas\(candidate\);[\s\S]*runtimePreparation = null;/,
+  "failed render preparation must adopt the fresh replacement canvas before allowing retry",
+);
+assert.doesNotMatch(
+  preparationBody,
+  /showError\(error\)/,
+  "an unpublished preparation failure must not race Python authoring to publish a fatal UI state",
 );
 assert.match(
   main,
@@ -111,4 +146,6 @@ assert.match(
   "the deployment must verify the public Pages site serves the expected revision",
 );
 
-console.log("✓ deferred playground runtime keeps recoverable scene errors outside fatal recovery");
+console.log(
+  "✓ overlapped playground preparation preserves unpublished ownership, canvas recovery, and recoverable scene-error boundaries",
+);

--- a/web/playground-startup.test.mjs
+++ b/web/playground-startup.test.mjs
@@ -4,13 +4,40 @@ import { readFile } from "node:fs/promises";
 const main = await readFile(new URL("./main.js", import.meta.url), "utf8");
 const worker = await readFile(new URL("./python-worker.source.js", import.meta.url), "utf8");
 
-const runtimeReadyStart = main.indexOf("async function ensureRuntimeReady({");
+const createRuntimeStart = main.indexOf("function createRuntimeClient()");
+const preparationStart = main.indexOf("function ensureRuntimePreparation()", createRuntimeStart);
+const runtimeReadyStart = main.indexOf("async function ensureRuntimeReady({", preparationStart);
 const executionReadyStart = main.indexOf("async function ensureExecutionReady()", runtimeReadyStart);
 assert.ok(
-  runtimeReadyStart >= 0 && executionReadyStart > runtimeReadyStart,
-  "on-demand runtime startup boundary must exist",
+  createRuntimeStart >= 0 &&
+    preparationStart > createRuntimeStart &&
+    runtimeReadyStart > preparationStart &&
+    executionReadyStart > runtimeReadyStart,
+  "on-demand preparation and authored-engine startup boundaries must exist in order",
 );
+const createRuntimeBody = main.slice(createRuntimeStart, preparationStart);
+const preparationBody = main.slice(preparationStart, runtimeReadyStart);
 const runtimeReadyBody = main.slice(runtimeReadyStart, executionReadyStart);
+assert.match(
+  createRuntimeBody,
+  /new AuthoringExecutionClient\(canvas,/,
+  "first Run must create the GPU execution owner on demand",
+);
+assert.match(
+  preparationBody,
+  /const ready = candidate\.prepare\(\);/,
+  "first Run must prepare the mode-free render owner before engine selection",
+);
+assert.doesNotMatch(
+  preparationBody,
+  /candidate\.start(?:RetainedCanonical)?\(/,
+  "mode-free preparation must not speculate a legacy or retained engine",
+);
+assert.match(
+  preparationBody,
+  /if \(runtimePreparation !== null\) return runtimePreparation;/,
+  "failed or stale Python runs must be able to reuse an already prepared candidate",
+);
 assert.doesNotMatch(
   runtimeReadyBody,
   /warmAuthoringClient\(/,
@@ -18,13 +45,18 @@ assert.doesNotMatch(
 );
 assert.match(
   runtimeReadyBody,
-  /new AuthoringExecutionClient\(canvas,/,
-  "first authored scene must create the GPU execution owner on demand",
+  /const prepared = preparation \?\? ensureRuntimePreparation\(\);/,
+  "authored startup must consume the candidate prepared in parallel with Python",
+);
+assert.match(
+  runtimeReadyBody,
+  /await prepared\.ready;/,
+  "authored engine attachment must wait for render-owner preparation",
 );
 assert.match(
   runtimeReadyBody,
   /await nextPlayer\.startRetainedCanonical\(sceneSpecJson,/,
-  "retained first runs must start directly from canonical SceneSpec",
+  "retained first runs must attach directly from canonical SceneSpec",
 );
 assert.doesNotMatch(
   runtimeReadyBody,
@@ -34,7 +66,7 @@ assert.doesNotMatch(
 assert.match(
   runtimeReadyBody,
   /await nextPlayer\.start\(sceneJson,/,
-  "geometry-only first runs must start their authored scene directly",
+  "geometry-only first runs must attach their authored scene directly",
 );
 assert.doesNotMatch(
   runtimeReadyBody,
@@ -56,6 +88,11 @@ assert.ok(
 );
 assert.match(
   runtimeReadyBody,
+  /if \(runtimePreparation === prepared\) \{\s*runtimePreparation = null;/,
+  "successful engine publication must consume the prepared candidate exactly once",
+);
+assert.match(
+  runtimeReadyBody,
   /playerNeedsRestart = false;/,
   "successful fresh runtime startup must clear stale restart state",
 );
@@ -69,14 +106,26 @@ const runSceneStart = main.indexOf("async function runScene()");
 const selectExampleStart = main.indexOf("async function selectExample(", runSceneStart);
 assert.ok(runSceneStart >= 0 && selectExampleStart > runSceneStart, "runScene boundary must exist");
 const runSceneBody = main.slice(runSceneStart, selectExampleStart);
+const preparationCall = runSceneBody.indexOf(
+  "const preparation = player === null ? ensureRuntimePreparation() : null;",
+);
 const authoringCall = runSceneBody.indexOf("authored = await client.run(source,");
 const ensureRuntimeCall = runSceneBody.indexOf("result = await ensureRuntimeReady({");
 const ensureExecutionCall = runSceneBody.indexOf("await ensureExecutionReady();");
 const reconcileCall = runSceneBody.indexOf("result = await player.reconcileScene(sceneJson,");
 assert.ok(authoringCall >= 0, "Run must author the selected Python source");
 assert.ok(
+  preparationCall >= 0 && preparationCall < authoringCall,
+  "cold Run must kick render/WASM preparation before awaiting Python authoring",
+);
+assert.ok(
   ensureRuntimeCall > authoringCall,
-  "cold execution startup must wait until authoring identifies the required engine mode",
+  "engine selection and attachment must wait until authoring identifies the required engine mode",
+);
+assert.match(
+  runSceneBody,
+  /result = await ensureRuntimeReady\(\{\s*preparation,/,
+  "cold authored startup must consume the preparation kicked off before Python",
 );
 assert.ok(
   ensureExecutionCall > authoringCall && reconcileCall > ensureExecutionCall,
@@ -100,7 +149,7 @@ assert.ok(bootCatch > bootStart, "playground boot boundary must terminate cleanl
 const bootBody = main.slice(bootStart, bootCatch);
 assert.doesNotMatch(
   bootBody,
-  /ensureAuthoringClient\(|new AuthoringExecutionClient\(|\.start\(.*objects.*tracks/,
+  /ensureAuthoringClient\(|ensureRuntimePreparation\(|new AuthoringExecutionClient\(|\.start\(.*objects.*tracks/,
   "initial page boot must not create Python or GPU runtime resources",
 );
 assert.doesNotMatch(
@@ -179,8 +228,8 @@ assert.match(
 );
 assert.match(
   bootBody,
-  /pagehide[\s\S]*stopMetricsPolling\(\)[\s\S]*authoringClient\?\.terminate\(\)[\s\S]*player\?\.terminate\(\)/,
-  "page teardown must release metrics, Python, and execution resources",
+  /pagehide[\s\S]*stopMetricsPolling\(\)[\s\S]*authoringClient\?\.terminate\(\)[\s\S]*preparation\?\.candidate\.terminate\(\)[\s\S]*player\?\.terminate\(\)/,
+  "page teardown must release metrics, Python, unpublished preparation, and execution resources",
 );
 
 const initializeStart = worker.indexOf("async function initializePyodide()");
@@ -211,5 +260,5 @@ assert.match(
 );
 
 console.log(
-  "✓ playground defers heavyweight startup, starts the authored engine mode directly, bounds gallery residency, and preserves parallel Python bootstrap",
+  "✓ playground defers page-load work, overlaps first-Run Python/render preparation, and selects the authored engine only after authoring",
 );


### PR DESCRIPTION
Current-master replacement for #657, built on the facade-level prepared-owner boundary merged in #941.

On a cold explicit Run, the playground now creates one unpublished `AuthoringExecutionClient` candidate and starts mode-free render/WASM preparation before awaiting Python authoring. The authored engine is still selected only after Python returns: canonical `SceneSpec` output attaches via `startRetainedCanonical`, while geometry/callback output attaches via the legacy `start` path.

Key invariants:
- page boot remains fully deferred; no Python or GPU resources are created before Run;
- render preparation and Python authoring overlap on the first Run;
- preparation does not speculate an engine mode and the candidate remains unpublished until the authored engine is ready;
- Python/stale failures can reuse a successfully prepared candidate on the next Run;
- render-preparation or engine-attachment failure terminates the candidate and adopts its replacement canvas;
- fatal callbacks from an unpublished candidate cannot mark a nonexistent public player for restart;
- page teardown terminates an unpublished prepared candidate as well as the published player.

Adds one focused static contract for the ordering/publication/recovery invariants. Existing PR Fast Gate and playground authoring-recovery workflow provide the runtime/browser qualification.

Supersedes #657. Tracks #642.