### PR TITLE
Remove obsolete branch cleanup workflow classification

### DIFF
--- a/web/ci-workflow-topology.test.mjs
+++ b/web/ci-workflow-topology.test.mjs
@@ -18,7 +18,6 @@ const exactFamilies = new Map([
   ["platform-release.yml", "platform-release"],
   ["pages.yml", "deployment"],
   ["fuzz.yml", "fuzz"],
-  ["branch-cleanup-once.yml", "maintenance"],
 ]);
 
 function classifyWorkflow(name) {


### PR DESCRIPTION
## Summary

Follow up the direct removal of the one-shot `branch-cleanup-once.yml` workflow by deleting its now-obsolete CI topology classification.

## Why

#1041 temporarily classified the one-shot workflow as `maintenance` so current master could pass the workflow inventory guard. The workflow has since been removed from master, so retaining an exact-family entry for a file that no longer exists leaves dead configuration in the topology test.

This removes only that stale map entry. Required workflow-family coverage and all other classifications remain unchanged.

## Scope

One line, one clean commit directly on master `7d8523f3b18032a513b32d114cfa730fe7d9deca`. No workflow, product, runtime, or renderer behavior changes.

Follow-up to #1039 and #1041.