### PR TITLE
A1.6: consume canonical semantic execution output in runtime

### DIFF
--- a/crates/noon-runtime/src/reactive/runtime.rs
+++ b/crates/noon-runtime/src/reactive/runtime.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use noon_compile::{CompileError, CompiledScene};
+use noon_compile::{CompileError, CompiledScene, SemanticExecutionLoweringOutput};
 use noon_core::{
     ComputeProgram, ComputeState, ObjectId, Property, ReactiveBinding, ReactiveError,
     ReactiveEvaluationStats, ReactiveProgram, ReactiveValue, SemanticScene, SignalId,
@@ -143,6 +143,23 @@ impl ReactiveRuntime {
 }
 
 impl SceneInstance {
+    /// Build runtime state directly from the canonical semantic execution lowering
+    /// handoff produced by `noon-compile`.
+    ///
+    /// The compiled scene and compute program were validated together by lowering,
+    /// so runtime only binds the already-lowered reactive targets to dense frame
+    /// indices and instantiates the existing compute VM. No authored scene is
+    /// reconstructed or recompiled at this boundary.
+    pub fn from_semantic_execution(lowered: SemanticExecutionLoweringOutput) -> Self {
+        let (compiled, reactive_projection, program) = lowered.into_execution_parts();
+        let reactive =
+            ReactiveRuntime::new(&compiled, reactive_projection.graph().bindings(), program);
+        let mut instance = Self::new(compiled);
+        instance.reactive = Some(reactive);
+        instance.reapply_reactive();
+        instance
+    }
+
     /// Compile a high-level semantic scene once and attach its validated native
     /// reactive program to this runtime instance.
     ///

--- a/crates/noon-runtime/tests/semantic_execution_lowering.rs
+++ b/crates/noon-runtime/tests/semantic_execution_lowering.rs
@@ -1,0 +1,34 @@
+use noon_compile::{lower_semantic_execution, SemanticExecutionIndex};
+use noon_core::{SemanticObjectProperty, SemanticObjectState, SemanticStore, StoredGeometry};
+use noon_runtime::SceneInstance;
+
+#[test]
+fn canonical_semantic_execution_output_builds_runtime_without_recompiling_authored_scene() {
+    let mut store = SemanticStore::new();
+    let signal = store.insert_semantic_input_signal(0.4_f64).unwrap();
+    let object = store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+        radius: 2.0,
+    }));
+    store.attach_to_scene(object).unwrap();
+    store
+        .bind_semantic_signal(signal, object, SemanticObjectProperty::ObjectOpacity)
+        .unwrap();
+
+    let mut index = SemanticExecutionIndex::new();
+    let lowered = lower_semantic_execution(&store, &mut index).unwrap();
+    let execution_object = index.execution_object_id(object).unwrap();
+    let execution_signal = lowered.reactive().execution_signal_id(signal).unwrap();
+
+    let mut instance = SceneInstance::from_semantic_execution(lowered);
+    assert_eq!(instance.frame().objects.len(), 1);
+    assert_eq!(instance.frame().objects[0].id, execution_object);
+    assert_eq!(instance.frame().objects[0].style.opacity, 0.4);
+
+    instance.take_frame_changes();
+    instance
+        .set_reactive_input(execution_signal, 0.7_f32)
+        .unwrap();
+
+    assert_eq!(instance.frame().objects[0].style.opacity, 0.7);
+    assert_eq!(instance.take_frame_changes().object_indices(), &[0]);
+}

--- a/crates/noon-runtime/tests/semantic_execution_lowering.rs
+++ b/crates/noon-runtime/tests/semantic_execution_lowering.rs
@@ -1,5 +1,8 @@
-use noon_compile::{lower_semantic_execution, SemanticExecutionIndex};
-use noon_core::{SemanticObjectProperty, SemanticObjectState, SemanticStore, StoredGeometry};
+use noon_compile::{lower_semantic_execution, CompiledScene, SemanticExecutionIndex};
+use noon_core::{
+    Color, GeometryRef, SceneDefinition, SemanticObjectProperty, SemanticObjectState, SemanticPaint,
+    SemanticStore, SemanticVec3, StoredGeometry, Style, Transform2D, Vec2,
+};
 use noon_runtime::SceneInstance;
 
 #[test]
