### PR TITLE
Ratchet active performance pages off deleted browser frontend

### DIFF
--- a/.github/workflows/architecture-ratchets.yml
+++ b/.github/workflows/architecture-ratchets.yml
@@ -25,10 +25,18 @@ jobs:
           fetch-depth: 0
 
       - name: Validate guardrail scripts
-        run: bash -n scripts/check.sh scripts/architecture-ratchet.sh scripts/architecture-ratchet.test.sh
+        run: >-
+          bash -n
+          scripts/check.sh
+          scripts/architecture-ratchet.sh
+          scripts/architecture-ratchet.test.sh
+          scripts/active-perf-frontend-ratchet.sh
+          scripts/active-perf-frontend-ratchet.test.sh
 
       - name: Exercise architecture guardrails
-        run: bash scripts/architecture-ratchet.test.sh
+        run: |
+          bash scripts/architecture-ratchet.test.sh
+          bash scripts/active-perf-frontend-ratchet.test.sh
 
       - name: Reject architecture regressions
         env:
@@ -43,3 +51,4 @@ jobs:
             base="HEAD^"
           fi
           bash scripts/architecture-ratchet.sh "$base"
+          bash scripts/active-perf-frontend-ratchet.sh

--- a/scripts/active-perf-frontend-ratchet.sh
+++ b/scripts/active-perf-frontend-ratchet.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+status=0
+for path in web/perf-profile.js web/scene-perf.js; do
+  if [[ ! -f "$path" ]]; then
+    printf 'active perf frontend ratchet: required migrated performance page is missing: %s\n' "$path" >&2
+    status=1
+    continue
+  fi
+
+  matches="$(
+    grep -nE '(^|[^[:alnum:]_])(NoonCanvasPlayer|demoSceneJson)([^[:alnum:]_]|$)' "$path" || true
+  )"
+  if [[ -n "$matches" ]]; then
+    printf 'active perf frontend ratchet: deleted browser frontend returned in %s\n' "$path" >&2
+    printf '%s\n' "$matches" >&2
+    status=1
+  fi
+done
+
+if (( status != 0 )); then
+  cat >&2 <<'EOF'
+
+The workflow-backed performance profiles were migrated to the split execution
+engine / renderer boundary by #1011 and #1012. They must not regain the deleted
+NoonCanvasPlayer/demoSceneJson frontend. Keep EngineScenePlayer as the temporary
+A4 transport seam until its own deletion lands. See #959/A4 and #961/A6.8.
+EOF
+  exit 1
+fi
+
+echo "active performance frontend absence ratchet passed"

--- a/scripts/active-perf-frontend-ratchet.test.sh
+++ b/scripts/active-perf-frontend-ratchet.test.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RATCHET="$ROOT/scripts/active-perf-frontend-ratchet.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+mkdir -p "$TMP/scripts" "$TMP/web"
+cp "$RATCHET" "$TMP/scripts/active-perf-frontend-ratchet.sh"
+
+cat > "$TMP/web/perf-profile.js" <<'EOF'
+import { EngineScenePlayer, ExecutionCanvasRenderer } from "./pkg/noon_web.js";
+EOF
+cat > "$TMP/web/scene-perf.js" <<'EOF'
+import { EngineScenePlayer, ExecutionCanvasRenderer } from "./pkg/noon_web.js";
+EOF
+
+(
+  cd "$TMP"
+  bash scripts/active-perf-frontend-ratchet.sh >/dev/null
+)
+
+expect_rejected() {
+  label="$1"
+  if (
+    cd "$TMP"
+    bash scripts/active-perf-frontend-ratchet.sh >/dev/null 2>&1
+  ); then
+    echo "active perf frontend ratchet test failed: accepted $label" >&2
+    exit 1
+  fi
+}
+
+cat > "$TMP/web/perf-profile.js" <<'EOF'
+import { NoonCanvasPlayer } from "./pkg/noon_web.js";
+EOF
+expect_rejected 'NoonCanvasPlayer in perf-profile.js'
+
+cat > "$TMP/web/perf-profile.js" <<'EOF'
+import { EngineScenePlayer, ExecutionCanvasRenderer } from "./pkg/noon_web.js";
+EOF
+cat > "$TMP/web/scene-perf.js" <<'EOF'
+const source = demoSceneJson();
+EOF
+expect_rejected 'demoSceneJson in scene-perf.js'
+
+rm "$TMP/web/scene-perf.js"
+expect_rejected 'missing migrated scene-perf.js'
+
+echo "active performance frontend absence ratchet self-test passed"


### PR DESCRIPTION
## Roadmap ownership

- A4 legacy/mixed execution deletion: #959
- A6 structural architecture ratchets: #961
- Parent roadmap: #953
- Follows #1011 and #1012

## What changed

Add a dedicated structural ratchet for the two workflow-backed performance pages migrated in #1011 and #1012:

- `web/perf-profile.js`
- `web/scene-perf.js`

The ratchet rejects either deleted frontend symbol (`NoonCanvasPlayer` or `demoSceneJson`) from returning in those files, and rejects either migrated page disappearing unexpectedly.

A focused self-test proves:

- the current `EngineScenePlayer` / `ExecutionCanvasRenderer` imports are accepted;
- `NoonCanvasPlayer` returning in `perf-profile.js` is rejected;
- `demoSceneJson` returning in `scene-perf.js` is rejected;
- a missing migrated performance page is rejected.

The existing `Architecture Ratchets` workflow now syntax-checks, self-tests, and executes this guardrail alongside the general architecture ratchet.

## Scope

This deliberately does **not** forbid `EngineScenePlayer`: that remains the explicit shrinking A4 transport seam tracked by #959. The ratchet protects only the completed browser-frontend cutover and does not claim final execution-owner deletion.

Refs #953 #959 #961 #1011 #1012.