### PR TITLE
perf: measure renderer-free authoring WASM specialization

### DIFF
--- a/.github/workflows/authoring-wasm-footprint.yml
+++ b/.github/workflows/authoring-wasm-footprint.yml
@@ -1,0 +1,110 @@
+name: Authoring WASM Footprint
+
+on:
+  pull_request:
+    paths:
+      - "crates/noon-web/Cargo.toml"
+      - "crates/noon-web/src/lib.rs"
+      - "scripts/build-web-authoring-package.sh"
+      - ".github/workflows/authoring-wasm-footprint.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: authoring-wasm-footprint-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  CARGO_INCREMENTAL: "0"
+  CARGO_PROFILE_DEV_DEBUG: "0"
+
+jobs:
+  measure:
+    name: Compare full and authoring WASM
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Use stable Rust and WASM target
+        run: |
+          rustup default stable
+          rustup target add wasm32-unknown-unknown
+
+      - name: Cache Cargo sources
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-sources-${{ hashFiles('Cargo.toml', 'crates/**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-sources-
+
+      - name: Install pinned wasm-pack
+        uses: taiki-e/install-action@e67fa11c4b9316fa714ddf0abed07a0c3143b95b # v2.87.4
+        with:
+          tool: wasm-pack@0.15.0
+          fallback: none
+
+      - name: Build full browser package
+        env:
+          NOON_SKIP_WEB_PREFLIGHT: "1"
+          NOON_SKIP_PLAYGROUND_TEST: "1"
+          NOON_WASM_PROFILE: "dev"
+          NOON_WASM_SKIP_OPT: "1"
+        run: bash scripts/build-web-demo.sh
+
+      - name: Build renderer-free authoring package
+        env:
+          NOON_WASM_PROFILE: "dev"
+          NOON_WASM_SKIP_OPT: "1"
+        run: bash scripts/build-web-authoring-package.sh
+
+      - name: Record package footprint
+        env:
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          mkdir -p browser-smoke-artifacts/authoring-wasm
+          node <<'NODE'
+          const fs = require("node:fs");
+          const path = require("node:path");
+
+          const fullPath = "web/pkg/noon_web_bg.wasm";
+          const authoringPath = "web/pkg-authoring/noon_web_bg.wasm";
+          const fullBytes = fs.statSync(fullPath).size;
+          const authoringBytes = fs.statSync(authoringPath).size;
+          const savedBytes = fullBytes - authoringBytes;
+          const savedFraction = fullBytes > 0 ? savedBytes / fullBytes : 0;
+          if (!(authoringBytes > 0 && authoringBytes < fullBytes)) {
+            throw new Error(
+              `authoring-only package must be smaller than full package: ${authoringBytes} vs ${fullBytes}`,
+            );
+          }
+          const report = {
+            schemaVersion: 1,
+            commit: process.env.PR_HEAD_SHA ?? null,
+            profile: "dev",
+            wasmOptSkipped: true,
+            full: { path: fullPath, bytes: fullBytes },
+            authoring: { path: authoringPath, bytes: authoringBytes },
+            savedBytes,
+            savedFraction,
+            authoringFraction: authoringBytes / fullBytes,
+            note:
+              "This is a package-size specialization experiment. It does not change the Python worker import or claim resident-memory savings.",
+          };
+          const output = "browser-smoke-artifacts/authoring-wasm/footprint.json";
+          fs.writeFileSync(output, `${JSON.stringify(report, null, 2)}\n`);
+          process.stdout.write(fs.readFileSync(output, "utf8"));
+          NODE
+
+      - name: Upload authoring WASM footprint
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: authoring-wasm-footprint-${{ github.event.pull_request.number }}
+          path: browser-smoke-artifacts/authoring-wasm/footprint.json
+          if-no-files-found: error
+          retention-days: 7

--- a/crates/noon-web/Cargo.toml
+++ b/crates/noon-web/Cargo.toml
@@ -8,6 +8,14 @@ description = "Browser-facing persistent runtime and live patch control for Noon
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[features]
+default = ["renderer"]
+renderer = [
+    "dep:noon-render-wgpu",
+    "dep:noon-text-render-wgpu",
+    "dep:wgpu",
+]
+
 [dependencies]
 ciborium = "0.2"
 noon = { path = "../noon" }
@@ -20,9 +28,9 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-noon-render-wgpu = { path = "../noon-render-wgpu", default-features = false, features = ["web"] }
-noon-text-render-wgpu = { path = "../noon-text-render-wgpu", default-features = false, features = ["web"] }
+noon-render-wgpu = { path = "../noon-render-wgpu", default-features = false, features = ["web"], optional = true }
+noon-text-render-wgpu = { path = "../noon-text-render-wgpu", default-features = false, features = ["web"], optional = true }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 web-sys = { version = "0.3", features = ["Event", "EventTarget", "HtmlCanvasElement", "OffscreenCanvas", "Performance", "Window"] }
-wgpu = { version = "30.0.1", default-features = false, features = ["std", "wgsl", "webgpu", "webgl"] }
+wgpu = { version = "30.0.1", default-features = false, features = ["std", "wgsl", "webgpu", "webgl"], optional = true }

--- a/crates/noon-web/src/lib.rs
+++ b/crates/noon-web/src/lib.rs
@@ -10,17 +10,18 @@ mod canonical_retained_engine_player;
 mod clock;
 mod composition;
 mod determinism;
-#[cfg(all(target_arch = "wasm32", debug_assertions))]
+#[cfg(all(feature = "renderer", target_arch = "wasm32", debug_assertions))]
 mod direct_execution_smoke;
+#[cfg(feature = "renderer")]
 mod execution_canvas;
 mod execution_transport;
 mod execution_wake;
 mod family_animation_authoring;
 mod family_bounds;
 mod family_write_authoring;
-#[cfg(any(target_arch = "wasm32", test))]
+#[cfg(all(feature = "renderer", any(target_arch = "wasm32", test)))]
 mod gpu_diagnostics;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "renderer", target_arch = "wasm32"))]
 mod gpu_timestamps;
 mod host_player;
 mod legacy;
