### PR TITLE
Make semantic object state node-owned

### DIFF
--- a/crates/noon-core/src/object_content.rs
+++ b/crates/noon-core/src/object_content.rs
@@ -57,7 +57,7 @@ pub struct SemanticObjectState {
     pub content: SemanticObjectContent,
     pub transform: SemanticTransform2_5D,
     pub style: SemanticStyle,
-    pub presentation: SemanticPresentation,
+    presentation: SemanticPresentation,
 }
 
 impl SemanticObjectState {
@@ -68,6 +68,30 @@ impl SemanticObjectState {
             style: SemanticStyle::default(),
             presentation: SemanticPresentation::default(),
         }
+    }
+
+    pub const fn presentation(&self) -> SemanticPresentation {
+        self.presentation
+    }
+
+    pub const fn z_index(&self) -> i32 {
+        self.presentation.z_index
+    }
+
+    pub fn set_z_index(&mut self, z_index: i32) {
+        self.presentation.z_index = z_index;
+    }
+
+    pub const fn insertion_order(&self) -> u64 {
+        self.presentation.insertion_order
+    }
+
+    /// Assign the stable painter-order tie break at semantic-store insertion.
+    ///
+    /// Frontends may author `z_index`, but insertion order belongs to the scene
+    /// authority so independent wrappers cannot manufacture conflicting order.
+    pub(crate) fn assign_insertion_order(&mut self, insertion_order: u64) {
+        self.presentation.insertion_order = insertion_order;
     }
 }
 
