### PR TITLE
Fix playback smoke current-time parsing

### DIFF
--- a/scripts/playground-playback-controls-smoke.mjs
+++ b/scripts/playground-playback-controls-smoke.mjs
@@ -48,7 +48,9 @@ async function waitForServer() {
 }
 
 function parseSeconds(text) {
-  const match = String(text).match(/([0-9]+(?:\.[0-9]+)?)\s*s/);
+  const match = String(text).match(
+    /^\s*([0-9]+(?:\.[0-9]+)?)(?:\s*\/\s*[0-9]+(?:\.[0-9]+)?)?\s*s\s*$/,
+  );
   assert.ok(match, `unable to parse seconds from ${JSON.stringify(text)}`);
   return Number(match[1]);
 }


### PR DESCRIPTION
Repairs the remaining red `Playground playback controls` diagnostic without changing runtime behavior.

The previous parser matched the number immediately before `s`. For playback labels such as `0.58 / 1.00 s`, that returns the total duration (`1.00`) instead of the current logical time (`0.58`). As a result, the pause-freeze assertion compared duration to duration and the subsequent metric-convergence wait targeted the wrong timestamp.

This makes `parseSeconds` strictly accept either `CURRENT s` or `CURRENT / DURATION s` and always return the leading current-time value. The existing pause, seek, restart, and resume assertions are otherwise unchanged, so this strengthens the smoke rather than weakening it.

The master artifact that exposed this already showed pause state and metrics converging at `0.58 s`; the failure was the parser targeting `1.00 s`.