### PR TITLE
A2/A6: project session wake state to browser primitives

### DIFF
--- a/crates/noon-web/src/execution_wake.rs
+++ b/crates/noon-web/src/execution_wake.rs
@@ -1,4 +1,4 @@
-use noon::ExecutionSession;
+use noon::{ExecutionSegment, ExecutionSession};
 use noon_runtime::{RuntimeWakeState, TimelineWakeState};
 
 /// Browser primitive requested by the target-neutral execution-session wake state.
@@ -35,6 +35,19 @@ impl BrowserExecutionWakePlan {
         Self::from_runtime(session.wake_state())
     }
 
+    /// Derive browser wake mechanics while driving one logical authored segment.
+    ///
+    /// Renderer dirtiness still comes from the ordinary runtime wake observation,
+    /// while authored-time cadence is clipped/supplemented by the session segment
+    /// boundary. A pure `wait()` can therefore request a timer without manufacturing
+    /// a no-op runtime track or giving the browser its own timeline model.
+    pub fn from_segment(session: &ExecutionSession, segment: ExecutionSegment) -> Self {
+        Self::from_parts(
+            session.wake_state().frame_pending(),
+            session.segment_state(segment).timeline(),
+        )
+    }
+
     /// Project one target-neutral runtime wake observation into browser primitives.
     pub fn from_runtime(state: RuntimeWakeState) -> Self {
         Self::from_parts(state.frame_pending(), state.timeline())
@@ -59,7 +72,7 @@ impl BrowserExecutionWakePlan {
         self.present_now
     }
 
-    /// Browser cadence corresponding exactly to the runtime timeline wake state.
+    /// Browser cadence corresponding exactly to the runtime/session wake state.
     pub const fn cadence(self) -> BrowserExecutionCadence {
         self.cadence
     }
@@ -97,6 +110,16 @@ mod tests {
 
     use super::*;
 
+    fn static_session() -> ExecutionSession {
+        let mut store = SemanticStore::new();
+        let object =
+            store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+                radius: 1.0,
+            }));
+        store.attach_to_scene(object).unwrap();
+        ExecutionSession::from_semantic_store(&store).unwrap()
+    }
+
     #[test]
     fn browser_projection_preserves_presentation_and_timeline_as_orthogonal_facts() {
         let present_static =
@@ -132,14 +155,7 @@ mod tests {
 
     #[test]
     fn direct_static_session_settles_after_its_initial_presentation() {
-        let mut store = SemanticStore::new();
-        let object =
-            store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
-                radius: 1.0,
-            }));
-        store.attach_to_scene(object).unwrap();
-
-        let mut session = ExecutionSession::from_semantic_store(&store).unwrap();
+        let mut session = static_session();
         let initial = BrowserExecutionWakePlan::from_session(&session);
         assert!(initial.present_now());
         assert_eq!(initial.cadence(), BrowserExecutionCadence::Idle);
@@ -147,5 +163,24 @@ mod tests {
         session.take_frame_changes();
         let settled = BrowserExecutionWakePlan::from_session(&session);
         assert!(settled.is_idle());
+    }
+
+    #[test]
+    fn pure_wait_uses_segment_deadline_while_raw_runtime_stays_idle() {
+        let mut session = static_session();
+        session.take_frame_changes();
+        let segment = session.wait_segment(2.0).unwrap();
+
+        assert!(BrowserExecutionWakePlan::from_session(&session).is_idle());
+        let waiting = BrowserExecutionWakePlan::from_segment(&session, segment);
+        assert_eq!(
+            waiting.cadence(),
+            BrowserExecutionCadence::TimerAtSceneTime(2.0)
+        );
+        assert_eq!(waiting.timer_delay_seconds(session.frame().time), Some(2.0));
+
+        session.advance_segment_to(segment, 9.0).unwrap();
+        assert!(BrowserExecutionWakePlan::from_segment(&session, segment).is_idle());
+        assert_eq!(session.frame().time, 2.0);
     }
 }

