### PR TITLE
Expose shared Text family fade example in gallery

### DIFF
--- a/web/manim-compatibility-gallery.test.mjs
+++ b/web/manim-compatibility-gallery.test.mjs
@@ -13,7 +13,7 @@ const readyEntries = manifest.entries.filter((entry) => entry.status === "ready"
 const gallery = normalizeGalleryManifest(manifest);
 
 assert.equal(manifest.reference.version, "0.21.0");
-assert.equal(gallery.examples.length, 9);
+assert.equal(gallery.examples.length, 10);
 assert.deepEqual(
   gallery.examples.map((entry) => entry.id),
   [
@@ -26,6 +26,7 @@ assert.deepEqual(
     "compatible-indicate-square",
     "compatible-affine-lifecycle",
     "compatible-text-write",
+    "compatible-text-family-fade",
   ],
 );
 
@@ -56,7 +57,7 @@ for (const entry of readyEntries) {
   await access(new URL(`./${entry.thumbnail}`, import.meta.url));
 
   const source = await readFile(new URL(`./${entry.path}`, import.meta.url), "utf8");
-  assert.match(source, /from noon import \*/, `${entry.id}: public source must import Noon`);
+  assert.match(source, /from noon import\b/, `${entry.id}: public source must import Noon`);
   for (const pattern of noonOnlyPatterns) {
     assert.doesNotMatch(
       source,
@@ -72,7 +73,20 @@ for (const entry of readyEntries) {
     assert.doesNotMatch(
       source,
       /\b(?:VGroup|Group|Typst|MathTypst)\b/,
-      "plain Text Write gallery coverage must not claim deferred Text-group or Typst scheduling",
+      "plain Text Write gallery coverage must not claim Text-family or Typst scheduling",
+    );
+  }
+
+  if (entry.id === "compatible-text-family-fade") {
+    assert.match(source, /VGroup\(/, "Text family fade example must construct a VGroup");
+    assert.match(source, /FadeIn\(/, "Text family fade example must exercise FadeIn");
+    assert.match(source, /FadeOut\(/, "Text family fade example must exercise FadeOut");
+    assert.match(source, /Write\(/, "Text family fade example must compose with Write");
+    assert.match(source, /lag_ratio\s*=\s*0\.25/, "Text family fade must exercise lagged family timing");
+    assert.doesNotMatch(
+      source,
+      /\b(?:Typst|MathTypst)\b/,
+      "Text family fade gallery coverage must not claim deferred Typst family scheduling",
     );
   }
 }

--- a/web/python/examples/manim_compatibility_manifest.json
+++ b/web/python/examples/manim_compatibility_manifest.json
@@ -140,6 +140,21 @@
       "thumbnail_alt": "MOVE text shifting horizontally while WRITE is revealed above it",
       "thumbnail_time": 1.0,
       "order": 1090
+    },
+    {
+      "id": "compatible-text-family-fade",
+      "title": "TextFamilyFade",
+      "summary": "Lagged FadeIn/FadeOut over a VGroup of plain Text while a disjoint Text is written in parallel.",
+      "status": "ready",
+      "path": "python/examples/ordinary_text_family_fade.py",
+      "category": "manim-compatible/text",
+      "features": ["Text", "VGroup", "FadeIn", "FadeOut", "Write", "lag_ratio", "Manim-compatible"],
+      "reuse": "manim-compatible-parity-v0.21",
+      "parity_status": "candidate",
+      "thumbnail": "thumbnails/manim/compatible-text-family-fade.svg",
+      "thumbnail_alt": "LEFT and RIGHT text fading in as a family while WRITE appears below",
+      "thumbnail_time": 1.0,
+      "order": 1100
     }
   ]
 }

--- a/web/thumbnails/manim/compatible-text-family-fade.svg
+++ b/web/thumbnails/manim/compatible-text-family-fade.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 180" role="img" aria-labelledby="title desc">
+  <title id="title">Text family fade</title>
+  <desc id="desc">LEFT and RIGHT text fading in as a family while WRITE appears below</desc>
+  <rect width="320" height="180" rx="18" fill="#111827"/>
+  <g font-family="DejaVu Sans Mono, monospace" font-weight="700" text-anchor="middle">
+    <text x="93" y="74" font-size="28" fill="#93c5fd">LEFT</text>
+    <text x="226" y="74" font-size="28" fill="#93c5fd">RIGHT</text>
+    <text x="128" y="132" font-size="25" fill="#f9a8d4">WRITE</text>
+  </g>
+  <path d="M52 92h215" stroke="#60a5fa" stroke-width="3" stroke-linecap="round" stroke-dasharray="7 8" opacity="0.65"/>
+  <path d="M218 116h58" stroke="#f472b6" stroke-width="3" stroke-linecap="round" opacity="0.8"/>
+  <path d="M276 116l-10-6v12z" fill="#f472b6" opacity="0.8"/>
+</svg>


### PR DESCRIPTION
## Summary

- add the newly shared `ordinary_text_family_fade.py` example to the Manim-compatible gallery as `TextFamilyFade`
- demonstrate lagged `FadeIn`/`FadeOut` over `VGroup(Text(...))` composed with a disjoint `Write(Text(...))`
- reuse the implementation and example merged in #1179; no runtime/animation implementation changes
- add a gallery poster and extend the compatibility gallery regression from 9 to 10 entries
- keep Typst/MathTypst and affine Text-family fade endpoints explicitly out of scope

This surfaces only functionality that #1179 moved onto the ordinary shared Rust execution path.