### PR TITLE
A1.6: validate runtime reactivity against compiled execution domain

### DIFF
--- a/crates/noon-runtime/src/reactive/runtime.rs
+++ b/crates/noon-runtime/src/reactive/runtime.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use noon_compile::{CompileError, CompiledScene};
 use noon_core::{
     ComputeProgram, ComputeState, ObjectId, Property, ReactiveBinding, ReactiveError,
-    ReactiveEvaluationStats, ReactiveValue, SemanticScene, SignalId,
+    ReactiveEvaluationStats, ReactiveProgram, ReactiveValue, SemanticScene, SignalId,
 };
 
 use crate::{FrameState, SceneInstance};
@@ -78,7 +78,7 @@ impl ReactiveRuntime {
         for binding in bindings {
             let object_index = compiled
                 .object_index(binding.object)
-                .expect("reactive graph was validated against the compiled definition")
+                .expect("reactive graph was validated against the compiled execution domain")
                 as usize;
             let target_index = targets.len();
             targets.push(ReactiveTarget {
@@ -152,7 +152,21 @@ impl SceneInstance {
     /// the timeline, or scan unrelated objects.
     pub fn from_semantic(scene: &SemanticScene) -> Result<Self, SceneBuildError> {
         let compiled = CompiledScene::compile(scene.definition())?;
-        let program = scene.compile_reactive()?.into_compute()?;
+        let program = ReactiveProgram::compile_for_execution_domain(
+            compiled
+                .objects()
+                .iter()
+                .filter(|object| object.live)
+                .map(|object| object.id),
+            compiled.tracks_iter().map(|track| {
+                let object = compiled
+                    .object_id_at_slot(track.object_index)
+                    .expect("compiled timeline track must reference a live object slot");
+                (object, track.property)
+            }),
+            scene.reactive(),
+        )?
+        .into_compute()?;
         let reactive = ReactiveRuntime::new(&compiled, scene.reactive().bindings(), program);
         let mut instance = Self::new(compiled);
         instance.reactive = Some(reactive);


### PR DESCRIPTION
## Scope

Continue A1.6 after #1066 by aligning the migration-era `SceneInstance::from_semantic` constructor with the same execution-domain reactive compiler now used by canonical semantic lowering.

## Changes

- keep the existing legacy `SemanticScene -> CompiledScene` compatibility constructor;
- replace `scene.compile_reactive()` with `ReactiveProgram::compile_for_execution_domain(...)` over the already-built `CompiledScene`;
- derive live object IDs from compiled object slots and timeline driver keys from compiled tracks;
- lower the resulting program into the existing `ComputeProgram` exactly as before;
- update the runtime invariant message to state that bindings were validated against the compiled execution domain.

## Architecture

No new runtime, scene, graph, scheduler, evaluator, identity map, or patch vocabulary is introduced. This only removes an authored-definition/compiled-target mismatch in a migration compatibility path: the reactive program is now validated against the same compiled object indices that `ReactiveRuntime::new` immediately resolves.

The canonical `SemanticStore -> {CompiledScene, SemanticReactiveProjection, ComputeProgram}` path from #1066 remains authoritative. This PR does not make `SemanticScene` or `SceneDefinition` more authoritative; it shrinks their compatibility role.

## Validation

Existing runtime reactive tests exercise initialization, dirty updates, seek reapplication, large static-object locality, and remove/recreate rebinding. Exact-head architecture, layer dependency, Rust/Clippy, web/WASM, browser, and WebGPU gates are required before merge.

Refs #957 #959 #969 #1063 #1066.