### PR TITLE
Add atomic semantic subscription changes

### DIFF
--- a/crates/noon-core/src/reactive/semantic_transaction.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction.rs
@@ -2,16 +2,16 @@ use std::collections::HashSet;
 
 use super::{
     SemanticNodeId, SemanticObjectProperty, SemanticObjectState, SemanticSceneOperationError,
-    SemanticSignalError, SemanticSignalSource, SemanticSignalValue, SemanticSignalValueKind,
-    SemanticStore,
+    SemanticSignalBinding, SemanticSignalError, SemanticSignalSource, SemanticSignalValue,
+    SemanticSignalValueKind, SemanticStore,
 };
 
 /// One mutation in the authoritative Semantic Scene transaction vocabulary.
 ///
-/// Signal values and object properties share the same transaction so frontends,
-/// editors, and host integrations cannot invent subsystem-specific patch paths.
-/// Dependency-expression rewiring remains authored declaration topology rather
-/// than being conflated with a value/property update.
+/// Signal values, object properties, and authored reactive subscriptions share
+/// the same transaction so frontends, editors, and host integrations cannot
+/// invent subsystem-specific patch paths. Dependency-expression rewiring remains
+/// authored declaration topology rather than being conflated with a value update.
 #[derive(Clone, Debug, PartialEq)]
 pub enum SemanticMutation {
     SetSignal {
@@ -23,13 +23,18 @@ pub enum SemanticMutation {
         property: SemanticObjectProperty,
         value: SemanticSignalValue,
     },
+    ChangeSubscription {
+        object: SemanticNodeId,
+        property: SemanticObjectProperty,
+        signal: Option<SemanticNodeId>,
+    },
 }
 
 impl SemanticMutation {
     pub const fn target(&self) -> SemanticNodeId {
         match self {
             Self::SetSignal { signal, .. } => *signal,
-            Self::SetProperty { object, .. } => *object,
+            Self::SetProperty { object, .. } | Self::ChangeSubscription { object, .. } => *object,
         }
     }
 
@@ -42,6 +47,12 @@ impl SemanticMutation {
                 object: *object,
                 property: *property,
             },
+            Self::ChangeSubscription {
+                object, property, ..
+            } => SemanticMutationKey::Subscription {
+                object: *object,
+                property: *property,
+            },
         }
     }
 }
