### PR TITLE
Add atomic semantic animation removal

### DIFF
--- a/crates/noon-core/src/reactive/semantic_transaction.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction.rs
@@ -51,6 +51,9 @@ pub enum SemanticMutation {
         member: SemanticNodeId,
         before: Option<SemanticNodeId>,
     },
+    RemoveAnimation {
+        animation: SemanticNodeId,
+    },
     RemoveNode {
         node: SemanticNodeId,
     },
@@ -66,6 +69,7 @@ impl SemanticMutation {
             Self::AddMember { family, .. }
             | Self::RemoveMember { family, .. }
             | Self::ReorderMember { family, .. } => *family,
+            Self::RemoveAnimation { animation } => *animation,
             Self::RemoveNode { node } => *node,
         }
     }
@@ -96,6 +100,7 @@ impl SemanticMutation {
                 family: *family,
                 member: *member,
             },
+            Self::RemoveAnimation { animation } => SemanticMutationKey::NodeRemoval(*animation),
             Self::RemoveNode { node } => SemanticMutationKey::NodeRemoval(*node),
         }
     }
@@ -262,14 +267,28 @@ impl SemanticMutationTransaction {
         self
     }
 
+    /// Delete one authored animation declaration through the same structural
+    /// transaction path as node deletion.
+    ///
+    /// The target must be a live animation at the transaction boundary. Removing a
+    /// child animation also removes parent compositions that can no longer remain
+    /// valid; composition children are references and are not owned/deleted when a
+    /// composition itself is removed.
+    pub fn remove_animation(&mut self, animation: SemanticNodeId) -> &mut Self {
+        self.mutations
+            .push(SemanticMutation::RemoveAnimation { animation });
+        self
+    }
+
     /// Delete one semantic identity and atomically clean declarations that cannot
     /// remain valid without it.
     ///
     /// Signal bindings are unbound. Derived signals and animation declarations
     /// that reference the removed identity are themselves removed, recursively.
     /// Structural removals are terminal within a transaction: once the first
-    /// `RemoveNode` is authored, no later non-removal mutation is accepted. This
-    /// keeps complete preflight valid through commit without staging a second scene.
+    /// structural removal is authored, no later non-removal mutation is accepted.
+    /// This keeps complete preflight valid through commit without staging a second
+    /// scene.
     pub fn remove_node(&mut self, node: SemanticNodeId) -> &mut Self {
         self.mutations.push(SemanticMutation::RemoveNode { node });
         self
@@ -364,16 +383,17 @@ impl SemanticMutationTransaction {
                         before,
                     });
                 }
