### PR TITLE
A2/A6: route native platform input through typed execution

### DIFF
--- a/crates/noon-compile/src/semantic_lowering/reactive.rs
+++ b/crates/noon-compile/src/semantic_lowering/reactive.rs
@@ -1,7 +1,8 @@
 use std::collections::{HashMap, HashSet};
 
 use noon_core::{
-    Property, ReactiveError, ReactiveExpr, ReactiveGraphDefinition, ReactiveValue, SemanticNodeId,
+    NativeEventSource, NativeStateSource, Property, ReactiveError, ReactiveExpr,
+    ReactiveGraphDefinition, ReactiveValue, SemanticNativeInputSource, SemanticNodeId,
     SemanticObjectProperty, SemanticSignalError, SemanticSignalExpr, SemanticSignalSource,
     SemanticSignalValue, SemanticStore, SignalDefinition, SignalId, SignalSource,
 };
@@ -13,11 +14,15 @@ use super::SemanticExecutionProjection;
 ///
 /// This is not a second authored graph. `SignalId` values are deterministic
 /// compatibility encodings used only by the existing native reactive compiler/VM;
-/// semantic `SemanticNodeId` remains authoritative.
+/// semantic `SemanticNodeId` remains authoritative. Native input routing is derived
+/// from signal-owned semantic declarations while the same dependency closure is
+/// lowered, so platform hosts never need execution signal identity.
 #[derive(Clone, Debug, PartialEq)]
 pub struct SemanticReactiveProjection {
     graph: ReactiveGraphDefinition,
     signal_ids: HashMap<SemanticNodeId, SignalId>,
+    native_state_targets: HashMap<NativeStateSource, Vec<SignalId>>,
+    native_event_targets: HashMap<NativeEventSource, Vec<SignalId>>,
 }
 
 impl SemanticReactiveProjection {
@@ -27,6 +32,25 @@ impl SemanticReactiveProjection {
 
     pub fn execution_signal_id(&self, semantic_id: SemanticNodeId) -> Option<SignalId> {
         self.signal_ids.get(&semantic_id).copied()
+    }
+
+    /// Execution targets for one normalized sampled native source.
+    ///
+    /// This is an execution-plan detail consumed by `ExecutionSession`; public
+    /// platform hosts continue to operate only on `NativeStateSource` values.
+    pub fn native_state_targets(&self, source: &NativeStateSource) -> &[SignalId] {
+        self.native_state_targets
+            .get(source)
+            .map(Vec::as_slice)
+            .unwrap_or(&[])
+    }
+
+    /// Execution targets for one normalized discrete native event source.
+    pub fn native_event_targets(&self, source: &NativeEventSource) -> &[SignalId] {
+        self.native_event_targets
+            .get(source)
+            .map(Vec::as_slice)
+            .unwrap_or(&[])
     }
 
     pub fn signal_count(&self) -> usize {
@@ -108,7 +132,8 @@ impl std::error::Error for SemanticReactiveLoweringError {}
 /// Unbound semantic signals remain authored scene state but do not consume execution
 /// VM slots. Dependencies are generation-checked through `SemanticStore`, and the
 /// resulting `ReactiveGraphDefinition` is the existing native execution graph rather
-/// than a new reactive runtime model.
+/// than a new reactive runtime model. Native input routes are captured only for the
+/// same lowered dependency closure, avoiding a second total-scene discovery pass.
 pub fn lower_semantic_reactive_projection(
     store: &SemanticStore,
     projection: &SemanticExecutionProjection,
@@ -118,6 +143,8 @@ pub fn lower_semantic_reactive_projection(
         definitions: Vec::new(),
         bindings: Vec::new(),
         signal_ids: HashMap::new(),
+        native_state_targets: HashMap::new(),
+        native_event_targets: HashMap::new(),
         visiting: HashSet::new(),
     };
 
@@ -137,6 +164,8 @@ pub fn lower_semantic_reactive_projection(
     Ok(SemanticReactiveProjection {
         graph,
         signal_ids: lowerer.signal_ids,
+        native_state_targets: lowerer.native_state_targets,
+        native_event_targets: lowerer.native_event_targets,
     })
 }
 
@@ -145,6 +174,8 @@ struct ReactiveLowerer<'a> {
     definitions: Vec<SignalDefinition>,
     bindings: Vec<noon_core::ReactiveBinding>,
     signal_ids: HashMap<SemanticNodeId, SignalId>,
+    native_state_targets: HashMap<NativeStateSource, Vec<SignalId>>,
+    native_event_targets: HashMap<NativeEventSource, Vec<SignalId>>,
     visiting: HashSet<SemanticNodeId>,
 }
 
@@ -160,17 +191,30 @@ impl ReactiveLowerer<'_> {
             return Err(SemanticReactiveLoweringError::DependencyCycle(semantic_id));
         }
 
-        let source = self
-            .store
-            .semantic_signal_state(semantic_id)?
-            .source()
-            .clone();
+        let state = self.store.semantic_signal_state(semantic_id)?;
+        let source = state.source().clone();
+        let native_input = state.native_input().cloned();
         let signal = compatibility_signal_id(semantic_id);
         let source = self.lower_source(semantic_id, &source)?;
         self.visiting.remove(&semantic_id);
         self.signal_ids.insert(semantic_id, signal);
         self.definitions
             .push(SignalDefinition { id: signal, source });
+        match native_input {
+            Some(SemanticNativeInputSource::State(source)) => {
+                self.native_state_targets
+                    .entry(source)
+                    .or_default()
+                    .push(signal);
+            }
+            Some(SemanticNativeInputSource::Event(source)) => {
+                self.native_event_targets
+                    .entry(source)
+                    .or_default()
+                    .push(signal);
+            }
+            None => {}
+        }
         Ok(signal)
     }
 
@@ -288,8 +332,8 @@ fn compatibility_signal_id(id: SemanticNodeId) -> SignalId {
 #[cfg(test)]
 mod tests {
     use noon_core::{
-        ReactiveBinding, SemanticObjectState, SemanticSignalExpr, SemanticVec3, StoredGeometry,
-        Vec2,
+        NativeEventSource, NativeStateSource, ReactiveBinding, SemanticObjectState,
+        SemanticSignalExpr, SemanticVec3, StoredGeometry, Vec2,
     };
 
     use super::*;
@@ -359,6 +403,64 @@ mod tests {
                         Box::new(ReactiveExpr::Constant(ReactiveValue::Scalar(3.0))),
                     ))
         }));
