### PR TITLE
Add target semantic family membership operations

### DIFF
--- a/crates/noon-core/src/reactive/semantic_scene_operations.rs
+++ b/crates/noon-core/src/reactive/semantic_scene_operations.rs
@@ -1,14 +1,19 @@
-use super::{SemanticNodeId, SemanticObjectState, SemanticStore, SemanticStoreError};
+use super::{
+    SemanticNode, SemanticNodeId, SemanticNodeKind, SemanticObjectState, SemanticStore,
+    SemanticStoreError,
+};
 
-/// Failure from a shared Semantic Scene object operation.
+/// Failure from a shared Semantic Scene authoring operation.
 ///
-/// These operations accept only target semantic objects: legacy compatibility
-/// objects, families, and the temporary state-less frontend identity seam are not
-/// valid substitutes for a node-owned [`SemanticObjectState`].
+/// Target operations deliberately reject migration-only legacy objects and the
+/// temporary state-less frontend identity seam instead of allowing them to become
+/// peer semantic authorities.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SemanticSceneOperationError {
     UnknownNode(SemanticNodeId),
     NotSemanticObject(SemanticNodeId),
+    NotSemanticFamily(SemanticNodeId),
+    NotSemanticAuthoringNode(SemanticNodeId),
     Store(SemanticStoreError),
 }
 
