### PR TITLE
A1/A6: add distinct publication revision domains

### DIFF
--- a/crates/noon-compile/src/semantic_lowering/entrypoint.rs
+++ b/crates/noon-compile/src/semantic_lowering/entrypoint.rs
@@ -1,6 +1,6 @@
 use noon_core::{
-    Camera2DState, ComputeProgram, ObjectId, ReactiveProgram, SemanticNodeId, SemanticObjectRole,
-    SemanticStore,
+    Camera2DState, ComputeProgram, ExecutionRevision, FrameEpoch, ObjectId, PublicationContext,
+    ReactiveProgram, SemanticNodeId, SemanticObjectRole, SemanticStore,
 };
 
 use crate::CompiledScene;
@@ -23,6 +23,7 @@ pub struct SemanticExecutionLoweringOutput {
     reactive: SemanticReactiveProjection,
     compute: ComputeProgram,
     camera_object: Option<ObjectId>,
+    publication: PublicationContext,
 }
 
 impl SemanticExecutionLoweringOutput {
@@ -36,6 +37,13 @@ impl SemanticExecutionLoweringOutput {
 
     pub fn compute(&self) -> &ComputeProgram {
         &self.compute
+    }
+
+    /// Publication context of the exact semantic snapshot from which this handoff
+    /// was derived. Initial lowering publishes execution revision/frame epoch zero;
+    /// later runtime publications advance those domains independently.
+    pub const fn publication_context(&self) -> PublicationContext {
+        self.publication
     }
 
     /// Execution identity of the unique semantic object carrying the canonical 2D
@@ -169,6 +177,11 @@ pub fn lower_semantic_execution(
         reactive,
         compute,
         camera_object,
+        publication: PublicationContext::new(
+            store.scene_revision(),
+            ExecutionRevision::default(),
+            FrameEpoch::default(),
+        ),
     })
 }
 
