### PR TITLE
Ratchet ScenePlayer consumer shrinkage

### DIFF
--- a/scripts/architecture-ratchet.sh
+++ b/scripts/architecture-ratchet.sh
@@ -126,6 +126,39 @@ and #961/A6.8.
 EOF
 fi
 
+scene_player_consumer_spread_found=0
+scene_player_references="$(
+  git grep -nE \
+    '(^|[^[:alnum:]_])ScenePlayer([^[:alnum:]_]|$)' \
+    -- 'crates/noon-web/src' || true
+)"
+
+while IFS= read -r reference; do
+  [[ -z "$reference" ]] && continue
+  reference_file="${reference%%:*}"
+  case "$reference_file" in
+    crates/noon-web/src/legacy.rs|\
+    crates/noon-web/src/execution_transport.rs|\
+    crates/noon-web/src/execution_visibility.rs|\
+    crates/noon-web/src/spatial_query.rs)
+      ;;
+    *.rs)
+      printf 'architecture ratchet: ScenePlayer consumer outside migration allowlist: %s\n' "$reference" >&2
+      scene_player_consumer_spread_found=1
+      ;;
+  esac
+done <<< "$scene_player_references"
+
+if (( scene_player_consumer_spread_found != 0 )); then
+  cat >&2 <<'EOF'
+
+ScenePlayer is a shrinking migration authority. New noon-web Rust modules must not
+consume it. The temporary allowlist is limited to its definition plus the live
+execution transport, visibility, and spatial-query seams; remove entries as those
+callers migrate rather than adding consumers. See #959/A4 and #961/A6.8.
+EOF
+fi
+
 identity_authority_found=0
 canonical_identity_file='crates/noon-core/src/semantic_store.rs'
 
@@ -167,8 +200,8 @@ creating a second identity/store definition elsewhere. See #961/A6.3.
 EOF
 fi
 
-if (( migration_found != 0 || module_indirection_found != 0 || normalized_runtime_module_indirection_found != 0 || normalized_web_tool_player_dependency_found != 0 || identity_authority_found != 0 )); then
+if (( migration_found != 0 || module_indirection_found != 0 || normalized_runtime_module_indirection_found != 0 || normalized_web_tool_player_dependency_found != 0 || scene_player_consumer_spread_found != 0 || identity_authority_found != 0 )); then
   exit 1
 fi
 
-echo "architecture migration-growth, module-growth, normalized-runtime-module, normalized-web-tool-player, and semantic-identity ratchets passed"
+echo "architecture migration-growth, module-growth, normalized-runtime-module, normalized-web-tool-player, ScenePlayer-consumer, and semantic-identity ratchets passed"

--- a/scripts/architecture-ratchet.test.sh
+++ b/scripts/architecture-ratchet.test.sh
@@ -51,6 +51,16 @@ printf 'pub fn runtime() {}\n' > crates/noon-runtime/src/runtime.rs
 printf 'pub fn deterministic_replay() {}\n' > crates/noon-web/src/determinism.rs
 printf 'pub fn semantic_snapshot() {}\n' > crates/noon-web/src/semantic_snapshot.rs
 
+# Model the deliberately shrinking ScenePlayer allowlist that remains during A4.
+cat > crates/noon-web/src/legacy.rs <<'EOF'
+pub struct ScenePlayer;
+EOF
+for consumer in execution_transport execution_visibility spatial_query; do
+  cat > "crates/noon-web/src/${consumer}.rs" <<'EOF'
+use crate::ScenePlayer;
+EOF
+done
+
 git add scripts/architecture-ratchet.sh src crates/noon-core/src/semantic_store.rs crates/noon-runtime/src crates/noon-web/src
 git commit -qm "baseline with semantic authority, known A5 debt, and normalized islands"
 BASE="$(git rev-parse HEAD)"
@@ -70,7 +80,7 @@ expect_rejected() {
 
 reset_to_base() {
   git reset -q --hard "$BASE"
-  rm -f src/new_hidden.rs src/duplicate_identity.rs src/runtime_structural_probe.rs src/web_tool_structural_probe.rs
+  rm -f src/new_hidden.rs src/duplicate_identity.rs src/runtime_structural_probe.rs src/web_tool_structural_probe.rs src/scene_player_spread_probe.rs
 }
 
 reset_to_base
@@ -173,6 +183,24 @@ git add src/web_tool_structural_probe.rs
 git commit -qm "unrelated change after web tool regression"
 if bash scripts/architecture-ratchet.sh "$WEB_TOOL_REGRESSION_BASE" >/dev/null 2>&1; then
   echo "architecture ratchet test failed: accepted pre-existing web tool migration-player dependency" >&2
+  exit 1
+fi
+
+# Prove ScenePlayer cannot spread to another noon-web Rust module. Put a new
+# consumer into the comparison base itself, then make an unrelated later commit;
+# the structural allowlist must still reject that repository state.
+reset_to_base
+cat > crates/noon-web/src/new_scene_player_consumer.rs <<'EOF'
+use crate::ScenePlayer;
+EOF
+git add crates/noon-web/src/new_scene_player_consumer.rs
+git commit -qm "model ScenePlayer consumer spread"
+SCENE_PLAYER_SPREAD_BASE="$(git rev-parse HEAD)"
+printf 'pub fn unrelated_after_scene_player_spread() {}\n' > src/scene_player_spread_probe.rs
+git add src/scene_player_spread_probe.rs
+git commit -qm "unrelated change after ScenePlayer spread"
+if bash scripts/architecture-ratchet.sh "$SCENE_PLAYER_SPREAD_BASE" >/dev/null 2>&1; then
+  echo "architecture ratchet test failed: accepted ScenePlayer consumer outside migration allowlist" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Roadmap ownership

- Owning issue: #961 / A6.8 structural ratchets
- Supports #959 / A4 migration-player deletion
- Follows merged #991, #994, and #995
- Independent of #992 Semantic Scene updater work

## What changed

Make `ScenePlayer` a structurally shrinking `noon-web` migration authority.

The architecture ratchet now allows `ScenePlayer` references only in the currently live migration island:

- `crates/noon-web/src/legacy.rs` — definition;
- `crates/noon-web/src/execution_transport.rs` — active execution adapter;
- `crates/noon-web/src/execution_visibility.rs` — visibility seam;
- `crates/noon-web/src/spatial_query.rs` — spatial-query seam.

Any `ScenePlayer` reference in another Rust module under `crates/noon-web/src` is rejected. The allowlist is intentionally one-way: remove entries as callers migrate; do not add consumers.

The self-test proves this is a full-tree invariant by committing a fifth consumer into the comparison baseline, making an unrelated later change, and verifying the repository is still rejected.

## Why

A4 cleanup is now actively shrinking this migration authority: #991 removed deterministic replay and #994 removed semantic snapshots. Preventing consumer spread keeps those deletions monotonic while the remaining live browser path is migrated seam-by-seam.

## Scope

- scripts/tests only;
- no runtime/browser/API/Semantic Scene/renderer behavior changes;
- no change to the still-live migration callers themselves;
- no overlap with #992.

## Validation

GitHub CI is the executable validation; no local test run is claimed.

Refs #953 #959 #961 #991 #994 #995.