### PR TITLE
Add atomic Semantic Scene family edge mutations

### DIFF
--- a/crates/noon-core/src/reactive/semantic_transaction.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction.rs
@@ -1,16 +1,20 @@
 use std::collections::HashSet;
 
 use super::{
-    SemanticNodeId, SemanticObjectContent, SemanticObjectProperty, SemanticObjectState,
-    SemanticSceneOperationError, SemanticSignalBinding, SemanticSignalError, SemanticSignalSource,
-    SemanticSignalValue, SemanticSignalValueKind, SemanticStore,
+    SemanticNodeId, SemanticNodeKind, SemanticObjectContent, SemanticObjectProperty,
+    SemanticObjectState, SemanticSceneOperationError, SemanticSignalBinding, SemanticSignalError,
+    SemanticSignalSource, SemanticSignalValue, SemanticSignalValueKind, SemanticStore,
+    SemanticStoreError,
 };
+
+mod family_edges;
+use family_edges::FamilyEdgePreflight;
 
 /// One mutation in the authoritative Semantic Scene transaction vocabulary.
 ///
-/// Signal values, object properties, authored content, and reactive subscriptions
-/// share the same transaction so frontends, editors, and host integrations cannot
-/// invent subsystem-specific patch paths. Dependency-expression rewiring remains
+/// Signal values, object properties, authored content, family membership, and reactive
+/// subscriptions share the same transaction so frontends, editors, and host integrations
+/// cannot invent subsystem-specific patch paths. Dependency-expression rewiring remains
 /// authored declaration topology rather than being conflated with a value update.
 #[derive(Clone, Debug, PartialEq)]
 pub enum SemanticMutation {
@@ -32,6 +36,14 @@ pub enum SemanticMutation {
         property: SemanticObjectProperty,
         signal: Option<SemanticNodeId>,
     },
+    AddMember {
+        family: SemanticNodeId,
+        member: SemanticNodeId,
+    },
+    RemoveMember {
+        family: SemanticNodeId,
+        member: SemanticNodeId,
+    },
 }
 
 impl SemanticMutation {
@@ -41,6 +53,7 @@ impl SemanticMutation {
             Self::SetProperty { object, .. }
             | Self::ReplaceContent { object, .. }
             | Self::ChangeSubscription { object, .. } => *object,
+            Self::AddMember { family, .. } | Self::RemoveMember { family, .. } => *family,
         }
     }
 
@@ -60,6 +73,12 @@ impl SemanticMutation {
                 object: *object,
                 property: *property,
             },
+            Self::AddMember { family, member } | Self::RemoveMember { family, member } => {
+                SemanticMutationKey::FamilyEdge {
+                    family: *family,
+                    member: *member,
+                }
+            }
         }
     }
 }
@@ -75,6 +94,10 @@ enum SemanticMutationKey {
     Subscription {
         object: SemanticNodeId,
         property: SemanticObjectProperty,
+    },
+    FamilyEdge {
+        family: SemanticNodeId,
+        member: SemanticNodeId,
     },
 }
 
@@ -98,6 +121,14 @@ pub enum SemanticMutationImpact {
     Subscription {
         object: SemanticNodeId,
         property: SemanticObjectProperty,
+    },
+    FamilyMemberAdded {
+        family: SemanticNodeId,
+        member: SemanticNodeId,
+    },
+    FamilyMemberRemoved {
+        family: SemanticNodeId,
+        member: SemanticNodeId,
     },
 }
 
@@ -179,6 +210,20 @@ impl SemanticMutationTransaction {
         self
     }
 
+    /// Add one direct ordered family edge through the authoritative transaction.
+    pub fn add_member(&mut self, family: SemanticNodeId, member: SemanticNodeId) -> &mut Self {
+        self.mutations
+            .push(SemanticMutation::AddMember { family, member });
+        self
+    }
+
+    /// Remove one direct ordered family edge through the authoritative transaction.
+    pub fn remove_member(&mut self, family: SemanticNodeId, member: SemanticNodeId) -> &mut Self {
+        self.mutations
+            .push(SemanticMutation::RemoveMember { family, member });
+        self
+    }
+
     pub fn mutations(&self) -> &[SemanticMutation] {
         &self.mutations
     }
