### PR TITLE
Add atomic Semantic Scene property mutations

### DIFF
--- a/crates/noon-core/src/reactive/semantic_transaction.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction.rs
@@ -1,19 +1,26 @@
 use std::collections::HashSet;
 
 use super::{
-    SemanticNodeId, SemanticSignalError, SemanticSignalSource, SemanticSignalValue,
-    SemanticSignalValueKind, SemanticStore,
+    SemanticNodeId, SemanticObjectProperty, SemanticObjectState, SemanticSceneOperationError,
+    SemanticSignalError, SemanticSignalSource, SemanticSignalValue, SemanticSignalValueKind,
+    SemanticStore,
 };
 
 /// One mutation in the authoritative Semantic Scene transaction vocabulary.
 ///
-/// This first A1.5 slice intentionally starts with input-signal value mutation.
-/// Dependency-expression rewiring remains an authored declaration operation rather
-/// than being conflated with a frame/value update.
+/// Signal values and object properties share the same transaction so frontends,
+/// editors, and host integrations cannot invent subsystem-specific patch paths.
+/// Dependency-expression rewiring remains authored declaration topology rather
+/// than being conflated with a value/property update.
 #[derive(Clone, Debug, PartialEq)]
 pub enum SemanticMutation {
     SetSignal {
         signal: SemanticNodeId,
+        value: SemanticSignalValue,
+    },
+    SetProperty {
+        object: SemanticNodeId,
+        property: SemanticObjectProperty,
         value: SemanticSignalValue,
     },
 }
