### PR TITLE
Restore WebGL rendering by replacing lost device resources

### DIFF
--- a/crates/noon-web/src/execution_canvas.rs
+++ b/crates/noon-web/src/execution_canvas.rs
@@ -483,6 +483,69 @@ mod wasm {
             }
         }
 
+        /// Recreate the complete WebGL wgpu stack after the browser restores its
+        /// context. wgpu-hal's GL device and queue retain context-created VAOs,
+        /// framebuffers, and buffers, so rebuilding only renderer pipelines cannot
+        /// make the old stack valid again.
+        #[wasm_bindgen(js_name = recoverWebGlContext)]
+        pub async fn recover_webgl_context(&mut self) -> Result<bool, JsValue> {
+            if self.backend != wgpu::Backend::Gl || !self.webgl_recovery_pending.get() {
+                return Ok(false);
+            }
+            let next_generation = self
+                .gpu_generation
+                .checked_add(1)
+                .ok_or_else(|| js_message("GPU recovery generation exhausted"))?;
+            let profiling_enabled = self.timestamp_profiler.is_some();
+            let InitializedGpu {
+                instance,
+                surface,
+                device,
+                queue,
+                backend,
+                config,
+                timestamp_query_supported,
+            } = initialize_gpu(&self.canvas, self.config.width, self.config.height).await?;
+            if backend != wgpu::Backend::Gl {
+                return Err(js_message(
+                    "WebGL context recovery unexpectedly selected a different GPU backend",
+                ));
+            }
+            install_wgpu_error_handler(
+                &device,
+                next_generation,
+                backend,
+                self.gpu_diagnostics.clone(),
+            );
+            let renderer = GpuRenderer::new(&device, config.format);
+            let direct_text_gpu = renderer.create_retained_text_state(&device, &queue);
+
+            self.instance = instance;
+            self.surface = surface;
+            self.device = device;
+            self.queue = queue;
+            self.backend = backend;
+            self.config = config;
+            self.timestamp_query_supported = timestamp_query_supported;
+            self.renderer = renderer;
+            self.direct_text_gpu = direct_text_gpu;
+            self.preparer = FramePreparer::new();
+            self.direct_preparer = RetainedFramePreparer::new();
+            self.timestamp_profiler =
+                profiling_enabled.then(|| GpuTimestampProfiler::new(&self.device, &self.queue));
+            self.gpu_generation = next_generation;
+            self.pending_changes = FrameChanges::all();
+            self.gpu_recovery_frame_pending = true;
+            self.last_draw_calls = 0;
+            self.last_text_draw_calls = 0;
+            self.last_instances_drawn = 0;
+            self.last_bytes_uploaded = 0;
+            self.last_geometry_cache_misses = 0;
+            self.update_camera()?;
+            self.webgl_recovery_pending.set(false);
+            Ok(true)
+        }
+
         pub fn render(&mut self) -> Result<bool, JsValue> {
             if self.webgl_context_lost.get() {
                 return Ok(false);
@@ -1204,69 +1267,6 @@ mod wasm {
             };
             result.update_camera()?;
             Ok(result)
-        }
-
-        /// Recreate the complete WebGL wgpu stack after the browser restores its
-        /// context. wgpu-hal's GL device and queue retain context-created VAOs,
-        /// framebuffers, and buffers, so rebuilding only renderer pipelines cannot
-        /// make the old stack valid again.
-        #[wasm_bindgen(js_name = recoverWebGlContext)]
-        pub async fn recover_webgl_context(&mut self) -> Result<bool, JsValue> {
-            if self.backend != wgpu::Backend::Gl || !self.webgl_recovery_pending.get() {
-                return Ok(false);
-            }
-            let next_generation = self
-                .gpu_generation
-                .checked_add(1)
-                .ok_or_else(|| js_message("GPU recovery generation exhausted"))?;
-            let profiling_enabled = self.timestamp_profiler.is_some();
-            let InitializedGpu {
-                instance,
-                surface,
-                device,
-                queue,
-                backend,
-                config,
-                timestamp_query_supported,
-            } = initialize_gpu(&self.canvas, self.config.width, self.config.height).await?;
-            if backend != wgpu::Backend::Gl {
-                return Err(js_message(
-                    "WebGL context recovery unexpectedly selected a different GPU backend",
-                ));
-            }
-            install_wgpu_error_handler(
-                &device,
-                next_generation,
-                backend,
-                self.gpu_diagnostics.clone(),
-            );
-            let renderer = GpuRenderer::new(&device, config.format);
-            let direct_text_gpu = renderer.create_retained_text_state(&device, &queue);
-
-            self.instance = instance;
-            self.surface = surface;
-            self.device = device;
-            self.queue = queue;
-            self.backend = backend;
-            self.config = config;
-            self.timestamp_query_supported = timestamp_query_supported;
-            self.renderer = renderer;
-            self.direct_text_gpu = direct_text_gpu;
-            self.preparer = FramePreparer::new();
-            self.direct_preparer = RetainedFramePreparer::new();
-            self.timestamp_profiler =
-                profiling_enabled.then(|| GpuTimestampProfiler::new(&self.device, &self.queue));
-            self.gpu_generation = next_generation;
-            self.pending_changes = FrameChanges::all();
-            self.gpu_recovery_frame_pending = true;
-            self.last_draw_calls = 0;
-            self.last_text_draw_calls = 0;
-            self.last_instances_drawn = 0;
-            self.last_bytes_uploaded = 0;
-            self.last_geometry_cache_misses = 0;
-            self.update_camera()?;
-            self.webgl_recovery_pending.set(false);
-            Ok(true)
         }
 
         fn render_direct(

--- a/crates/noon-web/src/execution_canvas.rs
+++ b/crates/noon-web/src/execution_canvas.rs
@@ -11,7 +11,7 @@ const MANIM_DEFAULT_CLEAR_COLOR: wgpu::Color = wgpu::Color {
 
 #[cfg(target_arch = "wasm32")]
 mod wasm {
-    use std::mem;
+    use std::{cell::Cell, mem, rc::Rc};
 
     use noon::{
         ExecutionSession, LiveContinuation, LiveProgram, LiveProgramStatus, RendererPublication,
@@ -27,7 +27,7 @@ mod wasm {
     use noon_runtime::{FrameChanges, FrameState};
     use noon_text_render_wgpu::TextDeviceMetrics;
     use serde::Serialize;
-    use wasm_bindgen::prelude::*;
+    use wasm_bindgen::{prelude::*, JsCast};
     use web_sys::OffscreenCanvas;
 
     use crate::{
@@ -426,6 +426,11 @@ mod wasm {
         last_geometry_cache_misses: usize,
         gpu_generation: u32,
         gpu_diagnostics: GpuDiagnosticMailbox,
+        webgl_context_lost: Rc<Cell<bool>>,
+        webgl_recovery_pending: Rc<Cell<bool>>,
+        webgl_loss_listener: Option<Closure<dyn FnMut(web_sys::Event)>>,
+        webgl_restore_listener: Option<Closure<dyn FnMut(web_sys::Event)>>,
+        gpu_recovery_frame_pending: bool,
     }
 
     #[wasm_bindgen(js_class = ExecutionCanvasRenderer)]
@@ -479,12 +484,21 @@ mod wasm {
         }
 
         pub fn render(&mut self) -> Result<bool, JsValue> {
+            if self.webgl_context_lost.get() {
+                return Ok(false);
+            }
+            if self.webgl_recovery_pending.replace(false) {
+                if let Err(error) = self.rebuild_restored_webgl_resources() {
+                    self.webgl_recovery_pending.set(true);
+                    return Err(error);
+                }
+            }
             let changes_pending = match &self.source {
                 CanvasExecutionSource::Transport(_) => !self.pending_changes.is_empty(),
                 CanvasExecutionSource::Direct(direct) => {
                     direct.session().wake_state().frame_pending()
                 }
-            };
+            } || self.gpu_recovery_frame_pending;
             if !self.drawable || !changes_pending {
                 return Ok(false);
             }
@@ -501,7 +515,11 @@ mod wasm {
                     }
                     wgpu::CurrentSurfaceTexture::Lost => {
                         self.surface = create_surface(&self.instance, &self.canvas)?;
-                        self.surface.configure(&self.device, &self.config);
+                        if self.backend == wgpu::Backend::Gl {
+                            self.rebuild_restored_webgl_resources()?;
+                        } else {
+                            self.surface.configure(&self.device, &self.config);
+                        }
                         return Ok(false);
                     }
                     // The device error callback owns validation diagnostics. Keep
@@ -511,7 +529,11 @@ mod wasm {
                 };
 
             if self.source.direct().is_some() {
-                return self.render_direct(surface_texture, reconfigure_after_present);
+                let rendered = self.render_direct(surface_texture, reconfigure_after_present)?;
+                if rendered {
+                    self.gpu_recovery_frame_pending = false;
+                }
+                return Ok(rendered);
             }
 
             let changes = mem::take(&mut self.pending_changes);
@@ -570,6 +592,7 @@ mod wasm {
             if reconfigure_after_present {
                 self.surface.configure(&self.device, &self.config);
             }
+            self.gpu_recovery_frame_pending = false;
             Ok(true)
         }
 
@@ -1141,6 +1164,12 @@ mod wasm {
             install_wgpu_error_handler(&device, gpu_generation, backend, gpu_diagnostics.clone());
             let renderer = GpuRenderer::new(&device, config.format);
             let direct_text_gpu = renderer.create_retained_text_state(&device, &queue);
+            let (
+                webgl_context_lost,
+                webgl_recovery_pending,
+                webgl_loss_listener,
+                webgl_restore_listener,
+            ) = install_webgl_context_recovery_listeners(&canvas, backend)?;
 
             let mut result = Self {
                 instance,
@@ -1170,9 +1199,48 @@ mod wasm {
                 last_geometry_cache_misses: 0,
                 gpu_generation,
                 gpu_diagnostics,
+                webgl_context_lost,
+                webgl_recovery_pending,
+                webgl_loss_listener,
+                webgl_restore_listener,
+                gpu_recovery_frame_pending: false,
             };
             result.update_camera()?;
             Ok(result)
+        }
+
+        fn rebuild_restored_webgl_resources(&mut self) -> Result<(), JsValue> {
+            if self.backend != wgpu::Backend::Gl {
+                return Ok(());
+            }
+            self.surface.configure(&self.device, &self.config);
+            let profiling_enabled = self.timestamp_profiler.is_some();
+            self.renderer = GpuRenderer::new(&self.device, self.config.format);
+            self.direct_text_gpu = self
+                .renderer
+                .create_retained_text_state(&self.device, &self.queue);
+            self.preparer = FramePreparer::new();
+            self.direct_preparer = RetainedFramePreparer::new();
+            self.timestamp_profiler =
+                profiling_enabled.then(|| GpuTimestampProfiler::new(&self.device, &self.queue));
+            self.gpu_generation = self
+                .gpu_generation
+                .checked_add(1)
+                .ok_or_else(|| js_message("GPU recovery generation exhausted"))?;
+            install_wgpu_error_handler(
+                &self.device,
+                self.gpu_generation,
+                self.backend,
+                self.gpu_diagnostics.clone(),
+            );
+            self.pending_changes = FrameChanges::all();
+            self.gpu_recovery_frame_pending = true;
+            self.last_draw_calls = 0;
+            self.last_text_draw_calls = 0;
+            self.last_instances_drawn = 0;
+            self.last_bytes_uploaded = 0;
+            self.last_geometry_cache_misses = 0;
+            self.update_camera()
         }
 
         fn render_direct(
@@ -1300,6 +1368,76 @@ mod wasm {
             self.renderer.set_camera(&self.queue, camera);
             Ok(())
         }
+    }
+
+    impl Drop for WasmExecutionCanvasRenderer {
+        fn drop(&mut self) {
+            if let Some(listener) = self.webgl_loss_listener.as_ref() {
+                let _ = self.canvas.remove_event_listener_with_callback(
+                    "webglcontextlost",
+                    listener.as_ref().unchecked_ref(),
+                );
+            }
+            if let Some(listener) = self.webgl_restore_listener.as_ref() {
+                let _ = self.canvas.remove_event_listener_with_callback(
+                    "webglcontextrestored",
+                    listener.as_ref().unchecked_ref(),
+                );
+            }
+        }
+    }
+
+    type WebGlContextRecoveryListeners = (
+        Rc<Cell<bool>>,
+        Rc<Cell<bool>>,
+        Option<Closure<dyn FnMut(web_sys::Event)>>,
+        Option<Closure<dyn FnMut(web_sys::Event)>>,
+    );
+
+    fn install_webgl_context_recovery_listeners(
+        canvas: &OffscreenCanvas,
+        backend: wgpu::Backend,
+    ) -> Result<WebGlContextRecoveryListeners, JsValue> {
+        let context_lost = Rc::new(Cell::new(false));
+        let recovery_pending = Rc::new(Cell::new(false));
+        if backend != wgpu::Backend::Gl {
+            return Ok((context_lost, recovery_pending, None, None));
+        }
+
+        let lost_state = Rc::clone(&context_lost);
+        let loss_listener = Closure::wrap(Box::new(move |event: web_sys::Event| {
+            event.prevent_default();
+            lost_state.set(true);
+        }) as Box<dyn FnMut(web_sys::Event)>);
+        canvas.add_event_listener_with_callback(
+            "webglcontextlost",
+            loss_listener.as_ref().unchecked_ref(),
+        )?;
+
+        let restored_lost_state = Rc::clone(&context_lost);
+        let restored_pending = Rc::clone(&recovery_pending);
+        let restore_listener = Closure::wrap(Box::new(move |_event: web_sys::Event| {
+            if restored_lost_state.replace(false) {
+                restored_pending.set(true);
+            }
+        }) as Box<dyn FnMut(web_sys::Event)>);
+        if let Err(error) = canvas.add_event_listener_with_callback(
+            "webglcontextrestored",
+            restore_listener.as_ref().unchecked_ref(),
+        ) {
+            let _ = canvas.remove_event_listener_with_callback(
+                "webglcontextlost",
+                loss_listener.as_ref().unchecked_ref(),
+            );
+            return Err(error);
+        }
+
+        Ok((
+            context_lost,
+            recovery_pending,
+            Some(loss_listener),
+            Some(restore_listener),
+        ))
     }
 
     async fn initialize_gpu(

--- a/crates/noon-web/src/execution_canvas.rs
+++ b/crates/noon-web/src/execution_canvas.rs
@@ -487,11 +487,8 @@ mod wasm {
             if self.webgl_context_lost.get() {
                 return Ok(false);
             }
-            if self.webgl_recovery_pending.replace(false) {
-                if let Err(error) = self.rebuild_restored_webgl_resources() {
-                    self.webgl_recovery_pending.set(true);
-                    return Err(error);
-                }
+            if self.webgl_recovery_pending.get() {
+                return Ok(false);
             }
             let changes_pending = match &self.source {
                 CanvasExecutionSource::Transport(_) => !self.pending_changes.is_empty(),
@@ -514,10 +511,10 @@ mod wasm {
                         return Ok(false);
                     }
                     wgpu::CurrentSurfaceTexture::Lost => {
-                        self.surface = create_surface(&self.instance, &self.canvas)?;
                         if self.backend == wgpu::Backend::Gl {
-                            self.rebuild_restored_webgl_resources()?;
+                            self.webgl_recovery_pending.set(true);
                         } else {
+                            self.surface = create_surface(&self.instance, &self.canvas)?;
                             self.surface.configure(&self.device, &self.config);
                         }
                         return Ok(false);
@@ -1209,30 +1206,57 @@ mod wasm {
             Ok(result)
         }
 
-        fn rebuild_restored_webgl_resources(&mut self) -> Result<(), JsValue> {
-            if self.backend != wgpu::Backend::Gl {
-                return Ok(());
+        /// Recreate the complete WebGL wgpu stack after the browser restores its
+        /// context. wgpu-hal's GL device and queue retain context-created VAOs,
+        /// framebuffers, and buffers, so rebuilding only renderer pipelines cannot
+        /// make the old stack valid again.
+        #[wasm_bindgen(js_name = recoverWebGlContext)]
+        pub async fn recover_webgl_context(&mut self) -> Result<bool, JsValue> {
+            if self.backend != wgpu::Backend::Gl || !self.webgl_recovery_pending.get() {
+                return Ok(false);
             }
-            self.surface.configure(&self.device, &self.config);
+            let next_generation = self
+                .gpu_generation
+                .checked_add(1)
+                .ok_or_else(|| js_message("GPU recovery generation exhausted"))?;
             let profiling_enabled = self.timestamp_profiler.is_some();
-            self.renderer = GpuRenderer::new(&self.device, self.config.format);
-            self.direct_text_gpu = self
-                .renderer
-                .create_retained_text_state(&self.device, &self.queue);
+            let InitializedGpu {
+                instance,
+                surface,
+                device,
+                queue,
+                backend,
+                config,
+                timestamp_query_supported,
+            } = initialize_gpu(&self.canvas, self.config.width, self.config.height).await?;
+            if backend != wgpu::Backend::Gl {
+                return Err(js_message(
+                    "WebGL context recovery unexpectedly selected a different GPU backend",
+                ));
+            }
+            install_wgpu_error_handler(
+                &device,
+                next_generation,
+                backend,
+                self.gpu_diagnostics.clone(),
+            );
+            let renderer = GpuRenderer::new(&device, config.format);
+            let direct_text_gpu = renderer.create_retained_text_state(&device, &queue);
+
+            self.instance = instance;
+            self.surface = surface;
+            self.device = device;
+            self.queue = queue;
+            self.backend = backend;
+            self.config = config;
+            self.timestamp_query_supported = timestamp_query_supported;
+            self.renderer = renderer;
+            self.direct_text_gpu = direct_text_gpu;
             self.preparer = FramePreparer::new();
             self.direct_preparer = RetainedFramePreparer::new();
             self.timestamp_profiler =
                 profiling_enabled.then(|| GpuTimestampProfiler::new(&self.device, &self.queue));
-            self.gpu_generation = self
-                .gpu_generation
-                .checked_add(1)
-                .ok_or_else(|| js_message("GPU recovery generation exhausted"))?;
-            install_wgpu_error_handler(
-                &self.device,
-                self.gpu_generation,
-                self.backend,
-                self.gpu_diagnostics.clone(),
-            );
+            self.gpu_generation = next_generation;
             self.pending_changes = FrameChanges::all();
             self.gpu_recovery_frame_pending = true;
             self.last_draw_calls = 0;
@@ -1240,7 +1264,9 @@ mod wasm {
             self.last_instances_drawn = 0;
             self.last_bytes_uploaded = 0;
             self.last_geometry_cache_misses = 0;
-            self.update_camera()
+            self.update_camera()?;
+            self.webgl_recovery_pending.set(false);
+            Ok(true)
         }
 
         fn render_direct(

--- a/scripts/check-web-package.mjs
+++ b/scripts/check-web-package.mjs
@@ -403,6 +403,7 @@ if (process.env.NOON_WASM_PROFILE === "dev"
     "export function createDirectOrdinaryStylePlaySmokeRenderer(",
   );
   expectedTypeSurface.push(
+    "recoverWebGlContext(): Promise<boolean>",
     "export function createDirectTypstTextSmokeRenderer(canvas: OffscreenCanvas): Promise<ExecutionCanvasRenderer>",
     "export function createDirectMathTypstTextSmokeRenderer(canvas: OffscreenCanvas): Promise<ExecutionCanvasRenderer>",
     "export function createDirectOrdinaryAffinePlaySmokeRenderer(canvas: OffscreenCanvas): Promise<ExecutionCanvasRenderer>",

--- a/scripts/renderer-webgl-context-loss-smoke.mjs
+++ b/scripts/renderer-webgl-context-loss-smoke.mjs
@@ -69,7 +69,15 @@ async function waitForHarness(page) {
   const metrics = await page.evaluate(() => window.noonSmoke.metrics());
   assert.equal(metrics.error, null, `renderer failed to initialize: ${metrics.error}`);
   assert.equal(metrics.rendererBackend, "WebGL2", `expected WebGL2, got ${metrics.rendererBackend}`);
-  return metrics;
+  const loaded = await page.evaluate(async () => {
+    const wasm = await import("./pkg/noon_web.js");
+    const { createExplicitTransportSceneJson } = await import(
+      "../scripts/explicit-transport-scene-fixture.js"
+    );
+    return window.noonSmoke.loadScene(createExplicitTransportSceneJson(wasm));
+  });
+  assert.equal(loaded.objectCount, 4, "context-loss fixture must contain visible geometry");
+  return page.evaluate(() => window.noonSmoke.metrics());
 }
 
 async function renderAndCapture(page, name) {
@@ -134,35 +142,8 @@ try {
   const baseline = await renderAndCapture(page, "baseline");
 
   const injection = await page.evaluate(() => {
-    const canvas = document.querySelector("#scene");
-    const gl = canvas?.getContext("webgl2");
-    const extension = gl?.getExtension("WEBGL_lose_context");
-    if (!canvas || !gl || !extension) {
-      return {
-        available: false,
-        hasCanvas: Boolean(canvas),
-        hasWebgl2: Boolean(gl),
-        hasLoseContextExtension: Boolean(extension),
-      };
-    }
-    window.__noonContextRecovery = {
-      lost: 0,
-      restored: 0,
-      extension,
-    };
-    canvas.addEventListener("webglcontextlost", (event) => {
-      event.preventDefault();
-      window.__noonContextRecovery.lost += 1;
-    });
-    canvas.addEventListener("webglcontextrestored", () => {
-      window.__noonContextRecovery.restored += 1;
-    });
-    return {
-      available: true,
-      hasCanvas: true,
-      hasWebgl2: true,
-      hasLoseContextExtension: true,
-    };
+    window.__noonContextRecovery = window.noonSmoke.webglContextControl();
+    return { available: window.__noonContextRecovery !== null };
   });
   assert.equal(
     injection.available,
@@ -170,24 +151,24 @@ try {
     `WEBGL_lose_context is unavailable: ${JSON.stringify(injection)}`,
   );
 
-  await page.evaluate(() => window.__noonContextRecovery.extension.loseContext());
-  await page.waitForFunction(() => window.__noonContextRecovery?.lost === 1, null, {
+  await page.evaluate(() => window.__noonContextRecovery.lose());
+  await page.waitForFunction(() => window.__noonContextRecovery?.state.lost === 1, null, {
     timeout: 10_000,
   });
 
   const duringLoss = await page.evaluate(() => ({
     metrics: window.noonSmoke.metrics(),
     context: {
-      lost: window.__noonContextRecovery.lost,
-      restored: window.__noonContextRecovery.restored,
+      lost: window.__noonContextRecovery.state.lost,
+      restored: window.__noonContextRecovery.state.restored,
     },
   }));
   assert.equal(duringLoss.metrics.rendererBackend, "WebGL2", "context loss changed semantic backend identity");
   assert.equal(duringLoss.metrics.revision, baseline.metrics.revision, "context loss reset scene revision");
   assert.equal(duringLoss.metrics.objectCount, baseline.metrics.objectCount, "context loss reset scene objects");
 
-  await page.evaluate(() => window.__noonContextRecovery.extension.restoreContext());
-  await page.waitForFunction(() => window.__noonContextRecovery?.restored === 1, null, {
+  await page.evaluate(() => window.__noonContextRecovery.restore());
+  await page.waitForFunction(() => window.__noonContextRecovery?.state.restored === 1, null, {
     timeout: 10_000,
   });
 
@@ -242,8 +223,8 @@ try {
   assert.deepEqual(freshErrors.consoleErrors, [], "fresh comparison renderer emitted console errors");
 
   const contextState = await page.evaluate(() => ({
-    lost: window.__noonContextRecovery.lost,
-    restored: window.__noonContextRecovery.restored,
+    lost: window.__noonContextRecovery.state.lost,
+    restored: window.__noonContextRecovery.state.restored,
   }));
   await writeDiagnostics("context-loss-recovery", {
     browserVersion: browser.version(),

--- a/scripts/renderer-webgl-context-loss-smoke.mjs
+++ b/scripts/renderer-webgl-context-loss-smoke.mjs
@@ -201,6 +201,7 @@ try {
   assert.ok(recovered, `WebGL context did not recover: ${lastRecoveryError ?? "no frame presented"}`);
   assert.equal(recovered.error, null, "recovered renderer reported an error");
   assert.equal(recovered.rendererBackend, "WebGL2", "recovered renderer changed backend");
+  assert.equal(recovered.gpuGeneration, baseline.metrics.gpuGeneration + 1, "recovery must replace the GPU generation once");
   assert.equal(recovered.revision, baseline.metrics.revision, "recovery reset scene revision");
   assert.equal(recovered.objectCount, baseline.metrics.objectCount, "recovery reset object count");
   assert.ok(Math.abs(recovered.time - sampleTime) < 1e-6, "recovery changed semantic playhead time");

--- a/scripts/renderer-webgl-context-loss-smoke.mjs
+++ b/scripts/renderer-webgl-context-loss-smoke.mjs
@@ -168,9 +168,22 @@ try {
   assert.equal(duringLoss.metrics.objectCount, baseline.metrics.objectCount, "context loss reset scene objects");
 
   await page.evaluate(() => window.__noonContextRecovery.restore());
-  await page.waitForFunction(() => window.__noonContextRecovery?.state.restored === 1, null, {
-    timeout: 10_000,
-  });
+  await page.waitForFunction(
+    () =>
+      window.__noonContextRecovery?.state.restored === 1 &&
+      window.__noonContextRecovery?.state.recovery !== "pending",
+    null,
+    { timeout: 10_000 },
+  );
+  const recoveryState = await page.evaluate(() => ({
+    recovery: window.__noonContextRecovery.state.recovery,
+    error: window.noonSmoke.metrics().error,
+  }));
+  assert.equal(
+    recoveryState.recovery,
+    "ready",
+    `WebGL GPU stack reconstruction failed: ${recoveryState.error ?? "unknown error"}`,
+  );
 
   let recovered = null;
   let lastRecoveryError = null;

--- a/web/authoring-render-worker.js
+++ b/web/authoring-render-worker.js
@@ -160,7 +160,7 @@ async function recoverAndPresentWebGlContext() {
       flushBootstrapQueue();
       drainTransport();
     }
-    if (needsPresent) scheduleFrame();
+    scheduleFrame();
   } catch (error) {
     fail(error, null);
   } finally {

--- a/web/authoring-render-worker.js
+++ b/web/authoring-render-worker.js
@@ -56,6 +56,7 @@ let scheduleTicket = 0;
 let presentedFrames = 0;
 let modeSwitches = 0;
 let rendererRebuilds = 0;
+let webglRecoveryPromise = null;
 
 self.addEventListener("message", (event) => {
   void handleMainMessage(event.data);
@@ -64,6 +65,7 @@ self.addEventListener("message", (event) => {
 async function handleMainMessage(message) {
   try {
     validateMainMessage(message);
+    if (webglRecoveryPromise !== null) await webglRecoveryPromise;
     switch (message.type) {
       case "init":
         await initialize(message);
@@ -132,6 +134,38 @@ async function prepareSurface(message, operation) {
   height = normalizedDimension(message.height ?? canvas.height);
   transportMode = message.transportMode;
   await init();
+  canvas.addEventListener("webglcontextrestored", wakeAfterWebGlContextRestored);
+}
+
+function wakeAfterWebGlContextRestored() {
+  // Rust records context restoration synchronously. Defer the platform wake
+  // until every restore listener has run, then rebuild before presenting even
+  // when the execution owner has settled to idle.
+  queueMicrotask(() => void recoverAndPresentWebGlContext());
+}
+
+async function recoverAndPresentWebGlContext() {
+  const restoringRenderer = renderer;
+  if (stopped || restoringRenderer === null || webglRecoveryPromise !== null) return;
+  const recovery = Promise.resolve(restoringRenderer.recoverWebGlContext?.());
+  webglRecoveryPromise = recovery;
+  try {
+    await recovery;
+    if (stopped || renderer !== restoringRenderer) return;
+    webglRecoveryPromise = null;
+    renderer.resize(width, height);
+    if (!drainGpuDiagnostics()) return;
+    needsPresent = true;
+    if (tryPresent()) {
+      flushBootstrapQueue();
+      drainTransport();
+    }
+    if (needsPresent) scheduleFrame();
+  } catch (error) {
+    fail(error, null);
+  } finally {
+    if (webglRecoveryPromise === recovery) webglRecoveryPromise = null;
+  }
 }
 
 function startEngine(message) {
@@ -240,6 +274,10 @@ function resize(message) {
   width = nextWidth;
   height = nextHeight;
   if (renderer === null) {
+    return;
+  }
+  if (webglRecoveryPromise !== null) {
+    needsPresent = true;
     return;
   }
   renderer.resize(width, height);
@@ -432,6 +470,10 @@ function consumeDelta(json, publication = null) {
     return true;
   }
 
+  if (webglRecoveryPromise !== null) {
+    return false;
+  }
+
   if (mode === MODE_RETAINED && reconnectResourceBundlePending) {
     throw new Error("retained authoring reconnect snapshot arrived before its resource bundle");
   }
@@ -567,7 +609,12 @@ async function bootstrapRenderer(initial, resumeFrameLoop = true, publication = 
 }
 
 function tryPresent() {
-  if (renderer === null || !needsPresent || !drainGpuDiagnostics()) {
+  if (
+    renderer === null ||
+    webglRecoveryPromise !== null ||
+    !needsPresent ||
+    !drainGpuDiagnostics()
+  ) {
     return false;
   }
   if (!renderer.render()) {
@@ -733,7 +780,7 @@ function cancelScheduledFrame() {
 
 function scheduleFrame(generation = frameLoopGeneration) {
   cancelScheduledFrame();
-  if (!running) return;
+  if (!running || webglRecoveryPromise !== null) return;
   const needsAnimationFrame = needsPresent || engineWake === null ||
     engineWake.cadence === "animation_frame";
   if (!needsAnimationFrame && engineWake.cadence === "idle") return;
@@ -753,9 +800,9 @@ function scheduleFrame(generation = frameLoopGeneration) {
 }
 
 function frame(timestamp, generation, ticket) {
-  if (ticket !== scheduleTicket || generation !== frameLoopGeneration ||
-      !running || !drainGpuDiagnostics()) return;
+  if (ticket !== scheduleTicket || generation !== frameLoopGeneration || !running) return;
   scheduledFrame = null;
+  if (webglRecoveryPromise !== null || !drainGpuDiagnostics()) return;
   lastFrameTimestamp = timestamp;
   if (needsPresent && tryPresent()) {
     flushBootstrapQueue();

--- a/web/browser-smoke.js
+++ b/web/browser-smoke.js
@@ -252,13 +252,21 @@ async function start() {
     const gl = rendererCanvas?.getContext("webgl2");
     const extension = gl?.getExtension("WEBGL_lose_context");
     if (!gl || !extension) return null;
-    const state = { lost: 0, restored: 0 };
+    const state = { lost: 0, restored: 0, recovery: "idle" };
     rendererCanvas.addEventListener("webglcontextlost", (event) => {
       event.preventDefault();
       state.lost += 1;
     });
-    rendererCanvas.addEventListener("webglcontextrestored", () => {
+    rendererCanvas.addEventListener("webglcontextrestored", async () => {
       state.restored += 1;
+      state.recovery = "pending";
+      try {
+        await renderer.recoverWebGlContext();
+        state.recovery = "ready";
+      } catch (error) {
+        state.recovery = "error";
+        state.error = String(error?.message ?? error);
+      }
     });
     webglContextRecovery = {
       state,

--- a/web/browser-smoke.js
+++ b/web/browser-smoke.js
@@ -70,6 +70,7 @@ function metrics() {
     uploadBytes: renderer?.lastBytesUploaded() ?? 0,
     geometryCacheMisses: renderer?.lastGeometryCacheMisses() ?? 0,
     rendererBackend: renderer?.rendererBackend() ?? null,
+    gpuGeneration: renderer?.gpuGeneration() ?? null,
     backingWidth,
     backingHeight,
     cssWidth: canvas.clientWidth,

--- a/web/browser-smoke.js
+++ b/web/browser-smoke.js
@@ -24,6 +24,8 @@ let renderer = null;
 let incrementalTime = null;
 let backingWidth = canvas.width;
 let backingHeight = canvas.height;
+let rendererCanvas = null;
+let webglContextRecovery = null;
 
 window.noonSmoke = {
   state,
@@ -40,6 +42,9 @@ window.noonSmoke = {
     throw new Error("Noon browser smoke harness is not ready");
   },
   resizeBacking() {
+    throw new Error("Noon browser smoke harness is not ready");
+  },
+  webglContextControl() {
     throw new Error("Noon browser smoke harness is not ready");
   },
   metrics() {
@@ -216,6 +221,7 @@ async function start() {
     1,
   );
   const offscreen = canvas.transferControlToOffscreen();
+  rendererCanvas = offscreen;
   renderer = await ExecutionCanvasRenderer.create(offscreen, engine.initialDeltaJson());
   renderer.resize(backingWidth, backingHeight);
   renderer.setCamera(0.0, 0.0, MANIM_DEFAULT_CAMERA_HEIGHT);
@@ -241,6 +247,26 @@ async function start() {
   window.noonSmoke.beginIncremental = beginIncremental;
   window.noonSmoke.renderIncrementalAt = presentIncrementalAt;
   window.noonSmoke.resizeBacking = resizeBacking;
+  window.noonSmoke.webglContextControl = () => {
+    if (webglContextRecovery !== null) return webglContextRecovery;
+    const gl = rendererCanvas?.getContext("webgl2");
+    const extension = gl?.getExtension("WEBGL_lose_context");
+    if (!gl || !extension) return null;
+    const state = { lost: 0, restored: 0 };
+    rendererCanvas.addEventListener("webglcontextlost", (event) => {
+      event.preventDefault();
+      state.lost += 1;
+    });
+    rendererCanvas.addEventListener("webglcontextrestored", () => {
+      state.restored += 1;
+    });
+    webglContextRecovery = {
+      state,
+      lose: () => extension.loseContext(),
+      restore: () => extension.restoreContext(),
+    };
+    return webglContextRecovery;
+  };
   window.noonSmoke.metrics = metrics;
   state.ready = true;
 }


### PR DESCRIPTION
After WebGL context restoration, presentation could report success while the canvas stayed blank: wgpu device/queue VAOs, framebuffers and buffers still referenced the lost context. The browser host now recreates the complete GPU stack on the same canvas, rebuilds derived renderer resources, and preserves the existing execution source, semantic revision, objects and playhead.

The host wakes a paused renderer on restoration, holds presentation/ticks during asynchronous device recovery, preserves incoming deltas using existing transport backpressure, and resumes the current execution cadence. Event listeners are removed when the renderer is disposed.

Advances #969 platform lifecycle correctness. Recovery belongs to `noon-web`; no semantic/runtime authority or serialization boundary is added. Clean frames remain idle. Actual context loss deliberately incurs a full GPU resource rebuild; local ordinary changes remain local.

Validation:
- `CARGO_TARGET_DIR=/Users/ykshin/Dev/me/noon/target CARGO_INCREMENTAL=0 NOON_SKIP_PLAYGROUND_TEST=1 NOON_SKIP_WEB_PREFLIGHT=1 NOON_WASM_PROFILE=dev bash scripts/check.sh full`: passed workspace formatting/check/clippy/tests/doc-tests and WASM package checks.
- `NOON_SKIP_PLAYGROUND_TEST=1 NOON_WEB_PREFLIGHT_ONLY=1 bash scripts/check.sh web`: passed 187 Python tests and JS checks.
- `node scripts/renderer-webgl-context-loss-smoke.mjs`: passed real OffscreenCanvas context loss/restoration, unchanged scene/time/backend, one GPU generation increment, and exact recovered-versus-fresh pixel equality.

The recovery is an explicit asynchronous platform-host operation; callers must await it before further renderer access. No native renderer behavior or authoring semantics changed.
