### PR TITLE
Add repository guardrails for isolated agent development

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: true
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/roadmap-task.yml
+++ b/.github/ISSUE_TEMPLATE/roadmap-task.yml
@@ -1,0 +1,69 @@
+name: Roadmap task
+description: Define implementation work against the authoritative Noon architecture.
+title: "[Roadmap ] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Read `docs/architecture.md` and `AGENTS.md` before filing cross-cutting work. GitHub issues hold implementation detail; they do not define a second architecture.
+  - type: input
+    id: roadmap
+    attributes:
+      label: Roadmap owner
+      description: Parent roadmap issue and implementation case.
+      placeholder: "#953 / A1.2"
+    validations:
+      required: true
+  - type: dropdown
+    id: layer
+    attributes:
+      label: Architecture layer
+      options:
+        - Semantic Scene
+        - Execution Plan / compiler
+        - Runtime
+        - Renderer
+        - Rust public API / shared semantics
+        - Python frontend
+        - Browser / WASM integration
+        - Testing / tooling / CI
+        - Cross-layer (explain below)
+    validations:
+      required: true
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: State the target behavior, not the migration mechanism.
+    validations:
+      required: true
+  - type: textarea
+    id: invariants
+    attributes:
+      label: Architecture invariants
+      description: Which architecture/locality/ownership invariants constrain this work?
+      placeholder: |
+        - one Semantic Scene authority
+        - Rust-native typed in-memory path
+        - local edit remains local
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Prefer executable/deterministic evidence over implementation-shaped prose.
+      placeholder: "- [ ] ..."
+    validations:
+      required: true
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies and migration seams
+      description: List prerequisite issues and any temporary seam this work introduces. Name the issue that deletes each seam.
+      placeholder: "None"
+  - type: textarea
+    id: handoff
+    attributes:
+      label: Handoff notes
+      description: Information an isolated agent needs to continue this task without conversation history.

--- a/.github/ISSUE_TEMPLATE/roadmap-task.yml
+++ b/.github/ISSUE_TEMPLATE/roadmap-task.yml
@@ -1,6 +1,5 @@
 name: Roadmap task
 description: Define implementation work against the authoritative Noon architecture.
-title: "[Roadmap ] "
 body:
   - type: markdown
     attributes:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/Toronto
+    open-pull-requests-limit: 5
+    groups:
+      rust-dependencies:
+        patterns:
+          - "*"
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:30"
+      timezone: America/Toronto
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+## Roadmap ownership
+
+- Owning issue/case: <!-- e.g. #957 A1.2 -->
+- Architecture layer: <!-- Semantic Scene / Execution Plan / Runtime / Renderer / frontend / tooling -->
+
+## What changed
+
+<!-- Keep this focused on the behavior/architecture this PR changes. -->
+
+## Architecture check
+
+- [ ] I read the relevant parts of `docs/architecture.md` and `AGENTS.md`.
+- [ ] This PR does not introduce a second scene authority, semantic ID space, scheduler, runtime, renderer authority, or feature-specific mutation system.
+- [ ] The Rust-native path remains typed and in-memory; no JSON/serialization/frontend bridge became an ordinary engine boundary.
+- [ ] Shared semantics live in Rust rather than a Python/JS parallel implementation.
+- [ ] Local operations remain local through lowering, runtime, renderer, and GPU/resource updates.
+
+## Migration seam
+
+<!-- Write `None`, or name every temporary compatibility/migration seam and the issue that deletes it. -->
+
+## Validation
+
+<!-- Exact commands/tests run, plus any focused invariant/performance coverage added. -->
+
+## Cleanup and handoff
+
+- [ ] Obsolete code made unnecessary by this change was deleted where in scope.
+- [ ] Any temporary compatibility code has an explicit deletion owner.
+- [ ] The owning issue/PR description says what landed and what remains.

--- a/.github/workflows/architecture-ratchets.yml
+++ b/.github/workflows/architecture-ratchets.yml
@@ -1,0 +1,42 @@
+name: Architecture Ratchets
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: architecture-ratchets-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  migration-growth:
+    name: Migration architecture does not grow
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate guardrail scripts
+        run: bash -n scripts/check.sh scripts/architecture-ratchet.sh
+
+      - name: Reject new migration-era architecture references
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          base="$PR_BASE_SHA"
+          if [[ -z "$base" ]]; then
+            base="$PUSH_BEFORE_SHA"
+          fi
+          if [[ -z "$base" || "$base" =~ ^0+$ ]]; then
+            base="HEAD^"
+          fi
+          bash scripts/architecture-ratchet.sh "$base"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,7 +159,19 @@ Use stable resource generations, dirty-range uploads, retained residency, and ex
 
 Text, Graph, interaction, and 3D are features of the same renderer/runtime architecture, not separate engines.
 
