### PR TITLE
Make supported Python play and wait use shared continuation by default

### DIFF
--- a/scripts/shared-authoring-smoke.mjs
+++ b/scripts/shared-authoring-smoke.mjs
@@ -164,6 +164,39 @@ assert builtins.__noon_export_boundary_setup_count == 0
 result = Scene()
 `;
 
+const unsupportedJspiSource = `from noon import *
+import builtins
+import pyodide.ffi
+
+builtins.__noon_unsupported_jspi_original = pyodide.ffi.can_run_sync
+pyodide.ffi.can_run_sync = lambda: False
+
+class UnsupportedJspiContinuation(Scene):
+    def construct(self):
+        circle = Circle(radius=0.4)
+        self.add(circle)
+        builtins.__noon_unsupported_jspi_scene = self
+        self.play(circle.animate.shift((2.0, 0.0, 0.0)), run_time=1.0, rate_func=linear)
+`;
+
+const restoreUnsupportedJspiSource = `from noon import *
+import builtins
+import pyodide.ffi
+
+try:
+    scene = builtins.__noon_unsupported_jspi_scene
+    context = scene._canonical_authoring_context
+    assert context.liveExecutionOwnership() == "none"
+    assert context.authoredDuration() == 0.0
+    assert scene.time == 0.0
+finally:
+    pyodide.ffi.can_run_sync = builtins.__noon_unsupported_jspi_original
+    del builtins.__noon_unsupported_jspi_original
+    del builtins.__noon_unsupported_jspi_scene
+
+result = Scene()
+`;
+
 const browserArgs = [
   "--enable-unsafe-webgpu",
   "--enable-unsafe-swiftshader",
@@ -713,6 +746,26 @@ try {
     /exportDocument cannot run an async Scene construct/,
   );
   assert.equal(exportBoundary.sentinelObjectCount, 0);
+
+  // A supported ordinary segment must fail at its JSPI capability gate instead
+  // of silently using endpoint-only execution. The restore request verifies the
+  // same worker-resident context never activated a player or advanced time.
+  const unsupportedJspi = await page.evaluate(async ({ source, restoreSource }) => {
+    const harness = window.sharedAuthoringSmoke;
+    let error = null;
+    try {
+      await harness.authoring.run(source, {});
+    } catch (failure) {
+      error = String(failure);
+    } finally {
+      await harness.authoring.run(restoreSource, {});
+    }
+    return { error };
+  }, { source: unsupportedJspiSource, restoreSource: restoreUnsupportedJspiSource });
+  assert.match(
+    unsupportedJspi.error ?? "",
+    /ordinary synchronous canonical play\/wait requires Pyodide JS Promise Integration/,
+  );
 
   // Async Python construct suspends on the worker-owned semantic endpoint. The
   // early descriptor starts the existing execution client while runPythonAsync

--- a/scripts/shared-authoring-smoke.mjs
+++ b/scripts/shared-authoring-smoke.mjs
@@ -146,11 +146,11 @@ class OrdinaryExportBoundary(Scene):
 const asyncExportBoundarySource = `from noon import *
 import builtins
 
-builtins.__noon_export_boundary_setup_count = 0
+builtins._noon_export_boundary_setup_count = 0
 
 class AsyncExportBoundary(Scene):
     def setup(self):
-        builtins.__noon_export_boundary_setup_count += 1
+        builtins._noon_export_boundary_setup_count += 1
         return super().setup()
 
     async def construct(self):
@@ -160,7 +160,7 @@ class AsyncExportBoundary(Scene):
 const exportBoundarySentinelSource = `from noon import *
 import builtins
 
-assert builtins.__noon_export_boundary_setup_count == 0
+assert builtins._noon_export_boundary_setup_count == 0
 result = Scene()
 `;
 
@@ -168,14 +168,14 @@ const unsupportedJspiSource = `from noon import *
 import builtins
 import pyodide.ffi
 
-builtins.__noon_unsupported_jspi_original = pyodide.ffi.can_run_sync
+builtins._noon_unsupported_jspi_original = pyodide.ffi.can_run_sync
 pyodide.ffi.can_run_sync = lambda: False
 
 class UnsupportedJspiContinuation(Scene):
     def construct(self):
         circle = Circle(radius=0.4)
         self.add(circle)
-        builtins.__noon_unsupported_jspi_scene = self
+        builtins._noon_unsupported_jspi_scene = self
         self.play(circle.animate.shift((2.0, 0.0, 0.0)), run_time=1.0, rate_func=linear)
 `;
 
