### PR TITLE
Decouple deterministic replay from ScenePlayer

### DIFF
--- a/crates/noon-web/src/determinism.rs
+++ b/crates/noon-web/src/determinism.rs
@@ -1,9 +1,9 @@
 //! Renderer-independent frame snapshots used by deterministic replay tests and tools.
 
-use noon_runtime::FrameState;
+use noon_compile::{CompileError, CompiledScene};
+use noon_ir::{decode_scene, IrError};
+use noon_runtime::{EvaluationError, FrameState, SlottedSceneInstance};
 use serde_json::{json, Value};
-
-use crate::{PlayerError, ScenePlayer};
 
 fn normalize_playhead(time: f64) -> f64 {
     const SCALE: f64 = 1_000_000_000_000.0;
@@ -57,23 +57,69 @@ fn normalized_frames_equal(left: &FrameState, right: &FrameState) -> bool {
         && left.render_geometries == right.render_geometries
 }
 
+#[derive(Debug)]
+pub enum ReplayRuntimeError {
+    Ir(IrError),
+    Compile(CompileError),
+    Evaluation(EvaluationError),
+}
+
+impl std::fmt::Display for ReplayRuntimeError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Ir(error) => error.fmt(formatter),
+            Self::Compile(error) => error.fmt(formatter),
+            Self::Evaluation(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl std::error::Error for ReplayRuntimeError {}
+
+impl From<IrError> for ReplayRuntimeError {
+    fn from(value: IrError) -> Self {
+        Self::Ir(value)
+    }
+}
+
+impl From<CompileError> for ReplayRuntimeError {
+    fn from(value: CompileError) -> Self {
+        Self::Compile(value)
+    }
+}
+
+impl From<EvaluationError> for ReplayRuntimeError {
+    fn from(value: EvaluationError) -> Self {
+        Self::Evaluation(value)
+    }
+}
+
+fn runtime_from_scene_json(scene_json: &str) -> Result<SlottedSceneInstance, ReplayRuntimeError> {
+    let definition = decode_scene(scene_json)?;
+    let compiled = CompiledScene::compile(&definition)?;
+    Ok(SlottedSceneInstance::new(compiled))
+}
+
 /// Evaluate a scene by seeking directly to `time` and return its normalized frame.
-pub fn scene_snapshot_json(scene_json: &str, time: f64) -> Result<String, PlayerError> {
-    let mut player = ScenePlayer::from_scene_json(scene_json)?;
-    player.seek(time)?;
-    Ok(normalized_frame_json(player.frame()))
+pub fn scene_snapshot_json(scene_json: &str, time: f64) -> Result<String, ReplayRuntimeError> {
+    let mut runtime = runtime_from_scene_json(scene_json)?;
+    runtime.seek(time)?;
+    Ok(normalized_frame_json(runtime.frame()))
 }
 
 /// Evaluate a scene through the supplied playhead sequence and return the final frame.
 ///
 /// The sequence may move backward. This intentionally exercises the same
 /// `advance_to` rewind behavior used by interactive scrubbing.
-pub fn playback_snapshot_json(scene_json: &str, times: &[f64]) -> Result<String, PlayerError> {
-    let mut player = ScenePlayer::from_scene_json(scene_json)?;
+pub fn playback_snapshot_json(
+    scene_json: &str,
+    times: &[f64],
+) -> Result<String, ReplayRuntimeError> {
+    let mut runtime = runtime_from_scene_json(scene_json)?;
     for &time in times {
-        player.advance_to(time)?;
+        runtime.advance_to(time)?;
     }
-    Ok(normalized_frame_json(player.frame()))
+    Ok(normalized_frame_json(runtime.frame()))
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -93,7 +139,7 @@ impl std::fmt::Display for ReplayVerificationMode {
 
 #[derive(Debug)]
 pub enum ReplayVerificationError {
-    Player(PlayerError),
+    Runtime(ReplayRuntimeError),
     InvalidForwardSampleCount(usize),
     NonFiniteTarget {
         index: usize,
@@ -112,7 +158,7 @@ pub enum ReplayVerificationError {
 impl std::fmt::Display for ReplayVerificationError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Player(error) => error.fmt(formatter),
+            Self::Runtime(error) => error.fmt(formatter),
             Self::InvalidForwardSampleCount(count) => {
                 write!(
                     formatter,
@@ -141,9 +187,9 @@ impl std::fmt::Display for ReplayVerificationError {
 
 impl std::error::Error for ReplayVerificationError {}
 
-impl From<PlayerError> for ReplayVerificationError {
-    fn from(value: PlayerError) -> Self {
-        Self::Player(value)
+impl From<ReplayRuntimeError> for ReplayVerificationError {
+    fn from(value: ReplayRuntimeError) -> Self {
+        Self::Runtime(value)
     }
 }
 
@@ -169,7 +215,7 @@ pub fn verify_scene_replay(
         }
     }
 
-    let mut direct = ScenePlayer::from_scene_json(scene_json)?;
+    let mut direct = runtime_from_scene_json(scene_json)?;
     let mut forward = direct.clone();
     let mut rewind = direct.clone();
     let denominator = (forward_sample_count - 1) as f64;

--- a/crates/noon-web/src/determinism.rs
+++ b/crates/noon-web/src/determinism.rs
@@ -193,6 +193,12 @@ impl From<ReplayRuntimeError> for ReplayVerificationError {
     }
 }
 
+impl From<EvaluationError> for ReplayVerificationError {
+    fn from(value: EvaluationError) -> Self {
+        Self::Runtime(ReplayRuntimeError::Evaluation(value))
+    }
+}
+
 /// Verify direct seek, incremental playback, and rewind equivalence for one scene.
 ///
 /// The scene is decoded and compiled once. Three persistent runtime instances then


### PR DESCRIPTION
## Roadmap ownership

- Owning issue: #959 / A4.6 narrow debug/export codecs
- Supports the eventual deletion of the temporary `ScenePlayer` seam tracked by draft #989
- Independent of #989: this PR touches only `determinism.rs`

## What changed

`crates/noon-web/src/determinism.rs` no longer constructs or depends on `ScenePlayer` / `PlayerError`.

Deterministic replay now owns its justified fixture boundary directly:

```text
serialized replay fixture
  -> decode
  -> compile
  -> SlottedSceneInstance
  -> normalized frame comparison
```

The replay helpers use `CompiledScene` + `SlottedSceneInstance` directly and expose a replay-specific error type for decode/compile/evaluation failures.

## Why

A4 explicitly permits narrow serialized fixtures when the codec/test boundary itself is intentional. Deterministic replay is such a boundary, but routing it through the mutable browser player makes a debug/test tool another production consumer of the migration player authority.

This removes one consumer without inventing an adapter or changing the fixture format. It also keeps #989 focused on deleting obsolete browser wrappers rather than making that temporary core more attractive to unrelated tooling.

## Architecture check

- no new scene/document model;
- no new serialization format;
- no compatibility wrapper or alias;
- no `ScenePlayer` dependency in deterministic replay;
- runtime evaluation behavior remains the same compiler/runtime path formerly reached through `ScenePlayer`.

## Validation

GitHub CI on head `328170a24f74b4ab655cc97bd0ad1b48068d2165`:

- Architecture Ratchets: passed
- Layer Dependency Ratchet: passed
- Rust format + Clippy: passed
- Rust fast unit tests: passed
- Web static/unit preflight: passed
- WASM browser package build: passed
- deterministic playback browser smoke: passed
- Manim-style authoring smoke: passed
- WebGPU rendering: passed
- WebGL rendering: passed

The broader authoring-recovery workflow is also running independently; no local test run is claimed.

Refs #953 #959 #989.