### PR TITLE
Route standalone retained Group fades through batch scheduling

### DIFF
--- a/scripts/mixed-family-retained-group-fade-smoke.mjs
+++ b/scripts/mixed-family-retained-group-fade-smoke.mjs
@@ -94,6 +94,7 @@ class MixedRetainedGroupFadeSameLeaf(Scene):
         assert peer._object is None
         assert peer._retained_object_id is None
         self.play(FadeIn(labels), run_time=0.25, rate_func=linear)
+        self.play(FadeOut(labels), run_time=0.25, rate_func=linear)
 `;
 
 const rollbackSource = `
@@ -183,6 +184,31 @@ function assertFadeTracks(result, objectIndexes) {
   }
 }
 
+function assertFadeOutTracks(result, objectIndexes) {
+  const presence = tracksFor(result, "presence");
+  const appearance = tracksFor(result, "appearance");
+  for (const object of objectIndexes) {
+    assert.ok(
+      presence.some(
+        (track) =>
+          track.object === object &&
+          track.values.bool?.from === true &&
+          track.values.bool?.to === false,
+      ),
+      `missing FadeOut presence track for retained object ${object}`,
+    );
+    assert.ok(
+      appearance.some(
+        (track) =>
+          track.object === object &&
+          track.values.scalar?.from === 1 &&
+          track.values.scalar?.to === 0,
+      ),
+      `missing FadeOut appearance track for retained object ${object}`,
+    );
+  }
+}
+
 let browser = null;
 try {
   await waitForServer();
@@ -232,6 +258,7 @@ try {
   assert.deepEqual(retainedSources(sameLeaf), ["SHARED", "PEER"]);
   assert.equal((sameLeaf.sceneSpec.family_animations ?? []).length, 0);
   assertFadeTracks(sameLeaf, [0, 1]);
+  assertFadeOutTracks(sameLeaf, [0, 1]);
 
   const rollback = await page.evaluate(
     (source) => window.noonManimCompat.run(source),
@@ -317,7 +344,7 @@ try {
     [],
     `browser errors while testing retained family fade batches:\n${errors.join("\n")}`,
   );
-  console.log("Mixed retained family Group/VGroup fade batch smoke passed, including edit -> rerun rebuild.");
+  console.log("Mixed retained family Group/VGroup fade batch smoke passed, including standalone FadeOut and edit -> rerun rebuild.");
 } finally {
   await browser?.close();
   server.kill("SIGTERM");

--- a/web/python/_manim_retained_family_fade_batch.py
+++ b/web/python/_manim_retained_family_fade_batch.py
@@ -1,10 +1,10 @@
 """Batch retained Group/VGroup fades across one source-level animation.
 
 The ordinary retained Text scheduler remains the sole owner of leaf lifecycle and
-property-track semantics. This adapter only classifies a source-level retained family
-fade into ordered leaves, then lets the existing leaf scheduler consume each leaf under
-the outer family-animation transaction. No public child FadeIn/FadeOut animations are
-created for mixed family/property plays.
+property-track semantics. This adapter classifies a source-level retained family fade
+into ordered leaves, then lets the existing leaf scheduler consume each leaf under the
+same retained batch plan for standalone and mixed family/property plays. It never
+materializes per-leaf public FadeIn/FadeOut animations.
 """
 
 from __future__ import annotations
@@ -100,25 +100,15 @@ def _family_fade_batch(animation: object) -> _RetainedFamilyFadeBatch | None:
     return _RetainedFamilyFadeBatch(target, retained, operation)
 
 
-def _legacy_expansion_from_batch(
+def _standalone_batch_passthrough(
     animation: object,
 ) -> tuple[_compat.Group, list[_typst._RetainedTextMobject], list[object]] | None:
-    """Keep standalone retained Scene.play behavior on the shared batch classifier."""
+    """Keep the source animation intact while the retained Scene.play hook classifies its family."""
 
     batch = _family_fade_batch(animation)
     if batch is None:
         return None
-
-    animation_args = _options.builder_args(animation)
-    children: list[object] = []
-    for index, member in enumerate(batch.leaves):
-        child = type(animation)(
-            member,
-            None if animation.key is None else f"{animation.key}.{index}",
-        )
-        object.__setattr__(child, "anim_args", copy.deepcopy(animation_args))
-        children.append(child)
-    return batch.family, list(batch.leaves), children
+    return batch.family, list(batch.leaves), [animation]
 
 
 def _animation_plan(animation: object) -> list[dict[str, Any]] | None:
@@ -272,7 +262,7 @@ def install() -> None:
     _ORIGINAL_SCHEDULE_PLAN = _retained._schedule_retained_plan
     _ORIGINAL_SCENE_PLAY = _compat.Scene.play
 
-    _retained._retained_family_fade_expansion = _legacy_expansion_from_batch
+    _retained._retained_family_fade_expansion = _standalone_batch_passthrough
     _retained._retained_animation_plan = _animation_plan
     _retained._retained_animation_source = _animation_source
     _retained._schedule_retained_plan = _schedule_plan

--- a/web/retained-family-fade-batch.test.mjs
+++ b/web/retained-family-fade-batch.test.mjs
@@ -17,7 +17,20 @@ test("retained family fades are represented as ordered leaf batches", () => {
   );
 });
 
-test("mixed family fade batches reuse the existing retained leaf scheduler", () => {
+test("standalone family fades preserve one source animation instead of constructing child fades", () => {
+  const passthrough = batchSource
+    .split("def _standalone_batch_passthrough(")[1]
+    .split("def _animation_plan(")[0];
+  assert.match(passthrough, /batch = _family_fade_batch\(animation\)/);
+  assert.match(passthrough, /return batch\.family, list\(batch\.leaves\), \[animation\]/);
+  assert.doesNotMatch(batchSource, /type\(animation\)\(/);
+  assert.match(
+    batchSource,
+    /_retained\._retained_family_fade_expansion = _standalone_batch_passthrough/,
+  );
+});
+
+test("standalone and mixed family fade batches reuse the existing retained leaf scheduler", () => {
   const schedule = batchSource.split("def _schedule_plan(")[1].split("def _scene_play(")[0];
   assert.match(schedule, /_ORIGINAL_SCHEDULE_PLAN\(/);
   assert.match(schedule, /_RetainedBatchLeafAnimation\(source\)/);


### PR DESCRIPTION
## Summary
- stop constructing per-leaf public `FadeIn` / `FadeOut` animations for standalone retained `Group` / `VGroup` fades
- preserve the original source animation through the retained Scene.play family adapter
- let the already-qualified `_RetainedFamilyFadeBatch` planner and existing retained leaf scheduler own both standalone and mixed family/property fade execution
- keep source-order family membership, all-leaf rollback, lifecycle tracks, and timing ownership unchanged

## Architecture
The retained Scene.play compatibility hook still classifies source-level Group/VGroup ownership, but its adapter now returns the original animation as a one-animation passthrough rather than synthesizing child fades. `_retained_animation_plan` converts that source animation into `_RetainedFamilyFadeBatch`, and `_schedule_plan` delegates every leaf to the existing retained scheduler. No fade interpolation or lifecycle logic is duplicated in the batch layer.

## Acceptance
- structural ratchet forbids `type(animation)(...)` child-fade construction in the batch adapter
- standalone FadeIn still emits exact per-leaf presence/appearance tracks
- standalone FadeOut now has browser coverage for per-leaf appearance and removal presence tracks
- existing mixed Write + Group/VGroup FadeIn, rollback, ordering, and edit -> rerun acceptance remains in the same smoke

Tracks #741 / #705 / #367.