@@ -24,6 +29,18 @@ impl std::fmt::Display for SemanticSceneOperationError {
             Self::NotSemanticObject(id) => write!(
                 formatter,
                 "semantic node {}:{} does not own target semantic object state",
+                id.slot(),
+                id.generation()
+            ),
+            Self::NotSemanticFamily(id) => write!(
+                formatter,
+                "semantic node {}:{} is not a target semantic family",
+                id.slot(),
+                id.generation()
+            ),
+            Self::NotSemanticAuthoringNode(id) => write!(
+                formatter,
+                "semantic node {}:{} is not a target semantic object or family",
                 id.slot(),
                 id.generation()
             ),
@@ -54,6 +71,37 @@ impl SemanticStore {
             .ok_or(SemanticSceneOperationError::UnknownNode(id))?;
         node.semantic_object_state()
             .ok_or(SemanticSceneOperationError::NotSemanticObject(id))
+    }
+
+    fn semantic_family_checked(
+        &self,
+        id: SemanticNodeId,
+    ) -> Result<&SemanticNode, SemanticSceneOperationError> {
+        let node = self
+            .node(id)
+            .ok_or(SemanticSceneOperationError::UnknownNode(id))?;
+        if !matches!(node.kind(), SemanticNodeKind::Family) {
+            return Err(SemanticSceneOperationError::NotSemanticFamily(id));
+        }
+        Ok(node)
+    }
+
+    fn semantic_authoring_node_checked(
+        &self,
+        id: SemanticNodeId,
+    ) -> Result<&SemanticNode, SemanticSceneOperationError> {
+        let node = self
+            .node(id)
+            .ok_or(SemanticSceneOperationError::UnknownNode(id))?;
+        let is_target = match node.kind() {
+            SemanticNodeKind::Family => true,
+            SemanticNodeKind::AuthoringObject => node.semantic_object_state().is_some(),
+            SemanticNodeKind::Object(_) => false,
+        };
+        if !is_target {
+            return Err(SemanticSceneOperationError::NotSemanticAuthoringNode(id));
+        }
+        Ok(node)
     }
 
     /// Add a target semantic object to authored top-level scene membership.
@@ -92,12 +140,55 @@ impl SemanticStore {
         let state = self.semantic_object_state_checked(id)?.clone();
         Ok(self.insert_semantic_object(state))
     }
+
+    /// Snapshot one target semantic family's direct members in authoritative order.
+    ///
+    /// This is a query allocation only; the mutable source of truth remains the
+    /// store's ordered family links.
+    pub fn semantic_family_members_checked(
+        &self,
+        family: SemanticNodeId,
+    ) -> Result<Vec<SemanticNodeId>, SemanticSceneOperationError> {
+        Ok(self.semantic_family_checked(family)?.members())
+    }
+
+    /// Append one target semantic object or family to a target family.
+    ///
+    /// Multi-parent aliasing remains valid. Duplicate membership is idempotent,
+    /// and cycle detection/order/locality are delegated to the authoritative store
+    /// primitive rather than repeated in a frontend facade.
+    pub fn add_semantic_family_member(
+        &mut self,
+        family: SemanticNodeId,
+        member: SemanticNodeId,
+    ) -> Result<(), SemanticSceneOperationError> {
+        self.semantic_family_checked(family)?;
+        self.semantic_authoring_node_checked(member)?;
+        self.add_member(family, member).map_err(Into::into)
+    }
+
+    /// Remove one direct target semantic family edge.
+    ///
+    /// Removing an alias from one family does not affect any other parent, scene
+    /// residency, source identity, or node-owned object state.
+    pub fn remove_semantic_family_member(
+        &mut self,
+        family: SemanticNodeId,
+        member: SemanticNodeId,
+    ) -> Result<bool, SemanticSceneOperationError> {
+        self.semantic_family_checked(family)?;
+        self.semantic_authoring_node_checked(member)?;
+        self.remove_member(family, member).map_err(Into::into)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{SemanticMutationStats, SemanticNodeResidency, SourceIdentity, StoredGeometry};
+    use crate::{
+        GeometryRef, ObjectDefinition, ObjectId, SemanticMutationStats, SemanticNodeResidency,
+        SourceIdentity, StoredGeometry,
+    };
 
     fn state(radius: f32) -> SemanticObjectState {
         SemanticObjectState::new(StoredGeometry::Circle { radius })
@@ -221,5 +312,126 @@ mod tests {
             store.node(source).unwrap().source_identity(),
             Some(&source_identity)
         );
+    }
+
+    #[test]
+    fn shared_family_membership_preserves_order_and_aliases() {
+        let mut store = SemanticStore::new();
+        let first = store.insert_semantic_object(state(1.0));
+        let second = store.insert_semantic_object(state(2.0));
+        let primary = store.insert_family();
+        let alias = store.insert_family();
+
+        store.add_semantic_family_member(primary, first).unwrap();
+        store.add_semantic_family_member(primary, second).unwrap();
+        store.add_semantic_family_member(alias, first).unwrap();
+
+        assert_eq!(
+            store.semantic_family_members_checked(primary).unwrap(),
+            vec![first, second]
+        );
+        assert_eq!(
+            store.semantic_family_members_checked(alias).unwrap(),
+            vec![first]
+        );
+        assert_eq!(store.node(first).unwrap().parents(), &[primary, alias]);
+
+        store.add_semantic_family_member(primary, first).unwrap();
+        assert_eq!(
+            store.last_mutation_stats(),
+            SemanticMutationStats::default()
+        );
+
+        assert!(store
+            .remove_semantic_family_member(primary, first)
+            .unwrap());
+        assert_eq!(
+            store.semantic_family_members_checked(primary).unwrap(),
+            vec![second]
+        );
+        assert_eq!(store.node(first).unwrap().parents(), &[alias]);
+        assert!(!store
+            .remove_semantic_family_member(primary, first)
+            .unwrap());
+        assert_eq!(
+            store.last_mutation_stats(),
+            SemanticMutationStats::default()
+        );
+    }
+
+    #[test]
+    fn shared_family_membership_rejects_migration_only_nodes() {
+        let mut store = SemanticStore::new();
+        let family = store.insert_family();
+        let identity_only = store.insert_authoring_object();
+        let legacy = store.insert_object(ObjectDefinition::new(
+            ObjectId::new(7),
+            GeometryRef::circle(1.0),
+        ));
+
+        for member in [identity_only, legacy] {
+            assert_eq!(
+                store.add_semantic_family_member(family, member),
+                Err(SemanticSceneOperationError::NotSemanticAuthoringNode(
+                    member
+                ))
+            );
+            assert_eq!(
+                store.remove_semantic_family_member(family, member),
+                Err(SemanticSceneOperationError::NotSemanticAuthoringNode(
+                    member
+                ))
+            );
+        }
+        assert!(store
+            .semantic_family_members_checked(family)
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn shared_family_operations_validate_family_identity_and_generation() {
+        let mut store = SemanticStore::new();
+        let object = store.insert_semantic_object(state(1.0));
+        assert_eq!(
+            store.semantic_family_members_checked(object),
+            Err(SemanticSceneOperationError::NotSemanticFamily(object))
+        );
+
+        let stale_family = store.insert_family();
+        store.remove_node(stale_family).unwrap();
+        let replacement = store.insert_family();
+        assert_eq!(stale_family.slot(), replacement.slot());
+        assert_ne!(stale_family.generation(), replacement.generation());
+        assert_eq!(
+            store.add_semantic_family_member(stale_family, object),
+            Err(SemanticSceneOperationError::UnknownNode(stale_family))
+        );
+    }
+
+    #[test]
+    fn shared_family_operations_preserve_cycle_rejection() {
+        let mut store = SemanticStore::new();
+        let outer = store.insert_family();
+        let inner = store.insert_family();
+
+        store.add_semantic_family_member(outer, inner).unwrap();
+        assert_eq!(
+            store.add_semantic_family_member(inner, outer),
+            Err(SemanticSceneOperationError::Store(
+                SemanticStoreError::FamilyCycle {
+                    family: inner,
+                    member: outer,
+                }
+            ))
+        );
+        assert_eq!(
+            store.semantic_family_members_checked(outer).unwrap(),
+            vec![inner]
+        );
+        assert!(store
+            .semantic_family_members_checked(inner)
+            .unwrap()
+            .is_empty());
     }
 }

--- a/crates/noon-core/src/reactive/semantic_scene_operations.rs
+++ b/crates/noon-core/src/reactive/semantic_scene_operations.rs
@@ -342,17 +342,13 @@ mod tests {
             SemanticMutationStats::default()
         );
 
-        assert!(store
-            .remove_semantic_family_member(primary, first)
-            .unwrap());
+        assert!(store.remove_semantic_family_member(primary, first).unwrap());
         assert_eq!(
             store.semantic_family_members_checked(primary).unwrap(),
             vec![second]
         );
         assert_eq!(store.node(first).unwrap().parents(), &[alias]);
-        assert!(!store
-            .remove_semantic_family_member(primary, first)
-            .unwrap());
+        assert!(!store.remove_semantic_family_member(primary, first).unwrap());
         assert_eq!(
             store.last_mutation_stats(),
             SemanticMutationStats::default()

--- a/crates/noon-core/src/reactive/semantic_scene_operations.rs
+++ b/crates/noon-core/src/reactive/semantic_scene_operations.rs
@@ -185,10 +185,7 @@ impl SemanticStore {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        GeometryRef, ObjectDefinition, ObjectId, SemanticMutationStats, SemanticNodeResidency,
-        SourceIdentity, StoredGeometry,
-    };
+    use crate::{SemanticMutationStats, SemanticNodeResidency, SourceIdentity, StoredGeometry};
 
     fn state(radius: f32) -> SemanticObjectState {
         SemanticObjectState::new(StoredGeometry::Circle { radius })
@@ -356,29 +353,23 @@ mod tests {
     }
 
     #[test]
-    fn shared_family_membership_rejects_migration_only_nodes() {
+    fn shared_family_membership_rejects_state_less_authoring_nodes() {
         let mut store = SemanticStore::new();
         let family = store.insert_family();
         let identity_only = store.insert_authoring_object();
-        let legacy = store.insert_object(ObjectDefinition::new(
-            ObjectId::new(7),
-            GeometryRef::circle(1.0),
-        ));
 
-        for member in [identity_only, legacy] {
-            assert_eq!(
-                store.add_semantic_family_member(family, member),
-                Err(SemanticSceneOperationError::NotSemanticAuthoringNode(
-                    member
-                ))
-            );
-            assert_eq!(
-                store.remove_semantic_family_member(family, member),
-                Err(SemanticSceneOperationError::NotSemanticAuthoringNode(
-                    member
-                ))
-            );
-        }
+        assert_eq!(
+            store.add_semantic_family_member(family, identity_only),
+            Err(SemanticSceneOperationError::NotSemanticAuthoringNode(
+                identity_only
+            ))
+        );
+        assert_eq!(
+            store.remove_semantic_family_member(family, identity_only),
+            Err(SemanticSceneOperationError::NotSemanticAuthoringNode(
+                identity_only
+            ))
+        );
         assert!(store
             .semantic_family_members_checked(family)
             .unwrap()


### PR DESCRIPTION
## Roadmap ownership

- Owning case: #957 / A1.3
- Builds on the H1 lifecycle/copy operations merged in #984
- H1 consumers: #958 / A2 and #61 / A3
- Architecture layer: authoritative Semantic Scene operations

## What changed

Extend the shared target-semantic operation contract with direct ordered family membership operations:

- `semantic_family_members_checked(family)` queries direct members in authoritative family order;
- `add_semantic_family_member(family, member)` appends a target semantic object/family through the existing ordered/cycle-safe storage primitive;
- `remove_semantic_family_member(family, member)` removes one direct edge without disturbing other aliases;
- target validation explicitly rejects legacy `SemanticNodeKind::Object(ObjectDefinition)` nodes and the temporary state-less `AuthoringObject` frontend seam;
- family validation distinguishes stale/unknown handles from live non-family nodes.

## Architecture check

- [x] Uses the one existing `SemanticStore` and one `SemanticNodeId` identity space.
- [x] Does not create a second family graph, parent map, ordering container, or frontend membership cache.
- [x] Ordering, duplicate idempotency, multi-parent aliasing, locality, and cycle validation remain owned by existing `add_member` / `remove_member` storage primitives.
- [x] New target APIs reject migration-only nodes instead of blessing them as permanent authoring values.
- [x] No transform/style mutation vocabulary is introduced here; A1.5 can still define the atomic mutation contract without undoing this slice.
- [x] No runtime, renderer, serialization, transport, or platform-host dependency is introduced.

## Deliberate scope limits

This is a direct family-edge H1 slice, not the full Manim-visible recursive `Scene.add/remove/reparent/reorder` contract. Recursive scene restructuring and atomic multi-edge reparenting remain later A1.3/A1.5 work.

## Tests

Focused tests cover:
- deterministic member order and multi-parent alias preservation;
- duplicate add/remove idempotency via existing mutation stats;
- migration-only object/identity rejection;
- stale family generation rejection;
- non-family validation;
- existing family-cycle rejection through the shared operation boundary.

Refs #953 #957 #958 #61 #961.