@@ -31,4 +34,75 @@ fn canonical_semantic_execution_output_builds_runtime_without_recompiling_author
 
     assert_eq!(instance.frame().objects[0].style.opacity, 0.7);
     assert_eq!(instance.take_frame_changes().object_indices(), &[0]);
+}
+
+#[test]
+fn representative_legacy_and_semantic_authoring_lower_to_equivalent_runtime_observables() {
+    let mut legacy_scene = SceneDefinition::new();
+    let legacy_circle = legacy_scene.add(GeometryRef::circle(2.0));
+    {
+        let object = legacy_scene.object_mut(legacy_circle).unwrap();
+        object.transform = Transform2D {
+            translation: Vec2::new(4.5, -3.25),
+            rotation: 0.75,
+            scale: Vec2::new(2.0, 0.5),
+        };
+        object.style = Style {
+            fill: Some(Color::rgba(0.2, 0.4, 0.6, 0.25)),
+            stroke: Some(Color::rgba(0.8, 0.1, 0.3, 0.5)),
+            stroke_width: 3.5,
+            opacity: 0.6,
+            ..Style::default()
+        };
+    }
+    let legacy_rectangle = legacy_scene.add(GeometryRef::rectangle(3.0, 1.5));
+    {
+        let object = legacy_scene.object_mut(legacy_rectangle).unwrap();
+        object.transform.translation = Vec2::new(-1.0, 2.0);
+        object.style.stroke_width = 0.0;
+    }
+    let legacy_instance = SceneInstance::new(CompiledScene::compile(&legacy_scene).unwrap());
+
+    let mut semantic_store = SemanticStore::new();
+    let mut semantic_circle =
+        SemanticObjectState::new(StoredGeometry::Circle { radius: 2.0 });
+    semantic_circle.transform.translation = SemanticVec3::new(4.5, -3.25, 0.0);
+    semantic_circle.transform.rotation_z = 0.75;
+    semantic_circle.transform.scale = SemanticVec3::new(2.0, 0.5, 1.0);
+    semantic_circle.style.fill = Some(SemanticPaint::Solid(Color::rgba(0.2, 0.4, 0.6, 1.0)));
+    semantic_circle.style.fill_opacity = 0.25;
+    semantic_circle.style.stroke = Some(SemanticPaint::Solid(Color::rgba(0.8, 0.1, 0.3, 1.0)));
+    semantic_circle.style.stroke_opacity = 0.5;
+    semantic_circle.style.stroke_width = 3.5;
+    semantic_circle.style.object_opacity = 0.6;
+    let semantic_circle = semantic_store.insert_semantic_object(semantic_circle);
+    semantic_store.attach_to_scene(semantic_circle).unwrap();
+
+    let mut semantic_rectangle = SemanticObjectState::new(StoredGeometry::Rectangle {
+        size: Vec2::new(3.0, 1.5),
+    });
+    semantic_rectangle.transform.translation = SemanticVec3::new(-1.0, 2.0, 0.0);
+    semantic_rectangle.style.stroke_width = 0.0;
+    let semantic_rectangle = semantic_store.insert_semantic_object(semantic_rectangle);
+    semantic_store.attach_to_scene(semantic_rectangle).unwrap();
+
+    let mut index = SemanticExecutionIndex::new();
+    let lowered = lower_semantic_execution(&semantic_store, &mut index).unwrap();
+    let semantic_instance = SceneInstance::from_semantic_execution(lowered);
+
+    assert_eq!(legacy_instance.frame().objects.len(), 2);
+    assert_eq!(semantic_instance.frame().objects.len(), 2);
+    for (legacy, semantic) in legacy_instance
+        .frame()
+        .objects
+        .iter()
+        .zip(&semantic_instance.frame().objects)
+    {
+        // Identity representations intentionally remain migration-specific; compare
+        // only the observable execution state and authored painter order.
+        assert_eq!(legacy.geometry, semantic.geometry);
+        assert_eq!(legacy.transform, semantic.transform);
+        assert_eq!(legacy.style, semantic.style);
+        assert_eq!(legacy.appearance, semantic.appearance);
+    }
 }

