### PR TITLE
A1.6: compile semantic reactive graph into existing VM

### DIFF
--- a/crates/noon-compile/src/semantic_lowering.rs
+++ b/crates/noon-compile/src/semantic_lowering.rs
@@ -4,6 +4,7 @@ mod membership;
 mod projection;
 mod reachability;
 mod reactive;
+mod reactive_target;
 
 pub use compiled_scene::*;
 pub use entrypoint::*;

--- a/crates/noon-compile/src/semantic_lowering/entrypoint.rs
+++ b/crates/noon-compile/src/semantic_lowering/entrypoint.rs
@@ -1,4 +1,4 @@
-use noon_core::SemanticStore;
+use noon_core::{ComputeProgram, ReactiveError, ReactiveProgram, SemanticStore};
 
 use crate::CompiledScene;
 
@@ -18,6 +18,7 @@ use super::{
 pub struct SemanticExecutionLoweringOutput {
     compiled: CompiledScene,
     reactive: SemanticReactiveProjection,
+    compute: ComputeProgram,
 }
 
 impl SemanticExecutionLoweringOutput {
@@ -29,8 +30,22 @@ impl SemanticExecutionLoweringOutput {
         &self.reactive
     }
 
+    /// Existing native reactive VM program compiled against the same lowered
+    /// `CompiledScene` object/timeline target as this semantic snapshot.
+    pub fn compute(&self) -> &ComputeProgram {
+        &self.compute
+    }
+
+    /// Compatibility decomposition retained while callers migrate to consuming the
+    /// complete canonical execution handoff.
     pub fn into_parts(self) -> (CompiledScene, SemanticReactiveProjection) {
         (self.compiled, self.reactive)
+    }
+
+    pub fn into_execution_parts(
+        self,
+    ) -> (CompiledScene, SemanticReactiveProjection, ComputeProgram) {
+        (self.compiled, self.reactive, self.compute)
     }
 }
 
@@ -39,6 +54,7 @@ pub enum SemanticExecutionLoweringError {
     Object(SemanticLoweringError),
     Reactive(SemanticReactiveLoweringError),
     Compiled(SemanticCompiledSceneError),
+    NativeReactive(ReactiveError),
 }
 
 impl From<SemanticLoweringError> for SemanticExecutionLoweringError {
@@ -59,6 +75,12 @@ impl From<SemanticCompiledSceneError> for SemanticExecutionLoweringError {
     }
 }
 
+impl From<ReactiveError> for SemanticExecutionLoweringError {
+    fn from(value: ReactiveError) -> Self {
+        Self::NativeReactive(value)
+    }
+}
+
 impl std::fmt::Display for SemanticExecutionLoweringError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -68,6 +90,9 @@ impl std::fmt::Display for SemanticExecutionLoweringError {
             }
             Self::Compiled(error) => {
                 write!(formatter, "compiled execution lowering failed: {error}")
+            }
+            Self::NativeReactive(error) => {
+                write!(formatter, "native reactive program compilation failed: {error}")
             }
         }
     }
@@ -79,8 +104,9 @@ impl std::error::Error for SemanticExecutionLoweringError {}
 ///
 /// Object values and active native-reactive bindings are lowered from the same
 /// semantic snapshot. The identity index is staged and published only after all
-/// downstream lowering succeeds, so unsupported compiled payloads or reactive
-/// channels cannot leave a partially admitted semantic-to-execution mapping.
+/// downstream lowering succeeds, so unsupported compiled payloads, reactive
+/// channels, or VM compilation cannot leave a partially admitted
+/// semantic-to-execution mapping.
 ///
 /// Authored animation declarations remain semantic intent until an explicit
 /// animation activation/composition root is supplied to its dedicated lowering
