### PR TITLE
Ratchet hidden Rust module ownership

### DIFF
--- a/.github/workflows/architecture-ratchets.yml
+++ b/.github/workflows/architecture-ratchets.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   migration-growth:
-    name: Migration architecture does not grow
+    name: Architecture constraints do not regress
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -25,9 +25,12 @@ jobs:
           fetch-depth: 0
 
       - name: Validate guardrail scripts
-        run: bash -n scripts/check.sh scripts/architecture-ratchet.sh
+        run: bash -n scripts/check.sh scripts/architecture-ratchet.sh scripts/architecture-ratchet.test.sh
 
-      - name: Reject new migration-era architecture references
+      - name: Exercise architecture guardrails
+        run: bash scripts/architecture-ratchet.test.sh
+
+      - name: Reject architecture regressions
         env:
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PUSH_BEFORE_SHA: ${{ github.event.before }}

--- a/scripts/architecture-ratchet.sh
+++ b/scripts/architecture-ratchet.sh
@@ -55,4 +55,28 @@ EOF
   exit 1
 fi
 
-echo "architecture migration-growth ratchet passed"
+module_indirection_found=0
+path_matches="$(git grep -nE '^[[:space:]]*#\[[[:space:]]*path[[:space:]]*=' -- '*.rs' || true)"
+include_matches="$(git grep -nE '(^|[^[:alnum:]_])include![[:space:]]*\(' -- '*.rs' || true)"
+
+if [[ -n "$path_matches" ]]; then
+  printf 'architecture ratchet: hidden Rust module ownership via #[path] is forbidden:\n%s\n' "$path_matches" >&2
+  module_indirection_found=1
+fi
+
+if [[ -n "$include_matches" ]]; then
+  printf 'architecture ratchet: hidden Rust module ownership via include! is forbidden:\n%s\n' "$include_matches" >&2
+  module_indirection_found=1
+fi
+
+if (( module_indirection_found != 0 )); then
+  cat >&2 <<'EOF'
+
+Rust module ownership must be visible from the normal module tree.
+Move code into explicit modules/crates with architecture-owned boundaries instead
+of using #[path] or include! to hide unrelated domains behind another module.
+EOF
+  exit 1
+fi
+
+echo "architecture migration-growth and module-structure ratchets passed"

--- a/scripts/architecture-ratchet.sh
+++ b/scripts/architecture-ratchet.sh
@@ -22,7 +22,8 @@ fi
 range="${base}...HEAD"
 forbidden='SceneDefinition|SceneSpec|SceneDocument|ObjectDefinition|ObjectSnapshot|from_legacy|noon::legacy|_manim_canonical_scene|scene_document|noon-ir'
 
-found=0
+migration_found=0
+module_indirection_found=0
 current_file=""
 while IFS= read -r line; do
   case "$line" in
@@ -32,10 +33,24 @@ while IFS= read -r line; do
     +*)
       [[ "$line" == "+++ "* ]] && continue
       added="${line:1}"
+
       if printf '%s\n' "$added" | grep -Eq "$forbidden"; then
         printf 'architecture ratchet: %s: +%s\n' "${current_file:-unknown}" "$added" >&2
-        found=1
+        migration_found=1
       fi
