### PR TITLE
Remove deleted demo frontend from renderer smoke

### DIFF
--- a/scripts/architecture-ratchet.sh
+++ b/scripts/architecture-ratchet.sh
@@ -164,6 +164,7 @@ deleted_legacy_web_references="$(
     -- \
     'crates/noon-web/src' \
     'web/browser-smoke.js' \
+    'web/execution-renderer-smoke.js' \
     'scripts/check-web-package.mjs' \
     'scripts/browser-smoke.mjs' || true
 )"
@@ -201,12 +202,12 @@ fi
 if (( deleted_legacy_web_surface_found != 0 )); then
   cat >&2 <<'EOF'
 
-The browser package/primary smoke boundary and duplicate playback clock were
-cleaned by #1003 and #1005. Those completed boundaries must not regain the
-NoonCanvasPlayer/demoSceneJson frontend, and noon-web must keep one PlaybackClock
-definition in crates/noon-web/src/clock.rs. Legacy performance tools that still
-use the old frontend remain separate A4 deletion debt; do not spread that debt
-back into cleaned product or validation paths. See #959/A4 and #961/A6.8.
+The browser package/smoke boundaries and duplicate playback clock were cleaned by
+#1003, #1005, and follow-up A4 migration. Those completed boundaries must not
+regain the NoonCanvasPlayer/demoSceneJson frontend, and noon-web must keep one
+PlaybackClock definition in crates/noon-web/src/clock.rs. Legacy performance tools
+that still use the old frontend remain separate A4 deletion debt; do not spread
+that debt back into cleaned product or validation paths. See #959/A4 and #961/A6.8.
 EOF
 fi
 

--- a/web/execution-renderer-smoke.js
+++ b/web/execution-renderer-smoke.js
@@ -1,7 +1,7 @@
 import init, {
+  AuthoringSceneCore,
   EngineScenePlayer,
   ExecutionCanvasRenderer,
-  demoSceneJson,
 } from "./pkg/noon_web.js";
 
 const state = {
@@ -14,7 +14,8 @@ window.noonExecutionRendererSmoke = state;
 
 async function start() {
   await init();
-  const engine = new EngineScenePlayer(demoSceneJson(), 4.0, 1);
+  const bootstrap = new AuthoringSceneCore();
+  const engine = new EngineScenePlayer(bootstrap.sceneJson(), 4.0, 1);
   const initialDelta = engine.initialDeltaJson();
   const canvas = new OffscreenCanvas(960, 540);
   const renderer = await ExecutionCanvasRenderer.create(canvas, initialDelta);


### PR DESCRIPTION
## Roadmap ownership

- A4 legacy/mixed execution deletion: #959
- Track V structural handoff: #961
- Parent roadmap: #953
- Follows #1003 and #1007

## What changed

Finish the renderer smoke migration that #1003 exposed:

- replace the deleted `demoSceneJson()` package export with an empty bootstrap authored through `AuthoringSceneCore`;
- keep `EngineScenePlayer -> ExecutionCanvasRenderer` as the actual execution/render path under test;
- extend the completed-boundary ratchet so `web/execution-renderer-smoke.js` cannot regain `NoonCanvasPlayer` or `demoSceneJson`.

## Architecture

This removes one more browser-side dependency on the deleted legacy frontend without introducing another scene document, renderer wrapper, or compatibility export. The smoke now bootstraps through the surviving authoring surface and immediately crosses the same `EngineScenePlayer`/typed execution-delta boundary as the primary renderer smoke.

The remaining performance pages that still import `NoonCanvasPlayer` are separate A4 debt; this PR does not pretend those are migrated.

## Validation

GitHub CI is the executable validation. Architecture ratchets should prove the deleted surface stays absent from this smoke, while normal browser/package checks validate the generated WASM surface.

Refs #953 #959 #961 #1003 #1007.