@@ -253,6 +266,18 @@ mod tests {
         assert_eq!(lowered.compiled().objects().len(), 1);
         assert_eq!(lowered.compiled().objects()[0].id, execution_id);
         assert_eq!(lowered.camera_object(), None);
+        assert_eq!(
+            lowered.publication_context().scene_revision(),
+            store.scene_revision()
+        );
+        assert_eq!(
+            lowered.publication_context().execution_revision(),
+            ExecutionRevision::default()
+        );
+        assert_eq!(
+            lowered.publication_context().frame_epoch(),
+            FrameEpoch::default()
+        );
         assert_eq!(lowered.reactive().signal_count(), 1);
         assert_eq!(lowered.compute().signal_count(), 1);
         assert_eq!(

--- a/crates/noon-core/src/reactive.rs
+++ b/crates/noon-core/src/reactive.rs
@@ -18,6 +18,9 @@ pub use host_semantics::*;
 mod lifecycle;
 pub use lifecycle::*;
 
+mod publication;
+pub use publication::*;
+
 #[path = "semantic_store.rs"]
 mod semantic_store;
 pub use semantic_store::*;

--- a/crates/noon-core/src/reactive/publication.rs
+++ b/crates/noon-core/src/reactive/publication.rs
@@ -1,0 +1,159 @@
+use serde::{Deserialize, Serialize};
+
+macro_rules! define_publication_revision {
+    ($(#[$meta:meta])* $name:ident) => {
+        #[derive(
+            Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize,
+        )]
+        $(#[$meta])*
+        pub struct $name(u64);
+
+        impl $name {
+            pub const fn new(raw: u64) -> Self {
+                Self(raw)
+            }
+
+            pub const fn get(self) -> u64 {
+                self.0
+            }
+
+            pub const fn checked_next(self) -> Option<Self> {
+                match self.0.checked_add(1) {
+                    Some(next) => Some(Self(next)),
+                    None => None,
+                }
+            }
+        }
+    };
+}
+
+define_publication_revision!(
+    /// Revision of the coherently published authoritative Semantic Scene.
+    ///
+    /// Semantic identity generations are intentionally a separate domain: replacing a
+    /// node may change identity without defining a scene publication clock, while one
+    /// atomic semantic transaction may touch several identities and still publish only
+    /// one scene revision.
+    SceneRevision
+);
+
+define_publication_revision!(
+    /// Revision of the coherently published derived execution projection.
+    ///
+    /// This changes when executable schedule/dependency/resource mapping changes, not
+    /// merely because authored time or an effective reactive value advances.
+    ExecutionRevision
+);
+
+define_publication_revision!(
+    /// Epoch of the latest coherent effective runtime frame publication.
+    ///
+    /// A pure timeline/reactive/host update may advance this epoch while both authored
+    /// scene and execution revisions remain unchanged.
+    FrameEpoch
+);
+
+/// Exact semantic/execution/effective context carried by one published frame view.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct PublicationContext {
+    scene_revision: SceneRevision,
+    execution_revision: ExecutionRevision,
+    frame_epoch: FrameEpoch,
+}
+
+impl PublicationContext {
+    pub const fn new(
+        scene_revision: SceneRevision,
+        execution_revision: ExecutionRevision,
+        frame_epoch: FrameEpoch,
+    ) -> Self {
+        Self {
+            scene_revision,
+            execution_revision,
+            frame_epoch,
+        }
+    }
+
+    pub const fn scene_revision(self) -> SceneRevision {
+        self.scene_revision
+    }
+
+    pub const fn execution_revision(self) -> ExecutionRevision {
+        self.execution_revision
+    }
+
+    pub const fn frame_epoch(self) -> FrameEpoch {
+        self.frame_epoch
+    }
+
+    pub const fn with_execution_revision(self, execution_revision: ExecutionRevision) -> Self {
+        Self {
+            execution_revision,
+            ..self
+        }
+    }
+
+    pub const fn with_frame_epoch(self, frame_epoch: FrameEpoch) -> Self {
+        Self {
+            frame_epoch,
+            ..self
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        SemanticMutationTransaction, SemanticNodeId, SemanticObjectProperty, SemanticObjectState,
+        SemanticStore, StoredGeometry,
+    };
+
+    #[test]
+    fn publication_domains_are_independent_typed_values() {
+        let context = PublicationContext::new(
+            SceneRevision::new(2),
+            ExecutionRevision::new(5),
+            FrameEpoch::new(11),
+        );
+        assert_eq!(context.scene_revision().get(), 2);
+        assert_eq!(context.execution_revision().get(), 5);
+        assert_eq!(context.frame_epoch().get(), 11);
+        assert_eq!(
+            SceneRevision::new(2).checked_next(),
+            Some(SceneRevision::new(3))
+        );
+        assert_eq!(FrameEpoch::new(u64::MAX).checked_next(), None);
+    }
+
+    #[test]
+    fn semantic_transaction_mints_one_scene_revision_only_for_changed_commit() {
+        let mut store = SemanticStore::new();
+        let object =
+            store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+                radius: 1.0,
+            }));
+        store.attach_to_scene(object).unwrap();
+        let initial = store.scene_revision();
+
+        let mut transaction = SemanticMutationTransaction::new();
+        transaction.set_property(object, SemanticObjectProperty::ObjectOpacity, 0.5_f64);
+        transaction.apply(&mut store).unwrap();
+        let committed = store.scene_revision();
+        assert_eq!(committed, initial.checked_next().unwrap());
+
+        let mut no_op = SemanticMutationTransaction::new();
+        no_op.set_property(object, SemanticObjectProperty::ObjectOpacity, 0.5_f64);
+        no_op.apply(&mut store).unwrap();
+        assert_eq!(store.scene_revision(), committed);
+
+        let mut failed = SemanticMutationTransaction::new();
+        failed.set_property(
+            SemanticNodeId::new(u32::MAX, 0),
+            SemanticObjectProperty::ObjectOpacity,
+            0.75_f64,
+        );
+        assert!(failed.apply(&mut store).is_err());
+        assert_eq!(store.scene_revision(), committed);
+    }
+}