@@ -50,6 +61,10 @@ impl SemanticMutation {
 enum SemanticMutationKey {
     Signal(SemanticNodeId),
     ObjectProperty {
+        object: SemanticNodeId,
+        property: SemanticObjectProperty,
+    },
+    Subscription {
         object: SemanticNodeId,
         property: SemanticObjectProperty,
     },
@@ -66,6 +81,10 @@ pub enum SemanticMutationImpact {
         signal: SemanticNodeId,
     },
     ObjectProperty {
+        object: SemanticNodeId,
+        property: SemanticObjectProperty,
+    },
+    Subscription {
         object: SemanticNodeId,
         property: SemanticObjectProperty,
     },
@@ -114,6 +133,25 @@ impl SemanticMutationTransaction {
         self
     }
 
+    /// Change the authored signal driver for one object property.
+    ///
+    /// `Some(signal)` binds or rebinds the property and `None` removes its
+    /// authored driver. Rebinding is one semantic mutation rather than a visible
+    /// remove/add pair, so the existing declaration position is preserved.
+    pub fn change_subscription(
+        &mut self,
+        object: SemanticNodeId,
+        property: SemanticObjectProperty,
+        signal: Option<SemanticNodeId>,
+    ) -> &mut Self {
+        self.mutations.push(SemanticMutation::ChangeSubscription {
+            object,
+            property,
+            signal,
+        });
+        self
+    }
+
     pub fn mutations(&self) -> &[SemanticMutation] {
         &self.mutations
     }
@@ -125,9 +163,9 @@ impl SemanticMutationTransaction {
     /// Preflight the complete transaction, then commit every changed mutation.
     ///
     /// No semantic slot is written until all mutations have passed generation,
-    /// target-kind, value-kind, finite-value, and duplicate-mutation validation.
-    /// Once preflight succeeds, commit cannot observe external scene changes
-    /// because the transaction owns `&mut SemanticStore` for the duration.
+    /// target-kind, value-kind, finite-value, subscription, and duplicate-mutation
+    /// validation. Once preflight succeeds, commit cannot observe external scene
+    /// changes because the transaction owns `&mut SemanticStore` for the duration.
     pub fn apply(
         self,
         store: &mut SemanticStore,
@@ -161,6 +199,15 @@ impl SemanticMutationTransaction {
                     written_slots.insert(object);
                     impacts.push(SemanticMutationImpact::ObjectProperty { object, property });
                 }
+                SemanticMutation::ChangeSubscription {
+                    object,
+                    property,
+                    signal,
+                } => {
+                    set_object_subscription(store, object, property, signal);
+                    written_slots.insert(object);
+                    impacts.push(SemanticMutationImpact::Subscription { object, property });
+                }
             }
         }
         store.set_last_mutation_writes(written_slots.len());
@@ -184,6 +231,13 @@ impl SemanticMutationTransaction {
                     }
                     SemanticMutationKey::ObjectProperty { object, property } => {
                         SemanticMutationTransactionError::DuplicateProperty {
+                            index,
+                            object,
+                            property,
+                        }
+                    }
+                    SemanticMutationKey::Subscription { object, property } => {
+                        SemanticMutationTransactionError::DuplicateSubscription {
                             index,
                             object,
                             property,
@@ -251,6 +305,48 @@ impl SemanticMutationTransaction {
                         });
                     }
                     changed.push(object_property_value(state, *property) != *value);
+                }
+                SemanticMutation::ChangeSubscription {
+                    object,
+                    property,
+                    signal,
+                } => {
+                    let state = store
+                        .semantic_object_state_checked(*object)
+                        .map_err(|error| SemanticMutationTransactionError::Object {
+                            index,
+                            error,
+                        })?;
+                    let existing = state
+                        .signal_bindings()
+                        .iter()
+                        .find(|binding| binding.property() == *property)
+                        .map(|binding| binding.signal());
+
+                    if let Some(signal) = signal {
+                        let actual = store.semantic_signal_value_kind(*signal).map_err(|error| {
+                            SemanticMutationTransactionError::Signal { index, error }
+                        })?;
+                        let expected = property.value_kind();
+                        if actual != expected {
+                            return Err(
+                                SemanticMutationTransactionError::SubscriptionTypeMismatch {
+                                    index,
+                                    object: *object,
+                                    property: *property,
+                                    signal: *signal,
+                                    expected,
+                                    actual,
+                                },
+                            );
+                        }
+                        changed.push(existing != Some(*signal));
+                    } else {
+                        // Unbinding is intentionally keyed only by object/property.
+                        // It must be able to remove a generation-safe stale source
+                        // declaration left by the current low-level RemoveNode seam.
+                        changed.push(existing.is_some());
+                    }
                 }
             }
         }
@@ -325,6 +421,35 @@ fn set_object_property(
     }
 }
 
