### PR TITLE
Normalize renderer GPU submodule ownership

### DIFF
--- a/crates/noon-render-wgpu/src/gpu.rs
+++ b/crates/noon-render-wgpu/src/gpu.rs
@@ -13,14 +13,11 @@ mod retained_text {
 }
 pub use retained_text::*;
 
-#[path = "gpu/retained_family_reveal.rs"]
 mod retained_family_reveal;
 pub use retained_family_reveal::*;
 
-#[path = "gpu/retained_family_draw_border_then_fill.rs"]
 mod retained_family_draw_border_then_fill;
 pub use retained_family_draw_border_then_fill::*;
 
-#[path = "gpu/retained_family_reveal_scene.rs"]
 mod retained_family_reveal_scene;
 pub use retained_family_reveal_scene::*;


### PR DESCRIPTION
## Roadmap ownership

- Owning case: #960 / A5.1
- Ratchet handoff: #961 / A6.8 and merged #972
- Architecture layer: renderer module ownership

## What changed

Remove three redundant `#[path = "gpu/..."]` annotations from `crates/noon-render-wgpu/src/gpu.rs`.

These child modules already live under Rust's normal nested-module directory for `gpu.rs`:

- `gpu/retained_family_reveal.rs`
- `gpu/retained_family_draw_border_then_fill.rs`
- `gpu/retained_family_reveal_scene.rs`

So ordinary `mod ...;` declarations resolve to the same files without hidden path indirection.

## Scope

This deliberately does **not** touch the remaining `include!` ownership debt in `gpu.rs`; that normalization may require a larger namespace/import cleanup and should be reviewed independently.

## Architecture check

- [x] Deletes three existing A5 hidden-module annotations.
- [x] Preserves the same Rust module names and source files.
- [x] No runtime/rendering behavior change intended.
- [x] No semantic/runtime/platform-host ownership changes.
- [x] Independent of the noon-web cleanup in #980.

## Validation

Diff is three deletions. Normal Rust/PR gates verify module resolution, compilation, and linting; Architecture Ratchets ensure no new module indirection is introduced.

Refs #953 #960 #961.