### PR TITLE
Add atomic semantic animation insertion

### DIFF
--- a/crates/noon-core/src/reactive/semantic_transaction.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction.rs
@@ -2,11 +2,14 @@ use std::collections::HashSet;
 
 use super::semantic_store::SemanticRemoveNodeEffect;
 use super::{
-    SemanticNodeId, SemanticNodeKind, SemanticObjectContent, SemanticObjectProperty,
-    SemanticObjectState, SemanticSceneOperationError, SemanticSignalBinding, SemanticSignalError,
-    SemanticSignalSource, SemanticSignalValue, SemanticSignalValueKind, SemanticStore,
-    SemanticStoreError,
+    SemanticAnimationState, SemanticNodeId, SemanticNodeKind, SemanticObjectContent,
+    SemanticObjectProperty, SemanticObjectState, SemanticSceneOperationError,
+    SemanticSignalBinding, SemanticSignalError, SemanticSignalSource, SemanticSignalValue,
+    SemanticSignalValueKind, SemanticStore, SemanticStoreError,
 };
+
+mod animation_addition;
+use animation_addition::{commit_add_animation, preflight_add_animation};
 
 mod family_edges;
 use family_edges::FamilyEdgePreflight;
@@ -14,10 +17,10 @@ use family_edges::FamilyEdgePreflight;
 /// One mutation in the authoritative Semantic Scene transaction vocabulary.
 ///
 /// Signal values, object properties, authored content, family membership/order,