--- a/crates/noon-web/src/execution_wake.rs
+++ b/crates/noon-web/src/execution_wake.rs
@@ -1,0 +1,151 @@
+use noon::ExecutionSession;
+use noon_runtime::{RuntimeWakeState, TimelineWakeState};
+
+/// Browser primitive requested by the target-neutral execution-session wake state.
+///
+/// This is only a host adaptation. Timeline ownership remains in the runtime; browser
+/// code must not synthesize another event heap or cadence model from scene contents.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum BrowserExecutionCadence {
+    /// Active authored-time work can vary continuously and should be driven by the
+    /// browser's next presentation-frame callback.
+    AnimationFrame,
+    /// No channel is active; wake when authored time reaches this deterministic
+    /// scene-time boundary. Browser code may realize this with a timer.
+    TimerAtSceneTime(f64),
+    /// No authored-time wake remains.
+    Idle,
+}
+
+/// Mechanical browser projection of [`ExecutionSession::wake_state`].
+///
+/// Presentation dirtiness stays orthogonal to authored-time cadence. A static scene
+/// can request one immediate presentation and still be `Idle` afterward, while an
+/// active scene can request an animation frame even when no renderer changes are
+/// pending at the instant this plan is observed.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct BrowserExecutionWakePlan {
+    present_now: bool,
+    cadence: BrowserExecutionCadence,
+}
+
+impl BrowserExecutionWakePlan {
+    /// Derive browser wake mechanics from the shared session/runtime authority.
+    pub fn from_session(session: &ExecutionSession) -> Self {
+        Self::from_runtime(session.wake_state())
+    }
+
+    /// Project one target-neutral runtime wake observation into browser primitives.
+    pub fn from_runtime(state: RuntimeWakeState) -> Self {
+        Self::from_parts(state.frame_pending(), state.timeline())
+    }
+
+    const fn from_parts(frame_pending: bool, timeline: TimelineWakeState) -> Self {
+        let cadence = match timeline {
+            TimelineWakeState::Continuous => BrowserExecutionCadence::AnimationFrame,
+            TimelineWakeState::Deadline(deadline) => {
+                BrowserExecutionCadence::TimerAtSceneTime(deadline)
+            }
+            TimelineWakeState::Quiescent => BrowserExecutionCadence::Idle,
+        };
+        Self {
+            present_now: frame_pending,
+            cadence,
+        }
+    }
+
+    /// Whether renderer-facing effective state is waiting for one presentation.
+    pub const fn present_now(self) -> bool {
+        self.present_now
+    }
+
+    /// Browser cadence corresponding exactly to the runtime timeline wake state.
+    pub const fn cadence(self) -> BrowserExecutionCadence {
+        self.cadence
+    }
+
+    /// Whether the browser should request its next presentation-frame callback.
+    pub const fn needs_animation_frame(self) -> bool {
+        matches!(self.cadence, BrowserExecutionCadence::AnimationFrame)
+    }
+
+    /// Relative authored-time delay for a deterministic timer wake.
+    ///
+    /// This deliberately does not read wall time or own a clock. A browser host that
+    /// is driving authored time 1:1 from a realtime wall clock can convert this delay
+    /// into its timer primitive. Invalid time is rejected rather than producing an
+    /// unrepresentable or accidental busy-loop delay.
+    pub fn timer_delay_seconds(self, current_scene_time: f64) -> Option<f64> {
+        let BrowserExecutionCadence::TimerAtSceneTime(deadline) = self.cadence else {
+            return None;
+        };
+        if !current_scene_time.is_finite() || !deadline.is_finite() {
+            return None;
+        }
+        Some((deadline - current_scene_time).max(0.0))
+    }
+
+    /// True only after presentation is clean and no authored-time wake remains.
+    pub const fn is_idle(self) -> bool {
+        !self.present_now && matches!(self.cadence, BrowserExecutionCadence::Idle)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use noon_core::{SemanticObjectState, SemanticStore, StoredGeometry};
+
+    use super::*;
+
+    #[test]
+    fn browser_projection_preserves_presentation_and_timeline_as_orthogonal_facts() {
+        let present_static =
+            BrowserExecutionWakePlan::from_parts(true, TimelineWakeState::Quiescent);
+        assert!(present_static.present_now());
+        assert_eq!(present_static.cadence(), BrowserExecutionCadence::Idle);
+        assert!(!present_static.is_idle());
+
+        let clean_active =
+            BrowserExecutionWakePlan::from_parts(false, TimelineWakeState::Continuous);
+        assert!(!clean_active.present_now());
+        assert!(clean_active.needs_animation_frame());
+
+        let clean_deadline =
+            BrowserExecutionWakePlan::from_parts(false, TimelineWakeState::Deadline(4.5));
+        assert_eq!(
+            clean_deadline.cadence(),
+            BrowserExecutionCadence::TimerAtSceneTime(4.5)
+        );
+    }
+
+    #[test]
+    fn browser_deadline_delay_is_authored_time_relative_and_fails_closed() {
+        let plan = BrowserExecutionWakePlan::from_parts(false, TimelineWakeState::Deadline(5.0));
+        assert_eq!(plan.timer_delay_seconds(3.5), Some(1.5));
+        assert_eq!(plan.timer_delay_seconds(6.0), Some(0.0));
+        assert_eq!(plan.timer_delay_seconds(f64::NAN), None);
+
+        let invalid =
+            BrowserExecutionWakePlan::from_parts(false, TimelineWakeState::Deadline(f64::INFINITY));
+        assert_eq!(invalid.timer_delay_seconds(0.0), None);
+    }
+
+    #[test]
+    fn direct_static_session_settles_after_its_initial_presentation() {
+        let mut store = SemanticStore::new();
+        let object =
+            store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+                radius: 1.0,
+            }));
+        store.attach_to_scene(object).unwrap();
+
+        let mut session = ExecutionSession::from_semantic_store(&store).unwrap();
+        let initial = BrowserExecutionWakePlan::from_session(&session);
+        assert!(initial.present_now());
+        assert_eq!(initial.cadence(), BrowserExecutionCadence::Idle);
+
+        session.take_frame_changes();
+        let settled = BrowserExecutionWakePlan::from_session(&session);
+        assert!(settled.is_idle());
+    }
+}