@@ -160,7 +184,7 @@ mod tests {
         state.transform.translation = SemanticVec3::new(0.7, -0.3, 4.5);
         state.transform.scale = SemanticVec3::new(1.25, 0.5, 2.0);
         state.style.object_opacity = 0.4;
-        state.presentation.z_index = 7;
+        state.set_z_index(7);
 
         assert_eq!(
             state.content.geometry(),
@@ -169,7 +193,8 @@ mod tests {
         assert_eq!(state.transform.translation.z, 4.5);
         assert_eq!(state.transform.scale.z, 2.0);
         assert_eq!(state.style.object_opacity, 0.4);
-        assert_eq!(state.presentation.z_index, 7);
+        assert_eq!(state.z_index(), 7);
+        assert_eq!(state.insertion_order(), 0);
     }
 
     #[test]
@@ -215,7 +240,7 @@ mod tests {
         state.transform.translation = SemanticVec3::new(1000.25, -2000.5, 3.0);
         state.style.stroke_width = 12.5;
         state.style.object_opacity = 0.25;
-        state.presentation.z_index = -3;
+        state.set_z_index(-3);
 
         assert_eq!(state.content, before);
         assert_eq!(

--- a/crates/noon-core/src/semantic_store.rs
+++ b/crates/noon-core/src/semantic_store.rs
@@ -2,8 +2,8 @@ use std::collections::{HashMap, HashSet};
 
 use serde::{Deserialize, Serialize};
 
-use crate::{ObjectDefinition, ObjectId, SceneDefinition};
 use crate::SemanticObjectState;
+use crate::{ObjectDefinition, ObjectId, SceneDefinition};
 
 /// Stable semantic identity independent of execution/render dense indices.
 ///
@@ -198,10 +198,6 @@ impl SemanticNode {
 
     pub fn kind(&self) -> &SemanticNodeKind {
         &self.kind
-    }
-
-    pub fn kind_mut(&mut self) -> &mut SemanticNodeKind {
-        &mut self.kind
     }
 
     pub fn object(&self) -> Option<&ObjectDefinition> {

--- a/crates/noon-core/src/semantic_store.rs
+++ b/crates/noon-core/src/semantic_store.rs
@@ -3,6 +3,7 @@ use std::collections::{HashMap, HashSet};
 use serde::{Deserialize, Serialize};
 
 use crate::{ObjectDefinition, ObjectId, SceneDefinition};
+use crate::SemanticObjectState;
 
 /// Stable semantic identity independent of execution/render dense indices.
 ///
@@ -163,8 +164,9 @@ impl OrderedFamilyMembers {
 pub enum SemanticNodeKind {
     /// Compatibility payload while `SceneDefinition` consumers migrate.
     Object(ObjectDefinition),
-    /// Stable frontend object identity whose mutable authoring payload lives in a
-    /// shared frontend handle rather than the legacy SceneDefinition object shape.
+    /// Semantic object identity. Target objects carry `SemanticObjectState`
+    /// directly on the node. State-less instances exist only for the temporary
+    /// frontend identity seam and are owned for migration by #61/#959.
     AuthoringObject,
     /// A semantic family/collection with no implied transform ownership.
     Family,
@@ -174,6 +176,11 @@ pub enum SemanticNodeKind {
 pub struct SemanticNode {
     id: SemanticNodeId,
     kind: SemanticNodeKind,
+    /// Authoritative authored object payload for target semantic objects.
+    ///
+    /// `None` is valid for families, legacy compatibility objects, and the
+    /// temporary state-less frontend identity seam only.
+    object_state: Option<SemanticObjectState>,
     source_identity: Option<SourceIdentity>,
     scene_membership: SemanticSceneMembership,
     /// Families containing this node. Multiple parents are intentional and
@@ -209,6 +216,14 @@ impl SemanticNode {
             SemanticNodeKind::Object(object) => Some(object),
             SemanticNodeKind::AuthoringObject | SemanticNodeKind::Family => None,
         }
+    }
+
+    pub fn semantic_object_state(&self) -> Option<&SemanticObjectState> {
+        self.object_state.as_ref()
+    }
+
+    pub fn semantic_object_state_mut(&mut self) -> Option<&mut SemanticObjectState> {
+        self.object_state.as_mut()
     }
 
     pub fn source_identity(&self) -> Option<&SourceIdentity> {
@@ -276,6 +291,7 @@ pub struct SemanticStore {
     scene_head: Option<SemanticNodeId>,
     scene_tail: Option<SemanticNodeId>,
     scene_nodes: usize,
+    next_insertion_order: u64,
     object_nodes: HashMap<ObjectId, SemanticNodeId>,
     source_nodes: HashMap<SourceIdentity, SemanticNodeId>,
     last_mutation: SemanticMutationStats,
@@ -309,6 +325,25 @@ impl SemanticStore {
         id
     }
 
+    /// Insert a target semantic object whose authored payload is owned directly by
+    /// the authoritative node. Stable painter insertion order is assigned here so
+    /// frontends cannot manufacture conflicting tie-break values.
+    pub fn insert_semantic_object(&mut self, mut state: SemanticObjectState) -> SemanticNodeId {
+        let insertion_order = self.next_insertion_order;
+        self.next_insertion_order = self
+            .next_insertion_order
+            .checked_add(1)
+            .expect("Noon semantic insertion-order space exhausted");
+        state.assign_insertion_order(insertion_order);
+        let id = self.insert_kind(SemanticNodeKind::AuthoringObject);
+        self.node_mut(id)
+            .expect("newly inserted semantic node exists")
+            .object_state = Some(state);
+        id
+    }
+
+    /// Temporary identity-only frontend seam. New target object authoring should
+    /// use `insert_semantic_object`; #61/#959 own migration/removal of this path.
     pub fn insert_authoring_object(&mut self) -> SemanticNodeId {
         self.insert_kind(SemanticNodeKind::AuthoringObject)
     }
@@ -336,6 +371,7 @@ impl SemanticStore {
         self.slots[slot_index as usize].node = Some(SemanticNode {
             id,
             kind,
+            object_state: None,
             source_identity: None,
             scene_membership: SemanticSceneMembership::Detached,
             parents: Vec::new(),

--- a/crates/noon-core/tests/semantic_object_state_store.rs
+++ b/crates/noon-core/tests/semantic_object_state_store.rs
@@ -18,11 +18,7 @@ fn semantic_store_owns_object_state_and_assigns_insertion_order() {
     let second = store.insert_semantic_object(second_state);
 
     let first_state = store.node(first).unwrap().semantic_object_state().unwrap();
-    let second_state = store
-        .node(second)
-        .unwrap()
-        .semantic_object_state()
-        .unwrap();
+    let second_state = store.node(second).unwrap().semantic_object_state().unwrap();
 
     assert_eq!(first_state.z_index(), 7);
     assert_eq!(second_state.z_index(), -3);
@@ -40,9 +36,8 @@ fn semantic_state_survives_detach_readd_and_family_aliasing() {
     );
 
     let mut store = SemanticStore::new();
-    let object = store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Resource(
-        geometry,
-    )));
+    let object =
+        store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Resource(geometry)));
     let first_family = store.insert_family();
     let second_family = store.insert_family();
     store.add_member(first_family, object).unwrap();
@@ -72,12 +67,12 @@ fn semantic_state_mutation_is_local_and_preserves_content_identity() {
     );
 
     let mut store = SemanticStore::new();
-    let object = store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Resource(
-        geometry,
-    )));
-    let unrelated = store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
-        radius: 5.0,
-    }));
+    let object =
+        store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Resource(geometry)));
+    let unrelated =
+        store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+            radius: 5.0,
+        }));
     let unrelated_before = store
         .node(unrelated)
         .unwrap()

--- a/crates/noon-core/tests/semantic_object_state_store.rs
+++ b/crates/noon-core/tests/semantic_object_state_store.rs
@@ -1,0 +1,151 @@
+use noon_core::{
+    GeometryResourceArena, SemanticObjectState, SemanticStore, SemanticVec3, StoredGeometry, Vec2,
+    VectorPath,
+};
+
+#[test]
+fn semantic_store_owns_object_state_and_assigns_insertion_order() {
+    let mut store = SemanticStore::new();
+
+    let mut first_state = SemanticObjectState::new(StoredGeometry::Circle { radius: 1.0 });
+    first_state.set_z_index(7);
+    let first = store.insert_semantic_object(first_state);
+
+    let mut second_state = SemanticObjectState::new(StoredGeometry::Rectangle {
+        size: Vec2::new(2.0, 1.0),
+    });
+    second_state.set_z_index(-3);
+    let second = store.insert_semantic_object(second_state);
+
+    let first_state = store.node(first).unwrap().semantic_object_state().unwrap();
+    let second_state = store
+        .node(second)
+        .unwrap()
+        .semantic_object_state()
+        .unwrap();
+
+    assert_eq!(first_state.z_index(), 7);
+    assert_eq!(second_state.z_index(), -3);
+    assert_eq!(first_state.insertion_order(), 0);
+    assert_eq!(second_state.insertion_order(), 1);
+}
+
+#[test]
+fn semantic_state_survives_detach_readd_and_family_aliasing() {
+    let mut arena = GeometryResourceArena::new();
+    let geometry = arena.insert_path(
+        VectorPath::new()
+            .move_to(Vec2::ZERO)
+            .line_to(Vec2::new(3.0, 4.0)),
+    );
+
+    let mut store = SemanticStore::new();
+    let object = store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Resource(
+        geometry,
+    )));
+    let first_family = store.insert_family();
+    let second_family = store.insert_family();
+    store.add_member(first_family, object).unwrap();
+    store.add_member(second_family, object).unwrap();
+
+    store.attach_to_scene(object).unwrap();
+    store.detach_from_scene(object).unwrap();
+    store.attach_to_scene(object).unwrap();
+
+    let node = store.node(object).unwrap();
+    assert_eq!(node.id(), object);
+    assert_eq!(node.parents(), &[first_family, second_family]);
+    assert_eq!(
+        node.semantic_object_state().unwrap().content.geometry(),
+        Some(StoredGeometry::Resource(geometry))
+    );
+    assert!(arena.get(geometry).is_some());
+}
+
+#[test]
+fn semantic_state_mutation_is_local_and_preserves_content_identity() {
+    let mut arena = GeometryResourceArena::new();
+    let geometry = arena.insert_path(
+        VectorPath::new()
+            .move_to(Vec2::ZERO)
+            .line_to(Vec2::new(1.0, 0.0)),
+    );
+
+    let mut store = SemanticStore::new();
+    let object = store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Resource(
+        geometry,
+    )));
+    let unrelated = store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+        radius: 5.0,
+    }));
+    let unrelated_before = store
+        .node(unrelated)
+        .unwrap()
+        .semantic_object_state()
+        .unwrap()
+        .clone();
+
+    let state = store
+        .node_mut(object)
+        .unwrap()
+        .semantic_object_state_mut()
+        .unwrap();
+    state.transform.translation = SemanticVec3::new(10.25, -2.5, 8.0);
+    state.style.object_opacity = 0.25;
+    state.set_z_index(11);
+
+    let state = store.node(object).unwrap().semantic_object_state().unwrap();
+    assert_eq!(
+        state.content.geometry(),
+        Some(StoredGeometry::Resource(geometry))
+    );
+    assert_eq!(state.transform.translation.z, 8.0);
+    assert_eq!(state.style.object_opacity, 0.25);
+    assert_eq!(state.z_index(), 11);
+    assert_eq!(
+        store
+            .node(unrelated)
+            .unwrap()
+            .semantic_object_state()
+            .unwrap(),
+        &unrelated_before
+    );
+    assert_eq!(arena.len(), 1);
+}
+
+#[test]
+fn deleted_semantic_state_cannot_be_reached_through_stale_generation() {
+    let mut store = SemanticStore::new();
+    let first = store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+        radius: 1.0,
+    }));
+    store.remove_node(first).unwrap();
+
+    let second = store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+        radius: 2.0,
+    }));
+    assert_eq!(first.slot(), second.slot());
+    assert_ne!(first.generation(), second.generation());
+    assert!(store.node(first).is_none());
+    assert_eq!(
+        store
+            .node(second)
+            .unwrap()
+            .semantic_object_state()
+            .unwrap()
+            .content
+            .geometry(),
+        Some(StoredGeometry::Circle { radius: 2.0 })
+    );
+}
+
+#[test]
+fn identity_only_frontend_seam_is_not_target_object_state() {
+    let mut store = SemanticStore::new();
+    let identity_only = store.insert_authoring_object();
+    assert!(store
+        .node(identity_only)
+        .unwrap()
+        .semantic_object_state()
+        .is_none());
+}


