### PR TITLE
A2/A6: align native input compatibility semantics

### DIFF
--- a/crates/noon-native/src/lib.rs
+++ b/crates/noon-native/src/lib.rs
@@ -529,9 +529,14 @@ impl NativeGpu {
 }
 
 fn native_key_code(code: KeyCode) -> String {
-    // winit's physical KeyCode variant names follow the W3C `KeyboardEvent.code`
-    // vocabulary used by Noon's browser native-input source identity.
-    format!("{code:?}")
+    // winit mostly follows the W3C `KeyboardEvent.code` vocabulary, but names
+    // MetaLeft/MetaRight as SuperLeft/SuperRight. Normalize those exceptions so
+    // browser and native hosts address the same authored source identity.
+    match code {
+        KeyCode::SuperLeft => "MetaLeft".to_owned(),
+        KeyCode::SuperRight => "MetaRight".to_owned(),
+        _ => format!("{code:?}"),
+    }
 }
 
 fn native_pointer_button(button: MouseButton) -> Option<u8> {
@@ -594,6 +599,8 @@ mod tests {
     fn native_key_and_pointer_identity_match_cross_platform_input_vocabulary() {
         assert_eq!(native_key_code(KeyCode::Space), "Space");
         assert_eq!(native_key_code(KeyCode::KeyA), "KeyA");
+        assert_eq!(native_key_code(KeyCode::SuperLeft), "MetaLeft");
+        assert_eq!(native_key_code(KeyCode::SuperRight), "MetaRight");
         assert_eq!(native_pointer_button(MouseButton::Left), Some(0));
         assert_eq!(native_pointer_button(MouseButton::Middle), Some(1));
         assert_eq!(native_pointer_button(MouseButton::Right), Some(2));

--- a/crates/noon/src/execution_session.rs
+++ b/crates/noon/src/execution_session.rs
@@ -11,6 +11,8 @@ use noon_core::{
 };
 use noon_runtime::{EvaluationError, FrameChanges, FrameState, SceneInstance};
 
+const NATIVE_EVENT_SEQUENCE_WRAP: f32 = 1_000_000.0;
+
 /// Error produced when semantic/native reactive input cannot be applied to this execution session.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ExecutionSessionInputError {
@@ -341,8 +343,8 @@ impl ExecutionSession {
                         "semantic native event declaration validates a scalar input signal"
                     )
                 };
-                if *current >= 1_000_000.0 {
-                    1.0
+                if *current >= NATIVE_EVENT_SEQUENCE_WRAP {
+                    0.0
                 } else {
                     *current + 1.0
                 }
@@ -524,6 +526,32 @@ mod tests {
             })
         );
         assert_eq!(session.frame().objects[0].transform.rotation, 2.0);
+    }
+
+    #[test]
+    fn native_discrete_event_counter_matches_existing_bounded_wrap_convention() {
+        let mut store = SemanticStore::new();
+        let signal = store
+            .insert_semantic_input_signal(NATIVE_EVENT_SEQUENCE_WRAP)
+            .unwrap();
+        let source = NativeEventSource::PointerDown { button: 0 };
+        store
+            .bind_semantic_native_event_input(signal, source.clone())
+            .unwrap();
+        let object =
+            store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+                radius: 1.0,
+            }));
+        store.attach_to_scene(object).unwrap();
+        store
+            .bind_semantic_signal(signal, object, SemanticObjectProperty::RotationZ)
+            .unwrap();
+        let mut session = ExecutionSession::from_semantic_store(&store).unwrap();
+
+        session
+            .emit_native_event(NativeEventOccurrence::new(0, source))
+            .unwrap();
+        assert_eq!(session.frame().objects[0].transform.rotation, 0.0);
     }
 
     #[test]


### PR DESCRIPTION
## Scope

Follow-up to #1083 after its merge raced with final compatibility review. Keep the new typed native-input ingress aligned with Noon's existing native-input semantics and browser source identity.

## Changes

- preserve the existing bounded discrete-event counter convention (`1_000_000 -> 0`) in `ExecutionSession`, with a regression;
- normalize winit `SuperLeft` / `SuperRight` to browser/W3C `KeyboardEvent.code` identities `MetaLeft` / `MetaRight`, with tests;
- no new input model, routing layer, queue, or platform-specific semantic vocabulary.

The source tree is otherwise exactly #1083 as merged in `e4de2197243e803301054acf9ff3e32d8f95c7f7`.

Refs #1083 #969 #69.