### PR TITLE
Remove superseded playback result-ordering workaround

### DIFF
--- a/web/python-worker-source.test.mjs
+++ b/web/python-worker-source.test.mjs
@@ -52,16 +52,6 @@ test("semantic continuation control bypasses the blocked interpreter request que
   assert.doesNotMatch(lane, /runPythonAsync/);
 });
 
-test("Python run results publish after source-continuation ownership is released", () => {
-  const runStart = source.indexOf('if (request.type === "run")');
-  const runEnd = source.indexOf('if (request.type === "attach_semantic_execution")', runStart);
-  assert.ok(runStart >= 0 && runEnd > runStart);
-  const run = source.slice(runStart, runEnd);
-  const cleanup = run.indexOf("if (activeAuthoringRun === run) activeAuthoringRun = null;");
-  const result = run.indexOf('post("result", { requestId, resultJson });');
-  assert.ok(cleanup >= 0 && result > cleanup);
-});
-
 test("semantic continuation delivers required callback work to its suspended source", () => {
   assert.match(source, /noonSetSemanticContinuationCallbackSession/);
   assert.match(source, /noonCompleteSemanticContinuationCallback/);

--- a/web/python-worker.source.js
+++ b/web/python-worker.source.js
@@ -657,9 +657,8 @@ async function handleRequest(request) {
       const run = { requestId, continuation: null, continuationCallbackSession: null };
       activeAuthoringRun = run;
       let completed = false;
-      let resultJson;
       try {
-        resultJson = await runAuthoringSource(
+        const resultJson = await runAuthoringSource(
           pyodide,
           request.source,
           request.context,
@@ -668,6 +667,7 @@ async function handleRequest(request) {
         if (run.continuation !== null) {
           await run.continuation.endpoint.publishContinuationResult(run.continuation.generation);
         }
+        post("result", { requestId, resultJson });
         completed = true;
       } finally {
         if (!completed && run.continuation !== null) {
@@ -678,11 +678,6 @@ async function handleRequest(request) {
         }
         if (activeAuthoringRun === run) activeAuthoringRun = null;
       }
-      // Publish only after activeAuthoringRun is cleared. The playground treats
-      // this result as the point where playback controls become usable; posting
-      // it earlier races the source-continuation ownership guard in the semantic
-      // endpoint.
-      post("result", { requestId, resultJson });
       return;
     }
     if (request.type === "attach_semantic_execution") {


### PR DESCRIPTION
Remove the superseded worker result-ordering workaround that remained in the #1157 branch ancestry. Playback availability is correctly owned by the existing continuation descriptor and the UI capability change; clearing activeAuthoringRun does not release the endpoint lease.

The shared continuation guard and qualified UI fix remain intact. This restores the worker source used by the passing integration product test and deletes the test for the abandoned workaround. Advances #961; no new boundary or migration seam.

Validation: `node --test web/python-worker-source.test.mjs web/playground-continuation.test.mjs`; actual product E2E already passed using this worker source in the integration tree.