-                SemanticMutation::RemoveNode { node } => {
+                SemanticMutation::RemoveAnimation { animation }
+                | SemanticMutation::RemoveNode { node: animation } => {
                     // An earlier explicit removal may have cascade-removed this
                     // node already. Preflight proved the handle was live at the
                     // transaction boundary; a cascade therefore satisfies this
                     // later structural mutation without duplicate impacts.
-                    if store.node(node).is_none() {
+                    if store.node(animation).is_none() {
                         continue;
                     }
                     let outcome = store
-                        .remove_node_with_reverse_cleanup(node)
+                        .remove_node_with_reverse_cleanup(animation)
                         .expect("preflighted node removal must remain valid while transaction owns the store");
                     written_slots.extend(outcome.written_slots().iter().copied());
                     for effect in outcome.effects() {
@@ -405,6 +425,22 @@ impl SemanticMutationTransaction {
         let mut removal_started = false;
         for (index, mutation) in self.mutations.iter().enumerate() {
             match mutation {
+                SemanticMutation::RemoveAnimation { animation } => {
+                    let Some(node) = store.node(*animation) else {
+                        return Err(SemanticMutationTransactionError::UnknownAnimation {
+                            index,
+                            animation: *animation,
+                        });
+                    };
+                    if !matches!(node.kind(), SemanticNodeKind::Animation(_)) {
+                        return Err(SemanticMutationTransactionError::NotAnimation {
+                            index,
+                            animation: *animation,
+                        });
+                    }
+                    removal_started = true;
+                    removed_nodes.insert(*animation);
+                }
                 SemanticMutation::RemoveNode { node } => {
                     removal_started = true;
                     removed_nodes.insert(*node);
@@ -422,8 +458,10 @@ impl SemanticMutationTransaction {
         let mut family_edges = FamilyEdgePreflight::default();
 
         for (index, mutation) in self.mutations.iter().enumerate() {
-            if !matches!(mutation, SemanticMutation::RemoveNode { .. })
-                && removed_nodes.contains(&mutation.target())
+            if !matches!(
+                mutation,
+                SemanticMutation::RemoveAnimation { .. } | SemanticMutation::RemoveNode { .. }
+            ) && removed_nodes.contains(&mutation.target())
             {
                 return Err(SemanticMutationTransactionError::TargetRemoved {
                     index,
@@ -664,6 +702,9 @@ impl SemanticMutationTransaction {
                             })?,
                     );
                 }
+                SemanticMutation::RemoveAnimation { .. } => {
+                    changed.push(true);
+                }
                 SemanticMutation::RemoveNode { node } => {
                     if store.node(*node).is_none() {
                         return Err(SemanticMutationTransactionError::Node {
@@ -879,6 +920,14 @@ pub enum SemanticMutationTransactionError {
         index: usize,
         error: SemanticSceneOperationError,
     },
+    UnknownAnimation {
+        index: usize,
+        animation: SemanticNodeId,
+    },
+    NotAnimation {
+        index: usize,
+        animation: SemanticNodeId,
+    },
     NonFinitePropertyValue {
         index: usize,
         object: SemanticNodeId,
@@ -974,7 +1023,7 @@ impl std::fmt::Display for SemanticMutationTransactionError {
             ),
             Self::MutationAfterRemove { index } => write!(
                 formatter,
-                "semantic transaction mutation {index} follows structural removal; RemoveNode mutations must be terminal"
+                "semantic transaction mutation {index} follows structural removal; structural removals must be terminal"
             ),
             Self::TargetRemoved { index, target } => write!(
                 formatter,
@@ -1043,6 +1092,18 @@ impl std::fmt::Display for SemanticMutationTransactionError {
             Self::Object { index, error } | Self::Family { index, error } => {
                 write!(formatter, "semantic transaction mutation {index}: {error}")
             }
+            Self::UnknownAnimation { index, animation } => write!(
+                formatter,
+                "semantic transaction mutation {index}: unknown semantic animation {}:{}",
+                animation.slot(),
+                animation.generation()
+            ),
+            Self::NotAnimation { index, animation } => write!(
+                formatter,
+                "semantic transaction mutation {index}: semantic node {}:{} is not an animation",
+                animation.slot(),
+                animation.generation()
+            ),
             Self::NonFinitePropertyValue {
                 index,
                 object,
@@ -1106,6 +1167,9 @@ mod family_edge_tests;
 
 #[cfg(test)]
 mod reorder_member_tests;
+
+#[cfg(test)]
+mod remove_animation_tests;
 
 #[cfg(test)]
 mod remove_node_tests;

--- a/crates/noon-core/src/reactive/semantic_transaction/remove_animation_tests.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction/remove_animation_tests.rs
@@ -1,0 +1,228 @@
+use super::*;
+use crate::{AnimationOptions, SemanticObjectState, StoredGeometry};
+
+fn object(store: &mut SemanticStore, radius: f32) -> SemanticNodeId {
+    store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle { radius }))
+}
+
+fn transform(store: &mut SemanticStore, radius: f32) -> SemanticNodeId {
+    let target = object(store, radius);
+    let target_state = object(store, radius + 0.5);
+    store
+        .insert_semantic_transform_animation(target, target_state, AnimationOptions::new())
+        .unwrap()
+}
+
+fn scalar_input(store: &SemanticStore, signal: SemanticNodeId) -> f64 {
+    let SemanticSignalSource::Input(SemanticSignalValue::Scalar(value)) =
+        store.semantic_signal_state(signal).unwrap().source()
+    else {
+        panic!("expected scalar input signal")
+    };
+    *value
+}
+
+#[test]
+fn remove_animation_cascades_parent_compositions_but_preserves_siblings() {
+    let mut store = SemanticStore::new();
+    let first = transform(&mut store, 1.0);
+    let second = transform(&mut store, 2.0);
+    let parent = store
+        .insert_semantic_parallel_animation(&[first, second], AnimationOptions::new())
+        .unwrap();
+    let third = transform(&mut store, 3.0);
+    let grandparent = store
+        .insert_semantic_sequence_animation(&[parent, third], AnimationOptions::new())
+        .unwrap();
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction.remove_animation(first);
+    let result = transaction.apply(&mut store).unwrap();
+
+    assert!(store.node(first).is_none());
+    assert!(store.node(parent).is_none());
+    assert!(store.node(grandparent).is_none());
+    assert!(store.semantic_animation_state(second).is_ok());
+    assert!(store.semantic_animation_state(third).is_ok());
+    assert_eq!(store.last_mutation_stats().slots_written, 3);
+    assert_eq!(
+        result.impacts(),
+        &[
+            SemanticMutationImpact::NodeRemoved { node: first },
+            SemanticMutationImpact::NodeRemoved { node: parent },
+            SemanticMutationImpact::NodeRemoved { node: grandparent },
+        ]
+    );
+}
+
+#[test]
+fn removing_composition_does_not_delete_referenced_children() {
+    let mut store = SemanticStore::new();
+    let first = transform(&mut store, 1.0);
+    let second = transform(&mut store, 2.0);
+    let composition = store
+        .insert_semantic_parallel_animation(&[first, second], AnimationOptions::new())
+        .unwrap();
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction.remove_animation(composition);
+    let result = transaction.apply(&mut store).unwrap();
+
+    assert!(store.node(composition).is_none());
+    assert!(store.semantic_animation_state(first).is_ok());
+    assert!(store.semantic_animation_state(second).is_ok());
+    assert_eq!(store.last_mutation_stats().slots_written, 1);
+    assert_eq!(
+        result.impacts(),
+        &[SemanticMutationImpact::NodeRemoved { node: composition }]
+    );
+}
+
+#[test]
+fn remove_animation_rejects_non_animation_before_earlier_commit() {
+    let mut store = SemanticStore::new();
+    let signal = store.insert_semantic_input_signal(1.0_f64).unwrap();
+    let not_animation = object(&mut store, 1.0);
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .set_signal(signal, 2.0_f64)
+        .remove_animation(not_animation);
+
+    assert_eq!(
+        transaction.apply(&mut store),
+        Err(SemanticMutationTransactionError::NotAnimation {
+            index: 1,
+            animation: not_animation,
+        })
+    );
+    assert_eq!(scalar_input(&store, signal), 1.0);
+    assert!(store.node(not_animation).is_some());
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+}
+
+#[test]
+fn stale_remove_animation_target_rolls_back_earlier_mutation() {
+    let mut store = SemanticStore::new();
+    let signal = store.insert_semantic_input_signal(1.0_f64).unwrap();
+    let stale = transform(&mut store, 1.0);
+    store.remove_node(stale).unwrap();
+    let replacement = object(&mut store, 9.0);
+    assert_eq!(stale.slot(), replacement.slot());
+    assert_ne!(stale.generation(), replacement.generation());
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .set_signal(signal, 2.0_f64)
+        .remove_animation(stale);
+
+    assert_eq!(
+        transaction.apply(&mut store),
+        Err(SemanticMutationTransactionError::UnknownAnimation {
+            index: 1,
+            animation: stale,
+        })
+    );
+    assert_eq!(scalar_input(&store, signal), 1.0);
+    assert!(store.node(replacement).is_some());
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+}
+
+#[test]
+fn remove_animation_is_terminal_with_other_structural_removals() {
+    let mut store = SemanticStore::new();
+    let animation = transform(&mut store, 1.0);
+    let signal = store.insert_semantic_input_signal(1.0_f64).unwrap();
+
+    let mut invalid_order = SemanticMutationTransaction::new();
+    invalid_order
+        .remove_animation(animation)
+        .set_signal(signal, 2.0_f64);
+    assert_eq!(
+        invalid_order.apply(&mut store),
+        Err(SemanticMutationTransactionError::MutationAfterRemove { index: 1 })
+    );
+    assert!(store.semantic_animation_state(animation).is_ok());
+    assert_eq!(scalar_input(&store, signal), 1.0);
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+
+    let unrelated = object(&mut store, 8.0);
+    let mut valid_terminal = SemanticMutationTransaction::new();
+    valid_terminal
+        .remove_animation(animation)
+        .remove_node(unrelated);
+    let result = valid_terminal.apply(&mut store).unwrap();
+    assert!(store.node(animation).is_none());
+    assert!(store.node(unrelated).is_none());
+    assert_eq!(result.impacts().len(), 2);
+}
+
+#[test]
+fn duplicate_typed_and_generic_removal_of_one_animation_is_rejected() {
+    let mut store = SemanticStore::new();
+    let animation = transform(&mut store, 1.0);
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .remove_animation(animation)
+        .remove_node(animation);
+
+    assert_eq!(
+        transaction.apply(&mut store),
+        Err(SemanticMutationTransactionError::DuplicateNodeRemoval {
+            index: 1,
+            node: animation,
+        })
+    );
+    assert!(store.semantic_animation_state(animation).is_ok());
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+}
+
+#[test]
+fn later_explicit_parent_removal_is_satisfied_by_earlier_cascade() {
+    let mut store = SemanticStore::new();
+    let first = transform(&mut store, 1.0);
+    let second = transform(&mut store, 2.0);
+    let parent = store
+        .insert_semantic_parallel_animation(&[first, second], AnimationOptions::new())
+        .unwrap();
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction.remove_animation(first).remove_animation(parent);
+    let result = transaction.apply(&mut store).unwrap();
+
+    assert!(store.node(first).is_none());
+    assert!(store.node(parent).is_none());
+    assert!(store.semantic_animation_state(second).is_ok());
+    assert_eq!(store.last_mutation_stats().slots_written, 2);
+    assert_eq!(
+        result.impacts(),
+        &[
+            SemanticMutationImpact::NodeRemoved { node: first },
+            SemanticMutationImpact::NodeRemoved { node: parent },
+        ]
+    );
+}
+
+#[test]
+fn remove_animation_cleanup_is_local_with_large_unrelated_scene() {
+    let mut store = SemanticStore::new();
+    for index in 0..10_000 {
+        object(&mut store, index as f32 + 1.0);
+    }
+    let first = transform(&mut store, 0.25);
+    let second = transform(&mut store, 0.5);
+    let parent = store
+        .insert_semantic_sequence_animation(&[first, second], AnimationOptions::new())
+        .unwrap();
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction.remove_animation(first);
+    let result = transaction.apply(&mut store).unwrap();
+
+    assert!(store.node(first).is_none());
+    assert!(store.node(parent).is_none());
+    assert!(store.semantic_animation_state(second).is_ok());
+    assert_eq!(store.last_mutation_stats().slots_written, 2);
+    assert_eq!(result.impacts().len(), 2);
+}


### PR DESCRIPTION
## Roadmap ownership

- Owning case: #957 / A1.5 — `RemoveAnimation` in the one Semantic Scene mutation transaction
- Builds directly on merged #1036 family reordering and #1034 reverse-reference cleanup
- Parent roadmap: #953
- Validation/locality: #961 / A6.4–A6.5

## What changed

Extend the existing `SemanticMutationTransaction` with typed authored-animation deletion:

- add `SemanticMutation::RemoveAnimation { animation }` and `remove_animation(...)`;
- validate that the requested identity is a live semantic animation before it enters transitive removal/conflict analysis;
- share the existing structural-removal key with `RemoveNode`, so typed/generic duplicate removal of one identity is rejected;
- make `RemoveAnimation` terminal with other structural removals, preserving the transaction's preflight-before-commit invariant;
- reuse `SemanticStore::remove_node_with_reverse_cleanup` rather than introducing a second deletion path;
- retain the existing generic `NodeRemoved` impact vocabulary so the effect of deleting an animation is identical whether it was explicitly removed or invalidated by another structural cascade.

## Semantics

Animation composition children are references, not ownership:

- removing a child animation recursively removes parent compositions that can no longer remain valid;
- removing a composition does not remove its child animations;
- if an earlier removal cascade already deleted a later explicit animation-removal target, the later mutation is satisfied without duplicate impacts;
- stale generations and non-animation identities fail before any earlier transaction mutation is committed.

## Locality

Removal follows the reverse-reference closure plus each removed node's direct structural relationships. It never scans unrelated scene state. A focused 10k-unrelated-object regression verifies that deleting one leaf plus its parent composition writes exactly those two semantic slots.

## Tests

Focused coverage includes:

- leaf removal cascading through nested parent compositions while preserving sibling animations;
- composition removal preserving referenced children;
- non-animation typed target rollback;
- stale-generation rollback after slot reuse;
- structural-removal terminal ordering and mixed terminal removals;
- duplicate typed/generic deletion rejection;
- later explicit parent removal satisfied by an earlier cascade without duplicate impacts;
- 10k unrelated-scene locality.

The branch is one clean commit directly on master `7d8523f3b18032a513b32d114cfa730fe7d9deca`. GitHub CI is the executable compile/test/architecture gate.

Refs #953 #957 #961 #1034 #1036.