@@ -43,6 +44,7 @@ mod retained_authoring_scene;
 mod retained_authoring_scene_spec;
 mod retained_authoring_tracks;
 mod retained_authoring_wire_scene;
+#[cfg(feature = "renderer")]
 mod retained_execution_canvas;
 mod retained_execution_resources;
 mod retained_execution_transport;
@@ -55,6 +57,7 @@ mod retained_resource_mutation_transport;
 mod retained_resource_transport;
 mod retained_scene_spec_runtime;
 mod retained_text_family_transport;
+#[cfg(feature = "renderer")]
 mod retained_typst_canvas;
 mod semantic_execution_player;
 mod semantic_snapshot;
@@ -69,9 +72,9 @@ pub use canonical_retained_engine_player::*;
 pub use clock::{ClockError, PlaybackClock};
 pub use composition::*;
 pub use determinism::*;
-#[cfg(all(target_arch = "wasm32", debug_assertions))]
+#[cfg(all(feature = "renderer", target_arch = "wasm32", debug_assertions))]
 pub use direct_execution_smoke::*;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "renderer", target_arch = "wasm32"))]
 pub use execution_canvas::*;
 pub use execution_transport::*;
 pub use execution_wake::*;
@@ -96,7 +99,7 @@ pub use retained_authoring_player::*;
 pub use retained_authoring_scene_spec::*;
 pub use retained_authoring_tracks::*;
 pub use retained_authoring_wire_scene::*;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "renderer", target_arch = "wasm32"))]
 pub use retained_execution_canvas::*;
 pub use retained_execution_resources::*;
 pub use retained_execution_transport::*;
@@ -108,7 +111,7 @@ pub use retained_resource_mutation_encoder::*;
 pub use retained_resource_mutation_transport::*;
 pub use retained_resource_transport::*;
 pub use retained_text_family_transport::*;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "renderer", target_arch = "wasm32"))]
 pub use retained_typst_canvas::*;
 pub use semantic_execution_player::*;
 pub use semantic_snapshot::*;

