### PR TITLE
Add atomic semantic RemoveNode reverse cleanup

### DIFF
--- a/crates/noon-core/src/reactive/semantic_bindings.rs
+++ b/crates/noon-core/src/reactive/semantic_bindings.rs
@@ -134,6 +134,7 @@ impl SemanticStore {
             .expect("semantic binding target validated before mutation")
             .signal_bindings_mut()
             .push(SemanticSignalBinding::new(signal, property));
+        self.register_semantic_references_for_owner(target);
         self.set_last_mutation_writes(1);
         Ok(true)
     }
@@ -150,19 +151,23 @@ impl SemanticStore {
         property: SemanticObjectProperty,
     ) -> Result<Option<SemanticSignalBinding>, SemanticSignalBindingError> {
         self.set_last_mutation_writes(0);
-        self.semantic_object_state_checked(target)?;
-        let bindings = self
-            .node_mut(target)
-            .and_then(|node| node.semantic_object_state_mut())
-            .expect("semantic binding target validated before mutation")
-            .signal_bindings_mut();
-        let Some(index) = bindings
+        let state = self.semantic_object_state_checked(target)?;
+        let Some(index) = state
+            .signal_bindings()
             .iter()
             .position(|binding| binding.property() == property)
         else {
             return Ok(None);
         };
-        let removed = bindings.remove(index);
+
+        self.unregister_semantic_references_for_owner(target);
+        let removed = self
+            .node_mut(target)
+            .and_then(|node| node.semantic_object_state_mut())
+            .expect("semantic binding target validated before mutation")
+            .signal_bindings_mut()
+            .remove(index);
+        self.register_semantic_references_for_owner(target);
         self.set_last_mutation_writes(1);
         Ok(Some(removed))
     }

--- a/crates/noon-core/src/reactive/semantic_signals.rs
+++ b/crates/noon-core/src/reactive/semantic_signals.rs
@@ -290,10 +290,12 @@ impl SemanticStore {
             return Ok(false);
         }
 
+        self.unregister_semantic_references_for_owner(id);
         self.node_mut(id)
             .and_then(|node| node.semantic_signal_state_mut())
             .expect("semantic signal existence validated before mutation")
             .source = source;
+        self.register_semantic_references_for_owner(id);
         self.set_last_mutation_writes(1);
         Ok(true)
     }

--- a/crates/noon-core/src/reactive/semantic_transaction.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 
+use super::semantic_store::SemanticRemoveNodeEffect;
 use super::{
     SemanticNodeId, SemanticNodeKind, SemanticObjectContent, SemanticObjectProperty,
     SemanticObjectState, SemanticSceneOperationError, SemanticSignalBinding, SemanticSignalError,
@@ -12,10 +13,11 @@ use family_edges::FamilyEdgePreflight;
 
 /// One mutation in the authoritative Semantic Scene transaction vocabulary.
 ///
-/// Signal values, object properties, authored content, family membership, and reactive
-/// subscriptions share the same transaction so frontends, editors, and host integrations
-/// cannot invent subsystem-specific patch paths. Dependency-expression rewiring remains
-/// authored declaration topology rather than being conflated with a value update.
+/// Signal values, object properties, authored content, family membership,
+/// reactive subscriptions, and structural deletion share the same transaction so
+/// frontends, editors, and host integrations cannot invent subsystem-specific
+/// patch paths. Dependency-expression rewiring remains authored declaration
+/// topology rather than being conflated with a value update.
 #[derive(Clone, Debug, PartialEq)]
 pub enum SemanticMutation {
     SetSignal {
@@ -44,6 +46,9 @@ pub enum SemanticMutation {
         family: SemanticNodeId,
         member: SemanticNodeId,
     },
+    RemoveNode {
+        node: SemanticNodeId,
+    },
 }
 
 impl SemanticMutation {
@@ -54,6 +59,7 @@ impl SemanticMutation {
             | Self::ReplaceContent { object, .. }
             | Self::ChangeSubscription { object, .. } => *object,
             Self::AddMember { family, .. } | Self::RemoveMember { family, .. } => *family,
+            Self::RemoveNode { node } => *node,
         }
     }
 
@@ -79,6 +85,7 @@ impl SemanticMutation {
                     member: *member,
                 }
             }
+            Self::RemoveNode { node } => SemanticMutationKey::NodeRemoval(*node),
         }
     }
 }
@@ -99,13 +106,15 @@ enum SemanticMutationKey {
         family: SemanticNodeId,
         member: SemanticNodeId,
     },
+    NodeRemoval(SemanticNodeId),
 }
 
 /// Locality classification emitted by committed semantic mutations.
 ///
 /// Lowering/runtime consumers can use this without re-interpreting the mutation
