### PR TITLE
Own semantic signal definitions in the Semantic Scene

### DIFF
--- a/crates/noon-core/src/reactive.rs
+++ b/crates/noon-core/src/reactive.rs
@@ -35,6 +35,9 @@ mod semantic_scene_restructure;
 
 mod semantic_declarations;
 
+mod semantic_signals;
+pub use semantic_signals::*;
+
 #[path = "semantic_family.rs"]
 mod semantic_family;
 

--- a/crates/noon-core/src/reactive/semantic_declarations.rs
+++ b/crates/noon-core/src/reactive/semantic_declarations.rs
@@ -69,7 +69,7 @@ fn target_node_checked(
     let is_target = match node.kind() {
         SemanticNodeKind::Family => true,
         SemanticNodeKind::AuthoringObject => node.semantic_object_state().is_some(),
-        SemanticNodeKind::Object(_) => false,
+        SemanticNodeKind::Object(_) | SemanticNodeKind::Signal(_) => false,
     };
     if !is_target {
         return Err(SemanticSceneOperationError::NotSemanticAuthoringNode(id));

--- a/crates/noon-core/src/reactive/semantic_scene_operations.rs
+++ b/crates/noon-core/src/reactive/semantic_scene_operations.rs
@@ -106,7 +106,7 @@ impl SemanticStore {
         let is_target = match node.kind() {
             SemanticNodeKind::Family => true,
             SemanticNodeKind::AuthoringObject => node.semantic_object_state().is_some(),
-            SemanticNodeKind::Object(_) => false,
+            SemanticNodeKind::Object(_) | SemanticNodeKind::Signal(_) => false,
         };
         if !is_target {
             return Err(SemanticSceneOperationError::NotSemanticAuthoringNode(id));

--- a/crates/noon-core/src/reactive/semantic_scene_restructure.rs
+++ b/crates/noon-core/src/reactive/semantic_scene_restructure.rs
@@ -85,7 +85,7 @@ fn target_node_checked(
     let is_target = match node.kind() {
         SemanticNodeKind::Family => true,
         SemanticNodeKind::AuthoringObject => node.semantic_object_state().is_some(),
-        SemanticNodeKind::Object(_) => false,
+        SemanticNodeKind::Object(_) | SemanticNodeKind::Signal(_) => false,
     };
     if !is_target {
         return Err(SemanticSceneOperationError::NotSemanticAuthoringNode(id));
@@ -357,7 +357,6 @@ mod tests {
         let survivor_right = object(&mut store, 4.0);
         let left_family = store.insert_family();
         let right_family = store.insert_family();
-
         store
             .add_semantic_family_member(left_family, removed_left)
             .unwrap();

--- a/crates/noon-core/src/reactive/semantic_signals.rs
+++ b/crates/noon-core/src/reactive/semantic_signals.rs
@@ -1,0 +1,316 @@
+use super::{SemanticNodeId, SemanticNodeKind, SemanticStore, SemanticVec3};
+
+/// High-precision authored value carried by a semantic signal.
+///
+/// This is semantic state, not a runtime slot value. Lowering may specialize it
+/// to a narrower representation when the target execution plan permits that.
+#[derive(Clone, Debug, PartialEq)]
+pub enum SemanticSignalValue {
+    Bool(bool),
+    Scalar(f64),
+    Vec3(SemanticVec3),
+}
+
+impl SemanticSignalValue {
+    pub fn is_finite(&self) -> bool {
+        match self {
+            Self::Bool(_) => true,
+            Self::Scalar(value) => value.is_finite(),
+            Self::Vec3(value) => value.is_finite(),
+        }
+    }
+}
+
+impl From<bool> for SemanticSignalValue {
+    fn from(value: bool) -> Self {
+        Self::Bool(value)
+    }
+}
+
+impl From<f64> for SemanticSignalValue {
+    fn from(value: f64) -> Self {
+        Self::Scalar(value)
+    }
+}
+
+impl From<f32> for SemanticSignalValue {
+    fn from(value: f32) -> Self {
+        Self::Scalar(value as f64)
+    }
+}
+
+impl From<SemanticVec3> for SemanticSignalValue {
+    fn from(value: SemanticVec3) -> Self {
+        Self::Vec3(value)
+    }
+}
+
+/// Author-authored native reactive expression over semantic signal identity.
+///
+/// Signal references use the same scene-global generational [`SemanticNodeId`]
+/// as every other semantic entity. `SignalId` remains a migration/execution-era
+/// identity and is deliberately absent from the target authored model.
+#[derive(Clone, Debug, PartialEq)]
+pub enum SemanticSignalExpr {
+    Constant(SemanticSignalValue),
+    Signal(SemanticNodeId),
+    Add(Box<Self>, Box<Self>),
+    Sub(Box<Self>, Box<Self>),
+    Mul(Box<Self>, Box<Self>),
+    Neg(Box<Self>),
+    Sin(Box<Self>),
+    Cos(Box<Self>),
+}
+
+impl SemanticSignalExpr {
+    pub const fn signal(signal: SemanticNodeId) -> Self {
+        Self::Signal(signal)
+    }
+
+    pub fn scalar(value: f64) -> Self {
+        Self::Constant(SemanticSignalValue::Scalar(value))
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum SemanticSignalSource {
+    Input(SemanticSignalValue),
+    Derived(SemanticSignalExpr),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct SemanticSignalState {
+    source: SemanticSignalSource,
+}
+
+impl SemanticSignalState {
+    pub const fn new(source: SemanticSignalSource) -> Self {
+        Self { source }
+    }
+
+    pub const fn source(&self) -> &SemanticSignalSource {
+        &self.source
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SemanticSignalError {
+    UnknownSignal(SemanticNodeId),
+    NotSignal(SemanticNodeId),
+    NonFiniteValue,
+}
+
+impl std::fmt::Display for SemanticSignalError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnknownSignal(id) => write!(
+                formatter,
+                "unknown semantic signal {}:{}",
+                id.slot(),
+                id.generation()
+            ),
+            Self::NotSignal(id) => write!(
+                formatter,
+                "semantic node {}:{} is not a signal",
+                id.slot(),
+                id.generation()
+            ),
+            Self::NonFiniteValue => formatter.write_str("semantic signal contains a non-finite value"),
+        }
+    }
+}
+
+impl std::error::Error for SemanticSignalError {}
+
+impl SemanticStore {
+    /// Insert one authored input signal into the authoritative semantic identity space.
+    pub fn insert_semantic_input_signal(
+        &mut self,
+        value: impl Into<SemanticSignalValue>,
+    ) -> Result<SemanticNodeId, SemanticSignalError> {
+        self.set_last_mutation_writes(0);
+        let value = value.into();
+        if !value.is_finite() {
+            return Err(SemanticSignalError::NonFiniteValue);
+        }
+        Ok(self.insert_semantic_signal_state(SemanticSignalState::new(
+            SemanticSignalSource::Input(value),
+        )))
+    }
+
+    /// Insert one authored derived signal after validating only its referenced closure.
+    ///
+    /// Because a new signal cannot reference its not-yet-allocated identity, this
+    /// creation-only slice cannot introduce a cycle. Source replacement/cycle
+    /// validation belongs with the later semantic mutation transaction work.
+    pub fn insert_semantic_derived_signal(
+        &mut self,
+        expression: SemanticSignalExpr,
+    ) -> Result<SemanticNodeId, SemanticSignalError> {
+        self.set_last_mutation_writes(0);
+        validate_expression(self, &expression)?;
+        Ok(self.insert_semantic_signal_state(SemanticSignalState::new(
+            SemanticSignalSource::Derived(expression),
+        )))
+    }
+
+    pub fn semantic_signal_state(
+        &self,
+        id: SemanticNodeId,
+    ) -> Result<&SemanticSignalState, SemanticSignalError> {
+        let node = self
+            .node(id)
+            .ok_or(SemanticSignalError::UnknownSignal(id))?;
+        match node.kind() {
+            SemanticNodeKind::Signal(state) => Ok(state),
+            _ => Err(SemanticSignalError::NotSignal(id)),
+        }
+    }
+}
+
+fn validate_expression(
+    store: &SemanticStore,
+    expression: &SemanticSignalExpr,
+) -> Result<(), SemanticSignalError> {
+    match expression {
+        SemanticSignalExpr::Constant(value) => {
+            if value.is_finite() {
+                Ok(())
+            } else {
+                Err(SemanticSignalError::NonFiniteValue)
+            }
+        }
+        SemanticSignalExpr::Signal(id) => {
+            store.semantic_signal_state(*id)?;
+            Ok(())
+        }
+        SemanticSignalExpr::Add(lhs, rhs)
+        | SemanticSignalExpr::Sub(lhs, rhs)
+        | SemanticSignalExpr::Mul(lhs, rhs) => {
+            validate_expression(store, lhs)?;
+            validate_expression(store, rhs)
+        }
+        SemanticSignalExpr::Neg(value)
+        | SemanticSignalExpr::Sin(value)
+        | SemanticSignalExpr::Cos(value) => validate_expression(store, value),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{SemanticObjectState, StoredGeometry};
+
+    fn object(store: &mut SemanticStore, radius: f32) -> SemanticNodeId {
+        store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle { radius }))
+    }
+
+    #[test]
+    fn signals_share_the_scene_global_generational_identity_space() {
+        let mut store = SemanticStore::new();
+        let object = object(&mut store, 1.0);
+        let signal = store.insert_semantic_input_signal(1.25_f64).unwrap();
+
+        assert_ne!(object, signal);
+        assert!(matches!(
+            store.semantic_signal_state(signal).unwrap().source(),
+            SemanticSignalSource::Input(SemanticSignalValue::Scalar(value)) if *value == 1.25
+        ));
+        assert_eq!(store.last_mutation_stats().slots_written, 1);
+        assert_eq!(store.scene_root_count(), 0);
+    }
+
+    #[test]
+    fn derived_signal_references_semantic_node_identity() {
+        let mut store = SemanticStore::new();
+        let input = store.insert_semantic_input_signal(2.0_f64).unwrap();
+        let derived = store
+            .insert_semantic_derived_signal(SemanticSignalExpr::Add(
+                Box::new(SemanticSignalExpr::signal(input)),
+                Box::new(SemanticSignalExpr::scalar(3.0)),
+            ))
+            .unwrap();
+
+        assert!(matches!(
+            store.semantic_signal_state(derived).unwrap().source(),
+            SemanticSignalSource::Derived(_)
+        ));
+        assert_eq!(store.last_mutation_stats().slots_written, 1);
+    }
+
+    #[test]
+    fn signal_validation_rejects_stale_and_non_signal_dependencies_before_insertion() {
+        let mut store = SemanticStore::new();
+        let stale = store.insert_semantic_input_signal(1.0_f64).unwrap();
+        store.remove_node(stale).unwrap();
+        let replacement = object(&mut store, 2.0);
+        assert_eq!(stale.slot(), replacement.slot());
+        assert_ne!(stale.generation(), replacement.generation());
+
+        let before = store.len();
+        assert_eq!(
+            store.insert_semantic_derived_signal(SemanticSignalExpr::signal(stale)),
+            Err(SemanticSignalError::UnknownSignal(stale))
+        );
+        assert_eq!(store.len(), before);
+        assert_eq!(store.last_mutation_stats().slots_written, 0);
+
+        assert_eq!(
+            store.insert_semantic_derived_signal(SemanticSignalExpr::signal(replacement)),
+            Err(SemanticSignalError::NotSignal(replacement))
+        );
+        assert_eq!(store.len(), before);
+        assert_eq!(store.last_mutation_stats().slots_written, 0);
+    }
+
+    #[test]
+    fn non_finite_signal_values_are_rejected_without_mutation() {
+        let mut store = SemanticStore::new();
+        assert_eq!(
+            store.insert_semantic_input_signal(f64::NAN),
+            Err(SemanticSignalError::NonFiniteValue)
+        );
+        assert_eq!(store.len(), 0);
+        assert_eq!(store.last_mutation_stats().slots_written, 0);
+    }
+
+    #[test]
+    fn signal_creation_cost_does_not_scale_with_unrelated_scene_nodes() {
+        let mut store = SemanticStore::new();
+        for index in 0..10_000 {
+            object(&mut store, index as f32 + 1.0);
+        }
+        let input = store
+            .insert_semantic_input_signal(SemanticVec3::new(1.0, 2.0, 3.0))
+            .unwrap();
+        assert_eq!(store.last_mutation_stats().slots_written, 1);
+
+        let derived = store
+            .insert_semantic_derived_signal(SemanticSignalExpr::Sin(Box::new(
+                SemanticSignalExpr::signal(input),
+            )))
+            .unwrap();
+        assert_eq!(store.last_mutation_stats().slots_written, 1);
+        assert!(store.semantic_signal_state(derived).is_ok());
+    }
+
+    #[test]
+    fn signal_nodes_are_not_scene_family_or_updater_targets() {
+        let mut store = SemanticStore::new();
+        let signal = store.insert_semantic_input_signal(true).unwrap();
+        let family = store.insert_family();
+
+        assert!(matches!(
+            store.add_semantic_scene_nodes(&[signal]),
+            Err(super::super::SemanticSceneOperationError::NotSemanticAuthoringNode(id)) if id == signal
+        ));
+        assert!(matches!(
+            store.add_semantic_family_member(family, signal),
+            Err(super::super::SemanticSceneOperationError::NotSemanticAuthoringNode(id)) if id == signal
+        ));
+        assert!(matches!(
+            store.add_semantic_updater(signal, super::super::HostCallbackId::new(1)),
+            Err(super::super::SemanticSceneOperationError::NotSemanticAuthoringNode(id)) if id == signal
+        ));
+    }
+}

--- a/crates/noon-core/src/reactive/semantic_signals.rs
+++ b/crates/noon-core/src/reactive/semantic_signals.rs
@@ -115,7 +115,9 @@ impl std::fmt::Display for SemanticSignalError {
                 id.slot(),
                 id.generation()
             ),
-            Self::NonFiniteValue => formatter.write_str("semantic signal contains a non-finite value"),
+            Self::NonFiniteValue => {
+                formatter.write_str("semantic signal contains a non-finite value")
+            }
         }
     }
 }

--- a/crates/noon-core/src/semantic_family.rs
+++ b/crates/noon-core/src/semantic_family.rs
@@ -33,6 +33,7 @@ impl SemanticStore {
                         collect(store, member, seen, leaves)?;
                     }
                 }
+                SemanticNodeKind::Signal(_) => {}
             }
             Ok(())
         }

--- a/crates/noon-core/src/semantic_store.rs
+++ b/crates/noon-core/src/semantic_store.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use serde::{Deserialize, Serialize};
 
-use crate::{HostCallbackId, SemanticObjectState};
+use crate::{HostCallbackId, SemanticObjectState, SemanticSignalState};
 use crate::{ObjectDefinition, ObjectId, SceneDefinition};
 
 /// Stable semantic identity independent of execution/render dense indices.
@@ -170,6 +170,9 @@ pub enum SemanticNodeKind {
     AuthoringObject,
     /// A semantic family/collection with no implied transform ownership.
     Family,
+    /// Authored native-reactive signal using the same scene-global generational
+    /// identity allocator as objects and families.
+    Signal(SemanticSignalState),
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -178,7 +181,7 @@ pub struct SemanticNode {
     kind: SemanticNodeKind,
     /// Authoritative authored object payload for target semantic objects.
     ///
-    /// `None` is valid for families, legacy compatibility objects, and the
+    /// `None` is valid for families, signals, legacy compatibility objects, and the
     /// temporary state-less frontend identity seam only.
     object_state: Option<SemanticObjectState>,
     source_identity: Option<SourceIdentity>,
@@ -210,14 +213,18 @@ impl SemanticNode {
     pub fn object(&self) -> Option<&ObjectDefinition> {
         match &self.kind {
             SemanticNodeKind::Object(object) => Some(object),
-            SemanticNodeKind::AuthoringObject | SemanticNodeKind::Family => None,
+            SemanticNodeKind::AuthoringObject
+            | SemanticNodeKind::Family
+            | SemanticNodeKind::Signal(_) => None,
         }
     }
 
     pub fn object_mut(&mut self) -> Option<&mut ObjectDefinition> {
         match &mut self.kind {
             SemanticNodeKind::Object(object) => Some(object),
-            SemanticNodeKind::AuthoringObject | SemanticNodeKind::Family => None,
+            SemanticNodeKind::AuthoringObject
+            | SemanticNodeKind::Family
+            | SemanticNodeKind::Signal(_) => None,
         }
     }
 
@@ -361,6 +368,13 @@ impl SemanticStore {
 
     pub fn insert_family(&mut self) -> SemanticNodeId {
         self.insert_kind(SemanticNodeKind::Family)
+    }
+
+    pub(crate) fn insert_semantic_signal_state(
+        &mut self,
+        state: SemanticSignalState,
+    ) -> SemanticNodeId {
+        self.insert_kind(SemanticNodeKind::Signal(state))
     }
 
     fn insert_kind(&mut self, kind: SemanticNodeKind) -> SemanticNodeId {

--- a/crates/noon-web/src/authoring_mobject.rs
+++ b/crates/noon-web/src/authoring_mobject.rs
@@ -954,7 +954,7 @@ impl FrontendFamilyArrangePlan {
             let leaves = match node.kind() {
                 SemanticNodeKind::AuthoringObject => vec![id],
                 SemanticNodeKind::Family => semantic_family_leaf_ids(store, id)?,
-                SemanticNodeKind::Object(_) => {
+                SemanticNodeKind::Object(_) | SemanticNodeKind::Signal(_) => {
                     return Err(format!(
                         "family arrange member {id:?} is not an authoring object"
                     ));
@@ -1054,7 +1054,7 @@ fn semantic_family_leaf_ids(
                 }
                 Ok(())
             }
-            SemanticNodeKind::Object(_) => Err(format!(
+            SemanticNodeKind::Object(_) | SemanticNodeKind::Signal(_) => Err(format!(
                 "family layout member {node_id:?} is not an authoring object"
             )),
         }


### PR DESCRIPTION
## Roadmap ownership

- Owning case: #957 / A1.4 — animation/reactive/host declarations
- Parent roadmap: #953
- Related target reactive work: #63
- Structural/locality ratchets: #961

## What changed

Move the first native-reactive signal declaration into the authoritative `SemanticStore` identity model:

- add `SemanticNodeKind::Signal(SemanticSignalState)` so signals use the same scene-global generational `SemanticNodeId` allocator as objects/families;
- add high-precision `SemanticSignalValue` (`bool`, `f64`, `SemanticVec3`) and authored expression/source types;
- derived expressions reference `SemanticNodeId`, never the migration-era `SignalId` allocator;
- validate finite constants plus stale/non-signal dependencies before allocation;
- keep signal nodes detached from object/family scene topology through the shared target validators;
- creation writes one semantic slot and validates only the expression/dependency closure.

## Architecture

This deliberately does **not** adapt the target model onto `ReactiveGraphDefinition`, `SemanticScene { definition, reactive }`, or `TimedSemanticScene`. Those are migration-era parallel authored structures and remain deletion/migration work under A1/A4/A1.6 rather than becoming the new contract.

No runtime evaluator, execution slot, timeline track, JSON/codec, frontend ID mapping, or second `SignalStore` is introduced.

## Scope limits / follow-up

This is a creation-only signal declaration slice. Bindings, signal source replacement, dependency-cycle mutation, timeline/native-input declaration ownership, and lowering remain follow-up A1.4/A1.5/A1.6 work. Creation cannot form a cycle because the new node identity does not exist until all dependencies validate.

## Tests

Focused tests cover:
- signals and objects sharing one generational `SemanticNodeId` arena;
- high-precision semantic signal values;
- derived expressions using semantic node references;
- stale and non-signal dependency rejection before insertion;
- non-finite rejection without mutation;
- 10k unrelated-node locality with one-slot signal writes;
- signal rejection from scene/family/updater target operations.

GitHub CI is the executable compile/validation gate for the new enum variant and will identify any remaining exhaustive `SemanticNodeKind` target checks.

Refs #953 #957 #63 #959 #961.