### PR DESCRIPTION
## Roadmap ownership

- Phase A1.2b in #957
- Builds on #976 / A1.2a
- Related foundations: #53, #62
- Migration owners: #61 for the identity-only frontend seam; #959/A4 for legacy object/scene payloads
- Architecture layer: authoritative Semantic Scene

## What this implements

Move the target `SemanticObjectState` into the authoritative semantic node rather than leaving mutable object meaning in frontend handles.

- `SemanticNode` now owns an optional `SemanticObjectState` field directly; there is no side map or second object-state allocator;
- `insert_semantic_object(state)` is the target object insertion path and assigns stable monotonic painter insertion order in `SemanticStore`;
- `SemanticObjectState::presentation` is private: frontends may author `z_index`, but only the store can assign `insertion_order`;
- typed node accessors expose the node-owned semantic state;
- the existing payload-less `insert_authoring_object()` remains explicitly a temporary #61/#959 frontend identity seam, not a target object representation;
- legacy `SemanticNodeKind::Object(ObjectDefinition)` remains the existing #959-owned compatibility seam and does not gain peer target authority.

No JSON, transport, execution slot, renderer ID, frontend ID, or new resource identity enters the target object state.

## Independent review

- [x] Target state lives on the semantic node, not in a parallel map/frontend object.
- [x] One existing generational `SemanticNodeId` remains the authored identity.
- [x] Store owns insertion-order tie breaking; frontend-authored `z_index` remains allowed.
- [x] Heavy immutable geometry remains referenced through the existing resource arena handle.
- [x] Detach/re-add and family aliasing do not move/copy object state.
- [x] State mutation is local to the addressed node and leaves unrelated state/content identity untouched.
- [x] State-less authoring objects are explicitly migration-only.
- [x] No serialization or new authority boundary is introduced.

## Tests

New focused integration tests cover:
- store-owned insertion order with frontend-authored z-index;
- state survival across detach/re-add and multi-family aliasing;
- local transform/style mutation preserving immutable content identity and unrelated state;
- stale generation cannot reach deleted semantic state after slot reuse;
- identity-only frontend seam has no target semantic payload.

Required before merge: Architecture Ratchets, rustfmt/clippy, Rust tests, web preflight and normal browser/WASM PR Fast Gate.

Refs #957 #53 #62 #61 #959.