-/// payload. Future A1.5 mutation kinds extend this enum rather than introducing
-/// frontend- or subsystem-specific patch classifications.
+/// payload. Structural cleanup emits impacts for every semantic declaration it
+/// actually invalidates; no frontend- or subsystem-specific patch classification
+/// is introduced.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SemanticMutationImpact {
     SignalValue {
@@ -129,6 +138,9 @@ pub enum SemanticMutationImpact {
     FamilyMemberRemoved {
         family: SemanticNodeId,
         member: SemanticNodeId,
+    },
+    NodeRemoved {
+        node: SemanticNodeId,
     },
 }
 
@@ -156,11 +168,6 @@ impl SemanticMutationTransaction {
 
     /// Set one node-owned authored object property in the same atomic mutation
     /// vocabulary as signal values.
-    ///
-    /// `SemanticSignalValue` is reused here as the existing high-precision typed
-    /// scalar/vector/bool value vocabulary; property-kind validation rejects the
-    /// bool case for current object properties instead of creating a duplicate
-    /// property-value type.
     pub fn set_property(
         &mut self,
         object: SemanticNodeId,
@@ -176,9 +183,6 @@ impl SemanticMutationTransaction {
     }
 
     /// Replace only the authored content reference/value of one semantic object.
-    ///
-    /// Transform, style, painter metadata, signal bindings, identity, family
-    /// relationships, and scene lifecycle are intentionally left untouched.
     pub fn replace_content(
         &mut self,
         object: SemanticNodeId,
@@ -192,10 +196,6 @@ impl SemanticMutationTransaction {
     }
 
     /// Change the authored signal driver for one object property.
-    ///
-    /// `Some(signal)` binds or rebinds the property and `None` removes its
-    /// authored driver. Rebinding is one semantic mutation rather than a visible
-    /// remove/add pair, so the existing declaration position is preserved.
     pub fn change_subscription(
         &mut self,
         object: SemanticNodeId,
@@ -224,6 +224,19 @@ impl SemanticMutationTransaction {
         self
     }
 
+    /// Delete one semantic identity and atomically clean declarations that cannot
+    /// remain valid without it.
+    ///
+    /// Signal bindings are unbound. Derived signals and animation declarations
+    /// that reference the removed identity are themselves removed, recursively.
+    /// Structural removals are terminal within a transaction: once the first
+    /// `RemoveNode` is authored, no later non-removal mutation is accepted. This
+    /// keeps complete preflight valid through commit without staging a second scene.
+    pub fn remove_node(&mut self, node: SemanticNodeId) -> &mut Self {
+        self.mutations.push(SemanticMutation::RemoveNode { node });
+        self
+    }
+
     pub fn mutations(&self) -> &[SemanticMutation] {
         &self.mutations
     }
@@ -233,12 +246,6 @@ impl SemanticMutationTransaction {
     }
 
     /// Preflight the complete transaction, then commit every changed mutation.
-    ///
-    /// No semantic slot is written until all mutations have passed generation,
-    /// target-kind, value-kind, finite-value, content, subscription, family-edge,
-    /// and duplicate-mutation validation. Once preflight succeeds, commit cannot
-    /// observe external scene changes because the transaction owns
-    /// `&mut SemanticStore` for the duration.
     pub fn apply(
         self,
         store: &mut SemanticStore,
@@ -303,6 +310,32 @@ impl SemanticMutationTransaction {
                     written_slots.insert(member);
                     impacts.push(SemanticMutationImpact::FamilyMemberRemoved { family, member });
                 }
+                SemanticMutation::RemoveNode { node } => {
+                    // An earlier explicit removal may have cascade-removed this
+                    // node already. Preflight proved the handle was live at the
+                    // transaction boundary; a cascade therefore satisfies this
+                    // later structural mutation without duplicate impacts.
+                    if store.node(node).is_none() {
+                        continue;
+                    }
+                    let outcome = store
+                        .remove_node_with_reverse_cleanup(node)
+                        .expect("preflighted node removal must remain valid while transaction owns the store");
+                    written_slots.extend(outcome.written_slots().iter().copied());
+                    for effect in outcome.effects() {
+                        match effect {
+                            SemanticRemoveNodeEffect::NodeRemoved(node) => {
+                                impacts.push(SemanticMutationImpact::NodeRemoved { node: *node });
+                            }
+                            SemanticRemoveNodeEffect::SubscriptionRemoved { object, property } => {
+                                impacts.push(SemanticMutationImpact::Subscription {
+                                    object: *object,
+                                    property: *property,
+                                });
+                            }
+                        }
+                    }
+                }
             }
         }
         store.set_last_mutation_writes(written_slots.len());
@@ -314,11 +347,66 @@ impl SemanticMutationTransaction {
         &self,
         store: &SemanticStore,
     ) -> Result<Vec<bool>, SemanticMutationTransactionError> {
+        let mut removed_nodes = HashSet::new();
+        let mut removal_started = false;
+        for (index, mutation) in self.mutations.iter().enumerate() {
+            match mutation {
+                SemanticMutation::RemoveNode { node } => {
+                    removal_started = true;
+                    removed_nodes.insert(*node);
+                }
+                _ if removal_started => {
+                    return Err(SemanticMutationTransactionError::MutationAfterRemove { index });
+                }
+                _ => {}
+            }
+        }
+        let removed_nodes = store.semantic_removal_closure(&removed_nodes);
+
         let mut targets = HashSet::with_capacity(self.mutations.len());
         let mut changed = Vec::with_capacity(self.mutations.len());
         let mut family_edges = FamilyEdgePreflight::default();
 
         for (index, mutation) in self.mutations.iter().enumerate() {
+            if !matches!(mutation, SemanticMutation::RemoveNode { .. })
+                && removed_nodes.contains(&mutation.target())
+            {
+                return Err(SemanticMutationTransactionError::TargetRemoved {
+                    index,
+                    target: mutation.target(),
+                });
+            }
+            if let SemanticMutation::ChangeSubscription {
+                object,
+                property,
+                signal: Some(signal),
+            } = mutation
+            {
+                if removed_nodes.contains(signal) {
+                    return Err(
+                        SemanticMutationTransactionError::SubscriptionUsesRemovedSignal {
+                            index,
+                            object: *object,
+                            property: *property,
+                            signal: *signal,
+                        },
+                    );
+                }
+            }
+            if let SemanticMutation::AddMember { family, member }
+            | SemanticMutation::RemoveMember { family, member } = mutation
+            {
+                if removed_nodes.contains(member) {
+                    return Err(
+                        SemanticMutationTransactionError::FamilyEdgeUsesRemovedNode {
+                            index,
+                            family: *family,
+                            member: *member,
+                        },
+                    );
+                }
+            }
+
             let key = mutation.key();
             if !targets.insert(key) {
                 return Err(match key {
@@ -348,6 +436,9 @@ impl SemanticMutationTransaction {
                             family,
                             member,
                         }
+                    }
+                    SemanticMutationKey::NodeRemoval(node) => {
+                        SemanticMutationTransactionError::DuplicateNodeRemoval { index, node }
                     }
                 });
             }
@@ -458,9 +549,6 @@ impl SemanticMutationTransaction {
                         }
                         changed.push(existing != Some(*signal));
                     } else {
-                        // Unbinding is intentionally keyed only by object/property.
-                        // It must be able to remove a generation-safe stale source
-                        // declaration left by the current low-level RemoveNode seam.
                         changed.push(existing.is_some());
                     }
                 }
@@ -473,6 +561,15 @@ impl SemanticMutationTransaction {
                     changed.push(family_edges.remove(store, *family, *member).map_err(
                         |error| SemanticMutationTransactionError::Family { index, error },
                     )?);
+                }
+                SemanticMutation::RemoveNode { node } => {
+                    if store.node(*node).is_none() {
+                        return Err(SemanticMutationTransactionError::Node {
+                            index,
+                            error: SemanticStoreError::UnknownNode(*node),
+                        });
+                    }
+                    changed.push(true);
                 }
             }
         }
@@ -565,6 +662,7 @@ fn set_object_subscription(
     property: SemanticObjectProperty,
     signal: Option<SemanticNodeId>,
 ) {
+    store.unregister_semantic_references_for_owner(object);
     let bindings = store
         .node_mut(object)
         .and_then(|node| node.semantic_object_state_mut())
@@ -586,6 +684,7 @@ fn set_object_subscription(
             unreachable!("unchanged missing subscription is filtered during transaction preflight")
         }
     }
+    store.register_semantic_references_for_owner(object);
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -620,6 +719,28 @@ pub enum SemanticMutationTransactionError {
         property: SemanticObjectProperty,
     },
     DuplicateFamilyEdge {
+        index: usize,
+        family: SemanticNodeId,
+        member: SemanticNodeId,
+    },
+    DuplicateNodeRemoval {
+        index: usize,
+        node: SemanticNodeId,
+    },
+    MutationAfterRemove {
+        index: usize,
+    },
+    TargetRemoved {
+        index: usize,
+        target: SemanticNodeId,
+    },
+    SubscriptionUsesRemovedSignal {
+        index: usize,
+        object: SemanticNodeId,
+        property: SemanticObjectProperty,
+        signal: SemanticNodeId,
+    },
+    FamilyEdgeUsesRemovedNode {
         index: usize,
         family: SemanticNodeId,
         member: SemanticNodeId,
@@ -665,6 +786,10 @@ pub enum SemanticMutationTransactionError {
         signal: SemanticNodeId,
         expected: SemanticSignalValueKind,
         actual: SemanticSignalValueKind,
+    },
+    Node {
+        index: usize,
+        error: SemanticStoreError,
     },
 }
 
@@ -717,6 +842,48 @@ impl std::fmt::Display for SemanticMutationTransactionError {
                 member.slot(),
                 member.generation()
             ),
+            Self::DuplicateNodeRemoval { index, node } => write!(
+                formatter,
+                "semantic transaction mutation {index} repeats removal of node {}:{}",
+                node.slot(),
+                node.generation()
+            ),
+            Self::MutationAfterRemove { index } => write!(
+                formatter,
+                "semantic transaction mutation {index} follows structural removal; RemoveNode mutations must be terminal"
+            ),
+            Self::TargetRemoved { index, target } => write!(
+                formatter,
+                "semantic transaction mutation {index} targets node {}:{} that is removed by the same transaction",
+                target.slot(),
+                target.generation()
+            ),
+            Self::SubscriptionUsesRemovedSignal {
+                index,
+                object,
+                property,
+                signal,
+            } => write!(
+                formatter,
+                "semantic transaction mutation {index} cannot bind signal {}:{} scheduled for removal to property {:?} on object {}:{}",
+                signal.slot(),
+                signal.generation(),
+                property,
+                object.slot(),
+                object.generation()
+            ),
+            Self::FamilyEdgeUsesRemovedNode {
+                index,
+                family,
+                member,
+            } => write!(
+                formatter,
+                "semantic transaction mutation {index} cannot change family edge {}:{} -> {}:{} because the member is removed by the same transaction",
+                family.slot(),
+                family.generation(),
+                member.slot(),
+                member.generation()
+            ),
             Self::Signal { index, error } => {
                 write!(formatter, "semantic transaction mutation {index}: {error}")
             }
@@ -737,10 +904,7 @@ impl std::fmt::Display for SemanticMutationTransactionError {
                 signal.slot(),
                 signal.generation()
             ),
-            Self::Object { index, error } => {
-                write!(formatter, "semantic transaction mutation {index}: {error}")
-            }
-            Self::Family { index, error } => {
+            Self::Object { index, error } | Self::Family { index, error } => {
                 write!(formatter, "semantic transaction mutation {index}: {error}")
             }
             Self::NonFinitePropertyValue {
@@ -783,6 +947,9 @@ impl std::fmt::Display for SemanticMutationTransactionError {
                 object.slot(),
                 object.generation()
             ),
+            Self::Node { index, error } => {
+                write!(formatter, "semantic transaction mutation {index}: {error}")
+            }
         }
     }
 }
