### PR TITLE
A1.6: activate semantic animations through execution session

### DIFF
--- a/crates/noon-runtime/src/execution_slots/mod.rs
+++ b/crates/noon-runtime/src/execution_slots/mod.rs
@@ -1,4 +1,5 @@
 mod base;
+mod runtime_transaction;
 mod semantic_membership;
 
 pub use base::*;

--- a/crates/noon-runtime/src/execution_slots/runtime_transaction.rs
+++ b/crates/noon-runtime/src/execution_slots/runtime_transaction.rs
@@ -1,0 +1,97 @@
+use noon_compile::CompilePatchError;
+use noon_core::{MutationTransaction, ObjectId, Transform2D};
+
+use crate::{FrameState, SceneInstance};
+
+impl SceneInstance {
+    /// Resolve one live execution object to its current effective transform.
+    ///
+    /// The stable compiled object index is used to address the corresponding frame
+    /// slot directly; callers do not scan renderer-facing frame objects by identity.
+    pub fn effective_transform(&self, id: ObjectId) -> Option<Transform2D> {
+        let object_index = self.compiled.object_index(id)? as usize;
+        self.frame
+            .objects
+            .get(object_index)
+            .map(|object| object.transform)
+    }
+
+    /// Publish one already-authored mutation transaction atomically into the runtime.
+    ///
+    /// The compiled scene preflights the complete transaction against staged
+    /// identity/channel metadata before any frame-visible mutation occurs. Once that
+    /// succeeds, each existing patch application is infallible by the compiled
+    /// preflight contract, so no partially applied transaction can escape this call.
+    pub fn apply_transaction(
+        &mut self,
+        transaction: &MutationTransaction,
+    ) -> Result<&FrameState, CompilePatchError> {
+        self.compiled.preflight_transaction(transaction)?;
+        for patch in transaction.mutations() {
+            self.apply_patch(patch)
+                .expect("runtime transaction was fully preflighted");
+        }
+        Ok(&self.frame)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use noon_compile::CompiledScene;
+    use noon_core::{
+        GeometryRef, SceneDefinition, ScenePatch, Style, Transform2D, Vec2,
+    };
+
+    use super::*;
+
+    #[test]
+    fn effective_transform_uses_the_stable_compiled_object_slot() {
+        let mut scene = SceneDefinition::new();
+        let object = scene.add(GeometryRef::circle(1.0));
+        let mut instance = SceneInstance::new(CompiledScene::compile(&scene).unwrap());
+        let transform = Transform2D {
+            translation: Vec2::new(3.0, -2.0),
+            rotation: 0.25,
+            scale: Vec2::new(2.0, 0.5),
+        };
+
+        instance
+            .apply_patch(&ScenePatch::SetTransform { object, transform })
+            .unwrap();
+
+        assert_eq!(instance.effective_transform(object), Some(transform));
+        assert_eq!(instance.effective_transform(ObjectId::new(999)), None);
+    }
+
+    #[test]
+    fn transaction_preflight_rejects_late_failure_before_runtime_publication() {
+        let mut scene = SceneDefinition::new();
+        let object = scene.add(GeometryRef::circle(1.0));
+        let mut instance = SceneInstance::new(CompiledScene::compile(&scene).unwrap());
+        let before = instance.frame().clone();
+        let missing = ObjectId::new(999);
+        let transaction = MutationTransaction::from_mutations([
+            ScenePatch::SetTransform {
+                object,
+                transform: Transform2D {
+                    translation: Vec2::new(4.0, 0.0),
+                    ..Transform2D::IDENTITY
+                },
+            },
+            ScenePatch::SetStyle {
+                object: missing,
+                style: Style::default(),
+            },
+        ]);
+
+        assert_eq!(
+            instance.apply_transaction(&transaction).unwrap_err(),
+            CompilePatchError::UnknownObject(missing)
+        );
+        assert_eq!(instance.frame(), &before);
+        assert_eq!(
+            instance.effective_transform(object),
+            Some(Transform2D::IDENTITY)
+        );
+    }
+}

--- a/crates/noon-runtime/src/execution_slots/runtime_transaction.rs
+++ b/crates/noon-runtime/src/execution_slots/runtime_transaction.rs
@@ -37,18 +37,30 @@ impl SceneInstance {
 
 #[cfg(test)]
 mod tests {
-    use noon_compile::CompiledScene;
+    use noon_compile::{lower_semantic_execution, SemanticExecutionIndex};
     use noon_core::{
-        GeometryRef, SceneDefinition, ScenePatch, Style, Transform2D, Vec2,
+        ScenePatch, SemanticObjectState, SemanticStore, StoredGeometry, Style, Transform2D, Vec2,
     };
 
     use super::*;
 
+    fn semantic_instance() -> (SceneInstance, ObjectId) {
+        let mut store = SemanticStore::new();
+        let semantic_object =
+            store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+                radius: 1.0,
+            }));
+        store.attach_to_scene(semantic_object).unwrap();
+
+        let mut index = SemanticExecutionIndex::new();
+        let lowered = lower_semantic_execution(&store, &mut index).unwrap();
+        let object = index.execution_object_id(semantic_object).unwrap();
+        (SceneInstance::from_semantic_execution(lowered), object)
+    }
+
     #[test]
     fn effective_transform_uses_the_stable_compiled_object_slot() {
-        let mut scene = SceneDefinition::new();
-        let object = scene.add(GeometryRef::circle(1.0));
-        let mut instance = SceneInstance::new(CompiledScene::compile(&scene).unwrap());
+        let (mut instance, object) = semantic_instance();
         let transform = Transform2D {
             translation: Vec2::new(3.0, -2.0),
             rotation: 0.25,
@@ -65,9 +77,7 @@ mod tests {
 
     #[test]
     fn transaction_preflight_rejects_late_failure_before_runtime_publication() {
-        let mut scene = SceneDefinition::new();
-        let object = scene.add(GeometryRef::circle(1.0));
-        let mut instance = SceneInstance::new(CompiledScene::compile(&scene).unwrap());
+        let (mut instance, object) = semantic_instance();
         let before = instance.frame().clone();
         let missing = ObjectId::new(999);
         let transaction = MutationTransaction::from_mutations([

--- a/crates/noon/src/execution_session.rs
+++ b/crates/noon/src/execution_session.rs
@@ -51,10 +51,19 @@ pub enum ExecutionSessionAnimationError {
 impl std::fmt::Display for ExecutionSessionAnimationError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Schedule(error) => write!(formatter, "semantic animation scheduling failed: {error}"),
-            Self::Payload(error) => write!(formatter, "semantic animation payload lowering failed: {error}"),
-            Self::Publication(error) => write!(formatter, "semantic animation publication failed: {error}"),
-            Self::TrackIdExhausted => formatter.write_str("execution animation track ID space exhausted"),
+            Self::Schedule(error) => {
+                write!(formatter, "semantic animation scheduling failed: {error}")
+            }
+            Self::Payload(error) => write!(
+                formatter,
+                "semantic animation payload lowering failed: {error}"
+            ),
+            Self::Publication(error) => {
+                write!(formatter, "semantic animation publication failed: {error}")
+            }
+            Self::TrackIdExhausted => {
+                formatter.write_str("execution animation track ID space exhausted")
+            }
         }
     }
 }

--- a/crates/noon/src/execution_session.rs
+++ b/crates/noon/src/execution_session.rs
@@ -1,8 +1,13 @@
 use noon_compile::{
-    lower_semantic_execution, SemanticExecutionIndex, SemanticExecutionLoweringError,
+    lower_semantic_affine_animation_tracks, lower_semantic_animation_schedule,
+    lower_semantic_execution, CompilePatchError, SemanticAffineAnimationTrackError,
+    SemanticAnimationScheduleError, SemanticExecutionIndex, SemanticExecutionLoweringError,
     SemanticReactiveProjection,
 };
-use noon_core::{ObjectId, ReactiveError, ReactiveValue, SemanticNodeId, SemanticStore};
+use noon_core::{
+    AnimationOptions, MutationTransaction, ObjectId, ReactiveError, ReactiveValue, ScenePatch,
+    SemanticNodeId, SemanticStore, TrackId,
+};
 use noon_runtime::{EvaluationError, FrameChanges, FrameState, SceneInstance};
 
 /// Error produced when a semantic reactive input cannot be applied to this execution session.
@@ -34,6 +39,46 @@ impl From<ReactiveError> for ExecutionSessionInputError {
     }
 }
 
+/// Error produced while activating one authoritative semantic animation declaration.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ExecutionSessionAnimationError {
+    Schedule(SemanticAnimationScheduleError),
+    Payload(SemanticAffineAnimationTrackError),
+    Publication(CompilePatchError),
+    TrackIdExhausted,
+}
+
+impl std::fmt::Display for ExecutionSessionAnimationError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Schedule(error) => write!(formatter, "semantic animation scheduling failed: {error}"),
+            Self::Payload(error) => write!(formatter, "semantic animation payload lowering failed: {error}"),
+            Self::Publication(error) => write!(formatter, "semantic animation publication failed: {error}"),
+            Self::TrackIdExhausted => formatter.write_str("execution animation track ID space exhausted"),
+        }
+    }
+}
+
+impl std::error::Error for ExecutionSessionAnimationError {}
+
+impl From<SemanticAnimationScheduleError> for ExecutionSessionAnimationError {
+    fn from(value: SemanticAnimationScheduleError) -> Self {
+        Self::Schedule(value)
+    }
+}
+
+impl From<SemanticAffineAnimationTrackError> for ExecutionSessionAnimationError {
+    fn from(value: SemanticAffineAnimationTrackError) -> Self {
+        Self::Payload(value)
+    }
+}
+
+impl From<CompilePatchError> for ExecutionSessionAnimationError {
+    fn from(value: CompilePatchError) -> Self {
+        Self::Publication(value)
+    }
+}
+
 /// Thin typed orchestration from authoritative semantic state into Noon's existing runtime.
 ///
 /// The session does not own or mirror the [`SemanticStore`]. It retains only the
