### PR TITLE
A1/A6: publish distinct scene, execution, and frame revisions (superseded by #1100)

### DIFF
--- a/crates/noon-compile/src/semantic_lowering/entrypoint.rs
+++ b/crates/noon-compile/src/semantic_lowering/entrypoint.rs
@@ -1,6 +1,6 @@
 use noon_core::{
-    Camera2DState, ComputeProgram, ObjectId, ReactiveProgram, SemanticNodeId, SemanticObjectRole,
-    SemanticStore,
+    Camera2DState, ComputeProgram, ExecutionRevision, FrameEpoch, ObjectId, PublicationContext,
+    ReactiveProgram, SemanticNodeId, SemanticObjectRole, SemanticStore,
 };
 
 use crate::CompiledScene;
@@ -23,6 +23,7 @@ pub struct SemanticExecutionLoweringOutput {
     reactive: SemanticReactiveProjection,
     compute: ComputeProgram,
     camera_object: Option<ObjectId>,
+    publication: PublicationContext,
 }
 
 impl SemanticExecutionLoweringOutput {
@@ -36,6 +37,13 @@ impl SemanticExecutionLoweringOutput {
 
     pub fn compute(&self) -> &ComputeProgram {
         &self.compute
+    }
+
+    /// Publication context of the exact semantic snapshot from which this handoff
+    /// was derived. Initial lowering publishes execution revision/frame epoch zero;
+    /// later runtime publications advance those domains independently.
+    pub const fn publication_context(&self) -> PublicationContext {
+        self.publication
     }
 
     /// Execution identity of the unique semantic object carrying the canonical 2D
@@ -169,6 +177,11 @@ pub fn lower_semantic_execution(
         reactive,
         compute,
         camera_object,
+        publication: PublicationContext::new(
+            store.scene_revision(),
+            ExecutionRevision::default(),
+            FrameEpoch::default(),
+        ),
     })
 }
 
@@ -253,6 +266,18 @@ mod tests {
         assert_eq!(lowered.compiled().objects().len(), 1);
         assert_eq!(lowered.compiled().objects()[0].id, execution_id);
         assert_eq!(lowered.camera_object(), None);
+        assert_eq!(
+            lowered.publication_context().scene_revision(),
+            store.scene_revision()
+        );
+        assert_eq!(
+            lowered.publication_context().execution_revision(),
+            ExecutionRevision::default()
+        );
+        assert_eq!(
+            lowered.publication_context().frame_epoch(),
+            FrameEpoch::default()
+        );
         assert_eq!(lowered.reactive().signal_count(), 1);
         assert_eq!(lowered.compute().signal_count(), 1);
         assert_eq!(

--- a/crates/noon-core/src/reactive.rs
+++ b/crates/noon-core/src/reactive.rs
@@ -18,6 +18,9 @@ pub use host_semantics::*;
 mod lifecycle;
 pub use lifecycle::*;
 
+mod publication;
+pub use publication::*;
+
 #[path = "semantic_store.rs"]
 mod semantic_store;
 pub use semantic_store::*;

--- a/crates/noon-core/src/reactive/publication.rs
+++ b/crates/noon-core/src/reactive/publication.rs
@@ -1,0 +1,159 @@
+use serde::{Deserialize, Serialize};
+
+macro_rules! define_publication_revision {
+    ($(#[$meta:meta])* $name:ident) => {
+        #[derive(
+            Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize,
+        )]
+        $(#[$meta])*
+        pub struct $name(u64);
+
+        impl $name {
+            pub const fn new(raw: u64) -> Self {
+                Self(raw)
+            }
+
+            pub const fn get(self) -> u64 {
+                self.0
+            }
+
+            pub const fn checked_next(self) -> Option<Self> {
+                match self.0.checked_add(1) {
+                    Some(next) => Some(Self(next)),
+                    None => None,
+                }
+            }
+        }
+    };
+}
+
+define_publication_revision!(
+    /// Revision of the coherently published authoritative Semantic Scene.
+    ///
+    /// Semantic identity generations are intentionally a separate domain: replacing a
+    /// node may change identity without defining a scene publication clock, while one
+    /// atomic semantic transaction may touch several identities and still publish only
+    /// one scene revision.
+    SceneRevision
+);
+
+define_publication_revision!(
+    /// Revision of the coherently published derived execution projection.
+    ///
+    /// This changes when executable schedule/dependency/resource mapping changes, not
+    /// merely because authored time or an effective reactive value advances.
+    ExecutionRevision
+);
+
+define_publication_revision!(
+    /// Epoch of the latest coherent effective runtime frame publication.
+    ///
+    /// A pure timeline/reactive/host update may advance this epoch while both authored
+    /// scene and execution revisions remain unchanged.
+    FrameEpoch
+);
+
+/// Exact semantic/execution/effective context carried by one published frame view.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct PublicationContext {
+    scene_revision: SceneRevision,
+    execution_revision: ExecutionRevision,
+    frame_epoch: FrameEpoch,
+}
+
+impl PublicationContext {
+    pub const fn new(
+        scene_revision: SceneRevision,
+        execution_revision: ExecutionRevision,
+        frame_epoch: FrameEpoch,
+    ) -> Self {
+        Self {
+            scene_revision,
+            execution_revision,
+            frame_epoch,
+        }
+    }
+
+    pub const fn scene_revision(self) -> SceneRevision {
+        self.scene_revision
+    }
+
+    pub const fn execution_revision(self) -> ExecutionRevision {
+        self.execution_revision
+    }
+
+    pub const fn frame_epoch(self) -> FrameEpoch {
+        self.frame_epoch
+    }
+
+    pub const fn with_execution_revision(self, execution_revision: ExecutionRevision) -> Self {
+        Self {
+            execution_revision,
+            ..self
+        }
+    }
+
+    pub const fn with_frame_epoch(self, frame_epoch: FrameEpoch) -> Self {
+        Self {
+            frame_epoch,
+            ..self
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        SemanticMutationTransaction, SemanticNodeId, SemanticObjectProperty, SemanticObjectState,
+        SemanticStore, StoredGeometry,
+    };
+
+    #[test]
+    fn publication_domains_are_independent_typed_values() {
+        let context = PublicationContext::new(
+            SceneRevision::new(2),
+            ExecutionRevision::new(5),
+            FrameEpoch::new(11),
+        );
+        assert_eq!(context.scene_revision().get(), 2);
+        assert_eq!(context.execution_revision().get(), 5);
+        assert_eq!(context.frame_epoch().get(), 11);
+        assert_eq!(
+            SceneRevision::new(2).checked_next(),
+            Some(SceneRevision::new(3))
+        );
+        assert_eq!(FrameEpoch::new(u64::MAX).checked_next(), None);
+    }
+
+    #[test]
+    fn semantic_transaction_mints_one_scene_revision_only_for_changed_commit() {
+        let mut store = SemanticStore::new();
+        let object =
+            store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+                radius: 1.0,
+            }));
+        store.attach_to_scene(object).unwrap();
+        let initial = store.scene_revision();
+
+        let mut transaction = SemanticMutationTransaction::new();
+        transaction.set_property(object, SemanticObjectProperty::ObjectOpacity, 0.5_f64);
+        transaction.apply(&mut store).unwrap();
+        let committed = store.scene_revision();
+        assert_eq!(committed, initial.checked_next().unwrap());
+
+        let mut no_op = SemanticMutationTransaction::new();
+        no_op.set_property(object, SemanticObjectProperty::ObjectOpacity, 0.5_f64);
+        no_op.apply(&mut store).unwrap();
+        assert_eq!(store.scene_revision(), committed);
+
+        let mut failed = SemanticMutationTransaction::new();
+        failed.set_property(
+            SemanticNodeId::new(u32::MAX, 0),
+            SemanticObjectProperty::ObjectOpacity,
+            0.75_f64,
+        );
+        assert!(failed.apply(&mut store).is_err());
+        assert_eq!(store.scene_revision(), committed);
+    }
+}

