### PR TITLE
Decouple semantic snapshot from ScenePlayer

### DIFF
--- a/crates/noon-web/src/semantic_snapshot.rs
+++ b/crates/noon-web/src/semantic_snapshot.rs
@@ -116,10 +116,7 @@ pub fn semantic_frame_value(frame: &FrameState) -> Value {
     })
 }
 
-pub fn semantic_frame_json(
-    scene_json: &str,
-    time: f64,
-) -> Result<String, SemanticSnapshotError> {
+pub fn semantic_frame_json(scene_json: &str, time: f64) -> Result<String, SemanticSnapshotError> {
     let definition = decode_scene(scene_json)?;
     let compiled = CompiledScene::compile(&definition)?;
     let mut runtime = SlottedSceneInstance::new(compiled);

--- a/crates/noon-web/src/semantic_snapshot.rs
+++ b/crates/noon-web/src/semantic_snapshot.rs
@@ -1,8 +1,8 @@
+use noon_compile::{CompileError, CompiledScene};
 use noon_core::{Color, ObjectSnapshot, Rect};
-use noon_runtime::FrameState;
+use noon_ir::{decode_scene, IrError};
+use noon_runtime::{EvaluationError, FrameState, SlottedSceneInstance};
 use serde_json::{json, Value};
-
-use crate::{PlayerError, ScenePlayer};
 
 fn paint_json(color: Option<Color>, opacity: f32) -> Value {
     match color {
@@ -25,6 +25,43 @@ fn bounds_json(bounds: Option<Rect>) -> Value {
             "height": bounds.height(),
         }),
         None => Value::Null,
+    }
+}
+
+#[derive(Debug)]
+pub enum SemanticSnapshotError {
+    Ir(IrError),
+    Compile(CompileError),
+    Evaluation(EvaluationError),
+}
+
+impl std::fmt::Display for SemanticSnapshotError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Ir(error) => error.fmt(formatter),
+            Self::Compile(error) => error.fmt(formatter),
+            Self::Evaluation(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl std::error::Error for SemanticSnapshotError {}
+
+impl From<IrError> for SemanticSnapshotError {
+    fn from(value: IrError) -> Self {
+        Self::Ir(value)
+    }
+}
+
+impl From<CompileError> for SemanticSnapshotError {
+    fn from(value: CompileError) -> Self {
+        Self::Compile(value)
+    }
+}
+
+impl From<EvaluationError> for SemanticSnapshotError {
+    fn from(value: EvaluationError) -> Self {
+        Self::Evaluation(value)
     }
 }
 
@@ -79,10 +116,15 @@ pub fn semantic_frame_value(frame: &FrameState) -> Value {
     })
 }
 
-pub fn semantic_frame_json(scene_json: &str, time: f64) -> Result<String, PlayerError> {
-    let mut player = ScenePlayer::from_scene_json(scene_json)?;
-    player.seek(time)?;
-    Ok(semantic_frame_value(player.frame()).to_string())
+pub fn semantic_frame_json(
+    scene_json: &str,
+    time: f64,
+) -> Result<String, SemanticSnapshotError> {
+    let definition = decode_scene(scene_json)?;
+    let compiled = CompiledScene::compile(&definition)?;
+    let mut runtime = SlottedSceneInstance::new(compiled);
+    runtime.seek(time)?;
+    Ok(semantic_frame_value(runtime.frame()).to_string())
 }
 
 #[cfg(target_arch = "wasm32")]


### PR DESCRIPTION
## Roadmap ownership

- Owning issue: #959 / A4.6 narrow debug/export codecs
- Follows merged #991, which removed the same temporary player dependency from deterministic replay
- Independent of #992: this PR touches only `crates/noon-web/src/semantic_snapshot.rs`

## What changed

`semantic_frame_json` no longer constructs or depends on `ScenePlayer` / `PlayerError`.

The explicit snapshot boundary now evaluates directly:

```text
serialized snapshot fixture
  -> decode
  -> compile
  -> SlottedSceneInstance
  -> semantic frame JSON
```

The snapshot helper owns a narrow `SemanticSnapshotError` for decode/compile/evaluation failures.

## Why

A4 explicitly permits narrow debug/export codecs. A semantic snapshot is such a boundary, but routing it through the mutable browser player unnecessarily made snapshot tooling another consumer of the migration player authority.

This removes that consumer without changing the snapshot format or inventing an adapter. Existing grandfathered migration-model references inside this file (`ObjectSnapshot` and its existing test fixture construction) are left untouched rather than spread or renamed.

## Architecture check

- no new scene/document model;
- no new serialization format;
- no compatibility wrapper or alias;
- no `ScenePlayer` dependency in semantic snapshot generation;
- runtime evaluation remains the same compiler/runtime path formerly reached through `ScenePlayer`;
- no overlap with #992 Semantic Scene updater declarations.

## Validation

GitHub CI is the executable validation; no local test run is claimed.

Refs #953 #959 #991.