### PR TITLE
A2/A6.3: propagate canonical semantic camera through typed execution

### DIFF
--- a/crates/noon-compile/src/semantic_lowering/entrypoint.rs
+++ b/crates/noon-compile/src/semantic_lowering/entrypoint.rs
@@ -1,10 +1,14 @@
-use noon_core::{ComputeProgram, ReactiveProgram, SemanticStore};
+use noon_core::{
+    Camera2DState, ComputeProgram, ObjectId, ReactiveProgram, SemanticNodeId, SemanticObjectRole,
+    SemanticStore,
+};
 
 use crate::CompiledScene;
 
 use super::{
     lower_semantic_reactive_projection, SemanticCompiledSceneError, SemanticExecutionIndex,
-    SemanticLoweringError, SemanticReactiveLoweringError, SemanticReactiveProjection,
+    SemanticExecutionProjection, SemanticLoweringError, SemanticReactiveLoweringError,
+    SemanticReactiveProjection,
 };
 
 /// One typed compiler handoff from the authoritative semantic scene into Noon's
@@ -18,6 +22,7 @@ pub struct SemanticExecutionLoweringOutput {
     compiled: CompiledScene,
     reactive: SemanticReactiveProjection,
     compute: ComputeProgram,
+    camera_object: Option<ObjectId>,
 }
 
 impl SemanticExecutionLoweringOutput {
@@ -31,6 +36,13 @@ impl SemanticExecutionLoweringOutput {
 
     pub fn compute(&self) -> &ComputeProgram {
         &self.compute
+    }
+
+    /// Execution identity of the unique semantic object carrying the canonical 2D
+    /// camera role, if authored. The camera value itself remains derived from this
+    /// object's effective runtime geometry/transform rather than duplicated here.
+    pub const fn camera_object(&self) -> Option<ObjectId> {
+        self.camera_object
     }
 
     /// Compatibility decomposition retained while callers migrate to consuming the
@@ -51,6 +63,13 @@ pub enum SemanticExecutionLoweringError {
     Object(SemanticLoweringError),
     Reactive(SemanticReactiveLoweringError),
     Compiled(SemanticCompiledSceneError),
+    MultipleCameraObjects {
+        first: SemanticNodeId,
+        second: SemanticNodeId,
+    },
+    InvalidCameraObject {
+        node: SemanticNodeId,
+    },
 }
 
 impl From<SemanticLoweringError> for SemanticExecutionLoweringError {
@@ -81,6 +100,20 @@ impl std::fmt::Display for SemanticExecutionLoweringError {
             Self::Compiled(error) => {
                 write!(formatter, "compiled execution lowering failed: {error}")
             }
+            Self::MultipleCameraObjects { first, second } => write!(
+                formatter,
+                "semantic scene has multiple 2D camera objects: {}:{} and {}:{}",
+                first.slot(),
+                first.generation(),
+                second.slot(),
+                second.generation()
+            ),
+            Self::InvalidCameraObject { node } => write!(
+                formatter,
+                "semantic 2D camera object {}:{} is not a valid rectangle frame",
+                node.slot(),
+                node.generation()
+            ),
         }
     }
 }
@@ -93,8 +126,9 @@ impl std::error::Error for SemanticExecutionLoweringError {}
 /// semantic snapshot. The reactive graph is validated against the already-lowered
 /// execution object/timeline domain and lowered into the existing compute VM. The
 /// identity index is staged and published only after all downstream lowering
-/// succeeds, including compute-program construction, so an invalid execution
-/// handoff cannot leave a partially admitted semantic-to-execution mapping.
+/// succeeds, including compute-program construction and camera-role validation, so
+/// an invalid execution handoff cannot leave a partially admitted
+/// semantic-to-execution mapping.
 ///
 /// Authored animation declarations remain semantic intent until an explicit
 /// animation activation/composition root is supplied to its dedicated lowering
@@ -106,8 +140,10 @@ pub fn lower_semantic_execution(
 ) -> Result<SemanticExecutionLoweringOutput, SemanticExecutionLoweringError> {
     let mut staged_index = index.clone();
     let projection = staged_index.lower_scene(store)?;
+    let camera = semantic_camera_object(store, &projection)?;
     let reactive = lower_semantic_reactive_projection(store, &projection)?;
     let compiled = CompiledScene::from_semantic_projection_after_reactive_lowering(&projection)?;
+    let camera_object = validate_camera_object(camera, &compiled)?;
     let program = ReactiveProgram::compile_for_execution_domain(
         compiled
             .objects()
@@ -132,20 +168,71 @@ pub fn lower_semantic_execution(
         compiled,
         reactive,
         compute,
+        camera_object,
     })
+}
+
+fn semantic_camera_object(
+    store: &SemanticStore,
+    projection: &SemanticExecutionProjection,
+) -> Result<Option<(SemanticNodeId, ObjectId)>, SemanticExecutionLoweringError> {
+    let mut camera = None;
+    for object in projection.objects() {
+        let state = store
+            .node(object.semantic_id)
+            .and_then(|node| node.semantic_object_state())
+            .expect("semantic projection object must retain authored object state");
+        if state.role() != SemanticObjectRole::Camera2D {
+            continue;
+        }
+        if let Some((first, _)) = camera {
+            return Err(SemanticExecutionLoweringError::MultipleCameraObjects {
+                first,
+                second: object.semantic_id,
+            });
+        }
+        camera = Some((object.semantic_id, object.execution_id));
+    }
+    Ok(camera)
+}
+
+fn validate_camera_object(
+    camera: Option<(SemanticNodeId, ObjectId)>,
+    compiled: &CompiledScene,
+) -> Result<Option<ObjectId>, SemanticExecutionLoweringError> {
+    let Some((node, object_id)) = camera else {
+        return Ok(None);
+    };
+    let object = compiled
+        .objects()
+        .iter()
+        .find(|object| object.live && object.id == object_id)
+        .expect("semantic camera object must exist in its compiled projection");
+    Camera2DState::from_frame_object(&object.geometry, object.base_transform)
+        .ok_or(SemanticExecutionLoweringError::InvalidCameraObject { node })?;
+    Ok(Some(object_id))
 }
 
 #[cfg(test)]
 mod tests {
     use noon_core::{
-        Property, ReactiveValue, SemanticObjectProperty, SemanticObjectState, SemanticStore,
-        StoredGeometry, TextResourceHandle, TextResourceId,
+        Property, ReactiveValue, SemanticObjectProperty, SemanticObjectRole, SemanticObjectState,
+        SemanticStore, SemanticVec3, StoredGeometry, TextResourceHandle, TextResourceId, Vec2,
     };
 
     use super::*;
 
     fn circle(radius: f32) -> SemanticObjectState {
         SemanticObjectState::new(StoredGeometry::Circle { radius })
+    }
+
+    fn camera(center: Vec2, height: f32) -> SemanticObjectState {
+        let mut state = SemanticObjectState::new(StoredGeometry::Rectangle {
+            size: Vec2::new(height * 16.0 / 9.0, height),
+        });
+        state.transform.translation = SemanticVec3::new(center.x as f64, center.y as f64, 0.0);
+        state.set_role(SemanticObjectRole::Camera2D);
+        state
     }
 
     #[test]
@@ -165,6 +252,7 @@ mod tests {
 
         assert_eq!(lowered.compiled().objects().len(), 1);
         assert_eq!(lowered.compiled().objects()[0].id, execution_id);
+        assert_eq!(lowered.camera_object(), None);
         assert_eq!(lowered.reactive().signal_count(), 1);
         assert_eq!(lowered.compute().signal_count(), 1);
         assert_eq!(
@@ -191,6 +279,67 @@ mod tests {
                 value: ReactiveValue::Scalar(0.7),
             }]
         );
+    }
+
+    #[test]
+    fn canonical_camera_role_lowers_to_existing_execution_object_identity() {
+        let mut store = SemanticStore::new();
+        let camera = store.insert_semantic_object(camera(Vec2::new(2.0, -1.0), 6.0));
+        store.attach_to_scene(camera).unwrap();
+
+        let mut index = SemanticExecutionIndex::new();
+        let lowered = lower_semantic_execution(&store, &mut index).unwrap();
+
+        assert_eq!(lowered.camera_object(), index.execution_object_id(camera));
+        let execution_id = lowered.camera_object().unwrap();
+        let compiled = lowered
+            .compiled()
+            .objects()
+            .iter()
+            .find(|object| object.id == execution_id)
+            .unwrap();
+        assert_eq!(
+            Camera2DState::from_frame_object(&compiled.geometry, compiled.base_transform),
+            Some(Camera2DState {
+                center: Vec2::new(2.0, -1.0),
+                height: 6.0,
+            })
+        );
+    }
+
+    #[test]
+    fn multiple_semantic_camera_roles_fail_without_publishing_identity() {
+        let mut store = SemanticStore::new();
+        let first = store.insert_semantic_object(camera(Vec2::ZERO, 8.0));
+        let second = store.insert_semantic_object(camera(Vec2::new(1.0, 0.0), 6.0));
+        store.attach_to_scene(first).unwrap();
+        store.attach_to_scene(second).unwrap();
+
+        let mut index = SemanticExecutionIndex::new();
+        assert!(matches!(
+            lower_semantic_execution(&store, &mut index),
+            Err(SemanticExecutionLoweringError::MultipleCameraObjects {
+                first: actual_first,
+                second: actual_second,
+            }) if actual_first == first && actual_second == second
+        ));
+        assert!(index.is_empty());
+    }
+
+    #[test]
+    fn non_frame_semantic_camera_fails_without_publishing_identity() {
+        let mut store = SemanticStore::new();
+        let mut state = circle(1.0);
+        state.set_role(SemanticObjectRole::Camera2D);
+        let camera = store.insert_semantic_object(state);
+        store.attach_to_scene(camera).unwrap();
+
+        let mut index = SemanticExecutionIndex::new();
+        assert!(matches!(
+            lower_semantic_execution(&store, &mut index),
+            Err(SemanticExecutionLoweringError::InvalidCameraObject { node }) if node == camera
+        ));
+        assert!(index.is_empty());
     }
 
     #[test]

--- a/crates/noon-core/src/reactive/object_content.rs
+++ b/crates/noon-core/src/reactive/object_content.rs
@@ -45,6 +45,19 @@ impl From<TextResourceHandle> for SemanticObjectContent {
     }
 }
 
