### PR TITLE
Keep semantic reorder preflight local

### DIFF
--- a/crates/noon-core/src/reactive/semantic_transaction.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction.rs
@@ -375,7 +375,9 @@ impl SemanticMutationTransaction {
                     let reordered = store.reorder_member(family, member, before).expect(
                         "preflighted family reorder must remain valid while transaction owns the semantic store",
                     );
-                    debug_assert!(reordered);
+                    if !reordered {
+                        continue;
+                    }
                     written_slots.insert(family);
                     impacts.push(SemanticMutationImpact::FamilyMemberReordered {
                         family,

--- a/crates/noon-core/src/reactive/semantic_transaction/family_edges.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction/family_edges.rs
@@ -8,8 +8,6 @@ use super::{
 #[derive(Debug, Default)]
 pub(super) struct FamilyEdgePreflight {
     overrides: HashMap<(SemanticNodeId, SemanticNodeId), bool>,
-    pending_appends: HashMap<SemanticNodeId, Vec<SemanticNodeId>>,
-    orders: HashMap<SemanticNodeId, Vec<SemanticNodeId>>,
 }
 
 impl FamilyEdgePreflight {
@@ -29,11 +27,6 @@ impl FamilyEdgePreflight {
             ));
         }
         self.overrides.insert((family, member), true);
-        if let Some(order) = self.orders.get_mut(&family) {
-            order.push(member);
-        } else {
-            self.pending_appends.entry(family).or_default().push(member);
-        }
         Ok(true)
     }
 
@@ -47,9 +40,6 @@ impl FamilyEdgePreflight {
         let changed = self.contains(store, family, member);
         if changed {
             self.overrides.insert((family, member), false);
-            if let Some(order) = self.orders.get_mut(&family) {
-                order.retain(|candidate| *candidate != member);
-            }
         }
         Ok(changed)
     }
@@ -78,67 +68,14 @@ impl FamilyEdgePreflight {
                 ));
             }
         }
-        if before == Some(member) {
-            return Ok(false);
-        }
 
