### PR TITLE
Run one-shot closed PR branch cleanup

### DIFF
--- a/.github/workflows/branch-cleanup-once.yml
+++ b/.github/workflows/branch-cleanup-once.yml
@@ -1,0 +1,88 @@
+name: One-shot closed-PR branch cleanup
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - .github/workflows/branch-cleanup-once.yml
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete closed-PR branches
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+
+          tmp="$(mktemp -d)"
+          trap 'rm -rf "$tmp"' EXIT
+
+          gh api --paginate "repos/$REPO/pulls?state=open&per_page=100" > "$tmp/open.jsonl"
+          gh api --paginate "repos/$REPO/pulls?state=closed&per_page=100" > "$tmp/closed.jsonl"
+          gh api --paginate "repos/$REPO/branches?per_page=100" > "$tmp/branches.jsonl"
+
+          jq -s --arg repo "$REPO" \
+            '[.[][] | select(.head.repo.full_name == $repo) | .head.ref] | unique' \
+            "$tmp/open.jsonl" > "$tmp/open-heads.json"
+          jq -s --arg repo "$REPO" \
+            '[.[][] | select(.head.repo.full_name == $repo) | .head.ref] | unique' \
+            "$tmp/closed.jsonl" > "$tmp/closed-heads.json"
+          jq -s '[.[][] | {name, protected}]' \
+            "$tmp/branches.jsonl" > "$tmp/branches.json"
+
+          deleted=0
+          preserved_open=0
+          preserved_protected=0
+          already_gone=0
+          failed=0
+
+          while IFS= read -r branch; do
+            [[ "$branch" == "$DEFAULT_BRANCH" ]] && continue
+
+            if jq -e --arg b "$branch" 'index($b) != null' "$tmp/open-heads.json" >/dev/null; then
+              preserved_open=$((preserved_open + 1))
+              continue
+            fi
+
+            protected="$(jq -r --arg b "$branch" '.[] | select(.name == $b) | .protected' "$tmp/branches.json" | head -n1)"
+            if [[ -z "$protected" ]]; then
+              already_gone=$((already_gone + 1))
+              continue
+            fi
+            if [[ "$protected" == "true" ]]; then
+              preserved_protected=$((preserved_protected + 1))
+              continue
+            fi
+
+            if gh api -X DELETE "repos/$REPO/git/refs/heads/$branch" >/dev/null; then
+              echo "deleted $branch"
+              deleted=$((deleted + 1))
+            else
+              echo "::warning::failed to delete $branch"
+              failed=$((failed + 1))
+            fi
+          done < <(jq -r '.[]' "$tmp/closed-heads.json")
+
+          echo "deleted=$deleted preserved_open=$preserved_open preserved_protected=$preserved_protected already_gone=$already_gone failed=$failed"
+
+          {
+            echo "## Closed-PR branch cleanup"
+            echo
+            echo "- Deleted: $deleted"
+            echo "- Preserved because branch backs an open PR: $preserved_open"
+            echo "- Preserved because protected: $preserved_protected"
+            echo "- Closed-PR heads already absent: $already_gone"
+            echo "- Delete failures: $failed"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          test "$failed" -eq 0


### PR DESCRIPTION
One-shot repository maintenance cleanup.

Policy is intentionally conservative:
- delete only same-repository branches that are heads of closed PRs;
- preserve `master`;
- preserve protected branches;
- preserve any branch currently backing an open PR, even if it also has older closed PR history;
- leave branches with no PR history untouched so unique/unreviewed work is not guessed away.

The temporary workflow will be removed after the cleanup run completes.