-/// reactive subscriptions, and structural deletion share the same transaction so
-/// frontends, editors, and host integrations cannot invent subsystem-specific
-/// patch paths. Dependency-expression rewiring remains authored declaration
-/// topology rather than being conflated with a value update.
+/// reactive subscriptions, animation declarations, and structural deletion share
+/// the same transaction so frontends, editors, and host integrations cannot invent
+/// subsystem-specific patch paths. Dependency-expression rewiring remains authored
+/// declaration topology rather than being conflated with a value update.
 #[derive(Clone, Debug, PartialEq)]
 pub enum SemanticMutation {
     SetSignal {
@@ -51,6 +54,9 @@ pub enum SemanticMutation {
         member: SemanticNodeId,
         before: Option<SemanticNodeId>,
     },
+    AddAnimation {
+        state: SemanticAnimationState,
+    },
     RemoveAnimation {
         animation: SemanticNodeId,
     },
@@ -60,48 +66,59 @@ pub enum SemanticMutation {
 }
 
 impl SemanticMutation {
-    pub const fn target(&self) -> SemanticNodeId {
+    /// Existing semantic identity directly targeted by this mutation.
+    ///
+    /// Allocation mutations do not have an identity until commit and therefore
+    /// return `None`. This keeps creation out of the existing-target conflict key
+    /// space and leaves room for `AddNode` to use the same allocation semantics.
+    pub const fn target(&self) -> Option<SemanticNodeId> {
         match self {
-            Self::SetSignal { signal, .. } => *signal,
+            Self::SetSignal { signal, .. } => Some(*signal),
             Self::SetProperty { object, .. }
             | Self::ReplaceContent { object, .. }
-            | Self::ChangeSubscription { object, .. } => *object,
+            | Self::ChangeSubscription { object, .. } => Some(*object),
             Self::AddMember { family, .. }
             | Self::RemoveMember { family, .. }
-            | Self::ReorderMember { family, .. } => *family,
-            Self::RemoveAnimation { animation } => *animation,
-            Self::RemoveNode { node } => *node,
+            | Self::ReorderMember { family, .. } => Some(*family),
+            Self::AddAnimation { .. } => None,
+            Self::RemoveAnimation { animation } => Some(*animation),
+            Self::RemoveNode { node } => Some(*node),
         }
     }
 
-    const fn key(&self) -> SemanticMutationKey {
+    const fn key(&self) -> Option<SemanticMutationKey> {
         match self {
-            Self::SetSignal { signal, .. } => SemanticMutationKey::Signal(*signal),
+            Self::SetSignal { signal, .. } => Some(SemanticMutationKey::Signal(*signal)),
             Self::SetProperty {
                 object, property, ..
-            } => SemanticMutationKey::ObjectProperty {
+            } => Some(SemanticMutationKey::ObjectProperty {
                 object: *object,
                 property: *property,
-            },
-            Self::ReplaceContent { object, .. } => SemanticMutationKey::ObjectContent(*object),
+            }),
+            Self::ReplaceContent { object, .. } => {
+                Some(SemanticMutationKey::ObjectContent(*object))
+            }
             Self::ChangeSubscription {
                 object, property, ..
-            } => SemanticMutationKey::Subscription {
+            } => Some(SemanticMutationKey::Subscription {
                 object: *object,
                 property: *property,
-            },
+            }),
             Self::AddMember { family, member } | Self::RemoveMember { family, member } => {
-                SemanticMutationKey::FamilyEdge {
+                Some(SemanticMutationKey::FamilyEdge {
                     family: *family,
                     member: *member,
-                }
+                })
             }
-            Self::ReorderMember { family, member, .. } => SemanticMutationKey::FamilyOrder {
+            Self::ReorderMember { family, member, .. } => Some(SemanticMutationKey::FamilyOrder {
                 family: *family,
                 member: *member,
-            },
-            Self::RemoveAnimation { animation } => SemanticMutationKey::NodeRemoval(*animation),
-            Self::RemoveNode { node } => SemanticMutationKey::NodeRemoval(*node),
+            }),
+            Self::AddAnimation { .. } => None,
+            Self::RemoveAnimation { animation } => {
+                Some(SemanticMutationKey::NodeRemoval(*animation))
+            }
+            Self::RemoveNode { node } => Some(SemanticMutationKey::NodeRemoval(*node)),
         }
     }
 }
@@ -163,6 +180,9 @@ pub enum SemanticMutationImpact {
         family: SemanticNodeId,
         member: SemanticNodeId,
         before: Option<SemanticNodeId>,
+    },
+    AnimationAdded {
+        animation: SemanticNodeId,
     },
     NodeRemoved {
         node: SemanticNodeId,
@@ -264,6 +284,17 @@ impl SemanticMutationTransaction {
             member,
             before,
         });
+        self
+    }
+
+    /// Add one authored animation declaration after complete transaction preflight.
+    ///
+    /// The declaration references existing scene-global semantic identities. The
+    /// newly allocated animation identity is reported by `AnimationAdded` in the
+    /// transaction result, rather than allocating semantic identity before commit.
+    pub fn add_animation(&mut self, state: SemanticAnimationState) -> &mut Self {
+        self.mutations
+            .push(SemanticMutation::AddAnimation { state });
         self
     }
 
@@ -385,6 +416,11 @@ impl SemanticMutationTransaction {
                         before,
                     });
                 }