-## 13. Tests and validation
+## 13. Local validation
+
+Use the repository validation entrypoint instead of reconstructing CI commands from memory:
+
+```bash
+bash scripts/check.sh fast
+```
+
+Use `bash scripts/check.sh full` before merge when the change affects Rust plus browser integration or when the owning issue/PR calls for the full local gate. Run narrower focused tests while iterating, but report the exact commands actually run in the PR.
+
+GitHub CI has additional parallel browser, parity, golden, differential, performance, and platform-specific jobs. A local `check.sh` pass does not replace required GitHub checks.
+
+## 14. Tests and validation
 
 Prefer deterministic structural tests over tests that merely make current implementation details permanent.
 
@@ -177,7 +189,7 @@ Protect invariants such as:
 
 JSON-based fixtures are fine when testing an explicit codec/transport/export boundary. Do not make a legacy serialized scene path the canonical engine qualification path.
 
-## 14. PR discipline
+## 15. PR discipline
 
 Keep PRs narrow enough that their architectural effect is reviewable.
 
@@ -194,7 +206,7 @@ Do not add a permanent compatibility layer to make a PR easier to merge.
 
 Do not add new permanent roadmap/architecture documents. Update `docs/architecture.md` only when the architecture itself changes. Put implementation checklists and remaining work in GitHub issues.
 
-## 15. Before finishing a task
+## 16. Before finishing a task
 
 Before declaring work complete:
 
@@ -204,6 +216,7 @@ Before declaring work complete:
 4. Ensure temporary compatibility code has an explicit deletion owner.
 5. Add focused tests for the invariant or behavior changed.
 6. Check that local operations remain local.
-7. Update the owning GitHub issue/PR with what landed and what remains.
+7. Run the appropriate `scripts/check.sh` mode and any focused validation required by the owning issue.
+8. Update the owning GitHub issue/PR with what landed and what remains.
 
 When uncertain, choose the design that keeps one semantic authority, one lowering boundary, one runtime, one renderer, and a fully Rust-native typed in-memory path.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "1.98.0"
+profile = "minimal"
+components = ["rustfmt", "clippy"]
+targets = ["wasm32-unknown-unknown"]