@@ -49,6 +94,7 @@ pub struct ExecutionSession {
     execution_index: SemanticExecutionIndex,
     reactive_projection: SemanticReactiveProjection,
     runtime: SceneInstance,
+    next_activation_track_id: Option<u64>,
 }
 
 impl ExecutionSession {
@@ -58,12 +104,19 @@ impl ExecutionSession {
     ) -> Result<Self, SemanticExecutionLoweringError> {
         let mut execution_index = SemanticExecutionIndex::new();
         let lowered = lower_semantic_execution(store, &mut execution_index)?;
+        let next_activation_track_id = lowered
+            .compiled()
+            .tracks_iter()
+            .map(|track| track.id.get())
+            .max()
+            .map_or(Some(0), |id| id.checked_add(1));
         let reactive_projection = lowered.reactive().clone();
         let runtime = SceneInstance::from_semantic_execution(lowered);
         Ok(Self {
             execution_index,
             reactive_projection,
             runtime,
+            next_activation_track_id,
         })
     }
 
@@ -92,6 +145,48 @@ impl ExecutionSession {
         self.runtime.advance_to(time)
     }
 
+    /// Activate one semantic animation root at the session's current deterministic time.
+    ///
+    /// The authoritative semantic store remains caller-owned. Scheduling reads the
+    /// current declaration, affine payload lowering captures each target's effective
+    /// runtime transform at most once, and the session attaches execution-local track
+    /// identity. All emitted tracks are then preflighted and published as one existing
+    /// [`MutationTransaction`], so a failed activation cannot expose a partial timeline.
+    pub fn activate_animation(
+        &mut self,
+        store: &SemanticStore,
+        root: SemanticNodeId,
+        play_options: AnimationOptions,
+    ) -> Result<&FrameState, ExecutionSessionAnimationError> {
+        let schedule = lower_semantic_animation_schedule(
+            store,
+            &self.execution_index,
+            root,
+            self.runtime.frame().time,
+            play_options,
+        )?;
+        let tracks = lower_semantic_affine_animation_tracks(store, &schedule, |object| {
+            self.runtime.effective_transform(object)
+        })?;
+        if tracks.is_empty() {
+            return Ok(self.runtime.frame());
+        }
+
+        let mut next_track_id = self.next_activation_track_id;
+        let mut mutations = Vec::with_capacity(tracks.len());
+        for track in tracks.tracks() {
+            let raw_id = next_track_id.ok_or(ExecutionSessionAnimationError::TrackIdExhausted)?;
+            let definition = track.with_track_id(TrackId::new(raw_id))?;
+            mutations.push(ScenePatch::AddTrack(definition));
+            next_track_id = raw_id.checked_add(1);
+        }
+
+        let transaction = MutationTransaction::from_mutations(mutations);
+        self.runtime.apply_transaction(&transaction)?;
+        self.next_activation_track_id = next_track_id;
+        Ok(self.runtime.frame())
+    }
+
     /// Apply one native-reactive input using authoritative semantic signal identity.
     ///
     /// The execution VM key remains an internal lowering detail. Current native
@@ -117,9 +212,18 @@ impl ExecutionSession {
 
 #[cfg(test)]
 mod tests {
-    use noon_core::{SemanticObjectProperty, SemanticObjectState, StoredGeometry};
+    use noon_core::{
+        AnimationOptions, RateFunction, SemanticObjectProperty, SemanticObjectState, SemanticVec3,
+        StoredGeometry, Vec2,
+    };
 
     use super::*;
+
+    fn linear_second() -> AnimationOptions {
+        AnimationOptions::new()
+            .run_time(1.0)
+            .rate_func(RateFunction::Linear)
+    }
 
     #[test]
     fn semantic_store_runs_through_typed_session_into_renderer_facing_changes() {
@@ -165,6 +269,62 @@ mod tests {
         assert_eq!(
             session.set_reactive_input(object, 1.0_f32),
             Err(ExecutionSessionInputError::UnknownSemanticSignal(object))
+        );
+    }
+
+    #[test]
+    fn chained_activation_starts_from_current_effective_affine_state() {
+        let mut store = SemanticStore::new();
+        let object =
+            store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+                radius: 1.0,
+            }));
+        store.attach_to_scene(object).unwrap();
+
+        let mut first_state = store.semantic_object_state_checked(object).unwrap().clone();
+        first_state.transform.translation = SemanticVec3::new(4.0, 0.0, 0.0);
+        first_state.transform.rotation_z = 0.5;
+        first_state.transform.scale = SemanticVec3::new(2.0, 2.0, 1.0);
+        let first_state = store.insert_semantic_object(first_state);
+        let first = store
+            .insert_semantic_transform_animation(object, first_state, AnimationOptions::new())
+            .unwrap();
+
+        let mut second_state = store.semantic_object_state_checked(object).unwrap().clone();
+        second_state.transform.translation = SemanticVec3::new(10.0, 0.0, 0.0);
+        second_state.transform.rotation_z = 1.5;
+        second_state.transform.scale = SemanticVec3::new(4.0, 1.0, 1.0);
+        let second_state = store.insert_semantic_object(second_state);
+        let second = store
+            .insert_semantic_transform_animation(object, second_state, AnimationOptions::new())
+            .unwrap();
+
+        let mut session = ExecutionSession::from_semantic_store(&store).unwrap();
+        session
+            .activate_animation(&store, first, linear_second())
+            .unwrap();
+        session.seek(1.0).unwrap();
+        assert_eq!(
+            session.frame().objects[0].transform,
+            noon_core::Transform2D {
+                translation: Vec2::new(4.0, 0.0),
+                rotation: 0.5,
+                scale: Vec2::new(2.0, 2.0),
+            }
+        );
+
+        session
+            .activate_animation(&store, second, linear_second())
+            .unwrap();
+        session.seek(1.5).unwrap();
+
+        assert_eq!(
+            session.frame().objects[0].transform,
+            noon_core::Transform2D {
+                translation: Vec2::new(7.0, 0.0),
+                rotation: 1.0,
+                scale: Vec2::new(3.0, 1.5),
+            }
         );
     }
 }


