### PR TITLE
Add atomic Semantic Scene content replacement

### DIFF
--- a/crates/noon-core/src/reactive/semantic_transaction.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction.rs
@@ -1,15 +1,15 @@
 use std::collections::HashSet;
 
 use super::{
-    SemanticNodeId, SemanticObjectProperty, SemanticObjectState, SemanticSceneOperationError,
-    SemanticSignalBinding, SemanticSignalError, SemanticSignalSource, SemanticSignalValue,
-    SemanticSignalValueKind, SemanticStore,
+    SemanticNodeId, SemanticObjectContent, SemanticObjectProperty, SemanticObjectState,
+    SemanticSceneOperationError, SemanticSignalBinding, SemanticSignalError, SemanticSignalSource,
+    SemanticSignalValue, SemanticSignalValueKind, SemanticStore,
 };
 
 /// One mutation in the authoritative Semantic Scene transaction vocabulary.
 ///
-/// Signal values, object properties, and authored reactive subscriptions share
-/// the same transaction so frontends, editors, and host integrations cannot
+/// Signal values, object properties, authored content, and reactive subscriptions
+/// share the same transaction so frontends, editors, and host integrations cannot
 /// invent subsystem-specific patch paths. Dependency-expression rewiring remains
 /// authored declaration topology rather than being conflated with a value update.
 #[derive(Clone, Debug, PartialEq)]
@@ -23,6 +23,10 @@ pub enum SemanticMutation {
         property: SemanticObjectProperty,
         value: SemanticSignalValue,
     },
