### PR TITLE
Add atomic semantic family reordering

### DIFF
--- a/crates/noon-core/src/reactive/semantic_transaction.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction.rs
@@ -13,7 +13,7 @@ use family_edges::FamilyEdgePreflight;
 
 /// One mutation in the authoritative Semantic Scene transaction vocabulary.
 ///
-/// Signal values, object properties, authored content, family membership,
+/// Signal values, object properties, authored content, family membership/order,
 /// reactive subscriptions, and structural deletion share the same transaction so
 /// frontends, editors, and host integrations cannot invent subsystem-specific
 /// patch paths. Dependency-expression rewiring remains authored declaration
@@ -46,6 +46,11 @@ pub enum SemanticMutation {
         family: SemanticNodeId,
         member: SemanticNodeId,
     },
+    ReorderMember {
+        family: SemanticNodeId,
+        member: SemanticNodeId,
+        before: Option<SemanticNodeId>,
+    },
     RemoveNode {
         node: SemanticNodeId,
     },
@@ -58,7 +63,9 @@ impl SemanticMutation {
             Self::SetProperty { object, .. }
             | Self::ReplaceContent { object, .. }
             | Self::ChangeSubscription { object, .. } => *object,
-            Self::AddMember { family, .. } | Self::RemoveMember { family, .. } => *family,
+            Self::AddMember { family, .. }
+            | Self::RemoveMember { family, .. }
+            | Self::ReorderMember { family, .. } => *family,
             Self::RemoveNode { node } => *node,
         }
     }
@@ -85,6 +92,10 @@ impl SemanticMutation {
                     member: *member,
                 }
             }
+            Self::ReorderMember { family, member, .. } => SemanticMutationKey::FamilyOrder {
+                family: *family,
+                member: *member,
+            },
             Self::RemoveNode { node } => SemanticMutationKey::NodeRemoval(*node),
         }
     }
@@ -103,6 +114,10 @@ enum SemanticMutationKey {
         property: SemanticObjectProperty,
     },
     FamilyEdge {
+        family: SemanticNodeId,
+        member: SemanticNodeId,
+    },
+    FamilyOrder {
         family: SemanticNodeId,
         member: SemanticNodeId,
     },
