### PR TITLE
A1.6: compile canonical semantic lowering into existing VM

### DIFF
--- a/crates/noon-compile/src/semantic_lowering/entrypoint.rs
+++ b/crates/noon-compile/src/semantic_lowering/entrypoint.rs
@@ -1,4 +1,4 @@
-use noon_core::SemanticStore;
+use noon_core::{ComputeProgram, ReactiveError, ReactiveProgram, SemanticStore};
 
 use crate::CompiledScene;
 
@@ -18,6 +18,7 @@ use super::{
 pub struct SemanticExecutionLoweringOutput {
     compiled: CompiledScene,
     reactive: SemanticReactiveProjection,
+    compute: ComputeProgram,
 }
 
 impl SemanticExecutionLoweringOutput {
@@ -29,8 +30,22 @@ impl SemanticExecutionLoweringOutput {
         &self.reactive
     }
 
+    /// Existing native reactive VM program compiled against the same lowered
+    /// object/timeline execution domain as this semantic snapshot.
+    pub fn compute(&self) -> &ComputeProgram {
+        &self.compute
+    }
+
+    /// Compatibility decomposition retained while callers migrate to consuming the
+    /// complete canonical execution handoff.
     pub fn into_parts(self) -> (CompiledScene, SemanticReactiveProjection) {
         (self.compiled, self.reactive)
+    }
+
+    pub fn into_execution_parts(
+        self,
+    ) -> (CompiledScene, SemanticReactiveProjection, ComputeProgram) {
+        (self.compiled, self.reactive, self.compute)
     }
 }
 
@@ -39,6 +54,7 @@ pub enum SemanticExecutionLoweringError {
     Object(SemanticLoweringError),
     Reactive(SemanticReactiveLoweringError),
     Compiled(SemanticCompiledSceneError),
+    NativeReactive(ReactiveError),
 }
 
 impl From<SemanticLoweringError> for SemanticExecutionLoweringError {
@@ -59,6 +75,12 @@ impl From<SemanticCompiledSceneError> for SemanticExecutionLoweringError {
     }
 }
 
+impl From<ReactiveError> for SemanticExecutionLoweringError {
+    fn from(value: ReactiveError) -> Self {
+        Self::NativeReactive(value)
+    }
+}
+
 impl std::fmt::Display for SemanticExecutionLoweringError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -68,6 +90,9 @@ impl std::fmt::Display for SemanticExecutionLoweringError {
             }
             Self::Compiled(error) => {
                 write!(formatter, "compiled execution lowering failed: {error}")
+            }
+            Self::NativeReactive(error) => {
+                write!(formatter, "native reactive program compilation failed: {error}")
             }
         }
     }
@@ -79,8 +104,9 @@ impl std::error::Error for SemanticExecutionLoweringError {}
 ///
 /// Object values and active native-reactive bindings are lowered from the same
 /// semantic snapshot. The identity index is staged and published only after all
-/// downstream lowering succeeds, so unsupported compiled payloads or reactive
-/// channels cannot leave a partially admitted semantic-to-execution mapping.
+/// downstream lowering succeeds, so unsupported compiled payloads, reactive
+/// channels, or VM compilation cannot leave a partially admitted
+/// semantic-to-execution mapping.
 ///
 /// Authored animation declarations remain semantic intent until an explicit
 /// animation activation/composition root is supplied to its dedicated lowering
