### PR TITLE
A2/A6: fail closed on unrepresentable native wake deadlines

### DIFF
--- a/crates/noon-native/src/lib.rs
+++ b/crates/noon-native/src/lib.rs
@@ -153,8 +153,8 @@ impl RealtimeClock {
         if offset <= 0.0 {
             return Some(self.wall_origin);
         }
-        self.wall_origin
-            .checked_add(Duration::from_secs_f64(offset))
+        let offset = Duration::try_from_secs_f64(offset).ok()?;
+        self.wall_origin.checked_add(offset)
     }
 }
 
@@ -678,6 +678,12 @@ mod tests {
             clock.wall_deadline(15.5),
             Some(wall_origin + Duration::from_secs(3))
         );
+    }
+
+    #[test]
+    fn realtime_clock_rejects_unrepresentable_deadline_without_panicking() {
+        let clock = RealtimeClock::new(Instant::now(), 0.0);
+        assert_eq!(clock.wall_deadline(f64::MAX), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Follow-up to #1091.

`RealtimeClock::wall_deadline` currently validates that the scene-time offset is finite, then calls `Duration::from_secs_f64(offset)`. A finite but unrepresentably large value can still panic there.

This changes the conversion to `Duration::try_from_secs_f64(offset).ok()?`, preserving the existing `Option<Instant>` fail-closed contract, and adds a regression using `f64::MAX`.

No wake architecture, runtime scheduler, session surface, or host policy changes are introduced here. The branch is one file and one commit directly on the #1091 merge commit.

Part of #969.