@@ -184,15 +184,15 @@ import builtins
 import pyodide.ffi
 
 try:
-    scene = builtins.__noon_unsupported_jspi_scene
+    scene = builtins._noon_unsupported_jspi_scene
     context = scene._canonical_authoring_context
     assert context.liveExecutionOwnership() == "none"
     assert context.authoredDuration() == 0.0
     assert scene.time == 0.0
 finally:
-    pyodide.ffi.can_run_sync = builtins.__noon_unsupported_jspi_original
-    del builtins.__noon_unsupported_jspi_original
-    del builtins.__noon_unsupported_jspi_scene
+    pyodide.ffi.can_run_sync = builtins._noon_unsupported_jspi_original
+    del builtins._noon_unsupported_jspi_original
+    del builtins._noon_unsupported_jspi_scene
 
 result = Scene()
 `;

--- a/scripts/shared-authoring-smoke.mjs
+++ b/scripts/shared-authoring-smoke.mjs
@@ -689,7 +689,6 @@ try {
     const sentinel = await harness.authoring.run(sentinelSource, {}, { exportDocument: true });
     return {
       ordinary: {
-        kind: ordinary.kind,
         duration: ordinary.duration,
         objectCount: ordinary.document.objects.length,
         trackCount: ordinary.sceneSpec.tracks.length,
@@ -704,7 +703,6 @@ try {
     asyncSource: asyncExportBoundarySource,
     sentinelSource: exportBoundarySentinelSource,
   });
-  assert.equal(exportBoundary.ordinary.kind, "scene_document");
   assert.equal(exportBoundary.ordinary.duration, 3);
   assert.equal(exportBoundary.ordinary.objectCount, 1);
   assert.ok(exportBoundary.ordinary.trackCount > 0, "export did not retain the affine endpoint track");

--- a/scripts/shared-authoring-smoke.mjs
+++ b/scripts/shared-authoring-smoke.mjs
@@ -490,7 +490,6 @@ try {
       filename,
     }) => {
       const harness = window.sharedAuthoringSmoke;
-      const authored = await harness.authoring.run(source, {});
       const canvas = document.createElement("canvas");
       canvas.id = `scene-${filename.replaceAll(".", "-")}`;
       canvas.width = 640;
@@ -499,12 +498,35 @@ try {
       const execution = new harness.AuthoringExecutionClient(canvas);
       let retainForInspection = false;
       try {
-        const options = {
-          authoringClient: harness.authoring,
-          transportMode: "transferable",
-        };
-        if (authored.duration > 0) options.loopDurationSeconds = authored.duration;
-        await execution.startSemanticExecution(authored.semanticExecution, options);
+        let continuation = null;
+        const authored = await harness.authoring.run(source, {}, {
+          async onSemanticContinuation(registration) {
+            if (continuation !== null) {
+              throw new Error(`${filename}: source registered more than one semantic continuation`);
+            }
+            continuation = registration;
+            await execution.startSemanticExecution(registration.semanticExecution, {
+              authoringClient: harness.authoring,
+              loopDurationSeconds: Math.max(1, registration.duration),
+              transportMode: "transferable",
+            });
+          },
+        });
+        if (continuation !== null) {
+          if (
+            authored.semanticExecution.contextId !== continuation.semanticExecution.contextId ||
+            authored.semanticExecution.continuationGeneration !== continuation.generation
+          ) {
+            throw new Error(`${filename}: final source result changed continuation context`);
+          }
+        } else {
+          const options = {
+            authoringClient: harness.authoring,
+            transportMode: "transferable",
+          };
+          if (authored.duration > 0) options.loopDurationSeconds = authored.duration;
+          await execution.startSemanticExecution(authored.semanticExecution, options);
+        }
 
         async function waitForFrame(afterPresentedFrames = 0) {
           let latest;

--- a/scripts/shared-authoring-smoke.mjs
+++ b/scripts/shared-authoring-smoke.mjs
@@ -1060,9 +1060,9 @@ try {
     window.sharedAuthoringSmoke.callbackContinuationAuthoredPromise = null;
   });
 
-  // A normal def construct opts into experimental Pyodide JSPI stack switching.
-  // Its source promise remains pending while the same continuation endpoint owns
-  // the Rust player and publishes a real intermediate frame.
+  // A normal def construct uses the canonical JSPI continuation when its first
+  // supported play reaches the shared Rust segment barrier. Its source promise
+  // stays pending while the one endpoint owns the player and presents a frame.
   const synchronousContinuationSource = await readFile(
     path.join(repoRoot, "web/python/examples/ordinary_affine_synchronous_continuation.py"),
     "utf8",

--- a/scripts/shared-authoring-smoke.mjs
+++ b/scripts/shared-authoring-smoke.mjs
@@ -133,6 +133,37 @@ assert abs(center.y + 1.0) < 1e-9
 result = scene
 `;
 
