### PR TITLE
Scope text and font resources to their owning semantic stores

### DIFF
--- a/crates/noon-compile/src/lib.rs
+++ b/crates/noon-compile/src/lib.rs
@@ -1853,6 +1853,7 @@ mod tests {
         let text = CompiledObject::new(
             text_id,
             TextResourceHandle {
+                arena: 0,
                 id: TextResourceId::new(7),
                 version: 3,
             },
@@ -1883,6 +1884,7 @@ mod tests {
         let text = CompiledObject::new(
             text_id,
             TextResourceHandle {
+                arena: 0,
                 id: TextResourceId::new(7),
                 version: 3,
             },

--- a/crates/noon-compile/src/semantic_lowering/compiled_scene.rs
+++ b/crates/noon-compile/src/semantic_lowering/compiled_scene.rs
@@ -372,6 +372,7 @@ mod tests {
     fn standalone_projection_rejects_text_without_its_owning_resource_scope() {
         let mut store = SemanticStore::new();
         let text = TextResourceHandle {
+            arena: 0,
             id: TextResourceId::new(11),
             version: 4,
         };

--- a/crates/noon-compile/src/semantic_lowering/projection.rs
+++ b/crates/noon-compile/src/semantic_lowering/projection.rs
@@ -489,6 +489,7 @@ mod tests {
 
     fn text(id: u64) -> SemanticObjectState {
         SemanticObjectState::new(TextResourceHandle {
+            arena: 0,
             id: TextResourceId::new(id),
             version: 0,
         })

--- a/crates/noon-core/src/reactive/font_resources.rs
+++ b/crates/noon-core/src/reactive/font_resources.rs
@@ -1,6 +1,21 @@
-use std::{collections::BTreeMap, mem::size_of, sync::Arc};
+use std::{
+    collections::BTreeMap,
+    mem::size_of,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+};
 
 use crate::FontFaceIdentity;
+
+static NEXT_FONT_RESOURCE_ARENA: AtomicU64 = AtomicU64::new(1);
+
+fn next_font_resource_arena() -> u64 {
+    NEXT_FONT_RESOURCE_ARENA
+        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |id| id.checked_add(1))
+        .expect("font resource arena identity exhausted")
+}
 
 /// Stable identity for one immutable OpenType font buffer.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -19,11 +34,12 @@ impl FontResourceId {
 /// Versioned reference to one immutable font buffer.
 ///
 /// Font resources are append-only for the lifetime of an arena, so version zero
-/// remains stable for every live handle. The version field keeps the handle shape
-/// compatible with Noon's other retained-resource boundaries and leaves room for a
-/// future explicit arena-generation model without changing renderer records.
+/// remains stable for every live handle. The owning arena still participates in the
+/// handle because same-slot values from another store must never alias this buffer.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct FontResourceHandle {
+    /// Owning resource namespace; equal slot/version values from another arena are unrelated.
+    pub arena: u64,
     pub id: FontResourceId,
     pub version: u64,
 }
@@ -87,15 +103,38 @@ pub struct FontResourceStats {
 /// for the arena lifetime. A shaped glyph ID is meaningful only relative to the
 /// exact font bytes that produced it, so a face key is never rebound to new bytes.
 /// Dropping the whole arena is the font-resource invalidation barrier.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct FontResourceArena {
+    namespace: u64,
     entries: Vec<FontResourceEntry>,
     handles_by_key: BTreeMap<FontResourceKey, FontResourceHandle>,
     retained_bytes: usize,
     font_bytes: usize,
 }
 
+impl Default for FontResourceArena {
+    fn default() -> Self {
+        Self {
+            namespace: next_font_resource_arena(),
+            entries: Vec::new(),
+            handles_by_key: BTreeMap::new(),
+            retained_bytes: 0,
+            font_bytes: 0,
+        }
+    }
+}
+
 impl FontResourceArena {
+    /// Assign a cloned independent store a distinct namespace and rebuild its derived
+    /// face index with local handles.
+    pub(crate) fn fork_namespace(&mut self) -> u64 {
+        self.namespace = next_font_resource_arena();
+        for handle in self.handles_by_key.values_mut() {
+            handle.arena = self.namespace;
+        }
+        self.namespace
+    }
+
     pub fn new() -> Self {
         Self::default()
     }
@@ -125,7 +164,11 @@ impl FontResourceArena {
         let id = FontResourceId::new(
             u64::try_from(self.entries.len()).expect("Noon font resource ID space exhausted"),
         );
-        let handle = FontResourceHandle { id, version: 0 };
+        let handle = FontResourceHandle {
+            arena: self.namespace,
+            id,
+            version: 0,
+        };
         let resource = Arc::new(FontResource {
             key: key.clone(),
             data,
@@ -143,6 +186,9 @@ impl FontResourceArena {
     }
 
     pub fn get(&self, handle: FontResourceHandle) -> Option<&FontResource> {
+        if handle.arena != self.namespace {
+            return None;
+        }
         let entry = self.entries.get(handle.id.get() as usize)?;
         if entry.version != handle.version {
             return None;
@@ -152,6 +198,9 @@ impl FontResourceArena {
 
     /// Share one immutable font payload with a derived compiled resource snapshot.
     pub fn get_shared(&self, handle: FontResourceHandle) -> Option<Arc<FontResource>> {
+        if handle.arena != self.namespace {
+            return None;
+        }
         let entry = self.entries.get(handle.id.get() as usize)?;
         (entry.version == handle.version).then(|| entry.value.clone())
     }
@@ -235,6 +284,42 @@ mod tests {
     }
 
     #[test]
+    fn same_slot_handle_from_another_arena_is_rejected() {
+        let mut first = FontResourceArena::new();
+        let mut second = FontResourceArena::new();
+        let a = first
+            .intern_face(&face(""), Arc::<[u8]>::from([1, 2, 3]))
+            .unwrap();
+        let b = second
+            .intern_face(&face(""), Arc::<[u8]>::from([1, 2, 3]))
+            .unwrap();
+
+        assert_eq!((a.id, a.version), (b.id, b.version));
+        assert_ne!(a.arena, b.arena);
+        assert!(first.get(b).is_none());
+        assert!(second.get(a).is_none());
+    }
+
+    #[test]
+    fn cloned_arena_requires_local_remap_but_shares_immutable_payloads() {
+        let mut source = FontResourceArena::new();
+        let source_handle = source
+            .intern_face(&face(""), Arc::<[u8]>::from([1, 2, 3]))
+            .unwrap();
+        let source_payload = source.get_shared(source_handle).unwrap();
+
+        let mut cloned = source.clone();
+        cloned.fork_namespace();
+        let local_handle = cloned.handle_for_face(&face("")).unwrap();
+        let local_payload = cloned.get_shared(local_handle).unwrap();
+
+        assert_ne!(source_handle.arena, local_handle.arena);
+        assert!(cloned.get(source_handle).is_none());
+        assert!(source.get(local_handle).is_none());
+        assert!(Arc::ptr_eq(&source_payload, &local_payload));
+    }
+
+    #[test]
     fn variable_font_runs_share_the_same_backing_resource() {
         let mut arena = FontResourceArena::new();
         let regular = arena
@@ -275,6 +360,12 @@ mod tests {
 
         assert_eq!(first, second);
         assert_eq!(first.version, 0);
+        assert!(arena
+            .get(FontResourceHandle {
+                version: 1,
+                ..first
+            })
+            .is_none());
         assert_eq!(arena.get(first).unwrap().data.as_ref(), &[1, 2, 3]);
         assert_eq!(arena.stats().live_resources, 1);
     }

--- a/crates/noon-core/src/reactive/object_content.rs
+++ b/crates/noon-core/src/reactive/object_content.rs
@@ -342,6 +342,7 @@ mod tests {
     #[test]
     fn semantic_text_content_uses_existing_versioned_resource_identity() {
         let handle = TextResourceHandle {
+            arena: 0,
             id: TextResourceId::new(11),
             version: 4,
         };
@@ -392,6 +393,7 @@ mod tests {
     #[test]
     fn legacy_text_object_keeps_only_the_versioned_resource_handle() {
         let handle = TextResourceHandle {
+            arena: 0,
             id: TextResourceId::new(11),
             version: 4,
         };

--- a/crates/noon-core/src/reactive/retained_animation_members.rs
+++ b/crates/noon-core/src/reactive/retained_animation_members.rs
@@ -284,6 +284,7 @@ mod tests {
     fn missing_or_unsupported_text_resources_fail_closed() {
         let texts = TextResourceArena::new();
         let missing = TextResourceHandle {
+            arena: 0,
             id: TextResourceId::new(99),
             version: 7,
         };
@@ -362,6 +363,7 @@ mod tests {
         let leaf = store.insert_authoring_object();
         let texts = TextResourceArena::new();
         let missing = TextResourceHandle {
+            arena: 0,
             id: TextResourceId::new(99),
             version: 7,
         };

--- a/crates/noon-core/src/reactive/text_resources.rs
+++ b/crates/noon-core/src/reactive/text_resources.rs
@@ -1,9 +1,20 @@
 use std::{
     mem::{size_of, size_of_val},
-    sync::Arc,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
 };
 
 use crate::{Color, GeometryResourceHandle, Rect, StrokeCap, StrokeJoin, Vec2};
+
+static NEXT_TEXT_RESOURCE_ARENA: AtomicU64 = AtomicU64::new(1);
+
+fn next_text_resource_arena() -> u64 {
+    NEXT_TEXT_RESOURCE_ARENA
+        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |id| id.checked_add(1))
+        .expect("text resource arena identity exhausted")
+}
 
 const TEXT_RESOURCE_SLOT_BITS: u32 = 32;
 const TEXT_RESOURCE_SLOT_MASK: u64 = u32::MAX as u64;
@@ -25,6 +36,8 @@ impl TextResourceId {
 /// Versioned reference to immutable shaped text/math data.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct TextResourceHandle {
+    /// Owning resource namespace; equal slot/version values from another arena are unrelated.
+    pub arena: u64,
     pub id: TextResourceId,
     pub version: u64,
 }
@@ -524,8 +537,9 @@ pub struct TextResourceStats {
 /// `TextResourceId` encodes a physical slot plus its generation. This lets the arena
 /// reuse storage at the live-working-set high-water mark without allowing a stale
 /// bare ID to alias a later occupant of the same slot.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct TextResourceArena {
+    namespace: u64,
     entries: Vec<TextResourceEntry>,
     free_slots: Vec<u32>,
     live_resources: usize,
@@ -535,7 +549,29 @@ pub struct TextResourceArena {
     parts: usize,
 }
 
+impl Default for TextResourceArena {
+    fn default() -> Self {
+        Self {
+            namespace: next_text_resource_arena(),
+            entries: Vec::new(),
+            free_slots: Vec::new(),
+            live_resources: 0,
+            retained_bytes: 0,
+            glyphs: 0,
+            vectors: 0,
+            parts: 0,
+        }
+    }
+}
+
 impl TextResourceArena {
+    /// Assign a cloned independent store a distinct resource namespace while retaining
+    /// the immutable payload allocations shared by its `Arc` entries.
+    pub(crate) fn fork_namespace(&mut self) -> u64 {
+        self.namespace = next_text_resource_arena();
+        self.namespace
+    }
+
     /// Rebind resource dependencies only while cloning an independent store.
     /// Live resource replacement continues to use versioned publication.
     pub(crate) fn remap_geometry_handles(
@@ -574,6 +610,7 @@ impl TextResourceArena {
             entry.version = 0;
             entry.value = Some(resource.clone());
             TextResourceHandle {
+                arena: self.namespace,
                 id: text_resource_id(index, entry.generation),
                 version: 0,
             }
@@ -585,7 +622,11 @@ impl TextResourceArena {
                 version: 0,
                 value: Some(resource.clone()),
             });
-            TextResourceHandle { id, version: 0 }
+            TextResourceHandle {
+                arena: self.namespace,
+                id,
+                version: 0,
+            }
         };
 
         self.add_stats(resource.as_ref());
@@ -594,6 +635,9 @@ impl TextResourceArena {
     }
 
     pub fn get(&self, handle: TextResourceHandle) -> Option<&TextResource> {
+        if handle.arena != self.namespace {
+            return None;
+        }
         let index = text_resource_slot(handle.id);
         let entry = self.entries.get(index)?;
         if text_resource_id(index, entry.generation) != handle.id || entry.version != handle.version
@@ -605,6 +649,9 @@ impl TextResourceArena {
 
     /// Share one immutable payload with a derived compiled resource snapshot.
     pub fn get_shared(&self, handle: TextResourceHandle) -> Option<Arc<TextResource>> {
+        if handle.arena != self.namespace {
+            return None;
+        }
         let index = text_resource_slot(handle.id);
         let entry = self.entries.get(index)?;
         if text_resource_id(index, entry.generation) != handle.id || entry.version != handle.version
@@ -622,6 +669,7 @@ impl TextResourceArena {
         }
         entry.value.as_ref()?;
         Some(TextResourceHandle {
+            arena: self.namespace,
             id,
             version: entry.version,
         })
@@ -661,7 +709,11 @@ impl TextResourceArena {
         self.subtract_stats(previous.as_ref());
         self.add_stats(&resource);
         self.entries[index].value = Some(Arc::new(resource));
-        Ok(TextResourceHandle { id, version })
+        Ok(TextResourceHandle {
+            arena: self.namespace,
+            id,
+            version,
+        })
     }
 
     pub fn remove(&mut self, id: TextResourceId) -> Result<Arc<TextResource>, TextResourceError> {
@@ -851,6 +903,36 @@ mod tests {
         assert_eq!(arena.len(), 1);
         assert_eq!(arena.stats().glyphs, 5);
         assert_eq!(arena.get(handle).unwrap().source.as_ref(), "hello");
+    }
+
+    #[test]
+    fn same_slot_handle_from_another_arena_is_rejected() {
+        let mut first = TextResourceArena::new();
+        let mut second = TextResourceArena::new();
+        let a = first.insert(sample_text("first")).unwrap();
+        let b = second.insert(sample_text("second")).unwrap();
+
+        assert_eq!((a.id, a.version), (b.id, b.version));
+        assert_ne!(a.arena, b.arena);
+        assert!(first.get(b).is_none());
+        assert!(second.get(a).is_none());
+    }
+
+    #[test]
+    fn cloned_arena_requires_local_remap_but_shares_immutable_payloads() {
+        let mut source = TextResourceArena::new();
+        let source_handle = source.insert(sample_text("shared")).unwrap();
+        let source_payload = source.get_shared(source_handle).unwrap();
+
+        let mut cloned = source.clone();
+        cloned.fork_namespace();
+        let local_handle = cloned.current_handle(source_handle.id).unwrap();
+        let local_payload = cloned.get_shared(local_handle).unwrap();
+
+        assert_ne!(source_handle.arena, local_handle.arena);
+        assert!(cloned.get(source_handle).is_none());
+        assert!(source.get(local_handle).is_none());
+        assert!(Arc::ptr_eq(&source_payload, &local_payload));
     }
 
     #[test]
@@ -1105,6 +1187,7 @@ mod tests {
     #[test]
     fn glyph_outlines_are_separate_lazy_geometry_resources() {
         let text = TextResourceHandle {
+            arena: 0,
             id: TextResourceId::new(3),
             version: 1,
         };

--- a/crates/noon-core/src/semantic_store.rs
+++ b/crates/noon-core/src/semantic_store.rs
@@ -431,22 +431,30 @@ impl Clone for SemanticStore {
         let mut geometry_resources = self.geometry_resources.clone();
         let namespace = geometry_resources.fork_namespace();
         let mut text_resources = self.text_resources.clone();
+        let text_namespace = text_resources.fork_namespace();
         text_resources.remap_geometry_handles(|handle| {
             if self.geometry_resources.get(*handle).is_some() {
                 handle.arena = namespace;
             }
         });
+        let mut font_resources = self.font_resources.clone();
+        font_resources.fork_namespace();
         let mut slots = self.slots.clone();
         for slot in &mut slots {
             if let Some(node) = slot.node.as_mut() {
                 if let Some(state) = node.object_state.as_mut() {
-                    if let crate::SemanticObjectContent::Geometry(
-                        crate::StoredGeometry::Resource(handle),
-                    ) = &mut state.content
-                    {
-                        if self.geometry_resources.get(*handle).is_some() {
+                    match &mut state.content {
+                        crate::SemanticObjectContent::Geometry(
+                            crate::StoredGeometry::Resource(handle),
+                        ) if self.geometry_resources.get(*handle).is_some() => {
                             handle.arena = namespace;
                         }
+                        crate::SemanticObjectContent::Text(handle)
+                            if self.text_resources.get(*handle).is_some() =>
+                        {
+                            handle.arena = text_namespace;
+                        }
+                        _ => {}
                     }
                 }
             }
@@ -455,7 +463,7 @@ impl Clone for SemanticStore {
             identity: SemanticStoreIdentity::default(),
             geometry_resources,
             text_resources,
-            font_resources: self.font_resources.clone(),
+            font_resources,
             slots,
             free_head: self.free_head,
             live_nodes: self.live_nodes,
@@ -1233,7 +1241,10 @@ mod tests {
 
     #[test]
     fn resources_are_store_scoped_and_clones_share_only_immutable_payloads() {
-        use crate::{GeometryResource, SemanticObjectContent, StoredGeometry, VectorPath};
+        use crate::{
+            FontFaceIdentity, GeometryResource, Rect, SemanticObjectContent, StoredGeometry,
+            TextResource, TextSourceKind, Vec2, VectorPath,
+        };
         use std::sync::Arc;
         let mut first = SemanticStore::new();
         let mut second = SemanticStore::new();
@@ -1248,6 +1259,31 @@ mod tests {
         // The low-level store fixture can contain invalid state; cloning must not legitimize it.
         let foreign =
             first.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Resource(b)));
+        let text = first
+            .text_resources
+            .insert(TextResource {
+                source: Arc::from(""),
+                kind: TextSourceKind::Plain,
+                runs: Arc::from([]),
+                vector_items: Arc::from([]),
+                render_items: Arc::from([]),
+                parts: Arc::from([]),
+                bounds: Rect::new(Vec2::ZERO, Vec2::ZERO),
+                baseline: 0.0,
+                layout_artifact: None,
+            })
+            .unwrap();
+        let text_node = first.insert_semantic_object(SemanticObjectState::new(text));
+        let face = FontFaceIdentity {
+            family: Arc::from("Test Sans"),
+            face_key: Arc::from("test-sans"),
+            face_index: 0,
+            variation_key: Arc::from(""),
+        };
+        let font = first
+            .font_resources
+            .intern_face(&face, Arc::<[u8]>::from([1, 2, 3]))
+            .unwrap();
         let cloned = first.clone();
         let SemanticObjectContent::Geometry(StoredGeometry::Resource(c)) =
             cloned.semantic_object_state_checked(node).unwrap().content
@@ -1267,6 +1303,28 @@ mod tests {
             SemanticObjectContent::Geometry(StoredGeometry::Resource(b))
         );
         assert!(cloned.geometry_resources().get(b).is_none());
+        let SemanticObjectContent::Text(cloned_text) = cloned
+            .semantic_object_state_checked(text_node)
+            .unwrap()
+            .content
+        else {
+            panic!("text resource content")
+        };
+        assert_ne!(text.arena, cloned_text.arena);
+        assert!(first.text_resources().get(cloned_text).is_none());
+        assert!(cloned.text_resources().get(text).is_none());
+        assert!(Arc::ptr_eq(
+            &first.text_resources().get_shared(text).unwrap(),
+            &cloned.text_resources().get_shared(cloned_text).unwrap(),
+        ));
+        let cloned_font = cloned.font_resources().handle_for_face(&face).unwrap();
+        assert_ne!(font.arena, cloned_font.arena);
+        assert!(first.font_resources().get(cloned_font).is_none());
+        assert!(cloned.font_resources().get(font).is_none());
+        assert!(Arc::ptr_eq(
+            &first.font_resources().get_shared(font).unwrap(),
+            &cloned.font_resources().get_shared(cloned_font).unwrap(),
+        ));
     }
 
     fn object(id: u64) -> ObjectDefinition {

--- a/crates/noon-core/src/semantic_text_resources.rs
+++ b/crates/noon-core/src/semantic_text_resources.rs
@@ -68,3 +68,44 @@ impl SemanticStore {
             .expect("text resource preflighted"))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::{Rect, TextSourceKind, Vec2};
+
+    fn empty_text() -> TextResource {
+        TextResource {
+            source: Arc::from(""),
+            kind: TextSourceKind::Plain,
+            runs: Arc::from([]),
+            vector_items: Arc::from([]),
+            render_items: Arc::from([]),
+            parts: Arc::from([]),
+            bounds: Rect::new(Vec2::ZERO, Vec2::ZERO),
+            baseline: 0.0,
+            layout_artifact: None,
+        }
+    }
+
+    #[test]
+    fn canonical_import_rebinds_text_to_the_target_store_arena() {
+        let mut source_texts = TextResourceArena::new();
+        let source = source_texts.insert(empty_text()).unwrap();
+        let source_resource = source_texts.get(source).unwrap().clone();
+        let mut target = SemanticStore::new();
+        let local = target
+            .import_text_resource(
+                source_resource,
+                &FontResourceArena::new(),
+                &GeometryResourceArena::new(),
+            )
+            .unwrap();
+
+        assert_ne!(source.arena, local.arena);
+        assert!(target.text_resources().get(source).is_none());
+        assert!(target.text_resources().get(local).is_some());
+    }
+}

--- a/crates/noon-render-wgpu/src/gpu/retained_text.rs
+++ b/crates/noon-render-wgpu/src/gpu/retained_text.rs
@@ -2141,6 +2141,7 @@ mod tests {
     fn outline_key(glyph_id: GlyphId) -> OutlineKey {
         OutlineKey {
             font: FontResourceHandle {
+                arena: 0,
                 id: FontResourceId::new(1),
                 version: 0,
             },

--- a/crates/noon-runtime/src/reactive/retained_text_family.rs
+++ b/crates/noon-runtime/src/reactive/retained_text_family.rs
@@ -395,6 +395,7 @@ mod tests {
 
     fn text_handle() -> TextResourceHandle {
         TextResourceHandle {
+            arena: 0,
             id: TextResourceId::new(11),
             version: 0,
         }

--- a/crates/noon-runtime/src/spatial_index.rs
+++ b/crates/noon-runtime/src/spatial_index.rs
@@ -515,6 +515,7 @@ mod tests {
             objects: vec![crate::FrameObjectState {
                 id: ObjectId::new(0),
                 content: ObjectContentRef::Text(TextResourceHandle {
+                    arena: 0,
                     id: TextResourceId::new(3),
                     version: 0,
                 }),

--- a/crates/noon-runtime/tests/instant_property_assignment.rs
+++ b/crates/noon-runtime/tests/instant_property_assignment.rs
@@ -8,6 +8,7 @@ use noon_runtime::SceneInstance;
 
 fn text_handle() -> TextResourceHandle {
     TextResourceHandle {
+        arena: 0,
         id: TextResourceId::new(41),
         version: 7,
     }

--- a/crates/noon-text-atlas/tests/gpu_residency_churn.rs
+++ b/crates/noon-text-atlas/tests/gpu_residency_churn.rs
@@ -11,6 +11,7 @@ use noon_text_raster::{
 fn glyph_key(glyph_id: u16) -> GlyphRasterKey {
     GlyphRasterKey {
         font: FontResourceHandle {
+            arena: 0,
             id: FontResourceId::new(0),
             version: 0,
         },

--- a/crates/noon-text-atlas/tests/gpu_upload.rs
+++ b/crates/noon-text-atlas/tests/gpu_upload.rs
@@ -11,6 +11,7 @@ use noon_text_raster::{
 fn glyph_key(glyph_id: u16) -> GlyphRasterKey {
     GlyphRasterKey {
         font: FontResourceHandle {
+            arena: 0,
             id: FontResourceId::new(0),
             version: 0,
         },

--- a/crates/noon-text-render-wgpu/src/gpu.rs
+++ b/crates/noon-text-render-wgpu/src/gpu.rs
@@ -744,6 +744,7 @@ mod tests {
     fn raster_key(glyph_id: u16) -> GlyphRasterKey {
         GlyphRasterKey {
             font: FontResourceHandle {
+                arena: 0,
                 id: FontResourceId::new(0),
                 version: 0,
             },
@@ -792,6 +793,7 @@ mod tests {
 
     fn text_handle() -> TextResourceHandle {
         TextResourceHandle {
+            arena: 0,
             id: TextResourceId::new(0),
             version: 0,
         }

--- a/crates/noon-text-render-wgpu/tests/live_atlas_pages.rs
+++ b/crates/noon-text-render-wgpu/tests/live_atlas_pages.rs
@@ -15,6 +15,7 @@ use noon_text_render_wgpu::{
 fn raster_key(glyph_id: u16) -> GlyphRasterKey {
     GlyphRasterKey {
         font: FontResourceHandle {
+            arena: 0,
             id: FontResourceId::new(0),
             version: 0,
         },
@@ -26,6 +27,7 @@ fn raster_key(glyph_id: u16) -> GlyphRasterKey {
 
 fn text_handle() -> TextResourceHandle {
     TextResourceHandle {
+        arena: 0,
         id: TextResourceId::new(0),
         version: 0,
     }

--- a/crates/noon-web/src/canonical_retained_engine_player.rs
+++ b/crates/noon-web/src/canonical_retained_engine_player.rs
@@ -616,7 +616,26 @@ mod tests {
 
         assert_family_midpoint(&forward_mirror, text_id, circle_id);
         assert_family_midpoint(&direct_mirror, text_id, circle_id);
-        assert_eq!(forward_mirror.frame(), direct_mirror.frame());
+        let forward_frame = forward_mirror.frame().unwrap();
+        let direct_frame = direct_mirror.frame().unwrap();
+        assert_eq!(
+            crate::determinism::normalized_frame_value(forward_frame),
+            crate::determinism::normalized_frame_value(direct_frame),
+        );
+        for (forward_object, direct_object) in
+            forward_frame.objects.iter().zip(&direct_frame.objects)
+        {
+            assert_eq!(forward_object.text_bounds, direct_object.text_bounds);
+            if let (Some(forward_text), Some(direct_text)) =
+                (forward_object.text(), direct_object.text())
+            {
+                assert_ne!(forward_text.arena, direct_text.arena);
+                assert_eq!(
+                    forward_mirror.resources().texts().get(forward_text),
+                    direct_mirror.resources().texts().get(direct_text),
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/noon-web/src/retained_execution_resources.rs
+++ b/crates/noon-web/src/retained_execution_resources.rs
@@ -28,9 +28,10 @@ impl InstalledRetainedExecutionMirror {
     pub fn from_bundle_bytes(bytes: &[u8]) -> Result<Self, InstalledExecutionError> {
         let resources = RetainedResourceBundle::decode_binary(bytes)?.install()?;
         Ok(Self {
-            wire: RetainedExecutionFrameMirror::with_render_geometries(
+            wire: RetainedExecutionFrameMirror::with_installed_resources(
                 resources.render_geometry_session(),
                 resources.render_geometries(),
+                resources.text_handle_remap(),
             ),
             resources,
             resolved: None,
@@ -185,7 +186,7 @@ impl InstalledRetainedExecutionMirror {
         let frame = wire
             .frame()
             .ok_or(InstalledExecutionError::MissingWireFrame)?;
-        self.resolve_wire_frame(frame)
+        Ok(self.resolve_wire_frame(frame))
     }
 
     fn rebuild_resolved_snapshot(&mut self) -> Result<(), InstalledExecutionError> {
@@ -193,25 +194,15 @@ impl InstalledRetainedExecutionMirror {
             .wire
             .frame()
             .ok_or(InstalledExecutionError::MissingWireFrame)?;
-        self.resolved = Some(self.resolve_wire_frame(wire)?);
+        self.resolved = Some(self.resolve_wire_frame(wire));
         Ok(())
     }
 
-    fn resolve_wire_frame(&self, wire: &FrameState) -> Result<FrameState, InstalledExecutionError> {
-        let mut resolved = wire.clone();
-        for object in &mut resolved.objects {
-            if let ObjectContentRef::Text(wire_handle) = object.content {
-                let transport = wire_handle.into();
-                let local = self.resources.resolve_text_handle(transport).ok_or(
-                    InstalledExecutionError::UnknownTextResource {
-                        id: transport.id,
-                        version: transport.version,
-                    },
-                )?;
-                object.content = ObjectContentRef::Text(local);
-            }
-        }
-        Ok(resolved)
+    fn resolve_wire_frame(&self, wire: &FrameState) -> FrameState {
+        // The wire mirror resolves every transport key through this installed bundle
+        // before it constructs a `FrameState`; cloned snapshots therefore retain only
+        // checked renderer-local handles.
+        wire.clone()
     }
 
     fn apply_resolved_incremental(

--- a/crates/noon-web/src/retained_execution_transport.rs
+++ b/crates/noon-web/src/retained_execution_transport.rs
@@ -5,7 +5,7 @@ use std::{
 
 use noon_core::{
     Camera2DState, GeometryRef, ObjectContentRef, ObjectId, Rect, Style, TextResourceHandle,
-    TextResourceId, Transform2D,
+    Transform2D,
 };
 use noon_runtime::{FrameChanges, FrameObjectState, FrameState};
 use serde::{Deserialize, Serialize};
@@ -26,19 +26,13 @@ pub struct TransportTextResourceHandle {
     pub version: u64,
 }
 
-impl From<TextResourceHandle> for TransportTextResourceHandle {
-    fn from(value: TextResourceHandle) -> Self {
+impl TransportTextResourceHandle {
+    /// Encode a source handle as an opaque key scoped to the paired resource bundle.
+    /// The worker must resolve this key through `InstalledRetainedResources`; it is
+    /// deliberately not a serializable core arena handle.
+    pub(crate) const fn from_source_handle(value: TextResourceHandle) -> Self {
         Self {
             id: value.id.get(),
-            version: value.version,
-        }
-    }
-}
-
-impl From<TransportTextResourceHandle> for TextResourceHandle {
-    fn from(value: TransportTextResourceHandle) -> Self {
-        Self {
-            id: TextResourceId::new(value.id),
             version: value.version,
         }
     }
@@ -58,17 +52,8 @@ impl From<&ObjectContentRef> for TransportObjectContent {
                 geometry: geometry.clone(),
             },
             ObjectContentRef::Text(text) => Self::Text {
-                text: (*text).into(),
+                text: TransportTextResourceHandle::from_source_handle(*text),
             },
-        }
-    }
-}
-
-impl From<TransportObjectContent> for ObjectContentRef {
-    fn from(value: TransportObjectContent) -> Self {
-        match value {
-            TransportObjectContent::Geometry { geometry } => Self::Geometry(geometry),
-            TransportObjectContent::Text { text } => Self::Text(text.into()),
         }
     }
 }
@@ -137,6 +122,7 @@ pub enum RetainedExecutionTransportError {
     AmbiguousRenderGeometry(TransportSlotId),
     MissingCompiledRenderResource(TransportSlotId),
     InvalidRenderTransform(TransportSlotId),
+    UnknownTextResource(TransportTextResourceHandle),
 }
 
 impl std::fmt::Display for RetainedExecutionTransportError {
@@ -224,6 +210,11 @@ impl std::fmt::Display for RetainedExecutionTransportError {
                 formatter,
                 "retained slot {}:{} has an invalid render transform",
                 slot.slot, slot.generation
+            ),
+            Self::UnknownTextResource(handle) => write!(
+                formatter,
+                "unknown retained transport text resource {}@{}",
+                handle.id, handle.version
             ),
         }
     }
@@ -386,6 +377,7 @@ pub struct RetainedExecutionFrameMirror {
     slot_indices: HashMap<TransportSlotId, usize>,
     render_geometries: Arc<[Arc<GeometryRef>]>,
     resource_session: Option<u32>,
+    text_handles: HashMap<TransportTextResourceHandle, TextResourceHandle>,
     camera: Camera2DState,
     frame: Option<FrameState>,
 }
@@ -399,6 +391,36 @@ impl RetainedExecutionFrameMirror {
             resource_session: session,
             render_geometries: geometries,
             ..Self::default()
+        }
+    }
+
+    pub(crate) fn with_installed_resources(
+        session: Option<u32>,
+        geometries: Arc<[Arc<GeometryRef>]>,
+        text_handles: HashMap<TransportTextResourceHandle, TextResourceHandle>,
+    ) -> Self {
+        Self {
+            resource_session: session,
+            render_geometries: geometries,
+            text_handles,
+            ..Self::default()
+        }
+    }
+
+    fn resolve_content(
+        &self,
+        content: &TransportObjectContent,
+    ) -> Result<ObjectContentRef, RetainedExecutionTransportError> {
+        match content {
+            TransportObjectContent::Geometry { geometry } => {
+                Ok(ObjectContentRef::Geometry(geometry.clone()))
+            }
+            TransportObjectContent::Text { text } => self
+                .text_handles
+                .get(text)
+                .copied()
+                .map(ObjectContentRef::Text)
+                .ok_or(RetainedExecutionTransportError::UnknownTextResource(*text)),
         }
     }
 
@@ -515,17 +537,25 @@ impl RetainedExecutionFrameMirror {
             .iter()
             .map(|object| self.resolve_render_geometry(object, delta.session))
             .collect::<Result<Vec<_>, _>>()?;
-        self.slots = objects.iter().map(|object| object.slot).collect();
-        self.slot_indices = self
-            .slots
+        let frame_objects = objects
+            .iter()
+            .map(|object| {
+                self.resolve_content(&object.content)
+                    .map(|content| frame_object(object, content))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let slots = objects.iter().map(|object| object.slot).collect::<Vec<_>>();
+        let slot_indices = slots
             .iter()
             .copied()
             .enumerate()
             .map(|(index, slot)| (slot, index))
             .collect();
+        self.slots = slots;
+        self.slot_indices = slot_indices;
         self.frame = Some(FrameState {
             time: delta.time,
-            objects: objects.iter().map(frame_object).collect(),
+            objects: frame_objects,
             presences: objects.iter().map(|object| object.presence).collect(),
             reveals: objects.iter().map(|object| object.reveal).collect(),
             morphs: objects.iter().map(|object| object.morph).collect(),
@@ -569,20 +599,20 @@ impl RetainedExecutionFrameMirror {
                     object.slot,
                 ));
             }
-            let content: ObjectContentRef = object.content.clone().into();
+            let content = self.resolve_content(&object.content)?;
             if !incremental_content_identity_matches(&current.content, &content) {
                 return Err(RetainedExecutionTransportError::ContentIdentityChanged(
                     object.slot,
                 ));
             }
             let geometry = self.resolve_render_geometry(object, delta.session)?;
-            updates.push((index, object, geometry));
+            updates.push((index, object, geometry, content));
         }
         // Validate all rows and resource references before mutating the live mirror.
         let frame = self.frame.as_mut().expect("validated retained frame");
         let mut changed = Vec::with_capacity(updates.len());
-        for (index, object, geometry) in updates {
-            frame.objects[index] = frame_object(object);
+        for (index, object, geometry, content) in updates {
+            frame.objects[index] = frame_object(object, content);
             frame.presences[index] = object.presence;
             frame.reveals[index] = object.reveal;
             frame.morphs[index] = object.morph;
@@ -714,10 +744,13 @@ fn validate_object_state(
     Ok(())
 }
 
-fn frame_object(object: &RetainedTransportObjectState) -> FrameObjectState {
+fn frame_object(
+    object: &RetainedTransportObjectState,
+    content: ObjectContentRef,
+) -> FrameObjectState {
     FrameObjectState {
         id: object.object,
-        content: object.content.clone().into(),
+        content,
         transform: object.transform,
         style: object.style,
         appearance: object.appearance,
@@ -731,8 +764,43 @@ mod tests {
 
     use super::*;
 
+    fn test_mirror() -> RetainedExecutionFrameMirror {
+        let handles = [
+            TextResourceHandle {
+                arena: 0,
+                id: TextResourceId::new(7),
+                version: 3,
+            },
+            TextResourceHandle {
+                arena: 0,
+                id: TextResourceId::new(8),
+                version: 1,
+            },
+        ]
+        .into_iter()
+        .map(|handle| {
+            (
+                TransportTextResourceHandle::from_source_handle(handle),
+                handle,
+            )
+        })
+        .collect();
+        RetainedExecutionFrameMirror::with_installed_resources(None, Arc::from([]), handles)
+    }
+
+    fn test_mirror_with_render_geometries(
+        session: u32,
+        geometries: Arc<[Arc<GeometryRef>]>,
+    ) -> RetainedExecutionFrameMirror {
+        let mut mirror = test_mirror();
+        mirror.resource_session = Some(session);
+        mirror.render_geometries = geometries;
+        mirror
+    }
+
     fn mixed_frame() -> FrameState {
         let text = TextResourceHandle {
+            arena: 0,
             id: TextResourceId::new(7),
             version: 3,
         };
@@ -788,11 +856,25 @@ mod tests {
 
         let json = serde_json::to_string(&delta).unwrap();
         let decoded: RetainedExecutionDeltaEnvelope = serde_json::from_str(&json).unwrap();
-        let mut mirror = RetainedExecutionFrameMirror::default();
+        let mut mirror = test_mirror();
         let (outcome, changes) = mirror.apply(decoded).unwrap();
         assert_eq!(outcome, RetainedTransportApplyOutcome::Applied);
         assert!(changes.is_all());
         assert_eq!(mirror.frame().unwrap(), &frame);
+    }
+
+    #[test]
+    fn wire_text_requires_an_installed_resource_remap() {
+        let frame = mixed_frame();
+        let delta = RetainedExecutionDeltaEncoder::new(4)
+            .encode_snapshot(&frame, Camera2DState::default())
+            .unwrap();
+        let mut mirror = RetainedExecutionFrameMirror::default();
+        assert!(matches!(
+            mirror.apply(delta),
+            Err(RetainedExecutionTransportError::UnknownTextResource(_))
+        ));
+        assert!(mirror.frame().is_none());
     }
 
     #[test]
@@ -802,7 +884,7 @@ mod tests {
         let initial = encoder
             .encode_snapshot(&frame, Camera2DState::default())
             .unwrap();
-        let mut mirror = RetainedExecutionFrameMirror::default();
+        let mut mirror = test_mirror();
         mirror.apply(initial).unwrap();
 
         let mut updated = frame.clone();
@@ -829,7 +911,7 @@ mod tests {
         let initial = encoder
             .encode_snapshot(&frame, Camera2DState::default())
             .unwrap();
-        let mut mirror = RetainedExecutionFrameMirror::default();
+        let mut mirror = test_mirror();
         mirror.apply(initial).unwrap();
 
         let mut updated = frame.clone();
@@ -861,11 +943,12 @@ mod tests {
         let initial = encoder
             .encode_snapshot(&frame, Camera2DState::default())
             .unwrap();
-        let mut mirror = RetainedExecutionFrameMirror::default();
+        let mut mirror = test_mirror();
         mirror.apply(initial).unwrap();
 
         let mut changed = frame.clone();
         changed.objects[1].content = ObjectContentRef::Text(TextResourceHandle {
+            arena: 0,
             id: TextResourceId::new(8),
             version: 1,
         });
@@ -890,7 +973,7 @@ mod tests {
         let initial = encoder
             .encode_snapshot(&frame, Camera2DState::default())
             .unwrap();
-        let mut mirror = RetainedExecutionFrameMirror::default();
+        let mut mirror = test_mirror();
         mirror.apply(initial).unwrap();
 
         let mut changed = frame.clone();
@@ -933,7 +1016,7 @@ mod tests {
         frame.render_transforms[0] = Some(Transform2D::IDENTITY);
         let mut encoder =
             RetainedExecutionDeltaEncoder::with_render_geometries(4, resources.clone());
-        let mut mirror = RetainedExecutionFrameMirror::with_render_geometries(Some(4), resources);
+        let mut mirror = test_mirror_with_render_geometries(4, resources);
         for (step, time) in [0.0, 0.25, 0.75, 0.0].into_iter().enumerate() {
             frame.time = time;
             frame.morphs[0] = time as f32;
@@ -982,7 +1065,7 @@ mod tests {
     fn invalid_later_resource_row_does_not_publish_earlier_rows_or_consume_sequence() {
         let frame = mixed_frame();
         let mut encoder = RetainedExecutionDeltaEncoder::new(4);
-        let mut mirror = RetainedExecutionFrameMirror::default();
+        let mut mirror = test_mirror();
         mirror
             .apply(
                 encoder
@@ -1024,7 +1107,7 @@ mod tests {
         let delta = encoder
             .encode_snapshot(&frame, Camera2DState::default())
             .unwrap();
-        let mut mirror = RetainedExecutionFrameMirror::with_render_geometries(Some(4), resources);
+        let mut mirror = test_mirror_with_render_geometries(4, resources);
         assert!(matches!(
             mirror.apply(delta),
             Err(RetainedExecutionTransportError::InvalidRenderGeometryResource(0))

--- a/crates/noon-web/src/retained_execution_transport.rs
+++ b/crates/noon-web/src/retained_execution_transport.rs
@@ -383,17 +383,6 @@ pub struct RetainedExecutionFrameMirror {
 }
 
 impl RetainedExecutionFrameMirror {
-    pub(crate) fn with_render_geometries(
-        session: Option<u32>,
-        geometries: Arc<[Arc<GeometryRef>]>,
-    ) -> Self {
-        Self {
-            resource_session: session,
-            render_geometries: geometries,
-            ..Self::default()
-        }
-    }
-
     pub(crate) fn with_installed_resources(
         session: Option<u32>,
         geometries: Arc<[Arc<GeometryRef>]>,

--- a/crates/noon-web/src/retained_resource_mutation_encoder.rs
+++ b/crates/noon-web/src/retained_resource_mutation_encoder.rs
@@ -107,7 +107,10 @@ mod tests {
         let fonts = FontResourceArena::new();
         let bundle =
             RetainedResourceBundle::capture([handle], &texts, &geometries, &fonts).unwrap();
-        (handle.into(), bundle)
+        (
+            TransportTextResourceHandle::from_source_handle(handle),
+            bundle,
+        )
     }
 
     #[test]

--- a/crates/noon-web/src/retained_resource_mutation_transport.rs
+++ b/crates/noon-web/src/retained_resource_mutation_transport.rs
@@ -235,7 +235,10 @@ mod tests {
         let fonts = FontResourceArena::new();
         let bundle =
             RetainedResourceBundle::capture([handle], &texts, &geometries, &fonts).unwrap();
-        (handle.into(), bundle)
+        (
+            TransportTextResourceHandle::from_source_handle(handle),
+            bundle,
+        )
     }
 
     #[test]

--- a/crates/noon-web/src/retained_resource_transport.rs
+++ b/crates/noon-web/src/retained_resource_transport.rs
@@ -209,9 +209,11 @@ impl RetainedResourceBundle {
         let mut text_entries = Vec::with_capacity(text_handles.len());
 
         for handle in text_handles {
-            let resource = texts
-                .get(handle)
-                .ok_or_else(|| RetainedResourceTransportError::UnknownText(handle.into()))?;
+            let resource = texts.get(handle).ok_or_else(|| {
+                RetainedResourceTransportError::UnknownText(
+                    TransportTextResourceHandle::from_source_handle(handle),
+                )
+            })?;
             for vector in resource.vector_items.iter() {
                 geometry_handles.insert(vector.geometry);
             }
@@ -232,7 +234,7 @@ impl RetainedResourceBundle {
                     });
             }
             text_entries.push(TransportTextEntry {
-                handle: handle.into(),
+                handle: TransportTextResourceHandle::from_source_handle(handle),
                 resource: TransportTextResource::from_core(resource),
             });
         }
@@ -463,6 +465,12 @@ impl InstalledRetainedResources {
         transport: TransportTextResourceHandle,
     ) -> Option<TextResourceHandle> {
         self.text_handles.get(&transport).copied()
+    }
+
+    pub(crate) fn text_handle_remap(
+        &self,
+    ) -> HashMap<TransportTextResourceHandle, TextResourceHandle> {
+        self.text_handles.clone()
     }
 }
 
@@ -1217,8 +1225,10 @@ mod tests {
         let installed = decoded.install().unwrap();
 
         for original in original_handles {
-            let transport = TransportTextResourceHandle::from(original);
+            let transport = TransportTextResourceHandle::from_source_handle(original);
             let local = installed.resolve_text_handle(transport).unwrap();
+            assert_ne!(original.arena, local.arena);
+            assert!(installed.texts().get(original).is_none());
             let resource = installed.texts().get(local).unwrap();
             assert!(matches!(
                 resource.kind,

--- a/crates/noon-web/src/retained_scene_spec_runtime.rs
+++ b/crates/noon-web/src/retained_scene_spec_runtime.rs
@@ -293,13 +293,24 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![camera, text_id, circle]
         );
-        assert_eq!(canonical.scene().objects(), split.scene().objects());
         assert_eq!(canonical.tracks(), split.tracks());
         assert_eq!(canonical.camera_object(), split.camera_object());
-        assert_eq!(canonical.compile().unwrap(), split.compile().unwrap());
+        // Independent lowering owns distinct arena namespaces; compare the
+        // executable observations and resolved content, not process-local handles.
+        let mut canonical_runtime = noon_runtime::SceneInstance::new(canonical.compile().unwrap());
+        let mut split_runtime = noon_runtime::SceneInstance::new(split.compile().unwrap());
+        for time in [0.0, 0.5, 1.0] {
+            canonical_runtime.seek(time).unwrap();
+            split_runtime.seek(time).unwrap();
+            assert_eq!(
+                crate::determinism::normalized_frame_value(canonical_runtime.frame()),
+                crate::determinism::normalized_frame_value(split_runtime.frame()),
+            );
+        }
 
         let canonical_handle = canonical.scene().objects()[1].content.text().unwrap();
         let split_handle = split.scene().objects()[1].content.text().unwrap();
+        assert_ne!(canonical_handle.arena, split_handle.arena);
         assert_eq!(
             canonical.scene().texts().get(canonical_handle),
             split.scene().texts().get(split_handle)

--- a/crates/noon-web/src/retained_text_family_transport.rs
+++ b/crates/noon-web/src/retained_text_family_transport.rs
@@ -83,6 +83,7 @@ mod tests {
 
     fn text_handle() -> TextResourceHandle {
         TextResourceHandle {
+            arena: 0,
             id: TextResourceId::new(17),
             version: 0,
         }


### PR DESCRIPTION
Text and font handles now identify their owning resource arena as well as their local ID and version. Two independent scenes can both allocate local resource 0 without either resolving the other scene’s content. Cloning a semantic store forks its resource scope and remaps its owned references. Explicit worker codecs map incoming wire IDs to installed handles at the transport boundary.

Advances #957 and #959; stacked on #1116. SemanticStore owns resource provenance; compiled plans retain dependency-closed immutable resources. This introduces no new in-process serialization or compatibility layer. Existing external codecs remain owned for deletion/consolidation by #959.

Tests cover foreign handles, store clone remapping, text/font lookup and equivalent independently authored content. Resource lookups remain indexed; resource creation/clone is the scope boundary. Paired `shared_text` Rust/Python examples continue to exercise the shared runtime and renderer.

Validation: these exact implementation commits passed the integration branch’s full Rust/web/WASM gate and shared/transferable plus WebGPU/WebGL browser suites. This PR isolates them onto the now-green #1116 base without re-running duplicate local build suites; its exact stack combination still requires CI qualification. `git diff --check codex/architecture-unified-content` passed.

Exact-stack CI at 05c8c962 passed all eight required jobs, including native surface presentation, browser checks, architecture guards and recovery. The superseded geometry-only mirror constructor was deleted after the first CI lint report. `bash scripts/architecture-ratchet.sh origin/master` passed locally.