@@ -790,447 +957,7 @@ impl std::fmt::Display for SemanticMutationTransactionError {
 impl std::error::Error for SemanticMutationTransactionError {}
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::{
-        SemanticObjectState, SemanticSignalBinding, SemanticSignalExpr, SemanticVec3,
-        StoredGeometry,
-    };
-
-    fn object(store: &mut SemanticStore, radius: f32) -> SemanticNodeId {
-        store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle { radius }))
-    }
-
-    fn input_value(store: &SemanticStore, signal: SemanticNodeId) -> SemanticSignalValue {
-        let SemanticSignalSource::Input(value) =
-            store.semantic_signal_state(signal).unwrap().source()
-        else {
-            panic!("expected input signal")
-        };
-        value.clone()
-    }
-
-    fn property_value(
-        store: &SemanticStore,
-        object: SemanticNodeId,
-        property: SemanticObjectProperty,
-    ) -> SemanticSignalValue {
-        object_property_value(
-            store.semantic_object_state_checked(object).unwrap(),
-            property,
-        )
-    }
-
-    #[test]
-    fn multiple_signal_values_commit_after_complete_preflight() {
-        let mut store = SemanticStore::new();
-        let scalar = store.insert_semantic_input_signal(1.0_f64).unwrap();
-        let vector = store
-            .insert_semantic_input_signal(SemanticVec3::new(1.0, 2.0, 3.0))
-            .unwrap();
-        let before_len = store.len();
-        let mut transaction = SemanticMutationTransaction::new();
-        transaction
-            .set_signal(scalar, 2.5_f64)
-            .set_signal(vector, SemanticVec3::new(4.0, 5.0, 6.0));
-
-        let result = transaction.apply(&mut store).unwrap();
-
-        assert_eq!(
-            input_value(&store, scalar),
-            SemanticSignalValue::Scalar(2.5)
-        );
-        assert_eq!(
-            input_value(&store, vector),
-            SemanticSignalValue::Vec3(SemanticVec3::new(4.0, 5.0, 6.0))
-        );
-        assert_eq!(store.len(), before_len);
-        assert_eq!(store.last_mutation_stats().slots_written, 2);
-        assert_eq!(
-            result.impacts(),
-            &[
-                SemanticMutationImpact::SignalValue { signal: scalar },
-                SemanticMutationImpact::SignalValue { signal: vector },
-            ]
-        );
-    }
-
-    #[test]
-    fn mixed_signal_and_properties_commit_atomically_and_count_unique_slots() {
-        let mut store = SemanticStore::new();
-        let signal = store.insert_semantic_input_signal(1.0_f64).unwrap();
-        let target = object(&mut store, 2.0);
-        let translation = SemanticVec3::new(4.0, -2.0, 7.0);
-        let mut transaction = SemanticMutationTransaction::new();
-        transaction
-            .set_signal(signal, 3.0_f64)
-            .set_property(target, SemanticObjectProperty::Translation, translation)
-            .set_property(target, SemanticObjectProperty::ObjectOpacity, 0.4_f64);
-
-        let result = transaction.apply(&mut store).unwrap();
-
-        assert_eq!(
-            input_value(&store, signal),
-            SemanticSignalValue::Scalar(3.0)
-        );
-        assert_eq!(
-            property_value(&store, target, SemanticObjectProperty::Translation),
-            SemanticSignalValue::Vec3(translation)
-        );
-        assert_eq!(
-            property_value(&store, target, SemanticObjectProperty::ObjectOpacity),
-            SemanticSignalValue::Scalar(0.4)
-        );
-        assert_eq!(store.last_mutation_stats().slots_written, 2);
-        assert_eq!(
-            result.impacts(),
-            &[
-                SemanticMutationImpact::SignalValue { signal },
-                SemanticMutationImpact::ObjectProperty {
-                    object: target,
-                    property: SemanticObjectProperty::Translation,
-                },
-                SemanticMutationImpact::ObjectProperty {
-                    object: target,
-                    property: SemanticObjectProperty::ObjectOpacity,
-                },
-            ]
-        );
-    }
-
-    #[test]
-    fn invalid_late_value_prevents_earlier_valid_mutation() {
-        let mut store = SemanticStore::new();
-        let first = store.insert_semantic_input_signal(1.0_f64).unwrap();
-        let second = store.insert_semantic_input_signal(2.0_f64).unwrap();
-        let first_before = input_value(&store, first);
-        let second_before = input_value(&store, second);
-        let mut transaction = SemanticMutationTransaction::new();
-        transaction
-            .set_signal(first, 10.0_f64)
-            .set_signal(second, f64::NAN);
-
-        assert_eq!(
-            transaction.apply(&mut store),
-            Err(SemanticMutationTransactionError::Signal {
-                index: 1,
-                error: SemanticSignalError::NonFiniteValue,
-            })
-        );
-        assert_eq!(input_value(&store, first), first_before);
-        assert_eq!(input_value(&store, second), second_before);
-        assert_eq!(store.last_mutation_stats().slots_written, 0);
-    }
-
-    #[test]
-    fn invalid_late_property_prevents_earlier_signal_and_property_mutation() {
-        let mut store = SemanticStore::new();
-        let signal = store.insert_semantic_input_signal(1.0_f64).unwrap();
-        let target = object(&mut store, 2.0);
-        let signal_before = input_value(&store, signal);
-        let translation_before =
-            property_value(&store, target, SemanticObjectProperty::Translation);
-        let mut transaction = SemanticMutationTransaction::new();
-        transaction
-            .set_signal(signal, 5.0_f64)
-            .set_property(
-                target,
-                SemanticObjectProperty::Translation,
-                SemanticVec3::new(1.0, 2.0, 3.0),
-            )
-            .set_property(target, SemanticObjectProperty::StrokeWidth, f64::NAN);
-
-        assert_eq!(
-            transaction.apply(&mut store),
-            Err(SemanticMutationTransactionError::NonFinitePropertyValue {
-                index: 2,
-                object: target,
-                property: SemanticObjectProperty::StrokeWidth,
-            })
-        );
-        assert_eq!(input_value(&store, signal), signal_before);
-        assert_eq!(
-            property_value(&store, target, SemanticObjectProperty::Translation),
-            translation_before
-        );
-        assert_eq!(store.last_mutation_stats().slots_written, 0);
-    }
-
-    #[test]
-    fn stale_late_target_prevents_earlier_valid_mutation() {
-        let mut store = SemanticStore::new();
-        let first = store.insert_semantic_input_signal(1.0_f64).unwrap();
-        let stale = store.insert_semantic_input_signal(2.0_f64).unwrap();
-        store.remove_node(stale).unwrap();
-        let replacement = object(&mut store, 3.0);
-        assert_eq!(stale.slot(), replacement.slot());
-        assert_ne!(stale.generation(), replacement.generation());
-        let first_before = input_value(&store, first);
-        let mut transaction = SemanticMutationTransaction::new();
-        transaction
-            .set_signal(first, 10.0_f64)
-            .set_signal(stale, 20.0_f64);
-
-        assert_eq!(
-            transaction.apply(&mut store),
-            Err(SemanticMutationTransactionError::Signal {
-                index: 1,
-                error: SemanticSignalError::UnknownSignal(stale),
-            })
-        );
-        assert_eq!(input_value(&store, first), first_before);
-        assert_eq!(store.last_mutation_stats().slots_written, 0);
-    }
-
-    #[test]
-    fn stale_property_target_prevents_earlier_valid_mutation() {
-        let mut store = SemanticStore::new();
-        let signal = store.insert_semantic_input_signal(1.0_f64).unwrap();
-        let stale = object(&mut store, 2.0);
-        store.remove_node(stale).unwrap();
-        let replacement = object(&mut store, 3.0);
-        assert_eq!(stale.slot(), replacement.slot());
-        assert_ne!(stale.generation(), replacement.generation());
-        let signal_before = input_value(&store, signal);
-        let mut transaction = SemanticMutationTransaction::new();
-        transaction.set_signal(signal, 2.0_f64).set_property(
-            stale,
-            SemanticObjectProperty::RotationZ,
-            0.5_f64,
-        );
-
-        assert_eq!(
-            transaction.apply(&mut store),
-            Err(SemanticMutationTransactionError::Object {
-                index: 1,
-                error: SemanticSceneOperationError::UnknownNode(stale),
-            })
-        );
-        assert_eq!(input_value(&store, signal), signal_before);
-        assert_eq!(store.last_mutation_stats().slots_written, 0);
-    }
-
-    #[test]
-    fn duplicate_target_is_rejected_before_mutation() {
-        let mut store = SemanticStore::new();
-        let signal = store.insert_semantic_input_signal(1.0_f64).unwrap();
-        let before = input_value(&store, signal);
-        let mut transaction = SemanticMutationTransaction::new();
-        transaction
-            .set_signal(signal, 2.0_f64)
-            .set_signal(signal, 3.0_f64);
-
-        assert_eq!(
-            transaction.apply(&mut store),
-            Err(SemanticMutationTransactionError::DuplicateTarget {
-                index: 1,
-                target: signal,
-            })
-        );
-        assert_eq!(input_value(&store, signal), before);
-        assert_eq!(store.last_mutation_stats().slots_written, 0);
-    }
-
-    #[test]
-    fn duplicate_property_is_rejected_but_distinct_properties_share_one_object() {
-        let mut store = SemanticStore::new();
-        let target = object(&mut store, 1.0);
-        let mut duplicate = SemanticMutationTransaction::new();
-        duplicate
-            .set_property(target, SemanticObjectProperty::RotationZ, 0.5_f64)
-            .set_property(target, SemanticObjectProperty::RotationZ, 1.0_f64);
-
-        assert_eq!(
-            duplicate.apply(&mut store),
-            Err(SemanticMutationTransactionError::DuplicateProperty {
-                index: 1,
-                object: target,
-                property: SemanticObjectProperty::RotationZ,
-            })
-        );
-        assert_eq!(
-            property_value(&store, target, SemanticObjectProperty::RotationZ),
-            SemanticSignalValue::Scalar(0.0)
-        );
-        assert_eq!(store.last_mutation_stats().slots_written, 0);
-
-        let mut distinct = SemanticMutationTransaction::new();
-        distinct
-            .set_property(target, SemanticObjectProperty::RotationZ, 0.5_f64)
-            .set_property(target, SemanticObjectProperty::StrokeWidth, 3.0_f64);
-        let result = distinct.apply(&mut store).unwrap();
-        assert_eq!(result.impacts().len(), 2);
-        assert_eq!(store.last_mutation_stats().slots_written, 1);
-    }
-
-    #[test]
-    fn type_mismatch_and_derived_signal_targets_fail_atomically() {
-        let mut store = SemanticStore::new();
-        let scalar = store.insert_semantic_input_signal(1.0_f64).unwrap();
-        let derived = store
-            .insert_semantic_derived_signal(SemanticSignalExpr::signal(scalar))
-            .unwrap();
-        let scalar_before = input_value(&store, scalar);
-
-        let mut mismatch = SemanticMutationTransaction::new();
-        mismatch.set_signal(scalar, SemanticVec3::new(1.0, 2.0, 3.0));
-        assert_eq!(
-            mismatch.apply(&mut store),
-            Err(SemanticMutationTransactionError::SignalTypeMismatch {
-                index: 0,
-                signal: scalar,
-                expected: SemanticSignalValueKind::Scalar,
-                actual: SemanticSignalValueKind::Vec3,
-            })
-        );
-        assert_eq!(input_value(&store, scalar), scalar_before);
-        assert_eq!(store.last_mutation_stats().slots_written, 0);
-
-        let mut derived_target = SemanticMutationTransaction::new();
-        derived_target.set_signal(derived, 4.0_f64);
-        assert_eq!(
-            derived_target.apply(&mut store),
-            Err(SemanticMutationTransactionError::NotInputSignal {
-                index: 0,
-                signal: derived,
-            })
-        );
-        assert_eq!(store.last_mutation_stats().slots_written, 0);
-    }
-
-    #[test]
-    fn property_type_and_target_kind_are_validated_before_mutation() {
-        let mut store = SemanticStore::new();
-        let target = object(&mut store, 1.0);
-        let family = store.insert_family();
-        let mut mismatch = SemanticMutationTransaction::new();
-        mismatch.set_property(target, SemanticObjectProperty::Scale, 2.0_f64);
-
-        assert_eq!(
-            mismatch.apply(&mut store),
-            Err(SemanticMutationTransactionError::PropertyTypeMismatch {
-                index: 0,
-                object: target,
-                property: SemanticObjectProperty::Scale,
-                expected: SemanticSignalValueKind::Vec3,
-                actual: SemanticSignalValueKind::Scalar,
-            })
-        );
-        assert_eq!(store.last_mutation_stats().slots_written, 0);
-
-        let mut wrong_target = SemanticMutationTransaction::new();
-        wrong_target.set_property(family, SemanticObjectProperty::RotationZ, 1.0_f64);
-        assert_eq!(
-            wrong_target.apply(&mut store),
-            Err(SemanticMutationTransactionError::Object {
-                index: 0,
-                error: SemanticSceneOperationError::NotSemanticObject(family),
-            })
-        );
-        assert_eq!(store.last_mutation_stats().slots_written, 0);
-    }
-
-    #[test]
-    fn unchanged_signal_is_a_noop_with_no_impact() {
-        let mut store = SemanticStore::new();
-        let signal = store.insert_semantic_input_signal(true).unwrap();
-        let mut transaction = SemanticMutationTransaction::new();
-        transaction.set_signal(signal, true);
-
-        let result = transaction.apply(&mut store).unwrap();
-
-        assert!(result.impacts().is_empty());
-        assert_eq!(store.last_mutation_stats().slots_written, 0);
-        assert_eq!(input_value(&store, signal), SemanticSignalValue::Bool(true));
-    }
-
-    #[test]
-    fn unchanged_property_is_a_noop_with_no_impact() {
-        let mut store = SemanticStore::new();
-        let target = object(&mut store, 1.0);
-        let mut transaction = SemanticMutationTransaction::new();
-        transaction.set_property(
-            target,
-            SemanticObjectProperty::Translation,
-            SemanticVec3::ZERO,
-        );
-
-        let result = transaction.apply(&mut store).unwrap();
-
-        assert!(result.impacts().is_empty());
-        assert_eq!(store.last_mutation_stats().slots_written, 0);
-    }
-
-    #[test]
-    fn set_property_preserves_signal_binding_declarations() {
-        let mut store = SemanticStore::new();
-        let signal = store.insert_semantic_input_signal(0.5_f64).unwrap();
-        let target = object(&mut store, 1.0);
-        store
-            .bind_semantic_signal(signal, target, SemanticObjectProperty::ObjectOpacity)
-            .unwrap();
-        let binding = SemanticSignalBinding::new(signal, SemanticObjectProperty::ObjectOpacity);
-        let mut transaction = SemanticMutationTransaction::new();
-        transaction.set_property(target, SemanticObjectProperty::ObjectOpacity, 0.25_f64);
-
-        let result = transaction.apply(&mut store).unwrap();
-
-        assert_eq!(
-            property_value(&store, target, SemanticObjectProperty::ObjectOpacity),
-            SemanticSignalValue::Scalar(0.25)
-        );
-        assert_eq!(
-            store.semantic_object_signal_bindings(target).unwrap(),
-            &[binding]
-        );
-        assert_eq!(
-            result.impacts(),
-            &[SemanticMutationImpact::ObjectProperty {
-                object: target,
-                property: SemanticObjectProperty::ObjectOpacity,
-            }]
-        );
-    }
-
-    #[test]
-    fn transaction_writes_only_changed_signal_slots_with_large_unrelated_scene() {
-        let mut store = SemanticStore::new();
-        for index in 0..10_000 {
-            object(&mut store, index as f32 + 1.0);
-        }
-        let first = store.insert_semantic_input_signal(1.0_f64).unwrap();
-        let second = store.insert_semantic_input_signal(2.0_f64).unwrap();
-        let unchanged = store.insert_semantic_input_signal(3.0_f64).unwrap();
-        let mut transaction = SemanticMutationTransaction::new();
-        transaction
-            .set_signal(first, 10.0_f64)
-            .set_signal(second, 20.0_f64)
-            .set_signal(unchanged, 3.0_f64);
-
-        let result = transaction.apply(&mut store).unwrap();
-
-        assert_eq!(store.last_mutation_stats().slots_written, 2);
-        assert_eq!(result.impacts().len(), 2);
-    }
-
-    #[test]
-    fn property_transaction_writes_only_target_slot_with_large_unrelated_scene() {
-        let mut store = SemanticStore::new();
-        for index in 0..10_000 {
-            object(&mut store, index as f32 + 1.0);
-        }
-        let target = object(&mut store, 0.5);
-        let mut transaction = SemanticMutationTransaction::new();
-        transaction
-            .set_property(target, SemanticObjectProperty::RotationZ, 0.75_f64)
-            .set_property(target, SemanticObjectProperty::StrokeWidth, 4.0_f64);
-
-        let result = transaction.apply(&mut store).unwrap();
-
-        assert_eq!(store.last_mutation_stats().slots_written, 1);
-        assert_eq!(result.impacts().len(), 2);
-    }
-}
+mod base_tests;
 
 #[cfg(test)]
 mod content_tests;
