### PR TITLE
A1.6: add canonical semantic execution lowering entry

### DIFF
--- a/crates/noon-compile/src/semantic_lowering.rs
+++ b/crates/noon-compile/src/semantic_lowering.rs
@@ -1,10 +1,12 @@
 mod compiled_scene;
+mod entrypoint;
 mod membership;
 mod projection;
 mod reachability;
 mod reactive;
 
 pub use compiled_scene::*;
+pub use entrypoint::*;
 pub use membership::*;
 pub use projection::*;
 pub use reachability::*;

--- a/crates/noon-compile/src/semantic_lowering/compiled_scene.rs
+++ b/crates/noon-compile/src/semantic_lowering/compiled_scene.rs
@@ -75,56 +75,72 @@ impl CompiledScene {
     /// Materialize the already value-lowered semantic object projection into the
     /// existing stable compiled object representation.
     ///
-    /// Frame-row order is the semantic presentation order. Execution identity is
-    /// preserved through each object's derived execution key, so ordering does not
-    /// manufacture or rewrite identity. Timeline/reactive declarations are outside
-    /// this object-value projection and are lowered through their dedicated A1.6
-    /// channels rather than being synthesized here.
+    /// This standalone compatibility entry remains fail-closed when native-reactive
+    /// bindings are present. Callers that need the complete semantic execution
+    /// boundary must use `lower_semantic_execution`, which lowers those bindings
+    /// through the native reactive graph before object materialization.
     pub fn from_semantic_projection(
         projection: &SemanticExecutionProjection,
     ) -> Result<Self, SemanticCompiledSceneError> {
-        let mut ordered = projection.objects().iter().collect::<Vec<_>>();
-        ordered.sort_by_key(|object| object.presentation.order_key());
-
-        let count = ordered.len();
-        if u32::try_from(count).is_err() {
-            return Err(SemanticCompiledSceneError::TooManyObjects(count));
-        }
-
-        let mut objects = Vec::with_capacity(count);
-        let mut object_indices = BTreeMap::new();
-
-        for (index, object) in ordered.into_iter().enumerate() {
-            if !object.signal_bindings.is_empty() {
-                return Err(SemanticCompiledSceneError::UnsupportedSignalBindings {
-                    node: object.semantic_id,
-                    count: object.signal_bindings.len(),
-                });
-            }
-
-            let object_index = u32::try_from(index)
-                .map_err(|_| SemanticCompiledSceneError::TooManyObjects(count))?;
-            let geometry = lower_geometry(object.semantic_id, object.content)?;
-            objects.push(CompiledObject {
-                id: object.execution_id,
-                geometry,
-                base_transform: object.base_transform,
-                base_style: object.base_style,
-                dynamic: DynamicProperties::default(),
-                live: true,
-            });
-            object_indices.insert(object.execution_id, object_index);
-        }
-
-        Ok(Self {
-            live_object_count: objects.len(),
-            objects,
-            tracks: BTreeMap::new(),
-            track_count: 0,
-            object_indices,
-            track_locators: BTreeMap::new(),
-        })
+        materialize_semantic_projection(projection, false)
     }
+
+    /// Materialize object values after the canonical A1.6 entry point has
+    /// successfully consumed every semantic signal binding into the native reactive
+    /// projection. Kept crate-private so standalone callers cannot silently drop
+    /// bindings by opting into this path directly.
+    pub(crate) fn from_semantic_projection_after_reactive_lowering(
+        projection: &SemanticExecutionProjection,
+    ) -> Result<Self, SemanticCompiledSceneError> {
+        materialize_semantic_projection(projection, true)
+    }
+}
+
+fn materialize_semantic_projection(
+    projection: &SemanticExecutionProjection,
+    reactive_bindings_lowered: bool,
+) -> Result<CompiledScene, SemanticCompiledSceneError> {
+    let mut ordered = projection.objects().iter().collect::<Vec<_>>();
+    ordered.sort_by_key(|object| object.presentation.order_key());
+
+    let count = ordered.len();
+    if u32::try_from(count).is_err() {
+        return Err(SemanticCompiledSceneError::TooManyObjects(count));
+    }
+
+    let mut objects = Vec::with_capacity(count);
+    let mut object_indices = BTreeMap::new();
+
+    for (index, object) in ordered.into_iter().enumerate() {
+        if !reactive_bindings_lowered && !object.signal_bindings.is_empty() {
+            return Err(SemanticCompiledSceneError::UnsupportedSignalBindings {
+                node: object.semantic_id,
+                count: object.signal_bindings.len(),
+            });
+        }
+
+        let object_index =
+            u32::try_from(index).map_err(|_| SemanticCompiledSceneError::TooManyObjects(count))?;
+        let geometry = lower_geometry(object.semantic_id, object.content)?;
+        objects.push(CompiledObject {
+            id: object.execution_id,
+            geometry,
+            base_transform: object.base_transform,
+            base_style: object.base_style,
+            dynamic: DynamicProperties::default(),
+            live: true,
+        });
+        object_indices.insert(object.execution_id, object_index);
+    }
+
+    Ok(CompiledScene {
+        live_object_count: objects.len(),
+        objects,
+        tracks: BTreeMap::new(),
+        track_count: 0,
+        object_indices,
+        track_locators: BTreeMap::new(),
+    })
 }
 
 fn lower_geometry(

--- a/crates/noon-compile/src/semantic_lowering/entrypoint.rs
+++ b/crates/noon-compile/src/semantic_lowering/entrypoint.rs
@@ -63,8 +63,12 @@ impl std::fmt::Display for SemanticExecutionLoweringError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Object(error) => write!(formatter, "semantic object lowering failed: {error}"),
-            Self::Reactive(error) => write!(formatter, "semantic reactive lowering failed: {error}"),
-            Self::Compiled(error) => write!(formatter, "compiled execution lowering failed: {error}"),
+            Self::Reactive(error) => {
+                write!(formatter, "semantic reactive lowering failed: {error}")
+            }
+            Self::Compiled(error) => {
+                write!(formatter, "compiled execution lowering failed: {error}")
+            }
         }
     }
 }
