### PR TITLE
Add family-aware semantic scene restructuring

### DIFF
--- a/crates/noon-core/src/reactive.rs
+++ b/crates/noon-core/src/reactive.rs
@@ -31,6 +31,9 @@ pub use semantic_store::*;
 mod semantic_scene_operations;
 pub use semantic_scene_operations::*;
 
+mod semantic_scene_restructure;
+pub use semantic_scene_restructure::*;
+
 #[path = "semantic_family.rs"]
 mod semantic_family;
 

--- a/crates/noon-core/src/reactive/semantic_scene_restructure.rs
+++ b/crates/noon-core/src/reactive/semantic_scene_restructure.rs
@@ -1,0 +1,219 @@
+use std::collections::HashSet;
+
+use super::{
+    SemanticNode, SemanticNodeId, SemanticNodeKind, SemanticSceneOperationError, SemanticStore,
+};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct SceneRootProjection {
+    root: SemanticNodeId,
+    replacements: Vec<SemanticNodeId>,
+}
+
+impl SemanticStore {
+    /// Add target semantic objects/families with family-aware top-level restructuring.
+    ///
+    /// The whole batch is validated and planned before any scene membership changes.
+    /// Existing family edges are not mutated. Descendants already represented by
+    /// an affected family root are removed from that root projection, surviving
+    /// siblings are promoted in place, and the explicit inputs are then appended
+    /// in caller order.
+    pub fn add_semantic_scene_nodes(
+        &mut self,
+        ids: &[SemanticNodeId],
+    ) -> Result<(), SemanticSceneOperationError> {
+        let explicit = validated_unique_nodes(self, ids)?;
+        if explicit.is_empty() {
+            self.set_last_mutation_writes(0);
+            return Ok(());
+        }
+
+        let remove_set = downward_target_closure(self, &explicit)?;
+        let plans = plan_scene_restructure(self, &remove_set)?;
+
+        let mut writes = 0;
+        for plan in plans {
+            writes += self.replace_scene_root_with_detached(plan.root, &plan.replacements);
+        }
+        for id in explicit {
+            let attached = self.attach_to_scene(id)?;
+            assert!(
+                attached,
+                "family-aware add planning must leave explicit nodes detached"
+            );
+            writes += self.last_mutation_stats().slots_written;
+        }
+        self.set_last_mutation_writes(writes);
+        Ok(())
+    }
+
+    /// Remove target semantic objects/families from the top-level scene projection.
+    ///
+    /// Removing a family removes that whole projected branch. Removing one of its
+    /// descendants dissolves only affected projected family roots and promotes the
+    /// surviving branches at the exact former root position. Family relationships
+    /// themselves remain unchanged.
+    pub fn remove_semantic_scene_nodes(
+        &mut self,
+        ids: &[SemanticNodeId],
+    ) -> Result<(), SemanticSceneOperationError> {
+        let remove_set = validated_unique_nodes(self, ids)?
+            .into_iter()
+            .collect::<HashSet<_>>();
+        if remove_set.is_empty() {
+            self.set_last_mutation_writes(0);
+            return Ok(());
+        }
+
+        let plans = plan_scene_restructure(self, &remove_set)?;
+        let mut writes = 0;
+        for plan in plans {
+            writes += self.replace_scene_root_with_detached(plan.root, &plan.replacements);
+        }
+        self.set_last_mutation_writes(writes);
+        Ok(())
+    }
+}
+
+fn target_node_checked(
+    store: &SemanticStore,
+    id: SemanticNodeId,
+) -> Result<&SemanticNode, SemanticSceneOperationError> {
+    let node = store
+        .node(id)
+        .ok_or(SemanticSceneOperationError::UnknownNode(id))?;
+    let is_target = match node.kind() {
+        SemanticNodeKind::Family => true,
+        SemanticNodeKind::AuthoringObject => node.semantic_object_state().is_some(),
+        SemanticNodeKind::Object(_) => false,
+    };
+    if !is_target {
+        return Err(SemanticSceneOperationError::NotSemanticAuthoringNode(id));
+    }
+    Ok(node)
+}
+
+fn validated_unique_nodes(
+    store: &SemanticStore,
+    ids: &[SemanticNodeId],
+) -> Result<Vec<SemanticNodeId>, SemanticSceneOperationError> {
+    let mut seen = HashSet::with_capacity(ids.len());
+    let mut unique = Vec::with_capacity(ids.len());
+    for id in ids.iter().copied() {
+        target_node_checked(store, id)?;
+        if seen.insert(id) {
+            unique.push(id);
+        }
+    }
+    Ok(unique)
+}
+
+fn downward_target_closure(
+    store: &SemanticStore,
+    roots: &[SemanticNodeId],
+) -> Result<HashSet<SemanticNodeId>, SemanticSceneOperationError> {
+    let mut closure = HashSet::new();
+    let mut stack = roots.to_vec();
+    while let Some(id) = stack.pop() {
+        if !closure.insert(id) {
+            continue;
+        }
+        let node = target_node_checked(store, id)?;
+        if matches!(node.kind(), SemanticNodeKind::Family) {
+            stack.extend(node.members());
+        }
+    }
+    Ok(closure)
+}
+
+fn affected_ancestor_closure(
+    store: &SemanticStore,
+    remove_set: &HashSet<SemanticNodeId>,
+) -> Result<(HashSet<SemanticNodeId>, Vec<SemanticNodeId>), SemanticSceneOperationError> {
+    let mut affected = HashSet::new();
+    let mut roots = Vec::new();
+    let mut stack = remove_set.iter().copied().collect::<Vec<_>>();
+
+    while let Some(id) = stack.pop() {
+        if !affected.insert(id) {
+            continue;
+        }
+        let node = target_node_checked(store, id)?;
+        if node.is_scene_owned() {
+            roots.push(id);
+        }
+        stack.extend(node.parents().iter().copied());
+    }
+
+    roots.sort_unstable();
+    roots.dedup();
+    Ok((affected, roots))
+}
+
+fn plan_scene_restructure(
+    store: &SemanticStore,
+    remove_set: &HashSet<SemanticNodeId>,
+) -> Result<Vec<SceneRootProjection>, SemanticSceneOperationError> {
+    let (affected, affected_roots) = affected_ancestor_closure(store, remove_set)?;
+    let mut promoted = HashSet::new();
+    let mut plans = Vec::with_capacity(affected_roots.len());
+
+    for root in affected_roots {
+        let mut replacements = Vec::new();
+        collect_root_replacements(
+            store,
+            root,
+            root,
+            remove_set,
+            &affected,
+            &mut promoted,
+            &mut replacements,
+        )?;
+        plans.push(SceneRootProjection { root, replacements });
+    }
+    Ok(plans)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn collect_root_replacements(
+    store: &SemanticStore,
+    current: SemanticNodeId,
+    current_root: SemanticNodeId,
+    remove_set: &HashSet<SemanticNodeId>,
+    affected: &HashSet<SemanticNodeId>,
+    promoted: &mut HashSet<SemanticNodeId>,
+    output: &mut Vec<SemanticNodeId>,
+) -> Result<(), SemanticSceneOperationError> {
+    if remove_set.contains(&current) {
+        return Ok(());
+    }
+
+    let node = target_node_checked(store, current)?;
+    if current != current_root && node.is_scene_owned() {
+        return Ok(());
+    }
+
+    if !affected.contains(&current) {
+        if promoted.insert(current) {
+            output.push(current);
+        }
+        return Ok(());
+    }
+
+    if matches!(node.kind(), SemanticNodeKind::Family) {
+        for member in node.members() {
+            collect_root_replacements(
+                store,
+                member,
+                current_root,
+                remove_set,
+                affected,
+                promoted,
+                output,
+            )?;
+        }
+    } else if promoted.insert(current) {
+        output.push(current);
+    }
+    Ok(())
+}

--- a/crates/noon-core/src/semantic_store.rs
+++ b/crates/noon-core/src/semantic_store.rs
@@ -562,6 +562,123 @@ impl SemanticStore {
         Ok(true)
     }
 
+    /// Replace one attached scene root with detached semantic nodes in place.
+    ///
+    /// This is a crate-private storage primitive for shared scene operations. It
+    /// preserves the old root's exact position and writes only that root, the
+    /// replacement nodes, and its immediate outside neighbors. Family links,
+    /// source identity, node identity, and authored object state are unchanged.
+    pub(crate) fn replace_scene_root_with_detached(
+        &mut self,
+        root: SemanticNodeId,
+        replacements: &[SemanticNodeId],
+    ) -> usize {
+        let membership = self
+            .node(root)
+            .expect("scene-root splice requires a live root")
+            .scene_membership;
+        let SemanticSceneMembership::Attached { previous, next } = membership else {
+            panic!("scene-root splice requires an attached root");
+        };
+
+        let mut seen = HashSet::with_capacity(replacements.len());
+        for replacement in replacements.iter().copied() {
+            assert_ne!(replacement, root, "scene-root splice cannot reinsert its root");
+            let node = self
+                .node(replacement)
+                .expect("scene-root splice replacement must be live");
+            assert!(
+                matches!(node.scene_membership, SemanticSceneMembership::Detached),
+                "scene-root splice replacement must be detached"
+            );
+            assert!(
+                seen.insert(replacement),
+                "scene-root splice replacements must be unique"
+            );
+        }
+
+        let first = replacements.first().copied();
+        let last = replacements.last().copied();
+
+        if let Some(previous_id) = previous {
+            let previous_node = self
+                .node_mut(previous_id)
+                .expect("scene previous link must reference a live semantic node");
+            match &mut previous_node.scene_membership {
+                SemanticSceneMembership::Attached {
+                    next: previous_next,
+                    ..
+                } => {
+                    *previous_next = first.or(next);
+                }
+                SemanticSceneMembership::Detached => {
+                    unreachable!("attached root cannot have a detached previous root")
+                }
+            }
+        } else {
+            debug_assert_eq!(self.scene_head, Some(root));
+            self.scene_head = first.or(next);
+        }
+
+        if let Some(next_id) = next {
+            let next_node = self
+                .node_mut(next_id)
+                .expect("scene next link must reference a live semantic node");
+            match &mut next_node.scene_membership {
+                SemanticSceneMembership::Attached {
+                    previous: next_previous,
+                    ..
+                } => {
+                    *next_previous = last.or(previous);
+                }
+                SemanticSceneMembership::Detached => {
+                    unreachable!("attached root cannot have a detached next root")
+                }
+            }
+        } else {
+            debug_assert_eq!(self.scene_tail, Some(root));
+            self.scene_tail = last.or(previous);
+        }
+
+        for (index, replacement) in replacements.iter().copied().enumerate() {
+            let replacement_previous = if index == 0 {
+                previous
+            } else {
+                Some(replacements[index - 1])
+            };
+            let replacement_next = if index + 1 == replacements.len() {
+                next
+            } else {
+                Some(replacements[index + 1])
+            };
+            self.node_mut(replacement)
+                .expect("scene-root splice replacement validated above")
+                .scene_membership = SemanticSceneMembership::Attached {
+                previous: replacement_previous,
+                next: replacement_next,
+            };
+        }
+
+        self.node_mut(root)
+            .expect("scene-root splice root validated above")
+            .scene_membership = SemanticSceneMembership::Detached;
+        self.scene_nodes = self.scene_nodes - 1 + replacements.len();
+        if self.scene_nodes == 0 {
+            debug_assert!(self.scene_head.is_none());
+            debug_assert!(self.scene_tail.is_none());
+        }
+
+        let slots_written = 1
+            + replacements.len()
+            + (previous.is_some() as usize)
+            + (next.is_some() as usize);
+        self.last_mutation = SemanticMutationStats {
+            slots_written,
+            cycle_nodes_visited: 0,
+        };
+        slots_written
+    }
+
     /// Iterate current top-level authored scene roots in deterministic authored order.
     pub fn scene_roots(&self) -> impl Iterator<Item = SemanticNodeId> + '_ {
         std::iter::successors(self.scene_head, move |id| {
@@ -755,6 +872,13 @@ impl SemanticStore {
 
     pub const fn last_mutation_stats(&self) -> SemanticMutationStats {
         self.last_mutation
+    }
+
+    pub(crate) fn set_last_mutation_writes(&mut self, slots_written: usize) {
+        self.last_mutation = SemanticMutationStats {
+            slots_written,
+            cycle_nodes_visited: 0,
+        };
     }
 }
 


### PR DESCRIPTION
Superseded by #990. The shared head branch was concurrently rewritten after review fixes were applied, so #990 carries the isolated reviewed version with compile wiring, focused tests, and the authored-scene-order alias fix.