### PR TITLE
Ratchet renderer platform-host boundary

### DIFF
--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -8,10 +8,10 @@ usage() {
   cat <<'EOF'
 Usage: bash scripts/check.sh [fast|full|rust|fmt-lint|test|web]
 
-  fast      Format/check/clippy plus workspace library tests.
+  fast      Architecture checks, format/check/clippy plus workspace library tests.
   full      Full Rust gate plus the browser build/validation entrypoint.
-  rust      Format/check/clippy plus all workspace tests.
-  fmt-lint  Format/check/clippy only.
+  rust      Architecture checks, format/check/clippy plus all workspace tests.
+  fmt-lint  Architecture checks plus format/check/clippy only.
   test      All workspace tests only.
   web       Browser build/validation only.
 
@@ -20,7 +20,12 @@ golden, differential, and platform-specific checks where appropriate.
 EOF
 }
 
+architecture_checks() {
+  bash scripts/renderer-host-boundary-ratchet.sh
+}
+
 fmt_lint() {
+  architecture_checks
   cargo fmt --all -- --check
   cargo check --workspace --all-targets --all-features
   cargo clippy --workspace --all-targets --all-features -- -D warnings

--- a/scripts/renderer-host-boundary-ratchet.sh
+++ b/scripts/renderer-host-boundary-ratchet.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+manifest="crates/noon-render-wgpu/Cargo.toml"
+source_root="crates/noon-render-wgpu/src"
+
+# noon-render-wgpu is reusable retained rendering machinery. Window/canvas/event-loop
+# and surface lifecycle dependencies belong to native/web platform integration.
+forbidden_direct_deps='^[[:space:]]*(winit|raw-window-handle|web-sys|js-sys|wasm-bindgen)[[:space:]]*='
+
+found=0
+if grep -En "$forbidden_direct_deps" "$manifest"; then
+  cat >&2 <<'EOF'
+renderer host-boundary ratchet: noon-render-wgpu gained a platform-host dependency.
+Window/browser lifecycle dependencies belong at the native/web platform edge (#960/#969),
+not in the reusable renderer.
+EOF
+  found=1
+fi
+
+mapfile -t rust_sources < <(git ls-files "$source_root" | grep -E '\.rs$' || true)
+if (( ${#rust_sources[@]} == 0 )); then
+  echo "renderer host-boundary ratchet: no tracked Rust sources found under $source_root" >&2
+  exit 2
+fi
+
+# wgpu device/queue/texture-view/encoder types are renderer machinery. Surface
+# creation/configuration/acquisition/presentation is platform-host lifecycle and must
+# remain outside this crate.
+forbidden_source_api='winit::|web_sys::|js_sys::|wasm_bindgen::|wgpu::Surface([^A-Za-z0-9_]|$)|wgpu::SurfaceConfiguration([^A-Za-z0-9_]|$)|wgpu::SurfaceTexture([^A-Za-z0-9_]|$)|create_surface[[:space:]]*\(|get_current_texture[[:space:]]*\('
+
+if grep -En "$forbidden_source_api" "${rust_sources[@]}"; then
+  cat >&2 <<'EOF'
+renderer host-boundary ratchet: noon-render-wgpu contains platform surface/window/browser lifecycle code.
+Keep surface creation/configuration/frame acquisition/presentation in the native or web host and pass
+renderer-owned GPU inputs through typed Rust APIs instead.
+EOF
+  found=1
+fi
+
+if (( found != 0 )); then
+  exit 1
+fi
+
+echo "renderer platform-host boundary ratchet passed"

--- a/scripts/renderer-host-boundary-ratchet.sh
+++ b/scripts/renderer-host-boundary-ratchet.sh
@@ -21,27 +21,30 @@ EOF
   found=1
 fi
 
-mapfile -t rust_sources < <(git ls-files "$source_root" | grep -E '\.rs$' || true)
-if (( ${#rust_sources[@]} == 0 )); then
-  echo "renderer host-boundary ratchet: no tracked Rust sources found under $source_root" >&2
-  exit 2
-fi
-
 # wgpu device/queue/texture-view/encoder types are renderer machinery. Surface
 # creation/configuration/acquisition/presentation is platform-host lifecycle and must
 # remain outside this crate.
 forbidden_source_api='winit::|web_sys::|js_sys::|wasm_bindgen::|wgpu::Surface([^A-Za-z0-9_]|$)|wgpu::SurfaceConfiguration([^A-Za-z0-9_]|$)|wgpu::SurfaceTexture([^A-Za-z0-9_]|$)|create_surface[[:space:]]*\(|get_current_texture[[:space:]]*\('
 
-if grep -En "$forbidden_source_api" "${rust_sources[@]}"; then
-  cat >&2 <<'EOF'
-renderer host-boundary ratchet: noon-render-wgpu contains platform surface/window/browser lifecycle code.
-Keep surface creation/configuration/frame acquisition/presentation in the native or web host and pass
-renderer-owned GPU inputs through typed Rust APIs instead.
-EOF
-  found=1
+source_count=0
+while IFS= read -r source; do
+  source_count=$((source_count + 1))
+  if grep -En "$forbidden_source_api" "$source"; then
+    found=1
+  fi
+done < <(git ls-files "$source_root" | grep -E '\.rs$' || true)
+
+if (( source_count == 0 )); then
+  echo "renderer host-boundary ratchet: no tracked Rust sources found under $source_root" >&2
+  exit 2
 fi
 
 if (( found != 0 )); then
+  cat >&2 <<'EOF'
+renderer host-boundary ratchet failed.
+Keep window/browser/surface creation, configuration, frame acquisition and presentation in the
+native or web platform host, and pass renderer-owned GPU inputs through typed Rust APIs instead.
+EOF
   exit 1
 fi
 


### PR DESCRIPTION
## Roadmap ownership

- Owning cases: #960 / A5.5 and #961 / A6.8
- Related execution owner: #969
- Architecture layer: Renderer / platform-host boundary

## What changed

Add an executable structural guard that keeps `noon-render-wgpu` reusable rendering machinery rather than allowing platform lifecycle to migrate into the renderer.

The new ratchet rejects:
- direct renderer dependencies on `winit`, `raw-window-handle`, `web-sys`, `js-sys`, or `wasm-bindgen`;
- renderer-source ownership of `winit`/browser bindings;
- `wgpu::Surface`, `SurfaceConfiguration`, or `SurfaceTexture` ownership;
- surface creation or frame acquisition (`create_surface`, `get_current_texture`) inside `noon-render-wgpu`.

`wgpu` device/queue/texture-view/encoder usage remains valid renderer machinery. Native/browser surface lifecycle remains owned by the platform-host work in #969.

The guard is run from the normal `scripts/check.sh` architecture/lint path, so `fast`, `rust`, `full`, and `fmt-lint` all enforce it locally and in CI callers that use the repository check entrypoint.

## Architecture check

- [x] Preserves `noon-render-wgpu` as renderer-only machinery.
- [x] Does not prescribe whether native host integration is a crate or module.
- [x] Does not introduce a platform implementation or alternate runtime.
- [x] Does not touch Semantic Scene/store implementation.
- [x] Does not overlap #972's architecture-ratchet/workflow files.
- [x] Script avoids Bash 4-only features so stock macOS Bash remains supported.

## Migration seam

None.

## Validation

- Current `noon-render-wgpu/Cargo.toml` has no forbidden platform-host dependencies.
- Repository code search found no current `winit`, `wgpu::Surface`, `SurfaceConfiguration`, or `get_current_texture` ownership to grandfather.
- Branch is based on current `master` after #962 merged and is 0 commits behind.
- Normal check entrypoint executes the new structural guard before Rust format/check/clippy.

## Locality / performance

No runtime behavior changes. This is a source/dependency ownership ratchet only.

Refs #953 #960 #961 #969.