### PR TITLE
Remove retained SceneDefinition lowering detour

### DIFF
--- a/crates/noon-web/src/retained_scene_spec_runtime.rs
+++ b/crates/noon-web/src/retained_scene_spec_runtime.rs
@@ -1,8 +1,6 @@
 use noon::{MathTypst, RetainedScene, Text as NativeText, Typst};
 use noon_compile::RetainedCompiledScene;
-use noon_core::{
-    Color, ObjectDefinition, ObjectId, SceneDefinition, Style, TrackDefinition, Transform2D,
-};
+use noon_core::{Color, ObjectId, Style, TrackDefinition, Transform2D};
 use noon_ir::{ObjectSpec, ObjectSpecContent, SceneSpec, TextSpec, TextSpecKind, TextSpecOptions};
 
 use crate::retained_authoring_scene::MixedRetainedAuthoringError;
@@ -31,27 +29,11 @@ impl CanonicalRetainedAuthoringScene {
             ..
         } = spec;
 
-        // `RetainedScene` already owns the correct resource-backed text insertion
-        // APIs. Seed it with only the geometry subset, preserving relative geometry
-        // order, then insert text at its structural global painter slots.
-        let geometry_objects = objects
-            .iter()
-            .filter_map(|object| {
-                let ObjectSpecContent::Geometry(geometry) = &object.content else {
-                    return None;
-                };
-                Some(ObjectDefinition {
-                    id: object.id,
-                    geometry: geometry.clone(),
-                    transform: object.transform,
-                    style: object.style,
-                })
-            })
-            .collect::<Vec<_>>();
-        let geometry_scene = SceneDefinition::from_parts(geometry_objects, Vec::new())
-            .map_err(|error| invalid_scene_spec(error.to_string()))?;
-        let mut scene = RetainedScene::from_legacy(&geometry_scene)?;
-
+        // Keep the migration lowering typed and in-process after `SceneSpec` has
+        // already been consumed. Geometry and text enter the retained migration
+        // container in their single structural painter order; do not reconstruct a
+        // legacy `SceneDefinition` or `ObjectDefinition` on this production path.
+        let mut scene = RetainedScene::new();
         for (order, object) in objects.into_iter().enumerate() {
             let ObjectSpec {
                 id,
@@ -59,8 +41,15 @@ impl CanonicalRetainedAuthoringScene {
                 transform,
                 style,
             } = object;
-            if let ObjectSpecContent::Text(text) = content {
-                insert_text_object(&mut scene, order, id, text, transform, style)?;
+            match content {
+                ObjectSpecContent::Geometry(geometry) => {
+                    scene
+                        .insert_migration_geometry_at(order, id, geometry, transform, style)
+                        .map_err(|error| invalid_scene_spec(error.to_string()))?;
+                }
+                ObjectSpecContent::Text(text) => {
+                    insert_text_object(&mut scene, order, id, text, transform, style)?;
+                }
             }
         }
 
@@ -225,8 +214,8 @@ fn invalid_scene_spec(error: impl std::fmt::Display) -> MixedRetainedAuthoringEr
 #[cfg(test)]
 mod tests {
     use noon_core::{
-        Color, GeometryRef, ObjectContentRef, Property, RateFunction, TrackTiming, TrackValues,
-        Transform2D, Vec2,
+        Color, GeometryRef, ObjectContentRef, Property, RateFunction, SceneDefinition, TrackTiming,
+        TrackValues, Transform2D, Vec2,
     };
 
     use super::*;
@@ -312,6 +301,19 @@ mod tests {
             canonical.scene().objects()[1].content,
             ObjectContentRef::Text(_)
         ));
+    }
+
+    #[test]
+    fn canonical_lowering_rejects_non_finite_geometry_without_legacy_scene() {
+        let object = ObjectId::new(7);
+        let mut geometry = ObjectSpec::geometry(object, GeometryRef::circle(1.0));
+        geometry.transform.rotation = f32::NAN;
+        let spec = SceneSpec::new(vec![geometry], Vec::new()).unwrap();
+
+        let error = CanonicalRetainedAuthoringScene::from_scene_spec(spec).unwrap_err();
+        let message = error.to_string();
+        assert!(message.contains("non-finite transform state"));
+        assert!(message.contains("7"));
     }
 
     #[test]

--- a/crates/noon/src/text_authoring.rs
+++ b/crates/noon/src/text_authoring.rs
@@ -9,9 +9,10 @@ use std::sync::Arc;
 
 use noon_compile::{RetainedCompileError, RetainedCompiledScene};
 use noon_core::{
-    Color, FontResourceArena, FontResourceError, GeometryResource, GeometryResourceArena, ObjectId,
-    RetainedObjectDefinition, SceneDefinition, Style, TextResource, TextResourceArena,
-    TextResourceValidationError, TextSourceKind, TrackDefinition, Transform2D, Vec2, WHITE,
+    validate_object_definition, Color, FontResourceArena, FontResourceError, GeometryResource,
+    GeometryResourceArena, ObjectDefinition, ObjectId, RetainedObjectDefinition, SceneDefinition,
+    Style, TextResource, TextResourceArena, TextResourceValidationError, TextSourceKind,
+    TrackDefinition, Transform2D, Vec2, WHITE,
 };
 use noon_text_native::{
     NativeFontFace, NativeTextCompiler, NativeTextError, NativeTextOptions,
@@ -392,6 +393,7 @@ pub enum TextAuthoringError {
     DuplicateObject(ObjectId),
     InvalidPainterOrder { order: usize, object_count: usize },
     ObjectIdSpaceExhausted,
+    InvalidGeometryObject(noon_core::PatchError),
     NativeText(NativeTextError),
     Typst(TypstBackendError),
     Font(FontResourceError),
@@ -429,6 +431,7 @@ impl std::fmt::Display for TextAuthoringError {
             Self::ObjectIdSpaceExhausted => {
                 formatter.write_str("retained object ID space is exhausted")
             }
+            Self::InvalidGeometryObject(error) => error.fmt(formatter),
             Self::NativeText(error) => error.fmt(formatter),
             Self::Typst(error) => error.fmt(formatter),
             Self::Font(error) => error.fmt(formatter),
@@ -510,6 +513,44 @@ impl RetainedScene {
             fonts: FontResourceArena::default(),
             next_object_id,
         })
+    }
+
+    /// Migration-only A4 bridge for inserting geometry without reconstructing a
+    /// legacy `SceneDefinition`. #959 owns deletion of this API together with the
+    /// retained migration object model once semantic lowering replaces this path.
+    #[doc(hidden)]
+    pub fn insert_migration_geometry_at(
+        &mut self,
+        order: usize,
+        id: ObjectId,
+        geometry: noon_core::GeometryRef,
+        transform: Transform2D,
+        style: Style,
+    ) -> Result<RetainedMobject, TextAuthoringError> {
+        if order > self.objects.len() {
+            return Err(TextAuthoringError::InvalidPainterOrder {
+                order,
+                object_count: self.objects.len(),
+            });
+        }
+        if self.objects.iter().any(|object| object.id == id) {
+            return Err(TextAuthoringError::DuplicateObject(id));
+        }
+        let next_object_id = self.next_object_id_after(id)?;
+        let candidate = ObjectDefinition {
+            id,
+            geometry: geometry.clone(),
+            transform,
+            style,
+        };
+        validate_object_definition(&candidate).map_err(TextAuthoringError::InvalidGeometryObject)?;
+
+        let mut object = RetainedObjectDefinition::geometry(id, geometry);
+        object.transform = transform;
+        object.style = style;
+        self.objects.insert(order, object);
+        self.next_object_id = next_object_id;
+        Ok(RetainedMobject { id })
     }
 
     pub fn add_text(&mut self, object: Text) -> Result<RetainedMobject, TextAuthoringError> {


### PR DESCRIPTION
## Roadmap ownership

- Owning issue/case: #959 / incremental A4.2
- Architecture layer: migration deletion / retained web lowering

## What changed

Delete one production legacy-scene hop identified by the A4.1 inventory:

```text
SceneSpec
  -> geometry ObjectDefinition list
  -> SceneDefinition::from_parts
  -> RetainedScene::from_legacy
```

The retained web lowerer now consumes the already-normalized `SceneSpec` object stream once and inserts geometry/text directly into the retained migration container in structural painter order.

To preserve the validation that `SceneDefinition::from_parts` previously supplied, `RetainedScene` gets one explicitly migration-only, doc-hidden geometry insertion entry point. It validates geometry/transform/style through the existing core object validator before committing any retained state. #959 owns deletion of this bridge together with the retained migration object model.

## Why this is an A4 deletion

- removes `SceneDefinition` and `ObjectDefinition` from the production `retained_scene_spec_runtime` lowering path;
- removes the production `RetainedScene::from_legacy` call from that path;
- does not introduce serialization or another scene authority;
- does not claim the retained migration container is the target Semantic Scene/lowering API;
- leaves unrelated legacy/test-oracle callers intact until their own per-seam migration handoff is complete.

## Correctness

The old `SceneDefinition::from_parts` detour also rejected malformed geometry state. The new migration geometry insertion preserves that behavior using `validate_object_definition` before mutation, including non-finite geometry/transform/style rejection, duplicate retained identity checks, painter-order checks, and object-ID overflow handling.

A new regression test constructs a `SceneSpec` with a non-finite geometry transform and verifies canonical retained lowering still rejects it even though no legacy `SceneDefinition` is materialized.

Existing canonical-vs-split equivalence coverage continues to protect mixed geometry/text painter order, text resources, tracks, camera identity, and compiled output.

## Architecture check

- [x] Read `AGENTS.md`, `docs/architecture.md`, #959 and the Phase A parallel work overlay.
- [x] Removes a migration authority hop rather than adapting around it.
- [x] No new semantic ID space, scene model, runtime, renderer authority, or transport format.
- [x] New helper is explicitly doc-hidden, migration-only, and has #959 as deletion owner.
- [x] Does not touch worker/cross-context transport; genuine transport remains independently owned.
- [x] Does not overlap the active A6 dependency-ratchet work.

## Validation

- Diff inspected against current `master`; branch is 0 commits behind at PR creation.
- Added focused malformed-geometry regression coverage in `noon-web`.
- GitHub CI is the executable validation for this connector-authored change; no local checkout/test run is claimed here.

## Cleanup / next handoff

This is intentionally one seam, not a wholesale resurrection of the historical retained-lowering branch. The next A4 deletion can remove another production `from_legacy`/scene-document consumer only after its corresponding caller has migrated, or tighten the structural ratchet after this seam is gone.

Refs #953 #959 #977.