--- a/crates/noon-web/src/reactive_player.rs
+++ b/crates/noon-web/src/reactive_player.rs
@@ -130,7 +130,7 @@ impl TimedScenePlayer {
     }
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "renderer", target_arch = "wasm32"))]
 mod wasm {
     use noon_core::{NativeEventSource, NativeStateSource, SignalId, Vec2};
     use noon_render_wgpu::{Camera2D, FramePreparer, GpuRenderer};

--- a/scripts/build-web-authoring-package.sh
+++ b/scripts/build-web-authoring-package.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+noon_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$noon_root"
+
+wasm_profile="${NOON_WASM_PROFILE:-release}"
+case "$wasm_profile" in
+  dev|release) ;;
+  *)
+    echo "unsupported NOON_WASM_PROFILE: $wasm_profile (expected dev or release)" >&2
+    exit 2
+    ;;
+esac
+
+out_dir="${NOON_AUTHORING_WASM_OUT_DIR:-web/pkg-authoring}"
+wasm_pack_args=(
+  build crates/noon-web
+  --target web
+  --out-dir "../../${out_dir}"
+  "--${wasm_profile}"
+)
+if [[ "${NOON_WASM_SKIP_OPT:-0}" == "1" ]]; then
+  wasm_pack_args+=(--no-opt)
+fi
+# wasm-pack forwards Cargo feature flags and everything after them to cargo,
+# so keep wasm-pack-owned flags (such as --no-opt) before this tail.
+wasm_pack_args+=(--no-default-features)
+
+wasm-pack "${wasm_pack_args[@]}"
+
+wasm_file="${out_dir}/noon_web_bg.wasm"
+js_file="${out_dir}/noon_web.js"
+[[ -s "$wasm_file" ]] || {
+  echo "authoring-only Noon WASM package is missing or empty: $wasm_file" >&2
+  exit 1
+}
+[[ -s "$js_file" ]] || {
+  echo "authoring-only Noon JS bindings are missing or empty: $js_file" >&2
+  exit 1
+}
+
+for symbol in WasmAuthoringStore RetainedNativeTextAuthoringHandle RetainedTypstAuthoringHandle; do
+  if ! grep -q "$symbol" "$js_file"; then
+    echo "authoring-only package is missing required export: $symbol" >&2
+    exit 1
+  fi
+done
+
+for symbol in ExecutionCanvasRenderer RetainedExecutionCanvasRenderer RetainedTypstCanvasRenderer; do
+  if grep -q "$symbol" "$js_file"; then
+    echo "authoring-only package unexpectedly exposes renderer symbol: $symbol" >&2
+    exit 1
+  fi
+done
+
+node - "$wasm_file" <<'NODE'
+const fs = require("node:fs");
+const wasmPath = process.argv[2];
+const bytes = fs.statSync(wasmPath).size;
+process.stdout.write(`${wasmPath}: ${bytes} bytes\n`);
+NODE


### PR DESCRIPTION
## Summary

- keep the existing full browser package behavior as the default `renderer` feature
- make the wasm32 WGPU/render dependencies optional and gate only renderer canvas/GPU modules behind that feature
- add a renderer-free `noon-web --no-default-features` authoring package build
- assert that required authoring exports remain while renderer exports are absent
- add a narrowly scoped CI workflow that builds both dev/no-opt packages and uploads a byte comparison artifact

## Why

The post-#1116 C6 measurement still shows the same monolithic Noon WASM package independently owned by the authoring, engine and render workers. On the refreshed #1116 merge result, `noon_web_bg.wasm` is 152,032,469 bytes and the three observed owners account for a 456,097,407-byte package-footprint proxy. Authoring-worker Noon WASM init is also on the critical path at ~2.62 s.

The Python authoring worker does not need the canvas/WGPU renderer surface. Before changing its import or worker topology, this PR makes that separation buildable and measures the resulting package size. This is deliberately an experiment/qualification slice: it does **not** change the Python worker import, worker ownership, execution transport, or renderer runtime.

## Measured result

Exact-head `3f8a111bd2f8166c5e236db97bc0f0b029e5d31c`, dev/no-opt:

- full package: **152,032,469 bytes**
- renderer-free authoring package: **125,653,919 bytes**
- saved: **26,378,550 bytes**
- reduction: **17.35%**
- authoring package is **82.65%** of the full package

This is a material package reduction, so the decision rule is satisfied: after this measurement slice is merged, the next C6 slice should wire the Python authoring worker to `pkg-authoring` and re-run the protected cold-start/Product Gate measurements. The measurement does not by itself claim equivalent resident-memory savings.

## Validation

- default `noon-web` features preserve the current full renderer package
- authoring-only wasm build compiles with `--no-default-features`
- generated authoring bindings contain `WasmAuthoringStore`, `RetainedNativeTextAuthoringHandle`, and `RetainedTypstAuthoringHandle`
- generated authoring bindings do not contain `ExecutionCanvasRenderer`, `RetainedExecutionCanvasRenderer`, or `RetainedTypstCanvasRenderer`
- renderer-only reactive WASM canvas code is gated behind the `renderer` feature while CPU `TimedScenePlayer` remains available
- CI records full bytes, authoring bytes, saved bytes and fraction in `authoring-wasm-footprint-1120`

Refs #642