### PR TITLE
Expose Noon-authored Manim-compatible demos in the gallery

### DIFF
--- a/web/example-gallery.js
+++ b/web/example-gallery.js
@@ -7,6 +7,7 @@ const READY_PARITY = new Set(["candidate", "parity-qualified"]);
 const THUMBNAIL_FALLBACK_MARKER = "noonThumbnailFallbackInstalled";
 const DEFAULT_GALLERY_MANIFEST = "./python/examples/manim_tutorial_manifest.json";
 const STRESS_GALLERY_MANIFEST = "./python/examples/manim_stress_manifest.json";
+const COMPATIBILITY_GALLERY_MANIFEST = "./python/examples/manim_compatibility_manifest.json";
 
 if (typeof document !== "undefined") {
   installGalleryThumbnailFallback(document);
@@ -109,18 +110,30 @@ export async function loadGalleryManifest(
     return normalizeGalleryManifest(manifest);
   }
 
-  const stressManifest = await fetchGalleryManifest(STRESS_GALLERY_MANIFEST, fetchImpl);
+  const [stressManifest, compatibilityManifest] = await Promise.all([
+    fetchGalleryManifest(STRESS_GALLERY_MANIFEST, fetchImpl),
+    fetchGalleryManifest(COMPATIBILITY_GALLERY_MANIFEST, fetchImpl),
+  ]);
   const referenceVersion = manifest.reference?.version ?? null;
-  const stressVersion = stressManifest.reference?.version ?? null;
-  if (stressVersion !== referenceVersion) {
-    throw new Error(
-      `Manim stress manifest version ${stressVersion ?? "unknown"} does not match gallery version ${referenceVersion ?? "unknown"}`,
-    );
+  for (const [label, supplementalManifest] of [
+    ["stress", stressManifest],
+    ["compatibility", compatibilityManifest],
+  ]) {
+    const supplementalVersion = supplementalManifest.reference?.version ?? null;
+    if (supplementalVersion !== referenceVersion) {
+      throw new Error(
+        `Manim ${label} manifest version ${supplementalVersion ?? "unknown"} does not match gallery version ${referenceVersion ?? "unknown"}`,
+      );
+    }
   }
 
   return normalizeGalleryManifest({
     ...manifest,
-    entries: [...manifest.entries, ...stressManifest.entries],
+    entries: [
+      ...manifest.entries,
+      ...stressManifest.entries,
+      ...compatibilityManifest.entries,
+    ],
   });
 }
 

--- a/web/manim-compatibility-gallery.test.mjs
+++ b/web/manim-compatibility-gallery.test.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { access, readFile } from "node:fs/promises";
+
+import { normalizeGalleryManifest } from "./example-gallery.js";
+
+const manifest = JSON.parse(
+  await readFile(
+    new URL("./python/examples/manim_compatibility_manifest.json", import.meta.url),
+    "utf8",
+  ),
+);
+const readyEntries = manifest.entries.filter((entry) => entry.status === "ready");
+const gallery = normalizeGalleryManifest(manifest);
+
+assert.equal(manifest.reference.version, "0.21.0");
+assert.equal(gallery.examples.length, 5);
+assert.deepEqual(
+  gallery.examples.map((entry) => entry.id),
+  [
+    "compatible-affine-fade",
+    "compatible-family-transform-indicate",
+    "compatible-timed-composition",
+    "compatible-family-write",
+    "compatible-subset-display",
+  ],
+);
+
+const noonOnlyPatterns = [
+  /self\.value_tracker\(/,
+  /self\.bind_position\(/,
+  /async\s+def\s+construct\(/,
+  /await\s+self\./,
+  /\._scene\b/,
+];
+
+for (const entry of readyEntries) {
+  assert.equal(
+    entry.reuse,
+    "manim-compatible-parity-v0.21",
+    `${entry.id}: authored compatibility examples must use the compatibility reuse class`,
+  );
+  assert.ok(
+    entry.category.startsWith("manim-compatible/"),
+    `${entry.id}: category must visibly identify the compatibility contract`,
+  );
+  assert.ok(
+    entry.features.includes("Manim-compatible"),
+    `${entry.id}: compatibility must remain searchable from the gallery`,
+  );
+
+  await access(new URL(`./${entry.path}`, import.meta.url));
+  await access(new URL(`./${entry.thumbnail}`, import.meta.url));
+
+  const source = await readFile(new URL(`./${entry.path}`, import.meta.url), "utf8");
+  assert.match(source, /from noon import \*/, `${entry.id}: public source must import Noon`);
+  for (const pattern of noonOnlyPatterns) {
+    assert.doesNotMatch(
+      source,
+      pattern,
+      `${entry.id}: Manim-compatible source must not depend on Noon-only helper ${pattern}`,
+    );
+  }
+}
+
+console.log("✓ Noon-authored Manim-compatible gallery examples");

--- a/web/manim-compatibility-gallery.test.mjs
+++ b/web/manim-compatibility-gallery.test.mjs
@@ -13,7 +13,7 @@ const readyEntries = manifest.entries.filter((entry) => entry.status === "ready"
 const gallery = normalizeGalleryManifest(manifest);
 
 assert.equal(manifest.reference.version, "0.21.0");
-assert.equal(gallery.examples.length, 5);
+assert.equal(gallery.examples.length, 8);
 assert.deepEqual(
   gallery.examples.map((entry) => entry.id),
   [
@@ -22,6 +22,9 @@ assert.deepEqual(
     "compatible-timed-composition",
     "compatible-family-write",
     "compatible-subset-display",
+    "compatible-scale-in-place",
+    "compatible-indicate-square",
+    "compatible-affine-lifecycle",
   ],
 );
 

--- a/web/python/examples/manim_compatibility_manifest.json
+++ b/web/python/examples/manim_compatibility_manifest.json
@@ -80,6 +80,51 @@
       "thumbnail_alt": "Colored circle rows illustrating increasing and one-by-one subset display",
       "thumbnail_time": 4.0,
       "order": 1050
+    },
+    {
+      "id": "compatible-scale-in-place",
+      "title": "ScaleInPlace",
+      "summary": "Scale a geometry object around its own center using the Manim-compatible ScaleInPlace animation.",
+      "status": "ready",
+      "path": "python/examples/manim_parity_scale_in_place.py",
+      "category": "manim-compatible/transform",
+      "features": ["ScaleInPlace", "Square", "transform", "Manim-compatible"],
+      "reuse": "manim-compatible-parity-v0.21",
+      "parity_status": "candidate",
+      "thumbnail": "thumbnails/manim/compatible-scale-in-place.svg",
+      "thumbnail_alt": "Blue square shown before and after an in-place scale",
+      "thumbnail_time": 0.5,
+      "order": 1060
+    },
+    {
+      "id": "compatible-indicate-square",
+      "title": "IndicateSquare",
+      "summary": "Pulse a geometry object with Manim-compatible Indicate semantics.",
+      "status": "ready",
+      "path": "python/examples/manim_parity_indicate_square.py",
+      "category": "manim-compatible/indication",
+      "features": ["Indicate", "Square", "indication", "Manim-compatible"],
+      "reuse": "manim-compatible-parity-v0.21",
+      "parity_status": "candidate",
+      "thumbnail": "thumbnails/manim/compatible-indicate-square.svg",
+      "thumbnail_alt": "Blue square with a surrounding indication pulse",
+      "thumbnail_time": 0.5,
+      "order": 1070
+    },
+    {
+      "id": "compatible-affine-lifecycle",
+      "title": "SpinInShrinkToCenter",
+      "summary": "Spin a square in from nothing, then remove it with ShrinkToCenter.",
+      "status": "ready",
+      "path": "python/examples/manim_parity_affine_lifecycle.py",
+      "category": "manim-compatible/creation",
+      "features": ["SpinInFromNothing", "ShrinkToCenter", "Square", "lifecycle", "Manim-compatible"],
+      "reuse": "manim-compatible-parity-v0.21",
+      "parity_status": "candidate",
+      "thumbnail": "thumbnails/manim/compatible-affine-lifecycle.svg",
+      "thumbnail_alt": "Blue square illustrating spin-in and shrink-to-center lifecycle",
+      "thumbnail_time": 1.0,
+      "order": 1080
     }
   ]
 }

--- a/web/python/examples/manim_compatibility_manifest.json
+++ b/web/python/examples/manim_compatibility_manifest.json
@@ -1,0 +1,85 @@
+{
+  "reference": {
+    "project": "Manim Community",
+    "version": "0.21.0",
+    "license": "MIT"
+  },
+  "policy": "These are Noon-authored public examples intentionally limited to the Manim-compatible API surface. They are not copied upstream Manim documentation examples, so they remain separate from the exact-source tutorial manifest.",
+  "entries": [
+    {
+      "id": "compatible-affine-fade",
+      "title": "AffineFade",
+      "summary": "Manim-compatible FadeIn/FadeOut using shift, scale, and target_position.",
+      "status": "ready",
+      "path": "python/examples/manim_compatible_affine_fade.py",
+      "category": "manim-compatible/fading",
+      "features": ["FadeIn", "FadeOut", "shift", "scale", "target_position", "Manim-compatible"],
+      "reuse": "manim-compatible-parity-v0.21",
+      "parity_status": "candidate",
+      "thumbnail": "thumbnails/manim/compatible-affine-fade.svg",
+      "thumbnail_alt": "Blue circle illustrating shifted and scaled fade endpoints",
+      "thumbnail_time": 1.0,
+      "order": 1010
+    },
+    {
+      "id": "compatible-family-transform-indicate",
+      "title": "FamilyTransformIndicate",
+      "summary": "Manim-compatible VGroup transform with lag_ratio followed by an Indicate pulse.",
+      "status": "ready",
+      "path": "python/examples/manim_compatible_family_indicate.py",
+      "category": "manim-compatible/transform",
+      "features": ["VGroup", "animate", "Indicate", "lag_ratio", "Manim-compatible"],
+      "reuse": "manim-compatible-parity-v0.21",
+      "parity_status": "candidate",
+      "thumbnail": "thumbnails/manim/compatible-family-indicate.svg",
+      "thumbnail_alt": "Pink square and blue circle with an indicate pulse",
+      "thumbnail_time": 2.5,
+      "order": 1020
+    },
+    {
+      "id": "compatible-timed-composition",
+      "title": "TimedComposition",
+      "summary": "Nested Succession with timed Add/Wait steps, then a LaggedStart of FadeOut animations.",
+      "status": "ready",
+      "path": "python/examples/ordinary_timed_composition.py",
+      "category": "manim-compatible/composition",
+      "features": ["Succession", "Add", "Wait", "LaggedStart", "FadeOut", "Manim-compatible"],
+      "reuse": "manim-compatible-parity-v0.21",
+      "parity_status": "candidate",
+      "thumbnail": "thumbnails/manim/compatible-timed-composition.svg",
+      "thumbnail_alt": "Three blue squares illustrating nested timed composition",
+      "thumbnail_time": 0.7,
+      "order": 1030
+    },
+    {
+      "id": "compatible-family-write",
+      "title": "FamilyWrite",
+      "summary": "Write a styled VGroup with lag_ratio so its members reveal in order.",
+      "status": "ready",
+      "path": "python/examples/manim_compatible_family_write.py",
+      "category": "manim-compatible/creation",
+      "features": ["Write", "VGroup", "lag_ratio", "style", "Manim-compatible"],
+      "reuse": "manim-compatible-parity-v0.21",
+      "parity_status": "candidate",
+      "thumbnail": "thumbnails/manim/compatible-family-write.svg",
+      "thumbnail_alt": "Styled orange square and pink circle being written as a family",
+      "thumbnail_time": 1.5,
+      "order": 1040
+    },
+    {
+      "id": "compatible-subset-display",
+      "title": "SubsetDisplay",
+      "summary": "ShowIncreasingSubsets followed by ShowSubmobjectsOneByOne on ordered VGroups.",
+      "status": "ready",
+      "path": "python/examples/ordinary_subset_display.py",
+      "category": "manim-compatible/creation",
+      "features": ["ShowIncreasingSubsets", "ShowSubmobjectsOneByOne", "VGroup", "Manim-compatible"],
+      "reuse": "manim-compatible-parity-v0.21",
+      "parity_status": "candidate",
+      "thumbnail": "thumbnails/manim/compatible-subset-display.svg",
+      "thumbnail_alt": "Colored circle rows illustrating increasing and one-by-one subset display",
+      "thumbnail_time": 4.0,
+      "order": 1050
+    }
+  ]
+}

--- a/web/python/examples/manim_compatible_affine_fade.py
+++ b/web/python/examples/manim_compatible_affine_fade.py
@@ -1,0 +1,22 @@
+from noon import *
+
+
+class AffineFadeDemo(Scene):
+    def construct(self):
+        circle = (
+            Circle(radius=0.6)
+            .set_fill(BLUE, opacity=1.0)
+            .set_stroke(opacity=0.0)
+        )
+
+        self.play(
+            FadeIn(circle, shift=2 * RIGHT, scale=0.25),
+            run_time=1.0,
+            rate_func=linear,
+        )
+        self.wait(0.25)
+        self.play(
+            FadeOut(circle, target_position=2 * RIGHT, scale=0.15),
+            run_time=1.0,
+            rate_func=linear,
+        )

--- a/web/python/examples/manim_compatible_family_indicate.py
+++ b/web/python/examples/manim_compatible_family_indicate.py
@@ -1,0 +1,26 @@
+from noon import *
+
+
+class FamilyTransformIndicateDemo(Scene):
+    def construct(self):
+        left = (
+            Square(side_length=0.9)
+            .set_fill(PINK, opacity=0.9)
+            .set_stroke(opacity=0.0)
+            .shift(LEFT * 2)
+        )
+        right = (
+            Circle(radius=0.45)
+            .set_fill(BLUE, opacity=0.9)
+            .set_stroke(opacity=0.0)
+        )
+        family = VGroup(left, right)
+
+        self.add(family)
+        self.play(
+            family.animate(run_time=2.0, rate_func=linear, lag_ratio=0.5).shift(RIGHT)
+        )
+        self.play(Indicate(family, run_time=2.0, lag_ratio=0.5))
+        self.wait(0.25)
+        left.shift(RIGHT)
+        self.wait(0.25)

--- a/web/python/examples/manim_compatible_family_write.py
+++ b/web/python/examples/manim_compatible_family_write.py
@@ -1,0 +1,19 @@
+from noon import *
+
+
+class FamilyWriteDemo(Scene):
+    def construct(self):
+        square = (
+            Square(side_length=0.8)
+            .set_fill(ORANGE, opacity=1.0)
+            .set_stroke(BLUE, width=6)
+        )
+        circle = (
+            Circle(radius=0.4)
+            .set_fill(PINK, opacity=1.0)
+            .set_stroke(width=0)
+        )
+        family = VGroup(square, circle).arrange(RIGHT, buff=1.2)
+
+        self.play(Write(family, run_time=3.0, lag_ratio=0.5))
+        self.wait(0.25)

--- a/web/stress-gallery.test.mjs
+++ b/web/stress-gallery.test.mjs
@@ -59,10 +59,31 @@ const primaryManifest = {
     },
   ],
 };
+const compatibilityManifest = {
+  reference: { version: "0.21.0" },
+  entries: [
+    {
+      id: "compatible-example",
+      title: "Compatible example",
+      status: "ready",
+      reuse: "manim-compatible-parity-v0.21",
+      path: "python/examples/manim_compatible_example.py",
+      thumbnail: "thumbnails/manim/compatible-example.svg",
+      features: ["AnimationGroup", "Manim-compatible"],
+      category: "manim-compatible/composition",
+      parity_status: "candidate",
+      order: 20,
+    },
+  ],
+};
 const requests = [];
 const merged = await loadGalleryManifest(undefined, async (url) => {
   requests.push(url);
-  const manifest = url.endsWith("manim_stress_manifest.json") ? stressManifest : primaryManifest;
+  const manifest = url.endsWith("manim_stress_manifest.json")
+    ? stressManifest
+    : url.endsWith("manim_compatibility_manifest.json")
+      ? compatibilityManifest
+      : primaryManifest;
   return {
     ok: true,
     status: 200,
@@ -74,11 +95,12 @@ const merged = await loadGalleryManifest(undefined, async (url) => {
 assert.deepEqual(requests, [
   "./python/examples/manim_tutorial_manifest.json",
   "./python/examples/manim_stress_manifest.json",
+  "./python/examples/manim_compatibility_manifest.json",
 ]);
 assert.deepEqual(
   merged.examples.map((example) => example.id),
-  ["base-example", "manim-parity-stress-grid"],
-  "default gallery load must merge and order custom stress workloads with the Manim corpus",
+  ["base-example", "manim-parity-stress-grid", "compatible-example"],
+  "default gallery load must merge exact-source, stress, and Manim-compatible Noon-authored examples",
 );
 
-console.log("✓ custom Manim parity stress gallery contract");
+console.log("✓ custom Manim parity stress + compatibility gallery contract");

--- a/web/thumbnails/manim/compatible-affine-fade.svg
+++ b/web/thumbnails/manim/compatible-affine-fade.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">Affine Fade demo</title>
+  <desc id="desc">A blue circle fading and scaling between two positions.</desc>
+  <rect width="640" height="360" fill="#10141d"/>
+  <circle cx="435" cy="180" r="72" fill="#58c4dd" opacity="0.18"/>
+  <circle cx="355" cy="180" r="62" fill="#58c4dd" opacity="0.42"/>
+  <circle cx="270" cy="180" r="52" fill="#58c4dd"/>
+  <path d="M165 180h55" stroke="#8f9bb3" stroke-width="6" stroke-linecap="round"/>
+  <path d="m205 160 22 20-22 20" fill="none" stroke="#8f9bb3" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/web/thumbnails/manim/compatible-affine-lifecycle.svg
+++ b/web/thumbnails/manim/compatible-affine-lifecycle.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-label="SpinIn and ShrinkToCenter preview">
+  <rect width="640" height="360" fill="#111722"/>
+  <g transform="translate(210 180) rotate(22)">
+    <rect x="-70" y="-70" width="140" height="140" rx="10" fill="#58C4DD" opacity="0.95"/>
+    <circle cx="0" cy="0" r="8" fill="#FC6255"/>
+  </g>
+  <path d="M310 180h80" stroke="#8390a8" stroke-width="8" stroke-linecap="round"/>
+  <path d="M370 155l30 25-30 25" fill="none" stroke="#8390a8" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect x="445" y="145" width="70" height="70" rx="8" fill="#58C4DD" opacity="0.6"/>
+  <text x="320" y="320" text-anchor="middle" fill="#dbe2ef" font-family="ui-monospace,monospace" font-size="24">SpinIn → ShrinkToCenter</text>
+</svg>

--- a/web/thumbnails/manim/compatible-family-indicate.svg
+++ b/web/thumbnails/manim/compatible-family-indicate.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">Family Transform and Indicate demo</title>
+  <desc id="desc">A pink square and blue circle moving together with an indicate pulse.</desc>
+  <rect width="640" height="360" fill="#10141d"/>
+  <rect x="195" y="125" width="110" height="110" rx="8" fill="#d147bd"/>
+  <circle cx="410" cy="180" r="58" fill="#58c4dd"/>
+  <circle cx="410" cy="180" r="82" fill="none" stroke="#f7d96f" stroke-width="8" opacity="0.7"/>
+  <rect x="173" y="103" width="154" height="154" rx="18" fill="none" stroke="#f7d96f" stroke-width="8" opacity="0.45"/>
+</svg>

--- a/web/thumbnails/manim/compatible-family-write.svg
+++ b/web/thumbnails/manim/compatible-family-write.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">Family Write demo</title>
+  <desc id="desc">An orange square and pink circle being written with a highlighted border.</desc>
+  <rect width="640" height="360" fill="#10141d"/>
+  <rect x="165" y="120" width="120" height="120" rx="8" fill="#ff862f" stroke="#58c4dd" stroke-width="10"/>
+  <circle cx="430" cy="180" r="62" fill="#d147bd" stroke="#f7d96f" stroke-width="8" stroke-dasharray="120 270" transform="rotate(-80 430 180)"/>
+  <path d="M330 110c55 16 86 43 104 83" fill="none" stroke="#f7d96f" stroke-width="7" stroke-linecap="round" opacity="0.7"/>
+</svg>

--- a/web/thumbnails/manim/compatible-indicate-square.svg
+++ b/web/thumbnails/manim/compatible-indicate-square.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-label="Indicate preview">
+  <rect width="640" height="360" fill="#111722"/>
+  <rect x="250" y="110" width="140" height="140" rx="10" fill="#58C4DD"/>
+  <rect x="225" y="85" width="190" height="190" rx="18" fill="none" stroke="#FFFF00" stroke-width="10" opacity="0.9"/>
+  <rect x="205" y="65" width="230" height="230" rx="24" fill="none" stroke="#FFFF00" stroke-width="5" opacity="0.35"/>
+  <text x="320" y="325" text-anchor="middle" fill="#dbe2ef" font-family="ui-monospace,monospace" font-size="26">Indicate</text>
+</svg>

--- a/web/thumbnails/manim/compatible-scale-in-place.svg
+++ b/web/thumbnails/manim/compatible-scale-in-place.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-label="ScaleInPlace preview">
+  <rect width="640" height="360" fill="#111722"/>
+  <rect x="160" y="120" width="120" height="120" rx="8" fill="#58C4DD" opacity="0.28"/>
+  <rect x="135" y="95" width="170" height="170" rx="10" fill="none" stroke="#58C4DD" stroke-width="10"/>
+  <path d="M350 180h90" stroke="#8390a8" stroke-width="8" stroke-linecap="round"/>
+  <path d="M420 155l30 25-30 25" fill="none" stroke="#8390a8" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="320" y="315" text-anchor="middle" fill="#dbe2ef" font-family="ui-monospace,monospace" font-size="26">ScaleInPlace</text>
+</svg>

--- a/web/thumbnails/manim/compatible-subset-display.svg
+++ b/web/thumbnails/manim/compatible-subset-display.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">Subset Display demo</title>
+  <desc id="desc">Two rows of colored circles demonstrating increasing subsets and one-by-one display.</desc>
+  <rect width="640" height="360" fill="#10141d"/>
+  <circle cx="210" cy="125" r="38" fill="#fc6255"/>
+  <circle cx="320" cy="125" r="38" fill="#83c167"/>
+  <circle cx="430" cy="125" r="38" fill="#58c4dd"/>
+  <circle cx="210" cy="235" r="38" fill="#ff862f" opacity="0.2"/>
+  <circle cx="320" cy="235" r="38" fill="#d147bd"/>
+  <circle cx="430" cy="235" r="38" fill="#f7d96f" opacity="0.2"/>
+</svg>

--- a/web/thumbnails/manim/compatible-timed-composition.svg
+++ b/web/thumbnails/manim/compatible-timed-composition.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">Timed Composition demo</title>
+  <desc id="desc">Three blue squares appearing in sequence and fading with a lag.</desc>
+  <rect width="640" height="360" fill="#10141d"/>
+  <rect x="125" y="130" width="100" height="100" rx="7" fill="#58c4dd" opacity="0.45"/>
+  <rect x="270" y="130" width="100" height="100" rx="7" fill="#58c4dd" opacity="0.72"/>
+  <rect x="415" y="130" width="100" height="100" rx="7" fill="#58c4dd"/>
+  <path d="M225 180h45M370 180h45" stroke="#8f9bb3" stroke-width="5" stroke-linecap="round" stroke-dasharray="8 10"/>
+</svg>


### PR DESCRIPTION
## Summary

- preserve the exact-source `manim_tutorial_manifest.json` contract unchanged
- add a separate `manim_compatibility_manifest.json` for Noon-authored scenes that intentionally stay on the Manim-compatible public API
- surface eight working geometry-only demos: `AffineFade`, `FamilyTransformIndicate`, `TimedComposition`, `FamilyWrite`, `SubsetDisplay`, `ScaleInPlace`, `IndicateSquare`, and `SpinInShrinkToCenter`
- categorize them under `manim-compatible/...` and make compatibility searchable through the `Manim-compatible` feature tag
- add static gallery posters for the compatibility entries
- merge exact-source, stress, and compatibility manifests in the gallery loader with matching Manim-version checks
- add tests for the supplemental-manifest merge and to reject obvious Noon-only helpers from the Manim-compatible cohort

This PR deliberately stays on geometry/shared animation paths and does not change runtime animation implementation. Text/Typst group animation migration remains deferred to #959. True Noon-specific examples such as `value_tracker`/`bind_position` and async retained-live construction remain outside this compatibility manifest.