### PR TITLE
Document noon-compile ownership boundary

### DIFF
--- a/crates/noon-compile/Cargo.toml
+++ b/crates/noon-compile/Cargo.toml
@@ -3,7 +3,8 @@ name = "noon-compile"
 version = "0.1.0"
 edition = "2021"
 license = "MIT"
-description = "Compiler from Noon authoring IR to dense runtime data"
+description = "Typed semantic lowering into renderer-independent execution data"
+readme = "README.md"
 
 [dependencies]
 noon-core = { path = "../noon-core" }

--- a/crates/noon-compile/README.md
+++ b/crates/noon-compile/README.md
@@ -1,0 +1,17 @@
+# noon-compile
+
+`noon-compile` owns typed, renderer-independent semantic analysis, lowering, and specialization into derived execution data.
+
+## Ownership
+
+The primary Phase A path lowers `noon_core::SemanticStore` into `SemanticExecutionLoweringOutput`, which `ExecutionSession` installs into the existing runtime machinery. This crate owns canonical reactive and animation lowering, execution specialization, and validation that fails before a new execution result is published.
+
+It also owns deterministic lowering work such as semantic-derived mapping, dense execution indices, and renderer-independent geometry/transform specialization. Durable `ExecutionSlotTable` identity belongs to the runtime. Runtime advancement, effective frame state, input/reactive execution, GPU resources, drawing, platform lifecycle, and language adaptation are outside this crate.
+
+`SceneDefinition` remains at temporary compatibility seams during migration. It is neither the primary authored input nor a peer scene model, and it does not create a serialization boundary.
+
+## Why this is a crate
+
+Lowering is deterministic, renderer-independent work with a concrete reuse and test boundary: the public Rust facade and runtime/session integration consume its derived execution data, while `noon-runtime` owns mutable execution state. The crate must not grow a parallel authoring IR.
+
+This boundary follows `docs/architecture.md` and the Phase A5 normalization rules in #960.


### PR DESCRIPTION
## Summary

Refresh `noon-compile` package documentation for the current typed lowering path and add its README metadata.

The crate now documents `SemanticStore -> SemanticExecutionLoweringOutput`, installed by `ExecutionSession`, plus canonical reactive/animation lowering and fail-before-publication validation. It assigns semantic-derived mapping and dense indices to lowering while leaving durable `ExecutionSlotTable` identity to runtime. `SceneDefinition` is described only as a temporary compatibility seam, not as an authoring IR or peer scene model.

## Validation

- `git diff --check`

The repository's integrated Rust gate is pending in the coordinating worktree.

## Architecture

`noon-compile` owns typed semantic analysis/lowering/specialization into derived execution data; runtime, rendering, and platform lifecycle remain outside its boundary.


Independent review: passed after correcting compiler/runtime identity ownership. Local validation: `cargo check --workspace --all-targets --all-features`, `cargo metadata --no-deps`, and `git diff --check` passed in the cleanup worktree. This PR changes documentation/package metadata only.