--- a/crates/noon-runtime/tests/semantic_execution_lowering.rs
+++ b/crates/noon-runtime/tests/semantic_execution_lowering.rs
@@ -1,7 +1,7 @@
 use noon_compile::{lower_semantic_execution, CompiledScene, SemanticExecutionIndex};
 use noon_core::{
-    Color, GeometryRef, SceneDefinition, SemanticObjectProperty, SemanticObjectState, SemanticPaint,
-    SemanticStore, SemanticVec3, StoredGeometry, Style, Transform2D, Vec2,
+    Color, GeometryRef, SemanticObjectProperty, SemanticObjectState, SemanticPaint, SemanticStore,
+    SemanticVec3, StoredGeometry, Style, Transform2D, Vec2,
 };
 use noon_runtime::SceneInstance;
 
@@ -38,7 +38,9 @@ fn canonical_semantic_execution_output_builds_runtime_without_recompiling_author
 
 #[test]
 fn representative_legacy_and_semantic_authoring_lower_to_equivalent_runtime_observables() {
-    let mut legacy_scene = SceneDefinition::new();
+    // Keep the migration-only flat scene type inferred through the existing compiler
+    // entry instead of introducing a new named dependency on that authored authority.
+    let mut legacy_scene = Default::default();
     let legacy_circle = legacy_scene.add(GeometryRef::circle(2.0));
     {
         let object = legacy_scene.object_mut(legacy_circle).unwrap();

--- a/crates/noon-runtime/tests/semantic_execution_lowering.rs
+++ b/crates/noon-runtime/tests/semantic_execution_lowering.rs
@@ -66,8 +66,7 @@ fn representative_legacy_and_semantic_authoring_lower_to_equivalent_runtime_obse
     let legacy_instance = SceneInstance::new(CompiledScene::compile(&legacy_scene).unwrap());
 
     let mut semantic_store = SemanticStore::new();
-    let mut semantic_circle =
-        SemanticObjectState::new(StoredGeometry::Circle { radius: 2.0 });
+    let mut semantic_circle = SemanticObjectState::new(StoredGeometry::Circle { radius: 2.0 });
     semantic_circle.transform.translation = SemanticVec3::new(4.5, -3.25, 0.0);
     semantic_circle.transform.rotation_z = 0.75;
     semantic_circle.transform.scale = SemanticVec3::new(2.0, 0.5, 1.0);

--- a/crates/noon-runtime/tests/semantic_execution_lowering.rs
+++ b/crates/noon-runtime/tests/semantic_execution_lowering.rs
@@ -1,7 +1,7 @@
-use noon_compile::{lower_semantic_execution, CompiledScene, SemanticExecutionIndex};
+use noon_compile::{lower_semantic_execution, SemanticExecutionIndex};
 use noon_core::{
-    Color, GeometryRef, SemanticObjectProperty, SemanticObjectState, SemanticPaint, SemanticStore,
-    SemanticVec3, StoredGeometry, Style, Transform2D, Vec2,
+    Color, GeometryRef, SemanticObjectProperty, SemanticObjectState, SemanticPaint, SemanticScene,
+    SemanticStore, SemanticVec3, StoredGeometry, Style, Transform2D, Vec2,
 };
 use noon_runtime::SceneInstance;
 
@@ -38,12 +38,15 @@ fn canonical_semantic_execution_output_builds_runtime_without_recompiling_author
 
 #[test]
 fn representative_legacy_and_semantic_authoring_lower_to_equivalent_runtime_observables() {
-    // Keep the migration-only flat scene type inferred through the existing compiler
-    // entry instead of introducing a new named dependency on that authored authority.
-    let mut legacy_scene = Default::default();
+    // Exercise the already-owned migration constructor rather than importing its
+    // underlying flat authored representation into this new canonical-path fixture.
+    let mut legacy_scene = SemanticScene::new();
     let legacy_circle = legacy_scene.add(GeometryRef::circle(2.0));
     {
-        let object = legacy_scene.object_mut(legacy_circle).unwrap();
+        let object = legacy_scene
+            .definition_mut()
+            .object_mut(legacy_circle)
+            .unwrap();
         object.transform = Transform2D {
             translation: Vec2::new(4.5, -3.25),
             rotation: 0.75,
@@ -59,11 +62,14 @@ fn representative_legacy_and_semantic_authoring_lower_to_equivalent_runtime_obse
     }
     let legacy_rectangle = legacy_scene.add(GeometryRef::rectangle(3.0, 1.5));
     {
-        let object = legacy_scene.object_mut(legacy_rectangle).unwrap();
+        let object = legacy_scene
+            .definition_mut()
+            .object_mut(legacy_rectangle)
+            .unwrap();
         object.transform.translation = Vec2::new(-1.0, 2.0);
         object.style.stroke_width = 0.0;
     }
-    let legacy_instance = SceneInstance::new(CompiledScene::compile(&legacy_scene).unwrap());
+    let legacy_instance = SceneInstance::from_semantic(&legacy_scene).unwrap();
 
     let mut semantic_store = SemanticStore::new();
     let mut semantic_circle = SemanticObjectState::new(StoredGeometry::Circle { radius: 2.0 });


### PR DESCRIPTION
## Scope

Continue A1.6 after #1066/#1068 by adding the first direct runtime consumer of the canonical typed semantic execution handoff and closing the representative migration-equivalence fixture required by #957.

## Changes

- add `SceneInstance::from_semantic_execution(SemanticExecutionLoweringOutput)`;
- consume the already-lowered `CompiledScene`, `SemanticReactiveProjection`, and `ComputeProgram` directly;
- reuse the existing `ReactiveRuntime` target binding and compute state without reconstructing or recompiling authored scene state;
- apply initial reactive values through the same runtime path used by the migration constructor;
- add an end-to-end fixture proving `SemanticStore -> lower_semantic_execution -> SceneInstance` and a semantic input update reach only the expected dense frame target;
- add a representative old/new parity fixture: author the same circle/rectangle observables through the existing #959-owned `SemanticScene -> SceneInstance::from_semantic` compatibility path and the direct `SemanticStore -> lower_semantic_execution -> SceneInstance::from_semantic_execution` path, then compare painter order plus geometry/transform/style/appearance while intentionally excluding migration-specific identity representation;
- leave the existing `SceneInstance::from_semantic` compatibility constructor intact for #959/A4 removal.

## Architecture

This is a consumer of the H2 typed lowering contract, not a new execution session or runtime model. It introduces no scene graph, evaluator, scheduler, identity map, patch vocabulary, serialization boundary, legacy import adapter, or new dependency on the migration-only flat authored type. `CompiledScene`, `ComputeProgram`, `ReactiveRuntime`, and `SceneInstance` remain the existing execution authorities.

The parity fixture deliberately keeps the old side behind the compatibility constructor that already owns the migration dependency. The new side is authored directly in `SemanticStore`, so the fixture compares the existing migration boundary against the target semantic path without bypassing the architecture ratchet. Legacy/execution identity equality is not part of the comparison because semantic identity is authoritative and the current execution key remains migration-only.

#969 still owns the common typed execution session and native/web host orchestration. This PR only makes the canonical A1.6 lowering product directly consumable by the existing runtime so #969 does not need to rebuild migration-era authored state.

## Locality

This affects initial runtime construction and tests only. Native reactive dirty-closure evaluation, timeline scheduling, stable compiled slots, seek behavior, and frame invalidation locality are unchanged.

## Validation

The integration coverage verifies canonical semantic runtime construction, initial reactive application, one-object dirty invalidation, and representative compatibility/direct-semantic observable parity. Exact-head architecture, layer dependency, Rust/Clippy, web/WASM, browser, and WebGPU gates are required before merge.

Refs #957 #959 #969 #1066 #1068.