### PR TITLE
perf: measure Python cold-start phases

### DIFF
--- a/scripts/playground-cold-start.mjs
+++ b/scripts/playground-cold-start.mjs
@@ -7,7 +7,12 @@ import { fileURLToPath } from "node:url";
 
 import playwright from "playwright";
 
-import { coldStartMilestones, summarizeWorkers } from "../web/playground-cold-start-metrics.js";
+import {
+  classifyWorkerUrl,
+  preloadedColdStartMilestones,
+  summarizeAuthoringStartup,
+  summarizeWorkers,
+} from "../web/playground-cold-start-metrics.js";
 
 const { chromium } = playwright;
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
@@ -49,9 +54,14 @@ try {
       const page = await browser.newPage({ viewport: { width: 1200, height: 900 } });
       const failures = [];
       const workers = [];
+      let authoringWorker = null;
       const origin = monotonicNow();
       page.on("worker", (worker) => {
-        workers.push({ url: worker.url(), atMs: monotonicNow() - origin });
+        const event = { url: worker.url(), atMs: monotonicNow() - origin };
+        workers.push(event);
+        if (classifyWorkerUrl(event.url) === "authoring") {
+          authoringWorker = worker;
+        }
       });
       page.on("pageerror", (error) => failures.push(`pageerror: ${error}`));
       page.on("console", (message) => {
@@ -62,25 +72,18 @@ try {
       await page.goto(`${baseUrl}/web/?example=${encodeURIComponent(example.id)}`, {
         waitUntil: "load",
       });
+      const pageReady = monotonicNow();
       await page.waitForFunction(
-        () => document.querySelector("#status")?.dataset.runtimeStartup === "deferred",
-        null,
+        (expectedId) => window.__noonExampleGallery?.selectedExampleId === expectedId,
+        example.id,
         { timeout: 60_000 },
       );
-      const pageReady = monotonicNow();
-      assert.equal(
-        await page.evaluate(() => window.__noonExampleGallery?.selectedExampleId),
-        example.id,
-      );
 
-      const runRequested = monotonicNow();
-      await page.click("#replace-scene");
       await page.waitForFunction(
         () => document.querySelector("#status")?.dataset.runtimeStartup === "started-on-demand",
         null,
         { timeout: 240_000 },
       );
-      const runtimeStarted = monotonicNow();
       await page.waitForFunction(
         () => {
           const draws = Number(document.querySelector("#metric-draws")?.value);
@@ -92,6 +95,22 @@ try {
       );
       const firstMetrics = monotonicNow();
       if (failures.length > 0) throw new Error(failures.join("\n"));
+
+      assert.ok(authoringWorker !== null, "automatic preload must create the Python authoring worker");
+      const authoringStartup = summarizeAuthoringStartup(
+        await authoringWorker.evaluate(
+          () => globalThis.__noonAuthoringStartupMetrics ?? null,
+        ),
+      );
+      const workerSummary = summarizeWorkers(workers);
+      assert.equal(
+        workerSummary.byRole.authoring,
+        1,
+        "cold preload must retain exactly one Python authoring worker",
+      );
+      const authoringWorkerEvent = workerSummary.workers.find(({ role }) => role === "authoring");
+      assert.ok(authoringWorkerEvent, "cold preload must record Python worker creation");
+      const preloadStarted = origin + authoringWorkerEvent.atMs;
 
       const status = await page.locator("#status").evaluate((node) => ({
         ...node.dataset,
@@ -105,21 +124,24 @@ try {
       const report = {
         label: example.label,
         exampleId: example.id,
-        milestones: coldStartMilestones({
+        milestones: preloadedColdStartMilestones({
           navigationStart,
           pageReady,
-          runRequested,
-          runtimeStarted,
+          preloadStarted,
           firstMetrics,
         }),
-        workers: summarizeWorkers(workers),
+        authoringStartup,
+        workers: workerSummary,
         status,
         metrics,
       };
       cases.push(report);
       console.log(
-        `${example.label}: run→runtime ${format(report.milestones.runToRuntimeMs)} ms, ` +
-          `run→metrics ${format(report.milestones.runToFirstMetricsMs)} ms, ` +
+        `${example.label}: preload→metrics ${format(report.milestones.preloadToFirstMetricsMs)} ms, ` +
+          `Python worker ${format(authoringStartup.totalMs)} ms ` +
+          `(module graph ${format(authoringStartup.moduleGraphLoadMs)} ms, ` +
+          `critical ${authoringStartup.criticalResource} ${format(authoringStartup.criticalResourceMs)} ms, ` +
+          `imports ${format(authoringStartup.compatibilityImportInstallMs)} ms), ` +
           `${report.workers.total} workers (${JSON.stringify(report.workers.byRole)})`,
       );
     } finally {
@@ -128,8 +150,8 @@ try {
   }
 
   const artifact = {
-    schemaVersion: 1,
-    benchmark: "Noon public playground cold first-run topology",
+    schemaVersion: 2,
+    benchmark: "Noon public playground preloaded cold-start topology",
     generatedAt: new Date().toISOString(),
     commit: commitSha,
     host: {
@@ -141,9 +163,14 @@ try {
       totalMemoryBytes: os.totalmem(),
       node: process.version,
     },
-    configuration: { backend, examples, freshBrowserProcessPerCase: true },
+    configuration: {
+      backend,
+      examples,
+      freshBrowserProcessPerCase: true,
+      automaticPreload: true,
+    },
     note:
-      "firstMetrics is the first metrics poll reporting positive object/draw counts; it is an observable proxy, not an exact GPU presentation timestamp.",
+      "firstMetrics is the first metrics poll reporting positive object/draw counts; it is an observable proxy, not an exact GPU presentation timestamp. preloadStarted is the Python authoring worker creation event. authoringStartup measures that persistent worker from worker time-origin through readiness: static worker module-graph loading (including the remote Pyodide module import) is measured separately, then Noon WASM, loadPyodide(), and the compatibility bundle start in parallel, followed by Rust authoring binding, compatibility FS install, and eager Python import/install phases.",
     cases,
   };
   await mkdir(path.dirname(artifactPath), { recursive: true });

--- a/web/playground-cold-start-metrics.js
+++ b/web/playground-cold-start-metrics.js
@@ -6,24 +6,98 @@ export function coldStartMilestones(timestamps) {
     "runtimeStarted",
     "firstMetrics",
   ];
-  for (const name of required) {
-    const value = timestamps?.[name];
-    if (!Number.isFinite(value) || value < 0) {
-      throw new TypeError(`cold-start milestone ${name} must be a finite non-negative number`);
-    }
-  }
-  for (let index = 1; index < required.length; index += 1) {
-    const previous = required[index - 1];
-    const current = required[index];
-    if (timestamps[current] < timestamps[previous]) {
-      throw new RangeError(`cold-start milestone ${current} precedes ${previous}`);
-    }
-  }
+  validateOrderedMilestones(timestamps, required, "cold-start");
   return Object.freeze({
     pageReadyMs: timestamps.pageReady - timestamps.navigationStart,
     runToRuntimeMs: timestamps.runtimeStarted - timestamps.runRequested,
     runToFirstMetricsMs: timestamps.firstMetrics - timestamps.runRequested,
     runtimeToFirstMetricsMs: timestamps.firstMetrics - timestamps.runtimeStarted,
+  });
+}
+
+export function preloadedColdStartMilestones(timestamps) {
+  const required = [
+    "navigationStart",
+    "pageReady",
+    "preloadStarted",
+    "firstMetrics",
+  ];
+  validateOrderedMilestones(timestamps, required, "preloaded cold-start");
+  return Object.freeze({
+    pageReadyMs: timestamps.pageReady - timestamps.navigationStart,
+    pageReadyToPreloadMs: timestamps.preloadStarted - timestamps.pageReady,
+    preloadToFirstMetricsMs: timestamps.firstMetrics - timestamps.preloadStarted,
+    navigationToFirstMetricsMs: timestamps.firstMetrics - timestamps.navigationStart,
+  });
+}
+
+export function validateAuthoringStartupMetrics(metrics) {
+  if (!isRecord(metrics) || metrics.version !== 1) {
+    throw new TypeError("authoring startup metrics must use schema version 1");
+  }
+  const durationFields = [
+    "totalMs",
+    "moduleGraphLoadMs",
+    "initializeMs",
+    "startupResourcesMs",
+    "noonWebInitMs",
+    "pyodideInitMs",
+    "compatibilityBundleMs",
+    "authoringBindingsMs",
+    "compatibilityFsInstallMs",
+    "compatibilityImportInstallMs",
+  ];
+  for (const field of durationFields) {
+    const value = metrics[field];
+    if (!Number.isFinite(value) || value < 0) {
+      throw new TypeError(`authoring startup metric ${field} must be finite and non-negative`);
+    }
+  }
+  if (
+    !Number.isSafeInteger(metrics.compatibilityModuleCount) ||
+    metrics.compatibilityModuleCount < 0
+  ) {
+    throw new TypeError(
+      "authoring startup compatibility module count must be a non-negative safe integer",
+    );
+  }
+  if (
+    !Number.isSafeInteger(metrics.compatibilitySourceChars) ||
+    metrics.compatibilitySourceChars < 0
+  ) {
+    throw new TypeError(
+      "authoring startup compatibility source chars must be a non-negative safe integer",
+    );
+  }
+  return Object.freeze({ ...metrics });
+}
+
+export function summarizeAuthoringStartup(metrics) {
+  const checked = validateAuthoringStartupMetrics(metrics);
+  const resources = [
+    ["noon-web", checked.noonWebInitMs],
+    ["pyodide", checked.pyodideInitMs],
+    ["compat-bundle", checked.compatibilityBundleMs],
+  ];
+  resources.sort((left, right) => right[1] - left[1]);
+  const [criticalResource, criticalResourceMs] = resources[0];
+  const resourceWorkMs = resources.reduce((total, [, duration]) => total + duration, 0);
+  const postResourceBootstrapMs =
+    checked.authoringBindingsMs +
+    checked.compatibilityFsInstallMs +
+    checked.compatibilityImportInstallMs;
+  return Object.freeze({
+    ...checked,
+    criticalResource,
+    criticalResourceMs,
+    resourceWorkMs,
+    resourceOverlapSavedMs: Math.max(0, resourceWorkMs - checked.startupResourcesMs),
+    postResourceBootstrapMs,
+    unattributedMs:
+      checked.totalMs -
+      checked.moduleGraphLoadMs -
+      checked.startupResourcesMs -
+      postResourceBootstrapMs,
   });
 }
 
@@ -55,4 +129,24 @@ export function summarizeWorkers(events) {
     byRole: Object.freeze(byRole),
     workers: Object.freeze(workers),
   });
+}
+
+function validateOrderedMilestones(timestamps, required, label) {
+  for (const name of required) {
+    const value = timestamps?.[name];
+    if (!Number.isFinite(value) || value < 0) {
+      throw new TypeError(`${label} milestone ${name} must be a finite non-negative number`);
+    }
+  }
+  for (let index = 1; index < required.length; index += 1) {
+    const previous = required[index - 1];
+    const current = required[index];
+    if (timestamps[current] < timestamps[previous]) {
+      throw new RangeError(`${label} milestone ${current} precedes ${previous}`);
+    }
+  }
+}
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/web/playground-cold-start-metrics.test.mjs
+++ b/web/playground-cold-start-metrics.test.mjs
@@ -3,7 +3,10 @@ import { test } from "node:test";
 import {
   classifyWorkerUrl,
   coldStartMilestones,
+  preloadedColdStartMilestones,
+  summarizeAuthoringStartup,
   summarizeWorkers,
+  validateAuthoringStartupMetrics,
 } from "./playground-cold-start-metrics.js";
 
 test("coldStartMilestones reports phase-local durations", () => {
@@ -46,6 +49,86 @@ test("coldStartMilestones rejects invalid or non-monotonic timestamps", () => {
         firstMetrics: Number.NaN,
       }),
     /finite non-negative/,
+  );
+});
+
+test("preloadedColdStartMilestones reports the automatic preload path", () => {
+  assert.deepEqual(
+    preloadedColdStartMilestones({
+      navigationStart: 100,
+      pageReady: 170,
+      preloadStarted: 205,
+      firstMetrics: 760,
+    }),
+    {
+      pageReadyMs: 70,
+      pageReadyToPreloadMs: 35,
+      preloadToFirstMetricsMs: 555,
+      navigationToFirstMetricsMs: 660,
+    },
+  );
+  assert.throws(
+    () =>
+      preloadedColdStartMilestones({
+        navigationStart: 0,
+        pageReady: 5,
+        preloadStarted: 4,
+        firstMetrics: 10,
+      }),
+    /precedes/,
+  );
+});
+
+test("authoring startup metrics expose module graph, parallel resources, and sequential bootstrap cost", () => {
+  const summary = summarizeAuthoringStartup({
+    version: 1,
+    totalMs: 1050,
+    moduleGraphLoadMs: 150,
+    initializeMs: 900,
+    startupResourcesMs: 600,
+    noonWebInitMs: 320,
+    pyodideInitMs: 590,
+    compatibilityBundleMs: 100,
+    authoringBindingsMs: 20,
+    compatibilityFsInstallMs: 30,
+    compatibilityImportInstallMs: 240,
+    compatibilityModuleCount: 27,
+    compatibilitySourceChars: 500_000,
+  });
+  assert.equal(summary.moduleGraphLoadMs, 150);
+  assert.equal(summary.initializeMs, 900);
+  assert.equal(summary.criticalResource, "pyodide");
+  assert.equal(summary.criticalResourceMs, 590);
+  assert.equal(summary.resourceWorkMs, 1010);
+  assert.equal(summary.resourceOverlapSavedMs, 410);
+  assert.equal(summary.postResourceBootstrapMs, 290);
+  assert.equal(summary.unattributedMs, 10);
+  assert.equal(summary.compatibilityModuleCount, 27);
+});
+
+test("authoring startup metrics reject malformed diagnostic payloads", () => {
+  assert.throws(
+    () => validateAuthoringStartupMetrics({ version: 2 }),
+    /schema version 1/,
+  );
+  assert.throws(
+    () =>
+      validateAuthoringStartupMetrics({
+        version: 1,
+        totalMs: Number.NaN,
+        moduleGraphLoadMs: 1,
+        initializeMs: 1,
+        startupResourcesMs: 1,
+        noonWebInitMs: 1,
+        pyodideInitMs: 1,
+        compatibilityBundleMs: 1,
+        authoringBindingsMs: 1,
+        compatibilityFsInstallMs: 1,
+        compatibilityImportInstallMs: 1,
+        compatibilityModuleCount: 27,
+        compatibilitySourceChars: 1,
+      }),
+    /totalMs/,
   );
 });
 

--- a/web/playground-startup.test.mjs
+++ b/web/playground-startup.test.mjs
@@ -236,15 +236,23 @@ const initializeStart = worker.indexOf("async function initializePyodide()");
 assert.notEqual(initializeStart, -1, "Python worker initializer must exist");
 const firstBarrier = worker.indexOf("await startupResourcesReady;", initializeStart);
 assert.ok(firstBarrier > initializeStart, "startup resources must share one handled readiness barrier");
-for (const kickoff of [
-  "const noonWebReady = initNoonWeb();",
-  "const pyodideReady = loadPyodide();",
-  "const compatibilityBundleReady = loadCompatibilityBundle();",
-  "const startupResourcesReady = Promise.all([",
+const initializeBody = worker.slice(initializeStart, firstBarrier);
+for (const [pattern, label] of [
+  [
+    /const noonWebReady = measureStartupTask\([\s\S]*?"noonWebInitMs"[\s\S]*?\(\) => initNoonWeb\(\)\);/,
+    "Noon WASM startup",
+  ],
+  [
+    /const pyodideReady = measureStartupTask\([\s\S]*?"pyodideInitMs"[\s\S]*?\(\) => loadPyodide\(\)\);/,
+    "Pyodide startup",
+  ],
+  [
+    /const compatibilityBundleReady = measureStartupTask\([\s\S]*?"compatibilityBundleMs"[\s\S]*?\(\) => loadCompatibilityBundle\(\),?[\s\S]*?\);/,
+    "compatibility bundle startup",
+  ],
+  [/const startupResourcesReady = Promise\.all\(\[/, "shared startup barrier"],
 ]) {
-  const position = worker.indexOf(kickoff, initializeStart);
-  assert.ok(position > initializeStart, `missing startup kickoff: ${kickoff}`);
-  assert.ok(position < firstBarrier, `${kickoff} must start before the first initialization barrier`);
+  assert.match(initializeBody, pattern, `${label} must start before the first initialization barrier`);
 }
 assert.doesNotMatch(worker, /await initNoonWeb\(\)/, "Noon WASM must not serialize Pyodide startup");
 assert.doesNotMatch(worker, /await loadPyodide\(\)/, "Pyodide must not serialize Noon WASM startup");
@@ -254,8 +262,8 @@ assert.doesNotMatch(
   "independent startup promises must be handled by the shared barrier",
 );
 assert.match(
-  worker,
-  /const compatibilityBundleReady = loadCompatibilityBundle\(\);/,
+  initializeBody,
+  /"compatibilityBundleMs"[\s\S]*?\(\) => loadCompatibilityBundle\(\)/,
   "compatibility source loading must remain parallel with WASM and Pyodide startup",
 );
 

--- a/web/python-worker.source.js
+++ b/web/python-worker.source.js
@@ -26,6 +26,8 @@ const AUTHORING_CHANNEL = "noon.authoring";
 const AUTHORING_PROTOCOL_VERSION = 6;
 const HOST_CHANNEL = "noon.host-callback";
 const HOST_PROTOCOL_VERSION = 1;
+const AUTHORING_STARTUP_METRICS_VERSION = 1;
+const moduleGraphReadyAt = performance.now();
 
 const pyodidePromise = initializePyodide();
 let requestQueue = Promise.resolve();
@@ -42,15 +44,22 @@ self.addEventListener("message", (event) => {
 });
 
 async function initializePyodide() {
-  const noonWebReady = initNoonWeb();
-  const pyodideReady = loadPyodide();
-  const compatibilityBundleReady = loadCompatibilityBundle();
+  const initializeStartedAt = performance.now();
+  const resourceDurations = {};
+  const noonWebReady = measureStartupTask(resourceDurations, "noonWebInitMs", () => initNoonWeb());
+  const pyodideReady = measureStartupTask(resourceDurations, "pyodideInitMs", () => loadPyodide());
+  const compatibilityBundleReady = measureStartupTask(
+    resourceDurations,
+    "compatibilityBundleMs",
+    () => loadCompatibilityBundle(),
+  );
   const startupResourcesReady = Promise.all([
     noonWebReady,
     pyodideReady,
     compatibilityBundleReady,
   ]);
   const [, pyodide, compatibilityModules] = await startupResourcesReady;
+  const resourcesReadyAt = performance.now();
   const authoringStore = new WasmAuthoringStore();
   self.noonCreateCanonicalAuthoringSceneContext = () =>
     authoringStore.createSceneContext();
@@ -98,12 +107,14 @@ async function initializePyodide() {
   self.noonResolveLifecyclePlan = resolveLifecyclePlanPlain;
   self.noonValidatePresenceTransition = validatePresenceTransitionPlain;
   self.noonCanonicalSceneSpecJson = canonicalRetainedSceneSpecJson;
+  const bindingsReadyAt = performance.now();
 
   for (const [index, descriptor] of PYTHON_COMPAT_MODULES.entries()) {
     pyodide.FS.writeFile(descriptor.runtimePath, compatibilityModules[index].source, {
       encoding: "utf8",
     });
   }
+  const compatibilityFilesReadyAt = performance.now();
 
   pyodide.runPython(`
 import sys
@@ -155,7 +166,40 @@ _manim_camera.install()
 import _manim_canonical_scene
 _manim_canonical_scene.install()
 `);
+  const importsReadyAt = performance.now();
+  self.__noonAuthoringStartupMetrics = Object.freeze({
+    version: AUTHORING_STARTUP_METRICS_VERSION,
+    totalMs: importsReadyAt,
+    moduleGraphLoadMs: moduleGraphReadyAt,
+    initializeMs: importsReadyAt - initializeStartedAt,
+    startupResourcesMs: resourcesReadyAt - initializeStartedAt,
+    noonWebInitMs: resourceDurations.noonWebInitMs,
+    pyodideInitMs: resourceDurations.pyodideInitMs,
+    compatibilityBundleMs: resourceDurations.compatibilityBundleMs,
+    authoringBindingsMs: bindingsReadyAt - resourcesReadyAt,
+    compatibilityFsInstallMs: compatibilityFilesReadyAt - bindingsReadyAt,
+    compatibilityImportInstallMs: importsReadyAt - compatibilityFilesReadyAt,
+    compatibilityModuleCount: compatibilityModules.length,
+    compatibilitySourceChars: compatibilityModules.reduce(
+      (total, module) => total + module.source.length,
+      0,
+    ),
+  });
   return pyodide;
+}
+
+function measureStartupTask(metrics, key, task) {
+  const startedAt = performance.now();
+  let result;
+  try {
+    result = task();
+  } catch (error) {
+    throw error;
+  }
+  return Promise.resolve(result).then((value) => {
+    metrics[key] = performance.now() - startedAt;
+    return value;
+  });
 }
 
 async function loadCompatibilityBundle() {


### PR DESCRIPTION
## Summary

- instrument the persistent Python authoring worker with internal cold-start phase timings
- measure worker module-graph load separately from `loadPyodide()`
- measure Noon WASM init, Pyodide init, and the compatibility bundle as parallel startup resources
- measure the sequential post-resource work separately: Rust authoring bindings, compatibility-module FS install, and eager Python import/install
- repair the playground cold-start benchmark after #1112 so it measures automatic preload instead of clicking Run
- keep the authoring protocol unchanged; benchmark code reads worker-local diagnostics directly through Playwright

## Why

#1112 moved the cold-start cost out of the Run button by preloading after initial paint, but the existing benchmark still encoded the old explicit-Run policy and could not explain where Python startup time was going.

This PR is measurement-only. It identifies which startup phase is actually worth optimizing before changing architecture.

## Metric shape

The authoring worker records:

- `moduleGraphLoadMs` — worker static module graph, including the remote Pyodide module import
- `startupResourcesMs` — critical-path wait for the parallel resource set
- `noonWebInitMs`
- `pyodideInitMs`
- `compatibilityBundleMs`
- `authoringBindingsMs`
- `compatibilityFsInstallMs`
- `compatibilityImportInstallMs`
- module/source-size counts and total startup time

The benchmark also derives the critical resource, resource-overlap savings, post-resource bootstrap cost, and total automatic preload-to-first-metrics latency.

## Hosted measurement

One fresh-browser WebGL sample was captured from the recovery CI build (`NOON_WASM_SKIP_OPT=1`) before the temporary sampling hook was removed from the branch:

- preload -> first observable metrics: **3651.6 ms**
- Python authoring worker ready: **2766.0 ms**
- worker/module graph: **70.4 ms**
- parallel resource barrier: **2408.5 ms**
  - Noon WASM: **2408.5 ms**
  - Pyodide: **2314.8 ms**
  - compatibility bundle: **44.4 ms**
- Rust authoring bindings: **0.5 ms**
- write 27 compatibility modules / 584,688 source chars: **8.0 ms**
- eager Python import/install graph: **278.3 ms**
- one authoring worker, one engine worker, one render worker

The immediate implication is that eager compatibility imports are not the dominant cold-start cost. Noon WASM and Pyodide overlap almost completely and define the worker critical path; the next investigation should focus on the authoring worker's Rust/WASM surface before spending effort on Python lazy imports.

## Architecture

No new worker, scene authority, scheduler, or runtime path is introduced. Instrumentation is worker-local diagnostics only, and the existing Python authoring message protocol remains unchanged.

## Validation

- metric helper/unit coverage includes preloaded milestones, malformed payload rejection, overlap accounting, and module-graph accounting
- startup ratchet proves Noon WASM, Pyodide, and compatibility delivery still start before the shared `Promise.all` barrier even through the timing wrapper
- hosted measurement harness completed successfully, followed by syntax/runtime recovery, stress-grid reruns, mixed retained-family reruns, and retained Typst authoring
- branch is squash-restacked onto current `master`: **1 ahead / 0 behind**, one commit; exact head `740eea4bfcbeebf4d9c24be6bfe9fdc3f8c98f9b`

Refs #642 #953 #1112