### PR TITLE
A2/A6: add direct native Rust viewport host

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/noon-compile",
     "crates/noon-runtime",
     "crates/noon-render-wgpu",
+    "crates/noon-native",
     "crates/noon-web",
     "crates/noon-typst",
     "crates/noon-text-native",

--- a/crates/noon-native/Cargo.toml
+++ b/crates/noon-native/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "noon-native"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+description = "Native window host for typed Noon execution sessions"
+
+[dependencies]
+noon = { path = "../noon" }
+noon-core = { path = "../noon-core" }
+noon-render-wgpu = { path = "../noon-render-wgpu", default-features = false, features = ["native"] }
+pollster = "0.4"
+wgpu = { version = "29.0.3", default-features = false, features = ["std"] }
+winit = "0.30.13"

--- a/crates/noon-native/examples/direct_semantic.rs
+++ b/crates/noon-native/examples/direct_semantic.rs
@@ -1,0 +1,14 @@
+use noon::ExecutionSession;
+use noon_core::{SemanticObjectState, SemanticStore, StoredGeometry};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut store = SemanticStore::new();
+    let circle = store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+        radius: 1.5,
+    }));
+    store.attach_to_scene(circle)?;
+
+    let session = ExecutionSession::from_semantic_store(&store)?;
+    noon_native::run(session)?;
+    Ok(())
+}

