### PR TITLE
Respect source continuation ownership in playground controls

### DIFF
--- a/scripts/playground-product-e2e.mjs
+++ b/scripts/playground-product-e2e.mjs
@@ -122,6 +122,7 @@ async function sampleRendererFps(page) {
 
 async function pauseAndSeek(page, seconds) {
   const toggle = page.locator(".playback-toggle");
+  if (await toggle.count() === 0) return false;
   await toggle.waitFor({ state: "visible", timeout: 10_000 });
   if ((await toggle.getAttribute("aria-label")) === "Pause animation") {
     await toggle.click();
@@ -134,6 +135,7 @@ async function pauseAndSeek(page, seconds) {
     input.dispatchEvent(new Event("input", { bubbles: true }));
   }, seconds);
   await page.waitForTimeout(150);
+  return true;
 }
 
 let browser = null;
@@ -198,7 +200,7 @@ try {
   }, marker);
   const edited = await runAndMeasure(page);
 
-  await pauseAndSeek(page, 0.5);
+  const sought = await pauseAndSeek(page, 0.5);
   const screenshotPath = path.join(artifactDir, "frame-0.5.png");
   const screenshot = await page.locator("#scene").screenshot({ path: screenshotPath });
   const visual = changedPixelStats(screenshot);
@@ -219,6 +221,7 @@ try {
     editRunMs: edited.milliseconds,
     fps,
     visual,
+    sought,
     screenshot: "frame-0.5.png",
     runtime: {
       backend: cold.state.backend,

--- a/scripts/playground-product-e2e.mjs
+++ b/scripts/playground-product-e2e.mjs
@@ -126,7 +126,7 @@ async function pauseAndSeek(page, seconds) {
     capability === "available" || capability === "unavailable",
     `product E2E did not publish playback capability (${capability})`,
   );
-  const toggle = page.locator(".playback-toggle");
+  const toggle = page.locator(".playback-controls .playback-toggle");
   const hasControls = (await toggle.count()) > 0;
   assert.equal(
     hasControls,

--- a/scripts/playground-product-e2e.mjs
+++ b/scripts/playground-product-e2e.mjs
@@ -121,8 +121,19 @@ async function sampleRendererFps(page) {
 }
 
 async function pauseAndSeek(page, seconds) {
+  const capability = await page.locator("#status").getAttribute("data-playback-controls");
+  assert.ok(
+    capability === "available" || capability === "unavailable",
+    `product E2E did not publish playback capability (${capability})`,
+  );
   const toggle = page.locator(".playback-toggle");
-  if (await toggle.count() === 0) return false;
+  const hasControls = (await toggle.count()) > 0;
+  assert.equal(
+    hasControls,
+    capability === "available",
+    "playback control DOM must match the execution ownership capability",
+  );
+  if (!hasControls) return false;
   await toggle.waitFor({ state: "visible", timeout: 10_000 });
   if ((await toggle.getAttribute("aria-label")) === "Pause animation") {
     await toggle.click();
@@ -201,7 +212,8 @@ try {
   const edited = await runAndMeasure(page);
 
   const sought = await pauseAndSeek(page, 0.5);
-  const screenshotPath = path.join(artifactDir, "frame-0.5.png");
+  const screenshotName = sought ? "frame-0.5.png" : "frame-final.png";
+  const screenshotPath = path.join(artifactDir, screenshotName);
   const screenshot = await page.locator("#scene").screenshot({ path: screenshotPath });
   const visual = changedPixelStats(screenshot);
   assert.ok(visual.changedPixels > 100, `product frame is effectively blank (${visual.changedPixels} changed pixels)`);
@@ -222,7 +234,7 @@ try {
     fps,
     visual,
     sought,
-    screenshot: "frame-0.5.png",
+    screenshot: screenshotName,
     runtime: {
       backend: cold.state.backend,
       executionMode: cold.state.executionMode,

--- a/web/main.js
+++ b/web/main.js
@@ -555,21 +555,26 @@ async function ensureRuntimeReady({
           ? "authoring-engine-render-workers"
           : "python-semantic-engine-render-worker";
       status.dataset.runtimeStartup = "started-on-demand";
-      playbackControls = new PlaygroundPlaybackControls(
-        nextPlayer,
-        document.querySelector(".preview-pane"),
-        {
-          durationSeconds: loopDurationSeconds,
-          onError: showPlaybackError,
-        },
-      );
+      const sourceOwnsExecution = semanticExecution?.continuationGeneration != null;
+      if (!sourceOwnsExecution) {
+        playbackControls = new PlaygroundPlaybackControls(
+          nextPlayer,
+          document.querySelector(".preview-pane"),
+          {
+            durationSeconds: loopDurationSeconds,
+            onError: showPlaybackError,
+          },
+        );
+      }
 
       patchStatus.dataset.sequence = String(initialState.nextPatchSequence);
-      playbackControls.sync({
-        time: initialState.time,
-        playing: initialState.playing,
-        durationSeconds: loopDurationSeconds,
-      });
+      if (playbackControls !== null) {
+        playbackControls.sync({
+          time: initialState.time,
+          playing: initialState.playing,
+          durationSeconds: loopDurationSeconds,
+        });
+      }
       startMetricsPolling();
       return {
         ...initialState,
@@ -873,6 +878,11 @@ async function runScene() {
       const sceneSpecJson = runtimeSceneSpec === null ? null : JSON.stringify(runtimeSceneSpec);
       const startRetained = semanticExecution === null && sceneSpecJson !== null;
       const loopDurationSeconds = authored.duration > 0 ? authored.duration : playbackDurationSeconds;
+
+      if (semanticExecution?.continuationGeneration != null) {
+        playbackControls?.destroy();
+        playbackControls = null;
+      }
 
       await runPlaygroundTestHook("beforeReconcile", {
         exampleId: example.id,

--- a/web/main.js
+++ b/web/main.js
@@ -465,6 +465,24 @@ function createRuntimeClient() {
   return candidate;
 }
 
+function updatePlaybackControls({ supported, player: nextPlayer, durationSeconds }) {
+  status.dataset.playbackControls = supported ? "available" : "unavailable";
+  if (!supported) {
+    playbackControls?.destroy();
+    playbackControls = null;
+    return;
+  }
+  if (playbackControls === null) {
+    playbackControls = new PlaygroundPlaybackControls(
+      nextPlayer,
+      document.querySelector(".preview-pane"),
+      { durationSeconds, onError: showPlaybackError },
+    );
+  } else {
+    playbackControls.setDuration(durationSeconds);
+  }
+}
+
 function ensureRuntimePreparation() {
   if (player !== null) return null;
   if (runtimePreparation !== null) return runtimePreparation;
@@ -556,14 +574,12 @@ async function ensureRuntimeReady({
           : "python-semantic-engine-render-worker";
       status.dataset.runtimeStartup = "started-on-demand";
       const sourceOwnsExecution = semanticExecution?.continuationGeneration != null;
+      status.dataset.playbackControls = sourceOwnsExecution ? "unavailable" : "available";
       if (!sourceOwnsExecution) {
         playbackControls = new PlaygroundPlaybackControls(
           nextPlayer,
           document.querySelector(".preview-pane"),
-          {
-            durationSeconds: loopDurationSeconds,
-            onError: showPlaybackError,
-          },
+          { durationSeconds: loopDurationSeconds, onError: showPlaybackError },
         );
       }
 
@@ -879,9 +895,12 @@ async function runScene() {
       const startRetained = semanticExecution === null && sceneSpecJson !== null;
       const loopDurationSeconds = authored.duration > 0 ? authored.duration : playbackDurationSeconds;
 
-      if (semanticExecution?.continuationGeneration != null) {
-        playbackControls?.destroy();
-        playbackControls = null;
+      if (player !== null) {
+        updatePlaybackControls({
+          supported: semanticExecution?.continuationGeneration == null,
+          player,
+          durationSeconds: loopDurationSeconds,
+        });
       }
 
       await runPlaygroundTestHook("beforeReconcile", {

--- a/web/playground-continuation.test.mjs
+++ b/web/playground-continuation.test.mjs
@@ -50,6 +50,7 @@ test("source-owned semantic runs do not expose unsupported playback controls", (
   assert.match(runtime, /if \(!sourceOwnsExecution\) \{[\s\S]*new PlaygroundPlaybackControls/);
   assert.match(
     runScene,
-    /if \(semanticExecution\?\.continuationGeneration != null\) \{[\s\S]*playbackControls = null;/,
+    /updatePlaybackControls\(\{\s*supported: semanticExecution\?\.continuationGeneration == null,/,
   );
+  assert.match(runtime, /playbackControls\?\.destroy\(\);\s*playbackControls = null;/);
 });

--- a/web/playground-continuation.test.mjs
+++ b/web/playground-continuation.test.mjs
@@ -41,3 +41,15 @@ test("playground tears down an early continuation when its run becomes stale", (
     /catch \(error\) \{\s*discardEarlyContinuationRuntime\(earlyContinuation\?\.attachedPlayer\)/,
   );
 });
+
+test("source-owned semantic runs do not expose unsupported playback controls", () => {
+  const runtimeStart = main.indexOf("async function ensureRuntimeReady(");
+  const runtimeEnd = main.indexOf("async function ensureExecutionReady(", runtimeStart);
+  const runtime = main.slice(runtimeStart, runtimeEnd);
+  assert.match(runtime, /semanticExecution\?\.continuationGeneration != null/);
+  assert.match(runtime, /if \(!sourceOwnsExecution\) \{[\s\S]*new PlaygroundPlaybackControls/);
+  assert.match(
+    runScene,
+    /if \(semanticExecution\?\.continuationGeneration != null\) \{[\s\S]*playbackControls = null;/,
+  );
+});

--- a/web/python-worker-source.test.mjs
+++ b/web/python-worker-source.test.mjs
@@ -52,6 +52,16 @@ test("semantic continuation control bypasses the blocked interpreter request que
   assert.doesNotMatch(lane, /runPythonAsync/);
 });
 
+test("Python run results publish after source-continuation ownership is released", () => {
+  const runStart = source.indexOf('if (request.type === "run")');
+  const runEnd = source.indexOf('if (request.type === "attach_semantic_execution")', runStart);
+  assert.ok(runStart >= 0 && runEnd > runStart);
+  const run = source.slice(runStart, runEnd);
+  const cleanup = run.indexOf("if (activeAuthoringRun === run) activeAuthoringRun = null;");
+  const result = run.indexOf('post("result", { requestId, resultJson });');
+  assert.ok(cleanup >= 0 && result > cleanup);
+});
+
 test("semantic continuation delivers required callback work to its suspended source", () => {
   assert.match(source, /noonSetSemanticContinuationCallbackSession/);
   assert.match(source, /noonCompleteSemanticContinuationCallback/);

--- a/web/python-worker.source.js
+++ b/web/python-worker.source.js
@@ -657,8 +657,9 @@ async function handleRequest(request) {
       const run = { requestId, continuation: null, continuationCallbackSession: null };
       activeAuthoringRun = run;
       let completed = false;
+      let resultJson;
       try {
-        const resultJson = await runAuthoringSource(
+        resultJson = await runAuthoringSource(
           pyodide,
           request.source,
           request.context,
@@ -667,7 +668,6 @@ async function handleRequest(request) {
         if (run.continuation !== null) {
           await run.continuation.endpoint.publishContinuationResult(run.continuation.generation);
         }
-        post("result", { requestId, resultJson });
         completed = true;
       } finally {
         if (!completed && run.continuation !== null) {
@@ -678,6 +678,11 @@ async function handleRequest(request) {
         }
         if (activeAuthoringRun === run) activeAuthoringRun = null;
       }
+      // Publish only after activeAuthoringRun is cleared. The playground treats
+      // this result as the point where playback controls become usable; posting
+      // it earlier races the source-continuation ownership guard in the semantic
+      // endpoint.
+      post("result", { requestId, resultJson });
       return;
     }
     if (request.type === "attach_semantic_execution") {


### PR DESCRIPTION
The playground exposed pause/seek controls for Python source continuations even though the shared execution endpoint deliberately rejects those commands. After a supported source such as SquareAndCircle completed, the product test hit that ownership guard.

Publish playback capability from the existing continuation descriptor, create controls only for seekable runs, and restore them when a warm run switches back to seekable execution. The product test asserts the capability against active controls and records a completed frame for source-owned runs. Disabled startup placeholders are distinct from active controls.

Advances #953/#61/#961 and repairs extended CI from #1156. Platform UI only; the semantic/runtime lease guard is unchanged. No migration seam or new execution authority.

Validation: 15 focused Node tests; full local Rust/web gate in the integration tree (1,698 Rust tests, 188 Python tests, 174 package contracts); actual `node scripts/playground-product-e2e.mjs` passed cold/warm/edit runs with no console or page errors. Browser qualification used the integration package including the pending rotation batch; UI source matches this PR.