+const ordinaryExportBoundarySource = `from noon import *
+
+class OrdinaryExportBoundary(Scene):
+    def construct(self):
+        circle = Circle(radius=0.4)
+        self.add(circle)
+        self.play(circle.animate.shift((2.0, 0.0, 0.0)), run_time=2.0, rate_func=linear)
+        self.wait(1.0)
+`;
+
+const asyncExportBoundarySource = `from noon import *
+import builtins
+
+builtins.__noon_export_boundary_setup_count = 0
+
+class AsyncExportBoundary(Scene):
+    def setup(self):
+        builtins.__noon_export_boundary_setup_count += 1
+        return super().setup()
+
+    async def construct(self):
+        raise AssertionError("async export must reject before construct")
+`;
+
+const exportBoundarySentinelSource = `from noon import *
+import builtins
+
+assert builtins.__noon_export_boundary_setup_count == 0
+result = Scene()
+`;
+
 const browserArgs = [
   "--enable-unsafe-webgpu",
   "--enable-unsafe-swiftshader",
@@ -630,6 +661,60 @@ try {
       });
     }
   }
+
+  // `exportDocument` is the explicit #959 codec boundary. It still runs the
+  // shared endpoint authoring operations, but it must never lease a renderer
+  // continuation from a normal def construct. Async source cannot satisfy that
+  // boundary and rejects before `Scene.setup` mutates the worker-resident scene.
+  const exportBoundary = await page.evaluate(async ({
+    ordinarySource,
+    asyncSource,
+    sentinelSource,
+  }) => {
+    const harness = window.sharedAuthoringSmoke;
+    let continuationRegistrations = 0;
+    const ordinary = await harness.authoring.run(ordinarySource, {}, {
+      exportDocument: true,
+      onSemanticContinuation() {
+        continuationRegistrations += 1;
+        throw new Error("document export must not register a continuation");
+      },
+    });
+    let asyncError = null;
+    try {
+      await harness.authoring.run(asyncSource, {}, { exportDocument: true });
+    } catch (error) {
+      asyncError = String(error);
+    }
+    const sentinel = await harness.authoring.run(sentinelSource, {}, { exportDocument: true });
+    return {
+      ordinary: {
+        kind: ordinary.kind,
+        duration: ordinary.duration,
+        objectCount: ordinary.document.objects.length,
+        trackCount: ordinary.sceneSpec.tracks.length,
+        hasSemanticExecution: Object.hasOwn(ordinary, "semanticExecution"),
+      },
+      continuationRegistrations,
+      asyncError,
+      sentinelObjectCount: sentinel.document.objects.length,
+    };
+  }, {
+    ordinarySource: ordinaryExportBoundarySource,
+    asyncSource: asyncExportBoundarySource,
+    sentinelSource: exportBoundarySentinelSource,
+  });
+  assert.equal(exportBoundary.ordinary.kind, "scene_document");
+  assert.equal(exportBoundary.ordinary.duration, 3);
+  assert.equal(exportBoundary.ordinary.objectCount, 1);
+  assert.ok(exportBoundary.ordinary.trackCount > 0, "export did not retain the affine endpoint track");
+  assert.equal(exportBoundary.ordinary.hasSemanticExecution, false);
+  assert.equal(exportBoundary.continuationRegistrations, 0);
+  assert.match(
+    exportBoundary.asyncError ?? "",
+    /exportDocument cannot run an async Scene construct/,
+  );
+  assert.equal(exportBoundary.sentinelObjectCount, 0);
 
   // Async Python construct suspends on the worker-owned semantic endpoint. The
   // early descriptor starts the existing execution client while runPythonAsync