@@ -1240,3 +967,6 @@ mod subscription_tests;
 
 #[cfg(test)]
 mod family_edge_tests;
+
+#[cfg(test)]
+mod remove_node_tests;

--- a/crates/noon-core/src/reactive/semantic_transaction/base_tests.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction/base_tests.rs
@@ -1,0 +1,436 @@
+use super::*;
+use crate::{
+    SemanticObjectState, SemanticSignalBinding, SemanticSignalExpr, SemanticVec3, StoredGeometry,
+};
+
+fn object(store: &mut SemanticStore, radius: f32) -> SemanticNodeId {
+    store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle { radius }))
+}
+
+fn input_value(store: &SemanticStore, signal: SemanticNodeId) -> SemanticSignalValue {
+    let SemanticSignalSource::Input(value) = store.semantic_signal_state(signal).unwrap().source()
+    else {
+        panic!("expected input signal")
+    };
+    value.clone()
+}
+
+fn property_value(
+    store: &SemanticStore,
+    object: SemanticNodeId,
+    property: SemanticObjectProperty,
+) -> SemanticSignalValue {
+    object_property_value(
+        store.semantic_object_state_checked(object).unwrap(),
+        property,
+    )
+}
+
+#[test]
+fn multiple_signal_values_commit_after_complete_preflight() {
+    let mut store = SemanticStore::new();
+    let scalar = store.insert_semantic_input_signal(1.0_f64).unwrap();
+    let vector = store
+        .insert_semantic_input_signal(SemanticVec3::new(1.0, 2.0, 3.0))
+        .unwrap();
+    let before_len = store.len();
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .set_signal(scalar, 2.5_f64)
+        .set_signal(vector, SemanticVec3::new(4.0, 5.0, 6.0));
+
+    let result = transaction.apply(&mut store).unwrap();
+
+    assert_eq!(
+        input_value(&store, scalar),
+        SemanticSignalValue::Scalar(2.5)
+    );
+    assert_eq!(
+        input_value(&store, vector),
+        SemanticSignalValue::Vec3(SemanticVec3::new(4.0, 5.0, 6.0))
+    );
+    assert_eq!(store.len(), before_len);
+    assert_eq!(store.last_mutation_stats().slots_written, 2);
+    assert_eq!(
+        result.impacts(),
+        &[
+            SemanticMutationImpact::SignalValue { signal: scalar },
+            SemanticMutationImpact::SignalValue { signal: vector },
+        ]
+    );
+}
+
+#[test]
+fn mixed_signal_and_properties_commit_atomically_and_count_unique_slots() {
+    let mut store = SemanticStore::new();
+    let signal = store.insert_semantic_input_signal(1.0_f64).unwrap();
+    let target = object(&mut store, 2.0);
+    let translation = SemanticVec3::new(4.0, -2.0, 7.0);
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .set_signal(signal, 3.0_f64)
+        .set_property(target, SemanticObjectProperty::Translation, translation)
+        .set_property(target, SemanticObjectProperty::ObjectOpacity, 0.4_f64);
+
+    let result = transaction.apply(&mut store).unwrap();
+
+    assert_eq!(
+        input_value(&store, signal),
+        SemanticSignalValue::Scalar(3.0)
+    );
+    assert_eq!(
+        property_value(&store, target, SemanticObjectProperty::Translation),
+        SemanticSignalValue::Vec3(translation)
+    );
+    assert_eq!(
+        property_value(&store, target, SemanticObjectProperty::ObjectOpacity),
+        SemanticSignalValue::Scalar(0.4)
+    );
+    assert_eq!(store.last_mutation_stats().slots_written, 2);
+    assert_eq!(
+        result.impacts(),
+        &[
+            SemanticMutationImpact::SignalValue { signal },
+            SemanticMutationImpact::ObjectProperty {
+                object: target,
+                property: SemanticObjectProperty::Translation,
+            },
+            SemanticMutationImpact::ObjectProperty {
+                object: target,
+                property: SemanticObjectProperty::ObjectOpacity,
+            },
+        ]
+    );
+}
+
+#[test]
+fn invalid_late_value_prevents_earlier_valid_mutation() {
+    let mut store = SemanticStore::new();
+    let first = store.insert_semantic_input_signal(1.0_f64).unwrap();
+    let second = store.insert_semantic_input_signal(2.0_f64).unwrap();
+    let first_before = input_value(&store, first);
+    let second_before = input_value(&store, second);
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .set_signal(first, 10.0_f64)
+        .set_signal(second, f64::NAN);
+
+    assert_eq!(
+        transaction.apply(&mut store),
+        Err(SemanticMutationTransactionError::Signal {
+            index: 1,
+            error: SemanticSignalError::NonFiniteValue,
+        })
+    );
+    assert_eq!(input_value(&store, first), first_before);
+    assert_eq!(input_value(&store, second), second_before);
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+}
+
+#[test]
+fn invalid_late_property_prevents_earlier_signal_and_property_mutation() {
+    let mut store = SemanticStore::new();
+    let signal = store.insert_semantic_input_signal(1.0_f64).unwrap();
+    let target = object(&mut store, 2.0);
+    let signal_before = input_value(&store, signal);
+    let translation_before = property_value(&store, target, SemanticObjectProperty::Translation);
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .set_signal(signal, 5.0_f64)
+        .set_property(
+            target,
+            SemanticObjectProperty::Translation,
+            SemanticVec3::new(1.0, 2.0, 3.0),
+        )
+        .set_property(target, SemanticObjectProperty::StrokeWidth, f64::NAN);
+
+    assert_eq!(
+        transaction.apply(&mut store),
+        Err(SemanticMutationTransactionError::NonFinitePropertyValue {
+            index: 2,
+            object: target,
+            property: SemanticObjectProperty::StrokeWidth,
+        })
+    );
+    assert_eq!(input_value(&store, signal), signal_before);
+    assert_eq!(
+        property_value(&store, target, SemanticObjectProperty::Translation),
+        translation_before
+    );
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+}
+
+#[test]
+fn stale_late_target_prevents_earlier_valid_mutation() {
+    let mut store = SemanticStore::new();
+    let first = store.insert_semantic_input_signal(1.0_f64).unwrap();
+    let stale = store.insert_semantic_input_signal(2.0_f64).unwrap();
+    store.remove_node(stale).unwrap();
+    let replacement = object(&mut store, 3.0);
+    assert_eq!(stale.slot(), replacement.slot());
+    assert_ne!(stale.generation(), replacement.generation());
+    let first_before = input_value(&store, first);
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .set_signal(first, 10.0_f64)
+        .set_signal(stale, 20.0_f64);
+
+    assert_eq!(
+        transaction.apply(&mut store),
+        Err(SemanticMutationTransactionError::Signal {
+            index: 1,
+            error: SemanticSignalError::UnknownSignal(stale),
+        })
+    );
+    assert_eq!(input_value(&store, first), first_before);
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+}
+
+#[test]
+fn stale_property_target_prevents_earlier_valid_mutation() {
+    let mut store = SemanticStore::new();
+    let signal = store.insert_semantic_input_signal(1.0_f64).unwrap();
+    let stale = object(&mut store, 2.0);
+    store.remove_node(stale).unwrap();
+    let replacement = object(&mut store, 3.0);
+    assert_eq!(stale.slot(), replacement.slot());
+    assert_ne!(stale.generation(), replacement.generation());
+    let signal_before = input_value(&store, signal);
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction.set_signal(signal, 2.0_f64).set_property(
+        stale,
+        SemanticObjectProperty::RotationZ,
+        0.5_f64,
+    );
+
+    assert_eq!(
+        transaction.apply(&mut store),
+        Err(SemanticMutationTransactionError::Object {
+            index: 1,
+            error: SemanticSceneOperationError::UnknownNode(stale),
+        })
+    );
+    assert_eq!(input_value(&store, signal), signal_before);
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+}
+
+#[test]
+fn duplicate_target_is_rejected_before_mutation() {
+    let mut store = SemanticStore::new();
+    let signal = store.insert_semantic_input_signal(1.0_f64).unwrap();
+    let before = input_value(&store, signal);
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .set_signal(signal, 2.0_f64)
+        .set_signal(signal, 3.0_f64);
+
+    assert_eq!(
+        transaction.apply(&mut store),
+        Err(SemanticMutationTransactionError::DuplicateTarget {
+            index: 1,
+            target: signal,
+        })
+    );
+    assert_eq!(input_value(&store, signal), before);
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+}
+
+#[test]
+fn duplicate_property_is_rejected_but_distinct_properties_share_one_object() {
+    let mut store = SemanticStore::new();
+    let target = object(&mut store, 1.0);
+    let mut duplicate = SemanticMutationTransaction::new();
+    duplicate
+        .set_property(target, SemanticObjectProperty::RotationZ, 0.5_f64)
+        .set_property(target, SemanticObjectProperty::RotationZ, 1.0_f64);
+
+    assert_eq!(
+        duplicate.apply(&mut store),
+        Err(SemanticMutationTransactionError::DuplicateProperty {
+            index: 1,
+            object: target,
+            property: SemanticObjectProperty::RotationZ,
+        })
+    );
+    assert_eq!(
+        property_value(&store, target, SemanticObjectProperty::RotationZ),
+        SemanticSignalValue::Scalar(0.0)
+    );
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+
+    let mut distinct = SemanticMutationTransaction::new();
+    distinct
+        .set_property(target, SemanticObjectProperty::RotationZ, 0.5_f64)
+        .set_property(target, SemanticObjectProperty::StrokeWidth, 3.0_f64);
+    let result = distinct.apply(&mut store).unwrap();
+    assert_eq!(result.impacts().len(), 2);
+    assert_eq!(store.last_mutation_stats().slots_written, 1);
+}
+
+#[test]
+fn type_mismatch_and_derived_signal_targets_fail_atomically() {
+    let mut store = SemanticStore::new();
+    let scalar = store.insert_semantic_input_signal(1.0_f64).unwrap();
+    let derived = store
+        .insert_semantic_derived_signal(SemanticSignalExpr::signal(scalar))
+        .unwrap();
+    let scalar_before = input_value(&store, scalar);
+
+    let mut mismatch = SemanticMutationTransaction::new();
+    mismatch.set_signal(scalar, SemanticVec3::new(1.0, 2.0, 3.0));
+    assert_eq!(
+        mismatch.apply(&mut store),
+        Err(SemanticMutationTransactionError::SignalTypeMismatch {
+            index: 0,
+            signal: scalar,
+            expected: SemanticSignalValueKind::Scalar,
+            actual: SemanticSignalValueKind::Vec3,
+        })
+    );
+    assert_eq!(input_value(&store, scalar), scalar_before);
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+
+    let mut derived_target = SemanticMutationTransaction::new();
+    derived_target.set_signal(derived, 4.0_f64);
+    assert_eq!(
+        derived_target.apply(&mut store),
+        Err(SemanticMutationTransactionError::NotInputSignal {
+            index: 0,
+            signal: derived,
+        })
+    );
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+}
+
+#[test]
+fn property_type_and_target_kind_are_validated_before_mutation() {
+    let mut store = SemanticStore::new();
+    let target = object(&mut store, 1.0);
+    let family = store.insert_family();
+    let mut mismatch = SemanticMutationTransaction::new();
+    mismatch.set_property(target, SemanticObjectProperty::Scale, 2.0_f64);
+
+    assert_eq!(
+        mismatch.apply(&mut store),
+        Err(SemanticMutationTransactionError::PropertyTypeMismatch {
+            index: 0,
+            object: target,
+            property: SemanticObjectProperty::Scale,
+            expected: SemanticSignalValueKind::Vec3,
+            actual: SemanticSignalValueKind::Scalar,
+        })
+    );
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+
+    let mut wrong_target = SemanticMutationTransaction::new();
+    wrong_target.set_property(family, SemanticObjectProperty::RotationZ, 1.0_f64);
+    assert_eq!(
+        wrong_target.apply(&mut store),
+        Err(SemanticMutationTransactionError::Object {
+            index: 0,
+            error: SemanticSceneOperationError::NotSemanticObject(family),
+        })
+    );
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+}
+
+#[test]
+fn unchanged_signal_is_a_noop_with_no_impact() {
+    let mut store = SemanticStore::new();
+    let signal = store.insert_semantic_input_signal(true).unwrap();
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction.set_signal(signal, true);
+
+    let result = transaction.apply(&mut store).unwrap();
+
+    assert!(result.impacts().is_empty());
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+    assert_eq!(input_value(&store, signal), SemanticSignalValue::Bool(true));
+}
+
+#[test]
+fn unchanged_property_is_a_noop_with_no_impact() {
+    let mut store = SemanticStore::new();
+    let target = object(&mut store, 1.0);
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction.set_property(
+        target,
+        SemanticObjectProperty::Translation,
+        SemanticVec3::ZERO,
+    );
+
+    let result = transaction.apply(&mut store).unwrap();
+
+    assert!(result.impacts().is_empty());
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+}
+
+#[test]
+fn set_property_preserves_signal_binding_declarations() {
+    let mut store = SemanticStore::new();
+    let signal = store.insert_semantic_input_signal(0.5_f64).unwrap();
+    let target = object(&mut store, 1.0);
+    store
+        .bind_semantic_signal(signal, target, SemanticObjectProperty::ObjectOpacity)
+        .unwrap();
+    let binding = SemanticSignalBinding::new(signal, SemanticObjectProperty::ObjectOpacity);
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction.set_property(target, SemanticObjectProperty::ObjectOpacity, 0.25_f64);
+
+    let result = transaction.apply(&mut store).unwrap();
+
+    assert_eq!(
+        property_value(&store, target, SemanticObjectProperty::ObjectOpacity),
+        SemanticSignalValue::Scalar(0.25)
+    );
+    assert_eq!(
+        store.semantic_object_signal_bindings(target).unwrap(),
+        &[binding]
+    );
+    assert_eq!(
+        result.impacts(),
+        &[SemanticMutationImpact::ObjectProperty {
+            object: target,
+            property: SemanticObjectProperty::ObjectOpacity,
+        }]
+    );
+}
+
+#[test]
+fn transaction_writes_only_changed_signal_slots_with_large_unrelated_scene() {
+    let mut store = SemanticStore::new();
+    for index in 0..10_000 {
+        object(&mut store, index as f32 + 1.0);
+    }
+    let first = store.insert_semantic_input_signal(1.0_f64).unwrap();
+    let second = store.insert_semantic_input_signal(2.0_f64).unwrap();
+    let unchanged = store.insert_semantic_input_signal(3.0_f64).unwrap();
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .set_signal(first, 10.0_f64)
+        .set_signal(second, 20.0_f64)
+        .set_signal(unchanged, 3.0_f64);
+
+    let result = transaction.apply(&mut store).unwrap();
+
+    assert_eq!(store.last_mutation_stats().slots_written, 2);
+    assert_eq!(result.impacts().len(), 2);
+}
+
+#[test]
+fn property_transaction_writes_only_target_slot_with_large_unrelated_scene() {
+    let mut store = SemanticStore::new();
+    for index in 0..10_000 {
+        object(&mut store, index as f32 + 1.0);
+    }
+    let target = object(&mut store, 0.5);
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .set_property(target, SemanticObjectProperty::RotationZ, 0.75_f64)
+        .set_property(target, SemanticObjectProperty::StrokeWidth, 4.0_f64);
+
+    let result = transaction.apply(&mut store).unwrap();
+
+    assert_eq!(store.last_mutation_stats().slots_written, 1);
+    assert_eq!(result.impacts().len(), 2);
+}