@@ -94,16 +120,34 @@ pub fn lower_semantic_execution(
     let projection = staged_index.lower_scene(store)?;
     let reactive = lower_semantic_reactive_projection(store, &projection)?;
     let compiled = CompiledScene::from_semantic_projection_after_reactive_lowering(&projection)?;
+    let compute = ReactiveProgram::compile_for_execution_domain(
+        compiled
+            .objects()
+            .iter()
+            .filter(|object| object.live)
+            .map(|object| object.id),
+        compiled.tracks_iter().filter_map(|track| {
+            compiled
+                .object_id_at_slot(track.object_index)
+                .map(|object| (object, track.property))
+        }),
+        reactive.graph(),
+    )?
+    .into_compute()?;
 
     *index = staged_index;
-    Ok(SemanticExecutionLoweringOutput { compiled, reactive })
+    Ok(SemanticExecutionLoweringOutput {
+        compiled,
+        reactive,
+        compute,
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use noon_core::{
-        Property, SemanticObjectProperty, SemanticObjectState, SemanticStore, StoredGeometry,
-        TextResourceHandle, TextResourceId,
+        Property, ReactiveValue, SemanticObjectProperty, SemanticObjectState, SemanticStore,
+        StoredGeometry, TextResourceHandle, TextResourceId,
     };
 
     use super::*;
@@ -113,7 +157,7 @@ mod tests {
     }
 
     #[test]
-    fn canonical_entry_lowers_object_values_and_reactive_bindings_together() {
+    fn canonical_entry_lowers_object_values_and_reactive_bindings_into_existing_vm() {
         let mut store = SemanticStore::new();
         let signal = store.insert_semantic_input_signal(0.4_f64).unwrap();
         let object = store.insert_semantic_object(circle(2.0));
@@ -125,10 +169,12 @@ mod tests {
         let mut index = SemanticExecutionIndex::new();
         let lowered = lower_semantic_execution(&store, &mut index).unwrap();
         let execution_id = index.execution_object_id(object).unwrap();
+        let execution_signal = lowered.reactive().execution_signal_id(signal).unwrap();
 
         assert_eq!(lowered.compiled().objects().len(), 1);
         assert_eq!(lowered.compiled().objects()[0].id, execution_id);
         assert_eq!(lowered.reactive().signal_count(), 1);
+        assert_eq!(lowered.compute().signal_count(), 1);
         assert_eq!(
             lowered.reactive().graph().bindings()[0].object,
             execution_id
@@ -139,7 +185,18 @@ mod tests {
         );
         assert_eq!(
             lowered.reactive().graph().bindings()[0].signal,
-            lowered.reactive().execution_signal_id(signal).unwrap()
+            execution_signal
+        );
+
+        let mut state = lowered.compute().clone().instantiate();
+        let update = state.set_input(execution_signal, 0.75_f32).unwrap();
+        assert_eq!(update.affected_objects(), vec![execution_id]);
+        assert_eq!(update.property_changes().len(), 1);
+        assert_eq!(update.property_changes()[0].object, execution_id);
+        assert_eq!(update.property_changes()[0].property, Property::Opacity);
+        assert_eq!(
+            update.property_changes()[0].value,
+            ReactiveValue::Scalar(0.75)
         );
     }
 


### PR DESCRIPTION
## Scope

Continue A1.6 after #1062 and #1063 by feeding the canonical semantic reactive projection directly into Noon's existing `ReactiveProgram` / `ComputeProgram` path.

## Changes

- extend `SemanticExecutionLoweringOutput` with the existing native `ComputeProgram` execution form;
- derive the live execution-object domain and timeline-driver keys from the same lowered `CompiledScene` snapshot;
- compile the existing `SemanticReactiveProjection` through #1063's `ReactiveProgram::compile_for_execution_domain(...)` API and lower it into the existing compute VM;
- publish the staged semantic-to-execution identity index only after reactive program/VM compilation succeeds;
- retain the previous two-part decomposition for compatibility while exposing the complete three-part execution handoff;
- add focused coverage proving a semantic input update flows through the existing compute VM to the expected compiled object/property.

## Architecture

This adds no compiler, evaluator, graph, or runtime model. `SemanticReactiveProjection` still lowers to the existing `ReactiveGraphDefinition`; #1063's `ReactiveProgram` remains the single validated dependency/dirty-closure compiler; `ComputeProgram` remains the native runtime VM. This slice only connects the canonical semantic lowering entry to those existing authorities.

## Validation

The focused canonical-lowering test instantiates the produced `ComputeProgram`, updates the execution signal, and verifies the resulting opacity invalidation targets the same stable compiled object identity. Exact-head architecture, layer, Rust, web/WASM, and browser gates remain required before merge.

Supersedes closed draft #1064 after its branch was cleanly force-restacked onto merged #1063.

Refs #957 #959 #1060 #1062 #1063.