+    }
+
+    #[test]
+    fn native_input_routes_are_lowered_with_the_active_reactive_dependency_closure() {
+        let mut store = SemanticStore::new();
+        let control = store.insert_semantic_input_signal(0.25_f64).unwrap();
+        let event = store.insert_semantic_input_signal(0.0_f64).unwrap();
+        let unrelated = store.insert_semantic_input_signal(false).unwrap();
+        let control_source = NativeStateSource::Control {
+            name: "opacity".to_owned(),
+        };
+        let event_source = NativeEventSource::KeyPress {
+            code: "Space".to_owned(),
+        };
+        store
+            .bind_semantic_native_state_input(control, control_source.clone())
+            .unwrap();
+        store
+            .bind_semantic_native_event_input(event, event_source.clone())
+            .unwrap();
+        store
+            .bind_semantic_native_state_input(
+                unrelated,
+                NativeStateSource::Key {
+                    code: "KeyZ".to_owned(),
+                },
+            )
+            .unwrap();
+        let object = visible_circle(&mut store);
+        store
+            .bind_semantic_signal(control, object, SemanticObjectProperty::ObjectOpacity)
+            .unwrap();
+        let derived = store
+            .insert_semantic_derived_signal(SemanticSignalExpr::Add(
+                Box::new(SemanticSignalExpr::signal(event)),
+                Box::new(SemanticSignalExpr::scalar(1.0)),
+            ))
+            .unwrap();
+        store
+            .bind_semantic_signal(derived, object, SemanticObjectProperty::RotationZ)
+            .unwrap();
+
+        let mut index = SemanticExecutionIndex::new();
+        let execution = projection(&store, &mut index);
+        let reactive = lower_semantic_reactive_projection(&store, &execution).unwrap();
+        let control_id = reactive.execution_signal_id(control).unwrap();
+        let event_id = reactive.execution_signal_id(event).unwrap();
+
+        assert_eq!(
+            reactive.native_state_targets(&control_source),
+            &[control_id]
+        );
+        assert_eq!(reactive.native_event_targets(&event_source), &[event_id]);
+        assert!(reactive
+            .native_state_targets(&NativeStateSource::Key {
+                code: "KeyZ".to_owned(),
+            })
+            .is_empty());
     }
 
     #[test]

--- a/crates/noon-core/src/reactive/native_inputs.rs
+++ b/crates/noon-core/src/reactive/native_inputs.rs
@@ -9,7 +9,7 @@ use crate::{ReactiveGraphDefinition, SignalId, SignalSource, ValueKind};
 /// Pointer positions are expressed in scene/world coordinates. Viewport size and
 /// wheel/gesture deltas use canvas CSS-pixel units. Controls are named scalar
 /// values supplied by the embedding UI.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum NativeStateSource {
     PointerPosition,
