### PR TITLE
Ratchet deleted legacy web surfaces

### DIFF
--- a/scripts/architecture-ratchet.sh
+++ b/scripts/architecture-ratchet.sh
@@ -157,6 +157,58 @@ adding consumers. See #959/A4 and #961/A6.8.
 EOF
 fi
 
+deleted_legacy_web_surface_found=0
+deleted_legacy_web_references="$(
+  git grep -nE \
+    '(^|[^[:alnum:]_])(NoonCanvasPlayer|demoSceneJson)([^[:alnum:]_]|$)' \
+    -- \
+    'crates/noon-web/src' \
+    'web' \
+    'scripts/check-web-package.mjs' \
+    'scripts/browser-smoke.mjs' || true
+)"
+
+if [[ -n "$deleted_legacy_web_references" ]]; then
+  printf '%s\n' "$deleted_legacy_web_references" >&2
+  deleted_legacy_web_surface_found=1
+fi
+
+canonical_clock_file='crates/noon-web/src/clock.rs'
+playback_clock_defs="$(
+  git grep -nE \
+    '^[[:space:]]*(pub([[:space:]]*\([^)]*\))?[[:space:]]+)?struct[[:space:]]+PlaybackClock([[:space:]{(;]|$)' \
+    -- 'crates/noon-web/src' || true
+)"
+playback_clock_count=0
+if [[ -n "$playback_clock_defs" ]]; then
+  playback_clock_count="$(printf '%s\n' "$playback_clock_defs" | wc -l | tr -d '[:space:]')"
+fi
+if [[ "$playback_clock_count" != "1" ]] || ! printf '%s\n' "$playback_clock_defs" | grep -q "^${canonical_clock_file}:"; then
+  printf 'architecture ratchet: PlaybackClock must exist exactly once in %s\n' "$canonical_clock_file" >&2
+  if [[ -n "$playback_clock_defs" ]]; then
+    printf '%s\n' "$playback_clock_defs" >&2
+  else
+    printf '(no matches)\n' >&2
+  fi
+  deleted_legacy_web_surface_found=1
+fi
+
+if [[ -e 'crates/noon-web/src/legacy/clock.rs' ]]; then
+  printf 'architecture ratchet: deleted legacy playback clock returned: crates/noon-web/src/legacy/clock.rs\n' >&2
+  deleted_legacy_web_surface_found=1
+fi
+
+if (( deleted_legacy_web_surface_found != 0 )); then
+  cat >&2 <<'EOF'
+
+The duplicate legacy browser frontend and playback clock were deleted by #1003
+and #1005. NoonCanvasPlayer/demoSceneJson must stay absent, and noon-web must keep
+one PlaybackClock definition in crates/noon-web/src/clock.rs. Restore neither the
+old frontend nor a second clock while the residual ScenePlayer transport seam is
+being removed. See #959/A4 and #961/A6.8.
+EOF
+fi
+
 identity_authority_found=0
 canonical_identity_file='crates/noon-core/src/semantic_store.rs'
 
@@ -198,8 +250,8 @@ creating a second identity/store definition elsewhere. See #961/A6.3.
 EOF
 fi
 
-if (( migration_found != 0 || module_indirection_found != 0 || normalized_runtime_module_indirection_found != 0 || normalized_web_tool_player_dependency_found != 0 || scene_player_consumer_spread_found != 0 || identity_authority_found != 0 )); then
+if (( migration_found != 0 || module_indirection_found != 0 || normalized_runtime_module_indirection_found != 0 || normalized_web_tool_player_dependency_found != 0 || scene_player_consumer_spread_found != 0 || deleted_legacy_web_surface_found != 0 || identity_authority_found != 0 )); then
   exit 1
 fi
 
