### PR TITLE
Ratchet normalized noon-runtime module ownership

### DIFF
--- a/scripts/architecture-ratchet.sh
+++ b/scripts/architecture-ratchet.sh
@@ -79,6 +79,28 @@ make that absence structural. See #960/A5 and #961/A6.8.
 EOF
 fi
 
+normalized_runtime_module_indirection_found=0
+normalized_runtime_module_indirections="$(
+  git grep -nE \
+    '^[[:space:]]*#\[[[:space:]]*path[[:space:]]*=|(^|[^[:alnum:]_])include![[:space:]]*(\(|\{|\[)' \
+    -- 'crates/noon-runtime/src' || true
+)"
+
+if [[ -n "$normalized_runtime_module_indirections" ]]; then
+  printf '%s\n' "$normalized_runtime_module_indirections" >&2
+  normalized_runtime_module_indirection_found=1
+fi
+
+if (( normalized_runtime_module_indirection_found != 0 )); then
+  cat >&2 <<'EOF'
+
+noon-runtime module ownership was normalized by #983 and must stay explicit.
+Organizational #[path] / include! indirection is structurally forbidden anywhere
+under crates/noon-runtime/src, including indirection that predates the current
+diff. Use ordinary Rust module layout instead. See #960/A5.2 and #961/A6.8.
+EOF
+fi
+
 identity_authority_found=0
 canonical_identity_file='crates/noon-core/src/semantic_store.rs'
 
@@ -120,8 +142,8 @@ creating a second identity/store definition elsewhere. See #961/A6.3.
 EOF
 fi
 
-if (( migration_found != 0 || module_indirection_found != 0 || identity_authority_found != 0 )); then
+if (( migration_found != 0 || module_indirection_found != 0 || normalized_runtime_module_indirection_found != 0 || identity_authority_found != 0 )); then
   exit 1
 fi
 
-echo "architecture migration-growth, module-growth, and semantic-identity ratchets passed"
+echo "architecture migration-growth, module-growth, normalized-runtime-module, and semantic-identity ratchets passed"

--- a/scripts/architecture-ratchet.test.sh
+++ b/scripts/architecture-ratchet.test.sh
@@ -6,7 +6,7 @@ RATCHET="$ROOT/scripts/architecture-ratchet.sh"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
-mkdir -p "$TMP/scripts" "$TMP/src" "$TMP/crates/noon-core/src"
+mkdir -p "$TMP/scripts" "$TMP/src" "$TMP/crates/noon-core/src" "$TMP/crates/noon-runtime/src"
 cp "$RATCHET" "$TMP/scripts/architecture-ratchet.sh"
 
 cd "$TMP"