@@ -190,8 +235,8 @@ impl SemanticMutationTransaction {
     /// Preflight the complete transaction, then commit every changed mutation.
     ///
     /// No semantic slot is written until all mutations have passed generation,
-    /// target-kind, value-kind, finite-value, content, subscription, and
-    /// duplicate-mutation validation. Once preflight succeeds, commit cannot
+    /// target-kind, value-kind, finite-value, content, subscription, family-edge,
+    /// and duplicate-mutation validation. Once preflight succeeds, commit cannot
     /// observe external scene changes because the transaction owns
     /// `&mut SemanticStore` for the duration.
     pub fn apply(
@@ -241,6 +286,23 @@ impl SemanticMutationTransaction {
                     written_slots.insert(object);
                     impacts.push(SemanticMutationImpact::Subscription { object, property });
                 }
+                SemanticMutation::AddMember { family, member } => {
+                    store.add_member(family, member).expect(
+                        "preflighted family add must remain valid while transaction owns the semantic store",
+                    );
+                    written_slots.insert(family);
+                    written_slots.insert(member);
+                    impacts.push(SemanticMutationImpact::FamilyMemberAdded { family, member });
+                }
+                SemanticMutation::RemoveMember { family, member } => {
+                    let removed = store.remove_member(family, member).expect(
+                        "preflighted family removal must remain valid while transaction owns the semantic store",
+                    );
+                    debug_assert!(removed);
+                    written_slots.insert(family);
+                    written_slots.insert(member);
+                    impacts.push(SemanticMutationImpact::FamilyMemberRemoved { family, member });
+                }
             }
         }
         store.set_last_mutation_writes(written_slots.len());
@@ -254,6 +316,7 @@ impl SemanticMutationTransaction {
     ) -> Result<Vec<bool>, SemanticMutationTransactionError> {
         let mut targets = HashSet::with_capacity(self.mutations.len());
         let mut changed = Vec::with_capacity(self.mutations.len());
+        let mut family_edges = FamilyEdgePreflight::default();
 
         for (index, mutation) in self.mutations.iter().enumerate() {
             let key = mutation.key();
@@ -277,6 +340,13 @@ impl SemanticMutationTransaction {
                             index,
                             object,
                             property,
+                        }
+                    }
+                    SemanticMutationKey::FamilyEdge { family, member } => {
+                        SemanticMutationTransactionError::DuplicateFamilyEdge {
+                            index,
+                            family,
+                            member,
                         }
                     }
                 });
@@ -393,6 +463,16 @@ impl SemanticMutationTransaction {
                         // declaration left by the current low-level RemoveNode seam.
                         changed.push(existing.is_some());
                     }
+                }
+                SemanticMutation::AddMember { family, member } => {
+                    changed.push(family_edges.add(store, *family, *member).map_err(|error| {
+                        SemanticMutationTransactionError::Family { index, error }
+                    })?);
+                }
+                SemanticMutation::RemoveMember { family, member } => {
+                    changed.push(family_edges.remove(store, *family, *member).map_err(
+                        |error| SemanticMutationTransactionError::Family { index, error },
+                    )?);
                 }
             }
         }
@@ -539,6 +619,11 @@ pub enum SemanticMutationTransactionError {
         object: SemanticNodeId,
         property: SemanticObjectProperty,
     },
