### PR TITLE
Batch retained Group fades with family animations

### DIFF
--- a/.github/workflows/playground-authoring-recovery.yml
+++ b/.github/workflows/playground-authoring-recovery.yml
@@ -12,6 +12,7 @@ on:
       - "scripts/playground-authoring-error-recovery-smoke.mjs"
       - "scripts/playground-stress-edit-smoke.mjs"
       - "scripts/mixed-family-retained-text-smoke.mjs"
+      - "scripts/mixed-family-retained-group-fade-smoke.mjs"
       - "web/**"
   pull_request:
     paths:
@@ -22,6 +23,7 @@ on:
       - "scripts/playground-authoring-error-recovery-smoke.mjs"
       - "scripts/playground-stress-edit-smoke.mjs"
       - "scripts/mixed-family-retained-text-smoke.mjs"
+      - "scripts/mixed-family-retained-group-fade-smoke.mjs"
       - "web/**"
   workflow_dispatch:
 
@@ -90,6 +92,8 @@ jobs:
         run: node scripts/playground-stress-edit-smoke.mjs
       - name: Test mixed retained family edit and rerun
         run: node scripts/mixed-family-retained-text-smoke.mjs
+      - name: Test mixed retained family Group fade edit and rerun
+        run: node scripts/mixed-family-retained-group-fade-smoke.mjs
       - name: Upload authoring recovery diagnostics
         if: always()
         uses: actions/upload-artifact@v4

--- a/scripts/mixed-family-retained-group-fade-smoke.mjs
+++ b/scripts/mixed-family-retained-group-fade-smoke.mjs
@@ -230,7 +230,7 @@ try {
     sameLeafSource,
   );
   assert.deepEqual(retainedSources(sameLeaf), ["SHARED", "PEER"]);
