### PR TITLE
Align AGENTS.md with dual-target Rust execution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Prefer deletion over compatibility scaffolding.
 
 If temporary migration code is unavoidable, the PR must identify the current issue that owns its deletion. Do not create an adapter with no explicit removal condition.
 
-## 3. Product invariant: Rust is first-class
+## 3. Product invariant: Rust is first-class on native and web
 
 The complete native product must work as a normal Rust library/runtime without Python, JavaScript, WASM, browser infrastructure, JSON, or another transport layer.
 
@@ -34,15 +34,33 @@ Rust API
   -> Execution Plan
   -> Runtime
   -> Renderer
+  -> native platform host / surface
 ```
 
 That path is typed and in-memory.
 
-Do not introduce serialization/deserialization, JSON, scene documents, wire payloads, IPC, WASM bindings, or frontend bridges as ordinary boundaries between these layers.
+The same Rust-authored scene semantics must also be able to run when the Rust engine is compiled to WASM:
+
+```text
+Rust/WASM API
+  -> Semantic Scene
+  -> Execution Plan
+  -> Runtime
+  -> Renderer
+  -> browser/WASM host / canvas
+```
+
+When these layers share one process or one WASM execution context, every arrow above is a typed in-process Rust boundary.
+
+Do not introduce serialization/deserialization, JSON, scene documents, execution mirrors, wire payloads, IPC, WASM bindings, or frontend bridges as ordinary boundaries between these layers.
+
+A browser target by itself is **not** a transport boundary. JavaScript may bootstrap WASM and supply browser objects such as a canvas, but it must not receive and re-send scene/runtime state between Rust engine layers.
+
+Serialization is acceptable only at explicit external boundaries such as debugging, export/import, test fixtures/goldens, persisted interchange, or genuine cross-context transport such as a separate Python/Pyodide worker communicating with an execution/render worker. Serializable data types do not imply that serialization is an engine boundary.
 
 Python and future JavaScript/TypeScript APIs are optional language wrappers over shared Rust semantic operations. They are not required engine components.
 
-Serialization is acceptable only at explicit external boundaries such as debugging, export/import, test fixtures/goldens, or genuine cross-context transport. Serializable data types do not imply that serialization is an engine boundary.
+Direct native/web execution work is owned by `#969` during Phase A.
 
 ## 4. The four authorities
 
@@ -53,12 +71,15 @@ There is exactly one authority at each architecture layer:
 3. **Runtime** — current mutable execution state.
 4. **Renderer** — derived retained GPU state and draw work.
 
+Platform hosts are integration shells around those layers. They own platform lifecycle, not semantic/runtime truth.
+
 Do not create:
 
 - another authored scene representation;
 - another semantic ID allocator;
 - frontend-owned semantic state;
 - frontend-owned animation scheduling/interpolation;
+- platform-host-owned semantic or scheduling state;
 - renderer-owned semantic truth;
 - feature-specific scene engines;
 - feature-specific runtimes;
@@ -75,7 +96,7 @@ Rust authoring is a direct first-class API over shared Rust semantic operations.
 
 Shared high-level behavior belongs in Rust semantic code: scene membership, family behavior, layout, bounds, target state, animation semantics, lifecycle, ordering, signals, and mutation rules.
 
-## 6. Frontend ownership
+## 6. Frontend ownership and paired examples
 
 Python may own Python-specific ergonomics such as class shape, signatures, argument coercion, exception mapping, Python callable identity, and invocation of arbitrary Python callbacks.
 
@@ -84,6 +105,17 @@ Python must not own a second valid scene, semantic object state, semantic IDs, f
 Future JavaScript/TypeScript follows the same rule.
 
 If equivalent Rust and Python authoring produce different semantic behavior, fix the shared Rust semantics rather than implementing two engines.
+
+For significant common semantics supported by both public APIs, maintain equivalent executable Rust and Python examples:
+
+- the Rust example is the direct first-class product/engine proof;
+- the Python example proves the wrapper reaches equivalent shared Rust semantics;
+- both should exercise the normal shared lowering/runtime/renderer path;
+- target bootstrap may differ, but scene semantics should remain equivalent;
+- representative Rust examples should run through both native and direct Rust/WASM targets where applicable;
+- migration-era `SceneDefinition`, scene-document, `noon-ir`, or other serialized scene paths are not the canonical parity mechanism.
+
+An implementation is not complete merely because only one frontend can demonstrate shared behavior that is intended to exist in both.
 
 ## 7. Mutations and live work
 