+    ReplaceContent {
+        object: SemanticNodeId,
+        content: SemanticObjectContent,
+    },
     ChangeSubscription {
         object: SemanticNodeId,
         property: SemanticObjectProperty,
@@ -34,7 +38,9 @@ impl SemanticMutation {
     pub const fn target(&self) -> SemanticNodeId {
         match self {
             Self::SetSignal { signal, .. } => *signal,
-            Self::SetProperty { object, .. } | Self::ChangeSubscription { object, .. } => *object,
+            Self::SetProperty { object, .. }
+            | Self::ReplaceContent { object, .. }
+            | Self::ChangeSubscription { object, .. } => *object,
         }
     }
 
@@ -47,6 +53,7 @@ impl SemanticMutation {
                 object: *object,
                 property: *property,
             },
+            Self::ReplaceContent { object, .. } => SemanticMutationKey::ObjectContent(*object),
             Self::ChangeSubscription {
                 object, property, ..
             } => SemanticMutationKey::Subscription {
@@ -64,6 +71,7 @@ enum SemanticMutationKey {
         object: SemanticNodeId,
         property: SemanticObjectProperty,
     },
+    ObjectContent(SemanticNodeId),
     Subscription {
         object: SemanticNodeId,
         property: SemanticObjectProperty,
@@ -83,6 +91,9 @@ pub enum SemanticMutationImpact {
     ObjectProperty {
         object: SemanticNodeId,
         property: SemanticObjectProperty,
+    },
+    ObjectContent {
+        object: SemanticNodeId,
     },
     Subscription {
         object: SemanticNodeId,
@@ -133,6 +144,22 @@ impl SemanticMutationTransaction {
         self
     }
 
+    /// Replace only the authored content reference/value of one semantic object.
+    ///
+    /// Transform, style, painter metadata, signal bindings, identity, family
+    /// relationships, and scene lifecycle are intentionally left untouched.
+    pub fn replace_content(
+        &mut self,
+        object: SemanticNodeId,
+        content: impl Into<SemanticObjectContent>,
+    ) -> &mut Self {
+        self.mutations.push(SemanticMutation::ReplaceContent {
+            object,
+            content: content.into(),
+        });
+        self
+    }
+
     /// Change the authored signal driver for one object property.
     ///
     /// `Some(signal)` binds or rebinds the property and `None` removes its
@@ -163,9 +190,10 @@ impl SemanticMutationTransaction {
     /// Preflight the complete transaction, then commit every changed mutation.
     ///
     /// No semantic slot is written until all mutations have passed generation,
-    /// target-kind, value-kind, finite-value, subscription, and duplicate-mutation
-    /// validation. Once preflight succeeds, commit cannot observe external scene
-    /// changes because the transaction owns `&mut SemanticStore` for the duration.
+    /// target-kind, value-kind, finite-value, content, subscription, and
+    /// duplicate-mutation validation. Once preflight succeeds, commit cannot
+    /// observe external scene changes because the transaction owns
+    /// `&mut SemanticStore` for the duration.
     pub fn apply(
         self,
         store: &mut SemanticStore,
@@ -198,6 +226,11 @@ impl SemanticMutationTransaction {
                     set_object_property(store, object, property, value);
                     written_slots.insert(object);
                     impacts.push(SemanticMutationImpact::ObjectProperty { object, property });
+                }
+                SemanticMutation::ReplaceContent { object, content } => {
+                    set_object_content(store, object, content);
+                    written_slots.insert(object);
+                    impacts.push(SemanticMutationImpact::ObjectContent { object });
                 }
                 SemanticMutation::ChangeSubscription {
                     object,
@@ -235,6 +268,9 @@ impl SemanticMutationTransaction {
                             object,
                             property,
                         }
+                    }
+                    SemanticMutationKey::ObjectContent(object) => {
+                        SemanticMutationTransactionError::DuplicateContent { index, object }
                     }
                     SemanticMutationKey::Subscription { object, property } => {
                         SemanticMutationTransactionError::DuplicateSubscription {
@@ -305,6 +341,15 @@ impl SemanticMutationTransaction {
                         });
                     }
                     changed.push(object_property_value(state, *property) != *value);
+                }
+                SemanticMutation::ReplaceContent { object, content } => {
+                    let state = store
+                        .semantic_object_state_checked(*object)
+                        .map_err(|error| SemanticMutationTransactionError::Object {
+                            index,
+                            error,
+                        })?;
+                    changed.push(state.content != *content);
                 }
                 SemanticMutation::ChangeSubscription {
                     object,
@@ -422,6 +467,18 @@ fn set_object_property(
     }
 }
 
+fn set_object_content(
+    store: &mut SemanticStore,
+    object: SemanticNodeId,
+    content: SemanticObjectContent,
+) {
+    store
+        .node_mut(object)
+        .and_then(|node| node.semantic_object_state_mut())
+        .expect("preflighted semantic object must remain valid while transaction owns the store")
+        .content = content;
+}
+
 fn set_object_subscription(
     store: &mut SemanticStore,
     object: SemanticNodeId,
@@ -472,6 +529,10 @@ pub enum SemanticMutationTransactionError {
         index: usize,
         object: SemanticNodeId,
         property: SemanticObjectProperty,
+    },
+    DuplicateContent {
+        index: usize,
+        object: SemanticNodeId,
     },
     DuplicateSubscription {
         index: usize,
@@ -535,6 +596,12 @@ impl std::fmt::Display for SemanticMutationTransactionError {
                 formatter,
                 "semantic transaction mutation {index} repeats property {:?} on object {}:{}",
                 property,
+                object.slot(),
+                object.generation()
+            ),
+            Self::DuplicateContent { index, object } => write!(
+                formatter,
+                "semantic transaction mutation {index} repeats content replacement on object {}:{}",
                 object.slot(),
                 object.generation()
             ),
@@ -1060,6 +1127,9 @@ mod tests {
         assert_eq!(result.impacts().len(), 2);
     }
 }
+
+#[cfg(test)]
+mod content_tests;
 
 #[cfg(test)]
 mod subscription_tests;

--- a/crates/noon-core/src/reactive/semantic_transaction/content_tests.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction/content_tests.rs
@@ -18,7 +18,11 @@ fn replace_content_changes_only_content_and_preserves_authored_state() {
     let signal = store.insert_semantic_input_signal(0.5_f64).unwrap();
     let target = object(&mut store, 1.0);
     {
-        let state = store.node_mut(target).unwrap().semantic_object_state_mut().unwrap();
+        let state = store
+            .node_mut(target)
+            .unwrap()
+            .semantic_object_state_mut()
+            .unwrap();
         state.transform.translation = SemanticVec3::new(1.0, 2.0, 3.0);
         state.style.object_opacity = 0.75;
         state.set_z_index(7);
@@ -57,11 +61,7 @@ fn content_property_and_subscription_changes_share_one_object_slot() {
     transaction
         .replace_content(target, replacement)
         .set_property(target, SemanticObjectProperty::RotationZ, 0.25_f64)
-        .change_subscription(
-            target,
-            SemanticObjectProperty::ObjectOpacity,
-            Some(signal),
-        );
+        .change_subscription(target, SemanticObjectProperty::ObjectOpacity, Some(signal));
     let result = transaction.apply(&mut store).unwrap();
 
     let state = store.semantic_object_state_checked(target).unwrap();
@@ -136,7 +136,10 @@ fn stale_late_content_target_rolls_back_earlier_mutations() {
         })
     );
     assert_eq!(store.semantic_signal_state(signal).unwrap(), &signal_before);
-    assert_eq!(store.semantic_object_state_checked(live).unwrap(), &live_before);
+    assert_eq!(
+        store.semantic_object_state_checked(live).unwrap(),
+        &live_before
+    );
     assert_eq!(store.last_mutation_stats().slots_written, 0);
 }
 

--- a/crates/noon-core/src/reactive/semantic_transaction/content_tests.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction/content_tests.rs
@@ -1,0 +1,184 @@
+use super::*;
+use crate::{SemanticObjectState, SemanticVec3, StoredGeometry, Vec2};
+
+fn object(store: &mut SemanticStore, radius: f32) -> SemanticNodeId {
+    store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle { radius }))
+}
+
+fn rectangle(width: f32, height: f32) -> SemanticObjectContent {
+    StoredGeometry::Rectangle {
+        size: Vec2::new(width, height),
+    }
+    .into()
+}
+
+#[test]
+fn replace_content_changes_only_content_and_preserves_authored_state() {
+    let mut store = SemanticStore::new();
+    let signal = store.insert_semantic_input_signal(0.5_f64).unwrap();
+    let target = object(&mut store, 1.0);
+    {
+        let state = store.node_mut(target).unwrap().semantic_object_state_mut().unwrap();
+        state.transform.translation = SemanticVec3::new(1.0, 2.0, 3.0);
+        state.style.object_opacity = 0.75;
+        state.set_z_index(7);
+    }
+    store
+        .bind_semantic_signal(signal, target, SemanticObjectProperty::ObjectOpacity)
+        .unwrap();
+    let before = store.semantic_object_state_checked(target).unwrap().clone();
+    let replacement = rectangle(4.0, 2.0);
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction.replace_content(target, replacement);
+    let result = transaction.apply(&mut store).unwrap();
+
+    let after = store.semantic_object_state_checked(target).unwrap();
+    assert_eq!(after.content, replacement);
+    assert_eq!(after.transform, before.transform);
+    assert_eq!(after.style, before.style);
+    assert_eq!(after.presentation(), before.presentation());
+    assert_eq!(after.signal_bindings(), before.signal_bindings());
+    assert_eq!(store.last_mutation_stats().slots_written, 1);
+    assert_eq!(
+        result.impacts(),
+        &[SemanticMutationImpact::ObjectContent { object: target }]
+    );
+}
+
+#[test]
+fn content_property_and_subscription_changes_share_one_object_slot() {
+    let mut store = SemanticStore::new();
+    let signal = store.insert_semantic_input_signal(0.4_f64).unwrap();
+    let target = object(&mut store, 1.0);
+    let replacement = rectangle(3.0, 5.0);
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .replace_content(target, replacement)
+        .set_property(target, SemanticObjectProperty::RotationZ, 0.25_f64)
+        .change_subscription(
+            target,
+            SemanticObjectProperty::ObjectOpacity,
+            Some(signal),
+        );
+    let result = transaction.apply(&mut store).unwrap();
+
+    let state = store.semantic_object_state_checked(target).unwrap();
+    assert_eq!(state.content, replacement);
+    assert_eq!(state.transform.rotation_z, 0.25);
+    assert_eq!(state.signal_bindings().len(), 1);
+    assert_eq!(store.last_mutation_stats().slots_written, 1);
+    assert_eq!(
+        result.impacts(),
+        &[
+            SemanticMutationImpact::ObjectContent { object: target },
+            SemanticMutationImpact::ObjectProperty {
+                object: target,
+                property: SemanticObjectProperty::RotationZ,
+            },
+            SemanticMutationImpact::Subscription {
+                object: target,
+                property: SemanticObjectProperty::ObjectOpacity,
+            },
+        ]
+    );
+}
+
+#[test]
+fn duplicate_content_replacement_is_rejected_before_mutation() {
+    let mut store = SemanticStore::new();
+    let target = object(&mut store, 1.0);
+    let before = store.semantic_object_state_checked(target).unwrap().content;
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .replace_content(target, rectangle(2.0, 2.0))
+        .replace_content(target, rectangle(3.0, 3.0));
+
+    assert_eq!(
+        transaction.apply(&mut store),
+        Err(SemanticMutationTransactionError::DuplicateContent {
+            index: 1,
+            object: target,
+        })
+    );
+    assert_eq!(
+        store.semantic_object_state_checked(target).unwrap().content,
+        before
+    );
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+}
+
+#[test]
+fn stale_late_content_target_rolls_back_earlier_mutations() {
+    let mut store = SemanticStore::new();
+    let signal = store.insert_semantic_input_signal(1.0_f64).unwrap();
+    let live = object(&mut store, 1.0);
+    let stale = object(&mut store, 2.0);
+    store.remove_node(stale).unwrap();
+    let replacement_node = object(&mut store, 3.0);
+    assert_eq!(stale.slot(), replacement_node.slot());
+    assert_ne!(stale.generation(), replacement_node.generation());
+    let live_before = store.semantic_object_state_checked(live).unwrap().clone();
+    let signal_before = store.semantic_signal_state(signal).unwrap().clone();
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .set_signal(signal, 2.0_f64)
+        .set_property(live, SemanticObjectProperty::RotationZ, 0.5_f64)
+        .replace_content(stale, rectangle(4.0, 4.0));
+
+    assert_eq!(
+        transaction.apply(&mut store),
+        Err(SemanticMutationTransactionError::Object {
+            index: 2,
+            error: SemanticSceneOperationError::UnknownNode(stale),
+        })
+    );
+    assert_eq!(store.semantic_signal_state(signal).unwrap(), &signal_before);
+    assert_eq!(store.semantic_object_state_checked(live).unwrap(), &live_before);
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+}
+
+#[test]
+fn unchanged_content_is_a_noop_and_wrong_target_fails_closed() {
+    let mut store = SemanticStore::new();
+    let target = object(&mut store, 1.0);
+    let content = store.semantic_object_state_checked(target).unwrap().content;
+    let mut unchanged = SemanticMutationTransaction::new();
+    unchanged.replace_content(target, content);
+    let result = unchanged.apply(&mut store).unwrap();
+    assert!(result.impacts().is_empty());
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+
+    let family = store.insert_family();
+    let mut wrong_target = SemanticMutationTransaction::new();
+    wrong_target.replace_content(family, rectangle(2.0, 2.0));
+    assert_eq!(
+        wrong_target.apply(&mut store),
+        Err(SemanticMutationTransactionError::Object {
+            index: 0,
+            error: SemanticSceneOperationError::NotSemanticObject(family),
+        })
+    );
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+}
+
+#[test]
+fn content_replacement_is_one_slot_local_with_large_unrelated_scene() {
+    let mut store = SemanticStore::new();
+    for index in 0..10_000 {
+        object(&mut store, index as f32 + 1.0);
+    }
+    let target = object(&mut store, 0.5);
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction.replace_content(target, rectangle(8.0, 6.0));
+
+    let result = transaction.apply(&mut store).unwrap();
+
+    assert_eq!(store.last_mutation_stats().slots_written, 1);
+    assert_eq!(
+        result.impacts(),
+        &[SemanticMutationImpact::ObjectContent { object: target }]
+    );
+}


### PR DESCRIPTION
## Roadmap ownership

- Owning case: #957 / A1.5 — `ReplaceContent` in the one Semantic Scene mutation transaction
- Builds on merged #1027 `ChangeSubscription`
- Parent roadmap: #953
- Validation/locality: #961 / A6.4

## What changed

Extend the existing `SemanticMutationTransaction` with authored object-content replacement rather than creating a content-specific patch path:

- add `SemanticMutation::ReplaceContent { object, content }` using the existing `SemanticObjectContent` vocabulary;
- add `SemanticMutationImpact::ObjectContent { object }`;
- validate live generational semantic object identity during complete transaction preflight;
- reject repeated content replacement of the same object in one transaction;
- treat unchanged content as a zero-write/no-impact no-op;
- replace only `SemanticObjectState::content`, preserving transform, style, presentation/insertion metadata, signal bindings, identity, family edges, and lifecycle;
- allow content replacement to coexist with property and subscription changes on the same object while counting one written semantic slot.

## Validation policy

This slice does not invent new geometry range or resource-liveness policy. `SemanticObjectContent` is already the authoritative authored content vocabulary; heavy geometry/text identities remain owned and validated by their existing resource arenas. `ReplaceContent` validates the semantic target and transaction conflicts, then swaps the authored content reference/value.

## Atomicity / locality

Focused tests cover:

- content-only mutation preserves every other authored object field;
- content + property + subscription changes on one object commit together and write one slot;
- duplicate content replacement rejects before mutation;
- a late stale content target rolls back earlier signal/property changes;
- unchanged content is a no-op and family/non-object targets fail closed;
- 10k unrelated semantic objects do not increase the one-slot write set.

GitHub CI is the executable compile/test/architecture gate.

Refs #953 #957 #961 #1023 #1025 #1027.