-  assert.equal(sameLeaf.sceneSpec.family_animations.length, 0);
+  assert.equal((sameLeaf.sceneSpec.family_animations ?? []).length, 0);
   assertFadeTracks(sameLeaf, [0, 1]);
 
   const rollback = await page.evaluate(
@@ -247,7 +247,7 @@ try {
     lagFailureSource,
   );
   assert.equal(lagFailure.sceneSpec.objects.length, 0);
-  assert.equal(lagFailure.sceneSpec.family_animations.length, 0);
+  assert.equal((lagFailure.sceneSpec.family_animations ?? []).length, 0);
 
   // Reconcile the two source versions through one persistent execution owner. The
   // retained object set must replace 3 -> 4 rather than accumulate the first run.

--- a/scripts/mixed-family-retained-group-fade-smoke.mjs
+++ b/scripts/mixed-family-retained-group-fade-smoke.mjs
@@ -1,0 +1,324 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import playwright from "playwright";
+
+const { chromium } = playwright;
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const port = 4199;
+const baseUrl = `http://127.0.0.1:${port}`;
+
+let serverOutput = "";
+const server = spawn(
+  "python3",
+  ["-m", "http.server", String(port), "--bind", "127.0.0.1", "--directory", repoRoot],
+  { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] },
+);
+server.stdout.on("data", (chunk) => (serverOutput += chunk));
+server.stderr.on("data", (chunk) => (serverOutput += chunk));
+
+async function waitForServer() {
+  let lastError = null;
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    try {
+      const response = await fetch(`${baseUrl}/web/manim-compat-smoke.html`);
+      if (response.ok) return;
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`mixed retained group fade smoke server did not start: ${lastError}\n${serverOutput}`);
+}
+
+const writeFirstSource = `
+from noon import *
+
+class MixedRetainedGroupFadeWriteFirst(Scene):
+    def construct(self):
+        writing = Text("WRITE")
+        first = Text("A")
+        second = Text("B")
+        labels = VGroup(first, second)
+        self.play(
+            Write(writing),
+            FadeIn(labels),
+            run_time=1.0,
+            rate_func=linear,
+        )
+`;
+
+const fadeFirstEditedSource = `
+from noon import *
+
+class MixedRetainedGroupFadeFirst(Scene):
+    def construct(self):
+        first = Text("A2")
+        second = Text("B2")
+        third = Text("C2")
+        labels = VGroup(first, second, third)
+        writing = Text("EDITED")
+        self.play(
+            FadeIn(labels),
+            Write(writing),
+            run_time=1.0,
+            rate_func=linear,
+        )
+`;
+
+const sameLeafSource = `
+from noon import *
+
+class MixedRetainedGroupFadeSameLeaf(Scene):
+    def construct(self):
+        shared = Text("SHARED")
+        peer = Text("PEER")
+        labels = VGroup(shared, peer)
+        try:
+            self.play(
+                Write(shared),
+                FadeIn(labels),
+                run_time=0.25,
+            )
+            raise AssertionError("same-leaf family/group-fade ownership must fail")
+        except ValueError as error:
+            assert "disjoint scene leaves" in str(error)
+        assert shared._scene is None
+        assert shared._object is None
+        assert shared._retained_object_id is None
+        assert peer._scene is None
+        assert peer._object is None
+        assert peer._retained_object_id is None
+        self.play(FadeIn(labels), run_time=0.25, rate_func=linear)
+`;
+
+const rollbackSource = `
+from noon import *
+
+class MixedRetainedGroupFadeRollback(Scene):
+    def construct(self):
+        first = Text("A")
+        second = Text("B")
+        labels = VGroup(first, second)
+        writing = Text("WRITE")
+        moving = Text("MOVE")
+        try:
+            self.play(
+                FadeIn(labels),
+                Write(writing),
+                moving.animate(run_time=-1.0).shift(RIGHT),
+            )
+            raise AssertionError("negative sibling run_time must fail")
+        except ValueError:
+            pass
+        for member in (first, second, writing, moving):
+            assert member._scene is None
+            assert member._object is None
+            assert member._retained_object_id is None
+        self.play(
+            Write(writing),
+            FadeIn(labels),
+            moving.animate.shift(RIGHT),
+            run_time=0.5,
+            rate_func=linear,
+        )
+`;
+
+const lagFailureSource = `
+from noon import *
+
+class MixedRetainedGroupFadeLagFailure(Scene):
+    def construct(self):
+        labels = VGroup(Text("A"), Text("B"))
+        writing = Text("WRITE")
+        try:
+            self.play(
+                Write(writing),
+                FadeIn(labels),
+                lag_ratio=0.25,
+            )
+            raise AssertionError("group fade play lag_ratio must fail")
+        except NotImplementedError as error:
+            assert "shared retained family scheduling" in str(error)
+        for member in (*labels.submobjects, writing):
+            assert member._scene is None
+            assert member._object is None
+            assert member._retained_object_id is None
+`;
+
+function retainedSources(result) {
+  return (result.retainedDocument?.objects ?? []).map((object) => object.text.source);
+}
+
+function tracksFor(result, property) {
+  return (result.retainedDocument?.tracks ?? []).filter((track) => track.property === property);
+}
+
+function assertFadeTracks(result, objectIndexes) {
+  const presence = tracksFor(result, "presence");
+  const appearance = tracksFor(result, "appearance");
+  for (const object of objectIndexes) {
+    assert.ok(
+      presence.some(
+        (track) =>
+          track.object === object &&
+          track.values.bool?.from === false &&
+          track.values.bool?.to === true,
+      ),
+      `missing FadeIn presence track for retained object ${object}`,
+    );
+    assert.ok(
+      appearance.some(
+        (track) =>
+          track.object === object &&
+          track.values.scalar?.from === 0 &&
+          track.values.scalar?.to === 1,
+      ),
+      `missing FadeIn appearance track for retained object ${object}`,
+    );
+  }
+}
+
+let browser = null;
+try {
+  await waitForServer();
+  browser = await chromium.launch({
+    channel: "chromium",
+    headless: true,
+    args: ["--disable-dev-shm-usage"],
+  });
+  const page = await browser.newPage();
+  const errors = [];
+  page.on("pageerror", (error) => errors.push(`pageerror: ${error}`));
+  page.on("console", (message) => {
+    if (message.type() === "error") errors.push(`console: ${message.text()}`);
+  });
+
+  await page.goto(`${baseUrl}/web/manim-compat-smoke.html`, { waitUntil: "load" });
+  await page.waitForFunction(() => window.noonManimCompat, null, { timeout: 30_000 });
+  await page.evaluate(() => window.noonManimCompat.ready());
+
+  const writeFirst = await page.evaluate(
+    (source) => window.noonManimCompat.run(source),
+    writeFirstSource,
+  );
+  assert.equal(writeFirst.kind, "scene_document");
+  assert.deepEqual(retainedSources(writeFirst), ["WRITE", "A", "B"]);
+  assert.equal(writeFirst.sceneSpec.objects.length, 3);
+  assert.equal(writeFirst.sceneSpec.family_animations.length, 1);
+  assert.equal(writeFirst.retainedDocument.family_animations.length, 1);
+  assert.equal(writeFirst.duration, 1);
+  assertFadeTracks(writeFirst, [1, 2]);
+
+  const fadeFirst = await page.evaluate(
+    (source) => window.noonManimCompat.run(source),
+    fadeFirstEditedSource,
+  );
+  assert.equal(fadeFirst.kind, "scene_document");
+  assert.deepEqual(retainedSources(fadeFirst), ["A2", "B2", "C2", "EDITED"]);
+  assert.equal(fadeFirst.sceneSpec.objects.length, 4);
+  assert.equal(fadeFirst.sceneSpec.family_animations.length, 1);
+  assert.equal(fadeFirst.retainedDocument.family_animations.length, 1);
+  assertFadeTracks(fadeFirst, [0, 1, 2]);
+
+  const sameLeaf = await page.evaluate(
+    (source) => window.noonManimCompat.run(source),
+    sameLeafSource,
+  );
+  assert.deepEqual(retainedSources(sameLeaf), ["SHARED", "PEER"]);
+  assert.equal(sameLeaf.sceneSpec.family_animations.length, 0);
+  assertFadeTracks(sameLeaf, [0, 1]);
+
+  const rollback = await page.evaluate(
+    (source) => window.noonManimCompat.run(source),
+    rollbackSource,
+  );
+  assert.deepEqual(retainedSources(rollback), ["WRITE", "A", "B", "MOVE"]);
+  assert.equal(rollback.sceneSpec.family_animations.length, 1);
+  assert.equal(tracksFor(rollback, "position").length, 1);
+  assertFadeTracks(rollback, [1, 2]);
+
+  const lagFailure = await page.evaluate(
+    (source) => window.noonManimCompat.run(source),
+    lagFailureSource,
+  );
+  assert.equal(lagFailure.sceneSpec.objects.length, 0);
+  assert.equal(lagFailure.sceneSpec.family_animations.length, 0);
+
+  // Reconcile the two source versions through one persistent execution owner. The
+  // retained object set must replace 3 -> 4 rather than accumulate the first run.
+  const rebuild = await page.evaluate(async ({ first, second }) => {
+    const { AuthoringExecutionClient } = await import("./authoring-execution-client.js");
+    const canvas = document.createElement("canvas");
+    canvas.width = 640;
+    canvas.height = 360;
+    document.body.appendChild(canvas);
+    const runtimeErrors = [];
+    const execution = new AuthoringExecutionClient(canvas, {
+      onError(error) {
+        runtimeErrors.push(String(error));
+      },
+    });
+
+    async function waitForObjectCount(expected) {
+      let latest = null;
+      for (let attempt = 0; attempt < 100; attempt += 1) {
+        latest = await execution.metrics();
+        if (runtimeErrors.length !== 0) throw new Error(runtimeErrors.join("; "));
+        if (latest.metrics?.objectCount === expected) return latest;
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      }
+      throw new Error(`retained object count did not converge to ${expected}: ${JSON.stringify(latest)}`);
+    }
+
+    try {
+      await execution.startRetainedCanonical(JSON.stringify(first.sceneSpec), {
+        loopDurationSeconds: first.duration,
+        transportMode: "transferable",
+      });
+      const persistentCanvas = execution.canvas;
+      const before = await waitForObjectCount(3);
+      const reconciled = await execution.reconcileScene(JSON.stringify(second.document), {
+        sceneSpecJson: JSON.stringify(second.sceneSpec),
+        loopDurationSeconds: second.duration,
+      });
+      const after = await waitForObjectCount(4);
+      return {
+        beforeCount: before.metrics.objectCount,
+        afterCount: after.metrics.objectCount,
+        beforeCanonical: Boolean(before.engineMetrics?.canonical),
+        afterCanonical: Boolean(after.engineMetrics?.canonical),
+        rebuilt: reconciled.rebuilt,
+        mode: reconciled.mode,
+        sameCanvas: execution.canvas === persistentCanvas,
+      };
+    } finally {
+      execution.terminate();
+      execution.canvas?.remove();
+    }
+  }, { first: writeFirst, second: fadeFirst });
+
+  assert.deepEqual(rebuild, {
+    beforeCount: 3,
+    afterCount: 4,
+    beforeCanonical: true,
+    afterCanonical: true,
+    rebuilt: true,
+    mode: "retained",
+    sameCanvas: true,
+  });
+
+  assert.deepEqual(
+    errors,
+    [],
+    `browser errors while testing retained family fade batches:\n${errors.join("\n")}`,
+  );
+  console.log("Mixed retained family Group/VGroup fade batch smoke passed, including edit -> rerun rebuild.");
+} finally {
+  await browser?.close();
+  server.kill("SIGTERM");
+}

