### PR TITLE
perf: record cold-start WASM and resource footprint

### DIFF
--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -124,7 +124,9 @@ jobs:
           fi
           changed_paths="$(git diff --name-only "$BASE_SHA" HEAD)"
           printf '%s\n' "$changed_paths"
+          node --test scripts/cold-start-risk-classifier.test.mjs
           printf '%s\n' "$changed_paths" | node scripts/pr-risk-classifier.mjs >> "$GITHUB_OUTPUT"
+          printf '%s\n' "$changed_paths" | node scripts/cold-start-risk-classifier.mjs >> "$GITHUB_OUTPUT"
 
       - name: Use stable Rust and WASM target
         run: |
@@ -188,6 +190,34 @@ jobs:
         run: |
           npm install --no-save --ignore-scripts playwright@1.62.1 pngjs@7.0.0
           npx playwright install chromium
+
+      - name: Check preloaded cold-start footprint
+        if: steps.browser-risk.outputs.cold_start == 'true'
+        id: cold-start
+        env:
+          NOON_COLD_START_BACKEND: webgl
+          NOON_COLD_START_EXAMPLES: geometry:parity-create-circle
+          NOON_COLD_START_ARTIFACT: browser-smoke-artifacts/cold-start/footprint.json
+        run: |
+          SECONDS=0
+          set +e
+          node scripts/playground-cold-start.mjs
+          status=$?
+          set -e
+          echo "seconds=$SECONDS" >> "$GITHUB_OUTPUT"
+          if [[ -f browser-smoke-artifacts/cold-start/footprint.json ]]; then
+            cat browser-smoke-artifacts/cold-start/footprint.json
+          fi
+          exit "$status"
+
+      - name: Upload cold-start footprint
+        if: always() && steps.browser-risk.outputs.cold_start == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: cold-start-footprint-${{ github.event.pull_request.number }}
+          path: browser-smoke-artifacts/cold-start/footprint.json
+          if-no-files-found: ignore
+          retention-days: 7
 
       - name: Check deterministic playback
         id: deterministic-replay
@@ -283,6 +313,8 @@ jobs:
         env:
           START_EPOCH: ${{ steps.browser-clock.outputs.epoch }}
           PACKAGE_SECONDS: ${{ steps.browser-package.outputs.seconds }}
+          COLD_START_REQUIRED: ${{ steps.browser-risk.outputs.cold_start }}
+          COLD_START_SECONDS: ${{ steps.cold-start.outputs.seconds }}
           REPLAY_SECONDS: ${{ steps.deterministic-replay.outputs.seconds }}
           AUTHORING_SECONDS: ${{ steps.manim-authoring.outputs.seconds }}
           RETAINED_REQUIRED: ${{ steps.browser-risk.outputs.retained_execution }}
@@ -308,6 +340,11 @@ jobs:
             fi
           }
 
+          cold_start_duration="skipped"
+          if [[ "$COLD_START_REQUIRED" == "true" ]]; then
+            cold_start_duration="$(display_seconds "$COLD_START_SECONDS")"
+          fi
+
           retained_duration="skipped"
           if [[ "$RETAINED_REQUIRED" == "true" ]]; then
             retained_duration="$(display_seconds "$RETAINED_SECONDS")"
@@ -329,6 +366,7 @@ jobs:
             echo "| Phase | Duration |"
             echo "| --- | ---: |"
             echo "| Browser package | $(display_seconds "$PACKAGE_SECONDS") |"
+            echo "| Preloaded cold start | $cold_start_duration |"
             echo "| Deterministic replay | $(display_seconds "$REPLAY_SECONDS") |"
             echo "| Manim authoring | $(display_seconds "$AUTHORING_SECONDS") |"
             echo "| Canonical retained execution | $retained_duration |"
@@ -338,6 +376,7 @@ jobs:
             echo "| Host-updater diagnostics | $(display_seconds "$HOST_UPDATER_SECONDS") |"
             echo "| Measured browser path | $(display_seconds "$total") |"
             echo
