### PR TITLE
Make the module ownership guard portable and fail closed

### DIFF
--- a/scripts/noon-core-module-ownership-ratchet.sh
+++ b/scripts/noon-core-module-ownership-ratchet.sh
@@ -9,12 +9,22 @@ cd "$ROOT"
 # a reviewed normalization may remove it, but no additional `#[path]` or
 # `include!` indirection is allowed.
 temporary_owner='crates/noon-core/src/reactive.rs'
-temporary_target='semantic_store.rs'
-module_indirections="$(
-  rg -n --glob '*.rs' \
+# Use the same baseline grep dependency as the other architecture guards.
+# Scan the working tree (including untracked Rust files), and distinguish an
+# empty match set from a tool/read failure so the guard cannot pass unchecked.
+if module_indirections="$(
+  grep -rnE --include='*.rs' \
     '^[[:space:]]*#\[[[:space:]]*path[[:space:]]*=|(^|[^[:alnum:]_])include![[:space:]]*(\(|\{|\[)' \
-    crates/noon-core/src || true
-)"
+    crates/noon-core/src
+)"; then
+  :
+else
+  scan_status=$?
+  if (( scan_status != 1 )); then
+    echo "noon-core module ownership ratchet: source scan failed" >&2
+    exit "$scan_status"
+  fi
+fi
 
 unexpected=0
 while IFS= read -r reference; do

--- a/scripts/noon-core-module-ownership-ratchet.test.sh
+++ b/scripts/noon-core-module-ownership-ratchet.test.sh
@@ -31,6 +31,12 @@ expect_rejected() {
   fi
 }
 
+# A failed scanner must not be interpreted as an empty/valid source tree.
+mkdir -p "$TMP/failing-tools"
+printf '#!/usr/bin/env bash\nexit 2\n' > "$TMP/failing-tools/grep"
+chmod +x "$TMP/failing-tools/grep"
+PATH="$TMP/failing-tools:$PATH" expect_rejected 'source scanner failure'
+
 printf '#[path = "hidden_impl.rs"]\nmod hidden_impl;\n' > crates/noon-core/src/hidden.rs
 printf 'pub fn hidden_impl() {}\n' > crates/noon-core/src/hidden_impl.rs
 expect_rejected 'additional #[path] indirection'


### PR DESCRIPTION
The module ownership ratchet introduced in #1029 called `rg`, which is unavailable on the Architecture Ratchets runner. Its `|| true` also treated scanner errors as an empty match set. Use the existing guards' baseline recursive `grep` dependency, retain working-tree/untracked Rust coverage, and fail on scanner errors while accepting an ordinary no-match result.

Validation: shell syntax, repository ratchet, and self-test pass locally. The self-test now covers a scanner exiting with status 2 as well as rejected untracked module indirection. Independent review recorded before merge.