+                SemanticMutation::AddAnimation { state } => {
+                    let animation = commit_add_animation(store, &state);
+                    written_slots.insert(animation);
+                    impacts.push(SemanticMutationImpact::AnimationAdded { animation });
+                }
                 SemanticMutation::RemoveAnimation { animation }
                 | SemanticMutation::RemoveNode { node: animation } => {
                     // An earlier explicit removal may have cascade-removed this
@@ -463,12 +499,15 @@ impl SemanticMutationTransaction {
             if !matches!(
                 mutation,
                 SemanticMutation::RemoveAnimation { .. } | SemanticMutation::RemoveNode { .. }
-            ) && removed_nodes.contains(&mutation.target())
-            {
-                return Err(SemanticMutationTransactionError::TargetRemoved {
-                    index,
-                    target: mutation.target(),
-                });
+            ) {
+                if let Some(target) = mutation.target() {
+                    if removed_nodes.contains(&target) {
+                        return Err(SemanticMutationTransactionError::TargetRemoved {
+                            index,
+                            target,
+                        });
+                    }
+                }
             }
             if let SemanticMutation::ChangeSubscription {
                 object,
@@ -528,47 +567,48 @@ impl SemanticMutationTransaction {
                 }
             }
 
-            let key = mutation.key();
-            if !targets.insert(key) {
-                return Err(match key {
-                    SemanticMutationKey::Signal(target) => {
-                        SemanticMutationTransactionError::DuplicateTarget { index, target }
-                    }
-                    SemanticMutationKey::ObjectProperty { object, property } => {
-                        SemanticMutationTransactionError::DuplicateProperty {
-                            index,
-                            object,
-                            property,
+            if let Some(key) = mutation.key() {
+                if !targets.insert(key) {
+                    return Err(match key {
+                        SemanticMutationKey::Signal(target) => {
+                            SemanticMutationTransactionError::DuplicateTarget { index, target }
                         }
-                    }
-                    SemanticMutationKey::ObjectContent(object) => {
-                        SemanticMutationTransactionError::DuplicateContent { index, object }
-                    }
-                    SemanticMutationKey::Subscription { object, property } => {
-                        SemanticMutationTransactionError::DuplicateSubscription {
-                            index,
-                            object,
-                            property,
+                        SemanticMutationKey::ObjectProperty { object, property } => {
+                            SemanticMutationTransactionError::DuplicateProperty {
+                                index,
+                                object,
+                                property,
+                            }
                         }
-                    }
-                    SemanticMutationKey::FamilyEdge { family, member } => {
-                        SemanticMutationTransactionError::DuplicateFamilyEdge {
-                            index,
-                            family,
-                            member,
+                        SemanticMutationKey::ObjectContent(object) => {
+                            SemanticMutationTransactionError::DuplicateContent { index, object }
                         }
-                    }
-                    SemanticMutationKey::FamilyOrder { family, member } => {
-                        SemanticMutationTransactionError::DuplicateFamilyOrder {
-                            index,
-                            family,
-                            member,
+                        SemanticMutationKey::Subscription { object, property } => {
+                            SemanticMutationTransactionError::DuplicateSubscription {
+                                index,
+                                object,
+                                property,
+                            }
                         }
-                    }
-                    SemanticMutationKey::NodeRemoval(node) => {
-                        SemanticMutationTransactionError::DuplicateNodeRemoval { index, node }
-                    }
-                });
+                        SemanticMutationKey::FamilyEdge { family, member } => {
+                            SemanticMutationTransactionError::DuplicateFamilyEdge {
+                                index,
+                                family,
+                                member,
+                            }
+                        }
+                        SemanticMutationKey::FamilyOrder { family, member } => {
+                            SemanticMutationTransactionError::DuplicateFamilyOrder {
+                                index,
+                                family,
+                                member,
+                            }
+                        }
+                        SemanticMutationKey::NodeRemoval(node) => {
+                            SemanticMutationTransactionError::DuplicateNodeRemoval { index, node }
+                        }
+                    });
+                }
             }
 
             match mutation {
@@ -703,6 +743,10 @@ impl SemanticMutationTransaction {
                                 error,
                             })?,
                     );
+                }
+                SemanticMutation::AddAnimation { state } => {
+                    preflight_add_animation(store, state, &removed_nodes, index)?;
+                    changed.push(true);
                 }
                 SemanticMutation::RemoveAnimation { .. } => {
                     changed.push(true);
@@ -900,6 +944,10 @@ pub enum SemanticMutationTransactionError {
         family: SemanticNodeId,
         node: SemanticNodeId,
     },
+    AnimationUsesRemovedNode {
+        index: usize,
+        node: SemanticNodeId,
+    },
     Signal {
         index: usize,
         error: SemanticSignalError,
@@ -922,6 +970,10 @@ pub enum SemanticMutationTransactionError {
         index: usize,
         error: SemanticSceneOperationError,
     },
+    AnimationTarget {
+        index: usize,
+        error: SemanticSceneOperationError,
+    },
     UnknownAnimation {
         index: usize,
         animation: SemanticNodeId,
@@ -929,6 +981,22 @@ pub enum SemanticMutationTransactionError {
     NotAnimation {
         index: usize,
         animation: SemanticNodeId,
+    },
+    EmptyAnimationComposition {
+        index: usize,
+    },
+    SameAnimationTargetAndTargetState {
+        index: usize,
+        node: SemanticNodeId,
+    },
+    InvalidAnimationRunTime {
+        index: usize,
+    },
+    InvalidAnimationLagRatio {
+        index: usize,
+    },
+    InvalidAnimationPathArc {
+        index: usize,
     },
     NonFinitePropertyValue {
         index: usize,
@@ -1071,6 +1139,12 @@ impl std::fmt::Display for SemanticMutationTransactionError {
                 node.slot(),
                 node.generation()
             ),
+            Self::AnimationUsesRemovedNode { index, node } => write!(
+                formatter,
+                "semantic transaction mutation {index} cannot add an animation referencing node {}:{} because that node is removed by the same transaction",
+                node.slot(),
+                node.generation()
+            ),
             Self::Signal { index, error } => {
                 write!(formatter, "semantic transaction mutation {index}: {error}")
             }
@@ -1094,6 +1168,10 @@ impl std::fmt::Display for SemanticMutationTransactionError {
             Self::Object { index, error } | Self::Family { index, error } => {
                 write!(formatter, "semantic transaction mutation {index}: {error}")
             }
+            Self::AnimationTarget { index, error } => write!(
+                formatter,
+                "semantic transaction mutation {index} cannot add animation: {error}"
+            ),
             Self::UnknownAnimation { index, animation } => write!(
                 formatter,
                 "semantic transaction mutation {index}: unknown semantic animation {}:{}",
@@ -1105,6 +1183,28 @@ impl std::fmt::Display for SemanticMutationTransactionError {
                 "semantic transaction mutation {index}: semantic node {}:{} is not an animation",
                 animation.slot(),
                 animation.generation()
+            ),
+            Self::EmptyAnimationComposition { index } => write!(
+                formatter,
+                "semantic transaction mutation {index} cannot add an empty animation composition"
+            ),
+            Self::SameAnimationTargetAndTargetState { index, node } => write!(
+                formatter,
+                "semantic transaction mutation {index} cannot add animation with identical target and target-state node {}:{}",
+                node.slot(),
+                node.generation()
+            ),
+            Self::InvalidAnimationRunTime { index } => write!(
+                formatter,
+                "semantic transaction mutation {index} cannot add animation with non-finite or non-positive run_time"
+            ),
+            Self::InvalidAnimationLagRatio { index } => write!(
+                formatter,
+                "semantic transaction mutation {index} cannot add animation with non-finite or negative lag_ratio"
+            ),
+            Self::InvalidAnimationPathArc { index } => write!(
+                formatter,
+                "semantic transaction mutation {index} cannot add animation with non-finite path_arc"
             ),
             Self::NonFinitePropertyValue {
                 index,
@@ -1169,6 +1269,9 @@ mod family_edge_tests;
 
 #[cfg(test)]
 mod reorder_member_tests;
+
+#[cfg(test)]
+mod add_animation_tests;
 
 #[cfg(test)]
 mod remove_animation_tests;

--- a/crates/noon-core/src/reactive/semantic_transaction/add_animation_tests.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction/add_animation_tests.rs
@@ -1,0 +1,317 @@
+use super::*;
+use crate::{
+    AnimationOptions, SemanticAnimationCompositionKind, SemanticAnimationIntent,
+    SemanticAnimationState, SemanticObjectState, StoredGeometry,
+};
+
+fn object(store: &mut SemanticStore, radius: f32) -> SemanticNodeId {
+    store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle { radius }))
+}
+
+fn transform(store: &mut SemanticStore, radius: f32) -> SemanticNodeId {
+    let target = object(store, radius);
+    let target_state = object(store, radius + 0.5);
+    store
+        .insert_semantic_transform_animation(target, target_state, AnimationOptions::new())
+        .unwrap()
+}
+
+fn transform_state(
+    target: SemanticNodeId,
+    target_state: SemanticNodeId,
+    options: AnimationOptions,
+) -> SemanticAnimationState {
+    SemanticAnimationState::new(
+        SemanticAnimationIntent::TransformTo {
+            target,
+            target_state,
+        },
+        options,
+    )
+}
+
+fn scalar_input(store: &SemanticStore, signal: SemanticNodeId) -> f64 {
+    let SemanticSignalSource::Input(SemanticSignalValue::Scalar(value)) =
+        store.semantic_signal_state(signal).unwrap().source()
+    else {
+        panic!("expected scalar input signal")
+    };
+    *value
+}
+
+#[test]
+fn add_animation_commits_one_authored_animation_and_reports_its_identity() {
+    let mut store = SemanticStore::new();
+    let target = object(&mut store, 1.0);
+    let target_state = object(&mut store, 2.0);
+    let state = transform_state(
+        target,
+        target_state,
+        AnimationOptions::new().run_time(1.5).lag_ratio(0.25),
+    );
+    let before_len = store.len();
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction.add_animation(state.clone());
+    let result = transaction.apply(&mut store).unwrap();
+
+    let [SemanticMutationImpact::AnimationAdded { animation }] = result.impacts() else {
+        panic!("expected one animation-added impact")
+    };
+    assert_eq!(store.semantic_animation_state(*animation).unwrap(), &state);
+    assert_eq!(store.len(), before_len + 1);
+    assert_eq!(store.last_mutation_stats().slots_written, 1);
+}
+
+#[test]
+fn add_animation_preserves_composition_order_and_unresolved_options() {
+    let mut store = SemanticStore::new();
+    let first = transform(&mut store, 1.0);
+    let second = transform(&mut store, 2.0);
+    let options = AnimationOptions::new().run_time(3.0).path_arc(0.75);
+    let state = SemanticAnimationState::new(
+        SemanticAnimationIntent::Composition {
+            kind: SemanticAnimationCompositionKind::Sequence,
+            children: vec![second, first],
+        },
+        options,
+    );
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction.add_animation(state.clone());
+    let result = transaction.apply(&mut store).unwrap();
+
+    let [SemanticMutationImpact::AnimationAdded { animation }] = result.impacts() else {
+        panic!("expected one animation-added impact")
+    };
+    assert_eq!(store.semantic_animation_state(*animation).unwrap(), &state);
+    assert_eq!(store.last_mutation_stats().slots_written, 1);
+}
+
+#[test]
+fn invalid_animation_target_rolls_back_earlier_mutation() {
+    let mut store = SemanticStore::new();
+    let signal = store.insert_semantic_input_signal(1.0_f64).unwrap();
+    let target = object(&mut store, 1.0);
+    let family = store.insert_family();
+    let before_len = store.len();
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .set_signal(signal, 2.0_f64)
+        .add_animation(transform_state(target, family, AnimationOptions::new()));
+
+    assert_eq!(
+        transaction.apply(&mut store),
+        Err(SemanticMutationTransactionError::AnimationTarget {
+            index: 1,
+            error: SemanticSceneOperationError::NotSemanticObject(family),
+        })
+    );
+    assert_eq!(scalar_input(&store, signal), 1.0);
+    assert_eq!(store.len(), before_len);
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+}
+
+#[test]
+fn stale_animation_reference_rolls_back_before_allocation() {
+    let mut store = SemanticStore::new();
+    let signal = store.insert_semantic_input_signal(1.0_f64).unwrap();
+    let target = object(&mut store, 1.0);
+    let stale = object(&mut store, 2.0);
+    store.remove_node(stale).unwrap();
+    let replacement = object(&mut store, 3.0);
+    assert_eq!(stale.slot(), replacement.slot());
+    assert_ne!(stale.generation(), replacement.generation());
+    let before_len = store.len();
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .set_signal(signal, 2.0_f64)
+        .add_animation(transform_state(target, stale, AnimationOptions::new()));
+
+    assert_eq!(
+        transaction.apply(&mut store),
+        Err(SemanticMutationTransactionError::AnimationTarget {
+            index: 1,
+            error: SemanticSceneOperationError::UnknownNode(stale),
+        })
+    );
+    assert_eq!(scalar_input(&store, signal), 1.0);
+    assert_eq!(store.len(), before_len);
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+}
+
+#[test]
+fn malformed_animation_options_use_equality_safe_transaction_errors() {
+    let mut store = SemanticStore::new();
+    let target = object(&mut store, 1.0);
+    let target_state = object(&mut store, 2.0);
+    let before_len = store.len();
+
+    let mut invalid_run_time = SemanticMutationTransaction::new();
+    invalid_run_time.add_animation(transform_state(
+        target,
+        target_state,
+        AnimationOptions::new().run_time(0.0),
+    ));
+    assert_eq!(
+        invalid_run_time.apply(&mut store),
+        Err(SemanticMutationTransactionError::InvalidAnimationRunTime { index: 0 })
+    );
+
+    let mut invalid_lag_ratio = SemanticMutationTransaction::new();
+    invalid_lag_ratio.add_animation(transform_state(
+        target,
+        target_state,
+        AnimationOptions::new().lag_ratio(-0.1),
+    ));
+    assert_eq!(
+        invalid_lag_ratio.apply(&mut store),
+        Err(SemanticMutationTransactionError::InvalidAnimationLagRatio { index: 0 })
+    );
+
+    let mut invalid_path_arc = SemanticMutationTransaction::new();
+    invalid_path_arc.add_animation(transform_state(
+        target,
+        target_state,
+        AnimationOptions::new().path_arc(f64::NAN),
+    ));
+    assert_eq!(
+        invalid_path_arc.apply(&mut store),
+        Err(SemanticMutationTransactionError::InvalidAnimationPathArc { index: 0 })
+    );
+
+    assert_eq!(store.len(), before_len);
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+}
+
+#[test]
+fn animation_cannot_reference_a_node_removed_by_the_same_transaction() {
+    let mut store = SemanticStore::new();
+    let target = object(&mut store, 1.0);
+    let target_state = object(&mut store, 2.0);
+    let before_len = store.len();
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .add_animation(transform_state(
+            target,
+            target_state,
+            AnimationOptions::new(),
+        ))
+        .remove_node(target_state);
+
+    assert_eq!(
+        transaction.apply(&mut store),
+        Err(SemanticMutationTransactionError::AnimationUsesRemovedNode {
+            index: 0,
+            node: target_state,
+        })
+    );
+    assert_eq!(store.len(), before_len);
+    assert!(store.node(target_state).is_some());
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+}
+
+#[test]
+fn structural_removal_then_add_animation_is_rejected_before_commit() {
+    let mut store = SemanticStore::new();
+    let target = object(&mut store, 1.0);
+    let target_state = object(&mut store, 2.0);
+    let unrelated = object(&mut store, 3.0);
+    let before_len = store.len();
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .remove_node(unrelated)
+        .add_animation(transform_state(
+            target,
+            target_state,
+            AnimationOptions::new(),
+        ));
+
+    assert_eq!(
+        transaction.apply(&mut store),
+        Err(SemanticMutationTransactionError::MutationAfterRemove { index: 1 })
+    );
+    assert_eq!(store.len(), before_len);
+    assert!(store.node(unrelated).is_some());
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+}
+
+#[test]
+fn repeated_identical_additions_create_distinct_semantic_identities() {
+    let mut store = SemanticStore::new();
+    let target = object(&mut store, 1.0);
+    let target_state = object(&mut store, 2.0);
+    let state = transform_state(target, target_state, AnimationOptions::new());
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .add_animation(state.clone())
+        .add_animation(state);
+    let result = transaction.apply(&mut store).unwrap();
+
+    let [SemanticMutationImpact::AnimationAdded { animation: first }, SemanticMutationImpact::AnimationAdded { animation: second }] =
+        result.impacts()
+    else {
+        panic!("expected two animation-added impacts")
+    };
+    assert_ne!(first, second);
+    assert_eq!(store.last_mutation_stats().slots_written, 2);
+}
+
+#[test]
+fn add_animation_can_precede_an_unrelated_terminal_removal() {
+    let mut store = SemanticStore::new();
+    let target = object(&mut store, 1.0);
+    let target_state = object(&mut store, 2.0);
+    let unrelated = object(&mut store, 3.0);
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .add_animation(transform_state(
+            target,
+            target_state,
+            AnimationOptions::new(),
+        ))
+        .remove_node(unrelated);
+    let result = transaction.apply(&mut store).unwrap();
+
+    assert_eq!(result.impacts().len(), 2);
+    assert!(matches!(
+        result.impacts()[0],
+        SemanticMutationImpact::AnimationAdded { .. }
+    ));
+    assert_eq!(
+        result.impacts()[1],
+        SemanticMutationImpact::NodeRemoved { node: unrelated }
+    );
+    assert_eq!(store.last_mutation_stats().slots_written, 2);
+}
+
+#[test]
+fn add_animation_is_local_with_large_unrelated_scene() {
+    let mut store = SemanticStore::new();
+    for index in 0..10_000 {
+        object(&mut store, index as f32 + 1.0);
+    }
+    let target = object(&mut store, 0.25);
+    let target_state = object(&mut store, 0.5);
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction.add_animation(transform_state(
+        target,
+        target_state,
+        AnimationOptions::new(),
+    ));
+    let result = transaction.apply(&mut store).unwrap();
+
+    assert_eq!(result.impacts().len(), 1);
+    assert!(matches!(
+        result.impacts()[0],
+        SemanticMutationImpact::AnimationAdded { .. }
+    ));
+    assert_eq!(store.last_mutation_stats().slots_written, 1);
+}

--- a/crates/noon-core/src/reactive/semantic_transaction/animation_addition.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction/animation_addition.rs
@@ -1,0 +1,132 @@
+use std::collections::HashSet;
+
+use crate::{
+    SemanticAnimationCompositionKind, SemanticAnimationError, SemanticAnimationIntent,
+    SemanticAnimationState,
+};
+
+use super::{SemanticMutationTransactionError, SemanticNodeId, SemanticStore};
+
+pub(super) fn preflight_add_animation(
+    store: &SemanticStore,
+    state: &SemanticAnimationState,
+    removed_nodes: &HashSet<SemanticNodeId>,
+    index: usize,
+) -> Result<(), SemanticMutationTransactionError> {
+    let options = state.options();
+    if options
+        .run_time
+        .is_some_and(|run_time| !run_time.is_finite() || run_time <= 0.0)
+    {
+        return Err(SemanticMutationTransactionError::InvalidAnimationRunTime { index });
+    }
+    if options
+        .lag_ratio
+        .is_some_and(|lag_ratio| !lag_ratio.is_finite() || lag_ratio < 0.0)
+    {
+        return Err(SemanticMutationTransactionError::InvalidAnimationLagRatio { index });
+    }
+    if options
+        .path_arc
+        .is_some_and(|path_arc| !path_arc.is_finite())
+    {
+        return Err(SemanticMutationTransactionError::InvalidAnimationPathArc { index });
+    }
+
+    match state.intent() {
+        SemanticAnimationIntent::TransformTo {
+            target,
+            target_state,
+        } => {
+            reject_removed_reference(removed_nodes, index, *target)?;
+            reject_removed_reference(removed_nodes, index, *target_state)?;
+            store
+                .semantic_object_state_checked(*target)
+                .map_err(|error| SemanticMutationTransactionError::AnimationTarget {
+                    index,
+                    error,
+                })?;
+            store
+                .semantic_object_state_checked(*target_state)
+                .map_err(|error| SemanticMutationTransactionError::AnimationTarget {
+                    index,
+                    error,
+                })?;
+            if target == target_state {
+                return Err(
+                    SemanticMutationTransactionError::SameAnimationTargetAndTargetState {
+                        index,
+                        node: *target,
+                    },
+                );
+            }
+        }
+        SemanticAnimationIntent::Composition { children, .. } => {
+            if children.is_empty() {
+                return Err(SemanticMutationTransactionError::EmptyAnimationComposition { index });
+            }
+            for &child in children {
+                reject_removed_reference(removed_nodes, index, child)?;
+                store
+                    .semantic_animation_state(child)
+                    .map_err(|error| animation_lookup_error(index, error))?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub(super) fn commit_add_animation(
+    store: &mut SemanticStore,
+    state: &SemanticAnimationState,
+) -> SemanticNodeId {
+    let options = state.options();
+    match state.intent() {
+        SemanticAnimationIntent::TransformTo {
+            target,
+            target_state,
+        } => store
+            .insert_semantic_transform_animation(*target, *target_state, options)
+            .expect("preflighted semantic animation insertion must remain valid while transaction owns the store"),
+        SemanticAnimationIntent::Composition { kind, children } => match kind {
+            SemanticAnimationCompositionKind::Parallel => store
+                .insert_semantic_parallel_animation(children, options)
+                .expect("preflighted semantic animation insertion must remain valid while transaction owns the store"),
+            SemanticAnimationCompositionKind::Sequence => store
+                .insert_semantic_sequence_animation(children, options)
+                .expect("preflighted semantic animation insertion must remain valid while transaction owns the store"),
+        },
+    }
+}
+
+fn reject_removed_reference(
+    removed_nodes: &HashSet<SemanticNodeId>,
+    index: usize,
+    node: SemanticNodeId,
+) -> Result<(), SemanticMutationTransactionError> {
+    if removed_nodes.contains(&node) {
+        return Err(SemanticMutationTransactionError::AnimationUsesRemovedNode { index, node });
+    }
+    Ok(())
+}
+
+fn animation_lookup_error(
+    index: usize,
+    error: SemanticAnimationError,
+) -> SemanticMutationTransactionError {
+    match error {
+        SemanticAnimationError::UnknownAnimation(animation) => {
+            SemanticMutationTransactionError::UnknownAnimation { index, animation }
+        }
+        SemanticAnimationError::NotAnimation(animation) => {
+            SemanticMutationTransactionError::NotAnimation { index, animation }
+        }
+        SemanticAnimationError::EmptyComposition
+        | SemanticAnimationError::Target(_)
+        | SemanticAnimationError::Options(_)
+        | SemanticAnimationError::SameTargetAndTargetState(_) => {
+            unreachable!("semantic_animation_state only validates animation identity")
+        }
+    }
+}


### PR DESCRIPTION
## Roadmap ownership

- Owning case: #957 / A1.5 — `AddAnimation` in the one Semantic Scene mutation transaction
- Pairs with merged #1042 `RemoveAnimation`
- Builds on #1034 reverse-reference cleanup and #1040 reorder-preflight locality
- Parent roadmap: #953
- Validation/locality: #961 / A6.4–A6.5

## What changed

Extend `SemanticMutationTransaction` with authored animation creation:

- add `SemanticMutation::AddAnimation { state }` and `add_animation(...)`;
- keep creation outside existing-target duplicate keys because the semantic `NodeId` is allocated only after complete preflight;
- report the allocated identity through `SemanticMutationImpact::AnimationAdded { animation }`;
- validate transform targets/target-state identities, composition children/order, unresolved authored options, and generation safety before commit;
- reject an animation if any referenced node is removed directly or transitively by the same transaction;
- keep structural removals terminal, while allowing creation before an unrelated terminal removal;
- preserve equality-safe `SemanticMutationTransactionError` by mapping invalid floating-point options to value-free variants;
- preserve #1040's local reorder preflight behavior.

## Atomicity / identity

`AddAnimation` consumes the existing authoritative `SemanticAnimationState`; it does not add another animation model or allocator. The new semantic identity is allocated only during commit, after the entire transaction preflights successfully. Identical additions are therefore valid and produce distinct scene-global generational identities.

This slice intentionally references existing scene-global semantic identities. It does not invent a provisional semantic-ID space solely for creation. The remaining A1.5 `AddNode` case can introduce transaction-local creation references if atomic graphs of mutually/newly-created nodes require them, without changing stored animation identity or lowering authority.

## Locality

Preflight touches only referenced targets/children plus the already-computed removal closure. Commit inserts one semantic animation slot and its bounded reverse-reference metadata. A focused 10k-unrelated-object regression verifies one semantic slot written.

## Tests

Focused coverage includes:

- transform animation insertion and returned identity impact;
- composition order/options preservation;
- invalid and stale target rollback after an earlier mutation;
- equality-safe invalid run-time / lag-ratio / path-arc failures;
- same-transaction referenced-node removal rejection;
- structural-removal terminal ordering;
- repeated identical additions yielding distinct identities;
- add-before-unrelated-remove atomic commit;
- 10k unrelated-scene locality.

GitHub CI is the executable compile/test/architecture gate. The branch will be squashed/restacked onto the latest `master` after the first exact-head pass.

Refs #953 #957 #961 #1034 #1040 #1042.