@@ -89,8 +93,7 @@ pub fn lower_semantic_execution(
     let mut staged_index = index.clone();
     let projection = staged_index.lower_scene(store)?;
     let reactive = lower_semantic_reactive_projection(store, &projection)?;
-    let compiled =
-        CompiledScene::from_semantic_projection_after_reactive_lowering(&projection)?;
+    let compiled = CompiledScene::from_semantic_projection_after_reactive_lowering(&projection)?;
 
     *index = staged_index;
     Ok(SemanticExecutionLoweringOutput { compiled, reactive })

--- a/crates/noon-compile/src/semantic_lowering/entrypoint.rs
+++ b/crates/noon-compile/src/semantic_lowering/entrypoint.rs
@@ -1,0 +1,184 @@
+use noon_core::SemanticStore;
+
+use crate::CompiledScene;
+
+use super::{
+    lower_semantic_reactive_projection, SemanticCompiledSceneError, SemanticExecutionIndex,
+    SemanticLoweringError, SemanticReactiveLoweringError, SemanticReactiveProjection,
+};
+
+/// One typed compiler handoff from the authoritative semantic scene into Noon's
+/// existing execution representations.
+///
+/// This is a composition boundary, not a second runtime scene model: object/timeline
+/// storage remains `CompiledScene`, native reactive execution remains the existing
+/// `ReactiveGraphDefinition`/compute VM, and durable runtime identity remains owned
+/// by `ExecutionSlotTable`.
+#[derive(Clone, Debug, PartialEq)]
+pub struct SemanticExecutionLoweringOutput {
+    compiled: CompiledScene,
+    reactive: SemanticReactiveProjection,
+}
+
+impl SemanticExecutionLoweringOutput {
+    pub fn compiled(&self) -> &CompiledScene {
+        &self.compiled
+    }
+
+    pub fn reactive(&self) -> &SemanticReactiveProjection {
+        &self.reactive
+    }
+
+    pub fn into_parts(self) -> (CompiledScene, SemanticReactiveProjection) {
+        (self.compiled, self.reactive)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum SemanticExecutionLoweringError {
+    Object(SemanticLoweringError),
+    Reactive(SemanticReactiveLoweringError),
+    Compiled(SemanticCompiledSceneError),
+}
+
+impl From<SemanticLoweringError> for SemanticExecutionLoweringError {
+    fn from(value: SemanticLoweringError) -> Self {
+        Self::Object(value)
+    }
+}
+
+impl From<SemanticReactiveLoweringError> for SemanticExecutionLoweringError {
+    fn from(value: SemanticReactiveLoweringError) -> Self {
+        Self::Reactive(value)
+    }
+}
+
+impl From<SemanticCompiledSceneError> for SemanticExecutionLoweringError {
+    fn from(value: SemanticCompiledSceneError) -> Self {
+        Self::Compiled(value)
+    }
+}
+
+impl std::fmt::Display for SemanticExecutionLoweringError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Object(error) => write!(formatter, "semantic object lowering failed: {error}"),
+            Self::Reactive(error) => write!(formatter, "semantic reactive lowering failed: {error}"),
+            Self::Compiled(error) => write!(formatter, "compiled execution lowering failed: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for SemanticExecutionLoweringError {}
+
+/// Canonical A1.6 initial-scene lowering entry point.
+///
+/// Object values and active native-reactive bindings are lowered from the same
+/// semantic snapshot. The identity index is staged and published only after all
+/// downstream lowering succeeds, so unsupported compiled payloads or reactive
+/// channels cannot leave a partially admitted semantic-to-execution mapping.
+///
+/// Authored animation declarations remain semantic intent until an explicit
+/// animation activation/composition root is supplied to its dedicated lowering
+/// channel; detached declarations are not implicitly scheduled by initial-scene
+/// lowering.
+pub fn lower_semantic_execution(
+    store: &SemanticStore,
+    index: &mut SemanticExecutionIndex,
+) -> Result<SemanticExecutionLoweringOutput, SemanticExecutionLoweringError> {
+    let mut staged_index = index.clone();
+    let projection = staged_index.lower_scene(store)?;
+    let reactive = lower_semantic_reactive_projection(store, &projection)?;
+    let compiled =
+        CompiledScene::from_semantic_projection_after_reactive_lowering(&projection)?;
+
+    *index = staged_index;
+    Ok(SemanticExecutionLoweringOutput { compiled, reactive })
+}
+
+#[cfg(test)]
+mod tests {
+    use noon_core::{
+        Property, SemanticObjectProperty, SemanticObjectState, SemanticStore, StoredGeometry,
+        TextResourceHandle, TextResourceId,
+    };
+
+    use super::*;
+
+    fn circle(radius: f32) -> SemanticObjectState {
+        SemanticObjectState::new(StoredGeometry::Circle { radius })
+    }
+
+    #[test]
+    fn canonical_entry_lowers_object_values_and_reactive_bindings_together() {
+        let mut store = SemanticStore::new();
+        let signal = store.insert_semantic_input_signal(0.4_f64).unwrap();
+        let object = store.insert_semantic_object(circle(2.0));
+        store.attach_to_scene(object).unwrap();
+        store
+            .bind_semantic_signal(signal, object, SemanticObjectProperty::ObjectOpacity)
+            .unwrap();
+
+        let mut index = SemanticExecutionIndex::new();
+        let lowered = lower_semantic_execution(&store, &mut index).unwrap();
+        let execution_id = index.execution_object_id(object).unwrap();
+
+        assert_eq!(lowered.compiled().objects().len(), 1);
+        assert_eq!(lowered.compiled().objects()[0].id, execution_id);
+        assert_eq!(lowered.reactive().signal_count(), 1);
+        assert_eq!(
+            lowered.reactive().graph().bindings()[0].object,
+            execution_id
+        );
+        assert_eq!(
+            lowered.reactive().graph().bindings()[0].property,
+            Property::Opacity
+        );
+        assert_eq!(
+            lowered.reactive().graph().bindings()[0].signal,
+            lowered.reactive().execution_signal_id(signal).unwrap()
+        );
+    }
+
+    #[test]
+    fn reactive_failure_does_not_publish_staged_execution_identity() {
+        let mut store = SemanticStore::new();
+        let signal = store.insert_semantic_input_signal(0.4_f64).unwrap();
+        let object = store.insert_semantic_object(circle(1.0));
+        store.attach_to_scene(object).unwrap();
+        store
+            .bind_semantic_signal(signal, object, SemanticObjectProperty::FillOpacity)
+            .unwrap();
+
+        let mut index = SemanticExecutionIndex::new();
+        assert!(matches!(
+            lower_semantic_execution(&store, &mut index),
+            Err(SemanticExecutionLoweringError::Reactive(
+                SemanticReactiveLoweringError::UnsupportedProperty {
+                    target,
+                    property: SemanticObjectProperty::FillOpacity,
+                }
+            )) if target == object
+        ));
+        assert!(index.is_empty());
+    }
+
+    #[test]
+    fn compiled_payload_failure_does_not_publish_staged_execution_identity() {
+        let mut store = SemanticStore::new();
+        let object = store.insert_semantic_object(SemanticObjectState::new(TextResourceHandle {
+            id: TextResourceId::new(9),
+            version: 2,
+        }));
+        store.attach_to_scene(object).unwrap();
+
+        let mut index = SemanticExecutionIndex::new();
+        assert!(matches!(
+            lower_semantic_execution(&store, &mut index),
+            Err(SemanticExecutionLoweringError::Compiled(
+                SemanticCompiledSceneError::UnsupportedText { node, .. }
+            )) if node == object
+        ));
+        assert!(index.is_empty());
+    }
+}


### PR DESCRIPTION
## Scope

Complete the next A1.6 handoff step after #1060/#1061 by exposing one canonical initial-scene lowering entry from the authoritative `SemanticStore` into the existing compiled/native-reactive execution representations.

## Changes

- add `lower_semantic_execution(store, index)` as the single typed compiler entry for rooted object values plus active semantic signal bindings;
- return a thin `SemanticExecutionLoweringOutput` containing the existing `CompiledScene` and `SemanticReactiveProjection` rather than introducing another execution-plan/runtime scene model;
- stage `SemanticExecutionIndex` and publish it only after object, reactive, and compiled lowering all succeed;
- preserve the standalone `CompiledScene::from_semantic_projection` fail-closed behavior for signal bindings;
- add a crate-private materialization path used only after the canonical entry has successfully lowered those bindings into `ReactiveGraphDefinition`;
- keep detached semantic animation declarations unscheduled: animation activation/composition roots remain a dedicated lowering input rather than implicitly treating every stored declaration as active execution.

## Architecture

The result composes existing authorities only:

`SemanticStore -> lower_semantic_execution -> { CompiledScene, SemanticReactiveProjection }`

`CompiledScene` remains object/timeline execution data, the existing reactive graph/compute VM remains native reactive execution, and `ExecutionSlotTable` remains durable runtime identity. This PR adds no alternate evaluator, authored patch vocabulary, transport document, or runtime scene authority.

## Validation

Focused tests cover:

- one semantic object + signal binding lowering coherently to the same execution object identity in both compiled and reactive outputs;
- reactive-channel failure leaving the staged semantic/execution identity index unchanged;
- unsupported compiled payload failure leaving the staged index unchanged;
- the legacy standalone compiled projection path continuing to reject unconsumed signal bindings.

Refs #957 #969 #959.