--- a/crates/noon-native/src/lib.rs
+++ b/crates/noon-native/src/lib.rs
@@ -1,0 +1,395 @@
+//! Native window lifecycle for Noon's typed in-process execution path.
+//!
+//! This crate owns the OS event loop, window, wgpu surface/device/queue, resize,
+//! realtime clock, frame acquisition, submission, and presentation. Semantic state,
+//! lowering/runtime behavior, and retained GPU rendering remain owned by their
+//! existing engine layers.
+
+#![forbid(unsafe_code)]
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use noon::{EvaluationError, ExecutionSession, FrameChanges};
+use noon_core::{Camera2DState, Vec2};
+use noon_render_wgpu::{Camera2D, FramePreparer, GpuRenderer};
+use winit::application::ApplicationHandler;
+use winit::dpi::PhysicalSize;
+use winit::event::WindowEvent;
+use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
+use winit::window::{Window, WindowId};
+
+const CLEAR_COLOR: wgpu::Color = wgpu::Color {
+    r: 0.0,
+    g: 0.0,
+    b: 0.0,
+    a: 1.0,
+};
+
+/// Minimal platform configuration for a native Noon viewport.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NativeViewportConfig {
+    pub title: String,
+    pub width: u32,
+    pub height: u32,
+}
+
+impl Default for NativeViewportConfig {
+    fn default() -> Self {
+        Self {
+            title: "Noon".to_owned(),
+            width: 960,
+            height: 540,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum NativeHostError {
+    Platform(String),
+    Gpu(String),
+    Runtime(EvaluationError),
+}
+
+impl std::fmt::Display for NativeHostError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Platform(message) => write!(formatter, "native platform error: {message}"),
+            Self::Gpu(message) => write!(formatter, "native GPU error: {message}"),
+            Self::Runtime(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl std::error::Error for NativeHostError {}
+
+impl From<EvaluationError> for NativeHostError {
+    fn from(value: EvaluationError) -> Self {
+        Self::Runtime(value)
+    }
+}
+
+/// Run one typed execution session in a native OS window.
+///
+/// No serialization or language host participates in this path. The function owns
+/// platform lifecycle until the viewport closes.
+pub fn run(session: ExecutionSession) -> Result<(), NativeHostError> {
+    run_with_config(session, NativeViewportConfig::default())
+}
+
+/// Run one typed execution session with explicit window configuration.
+pub fn run_with_config(
+    session: ExecutionSession,
+    config: NativeViewportConfig,
+) -> Result<(), NativeHostError> {
+    if config.width == 0 || config.height == 0 {
+        return Err(NativeHostError::Platform(
+            "initial viewport dimensions must be positive".to_owned(),
+        ));
+    }
+
+    let event_loop =
+        EventLoop::new().map_err(|error| NativeHostError::Platform(error.to_string()))?;
+    event_loop.set_control_flow(ControlFlow::Poll);
+    let mut app = NativeApp::new(session, config);
+    event_loop
+        .run_app(&mut app)
+        .map_err(|error| NativeHostError::Platform(error.to_string()))?;
+    if let Some(error) = app.error.take() {
+        return Err(error);
+    }
+    Ok(())
+}
+
+struct NativeApp {
+    session: ExecutionSession,
+    config: NativeViewportConfig,
+    window: Option<Arc<Window>>,
+    gpu: Option<NativeGpu>,
+    started: Option<Instant>,
+    force_full_redraw: bool,
+    error: Option<NativeHostError>,
+}
+
+impl NativeApp {
+    fn new(session: ExecutionSession, config: NativeViewportConfig) -> Self {
+        Self {
+            session,
+            config,
+            window: None,
+            gpu: None,
+            started: None,
+            force_full_redraw: false,
+            error: None,
+        }
+    }
+
+    fn fail(&mut self, event_loop: &ActiveEventLoop, error: NativeHostError) {
+        if self.error.is_none() {
+            self.error = Some(error);
+        }
+        event_loop.exit();
+    }
+
+    fn redraw(&mut self) -> Result<(), NativeHostError> {
+        let Some(window) = self.window.as_ref().cloned() else {
+            return Ok(());
+        };
+        let Some(gpu) = self.gpu.as_mut() else {
+            return Ok(());
+        };
+        if !gpu.drawable {
+            return Ok(());
+        }
+
+        let started = self.started.get_or_insert_with(Instant::now);
+        self.session.advance_to(started.elapsed().as_secs_f64())?;
+        let changes = self.session.take_frame_changes();
+        let changes = if self.force_full_redraw {
+            FrameChanges::all()
+        } else {
+            changes
+        };
+        if changes.is_empty() {
+            return Ok(());
+        }
+
+        let Some((surface_texture, reconfigure_after_present)) = gpu.acquire(window.clone())?
+        else {
+            // The runtime invalidation has already been consumed. Preserve correctness
+            // across a transient surface failure by rebuilding the next presented frame.
+            self.force_full_redraw = true;
+            return Ok(());
+        };
+
+        let frame = self.session.frame();
+        let prepared = gpu.preparer.prepare_incremental(frame, &changes);
+        gpu.renderer.upload(&gpu.device, &gpu.queue, &prepared);
+        let view = surface_texture
+            .texture
+            .create_view(&wgpu::TextureViewDescriptor::default());
+        let mut encoder = gpu
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("Noon native frame"),
+            });
+        gpu.renderer
+            .encode(&mut encoder, &view, &prepared, CLEAR_COLOR);
+        window.pre_present_notify();
+        gpu.queue.submit(Some(encoder.finish()));
+        surface_texture.present();
+        if reconfigure_after_present {
+            gpu.surface.configure(&gpu.device, &gpu.config);
+        }
+        self.force_full_redraw = false;
+        Ok(())
+    }
+}
+
+impl ApplicationHandler for NativeApp {
+    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+        if self.window.is_none() {
+            let attributes = Window::default_attributes()
+                .with_title(self.config.title.clone())
+                .with_inner_size(PhysicalSize::new(self.config.width, self.config.height));
+            let window = match event_loop.create_window(attributes) {
+                Ok(window) => Arc::new(window),
+                Err(error) => {
+                    self.fail(event_loop, NativeHostError::Platform(error.to_string()));
+                    return;
+                }
+            };
+            self.window = Some(window);
+        }
+
+        if self.gpu.is_none() {
+            let window = self
+                .window
+                .as_ref()
+                .expect("resumed native host must own a window")
+                .clone();
+            match pollster::block_on(NativeGpu::new(window)) {
+                Ok(gpu) => {
+                    self.gpu = Some(gpu);
+                    self.started = Some(Instant::now());
+                    self.force_full_redraw = true;
+                }
+                Err(error) => self.fail(event_loop, error),
+            }
+        }
+    }
+
+    fn window_event(
+        &mut self,
+        event_loop: &ActiveEventLoop,
+        window_id: WindowId,
+        event: WindowEvent,
+    ) {
+        let Some(window) = self.window.as_ref() else {
+            return;
+        };
+        if window.id() != window_id {
+            return;
+        }
+
+        match event {
+            WindowEvent::CloseRequested => event_loop.exit(),
+            WindowEvent::Resized(size) => {
+                if let Some(gpu) = self.gpu.as_mut() {
+                    if let Err(error) = gpu.resize(size) {
+                        self.fail(event_loop, error);
+                        return;
+                    }
+                    self.force_full_redraw = true;
+                }
+            }
+            WindowEvent::RedrawRequested => {
+                if let Err(error) = self.redraw() {
+                    self.fail(event_loop, error);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn about_to_wait(&mut self, _event_loop: &ActiveEventLoop) {
+        if let Some(window) = self.window.as_ref() {
+            window.request_redraw();
+        }
+    }
+}
+
+struct NativeGpu {
+    instance: wgpu::Instance,
+    surface: wgpu::Surface<'static>,
+    device: wgpu::Device,
+    queue: wgpu::Queue,
+    config: wgpu::SurfaceConfiguration,
+    drawable: bool,
+    preparer: FramePreparer,
+    renderer: GpuRenderer,
+}
+
+impl NativeGpu {
+    async fn new(window: Arc<Window>) -> Result<Self, NativeHostError> {
+        let size = window.inner_size();
+        let width = size.width.max(1);
+        let height = size.height.max(1);
+        let instance = wgpu::Instance::default();
+        let surface = instance
+            .create_surface(window)
+            .map_err(|error| NativeHostError::Gpu(error.to_string()))?;
+        let adapter = instance
+            .request_adapter(&wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::HighPerformance,
+                force_fallback_adapter: false,
+                compatible_surface: Some(&surface),
+            })
+            .await
+            .map_err(|error| NativeHostError::Gpu(error.to_string()))?;
+        let (device, queue) = adapter
+            .request_device(&wgpu::DeviceDescriptor {
+                label: Some("Noon native GPU device"),
+                required_features: wgpu::Features::empty(),
+                required_limits: wgpu::Limits::default(),
+                ..Default::default()
+            })
+            .await
+            .map_err(|error| NativeHostError::Gpu(error.to_string()))?;
+        let config = surface
+            .get_default_config(&adapter, width, height)
+            .ok_or_else(|| {
+                NativeHostError::Gpu("surface has no supported configuration".to_owned())
+            })?;
+        surface.configure(&device, &config);
+
+        let mut renderer = GpuRenderer::new(&device, config.format);
+        renderer.set_viewport(&device, &queue, width, height);
+        renderer.set_camera(&queue, camera_for_viewport(width, height)?);
+
+        Ok(Self {
+            instance,
+            surface,
+            device,
+            queue,
+            config,
+            drawable: size.width > 0 && size.height > 0,
+            preparer: FramePreparer::new(),
+            renderer,
+        })
+    }
+
+    fn resize(&mut self, size: PhysicalSize<u32>) -> Result<(), NativeHostError> {
+        self.drawable = size.width > 0 && size.height > 0;
+        if !self.drawable {
+            return Ok(());
+        }
+        self.config.width = size.width;
+        self.config.height = size.height;
+        self.surface.configure(&self.device, &self.config);
+        self.renderer
+            .set_viewport(&self.device, &self.queue, size.width, size.height);
+        self.renderer
+            .set_camera(&self.queue, camera_for_viewport(size.width, size.height)?);
+        Ok(())
+    }
+
+    fn acquire(
+        &mut self,
+        window: Arc<Window>,
+    ) -> Result<Option<(wgpu::SurfaceTexture, bool)>, NativeHostError> {
+        match self.surface.get_current_texture() {
+            wgpu::CurrentSurfaceTexture::Success(texture) => Ok(Some((texture, false))),
+            wgpu::CurrentSurfaceTexture::Suboptimal(texture) => Ok(Some((texture, true))),
+            wgpu::CurrentSurfaceTexture::Timeout | wgpu::CurrentSurfaceTexture::Occluded => {
+                Ok(None)
+            }
+            wgpu::CurrentSurfaceTexture::Outdated => {
+                self.surface.configure(&self.device, &self.config);
+                Ok(None)
+            }
+            wgpu::CurrentSurfaceTexture::Lost => {
+                self.surface = self
+                    .instance
+                    .create_surface(window)
+                    .map_err(|error| NativeHostError::Gpu(error.to_string()))?;
+                self.surface.configure(&self.device, &self.config);
+                Ok(None)
+            }
+            wgpu::CurrentSurfaceTexture::Validation => Err(NativeHostError::Gpu(
+                "surface acquisition reported a validation failure".to_owned(),
+            )),
+        }
+    }
+}
+
+fn camera_for_viewport(width: u32, height: u32) -> Result<Camera2D, NativeHostError> {
+    if width == 0 || height == 0 {
+        return Err(NativeHostError::Gpu(
+            "camera viewport dimensions must be positive".to_owned(),
+        ));
+    }
+    let state = Camera2DState::default();
+    let aspect = width as f32 / height as f32;
+    Camera2D::new(state.center, Vec2::new(state.height * aspect, state.height))
+        .map_err(|error| NativeHostError::Gpu(error.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_camera_tracks_native_viewport_aspect() {
+        let camera = camera_for_viewport(1600, 900).unwrap();
+        assert_eq!(camera.center, Vec2::ZERO);
+        assert!((camera.world_size.x - (8.0 * 16.0 / 9.0)).abs() < 1.0e-5);
+        assert_eq!(camera.world_size.y, 8.0);
+    }
+
+    #[test]
+    fn zero_sized_camera_viewport_is_rejected() {
+        assert!(camera_for_viewport(0, 720).is_err());
+        assert!(camera_for_viewport(1280, 0).is_err());
+    }
+}

--- a/scripts/layer-dependency-ratchet.sh
+++ b/scripts/layer-dependency-ratchet.sh
@@ -36,22 +36,27 @@ check_layer() {
 check_layer \
   "crates/noon-core/Cargo.toml" \
   "Semantic Scene / noon-core" \
-  noon-compile noon-runtime noon-render-wgpu noon-web noon
+  noon-compile noon-runtime noon-render-wgpu noon-native noon-web noon
 
 check_layer \
   "crates/noon-compile/Cargo.toml" \
   "Execution Plan compiler / noon-compile" \
-  noon-runtime noon-render-wgpu noon-web noon
+  noon-runtime noon-render-wgpu noon-native noon-web noon
 
 check_layer \
   "crates/noon-runtime/Cargo.toml" \
   "Runtime / noon-runtime" \
-  noon-render-wgpu noon-web noon
+  noon-render-wgpu noon-native noon-web noon
 
 check_layer \
   "crates/noon-render-wgpu/Cargo.toml" \
   "Renderer / noon-render-wgpu" \
-  noon-web noon
+  noon-native noon-web noon
+
+check_layer \
+  "crates/noon/Cargo.toml" \
+  "Authoring facade / noon" \
+  noon-native noon-web
 
 if (( found != 0 )); then
   cat >&2 <<'EOF'

--- a/scripts/layer-dependency-ratchet.test.sh
+++ b/scripts/layer-dependency-ratchet.test.sh
@@ -10,7 +10,8 @@ mkdir -p \
   "$TMP/crates/noon-core" \
   "$TMP/crates/noon-compile" \
   "$TMP/crates/noon-runtime" \
-  "$TMP/crates/noon-render-wgpu"
+  "$TMP/crates/noon-render-wgpu" \
+  "$TMP/crates/noon"
 
 write_clean_fixture() {
   cat >"$TMP/crates/noon-core/Cargo.toml" <<'EOF'
@@ -38,6 +39,14 @@ EOF
   cat >"$TMP/crates/noon-render-wgpu/Cargo.toml" <<'EOF'
 [package]
 name = "noon-render-wgpu"
+[dependencies]
+noon-core = { path = "../noon-core" }
+noon-runtime = { path = "../noon-runtime" }
+EOF
+
+  cat >"$TMP/crates/noon/Cargo.toml" <<'EOF'
+[package]
+name = "noon"
 [dependencies]
 noon-core = { path = "../noon-core" }
 noon-runtime = { path = "../noon-runtime" }
@@ -75,5 +84,9 @@ cat >>"$TMP/crates/noon-render-wgpu/Cargo.toml" <<'EOF'
 path = "../noon"
 EOF
 expect_failure "noon-render-wgpu -> noon through dependency table"
+
+write_clean_fixture
+echo 'noon-native = { path = "../noon-native" }' >>"$TMP/crates/noon/Cargo.toml"
+expect_failure "noon authoring facade -> native platform host"
 
 echo "architecture layer dependency ratchet self-test passed"


### PR DESCRIPTION
## Scope

Continue #969 A2/A6.2 after #1071 established the common typed `ExecutionSession` and #1075 proved the direct Rust/WASM browser host. Add the first native platform host that owns OS/window/GPU presentation lifecycle while consuming the same typed execution/runtime/renderer path.

This is the native-host foundation slice. It deliberately does not introduce a new runtime, renderer abstraction, semantic camera model, or generic application framework.

## Changes

- add a dedicated `noon-native` platform crate because native window/event-loop dependencies must remain outside `noon` and `noon-render-wgpu`;
- expose only `run(ExecutionSession)` and `run_with_config(...)` as the initial host surface;
- own winit window/event-loop lifecycle, wgpu instance/surface/adapter/device/queue/configuration, resize, realtime clock, frame acquisition, submission, and presentation in the platform crate;
- drive `ExecutionSession::advance_to`, consume `FrameChanges`, and feed the existing `FramePreparer`/`GpuRenderer` incrementally;
- preserve invalidation across transient surface acquisition failures with one explicit full-frame retry rather than losing consumed runtime changes;
- derive the initial native viewport from the existing normalized `Camera2DState` default contract; semantic 2D camera ownership remains with B6/#89;
- add a Rust-only representative example: `SemanticStore -> ExecutionSession -> noon_native::run`;
- ratchet dependency direction so engine/authoring crates cannot depend upward on `noon-native`.

## Architecture

```text
Rust SemanticStore
    -> ExecutionSession
    -> FrameState / FrameChanges
    -> noon-native platform lifecycle
    -> existing FramePreparer / GpuRenderer
    -> native wgpu Surface
```

`noon-native` owns platform lifecycle only. Semantic state/lowering/runtime stay below it; `noon-render-wgpu` remains independent of window/event-loop ownership. There is no serialization or transport mirror in this path.

## Validation

Required before merge:

- architecture and layer-dependency ratchets;
- Rust format and Clippy across all targets/features;
- Rust unit tests, including native viewport/camera normalization helpers;
- representative native example compiles in the all-target Clippy lane;
- existing web/WASM/browser gates remain green, proving the new native host does not contaminate browser/platform boundaries.

A dedicated virtual-display native rendering smoke and native reactive input ingress remain follow-up A2/A6.2 slices before the full native-host exit ratchet.

Refs #969 #1071 #1075 #89.