--- a/scripts/shared-authoring-smoke.mjs
+++ b/scripts/shared-authoring-smoke.mjs
@@ -724,7 +724,7 @@ try {
       ordinary: {
         duration: ordinary.duration,
         objectCount: ordinary.document.objects.length,
-        trackCount: ordinary.sceneSpec.tracks.length,
+        translation: ordinary.document.objects[0].transform.translation,
         hasSemanticExecution: Object.hasOwn(ordinary, "semanticExecution"),
       },
       continuationRegistrations,
@@ -738,7 +738,7 @@ try {
   });
   assert.equal(exportBoundary.ordinary.duration, 3);
   assert.equal(exportBoundary.ordinary.objectCount, 1);
-  assert.ok(exportBoundary.ordinary.trackCount > 0, "export did not retain the affine endpoint track");
+  assert.deepEqual(exportBoundary.ordinary.translation, { x: 2, y: 0 });
   assert.equal(exportBoundary.ordinary.hasSemanticExecution, false);
   assert.equal(exportBoundary.continuationRegistrations, 0);
   assert.match(

--- a/web/python-worker-source.test.mjs
+++ b/web/python-worker-source.test.mjs
@@ -111,3 +111,11 @@ test("explicit document export bypasses continuation leasing before construct mu
     /def _start_default_synchronous_continuation\(scene: _base\.Scene\)[\s\S]*?getattr\(scene, _EXPORT_DOCUMENT_CONSTRUCT, False\)[\s\S]*?return/,
   );
 });
