### PR TITLE
A2/A6: prove direct native Rust rendering in CI

### DIFF
--- a/.github/workflows/native-host-smoke.yml
+++ b/.github/workflows/native-host-smoke.yml
@@ -1,0 +1,57 @@
+name: Native Host Smoke
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/native-host-smoke.yml"
+      - "Cargo.toml"
+      - "rust-toolchain.toml"
+      - "crates/noon-native/**"
+      - "crates/noon/**"
+      - "crates/noon-core/**"
+      - "crates/noon-compile/**"
+      - "crates/noon-runtime/**"
+      - "crates/noon-render-wgpu/**"
+  push:
+    branches: [master]
+    paths:
+      - ".github/workflows/native-host-smoke.yml"
+      - "Cargo.toml"
+      - "rust-toolchain.toml"
+      - "crates/noon-native/**"
+      - "crates/noon/**"
+      - "crates/noon-core/**"
+      - "crates/noon-compile/**"
+      - "crates/noon-runtime/**"
+      - "crates/noon-render-wgpu/**"
+
+permissions:
+  contents: read
+
+jobs:
+  native-surface-presentation:
+    name: Rust semantic scene presents natively
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      CARGO_INCREMENTAL: 0
+      CARGO_PROFILE_TEST_DEBUG: 0
+      WGPU_BACKEND: vulkan
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use stable Rust
+        run: |
+          rustup default stable
+
+      - name: Install virtual display and software Vulkan
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xvfb mesa-vulkan-drivers libvulkan1
+
+      - name: Present typed Rust semantic scene through native host
+        run: |
+          xvfb-run -a -s "-screen 0 1280x720x24" \
+            cargo test -p noon-native native_surface_smoke_presents_typed_semantic_frame \
+              -- --ignored --nocapture --test-threads=1

--- a/.github/workflows/native-host-smoke.yml
+++ b/.github/workflows/native-host-smoke.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install virtual display and software Vulkan
         run: |
           sudo apt-get update
-          sudo apt-get install -y xvfb mesa-vulkan-drivers libvulkan1
+          sudo apt-get install -y xvfb mesa-vulkan-drivers libvulkan1 libxkbcommon-x11-0
 
       - name: Present typed Rust semantic scene through native host
         run: |

--- a/crates/noon-native/src/lib.rs
+++ b/crates/noon-native/src/lib.rs
@@ -418,9 +418,10 @@ mod tests {
         use winit::platform::x11::EventLoopBuilderExtX11;
 
         let mut store = SemanticStore::new();
-        let circle = store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
-            radius: 1.5,
-        }));
+        let circle =
+            store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+                radius: 1.5,
+            }));
         store.attach_to_scene(circle).unwrap();
         let session = ExecutionSession::from_semantic_store(&store).unwrap();
 
@@ -443,6 +444,9 @@ mod tests {
         if let Some(error) = app.error.take() {
             panic!("native surface smoke failed before presentation: {error}");
         }
-        assert!(app.presented_frame, "native host exited without presenting a frame");
+        assert!(
+            app.presented_frame,
+            "native host exited without presenting a frame"
+        );
     }
 }