--- a/crates/noon-core/src/reactive/semantic_transaction/remove_node_tests.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction/remove_node_tests.rs
@@ -1,0 +1,329 @@
+use super::*;
+use crate::{
+    AnimationOptions, SemanticObjectState, SemanticSignalExpr, SemanticSignalSource, StoredGeometry,
+};
+
+fn object(store: &mut SemanticStore, radius: f32) -> SemanticNodeId {
+    store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle { radius }))
+}
+
+fn input_scalar(store: &SemanticStore, signal: SemanticNodeId) -> f64 {
+    let SemanticSignalSource::Input(SemanticSignalValue::Scalar(value)) =
+        store.semantic_signal_state(signal).unwrap().source()
+    else {
+        panic!("expected scalar input signal")
+    };
+    *value
+}
+
+#[test]
+fn remove_node_unbinds_properties_and_cascades_invalid_derived_signals() {
+    let mut store = SemanticStore::new();
+    let source = store.insert_semantic_input_signal(1.0_f64).unwrap();
+    let derived = store
+        .insert_semantic_derived_signal(SemanticSignalExpr::Add(
+            Box::new(SemanticSignalExpr::signal(source)),
+            Box::new(SemanticSignalExpr::scalar(2.0)),
+        ))
+        .unwrap();
+    let target = object(&mut store, 1.0);
+    store
+        .bind_semantic_signal(derived, target, SemanticObjectProperty::ObjectOpacity)
+        .unwrap();
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction.remove_node(source);
+    let result = transaction.apply(&mut store).unwrap();
+
+    assert!(store.node(source).is_none());
+    assert!(store.node(derived).is_none());
+    assert!(store.node(target).is_some());
+    assert!(store
+        .semantic_object_signal_bindings(target)
+        .unwrap()
+        .is_empty());
+    assert_eq!(store.last_mutation_stats().slots_written, 3);
+    assert_eq!(
+        result.impacts(),
+        &[
+            SemanticMutationImpact::NodeRemoved { node: source },
+            SemanticMutationImpact::NodeRemoved { node: derived },
+            SemanticMutationImpact::Subscription {
+                object: target,
+                property: SemanticObjectProperty::ObjectOpacity,
+            },
+        ]
+    );
+}
+
+#[test]
+fn removing_animation_target_cascades_leaf_and_parent_composition_only() {
+    let mut store = SemanticStore::new();
+    let target = object(&mut store, 1.0);
+    let target_state = object(&mut store, 2.0);
+    let leaf = store
+        .insert_semantic_transform_animation(target, target_state, AnimationOptions::new())
+        .unwrap();
+
+    let other_target = object(&mut store, 3.0);
+    let other_target_state = object(&mut store, 4.0);
+    let other_leaf = store
+        .insert_semantic_transform_animation(
+            other_target,
+            other_target_state,
+            AnimationOptions::new(),
+        )
+        .unwrap();
+    let composition = store
+        .insert_semantic_parallel_animation(&[leaf, other_leaf], AnimationOptions::new())
+        .unwrap();
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction.remove_node(target);
+    let result = transaction.apply(&mut store).unwrap();
+
+    assert!(store.node(target).is_none());
+    assert!(store.node(leaf).is_none());
+    assert!(store.node(composition).is_none());
+    assert!(store.node(target_state).is_some());
+    assert!(store.node(other_target).is_some());
+    assert!(store.node(other_target_state).is_some());
+    assert!(store.node(other_leaf).is_some());
+    assert_eq!(store.last_mutation_stats().slots_written, 3);
+    assert_eq!(
+        result.impacts(),
+        &[
+            SemanticMutationImpact::NodeRemoved { node: target },
+            SemanticMutationImpact::NodeRemoved { node: leaf },
+            SemanticMutationImpact::NodeRemoved { node: composition },
+        ]
+    );
+}
+
+#[test]
+fn stale_remove_target_rolls_back_earlier_valid_mutation() {
+    let mut store = SemanticStore::new();
+    let signal = store.insert_semantic_input_signal(1.0_f64).unwrap();
+    let stale = object(&mut store, 1.0);
+    store.remove_node(stale).unwrap();
+    let replacement = object(&mut store, 2.0);
+    assert_eq!(stale.slot(), replacement.slot());
+    assert_ne!(stale.generation(), replacement.generation());
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction.set_signal(signal, 2.0_f64).remove_node(stale);
+
+    assert_eq!(
+        transaction.apply(&mut store),
+        Err(SemanticMutationTransactionError::Node {
+            index: 1,
+            error: SemanticStoreError::UnknownNode(stale),
+        })
+    );
+    assert_eq!(input_scalar(&store, signal), 1.0);
+    assert!(store.node(replacement).is_some());
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+}
+
+#[test]
+fn structural_removals_are_terminal_and_preflighted_before_commit() {
+    let mut store = SemanticStore::new();
+    let target = object(&mut store, 1.0);
+    let signal = store.insert_semantic_input_signal(1.0_f64).unwrap();
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction.remove_node(target).set_signal(signal, 2.0_f64);
+
+    assert_eq!(
+        transaction.apply(&mut store),
+        Err(SemanticMutationTransactionError::MutationAfterRemove { index: 1 })
+    );
+    assert!(store.node(target).is_some());
+    assert_eq!(input_scalar(&store, signal), 1.0);
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+}
+
+#[test]
+fn transaction_rejects_mutating_a_node_it_also_removes() {
+    let mut store = SemanticStore::new();
+    let target = object(&mut store, 1.0);
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .set_property(target, SemanticObjectProperty::RotationZ, 0.5_f64)
+        .remove_node(target);
+
+    assert_eq!(
+        transaction.apply(&mut store),
+        Err(SemanticMutationTransactionError::TargetRemoved { index: 0, target })
+    );
+    assert!(store.node(target).is_some());
+    assert_eq!(
+        store
+            .semantic_object_state_checked(target)
+            .unwrap()
+            .transform
+            .rotation_z,
+        0.0
+    );
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+}
+
+#[test]
+fn transaction_rejects_binding_a_signal_it_also_removes() {
+    let mut store = SemanticStore::new();
+    let signal = store.insert_semantic_input_signal(0.5_f64).unwrap();
+    let target = object(&mut store, 1.0);
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .change_subscription(target, SemanticObjectProperty::ObjectOpacity, Some(signal))
+        .remove_node(signal);
+
+    assert_eq!(
+        transaction.apply(&mut store),
+        Err(
+            SemanticMutationTransactionError::SubscriptionUsesRemovedSignal {
+                index: 0,
+                object: target,
+                property: SemanticObjectProperty::ObjectOpacity,
+                signal,
+            }
+        )
+    );
+    assert!(store.node(signal).is_some());
+    assert!(store
+        .semantic_object_signal_bindings(target)
+        .unwrap()
+        .is_empty());
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+}
+
+#[test]
+fn transaction_rejects_binding_a_signal_removed_by_later_cascade() {
+    let mut store = SemanticStore::new();
+    let source = store.insert_semantic_input_signal(0.5_f64).unwrap();
+    let derived = store
+        .insert_semantic_derived_signal(SemanticSignalExpr::signal(source))
+        .unwrap();
+    let target = object(&mut store, 1.0);
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .change_subscription(target, SemanticObjectProperty::ObjectOpacity, Some(derived))
+        .remove_node(source);
+
+    assert_eq!(
+        transaction.apply(&mut store),
+        Err(
+            SemanticMutationTransactionError::SubscriptionUsesRemovedSignal {
+                index: 0,
+                object: target,
+                property: SemanticObjectProperty::ObjectOpacity,
+                signal: derived,
+            }
+        )
+    );
+    assert!(store.node(source).is_some());
+    assert!(store.node(derived).is_some());
+    assert!(store
+        .semantic_object_signal_bindings(target)
+        .unwrap()
+        .is_empty());
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+}
+
+#[test]
+fn subscription_rebind_moves_reverse_reference_to_the_new_signal() {
+    let mut store = SemanticStore::new();
+    let first = store.insert_semantic_input_signal(0.25_f64).unwrap();
+    let second = store.insert_semantic_input_signal(0.75_f64).unwrap();
+    let target = object(&mut store, 1.0);
+    store
+        .bind_semantic_signal(first, target, SemanticObjectProperty::ObjectOpacity)
+        .unwrap();
+
+    let mut rebind = SemanticMutationTransaction::new();
+    rebind.change_subscription(target, SemanticObjectProperty::ObjectOpacity, Some(second));
+    rebind.apply(&mut store).unwrap();
+
+    let mut remove_first = SemanticMutationTransaction::new();
+    remove_first.remove_node(first);
+    let first_result = remove_first.apply(&mut store).unwrap();
+    assert_eq!(
+        store.semantic_object_signal_bindings(target).unwrap()[0].signal(),
+        second
+    );
+    assert_eq!(store.last_mutation_stats().slots_written, 1);
+    assert_eq!(
+        first_result.impacts(),
+        &[SemanticMutationImpact::NodeRemoved { node: first }]
+    );
+
+    let mut remove_second = SemanticMutationTransaction::new();
+    remove_second.remove_node(second);
+    let second_result = remove_second.apply(&mut store).unwrap();
+    assert!(store
+        .semantic_object_signal_bindings(target)
+        .unwrap()
+        .is_empty());
+    assert_eq!(store.last_mutation_stats().slots_written, 2);
+    assert_eq!(
+        second_result.impacts(),
+        &[
+            SemanticMutationImpact::NodeRemoved { node: second },
+            SemanticMutationImpact::Subscription {
+                object: target,
+                property: SemanticObjectProperty::ObjectOpacity,
+            },
+        ]
+    );
+}
+
+#[test]
+fn signal_source_rewire_moves_reverse_dependency_to_the_new_source() {
+    let mut store = SemanticStore::new();
+    let dependency = store.insert_semantic_input_signal(1.0_f64).unwrap();
+    let target = store.insert_semantic_input_signal(2.0_f64).unwrap();
+    store
+        .set_semantic_signal_source(
+            target,
+            SemanticSignalSource::Derived(SemanticSignalExpr::signal(dependency)),
+        )
+        .unwrap();
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction.remove_node(dependency);
+    let result = transaction.apply(&mut store).unwrap();
+
+    assert!(store.node(dependency).is_none());
+    assert!(store.node(target).is_none());
+    assert_eq!(store.last_mutation_stats().slots_written, 2);
+    assert_eq!(
+        result.impacts(),
+        &[
+            SemanticMutationImpact::NodeRemoved { node: dependency },
+            SemanticMutationImpact::NodeRemoved { node: target },
+        ]
+    );
+}
+
+#[test]
+fn remove_node_cleanup_is_local_with_large_unrelated_scene() {
+    let mut store = SemanticStore::new();
+    for index in 0..10_000 {
+        object(&mut store, index as f32 + 1.0);
+    }
+    let source = store.insert_semantic_input_signal(1.0_f64).unwrap();
+    let derived = store
+        .insert_semantic_derived_signal(SemanticSignalExpr::signal(source))
+        .unwrap();
+    let target = object(&mut store, 0.5);
+    store
+        .bind_semantic_signal(derived, target, SemanticObjectProperty::ObjectOpacity)
+        .unwrap();
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction.remove_node(source);
+    let result = transaction.apply(&mut store).unwrap();
+
+    assert_eq!(store.last_mutation_stats().slots_written, 3);
+    assert_eq!(result.impacts().len(), 3);
+    assert_eq!(store.len(), 10_001);
+}

