### PR TITLE
Complete semantic style, resource ownership, and scene-root lowering

### DIFF
--- a/crates/noon-compile/src/semantic_lowering/compiled_scene.rs
+++ b/crates/noon-compile/src/semantic_lowering/compiled_scene.rs
@@ -1,8 +1,8 @@
 use std::collections::BTreeMap;
 
 use noon_core::{
-    GeometryRef, GeometryResourceHandle, SemanticNodeId, SemanticObjectContent, StoredGeometry,
-    TextResourceHandle,
+    GeometryRef, GeometryResource, GeometryResourceArena, GeometryResourceHandle, SemanticNodeId,
+    SemanticObjectContent, StoredGeometry, TextResourceHandle,
 };
 
 use crate::{CompiledObject, CompiledScene, DynamicProperties};
@@ -51,7 +51,7 @@ impl std::fmt::Display for SemanticCompiledSceneError {
             ),
             Self::UnsupportedGeometryResource { node, resource } => write!(
                 formatter,
-                "semantic object {}:{} uses versioned geometry resource {}@{} before the compiled resource key carries version identity",
+                "semantic object {}:{} uses unresolved geometry resource {}@{}",
                 node.slot(),
                 node.generation(),
                 resource.id.get(),
@@ -82,7 +82,7 @@ impl CompiledScene {
     pub fn from_semantic_projection(
         projection: &SemanticExecutionProjection,
     ) -> Result<Self, SemanticCompiledSceneError> {
-        materialize_semantic_projection(projection, false)
+        materialize_semantic_projection(projection, false, None)
     }
 
     /// Materialize object values after the canonical A1.6 entry point has
@@ -91,14 +91,16 @@ impl CompiledScene {
     /// bindings by opting into this path directly.
     pub(crate) fn from_semantic_projection_after_reactive_lowering(
         projection: &SemanticExecutionProjection,
+        resources: &GeometryResourceArena,
     ) -> Result<Self, SemanticCompiledSceneError> {
-        materialize_semantic_projection(projection, true)
+        materialize_semantic_projection(projection, true, Some(resources))
     }
 }
 
 fn materialize_semantic_projection(
     projection: &SemanticExecutionProjection,
     reactive_bindings_lowered: bool,
+    resources: Option<&GeometryResourceArena>,
 ) -> Result<CompiledScene, SemanticCompiledSceneError> {
     let mut ordered = projection.objects().iter().collect::<Vec<_>>();
     ordered.sort_by_key(|object| object.presentation.order_key());
@@ -121,7 +123,7 @@ fn materialize_semantic_projection(
 
         let object_index =
             u32::try_from(index).map_err(|_| SemanticCompiledSceneError::TooManyObjects(count))?;
-        let geometry = lower_geometry(object.semantic_id, object.content)?;
+        let geometry = lower_geometry(object.semantic_id, object.content, resources)?;
         objects.push(CompiledObject {
             id: object.execution_id,
             geometry,
@@ -146,6 +148,7 @@ fn materialize_semantic_projection(
 fn lower_geometry(
     node: SemanticNodeId,
     content: SemanticObjectContent,
+    resources: Option<&GeometryResourceArena>,
 ) -> Result<GeometryRef, SemanticCompiledSceneError> {
     match content {
         SemanticObjectContent::Geometry(StoredGeometry::Circle { radius }) => {
@@ -171,7 +174,14 @@ fn lower_geometry(
             Ok(GeometryRef::line(start, end))
         }
         SemanticObjectContent::Geometry(StoredGeometry::Resource(resource)) => {
-            Err(SemanticCompiledSceneError::UnsupportedGeometryResource { node, resource })
+            match resources.and_then(|arena| arena.get(resource)) {
+                Some(GeometryResource::VectorPath(path)) => {
+                    Ok(GeometryRef::path(path.as_ref().clone()))
+                }
+                None => {
+                    Err(SemanticCompiledSceneError::UnsupportedGeometryResource { node, resource })
+                }
+            }
         }
         SemanticObjectContent::Text(text) => {
             Err(SemanticCompiledSceneError::UnsupportedText { node, text })
@@ -188,6 +198,31 @@ mod tests {
 
     use super::*;
     use crate::SemanticExecutionIndex;
+
+    #[test]
+    fn canonical_lowering_resolves_only_the_owning_stores_path() {
+        use noon_core::VectorPath;
+        let mut store = SemanticStore::new();
+        let path = VectorPath::new().move_to(Vec2::ZERO).line_to(Vec2::ONE);
+        let resource = store.insert_geometry_path(path.clone());
+        let node = store
+            .insert_semantic_object(SemanticObjectState::new(StoredGeometry::Resource(resource)));
+        store.attach_to_scene(node).unwrap();
+        let mut index = SemanticExecutionIndex::new();
+        let lowered = crate::lower_semantic_execution(&store, &mut index).unwrap();
+        assert_eq!(
+            lowered.compiled().objects()[0].geometry,
+            GeometryRef::path(path)
+        );
+        let mut foreign = SemanticStore::new();
+        foreign.insert_geometry_path(VectorPath::new());
+        let node = foreign
+            .insert_semantic_object(SemanticObjectState::new(StoredGeometry::Resource(resource)));
+        foreign.attach_to_scene(node).unwrap();
+        assert!(
+            crate::lower_semantic_execution(&foreign, &mut SemanticExecutionIndex::new()).is_err()
+        );
+    }
 
     fn circle(radius: f32) -> SemanticObjectState {
         SemanticObjectState::new(StoredGeometry::Circle { radius })
@@ -296,6 +331,7 @@ mod tests {
     fn versioned_geometry_resource_is_not_degraded_to_an_unversioned_key() {
         let mut store = SemanticStore::new();
         let resource = GeometryResourceHandle {
+            arena: 0,
             id: GeometryId::new(7),
             version: 3,
         };

--- a/crates/noon-compile/src/semantic_lowering/entrypoint.rs
+++ b/crates/noon-compile/src/semantic_lowering/entrypoint.rs
@@ -148,9 +148,39 @@ pub fn lower_semantic_execution(
 ) -> Result<SemanticExecutionLoweringOutput, SemanticExecutionLoweringError> {
     let mut staged_index = index.clone();
     let projection = staged_index.lower_scene(store)?;
+    finish_semantic_execution(store, index, staged_index, projection)
+}
+
+/// Canonical initial lowering scoped to one semantic scene family.
+///
+/// Uses the same object/reactive/compute/camera handoff as [`lower_semantic_execution`].
+/// Only the selected family's reachable leaves and their signal dependencies enter
+/// execution; other attached or detached scene families remain untouched. This is
+/// initial lowering, not a live membership or runtime publication operation.
+/// `root` must be a live family ID from `store`; language wrappers must additionally
+/// validate store ownership before passing a store-local ID across their boundary.
+pub fn lower_semantic_execution_root(
+    store: &SemanticStore,
+    root: SemanticNodeId,
+    index: &mut SemanticExecutionIndex,
+) -> Result<SemanticExecutionLoweringOutput, SemanticExecutionLoweringError> {
+    let mut staged_index = index.clone();
+    let projection = staged_index.lower_root(store, root)?;
+    finish_semantic_execution(store, index, staged_index, projection)
+}
+
+fn finish_semantic_execution(
+    store: &SemanticStore,
+    index: &mut SemanticExecutionIndex,
+    staged_index: SemanticExecutionIndex,
+    projection: SemanticExecutionProjection,
+) -> Result<SemanticExecutionLoweringOutput, SemanticExecutionLoweringError> {
     let camera = semantic_camera_object(store, &projection)?;
     let reactive = lower_semantic_reactive_projection(store, &projection)?;
-    let compiled = CompiledScene::from_semantic_projection_after_reactive_lowering(&projection)?;
+    let compiled = CompiledScene::from_semantic_projection_after_reactive_lowering(
+        &projection,
+        store.geometry_resources(),
+    )?;
     let camera_object = validate_camera_object(camera, &compiled)?;
     let program = ReactiveProgram::compile_for_execution_domain(
         compiled
@@ -246,6 +276,112 @@ mod tests {
         state.transform.translation = SemanticVec3::new(center.x as f64, center.y as f64, 0.0);
         state.set_role(SemanticObjectRole::Camera2D);
         state
+    }
+
+    #[test]
+    fn scoped_root_preserves_order_aliases_and_ignores_unrelated_scene_state() {
+        let mut store = SemanticStore::new();
+        let selected = store.insert_family();
+        let nested = store.insert_family();
+        let sibling = store.insert_family();
+        let first = store.insert_semantic_object(circle(1.0));
+        let second = store.insert_semantic_object(circle(2.0));
+        let mut invalid_state = circle(1.0);
+        invalid_state.transform.translation.x = f64::NAN;
+        let invalid = store.insert_semantic_object(invalid_state);
+        let signal = store.insert_semantic_input_signal(0.4_f64).unwrap();
+        store
+            .bind_semantic_signal(signal, second, SemanticObjectProperty::ObjectOpacity)
+            .unwrap();
+        store.add_semantic_family_member(selected, first).unwrap();
+        store.add_semantic_family_member(selected, nested).unwrap();
+        store.add_semantic_family_member(nested, second).unwrap();
+        store.add_semantic_family_member(nested, first).unwrap();
+        store.add_semantic_family_member(sibling, invalid).unwrap();
+        store.attach_to_scene(sibling).unwrap();
+        let roots = store.scene_roots().collect::<Vec<_>>();
+        let revision = store.scene_revision();
+        let mut index = SemanticExecutionIndex::new();
+
+        let lowered = lower_semantic_execution_root(&store, selected, &mut index).unwrap();
+
+        assert_eq!(
+            lowered
+                .compiled()
+                .objects()
+                .iter()
+                .map(|object| object.id)
+                .collect::<Vec<_>>(),
+            [
+                index.execution_object_id(first).unwrap(),
+                index.execution_object_id(second).unwrap()
+            ]
+        );
+        assert_eq!(index.len(), 2);
+        assert_eq!(index.execution_object_id(invalid), None);
+        assert_eq!(lowered.reactive().signal_count(), 1);
+        assert_eq!(lowered.compute().signal_count(), 1);
+        assert_eq!(store.scene_roots().collect::<Vec<_>>(), roots);
+        assert_eq!(store.scene_revision(), revision);
+        assert!(!store.node(selected).unwrap().is_scene_owned());
+        // The existing all-roots entry still observes (and rejects) the unrelated
+        // invalid attached family; scoped lowering does not rewrite membership.
+        assert!(lower_semantic_execution(&store, &mut SemanticExecutionIndex::new()).is_err());
+    }
+
+    #[test]
+    fn scoped_root_validates_family_identity_and_rejects_stale_generation() {
+        let mut store = SemanticStore::new();
+        let object = store.insert_semantic_object(circle(1.0));
+        let stale = store.insert_family();
+        store.remove_node(stale).unwrap();
+        let replacement = store.insert_family();
+        assert_eq!(replacement.slot(), stale.slot());
+        assert_ne!(replacement.generation(), stale.generation());
+        let mut index = SemanticExecutionIndex::new();
+        for (root, expected) in [
+            (object, noon_core::SemanticStoreError::NotFamily(object)),
+            (stale, noon_core::SemanticStoreError::UnknownNode(stale)),
+        ] {
+            assert_eq!(
+                lower_semantic_execution_root(&store, root, &mut index),
+                Err(SemanticExecutionLoweringError::Object(
+                    SemanticLoweringError::Store(expected)
+                ))
+            );
+            assert!(index.is_empty());
+        }
+        let empty = lower_semantic_execution_root(&store, replacement, &mut index).unwrap();
+        assert!(empty.compiled().objects().is_empty());
+        assert!(index.is_empty());
+    }
+
+    #[test]
+    fn scoped_root_failure_keeps_preexisting_execution_index_unchanged() {
+        let mut store = SemanticStore::new();
+        let first_root = store.insert_family();
+        let first = store.insert_semantic_object(circle(1.0));
+        store.add_semantic_family_member(first_root, first).unwrap();
+        let second_root = store.insert_family();
+        let second = store.insert_semantic_object(circle(2.0));
+        store
+            .add_semantic_family_member(second_root, second)
+            .unwrap();
+        let unlowerable = store.insert_semantic_input_signal(f64::MAX).unwrap();
+        store
+            .bind_semantic_signal(unlowerable, second, SemanticObjectProperty::ObjectOpacity)
+            .unwrap();
+        let mut index = SemanticExecutionIndex::new();
+        lower_semantic_execution_root(&store, first_root, &mut index).unwrap();
+        let first_id = index.execution_object_id(first).unwrap();
+
+        assert!(matches!(
+            lower_semantic_execution_root(&store, second_root, &mut index),
+            Err(SemanticExecutionLoweringError::Reactive(_))
+        ));
+        assert_eq!(index.len(), 1);
+        assert_eq!(index.execution_object_id(first), Some(first_id));
+        assert_eq!(index.execution_object_id(second), None);
     }
 
     #[test]

--- a/crates/noon-compile/src/semantic_lowering/projection.rs
+++ b/crates/noon-compile/src/semantic_lowering/projection.rs
@@ -2,8 +2,9 @@ use std::collections::{HashMap, HashSet};
 
 use noon_core::{
     Color, ObjectId, SemanticMutationImpact, SemanticMutationTransactionResult, SemanticNodeId,
-    SemanticObjectContent, SemanticObjectState, SemanticPaint, SemanticPresentation,
-    SemanticSignalBinding, SemanticStore, SemanticStoreError, Style, Transform2D,
+    SemanticNodeKind, SemanticObjectContent, SemanticObjectState, SemanticPaint,
+    SemanticPresentation, SemanticSignalBinding, SemanticStore, SemanticStoreError, Style,
+    Transform2D,
 };
 
 /// Compiler-owned identity bridge from authoritative semantic nodes to the existing
@@ -77,6 +78,7 @@ impl SemanticExecutionIndex {
                 SemanticMutationImpact::SignalValue { .. }
                 | SemanticMutationImpact::ObjectProperty { .. }
                 | SemanticMutationImpact::ObjectContent { .. }
+                | SemanticMutationImpact::ObjectStyle { .. }
                 | SemanticMutationImpact::Subscription { .. }
                 | SemanticMutationImpact::FamilyMemberAdded { .. }
                 | SemanticMutationImpact::FamilyMemberRemoved { .. }
@@ -104,10 +106,38 @@ impl SemanticExecutionIndex {
         &mut self,
         store: &SemanticStore,
     ) -> Result<SemanticExecutionProjection, SemanticLoweringError> {
+        self.lower_roots(store, store.scene_roots())
+    }
+
+    /// Lower one semantic family as an isolated initial scene root.
+    ///
+    /// The family may be detached. Membership and ordering are read from the same
+    /// store without attaching/detaching roots, cloning the store, or visiting other
+    /// scene families. The caller must retain the originating store with `root`:
+    /// a bare semantic ID is store-local, not a cross-store identity token.
+    pub fn lower_root(
+        &mut self,
+        store: &SemanticStore,
+        root: SemanticNodeId,
+    ) -> Result<SemanticExecutionProjection, SemanticLoweringError> {
+        let node = store
+            .node(root)
+            .ok_or(SemanticStoreError::UnknownNode(root))?;
+        if !matches!(node.kind(), SemanticNodeKind::Family) {
+            return Err(SemanticStoreError::NotFamily(root).into());
+        }
+        self.lower_roots(store, std::iter::once(root))
+    }
+
+    fn lower_roots(
+        &mut self,
+        store: &SemanticStore,
+        roots: impl IntoIterator<Item = SemanticNodeId>,
+    ) -> Result<SemanticExecutionProjection, SemanticLoweringError> {
         let mut pending = Vec::new();
         let mut seen = HashSet::new();
 
-        for root in store.scene_roots() {
+        for root in roots {
             for semantic_id in store.ordered_leaf_nodes(root)? {
                 if !seen.insert(semantic_id) {
                     continue;
@@ -390,8 +420,9 @@ fn lower_style(
         stroke,
         stroke_width,
         stroke_width_mode: state.style.stroke_width_mode,
+        stroke_join: state.style.stroke_join,
+        stroke_cap: state.style.stroke_cap,
         opacity,
-        ..Style::default()
     })
 }
 
@@ -512,6 +543,8 @@ mod tests {
         state.style.fill = Some(SemanticPaint::Solid(Color::rgba(0.2, 0.4, 0.6, 0.8)));
         state.style.fill_opacity = 0.25;
         state.style.stroke_width = 3.5;
+        state.style.stroke_join = noon_core::StrokeJoin::Bevel;
+        state.style.stroke_cap = noon_core::StrokeCap::Square;
         state.style.object_opacity = 0.6;
         state.set_z_index(9);
         let object = attach(&mut store, state);
@@ -531,6 +564,14 @@ mod tests {
         assert_eq!((fill.red, fill.green, fill.blue), (0.2, 0.4, 0.6));
         assert!((fill.alpha - 0.2).abs() < 1e-6);
         assert_eq!(object_state.base_style.stroke_width, 3.5);
+        assert_eq!(
+            object_state.base_style.stroke_join,
+            noon_core::StrokeJoin::Bevel
+        );
+        assert_eq!(
+            object_state.base_style.stroke_cap,
+            noon_core::StrokeCap::Square
+        );
         assert_eq!(object_state.base_style.opacity, 0.6);
         assert_eq!(object_state.presentation.z_index, 9);
         assert_eq!(object_state.presentation.insertion_order, 0);

--- a/crates/noon-compile/src/semantic_lowering/reachability.rs
+++ b/crates/noon-compile/src/semantic_lowering/reachability.rs
@@ -191,6 +191,7 @@ impl SemanticExecutionReachability {
                 SemanticMutationImpact::SignalValue { .. }
                 | SemanticMutationImpact::ObjectProperty { .. }
                 | SemanticMutationImpact::ObjectContent { .. }
+                | SemanticMutationImpact::ObjectStyle { .. }
                 | SemanticMutationImpact::Subscription { .. }
                 | SemanticMutationImpact::FamilyMemberReordered { .. }
                 | SemanticMutationImpact::NodeAdded { .. }

--- a/crates/noon-core/src/reactive/resource_arena.rs
+++ b/crates/noon-core/src/reactive/resource_arena.rs
@@ -1,9 +1,20 @@
 use std::{
     mem::{size_of, size_of_val},
-    sync::Arc,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
 };
 
 use crate::{GeometryId, GeometryRef, Vec2, VectorPath};
+
+static NEXT_GEOMETRY_ARENA: AtomicU64 = AtomicU64::new(1);
+
+fn next_geometry_arena() -> u64 {
+    NEXT_GEOMETRY_ARENA
+        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |id| id.checked_add(1))
+        .expect("geometry arena identity exhausted")
+}
 
 const GEOMETRY_RESOURCE_SLOT_BITS: u32 = 32;
 const GEOMETRY_RESOURCE_SLOT_MASK: u64 = u32::MAX as u64;
@@ -14,6 +25,8 @@ const GEOMETRY_RESOURCE_SLOT_MASK: u64 = u32::MAX as u64;
 /// the version so caches and old snapshots cannot silently observe new payloads.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct GeometryResourceHandle {
+    /// Owning resource namespace; equal slot/version values from another arena are unrelated.
+    pub arena: u64,
     pub id: GeometryId,
     pub version: u64,
 }
@@ -71,15 +84,33 @@ pub struct GeometryResourceStats {
 /// `GeometryId` encodes a physical slot plus its generation. This lets the arena
 /// reuse storage at the live-working-set high-water mark without allowing a stale
 /// bare ID to alias a later occupant of the same slot.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct GeometryResourceArena {
+    namespace: u64,
     entries: Vec<ResourceEntry>,
     free_slots: Vec<u32>,
     live_resources: usize,
     retained_bytes: usize,
 }
 
+impl Default for GeometryResourceArena {
+    fn default() -> Self {
+        Self {
+            namespace: next_geometry_arena(),
+            entries: Vec::new(),
+            free_slots: Vec::new(),
+            live_resources: 0,
+            retained_bytes: 0,
+        }
+    }
+}
+
 impl GeometryResourceArena {
+    pub(crate) fn fork_namespace(&mut self) -> u64 {
+        self.namespace = next_geometry_arena();
+        self.namespace
+    }
+
     pub fn new() -> Self {
         Self::default()
     }
@@ -97,6 +128,7 @@ impl GeometryResourceArena {
             entry.version = 0;
             entry.value = Some(resource);
             GeometryResourceHandle {
+                arena: self.namespace,
                 id: geometry_resource_id(index, entry.generation),
                 version: 0,
             }
@@ -108,7 +140,11 @@ impl GeometryResourceArena {
                 version: 0,
                 value: Some(resource),
             });
-            GeometryResourceHandle { id, version: 0 }
+            GeometryResourceHandle {
+                arena: self.namespace,
+                id,
+                version: 0,
+            }
         };
 
         self.retained_bytes = self.retained_bytes.saturating_add(resource_bytes);
@@ -144,6 +180,9 @@ impl GeometryResourceArena {
     }
 
     pub fn get(&self, handle: GeometryResourceHandle) -> Option<&GeometryResource> {
+        if handle.arena != self.namespace {
+            return None;
+        }
         let index = geometry_resource_slot(handle.id);
         let entry = self.entries.get(index)?;
         if geometry_resource_id(index, entry.generation) != handle.id
@@ -162,6 +201,7 @@ impl GeometryResourceArena {
         }
         entry.value.as_ref()?;
         Some(GeometryResourceHandle {
+            arena: self.namespace,
             id,
             version: entry.version,
         })
@@ -196,6 +236,7 @@ impl GeometryResourceArena {
         entry.version = next_version;
         entry.value = Some(resource);
         Ok(GeometryResourceHandle {
+            arena: self.namespace,
             id,
             version: entry.version,
         })
@@ -428,6 +469,7 @@ mod tests {
         arena.entries[slot].generation = u32::MAX;
         let exhausted_id = geometry_resource_id(slot, u32::MAX);
         let exhausted = GeometryResourceHandle {
+            arena: first.arena,
             id: exhausted_id,
             version: first.version,
         };
@@ -448,6 +490,7 @@ mod tests {
         let entry = &mut arena.entries[geometry_resource_slot(first.id)];
         entry.version = u64::MAX;
         let exhausted = GeometryResourceHandle {
+            arena: first.arena,
             id: first.id,
             version: u64::MAX,
         };
@@ -476,6 +519,7 @@ mod tests {
         let entry = &mut arena.entries[geometry_resource_slot(first.id)];
         entry.version = u64::MAX;
         let exhausted = GeometryResourceHandle {
+            arena: first.arena,
             id: first.id,
             version: u64::MAX,
         };

--- a/crates/noon-core/src/reactive/resource_transaction.rs
+++ b/crates/noon-core/src/reactive/resource_transaction.rs
@@ -349,6 +349,7 @@ mod tests {
         let geometries = GeometryResourceArena::new();
         let fonts = FontResourceArena::new();
         let missing = GeometryResourceHandle {
+            arena: 0,
             id: GeometryId::new(42),
             version: 0,
         };

--- a/crates/noon-core/src/reactive/semantic_model.rs
+++ b/crates/noon-core/src/reactive/semantic_model.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{Color, PathCommand, Style, Vec2, VectorPath};
+use crate::{Color, PathCommand, StrokeCap, StrokeJoin, Style, Vec2, VectorPath};
 
 /// High-precision authoring vector. The current renderer remains 2D/f32; this
 /// type prevents frontend compatibility from being constrained by that backend.
@@ -94,6 +94,10 @@ pub struct SemanticStyle {
     pub stroke_opacity: f64,
     pub stroke_width: f64,
     pub stroke_width_mode: StrokeWidthMode,
+    #[serde(default)]
+    pub stroke_join: StrokeJoin,
+    #[serde(default)]
+    pub stroke_cap: StrokeCap,
     pub object_opacity: f64,
 }
 
@@ -106,6 +110,8 @@ impl Default for SemanticStyle {
             stroke_opacity: 1.0,
             stroke_width: 0.0,
             stroke_width_mode: StrokeWidthMode::ScaleWithObject,
+            stroke_join: StrokeJoin::Round,
+            stroke_cap: StrokeCap::Round,
             object_opacity: 1.0,
         }
     }
@@ -122,6 +128,8 @@ impl SemanticStyle {
             stroke_opacity: 1.0,
             stroke_width: style.stroke_width as f64,
             stroke_width_mode: style.stroke_width_mode,
+            stroke_join: style.stroke_join,
+            stroke_cap: style.stroke_cap,
             object_opacity: style.opacity as f64,
         }
     }
@@ -428,6 +436,18 @@ mod tests {
         };
         assert!((style.effective_fill_opacity() - 0.2).abs() < 1e-12);
         assert!((style.effective_stroke_opacity() - 0.1).abs() < 1e-12);
+    }
+
+    #[test]
+    fn style_preserves_legacy_stroke_topology() {
+        let semantic = SemanticStyle::from_legacy(Style {
+            stroke_join: StrokeJoin::Bevel,
+            stroke_cap: StrokeCap::Square,
+            ..Style::default()
+        });
+
+        assert_eq!(semantic.stroke_join, StrokeJoin::Bevel);
+        assert_eq!(semantic.stroke_cap, StrokeCap::Square);
     }
 
     #[test]

--- a/crates/noon-core/src/reactive/semantic_transaction.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction.rs
@@ -5,7 +5,7 @@ use super::{
     SemanticAnimationState, SemanticNodeId, SemanticNodeKind, SemanticObjectContent,
     SemanticObjectProperty, SemanticObjectState, SemanticSceneOperationError,
     SemanticSignalBinding, SemanticSignalError, SemanticSignalSource, SemanticSignalValue,
-    SemanticSignalValueKind, SemanticStore, SemanticStoreError,
+    SemanticSignalValueKind, SemanticStore, SemanticStoreError, SemanticStyle, StoredGeometry,
 };
 
 mod animation_addition;
@@ -40,6 +40,10 @@ pub enum SemanticMutation {
     ReplaceContent {
         object: SemanticNodeId,
         content: SemanticObjectContent,
+    },
+    ReplaceStyle {
+        object: SemanticNodeId,
+        style: SemanticStyle,
     },
     ChangeSubscription {
         object: SemanticNodeId,
@@ -84,6 +88,7 @@ impl SemanticMutation {
             Self::SetSignal { signal, .. } => Some(*signal),
             Self::SetProperty { object, .. }
             | Self::ReplaceContent { object, .. }
+            | Self::ReplaceStyle { object, .. }
             | Self::ChangeSubscription { object, .. } => Some(*object),
             Self::AddMember { family, .. }
             | Self::RemoveMember { family, .. }
@@ -106,6 +111,7 @@ impl SemanticMutation {
             Self::ReplaceContent { object, .. } => {
                 Some(SemanticMutationKey::ObjectContent(*object))
             }
+            Self::ReplaceStyle { object, .. } => Some(SemanticMutationKey::ObjectStyle(*object)),
             Self::ChangeSubscription {
                 object, property, ..
             } => Some(SemanticMutationKey::Subscription {
@@ -139,6 +145,7 @@ enum SemanticMutationKey {
         property: SemanticObjectProperty,
     },
     ObjectContent(SemanticNodeId),
+    ObjectStyle(SemanticNodeId),
     Subscription {
         object: SemanticNodeId,
         property: SemanticObjectProperty,
@@ -170,6 +177,9 @@ pub enum SemanticMutationImpact {
         property: SemanticObjectProperty,
     },
     ObjectContent {
+        object: SemanticNodeId,
+    },
+    ObjectStyle {
         object: SemanticNodeId,
     },
     Subscription {
@@ -248,6 +258,17 @@ impl SemanticMutationTransaction {
             object,
             content: content.into(),
         });
+        self
+    }
+
+    /// Replace the complete authored style of one semantic object.
+    ///
+    /// This carries paints and discrete stroke topology through the same atomic
+    /// mutation vocabulary as scalar style properties. A transaction cannot mix
+    /// full-style replacement with scalar style writes for the same object.
+    pub fn replace_style(&mut self, object: SemanticNodeId, style: SemanticStyle) -> &mut Self {
+        self.mutations
+            .push(SemanticMutation::ReplaceStyle { object, style });
         self
     }
 
@@ -406,6 +427,11 @@ impl SemanticMutationTransaction {
                     written_slots.insert(object);
                     impacts.push(SemanticMutationImpact::ObjectContent { object });
                 }
+                SemanticMutation::ReplaceStyle { object, style } => {
+                    set_object_style(store, object, style);
+                    written_slots.insert(object);
+                    impacts.push(SemanticMutationImpact::ObjectStyle { object });
+                }
                 SemanticMutation::ChangeSubscription {
                     object,
                     property,
@@ -543,6 +569,8 @@ impl SemanticMutationTransaction {
         let removed_nodes = store.semantic_removal_closure(&removed_nodes);
 
         let mut targets = HashSet::with_capacity(self.mutations.len());
+        let mut style_replacements = HashSet::new();
+        let mut style_property_writes = HashSet::new();
         let mut changed = Vec::with_capacity(self.mutations.len());
         let mut family_edges = FamilyEdgePreflight::default();
         let mut pending_sources = HashSet::new();
@@ -619,6 +647,30 @@ impl SemanticMutationTransaction {
                 }
             }
 
+            match mutation {
+                SemanticMutation::ReplaceStyle { object, .. } => {
+                    if style_property_writes.contains(object) {
+                        return Err(SemanticMutationTransactionError::ConflictingStyleMutation {
+                            index,
+                            object: *object,
+                        });
+                    }
+                    style_replacements.insert(*object);
+                }
+                SemanticMutation::SetProperty {
+                    object, property, ..
+                } if is_style_property(*property) => {
+                    if style_replacements.contains(object) {
+                        return Err(SemanticMutationTransactionError::ConflictingStyleMutation {
+                            index,
+                            object: *object,
+                        });
+                    }
+                    style_property_writes.insert(*object);
+                }
+                _ => {}
+            }
+
             if let Some(key) = mutation.key() {
                 if !targets.insert(key) {
                     return Err(match key {
@@ -634,6 +686,9 @@ impl SemanticMutationTransaction {
                         }
                         SemanticMutationKey::ObjectContent(object) => {
                             SemanticMutationTransactionError::DuplicateContent { index, object }
+                        }
+                        SemanticMutationKey::ObjectStyle(object) => {
+                            SemanticMutationTransactionError::DuplicateStyle { index, object }
                         }
                         SemanticMutationKey::Subscription { object, property } => {
                             SemanticMutationTransactionError::DuplicateSubscription {
@@ -730,7 +785,23 @@ impl SemanticMutationTransaction {
                             index,
                             error,
                         })?;
+                    validate_object_content_resource(store, *content, index)?;
                     changed.push(state.content != *content);
+                }
+                SemanticMutation::ReplaceStyle { object, style } => {
+                    let state = store
+                        .semantic_object_state_checked(*object)
+                        .map_err(|error| SemanticMutationTransactionError::Object {
+                            index,
+                            error,
+                        })?;
+                    if !semantic_style_is_finite(style) {
+                        return Err(SemanticMutationTransactionError::InvalidStyle {
+                            index,
+                            object: *object,
+                        });
+                    }
+                    changed.push(state.style != *style);
                 }
                 SemanticMutation::ChangeSubscription {
                     object,
@@ -907,6 +978,59 @@ fn set_object_content(
         .content = content;
 }
 
+pub(super) fn validate_object_content_resource(
+    store: &SemanticStore,
+    content: SemanticObjectContent,
+    index: usize,
+) -> Result<(), SemanticMutationTransactionError> {
+    let SemanticObjectContent::Geometry(StoredGeometry::Resource(resource)) = content else {
+        return Ok(());
+    };
+    if store.geometry_resources().get(resource).is_none() {
+        return Err(SemanticMutationTransactionError::InvalidGeometryResource { index, resource });
+    }
+    Ok(())
+}
+
+fn set_object_style(store: &mut SemanticStore, object: SemanticNodeId, style: SemanticStyle) {
+    store
+        .node_mut(object)
+        .and_then(|node| node.semantic_object_state_mut())
+        .expect("preflighted semantic object must remain valid while transaction owns the store")
+        .style = style;
+}
+
+const fn is_style_property(property: SemanticObjectProperty) -> bool {
+    matches!(
+        property,
+        SemanticObjectProperty::FillOpacity
+            | SemanticObjectProperty::StrokeOpacity
+            | SemanticObjectProperty::StrokeWidth
+            | SemanticObjectProperty::ObjectOpacity
+    )
+}
+
+fn semantic_style_is_finite(style: &SemanticStyle) -> bool {
+    semantic_paint_is_finite(style.fill.as_ref())
+        && semantic_paint_is_finite(style.stroke.as_ref())
+        && style.fill_opacity.is_finite()
+        && style.stroke_opacity.is_finite()
+        && style.stroke_width.is_finite()
+        && style.object_opacity.is_finite()
+}
+
+fn semantic_paint_is_finite(paint: Option<&super::SemanticPaint>) -> bool {
+    match paint {
+        Some(super::SemanticPaint::Solid(color)) => {
+            color.red.is_finite()
+                && color.green.is_finite()
+                && color.blue.is_finite()
+                && color.alpha.is_finite()
+        }
+        Some(super::SemanticPaint::Resource(_)) | None => true,
+    }
+}
+
 fn set_object_subscription(
     store: &mut SemanticStore,
     object: SemanticNodeId,
@@ -961,6 +1085,14 @@ pub enum SemanticMutationTransactionError {
         property: SemanticObjectProperty,
     },
     DuplicateContent {
+        index: usize,
+        object: SemanticNodeId,
+    },
+    DuplicateStyle {
+        index: usize,
+        object: SemanticNodeId,
+    },
+    ConflictingStyleMutation {
         index: usize,
         object: SemanticNodeId,
     },
@@ -1078,6 +1210,14 @@ pub enum SemanticMutationTransactionError {
         object: SemanticNodeId,
         property: SemanticObjectProperty,
     },
+    InvalidStyle {
+        index: usize,
+        object: SemanticNodeId,
+    },
+    InvalidGeometryResource {
+        index: usize,
+        resource: crate::GeometryResourceHandle,
+    },
     PropertyTypeMismatch {
         index: usize,
         object: SemanticNodeId,
@@ -1122,6 +1262,18 @@ impl std::fmt::Display for SemanticMutationTransactionError {
             Self::DuplicateContent { index, object } => write!(
                 formatter,
                 "semantic transaction mutation {index} repeats content replacement on object {}:{}",
+                object.slot(),
+                object.generation()
+            ),
+            Self::DuplicateStyle { index, object } => write!(
+                formatter,
+                "semantic transaction mutation {index} repeats style replacement on object {}:{}",
+                object.slot(),
+                object.generation()
+            ),
+            Self::ConflictingStyleMutation { index, object } => write!(
+                formatter,
+                "semantic transaction mutation {index} mixes full-style replacement with scalar style mutation on object {}:{}",
                 object.slot(),
                 object.generation()
             ),
@@ -1313,6 +1465,17 @@ impl std::fmt::Display for SemanticMutationTransactionError {
                 object.slot(),
                 object.generation()
             ),
+            Self::InvalidStyle { index, object } => write!(
+                formatter,
+                "semantic transaction mutation {index} cannot replace style on object {}:{} with non-finite authored values",
+                object.slot(),
+                object.generation()
+            ),
+            Self::InvalidGeometryResource { index, resource } => write!(
+                formatter,
+                "semantic transaction mutation {index} references unavailable geometry resource {:?}",
+                resource
+            ),
             Self::PropertyTypeMismatch {
                 index,
                 object,
@@ -1356,6 +1519,9 @@ mod base_tests;
 
 #[cfg(test)]
 mod content_tests;
+
+#[cfg(test)]
+mod style_tests;
 
 #[cfg(test)]
 mod subscription_tests;

--- a/crates/noon-core/src/reactive/semantic_transaction/add_node_tests.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction/add_node_tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{SemanticNodeResidency, SourceIdentity, StoredGeometry};
+use crate::{SemanticNodeResidency, SourceIdentity, StoredGeometry, Vec2, VectorPath};
 
 fn object_state(radius: f32) -> SemanticObjectState {
     SemanticObjectState::new(StoredGeometry::Circle { radius })
@@ -91,6 +91,44 @@ fn invalid_object_state_rolls_back_earlier_mutation_before_allocation() {
     assert_eq!(scalar_input(&store, signal), 1.0);
     assert_eq!(store.len(), before_len);
     assert_eq!(store.last_mutation_stats().slots_written, 0);
+}
+
+#[test]
+fn unavailable_geometry_resource_is_rejected_before_node_allocation() {
+    let mut store = SemanticStore::new();
+    let signal = store.insert_semantic_input_signal(1.0_f64).unwrap();
+    let valid = store.insert_geometry_path(
+        VectorPath::new()
+            .move_to(Vec2::ZERO)
+            .line_to(Vec2::new(1.0, 0.0)),
+    );
+    let mut foreign_store = SemanticStore::new();
+    let foreign = foreign_store.insert_geometry_path(VectorPath::new().move_to(Vec2::ZERO));
+    let stale = crate::GeometryResourceHandle {
+        version: valid.version + 1,
+        ..valid
+    };
+
+    for unavailable in [foreign, stale] {
+        let before_len = store.len();
+        let mut transaction = SemanticMutationTransaction::new();
+        transaction
+            .set_signal(signal, 2.0_f64)
+            .add_node(SemanticNodeCreation::object(SemanticObjectState::new(
+                StoredGeometry::Resource(unavailable),
+            )));
+
+        assert_eq!(
+            transaction.apply(&mut store),
+            Err(SemanticMutationTransactionError::InvalidGeometryResource {
+                index: 1,
+                resource: unavailable,
+            })
+        );
+        assert_eq!(scalar_input(&store, signal), 1.0);
+        assert_eq!(store.len(), before_len);
+        assert_eq!(store.last_mutation_stats().slots_written, 0);
+    }
 }
 
 #[test]

--- a/crates/noon-core/src/reactive/semantic_transaction/content_tests.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction/content_tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{SemanticObjectState, SemanticVec3, StoredGeometry, Vec2};
+use crate::{SemanticObjectState, SemanticVec3, StoredGeometry, Vec2, VectorPath};
 
 fn object(store: &mut SemanticStore, radius: f32) -> SemanticNodeId {
     store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle { radius }))
@@ -184,4 +184,48 @@ fn content_replacement_is_one_slot_local_with_large_unrelated_scene() {
         result.impacts(),
         &[SemanticMutationImpact::ObjectContent { object: target }]
     );
+}
+
+#[test]
+fn unavailable_geometry_resource_replacement_rolls_back_atomically() {
+    let mut store = SemanticStore::new();
+    let live = object(&mut store, 1.0);
+    let earlier = object(&mut store, 2.0);
+    let valid = store.insert_geometry_path(
+        VectorPath::new()
+            .move_to(Vec2::ZERO)
+            .line_to(Vec2::new(1.0, 0.0)),
+    );
+    let mut foreign_store = SemanticStore::new();
+    let foreign = foreign_store.insert_geometry_path(VectorPath::new().move_to(Vec2::ZERO));
+    let stale = crate::GeometryResourceHandle {
+        version: valid.version + 1,
+        ..valid
+    };
+
+    for unavailable in [foreign, stale] {
+        let before = store.semantic_object_state_checked(live).unwrap().clone();
+        let mut transaction = SemanticMutationTransaction::new();
+        transaction
+            .set_property(earlier, SemanticObjectProperty::RotationZ, 0.5_f64)
+            .replace_content(live, StoredGeometry::Resource(unavailable));
+
+        assert_eq!(
+            transaction.apply(&mut store),
+            Err(SemanticMutationTransactionError::InvalidGeometryResource {
+                index: 1,
+                resource: unavailable,
+            })
+        );
+        assert_eq!(store.semantic_object_state_checked(live).unwrap(), &before);
+        assert_eq!(
+            store
+                .semantic_object_state_checked(earlier)
+                .unwrap()
+                .transform
+                .rotation_z,
+            0.0
+        );
+        assert_eq!(store.last_mutation_stats().slots_written, 0);
+    }
 }

--- a/crates/noon-core/src/reactive/semantic_transaction/node_addition.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction/node_addition.rs
@@ -4,7 +4,7 @@ use crate::{
     SemanticNodeId, SemanticObjectState, SemanticStore, SemanticStoreError, SourceIdentity,
 };
 
-use super::SemanticMutationTransactionError;
+use super::{validate_object_content_resource, SemanticMutationTransactionError};
 
 /// Authored payload for allocating one new scene node through the semantic
 /// mutation transaction.
@@ -98,6 +98,7 @@ pub(super) fn preflight_add_node(
     {
         return Err(SemanticMutationTransactionError::InvalidNodeObjectState { index });
     }
+    validate_object_content_resource(store, state.content, index)?;
 
     for binding in state.signal_bindings() {
         let signal = binding.signal();

--- a/crates/noon-core/src/reactive/semantic_transaction/style_tests.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction/style_tests.rs
@@ -1,0 +1,190 @@
+use super::*;
+use crate::{SemanticObjectState, SemanticPaint, StoredGeometry, StrokeCap, StrokeJoin, Style};
+
+fn object(store: &mut SemanticStore) -> SemanticNodeId {
+    store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+        radius: 1.0,
+    }))
+}
+
+fn replacement_style() -> SemanticStyle {
+    let mut style = SemanticStyle::from_legacy(Style {
+        stroke_join: StrokeJoin::Bevel,
+        stroke_cap: StrokeCap::Square,
+        ..Style::default()
+    });
+    style.fill = Some(SemanticPaint::Solid(crate::Color::RED));
+    style.stroke_width = 3.5;
+    style
+}
+
+#[test]
+fn replace_style_changes_only_style_and_publishes_once() {
+    let mut store = SemanticStore::new();
+    let target = object(&mut store);
+    let before = store.semantic_object_state_checked(target).unwrap().clone();
+    let before_revision = store.scene_revision();
+    let replacement = replacement_style();
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction.replace_style(target, replacement.clone());
+    let result = transaction.apply(&mut store).unwrap();
+
+    let after = store.semantic_object_state_checked(target).unwrap();
+    assert_eq!(after.style, replacement);
+    assert_eq!(after.content, before.content);
+    assert_eq!(after.transform, before.transform);
+    assert_eq!(after.presentation(), before.presentation());
+    assert_eq!(after.signal_bindings(), before.signal_bindings());
+    assert_eq!(store.last_mutation_stats().slots_written, 1);
+    assert_eq!(
+        store.scene_revision(),
+        before_revision.checked_next().unwrap()
+    );
+    assert_eq!(
+        result.impacts(),
+        &[SemanticMutationImpact::ObjectStyle { object: target }]
+    );
+}
+
+#[test]
+fn unchanged_style_is_a_noop_and_invalid_style_fails_atomically() {
+    let mut store = SemanticStore::new();
+    let target = object(&mut store);
+    let original = store
+        .semantic_object_state_checked(target)
+        .unwrap()
+        .style
+        .clone();
+    let original_revision = store.scene_revision();
+
+    let mut unchanged = SemanticMutationTransaction::new();
+    unchanged.replace_style(target, original.clone());
+    let result = unchanged.apply(&mut store).unwrap();
+    assert!(result.impacts().is_empty());
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+    assert_eq!(store.scene_revision(), original_revision);
+
+    let other = object(&mut store);
+    let mut invalid = replacement_style();
+    invalid.stroke_width = f64::NAN;
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .set_property(other, SemanticObjectProperty::RotationZ, 0.5_f64)
+        .replace_style(target, invalid);
+    assert_eq!(
+        transaction.apply(&mut store),
+        Err(SemanticMutationTransactionError::InvalidStyle {
+            index: 1,
+            object: target,
+        })
+    );
+    assert_eq!(
+        store.semantic_object_state_checked(target).unwrap().style,
+        original
+    );
+    assert_eq!(
+        store
+            .semantic_object_state_checked(other)
+            .unwrap()
+            .transform
+            .rotation_z,
+        0.0
+    );
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+
+    let mut invalid_paint = replacement_style();
+    invalid_paint.fill = Some(SemanticPaint::Solid(crate::Color {
+        red: f32::NAN,
+        ..crate::Color::RED
+    }));
+    let mut paint_transaction = SemanticMutationTransaction::new();
+    paint_transaction
+        .set_property(other, SemanticObjectProperty::RotationZ, 0.5_f64)
+        .replace_style(target, invalid_paint);
+    assert_eq!(
+        paint_transaction.apply(&mut store),
+        Err(SemanticMutationTransactionError::InvalidStyle {
+            index: 1,
+            object: target,
+        })
+    );
+    assert_eq!(
+        store.semantic_object_state_checked(target).unwrap().style,
+        original
+    );
+    assert_eq!(
+        store
+            .semantic_object_state_checked(other)
+            .unwrap()
+            .transform
+            .rotation_z,
+        0.0
+    );
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+}
+
+#[test]
+fn full_style_and_scalar_style_writes_conflict_in_either_order() {
+    let mut store = SemanticStore::new();
+    let target = object(&mut store);
+
+    let mut replacement_first = SemanticMutationTransaction::new();
+    replacement_first
+        .replace_style(target, replacement_style())
+        .set_property(target, SemanticObjectProperty::StrokeWidth, 2.0_f64);
+    assert_eq!(
+        replacement_first.apply(&mut store),
+        Err(SemanticMutationTransactionError::ConflictingStyleMutation {
+            index: 1,
+            object: target,
+        })
+    );
+
+    let mut property_first = SemanticMutationTransaction::new();
+    property_first
+        .set_property(target, SemanticObjectProperty::FillOpacity, 0.5_f64)
+        .replace_style(target, replacement_style());
+    assert_eq!(
+        property_first.apply(&mut store),
+        Err(SemanticMutationTransactionError::ConflictingStyleMutation {
+            index: 1,
+            object: target,
+        })
+    );
+
+    let mut distinct_properties = SemanticMutationTransaction::new();
+    distinct_properties
+        .set_property(target, SemanticObjectProperty::FillOpacity, 0.5_f64)
+        .set_property(target, SemanticObjectProperty::StrokeWidth, 2.0_f64);
+    assert!(distinct_properties.apply(&mut store).is_ok());
+}
+
+#[test]
+fn duplicate_style_and_non_object_target_fail_before_commit() {
+    let mut store = SemanticStore::new();
+    let target = object(&mut store);
+    let mut duplicate = SemanticMutationTransaction::new();
+    duplicate
+        .replace_style(target, replacement_style())
+        .replace_style(target, SemanticStyle::default());
+    assert_eq!(
+        duplicate.apply(&mut store),
+        Err(SemanticMutationTransactionError::DuplicateStyle {
+            index: 1,
+            object: target,
+        })
+    );
+
+    let family = store.insert_family();
+    let mut wrong_target = SemanticMutationTransaction::new();
+    wrong_target.replace_style(family, replacement_style());
+    assert_eq!(
+        wrong_target.apply(&mut store),
+        Err(SemanticMutationTransactionError::Object {
+            index: 0,
+            error: SemanticSceneOperationError::NotSemanticObject(family),
+        })
+    );
+    assert_eq!(store.last_mutation_stats().slots_written, 0);
+}

--- a/crates/noon-core/src/reactive/text_resources.rs
+++ b/crates/noon-core/src/reactive/text_resources.rs
@@ -948,6 +948,7 @@ mod tests {
     #[test]
     fn vector_math_items_share_geometry_resource_handles() {
         let geometry = GeometryResourceHandle {
+            arena: 0,
             id: GeometryId::new(7),
             version: 2,
         };
@@ -966,6 +967,7 @@ mod tests {
         let mut resource = sample_text("x");
         resource.vector_items = Arc::from([TextVectorItem {
             geometry: GeometryResourceHandle {
+                arena: 0,
                 id: GeometryId::new(8),
                 version: 0,
             },
@@ -1075,6 +1077,7 @@ mod tests {
             version: 1,
         };
         let geometry = GeometryResourceHandle {
+            arena: 0,
             id: GeometryId::new(12),
             version: 4,
         };

--- a/crates/noon-core/src/semantic_store.rs
+++ b/crates/noon-core/src/semantic_store.rs
@@ -385,8 +385,9 @@ pub struct SemanticMutationStats {
     pub cycle_nodes_visited: usize,
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Debug, Default)]
 pub struct SemanticStore {
+    geometry_resources: crate::GeometryResourceArena,
     slots: Vec<SemanticSlot>,
     free_head: Option<u32>,
     live_nodes: usize,
@@ -401,7 +402,58 @@ pub struct SemanticStore {
     scene_revision: crate::SceneRevision,
 }
 
+// A cloned scene is an independent authoring store. Re-namespace its resource
+// references while sharing immutable payload allocations through the arena's Arc values.
+impl Clone for SemanticStore {
+    fn clone(&self) -> Self {
+        let mut geometry_resources = self.geometry_resources.clone();
+        let namespace = geometry_resources.fork_namespace();
+        let mut slots = self.slots.clone();
+        for slot in &mut slots {
+            if let Some(node) = slot.node.as_mut() {
+                if let Some(state) = node.object_state.as_mut() {
+                    if let crate::SemanticObjectContent::Geometry(
+                        crate::StoredGeometry::Resource(handle),
+                    ) = &mut state.content
+                    {
+                        if self.geometry_resources.get(*handle).is_some() {
+                            handle.arena = namespace;
+                        }
+                    }
+                }
+            }
+        }
+        Self {
+            geometry_resources,
+            slots,
+            free_head: self.free_head,
+            live_nodes: self.live_nodes,
+            scene_head: self.scene_head,
+            scene_tail: self.scene_tail,
+            scene_nodes: self.scene_nodes,
+            next_insertion_order: self.next_insertion_order,
+            object_nodes: self.object_nodes.clone(),
+            source_nodes: self.source_nodes.clone(),
+            incoming_references: self.incoming_references.clone(),
+            last_mutation: self.last_mutation,
+            scene_revision: self.scene_revision,
+        }
+    }
+}
+
 impl SemanticStore {
+    pub fn geometry_resources(&self) -> &crate::GeometryResourceArena {
+        &self.geometry_resources
+    }
+
+    /// Intern immutable path content in this store's resource namespace.
+    pub fn insert_geometry_path(
+        &mut self,
+        path: crate::VectorPath,
+    ) -> crate::GeometryResourceHandle {
+        self.geometry_resources.insert_path(path)
+    }
+
     pub fn new() -> Self {
         Self::default()
     }
@@ -1139,6 +1191,44 @@ mod tests {
     use crate::GeometryRef;
 
     use super::*;
+
+    #[test]
+    fn resources_are_store_scoped_and_clones_share_only_immutable_payloads() {
+        use crate::{GeometryResource, SemanticObjectContent, StoredGeometry, VectorPath};
+        use std::sync::Arc;
+        let mut first = SemanticStore::new();
+        let mut second = SemanticStore::new();
+        let a = first.insert_geometry_path(VectorPath::new());
+        let b = second.insert_geometry_path(VectorPath::new());
+        assert_eq!((a.id, a.version), (b.id, b.version));
+        assert_ne!(a.arena, b.arena);
+        assert!(first.geometry_resources().get(b).is_none());
+        assert!(second.geometry_resources().get(a).is_none());
+        let node =
+            first.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Resource(a)));
+        // The low-level store fixture can contain invalid state; cloning must not legitimize it.
+        let foreign =
+            first.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Resource(b)));
+        let cloned = first.clone();
+        let SemanticObjectContent::Geometry(StoredGeometry::Resource(c)) =
+            cloned.semantic_object_state_checked(node).unwrap().content
+        else {
+            panic!("resource content")
+        };
+        assert_ne!(a.arena, c.arena);
+        assert!(cloned.geometry_resources().get(a).is_none());
+        let GeometryResource::VectorPath(original) = first.geometry_resources().get(a).unwrap();
+        let GeometryResource::VectorPath(copied) = cloned.geometry_resources().get(c).unwrap();
+        assert!(Arc::ptr_eq(original, copied));
+        assert_eq!(
+            cloned
+                .semantic_object_state_checked(foreign)
+                .unwrap()
+                .content,
+            SemanticObjectContent::Geometry(StoredGeometry::Resource(b))
+        );
+        assert!(cloned.geometry_resources().get(b).is_none());
+    }
 
     fn object(id: u64) -> ObjectDefinition {
         ObjectDefinition::new(ObjectId::new(id), GeometryRef::circle(1.0))

--- a/crates/noon-runtime/tests/semantic_execution_lowering.rs
+++ b/crates/noon-runtime/tests/semantic_execution_lowering.rs
@@ -1,7 +1,7 @@
 use noon_compile::{lower_semantic_execution, SemanticExecutionIndex};
 use noon_core::{
     Color, GeometryRef, SemanticObjectProperty, SemanticObjectState, SemanticPaint, SemanticScene,
-    SemanticStore, SemanticVec3, StoredGeometry, Style, Transform2D, Vec2,
+    SemanticStore, SemanticVec3, StoredGeometry, StrokeCap, StrokeJoin, Style, Transform2D, Vec2,
 };
 use noon_runtime::SceneInstance;
 
@@ -56,6 +56,8 @@ fn representative_legacy_and_semantic_authoring_lower_to_equivalent_runtime_obse
             fill: Some(Color::rgba(0.2, 0.4, 0.6, 0.25)),
             stroke: Some(Color::rgba(0.8, 0.1, 0.3, 0.5)),
             stroke_width: 3.5,
+            stroke_join: StrokeJoin::Bevel,
+            stroke_cap: StrokeCap::Square,
             opacity: 0.6,
             ..Style::default()
         };
@@ -81,6 +83,8 @@ fn representative_legacy_and_semantic_authoring_lower_to_equivalent_runtime_obse
     semantic_circle.style.stroke = Some(SemanticPaint::Solid(Color::rgba(0.8, 0.1, 0.3, 1.0)));
     semantic_circle.style.stroke_opacity = 0.5;
     semantic_circle.style.stroke_width = 3.5;
+    semantic_circle.style.stroke_join = StrokeJoin::Bevel;
+    semantic_circle.style.stroke_cap = StrokeCap::Square;
     semantic_circle.style.object_opacity = 0.6;
     let semantic_circle = semantic_store.insert_semantic_object(semantic_circle);
     semantic_store.attach_to_scene(semantic_circle).unwrap();

--- a/crates/noon-web/src/retained_resource_transport.rs
+++ b/crates/noon-web/src/retained_resource_transport.rs
@@ -22,10 +22,11 @@ use crate::TransportTextResourceHandle;
 /// shaped text, vector-decoration geometry, and exact OpenType buffers once when a
 /// retained scene is installed. Python never owns or serializes these payloads.
 pub const RETAINED_RESOURCE_TRANSPORT_CHANNEL: &str = "noon.execution.retained.resources";
-pub const RETAINED_RESOURCE_TRANSPORT_VERSION: u32 = 1;
+pub const RETAINED_RESOURCE_TRANSPORT_VERSION: u32 = 2;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct TransportGeometryResourceHandle {
+    pub arena: u64,
     pub id: u64,
     pub version: u64,
 }
@@ -33,6 +34,7 @@ pub struct TransportGeometryResourceHandle {
 impl From<GeometryResourceHandle> for TransportGeometryResourceHandle {
     fn from(value: GeometryResourceHandle) -> Self {
         Self {
+            arena: value.arena,
             id: value.id.get(),
             version: value.version,
         }

--- a/crates/noon/src/execution_session.rs
+++ b/crates/noon/src/execution_session.rs
@@ -1,9 +1,9 @@
 use crate::execution_segment::{ExecutionSegment, ExecutionSegmentError};
 use noon_compile::{
     lower_semantic_affine_animation_tracks, lower_semantic_animation_schedule,
-    lower_semantic_execution, CompilePatchError, SemanticAffineAnimationTrackError,
-    SemanticAnimationScheduleError, SemanticExecutionIndex, SemanticExecutionLoweringError,
-    SemanticReactiveProjection,
+    lower_semantic_execution, lower_semantic_execution_root, CompilePatchError,
+    SemanticAffineAnimationTrackError, SemanticAnimationScheduleError, SemanticExecutionIndex,
+    SemanticExecutionLoweringError, SemanticExecutionLoweringOutput, SemanticReactiveProjection,
 };
 use noon_core::{
     AnimationOptions, Camera2DState, MutationTransaction, NativeEventOccurrence,
@@ -180,6 +180,28 @@ impl ExecutionSession {
     ) -> Result<Self, SemanticExecutionLoweringError> {
         let mut execution_index = SemanticExecutionIndex::new();
         let lowered = lower_semantic_execution(store, &mut execution_index)?;
+        Ok(Self::from_lowered(execution_index, lowered))
+    }
+
+    /// Instantiate the existing runtime for one semantic scene family.
+    ///
+    /// Detached families are valid initial scene roots. Other families in the
+    /// shared store do not enter this execution domain. Membership remains owned
+    /// by the store; this constructor neither mutates it nor establishes a live
+    /// structural mutation contract. `root` must originate from `store`.
+    pub fn from_semantic_root(
+        store: &SemanticStore,
+        root: SemanticNodeId,
+    ) -> Result<Self, SemanticExecutionLoweringError> {
+        let mut execution_index = SemanticExecutionIndex::new();
+        let lowered = lower_semantic_execution_root(store, root, &mut execution_index)?;
+        Ok(Self::from_lowered(execution_index, lowered))
+    }
+
+    fn from_lowered(
+        execution_index: SemanticExecutionIndex,
+        lowered: SemanticExecutionLoweringOutput,
+    ) -> Self {
         let camera_object = lowered.camera_object();
         let next_activation_track_id = lowered
             .compiled()
@@ -189,14 +211,14 @@ impl ExecutionSession {
             .map_or(Some(0), |id| id.checked_add(1));
         let reactive_projection = lowered.reactive().clone();
         let runtime = SceneInstance::from_semantic_execution(lowered);
-        Ok(Self {
+        Self {
             execution_index,
             reactive_projection,
             runtime,
             camera_object,
             next_activation_track_id,
             last_native_event_sequence: None,
-        })
+        }
     }
 
     /// Current renderer-facing runtime frame.
@@ -453,6 +475,61 @@ mod tests {
         state.transform.translation = SemanticVec3::new(center.x as f64, center.y as f64, 0.0);
         state.set_role(SemanticObjectRole::Camera2D);
         state
+    }
+
+    #[test]
+    fn semantic_family_sessions_isolate_camera_objects_and_reactive_state() {
+        let mut store = SemanticStore::new();
+        let left_root = store.insert_family();
+        let right_root = store.insert_family();
+        let left_camera = store.insert_semantic_object(camera_state(Vec2::new(-2.0, 0.0), 4.0));
+        let right_camera = store.insert_semantic_object(camera_state(Vec2::new(3.0, 1.0), 6.0));
+        let shared =
+            store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+                radius: 1.0,
+            }));
+        let signal = store.insert_semantic_input_signal(0.4_f64).unwrap();
+        store
+            .bind_semantic_signal(signal, shared, SemanticObjectProperty::ObjectOpacity)
+            .unwrap();
+        for (root, camera) in [(left_root, left_camera), (right_root, right_camera)] {
+            store.add_semantic_family_member(root, camera).unwrap();
+            store.add_semantic_family_member(root, shared).unwrap();
+        }
+        let mut left = ExecutionSession::from_semantic_root(&store, left_root).unwrap();
+        let right = ExecutionSession::from_semantic_root(&store, right_root).unwrap();
+        assert_eq!(left.frame().objects.len(), 2);
+        assert_eq!(right.frame().objects.len(), 2);
+        assert_eq!(left.execution_object_id(right_camera), None);
+        assert_eq!(right.execution_object_id(left_camera), None);
+        assert_eq!(
+            left.execution_object_id(shared),
+            right.execution_object_id(shared)
+        );
+        assert_eq!(
+            left.camera().unwrap(),
+            Camera2DState {
+                center: Vec2::new(-2.0, 0.0),
+                height: 4.0
+            }
+        );
+        assert_eq!(
+            right.camera().unwrap(),
+            Camera2DState {
+                center: Vec2::new(3.0, 1.0),
+                height: 6.0
+            }
+        );
+        left.set_reactive_input(signal, 0.8_f32).unwrap();
+        assert_eq!(left.frame().objects[1].style.opacity, 0.8);
+        assert_eq!(right.frame().objects[1].style.opacity, 0.4);
+        assert_eq!(store.scene_roots().count(), 0);
+        // Existing all-roots consumers still see the store's actual attached roots.
+        assert!(ExecutionSession::from_semantic_store(&store)
+            .unwrap()
+            .frame()
+            .objects
+            .is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Shared authoring needs complete style state, safe geometry references, and isolated scene roots before frontend objects can lower directly into execution.

This change preserves stroke joins/caps through semantic lowering, adds atomic full-style transactions, rejects invalid paints and foreign/stale geometry resource handles, and gives each independent semantic store its own resource namespace. Root-scoped lowering creates an ExecutionSession from one family without copying or filtering the shared store. Canonical resource lowering resolves paths through their exact owning arena. Retained resource transport moves to version 2 for namespaced handles.

Validation: `bash scripts/check.sh full` passed in an isolated worktree at 090409ea (architecture ratchet, formatting, workspace check/clippy, all workspace tests, browser validation, optimized WASM build). Focused tests cover style no-ops/conflicts/rollback, store resource collisions and clone isolation, root isolation, and exact resource lowering. Separate review passed with no blocking findings. Broader frontend consumer migration continues separately under #959 and #61; this does not close those roadmap items.
