### PR TITLE
Add transaction-local semantic references for atomic creation

### DIFF
--- a/crates/noon-compile/src/semantic_lowering/publication.rs
+++ b/crates/noon-compile/src/semantic_lowering/publication.rs
@@ -52,6 +52,7 @@ fn validate_mutations(
                 | SemanticMutation::ReplaceStyle { .. }
                 | SemanticMutation::AddNode { .. }
                 | SemanticMutation::AddAnimation { .. }
+                | SemanticMutation::AddTransformAnimation { .. }
         ) {
             return Err(SemanticPublicationLoweringError::UnsupportedMutation { index: position });
         }
@@ -77,7 +78,10 @@ pub fn lower_semantic_publication(
             SemanticMutation::SetProperty {
                 object, property, ..
             } => {
-                let flags = domains.entry(*object).or_default();
+                let Some(object) = object.existing() else {
+                    continue;
+                };
+                let flags = domains.entry(object).or_default();
                 match property {
                     SemanticObjectProperty::Translation
                     | SemanticObjectProperty::Scale
@@ -86,9 +90,13 @@ pub fn lower_semantic_publication(
                 }
             }
             SemanticMutation::ReplaceStyle { object, .. } => {
-                domains.entry(*object).or_default().1 = true
+                if let Some(object) = object.existing() {
+                    domains.entry(object).or_default().1 = true;
+                }
             }
-            SemanticMutation::AddNode { .. } | SemanticMutation::AddAnimation { .. } => {}
+            SemanticMutation::AddNode { .. }
+            | SemanticMutation::AddAnimation { .. }
+            | SemanticMutation::AddTransformAnimation { .. } => {}
             _ => unreachable!("supported vocabulary checked above"),
         }
     }

--- a/crates/noon-core/src/reactive/semantic_transaction.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction.rs
@@ -692,24 +692,22 @@ impl SemanticMutationTransaction {
                         );
                     }
                 }
