### PR TITLE
Keep the Reset smoke valid during live source execution

### DIFF
--- a/scripts/playground-layout-smoke.mjs
+++ b/scripts/playground-layout-smoke.mjs
@@ -283,12 +283,14 @@ try {
   assert.match(page.url(), /example=parity-different-rotations/);
   assert.match(await sceneSource(page), /Rotate\(right_square/);
 
+  const selectedSource = await sceneSource(page);
   await page.locator("#python-scene-source").focus();
   await page.waitForSelector("#scene-editor-panel .python-code-editor[data-editor-ready='true']");
-  await page.locator("#scene-editor-panel .cm-content").fill("# local draft\n");
+  // Keep the draft executable if live authoring runs before Reset on a slower host.
+  await page.locator("#scene-editor-panel .cm-content").fill(`${selectedSource}\n# local draft\n`);
   assert.equal(await page.locator(".reset-example").isDisabled(), false);
   await page.locator(".reset-example").click();
-  assert.match(await sceneSource(page), /from noon import \*/);
+  assert.equal(await sceneSource(page), selectedSource);
 
   await page.setViewportSize({ width: 900, height: 800 });
   const stacked = await layout(page);


### PR DESCRIPTION
The Reset/layout smoke replaced the selected example with a comment-only draft. On a slower host, live authoring ran that invalid scene before Reset, and the test then failed its own no-browser-errors assertion. Keep the original executable scene plus a draft comment and verify Reset restores the exact original source.

This fixes the #1153 product-gate timing failure without suppressing errors or changing product behavior. `node scripts/playground-layout-smoke.mjs` passed on Chromium WebGL2 at DPR1.25 (desktop and mobile layouts); Node syntax and diff checks passed. No architecture or runtime change.
