### PR TITLE
Expose plain Text Write example in gallery

### DIFF
--- a/web/manim-compatibility-gallery.test.mjs
+++ b/web/manim-compatibility-gallery.test.mjs
@@ -13,7 +13,7 @@ const readyEntries = manifest.entries.filter((entry) => entry.status === "ready"
 const gallery = normalizeGalleryManifest(manifest);
 
 assert.equal(manifest.reference.version, "0.21.0");
-assert.equal(gallery.examples.length, 8);
+assert.equal(gallery.examples.length, 9);
 assert.deepEqual(
   gallery.examples.map((entry) => entry.id),
   [
@@ -25,6 +25,7 @@ assert.deepEqual(
     "compatible-scale-in-place",
     "compatible-indicate-square",
     "compatible-affine-lifecycle",
+    "compatible-text-write",
   ],
 );
 
@@ -61,6 +62,17 @@ for (const entry of readyEntries) {
       source,
       pattern,
       `${entry.id}: Manim-compatible source must not depend on Noon-only helper ${pattern}`,
+    );
+  }
+
+  if (entry.id === "compatible-text-write") {
+    assert.match(source, /Text\(/, "plain Text Write example must construct Text");
+    assert.match(source, /Write\(/, "plain Text Write example must exercise Write");
+    assert.match(source, /Unwrite\(/, "plain Text Write example must exercise Unwrite");
+    assert.doesNotMatch(
+      source,
+      /\b(?:VGroup|Group|Typst|MathTypst)\b/,
+      "plain Text Write gallery coverage must not claim deferred Text-group or Typst scheduling",
     );
   }
 }

--- a/web/python/examples/manim_compatibility_manifest.json
+++ b/web/python/examples/manim_compatibility_manifest.json
@@ -125,6 +125,21 @@
       "thumbnail_alt": "Blue square illustrating spin-in and shrink-to-center lifecycle",
       "thumbnail_time": 1.0,
       "order": 1080
+    },
+    {
+      "id": "compatible-text-write",
+      "title": "TextWrite",
+      "summary": "Move one plain Text object while writing another, then remove it with Unwrite.",
+      "status": "ready",
+      "path": "python/examples/ordinary_text_write.py",
+      "category": "manim-compatible/text",
+      "features": ["Text", "Write", "Unwrite", "animate", "Manim-compatible"],
+      "reuse": "manim-compatible-parity-v0.21",
+      "parity_status": "candidate",
+      "thumbnail": "thumbnails/manim/compatible-text-write.svg",
+      "thumbnail_alt": "MOVE text shifting horizontally while WRITE is revealed above it",
+      "thumbnail_time": 1.0,
+      "order": 1090
     }
   ]
 }

--- a/web/thumbnails/manim/compatible-text-write.svg
+++ b/web/thumbnails/manim/compatible-text-write.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">Text Write example</title>
+  <desc id="desc">MOVE shifts along the lower row while WRITE is revealed above it.</desc>
+  <rect width="640" height="360" rx="24" fill="#111827"/>
+  <text x="320" y="128" text-anchor="middle" font-family="sans-serif" font-size="58" font-weight="700" fill="#f9fafb">WRITE</text>
+  <line x1="198" y1="149" x2="442" y2="149" stroke="#60a5fa" stroke-width="8" stroke-linecap="round"/>
+  <text x="365" y="248" text-anchor="middle" font-family="sans-serif" font-size="50" font-weight="700" fill="#f9fafb">MOVE</text>
+  <path d="M170 268 H300" fill="none" stroke="#a78bfa" stroke-width="8" stroke-linecap="round"/>
+  <path d="M286 252 L306 268 L286 284" fill="none" stroke="#a78bfa" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## Summary

- add the already-working `ordinary_text_write.py` example to the Manim-compatible gallery as `TextWrite`
- reuse the existing plain `Text` + `Write` + `Unwrite` implementation from #1174
- add a gallery poster
- extend the compatibility regression test from 8 to 9 entries
- explicitly reject `VGroup`/`Group`/Typst coverage in this TextWrite entry so deferred text-group scheduling is not implied

No runtime or animation implementation changes are included.