### PR TITLE
Establish ordered semantic scene membership and lifecycle

### DIFF
--- a/crates/noon-core/src/semantic_family.rs
+++ b/crates/noon-core/src/semantic_family.rs
@@ -30,7 +30,7 @@ impl SemanticStore {
                 }
                 SemanticNodeKind::Family => {
                     for member in node.members() {
-                        collect(store, *member, seen, leaves)?;
+                        collect(store, member, seen, leaves)?;
                     }
                 }
             }

--- a/crates/noon-core/src/semantic_store.rs
+++ b/crates/noon-core/src/semantic_store.rs
@@ -68,6 +68,97 @@ enum SemanticSceneMembership {
     },
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct FamilyMemberLink {
+    previous: Option<SemanticNodeId>,
+    next: Option<SemanticNodeId>,
+}
+
+/// Ordered family membership with local lookup/add/remove.
+///
+/// The hash map is identity lookup only; deterministic semantic order follows
+/// the private previous/next links from `head` to `tail`.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+struct OrderedFamilyMembers {
+    head: Option<SemanticNodeId>,
+    tail: Option<SemanticNodeId>,
+    links: HashMap<SemanticNodeId, FamilyMemberLink>,
+}
+
+impl OrderedFamilyMembers {
+    fn contains(&self, member: SemanticNodeId) -> bool {
+        self.links.contains_key(&member)
+    }
+
+    fn push(&mut self, member: SemanticNodeId) -> bool {
+        if self.contains(member) {
+            return false;
+        }
+        let previous = self.tail;
+        if let Some(previous_id) = previous {
+            self.links
+                .get_mut(&previous_id)
+                .expect("family tail must have a membership link")
+                .next = Some(member);
+        } else {
+            debug_assert!(self.head.is_none());
+            self.head = Some(member);
+        }
+        self.links.insert(
+            member,
+            FamilyMemberLink {
+                previous,
+                next: None,
+            },
+        );
+        self.tail = Some(member);
+        true
+    }
+
+    fn remove(&mut self, member: SemanticNodeId) -> bool {
+        let Some(link) = self.links.remove(&member) else {
+            return false;
+        };
+        if let Some(previous_id) = link.previous {
+            self.links
+                .get_mut(&previous_id)
+                .expect("family previous link must exist")
+                .next = link.next;
+        } else {
+            debug_assert_eq!(self.head, Some(member));
+            self.head = link.next;
+        }
+        if let Some(next_id) = link.next {
+            self.links
+                .get_mut(&next_id)
+                .expect("family next link must exist")
+                .previous = link.previous;
+        } else {
+            debug_assert_eq!(self.tail, Some(member));
+            self.tail = link.previous;
+        }
+        if self.links.is_empty() {
+            debug_assert!(self.head.is_none());
+            debug_assert!(self.tail.is_none());
+        }
+        true
+    }
+
+    fn iter(&self) -> impl Iterator<Item = SemanticNodeId> + '_ {
+        std::iter::successors(self.head, move |id| {
+            self.links.get(id).and_then(|link| link.next)
+        })
+    }
+
+    fn len(&self) -> usize {
+        self.links.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.links.is_empty()
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum SemanticNodeKind {
     /// Compatibility payload while `SceneDefinition` consumers migrate.
@@ -86,11 +177,11 @@ pub struct SemanticNode {
     source_identity: Option<SourceIdentity>,
     scene_membership: SemanticSceneMembership,
     /// Families containing this node. Multiple parents are intentional and
-    /// preserve Manim-style aliasing/reference semantics.
+    /// preserve Manim-style aliasing/reference semantics. This list contains only
+    /// direct relationships, so scans are proportional to this node's own degree.
     parents: Vec<SemanticNodeId>,
-    /// Ordered family membership. Ordering is semantic/presentation relevant,
-    /// but does not imply ownership of the child's transform.
-    members: Vec<SemanticNodeId>,
+    /// Ordered direct family membership with O(1) identity removal and append.
+    members: OrderedFamilyMembers,
 }
 
 impl SemanticNode {
@@ -149,8 +240,15 @@ impl SemanticNode {
         &self.parents
     }
 
-    pub fn members(&self) -> &[SemanticNodeId] {
-        &self.members
+    /// Snapshot direct members in deterministic family order.
+    ///
+    /// The allocation is query-only; mutation storage remains linked and local.
+    pub fn members(&self) -> Vec<SemanticNodeId> {
+        self.members.iter().collect()
+    }
+
+    pub fn member_count(&self) -> usize {
+        self.members.len()
     }
 }
 
@@ -241,7 +339,7 @@ impl SemanticStore {
             source_identity: None,
             scene_membership: SemanticSceneMembership::Detached,
             parents: Vec::new(),
-            members: Vec::new(),
+            members: OrderedFamilyMembers::default(),
         });
         self.live_nodes += 1;
         self.last_mutation = SemanticMutationStats {
@@ -444,6 +542,9 @@ impl SemanticStore {
     }
 
     /// Add an ordered family edge. A member may belong to multiple families.
+    ///
+    /// Direct duplicate lookup and ordered append are O(1); cycle validation is
+    /// proportional to the affected reachable family subgraph.
     pub fn add_member(
         &mut self,
         family: SemanticNodeId,
@@ -465,7 +566,7 @@ impl SemanticStore {
             .node(family)
             .expect("family validated above")
             .members
-            .contains(&member)
+            .contains(member)
         {
             self.last_mutation = SemanticMutationStats::default();
             return Ok(());
@@ -480,10 +581,12 @@ impl SemanticStore {
             return Err(SemanticStoreError::FamilyCycle { family, member });
         }
 
-        self.node_mut(family)
+        let inserted = self
+            .node_mut(family)
             .expect("family validated above")
             .members
             .push(member);
+        debug_assert!(inserted);
         self.node_mut(member)
             .expect("member validated above")
             .parents
@@ -495,6 +598,7 @@ impl SemanticStore {
         Ok(())
     }
 
+    /// Remove one direct family edge without scanning unrelated siblings.
     pub fn remove_member(
         &mut self,
         family: SemanticNodeId,
@@ -509,15 +613,15 @@ impl SemanticStore {
         if self.node(member).is_none() {
             return Err(SemanticStoreError::UnknownNode(member));
         }
-        let family_members = &mut self
+        let removed = self
             .node_mut(family)
             .expect("family validated above")
-            .members;
-        let Some(position) = family_members.iter().position(|id| *id == member) else {
+            .members
+            .remove(member);
+        if !removed {
             self.last_mutation = SemanticMutationStats::default();
             return Ok(false);
-        };
-        family_members.remove(position);
+        }
         let parents = &mut self
             .node_mut(member)
             .expect("member validated above")
@@ -534,8 +638,9 @@ impl SemanticStore {
 
     /// Remove a node without renumbering any unrelated semantic identity.
     ///
-    /// Attached root membership is removed locally first. Remaining writes are
-    /// proportional to this node's direct family edges, never total scene size.
+    /// Attached root membership is removed locally first. Remaining work is
+    /// proportional to this node's direct parent/member relationships plus free-list
+    /// bookkeeping; family sibling lists are never scanned for this removal.
     pub fn remove_node(&mut self, id: SemanticNodeId) -> Result<SemanticNode, SemanticStoreError> {
         let node = self
             .node(id)
@@ -550,11 +655,12 @@ impl SemanticStore {
 
         for parent in node.parents.iter().copied() {
             if let Some(parent_node) = self.node_mut(parent) {
-                parent_node.members.retain(|member| *member != id);
+                let removed = parent_node.members.remove(id);
+                debug_assert!(removed);
                 writes += 1;
             }
         }
-        for member in node.members.iter().copied() {
+        for member in node.members.iter() {
             if let Some(member_node) = self.node_mut(member) {
                 member_node.parents.retain(|parent| *parent != id);
                 writes += 1;
@@ -597,7 +703,7 @@ impl SemanticStore {
                 return (true, visited);
             }
             if let Some(node) = self.node(current) {
-                stack.extend(node.members.iter().copied());
+                stack.extend(node.members.iter());
             }
         }
         (false, visited)
@@ -684,16 +790,15 @@ mod tests {
         store.add_member(family, first).unwrap();
         store.add_member(family, second).unwrap();
         store.add_member(alias, first).unwrap();
-        assert_eq!(store.node(family).unwrap().members(), &[first, second]);
+        assert_eq!(store.node(family).unwrap().members(), vec![first, second]);
         assert_eq!(store.node(first).unwrap().parents(), &[family, alias]);
 
-        // SemanticStore owns duplicate suppression and direct-member ordering.
         store.add_member(family, first).unwrap();
-        assert_eq!(store.node(family).unwrap().members(), &[first, second]);
+        assert_eq!(store.node(family).unwrap().members(), vec![first, second]);
         assert_eq!(store.node(first).unwrap().parents(), &[family, alias]);
 
         assert!(store.remove_member(family, first).unwrap());
-        assert_eq!(store.node(family).unwrap().members(), &[second]);
+        assert_eq!(store.node(family).unwrap().members(), vec![second]);
         assert_eq!(store.node(first).unwrap().parents(), &[alias]);
         assert!(!store.remove_member(family, first).unwrap());
     }
@@ -762,7 +867,7 @@ mod tests {
         assert!(store.detach_from_scene(child).unwrap());
         assert_eq!(store.node(child).unwrap().id(), child);
         assert_eq!(store.node(child).unwrap().parents(), &[family]);
-        assert_eq!(store.node(family).unwrap().members(), &[child]);
+        assert_eq!(store.node(family).unwrap().members(), vec![child]);
         assert_eq!(store.node_for_source(&source), Some(child));
 
         assert!(store.attach_to_scene(child).unwrap());
@@ -799,6 +904,48 @@ mod tests {
         assert_eq!(store.last_mutation_stats().slots_written, 3);
         assert!(store.attach_to_scene(target).unwrap());
         assert_eq!(store.last_mutation_stats().slots_written, 2);
+    }
+
+    #[test]
+    fn family_member_removal_does_not_scan_unrelated_siblings() {
+        let mut store = SemanticStore::new();
+        let family = store.insert_family();
+        let members = (0..10_000)
+            .map(|_| store.insert_authoring_object())
+            .collect::<Vec<_>>();
+        for member in members.iter().copied() {
+            store.add_member(family, member).unwrap();
+        }
+        let target = members[5_000];
+
+        assert!(store.remove_member(family, target).unwrap());
+        assert_eq!(store.last_mutation_stats().slots_written, 2);
+        assert_eq!(store.node(family).unwrap().member_count(), 9_999);
+        assert!(!store.node(family).unwrap().members().contains(&target));
+
+        store.add_member(family, target).unwrap();
+        assert_eq!(store.last_mutation_stats().slots_written, 2);
+        let ordered = store.node(family).unwrap().members();
+        assert_eq!(ordered.last(), Some(&target));
+    }
+
+    #[test]
+    fn deleting_member_from_large_family_is_local() {
+        let mut store = SemanticStore::new();
+        let family = store.insert_family();
+        let members = (0..10_000)
+            .map(|_| store.insert_authoring_object())
+            .collect::<Vec<_>>();
+        for member in members.iter().copied() {
+            store.add_member(family, member).unwrap();
+        }
+        let target = members[5_000];
+
+        store.remove_node(target).unwrap();
+        assert_eq!(store.last_mutation_stats().slots_written, 2);
+        assert_eq!(store.node(family).unwrap().member_count(), 9_999);
+        assert!(store.node(target).is_none());
+        assert!(!store.node(family).unwrap().members().contains(&target));
     }
 
     #[test]
@@ -856,8 +1003,8 @@ mod tests {
             store.node(child).unwrap().parents(),
             &[first_family, second_family]
         );
-        assert_eq!(store.node(first_family).unwrap().members(), &[child]);
-        assert_eq!(store.node(second_family).unwrap().members(), &[child]);
+        assert_eq!(store.node(first_family).unwrap().members(), vec![child]);
+        assert_eq!(store.node(second_family).unwrap().members(), vec![child]);
 
         store.attach_to_scene(child).unwrap();
         store.detach_from_scene(child).unwrap();
@@ -879,6 +1026,21 @@ mod tests {
         store.remove_node(child).unwrap();
         assert!(store.node(first_family).unwrap().members().is_empty());
         assert!(store.node(second_family).unwrap().members().is_empty());
+        assert_eq!(store.last_mutation_stats().slots_written, 3);
+    }
+
+    #[test]
+    fn deleting_family_cleans_member_parent_edges_in_order() {
+        let mut store = SemanticStore::new();
+        let family = store.insert_family();
+        let first = store.insert_authoring_object();
+        let second = store.insert_authoring_object();
+        store.add_member(family, first).unwrap();
+        store.add_member(family, second).unwrap();
+
+        store.remove_node(family).unwrap();
+        assert!(store.node(first).unwrap().parents().is_empty());
+        assert!(store.node(second).unwrap().parents().is_empty());
         assert_eq!(store.last_mutation_stats().slots_written, 3);
     }
 

--- a/crates/noon-core/src/semantic_store.rs
+++ b/crates/noon-core/src/semantic_store.rs
@@ -132,7 +132,10 @@ impl SemanticNode {
     }
 
     pub const fn is_scene_owned(&self) -> bool {
-        matches!(self.scene_membership, SemanticSceneMembership::Attached { .. })
+        matches!(
+            self.scene_membership,
+            SemanticSceneMembership::Attached { .. }
+        )
     }
 
     const fn scene_next(&self) -> Option<SemanticNodeId> {

--- a/crates/noon-core/src/semantic_store.rs
+++ b/crates/noon-core/src/semantic_store.rs
@@ -719,10 +719,16 @@ mod tests {
         assert_eq!(store.node(b).unwrap().id(), b);
 
         assert!(!store.attach_to_scene(b).unwrap());
-        assert_eq!(store.last_mutation_stats(), SemanticMutationStats::default());
+        assert_eq!(
+            store.last_mutation_stats(),
+            SemanticMutationStats::default()
+        );
         let detached = store.insert_authoring_object();
         assert!(!store.detach_from_scene(detached).unwrap());
-        assert_eq!(store.last_mutation_stats(), SemanticMutationStats::default());
+        assert_eq!(
+            store.last_mutation_stats(),
+            SemanticMutationStats::default()
+        );
     }
 
     #[test]
@@ -900,7 +906,9 @@ mod tests {
 
         store.remove_node(first).unwrap();
         assert_eq!(store.node_for_source(&source), None);
-        store.set_source_identity(second, Some(source.clone())).unwrap();
+        store
+            .set_source_identity(second, Some(source.clone()))
+            .unwrap();
         assert_eq!(store.node_for_source(&source), Some(second));
     }
 

--- a/crates/noon-core/src/semantic_store.rs
+++ b/crates/noon-core/src/semantic_store.rs
@@ -42,6 +42,22 @@ pub enum SourceIdentity {
     },
 }
 
+/// Authoritative top-level scene membership for one semantic node.
+///
+/// The attached variant carries the node's intrusive ordered-root links, so
+/// membership and authored top-level ordering cannot drift into separate truths.
+/// Detached nodes remain valid semantic objects and retain source/family identity.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SemanticNodeResidency {
+    #[default]
+    Detached,
+    SceneOwned {
+        previous: Option<SemanticNodeId>,
+        next: Option<SemanticNodeId>,
+    },
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum SemanticNodeKind {
     /// Compatibility payload while `SceneDefinition` consumers migrate.
@@ -58,6 +74,7 @@ pub struct SemanticNode {
     id: SemanticNodeId,
     kind: SemanticNodeKind,
     source_identity: Option<SourceIdentity>,
+    residency: SemanticNodeResidency,
     /// Families containing this node. Multiple parents are intentional and
     /// preserve Manim-style aliasing/reference semantics.
     parents: Vec<SemanticNodeId>,
@@ -97,6 +114,28 @@ impl SemanticNode {
         self.source_identity.as_ref()
     }
 
+    pub const fn residency(&self) -> SemanticNodeResidency {
+        self.residency
+    }
+
+    pub const fn is_scene_owned(&self) -> bool {
+        matches!(self.residency, SemanticNodeResidency::SceneOwned { .. })
+    }
+
+    pub const fn scene_previous(&self) -> Option<SemanticNodeId> {
+        match self.residency {
+            SemanticNodeResidency::Detached => None,
+            SemanticNodeResidency::SceneOwned { previous, .. } => previous,
+        }
+    }
+
+    pub const fn scene_next(&self) -> Option<SemanticNodeId> {
+        match self.residency {
+            SemanticNodeResidency::Detached => None,
+            SemanticNodeResidency::SceneOwned { next, .. } => next,
+        }
+    }
+
     pub fn parents(&self) -> &[SemanticNodeId] {
         &self.parents
     }
@@ -115,8 +154,8 @@ struct SemanticSlot {
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct SemanticMutationStats {
-    /// Direct slots changed by the most recent operation. This excludes nodes
-    /// visited only for cycle validation.
+    /// Direct semantic slots changed by the most recent operation. This excludes
+    /// store-level head/tail/count metadata and nodes visited only for validation.
     pub slots_written: usize,
     /// Nodes inspected while validating a family cycle.
     pub cycle_nodes_visited: usize,
@@ -127,6 +166,9 @@ pub struct SemanticStore {
     slots: Vec<SemanticSlot>,
     free_head: Option<u32>,
     live_nodes: usize,
+    scene_head: Option<SemanticNodeId>,
+    scene_tail: Option<SemanticNodeId>,
+    scene_nodes: usize,
     object_nodes: HashMap<ObjectId, SemanticNodeId>,
     source_nodes: HashMap<SourceIdentity, SemanticNodeId>,
     last_mutation: SemanticMutationStats,
@@ -138,10 +180,17 @@ impl SemanticStore {
     }
 
     /// Compatibility adapter for the current flat scene model.
+    ///
+    /// This adapter is migration-only and is owned for deletion by #959/A4.
+    /// Objects are attached in legacy authored order so current callers remain
+    /// coherent while the authoritative semantic authoring path replaces it.
     pub fn from_scene_definition(scene: &SceneDefinition) -> Self {
         let mut store = Self::new();
         for object in scene.objects() {
-            store.insert_object(object.clone());
+            let id = store.insert_object(object.clone());
+            store
+                .attach_to_scene(id)
+                .expect("newly inserted compatibility node exists");
         }
         store
     }
@@ -181,6 +230,7 @@ impl SemanticStore {
             id,
             kind,
             source_identity: None,
+            residency: SemanticNodeResidency::Detached,
             parents: Vec::new(),
             members: Vec::new(),
         });
@@ -252,6 +302,136 @@ impl SemanticStore {
             cycle_nodes_visited: 0,
         };
         Ok(())
+    }
+
+    /// Attach an existing semantic node as the last authored top-level scene root.
+    ///
+    /// Identity, source identity and family relationships are preserved. The
+    /// operation writes only this node and the former tail node, if any.
+    pub fn attach_to_scene(&mut self, id: SemanticNodeId) -> Result<bool, SemanticStoreError> {
+        let residency = self
+            .node(id)
+            .ok_or(SemanticStoreError::UnknownNode(id))?
+            .residency;
+        if !matches!(residency, SemanticNodeResidency::Detached) {
+            self.last_mutation = SemanticMutationStats::default();
+            return Ok(false);
+        }
+
+        let previous = self.scene_tail;
+        if let Some(previous_id) = previous {
+            let previous_node = self
+                .node_mut(previous_id)
+                .expect("scene tail must reference a live semantic node");
+            match &mut previous_node.residency {
+                SemanticNodeResidency::SceneOwned { next, .. } => {
+                    debug_assert!(next.is_none());
+                    *next = Some(id);
+                }
+                SemanticNodeResidency::Detached => {
+                    unreachable!("scene tail cannot reference a detached semantic node")
+                }
+            }
+        } else {
+            debug_assert!(self.scene_head.is_none());
+            self.scene_head = Some(id);
+        }
+
+        self.node_mut(id)
+            .expect("node existence validated above")
+            .residency = SemanticNodeResidency::SceneOwned {
+            previous,
+            next: None,
+        };
+        self.scene_tail = Some(id);
+        self.scene_nodes += 1;
+        self.last_mutation = SemanticMutationStats {
+            slots_written: 1 + (previous.is_some() as usize),
+            cycle_nodes_visited: 0,
+        };
+        Ok(true)
+    }
+
+    /// Detach an existing semantic node from authored top-level scene membership.
+    ///
+    /// The handle remains valid and can later be re-attached. Only the node and
+    /// its immediate root-order neighbors are written.
+    pub fn detach_from_scene(&mut self, id: SemanticNodeId) -> Result<bool, SemanticStoreError> {
+        let residency = self
+            .node(id)
+            .ok_or(SemanticStoreError::UnknownNode(id))?
+            .residency;
+        let SemanticNodeResidency::SceneOwned { previous, next } = residency else {
+            self.last_mutation = SemanticMutationStats::default();
+            return Ok(false);
+        };
+
+        if let Some(previous_id) = previous {
+            let previous_node = self
+                .node_mut(previous_id)
+                .expect("scene previous link must reference a live semantic node");
+            match &mut previous_node.residency {
+                SemanticNodeResidency::SceneOwned {
+                    next: previous_next,
+                    ..
+                } => {
+                    debug_assert_eq!(*previous_next, Some(id));
+                    *previous_next = next;
+                }
+                SemanticNodeResidency::Detached => {
+                    unreachable!("attached node cannot have a detached previous root")
+                }
+            }
+        } else {
+            debug_assert_eq!(self.scene_head, Some(id));
+            self.scene_head = next;
+        }
+
+        if let Some(next_id) = next {
+            let next_node = self
+                .node_mut(next_id)
+                .expect("scene next link must reference a live semantic node");
+            match &mut next_node.residency {
+                SemanticNodeResidency::SceneOwned {
+                    previous: next_previous,
+                    ..
+                } => {
+                    debug_assert_eq!(*next_previous, Some(id));
+                    *next_previous = previous;
+                }
+                SemanticNodeResidency::Detached => {
+                    unreachable!("attached node cannot have a detached next root")
+                }
+            }
+        } else {
+            debug_assert_eq!(self.scene_tail, Some(id));
+            self.scene_tail = previous;
+        }
+
+        self.node_mut(id)
+            .expect("node existence validated above")
+            .residency = SemanticNodeResidency::Detached;
+        self.scene_nodes -= 1;
+        if self.scene_nodes == 0 {
+            debug_assert!(self.scene_head.is_none());
+            debug_assert!(self.scene_tail.is_none());
+        }
+        self.last_mutation = SemanticMutationStats {
+            slots_written: 1 + (previous.is_some() as usize) + (next.is_some() as usize),
+            cycle_nodes_visited: 0,
+        };
+        Ok(true)
+    }
+
+    /// Iterate current top-level authored scene roots in deterministic painter order.
+    pub fn scene_roots(&self) -> impl Iterator<Item = SemanticNodeId> + '_ {
+        std::iter::successors(self.scene_head, move |id| {
+            self.node(*id).and_then(SemanticNode::scene_next)
+        })
+    }
+
+    pub const fn scene_root_count(&self) -> usize {
+        self.scene_nodes
     }
 
     /// Add an ordered family edge. A member may belong to multiple families.
@@ -345,14 +525,20 @@ impl SemanticStore {
 
     /// Remove a node without renumbering any unrelated semantic identity.
     ///
-    /// Cost is proportional to this node's direct family edges, never the total
-    /// number of nodes in the store.
+    /// Attached root membership is removed locally first. Remaining cost is
+    /// proportional to this node's direct family edges, never total scene size.
     pub fn remove_node(&mut self, id: SemanticNodeId) -> Result<SemanticNode, SemanticStoreError> {
         let node = self
             .node(id)
             .ok_or(SemanticStoreError::UnknownNode(id))?
             .clone();
-        let mut writes = 1;
+
+        let mut writes = 0;
+        if node.is_scene_owned() {
+            self.detach_from_scene(id)?;
+            writes += self.last_mutation.slots_written;
+        }
+
         for parent in node.parents.iter().copied() {
             if let Some(parent_node) = self.node_mut(parent) {
                 parent_node.members.retain(|member| *member != id);
@@ -381,6 +567,7 @@ impl SemanticStore {
         slot.next_free = self.free_head;
         self.free_head = Some(id.slot);
         self.live_nodes -= 1;
+        writes += 1;
         self.last_mutation = SemanticMutationStats {
             slots_written: writes,
             cycle_nodes_visited: 0,
@@ -503,6 +690,71 @@ mod tests {
     }
 
     #[test]
+    fn scene_membership_order_is_authoritative_and_local() {
+        let mut store = SemanticStore::new();
+        let a = store.insert_authoring_object();
+        let b = store.insert_authoring_object();
+        let c = store.insert_authoring_object();
+
+        assert_eq!(store.scene_root_count(), 0);
+        assert!(store.scene_roots().next().is_none());
+
+        assert!(store.attach_to_scene(a).unwrap());
+        assert_eq!(store.last_mutation_stats().slots_written, 1);
+        assert!(store.attach_to_scene(b).unwrap());
+        assert_eq!(store.last_mutation_stats().slots_written, 2);
+        assert!(store.attach_to_scene(c).unwrap());
+        assert_eq!(store.last_mutation_stats().slots_written, 2);
+        assert_eq!(store.scene_roots().collect::<Vec<_>>(), vec![a, b, c]);
+
+        assert!(store.detach_from_scene(b).unwrap());
+        assert_eq!(store.last_mutation_stats().slots_written, 3);
+        assert_eq!(store.scene_roots().collect::<Vec<_>>(), vec![a, c]);
+        assert_eq!(store.node(a).unwrap().scene_next(), Some(c));
+        assert_eq!(store.node(c).unwrap().scene_previous(), Some(a));
+
+        assert!(store.attach_to_scene(b).unwrap());
+        assert_eq!(store.last_mutation_stats().slots_written, 2);
+        assert_eq!(store.scene_roots().collect::<Vec<_>>(), vec![a, c, b]);
+        assert_eq!(store.node(b).unwrap().id(), b);
+
+        assert!(!store.attach_to_scene(b).unwrap());
+        assert_eq!(store.last_mutation_stats(), SemanticMutationStats::default());
+        let detached = store.insert_authoring_object();
+        assert!(!store.detach_from_scene(detached).unwrap());
+        assert_eq!(store.last_mutation_stats(), SemanticMutationStats::default());
+    }
+
+    #[test]
+    fn detached_scene_lifecycle_preserves_semantic_identity_and_family_links() {
+        let mut store = SemanticStore::new();
+        let family = store.insert_family();
+        let child = store.insert_authoring_object();
+        let source = SourceIdentity::ExplicitKey("child".into());
+        store
+            .set_source_identity(child, Some(source.clone()))
+            .unwrap();
+        store.add_member(family, child).unwrap();
+
+        assert_eq!(
+            store.node(child).unwrap().residency(),
+            SemanticNodeResidency::Detached
+        );
+        assert!(store.attach_to_scene(child).unwrap());
+        assert!(store.node(child).unwrap().is_scene_owned());
+
+        assert!(store.detach_from_scene(child).unwrap());
+        assert_eq!(store.node(child).unwrap().id(), child);
+        assert_eq!(store.node(child).unwrap().parents(), &[family]);
+        assert_eq!(store.node(family).unwrap().members(), &[child]);
+        assert_eq!(store.node_for_source(&source), Some(child));
+
+        assert!(store.attach_to_scene(child).unwrap());
+        assert_eq!(store.node(child).unwrap().id(), child);
+        assert_eq!(store.scene_roots().collect::<Vec<_>>(), vec![child]);
+    }
+
+    #[test]
     fn deletion_does_not_renumber_unrelated_semantic_handles() {
         let mut store = SemanticStore::new();
         let ids = (0..100_000)
@@ -516,15 +768,66 @@ mod tests {
     }
 
     #[test]
-    fn reused_slot_invalidates_stale_generation() {
+    fn attach_detach_cost_does_not_scale_with_unrelated_nodes() {
+        let mut store = SemanticStore::new();
+        let roots = (0..10_000)
+            .map(|_| store.insert_authoring_object())
+            .collect::<Vec<_>>();
+        let target = roots[5_000];
+
+        store.attach_to_scene(roots[0]).unwrap();
+        store.attach_to_scene(target).unwrap();
+        store.attach_to_scene(roots[9_999]).unwrap();
+
+        assert!(store.detach_from_scene(target).unwrap());
+        assert_eq!(store.last_mutation_stats().slots_written, 3);
+        assert!(store.attach_to_scene(target).unwrap());
+        assert_eq!(store.last_mutation_stats().slots_written, 2);
+    }
+
+    #[test]
+    fn reused_slot_invalidates_stale_generation_for_all_lifecycle_operations() {
         let mut store = SemanticStore::new();
         let first = store.insert_object(object(1));
+        store.attach_to_scene(first).unwrap();
         store.remove_node(first).unwrap();
         let second = store.insert_object(object(2));
+
         assert_eq!(first.slot(), second.slot());
         assert_ne!(first.generation(), second.generation());
         assert!(store.node(first).is_none());
         assert!(store.node(second).is_some());
+        assert!(matches!(
+            store.attach_to_scene(first),
+            Err(SemanticStoreError::UnknownNode(id)) if id == first
+        ));
+        assert!(matches!(
+            store.detach_from_scene(first),
+            Err(SemanticStoreError::UnknownNode(id)) if id == first
+        ));
+        assert!(matches!(
+            store.remove_node(first),
+            Err(SemanticStoreError::UnknownNode(id)) if id == first
+        ));
+    }
+
+    #[test]
+    fn deleting_attached_root_repairs_order_without_touching_unrelated_roots() {
+        let mut store = SemanticStore::new();
+        let a = store.insert_authoring_object();
+        let b = store.insert_authoring_object();
+        let c = store.insert_authoring_object();
+        store.attach_to_scene(a).unwrap();
+        store.attach_to_scene(b).unwrap();
+        store.attach_to_scene(c).unwrap();
+
+        store.remove_node(b).unwrap();
+        assert_eq!(store.scene_roots().collect::<Vec<_>>(), vec![a, c]);
+        assert_eq!(store.node(a).unwrap().scene_next(), Some(c));
+        assert_eq!(store.node(c).unwrap().scene_previous(), Some(a));
+        assert_eq!(store.scene_root_count(), 2);
+        assert_eq!(store.node(a).unwrap().id(), a);
+        assert_eq!(store.node(c).unwrap().id(), c);
     }
 
     #[test]
@@ -541,6 +844,28 @@ mod tests {
         );
         assert_eq!(store.node(first_family).unwrap().members(), &[child]);
         assert_eq!(store.node(second_family).unwrap().members(), &[child]);
+
+        store.attach_to_scene(child).unwrap();
+        store.detach_from_scene(child).unwrap();
+        assert_eq!(
+            store.node(child).unwrap().parents(),
+            &[first_family, second_family]
+        );
+    }
+
+    #[test]
+    fn deleting_node_cleans_direct_family_edges() {
+        let mut store = SemanticStore::new();
+        let first_family = store.insert_family();
+        let second_family = store.insert_family();
+        let child = store.insert_authoring_object();
+        store.add_member(first_family, child).unwrap();
+        store.add_member(second_family, child).unwrap();
+
+        store.remove_node(child).unwrap();
+        assert!(store.node(first_family).unwrap().members().is_empty());
+        assert!(store.node(second_family).unwrap().members().is_empty());
+        assert_eq!(store.last_mutation_stats().slots_written, 3);
     }
 
     #[test]
@@ -556,28 +881,44 @@ mod tests {
     }
 
     #[test]
-    fn source_identity_is_unique_and_stable() {
+    fn source_identity_is_unique_stable_and_released_on_delete() {
         let mut store = SemanticStore::new();
         let first = store.insert_object(object(1));
         let second = store.insert_object(object(2));
         let source = SourceIdentity::ExplicitKey("hero".into());
+
         store
             .set_source_identity(first, Some(source.clone()))
             .unwrap();
+        store.attach_to_scene(first).unwrap();
+        store.detach_from_scene(first).unwrap();
         assert_eq!(store.node_for_source(&source), Some(first));
         assert!(matches!(
-            store.set_source_identity(second, Some(source)),
+            store.set_source_identity(second, Some(source.clone())),
             Err(SemanticStoreError::DuplicateSourceIdentity(_))
         ));
+
+        store.remove_node(first).unwrap();
+        assert_eq!(store.node_for_source(&source), None);
+        store.set_source_identity(second, Some(source.clone())).unwrap();
+        assert_eq!(store.node_for_source(&source), Some(second));
     }
 
     #[test]
-    fn flat_scene_adapter_preserves_legacy_object_lookup() {
+    fn flat_scene_adapter_preserves_legacy_lookup_and_root_order() {
+        // Compatibility-only regression owned for deletion by #959/A4.
         let mut scene = SceneDefinition::new();
         let first = scene.add(GeometryRef::circle(1.0));
         let second = scene.add(GeometryRef::rectangle(2.0, 1.0));
         let store = SemanticStore::from_scene_definition(&scene);
-        assert!(store.node(store.node_for_object(first).unwrap()).is_some());
-        assert!(store.node(store.node_for_object(second).unwrap()).is_some());
+        let first_node = store.node_for_object(first).unwrap();
+        let second_node = store.node_for_object(second).unwrap();
+
+        assert!(store.node(first_node).unwrap().is_scene_owned());
+        assert!(store.node(second_node).unwrap().is_scene_owned());
+        assert_eq!(
+            store.scene_roots().collect::<Vec<_>>(),
+            vec![first_node, second_node]
+        );
     }
 }

--- a/crates/noon-core/src/semantic_store.rs
+++ b/crates/noon-core/src/semantic_store.rs
@@ -137,7 +137,7 @@ impl OrderedFamilyMembers {
             debug_assert_eq!(self.tail, Some(member));
             self.tail = link.previous;
         }
-        if self.links.is_empty() {
+        if self.is_empty() {
             debug_assert!(self.head.is_none());
             debug_assert!(self.tail.is_none());
         }

--- a/crates/noon-core/src/semantic_store.rs
+++ b/crates/noon-core/src/semantic_store.rs
@@ -42,17 +42,27 @@ pub enum SourceIdentity {
     },
 }
 
-/// Authoritative top-level scene membership for one semantic node.
+/// Whether a semantic node currently participates in authored top-level scene membership.
 ///
-/// The attached variant carries the node's intrusive ordered-root links, so
-/// membership and authored top-level ordering cannot drift into separate truths.
-/// Detached nodes remain valid semantic objects and retain source/family identity.
+/// This is the semantic view only. Intrusive ordering links remain private storage
+/// detail so they cannot become an accidental frontend or serialization contract.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SemanticNodeResidency {
     #[default]
     Detached,
-    SceneOwned {
+    SceneOwned,
+}
+
+/// Authoritative storage for top-level scene membership and order.
+///
+/// Membership and ordering are one representation: an attached node carries its
+/// previous/next links; a detached node carries no scene-order state.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum SemanticSceneMembership {
+    #[default]
+    Detached,
+    Attached {
         previous: Option<SemanticNodeId>,
         next: Option<SemanticNodeId>,
     },
@@ -74,7 +84,7 @@ pub struct SemanticNode {
     id: SemanticNodeId,
     kind: SemanticNodeKind,
     source_identity: Option<SourceIdentity>,
-    residency: SemanticNodeResidency,
+    scene_membership: SemanticSceneMembership,
     /// Families containing this node. Multiple parents are intentional and
     /// preserve Manim-style aliasing/reference semantics.
     parents: Vec<SemanticNodeId>,
@@ -115,24 +125,20 @@ impl SemanticNode {
     }
 
     pub const fn residency(&self) -> SemanticNodeResidency {
-        self.residency
-    }
-
-    pub const fn is_scene_owned(&self) -> bool {
-        matches!(self.residency, SemanticNodeResidency::SceneOwned { .. })
-    }
-
-    pub const fn scene_previous(&self) -> Option<SemanticNodeId> {
-        match self.residency {
-            SemanticNodeResidency::Detached => None,
-            SemanticNodeResidency::SceneOwned { previous, .. } => previous,
+        match self.scene_membership {
+            SemanticSceneMembership::Detached => SemanticNodeResidency::Detached,
+            SemanticSceneMembership::Attached { .. } => SemanticNodeResidency::SceneOwned,
         }
     }
 
-    pub const fn scene_next(&self) -> Option<SemanticNodeId> {
-        match self.residency {
-            SemanticNodeResidency::Detached => None,
-            SemanticNodeResidency::SceneOwned { next, .. } => next,
+    pub const fn is_scene_owned(&self) -> bool {
+        matches!(self.scene_membership, SemanticSceneMembership::Attached { .. })
+    }
+
+    const fn scene_next(&self) -> Option<SemanticNodeId> {
+        match self.scene_membership {
+            SemanticSceneMembership::Detached => None,
+            SemanticSceneMembership::Attached { next, .. } => next,
         }
     }
 
@@ -230,7 +236,7 @@ impl SemanticStore {
             id,
             kind,
             source_identity: None,
-            residency: SemanticNodeResidency::Detached,
+            scene_membership: SemanticSceneMembership::Detached,
             parents: Vec::new(),
             members: Vec::new(),
         });
@@ -309,11 +315,11 @@ impl SemanticStore {
     /// Identity, source identity and family relationships are preserved. The
     /// operation writes only this node and the former tail node, if any.
     pub fn attach_to_scene(&mut self, id: SemanticNodeId) -> Result<bool, SemanticStoreError> {
-        let residency = self
+        let membership = self
             .node(id)
             .ok_or(SemanticStoreError::UnknownNode(id))?
-            .residency;
-        if !matches!(residency, SemanticNodeResidency::Detached) {
+            .scene_membership;
+        if !matches!(membership, SemanticSceneMembership::Detached) {
             self.last_mutation = SemanticMutationStats::default();
             return Ok(false);
         }
@@ -323,12 +329,12 @@ impl SemanticStore {
             let previous_node = self
                 .node_mut(previous_id)
                 .expect("scene tail must reference a live semantic node");
-            match &mut previous_node.residency {
-                SemanticNodeResidency::SceneOwned { next, .. } => {
+            match &mut previous_node.scene_membership {
+                SemanticSceneMembership::Attached { next, .. } => {
                     debug_assert!(next.is_none());
                     *next = Some(id);
                 }
-                SemanticNodeResidency::Detached => {
+                SemanticSceneMembership::Detached => {
                     unreachable!("scene tail cannot reference a detached semantic node")
                 }
             }
@@ -339,7 +345,7 @@ impl SemanticStore {
 
         self.node_mut(id)
             .expect("node existence validated above")
-            .residency = SemanticNodeResidency::SceneOwned {
+            .scene_membership = SemanticSceneMembership::Attached {
             previous,
             next: None,
         };
@@ -357,11 +363,11 @@ impl SemanticStore {
     /// The handle remains valid and can later be re-attached. Only the node and
     /// its immediate root-order neighbors are written.
     pub fn detach_from_scene(&mut self, id: SemanticNodeId) -> Result<bool, SemanticStoreError> {
-        let residency = self
+        let membership = self
             .node(id)
             .ok_or(SemanticStoreError::UnknownNode(id))?
-            .residency;
-        let SemanticNodeResidency::SceneOwned { previous, next } = residency else {
+            .scene_membership;
+        let SemanticSceneMembership::Attached { previous, next } = membership else {
             self.last_mutation = SemanticMutationStats::default();
             return Ok(false);
         };
@@ -370,15 +376,15 @@ impl SemanticStore {
             let previous_node = self
                 .node_mut(previous_id)
                 .expect("scene previous link must reference a live semantic node");
-            match &mut previous_node.residency {
-                SemanticNodeResidency::SceneOwned {
+            match &mut previous_node.scene_membership {
+                SemanticSceneMembership::Attached {
                     next: previous_next,
                     ..
                 } => {
                     debug_assert_eq!(*previous_next, Some(id));
                     *previous_next = next;
                 }
-                SemanticNodeResidency::Detached => {
+                SemanticSceneMembership::Detached => {
                     unreachable!("attached node cannot have a detached previous root")
                 }
             }
@@ -391,15 +397,15 @@ impl SemanticStore {
             let next_node = self
                 .node_mut(next_id)
                 .expect("scene next link must reference a live semantic node");
-            match &mut next_node.residency {
-                SemanticNodeResidency::SceneOwned {
+            match &mut next_node.scene_membership {
+                SemanticSceneMembership::Attached {
                     previous: next_previous,
                     ..
                 } => {
                     debug_assert_eq!(*next_previous, Some(id));
                     *next_previous = previous;
                 }
-                SemanticNodeResidency::Detached => {
+                SemanticSceneMembership::Detached => {
                     unreachable!("attached node cannot have a detached next root")
                 }
             }
@@ -410,7 +416,7 @@ impl SemanticStore {
 
         self.node_mut(id)
             .expect("node existence validated above")
-            .residency = SemanticNodeResidency::Detached;
+            .scene_membership = SemanticSceneMembership::Detached;
         self.scene_nodes -= 1;
         if self.scene_nodes == 0 {
             debug_assert!(self.scene_head.is_none());
@@ -423,7 +429,7 @@ impl SemanticStore {
         Ok(true)
     }
 
-    /// Iterate current top-level authored scene roots in deterministic painter order.
+    /// Iterate current top-level authored scene roots in deterministic authored order.
     pub fn scene_roots(&self) -> impl Iterator<Item = SemanticNodeId> + '_ {
         std::iter::successors(self.scene_head, move |id| {
             self.node(*id).and_then(SemanticNode::scene_next)
@@ -525,7 +531,7 @@ impl SemanticStore {
 
     /// Remove a node without renumbering any unrelated semantic identity.
     ///
-    /// Attached root membership is removed locally first. Remaining cost is
+    /// Attached root membership is removed locally first. Remaining writes are
     /// proportional to this node's direct family edges, never total scene size.
     pub fn remove_node(&mut self, id: SemanticNodeId) -> Result<SemanticNode, SemanticStoreError> {
         let node = self
@@ -710,8 +716,6 @@ mod tests {
         assert!(store.detach_from_scene(b).unwrap());
         assert_eq!(store.last_mutation_stats().slots_written, 3);
         assert_eq!(store.scene_roots().collect::<Vec<_>>(), vec![a, c]);
-        assert_eq!(store.node(a).unwrap().scene_next(), Some(c));
-        assert_eq!(store.node(c).unwrap().scene_previous(), Some(a));
 
         assert!(store.attach_to_scene(b).unwrap());
         assert_eq!(store.last_mutation_stats().slots_written, 2);
@@ -747,7 +751,10 @@ mod tests {
             SemanticNodeResidency::Detached
         );
         assert!(store.attach_to_scene(child).unwrap());
-        assert!(store.node(child).unwrap().is_scene_owned());
+        assert_eq!(
+            store.node(child).unwrap().residency(),
+            SemanticNodeResidency::SceneOwned
+        );
 
         assert!(store.detach_from_scene(child).unwrap());
         assert_eq!(store.node(child).unwrap().id(), child);
@@ -829,8 +836,6 @@ mod tests {
 
         store.remove_node(b).unwrap();
         assert_eq!(store.scene_roots().collect::<Vec<_>>(), vec![a, c]);
-        assert_eq!(store.node(a).unwrap().scene_next(), Some(c));
-        assert_eq!(store.node(c).unwrap().scene_previous(), Some(a));
         assert_eq!(store.scene_root_count(), 2);
         assert_eq!(store.node(a).unwrap().id(), a);
         assert_eq!(store.node(c).unwrap().id(), c);

--- a/crates/noon-web/src/authoring_mobject.rs
+++ b/crates/noon-web/src/authoring_mobject.rs
@@ -1050,7 +1050,7 @@ fn semantic_family_leaf_ids(
             }
             SemanticNodeKind::Family => {
                 for member in node.members() {
-                    collect(store, *member, leaves)?;
+                    collect(store, member, leaves)?;
                 }
                 Ok(())
             }


### PR DESCRIPTION
## Roadmap ownership

Phase A / #953, A1.1 in #957. Migration seam deletion owner: #959/A4.

## What this implements

The stale branch was reset onto current `master` and reworked against the A1.1 implementation/review/test contract in #957.

This establishes one generational authored identity space plus authoritative ordered scene/family membership:

- new semantic nodes start detached;
- attaching appends the existing `SemanticNodeId` to authored scene order;
- detaching preserves semantic identity, source identity and family/alias edges;
- re-attaching preserves identity and appends according to current authored order;
- scene membership and order are one private intrusive storage representation; public `SemanticNodeResidency` exposes only `Detached | SceneOwned`, so previous/next storage topology is not frontend/serialization API;
- ordered family membership uses private identity-indexed links, preserving deterministic order while making duplicate lookup, append and member removal local;
- a member may belong to multiple families without transform ownership;
- deletion removes attached root membership locally, cleans only direct family/source/legacy mappings, invalidates the generation and never renumbers unrelated nodes;
- stale generations are rejected for read/attach/detach/delete;
- source identity survives detach/re-add and is released on deletion;
- family membership remains independent from scene residency at the storage primitive; A1.3 owns user-visible recursive scene/group operations.

## Temporary migration seam

`SemanticNodeKind::Object(ObjectDefinition)`, legacy `ObjectId -> SemanticNodeId` lookup, and `SemanticStore::from_scene_definition()` remain compatibility-only while A2/A3 migrate callers. The adapter imports current flat objects into semantic scene order only to keep the repository coherent. These paths are explicitly owned for deletion by #959/A4 and are not target architecture or a format-compatibility commitment.

No JSON/serialization/transport boundary is introduced into the Rust engine path. Deriving `Serialize`/`Deserialize` on semantic value types does not make serialization an internal engine boundary.

## Locality

- `NodeId` lookup: O(1);
- root attach: O(1), writes node + former tail at most;
- root detach: O(1), writes node + immediate previous/next at most;
- ordered root iteration: O(number of attached roots);
- direct family duplicate lookup/append/remove: expected O(1) identity lookup plus constant link rewrites;
- deleting a node touches its immediate root links plus its direct parent/member relationships; unrelated family siblings are not scanned;
- cycle validation is proportional to the affected reachable family subgraph, not hidden mutation work.

## Validation added

Focused tests cover:
- authored scene order A/B/C -> detach B -> A/C -> reattach B -> A/C/B;
- idempotent attach/detach;
- identity/source/family preservation across detach/re-add;
- 100k-node unrelated identity stability;
- bounded attach/detach mutation counts with 10k unrelated nodes;
- 10k-member family removal and node deletion without sibling scans;
- deterministic family order after remove/re-add;
- stale generation rejection for lifecycle operations;
- deletion repair of ordered scene links;
- family alias cleanup, family deletion cleanup and cycle behavior;
- source identity release/reuse;
- compatibility import preserving authored order while the adapter exists.

## Independent review result

Architecture/correctness/locality review found and fixed two issues during the PR:
1. root previous/next links were moved out of public `SemanticNodeResidency` into private storage so topology cannot become serialized/frontend API;
2. the pre-existing family `Vec` removal path was replaced with ordered identity-indexed links so A1.1 deletion/member locality no longer scans unrelated siblings.

Merge only after the final exact head passes architecture ratchet, format/clippy, Rust unit tests and the normal browser/web PR gate.

Refs #953 #957 #959.