### PR TITLE
Normalize noon-web legacy module ownership

### DIFF
--- a/crates/noon-web/src/legacy.rs
+++ b/crates/noon-web/src/legacy.rs
@@ -5,10 +5,6 @@
 
 #![forbid(unsafe_code)]
 
-mod clock;
-
-pub use clock::*;
-
 use noon_compile::{CompileError, CompilePatchError, CompiledScene};
 use std::collections::{BTreeMap, BTreeSet};
 

--- a/crates/noon-web/src/lib.rs
+++ b/crates/noon-web/src/lib.rs
@@ -7,6 +7,7 @@ mod authoring_semantics;
 mod canonical_authoring_scene;
 mod canonical_family_animation;
 mod canonical_retained_engine_player;
+mod clock;
 mod composition;
 mod determinism;
 #[cfg(all(target_arch = "wasm32", debug_assertions))]
@@ -20,7 +21,6 @@ mod family_write_authoring;
 #[cfg(any(target_arch = "wasm32", test))]
 mod gpu_diagnostics;
 mod host_player;
-#[path = "legacy.rs"]
 mod legacy;
 mod lifecycle;
 mod manim_dashed_line_bridge;
@@ -62,6 +62,7 @@ pub use authoring_semantics::*;
 pub use canonical_authoring_scene::*;
 pub use canonical_family_animation::*;
 pub use canonical_retained_engine_player::*;
+pub use clock::{ClockError, PlaybackClock};
 pub use composition::*;
 pub use determinism::*;
 #[cfg(all(target_arch = "wasm32", debug_assertions))]
@@ -76,7 +77,7 @@ pub use family_bounds::*;
 #[cfg(target_arch = "wasm32")]
 pub use family_write_authoring::*;
 pub use host_player::*;
-pub use legacy::{ClockError, PlaybackClock, PlayerError, ReconcileOutcome};
+pub use legacy::{PlayerError, ReconcileOutcome};
 pub use lifecycle::*;
 pub use manim_dashed_line_bridge::*;
 pub use manim_elbow_bridge::*;


### PR DESCRIPTION
## Summary

Normalize `noon-web` clock ownership without changing the migration scope. `clock` is now an ordinary crate-root module, while `legacy` continues to own the temporary browser execution kernel and its `ScenePlayer` migration path.

This removes the `#[path = "legacy.rs"]` indirection without treating it as a deletion of the legacy kernel. #959 continues to own that deletion.

## Validation

- `git diff --check`

The repository's integrated Rust gate is pending in the coordinating worktree.

## Architecture

`noon-web` remains browser/WASM platform integration. This is structural module normalization under #960/#961 only; it introduces no new scene, runtime, transport, or platform authority.


Independent architecture/code review: passed. Integrated local workspace format/check/clippy and all workspace tests passed; module-ownership ratchet live/self-tests and `git diff --check` passed. The full browser build continues as additional integrated validation; no slow CI wait was required for this reviewed change.
