### PR TITLE
Own updater declarations in the Semantic Scene

### DIFF
--- a/crates/noon-core/src/reactive.rs
+++ b/crates/noon-core/src/reactive.rs
@@ -34,7 +34,6 @@ pub use semantic_scene_operations::*;
 mod semantic_scene_restructure;
 
 mod semantic_declarations;
-pub use semantic_declarations::*;
 
 #[path = "semantic_family.rs"]
 mod semantic_family;

--- a/crates/noon-core/src/reactive.rs
+++ b/crates/noon-core/src/reactive.rs
@@ -33,6 +33,9 @@ pub use semantic_scene_operations::*;
 
 mod semantic_scene_restructure;
 
+mod semantic_declarations;
+pub use semantic_declarations::*;
+
 #[path = "semantic_family.rs"]
 mod semantic_family;
 

--- a/crates/noon-core/src/reactive/semantic_declarations.rs
+++ b/crates/noon-core/src/reactive/semantic_declarations.rs
@@ -83,9 +83,7 @@ mod tests {
     use crate::{SemanticMutationStats, SemanticObjectState, StoredGeometry};
 
     fn object(store: &mut SemanticStore, radius: f32) -> SemanticNodeId {
-        store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
-            radius,
-        }))
+        store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle { radius }))
     }
 
     #[test]
@@ -196,10 +194,8 @@ mod tests {
             .add_semantic_updater(target, HostCallbackId::new(99))
             .unwrap();
         assert_eq!(store.last_mutation_stats().slots_written, 1);
-        assert!(targets
-            .iter()
-            .enumerate()
-            .all(|(index, id)| index == 5_000
-                || store.node(*id).unwrap().host_updaters().is_empty()));
+        assert!(targets.iter().enumerate().all(
+            |(index, id)| index == 5_000 || store.node(*id).unwrap().host_updaters().is_empty()
+        ));
     }
 }

