### PR TITLE
Ratchet one-way engine dependency layers

### DIFF
--- a/.github/workflows/layer-dependency-ratchet.yml
+++ b/.github/workflows/layer-dependency-ratchet.yml
@@ -1,0 +1,32 @@
+name: Layer Dependency Ratchet
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: layer-dependency-ratchet-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  architecture-layering:
+    name: Engine dependency direction stays one-way
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate ratchet scripts
+        run: bash -n scripts/layer-dependency-ratchet.sh scripts/layer-dependency-ratchet.test.sh
+
+      - name: Prove ratchet catches forbidden edges
+        run: bash scripts/layer-dependency-ratchet.test.sh
+
+      - name: Enforce architecture layer dependencies
+        run: bash scripts/layer-dependency-ratchet.sh

--- a/scripts/layer-dependency-ratchet.sh
+++ b/scripts/layer-dependency-ratchet.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="${NOON_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+
+found=0
+
+check_layer() {
+  manifest="$1"
+  layer="$2"
+  shift 2
+
+  if [[ ! -f "$ROOT/$manifest" ]]; then
+    echo "layer dependency ratchet: missing manifest for $layer: $manifest" >&2
+    exit 2
+  fi
+
+  dep=""
+  for dep in "$@"; do
+    matches="$(
+      grep -En \
+        -e "^[[:space:]]*(\"${dep}\"|'${dep}'|${dep})[[:space:]]*=" \
+        -e "^[[:space:]]*\\[[^]]*dependencies\\.(\"${dep}\"|'${dep}'|${dep})\\][[:space:]]*$" \
+        "$ROOT/$manifest" || true
+    )"
+    if [[ -n "$matches" ]]; then
+      printf '%s\n' "$matches" >&2
+      echo "layer dependency ratchet: $layer must not depend on $dep" >&2
+      found=1
+    fi
+  done
+}
+
+# Dependency arrows point down the engine stack. Lower layers must not import
+# frontend/platform layers or later engine authorities merely for convenience.
+check_layer \
+  "crates/noon-core/Cargo.toml" \
+  "Semantic Scene / noon-core" \
+  noon-compile noon-runtime noon-render-wgpu noon-web noon
+
+check_layer \
+  "crates/noon-compile/Cargo.toml" \
+  "Execution Plan compiler / noon-compile" \
+  noon-runtime noon-render-wgpu noon-web noon
+
+check_layer \
+  "crates/noon-runtime/Cargo.toml" \
+  "Runtime / noon-runtime" \
+  noon-render-wgpu noon-web noon
+
+check_layer \
+  "crates/noon-render-wgpu/Cargo.toml" \
+  "Renderer / noon-render-wgpu" \
+  noon-web noon
+
+if (( found != 0 )); then
+  cat >&2 <<'EOF'
+
+Phase A layer dependency direction was violated.
+Keep Semantic Scene, lowering/compiler, Runtime, Renderer, and platform/frontend
+ownership one-way. Move shared data/behavior to its owning lower layer instead of
+adding an upward dependency. See #953, #960 A5 and #961 A6.8.
+EOF
+  exit 1
+fi
+
+echo "architecture layer dependency ratchet passed"

