### PR TITLE
Migrate active performance profile off deleted canvas player

### DIFF
--- a/web/perf-profile.js
+++ b/web/perf-profile.js
@@ -1,7 +1,11 @@
 import init, { EngineScenePlayer, ExecutionCanvasRenderer } from "./pkg/noon_web.js";
 import { BrowserJankMonitor, estimateUnattributedFrameMs } from "./browser-jank.js";
 import { FrameMetrics, SampleWindow } from "./frame-metrics.js";
-import { ANALYTIC_LAYOUTS, buildAnalyticScene } from "./perf-workloads.js";
+import {
+  ANALYTIC_LAYOUTS,
+  buildAnalyticScene,
+  installIncrementalPositionDriver,
+} from "./perf-workloads.js";
 import {
   drainRendererGpuDiagnostics,
   formatGpuDiagnostic,
@@ -38,7 +42,7 @@ let workload = null;
 try {
   await init();
   workload = buildAnalyticScene({ count: objectCount, layout, aspect: width / height });
-  installIncrementalDriver(workload.document, driverDurationSeconds);
+  installIncrementalPositionDriver(workload.document, driverDurationSeconds);
 
   const sceneJson = JSON.stringify(workload.document);
   const createStarted = performance.now();
@@ -176,37 +180,6 @@ try {
   browserJank.stop();
   renderer?.free?.();
   engine?.free?.();
-}
-
-function installIncrementalDriver(document, durationSeconds) {
-  if (!Array.isArray(document.objects) || document.objects.length === 0) {
-    throw new Error("performance workload must contain at least one object");
-  }
-  if (!Array.isArray(document.tracks) || document.tracks.length !== 0) {
-    throw new Error("analytic performance workload must start without animation tracks");
-  }
-
-  const object = document.objects[0];
-  const from = object.transform?.translation;
-  if (!from || !Number.isFinite(from.x) || !Number.isFinite(from.y)) {
-    throw new Error("performance driver object must have a finite translation");
-  }
-  document.tracks.push({
-    id: 0,
-    object: object.id,
-    property: "position",
-    values: {
-      vec2: {
-        from: { x: from.x, y: from.y },
-        to: { x: from.x + 8, y: from.y },
-      },
-    },
-    timing: {
-      start_time: 0,
-      duration: durationSeconds,
-      easing: "linear",
-    },
-  });
 }
 
 function presentSceneTime(sceneTime) {

--- a/web/perf-profile.js
+++ b/web/perf-profile.js
@@ -196,8 +196,8 @@ function presentSceneTime(sceneTime) {
   if (!renderer.applyDeltaJson(delta)) {
     throw new Error(`renderer rejected incremental performance delta at t=${sceneTime}`);
   }
-  // The synthetic SceneDefinition has no authored camera object. Keep the
-  // profiling viewport explicit after each transport delta updates mirror state.
+  // This synthetic workload has no authored camera object. Keep the profiling
+  // viewport explicit after each transport delta updates mirror state.
   renderer.setCamera(0, 0, workload.cameraHeight);
   drainGpuDiagnostics();
   const transportApplyMs = performance.now() - applyStarted;

--- a/web/perf-profile.js
+++ b/web/perf-profile.js
@@ -1,8 +1,11 @@
-import init, { NoonCanvasPlayer } from "./pkg/noon_web.js";
+import init, { EngineScenePlayer, ExecutionCanvasRenderer } from "./pkg/noon_web.js";
 import { BrowserJankMonitor, estimateUnattributedFrameMs } from "./browser-jank.js";
 import { FrameMetrics, SampleWindow } from "./frame-metrics.js";
-import { readCompletePlayerFrameMetrics } from "./player-frame-metrics.js";
 import { ANALYTIC_LAYOUTS, buildAnalyticScene } from "./perf-workloads.js";
+import {
+  drainRendererGpuDiagnostics,
+  formatGpuDiagnostic,
+} from "./render-gpu-diagnostics.js";
 
 const parameters = new URLSearchParams(location.search);
 const objectCount = positiveInteger("objects", 10_000);
@@ -23,74 +26,66 @@ canvas.width = width;
 canvas.height = height;
 canvas.style.aspectRatio = `${width} / ${height}`;
 
-let player = null;
+const driverDurationSeconds = Math.max(
+  60,
+  ((warmupFrames + measuredFrames + 16) / targetHz) * 2,
+);
 const browserJank = new BrowserJankMonitor();
+let engine = null;
+let renderer = null;
+let workload = null;
+
 try {
   await init();
-  const workload = buildAnalyticScene({ count: objectCount, layout, aspect: width / height });
-  const createStarted = performance.now();
-  player = await NoonCanvasPlayer.create(canvas, JSON.stringify(workload.document), 4.0);
-  const playerCreateMs = performance.now() - createStarted;
-  player.resize(width, height);
-  player.setCamera(0, 0, workload.cameraHeight);
+  workload = buildAnalyticScene({ count: objectCount, layout, aspect: width / height });
+  installIncrementalDriver(workload.document, driverDurationSeconds);
 
-  const gpuSupported = player.gpuProfilingSupported();
-  player.setGpuProfilingEnabled(gpuSupported);
-  player.resetGpuProfiling();
+  const sceneJson = JSON.stringify(workload.document);
+  const createStarted = performance.now();
+  engine = new EngineScenePlayer(sceneJson, driverDurationSeconds, 1);
+  const offscreen = canvas.transferControlToOffscreen();
+  renderer = await ExecutionCanvasRenderer.create(offscreen, engine.initialDeltaJson());
+  renderer.resize(width, height);
+  renderer.setCamera(0, 0, workload.cameraHeight);
+  if (!presentPending()) {
+    throw new Error("initial performance frame was not presented");
+  }
+  const playerCreateMs = performance.now() - createStarted;
 
   status.value = `Warming ${layout} / ${objectCount.toLocaleString()} objects…`;
   for (let frame = 0; frame < warmupFrames; frame += 1) {
-    const timestamp = await nextAnimationFrame();
-    player.renderFrame(timestamp);
+    await nextAnimationFrame();
+    presentSceneTime((frame + 1) / targetHz);
   }
 
-  player.resetGpuProfiling();
-  player.resetClock();
+  // Keep the measurement phase deterministic across devices. Browser rAF owns
+  // cadence sampling only; semantic scene time advances by one target-Hz step.
+  presentSceneTime(0);
   const cadence = new FrameMetrics({ targetHz });
   const windows = {
     cpuFrameMs: new SampleWindow(measuredFrames),
     runtimeMs: new SampleWindow(measuredFrames),
-    prepareMs: new SampleWindow(measuredFrames),
-    uploadMs: new SampleWindow(measuredFrames),
-    encodeSubmitMs: new SampleWindow(measuredFrames),
+    transportApplyMs: new SampleWindow(measuredFrames),
+    rendererRenderMs: new SampleWindow(measuredFrames),
     unattributedFrameMs: new SampleWindow(measuredFrames),
   };
   browserJank.start();
   const measurementStartMs = performance.now();
   let previousTimestamp = null;
-  let incompleteMetricFrames = 0;
   let measured = 0;
   while (measured < measuredFrames) {
     status.value = `Measuring ${measured + 1}/${measuredFrames} · ${layout} / ${objectCount.toLocaleString()} objects…`;
     const timestamp = await nextAnimationFrame();
-    const started = performance.now();
-    const presented = player.renderFrame(timestamp);
-    const browserCallMs = performance.now() - started;
-    if (!presented) {
-      previousTimestamp = null;
-      continue;
-    }
+    const timings = presentSceneTime((measured + 1) / targetHz);
 
-    const metrics = readCompletePlayerFrameMetrics(player);
-    if (metrics === null) {
-      // GPU/context recovery can replace renderer-owned instrumentation between
-      // runtime evaluation and presentation. Exclude that whole frame rather than
-      // mixing partial measurements into percentile windows. The skipped count is
-      // reported so repeated recovery remains visible instead of being hidden.
-      incompleteMetricFrames += 1;
-      previousTimestamp = null;
-      continue;
-    }
-
-    cadence.record(timestamp, browserCallMs);
-    windows.cpuFrameMs.record(metrics.cpuFrameMs);
-    windows.runtimeMs.record(metrics.runtimeMs);
-    windows.prepareMs.record(metrics.prepareMs);
-    windows.uploadMs.record(metrics.uploadMs);
-    windows.encodeSubmitMs.record(metrics.encodeSubmitMs);
+    cadence.record(timestamp, timings.cpuFrameMs);
+    windows.cpuFrameMs.record(timings.cpuFrameMs);
+    windows.runtimeMs.record(timings.runtimeMs);
+    windows.transportApplyMs.record(timings.transportApplyMs);
+    windows.rendererRenderMs.record(timings.rendererRenderMs);
     if (previousTimestamp !== null) {
       windows.unattributedFrameMs.record(
-        estimateUnattributedFrameMs(timestamp - previousTimestamp, metrics.cpuFrameMs),
+        estimateUnattributedFrameMs(timestamp - previousTimestamp, timings.cpuFrameMs),
       );
     }
     previousTimestamp = timestamp;
@@ -99,36 +94,38 @@ try {
   const measurementEndMs = performance.now();
   browserJank.stop();
 
-  await waitForGpuSamples(player, gpuSupported, measuredFrames);
   const frame = cadence.summary();
   const report = {
     schemaVersion: 1,
-    benchmark: "Noon end-to-end analytic frame profile",
+    benchmark: "Noon incremental analytic frame profile",
     generatedAt: new Date().toISOString(),
     workload: {
-      family: "analytic-static",
+      family: "analytic-incremental",
       layout,
-      description: workload.description,
+      description:
+        `${workload.description}; one object carries a deterministic position track ` +
+        "so each frame crosses the execution-delta boundary without rebuilding the scene",
       objects: objectCount,
+      incrementalDriverObjects: 1,
+      driverDurationSeconds,
     },
     environment: {
       userAgent: navigator.userAgent,
-      rendererBackend: player.rendererBackend(),
+      rendererBackend: renderer.rendererBackend(),
       hardwareConcurrency: navigator.hardwareConcurrency ?? null,
       deviceMemoryGiB: navigator.deviceMemory ?? null,
       devicePixelRatio: window.devicePixelRatio || 1,
       canvasCssSize: [canvas.clientWidth, canvas.clientHeight],
       backingResolution: [width, height],
       targetHz,
-      observedRefreshHz:
-        frame.interval?.p50 > 0 ? 1000 / frame.interval.p50 : null,
+      observedRefreshHz: frame.interval?.p50 > 0 ? 1000 / frame.interval.p50 : null,
       crossOriginIsolated: window.crossOriginIsolated,
     },
     setup: {
       playerCreateMs,
       warmupFrames,
       measuredFrames: frame.frames,
-      incompleteMetricFrames,
+      incompleteMetricFrames: 0,
     },
     cadence: {
       frameIntervalMs: frame.interval,
@@ -142,33 +139,25 @@ try {
     cpu: {
       frameMs: windows.cpuFrameMs.summary(),
       runtimeEvaluationMs: windows.runtimeMs.summary(),
-      framePrepareMs: windows.prepareMs.summary(),
-      uploadMs: windows.uploadMs.summary(),
-      encodeSubmitMs: windows.encodeSubmitMs.summary(),
+      transportApplyMs: windows.transportApplyMs.summary(),
+      rendererRenderMs: windows.rendererRenderMs.summary(),
+      // The split execution renderer currently exposes aggregate render-host
+      // timing rather than the deleted monolith's prepare/upload/encode timers.
+      framePrepareMs: null,
+      uploadMs: null,
+      encodeSubmitMs: null,
     },
     renderer: {
-      drawCalls: player.lastDrawCalls(),
-      instances: player.lastInstancesDrawn(),
-      lastUploadBytes: player.lastBytesUploaded(),
-      geometryCacheMisses: player.lastGeometryCacheMisses(),
+      drawCalls: renderer.lastDrawCalls(),
+      instances: renderer.lastInstancesDrawn(),
+      lastUploadBytes: renderer.lastBytesUploaded(),
+      geometryCacheMisses: renderer.lastGeometryCacheMisses(),
     },
-    gpu: gpuSupported
-      ? {
-          timestampSupported: true,
-          samples: player.gpuProfiledFrameCount(),
-          dropped: player.gpuDroppedSampleCount(),
-          failed: player.gpuFailedSampleCount(),
-          renderPassMs: {
-            p50: finiteOrNull(player.gpuRenderP50Ms()),
-            p95: finiteOrNull(player.gpuRenderP95Ms()),
-            p99:
-              typeof player.gpuRenderP99Ms === "function"
-                ? finiteOrNull(player.gpuRenderP99Ms())
-                : null,
-            last: finiteOrNull(player.lastGpuRenderMs()),
-          },
-        }
-      : { timestampSupported: false },
+    gpu: {
+      timestampSupported: false,
+      unavailableReason:
+        "ExecutionCanvasRenderer does not yet expose WebGPU timestamp-query profiling",
+    },
   };
 
   window.__NOON_PERF_REPORT__ = report;
@@ -185,23 +174,99 @@ try {
   status.dataset.state = "error";
 } finally {
   browserJank.stop();
-  player?.free?.();
+  renderer?.free?.();
+  engine?.free?.();
 }
 
-async function waitForGpuSamples(player, supported, expectedFrames) {
-  if (!supported) {
-    return;
+function installIncrementalDriver(document, durationSeconds) {
+  if (!Array.isArray(document.objects) || document.objects.length === 0) {
+    throw new Error("performance workload must contain at least one object");
   }
-  const deadline = performance.now() + 2_000;
-  while (performance.now() < deadline) {
-    const accounted =
-      player.gpuProfiledFrameCount() +
-      player.gpuDroppedSampleCount() +
-      player.gpuFailedSampleCount();
-    if (accounted >= expectedFrames) {
-      return;
+  if (!Array.isArray(document.tracks) || document.tracks.length !== 0) {
+    throw new Error("analytic performance workload must start without animation tracks");
+  }
+
+  const object = document.objects[0];
+  const from = object.transform?.translation;
+  if (!from || !Number.isFinite(from.x) || !Number.isFinite(from.y)) {
+    throw new Error("performance driver object must have a finite translation");
+  }
+  document.tracks.push({
+    id: 0,
+    object: object.id,
+    property: "position",
+    values: {
+      vec2: {
+        from: { x: from.x, y: from.y },
+        to: { x: from.x + 8, y: from.y },
+      },
+    },
+    timing: {
+      start_time: 0,
+      duration: durationSeconds,
+      easing: "linear",
+    },
+  });
+}
+
+function presentSceneTime(sceneTime) {
+  const frameStarted = performance.now();
+
+  const runtimeStarted = performance.now();
+  const delta = engine.seekDeltaJson(sceneTime);
+  const runtimeMs = performance.now() - runtimeStarted;
+  if (delta === undefined || delta === null) {
+    throw new Error(`incremental performance driver emitted no delta at t=${sceneTime}`);
+  }
+
+  const applyStarted = performance.now();
+  if (!renderer.applyDeltaJson(delta)) {
+    throw new Error(`renderer rejected incremental performance delta at t=${sceneTime}`);
+  }
+  // The synthetic SceneDefinition has no authored camera object. Keep the
+  // profiling viewport explicit after each transport delta updates mirror state.
+  renderer.setCamera(0, 0, workload.cameraHeight);
+  drainGpuDiagnostics();
+  const transportApplyMs = performance.now() - applyStarted;
+
+  const renderStarted = performance.now();
+  if (!presentPending()) {
+    throw new Error(`performance frame was not presented at t=${sceneTime}`);
+  }
+  const rendererRenderMs = performance.now() - renderStarted;
+
+  return {
+    cpuFrameMs: performance.now() - frameStarted,
+    runtimeMs,
+    transportApplyMs,
+    rendererRenderMs,
+  };
+}
+
+function presentPending() {
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    drainGpuDiagnostics();
+    const presented = renderer.render();
+    drainGpuDiagnostics();
+    if (presented) {
+      return true;
     }
-    await nextAnimationFrame();
+  }
+  return false;
+}
+
+function drainGpuDiagnostics() {
+  let fatal = null;
+  const healthy = drainRendererGpuDiagnostics(renderer, {
+    onRecoverable(diagnostic) {
+      console.warn(formatGpuDiagnostic(diagnostic));
+    },
+    onFatal(diagnostic) {
+      fatal = new Error(formatGpuDiagnostic(diagnostic));
+    },
+  });
+  if (!healthy) {
+    throw fatal ?? new Error("renderer reported a fatal GPU diagnostic");
   }
 }
 
@@ -231,10 +296,6 @@ function positiveNumber(name, fallback) {
     throw new Error(`${name} must be a positive number`);
   }
   return parsed;
-}
-
-function finiteOrNull(value) {
-  return Number.isFinite(value) ? value : null;
 }
 
 function formatNumber(value) {

--- a/web/perf-workloads.js
+++ b/web/perf-workloads.js
@@ -20,6 +20,45 @@ export function buildAnalyticScene({ count, layout = "fit", aspect = 16 / 9 } = 
   return buildOverdraw(count);
 }
 
+export function installIncrementalPositionDriver(document, durationSeconds, distance = 8) {
+  if (!Number.isFinite(durationSeconds) || durationSeconds <= 0) {
+    throw new RangeError("incremental driver duration must be positive and finite");
+  }
+  if (!Number.isFinite(distance) || distance === 0) {
+    throw new RangeError("incremental driver distance must be finite and non-zero");
+  }
+  if (!Array.isArray(document?.objects) || document.objects.length === 0) {
+    throw new Error("performance workload must contain at least one object");
+  }
+  if (!Array.isArray(document.tracks) || document.tracks.length !== 0) {
+    throw new Error("analytic performance workload must start without animation tracks");
+  }
+
+  const object = document.objects[0];
+  const from = object.transform?.translation;
+  if (!from || !Number.isFinite(from.x) || !Number.isFinite(from.y)) {
+    throw new Error("performance driver object must have a finite translation");
+  }
+  const to = { x: from.x + distance, y: from.y };
+  document.tracks.push({
+    id: 0,
+    object: object.id,
+    property: "position",
+    values: {
+      vec2: {
+        from: { x: from.x, y: from.y },
+        to,
+      },
+    },
+    timing: {
+      start_time: 0,
+      duration: durationSeconds,
+      easing: "linear",
+    },
+  });
+  return { object: object.id, from: { x: from.x, y: from.y }, to, durationSeconds };
+}
+
 function buildFitGrid(count, aspect) {
   const columns = Math.ceil(Math.sqrt(count * aspect));
   const rows = Math.ceil(count / columns);

--- a/web/perf-workloads.test.mjs
+++ b/web/perf-workloads.test.mjs
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { ANALYTIC_LAYOUTS, buildAnalyticScene } from "./perf-workloads.js";
+import {
+  ANALYTIC_LAYOUTS,
+  buildAnalyticScene,
+  installIncrementalPositionDriver,
+} from "./perf-workloads.js";
 
 test("analytic workloads are deterministic and preserve requested object count", () => {
   for (const layout of ANALYTIC_LAYOUTS) {
@@ -37,8 +41,49 @@ test("overdraw workload keeps transparent objects concentrated near the origin",
   }
 });
 
+test("incremental driver dirties exactly one object through a deterministic position track", () => {
+  const workload = buildAnalyticScene({ count: 10, layout: "fit" });
+  const original = { ...workload.document.objects[0].transform.translation };
+  const driver = installIncrementalPositionDriver(workload.document, 120, 8);
+
+  assert.equal(workload.document.tracks.length, 1);
+  assert.deepEqual(workload.document.tracks[0], {
+    id: 0,
+    object: 0,
+    property: "position",
+    values: {
+      vec2: {
+        from: original,
+        to: { x: original.x + 8, y: original.y },
+      },
+    },
+    timing: {
+      start_time: 0,
+      duration: 120,
+      easing: "linear",
+    },
+  });
+  assert.deepEqual(driver, {
+    object: 0,
+    from: original,
+    to: { x: original.x + 8, y: original.y },
+    durationSeconds: 120,
+  });
+  assert.equal(workload.document.objects.length, 10);
+});
+
 test("analytic workload parameters reject invalid values", () => {
   assert.throws(() => buildAnalyticScene({ count: 0 }), /positive integer/);
   assert.throws(() => buildAnalyticScene({ count: 1, layout: "unknown" }), /unknown analytic layout/);
   assert.throws(() => buildAnalyticScene({ count: 1, aspect: 0 }), /positive finite/);
+
+  const workload = buildAnalyticScene({ count: 1 });
+  assert.throws(
+    () => installIncrementalPositionDriver(workload.document, 0),
+    /duration must be positive/,
+  );
+  assert.throws(
+    () => installIncrementalPositionDriver(workload.document, 1, 0),
+    /distance must be finite and non-zero/,
+  );
 });


### PR DESCRIPTION
## Roadmap ownership

- A4 legacy/mixed execution deletion: #959
- Track V executable evidence: #961
- Parent roadmap: #953
- Follows #1003, #1007, and #1008

## Problem

#1003 correctly deleted the monolithic `NoonCanvasPlayer`, but the active physical-device baseline still launches `web/perf-profile.html`. Its page imported the deleted export, so `.github/workflows/perf-physical-device.yml -> scripts/perf-device-run.mjs -> scripts/perf-profile.mjs` could no longer run the frame suite.

## What changed

- move `web/perf-profile.js` onto the existing split `EngineScenePlayer -> execution delta -> ExecutionCanvasRenderer` path;
- convert the synthetic static workload into an explicit incremental benchmark by giving exactly one object a deterministic position track;
- advance semantic scene time deterministically while using browser rAF only for cadence sampling;
- measure execution-delta creation, renderer transport application, aggregate renderer host time, end-to-end CPU frame time, draw/instance counts, upload bytes, and geometry-cache misses;
- keep the full 1k/10k/100k scene in the renderer while only one object is dirty per frame, so the benchmark exercises local runtime/upload work plus full draw scaling instead of forcing full snapshots;
- add and unit-test `installIncrementalPositionDriver` in `web/perf-workloads.js`.

## GPU timestamp accounting

The deleted monolithic player owned WebGPU timestamp-query profiling. `ExecutionCanvasRenderer` does not expose that capability yet. This PR reports `gpu.timestampSupported: false` with an explicit reason rather than recreating the monolith or inventing timings. `NOON_PERF_REQUIRE_GPU_TIMESTAMPS=1` therefore continues to fail clearly until timestamp profiling is reintroduced at the target renderer/host boundary.

## Architecture

This is an incremental A4 cutover, not the final execution-owner deletion: `EngineScenePlayer` is still the residual transport seam tracked by #959. The browser profiler no longer depends on the deleted canvas/player authority and now measures the split engine/renderer architecture that Phase A is converging on.

## Validation

- `web/perf-workloads.test.mjs` validates the one-object incremental driver shape and invariants.
- PR Fast Gate should run web static/unit checks, Rust checks, package build, and browser smoke against the same WASM surface.

Refs #953 #959 #961 #1003 #1007 #1008.