### PR TITLE
web: preload live Python authoring and rerun edits

### DIFF
--- a/scripts/playground-authoring-error-recovery-smoke.mjs
+++ b/scripts/playground-authoring-error-recovery-smoke.mjs
@@ -75,6 +75,7 @@ async function snapshot(page) {
     return {
       runtimeState: status?.dataset.state ?? "",
       runtimeStartup: status?.dataset.runtimeStartup ?? "",
+      liveAuthoring: status?.dataset.liveAuthoring ?? "",
       rendererBackend: status?.dataset.rendererBackend ?? "",
       executionMode: status?.dataset.executionMode ?? "",
       presentedFrames: Number(status?.dataset.presentedFrames ?? "0"),
@@ -91,33 +92,42 @@ async function snapshot(page) {
 
 async function waitForInitialScene(page) {
   await page.waitForFunction(() => window.__noonExampleGallery !== undefined);
-  const deferred = await snapshot(page);
-  assert.equal(deferred.runtimeStartup, "deferred", "authoring runtime must stay deferred on page load");
-  assert.equal(deferred.rendererBackend, "", "deferred authoring page must not initialize the renderer");
-  assert.equal(deferred.presentedFrames, 0, "deferred authoring page must not render frames");
-
-  const sourceTextarea = page.locator("#python-scene-source");
-  await sourceTextarea.focus();
   await page.waitForSelector("#scene-editor-panel .python-code-editor[data-editor-ready='true'] .cm-content", {
     timeout: 30_000,
   });
-
-  const runButton = page.locator("#replace-scene");
-  assert.equal(await runButton.isEnabled(), true, "Run must remain available after lazy editor startup");
-  await runButton.click();
   await page.waitForFunction(
     () => {
       const status = document.querySelector("#status");
       const patch = document.querySelector("#patch-status");
       return (
+        status?.dataset.liveAuthoring === "ready" &&
         status?.dataset.state === "running" &&
         status?.dataset.rendererBackend === "WebGL2" &&
+        Number(status?.dataset.presentedFrames ?? "0") > 0 &&
         patch?.dataset.state === "applied" &&
         !document.querySelector("#replace-scene")?.disabled
       );
     },
     null,
     { timeout: 60_000 },
+  );
+
+  const preloaded = await snapshot(page);
+  assert.equal(
+    preloaded.runtimeStartup,
+    "started-on-demand",
+    "live authoring preload must start the existing execution owner before an explicit Run",
+  );
+  assert.equal(preloaded.liveAuthoring, "ready", "live authoring preload must reach ready state");
+  assert.equal(preloaded.rendererBackend, "WebGL2");
+  assert.ok(preloaded.presentedFrames > 0, "preload must present the initial scene");
+
+  const editor = page.locator("#scene-editor-panel .cm-content");
+  await editor.focus();
+  assert.equal(
+    await page.locator("#replace-scene").isEnabled(),
+    true,
+    "explicit Run must remain available after preload",
   );
 }
 
@@ -138,17 +148,16 @@ async function setEditorSource(page, source) {
   );
 }
 
-async function runAndWait(page, expectedState) {
-  const button = page.locator("#replace-scene");
-  assert.equal(await button.isEnabled(), true, "Run button must be enabled before rerun");
-  await button.click();
+async function waitForAutomaticRun(page, { expectedState, expectedObjectCount = null }) {
   await page.waitForFunction(
-    (state) => {
+    ({ state, objectCount }) => {
       const patch = document.querySelector("#patch-status");
       const run = document.querySelector("#replace-scene");
-      return patch?.dataset.state === state && !run?.disabled;
+      if (patch?.dataset.state !== state || run?.disabled) return false;
+      if (objectCount === null) return true;
+      return document.querySelector("#metric-objects")?.value === String(objectCount);
     },
-    expectedState,
+    { state: expectedState, objectCount: expectedObjectCount },
     { timeout: 60_000 },
   );
   return snapshot(page);
@@ -213,6 +222,7 @@ try {
   phase = "baseline";
   diagnostics.snapshots.baseline = await snapshot(page);
   assert.equal(diagnostics.snapshots.baseline.runtimeState, "running");
+  assert.equal(diagnostics.snapshots.baseline.liveAuthoring, "ready");
   assert.equal(diagnostics.snapshots.baseline.rendererBackend, "WebGL2");
   assert.equal(diagnostics.snapshots.baseline.exampleId, "parity-create-circle");
   assert.notEqual(diagnostics.snapshots.baseline.patchSequence, "");
@@ -220,7 +230,7 @@ try {
 
   phase = "syntax-error";
   await setEditorSource(page, SOURCES.syntaxError);
-  diagnostics.snapshots.syntaxError = await runAndWait(page, "error");
+  diagnostics.snapshots.syntaxError = await waitForAutomaticRun(page, { expectedState: "error" });
   assert.match(diagnostics.snapshots.syntaxError.patchText, /Python failed:/);
   assert.equal(diagnostics.snapshots.syntaxError.runtimeState, "running");
   assert.equal(diagnostics.snapshots.syntaxError.rendererBackend, diagnostics.snapshots.baseline.rendererBackend);
@@ -238,16 +248,17 @@ try {
 
   phase = "syntax-recovery";
   await setEditorSource(page, SOURCES.twoObjects);
-  await runAndWait(page, "applied");
-  await waitForObjectCount(page, 2);
-  diagnostics.snapshots.syntaxRecovered = await snapshot(page);
+  diagnostics.snapshots.syntaxRecovered = await waitForAutomaticRun(page, {
+    expectedState: "applied",
+    expectedObjectCount: 2,
+  });
   assert.match(diagnostics.snapshots.syntaxRecovered.patchText, /2 objects/);
   assert.equal(diagnostics.snapshots.syntaxRecovered.runtimeState, "running");
   assert.equal(diagnostics.snapshots.syntaxRecovered.rendererBackend, "WebGL2");
 
   phase = "runtime-error";
   await setEditorSource(page, SOURCES.runtimeError);
-  diagnostics.snapshots.runtimeError = await runAndWait(page, "error");
+  diagnostics.snapshots.runtimeError = await waitForAutomaticRun(page, { expectedState: "error" });
   assert.match(diagnostics.snapshots.runtimeError.patchText, /Python failed:/);
   assert.equal(diagnostics.snapshots.runtimeError.runtimeState, "running");
   assert.equal(diagnostics.snapshots.runtimeError.rendererBackend, "WebGL2");
@@ -265,9 +276,10 @@ try {
 
   phase = "runtime-recovery";
   await setEditorSource(page, SOURCES.oneObject);
-  await runAndWait(page, "applied");
-  await waitForObjectCount(page, 1);
-  diagnostics.snapshots.runtimeRecovered = await snapshot(page);
+  diagnostics.snapshots.runtimeRecovered = await waitForAutomaticRun(page, {
+    expectedState: "applied",
+    expectedObjectCount: 1,
+  });
   assert.match(diagnostics.snapshots.runtimeRecovered.patchText, /1 objects/);
   assert.equal(diagnostics.snapshots.runtimeRecovered.runtimeState, "running");
   assert.equal(diagnostics.snapshots.runtimeRecovered.rendererBackend, "WebGL2");
@@ -293,7 +305,7 @@ try {
   diagnostics.serverOutput = serverOutput;
   await writeFile(path.join(artifactDir, "diagnostics.json"), `${JSON.stringify(diagnostics, null, 2)}\n`);
   console.log(
-    `playground authoring recovery ok: ${diagnostics.snapshots.baseline.objectCount} -> ` +
+    `playground live authoring recovery ok: ${diagnostics.snapshots.baseline.objectCount} -> ` +
       `${diagnostics.snapshots.syntaxRecovered.objectCount} -> ${diagnostics.snapshots.runtimeRecovered.objectCount} objects`,
   );
 } catch (error) {
@@ -301,6 +313,7 @@ try {
   diagnostics.serverOutput = serverOutput;
   if (page !== null) {
     try {
+      diagnostics.snapshots.failure = await snapshot(page);
       await page.screenshot({ path: path.join(artifactDir, "failure.png"), fullPage: true });
     } catch (screenshotError) {
       diagnostics.screenshotFailure = String(screenshotError);

--- a/scripts/playground-stress-edit-smoke.mjs
+++ b/scripts/playground-stress-edit-smoke.mjs
@@ -47,10 +47,14 @@ async function snapshot(page) {
     const scroller = document.querySelector("#scene-editor-panel .cm-scroller");
     return {
       runtimeState: status?.dataset.state ?? "",
+      runtimeStartup: status?.dataset.runtimeStartup ?? "",
+      liveAuthoring: status?.dataset.liveAuthoring ?? "",
       rendererBackend: status?.dataset.rendererBackend ?? "",
       executionMode: status?.dataset.executionMode ?? "",
+      presentedFrames: Number(status?.dataset.presentedFrames ?? "0"),
       patchState: patch?.dataset.state ?? "",
       patchText: patch?.value ?? patch?.textContent ?? "",
+      patchSequence: patch?.dataset.sequence ?? "",
       exampleId: patch?.dataset.exampleId ?? "",
       objectCount: document.querySelector("#metric-objects")?.value ?? "",
       editorHeight: pane?.getBoundingClientRect().height ?? 0,
@@ -63,26 +67,56 @@ async function snapshot(page) {
   });
 }
 
-async function runAndWait(page) {
-  const button = page.locator("#replace-scene");
-  assert.equal(await button.isEnabled(), true, "Run must be enabled before stress-scene execution");
-  await button.click();
-  await page.waitForFunction(
-    () => document.querySelector("#replace-scene")?.disabled === true,
-    null,
-    { timeout: 15_000 },
-  );
+async function waitForPreloadedScene(page) {
   await page.waitForFunction(
     () => {
+      const status = document.querySelector("#status");
       const patch = document.querySelector("#patch-status");
-      const run = document.querySelector("#replace-scene");
-      return (patch?.dataset.state === "applied" || patch?.dataset.state === "error") && !run?.disabled;
+      return (
+        status?.dataset.liveAuthoring === "ready" &&
+        status?.dataset.state === "running" &&
+        Number(status?.dataset.presentedFrames ?? "0") > 0 &&
+        patch?.dataset.state === "applied" &&
+        !document.querySelector("#replace-scene")?.disabled
+      );
     },
     null,
     { timeout: 120_000 },
   );
   const state = await snapshot(page);
-  assert.equal(state.patchState, "applied", `stress scene must run successfully: ${state.patchText}`);
+  assert.equal(
+    state.runtimeStartup,
+    "started-on-demand",
+    "stress playground must preload the existing execution owner without an explicit Run",
+  );
+  assert.equal(state.liveAuthoring, "ready");
+  assert.ok(state.presentedFrames > 0, "stress preload must present a frame");
+  assert.equal(state.patchState, "applied", `stress preload must succeed: ${state.patchText}`);
+  return state;
+}
+
+async function waitForAutomaticRun(page, previousObjectCount) {
+  await page.waitForFunction(
+    (priorObjectCount) => {
+      const patch = document.querySelector("#patch-status");
+      const run = document.querySelector("#replace-scene");
+      if (run?.disabled) return false;
+      if (patch?.dataset.state === "error") return true;
+      return (
+        patch?.dataset.state === "applied" &&
+        document.querySelector("#metric-objects")?.value !== priorObjectCount
+      );
+    },
+    previousObjectCount,
+    { timeout: 120_000 },
+  );
+  const state = await snapshot(page);
+  assert.equal(state.patchState, "applied", `stress scene must rerun successfully: ${state.patchText}`);
+  assert.notEqual(
+    state.objectCount,
+    previousObjectCount,
+    "successful structural edit must publish a different object count",
+  );
   return state;
 }
 
@@ -155,7 +189,7 @@ try {
     `focusing CodeMirror must not expand the editor pane (${diagnostics.snapshots.loaded.editorHeight} -> ${focused.editorHeight})`,
   );
 
-  diagnostics.snapshots.baseline = await runAndWait(page);
+  diagnostics.snapshots.baseline = await waitForPreloadedScene(page);
   assert.equal(diagnostics.snapshots.baseline.exampleId, "manim-parity-stress-grid");
   assert.equal(diagnostics.snapshots.baseline.executionMode, "retained");
   assert.match(diagnostics.snapshots.baseline.patchText, /Scene rebuilt atomically/);
@@ -165,12 +199,13 @@ try {
   );
   assert.match(source, /rows = 20/);
   let editedSource = source;
+  let previousObjectCount = diagnostics.snapshots.baseline.objectCount;
   for (const rows of [5, 7, 20]) {
     const nextSource = editedSource.replace(/rows = \d+/, `rows = ${rows}`);
     assert.notEqual(nextSource, editedSource);
 
-    // Use the real CodeMirror input path on every edit so identity stabilization is
-    // exercised across consecutive authoring results, not just one structural rerun.
+    // Use the real CodeMirror input path on every edit so identity stabilization and the
+    // latest-source debounce are exercised across consecutive automatic authoring results.
     await editor.click();
     await page.keyboard.press("Control+A");
     await page.keyboard.insertText(nextSource);
@@ -188,12 +223,16 @@ try {
       "editing the long source must not grow the editor pane",
     );
 
-    diagnostics.snapshots[`rows${rows}Rerun`] = await runAndWait(page);
+    diagnostics.snapshots[`rows${rows}Rerun`] = await waitForAutomaticRun(
+      page,
+      previousObjectCount,
+    );
     assert.equal(diagnostics.snapshots[`rows${rows}Rerun`].executionMode, "retained");
     assert.match(
       diagnostics.snapshots[`rows${rows}Rerun`].patchText,
       /Scene rebuilt atomically/,
     );
+    previousObjectCount = diagnostics.snapshots[`rows${rows}Rerun`].objectCount;
     editedSource = nextSource;
   }
 
@@ -208,7 +247,7 @@ try {
   await page.screenshot({ path: path.join(artifactDir, "stress-edited.png"), fullPage: true });
   await writeFile(path.join(artifactDir, "diagnostics.json"), `${JSON.stringify(diagnostics, null, 2)}\n`);
   console.log(
-    `playground repeated structural stress edits ok: ${diagnostics.snapshots.loaded.editorHeight}px editor, rows=5 -> 7 -> 20 applied`,
+    `playground live structural stress edits ok: ${diagnostics.snapshots.loaded.editorHeight}px editor, rows=5 -> 7 -> 20 applied`,
   );
 } catch (error) {
   diagnostics.failure = error instanceof Error ? error.stack ?? error.message : String(error);

--- a/web/latest-source-runner.js
+++ b/web/latest-source-runner.js
@@ -1,0 +1,153 @@
+const DEFAULT_DELAY_MS = 180;
+
+function requireFunction(value, label) {
+  if (typeof value !== "function") {
+    throw new TypeError(`${label} must be a function`);
+  }
+  return value;
+}
+
+function requireExampleId(exampleId) {
+  if (typeof exampleId !== "string" || exampleId.trim() === "") {
+    throw new TypeError("latest-source runner requires a non-empty example ID");
+  }
+  return exampleId;
+}
+
+function checkedNext(current) {
+  if (!Number.isSafeInteger(current) || current < 0 || current >= Number.MAX_SAFE_INTEGER) {
+    throw new Error("latest-source runner generation space exhausted");
+  }
+  return current + 1;
+}
+
+/// Coalesces editor-triggered full-source reruns without owning authored or execution state.
+///
+/// Noon still performs each accepted run through the existing Python authoring -> Semantic Scene
+/// -> execution reconciliation path. This helper only ensures that edits arriving while a run is
+/// in flight collapse to one rerun of the latest editor source instead of being silently absorbed
+/// by the playground's in-flight Run guard.
+export class LatestSourceRunner {
+  #run;
+  #runInFlight;
+  #currentExampleId;
+  #delayMs;
+  #setTimer;
+  #clearTimer;
+  #timer = null;
+  #requestedVersion = 0;
+  #completedVersion = 0;
+  #requestedExampleId = null;
+  #drainPromise = null;
+  #disposed = false;
+
+  constructor({
+    run,
+    runInFlight,
+    currentExampleId,
+    delayMs = DEFAULT_DELAY_MS,
+    setTimer = globalThis.setTimeout.bind(globalThis),
+    clearTimer = globalThis.clearTimeout.bind(globalThis),
+  }) {
+    this.#run = requireFunction(run, "latest-source run");
+    this.#runInFlight = requireFunction(runInFlight, "latest-source runInFlight");
+    this.#currentExampleId = requireFunction(
+      currentExampleId,
+      "latest-source currentExampleId",
+    );
+    if (!Number.isFinite(delayMs) || delayMs < 0) {
+      throw new TypeError("latest-source delay must be a non-negative finite number");
+    }
+    this.#delayMs = delayMs;
+    this.#setTimer = requireFunction(setTimer, "latest-source setTimer");
+    this.#clearTimer = requireFunction(clearTimer, "latest-source clearTimer");
+  }
+
+  get diagnostics() {
+    return Object.freeze({
+      requestedVersion: this.#requestedVersion,
+      completedVersion: this.#completedVersion,
+      requestedExampleId: this.#requestedExampleId,
+      pending: this.#completedVersion < this.#requestedVersion,
+      draining: this.#drainPromise !== null,
+      disposed: this.#disposed,
+    });
+  }
+
+  request(exampleId, { immediate = false } = {}) {
+    if (this.#disposed) return null;
+    this.#requestedVersion = checkedNext(this.#requestedVersion);
+    this.#requestedExampleId = requireExampleId(exampleId);
+    this.#cancelTimer();
+
+    if (immediate) {
+      return this.#drain();
+    }
+
+    this.#timer = this.#setTimer(() => {
+      this.#timer = null;
+      void this.#drain();
+    }, this.#delayMs);
+    return null;
+  }
+
+  flush() {
+    if (this.#disposed) return Promise.resolve();
+    this.#cancelTimer();
+    return this.#drain();
+  }
+
+  dispose() {
+    if (this.#disposed) return;
+    this.#disposed = true;
+    this.#cancelTimer();
+  }
+
+  #cancelTimer() {
+    if (this.#timer === null) return;
+    this.#clearTimer(this.#timer);
+    this.#timer = null;
+  }
+
+  #drain() {
+    if (this.#disposed) return Promise.resolve();
+    if (this.#drainPromise !== null) return this.#drainPromise;
+
+    const task = (async () => {
+      while (!this.#disposed && this.#completedVersion < this.#requestedVersion) {
+        const targetVersion = this.#requestedVersion;
+        const targetExampleId = this.#requestedExampleId;
+
+        // Selection changes have their own run path. Do not replay an edit request from the
+        // previous example against the newly selected source.
+        if (targetExampleId !== this.#currentExampleId()) {
+          this.#completedVersion = targetVersion;
+          continue;
+        }
+
+        // If an explicit/gallery Run is already active, wait for it but do not claim that it
+        // contained the edit which arrived afterward. The loop will issue one fresh run next.
+        const joinedExistingRun = Boolean(this.#runInFlight());
+        await this.#run();
+        if (joinedExistingRun) {
+          continue;
+        }
+
+        this.#completedVersion = targetVersion;
+      }
+    })();
+
+    this.#drainPromise = task;
+    void task.then(
+      () => {
+        if (this.#drainPromise === task) this.#drainPromise = null;
+      },
+      () => {
+        if (this.#drainPromise === task) this.#drainPromise = null;
+      },
+    );
+    return task;
+  }
+}
+
+export const LIVE_SOURCE_RERUN_DELAY_MS = DEFAULT_DELAY_MS;

--- a/web/latest-source-runner.test.mjs
+++ b/web/latest-source-runner.test.mjs
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { LatestSourceRunner } from "./latest-source-runner.js";
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function createRunHarness() {
+  let active = null;
+  const starts = [];
+
+  const run = () => {
+    if (active !== null) return active.promise;
+    const gate = deferred();
+    active = gate;
+    starts.push(gate);
+    return gate.promise.finally(() => {
+      if (active === gate) active = null;
+    });
+  };
+
+  return {
+    run,
+    runInFlight: () => active !== null,
+    starts,
+  };
+}
+
+async function flushMicrotasks() {
+  for (let index = 0; index < 6; index += 1) {
+    await Promise.resolve();
+  }
+}
+
+test("edits arriving during a live run collapse to one latest-source rerun", async () => {
+  const harness = createRunHarness();
+  const runner = new LatestSourceRunner({
+    run: harness.run,
+    runInFlight: harness.runInFlight,
+    currentExampleId: () => "example-a",
+    delayMs: 0,
+  });
+
+  const drain = runner.request("example-a", { immediate: true });
+  assert.equal(harness.starts.length, 1);
+
+  runner.request("example-a", { immediate: true });
+  runner.request("example-a", { immediate: true });
+  assert.equal(harness.starts.length, 1, "in-flight edits must not start parallel Python runs");
+
+  harness.starts[0].resolve();
+  await flushMicrotasks();
+  assert.equal(
+    harness.starts.length,
+    2,
+    "all edits received during the first run must collapse to one fresh rerun",
+  );
+
+  harness.starts[1].resolve();
+  await drain;
+  assert.deepEqual(runner.diagnostics, {
+    requestedVersion: 3,
+    completedVersion: 3,
+    requestedExampleId: "example-a",
+    pending: false,
+    draining: false,
+    disposed: false,
+  });
+});
+
+test("an edit that joins an older explicit Run is rerun after that Run completes", async () => {
+  const harness = createRunHarness();
+  const runner = new LatestSourceRunner({
+    run: harness.run,
+    runInFlight: harness.runInFlight,
+    currentExampleId: () => "example-a",
+    delayMs: 0,
+  });
+
+  const explicitRun = harness.run();
+  assert.equal(harness.starts.length, 1);
+
+  const drain = runner.request("example-a", { immediate: true });
+  assert.equal(
+    harness.starts.length,
+    1,
+    "the runner must join the existing Run instead of starting a concurrent authoring request",
+  );
+
+  harness.starts[0].resolve();
+  await explicitRun;
+  await flushMicrotasks();
+  assert.equal(
+    harness.starts.length,
+    2,
+    "joining an older Run must not falsely mark the newer editor source as rendered",
+  );
+
+  harness.starts[1].resolve();
+  await drain;
+  assert.equal(runner.diagnostics.completedVersion, runner.diagnostics.requestedVersion);
+});
+
+test("queued edits from a previous example are dropped after selection changes", async () => {
+  const harness = createRunHarness();
+  let currentExampleId = "example-a";
+  let timerCallback = null;
+  const runner = new LatestSourceRunner({
+    run: harness.run,
+    runInFlight: harness.runInFlight,
+    currentExampleId: () => currentExampleId,
+    delayMs: 180,
+    setTimer(callback) {
+      timerCallback = callback;
+      return 1;
+    },
+    clearTimer() {
+      timerCallback = null;
+    },
+  });
+
+  runner.request("example-a");
+  assert.equal(typeof timerCallback, "function");
+  currentExampleId = "example-b";
+  await runner.flush();
+
+  assert.equal(harness.starts.length, 0);
+  assert.equal(runner.diagnostics.pending, false);
+});
+
+test("dispose cancels a pending debounce without creating execution work", () => {
+  const harness = createRunHarness();
+  let cleared = false;
+  const runner = new LatestSourceRunner({
+    run: harness.run,
+    runInFlight: harness.runInFlight,
+    currentExampleId: () => "example-a",
+    setTimer() {
+      return 7;
+    },
+    clearTimer(timer) {
+      assert.equal(timer, 7);
+      cleared = true;
+    },
+  });
+
+  runner.request("example-a");
+  runner.dispose();
+
+  assert.equal(cleared, true);
+  assert.equal(runner.diagnostics.disposed, true);
+  assert.equal(harness.starts.length, 0);
+});

--- a/web/live-authoring-bootstrap.js
+++ b/web/live-authoring-bootstrap.js
@@ -1,0 +1,96 @@
+import { LatestSourceRunner } from "./latest-source-runner.js";
+
+const API_POLL_MS = 16;
+const API_WAIT_TIMEOUT_MS = 15_000;
+
+const editor = document.querySelector("#python-scene-source");
+const status = document.querySelector("#status");
+
+if (!(editor instanceof HTMLTextAreaElement) || !(status instanceof HTMLOutputElement)) {
+  throw new Error("Noon live authoring requires the playground editor and status surfaces");
+}
+
+void startLiveAuthoring();
+
+async function startLiveAuthoring() {
+  let runner = null;
+  let disposed = false;
+
+  try {
+    const gallery = await waitForGalleryApi();
+    runner = new LatestSourceRunner({
+      run: () => gallery.run(),
+      runInFlight: () => gallery.runInFlight,
+      currentExampleId: () => gallery.selectedExampleId,
+    });
+
+    const requestLatestSource = ({ immediate = false } = {}) => {
+      const exampleId = gallery.selectedExampleId;
+      if (typeof exampleId !== "string" || exampleId === "") return null;
+      return runner.request(exampleId, { immediate });
+    };
+
+    const onInput = () => {
+      requestLatestSource();
+    };
+    editor.addEventListener("input", onInput);
+
+    window.addEventListener(
+      "pagehide",
+      () => {
+        disposed = true;
+        editor.removeEventListener("input", onInput);
+        runner?.dispose();
+        runner = null;
+      },
+      { once: true },
+    );
+
+    // Cross a real paint boundary after the loaded source/gallery is ready, then immediately
+    // warm the persistent Pyodide + execution session. One rAF is not enough here because its
+    // promise continuation can still run before that frame is presented; the second rAF proves
+    // the browser had a rendering opportunity between callbacks.
+    status.dataset.liveAuthoring = "preloading";
+    await afterInitialPaint();
+    if (disposed) return;
+    await requestLatestSource({ immediate: true });
+    if (!disposed) {
+      status.dataset.liveAuthoring =
+        status.dataset.authoringWarmup === "failed" ? "error" : "ready";
+    }
+  } catch (error) {
+    if (!disposed) {
+      status.dataset.liveAuthoring = "error";
+      console.warn("Noon live authoring preload failed", error);
+    }
+    runner?.dispose();
+  }
+}
+
+async function waitForGalleryApi() {
+  const startedAt = performance.now();
+  while (performance.now() - startedAt < API_WAIT_TIMEOUT_MS) {
+    const gallery = window.__noonExampleGallery;
+    if (
+      gallery &&
+      typeof gallery.run === "function" &&
+      typeof gallery.selectedExampleId === "string"
+    ) {
+      return gallery;
+    }
+    await delay(API_POLL_MS);
+  }
+  throw new Error("Noon playground API did not become ready for live authoring");
+}
+
+function delay(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function afterInitialPaint() {
+  return new Promise((resolve) => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => resolve());
+    });
+  });
+}

--- a/web/live-authoring-bootstrap.test.mjs
+++ b/web/live-authoring-bootstrap.test.mjs
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const bootstrap = await readFile(new URL("./live-authoring-bootstrap.js", import.meta.url), "utf8");
+const editorBootstrap = await readFile(new URL("./python-editor-bootstrap.js", import.meta.url), "utf8");
+const runner = await readFile(new URL("./latest-source-runner.js", import.meta.url), "utf8");
+
+assert.match(
+  editorBootstrap,
+  /import\("\.\/live-authoring-bootstrap\.js"\)/,
+  "playground bootstrap must start live-authoring preload without waiting for explicit Run",
+);
+assert.match(
+  bootstrap,
+  /await waitForGalleryApi\(\);/,
+  "live authoring must reuse the initialized playground API instead of constructing a parallel client",
+);
+assert.match(
+  bootstrap,
+  /run: \(\) => gallery\.run\(\)/,
+  "live edits must use the existing full-source Run path",
+);
+assert.match(
+  bootstrap,
+  /runInFlight: \(\) => gallery\.runInFlight/,
+  "live edits must observe the existing in-flight Run boundary",
+);
+assert.match(
+  bootstrap,
+  /currentExampleId: \(\) => gallery\.selectedExampleId/,
+  "live edits must stay pinned to the currently selected example",
+);
+assert.match(
+  bootstrap,
+  /editor\.addEventListener\("input", onInput\)/,
+  "editor input must schedule a debounced full-source rerun",
+);
+assert.match(
+  bootstrap,
+  /await afterInitialPaint\(\);[\s\S]*requestLatestSource\(\{ immediate: true \}\)/,
+  "initial preload must cross the explicit paint boundary before warming Python/runtime",
+);
+assert.match(
+  bootstrap,
+  /function afterInitialPaint\(\)[\s\S]*requestAnimationFrame\(\(\) => \{[\s\S]*requestAnimationFrame\(\(\) => resolve\(\)\)/,
+  "paint boundary helper must span two animation frames so one presentation opportunity occurs before preload",
+);
+assert.match(
+  bootstrap,
+  /status\.dataset\.liveAuthoring = "preloading"/,
+  "browser diagnostics must expose live-authoring preload state",
+);
+assert.doesNotMatch(
+  bootstrap,
+  /new PythonAuthoringClient|new AuthoringExecutionClient|new Worker/,
+  "live authoring must not introduce another Python client, execution owner, or worker topology",
+);
+
+assert.match(
+  runner,
+  /const joinedExistingRun = Boolean\(this\.#runInFlight\(\)\);[\s\S]*await this\.#run\(\);[\s\S]*if \(joinedExistingRun\) \{\s*continue;/,
+  "an edit that arrives during an older Run must issue a fresh rerun after that Run completes",
+);
+assert.match(
+  runner,
+  /targetExampleId !== this\.#currentExampleId\(\)/,
+  "queued edits must not leak across example selection changes",
+);
+assert.doesNotMatch(
+  runner,
+  /PythonAuthoringClient|AuthoringExecutionClient|ExecutionWorkerClient|SemanticMutation|SceneRevision|ExecutionRevision|FrameEpoch/,
+  "editor request coalescing must remain outside engine semantic/publication authority",
+);
+
+console.log("✓ live authoring preloads one existing session after paint and coalesces edits onto full-source Run");

--- a/web/playground-startup.test.mjs
+++ b/web/playground-startup.test.mjs
@@ -21,12 +21,12 @@ const runtimeReadyBody = main.slice(runtimeReadyStart, executionReadyStart);
 assert.match(
   createRuntimeBody,
   /new AuthoringExecutionClient\(canvas,/,
-  "first Run must create the GPU execution owner on demand",
+  "first authored Run must create the GPU execution owner on demand",
 );
 assert.match(
   preparationBody,
   /const ready = candidate\.prepare\(\);/,
-  "first Run must prepare the mode-free render owner before engine selection",
+  "first authored Run must prepare the mode-free render owner before engine selection",
 );
 assert.doesNotMatch(
   preparationBody,
@@ -116,7 +116,7 @@ const reconcileCall = runSceneBody.indexOf("await player.reconcileScene(sceneJso
 assert.ok(authoringCall >= 0, "Run must author the selected Python source");
 assert.ok(
   preparationCall >= 0 && preparationCall < authoringCall,
-  "cold Run must kick render/WASM preparation before awaiting Python authoring",
+  "cold authored Run must kick render/WASM preparation before awaiting Python authoring",
 );
 assert.ok(
   ensureRuntimeCall > authoringCall,
@@ -150,27 +150,27 @@ const bootBody = main.slice(bootStart, bootCatch);
 assert.doesNotMatch(
   bootBody,
   /ensureAuthoringClient\(|ensureRuntimePreparation\(|new AuthoringExecutionClient\(|\.start\(.*objects.*tracks/,
-  "initial page boot must not create Python or GPU runtime resources",
+  "initial main boot must not synchronously create Python or GPU runtime resources before the post-paint preload",
 );
 assert.doesNotMatch(
   bootBody,
   /scheduleStartupAutoplay|(?:await|void) runScene\(\)/,
-  "initial page boot must not autoplay a Python scene",
+  "initial main boot must not directly autoplay a Python scene before the post-paint preload",
 );
 assert.match(
   bootBody,
   /await selectExample\(initialExample, \{ run: false \}\);/,
-  "initial page boot must load only the selected source",
+  "initial main boot must load the selected source before preload begins",
 );
 assert.match(
   bootBody,
   /status\.dataset\.runtimeStartup = "deferred"/,
-  "initial page boot must expose deferred runtime state",
+  "initial main boot must expose deferred runtime state until the post-paint preload starts",
 );
 assert.match(
   bootBody,
   /window\.__noonExampleGallery =/,
-  "gallery API must become available without waiting for Pyodide or GPU startup",
+  "gallery API must become available without synchronously waiting for Pyodide or GPU startup",
 );
 
 assert.doesNotMatch(
@@ -260,5 +260,5 @@ assert.match(
 );
 
 console.log(
-  "✓ playground defers page-load work, overlaps first-Run Python/render preparation, and selects the authored engine only after authoring",
+  "✓ playground paints source first, post-paint preload reuses the existing authored Run path, and Python/render preparation remains overlapped",
 );

--- a/web/python-editor-bootstrap.js
+++ b/web/python-editor-bootstrap.js
@@ -1,6 +1,12 @@
-// Start the presentation-only editor enhancement as soon as the playground DOM is ready.
-// The Python authoring/runtime clients remain independent and still start only on Run.
+// Start presentation-only editor enhancement as soon as the playground DOM is ready.
 // Ruff's WASM linter remains lazy until the first real editor input.
 void import("./python-editor.js").catch((error) => {
   console.warn("Optional Python editor unavailable; using textarea fallback", error);
+});
+
+// Warm one persistent full-source authoring/execution session after the initial source/gallery
+// paint, then coalesce editor changes onto the existing Run path. This is browser UX plumbing;
+// semantic identity, scheduling and reconciliation remain owned by the existing engine path.
+void import("./live-authoring-bootstrap.js").catch((error) => {
+  console.warn("Live Python authoring unavailable; explicit Run remains available", error);
 });


### PR DESCRIPTION
## Summary

- preload the existing playground authoring + execution session after the initial source/gallery **has a real paint opportunity** instead of waiting for an explicit Run
- keep Pyodide and the existing execution owner resident, then debounce editor changes into full-source Python reruns (Option A)
- coalesce edits that arrive while a Run is in flight so only the newest source receives the follow-up rerun
- drop queued editor work when example selection changes
- reuse `window.__noonExampleGallery.run()` end to end; no second Python client, Semantic Scene, scheduler, runtime, or worker topology is introduced

## Architecture boundary

This is deliberately **warm full-source rerun**, not Phase C4 local hot reload. Every accepted edit still follows the existing Python facade -> canonical Semantic Scene -> existing execution reconciliation path. The PR does not change semantic transaction, revision/publication, callback, resource, `play()`/`wait()`, or renderer ownership contracts, so #1086/#1087/#958/#61/#969 can continue independently.

True stable-source-identity diffing into local `SemanticMutationTransaction`s remains later C4/#64 work if measurement shows it is necessary.

## Startup policy

#642 has been revised to make prewarming the baseline interactive behavior. `main.js` still finishes the initial source/gallery boot without synchronously creating Python/GPU resources; the separate live-authoring bootstrap waits for the gallery API and crosses two animation frames before starting the existing authored Run path. This keeps initial source visibility ahead of heavy Pyodide/runtime startup without inventing another execution mode.

## Live edit behavior

- editor input uses a 180 ms debounce
- edits during an active run collapse to one fresh rerun of the newest source
- an edit that arrives while an older explicit Run is active is not falsely treated as rendered by that older Run
- selection changes discard queued work for the previous example
- syntax/runtime authoring failures keep the last good rendered scene and later edits recover through the same resident session

## Validation

- focused `LatestSourceRunner` unit tests cover edit coalescing, edits during an older explicit Run, selection changes, and teardown
- startup/source ratchets prove preload reuses the existing gallery Run path, introduces no second authoring/execution owner, and crosses a real paint boundary
- dedicated Playwright recovery and stress-edit smokes validate **automatic** preload/rerun behavior instead of the old manual-Run policy
- recovery CI exposed two obsolete smoke assumptions, not product failures: transient `running` state could be missed between Playwright polls, and atomic full-scene rebuilds may republish with patch sequence `0`; final smokes wait on stable applied/error state plus the requested scene result instead
- exact-head syntax/runtime error recovery is green, including preserving the last good scene and automatically recovering to later valid source
- exact-head stress-grid live edits are green for `rows=20 -> 5 -> 7 -> 20`
- mixed retained-family rerun and Group-fade rerun recovery are green
- branch is squash-restacked onto current `master`: **1 ahead / 0 behind**, one commit; exact head `98c8cefb587a78db505fb602fbc91b15599356bd`
- exact-head PR Fast Gate, Architecture Ratchets, Layer Dependency Ratchet, and Playground authoring recovery are all green

Refs #642 #955 #61 #953