--- a/crates/noon-core/src/reactive/semantic_declarations.rs
+++ b/crates/noon-core/src/reactive/semantic_declarations.rs
@@ -1,0 +1,205 @@
+use super::{
+    HostCallbackId, SemanticNodeId, SemanticNodeKind, SemanticSceneOperationError, SemanticStore,
+};
+
+impl SemanticStore {
+    /// Return authored host-updater registrations for one target semantic node.
+    ///
+    /// Registration order is semantic authoring state. The host owns executable
+    /// callable code keyed by [`HostCallbackId`]; Runtime scheduling is a lowering
+    /// concern and is deliberately absent here.
+    pub fn semantic_updater_callbacks(
+        &self,
+        target: SemanticNodeId,
+    ) -> Result<&[HostCallbackId], SemanticSceneOperationError> {
+        target_node_checked(self, target)?;
+        Ok(self
+            .node(target)
+            .expect("semantic updater target validated above")
+            .host_updaters())
+    }
+
+    /// Append one authored updater declaration to a semantic object or family.
+    ///
+    /// Reusing the same callback identity is intentional: a host callable may be
+    /// registered more than once, and order remains observable authoring state.
+    pub fn add_semantic_updater(
+        &mut self,
+        target: SemanticNodeId,
+        callback: HostCallbackId,
+    ) -> Result<(), SemanticSceneOperationError> {
+        target_node_checked(self, target)?;
+        self.node_mut(target)
+            .expect("semantic updater target validated above")
+            .host_updaters_mut()
+            .push(callback);
+        self.set_last_mutation_writes(1);
+        Ok(())
+    }
+
+    /// Remove every authored registration of `callback` from one semantic target.
+    ///
+    /// This mirrors updater-list semantics without consulting Runtime or a host
+    /// callable table. Work is proportional only to this target's updater degree.
+    pub fn remove_semantic_updater(
+        &mut self,
+        target: SemanticNodeId,
+        callback: HostCallbackId,
+    ) -> Result<bool, SemanticSceneOperationError> {
+        target_node_checked(self, target)?;
+        let callbacks = self
+            .node_mut(target)
+            .expect("semantic updater target validated above")
+            .host_updaters_mut();
+        let before = callbacks.len();
+        callbacks.retain(|candidate| *candidate != callback);
+        let removed = callbacks.len() != before;
+        self.set_last_mutation_writes(removed as usize);
+        Ok(removed)
+    }
+}
+
+fn target_node_checked(
+    store: &SemanticStore,
+    id: SemanticNodeId,
+) -> Result<(), SemanticSceneOperationError> {
+    let node = store
+        .node(id)
+        .ok_or(SemanticSceneOperationError::UnknownNode(id))?;
+    let is_target = match node.kind() {
+        SemanticNodeKind::Family => true,
+        SemanticNodeKind::AuthoringObject => node.semantic_object_state().is_some(),
+        SemanticNodeKind::Object(_) => false,
+    };
+    if !is_target {
+        return Err(SemanticSceneOperationError::NotSemanticAuthoringNode(id));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{SemanticMutationStats, SemanticObjectState, StoredGeometry};
+
+    fn object(store: &mut SemanticStore, radius: f32) -> SemanticNodeId {
+        store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+            radius,
+        }))
+    }
+
+    #[test]
+    fn updater_declarations_are_ordered_scene_owned_authoring_state() {
+        let mut store = SemanticStore::new();
+        let target = object(&mut store, 1.0);
+        let first = HostCallbackId::new(7);
+        let second = HostCallbackId::new(3);
+
+        store.add_semantic_updater(target, first).unwrap();
+        assert_eq!(store.last_mutation_stats().slots_written, 1);
+        store.add_semantic_updater(target, second).unwrap();
+        store.add_semantic_updater(target, first).unwrap();
+
+        assert_eq!(
+            store.semantic_updater_callbacks(target).unwrap(),
+            &[first, second, first]
+        );
+        assert_eq!(store.last_mutation_stats().slots_written, 1);
+    }
+
+    #[test]
+    fn updater_declarations_survive_detach_and_readd() {
+        let mut store = SemanticStore::new();
+        let target = object(&mut store, 1.0);
+        let callback = HostCallbackId::new(11);
+        store.add_semantic_updater(target, callback).unwrap();
+
+        store.attach_semantic_object(target).unwrap();
+        store.detach_semantic_object(target).unwrap();
+        assert_eq!(
+            store.semantic_updater_callbacks(target).unwrap(),
+            &[callback]
+        );
+        store.attach_semantic_object(target).unwrap();
+        assert_eq!(
+            store.semantic_updater_callbacks(target).unwrap(),
+            &[callback]
+        );
+    }
+
+    #[test]
+    fn semantic_families_can_own_updater_declarations() {
+        let mut store = SemanticStore::new();
+        let family = store.insert_family();
+        let callback = HostCallbackId::new(4);
+
+        store.add_semantic_updater(family, callback).unwrap();
+        assert_eq!(
+            store.semantic_updater_callbacks(family).unwrap(),
+            &[callback]
+        );
+    }
+
+    #[test]
+    fn state_less_and_stale_targets_are_rejected_before_mutation() {
+        let mut store = SemanticStore::new();
+        let identity_only = store.insert_authoring_object();
+        assert_eq!(
+            store.add_semantic_updater(identity_only, HostCallbackId::new(1)),
+            Err(SemanticSceneOperationError::NotSemanticAuthoringNode(
+                identity_only
+            ))
+        );
+
+        let stale = object(&mut store, 2.0);
+        store.remove_node(stale).unwrap();
+        assert_eq!(
+            store.semantic_updater_callbacks(stale),
+            Err(SemanticSceneOperationError::UnknownNode(stale))
+        );
+    }
+
+    #[test]
+    fn removing_updater_is_local_order_preserving_and_idempotent() {
+        let mut store = SemanticStore::new();
+        let target = object(&mut store, 1.0);
+        let first = HostCallbackId::new(1);
+        let removed = HostCallbackId::new(2);
+        let last = HostCallbackId::new(3);
+        for callback in [first, removed, last, removed] {
+            store.add_semantic_updater(target, callback).unwrap();
+        }
+
+        assert!(store.remove_semantic_updater(target, removed).unwrap());
+        assert_eq!(store.last_mutation_stats().slots_written, 1);
+        assert_eq!(
+            store.semantic_updater_callbacks(target).unwrap(),
+            &[first, last]
+        );
+
+        assert!(!store.remove_semantic_updater(target, removed).unwrap());
+        assert_eq!(
+            store.last_mutation_stats(),
+            SemanticMutationStats::default()
+        );
+    }
+
+    #[test]
+    fn updater_mutation_does_not_touch_unrelated_semantic_nodes() {
+        let mut store = SemanticStore::new();
+        let targets = (0..10_000)
+            .map(|index| object(&mut store, index as f32 + 1.0))
+            .collect::<Vec<_>>();
+        let target = targets[5_000];
+
+        store
+            .add_semantic_updater(target, HostCallbackId::new(99))
+            .unwrap();
+        assert_eq!(store.last_mutation_stats().slots_written, 1);
+        assert!(targets
+            .iter()
+            .enumerate()
+            .all(|(index, id)| index == 5_000
+                || store.node(*id).unwrap().host_updaters().is_empty()));
+    }
+}

