### PR TITLE
A1.6: compile semantic reactivity against execution target

### DIFF
--- a/crates/noon-compile/src/semantic_lowering.rs
+++ b/crates/noon-compile/src/semantic_lowering.rs
@@ -4,6 +4,7 @@ mod membership;
 mod projection;
 mod reachability;
 mod reactive;
+mod reactive_target;
 
 pub use compiled_scene::*;
 pub use entrypoint::*;

--- a/crates/noon-compile/src/semantic_lowering/entrypoint.rs
+++ b/crates/noon-compile/src/semantic_lowering/entrypoint.rs
@@ -1,4 +1,4 @@
-use noon_core::SemanticStore;
+use noon_core::{ComputeProgram, ReactiveProgram, SemanticStore};
 
 use crate::CompiledScene;
 
@@ -18,6 +18,7 @@ use super::{
 pub struct SemanticExecutionLoweringOutput {
     compiled: CompiledScene,
     reactive: SemanticReactiveProjection,
+    compute: ComputeProgram,
 }
 
 impl SemanticExecutionLoweringOutput {
@@ -29,8 +30,12 @@ impl SemanticExecutionLoweringOutput {
         &self.reactive
     }
 
-    pub fn into_parts(self) -> (CompiledScene, SemanticReactiveProjection) {
-        (self.compiled, self.reactive)
+    pub fn compute(&self) -> &ComputeProgram {
+        &self.compute
+    }
+
+    pub fn into_parts(self) -> (CompiledScene, SemanticReactiveProjection, ComputeProgram) {
+        (self.compiled, self.reactive, self.compute)
     }
 }
 
@@ -78,9 +83,12 @@ impl std::error::Error for SemanticExecutionLoweringError {}
 /// Canonical A1.6 initial-scene lowering entry point.
 ///
 /// Object values and active native-reactive bindings are lowered from the same
-/// semantic snapshot. The identity index is staged and published only after all
-/// downstream lowering succeeds, so unsupported compiled payloads or reactive
-/// channels cannot leave a partially admitted semantic-to-execution mapping.
+/// semantic snapshot. Reactive target validation runs against the materialized
+/// `CompiledScene`, then the validated graph is lowered immediately into the
+/// existing typed `ComputeProgram`. No legacy authored scene is reconstructed.
+/// The identity index is staged and published only after all downstream lowering
+/// succeeds, so unsupported compiled payloads or reactive channels cannot leave a
+/// partially admitted semantic-to-execution mapping.
 ///
 /// Authored animation declarations remain semantic intent until an explicit
 /// animation activation/composition root is supplied to its dedicated lowering
@@ -94,9 +102,18 @@ pub fn lower_semantic_execution(
     let projection = staged_index.lower_scene(store)?;
     let reactive = lower_semantic_reactive_projection(store, &projection)?;
     let compiled = CompiledScene::from_semantic_projection_after_reactive_lowering(&projection)?;
+    let program = ReactiveProgram::compile_for_target(&compiled, reactive.graph())
+        .map_err(SemanticReactiveLoweringError::from)?;
+    let compute = program
+        .into_compute()
+        .map_err(SemanticReactiveLoweringError::from)?;
 
     *index = staged_index;
-    Ok(SemanticExecutionLoweringOutput { compiled, reactive })
+    Ok(SemanticExecutionLoweringOutput {
+        compiled,
+        reactive,
+        compute,
+    })
 }
 
 #[cfg(test)]
@@ -113,7 +130,7 @@ mod tests {
     }
 
     #[test]
-    fn canonical_entry_lowers_object_values_and_reactive_bindings_together() {
+    fn canonical_entry_lowers_object_values_and_reactive_bindings_into_compute_vm() {
         let mut store = SemanticStore::new();
         let signal = store.insert_semantic_input_signal(0.4_f64).unwrap();
         let object = store.insert_semantic_object(circle(2.0));
@@ -129,6 +146,7 @@ mod tests {
         assert_eq!(lowered.compiled().objects().len(), 1);
         assert_eq!(lowered.compiled().objects()[0].id, execution_id);
         assert_eq!(lowered.reactive().signal_count(), 1);
+        assert_eq!(lowered.compute().signal_count(), 1);
         assert_eq!(
             lowered.reactive().graph().bindings()[0].object,
             execution_id

--- a/crates/noon-compile/src/semantic_lowering/reactive_target.rs
+++ b/crates/noon-compile/src/semantic_lowering/reactive_target.rs
@@ -1,0 +1,84 @@
+use noon_core::{ObjectId, Property, ReactiveCompileTarget};
+
+use crate::{CompiledChannelKey, CompiledScene};
+
+/// Let the native reactive compiler validate directly against the compiled
+/// execution target rather than reconstructing a legacy authored scene.
+impl ReactiveCompileTarget for CompiledScene {
+    fn contains_object(&self, object: ObjectId) -> bool {
+        self.object_index(object).is_some()
+    }
+
+    fn has_timeline_driver(&self, object: ObjectId, property: Property) -> bool {
+        let Some(object_index) = self.object_index(object) else {
+            return false;
+        };
+        self.has_channel(CompiledChannelKey::new(object_index, property))
+    }
+
+    fn has_timeline_activity(&self, object: ObjectId) -> bool {
+        let Some(object_index) = self.object_index(object) else {
+            return false;
+        };
+        self.objects()[object_index as usize].dynamic.any()
+    }
+
+    fn visit_objects(&self, visitor: &mut dyn FnMut(ObjectId)) {
+        for object in self.objects().iter().filter(|object| object.live) {
+            visitor(object.id);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use noon_core::{
+        ObjectExecutionClass, ReactiveError, ReactiveGraphDefinition, ReactiveProgram,
+        SemanticObjectState, SemanticStore, StoredGeometry,
+    };
+
+    use super::*;
+    use crate::SemanticExecutionIndex;
+
+    fn compiled_circle() -> (CompiledScene, ObjectId) {
+        let mut store = SemanticStore::new();
+        let object = store.insert_semantic_object(SemanticObjectState::new(
+            StoredGeometry::Circle { radius: 1.0 },
+        ));
+        store.attach_to_scene(object).unwrap();
+
+        let mut index = SemanticExecutionIndex::new();
+        let projection = index.lower_scene(&store).unwrap();
+        let execution_id = index.execution_object_id(object).unwrap();
+        let compiled = CompiledScene::from_semantic_projection(&projection).unwrap();
+        (compiled, execution_id)
+    }
+
+    #[test]
+    fn compiled_scene_is_a_native_reactive_compile_target() {
+        let (compiled, object) = compiled_circle();
+        let mut graph = ReactiveGraphDefinition::new();
+        let signal = graph.add_input(0.5_f32);
+        graph.bind(signal, object, Property::Opacity);
+
+        let program = ReactiveProgram::compile_for_target(&compiled, &graph).unwrap();
+        assert_eq!(
+            program.analysis().class_for(object),
+            Some(ObjectExecutionClass::Reactive)
+        );
+    }
+
+    #[test]
+    fn compiled_target_rejects_bindings_to_nonexistent_execution_objects() {
+        let (compiled, _) = compiled_circle();
+        let unknown = ObjectId::new(u64::MAX);
+        let mut graph = ReactiveGraphDefinition::new();
+        let signal = graph.add_input(0.5_f32);
+        graph.bind(signal, unknown, Property::Opacity);
+
+        assert_eq!(
+            ReactiveProgram::compile_for_target(&compiled, &graph).unwrap_err(),
+            ReactiveError::UnknownObject(unknown)
+        );
+    }
+}

--- a/crates/noon-core/src/reactive/native_reactive.rs
+++ b/crates/noon-core/src/reactive/native_reactive.rs
@@ -6,6 +6,47 @@ use crate::{GeometryRef, ObjectId, Property, SceneDefinition, SignalId, ValueKin
 mod compute_ir;
 pub use compute_ir::*;
 
+/// Minimal execution-target facts needed to validate and classify a native reactive graph.
+///
+/// This is a compile-time query boundary, not another scene representation. Implementors
+/// expose existing object/timeline facts in their own storage order; the reactive compiler
+/// neither owns nor mutates that storage.
+pub trait ReactiveCompileTarget {
+    /// Whether `object` names a live execution object.
+    fn contains_object(&self, object: ObjectId) -> bool;
+
+    /// Whether the target already has a timeline driver for this exact property.
+    fn has_timeline_driver(&self, object: ObjectId, property: Property) -> bool;
+
+    /// Whether the target has any timeline activity for this object.
+    fn has_timeline_activity(&self, object: ObjectId) -> bool;
+
+    /// Visit live execution objects in deterministic target order.
+    fn visit_objects(&self, visitor: &mut dyn FnMut(ObjectId));
+}
+
+impl ReactiveCompileTarget for SceneDefinition {
+    fn contains_object(&self, object: ObjectId) -> bool {
+        self.object(object).is_some()
+    }
+
+    fn has_timeline_driver(&self, object: ObjectId, property: Property) -> bool {
+        self.tracks()
+            .iter()
+            .any(|track| track.object == object && track.property == property)
+    }
+
+    fn has_timeline_activity(&self, object: ObjectId) -> bool {
+        self.tracks().iter().any(|track| track.object == object)
+    }
+
+    fn visit_objects(&self, visitor: &mut dyn FnMut(ObjectId)) {
+        for object in self.objects() {
+            visitor(object.id);
+        }
+    }
+}
+
 /// A value that can participate in the native reactive graph.
 ///
 /// Object snapshots are intentionally excluded from this first reactive slice:
@@ -329,8 +370,19 @@ pub struct ReactiveProgram {
 }
 
 impl ReactiveProgram {
+    /// Compatibility entry for the migration-era normalized scene definition.
+    /// New lowering code should validate against its actual execution target through
+    /// [`ReactiveCompileTarget`] instead of reconstructing authored scene state.
     pub fn compile(
         scene: &SceneDefinition,
+        graph: &ReactiveGraphDefinition,
+    ) -> Result<Self, ReactiveError> {
+        Self::compile_for_target(scene, graph)
+    }
+
+    /// Compile one native reactive graph against the actual execution target facts.
+    pub fn compile_for_target<T: ReactiveCompileTarget + ?Sized>(
+        target: &T,
         graph: &ReactiveGraphDefinition,
     ) -> Result<Self, ReactiveError> {
         let mut signal_indices = BTreeMap::new();
@@ -409,7 +461,7 @@ impl ReactiveProgram {
             let signal_index = *signal_indices
                 .get(&binding.signal)
                 .ok_or(ReactiveError::UnknownSignal(binding.signal))?;
-            if scene.object(binding.object).is_none() {
+            if !target.contains_object(binding.object) {
                 return Err(ReactiveError::UnknownObject(binding.object));
             }
             if seen_targets.contains(&(binding.object, binding.property)) {
@@ -418,11 +470,7 @@ impl ReactiveProgram {
                     property: binding.property,
                 });
             }
-            if scene
-                .tracks()
-                .iter()
-                .any(|track| track.object == binding.object && track.property == binding.property)
-            {
+            if target.has_timeline_driver(binding.object, binding.property) {
                 return Err(ReactiveError::ConflictingDriver {
                     object: binding.object,
                     property: binding.property,
@@ -445,7 +493,7 @@ impl ReactiveProgram {
             });
         }
 
-        let analysis = build_execution_analysis(scene, graph);
+        let analysis = build_execution_analysis(target, graph);
         Ok(Self {
             signals: compiled_signals,
             signal_indices,
@@ -480,17 +528,17 @@ impl ReactiveProgram {
     }
 }
 
-fn build_execution_analysis(
-    scene: &SceneDefinition,
+fn build_execution_analysis<T: ReactiveCompileTarget + ?Sized>(
+    target: &T,
     graph: &ReactiveGraphDefinition,
 ) -> ExecutionAnalysis {
     let mut analysis = ExecutionAnalysis::default();
-    for object in scene.objects() {
-        let timeline = scene.tracks().iter().any(|track| track.object == object.id);
+    target.visit_objects(&mut |object| {
+        let timeline = target.has_timeline_activity(object);
         let reactive = graph
             .bindings
             .iter()
-            .any(|binding| binding.object == object.id);
+            .any(|binding| binding.object == object);
         let class = match (timeline, reactive) {
             (false, false) => {
                 analysis.static_objects += 1;
@@ -509,11 +557,8 @@ fn build_execution_analysis(
                 ObjectExecutionClass::TimelineAndReactive
             }
         };
-        analysis.objects.push(ObjectExecution {
-            object: object.id,
-            class,
-        });
-    }
+        analysis.objects.push(ObjectExecution { object, class });
+    });
     analysis
 }
 


### PR DESCRIPTION
## Scope

Continue A1.6 after #1062 by removing legacy `SceneDefinition` from native-reactive target validation on the canonical semantic lowering path.

## Changes

- add a narrow `ReactiveCompileTarget` query contract in `noon-core` for live object membership, exact timeline-driver conflicts, any timeline activity, and deterministic object iteration;
- keep `ReactiveProgram::compile(SceneDefinition, …)` as a compatibility wrapper but move all compiler logic into one `compile_for_target` body;
- implement the target contract for existing `CompiledScene` using stable object indices/channels/tombstones;
- make `lower_semantic_execution` validate its semantic reactive projection against its actual `CompiledScene`;
- immediately lower the validated graph into the existing `ComputeProgram`, so the canonical H2 handoff is execution-ready;
- preserve fail-atomic `SemanticExecutionIndex` publication through compute lowering;
- add semantic-only compiled-target tests without adding new `GeometryRef`/`ObjectDefinition` migration dependencies.

## Architecture

No new scene/runtime model, reactive graph, scheduler, evaluator, serializer, or patch vocabulary. The flow is:

`SemanticStore -> lower_semantic_execution -> { CompiledScene, SemanticReactiveProjection, ComputeProgram }`

The compatibility `SceneDefinition` compile entry delegates to the same compiler body; it is not a parallel lowerer.

A follow-on compatibility cleanup can migrate `SceneInstance::from_semantic` to the compiled target query path too, but this PR does not require runtime host changes.

## Validation

Exact-head architecture, dependency, Rust/Clippy, web, and browser/WebGPU gates are required before merge.

Refs #957 #969 #959