### PR TITLE
Keep mixed Text callback updates local and observable

### DIFF
--- a/crates/noon-render-wgpu/src/gpu/retained_text.rs
+++ b/crates/noon-render-wgpu/src/gpu/retained_text.rs
@@ -2843,10 +2843,12 @@ mod tests {
 
     fn geometry_only_mega_path_frame() -> FrameState {
         let path = |id, y| {
-            let mut style = Style::default();
-            style.fill = None;
-            style.stroke = Some(Color::WHITE);
-            style.stroke_width = 0.01;
+            let style = Style {
+                fill: None,
+                stroke: Some(Color::WHITE),
+                stroke_width: 0.01,
+                ..Style::default()
+            };
             FrameObjectState {
                 id: ObjectId::new(id),
                 content: ObjectContentRef::Geometry(GeometryRef::path(

--- a/crates/noon-render-wgpu/src/gpu/retained_text.rs
+++ b/crates/noon-render-wgpu/src/gpu/retained_text.rs
@@ -12,7 +12,7 @@ use noon_core::{
     TextRenderItem, TextResourceLookup, TextVectorItem, Transform2D, Vec2, VectorPath,
 };
 #[cfg(test)]
-use noon_core::{FontResourceArena, GeometryResourceArena, TextResourceArena};
+use noon_core::{FontResourceArena, GeometryResourceArena, TextResourceArena, TextVectorStyle};
 use noon_runtime::{FrameChanges, FrameObjectState, FrameState, RendererPublication};
 use noon_text_atlas::{GlyphAtlasPlane, GpuGlyphAtlas};
 use noon_text_render_wgpu::{
@@ -2426,17 +2426,24 @@ impl GpuRenderer {
         self.upload_retained_inner(device, queue, prepared, text_state, None)
     }
 
-    /// Upload a retained frame while recording exact geometry and glyph-instance
-    /// buffer writes. The caller owns the opt-in trace allocation.
+    /// Upload a retained frame while recording only writes that intersect one
+    /// prepared target. The caller owns the opt-in trace allocation.
     pub fn upload_retained_with_trace(
         &mut self,
         device: &wgpu::Device,
         queue: &wgpu::Queue,
         prepared: &PreparedRetainedGpuFrame<'_>,
         text_state: &mut RetainedTextGpuState,
+        observed: &RetainedPreparedObjectObservation,
         upload_writes: &mut Vec<crate::UploadWrite>,
     ) -> RetainedUploadStats {
-        self.upload_retained_inner(device, queue, prepared, text_state, Some(upload_writes))
+        self.upload_retained_inner(
+            device,
+            queue,
+            prepared,
+            text_state,
+            Some((observed, upload_writes)),
+        )
     }
 
     fn upload_retained_inner(
@@ -2445,10 +2452,18 @@ impl GpuRenderer {
         queue: &wgpu::Queue,
         prepared: &PreparedRetainedGpuFrame<'_>,
         text_state: &mut RetainedTextGpuState,
-        mut upload_writes: Option<&mut Vec<crate::UploadWrite>>,
+        mut observed_uploads: Option<(
+            &RetainedPreparedObjectObservation,
+            &mut Vec<crate::UploadWrite>,
+        )>,
     ) -> RetainedUploadStats {
-        let geometry = if let Some(writes) = upload_writes.as_deref_mut() {
-            self.upload_with_trace(device, queue, &prepared.geometry, writes)
+        let geometry = if let Some((observed, writes)) = observed_uploads.as_mut() {
+            let mut trace = |buffer, range, offset, bytes: &[u8]| {
+                if observed_geometry_write_matches(observed, buffer, &range) {
+                    push_upload_write(writes, buffer, range, offset, bytes);
+                }
+            };
+            self.upload_with_write_trace(device, queue, &prepared.geometry, &mut trace)
         } else {
             self.upload(device, queue, &prepared.geometry)
         };
@@ -2463,13 +2478,15 @@ impl GpuRenderer {
             let partial = prepared.text.partial_upload_base_generation.is_some()
                 && prepared.text.partial_upload_base_generation
                     == text_state.last_uploaded_generation;
-            let uploaded = if let Some(writes) = upload_writes.as_deref_mut() {
+            let uploaded = if let Some((observed, writes)) = observed_uploads.as_mut() {
                 let mut trace = |plane, range, offset, bytes: &[u8]| {
                     let buffer = match plane {
                         GlyphAtlasPlane::Mask => "text_mask",
                         GlyphAtlasPlane::Color => "text_color",
                     };
-                    push_upload_write(writes, buffer, range, offset, bytes);
+                    if observed_text_write_matches(observed, plane, &range) {
+                        push_upload_write(writes, buffer, range, offset, bytes);
+                    }
                 };
                 if partial {
                     text_state.glyphs.upload_ranges_with_trace(
@@ -2667,6 +2684,38 @@ impl GpuRenderer {
     }
 }
 
+fn observed_geometry_write_matches(
+    observed: &RetainedPreparedObjectObservation,
+    buffer: &'static str,
+    range: &std::ops::Range<usize>,
+) -> bool {
+    observed.geometry.as_ref().is_some_and(|geometry| {
+        let target_buffer = match geometry.primitive {
+            RenderPrimitive::Circle => "circle",
+            RenderPrimitive::Rectangle => "rectangle",
+            RenderPrimitive::Line => "line",
+            RenderPrimitive::Path { .. } | RenderPrimitive::MegaPath { .. } => "path_instance",
+        };
+        buffer == target_buffer && range.contains(&geometry.instance_index)
+    })
+}
+
+fn observed_text_write_matches(
+    observed: &RetainedPreparedObjectObservation,
+    plane: GlyphAtlasPlane,
+    range: &std::ops::Range<usize>,
+) -> bool {
+    observed.glyph_ranges.iter().any(|target| {
+        let target_plane = match target.plane {
+            RetainedGlyphPlane::Mask => GlyphAtlasPlane::Mask,
+            RetainedGlyphPlane::Color => GlyphAtlasPlane::Color,
+        };
+        target_plane == plane
+            && range.start < target.instance_range.end as usize
+            && (target.instance_range.start as usize) < range.end
+    })
+}
+
 impl std::ops::AddAssign for DrawStats {
     fn add_assign(&mut self, rhs: Self) {
         self.draw_calls = self.draw_calls.saturating_add(rhs.draw_calls);
@@ -2708,10 +2757,37 @@ mod tests {
 
     use super::*;
 
-    fn mixed_text_frame() -> (FrameState, TextResourceArena, FontResourceArena) {
-        let artifact = compile_typst_resource("A", TypstMode::Markup).unwrap();
+    fn mixed_text_frame() -> (
+        FrameState,
+        TextResourceArena,
+        FontResourceArena,
+        GeometryResourceArena,
+    ) {
+        let mut artifact = compile_typst_resource("A", TypstMode::Markup).unwrap();
         let bounds = artifact.resource.bounds;
         let fonts = artifact.fonts;
+        let mut geometries = GeometryResourceArena::new();
+        let vector = geometries.insert_path(
+            VectorPath::new()
+                .move_to(Vec2::new(-0.25, -0.05))
+                .line_to(Vec2::new(0.25, -0.05))
+                .line_to(Vec2::new(0.25, 0.05))
+                .line_to(Vec2::new(-0.25, 0.05))
+                .close(),
+        );
+        let mut vector_items = artifact.resource.vector_items.to_vec();
+        let vector_index = vector_items.len() as u32;
+        vector_items.push(TextVectorItem {
+            geometry: vector,
+            transform: TextAffineTransform::IDENTITY,
+            style: TextVectorStyle::default(),
+            source_span: None,
+            semantic_key: Some(Arc::from("test-rule")),
+        });
+        artifact.resource.vector_items = vector_items.into();
+        let mut render_items = artifact.resource.render_items.to_vec();
+        render_items.push(TextRenderItem::Vector(vector_index));
+        artifact.resource.render_items = render_items.into();
         let mut texts = TextResourceArena::new();
         let text = texts.insert(artifact.resource).unwrap();
         (
@@ -2743,6 +2819,7 @@ mod tests {
             },
             texts,
             fonts,
+            geometries,
         )
     }
 
@@ -2957,8 +3034,7 @@ mod tests {
 
     #[test]
     fn observed_text_object_reuses_its_existing_glyph_instance_ranges() {
-        let (frame, texts, fonts) = mixed_text_frame();
-        let geometries = GeometryResourceArena::new();
+        let (frame, texts, fonts, geometries) = mixed_text_frame();
         let metrics = TextDeviceMetrics::uniform(100.0).unwrap();
         let (device, queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
         let mut preparer = RetainedFramePreparer::new();
@@ -2976,10 +3052,8 @@ mod tests {
             .unwrap();
 
         let observed = prepared.observe_object(1, ObjectId::new(2)).unwrap();
-        assert!(matches!(
-            observed.kind,
-            RetainedPreparedObjectKind::Text | RetainedPreparedObjectKind::Mixed
-        ));
+        assert_eq!(observed.kind, RetainedPreparedObjectKind::Mixed);
+        assert!(observed.geometry.is_some());
         assert_eq!(observed.glyph_ranges.len(), observed.glyph_item_count);
         assert!(!observed.glyph_ranges.is_empty());
         for range in &observed.glyph_ranges {
@@ -3018,9 +3092,84 @@ mod tests {
     }
 
     #[test]
+    fn actual_mixed_text_preparation_traces_target_uploads_and_draws() {
+        let (frame, texts, fonts, geometries) = mixed_text_frame();
+        let metrics = TextDeviceMetrics::uniform(100.0).unwrap();
+        let (device, queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
+        let mut preparer = RetainedFramePreparer::new();
+        let prepared = preparer
+            .prepare_with_changes(
+                &device,
+                &queue,
+                &frame,
+                &FrameChanges::all(),
+                &texts,
+                &fonts,
+                &geometries,
+                metrics,
+            )
+            .unwrap();
+        let observed = prepared.observe_object(1, ObjectId::new(2)).unwrap();
+        assert_eq!(observed.kind, RetainedPreparedObjectKind::Mixed);
+        assert!(observed.geometry.is_some());
+        assert!(!observed.glyph_ranges.is_empty());
+
+        let format = wgpu::TextureFormat::Rgba8Unorm;
+        let mut renderer = GpuRenderer::new(&device, format);
+        renderer.set_viewport(&device, &queue, 64, 64);
+        let mut text_state = renderer.create_retained_text_state(&device, &queue);
+        let mut writes = Vec::new();
+        let upload = renderer.upload_retained_with_trace(
+            &device,
+            &queue,
+            &prepared,
+            &mut text_state,
+            &observed,
+            &mut writes,
+        );
+        assert!(upload.geometry.bytes_uploaded > 0);
+        assert!(upload.text.bytes_uploaded > 0);
+        assert!(writes.iter().any(|write| write.buffer == "path_instance"));
+        assert!(writes
+            .iter()
+            .any(|write| matches!(write.buffer, "text_mask" | "text_color")));
+        assert!(writes.iter().all(|write| write.buffer != "circle"));
+
+        let texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("Noon mixed text observation target"),
+            size: wgpu::Extent3d {
+                width: 64,
+                height: 64,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            view_formats: &[],
+        });
+        let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("Noon mixed text observation encoder"),
+        });
+        let draw = renderer
+            .encode_retained(
+                &mut encoder,
+                &view,
+                &prepared,
+                &text_state,
+                wgpu::Color::TRANSPARENT,
+            )
+            .unwrap();
+        queue.submit(Some(encoder.finish()));
+        assert!(draw.geometry.draw_calls > 0);
+        assert!(draw.text.draw_calls > 0);
+    }
+
+    #[test]
     fn unchanged_frame_reuses_semantic_scratch_generation() {
-        let (mut frame, texts, fonts) = mixed_text_frame();
-        let geometries = GeometryResourceArena::new();
+        let (mut frame, texts, fonts, geometries) = mixed_text_frame();
         let metrics = TextDeviceMetrics::uniform(100.0).unwrap();
         let (device, queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
         let mut preparer = RetainedFramePreparer::new();
@@ -3092,8 +3241,7 @@ mod tests {
 
     #[test]
     fn mixed_visibility_projects_geometry_and_text_enter_exit_in_painter_order() {
-        let (frame, texts, fonts) = mixed_text_frame();
-        let geometries = GeometryResourceArena::new();
+        let (frame, texts, fonts, geometries) = mixed_text_frame();
         let metrics = TextDeviceMetrics::uniform(100.0).unwrap();
         let (device, queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
         let mut preparer = RetainedFramePreparer::new();
@@ -3177,8 +3325,7 @@ mod tests {
 
     #[test]
     fn unchanged_text_candidate_reuses_projection_across_clean_and_offscreen_changes() {
-        let (mut frame, texts, fonts) = mixed_text_frame();
-        let geometries = GeometryResourceArena::new();
+        let (mut frame, texts, fonts, geometries) = mixed_text_frame();
         let metrics = TextDeviceMetrics::uniform(100.0).unwrap();
         let (device, queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
         let mut preparer = RetainedFramePreparer::new();
@@ -3252,8 +3399,7 @@ mod tests {
 
     #[test]
     fn metric_change_does_not_reuse_parent_generation() {
-        let (mut frame, texts, fonts) = mixed_text_frame();
-        let geometries = GeometryResourceArena::new();
+        let (mut frame, texts, fonts, geometries) = mixed_text_frame();
         let first_metrics = TextDeviceMetrics::uniform(100.0).unwrap();
         let second_metrics = TextDeviceMetrics::uniform(200.0).unwrap();
         let (device, queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());

--- a/crates/noon-render-wgpu/src/gpu/retained_text.rs
+++ b/crates/noon-render-wgpu/src/gpu/retained_text.rs
@@ -1126,31 +1126,22 @@ impl RetainedFramePreparer {
         } else {
             self.geometry_only_classification = Some(false);
         }
-        if self.can_update_mixed_geometry_locally(frame, changes, metrics) {
-            return self.prepare_mixed_geometry_locally(
+        if self.can_update_mixed_properties_locally(frame, changes, texts, metrics)? {
+            return self.prepare_mixed_properties_locally(
+                device,
+                queue,
                 frame,
                 changes,
+                texts,
+                fonts,
                 geometries,
                 metrics,
                 visible_object_indices,
             );
         }
 
-        let text_can_update_locally = if changes.is_empty() {
-            false
-        } else {
-            self.text
-                .can_update_objects_locally(frame, changes, texts, metrics)?
-                && self.changes_are_fast_text_only(frame, changes)
-        };
-        let scratch_reused = self.prepare_scratch_with_changes(
-            frame,
-            changes,
-            text_can_update_locally,
-            texts,
-            fonts,
-            geometries,
-        )?;
+        let scratch_reused =
+            self.prepare_scratch_with_changes(frame, changes, texts, fonts, geometries)?;
 
         if scratch_reused
             && changes.is_empty()
@@ -1186,63 +1177,6 @@ impl RetainedFramePreparer {
                 stats: self.snapshot_text_stats,
                 atlas: self.text.atlas(),
                 partial_upload_base_generation: None,
-                dirty_mask_ranges: &self.dirty_mask_ranges,
-                dirty_color_ranges: &self.dirty_color_ranges,
-            };
-            return Ok(PreparedRetainedGpuFrame {
-                applied_publication: &mut self.last_applied_publication,
-                geometry,
-                geometry_only: false,
-                text_generation: self.text_generation,
-                text,
-                render_items: if visible_object_indices.is_some() {
-                    &self.visible_render_items
-                } else {
-                    &self.render_items
-                },
-                stats: self.snapshot_prepare_stats,
-                source_geometry_slots: Some(&self.scratch_slots),
-                render_item_ranges: visible_object_indices
-                    .is_none()
-                    .then_some(&self.render_item_ranges),
-            });
-        }
-
-        if text_can_update_locally {
-            self.prepared_generation_ready = false;
-            let partial_upload_base_generation = self.text_generation;
-            let prepared = self
-                .text
-                .prepare_with_changes(device, queue, frame, changes, texts, fonts, metrics)?;
-            copy_local_text_snapshot_updates(
-                &mut self.snapshot_mask_quads,
-                &mut self.snapshot_color_quads,
-                &self.text_item_ranges,
-                prepared.items,
-                prepared.mask_quads,
-                prepared.color_quads,
-                changes,
-                &mut self.dirty_mask_ranges,
-                &mut self.dirty_color_ranges,
-            );
-            self.text_generation = self
-                .text_generation
-                .checked_add(1)
-                .expect("retained text generation counter exhausted");
-            self.project_mixed_visibility(frame, visible_object_indices);
-            let no_changes = FrameChanges::default();
-            let geometry = self
-                .geometry
-                .prepare_incremental(&self.scratch, &no_changes);
-            self.prepared_generation_ready = true;
-            let text = PreparedRetainedTextSnapshot {
-                time: frame.time,
-                mask_quads: &self.snapshot_mask_quads,
-                color_quads: &self.snapshot_color_quads,
-                items: &self.snapshot_text_items,
-                stats: self.snapshot_text_stats,
-                atlas: self.text.atlas(),
-                partial_upload_base_generation: Some(partial_upload_base_generation),
                 dirty_mask_ranges: &self.dirty_mask_ranges,
                 dirty_color_ranges: &self.dirty_color_ranges,
             };
@@ -1413,13 +1347,12 @@ impl RetainedFramePreparer {
         &mut self,
         frame: &FrameState,
         changes: &FrameChanges,
-        text_only_local: bool,
         texts: &(impl TextResourceLookup + ?Sized),
         fonts: &(impl FontResourceLookup + ?Sized),
         geometries: &(impl GeometryResourceLookup + ?Sized),
     ) -> Result<bool, RetainedPrepareError> {
         if self.scratch_ready
-            && (changes.is_empty() || text_only_local)
+            && changes.is_empty()
             && frame.objects.len() == self.scratch_object_count
         {
             self.scratch.time = frame.time;
@@ -1518,12 +1451,13 @@ impl RetainedFramePreparer {
         })
     }
 
-    fn can_update_mixed_geometry_locally(
+    fn can_update_mixed_properties_locally(
         &self,
         frame: &FrameState,
         changes: &FrameChanges,
+        texts: &(impl TextResourceLookup + ?Sized),
         metrics: TextDeviceMetrics,
-    ) -> bool {
+    ) -> Result<bool, RetainedPrepareError> {
         if self.geometry_only_classification != Some(false)
             || !self.scratch_ready
             || !self.prepared_generation_ready
@@ -1532,12 +1466,24 @@ impl RetainedFramePreparer {
             || changes.is_structural()
             || changes.is_empty()
         {
-            return false;
+            return Ok(false);
         }
-        changes.object_indices().iter().all(|&index| {
+        let includes_text = changes_include_text(frame, changes);
+        if includes_text
+            && !self
+                .text
+                .can_update_objects_locally(frame, changes, texts, metrics)?
+        {
+            return Ok(false);
+        }
+        Ok(changes.object_indices().iter().all(|&index| {
             let Some(object) = frame.objects.get(index) else {
                 return false;
             };
+            if object.text().is_some() {
+                return frame.is_present(index)
+                    && self.fast_text_only.get(index).copied().unwrap_or(false);
+            }
             let Some(scratch_slot) = self.scratch_slots.get(index).and_then(|slot| *slot) else {
                 return false;
             };
@@ -1552,22 +1498,59 @@ impl RetainedFramePreparer {
                             && frame.reveal(index) == self.scratch.reveal(scratch_slot)
                             && frame.morph(index) == self.scratch.morph(scratch_slot)
                     })
-        })
+        }))
     }
 
-    fn prepare_mixed_geometry_locally<'a>(
+    #[allow(clippy::too_many_arguments)]
+    fn prepare_mixed_properties_locally<'a>(
         &'a mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
         frame: &FrameState,
         changes: &FrameChanges,
+        texts: &(impl TextResourceLookup + ?Sized),
+        fonts: &(impl FontResourceLookup + ?Sized),
         geometries: &(impl GeometryResourceLookup + ?Sized),
         metrics: TextDeviceMetrics,
         visible_object_indices: Option<&[usize]>,
     ) -> Result<PreparedRetainedGpuFrame<'a>, RetainedPrepareError> {
         self.prepared_generation_ready = false;
+        let partial_upload_base_generation = self.text_generation;
+        let includes_text = changes_include_text(frame, changes);
+        if includes_text {
+            let prepared_text = self
+                .text
+                .prepare_with_changes(device, queue, frame, changes, texts, fonts, metrics)?;
+            copy_local_text_snapshot_updates(
+                &mut self.snapshot_mask_quads,
+                &mut self.snapshot_color_quads,
+                &self.text_item_ranges,
+                prepared_text.items,
+                prepared_text.mask_quads,
+                prepared_text.color_quads,
+                changes,
+                &mut self.dirty_mask_ranges,
+                &mut self.dirty_color_ranges,
+            );
+        } else {
+            self.dirty_mask_ranges.clear();
+            self.dirty_color_ranges.clear();
+        }
+        let text_instances_dirty =
+            !self.dirty_mask_ranges.is_empty() || !self.dirty_color_ranges.is_empty();
+        if text_instances_dirty {
+            self.text_generation = self
+                .text_generation
+                .checked_add(1)
+                .expect("retained text generation counter exhausted");
+        }
+
         let mut scratch_changes = Vec::with_capacity(changes.object_indices().len());
         for &index in changes.object_indices() {
+            let Some(scratch_slot) = self.scratch_slots[index] else {
+                continue;
+            };
             let object = &frame.objects[index];
-            let scratch_slot = self.scratch_slots[index].expect("validated mixed geometry slot");
             let source_geometry = frame
                 .render_geometry(index)
                 .unwrap_or_else(|| object.geometry().expect("validated mixed geometry object"));
@@ -1585,10 +1568,13 @@ impl RetainedFramePreparer {
         self.scratch.time = frame.time;
         self.incremental_stats.scratch_reuses =
             self.incremental_stats.scratch_reuses.saturating_add(1);
-        let scratch_changes = FrameChanges::objects(scratch_changes);
-        let geometry = self
-            .geometry
-            .prepare_incremental(&self.scratch, &scratch_changes);
+        let geometry = if scratch_changes.is_empty() {
+            self.geometry
+                .prepare_incremental(&self.scratch, &FrameChanges::default())
+        } else {
+            self.geometry
+                .prepare_incremental(&self.scratch, &FrameChanges::objects(scratch_changes))
+        };
         if geometry.stats.full_rebuilds > 0 {
             self.render_items.clear();
             rebuild_mixed_order(
@@ -1625,7 +1611,8 @@ impl RetainedFramePreparer {
             items: &self.snapshot_text_items,
             stats: self.snapshot_text_stats,
             atlas: self.text.atlas(),
-            partial_upload_base_generation: None,
+            partial_upload_base_generation: text_instances_dirty
+                .then_some(partial_upload_base_generation),
             dirty_mask_ranges: &self.dirty_mask_ranges,
             dirty_color_ranges: &self.dirty_color_ranges,
         };
@@ -1765,22 +1752,6 @@ fn validate_visible_object_indices(
 }
 
 impl RetainedFramePreparer {
-    fn changes_are_fast_text_only(&self, frame: &FrameState, changes: &FrameChanges) -> bool {
-        if !self.scratch_ready || changes.is_all() || changes.is_structural() || changes.is_empty()
-        {
-            return false;
-        }
-        changes.object_indices().iter().all(|&index| {
-            let Some(object) = frame.objects.get(index) else {
-                return false;
-            };
-            if !frame.is_present(index) || !matches!(&object.content, ObjectContentRef::Text(_)) {
-                return false;
-            }
-            self.fast_text_only.get(index).copied().unwrap_or(false)
-        })
-    }
-
     fn build_scratch_frame(
         &mut self,
         frame: &FrameState,
@@ -2126,6 +2097,15 @@ fn push_coalesced_range(ranges: &mut Vec<std::ops::Range<u32>>, range: std::ops:
         }
     }
     ranges.push(range);
+}
+
+fn changes_include_text(frame: &FrameState, changes: &FrameChanges) -> bool {
+    changes.object_indices().iter().any(|&index| {
+        frame
+            .objects
+            .get(index)
+            .is_some_and(|object| object.text().is_some())
+    })
 }
 
 fn same_analytic_geometry_kind(left: Option<&GeometryRef>, right: Option<&GeometryRef>) -> bool {
@@ -2867,6 +2847,50 @@ mod tests {
         )
     }
 
+    fn geometry_and_fast_text_frame() -> (
+        FrameState,
+        TextResourceArena,
+        FontResourceArena,
+        GeometryResourceArena,
+    ) {
+        let artifact = compile_typst_resource("A", TypstMode::Markup).unwrap();
+        let bounds = artifact.resource.bounds;
+        let fonts = artifact.fonts;
+        let mut texts = TextResourceArena::new();
+        let text = texts.insert(artifact.resource).unwrap();
+        (
+            FrameState {
+                time: 0.0,
+                objects: vec![
+                    FrameObjectState {
+                        id: ObjectId::new(1),
+                        content: ObjectContentRef::Geometry(GeometryRef::circle(1.0)),
+                        text_bounds: None,
+                        transform: Transform2D::default(),
+                        style: Style::default(),
+                        appearance: 1.0,
+                    },
+                    FrameObjectState {
+                        id: ObjectId::new(2),
+                        content: ObjectContentRef::Text(text),
+                        text_bounds: Some(bounds),
+                        transform: Transform2D::default(),
+                        style: Style::default(),
+                        appearance: 1.0,
+                    },
+                ],
+                presences: vec![true, true],
+                reveals: vec![1.0, 1.0],
+                morphs: vec![0.0, 0.0],
+                render_geometries: vec![None, None],
+                render_transforms: vec![None, None],
+            },
+            texts,
+            fonts,
+            GeometryResourceArena::new(),
+        )
+    }
+
     fn geometry_only_mega_path_frame() -> FrameState {
         let path = |id, y| {
             let style = Style {
@@ -3167,6 +3191,102 @@ mod tests {
                         && instance_range == &range.instance_range
                 }));
         }
+    }
+
+    #[test]
+    fn simultaneous_geometry_and_text_properties_update_local_instance_ranges() {
+        let (mut frame, texts, fonts, geometries) = geometry_and_fast_text_frame();
+        let metrics = TextDeviceMetrics::uniform(100.0).unwrap();
+        let (device, queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
+        let mut preparer = RetainedFramePreparer::new();
+        let mut renderer = GpuRenderer::new(&device, wgpu::TextureFormat::Rgba8Unorm);
+        let mut text_state = renderer.create_retained_text_state(&device, &queue);
+        let initial_text_generation;
+
+        {
+            let prepared = preparer
+                .prepare_with_changes(
+                    &device,
+                    &queue,
+                    &frame,
+                    &FrameChanges::all(),
+                    &texts,
+                    &fonts,
+                    &geometries,
+                    metrics,
+                )
+                .unwrap();
+            let observed = prepared.observe_object(1, ObjectId::new(2)).unwrap();
+            assert_eq!(observed.kind, RetainedPreparedObjectKind::Text);
+            assert!(!observed.glyph_ranges.is_empty());
+            initial_text_generation = prepared.text_generation;
+            let upload = renderer.upload_retained(&device, &queue, &prepared, &mut text_state);
+            assert!(upload.geometry.bytes_uploaded > 0);
+            assert!(upload.text.bytes_uploaded > 0);
+        }
+        let baseline = preparer.incremental_stats();
+
+        frame.time = 0.5;
+        frame.objects[0].transform.translation = Vec2::new(-1.0, 0.0);
+        frame.objects[1].transform.translation = Vec2::new(1.0, 1.0);
+        frame.objects[1].style.opacity = 0.5;
+        {
+            let prepared = preparer
+                .prepare_with_changes(
+                    &device,
+                    &queue,
+                    &frame,
+                    &FrameChanges::objects(vec![0, 1]),
+                    &texts,
+                    &fonts,
+                    &geometries,
+                    metrics,
+                )
+                .unwrap();
+            assert_eq!(prepared.geometry_stats().full_rebuilds, 0);
+            assert_eq!(prepared.geometry_stats().instances_repacked, 1);
+            assert_eq!(prepared.geometry_stats().dirty_instance_count, 1);
+            assert_eq!(prepared.text_generation, initial_text_generation + 1);
+
+            let observed = prepared.observe_object(1, ObjectId::new(2)).unwrap();
+            assert_eq!(observed.kind, RetainedPreparedObjectKind::Text);
+            assert_eq!(observed.full_rebuilds, 0);
+            assert!(observed.geometry.is_none());
+            assert!(observed
+                .glyph_ranges
+                .iter()
+                .all(|range| range.instance_dirty));
+
+            let mut writes = Vec::new();
+            let upload = renderer.upload_retained_with_trace(
+                &device,
+                &queue,
+                &prepared,
+                &mut text_state,
+                &observed,
+                &mut writes,
+            );
+            assert!(upload.geometry.bytes_uploaded > 0);
+            assert!(upload.text.bytes_uploaded > 0);
+            assert!(!writes.is_empty());
+            assert!(writes
+                .iter()
+                .all(|write| matches!(write.buffer, "text_mask" | "text_color")));
+            assert!(writes
+                .iter()
+                .all(|write| observed
+                    .glyph_ranges
+                    .iter()
+                    .any(|range| (range.instance_range.start as usize)
+                        < write.instance_range.end
+                        && write.instance_range.start < range.instance_range.end as usize)));
+        }
+
+        let after = preparer.incremental_stats();
+        assert_eq!(after.scratch_rebuilds, baseline.scratch_rebuilds);
+        assert_eq!(after.scratch_reuses, baseline.scratch_reuses + 1);
+        assert_eq!(after.text_snapshot_copies, baseline.text_snapshot_copies);
+        assert_eq!(after.mixed_order_rebuilds, baseline.mixed_order_rebuilds);
     }
 
     #[test]

--- a/crates/noon-render-wgpu/src/gpu/retained_text.rs
+++ b/crates/noon-render-wgpu/src/gpu/retained_text.rs
@@ -287,15 +287,31 @@ impl PreparedRetainedGpuFrame<'_> {
                 crate::PreparedGeometryObjectOutcome::Unsupported(object) => {
                     RetainedPreparedObjectOutcome::Unsupported(object)
                 }
-            })?
-            .map(|mut prepared| {
-                // Mixed preparation assigns renderer-private scratch IDs. The
-                // indexed source-to-scratch map above proves ownership, so expose
-                // the semantic object selected by the caller rather than leaking
-                // the private scratch ID from the geometry preparer.
-                prepared.object = object;
-                prepared
-            });
+            })?;
+        if geometry.as_ref().is_some_and(|prepared| {
+            let Ok(instance_index) = u32::try_from(prepared.instance_index) else {
+                return true;
+            };
+            !items.iter().any(|item| {
+                matches!(
+                    item,
+                    RetainedRenderItem::Geometry { object_id, batch }
+                        if *object_id == object
+                            && batch.primitive == prepared.primitive
+                            && batch.instance_range.contains(&instance_index)
+                )
+            })
+        }) {
+            return Err(RetainedPreparedObjectOutcome::Absent);
+        }
+        let geometry = geometry.map(|mut prepared| {
+            // Mixed preparation assigns renderer-private scratch IDs. The
+            // indexed source-to-scratch map and target render-item match above
+            // prove ownership, so expose the semantic object selected by the
+            // caller rather than leaking the private scratch ID.
+            prepared.object = object;
+            prepared
+        });
         if items.is_empty() && geometry.is_none() {
             return Err(RetainedPreparedObjectOutcome::Absent);
         }
@@ -3151,6 +3167,35 @@ mod tests {
                         && instance_range == &range.instance_range
                 }));
         }
+    }
+
+    #[test]
+    fn mixed_observation_rejects_a_mismatched_frame_index_and_object() {
+        let (frame, texts, fonts, geometries) = mixed_text_frame();
+        let metrics = TextDeviceMetrics::uniform(100.0).unwrap();
+        let (device, queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
+        let mut preparer = RetainedFramePreparer::new();
+        let prepared = preparer
+            .prepare_with_changes(
+                &device,
+                &queue,
+                &frame,
+                &FrameChanges::all(),
+                &texts,
+                &fonts,
+                &geometries,
+                metrics,
+            )
+            .unwrap();
+
+        assert_eq!(
+            prepared.observe_object(0, ObjectId::new(2)),
+            Err(RetainedPreparedObjectOutcome::Absent)
+        );
+        assert_eq!(
+            prepared.observe_object(1, ObjectId::new(1)),
+            Err(RetainedPreparedObjectOutcome::Absent)
+        );
     }
 
     #[test]

--- a/crates/noon-render-wgpu/src/gpu/retained_text.rs
+++ b/crates/noon-render-wgpu/src/gpu/retained_text.rs
@@ -186,6 +186,10 @@ pub enum RetainedPreparedObjectOutcome {
     Unsupported(ObjectId),
     VisibilityProjectionUnavailable,
     FamilyProjectionUnavailable,
+    /// A geometry-only frame compacted its source paths into the shared mega-path
+    /// stream. The prepared source slot does not retain an exact object-to-mega
+    /// instance range, so upload observation must not guess one.
+    MegaPathMappingUnavailable,
 }
 
 impl PreparedRetainedGpuFrame<'_> {
@@ -230,6 +234,9 @@ impl PreparedRetainedGpuFrame<'_> {
                 })?;
             if geometry.object != object {
                 return Err(RetainedPreparedObjectOutcome::Absent);
+            }
+            if geometry_path_mapping_is_compacted(&self.geometry, &geometry) {
+                return Err(RetainedPreparedObjectOutcome::MegaPathMappingUnavailable);
             }
             let Some(submission_membership) = geometry.submission_membership else {
                 return Err(RetainedPreparedObjectOutcome::VisibilityProjectionUnavailable);
@@ -310,6 +317,17 @@ impl PreparedRetainedGpuFrame<'_> {
             instances_repacked: self.geometry.stats.instances_repacked,
         })
     }
+}
+
+fn geometry_path_mapping_is_compacted(
+    frame: &crate::PreparedFrame<'_>,
+    geometry: &crate::PreparedGeometryObjectObservation,
+) -> bool {
+    matches!(geometry.primitive, RenderPrimitive::Path { .. })
+        && frame
+            .render_batches
+            .iter()
+            .any(|batch| matches!(batch.primitive, RenderPrimitive::MegaPath { .. }))
 }
 
 fn observed_glyph_ranges(
@@ -2823,6 +2841,36 @@ mod tests {
         )
     }
 
+    fn geometry_only_mega_path_frame() -> FrameState {
+        let path = |id, y| {
+            let mut style = Style::default();
+            style.fill = None;
+            style.stroke = Some(Color::WHITE);
+            style.stroke_width = 0.01;
+            FrameObjectState {
+                id: ObjectId::new(id),
+                content: ObjectContentRef::Geometry(GeometryRef::path(
+                    VectorPath::new()
+                        .move_to(Vec2::new(-0.5, y))
+                        .line_to(Vec2::new(0.5, y)),
+                )),
+                text_bounds: None,
+                transform: Transform2D::IDENTITY,
+                style,
+                appearance: 1.0,
+            }
+        };
+        FrameState {
+            time: 0.0,
+            objects: vec![path(1, 0.0), path(2, 0.2)],
+            presences: vec![true, true],
+            reveals: vec![1.0, 1.0],
+            morphs: vec![0.0, 0.0],
+            render_geometries: vec![None, None],
+            render_transforms: vec![None, None],
+        }
+    }
+
     fn outline_key(glyph_id: GlyphId) -> OutlineKey {
         OutlineKey {
             font: FontResourceHandle {
@@ -3165,6 +3213,38 @@ mod tests {
         queue.submit(Some(encoder.finish()));
         assert!(draw.geometry.draw_calls > 0);
         assert!(draw.text.draw_calls > 0);
+    }
+
+    #[test]
+    fn observed_geometry_only_mega_path_is_explicitly_unavailable() {
+        let frame = geometry_only_mega_path_frame();
+        let texts = TextResourceArena::new();
+        let fonts = FontResourceArena::new();
+        let geometries = GeometryResourceArena::new();
+        let metrics = TextDeviceMetrics::uniform(100.0).unwrap();
+        let (device, queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
+        let mut preparer = RetainedFramePreparer::new();
+        let prepared = preparer
+            .prepare_with_changes(
+                &device,
+                &queue,
+                &frame,
+                &FrameChanges::all(),
+                &texts,
+                &fonts,
+                &geometries,
+                metrics,
+            )
+            .unwrap();
+
+        assert!(prepared.geometry_only);
+        assert!(prepared.geometry.render_batches.iter().any(|batch| {
+            matches!(batch.primitive, RenderPrimitive::MegaPath { .. })
+        }));
+        assert!(matches!(
+            prepared.observe_object(0, ObjectId::new(1)),
+            Err(RetainedPreparedObjectOutcome::MegaPathMappingUnavailable)
+        ));
     }
 
     #[test]

--- a/crates/noon-render-wgpu/src/gpu/retained_text.rs
+++ b/crates/noon-render-wgpu/src/gpu/retained_text.rs
@@ -287,13 +287,15 @@ impl PreparedRetainedGpuFrame<'_> {
                 crate::PreparedGeometryObjectOutcome::Unsupported(object) => {
                     RetainedPreparedObjectOutcome::Unsupported(object)
                 }
-            })?;
-        if geometry
-            .as_ref()
-            .is_some_and(|prepared| prepared.object != object)
-        {
-            return Err(RetainedPreparedObjectOutcome::Absent);
-        }
+            })?
+            .map(|mut prepared| {
+                // Mixed preparation assigns renderer-private scratch IDs. The
+                // indexed source-to-scratch map above proves ownership, so expose
+                // the semantic object selected by the caller rather than leaking
+                // the private scratch ID from the geometry preparer.
+                prepared.object = object;
+                prepared
+            });
         if items.is_empty() && geometry.is_none() {
             return Err(RetainedPreparedObjectOutcome::Absent);
         }
@@ -1815,6 +1817,7 @@ impl RetainedFramePreparer {
                 }
                 ObjectContentRef::Text(handle) => {
                     let mut fast_text_only = true;
+                    let first_scratch_slot = self.scratch.objects.len();
                     let resource = texts
                         .get(*handle)
                         .ok_or(RetainedPrepareError::MissingTextResource)?;
@@ -1861,6 +1864,13 @@ impl RetainedFramePreparer {
                                 )?;
                             }
                         }
+                    }
+                    if self.scratch.objects.len() > first_scratch_slot {
+                        // Text vector decorations and outlined glyphs are ordinary
+                        // prepared geometry. Retain the first exact scratch slot so
+                        // an object observation can correlate its geometry upload
+                        // without guessing from semantic or packed IDs.
+                        self.scratch_slots[object_index] = Some(first_scratch_slot);
                     }
                     self.fast_text_only[object_index] = fast_text_only;
                 }
@@ -3102,6 +3112,8 @@ mod tests {
             .unwrap();
 
         let observed = prepared.observe_object(1, ObjectId::new(2)).unwrap();
+        assert_eq!(observed.object, ObjectId::new(2));
+        assert_eq!(observed.geometry.as_ref().unwrap().object, ObjectId::new(2));
         assert_eq!(observed.kind, RetainedPreparedObjectKind::Mixed);
         assert!(observed.geometry.is_some());
         assert_eq!(observed.glyph_ranges.len(), observed.glyph_item_count);
@@ -3220,29 +3232,41 @@ mod tests {
     #[test]
     fn observed_geometry_only_mega_path_is_explicitly_unavailable() {
         let frame = geometry_only_mega_path_frame();
-        let texts = TextResourceArena::new();
-        let fonts = FontResourceArena::new();
-        let geometries = GeometryResourceArena::new();
-        let metrics = TextDeviceMetrics::uniform(100.0).unwrap();
-        let (device, queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
-        let mut preparer = RetainedFramePreparer::new();
-        let prepared = preparer
-            .prepare_with_changes(
-                &device,
-                &queue,
-                &frame,
-                &FrameChanges::all(),
-                &texts,
-                &fonts,
-                &geometries,
-                metrics,
-            )
-            .unwrap();
+        // Retained mixed preparation intentionally keeps individual path draws
+        // for painter interleaving. Construct the compacted geometry state that
+        // this defensive boundary protects without changing that policy.
+        let mut geometry_preparer = FramePreparer::new();
+        let geometry = geometry_preparer.prepare(&frame);
+        let text_preparer = RetainedTextQuadPreparer::default();
+        let mut applied_publication = None;
+        let prepared = PreparedRetainedGpuFrame {
+            applied_publication: &mut applied_publication,
+            geometry,
+            geometry_only: true,
+            text_generation: 0,
+            text: PreparedRetainedTextSnapshot {
+                time: frame.time,
+                mask_quads: &[],
+                color_quads: &[],
+                items: &[],
+                stats: RetainedTextPrepareStats::default(),
+                atlas: text_preparer.atlas(),
+                partial_upload_base_generation: None,
+                dirty_mask_ranges: &[],
+                dirty_color_ranges: &[],
+            },
+            render_items: &[],
+            stats: RetainedPrepareStats::default(),
+            source_geometry_slots: None,
+            render_item_ranges: None,
+        };
 
         assert!(prepared.geometry_only);
-        assert!(prepared.geometry.render_batches.iter().any(|batch| {
-            matches!(batch.primitive, RenderPrimitive::MegaPath { .. })
-        }));
+        assert!(prepared
+            .geometry
+            .render_batches
+            .iter()
+            .any(|batch| { matches!(batch.primitive, RenderPrimitive::MegaPath { .. }) }));
         assert!(matches!(
             prepared.observe_object(0, ObjectId::new(1)),
             Err(RetainedPreparedObjectOutcome::MegaPathMappingUnavailable)

--- a/crates/noon-render-wgpu/src/gpu/retained_text.rs
+++ b/crates/noon-render-wgpu/src/gpu/retained_text.rs
@@ -14,7 +14,7 @@ use noon_core::{
 #[cfg(test)]
 use noon_core::{FontResourceArena, GeometryResourceArena, TextResourceArena};
 use noon_runtime::{FrameChanges, FrameObjectState, FrameState, RendererPublication};
-use noon_text_atlas::GpuGlyphAtlas;
+use noon_text_atlas::{GlyphAtlasPlane, GpuGlyphAtlas};
 use noon_text_render_wgpu::{
     GlyphQuadInstance, PreparedRetainedTextFrame, PreparedTextItem, RetainedTextPrepareStats,
     RetainedTextQuadPreparer, TextCamera2D, TextDeviceMetrics, TextGlyphGpuRenderer,
@@ -28,7 +28,7 @@ use swash::{
     CacheKey, FontRef, GlyphId,
 };
 
-use super::{Camera2D, DrawStats, GpuRenderer, UploadStats, PATH_SAMPLE_COUNT};
+use super::{push_upload_write, Camera2D, DrawStats, GpuRenderer, UploadStats, PATH_SAMPLE_COUNT};
 use crate::{
     FramePreparer, OrderedRenderBatch, PreparedFrame, RenderPrimitive, VisibleRenderError,
 };
@@ -151,7 +151,21 @@ pub enum RetainedPreparedObjectKind {
     Mixed,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RetainedGlyphPlane {
+    Mask,
+    Color,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RetainedPreparedGlyphRange {
+    pub plane: RetainedGlyphPlane,
+    pub page: u32,
+    pub instance_range: std::ops::Range<u32>,
+    pub instance_dirty: bool,
+}
+
+#[derive(Clone, Debug, PartialEq)]
 pub struct RetainedPreparedObjectObservation {
     pub object: ObjectId,
     pub kind: RetainedPreparedObjectKind,
@@ -160,6 +174,7 @@ pub struct RetainedPreparedObjectObservation {
     pub render_item_end: Option<usize>,
     pub render_item_count: usize,
     pub glyph_item_count: usize,
+    pub glyph_ranges: Vec<RetainedPreparedGlyphRange>,
     pub submission_membership: bool,
     pub full_rebuilds: usize,
     pub instances_repacked: usize,
@@ -227,6 +242,7 @@ impl PreparedRetainedGpuFrame<'_> {
                 render_item_end: None,
                 render_item_count: usize::from(submission_membership),
                 glyph_item_count: 0,
+                glyph_ranges: Vec::new(),
                 submission_membership,
                 full_rebuilds: self.geometry.stats.full_rebuilds,
                 instances_repacked: self.geometry.stats.instances_repacked,
@@ -248,6 +264,7 @@ impl PreparedRetainedGpuFrame<'_> {
             .iter()
             .filter(|item| matches!(item, RetainedRenderItem::Glyph { .. }))
             .count();
+        let glyph_ranges = observed_glyph_ranges(&self.text, items);
         let geometry_item_count = items.len().saturating_sub(glyph_item_count);
         let geometry = self
             .source_geometry_slots
@@ -287,11 +304,58 @@ impl PreparedRetainedGpuFrame<'_> {
             render_item_end: Some(range.end),
             render_item_count: items.len(),
             glyph_item_count,
+            glyph_ranges,
             submission_membership: !items.is_empty(),
             full_rebuilds: self.geometry.stats.full_rebuilds,
             instances_repacked: self.geometry.stats.instances_repacked,
         })
     }
+}
+
+fn observed_glyph_ranges(
+    text: &PreparedRetainedTextSnapshot<'_>,
+    items: &[RetainedRenderItem],
+) -> Vec<RetainedPreparedGlyphRange> {
+    items
+        .iter()
+        .filter_map(|item| {
+            let RetainedRenderItem::Glyph {
+                text_item_index, ..
+            } = item
+            else {
+                return None;
+            };
+            let PreparedTextItem::GlyphBatch {
+                plane,
+                page,
+                instance_range,
+                ..
+            } = text.items.get(*text_item_index)?
+            else {
+                return None;
+            };
+            let dirty_ranges = match plane {
+                noon_text_atlas::GlyphAtlasPlane::Mask => text.dirty_mask_ranges,
+                noon_text_atlas::GlyphAtlasPlane::Color => text.dirty_color_ranges,
+            };
+            Some(RetainedPreparedGlyphRange {
+                plane: match plane {
+                    noon_text_atlas::GlyphAtlasPlane::Mask => RetainedGlyphPlane::Mask,
+                    noon_text_atlas::GlyphAtlasPlane::Color => RetainedGlyphPlane::Color,
+                },
+                page: *page,
+                instance_range: instance_range.clone(),
+                instance_dirty: sorted_ranges_overlap(dirty_ranges, instance_range),
+            })
+        })
+        .collect()
+}
+
+fn sorted_ranges_overlap(ranges: &[std::ops::Range<u32>], target: &std::ops::Range<u32>) -> bool {
+    let candidate = ranges.partition_point(|range| range.end <= target.start);
+    ranges
+        .get(candidate)
+        .is_some_and(|range| range.start < target.end)
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -2362,19 +2426,17 @@ impl GpuRenderer {
         self.upload_retained_inner(device, queue, prepared, text_state, None)
     }
 
-    /// Upload a retained frame while recording exact geometry-buffer writes.
-    ///
-    /// The caller owns the opt-in trace allocation. Text retains its existing
-    /// aggregate upload statistics until the glyph renderer exposes typed ranges.
+    /// Upload a retained frame while recording exact geometry and glyph-instance
+    /// buffer writes. The caller owns the opt-in trace allocation.
     pub fn upload_retained_with_trace(
         &mut self,
         device: &wgpu::Device,
         queue: &wgpu::Queue,
         prepared: &PreparedRetainedGpuFrame<'_>,
         text_state: &mut RetainedTextGpuState,
-        geometry_writes: &mut Vec<crate::UploadWrite>,
+        upload_writes: &mut Vec<crate::UploadWrite>,
     ) -> RetainedUploadStats {
-        self.upload_retained_inner(device, queue, prepared, text_state, Some(geometry_writes))
+        self.upload_retained_inner(device, queue, prepared, text_state, Some(upload_writes))
     }
 
     fn upload_retained_inner(
@@ -2383,9 +2445,9 @@ impl GpuRenderer {
         queue: &wgpu::Queue,
         prepared: &PreparedRetainedGpuFrame<'_>,
         text_state: &mut RetainedTextGpuState,
-        geometry_writes: Option<&mut Vec<crate::UploadWrite>>,
+        mut upload_writes: Option<&mut Vec<crate::UploadWrite>>,
     ) -> RetainedUploadStats {
-        let geometry = if let Some(writes) = geometry_writes {
+        let geometry = if let Some(writes) = upload_writes.as_deref_mut() {
             self.upload_with_trace(device, queue, &prepared.geometry, writes)
         } else {
             self.upload(device, queue, &prepared.geometry)
@@ -2398,10 +2460,37 @@ impl GpuRenderer {
             prepared.text_generation,
         ) {
             let text_frame = prepared.text.as_prepared_frame();
-            let uploaded = if prepared.text.partial_upload_base_generation.is_some()
+            let partial = prepared.text.partial_upload_base_generation.is_some()
                 && prepared.text.partial_upload_base_generation
-                    == text_state.last_uploaded_generation
-            {
+                    == text_state.last_uploaded_generation;
+            let uploaded = if let Some(writes) = upload_writes.as_deref_mut() {
+                let mut trace = |plane, range, offset, bytes: &[u8]| {
+                    let buffer = match plane {
+                        GlyphAtlasPlane::Mask => "text_mask",
+                        GlyphAtlasPlane::Color => "text_color",
+                    };
+                    push_upload_write(writes, buffer, range, offset, bytes);
+                };
+                if partial {
+                    text_state.glyphs.upload_ranges_with_trace(
+                        device,
+                        queue,
+                        &text_frame,
+                        prepared.text.atlas,
+                        prepared.text.dirty_mask_ranges,
+                        prepared.text.dirty_color_ranges,
+                        &mut trace,
+                    )
+                } else {
+                    text_state.glyphs.upload_with_trace(
+                        device,
+                        queue,
+                        &text_frame,
+                        prepared.text.atlas,
+                        &mut trace,
+                    )
+                }
+            } else if partial {
                 text_state.glyphs.upload_ranges(
                     device,
                     queue,
@@ -2864,6 +2953,68 @@ mod tests {
         assert!(text_upload_needed(None, 1));
         assert!(!text_upload_needed(Some(1), 1));
         assert!(text_upload_needed(Some(1), 2));
+    }
+
+    #[test]
+    fn observed_text_object_reuses_its_existing_glyph_instance_ranges() {
+        let (frame, texts, fonts) = mixed_text_frame();
+        let geometries = GeometryResourceArena::new();
+        let metrics = TextDeviceMetrics::uniform(100.0).unwrap();
+        let (device, queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
+        let mut preparer = RetainedFramePreparer::new();
+        let prepared = preparer
+            .prepare_with_changes(
+                &device,
+                &queue,
+                &frame,
+                &FrameChanges::all(),
+                &texts,
+                &fonts,
+                &geometries,
+                metrics,
+            )
+            .unwrap();
+
+        let observed = prepared.observe_object(1, ObjectId::new(2)).unwrap();
+        assert!(matches!(
+            observed.kind,
+            RetainedPreparedObjectKind::Text | RetainedPreparedObjectKind::Mixed
+        ));
+        assert_eq!(observed.glyph_ranges.len(), observed.glyph_item_count);
+        assert!(!observed.glyph_ranges.is_empty());
+        for range in &observed.glyph_ranges {
+            assert!(!range.instance_range.is_empty());
+            assert!(prepared.render_items
+                [observed.render_item_start.unwrap()..observed.render_item_end.unwrap()]
+                .iter()
+                .filter_map(|item| {
+                    let RetainedRenderItem::Glyph {
+                        text_item_index, ..
+                    } = item
+                    else {
+                        return None;
+                    };
+                    let PreparedTextItem::GlyphBatch {
+                        plane,
+                        page,
+                        instance_range,
+                        ..
+                    } = &prepared.text.items[*text_item_index]
+                    else {
+                        return None;
+                    };
+                    Some((plane, page, instance_range))
+                })
+                .any(|(plane, page, instance_range)| {
+                    let plane = match plane {
+                        GlyphAtlasPlane::Mask => RetainedGlyphPlane::Mask,
+                        GlyphAtlasPlane::Color => RetainedGlyphPlane::Color,
+                    };
+                    plane == range.plane
+                        && *page == range.page
+                        && instance_range == &range.instance_range
+                }));
+        }
     }
 
     #[test]

--- a/crates/noon-render-wgpu/src/gpu_geometry.rs
+++ b/crates/noon-render-wgpu/src/gpu_geometry.rs
@@ -261,6 +261,9 @@ pub struct UploadWrite {
     pub payload_hash: u64,
 }
 
+pub(crate) type UploadWriteTrace<'a> =
+    dyn FnMut(&'static str, std::ops::Range<usize>, wgpu::BufferAddress, &[u8]) + 'a;
+
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct DrawStats {
     pub draw_calls: usize,
@@ -638,7 +641,20 @@ impl GpuRenderer {
         prepared: &PreparedFrame<'_>,
         writes: &mut Vec<UploadWrite>,
     ) -> UploadStats {
-        self.upload_inner(device, queue, prepared, Some(writes))
+        let mut trace = |buffer, instance_range, byte_offset, bytes: &[u8]| {
+            push_upload_write(writes, buffer, instance_range, byte_offset, bytes);
+        };
+        self.upload_inner(device, queue, prepared, Some(&mut trace))
+    }
+
+    pub(crate) fn upload_with_write_trace(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        prepared: &PreparedFrame<'_>,
+        trace: &mut UploadWriteTrace<'_>,
+    ) -> UploadStats {
+        self.upload_inner(device, queue, prepared, Some(trace))
     }
 
     fn upload_inner(
@@ -646,7 +662,7 @@ impl GpuRenderer {
         device: &wgpu::Device,
         queue: &wgpu::Queue,
         prepared: &PreparedFrame<'_>,
-        mut writes: Option<&mut Vec<UploadWrite>>,
+        mut trace: Option<&mut UploadWriteTrace<'_>>,
     ) -> UploadStats {
         let circle_bytes = std::mem::size_of_val(prepared.circles);
         let rectangle_bytes = std::mem::size_of_val(prepared.rectangles);
@@ -746,7 +762,7 @@ impl GpuRenderer {
             prepared.circle_dirty_ranges,
             circle_reallocated,
             "circle",
-            &mut writes,
+            &mut trace,
         ) + upload_dirty(
             queue,
             &self.rectangle_buffer,
@@ -754,7 +770,7 @@ impl GpuRenderer {
             prepared.rectangle_dirty_ranges,
             rectangle_reallocated,
             "rectangle",
-            &mut writes,
+            &mut trace,
         ) + upload_dirty(
             queue,
             &self.line_buffer,
@@ -762,7 +778,7 @@ impl GpuRenderer {
             prepared.line_dirty_ranges,
             line_reallocated,
             "line",
-            &mut writes,
+            &mut trace,
         ) + upload_dirty(
             queue,
             &self.path_vertex_buffer,
@@ -770,7 +786,7 @@ impl GpuRenderer {
             prepared.path_vertex_dirty_ranges,
             path_vertex_reallocated,
             "path_vertex",
-            &mut writes,
+            &mut trace,
         ) + upload_dirty(
             queue,
             &self.path_index_buffer,
@@ -778,7 +794,7 @@ impl GpuRenderer {
             prepared.path_index_dirty_ranges,
             path_index_reallocated,
             "path_index",
-            &mut writes,
+            &mut trace,
         ) + upload_dirty(
             queue,
             &self.path_instance_buffer,
@@ -786,7 +802,7 @@ impl GpuRenderer {
             prepared.path_dirty_ranges,
             path_instance_reallocated,
             "path_instance",
-            &mut writes,
+            &mut trace,
         ) + upload_dirty(
             queue,
             &self.mega_path_index_buffer,
@@ -794,7 +810,7 @@ impl GpuRenderer {
             prepared.mega_path_index_dirty_ranges,
             mega_path_index_reallocated,
             "mega_path_index",
-            &mut writes,
+            &mut trace,
         ) + upload_dirty(
             queue,
             &self.mega_path_vertex_instance_buffer,
@@ -802,7 +818,7 @@ impl GpuRenderer {
             prepared.mega_path_instance_dirty_ranges,
             mega_path_vertex_instance_reallocated,
             "mega_path_vertex_instance",
-            &mut writes,
+            &mut trace,
         );
 
         UploadStats {
@@ -1395,14 +1411,14 @@ fn upload_dirty<T: Pod>(
     dirty_ranges: &[std::ops::Range<usize>],
     force_full_upload: bool,
     buffer_name: &'static str,
-    writes: &mut Option<&mut Vec<UploadWrite>>,
+    trace: &mut Option<&mut UploadWriteTrace<'_>>,
 ) -> usize {
     if instances.is_empty() {
         return 0;
     }
     if force_full_upload {
         let bytes = bytemuck::cast_slice(instances);
-        record_upload_write(writes, buffer_name, 0..instances.len(), 0, bytes);
+        record_upload_write(trace, buffer_name, 0..instances.len(), 0, bytes);
         queue.write_buffer(buffer, 0, bytes);
         return bytes.len();
     }
@@ -1412,7 +1428,7 @@ fn upload_dirty<T: Pod>(
     for range in dirty_ranges {
         let bytes = bytemuck::cast_slice(&instances[range.clone()]);
         let byte_offset = (range.start * stride) as wgpu::BufferAddress;
-        record_upload_write(writes, buffer_name, range.clone(), byte_offset, bytes);
+        record_upload_write(trace, buffer_name, range.clone(), byte_offset, bytes);
         queue.write_buffer(buffer, byte_offset, bytes);
         bytes_uploaded += bytes.len();
     }
@@ -1420,14 +1436,14 @@ fn upload_dirty<T: Pod>(
 }
 
 fn record_upload_write(
-    writes: &mut Option<&mut Vec<UploadWrite>>,
+    trace: &mut Option<&mut UploadWriteTrace<'_>>,
     buffer: &'static str,
     instance_range: std::ops::Range<usize>,
     byte_offset: wgpu::BufferAddress,
     bytes: &[u8],
 ) {
-    if let Some(writes) = writes.as_deref_mut() {
-        push_upload_write(writes, buffer, instance_range, byte_offset, bytes);
+    if let Some(trace) = trace.as_deref_mut() {
+        trace(buffer, instance_range, byte_offset, bytes);
     }
 }
 

--- a/crates/noon-render-wgpu/src/gpu_geometry.rs
+++ b/crates/noon-render-wgpu/src/gpu_geometry.rs
@@ -1427,14 +1427,24 @@ fn record_upload_write(
     bytes: &[u8],
 ) {
     if let Some(writes) = writes.as_deref_mut() {
-        writes.push(UploadWrite {
-            buffer,
-            instance_range,
-            byte_offset,
-            byte_length: bytes.len(),
-            payload_hash: payload_hash(bytes),
-        });
+        push_upload_write(writes, buffer, instance_range, byte_offset, bytes);
     }
+}
+
+pub(crate) fn push_upload_write(
+    writes: &mut Vec<UploadWrite>,
+    buffer: &'static str,
+    instance_range: std::ops::Range<usize>,
+    byte_offset: wgpu::BufferAddress,
+    bytes: &[u8],
+) {
+    writes.push(UploadWrite {
+        buffer,
+        instance_range,
+        byte_offset,
+        byte_length: bytes.len(),
+        payload_hash: payload_hash(bytes),
+    });
 }
 
 fn payload_hash(bytes: &[u8]) -> u64 {

--- a/crates/noon-text-render-wgpu/src/gpu.rs
+++ b/crates/noon-text-render-wgpu/src/gpu.rs
@@ -111,6 +111,14 @@ pub struct TextGpuUploadStats {
     pub buffer_reallocations: usize,
 }
 
+/// Caller-owned observation of actual glyph instance buffer writes.
+///
+/// The byte slice is borrowed only for the duration of the call so an upper
+/// renderer can reuse its existing upload-write fingerprint without this crate
+/// allocating a parallel trace. Normal uploads do not install a trace.
+pub type TextUploadTrace<'a> =
+    dyn FnMut(GlyphAtlasPlane, Range<usize>, wgpu::BufferAddress, &[u8]) + 'a;
+
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct TextGpuDrawStats {
     pub draw_calls: usize,
@@ -360,7 +368,20 @@ impl TextGlyphGpuRenderer {
         prepared: &PreparedRetainedTextFrame<'_>,
         atlas: &GpuGlyphAtlas,
     ) -> TextGpuUploadStats {
-        self.upload_impl(device, queue, prepared, atlas, None, None)
+        self.upload_impl(device, queue, prepared, atlas, None, None, None)
+    }
+
+    /// Upload a full text frame while reporting its actual buffer writes to a
+    /// caller-owned opt-in trace.
+    pub fn upload_with_trace(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        prepared: &PreparedRetainedTextFrame<'_>,
+        atlas: &GpuGlyphAtlas,
+        trace: &mut TextUploadTrace<'_>,
+    ) -> TextGpuUploadStats {
+        self.upload_impl(device, queue, prepared, atlas, None, None, Some(trace))
     }
 
     /// Upload only changed instance ranges when the caller knows the GPU buffers
@@ -383,9 +404,36 @@ impl TextGlyphGpuRenderer {
             atlas,
             Some(mask_ranges),
             Some(color_ranges),
+            None,
         )
     }
 
+    /// Upload dirty text ranges while reporting the actual writes to a
+    /// caller-owned opt-in trace. Buffer growth still reports the required full
+    /// plane write.
+    #[allow(clippy::too_many_arguments)]
+    pub fn upload_ranges_with_trace(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        prepared: &PreparedRetainedTextFrame<'_>,
+        atlas: &GpuGlyphAtlas,
+        mask_ranges: &[Range<u32>],
+        color_ranges: &[Range<u32>],
+        trace: &mut TextUploadTrace<'_>,
+    ) -> TextGpuUploadStats {
+        self.upload_impl(
+            device,
+            queue,
+            prepared,
+            atlas,
+            Some(mask_ranges),
+            Some(color_ranges),
+            Some(trace),
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
     fn upload_impl(
         &mut self,
         device: &wgpu::Device,
@@ -394,6 +442,7 @@ impl TextGlyphGpuRenderer {
         atlas: &GpuGlyphAtlas,
         mask_ranges: Option<&[Range<u32>]>,
         color_ranges: Option<&[Range<u32>]>,
+        mut trace: Option<&mut TextUploadTrace<'_>>,
     ) -> TextGpuUploadStats {
         let mask_bytes = std::mem::size_of_val(prepared.mask_quads);
         let color_bytes = std::mem::size_of_val(prepared.color_quads);
@@ -418,12 +467,16 @@ impl TextGlyphGpuRenderer {
             prepared.mask_quads,
             mask_ranges,
             mask_reallocated,
+            GlyphAtlasPlane::Mask,
+            &mut trace,
         ) + upload_plane_instances(
             queue,
             &self.color_buffer,
             prepared.color_quads,
             color_ranges,
             color_reallocated,
+            GlyphAtlasPlane::Color,
+            &mut trace,
         );
         self.mask_instances = u32::try_from(prepared.mask_quads.len())
             .expect("mask glyph instance count exceeds u32 draw limits");
@@ -571,12 +624,17 @@ fn upload_plane_instances(
     instances: &[GlyphQuadInstance],
     ranges: Option<&[Range<u32>]>,
     reallocated: bool,
+    plane: GlyphAtlasPlane,
+    trace: &mut Option<&mut TextUploadTrace<'_>>,
 ) -> usize {
     if instances.is_empty() {
         return 0;
     }
     if reallocated || ranges.is_none() {
         let bytes = bytemuck::cast_slice(instances);
+        if let Some(trace) = trace.as_deref_mut() {
+            trace(plane, 0..instances.len(), 0, bytes);
+        }
         queue.write_buffer(buffer, 0, bytes);
         return bytes.len();
     }
@@ -596,6 +654,9 @@ fn upload_plane_instances(
         let offset = start
             .checked_mul(size_of::<GlyphQuadInstance>())
             .expect("text glyph upload offset overflow") as u64;
+        if let Some(trace) = trace.as_deref_mut() {
+            trace(plane, start..end, offset, bytes);
+        }
         queue.write_buffer(buffer, offset, bytes);
         bytes_uploaded += bytes.len();
     }
@@ -1052,6 +1113,42 @@ mod tests {
     }
 
     #[test]
+    fn dirty_range_trace_reports_the_exact_written_plane_and_bytes() {
+        let (device, queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
+        let atlas = GpuGlyphAtlas::new(16).unwrap();
+        let quads: [GlyphQuadInstance; 4] = std::array::from_fn(|_| test_quad());
+        let prepared = prepared_mask_frame(&quads, &[]);
+        let mut renderer = TextGlyphGpuRenderer::new(
+            &device,
+            &queue,
+            wgpu::TextureFormat::Rgba8Unorm,
+            TextCamera2D::DEFAULT,
+        );
+        renderer.upload(&device, &queue, &prepared, &atlas);
+
+        let mut writes = Vec::new();
+        let mut trace = |plane, range, offset, bytes: &[u8]| {
+            writes.push((plane, range, offset, bytes.len()));
+        };
+        let stats = renderer.upload_ranges_with_trace(
+            &device,
+            &queue,
+            &prepared,
+            &atlas,
+            &[1..3],
+            &[],
+            &mut trace,
+        );
+
+        let stride = size_of::<GlyphQuadInstance>();
+        assert_eq!(stats.bytes_uploaded, stride * 2);
+        assert_eq!(
+            writes,
+            vec![(GlyphAtlasPlane::Mask, 1..3, stride as u64, stride * 2)]
+        );
+    }
+
+    #[test]
     fn dirty_range_upload_falls_back_to_full_plane_after_reallocation() {
         let (device, queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
         let atlas = GpuGlyphAtlas::new(16).unwrap();
@@ -1064,11 +1161,32 @@ mod tests {
             TextCamera2D::DEFAULT,
         );
 
-        let stats = renderer.upload_ranges(&device, &queue, &prepared, &atlas, &[1..2], &[]);
+        let mut writes = Vec::new();
+        let mut trace = |plane, range, offset, bytes: &[u8]| {
+            writes.push((plane, range, offset, bytes.len()));
+        };
+        let stats = renderer.upload_ranges_with_trace(
+            &device,
+            &queue,
+            &prepared,
+            &atlas,
+            &[1..2],
+            &[],
+            &mut trace,
+        );
         assert_eq!(stats.buffer_reallocations, 1);
         assert_eq!(
             stats.bytes_uploaded,
             quads.len() * size_of::<GlyphQuadInstance>()
+        );
+        assert_eq!(
+            writes,
+            vec![(
+                GlyphAtlasPlane::Mask,
+                0..quads.len(),
+                0,
+                quads.len() * size_of::<GlyphQuadInstance>()
+            )]
         );
     }
 

--- a/crates/noon-web/src/renderer_observation/retained.rs
+++ b/crates/noon-web/src/renderer_observation/retained.rs
@@ -370,6 +370,14 @@ pub(crate) fn finish_renderer_observation(
                 resource: "family_projection_mapping",
             };
         }
+        Err(RetainedPreparedObjectOutcome::MegaPathMappingUnavailable) => {
+            return RendererObservationOutcome::ResourceUnavailable {
+                schema_version: RENDERER_OBSERVATION_VERSION,
+                publication: target.request.publication,
+                slot: target.request.slot,
+                resource: "mega_path_instance_mapping",
+            };
+        }
     };
     let geometry = prepared.geometry;
     let target_write = if let Some(geometry) = geometry {
@@ -775,6 +783,33 @@ mod tests {
         );
         assert!(observation.draw.submission_membership);
         assert_eq!(observation.draw.text_instances_drawn, 3);
+    }
+
+    #[test]
+    fn compacted_path_observation_reports_its_missing_source_mapping() {
+        let mirror = mirror();
+        let slot = TransportSlotId {
+            slot: 4,
+            generation: 2,
+        };
+        let target = resolve_renderer_observation_target(request(0, slot), &mirror).unwrap();
+        let outcome = finish_renderer_observation(
+            target,
+            Err(RetainedPreparedObjectOutcome::MegaPathMappingUnavailable),
+            &[],
+            RetainedUploadStats::default(),
+            RetainedDrawStats::default(),
+            4,
+            "WebGPU",
+            "success",
+        );
+        assert!(matches!(
+            outcome,
+            RendererObservationOutcome::ResourceUnavailable {
+                resource: "mega_path_instance_mapping",
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/crates/noon-web/src/renderer_observation/retained.rs
+++ b/crates/noon-web/src/renderer_observation/retained.rs
@@ -374,14 +374,6 @@ pub(crate) fn finish_renderer_observation(
     let geometry = prepared.geometry;
     let target_write = if let Some(geometry) = geometry {
         let primitive: RendererPreparedPrimitive = geometry.primitive.into();
-        if primitive == RendererPreparedPrimitive::Path {
-            return RendererObservationOutcome::ResourceUnavailable {
-                schema_version: RENDERER_OBSERVATION_VERSION,
-                publication: target.request.publication,
-                slot: target.request.slot,
-                resource: "path_draw_instance_mapping",
-            };
-        }
         let write = upload_writes.iter().find(|write| {
             write.buffer == primitive.upload_buffer()
                 && write.instance_range.contains(&geometry.instance_index)
@@ -403,8 +395,10 @@ pub(crate) fn finish_renderer_observation(
         .filter(|write| {
             prepared.glyph_ranges.iter().any(|range| {
                 write.buffer == glyph_upload_buffer(range.plane)
-                    && write.instance_range.start <= range.instance_range.start as usize
-                    && write.instance_range.end >= range.instance_range.end as usize
+                    && instance_ranges_overlap(
+                        &write.instance_range,
+                        &(range.instance_range.start as usize..range.instance_range.end as usize),
+                    )
             })
         })
         .map(Into::into)
@@ -413,8 +407,10 @@ pub(crate) fn finish_renderer_observation(
         range.instance_dirty
             && !upload_writes.iter().any(|write| {
                 write.buffer == glyph_upload_buffer(range.plane)
-                    && write.instance_range.start <= range.instance_range.start as usize
-                    && write.instance_range.end >= range.instance_range.end as usize
+                    && instance_ranges_overlap(
+                        &write.instance_range,
+                        &(range.instance_range.start as usize..range.instance_range.end as usize),
+                    )
             })
     }) {
         return RendererObservationOutcome::ResourceUnavailable {
@@ -456,6 +452,10 @@ pub(crate) fn finish_renderer_observation(
             present_called: true,
         },
     }))
+}
+
+fn instance_ranges_overlap(left: &std::ops::Range<usize>, right: &std::ops::Range<usize>) -> bool {
+    left.start < right.end && right.start < left.end
 }
 
 const fn glyph_upload_buffer(plane: RetainedGlyphPlane) -> &'static str {
@@ -718,13 +718,13 @@ mod tests {
         };
         let write = UploadWrite {
             buffer: "text_mask",
-            instance_range: 2..7,
-            byte_offset: 128,
-            byte_length: 320,
+            instance_range: 4..5,
+            byte_offset: 256,
+            byte_length: 64,
             payload_hash: 23,
         };
         let mut upload = RetainedUploadStats::default();
-        upload.text.bytes_uploaded = 320;
+        upload.text.bytes_uploaded = 64;
         let mut draw = RetainedDrawStats::default();
         draw.text.draw_calls = 1;
         draw.text.instances_drawn = 3;
@@ -766,6 +766,13 @@ mod tests {
         assert!(observation.upload.target_write.is_none());
         assert_eq!(observation.upload.target_text_writes.len(), 1);
         assert_eq!(observation.upload.target_text_writes[0].buffer, "text_mask");
+        assert_eq!(
+            (
+                observation.upload.target_text_writes[0].instance_start,
+                observation.upload.target_text_writes[0].instance_end,
+            ),
+            (4, 5)
+        );
         assert!(observation.draw.submission_membership);
         assert_eq!(observation.draw.text_instances_drawn, 3);
     }
@@ -783,7 +790,7 @@ mod tests {
             kind: RetainedPreparedObjectKind::Mixed,
             geometry: Some(PreparedGeometryObjectObservation {
                 object: ObjectId::new(21),
-                primitive: RenderPrimitive::Circle,
+                primitive: RenderPrimitive::Path { batch: 0 },
                 instance_index: 3,
                 instance_start: 3,
                 instance_end: 4,
@@ -799,7 +806,7 @@ mod tests {
             glyph_ranges: vec![noon_render_wgpu::RetainedPreparedGlyphRange {
                 plane: RetainedGlyphPlane::Color,
                 page: 1,
-                instance_range: 5..6,
+                instance_range: 5..8,
                 instance_dirty: true,
             }],
             submission_membership: true,
@@ -808,7 +815,7 @@ mod tests {
         };
         let writes = [
             UploadWrite {
-                buffer: "circle",
+                buffer: "path_instance",
                 instance_range: 3..4,
                 byte_offset: 240,
                 byte_length: 80,
@@ -816,8 +823,8 @@ mod tests {
             },
             UploadWrite {
                 buffer: "text_color",
-                instance_range: 5..6,
-                byte_offset: 320,
+                instance_range: 6..7,
+                byte_offset: 384,
                 byte_length: 64,
                 payload_hash: 29,
             },
@@ -845,11 +852,21 @@ mod tests {
             panic!("an exact mixed retained observation must be publishable");
         };
         assert_eq!(observation.prepared.kind, RendererPreparedKind::Mixed);
-        assert_eq!(observation.upload.target_write.unwrap().buffer, "circle");
+        assert_eq!(
+            observation.upload.target_write.unwrap().buffer,
+            "path_instance"
+        );
         assert_eq!(observation.upload.target_text_writes.len(), 1);
         assert_eq!(
             observation.upload.target_text_writes[0].buffer,
             "text_color"
+        );
+        assert_eq!(
+            (
+                observation.upload.target_text_writes[0].instance_start,
+                observation.upload.target_text_writes[0].instance_end,
+            ),
+            (6, 7)
         );
         assert!(observation.draw.submission_membership);
     }

--- a/crates/noon-web/src/renderer_observation/retained.rs
+++ b/crates/noon-web/src/renderer_observation/retained.rs
@@ -1,7 +1,7 @@
 use noon_render_wgpu::{
-    PackedStyle, PackedTransform, RenderPrimitive, RetainedDrawStats, RetainedPreparedObjectKind,
-    RetainedPreparedObjectObservation, RetainedPreparedObjectOutcome, RetainedUploadStats,
-    UploadWrite,
+    PackedStyle, PackedTransform, RenderPrimitive, RetainedDrawStats, RetainedGlyphPlane,
+    RetainedPreparedObjectKind, RetainedPreparedObjectObservation, RetainedPreparedObjectOutcome,
+    RetainedUploadStats, UploadWrite,
 };
 
 use crate::RetainedExecutionFrameMirror;
@@ -121,8 +121,18 @@ pub struct RendererPreparedObjectObservation {
     pub render_item_end: Option<usize>,
     pub render_item_count: usize,
     pub glyph_item_count: usize,
+    pub glyph_ranges: Vec<RendererPreparedGlyphRangeObservation>,
     pub full_rebuilds: usize,
     pub instances_repacked: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct RendererPreparedGlyphRangeObservation {
+    pub plane: &'static str,
+    pub page: u32,
+    pub instance_start: u32,
+    pub instance_end: u32,
+    pub instance_dirty: bool,
 }
 
 impl From<RetainedPreparedObjectObservation> for RendererPreparedObjectObservation {
@@ -140,6 +150,20 @@ impl From<RetainedPreparedObjectObservation> for RendererPreparedObjectObservati
             render_item_end: value.render_item_end,
             render_item_count: value.render_item_count,
             glyph_item_count: value.glyph_item_count,
+            glyph_ranges: value
+                .glyph_ranges
+                .into_iter()
+                .map(|range| RendererPreparedGlyphRangeObservation {
+                    plane: match range.plane {
+                        RetainedGlyphPlane::Mask => "mask",
+                        RetainedGlyphPlane::Color => "color",
+                    },
+                    page: range.page,
+                    instance_start: range.instance_range.start,
+                    instance_end: range.instance_range.end,
+                    instance_dirty: range.instance_dirty,
+                })
+                .collect(),
             full_rebuilds: value.full_rebuilds,
             instances_repacked: value.instances_repacked,
         }
@@ -172,6 +196,7 @@ impl From<&UploadWrite> for RendererUploadWriteObservation {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct RendererUploadObservation {
     pub target_write: Option<RendererUploadWriteObservation>,
+    pub target_text_writes: Vec<RendererUploadWriteObservation>,
     pub geometry_bytes_uploaded: usize,
     pub text_bytes_uploaded: usize,
     pub buffer_reallocations: usize,
@@ -298,7 +323,7 @@ pub(crate) fn resolve_renderer_observation_target(
 pub(crate) fn finish_renderer_observation(
     target: ResolvedRendererObservationTarget,
     prepared: Result<RetainedPreparedObjectObservation, RetainedPreparedObjectOutcome>,
-    geometry_writes: &[UploadWrite],
+    upload_writes: &[UploadWrite],
     upload: RetainedUploadStats,
     draw: RetainedDrawStats,
     presentation_sequence: u64,
@@ -346,39 +371,57 @@ pub(crate) fn finish_renderer_observation(
             };
         }
     };
-    if matches!(
-        prepared.kind,
-        RetainedPreparedObjectKind::Text | RetainedPreparedObjectKind::Mixed
-    ) {
+    let geometry = prepared.geometry;
+    let target_write = if let Some(geometry) = geometry {
+        let primitive: RendererPreparedPrimitive = geometry.primitive.into();
+        if primitive == RendererPreparedPrimitive::Path {
+            return RendererObservationOutcome::ResourceUnavailable {
+                schema_version: RENDERER_OBSERVATION_VERSION,
+                publication: target.request.publication,
+                slot: target.request.slot,
+                resource: "path_draw_instance_mapping",
+            };
+        }
+        let write = upload_writes.iter().find(|write| {
+            write.buffer == primitive.upload_buffer()
+                && write.instance_range.contains(&geometry.instance_index)
+        });
+        if geometry.instance_dirty && write.is_none() {
+            return RendererObservationOutcome::ResourceUnavailable {
+                schema_version: RENDERER_OBSERVATION_VERSION,
+                publication: target.request.publication,
+                slot: target.request.slot,
+                resource: "geometry_upload_write",
+            };
+        }
+        write
+    } else {
+        None
+    };
+    let target_text_writes = upload_writes
+        .iter()
+        .filter(|write| {
+            prepared.glyph_ranges.iter().any(|range| {
+                write.buffer == glyph_upload_buffer(range.plane)
+                    && write.instance_range.start <= range.instance_range.start as usize
+                    && write.instance_range.end >= range.instance_range.end as usize
+            })
+        })
+        .map(Into::into)
+        .collect::<Vec<_>>();
+    if prepared.glyph_ranges.iter().any(|range| {
+        range.instance_dirty
+            && !upload_writes.iter().any(|write| {
+                write.buffer == glyph_upload_buffer(range.plane)
+                    && write.instance_range.start <= range.instance_range.start as usize
+                    && write.instance_range.end >= range.instance_range.end as usize
+            })
+    }) {
         return RendererObservationOutcome::ResourceUnavailable {
             schema_version: RENDERER_OBSERVATION_VERSION,
             publication: target.request.publication,
             slot: target.request.slot,
-            resource: "text_upload_ranges",
-        };
-    }
-    let geometry = prepared
-        .geometry
-        .expect("geometry-only observation has one instance");
-    let primitive: RendererPreparedPrimitive = geometry.primitive.into();
-    if primitive == RendererPreparedPrimitive::Path {
-        return RendererObservationOutcome::ResourceUnavailable {
-            schema_version: RENDERER_OBSERVATION_VERSION,
-            publication: target.request.publication,
-            slot: target.request.slot,
-            resource: "path_draw_instance_mapping",
-        };
-    }
-    let target_write = geometry_writes.iter().find(|write| {
-        write.buffer == primitive.upload_buffer()
-            && write.instance_range.contains(&geometry.instance_index)
-    });
-    if geometry.instance_dirty && target_write.is_none() {
-        return RendererObservationOutcome::ResourceUnavailable {
-            schema_version: RENDERER_OBSERVATION_VERSION,
-            publication: target.request.publication,
-            slot: target.request.slot,
-            resource: "geometry_upload_write",
+            resource: "text_upload_write",
         };
     }
     let submission_membership = prepared.submission_membership;
@@ -391,9 +434,13 @@ pub(crate) fn finish_renderer_observation(
         prepared: prepared.into(),
         upload: RendererUploadObservation {
             target_write: target_write.map(Into::into),
+            target_text_writes,
             geometry_bytes_uploaded: upload.geometry.bytes_uploaded,
             text_bytes_uploaded: upload.text.bytes_uploaded,
-            buffer_reallocations: upload.geometry.buffer_reallocations,
+            buffer_reallocations: upload
+                .geometry
+                .buffer_reallocations
+                .saturating_add(upload.text.buffer_reallocations),
         },
         draw: RendererDrawObservation {
             submission_membership,
@@ -409,6 +456,13 @@ pub(crate) fn finish_renderer_observation(
             present_called: true,
         },
     }))
+}
+
+const fn glyph_upload_buffer(plane: RetainedGlyphPlane) -> &'static str {
+    match plane {
+        RetainedGlyphPlane::Mask => "text_mask",
+        RetainedGlyphPlane::Color => "text_color",
+    }
 }
 
 #[cfg(test)]
@@ -564,6 +618,7 @@ mod tests {
             render_item_end: Some(8),
             render_item_count: 1,
             glyph_item_count: 0,
+            glyph_ranges: Vec::new(),
             submission_membership: true,
             full_rebuilds: 0,
             instances_repacked: 1,
@@ -628,9 +683,174 @@ mod tests {
             (3, 4)
         );
         assert_eq!(target_write.byte_offset, 240);
+        assert!(upload.target_text_writes.is_empty());
         assert!(draw.submission_membership);
         assert_eq!(presentation.presentation_sequence, 4);
         assert!(presentation.submit_called);
         assert!(presentation.present_called);
+    }
+
+    #[test]
+    fn presented_text_observation_requires_and_reports_its_local_upload_write() {
+        let mirror = mirror();
+        let slot = TransportSlotId {
+            slot: 4,
+            generation: 2,
+        };
+        let target = resolve_renderer_observation_target(request(0, slot), &mirror).unwrap();
+        let prepared = RetainedPreparedObjectObservation {
+            object: ObjectId::new(21),
+            kind: RetainedPreparedObjectKind::Text,
+            geometry: None,
+            render_item_start: Some(7),
+            render_item_end: Some(8),
+            render_item_count: 1,
+            glyph_item_count: 1,
+            glyph_ranges: vec![noon_render_wgpu::RetainedPreparedGlyphRange {
+                plane: RetainedGlyphPlane::Mask,
+                page: 0,
+                instance_range: 3..6,
+                instance_dirty: true,
+            }],
+            submission_membership: true,
+            full_rebuilds: 0,
+            instances_repacked: 0,
+        };
+        let write = UploadWrite {
+            buffer: "text_mask",
+            instance_range: 2..7,
+            byte_offset: 128,
+            byte_length: 320,
+            payload_hash: 23,
+        };
+        let mut upload = RetainedUploadStats::default();
+        upload.text.bytes_uploaded = 320;
+        let mut draw = RetainedDrawStats::default();
+        draw.text.draw_calls = 1;
+        draw.text.instances_drawn = 3;
+
+        let missing = finish_renderer_observation(
+            target.clone(),
+            Ok(prepared.clone()),
+            &[],
+            upload,
+            draw,
+            4,
+            "WebGPU",
+            "success",
+        );
+        assert!(matches!(
+            missing,
+            RendererObservationOutcome::ResourceUnavailable {
+                resource: "text_upload_write",
+                ..
+            }
+        ));
+
+        let outcome = finish_renderer_observation(
+            target,
+            Ok(prepared),
+            &[write],
+            upload,
+            draw,
+            4,
+            "WebGPU",
+            "success",
+        );
+        let RendererObservationOutcome::Presented(observation) = outcome else {
+            panic!("an exact retained text observation must be publishable");
+        };
+        assert_eq!(observation.prepared.kind, RendererPreparedKind::Text);
+        assert_eq!(observation.prepared.glyph_ranges.len(), 1);
+        assert!(observation.prepared.glyph_ranges[0].instance_dirty);
+        assert!(observation.upload.target_write.is_none());
+        assert_eq!(observation.upload.target_text_writes.len(), 1);
+        assert_eq!(observation.upload.target_text_writes[0].buffer, "text_mask");
+        assert!(observation.draw.submission_membership);
+        assert_eq!(observation.draw.text_instances_drawn, 3);
+    }
+
+    #[test]
+    fn presented_mixed_observation_keeps_geometry_and_text_evidence_together() {
+        let mirror = mirror();
+        let slot = TransportSlotId {
+            slot: 4,
+            generation: 2,
+        };
+        let target = resolve_renderer_observation_target(request(0, slot), &mirror).unwrap();
+        let prepared = RetainedPreparedObjectObservation {
+            object: ObjectId::new(21),
+            kind: RetainedPreparedObjectKind::Mixed,
+            geometry: Some(PreparedGeometryObjectObservation {
+                object: ObjectId::new(21),
+                primitive: RenderPrimitive::Circle,
+                instance_index: 3,
+                instance_start: 3,
+                instance_end: 4,
+                transform: PackedTransform::from(target.mirrored.transform),
+                style: PackedStyle::from(target.mirrored.style),
+                instance_dirty: true,
+                submission_membership: Some(true),
+            }),
+            render_item_start: Some(7),
+            render_item_end: Some(9),
+            render_item_count: 2,
+            glyph_item_count: 1,
+            glyph_ranges: vec![noon_render_wgpu::RetainedPreparedGlyphRange {
+                plane: RetainedGlyphPlane::Color,
+                page: 1,
+                instance_range: 5..6,
+                instance_dirty: true,
+            }],
+            submission_membership: true,
+            full_rebuilds: 0,
+            instances_repacked: 1,
+        };
+        let writes = [
+            UploadWrite {
+                buffer: "circle",
+                instance_range: 3..4,
+                byte_offset: 240,
+                byte_length: 80,
+                payload_hash: 17,
+            },
+            UploadWrite {
+                buffer: "text_color",
+                instance_range: 5..6,
+                byte_offset: 320,
+                byte_length: 64,
+                payload_hash: 29,
+            },
+        ];
+        let mut upload = RetainedUploadStats::default();
+        upload.geometry.bytes_uploaded = 80;
+        upload.text.bytes_uploaded = 64;
+        let mut draw = RetainedDrawStats::default();
+        draw.geometry.draw_calls = 1;
+        draw.geometry.instances_drawn = 1;
+        draw.text.draw_calls = 1;
+        draw.text.instances_drawn = 1;
+
+        let outcome = finish_renderer_observation(
+            target,
+            Ok(prepared),
+            &writes,
+            upload,
+            draw,
+            5,
+            "WebGPU",
+            "success",
+        );
+        let RendererObservationOutcome::Presented(observation) = outcome else {
+            panic!("an exact mixed retained observation must be publishable");
+        };
+        assert_eq!(observation.prepared.kind, RendererPreparedKind::Mixed);
+        assert_eq!(observation.upload.target_write.unwrap().buffer, "circle");
+        assert_eq!(observation.upload.target_text_writes.len(), 1);
+        assert_eq!(
+            observation.upload.target_text_writes[0].buffer,
+            "text_color"
+        );
+        assert!(observation.draw.submission_membership);
     }
 }

--- a/crates/noon-web/src/retained_execution_canvas.rs
+++ b/crates/noon-web/src/retained_execution_canvas.rs
@@ -331,18 +331,20 @@ mod wasm {
             let prepared_observation = resolved_observation_target.as_ref().map(|target| {
                 prepared.observe_object(target.mirrored.frame_index, target.mirrored.object)
             });
-            let mut upload_writes = resolved_observation_target
-                .is_some()
-                .then(Vec::<UploadWrite>::new);
-            let upload = if resolved_observation_target.is_some() {
+            let observed_prepared = prepared_observation
+                .as_ref()
+                .and_then(|observation| observation.as_ref().ok());
+            let mut upload_writes = observed_prepared.map(|_| Vec::<UploadWrite>::new());
+            let upload = if let Some(observed) = observed_prepared {
                 self.renderer.upload_retained_with_trace(
                     &self.device,
                     &self.queue,
                     &prepared,
                     &mut self.text_gpu,
+                    observed,
                     upload_writes
                         .as_mut()
-                        .expect("resolved observation owns its upload trace"),
+                        .expect("prepared observation owns its upload trace"),
                 )
             } else {
                 self.renderer.upload_retained(

--- a/crates/noon-web/src/retained_execution_canvas.rs
+++ b/crates/noon-web/src/retained_execution_canvas.rs
@@ -331,7 +331,7 @@ mod wasm {
             let prepared_observation = resolved_observation_target.as_ref().map(|target| {
                 prepared.observe_object(target.mirrored.frame_index, target.mirrored.object)
             });
-            let mut geometry_writes = resolved_observation_target
+            let mut upload_writes = resolved_observation_target
                 .is_some()
                 .then(Vec::<UploadWrite>::new);
             let upload = if resolved_observation_target.is_some() {
@@ -340,7 +340,7 @@ mod wasm {
                     &self.queue,
                     &prepared,
                     &mut self.text_gpu,
-                    geometry_writes
+                    upload_writes
                         .as_mut()
                         .expect("resolved observation owns its upload trace"),
                 )
@@ -386,7 +386,7 @@ mod wasm {
                     Ok(target) => finish_renderer_observation(
                         target,
                         prepared_observation.expect("resolved target was prepared"),
-                        geometry_writes.as_deref().unwrap_or_default(),
+                        upload_writes.as_deref().unwrap_or_default(),
                         upload,
                         draw,
                         self.presentation_sequence,

--- a/crates/noon/src/example_scenes.rs
+++ b/crates/noon/src/example_scenes.rs
@@ -11,6 +11,7 @@ use crate::{
 const SET_Y: HostCallbackId = HostCallbackId::new(1);
 const SET_OPACITY: HostCallbackId = HostCallbackId::new(2);
 const ACCUMULATE_DT: HostCallbackId = HostCallbackId::new(3);
+const ACCUMULATE_TEXT_DT: HostCallbackId = HostCallbackId::new(4);
 
 /// Build the paired affine callback example without selecting a platform host.
 ///
@@ -20,11 +21,14 @@ const ACCUMULATE_DT: HostCallbackId = HostCallbackId::new(3);
 pub fn live_affine_callbacks() -> Result<(ExecutionSession, RustHostCallbackTable), Box<dyn Error>>
 {
     let mut scene = Scene::new();
+    let mut label = scene.text("Noon")?;
+    label.set_translation(0.0, -2.0)?;
     let mut source = scene.circle(1.0)?;
     source.set_fill(1.0, 1.0, 1.0, 1.0)?;
     let mut drift = scene.circle(0.5)?;
     drift.set_fill(1.0, 1.0, 1.0, 1.0)?;
     drift.set_translation(-3.0, 0.0)?;
+    scene.add(&label)?;
     scene.add(&source)?;
     scene.add(&drift)?;
 
@@ -56,9 +60,15 @@ pub fn live_affine_callbacks() -> Result<(ExecutionSession, RustHostCallbackTabl
         transform.translation.y += context.delta_time() as f32;
         context.set_target_transform(transform)
     })?;
+    callbacks.insert(ACCUMULATE_TEXT_DT, |context| {
+        let mut transform = context.target_state().transform;
+        transform.translation.x += context.delta_time() as f32;
+        context.set_target_transform(transform)
+    })?;
 
     {
         let mut store = scene.store().borrow_mut();
+        callbacks.add_updater(&mut store, label.node_id(), ACCUMULATE_TEXT_DT, 0.0, None)?;
         callbacks.add_updater(&mut store, source.node_id(), SET_Y, 0.0, None)?;
         callbacks.add_updater(&mut store, source.node_id(), SET_OPACITY, 0.0, None)?;
         callbacks.add_updater(&mut store, drift.node_id(), ACCUMULATE_DT, 0.0, None)?;

--- a/scripts/browser-smoke.mjs
+++ b/scripts/browser-smoke.mjs
@@ -279,8 +279,8 @@ async function directExecutionProof(page, expectedBackend) {
   );
   assert.equal(
     direct.metrics.affineCallbacks?.objectCount,
-    2,
-    "direct Rust/WASM callback scene did not retain both Rust-authored objects",
+    3,
+    "direct Rust/WASM callback scene did not retain its Text and two geometry objects",
   );
   assert.ok(
     direct.metrics.affineCallbacks?.sourceLuma >= 180,

--- a/scripts/shared-authoring-smoke.mjs
+++ b/scripts/shared-authoring-smoke.mjs
@@ -838,7 +838,7 @@ result = scene
   assert.ok(Number.isSafeInteger(publication.session));
   assert.ok(Number.isSafeInteger(publication.sequence));
   assert.equal(committed.time, callbackResult.requestedTime);
-  assert.equal(committed.dirty, "updated");
+  assert.equal(committed.dirty, "updated", JSON.stringify(rendererObservation));
   assert.equal(committed.presence, true);
   assert.deepEqual(committed.transform.translation, { x: 1, y: -2 });
   assert.equal(committed.transform.rotation, 0);

--- a/scripts/shared-authoring-smoke.mjs
+++ b/scripts/shared-authoring-smoke.mjs
@@ -827,7 +827,7 @@ result = scene
   assert.equal(callbackResult.paused.playing, false);
   assert.equal(callbackResult.advanced.playing, false);
   assert.equal(callbackResult.advanced.time, callbackResult.requestedTime);
-  assert.equal(callbackResult.metrics.objectCount, 2);
+  assert.equal(callbackResult.metrics.objectCount, 3);
   assert.ok(callbackResult.metrics.drawCalls > 0);
   const rendererObservation = callbackResult.rendererObservation;
   const {
@@ -840,11 +840,10 @@ result = scene
   assert.equal(committed.time, callbackResult.requestedTime);
   assert.equal(committed.dirty, "updated");
   assert.equal(committed.presence, true);
-  assert.deepEqual(committed.transform.translation, { x: 1, y: 1 });
-  assert.deepEqual(committed.transform.scale, { x: 1, y: 1 });
+  assert.deepEqual(committed.transform.translation, { x: 1, y: -2 });
   assert.equal(committed.transform.rotation, 0);
   assert.equal(committed.style.fill.alpha, 1);
-  assert.equal(committed.style.opacity, 0.5);
+  assert.equal(committed.style.opacity, 1);
   assert.equal(mirrored.object, committed.object);
   assert.equal(mirrored.frame_index, committed.frame_index);
   assert.equal(mirrored.time, committed.time);
@@ -852,35 +851,37 @@ result = scene
   assert.deepEqual(mirrored.style, committed.style);
   assert.equal(mirrored.presence, committed.presence);
 
-  assert.equal(prepared.kind, "geometry");
-  assert.equal(prepared.primitive, "circle");
-  assert.deepEqual(prepared.transform.translation, [1, 1]);
-  assert.deepEqual(prepared.transform.scale, [1, 1]);
-  assert.equal(prepared.transform.rotation, 0);
-  assert.equal(prepared.style.fill[3], 1);
-  assert.equal(prepared.style.opacity, 0.5);
-  assert.equal(prepared.instance_end, prepared.instance_start + 1);
-  // The geometry fast path draws packed instances directly; it does not build
-  // the mixed text/geometry render-item table.
-  assert.equal(prepared.render_item_start, null);
-  assert.equal(prepared.render_item_end, null);
-  assert.equal(prepared.render_item_count, 1);
-  assert.equal(prepared.glyph_item_count, 0);
+  assert.equal(prepared.kind, "text");
+  assert.equal(prepared.primitive, null);
+  assert.equal(prepared.transform, null);
+  assert.equal(prepared.style, null);
+  assert.equal(prepared.instance_start, null);
+  assert.equal(prepared.instance_end, null);
+  assert.ok(prepared.render_item_end > prepared.render_item_start);
+  assert.equal(prepared.render_item_count, prepared.glyph_item_count);
+  assert.ok(prepared.glyph_item_count > 0);
+  assert.equal(prepared.glyph_ranges.length, prepared.glyph_item_count);
+  assert.ok(prepared.glyph_ranges.every((range) =>
+    ["mask", "color"].includes(range.plane) &&
+    range.instance_end > range.instance_start &&
+    range.instance_dirty === true));
   assert.equal(prepared.full_rebuilds, 0);
-  assert.ok(prepared.instances_repacked > 0);
 
-  assert.equal(upload.target_write.buffer, "circle");
-  assert.ok(upload.target_write.instance_start <= prepared.instance_start);
-  assert.ok(upload.target_write.instance_end >= prepared.instance_end);
-  assert.ok(upload.target_write.byte_length > 0);
-  assert.ok(upload.geometry_bytes_uploaded >= upload.target_write.byte_length);
-  assert.equal(upload.text_bytes_uploaded, 0);
+  assert.equal(upload.target_write, null);
+  assert.ok(upload.target_text_writes.length > 0);
+  assert.ok(upload.target_text_writes.every((write) =>
+    ["text_mask", "text_color"].includes(write.buffer) &&
+    write.instance_end > write.instance_start &&
+    write.byte_length > 0 &&
+    write.payload_hash > 0));
+  assert.ok(upload.text_bytes_uploaded >= upload.target_text_writes
+    .reduce((total, write) => total + write.byte_length, 0));
   assert.equal(upload.buffer_reallocations, 0);
   assert.equal(draw.submission_membership, true);
   assert.ok(draw.geometry_draw_calls > 0);
   assert.ok(draw.geometry_instances_drawn >= 2);
-  assert.equal(draw.text_draw_calls, 0);
-  assert.equal(draw.text_instances_drawn, 0);
+  assert.ok(draw.text_draw_calls > 0);
+  assert.ok(draw.text_instances_drawn > 0);
   assert.ok(["success", "suboptimal"].includes(presentation.surface_status));
   assert.ok(presentation.presentation_sequence > 0);
   assert.equal(presentation.submit_called, true);
@@ -892,12 +893,15 @@ result = scene
   const callbackScreenshot = await page.locator(`#${callbackResult.canvasId}`).screenshot();
   const callbackPixels = {
     animated: visiblePixelStats(callbackScreenshot,
-      (r, g, b, x) => x > 300 && Math.min(r, g, b) > 35),
+      (r, g, b, x, y) => x > 300 && y < 220 && Math.min(r, g, b) > 35),
     drift: visiblePixelStats(callbackScreenshot,
-      (r, g, b, x) => x < 250 && Math.min(r, g, b) > 35),
+      (r, g, b, x, y) => x < 250 && y < 220 && Math.min(r, g, b) > 35),
+    label: visiblePixelStats(callbackScreenshot,
+      (r, g, b, x, y) => x > 300 && x < 430 && y > 230 && Math.min(r, g, b) > 35),
   };
   assert.ok(callbackPixels.animated.count > 500, "ordered callback circle was blank");
   assert.ok(callbackPixels.drift.count > 100, "accumulating callback circle was blank");
+  assert.ok(callbackPixels.label.count > 20, "observed callback text was blank");
   assert.ok(Math.abs(callbackPixels.animated.centerX - 365) < 4, "timeline midpoint x");
   assert.ok(Math.abs(callbackPixels.animated.centerY - 135) < 4, "ordered callback lift y");
   assert.ok(Math.abs(callbackPixels.drift.centerX - 185) < 4, "unowned callback x");

--- a/web/direct-execution-smoke-probe.js
+++ b/web/direct-execution-smoke-probe.js
@@ -171,6 +171,7 @@ async function directAffineCallbackProof(expectedBackend) {
     authoredTime: renderer.time(),
     objectCount: renderer.objectCount(),
     drawCalls: renderer.lastDrawCalls(),
+    textDrawCalls: renderer.lastTextDrawCalls(),
     sourceLuma,
     driftLuma,
     backgroundLuma,
@@ -186,7 +187,7 @@ async function directAffineCallbackProof(expectedBackend) {
   if (metrics.authoredTime !== 2) {
     throw new Error(`direct affine callback authored time is ${metrics.authoredTime}; expected 2`);
   }
-  if (metrics.objectCount !== 2 || metrics.drawCalls <= 0) {
+  if (metrics.objectCount !== 3 || metrics.drawCalls <= 0 || metrics.textDrawCalls <= 0) {
     throw new Error(`direct affine callback renderer produced invalid metrics ${JSON.stringify(metrics)}`);
   }
   if (

--- a/web/python/_manim_typst.py
+++ b/web/python/_manim_typst.py
@@ -385,13 +385,7 @@ class _RetainedTextMobject(_base.Mobject):
         if self._semantic_handle is not None:
             _base.Mobject.scale(self, value)
             return self
-        # Native Text aliases the ordinary shared Mobject handle, whose affine
-        # scale takes independent x/y values. Typst's retained handle remains
-        # uniform until that backend reaches the same resource path.
-        if getattr(self, "_semantic_handle", None) is not None:
-            self._retained_handle.scale(value, value)
-        else:
-            self._retained_handle.scale(value)
+        self._retained_handle.scale(value)
         return self
 
     def rotate(self, angle: float, *args: Any, **kwargs: Any) -> _RetainedTextMobject:

--- a/web/python/_manim_typst.py
+++ b/web/python/_manim_typst.py
@@ -159,6 +159,16 @@ def _native_layout_handle(handle: object):
     return handle
 
 
+def _in_canonical_callback_phase(mobject: _base.Mobject) -> bool:
+    """Inspect the existing property overlay without creating Text-local state."""
+
+    # Lazy import avoids making retained Text initialization depend on updater
+    # installation. Production installs the updater adapter after this module.
+    import _manim_updaters
+
+    return _manim_updaters._canonical_phase_context(mobject) is not None
+
+
 class _RetainedTextMobject(_base.Mobject):
     """Python semantic identity for one retained resource-backed text object."""
 
@@ -323,10 +333,15 @@ class _RetainedTextMobject(_base.Mobject):
         return json.loads(str(self._retained_handle.specJson()))
 
     def get_center(self) -> _base.Vec2:
+        if self._semantic_handle is not None:
+            return _base.Mobject.get_center(self)
         point = self._spec()["transform"]["translation"]
         return _base.Vec2(float(point["x"]), float(point["y"]))
 
     def shift(self, direction: object) -> _RetainedTextMobject:
+        if self._semantic_handle is not None:
+            _base.Mobject.shift(self, direction)
+            return self
         offset = _compat._as_vec2(direction)
         self._retained_handle.shift(float(offset.x), float(offset.y))
         return self
@@ -334,6 +349,9 @@ class _RetainedTextMobject(_base.Mobject):
     def move_to(self, point: object, *args: Any, **kwargs: Any) -> _RetainedTextMobject:
         if args or kwargs:
             raise NotImplementedError("retained text move_to currently supports point targets only")
+        if self._semantic_handle is not None:
+            _base.Mobject.move_to(self, point)
+            return self
         target = _compat._as_vec2(point)
         self._retained_handle.moveTo(float(target.x), float(target.y))
         return self
@@ -342,11 +360,17 @@ class _RetainedTextMobject(_base.Mobject):
         return self.move_to(_base.ORIGIN)
 
     def set_x(self, x: float) -> _RetainedTextMobject:
+        if self._semantic_handle is not None:
+            _base.Mobject.set_x(self, x)
+            return self
         center = self.get_center()
         self._retained_handle.moveTo(float(x), float(center.y))
         return self
 
     def set_y(self, y: float) -> _RetainedTextMobject:
+        if self._semantic_handle is not None:
+            _base.Mobject.set_y(self, y)
+            return self
         center = self.get_center()
         self._retained_handle.moveTo(float(center.x), float(y))
         return self
@@ -358,6 +382,9 @@ class _RetainedTextMobject(_base.Mobject):
         value = float(factor)
         if not math.isfinite(value) or value <= 0.0:
             raise ValueError("scale factor must be finite and positive")
+        if self._semantic_handle is not None:
+            _base.Mobject.scale(self, value)
+            return self
         # Native Text aliases the ordinary shared Mobject handle, whose affine
         # scale takes independent x/y values. Typst's retained handle remains
         # uniform until that backend reaches the same resource path.
@@ -373,12 +400,18 @@ class _RetainedTextMobject(_base.Mobject):
         value = float(angle)
         if not math.isfinite(value):
             raise ValueError("rotation angle must be finite")
+        if self._semantic_handle is not None:
+            _base.Mobject.rotate(self, value)
+            return self
         self._retained_handle.rotate(value)
         return self
 
     def set_color(self, color: _base.Color, family: bool = True) -> _RetainedTextMobject:
         del family
         value = _as_color(color)
+        if self._semantic_handle is not None:
+            _base.Mobject.set_color(self, value)
+            return self
         self._retained_handle.setColor(
             float(value.red),
             float(value.green),
@@ -392,16 +425,26 @@ class _RetainedTextMobject(_base.Mobject):
         value = float(opacity)
         if not math.isfinite(value) or not 0.0 <= value <= 1.0:
             raise ValueError("opacity must be finite and between 0 and 1")
-        if getattr(self, "_semantic_handle", None) is not None:
-            self._retained_handle.setObjectOpacity(value)
-        else:
-            self._retained_handle.setOpacity(value)
+        if self._semantic_handle is not None and _in_canonical_callback_phase(self):
+            _base.Mobject.set_opacity(self, value)
+            return self
+        if self._semantic_handle is not None:
+            # The shared semantic handler publishes through an active live
+            # session, rejects a transferred lease, and mutates the authored
+            # handle only while no live runtime owns the object.
+            _base.Mobject.set_object_opacity(self, value)
+            return self
+        self._retained_handle.setOpacity(value)
         return self
 
     def _copy_constructor(self) -> _RetainedTextMobject:
         raise NotImplementedError
 
     def copy(self) -> _RetainedTextMobject:
+        if self._semantic_handle is not None and _in_canonical_callback_phase(self):
+            raise NotImplementedError(
+                "canonical callback Text copy is unsupported; use property operations"
+            )
         if self._semantic_handle is not None:
             clone = self._copy_constructor()
             source = self._retained_handle
@@ -527,11 +570,19 @@ class Text(_RetainedTextMobject):
         return self._line_spacing
 
     def get_center(self) -> _base.Vec2:
+        if self._semantic_handle is not None:
+            return _base.Mobject.get_center(self)
         handle = _native_layout_handle(self._retained_handle)
         return _base.Vec2(float(handle.centerX), float(handle.centerY))
 
     @property
     def width(self) -> float:
+        if self._semantic_handle is not None and _in_canonical_callback_phase(self):
+            raise NotImplementedError(
+                "canonical callback Text width requires a shared effective layout query"
+            )
+        if self._semantic_handle is not None:
+            return float(_base.Mobject.width.__get__(self, type(self)))
         return float(_native_layout_handle(self._retained_handle).width)
 
     @width.setter
@@ -546,6 +597,12 @@ class Text(_RetainedTextMobject):
 
     @property
     def height(self) -> float:
+        if self._semantic_handle is not None and _in_canonical_callback_phase(self):
+            raise NotImplementedError(
+                "canonical callback Text height requires a shared effective layout query"
+            )
+        if self._semantic_handle is not None:
+            return float(_base.Mobject.height.__get__(self, type(self)))
         return float(_native_layout_handle(self._retained_handle).height)
 
     @height.setter

--- a/web/python/_manim_updaters.py
+++ b/web/python/_manim_updaters.py
@@ -496,7 +496,9 @@ class _CallbackContext:
                     fill=_color(after.style["fill"]),
                     stroke=_color(after.style["stroke"]),
                     stroke_width=after.style["stroke_width"],
-                    stroke_width_mode=after.style.get("stroke_width_mode", "scale_with_object"),
+                    stroke_width_mode=after.style.get(
+                        "stroke_width_mode", _DEFAULT_STROKE_WIDTH_MODE
+                    ),
                     stroke_join=after.style["stroke_join"],
                     stroke_cap=after.style["stroke_cap"],
                     opacity=after.style["opacity"],
@@ -536,6 +538,9 @@ class _PhaseTransform:
         }
 
 
+_DEFAULT_STROKE_WIDTH_MODE = "scale_with_object"
+
+
 @dataclass(frozen=True, slots=True)
 class _PhaseStyle:
     fill: tuple[float, float, float, float] | None
@@ -550,14 +555,22 @@ class _PhaseStyle:
     def from_wire(cls, value: object) -> "_PhaseStyle":
         if not isinstance(value, dict):
             raise TypeError("canonical callback style must be an object")
-        for key in ("stroke_width_mode", "stroke_join", "stroke_cap"):
-            if not isinstance(value.get(key), str):
+        stroke_width_mode = value.get(
+            "stroke_width_mode", _DEFAULT_STROKE_WIDTH_MODE
+        )
+        string_fields = {
+            "stroke_width_mode": stroke_width_mode,
+            "stroke_join": value.get("stroke_join"),
+            "stroke_cap": value.get("stroke_cap"),
+        }
+        for key, field in string_fields.items():
+            if not isinstance(field, str):
                 raise TypeError(f"canonical callback style.{key} must be a string")
         return cls(
             _phase_color("style.fill", value.get("fill")),
             _phase_color("style.stroke", value.get("stroke")),
             _phase_number("style.stroke_width", value.get("stroke_width")),
-            value["stroke_width_mode"],
+            stroke_width_mode,
             value["stroke_join"],
             value["stroke_cap"],
             _phase_number("style.opacity", value.get("opacity")),

--- a/web/python/examples/live_affine_callbacks.py
+++ b/web/python/examples/live_affine_callbacks.py
@@ -7,14 +7,15 @@ property batch through the Pyodide worker boundary. This source deliberately doe
 not seek or replay opaque callbacks: browser execution advances it forward.
 """
 
-from noon import Circle, Scene, WHITE, linear
+from noon import Circle, Scene, Text, WHITE, linear
 
 
 class LiveAffineCallbacks(Scene):
     def construct(self):
+        label = Text("Noon", font_size=48).shift((0.0, -2.0, 0.0))
         animated = Circle(1.0).set_fill(WHITE, opacity=1.0)
         drift = Circle(0.5).set_fill(WHITE, opacity=1.0).shift((-3.0, 0.0, 0.0))
-        self.add(animated, drift)
+        self.add(label, animated, drift)
 
         target = animated.copy().shift((2.0, 0.0, 0.0))
         animation = self.declare_live_transform_to(
@@ -35,6 +36,10 @@ class LiveAffineCallbacks(Scene):
         def accumulate_drift(mobject, dt):
             mobject.shift((0.0, dt, 0.0))
 
+        def accumulate_text(mobject, dt):
+            mobject.shift((dt, 0.0, 0.0))
+
+        label.add_updater(accumulate_text)
         animated.add_updater(lift)
         animated.add_updater(style_after_lift)
         drift.add_updater(accumulate_drift)

--- a/web/python/test_updater_snapshot.py
+++ b/web/python/test_updater_snapshot.py
@@ -82,6 +82,24 @@ class CallbackContextTests(unittest.TestCase):
 
 
 class CanonicalCallbackPropertyRowTests(unittest.TestCase):
+    def test_style_wire_uses_rust_default_and_preserves_explicit_mode(self) -> None:
+        omitted_default = _object(0)["style"]
+        self.assertNotIn("stroke_width_mode", omitted_default)
+
+        default_style = updaters._PhaseStyle.from_wire(omitted_default)
+        self.assertEqual(default_style.stroke_width_mode, "scale_with_object")
+        self.assertEqual(
+            default_style.to_wire()["stroke_width_mode"], "scale_with_object"
+        )
+
+        explicit_style = updaters._PhaseStyle.from_wire(
+            {**omitted_default, "stroke_width_mode": "screen_space"}
+        )
+        self.assertEqual(explicit_style.stroke_width_mode, "screen_space")
+        self.assertEqual(
+            explicit_style.to_wire()["stroke_width_mode"], "screen_space"
+        )
+
     @staticmethod
     def _mobject_and_context() -> tuple[object, object, object]:
         compat.install()

--- a/web/python/test_updater_snapshot.py
+++ b/web/python/test_updater_snapshot.py
@@ -2,6 +2,7 @@ import unittest
 from types import SimpleNamespace
 
 import _manim_compat as compat
+import _manim_typst as typst
 import _manim_updaters as updaters
 
 
@@ -174,6 +175,64 @@ class CanonicalCallbackPropertyRowTests(unittest.TestCase):
                 mobject.copy()
         finally:
             updaters._ACTIVE_CONTEXTS.pop(id(scene), None)
+
+    def test_native_text_uses_the_same_effective_overlay_without_authored_writes(self) -> None:
+        scene, _, context = self._mobject_and_context()
+
+        class SemanticTextHandle:
+            semanticSlot = 11
+            semanticGeneration = 3
+
+            def __init__(self) -> None:
+                self.authored_revision = 17
+                self.authored_translation = (2.0, -1.0)
+                self.authored_opacity = 1.0
+                self.calls: list[tuple[object, ...]] = []
+
+            def shift(self, x: float, y: float) -> None:
+                self.calls.append(("shift", x, y))
+                self.authored_translation = (
+                    self.authored_translation[0] + x,
+                    self.authored_translation[1] + y,
+                )
+                self.authored_revision += 1
+
+            def setObjectOpacity(self, opacity: float) -> None:
+                self.calls.append(("setObjectOpacity", opacity))
+                self.authored_opacity = opacity
+                self.authored_revision += 1
+
+        handle = SemanticTextHandle()
+        text = object.__new__(typst.Text)
+        text._scene = scene
+        text._object = SimpleNamespace(id=0)
+        text._semantic_handle = handle
+        text._semantic_handle_fresh = True
+        text._retained_handle = handle
+
+        updaters._ACTIVE_CONTEXTS[id(scene)] = context
+        try:
+            self.assertEqual(text.get_center(), updaters._base.Vec2(2.0, -1.0))
+            text.shift((0.25, 0.5))
+            text.set_opacity(0.4)
+            self.assertEqual(text.get_center(), updaters._base.Vec2(2.25, -0.5))
+            with self.assertRaises(NotImplementedError):
+                text.scale(2.0)
+            with self.assertRaises(NotImplementedError):
+                text.width
+            writes = context.effective_batch()["writes"]
+        finally:
+            updaters._ACTIVE_CONTEXTS.pop(id(scene), None)
+
+        self.assertEqual([write["kind"] for write in writes], ["transform", "style"])
+        self.assertEqual(
+            writes[0]["transform"]["translation"], {"x": 2.25, "y": -0.5}
+        )
+        self.assertEqual(writes[1]["style"]["opacity"], 0.4)
+        self.assertEqual(handle.authored_translation, (2.0, -1.0))
+        self.assertEqual(handle.authored_opacity, 1.0)
+        self.assertEqual(handle.authored_revision, 17)
+        self.assertEqual(handle.calls, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Simultaneous Text and geometry callback updates previously rebuilt the mixed retained frame, and native Text wrappers bypassed the callback overlay. The shared renderer now updates stable geometry slots and glyph instance ranges together; Text property callbacks use the existing effective-write path. Paired Rust/Python examples exercise both in one scene.

The existing opt-in renderer observation now identifies target glyph atlas planes/pages and exact instance ranges, recording only overlapping uploads. Text-owned vector geometry is correlated through the renderer's scratch mapping and checked against the target render-item range. Normal rendering performs no observation hashing or trace allocation. Observation work is proportional to selected prepared items and overlapping writes; supported local property updates preserve scratch/order snapshots and resident resources.

Advances #959, #969 and #955; stacked on #1134. Ownership stays in the renderer and shared callback/runtime boundaries. Observation is an explicit diagnostic across a real worker boundary. No new authority or migration seam is introduced. The old host diagnostic is deleted with its consumers in the following #959 slice. Individual-path policy is unchanged; missing exact mega-path mapping reports unavailable.

Validation:
- `NOON_SKIP_PLAYGROUND_TEST=1 NOON_WASM_PROFILE=dev bash scripts/check.sh full` passed before the final localized fixes (workspace tests include playground integration).
- Final Rust changes: `bash scripts/check.sh fmt-lint`, `cargo test --workspace --all-features retained_`, and `cargo test --workspace --all-features --lib simultaneous_geometry_and_text_properties` passed.
- Final Python changes: web preflight passed, plus six focused callback wire tests.
- Final package: `NOON_WASM_PROFILE=dev NOON_SKIP_WEB_PREFLIGHT=1 bash scripts/check.sh web` passed (127 API contracts).
- `node scripts/shared-authoring-smoke.mjs` passed with the final package, including real Text+geometry callback publication and partial uploads.
- `bash scripts/architecture-ratchet.sh 407d6a79` and `git diff --check 407d6a79 HEAD` passed.

Rust commands used `CARGO_INCREMENTAL=0` and the shared target directory. GitHub native/backend and other required checks remain independent merge gates.