@@ -30,8 +30,9 @@ impl SemanticNodeId {
 pub struct SemanticStore;
 EOF
 
-# Model the repository during Phase A: old module indirection may still exist,
-# but the ratchet must prevent it from growing while A5 removes the debt.
+# Model the repository during Phase A: old module indirection may still exist
+# outside ownership islands already normalized by A5. The growth ratchet must
+# prevent that debt from spreading while cleaned islands stay structurally clean.
 cat > src/lib.rs <<'EOF'
 #[path = "existing_hidden.rs"]
 mod existing_hidden;
@@ -39,8 +40,15 @@ include!("existing_impl.rs");
 EOF
 printf 'pub fn existing_hidden() {}\n' > src/existing_hidden.rs
 printf 'pub fn existing_impl() {}\n' > src/existing_impl.rs
-git add scripts/architecture-ratchet.sh src crates/noon-core/src/semantic_store.rs
-git commit -qm "baseline with semantic authority and known A5 debt"
+
+# noon-runtime models a post-A5 normalized island: only ordinary module layout.
+cat > crates/noon-runtime/src/lib.rs <<'EOF'
+mod runtime;
+EOF
+printf 'pub fn runtime() {}\n' > crates/noon-runtime/src/runtime.rs
+
+git add scripts/architecture-ratchet.sh src crates/noon-core/src/semantic_store.rs crates/noon-runtime/src
+git commit -qm "baseline with semantic authority, known A5 debt, and normalized runtime"
 BASE="$(git rev-parse HEAD)"
 
 printf 'pub fn visible_module_tree() {}\n' > src/visible.rs
@@ -58,7 +66,7 @@ expect_rejected() {
 
 reset_to_base() {
   git reset -q --hard "$BASE"
-  rm -f src/new_hidden.rs src/duplicate_identity.rs
+  rm -f src/new_hidden.rs src/duplicate_identity.rs src/runtime_structural_probe.rs
 }
 
 reset_to_base
@@ -119,5 +127,26 @@ EOF
 git add src/duplicate_identity.rs
 git commit -qm "move semantic id allocator api"
 expect_rejected 'SemanticNodeId inherent implementation outside canonical owner'
+
+# Prove noon-runtime is no longer merely growth-ratcheted. Put hidden ownership
+# into the comparison base itself, then make an unrelated later commit. A diff-
+# only growth check cannot see the old line; the full-tree normalized-island gate
+# still must reject the repository state.
+reset_to_base
+cat > crates/noon-runtime/src/lib.rs <<'EOF'
+#[path = "runtime_hidden.rs"]
+mod runtime_hidden;
+EOF
+printf 'pub fn runtime_hidden() {}\n' > crates/noon-runtime/src/runtime_hidden.rs
+git add crates/noon-runtime/src
+git commit -qm "model regressed normalized runtime baseline"
+RUNTIME_REGRESSION_BASE="$(git rev-parse HEAD)"
+printf 'pub fn unrelated_after_runtime_regression() {}\n' > src/runtime_structural_probe.rs
+git add src/runtime_structural_probe.rs
+git commit -qm "unrelated change after runtime regression"
+if bash scripts/architecture-ratchet.sh "$RUNTIME_REGRESSION_BASE" >/dev/null 2>&1; then
+  echo "architecture ratchet test failed: accepted pre-existing noon-runtime module indirection" >&2
+  exit 1
+fi
 
 echo "architecture ratchet self-test passed"


### PR DESCRIPTION
## Roadmap ownership

- Owning issue/case: #961 / incremental A6.8
- Follows #960/A5.2 and merged #983
- Builds on repo-wide growth guard #972
- Architecture layer: structural dependency/module invariant

## What changed

After #983 removed all organizational `#[path]`/`include!` ownership under `crates/noon-runtime/src`, make that cleanup structural.

- keep the existing repo-wide growth guard unchanged;
- add a full-tree zero-occurrence check scoped to `crates/noon-runtime/src`;
- keep other crates' existing A5 debt grandfathered;
- extend the ratchet self-test with a pre-existing-in-base runtime regression case, proving full-tree rather than diff-only protection.

## Why

#960/A5 says once an ownership island is normalized, #961 should tighten absence structurally. Without this, hidden runtime ownership could be present in the comparison base and escape a diff-only growth check.

## Scope

- scripts only;
- no runtime/API/behavior changes;
- no crate moves;
- no Semantic Scene changes;
- no overlap with current semantic lowering/family work.

## Architecture check

- [x] Ratchets a boundary already made real by #983.
- [x] Does not grandfather new runtime debt.
- [x] Does not prematurely require still-unmigrated crates to be clean.
- [x] No bypass or allowlist.
- [x] Self-test proves the structural invariant catches debt that predates the current diff.

## Validation

- Branch is 0 commits behind current `master`.
- Updated head `20f2666beaf170d20a722666c3a97dd1ffce08b1` is green on:
  - Architecture Ratchets, including the new bad-comparison-base structural self-test;
  - Layer Dependency Ratchet;
  - Rust formatting and Clippy/workspace lint;
  - Rust fast unit tests;
  - web static/unit preflight;
  - browser/WASM fast checks, including WASM package build, deterministic playback, Manim-style authoring, and primary WebGPU rendering.
- Changes only `scripts/architecture-ratchet.sh` and `scripts/architecture-ratchet.test.sh`.
- No local checkout/test run is claimed; validation above is GitHub CI on the PR head.

Refs #953 #960 #961 #972 #983.