+    DuplicateFamilyEdge {
+        index: usize,
+        family: SemanticNodeId,
+        member: SemanticNodeId,
+    },
     Signal {
         index: usize,
         error: SemanticSignalError,
@@ -554,6 +639,10 @@ pub enum SemanticMutationTransactionError {
         actual: SemanticSignalValueKind,
     },
     Object {
+        index: usize,
+        error: SemanticSceneOperationError,
+    },
+    Family {
         index: usize,
         error: SemanticSceneOperationError,
     },
@@ -616,6 +705,18 @@ impl std::fmt::Display for SemanticMutationTransactionError {
                 object.slot(),
                 object.generation()
             ),
+            Self::DuplicateFamilyEdge {
+                index,
+                family,
+                member,
+            } => write!(
+                formatter,
+                "semantic transaction mutation {index} repeats family edge {}:{} -> {}:{}",
+                family.slot(),
+                family.generation(),
+                member.slot(),
+                member.generation()
+            ),
             Self::Signal { index, error } => {
                 write!(formatter, "semantic transaction mutation {index}: {error}")
             }
@@ -637,6 +738,9 @@ impl std::fmt::Display for SemanticMutationTransactionError {
                 signal.generation()
             ),
             Self::Object { index, error } => {
+                write!(formatter, "semantic transaction mutation {index}: {error}")
+            }
+            Self::Family { index, error } => {
                 write!(formatter, "semantic transaction mutation {index}: {error}")
             }
             Self::NonFinitePropertyValue {
@@ -1133,3 +1237,6 @@ mod content_tests;
 
 #[cfg(test)]
 mod subscription_tests;
+
+#[cfg(test)]
+mod family_edge_tests;

--- a/crates/noon-core/src/reactive/semantic_transaction/family_edge_tests.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction/family_edge_tests.rs
@@ -1,0 +1,260 @@
+use super::*;
+use crate::{SemanticObjectState, SemanticVec3, StoredGeometry};
+
+fn object(store: &mut SemanticStore, radius: f32) -> SemanticNodeId {
+    store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle { radius }))
+}
+
+fn scalar_input(store: &SemanticStore, signal: SemanticNodeId) -> f64 {
+    let SemanticSignalSource::Input(SemanticSignalValue::Scalar(value)) =
+        store.semantic_signal_state(signal).unwrap().source()
+    else {
+        panic!("expected scalar input signal")
+    };
+    *value
+}
+
+#[test]
+fn family_edges_share_the_atomic_transaction_and_impact_order() {
+    let mut store = SemanticStore::new();
+    let signal = store.insert_semantic_input_signal(0.5_f64).unwrap();
+    let target = object(&mut store, 1.0);
+    let family = store.insert_family();
+    let first = object(&mut store, 2.0);
+    let second = object(&mut store, 3.0);
+    store.add_member(family, first).unwrap();
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .set_signal(signal, 0.75_f64)
+        .set_property(
+            target,
+            SemanticObjectProperty::Translation,
+            SemanticVec3::new(1.0, 2.0, 3.0),
+        )
+        .remove_member(family, first)
+        .add_member(family, second);
+
+    let result = transaction.apply(&mut store).unwrap();
+
+    assert_eq!(scalar_input(&store, signal), 0.75);
+    assert_eq!(store.node(family).unwrap().members(), vec![second]);
+    assert!(store.node(first).unwrap().parents().is_empty());
+    assert_eq!(store.node(second).unwrap().parents(), &[family]);
+    assert_eq!(store.last_mutation_stats().slots_written, 5);
+    assert_eq!(
+        result.impacts(),
+        &[
+            SemanticMutationImpact::SignalValue { signal },
+            SemanticMutationImpact::ObjectProperty {
+                object: target,
+                property: SemanticObjectProperty::Translation,
+            },
+            SemanticMutationImpact::FamilyMemberRemoved {
+                family,
+                member: first,
+            },
+            SemanticMutationImpact::FamilyMemberAdded {
+                family,
+                member: second,
+            },
+        ]
+    );
+}
+
+#[test]
+fn late_family_cycle_rolls_back_earlier_value_and_edge_changes() {
+    let mut store = SemanticStore::new();
+    let signal = store.insert_semantic_input_signal(1.0_f64).unwrap();
+    let outer = store.insert_family();
+    let inner = store.insert_family();
+    let leaf = object(&mut store, 1.0);
+    store.add_member(outer, inner).unwrap();
+    let signal_before = scalar_input(&store, signal);
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .set_signal(signal, 2.0_f64)
+        .add_member(inner, leaf)
+        .add_member(inner, outer);
+
+    assert_eq!(
+        transaction.apply(&mut store),
+        Err(SemanticMutationTransactionError::Family {
+            index: 2,
+            error: SemanticSceneOperationError::Store(SemanticStoreError::FamilyCycle {
+                family: inner,
+                member: outer,
+            }),
+        })
+    );
+    assert_eq!(scalar_input(&store, signal), signal_before);
+    assert!(store.node(inner).unwrap().members().is_empty());
+    assert_eq!(store.node(outer).unwrap().members(), vec![inner]);
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+}
+
+#[test]
+fn family_preflight_detects_cycle_created_only_by_multiple_pending_adds() {
+    let mut store = SemanticStore::new();
+    let first = store.insert_family();
+    let second = store.insert_family();
+    let third = store.insert_family();
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .add_member(first, second)
+        .add_member(second, third)
+        .add_member(third, first);
+
+    assert_eq!(
+        transaction.apply(&mut store),
+        Err(SemanticMutationTransactionError::Family {
+            index: 2,
+            error: SemanticSceneOperationError::Store(SemanticStoreError::FamilyCycle {
+                family: third,
+                member: first,
+            }),
+        })
+    );
+    assert!(store.node(first).unwrap().members().is_empty());
+    assert!(store.node(second).unwrap().members().is_empty());
+    assert!(store.node(third).unwrap().members().is_empty());
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+}
+
+#[test]
+fn pending_removal_is_visible_to_later_cycle_validation() {
+    let mut store = SemanticStore::new();
+    let first = store.insert_family();
+    let second = store.insert_family();
+    let third = store.insert_family();
+    store.add_member(first, second).unwrap();
+    store.add_member(second, third).unwrap();
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .remove_member(first, second)
+        .add_member(third, first);
+
+    let result = transaction.apply(&mut store).unwrap();
+
+    assert!(store.node(first).unwrap().members().is_empty());
+    assert_eq!(store.node(second).unwrap().members(), vec![third]);
+    assert_eq!(store.node(third).unwrap().members(), vec![first]);
+    assert_eq!(result.impacts().len(), 2);
+    assert_eq!(store.last_mutation_stats().slots_written, 3);
+}
+
+#[test]
+fn repeated_family_edge_mutation_is_rejected_before_commit() {
+    let mut store = SemanticStore::new();
+    let family = store.insert_family();
+    let member = object(&mut store, 1.0);
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .add_member(family, member)
+        .remove_member(family, member);
+
+    assert_eq!(
+        transaction.apply(&mut store),
+        Err(SemanticMutationTransactionError::DuplicateFamilyEdge {
+            index: 1,
+            family,
+            member,
+        })
+    );
+    assert!(store.node(family).unwrap().members().is_empty());
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+}
+
+#[test]
+fn stale_family_member_identity_fails_closed_and_rolls_back() {
+    let mut store = SemanticStore::new();
+    let signal = store.insert_semantic_input_signal(1.0_f64).unwrap();
+    let family = store.insert_family();
+    let stale = object(&mut store, 1.0);
+    store.remove_node(stale).unwrap();
+    let replacement = object(&mut store, 2.0);
+    assert_eq!(stale.slot(), replacement.slot());
+    assert_ne!(stale.generation(), replacement.generation());
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .set_signal(signal, 2.0_f64)
+        .add_member(family, stale);
+
+    assert_eq!(
+        transaction.apply(&mut store),
+        Err(SemanticMutationTransactionError::Family {
+            index: 1,
+            error: SemanticSceneOperationError::UnknownNode(stale),
+        })
+    );
+    assert_eq!(scalar_input(&store, signal), 1.0);
+    assert!(store.node(family).unwrap().members().is_empty());
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+}
+
+#[test]
+fn family_edge_rejects_non_target_authoring_members() {
+    let mut store = SemanticStore::new();
+    let family = store.insert_family();
+    let signal = store.insert_semantic_input_signal(1.0_f64).unwrap();
+    let identity_only = store.insert_authoring_object();
+
+    for member in [signal, identity_only] {
+        let mut transaction = SemanticMutationTransaction::new();
+        transaction.add_member(family, member);
+        assert_eq!(
+            transaction.apply(&mut store),
+            Err(SemanticMutationTransactionError::Family {
+                index: 0,
+                error: SemanticSceneOperationError::NotSemanticAuthoringNode(member),
+            })
+        );
+        assert!(store.node(family).unwrap().members().is_empty());
+        assert_eq!(store.last_mutation_stats().slots_written, 0);
+    }
+}
+
+#[test]
+fn existing_add_and_absent_remove_are_noops() {
+    let mut store = SemanticStore::new();
+    let family = store.insert_family();
+    let existing = object(&mut store, 1.0);
+    let absent = object(&mut store, 2.0);
+    store.add_member(family, existing).unwrap();
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .add_member(family, existing)
+        .remove_member(family, absent);
+
+    let result = transaction.apply(&mut store).unwrap();
+
+    assert_eq!(store.node(family).unwrap().members(), vec![existing]);
+    assert!(result.impacts().is_empty());
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+}
+
+#[test]
+fn family_edge_transaction_writes_only_affected_slots_with_large_unrelated_scene() {
+    let mut store = SemanticStore::new();
+    for index in 0..10_000 {
+        object(&mut store, index as f32 + 1.0);
+    }
+    let family = store.insert_family();
+    let removed = object(&mut store, 1.0);
+    let added = object(&mut store, 2.0);
+    store.add_member(family, removed).unwrap();
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .remove_member(family, removed)
+        .add_member(family, added);
+
+    let result = transaction.apply(&mut store).unwrap();
+
+    assert_eq!(store.node(family).unwrap().members(), vec![added]);
+    assert_eq!(store.last_mutation_stats().slots_written, 3);
+    assert_eq!(result.impacts().len(), 2);
+}