--- a/crates/noon-core/src/semantic_store.rs
+++ b/crates/noon-core/src/semantic_store.rs
@@ -398,6 +398,7 @@ pub struct SemanticStore {
     source_nodes: HashMap<SourceIdentity, SemanticNodeId>,
     incoming_references: HashMap<SemanticNodeId, Vec<SemanticIncomingReference>>,
     last_mutation: SemanticMutationStats,
+    scene_revision: crate::SceneRevision,
 }
 
 impl SemanticStore {
@@ -917,7 +918,7 @@ impl SemanticStore {
     ///
     /// `Some(anchor)` moves `member` immediately before the anchor. `None` moves
     /// the member to the tail. Identity validation and link rewiring are O(1) and
-    /// only the family semantic slot is mutated.
+    /// only the family's authoritative order is mutated.
     pub fn reorder_member(
         &mut self,
         family: SemanticNodeId,
@@ -1052,6 +1053,15 @@ impl SemanticStore {
         self.slots.len()
     }
 
+    /// Revision of the last coherently published authoritative semantic transaction.
+    ///
+    /// Direct storage-building helpers intentionally do not advance this clock;
+    /// `SemanticMutationTransaction::apply` is the publication boundary and calls
+    /// `set_last_mutation_writes` once after complete preflight/commit.
+    pub const fn scene_revision(&self) -> crate::SceneRevision {
+        self.scene_revision
+    }
+
     pub const fn last_mutation_stats(&self) -> SemanticMutationStats {
         self.last_mutation
     }
@@ -1061,6 +1071,12 @@ impl SemanticStore {
             slots_written,
             cycle_nodes_visited: 0,
         };
+        if slots_written > 0 {
+            self.scene_revision = self
+                .scene_revision
+                .checked_next()
+                .expect("Noon scene revision space exhausted");
+        }
     }
 }
 

--- a/crates/noon-runtime/src/execution_slots/runtime_transaction.rs
+++ b/crates/noon-runtime/src/execution_slots/runtime_transaction.rs
@@ -31,6 +31,9 @@ impl SceneInstance {
             self.apply_patch(patch)
                 .expect("runtime transaction was fully preflighted");
         }
+        if !transaction.mutations().is_empty() {
+            self.publish_execution_change();
+        }
         Ok(&self.frame)
     }
 }