--- a/crates/noon-core/src/semantic_references.rs
+++ b/crates/noon-core/src/semantic_references.rs
@@ -1,0 +1,335 @@
+use std::collections::HashSet;
+
+use crate::{
+    SemanticAnimationIntent, SemanticObjectProperty, SemanticSignalExpr, SemanticSignalSource,
+};
+
+use super::{
+    SemanticNode, SemanticNodeId, SemanticNodeKind, SemanticSceneMembership, SemanticStore,
+    SemanticStoreError,
+};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SemanticReferenceKind {
+    SignalDependency,
+    SignalBinding { property: SemanticObjectProperty },
+    AnimationTarget,
+    AnimationTargetState,
+    AnimationChild,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct SemanticIncomingReference {
+    owner: SemanticNodeId,
+    kind: SemanticReferenceKind,
+}
+
+impl SemanticIncomingReference {
+    const fn new(owner: SemanticNodeId, kind: SemanticReferenceKind) -> Self {
+        Self { owner, kind }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SemanticRemoveNodeEffect {
+    NodeRemoved(SemanticNodeId),
+    SubscriptionRemoved {
+        object: SemanticNodeId,
+        property: SemanticObjectProperty,
+    },
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct SemanticRemoveNodeOutcome {
+    effects: Vec<SemanticRemoveNodeEffect>,
+    written_slots: HashSet<SemanticNodeId>,
+}
+
+impl SemanticRemoveNodeOutcome {
+    pub(crate) fn effects(&self) -> &[SemanticRemoveNodeEffect] {
+        &self.effects
+    }
+
+    pub(crate) fn written_slots(&self) -> &HashSet<SemanticNodeId> {
+        &self.written_slots
+    }
+}
+
+impl SemanticStore {
+    /// Register all currently live semantic identities referenced by one owner.
+    ///
+    /// The reverse index is store metadata rather than authored node payload. Work
+    /// is proportional to the owner's direct reference declarations; unrelated
+    /// semantic slots are never scanned.
+    pub(crate) fn register_semantic_references_for_owner(&mut self, owner: SemanticNodeId) {
+        for (target, kind) in self.semantic_outgoing_references(owner) {
+            if self.node(target).is_none() {
+                // Low-level raw removal is still allowed to leave generation-safe
+                // stale declarations. Such references deliberately do not attach
+                // themselves to a later slot reuse.
+                continue;
+            }
+            let reference = SemanticIncomingReference::new(owner, kind);
+            let incoming = self.incoming_references.entry(target).or_default();
+            if !incoming.contains(&reference) {
+                incoming.push(reference);
+            }
+        }
+    }
+
+    /// Remove reverse-index entries owned by one node before changing or deleting
+    /// its declaration topology.
+    pub(crate) fn unregister_semantic_references_for_owner(&mut self, owner: SemanticNodeId) {
+        for (target, kind) in self.semantic_outgoing_references(owner) {
+            let reference = SemanticIncomingReference::new(owner, kind);
+            let remove_key = if let Some(incoming) = self.incoming_references.get_mut(&target) {
+                incoming.retain(|candidate| *candidate != reference);
+                incoming.is_empty()
+            } else {
+                false
+            };
+            if remove_key {
+                self.incoming_references.remove(&target);
+            }
+        }
+    }
+
+    fn semantic_outgoing_references(
+        &self,
+        owner: SemanticNodeId,
+    ) -> Vec<(SemanticNodeId, SemanticReferenceKind)> {
+        let Some(node) = self.node(owner) else {
+            return Vec::new();
+        };
+        outgoing_references(node)
+    }
+
+    /// Compute every declaration that would be removed by the given explicit roots.
+    ///
+    /// Bindings are soft references and therefore do not add their owner to the
+    /// removal set. Derived-signal and animation references are structural
+    /// dependencies and do. Work follows only the reverse-reference closure.
+    pub(crate) fn semantic_removal_closure(
+        &self,
+        roots: &HashSet<SemanticNodeId>,
+    ) -> HashSet<SemanticNodeId> {
+        let mut removed = HashSet::new();
+        let mut stack = roots.iter().copied().collect::<Vec<_>>();
+
+        while let Some(id) = stack.pop() {
+            if !removed.insert(id) {
+                continue;
+            }
+            let incoming = self
+                .incoming_references
+                .get(&id)
+                .map(Vec::as_slice)
+                .unwrap_or(&[]);
+            for reference in incoming.iter().copied() {
+                if self.node(reference.owner).is_none()
+                    || !self.owner_still_references(reference.owner, id, reference.kind)
+                {
+                    continue;
+                }
+                match reference.kind {
+                    SemanticReferenceKind::SignalBinding { .. } => {}
+                    SemanticReferenceKind::SignalDependency
+                    | SemanticReferenceKind::AnimationTarget
+                    | SemanticReferenceKind::AnimationTargetState
+                    | SemanticReferenceKind::AnimationChild => stack.push(reference.owner),
+                }
+            }
+        }
+
+        removed
+    }
+
+    /// Atomically remove one live node plus semantic declarations that cannot
+    /// remain valid without it.
+    ///
+    /// Signal bindings are unbound in place. Derived signals and authored
+    /// animations/compositions that directly reference the removed identity are
+    /// themselves removed, which recursively cleans their referrers. Complexity is
+    /// proportional to the transitive reverse-reference closure and the ordinary
+    /// direct root/family relationships of removed nodes, never total scene size.
+    pub(crate) fn remove_node_with_reverse_cleanup(
+        &mut self,
+        id: SemanticNodeId,
+    ) -> Result<super::SemanticRemoveNodeOutcome, SemanticStoreError> {
+        if self.node(id).is_none() {
+            return Err(SemanticStoreError::UnknownNode(id));
+        }
+
+        let mut outcome = SemanticRemoveNodeOutcome::default();
+        let mut visiting = HashSet::new();
+        self.remove_node_with_reverse_cleanup_inner(id, &mut outcome, &mut visiting)?;
+        self.set_last_mutation_writes(outcome.written_slots.len());
+        Ok(outcome)
+    }
+
+    fn remove_node_with_reverse_cleanup_inner(
+        &mut self,
+        id: SemanticNodeId,
+        outcome: &mut SemanticRemoveNodeOutcome,
+        visiting: &mut HashSet<SemanticNodeId>,
+    ) -> Result<(), SemanticStoreError> {
+        if self.node(id).is_none() {
+            return Ok(());
+        }
+        if !visiting.insert(id) {
+            // Signal dependency cycles are already forbidden and animation
+            // declarations are append-only today. Keep this guard so corrupted
+            // metadata cannot turn deletion into unbounded recursion.
+            return Ok(());
+        }
+
+        outcome
+            .effects
+            .push(SemanticRemoveNodeEffect::NodeRemoved(id));
+        let incoming = self
+            .incoming_references
+            .get(&id)
+            .cloned()
+            .unwrap_or_default();
+
+        for reference in incoming {
+            if self.node(reference.owner).is_none()
+                || !self.owner_still_references(reference.owner, id, reference.kind)
+            {
+                continue;
+            }
+
+            match reference.kind {
+                SemanticReferenceKind::SignalBinding { property } => {
+                    let binding_matches = self
+                        .node(reference.owner)
+                        .and_then(SemanticNode::semantic_object_state)
+                        .and_then(|state| {
+                            state
+                                .signal_bindings()
+                                .iter()
+                                .find(|binding| binding.property() == property)
+                        })
+                        .is_some_and(|binding| binding.signal() == id);
+                    if binding_matches {
+                        self.remove_semantic_signal_binding(reference.owner, property)
+                            .expect("indexed semantic binding owner must remain a valid object");
+                        outcome.written_slots.insert(reference.owner);
+                        outcome
+                            .effects
+                            .push(SemanticRemoveNodeEffect::SubscriptionRemoved {
+                                object: reference.owner,
+                                property,
+                            });
+                    }
+                }
+                SemanticReferenceKind::SignalDependency
+                | SemanticReferenceKind::AnimationTarget
+                | SemanticReferenceKind::AnimationTargetState
+                | SemanticReferenceKind::AnimationChild => {
+                    self.remove_node_with_reverse_cleanup_inner(
+                        reference.owner,
+                        outcome,
+                        visiting,
+                    )?;
+                }
+            }
+        }
+
+        let node = self
+            .node(id)
+            .expect("node remains live until its reverse referrers are cleaned")
+            .clone();
+        record_direct_remove_writes(&node, &mut outcome.written_slots);
+        self.remove_node(id)?;
+        visiting.remove(&id);
+        Ok(())
+    }
+
+    fn owner_still_references(
+        &self,
+        owner: SemanticNodeId,
+        target: SemanticNodeId,
+        kind: SemanticReferenceKind,
+    ) -> bool {
+        self.semantic_outgoing_references(owner)
+            .into_iter()
+            .any(|candidate| candidate == (target, kind))
+    }
+}
+
+fn outgoing_references(node: &SemanticNode) -> Vec<(SemanticNodeId, SemanticReferenceKind)> {
+    let mut references = Vec::new();
+
+    if let Some(state) = node.semantic_object_state() {
+        references.extend(state.signal_bindings().iter().map(|binding| {
+            (
+                binding.signal(),
+                SemanticReferenceKind::SignalBinding {
+                    property: binding.property(),
+                },
+            )
+        }));
+    }
+
+    match node.kind() {
+        SemanticNodeKind::Signal(state) => {
+            if let SemanticSignalSource::Derived(expression) = state.source() {
+                collect_signal_dependencies(expression, &mut references);
+            }
+        }
+        SemanticNodeKind::Animation(state) => match state.intent() {
+            SemanticAnimationIntent::TransformTo {
+                target,
+                target_state,
+            } => {
+                references.push((*target, SemanticReferenceKind::AnimationTarget));
+                references.push((*target_state, SemanticReferenceKind::AnimationTargetState));
+            }
+            SemanticAnimationIntent::Composition { children, .. } => {
+                references.extend(
+                    children
+                        .iter()
+                        .copied()
+                        .map(|child| (child, SemanticReferenceKind::AnimationChild)),
+                );
+            }
+        },
+        SemanticNodeKind::Object(_)
+        | SemanticNodeKind::AuthoringObject
+        | SemanticNodeKind::Family => {}
+    }
+
+    references
+}
+
+fn collect_signal_dependencies(
+    expression: &SemanticSignalExpr,
+    references: &mut Vec<(SemanticNodeId, SemanticReferenceKind)>,
+) {
+    match expression {
+        SemanticSignalExpr::Constant(_) => {}
+        SemanticSignalExpr::Signal(signal) => {
+            references.push((*signal, SemanticReferenceKind::SignalDependency));
+        }
+        SemanticSignalExpr::Add(lhs, rhs)
+        | SemanticSignalExpr::Sub(lhs, rhs)
+        | SemanticSignalExpr::Mul(lhs, rhs) => {
+            collect_signal_dependencies(lhs, references);
+            collect_signal_dependencies(rhs, references);
+        }
+        SemanticSignalExpr::Neg(value)
+        | SemanticSignalExpr::Sin(value)
+        | SemanticSignalExpr::Cos(value) => collect_signal_dependencies(value, references),
+    }
+}
+
+fn record_direct_remove_writes(node: &SemanticNode, written_slots: &mut HashSet<SemanticNodeId>) {
+    written_slots.insert(node.id());
+    if let SemanticSceneMembership::Attached { previous, next } = node.scene_membership {
+        written_slots.extend(previous);
+        written_slots.extend(next);
+    }
+    written_slots.extend(node.parents().iter().copied());
+    written_slots.extend(node.members());
+}

--- a/crates/noon-core/src/semantic_store.rs
+++ b/crates/noon-core/src/semantic_store.rs
@@ -5,6 +5,10 @@ use serde::{Deserialize, Serialize};
 use crate::{HostCallbackId, SemanticAnimationState, SemanticObjectState, SemanticSignalState};
 use crate::{ObjectDefinition, ObjectId, SceneDefinition};
 
+mod semantic_references;
+use semantic_references::SemanticIncomingReference;
+pub(crate) use semantic_references::{SemanticRemoveNodeEffect, SemanticRemoveNodeOutcome};
+
 /// Stable semantic identity independent of execution/render dense indices.
 ///
 /// Reusing a vacant slot increments its generation, so stale handles never
@@ -324,6 +328,7 @@ pub struct SemanticStore {
     next_insertion_order: u64,
     object_nodes: HashMap<ObjectId, SemanticNodeId>,
     source_nodes: HashMap<SourceIdentity, SemanticNodeId>,
+    incoming_references: HashMap<SemanticNodeId, Vec<SemanticIncomingReference>>,
     last_mutation: SemanticMutationStats,
 }
 
@@ -369,6 +374,7 @@ impl SemanticStore {
         self.node_mut(id)
             .expect("newly inserted semantic node exists")
             .object_state = Some(state);
+        self.register_semantic_references_for_owner(id);
         id
     }
 
@@ -386,14 +392,18 @@ impl SemanticStore {
         &mut self,
         state: SemanticSignalState,
     ) -> SemanticNodeId {
-        self.insert_kind(SemanticNodeKind::Signal(state))
+        let id = self.insert_kind(SemanticNodeKind::Signal(state));
+        self.register_semantic_references_for_owner(id);
+        id
     }
 
     pub(crate) fn insert_semantic_animation_state(
         &mut self,
         state: SemanticAnimationState,
     ) -> SemanticNodeId {
-        self.insert_kind(SemanticNodeKind::Animation(state))
+        let id = self.insert_kind(SemanticNodeKind::Animation(state));
+        self.register_semantic_references_for_owner(id);
+        id
     }
 
     fn insert_kind(&mut self, kind: SemanticNodeKind) -> SemanticNodeId {
@@ -845,6 +855,7 @@ impl SemanticStore {
             .node(id)
             .ok_or(SemanticStoreError::UnknownNode(id))?
             .clone();
+        self.unregister_semantic_references_for_owner(id);
 
         let mut writes = 0;
         if node.is_scene_owned() {
@@ -871,6 +882,7 @@ impl SemanticStore {
         if let Some(source) = &node.source_identity {
             self.source_nodes.remove(source);
         }
+        self.incoming_references.remove(&id);
 
         let slot = &mut self.slots[id.slot as usize];
         let removed = slot.node.take().expect("node existence validated above");


### PR DESCRIPTION
## Roadmap ownership

- Owning case: #957 / A1.5 — `RemoveNode` in the one Semantic Scene mutation transaction
- Builds directly on merged #1032 family-edge mutations, which in turn include merged #1030 `ReplaceContent`
- Parent roadmap: #953
- Validation/locality: #961 / A6.4

## What changed

Extend the existing `SemanticMutationTransaction` with structural semantic deletion instead of adding a second lifecycle patch path:

- add `SemanticMutation::RemoveNode { node }` and `SemanticMutationImpact::NodeRemoved { node }`;
- preserve the low-level `SemanticStore::remove_node` primitive and its generation-safe stale-reference migration semantics;
- add store-owned reverse-reference metadata for authored semantic references, covering:
  - derived-signal dependencies;
  - signal→object-property bindings;
  - animation target / target-state references;
  - animation composition children;
- maintain that reverse metadata on signal insertion/source rewiring, object binding insertion/removal/rebind, object insertion/copy, and animation insertion;
- transaction-level `RemoveNode` walks only the transitive reverse-reference closure plus each removed node's direct root/family relationships — it does not scan the total scene.

## Cleanup semantics

A surviving Semantic Scene must not retain authored declarations that are invalid after transactional deletion:

- signal bindings to a removed source are automatically unbound in place;
- a derived signal whose dependency is removed is itself removed;
- an animation whose target or target-state is removed is itself removed;
- a composition containing a removed animation is itself removed;
- those declaration removals cascade through their own reverse references.

This is conservative referential-integrity cleanup. Generational identity still prevents accidental retargeting, but the transaction no longer leaves stale semantic declarations behind.

## Atomicity / ordering

The complete transaction is still preflighted before the first semantic write.

`RemoveNode` is terminal within one transaction: once structural removal begins, only further `RemoveNode` mutations may follow. Preflight expands explicit removals through the same reverse dependency closure used by commit, and rejects:

- duplicate explicit node removals;
- an earlier mutation targeting a node the same transaction removes explicitly or transitively;
- binding a signal that the same transaction removes explicitly or transitively;
- family-edge changes involving a node removed by the transaction;
- stale removal targets.

Multiple terminal removals remain valid; if an earlier removal cascade already removes a later explicitly requested node, the later removal is treated as already satisfied and emits no duplicate impact.

## Impact / locality accounting

Removal emits `NodeRemoved` for every semantic declaration actually deleted and `Subscription` for automatic unbinds. Aggregate `slots_written` counts unique authored semantic slots touched, including root/family neighbors repaired by the existing low-level removal primitive, while reverse-index metadata itself is not misreported as authored slot mutation.

Focused locality coverage builds 10k unrelated semantic objects, then removes a source with one derived dependent and one bound target; the transaction still writes exactly those three semantic slots. Preflight closure traversal is likewise proportional only to the reverse-reference closure.

## Tests

Existing transaction regression coverage was moved intact to `semantic_transaction/base_tests.rs` rather than deleted during the structural edit.

New focused tests cover:

- source removal -> derived-signal cascade + property unbind;
- animation target removal -> leaf + parent-composition cascade while unrelated animation state survives;
- stale removal rollback of earlier valid mutations;
- terminal structural ordering;
- same-transaction target/removal and direct subscription/removal conflicts;
- a subscription to a derived signal that would be removed transitively by a later source deletion;
- reverse-index correctness after subscription rebind;
- reverse-index correctness after signal-source rewiring;
- 10k unrelated-node locality.

GitHub CI is the executable compile/test/architecture gate.

Refs #953 #957 #961 #1013 #1016 #1023 #1027 #1030 #1032.