### PR TITLE
Ratchet normalized noon-core module ownership

### DIFF
--- a/.github/workflows/architecture-ratchets.yml
+++ b/.github/workflows/architecture-ratchets.yml
@@ -30,12 +30,15 @@ jobs:
           scripts/check.sh
           scripts/architecture-ratchet.sh
           scripts/architecture-ratchet.test.sh
+          scripts/noon-core-module-ownership-ratchet.sh
+          scripts/noon-core-module-ownership-ratchet.test.sh
           scripts/active-perf-frontend-ratchet.sh
           scripts/active-perf-frontend-ratchet.test.sh
 
       - name: Exercise architecture guardrails
         run: |
           bash scripts/architecture-ratchet.test.sh
+          bash scripts/noon-core-module-ownership-ratchet.test.sh
           bash scripts/active-perf-frontend-ratchet.test.sh
 
       - name: Keep ScenePlayer crate-private
@@ -59,4 +62,5 @@ jobs:
             base="HEAD^"
           fi
           bash scripts/architecture-ratchet.sh "$base"
+          bash scripts/noon-core-module-ownership-ratchet.sh
           bash scripts/active-perf-frontend-ratchet.sh

--- a/scripts/noon-core-module-ownership-ratchet.sh
+++ b/scripts/noon-core-module-ownership-ratchet.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+# `reactive.rs -> semantic_store.rs` is a temporary migration seam. This
+# guard protects ordinary module ownership without making that seam permanent:
+# a reviewed normalization may remove it, but no additional `#[path]` or
+# `include!` indirection is allowed.
+temporary_owner='crates/noon-core/src/reactive.rs'
+temporary_target='semantic_store.rs'
+module_indirections="$(
+  rg -n --glob '*.rs' \
+    '^[[:space:]]*#\[[[:space:]]*path[[:space:]]*=|(^|[^[:alnum:]_])include![[:space:]]*(\(|\{|\[)' \
+    crates/noon-core/src || true
+)"
+
+unexpected=0
+while IFS= read -r reference; do
+  [[ -z "$reference" ]] && continue
+
+  reference_file="${reference%%:*}"
+  remainder="${reference#*:}"
+  reference_line="${remainder#*:}"
+  if [[ "$reference_file" != "$temporary_owner" ]] || \
+     ! printf '%s\n' "$reference_line" | grep -Eq \
+       '^[[:space:]]*#\[[[:space:]]*path[[:space:]]*=[[:space:]]*"semantic_store\.rs"[[:space:]]*\][[:space:]]*$'; then
+    printf 'noon-core module ownership ratchet: unexpected indirection: %s\n' "$reference" >&2
+    unexpected=1
+  fi
+done <<< "$module_indirections"
+
+if (( unexpected != 0 )); then
+  cat >&2 <<'EOF'
+
+noon-core module ownership must remain explicit. The current
+`reactive.rs -> semantic_store.rs` `#[path]` is a temporary migration seam;
+it may be removed by a reviewed ownership normalization, but it does not
+authorize another organizational `#[path]` or `include!` indirection.
+EOF
+  exit 1
+fi
+
+echo "noon-core module ownership ratchet passed"

--- a/scripts/noon-core-module-ownership-ratchet.test.sh
+++ b/scripts/noon-core-module-ownership-ratchet.test.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RATCHET="$ROOT/scripts/noon-core-module-ownership-ratchet.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+mkdir -p "$TMP/scripts" "$TMP/crates/noon-core/src"
+cp "$RATCHET" "$TMP/scripts/noon-core-module-ownership-ratchet.sh"
+cd "$TMP"
+git init -q
+git config user.name "Noon Core Module Ownership Ratchet Test"
+git config user.email "ratchet-test@example.invalid"
+
+printf 'mod semantic_store;\nmod ordinary;\n' > crates/noon-core/src/reactive.rs
+printf 'pub struct SemanticStore;\n' > crates/noon-core/src/semantic_store.rs
+printf 'pub fn ordinary() {}\n' > crates/noon-core/src/ordinary.rs
+git add scripts crates/noon-core/src
+git commit -qm "normalized noon-core baseline"
+
+# Fully ordinary ownership is valid: the ratchet must not preserve the
+# temporary seam forever.
+bash scripts/noon-core-module-ownership-ratchet.sh >/dev/null
+
+expect_rejected() {
+  label="$1"
+  if bash scripts/noon-core-module-ownership-ratchet.sh >/dev/null 2>&1; then
+    echo "noon-core module ownership ratchet test failed: accepted $label" >&2
+    exit 1
+  fi
+}
+
+printf '#[path = "hidden_impl.rs"]\nmod hidden_impl;\n' > crates/noon-core/src/hidden.rs
+printf 'pub fn hidden_impl() {}\n' > crates/noon-core/src/hidden_impl.rs
+expect_rejected 'additional #[path] indirection'
+rm crates/noon-core/src/hidden.rs crates/noon-core/src/hidden_impl.rs
+
+printf 'include!("hidden_impl.rs");\n' > crates/noon-core/src/hidden.rs
+printf 'pub fn hidden_impl() {}\n' > crates/noon-core/src/hidden_impl.rs
+expect_rejected 'additional include! indirection'
+
+echo "noon-core module ownership ratchet self-test passed"


### PR DESCRIPTION
## Summary

Add a `noon-core` module-ownership ratchet and wire it into the architecture workflow. It rejects additional organizational `#[path]` and `include!` indirections, including ones present before an unrelated change.

The current `reactive.rs -> semantic_store.rs` seam is treated only as a temporary exception. The ratchet also accepts its reviewed removal, so it does not make that seam a permanent architectural requirement.

## Validation

- `bash scripts/noon-core-module-ownership-ratchet.test.sh`
- `bash scripts/noon-core-module-ownership-ratchet.sh`
- `git diff --check`

## Architecture

The Semantic Scene/store remains the authority. The guard scans the working tree, including untracked files, so it cannot miss a new indirection merely because `git grep` would omit it.


Independent review passed. Local live guard, guard self-test (including untracked regressions and removal of the temporary seam), and `git diff --check` pass. The integrated workspace compile/tests also passed with this guard installed.