+fn set_object_subscription(
+    store: &mut SemanticStore,
+    object: SemanticNodeId,
+    property: SemanticObjectProperty,
+    signal: Option<SemanticNodeId>,
+) {
+    let bindings = store
+        .node_mut(object)
+        .and_then(|node| node.semantic_object_state_mut())
+        .expect("preflighted semantic object must remain valid while transaction owns the store")
+        .signal_bindings_mut();
+    let position = bindings
+        .iter()
+        .position(|binding| binding.property() == property);
+
+    match (position, signal) {
+        (Some(position), Some(signal)) => {
+            bindings[position] = SemanticSignalBinding::new(signal, property);
+        }
+        (None, Some(signal)) => bindings.push(SemanticSignalBinding::new(signal, property)),
+        (Some(position), None) => {
+            bindings.remove(position);
+        }
+        (None, None) => {
+            unreachable!("unchanged missing subscription is filtered during transaction preflight")
+        }
+    }
+}
+
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct SemanticMutationTransactionResult {
     impacts: Vec<SemanticMutationImpact>,
@@ -343,6 +468,11 @@ pub enum SemanticMutationTransactionError {
         target: SemanticNodeId,
     },
     DuplicateProperty {
+        index: usize,
+        object: SemanticNodeId,
+        property: SemanticObjectProperty,
+    },
+    DuplicateSubscription {
         index: usize,
         object: SemanticNodeId,
         property: SemanticObjectProperty,
@@ -377,6 +507,14 @@ pub enum SemanticMutationTransactionError {
         expected: SemanticSignalValueKind,
         actual: SemanticSignalValueKind,
     },
+    SubscriptionTypeMismatch {
+        index: usize,
+        object: SemanticNodeId,
+        property: SemanticObjectProperty,
+        signal: SemanticNodeId,
+        expected: SemanticSignalValueKind,
+        actual: SemanticSignalValueKind,
+    },
 }
 
 impl std::fmt::Display for SemanticMutationTransactionError {
@@ -395,6 +533,17 @@ impl std::fmt::Display for SemanticMutationTransactionError {
             } => write!(
                 formatter,
                 "semantic transaction mutation {index} repeats property {:?} on object {}:{}",
+                property,
+                object.slot(),
+                object.generation()
+            ),
+            Self::DuplicateSubscription {
+                index,
+                object,
+                property,
+            } => write!(
+                formatter,
+                "semantic transaction mutation {index} repeats subscription for property {:?} on object {}:{}",
                 property,
                 object.slot(),
                 object.generation()
@@ -442,6 +591,22 @@ impl std::fmt::Display for SemanticMutationTransactionError {
             } => write!(
                 formatter,
                 "semantic transaction mutation {index} cannot set property {:?} on object {}:{} of kind {expected} to {actual}",
+                property,
+                object.slot(),
+                object.generation()
+            ),
+            Self::SubscriptionTypeMismatch {
+                index,
+                object,
+                property,
+                signal,
+                expected,
+                actual,
+            } => write!(
+                formatter,
+                "semantic transaction mutation {index} cannot bind {actual} signal {}:{} to property {:?} on object {}:{} requiring {expected}",
+                signal.slot(),
+                signal.generation(),
                 property,
                 object.slot(),
                 object.generation()
@@ -894,3 +1059,6 @@ mod tests {
         assert_eq!(result.impacts().len(), 2);
     }
 }
+
+#[cfg(test)]
+mod subscription_tests;

--- a/crates/noon-core/src/reactive/semantic_transaction.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction.rs
@@ -324,9 +324,10 @@ impl SemanticMutationTransaction {
                         .map(|binding| binding.signal());
 
                     if let Some(signal) = signal {
-                        let actual = store.semantic_signal_value_kind(*signal).map_err(|error| {
-                            SemanticMutationTransactionError::Signal { index, error }
-                        })?;
+                        let actual =
+                            store.semantic_signal_value_kind(*signal).map_err(|error| {
+                                SemanticMutationTransactionError::Signal { index, error }
+                            })?;
                         let expected = property.value_kind();
                         if actual != expected {
                             return Err(

--- a/crates/noon-core/src/reactive/semantic_transaction/subscription_tests.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction/subscription_tests.rs
@@ -1,0 +1,276 @@
+use super::*;
+use crate::{SemanticObjectState, SemanticVec3, StoredGeometry};
+
+fn object(store: &mut SemanticStore, radius: f32) -> SemanticNodeId {
+    store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle { radius }))
+}
+
+fn scalar_input(store: &SemanticStore, signal: SemanticNodeId) -> f64 {
+    let SemanticSignalSource::Input(SemanticSignalValue::Scalar(value)) =
+        store.semantic_signal_state(signal).unwrap().source()
+    else {
+        panic!("expected scalar input signal")
+    };
+    *value
+}
+
+#[test]
+fn mixed_value_property_and_subscription_changes_commit_together() {
+    let mut store = SemanticStore::new();
+    let signal = store.insert_semantic_input_signal(0.5_f64).unwrap();
+    let target = object(&mut store, 1.0);
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .set_signal(signal, 0.75_f64)
+        .set_property(target, SemanticObjectProperty::RotationZ, 0.5_f64)
+        .change_subscription(
+            target,
+            SemanticObjectProperty::ObjectOpacity,
+            Some(signal),
+        );
+
+    let result = transaction.apply(&mut store).unwrap();
+
+    assert_eq!(scalar_input(&store, signal), 0.75);
+    assert_eq!(
+        store
+            .semantic_object_state_checked(target)
+            .unwrap()
+            .transform
+            .rotation_z,
+        0.5
+    );
+    assert_eq!(
+        store.semantic_object_signal_bindings(target).unwrap(),
+        &[SemanticSignalBinding::new(
+            signal,
+            SemanticObjectProperty::ObjectOpacity,
+        )]
+    );
+    assert_eq!(store.last_mutation_stats().slots_written, 2);
+    assert_eq!(
+        result.impacts(),
+        &[
+            SemanticMutationImpact::SignalValue { signal },
+            SemanticMutationImpact::ObjectProperty {
+                object: target,
+                property: SemanticObjectProperty::RotationZ,
+            },
+            SemanticMutationImpact::Subscription {
+                object: target,
+                property: SemanticObjectProperty::ObjectOpacity,
+            },
+        ]
+    );
+}
+
+#[test]
+fn invalid_late_subscription_rolls_back_earlier_changes() {
+    let mut store = SemanticStore::new();
+    let scalar = store.insert_semantic_input_signal(1.0_f64).unwrap();
+    let vector = store
+        .insert_semantic_input_signal(SemanticVec3::new(1.0, 2.0, 3.0))
+        .unwrap();
+    let target = object(&mut store, 1.0);
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .set_signal(scalar, 2.0_f64)
+        .set_property(target, SemanticObjectProperty::RotationZ, 0.5_f64)
+        .change_subscription(
+            target,
+            SemanticObjectProperty::ObjectOpacity,
+            Some(vector),
+        );
+
+    assert_eq!(
+        transaction.apply(&mut store),
+        Err(SemanticMutationTransactionError::SubscriptionTypeMismatch {
+            index: 2,
+            object: target,
+            property: SemanticObjectProperty::ObjectOpacity,
+            signal: vector,
+            expected: SemanticSignalValueKind::Scalar,
+            actual: SemanticSignalValueKind::Vec3,
+        })
+    );
+    assert_eq!(scalar_input(&store, scalar), 1.0);
+    assert_eq!(
+        store
+            .semantic_object_state_checked(target)
+            .unwrap()
+            .transform
+            .rotation_z,
+        0.0
+    );
+    assert!(store
+        .semantic_object_signal_bindings(target)
+        .unwrap()
+        .is_empty());
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+}
+
+#[test]
+fn rebind_preserves_existing_subscription_order() {
+    let mut store = SemanticStore::new();
+    let first = store.insert_semantic_input_signal(0.25_f64).unwrap();
+    let replacement = store.insert_semantic_input_signal(0.75_f64).unwrap();
+    let second = store.insert_semantic_input_signal(2.0_f64).unwrap();
+    let target = object(&mut store, 1.0);
+    store
+        .bind_semantic_signal(first, target, SemanticObjectProperty::ObjectOpacity)
+        .unwrap();
+    store
+        .bind_semantic_signal(second, target, SemanticObjectProperty::StrokeWidth)
+        .unwrap();
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction.change_subscription(
+        target,
+        SemanticObjectProperty::ObjectOpacity,
+        Some(replacement),
+    );
+    let result = transaction.apply(&mut store).unwrap();
+
+    assert_eq!(
+        store.semantic_object_signal_bindings(target).unwrap(),
+        &[
+            SemanticSignalBinding::new(replacement, SemanticObjectProperty::ObjectOpacity),
+            SemanticSignalBinding::new(second, SemanticObjectProperty::StrokeWidth),
+        ]
+    );
+    assert_eq!(store.last_mutation_stats().slots_written, 1);
+    assert_eq!(
+        result.impacts(),
+        &[SemanticMutationImpact::Subscription {
+            object: target,
+            property: SemanticObjectProperty::ObjectOpacity,
+        }]
+    );
+}
+
+#[test]
+fn unbind_cleans_stale_source_and_missing_unbind_is_a_noop() {
+    let mut store = SemanticStore::new();
+    let signal = store.insert_semantic_input_signal(0.5_f64).unwrap();
+    let target = object(&mut store, 1.0);
+    store
+        .bind_semantic_signal(signal, target, SemanticObjectProperty::ObjectOpacity)
+        .unwrap();
+    store.remove_node(signal).unwrap();
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction.change_subscription(target, SemanticObjectProperty::ObjectOpacity, None);
+    let result = transaction.apply(&mut store).unwrap();
+    assert!(store
+        .semantic_object_signal_bindings(target)
+        .unwrap()
+        .is_empty());
+    assert_eq!(store.last_mutation_stats().slots_written, 1);
+    assert_eq!(result.impacts().len(), 1);
+
+    let mut noop = SemanticMutationTransaction::new();
+    noop.change_subscription(target, SemanticObjectProperty::ObjectOpacity, None);
+    let result = noop.apply(&mut store).unwrap();
+    assert!(result.impacts().is_empty());
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+}
+
+#[test]
+fn duplicate_subscription_is_rejected_but_base_property_change_is_independent() {
+    let mut store = SemanticStore::new();
+    let first = store.insert_semantic_input_signal(0.25_f64).unwrap();
+    let second = store.insert_semantic_input_signal(0.75_f64).unwrap();
+    let target = object(&mut store, 1.0);
+    let mut duplicate = SemanticMutationTransaction::new();
+    duplicate
+        .change_subscription(
+            target,
+            SemanticObjectProperty::ObjectOpacity,
+            Some(first),
+        )
+        .change_subscription(
+            target,
+            SemanticObjectProperty::ObjectOpacity,
+            Some(second),
+        );
+
+    assert_eq!(
+        duplicate.apply(&mut store),
+        Err(SemanticMutationTransactionError::DuplicateSubscription {
+            index: 1,
+            object: target,
+            property: SemanticObjectProperty::ObjectOpacity,
+        })
+    );
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+
+    let mut mixed = SemanticMutationTransaction::new();
+    mixed
+        .set_property(target, SemanticObjectProperty::ObjectOpacity, 0.4_f64)
+        .change_subscription(
+            target,
+            SemanticObjectProperty::ObjectOpacity,
+            Some(first),
+        );
+    let result = mixed.apply(&mut store).unwrap();
+    assert_eq!(result.impacts().len(), 2);
+    assert_eq!(store.last_mutation_stats().slots_written, 1);
+}
+
+#[test]
+fn stale_subscription_source_fails_closed_before_mutation() {
+    let mut store = SemanticStore::new();
+    let stale = store.insert_semantic_input_signal(0.5_f64).unwrap();
+    store.remove_node(stale).unwrap();
+    let replacement = object(&mut store, 2.0);
+    assert_eq!(stale.slot(), replacement.slot());
+    assert_ne!(stale.generation(), replacement.generation());
+    let target = object(&mut store, 1.0);
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction.change_subscription(
+        target,
+        SemanticObjectProperty::ObjectOpacity,
+        Some(stale),
+    );
+
+    assert_eq!(
+        transaction.apply(&mut store),
+        Err(SemanticMutationTransactionError::Signal {
+            index: 0,
+            error: SemanticSignalError::UnknownSignal(stale),
+        })
+    );
+    assert!(store
+        .semantic_object_signal_bindings(target)
+        .unwrap()
+        .is_empty());
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+}
+
+#[test]
+fn multiple_subscription_changes_on_one_object_write_one_slot() {
+    let mut store = SemanticStore::new();
+    for index in 0..10_000 {
+        object(&mut store, index as f32 + 1.0);
+    }
+    let opacity = store.insert_semantic_input_signal(0.5_f64).unwrap();
+    let width = store.insert_semantic_input_signal(2.0_f64).unwrap();
+    let target = object(&mut store, 0.5);
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .change_subscription(
+            target,
+            SemanticObjectProperty::ObjectOpacity,
+            Some(opacity),
+        )
+        .change_subscription(
+            target,
+            SemanticObjectProperty::StrokeWidth,
+            Some(width),
+        );
+
+    let result = transaction.apply(&mut store).unwrap();
+
+    assert_eq!(store.last_mutation_stats().slots_written, 1);
+    assert_eq!(result.impacts().len(), 2);
+}

--- a/crates/noon-core/src/reactive/semantic_transaction/subscription_tests.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction/subscription_tests.rs
@@ -23,11 +23,7 @@ fn mixed_value_property_and_subscription_changes_commit_together() {
     transaction
         .set_signal(signal, 0.75_f64)
         .set_property(target, SemanticObjectProperty::RotationZ, 0.5_f64)
-        .change_subscription(
-            target,
-            SemanticObjectProperty::ObjectOpacity,
-            Some(signal),
-        );
+        .change_subscription(target, SemanticObjectProperty::ObjectOpacity, Some(signal));
 
     let result = transaction.apply(&mut store).unwrap();
 
@@ -76,11 +72,7 @@ fn invalid_late_subscription_rolls_back_earlier_changes() {
     transaction
         .set_signal(scalar, 2.0_f64)
         .set_property(target, SemanticObjectProperty::RotationZ, 0.5_f64)
-        .change_subscription(
-            target,
-            SemanticObjectProperty::ObjectOpacity,
-            Some(vector),
-        );
+        .change_subscription(target, SemanticObjectProperty::ObjectOpacity, Some(vector));
 
     assert_eq!(
         transaction.apply(&mut store),
@@ -183,16 +175,8 @@ fn duplicate_subscription_is_rejected_but_base_property_change_is_independent() 
     let target = object(&mut store, 1.0);
     let mut duplicate = SemanticMutationTransaction::new();
     duplicate
-        .change_subscription(
-            target,
-            SemanticObjectProperty::ObjectOpacity,
-            Some(first),
-        )
-        .change_subscription(
-            target,
-            SemanticObjectProperty::ObjectOpacity,
-            Some(second),
-        );
+        .change_subscription(target, SemanticObjectProperty::ObjectOpacity, Some(first))
+        .change_subscription(target, SemanticObjectProperty::ObjectOpacity, Some(second));
 
     assert_eq!(
         duplicate.apply(&mut store),
@@ -207,11 +191,7 @@ fn duplicate_subscription_is_rejected_but_base_property_change_is_independent() 
     let mut mixed = SemanticMutationTransaction::new();
     mixed
         .set_property(target, SemanticObjectProperty::ObjectOpacity, 0.4_f64)
-        .change_subscription(
-            target,
-            SemanticObjectProperty::ObjectOpacity,
-            Some(first),
-        );
+        .change_subscription(target, SemanticObjectProperty::ObjectOpacity, Some(first));
     let result = mixed.apply(&mut store).unwrap();
     assert_eq!(result.impacts().len(), 2);
     assert_eq!(store.last_mutation_stats().slots_written, 1);
@@ -227,11 +207,7 @@ fn stale_subscription_source_fails_closed_before_mutation() {
     assert_ne!(stale.generation(), replacement.generation());
     let target = object(&mut store, 1.0);
     let mut transaction = SemanticMutationTransaction::new();
-    transaction.change_subscription(
-        target,
-        SemanticObjectProperty::ObjectOpacity,
-        Some(stale),
-    );
+    transaction.change_subscription(target, SemanticObjectProperty::ObjectOpacity, Some(stale));
 
     assert_eq!(
         transaction.apply(&mut store),
@@ -258,16 +234,8 @@ fn multiple_subscription_changes_on_one_object_write_one_slot() {
     let target = object(&mut store, 0.5);
     let mut transaction = SemanticMutationTransaction::new();
     transaction
-        .change_subscription(
-            target,
-            SemanticObjectProperty::ObjectOpacity,
-            Some(opacity),
-        )
-        .change_subscription(
-            target,
-            SemanticObjectProperty::StrokeWidth,
-            Some(width),
-        );
+        .change_subscription(target, SemanticObjectProperty::ObjectOpacity, Some(opacity))
+        .change_subscription(target, SemanticObjectProperty::StrokeWidth, Some(width));
 
     let result = transaction.apply(&mut store).unwrap();
 


### PR DESCRIPTION
## Roadmap ownership

- Owning case: #957 / A1.5 — `ChangeSubscription` in the one Semantic Scene mutation transaction
- Builds directly on merged #1025 `SetProperty`
- Parent roadmap: #953
- Validation/locality: #961 / A6.4

## What changed

Extend the existing `SemanticMutationTransaction` with authored signal→property subscription changes:

- add `SemanticMutation::ChangeSubscription { object, property, signal: Option<SemanticNodeId> }`;
- `Some(signal)` binds or rebinds one property; `None` removes its authored driver;
- validate live generational object identity, live signal identity, and signal/property value-kind compatibility during complete transaction preflight;
- rebind in place so replacing a source signal preserves the existing ordered declaration position;
- allow explicit unbind to clean a generation-safe stale source declaration without re-validating that stale source;
- add `SemanticMutationImpact::Subscription { object, property }`;
- count only the target object slot as written; source signal nodes remain read-only.

## Atomicity / interaction with existing mutations

`ChangeSubscription` shares the same complete preflight/commit boundary as `SetSignal` and `SetProperty`. A late invalid subscription prevents earlier valid value/property changes from committing.

Subscription conflict identity is `(object, property)` but is deliberately distinct from the base-property mutation key. This permits one transaction to change a property's authored/base value and its reactive driver together without conflating the two authorities.

Repeated subscription changes to the same `(object, property)` in one transaction are rejected before mutation.

## Stale-reference behavior

Binding/rebinding to `Some(signal)` requires a live signal and fails closed on a stale generation. Unbinding with `None` is keyed only by object/property, matching the existing explicit cleanup contract: it can remove a stale binding left by the temporary low-level `RemoveNode` seam. Automatic reverse cleanup on node deletion remains a later A1.5 concern and is not replaced by an O(total-scene) scan here.

## Tests / locality

Focused tests cover:

- mixed `SetSignal` + `SetProperty` + `ChangeSubscription` commit and impact order;
- late subscription validation failure rolling back earlier mutations;
- rebind preserving binding order;
- stale-source explicit unbind and absent-unbind no-op;
- duplicate subscription rejection while allowing base-property + subscription change on the same property;
- stale source generation rejection;
- 10k unrelated-object locality with two subscription changes on one target writing one semantic slot.

The branch was stacked from #1025's tested head; current master differs only by #1025's merge commit, and the PR tree diff is subscription-only.

Refs #953 #957 #961 #1023 #1025.