### PR TITLE
Route browser DOM input into canonical execution sessions

### DIFF
--- a/crates/noon-web/src/execution_canvas.rs
+++ b/crates/noon-web/src/execution_canvas.rs
@@ -1076,6 +1076,87 @@ mod wasm {
             self.apply_direct_native_input(move |direct| direct.emit_native_event(source))
         }
 
+        /// Deliver a DOM-normalized pointer position through the current typed
+        /// camera into the canonical session.
+        #[wasm_bindgen(js_name = nativePointerPosition)]
+        pub fn native_pointer_position(
+            &mut self,
+            normalized_x: f32,
+            normalized_y: f32,
+        ) -> Result<bool, JsValue> {
+            let position = self.normalized_pointer_world_position(normalized_x, normalized_y)?;
+            self.set_native_state_input(
+                NativeStateSource::PointerPosition,
+                NativeInputValue::Vec2(position),
+            )
+        }
+
+        /// Deliver one pointer button sample followed by its ordered edge event.
+        #[wasm_bindgen(js_name = nativePointerButton)]
+        pub fn native_pointer_button(
+            &mut self,
+            button: u8,
+            pressed: bool,
+        ) -> Result<bool, JsValue> {
+            self.apply_direct_native_input(move |direct| {
+                direct.set_native_state_input(
+                    NativeStateSource::PointerButton { button },
+                    NativeInputValue::Bool(pressed),
+                )?;
+                direct.emit_native_event(if pressed {
+                    NativeEventSource::PointerDown { button }
+                } else {
+                    NativeEventSource::PointerUp { button }
+                })
+            })
+        }
+
+        /// Deliver one keyboard state sample followed by its ordered edge event.
+        #[wasm_bindgen(js_name = nativeKey)]
+        pub fn native_key(&mut self, code: String, pressed: bool) -> Result<bool, JsValue> {
+            validate_native_name("key code", &code)?;
+            self.apply_direct_native_input(move |direct| {
+                direct.set_native_state_input(
+                    NativeStateSource::Key { code: code.clone() },
+                    NativeInputValue::Bool(pressed),
+                )?;
+                direct.emit_native_event(if pressed {
+                    NativeEventSource::KeyPress { code }
+                } else {
+                    NativeEventSource::KeyRelease { code }
+                })
+            })
+        }
+
+        /// Deliver one CSS-pixel wheel sample followed by its ordered event.
+        #[wasm_bindgen(js_name = nativeWheel)]
+        pub fn native_wheel(&mut self, x: f32, y: f32) -> Result<bool, JsValue> {
+            self.apply_direct_native_input(move |direct| {
+                direct.set_native_state_input(
+                    NativeStateSource::WheelDelta,
+                    NativeInputValue::Vec2(Vec2::new(x, y)),
+                )?;
+                direct.emit_native_event(NativeEventSource::Wheel)
+            })
+        }
+
+        /// Deliver one named scalar control sample.
+        #[wasm_bindgen(js_name = nativeControl)]
+        pub fn native_control(&mut self, name: String, value: f32) -> Result<bool, JsValue> {
+            validate_native_name("control name", &name)?;
+            self.set_native_state_input(
+                NativeStateSource::Control { name },
+                NativeInputValue::Scalar(value),
+            )
+        }
+
+        /// Deliver one ordered named-control commit event.
+        #[wasm_bindgen(js_name = nativeControlCommit)]
+        pub fn native_control_commit(&mut self, name: String) -> Result<bool, JsValue> {
+            validate_native_name("control name", &name)?;
+            self.emit_native_event(NativeEventSource::ControlCommit { name })
+        }
+
         fn apply_direct_native_input(
             &mut self,
             apply: impl FnOnce(&mut DirectExecutionSource) -> Result<(), JsValue>,
@@ -1090,6 +1171,24 @@ mod wasm {
             };
             self.sync_camera(camera)?;
             Ok(pending)
+        }
+
+        fn normalized_pointer_world_position(
+            &self,
+            normalized_x: f32,
+            normalized_y: f32,
+        ) -> Result<Vec2, JsValue> {
+            if !normalized_x.is_finite() || !normalized_y.is_finite() {
+                return Err(js_message("normalized pointer coordinates must be finite"));
+            }
+            let x = normalized_x.clamp(0.0, 1.0);
+            let y = normalized_y.clamp(0.0, 1.0);
+            let aspect = self.config.width as f32 / self.config.height.max(1) as f32;
+            let world_width = self.camera_height * aspect;
+            Ok(Vec2::new(
+                self.camera_center.x + (x - 0.5) * world_width,
+                self.camera_center.y + (0.5 - y) * self.camera_height,
+            ))
         }
 
         fn ensure_direct_source_idle(&self) -> Result<(), JsValue> {
@@ -1441,6 +1540,13 @@ mod wasm {
 
     fn js_value_message(value: JsValue) -> String {
         value.as_string().unwrap_or_else(|| format!("{value:?}"))
+    }
+
+    fn validate_native_name(kind: &str, value: &str) -> Result<(), JsValue> {
+        if value.trim().is_empty() {
+            return Err(js_message(&format!("{kind} must be a non-empty string")));
+        }
+        Ok(())
     }
 
     fn js_error(error: impl std::fmt::Display) -> JsValue {

--- a/crates/noon-web/src/execution_canvas.rs
+++ b/crates/noon-web/src/execution_canvas.rs
@@ -665,6 +665,87 @@ mod wasm {
             Ok(pending)
         }
 
+        /// Deliver a DOM-normalized pointer position through the current typed
+        /// camera into the canonical session.
+        #[wasm_bindgen(js_name = nativePointerPosition)]
+        pub fn native_pointer_position(
+            &mut self,
+            normalized_x: f32,
+            normalized_y: f32,
+        ) -> Result<bool, JsValue> {
+            let position = self.normalized_pointer_world_position(normalized_x, normalized_y)?;
+            self.set_native_state_input(
+                NativeStateSource::PointerPosition,
+                NativeInputValue::Vec2(position),
+            )
+        }
+
+        /// Deliver one pointer button sample followed by its ordered edge event.
+        #[wasm_bindgen(js_name = nativePointerButton)]
+        pub fn native_pointer_button(
+            &mut self,
+            button: u8,
+            pressed: bool,
+        ) -> Result<bool, JsValue> {
+            self.apply_direct_native_input(move |direct| {
+                direct.set_native_state_input(
+                    NativeStateSource::PointerButton { button },
+                    NativeInputValue::Bool(pressed),
+                )?;
+                direct.emit_native_event(if pressed {
+                    NativeEventSource::PointerDown { button }
+                } else {
+                    NativeEventSource::PointerUp { button }
+                })
+            })
+        }
+
+        /// Deliver one keyboard state sample followed by its ordered edge event.
+        #[wasm_bindgen(js_name = nativeKey)]
+        pub fn native_key(&mut self, code: String, pressed: bool) -> Result<bool, JsValue> {
+            validate_native_name("key code", &code)?;
+            self.apply_direct_native_input(move |direct| {
+                direct.set_native_state_input(
+                    NativeStateSource::Key { code: code.clone() },
+                    NativeInputValue::Bool(pressed),
+                )?;
+                direct.emit_native_event(if pressed {
+                    NativeEventSource::KeyPress { code }
+                } else {
+                    NativeEventSource::KeyRelease { code }
+                })
+            })
+        }
+
+        /// Deliver one CSS-pixel wheel sample followed by its ordered event.
+        #[wasm_bindgen(js_name = nativeWheel)]
+        pub fn native_wheel(&mut self, x: f32, y: f32) -> Result<bool, JsValue> {
+            self.apply_direct_native_input(move |direct| {
+                direct.set_native_state_input(
+                    NativeStateSource::WheelDelta,
+                    NativeInputValue::Vec2(Vec2::new(x, y)),
+                )?;
+                direct.emit_native_event(NativeEventSource::Wheel)
+            })
+        }
+
+        /// Deliver one named scalar control sample.
+        #[wasm_bindgen(js_name = nativeControl)]
+        pub fn native_control(&mut self, name: String, value: f32) -> Result<bool, JsValue> {
+            validate_native_name("control name", &name)?;
+            self.set_native_state_input(
+                NativeStateSource::Control { name },
+                NativeInputValue::Scalar(value),
+            )
+        }
+
+        /// Deliver one ordered named-control commit event.
+        #[wasm_bindgen(js_name = nativeControlCommit)]
+        pub fn native_control_commit(&mut self, name: String) -> Result<bool, JsValue> {
+            validate_native_name("control name", &name)?;
+            self.emit_native_event(NativeEventSource::ControlCommit { name })
+        }
+
         #[wasm_bindgen(js_name = objectCount)]
         pub fn object_count(&self) -> usize {
             self.source.live_object_count()
@@ -1074,87 +1155,6 @@ mod wasm {
         /// rejected occurrence does not consume the serial.
         pub fn emit_native_event(&mut self, source: NativeEventSource) -> Result<bool, JsValue> {
             self.apply_direct_native_input(move |direct| direct.emit_native_event(source))
-        }
-
-        /// Deliver a DOM-normalized pointer position through the current typed
-        /// camera into the canonical session.
-        #[wasm_bindgen(js_name = nativePointerPosition)]
-        pub fn native_pointer_position(
-            &mut self,
-            normalized_x: f32,
-            normalized_y: f32,
-        ) -> Result<bool, JsValue> {
-            let position = self.normalized_pointer_world_position(normalized_x, normalized_y)?;
-            self.set_native_state_input(
-                NativeStateSource::PointerPosition,
-                NativeInputValue::Vec2(position),
-            )
-        }
-
-        /// Deliver one pointer button sample followed by its ordered edge event.
-        #[wasm_bindgen(js_name = nativePointerButton)]
-        pub fn native_pointer_button(
-            &mut self,
-            button: u8,
-            pressed: bool,
-        ) -> Result<bool, JsValue> {
-            self.apply_direct_native_input(move |direct| {
-                direct.set_native_state_input(
-                    NativeStateSource::PointerButton { button },
-                    NativeInputValue::Bool(pressed),
-                )?;
-                direct.emit_native_event(if pressed {
-                    NativeEventSource::PointerDown { button }
-                } else {
-                    NativeEventSource::PointerUp { button }
-                })
-            })
-        }
-
-        /// Deliver one keyboard state sample followed by its ordered edge event.
-        #[wasm_bindgen(js_name = nativeKey)]
-        pub fn native_key(&mut self, code: String, pressed: bool) -> Result<bool, JsValue> {
-            validate_native_name("key code", &code)?;
-            self.apply_direct_native_input(move |direct| {
-                direct.set_native_state_input(
-                    NativeStateSource::Key { code: code.clone() },
-                    NativeInputValue::Bool(pressed),
-                )?;
-                direct.emit_native_event(if pressed {
-                    NativeEventSource::KeyPress { code }
-                } else {
-                    NativeEventSource::KeyRelease { code }
-                })
-            })
-        }
-
-        /// Deliver one CSS-pixel wheel sample followed by its ordered event.
-        #[wasm_bindgen(js_name = nativeWheel)]
-        pub fn native_wheel(&mut self, x: f32, y: f32) -> Result<bool, JsValue> {
-            self.apply_direct_native_input(move |direct| {
-                direct.set_native_state_input(
-                    NativeStateSource::WheelDelta,
-                    NativeInputValue::Vec2(Vec2::new(x, y)),
-                )?;
-                direct.emit_native_event(NativeEventSource::Wheel)
-            })
-        }
-
-        /// Deliver one named scalar control sample.
-        #[wasm_bindgen(js_name = nativeControl)]
-        pub fn native_control(&mut self, name: String, value: f32) -> Result<bool, JsValue> {
-            validate_native_name("control name", &name)?;
-            self.set_native_state_input(
-                NativeStateSource::Control { name },
-                NativeInputValue::Scalar(value),
-            )
-        }
-
-        /// Deliver one ordered named-control commit event.
-        #[wasm_bindgen(js_name = nativeControlCommit)]
-        pub fn native_control_commit(&mut self, name: String) -> Result<bool, JsValue> {
-            validate_native_name("control name", &name)?;
-            self.emit_native_event(NativeEventSource::ControlCommit { name })
         }
 
         fn apply_direct_native_input(

--- a/scripts/native-input-smoke.mjs
+++ b/scripts/native-input-smoke.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
+import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -11,6 +12,10 @@ const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, "..");
 const port = 4185;
 const baseUrl = `http://127.0.0.1:${port}`;
+const source = await readFile(
+  path.join(repoRoot, "web/python/examples/live_native_signals.py"),
+  "utf8",
+);
 
 let serverOutput = "";
 const server = spawn(
@@ -25,7 +30,7 @@ async function waitForServer() {
   let lastError = null;
   for (let attempt = 0; attempt < 80; attempt += 1) {
     try {
-      const response = await fetch(`${baseUrl}/web/manim-compat-smoke.html`);
+      const response = await fetch(`${baseUrl}/web/execution-worker-smoke.html`);
       if (response.ok) return;
       lastError = new Error(`HTTP ${response.status}`);
     } catch (error) {
@@ -42,6 +47,7 @@ function foregroundStats(buffer) {
   let weightedX = 0;
   let weight = 0;
   let changedPixels = 0;
+  let blue = 0;
   for (let y = 0; y < image.height; y += 1) {
     for (let x = 0; x < image.width; x += 1) {
       const offset = (y * image.width + x) * 4;
@@ -54,49 +60,49 @@ function foregroundStats(buffer) {
       changedPixels += 1;
       weightedX += x * distance;
       weight += distance;
+      blue += image.data[offset + 2];
     }
   }
   return {
     changedPixels,
     centroidX: weight === 0 ? Number.NaN : weightedX / weight,
+    meanBlue: changedPixels === 0 ? 0 : blue / changedPixels,
   };
 }
 
-async function presentCurrent(page) {
-  await page.evaluate(() => {
-    const player = window.__nativeInputPlayer;
-    if (!player.seek(player.time())) throw new Error("native input frame was not presented");
-  });
-  await page.evaluate(
-    () => new Promise((resolve) => requestAnimationFrame(() => resolve())),
-  );
+function differingPixels(beforeBuffer, afterBuffer) {
+  const before = PNG.sync.read(beforeBuffer);
+  const after = PNG.sync.read(afterBuffer);
+  assert.equal(before.width, after.width);
+  assert.equal(before.height, after.height);
+  let differing = 0;
+  for (let offset = 0; offset < before.data.length; offset += 4) {
+    const distance =
+      Math.abs(before.data[offset] - after.data[offset]) +
+      Math.abs(before.data[offset + 1] - after.data[offset + 1]) +
+      Math.abs(before.data[offset + 2] - after.data[offset + 2]) +
+      Math.abs(before.data[offset + 3] - after.data[offset + 3]);
+    if (distance >= 32) differing += 1;
+  }
+  return differing;
 }
 
-const source = `
-from noon import *
-
-class NativeInputDemo(Scene):
-    def construct(self):
-        square = Square(side_length=0.9, color=BLUE)
-        self.add(square)
-
-        pointer = self.pointer_position_signal()
-        self.bind_position(square, pointer)
-
-        visible = self.key_state_signal("Space", False)
-        self.bind_presence(square, visible)
-
-        opacity = self.control_signal("opacity", 1.0)
-        self.bind_opacity(square, opacity)
-
-        clicks = self.pointer_down_events(0)
-        self.bind_rotation(square, clicks)
-
-        self.viewport_size_signal()
-        self.wheel_delta_signal()
-        self.wheel_events()
-        self.control_commit_events("opacity")
-`;
+async function waitForPresentedFrame(page, afterPresentedFrames, objectCount) {
+  return page.evaluate(async ({ afterPresentedFrames, objectCount }) => {
+    const execution = window.__nativeInputExecution;
+    let latest;
+    for (let attempt = 0; attempt < 150; attempt += 1) {
+      latest = (await execution.metrics()).metrics;
+      if (
+        latest.presentedFrames > afterPresentedFrames &&
+        latest.objectCount === objectCount &&
+        (objectCount === 0 || latest.drawCalls > 0)
+      ) return latest;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    throw new Error(`native input did not render: ${JSON.stringify(latest)}`);
+  }, { afterPresentedFrames, objectCount });
+}
 
 let browser = null;
 try {
@@ -125,44 +131,24 @@ try {
   page.on("console", (message) => {
     if (message.type() === "error") errors.push(`console: ${message.text()}`);
   });
+  await page.goto(`${baseUrl}/web/execution-worker-smoke.html`, { waitUntil: "load" });
 
-  await page.goto(`${baseUrl}/web/manim-compat-smoke.html`, { waitUntil: "load" });
-  await page.waitForFunction(() => window.noonManimCompat, null, { timeout: 30_000 });
-  await page.evaluate(() => window.noonManimCompat.ready());
-  const authored = await page.evaluate(
-    (pythonSource) => window.noonManimCompat.run(pythonSource),
-    source,
-  );
+  const runtimeInfo = await page.evaluate(async (pythonSource) => {
+    const { PythonAuthoringClient } = await import("./authoring-client.js");
+    const { AuthoringExecutionClient } = await import("./authoring-execution-client.js");
+    const {
+      attachNativeInputs,
+      bindNativeControl,
+      createExecutionWorkerNativeInputHost,
+    } = await import("./native-inputs.js");
+    const authoring = new PythonAuthoringClient();
+    await authoring.ready();
+    const authored = await authoring.run(pythonSource, {});
+    if ("document" in authored || "sceneSpec" in authored) {
+      throw new Error("canonical native input scene exported legacy state");
+    }
 
-  assert.ok(Array.isArray(authored.document.native_inputs));
-  const sourceKinds = authored.document.native_inputs.map((binding) => {
-    const payload = binding.state ?? binding.event;
-    return payload.source.kind;
-  });
-  for (const kind of [
-    "pointer_position",
-    "key",
-    "control",
-    "pointer_down",
-    "viewport_size",
-    "wheel_delta",
-    "wheel",
-    "control_commit",
-  ]) {
-    assert.ok(sourceKinds.includes(kind), `missing authored native input kind ${kind}`);
-  }
-
-  const runtimeInfo = await page.evaluate(async (sceneDocument) => {
-    const wasm = await import("./pkg/noon_web.js");
-    const nativeInputs = await import("./native-inputs.js");
-    await wasm.default();
-
-    const canvas = document.createElement("canvas");
-    canvas.id = "native-input-canvas";
-    canvas.width = 640;
-    canvas.height = 360;
-    canvas.style.width = "640px";
-    canvas.style.height = "360px";
+    const canvas = document.querySelector("#scene");
     const slider = document.createElement("input");
     slider.id = "opacity-control";
     slider.type = "range";
@@ -170,87 +156,110 @@ try {
     slider.max = "1";
     slider.step = "0.1";
     slider.value = "1";
+    document.body.append(slider);
 
-    document.body.innerHTML = "";
-    document.body.append(canvas, slider);
+    const inputErrors = [];
+    const recordError = (error) => inputErrors.push(String(error));
+    const execution = new AuthoringExecutionClient(canvas, { onError: recordError });
+    const ready = await execution.startSemanticExecution(authored.semanticExecution, {
+      authoringClient: authoring,
+      transportMode: "transferable",
+    });
+    let initial;
+    for (let attempt = 0; attempt < 150; attempt += 1) {
+      initial = (await execution.metrics()).metrics;
+      if (initial.presentedFrames > 0 && initial.objectCount === 0) break;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    if (!(initial?.presentedFrames > 0) || initial.objectCount !== 0) {
+      throw new Error(`native input initial frame did not stay hidden: ${JSON.stringify(initial)}`);
+    }
+    const paused = await execution.pause();
+    if (paused.playing) throw new Error("native input execution did not pause");
 
-    const player = await wasm.ReactiveCanvasPlayer.create(
-      canvas,
-      JSON.stringify(sceneDocument),
-      4.0,
-    );
-    const detachInputs = nativeInputs.attachNativeInputs(player, canvas);
-    const detachControl = nativeInputs.bindNativeControl(player, slider, "opacity");
-    window.__nativeInputPlayer = player;
-    window.__detachNativeInputs = detachInputs;
-    window.__detachNativeControl = detachControl;
-    if (!player.seek(0.0)) throw new Error("initial native-input frame was not presented");
-    return {
-      backend: player.rendererBackend(),
-      objectCount: player.objectCount(),
-      time: player.time(),
+    // This fixture uses the default canonical viewport. A split-worker product
+    // host supplies its platform viewport mapping through the same adapter.
+    const host = createExecutionWorkerNativeInputHost(execution, {
+      pointerToScene(normalizedX, normalizedY) {
+        const frameHeight = 8;
+        const frameWidth = frameHeight * (canvas.width / canvas.height);
+        return {
+          x: (normalizedX - 0.5) * frameWidth,
+          y: (0.5 - normalizedY) * frameHeight,
+        };
+      },
+    });
+    const detachInputs = attachNativeInputs(host, canvas, { onError: recordError });
+    const detachControl = bindNativeControl(host, slider, "opacity", { onError: recordError });
+    window.__nativeInputExecution = execution;
+    window.__nativeInputCleanup = () => {
+      detachInputs();
+      detachControl();
+      execution.terminate();
+      authoring.terminate();
     };
-  }, authored.document);
+    window.__nativeInputErrors = inputErrors;
+    return {
+      backend: ready.render.backend,
+      objectCount: initial.objectCount,
+      presentedFrames: initial.presentedFrames,
+    };
+  }, source);
 
   assert.equal(runtimeInfo.backend, "WebGPU");
-  assert.equal(runtimeInfo.objectCount, 1);
-  assert.equal(runtimeInfo.time, 0);
-
-  const canvas = page.locator("#native-input-canvas");
+  assert.equal(runtimeInfo.objectCount, 0);
+  const canvas = page.locator("#scene");
   const hidden = foregroundStats(await canvas.screenshot());
-  assert.ok(
-    hidden.changedPixels < 50,
-    `key-owned presence should initially hide the object; got ${hidden.changedPixels} pixels`,
-  );
+  assert.ok(hidden.changedPixels < 50, "Space=false must keep the native square hidden");
 
   await page.keyboard.down("Space");
-  await presentCurrent(page);
-  const visible = foregroundStats(await canvas.screenshot());
-  assert.ok(
-    visible.changedPixels > 200,
-    `Space key state should reveal the object; got ${visible.changedPixels} pixels`,
-  );
+  const visibleMetrics = await waitForPresentedFrame(page, runtimeInfo.presentedFrames, 1);
+  const visibleBuffer = await canvas.screenshot();
+  const visible = foregroundStats(visibleBuffer);
+  assert.ok(visible.changedPixels > 200, "Space key state did not reveal the square");
 
   const box = await canvas.boundingBox();
   assert.ok(box !== null);
   await page.mouse.move(box.x + box.width * 0.78, box.y + box.height * 0.5);
-  await presentCurrent(page);
-  const moved = foregroundStats(await canvas.screenshot());
+  const movedMetrics = await waitForPresentedFrame(page, visibleMetrics.presentedFrames, 1);
+  const movedBuffer = await canvas.screenshot();
+  const moved = foregroundStats(movedBuffer);
   assert.ok(
     moved.centroidX - visible.centroidX > 100,
-    `pointer world-position signal should move object right (${visible.centroidX} -> ${moved.centroidX})`,
+    `normalized pointer did not move the square through the canonical camera (${visible.centroidX} -> ${moved.centroidX})`,
   );
 
   await page.mouse.down({ button: "left" });
-  await page.mouse.up({ button: "left" });
-  await page.mouse.wheel(12, -30);
+  const rotatedMetrics = await waitForPresentedFrame(page, movedMetrics.presentedFrames, 1);
+  const rotatedBuffer = await canvas.screenshot();
+  assert.ok(
+    differingPixels(movedBuffer, rotatedBuffer) > 100,
+    "ordered pointer-down event did not rotate the square",
+  );
 
   await page.locator("#opacity-control").evaluate((element) => {
     element.value = "0.4";
     element.dispatchEvent(new Event("input", { bubbles: true }));
     element.dispatchEvent(new Event("change", { bubbles: true }));
   });
-  await presentCurrent(page);
+  const dimmedMetrics = await waitForPresentedFrame(page, rotatedMetrics.presentedFrames, 1);
+  const dimmed = foregroundStats(await canvas.screenshot());
+  const rotated = foregroundStats(rotatedBuffer);
+  assert.ok(
+    dimmed.meanBlue < rotated.meanBlue * 0.75,
+    `native control did not dim the square (${rotated.meanBlue} -> ${dimmed.meanBlue})`,
+  );
 
   await page.keyboard.up("Space");
-  await presentCurrent(page);
+  await waitForPresentedFrame(page, dimmedMetrics.presentedFrames, 0);
   const hiddenAgain = foregroundStats(await canvas.screenshot());
-  assert.ok(
-    hiddenAgain.changedPixels < 50,
-    `key release should hide the object again; got ${hiddenAgain.changedPixels} pixels`,
-  );
+  assert.ok(hiddenAgain.changedPixels < 50, "Space key release did not hide the square");
 
-  const stats = await page.evaluate(() =>
-    JSON.parse(window.__nativeInputPlayer.nativeInputStatsJson()),
-  );
-  assert.ok(stats.state_samples_received >= 6, JSON.stringify(stats));
-  assert.ok(stats.events_received >= 3, JSON.stringify(stats));
-  assert.ok(stats.reactive_updates >= 6, JSON.stringify(stats));
-  assert.equal(stats.state_dispatches_dropped, 0, JSON.stringify(stats));
-  assert.equal(stats.event_dispatches_dropped, 0, JSON.stringify(stats));
-  assert.equal(errors.length, 0, errors.join("\n"));
-
-  console.log("native browser input smoke test passed");
+  const inputErrors = await page.evaluate(() => window.__nativeInputErrors.slice());
+  assert.deepEqual(inputErrors, []);
+  assert.deepEqual(errors, []);
+  await page.evaluate(() => window.__nativeInputCleanup());
+  console.log("canonical native browser input smoke test passed");
 } finally {
   if (browser !== null) await browser.close();
   server.kill("SIGTERM");

--- a/web/native-inputs.js
+++ b/web/native-inputs.js
@@ -1,3 +1,5 @@
+import { MAX_PENDING_SEMANTIC_CONTROLS } from "./semantic-engine-endpoint.js";
+
 function normalizedPointer(canvas, event) {
   const rect = canvas.getBoundingClientRect();
   if (!(rect.width > 0) || !(rect.height > 0)) return null;
@@ -38,33 +40,40 @@ function wheelDeltaCssPixels(canvas, event, resolveLinePixels) {
 }
 
 /**
- * Attach browser pointer/keyboard/wheel input to a ReactiveCanvasPlayer.
+ * Attach browser pointer/keyboard/wheel input to one canonical execution host.
  *
- * The collector only forwards semantic source samples/events. It never calls
- * Python and never renders synchronously; the existing render loop presents the
- * resulting native reactive state on its next frame.
+ * The collector owns DOM normalization and listener lifetime only. Source
+ * routing, semantic identity, reactive evaluation, and rendering remain in the
+ * canonical Rust session behind the host methods.
  */
 export function attachNativeInputs(
-  player,
+  host,
   canvas,
-  { keyboardTarget = window, preventWheelDefault = false } = {},
+  {
+    keyboardTarget = window,
+    preventWheelDefault = false,
+    onError = defaultInputError,
+  } = {},
 ) {
-  if (!player || !canvas) throw new TypeError("player and canvas are required");
+  validateHost(host);
+  if (!canvas) throw new TypeError("host and canvas are required");
+  if (typeof onError !== "function") throw new TypeError("onError must be a function");
+  const invoke = (method, ...args) => invokeHost(host, method, args, onError);
 
   const pointerMove = (event) => {
     const point = normalizedPointer(canvas, event);
-    if (point !== null) player.dispatchPointerPosition(point.x, point.y);
+    if (point !== null) invoke("nativePointerPosition", point.x, point.y);
   };
   const pointerDown = (event) => {
     pointerMove(event);
-    player.dispatchPointerButton(event.button, true);
+    invoke("nativePointerButton", event.button, true);
   };
   const pointerUp = (event) => {
     pointerMove(event);
-    player.dispatchPointerButton(event.button, false);
+    invoke("nativePointerButton", event.button, false);
   };
-  const keyDown = (event) => player.dispatchKey(event.code, true);
-  const keyUp = (event) => player.dispatchKey(event.code, false);
+  const keyDown = (event) => invoke("nativeKey", event.code, true);
+  const keyUp = (event) => invoke("nativeKey", event.code, false);
   let cachedLinePixels = null;
   const resolveLinePixels = () => {
     cachedLinePixels ??= wheelLinePixels(canvas);
@@ -73,7 +82,7 @@ export function attachNativeInputs(
   const wheel = (event) => {
     if (preventWheelDefault) event.preventDefault();
     const delta = wheelDeltaCssPixels(canvas, event, resolveLinePixels);
-    player.dispatchWheel(delta.x, delta.y);
+    invoke("nativeWheel", delta.x, delta.y);
   };
 
   canvas.addEventListener("pointermove", pointerMove);
@@ -94,8 +103,15 @@ export function attachNativeInputs(
 }
 
 /** Bind a numeric input/range element to a named native scalar control. */
-export function bindNativeControl(player, element, name) {
-  if (!player || !element) throw new TypeError("player and element are required");
+export function bindNativeControl(
+  player,
+  element,
+  name,
+  { onError = defaultInputError } = {},
+) {
+  validateHost(player);
+  if (!element) throw new TypeError("host and element are required");
+  if (typeof onError !== "function") throw new TypeError("onError must be a function");
   if (typeof name !== "string" || name.trim().length === 0) {
     throw new TypeError("control name must be a non-empty string");
   }
@@ -103,11 +119,11 @@ export function bindNativeControl(player, element, name) {
   const sample = () => {
     const value = Number(element.value);
     if (!Number.isFinite(value)) throw new TypeError("control value must be finite");
-    player.dispatchControl(name, value);
+    invokeHost(player, "nativeControl", [name, value], onError);
   };
   const commit = () => {
     sample();
-    player.dispatchControlCommit(name);
+    invokeHost(player, "nativeControlCommit", [name], onError);
   };
 
   element.addEventListener("input", sample);
@@ -118,4 +134,124 @@ export function bindNativeControl(player, element, name) {
     element.removeEventListener("input", sample);
     element.removeEventListener("change", commit);
   };
+}
+
+/**
+ * Adapt the genuine semantic execution-worker boundary to the DOM host shape.
+ *
+ * Pointer conversion is supplied by the platform integration because canonical
+ * pointer signals carry scene coordinates. Calls are admitted synchronously and
+ * then forwarded immediately; the endpoint's bounded control queue remains the
+ * only ordered queue.
+ */
+export function createExecutionWorkerNativeInputHost(
+  client,
+  { pointerToScene, maxInFlight = MAX_PENDING_SEMANTIC_CONTROLS } = {},
+) {
+  if (
+    typeof client?.setNativeStateInput !== "function" ||
+    typeof client?.emitNativeEvent !== "function"
+  ) {
+    throw new TypeError("worker native input requires a canonical execution client");
+  }
+  if (typeof pointerToScene !== "function") {
+    throw new TypeError("worker native input requires pointerToScene");
+  }
+  if (!Number.isSafeInteger(maxInFlight) || maxInFlight <= 0) {
+    throw new TypeError("maxInFlight must be a positive safe integer");
+  }
+  let inFlight = 0;
+  const submit = (operations) => {
+    if (inFlight + operations.length > maxInFlight) {
+      return Promise.reject(new Error(
+        "native input admission is full; wait for pending commands before retrying",
+      ));
+    }
+    inFlight += operations.length;
+    const results = operations.map((operation) => {
+      try {
+        return Promise.resolve(operation());
+      } catch (error) {
+        return Promise.reject(error);
+      }
+    }).map((result) => result.finally(() => {
+      inFlight -= 1;
+    }));
+    return results.length === 1 ? results[0] : Promise.all(results);
+  };
+  const state = (source, value) => () => client.setNativeStateInput(source, value);
+  const event = (source) => () => client.emitNativeEvent(source);
+
+  return Object.freeze({
+    nativePointerPosition(normalizedX, normalizedY) {
+      const point = pointerToScene(normalizedX, normalizedY);
+      if (!Number.isFinite(point?.x) || !Number.isFinite(point?.y)) {
+        throw new TypeError("pointerToScene must return finite x and y coordinates");
+      }
+      return submit([state(
+        { kind: "pointer_position" },
+        { kind: "vec2", x: point.x, y: point.y },
+      )]);
+    },
+    nativePointerButton(button, pressed) {
+      return submit([
+        state(
+          { kind: "pointer_button", button },
+          { kind: "bool", value: pressed },
+        ),
+        event({ kind: pressed ? "pointer_down" : "pointer_up", button }),
+      ]);
+    },
+    nativeKey(code, pressed) {
+      return submit([
+        state({ kind: "key", code }, { kind: "bool", value: pressed }),
+        event({ kind: pressed ? "key_press" : "key_release", code }),
+      ]);
+    },
+    nativeWheel(x, y) {
+      return submit([
+        state({ kind: "wheel_delta" }, { kind: "vec2", x, y }),
+        event({ kind: "wheel" }),
+      ]);
+    },
+    nativeControl(name, value) {
+      return submit([state({ kind: "control", name }, { kind: "scalar", value })]);
+    },
+    nativeControlCommit(name) {
+      return submit([event({ kind: "control_commit", name })]);
+    },
+  });
+}
+
+function validateHost(host) {
+  if (!host) throw new TypeError("canonical native input host is required");
+  for (const method of [
+    "nativePointerPosition",
+    "nativePointerButton",
+    "nativeKey",
+    "nativeWheel",
+    "nativeControl",
+    "nativeControlCommit",
+  ]) {
+    if (typeof host[method] !== "function") {
+      throw new TypeError(`canonical native input host requires ${method}`);
+    }
+  }
+}
+
+function invokeHost(host, method, args, onError) {
+  try {
+    const result = host[method](...args);
+    if (result && typeof result.then === "function") {
+      result.catch(onError);
+    }
+  } catch (error) {
+    onError(error);
+  }
+}
+
+function defaultInputError(error) {
+  queueMicrotask(() => {
+    throw error;
+  });
 }

--- a/web/native-inputs.test.mjs
+++ b/web/native-inputs.test.mjs
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import test from "node:test";
 
-import { attachNativeInputs } from "./native-inputs.js";
+import {
+  attachNativeInputs,
+  bindNativeControl,
+  createExecutionWorkerNativeInputHost,
+} from "./native-inputs.js";
 
 class FakeTarget {
   listeners = new Map();
@@ -53,23 +58,26 @@ function wheelEvent(deltaX, deltaY, deltaMode) {
   };
 }
 
-function recordingPlayer() {
+function recordingHost(overrides = {}) {
   const wheel = [];
   return {
     wheel,
-    dispatchPointerPosition() {},
-    dispatchPointerButton() {},
-    dispatchKey() {},
-    dispatchWheel(x, y) {
+    nativePointerPosition() {},
+    nativePointerButton() {},
+    nativeKey() {},
+    nativeWheel(x, y) {
       wheel.push([x, y]);
     },
+    nativeControl() {},
+    nativeControlCommit() {},
+    ...overrides,
   };
 }
 
 test("native wheel input normalizes browser delta modes to CSS pixels", () => {
   const canvas = new FakeCanvas();
   const keyboardTarget = new FakeTarget();
-  const player = recordingPlayer();
+  const player = recordingHost();
   const detach = attachNativeInputs(player, canvas, {
     keyboardTarget,
     preventWheelDefault: true,
@@ -98,7 +106,7 @@ test("native wheel input normalizes browser delta modes to CSS pixels", () => {
 
 test("line-mode wheel input falls back to computed font size for normal line-height", () => {
   const canvas = new FakeCanvas({ lineHeight: "normal", fontSize: "18px" });
-  const player = recordingPlayer();
+  const player = recordingHost();
   const detach = attachNativeInputs(player, canvas, {
     keyboardTarget: new FakeTarget(),
   });
@@ -110,7 +118,7 @@ test("line-mode wheel input falls back to computed font size for normal line-hei
 
 test("unknown browser wheel delta modes fail instead of silently changing units", () => {
   const canvas = new FakeCanvas();
-  const player = recordingPlayer();
+  const player = recordingHost();
   const detach = attachNativeInputs(player, canvas, {
     keyboardTarget: new FakeTarget(),
   });
@@ -121,4 +129,120 @@ test("unknown browser wheel delta modes fail instead of silently changing units"
   );
   assert.deepEqual(player.wheel, []);
   detach();
+});
+
+test("canonical DOM input preserves sampled-state then ordered-event delivery", async () => {
+  const calls = [];
+  const client = {
+    setNativeStateInput(source, value) {
+      calls.push(["state", source, value]);
+      return Promise.resolve();
+    },
+    emitNativeEvent(source) {
+      calls.push(["event", source]);
+      return Promise.resolve();
+    },
+  };
+  const host = createExecutionWorkerNativeInputHost(client, {
+    pointerToScene: (x, y) => ({ x: x * 10, y: -y * 10 }),
+  });
+  const canvas = new FakeCanvas();
+  const errors = [];
+  const detach = attachNativeInputs(host, canvas, {
+    keyboardTarget: new FakeTarget(),
+    onError: (error) => errors.push(String(error)),
+  });
+
+  canvas.dispatch("pointerdown", { clientX: 320, clientY: 90, button: 0 });
+  await Promise.resolve();
+
+  assert.deepEqual(calls, [
+    [
+      "state",
+      { kind: "pointer_position" },
+      { kind: "vec2", x: 5, y: -2.5 },
+    ],
+    [
+      "state",
+      { kind: "pointer_button", button: 0 },
+      { kind: "bool", value: true },
+    ],
+    ["event", { kind: "pointer_down", button: 0 }],
+  ]);
+  assert.deepEqual(errors, []);
+  detach();
+});
+
+test("worker native ingress rejects synchronously at its in-flight bound without queuing", async () => {
+  const pending = [];
+  const client = {
+    setNativeStateInput() {
+      return new Promise((resolve) => pending.push(resolve));
+    },
+    emitNativeEvent() {
+      return new Promise((resolve) => pending.push(resolve));
+    },
+  };
+  const host = createExecutionWorkerNativeInputHost(client, {
+    pointerToScene: (x, y) => ({ x, y }),
+    maxInFlight: 2,
+  });
+
+  const accepted = host.nativePointerButton(0, true);
+  await assert.rejects(
+    host.nativeControl("opacity", 0.5),
+    /native input admission is full/,
+  );
+  assert.equal(pending.length, 2, "overflow must not enqueue another worker request");
+  pending.splice(0).forEach((resolve) => resolve());
+  await accepted;
+  const retried = host.nativeControl("opacity", 0.5);
+  assert.equal(pending.length, 1);
+  pending.splice(0).forEach((resolve) => resolve());
+  await retried;
+});
+
+test("listener and control async failures surface through the configured error path", async () => {
+  const failure = new Error("semantic native input rejected");
+  const host = recordingHost({
+    nativeKey: () => Promise.reject(failure),
+    nativeControl: () => Promise.reject(failure),
+  });
+  const keyboardTarget = new FakeTarget();
+  const canvas = new FakeCanvas();
+  const errors = [];
+  const onError = (error) => errors.push(error);
+  const detachInputs = attachNativeInputs(host, canvas, { keyboardTarget, onError });
+  const control = new FakeTarget();
+  control.value = "0.5";
+  const detachControl = bindNativeControl(host, control, "opacity", { onError });
+
+  keyboardTarget.dispatch("keydown", { code: "Space" });
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.deepEqual(errors, [failure, failure]);
+
+  detachInputs();
+  detachControl();
+});
+
+test("DOM collector and direct canvas expose canonical native ingress", async () => {
+  const [collector, directCanvas] = await Promise.all([
+    readFile(new URL("./native-inputs.js", import.meta.url), "utf8"),
+    readFile(new URL("../crates/noon-web/src/execution_canvas.rs", import.meta.url), "utf8"),
+  ]);
+  assert.ok(collector.includes("createExecutionWorkerNativeInputHost"));
+  assert.ok(collector.includes("MAX_PENDING_SEMANTIC_CONTROLS"));
+  for (const method of [
+    "nativePointerPosition",
+    "nativePointerButton",
+    "nativeKey",
+    "nativeWheel",
+    "nativeControl",
+    "nativeControlCommit",
+  ]) {
+    assert.ok(directCanvas.includes(method), `direct typed canvas is missing ${method}`);
+  }
+  assert.ok(directCanvas.includes("normalized_pointer_world_position"));
+  assert.ok(directCanvas.includes("NativeEventOccurrence::new"));
 });


### PR DESCRIPTION
Browser DOM input now drives a canonical semantic execution session. The native-input smoke authors the paired Python native-signal scene and verifies real DOM key, pointer, control and click effects; it no longer constructs a timed scene document, ReactiveCanvasPlayer or a second native router.

Advances #959 and #969. Browser glue owns DOM normalization/listener lifecycle and bounded admission; Rust owns current-camera pointer conversion on the direct path, source routing, signal identity, evaluation and publication.

- Direct single-context Rust/WASM methods accept primitive input and construct typed Rust source/value enums in ExecutionCanvas. No JSON engine boundary is added.
- The genuine worker adapter forwards envelopes immediately in order through existing semantic control APIs, with bounded in-flight admission and surfaced errors. It adds no event queue, interpolation or semantic state mirror.
- Split-worker pointer-to-scene mapping is supplied by platform viewport integration, since the DOM thread does not own the renderer camera.

Validation:

- `node --test web/native-inputs.test.mjs`: 7/7 normalization, ordering, bounded admission, error and host-surface tests passed; syntax and diff checks passed.
- Integrated with ordinary animation authoring: `CARGO_TARGET_DIR=/Users/ykshin/Dev/me/noon/target CARGO_INCREMENTAL=0 NOON_WASM_PROFILE=dev NOON_SKIP_WEB_PREFLIGHT=1 bash scripts/check.sh full` completed architecture, format/check/Clippy and all Rust tests/doctests. A WASM-only export-impl placement error was fixed by moving only the six JS methods into the existing exported impl.
- Resumed `bash scripts/check.sh web` with the same environment and `NOON_SKIP_WEB_PREFLIGHT=1`; WASM built, then the unrelated new example declaration assertion was corrected and `node scripts/check-web-package.mjs` passed (166,150,546-byte module, 117 public contracts).
- `node scripts/native-input-smoke.mjs` passed actual Python authoring → canonical semantic worker → renderer with real DOM key, pointer, click and control input.
- Combined Node preflight and final Python174/174 suite passed. Exact standalone branch CI remains required before merge.

The integration tree contains additional ordinary-animation changes; this branch contains only the DOM input consumer cutover and its direct export fix.
