### PR TITLE
Add atomic semantic scene-node creation

### DIFF
--- a/crates/noon-core/src/reactive/semantic_transaction.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction.rs
@@ -14,13 +14,18 @@ use animation_addition::{commit_add_animation, preflight_add_animation};
 mod family_edges;
 use family_edges::FamilyEdgePreflight;
 
+mod node_addition;
+pub use node_addition::SemanticNodeCreation;
+use node_addition::{commit_add_node, preflight_add_node};
+
 /// One mutation in the authoritative Semantic Scene transaction vocabulary.
 ///
-/// Signal values, object properties, authored content, family membership/order,
-/// reactive subscriptions, animation declarations, and structural deletion share
-/// the same transaction so frontends, editors, and host integrations cannot invent
-/// subsystem-specific patch paths. Dependency-expression rewiring remains authored
-/// declaration topology rather than being conflated with a value update.
+/// Signal values, object properties, authored content, scene-node allocation,
+/// family membership/order, reactive subscriptions, animation declarations, and
+/// structural deletion share the same transaction so frontends, editors, and host
+/// integrations cannot invent subsystem-specific patch paths. Dependency-expression
+/// rewiring remains authored declaration topology rather than being conflated with a
+/// value update.
 #[derive(Clone, Debug, PartialEq)]
 pub enum SemanticMutation {
     SetSignal {
@@ -54,6 +59,9 @@ pub enum SemanticMutation {
         member: SemanticNodeId,
         before: Option<SemanticNodeId>,
     },
+    AddNode {
+        creation: SemanticNodeCreation,
+    },
     AddAnimation {
         state: SemanticAnimationState,
     },
@@ -70,7 +78,7 @@ impl SemanticMutation {
     ///
     /// Allocation mutations do not have an identity until commit and therefore
     /// return `None`. This keeps creation out of the existing-target conflict key
-    /// space and leaves room for `AddNode` to use the same allocation semantics.
+    /// space without reserving or manufacturing semantic identity before preflight.
     pub const fn target(&self) -> Option<SemanticNodeId> {
         match self {
             Self::SetSignal { signal, .. } => Some(*signal),
@@ -80,7 +88,7 @@ impl SemanticMutation {
             Self::AddMember { family, .. }
             | Self::RemoveMember { family, .. }
             | Self::ReorderMember { family, .. } => Some(*family),
-            Self::AddAnimation { .. } => None,
+            Self::AddNode { .. } | Self::AddAnimation { .. } => None,
             Self::RemoveAnimation { animation } => Some(*animation),
             Self::RemoveNode { node } => Some(*node),
         }
@@ -114,7 +122,7 @@ impl SemanticMutation {
                 family: *family,
                 member: *member,
             }),
-            Self::AddAnimation { .. } => None,
+            Self::AddNode { .. } | Self::AddAnimation { .. } => None,
             Self::RemoveAnimation { animation } => {
                 Some(SemanticMutationKey::NodeRemoval(*animation))
             }
@@ -180,6 +188,9 @@ pub enum SemanticMutationImpact {
         family: SemanticNodeId,
         member: SemanticNodeId,
         before: Option<SemanticNodeId>,
+    },
+    NodeAdded {
+        node: SemanticNodeId,
     },
     AnimationAdded {
         animation: SemanticNodeId,
@@ -287,6 +298,20 @@ impl SemanticMutationTransaction {
         self
     }
 
+    /// Allocate one new detached semantic scene node after complete transaction
+    /// preflight.
+    ///
+    /// Object/family creation uses the same scene-global generational allocator as
+    /// all other semantic entities. The real identity is reported by `NodeAdded`;
+    /// no provisional semantic ID is reserved before commit. Optional source
+    /// identity is assigned atomically after terminal removals, allowing hot-reload
+    /// replacement to transfer one stable source key from an old node to its new
+    /// identity without creating a second identity model.
+    pub fn add_node(&mut self, creation: SemanticNodeCreation) -> &mut Self {
+        self.mutations.push(SemanticMutation::AddNode { creation });
+        self
+    }
+
     /// Add one authored animation declaration after complete transaction preflight.
     ///
     /// The declaration references existing scene-global semantic identities. The
@@ -343,6 +368,7 @@ impl SemanticMutationTransaction {
 
         let mut impacts = Vec::with_capacity(self.mutations.len());
         let mut written_slots = HashSet::with_capacity(self.mutations.len());
+        let mut pending_source_assignments = Vec::new();
         for (mutation, changed) in self.mutations.into_iter().zip(preflight) {
             if !changed {
                 continue;
@@ -416,6 +442,14 @@ impl SemanticMutationTransaction {
                         before,
                     });
                 }
+                SemanticMutation::AddNode { creation } => {
+                    let (node, source_identity) = commit_add_node(store, creation);
+                    written_slots.insert(node);
+                    if let Some(source_identity) = source_identity {
+                        pending_source_assignments.push((node, source_identity));
+                    }
+                    impacts.push(SemanticMutationImpact::NodeAdded { node });
+                }
                 SemanticMutation::AddAnimation { state } => {
                     let animation = commit_add_animation(store, &state);
                     written_slots.insert(animation);
@@ -449,6 +483,12 @@ impl SemanticMutationTransaction {
                     }
                 }
             }
+        }
+
+        for (node, source_identity) in pending_source_assignments {
+            store
+                .set_source_identity(node, Some(source_identity))
+                .expect("preflighted source identity must be available after terminal removals");
         }
         store.set_last_mutation_writes(written_slots.len());
 
@@ -494,6 +534,7 @@ impl SemanticMutationTransaction {
         let mut targets = HashSet::with_capacity(self.mutations.len());
         let mut changed = Vec::with_capacity(self.mutations.len());
         let mut family_edges = FamilyEdgePreflight::default();
+        let mut pending_sources = HashSet::new();
 
         for (index, mutation) in self.mutations.iter().enumerate() {
             if !matches!(
@@ -744,6 +785,16 @@ impl SemanticMutationTransaction {
                             })?,
                     );
                 }
+                SemanticMutation::AddNode { creation } => {
+                    preflight_add_node(
+                        store,
+                        creation,
+                        &removed_nodes,
+                        &mut pending_sources,
+                        index,
+                    )?;
+                    changed.push(true);
+                }
                 SemanticMutation::AddAnimation { state } => {
                     preflight_add_animation(store, state, &removed_nodes, index)?;
                     changed.push(true);
@@ -944,9 +995,22 @@ pub enum SemanticMutationTransactionError {
         family: SemanticNodeId,
         node: SemanticNodeId,
     },
+    NodeCreationUsesRemovedNode {
+        index: usize,
+        node: SemanticNodeId,
+    },
     AnimationUsesRemovedNode {
         index: usize,
         node: SemanticNodeId,
+    },
+    InvalidNodeObjectState {
+        index: usize,
+    },
+    NodeCreationBindingTypeMismatch {
+        index: usize,
+        signal: SemanticNodeId,
+        expected: SemanticSignalValueKind,
+        actual: SemanticSignalValueKind,
     },
     Signal {
         index: usize,
@@ -1139,11 +1203,32 @@ impl std::fmt::Display for SemanticMutationTransactionError {
                 node.slot(),
                 node.generation()
             ),
+            Self::NodeCreationUsesRemovedNode { index, node } => write!(
+                formatter,
+                "semantic transaction mutation {index} cannot add a node referencing semantic node {}:{} because that node is removed by the same transaction",
+                node.slot(),
+                node.generation()
+            ),
             Self::AnimationUsesRemovedNode { index, node } => write!(
                 formatter,
                 "semantic transaction mutation {index} cannot add an animation referencing node {}:{} because that node is removed by the same transaction",
                 node.slot(),
                 node.generation()
+            ),
+            Self::InvalidNodeObjectState { index } => write!(
+                formatter,
+                "semantic transaction mutation {index} cannot add an object with non-finite authored transform/style values"
+            ),
+            Self::NodeCreationBindingTypeMismatch {
+                index,
+                signal,
+                expected,
+                actual,
+            } => write!(
+                formatter,
+                "semantic transaction mutation {index} cannot add an object binding {actual} signal {}:{} to a property requiring {expected}",
+                signal.slot(),
+                signal.generation()
             ),
             Self::Signal { index, error } => {
                 write!(formatter, "semantic transaction mutation {index}: {error}")
@@ -1269,6 +1354,9 @@ mod family_edge_tests;
 
 #[cfg(test)]
 mod reorder_member_tests;
+
+#[cfg(test)]
+mod add_node_tests;
 
 #[cfg(test)]
 mod add_animation_tests;

--- a/crates/noon-core/src/reactive/semantic_transaction/add_node_tests.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction/add_node_tests.rs
@@ -1,0 +1,227 @@
+use super::*;
+use crate::{SemanticNodeResidency, SourceIdentity, StoredGeometry};
+
+fn object_state(radius: f32) -> SemanticObjectState {
+    SemanticObjectState::new(StoredGeometry::Circle { radius })
+}
+
+fn object(store: &mut SemanticStore, radius: f32) -> SemanticNodeId {
+    store.insert_semantic_object(object_state(radius))
+}
+
+fn scalar_input(store: &SemanticStore, signal: SemanticNodeId) -> f64 {
+    let SemanticSignalSource::Input(SemanticSignalValue::Scalar(value)) =
+        store.semantic_signal_state(signal).unwrap().source()
+    else {
+        panic!("expected scalar input signal")
+    };
+    *value
+}
+
+#[test]
+fn add_node_allocates_detached_object_and_family_and_reports_real_identities() {
+    let mut store = SemanticStore::new();
+    let root_count = store.scene_root_count();
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .add_node(SemanticNodeCreation::object(object_state(1.0)))
+        .add_node(SemanticNodeCreation::family());
+    let result = transaction.apply(&mut store).unwrap();
+
+    let [SemanticMutationImpact::NodeAdded { node: object }, SemanticMutationImpact::NodeAdded { node: family }] =
+        result.impacts()
+    else {
+        panic!("expected two node-added impacts")
+    };
+    assert!(store.semantic_object_state_checked(*object).is_ok());
+    assert!(matches!(
+        store.node(*family).unwrap().kind(),
+        SemanticNodeKind::Family
+    ));
+    assert_eq!(
+        store.node(*object).unwrap().residency(),
+        SemanticNodeResidency::Detached
+    );
+    assert_eq!(
+        store.node(*family).unwrap().residency(),
+        SemanticNodeResidency::Detached
+    );
+    assert_eq!(store.scene_root_count(), root_count);
+    assert_eq!(store.last_mutation_stats().slots_written, 2);
+}
+
+#[test]
+fn repeated_identical_add_node_mutations_allocate_distinct_identities() {
+    let mut store = SemanticStore::new();
+    let state = object_state(1.0);
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .add_node(SemanticNodeCreation::object(state.clone()))
+        .add_node(SemanticNodeCreation::object(state));
+    let result = transaction.apply(&mut store).unwrap();
+
+    let [SemanticMutationImpact::NodeAdded { node: first }, SemanticMutationImpact::NodeAdded { node: second }] =
+        result.impacts()
+    else {
+        panic!("expected two node-added impacts")
+    };
+    assert_ne!(first, second);
+    assert_eq!(store.last_mutation_stats().slots_written, 2);
+}
+
+#[test]
+fn invalid_object_state_rolls_back_earlier_mutation_before_allocation() {
+    let mut store = SemanticStore::new();
+    let signal = store.insert_semantic_input_signal(1.0_f64).unwrap();
+    let before_len = store.len();
+    let mut invalid = object_state(1.0);
+    invalid.transform.rotation_z = f64::NAN;
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .set_signal(signal, 2.0_f64)
+        .add_node(SemanticNodeCreation::object(invalid));
+
+    assert_eq!(
+        transaction.apply(&mut store),
+        Err(SemanticMutationTransactionError::InvalidNodeObjectState { index: 1 })
+    );
+    assert_eq!(scalar_input(&store, signal), 1.0);
+    assert_eq!(store.len(), before_len);
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+}
+
+#[test]
+fn cloned_object_with_stale_binding_is_rejected_before_allocation() {
+    let mut store = SemanticStore::new();
+    let signal = store.insert_semantic_input_signal(0.5_f64).unwrap();
+    let source = object(&mut store, 1.0);
+    store
+        .bind_semantic_signal(signal, source, SemanticObjectProperty::ObjectOpacity)
+        .unwrap();
+    let cloned = store.semantic_object_state_checked(source).unwrap().clone();
+    store.remove_node(signal).unwrap();
+    let before_len = store.len();
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction.add_node(SemanticNodeCreation::object(cloned));
+
+    assert_eq!(
+        transaction.apply(&mut store),
+        Err(SemanticMutationTransactionError::Signal {
+            index: 0,
+            error: SemanticSignalError::UnknownSignal(signal),
+        })
+    );
+    assert_eq!(store.len(), before_len);
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+}
+
+#[test]
+fn new_object_cannot_bind_signal_removed_by_same_transaction() {
+    let mut store = SemanticStore::new();
+    let signal = store.insert_semantic_input_signal(0.5_f64).unwrap();
+    let source = object(&mut store, 1.0);
+    store
+        .bind_semantic_signal(signal, source, SemanticObjectProperty::ObjectOpacity)
+        .unwrap();
+    let cloned = store.semantic_object_state_checked(source).unwrap().clone();
+    let before_len = store.len();
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .add_node(SemanticNodeCreation::object(cloned))
+        .remove_node(signal);
+
+    assert_eq!(
+        transaction.apply(&mut store),
+        Err(
+            SemanticMutationTransactionError::NodeCreationUsesRemovedNode {
+                index: 0,
+                node: signal,
+            }
+        )
+    );
+    assert_eq!(store.len(), before_len);
+    assert!(store.node(signal).is_some());
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+}
+
+#[test]
+fn duplicate_pending_source_identity_rolls_back_every_creation() {
+    let mut store = SemanticStore::new();
+    let source = SourceIdentity::ExplicitKey("same".to_owned());
+    let before_len = store.len();
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .add_node(
+            SemanticNodeCreation::object(object_state(1.0)).with_source_identity(source.clone()),
+        )
+        .add_node(SemanticNodeCreation::family().with_source_identity(source.clone()));
+
+    assert_eq!(
+        transaction.apply(&mut store),
+        Err(SemanticMutationTransactionError::Node {
+            index: 1,
+            error: SemanticStoreError::DuplicateSourceIdentity(source),
+        })
+    );
+    assert_eq!(store.len(), before_len);
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+}
+
+#[test]
+fn source_identity_can_move_atomically_from_removed_node_to_replacement() {
+    let mut store = SemanticStore::new();
+    let source = SourceIdentity::ExplicitKey("stable-source".to_owned());
+    let old = object(&mut store, 1.0);
+    store
+        .set_source_identity(old, Some(source.clone()))
+        .unwrap();
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .add_node(
+            SemanticNodeCreation::object(object_state(2.0)).with_source_identity(source.clone()),
+        )
+        .remove_node(old);
+    let result = transaction.apply(&mut store).unwrap();
+
+    let [SemanticMutationImpact::NodeAdded { node: replacement }, SemanticMutationImpact::NodeRemoved { node }] =
+        result.impacts()
+    else {
+        panic!("expected replacement creation followed by old-node removal")
+    };
+    assert_eq!(*node, old);
+    assert!(store.node(old).is_none());
+    assert_eq!(store.node_for_source(&source), Some(*replacement));
+    assert_eq!(
+        store.node(*replacement).unwrap().residency(),
+        SemanticNodeResidency::Detached
+    );
+    assert_eq!(store.last_mutation_stats().slots_written, 2);
+}
+
+#[test]
+fn add_node_is_local_with_large_unrelated_scene() {
+    let mut store = SemanticStore::new();
+    for index in 0..10_000 {
+        object(&mut store, index as f32 + 1.0);
+    }
+    let before_len = store.len();
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction.add_node(SemanticNodeCreation::object(object_state(0.25)));
+    let result = transaction.apply(&mut store).unwrap();
+
+    assert_eq!(result.impacts().len(), 1);
+    assert!(matches!(
+        result.impacts()[0],
+        SemanticMutationImpact::NodeAdded { .. }
+    ));
+    assert_eq!(store.len(), before_len + 1);
+    assert_eq!(store.last_mutation_stats().slots_written, 1);
+}

--- a/crates/noon-core/src/reactive/semantic_transaction/node_addition.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction/node_addition.rs
@@ -1,0 +1,144 @@
+use std::collections::HashSet;
+
+use crate::{
+    SemanticNodeId, SemanticObjectState, SemanticStore, SemanticStoreError, SourceIdentity,
+};
+
+use super::SemanticMutationTransactionError;
+
+/// Authored payload for allocating one new scene node through the semantic
+/// mutation transaction.
+///
+/// Nodes created here start detached. Animation declarations keep their dedicated
+/// `AddAnimation` mutation, while signal declarations keep the typed signal
+/// authoring APIs; this creation payload owns only scene object/family identity.
+#[derive(Clone, Debug, PartialEq)]
+pub enum SemanticNodeCreation {
+    Object {
+        state: Box<SemanticObjectState>,
+        source_identity: Option<SourceIdentity>,
+    },
+    Family {
+        source_identity: Option<SourceIdentity>,
+    },
+}
+
+impl SemanticNodeCreation {
+    pub fn object(state: SemanticObjectState) -> Self {
+        Self::Object {
+            state: Box::new(state),
+            source_identity: None,
+        }
+    }
+
+    pub const fn family() -> Self {
+        Self::Family {
+            source_identity: None,
+        }
+    }
+
+    pub fn with_source_identity(mut self, source_identity: SourceIdentity) -> Self {
+        match &mut self {
+            Self::Object {
+                source_identity: source,
+                ..
+            }
+            | Self::Family {
+                source_identity: source,
+            } => *source = Some(source_identity),
+        }
+        self
+    }
+
+    pub const fn source_identity(&self) -> Option<&SourceIdentity> {
+        match self {
+            Self::Object {
+                source_identity, ..
+            }
+            | Self::Family { source_identity } => source_identity.as_ref(),
+        }
+    }
+}
+
+pub(super) fn preflight_add_node(
+    store: &SemanticStore,
+    creation: &SemanticNodeCreation,
+    removed_nodes: &HashSet<SemanticNodeId>,
+    pending_sources: &mut HashSet<SourceIdentity>,
+    index: usize,
+) -> Result<(), SemanticMutationTransactionError> {
+    if let Some(source) = creation.source_identity() {
+        if let Some(existing) = store.node_for_source(source) {
+            if !removed_nodes.contains(&existing) {
+                return Err(SemanticMutationTransactionError::Node {
+                    index,
+                    error: SemanticStoreError::DuplicateSourceIdentity(source.clone()),
+                });
+            }
+        }
+        if !pending_sources.insert(source.clone()) {
+            return Err(SemanticMutationTransactionError::Node {
+                index,
+                error: SemanticStoreError::DuplicateSourceIdentity(source.clone()),
+            });
+        }
+    }
+
+    let SemanticNodeCreation::Object { state, .. } = creation else {
+        return Ok(());
+    };
+
+    if !state.transform.translation.is_finite()
+        || !state.transform.scale.is_finite()
+        || !state.transform.rotation_z.is_finite()
+        || !state.style.fill_opacity.is_finite()
+        || !state.style.stroke_opacity.is_finite()
+        || !state.style.stroke_width.is_finite()
+        || !state.style.object_opacity.is_finite()
+    {
+        return Err(SemanticMutationTransactionError::InvalidNodeObjectState { index });
+    }
+
+    for binding in state.signal_bindings() {
+        let signal = binding.signal();
+        if removed_nodes.contains(&signal) {
+            return Err(
+                SemanticMutationTransactionError::NodeCreationUsesRemovedNode {
+                    index,
+                    node: signal,
+                },
+            );
+        }
+        let actual = store
+            .semantic_signal_value_kind(signal)
+            .map_err(|error| SemanticMutationTransactionError::Signal { index, error })?;
+        let expected = binding.property().value_kind();
+        if actual != expected {
+            return Err(
+                SemanticMutationTransactionError::NodeCreationBindingTypeMismatch {
+                    index,
+                    signal,
+                    expected,
+                    actual,
+                },
+            );
+        }
+    }
+
+    Ok(())
+}
+
+pub(super) fn commit_add_node(
+    store: &mut SemanticStore,
+    creation: SemanticNodeCreation,
+) -> (SemanticNodeId, Option<SourceIdentity>) {
+    match creation {
+        SemanticNodeCreation::Object {
+            state,
+            source_identity,
+        } => (store.insert_semantic_object(*state), source_identity),
+        SemanticNodeCreation::Family { source_identity } => {
+            (store.insert_family(), source_identity)
+        }
+    }
+}


### PR DESCRIPTION
## Scope

Close the remaining narrow A1.5 `AddNode` vocabulary gap for semantic scene nodes without conflating identity allocation with A1.3 `Scene.add()` membership.

## Semantics

- Add `SemanticMutation::AddNode { creation }` and `SemanticMutationImpact::NodeAdded { node }`.
- `SemanticNodeCreation` allocates authoritative semantic Objects and Families through the existing scene-global generational allocator; new nodes start detached.
- Animation declarations remain on the dedicated `AddAnimation` path, and signal declarations remain on the typed semantic-signal authoring path rather than adding a second declaration model.
- Allocation mutations have no pre-commit `SemanticNodeId`, so `target()` / conflict keys remain `None`; the committed identity is returned through `NodeAdded`.
- Optional `SourceIdentity` is preflighted atomically. A replacement may reuse the old source key when that old node is in the same transaction's removal closure: creation is allocated without the key, terminal removals run, then the key is assigned to the replacement.
- Object creation validates finite authored transform/style fields and validates carried signal bindings against live generation-safe signal identities and type requirements before any allocation.
- Object bindings may not reference a signal removed (including cascade removal) by the same transaction.
- Repeated identical additions intentionally allocate distinct semantic identities.

## Boundary

This slice does not invent provisional semantic IDs or a draft peer scene model for cross-new-node references. New-node payloads reference existing scene-global identities only. If atomic construction of a graph whose edges connect multiple newly-created identities is required, that should be explicit follow-up transaction-addressing work rather than hidden inside AddNode.

## Evidence

Focused tests cover detached object/family creation, distinct repeated allocation, invalid-state rollback, stale/carried binding rejection, same-transaction removed-signal rejection, duplicate source rollback, atomic source-key replacement, and 10k-unrelated-node locality.