@@ -94,16 +120,21 @@ pub fn lower_semantic_execution(
     let projection = staged_index.lower_scene(store)?;
     let reactive = lower_semantic_reactive_projection(store, &projection)?;
     let compiled = CompiledScene::from_semantic_projection_after_reactive_lowering(&projection)?;
+    let compute = ReactiveProgram::compile(&compiled, reactive.graph())?.into_compute()?;
 
     *index = staged_index;
-    Ok(SemanticExecutionLoweringOutput { compiled, reactive })
+    Ok(SemanticExecutionLoweringOutput {
+        compiled,
+        reactive,
+        compute,
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use noon_core::{
-        Property, SemanticObjectProperty, SemanticObjectState, SemanticStore, StoredGeometry,
-        TextResourceHandle, TextResourceId,
+        Property, ReactiveValue, SemanticObjectProperty, SemanticObjectState, SemanticStore,
+        StoredGeometry, TextResourceHandle, TextResourceId,
     };
 
     use super::*;
@@ -113,7 +144,7 @@ mod tests {
     }
 
     #[test]
-    fn canonical_entry_lowers_object_values_and_reactive_bindings_together() {
+    fn canonical_entry_lowers_object_values_and_reactive_bindings_into_existing_vm() {
         let mut store = SemanticStore::new();
         let signal = store.insert_semantic_input_signal(0.4_f64).unwrap();
         let object = store.insert_semantic_object(circle(2.0));
@@ -125,10 +156,12 @@ mod tests {
         let mut index = SemanticExecutionIndex::new();
         let lowered = lower_semantic_execution(&store, &mut index).unwrap();
         let execution_id = index.execution_object_id(object).unwrap();
+        let execution_signal = lowered.reactive().execution_signal_id(signal).unwrap();
 
         assert_eq!(lowered.compiled().objects().len(), 1);
         assert_eq!(lowered.compiled().objects()[0].id, execution_id);
         assert_eq!(lowered.reactive().signal_count(), 1);
+        assert_eq!(lowered.compute().signal_count(), 1);
         assert_eq!(
             lowered.reactive().graph().bindings()[0].object,
             execution_id
@@ -139,7 +172,18 @@ mod tests {
         );
         assert_eq!(
             lowered.reactive().graph().bindings()[0].signal,
-            lowered.reactive().execution_signal_id(signal).unwrap()
+            execution_signal
+        );
+
+        let mut state = lowered.compute().clone().instantiate();
+        let update = state.set_input(execution_signal, 0.75_f32).unwrap();
+        assert_eq!(update.affected_objects(), vec![execution_id]);
+        assert_eq!(update.property_changes().len(), 1);
+        assert_eq!(update.property_changes()[0].object, execution_id);
+        assert_eq!(update.property_changes()[0].property, Property::Opacity);
+        assert_eq!(
+            update.property_changes()[0].value,
+            ReactiveValue::Scalar(0.75)
         );
     }
 

--- a/crates/noon-compile/src/semantic_lowering/reactive_target.rs
+++ b/crates/noon-compile/src/semantic_lowering/reactive_target.rs
@@ -1,0 +1,94 @@
+use noon_core::{ObjectId, Property, ReactiveCompileTarget};
+
+use crate::{CompiledChannelKey, CompiledScene};
+
+impl ReactiveCompileTarget for CompiledScene {
+    fn object_slot_count(&self) -> usize {
+        self.objects().len()
+    }
+
+    fn object_at_slot(&self, slot: usize) -> Option<ObjectId> {
+        let slot = u32::try_from(slot).ok()?;
+        CompiledScene::object_id_at_slot(self, slot)
+    }
+
+    fn contains_object(&self, object: ObjectId) -> bool {
+        self.object_index(object).is_some()
+    }
+
+    fn has_timeline_driver(&self, object: ObjectId, property: Property) -> bool {
+        self.object_index(object)
+            .is_some_and(|object_index| self.has_channel(CompiledChannelKey::new(object_index, property)))
+    }
+
+    fn has_any_timeline_driver(&self, object: ObjectId) -> bool {
+        self.object_index(object).is_some_and(|object_index| {
+            self.channels()
+                .any(|channel| channel.object_index == object_index)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use noon_core::{
+        GeometryRef, RateFunction, ReactiveError, ReactiveGraphDefinition, ReactiveProgram,
+        SceneDefinition, TrackTiming,
+    };
+
+    use super::*;
+
+    #[test]
+    fn compiled_scene_drives_existing_reactive_program_validation() {
+        let mut scene = SceneDefinition::new();
+        let object = scene.add(GeometryRef::circle(1.0));
+        scene
+            .animate_scalar(
+                object,
+                Property::Opacity,
+                0.0,
+                1.0,
+                TrackTiming::new(0.0, 1.0, RateFunction::Linear),
+            )
+            .unwrap();
+        let compiled = CompiledScene::compile(&scene).unwrap();
+
+        let mut graph = ReactiveGraphDefinition::new();
+        let signal = graph.add_input(0.5_f32);
+        graph.bind(signal, object, Property::Opacity);
+
+        assert!(matches!(
+            ReactiveProgram::compile(&compiled, &graph),
+            Err(ReactiveError::ConflictingDriver {
+                object: conflict_object,
+                property: Property::Opacity,
+            }) if conflict_object == object
+        ));
+    }
+
+    #[test]
+    fn compiled_scene_preserves_execution_analysis_classes() {
+        let mut scene = SceneDefinition::new();
+        let static_object = scene.add(GeometryRef::circle(1.0));
+        let timeline_object = scene.add(GeometryRef::circle(1.0));
+        scene
+            .animate_scalar(
+                timeline_object,
+                Property::Rotation,
+                0.0,
+                1.0,
+                TrackTiming::new(0.0, 1.0, RateFunction::Linear),
+            )
+            .unwrap();
+        let compiled = CompiledScene::compile(&scene).unwrap();
+
+        let mut graph = ReactiveGraphDefinition::new();
+        let signal = graph.add_input(0.5_f32);
+        graph.bind(signal, static_object, Property::Opacity);
+
+        let program = ReactiveProgram::compile(&compiled, &graph).unwrap();
+        assert_eq!(program.analysis().static_objects, 0);
+        assert_eq!(program.analysis().timeline_only_objects, 1);
+        assert_eq!(program.analysis().reactive_only_objects, 1);
+    }
+}

--- a/crates/noon-core/src/reactive/native_reactive.rs
+++ b/crates/noon-core/src/reactive/native_reactive.rs
@@ -303,6 +303,45 @@ impl ExecutionAnalysis {
     }
 }
 
+/// Minimal execution-target facts required to validate and classify one native
+/// reactive graph.
+///
+/// This is a compiler query surface, not another scene representation. Implementors
+/// expose object identity and timeline-driver facts already owned by their existing
+/// execution representation so `ReactiveProgram` can reuse one graph compiler for
+/// legacy `SceneDefinition` and lowered compiled scenes.
+pub trait ReactiveCompileTarget {
+    fn object_slot_count(&self) -> usize;
+    fn object_at_slot(&self, slot: usize) -> Option<ObjectId>;
+    fn contains_object(&self, object: ObjectId) -> bool;
+    fn has_timeline_driver(&self, object: ObjectId, property: Property) -> bool;
+    fn has_any_timeline_driver(&self, object: ObjectId) -> bool;
+}
+
+impl ReactiveCompileTarget for SceneDefinition {
+    fn object_slot_count(&self) -> usize {
+        self.objects().len()
+    }
+
+    fn object_at_slot(&self, slot: usize) -> Option<ObjectId> {
+        self.objects().get(slot).map(|object| object.id)
+    }
+
+    fn contains_object(&self, object: ObjectId) -> bool {
+        self.object(object).is_some()
+    }
+
+    fn has_timeline_driver(&self, object: ObjectId, property: Property) -> bool {
+        self.tracks()
+            .iter()
+            .any(|track| track.object == object && track.property == property)
+    }
+
+    fn has_any_timeline_driver(&self, object: ObjectId) -> bool {
+        self.tracks().iter().any(|track| track.object == object)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 struct CompiledSignal {
     id: SignalId,
@@ -329,8 +368,8 @@ pub struct ReactiveProgram {
 }
 
 impl ReactiveProgram {
-    pub fn compile(
-        scene: &SceneDefinition,
+    pub fn compile<T: ReactiveCompileTarget + ?Sized>(
+        target: &T,
         graph: &ReactiveGraphDefinition,
     ) -> Result<Self, ReactiveError> {
         let mut signal_indices = BTreeMap::new();
@@ -409,7 +448,7 @@ impl ReactiveProgram {
             let signal_index = *signal_indices
                 .get(&binding.signal)
                 .ok_or(ReactiveError::UnknownSignal(binding.signal))?;
-            if scene.object(binding.object).is_none() {
+            if !target.contains_object(binding.object) {
                 return Err(ReactiveError::UnknownObject(binding.object));
             }
             if seen_targets.contains(&(binding.object, binding.property)) {
@@ -418,11 +457,7 @@ impl ReactiveProgram {
                     property: binding.property,
                 });
             }
-            if scene
-                .tracks()
-                .iter()
-                .any(|track| track.object == binding.object && track.property == binding.property)
-            {
+            if target.has_timeline_driver(binding.object, binding.property) {
                 return Err(ReactiveError::ConflictingDriver {
                     object: binding.object,
                     property: binding.property,
@@ -445,7 +480,7 @@ impl ReactiveProgram {
             });
         }
 
-        let analysis = build_execution_analysis(scene, graph);
+        let analysis = build_execution_analysis(target, graph);
         Ok(Self {
             signals: compiled_signals,
             signal_indices,
@@ -480,17 +515,20 @@ impl ReactiveProgram {
     }
 }
 
-fn build_execution_analysis(
-    scene: &SceneDefinition,
+fn build_execution_analysis<T: ReactiveCompileTarget + ?Sized>(
+    target: &T,
     graph: &ReactiveGraphDefinition,
 ) -> ExecutionAnalysis {
     let mut analysis = ExecutionAnalysis::default();
-    for object in scene.objects() {
-        let timeline = scene.tracks().iter().any(|track| track.object == object.id);
+    for slot in 0..target.object_slot_count() {
+        let Some(object) = target.object_at_slot(slot) else {
+            continue;
+        };
+        let timeline = target.has_any_timeline_driver(object);
         let reactive = graph
             .bindings
             .iter()
-            .any(|binding| binding.object == object.id);
+            .any(|binding| binding.object == object);
         let class = match (timeline, reactive) {
             (false, false) => {
                 analysis.static_objects += 1;
@@ -509,10 +547,7 @@ fn build_execution_analysis(
                 ObjectExecutionClass::TimelineAndReactive
             }
         };
-        analysis.objects.push(ObjectExecution {
-            object: object.id,
-            class,
-        });
+        analysis.objects.push(ObjectExecution { object, class });
     }
     analysis
 }


### PR DESCRIPTION
## Scope

Continue A1.6 after #1062 and #1063 by feeding the canonical semantic reactive projection directly into Noon's existing `ReactiveProgram` / `ComputeProgram` path.

## Changes

- extend `SemanticExecutionLoweringOutput` with the existing native `ComputeProgram` execution form;
- derive the live execution-object domain and timeline-driver keys from the same lowered `CompiledScene` snapshot;
- compile the existing `SemanticReactiveProjection` through #1063's `ReactiveProgram::compile_for_execution_domain(...)` API and lower it into the existing compute VM;
- publish the staged semantic-to-execution identity index only after reactive program/VM compilation succeeds;
- retain the previous two-part decomposition for compatibility while exposing the complete three-part execution handoff;
- add focused coverage proving a semantic input update flows through the existing compute VM to the expected compiled object/property.

## Architecture

This adds no compiler, evaluator, graph, or runtime model. `SemanticReactiveProjection` still lowers to the existing `ReactiveGraphDefinition`; #1063's `ReactiveProgram` remains the single validated dependency/dirty-closure compiler; `ComputeProgram` remains the native runtime VM. This slice only connects the canonical semantic lowering entry to those existing authorities.

## Validation

The focused canonical-lowering test instantiates the produced `ComputeProgram`, updates the execution signal, and verifies the resulting opacity invalidation targets the same stable compiled object identity. Exact-head architecture, layer, Rust, web/WASM, and browser gates remain required before merge.

Refs #957 #959 #1060 #1062 #1063.