@@ -138,6 +153,11 @@ pub enum SemanticMutationImpact {
     FamilyMemberRemoved {
         family: SemanticNodeId,
         member: SemanticNodeId,
+    },
+    FamilyMemberReordered {
+        family: SemanticNodeId,
+        member: SemanticNodeId,
+        before: Option<SemanticNodeId>,
     },
     NodeRemoved {
         node: SemanticNodeId,
@@ -221,6 +241,24 @@ impl SemanticMutationTransaction {
     pub fn remove_member(&mut self, family: SemanticNodeId, member: SemanticNodeId) -> &mut Self {
         self.mutations
             .push(SemanticMutation::RemoveMember { family, member });
+        self
+    }
+
+    /// Move one direct family member before another direct member, or to the tail.
+    ///
+    /// `before=None` means tail. Reordering preserves membership and parent edges;
+    /// only the family's authoritative order is mutated.
+    pub fn reorder_member(
+        &mut self,
+        family: SemanticNodeId,
+        member: SemanticNodeId,
+        before: Option<SemanticNodeId>,
+    ) -> &mut Self {
+        self.mutations.push(SemanticMutation::ReorderMember {
+            family,
+            member,
+            before,
+        });
         self
     }
 
@@ -309,6 +347,22 @@ impl SemanticMutationTransaction {
                     written_slots.insert(family);
                     written_slots.insert(member);
                     impacts.push(SemanticMutationImpact::FamilyMemberRemoved { family, member });
+                }
+                SemanticMutation::ReorderMember {
+                    family,
+                    member,
+                    before,
+                } => {
+                    let reordered = store.reorder_member(family, member, before).expect(
+                        "preflighted family reorder must remain valid while transaction owns the semantic store",
+                    );
+                    debug_assert!(reordered);
+                    written_slots.insert(family);
+                    impacts.push(SemanticMutationImpact::FamilyMemberReordered {
+                        family,
+                        member,
+                        before,
+                    });
                 }
                 SemanticMutation::RemoveNode { node } => {
                     // An earlier explicit removal may have cascade-removed this
@@ -406,6 +460,33 @@ impl SemanticMutationTransaction {
                     );
                 }
             }
+            if let SemanticMutation::ReorderMember {
+                family,
+                member,
+                before,
+            } = mutation
+            {
+                if removed_nodes.contains(member) {
+                    return Err(
+                        SemanticMutationTransactionError::FamilyOrderUsesRemovedNode {
+                            index,
+                            family: *family,
+                            node: *member,
+                        },
+                    );
+                }
+                if let Some(anchor) = before {
+                    if removed_nodes.contains(anchor) {
+                        return Err(
+                            SemanticMutationTransactionError::FamilyOrderUsesRemovedNode {
+                                index,
+                                family: *family,
+                                node: *anchor,
+                            },
+                        );
+                    }
+                }
+            }
 
             let key = mutation.key();
             if !targets.insert(key) {
@@ -432,6 +513,13 @@ impl SemanticMutationTransaction {
                     }
                     SemanticMutationKey::FamilyEdge { family, member } => {
                         SemanticMutationTransactionError::DuplicateFamilyEdge {
+                            index,
+                            family,
+                            member,
+                        }
+                    }
+                    SemanticMutationKey::FamilyOrder { family, member } => {
+                        SemanticMutationTransactionError::DuplicateFamilyOrder {
                             index,
                             family,
                             member,
@@ -561,6 +649,20 @@ impl SemanticMutationTransaction {
                     changed.push(family_edges.remove(store, *family, *member).map_err(
                         |error| SemanticMutationTransactionError::Family { index, error },
                     )?);
+                }
+                SemanticMutation::ReorderMember {
+                    family,
+                    member,
+                    before,
+                } => {
+                    changed.push(
+                        family_edges
+                            .reorder(store, *family, *member, *before)
+                            .map_err(|error| SemanticMutationTransactionError::Family {
+                                index,
+                                error,
+                            })?,
+                    );
                 }
                 SemanticMutation::RemoveNode { node } => {
                     if store.node(*node).is_none() {
@@ -723,6 +825,11 @@ pub enum SemanticMutationTransactionError {
         family: SemanticNodeId,
         member: SemanticNodeId,
     },
+    DuplicateFamilyOrder {
+        index: usize,
+        family: SemanticNodeId,
+        member: SemanticNodeId,
+    },
     DuplicateNodeRemoval {
         index: usize,
         node: SemanticNodeId,
@@ -744,6 +851,11 @@ pub enum SemanticMutationTransactionError {
         index: usize,
         family: SemanticNodeId,
         member: SemanticNodeId,
+    },
+    FamilyOrderUsesRemovedNode {
+        index: usize,
+        family: SemanticNodeId,
+        node: SemanticNodeId,
     },
     Signal {
         index: usize,
@@ -842,6 +954,18 @@ impl std::fmt::Display for SemanticMutationTransactionError {
                 member.slot(),
                 member.generation()
             ),
+            Self::DuplicateFamilyOrder {
+                index,
+                family,
+                member,
+            } => write!(
+                formatter,
+                "semantic transaction mutation {index} repeats family reorder for member {}:{} in family {}:{}",
+                member.slot(),
+                member.generation(),
+                family.slot(),
+                family.generation()
+            ),
             Self::DuplicateNodeRemoval { index, node } => write!(
                 formatter,
                 "semantic transaction mutation {index} repeats removal of node {}:{}",
@@ -883,6 +1007,18 @@ impl std::fmt::Display for SemanticMutationTransactionError {
                 family.generation(),
                 member.slot(),
                 member.generation()
+            ),
+            Self::FamilyOrderUsesRemovedNode {
+                index,
+                family,
+                node,
+            } => write!(
+                formatter,
+                "semantic transaction mutation {index} cannot reorder family {}:{} using node {}:{} because that node is removed by the same transaction",
+                family.slot(),
+                family.generation(),
+                node.slot(),
+                node.generation()
             ),
             Self::Signal { index, error } => {
                 write!(formatter, "semantic transaction mutation {index}: {error}")
@@ -967,6 +1103,9 @@ mod subscription_tests;
 
 #[cfg(test)]
 mod family_edge_tests;
+
+#[cfg(test)]
+mod reorder_member_tests;
 
 #[cfg(test)]
 mod remove_node_tests;

--- a/crates/noon-core/src/reactive/semantic_transaction/family_edges.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction/family_edges.rs
@@ -8,6 +8,8 @@ use super::{
 #[derive(Debug, Default)]
 pub(super) struct FamilyEdgePreflight {
     overrides: HashMap<(SemanticNodeId, SemanticNodeId), bool>,
+    pending_appends: HashMap<SemanticNodeId, Vec<SemanticNodeId>>,
+    orders: HashMap<SemanticNodeId, Vec<SemanticNodeId>>,
 }
 
 impl FamilyEdgePreflight {
@@ -27,6 +29,11 @@ impl FamilyEdgePreflight {
             ));
         }
         self.overrides.insert((family, member), true);
+        if let Some(order) = self.orders.get_mut(&family) {
+            order.push(member);
+        } else {
+            self.pending_appends.entry(family).or_default().push(member);
+        }
         Ok(true)
     }
 
@@ -40,8 +47,98 @@ impl FamilyEdgePreflight {
         let changed = self.contains(store, family, member);
         if changed {
             self.overrides.insert((family, member), false);
+            if let Some(order) = self.orders.get_mut(&family) {
+                order.retain(|candidate| *candidate != member);
+            }
         }
         Ok(changed)
+    }
+
+    pub(super) fn reorder(
+        &mut self,
+        store: &SemanticStore,
+        family: SemanticNodeId,
+        member: SemanticNodeId,
+        before: Option<SemanticNodeId>,
+    ) -> Result<bool, SemanticSceneOperationError> {
+        validate_edge(store, family, member)?;
+        if !self.contains(store, family, member) {
+            return Err(SemanticSceneOperationError::Store(
+                SemanticStoreError::NotFamilyMember { family, member },
+            ));
+        }
+        if let Some(anchor) = before {
+            validate_edge(store, family, anchor)?;
+            if !self.contains(store, family, anchor) {
+                return Err(SemanticSceneOperationError::Store(
+                    SemanticStoreError::NotFamilyMember {
+                        family,
+                        member: anchor,
+                    },
+                ));
+            }
+        }
+        if before == Some(member) {
+            return Ok(false);
+        }
+
+        self.ensure_order(store, family);
+        let order = self
+            .orders
+            .get_mut(&family)
+            .expect("family order initialized above");
+        let member_index = order
+            .iter()
+            .position(|candidate| *candidate == member)
+            .expect("preflight membership and order must agree");
+        let already_positioned = match before {
+            Some(anchor) => order.get(member_index + 1) == Some(&anchor),
+            None => member_index + 1 == order.len(),
+        };
+        if already_positioned {
+            return Ok(false);
+        }
+
+        order.remove(member_index);
+        let insertion_index = match before {
+            Some(anchor) => order
+                .iter()
+                .position(|candidate| *candidate == anchor)
+                .expect("preflight anchor membership and order must agree"),
+            None => order.len(),
+        };
+        order.insert(insertion_index, member);
+        Ok(true)
+    }
+
+    fn ensure_order(&mut self, store: &SemanticStore, family: SemanticNodeId) {
+        if self.orders.contains_key(&family) {
+            return;
+        }
+        let mut order = store
+            .node(family)
+            .map(|node| node.members())
+            .unwrap_or_default();
+        order.retain(|member| {
+            self.overrides
+                .get(&(family, *member))
+                .copied()
+                .unwrap_or(true)
+        });
+        if let Some(appends) = self.pending_appends.remove(&family) {
+            for member in appends {
+                if self
+                    .overrides
+                    .get(&(family, member))
+                    .copied()
+                    .unwrap_or(false)
+                    && !order.contains(&member)
+                {
+                    order.push(member);
+                }
+            }
+        }
+        self.orders.insert(family, order);
     }
 
     fn contains(
@@ -81,6 +178,9 @@ impl FamilyEdgePreflight {
     }
 
     fn members(&self, store: &SemanticStore, family: SemanticNodeId) -> Vec<SemanticNodeId> {
+        if let Some(order) = self.orders.get(&family) {
+            return order.clone();
+        }
         let mut members = store
             .node(family)
             .map(|node| node.members())
@@ -91,9 +191,17 @@ impl FamilyEdgePreflight {
                 .copied()
                 .unwrap_or(true)
         });
-        for ((override_family, member), present) in &self.overrides {
-            if *override_family == family && *present && !members.contains(member) {
-                members.push(*member);
+        if let Some(appends) = self.pending_appends.get(&family) {
+            for member in appends {
+                if self
+                    .overrides
+                    .get(&(family, *member))
+                    .copied()
+                    .unwrap_or(false)
+                    && !members.contains(member)
+                {
+                    members.push(*member);
+                }
             }
         }
         members

--- a/crates/noon-core/src/reactive/semantic_transaction/reorder_member_tests.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction/reorder_member_tests.rs
@@ -1,0 +1,245 @@
+use super::*;
+use crate::{SemanticObjectState, StoredGeometry};
+
+fn object(store: &mut SemanticStore, radius: f32) -> SemanticNodeId {
+    store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle { radius }))
+}
+
+fn scalar_input(store: &SemanticStore, signal: SemanticNodeId) -> f64 {
+    let SemanticSignalSource::Input(SemanticSignalValue::Scalar(value)) =
+        store.semantic_signal_state(signal).unwrap().source()
+    else {
+        panic!("expected scalar input signal")
+    };
+    *value
+}
+
+#[test]
+fn reorder_member_changes_only_family_order_and_emits_one_impact() {
+    let mut store = SemanticStore::new();
+    let family = store.insert_family();
+    let first = object(&mut store, 1.0);
+    let second = object(&mut store, 2.0);
+    let third = object(&mut store, 3.0);
+    store.add_member(family, first).unwrap();
+    store.add_member(family, second).unwrap();
+    store.add_member(family, third).unwrap();
+    let parents_before = store.node(third).unwrap().parents().to_vec();
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction.reorder_member(family, third, Some(first));
+    let result = transaction.apply(&mut store).unwrap();
+
+    assert_eq!(
+        store.node(family).unwrap().members(),
+        vec![third, first, second]
+    );
+    assert_eq!(store.node(third).unwrap().parents(), parents_before);
+    assert_eq!(store.last_mutation_stats().slots_written, 1);
+    assert_eq!(
+        result.impacts(),
+        &[SemanticMutationImpact::FamilyMemberReordered {
+            family,
+            member: third,
+            before: Some(first),
+        }]
+    );
+}
+
+#[test]
+fn reorder_member_supports_tail_and_noop_positions() {
+    let mut store = SemanticStore::new();
+    let family = store.insert_family();
+    let first = object(&mut store, 1.0);
+    let second = object(&mut store, 2.0);
+    let third = object(&mut store, 3.0);
+    store.add_member(family, first).unwrap();
+    store.add_member(family, second).unwrap();
+    store.add_member(family, third).unwrap();
+
+    let mut already_before = SemanticMutationTransaction::new();
+    already_before.reorder_member(family, first, Some(second));
+    let result = already_before.apply(&mut store).unwrap();
+    assert!(result.impacts().is_empty());
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+
+    let mut already_tail = SemanticMutationTransaction::new();
+    already_tail.reorder_member(family, third, None);
+    let result = already_tail.apply(&mut store).unwrap();
+    assert!(result.impacts().is_empty());
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+
+    let mut move_tail = SemanticMutationTransaction::new();
+    move_tail.reorder_member(family, first, None);
+    let result = move_tail.apply(&mut store).unwrap();
+    assert_eq!(
+        store.node(family).unwrap().members(),
+        vec![second, third, first]
+    );
+    assert_eq!(store.last_mutation_stats().slots_written, 1);
+    assert_eq!(result.impacts().len(), 1);
+}
+
+#[test]
+fn add_then_reorder_is_preflighted_and_committed_in_transaction_order() {
+    let mut store = SemanticStore::new();
+    let family = store.insert_family();
+    let first = object(&mut store, 1.0);
+    let second = object(&mut store, 2.0);
+    let added = object(&mut store, 3.0);
+    store.add_member(family, first).unwrap();
+    store.add_member(family, second).unwrap();
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .add_member(family, added)
+        .reorder_member(family, added, Some(first));
+    let result = transaction.apply(&mut store).unwrap();
+
+    assert_eq!(
+        store.node(family).unwrap().members(),
+        vec![added, first, second]
+    );
+    assert_eq!(store.last_mutation_stats().slots_written, 2);
+    assert_eq!(
+        result.impacts(),
+        &[
+            SemanticMutationImpact::FamilyMemberAdded {
+                family,
+                member: added,
+            },
+            SemanticMutationImpact::FamilyMemberReordered {
+                family,
+                member: added,
+                before: Some(first),
+            },
+        ]
+    );
+}
+
+#[test]
+fn invalid_late_reorder_rolls_back_earlier_mutations() {
+    let mut store = SemanticStore::new();
+    let signal = store.insert_semantic_input_signal(1.0_f64).unwrap();
+    let family = store.insert_family();
+    let member = object(&mut store, 1.0);
+    let non_member = object(&mut store, 2.0);
+    store.add_member(family, member).unwrap();
+    let before = store.node(family).unwrap().members();
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .set_signal(signal, 2.0_f64)
+        .reorder_member(family, member, Some(non_member));
+
+    assert_eq!(
+        transaction.apply(&mut store),
+        Err(SemanticMutationTransactionError::Family {
+            index: 1,
+            error: SemanticSceneOperationError::Store(SemanticStoreError::NotFamilyMember {
+                family,
+                member: non_member,
+            }),
+        })
+    );
+    assert_eq!(scalar_input(&store, signal), 1.0);
+    assert_eq!(store.node(family).unwrap().members(), before);
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+}
+
+#[test]
+fn duplicate_reorder_for_one_member_is_rejected_before_commit() {
+    let mut store = SemanticStore::new();
+    let family = store.insert_family();
+    let first = object(&mut store, 1.0);
+    let second = object(&mut store, 2.0);
+    let third = object(&mut store, 3.0);
+    store.add_member(family, first).unwrap();
+    store.add_member(family, second).unwrap();
+    store.add_member(family, third).unwrap();
+    let before = store.node(family).unwrap().members();
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .reorder_member(family, third, Some(first))
+        .reorder_member(family, third, Some(second));
+
+    assert_eq!(
+        transaction.apply(&mut store),
+        Err(SemanticMutationTransactionError::DuplicateFamilyOrder {
+            index: 1,
+            family,
+            member: third
+        })
+    );
+    assert_eq!(store.node(family).unwrap().members(), before);
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+}
+
+#[test]
+fn reorder_rejects_member_or_anchor_removed_by_same_transaction() {
+    let mut store = SemanticStore::new();
+    let family = store.insert_family();
+    let first = object(&mut store, 1.0);
+    let second = object(&mut store, 2.0);
+    store.add_member(family, first).unwrap();
+    store.add_member(family, second).unwrap();
+
+    let mut member_removed = SemanticMutationTransaction::new();
+    member_removed
+        .reorder_member(family, first, None)
+        .remove_node(first);
+    assert_eq!(
+        member_removed.apply(&mut store),
+        Err(
+            SemanticMutationTransactionError::FamilyOrderUsesRemovedNode {
+                index: 0,
+                family,
+                node: first,
+            }
+        )
+    );
+
+    let mut anchor_removed = SemanticMutationTransaction::new();
+    anchor_removed
+        .reorder_member(family, second, Some(first))
+        .remove_node(first);
+    assert_eq!(
+        anchor_removed.apply(&mut store),
+        Err(
+            SemanticMutationTransactionError::FamilyOrderUsesRemovedNode {
+                index: 0,
+                family,
+                node: first,
+            }
+        )
+    );
+    assert_eq!(store.node(family).unwrap().members(), vec![first, second]);
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+}
+
+#[test]
+fn reorder_writes_one_slot_with_large_unrelated_scene() {
+    let mut store = SemanticStore::new();
+    for index in 0..10_000 {
+        object(&mut store, index as f32 + 1.0);
+    }
+    let family = store.insert_family();
+    let first = object(&mut store, 0.25);
+    let second = object(&mut store, 0.5);
+    let third = object(&mut store, 0.75);
+    store.add_member(family, first).unwrap();
+    store.add_member(family, second).unwrap();
+    store.add_member(family, third).unwrap();
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction.reorder_member(family, third, Some(first));
+    let result = transaction.apply(&mut store).unwrap();
+
+    assert_eq!(
+        store.node(family).unwrap().members(),
+        vec![third, first, second]
+    );
+    assert_eq!(store.last_mutation_stats().slots_written, 1);
+    assert_eq!(result.impacts().len(), 1);
+}

--- a/crates/noon-core/src/semantic_store.rs
+++ b/crates/noon-core/src/semantic_store.rs
@@ -79,7 +79,7 @@ struct FamilyMemberLink {
     next: Option<SemanticNodeId>,
 }
 
-/// Ordered family membership with local lookup/add/remove.
+/// Ordered family membership with local lookup/add/remove/reorder.
 ///
 /// The hash map is identity lookup only; deterministic semantic order follows
 /// the private previous/next links from `head` to `tail`.
@@ -146,6 +146,74 @@ impl OrderedFamilyMembers {
             debug_assert!(self.head.is_none());
             debug_assert!(self.tail.is_none());
         }
+        true
+    }
+
+    /// Move an existing member immediately before `before`, or to the tail when
+    /// `before` is `None`. All link lookup and rewiring is O(1).
+    fn move_before(&mut self, member: SemanticNodeId, before: Option<SemanticNodeId>) -> bool {
+        let link = *self
+            .links
+            .get(&member)
+            .expect("family reorder member must have a membership link");
+        if before == Some(member)
+            || before.is_some_and(|before| link.next == Some(before))
+            || (before.is_none() && self.tail == Some(member))
+        {
+            return false;
+        }
+
+        // Detach the member without changing membership identity.
+        if let Some(previous_id) = link.previous {
+            self.links
+                .get_mut(&previous_id)
+                .expect("family previous link must exist")
+                .next = link.next;
+        } else {
+            debug_assert_eq!(self.head, Some(member));
+            self.head = link.next;
+        }
+        if let Some(next_id) = link.next {
+            self.links
+                .get_mut(&next_id)
+                .expect("family next link must exist")
+                .previous = link.previous;
+        } else {
+            debug_assert_eq!(self.tail, Some(member));
+            self.tail = link.previous;
+        }
+
+        let (previous, next) = if let Some(before_id) = before {
+            let before_link = *self
+                .links
+                .get(&before_id)
+                .expect("family reorder anchor must have a membership link");
+            (before_link.previous, Some(before_id))
+        } else {
+            (self.tail, None)
+        };
+
+        if let Some(previous_id) = previous {
+            self.links
+                .get_mut(&previous_id)
+                .expect("family reorder previous link must exist")
+                .next = Some(member);
+        } else {
+            self.head = Some(member);
+        }
+        if let Some(next_id) = next {
+            self.links
+                .get_mut(&next_id)
+                .expect("family reorder next link must exist")
+                .previous = Some(member);
+        } else {
+            self.tail = Some(member);
+        }
+        *self
+            .links
+            .get_mut(&member)
+            .expect("family reorder member link must remain present") =
+            FamilyMemberLink { previous, next };
         true
     }
 
@@ -845,6 +913,58 @@ impl SemanticStore {
         Ok(true)
     }
 
+    /// Reorder one direct family member without changing membership or parent edges.
+    ///
+    /// `Some(anchor)` moves `member` immediately before the anchor. `None` moves
+    /// the member to the tail. Identity validation and link rewiring are O(1) and
+    /// only the family semantic slot is mutated.
+    pub fn reorder_member(
+        &mut self,
+        family: SemanticNodeId,
+        member: SemanticNodeId,
+        before: Option<SemanticNodeId>,
+    ) -> Result<bool, SemanticStoreError> {
+        if !matches!(
+            self.node(family).map(SemanticNode::kind),
+            Some(SemanticNodeKind::Family)
+        ) {
+            return Err(SemanticStoreError::NotFamily(family));
+        }
+        if self.node(member).is_none() {
+            return Err(SemanticStoreError::UnknownNode(member));
+        }
+        let members = &self.node(family).expect("family validated above").members;
+        if !members.contains(member) {
+            return Err(SemanticStoreError::NotFamilyMember { family, member });
+        }
+        if let Some(anchor) = before {
+            if self.node(anchor).is_none() {
+                return Err(SemanticStoreError::UnknownNode(anchor));
+            }
+            if !members.contains(anchor) {
+                return Err(SemanticStoreError::NotFamilyMember {
+                    family,
+                    member: anchor,
+                });
+            }
+        }
+
+        let changed = self
+            .node_mut(family)
+            .expect("family validated above")
+            .members
+            .move_before(member, before);
+        self.last_mutation = if changed {
+            SemanticMutationStats {
+                slots_written: 1,
+                cycle_nodes_visited: 0,
+            }
+        } else {
+            SemanticMutationStats::default()
+        };
+        Ok(changed)
+    }
+
     /// Remove a node without renumbering any unrelated semantic identity.
     ///
     /// Attached root membership is removed locally first. Remaining work is
@@ -948,6 +1068,10 @@ impl SemanticStore {
 pub enum SemanticStoreError {
     UnknownNode(SemanticNodeId),
     NotFamily(SemanticNodeId),
+    NotFamilyMember {
+        family: SemanticNodeId,
+        member: SemanticNodeId,
+    },
     FamilyCycle {
         family: SemanticNodeId,
         member: SemanticNodeId,
@@ -969,6 +1093,14 @@ impl std::fmt::Display for SemanticStoreError {
                 "semantic node {}:{} is not a family",
                 id.slot(),
                 id.generation()
+            ),
+            Self::NotFamilyMember { family, member } => write!(
+                formatter,
+                "semantic node {}:{} is not a direct member of family {}:{}",
+                member.slot(),
+                member.generation(),
+                family.slot(),
+                family.generation()
             ),
             Self::FamilyCycle { family, member } => write!(
                 formatter,
@@ -1145,6 +1277,34 @@ mod tests {
         assert_eq!(store.last_mutation_stats().slots_written, 2);
         let ordered = store.node(family).unwrap().members();
         assert_eq!(ordered.last(), Some(&target));
+    }
+
+    #[test]
+    fn family_member_reorder_is_one_slot_local() {
+        let mut store = SemanticStore::new();
+        let family = store.insert_family();
+        let members = (0..10_000)
+            .map(|_| store.insert_authoring_object())
+            .collect::<Vec<_>>();
+        for member in members.iter().copied() {
+            store.add_member(family, member).unwrap();
+        }
+        let target = members[5_000];
+        let anchor = members[10];
+        let parents_before = store.node(target).unwrap().parents().to_vec();
+
+        assert!(store.reorder_member(family, target, Some(anchor)).unwrap());
+        assert_eq!(store.last_mutation_stats().slots_written, 1);
+        assert_eq!(store.node(target).unwrap().parents(), parents_before);
+        let ordered = store.node(family).unwrap().members();
+        let anchor_index = ordered.iter().position(|id| *id == anchor).unwrap();
+        assert_eq!(ordered[anchor_index - 1], target);
+
+        assert!(!store.reorder_member(family, target, Some(anchor)).unwrap());
+        assert_eq!(store.last_mutation_stats().slots_written, 0);
+        assert!(store.reorder_member(family, target, None).unwrap());
+        assert_eq!(store.last_mutation_stats().slots_written, 1);
+        assert_eq!(store.node(family).unwrap().members().last(), Some(&target));
     }
 
     #[test]


### PR DESCRIPTION
## Roadmap ownership

- Owning case: #957 / A1.5 — `ReorderMember` in the one Semantic Scene mutation transaction
- Builds directly on merged #1034 transactional `RemoveNode` / reverse cleanup
- Parent roadmap: #953
- Validation/locality: #961 / A6.4

## What changed

Extend the existing `SemanticMutationTransaction` with deterministic family ordering instead of introducing a separate reorder API:

- add `SemanticMutation::ReorderMember { family, member, before }`;
- `Some(anchor)` moves the direct member immediately before another direct member;
- `None` moves the member to the family tail;
- add `SemanticMutationImpact::FamilyMemberReordered`;
- add a local `SemanticStore::reorder_member` primitive that rewires only the family's private identity-indexed order links;
- preserve child parent edges and every other semantic node field;
- report exactly one written semantic slot for a changed reorder.

## Atomicity / composition

Family preflight now tracks order only for families that actually use `ReorderMember`. Ordinary add/remove preflight keeps its prior lightweight path.

The transaction can compose `AddMember -> ReorderMember` in one atomic sequence. Invalid/stale/non-member anchors fail before any commit, repeated reorders of the same `(family, member)` are rejected, and `RemoveNode` conflict validation covers both the reordered member and its anchor.

## Locality

The committed store reorder is O(1): direct member and anchor identities address the intrusive family links directly, so no sibling or total-scene scan is needed to mutate order. Transaction preflight materializes only an affected family's order when reordering is present so pending family-edge mutations can be simulated coherently; unrelated scene nodes are never inspected.

## Tests

Focused coverage includes:

- move-before ordering and one-slot impact accounting;
- tail moves plus already-correct no-ops;
- `AddMember -> ReorderMember` transaction sequencing;
- late invalid anchor rollback of an earlier signal mutation;
- duplicate reorder rejection;
- member/anchor conflicts with same-transaction `RemoveNode`;
- 10k unrelated-object locality;
- direct 10k-member storage reorder preserving parent edges while writing one slot.

GitHub CI is the executable compile/test/architecture gate.

Refs #953 #957 #961 #1032 #1034.