-                if let Some(anchor) = before {
-                    if let SemanticTransactionNodeRef::Existing(anchor) = anchor {
-                        if removed_nodes.contains(anchor) {
-                            let SemanticTransactionNodeRef::Existing(family) = family else {
-                                return Err(SemanticMutationTransactionError::PendingFamilyOrderUsesRemovedNode {
+                if let Some(SemanticTransactionNodeRef::Existing(anchor)) = before {
+                    if removed_nodes.contains(anchor) {
+                        let SemanticTransactionNodeRef::Existing(family) = family else {
+                            return Err(SemanticMutationTransactionError::PendingFamilyOrderUsesRemovedNode {
                                 index,
                                 family: *family,
                                 node: (*anchor).into(),
                             });
-                            };
-                            return Err(
-                                SemanticMutationTransactionError::FamilyOrderUsesRemovedNode {
-                                    index,
-                                    family: *family,
-                                    node: *anchor,
-                                },
-                            );
-                        }
+                        };
+                        return Err(
+                            SemanticMutationTransactionError::FamilyOrderUsesRemovedNode {
+                                index,
+                                family: *family,
+                                node: *anchor,
+                            },
+                        );
                     }
                 }
             }

--- a/crates/noon-core/src/reactive/semantic_transaction.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction.rs
@@ -1,18 +1,21 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use super::semantic_store::SemanticRemoveNodeEffect;
 use super::{
-    SemanticAnimationState, SemanticNodeId, SemanticNodeKind, SemanticObjectContent,
-    SemanticObjectProperty, SemanticObjectState, SemanticSceneOperationError,
-    SemanticSignalBinding, SemanticSignalError, SemanticSignalSource, SemanticSignalValue,
-    SemanticSignalValueKind, SemanticStore, SemanticStoreError, SemanticStyle, StoredGeometry,
+    AnimationOptions, SemanticAnimationIntent, SemanticAnimationState, SemanticNodeId,
+    SemanticNodeKind, SemanticObjectContent, SemanticObjectProperty, SemanticObjectState,
+    SemanticSceneOperationError, SemanticSignalBinding, SemanticSignalError, SemanticSignalSource,
+    SemanticSignalValue, SemanticSignalValueKind, SemanticStore, SemanticStoreError, SemanticStyle,
+    StoredGeometry,
 };
 
 mod prepared;
-pub use prepared::PreparedSemanticMutationTransaction;
+pub use prepared::{PreparedSemanticMutationTransaction, SemanticTransactionReadError};
 
 mod animation_addition;
-use animation_addition::{commit_add_animation, preflight_add_animation};
+use animation_addition::{
+    commit_add_animation, preflight_add_animation, preflight_animation_options,
+};
 
 mod family_edges;
 use family_edges::FamilyEdgePreflight;
@@ -20,6 +23,17 @@ use family_edges::FamilyEdgePreflight;
 mod node_addition;
 pub use node_addition::SemanticNodeCreation;
 use node_addition::{commit_add_node, preflight_add_node};
+
+mod provisional;
+use provisional::{
+    conflicting_style_error, duplicate_mutation_error, invalid_style_error,
+    non_finite_property_error, property_type_error, replace_object_binding,
+    subscription_type_error,
+};
+use provisional::{next_transaction_id, TransactionNodeCatalog};
+pub use provisional::{
+    SemanticLocalNodeToken, SemanticPendingNodeKind, SemanticTransactionNodeRef,
+};
 
 /// One mutation in the authoritative Semantic Scene transaction vocabulary.
 ///
@@ -36,51 +50,94 @@ pub enum SemanticMutation {
         value: SemanticSignalValue,
     },
     SetProperty {
-        object: SemanticNodeId,
+        object: SemanticTransactionNodeRef,
         property: SemanticObjectProperty,
         value: SemanticSignalValue,
     },
     ReplaceContent {
-        object: SemanticNodeId,
+        object: SemanticTransactionNodeRef,
         content: SemanticObjectContent,
     },
     ReplaceStyle {
-        object: SemanticNodeId,
+        object: SemanticTransactionNodeRef,
         style: SemanticStyle,
     },
     ChangeSubscription {
-        object: SemanticNodeId,
+        object: SemanticTransactionNodeRef,
         property: SemanticObjectProperty,
         signal: Option<SemanticNodeId>,
     },
     AddMember {
-        family: SemanticNodeId,
-        member: SemanticNodeId,
+        family: SemanticTransactionNodeRef,
+        member: SemanticTransactionNodeRef,
     },
     RemoveMember {
-        family: SemanticNodeId,
-        member: SemanticNodeId,
+        family: SemanticTransactionNodeRef,
+        member: SemanticTransactionNodeRef,
     },
     ReorderMember {
-        family: SemanticNodeId,
-        member: SemanticNodeId,
-        before: Option<SemanticNodeId>,
+        family: SemanticTransactionNodeRef,
+        member: SemanticTransactionNodeRef,
+        before: Option<SemanticTransactionNodeRef>,
     },
     AddNode {
+        token: SemanticLocalNodeToken,
         creation: SemanticNodeCreation,
     },
     AddAnimation {
         state: SemanticAnimationState,
     },
+    AddTransformAnimation {
+        target: SemanticTransactionNodeRef,
+        target_state: SemanticTransactionNodeRef,
+        options: AnimationOptions,
+    },
     RemoveAnimation {
         animation: SemanticNodeId,
     },
     RemoveNode {
-        node: SemanticNodeId,
+        node: SemanticTransactionNodeRef,
     },
 }
 
 impl SemanticMutation {
+    fn node_references(&self) -> Vec<SemanticTransactionNodeRef> {
+        match self {
+            Self::SetProperty { object, .. }
+            | Self::ReplaceContent { object, .. }
+            | Self::ReplaceStyle { object, .. }
+            | Self::ChangeSubscription { object, .. } => vec![*object],
+            Self::AddMember { family, member } | Self::RemoveMember { family, member } => {
+                vec![*family, *member]
+            }
+            Self::ReorderMember {
+                family,
+                member,
+                before,
+            } => {
+                let mut references = vec![*family, *member];
+                references.extend(*before);
+                references
+            }
+            Self::RemoveNode { node } => vec![*node],
+            Self::AddTransformAnimation {
+                target,
+                target_state,
+                ..
+            } => vec![*target, *target_state],
+            Self::SetSignal { .. }
+            | Self::AddNode { .. }
+            | Self::AddAnimation { .. }
+            | Self::RemoveAnimation { .. } => Vec::new(),
+        }
+    }
+
+    fn references_any_pending(&self, removed: &HashSet<SemanticLocalNodeToken>) -> bool {
+        self.node_references().into_iter().any(
+            |node| matches!(node, SemanticTransactionNodeRef::Pending(token) if removed.contains(&token)),
+        ) || matches!(self, Self::AddNode { token, .. } if removed.contains(token))
+    }
+
     /// Existing semantic identity directly targeted by this mutation.
     ///
     /// Allocation mutations do not have an identity until commit and therefore
@@ -92,13 +149,15 @@ impl SemanticMutation {
             Self::SetProperty { object, .. }
             | Self::ReplaceContent { object, .. }
             | Self::ReplaceStyle { object, .. }
-            | Self::ChangeSubscription { object, .. } => Some(*object),
+            | Self::ChangeSubscription { object, .. } => object.existing(),
             Self::AddMember { family, .. }
             | Self::RemoveMember { family, .. }
-            | Self::ReorderMember { family, .. } => Some(*family),
-            Self::AddNode { .. } | Self::AddAnimation { .. } => None,
+            | Self::ReorderMember { family, .. } => family.existing(),
+            Self::AddNode { .. }
+            | Self::AddAnimation { .. }
+            | Self::AddTransformAnimation { .. } => None,
             Self::RemoveAnimation { animation } => Some(*animation),
-            Self::RemoveNode { node } => Some(*node),
+            Self::RemoveNode { node } => node.existing(),
         }
     }
 
@@ -131,37 +190,39 @@ impl SemanticMutation {
                 family: *family,
                 member: *member,
             }),
-            Self::AddNode { .. } | Self::AddAnimation { .. } => None,
-            Self::RemoveAnimation { animation } => {
-                Some(SemanticMutationKey::NodeRemoval(*animation))
-            }
+            Self::AddNode { .. }
+            | Self::AddAnimation { .. }
+            | Self::AddTransformAnimation { .. } => None,
+            Self::RemoveAnimation { animation } => Some(SemanticMutationKey::NodeRemoval(
+                SemanticTransactionNodeRef::Existing(*animation),
+            )),
             Self::RemoveNode { node } => Some(SemanticMutationKey::NodeRemoval(*node)),
         }
     }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-enum SemanticMutationKey {
+pub(super) enum SemanticMutationKey {
     Signal(SemanticNodeId),
     ObjectProperty {
-        object: SemanticNodeId,
+        object: SemanticTransactionNodeRef,
         property: SemanticObjectProperty,
     },
-    ObjectContent(SemanticNodeId),
-    ObjectStyle(SemanticNodeId),
+    ObjectContent(SemanticTransactionNodeRef),
+    ObjectStyle(SemanticTransactionNodeRef),
     Subscription {
-        object: SemanticNodeId,
+        object: SemanticTransactionNodeRef,
         property: SemanticObjectProperty,
     },
     FamilyEdge {
-        family: SemanticNodeId,
-        member: SemanticNodeId,
+        family: SemanticTransactionNodeRef,
+        member: SemanticTransactionNodeRef,
     },
     FamilyOrder {
-        family: SemanticNodeId,
-        member: SemanticNodeId,
+        family: SemanticTransactionNodeRef,
+        member: SemanticTransactionNodeRef,
     },
-    NodeRemoval(SemanticNodeId),
+    NodeRemoval(SemanticTransactionNodeRef),
 }
 
 /// Locality classification emitted by committed semantic mutations.
@@ -213,9 +274,32 @@ pub enum SemanticMutationImpact {
     },
 }
 
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct SemanticMutationTransaction {
+    id: u32,
+    next_token: u32,
     mutations: Vec<SemanticMutation>,
+}
+
+pub(super) struct SemanticTransactionPreflight {
+    changed: Vec<bool>,
+    staged_objects: HashMap<SemanticTransactionNodeRef, SemanticObjectState>,
+    staged_object_order: Vec<SemanticTransactionNodeRef>,
+    family_edges: FamilyEdgePreflight,
+    pending_creations: HashMap<SemanticLocalNodeToken, SemanticNodeCreation>,
+    removed_existing: HashSet<SemanticNodeId>,
+    removed_pending: HashSet<SemanticLocalNodeToken>,
+}
+
+impl Default for SemanticMutationTransaction {
+    fn default() -> Self {
+        let id = next_transaction_id();
+        Self {
+            id,
+            next_token: 0,
+            mutations: Vec::new(),
+        }
+    }
 }
 
 impl SemanticMutationTransaction {
@@ -239,12 +323,12 @@ impl SemanticMutationTransaction {
     /// vocabulary as signal values.
     pub fn set_property(
         &mut self,
-        object: SemanticNodeId,
+        object: impl Into<SemanticTransactionNodeRef>,
         property: SemanticObjectProperty,
         value: impl Into<SemanticSignalValue>,
     ) -> &mut Self {
         self.mutations.push(SemanticMutation::SetProperty {
-            object,
+            object: object.into(),
             property,
             value: value.into(),
         });
@@ -254,11 +338,11 @@ impl SemanticMutationTransaction {
     /// Replace only the authored content reference/value of one semantic object.
     pub fn replace_content(
         &mut self,
-        object: SemanticNodeId,
+        object: impl Into<SemanticTransactionNodeRef>,
         content: impl Into<SemanticObjectContent>,
     ) -> &mut Self {
         self.mutations.push(SemanticMutation::ReplaceContent {
-            object,
+            object: object.into(),
             content: content.into(),
         });
         self
@@ -269,21 +353,27 @@ impl SemanticMutationTransaction {
     /// This carries paints and discrete stroke topology through the same atomic
     /// mutation vocabulary as scalar style properties. A transaction cannot mix
     /// full-style replacement with scalar style writes for the same object.
-    pub fn replace_style(&mut self, object: SemanticNodeId, style: SemanticStyle) -> &mut Self {
-        self.mutations
-            .push(SemanticMutation::ReplaceStyle { object, style });
+    pub fn replace_style(
+        &mut self,
+        object: impl Into<SemanticTransactionNodeRef>,
+        style: SemanticStyle,
+    ) -> &mut Self {
+        self.mutations.push(SemanticMutation::ReplaceStyle {
+            object: object.into(),
+            style,
+        });
         self
     }
 
     /// Change the authored signal driver for one object property.
     pub fn change_subscription(
         &mut self,
-        object: SemanticNodeId,
+        object: impl Into<SemanticTransactionNodeRef>,
         property: SemanticObjectProperty,
         signal: Option<SemanticNodeId>,
     ) -> &mut Self {
         self.mutations.push(SemanticMutation::ChangeSubscription {
-            object,
+            object: object.into(),
             property,
             signal,
         });
@@ -291,16 +381,28 @@ impl SemanticMutationTransaction {
     }
 
     /// Add one direct ordered family edge through the authoritative transaction.
-    pub fn add_member(&mut self, family: SemanticNodeId, member: SemanticNodeId) -> &mut Self {
-        self.mutations
-            .push(SemanticMutation::AddMember { family, member });
+    pub fn add_member(
+        &mut self,
+        family: impl Into<SemanticTransactionNodeRef>,
+        member: impl Into<SemanticTransactionNodeRef>,
+    ) -> &mut Self {
+        self.mutations.push(SemanticMutation::AddMember {
+            family: family.into(),
+            member: member.into(),
+        });
         self
     }
 
     /// Remove one direct ordered family edge through the authoritative transaction.
-    pub fn remove_member(&mut self, family: SemanticNodeId, member: SemanticNodeId) -> &mut Self {
-        self.mutations
-            .push(SemanticMutation::RemoveMember { family, member });
+    pub fn remove_member(
+        &mut self,
+        family: impl Into<SemanticTransactionNodeRef>,
+        member: impl Into<SemanticTransactionNodeRef>,
+    ) -> &mut Self {
+        self.mutations.push(SemanticMutation::RemoveMember {
+            family: family.into(),
+            member: member.into(),
+        });
         self
     }
 
@@ -310,13 +412,23 @@ impl SemanticMutationTransaction {
     /// only the family's authoritative order is mutated.
     pub fn reorder_member(
         &mut self,
-        family: SemanticNodeId,
-        member: SemanticNodeId,
+        family: impl Into<SemanticTransactionNodeRef>,
+        member: impl Into<SemanticTransactionNodeRef>,
         before: Option<SemanticNodeId>,
     ) -> &mut Self {
+        self.reorder_member_ref(family, member, before.map(Into::into))
+    }
+
+    /// Move a direct family member using existing or transaction-local identities.
+    pub fn reorder_member_ref(
+        &mut self,
+        family: impl Into<SemanticTransactionNodeRef>,
+        member: impl Into<SemanticTransactionNodeRef>,
+        before: Option<SemanticTransactionNodeRef>,
+    ) -> &mut Self {
         self.mutations.push(SemanticMutation::ReorderMember {
-            family,
-            member,
+            family: family.into(),
+            member: member.into(),
             before,
         });
         self
@@ -332,8 +444,21 @@ impl SemanticMutationTransaction {
     /// replacement to transfer one stable source key from an old node to its new
     /// identity without creating a second identity model.
     pub fn add_node(&mut self, creation: SemanticNodeCreation) -> &mut Self {
-        self.mutations.push(SemanticMutation::AddNode { creation });
+        self.create_node(creation);
         self
+    }
+
+    /// Stage a node allocation and return its transaction-local reference token.
+    pub fn create_node(&mut self, creation: SemanticNodeCreation) -> SemanticLocalNodeToken {
+        let ordinal = self.next_token;
+        self.next_token = self
+            .next_token
+            .checked_add(1)
+            .expect("Noon semantic transaction local-node space exhausted");
+        let token = SemanticLocalNodeToken::new(self.id, ordinal);
+        self.mutations
+            .push(SemanticMutation::AddNode { token, creation });
+        token
     }
 
     /// Add one authored animation declaration after complete transaction preflight.
@@ -344,6 +469,22 @@ impl SemanticMutationTransaction {
     pub fn add_animation(&mut self, state: SemanticAnimationState) -> &mut Self {
         self.mutations
             .push(SemanticMutation::AddAnimation { state });
+        self
+    }
+
+    /// Add a transform declaration that may reference objects staged in this batch.
+    pub fn add_transform_animation(
+        &mut self,
+        target: impl Into<SemanticTransactionNodeRef>,
+        target_state: impl Into<SemanticTransactionNodeRef>,
+        options: AnimationOptions,
+    ) -> &mut Self {
+        self.mutations
+            .push(SemanticMutation::AddTransformAnimation {
+                target: target.into(),
+                target_state: target_state.into(),
+                options,
+            });
         self
     }
 
@@ -368,9 +509,12 @@ impl SemanticMutationTransaction {
     /// Structural removals are terminal within a transaction: once the first
     /// structural removal is authored, no later non-removal mutation is accepted.
     /// This keeps complete preflight valid through commit without staging a second
-    /// scene.
-    pub fn remove_node(&mut self, node: SemanticNodeId) -> &mut Self {
-        self.mutations.push(SemanticMutation::RemoveNode { node });
+    /// scene. Removing a pending node cancels its allocation and any staged edge or
+    /// animation declaration that references it; those mutations are still fully
+    /// preflighted so cancellation cannot hide an invalid family, kind, or value.
+    pub fn remove_node(&mut self, node: impl Into<SemanticTransactionNodeRef>) -> &mut Self {
+        self.mutations
+            .push(SemanticMutation::RemoveNode { node: node.into() });
         self
     }
 
@@ -404,8 +548,10 @@ impl SemanticMutationTransaction {
     fn preflight(
         &self,
         store: &SemanticStore,
-    ) -> Result<Vec<bool>, SemanticMutationTransactionError> {
+    ) -> Result<SemanticTransactionPreflight, SemanticMutationTransactionError> {
+        let catalog = TransactionNodeCatalog::new(self, store);
         let mut removed_nodes = HashSet::new();
+        let mut removed_pending = HashSet::new();
         let mut removal_started = false;
         for (index, mutation) in self.mutations.iter().enumerate() {
             match mutation {
@@ -425,9 +571,18 @@ impl SemanticMutationTransaction {
                     removal_started = true;
                     removed_nodes.insert(*animation);
                 }
-                SemanticMutation::RemoveNode { node } => {
+                SemanticMutation::RemoveNode {
+                    node: SemanticTransactionNodeRef::Existing(node),
+                } => {
                     removal_started = true;
                     removed_nodes.insert(*node);
+                }
+                SemanticMutation::RemoveNode {
+                    node: SemanticTransactionNodeRef::Pending(token),
+                } => {
+                    catalog.validate_pending((*token).into(), index)?;
+                    removal_started = true;
+                    removed_pending.insert(*token);
                 }
                 _ if removal_started => {
                     return Err(SemanticMutationTransactionError::MutationAfterRemove { index });
@@ -436,6 +591,7 @@ impl SemanticMutationTransaction {
             }
         }
         let removed_nodes = store.semantic_removal_closure(&removed_nodes);
+        let pending_creations = catalog.cloned_creations();
 
         let mut targets = HashSet::with_capacity(self.mutations.len());
         let mut style_replacements = HashSet::new();
@@ -443,8 +599,13 @@ impl SemanticMutationTransaction {
         let mut changed = Vec::with_capacity(self.mutations.len());
         let mut family_edges = FamilyEdgePreflight::default();
         let mut pending_sources = HashSet::new();
+        let mut staged_objects = HashMap::new();
+        let mut staged_object_order = Vec::new();
 
         for (index, mutation) in self.mutations.iter().enumerate() {
+            for node in mutation.node_references() {
+                catalog.validate_pending(node, index)?;
+            }
             if !matches!(
                 mutation,
                 SemanticMutation::RemoveAnimation { .. } | SemanticMutation::RemoveNode { .. }
@@ -465,27 +626,46 @@ impl SemanticMutationTransaction {
             } = mutation
             {
                 if removed_nodes.contains(signal) {
-                    return Err(
-                        SemanticMutationTransactionError::SubscriptionUsesRemovedSignal {
-                            index,
-                            object: *object,
-                            property: *property,
-                            signal: *signal,
-                        },
-                    );
+                    return Err(match object {
+                        SemanticTransactionNodeRef::Existing(object) => {
+                            SemanticMutationTransactionError::SubscriptionUsesRemovedSignal {
+                                index,
+                                object: *object,
+                                property: *property,
+                                signal: *signal,
+                            }
+                        }
+                        SemanticTransactionNodeRef::Pending(token) => {
+                            SemanticMutationTransactionError::PendingSubscriptionUsesRemovedSignal {
+                                index,
+                                object: *token,
+                                property: *property,
+                                signal: *signal,
+                            }
+                        }
+                    });
                 }
             }
             if let SemanticMutation::AddMember { family, member }
             | SemanticMutation::RemoveMember { family, member } = mutation
             {
-                if removed_nodes.contains(member) {
-                    return Err(
-                        SemanticMutationTransactionError::FamilyEdgeUsesRemovedNode {
+                if let SemanticTransactionNodeRef::Existing(member) = member {
+                    if removed_nodes.contains(member) {
+                        let SemanticTransactionNodeRef::Existing(family) = family else {
+                            return Err(SemanticMutationTransactionError::PendingFamilyEdgeUsesRemovedNode {
                             index,
                             family: *family,
                             member: *member,
-                        },
-                    );
+                        });
+                        };
+                        return Err(
+                            SemanticMutationTransactionError::FamilyEdgeUsesRemovedNode {
+                                index,
+                                family: *family,
+                                member: *member,
+                            },
+                        );
+                    }
                 }
             }
             if let SemanticMutation::ReorderMember {
@@ -494,24 +674,61 @@ impl SemanticMutationTransaction {
                 before,
             } = mutation
             {
-                if removed_nodes.contains(member) {
-                    return Err(
-                        SemanticMutationTransactionError::FamilyOrderUsesRemovedNode {
+                if let SemanticTransactionNodeRef::Existing(member) = member {
+                    if removed_nodes.contains(member) {
+                        let SemanticTransactionNodeRef::Existing(family) = family else {
+                            return Err(SemanticMutationTransactionError::PendingFamilyOrderUsesRemovedNode {
                             index,
                             family: *family,
-                            node: *member,
-                        },
-                    );
-                }
-                if let Some(anchor) = before {
-                    if removed_nodes.contains(anchor) {
+                            node: (*member).into(),
+                        });
+                        };
                         return Err(
                             SemanticMutationTransactionError::FamilyOrderUsesRemovedNode {
                                 index,
                                 family: *family,
-                                node: *anchor,
+                                node: *member,
                             },
                         );
+                    }
+                }
+                if let Some(anchor) = before {
+                    if let SemanticTransactionNodeRef::Existing(anchor) = anchor {
+                        if removed_nodes.contains(anchor) {
+                            let SemanticTransactionNodeRef::Existing(family) = family else {
+                                return Err(SemanticMutationTransactionError::PendingFamilyOrderUsesRemovedNode {
+                                index,
+                                family: *family,
+                                node: (*anchor).into(),
+                            });
+                            };
+                            return Err(
+                                SemanticMutationTransactionError::FamilyOrderUsesRemovedNode {
+                                    index,
+                                    family: *family,
+                                    node: *anchor,
+                                },
+                            );
+                        }
+                    }
+                }
+            }
+            if let SemanticMutation::AddTransformAnimation {
+                target,
+                target_state,
+                ..
+            } = mutation
+            {
+                for node in [*target, *target_state] {
+                    if let SemanticTransactionNodeRef::Existing(node) = node {
+                        if removed_nodes.contains(&node) {
+                            return Err(
+                                SemanticMutationTransactionError::AnimationUsesRemovedNode {
+                                    index,
+                                    node,
+                                },
+                            );
+                        }
                     }
                 }
             }
@@ -519,10 +736,7 @@ impl SemanticMutationTransaction {
             match mutation {
                 SemanticMutation::ReplaceStyle { object, .. } => {
                     if style_property_writes.contains(object) {
-                        return Err(SemanticMutationTransactionError::ConflictingStyleMutation {
-                            index,
-                            object: *object,
-                        });
+                        return Err(conflicting_style_error(index, *object));
                     }
                     style_replacements.insert(*object);
                 }
@@ -530,10 +744,7 @@ impl SemanticMutationTransaction {
                     object, property, ..
                 } if is_style_property(*property) => {
                     if style_replacements.contains(object) {
-                        return Err(SemanticMutationTransactionError::ConflictingStyleMutation {
-                            index,
-                            object: *object,
-                        });
+                        return Err(conflicting_style_error(index, *object));
                     }
                     style_property_writes.insert(*object);
                 }
@@ -542,48 +753,7 @@ impl SemanticMutationTransaction {
 
             if let Some(key) = mutation.key() {
                 if !targets.insert(key) {
-                    return Err(match key {
-                        SemanticMutationKey::Signal(target) => {
-                            SemanticMutationTransactionError::DuplicateTarget { index, target }
-                        }
-                        SemanticMutationKey::ObjectProperty { object, property } => {
-                            SemanticMutationTransactionError::DuplicateProperty {
-                                index,
-                                object,
-                                property,
-                            }
-                        }
-                        SemanticMutationKey::ObjectContent(object) => {
-                            SemanticMutationTransactionError::DuplicateContent { index, object }
-                        }
-                        SemanticMutationKey::ObjectStyle(object) => {
-                            SemanticMutationTransactionError::DuplicateStyle { index, object }
-                        }
-                        SemanticMutationKey::Subscription { object, property } => {
-                            SemanticMutationTransactionError::DuplicateSubscription {
-                                index,
-                                object,
-                                property,
-                            }
-                        }
-                        SemanticMutationKey::FamilyEdge { family, member } => {
-                            SemanticMutationTransactionError::DuplicateFamilyEdge {
-                                index,
-                                family,
-                                member,
-                            }
-                        }
-                        SemanticMutationKey::FamilyOrder { family, member } => {
-                            SemanticMutationTransactionError::DuplicateFamilyOrder {
-                                index,
-                                family,
-                                member,
-                            }
-                        }
-                        SemanticMutationKey::NodeRemoval(node) => {
-                            SemanticMutationTransactionError::DuplicateNodeRemoval { index, node }
-                        }
-                    });
+                    return Err(duplicate_mutation_error(index, key));
                 }
             }
 
@@ -621,68 +791,69 @@ impl SemanticMutationTransaction {
                     property,
                     value,
                 } => {
-                    let state = store
-                        .semantic_object_state_checked(*object)
-                        .map_err(|error| SemanticMutationTransactionError::Object {
-                            index,
-                            error,
-                        })?;
+                    let state = catalog.staged_object_state(
+                        &mut staged_objects,
+                        &mut staged_object_order,
+                        *object,
+                        index,
+                    )?;
                     if !value.is_finite() {
-                        return Err(SemanticMutationTransactionError::NonFinitePropertyValue {
-                            index,
-                            object: *object,
-                            property: *property,
-                        });
+                        return Err(non_finite_property_error(index, *object, *property));
                     }
                     let expected = property.value_kind();
                     let actual = value.value_kind();
                     if actual != expected {
-                        return Err(SemanticMutationTransactionError::PropertyTypeMismatch {
-                            index,
-                            object: *object,
-                            property: *property,
-                            expected,
-                            actual,
-                        });
+                        return Err(property_type_error(
+                            index, *object, *property, expected, actual,
+                        ));
                     }
-                    changed.push(object_property_value(state, *property) != *value);
+                    let did_change = object_property_value(state, *property) != *value;
+                    if did_change {
+                        apply_object_property(state, *property, value.clone());
+                    }
+                    changed.push(did_change);
                 }
                 SemanticMutation::ReplaceContent { object, content } => {
-                    let state = store
-                        .semantic_object_state_checked(*object)
-                        .map_err(|error| SemanticMutationTransactionError::Object {
-                            index,
-                            error,
-                        })?;
+                    let state = catalog.staged_object_state(
+                        &mut staged_objects,
+                        &mut staged_object_order,
+                        *object,
+                        index,
+                    )?;
                     validate_object_content_resource(store, *content, index)?;
-                    changed.push(state.content != *content);
+                    let did_change = state.content != *content;
+                    if did_change {
+                        state.content = *content;
+                    }
+                    changed.push(did_change);
                 }
                 SemanticMutation::ReplaceStyle { object, style } => {
-                    let state = store
-                        .semantic_object_state_checked(*object)
-                        .map_err(|error| SemanticMutationTransactionError::Object {
-                            index,
-                            error,
-                        })?;
+                    let state = catalog.staged_object_state(
+                        &mut staged_objects,
+                        &mut staged_object_order,
+                        *object,
+                        index,
+                    )?;
                     if !style.is_finite() {
-                        return Err(SemanticMutationTransactionError::InvalidStyle {
-                            index,
-                            object: *object,
-                        });
+                        return Err(invalid_style_error(index, *object));
                     }
-                    changed.push(state.style != *style);
+                    let did_change = state.style != *style;
+                    if did_change {
+                        state.style = style.clone();
+                    }
+                    changed.push(did_change);
                 }
                 SemanticMutation::ChangeSubscription {
                     object,
                     property,
                     signal,
                 } => {
-                    let state = store
-                        .semantic_object_state_checked(*object)
-                        .map_err(|error| SemanticMutationTransactionError::Object {
-                            index,
-                            error,
-                        })?;
+                    let state = catalog.staged_object_state(
+                        &mut staged_objects,
+                        &mut staged_object_order,
+                        *object,
+                        index,
+                    )?;
                     let existing = state
                         .signal_bindings()
                         .iter()
@@ -696,76 +867,127 @@ impl SemanticMutationTransaction {
                             })?;
                         let expected = property.value_kind();
                         if actual != expected {
-                            return Err(
-                                SemanticMutationTransactionError::SubscriptionTypeMismatch {
-                                    index,
-                                    object: *object,
-                                    property: *property,
-                                    signal: *signal,
-                                    expected,
-                                    actual,
-                                },
-                            );
+                            return Err(subscription_type_error(
+                                index, *object, *property, *signal, expected, actual,
+                            ));
                         }
-                        changed.push(existing != Some(*signal));
+                        let did_change = existing != Some(*signal);
+                        if did_change {
+                            replace_object_binding(state, *property, Some(*signal));
+                        }
+                        changed.push(did_change);
                     } else {
-                        changed.push(existing.is_some());
+                        let did_change = existing.is_some();
+                        if did_change {
+                            replace_object_binding(state, *property, None);
+                        }
+                        changed.push(did_change);
                     }
                 }
                 SemanticMutation::AddMember { family, member } => {
-                    changed.push(family_edges.add(store, *family, *member).map_err(|error| {
-                        SemanticMutationTransactionError::Family { index, error }
-                    })?);
+                    changed.push(family_edges.add(&catalog, *family, *member, index)?);
                 }
                 SemanticMutation::RemoveMember { family, member } => {
-                    changed.push(family_edges.remove(store, *family, *member).map_err(
-                        |error| SemanticMutationTransactionError::Family { index, error },
-                    )?);
+                    changed.push(family_edges.remove(&catalog, *family, *member, index)?);
                 }
                 SemanticMutation::ReorderMember {
                     family,
                     member,
                     before,
                 } => {
-                    changed.push(
-                        family_edges
-                            .reorder(store, *family, *member, *before)
-                            .map_err(|error| SemanticMutationTransactionError::Family {
-                                index,
-                                error,
-                            })?,
-                    );
+                    changed.push(family_edges.reorder(&catalog, *family, *member, *before, index)?);
                 }
-                SemanticMutation::AddNode { creation } => {
+                SemanticMutation::AddNode { token, creation } => {
                     preflight_add_node(
                         store,
                         creation,
                         &removed_nodes,
                         &mut pending_sources,
+                        !removed_pending.contains(token),
                         index,
                     )?;
-                    changed.push(true);
+                    if let SemanticNodeCreation::Object { state, .. } = creation {
+                        staged_objects
+                            .entry((*token).into())
+                            .or_insert_with(|| (**state).clone());
+                    }
+                    changed.push(!removed_pending.contains(token));
                 }
                 SemanticMutation::AddAnimation { state } => {
                     preflight_add_animation(store, state, &removed_nodes, index)?;
                     changed.push(true);
                 }
-                SemanticMutation::RemoveAnimation { .. } => {
-                    changed.push(true);
-                }
-                SemanticMutation::RemoveNode { node } => {
-                    if store.node(*node).is_none() {
-                        return Err(SemanticMutationTransactionError::Node {
-                            index,
-                            error: SemanticStoreError::UnknownNode(*node),
+                SemanticMutation::AddTransformAnimation {
+                    target,
+                    target_state,
+                    options,
+                } => {
+                    preflight_animation_options(*options, index)?;
+                    catalog.staged_object_state(
+                        &mut staged_objects,
+                        &mut staged_object_order,
+                        *target,
+                        index,
+                    )?;
+                    catalog.staged_object_state(
+                        &mut staged_objects,
+                        &mut staged_object_order,
+                        *target_state,
+                        index,
+                    )?;
+                    if target == target_state {
+                        return Err(match target {
+                            SemanticTransactionNodeRef::Existing(node) => {
+                                SemanticMutationTransactionError::SameAnimationTargetAndTargetState {
+                                    index,
+                                    node: *node,
+                                }
+                            }
+                            SemanticTransactionNodeRef::Pending(_) => {
+                                SemanticMutationTransactionError::SamePendingAnimationTargetAndTargetState {
+                                    index,
+                                    node: *target,
+                                }
+                            }
                         });
                     }
                     changed.push(true);
                 }
+                SemanticMutation::RemoveAnimation { .. } => {
+                    changed.push(true);
+                }
+                SemanticMutation::RemoveNode { node } => match node {
+                    SemanticTransactionNodeRef::Existing(node) => {
+                        if store.node(*node).is_none() {
+                            return Err(SemanticMutationTransactionError::Node {
+                                index,
+                                error: SemanticStoreError::UnknownNode(*node),
+                            });
+                        }
+                        changed.push(true);
+                    }
+                    SemanticTransactionNodeRef::Pending(_) => changed.push(false),
+                },
             }
         }
 
-        Ok(changed)
+        for (mutation, changed) in self.mutations.iter().zip(&mut changed) {
+            if mutation.references_any_pending(&removed_pending) {
+                *changed = false;
+            }
+        }
+        staged_objects.retain(|node, _| {
+            !matches!(node, SemanticTransactionNodeRef::Pending(token) if removed_pending.contains(token))
+        });
+        Ok(SemanticTransactionPreflight {
+            changed,
+            staged_objects,
+            staged_object_order,
+            family_edges,
+            pending_creations,
+            removed_existing: removed_nodes,
+            removed_pending,
+        })
     }
 }
 
@@ -926,17 +1148,99 @@ fn set_object_subscription(
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct SemanticMutationTransactionResult {
     impacts: Vec<SemanticMutationImpact>,
+    committed_nodes: HashMap<SemanticLocalNodeToken, SemanticNodeId>,
 }
 
 impl SemanticMutationTransactionResult {
     pub fn impacts(&self) -> &[SemanticMutationImpact] {
         &self.impacts
     }
+
+    /// Resolve one token from this committed transaction to its real semantic ID.
+    /// Canceled or foreign tokens return `None`.
+    pub fn resolve(&self, token: SemanticLocalNodeToken) -> Option<SemanticNodeId> {
+        self.committed_nodes.get(&token).copied()
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SemanticMutationTransactionError {
     SceneRevisionExhausted,
+    PendingNodeFromDifferentTransaction {
+        index: usize,
+        token: SemanticLocalNodeToken,
+    },
+    UnknownPendingNode {
+        index: usize,
+        token: SemanticLocalNodeToken,
+    },
+    PendingNodeKindMismatch {
+        index: usize,
+        token: SemanticLocalNodeToken,
+        expected: SemanticPendingNodeKind,
+    },
+    DuplicatePendingMutation {
+        index: usize,
+        node: SemanticLocalNodeToken,
+    },
+    ConflictingPendingStyleMutation {
+        index: usize,
+        object: SemanticLocalNodeToken,
+    },
+    PendingFamilyCycle {
+        index: usize,
+        family: SemanticTransactionNodeRef,
+        member: SemanticTransactionNodeRef,
+    },
+    PendingNotFamilyMember {
+        index: usize,
+        family: SemanticTransactionNodeRef,
+        member: SemanticTransactionNodeRef,
+    },
+    PendingSubscriptionUsesRemovedSignal {
+        index: usize,
+        object: SemanticLocalNodeToken,
+        property: SemanticObjectProperty,
+        signal: SemanticNodeId,
+    },
+    PendingFamilyEdgeUsesRemovedNode {
+        index: usize,
+        family: SemanticTransactionNodeRef,
+        member: SemanticNodeId,
+    },
+    PendingFamilyOrderUsesRemovedNode {
+        index: usize,
+        family: SemanticTransactionNodeRef,
+        node: SemanticTransactionNodeRef,
+    },
+    PendingNonFinitePropertyValue {
+        index: usize,
+        object: SemanticLocalNodeToken,
+        property: SemanticObjectProperty,
+    },
+    PendingPropertyTypeMismatch {
+        index: usize,
+        object: SemanticLocalNodeToken,
+        property: SemanticObjectProperty,
+        expected: SemanticSignalValueKind,
+        actual: SemanticSignalValueKind,
+    },
+    InvalidPendingStyle {
+        index: usize,
+        object: SemanticLocalNodeToken,
+    },
+    PendingSubscriptionTypeMismatch {
+        index: usize,
+        object: SemanticLocalNodeToken,
+        property: SemanticObjectProperty,
+        signal: SemanticNodeId,
+        expected: SemanticSignalValueKind,
+        actual: SemanticSignalValueKind,
+    },
+    SamePendingAnimationTargetAndTargetState {
+        index: usize,
+        node: SemanticTransactionNodeRef,
+    },
     DuplicateTarget {
         index: usize,
         target: SemanticNodeId,
@@ -1108,6 +1412,66 @@ impl std::fmt::Display for SemanticMutationTransactionError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::SceneRevisionExhausted => write!(formatter, "Noon scene revision space exhausted"),
+            Self::PendingNodeFromDifferentTransaction { index, token } => write!(
+                formatter,
+                "semantic transaction mutation {index} uses pending node {token:?} from another transaction"
+            ),
+            Self::UnknownPendingNode { index, token } => write!(
+                formatter,
+                "semantic transaction mutation {index} uses unknown pending node {token:?}"
+            ),
+            Self::PendingNodeKindMismatch { index, token, expected } => write!(
+                formatter,
+                "semantic transaction mutation {index} requires pending node {token:?} to be {expected:?}"
+            ),
+            Self::DuplicatePendingMutation { index, node } => write!(
+                formatter,
+                "semantic transaction mutation {index} repeats a mutation target involving pending node {node:?}"
+            ),
+            Self::ConflictingPendingStyleMutation { index, object } => write!(
+                formatter,
+                "semantic transaction mutation {index} mixes full and scalar style mutation on pending object {object:?}"
+            ),
+            Self::PendingFamilyCycle { index, family, member } => write!(
+                formatter,
+                "semantic transaction mutation {index} creates a family cycle {family:?} -> {member:?}"
+            ),
+            Self::PendingNotFamilyMember { index, family, member } => write!(
+                formatter,
+                "semantic transaction mutation {index} cannot reorder non-member {member:?} in family {family:?}"
+            ),
+            Self::PendingSubscriptionUsesRemovedSignal { index, object, property, signal } => write!(
+                formatter,
+                "semantic transaction mutation {index} cannot bind removed signal {signal:?} to {property:?} on pending object {object:?}"
+            ),
+            Self::PendingFamilyEdgeUsesRemovedNode { index, family, member } => write!(
+                formatter,
+                "semantic transaction mutation {index} cannot use removed node {member:?} in pending family edge for {family:?}"
+            ),
+            Self::PendingFamilyOrderUsesRemovedNode { index, family, node } => write!(
+                formatter,
+                "semantic transaction mutation {index} cannot use removed node {node:?} in pending family order for {family:?}"
+            ),
+            Self::PendingNonFinitePropertyValue { index, object, property } => write!(
+                formatter,
+                "semantic transaction mutation {index} cannot set {property:?} on pending object {object:?} to a non-finite value"
+            ),
+            Self::PendingPropertyTypeMismatch { index, object, property, expected, actual } => write!(
+                formatter,
+                "semantic transaction mutation {index} cannot set {property:?} on pending object {object:?} requiring {expected} to {actual}"
+            ),
+            Self::InvalidPendingStyle { index, object } => write!(
+                formatter,
+                "semantic transaction mutation {index} cannot set a non-finite style on pending object {object:?}"
+            ),
+            Self::PendingSubscriptionTypeMismatch { index, object, property, signal, expected, actual } => write!(
+                formatter,
+                "semantic transaction mutation {index} cannot bind {actual} signal {signal:?} to {property:?} on pending object {object:?} requiring {expected}"
+            ),
+            Self::SamePendingAnimationTargetAndTargetState { index, node } => write!(
+                formatter,
+                "semantic transaction mutation {index} cannot add an animation with identical pending target and target state {node:?}"
+            ),
             Self::DuplicateTarget { index, target } => write!(
                 formatter,
                 "semantic transaction mutation {index} repeats target {}:{}",
@@ -1413,3 +1777,6 @@ mod remove_node_tests;
 
 #[cfg(test)]
 mod prepared_tests;
+
+#[cfg(test)]
+mod provisional_tests;

--- a/crates/noon-core/src/reactive/semantic_transaction/animation_addition.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction/animation_addition.rs
@@ -1,8 +1,8 @@
 use std::collections::HashSet;
 
 use crate::{
-    SemanticAnimationCompositionKind, SemanticAnimationError, SemanticAnimationIntent,
-    SemanticAnimationState,
+    AnimationOptions, SemanticAnimationCompositionKind, SemanticAnimationError,
+    SemanticAnimationIntent, SemanticAnimationState,
 };
 
 use super::{SemanticMutationTransactionError, SemanticNodeId, SemanticStore};
@@ -13,26 +13,7 @@ pub(super) fn preflight_add_animation(
     removed_nodes: &HashSet<SemanticNodeId>,
     index: usize,
 ) -> Result<(), SemanticMutationTransactionError> {
-    let options = state.options();
-    if options
-        .run_time
-        .is_some_and(|run_time| !run_time.is_finite() || run_time <= 0.0)
-    {
-        return Err(SemanticMutationTransactionError::InvalidAnimationRunTime { index });
-    }
-    if options
-        .lag_ratio
-        .is_some_and(|lag_ratio| !lag_ratio.is_finite() || lag_ratio < 0.0)
-    {
-        return Err(SemanticMutationTransactionError::InvalidAnimationLagRatio { index });
-    }
-    if options
-        .path_arc
-        .is_some_and(|path_arc| !path_arc.is_finite())
-    {
-        return Err(SemanticMutationTransactionError::InvalidAnimationPathArc { index });
-    }
-
+    preflight_animation_options(state.options(), index)?;
     match state.intent() {
         SemanticAnimationIntent::TransformTo {
             target,
@@ -72,6 +53,32 @@ pub(super) fn preflight_add_animation(
                     .map_err(|error| animation_lookup_error(index, error))?;
             }
         }
+    }
+
+    Ok(())
+}
+
+pub(super) fn preflight_animation_options(
+    options: AnimationOptions,
+    index: usize,
+) -> Result<(), SemanticMutationTransactionError> {
+    if options
+        .run_time
+        .is_some_and(|run_time| !run_time.is_finite() || run_time <= 0.0)
+    {
+        return Err(SemanticMutationTransactionError::InvalidAnimationRunTime { index });
+    }
+    if options
+        .lag_ratio
+        .is_some_and(|lag_ratio| !lag_ratio.is_finite() || lag_ratio < 0.0)
+    {
+        return Err(SemanticMutationTransactionError::InvalidAnimationLagRatio { index });
+    }
+    if options
+        .path_arc
+        .is_some_and(|path_arc| !path_arc.is_finite())
+    {
+        return Err(SemanticMutationTransactionError::InvalidAnimationPathArc { index });
     }
 
     Ok(())

--- a/crates/noon-core/src/reactive/semantic_transaction/family_edges.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction/family_edges.rs
@@ -1,104 +1,200 @@
 use std::collections::{HashMap, HashSet};
 
 use super::{
-    SemanticNodeId, SemanticNodeKind, SemanticSceneOperationError, SemanticStore,
-    SemanticStoreError,
+    SemanticMutationTransactionError, SemanticSceneOperationError, SemanticStoreError,
+    SemanticTransactionNodeRef, TransactionNodeCatalog,
 };
 
 #[derive(Debug, Default)]
 pub(super) struct FamilyEdgePreflight {
-    overrides: HashMap<(SemanticNodeId, SemanticNodeId), bool>,
+    overrides: HashMap<(SemanticTransactionNodeRef, SemanticTransactionNodeRef), bool>,
+    added_order: Vec<(SemanticTransactionNodeRef, SemanticTransactionNodeRef)>,
+    events: Vec<FamilyEdgeEvent>,
+}
+
+#[derive(Debug)]
+enum FamilyEdgeEvent {
+    Add(SemanticTransactionNodeRef, SemanticTransactionNodeRef),
+    Remove(SemanticTransactionNodeRef, SemanticTransactionNodeRef),
+    Reorder {
+        family: SemanticTransactionNodeRef,
+        member: SemanticTransactionNodeRef,
+        before: Option<SemanticTransactionNodeRef>,
+    },
 }
 
 impl FamilyEdgePreflight {
     pub(super) fn add(
         &mut self,
-        store: &SemanticStore,
-        family: SemanticNodeId,
-        member: SemanticNodeId,
-    ) -> Result<bool, SemanticSceneOperationError> {
-        validate_edge(store, family, member)?;
-        if self.contains(store, family, member) {
+        catalog: &TransactionNodeCatalog<'_>,
+        family: SemanticTransactionNodeRef,
+        member: SemanticTransactionNodeRef,
+        index: usize,
+    ) -> Result<bool, SemanticMutationTransactionError> {
+        catalog.ensure_family(family, index)?;
+        catalog.ensure_authoring_node(member, index)?;
+        if self.contains(catalog, family, member) {
             return Ok(false);
         }
-        if family == member || self.reaches(store, member, family) {
-            return Err(SemanticSceneOperationError::Store(
-                SemanticStoreError::FamilyCycle { family, member },
-            ));
+        if family == member || self.reaches(catalog, member, family) {
+            return Err(match (family, member) {
+                (
+                    SemanticTransactionNodeRef::Existing(family),
+                    SemanticTransactionNodeRef::Existing(member),
+                ) => SemanticMutationTransactionError::Family {
+                    index,
+                    error: SemanticSceneOperationError::Store(SemanticStoreError::FamilyCycle {
+                        family,
+                        member,
+                    }),
+                },
+                _ => SemanticMutationTransactionError::PendingFamilyCycle {
+                    index,
+                    family,
+                    member,
+                },
+            });
         }
         self.overrides.insert((family, member), true);
+        self.added_order.push((family, member));
+        self.events.push(FamilyEdgeEvent::Add(family, member));
         Ok(true)
     }
 
     pub(super) fn remove(
         &mut self,
-        store: &SemanticStore,
-        family: SemanticNodeId,
-        member: SemanticNodeId,
-    ) -> Result<bool, SemanticSceneOperationError> {
-        validate_edge(store, family, member)?;
-        let changed = self.contains(store, family, member);
+        catalog: &TransactionNodeCatalog<'_>,
+        family: SemanticTransactionNodeRef,
+        member: SemanticTransactionNodeRef,
+        index: usize,
+    ) -> Result<bool, SemanticMutationTransactionError> {
+        catalog.ensure_family(family, index)?;
+        catalog.ensure_authoring_node(member, index)?;
+        let changed = self.contains(catalog, family, member);
         if changed {
             self.overrides.insert((family, member), false);
+            self.events.push(FamilyEdgeEvent::Remove(family, member));
         }
         Ok(changed)
     }
 
     pub(super) fn reorder(
         &mut self,
-        store: &SemanticStore,
-        family: SemanticNodeId,
-        member: SemanticNodeId,
-        before: Option<SemanticNodeId>,
-    ) -> Result<bool, SemanticSceneOperationError> {
-        validate_edge(store, family, member)?;
-        if !self.contains(store, family, member) {
-            return Err(SemanticSceneOperationError::Store(
-                SemanticStoreError::NotFamilyMember { family, member },
-            ));
+        catalog: &TransactionNodeCatalog<'_>,
+        family: SemanticTransactionNodeRef,
+        member: SemanticTransactionNodeRef,
+        before: Option<SemanticTransactionNodeRef>,
+        index: usize,
+    ) -> Result<bool, SemanticMutationTransactionError> {
+        catalog.ensure_family(family, index)?;
+        catalog.ensure_authoring_node(member, index)?;
+        if !self.contains(catalog, family, member) {
+            return Err(self.not_member_error(index, family, member));
         }
         if let Some(anchor) = before {
-            validate_edge(store, family, anchor)?;
-            if !self.contains(store, family, anchor) {
-                return Err(SemanticSceneOperationError::Store(
-                    SemanticStoreError::NotFamilyMember {
-                        family,
-                        member: anchor,
-                    },
-                ));
+            catalog.ensure_authoring_node(anchor, index)?;
+            if !self.contains(catalog, family, anchor) {
+                return Err(self.not_member_error(index, family, anchor));
             }
         }
+        let changed = before != Some(member);
+        if changed {
+            self.events.push(FamilyEdgeEvent::Reorder {
+                family,
+                member,
+                before,
+            });
+        }
+        Ok(changed)
+    }
 
-        // Exact order is intentionally not materialized during preflight. Direct
-        // membership is the only validity requirement for identity-relative reorder.
-        // Commit classifies already-correct adjacency/tail placement as a no-op after
-        // the complete transaction has been validated. This keeps reorder-only
-        // preflight proportional to the touched nodes' direct parent degree rather
-        // than to the number of siblings in the family.
-        Ok(before != Some(member))
+    pub(super) fn members_for_read(
+        &self,
+        store: &crate::SemanticStore,
+        family: SemanticTransactionNodeRef,
+    ) -> Vec<SemanticTransactionNodeRef> {
+        let mut members = match family {
+            SemanticTransactionNodeRef::Existing(family) => store
+                .node(family)
+                .map(|node| node.members().into_iter().map(Into::into).collect())
+                .unwrap_or_default(),
+            SemanticTransactionNodeRef::Pending(_) => Vec::new(),
+        };
+        for event in &self.events {
+            match *event {
+                FamilyEdgeEvent::Add(event_family, member) if event_family == family => {
+                    if !members.contains(&member) {
+                        members.push(member);
+                    }
+                }
+                FamilyEdgeEvent::Remove(event_family, member) if event_family == family => {
+                    members.retain(|candidate| *candidate != member);
+                }
+                FamilyEdgeEvent::Reorder {
+                    family: event_family,
+                    member,
+                    before,
+                } if event_family == family => {
+                    if let Some(position) =
+                        members.iter().position(|candidate| *candidate == member)
+                    {
+                        members.remove(position);
+                        let position = before
+                            .and_then(|anchor| {
+                                members.iter().position(|candidate| *candidate == anchor)
+                            })
+                            .unwrap_or(members.len());
+                        members.insert(position, member);
+                    }
+                }
+                _ => {}
+            }
+        }
+        members
+    }
+
+    fn not_member_error(
+        &self,
+        index: usize,
+        family: SemanticTransactionNodeRef,
+        member: SemanticTransactionNodeRef,
+    ) -> SemanticMutationTransactionError {
+        match (family, member) {
+            (
+                SemanticTransactionNodeRef::Existing(family),
+                SemanticTransactionNodeRef::Existing(member),
+            ) => SemanticMutationTransactionError::Family {
+                index,
+                error: SemanticSceneOperationError::Store(SemanticStoreError::NotFamilyMember {
+                    family,
+                    member,
+                }),
+            },
+            _ => SemanticMutationTransactionError::PendingNotFamilyMember {
+                index,
+                family,
+                member,
+            },
+        }
     }
 
     fn contains(
         &self,
-        store: &SemanticStore,
-        family: SemanticNodeId,
-        member: SemanticNodeId,
+        catalog: &TransactionNodeCatalog<'_>,
+        family: SemanticTransactionNodeRef,
+        member: SemanticTransactionNodeRef,
     ) -> bool {
         self.overrides
             .get(&(family, member))
             .copied()
-            .unwrap_or_else(|| {
-                store
-                    .node(member)
-                    .is_some_and(|node| node.parents().contains(&family))
-            })
+            .unwrap_or_else(|| catalog.contains(family, member))
     }
 
     fn reaches(
         &self,
-        store: &SemanticStore,
-        start: SemanticNodeId,
-        target: SemanticNodeId,
+        catalog: &TransactionNodeCatalog<'_>,
+        start: SemanticTransactionNodeRef,
+        target: SemanticTransactionNodeRef,
     ) -> bool {
         let mut stack = vec![start];
         let mut seen = HashSet::new();
@@ -109,57 +205,35 @@ impl FamilyEdgePreflight {
             if current == target {
                 return true;
             }
-            stack.extend(self.members(store, current));
+            stack.extend(self.members(catalog, current));
         }
         false
     }
 
-    fn members(&self, store: &SemanticStore, family: SemanticNodeId) -> Vec<SemanticNodeId> {
-        let mut members = store
-            .node(family)
-            .map(|node| node.members())
-            .unwrap_or_default();
+    fn members(
+        &self,
+        catalog: &TransactionNodeCatalog<'_>,
+        family: SemanticTransactionNodeRef,
+    ) -> Vec<SemanticTransactionNodeRef> {
+        let mut members = catalog.members(family);
         members.retain(|member| {
             self.overrides
                 .get(&(family, *member))
                 .copied()
                 .unwrap_or(true)
         });
-        for ((override_family, member), present) in &self.overrides {
-            if *override_family == family && *present && !members.contains(member) {
+        for (added_family, member) in &self.added_order {
+            if *added_family == family
+                && self
+                    .overrides
+                    .get(&(family, *member))
+                    .copied()
+                    .unwrap_or(false)
+                && !members.contains(member)
+            {
                 members.push(*member);
             }
         }
         members
     }
-}
-
-fn validate_edge(
-    store: &SemanticStore,
-    family: SemanticNodeId,
-    member: SemanticNodeId,
-) -> Result<(), SemanticSceneOperationError> {
-    let family_node = store
-        .node(family)
-        .ok_or(SemanticSceneOperationError::UnknownNode(family))?;
-    if !matches!(family_node.kind(), SemanticNodeKind::Family) {
-        return Err(SemanticSceneOperationError::NotSemanticFamily(family));
-    }
-
-    let member_node = store
-        .node(member)
-        .ok_or(SemanticSceneOperationError::UnknownNode(member))?;
-    let is_target_authoring_node = match member_node.kind() {
-        SemanticNodeKind::Family => true,
-        SemanticNodeKind::AuthoringObject => member_node.semantic_object_state().is_some(),
-        SemanticNodeKind::Object(_)
-        | SemanticNodeKind::Signal(_)
-        | SemanticNodeKind::Animation(_) => false,
-    };
-    if !is_target_authoring_node {
-        return Err(SemanticSceneOperationError::NotSemanticAuthoringNode(
-            member,
-        ));
-    }
-    Ok(())
 }

--- a/crates/noon-core/src/reactive/semantic_transaction/node_addition.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction/node_addition.rs
@@ -65,9 +65,13 @@ pub(super) fn preflight_add_node(
     creation: &SemanticNodeCreation,
     removed_nodes: &HashSet<SemanticNodeId>,
     pending_sources: &mut HashSet<SourceIdentity>,
+    validate_source_identity: bool,
     index: usize,
 ) -> Result<(), SemanticMutationTransactionError> {
-    if let Some(source) = creation.source_identity() {
+    if let Some(source) = creation
+        .source_identity()
+        .filter(|_| validate_source_identity)
+    {
         if let Some(existing) = store.node_for_source(source) {
             if !removed_nodes.contains(&existing) {
                 return Err(SemanticMutationTransactionError::Node {

--- a/crates/noon-core/src/reactive/semantic_transaction/prepared.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction/prepared.rs
@@ -1,7 +1,30 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use super::*;
 use crate::SceneRevision;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SemanticTransactionReadError {
+    PendingNodeFromDifferentTransaction(SemanticLocalNodeToken),
+    UnknownPendingNode(SemanticLocalNodeToken),
+    RemovedPendingNode(SemanticLocalNodeToken),
+    RemovedExistingNode(SemanticNodeId),
+    UnknownExistingNode(SemanticNodeId),
+    NotObject(SemanticTransactionNodeRef),
+    NotFamily(SemanticTransactionNodeRef),
+    Existing(SemanticSceneOperationError),
+}
+
+impl std::fmt::Display for SemanticTransactionReadError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "semantic transaction staged read failed: {self:?}"
+        )
+    }
+}
+
+impl std::error::Error for SemanticTransactionReadError {}
 
 /// A fully validated mutation batch holding the store exclusively until commit.
 ///
@@ -19,7 +42,7 @@ use crate::SceneRevision;
 pub struct PreparedSemanticMutationTransaction<'a> {
     store: &'a mut SemanticStore,
     transaction: SemanticMutationTransaction,
-    preflight: Vec<bool>,
+    preflight: SemanticTransactionPreflight,
     next_revision: Option<SceneRevision>,
 }
 
@@ -29,7 +52,7 @@ impl<'a> PreparedSemanticMutationTransaction<'a> {
         store: &'a mut SemanticStore,
     ) -> Result<Self, SemanticMutationTransactionError> {
         let preflight = transaction.preflight(store)?;
-        let next_revision = if preflight.iter().any(|changed| *changed) {
+        let next_revision = if preflight.changed.iter().any(|changed| *changed) {
             Some(
                 store
                     .scene_revision()
@@ -65,7 +88,7 @@ impl<'a> PreparedSemanticMutationTransaction<'a> {
         self.transaction
             .mutations
             .iter()
-            .zip(&self.preflight)
+            .zip(&self.preflight.changed)
             .filter_map(|(mutation, changed)| changed.then_some(mutation))
     }
 
@@ -86,40 +109,139 @@ impl<'a> PreparedSemanticMutationTransaction<'a> {
     /// `ReplaceContent`. It is not a structural or subscription overlay; consumers
     /// must separately check which mutation classes they support. One pass over
     /// the batch clones only the affected object states, never the store or arena.
-    pub fn object_updates(&self) -> impl Iterator<Item = (SemanticNodeId, SemanticObjectState)> {
-        let mut positions = HashMap::<SemanticNodeId, usize>::new();
-        let mut updates: Vec<(SemanticNodeId, SemanticObjectState)> = Vec::new();
-        for mutation in self.candidate_mutations() {
-            let (SemanticMutation::SetProperty { object, .. }
-            | SemanticMutation::ReplaceStyle { object, .. }
-            | SemanticMutation::ReplaceContent { object, .. }) = mutation
-            else {
-                continue;
-            };
-            let position = *positions.entry(*object).or_insert_with(|| {
-                let position = updates.len();
-                updates.push((
-                    *object,
-                    self.store
-                        .semantic_object_state_checked(*object)
-                        .expect("preflighted object remains valid under the exclusive store borrow")
-                        .clone(),
-                ));
-                position
-            });
-            let state = &mut updates[position].1;
-            match mutation {
-                SemanticMutation::SetProperty {
-                    property, value, ..
-                } => {
-                    apply_object_property(state, *property, value.clone());
-                }
-                SemanticMutation::ReplaceStyle { style, .. } => state.style = style.clone(),
-                SemanticMutation::ReplaceContent { content, .. } => state.content = *content,
-                _ => unreachable!("presentation mutations selected above"),
+    pub fn object_updates(
+        &self,
+    ) -> impl Iterator<Item = (SemanticNodeId, SemanticObjectState)> + '_ {
+        let changed_objects: HashSet<_> = self
+            .candidate_mutations()
+            .filter_map(|mutation| match mutation {
+                SemanticMutation::SetProperty { object, .. }
+                | SemanticMutation::ReplaceStyle { object, .. }
+                | SemanticMutation::ReplaceContent { object, .. } => Some(*object),
+                _ => None,
+            })
+            .collect();
+        self.preflight
+            .staged_object_order
+            .iter()
+            .filter_map(move |node| {
+                let SemanticTransactionNodeRef::Existing(node_id) = node else {
+                    return None;
+                };
+                changed_objects
+                    .contains(node)
+                    .then(|| (*node_id, self.preflight.staged_objects[node].clone()))
+            })
+    }
+
+    /// Read the final staged authored object state without publishing the batch.
+    pub fn object_state(
+        &self,
+        object: impl Into<SemanticTransactionNodeRef>,
+    ) -> Result<&SemanticObjectState, SemanticTransactionReadError> {
+        let object = object.into();
+        if let SemanticTransactionNodeRef::Existing(node) = object {
+            if self.preflight.removed_existing.contains(&node) {
+                return Err(SemanticTransactionReadError::RemovedExistingNode(node));
             }
         }
-        updates.into_iter()
+        if let SemanticTransactionNodeRef::Pending(token) = object {
+            self.validate_read_token(token)?;
+            if self.preflight.removed_pending.contains(&token) {
+                return Err(SemanticTransactionReadError::RemovedPendingNode(token));
+            }
+        }
+        if let Some(state) = self.preflight.staged_objects.get(&object) {
+            return Ok(state);
+        }
+        match object {
+            SemanticTransactionNodeRef::Existing(object) => self
+                .store
+                .semantic_object_state_checked(object)
+                .map_err(SemanticTransactionReadError::Existing),
+            SemanticTransactionNodeRef::Pending(token) => match self.pending_creation(token) {
+                Some(SemanticNodeCreation::Object { state, .. }) => Ok(state),
+                Some(SemanticNodeCreation::Family { .. }) => {
+                    Err(SemanticTransactionReadError::NotObject(object))
+                }
+                None => Err(SemanticTransactionReadError::UnknownPendingNode(token)),
+            },
+        }
+    }
+
+    /// Read final direct family order through the transaction-local overlay.
+    pub fn family_members(
+        &self,
+        family: impl Into<SemanticTransactionNodeRef>,
+    ) -> Result<Vec<SemanticTransactionNodeRef>, SemanticTransactionReadError> {
+        let family = family.into();
+        if let SemanticTransactionNodeRef::Existing(node) = family {
+            if self.preflight.removed_existing.contains(&node) {
+                return Err(SemanticTransactionReadError::RemovedExistingNode(node));
+            }
+        }
+        if let SemanticTransactionNodeRef::Pending(token) = family {
+            self.validate_read_token(token)?;
+            if self.preflight.removed_pending.contains(&token) {
+                return Err(SemanticTransactionReadError::RemovedPendingNode(token));
+            }
+        }
+        match family {
+            SemanticTransactionNodeRef::Existing(family) => {
+                let node = self
+                    .store
+                    .node(family)
+                    .ok_or(SemanticTransactionReadError::UnknownExistingNode(family))?;
+                if !matches!(node.kind(), SemanticNodeKind::Family) {
+                    return Err(SemanticTransactionReadError::NotFamily(family.into()));
+                }
+                Ok(self
+                    .preflight
+                    .family_edges
+                    .members_for_read(self.store, family.into())
+                    .into_iter()
+                    .filter(|member| !self.is_removed_ref(*member))
+                    .collect())
+            }
+            SemanticTransactionNodeRef::Pending(token) => match self.pending_creation(token) {
+                Some(SemanticNodeCreation::Family { .. }) => Ok(self
+                    .preflight
+                    .family_edges
+                    .members_for_read(self.store, family)
+                    .into_iter()
+                    .filter(|member| !self.is_removed_ref(*member))
+                    .collect()),
+                Some(SemanticNodeCreation::Object { .. }) => {
+                    Err(SemanticTransactionReadError::NotFamily(family))
+                }
+                None => Err(SemanticTransactionReadError::UnknownPendingNode(token)),
+            },
+        }
+    }
+
+    fn validate_read_token(
+        &self,
+        token: SemanticLocalNodeToken,
+    ) -> Result<(), SemanticTransactionReadError> {
+        if !token.belongs_to(self.transaction.id) {
+            return Err(SemanticTransactionReadError::PendingNodeFromDifferentTransaction(token));
+        }
+        Ok(())
+    }
+
+    fn pending_creation(&self, token: SemanticLocalNodeToken) -> Option<&SemanticNodeCreation> {
+        self.preflight.pending_creations.get(&token)
+    }
+
+    fn is_removed_ref(&self, node: SemanticTransactionNodeRef) -> bool {
+        match node {
+            SemanticTransactionNodeRef::Existing(node) => {
+                self.preflight.removed_existing.contains(&node)
+            }
+            SemanticTransactionNodeRef::Pending(token) => {
+                self.preflight.removed_pending.contains(&token)
+            }
+        }
     }
 
     /// Publish the validated batch exactly once, without another preflight.
@@ -133,7 +255,22 @@ impl<'a> PreparedSemanticMutationTransaction<'a> {
         let mut impacts = Vec::with_capacity(transaction.mutations.len());
         let mut written_slots = HashSet::with_capacity(transaction.mutations.len());
         let mut pending_source_assignments = Vec::new();
-        for (mutation, changed) in transaction.mutations.into_iter().zip(preflight) {
+        let mut committed_nodes = HashMap::new();
+        for mutation in &transaction.mutations {
+            let SemanticMutation::AddNode { token, creation } = mutation else {
+                continue;
+            };
+            if preflight.removed_pending.contains(token) {
+                continue;
+            }
+            let (node, source_identity) = commit_add_node(store, creation.clone());
+            committed_nodes.insert(*token, node);
+            written_slots.insert(node);
+            if let Some(source_identity) = source_identity {
+                pending_source_assignments.push((node, source_identity));
+            }
+        }
+        for (mutation, changed) in transaction.mutations.into_iter().zip(preflight.changed) {
             if !changed {
                 continue;
             }
@@ -153,16 +290,19 @@ impl<'a> PreparedSemanticMutationTransaction<'a> {
                     property,
                     value,
                 } => {
+                    let object = resolve_node_ref(object, &committed_nodes);
                     set_object_property(store, object, property, value);
                     written_slots.insert(object);
                     impacts.push(SemanticMutationImpact::ObjectProperty { object, property });
                 }
                 SemanticMutation::ReplaceContent { object, content } => {
+                    let object = resolve_node_ref(object, &committed_nodes);
                     set_object_content(store, object, content);
                     written_slots.insert(object);
                     impacts.push(SemanticMutationImpact::ObjectContent { object });
                 }
                 SemanticMutation::ReplaceStyle { object, style } => {
+                    let object = resolve_node_ref(object, &committed_nodes);
                     set_object_style(store, object, style);
                     written_slots.insert(object);
                     impacts.push(SemanticMutationImpact::ObjectStyle { object });
@@ -172,11 +312,14 @@ impl<'a> PreparedSemanticMutationTransaction<'a> {
                     property,
                     signal,
                 } => {
+                    let object = resolve_node_ref(object, &committed_nodes);
                     set_object_subscription(store, object, property, signal);
                     written_slots.insert(object);
                     impacts.push(SemanticMutationImpact::Subscription { object, property });
                 }
                 SemanticMutation::AddMember { family, member } => {
+                    let family = resolve_node_ref(family, &committed_nodes);
+                    let member = resolve_node_ref(member, &committed_nodes);
                     store.add_member(family, member).expect(
                         "preflighted family add must remain valid while transaction owns the semantic store",
                     );
@@ -185,6 +328,8 @@ impl<'a> PreparedSemanticMutationTransaction<'a> {
                     impacts.push(SemanticMutationImpact::FamilyMemberAdded { family, member });
                 }
                 SemanticMutation::RemoveMember { family, member } => {
+                    let family = resolve_node_ref(family, &committed_nodes);
+                    let member = resolve_node_ref(member, &committed_nodes);
                     let removed = store.remove_member(family, member).expect(
                         "preflighted family removal must remain valid while transaction owns the semantic store",
                     );
@@ -198,6 +343,9 @@ impl<'a> PreparedSemanticMutationTransaction<'a> {
                     member,
                     before,
                 } => {
+                    let family = resolve_node_ref(family, &committed_nodes);
+                    let member = resolve_node_ref(member, &committed_nodes);
+                    let before = before.map(|node| resolve_node_ref(node, &committed_nodes));
                     let reordered = store.reorder_member(family, member, before).expect(
                         "preflighted family reorder must remain valid while transaction owns the semantic store",
                     );
@@ -211,12 +359,8 @@ impl<'a> PreparedSemanticMutationTransaction<'a> {
                         before,
                     });
                 }
-                SemanticMutation::AddNode { creation } => {
-                    let (node, source_identity) = commit_add_node(store, creation);
-                    written_slots.insert(node);
-                    if let Some(source_identity) = source_identity {
-                        pending_source_assignments.push((node, source_identity));
-                    }
+                SemanticMutation::AddNode { token, .. } => {
+                    let node = committed_nodes[&token];
                     impacts.push(SemanticMutationImpact::NodeAdded { node });
                 }
                 SemanticMutation::AddAnimation { state } => {
@@ -224,8 +368,28 @@ impl<'a> PreparedSemanticMutationTransaction<'a> {
                     written_slots.insert(animation);
                     impacts.push(SemanticMutationImpact::AnimationAdded { animation });
                 }
+                SemanticMutation::AddTransformAnimation {
+                    target,
+                    target_state,
+                    options,
+                } => {
+                    let target = resolve_node_ref(target, &committed_nodes);
+                    let target_state = resolve_node_ref(target_state, &committed_nodes);
+                    let state = SemanticAnimationState::new(
+                        SemanticAnimationIntent::TransformTo {
+                            target,
+                            target_state,
+                        },
+                        options,
+                    );
+                    let animation = commit_add_animation(store, &state);
+                    written_slots.insert(animation);
+                    impacts.push(SemanticMutationImpact::AnimationAdded { animation });
+                }
                 SemanticMutation::RemoveAnimation { animation }
-                | SemanticMutation::RemoveNode { node: animation } => {
+                | SemanticMutation::RemoveNode {
+                    node: SemanticTransactionNodeRef::Existing(animation),
+                } => {
                     // An earlier explicit removal may have cascade-removed this
                     // node already. Preflight proved the handle was live at the
                     // transaction boundary; a cascade therefore satisfies this
@@ -251,6 +415,9 @@ impl<'a> PreparedSemanticMutationTransaction<'a> {
                         }
                     }
                 }
+                SemanticMutation::RemoveNode {
+                    node: SemanticTransactionNodeRef::Pending(_),
+                } => unreachable!("pending removal cancels allocation during preflight"),
             }
         }
 
@@ -264,6 +431,19 @@ impl<'a> PreparedSemanticMutationTransaction<'a> {
             store.publish_scene_revision(next_revision.expect("changed transaction preflighted"));
         }
 
-        SemanticMutationTransactionResult { impacts }
+        SemanticMutationTransactionResult {
+            impacts,
+            committed_nodes,
+        }
+    }
+}
+
+fn resolve_node_ref(
+    node: SemanticTransactionNodeRef,
+    committed: &HashMap<SemanticLocalNodeToken, SemanticNodeId>,
+) -> SemanticNodeId {
+    match node {
+        SemanticTransactionNodeRef::Existing(node) => node,
+        SemanticTransactionNodeRef::Pending(token) => committed[&token],
     }
 }

--- a/crates/noon-core/src/reactive/semantic_transaction/prepared_tests.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction/prepared_tests.rs
@@ -207,7 +207,7 @@ fn detached_additions_allocate_only_on_commit() {
         .add_node(SemanticNodeCreation::object(SemanticObjectState::new(
             StoredGeometry::Circle { radius: 2.0 },
         )));
-    let prepared = transaction.clone().prepare(&mut store).unwrap();
+    let prepared = transaction.prepare(&mut store).unwrap();
     assert_eq!(prepared.mutations().len(), 2);
     assert_eq!(prepared.candidate_mutations().count(), 2);
     assert_eq!(prepared.object_updates().count(), 0);
@@ -218,6 +218,12 @@ fn detached_additions_allocate_only_on_commit() {
     assert_eq!(store.slot_capacity(), before_capacity);
     assert_eq!(store.scene_revision(), revision);
 
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction
+        .add_node(SemanticNodeCreation::family())
+        .add_node(SemanticNodeCreation::object(SemanticObjectState::new(
+            StoredGeometry::Circle { radius: 2.0 },
+        )));
     let committed = transaction.prepare(&mut store).unwrap().commit();
     assert_eq!(committed.impacts().len(), 2);
     assert_eq!(store.len(), before_len + 2);

--- a/crates/noon-core/src/reactive/semantic_transaction/provisional.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction/provisional.rs
@@ -1,0 +1,459 @@
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use super::*;
+
+static NEXT_SEMANTIC_TRANSACTION_ID: AtomicU32 = AtomicU32::new(1);
+
+pub(super) fn next_transaction_id() -> u32 {
+    NEXT_SEMANTIC_TRANSACTION_ID
+        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |id| id.checked_add(1))
+        .expect("Noon semantic transaction token space exhausted")
+}
+
+/// A transaction-scoped name for a semantic node that will be allocated at commit.
+///
+/// This token is not a semantic identity. Its transaction provenance prevents a
+/// token from accidentally naming an equally-positioned creation in another batch.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct SemanticLocalNodeToken {
+    transaction: u32,
+    ordinal: u32,
+}
+
+impl SemanticLocalNodeToken {
+    pub(super) const fn new(transaction: u32, ordinal: u32) -> Self {
+        Self {
+            transaction,
+            ordinal,
+        }
+    }
+
+    pub(super) const fn belongs_to(self, transaction: u32) -> bool {
+        self.transaction == transaction
+    }
+}
+
+/// A node reference accepted by staged semantic mutations.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum SemanticTransactionNodeRef {
+    Existing(SemanticNodeId),
+    Pending(SemanticLocalNodeToken),
+}
+
+impl SemanticTransactionNodeRef {
+    pub const fn existing(self) -> Option<SemanticNodeId> {
+        match self {
+            Self::Existing(node) => Some(node),
+            Self::Pending(_) => None,
+        }
+    }
+}
+
+impl From<SemanticNodeId> for SemanticTransactionNodeRef {
+    fn from(node: SemanticNodeId) -> Self {
+        Self::Existing(node)
+    }
+}
+
+impl From<SemanticLocalNodeToken> for SemanticTransactionNodeRef {
+    fn from(token: SemanticLocalNodeToken) -> Self {
+        Self::Pending(token)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SemanticPendingNodeKind {
+    Object,
+    Family,
+    AuthoringNode,
+}
+
+pub(super) struct TransactionNodeCatalog<'a> {
+    transaction_id: u32,
+    store: &'a SemanticStore,
+    pending: HashMap<SemanticLocalNodeToken, &'a SemanticNodeCreation>,
+}
+
+impl<'a> TransactionNodeCatalog<'a> {
+    pub(super) fn new(
+        transaction: &'a SemanticMutationTransaction,
+        store: &'a SemanticStore,
+    ) -> Self {
+        let pending = transaction
+            .mutations
+            .iter()
+            .filter_map(|mutation| match mutation {
+                SemanticMutation::AddNode { token, creation } => Some((*token, creation)),
+                _ => None,
+            })
+            .collect();
+        Self {
+            transaction_id: transaction.id,
+            store,
+            pending,
+        }
+    }
+
+    pub(super) fn validate_pending(
+        &self,
+        node: SemanticTransactionNodeRef,
+        index: usize,
+    ) -> Result<(), SemanticMutationTransactionError> {
+        let SemanticTransactionNodeRef::Pending(token) = node else {
+            return Ok(());
+        };
+        if !token.belongs_to(self.transaction_id) {
+            return Err(
+                SemanticMutationTransactionError::PendingNodeFromDifferentTransaction {
+                    index,
+                    token,
+                },
+            );
+        }
+        if !self.pending.contains_key(&token) {
+            return Err(SemanticMutationTransactionError::UnknownPendingNode { index, token });
+        }
+        Ok(())
+    }
+
+    pub(super) fn cloned_creations(&self) -> HashMap<SemanticLocalNodeToken, SemanticNodeCreation> {
+        self.pending
+            .iter()
+            .map(|(token, creation)| (*token, (*creation).clone()))
+            .collect()
+    }
+
+    pub(super) fn ensure_family(
+        &self,
+        node: SemanticTransactionNodeRef,
+        index: usize,
+    ) -> Result<(), SemanticMutationTransactionError> {
+        match node {
+            SemanticTransactionNodeRef::Existing(node) => {
+                let Some(existing) = self.store.node(node) else {
+                    return Err(SemanticMutationTransactionError::Family {
+                        index,
+                        error: SemanticSceneOperationError::UnknownNode(node),
+                    });
+                };
+                if !matches!(existing.kind(), SemanticNodeKind::Family) {
+                    return Err(SemanticMutationTransactionError::Family {
+                        index,
+                        error: SemanticSceneOperationError::NotSemanticFamily(node),
+                    });
+                }
+            }
+            SemanticTransactionNodeRef::Pending(token) => {
+                self.validate_pending(node, index)?;
+                if !matches!(self.pending[&token], SemanticNodeCreation::Family { .. }) {
+                    return Err(SemanticMutationTransactionError::PendingNodeKindMismatch {
+                        index,
+                        token,
+                        expected: SemanticPendingNodeKind::Family,
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) fn ensure_authoring_node(
+        &self,
+        node: SemanticTransactionNodeRef,
+        index: usize,
+    ) -> Result<(), SemanticMutationTransactionError> {
+        match node {
+            SemanticTransactionNodeRef::Existing(node) => {
+                let Some(existing) = self.store.node(node) else {
+                    return Err(SemanticMutationTransactionError::Family {
+                        index,
+                        error: SemanticSceneOperationError::UnknownNode(node),
+                    });
+                };
+                let valid = matches!(existing.kind(), SemanticNodeKind::Family)
+                    || matches!(existing.kind(), SemanticNodeKind::AuthoringObject)
+                        && existing.semantic_object_state().is_some();
+                if !valid {
+                    return Err(SemanticMutationTransactionError::Family {
+                        index,
+                        error: SemanticSceneOperationError::NotSemanticAuthoringNode(node),
+                    });
+                }
+            }
+            SemanticTransactionNodeRef::Pending(_) => self.validate_pending(node, index)?,
+        }
+        Ok(())
+    }
+
+    pub(super) fn members(
+        &self,
+        family: SemanticTransactionNodeRef,
+    ) -> Vec<SemanticTransactionNodeRef> {
+        match family {
+            SemanticTransactionNodeRef::Existing(family) => self
+                .store
+                .node(family)
+                .map(|node| node.members().into_iter().map(Into::into).collect())
+                .unwrap_or_default(),
+            SemanticTransactionNodeRef::Pending(_) => Vec::new(),
+        }
+    }
+
+    pub(super) fn contains(
+        &self,
+        family: SemanticTransactionNodeRef,
+        member: SemanticTransactionNodeRef,
+    ) -> bool {
+        match (family, member) {
+            (
+                SemanticTransactionNodeRef::Existing(family),
+                SemanticTransactionNodeRef::Existing(member),
+            ) => self
+                .store
+                .node(member)
+                .is_some_and(|node| node.parents().contains(&family)),
+            _ => false,
+        }
+    }
+
+    pub(super) fn staged_object_state<'b>(
+        &self,
+        staged: &'b mut HashMap<SemanticTransactionNodeRef, SemanticObjectState>,
+        order: &mut Vec<SemanticTransactionNodeRef>,
+        object: SemanticTransactionNodeRef,
+        index: usize,
+    ) -> Result<&'b mut SemanticObjectState, SemanticMutationTransactionError> {
+        if !staged.contains_key(&object) {
+            let state = match object {
+                SemanticTransactionNodeRef::Existing(object) => self
+                    .store
+                    .semantic_object_state_checked(object)
+                    .map_err(|error| SemanticMutationTransactionError::Object { index, error })?
+                    .clone(),
+                SemanticTransactionNodeRef::Pending(token) => match self.pending[&token] {
+                    SemanticNodeCreation::Object { state, .. } => (**state).clone(),
+                    SemanticNodeCreation::Family { .. } => {
+                        return Err(SemanticMutationTransactionError::PendingNodeKindMismatch {
+                            index,
+                            token,
+                            expected: SemanticPendingNodeKind::Object,
+                        });
+                    }
+                },
+            };
+            staged.insert(object, state);
+            order.push(object);
+        }
+        Ok(staged
+            .get_mut(&object)
+            .expect("staged object inserted above"))
+    }
+}
+
+pub(super) fn replace_object_binding(
+    state: &mut SemanticObjectState,
+    property: SemanticObjectProperty,
+    signal: Option<SemanticNodeId>,
+) {
+    let bindings = state.signal_bindings_mut();
+    let position = bindings
+        .iter()
+        .position(|binding| binding.property() == property);
+    match (position, signal) {
+        (Some(position), Some(signal)) => {
+            bindings[position] = SemanticSignalBinding::new(signal, property)
+        }
+        (None, Some(signal)) => bindings.push(SemanticSignalBinding::new(signal, property)),
+        (Some(position), None) => {
+            bindings.remove(position);
+        }
+        (None, None) => {}
+    }
+}
+
+pub(super) fn conflicting_style_error(
+    index: usize,
+    object: SemanticTransactionNodeRef,
+) -> SemanticMutationTransactionError {
+    match object {
+        SemanticTransactionNodeRef::Existing(object) => {
+            SemanticMutationTransactionError::ConflictingStyleMutation { index, object }
+        }
+        SemanticTransactionNodeRef::Pending(object) => {
+            SemanticMutationTransactionError::ConflictingPendingStyleMutation { index, object }
+        }
+    }
+}
+
+pub(super) fn duplicate_mutation_error(
+    index: usize,
+    key: SemanticMutationKey,
+) -> SemanticMutationTransactionError {
+    let pending = match key {
+        SemanticMutationKey::ObjectProperty { object, .. }
+        | SemanticMutationKey::ObjectContent(object)
+        | SemanticMutationKey::ObjectStyle(object)
+        | SemanticMutationKey::Subscription { object, .. }
+        | SemanticMutationKey::NodeRemoval(object) => match object {
+            SemanticTransactionNodeRef::Pending(token) => Some(token),
+            SemanticTransactionNodeRef::Existing(_) => None,
+        },
+        SemanticMutationKey::FamilyEdge { family, member }
+        | SemanticMutationKey::FamilyOrder { family, member } => {
+            [family, member].into_iter().find_map(|node| match node {
+                SemanticTransactionNodeRef::Pending(token) => Some(token),
+                SemanticTransactionNodeRef::Existing(_) => None,
+            })
+        }
+        SemanticMutationKey::Signal(_) => None,
+    };
+    if let Some(node) = pending {
+        return SemanticMutationTransactionError::DuplicatePendingMutation { index, node };
+    }
+    match key {
+        SemanticMutationKey::Signal(target) => {
+            SemanticMutationTransactionError::DuplicateTarget { index, target }
+        }
+        SemanticMutationKey::ObjectProperty {
+            object: SemanticTransactionNodeRef::Existing(object),
+            property,
+        } => SemanticMutationTransactionError::DuplicateProperty {
+            index,
+            object,
+            property,
+        },
+        SemanticMutationKey::ObjectContent(SemanticTransactionNodeRef::Existing(object)) => {
+            SemanticMutationTransactionError::DuplicateContent { index, object }
+        }
+        SemanticMutationKey::ObjectStyle(SemanticTransactionNodeRef::Existing(object)) => {
+            SemanticMutationTransactionError::DuplicateStyle { index, object }
+        }
+        SemanticMutationKey::Subscription {
+            object: SemanticTransactionNodeRef::Existing(object),
+            property,
+        } => SemanticMutationTransactionError::DuplicateSubscription {
+            index,
+            object,
+            property,
+        },
+        SemanticMutationKey::FamilyEdge {
+            family: SemanticTransactionNodeRef::Existing(family),
+            member: SemanticTransactionNodeRef::Existing(member),
+        } => SemanticMutationTransactionError::DuplicateFamilyEdge {
+            index,
+            family,
+            member,
+        },
+        SemanticMutationKey::FamilyOrder {
+            family: SemanticTransactionNodeRef::Existing(family),
+            member: SemanticTransactionNodeRef::Existing(member),
+        } => SemanticMutationTransactionError::DuplicateFamilyOrder {
+            index,
+            family,
+            member,
+        },
+        SemanticMutationKey::NodeRemoval(SemanticTransactionNodeRef::Existing(node)) => {
+            SemanticMutationTransactionError::DuplicateNodeRemoval { index, node }
+        }
+        _ => unreachable!("pending duplicate returned above"),
+    }
+}
+
+pub(super) fn non_finite_property_error(
+    index: usize,
+    object: SemanticTransactionNodeRef,
+    property: SemanticObjectProperty,
+) -> SemanticMutationTransactionError {
+    match object {
+        SemanticTransactionNodeRef::Existing(object) => {
+            SemanticMutationTransactionError::NonFinitePropertyValue {
+                index,
+                object,
+                property,
+            }
+        }
+        SemanticTransactionNodeRef::Pending(object) => {
+            SemanticMutationTransactionError::PendingNonFinitePropertyValue {
+                index,
+                object,
+                property,
+            }
+        }
+    }
+}
+
+pub(super) fn property_type_error(
+    index: usize,
+    object: SemanticTransactionNodeRef,
+    property: SemanticObjectProperty,
+    expected: SemanticSignalValueKind,
+    actual: SemanticSignalValueKind,
+) -> SemanticMutationTransactionError {
+    match object {
+        SemanticTransactionNodeRef::Existing(object) => {
+            SemanticMutationTransactionError::PropertyTypeMismatch {
+                index,
+                object,
+                property,
+                expected,
+                actual,
+            }
+        }
+        SemanticTransactionNodeRef::Pending(object) => {
+            SemanticMutationTransactionError::PendingPropertyTypeMismatch {
+                index,
+                object,
+                property,
+                expected,
+                actual,
+            }
+        }
+    }
+}
+
+pub(super) fn invalid_style_error(
+    index: usize,
+    object: SemanticTransactionNodeRef,
+) -> SemanticMutationTransactionError {
+    match object {
+        SemanticTransactionNodeRef::Existing(object) => {
+            SemanticMutationTransactionError::InvalidStyle { index, object }
+        }
+        SemanticTransactionNodeRef::Pending(object) => {
+            SemanticMutationTransactionError::InvalidPendingStyle { index, object }
+        }
+    }
+}
+
+pub(super) fn subscription_type_error(
+    index: usize,
+    object: SemanticTransactionNodeRef,
+    property: SemanticObjectProperty,
+    signal: SemanticNodeId,
+    expected: SemanticSignalValueKind,
+    actual: SemanticSignalValueKind,
+) -> SemanticMutationTransactionError {
+    match object {
+        SemanticTransactionNodeRef::Existing(object) => {
+            SemanticMutationTransactionError::SubscriptionTypeMismatch {
+                index,
+                object,
+                property,
+                signal,
+                expected,
+                actual,
+            }
+        }
+        SemanticTransactionNodeRef::Pending(object) => {
+            SemanticMutationTransactionError::PendingSubscriptionTypeMismatch {
+                index,
+                object,
+                property,
+                signal,
+                expected,
+                actual,
+            }
+        }
+    }
+}

--- a/crates/noon-core/src/reactive/semantic_transaction/provisional.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction/provisional.rs
@@ -224,7 +224,7 @@ impl<'a> TransactionNodeCatalog<'a> {
         object: SemanticTransactionNodeRef,
         index: usize,
     ) -> Result<&'b mut SemanticObjectState, SemanticMutationTransactionError> {
-        if !staged.contains_key(&object) {
+        if let std::collections::hash_map::Entry::Vacant(entry) = staged.entry(object) {
             let state = match object {
                 SemanticTransactionNodeRef::Existing(object) => self
                     .store
@@ -242,7 +242,7 @@ impl<'a> TransactionNodeCatalog<'a> {
                     }
                 },
             };
-            staged.insert(object, state);
+            entry.insert(state);
             order.push(object);
         }
         Ok(staged

--- a/crates/noon-core/src/reactive/semantic_transaction/provisional_tests.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction/provisional_tests.rs
@@ -1,0 +1,286 @@
+use super::*;
+use crate::{AnimationOptions, SemanticNodeResidency, SemanticVec3};
+
+fn object_state(radius: f32) -> SemanticObjectState {
+    SemanticObjectState::new(StoredGeometry::Circle { radius })
+}
+
+#[test]
+fn pending_object_can_be_mutated_read_attached_and_resolved_atomically() {
+    let mut store = SemanticStore::new();
+    let family = store.insert_family();
+    let revision = store.scene_revision();
+    let mut transaction = SemanticMutationTransaction::new();
+    let object = transaction.create_node(SemanticNodeCreation::object(object_state(1.0)));
+    let translation = SemanticVec3::new(2.0, 3.0, 4.0);
+    transaction
+        .set_property(object, SemanticObjectProperty::Translation, translation)
+        .add_member(family, object);
+
+    let prepared = transaction.prepare(&mut store).unwrap();
+    assert_eq!(
+        prepared.object_state(object).unwrap().transform.translation,
+        translation
+    );
+    assert_eq!(
+        prepared.family_members(family).unwrap(),
+        [SemanticTransactionNodeRef::Pending(object)]
+    );
+    assert_eq!(prepared.store().len(), 1);
+
+    let result = prepared.commit();
+    let committed = result.resolve(object).unwrap();
+    assert_eq!(
+        store
+            .semantic_object_state_checked(committed)
+            .unwrap()
+            .transform
+            .translation,
+        translation
+    );
+    assert_eq!(store.node(family).unwrap().members(), [committed]);
+    assert_eq!(
+        store.node(committed).unwrap().residency(),
+        SemanticNodeResidency::Detached
+    );
+    assert_eq!(store.scene_revision(), revision.checked_next().unwrap());
+    assert_eq!(
+        result.impacts(),
+        &[
+            SemanticMutationImpact::NodeAdded { node: committed },
+            SemanticMutationImpact::ObjectProperty {
+                object: committed,
+                property: SemanticObjectProperty::Translation,
+            },
+            SemanticMutationImpact::FamilyMemberAdded {
+                family,
+                member: committed,
+            },
+        ]
+    );
+}
+
+#[test]
+fn multiple_pending_nodes_support_ordered_edges_and_reject_cycles_before_allocation() {
+    let mut store = SemanticStore::new();
+    let before_capacity = store.slot_capacity();
+    let before_revision = store.scene_revision();
+    let mut transaction = SemanticMutationTransaction::new();
+    let outer = transaction.create_node(SemanticNodeCreation::family());
+    let inner = transaction.create_node(SemanticNodeCreation::family());
+    let leaf = transaction.create_node(SemanticNodeCreation::object(object_state(1.0)));
+    transaction
+        .add_member(outer, inner)
+        .add_member(inner, leaf)
+        .add_member(inner, outer);
+
+    let error = match transaction.prepare(&mut store) {
+        Ok(_) => panic!("cycle must fail preflight"),
+        Err(error) => error,
+    };
+    assert_eq!(
+        error,
+        SemanticMutationTransactionError::PendingFamilyCycle {
+            index: 5,
+            family: inner.into(),
+            member: outer.into(),
+        }
+    );
+    assert_eq!(store.len(), 0);
+    assert_eq!(store.slot_capacity(), before_capacity);
+    assert_eq!(store.scene_revision(), before_revision);
+}
+
+#[test]
+fn pending_family_members_have_a_staged_and_committed_order() {
+    let mut store = SemanticStore::new();
+    let mut transaction = SemanticMutationTransaction::new();
+    let family = transaction.create_node(SemanticNodeCreation::family());
+    let first = transaction.create_node(SemanticNodeCreation::object(object_state(1.0)));
+    let second = transaction.create_node(SemanticNodeCreation::object(object_state(2.0)));
+    transaction
+        .add_member(family, first)
+        .add_member(family, second)
+        .reorder_member_ref(family, second, Some(first.into()));
+
+    let prepared = transaction.prepare(&mut store).unwrap();
+    assert_eq!(
+        prepared.family_members(family).unwrap(),
+        [second.into(), first.into()]
+    );
+    let result = prepared.commit();
+    let family = result.resolve(family).unwrap();
+    let first = result.resolve(first).unwrap();
+    let second = result.resolve(second).unwrap();
+    assert_eq!(store.node(family).unwrap().members(), [second, first]);
+}
+
+#[test]
+fn animation_can_reference_two_pending_objects() {
+    let mut store = SemanticStore::new();
+    let mut transaction = SemanticMutationTransaction::new();
+    let target = transaction.create_node(SemanticNodeCreation::object(object_state(1.0)));
+    let target_state = transaction.create_node(SemanticNodeCreation::object(object_state(2.0)));
+    transaction.add_transform_animation(target, target_state, AnimationOptions::default());
+
+    let result = transaction.apply(&mut store).unwrap();
+    let target = result.resolve(target).unwrap();
+    let target_state = result.resolve(target_state).unwrap();
+    let SemanticMutationImpact::AnimationAdded { animation } = result.impacts()[2] else {
+        panic!("expected committed animation identity")
+    };
+    assert_eq!(
+        store.semantic_animation_state(animation).unwrap().intent(),
+        &SemanticAnimationIntent::TransformTo {
+            target,
+            target_state,
+        }
+    );
+}
+
+#[test]
+fn pending_tokens_are_rejected_by_other_transactions() {
+    let mut store = SemanticStore::new();
+    let mut owner = SemanticMutationTransaction::new();
+    let pending = owner.create_node(SemanticNodeCreation::object(object_state(1.0)));
+    let mut foreign = SemanticMutationTransaction::new();
+    foreign.set_property(pending, SemanticObjectProperty::RotationZ, 0.5_f64);
+
+    let error = match foreign.prepare(&mut store) {
+        Ok(_) => panic!("foreign pending token must fail preflight"),
+        Err(error) => error,
+    };
+    assert_eq!(
+        error,
+        SemanticMutationTransactionError::PendingNodeFromDifferentTransaction {
+            index: 0,
+            token: pending,
+        }
+    );
+    assert_eq!(store.len(), 0);
+}
+
+#[test]
+fn pending_kind_errors_fail_without_publishing_identity() {
+    let mut store = SemanticStore::new();
+    let before_revision = store.scene_revision();
+    let mut transaction = SemanticMutationTransaction::new();
+    let family = transaction.create_node(SemanticNodeCreation::family());
+    transaction.set_property(family, SemanticObjectProperty::RotationZ, 0.5_f64);
+
+    let error = match transaction.prepare(&mut store) {
+        Ok(_) => panic!("pending family cannot accept object properties"),
+        Err(error) => error,
+    };
+    assert_eq!(
+        error,
+        SemanticMutationTransactionError::PendingNodeKindMismatch {
+            index: 1,
+            token: family,
+            expected: SemanticPendingNodeKind::Object,
+        }
+    );
+    assert_eq!(store.len(), 0);
+    assert_eq!(store.scene_revision(), before_revision);
+}
+
+#[test]
+fn terminal_pending_removal_cancels_creation_and_all_references() {
+    let mut store = SemanticStore::new();
+    let family = store.insert_family();
+    let before_capacity = store.slot_capacity();
+    let before_revision = store.scene_revision();
+    let mut transaction = SemanticMutationTransaction::new();
+    let pending = transaction.create_node(SemanticNodeCreation::object(object_state(1.0)));
+    transaction
+        .set_property(pending, SemanticObjectProperty::RotationZ, 0.5_f64)
+        .add_member(family, pending)
+        .remove_node(pending);
+
+    let prepared = transaction.prepare(&mut store).unwrap();
+    assert_eq!(
+        prepared.object_state(pending),
+        Err(SemanticTransactionReadError::RemovedPendingNode(pending))
+    );
+    assert!(prepared.family_members(family).unwrap().is_empty());
+    let result = prepared.commit();
+    assert_eq!(result.resolve(pending), None);
+    assert!(result.impacts().is_empty());
+    assert_eq!(store.len(), 1);
+    assert_eq!(store.slot_capacity(), before_capacity);
+    assert_eq!(store.scene_revision(), before_revision);
+    assert!(store.node(family).unwrap().members().is_empty());
+}
+
+#[test]
+fn staged_reads_hide_existing_nodes_in_the_terminal_removal_closure() {
+    let mut store = SemanticStore::new();
+    let family = store.insert_family();
+    let member = store.insert_semantic_object(object_state(1.0));
+    store.add_member(family, member).unwrap();
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction.remove_node(member);
+
+    let prepared = transaction.prepare(&mut store).unwrap();
+    assert_eq!(
+        prepared.object_state(member),
+        Err(SemanticTransactionReadError::RemovedExistingNode(member))
+    );
+    assert!(prepared.family_members(family).unwrap().is_empty());
+    prepared.commit();
+    assert!(store.node(member).is_none());
+}
+
+#[test]
+fn pending_removal_cancels_dependent_animation_but_keeps_unrelated_creation() {
+    let mut store = SemanticStore::new();
+    let mut transaction = SemanticMutationTransaction::new();
+    let removed_target = transaction.create_node(SemanticNodeCreation::object(object_state(1.0)));
+    let surviving_target = transaction.create_node(SemanticNodeCreation::object(object_state(2.0)));
+    transaction
+        .add_transform_animation(
+            removed_target,
+            surviving_target,
+            AnimationOptions::default(),
+        )
+        .remove_node(removed_target);
+
+    let result = transaction.apply(&mut store).unwrap();
+    assert_eq!(result.resolve(removed_target), None);
+    let surviving_target = result.resolve(surviving_target).unwrap();
+    assert_eq!(store.len(), 1);
+    assert!(store.node(surviving_target).is_some());
+    assert_eq!(
+        result.impacts(),
+        &[SemanticMutationImpact::NodeAdded {
+            node: surviving_target,
+        }]
+    );
+}
+
+#[test]
+fn pending_preflight_is_bounded_and_does_not_touch_large_unrelated_scene() {
+    let mut store = SemanticStore::new();
+    for index in 0..10_000 {
+        store.insert_semantic_object(object_state(index as f32 + 1.0));
+    }
+    let before_len = store.len();
+    let before_capacity = store.slot_capacity();
+    let before_stats = store.last_mutation_stats();
+    let mut transaction = SemanticMutationTransaction::new();
+    let pending = transaction.create_node(SemanticNodeCreation::object(object_state(0.5)));
+    transaction.set_property(
+        pending,
+        SemanticObjectProperty::Scale,
+        SemanticVec3::new(2.0, 2.0, 1.0),
+    );
+
+    let prepared = transaction.prepare(&mut store).unwrap();
+    assert_eq!(prepared.store().len(), before_len);
+    assert_eq!(prepared.store().slot_capacity(), before_capacity);
+    assert_eq!(prepared.store().last_mutation_stats(), before_stats);
+    let result = prepared.commit();
+    assert!(result.resolve(pending).is_some());
+    assert_eq!(store.len(), before_len + 1);
+    assert_eq!(store.last_mutation_stats().slots_written, 1);
+}


### PR DESCRIPTION
Semantic transactions can now create objects and families, mutate them, connect them, and inspect the prepared result before allocating any permanent semantic identity. Transaction-scoped tokens resolve to real generational handles only at commit; foreign tokens, invalid types, cycles, and source conflicts fail before publication. Terminal pending removal cancels its allocation and dependent staged work after validation.

Advances #1086 under #957. The semantic layer owns tokens, sparse preflight/read overlays, and commit resolution. Lowering only updates its exhaustive publication vocabulary; no new runtime, scene store, serialization boundary, or temporary migration adapter is introduced. Work and temporary storage scale with the transaction and affected relationship closure; explicit family reads may materialize the family being requested. A mutable callback read/write facade remains work for #70.

Validation on the integrated architecture branch with this exact core/compiler change:
- `CARGO_TARGET_DIR=/Users/ykshin/Dev/me/noon/target CARGO_INCREMENTAL=0 bash scripts/check.sh fast` — passed, 1,244 library tests.
- `CARGO_TARGET_DIR=/Users/ykshin/Dev/me/noon/target CARGO_INCREMENTAL=0 NOON_WASM_PROFILE=dev bash scripts/check.sh full` — passed, including all workspace tests and WASM package build.
- Focused coverage includes token provenance, pending object/family edges and order, staged reads, commit mapping, abort/cancellation, pending transform-animation references, and bounded preflight with 10,000 unrelated nodes.

This is a transaction foundation; it does not claim completed arbitrary Python callback integration or structural runtime publication.
