### PR TITLE
Restore retained demo animation geometry parity

### DIFF
--- a/crates/noon-render-wgpu/src/gpu/retained_family_draw_border_prepare.rs
+++ b/crates/noon-render-wgpu/src/gpu/retained_family_draw_border_prepare.rs
@@ -204,7 +204,6 @@ impl RetainedFramePreparer {
                 SourceItem::Geometry {
                     object_id,
                     scratch_id,
-                    kind,
                 } => {
                     let object_index = frame
                         .retained
@@ -234,7 +233,6 @@ impl RetainedFramePreparer {
                     self.sources.push(SourceItem::Geometry {
                         object_id,
                         scratch_id,
-                        kind,
                     });
                 }
                 SourceItem::FastGlyphRun {

--- a/crates/noon-render-wgpu/src/gpu/retained_family_plan_set_prepare.rs
+++ b/crates/noon-render-wgpu/src/gpu/retained_family_plan_set_prepare.rs
@@ -158,7 +158,6 @@ impl RetainedFramePreparer {
                 SourceItem::Geometry {
                     object_id,
                     scratch_id,
-                    kind,
                 } => {
                     let object_index = frame
                         .retained
@@ -170,7 +169,6 @@ impl RetainedFramePreparer {
                         self.sources.push(SourceItem::Geometry {
                             object_id,
                             scratch_id,
-                            kind,
                         });
                         continue;
                     };
@@ -194,7 +192,6 @@ impl RetainedFramePreparer {
                             self.sources.push(SourceItem::Geometry {
                                 object_id,
                                 scratch_id,
-                                kind,
                             });
                         }
                         noon_core::FamilyAnimationMode::DrawBorderThenFill => {

--- a/crates/noon-render-wgpu/src/gpu/retained_family_prepare.rs
+++ b/crates/noon-render-wgpu/src/gpu/retained_family_prepare.rs
@@ -214,7 +214,6 @@ impl RetainedFramePreparer {
                 SourceItem::Geometry {
                     object_id,
                     scratch_id,
-                    kind,
                 } => {
                     let object_index = frame
                         .retained
@@ -236,7 +235,6 @@ impl RetainedFramePreparer {
                     self.sources.push(SourceItem::Geometry {
                         object_id,
                         scratch_id,
-                        kind,
                     });
                 }
                 SourceItem::FastGlyphRun {

--- a/crates/noon-render-wgpu/src/gpu/retained_text.rs
+++ b/crates/noon-render-wgpu/src/gpu/retained_text.rs
@@ -517,22 +517,12 @@ enum SourceItem {
     Geometry {
         object_id: ObjectId,
         scratch_id: ObjectId,
-        kind: ScratchGeometryKind,
     },
     FastGlyphRun {
         object_id: ObjectId,
         object_index: u32,
         run_index: u32,
     },
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum ScratchGeometryKind {
-    Circle,
-    Rectangle,
-    Line,
-    Path,
-    Unsupported,
 }
 
 /// Persistent preparation state for the mixed retained renderer.
@@ -663,15 +653,14 @@ impl RetainedFramePreparer {
             self.text.can_update_objects_locally(frame, changes, texts, metrics)?
                 && self.changes_are_fast_text_only(frame, changes)
         };
-        let scratch_reused =
-            self.prepare_scratch_with_changes(
-                frame,
-                changes,
-                text_can_update_locally,
-                texts,
-                fonts,
-                geometries,
-            )?;
+        let scratch_reused = self.prepare_scratch_with_changes(
+            frame,
+            changes,
+            text_can_update_locally,
+            texts,
+            fonts,
+            geometries,
+        )?;
 
         if scratch_reused
             && changes.is_empty()
@@ -930,7 +919,10 @@ impl RetainedFramePreparer {
                 continue;
             }
             match &object.content {
-                ObjectContentRef::Geometry(geometry) => {
+                ObjectContentRef::Geometry(semantic_geometry) => {
+                    let geometry = frame
+                        .render_geometry(object_index)
+                        .unwrap_or(semantic_geometry);
                     let geometry = resolve_geometry_ref(geometry, geometries)?;
                     self.push_geometry(
                         object.id,
@@ -1010,7 +1002,6 @@ impl RetainedFramePreparer {
         morph: f32,
     ) {
         let scratch_id = ObjectId::new(self.scratch.objects.len() as u64);
-        let kind = geometry_kind(&geometry);
         self.scratch.objects.push(FrameObjectState {
             id: scratch_id,
             geometry,
@@ -1025,7 +1016,6 @@ impl RetainedFramePreparer {
         self.sources.push(SourceItem::Geometry {
             object_id,
             scratch_id,
-            kind,
         });
     }
 
@@ -1223,16 +1213,6 @@ fn push_coalesced_range(ranges: &mut Vec<std::ops::Range<u32>>, range: std::ops:
     ranges.push(range);
 }
 
-fn geometry_kind(geometry: &GeometryRef) -> ScratchGeometryKind {
-    match geometry {
-        GeometryRef::Circle { .. } => ScratchGeometryKind::Circle,
-        GeometryRef::Rectangle { .. } => ScratchGeometryKind::Rectangle,
-        GeometryRef::Line { .. } => ScratchGeometryKind::Line,
-        GeometryRef::VectorPath(_) => ScratchGeometryKind::Path,
-        GeometryRef::External(_) => ScratchGeometryKind::Unsupported,
-    }
-}
-
 fn resolve_geometry_ref(
     geometry: &GeometryRef,
     geometries: &GeometryResourceArena,
@@ -1306,51 +1286,43 @@ fn rebuild_mixed_order(
             SourceItem::Geometry {
                 object_id,
                 scratch_id,
-                kind,
-            } => match kind {
-                ScratchGeometryKind::Circle => {
-                    if let Some(&index) = circle_indices.get(scratch_id) {
-                        push_geometry_item(output, *object_id, RenderPrimitive::Circle, index);
+            } => {
+                // Preparation is allowed to change the renderer primitive for one
+                // semantic object. In particular analytic Create/Uncreate lowers a
+                // circle/rectangle/line to a temporary path. Recover painter order
+                // from the primitive that was actually prepared rather than from the
+                // source geometry kind captured before preparation.
+                if let Some(&index) = path_indices.get(scratch_id) {
+                    if let Some((batch, _)) = geometry
+                        .path_batches
+                        .iter()
+                        .enumerate()
+                        .find(|(_, batch)| batch.instance_range.contains(&(index as u32)))
+                    {
+                        push_geometry_item(
+                            output,
+                            *object_id,
+                            RenderPrimitive::Path { batch },
+                            index,
+                        );
                     }
-                }
-                ScratchGeometryKind::Rectangle => {
-                    if let Some(&index) = rectangle_indices.get(scratch_id) {
-                        push_geometry_item(output, *object_id, RenderPrimitive::Rectangle, index);
-                    }
-                }
-                ScratchGeometryKind::Line => {
+                    // Create reveal heads are packed as lines sharing the scratch ID
+                    // and must remain immediately above the path body.
                     if let Some(indices) = line_indices.get(scratch_id) {
                         for &index in indices {
                             push_geometry_item(output, *object_id, RenderPrimitive::Line, index);
                         }
                     }
-                }
-                ScratchGeometryKind::Path => {
-                    if let Some(&index) = path_indices.get(scratch_id) {
-                        if let Some((batch, _)) = geometry
-                            .path_batches
-                            .iter()
-                            .enumerate()
-                            .find(|(_, batch)| batch.instance_range.contains(&(index as u32)))
-                        {
-                            push_geometry_item(
-                                output,
-                                *object_id,
-                                RenderPrimitive::Path { batch },
-                                index,
-                            );
-                        }
-                    }
-                    // `Create` reveal heads are packed as a line sharing the scratch
-                    // ID and must remain immediately above this path body.
-                    if let Some(indices) = line_indices.get(scratch_id) {
-                        for &index in indices {
-                            push_geometry_item(output, *object_id, RenderPrimitive::Line, index);
-                        }
+                } else if let Some(&index) = circle_indices.get(scratch_id) {
+                    push_geometry_item(output, *object_id, RenderPrimitive::Circle, index);
+                } else if let Some(&index) = rectangle_indices.get(scratch_id) {
+                    push_geometry_item(output, *object_id, RenderPrimitive::Rectangle, index);
+                } else if let Some(indices) = line_indices.get(scratch_id) {
+                    for &index in indices {
+                        push_geometry_item(output, *object_id, RenderPrimitive::Line, index);
                     }
                 }
-                ScratchGeometryKind::Unsupported => {}
-            },
+            }
         }
     }
 }

--- a/crates/noon-render-wgpu/tests/retained_animation_geometry_parity.rs
+++ b/crates/noon-render-wgpu/tests/retained_animation_geometry_parity.rs
@@ -1,0 +1,93 @@
+use noon_core::{
+    FontResourceArena, GeometryRef, GeometryResourceArena, ObjectContentRef, ObjectId, Style,
+    TextResourceArena, Transform2D, Vec2, VectorPath,
+};
+use noon_render_wgpu::{RenderPrimitive, RetainedFramePreparer, RetainedRenderItem};
+use noon_runtime::{FrameChanges, RetainedFrameObjectState, RetainedFrameState};
+use noon_text_render_wgpu::TextDeviceMetrics;
+
+fn retained_geometry_frame(
+    semantic_geometry: GeometryRef,
+    render_geometry: Option<GeometryRef>,
+    reveal: f32,
+    morph: f32,
+) -> RetainedFrameState {
+    RetainedFrameState {
+        time: 0.5,
+        objects: vec![RetainedFrameObjectState {
+            id: ObjectId::new(1),
+            content: ObjectContentRef::Geometry(semantic_geometry),
+            transform: Transform2D::default(),
+            style: Style::default(),
+            appearance: 1.0,
+        }],
+        presences: vec![true],
+        reveals: vec![reveal],
+        morphs: vec![morph],
+        render_geometries: vec![render_geometry],
+    }
+}
+
+fn assert_prepares_path(frame: &RetainedFrameState) {
+    let texts = TextResourceArena::new();
+    let fonts = FontResourceArena::new();
+    let geometries = GeometryResourceArena::new();
+    let metrics = TextDeviceMetrics::uniform(100.0).unwrap();
+    let (device, queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
+    let mut preparer = RetainedFramePreparer::new();
+
+    let prepared = preparer
+        .prepare_with_changes(
+            &device,
+            &queue,
+            frame,
+            &FrameChanges::all(),
+            &texts,
+            &fonts,
+            &geometries,
+            metrics,
+        )
+        .unwrap();
+
+    assert!(prepared.render_items.iter().any(|item| {
+        matches!(
+            item,
+            RetainedRenderItem::Geometry {
+                object_id,
+                batch,
+            } if *object_id == ObjectId::new(1)
+                && matches!(batch.primitive, RenderPrimitive::Path { .. })
+        )
+    }));
+}
+
+#[test]
+fn retained_analytic_create_uses_prepared_path_primitive_in_painter_order() {
+    let frame = retained_geometry_frame(GeometryRef::circle(1.0), None, 0.5, 0.0);
+    assert_prepares_path(&frame);
+}
+
+#[test]
+fn retained_transform_preserves_runtime_effective_render_geometry() {
+    let source = VectorPath::new()
+        .move_to(Vec2::new(-1.0, 0.0))
+        .line_to(Vec2::new(0.0, 1.0))
+        .line_to(Vec2::new(1.0, 0.0))
+        .line_to(Vec2::new(0.0, -1.0))
+        .close();
+    let target = VectorPath::new()
+        .move_to(Vec2::new(-1.0, -1.0))
+        .line_to(Vec2::new(-1.0, 1.0))
+        .line_to(Vec2::new(1.0, 1.0))
+        .line_to(Vec2::new(1.0, -1.0))
+        .close();
+    let render_geometry = GeometryRef::path(source.with_morph_target(target));
+    let frame = retained_geometry_frame(
+        GeometryRef::circle(1.0),
+        Some(render_geometry),
+        1.0,
+        0.5,
+    );
+
+    assert_prepares_path(&frame);
+}

--- a/crates/noon-render-wgpu/tests/retained_animation_geometry_parity.rs
+++ b/crates/noon-render-wgpu/tests/retained_animation_geometry_parity.rs
@@ -82,12 +82,7 @@ fn retained_transform_preserves_runtime_effective_render_geometry() {
         .line_to(Vec2::new(1.0, -1.0))
         .close();
     let render_geometry = GeometryRef::path(source.with_morph_target(target));
-    let frame = retained_geometry_frame(
-        GeometryRef::circle(1.0),
-        Some(render_geometry),
-        1.0,
-        0.5,
-    );
+    let frame = retained_geometry_frame(GeometryRef::circle(1.0), Some(render_geometry), 1.0, 0.5);
 
     assert_prepares_path(&frame);
 }


### PR DESCRIPTION
## Summary

- preserve `RetainedFrameState::render_geometry()` when the mixed retained adapter builds renderer scratch geometry, so transient transform geometry reaches `FramePreparer`
- stop caching pre-preparation primitive kind in painter-order sources; recover the primitive from the geometry actually prepared instead
- keep Create/Uncreate reveal-head lines immediately above their prepared path body
- add focused renderer regressions for partial analytic `Create` and semantic-circle + transient morph-path transform state

## Regression

Normal Python playground authoring now routes through canonical retained execution. Two latent adapter parity holes became visible there:

1. heterogeneous transforms (for example circle → square) carry their in-progress path in `RetainedFrameState::render_geometries`, but the retained scratch adapter rebuilt from semantic `object.content` and discarded that path;
2. analytic Create/Uncreate may enter `FramePreparer` as Circle/Rectangle/Line but be prepared as a temporary Path, while mixed painter-order reconstruction still looked up the pre-preparation primitive kind and therefore emitted no draw item.

This fixes the shared retained-frame → renderer-scratch boundary rather than special-casing the demo authoring APIs.