### PR TITLE
Ratchet semantic identity authority

### DIFF
--- a/scripts/architecture-ratchet.sh
+++ b/scripts/architecture-ratchet.sh
@@ -79,8 +79,49 @@ make that absence structural. See #960/A5 and #961/A6.8.
 EOF
 fi
 
-if (( migration_found != 0 || module_indirection_found != 0 )); then
+identity_authority_found=0
+canonical_identity_file='crates/noon-core/src/semantic_store.rs'
+
+semantic_node_defs="$(git grep -nE '^[[:space:]]*(pub([[:space:]]*\([^)]*\))?[[:space:]]+)?struct[[:space:]]+SemanticNodeId([[:space:]{(;]|$)' -- '*.rs' || true)"
+semantic_store_defs="$(git grep -nE '^[[:space:]]*(pub([[:space:]]*\([^)]*\))?[[:space:]]+)?struct[[:space:]]+SemanticStore([[:space:]{(;]|$)' -- '*.rs' || true)"
+semantic_node_impls="$(git grep -nE '^[[:space:]]*impl[[:space:]]+SemanticNodeId([[:space:]{]|$)' -- '*.rs' || true)"
+
+require_canonical_only() {
+  label="$1"
+  matches="$2"
+
+  count=0
+  if [[ -n "$matches" ]]; then
+    count="$(printf '%s\n' "$matches" | wc -l | tr -d '[:space:]')"
+  fi
+
+  if [[ "$count" != "1" ]] || ! printf '%s\n' "$matches" | grep -q "^${canonical_identity_file}:"; then
+    printf 'architecture ratchet: %s must exist exactly once in %s\n' "$label" "$canonical_identity_file" >&2
+    if [[ -n "$matches" ]]; then
+      printf '%s\n' "$matches" >&2
+    else
+      printf '(no matches)\n' >&2
+    fi
+    identity_authority_found=1
+  fi
+}
+
+require_canonical_only 'SemanticNodeId definition' "$semantic_node_defs"
+require_canonical_only 'SemanticStore definition' "$semantic_store_defs"
+require_canonical_only 'SemanticNodeId inherent implementation' "$semantic_node_impls"
+
+if (( identity_authority_found != 0 )); then
+  cat >&2 <<'EOF'
+
+Semantic author identity has one canonical owner. SemanticNodeId and its inherent
+allocator API must stay in crates/noon-core/src/semantic_store.rs, alongside the
+single SemanticStore definition. Add behavior through that authority instead of
+creating a second identity/store definition elsewhere. See #961/A6.3.
+EOF
+fi
+
+if (( migration_found != 0 || module_indirection_found != 0 || identity_authority_found != 0 )); then
   exit 1
 fi
 
-echo "architecture migration-growth and module-growth ratchets passed"
+echo "architecture migration-growth, module-growth, and semantic-identity ratchets passed"

--- a/scripts/architecture-ratchet.test.sh
+++ b/scripts/architecture-ratchet.test.sh
@@ -6,13 +6,29 @@ RATCHET="$ROOT/scripts/architecture-ratchet.sh"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
-mkdir -p "$TMP/scripts" "$TMP/src"
+mkdir -p "$TMP/scripts" "$TMP/src" "$TMP/crates/noon-core/src"
 cp "$RATCHET" "$TMP/scripts/architecture-ratchet.sh"
 
 cd "$TMP"
 git init -q
 git config user.name "Noon Architecture Ratchet Test"
 git config user.email "ratchet-test@example.invalid"
+
+# Model the canonical semantic identity authority established by Phase A1.
+cat > crates/noon-core/src/semantic_store.rs <<'EOF'
+pub struct SemanticNodeId {
+    slot: u32,
+    generation: u32,
+}
+
+impl SemanticNodeId {
+    pub const fn new(slot: u32, generation: u32) -> Self {
+        Self { slot, generation }
+    }
+}
+
+pub struct SemanticStore;
+EOF
 
 # Model the repository during Phase A: old module indirection may still exist,
 # but the ratchet must prevent it from growing while A5 removes the debt.
@@ -23,8 +39,8 @@ include!("existing_impl.rs");
 EOF
 printf 'pub fn existing_hidden() {}\n' > src/existing_hidden.rs
 printf 'pub fn existing_impl() {}\n' > src/existing_impl.rs
-git add scripts/architecture-ratchet.sh src
-git commit -qm "baseline with known A5 debt"
+git add scripts/architecture-ratchet.sh src crates/noon-core/src/semantic_store.rs
+git commit -qm "baseline with semantic authority and known A5 debt"
 BASE="$(git rev-parse HEAD)"
 
 printf 'pub fn visible_module_tree() {}\n' > src/visible.rs
@@ -42,7 +58,7 @@ expect_rejected() {
 
 reset_to_base() {
   git reset -q --hard "$BASE"
-  rm -f src/new_hidden.rs
+  rm -f src/new_hidden.rs src/duplicate_identity.rs
 }
 
 reset_to_base
@@ -77,5 +93,31 @@ EOF
 git add src/new_hidden.rs
 git commit -qm "add include brackets"
 expect_rejected 'include! [...] module indirection growth'
+
+reset_to_base
+cat > src/duplicate_identity.rs <<'EOF'
+pub struct SemanticNodeId(u64);
+EOF
+git add src/duplicate_identity.rs
+git commit -qm "duplicate semantic node identity"
+expect_rejected 'second SemanticNodeId definition'
+
+reset_to_base
+cat > src/duplicate_identity.rs <<'EOF'
+pub struct SemanticStore;
+EOF
+git add src/duplicate_identity.rs
+git commit -qm "duplicate semantic store"
+expect_rejected 'second SemanticStore definition'
+
+reset_to_base
+cat > src/duplicate_identity.rs <<'EOF'
+impl SemanticNodeId {
+    pub fn fabricated() -> Self { unreachable!() }
+}
+EOF
+git add src/duplicate_identity.rs
+git commit -qm "move semantic id allocator api"
+expect_rejected 'SemanticNodeId inherent implementation outside canonical owner'
 
 echo "architecture ratchet self-test passed"


### PR DESCRIPTION
## Roadmap ownership

- Owning case: #961 / A6.3
- Architecture layer: Semantic identity authority

## What changed

Tighten the existing Architecture Ratchets check so the semantic identity/store authority established by #962 cannot split again.

The structural ratchet now requires:
- exactly one `SemanticNodeId` definition;
- exactly one `SemanticStore` definition;
- exactly one inherent `impl SemanticNodeId` block;
- all three must live in `crates/noon-core/src/semantic_store.rs`.

This does not freeze the public API or block normal `SemanticStore` behavior extensions in other modules. It specifically protects the identity allocator/type authority from being redefined or gaining a second inherent allocator API elsewhere.

The existing migration-growth and `#[path]`/`include!` growth ratchets remain unchanged.

## Architecture check

- [x] Encodes A6.3 after A1.1/#962 established the canonical generational semantic store.
- [x] No Semantic Scene/store implementation changes.
- [x] No frontend, renderer, runtime, or platform-host behavior changes.
- [x] No new workflow family; uses the existing Architecture Ratchets workflow.
- [x] Independent of #975's dependency-layer ratchet.

## Validation

The ratchet self-test models the canonical `semantic_store.rs` owner and proves:
- an unrelated clean change passes;
- existing A5 module-indirection debt remains grandfathered but cannot grow;
- a second `SemanticNodeId` definition fails;
- a second `SemanticStore` definition fails;
- an inherent `impl SemanticNodeId` outside the canonical owner fails.

Branch is based on current master after #972 and #974 merged.

Refs #953 #961.