@@ -39,7 +39,7 @@ impl NativeStateSource {
 /// Each event drives a scalar event-sequence signal. Runtime dispatch increments
 /// that signal (with a bounded wrap) for every event, so identical repeated events
 /// still invalidate their dependency closure without requiring a host callback.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum NativeEventSource {
     PointerDown { button: u8 },

--- a/crates/noon-core/src/reactive/semantic_signals.rs
+++ b/crates/noon-core/src/reactive/semantic_signals.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
 
-use super::{SemanticNodeId, SemanticNodeKind, SemanticStore, SemanticVec3};
+use super::{
+    NativeEventSource, NativeStateSource, SemanticNodeId, SemanticNodeKind, SemanticStore,
+    SemanticVec3,
+};
 
 /// Stable authored value kind of a semantic signal.
 ///
@@ -110,10 +113,23 @@ pub enum SemanticSignalSource {
     Derived(SemanticSignalExpr),
 }
 
+/// Authored native source that drives one semantic input signal.
+///
+/// Platform hosts collect these language-neutral sources, while lowering maps the
+/// owning semantic signal onto private execution `SignalId`s. Native source identity
+/// never becomes authored object identity and no platform-specific event type enters
+/// the semantic scene.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum SemanticNativeInputSource {
+    State(NativeStateSource),
+    Event(NativeEventSource),
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct SemanticSignalState {
     source: SemanticSignalSource,
     value_kind: SemanticSignalValueKind,
+    native_input: Option<SemanticNativeInputSource>,
 }
 
 impl SemanticSignalState {
@@ -121,7 +137,11 @@ impl SemanticSignalState {
         source: SemanticSignalSource,
         value_kind: SemanticSignalValueKind,
     ) -> Self {
-        Self { source, value_kind }
+        Self {
+            source,
+            value_kind,
+            native_input: None,
+        }
     }
 
     pub const fn source(&self) -> &SemanticSignalSource {
@@ -130,6 +150,10 @@ impl SemanticSignalState {
 
     pub const fn value_kind(&self) -> SemanticSignalValueKind {
         self.value_kind
+    }
+
+    pub const fn native_input(&self) -> Option<&SemanticNativeInputSource> {
+        self.native_input.as_ref()
     }
 }
 
@@ -149,6 +173,14 @@ pub enum SemanticSignalError {
         rhs: SemanticSignalValueKind,
     },
     SourceTypeMismatch {
+        signal: SemanticNodeId,
+        expected: SemanticSignalValueKind,
+        actual: SemanticSignalValueKind,
+    },
+    NativeInputRequiresInputSignal {
+        signal: SemanticNodeId,
+    },
+    NativeInputTypeMismatch {
         signal: SemanticNodeId,
         expected: SemanticSignalValueKind,
         actual: SemanticSignalValueKind,
@@ -198,6 +230,22 @@ impl std::fmt::Display for SemanticSignalError {
             } => write!(
                 formatter,
                 "semantic signal {}:{} has stable kind {expected}, but replacement source is {actual}",
+                signal.slot(),
+                signal.generation()
+            ),
+            Self::NativeInputRequiresInputSignal { signal } => write!(
+                formatter,
+                "semantic signal {}:{} must remain an input signal while a native input source is attached",
+                signal.slot(),
+                signal.generation()
+            ),
+            Self::NativeInputTypeMismatch {
+                signal,
+                expected,
+                actual,
+            } => write!(
+                formatter,
+                "native input source for semantic signal {}:{} requires {expected}, but the signal is {actual}",
                 signal.slot(),
                 signal.generation()
             ),
@@ -261,6 +309,70 @@ impl SemanticStore {
         Ok(self.semantic_signal_state(id)?.value_kind())
     }
 
+    /// Attach or clear the language-neutral native input source for one semantic signal.
+    ///
+    /// The declaration lives on the authoritative signal node and therefore follows
+    /// its generational identity automatically. Validation and mutation are O(1) and
+    /// touch exactly that signal slot; no execution identity or scene scan is involved.
+    pub fn set_semantic_native_input(
+        &mut self,
+        id: SemanticNodeId,
+        native_input: Option<SemanticNativeInputSource>,
+    ) -> Result<bool, SemanticSignalError> {
+        self.set_last_mutation_writes(0);
+        let state = self.semantic_signal_state(id)?;
+        let previous = state.native_input().cloned();
+
+        if let Some(native_input) = native_input.as_ref() {
+            if !matches!(state.source(), SemanticSignalSource::Input(_)) {
+                return Err(SemanticSignalError::NativeInputRequiresInputSignal { signal: id });
+            }
+            let expected = native_input_signal_kind(native_input);
+            let actual = state.value_kind();
+            if expected != actual {
+                return Err(SemanticSignalError::NativeInputTypeMismatch {
+                    signal: id,
+                    expected,
+                    actual,
+                });
+            }
+        }
+
+        if previous == native_input {
+            return Ok(false);
+        }
+
+        self.node_mut(id)
+            .and_then(|node| node.semantic_signal_state_mut())
+            .expect("semantic signal existence validated before native input mutation")
+            .native_input = native_input;
+        self.set_last_mutation_writes(1);
+        Ok(true)
+    }
+
+    pub fn bind_semantic_native_state_input(
+        &mut self,
+        id: SemanticNodeId,
+        source: NativeStateSource,
+    ) -> Result<bool, SemanticSignalError> {
+        self.set_semantic_native_input(id, Some(SemanticNativeInputSource::State(source)))
+    }
+
+    pub fn bind_semantic_native_event_input(
+        &mut self,
+        id: SemanticNodeId,
+        source: NativeEventSource,
+    ) -> Result<bool, SemanticSignalError> {
+        self.set_semantic_native_input(id, Some(SemanticNativeInputSource::Event(source)))
+    }
+
+    pub fn clear_semantic_native_input(
+        &mut self,
+        id: SemanticNodeId,
+    ) -> Result<bool, SemanticSignalError> {
+        self.set_semantic_native_input(id, None)
+    }
+
     /// Replace one signal's authored source while preserving semantic identity and kind.
     ///
     /// Validation completes before the target node is written. Work is proportional
@@ -276,6 +388,9 @@ impl SemanticStore {
         let state = self.semantic_signal_state(id)?;
         let previous = state.source().clone();
         let expected = state.value_kind();
+        if state.native_input().is_some() && !matches!(&source, SemanticSignalSource::Input(_)) {
+            return Err(SemanticSignalError::NativeInputRequiresInputSignal { signal: id });
+        }
 
         let mut cache = HashMap::new();
         let actual = infer_source_kind(self, &source, Some(id), &mut cache)?;
@@ -298,6 +413,22 @@ impl SemanticStore {
         self.register_semantic_references_for_owner(id);
         self.set_last_mutation_writes(1);
         Ok(true)
+    }
+}
+
+fn native_input_signal_kind(source: &SemanticNativeInputSource) -> SemanticSignalValueKind {
+    match source {
+        SemanticNativeInputSource::State(
+            NativeStateSource::PointerPosition
+            | NativeStateSource::ViewportSize
+            | NativeStateSource::WheelDelta
+            | NativeStateSource::GestureDelta { .. },
+        ) => SemanticSignalValueKind::Vec3,
+        SemanticNativeInputSource::State(
+            NativeStateSource::PointerButton { .. } | NativeStateSource::Key { .. },
+        ) => SemanticSignalValueKind::Bool,
+        SemanticNativeInputSource::State(NativeStateSource::Control { .. })
+        | SemanticNativeInputSource::Event(_) => SemanticSignalValueKind::Scalar,
     }
 }
 
@@ -489,6 +620,145 @@ mod tests {
             SemanticSignalValueKind::Scalar
         );
         assert_eq!(store.last_mutation_stats().slots_written, 1);
+    }
+
+    #[test]
+    fn semantic_native_input_declaration_is_signal_owned_typed_and_local() {
+        let mut store = SemanticStore::new();
+        for index in 0..10_000 {
+            object(&mut store, index as f32 + 1.0);
+        }
+        let key = store.insert_semantic_input_signal(false).unwrap();
+        let viewport = store
+            .insert_semantic_input_signal(SemanticVec3::new(0.0, 0.0, 0.0))
+            .unwrap();
+        let event = store.insert_semantic_input_signal(0.0_f64).unwrap();
+
+        let key_source = NativeStateSource::Key {
+            code: "Space".to_owned(),
+        };
+        assert!(store
+            .bind_semantic_native_state_input(key, key_source.clone())
+            .unwrap());
+        assert_eq!(store.last_mutation_stats().slots_written, 1);
+        assert_eq!(
+            store.semantic_signal_state(key).unwrap().native_input(),
+            Some(&SemanticNativeInputSource::State(key_source))
+        );
+
+        assert!(store
+            .bind_semantic_native_state_input(viewport, NativeStateSource::ViewportSize)
+            .unwrap());
+        assert!(store
+            .bind_semantic_native_event_input(
+                event,
+                NativeEventSource::KeyPress {
+                    code: "Space".to_owned(),
+                },
+            )
+            .unwrap());
+        assert_eq!(store.last_mutation_stats().slots_written, 1);
+
+        assert!(store.clear_semantic_native_input(key).unwrap());
+        assert_eq!(store.last_mutation_stats().slots_written, 1);
+        assert_eq!(
+            store.semantic_signal_state(key).unwrap().native_input(),
+            None
+        );
+        assert!(!store.clear_semantic_native_input(key).unwrap());
+        assert_eq!(store.last_mutation_stats().slots_written, 0);
+    }
+
+    #[test]
+    fn semantic_native_input_rejects_derived_and_mismatched_signals_atomically() {
+        let mut store = SemanticStore::new();
+        let scalar = store.insert_semantic_input_signal(0.0_f64).unwrap();
+        let boolean = store.insert_semantic_input_signal(false).unwrap();
+        let derived = store
+            .insert_semantic_derived_signal(SemanticSignalExpr::signal(scalar))
+            .unwrap();
+
+        assert_eq!(
+            store.bind_semantic_native_state_input(
+                scalar,
+                NativeStateSource::Key {
+                    code: "KeyA".to_owned(),
+                },
+            ),
+            Err(SemanticSignalError::NativeInputTypeMismatch {
+                signal: scalar,
+                expected: SemanticSignalValueKind::Bool,
+                actual: SemanticSignalValueKind::Scalar,
+            })
+        );
+        assert_eq!(store.last_mutation_stats().slots_written, 0);
+
+        assert_eq!(
+            store.bind_semantic_native_event_input(
+                boolean,
+                NativeEventSource::KeyPress {
+                    code: "KeyA".to_owned(),
+                },
+            ),
+            Err(SemanticSignalError::NativeInputTypeMismatch {
+                signal: boolean,
+                expected: SemanticSignalValueKind::Scalar,
+                actual: SemanticSignalValueKind::Bool,
+            })
+        );
+        assert_eq!(store.last_mutation_stats().slots_written, 0);
+
+        assert_eq!(
+            store.bind_semantic_native_state_input(
+                derived,
+                NativeStateSource::Control {
+                    name: "zoom".to_owned(),
+                },
+            ),
+            Err(SemanticSignalError::NativeInputRequiresInputSignal { signal: derived })
+        );
+        assert_eq!(store.last_mutation_stats().slots_written, 0);
+    }
+
+    #[test]
+    fn attached_native_input_prevents_silent_conversion_to_a_derived_signal() {
+        let mut store = SemanticStore::new();
+        let dependency = store.insert_semantic_input_signal(1.0_f64).unwrap();
+        let target = store.insert_semantic_input_signal(0.0_f64).unwrap();
+        store
+            .bind_semantic_native_state_input(
+                target,
+                NativeStateSource::Control {
+                    name: "zoom".to_owned(),
+                },
+            )
+            .unwrap();
+        let before = store
+            .semantic_signal_state(target)
+            .unwrap()
+            .source()
+            .clone();
+
+        assert_eq!(
+            store.set_semantic_signal_source(
+                target,
+                SemanticSignalSource::Derived(SemanticSignalExpr::signal(dependency)),
+            ),
+            Err(SemanticSignalError::NativeInputRequiresInputSignal { signal: target })
+        );
+        assert_eq!(
+            store.semantic_signal_state(target).unwrap().source(),
+            &before
+        );
+        assert_eq!(store.last_mutation_stats().slots_written, 0);
+
+        store.clear_semantic_native_input(target).unwrap();
+        assert!(store
+            .set_semantic_signal_source(
+                target,
+                SemanticSignalSource::Derived(SemanticSignalExpr::signal(dependency)),
+            )
+            .unwrap());
     }
 
     #[test]

--- a/crates/noon-native/src/lib.rs
+++ b/crates/noon-native/src/lib.rs
@@ -1,22 +1,29 @@
 //! Native window lifecycle for Noon's typed in-process execution path.
 //!
 //! This crate owns the OS event loop, window, wgpu surface/device/queue, resize,
-//! realtime clock, frame acquisition, submission, and presentation. Semantic state,
-//! lowering/runtime behavior, and retained GPU rendering remain owned by their
-//! existing engine layers.
+//! realtime clock, native platform input collection, frame acquisition, submission,
+//! and presentation. Semantic state, input declarations, lowering/runtime behavior,
+//! and retained GPU rendering remain owned by their existing engine layers.
 
 #![forbid(unsafe_code)]
 
 use std::sync::Arc;
 use std::time::Instant;
 
-use noon::{EvaluationError, ExecutionSession, ExecutionSessionCameraError, FrameChanges};
-use noon_core::{Camera2DState, Vec2};
+use noon::{
+    EvaluationError, ExecutionSession, ExecutionSessionCameraError, ExecutionSessionInputError,
+    FrameChanges,
+};
+use noon_core::{
+    Camera2DState, NativeEventOccurrence, NativeEventSource, NativeInputValue, NativeStateSource,
+    Vec2,
+};
 use noon_render_wgpu::{Camera2D, FramePreparer, GpuRenderer};
 use winit::application::ApplicationHandler;
 use winit::dpi::PhysicalSize;
-use winit::event::WindowEvent;
+use winit::event::{ElementState, MouseButton, WindowEvent};
 use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
+use winit::keyboard::{KeyCode, PhysicalKey};
 use winit::window::{Window, WindowId};
 
 const CLEAR_COLOR: wgpu::Color = wgpu::Color {
@@ -50,6 +57,7 @@ pub enum NativeHostError {
     Gpu(String),
     Runtime(EvaluationError),
     Camera(ExecutionSessionCameraError),
+    Input(ExecutionSessionInputError),
 }
 
 impl std::fmt::Display for NativeHostError {
@@ -59,6 +67,7 @@ impl std::fmt::Display for NativeHostError {
             Self::Gpu(message) => write!(formatter, "native GPU error: {message}"),
             Self::Runtime(error) => error.fmt(formatter),
             Self::Camera(error) => error.fmt(formatter),
+            Self::Input(error) => error.fmt(formatter),
         }
     }
 }
@@ -74,6 +83,12 @@ impl From<EvaluationError> for NativeHostError {
 impl From<ExecutionSessionCameraError> for NativeHostError {
     fn from(value: ExecutionSessionCameraError) -> Self {
         Self::Camera(value)
+    }
+}
+
+impl From<ExecutionSessionInputError> for NativeHostError {
+    fn from(value: ExecutionSessionInputError) -> Self {
+        Self::Input(value)
     }
 }
 
@@ -115,6 +130,7 @@ struct NativeApp {
     window: Option<Arc<Window>>,
     gpu: Option<NativeGpu>,
     started: Option<Instant>,
+    next_input_sequence: u64,
     force_full_redraw: bool,
     error: Option<NativeHostError>,
     #[cfg(test)]
@@ -131,6 +147,7 @@ impl NativeApp {
             window: None,
             gpu: None,
             started: None,
+            next_input_sequence: 0,
             force_full_redraw: false,
             error: None,
             #[cfg(test)]
@@ -145,6 +162,79 @@ impl NativeApp {
             self.error = Some(error);
         }
         event_loop.exit();
+    }
+
+    fn dispatch_state(
+        &mut self,
+        source: NativeStateSource,
+        value: NativeInputValue,
+    ) -> Result<(), NativeHostError> {
+        self.session.set_native_state_input(source, value)?;
+        Ok(())
+    }
+
+    fn dispatch_event(&mut self, source: NativeEventSource) -> Result<(), NativeHostError> {
+        let sequence = self.next_input_sequence;
+        let next = sequence.checked_add(1).ok_or_else(|| {
+            NativeHostError::Platform("native input event sequence exhausted".to_owned())
+        })?;
+        self.session
+            .emit_native_event(NativeEventOccurrence::new(sequence, source))?;
+        self.next_input_sequence = next;
+        Ok(())
+    }
+
+    fn dispatch_viewport_size(
+        &mut self,
+        window: &Window,
+        size: PhysicalSize<u32>,
+    ) -> Result<(), NativeHostError> {
+        let logical = size.to_logical::<f32>(window.scale_factor());
+        self.dispatch_state(
+            NativeStateSource::ViewportSize,
+            NativeInputValue::Vec2(Vec2::new(logical.width, logical.height)),
+        )
+    }
+
+    fn dispatch_keyboard(
+        &mut self,
+        physical_key: PhysicalKey,
+        state: ElementState,
+    ) -> Result<(), NativeHostError> {
+        let PhysicalKey::Code(code) = physical_key else {
+            return Ok(());
+        };
+        let code = native_key_code(code);
+        let pressed = state == ElementState::Pressed;
+        self.dispatch_state(
+            NativeStateSource::Key { code: code.clone() },
+            NativeInputValue::Bool(pressed),
+        )?;
+        self.dispatch_event(if pressed {
+            NativeEventSource::KeyPress { code }
+        } else {
+            NativeEventSource::KeyRelease { code }
+        })
+    }
+
+    fn dispatch_pointer_button(
+        &mut self,
+        button: MouseButton,
+        state: ElementState,
+    ) -> Result<(), NativeHostError> {
+        let Some(button) = native_pointer_button(button) else {
+            return Ok(());
+        };
+        let pressed = state == ElementState::Pressed;
+        self.dispatch_state(
+            NativeStateSource::PointerButton { button },
+            NativeInputValue::Bool(pressed),
+        )?;
+        self.dispatch_event(if pressed {
+            NativeEventSource::PointerDown { button }
+        } else {
+            NativeEventSource::PointerUp { button }
+        })
     }
 
     fn redraw(&mut self) -> Result<(), NativeHostError> {
@@ -221,6 +311,10 @@ impl ApplicationHandler for NativeApp {
                     return;
                 }
             };
+            if let Err(error) = self.dispatch_viewport_size(&window, window.inner_size()) {
+                self.fail(event_loop, error);
+                return;
+            }
             self.window = Some(window);
         }
 
@@ -254,7 +348,7 @@ impl ApplicationHandler for NativeApp {
         window_id: WindowId,
         event: WindowEvent,
     ) {
-        let Some(window) = self.window.as_ref() else {
+        let Some(window) = self.window.as_ref().cloned() else {
             return;
         };
         if window.id() != window_id {
@@ -264,6 +358,10 @@ impl ApplicationHandler for NativeApp {
         match event {
             WindowEvent::CloseRequested => event_loop.exit(),
             WindowEvent::Resized(size) => {
+                if let Err(error) = self.dispatch_viewport_size(&window, size) {
+                    self.fail(event_loop, error);
+                    return;
+                }
                 let camera = match self.session.camera() {
                     Ok(camera) => camera,
                     Err(error) => {
@@ -277,6 +375,16 @@ impl ApplicationHandler for NativeApp {
                         return;
                     }
                     self.force_full_redraw = true;
+                }
+            }
+            WindowEvent::KeyboardInput { event, .. } => {
+                if let Err(error) = self.dispatch_keyboard(event.physical_key, event.state) {
+                    self.fail(event_loop, error);
+                }
+            }
+            WindowEvent::MouseInput { state, button, .. } => {
+                if let Err(error) = self.dispatch_pointer_button(button, state) {
+                    self.fail(event_loop, error);
                 }
             }
             WindowEvent::RedrawRequested => {
@@ -420,6 +528,23 @@ impl NativeGpu {
     }
 }
 
+fn native_key_code(code: KeyCode) -> String {
+    // winit's physical KeyCode variant names follow the W3C `KeyboardEvent.code`
+    // vocabulary used by Noon's browser native-input source identity.
+    format!("{code:?}")
+}
+
+fn native_pointer_button(button: MouseButton) -> Option<u8> {
+    match button {
+        MouseButton::Left => Some(0),
+        MouseButton::Middle => Some(1),
+        MouseButton::Right => Some(2),
+        MouseButton::Back => Some(3),
+        MouseButton::Forward => Some(4),
+        MouseButton::Other(button) => u8::try_from(button).ok(),
+    }
+}
+
 fn camera_for_viewport(
     state: Camera2DState,
     width: u32,
@@ -463,6 +588,78 @@ mod tests {
     fn zero_sized_camera_viewport_is_rejected() {
         assert!(camera_for_viewport(Camera2DState::default(), 0, 720).is_err());
         assert!(camera_for_viewport(Camera2DState::default(), 1280, 0).is_err());
+    }
+
+    #[test]
+    fn native_key_and_pointer_identity_match_cross_platform_input_vocabulary() {
+        assert_eq!(native_key_code(KeyCode::Space), "Space");
+        assert_eq!(native_key_code(KeyCode::KeyA), "KeyA");
+        assert_eq!(native_pointer_button(MouseButton::Left), Some(0));
+        assert_eq!(native_pointer_button(MouseButton::Middle), Some(1));
+        assert_eq!(native_pointer_button(MouseButton::Right), Some(2));
+        assert_eq!(native_pointer_button(MouseButton::Back), Some(3));
+        assert_eq!(native_pointer_button(MouseButton::Forward), Some(4));
+        assert_eq!(native_pointer_button(MouseButton::Other(42)), Some(42));
+        assert_eq!(native_pointer_button(MouseButton::Other(300)), None);
+    }
+
+    #[test]
+    fn native_app_dispatches_normalized_state_and_events_through_execution_session() {
+        use noon_core::{
+            SemanticObjectProperty, SemanticObjectState, SemanticStore, SemanticVec3,
+            StoredGeometry,
+        };
+
+        let mut store = SemanticStore::new();
+        let viewport = store
+            .insert_semantic_input_signal(SemanticVec3::new(0.0, 0.0, 0.0))
+            .unwrap();
+        store
+            .bind_semantic_native_state_input(viewport, NativeStateSource::ViewportSize)
+            .unwrap();
+        let key_event = store.insert_semantic_input_signal(0.0_f64).unwrap();
+        store
+            .bind_semantic_native_event_input(
+                key_event,
+                NativeEventSource::KeyPress {
+                    code: "Space".to_owned(),
+                },
+            )
+            .unwrap();
+        let object =
+            store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+                radius: 1.0,
+            }));
+        store.attach_to_scene(object).unwrap();
+        store
+            .bind_semantic_signal(viewport, object, SemanticObjectProperty::Translation)
+            .unwrap();
+        store
+            .bind_semantic_signal(key_event, object, SemanticObjectProperty::RotationZ)
+            .unwrap();
+        let session = ExecutionSession::from_semantic_store(&store).unwrap();
+        let mut app = NativeApp::new(session, NativeViewportConfig::default());
+
+        app.dispatch_state(
+            NativeStateSource::ViewportSize,
+            NativeInputValue::Vec2(Vec2::new(640.0, 360.0)),
+        )
+        .unwrap();
+        assert_eq!(
+            app.session.frame().objects[0].transform.translation,
+            Vec2::new(640.0, 360.0)
+        );
+
+        app.dispatch_event(NativeEventSource::KeyPress {
+            code: "Space".to_owned(),
+        })
+        .unwrap();
+        app.dispatch_event(NativeEventSource::KeyPress {
+            code: "Space".to_owned(),
+        })
+        .unwrap();
+        assert_eq!(app.session.frame().objects[0].transform.rotation, 2.0);
+        assert_eq!(app.next_input_sequence, 2);
     }
 
     #[cfg(target_os = "linux")]

--- a/crates/noon/src/execution_session.rs
+++ b/crates/noon/src/execution_session.rs
@@ -5,15 +5,18 @@ use noon_compile::{
     SemanticReactiveProjection,
 };
 use noon_core::{
-    AnimationOptions, Camera2DState, MutationTransaction, ObjectId, ReactiveError, ReactiveValue,
-    ScenePatch, SemanticNodeId, SemanticStore, TrackId,
+    AnimationOptions, Camera2DState, MutationTransaction, NativeEventOccurrence,
+    NativeInputRuntimeError, NativeInputValue, NativeStateSource, NativeStateUpdate, ObjectId,
+    ReactiveError, ReactiveValue, ScenePatch, SemanticNodeId, SemanticStore, TrackId,
 };
 use noon_runtime::{EvaluationError, FrameChanges, FrameState, SceneInstance};
 
-/// Error produced when a semantic reactive input cannot be applied to this execution session.
+/// Error produced when semantic/native reactive input cannot be applied to this execution session.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ExecutionSessionInputError {
     UnknownSemanticSignal(SemanticNodeId),
+    NativeInput(NativeInputRuntimeError),
+    NativeEventOutOfOrder { previous: u64, next: u64 },
     Reactive(ReactiveError),
 }
 
@@ -26,12 +29,23 @@ impl std::fmt::Display for ExecutionSessionInputError {
                 signal.slot(),
                 signal.generation()
             ),
+            Self::NativeInput(error) => error.fmt(formatter),
+            Self::NativeEventOutOfOrder { previous, next } => write!(
+                formatter,
+                "native input event sequence must increase: previous {previous}, next {next}"
+            ),
             Self::Reactive(error) => error.fmt(formatter),
         }
     }
 }
 
 impl std::error::Error for ExecutionSessionInputError {}
+
+impl From<NativeInputRuntimeError> for ExecutionSessionInputError {
+    fn from(value: NativeInputRuntimeError) -> Self {
+        Self::NativeInput(value)
+    }
+}
 
 impl From<ReactiveError> for ExecutionSessionInputError {
     fn from(value: ReactiveError) -> Self {
@@ -132,6 +146,7 @@ pub struct ExecutionSession {
     runtime: SceneInstance,
     camera_object: Option<ObjectId>,
     next_activation_track_id: Option<u64>,
+    last_native_event_sequence: Option<u64>,
 }
 
 impl ExecutionSession {
@@ -156,6 +171,7 @@ impl ExecutionSession {
             runtime,
             camera_object,
             next_activation_track_id,
+            last_native_event_sequence: None,
         })
     }
 
@@ -268,17 +284,98 @@ impl ExecutionSession {
         Ok(self.runtime.set_reactive_input(execution_signal, value)?)
     }
 
+    /// Deliver one normalized sampled native state source through signal-owned routes.
+    ///
+    /// Source/value validation is shared with browser/native input envelopes. The
+    /// source is resolved only against routes emitted by semantic reactive lowering;
+    /// platform hosts never receive or construct execution `SignalId`s. An unbound
+    /// source is a valid no-op.
+    pub fn set_native_state_input(
+        &mut self,
+        source: NativeStateSource,
+        value: NativeInputValue,
+    ) -> Result<&FrameState, ExecutionSessionInputError> {
+        let update = NativeStateUpdate::new(source, value)?;
+        let targets = self
+            .reactive_projection
+            .native_state_targets(&update.source)
+            .to_vec();
+        let value = reactive_value_from_native(update.value);
+        for signal in targets {
+            self.runtime.set_reactive_input(signal, value.clone())?;
+        }
+        Ok(self.runtime.frame())
+    }
+
+    /// Deliver one explicitly ordered discrete native event occurrence.
+    ///
+    /// Occurrences are never coalesced. The session rejects duplicate/out-of-order
+    /// sequence numbers before changing any event signal, then advances each lowered
+    /// scalar event counter using the existing native-event convention.
+    pub fn emit_native_event(
+        &mut self,
+        occurrence: NativeEventOccurrence,
+    ) -> Result<&FrameState, ExecutionSessionInputError> {
+        if let Some(previous) = self.last_native_event_sequence {
+            if occurrence.sequence <= previous {
+                return Err(ExecutionSessionInputError::NativeEventOutOfOrder {
+                    previous,
+                    next: occurrence.sequence,
+                });
+            }
+        }
+
+        let targets = self
+            .reactive_projection
+            .native_event_targets(&occurrence.source)
+            .to_vec();
+        let next_values = targets
+            .iter()
+            .map(|signal| {
+                let value = self
+                    .runtime
+                    .reactive_value(*signal)
+                    .expect("lowered native event target must remain a live reactive signal");
+                let ReactiveValue::Scalar(current) = value else {
+                    unreachable!(
+                        "semantic native event declaration validates a scalar input signal"
+                    )
+                };
+                if *current >= 1_000_000.0 {
+                    1.0
+                } else {
+                    *current + 1.0
+                }
+            })
+            .collect::<Vec<_>>();
+
+        for (signal, next) in targets.into_iter().zip(next_values) {
+            self.runtime.set_reactive_input(signal, next)?;
+        }
+        self.last_native_event_sequence = Some(occurrence.sequence);
+        Ok(self.runtime.frame())
+    }
+
     /// Resolve an authoritative semantic object identity to its current execution key.
     pub fn execution_object_id(&self, node: SemanticNodeId) -> Option<ObjectId> {
         self.execution_index.execution_object_id(node)
     }
 }
 
+fn reactive_value_from_native(value: NativeInputValue) -> ReactiveValue {
+    match value {
+        NativeInputValue::Scalar(value) => ReactiveValue::Scalar(value),
+        NativeInputValue::Bool(value) => ReactiveValue::Bool(value),
+        NativeInputValue::Vec2(value) => ReactiveValue::Vec2(value),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use noon_core::{
-        AnimationOptions, RateFunction, SemanticObjectProperty, SemanticObjectRole,
-        SemanticObjectState, SemanticVec3, StoredGeometry, Vec2,
+        AnimationOptions, NativeEventSource, NativeStateSource, RateFunction,
+        SemanticObjectProperty, SemanticObjectRole, SemanticObjectState, SemanticVec3,
+        StoredGeometry, Vec2,
     };
 
     use super::*;
@@ -328,6 +425,105 @@ mod tests {
         session.seek(1.25).unwrap();
         assert_eq!(session.frame().time, 1.25);
         assert_eq!(session.frame().objects[0].style.opacity, 0.7);
+    }
+
+    #[test]
+    fn native_sampled_source_reaches_runtime_without_exposing_signal_identity() {
+        let mut store = SemanticStore::new();
+        let signal = store.insert_semantic_input_signal(0.25_f64).unwrap();
+        let source = NativeStateSource::Control {
+            name: "opacity".to_owned(),
+        };
+        store
+            .bind_semantic_native_state_input(signal, source.clone())
+            .unwrap();
+        let object =
+            store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+                radius: 1.0,
+            }));
+        store.attach_to_scene(object).unwrap();
+        store
+            .bind_semantic_signal(signal, object, SemanticObjectProperty::ObjectOpacity)
+            .unwrap();
+        let mut session = ExecutionSession::from_semantic_store(&store).unwrap();
+
+        session.take_frame_changes();
+        session
+            .set_native_state_input(source, NativeInputValue::Scalar(0.8))
+            .unwrap();
+        assert_eq!(session.frame().objects[0].style.opacity, 0.8);
+        assert_eq!(session.take_frame_changes().object_indices(), &[0]);
+    }
+
+    #[test]
+    fn native_sampled_source_validates_value_before_runtime_mutation() {
+        let mut store = SemanticStore::new();
+        let signal = store
+            .insert_semantic_input_signal(SemanticVec3::new(0.0, 0.0, 0.0))
+            .unwrap();
+        store
+            .bind_semantic_native_state_input(signal, NativeStateSource::ViewportSize)
+            .unwrap();
+        let object =
+            store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+                radius: 1.0,
+            }));
+        store.attach_to_scene(object).unwrap();
+        store
+            .bind_semantic_signal(signal, object, SemanticObjectProperty::Translation)
+            .unwrap();
+        let mut session = ExecutionSession::from_semantic_store(&store).unwrap();
+        let before = session.frame().clone();
+
+        assert!(matches!(
+            session.set_native_state_input(
+                NativeStateSource::ViewportSize,
+                NativeInputValue::Scalar(1.0),
+            ),
+            Err(ExecutionSessionInputError::NativeInput(
+                NativeInputRuntimeError::TypeMismatch { .. }
+            ))
+        ));
+        assert_eq!(session.frame(), &before);
+    }
+
+    #[test]
+    fn native_discrete_events_are_ordered_and_never_coalesced() {
+        let mut store = SemanticStore::new();
+        let signal = store.insert_semantic_input_signal(0.0_f64).unwrap();
+        let source = NativeEventSource::KeyPress {
+            code: "Space".to_owned(),
+        };
+        store
+            .bind_semantic_native_event_input(signal, source.clone())
+            .unwrap();
+        let object =
+            store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+                radius: 1.0,
+            }));
+        store.attach_to_scene(object).unwrap();
+        store
+            .bind_semantic_signal(signal, object, SemanticObjectProperty::RotationZ)
+            .unwrap();
+        let mut session = ExecutionSession::from_semantic_store(&store).unwrap();
+
+        session
+            .emit_native_event(NativeEventOccurrence::new(10, source.clone()))
+            .unwrap();
+        assert_eq!(session.frame().objects[0].transform.rotation, 1.0);
+        session
+            .emit_native_event(NativeEventOccurrence::new(11, source.clone()))
+            .unwrap();
+        assert_eq!(session.frame().objects[0].transform.rotation, 2.0);
+
+        assert_eq!(
+            session.emit_native_event(NativeEventOccurrence::new(11, source)),
+            Err(ExecutionSessionInputError::NativeEventOutOfOrder {
+                previous: 11,
+                next: 11,
+            })
+        );
+        assert_eq!(session.frame().objects[0].transform.rotation, 2.0);
     }
 
     #[test]