-        self.ensure_order(store, family);
-        let order = self
-            .orders
-            .get_mut(&family)
-            .expect("family order initialized above");
-        let member_index = order
-            .iter()
-            .position(|candidate| *candidate == member)
-            .expect("preflight membership and order must agree");
-        let already_positioned = match before {
-            Some(anchor) => order.get(member_index + 1) == Some(&anchor),
-            None => member_index + 1 == order.len(),
-        };
-        if already_positioned {
-            return Ok(false);
-        }
-
-        order.remove(member_index);
-        let insertion_index = match before {
-            Some(anchor) => order
-                .iter()
-                .position(|candidate| *candidate == anchor)
-                .expect("preflight anchor membership and order must agree"),
-            None => order.len(),
-        };
-        order.insert(insertion_index, member);
-        Ok(true)
-    }
-
-    fn ensure_order(&mut self, store: &SemanticStore, family: SemanticNodeId) {
-        if self.orders.contains_key(&family) {
-            return;
-        }
-        let mut order = store
-            .node(family)
-            .map(|node| node.members())
-            .unwrap_or_default();
-        order.retain(|member| {
-            self.overrides
-                .get(&(family, *member))
-                .copied()
-                .unwrap_or(true)
-        });
-        if let Some(appends) = self.pending_appends.remove(&family) {
-            for member in appends {
-                if self
-                    .overrides
-                    .get(&(family, member))
-                    .copied()
-                    .unwrap_or(false)
-                    && !order.contains(&member)
-                {
-                    order.push(member);
-                }
-            }
-        }
-        self.orders.insert(family, order);
+        // Exact order is intentionally not materialized during preflight. Direct
+        // membership is the only validity requirement for identity-relative reorder.
+        // Commit classifies already-correct adjacency/tail placement as a no-op after
+        // the complete transaction has been validated. This keeps reorder-only
+        // preflight proportional to the touched nodes' direct parent degree rather
+        // than to the number of siblings in the family.
+        Ok(before != Some(member))
     }
 
     fn contains(
@@ -152,8 +89,8 @@ impl FamilyEdgePreflight {
             .copied()
             .unwrap_or_else(|| {
                 store
-                    .node(family)
-                    .is_some_and(|node| node.members().contains(&member))
+                    .node(member)
+                    .is_some_and(|node| node.parents().contains(&family))
             })
     }
 
@@ -178,9 +115,6 @@ impl FamilyEdgePreflight {
     }
 
     fn members(&self, store: &SemanticStore, family: SemanticNodeId) -> Vec<SemanticNodeId> {
-        if let Some(order) = self.orders.get(&family) {
-            return order.clone();
-        }
         let mut members = store
             .node(family)
             .map(|node| node.members())
@@ -191,17 +125,9 @@ impl FamilyEdgePreflight {
                 .copied()
                 .unwrap_or(true)
         });
-        if let Some(appends) = self.pending_appends.get(&family) {
-            for member in appends {
-                if self
-                    .overrides
-                    .get(&(family, *member))
-                    .copied()
-                    .unwrap_or(false)
-                    && !members.contains(member)
-                {
-                    members.push(*member);
-                }
+        for ((override_family, member), present) in &self.overrides {
+            if *override_family == family && *present && !members.contains(member) {
+                members.push(*member);
             }
         }
         members

--- a/crates/noon-core/src/reactive/semantic_transaction/reorder_member_tests.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction/reorder_member_tests.rs
@@ -243,3 +243,68 @@ fn reorder_writes_one_slot_with_large_unrelated_scene() {
     assert_eq!(store.last_mutation_stats().slots_written, 1);
     assert_eq!(result.impacts().len(), 1);
 }
+
+#[test]
+fn earlier_reorder_can_make_later_distinct_reorder_a_commit_time_noop() {
+    let mut store = SemanticStore::new();
+    let family = store.insert_family();
+    let first = object(&mut store, 1.0);
+    let second = object(&mut store, 2.0);
+    let third = object(&mut store, 3.0);
+    let fourth = object(&mut store, 4.0);
+    for member in [first, second, third, fourth] {
+        store.add_member(family, member).unwrap();
+    }
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .reorder_member(family, third, Some(first))
+        .reorder_member(family, second, Some(fourth));
+    let result = transaction.apply(&mut store).unwrap();
+
+    assert_eq!(
+        store.node(family).unwrap().members(),
+        vec![third, first, second, fourth]
+    );
+    assert_eq!(store.last_mutation_stats().slots_written, 1);
+    assert_eq!(
+        result.impacts(),
+        &[SemanticMutationImpact::FamilyMemberReordered {
+            family,
+            member: third,
+            before: Some(first),
+        }]
+    );
+}
+
+#[test]
+fn reorder_transaction_handles_ten_thousand_member_family() {
+    let mut store = SemanticStore::new();
+    let family = store.insert_family();
+    let members = (0..10_000)
+        .map(|index| object(&mut store, index as f32 + 1.0))
+        .collect::<Vec<_>>();
+    for member in members.iter().copied() {
+        store.add_member(family, member).unwrap();
+    }
+    let target = members[5_000];
+    let anchor = members[10];
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction.reorder_member(family, target, Some(anchor));
+    let result = transaction.apply(&mut store).unwrap();
+
+    let ordered = store.node(family).unwrap().members();
+    assert_eq!(ordered.len(), 10_000);
+    assert_eq!(ordered[10], target);
+    assert_eq!(ordered[11], anchor);
+    assert_eq!(store.last_mutation_stats().slots_written, 1);
+    assert_eq!(
+        result.impacts(),
+        &[SemanticMutationImpact::FamilyMemberReordered {
+            family,
+            member: target,
+            before: Some(anchor),
+        }]
+    );
+}


### PR DESCRIPTION
## Roadmap ownership

- Follow-up to merged #1036 / #957 A1.5 `ReorderMember`
- Locality/validation owner: #961 / A6.4

## Finding

Independent review after #1036 merged found a locality mismatch: committed family reorder is O(1), but transaction preflight materialized the entire affected family order into a `Vec` and used identity scans whenever `ReorderMember` appeared. The existing 10k-member test covered the low-level store primitive, while the transaction locality test used only a three-member family.

## What changed

- preserve #1036's public `ReorderMember` mutation, impact, and error contracts unchanged;
- remove family-wide `orders` / `pending_appends` snapshots from family-edge preflight;
- validate reorder against projected direct membership only;
- base membership lookup follows the touched member's direct `parents` edge, so reorder-only preflight scales with direct parent degree rather than sibling count;
- pending `AddMember` / `RemoveMember` membership remains represented by the existing override map;
- exact adjacency/tail no-op classification is deferred until commit, after the complete transaction has already passed validation;
- if the authoritative O(1) store reorder reports an already-correct placement, commit emits no impact/write exactly as before.

Cycle reachability for `AddMember` is intentionally unchanged; this PR only removes the reorder-specific family-size scan.

## Tests

- existing head/tail no-op behavior remains unchanged;
- an earlier reorder can make a later distinct reorder a no-op at commit, proving deferred no-op classification is safe;
- a full transaction now exercises a 10k-member family rather than only 10k unrelated scene objects;
- existing rollback, duplicate reorder, AddMember composition, RemoveNode conflict, Rust/browser/architecture coverage remains intact.

One clean commit on current `master`. Merge requires exact-head CI green.

Refs #957 #961 #1036.