--- a/web/python-compat-modules.js
+++ b/web/python-compat-modules.js
@@ -6,6 +6,7 @@ export const PYTHON_COMPAT_MODULES = Object.freeze([
   { sourcePath: "python/_manim_typst.py", runtimePath: "/tmp/_manim_typst.py", label: "Noon retained Typst compatibility layer" },
   { sourcePath: "python/_manim_retained_animate.py", runtimePath: "/tmp/_manim_retained_animate.py", label: "Noon retained text animation layer" },
   { sourcePath: "python/_manim_family_creation.py", runtimePath: "/tmp/_manim_family_creation.py", label: "Noon retained family creation-animation layer" },
+  { sourcePath: "python/_manim_retained_family_fade_batch.py", runtimePath: "/tmp/_manim_retained_family_fade_batch.py", label: "Noon retained family fade batch layer" },
   { sourcePath: "python/_manim_retained_state.py", runtimePath: "/tmp/_manim_retained_state.py", label: "Noon retained text canonical state layer" },
   { sourcePath: "python/_manim_rate_functions.py", runtimePath: "/tmp/_manim_rate_functions.py", label: "Noon Manim rate functions" },
   { sourcePath: "python/_manim_phase_b.py", runtimePath: "/tmp/_manim_phase_b.py", label: "Noon Manim Phase B layer" },

--- a/web/python/_manim_camera.py
+++ b/web/python/_manim_camera.py
@@ -8,6 +8,7 @@ import noon as _base
 import _manim_compat as _compat
 import _manim_family_creation as _family_creation
 import _manim_phase_b as _phase_b
+import _manim_retained_family_fade_batch as _retained_family_fade_batch
 
 
 class _CameraFrame(_compat.Rectangle):
@@ -55,9 +56,10 @@ def install() -> None:
     """Install final authoring wrappers and expose the moving-camera name."""
 
     # Camera is the final compatibility module installed by the browser bootstrap.
-    # Install semantic-family creation animations here so Create/Uncreate/Write/Unwrite
-    # wrap every earlier Scene.play layer and delegate unrelated animations unchanged.
+    # Install semantic-family creation first, then the retained family-fade batch
+    # coordinator above that transaction so it can reuse the existing leaf scheduler.
     _family_creation.install()
+    _retained_family_fade_batch.install()
     _base.MovingCameraScene = MovingCameraScene
     if "MovingCameraScene" not in _base.__all__:
         _base.__all__.append("MovingCameraScene")

--- a/web/python/_manim_retained_family_fade_batch.py
+++ b/web/python/_manim_retained_family_fade_batch.py
@@ -1,0 +1,279 @@
+"""Batch retained Group/VGroup fades across one source-level animation.
+
+The ordinary retained Text scheduler remains the sole owner of leaf lifecycle and
+property-track semantics. This adapter only classifies a source-level retained family
+fade into ordered leaves, then lets the existing leaf scheduler consume each leaf under
+the outer family-animation transaction. No public child FadeIn/FadeOut animations are
+created for mixed family/property plays.
+"""
+
+from __future__ import annotations
+
+import copy
+import math
+from typing import Any
+
+import _manim_animation_options as _options
+import _manim_animate as _animate
+import _manim_compat as _compat
+import _manim_retained_animate as _retained
+import _manim_typst as _typst
+
+
+_INSTALLED = False
+_ORIGINAL_SCENE_PLAY = None
+_ORIGINAL_ANIMATION_PLAN = None
+_ORIGINAL_ANIMATION_SOURCE = None
+_ORIGINAL_SCHEDULE_PLAN = None
+
+
+class _RetainedFamilyFadeBatch(list[dict[str, Any]]):
+    """One source animation plus the ordered retained leaves it owns."""
+
+    def __init__(
+        self,
+        family: _compat.Group,
+        leaves: list[_typst._RetainedTextMobject],
+        operation: dict[str, Any],
+    ) -> None:
+        super().__init__([copy.deepcopy(operation)])
+        self.family = family
+        self.leaves = tuple(leaves)
+
+
+class _RetainedBatchLeafAnimation:
+    """Internal source carrier for the existing retained leaf scheduler."""
+
+    def __init__(self, source: _typst._RetainedTextMobject) -> None:
+        self.source = source
+
+
+def _family_fade_batch(animation: object) -> _RetainedFamilyFadeBatch | None:
+    if not isinstance(animation, (_animate.FadeIn, _animate.FadeOut)):
+        return None
+    target = getattr(animation, "target", None)
+    if not isinstance(target, _compat.Group):
+        return None
+
+    leaves = _compat._leaf_mobjects(target)
+    retained = [
+        member for member in leaves if isinstance(member, _typst._RetainedTextMobject)
+    ]
+    if not retained:
+        return None
+    if len(retained) != len(leaves):
+        raise NotImplementedError(
+            "mixing retained Text and legacy Mobjects in one Group/VGroup fade is not supported"
+        )
+
+    shift = _compat._as_vec2(animation._fade_shift_vector)
+    scale_factor = float(animation._fade_scale_factor)
+    if not math.isfinite(scale_factor):
+        raise ValueError("retained text family fade scale must be finite")
+    default_endpoint = (
+        math.isclose(float(shift.x), 0.0, abs_tol=1e-15)
+        and math.isclose(float(shift.y), 0.0, abs_tol=1e-15)
+        and math.isclose(scale_factor, 1.0, rel_tol=0.0, abs_tol=1e-15)
+        and not bool(animation._fade_point_target)
+    )
+    if not default_endpoint:
+        raise NotImplementedError(
+            "retained Text Group/VGroup fades with shift, scale, or target_position "
+            "require shared retained family layout semantics"
+        )
+
+    animation_args = _options.builder_args(animation)
+    family_lag_ratio = float(animation_args.get("lag_ratio", 0.0))
+    if not math.isfinite(family_lag_ratio):
+        raise ValueError("retained text family fade lag_ratio must be finite")
+    if not math.isclose(family_lag_ratio, 0.0, rel_tol=0.0, abs_tol=1e-15):
+        raise NotImplementedError(
+            "retained Text Group/VGroup fade lag_ratio requires shared retained family scheduling"
+        )
+
+    operation = {
+        "kind": "fade_in" if isinstance(animation, _animate.FadeIn) else "fade_out",
+        "shift": {"x": float(shift.x), "y": float(shift.y)},
+        "scale_factor": scale_factor,
+        "point_target": bool(animation._fade_point_target),
+    }
+    return _RetainedFamilyFadeBatch(target, retained, operation)
+
+
+def _legacy_expansion_from_batch(
+    animation: object,
+) -> tuple[_compat.Group, list[_typst._RetainedTextMobject], list[object]] | None:
+    """Keep standalone retained Scene.play behavior on the shared batch classifier."""
+
+    batch = _family_fade_batch(animation)
+    if batch is None:
+        return None
+
+    animation_args = _options.builder_args(animation)
+    children: list[object] = []
+    for index, member in enumerate(batch.leaves):
+        child = type(animation)(
+            member,
+            None if animation.key is None else f"{animation.key}.{index}",
+        )
+        object.__setattr__(child, "anim_args", copy.deepcopy(animation_args))
+        children.append(child)
+    return batch.family, list(batch.leaves), children
+
+
+def _animation_plan(animation: object) -> list[dict[str, Any]] | None:
+    batch = _family_fade_batch(animation)
+    if batch is not None:
+        return batch
+    assert _ORIGINAL_ANIMATION_PLAN is not None
+    return _ORIGINAL_ANIMATION_PLAN(animation)
+
+
+def _animation_source(animation: object) -> _typst._RetainedTextMobject | None:
+    if isinstance(animation, _RetainedBatchLeafAnimation):
+        return animation.source
+    batch = _family_fade_batch(animation)
+    if batch is not None:
+        # The existing family transaction snapshots one retained source itself. The
+        # outer batch wrapper snapshots every leaf, so returning the first leaf keeps
+        # the legacy single-source contract valid without losing rollback coverage.
+        return batch.leaves[0]
+    assert _ORIGINAL_ANIMATION_SOURCE is not None
+    return _ORIGINAL_ANIMATION_SOURCE(animation)
+
+
+def _schedule_plan(
+    scene: _compat.Scene,
+    animation: object,
+    operations: list[dict[str, Any]],
+    *,
+    start_time: float,
+    duration: float,
+    easing: str,
+) -> None:
+    assert _ORIGINAL_SCHEDULE_PLAN is not None
+    if not isinstance(operations, _RetainedFamilyFadeBatch):
+        _ORIGINAL_SCHEDULE_PLAN(
+            scene,
+            animation,
+            operations,
+            start_time=start_time,
+            duration=duration,
+            easing=easing,
+        )
+        return
+
+    leaf_operations = [copy.deepcopy(operations[0])]
+    for source in operations.leaves:
+        _ORIGINAL_SCHEDULE_PLAN(
+            scene,
+            _RetainedBatchLeafAnimation(source),
+            leaf_operations,
+            start_time=start_time,
+            duration=duration,
+            easing=easing,
+        )
+
+
+def _scene_play(
+    self: _compat.Scene,
+    *animations: Any,
+    duration: float | None = None,
+    run_time: float | None = None,
+    start_time: float | None = None,
+    easing: str | None = None,
+    rate_func: object | None = None,
+    lag_ratio: float | None = None,
+    **kwargs: Any,
+) -> _compat.Scene:
+    batches = [
+        batch for animation in animations if (batch := _family_fade_batch(animation)) is not None
+    ]
+    if not batches:
+        assert _ORIGINAL_SCENE_PLAY is not None
+        return _ORIGINAL_SCENE_PLAY(
+            self,
+            *animations,
+            duration=duration,
+            run_time=run_time,
+            start_time=start_time,
+            easing=easing,
+            rate_func=rate_func,
+            lag_ratio=lag_ratio,
+            **kwargs,
+        )
+
+    if lag_ratio is not None:
+        play_lag_ratio = float(lag_ratio)
+        if not math.isfinite(play_lag_ratio):
+            raise ValueError("retained text family fade lag_ratio must be finite")
+        if not math.isclose(play_lag_ratio, 0.0, rel_tol=0.0, abs_tol=1e-15):
+            raise NotImplementedError(
+                "retained Text Group/VGroup Scene.play lag_ratio requires shared retained family scheduling"
+            )
+
+    top_level_before = list(self._compat_top_level)
+    wrapper_states = {
+        id(source): (
+            source,
+            source._scene,
+            source._object,
+            source._retained_object_id,
+            source._retained_order,
+        )
+        for batch in batches
+        for source in batch.leaves
+    }
+
+    assert _ORIGINAL_SCENE_PLAY is not None
+    try:
+        result = _ORIGINAL_SCENE_PLAY(
+            self,
+            *animations,
+            duration=duration,
+            run_time=run_time,
+            start_time=start_time,
+            easing=easing,
+            rate_func=rate_func,
+            lag_ratio=lag_ratio,
+            **kwargs,
+        )
+        _retained._normalize_retained_family_top_level(
+            self,
+            [(batch.family, list(batch.leaves)) for batch in batches],
+            top_level_before,
+        )
+        return result
+    except Exception:
+        self._compat_top_level = top_level_before
+        for source, old_scene, old_object, old_object_id, old_order in wrapper_states.values():
+            source._scene = old_scene
+            source._object = old_object
+            source._retained_object_id = old_object_id
+            source._retained_order = old_order
+        raise
+
+
+def install() -> None:
+    """Install above canonical family creation after its outer transaction exists."""
+
+    global _INSTALLED
+    global _ORIGINAL_SCENE_PLAY
+    global _ORIGINAL_ANIMATION_PLAN
+    global _ORIGINAL_ANIMATION_SOURCE
+    global _ORIGINAL_SCHEDULE_PLAN
+
+    if _INSTALLED:
+        return
+    _INSTALLED = True
+
+    _ORIGINAL_ANIMATION_PLAN = _retained._retained_animation_plan
+    _ORIGINAL_ANIMATION_SOURCE = _retained._retained_animation_source
+    _ORIGINAL_SCHEDULE_PLAN = _retained._schedule_retained_plan
+    _ORIGINAL_SCENE_PLAY = _compat.Scene.play
+
+    _retained._retained_family_fade_expansion = _legacy_expansion_from_batch
+    _retained._retained_animation_plan = _animation_plan
+    _retained._retained_animation_source = _animation_source
+    _retained._schedule_retained_plan = _schedule_plan
+    _compat.Scene.play = _scene_play

--- a/web/retained-family-fade-batch.test.mjs
+++ b/web/retained-family-fade-batch.test.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const batchSource = readFileSync("web/python/_manim_retained_family_fade_batch.py", "utf8");
+const cameraSource = readFileSync("web/python/_manim_camera.py", "utf8");
+const manifestSource = readFileSync("web/python-compat-modules.js", "utf8");
+
+test("retained family fades are represented as ordered leaf batches", () => {
+  assert.match(batchSource, /class _RetainedFamilyFadeBatch/);
+  assert.match(batchSource, /self\.leaves = tuple\(leaves\)/);
+  assert.match(batchSource, /_compat\._leaf_mobjects\(target\)/);
+  assert.match(batchSource, /len\(retained\) != len\(leaves\)/);
+  assert.match(batchSource, /family fade lag_ratio requires shared retained family scheduling/);
+});
+
+test("mixed family fade batches reuse the existing retained leaf scheduler", () => {
+  const schedule = batchSource.split("def _schedule_plan(")[1].split("def _scene_play(")[0];
+  assert.match(schedule, /_ORIGINAL_SCHEDULE_PLAN\(/);
+  assert.match(schedule, /_RetainedBatchLeafAnimation\(source\)/);
+  assert.doesNotMatch(schedule, /_schedule_retained_fade\(/);
+  assert.doesNotMatch(schedule, /_append_(?:vec2|scalar|presence)_track\(/);
+  assert.doesNotMatch(schedule, /type\(animation\)\(/);
+});
+
+test("batch wrapper snapshots every retained leaf and restores source-level family membership", () => {
+  assert.match(batchSource, /for batch in batches\s+for source in batch\.leaves/);
+  assert.match(batchSource, /_normalize_retained_family_top_level/);
+  assert.match(batchSource, /source\._object = old_object/);
+  assert.match(batchSource, /source\._retained_object_id = old_object_id/);
+  assert.match(batchSource, /source\._retained_order = old_order/);
+});
+
+test("batch adapter is installed above the canonical family transaction", () => {
+  assert.match(manifestSource, /_manim_family_creation\.py[\s\S]*_manim_retained_family_fade_batch\.py/);
+  const familyInstall = cameraSource.indexOf("_family_creation.install()");
+  const batchInstall = cameraSource.indexOf("_retained_family_fade_batch.install()");
+  assert.ok(familyInstall >= 0 && batchInstall > familyInstall);
+  assert.match(batchSource, /_retained\._retained_animation_plan = _animation_plan/);
+  assert.match(batchSource, /_retained\._schedule_retained_plan = _schedule_plan/);
+  assert.match(batchSource, /_compat\.Scene\.play = _scene_play/);
+});

--- a/web/retained-family-fade-batch.test.mjs
+++ b/web/retained-family-fade-batch.test.mjs
@@ -11,7 +11,10 @@ test("retained family fades are represented as ordered leaf batches", () => {
   assert.match(batchSource, /self\.leaves = tuple\(leaves\)/);
   assert.match(batchSource, /_compat\._leaf_mobjects\(target\)/);
   assert.match(batchSource, /len\(retained\) != len\(leaves\)/);
-  assert.match(batchSource, /family fade lag_ratio requires shared retained family scheduling/);
+  assert.match(
+    batchSource,
+    /retained Text Group\/VGroup fade lag_ratio requires shared retained family scheduling/,
+  );
 });
 
 test("mixed family fade batches reuse the existing retained leaf scheduler", () => {


### PR DESCRIPTION
## Summary
- allow retained `FadeIn` / `FadeOut` of an all-retained `Group`/`VGroup` to compose with canonical family animations such as `Write(Text(...))` in one `Scene.play(...)`
- represent the source-level group fade as one ordered retained leaf batch for the mixed-family path
- reuse the existing retained leaf scheduler for lifecycle and property tracks instead of cloning fade interpolation semantics
- snapshot every retained leaf around the outer family transaction so failures after partial scheduling restore wrapper, retained sidecar, and canonical authoring state
- preserve source-order binding and source-level Group/VGroup membership normalization
- keep non-default group fade shift/scale/target-position and nonzero family lag explicit until shared retained family layout/timing semantics exist

## Architecture
`_manim_retained_family_fade_batch.py` installs above the canonical family transaction. It owns only source-level batch classification and transaction coordination. Each batch leaf is passed back to the already-qualified retained scheduler through an internal source carrier; it does not emit lifecycle/property tracks itself. The same classifier also backs the existing standalone retained group-fade expansion so endpoint/lag capability checks have one owner.

The direct standalone retained path still materializes per-leaf public fade adapters internally; this PR removes that workaround from the mixed family/property path without changing standalone behavior. A later cleanup can move standalone scheduling onto the same batch object once this mixed transaction boundary is qualified.

## Acceptance
The focused browser smoke covers:
- `Write(Text)` then `FadeIn(VGroup(Text, Text))`
- group fade first then `Write(Text)`, preserving painter/source order
- exact presence/appearance tracks for every retained group leaf
- same-leaf family/group-fade rejection before mutation
- rollback after the group batch and a family request have already been authored
- explicit rejection of nonzero play-level family lag
- persistent canonical edit -> rerun replacement from 3 objects to 4 on one execution canvas

The smoke runs in the existing Playground authoring recovery workflow and reuses its single browser/WASM build.

Tracks #741 / #705 / #367.