### PR TITLE
Add reviewed family-aware semantic scene restructuring

### DIFF
--- a/crates/noon-core/src/reactive.rs
+++ b/crates/noon-core/src/reactive.rs
@@ -31,6 +31,8 @@ pub use semantic_store::*;
 mod semantic_scene_operations;
 pub use semantic_scene_operations::*;
 
+mod semantic_scene_restructure;
+
 #[path = "semantic_family.rs"]
 mod semantic_family;
 

--- a/crates/noon-core/src/reactive/semantic_scene_restructure.rs
+++ b/crates/noon-core/src/reactive/semantic_scene_restructure.rs
@@ -360,9 +360,6 @@ mod tests {
 
         store.remove_semantic_scene_nodes(&[removed]).unwrap();
 
-        assert_eq!(
-            store.scene_roots().collect::<Vec<_>>(),
-            vec![shared, tail]
-        );
+        assert_eq!(store.scene_roots().collect::<Vec<_>>(), vec![shared, tail]);
     }
 }

--- a/crates/noon-core/src/reactive/semantic_scene_restructure.rs
+++ b/crates/noon-core/src/reactive/semantic_scene_restructure.rs
@@ -1,0 +1,219 @@
+use std::collections::HashSet;
+
+use super::{
+    SemanticNode, SemanticNodeId, SemanticNodeKind, SemanticSceneOperationError, SemanticStore,
+};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct SceneRootProjection {
+    root: SemanticNodeId,
+    replacements: Vec<SemanticNodeId>,
+}
+
+impl SemanticStore {
+    /// Add target semantic objects/families with family-aware top-level restructuring.
+    ///
+    /// The whole batch is validated and planned before any scene membership changes.
+    /// Existing family edges are not mutated. Descendants already represented by
+    /// an affected family root are removed from that root projection, surviving
+    /// siblings are promoted in place, and the explicit inputs are then appended
+    /// in caller order.
+    pub fn add_semantic_scene_nodes(
+        &mut self,
+        ids: &[SemanticNodeId],
+    ) -> Result<(), SemanticSceneOperationError> {
+        let explicit = validated_unique_nodes(self, ids)?;
+        if explicit.is_empty() {
+            self.set_last_mutation_writes(0);
+            return Ok(());
+        }
+
+        let remove_set = downward_target_closure(self, &explicit)?;
+        let plans = plan_scene_restructure(self, &remove_set)?;
+
+        let mut writes = 0;
+        for plan in plans {
+            writes += self.replace_scene_root_with_detached(plan.root, &plan.replacements);
+        }
+        for id in explicit {
+            let attached = self.attach_to_scene(id)?;
+            assert!(
+                attached,
+                "family-aware add planning must leave explicit nodes detached"
+            );
+            writes += self.last_mutation_stats().slots_written;
+        }
+        self.set_last_mutation_writes(writes);
+        Ok(())
+    }
+
+    /// Remove target semantic objects/families from the top-level scene projection.
+    ///
+    /// Removing a family removes that whole projected branch. Removing one of its
+    /// descendants dissolves only affected projected family roots and promotes the
+    /// surviving branches at the exact former root position. Family relationships
+    /// themselves remain unchanged.
+    pub fn remove_semantic_scene_nodes(
+        &mut self,
+        ids: &[SemanticNodeId],
+    ) -> Result<(), SemanticSceneOperationError> {
+        let remove_set = validated_unique_nodes(self, ids)?
+            .into_iter()
+            .collect::<HashSet<_>>();
+        if remove_set.is_empty() {
+            self.set_last_mutation_writes(0);
+            return Ok(());
+        }
+
+        let plans = plan_scene_restructure(self, &remove_set)?;
+        let mut writes = 0;
+        for plan in plans {
+            writes += self.replace_scene_root_with_detached(plan.root, &plan.replacements);
+        }
+        self.set_last_mutation_writes(writes);
+        Ok(())
+    }
+}
+
+fn target_node_checked(
+    store: &SemanticStore,
+    id: SemanticNodeId,
+) -> Result<&SemanticNode, SemanticSceneOperationError> {
+    let node = store
+        .node(id)
+        .ok_or(SemanticSceneOperationError::UnknownNode(id))?;
+    let is_target = match node.kind() {
+        SemanticNodeKind::Family => true,
+        SemanticNodeKind::AuthoringObject => node.semantic_object_state().is_some(),
+        SemanticNodeKind::Object(_) => false,
+    };
+    if !is_target {
+        return Err(SemanticSceneOperationError::NotSemanticAuthoringNode(id));
+    }
+    Ok(node)
+}
+
+fn validated_unique_nodes(
+    store: &SemanticStore,
+    ids: &[SemanticNodeId],
+) -> Result<Vec<SemanticNodeId>, SemanticSceneOperationError> {
+    let mut seen = HashSet::with_capacity(ids.len());
+    let mut unique = Vec::with_capacity(ids.len());
+    for id in ids.iter().copied() {
+        target_node_checked(store, id)?;
+        if seen.insert(id) {
+            unique.push(id);
+        }
+    }
+    Ok(unique)
+}
+
+fn downward_target_closure(
+    store: &SemanticStore,
+    roots: &[SemanticNodeId],
+) -> Result<HashSet<SemanticNodeId>, SemanticSceneOperationError> {
+    let mut closure = HashSet::new();
+    let mut stack = roots.to_vec();
+    while let Some(id) = stack.pop() {
+        if !closure.insert(id) {
+            continue;
+        }
+        let node = target_node_checked(store, id)?;
+        if matches!(node.kind(), SemanticNodeKind::Family) {
+            stack.extend(node.members());
+        }
+    }
+    Ok(closure)
+}
+
+fn affected_ancestor_closure(
+    store: &SemanticStore,
+    remove_set: &HashSet<SemanticNodeId>,
+) -> Result<(HashSet<SemanticNodeId>, Vec<SemanticNodeId>), SemanticSceneOperationError> {
+    let mut affected = HashSet::new();
+    let mut roots = Vec::new();
+    let mut stack = remove_set.iter().copied().collect::<Vec<_>>();
+
+    while let Some(id) = stack.pop() {
+        if !affected.insert(id) {
+            continue;
+        }
+        let node = target_node_checked(store, id)?;
+        if node.is_scene_owned() {
+            roots.push(id);
+        }
+        stack.extend(node.parents().iter().copied());
+    }
+
+    roots.sort_unstable();
+    roots.dedup();
+    Ok((affected, roots))
+}
+
+fn plan_scene_restructure(
+    store: &SemanticStore,
+    remove_set: &HashSet<SemanticNodeId>,
+) -> Result<Vec<SceneRootProjection>, SemanticSceneOperationError> {
+    let (affected, affected_roots) = affected_ancestor_closure(store, remove_set)?;
+    let mut promoted = HashSet::new();
+    let mut plans = Vec::with_capacity(affected_roots.len());
+
+    for root in affected_roots {
+        let mut replacements = Vec::new();
+        collect_root_replacements(
+            store,
+            root,
+            root,
+            remove_set,
+            &affected,
+            &mut promoted,
+            &mut replacements,
+        )?;
+        plans.push(SceneRootProjection { root, replacements });
+    }
+    Ok(plans)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn collect_root_replacements(
+    store: &SemanticStore,
+    current: SemanticNodeId,
+    current_root: SemanticNodeId,
+    remove_set: &HashSet<SemanticNodeId>,
+    affected: &HashSet<SemanticNodeId>,
+    promoted: &mut HashSet<SemanticNodeId>,
+    output: &mut Vec<SemanticNodeId>,
+) -> Result<(), SemanticSceneOperationError> {
+    if remove_set.contains(&current) {
+        return Ok(());
+    }
+
+    let node = target_node_checked(store, current)?;
+    if current != current_root && node.is_scene_owned() {
+        return Ok(());
+    }
+
+    if !affected.contains(&current) {
+        if promoted.insert(current) {
+            output.push(current);
+        }
+        return Ok(());
+    }
+
+    if matches!(node.kind(), SemanticNodeKind::Family) {
+        for member in node.members() {
+            collect_root_replacements(
+                store,
+                member,
+                current_root,
+                remove_set,
+                affected,
+                promoted,
+                output,
+            )?;
+        }
+    } else if promoted.insert(current) {
+        output.push(current);
+    }
+    Ok(())
+}

--- a/crates/noon-core/src/reactive/semantic_scene_restructure.rs
+++ b/crates/noon-core/src/reactive/semantic_scene_restructure.rs
@@ -131,7 +131,7 @@ fn affected_ancestor_closure(
     remove_set: &HashSet<SemanticNodeId>,
 ) -> Result<(HashSet<SemanticNodeId>, Vec<SemanticNodeId>), SemanticSceneOperationError> {
     let mut affected = HashSet::new();
-    let mut roots = Vec::new();
+    let mut root_set = HashSet::new();
     let mut stack = remove_set.iter().copied().collect::<Vec<_>>();
 
     while let Some(id) = stack.pop() {
@@ -140,13 +140,24 @@ fn affected_ancestor_closure(
         }
         let node = target_node_checked(store, id)?;
         if node.is_scene_owned() {
-            roots.push(id);
+            root_set.insert(id);
         }
         stack.extend(node.parents().iter().copied());
     }
 
-    roots.sort_unstable();
-    roots.dedup();
+    // Cross-root aliases require one deterministic first occurrence. The linked
+    // authored root list is the ordering authority, so NodeId allocation order is
+    // never used as a proxy for current scene order. Most operations affect at most
+    // one root and avoid this scan entirely.
+    let roots = if root_set.len() <= 1 {
+        root_set.iter().copied().collect::<Vec<_>>()
+    } else {
+        store
+            .scene_roots()
+            .filter(|id| root_set.contains(id))
+            .collect::<Vec<_>>()
+    };
+    debug_assert_eq!(roots.len(), root_set.len());
     Ok((affected, roots))
 }
 
@@ -216,4 +227,142 @@ fn collect_root_replacements(
         output.push(current);
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{SemanticNodeResidency, SemanticObjectState, StoredGeometry};
+
+    fn object(store: &mut SemanticStore, radius: f32) -> SemanticNodeId {
+        store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle { radius }))
+    }
+
+    #[test]
+    fn adding_family_collapses_existing_descendant_roots_and_appends_family() {
+        let mut store = SemanticStore::new();
+        let left = object(&mut store, 0.5);
+        let first = object(&mut store, 1.0);
+        let second = object(&mut store, 2.0);
+        let right = object(&mut store, 3.0);
+        let family = store.insert_family();
+        store.add_semantic_family_member(family, first).unwrap();
+        store.add_semantic_family_member(family, second).unwrap();
+
+        store.attach_semantic_object(left).unwrap();
+        store.attach_semantic_object(first).unwrap();
+        store.attach_semantic_object(second).unwrap();
+        store.attach_semantic_object(right).unwrap();
+
+        store.add_semantic_scene_nodes(&[family]).unwrap();
+
+        assert_eq!(
+            store.scene_roots().collect::<Vec<_>>(),
+            vec![left, right, family]
+        );
+        assert_eq!(
+            store.node(first).unwrap().residency(),
+            SemanticNodeResidency::Detached
+        );
+        assert_eq!(
+            store.node(second).unwrap().residency(),
+            SemanticNodeResidency::Detached
+        );
+        assert_eq!(
+            store.semantic_family_members_checked(family).unwrap(),
+            vec![first, second]
+        );
+    }
+
+    #[test]
+    fn removing_descendant_promotes_surviving_sibling_at_family_root_position() {
+        let mut store = SemanticStore::new();
+        let left = object(&mut store, 0.5);
+        let removed = object(&mut store, 1.0);
+        let survivor = object(&mut store, 2.0);
+        let right = object(&mut store, 3.0);
+        let family = store.insert_family();
+        store.add_semantic_family_member(family, removed).unwrap();
+        store.add_semantic_family_member(family, survivor).unwrap();
+
+        store.attach_semantic_object(left).unwrap();
+        store.add_semantic_scene_nodes(&[family]).unwrap();
+        store.attach_semantic_object(right).unwrap();
+        assert_eq!(
+            store.scene_roots().collect::<Vec<_>>(),
+            vec![left, family, right]
+        );
+
+        store.remove_semantic_scene_nodes(&[removed]).unwrap();
+
+        assert_eq!(
+            store.scene_roots().collect::<Vec<_>>(),
+            vec![left, survivor, right]
+        );
+        assert_eq!(
+            store.node(family).unwrap().residency(),
+            SemanticNodeResidency::Detached
+        );
+        assert_eq!(
+            store.semantic_family_members_checked(family).unwrap(),
+            vec![removed, survivor]
+        );
+    }
+
+    #[test]
+    fn batch_validation_happens_before_any_scene_membership_change() {
+        let mut store = SemanticStore::new();
+        let existing = object(&mut store, 0.5);
+        let valid = object(&mut store, 1.0);
+        let identity_only = store.insert_authoring_object();
+        store.attach_semantic_object(existing).unwrap();
+
+        assert_eq!(
+            store.add_semantic_scene_nodes(&[valid, identity_only]),
+            Err(SemanticSceneOperationError::NotSemanticAuthoringNode(
+                identity_only
+            ))
+        );
+        assert_eq!(store.scene_roots().collect::<Vec<_>>(), vec![existing]);
+        assert_eq!(
+            store.node(valid).unwrap().residency(),
+            SemanticNodeResidency::Detached
+        );
+    }
+
+    #[test]
+    fn cross_root_alias_dedup_uses_current_scene_order_not_node_id_order() {
+        let mut store = SemanticStore::new();
+        let removed = object(&mut store, 1.0);
+        let shared = object(&mut store, 2.0);
+        let tail = object(&mut store, 3.0);
+        let older_family = store.insert_family();
+        let newer_family = store.insert_family();
+
+        for family in [older_family, newer_family] {
+            store.add_semantic_family_member(family, removed).unwrap();
+            store.add_semantic_family_member(family, shared).unwrap();
+        }
+
+        // Storage primitives can represent aliased family roots. Re-attach the
+        // lower-NodeId family last so current authored root order intentionally
+        // disagrees with allocation order.
+        store.attach_to_scene(older_family).unwrap();
+        store.attach_to_scene(newer_family).unwrap();
+        store.attach_semantic_object(tail).unwrap();
+        store.detach_from_scene(older_family).unwrap();
+        store.attach_to_scene(older_family).unwrap();
+        assert!(older_family < newer_family);
+        assert_eq!(
+            store.scene_roots().collect::<Vec<_>>(),
+            vec![newer_family, tail, older_family]
+        );
+
+        store.remove_semantic_scene_nodes(&[removed]).unwrap();
+
+        assert_eq!(
+            store.scene_roots().collect::<Vec<_>>(),
+            vec![shared, tail]
+        );
+    }
 }