--- a/crates/noon-core/src/semantic_store.rs
+++ b/crates/noon-core/src/semantic_store.rs
@@ -398,6 +398,7 @@ pub struct SemanticStore {
     source_nodes: HashMap<SourceIdentity, SemanticNodeId>,
     incoming_references: HashMap<SemanticNodeId, Vec<SemanticIncomingReference>>,
     last_mutation: SemanticMutationStats,
+    scene_revision: crate::SceneRevision,
 }
 
 impl SemanticStore {
@@ -917,7 +918,7 @@ impl SemanticStore {
     ///
     /// `Some(anchor)` moves `member` immediately before the anchor. `None` moves
     /// the member to the tail. Identity validation and link rewiring are O(1) and
-    /// only the family semantic slot is mutated.
+    /// only the family's authoritative order is mutated.
     pub fn reorder_member(
         &mut self,
         family: SemanticNodeId,
@@ -1052,6 +1053,15 @@ impl SemanticStore {
         self.slots.len()
     }
 
+    /// Revision of the last coherently published authoritative semantic transaction.
+    ///
+    /// Direct storage-building helpers intentionally do not advance this clock;
+    /// `SemanticMutationTransaction::apply` is the publication boundary and calls
+    /// `set_last_mutation_writes` once after complete preflight/commit.
+    pub const fn scene_revision(&self) -> crate::SceneRevision {
+        self.scene_revision
+    }
+
     pub const fn last_mutation_stats(&self) -> SemanticMutationStats {
         self.last_mutation
     }
@@ -1061,6 +1071,12 @@ impl SemanticStore {
             slots_written,
             cycle_nodes_visited: 0,
         };
+        if slots_written > 0 {
+            self.scene_revision = self
+                .scene_revision
+                .checked_next()
+                .expect("Noon scene revision space exhausted");
+        }
     }
 }
 

--- a/crates/noon-runtime/src/execution_slots/runtime_transaction.rs
+++ b/crates/noon-runtime/src/execution_slots/runtime_transaction.rs
@@ -31,6 +31,9 @@ impl SceneInstance {
             self.apply_patch(patch)
                 .expect("runtime transaction was fully preflighted");
         }
+        if !transaction.mutations().is_empty() {
+            self.publish_execution_change();
+        }
         Ok(&self.frame)
     }
 }