@@ -123,7 +155,8 @@ Use the current roadmap issues to locate ownership before implementing broad wor
 - `#953` — Phase A: architecture consolidation;
 - `#954` — Phase B: common 2D semantics;
 - `#955` — Phase C: native interaction, locality, and live authoring;
-- `#956` — Phase D: 3D and broader capability on the same engine.
+- `#956` — Phase D: 3D and broader capability on the same engine;
+- `#969` — Phase A2/A6: direct Rust execution hosts for native and web.
 
 During Phase A, avoid broad feature expansion unless the work is a correctness fix or architecture-neutral.
 
@@ -133,13 +166,15 @@ Do not resurrect closed architecture issues or old PR branches wholesale. Replay
 
 The repository is in active architectural consolidation.
 
-Do not infer the target design solely from existing types, tests, modules, JSON paths, compatibility functions, crate boundaries, or browser plumbing.
+Do not infer the target design solely from existing types, tests, modules, JSON paths, compatibility functions, crate boundaries, browser plumbing, or renderer mirrors.
 
-In particular, legacy scene models, `SceneDefinition`/`SceneSpec`-style structures, retained sidecars, migration JSON APIs, and compatibility adapters may exist only because Phase A has not deleted them yet.
+In particular, legacy scene models, `SceneDefinition`/`SceneSpec`-style structures, retained sidecars, migration JSON APIs, execution mirrors, and compatibility adapters may exist only because Phase A has not deleted them yet.
+
+The current browser renderer using JSON/transport does not make that transport mandatory for direct single-context Rust/WASM execution.
 
 When new architecture makes old code unnecessary, remove it rather than wrapping it.
 
-## 11. Crates and modules
+## 11. Crates, modules, renderer, and platform hosts
 
 Crates require a real dependency, compilation-target, or reuse boundary.
 
@@ -149,17 +184,23 @@ Do not preserve a crate merely because another crate currently imports it. First
 
 Module structure should make ownership obvious. Avoid `#[path]` and `include!` structures that hide unrelated domains behind one module.
 
-## 12. Renderer rules
+`noon-render-wgpu` owns reusable retained GPU rendering. It may own renderer-local camera/viewport data, GPU resources, preparation/upload logic, command encoding, and disposable renderer caches.
 
-The renderer consumes runtime/execution state and owns only derived/disposable retained GPU state.
+It must not become the application/platform shell merely for convenience. Platform integration owns concerns such as:
 
-Transform/style/visibility-only changes must not regenerate immutable geometry or text resources unnecessarily.
+- native OS window or browser canvas lifecycle;
+- application/browser event loop and frame scheduling;
+- wgpu instance/surface/adapter/device/queue/configuration where platform integration owns them;
+- resize and input translation;
+- surface/frame acquisition, queue submission, presentation, and recovery policy.
 
-Use stable resource generations, dirty-range uploads, retained residency, and execution-owned visibility/spatial information.
+Native host integration may be a separate crate only if window/platform dependencies create a real compilation/dependency boundary. Do not create `noon-native` merely for naming symmetry with `noon-web`.
+
+`noon-web` owns browser/WASM platform integration, not semantic or renderer authority. Its direct Rust/WASM path must not require a serialized execution transport when all engine layers share one WASM context.
 
 Text, Graph, interaction, and 3D are features of the same renderer/runtime architecture, not separate engines.
 
-## 13. Local validation
+## 12. Local validation
 
 Use the repository validation entrypoint instead of reconstructing CI commands from memory:
 
@@ -171,7 +212,7 @@ Use `bash scripts/check.sh full` before merge when the change affects Rust plus 
 
 GitHub CI has additional parallel browser, parity, golden, differential, performance, and platform-specific jobs. A local `check.sh` pass does not replace required GitHub checks.
 
-## 14. Tests and validation
+## 13. Tests and validation
 
 Prefer deterministic structural tests over tests that merely make current implementation details permanent.
 
