### PR TITLE
A1.6: reject non-finite analytic geometry at compiled boundary

### DIFF
--- a/crates/noon-compile/src/semantic_lowering/compiled_scene.rs
+++ b/crates/noon-compile/src/semantic_lowering/compiled_scene.rs
@@ -18,6 +18,9 @@ pub enum SemanticCompiledSceneError {
         node: SemanticNodeId,
         count: usize,
     },
+    InvalidAnalyticGeometry {
+        node: SemanticNodeId,
+    },
     UnsupportedGeometryResource {
         node: SemanticNodeId,
         resource: GeometryResourceHandle,
@@ -37,6 +40,12 @@ impl std::fmt::Display for SemanticCompiledSceneError {
             Self::UnsupportedSignalBindings { node, count } => write!(
                 formatter,
                 "semantic object {}:{} carries {count} native-reactive signal binding(s) before compiled execution slots consume semantic bindings",
+                node.slot(),
+                node.generation()
+            ),
+            Self::InvalidAnalyticGeometry { node } => write!(
+                formatter,
+                "semantic object {}:{} contains non-finite analytic geometry",
                 node.slot(),
                 node.generation()
             ),
@@ -124,12 +133,25 @@ fn lower_geometry(
 ) -> Result<GeometryRef, SemanticCompiledSceneError> {
     match content {
         SemanticObjectContent::Geometry(StoredGeometry::Circle { radius }) => {
+            if !radius.is_finite() {
+                return Err(SemanticCompiledSceneError::InvalidAnalyticGeometry { node });
+            }
             Ok(GeometryRef::circle(radius))
         }
         SemanticObjectContent::Geometry(StoredGeometry::Rectangle { size }) => {
+            if !size.x.is_finite() || !size.y.is_finite() {
+                return Err(SemanticCompiledSceneError::InvalidAnalyticGeometry { node });
+            }
             Ok(GeometryRef::Rectangle { size })
         }
         SemanticObjectContent::Geometry(StoredGeometry::Line { start, end }) => {
+            if !start.x.is_finite()
+                || !start.y.is_finite()
+                || !end.x.is_finite()
+                || !end.y.is_finite()
+            {
+                return Err(SemanticCompiledSceneError::InvalidAnalyticGeometry { node });
+            }
             Ok(GeometryRef::line(start, end))
         }
         SemanticObjectContent::Geometry(StoredGeometry::Resource(resource)) => {
@@ -145,7 +167,7 @@ fn lower_geometry(
 mod tests {
     use noon_core::{
         Color, GeometryId, SemanticObjectProperty, SemanticObjectState, SemanticPaint,
-        SemanticStore, SemanticVec3, TextResourceId,
+        SemanticStore, SemanticVec3, TextResourceId, Vec2,
     };
 
     use super::*;
@@ -207,6 +229,33 @@ mod tests {
         assert_eq!(compiled.objects()[1].base_transform.translation.y, 3.0);
         assert_eq!(compiled.objects()[1].base_style.fill.unwrap().alpha, 0.5);
         assert!(compiled.tracks().is_empty());
+    }
+
+    #[test]
+    fn non_finite_analytic_geometry_is_rejected_before_compiled_scene_creation() {
+        let cases = [
+            StoredGeometry::Circle { radius: f32::NAN },
+            StoredGeometry::Rectangle {
+                size: Vec2::new(f32::INFINITY, 1.0),
+            },
+            StoredGeometry::Line {
+                start: Vec2::new(0.0, f32::NEG_INFINITY),
+                end: Vec2::ZERO,
+            },
+        ];
+
+        for geometry in cases {
+            let mut store = SemanticStore::new();
+            let node = store.insert_semantic_object(SemanticObjectState::new(geometry));
+            store.attach_to_scene(node).unwrap();
+
+            let mut index = SemanticExecutionIndex::new();
+            let projection = index.lower_scene(&store).unwrap();
+            assert_eq!(
+                CompiledScene::from_semantic_projection(&projection).unwrap_err(),
+                SemanticCompiledSceneError::InvalidAnalyticGeometry { node }
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Scope

Follow up merged #1057 by restoring the renderer-independent finite-geometry admission that the direct semantic -> `CompiledScene` path bypasses when it does not pass through legacy `SceneDefinition` validation.

## Changes

- add `SemanticCompiledSceneError::InvalidAnalyticGeometry`;
- reject non-finite circle radius values;
- reject non-finite rectangle size components;
- reject non-finite line endpoint components;
- cover all three analytic variants with a focused regression test that proves invalid semantic geometry fails before `CompiledScene` construction.

## Why

`SemanticObjectState` admission currently validates transform/style values but can still carry non-finite inline analytic geometry. #1057 correctly connects the semantic projection directly to stable compiled/runtime slots, but its analytic adapter copied those values into `GeometryRef` without the finite checks enforced by the older `SceneDefinition` object-validation path.

This keeps the new direct path at least as strict as the execution representation it replaces instead of allowing NaN/inf geometry to reach runtime/rendering state.

## Boundary

No change to semantic painter ordering, semantic/execution identity, signal-binding behavior, resource/text rejection, timeline lowering, execution slots, or runtime state. No compatibility wrapper or new model is introduced.

One changed compiler file and one clean commit directly on #1057 merge `2cad3c25509dcb8d22d7d9794058180a0abfff3a`.

Refs #957 #1057.