--- a/crates/noon-web/src/lib.rs
+++ b/crates/noon-web/src/lib.rs
@@ -13,6 +13,7 @@ mod determinism;
 mod direct_execution_smoke;
 mod execution_canvas;
 mod execution_transport;
+mod execution_wake;
 mod family_animation_authoring;
 mod family_bounds;
 mod family_write_authoring;
@@ -68,6 +69,7 @@ pub use direct_execution_smoke::*;
 #[cfg(target_arch = "wasm32")]
 pub use execution_canvas::*;
 pub use execution_transport::*;
+pub use execution_wake::*;
 #[cfg(target_arch = "wasm32")]
 pub use family_animation_authoring::*;
 pub use family_bounds::*;


### PR DESCRIPTION
## Scope

Continue #1085 after #1091/#1092 established the target-neutral runtime/session wake contract and consumed it in the native host. Add the first direct Rust/WASM browser adaptation seam without introducing another scheduler or wall-clock authority.

## Changes

- add `BrowserExecutionWakePlan` derived directly from `ExecutionSession::wake_state()` / `RuntimeWakeState`;
- map runtime cadence mechanically: `Continuous -> AnimationFrame`, `Deadline(scene_time) -> TimerAtSceneTime(scene_time)`, `Quiescent -> Idle`;
- keep renderer-facing presentation dirtiness orthogonal to authored-time cadence, so a static scene may need one presentation and then settle;
- expose an authored-time-relative timer delay helper without reading wall time or owning a browser clock;
- reject non-finite timer inputs rather than synthesizing a busy-loop or invalid delay;
- prove a direct static `ExecutionSession` becomes browser-idle after its initial renderer-facing changes are consumed.

## Architecture

```text
existing TimelineEventScheduler
    -> RuntimeWakeState
    -> ExecutionSession::wake_state()
    -> BrowserExecutionWakePlan
    -> RAF / timer / idle primitive
```

The new type is a mechanical host projection only. It does not inspect timeline contents, own an event heap, advance authored time, or schedule JavaScript callbacks itself.

## Boundary

This slice intentionally establishes the browser wake-plan contract before wiring it into the moved direct-session canvas renderer. Callback/resource completion wakes remain follow-on #1085 work and should consume real completion authorities rather than synthesized polling.

Refs #1085 #969 #961