### PR TITLE
Ratchet web tool independence from ScenePlayer

### DIFF
--- a/scripts/architecture-ratchet.sh
+++ b/scripts/architecture-ratchet.sh
@@ -101,6 +101,31 @@ diff. Use ordinary Rust module layout instead. See #960/A5.2 and #961/A6.8.
 EOF
 fi
 
+normalized_web_tool_player_dependency_found=0
+normalized_web_tool_player_dependencies="$(
+  git grep -nE \
+    '(^|[^[:alnum:]_])(ScenePlayer|PlayerError)([^[:alnum:]_]|$)' \
+    -- \
+    'crates/noon-web/src/determinism.rs' \
+    'crates/noon-web/src/semantic_snapshot.rs' || true
+)"
+
+if [[ -n "$normalized_web_tool_player_dependencies" ]]; then
+  printf '%s\n' "$normalized_web_tool_player_dependencies" >&2
+  normalized_web_tool_player_dependency_found=1
+fi
+
+if (( normalized_web_tool_player_dependency_found != 0 )); then
+  cat >&2 <<'EOF'
+
+Deterministic replay and semantic snapshots were detached from the migration
+ScenePlayer authority by #991 and #994. Those explicit debug/export boundaries
+must stay compiler/runtime-owned and may not regain ScenePlayer or PlayerError
+dependencies, including dependencies that predate the current diff. See #959/A4.6
+and #961/A6.8.
+EOF
+fi
+
 identity_authority_found=0
 canonical_identity_file='crates/noon-core/src/semantic_store.rs'
 
@@ -142,8 +167,8 @@ creating a second identity/store definition elsewhere. See #961/A6.3.
 EOF
 fi
 
-if (( migration_found != 0 || module_indirection_found != 0 || normalized_runtime_module_indirection_found != 0 || identity_authority_found != 0 )); then
+if (( migration_found != 0 || module_indirection_found != 0 || normalized_runtime_module_indirection_found != 0 || normalized_web_tool_player_dependency_found != 0 || identity_authority_found != 0 )); then
   exit 1
 fi
 
-echo "architecture migration-growth, module-growth, normalized-runtime-module, and semantic-identity ratchets passed"
+echo "architecture migration-growth, module-growth, normalized-runtime-module, normalized-web-tool-player, and semantic-identity ratchets passed"

--- a/scripts/architecture-ratchet.test.sh
+++ b/scripts/architecture-ratchet.test.sh
@@ -6,7 +6,7 @@ RATCHET="$ROOT/scripts/architecture-ratchet.sh"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
-mkdir -p "$TMP/scripts" "$TMP/src" "$TMP/crates/noon-core/src" "$TMP/crates/noon-runtime/src"
+mkdir -p "$TMP/scripts" "$TMP/src" "$TMP/crates/noon-core/src" "$TMP/crates/noon-runtime/src" "$TMP/crates/noon-web/src"
 cp "$RATCHET" "$TMP/scripts/architecture-ratchet.sh"
 
 cd "$TMP"
@@ -47,8 +47,12 @@ mod runtime;
 EOF
 printf 'pub fn runtime() {}\n' > crates/noon-runtime/src/runtime.rs
 
-git add scripts/architecture-ratchet.sh src crates/noon-core/src/semantic_store.rs crates/noon-runtime/src
-git commit -qm "baseline with semantic authority, known A5 debt, and normalized runtime"
+# These web tools were detached from the migration player by #991 and #994.
+printf 'pub fn deterministic_replay() {}\n' > crates/noon-web/src/determinism.rs
+printf 'pub fn semantic_snapshot() {}\n' > crates/noon-web/src/semantic_snapshot.rs
+
+git add scripts/architecture-ratchet.sh src crates/noon-core/src/semantic_store.rs crates/noon-runtime/src crates/noon-web/src
+git commit -qm "baseline with semantic authority, known A5 debt, and normalized islands"
 BASE="$(git rev-parse HEAD)"
 
 printf 'pub fn visible_module_tree() {}\n' > src/visible.rs
@@ -66,7 +70,7 @@ expect_rejected() {
 
 reset_to_base() {
   git reset -q --hard "$BASE"
-  rm -f src/new_hidden.rs src/duplicate_identity.rs src/runtime_structural_probe.rs
+  rm -f src/new_hidden.rs src/duplicate_identity.rs src/runtime_structural_probe.rs src/web_tool_structural_probe.rs
 }
 
 reset_to_base
@@ -146,6 +150,29 @@ git add src/runtime_structural_probe.rs
 git commit -qm "unrelated change after runtime regression"
 if bash scripts/architecture-ratchet.sh "$RUNTIME_REGRESSION_BASE" >/dev/null 2>&1; then
   echo "architecture ratchet test failed: accepted pre-existing noon-runtime module indirection" >&2
+  exit 1
+fi
+
+# Prove the completed A4.6 tool cutovers are structural, not just growth-ratcheted.
+# Put migration-player dependencies into the comparison base itself, then make an
+# unrelated later commit. The full-tree guard must still reject both tool paths.
+reset_to_base
+cat > crates/noon-web/src/determinism.rs <<'EOF'
+use crate::ScenePlayer;
+pub fn deterministic_replay() {}
+EOF
+cat > crates/noon-web/src/semantic_snapshot.rs <<'EOF'
+use crate::PlayerError;
+pub fn semantic_snapshot() {}
+EOF
+git add crates/noon-web/src
+git commit -qm "model regressed web tool player baseline"
+WEB_TOOL_REGRESSION_BASE="$(git rev-parse HEAD)"
+printf 'pub fn unrelated_after_web_tool_regression() {}\n' > src/web_tool_structural_probe.rs
+git add src/web_tool_structural_probe.rs
+git commit -qm "unrelated change after web tool regression"
+if bash scripts/architecture-ratchet.sh "$WEB_TOOL_REGRESSION_BASE" >/dev/null 2>&1; then
+  echo "architecture ratchet test failed: accepted pre-existing web tool migration-player dependency" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Roadmap ownership

- Owning issue: #961 / A6.8 structural ratchets
- Ratchets completed A4.6 cutovers from merged #991 and #994
- Independent of #992 Semantic Scene updater work

## What changed

Add a full-tree architecture invariant for:

- `crates/noon-web/src/determinism.rs`
- `crates/noon-web/src/semantic_snapshot.rs`

Neither file may contain a `ScenePlayer` or `PlayerError` dependency.

This is deliberately structural rather than diff-only: once these debug/export tools were detached from the migration player, a later unrelated change must not be able to grandfather a regression back in.

The ratchet self-test commits both bad dependencies into a comparison baseline, adds an unrelated later commit, and proves the repository is still rejected. That distinguishes this invariant from the existing migration-growth guard.

## Why

#991 moved deterministic replay to its explicit fixture codec followed by compiler/runtime evaluation. #994 did the same for semantic snapshot generation. Those A4.6 boundaries are now stable enough to ratchet immediately rather than leaving their deletion reversible.

## Scope

- scripts/tests only;
- no runtime, browser API, Semantic Scene, Execution Plan, renderer, or serialization behavior changes;
- no changes to the still-live `EngineScenePlayer` execution path;
- no overlap with #992.

## Validation

GitHub CI is the executable validation; no local test run is claimed.

Refs #953 #959 #961 #991 #994.