--- a/crates/noon-core/src/semantic_store.rs
+++ b/crates/noon-core/src/semantic_store.rs
@@ -583,7 +583,10 @@ impl SemanticStore {
 
         let mut seen = HashSet::with_capacity(replacements.len());
         for replacement in replacements.iter().copied() {
-            assert_ne!(replacement, root, "scene-root splice cannot reinsert its root");
+            assert_ne!(
+                replacement, root,
+                "scene-root splice cannot reinsert its root"
+            );
             let node = self
                 .node(replacement)
                 .expect("scene-root splice replacement must be live");
@@ -668,10 +671,8 @@ impl SemanticStore {
             debug_assert!(self.scene_tail.is_none());
         }
 
-        let slots_written = 1
-            + replacements.len()
-            + (previous.is_some() as usize)
-            + (next.is_some() as usize);
+        let slots_written =
+            1 + replacements.len() + (previous.is_some() as usize) + (next.is_some() as usize);
         self.last_mutation = SemanticMutationStats {
             slots_written,
             cycle_nodes_visited: 0,

--- a/crates/noon-core/src/semantic_store.rs
+++ b/crates/noon-core/src/semantic_store.rs
@@ -562,6 +562,123 @@ impl SemanticStore {
         Ok(true)
     }
 
+    /// Replace one attached scene root with detached semantic nodes in place.
+    ///
+    /// This is a crate-private storage primitive for shared scene operations. It
+    /// preserves the old root's exact position and writes only that root, the
+    /// replacement nodes, and its immediate outside neighbors. Family links,
+    /// source identity, node identity, and authored object state are unchanged.
+    pub(crate) fn replace_scene_root_with_detached(
+        &mut self,
+        root: SemanticNodeId,
+        replacements: &[SemanticNodeId],
+    ) -> usize {
+        let membership = self
+            .node(root)
+            .expect("scene-root splice requires a live root")
+            .scene_membership;
+        let SemanticSceneMembership::Attached { previous, next } = membership else {
+            panic!("scene-root splice requires an attached root");
+        };
+
+        let mut seen = HashSet::with_capacity(replacements.len());
+        for replacement in replacements.iter().copied() {
+            assert_ne!(replacement, root, "scene-root splice cannot reinsert its root");
+            let node = self
+                .node(replacement)
+                .expect("scene-root splice replacement must be live");
+            assert!(
+                matches!(node.scene_membership, SemanticSceneMembership::Detached),
+                "scene-root splice replacement must be detached"
+            );
+            assert!(
+                seen.insert(replacement),
+                "scene-root splice replacements must be unique"
+            );
+        }
+
+        let first = replacements.first().copied();
+        let last = replacements.last().copied();
+
+        if let Some(previous_id) = previous {
+            let previous_node = self
+                .node_mut(previous_id)
+                .expect("scene previous link must reference a live semantic node");
+            match &mut previous_node.scene_membership {
+                SemanticSceneMembership::Attached {
+                    next: previous_next,
+                    ..
+                } => {
+                    *previous_next = first.or(next);
+                }
+                SemanticSceneMembership::Detached => {
+                    unreachable!("attached root cannot have a detached previous root")
+                }
+            }
+        } else {
+            debug_assert_eq!(self.scene_head, Some(root));
+            self.scene_head = first.or(next);
+        }
+
+        if let Some(next_id) = next {
+            let next_node = self
+                .node_mut(next_id)
+                .expect("scene next link must reference a live semantic node");
+            match &mut next_node.scene_membership {
+                SemanticSceneMembership::Attached {
+                    previous: next_previous,
+                    ..
+                } => {
+                    *next_previous = last.or(previous);
+                }
+                SemanticSceneMembership::Detached => {
+                    unreachable!("attached root cannot have a detached next root")
+                }
+            }
+        } else {
+            debug_assert_eq!(self.scene_tail, Some(root));
+            self.scene_tail = last.or(previous);
+        }
+
+        for (index, replacement) in replacements.iter().copied().enumerate() {
+            let replacement_previous = if index == 0 {
+                previous
+            } else {
+                Some(replacements[index - 1])
+            };
+            let replacement_next = if index + 1 == replacements.len() {
+                next
+            } else {
+                Some(replacements[index + 1])
+            };
+            self.node_mut(replacement)
+                .expect("scene-root splice replacement validated above")
+                .scene_membership = SemanticSceneMembership::Attached {
+                previous: replacement_previous,
+                next: replacement_next,
+            };
+        }
+
+        self.node_mut(root)
+            .expect("scene-root splice root validated above")
+            .scene_membership = SemanticSceneMembership::Detached;
+        self.scene_nodes = self.scene_nodes - 1 + replacements.len();
+        if self.scene_nodes == 0 {
+            debug_assert!(self.scene_head.is_none());
+            debug_assert!(self.scene_tail.is_none());
+        }
+
+        let slots_written = 1
+            + replacements.len()
+            + (previous.is_some() as usize)
+            + (next.is_some() as usize);
+        self.last_mutation = SemanticMutationStats {
+            slots_written,
+            cycle_nodes_visited: 0,
+        };
+        slots_written
+    }
+
     /// Iterate current top-level authored scene roots in deterministic authored order.
     pub fn scene_roots(&self) -> impl Iterator<Item = SemanticNodeId> + '_ {
         std::iter::successors(self.scene_head, move |id| {
@@ -755,6 +872,13 @@ impl SemanticStore {
 
     pub const fn last_mutation_stats(&self) -> SemanticMutationStats {
         self.last_mutation
+    }
+
+    pub(crate) fn set_last_mutation_writes(&mut self, slots_written: usize) {
+        self.last_mutation = SemanticMutationStats {
+            slots_written,
+            cycle_nodes_visited: 0,
+        };
     }
 }
 


### PR DESCRIPTION
Supersedes #988, whose shared head branch was concurrently rewritten after review fixes were applied.

## Roadmap ownership

- Owning case: #957 / A1.3
- Builds on direct semantic family operations merged in #986
- H1 consumers: #958 / A2 and #61 / A3

## What changed

Add recursive scene-facing add/remove semantics on the authoritative `SemanticStore`:

- `add_semantic_scene_nodes(ids)` validates the full batch, collapses descendant roots already represented in the scene projection, promotes unaffected branches in place, then appends explicit target nodes in caller order;
- `remove_semantic_scene_nodes(ids)` removes explicit targets while dissolving only affected family roots and promoting surviving branches at the former root position;
- family membership, source identity, semantic identity, and authored state are not mutated;
- a crate-private root-splice primitive performs bounded local writes to the replaced root, replacement nodes, and immediate neighbors;
- the new module is actually compiled through ordinary Rust module ownership.

## Review fixes

The prototype sorted affected roots by `SemanticNodeId` before cross-root alias de-duplication. That is incorrect after detach/re-attach because NodeId allocation order can disagree with authored scene order. This version uses current linked scene-root order whenever multiple affected roots require first-occurrence de-duplication; the common single-root case avoids the scan.

## Tests

Focused tests cover:
- adding a family collapses existing descendant roots and appends the family;
- removing a descendant promotes a surviving sibling at the exact family-root position;
- invalid mixed batches fail before scene membership changes;
- cross-root alias de-dup follows authored scene order even when NodeId order intentionally disagrees after detach/re-attach.

## Architecture

- one `SemanticStore` / `SemanticNodeId` authority;
- no duplicate family graph, root-order cache, frontend model, runtime model, codec, or renderer dependency;
- no new `#[path]`/`include!` debt;
- reparent/reorder and transform/style mutations remain for the atomic mutation vocabulary rather than ad-hoc partial transactions here.

Refs #953 #957 #958 #61 #961.