+            echo "Cold-start benchmark escalation required: ${COLD_START_REQUIRED:-unknown}."
             echo "Retained execution escalation required: ${RETAINED_REQUIRED:-unknown}."
             echo "Render mode-switch escalation required: ${MODE_SWITCH_REQUIRED:-unknown}."
             echo "Renderer-critical WebGL escalation required: ${RENDERER_CRITICAL:-unknown}."

--- a/scripts/build-web-demo.sh
+++ b/scripts/build-web-demo.sh
@@ -58,6 +58,7 @@ if [[ "$skip_web_preflight" != "1" ]]; then
   node --check scripts/perf-compare.mjs
   node --check scripts/perf-corpus.mjs
   node --check scripts/host-callback-perf.mjs
+  node --check scripts/playground-cold-start.mjs
   node --check scripts/deterministic-replay-smoke.mjs
   node --check scripts/cross-language-parity.mjs
   node --check scripts/manim-compat-smoke.mjs

--- a/scripts/cold-start-risk-classifier.mjs
+++ b/scripts/cold-start-risk-classifier.mjs
@@ -1,0 +1,47 @@
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const coldStartBenchmarkPaths = new Set([
+  ".github/workflows/pr-fast.yml",
+  "scripts/build-web-demo.sh",
+  "scripts/cold-start-risk-classifier.mjs",
+  "scripts/cold-start-risk-classifier.test.mjs",
+  "scripts/playground-cold-start.mjs",
+  "web/live-authoring-bootstrap.js",
+  "web/main.js",
+  "web/playground-cold-start-metrics.js",
+  "web/playground-cold-start-metrics.test.mjs",
+  "web/python-worker.source.js",
+]);
+
+function normalizeRepositoryPath(path) {
+  return String(path ?? "").trim().replaceAll("\\", "/").replace(/^\.\//, "");
+}
+
+export function requiresColdStartBenchmark(path) {
+  return coldStartBenchmarkPaths.has(normalizeRepositoryPath(path));
+}
+
+export function classifyColdStartRisk(paths) {
+  if (!Array.isArray(paths)) {
+    throw new TypeError("cold-start risk paths must be an array");
+  }
+  const normalizedPaths = [...new Set(paths.map(normalizeRepositoryPath).filter(Boolean))];
+  const benchmarkPaths = normalizedPaths.filter(requiresColdStartBenchmark).sort();
+  return Object.freeze({
+    coldStartBenchmark: benchmarkPaths.length > 0,
+    coldStartBenchmarkPaths: Object.freeze(benchmarkPaths),
+  });
+}
+
+function runCli() {
+  const paths = readFileSync(0, "utf8").split(/\r?\n/);
+  const risk = classifyColdStartRisk(paths);
+  process.stdout.write(`cold_start=${risk.coldStartBenchmark}\n`);
+  const detail = risk.coldStartBenchmark ? risk.coldStartBenchmarkPaths.join(", ") : "none";
+  process.stderr.write(`cold-start benchmark risk paths: ${detail}\n`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runCli();
+}

--- a/scripts/cold-start-risk-classifier.test.mjs
+++ b/scripts/cold-start-risk-classifier.test.mjs
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  classifyColdStartRisk,
+  requiresColdStartBenchmark,
+} from "./cold-start-risk-classifier.mjs";
+
+const startupChanges = [
+  ".github/workflows/pr-fast.yml",
+  "scripts/build-web-demo.sh",
+  "scripts/cold-start-risk-classifier.mjs",
+  "scripts/cold-start-risk-classifier.test.mjs",
+  "scripts/playground-cold-start.mjs",
+  "web/live-authoring-bootstrap.js",
+  "web/main.js",
+  "web/playground-cold-start-metrics.js",
+  "web/playground-cold-start-metrics.test.mjs",
+  "web/python-worker.source.js",
+];
+
+test("startup and measurement changes escalate the preloaded cold-start benchmark", () => {
+  const risk = classifyColdStartRisk(startupChanges);
+  assert.equal(risk.coldStartBenchmark, true);
+  assert.deepEqual(risk.coldStartBenchmarkPaths, startupChanges.slice().sort());
+  for (const path of startupChanges) {
+    assert.equal(requiresColdStartBenchmark(path), true, path);
+  }
+});
+
+test("ordinary runtime and documentation changes do not escalate cold-start measurement", () => {
+  const paths = [
+    "README.md",
+    "docs/architecture.md",
+    "crates/noon-core/src/lib.rs",
+    "web/playground-gallery.js",
+    "scripts/browser-smoke.mjs",
+    "scripts/pr-risk-classifier.mjs",
+  ];
+  const risk = classifyColdStartRisk(paths);
+  assert.equal(risk.coldStartBenchmark, false);
+  assert.deepEqual(risk.coldStartBenchmarkPaths, []);
+});
+
+test("cold-start classifier normalizes paths and de-duplicates triggers", () => {
+  const risk = classifyColdStartRisk([
+    "./web/main.js",
+    "web\\main.js",
+    "web/main.js",
+    "",
+  ]);
+  assert.equal(risk.coldStartBenchmark, true);
+  assert.deepEqual(risk.coldStartBenchmarkPaths, ["web/main.js"]);
+});
+
+test("cold-start classifier rejects non-array inputs", () => {
+  assert.throws(() => classifyColdStartRisk(null), /must be an array/);
+});

--- a/scripts/playground-cold-start.mjs
+++ b/scripts/playground-cold-start.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawn, spawnSync } from "node:child_process";
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, stat, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -11,6 +11,7 @@ import {
   classifyWorkerUrl,
   preloadedColdStartMilestones,
   summarizeAuthoringStartup,
+  summarizeResourceFootprint,
   summarizeWorkers,
 } from "../web/playground-cold-start-metrics.js";
 
