### PR TITLE
Measure host callbacks through canonical execution

### DIFF
--- a/scripts/host-callback-perf.mjs
+++ b/scripts/host-callback-perf.mjs
@@ -47,17 +47,25 @@ try {
     const state = await page.locator("#status").getAttribute("data-state");
     if (state === "error") throw new Error(await page.locator("#status").textContent());
     const report = await page.evaluate(() => window.__NOON_HOST_CALLBACK_PERF__);
+    assert.equal(report.schemaVersion, 2);
+    assert.equal(report.workload.objects, testCase.objects);
+    assert.equal(report.workload.active, testCase.active);
+    assert.equal(report.native.locality.lastPublication.objectCount, testCase.objects);
+    assert.equal(report.host.locality.lastPublication.objectCount, testCase.objects);
+    assert.equal(report.native.finalState.playing, false);
+    assert.equal(report.host.finalState.playing, false);
     results.push(report);
     console.log(
-      `native ${fmt(report.native.frameWorkMs?.p95)} ms, host ${fmt(report.host.frameWorkMs?.p95)} ms, ` +
-        `callback ${fmt(report.host.callbackRoundTripMs?.p95)} ms, snapshot ${fmt(report.host.callbackSnapshotBytes?.p50)} B`,
+      `native ${fmt(report.native.advanceRoundTripMs?.p95)} ms, ` +
+        `host ${fmt(report.host.advanceRoundTripMs?.p95)} ms, ` +
+        `host upload ${fmt(report.host.locality.lastPublication.bytesUploaded)} B`,
     );
     await page.close();
   }
   const commit = spawnSync("git", ["rev-parse", "HEAD"], { cwd: repoRoot, encoding: "utf8" });
   const artifact = {
-    schemaVersion: 1,
-    benchmark: "Noon native versus Python host callback matrix",
+    schemaVersion: 2,
+    benchmark: "Noon canonical native timeline versus Python callback matrix",
     generatedAt: new Date().toISOString(),
     commit: commit.status === 0 ? commit.stdout.trim() : null,
     host: { platform: os.platform(), release: os.release(), arch: os.arch(), cpu: os.cpus()[0]?.model ?? null },

--- a/scripts/host-callback-perf.mjs
+++ b/scripts/host-callback-perf.mjs
@@ -27,7 +27,18 @@ server.stderr.on("data", (chunk) => (serverOutput += chunk));
 let browser = null;
 try {
   await waitForServer();
-  browser = await chromium.launch({ channel: "chromium", headless: true, args: ["--disable-dev-shm-usage"] });
+  browser = await chromium.launch({
+    channel: "chromium",
+    headless: true,
+    args: [
+      "--disable-features=WebGPU",
+      "--enable-unsafe-swiftshader",
+      "--use-gl=angle",
+      "--use-angle=swiftshader",
+      "--disable-gpu-sandbox",
+      "--disable-dev-shm-usage",
+    ],
+  });
   const results = [];
   for (const testCase of cases) {
     const page = await browser.newPage();
@@ -50,6 +61,8 @@ try {
     assert.equal(report.schemaVersion, 2);
     assert.equal(report.workload.objects, testCase.objects);
     assert.equal(report.workload.active, testCase.active);
+    assert.equal(report.native.rendererBackend, "WebGL2");
+    assert.equal(report.host.rendererBackend, "WebGL2");
     assert.equal(report.native.locality.lastPublication.objectCount, testCase.objects);
     assert.equal(report.host.locality.lastPublication.objectCount, testCase.objects);
     assert.equal(report.native.finalState.playing, false);
@@ -69,7 +82,7 @@ try {
     generatedAt: new Date().toISOString(),
     commit: commit.status === 0 ? commit.stdout.trim() : null,
     host: { platform: os.platform(), release: os.release(), arch: os.arch(), cpu: os.cpus()[0]?.model ?? null },
-    configuration: { cases, frames, warmup },
+    configuration: { cases, frames, warmup, rendererBackend: "WebGL2 (SwiftShader)" },
     results,
   };
   await mkdir(path.dirname(artifactPath), { recursive: true });

--- a/web/host-callback-perf.js
+++ b/web/host-callback-perf.js
@@ -1,40 +1,55 @@
-import initNoonWeb, { HostScenePlayer } from "./pkg/noon_web.js";
 import { PythonAuthoringClient } from "./authoring-client.js";
+import { AuthoringExecutionClient } from "./authoring-execution-client.js";
 import { BrowserJankMonitor } from "./browser-jank.js";
 import { FrameMetrics, SampleWindow } from "./frame-metrics.js";
 
+const SAMPLE_RATE_HZ = 60;
+const SAMPLE_STEP_SECONDS = 1 / SAMPLE_RATE_HZ;
 const parameters = new URLSearchParams(location.search);
 const objectCount = positiveInteger("objects", 1_000);
 const activeCount = positiveInteger("active", 1);
 const warmupFrames = positiveInteger("warmup", 30);
 const measuredFrames = positiveInteger("frames", 300);
-if (activeCount > objectCount) throw new Error("active updater count cannot exceed object count");
+if (activeCount > objectCount) throw new Error("active object count cannot exceed object count");
 
 const status = document.querySelector("#status");
 const output = document.querySelector("#json");
-const encoder = new TextEncoder();
-let client = null;
+let authoring = null;
 
 try {
-  await initNoonWeb();
-  client = new PythonAuthoringClient();
-  await client.ready();
+  authoring = new PythonAuthoringClient();
+  await authoring.ready();
 
-  const native = await author(nativeSource(objectCount, activeCount));
-  const host = await author(hostSource(objectCount, activeCount));
-  if (native.callbacks !== null) throw new Error("native comparison scene unexpectedly registered callbacks");
-  if (host.callbacks === null) throw new Error("host comparison scene did not register callbacks");
+  // Leave enough authored extent for startup ticks plus every exact benchmark
+  // sample. The endpoint, rather than this harness, remains the execution clock.
+  const workloadDurationSeconds =
+    (warmupFrames + measuredFrames) * SAMPLE_STEP_SECONDS + 2;
+  const native = await author(nativeSource(objectCount, activeCount, workloadDurationSeconds));
+  const host = await author(hostSource(objectCount, activeCount, workloadDurationSeconds));
+  if (native.semanticExecution.callbackSessionId !== undefined) {
+    throw new Error("native comparison scene unexpectedly registered callbacks");
+  }
+  if (host.semanticExecution.callbackSessionId === undefined) {
+    throw new Error("host comparison scene did not register callbacks");
+  }
 
-  status.value = `Native baseline · ${activeCount}/${objectCount} active…`;
-  const nativeResult = await measureNative(native.document);
+  status.value = `Native timeline · ${activeCount}/${objectCount} active…`;
+  const nativeResult = await measureWorkload(native, workloadDurationSeconds);
   status.value = `Python updater · ${activeCount}/${objectCount} active…`;
-  const hostResult = await measureHost(host);
+  const hostResult = await measureWorkload(host, workloadDurationSeconds);
 
   const report = {
-    schemaVersion: 1,
-    benchmark: "Noon native versus Python host callback frame cost",
+    schemaVersion: 2,
+    benchmark: "Noon canonical native timeline versus Python callback advance round trip",
     generatedAt: new Date().toISOString(),
-    workload: { objects: objectCount, active: activeCount, warmupFrames, measuredFrames },
+    workload: {
+      objects: objectCount,
+      active: activeCount,
+      warmupFrames,
+      measuredFrames,
+      authoredSampleRateHz: SAMPLE_RATE_HZ,
+      semantics: "the first active objects translate right at 0.1 authored units per second",
+    },
     environment: {
       userAgent: navigator.userAgent,
       hardwareConcurrency: navigator.hardwareConcurrency ?? null,
@@ -43,19 +58,25 @@ try {
     native: nativeResult,
     host: hostResult,
     overhead: {
-      frameWorkP95Ms: difference(hostResult.frameWorkMs?.p95, nativeResult.frameWorkMs?.p95),
-      cadenceP95Ms: difference(hostResult.frameIntervalMs?.p95, nativeResult.frameIntervalMs?.p95),
-      callbackRoundTripP95Ms: hostResult.callbackRoundTripMs?.p95 ?? null,
-      callbackSnapshotBytesP50: hostResult.callbackSnapshotBytes?.p50 ?? null,
-      patchBytesP50: hostResult.patchBytes?.p50 ?? null,
+      advanceRoundTripP95Ms: difference(
+        hostResult.advanceRoundTripMs?.p95,
+        nativeResult.advanceRoundTripMs?.p95,
+      ),
+      cadenceP95Ms: difference(
+        hostResult.frameIntervalMs?.p95,
+        nativeResult.frameIntervalMs?.p95,
+      ),
+      lastPublicationUploadBytes: difference(
+        hostResult.locality.lastPublication.bytesUploaded,
+        nativeResult.locality.lastPublication.bytesUploaded,
+      ),
     },
   };
   window.__NOON_HOST_CALLBACK_PERF__ = report;
   output.textContent = JSON.stringify(report, null, 2);
   status.value =
-    `Complete · native work p95 ${format(nativeResult.frameWorkMs?.p95)} ms · ` +
-    `host p95 ${format(hostResult.frameWorkMs?.p95)} ms · ` +
-    `callback ${format(hostResult.callbackRoundTripMs?.p95)} ms`;
+    `Complete · native round trip p95 ${format(nativeResult.advanceRoundTripMs?.p95)} ms · ` +
+    `host ${format(hostResult.advanceRoundTripMs?.p95)} ms`;
   status.dataset.state = "complete";
   console.log("NOON_HOST_CALLBACK_PERF", report);
 } catch (error) {
@@ -63,158 +84,148 @@ try {
   status.value = `Host callback profile failed: ${error}`;
   status.dataset.state = "error";
 } finally {
-  client?.terminate();
+  authoring?.terminate();
 }
 
 async function author(source) {
-  const result = await client.run(source);
-  if (result.kind !== "scene_document") throw new Error("performance source did not return a scene");
+  const result = await authoring.run(source);
+  if (result.kind !== "scene_document" || result.semanticExecution === null) {
+    throw new Error("performance source did not return canonical semantic execution");
+  }
   return result;
 }
 
-async function measureNative(document) {
-  const player = new HostScenePlayer(JSON.stringify(document), "[]");
+async function measureWorkload(authored, workloadDurationSeconds) {
+  const canvas = document.createElement("canvas");
+  canvas.width = 320;
+  canvas.height = 180;
+  canvas.style.cssText =
+    "position:fixed;left:-10000px;top:0;width:320px;height:180px;pointer-events:none";
+  document.body.append(canvas);
+  const execution = new AuthoringExecutionClient(canvas);
   try {
-    for (let frame = 0; frame < warmupFrames; frame += 1) {
-      player.advanceTo((frame + 1) / 60);
+    const ready = await execution.startSemanticExecution(authored.semanticExecution, {
+      authoringClient: authoring,
+      loopDurationSeconds: workloadDurationSeconds,
+      transportMode: "transferable",
+    });
+    const started = await execution.state();
+    const paused = await execution.pause();
+    if (paused.playing !== false || !Number.isFinite(paused.time)) {
+      throw new Error("canonical performance endpoint did not pause coherently");
     }
-    const cadence = new FrameMetrics();
-    const work = new SampleWindow(measuredFrames);
+
+    // Start on the next exact 60 Hz authored-time boundary after any startup
+    // presentation. RAF paces samples only and never determines authored time.
+    const firstSampleIndex = Math.floor(paused.time * SAMPLE_RATE_HZ + 1e-9) + 1;
+    const sampleTime = (index) => (firstSampleIndex + index) * SAMPLE_STEP_SECONDS;
+    const finalTime = sampleTime(warmupFrames + measuredFrames - 1);
+    if (finalTime > workloadDurationSeconds) {
+      throw new Error("performance sample range exceeds the authored workload extent");
+    }
+
+    for (let frame = 0; frame < warmupFrames; frame += 1) {
+      await execution.advanceTo(sampleTime(frame));
+    }
+    const metricsBefore = await execution.metrics();
+    const cadence = new FrameMetrics({ targetHz: SAMPLE_RATE_HZ });
+    const roundTrip = new SampleWindow(measuredFrames);
     const jank = new BrowserJankMonitor();
-    let firstTimestamp = null;
     const start = performance.now();
     jank.start();
     for (let frame = 0; frame < measuredFrames; frame += 1) {
       const timestamp = await nextAnimationFrame();
-      firstTimestamp ??= timestamp;
-      const semanticTime = warmupFrames / 60 + (timestamp - firstTimestamp) / 1000 + 1 / 60;
       const began = performance.now();
-      player.advanceTo(semanticTime);
+      const requestedTime = sampleTime(warmupFrames + frame);
+      const advanced = await execution.advanceTo(requestedTime);
+      if (advanced.playing !== false || Math.abs(advanced.time - requestedTime) > 1e-9) {
+        throw new Error(`canonical endpoint did not publish exact time ${requestedTime}`);
+      }
       const elapsed = performance.now() - began;
-      cadence.record(timestamp, elapsed);
-      work.record(elapsed);
-    }
-    const end = performance.now();
-    jank.stop();
-    const frame = cadence.summary();
-    return {
-      frameWorkMs: work.summary(),
-      frameIntervalMs: frame.interval,
-      cadence: frame.cadence,
-      longTasks: jank.summary(start, end),
-    };
-  } finally {
-    player.free();
-  }
-}
-
-async function measureHost(authored) {
-  const player = new HostScenePlayer(
-    JSON.stringify(authored.document),
-    JSON.stringify(authored.callbacks.slots),
-  );
-  try {
-    let sequence = 0;
-    for (let frame = 0; frame < warmupFrames; frame += 1) {
-      player.advanceTo((frame + 1) / 60);
-      const snapshot = JSON.parse(player.callbackFrameJson());
-      const batch = await client.runCallbackPhase(authored.callbacks.session_id, snapshot, sequence);
-      player.commitPatchBatch(JSON.stringify(batch));
-      sequence += 1;
-    }
-
-    const cadence = new FrameMetrics();
-    const windows = {
-      work: new SampleWindow(measuredFrames),
-      advance: new SampleWindow(measuredFrames),
-      snapshot: new SampleWindow(measuredFrames),
-      parse: new SampleWindow(measuredFrames),
-      callback: new SampleWindow(measuredFrames),
-      serialize: new SampleWindow(measuredFrames),
-      commit: new SampleWindow(measuredFrames),
-      snapshotBytes: new SampleWindow(measuredFrames),
-      patchBytes: new SampleWindow(measuredFrames),
-      patchCount: new SampleWindow(measuredFrames),
-    };
-    const jank = new BrowserJankMonitor();
-    let firstTimestamp = null;
-    const start = performance.now();
-    jank.start();
-    for (let frame = 0; frame < measuredFrames; frame += 1) {
-      const timestamp = await nextAnimationFrame();
-      firstTimestamp ??= timestamp;
-      const semanticTime = warmupFrames / 60 + (timestamp - firstTimestamp) / 1000 + 1 / 60;
-      const frameStarted = performance.now();
-
-      let began = performance.now();
-      player.advanceTo(semanticTime);
-      windows.advance.record(performance.now() - began);
-
-      began = performance.now();
-      const snapshotJson = player.callbackFrameJson();
-      windows.snapshot.record(performance.now() - began);
-      windows.snapshotBytes.record(encoder.encode(snapshotJson).byteLength);
-
-      began = performance.now();
-      const snapshot = JSON.parse(snapshotJson);
-      windows.parse.record(performance.now() - began);
-
-      began = performance.now();
-      const batch = await client.runCallbackPhase(authored.callbacks.session_id, snapshot, sequence);
-      windows.callback.record(performance.now() - began);
-
-      began = performance.now();
-      const patchJson = JSON.stringify(batch);
-      windows.serialize.record(performance.now() - began);
-      windows.patchBytes.record(encoder.encode(patchJson).byteLength);
-      windows.patchCount.record(batch.patches.length);
-
-      began = performance.now();
-      player.commitPatchBatch(patchJson);
-      windows.commit.record(performance.now() - began);
-      sequence += 1;
-
-      const elapsed = performance.now() - frameStarted;
-      windows.work.record(elapsed);
+      roundTrip.record(elapsed);
       cadence.record(timestamp, elapsed);
     }
     const end = performance.now();
     jank.stop();
+    const metricsAfter = await execution.metrics();
+    const finalState = await execution.state();
     const frame = cadence.summary();
     return {
-      frameWorkMs: windows.work.summary(),
+      executionMode: execution.mode,
+      rendererBackend: execution.rendererBackend,
+      transportMode: ready.transportMode,
+      startup: {
+        beforePause: { time: started.time, playing: started.playing },
+        afterPause: { time: paused.time, playing: paused.playing },
+        firstExactSampleIndex: firstSampleIndex,
+      },
+      authoredSamples: {
+        warmupFirst: sampleTime(0),
+        measuredFirst: sampleTime(warmupFrames),
+        last: finalTime,
+        stepSeconds: SAMPLE_STEP_SECONDS,
+      },
+      advanceRoundTripMs: roundTrip.summary(),
       frameIntervalMs: frame.interval,
       cadence: frame.cadence,
-      advanceMs: windows.advance.summary(),
-      callbackSnapshotMs: windows.snapshot.summary(),
-      mainThreadParseMs: windows.parse.summary(),
-      callbackRoundTripMs: windows.callback.summary(),
-      patchSerializeMs: windows.serialize.summary(),
-      patchCommitMs: windows.commit.summary(),
-      callbackSnapshotBytes: windows.snapshotBytes.summary(),
-      patchBytes: windows.patchBytes.summary(),
-      patchCount: windows.patchCount.summary(),
       longTasks: jank.summary(start, end),
+      locality: localitySummary(metricsBefore, metricsAfter),
+      finalState: {
+        time: finalState.time,
+        playing: finalState.playing,
+      },
     };
   } finally {
-    player.free();
+    execution.terminate();
+    canvas.remove();
   }
 }
 
-function nativeSource(objects, active) {
+function localitySummary(before, after) {
+  const beforePresented = finiteCounter(before.presentedFrames, "starting presented frame count");
+  const afterPresented = finiteCounter(after.presentedFrames, "ending presented frame count");
+  const presentedFrames = afterPresented - beforePresented;
+  if (presentedFrames !== measuredFrames) {
+    throw new Error(
+      `exact advances presented ${presentedFrames} frames instead of ${measuredFrames}`,
+    );
+  }
+  const objectCountAfter = finiteCounter(after.objectCount, "renderer object count");
+  if (objectCountAfter !== objectCount) {
+    throw new Error(`renderer object count ${objectCountAfter} did not match ${objectCount}`);
+  }
+  return {
+    presentedFrames,
+    lastPublication: {
+      objectCount: objectCountAfter,
+      drawCalls: finiteCounter(after.drawCalls, "draw call count"),
+      instancesDrawn: finiteCounter(after.instancesDrawn, "instance count"),
+      bytesUploaded: finiteCounter(after.bytesUploaded, "uploaded byte count"),
+      geometryCacheMisses: finiteCounter(after.geometryCacheMisses, "geometry cache miss count"),
+      bufferedDeltas: finiteCounter(after.bufferedDeltas, "buffered delta count"),
+      needsPresent: Boolean(after.needsPresent),
+    },
+  };
+}
+
+function nativeSource(objects, active, duration) {
   return `
-from noon import Circle, Scene, Vec2
+from noon import Circle, RIGHT, Scene, linear
 scene = Scene()
 dots = [Circle(0.1) for _ in range(${objects})]
 for index, dot in enumerate(dots):
     scene.add(dot, key=f"dot.{index}")
-for index, dot in enumerate(dots[:${active}]):
-    scene.animate_position(dot, Vec2(0.0, 0.0), Vec2(1.0, 0.0), duration=60.0, key=f"move.{index}")
+progress = scene.value_tracker(0.0)
+for dot in dots[:${active}]:
+    scene.bind_position(dot, progress, direction=RIGHT * 0.1)
+scene.play(progress.animate(run_time=${duration}, rate_func=linear).set_value(${duration}))
+live = scene.live_execution(duration=${duration})
+live.evaluate(0.0)
 result = scene
 `;
 }
 
-function hostSource(objects, active) {
+function hostSource(objects, active, duration) {
   return `
 from noon import Circle, RIGHT, Scene
 scene = Scene()
@@ -227,12 +238,19 @@ def move(mobject, dt):
 
 for dot in dots[:${active}]:
     dot.add_updater(move)
+live = scene.live_execution(duration=${duration})
+assert live.wait(${duration}) == ${duration}
 result = scene
 `;
 }
 
 function nextAnimationFrame() {
   return new Promise((resolve) => requestAnimationFrame(resolve));
+}
+
+function finiteCounter(value, name) {
+  if (!Number.isFinite(value) || value < 0) throw new Error(`${name} must be finite and non-negative`);
+  return value;
 }
 
 function positiveInteger(name, fallback) {

--- a/web/host-callback-perf.js
+++ b/web/host-callback-perf.js
@@ -24,19 +24,18 @@ try {
   // sample. The endpoint, rather than this harness, remains the execution clock.
   const workloadDurationSeconds =
     (warmupFrames + measuredFrames) * SAMPLE_STEP_SECONDS + 2;
-  const native = await author(nativeSource(objectCount, activeCount, workloadDurationSeconds));
-  const host = await author(hostSource(objectCount, activeCount, workloadDurationSeconds));
-  if (native.semanticExecution.callbackSessionId !== undefined) {
-    throw new Error("native comparison scene unexpectedly registered callbacks");
-  }
-  if (host.semanticExecution.callbackSessionId === undefined) {
-    throw new Error("host comparison scene did not register callbacks");
-  }
-
   status.value = `Native timeline · ${activeCount}/${objectCount} active…`;
-  const nativeResult = await measureWorkload(native, workloadDurationSeconds);
+  const nativeResult = await authorAndMeasure(
+    nativeSource(objectCount, activeCount, workloadDurationSeconds),
+    workloadDurationSeconds,
+    false,
+  );
   status.value = `Python updater · ${activeCount}/${objectCount} active…`;
-  const hostResult = await measureWorkload(host, workloadDurationSeconds);
+  const hostResult = await authorAndMeasure(
+    hostSource(objectCount, activeCount, workloadDurationSeconds),
+    workloadDurationSeconds,
+    true,
+  );
 
   const report = {
     schemaVersion: 2,
@@ -95,6 +94,23 @@ async function author(source) {
     throw new Error("performance source did not return canonical semantic execution");
   }
   return result;
+}
+
+async function authorAndMeasure(source, workloadDurationSeconds, expectsCallbacks) {
+  const authored = await author(source);
+  try {
+    const hasCallbacks = authored.semanticExecution.callbackSessionId !== undefined;
+    if (hasCallbacks !== expectsCallbacks) {
+      throw new Error(
+        expectsCallbacks
+          ? "host comparison scene did not register callbacks"
+          : "native comparison scene unexpectedly registered callbacks",
+      );
+    }
+    return await measureWorkload(authored, workloadDurationSeconds);
+  } finally {
+    await authoring.releaseSemanticExecution(authored.semanticExecution.contextId);
+  }
 }
 
 async function measureWorkload(authored, workloadDurationSeconds) {

--- a/web/host-callback-perf.js
+++ b/web/host-callback-perf.js
@@ -90,7 +90,7 @@ try {
 
 async function author(source) {
   const result = await authoring.run(source);
-  if (result.kind !== "scene_document" || result.semanticExecution === null) {
+  if (typeof result.semanticExecution?.contextId !== "string") {
     throw new Error("performance source did not return canonical semantic execution");
   }
   return result;

--- a/web/host-callback-perf.js
+++ b/web/host-callback-perf.js
@@ -49,6 +49,8 @@ try {
       measuredFrames,
       authoredSampleRateHz: SAMPLE_RATE_HZ,
       semantics: "the first active objects translate right at 0.1 authored units per second",
+      layout:
+        "all objects remain coincident and visible, matching the previous benchmark workload",
     },
     environment: {
       userAgent: navigator.userAgent,
@@ -127,7 +129,7 @@ async function measureWorkload(authored, workloadDurationSeconds) {
     for (let frame = 0; frame < warmupFrames; frame += 1) {
       await execution.advanceTo(sampleTime(frame));
     }
-    const metricsBefore = await execution.metrics();
+    const metricsBefore = rendererMetrics(await execution.metrics());
     const cadence = new FrameMetrics({ targetHz: SAMPLE_RATE_HZ });
     const roundTrip = new SampleWindow(measuredFrames);
     const jank = new BrowserJankMonitor();
@@ -147,7 +149,7 @@ async function measureWorkload(authored, workloadDurationSeconds) {
     }
     const end = performance.now();
     jank.stop();
-    const metricsAfter = await execution.metrics();
+    const metricsAfter = rendererMetrics(await execution.metrics());
     const finalState = await execution.state();
     const frame = cadence.summary();
     return {
@@ -206,6 +208,18 @@ function localitySummary(before, after) {
       needsPresent: Boolean(after.needsPresent),
     },
   };
+}
+
+function rendererMetrics(report) {
+  if (
+    report === null ||
+    typeof report !== "object" ||
+    report.metrics === null ||
+    typeof report.metrics !== "object"
+  ) {
+    throw new Error("canonical execution returned an invalid renderer metrics envelope");
+  }
+  return report.metrics;
 }
 
 function nativeSource(objects, active, duration) {


### PR DESCRIPTION
The host callback benchmark now measures the native timeline and Python updater through the same canonical execution endpoint and retained renderer. It deletes its HostScenePlayer, snapshot/patch replay and legacy microtiming consumer. Exact 60 Hz authored samples are an external benchmark input; the runtime still owns evaluation, callbacks and publication. Contexts are authored, measured and released sequentially so one live session is not invalidated by authoring the next case.

Advances #959/#955, stacked on #1140. The external artifact is schema 2: inclusive advance/presentation round trip, cadence, startup, and publication/upload locality. Default coverage remains 1k/10k objects × 1/100 active, 300 measured frames. Raster/gallery HostScenePlayer consumers remain pending canonical cross-target reads and Line-content coverage; this does not claim whole-player deletion.

Validation:
- JavaScript syntax checks and exact-base architecture ratchet/diff check passed.
- `NOON_HOST_CALLBACK_CASES=1000:1 NOON_HOST_CALLBACK_FRAMES=5 NOON_HOST_CALLBACK_WARMUP=2 node scripts/host-callback-perf.mjs` passed against the qualified #1140 WASM package.
- `NOON_HOST_CALLBACK_FRAMES=30 NOON_HOST_CALLBACK_WARMUP=5 node scripts/host-callback-perf.mjs` passed all four cases on explicitly asserted SwiftShader WebGL2. Artifacts were saved outside the repository.
- One active object uploaded 88 bytes and 100 active objects uploaded 8,800 bytes at both total scene sizes. Geometry cache misses and buffered deltas were zero; measured cases had 30 matching presentations and exact object/instance counts.
- Observed p95 inclusive native/host round trip: 1k/1 = 3.2/4.4 ms; 1k/100 = 12.6/38.3 ms; 10k/1 = 2.9/4.7 ms; 10k/100 = 11.9/39.7 ms. These short software-renderer samples qualify workload execution/locality; they are not hardware performance claims.
- No Rust changed or Cargo rerun. The default 300-frame benchmark remains available for longer measurement.
