### PR TITLE
Remove retained SceneDefinition lowering detour

### DIFF
--- a/crates/noon-web/src/retained_scene_spec_runtime.rs
+++ b/crates/noon-web/src/retained_scene_spec_runtime.rs
@@ -1,8 +1,6 @@
 use noon::{MathTypst, RetainedScene, Text as NativeText, Typst};
 use noon_compile::RetainedCompiledScene;
-use noon_core::{
-    Color, ObjectDefinition, ObjectId, SceneDefinition, Style, TrackDefinition, Transform2D,
-};
+use noon_core::{Color, ObjectId, Style, TrackDefinition, Transform2D};
 use noon_ir::{ObjectSpec, ObjectSpecContent, SceneSpec, TextSpec, TextSpecKind, TextSpecOptions};
 
 use crate::retained_authoring_scene::MixedRetainedAuthoringError;
@@ -31,27 +29,11 @@ impl CanonicalRetainedAuthoringScene {
             ..
         } = spec;
 
-        // `RetainedScene` already owns the correct resource-backed text insertion
-        // APIs. Seed it with only the geometry subset, preserving relative geometry
-        // order, then insert text at its structural global painter slots.
-        let geometry_objects = objects
-            .iter()
-            .filter_map(|object| {
-                let ObjectSpecContent::Geometry(geometry) = &object.content else {
-                    return None;
-                };
-                Some(ObjectDefinition {
-                    id: object.id,
-                    geometry: geometry.clone(),
-                    transform: object.transform,
-                    style: object.style,
-                })
-            })
-            .collect::<Vec<_>>();
-        let geometry_scene = SceneDefinition::from_parts(geometry_objects, Vec::new())
-            .map_err(|error| invalid_scene_spec(error.to_string()))?;
-        let mut scene = RetainedScene::from_legacy(&geometry_scene)?;
-
+        // Keep the migration lowering typed and in-process after `SceneSpec` has
+        // already been consumed. Geometry and text enter the retained migration
+        // container in their single structural painter order; do not reconstruct a
+        // legacy `SceneDefinition` or `ObjectDefinition` on this production path.
+        let mut scene = RetainedScene::new();
         for (order, object) in objects.into_iter().enumerate() {
             let ObjectSpec {
                 id,
@@ -59,8 +41,15 @@ impl CanonicalRetainedAuthoringScene {
                 transform,
                 style,
             } = object;
-            if let ObjectSpecContent::Text(text) = content {
-                insert_text_object(&mut scene, order, id, text, transform, style)?;
+            match content {
+                ObjectSpecContent::Geometry(geometry) => {
+                    scene
+                        .insert_migration_geometry_at(order, id, geometry, transform, style)
+                        .map_err(|error| invalid_scene_spec(error.to_string()))?;
+                }
+                ObjectSpecContent::Text(text) => {
+                    insert_text_object(&mut scene, order, id, text, transform, style)?;
+                }
             }
         }
 
@@ -225,8 +214,8 @@ fn invalid_scene_spec(error: impl std::fmt::Display) -> MixedRetainedAuthoringEr
 #[cfg(test)]
 mod tests {
     use noon_core::{
-        Color, GeometryRef, ObjectContentRef, Property, RateFunction, TrackTiming, TrackValues,
-        Transform2D, Vec2,
+        Color, GeometryRef, ObjectContentRef, Property, RateFunction, SceneDefinition, TrackTiming,
+        TrackValues, Transform2D, Vec2,
     };
 
     use super::*;
@@ -312,6 +301,19 @@ mod tests {
             canonical.scene().objects()[1].content,
             ObjectContentRef::Text(_)
         ));
+    }
+
+    #[test]
+    fn canonical_lowering_rejects_non_finite_geometry_without_legacy_scene() {
+        let object = ObjectId::new(7);
+        let mut geometry = ObjectSpec::geometry(object, GeometryRef::circle(1.0));
+        geometry.transform.rotation = f32::NAN;
+        let spec = SceneSpec::new(vec![geometry], Vec::new()).unwrap();
+
+        let error = CanonicalRetainedAuthoringScene::from_scene_spec(spec).unwrap_err();
+        let message = error.to_string();
+        assert!(message.contains("non-finite transform state"));
+        assert!(message.contains("7"));
     }
 
     #[test]

--- a/crates/noon/src/text_authoring.rs
+++ b/crates/noon/src/text_authoring.rs
@@ -9,9 +9,10 @@ use std::sync::Arc;
 
 use noon_compile::{RetainedCompileError, RetainedCompiledScene};
 use noon_core::{
-    Color, FontResourceArena, FontResourceError, GeometryResource, GeometryResourceArena, ObjectId,
-    RetainedObjectDefinition, SceneDefinition, Style, TextResource, TextResourceArena,
-    TextResourceValidationError, TextSourceKind, TrackDefinition, Transform2D, Vec2, WHITE,
+    validate_object_definition, Color, FontResourceArena, FontResourceError, GeometryResource,
+    GeometryResourceArena, ObjectDefinition, ObjectId, RetainedObjectDefinition, SceneDefinition,
+    Style, TextResource, TextResourceArena, TextResourceValidationError, TextSourceKind,
+    TrackDefinition, Transform2D, Vec2, WHITE,
 };
 use noon_text_native::{
     NativeFontFace, NativeTextCompiler, NativeTextError, NativeTextOptions,
@@ -392,6 +393,7 @@ pub enum TextAuthoringError {
     DuplicateObject(ObjectId),
     InvalidPainterOrder { order: usize, object_count: usize },
     ObjectIdSpaceExhausted,
+    InvalidGeometryObject(noon_core::PatchError),
     NativeText(NativeTextError),
     Typst(TypstBackendError),
     Font(FontResourceError),
@@ -429,6 +431,7 @@ impl std::fmt::Display for TextAuthoringError {
             Self::ObjectIdSpaceExhausted => {
                 formatter.write_str("retained object ID space is exhausted")
             }
+            Self::InvalidGeometryObject(error) => error.fmt(formatter),
             Self::NativeText(error) => error.fmt(formatter),
             Self::Typst(error) => error.fmt(formatter),
             Self::Font(error) => error.fmt(formatter),
@@ -510,6 +513,44 @@ impl RetainedScene {
             fonts: FontResourceArena::default(),
             next_object_id,
         })
+    }
+
+    /// Migration-only A4 bridge for inserting geometry without reconstructing a
+    /// legacy `SceneDefinition`. #959 owns deletion of this API together with the
+    /// retained migration object model once semantic lowering replaces this path.
+    #[doc(hidden)]
+    pub fn insert_migration_geometry_at(
+        &mut self,
+        order: usize,
+        id: ObjectId,
+        geometry: noon_core::GeometryRef,
+        transform: Transform2D,
+        style: Style,
+    ) -> Result<RetainedMobject, TextAuthoringError> {
+        if order > self.objects.len() {
+            return Err(TextAuthoringError::InvalidPainterOrder {
+                order,
+                object_count: self.objects.len(),
+            });
+        }
+        if self.objects.iter().any(|object| object.id == id) {
+            return Err(TextAuthoringError::DuplicateObject(id));
+        }
+        let next_object_id = self.next_object_id_after(id)?;
+        let candidate = ObjectDefinition {
+            id,
+            geometry: geometry.clone(),
+            transform,
+            style,
+        };
+        validate_object_definition(&candidate).map_err(TextAuthoringError::InvalidGeometryObject)?;
+
+        let mut object = RetainedObjectDefinition::geometry(id, geometry);
+        object.transform = transform;
+        object.style = style;
+        self.objects.insert(order, object);
+        self.next_object_id = next_object_id;
+        Ok(RetainedMobject { id })
     }
 
     pub fn add_text(&mut self, object: Text) -> Result<RetainedMobject, TextAuthoringError> {


### PR DESCRIPTION
## Closed as architecturally stale

This branch successfully demonstrated how to remove the concrete `SceneSpec -> SceneDefinition -> RetainedScene::from_legacy` detour, but the architecture ratchet correctly rejected the replacement.

The proposed `insert_migration_geometry_at` helper spreads fresh migration-era object-model construction (`ObjectDefinition` / `RetainedObjectDefinition`) into a new API. That trades one migration detour for another migration surface, which violates A4's deletion direction and the no-migration-growth invariant.

The current `RetainedScene` still stores the retained migration object model and does not expose a target-shaped geometry insertion primitive that would make this cutover clean. Do not bypass or weaken the ratchet for this branch.

Revisit this detour only after the target Semantic Scene -> Execution Plan / retained-resource handoff can consume geometry without introducing new legacy object-model references.

Refs #953 #959 #961 #969.