### PR TITLE
A2/A6: drive direct browser host from session wake plan

### DIFF
--- a/crates/noon-web/src/direct_execution_smoke.rs
+++ b/crates/noon-web/src/direct_execution_smoke.rs
@@ -1,7 +1,7 @@
 use noon::ExecutionSession;
 use noon_core::{
-    Camera2DState, SemanticObjectProperty, SemanticObjectRole, SemanticObjectState, SemanticStore,
-    SemanticVec3, StoredGeometry, Vec2,
+    AnimationOptions, Camera2DState, RateFunction, SemanticObjectProperty, SemanticObjectRole,
+    SemanticObjectState, SemanticStore, SemanticVec3, StoredGeometry, Vec2,
 };
 use wasm_bindgen::prelude::*;
 use web_sys::OffscreenCanvas;
@@ -26,6 +26,16 @@ pub async fn create_direct_execution_smoke_renderer(
         .bind_semantic_signal(opacity, object, SemanticObjectProperty::ObjectOpacity)
         .map_err(js_error)?;
 
+    let mut target_state = store
+        .semantic_object_state_checked(object)
+        .map_err(js_error)?
+        .clone();
+    target_state.transform.translation = SemanticVec3::new(3.0, 0.0, 0.0);
+    let target = store.insert_semantic_object(target_state);
+    let animation = store
+        .insert_semantic_transform_animation(object, target, AnimationOptions::new())
+        .map_err(js_error)?;
+
     let mut camera_state = SemanticObjectState::new(StoredGeometry::Rectangle {
         size: Vec2::new(12.0, 6.0),
     });
@@ -34,7 +44,7 @@ pub async fn create_direct_execution_smoke_renderer(
     let camera = store.insert_semantic_object(camera_state);
     store.attach_to_scene(camera).map_err(js_error)?;
 
-    let session = ExecutionSession::from_semantic_store(&store).map_err(js_error)?;
+    let mut session = ExecutionSession::from_semantic_store(&store).map_err(js_error)?;
     let resolved_camera = session.camera().map_err(js_error)?;
     if resolved_camera
         != (Camera2DState {
@@ -46,6 +56,17 @@ pub async fn create_direct_execution_smoke_renderer(
             "direct Rust/WASM smoke did not resolve its authored semantic camera",
         ));
     }
+
+    session
+        .activate_animation(
+            &store,
+            animation,
+            AnimationOptions::new()
+                .run_time(0.1)
+                .rate_func(RateFunction::Linear),
+        )
+        .map_err(js_error)?;
+
     WasmExecutionCanvasRenderer::create_from_execution_session(canvas, session).await
 }
 

--- a/crates/noon-web/src/execution_canvas.rs
+++ b/crates/noon-web/src/execution_canvas.rs
@@ -28,7 +28,8 @@ mod wasm {
 
     use crate::{
         gpu_diagnostics::{install_wgpu_error_handler, GpuDiagnosticMailbox},
-        ExecutionFrameMirror, TransportApplyOutcome, TransportSlotId,
+        BrowserExecutionCadence, BrowserExecutionWakePlan, ExecutionFrameMirror,
+        TransportApplyOutcome, TransportSlotId,
     };
 
     use super::MANIM_DEFAULT_CLEAR_COLOR;
@@ -183,6 +184,13 @@ mod wasm {
             match self {
                 Self::Transport(mirror) => Some(mirror),
                 Self::Direct(_) => None,
+            }
+        }
+
+        fn direct(&self) -> Option<&ExecutionSession> {
+            match self {
+                Self::Transport(_) => None,
+                Self::Direct(session) => Some(session),
             }
         }
 
@@ -435,6 +443,31 @@ mod wasm {
 
         pub fn time(&self) -> f64 {
             self.source.frame().map_or(0.0, |frame| frame.time)
+        }
+
+        #[wasm_bindgen(js_name = directPresentPending)]
+        pub fn direct_present_pending(&self) -> Result<bool, JsValue> {
+            Ok(self.direct_wake_plan()?.present_now())
+        }
+
+        #[wasm_bindgen(js_name = directWakeCadence)]
+        pub fn direct_wake_cadence(&self) -> Result<String, JsValue> {
+            let cadence = match self.direct_wake_plan()?.cadence() {
+                BrowserExecutionCadence::AnimationFrame => "animation-frame",
+                BrowserExecutionCadence::TimerAtSceneTime(_) => "timer",
+                BrowserExecutionCadence::Idle => "idle",
+            };
+            Ok(cadence.to_owned())
+        }
+
+        #[wasm_bindgen(js_name = directTimerDelaySeconds)]
+        pub fn direct_timer_delay_seconds(&self) -> Result<Option<f64>, JsValue> {
+            Ok(self.direct_wake_plan()?.timer_delay_seconds(self.time()))
+        }
+
+        #[wasm_bindgen(js_name = advanceDirectToSceneTime)]
+        pub fn advance_direct_to_scene_time(&mut self, time: f64) -> Result<bool, JsValue> {
+            self.evaluate(time)
         }
 
         #[wasm_bindgen(js_name = objectCount)]
@@ -781,6 +814,14 @@ mod wasm {
             self.sync_camera(camera)?;
             self.pending_changes = pending_changes;
             Ok(!self.pending_changes.is_empty())
+        }
+
+        fn direct_wake_plan(&self) -> Result<BrowserExecutionWakePlan, JsValue> {
+            let session = self.source.direct().ok_or_else(|| {
+                js_message("direct wake APIs require a direct ExecutionSession source")
+            })?;
+            Ok(BrowserExecutionWakePlan::from_session(session)
+                .with_additional_presentation_pending(!self.pending_changes.is_empty()))
         }
 
         fn ensure_direct_source_idle(&self) -> Result<(), JsValue> {

--- a/crates/noon-web/src/execution_wake.rs
+++ b/crates/noon-web/src/execution_wake.rs
@@ -67,6 +67,19 @@ impl BrowserExecutionWakePlan {
         }
     }
 
+    /// Preserve presentation work that has already moved from the execution session
+    /// into a host-owned renderer queue.
+    ///
+    /// Direct canvas construction drains [`ExecutionSession::take_frame_changes`] so
+    /// the renderer can own the exact changes it must present. That ownership transfer
+    /// must not make the host forget the pending presentation when it subsequently
+    /// projects the session's timeline cadence. This operation only ORs presentation
+    /// dirtiness back into the plan; it never changes runtime timeline authority.
+    pub const fn with_additional_presentation_pending(mut self, pending: bool) -> Self {
+        self.present_now |= pending;
+        self
+    }
+
     /// Whether renderer-facing effective state is waiting for one presentation.
     pub const fn present_now(self) -> bool {
         self.present_now
@@ -137,6 +150,24 @@ mod tests {
             BrowserExecutionWakePlan::from_parts(false, TimelineWakeState::Deadline(4.5));
         assert_eq!(
             clean_deadline.cadence(),
+            BrowserExecutionCadence::TimerAtSceneTime(4.5)
+        );
+    }
+
+    #[test]
+    fn host_owned_presentation_is_recombined_without_changing_runtime_cadence() {
+        let clean_active =
+            BrowserExecutionWakePlan::from_parts(false, TimelineWakeState::Continuous);
+        let queued = clean_active.with_additional_presentation_pending(true);
+        assert!(queued.present_now());
+        assert_eq!(queued.cadence(), BrowserExecutionCadence::AnimationFrame);
+
+        let already_pending =
+            BrowserExecutionWakePlan::from_parts(true, TimelineWakeState::Deadline(4.5));
+        let preserved = already_pending.with_additional_presentation_pending(false);
+        assert!(preserved.present_now());
+        assert_eq!(
+            preserved.cadence(),
             BrowserExecutionCadence::TimerAtSceneTime(4.5)
         );
     }

--- a/web/direct-execution-boundary.test.mjs
+++ b/web/direct-execution-boundary.test.mjs
@@ -9,6 +9,10 @@ const directCanvasHost = await readFile(
   new URL("../crates/noon-web/src/execution_canvas.rs", import.meta.url),
   "utf8",
 );
+const browserWakePlan = await readFile(
+  new URL("../crates/noon-web/src/execution_wake.rs", import.meta.url),
+  "utf8",
+);
 const browserProbe = await readFile(
   new URL("./direct-execution-smoke-probe.js", import.meta.url),
   "utf8",
@@ -23,6 +27,7 @@ for (const required of [
   "SemanticObjectRole::Camera2D",
   "session.camera()",
   "ExecutionSession::from_semantic_store",
+  "session\n        .activate_animation(",
   "create_from_execution_session",
 ]) {
   assert.ok(rustHarness.includes(required), `direct Rust/WASM proof must contain ${required}`);
@@ -43,14 +48,31 @@ for (const forbidden of [
 for (const required of [
   "let camera = session.camera().map_err(js_error)?;",
   "self.sync_camera(camera)?;",
+  "BrowserExecutionWakePlan::from_session(session)",
+  "with_additional_presentation_pending(!self.pending_changes.is_empty())",
+  "directWakeCadence",
+  "advanceDirectToSceneTime",
 ]) {
   assert.ok(
     directCanvasHost.includes(required),
-    `direct canvas host must consume canonical session camera through ${required}`,
+    `direct canvas host must consume canonical session state through ${required}`,
   );
 }
+assert.ok(
+  browserWakePlan.includes("with_additional_presentation_pending"),
+  "browser wake plan must preserve presentation work after the canvas host drains session changes",
+);
 
-for (const required of ["createDirectExecutionSmokeRenderer", "new OffscreenCanvas"]) {
+for (const required of [
+  "createDirectExecutionSmokeRenderer",
+  "new OffscreenCanvas",
+  "directPresentPending",
+  "directWakeCadence",
+  "directTimerDelaySeconds",
+  "advanceDirectToSceneTime",
+  "requestAnimationFrame",
+  'cadence === "idle"',
+]) {
   assert.ok(browserProbe.includes(required), `browser direct-execution proof must contain ${required}`);
 }
 for (const forbidden of [

--- a/web/direct-execution-smoke-probe.js
+++ b/web/direct-execution-smoke-probe.js
@@ -11,6 +11,10 @@ function sleep(milliseconds) {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
+function nextAnimationFrame() {
+  return new Promise((resolve) => requestAnimationFrame(resolve));
+}
+
 async function waitForPrimaryRenderer() {
   for (let attempt = 0; attempt < 3000; attempt += 1) {
     const primary = window.noonSmoke;
@@ -25,21 +29,79 @@ async function waitForPrimaryRenderer() {
   throw new Error("primary browser smoke did not initialize before direct execution proof");
 }
 
+async function driveFromSessionWakePlan(renderer) {
+  let presented = false;
+  let animationFrames = 0;
+  let timerWakes = 0;
+  let wallOriginMilliseconds = null;
+  let sceneOriginSeconds = renderer.time();
+
+  for (let wake = 0; wake < 240; wake += 1) {
+    if (renderer.directPresentPending()) {
+      if (!renderer.render()) {
+        await sleep(0);
+        continue;
+      }
+      presented = true;
+    }
+
+    const cadence = renderer.directWakeCadence();
+    if (cadence === "idle") {
+      if (renderer.directPresentPending()) {
+        continue;
+      }
+      return {
+        presented,
+        animationFrames,
+        timerWakes,
+        wakeCycles: wake + 1,
+        settled: true,
+      };
+    }
+
+    if (cadence === "animation-frame") {
+      const wallNowMilliseconds = await nextAnimationFrame();
+      if (wallOriginMilliseconds === null) {
+        wallOriginMilliseconds = wallNowMilliseconds;
+        sceneOriginSeconds = renderer.time();
+      }
+      const sceneTime =
+        sceneOriginSeconds + (wallNowMilliseconds - wallOriginMilliseconds) / 1000;
+      renderer.advanceDirectToSceneTime(sceneTime);
+      animationFrames += 1;
+      continue;
+    }
+
+    if (cadence === "timer") {
+      const delaySeconds = renderer.directTimerDelaySeconds();
+      if (!Number.isFinite(delaySeconds)) {
+        throw new Error("direct execution timer cadence did not expose a finite delay");
+      }
+      await sleep(Math.max(0, delaySeconds * 1000));
+      renderer.advanceDirectToSceneTime(renderer.time() + delaySeconds);
+      wallOriginMilliseconds = null;
+      timerWakes += 1;
+      continue;
+    }
+
+    throw new Error(`direct execution renderer exposed unknown wake cadence: ${cadence}`);
+  }
+
+  throw new Error("direct execution renderer did not settle within bounded wake cycles");
+}
+
 async function start() {
   const expectedBackend = await waitForPrimaryRenderer();
   const canvas = new OffscreenCanvas(960, 540);
   const renderer = await createDirectExecutionSmokeRenderer(canvas);
   renderer.resize(canvas.width, canvas.height);
 
-  let presented = false;
-  for (let attempt = 0; attempt < 4 && !presented; attempt += 1) {
-    presented = renderer.render();
-  }
-
+  const wakeMetrics = await driveFromSessionWakePlan(renderer);
   const metrics = {
     backend: renderer.rendererBackend(),
-    presented,
+    ...wakeMetrics,
     objectCount: renderer.objectCount(),
+    finalSceneTime: renderer.time(),
     drawCalls: renderer.lastDrawCalls(),
     bytesUploaded: renderer.lastBytesUploaded(),
   };
@@ -51,6 +113,15 @@ async function start() {
   }
   if (!metrics.presented) {
     throw new Error("direct execution renderer did not present its semantic frame");
+  }
+  if (!metrics.settled) {
+    throw new Error("direct execution renderer did not settle after active authored work");
+  }
+  if (metrics.animationFrames <= 0) {
+    throw new Error("direct execution renderer never requested animation-frame cadence");
+  }
+  if (metrics.finalSceneTime <= 0) {
+    throw new Error(`direct execution renderer never advanced authored time: ${metrics.finalSceneTime}`);
   }
   if (metrics.objectCount !== 2) {
     throw new Error(


### PR DESCRIPTION
## Scope

Continue #1085 after #1093 by making the direct Rust/WASM canvas path consume the public session wake projection instead of relying on unconditional/manual render retries.

## Changes

- preserve renderer-owned presentation dirtiness after `ExecutionSession::take_frame_changes()` transfers changes into the canvas host;
- expose a narrow direct-canvas browser bridge for presentation pending, wake cadence, timer delay, and authored-time advancement;
- keep cadence authority in `ExecutionSession::wake_state()` / `BrowserExecutionWakePlan`; the browser only maps `AnimationFrame`, timer, and idle to platform primitives;
- make the debug direct Rust/WASM proof activate a real semantic transform animation and drive it with `requestAnimationFrame` until the session reports idle;
- retain the existing direct in-process path: no scene JSON, execution delta, transport mirror, or second event/timeline scheduler;
- add structural ratchets proving the browser proof consumes the direct wake bridge.

The branch is a single commit on exact master `96e13b56b78f65fd524217d573c9803cdb03001c`.

Refs #1085 #969 #961