### PR TITLE
A2/A6: derive native host wake state from runtime

### DIFF
--- a/crates/noon-native/src/lib.rs
+++ b/crates/noon-native/src/lib.rs
@@ -8,11 +8,11 @@
 #![forbid(unsafe_code)]
 
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use noon::{
     EvaluationError, ExecutionSession, ExecutionSessionCameraError, ExecutionSessionInputError,
-    FrameChanges,
+    FrameChanges, TimelineWakeState,
 };
 use noon_core::{
     Camera2DState, NativeEventOccurrence, NativeEventSource, NativeInputValue, NativeStateSource,
@@ -113,7 +113,7 @@ pub fn run_with_config(
 
     let event_loop =
         EventLoop::new().map_err(|error| NativeHostError::Platform(error.to_string()))?;
-    event_loop.set_control_flow(ControlFlow::Poll);
+    event_loop.set_control_flow(ControlFlow::Wait);
     let mut app = NativeApp::new(session, config);
     event_loop
         .run_app(&mut app)
@@ -124,12 +124,46 @@ pub fn run_with_config(
     Ok(())
 }
 
+#[derive(Clone, Copy, Debug)]
+struct RealtimeClock {
+    wall_origin: Instant,
+    scene_origin: f64,
+}
+
+impl RealtimeClock {
+    const fn new(wall_origin: Instant, scene_origin: f64) -> Self {
+        Self {
+            wall_origin,
+            scene_origin,
+        }
+    }
+
+    fn scene_time_at(self, now: Instant) -> f64 {
+        self.scene_origin
+            + now
+                .saturating_duration_since(self.wall_origin)
+                .as_secs_f64()
+    }
+
+    fn wall_deadline(self, scene_time: f64) -> Option<Instant> {
+        let offset = scene_time - self.scene_origin;
+        if !offset.is_finite() {
+            return None;
+        }
+        if offset <= 0.0 {
+            return Some(self.wall_origin);
+        }
+        self.wall_origin
+            .checked_add(Duration::from_secs_f64(offset))
+    }
+}
+
 struct NativeApp {
     session: ExecutionSession,
     config: NativeViewportConfig,
     window: Option<Arc<Window>>,
     gpu: Option<NativeGpu>,
-    started: Option<Instant>,
+    realtime_clock: Option<RealtimeClock>,
     next_input_sequence: u64,
     force_full_redraw: bool,
     error: Option<NativeHostError>,
@@ -146,7 +180,7 @@ impl NativeApp {
             config,
             window: None,
             gpu: None,
-            started: None,
+            realtime_clock: None,
             next_input_sequence: 0,
             force_full_redraw: false,
             error: None,
@@ -237,20 +271,42 @@ impl NativeApp {
         })
     }
 
+    fn advance_realtime_timeline(&mut self, now: Instant) -> Result<(), NativeHostError> {
+        let Some(clock) = self.realtime_clock else {
+            return Ok(());
+        };
+        match self.session.wake_state().timeline() {
+            TimelineWakeState::Continuous => {
+                self.session.advance_to(clock.scene_time_at(now))?;
+            }
+            TimelineWakeState::Deadline(scene_time) => {
+                if clock
+                    .wall_deadline(scene_time)
+                    .is_some_and(|deadline| deadline <= now)
+                {
+                    self.session
+                        .advance_to(clock.scene_time_at(now).max(scene_time))?;
+                }
+            }
+            TimelineWakeState::Quiescent => {}
+        }
+        Ok(())
+    }
+
     fn redraw(&mut self) -> Result<(), NativeHostError> {
         let Some(window) = self.window.as_ref().cloned() else {
             return Ok(());
         };
-        let Some(gpu) = self.gpu.as_mut() else {
-            return Ok(());
-        };
-        if !gpu.drawable {
+        if !self.gpu.as_ref().is_some_and(|gpu| gpu.drawable) {
             return Ok(());
         }
 
-        let started = self.started.get_or_insert_with(Instant::now);
-        self.session.advance_to(started.elapsed().as_secs_f64())?;
+        self.advance_realtime_timeline(Instant::now())?;
         let camera = self.session.camera()?;
+        let gpu = self
+            .gpu
+            .as_mut()
+            .expect("drawable native host must own GPU state");
         gpu.set_camera(camera)?;
         let changes = self.session.take_frame_changes();
         let changes = if self.force_full_redraw {
@@ -334,7 +390,10 @@ impl ApplicationHandler for NativeApp {
             match pollster::block_on(NativeGpu::new(window, camera)) {
                 Ok(gpu) => {
                     self.gpu = Some(gpu);
-                    self.started = Some(Instant::now());
+                    self.realtime_clock = Some(RealtimeClock::new(
+                        Instant::now(),
+                        self.session.frame().time,
+                    ));
                     self.force_full_redraw = true;
                 }
                 Err(error) => self.fail(event_loop, error),
@@ -400,9 +459,48 @@ impl ApplicationHandler for NativeApp {
         }
     }
 
-    fn about_to_wait(&mut self, _event_loop: &ActiveEventLoop) {
-        if let Some(window) = self.window.as_ref() {
+    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
+        let Some(window) = self.window.as_ref() else {
+            event_loop.set_control_flow(ControlFlow::Wait);
+            return;
+        };
+        if !self.gpu.as_ref().is_some_and(|gpu| gpu.drawable) {
+            event_loop.set_control_flow(ControlFlow::Wait);
+            return;
+        }
+
+        let wake = self.session.wake_state();
+        if self.force_full_redraw || wake.frame_pending() {
             window.request_redraw();
+            event_loop.set_control_flow(ControlFlow::Wait);
+            return;
+        }
+
+        match wake.timeline() {
+            TimelineWakeState::Continuous => {
+                window.request_redraw();
+                event_loop.set_control_flow(ControlFlow::Poll);
+            }
+            TimelineWakeState::Deadline(scene_time) => {
+                let Some(clock) = self.realtime_clock else {
+                    window.request_redraw();
+                    event_loop.set_control_flow(ControlFlow::Wait);
+                    return;
+                };
+                let Some(deadline) = clock.wall_deadline(scene_time) else {
+                    event_loop.set_control_flow(ControlFlow::Wait);
+                    return;
+                };
+                if deadline <= Instant::now() {
+                    window.request_redraw();
+                    event_loop.set_control_flow(ControlFlow::Wait);
+                } else {
+                    event_loop.set_control_flow(ControlFlow::WaitUntil(deadline));
+                }
+            }
+            TimelineWakeState::Quiescent => {
+                event_loop.set_control_flow(ControlFlow::Wait);
+            }
         }
     }
 }
@@ -570,6 +668,19 @@ mod tests {
     use super::*;
 
     #[test]
+    fn realtime_clock_preserves_nonzero_authored_time_origin() {
+        let wall_origin = Instant::now();
+        let clock = RealtimeClock::new(wall_origin, 12.5);
+        let two_seconds_later = wall_origin + Duration::from_secs(2);
+
+        assert_eq!(clock.scene_time_at(two_seconds_later), 14.5);
+        assert_eq!(
+            clock.wall_deadline(15.5),
+            Some(wall_origin + Duration::from_secs(3))
+        );
+    }
+
+    #[test]
     fn canonical_camera_tracks_native_viewport_aspect() {
         let state = Camera2DState {
             center: Vec2::new(2.0, -1.0),
@@ -656,6 +767,7 @@ mod tests {
             app.session.frame().objects[0].transform.translation,
             Vec2::new(640.0, 360.0)
         );
+        assert_eq!(app.session.frame().time, 0.0);
 
         app.dispatch_event(NativeEventSource::KeyPress {
             code: "Space".to_owned(),
@@ -666,6 +778,7 @@ mod tests {
         })
         .unwrap();
         assert_eq!(app.session.frame().objects[0].transform.rotation, 2.0);
+        assert_eq!(app.session.frame().time, 0.0);
         assert_eq!(app.next_input_sequence, 2);
     }
 
@@ -705,7 +818,7 @@ mod tests {
         let mut event_loop_builder = EventLoop::builder();
         event_loop_builder.with_any_thread(true);
         let event_loop = event_loop_builder.build().unwrap();
-        event_loop.set_control_flow(ControlFlow::Poll);
+        event_loop.set_control_flow(ControlFlow::Wait);
 
         let mut app = NativeApp::new(
             session,

--- a/crates/noon-runtime/src/reactive.rs
+++ b/crates/noon-runtime/src/reactive.rs
@@ -17,6 +17,9 @@ pub use signal_timeline::*;
 mod timeline_scheduler;
 pub use timeline_scheduler::*;
 
+mod wake;
+pub use wake::*;
+
 // Retained objects reuse the same deterministic scheduler until frame storage is unified.
 mod retained_runtime;
 pub use retained_runtime::*;

--- a/crates/noon-runtime/src/reactive/timeline_scheduler.rs
+++ b/crates/noon-runtime/src/reactive/timeline_scheduler.rs
@@ -1,7 +1,7 @@
 use std::{
     cmp::Ordering,
     collections::BTreeMap,
-    ops::Bound::{Excluded, Included},
+    ops::Bound::{Excluded, Included, Unbounded},
 };
 
 use noon_compile::{CompiledChannelKey, CompiledScene, CompiledTrack};
@@ -149,6 +149,14 @@ impl TimelineEventScheduler {
 
     pub fn live_group_count(&self) -> usize {
         self.group_indices.len()
+    }
+
+    pub(crate) fn next_event_time(&self) -> Option<f64> {
+        let lower = time_upper_bound(self.time);
+        self.events
+            .range((Excluded(lower), Unbounded))
+            .next()
+            .map(|(key, _kind)| key.time.0)
     }
 
     /// Replace the event/index lowering for exactly one object/property channel.
@@ -533,6 +541,25 @@ mod tests {
         scheduler.seek(0.5);
         assert_eq!(scheduler.advance(1.0), 1);
         assert_eq!(scheduler.active_groups().len(), 1);
+    }
+
+    #[test]
+    fn next_event_time_tracks_strictly_future_boundary() {
+        let tracks = vec![
+            position_track(1, 0, 1.0, 2.0),
+            position_track(2, 1, 4.0, 1.0),
+        ];
+        let mut scheduler = TimelineEventScheduler::new(&tracks);
+        scheduler.seek(0.0);
+        assert_eq!(scheduler.next_event_time(), Some(1.0));
+        scheduler.advance(1.0);
+        assert_eq!(scheduler.next_event_time(), Some(3.0));
+        scheduler.advance(3.0);
+        assert_eq!(scheduler.next_event_time(), Some(4.0));
+        scheduler.advance(4.0);
+        assert_eq!(scheduler.next_event_time(), Some(5.0));
+        scheduler.advance(5.0);
+        assert_eq!(scheduler.next_event_time(), None);
     }
 
     #[test]

--- a/crates/noon-runtime/src/reactive/wake.rs
+++ b/crates/noon-runtime/src/reactive/wake.rs
@@ -1,0 +1,111 @@
+use crate::{SceneInstance, TimelineEventScheduler};
+
+/// Timeline cadence requested by the existing event-driven runtime scheduler.
+///
+/// This is a scheduling observation, not a second scheduler. Hosts decide how to
+/// realize it with RAF, `WaitUntil`, platform timers, or another wake primitive.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum TimelineWakeState {
+    /// At least one authored timeline channel is active and can vary with scene time.
+    Continuous,
+    /// No channel is active; the next authored timeline boundary is at this scene time.
+    Deadline(f64),
+    /// No active channel or future authored timeline boundary remains.
+    Quiescent,
+}
+
+/// Target-neutral host wake state for one runtime instance.
+///
+/// Presentation dirtiness is orthogonal to timeline cadence: a static scene can need
+/// one presentation after input and then become quiescent again. Keeping both facts
+/// prevents hosts from inventing their own dirty/deadline model.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct RuntimeWakeState {
+    frame_pending: bool,
+    timeline: TimelineWakeState,
+}
+
+impl RuntimeWakeState {
+    pub const fn frame_pending(self) -> bool {
+        self.frame_pending
+    }
+
+    pub const fn timeline(self) -> TimelineWakeState {
+        self.timeline
+    }
+
+    pub const fn is_quiescent(self) -> bool {
+        !self.frame_pending && matches!(self.timeline, TimelineWakeState::Quiescent)
+    }
+}
+
+impl TimelineEventScheduler {
+    pub fn wake_state(&self) -> TimelineWakeState {
+        if !self.active_groups().is_empty() {
+            TimelineWakeState::Continuous
+        } else if let Some(deadline) = self.next_event_time() {
+            TimelineWakeState::Deadline(deadline)
+        } else {
+            TimelineWakeState::Quiescent
+        }
+    }
+}
+
+impl SceneInstance {
+    /// Current runtime-owned dirty/deadline/completion state for platform hosts.
+    pub fn wake_state(&self) -> RuntimeWakeState {
+        RuntimeWakeState {
+            frame_pending: !self.changes.is_empty(),
+            timeline: self.timeline_scheduler.wake_state(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use noon_compile::CompiledTrack;
+    use noon_core::{
+        CompositionTimeMap, Property, RateFunction, TrackId, TrackTiming, TrackValues, Vec2,
+    };
+
+    use super::*;
+
+    fn position_track(start: f64, duration: f64) -> CompiledTrack {
+        CompiledTrack {
+            id: TrackId::new(1),
+            object_index: 0,
+            property: Property::Position,
+            values: TrackValues::Vec2 {
+                from: Vec2::ZERO,
+                to: Vec2::new(1.0, 0.0),
+            },
+            timing: TrackTiming {
+                start_time: start,
+                duration,
+                easing: RateFunction::Linear,
+            },
+            time_map: CompositionTimeMap::default(),
+            transform_geometry_plan: None,
+        }
+    }
+
+    #[test]
+    fn timeline_wake_state_reuses_active_set_and_next_event_index() {
+        let mut scheduler = TimelineEventScheduler::new(&[position_track(5.0, 2.0)]);
+        scheduler.seek(0.0);
+        assert_eq!(scheduler.wake_state(), TimelineWakeState::Deadline(5.0));
+
+        scheduler.advance(5.0);
+        assert_eq!(scheduler.wake_state(), TimelineWakeState::Continuous);
+
+        scheduler.advance(7.0);
+        assert_eq!(scheduler.wake_state(), TimelineWakeState::Quiescent);
+    }
+
+    #[test]
+    fn empty_timeline_is_quiescent_without_a_synthetic_deadline() {
+        let mut scheduler = TimelineEventScheduler::new(&[]);
+        scheduler.seek(0.0);
+        assert_eq!(scheduler.wake_state(), TimelineWakeState::Quiescent);
+    }
+}

--- a/crates/noon/src/execution_session.rs
+++ b/crates/noon/src/execution_session.rs
@@ -9,7 +9,7 @@ use noon_core::{
     NativeInputRuntimeError, NativeInputValue, NativeStateSource, NativeStateUpdate, ObjectId,
     ReactiveError, ReactiveValue, ScenePatch, SemanticNodeId, SemanticStore, TrackId,
 };
-use noon_runtime::{EvaluationError, FrameChanges, FrameState, SceneInstance};
+use noon_runtime::{EvaluationError, FrameChanges, FrameState, RuntimeWakeState, SceneInstance};
 
 const NATIVE_EVENT_SEQUENCE_WRAP: f32 = 1_000_000.0;
 
@@ -207,6 +207,12 @@ impl ExecutionSession {
         )
     }
 
+    /// Read runtime-owned presentation dirtiness and timeline cadence without
+    /// exposing the runtime scheduler or introducing a host-side timing model.
+    pub fn wake_state(&self) -> RuntimeWakeState {
+        self.runtime.wake_state()
+    }
+
     /// Consume renderer-facing invalidation state accumulated by the runtime.
     pub fn take_frame_changes(&mut self) -> FrameChanges {
         self.runtime.take_frame_changes()
@@ -379,6 +385,7 @@ mod tests {
         SemanticObjectProperty, SemanticObjectRole, SemanticObjectState, SemanticVec3,
         StoredGeometry, Vec2,
     };
+    use noon_runtime::TimelineWakeState;
 
     use super::*;
 
@@ -427,6 +434,57 @@ mod tests {
         session.seek(1.25).unwrap();
         assert_eq!(session.frame().time, 1.25);
         assert_eq!(session.frame().objects[0].style.opacity, 0.7);
+    }
+
+    #[test]
+    fn wake_state_separates_one_pending_frame_from_static_completion() {
+        let mut store = SemanticStore::new();
+        let object =
+            store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+                radius: 1.0,
+            }));
+        store.attach_to_scene(object).unwrap();
+        let mut session = ExecutionSession::from_semantic_store(&store).unwrap();
+
+        let wake = session.wake_state();
+        assert!(wake.frame_pending());
+        assert_eq!(wake.timeline(), TimelineWakeState::Quiescent);
+        assert!(!wake.is_quiescent());
+
+        session.take_frame_changes();
+        assert!(session.wake_state().is_quiescent());
+    }
+
+    #[test]
+    fn activated_animation_requests_continuous_frames_until_endpoint() {
+        let mut store = SemanticStore::new();
+        let object =
+            store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+                radius: 1.0,
+            }));
+        store.attach_to_scene(object).unwrap();
+        let mut target_state = store.semantic_object_state_checked(object).unwrap().clone();
+        target_state.transform.translation = SemanticVec3::new(4.0, 0.0, 0.0);
+        let target = store.insert_semantic_object(target_state);
+        let animation = store
+            .insert_semantic_transform_animation(object, target, AnimationOptions::new())
+            .unwrap();
+        let mut session = ExecutionSession::from_semantic_store(&store).unwrap();
+        session.take_frame_changes();
+
+        session
+            .activate_animation(&store, animation, linear_second())
+            .unwrap();
+        assert_eq!(
+            session.wake_state().timeline(),
+            TimelineWakeState::Continuous
+        );
+
+        session.seek(1.0).unwrap();
+        assert_eq!(
+            session.wake_state().timeline(),
+            TimelineWakeState::Quiescent
+        );
     }
 
     #[test]

--- a/crates/noon/src/lib.rs
+++ b/crates/noon/src/lib.rs
@@ -32,7 +32,10 @@ pub use execution_session::*;
 pub use geometry_authoring::*;
 pub use legacy::*;
 pub use line_matcher_authoring::*;
-pub use noon_runtime::{EvaluationError, FrameChanges, FrameObjectState, FrameState};
+pub use noon_runtime::{
+    EvaluationError, FrameChanges, FrameObjectState, FrameState, RuntimeWakeState,
+    TimelineWakeState,
+};
 pub use polygram_authoring::*;
 pub use reactive_authoring::*;
 pub use retained_family_authoring_lowering::*;


### PR DESCRIPTION
## Scope

Start #1085 by establishing the target-neutral runtime/session wake contract and consuming it in the native host. This slice removes unconditional polling for clean/static scenes without introducing another scheduler authority.

## Changes

- derive timeline cadence directly from the existing `TimelineEventScheduler` active set and next-event B-tree index;
- expose target-neutral `TimelineWakeState` / `RuntimeWakeState` through `SceneInstance` and `ExecutionSession` without exposing scheduler internals;
- keep renderer-facing frame dirtiness orthogonal to timeline cadence so one input/expose redraw can settle again;
- switch `noon-native` to `ControlFlow::Wait` / `WaitUntil` for clean scenes and future authored deadlines; active timeline interpolation remains realtime-driven;
- anchor native wall time to the session's current authored time rather than assuming authored time starts at zero;
- do not advance authored time for static/input/presentation-only redraws; input on a settled scene therefore publishes with authored `dt == 0` and settles again;
- preserve transient surface recovery through the existing full-redraw fallback.

## Architecture

```text
existing TimelineEventScheduler active set / event index
    -> RuntimeWakeState
    -> ExecutionSession::wake_state()
    -> native platform Wait / WaitUntil / active redraw
```

No host-side timeline scan, duplicate event heap, timer authority, transport queue, or mutable runtime escape hatch is added.

## Coverage

- static runtime separates one pending presentation from timeline quiescence;
- active animation reports continuous cadence and becomes quiescent at its endpoint;
- next-event lookup is strictly future and reuses the existing event index;
- native realtime mapping preserves nonzero authored-time origins;
- native sampled/discrete input leaves authored time unchanged while settled;
- existing native surface smoke continues to exercise real present.

Callback/resource completion wakes and direct-WASM/browser timer adaptation remain follow-on #1085 cases and are intentionally not synthesized in this slice.

Refs #1085 #969 #961