### PR TITLE
Normalize noon-web legacy module ownership

### DIFF
--- a/crates/noon-web/src/lib.rs
+++ b/crates/noon-web/src/lib.rs
@@ -18,7 +18,6 @@ mod family_write_authoring;
 #[cfg(any(target_arch = "wasm32", test))]
 mod gpu_diagnostics;
 mod host_player;
-#[path = "legacy.rs"]
 mod legacy;
 mod lifecycle;
 mod manim_dashed_line_bridge;


### PR DESCRIPTION
## Roadmap ownership

- Owning case: #960 / A5.1
- Ratchet handoff: #961 / A6.8 and merged #972
- Architecture layer: noon-web module ownership

## Result

Closed after CI proved this is **not** a semantics-preserving one-line normalization.

Removing `#[path = "legacy.rs"]` changes Rust child-module resolution for `legacy.rs`. Under ordinary `mod legacy;`, its `clock` child resolves through `crates/noon-web/src/legacy/clock.rs`, whose `PlaybackClock` does not provide the playback-control methods used by current `canonical_retained_engine_player` / `execution_transport` callers (`set_loop_duration`, `pause`, `resume`, `seek`, `is_playing`).

The existing path annotation therefore encodes hidden ownership/layout behavior rather than being a redundant spelling.

A correct A5 cleanup must normalize the whole legacy module island (for example by relocating the module root / reconciling child ownership) and prove the intended clock implementation remains authoritative. That should be a separate reviewed change, not an API patch added just to make this PR compile.

## Validation finding

Architecture/dependency guardrails passed, while Rust unit/lint and WASM build gates failed consistently on the changed module resolution. No code from this PR should merge.

Refs #953 #960 #961.