+
+      case "$current_file" in
+        *.rs)
+          if printf '%s\n' "$added" | grep -Eq '^[[:space:]]*#\[[[:space:]]*path[[:space:]]*='; then
+            printf 'architecture ratchet: new hidden Rust module ownership: %s: +%s\n' "$current_file" "$added" >&2
+            module_indirection_found=1
+          fi
+          if printf '%s\n' "$added" | grep -Eq '(^|[^[:alnum:]_])include![[:space:]]*(\(|\{|\[)'; then
+            printf 'architecture ratchet: new hidden Rust module ownership: %s: +%s\n' "$current_file" "$added" >&2
+            module_indirection_found=1
+          fi
+          ;;
+      esac
       ;;
   esac
 done < <(
@@ -44,7 +59,7 @@ done < <(
     'Cargo.toml' '*/Cargo.toml' 'crates/*/Cargo.toml'
 )
 
-if (( found != 0 )); then
+if (( migration_found != 0 )); then
   cat >&2 <<'EOF'
 
 New migration-era architecture references are not allowed to grow.
@@ -52,31 +67,20 @@ Delete/rewrite the dependency instead of spreading it. If a target architecture
 change genuinely requires one of these tokens, update docs/architecture.md and
 this ratchet explicitly in the same reviewed PR rather than bypassing the check.
 EOF
-  exit 1
-fi
-
-module_indirection_found=0
-path_matches="$(git grep -nE '^[[:space:]]*#\[[[:space:]]*path[[:space:]]*=' -- '*.rs' || true)"
-include_matches="$(git grep -nE '(^|[^[:alnum:]_])include![[:space:]]*(\(|\{|\[)' -- '*.rs' || true)"
-
-if [[ -n "$path_matches" ]]; then
-  printf 'architecture ratchet: hidden Rust module ownership via #[path] is forbidden:\n%s\n' "$path_matches" >&2
-  module_indirection_found=1
-fi
-
-if [[ -n "$include_matches" ]]; then
-  printf 'architecture ratchet: hidden Rust module ownership via include! is forbidden:\n%s\n' "$include_matches" >&2
-  module_indirection_found=1
 fi
 
 if (( module_indirection_found != 0 )); then
   cat >&2 <<'EOF'
 
-Rust module ownership must be visible from the normal module tree.
-Move code into explicit modules/crates with architecture-owned boundaries instead
-of using #[path] or include! to hide unrelated domains behind another module.
+New Rust #[path] / include! module indirection is not allowed.
+Existing A5 migration debt is grandfathered only until its owning cleanup lands;
+do not move or duplicate it. Once an area is normalized, tighten this ratchet to
+make that absence structural. See #960/A5 and #961/A6.8.
 EOF
+fi
+
+if (( migration_found != 0 || module_indirection_found != 0 )); then
   exit 1
 fi
 
-echo "architecture migration-growth and module-structure ratchets passed"
+echo "architecture migration-growth and module-growth ratchets passed"

--- a/scripts/architecture-ratchet.sh
+++ b/scripts/architecture-ratchet.sh
@@ -57,7 +57,7 @@ fi
 
 module_indirection_found=0
 path_matches="$(git grep -nE '^[[:space:]]*#\[[[:space:]]*path[[:space:]]*=' -- '*.rs' || true)"
-include_matches="$(git grep -nE '(^|[^[:alnum:]_])include![[:space:]]*\(' -- '*.rs' || true)"
+include_matches="$(git grep -nE '(^|[^[:alnum:]_])include![[:space:]]*(\(|\{|\[)' -- '*.rs' || true)"
 
 if [[ -n "$path_matches" ]]; then
   printf 'architecture ratchet: hidden Rust module ownership via #[path] is forbidden:\n%s\n' "$path_matches" >&2

--- a/scripts/architecture-ratchet.test.sh
+++ b/scripts/architecture-ratchet.test.sh
@@ -13,40 +13,69 @@ cd "$TMP"
 git init -q
 git config user.name "Noon Architecture Ratchet Test"
 git config user.email "ratchet-test@example.invalid"
-printf 'pub fn visible_module_tree() {}\n' > src/lib.rs
-git add scripts/architecture-ratchet.sh src/lib.rs
-git commit -qm "baseline"
 
-bash scripts/architecture-ratchet.sh HEAD >/dev/null
+# Model the repository during Phase A: old module indirection may still exist,
+# but the ratchet must prevent it from growing while A5 removes the debt.
+cat > src/lib.rs <<'EOF'
+#[path = "existing_hidden.rs"]
+mod existing_hidden;
+include!("existing_impl.rs");
+EOF
+printf 'pub fn existing_hidden() {}\n' > src/existing_hidden.rs
+printf 'pub fn existing_impl() {}\n' > src/existing_impl.rs
+git add scripts/architecture-ratchet.sh src
+git commit -qm "baseline with known A5 debt"
+BASE="$(git rev-parse HEAD)"
+
+printf 'pub fn visible_module_tree() {}\n' > src/visible.rs
+git add src/visible.rs
+git commit -qm "unrelated clean change"
+bash scripts/architecture-ratchet.sh "$BASE" >/dev/null
 
 expect_rejected() {
-  local label="$1"
-  if bash scripts/architecture-ratchet.sh HEAD >/dev/null 2>&1; then
+  label="$1"
+  if bash scripts/architecture-ratchet.sh "$BASE" >/dev/null 2>&1; then
     echo "architecture ratchet test failed: accepted $label" >&2
     exit 1
   fi
 }
 
-cat > src/lib.rs <<'EOF'
-#[path = "hidden.rs"]
-mod hidden;
-EOF
-expect_rejected '#[path] module indirection'
+reset_to_base() {
+  git reset -q --hard "$BASE"
+  rm -f src/new_hidden.rs
+}
 
-git checkout -q -- src/lib.rs
-cat > src/lib.rs <<'EOF'
-include!("hidden.rs");
+reset_to_base
+cat > src/new_hidden.rs <<'EOF'
+#[path = "another_hidden.rs"]
+mod another_hidden;
 EOF
-expect_rejected 'include!(...) module indirection'
+git add src/new_hidden.rs
+git commit -qm "add path indirection"
+expect_rejected '#[path] module indirection growth'
 
-cat > src/lib.rs <<'EOF'
-include! { "hidden.rs" }
+reset_to_base
+cat > src/new_hidden.rs <<'EOF'
+include!("another_hidden.rs");
 EOF
-expect_rejected 'include! {...} module indirection'
+git add src/new_hidden.rs
+git commit -qm "add include parens"
+expect_rejected 'include!(...) module indirection growth'
 
-cat > src/lib.rs <<'EOF'
-include! [ "hidden.rs" ]
+reset_to_base
+cat > src/new_hidden.rs <<'EOF'
+include! { "another_hidden.rs" }
 EOF
-expect_rejected 'include! [...] module indirection'
+git add src/new_hidden.rs
+git commit -qm "add include braces"
+expect_rejected 'include! {...} module indirection growth'
+
+reset_to_base
+cat > src/new_hidden.rs <<'EOF'
+include! [ "another_hidden.rs" ]
+EOF
+git add src/new_hidden.rs
+git commit -qm "add include brackets"
+expect_rejected 'include! [...] module indirection growth'
 
 echo "architecture ratchet self-test passed"

--- a/scripts/architecture-ratchet.test.sh
+++ b/scripts/architecture-ratchet.test.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RATCHET="$ROOT/scripts/architecture-ratchet.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+mkdir -p "$TMP/scripts" "$TMP/src"
+cp "$RATCHET" "$TMP/scripts/architecture-ratchet.sh"
+
+cd "$TMP"
+git init -q
+git config user.name "Noon Architecture Ratchet Test"
+git config user.email "ratchet-test@example.invalid"
+printf 'pub fn visible_module_tree() {}\n' > src/lib.rs
+git add scripts/architecture-ratchet.sh src/lib.rs
+git commit -qm "baseline"
+
+bash scripts/architecture-ratchet.sh HEAD >/dev/null
+
+expect_rejected() {
+  local label="$1"
+  if bash scripts/architecture-ratchet.sh HEAD >/dev/null 2>&1; then
+    echo "architecture ratchet test failed: accepted $label" >&2
+    exit 1
+  fi
+}
+
+cat > src/lib.rs <<'EOF'
+#[path = "hidden.rs"]
+mod hidden;
+EOF
+expect_rejected '#[path] module indirection'
+
+git checkout -q -- src/lib.rs
+cat > src/lib.rs <<'EOF'
+include!("hidden.rs");
+EOF
+expect_rejected 'include!(...) module indirection'
+
+cat > src/lib.rs <<'EOF'
+include! { "hidden.rs" }
+EOF
+expect_rejected 'include! {...} module indirection'
+
+cat > src/lib.rs <<'EOF'
+include! [ "hidden.rs" ]
+EOF
+expect_rejected 'include! [...] module indirection'
+
+echo "architecture ratchet self-test passed"


### PR DESCRIPTION
## Roadmap ownership

- Owning issue/case: #961 / A6.8
- Architecture layer: Testing / tooling / CI (Track V)

## What changed

Tighten the existing architecture ratchet so hidden Rust module ownership cannot **grow** while #960/A5 removes the repository's existing `#[path]` / `include!` migration debt.

- rejects newly-added `#[path = ...]` module indirection in Rust source;
- rejects newly-added `include!` module indirection with `(...)`, `{...}`, or `[...]` delimiters;
- does not grandfather *new* locations by moving existing debt around;
- preserves the existing migration-growth checks for legacy scene/IR architecture;
- adds an isolated self-test proving pre-existing A5 debt does not block unrelated work while every new forbidden form fails;
- runs the self-test in the existing Architecture Ratchets workflow.

This is intentionally an incremental ratchet, not the final A5 exit check. The repository currently contains known module-indirection debt in areas including `noon-core`, `noon-runtime`, renderer integration, `noon-ir`, `noon-web`, and `noon`. #960 owns normalizing those areas. As each ownership island is cleaned, #961 can tighten the relevant absence from growth-only to structural/full-tree.

## Architecture check

- [x] Read the relevant `docs/architecture.md`, `AGENTS.md`, #960 and #961.
- [x] Does not introduce a second scene authority, semantic ID space, scheduler, runtime, renderer authority, or feature-specific mutation system.
- [x] Does not introduce serialization or a frontend/platform bridge.
- [x] Matches #961's incremental ratchet cadence: A6 tightens behind A5 rather than pretending A5 cleanup is already complete.
- [x] Independent of A1 semantic-store implementation.

## Migration seam

Existing module-indirection debt is explicitly owned by #960/A5; this PR prevents that debt from growing. It does not create a new seam.

## Validation

- Architecture Ratchets CI originally exposed an incorrect assumption in this PR: current master still contains existing `#[path]` / `include!` debt. The implementation has been corrected rather than allow-listing or hiding that debt.
- `scripts/architecture-ratchet.test.sh` now models an existing-debt baseline and verifies:
  - an unrelated clean change passes;
  - new `#[path = ...]` fails;
  - new `include!(...)` fails;
  - new `include! {...}` fails;
  - new `include! [...]` fails.
- The normal migration-era token growth ratchet remains active.

## Cleanup and handoff

- [x] No obsolete compatibility code added.
- [x] No new temporary compatibility seam.
- [x] #960 remains the owner for deleting existing module indirection.
- [x] #961 can convert cleaned ownership islands to full structural absence as A5 lands.

Refs #953 #960 #961.