@@ -79,6 +82,7 @@ mod tests {
     fn transaction_preflight_rejects_late_failure_before_runtime_publication() {
         let (mut instance, object) = semantic_instance();
         let before = instance.frame().clone();
+        let publication_before = instance.publication_context();
         let missing = ObjectId::new(999);
         let transaction = MutationTransaction::from_mutations([
             ScenePatch::SetTransform {
@@ -99,9 +103,35 @@ mod tests {
             CompilePatchError::UnknownObject(missing)
         );
         assert_eq!(instance.frame(), &before);
+        assert_eq!(instance.publication_context(), publication_before);
         assert_eq!(
             instance.effective_transform(object),
             Some(Transform2D::IDENTITY)
+        );
+    }
+
+    #[test]
+    fn successful_execution_transaction_advances_execution_and_frame_once() {
+        let (mut instance, object) = semantic_instance();
+        let before = instance.publication_context();
+        let transaction = MutationTransaction::from_mutations([ScenePatch::SetTransform {
+            object,
+            transform: Transform2D {
+                translation: Vec2::new(4.0, 0.0),
+                ..Transform2D::IDENTITY
+            },
+        }]);
+
+        instance.apply_transaction(&transaction).unwrap();
+        let after = instance.publication_context();
+        assert_eq!(after.scene_revision(), before.scene_revision());
+        assert_eq!(
+            after.execution_revision(),
+            before.execution_revision().checked_next().unwrap()
+        );
+        assert_eq!(
+            after.frame_epoch(),
+            before.frame_epoch().checked_next().unwrap()
         );
     }
 }

--- a/crates/noon-runtime/src/lib.rs
+++ b/crates/noon-runtime/src/lib.rs
@@ -16,8 +16,8 @@ use noon_compile::{
     CompilePatchError, CompiledChannelKey, CompiledScene, CompiledTrack, TransformGeometryPlan,
 };
 use noon_core::{
-    Color, GeometryRef, ObjectId, ObjectSnapshot, PathCommand, Property, ScenePatch,
-    StrokeWidthMode, Style, TrackValues, Transform2D, Vec2, VectorPath,
+    Color, GeometryRef, ObjectId, ObjectSnapshot, PathCommand, Property, PublicationContext,
+    ScenePatch, StrokeWidthMode, Style, TrackValues, Transform2D, Vec2, VectorPath,
 };
 
 #[derive(Clone, Debug, PartialEq)]
@@ -242,6 +242,7 @@ pub struct SceneInstance {
     spatial_changes: FrameChanges,
     reactive: Option<ReactiveRuntime>,
     last_reactive_stats: ReactiveRuntimeStats,
+    publication: PublicationContext,
 }
 
 impl SceneInstance {
@@ -260,6 +261,7 @@ impl SceneInstance {
             spatial_changes: FrameChanges::all(),
             reactive: None,
             last_reactive_stats: ReactiveRuntimeStats::default(),
+            publication: PublicationContext::default(),
         };
         instance.seek_unchecked(0.0);
         instance

--- a/crates/noon-runtime/src/reactive/runtime.rs
+++ b/crates/noon-runtime/src/reactive/runtime.rs
@@ -2,8 +2,9 @@ use std::collections::BTreeMap;
 
 use noon_compile::{CompileError, CompiledScene, SemanticExecutionLoweringOutput};
 use noon_core::{
-    ComputeProgram, ComputeState, ObjectId, Property, ReactiveBinding, ReactiveError,
-    ReactiveEvaluationStats, ReactiveProgram, ReactiveValue, SemanticScene, SignalId,
+    ComputeProgram, ComputeState, ObjectId, Property, PublicationContext, ReactiveBinding,
+    ReactiveError, ReactiveEvaluationStats, ReactiveProgram, ReactiveValue, SemanticScene,
+    SignalId,
 };
 
 use crate::{FrameState, SceneInstance};
@@ -151,10 +152,12 @@ impl SceneInstance {
     /// indices and instantiates the existing compute VM. No authored scene is
     /// reconstructed or recompiled at this boundary.
     pub fn from_semantic_execution(lowered: SemanticExecutionLoweringOutput) -> Self {
+        let publication = lowered.publication_context();
         let (compiled, reactive_projection, program) = lowered.into_execution_parts();
         let reactive =
             ReactiveRuntime::new(&compiled, reactive_projection.graph().bindings(), program);
         let mut instance = Self::new(compiled);
+        instance.publication = publication;
         instance.reactive = Some(reactive);
         instance.reapply_reactive();
         instance
@@ -189,6 +192,39 @@ impl SceneInstance {
         instance.reactive = Some(reactive);
         instance.reapply_reactive();
         Ok(instance)
+    }
+
+    /// Exact authored/executable/effective publication context of this runtime view.
+    pub const fn publication_context(&self) -> PublicationContext {
+        self.publication
+    }
+
+    /// Publish a coherent effective-only frame change.
+    pub(crate) fn publish_effective_change(&mut self) {
+        let next = self
+            .publication
+            .frame_epoch()
+            .checked_next()
+            .expect("Noon frame epoch space exhausted");
+        self.publication = self.publication.with_frame_epoch(next);
+    }
+
+    /// Publish one coherent executable-projection change and the corresponding new
+    /// effective frame context. Authored scene revision remains pinned to the
+    /// semantic snapshot from which this session was built.
+    pub(crate) fn publish_execution_change(&mut self) {
+        let execution = self
+            .publication
+            .execution_revision()
+            .checked_next()
+            .expect("Noon execution revision space exhausted");
+        let frame = self
+            .publication
+            .frame_epoch()
+            .checked_next()
+            .expect("Noon frame epoch space exhausted");
+        self.publication =
+            PublicationContext::new(self.publication.scene_revision(), execution, frame);
     }
 
     pub const fn last_reactive_stats(&self) -> ReactiveRuntimeStats {
@@ -241,6 +277,9 @@ impl SceneInstance {
         }
 
         self.last_reactive_stats = runtime_stats(evaluation, applied_targets, changed_targets);
+        if changed_targets > 0 {
+            self.publish_effective_change();
+        }
         Ok(&self.frame)
     }
 

--- a/crates/noon/src/execution_session.rs
+++ b/crates/noon/src/execution_session.rs
@@ -8,7 +8,8 @@ use noon_compile::{
 use noon_core::{
     AnimationOptions, Camera2DState, MutationTransaction, NativeEventOccurrence,
     NativeInputRuntimeError, NativeInputValue, NativeStateSource, NativeStateUpdate, ObjectId,
-    ReactiveError, ReactiveValue, ScenePatch, SemanticNodeId, SemanticStore, TrackId,
+    PublicationContext, ReactiveError, ReactiveValue, ScenePatch, SemanticNodeId, SemanticStore,
+    TrackId,
 };
 use noon_runtime::{EvaluationError, FrameChanges, FrameState, RuntimeWakeState, SceneInstance};
 
@@ -192,6 +193,11 @@ impl ExecutionSession {
     /// Current renderer-facing runtime frame.
     pub fn frame(&self) -> &FrameState {
         self.runtime.frame()
+    }
+
+    /// Exact authored/executable/effective revision context of the current session view.
+    pub const fn publication_context(&self) -> PublicationContext {
+        self.runtime.publication_context()
     }
 
     /// Current canonical 2D camera derived from the effective runtime frame object.
@@ -456,10 +462,28 @@ mod tests {
         assert_eq!(session.camera().unwrap(), Camera2DState::default());
 
         session.take_frame_changes();
+        let publication_before = session.publication_context();
         session.set_reactive_input(signal, 0.7_f32).unwrap();
+        let publication_after = session.publication_context();
 
         assert_eq!(session.frame().objects[0].style.opacity, 0.7);
+        assert_eq!(
+            publication_after.scene_revision(),
+            publication_before.scene_revision()
+        );
+        assert_eq!(
+            publication_after.execution_revision(),
+            publication_before.execution_revision()
+        );
+        assert_eq!(
+            publication_after.frame_epoch(),
+            publication_before.frame_epoch().checked_next().unwrap()
+        );
         assert_eq!(session.take_frame_changes().object_indices(), &[0]);
+
+        session.set_reactive_input(signal, 0.7_f32).unwrap();
+        assert_eq!(session.publication_context(), publication_after);
+        assert!(session.take_frame_changes().is_empty());
 
         session.seek(1.25).unwrap();
         assert_eq!(session.frame().time, 1.25);


### PR DESCRIPTION
Superseded by merged #1100, which is based on the same publication-domain foundation and additionally covers timeline `FrameEpoch` publication, signal-only effective reactive publication, same-time/same-value no-op behavior, session observation, and exact-head architecture/browser/native CI.

Keeping this branch unmerged avoids reintroducing the weaker pre-#1100 variant.

Refs #1087 #1100