### PR TITLE
Document noon-runtime ownership boundary

### DIFF
--- a/crates/noon-runtime/Cargo.toml
+++ b/crates/noon-runtime/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT"
 description = "Deterministic renderer-free runtime for compiled Noon scenes"
+readme = "README.md"
 
 [dependencies]
 noon-core = { path = "../noon-core" }

--- a/crates/noon-runtime/README.md
+++ b/crates/noon-runtime/README.md
@@ -1,0 +1,19 @@
+# noon-runtime
+
+`noon-runtime` is Noon's deterministic, renderer-independent execution layer.
+
+## Ownership
+
+This crate owns coherent effective state at a published `FrameEpoch`: active timeline, reactive, native-input, and host execution; dirty and spatial state; and renderer-facing change sets. Its effective values are derived from authored Semantic Scene state and execution data; the runtime does not own authored truth.
+
+It also owns deterministic time advancement, execution-slot identity, structural mutation application, retained/family runtime state, and runtime-local diagnostics. Its frame/change-set output is consumed by `noon-render-wgpu` and browser integration without coupling runtime execution to WGPU, browser APIs, or a platform event loop.
+
+## Boundaries
+
+This crate does not own Semantic Scene authoring or language APIs, semantic analysis/lowering, GPU resources or presentation, native/window/browser lifecycle, or serialization as an in-process engine boundary.
+
+`ExecutionSession` composes existing lowering and runtime state; it is not a fifth authority. Host-facing settle and wake orchestration is owned by #1085, outside this crate-local boundary.
+
+The engine path remains `Semantic Scene -> Execution Plan -> Runtime -> Renderer`. Migration-era compiled-scene and patch types at some seams do not create another authored-scene authority.
+
+This boundary follows `docs/architecture.md` and the Phase A5 normalization rules in #960.


### PR DESCRIPTION
## Summary

Refresh `noon-runtime` package documentation for the current effective-state contract and add its README metadata.

The README records that runtime owns coherent effective state at `FrameEpoch`, active timeline/reactive/native-input/host execution, dirty/spatial state, and renderer-facing change sets. It explicitly excludes authored Semantic Scene truth and keeps `ExecutionSession` composition and host settle/wake orchestration from becoming a fifth authority.

## Validation

- `git diff --check`

The repository's integrated Rust gate is pending in the coordinating worktree.

## Architecture

Runtime consumes derived execution data and publishes renderer-facing state. #1085 owns the host-facing settle/wake surface.


Independent review passed. Local `cargo check --workspace --all-targets --all-features`, `cargo metadata --no-deps`, and `git diff --check` passed in the cleanup worktree. Documentation/package metadata only; remaining publication/resource-retirement work is explicitly identified as target behavior.