+/// Scene-level role carried by an ordinary semantic object.
+///
+/// Roles describe how shared semantic scene state interprets an object; they do
+/// not create a second renderer/runtime object model. In particular, a 2D camera
+/// remains an ordinary semantic frame object whose effective execution transform
+/// determines the renderer-facing [`crate::Camera2DState`].
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum SemanticObjectRole {
+    #[default]
+    Ordinary,
+    Camera2D,
+}
+
 /// Stable authored object properties that may be driven by native-reactive signals.
 ///
 /// These names describe semantic state, not execution slots or legacy timeline
@@ -105,8 +118,8 @@ impl SemanticSignalBinding {
 /// Identity and family/lifecycle relationships belong to `SemanticNode`; immutable
 /// heavy content belongs to the existing resource arenas. This value owns the
 /// mutable authored content reference, high-precision transform, semantic style,
-/// painter metadata, and typed native-reactive property bindings that frontends
-/// must share.
+/// painter metadata, scene role, and typed native-reactive property bindings that
+/// frontends must share.
 ///
 /// Bounds are intentionally absent. Layout-accurate and conservative bounds are
 /// derived from content + transform + style (and may be cached as disposable
@@ -117,6 +130,7 @@ pub struct SemanticObjectState {
     pub transform: SemanticTransform2_5D,
     pub style: SemanticStyle,
     presentation: SemanticPresentation,
+    role: SemanticObjectRole,
     signal_bindings: Vec<SemanticSignalBinding>,
 }
 
@@ -127,6 +141,7 @@ impl SemanticObjectState {
             transform: SemanticTransform2_5D::default(),
             style: SemanticStyle::default(),
             presentation: SemanticPresentation::default(),
+            role: SemanticObjectRole::default(),
             signal_bindings: Vec::new(),
         }
     }