+
+test("default canonical continuation rejects unsupported JSPI before activation", () => {
+  assert.match(
+    canonicalScene,
+    /def _start_default_synchronous_continuation\(scene: _base\.Scene\)[\s\S]*?from pyodide\.ffi import can_run_sync[\s\S]*?if not can_run_sync\(\):[\s\S]*?raise RuntimeError\(/,
+  );
+  assert.match(canonicalScene, /ordinary synchronous canonical play\/wait requires Pyodide JS Promise/);
+});

--- a/web/python-worker-source.test.mjs
+++ b/web/python-worker-source.test.mjs
@@ -3,6 +3,10 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 const source = await readFile(new URL("./python-worker.source.js", import.meta.url), "utf8");
+const canonicalScene = await readFile(
+  new URL("./python/_manim_canonical_scene.py", import.meta.url),
+  "utf8",
+);
 
 test("Python authoring worker keeps request validation helper", () => {
   assert.match(source, /function\s+validateRequest\s*\(/);
@@ -24,7 +28,10 @@ test("semantic continuation control bypasses the blocked interpreter request que
   assert.match(source, /if\s*\(isContinuationControl\(event\.data\)\)/);
   assert.match(source, /void\s+handleContinuationControl\(event\.data\)/);
   assert.match(source, /requestQueue\s*=\s*requestQueue\.then\(\(\)\s*=>\s*handleRequest/);
-  assert.match(source, /await\s+execute_construct\(__noon_result\)/);
+  assert.match(
+    source,
+    /await\s+execute_construct\(\s*__noon_result,\s*export_document=bool\(__noon_export_document\)\s*\)/,
+  );
   assert.match(source, /continuation\.endpoint\.startContinuation\(continuation\.generation\)/);
   assert.match(source, /continuation\.runRequestId\s*!==\s*request\.continuationRunRequestId/);
   assert.match(source, /noonRequireSemanticContinuationActive/);
@@ -51,7 +58,10 @@ test("worker delegates every Scene construct lifecycle to the canonical adapter"
     source.indexOf("async function runAuthoringSource"),
     source.indexOf("async function runCallbackPhase"),
   );
-  assert.match(authoring, /await\s+execute_construct\(__noon_result\)/);
+  assert.match(
+    authoring,
+    /await\s+execute_construct\(\s*__noon_result,\s*export_document=bool\(__noon_export_document\)\s*\)/,
+  );
   assert.doesNotMatch(authoring, /__noon_result\.(?:setup|construct|tear_down)\(/);
   assert.doesNotMatch(authoring, /_(?:begin|finish)_(?:async|synchronous)_continuation_construct/);
 });
@@ -80,4 +90,20 @@ test("retired callback sessions release only after the active Python run unwinds
   finishRun();
   await released;
   assert.equal(releases, 1);
+});
+
+test("explicit document export bypasses continuation leasing before construct mutation", () => {
+  assert.match(
+    canonicalScene,
+    /if export_document and inspect\.iscoroutinefunction\(scene\.construct\):[\s\S]*?raise RuntimeError\([\s\S]*?"exportDocument cannot run an async Scene construct;/,
+  );
+  const rejection = canonicalScene.indexOf(
+    "if export_document and inspect.iscoroutinefunction(scene.construct):",
+  );
+  const setup = canonicalScene.indexOf("    scene.setup()", rejection);
+  assert.ok(rejection >= 0 && setup > rejection, "async export must reject before Scene.setup");
+  assert.match(
+    canonicalScene,
+    /if export_document:[\s\S]*?setattr\(scene, _EXPORT_DOCUMENT_CONSTRUCT, True\)[\s\S]*?scene\.construct\(\)[\s\S]*?setattr\(scene, _EXPORT_DOCUMENT_CONSTRUCT, False\)/,
+  );
 });

--- a/web/python-worker-source.test.mjs
+++ b/web/python-worker-source.test.mjs
@@ -3,10 +3,6 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 const source = await readFile(new URL("./python-worker.source.js", import.meta.url), "utf8");
-const canonicalScene = await readFile(
-  new URL("./python/_manim_canonical_scene.py", import.meta.url),
-  "utf8",
-);
 
 test("Python authoring worker keeps request validation helper", () => {
   assert.match(source, /function\s+validateRequest\s*\(/);
@@ -90,32 +86,4 @@ test("retired callback sessions release only after the active Python run unwinds
   finishRun();
   await released;
   assert.equal(releases, 1);
-});
-
-test("explicit document export bypasses continuation leasing before construct mutation", () => {
-  assert.match(
-    canonicalScene,
-    /if export_document and inspect\.iscoroutinefunction\(scene\.construct\):[\s\S]*?raise RuntimeError\([\s\S]*?"exportDocument cannot run an async Scene construct;/,
-  );
-  const rejection = canonicalScene.indexOf(
-    "if export_document and inspect.iscoroutinefunction(scene.construct):",
-  );
-  const setup = canonicalScene.indexOf("    scene.setup()", rejection);
-  assert.ok(rejection >= 0 && setup > rejection, "async export must reject before Scene.setup");
-  assert.match(
-    canonicalScene,
-    /if export_document:[\s\S]*?setattr\(scene, _EXPORT_DOCUMENT_CONSTRUCT, True\)[\s\S]*?scene\.construct\(\)[\s\S]*?setattr\(scene, _EXPORT_DOCUMENT_CONSTRUCT, False\)/,
-  );
-  assert.match(
-    canonicalScene,
-    /def _start_default_synchronous_continuation\(scene: _base\.Scene\)[\s\S]*?getattr\(scene, _EXPORT_DOCUMENT_CONSTRUCT, False\)[\s\S]*?return/,
-  );
-});
-
-test("default canonical continuation rejects unsupported JSPI before activation", () => {
-  assert.match(
-    canonicalScene,
-    /def _start_default_synchronous_continuation\(scene: _base\.Scene\)[\s\S]*?from pyodide\.ffi import can_run_sync[\s\S]*?if not can_run_sync\(\):[\s\S]*?raise RuntimeError\(/,
-  );
-  assert.match(canonicalScene, /ordinary synchronous canonical play\/wait requires Pyodide JS Promise/);
 });

--- a/web/python-worker-source.test.mjs
+++ b/web/python-worker-source.test.mjs
@@ -106,4 +106,8 @@ test("explicit document export bypasses continuation leasing before construct mu
     canonicalScene,
     /if export_document:[\s\S]*?setattr\(scene, _EXPORT_DOCUMENT_CONSTRUCT, True\)[\s\S]*?scene\.construct\(\)[\s\S]*?setattr\(scene, _EXPORT_DOCUMENT_CONSTRUCT, False\)/,
   );
+  assert.match(
+    canonicalScene,
+    /def _start_default_synchronous_continuation\(scene: _base\.Scene\)[\s\S]*?getattr\(scene, _EXPORT_DOCUMENT_CONSTRUCT, False\)[\s\S]*?return/,
+  );
 });

--- a/web/python-worker.source.js
+++ b/web/python-worker.source.js
@@ -737,7 +737,9 @@ else:
             f"select one explicitly via result = SceneClass(): {__noon_names}"
         )
     __noon_result = __noon_scene_classes[0]()
-    await execute_construct(__noon_result)
+    await execute_construct(
+        __noon_result, export_document=bool(__noon_export_document)
+    )
 
 if isinstance(__noon_result, Scene):
     __noon_kind = "scene_document"

--- a/web/python/_manim_canonical_scene.py
+++ b/web/python/_manim_canonical_scene.py
@@ -50,6 +50,7 @@ _ORIGINAL_IDENTITY_DOCUMENT = _ir.Scene.identity_document
 _ASYNC_CONTINUATION_MODE = "_noon_async_continuation_mode"
 _ASYNC_CONTINUATION_PENDING = "_noon_async_continuation_pending"
 _SYNCHRONOUS_CONTINUATION_MODE = "_noon_synchronous_continuation_mode"
+_EXPORT_DOCUMENT_CONSTRUCT = "_noon_export_document_construct"
 
 
 def _json(value: object) -> str:
@@ -296,11 +297,27 @@ def _semantic_continuation_active(scene: _base.Scene) -> bool:
     return _async_continuation_active(scene) or _synchronous_continuation_active(scene)
 
 
-async def execute_construct(scene: _base.Scene) -> None:
+async def execute_construct(
+    scene: _base.Scene, *, export_document: bool = False
+) -> None:
     """Run one Scene construct lifecycle with its canonical continuation mode."""
+    if export_document and inspect.iscoroutinefunction(scene.construct):
+        raise RuntimeError(
+            "exportDocument cannot run an async Scene construct; "
+            "async source requires a semantic continuation renderer"
+        )
     scene.setup()
     try:
-        if inspect.iscoroutinefunction(scene.construct):
+        if export_document:
+            # #959 owns this explicit codec/export boundary. Ordinary supported
+            # operations retain their existing Rust endpoint helpers here; they
+            # must not request a renderer continuation lease from an exporter.
+            setattr(scene, _EXPORT_DOCUMENT_CONSTRUCT, True)
+            try:
+                scene.construct()
+            finally:
+                setattr(scene, _EXPORT_DOCUMENT_CONSTRUCT, False)
+        elif inspect.iscoroutinefunction(scene.construct):
             _begin_async_continuation_construct(scene)
             try:
                 await scene.construct()

--- a/web/python/_manim_canonical_scene.py
+++ b/web/python/_manim_canonical_scene.py
@@ -51,6 +51,9 @@ _ASYNC_CONTINUATION_MODE = "_noon_async_continuation_mode"
 _ASYNC_CONTINUATION_PENDING = "_noon_async_continuation_pending"
 _SYNCHRONOUS_CONTINUATION_MODE = "_noon_synchronous_continuation_mode"
 _EXPORT_DOCUMENT_CONSTRUCT = "_noon_export_document_construct"
+_DEFAULT_SYNCHRONOUS_CONTINUATION_CANDIDATE = (
+    "_noon_default_synchronous_continuation_candidate"
+)
 
 
 def _json(value: object) -> str:
@@ -262,25 +265,28 @@ def _async_continuation_active(scene: _base.Scene) -> bool:
     return bool(getattr(scene, _ASYNC_CONTINUATION_MODE, False))
 
 
-def _synchronous_continuation_requested(scene: _base.Scene) -> bool:
-    """Return the explicit opt-in for JSPI-backed synchronous continuation.
-
-    Ordinary ``def construct`` remains endpoint-only by default. This opt-in is
-    per Scene while JSPI remains experimental; it never selects the legacy
-    scheduler when the runtime cannot suspend.
-    """
-    return getattr(scene, "realtime_continuation", False) is True
+def _default_synchronous_continuation_candidate(scene: _base.Scene) -> bool:
+    """Whether this ordinary construct may enter one supported JSPI barrier."""
+    return bool(getattr(scene, _DEFAULT_SYNCHRONOUS_CONTINUATION_CANDIDATE, False))
 
 
-def _begin_synchronous_continuation_construct(scene: _base.Scene) -> None:
-    if _async_continuation_active(scene) or getattr(scene, _SYNCHRONOUS_CONTINUATION_MODE, False):
-        raise RuntimeError("canonical synchronous construct is already active")
+def _start_default_synchronous_continuation(scene: _base.Scene) -> None:
+    """Enter the existing synchronous continuation only before Rust mutation."""
+    if (
+        not _default_synchronous_continuation_candidate(scene)
+        or getattr(scene, _EXPORT_DOCUMENT_CONSTRUCT, False)
+    ):
+        return
+    if _synchronous_continuation_active(scene):
+        return
+    if _async_continuation_active(scene):
+        raise RuntimeError("canonical async and synchronous constructs cannot overlap")
     from pyodide.ffi import can_run_sync
 
     if not can_run_sync():
         raise RuntimeError(
-            "synchronous realtime continuation requires JS Promise Integration; "
-            "use async construct or a JSPI-capable browser"
+            "ordinary synchronous canonical play/wait requires Pyodide JS Promise "
+            "Integration in this browser; use async construct or a JSPI-capable browser"
         )
     setattr(scene, _SYNCHRONOUS_CONTINUATION_MODE, True)
 
@@ -323,14 +329,17 @@ async def execute_construct(
                 await scene.construct()
             finally:
                 _finish_async_continuation_construct(scene)
-        elif _synchronous_continuation_requested(scene):
-            _begin_synchronous_continuation_construct(scene)
+        else:
+            # Do not probe JSPI for a static or legacy-only ordinary construct.
+            # The first supported canonical segment preflights it before Rust
+            # creates or activates that segment, so unsupported browsers fail
+            # without selecting endpoint-only execution for the same operation.
+            setattr(scene, _DEFAULT_SYNCHRONOUS_CONTINUATION_CANDIDATE, True)
             try:
                 scene.construct()
             finally:
+                setattr(scene, _DEFAULT_SYNCHRONOUS_CONTINUATION_CANDIDATE, False)
                 _finish_synchronous_continuation_construct(scene)
-        else:
-            scene.construct()
     finally:
         scene.tear_down()
 
@@ -479,6 +488,12 @@ def _synchronous_continuation_wait(scene: _base.Scene) -> _base.Scene:
 def _canonical_wait(
     scene: _base.Scene, duration: float = 1.0
 ) -> _base.Scene | _SemanticContinuationAwaitable:
+    if (
+        _default_synchronous_continuation_candidate(scene)
+        and not getattr(scene, "_legacy_geometry_materialized", False)
+        and getattr(scene, "_canonical_authoring_context", None) is not None
+    ):
+        _start_default_synchronous_continuation(scene)
     if _semantic_continuation_active(scene):
         try:
             _require_semantic_continuation_active(scene)
@@ -550,6 +565,7 @@ def _play_canonical_tracker(
             "canonical ValueTracker.play cannot follow legacy Scene timing"
         )
     try:
+        _start_default_synchronous_continuation(self)
         _require_semantic_continuation_active(self)
         if _semantic_continuation_active(self):
             _prepare_semantic_continuation_callbacks(self, context)
@@ -739,6 +755,7 @@ def _play_canonical_affine(
         raise NotImplementedError(
             "canonical ordinary Scene.play currently supports one linear affine transform"
         )
+    _start_default_synchronous_continuation(self)
     context = _context(self)
     try:
         _require_semantic_continuation_active(self)
@@ -890,6 +907,7 @@ def _play_canonical_fade(
         raise NotImplementedError(
             "canonical ordinary Fade currently supports one basic leaf appearance lifecycle"
         )
+    _start_default_synchronous_continuation(self)
     object_id, reservation = _fade_object_id(self, target, direction)
     context = _context(self)
     try:
@@ -1059,6 +1077,7 @@ def _play_canonical_composition(
         raise NotImplementedError(
             "canonical ordinary composition cannot follow legacy Scene timing"
         )
+    _start_default_synchronous_continuation(self)
     context = _context(self)
     try:
         if _semantic_continuation_active(self):
@@ -1186,10 +1205,6 @@ def _play(self, *args, **kwargs):
         )
     canonical_builders = [argument for argument in args if _canonical_tracker_builder(argument)]
     if canonical_builders:
-        if _semantic_continuation_active(self):
-            raise NotImplementedError(
-                "realtime construct does not yet support ValueTracker play"
-            )
         if len(canonical_builders) != 1 or len(args) != 1:
             raise NotImplementedError(
                 "canonical ValueTracker.play currently supports one scalar track without ordinary animations"

--- a/web/python/examples/ordinary_affine_synchronous_continuation.py
+++ b/web/python/examples/ordinary_affine_synchronous_continuation.py
@@ -1,13 +1,9 @@
-"""Synchronous JSPI continuation over the shared canonical affine runtime."""
+"""Ordinary synchronous continuation over the shared canonical affine runtime."""
 
 from noon import Circle, Color, Scene, Transform, linear
 
 
 class OrdinaryAffineSynchronousContinuation(Scene):
-    # Explicit while Pyodide JSPI/run_sync remains experimental. Ordinary
-    # synchronous constructs retain endpoint-only behavior by default.
-    realtime_continuation = True
-
     def construct(self):
         circle = Circle(radius=0.4).set_fill(Color(0.0, 0.4, 1.0), opacity=1.0)
         self.add(circle)

--- a/web/python/examples/ordinary_fade_synchronous_continuation.py
+++ b/web/python/examples/ordinary_fade_synchronous_continuation.py
@@ -1,13 +1,9 @@
-"""Synchronous JSPI continuation for canonical FadeIn/FadeOut lifecycle."""
+"""Ordinary synchronous continuation for canonical FadeIn/FadeOut lifecycle."""
 
 from noon import Circle, Color, FadeIn, FadeOut, Scene, linear
 
 
 class OrdinaryFadeSynchronousContinuation(Scene):
-    # Explicit while Pyodide JSPI/run_sync remains experimental. Ordinary
-    # synchronous constructs retain endpoint-only behavior by default.
-    realtime_continuation = True
-
     def construct(self):
         circle = Circle(radius=0.4).set_fill(Color(0.0, 0.4, 1.0), opacity=1.0)
 


### PR DESCRIPTION
Supported ordinary Python `def construct` play/wait operations now use the shared Rust continuation by default. The first eligible operation checks Pyodide JSPI before Rust activation, then suspends the current source stack on the existing player/segment/presentation protocol. Static source does not probe JSPI; async source retains its existing awaitable API. The example-only `realtime_continuation` opt-in is removed.

The app already attaches the early semantic renderer once. The general shared browser examples now do the same, so authoring can remain suspended while the real frame is visible. Unsupported operations after canonical ownership begins continue to reject instead of selecting legacy execution.

`exportDocument` is passed into construct execution explicitly. Normal synchronous export uses the existing Rust endpoint operations without leasing a continuation renderer, then emits the existing current-state codec; async export rejects before setup. This preserves the existing external snapshot behavior after endpoint reconciliation. It does not claim to export a replayable history for completed live segments. That codec and its remaining consumers are still temporary #959 deletion work.

Advances #969/#1088/#61; stacked on #1144. No Rust, renderer authority, scheduler, clock, or new execution transport is added. The same paired native/direct Rust programs remain the engine proofs; ordinary Python affine/fade examples now demonstrate the default language surface.

Validation:
- `NOON_WEB_PREFLIGHT_ONLY=1 NOON_SKIP_PLAYGROUND_TEST=1 bash scripts/check.sh web` passed web source/unit checks and all 174 Python tests.
- `node scripts/shared-authoring-smoke.mjs` passed actual default and async source continuation, scalar/composition/callback/fade midpoint/final pixels, early context reuse, and static/live source cases.
- The same browser run verifies ordinary affine+wait export has the reconciled current transform and duration without a semantic execution descriptor or continuation registration; async export rejects before setup.
- A targeted worker fixture forces JSPI unavailable, verifies the clear capability error, confirms no player activation or time advance, and restores the capability function. Test sentinels avoid Python class name mangling.
- Exact-base architecture ratchet and diff check passed. The six worker lifecycle tests include the previously qualified callback-session retirement regression.
- Reused #1144's exact qualified Rust/WASM package (145 contracts); no Rust changes require another Cargo or direct backend run for this source-only slice. #1144 passed native-window, Rust, browser and architecture CI at publication time, with recovery still pending.