--- a/crates/noon-core/src/reactive/semantic_scene_operations.rs
+++ b/crates/noon-core/src/reactive/semantic_scene_operations.rs
@@ -139,16 +139,26 @@ impl SemanticStore {
 
     /// Copy one target semantic object into a fresh detached semantic node.
     ///
-    /// Authored content/transform/style/z-index are copied. Scene membership,
-    /// source identity, and family relationships are intentionally not copied.
-    /// The store assigns both a fresh generational NodeId and a fresh stable
-    /// painter insertion-order tie break.
+    /// Authored content/transform/style/z-index and updater declarations are copied.
+    /// Scene membership, source identity, and family relationships are intentionally
+    /// not copied. The store assigns both a fresh generational NodeId and a fresh
+    /// stable painter insertion-order tie break.
     pub fn copy_semantic_object(
         &mut self,
         id: SemanticNodeId,
     ) -> Result<SemanticNodeId, SemanticSceneOperationError> {
         let state = self.semantic_object_state_checked(id)?.clone();
-        Ok(self.insert_semantic_object(state))
+        let updaters = self
+            .node(id)
+            .expect("semantic object identity validated above")
+            .host_updaters()
+            .to_vec();
+        let copy = self.insert_semantic_object(state);
+        self.node_mut(copy)
+            .expect("newly inserted semantic copy exists")
+            .host_updaters_mut()
+            .extend(updaters);
+        Ok(copy)
     }
 
     /// Snapshot one target semantic family's direct members in authoritative order.
@@ -195,7 +205,10 @@ impl SemanticStore {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{SemanticMutationStats, SemanticNodeResidency, SourceIdentity, StoredGeometry};
+    use crate::{
+        HostCallbackId, SemanticMutationStats, SemanticNodeResidency, SourceIdentity,
+        StoredGeometry,
+    };
 
     fn state(radius: f32) -> SemanticObjectState {
         SemanticObjectState::new(StoredGeometry::Circle { radius })
@@ -282,6 +295,8 @@ mod tests {
         authored.style.object_opacity = 0.4;
         authored.set_z_index(7);
         let source = store.insert_semantic_object(authored);
+        let callback = HostCallbackId::new(42);
+        store.add_semantic_updater(source, callback).unwrap();
         let family = store.insert_family();
         store.add_member(family, source).unwrap();
         let source_identity = SourceIdentity::ExplicitKey("hero".into());
@@ -303,6 +318,7 @@ mod tests {
             copied_state.insertion_order(),
             source_state.insertion_order()
         );
+        assert_eq!(store.semantic_updater_callbacks(copy).unwrap(), &[callback]);
         assert_eq!(
             store.node(copy).unwrap().residency(),
             SemanticNodeResidency::Detached
@@ -350,6 +366,7 @@ mod tests {
         );
 
         assert!(store.remove_semantic_family_member(primary, first).unwrap());
+        assert_eq!(store.last_mutation_stats().slots_written, 2);
         assert_eq!(
             store.semantic_family_members_checked(primary).unwrap(),
             vec![second]

--- a/crates/noon-core/src/semantic_store.rs
+++ b/crates/noon-core/src/semantic_store.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use serde::{Deserialize, Serialize};
 
-use crate::SemanticObjectState;
+use crate::{HostCallbackId, SemanticObjectState};
 use crate::{ObjectDefinition, ObjectId, SceneDefinition};
 
 /// Stable semantic identity independent of execution/render dense indices.
@@ -189,6 +189,13 @@ pub struct SemanticNode {
     parents: Vec<SemanticNodeId>,
     /// Ordered direct family membership with O(1) identity removal and append.
     members: OrderedFamilyMembers,
+    /// Ordered authored host-updater registrations for this semantic node.
+    ///
+    /// `HostCallbackId` identifies host-owned callable code; the registration itself
+    /// belongs to the Semantic Scene and therefore follows this node across
+    /// detach/re-attach. Lowering decides how these declarations become runtime
+    /// callback slots.
+    host_updaters: Vec<HostCallbackId>,
 }
 
 impl SemanticNode {
@@ -260,6 +267,14 @@ impl SemanticNode {
 
     pub fn member_count(&self) -> usize {
         self.members.len()
+    }
+
+    pub fn host_updaters(&self) -> &[HostCallbackId] {
+        &self.host_updaters
+    }
+
+    pub(crate) fn host_updaters_mut(&mut self) -> &mut Vec<HostCallbackId> {
+        &mut self.host_updaters
     }
 }
 
@@ -372,6 +387,7 @@ impl SemanticStore {
             scene_membership: SemanticSceneMembership::Detached,
             parents: Vec::new(),
             members: OrderedFamilyMembers::default(),
+            host_updaters: Vec::new(),
         });
         self.live_nodes += 1;
         self.last_mutation = SemanticMutationStats {


### PR DESCRIPTION
Supersedes #992, which GitHub auto-closed while its head was temporarily reset to master during a conflict-safe restack.

## Roadmap ownership

- Owning case: #957 / A1.4 — animation/reactive/host declarations
- Architecture layer: authoritative Semantic Scene
- Consumers/follow-up: #61/A3 frontend facade and #957/A1.6 typed lowering

## What changed

Introduce the first target A1.4 host declaration directly on semantic nodes:

- target semantic objects and families own ordered `HostCallbackId` updater registrations;
- `add_semantic_updater`, `remove_semantic_updater`, and `semantic_updater_callbacks` are shared Rust semantic operations over `SemanticNodeId`;
- detach/re-add preserves updater declarations automatically because they are node-owned authored state;
- deleting the semantic node deletes its declarations with the node, with no registry scan;
- `copy_semantic_object` copies updater registrations while preserving the existing fresh-NodeId / detached-copy lifecycle contract;
- mutations write only the target semantic slot and reuse `SemanticMutationStats` locality accounting.

`HostCallbackId` remains only the host-owned callable key. Executable callback code, invocation, scheduling, frame capture, transport, and runtime slots are deliberately absent from this semantic declaration.

## Restack safety

The branch was rebuilt from #993 master (`2017f181...`) rather than merging the pre-#990 store wholesale. The resulting diff is exactly four files; `semantic_store.rs` retains the A1.3 root-splice primitive and differs only by updater-declaration storage/accessors. Current master is a few commits ahead only in unrelated A6/web ratchet work, which Git can merge normally.

## Architecture check

- [x] One authoritative `SemanticStore`; no wrapper/side scene or declaration registry.
- [x] Targets use scene-global generational `SemanticNodeId`, never legacy `ObjectId`.
- [x] No runtime scheduler, execution track, renderer state, JSON, or transport is introduced.
- [x] Existing `HostCallbackRegistry` remains a migration/runtime-facing structure, not the new authored authority; A1.6/A4 can lower/delete/reshape it without changing this semantic contract.
- [x] Updater mutation is O(the target updater degree) and never scans unrelated scene nodes.
- [x] Normal Rust module wiring; no new `#[path]`/`include!` seam.

## Deliberate scope limits

This is the first narrow A1.4 declaration slice, not the full animation/reactive model. Activation windows, event declarations, observed-node dependency capture, native signal declarations, semantic AnimationGraph nodes/options, and lowering remain follow-up A1.4/A1.6 work.

## Tests

Focused tests cover:
- declaration order and repeated callable registration;
- detach/re-add preservation;
- family targets;
- stale/state-less target rejection;
- order-preserving updater removal/idempotency;
- 10k unrelated-node locality;
- semantic object copy preserving updater declarations while retaining fresh identity and detached lifecycle.

Refs #953 #957 #63 #961.