### PR DESCRIPTION
## Scope

Continue #969/#957 A1.6 after #1074 by connecting the canonical semantic animation schedule/payload lowering path to the existing `ExecutionSession` and `SceneInstance` runtime.

This is the activation/publication slice only. It introduces no animation graph, scheduler, evaluator, scene model, transport, or new runtime authority.

## Changes

- extend `ExecutionSession` with `activate_animation(&SemanticStore, root, play_options)` at the session's current deterministic time;
- resolve the root through the existing `lower_semantic_animation_schedule(...)` path;
- capture activation-time effective target transforms from the live `SceneInstance` through an indexed `ObjectId -> compiled slot -> frame slot` accessor rather than scanning renderer-facing frame objects;
- lower through #1074's single canonical `lower_semantic_affine_animation_tracks(...)` payload path;
- keep execution `TrackId` ownership in the session, seeded after any initially compiled timeline IDs and advanced only after successful publication;
- attach IDs through the existing validated `with_track_id()` boundary;
- publish all resulting existing `ScenePatch::AddTrack` mutations as one `MutationTransaction`;
- add `SceneInstance::apply_transaction(...)` backed by the existing `CompiledScene::preflight_transaction(...)`, so a late compiled failure cannot expose a partially applied multi-channel activation;
- keep the session's raw runtime/patch authority private;
- add focused regressions for indexed effective-transform capture, fail-before-publication transaction behavior, and chained affine activation that proves the second animation starts from live effective state rather than authored base state.

## Architecture

The path remains:

`SemanticStore -> semantic schedule -> canonical affine payload lowering -> validated TrackDefinition -> MutationTransaction/ScenePatch -> CompiledScene/SceneInstance -> FrameState`

`ExecutionSession` is the orchestration barrier. It does not own/mirror semantic state and does not expose mutable `SceneInstance` or raw patches to hosts. Runtime transaction publication reuses the existing compiled preflight metadata path and existing per-patch runtime machinery rather than staging/cloning a second scene.

Unsupported content/style/painter/depth/lifecycle and unresolved reactive/same-property composition semantics remain fail-closed in #1074's payload lowerer.

## Locality

- effective-state lookup uses the existing compiled object index plus direct frame-slot access;
- semantic scheduling/payload work remains proportional to the activated composition;
- transaction preflight uses existing compact identity/channel metadata and does not clone scene payloads;
- no unrelated frame scan or second execution identity map is introduced.

## Validation

Required before merge: architecture/layer ratchets, rustfmt, Clippy/Rust tests, web/WASM, deterministic playback, Manim-style authoring, and primary WebGPU gates.

Refs #969 #957 #1070 #1071 #1074.