### PR TITLE
Add shared semantic object lifecycle operations

### DIFF
--- a/crates/noon-core/src/reactive.rs
+++ b/crates/noon-core/src/reactive.rs
@@ -28,6 +28,9 @@ pub use lifecycle::*;
 mod semantic_store;
 pub use semantic_store::*;
 
+mod semantic_scene_operations;
+pub use semantic_scene_operations::*;
+
 #[path = "semantic_family.rs"]
 mod semantic_family;
 

--- a/crates/noon-core/src/reactive/semantic_scene_operations.rs
+++ b/crates/noon-core/src/reactive/semantic_scene_operations.rs
@@ -97,9 +97,7 @@ impl SemanticStore {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        SemanticMutationStats, SemanticNodeResidency, SourceIdentity, StoredGeometry,
-    };
+    use crate::{SemanticMutationStats, SemanticNodeResidency, SourceIdentity, StoredGeometry};
 
     fn state(radius: f32) -> SemanticObjectState {
         SemanticObjectState::new(StoredGeometry::Circle { radius })
@@ -203,7 +201,10 @@ mod tests {
         assert_eq!(copied_state.transform, source_state.transform);
         assert_eq!(copied_state.style, source_state.style);
         assert_eq!(copied_state.z_index(), source_state.z_index());
-        assert_ne!(copied_state.insertion_order(), source_state.insertion_order());
+        assert_ne!(
+            copied_state.insertion_order(),
+            source_state.insertion_order()
+        );
         assert_eq!(
             store.node(copy).unwrap().residency(),
             SemanticNodeResidency::Detached

--- a/crates/noon-core/src/reactive/semantic_scene_operations.rs
+++ b/crates/noon-core/src/reactive/semantic_scene_operations.rs
@@ -1,6 +1,4 @@
-use super::{
-    SemanticNodeId, SemanticNodeResidency, SemanticObjectState, SemanticStore, SemanticStoreError,
-};
+use super::{SemanticNodeId, SemanticObjectState, SemanticStore, SemanticStoreError};
 
 /// Failure from a shared Semantic Scene object operation.
 ///
@@ -99,7 +97,9 @@ impl SemanticStore {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{SemanticMutationStats, SourceIdentity, StoredGeometry};
+    use crate::{
+        SemanticMutationStats, SemanticNodeResidency, SourceIdentity, StoredGeometry,
+    };
 
     fn state(radius: f32) -> SemanticObjectState {
         SemanticObjectState::new(StoredGeometry::Circle { radius })
@@ -188,8 +188,9 @@ mod tests {
         let source = store.insert_semantic_object(authored);
         let family = store.insert_family();
         store.add_member(family, source).unwrap();
+        let source_identity = SourceIdentity::ExplicitKey("hero".into());
         store
-            .set_source_identity(source, Some(SourceIdentity::ExplicitKey("hero".into())))
+            .set_source_identity(source, Some(source_identity.clone()))
             .unwrap();
         store.attach_semantic_object(source).unwrap();
 
@@ -217,7 +218,7 @@ mod tests {
         assert_eq!(store.node(source).unwrap().parents(), &[family]);
         assert_eq!(
             store.node(source).unwrap().source_identity(),
-            Some(&SourceIdentity::ExplicitKey("hero".into()))
+            Some(&source_identity)
         );
     }
 }

--- a/crates/noon-core/src/reactive/semantic_scene_operations.rs
+++ b/crates/noon-core/src/reactive/semantic_scene_operations.rs
@@ -1,0 +1,223 @@
+use super::{
+    SemanticNodeId, SemanticNodeResidency, SemanticObjectState, SemanticStore, SemanticStoreError,
+};
+
+/// Failure from a shared Semantic Scene object operation.
+///
+/// These operations accept only target semantic objects: legacy compatibility
+/// objects, families, and the temporary state-less frontend identity seam are not
+/// valid substitutes for a node-owned [`SemanticObjectState`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SemanticSceneOperationError {
+    UnknownNode(SemanticNodeId),
+    NotSemanticObject(SemanticNodeId),
+    Store(SemanticStoreError),
+}
+
+impl std::fmt::Display for SemanticSceneOperationError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnknownNode(id) => write!(
+                formatter,
+                "unknown semantic node {}:{}",
+                id.slot(),
+                id.generation()
+            ),
+            Self::NotSemanticObject(id) => write!(
+                formatter,
+                "semantic node {}:{} does not own target semantic object state",
+                id.slot(),
+                id.generation()
+            ),
+            Self::Store(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl std::error::Error for SemanticSceneOperationError {}
+
+impl From<SemanticStoreError> for SemanticSceneOperationError {
+    fn from(value: SemanticStoreError) -> Self {
+        match value {
+            SemanticStoreError::UnknownNode(id) => Self::UnknownNode(id),
+            other => Self::Store(other),
+        }
+    }
+}
+
+impl SemanticStore {
+    /// Return the node-owned authored state after validating target-object identity.
+    pub fn semantic_object_state_checked(
+        &self,
+        id: SemanticNodeId,
+    ) -> Result<&SemanticObjectState, SemanticSceneOperationError> {
+        let node = self
+            .node(id)
+            .ok_or(SemanticSceneOperationError::UnknownNode(id))?;
+        node.semantic_object_state()
+            .ok_or(SemanticSceneOperationError::NotSemanticObject(id))
+    }
+
+    /// Add a target semantic object to authored top-level scene membership.
+    ///
+    /// This delegates ordering and locality to the authoritative store primitive:
+    /// first attach appends to authored root order and a repeated attach is a no-op.
+    pub fn attach_semantic_object(
+        &mut self,
+        id: SemanticNodeId,
+    ) -> Result<bool, SemanticSceneOperationError> {
+        self.semantic_object_state_checked(id)?;
+        self.attach_to_scene(id).map_err(Into::into)
+    }
+
+    /// Remove a target semantic object from top-level scene membership without
+    /// deleting it. Semantic identity, state, source identity, and family links
+    /// remain valid; a repeated detach is a no-op.
+    pub fn detach_semantic_object(
+        &mut self,
+        id: SemanticNodeId,
+    ) -> Result<bool, SemanticSceneOperationError> {
+        self.semantic_object_state_checked(id)?;
+        self.detach_from_scene(id).map_err(Into::into)
+    }
+
+    /// Copy one target semantic object into a fresh detached semantic node.
+    ///
+    /// Authored content/transform/style/z-index are copied. Scene membership,
+    /// source identity, and family relationships are intentionally not copied.
+    /// The store assigns both a fresh generational NodeId and a fresh stable
+    /// painter insertion-order tie break.
+    pub fn copy_semantic_object(
+        &mut self,
+        id: SemanticNodeId,
+    ) -> Result<SemanticNodeId, SemanticSceneOperationError> {
+        let state = self.semantic_object_state_checked(id)?.clone();
+        Ok(self.insert_semantic_object(state))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{SemanticMutationStats, SourceIdentity, StoredGeometry};
+
+    fn state(radius: f32) -> SemanticObjectState {
+        SemanticObjectState::new(StoredGeometry::Circle { radius })
+    }
+
+    #[test]
+    fn semantic_object_lifecycle_delegates_to_authoritative_membership() {
+        let mut store = SemanticStore::new();
+        let object = store.insert_semantic_object(state(1.0));
+
+        assert_eq!(
+            store.node(object).unwrap().residency(),
+            SemanticNodeResidency::Detached
+        );
+        assert!(store.attach_semantic_object(object).unwrap());
+        assert_eq!(store.last_mutation_stats().slots_written, 1);
+        assert_eq!(store.scene_roots().collect::<Vec<_>>(), vec![object]);
+
+        assert!(!store.attach_semantic_object(object).unwrap());
+        assert_eq!(
+            store.last_mutation_stats(),
+            SemanticMutationStats::default()
+        );
+
+        assert!(store.detach_semantic_object(object).unwrap());
+        assert_eq!(store.last_mutation_stats().slots_written, 1);
+        assert_eq!(
+            store.node(object).unwrap().residency(),
+            SemanticNodeResidency::Detached
+        );
+        assert!(store.scene_roots().next().is_none());
+
+        assert!(!store.detach_semantic_object(object).unwrap());
+        assert_eq!(
+            store.last_mutation_stats(),
+            SemanticMutationStats::default()
+        );
+        assert!(store.semantic_object_state_checked(object).is_ok());
+    }
+
+    #[test]
+    fn lifecycle_rejects_nodes_without_target_semantic_state() {
+        let mut store = SemanticStore::new();
+        let identity_only = store.insert_authoring_object();
+        let family = store.insert_family();
+
+        for id in [identity_only, family] {
+            assert_eq!(
+                store.attach_semantic_object(id),
+                Err(SemanticSceneOperationError::NotSemanticObject(id))
+            );
+            assert_eq!(
+                store.detach_semantic_object(id),
+                Err(SemanticSceneOperationError::NotSemanticObject(id))
+            );
+        }
+        assert_eq!(store.scene_root_count(), 0);
+    }
+
+    #[test]
+    fn stale_generation_fails_shared_object_operations() {
+        let mut store = SemanticStore::new();
+        let stale = store.insert_semantic_object(state(1.0));
+        store.remove_node(stale).unwrap();
+        let replacement = store.insert_semantic_object(state(2.0));
+
+        assert_eq!(stale.slot(), replacement.slot());
+        assert_ne!(stale.generation(), replacement.generation());
+        assert_eq!(
+            store.attach_semantic_object(stale),
+            Err(SemanticSceneOperationError::UnknownNode(stale))
+        );
+        assert_eq!(
+            store.copy_semantic_object(stale),
+            Err(SemanticSceneOperationError::UnknownNode(stale))
+        );
+    }
+
+    #[test]
+    fn copy_gets_fresh_identity_and_order_without_copying_relationships() {
+        let mut store = SemanticStore::new();
+        let mut authored = state(2.0);
+        authored.transform.translation.x = 4.5;
+        authored.style.object_opacity = 0.4;
+        authored.set_z_index(7);
+        let source = store.insert_semantic_object(authored);
+        let family = store.insert_family();
+        store.add_member(family, source).unwrap();
+        store
+            .set_source_identity(source, Some(SourceIdentity::ExplicitKey("hero".into())))
+            .unwrap();
+        store.attach_semantic_object(source).unwrap();
+
+        let source_state = store.semantic_object_state_checked(source).unwrap().clone();
+        let copy = store.copy_semantic_object(source).unwrap();
+        let copied_state = store.semantic_object_state_checked(copy).unwrap();
+
+        assert_ne!(copy, source);
+        assert_eq!(copied_state.content, source_state.content);
+        assert_eq!(copied_state.transform, source_state.transform);
+        assert_eq!(copied_state.style, source_state.style);
+        assert_eq!(copied_state.z_index(), source_state.z_index());
+        assert_ne!(copied_state.insertion_order(), source_state.insertion_order());
+        assert_eq!(
+            store.node(copy).unwrap().residency(),
+            SemanticNodeResidency::Detached
+        );
+        assert!(store.node(copy).unwrap().parents().is_empty());
+        assert!(store.node(copy).unwrap().source_identity().is_none());
+
+        assert_eq!(
+            store.node(source).unwrap().residency(),
+            SemanticNodeResidency::SceneOwned
+        );
+        assert_eq!(store.node(source).unwrap().parents(), &[family]);
+        assert_eq!(
+            store.node(source).unwrap().source_identity(),
+            Some(&SourceIdentity::ExplicitKey("hero".into()))
+        );
+    }
+}


### PR DESCRIPTION
## Roadmap ownership

- Owning case: #957 / A1.3
- H1 consumers: #958 / A2 and #61 / A3
- Ratchet handoff: #961
- Architecture layer: authoritative Semantic Scene operations

## What changed

Add the first narrow A1.3 shared operation family for **target semantic objects** whose `SemanticObjectState` is node-owned after #979.

The authoritative `SemanticStore` now exposes:
- `semantic_object_state_checked(NodeId)` — validate that a handle is live and actually owns target semantic object state;
- `attach_semantic_object(NodeId)` — validated top-level scene attach using the existing authoritative root-membership primitive;
- `detach_semantic_object(NodeId)` — validated detach without deleting identity/state/family/source relationships;
- `copy_semantic_object(NodeId)` — clone authored object state into a fresh detached semantic node with a fresh generational identity and store-assigned insertion-order tie break.

Copy intentionally preserves authored content/transform/style/z-index while **not** copying scene membership, source identity, or family relationships.

## Architecture check

- [x] Operates on the one existing `SemanticStore`; no second scene/store/identity allocator.
- [x] Rejects the temporary state-less frontend identity seam and non-object family nodes instead of treating them as target objects.
- [x] Attach/detach delegate to the existing authoritative membership/order representation, preserving locality and idempotency.
- [x] Copy delegates identity/order allocation to `insert_semantic_object`; frontends cannot manufacture semantic IDs or painter insertion order.
- [x] Uses a normal Rust child module under `reactive/`; no new `#[path]` or `include!` ownership debt.
- [x] No JSON/serialization, runtime, renderer, or platform-host boundary introduced.

## Deliberate scope limits

This is not the whole A1.3 surface.

- recursive Manim-visible family add/remove/reparent semantics remain a later shared-operation slice;
- transform/style mutation APIs are not introduced here, avoiding premature overlap with A1.5's atomic mutation vocabulary;
- public Rust/Python handle migration remains owned by #958/#61 and can consume this H1 operation family once merged.

## Tests

Focused tests prove:
- target object attach/detach preserves NodeId and delegates existing mutation-locality/idempotency behavior;
- state-less migration handles and families are rejected without scene mutation;
- stale generations fail at the shared operation boundary;
- copied objects receive fresh NodeId + insertion order while preserving authored state and remaining detached/unparented/source-unbound.

Refs #953 #957 #958 #61 #961.