### PR TITLE
Classify one-shot branch cleanup workflow

### DIFF
--- a/web/ci-workflow-topology.test.mjs
+++ b/web/ci-workflow-topology.test.mjs
@@ -18,6 +18,7 @@ const exactFamilies = new Map([
   ["platform-release.yml", "platform-release"],
   ["pages.yml", "deployment"],
   ["fuzz.yml", "fuzz"],
+  ["branch-cleanup-once.yml", "maintenance"],
 ]);
 
 function classifyWorkflow(name) {


### PR DESCRIPTION
Follow-up to #1039.

`branch-cleanup-once.yml` was added to the workflow inventory but not classified in `web/ci-workflow-topology.test.mjs`, so current `master` fails the web preflight with `new workflow families must be classified explicitly: branch-cleanup-once.yml`.

Classify that one-shot operational workflow as `maintenance`. No required-family ratchet changes and no runtime/product code changes.

This also unblocks unrelated PR fast gates based on current `master`.

Refs #1039.