### PR TITLE
Pin tinyvec before broken 1.13.0

### DIFF
--- a/crates/noon-typst/Cargo.toml
+++ b/crates/noon-typst/Cargo.toml
@@ -9,6 +9,9 @@ description = "Typst text and math layout backend for Noon"
 noon-core = { path = "../noon-core" }
 typst-as-lib = { version = "=0.16.0", default-features = false }
 typst-assets = { version = "=0.15.1", features = ["fonts"] }
+# Keep Typst's shared font/normalization dependency on the last known-good release.
+# tinyvec 1.13.0 fails to compile its alloc-backed TinyVec path under this workspace.
+tinyvec = { version = "=1.12.0", default-features = false }
 # Direct normalization consumes Typst's paged frame layout instead of retained SVG.
 typst-layout = "=0.15.1"
 typst-library = "=0.15.1"


### PR DESCRIPTION
## Problem

The lockfile-free workspace now resolves newly released `tinyvec 1.13.0` on a fresh CI checkout. Rust tests, Clippy, and the browser/WASM build all fail inside `tinyvec` before Noon code is compiled:

`TinyVec::Heap(vec![...])` fails because the `vec!` macro is not in scope for the alloc-backed path selected by the current transitive feature set.

A dependency-tree diagnostic shows this `tinyvec` instance is reached through the Typst integration (`fontdb` and `unicode-normalization` -> `typst-library`), not through the semantic transaction work that first exposed the fresh resolution.

## Fix

Add an exact `tinyvec = 1.12.0` compatibility constraint in `noon-typst` while keeping `default-features = false`.

This constrains the shared Typst dependency to the last known-good release without adding a workspace lockfile, changing global dependency policy, or changing Noon runtime/source behavior. Transitive Typst consumers still union the features they require.

The pin is intentionally narrow and can be removed once an upstream fixed release is available.

This restores the repository baseline and unblocks unrelated PRs such as #1046.
