### PR TITLE
A2/A6: drive direct WASM execution from session wake state

### DIFF
--- a/crates/noon-web/src/direct_execution_smoke.rs
+++ b/crates/noon-web/src/direct_execution_smoke.rs
@@ -1,7 +1,7 @@
 use noon::ExecutionSession;
 use noon_core::{
-    Camera2DState, SemanticObjectProperty, SemanticObjectRole, SemanticObjectState, SemanticStore,
-    SemanticVec3, StoredGeometry, Vec2,
+    AnimationOptions, Camera2DState, RateFunction, SemanticObjectProperty, SemanticObjectRole,
+    SemanticObjectState, SemanticStore, SemanticVec3, StoredGeometry, Vec2,
 };
 use wasm_bindgen::prelude::*;
 use web_sys::OffscreenCanvas;
@@ -26,6 +26,16 @@ pub async fn create_direct_execution_smoke_renderer(
         .bind_semantic_signal(opacity, object, SemanticObjectProperty::ObjectOpacity)
         .map_err(js_error)?;
 
+    let mut target_state = store
+        .semantic_object_state_checked(object)
+        .map_err(js_error)?
+        .clone();
+    target_state.transform.translation = SemanticVec3::new(2.0, 0.0, 0.0);
+    let target = store.insert_semantic_object(target_state);
+    let animation = store
+        .insert_semantic_transform_animation(object, target, AnimationOptions::new())
+        .map_err(js_error)?;
+
     let mut camera_state = SemanticObjectState::new(StoredGeometry::Rectangle {
         size: Vec2::new(12.0, 6.0),
     });
@@ -34,7 +44,7 @@ pub async fn create_direct_execution_smoke_renderer(
     let camera = store.insert_semantic_object(camera_state);
     store.attach_to_scene(camera).map_err(js_error)?;
 
-    let session = ExecutionSession::from_semantic_store(&store).map_err(js_error)?;
+    let mut session = ExecutionSession::from_semantic_store(&store).map_err(js_error)?;
     let resolved_camera = session.camera().map_err(js_error)?;
     if resolved_camera
         != (Camera2DState {
@@ -46,6 +56,15 @@ pub async fn create_direct_execution_smoke_renderer(
             "direct Rust/WASM smoke did not resolve its authored semantic camera",
         ));
     }
+    session
+        .activate_animation(
+            &store,
+            animation,
+            AnimationOptions::new()
+                .run_time(0.1)
+                .rate_func(RateFunction::Linear),
+        )
+        .map_err(js_error)?;
     WasmExecutionCanvasRenderer::create_from_execution_session(canvas, session).await
 }
 

--- a/crates/noon-web/src/execution_canvas.rs
+++ b/crates/noon-web/src/execution_canvas.rs
@@ -28,7 +28,8 @@ mod wasm {
 
     use crate::{
         gpu_diagnostics::{install_wgpu_error_handler, GpuDiagnosticMailbox},
-        ExecutionFrameMirror, TransportApplyOutcome, TransportSlotId,
+        BrowserExecutionCadence, BrowserExecutionWakeClock, BrowserExecutionWakePlan,
+        BrowserHostWake, ExecutionFrameMirror, TransportApplyOutcome, TransportSlotId,
     };
 
     use super::MANIM_DEFAULT_CLEAR_COLOR;
@@ -138,6 +139,14 @@ mod wasm {
         present_call: DiagnosticPresentationCall,
     }
 
+    #[derive(Clone, Copy, Debug, Serialize)]
+    #[serde(rename_all = "camelCase")]
+    struct DirectWakeDirectiveJson {
+        present_now: bool,
+        cadence: &'static str,
+        delay_ms: Option<f64>,
+    }
+
     struct InitializedGpu {
         instance: wgpu::Instance,
         surface: wgpu::Surface<'static>,
@@ -186,6 +195,13 @@ mod wasm {
             }
         }
 
+        fn direct(&self) -> Option<&ExecutionSession> {
+            match self {
+                Self::Transport(_) => None,
+                Self::Direct(session) => Some(session),
+            }
+        }
+
         fn direct_mut(&mut self) -> Option<&mut ExecutionSession> {
             match self {
                 Self::Transport(_) => None,
@@ -206,6 +222,7 @@ mod wasm {
         drawable: bool,
         source: CanvasExecutionSource,
         pending_changes: FrameChanges,
+        direct_wake_clock: BrowserExecutionWakeClock,
         preparer: FramePreparer,
         renderer: GpuRenderer,
         camera_center: Vec2,
@@ -290,7 +307,11 @@ mod wasm {
         }
 
         pub fn render(&mut self) -> Result<bool, JsValue> {
-            if !self.drawable || self.pending_changes.is_empty() {
+            let changes_pending = match &self.source {
+                CanvasExecutionSource::Transport(_) => !self.pending_changes.is_empty(),
+                CanvasExecutionSource::Direct(session) => session.wake_state().frame_pending(),
+            };
+            if !self.drawable || !changes_pending {
                 return Ok(false);
             }
 
@@ -317,7 +338,11 @@ mod wasm {
                     wgpu::CurrentSurfaceTexture::Validation => return Ok(false),
                 };
 
-            let changes = mem::take(&mut self.pending_changes);
+            let changes = if let Some(session) = self.source.direct_mut() {
+                session.take_frame_changes()
+            } else {
+                mem::take(&mut self.pending_changes)
+            };
             let frame = self
                 .source
                 .frame()
@@ -435,6 +460,81 @@ mod wasm {
 
         pub fn time(&self) -> f64 {
             self.source.frame().map_or(0.0, |frame| frame.time)
+        }
+
+        /// Return one direct-session browser scheduling directive. JavaScript owns
+        /// only the concrete RAF/timer handles; cadence, deadlines, and presentation
+        /// dirtiness remain derived from the authoritative ExecutionSession.
+        #[wasm_bindgen(js_name = directWakeDirectiveJson)]
+        pub fn direct_wake_directive_json(&mut self, wall_time_ms: f64) -> Result<String, JsValue> {
+            let (plan, scene_time) = self.direct_wake_observation()?;
+            let directive = self
+                .direct_wake_clock
+                .directive(plan, wall_time_ms, scene_time)
+                .ok_or_else(|| js_message("direct execution wake clock received invalid time"))?;
+            let (cadence, delay_ms) = match directive.wake() {
+                BrowserHostWake::AnimationFrame => ("animation-frame", None),
+                BrowserHostWake::TimerAfterMilliseconds(delay_ms) => ("timer", Some(delay_ms)),
+                BrowserHostWake::Idle => ("idle", None),
+            };
+            serde_json::to_string(&DirectWakeDirectiveJson {
+                present_now: directive.present_now(),
+                cadence,
+                delay_ms,
+            })
+            .map_err(js_error)
+        }
+
+        /// Advance direct authored time from one browser monotonic callback timestamp.
+        ///
+        /// A RAF advances continuously. A deterministic timer advances only after its
+        /// runtime-authored deadline is due. Idle observations never advance scene time.
+        #[wasm_bindgen(js_name = advanceDirectRealtime)]
+        pub fn advance_direct_realtime(&mut self, wall_time_ms: f64) -> Result<bool, JsValue> {
+            let (plan, scene_time) = self.direct_wake_observation()?;
+            let directive = self
+                .direct_wake_clock
+                .directive(plan, wall_time_ms, scene_time)
+                .ok_or_else(|| js_message("direct execution wake clock received invalid time"))?;
+
+            let target_time = match (directive.wake(), plan.cadence()) {
+                (BrowserHostWake::AnimationFrame, BrowserExecutionCadence::AnimationFrame) => {
+                    Some(self.direct_scene_time_at(wall_time_ms)?)
+                }
+                (
+                    BrowserHostWake::TimerAfterMilliseconds(delay_ms),
+                    BrowserExecutionCadence::TimerAtSceneTime(scene_deadline),
+                ) if delay_ms <= 0.0 => {
+                    Some(self.direct_scene_time_at(wall_time_ms)?.max(scene_deadline))
+                }
+                (BrowserHostWake::TimerAfterMilliseconds(_), _) | (BrowserHostWake::Idle, _) => {
+                    None
+                }
+                _ => {
+                    return Err(js_message(
+                        "direct execution wake directive diverged from session cadence",
+                    ));
+                }
+            };
+
+            let Some(target_time) = target_time else {
+                return Ok(false);
+            };
+            let (pending, camera) = {
+                let session = self.source.direct_mut().ok_or_else(|| {
+                    js_message("direct realtime APIs require a direct ExecutionSession source")
+                })?;
+                session.advance_to(target_time).map_err(js_error)?;
+                let camera = session.camera().map_err(js_error)?;
+                (session.wake_state().frame_pending(), camera)
+            };
+            self.sync_camera(camera)?;
+
+            let (next_plan, next_scene_time) = self.direct_wake_observation()?;
+            self.direct_wake_clock
+                .directive(next_plan, wall_time_ms, next_scene_time)
+                .ok_or_else(|| js_message("direct execution wake clock received invalid time"))?;
+            Ok(pending)
         }
 
         #[wasm_bindgen(js_name = objectCount)]
@@ -715,14 +815,13 @@ mod wasm {
         /// WASM bootstrap, but no scene/execution document or transport mirror is introduced.
         pub async fn create_from_execution_session(
             canvas: OffscreenCanvas,
-            mut session: ExecutionSession,
+            session: ExecutionSession,
         ) -> Result<Self, JsValue> {
             let camera = session.camera().map_err(js_error)?;
-            let pending_changes = session.take_frame_changes();
             Self::create_with_source(
                 canvas,
                 CanvasExecutionSource::Direct(session),
-                pending_changes,
+                FrameChanges::default(),
                 camera.center,
                 camera.height,
             )
@@ -732,33 +831,33 @@ mod wasm {
         /// Evaluate a direct Rust/WASM execution session and publish only its runtime changes.
         pub fn evaluate(&mut self, time: f64) -> Result<bool, JsValue> {
             self.ensure_direct_source_idle()?;
-            let (pending_changes, camera) = {
+            let (pending, camera) = {
                 let session = self.source.direct_mut().ok_or_else(|| {
                     js_message("typed execution APIs require a direct session source")
                 })?;
                 session.evaluate(time).map_err(js_error)?;
                 let camera = session.camera().map_err(js_error)?;
-                (session.take_frame_changes(), camera)
+                (session.wake_state().frame_pending(), camera)
             };
             self.sync_camera(camera)?;
-            self.pending_changes = pending_changes;
-            Ok(!self.pending_changes.is_empty())
+            self.direct_wake_clock = BrowserExecutionWakeClock::default();
+            Ok(pending)
         }
 
         /// Seek a direct Rust/WASM execution session and publish its renderer-facing changes.
         pub fn seek(&mut self, time: f64) -> Result<bool, JsValue> {
             self.ensure_direct_source_idle()?;
-            let (pending_changes, camera) = {
+            let (pending, camera) = {
                 let session = self.source.direct_mut().ok_or_else(|| {
                     js_message("typed execution APIs require a direct session source")
                 })?;
                 session.seek(time).map_err(js_error)?;
                 let camera = session.camera().map_err(js_error)?;
-                (session.take_frame_changes(), camera)
+                (session.wake_state().frame_pending(), camera)
             };
             self.sync_camera(camera)?;
-            self.pending_changes = pending_changes;
-            Ok(!self.pending_changes.is_empty())
+            self.direct_wake_clock = BrowserExecutionWakeClock::default();
+            Ok(pending)
         }
 
         /// Apply one semantic native-reactive input without exposing the execution VM signal ID.
@@ -768,7 +867,7 @@ mod wasm {
             value: impl Into<ReactiveValue>,
         ) -> Result<bool, JsValue> {
             self.ensure_direct_source_idle()?;
-            let (pending_changes, camera) = {
+            let (pending, camera) = {
                 let session = self.source.direct_mut().ok_or_else(|| {
                     js_message("typed execution APIs require a direct session source")
                 })?;
@@ -776,25 +875,38 @@ mod wasm {
                     .set_reactive_input(signal, value)
                     .map_err(js_error)?;
                 let camera = session.camera().map_err(js_error)?;
-                (session.take_frame_changes(), camera)
+                (session.wake_state().frame_pending(), camera)
             };
             self.sync_camera(camera)?;
-            self.pending_changes = pending_changes;
-            Ok(!self.pending_changes.is_empty())
+            Ok(pending)
         }
 
         fn ensure_direct_source_idle(&self) -> Result<(), JsValue> {
-            if self.source.transport().is_some() {
-                return Err(js_message(
-                    "typed execution APIs require a direct ExecutionSession source",
-                ));
-            }
-            if !self.pending_changes.is_empty() {
+            let session = self.source.direct().ok_or_else(|| {
+                js_message("typed execution APIs require a direct ExecutionSession source")
+            })?;
+            if session.wake_state().frame_pending() {
                 return Err(js_message(
                     "direct execution host must present pending runtime changes before advancing again",
                 ));
             }
             Ok(())
+        }
+
+        fn direct_wake_observation(&self) -> Result<(BrowserExecutionWakePlan, f64), JsValue> {
+            let session = self.source.direct().ok_or_else(|| {
+                js_message("direct wake APIs require a direct ExecutionSession source")
+            })?;
+            Ok((
+                BrowserExecutionWakePlan::from_session(session),
+                session.frame().time,
+            ))
+        }
+
+        fn direct_scene_time_at(&self, wall_time_ms: f64) -> Result<f64, JsValue> {
+            self.direct_wake_clock
+                .scene_time_at(wall_time_ms)
+                .ok_or_else(|| js_message("direct execution wake clock has no active time anchor"))
         }
 
         async fn create_with_source(
@@ -830,6 +942,7 @@ mod wasm {
                 drawable: true,
                 source,
                 pending_changes,
+                direct_wake_clock: BrowserExecutionWakeClock::default(),
                 preparer: FramePreparer::new(),
                 renderer,
                 camera_center,

--- a/crates/noon-web/src/execution_wake.rs
+++ b/crates/noon-web/src/execution_wake.rs
@@ -104,6 +104,125 @@ impl BrowserExecutionWakePlan {
     }
 }
 
+/// Concrete browser callback primitive after mapping authored scene time onto the
+/// browser's monotonic high-resolution wall clock.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum BrowserHostWake {
+    AnimationFrame,
+    TimerAfterMilliseconds(f64),
+    Idle,
+}
+
+/// One browser-host scheduling observation.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct BrowserExecutionWakeDirective {
+    present_now: bool,
+    wake: BrowserHostWake,
+}
+
+impl BrowserExecutionWakeDirective {
+    pub const fn present_now(self) -> bool {
+        self.present_now
+    }
+
+    pub const fn wake(self) -> BrowserHostWake {
+        self.wake
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct BrowserRealtimeAnchor {
+    wall_origin_ms: f64,
+    scene_origin: f64,
+}
+
+/// Stateful wall↔authored-time mapping for the direct browser execution host.
+///
+/// The mapping deliberately disappears while the runtime is idle. When timed work
+/// starts again, the next host observation anchors the current authored time to the
+/// current browser monotonic timestamp, so elapsed wall time while idle is never
+/// charged to newly activated authored work. This is only a clock conversion layer;
+/// cadence and deadlines remain owned by [`BrowserExecutionWakePlan`].
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct BrowserExecutionWakeClock {
+    anchor: Option<BrowserRealtimeAnchor>,
+}
+
+impl BrowserExecutionWakeClock {
+    /// Realize one target-neutral wake plan against a browser monotonic timestamp.
+    ///
+    /// `wall_time_ms` is expected to share the `performance.now()` / RAF timestamp
+    /// time origin. Invalid or unrepresentable values fail closed with `None`.
+    pub fn directive(
+        &mut self,
+        plan: BrowserExecutionWakePlan,
+        wall_time_ms: f64,
+        current_scene_time: f64,
+    ) -> Option<BrowserExecutionWakeDirective> {
+        if !wall_time_ms.is_finite() || !current_scene_time.is_finite() {
+            return None;
+        }
+
+        let wake = match plan.cadence() {
+            BrowserExecutionCadence::Idle => {
+                self.anchor = None;
+                BrowserHostWake::Idle
+            }
+            BrowserExecutionCadence::AnimationFrame => {
+                self.ensure_anchor(wall_time_ms, current_scene_time);
+                BrowserHostWake::AnimationFrame
+            }
+            BrowserExecutionCadence::TimerAtSceneTime(scene_deadline) => {
+                if !scene_deadline.is_finite() {
+                    return None;
+                }
+                let anchor = self.ensure_anchor(wall_time_ms, current_scene_time);
+                let scene_offset_ms = (scene_deadline - anchor.scene_origin) * 1_000.0;
+                if !scene_offset_ms.is_finite() {
+                    return None;
+                }
+                let wall_deadline_ms = if scene_offset_ms <= 0.0 {
+                    anchor.wall_origin_ms
+                } else {
+                    anchor.wall_origin_ms + scene_offset_ms
+                };
+                if !wall_deadline_ms.is_finite() {
+                    return None;
+                }
+                BrowserHostWake::TimerAfterMilliseconds((wall_deadline_ms - wall_time_ms).max(0.0))
+            }
+        };
+
+        Some(BrowserExecutionWakeDirective {
+            present_now: plan.present_now(),
+            wake,
+        })
+    }
+
+    /// Map one browser monotonic timestamp into authored scene time while timed work
+    /// is active. Timestamps before the current anchor saturate at the authored origin.
+    pub fn scene_time_at(self, wall_time_ms: f64) -> Option<f64> {
+        if !wall_time_ms.is_finite() {
+            return None;
+        }
+        let anchor = self.anchor?;
+        let elapsed_seconds = ((wall_time_ms - anchor.wall_origin_ms).max(0.0)) / 1_000.0;
+        let scene_time = anchor.scene_origin + elapsed_seconds;
+        scene_time.is_finite().then_some(scene_time)
+    }
+
+    fn ensure_anchor(
+        &mut self,
+        wall_time_ms: f64,
+        current_scene_time: f64,
+    ) -> BrowserRealtimeAnchor {
+        *self.anchor.get_or_insert(BrowserRealtimeAnchor {
+            wall_origin_ms: wall_time_ms,
+            scene_origin: current_scene_time,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use noon_core::{SemanticObjectState, SemanticStore, StoredGeometry};
@@ -182,5 +301,47 @@ mod tests {
         session.advance_segment_to(segment, 9.0).unwrap();
         assert!(BrowserExecutionWakePlan::from_segment(&session, segment).is_idle());
         assert_eq!(session.frame().time, 2.0);
+    }
+
+    #[test]
+    fn browser_realtime_clock_does_not_charge_quiescent_wall_time_to_later_work() {
+        let mut clock = BrowserExecutionWakeClock::default();
+        let idle = BrowserExecutionWakePlan::from_parts(false, TimelineWakeState::Quiescent);
+        assert_eq!(
+            clock.directive(idle, 1_000.0, 0.0).unwrap().wake(),
+            BrowserHostWake::Idle
+        );
+        assert_eq!(clock.scene_time_at(30_000.0), None);
+
+        let active = BrowserExecutionWakePlan::from_parts(false, TimelineWakeState::Continuous);
+        assert_eq!(
+            clock.directive(active, 31_000.0, 0.0).unwrap().wake(),
+            BrowserHostWake::AnimationFrame
+        );
+        assert_eq!(clock.scene_time_at(31_000.0), Some(0.0));
+        assert_eq!(clock.scene_time_at(31_500.0), Some(0.5));
+
+        clock.directive(idle, 32_000.0, 1.0).unwrap();
+        assert_eq!(clock.scene_time_at(60_000.0), None);
+
+        let deadline =
+            BrowserExecutionWakePlan::from_parts(false, TimelineWakeState::Deadline(3.0));
+        assert_eq!(
+            clock.directive(deadline, 62_000.0, 1.0).unwrap().wake(),
+            BrowserHostWake::TimerAfterMilliseconds(2_000.0)
+        );
+        assert_eq!(clock.scene_time_at(62_000.0), Some(1.0));
+    }
+
+    #[test]
+    fn browser_realtime_clock_rejects_invalid_or_unrepresentable_wall_mapping() {
+        let mut clock = BrowserExecutionWakeClock::default();
+        let active = BrowserExecutionWakePlan::from_parts(false, TimelineWakeState::Continuous);
+        assert_eq!(clock.directive(active, f64::NAN, 0.0), None);
+        assert_eq!(clock.directive(active, 0.0, f64::INFINITY), None);
+
+        let deadline =
+            BrowserExecutionWakePlan::from_parts(false, TimelineWakeState::Deadline(f64::MAX));
+        assert_eq!(clock.directive(deadline, 0.0, 0.0), None);
     }
 }

--- a/web/direct-execution-boundary.test.mjs
+++ b/web/direct-execution-boundary.test.mjs
@@ -9,6 +9,14 @@ const directCanvasHost = await readFile(
   new URL("../crates/noon-web/src/execution_canvas.rs", import.meta.url),
   "utf8",
 );
+const wakeProjection = await readFile(
+  new URL("../crates/noon-web/src/execution_wake.rs", import.meta.url),
+  "utf8",
+);
+const browserDriver = await readFile(
+  new URL("./direct-execution-wake-driver.js", import.meta.url),
+  "utf8",
+);
 const browserProbe = await readFile(
   new URL("./direct-execution-smoke-probe.js", import.meta.url),
   "utf8",
@@ -24,6 +32,7 @@ for (const required of [
   "session.camera()",
   "ExecutionSession::from_semantic_store",
   "create_from_execution_session",
+  "activate_animation",
 ]) {
   assert.ok(rustHarness.includes(required), `direct Rust/WASM proof must contain ${required}`);
 }
@@ -43,14 +52,63 @@ for (const forbidden of [
 for (const required of [
   "let camera = session.camera().map_err(js_error)?;",
   "self.sync_camera(camera)?;",
+  "BrowserExecutionWakePlan::from_session(session)",
+  "session.wake_state().frame_pending()",
+  "session.take_frame_changes()",
+  "directWakeDirectiveJson",
+  "advanceDirectRealtime",
 ]) {
   assert.ok(
     directCanvasHost.includes(required),
-    `direct canvas host must consume canonical session camera through ${required}`,
+    `direct canvas host must consume canonical session authority through ${required}`,
+  );
+}
+assert.equal(
+  directCanvasHost.includes("let pending_changes = session.take_frame_changes();"),
+  false,
+  "direct canvas host must not drain session invalidation before presentation",
+);
+
+for (const required of [
+  "BrowserExecutionWakeClock",
+  "BrowserHostWake::AnimationFrame",
+  "BrowserHostWake::TimerAfterMilliseconds",
+  "self.anchor = None",
+]) {
+  assert.ok(
+    wakeProjection.includes(required),
+    `browser wake projection must retain ${required}`,
   );
 }
 
-for (const required of ["createDirectExecutionSmokeRenderer", "new OffscreenCanvas"]) {
+for (const required of [
+  "directWakeDirectiveJson",
+  "advanceDirectRealtime",
+  "requestAnimationFrame",
+  "setTimeout",
+]) {
+  assert.ok(browserDriver.includes(required), `browser wake driver must contain ${required}`);
+}
+for (const forbidden of [
+  ".evaluate(",
+  ".seek(",
+  "ExecutionFrameMirror",
+  "sceneJson",
+  "initialDeltaJson",
+  "applyDeltaJson",
+]) {
+  assert.equal(
+    browserDriver.includes(forbidden),
+    false,
+    `browser wake driver must not create timeline or transport authority through ${forbidden}`,
+  );
+}
+
+for (const required of [
+  "createDirectExecutionSmokeRenderer",
+  "createDirectExecutionWakeDriver",
+  "new OffscreenCanvas",
+]) {
   assert.ok(browserProbe.includes(required), `browser direct-execution proof must contain ${required}`);
 }
 for (const forbidden of [
@@ -61,7 +119,6 @@ for (const forbidden of [
   "initialDeltaJson",
   "applyDeltaJson",
   "setCamera",
-  "JSON.stringify",
 ]) {
   assert.equal(
     browserProbe.includes(forbidden),

--- a/web/direct-execution-smoke-probe.js
+++ b/web/direct-execution-smoke-probe.js
@@ -1,4 +1,5 @@
 import { createDirectExecutionSmokeRenderer } from "./pkg/noon_web.js";
+import { createDirectExecutionWakeDriver } from "./direct-execution-wake-driver.js";
 
 const state = {
   ready: false,
@@ -25,23 +26,43 @@ async function waitForPrimaryRenderer() {
   throw new Error("primary browser smoke did not initialize before direct execution proof");
 }
 
+async function waitForDirectExecutionToSettle(renderer, driver) {
+  for (let attempt = 0; attempt < 300; attempt += 1) {
+    const stats = driver.stats();
+    if (renderer.time() >= 0.1 && stats.idle && stats.presentedFrames > 0) {
+      return stats;
+    }
+    await sleep(10);
+  }
+  throw new Error(
+    `direct execution wake driver did not settle: time=${renderer.time()}, stats=${JSON.stringify(driver.stats())}`,
+  );
+}
+
 async function start() {
   const expectedBackend = await waitForPrimaryRenderer();
   const canvas = new OffscreenCanvas(960, 540);
   const renderer = await createDirectExecutionSmokeRenderer(canvas);
   renderer.resize(canvas.width, canvas.height);
+  const driver = createDirectExecutionWakeDriver(renderer);
 
-  let presented = false;
-  for (let attempt = 0; attempt < 4 && !presented; attempt += 1) {
-    presented = renderer.render();
+  let wakeStats;
+  try {
+    wakeStats = await waitForDirectExecutionToSettle(renderer, driver);
+  } finally {
+    driver.stop();
   }
 
   const metrics = {
     backend: renderer.rendererBackend(),
-    presented,
+    presented: wakeStats.presentedFrames > 0,
     objectCount: renderer.objectCount(),
     drawCalls: renderer.lastDrawCalls(),
     bytesUploaded: renderer.lastBytesUploaded(),
+    authoredTime: renderer.time(),
+    scheduledAnimationFrames: wakeStats.scheduledAnimationFrames,
+    scheduledTimers: wakeStats.scheduledTimers,
+    idle: wakeStats.idle,
   };
 
   if (metrics.backend !== expectedBackend) {
@@ -62,6 +83,15 @@ async function start() {
   }
   if (metrics.bytesUploaded <= 0) {
     throw new Error(`direct execution renderer uploaded ${metrics.bytesUploaded} bytes`);
+  }
+  if (metrics.authoredTime < 0.1) {
+    throw new Error(`direct execution authored time stopped at ${metrics.authoredTime}`);
+  }
+  if (metrics.scheduledAnimationFrames <= 0) {
+    throw new Error("direct execution wake driver never requested an animation frame");
+  }
+  if (!metrics.idle) {
+    throw new Error("direct execution wake driver did not become idle after authored work settled");
   }
 
   state.metrics = metrics;

--- a/web/direct-execution-wake-driver.js
+++ b/web/direct-execution-wake-driver.js
@@ -1,0 +1,132 @@
+export function createDirectExecutionWakeDriver(renderer, options = {}) {
+  const now = options.now ?? (() => performance.now());
+  const requestAnimationFrameFn =
+    options.requestAnimationFrame ?? ((callback) => globalThis.requestAnimationFrame(callback));
+  const cancelAnimationFrameFn =
+    options.cancelAnimationFrame ?? ((handle) => globalThis.cancelAnimationFrame(handle));
+  const setTimeoutFn =
+    options.setTimeout ?? ((callback, delay) => globalThis.setTimeout(callback, delay));
+  const clearTimeoutFn =
+    options.clearTimeout ?? ((handle) => globalThis.clearTimeout(handle));
+
+  let running = true;
+  let animationFrameHandle = null;
+  let timerHandle = null;
+  let idle = false;
+  let scheduledAnimationFrames = 0;
+  let scheduledTimers = 0;
+  let presentationAttempts = 0;
+  let presentedFrames = 0;
+
+  function cancelScheduledWake() {
+    if (animationFrameHandle !== null) {
+      cancelAnimationFrameFn(animationFrameHandle);
+      animationFrameHandle = null;
+    }
+    if (timerHandle !== null) {
+      clearTimeoutFn(timerHandle);
+      timerHandle = null;
+    }
+  }
+
+  function readDirective(wallTimeMs) {
+    return JSON.parse(renderer.directWakeDirectiveJson(wallTimeMs));
+  }
+
+  function presentPending() {
+    presentationAttempts += 1;
+    const presented = renderer.render();
+    if (presented) {
+      presentedFrames += 1;
+    }
+    return presented;
+  }
+
+  function scheduleAnimationFrame() {
+    idle = false;
+    scheduledAnimationFrames += 1;
+    animationFrameHandle = requestAnimationFrameFn(onAnimationFrame);
+  }
+
+  function scheduleTimer(delayMs) {
+    idle = false;
+    scheduledTimers += 1;
+    timerHandle = setTimeoutFn(onTimer, delayMs);
+  }
+
+  function schedule() {
+    if (!running) {
+      return;
+    }
+    cancelScheduledWake();
+
+    const wallTimeMs = now();
+    let directive = readDirective(wallTimeMs);
+    if (directive.presentNow) {
+      if (!presentPending()) {
+        // Surface acquisition can be transiently unavailable. Keep the session's
+        // authoritative invalidation intact and retry on one presentation callback.
+        scheduleAnimationFrame();
+        return;
+      }
+      directive = readDirective(now());
+    }
+
+    switch (directive.cadence) {
+      case "animation-frame":
+        scheduleAnimationFrame();
+        return;
+      case "timer":
+        scheduleTimer(directive.delayMs);
+        return;
+      case "idle":
+        idle = true;
+        return;
+      default:
+        throw new Error(`unknown direct execution wake cadence: ${directive.cadence}`);
+    }
+  }
+
+  function onAnimationFrame(timestamp) {
+    animationFrameHandle = null;
+    if (!running) {
+      return;
+    }
+    renderer.advanceDirectRealtime(timestamp);
+    presentPending();
+    schedule();
+  }
+
+  function onTimer() {
+    timerHandle = null;
+    if (!running) {
+      return;
+    }
+    const wallTimeMs = now();
+    renderer.advanceDirectRealtime(wallTimeMs);
+    presentPending();
+    schedule();
+  }
+
+  schedule();
+
+  return {
+    wake() {
+      schedule();
+    },
+    stop() {
+      running = false;
+      idle = false;
+      cancelScheduledWake();
+    },
+    stats() {
+      return {
+        idle,
+        scheduledAnimationFrames,
+        scheduledTimers,
+        presentationAttempts,
+        presentedFrames,
+      };
+    },
+  };
+}

--- a/web/direct-execution-wake-driver.test.mjs
+++ b/web/direct-execution-wake-driver.test.mjs
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createDirectExecutionWakeDriver } from "./direct-execution-wake-driver.js";
+
+function fakeScheduler(initialNow = 1_000) {
+  let now = initialNow;
+  let nextHandle = 1;
+  const animationFrames = new Map();
+  const timers = new Map();
+
+  return {
+    options: {
+      now: () => now,
+      requestAnimationFrame(callback) {
+        const handle = nextHandle++;
+        animationFrames.set(handle, callback);
+        return handle;
+      },
+      cancelAnimationFrame(handle) {
+        animationFrames.delete(handle);
+      },
+      setTimeout(callback, delay) {
+        const handle = nextHandle++;
+        timers.set(handle, { callback, delay });
+        return handle;
+      },
+      clearTimeout(handle) {
+        timers.delete(handle);
+      },
+    },
+    animationFrames,
+    timers,
+    setNow(value) {
+      now = value;
+    },
+  };
+}
+
+function fakeRenderer(initialDirective, onAdvance) {
+  let directive = initialDirective;
+  let renders = 0;
+  const advances = [];
+
+  return {
+    directWakeDirectiveJson() {
+      return JSON.stringify(directive);
+    },
+    advanceDirectRealtime(wallTimeMs) {
+      advances.push(wallTimeMs);
+      directive = onAdvance?.(wallTimeMs, directive) ?? directive;
+      return directive.presentNow;
+    },
+    render() {
+      renders += 1;
+      if (!directive.presentNow) {
+        return false;
+      }
+      directive = { ...directive, presentNow: false };
+      return true;
+    },
+    get renders() {
+      return renders;
+    },
+    advances,
+  };
+}
+
+test("static direct execution presents once and then owns no callback", () => {
+  const scheduler = fakeScheduler();
+  const renderer = fakeRenderer({
+    presentNow: true,
+    cadence: "idle",
+    delayMs: null,
+  });
+  const driver = createDirectExecutionWakeDriver(renderer, scheduler.options);
+
+  assert.equal(renderer.renders, 1);
+  assert.equal(scheduler.animationFrames.size, 0);
+  assert.equal(scheduler.timers.size, 0);
+  assert.deepEqual(driver.stats(), {
+    idle: true,
+    scheduledAnimationFrames: 0,
+    scheduledTimers: 0,
+    presentationAttempts: 1,
+    presentedFrames: 1,
+  });
+});
+
+test("continuous direct execution uses one RAF and settles when runtime becomes idle", () => {
+  const scheduler = fakeScheduler();
+  const renderer = fakeRenderer(
+    { presentNow: true, cadence: "animation-frame", delayMs: null },
+    () => ({ presentNow: true, cadence: "idle", delayMs: null }),
+  );
+  const driver = createDirectExecutionWakeDriver(renderer, scheduler.options);
+
+  assert.equal(scheduler.animationFrames.size, 1);
+  const [[handle, callback]] = scheduler.animationFrames.entries();
+  scheduler.animationFrames.delete(handle);
+  callback(1_016);
+
+  assert.deepEqual(renderer.advances, [1_016]);
+  assert.equal(renderer.renders, 2);
+  assert.equal(scheduler.animationFrames.size, 0);
+  assert.equal(scheduler.timers.size, 0);
+  assert.equal(driver.stats().idle, true);
+  assert.equal(driver.stats().scheduledAnimationFrames, 1);
+});
+
+test("deadline direct execution uses only the delay projected by Rust", () => {
+  const scheduler = fakeScheduler();
+  const renderer = fakeRenderer(
+    { presentNow: false, cadence: "timer", delayMs: 250 },
+    () => ({ presentNow: true, cadence: "idle", delayMs: null }),
+  );
+  const driver = createDirectExecutionWakeDriver(renderer, scheduler.options);
+
+  assert.equal(scheduler.animationFrames.size, 0);
+  assert.equal(scheduler.timers.size, 1);
+  const [[handle, timer]] = scheduler.timers.entries();
+  assert.equal(timer.delay, 250);
+  scheduler.timers.delete(handle);
+  scheduler.setNow(1_250);
+  timer.callback();
+
+  assert.deepEqual(renderer.advances, [1_250]);
+  assert.equal(renderer.renders, 1);
+  assert.equal(driver.stats().idle, true);
+  assert.equal(driver.stats().scheduledTimers, 1);
+});


### PR DESCRIPTION
## Scope

Continue #1085 after #1093/#1095 by wiring the direct Rust/WASM canvas host to the public execution-session wake contract. This turns the existing browser wake projection into the actual direct-session host policy rather than leaving JavaScript or callers to invent a polling cadence.

## Changes

- keep direct-session `FrameChanges` authoritative in `ExecutionSession` until the canvas successfully acquires a presentation surface; the transport-mirror path keeps its existing renderer-owned pending changes;
- add a browser realtime wake clock that exists only while authored timed work is non-idle, re-anchoring current authored time after quiescence so idle wall time is never charged to later work;
- expose one mechanical direct-session wake directive (`present now` + RAF/timer/idle) and one realtime callback advance API from the WASM canvas host;
- add a thin browser driver that owns only RAF/timer callback handles and consumes those Rust directives; it does not scan scene contents, call `evaluate`/`seek`, or maintain a second deadline model;
- keep transient surface failures correct by retaining session invalidation and retrying presentation on a browser frame callback;
- upgrade the direct browser smoke to activate a real 100 ms semantic transform animation and prove initial presentation, RAF-driven authored-time progress, and eventual idle;
- add deterministic JS unit coverage for static idle, continuous RAF, and deadline timer mechanics plus boundary ratchets preventing transport/timeline authority from leaking into the driver.

Callback/resource-completion wake sources remain follow-on #1085 work because their authoritative async completion model is not yet established.

Refs #1085 #969 #961