--- a/scripts/architecture-ratchet.sh
+++ b/scripts/architecture-ratchet.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+base="${1:-}"
+if [[ -z "$base" ]]; then
+  if git rev-parse --verify HEAD^ >/dev/null 2>&1; then
+    base="HEAD^"
+  else
+    echo "architecture ratchet needs a base commit" >&2
+    exit 2
+  fi
+fi
+
+if ! git cat-file -e "${base}^{commit}" 2>/dev/null; then
+  echo "architecture ratchet base commit is unavailable: $base" >&2
+  exit 2
+fi
+
+range="${base}...HEAD"
+forbidden='SceneDefinition|SceneSpec|SceneDocument|ObjectDefinition|ObjectSnapshot|from_legacy|noon::legacy|_manim_canonical_scene|scene_document|noon-ir'
+
+found=0
+current_file=""
+while IFS= read -r line; do
+  case "$line" in
+    "+++ b/"*)
+      current_file="${line#+++ b/}"
+      ;;
+    +*)
+      [[ "$line" == "+++ "* ]] && continue
+      added="${line:1}"
+      if printf '%s\n' "$added" | grep -Eq "$forbidden"; then
+        printf 'architecture ratchet: %s: +%s\n' "${current_file:-unknown}" "$added" >&2
+        found=1
+      fi
+      ;;
+  esac
+done < <(
+  git diff --no-color --unified=0 "$range" -- \
+    '*.rs' '*.py' '*.js' '*.mjs' '*.ts' '*.tsx' \
+    'Cargo.toml' '*/Cargo.toml' 'crates/*/Cargo.toml'
+)
+
+if (( found != 0 )); then
+  cat >&2 <<'EOF'
+
+New migration-era architecture references are not allowed to grow.
+Delete/rewrite the dependency instead of spreading it. If a target architecture
+change genuinely requires one of these tokens, update docs/architecture.md and
+this ratchet explicitly in the same reviewed PR rather than bypassing the check.
+EOF
+  exit 1
+fi
+
+echo "architecture migration-growth ratchet passed"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+usage() {
+  cat <<'EOF'
+Usage: bash scripts/check.sh [fast|full|rust|fmt-lint|test|web]
+
+  fast      Format/check/clippy plus workspace library tests.
+  full      Full Rust gate plus the browser build/validation entrypoint.
+  rust      Format/check/clippy plus all workspace tests.
+  fmt-lint  Format/check/clippy only.
+  test      All workspace tests only.
+  web       Browser build/validation only.
+
+The repository's extended GitHub workflows additionally run browser, parity,
+golden, differential, and platform-specific checks where appropriate.
+EOF
+}
+
+fmt_lint() {
+  cargo fmt --all -- --check
+  cargo check --workspace --all-targets --all-features
+  cargo clippy --workspace --all-targets --all-features -- -D warnings
+}
+
+fast_tests() {
+  cargo test --workspace --all-features --lib
+}
+
+all_tests() {
+  cargo test --workspace --all-features
+}
+
+web_check() {
+  bash scripts/build-web-demo.sh
+}
+
+mode="${1:-fast}"
+case "$mode" in
+  fast)
+    fmt_lint
+    fast_tests
+    ;;
+  full)
+    fmt_lint
+    all_tests
+    web_check
+    ;;
+  rust)
+    fmt_lint
+    all_tests
+    ;;
+  fmt-lint)
+    fmt_lint
+    ;;
+  test)
+    all_tests
+    ;;
+  web)
+    web_check
+    ;;
+  -h|--help|help)
+    usage
+    ;;
+  *)
+    echo "unknown check mode: $mode" >&2
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/web/ci-workflow-topology.test.mjs
+++ b/web/ci-workflow-topology.test.mjs
@@ -11,6 +11,7 @@ assert.ok(workflowFiles.length > 0, "CI workflow inventory must not be empty");
 const exactFamilies = new Map([
   ["pr-fast.yml", "pr-fast"],
   ["ci.yml", "main"],
+  ["architecture-ratchets.yml", "architecture"],
   ["compiler-cache-seed.yml", "cache-seed"],
   ["test-coverage.yml", "coverage"],
   ["platform-release.yml", "platform-release"],
@@ -44,6 +45,7 @@ assert.deepEqual(
 const requiredFamilies = new Set([
   "pr-fast",
   "main",
+  "architecture",
   "cache-seed",
   "coverage",
   "platform-release",

--- a/web/ci-workflow-topology.test.mjs
+++ b/web/ci-workflow-topology.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { readdir, readFile } from "node:fs/promises";
+import { readdir } from "node:fs/promises";
 
 const workflowDir = new URL("../.github/workflows/", import.meta.url);
 const workflowFiles = (await readdir(workflowDir))
@@ -55,18 +55,6 @@ const requiredFamilies = new Set([
 const presentFamilies = new Set(classified.map(({ family }) => family));
 for (const family of requiredFamilies) {
   assert.ok(presentFamilies.has(family), `required CI family ${family} must remain represented`);
-}
-
-const ciDocs = await readFile(new URL("../docs/ci.md", import.meta.url), "utf8");
-for (const [needle, purpose] of [
-  [".github/workflows/pr-fast.yml", "pull-request fast gate"],
-  [".github/workflows/ci.yml", "main CI"],
-  [".github/workflows/compiler-cache-seed.yml", "compiler-cache seed"],
-  [".github/workflows/platform-release.yml", "platform/release validation"],
-  [".github/workflows/test-coverage.yml", "test observability"],
-  ["Manim compatibility workflows", "Manim validation family"],
-]) {
-  assert.match(ciDocs, new RegExp(needle.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")), `${purpose} must remain documented`);
 }
 
 const counts = Object.fromEntries(


### PR DESCRIPTION
## Roadmap ownership

- Owning issues: #953 / #961 (initial Phase A6 guardrails)
- Architecture layer: tooling / CI; no production engine behavior changes

## What changed

Adds lightweight repository scaffolding for Noon's isolated-agent development model without creating another architecture document:

- root `rust-toolchain.toml` pinned to Rust 1.98.0 with rustfmt/clippy/WASM target;
- PR template requiring roadmap ownership, architecture-layer review, migration-seam ownership, locality review, validation, cleanup, and handoff state;
- roadmap-task issue form for persistent cross-session implementation context;
- `scripts/check.sh` as the canonical local fast/full validation entrypoint, documented in `AGENTS.md`;
- PR/push architecture ratchet rejecting newly added references to known migration-era scene/IR/legacy architecture;
- Dependabot for Cargo and GitHub Actions updates;
- workflow-topology validation now classifies the architecture gate and no longer depends on deleted `docs/ci.md`.

## Architecture check

- Rust-native authoring/execution remains typed and in-memory.
- No general JSON ban was added: explicit codecs, tests, exports, and genuine cross-context transport remain allowed.
- The ratchet only prevents known migration architecture (`SceneDefinition`, `SceneSpec`, `scene_document`, `noon-ir`, legacy adapters, etc.) from spreading while A1-A4 delete it.
- No new architecture/roadmap document was introduced.

## Migration seam

None introduced. The ratchet exists specifically to stop current migration seams from growing.

## Validation

- new `Architecture Ratchets` workflow passes;
- existing Rust format/lint passes under the pinned toolchain;
- existing web static/unit preflight passes after removing its stale `docs/ci.md` dependency;
- remaining existing PR browser/Rust workflows provide the normal integration gate.

## Cleanup and handoff

The repository admin ruleset/branch-protection setting for `master` is not changed by this PR because the connected GitHub integration does not expose a ruleset/protection write action. Repository rulesets currently report none; this remains an account-level GitHub setting to enable separately.