### PR TITLE
Document noon-render-wgpu ownership boundary

### DIFF
--- a/crates/noon-render-wgpu/Cargo.toml
+++ b/crates/noon-render-wgpu/Cargo.toml
@@ -3,6 +3,8 @@ name = "noon-render-wgpu"
 version = "0.1.0"
 edition = "2021"
 license = "MIT"
+description = "Reusable retained WGPU renderer for Noon runtime state"
+readme = "README.md"
 
 [features]
 default = ["native", "ci-noop"]

--- a/crates/noon-render-wgpu/README.md
+++ b/crates/noon-render-wgpu/README.md
@@ -1,0 +1,17 @@
+# noon-render-wgpu
+
+`noon-render-wgpu` is Noon's reusable retained GPU renderer for WGPU targets.
+
+## Ownership
+
+This crate projects renderer-facing `noon-runtime` frame state, resources, and change sets into retained GPU resources and draw work. It owns WGPU-specific preparation/upload, command encoding, and the native/web/CI feature split needed to build the same renderer for multiple targets.
+
+The renderer derives GPU state from runtime output. It does not read or own mutable Semantic Scene truth, session wake or scheduling policy, or platform lifecycle. The architecture requires renderer input to become coherent effective runtime state at a published `FrameEpoch`, with versioned resources retained until in-flight submissions are safe to retire; this README does not claim those publication and retirement mechanics are already implemented in this crate.
+
+WGPU and its target feature matrix create a real dependency and compilation boundary, so this remains a crate rather than merely mirroring an architecture box.
+
+## Platform boundary
+
+Platform hosts own native window or browser-canvas lifecycle, surface creation/configuration, event-loop/frame scheduling, input translation, presentation, and recovery policy. `noon-native` owns native lifecycle; `noon-web` owns browser/WASM integration. Keeping those concerns outside this crate leaves the renderer reusable by both hosts.
+
+This boundary follows `docs/architecture.md` and the Phase A5 normalization rules in #960.


### PR DESCRIPTION
## Summary

Document `noon-render-wgpu` as the reusable retained WGPU renderer and add its package metadata.

The README now distinguishes current behavior from the target contract. It records that renderer input must become coherent effective runtime state at a published `FrameEpoch`, with versioned resources retained until in-flight submissions are safe, without claiming those publication and retirement mechanics are already implemented. It also records that the renderer does not read mutable Semantic Scene truth or own session wake/scheduling.

## Validation

- `git diff --check`

The repository's integrated Rust gate is pending in the coordinating worktree.

## Architecture

`noon-native` owns native lifecycle and `noon-web` owns browser/WASM integration. This crate remains reusable retained GPU rendering under #960.


Independent review passed. Local `cargo check --workspace --all-targets --all-features`, `cargo metadata --no-deps`, and `git diff --check` passed in the cleanup worktree. Documentation/package metadata only; remaining publication/resource-retirement work is explicitly identified as target behavior.