@@ -22,8 +29,30 @@ impl SemanticMutation {
     pub const fn target(&self) -> SemanticNodeId {
         match self {
             Self::SetSignal { signal, .. } => *signal,
+            Self::SetProperty { object, .. } => *object,
         }
     }
+
+    const fn key(&self) -> SemanticMutationKey {
+        match self {
+            Self::SetSignal { signal, .. } => SemanticMutationKey::Signal(*signal),
+            Self::SetProperty {
+                object, property, ..
+            } => SemanticMutationKey::ObjectProperty {
+                object: *object,
+                property: *property,
+            },
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+enum SemanticMutationKey {
+    Signal(SemanticNodeId),
+    ObjectProperty {
+        object: SemanticNodeId,
+        property: SemanticObjectProperty,
+    },
 }
 
 /// Locality classification emitted by committed semantic mutations.
@@ -33,7 +62,13 @@ impl SemanticMutation {
 /// frontend- or subsystem-specific patch classifications.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SemanticMutationImpact {
-    SignalValue { signal: SemanticNodeId },
+    SignalValue {
+        signal: SemanticNodeId,
+    },
+    ObjectProperty {
+        object: SemanticNodeId,
+        property: SemanticObjectProperty,
+    },
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -58,6 +93,27 @@ impl SemanticMutationTransaction {
         self
     }
 
+    /// Set one node-owned authored object property in the same atomic mutation
+    /// vocabulary as signal values.
+    ///
+    /// `SemanticSignalValue` is reused here as the existing high-precision typed
+    /// scalar/vector/bool value vocabulary; property-kind validation rejects the
+    /// bool case for current object properties instead of creating a duplicate
+    /// property-value type.
+    pub fn set_property(
+        &mut self,
+        object: SemanticNodeId,
+        property: SemanticObjectProperty,
+        value: impl Into<SemanticSignalValue>,
+    ) -> &mut Self {
+        self.mutations.push(SemanticMutation::SetProperty {
+            object,
+            property,
+            value: value.into(),
+        });
+        self
+    }
+
     pub fn mutations(&self) -> &[SemanticMutation] {
         &self.mutations
     }
@@ -69,9 +125,9 @@ impl SemanticMutationTransaction {
     /// Preflight the complete transaction, then commit every changed mutation.
     ///
     /// No semantic slot is written until all mutations have passed generation,
-    /// target-kind, input-kind, value-kind, finite-value, and duplicate-target
-    /// validation. Once preflight succeeds, commit cannot observe external scene
-    /// changes because the transaction owns `&mut SemanticStore` for the duration.
+    /// target-kind, value-kind, finite-value, and duplicate-mutation validation.
+    /// Once preflight succeeds, commit cannot observe external scene changes
+    /// because the transaction owns `&mut SemanticStore` for the duration.
     pub fn apply(
         self,
         store: &mut SemanticStore,
@@ -80,7 +136,7 @@ impl SemanticMutationTransaction {
         let preflight = self.preflight(store)?;
 
         let mut impacts = Vec::with_capacity(self.mutations.len());
-        let mut writes = 0;
+        let mut written_slots = HashSet::with_capacity(self.mutations.len());
         for (mutation, changed) in self.mutations.into_iter().zip(preflight) {
             if !changed {
                 continue;
@@ -93,12 +149,21 @@ impl SemanticMutationTransaction {
                             "preflighted input signal update must remain valid while transaction owns the semantic store",
                         );
                     debug_assert!(changed);
-                    writes += 1;
+                    written_slots.insert(signal);
                     impacts.push(SemanticMutationImpact::SignalValue { signal });
+                }
+                SemanticMutation::SetProperty {
+                    object,
+                    property,
+                    value,
+                } => {
+                    set_object_property(store, object, property, value);
+                    written_slots.insert(object);
+                    impacts.push(SemanticMutationImpact::ObjectProperty { object, property });
                 }
             }
         }
-        store.set_last_mutation_writes(writes);
+        store.set_last_mutation_writes(written_slots.len());
 
         Ok(SemanticMutationTransactionResult { impacts })
     }
@@ -111,9 +176,20 @@ impl SemanticMutationTransaction {
         let mut changed = Vec::with_capacity(self.mutations.len());
 
         for (index, mutation) in self.mutations.iter().enumerate() {
-            let target = mutation.target();
-            if !targets.insert(target) {
-                return Err(SemanticMutationTransactionError::DuplicateTarget { index, target });
+            let key = mutation.key();
+            if !targets.insert(key) {
+                return Err(match key {
+                    SemanticMutationKey::Signal(target) => {
+                        SemanticMutationTransactionError::DuplicateTarget { index, target }
+                    }
+                    SemanticMutationKey::ObjectProperty { object, property } => {
+                        SemanticMutationTransactionError::DuplicateProperty {
+                            index,
+                            object,
+                            property,
+                        }
+                    }
+                });
             }
 
             match mutation {
@@ -145,10 +221,94 @@ impl SemanticMutationTransaction {
                     }
                     changed.push(previous != value);
                 }
+                SemanticMutation::SetProperty {
+                    object,
+                    property,
+                    value,
+                } => {
+                    let state = store.semantic_object_state_checked(*object).map_err(|error| {
+                        SemanticMutationTransactionError::Object { index, error }
+                    })?;
+                    if !value.is_finite() {
+                        return Err(SemanticMutationTransactionError::NonFinitePropertyValue {
+                            index,
+                            object: *object,
+                            property: *property,
+                        });
+                    }
+                    let expected = property.value_kind();
+                    let actual = value.value_kind();
+                    if actual != expected {
+                        return Err(SemanticMutationTransactionError::PropertyTypeMismatch {
+                            index,
+                            object: *object,
+                            property: *property,
+                            expected,
+                            actual,
+                        });
+                    }
+                    changed.push(object_property_value(state, *property) != *value);
+                }
             }
         }
 
         Ok(changed)
+    }
+}
+
+fn object_property_value(
+    state: &SemanticObjectState,
+    property: SemanticObjectProperty,
+) -> SemanticSignalValue {
+    match property {
+        SemanticObjectProperty::Translation => SemanticSignalValue::Vec3(state.transform.translation),
+        SemanticObjectProperty::Scale => SemanticSignalValue::Vec3(state.transform.scale),
+        SemanticObjectProperty::RotationZ => SemanticSignalValue::Scalar(state.transform.rotation_z),
+        SemanticObjectProperty::FillOpacity => SemanticSignalValue::Scalar(state.style.fill_opacity),
+        SemanticObjectProperty::StrokeOpacity => {
+            SemanticSignalValue::Scalar(state.style.stroke_opacity)
+        }
+        SemanticObjectProperty::StrokeWidth => SemanticSignalValue::Scalar(state.style.stroke_width),
+        SemanticObjectProperty::ObjectOpacity => {
+            SemanticSignalValue::Scalar(state.style.object_opacity)
+        }
+    }
+}
+
+fn set_object_property(
+    store: &mut SemanticStore,
+    object: SemanticNodeId,
+    property: SemanticObjectProperty,
+    value: SemanticSignalValue,
+) {
+    let state = store
+        .node_mut(object)
+        .and_then(|node| node.semantic_object_state_mut())
+        .expect("preflighted semantic object must remain valid while transaction owns the store");
+
+    match (property, value) {
+        (SemanticObjectProperty::Translation, SemanticSignalValue::Vec3(value)) => {
+            state.transform.translation = value;
+        }
+        (SemanticObjectProperty::Scale, SemanticSignalValue::Vec3(value)) => {
+            state.transform.scale = value;
+        }
+        (SemanticObjectProperty::RotationZ, SemanticSignalValue::Scalar(value)) => {
+            state.transform.rotation_z = value;
+        }
+        (SemanticObjectProperty::FillOpacity, SemanticSignalValue::Scalar(value)) => {
+            state.style.fill_opacity = value;
+        }
+        (SemanticObjectProperty::StrokeOpacity, SemanticSignalValue::Scalar(value)) => {
+            state.style.stroke_opacity = value;
+        }
+        (SemanticObjectProperty::StrokeWidth, SemanticSignalValue::Scalar(value)) => {
+            state.style.stroke_width = value;
+        }
+        (SemanticObjectProperty::ObjectOpacity, SemanticSignalValue::Scalar(value)) => {
+            state.style.object_opacity = value;
+        }
+        _ => unreachable!("semantic property value kind was validated during transaction preflight"),
     }
 }
 
@@ -163,11 +323,16 @@ impl SemanticMutationTransactionResult {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SemanticMutationTransactionError {
     DuplicateTarget {
         index: usize,
         target: SemanticNodeId,
+    },
+    DuplicateProperty {
+        index: usize,
+        object: SemanticNodeId,
+        property: SemanticObjectProperty,
     },
     Signal {
         index: usize,
@@ -183,6 +348,22 @@ pub enum SemanticMutationTransactionError {
         expected: SemanticSignalValueKind,
         actual: SemanticSignalValueKind,
     },
+    Object {
+        index: usize,
+        error: SemanticSceneOperationError,
+    },
+    NonFinitePropertyValue {
+        index: usize,
+        object: SemanticNodeId,
+        property: SemanticObjectProperty,
+    },
+    PropertyTypeMismatch {
+        index: usize,
+        object: SemanticNodeId,
+        property: SemanticObjectProperty,
+        expected: SemanticSignalValueKind,
+        actual: SemanticSignalValueKind,
+    },
 }
 
 impl std::fmt::Display for SemanticMutationTransactionError {
@@ -193,6 +374,17 @@ impl std::fmt::Display for SemanticMutationTransactionError {
                 "semantic transaction mutation {index} repeats target {}:{}",
                 target.slot(),
                 target.generation()
+            ),
+            Self::DuplicateProperty {
+                index,
+                object,
+                property,
+            } => write!(
+                formatter,
+                "semantic transaction mutation {index} repeats property {:?} on object {}:{}",
+                property,
+                object.slot(),
+                object.generation()
             ),
             Self::Signal { index, error } => {
                 write!(formatter, "semantic transaction mutation {index}: {error}")
@@ -214,6 +406,33 @@ impl std::fmt::Display for SemanticMutationTransactionError {
                 signal.slot(),
                 signal.generation()
             ),
+            Self::Object { index, error } => {
+                write!(formatter, "semantic transaction mutation {index}: {error}")
+            }
+            Self::NonFinitePropertyValue {
+                index,
+                object,
+                property,
+            } => write!(
+                formatter,
+                "semantic transaction mutation {index} cannot set property {:?} on object {}:{} to a non-finite value",
+                property,
+                object.slot(),
+                object.generation()
+            ),
+            Self::PropertyTypeMismatch {
+                index,
+                object,
+                property,
+                expected,
+                actual,
+            } => write!(
+                formatter,
+                "semantic transaction mutation {index} cannot set property {:?} on object {}:{} of kind {expected} to {actual}",
+                property,
+                object.slot(),
+                object.generation()
+            ),
         }
     }
 }
@@ -223,7 +442,10 @@ impl std::error::Error for SemanticMutationTransactionError {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{SemanticObjectState, SemanticSignalExpr, SemanticVec3, StoredGeometry};
+    use crate::{
+        SemanticObjectState, SemanticSignalBinding, SemanticSignalExpr, SemanticVec3,
+        StoredGeometry,
+    };
 
     fn object(store: &mut SemanticStore, radius: f32) -> SemanticNodeId {
         store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle { radius }))
@@ -236,6 +458,14 @@ mod tests {
             panic!("expected input signal")
         };
         value.clone()
+    }
+
+    fn property_value(
+        store: &SemanticStore,
+        object: SemanticNodeId,
+        property: SemanticObjectProperty,
+    ) -> SemanticSignalValue {
+        object_property_value(store.semantic_object_state_checked(object).unwrap(), property)
     }
 
     #[test]
@@ -273,6 +503,53 @@ mod tests {
     }
 
     #[test]
+    fn mixed_signal_and_properties_commit_atomically_and_count_unique_slots() {
+        let mut store = SemanticStore::new();
+        let signal = store.insert_semantic_input_signal(1.0_f64).unwrap();
+        let target = object(&mut store, 2.0);
+        let translation = SemanticVec3::new(4.0, -2.0, 7.0);
+        let mut transaction = SemanticMutationTransaction::new();
+        transaction
+            .set_signal(signal, 3.0_f64)
+            .set_property(
+                target,
+                SemanticObjectProperty::Translation,
+                translation,
+            )
+            .set_property(target, SemanticObjectProperty::ObjectOpacity, 0.4_f64);
+
+        let result = transaction.apply(&mut store).unwrap();
+
+        assert_eq!(
+            input_value(&store, signal),
+            SemanticSignalValue::Scalar(3.0)
+        );
+        assert_eq!(
+            property_value(&store, target, SemanticObjectProperty::Translation),
+            SemanticSignalValue::Vec3(translation)
+        );
+        assert_eq!(
+            property_value(&store, target, SemanticObjectProperty::ObjectOpacity),
+            SemanticSignalValue::Scalar(0.4)
+        );
+        assert_eq!(store.last_mutation_stats().slots_written, 2);
+        assert_eq!(
+            result.impacts(),
+            &[
+                SemanticMutationImpact::SignalValue { signal },
+                SemanticMutationImpact::ObjectProperty {
+                    object: target,
+                    property: SemanticObjectProperty::Translation,
+                },
+                SemanticMutationImpact::ObjectProperty {
+                    object: target,
+                    property: SemanticObjectProperty::ObjectOpacity,
+                },
+            ]
+        );
+    }
+
+    #[test]
     fn invalid_late_value_prevents_earlier_valid_mutation() {
         let mut store = SemanticStore::new();
         let first = store.insert_semantic_input_signal(1.0_f64).unwrap();
@@ -293,6 +570,43 @@ mod tests {
         );
         assert_eq!(input_value(&store, first), first_before);
         assert_eq!(input_value(&store, second), second_before);
+        assert_eq!(store.last_mutation_stats().slots_written, 0);
+    }
+
+    #[test]
+    fn invalid_late_property_prevents_earlier_signal_and_property_mutation() {
+        let mut store = SemanticStore::new();
+        let signal = store.insert_semantic_input_signal(1.0_f64).unwrap();
+        let target = object(&mut store, 2.0);
+        let signal_before = input_value(&store, signal);
+        let translation_before = property_value(
+            &store,
+            target,
+            SemanticObjectProperty::Translation,
+        );
+        let mut transaction = SemanticMutationTransaction::new();
+        transaction
+            .set_signal(signal, 5.0_f64)
+            .set_property(
+                target,
+                SemanticObjectProperty::Translation,
+                SemanticVec3::new(1.0, 2.0, 3.0),
+            )
+            .set_property(target, SemanticObjectProperty::StrokeWidth, f64::NAN);
+
+        assert_eq!(
+            transaction.apply(&mut store),
+            Err(SemanticMutationTransactionError::NonFinitePropertyValue {
+                index: 2,
+                object: target,
+                property: SemanticObjectProperty::StrokeWidth,
+            })
+        );
+        assert_eq!(input_value(&store, signal), signal_before);
+        assert_eq!(
+            property_value(&store, target, SemanticObjectProperty::Translation),
+            translation_before
+        );
         assert_eq!(store.last_mutation_stats().slots_written, 0);
     }
 
@@ -323,6 +637,32 @@ mod tests {
     }
 
     #[test]
+    fn stale_property_target_prevents_earlier_valid_mutation() {
+        let mut store = SemanticStore::new();
+        let signal = store.insert_semantic_input_signal(1.0_f64).unwrap();
+        let stale = object(&mut store, 2.0);
+        store.remove_node(stale).unwrap();
+        let replacement = object(&mut store, 3.0);
+        assert_eq!(stale.slot(), replacement.slot());
+        assert_ne!(stale.generation(), replacement.generation());
+        let signal_before = input_value(&store, signal);
+        let mut transaction = SemanticMutationTransaction::new();
+        transaction
+            .set_signal(signal, 2.0_f64)
+            .set_property(stale, SemanticObjectProperty::RotationZ, 0.5_f64);
+
+        assert_eq!(
+            transaction.apply(&mut store),
+            Err(SemanticMutationTransactionError::Object {
+                index: 1,
+                error: SemanticSceneOperationError::UnknownNode(stale),
+            })
+        );
+        assert_eq!(input_value(&store, signal), signal_before);
+        assert_eq!(store.last_mutation_stats().slots_written, 0);
+    }
+
+    #[test]
     fn duplicate_target_is_rejected_before_mutation() {
         let mut store = SemanticStore::new();
         let signal = store.insert_semantic_input_signal(1.0_f64).unwrap();
@@ -341,6 +681,38 @@ mod tests {
         );
         assert_eq!(input_value(&store, signal), before);
         assert_eq!(store.last_mutation_stats().slots_written, 0);
+    }
+
+    #[test]
+    fn duplicate_property_is_rejected_but_distinct_properties_share_one_object() {
+        let mut store = SemanticStore::new();
+        let target = object(&mut store, 1.0);
+        let mut duplicate = SemanticMutationTransaction::new();
+        duplicate
+            .set_property(target, SemanticObjectProperty::RotationZ, 0.5_f64)
+            .set_property(target, SemanticObjectProperty::RotationZ, 1.0_f64);
+
+        assert_eq!(
+            duplicate.apply(&mut store),
+            Err(SemanticMutationTransactionError::DuplicateProperty {
+                index: 1,
+                object: target,
+                property: SemanticObjectProperty::RotationZ,
+            })
+        );
+        assert_eq!(
+            property_value(&store, target, SemanticObjectProperty::RotationZ),
+            SemanticSignalValue::Scalar(0.0)
+        );
+        assert_eq!(store.last_mutation_stats().slots_written, 0);
+
+        let mut distinct = SemanticMutationTransaction::new();
+        distinct
+            .set_property(target, SemanticObjectProperty::RotationZ, 0.5_f64)
+            .set_property(target, SemanticObjectProperty::StrokeWidth, 3.0_f64);
+        let result = distinct.apply(&mut store).unwrap();
+        assert_eq!(result.impacts().len(), 2);
+        assert_eq!(store.last_mutation_stats().slots_written, 1);
     }
 
     #[test]
@@ -379,6 +751,38 @@ mod tests {
     }
 
     #[test]
+    fn property_type_and_target_kind_are_validated_before_mutation() {
+        let mut store = SemanticStore::new();
+        let target = object(&mut store, 1.0);
+        let family = store.insert_family();
+        let mut mismatch = SemanticMutationTransaction::new();
+        mismatch.set_property(target, SemanticObjectProperty::Scale, 2.0_f64);
+
+        assert_eq!(
+            mismatch.apply(&mut store),
+            Err(SemanticMutationTransactionError::PropertyTypeMismatch {
+                index: 0,
+                object: target,
+                property: SemanticObjectProperty::Scale,
+                expected: SemanticSignalValueKind::Vec3,
+                actual: SemanticSignalValueKind::Scalar,
+            })
+        );
+        assert_eq!(store.last_mutation_stats().slots_written, 0);
+
+        let mut wrong_target = SemanticMutationTransaction::new();
+        wrong_target.set_property(family, SemanticObjectProperty::RotationZ, 1.0_f64);
+        assert_eq!(
+            wrong_target.apply(&mut store),
+            Err(SemanticMutationTransactionError::Object {
+                index: 0,
+                error: SemanticSceneOperationError::NotSemanticObject(family),
+            })
+        );
+        assert_eq!(store.last_mutation_stats().slots_written, 0);
+    }
+
+    #[test]
     fn unchanged_signal_is_a_noop_with_no_impact() {
         let mut store = SemanticStore::new();
         let signal = store.insert_semantic_input_signal(true).unwrap();
@@ -390,6 +794,54 @@ mod tests {
         assert!(result.impacts().is_empty());
         assert_eq!(store.last_mutation_stats().slots_written, 0);
         assert_eq!(input_value(&store, signal), SemanticSignalValue::Bool(true));
+    }
+
+    #[test]
+    fn unchanged_property_is_a_noop_with_no_impact() {
+        let mut store = SemanticStore::new();
+        let target = object(&mut store, 1.0);
+        let mut transaction = SemanticMutationTransaction::new();
+        transaction.set_property(
+            target,
+            SemanticObjectProperty::Translation,
+            SemanticVec3::ZERO,
+        );
+
+        let result = transaction.apply(&mut store).unwrap();
+
+        assert!(result.impacts().is_empty());
+        assert_eq!(store.last_mutation_stats().slots_written, 0);
+    }
+
+    #[test]
+    fn set_property_preserves_signal_binding_declarations() {
+        let mut store = SemanticStore::new();
+        let signal = store.insert_semantic_input_signal(0.5_f64).unwrap();
+        let target = object(&mut store, 1.0);
+        store
+            .bind_semantic_signal(signal, target, SemanticObjectProperty::ObjectOpacity)
+            .unwrap();
+        let binding = SemanticSignalBinding::new(signal, SemanticObjectProperty::ObjectOpacity);
+        let mut transaction = SemanticMutationTransaction::new();
+        transaction.set_property(target, SemanticObjectProperty::ObjectOpacity, 0.25_f64);
+
+        let result = transaction.apply(&mut store).unwrap();
+
+        assert_eq!(
+            property_value(&store, target, SemanticObjectProperty::ObjectOpacity),
+            SemanticSignalValue::Scalar(0.25)
+        );
+        assert_eq!(
+            store.semantic_object_signal_bindings(target).unwrap(),
+            &[binding]
+        );
+        assert_eq!(
+            result.impacts(),
+            &[SemanticMutationImpact::ObjectProperty {
+                object: target,
+                property: SemanticObjectProperty::ObjectOpacity,
+            }]
+        );
     }
 
     #[test]
@@ -410,6 +862,24 @@ mod tests {
         let result = transaction.apply(&mut store).unwrap();
 
         assert_eq!(store.last_mutation_stats().slots_written, 2);
+        assert_eq!(result.impacts().len(), 2);
+    }
+
+    #[test]
+    fn property_transaction_writes_only_target_slot_with_large_unrelated_scene() {
+        let mut store = SemanticStore::new();
+        for index in 0..10_000 {
+            object(&mut store, index as f32 + 1.0);
+        }
+        let target = object(&mut store, 0.5);
+        let mut transaction = SemanticMutationTransaction::new();
+        transaction
+            .set_property(target, SemanticObjectProperty::RotationZ, 0.75_f64)
+            .set_property(target, SemanticObjectProperty::StrokeWidth, 4.0_f64);
+
+        let result = transaction.apply(&mut store).unwrap();
+
+        assert_eq!(store.last_mutation_stats().slots_written, 1);
         assert_eq!(result.impacts().len(), 2);
     }
 }

--- a/crates/noon-core/src/reactive/semantic_transaction.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction.rs
@@ -226,9 +226,12 @@ impl SemanticMutationTransaction {
                     property,
                     value,
                 } => {
-                    let state = store.semantic_object_state_checked(*object).map_err(|error| {
-                        SemanticMutationTransactionError::Object { index, error }
-                    })?;
+                    let state = store
+                        .semantic_object_state_checked(*object)
+                        .map_err(|error| SemanticMutationTransactionError::Object {
+                            index,
+                            error,
+                        })?;
                     if !value.is_finite() {
                         return Err(SemanticMutationTransactionError::NonFinitePropertyValue {
                             index,
@@ -261,14 +264,22 @@ fn object_property_value(
     property: SemanticObjectProperty,
 ) -> SemanticSignalValue {
     match property {
-        SemanticObjectProperty::Translation => SemanticSignalValue::Vec3(state.transform.translation),
+        SemanticObjectProperty::Translation => {
+            SemanticSignalValue::Vec3(state.transform.translation)
+        }
         SemanticObjectProperty::Scale => SemanticSignalValue::Vec3(state.transform.scale),
-        SemanticObjectProperty::RotationZ => SemanticSignalValue::Scalar(state.transform.rotation_z),
-        SemanticObjectProperty::FillOpacity => SemanticSignalValue::Scalar(state.style.fill_opacity),
+        SemanticObjectProperty::RotationZ => {
+            SemanticSignalValue::Scalar(state.transform.rotation_z)
+        }
+        SemanticObjectProperty::FillOpacity => {
+            SemanticSignalValue::Scalar(state.style.fill_opacity)
+        }
         SemanticObjectProperty::StrokeOpacity => {
             SemanticSignalValue::Scalar(state.style.stroke_opacity)
         }
-        SemanticObjectProperty::StrokeWidth => SemanticSignalValue::Scalar(state.style.stroke_width),
+        SemanticObjectProperty::StrokeWidth => {
+            SemanticSignalValue::Scalar(state.style.stroke_width)
+        }
         SemanticObjectProperty::ObjectOpacity => {
             SemanticSignalValue::Scalar(state.style.object_opacity)
         }
@@ -308,7 +319,9 @@ fn set_object_property(
         (SemanticObjectProperty::ObjectOpacity, SemanticSignalValue::Scalar(value)) => {
             state.style.object_opacity = value;
         }
-        _ => unreachable!("semantic property value kind was validated during transaction preflight"),
+        _ => {
+            unreachable!("semantic property value kind was validated during transaction preflight")
+        }
     }
 }
 
@@ -465,7 +478,10 @@ mod tests {
         object: SemanticNodeId,
         property: SemanticObjectProperty,
     ) -> SemanticSignalValue {
-        object_property_value(store.semantic_object_state_checked(object).unwrap(), property)
+        object_property_value(
+            store.semantic_object_state_checked(object).unwrap(),
+            property,
+        )
     }
 
     #[test]
@@ -511,11 +527,7 @@ mod tests {
         let mut transaction = SemanticMutationTransaction::new();
         transaction
             .set_signal(signal, 3.0_f64)
-            .set_property(
-                target,
-                SemanticObjectProperty::Translation,
-                translation,
-            )
+            .set_property(target, SemanticObjectProperty::Translation, translation)
             .set_property(target, SemanticObjectProperty::ObjectOpacity, 0.4_f64);
 
         let result = transaction.apply(&mut store).unwrap();
@@ -579,11 +591,8 @@ mod tests {
         let signal = store.insert_semantic_input_signal(1.0_f64).unwrap();
         let target = object(&mut store, 2.0);
         let signal_before = input_value(&store, signal);
-        let translation_before = property_value(
-            &store,
-            target,
-            SemanticObjectProperty::Translation,
-        );
+        let translation_before =
+            property_value(&store, target, SemanticObjectProperty::Translation);
         let mut transaction = SemanticMutationTransaction::new();
         transaction
             .set_signal(signal, 5.0_f64)
@@ -647,9 +656,11 @@ mod tests {
         assert_ne!(stale.generation(), replacement.generation());
         let signal_before = input_value(&store, signal);
         let mut transaction = SemanticMutationTransaction::new();
-        transaction
-            .set_signal(signal, 2.0_f64)
-            .set_property(stale, SemanticObjectProperty::RotationZ, 0.5_f64);
+        transaction.set_signal(signal, 2.0_f64).set_property(
+            stale,
+            SemanticObjectProperty::RotationZ,
+            0.5_f64,
+        );
 
         assert_eq!(
             transaction.apply(&mut store),


### PR DESCRIPTION
## Roadmap ownership

- Owning case: #957 / A1.5 — one semantic mutation transaction
- Builds directly on #1023 `SetSignal` transaction foundation
- Parent roadmap: #953
- Validation/locality: #961 / A6.4

## What changed

Extend the one authoritative `SemanticMutationTransaction` with `SetProperty` instead of creating a second object/frontend patch path:

- add `SemanticMutation::SetProperty { object, property, value }` using the existing `SemanticObjectProperty` vocabulary;
- reuse the existing high-precision typed semantic scalar/`Vec3` value representation rather than adding a duplicate property-value model;
- support mixed `SetSignal` + `SetProperty` transactions under one complete preflight/commit boundary;
- allow multiple distinct properties of one object in a transaction while rejecting duplicate writes to the same property;
- emit ordered `SemanticMutationImpact::ObjectProperty { object, property }` records;
- count unique semantic node slots touched, so multiple property changes on one object remain one-slot-local.

## Validation / atomicity

Before any semantic write, the complete transaction validates:

- live generational semantic object identity;
- target owns target `SemanticObjectState` rather than migration/state-less/family/signal state;
- value kind matches the property's existing scalar/`Vec3` contract;
- values are finite;
- no duplicate signal target or duplicate object/property target exists.

No new range/clamping policy is introduced for opacity/stroke width in this slice; the current semantic model has no such authored-state validator, so A1.5 does not silently invent one.

A late invalid/stale property prevents earlier valid signal/property mutations from committing. Unchanged values are no-ops with no impact.

## Reactive ownership

`SetProperty` changes the node-owned authored/base property only. Existing signal-binding declarations remain intact. `ChangeSubscription` owns binding changes later in A1.5; this slice does not conflate property mutation with reactive topology.

## Locality

A 10k unrelated-object fixture proves two changed properties on one target write one semantic node slot. Mixed signal + multiple target-property changes write only the unique changed semantic nodes.

## Deliberately deferred

- `ReplaceContent`, structural/family mutations, animation mutations, and `ChangeSubscription`;
- reverse-reference indexing and atomic `RemoveNode` cleanup;
- A1.6 lowering/runtime consumption of impact records.

GitHub CI is the exhaustive compile/test/architecture/atomicity gate.

Refs #953 #957 #961 #1023.