### PR DESCRIPTION
## Scope

Continue #969 A2/A6.2 after #1079 proved real native surface presentation. Add the first production native input ingress onto the same typed `SemanticStore -> ExecutionSession -> SceneInstance` path.

This slice does **not** add a second input model, runtime router, transport queue, or winit-specific semantic vocabulary. It reuses Noon's existing language-neutral `NativeStateSource` / `NativeEventSource` contracts.

## Changes

- let authoritative `SemanticSignalState` own at most one optional normalized native state/event source declaration;
- validate native source kind against semantic signal kind and require externally driven signals to remain authored input signals;
- derive source -> existing execution `SignalId` routing while lowering the already-active semantic reactive dependency closure, with no separate total-scene input scan;
- add `ExecutionSession` sampled-state delivery and explicitly ordered discrete-event delivery without exposing VM signal identity;
- keep discrete events non-coalescing and reject duplicate/out-of-order ingress sequence numbers before mutation;
- collect unambiguous native platform inputs in `noon-native`: logical viewport size, physical-key state/press/release, and pointer-button state/down/up;
- preserve cross-platform key/button source identity (`KeyA`, `Space`, web-compatible button numbers);
- leave pointer-position world-coordinate normalization plus wheel/gesture/control breadth to #69 rather than guessing around camera/DPI semantics in the host boundary.

## Architecture

```text
SemanticSignalState native-input declaration
  -> semantic reactive lowering
  -> private source -> execution SignalId routes
  -> ExecutionSession
  -> existing reactive VM / FrameChanges

winit WindowEvent
  -> normalized NativeStateSource / NativeEventSource
  -> ExecutionSession
```

Semantic identity remains authoritative; `SignalId` stays below the session boundary. `noon-native` owns only platform collection/normalization and event sequence assignment.

## Coverage

- O(1), one-slot semantic declaration mutation and kind validation;
- derived-signal/native-driver conflicts fail before mutation;
- route lowering is limited to the active reactive dependency closure;
- sampled state reaches renderer-facing state through the session;
- invalid sampled values fail before runtime mutation;
- discrete events are ordered and never coalesced;
- native key/button normalization matches the existing cross-platform vocabulary;
- native app dispatch helpers exercise the real `ExecutionSession` input path.

Refs #969 #69 #1079.