--- a/crates/noon-native/src/lib.rs
+++ b/crates/noon-native/src/lib.rs
@@ -258,7 +258,6 @@ impl ApplicationHandler for NativeApp {
             WindowEvent::RedrawRequested => {
                 if let Err(error) = self.redraw() {
                     self.fail(event_loop, error);
-                    return;
                 }
                 #[cfg(test)]
                 if self.exit_after_present && self.presented_frame {

--- a/crates/noon-native/src/lib.rs
+++ b/crates/noon-native/src/lib.rs
@@ -109,6 +109,10 @@ struct NativeApp {
     started: Option<Instant>,
     force_full_redraw: bool,
     error: Option<NativeHostError>,
+    #[cfg(test)]
+    exit_after_present: bool,
+    #[cfg(test)]
+    presented_frame: bool,
 }
 
 impl NativeApp {
@@ -121,6 +125,10 @@ impl NativeApp {
             started: None,
             force_full_redraw: false,
             error: None,
+            #[cfg(test)]
+            exit_after_present: false,
+            #[cfg(test)]
+            presented_frame: false,
         }
     }
 
@@ -178,6 +186,10 @@ impl NativeApp {
         window.pre_present_notify();
         gpu.queue.submit(Some(encoder.finish()));
         surface_texture.present();
+        #[cfg(test)]
+        {
+            self.presented_frame = true;
+        }
         if reconfigure_after_present {
             gpu.surface.configure(&gpu.device, &gpu.config);
         }
@@ -246,6 +258,11 @@ impl ApplicationHandler for NativeApp {
             WindowEvent::RedrawRequested => {
                 if let Err(error) = self.redraw() {
                     self.fail(event_loop, error);
+                    return;
+                }
+                #[cfg(test)]
+                if self.exit_after_present && self.presented_frame {
+                    event_loop.exit();
                 }
             }
             _ => {}
@@ -391,5 +408,41 @@ mod tests {
     fn zero_sized_camera_viewport_is_rejected() {
         assert!(camera_for_viewport(0, 720).is_err());
         assert!(camera_for_viewport(1280, 0).is_err());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    #[ignore = "requires an X11 display and a working native wgpu adapter"]
+    fn native_surface_smoke_presents_typed_semantic_frame() {
+        use noon_core::{SemanticObjectState, SemanticStore, StoredGeometry};
+        use winit::platform::x11::EventLoopBuilderExtX11;
+
+        let mut store = SemanticStore::new();
+        let circle = store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+            radius: 1.5,
+        }));
+        store.attach_to_scene(circle).unwrap();
+        let session = ExecutionSession::from_semantic_store(&store).unwrap();
+
+        let mut event_loop_builder = EventLoop::builder();
+        event_loop_builder.with_any_thread(true);
+        let event_loop = event_loop_builder.build().unwrap();
+        event_loop.set_control_flow(ControlFlow::Poll);
+
+        let mut app = NativeApp::new(
+            session,
+            NativeViewportConfig {
+                title: "Noon native smoke".to_owned(),
+                width: 320,
+                height: 180,
+            },
+        );
+        app.exit_after_present = true;
+        event_loop.run_app(&mut app).unwrap();
+
+        if let Some(error) = app.error.take() {
+            panic!("native surface smoke failed before presentation: {error}");
+        }
+        assert!(app.presented_frame, "native host exited without presenting a frame");
     }
 }

--- a/web/ci-workflow-topology.test.mjs
+++ b/web/ci-workflow-topology.test.mjs
@@ -16,6 +16,7 @@ const exactFamilies = new Map([
   ["compiler-cache-seed.yml", "cache-seed"],
   ["test-coverage.yml", "coverage"],
   ["platform-release.yml", "platform-release"],
+  ["native-host-smoke.yml", "native-host"],
   ["pages.yml", "deployment"],
   ["fuzz.yml", "fuzz"],
   ["branch-cleanup-once.yml", "maintenance"],


### PR DESCRIPTION
## Scope

Continue #969 A2/A6.2 after #1077 added the direct native Rust viewport host. Convert that compile-time proof into an executable native rendering proof under CI.

This slice is intentionally narrow: it does not add input ingress, a capture API, a public frame-limit knob, or a second host implementation.

## Changes

- add an ignored Linux native-surface smoke test inside `noon-native`;
- construct a canonical semantic circle and lower it through the ordinary `ExecutionSession` path;
- run the same production `NativeApp` / `NativeGpu` / `FramePreparer` / `GpuRenderer` code used by `noon_native::run`;
- mark smoke success only after `SurfaceTexture::present()` has completed for a rendered frame;
- keep deterministic auto-exit state entirely behind `#[cfg(test)]`, leaving the public native host API and production behavior unchanged;
- add a dedicated Xvfb + Mesa software-Vulkan workflow so pull requests and master changes affecting the native engine path execute the proof.

## Architecture

```text
SemanticStore
  -> ExecutionSession
  -> NativeApp realtime tick
  -> FrameChanges
  -> FramePreparer / GpuRenderer
  -> wgpu native Surface
  -> present()
```

The smoke exercises the real native platform host rather than a parallel test renderer or duplicated event loop implementation. Serialization, Python, JS, WASM and `noon-ir` are absent from the path.

## Validation

Required before merge:

- native surface smoke passes under Xvfb/software Vulkan;
- architecture and layer-dependency ratchets remain green;
- workspace rustfmt/Clippy and Rust tests remain green;
- existing web/WASM/browser fast gates remain green.

After this slice, the remaining substantive A2/A6.2 responsibility is native input ingress needed by the shared runtime, followed by the native-host exit ratchet integration.

Refs #969 #1077.