-echo "architecture migration-growth, module-growth, normalized-runtime-module, normalized-web-tool-player, ScenePlayer-consumer, and semantic-identity ratchets passed"
+echo "architecture migration-growth, module-growth, normalized-runtime-module, normalized-web-tool-player, ScenePlayer-consumer, deleted-legacy-web-surface, and semantic-identity ratchets passed"

--- a/scripts/architecture-ratchet.sh
+++ b/scripts/architecture-ratchet.sh
@@ -163,7 +163,7 @@ deleted_legacy_web_references="$(
     '(^|[^[:alnum:]_])(NoonCanvasPlayer|demoSceneJson)([^[:alnum:]_]|$)' \
     -- \
     'crates/noon-web/src' \
-    'web' \
+    'web/browser-smoke.js' \
     'scripts/check-web-package.mjs' \
     'scripts/browser-smoke.mjs' || true
 )"
@@ -201,11 +201,12 @@ fi
 if (( deleted_legacy_web_surface_found != 0 )); then
   cat >&2 <<'EOF'
 
-The duplicate legacy browser frontend and playback clock were deleted by #1003
-and #1005. NoonCanvasPlayer/demoSceneJson must stay absent, and noon-web must keep
-one PlaybackClock definition in crates/noon-web/src/clock.rs. Restore neither the
-old frontend nor a second clock while the residual ScenePlayer transport seam is
-being removed. See #959/A4 and #961/A6.8.
+The browser package/primary smoke boundary and duplicate playback clock were
+cleaned by #1003 and #1005. Those completed boundaries must not regain the
+NoonCanvasPlayer/demoSceneJson frontend, and noon-web must keep one PlaybackClock
+definition in crates/noon-web/src/clock.rs. Legacy performance tools that still
+use the old frontend remain separate A4 deletion debt; do not spread that debt
+back into cleaned product or validation paths. See #959/A4 and #961/A6.8.
 EOF
 fi
 

