### PR TITLE
Wait for Run readiness at the browser action boundary

### DIFF
--- a/scripts/playground-browser-matrix-smoke.mjs
+++ b/scripts/playground-browser-matrix-smoke.mjs
@@ -346,8 +346,7 @@ async function editAndRerun(page, expectedExampleId) {
   }, editMarker);
 
   const runButton = page.locator("#replace-scene");
-  await runButton.waitFor({ state: "attached" });
-  assert.equal(await runButton.isDisabled(), false, `${browserName}/${profileName}: Run stayed disabled`);
+  // click waits for the control to be enabled, including pending source loads.
   await runButton.click();
   await waitForAppliedScene(page, expectedExampleId);
 
@@ -442,10 +441,8 @@ try {
     );
   } else {
     const runButton = page.locator("#replace-scene");
-    // Gallery metadata can appear before the asynchronously selected source loads.
-    // Observe readiness before asserting or clicking the Run control.
-    await page.waitForFunction(() => !document.querySelector("#replace-scene")?.disabled);
-    assert.equal(await runButton.isDisabled(), false, `${browserName}/${profileName}: Run stayed disabled`);
+    // Source loading can disable Run after the shell appears. The locator's
+    // actionability wait observes readiness at the click, without a stale snapshot.
     await runButton.click();
     finalRuntime = await waitForAppliedScene(page, "parity-square-and-circle");
     assert.ok(


### PR DESCRIPTION
The Chromium matrix on #1162 failed because the test sampled Run as enabled and asserted that stale state while the asynchronously selected source was still loading. The old optional-chain readiness predicate also passed when the button was absent. Use Playwright locator click actionability to wait for the actual enabled control, for both initial Run and edit/rerun.

Advances #961 validation. No product/runtime behavior, architecture boundary or timeout changes. The click still fails if Run remains disabled.

Validation: `NOON_PLAYGROUND_BROWSER=chromium NOON_PLAYGROUND_PROFILE=desktop-dpr1 NOON_PLAYGROUND_MATRIX_ARTIFACTS=/Users/ykshin/.codex/memories/noon-architecture/lifecycle-run-readiness-artifacts node scripts/playground-browser-matrix-smoke.mjs` passed: deferred load, public select/edit/rerun and resize on WebGL2. `node --check scripts/playground-browser-matrix-smoke.mjs` and `git diff --check` passed. Existing qualified #1162 WASM package used; no engine rebuild needed for the test-only change.