@@ -79,6 +82,7 @@ mod tests {
     fn transaction_preflight_rejects_late_failure_before_runtime_publication() {
         let (mut instance, object) = semantic_instance();
         let before = instance.frame().clone();
+        let publication_before = instance.publication_context();
         let missing = ObjectId::new(999);
         let transaction = MutationTransaction::from_mutations([
             ScenePatch::SetTransform {
@@ -99,9 +103,35 @@ mod tests {
             CompilePatchError::UnknownObject(missing)
         );
         assert_eq!(instance.frame(), &before);
+        assert_eq!(instance.publication_context(), publication_before);
         assert_eq!(
             instance.effective_transform(object),
             Some(Transform2D::IDENTITY)
+        );
+    }
+
+    #[test]
+    fn successful_execution_transaction_advances_execution_and_frame_once() {
+        let (mut instance, object) = semantic_instance();
+        let before = instance.publication_context();
+        let transaction = MutationTransaction::from_mutations([ScenePatch::SetTransform {
+            object,
+            transform: Transform2D {
+                translation: Vec2::new(4.0, 0.0),
+                ..Transform2D::IDENTITY
+            },
+        }]);
+
+        instance.apply_transaction(&transaction).unwrap();
+        let after = instance.publication_context();
+        assert_eq!(after.scene_revision(), before.scene_revision());
+        assert_eq!(
+            after.execution_revision(),
+            before.execution_revision().checked_next().unwrap()
+        );
+        assert_eq!(
+            after.frame_epoch(),
+            before.frame_epoch().checked_next().unwrap()
         );
     }
 }

--- a/crates/noon-runtime/src/lib.rs
+++ b/crates/noon-runtime/src/lib.rs
@@ -15,6 +15,7 @@ use std::collections::BTreeMap;
 use noon_compile::{
     CompilePatchError, CompiledChannelKey, CompiledScene, CompiledTrack, TransformGeometryPlan,
 };
+use noon_core::PublicationContext;
 use noon_core::{
     Color, GeometryRef, ObjectId, ObjectSnapshot, PathCommand, Property, ScenePatch,
     StrokeWidthMode, Style, TrackValues, Transform2D, Vec2, VectorPath,
@@ -242,6 +243,7 @@ pub struct SceneInstance {
     spatial_changes: FrameChanges,
     reactive: Option<ReactiveRuntime>,
     last_reactive_stats: ReactiveRuntimeStats,
+    publication: PublicationContext,
 }
 
 impl SceneInstance {
@@ -260,6 +262,7 @@ impl SceneInstance {
             spatial_changes: FrameChanges::all(),
             reactive: None,
             last_reactive_stats: ReactiveRuntimeStats::default(),
+            publication: PublicationContext::default(),
         };
         instance.seek_unchecked(0.0);
         instance
@@ -320,10 +323,14 @@ impl SceneInstance {
         if !time.is_finite() {
             return Err(EvaluationError::InvalidTime(time));
         }
-        if time >= self.frame.time {
+        let previous_time = self.frame.time;
+        if time >= previous_time {
             self.advance_unchecked(time);
         } else {
             self.seek_unchecked(time);
+        }
+        if self.frame.time != previous_time {
+            self.publish_effective_change();
         }
         Ok(&self.frame)
     }
@@ -332,7 +339,11 @@ impl SceneInstance {
         if !time.is_finite() {
             return Err(EvaluationError::InvalidTime(time));
         }
+        let previous_time = self.frame.time;
         self.seek_unchecked(time);
+        if self.frame.time != previous_time {
+            self.publish_effective_change();
+        }
         Ok(&self.frame)
     }
 
@@ -340,10 +351,14 @@ impl SceneInstance {
         if !time.is_finite() {
             return Err(EvaluationError::InvalidTime(time));
         }
-        if time < self.frame.time {
+        let previous_time = self.frame.time;
+        if time < previous_time {
             self.seek_unchecked(time);
         } else {
             self.advance_unchecked(time);
+        }
+        if self.frame.time != previous_time {
+            self.publish_effective_change();
         }
         Ok(&self.frame)
     }
@@ -1695,6 +1710,33 @@ mod tests {
         }
         direct.seek(2.5).expect("valid time");
         assert_eq!(sequential.frame(), direct.frame());
+    }
+
+    #[test]
+    fn timeline_publication_advances_only_frame_epoch_and_same_time_is_a_no_op() {
+        let mut instance = SceneInstance::new(compile_linear_scene());
+        let before = instance.publication_context();
+
+        instance.advance_to(2.0).expect("valid time");
+        let advanced = instance.publication_context();
+        assert_eq!(advanced.scene_revision(), before.scene_revision());
+        assert_eq!(advanced.execution_revision(), before.execution_revision());
+        assert_eq!(
+            advanced.frame_epoch(),
+            before.frame_epoch().checked_next().unwrap()
+        );
+
+        instance.advance_to(2.0).expect("same time is valid");
+        assert_eq!(instance.publication_context(), advanced);
+
+        instance.seek(1.0).expect("backward seek is valid");
+        let sought = instance.publication_context();
+        assert_eq!(sought.scene_revision(), advanced.scene_revision());
+        assert_eq!(sought.execution_revision(), advanced.execution_revision());
+        assert_eq!(
+            sought.frame_epoch(),
+            advanced.frame_epoch().checked_next().unwrap()
+        );
     }
 
     #[test]

--- a/crates/noon-runtime/src/reactive/runtime.rs
+++ b/crates/noon-runtime/src/reactive/runtime.rs
@@ -2,8 +2,9 @@ use std::collections::BTreeMap;
 
 use noon_compile::{CompileError, CompiledScene, SemanticExecutionLoweringOutput};
 use noon_core::{
-    ComputeProgram, ComputeState, ObjectId, Property, ReactiveBinding, ReactiveError,
-    ReactiveEvaluationStats, ReactiveProgram, ReactiveValue, SemanticScene, SignalId,
+    ComputeProgram, ComputeState, ObjectId, Property, PublicationContext, ReactiveBinding,
+    ReactiveError, ReactiveEvaluationStats, ReactiveProgram, ReactiveValue, SemanticScene,
+    SignalId,
 };
 
 use crate::{FrameState, SceneInstance};
@@ -151,10 +152,12 @@ impl SceneInstance {
     /// indices and instantiates the existing compute VM. No authored scene is
     /// reconstructed or recompiled at this boundary.
     pub fn from_semantic_execution(lowered: SemanticExecutionLoweringOutput) -> Self {
+        let publication = lowered.publication_context();
         let (compiled, reactive_projection, program) = lowered.into_execution_parts();
         let reactive =
             ReactiveRuntime::new(&compiled, reactive_projection.graph().bindings(), program);
         let mut instance = Self::new(compiled);
+        instance.publication = publication;
         instance.reactive = Some(reactive);
         instance.reapply_reactive();
         instance
@@ -191,6 +194,39 @@ impl SceneInstance {
         Ok(instance)
     }
 
+    /// Exact authored/executable/effective publication context of this runtime view.
+    pub const fn publication_context(&self) -> PublicationContext {
+        self.publication
+    }
+
+    /// Publish a coherent effective-only frame change.
+    pub(crate) fn publish_effective_change(&mut self) {
+        let next = self
+            .publication
+            .frame_epoch()
+            .checked_next()
+            .expect("Noon frame epoch space exhausted");
+        self.publication = self.publication.with_frame_epoch(next);
+    }
+
+    /// Publish one coherent executable-projection change and the corresponding new
+    /// effective frame context. Authored scene revision remains pinned to the
+    /// semantic snapshot from which this session was built.
+    pub(crate) fn publish_execution_change(&mut self) {
+        let execution = self
+            .publication
+            .execution_revision()
+            .checked_next()
+            .expect("Noon execution revision space exhausted");
+        let frame = self
+            .publication
+            .frame_epoch()
+            .checked_next()
+            .expect("Noon frame epoch space exhausted");
+        self.publication =
+            PublicationContext::new(self.publication.scene_revision(), execution, frame);
+    }
+
     pub const fn last_reactive_stats(&self) -> ReactiveRuntimeStats {
         self.last_reactive_stats
     }
@@ -212,6 +248,7 @@ impl SceneInstance {
             .ok_or(ReactiveError::UnknownSignal(signal))?
             .state
             .set_input(signal, value)?;
+        let effective_changed = !update.signal_changes().is_empty();
         let evaluation = update.stats();
         let mut applied_targets = 0;
         let mut changed_targets = 0;
@@ -241,6 +278,9 @@ impl SceneInstance {
         }
 
         self.last_reactive_stats = runtime_stats(evaluation, applied_targets, changed_targets);
+        if effective_changed {
+            self.publish_effective_change();
+        }
         Ok(&self.frame)
     }
 
@@ -471,6 +511,39 @@ mod tests {
                 dense_targets_changed: 1,
             }
         );
+    }
+
+    #[test]
+    fn signal_only_reactive_update_publishes_frame_epoch_without_frame_dirtiness() {
+        let mut scene = SemanticScene::new();
+        scene.add(GeometryRef::circle(1.0));
+        let input = scene.add_input(1.0_f32);
+        let mut instance =
+            SceneInstance::from_semantic(&scene).expect("semantic scene must compile");
+        instance.take_frame_changes();
+        let before = instance.publication_context();
+
+        instance
+            .set_reactive_input(input, 2.0_f32)
+            .expect("input update must work");
+        let after = instance.publication_context();
+        assert_eq!(after.scene_revision(), before.scene_revision());
+        assert_eq!(after.execution_revision(), before.execution_revision());
+        assert_eq!(
+            after.frame_epoch(),
+            before.frame_epoch().checked_next().unwrap()
+        );
+        assert_eq!(
+            instance.reactive_value(input),
+            Some(&ReactiveValue::Scalar(2.0))
+        );
+        assert!(instance.take_frame_changes().is_empty());
+
+        instance
+            .set_reactive_input(input, 2.0_f32)
+            .expect("same input is a valid no-op");
+        assert_eq!(instance.publication_context(), after);
+        assert!(instance.take_frame_changes().is_empty());
     }
 
     #[test]

--- a/crates/noon/src/execution_session.rs
+++ b/crates/noon/src/execution_session.rs
@@ -194,6 +194,15 @@ impl ExecutionSession {
         self.runtime.frame()
     }
 
+    /// Exact authored/executable/effective publication context of this session.
+    ///
+    /// Hosts can pin coherent live reads and cross-context work to this typed context
+    /// without receiving mutable runtime authority or substituting identity generations
+    /// for revision clocks.
+    pub const fn publication_context(&self) -> noon_core::PublicationContext {
+        self.runtime.publication_context()
+    }
+
     /// Current canonical 2D camera derived from the effective runtime frame object.
     ///
     /// Scenes without an authored camera use the shared Manim-compatible default.
@@ -449,6 +458,7 @@ mod tests {
 
         let mut session = ExecutionSession::from_semantic_store(&store).unwrap();
         let execution_object = session.execution_object_id(object).unwrap();
+        let initial_publication = session.publication_context();
 
         assert_eq!(session.frame().objects.len(), 1);
         assert_eq!(session.frame().objects[0].id, execution_object);
@@ -457,13 +467,42 @@ mod tests {
 
         session.take_frame_changes();
         session.set_reactive_input(signal, 0.7_f32).unwrap();
+        let reactive_publication = session.publication_context();
 
         assert_eq!(session.frame().objects[0].style.opacity, 0.7);
         assert_eq!(session.take_frame_changes().object_indices(), &[0]);
+        assert_eq!(
+            reactive_publication.scene_revision(),
+            initial_publication.scene_revision()
+        );
+        assert_eq!(
+            reactive_publication.execution_revision(),
+            initial_publication.execution_revision()
+        );
+        assert_eq!(
+            reactive_publication.frame_epoch(),
+            initial_publication.frame_epoch().checked_next().unwrap()
+        );
+
+        session.set_reactive_input(signal, 0.7_f32).unwrap();
+        assert_eq!(session.publication_context(), reactive_publication);
 
         session.seek(1.25).unwrap();
+        let timeline_publication = session.publication_context();
         assert_eq!(session.frame().time, 1.25);
         assert_eq!(session.frame().objects[0].style.opacity, 0.7);
+        assert_eq!(
+            timeline_publication.scene_revision(),
+            reactive_publication.scene_revision()
+        );
+        assert_eq!(
+            timeline_publication.execution_revision(),
+            reactive_publication.execution_revision()
+        );
+        assert_eq!(
+            timeline_publication.frame_epoch(),
+            reactive_publication.frame_epoch().checked_next().unwrap()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Start #1087 with the shared publication context needed before stale-safe callback/resource/spatial work can land.

- add strongly typed `SceneRevision`, `ExecutionRevision`, and `FrameEpoch` values plus `PublicationContext`;
- make successful semantic transaction publication advance `SceneRevision` exactly once while failed/no-op transactions do not;
- carry the semantic revision through canonical lowering into runtime;
- advance `ExecutionRevision` + `FrameEpoch` once for successful executable transaction publication;
- advance only `FrameEpoch` for effective timeline and native-reactive state changes;
- keep same-time timeline calls and same-value reactive inputs from minting false progress;
- expose the coherent typed context through `ExecutionSession`;
- keep renderer dirtiness independent: a changed unbound reactive signal advances the effective epoch without inventing renderer changes.

This is a bounded #1087 foundation. It does not yet claim stale-result rejection for asynchronous callbacks/resources/spatial work, renderer/resource version propagation, or the final host/editor patch publication policy.

The branch is one commit directly on current `master` and preserves #1098's canonical `ExecutionSegment` activation surface.

No second scene/runtime authority, global scan, or ad-hoc timestamp/counter is introduced.

Refs #1087 #969 #957 #961 #1085