### PR TITLE
A2/A6: activate semantic animations in execution sessions

### DIFF
--- a/crates/noon-runtime/src/execution_slots/mod.rs
+++ b/crates/noon-runtime/src/execution_slots/mod.rs
@@ -1,5 +1,6 @@
 mod base;
 mod semantic_membership;
+mod transaction;
 
 pub use base::*;
 pub use semantic_membership::*;

--- a/crates/noon-runtime/src/execution_slots/transaction.rs
+++ b/crates/noon-runtime/src/execution_slots/transaction.rs
@@ -1,0 +1,96 @@
+use noon_compile::CompilePatchError;
+use noon_core::{MutationTransaction, ObjectId, Transform2D};
+
+use crate::SceneInstance;
+
+impl SceneInstance {
+    /// Return the already-evaluated effective transform for one live execution object.
+    ///
+    /// Stable compiled object identity resolves directly to the matching frame slot;
+    /// this does not resample the scene or scan renderer-facing frame objects.
+    pub fn effective_transform(&self, object: ObjectId) -> Option<Transform2D> {
+        let object_index = self.compiled.object_index(object)? as usize;
+        self.frame
+            .objects
+            .get(object_index)
+            .map(|state| state.transform)
+    }
+
+    /// Publish one preflighted mutation transaction as a single runtime operation.
+    ///
+    /// Validation completes against the full transaction before the first live patch is
+    /// applied. Individual patches then reuse the existing localized runtime update path;
+    /// after successful preflight, a patch rejection would indicate an internal compiler/
+    /// runtime invariant violation rather than a recoverable transaction error.
+    pub fn apply_transaction(
+        &mut self,
+        transaction: &MutationTransaction,
+    ) -> Result<&crate::FrameState, CompilePatchError> {
+        self.compiled.preflight_transaction(transaction)?;
+        for patch in transaction.mutations() {
+            self.apply_patch(patch)
+                .expect("preflighted runtime transaction patch must remain valid");
+        }
+        Ok(&self.frame)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use noon_compile::CompiledScene;
+    use noon_core::{GeometryRef, MutationTransaction, ObjectId, SceneDefinition, ScenePatch, Vec2};
+
+    use super::*;
+
+    #[test]
+    fn effective_transform_resolves_through_compiled_object_slot() {
+        let mut scene = SceneDefinition::new();
+        let object = scene.add(GeometryRef::circle(1.0));
+        let transform = Transform2D {
+            translation: Vec2::new(3.0, -2.0),
+            rotation: 0.25,
+            scale: Vec2::new(2.0, 0.5),
+        };
+        scene.object_mut(object).unwrap().transform = transform;
+        let instance = SceneInstance::new(CompiledScene::compile(&scene).unwrap());
+
+        assert_eq!(instance.effective_transform(object), Some(transform));
+        assert_eq!(
+            instance.effective_transform(ObjectId::new(u64::MAX)),
+            None
+        );
+    }
+
+    #[test]
+    fn transaction_preflight_rejects_before_any_live_patch_is_published() {
+        let mut scene = SceneDefinition::new();
+        let object = scene.add(GeometryRef::circle(1.0));
+        let mut instance = SceneInstance::new(CompiledScene::compile(&scene).unwrap());
+        let before = instance.frame().clone();
+        let moved = Transform2D {
+            translation: Vec2::new(5.0, 0.0),
+            ..Transform2D::IDENTITY
+        };
+        let missing = ObjectId::new(u64::MAX);
+        let transaction = MutationTransaction::from_mutations([
+            ScenePatch::SetTransform {
+                object,
+                transform: moved,
+            },
+            ScenePatch::SetTransform {
+                object: missing,
+                transform: moved,
+            },
+        ]);
+
+        assert_eq!(
+            instance.apply_transaction(&transaction),
+            Err(CompilePatchError::UnknownObject(missing))
+        );
+        assert_eq!(instance.frame(), &before);
+        assert_eq!(
+            instance.effective_transform(object),
+            Some(Transform2D::IDENTITY)
+        );
+    }
+}

--- a/crates/noon/src/execution_session.rs
+++ b/crates/noon/src/execution_session.rs
@@ -1,8 +1,13 @@
 use noon_compile::{
-    lower_semantic_execution, SemanticExecutionIndex, SemanticExecutionLoweringError,
+    lower_semantic_affine_animation_tracks, lower_semantic_animation_schedule,
+    lower_semantic_execution, CompilePatchError, SemanticAffineAnimationTrackError,
+    SemanticAnimationScheduleError, SemanticExecutionIndex, SemanticExecutionLoweringError,
     SemanticReactiveProjection,
 };
-use noon_core::{ObjectId, ReactiveError, ReactiveValue, SemanticNodeId, SemanticStore};
+use noon_core::{
+    AnimationOptions, MutationTransaction, ObjectId, ReactiveError, ReactiveValue, ScenePatch,
+    SemanticNodeId, SemanticStore, TrackId,
+};
 use noon_runtime::{EvaluationError, FrameChanges, FrameState, SceneInstance};
 
 /// Error produced when a semantic reactive input cannot be applied to this execution session.
@@ -34,6 +39,50 @@ impl From<ReactiveError> for ExecutionSessionInputError {
     }
 }
 
