### PR TITLE
Delete noon facade dev dependency on noon-ir

### DIFF
--- a/crates/noon/Cargo.toml
+++ b/crates/noon/Cargo.toml
@@ -12,6 +12,3 @@ noon-text-native = { path = "../noon-text-native" }
 noon-typst = { path = "../noon-typst" }
 swash = "=0.2.10"
 typst-assets = { version = "=0.15.1", features = ["fonts"] }
-
-[dev-dependencies]
-noon-ir = { path = "../noon-ir" }


### PR DESCRIPTION
## Closed after validation

This deletion was proposed as A4/A5.4 cleanup, but the full-target Clippy gate exposed a real dev/example consumer: `crates/noon/examples/manim_quickstart_equivalents.rs` imports `noon_ir::encode_scene`. A follow-up audit also found `crates/noon/examples/cross_language_parity.rs` intentionally uses `encode_scene` / `encode_timed_semantic_scene` to emit cross-language comparison payloads.

That makes the `noon-ir` edge a **dev-only explicit test/external serialization boundary**, which is allowed by the Phase A architecture. Removing it would delete legitimate parity/fixture capability rather than legacy production coupling.

The architecture and layer ratchets passed and Rust unit tests passed, but `cargo clippy --workspace --all-targets --all-features` correctly failed because examples require this dependency. No ratchet or coverage is being weakened; this PR is closed unmerged.

Refs #953 #959 #960 #961.