@@ -183,13 +224,16 @@ Protect invariants such as:
 - mutations are atomic and rollback-safe;
 - local mutations remain local;
 - retained resources are reused when content did not change;
-- Rust and Python authoring share semantic behavior;
+- Rust and Python authoring share semantic behavior through paired representative examples;
 - Manim compatibility is checked at supported semantic/visual boundaries;
-- native Rust execution does not depend on serialization or language frontends.
+- native Rust execution does not depend on serialization or language frontends;
+- direct Rust/WASM execution does not serialize between in-process engine layers;
+- platform hosts do not become semantic/runtime authorities;
+- `noon-render-wgpu` does not become the native/browser application event-loop owner.
 
 JSON-based fixtures are fine when testing an explicit codec/transport/export boundary. Do not make a legacy serialized scene path the canonical engine qualification path.
 
-## 15. PR discipline
+## 14. PR discipline
 
 Keep PRs narrow enough that their architectural effect is reviewable.
 
@@ -206,17 +250,20 @@ Do not add a permanent compatibility layer to make a PR easier to merge.
 
 Do not add new permanent roadmap/architecture documents. Update `docs/architecture.md` only when the architecture itself changes. Put implementation checklists and remaining work in GitHub issues.
 
-## 16. Before finishing a task
+## 15. Before finishing a task
 
 Before declaring work complete:
 
 1. Re-read the relevant section of `docs/architecture.md`.
-2. Check whether the change created a second authority, identity space, scheduler, runtime, renderer model, or serialization boundary.
-3. Search for obsolete code made unnecessary by the change and delete it when safe within scope.
-4. Ensure temporary compatibility code has an explicit deletion owner.
-5. Add focused tests for the invariant or behavior changed.
-6. Check that local operations remain local.
-7. Run the appropriate `scripts/check.sh` mode and any focused validation required by the owning issue.
-8. Update the owning GitHub issue/PR with what landed and what remains.
+2. Check whether the change created a second authority, identity space, scheduler, runtime, renderer model, platform-host authority, or serialization boundary.
+3. If browser-targeted, ask whether there is a genuine cross-context boundary; do not introduce transport merely because the code runs in a browser.
+4. For common semantics supported in Rust and Python, add/update equivalent executable examples and shared parity evidence.
+5. For Rust execution work, preserve both the native and direct Rust/WASM typed paths where applicable.
+6. Search for obsolete code made unnecessary by the change and delete it when safe within scope.
+7. Ensure temporary compatibility code has an explicit deletion owner.
+8. Add focused tests for the invariant or behavior changed.
+9. Check that local operations remain local.
+10. Run the appropriate `scripts/check.sh` mode and any focused validation required by the owning issue.
+11. Update the owning GitHub issue/PR with what landed and what remains.
 
-When uncertain, choose the design that keeps one semantic authority, one lowering boundary, one runtime, one renderer, and a fully Rust-native typed in-memory path.
+When uncertain, choose the design that keeps one semantic authority, one lowering boundary, one runtime, one reusable renderer, platform hosts as lifecycle-only shells, and typed in-process Rust boundaries on both native and direct single-context Rust/WASM paths.


### PR DESCRIPTION
## Roadmap ownership

- Architecture authority: `docs/architecture.md`
- Execution-host owner: #969
- Related Phase A/B trackers: #953 #958 #961 #954 #91

## What changed

Updates the isolated-agent operating contract to match the architecture clarified in #970:

- Rust is first-class on both native and direct Rust/WASM web targets;
- a browser target alone is not a transport boundary;
- no JSON/scene document/execution mirror is allowed between engine layers when they share one process/WASM context;
- JavaScript may bootstrap WASM/provide browser objects but must not mediate engine-layer state;
- `noon-render-wgpu` remains reusable retained rendering machinery rather than the platform application shell;
- native/browser platform hosts own window/canvas/event-loop/surface/frame lifecycle only;
- significant shared semantics should have paired executable Rust/Python examples;
- Rust examples are the direct engine proof and Python examples prove wrapper/compatibility behavior;
- #969 is explicitly listed as the Phase A owner for direct native/web Rust execution.

## Migration seam

None introduced.

## Validation

Docs-only agent-contract update. Normal PR CI and architecture ratchets apply.