--- a/scripts/architecture-ratchet.test.sh
+++ b/scripts/architecture-ratchet.test.sh
@@ -84,7 +84,7 @@ expect_rejected() {
 reset_to_base() {
   git reset -q --hard "$BASE"
   rm -f src/new_hidden.rs src/duplicate_identity.rs src/runtime_structural_probe.rs src/web_tool_structural_probe.rs src/scene_player_spread_probe.rs src/deleted_legacy_web_probe.rs src/duplicate_clock_probe.rs src/legacy_clock_probe.rs
-  rm -f web/deleted_frontend_regression.js crates/noon-web/src/duplicate_clock.rs crates/noon-web/src/legacy/clock.rs
+  rm -f web/browser-smoke.js crates/noon-web/src/duplicate_clock.rs crates/noon-web/src/legacy/clock.rs
   rmdir crates/noon-web/src/legacy 2>/dev/null || true
 }
 
@@ -209,21 +209,21 @@ if bash scripts/architecture-ratchet.sh "$SCENE_PLAYER_SPREAD_BASE" >/dev/null 2
   exit 1
 fi
 
-# Prove the deleted #1003 browser frontend cannot return in a pre-existing base.
-# This is a full-tree absence check, not a current-diff keyword check.
+# Prove the cleaned #1003 primary browser smoke cannot regain the deleted frontend
+# even when the regression predates the current diff.
 reset_to_base
-cat > web/deleted_frontend_regression.js <<'EOF'
+cat > web/browser-smoke.js <<'EOF'
 export class NoonCanvasPlayer {}
 export function demoSceneJson() { return "{}"; }
 EOF
-git add web/deleted_frontend_regression.js
-git commit -qm "model deleted browser frontend returning"
+git add web/browser-smoke.js
+git commit -qm "model deleted primary browser frontend returning"
 DELETED_FRONTEND_REGRESSION_BASE="$(git rev-parse HEAD)"
 printf 'pub fn unrelated_after_deleted_frontend() {}\n' > src/deleted_legacy_web_probe.rs
 git add src/deleted_legacy_web_probe.rs
 git commit -qm "unrelated change after deleted frontend regression"
 if bash scripts/architecture-ratchet.sh "$DELETED_FRONTEND_REGRESSION_BASE" >/dev/null 2>&1; then
-  echo "architecture ratchet test failed: accepted deleted NoonCanvasPlayer/demoSceneJson surface" >&2
+  echo "architecture ratchet test failed: accepted deleted primary NoonCanvasPlayer/demoSceneJson surface" >&2
   exit 1
 fi
 

--- a/scripts/architecture-ratchet.test.sh
+++ b/scripts/architecture-ratchet.test.sh
@@ -6,7 +6,7 @@ RATCHET="$ROOT/scripts/architecture-ratchet.sh"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
-mkdir -p "$TMP/scripts" "$TMP/src" "$TMP/crates/noon-core/src" "$TMP/crates/noon-runtime/src" "$TMP/crates/noon-web/src"
+mkdir -p "$TMP/scripts" "$TMP/src" "$TMP/web" "$TMP/crates/noon-core/src" "$TMP/crates/noon-runtime/src" "$TMP/crates/noon-web/src"
 cp "$RATCHET" "$TMP/scripts/architecture-ratchet.sh"
 
 cd "$TMP"
@@ -61,7 +61,10 @@ use crate::ScenePlayer;
 EOF
 done
 
-git add scripts/architecture-ratchet.sh src crates/noon-core/src/semantic_store.rs crates/noon-runtime/src crates/noon-web/src
+# Model the canonical playback clock left after #1005 removed its legacy duplicate.
+printf 'pub struct PlaybackClock;\n' > crates/noon-web/src/clock.rs
+
+git add scripts/architecture-ratchet.sh src crates/noon-core/src/semantic_store.rs crates/noon-runtime/src crates/noon-web/src web
 git commit -qm "baseline with semantic authority, known A5 debt, and normalized islands"
 BASE="$(git rev-parse HEAD)"
 
@@ -80,7 +83,9 @@ expect_rejected() {
 
 reset_to_base() {
   git reset -q --hard "$BASE"
-  rm -f src/new_hidden.rs src/duplicate_identity.rs src/runtime_structural_probe.rs src/web_tool_structural_probe.rs src/scene_player_spread_probe.rs
+  rm -f src/new_hidden.rs src/duplicate_identity.rs src/runtime_structural_probe.rs src/web_tool_structural_probe.rs src/scene_player_spread_probe.rs src/deleted_legacy_web_probe.rs src/duplicate_clock_probe.rs src/legacy_clock_probe.rs
+  rm -f web/deleted_frontend_regression.js crates/noon-web/src/duplicate_clock.rs crates/noon-web/src/legacy/clock.rs
+  rmdir crates/noon-web/src/legacy 2>/dev/null || true
 }
 
 reset_to_base
@@ -201,6 +206,54 @@ git add src/scene_player_spread_probe.rs
 git commit -qm "unrelated change after ScenePlayer spread"
 if bash scripts/architecture-ratchet.sh "$SCENE_PLAYER_SPREAD_BASE" >/dev/null 2>&1; then
   echo "architecture ratchet test failed: accepted ScenePlayer consumer outside migration allowlist" >&2
+  exit 1
+fi
+
+# Prove the deleted #1003 browser frontend cannot return in a pre-existing base.
+# This is a full-tree absence check, not a current-diff keyword check.
+reset_to_base
+cat > web/deleted_frontend_regression.js <<'EOF'
+export class NoonCanvasPlayer {}
+export function demoSceneJson() { return "{}"; }
+EOF
+git add web/deleted_frontend_regression.js
+git commit -qm "model deleted browser frontend returning"
+DELETED_FRONTEND_REGRESSION_BASE="$(git rev-parse HEAD)"
+printf 'pub fn unrelated_after_deleted_frontend() {}\n' > src/deleted_legacy_web_probe.rs
+git add src/deleted_legacy_web_probe.rs
+git commit -qm "unrelated change after deleted frontend regression"
+if bash scripts/architecture-ratchet.sh "$DELETED_FRONTEND_REGRESSION_BASE" >/dev/null 2>&1; then
+  echo "architecture ratchet test failed: accepted deleted NoonCanvasPlayer/demoSceneJson surface" >&2
+  exit 1
+fi
+
+# Prove playback clock ownership remains singular after #1005.
+reset_to_base
+printf 'pub struct PlaybackClock;\n' > crates/noon-web/src/duplicate_clock.rs
+git add crates/noon-web/src/duplicate_clock.rs
+git commit -qm "model duplicate playback clock"
+DUPLICATE_CLOCK_REGRESSION_BASE="$(git rev-parse HEAD)"
+printf 'pub fn unrelated_after_duplicate_clock() {}\n' > src/duplicate_clock_probe.rs
+git add src/duplicate_clock_probe.rs
+git commit -qm "unrelated change after duplicate clock regression"
+if bash scripts/architecture-ratchet.sh "$DUPLICATE_CLOCK_REGRESSION_BASE" >/dev/null 2>&1; then
+  echo "architecture ratchet test failed: accepted duplicate PlaybackClock authority" >&2
+  exit 1
+fi
+
+# Prove the exact deleted legacy clock module path cannot be recreated even if it
+# does not itself declare another PlaybackClock yet.
+reset_to_base
+mkdir -p crates/noon-web/src/legacy
+printf 'pub fn stale_clock_module() {}\n' > crates/noon-web/src/legacy/clock.rs
+git add crates/noon-web/src/legacy/clock.rs
+git commit -qm "model deleted legacy clock path returning"
+LEGACY_CLOCK_REGRESSION_BASE="$(git rev-parse HEAD)"
+printf 'pub fn unrelated_after_legacy_clock() {}\n' > src/legacy_clock_probe.rs
+git add src/legacy_clock_probe.rs
+git commit -qm "unrelated change after legacy clock regression"
+if bash scripts/architecture-ratchet.sh "$LEGACY_CLOCK_REGRESSION_BASE" >/dev/null 2>&1; then
+  echo "architecture ratchet test failed: accepted deleted legacy clock module path" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Roadmap ownership

- Track V / A6.8 structural architecture ratchets: #961
- A4 deletion owner: #959
- Parent architecture roadmap: #953
- Protects completed deletions #1003 and #1005

## What changed

Turn the just-completed legacy web deletions into structural invariants:

- reject return of the deleted `NoonCanvasPlayer` or `demoSceneJson` surface inside `noon-web`, the generated-package contract, and the primary browser smoke path migrated by #1003;
- require exactly one `PlaybackClock` definition under `crates/noon-web/src`, owned by `crates/noon-web/src/clock.rs`;
- reject recreation of the deleted `crates/noon-web/src/legacy/clock.rs` module path;
- add self-tests that place each regression in the comparison base and then make an unrelated commit, proving these are full-tree ratchets rather than diff-only keyword checks.

## Architecture

This does not constrain the remaining `ScenePlayer` migration beyond the existing shrinking consumer allowlist. `legacy.rs` and `execution_transport.rs` remain the temporary allowed owner/consumer until A4 moves the transport kernel to the target retained/Semantic Scene execution path.

Several legacy performance pages still reference `NoonCanvasPlayer`; CI exposed those as separate A4 deletion/migration debt. This PR deliberately does not grandfather that debt as target architecture or claim it is already removed. It prevents the obsolete surface from spreading back into product/package/primary validation boundaries that have already been cleaned.

No compatibility surface, runtime behavior, module reorganization, or new authority is introduced.

## Validation

GitHub CI is the executable validation. The Architecture Ratchets workflow exercises the new positive and negative self-test cases; normal Fast Gate and layer checks should remain unaffected.

Refs #953 #959 #961 #1003 #1005.