### PR TITLE
Split transform geometry compilation from compiler root

### DIFF
--- a/crates/noon-compile/src/lib.rs
+++ b/crates/noon-compile/src/lib.rs
@@ -2,6 +2,8 @@
 
 #![forbid(unsafe_code)]
 
+mod transform;
+
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
 
@@ -9,8 +11,11 @@ use noon_core::{
     validate_object_definition, validate_property_patch, validate_track_definition,
     CompositionTimeMap, GeometryRef, MutationTransaction, ObjectId, ObjectStateField, Property,
     SceneDefinition, ScenePatch, Style, TimelineError, TrackDefinition, TrackId, TrackTiming,
-    TrackValues, Transform2D, VectorPath,
+    TrackValues, Transform2D,
 };
+use transform::{compile_transform_geometry_plan, TransformCompileFailure};
+
+pub use transform::TransformGeometryPlan;
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct DynamicProperties {
@@ -63,27 +68,6 @@ pub struct CompiledObject {
     /// Whether this stable compiled slot currently contains a live scene object.
     /// Removed objects leave tombstones so unrelated slot numbers never change.
     pub live: bool,
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub enum TransformGeometryPlan {
-    Static,
-    PointwiseRotation,
-    Circle {
-        from_radius: f32,
-        to_radius: f32,
-    },
-    Rectangle {
-        from_size: noon_core::Vec2,
-        to_size: noon_core::Vec2,
-    },
-    Line {
-        from_start: noon_core::Vec2,
-        from_end: noon_core::Vec2,
-        to_start: noon_core::Vec2,
-        to_end: noon_core::Vec2,
-    },
-    PathPair(GeometryRef),
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -904,13 +888,6 @@ impl CompiledScene {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum TransformCompileFailure {
-    UnsupportedGeometry,
-    RequiresRetessellation,
-    UnsafeFilledPath,
-}
-
 fn compile_track(
     track: &TrackDefinition,
     object_index: u32,
@@ -924,106 +901,6 @@ fn compile_track(
         time_map: track.time_map.clone(),
         transform_geometry_plan: compile_transform_geometry_plan(track)?,
     })
-}
-
-fn compile_transform_geometry_plan(
-    track: &TrackDefinition,
-) -> Result<Option<TransformGeometryPlan>, TransformCompileFailure> {
-    if track.property != Property::Transform {
-        return Ok(None);
-    }
-    let TrackValues::Object { from, to } = &track.values else {
-        unreachable!("validated Transform track must contain object snapshots");
-    };
-
-    if let (GeometryRef::VectorPath(_), GeometryRef::VectorPath(_)) = (&from.geometry, &to.geometry)
-    {
-        if path_style_requires_retessellation(from.style, to.style) {
-            return Err(TransformCompileFailure::RequiresRetessellation);
-        }
-    }
-
-    if from.geometry == to.geometry {
-        if from.transform.scale == to.transform.scale
-            && from.transform.rotation.to_bits() != to.transform.rotation.to_bits()
-        {
-            return Ok(Some(TransformGeometryPlan::PointwiseRotation));
-        }
-        return Ok(Some(TransformGeometryPlan::Static));
-    }
-
-    let plan = match (&from.geometry, &to.geometry) {
-        (
-            GeometryRef::Circle {
-                radius: from_radius,
-            },
-            GeometryRef::Circle { radius: to_radius },
-        ) => TransformGeometryPlan::Circle {
-            from_radius: *from_radius,
-            to_radius: *to_radius,
-        },
-        (GeometryRef::Rectangle { size: from_size }, GeometryRef::Rectangle { size: to_size }) => {
-            TransformGeometryPlan::Rectangle {
-                from_size: *from_size,
-                to_size: *to_size,
-            }
-        }
-        (
-            GeometryRef::Line {
-                start: from_start,
-                end: from_end,
-            },
-            GeometryRef::Line {
-                start: to_start,
-                end: to_end,
-            },
-        ) => TransformGeometryPlan::Line {
-            from_start: *from_start,
-            from_end: *from_end,
-            to_start: *to_start,
-            to_end: *to_end,
-        },
-        (GeometryRef::VectorPath(source), GeometryRef::VectorPath(target)) => {
-            compile_path_pair(from, to, source.clone(), target.clone())?
-        }
-        (GeometryRef::Circle { .. }, GeometryRef::Rectangle { .. })
-        | (GeometryRef::Rectangle { .. }, GeometryRef::Circle { .. }) => {
-            let source = noon_geometry::canonical_outline_path(&from.geometry)
-                .expect("closed analytic source geometry must convert to a path");
-            let target = noon_geometry::canonical_outline_path(&to.geometry)
-                .expect("closed analytic target geometry must convert to a path");
-            compile_path_pair(from, to, source, target)?
-        }
-        _ => return Err(TransformCompileFailure::UnsupportedGeometry),
-    };
-    Ok(Some(plan))
-}
-
-fn path_style_requires_retessellation(from: Style, to: Style) -> bool {
-    from.stroke_width.to_bits() != to.stroke_width.to_bits()
-        || from.stroke_join != to.stroke_join
-        || from.stroke_cap != to.stroke_cap
-        || from.fill.is_some() != to.fill.is_some()
-}
-
-fn compile_path_pair(
-    from: &noon_core::ObjectSnapshot,
-    to: &noon_core::ObjectSnapshot,
-    source: VectorPath,
-    target: VectorPath,
-) -> Result<TransformGeometryPlan, TransformCompileFailure> {
-    if path_style_requires_retessellation(from.style, to.style) {
-        return Err(TransformCompileFailure::RequiresRetessellation);
-    }
-    if from.style.fill.is_some()
-        && noon_geometry::plan_filled_morph(&source, &target, noon_geometry::MorphOptions::DEFAULT)
-            .is_err()
-    {
-        return Err(TransformCompileFailure::UnsafeFilledPath);
-    }
-    Ok(TransformGeometryPlan::PathPair(GeometryRef::path(
-        source.with_morph_target(target),
-    )))
 }
 
 fn compile_error(id: TrackId, error: TransformCompileFailure) -> CompileError {

--- a/crates/noon-compile/src/transform.rs
+++ b/crates/noon-compile/src/transform.rs
@@ -1,0 +1,129 @@
+use noon_core::{GeometryRef, ObjectSnapshot, Property, Style, TrackDefinition, TrackValues, VectorPath};
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum TransformGeometryPlan {
+    Static,
+    PointwiseRotation,
+    Circle {
+        from_radius: f32,
+        to_radius: f32,
+    },
+    Rectangle {
+        from_size: noon_core::Vec2,
+        to_size: noon_core::Vec2,
+    },
+    Line {
+        from_start: noon_core::Vec2,
+        from_end: noon_core::Vec2,
+        to_start: noon_core::Vec2,
+        to_end: noon_core::Vec2,
+    },
+    PathPair(GeometryRef),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum TransformCompileFailure {
+    UnsupportedGeometry,
+    RequiresRetessellation,
+    UnsafeFilledPath,
+}
+
+pub(crate) fn compile_transform_geometry_plan(
+    track: &TrackDefinition,
+) -> Result<Option<TransformGeometryPlan>, TransformCompileFailure> {
+    if track.property != Property::Transform {
+        return Ok(None);
+    }
+    let TrackValues::Object { from, to } = &track.values else {
+        unreachable!("validated Transform track must contain object snapshots");
+    };
+
+    if let (GeometryRef::VectorPath(_), GeometryRef::VectorPath(_)) = (&from.geometry, &to.geometry)
+    {
+        if path_style_requires_retessellation(from.style, to.style) {
+            return Err(TransformCompileFailure::RequiresRetessellation);
+        }
+    }
+
+    if from.geometry == to.geometry {
+        if from.transform.scale == to.transform.scale
+            && from.transform.rotation.to_bits() != to.transform.rotation.to_bits()
+        {
+            return Ok(Some(TransformGeometryPlan::PointwiseRotation));
+        }
+        return Ok(Some(TransformGeometryPlan::Static));
+    }
+
+    let plan = match (&from.geometry, &to.geometry) {
+        (
+            GeometryRef::Circle {
+                radius: from_radius,
+            },
+            GeometryRef::Circle { radius: to_radius },
+        ) => TransformGeometryPlan::Circle {
+            from_radius: *from_radius,
+            to_radius: *to_radius,
+        },
+        (GeometryRef::Rectangle { size: from_size }, GeometryRef::Rectangle { size: to_size }) => {
+            TransformGeometryPlan::Rectangle {
+                from_size: *from_size,
+                to_size: *to_size,
+            }
+        }
+        (
+            GeometryRef::Line {
+                start: from_start,
+                end: from_end,
+            },
+            GeometryRef::Line {
+                start: to_start,
+                end: to_end,
+            },
+        ) => TransformGeometryPlan::Line {
+            from_start: *from_start,
+            from_end: *from_end,
+            to_start: *to_start,
+            to_end: *to_end,
+        },
+        (GeometryRef::VectorPath(source), GeometryRef::VectorPath(target)) => {
+            compile_path_pair(from, to, source.clone(), target.clone())?
+        }
+        (GeometryRef::Circle { .. }, GeometryRef::Rectangle { .. })
+        | (GeometryRef::Rectangle { .. }, GeometryRef::Circle { .. }) => {
+            let source = noon_geometry::canonical_outline_path(&from.geometry)
+                .expect("closed analytic source geometry must convert to a path");
+            let target = noon_geometry::canonical_outline_path(&to.geometry)
+                .expect("closed analytic target geometry must convert to a path");
+            compile_path_pair(from, to, source, target)?
+        }
+        _ => return Err(TransformCompileFailure::UnsupportedGeometry),
+    };
+    Ok(Some(plan))
+}
+
+fn path_style_requires_retessellation(from: Style, to: Style) -> bool {
+    from.stroke_width.to_bits() != to.stroke_width.to_bits()
+        || from.stroke_join != to.stroke_join
+        || from.stroke_cap != to.stroke_cap
+        || from.fill.is_some() != to.fill.is_some()
+}
+
+fn compile_path_pair(
+    from: &ObjectSnapshot,
+    to: &ObjectSnapshot,
+    source: VectorPath,
+    target: VectorPath,
+) -> Result<TransformGeometryPlan, TransformCompileFailure> {
+    if path_style_requires_retessellation(from.style, to.style) {
+        return Err(TransformCompileFailure::RequiresRetessellation);
+    }
+    if from.style.fill.is_some()
+        && noon_geometry::plan_filled_morph(&source, &target, noon_geometry::MorphOptions::DEFAULT)
+            .is_err()
+    {
+        return Err(TransformCompileFailure::UnsafeFilledPath);
+    }
+    Ok(TransformGeometryPlan::PathPair(GeometryRef::path(
+        source.with_morph_target(target),
+    )))
+}

--- a/crates/noon-compile/src/transform.rs
+++ b/crates/noon-compile/src/transform.rs
@@ -1,4 +1,4 @@
-use noon_core::{GeometryRef, ObjectSnapshot, Property, Style, TrackDefinition, TrackValues, VectorPath};
+use noon_core::{GeometryRef, Property, Style, TrackDefinition, TrackValues, VectorPath};
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum TransformGeometryPlan {
@@ -86,7 +86,7 @@ pub(crate) fn compile_transform_geometry_plan(
             to_end: *to_end,
         },
         (GeometryRef::VectorPath(source), GeometryRef::VectorPath(target)) => {
-            compile_path_pair(from, to, source.clone(), target.clone())?
+            compile_path_pair(from.style, to.style, source.clone(), target.clone())?
         }
         (GeometryRef::Circle { .. }, GeometryRef::Rectangle { .. })
         | (GeometryRef::Rectangle { .. }, GeometryRef::Circle { .. }) => {
@@ -94,7 +94,7 @@ pub(crate) fn compile_transform_geometry_plan(
                 .expect("closed analytic source geometry must convert to a path");
             let target = noon_geometry::canonical_outline_path(&to.geometry)
                 .expect("closed analytic target geometry must convert to a path");
-            compile_path_pair(from, to, source, target)?
+            compile_path_pair(from.style, to.style, source, target)?
         }
         _ => return Err(TransformCompileFailure::UnsupportedGeometry),
     };
@@ -109,15 +109,15 @@ fn path_style_requires_retessellation(from: Style, to: Style) -> bool {
 }
 
 fn compile_path_pair(
-    from: &ObjectSnapshot,
-    to: &ObjectSnapshot,
+    from_style: Style,
+    to_style: Style,
     source: VectorPath,
     target: VectorPath,
 ) -> Result<TransformGeometryPlan, TransformCompileFailure> {
-    if path_style_requires_retessellation(from.style, to.style) {
+    if path_style_requires_retessellation(from_style, to_style) {
         return Err(TransformCompileFailure::RequiresRetessellation);
     }
-    if from.style.fill.is_some()
+    if from_style.fill.is_some()
         && noon_geometry::plan_filled_morph(&source, &target, noon_geometry::MorphOptions::DEFAULT)
             .is_err()
     {


### PR DESCRIPTION
## Roadmap ownership

- A5.3 split oversized files by ownership: #960
- Parent Phase A roadmap: #953
- Validation/ratchets: #961

## What changed

Extract the transform-geometry planning subsystem from `crates/noon-compile/src/lib.rs` into an ordinary `src/transform.rs` module:

- move `TransformGeometryPlan` and the transform compile failure classification;
- move transform-track geometry planning, path-pair morph planning, and retessellation/fill-safety checks;
- keep general scene compilation, mutation/preflight logic, public compile errors, and existing tests in the compiler root;
- re-export `TransformGeometryPlan` from the crate root so the public API remains `noon_compile::TransformGeometryPlan`.

The architecture ratchet rejected the first mechanical extraction because it would have spread the migration-era `ObjectSnapshot` type into the new module. The fix does not weaken or whitelist the ratchet: path-pair safety now receives only the endpoint `Style` values it actually needs, so the forbidden type is not introduced as a dependency of the extracted helper boundary.

No compatibility layer, serialization boundary, or behavioral policy is introduced.

## Why this boundary

Transform geometry compilation owns a distinct responsibility: deciding whether transform endpoints can execute as static/analytic geometry, fixed path-pair interpolation, or must fail because retessellation/fill topology would be unsafe. That policy depends on geometry/style endpoint state and `noon-geometry`, while the compiler root owns scene slotting, track channels, transaction preflight, dynamic-property accounting, and patch application.

## Validation

GitHub CI is green on the current head:

- Architecture Ratchets: pass
- Layer Dependency Ratchet: pass
- Rust formatting + Clippy: pass
- Rust unit tests: pass
- Web static/unit preflight: pass
- WASM/browser package build: pass
- deterministic playback: pass
- Manim-style authoring: pass
- primary WebGPU rendering: pass

Risk-classified canonical retained execution, persistent render-mode switching, WebGL rendering, and host-updater diagnostics were skipped. No local test run is claimed.

Refs #953 #960 #961.