@@ -29,6 +30,9 @@ const artifactPath = path.resolve(
   repoRoot,
   process.env.NOON_COLD_START_ARTIFACT ?? `perf-artifacts/playground-cold-start-${backend}.json`,
 );
+const noonWasmPath = path.join(repoRoot, "web", "pkg", "noon_web_bg.wasm");
+const noonWasmPackageBytes = (await stat(noonWasmPath)).size;
+assert.ok(noonWasmPackageBytes > 0, "built Noon WASM package must be non-empty");
 
 const commit = spawnSync("git", ["rev-parse", "HEAD"], { cwd: repoRoot, encoding: "utf8" });
 const commitSha = commit.status === 0 ? commit.stdout.trim() : null;
@@ -54,12 +58,23 @@ try {
       const page = await browser.newPage({ viewport: { width: 1200, height: 900 } });
       const failures = [];
       const workers = [];
+      const workerHandles = [];
+      const workerRoleCounts = { authoring: 0, engine: 0, render: 0, other: 0 };
       let authoringWorker = null;
       const origin = monotonicNow();
       page.on("worker", (worker) => {
         const event = { url: worker.url(), atMs: monotonicNow() - origin };
+        const role = classifyWorkerUrl(event.url);
+        const roleIndex = workerRoleCounts[role];
+        workerRoleCounts[role] += 1;
         workers.push(event);
-        if (classifyWorkerUrl(event.url) === "authoring") {
+        workerHandles.push({
+          worker,
+          name: `${role}-${roleIndex}`,
+          role,
+          url: event.url,
+        });
+        if (role === "authoring") {
           authoringWorker = worker;
         }
       });
@@ -112,6 +127,24 @@ try {
       assert.ok(authoringWorkerEvent, "cold preload must record Python worker creation");
       const preloadStarted = origin + authoringWorkerEvent.atMs;
 
+      const resourceContexts = [
+        {
+          name: "page",
+          role: "page",
+          entries: await page.evaluate(resourceTimingSnapshot),
+        },
+      ];
+      for (const handle of workerHandles) {
+        resourceContexts.push({
+          name: handle.name,
+          role: handle.role,
+          entries: await handle.worker.evaluate(resourceTimingSnapshot),
+        });
+      }
+      const resourceFootprint = summarizeResourceFootprint(resourceContexts, {
+        noonWasmPackageBytes,
+      });
+
       const status = await page.locator("#status").evaluate((node) => ({
         ...node.dataset,
         text: node.textContent,
@@ -131,6 +164,7 @@ try {
           firstMetrics,
         }),
         authoringStartup,
+        resourceFootprint,
         workers: workerSummary,
         status,
         metrics,
@@ -142,6 +176,9 @@ try {
           `(module graph ${format(authoringStartup.moduleGraphLoadMs)} ms, ` +
           `critical ${authoringStartup.criticalResource} ${format(authoringStartup.criticalResourceMs)} ms, ` +
           `imports ${format(authoringStartup.compatibilityImportInstallMs)} ms), ` +
+          `Noon WASM ${formatBytes(resourceFootprint.noonWasm.packageBytes)} × ` +
+          `${resourceFootprint.noonWasm.observedOwnerCount} observed owners = ` +
+          `${formatBytes(resourceFootprint.noonWasm.packageBytesAcrossObservedOwners)} package footprint, ` +
           `${report.workers.total} workers (${JSON.stringify(report.workers.byRole)})`,
       );
     } finally {
@@ -150,7 +187,7 @@ try {
   }
 
   const artifact = {
-    schemaVersion: 2,
+    schemaVersion: 3,
     benchmark: "Noon public playground preloaded cold-start topology",
     generatedAt: new Date().toISOString(),
     commit: commitSha,
@@ -163,6 +200,10 @@ try {
       totalMemoryBytes: os.totalmem(),
       node: process.version,
     },
+    package: {
+      noonWasmPath: path.relative(repoRoot, noonWasmPath),
+      noonWasmPackageBytes,
+    },
     configuration: {
       backend,
       examples,
@@ -170,7 +211,7 @@ try {
       automaticPreload: true,
     },
     note:
-      "firstMetrics is the first metrics poll reporting positive object/draw counts; it is an observable proxy, not an exact GPU presentation timestamp. preloadStarted is the Python authoring worker creation event. authoringStartup measures that persistent worker from worker time-origin through readiness: static worker module-graph loading (including the remote Pyodide module import) is measured separately, then Noon WASM, loadPyodide(), and the compatibility bundle start in parallel, followed by Rust authoring binding, compatibility FS install, and eager Python import/install phases.",
+      "firstMetrics is the first metrics poll reporting positive object/draw counts; it is an observable proxy, not an exact GPU presentation timestamp. preloadStarted is the Python authoring worker creation event. authoringStartup measures that persistent worker from worker time-origin through readiness. resourceFootprint is collected from PerformanceResourceTiming on the page and every observed live worker after first metrics. Browser transferSize may be zero for cached or cross-origin entries; encodedBodySize/decodedBodySize are reported separately. Non-finite resource duration values are normalized to zero because duration is diagnostic-only and is not used in byte accounting. packageBytesAcrossObservedOwners multiplies the built noon_web_bg.wasm file size by workers that independently report that WASM resource; it is a package-footprint proxy, not a claim about resident WebAssembly memory.",
     cases,
   };
   await mkdir(path.dirname(artifactPath), { recursive: true });
@@ -193,6 +234,17 @@ async function waitForServer() {
     await new Promise((resolve) => setTimeout(resolve, 100));
   }
   throw new Error(`cold-start server did not start: ${lastError}\n${serverOutput}`);
+}
+
+function resourceTimingSnapshot() {
+  return performance.getEntriesByType("resource").map((entry) => ({
+    name: entry.name,
+    initiatorType: entry.initiatorType,
+    transferSize: entry.transferSize,
+    encodedBodySize: entry.encodedBodySize,
+    decodedBodySize: entry.decodedBodySize,
+    duration: Number.isFinite(entry.duration) && entry.duration >= 0 ? entry.duration : 0,
+  }));
 }
 
 function parseExamples(value) {
@@ -243,4 +295,12 @@ function positiveInteger(value, name) {
 
 function format(value) {
   return Number(value).toFixed(2);
+}
+
+function formatBytes(value) {
+  const bytes = Number(value);
+  if (!Number.isFinite(bytes) || bytes < 0) return "n/a";
+  if (bytes < 1024) return `${bytes.toFixed(0)} B`;
+  if (bytes < 1024 ** 2) return `${(bytes / 1024).toFixed(1)} KiB`;
+  return `${(bytes / 1024 ** 2).toFixed(2)} MiB`;
 }

--- a/web/playground-cold-start-metrics.js
+++ b/web/playground-cold-start-metrics.js
@@ -131,6 +131,133 @@ export function summarizeWorkers(events) {
   });
 }
 
+export function classifyColdStartResource(url) {
+  const value = String(url ?? "");
+  if (/\/noon_web_bg\.wasm(?:[?#]|$)/.test(value)) return "noon-wasm";
+  if (/\/pyodide\.asm\.wasm(?:[?#]|$)/.test(value)) return "pyodide-wasm";
+  if (/\/pyodide(?:\.mjs|\.js)(?:[?#]|$)/.test(value)) return "pyodide";
+  if (/\.wasm(?:[?#]|$)/.test(value)) return "wasm";
+  if (/compat-bundle(?:\.[a-f0-9]+)?\.json(?:[?#]|$)/.test(value)) return "compat-bundle";
+  return "other";
+}
+
+export function summarizeResourceFootprint(contexts, { noonWasmPackageBytes } = {}) {
+  if (!Array.isArray(contexts) || contexts.length === 0) {
+    throw new TypeError("resource footprint contexts must be a non-empty array");
+  }
+  if (!Number.isSafeInteger(noonWasmPackageBytes) || noonWasmPackageBytes <= 0) {
+    throw new TypeError("Noon WASM package bytes must be a positive safe integer");
+  }
+
+  const rows = [];
+  const contextSummaries = [];
+  for (const context of contexts) {
+    if (
+      !isRecord(context) ||
+      typeof context.name !== "string" ||
+      context.name.trim() === "" ||
+      typeof context.role !== "string" ||
+      context.role.trim() === "" ||
+      !Array.isArray(context.entries)
+    ) {
+      throw new TypeError("resource footprint context must contain name, role, and entries");
+    }
+    let transferBytes = 0;
+    let encodedBodyBytes = 0;
+    let decodedBodyBytes = 0;
+    let wasmRequests = 0;
+    for (const entry of context.entries) {
+      const checked = validateResourceTimingEntry(entry);
+      const kind = classifyColdStartResource(checked.name);
+      if (kind === "noon-wasm" || kind === "pyodide-wasm" || kind === "wasm") {
+        wasmRequests += 1;
+      }
+      transferBytes += checked.transferSize;
+      encodedBodyBytes += checked.encodedBodySize;
+      decodedBodyBytes += checked.decodedBodySize;
+      rows.push({
+        context: context.name,
+        role: context.role,
+        kind,
+        ...checked,
+      });
+    }
+    contextSummaries.push(
+      Object.freeze({
+        name: context.name,
+        role: context.role,
+        requests: context.entries.length,
+        transferBytes,
+        encodedBodyBytes,
+        decodedBodyBytes,
+        wasmRequests,
+      }),
+    );
+  }
+
+  const noonWasmRows = rows.filter(({ kind }) => kind === "noon-wasm");
+  const wasmRows = rows.filter(
+    ({ kind }) => kind === "noon-wasm" || kind === "pyodide-wasm" || kind === "wasm",
+  );
+  const noonWasmOwners = [...new Set(noonWasmRows.map(({ context }) => context))].sort();
+  const uniqueWasmUrls = [...new Set(wasmRows.map(({ name }) => name))].sort();
+  const sum = (values, field) => values.reduce((total, value) => total + value[field], 0);
+  const largestResources = rows
+    .slice()
+    .sort((left, right) => {
+      const leftSize = Math.max(left.encodedBodySize, left.transferSize);
+      const rightSize = Math.max(right.encodedBodySize, right.transferSize);
+      return rightSize - leftSize || left.name.localeCompare(right.name);
+    })
+    .slice(0, 20)
+    .map((row) => Object.freeze({ ...row }));
+
+  return Object.freeze({
+    contextCount: contexts.length,
+    requestCount: rows.length,
+    transferBytes: sum(rows, "transferSize"),
+    encodedBodyBytes: sum(rows, "encodedBodySize"),
+    decodedBodyBytes: sum(rows, "decodedBodySize"),
+    wasmRequestCount: wasmRows.length,
+    uniqueWasmUrls: Object.freeze(uniqueWasmUrls),
+    noonWasm: Object.freeze({
+      requestCount: noonWasmRows.length,
+      observedOwnerCount: noonWasmOwners.length,
+      owners: Object.freeze(noonWasmOwners),
+      transferBytes: sum(noonWasmRows, "transferSize"),
+      encodedBodyBytes: sum(noonWasmRows, "encodedBodySize"),
+      decodedBodyBytes: sum(noonWasmRows, "decodedBodySize"),
+      packageBytes: noonWasmPackageBytes,
+      packageBytesAcrossObservedOwners: noonWasmPackageBytes * noonWasmOwners.length,
+    }),
+    contexts: Object.freeze(contextSummaries),
+    largestResources: Object.freeze(largestResources),
+  });
+}
+
+function validateResourceTimingEntry(entry) {
+  if (!isRecord(entry) || typeof entry.name !== "string" || entry.name.trim() === "") {
+    throw new TypeError("resource timing entry must contain a non-empty name");
+  }
+  const checked = {
+    name: entry.name,
+    initiatorType: typeof entry.initiatorType === "string" ? entry.initiatorType : "",
+  };
+  for (const field of [
+    "transferSize",
+    "encodedBodySize",
+    "decodedBodySize",
+    "duration",
+  ]) {
+    const value = entry[field];
+    if (!Number.isFinite(value) || value < 0) {
+      throw new TypeError(`resource timing ${field} must be finite and non-negative`);
+    }
+    checked[field] = value;
+  }
+  return checked;
+}
+
 function validateOrderedMilestones(timestamps, required, label) {
   for (const name of required) {
     const value = timestamps?.[name];

--- a/web/playground-cold-start-metrics.test.mjs
+++ b/web/playground-cold-start-metrics.test.mjs
@@ -1,10 +1,12 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
+  classifyColdStartResource,
   classifyWorkerUrl,
   coldStartMilestones,
   preloadedColdStartMilestones,
   summarizeAuthoringStartup,
+  summarizeResourceFootprint,
   summarizeWorkers,
   validateAuthoringStartupMetrics,
 } from "./playground-cold-start-metrics.js";
@@ -129,6 +131,108 @@ test("authoring startup metrics reject malformed diagnostic payloads", () => {
         compatibilitySourceChars: 1,
       }),
     /totalMs/,
+  );
+});
+
+test("cold-start resource classification distinguishes Noon and Pyodide WASM", () => {
+  assert.equal(classifyColdStartResource("http://localhost/web/pkg/noon_web_bg.wasm"), "noon-wasm");
+  assert.equal(
+    classifyColdStartResource("https://cdn.jsdelivr.net/pyodide/v314.0.5/full/pyodide.asm.wasm"),
+    "pyodide-wasm",
+  );
+  assert.equal(
+    classifyColdStartResource("https://cdn.jsdelivr.net/pyodide/v314.0.5/full/pyodide.mjs"),
+    "pyodide",
+  );
+  assert.equal(classifyColdStartResource("http://localhost/runtime.wasm?x=1"), "wasm");
+  assert.equal(
+    classifyColdStartResource("http://localhost/web/python/compat-bundle.abc123.json"),
+    "compat-bundle",
+  );
+});
+
+test("resource footprint preserves per-context transfer sizes and counts repeated Noon WASM owners", () => {
+  const entry = (name, transferSize, encodedBodySize, decodedBodySize, duration = 10) => ({
+    name,
+    initiatorType: "fetch",
+    transferSize,
+    encodedBodySize,
+    decodedBodySize,
+    duration,
+  });
+  const summary = summarizeResourceFootprint(
+    [
+      {
+        name: "page",
+        role: "page",
+        entries: [entry("http://localhost/web/main.js", 1200, 900, 900)],
+      },
+      {
+        name: "authoring-0",
+        role: "authoring",
+        entries: [
+          entry("http://localhost/web/pkg/noon_web_bg.wasm", 1_000_300, 1_000_000, 1_000_000, 100),
+          entry(
+            "https://cdn.jsdelivr.net/pyodide/v314.0.5/full/pyodide.asm.wasm",
+            2_000_300,
+            2_000_000,
+            2_000_000,
+            200,
+          ),
+        ],
+      },
+      {
+        name: "engine-0",
+        role: "engine",
+        entries: [entry("http://localhost/web/pkg/noon_web_bg.wasm", 0, 1_000_000, 1_000_000, 80)],
+      },
+      {
+        name: "render-0",
+        role: "render",
+        entries: [entry("http://localhost/web/pkg/noon_web_bg.wasm", 0, 1_000_000, 1_000_000, 70)],
+      },
+    ],
+    { noonWasmPackageBytes: 1_000_000 },
+  );
+
+  assert.equal(summary.contextCount, 4);
+  assert.equal(summary.requestCount, 5);
+  assert.equal(summary.wasmRequestCount, 4);
+  assert.equal(summary.noonWasm.requestCount, 3);
+  assert.equal(summary.noonWasm.observedOwnerCount, 3);
+  assert.deepEqual(summary.noonWasm.owners, ["authoring-0", "engine-0", "render-0"]);
+  assert.equal(summary.noonWasm.packageBytes, 1_000_000);
+  assert.equal(summary.noonWasm.packageBytesAcrossObservedOwners, 3_000_000);
+  assert.equal(summary.noonWasm.transferBytes, 1_000_300);
+  assert.equal(summary.noonWasm.encodedBodyBytes, 3_000_000);
+  assert.equal(summary.transferBytes, 3_001_800);
+  assert.equal(summary.encodedBodyBytes, 5_000_900);
+  assert.equal(summary.contexts.find(({ role }) => role === "authoring").wasmRequests, 2);
+  assert.equal(summary.largestResources[0].kind, "pyodide-wasm");
+});
+
+test("resource footprint rejects missing package size and malformed timing fields", () => {
+  const contexts = [
+    {
+      name: "page",
+      role: "page",
+      entries: [
+        {
+          name: "http://localhost/main.js",
+          initiatorType: "script",
+          transferSize: 1,
+          encodedBodySize: 1,
+          decodedBodySize: 1,
+          duration: 1,
+        },
+      ],
+    },
+  ];
+  assert.throws(() => summarizeResourceFootprint(contexts, {}), /package bytes/);
+  contexts[0].entries[0].transferSize = Number.NaN;
+  assert.throws(
+    () => summarizeResourceFootprint(contexts, { noonWasmPackageBytes: 1 }),
+    /transferSize/,
   );
 });
 


### PR DESCRIPTION
## Summary

- extend the preloaded cold-start benchmark with page + worker `PerformanceResourceTiming` footprint data
- distinguish Noon WASM, Pyodide WASM, other WASM, Pyodide JS, and compatibility-bundle resources
- record the built `noon_web_bg.wasm` file size and multiply it only by workers that independently report that WASM resource
- keep browser `transferSize`, `encodedBodySize`, and `decodedBodySize` separate so cache hits are not misreported as zero-sized resources
- run one WebGL `parity-create-circle` cold-start case in PR Fast Gate only when startup/measurement plumbing changes, and upload the JSON artifact
- add preflight syntax coverage for the cold-start benchmark itself

## Why

#1114 measured the authoring-worker critical path at ~2.77 s and showed Noon WASM (~2.41 s) and Pyodide (~2.31 s) dominate while compatibility import/install is ~278 ms. Before specializing the authoring package under #642 C6.3/C6.4, we need concrete byte/owner evidence rather than inferring duplication from source imports.

This PR is intentionally isolated from the active #1115/#1116 Phase A stack. It does not modify `crates/noon-web`, `python-worker.source.js`, semantic execution, renderer ownership, or runtime topology.

## Metric semantics

`resourceFootprint` is sampled after first observable metrics from the page and every live worker. The benchmark reports:

- per-context request and byte totals
- total WASM requests and unique WASM URLs
- observed contexts that independently report `noon_web_bg.wasm`
- browser-reported transfer/encoded/decoded sizes
- built Noon WASM package size
- `packageBytesAcrossObservedOwners = package file size × observed Noon-WASM owners`
- the 20 largest observed resources

`packageBytesAcrossObservedOwners` is explicitly a package-footprint proxy, **not** a claim about resident WebAssembly memory.

## Hosted measurement

Exact-head PR Fast Gate on the dev / `NOON_WASM_SKIP_OPT=1` WebGL build (`parity-create-circle`) produced:

- navigation → first observable metrics: **4046 ms**
- preload → first observable metrics: **3806 ms**
- Python authoring worker ready: **2644 ms**
- Noon WASM init in authoring worker: **2358 ms**
- Pyodide init: **2216 ms**
- compatibility import/install: **206 ms**
- workers: **1 authoring + 1 engine + 1 render**
- built `noon_web_bg.wasm`: **151,154,644 bytes** (~144.15 MiB)
- observed Noon-WASM owners: **3** — `authoring-0`, `engine-0`, `render-0`
- Noon-WASM encoded body across those owners: **453,463,932 bytes** (~432.46 MiB)
- Noon-WASM transfer bytes in this no-cache local-server measurement: **453,464,832 bytes**
- Pyodide WASM encoded body: **3,435,946 bytes**; decoded body: **9,597,831 bytes**
- total observed transfer bytes across all contexts: **461,155,240 bytes**

The dev/no-opt package size is **not** a production transfer-size claim. The important topology result is that the same Noon WASM package is independently instantiated by all three live worker owners on the preloaded path. Browser/network cache policy may reduce repeated production transfer, but it does not remove the separate worker/package ownership boundary.

This is strong evidence for C6.3/C6.4 package/worker specialization once the active #1115/#1116 semantic/web ownership stack settles. In particular, the Python authoring worker should not need renderer/WGPU code, while the engine should not need renderer canvas code.

## CI policy

The cold-start case runs only when its startup/measurement surfaces change (`main.js`, live-authoring bootstrap, Python-worker source, cold-start benchmark/metrics, build plumbing, or the PR risk policy/workflow). Ordinary PRs stay on the existing fast path.

## Validation

- exact-head web preflight and footprint unit coverage are green
- exact-head architecture and layer ratchets are green
- exact-head cold-start footprint browser measurement passed and uploaded its JSON artifact
- full Browser Fast and authoring-recovery workflows remain in progress at the time of this update

Refs #642 #953 #1114