--- a/crates/noon-core/src/reactive/semantic_transaction/family_edges.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction/family_edges.rs
@@ -1,0 +1,131 @@
+use std::collections::{HashMap, HashSet};
+
+use super::{
+    SemanticNodeId, SemanticNodeKind, SemanticSceneOperationError, SemanticStore,
+    SemanticStoreError,
+};
+
+#[derive(Debug, Default)]
+pub(super) struct FamilyEdgePreflight {
+    overrides: HashMap<(SemanticNodeId, SemanticNodeId), bool>,
+}
+
+impl FamilyEdgePreflight {
+    pub(super) fn add(
+        &mut self,
+        store: &SemanticStore,
+        family: SemanticNodeId,
+        member: SemanticNodeId,
+    ) -> Result<bool, SemanticSceneOperationError> {
+        validate_edge(store, family, member)?;
+        if self.contains(store, family, member) {
+            return Ok(false);
+        }
+        if family == member || self.reaches(store, member, family) {
+            return Err(SemanticSceneOperationError::Store(
+                SemanticStoreError::FamilyCycle { family, member },
+            ));
+        }
+        self.overrides.insert((family, member), true);
+        Ok(true)
+    }
+
+    pub(super) fn remove(
+        &mut self,
+        store: &SemanticStore,
+        family: SemanticNodeId,
+        member: SemanticNodeId,
+    ) -> Result<bool, SemanticSceneOperationError> {
+        validate_edge(store, family, member)?;
+        let changed = self.contains(store, family, member);
+        if changed {
+            self.overrides.insert((family, member), false);
+        }
+        Ok(changed)
+    }
+
+    fn contains(
+        &self,
+        store: &SemanticStore,
+        family: SemanticNodeId,
+        member: SemanticNodeId,
+    ) -> bool {
+        self.overrides
+            .get(&(family, member))
+            .copied()
+            .unwrap_or_else(|| {
+                store
+                    .node(family)
+                    .is_some_and(|node| node.members().contains(&member))
+            })
+    }
+
+    fn reaches(
+        &self,
+        store: &SemanticStore,
+        start: SemanticNodeId,
+        target: SemanticNodeId,
+    ) -> bool {
+        let mut stack = vec![start];
+        let mut seen = HashSet::new();
+        while let Some(current) = stack.pop() {
+            if !seen.insert(current) {
+                continue;
+            }
+            if current == target {
+                return true;
+            }
+            stack.extend(self.members(store, current));
+        }
+        false
+    }
+
+    fn members(&self, store: &SemanticStore, family: SemanticNodeId) -> Vec<SemanticNodeId> {
+        let mut members = store
+            .node(family)
+            .map(|node| node.members())
+            .unwrap_or_default();
+        members.retain(|member| {
+            self.overrides
+                .get(&(family, *member))
+                .copied()
+                .unwrap_or(true)
+        });
+        for ((override_family, member), present) in &self.overrides {
+            if *override_family == family && *present && !members.contains(member) {
+                members.push(*member);
+            }
+        }
+        members
+    }
+}
+
+fn validate_edge(
+    store: &SemanticStore,
+    family: SemanticNodeId,
+    member: SemanticNodeId,
+) -> Result<(), SemanticSceneOperationError> {
+    let family_node = store
+        .node(family)
+        .ok_or(SemanticSceneOperationError::UnknownNode(family))?;
+    if !matches!(family_node.kind(), SemanticNodeKind::Family) {
+        return Err(SemanticSceneOperationError::NotSemanticFamily(family));
+    }
+
+    let member_node = store
+        .node(member)
+        .ok_or(SemanticSceneOperationError::UnknownNode(member))?;
+    let is_target_authoring_node = match member_node.kind() {
+        SemanticNodeKind::Family => true,
+        SemanticNodeKind::AuthoringObject => member_node.semantic_object_state().is_some(),
+        SemanticNodeKind::Object(_)
+        | SemanticNodeKind::Signal(_)
+        | SemanticNodeKind::Animation(_) => false,
+    };
+    if !is_target_authoring_node {
+        return Err(SemanticSceneOperationError::NotSemanticAuthoringNode(
+            member,
+        ));
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Roadmap ownership

- Owning case: #957 / A1.5 — `AddMember` / `RemoveMember` in the one Semantic Scene mutation transaction
- Builds on merged #1030 `ReplaceContent`
- Parent roadmap: #953
- Validation/locality: #961 / A6.4

## What changed

Extend the existing `SemanticMutationTransaction` with direct ordered family-edge changes rather than creating a structural patch API:

- add `SemanticMutation::AddMember { family, member }` and `RemoveMember { family, member }`;
- add ordered family-membership impact classifications;
- use a transaction-local family-edge overlay during preflight so earlier pending adds/removes are visible to later cycle checks without cloning/scanning the whole Semantic Store;
- reject repeated/contradictory mutation of the same `(family, member)` edge before commit;
- preserve idempotent existing-add / absent-remove behavior as zero-write/no-impact;
- commit through the authoritative store family primitives after complete preflight;
- count unique written semantic nodes across family/value/property mutations.

## Target family contract

Transaction preflight follows the shared target family API, not the lower-level migration-capable store primitive: the family must be a semantic family and members must be target semantic objects or families. Signals, animations, migration objects, and state-less authoring seams are rejected.

## Atomicity / locality

Focused tests cover:

- mixed signal/property/remove/add commit and deterministic impact order;
- a late cycle rolling back earlier value and edge mutations;
- cycles created only by multiple pending adds;
- a pending remove affecting a later cycle check;
- duplicate/contradictory same-edge mutations;
- stale generation and non-target member rejection;
- idempotent existing-add / absent-remove no-ops;
- 10k unrelated semantic objects while two family-edge changes touch only the family and two members.

The transaction-local overlay is proportional to the affected family closure plus the transaction's own edge changes; no O(total-scene) scan is introduced.

GitHub CI is the executable compile/test/architecture gate.

Refs #953 #957 #961 #1023 #1025 #1027 #1030.