--- a/scripts/layer-dependency-ratchet.test.sh
+++ b/scripts/layer-dependency-ratchet.test.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RATCHET="$ROOT/scripts/layer-dependency-ratchet.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+mkdir -p \
+  "$TMP/crates/noon-core" \
+  "$TMP/crates/noon-compile" \
+  "$TMP/crates/noon-runtime" \
+  "$TMP/crates/noon-render-wgpu"
+
+write_clean_fixture() {
+  cat >"$TMP/crates/noon-core/Cargo.toml" <<'EOF'
+[package]
+name = "noon-core"
+[dependencies]
+serde = "1"
+EOF
+
+  cat >"$TMP/crates/noon-compile/Cargo.toml" <<'EOF'
+[package]
+name = "noon-compile"
+[dependencies]
+noon-core = { path = "../noon-core" }
+EOF
+
+  cat >"$TMP/crates/noon-runtime/Cargo.toml" <<'EOF'
+[package]
+name = "noon-runtime"
+[dependencies]
+noon-core = { path = "../noon-core" }
+noon-compile = { path = "../noon-compile" }
+EOF
+
+  cat >"$TMP/crates/noon-render-wgpu/Cargo.toml" <<'EOF'
+[package]
+name = "noon-render-wgpu"
+[dependencies]
+noon-core = { path = "../noon-core" }
+noon-runtime = { path = "../noon-runtime" }
+EOF
+}
+
+expect_failure() {
+  label="$1"
+  if NOON_ROOT="$TMP" bash "$RATCHET" >"$TMP/output" 2>&1; then
+    echo "layer dependency ratchet self-test unexpectedly passed: $label" >&2
+    cat "$TMP/output" >&2
+    exit 1
+  fi
+}
+
+write_clean_fixture
+NOON_ROOT="$TMP" bash "$RATCHET" >/dev/null
+
+write_clean_fixture
+echo 'noon-runtime = { path = "../noon-runtime" }' >>"$TMP/crates/noon-core/Cargo.toml"
+expect_failure "noon-core -> noon-runtime"
+
+write_clean_fixture
+echo 'noon-render-wgpu = { path = "../noon-render-wgpu" }' >>"$TMP/crates/noon-compile/Cargo.toml"
+expect_failure "noon-compile -> noon-render-wgpu"
+
+write_clean_fixture
+echo '"noon-web" = { path = "../noon-web" }' >>"$TMP/crates/noon-runtime/Cargo.toml"
+expect_failure "noon-runtime -> noon-web with quoted TOML key"
+
+write_clean_fixture
+cat >>"$TMP/crates/noon-render-wgpu/Cargo.toml" <<'EOF'
+
+[target.'cfg(target_arch = "wasm32")'.dependencies.noon]
+path = "../noon"
+EOF
+expect_failure "noon-render-wgpu -> noon through dependency table"
+
+echo "architecture layer dependency ratchet self-test passed"

--- a/web/ci-workflow-topology.test.mjs
+++ b/web/ci-workflow-topology.test.mjs
@@ -12,6 +12,7 @@ const exactFamilies = new Map([
   ["pr-fast.yml", "pr-fast"],
   ["ci.yml", "main"],
   ["architecture-ratchets.yml", "architecture"],
+  ["layer-dependency-ratchet.yml", "architecture"],
   ["compiler-cache-seed.yml", "cache-seed"],
   ["test-coverage.yml", "coverage"],
   ["platform-release.yml", "platform-release"],


### PR DESCRIPTION
## Roadmap ownership

- Owning cases: #960 / A5 validation and #961 / A6.8
- Architecture layer: Cross-layer dependency structure

## What changed

Add a structural CI ratchet that keeps the core engine dependency graph one-way:

```text
noon-core
  <- noon-compile
  <- noon-runtime
  <- noon-render-wgpu
  <- platform/frontends
```

The ratchet rejects upward dependencies that would blur authority boundaries:
- `noon-core` cannot depend on compiler/runtime/renderer/web/public frontend crates;
- `noon-compile` cannot depend on runtime/renderer/web/public frontend crates;
- `noon-runtime` cannot depend on renderer/web/public frontend crates;
- `noon-render-wgpu` cannot depend on web/public frontend crates.

It checks both ordinary TOML dependency keys and target-specific `[...dependencies.<crate>]` tables.

A self-test builds isolated temporary manifests and proves representative forbidden edges fail, including quoted dependency keys and target-specific dependency tables.

The ratchet runs in a dedicated workflow, so this PR has no file overlap with #972's architecture-ratchet workflow/script or #974's `scripts/check.sh` / renderer-host-boundary script.

## Architecture check

- [x] Encodes existing authority direction; introduces no new architecture layer.
- [x] Does not touch Semantic Scene/store implementation.
- [x] Does not constrain valid lower-layer dependencies (runtime -> compile/core and renderer -> runtime/core remain allowed).
- [x] Does not prescribe native-host crate/module placement.
- [x] Does not add serialization, frontend bridges, or alternate authorities.

## Migration seam

None.

## Validation

Current manifests satisfy the intended graph:
- `noon-core` depends only on serde;
- `noon-compile` depends on `noon-core` and geometry;
- `noon-runtime` depends on `noon-core` and `noon-compile`;
- `noon-render-wgpu` consumes core/runtime/rendering helpers but not `noon` or `noon-web`.

The self-test proves failures for:
- core -> runtime;
- compiler -> renderer;
- runtime -> web (quoted key);
- renderer -> public frontend through a target-specific dependency table.

Branch is based on current `master` after #962 and is 0 commits behind.

Refs #953 #960 #961.