+/// Error produced when a semantic animation cannot be activated into this execution session.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ExecutionSessionAnimationError {
+    Schedule(SemanticAnimationScheduleError),
+    AffinePayload(SemanticAffineAnimationTrackError),
+    TrackIdExhausted,
+    Publication(CompilePatchError),
+}
+
+impl std::fmt::Display for ExecutionSessionAnimationError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Schedule(error) => error.fmt(formatter),
+            Self::AffinePayload(error) => error.fmt(formatter),
+            Self::TrackIdExhausted => {
+                formatter.write_str("execution animation TrackId space exhausted")
+            }
+            Self::Publication(error) => {
+                write!(formatter, "execution animation publication failed: {error}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ExecutionSessionAnimationError {}
+
+impl From<SemanticAnimationScheduleError> for ExecutionSessionAnimationError {
+    fn from(value: SemanticAnimationScheduleError) -> Self {
+        Self::Schedule(value)
+    }
+}
+
+impl From<SemanticAffineAnimationTrackError> for ExecutionSessionAnimationError {
+    fn from(value: SemanticAffineAnimationTrackError) -> Self {
+        Self::AffinePayload(value)
+    }
+}
+
+impl From<CompilePatchError> for ExecutionSessionAnimationError {
+    fn from(value: CompilePatchError) -> Self {
+        Self::Publication(value)
+    }
+}
+
 /// Thin typed orchestration from authoritative semantic state into Noon's existing runtime.
 ///
 /// The session does not own or mirror the [`SemanticStore`]. It retains only the
@@ -49,6 +98,7 @@ pub struct ExecutionSession {
     execution_index: SemanticExecutionIndex,
     reactive_projection: SemanticReactiveProjection,
     runtime: SceneInstance,
+    next_execution_track_id: Option<u64>,
 }
 
 impl ExecutionSession {
@@ -64,6 +114,9 @@ impl ExecutionSession {
             execution_index,
             reactive_projection,
             runtime,
+            // Canonical initial semantic lowering currently emits no execution tracks.
+            // Activation IDs are session-owned and advance only after atomic publication.
+            next_execution_track_id: Some(0),
         })
     }
 
@@ -92,6 +145,43 @@ impl ExecutionSession {
         self.runtime.advance_to(time)
     }
 
+    /// Activate one authoritative semantic animation at the current session time.
+    ///
+    /// Scheduling and payload lowering remain compiler-owned. The runtime contributes only
+    /// activation-time effective transforms and atomically publishes the resulting existing
+    /// `ScenePatch::AddTrack` operations. Execution TrackIds are session-local and are not
+    /// committed until publication succeeds.
+    pub fn activate_animation(
+        &mut self,
+        store: &SemanticStore,
+        animation: SemanticNodeId,
+        play_options: AnimationOptions,
+    ) -> Result<&FrameState, ExecutionSessionAnimationError> {
+        let schedule = lower_semantic_animation_schedule(
+            store,
+            &self.execution_index,
+            animation,
+            self.runtime.frame().time,
+            play_options,
+        )?;
+        let tracks = lower_semantic_affine_animation_tracks(store, &schedule, |object| {
+            self.runtime.effective_transform(object)
+        })?;
+
+        let mut next_execution_track_id = self.next_execution_track_id;
+        let mut transaction = MutationTransaction::new();
+        for track in tracks.tracks() {
+            let raw = next_execution_track_id
+                .ok_or(ExecutionSessionAnimationError::TrackIdExhausted)?;
+            transaction.push(ScenePatch::AddTrack(track.with_track_id(TrackId::new(raw))?));
+            next_execution_track_id = raw.checked_add(1);
+        }
+
+        self.runtime.apply_transaction(&transaction)?;
+        self.next_execution_track_id = next_execution_track_id;
+        Ok(self.runtime.frame())
+    }
+
     /// Apply one native-reactive input using authoritative semantic signal identity.
     ///
     /// The execution VM key remains an internal lowering detail. Current native
@@ -117,9 +207,36 @@ impl ExecutionSession {
 
 #[cfg(test)]
 mod tests {
-    use noon_core::{SemanticObjectProperty, SemanticObjectState, StoredGeometry};
+    use noon_core::{
+        AnimationOptions, RateFunction, SemanticObjectProperty, SemanticObjectState, SemanticVec3,
+        StoredGeometry, Vec2,
+    };
 
     use super::*;
+
+    fn visible_circle(store: &mut SemanticStore) -> SemanticNodeId {
+        let object =
+            store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+                radius: 1.0,
+            }));
+        store.attach_to_scene(object).unwrap();
+        object
+    }
+
+    fn transform_state(
+        store: &mut SemanticStore,
+        source: SemanticNodeId,
+        translation_x: f64,
+        rotation_z: f64,
+        scale_x: f64,
+        scale_y: f64,
+    ) -> SemanticNodeId {
+        let mut state = store.semantic_object_state_checked(source).unwrap().clone();
+        state.transform.translation = SemanticVec3::new(translation_x, 0.0, 0.0);
+        state.transform.rotation_z = rotation_z;
+        state.transform.scale = SemanticVec3::new(scale_x, scale_y, 1.0);
+        store.insert_semantic_object(state)
+    }
 
     #[test]
     fn semantic_store_runs_through_typed_session_into_renderer_facing_changes() {
@@ -165,6 +282,100 @@ mod tests {
         assert_eq!(
             session.set_reactive_input(object, 1.0_f32),
             Err(ExecutionSessionInputError::UnknownSemanticSignal(object))
+        );
+    }
+
+    #[test]
+    fn animation_activation_chains_from_effective_state_at_current_session_time() {
+        let mut store = SemanticStore::new();
+        let object = visible_circle(&mut store);
+        let first_state = transform_state(&mut store, object, 4.0, 0.4, 2.0, 2.0);
+        let second_state = transform_state(&mut store, object, 10.0, 1.0, 4.0, 3.0);
+        let first = store
+            .insert_semantic_transform_animation(
+                object,
+                first_state,
+                AnimationOptions::new()
+                    .run_time(2.0)
+                    .rate_func(RateFunction::Linear),
+            )
+            .unwrap();
+        let second = store
+            .insert_semantic_transform_animation(
+                object,
+                second_state,
+                AnimationOptions::new()
+                    .run_time(2.0)
+                    .rate_func(RateFunction::Linear),
+            )
+            .unwrap();
+        let mut session = ExecutionSession::from_semantic_store(&store).unwrap();
+
+        session
+            .activate_animation(&store, first, AnimationOptions::new())
+            .unwrap();
+        session.seek(1.0).unwrap();
+        let captured = session.frame().objects[0].transform;
+        assert_eq!(captured.translation, Vec2::new(2.0, 0.0));
+        assert!((captured.rotation - 0.2).abs() < 1.0e-6);
+        assert_eq!(captured.scale, Vec2::new(1.5, 1.5));
+
+        session
+            .activate_animation(&store, second, AnimationOptions::new())
+            .unwrap();
+        assert_eq!(session.frame().objects[0].transform, captured);
+
+        session.seek(2.0).unwrap();
+        let halfway = session.frame().objects[0].transform;
+        assert_eq!(halfway.translation, Vec2::new(6.0, 0.0));
+        assert!((halfway.rotation - 0.6).abs() < 1.0e-6);
+        assert_eq!(halfway.scale, Vec2::new(2.75, 2.25));
+    }
+
+    #[test]
+    fn execution_track_id_commits_only_after_successful_publication() {
+        let mut store = SemanticStore::new();
+        let object = visible_circle(&mut store);
+        let first_state = transform_state(&mut store, object, 4.0, 0.0, 1.0, 1.0);
+        let second_state = transform_state(&mut store, object, 8.0, 0.0, 1.0, 1.0);
+        let first = store
+            .insert_semantic_transform_animation(
+                object,
+                first_state,
+                AnimationOptions::new()
+                    .run_time(2.0)
+                    .rate_func(RateFunction::Linear),
+            )
+            .unwrap();
+        let second = store
+            .insert_semantic_transform_animation(
+                object,
+                second_state,
+                AnimationOptions::new()
+                    .run_time(2.0)
+                    .rate_func(RateFunction::Linear),
+            )
+            .unwrap();
+        let mut session = ExecutionSession::from_semantic_store(&store).unwrap();
+
+        session
+            .activate_animation(&store, first, AnimationOptions::new())
+            .unwrap();
+        assert_eq!(session.next_execution_track_id, Some(1));
+
+        session.next_execution_track_id = Some(0);
+        assert_eq!(
+            session.activate_animation(&store, second, AnimationOptions::new()),
+            Err(ExecutionSessionAnimationError::Publication(
+                CompilePatchError::DuplicateTrack(TrackId::new(0))
+            ))
+        );
+        assert_eq!(session.next_execution_track_id, Some(0));
+
+        session.seek(1.0).unwrap();
+        assert_eq!(
+            session.frame().objects[0].transform.translation,
+            Vec2::new(2.0, 0.0)
         );
     }
 }


### PR DESCRIPTION
## Superseded

Closed without merge because #1076 landed on `master` while this branch was being prepared and implements the same activation/publication slice on the canonical path.

#1076 is stronger in one important detail: it seeds session-owned activation `TrackId` allocation after any initially compiled timeline IDs rather than relying on the current zero-track initial lowering invariant.

No code from this duplicate PR should be merged.

Refs #969 #1076.