### PR TITLE
Populate painter order in release execution sessions

### DIFF
--- a/crates/noon/src/execution_session.rs
+++ b/crates/noon/src/execution_session.rs
@@ -2173,8 +2173,10 @@ impl SemanticPainterOrderIndex {
     }
 
     fn insert(&mut self, node: SemanticNodeId, key: (i32, u64)) {
-        debug_assert!(self.keys.insert(node, key).is_none());
-        debug_assert!(self.ordered.insert(key, node).is_none());
+        let previous_key = self.keys.insert(node, key);
+        let previous_node = self.ordered.insert(key, node);
+        debug_assert!(previous_key.is_none());
+        debug_assert!(previous_node.is_none());
     }
 
     fn remove(&mut self, node: SemanticNodeId) {


### PR DESCRIPTION
Release builds skipped both painter-order index insertions because the mutations were expressions inside `debug_assert!`. Removing a live object then panicked because its order entry did not exist. Move the two insertions outside the assertions so debug and release execute the same state update.

Fixes the release-WASM detached Text Shrink export failure in #1162, and protects the same membership bookkeeping for other live removals. Owned by shared execution publication (#958/#961). No new architecture boundary, compatibility seam, or locality change: index updates remain proportional to the affected object.

Validation:
- Reproduced the optimized WASM trap in all-29 tutorial export execution; a temporary diagnostic hook identified `exited execution object has a painter-order entry` as the panic.
- Rebuilt release WASM with the fix and removed hook; `node scripts/manim-tutorial-smoke.mjs`: 29/29 passed, including detached Text Shrink. Used `CARGO_TARGET_DIR=/Users/ykshin/Dev/me/noon/target CARGO_INCREMENTAL=0 NOON_SKIP_WEB_PREFLIGHT=1 NOON_WASM_PROFILE=release bash scripts/build-web-demo.sh`. Local wasm-pack 0.10.2 required temporary package metadata to disable wasm-opt, equivalent to CI's skip-opt setting; that metadata and diagnostic script are removed.
- `CARGO_TARGET_DIR=/Users/ykshin/Dev/me/noon/target CARGO_INCREMENTAL=0 bash scripts/check.sh fast`: passed.
- `git diff --check`: passed.