@@ -145,6 +160,14 @@ impl SemanticObjectState {
 
     pub const fn insertion_order(&self) -> u64 {
         self.presentation.insertion_order
+    }
+
+    pub const fn role(&self) -> SemanticObjectRole {
+        self.role
+    }
+
+    pub fn set_role(&mut self, role: SemanticObjectRole) {
+        self.role = role;
     }
 
     pub fn signal_bindings(&self) -> &[SemanticSignalBinding] {
@@ -264,7 +287,18 @@ mod tests {
         assert_eq!(state.style.object_opacity, 0.4);
         assert_eq!(state.z_index(), 7);
         assert_eq!(state.insertion_order(), 0);
+        assert_eq!(state.role(), SemanticObjectRole::Ordinary);
         assert!(state.signal_bindings().is_empty());
+    }
+
+    #[test]
+    fn semantic_object_role_is_explicit_and_defaults_to_ordinary() {
+        let mut state = SemanticObjectState::new(StoredGeometry::Rectangle {
+            size: Vec2::new(14.0, 8.0),
+        });
+        assert_eq!(state.role(), SemanticObjectRole::Ordinary);
+        state.set_role(SemanticObjectRole::Camera2D);
+        assert_eq!(state.role(), SemanticObjectRole::Camera2D);
     }
 
     #[test]

--- a/crates/noon-native/src/lib.rs
+++ b/crates/noon-native/src/lib.rs
@@ -10,7 +10,7 @@
 use std::sync::Arc;
 use std::time::Instant;
 
-use noon::{EvaluationError, ExecutionSession, FrameChanges};
+use noon::{EvaluationError, ExecutionSession, ExecutionSessionCameraError, FrameChanges};
 use noon_core::{Camera2DState, Vec2};
 use noon_render_wgpu::{Camera2D, FramePreparer, GpuRenderer};
 use winit::application::ApplicationHandler;
@@ -49,6 +49,7 @@ pub enum NativeHostError {
     Platform(String),
     Gpu(String),
     Runtime(EvaluationError),
+    Camera(ExecutionSessionCameraError),
 }
 
 impl std::fmt::Display for NativeHostError {
@@ -57,6 +58,7 @@ impl std::fmt::Display for NativeHostError {
             Self::Platform(message) => write!(formatter, "native platform error: {message}"),
             Self::Gpu(message) => write!(formatter, "native GPU error: {message}"),
             Self::Runtime(error) => error.fmt(formatter),
+            Self::Camera(error) => error.fmt(formatter),
         }
     }
 }
@@ -66,6 +68,12 @@ impl std::error::Error for NativeHostError {}
 impl From<EvaluationError> for NativeHostError {
     fn from(value: EvaluationError) -> Self {
         Self::Runtime(value)
+    }
+}
+
+impl From<ExecutionSessionCameraError> for NativeHostError {
+    fn from(value: ExecutionSessionCameraError) -> Self {
+        Self::Camera(value)
     }
 }
 
@@ -152,6 +160,8 @@ impl NativeApp {
 
         let started = self.started.get_or_insert_with(Instant::now);
         self.session.advance_to(started.elapsed().as_secs_f64())?;
+        let camera = self.session.camera()?;
+        gpu.set_camera(camera)?;
         let changes = self.session.take_frame_changes();
         let changes = if self.force_full_redraw {
             FrameChanges::all()
@@ -220,7 +230,14 @@ impl ApplicationHandler for NativeApp {
                 .as_ref()
                 .expect("resumed native host must own a window")
                 .clone();
-            match pollster::block_on(NativeGpu::new(window)) {
+            let camera = match self.session.camera() {
+                Ok(camera) => camera,
+                Err(error) => {
+                    self.fail(event_loop, error.into());
+                    return;
+                }
+            };
+            match pollster::block_on(NativeGpu::new(window, camera)) {
                 Ok(gpu) => {
                     self.gpu = Some(gpu);
                     self.started = Some(Instant::now());
@@ -247,8 +264,15 @@ impl ApplicationHandler for NativeApp {
         match event {
             WindowEvent::CloseRequested => event_loop.exit(),
             WindowEvent::Resized(size) => {
+                let camera = match self.session.camera() {
+                    Ok(camera) => camera,
+                    Err(error) => {
+                        self.fail(event_loop, error.into());
+                        return;
+                    }
+                };
                 if let Some(gpu) = self.gpu.as_mut() {
-                    if let Err(error) = gpu.resize(size) {
+                    if let Err(error) = gpu.resize(size, camera) {
                         self.fail(event_loop, error);
                         return;
                     }
@@ -287,7 +311,7 @@ struct NativeGpu {
 }
 
 impl NativeGpu {
-    async fn new(window: Arc<Window>) -> Result<Self, NativeHostError> {
+    async fn new(window: Arc<Window>, camera: Camera2DState) -> Result<Self, NativeHostError> {
         let size = window.inner_size();
         let width = size.width.max(1);
         let height = size.height.max(1);
@@ -321,7 +345,7 @@ impl NativeGpu {
 
         let mut renderer = GpuRenderer::new(&device, config.format);
         renderer.set_viewport(&device, &queue, width, height);
-        renderer.set_camera(&queue, camera_for_viewport(width, height)?);
+        renderer.set_camera(&queue, camera_for_viewport(camera, width, height)?);
 
         Ok(Self {
             instance,
@@ -335,7 +359,11 @@ impl NativeGpu {
         })
     }
 
-    fn resize(&mut self, size: PhysicalSize<u32>) -> Result<(), NativeHostError> {
+    fn resize(
+        &mut self,
+        size: PhysicalSize<u32>,
+        camera: Camera2DState,
+    ) -> Result<(), NativeHostError> {
         self.drawable = size.width > 0 && size.height > 0;
         if !self.drawable {
             return Ok(());
@@ -345,8 +373,21 @@ impl NativeGpu {
         self.surface.configure(&self.device, &self.config);
         self.renderer
             .set_viewport(&self.device, &self.queue, size.width, size.height);
-        self.renderer
-            .set_camera(&self.queue, camera_for_viewport(size.width, size.height)?);
+        self.renderer.set_camera(
+            &self.queue,
+            camera_for_viewport(camera, size.width, size.height)?,
+        );
+        Ok(())
+    }
+
+    fn set_camera(&mut self, camera: Camera2DState) -> Result<(), NativeHostError> {
+        if !self.drawable {
+            return Ok(());
+        }
+        self.renderer.set_camera(
+            &self.queue,
+            camera_for_viewport(camera, self.config.width, self.config.height)?,
+        );
         Ok(())
     }
 
@@ -379,13 +420,16 @@ impl NativeGpu {
     }
 }
 
-fn camera_for_viewport(width: u32, height: u32) -> Result<Camera2D, NativeHostError> {
+fn camera_for_viewport(
+    state: Camera2DState,
+    width: u32,
+    height: u32,
+) -> Result<Camera2D, NativeHostError> {
     if width == 0 || height == 0 {
         return Err(NativeHostError::Gpu(
             "camera viewport dimensions must be positive".to_owned(),
         ));
     }
-    let state = Camera2DState::default();
     let aspect = width as f32 / height as f32;
     Camera2D::new(state.center, Vec2::new(state.height * aspect, state.height))
         .map_err(|error| NativeHostError::Gpu(error.to_string()))
@@ -396,8 +440,20 @@ mod tests {
     use super::*;
 
     #[test]
+    fn canonical_camera_tracks_native_viewport_aspect() {
+        let state = Camera2DState {
+            center: Vec2::new(2.0, -1.0),
+            height: 6.0,
+        };
+        let camera = camera_for_viewport(state, 1600, 900).unwrap();
+        assert_eq!(camera.center, state.center);
+        assert!((camera.world_size.x - (6.0 * 16.0 / 9.0)).abs() < 1.0e-5);
+        assert_eq!(camera.world_size.y, 6.0);
+    }
+
+    #[test]
     fn default_camera_tracks_native_viewport_aspect() {
-        let camera = camera_for_viewport(1600, 900).unwrap();
+        let camera = camera_for_viewport(Camera2DState::default(), 1600, 900).unwrap();
         assert_eq!(camera.center, Vec2::ZERO);
         assert!((camera.world_size.x - (8.0 * 16.0 / 9.0)).abs() < 1.0e-5);
         assert_eq!(camera.world_size.y, 8.0);
@@ -405,15 +461,17 @@ mod tests {
 
     #[test]
     fn zero_sized_camera_viewport_is_rejected() {
-        assert!(camera_for_viewport(0, 720).is_err());
-        assert!(camera_for_viewport(1280, 0).is_err());
+        assert!(camera_for_viewport(Camera2DState::default(), 0, 720).is_err());
+        assert!(camera_for_viewport(Camera2DState::default(), 1280, 0).is_err());
     }
 
     #[cfg(target_os = "linux")]
     #[test]
     #[ignore = "requires an X11 display and a working native wgpu adapter"]
     fn native_surface_smoke_presents_typed_semantic_frame() {
-        use noon_core::{SemanticObjectState, SemanticStore, StoredGeometry};
+        use noon_core::{
+            SemanticObjectRole, SemanticObjectState, SemanticStore, SemanticVec3, StoredGeometry,
+        };
         use winit::platform::x11::EventLoopBuilderExtX11;
 
         let mut store = SemanticStore::new();
@@ -422,7 +480,23 @@ mod tests {
                 radius: 1.5,
             }));
         store.attach_to_scene(circle).unwrap();
+
+        let mut camera_state = SemanticObjectState::new(StoredGeometry::Rectangle {
+            size: Vec2::new(12.0, 6.0),
+        });
+        camera_state.transform.translation = SemanticVec3::new(2.0, -1.0, 0.0);
+        camera_state.set_role(SemanticObjectRole::Camera2D);
+        let camera = store.insert_semantic_object(camera_state);
+        store.attach_to_scene(camera).unwrap();
+
         let session = ExecutionSession::from_semantic_store(&store).unwrap();
+        assert_eq!(
+            session.camera().unwrap(),
+            Camera2DState {
+                center: Vec2::new(2.0, -1.0),
+                height: 6.0,
+            }
+        );
 
         let mut event_loop_builder = EventLoop::builder();
         event_loop_builder.with_any_thread(true);

--- a/crates/noon-web/src/direct_execution_smoke.rs
+++ b/crates/noon-web/src/direct_execution_smoke.rs
@@ -1,5 +1,8 @@
 use noon::ExecutionSession;
-use noon_core::{SemanticObjectProperty, SemanticObjectState, SemanticStore, StoredGeometry};
+use noon_core::{
+    Camera2DState, SemanticObjectProperty, SemanticObjectRole, SemanticObjectState, SemanticStore,
+    SemanticVec3, StoredGeometry, Vec2,
+};
 use wasm_bindgen::prelude::*;
 use web_sys::OffscreenCanvas;
 
@@ -23,7 +26,26 @@ pub async fn create_direct_execution_smoke_renderer(
         .bind_semantic_signal(opacity, object, SemanticObjectProperty::ObjectOpacity)
         .map_err(js_error)?;
 
+    let mut camera_state = SemanticObjectState::new(StoredGeometry::Rectangle {
+        size: Vec2::new(12.0, 6.0),
+    });
+    camera_state.transform.translation = SemanticVec3::new(2.0, -1.0, 0.0);
+    camera_state.set_role(SemanticObjectRole::Camera2D);
+    let camera = store.insert_semantic_object(camera_state);
+    store.attach_to_scene(camera).map_err(js_error)?;
+
     let session = ExecutionSession::from_semantic_store(&store).map_err(js_error)?;
+    let resolved_camera = session.camera().map_err(js_error)?;
+    if resolved_camera
+        != (Camera2DState {
+            center: Vec2::new(2.0, -1.0),
+            height: 6.0,
+        })
+    {
+        return Err(JsValue::from_str(
+            "direct Rust/WASM smoke did not resolve its authored semantic camera",
+        ));
+    }
     WasmExecutionCanvasRenderer::create_from_execution_session(canvas, session).await
 }
 

--- a/crates/noon-web/src/execution_canvas.rs
+++ b/crates/noon-web/src/execution_canvas.rs
@@ -1,4 +1,4 @@
-#[cfg(any(test, target_arch = "wasm32"))]
+#[cfg(test)]
 const MANIM_DEFAULT_CAMERA_HEIGHT: f32 = 8.0;
 
 #[cfg(target_arch = "wasm32")]
@@ -14,7 +14,9 @@ mod wasm {
     use std::mem;
 
     use noon::ExecutionSession;
-    use noon_core::{GeometryRef, ObjectId, ReactiveValue, SemanticNodeId, Transform2D, Vec2};
+    use noon_core::{
+        Camera2DState, GeometryRef, ObjectId, ReactiveValue, SemanticNodeId, Transform2D, Vec2,
+    };
     use noon_render_wgpu::{
         Camera2D, DrawStats, FramePreparer, GpuRenderer, PackedTransform, PreparedFrame,
         RenderPrimitive, UploadStats, UploadWrite,
@@ -29,7 +31,7 @@ mod wasm {
         ExecutionFrameMirror, TransportApplyOutcome, TransportSlotId,
     };
 
-    use super::{MANIM_DEFAULT_CAMERA_HEIGHT, MANIM_DEFAULT_CLEAR_COLOR};
+    use super::MANIM_DEFAULT_CLEAR_COLOR;
 
     #[derive(Debug)]
     struct WebDisplaySource;
@@ -262,11 +264,7 @@ mod wasm {
             };
             match outcome {
                 TransportApplyOutcome::Applied => {
-                    if camera.center != self.camera_center || camera.height != self.camera_height {
-                        self.camera_center = camera.center;
-                        self.camera_height = camera.height;
-                        self.update_camera()?;
-                    }
+                    self.sync_camera(camera)?;
                     self.pending_changes = changes;
                     Ok(true)
                 }
@@ -397,8 +395,8 @@ mod wasm {
             Ok(())
         }
 
-        /// Manual camera control remains as a low-level host API. Semantic scene
-        /// deltas automatically overwrite it with their shared Rust camera state.
+        /// Manual camera control remains as a low-level host API. Authoritative
+        /// transport or direct-session camera updates overwrite it when published.
         #[wasm_bindgen(js_name = setCamera)]
         pub fn set_camera(
             &mut self,
@@ -719,13 +717,14 @@ mod wasm {
             canvas: OffscreenCanvas,
             mut session: ExecutionSession,
         ) -> Result<Self, JsValue> {
+            let camera = session.camera().map_err(js_error)?;
             let pending_changes = session.take_frame_changes();
             Self::create_with_source(
                 canvas,
                 CanvasExecutionSource::Direct(session),
                 pending_changes,
-                Vec2::ZERO,
-                MANIM_DEFAULT_CAMERA_HEIGHT,
+                camera.center,
+                camera.height,
             )
             .await
         }
@@ -733,22 +732,32 @@ mod wasm {
         /// Evaluate a direct Rust/WASM execution session and publish only its runtime changes.
         pub fn evaluate(&mut self, time: f64) -> Result<bool, JsValue> {
             self.ensure_direct_source_idle()?;
-            let session = self.source.direct_mut().ok_or_else(|| {
-                js_message("typed execution APIs require a direct session source")
-            })?;
-            session.evaluate(time).map_err(js_error)?;
-            self.pending_changes = session.take_frame_changes();
+            let (pending_changes, camera) = {
+                let session = self.source.direct_mut().ok_or_else(|| {
+                    js_message("typed execution APIs require a direct session source")
+                })?;
+                session.evaluate(time).map_err(js_error)?;
+                let camera = session.camera().map_err(js_error)?;
+                (session.take_frame_changes(), camera)
+            };
+            self.sync_camera(camera)?;
+            self.pending_changes = pending_changes;
             Ok(!self.pending_changes.is_empty())
         }
 
         /// Seek a direct Rust/WASM execution session and publish its renderer-facing changes.
         pub fn seek(&mut self, time: f64) -> Result<bool, JsValue> {
             self.ensure_direct_source_idle()?;
-            let session = self.source.direct_mut().ok_or_else(|| {
-                js_message("typed execution APIs require a direct session source")
-            })?;
-            session.seek(time).map_err(js_error)?;
-            self.pending_changes = session.take_frame_changes();
+            let (pending_changes, camera) = {
+                let session = self.source.direct_mut().ok_or_else(|| {
+                    js_message("typed execution APIs require a direct session source")
+                })?;
+                session.seek(time).map_err(js_error)?;
+                let camera = session.camera().map_err(js_error)?;
+                (session.take_frame_changes(), camera)
+            };
+            self.sync_camera(camera)?;
+            self.pending_changes = pending_changes;
             Ok(!self.pending_changes.is_empty())
         }
 
@@ -759,13 +768,18 @@ mod wasm {
             value: impl Into<ReactiveValue>,
         ) -> Result<bool, JsValue> {
             self.ensure_direct_source_idle()?;
-            let session = self.source.direct_mut().ok_or_else(|| {
-                js_message("typed execution APIs require a direct session source")
-            })?;
-            session
-                .set_reactive_input(signal, value)
-                .map_err(js_error)?;
-            self.pending_changes = session.take_frame_changes();
+            let (pending_changes, camera) = {
+                let session = self.source.direct_mut().ok_or_else(|| {
+                    js_message("typed execution APIs require a direct session source")
+                })?;
+                session
+                    .set_reactive_input(signal, value)
+                    .map_err(js_error)?;
+                let camera = session.camera().map_err(js_error)?;
+                (session.take_frame_changes(), camera)
+            };
+            self.sync_camera(camera)?;
+            self.pending_changes = pending_changes;
             Ok(!self.pending_changes.is_empty())
         }
 
@@ -833,6 +847,15 @@ mod wasm {
             };
             result.update_camera()?;
             Ok(result)
+        }
+
+        fn sync_camera(&mut self, camera: Camera2DState) -> Result<(), JsValue> {
+            if camera.center == self.camera_center && camera.height == self.camera_height {
+                return Ok(());
+            }
+            self.camera_center = camera.center;
+            self.camera_height = camera.height;
+            self.update_camera()
         }
 
         fn update_camera(&mut self) -> Result<(), JsValue> {

--- a/crates/noon/src/execution_session.rs
+++ b/crates/noon/src/execution_session.rs
@@ -5,8 +5,8 @@ use noon_compile::{
     SemanticReactiveProjection,
 };
 use noon_core::{
-    AnimationOptions, MutationTransaction, ObjectId, ReactiveError, ReactiveValue, ScenePatch,
-    SemanticNodeId, SemanticStore, TrackId,
+    AnimationOptions, Camera2DState, MutationTransaction, ObjectId, ReactiveError, ReactiveValue,
+    ScenePatch, SemanticNodeId, SemanticStore, TrackId,
 };
 use noon_runtime::{EvaluationError, FrameChanges, FrameState, SceneInstance};
 
@@ -38,6 +38,31 @@ impl From<ReactiveError> for ExecutionSessionInputError {
         Self::Reactive(value)
     }
 }
+
+/// Error produced when the canonical semantic camera cannot be derived from the
+/// current effective runtime frame.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ExecutionSessionCameraError {
+    object: ObjectId,
+}
+
+impl ExecutionSessionCameraError {
+    pub const fn object(self) -> ObjectId {
+        self.object
+    }
+}
+
+impl std::fmt::Display for ExecutionSessionCameraError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "execution camera object {} is missing or not a valid 2D frame",
+            self.object.get()
+        )
+    }
+}
+
+impl std::error::Error for ExecutionSessionCameraError {}
 
 /// Error produced while activating one authoritative semantic animation declaration.
 #[derive(Clone, Debug, PartialEq)]
@@ -93,7 +118,9 @@ impl From<CompilePatchError> for ExecutionSessionAnimationError {
 /// The session does not own or mirror the [`SemanticStore`]. It retains only the
 /// compiler-owned semantic/execution identity mappings needed by hosts plus the
 /// existing [`SceneInstance`] runtime. Renderer and platform lifecycle remain outside
-/// this type.
+/// this type. The canonical camera is retained only as the execution identity of its
+/// ordinary semantic frame object; its value is always derived from the effective
+/// runtime frame.
 ///
 /// Runtime mutation is intentionally not exposed as a mutable escape hatch here:
 /// authored/live structural mutation remains owned by semantic transactions and
@@ -103,6 +130,7 @@ pub struct ExecutionSession {
     execution_index: SemanticExecutionIndex,
     reactive_projection: SemanticReactiveProjection,
     runtime: SceneInstance,
+    camera_object: Option<ObjectId>,
     next_activation_track_id: Option<u64>,
 }
 
@@ -113,6 +141,7 @@ impl ExecutionSession {
     ) -> Result<Self, SemanticExecutionLoweringError> {
         let mut execution_index = SemanticExecutionIndex::new();
         let lowered = lower_semantic_execution(store, &mut execution_index)?;
+        let camera_object = lowered.camera_object();
         let next_activation_track_id = lowered
             .compiled()
             .tracks_iter()
@@ -125,6 +154,7 @@ impl ExecutionSession {
             execution_index,
             reactive_projection,
             runtime,
+            camera_object,
             next_activation_track_id,
         })
     }
@@ -132,6 +162,31 @@ impl ExecutionSession {
     /// Current renderer-facing runtime frame.
     pub fn frame(&self) -> &FrameState {
         self.runtime.frame()
+    }
+
+    /// Current canonical 2D camera derived from the effective runtime frame object.
+    ///
+    /// Scenes without an authored camera use the shared Manim-compatible default.
+    /// An authored camera never falls back silently: if its effective frame becomes
+    /// invalid, the host receives an error just as the transport encoder does.
+    pub fn camera(&self) -> Result<Camera2DState, ExecutionSessionCameraError> {
+        let Some(camera_object) = self.camera_object else {
+            return Ok(Camera2DState::default());
+        };
+        let object = self
+            .runtime
+            .frame()
+            .objects
+            .iter()
+            .find(|object| object.id == camera_object)
+            .ok_or(ExecutionSessionCameraError {
+                object: camera_object,
+            })?;
+        Camera2DState::from_frame_object(&object.geometry, object.transform).ok_or(
+            ExecutionSessionCameraError {
+                object: camera_object,
+            },
+        )
     }
 
     /// Consume renderer-facing invalidation state accumulated by the runtime.
@@ -222,8 +277,8 @@ impl ExecutionSession {
 #[cfg(test)]
 mod tests {
     use noon_core::{
-        AnimationOptions, RateFunction, SemanticObjectProperty, SemanticObjectState, SemanticVec3,
-        StoredGeometry, Vec2,
+        AnimationOptions, RateFunction, SemanticObjectProperty, SemanticObjectRole,
+        SemanticObjectState, SemanticVec3, StoredGeometry, Vec2,
     };
 
     use super::*;
@@ -232,6 +287,15 @@ mod tests {
         AnimationOptions::new()
             .run_time(1.0)
             .rate_func(RateFunction::Linear)
+    }
+
+    fn camera_state(center: Vec2, height: f32) -> SemanticObjectState {
+        let mut state = SemanticObjectState::new(StoredGeometry::Rectangle {
+            size: Vec2::new(height * 16.0 / 9.0, height),
+        });
+        state.transform.translation = SemanticVec3::new(center.x as f64, center.y as f64, 0.0);
+        state.set_role(SemanticObjectRole::Camera2D);
+        state
     }
 
     #[test]
@@ -253,6 +317,7 @@ mod tests {
         assert_eq!(session.frame().objects.len(), 1);
         assert_eq!(session.frame().objects[0].id, execution_object);
         assert_eq!(session.frame().objects[0].style.opacity, 0.4);
+        assert_eq!(session.camera().unwrap(), Camera2DState::default());
 
         session.take_frame_changes();
         session.set_reactive_input(signal, 0.7_f32).unwrap();
@@ -263,6 +328,42 @@ mod tests {
         session.seek(1.25).unwrap();
         assert_eq!(session.frame().time, 1.25);
         assert_eq!(session.frame().objects[0].style.opacity, 0.7);
+    }
+
+    #[test]
+    fn canonical_camera_is_derived_from_effective_runtime_transform() {
+        let mut store = SemanticStore::new();
+        let camera = store.insert_semantic_object(camera_state(Vec2::new(1.0, 2.0), 8.0));
+        store.attach_to_scene(camera).unwrap();
+
+        let mut target_state = store.semantic_object_state_checked(camera).unwrap().clone();
+        target_state.transform.translation = SemanticVec3::new(5.0, -2.0, 0.0);
+        target_state.transform.scale = SemanticVec3::new(1.0, 0.5, 1.0);
+        let target = store.insert_semantic_object(target_state);
+        let animation = store
+            .insert_semantic_transform_animation(camera, target, AnimationOptions::new())
+            .unwrap();
+
+        let mut session = ExecutionSession::from_semantic_store(&store).unwrap();
+        assert_eq!(
+            session.camera().unwrap(),
+            Camera2DState {
+                center: Vec2::new(1.0, 2.0),
+                height: 8.0,
+            }
+        );
+
+        session
+            .activate_animation(&store, animation, linear_second())
+            .unwrap();
+        session.seek(0.5).unwrap();
+        assert_eq!(
+            session.camera().unwrap(),
+            Camera2DState {
+                center: Vec2::new(3.0, 0.0),
+                height: 6.0,
+            }
+        );
     }
 
     #[test]

--- a/web/direct-execution-boundary.test.mjs
+++ b/web/direct-execution-boundary.test.mjs
@@ -5,6 +5,10 @@ const rustHarness = await readFile(
   new URL("../crates/noon-web/src/direct_execution_smoke.rs", import.meta.url),
   "utf8",
 );
+const directCanvasHost = await readFile(
+  new URL("../crates/noon-web/src/execution_canvas.rs", import.meta.url),
+  "utf8",
+);
 const browserProbe = await readFile(
   new URL("./direct-execution-smoke-probe.js", import.meta.url),
   "utf8",
@@ -16,6 +20,8 @@ const browserSmokeHtml = await readFile(
 
 for (const required of [
   "SemanticStore::new()",
+  "SemanticObjectRole::Camera2D",
+  "session.camera()",
   "ExecutionSession::from_semantic_store",
   "create_from_execution_session",
 ]) {
@@ -34,6 +40,16 @@ for (const forbidden of [
   );
 }
 
+for (const required of [
+  "let camera = session.camera().map_err(js_error)?;",
+  "self.sync_camera(camera)?;",
+]) {
+  assert.ok(
+    directCanvasHost.includes(required),
+    `direct canvas host must consume canonical session camera through ${required}`,
+  );
+}
+
 for (const required of ["createDirectExecutionSmokeRenderer", "new OffscreenCanvas"]) {
   assert.ok(browserProbe.includes(required), `browser direct-execution proof must contain ${required}`);
 }
@@ -44,6 +60,7 @@ for (const forbidden of [
   "sceneJson",
   "initialDeltaJson",
   "applyDeltaJson",
+  "setCamera",
   "JSON.stringify",
 ]) {
   assert.equal(

--- a/web/direct-execution-smoke-probe.js
+++ b/web/direct-execution-smoke-probe.js
@@ -52,8 +52,10 @@ async function start() {
   if (!metrics.presented) {
     throw new Error("direct execution renderer did not present its semantic frame");
   }
-  if (metrics.objectCount !== 1) {
-    throw new Error(`direct execution renderer expected 1 object, got ${metrics.objectCount}`);
+  if (metrics.objectCount !== 2) {
+    throw new Error(
+      `direct execution renderer expected semantic object plus camera frame (2 objects), got ${metrics.objectCount}`,
+    );
   }
   if (metrics.drawCalls <= 0) {
     throw new Error(`direct execution renderer emitted ${metrics.drawCalls} draw calls`);


### PR DESCRIPTION
## Summary

Continue #969 A2/A6.3 by moving 2D camera authority onto the canonical typed semantic/execution path.

This branch establishes one camera authority across the typed execution hosts:

- an ordinary `SemanticObjectState` can carry the `Camera2D` scene role;
- canonical semantic lowering resolves at most one visible camera role to the existing execution `ObjectId` and validates its rectangle-frame contract fail-atomically;
- `ExecutionSession` retains only that identity and derives `Camera2DState` from the current effective runtime frame, so animation/reactivity can move/scale the camera without a duplicate mutable camera value;
- the direct native Rust host and direct Rust/WASM canvas host both consume `ExecutionSession::camera()`; viewport aspect remains a renderer-boundary concern;
- scenes without an authored camera preserve the shared Manim-compatible default; authored invalid cameras fail closed;
- the exact-head native surface smoke from #1079 is preserved and extended with a non-default authored camera.

Refs #969