### PR TITLE
Add capability-aware Noon authoring skill and offline agent inventory

### DIFF
--- a/.github/workflows/noon-agent-foundation.yml
+++ b/.github/workflows/noon-agent-foundation.yml
@@ -1,0 +1,57 @@
+name: Noon agent foundation
+
+on:
+  pull_request:
+    paths:
+      - "skills/noon-authoring/**"
+      - "scripts/noon-capabilities.py"
+      - "scripts/test_noon_capabilities.py"
+      - "scripts/check-noon-agent-skill.py"
+      - "scripts/manim-api-coverage.py"
+      - "compat/manim-v0.21.0.json"
+      - "web/python/**"
+      - "parity/manim-v0.21/upstream-examples/**"
+      - ".github/workflows/noon-agent-foundation.yml"
+  push:
+    branches: [master]
+    paths:
+      - "skills/noon-authoring/**"
+      - "scripts/noon-capabilities.py"
+      - "scripts/test_noon_capabilities.py"
+      - "scripts/check-noon-agent-skill.py"
+      - "scripts/manim-api-coverage.py"
+      - "compat/manim-v0.21.0.json"
+      - "web/python/**"
+      - "parity/manim-v0.21/upstream-examples/**"
+      - ".github/workflows/noon-agent-foundation.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: noon-agent-foundation-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  inventory:
+    name: Capability inventory and skill contracts
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - name: Test offline discovery and negative cases
+        run: python -B -m unittest discover -s scripts -p test_noon_capabilities.py -v
+      - name: Validate actual checkout inventory without Manim
+        run: python -S -B scripts/noon-capabilities.py > "$RUNNER_TEMP/noon-agent-capabilities.json"
+      - name: Validate skill and current example references
+        run: python -S -B scripts/check-noon-agent-skill.py
+      - name: Upload source inventory (not runtime qualification)
+        uses: actions/upload-artifact@v7
+        with:
+          name: noon-agent-capabilities
+          path: ${{ runner.temp }}/noon-agent-capabilities.json
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/playground-product-gate.yml
+++ b/.github/workflows/playground-product-gate.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths:
       - ".github/workflows/playground-product-gate.yml"
+      - "skills/noon-authoring/**"
+      - "scripts/noon-capabilities.py"
       - "Cargo.toml"
       - "Cargo.lock"
       - "crates/noon/**"

--- a/scripts/check-noon-agent-skill.py
+++ b/scripts/check-noon-agent-skill.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Validate the repository-bound Noon skill and its maintained example references."""
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL = "skills/noon-authoring"
+COMMANDS = (
+    "scripts/noon-capabilities.py", "scripts/build-web-demo.sh",
+    "scripts/check.sh", "scripts/manim-tutorial-smoke.mjs",
+)
+
+
+def validate_skill(root: Path, report: dict[str, Any]) -> int:
+    directory = root / SKILL
+    text = (directory / "SKILL.md").read_text(encoding="utf-8")
+    match = re.match(r"\A---\n(.*?)\n---\n", text, re.DOTALL)
+    if not match:
+        raise ValueError("SKILL.md requires YAML frontmatter")
+    fields = dict(re.findall(r"^(name|description|compatibility): (.+)$", match[1], re.MULTILINE))
+    if fields.get("name") != directory.name:
+        raise ValueError("skill name must match noon-authoring directory")
+    if not 1 <= len(fields.get("description", "")) <= 1024:
+        raise ValueError("skill description must be a non-empty one-line scalar <= 1024 characters")
+    if not 1 <= len(fields.get("compatibility", "")) <= 500:
+        raise ValueError("skill compatibility must state requirements in <= 500 characters")
+    for path in sorted(directory.rglob("*.md")):
+        for target in re.findall(r"\[[^\]]*\]\(([^)]+)\)", path.read_text(encoding="utf-8")):
+            if "://" in target or target.startswith("#"):
+                continue
+            resolved = (path.parent / target.split("#", 1)[0]).resolve()
+            if not resolved.is_relative_to(root.resolve()) or not resolved.is_file():
+                raise ValueError(f"{path.name}: missing or unconfined link {target!r}")
+    for command in COMMANDS:
+        if not (root / command).is_file():
+            raise ValueError(f"missing documented command: {command}")
+    examples = (directory / "references/examples.md").read_text(encoding="utf-8")
+    ids = re.findall(r"^\| `([^`]+)` \|", examples, re.MULTILINE)
+    if not ids or len(ids) != len(set(ids)):
+        raise ValueError("example table must contain unique example IDs")
+    for example_id in ids:
+        record = report["examples"].get(example_id)
+        if not record or record.get("status") != "ready":
+            raise ValueError(f"skill example is missing or not ready: {example_id}")
+        relative = record.get("repository_path")
+        if not isinstance(relative, str):
+            raise ValueError(f"skill example has no source: {example_id}")
+        resolved = (root / relative).resolve()
+        if not resolved.is_relative_to(root.resolve()) or not resolved.is_file():
+            raise ValueError(f"skill example source is missing or unconfined: {example_id}")
+    return len(ids)
+
+
+def main() -> int:
+    try:
+        spec = importlib.util.spec_from_file_location("noon_capabilities", ROOT / COMMANDS[0])
+        if spec is None or spec.loader is None:
+            raise ValueError("cannot load capability exporter")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        count = validate_skill(ROOT, module.build_report(ROOT))
+    except (OSError, ValueError, TypeError, KeyError, SyntaxError) as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}), file=sys.stderr)
+        return 1
+    print(f"Noon skill metadata, links, commands and {count} ready example references validated (no scenes executed).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/noon-capabilities.py
+++ b/scripts/noon-capabilities.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Export a conservative Noon source inventory; never import Manim or execute scenes."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+POLICY = "compat/manim-v0.21.0.json"
+TUTORIALS = "web/python/examples/manim_tutorial_manifest.json"
+SCHEMA_VERSION = 1
+
+
+def read_object(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"{path.name}: expected a JSON object")
+    return value
+
+
+def local_file(root: Path, relative: str) -> Path:
+    """Accept only explicit, confined repository paths (including symlink targets)."""
+    if not isinstance(relative, str) or not relative or "\\" in relative:
+        raise ValueError(f"invalid repository path: {relative!r}")
+    path = PurePosixPath(relative)
+    if path.is_absolute() or ".." in path.parts:
+        raise ValueError(f"unsafe repository path: {relative!r}")
+    resolved = (root / relative).resolve()
+    if not resolved.is_relative_to(root.resolve()) or not resolved.is_file():
+        raise ValueError(f"missing or unconfined repository file: {relative!r}")
+    return resolved
+
+
+def coverage_module(root: Path) -> Any:
+    # Reuse the coverage job's static export discovery; do not import noon.py.
+    path = local_file(root, "scripts/manim-api-coverage.py")
+    spec = importlib.util.spec_from_file_location("noon_coverage_inventory", path)
+    if spec is None or spec.loader is None:
+        raise ValueError("cannot load the repository coverage helper")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def source_revision(root: Path) -> dict[str, Any]:
+    def git(*args: str) -> str:
+        return subprocess.check_output(
+            ["git", "-C", str(root), *args], stderr=subprocess.DEVNULL,
+            text=True, timeout=5,
+        ).strip()
+
+    try:
+        # Never attribute a source archive to an unrelated parent checkout.
+        if Path(git("rev-parse", "--show-toplevel")).resolve() != root.resolve():
+            return {"revision": None, "dirty": None}
+        return {
+            "revision": git("rev-parse", "HEAD"),
+            "dirty": bool(git("status", "--porcelain", "--untracked-files=normal")),
+        }
+    except (OSError, subprocess.SubprocessError):
+        return {"revision": None, "dirty": None}
+
+
+def build_report(root: Path = ROOT) -> dict[str, Any]:
+    root = root.resolve()
+    policy = read_object(local_file(root, POLICY))
+    tutorial = read_object(local_file(root, TUTORIALS))
+    reference = policy.get("reference")
+    if not isinstance(reference, dict) or reference.get("package") != "manim":
+        raise ValueError("compatibility reference must identify the manim package")
+    version = reference.get("version")
+    if not isinstance(version, str) or not version:
+        raise ValueError("compatibility reference requires a version")
+    if not isinstance(tutorial.get("reference"), dict) or tutorial["reference"].get("version") != version:
+        raise ValueError("tutorial and compatibility reference versions differ")
+    statuses = policy.get("statuses")
+    if not isinstance(statuses, list) or not statuses or not all(isinstance(s, str) for s in statuses):
+        raise ValueError("compatibility statuses must be a non-empty string array")
+    if len(set(statuses)) != len(statuses):
+        raise ValueError("duplicate compatibility status")
+    overrides = policy.get("overrides")
+    if not isinstance(overrides, dict):
+        raise ValueError("compatibility overrides must be an object")
+    entries = tutorial.get("entries")
+    if not isinstance(entries, list):
+        raise ValueError("tutorial entries must be an array")
+
+    inputs = {POLICY, TUTORIALS, "scripts/manim-api-coverage.py", "scripts/noon-capabilities.py", "web/python/noon.py"}
+    inputs.update(path.relative_to(root).as_posix() for path in (root / "web/python").glob("_manim*.py"))
+    for name in inputs:
+        local_file(root, name)
+    coverage = coverage_module(root)
+    errors = coverage.validate_tutorial_examples(entries)
+    if errors:
+        raise ValueError("; ".join(errors))
+    exports = coverage.noon_public_exports()
+    examples: dict[str, Any] = {}
+    for entry in entries:
+        entry_id = entry["id"]
+        features = entry.get("features", [])
+        if not isinstance(features, list) or not all(isinstance(f, str) for f in features):
+            raise ValueError(f"{entry_id}: features must be a string array")
+        parity = entry.get("parity_status")
+        if parity not in (None, "candidate", "parity-qualified"):
+            raise ValueError(f"{entry_id}: invalid parity_status")
+        if parity == "parity-qualified" and not entry.get("parity_fixture"):
+            raise ValueError(f"{entry_id}: parity-qualified requires a parity fixture")
+        row = dict(entry)
+        row["runtime_verified"] = False
+        if entry["status"] == "ready":
+            # Manifest paths are relative to web/, never to the current directory.
+            relative = "web/" + entry["path"]
+            if PurePosixPath(entry["path"]).is_absolute():
+                raise ValueError(f"{entry_id}: unsafe absolute example path")
+            source = local_file(root, relative)
+            inputs.add(relative)
+            row["repository_path"] = relative
+            row["source_sha256"] = hashlib.sha256(source.read_bytes()).hexdigest()
+            upstream = entry.get("upstream_source")
+            if upstream is not None:
+                local_file(root, upstream)
+                inputs.add(upstream)
+        examples[entry_id] = row
+
+    symbols: dict[str, Any] = {}
+    for name in sorted(set(overrides) | exports):
+        explicit = name in overrides
+        row = dict(overrides[name]) if isinstance(overrides.get(name), dict) else {}
+        if explicit and not row:
+            raise ValueError(f"{name}: override must be a non-empty object")
+        if explicit and row.get("status") not in statuses:
+            raise ValueError(f"{name}: invalid policy status {row.get('status')!r}")
+        if not explicit:
+            # Upstream module rules need Manim introspection. Do not guess them.
+            row = {"status": "partial", "reason": "Statically exported; no explicit per-symbol behavioral classification."}
+        present = name in exports
+        if row["status"] in {"supported", "partial"} and not present:
+            raise ValueError(f"{name}: policy claims {row['status']} but export is absent")
+        if row["status"] == "supported" and not row.get("evidence"):
+            raise ValueError(f"{name}: supported policy requires declared evidence")
+        evidence_ids = coverage.browser_evidence_for(name, entries)
+        if row["status"] == "blocked" and present and evidence_ids:
+            raise ValueError(f"{name}: blocked export has ready tutorial evidence")
+        symbols[name] = {
+            "policy": row,
+            "classification_source": "override" if explicit else "unclassified-export",
+            "exported": present,
+            "export_detection": "static",
+            "ready_examples": evidence_ids,
+            "runtime_verified": False,
+        }
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "kind": "noon-agent-capabilities",
+        "scope": "source-inventory",
+        "reference": reference,
+        "provenance": {
+            **source_revision(root),
+            "input_sha256": {
+                name: hashlib.sha256(local_file(root, name).read_bytes()).hexdigest()
+                for name in sorted(inputs)
+            },
+        },
+        "qualification": {
+            "behavioral_tests_run": False,
+            "upstream_module_rules_applied": False,
+            "note": "Policy and ready/parity labels are declarations, not proof of this build or session. Read restrictions and validate rendered behavior.",
+        },
+        "runtime": {"host": None, "renderer_backend": None, "session_capabilities": None},
+        "symbols": symbols,
+        "examples": dict(sorted(examples.items())),
+    }
+
+
+def select_report(report: dict[str, Any], symbols: list[str], examples: list[str]) -> dict[str, Any]:
+    # Validate the whole inventory before narrowing output; filters cannot hide drift.
+    for kind, names in (("symbols", symbols), ("examples", examples)):
+        unknown = sorted(set(names) - report[kind].keys())
+        if unknown:
+            raise ValueError(f"unknown {kind}: {', '.join(unknown)}")
+    selected = dict(report)
+    if symbols:
+        selected["symbols"] = {name: report["symbols"][name] for name in sorted(set(symbols))}
+    if examples:
+        selected["examples"] = {name: report["examples"][name] for name in sorted(set(examples))}
+    elif symbols:
+        ids = {item for name in symbols for item in report["symbols"][name]["ready_examples"]}
+        selected["examples"] = {name: report["examples"][name] for name in sorted(ids)}
+    return selected
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--symbol", action="append", default=[], help="Restrict symbols (repeatable). Unknown names fail.")
+    parser.add_argument("--example", action="append", default=[], help="Restrict example IDs (repeatable), including blocked entries.")
+    args = parser.parse_args(argv)
+    try:
+        report = select_report(build_report(), args.symbol, args.example)
+    except (OSError, ValueError, SyntaxError, TypeError, KeyError) as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}, sort_keys=True), file=sys.stderr)
+        return 1
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_noon_capabilities.py
+++ b/scripts/test_noon_capabilities.py
@@ -1,0 +1,282 @@
+"""Deterministic source-inventory tests; no Manim, WASM, browser or scenes run."""
+from __future__ import annotations
+
+import copy
+import hashlib
+import importlib.util
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+SCRIPTS = Path(__file__).resolve().parent
+spec = importlib.util.spec_from_file_location("noon_capabilities", SCRIPTS / "noon-capabilities.py")
+assert spec and spec.loader
+cap = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cap)
+
+
+class CapabilityTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        for directory in ("scripts", "compat", "web/python/examples"):
+            (self.root / directory).mkdir(parents=True)
+        for name in ("manim-api-coverage.py", "noon-capabilities.py"):
+            shutil.copyfile(SCRIPTS / name, self.root / "scripts" / name)
+        (self.root / "web/python/noon.py").write_text(
+            '__all__ = ["Circle", "Text", "NewThing"]\nraise RuntimeError("must not import noon")\n',
+            encoding="utf-8",
+        )
+        (self.root / "web/python/_manim_test.py").write_text(
+            'public = {"Create": None}\nraise RuntimeError("must not import adapter")\n', encoding="utf-8",
+        )
+        (self.root / "web/python/examples/circle.py").write_text(
+            'raise RuntimeError("must not execute example")\n', encoding="utf-8",
+        )
+        self.policy = {
+            "reference": {"package": "manim", "version": "0.21.0"},
+            "statuses": ["supported", "partial", "missing", "blocked", "deferred", "intentional-divergence"],
+            "overrides": {
+                "Circle": {"status": "supported", "evidence": "fixture test"},
+                "Text": {"status": "partial", "reason": "No exact glyph parity", "dependency": "#83"},
+                "Axes": {"status": "missing", "dependency": "#85"},
+            },
+        }
+        self.tutorial = {
+            "reference": {"version": "0.21.0"},
+            "entries": [
+                {"id": "circle", "status": "ready", "path": "python/examples/circle.py",
+                 "features": ["Circle", "Create"], "upstream": "quickstart", "reuse": "fixture",
+                 "parity_status": "candidate", "qualification_mode": "shared-live"},
+                {"id": "plot", "status": "blocked", "dependency": "#85", "features": ["Axes"]},
+            ],
+        }
+        self.save()
+
+    def save(self):
+        (self.root / cap.POLICY).write_text(json.dumps(self.policy), encoding="utf-8")
+        (self.root / cap.TUTORIALS).write_text(json.dumps(self.tutorial), encoding="utf-8")
+
+    def report(self):
+        self.save()
+        return cap.build_report(self.root)
+
+    def test_source_inventory_is_not_runtime_qualification(self):
+        report = self.report()
+        self.assertEqual(report["schema_version"], 1)
+        self.assertEqual(report["scope"], "source-inventory")
+        self.assertFalse(report["qualification"]["behavioral_tests_run"])
+        self.assertTrue(all(value is None for value in report["runtime"].values()))
+        self.assertIsNone(report["provenance"]["revision"])
+        self.assertFalse(report["symbols"]["Circle"]["runtime_verified"])
+
+    def test_noon_adapter_and_example_are_not_executed(self):
+        report = self.report()  # All three fixture files would raise on execution.
+        self.assertTrue(report["symbols"]["Create"]["exported"])
+        self.assertNotIn("manim", sys.modules)
+
+    def test_unclassified_export_cannot_be_promoted(self):
+        row = self.report()["symbols"]["NewThing"]
+        self.assertEqual(row["policy"]["status"], "partial")
+        self.assertEqual(row["classification_source"], "unclassified-export")
+
+    def test_restrictions_and_dependencies_survive(self):
+        row = self.report()["symbols"]["Text"]
+        self.assertEqual(row["policy"], self.policy["overrides"]["Text"])
+        self.assertEqual(row["ready_examples"], [])
+
+    def test_ready_candidate_is_not_parity_qualified(self):
+        row = self.report()["examples"]["circle"]
+        self.assertEqual(row["parity_status"], "candidate")
+        self.assertEqual(row["qualification_mode"], "shared-live")
+        self.assertFalse(row["runtime_verified"])
+
+    def test_qualified_label_needs_fixture(self):
+        self.tutorial["entries"][0]["parity_status"] = "parity-qualified"
+        with self.assertRaisesRegex(ValueError, "requires a parity fixture"):
+            self.report()
+
+    def test_unknown_parity_label_fails(self):
+        self.tutorial["entries"][0]["parity_status"] = "looks-good"
+        with self.assertRaisesRegex(ValueError, "invalid parity_status"):
+            self.report()
+
+    def test_supported_requires_export(self):
+        self.policy["overrides"]["Ghost"] = {"status": "supported", "evidence": "test"}
+        with self.assertRaisesRegex(ValueError, "export is absent"):
+            self.report()
+
+    def test_supported_requires_evidence(self):
+        del self.policy["overrides"]["Circle"]["evidence"]
+        with self.assertRaisesRegex(ValueError, "requires declared evidence"):
+            self.report()
+
+    def test_blocked_export_with_ready_evidence_fails(self):
+        self.policy["overrides"]["Circle"]["status"] = "blocked"
+        with self.assertRaisesRegex(ValueError, "blocked export"):
+            self.report()
+
+    def test_missing_inventory_fails(self):
+        (self.root / cap.TUTORIALS).unlink()
+        with self.assertRaisesRegex(ValueError, "missing or unconfined"):
+            cap.build_report(self.root)
+
+    def test_malformed_inventory_fails(self):
+        (self.root / cap.POLICY).write_text("[]", encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "JSON object"):
+            cap.build_report(self.root)
+
+    def test_version_mismatch_fails(self):
+        self.tutorial["reference"]["version"] = "99"
+        with self.assertRaisesRegex(ValueError, "versions differ"):
+            self.report()
+
+    def test_invalid_policy_status_fails(self):
+        self.policy["overrides"]["Circle"]["status"] = "probably"
+        with self.assertRaisesRegex(ValueError, "invalid policy status"):
+            self.report()
+
+    def test_duplicate_example_fails(self):
+        self.tutorial["entries"].append(copy.deepcopy(self.tutorial["entries"][0]))
+        with self.assertRaisesRegex(ValueError, "duplicate id"):
+            self.report()
+
+    def test_missing_ready_example_fails(self):
+        (self.root / "web/python/examples/circle.py").unlink()
+        with self.assertRaisesRegex(ValueError, "missing fixture"):
+            self.report()
+
+    def test_parent_traversal_is_rejected_even_when_file_exists(self):
+        self.tutorial["entries"][0]["path"] = "../web/python/examples/circle.py"
+        with self.assertRaisesRegex(ValueError, "unsafe repository path"):
+            self.report()
+
+    def test_absolute_example_is_rejected(self):
+        self.tutorial["entries"][0]["path"] = str(self.root / "web/python/examples/circle.py")
+        with self.assertRaisesRegex(ValueError, "unsafe absolute"):
+            self.report()
+
+    def test_symlink_escape_is_rejected(self):
+        with tempfile.TemporaryDirectory() as outside:
+            target = Path(outside) / "outside.py"
+            target.write_text("secret", encoding="utf-8")
+            fixture = self.root / "web/python/examples/circle.py"
+            fixture.unlink()
+            fixture.symlink_to(target)
+            with self.assertRaisesRegex(ValueError, "unconfined"):
+                self.report()
+
+    def test_invalid_features_fail(self):
+        self.tutorial["entries"][0]["features"] = "Circle"
+        with self.assertRaisesRegex(ValueError, "features must be"):
+            self.report()
+
+    def test_hashes_cover_inputs_and_change_with_source(self):
+        before = self.report()
+        path = "web/python/examples/circle.py"
+        expected = hashlib.sha256((self.root / path).read_bytes()).hexdigest()
+        self.assertEqual(before["provenance"]["input_sha256"][path], expected)
+        self.assertEqual(before["examples"]["circle"]["source_sha256"], expected)
+        (self.root / path).write_text("# changed\n", encoding="utf-8")
+        self.assertNotEqual(self.report()["examples"]["circle"]["source_sha256"], expected)
+
+    def test_output_is_deterministic(self):
+        self.assertEqual(self.report(), self.report())
+
+    def test_symbol_filter_returns_relevant_ready_examples(self):
+        report = self.report()
+        selected = cap.select_report(report, ["Circle"], [])
+        self.assertEqual(list(selected["symbols"]), ["Circle"])
+        self.assertEqual(list(selected["examples"]), ["circle"])
+        self.assertIn("Text", report["symbols"])  # No mutation of input.
+
+    def test_unknown_symbol_and_example_fail(self):
+        report = self.report()
+        for symbols, examples in ((["typo"], []), ([], ["typo"])):
+            with self.subTest(symbols=symbols, examples=examples):
+                with self.assertRaisesRegex(ValueError, "unknown"):
+                    cap.select_report(report, symbols, examples)
+
+    def test_blocked_example_is_visible_but_not_ready_evidence(self):
+        selected = cap.select_report(self.report(), ["Axes"], ["plot"])
+        self.assertEqual(selected["examples"]["plot"]["status"], "blocked")
+        self.assertEqual(selected["symbols"]["Axes"]["ready_examples"], [])
+
+    def test_cli_works_from_another_directory_without_site_packages(self):
+        result = subprocess.run(
+            [sys.executable, "-S", "-B", str(self.root / "scripts/noon-capabilities.py"), "--symbol", "Circle"],
+            cwd="/", capture_output=True, text=True, timeout=10,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(list(json.loads(result.stdout)["symbols"]), ["Circle"])
+        self.assertEqual(result.stderr, "")
+
+    def test_cli_invalid_query_has_no_success_output(self):
+        result = subprocess.run(
+            [sys.executable, "-S", "-B", str(self.root / "scripts/noon-capabilities.py"), "--symbol", "typo"],
+            capture_output=True, text=True, timeout=10,
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(result.stdout, "")
+        self.assertFalse(json.loads(result.stderr)["ok"])
+
+    def test_git_unavailable_is_not_a_fake_revision(self):
+        with patch.object(cap.subprocess, "check_output", side_effect=FileNotFoundError):
+            self.assertEqual(cap.source_revision(self.root), {"revision": None, "dirty": None})
+
+
+class SkillTests(unittest.TestCase):
+    save = CapabilityTests.save
+    report = CapabilityTests.report
+    def setUp(self):
+        CapabilityTests.setUp(self)
+        spec = importlib.util.spec_from_file_location("skill_check", SCRIPTS / "check-noon-agent-skill.py")
+        assert spec and spec.loader
+        self.checker = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(self.checker)
+        self.skill = self.root / "skills/noon-authoring"
+        (self.skill / "references").mkdir(parents=True)
+        (self.skill / "SKILL.md").write_text(
+            "---\nname: noon-authoring\ndescription: Author Noon scenes.\ncompatibility: Trusted Noon checkout.\n---\n"
+            "[Examples](references/examples.md)\n", encoding="utf-8",
+        )
+        (self.skill / "references/examples.md").write_text("| `circle` | Basic geometry. |\n", encoding="utf-8")
+        for name in self.checker.COMMANDS:
+            path = self.root / name
+            if not path.exists():
+                path.write_text("# fixture entrypoint\n", encoding="utf-8")
+
+    def test_skill_valid_references(self):
+        self.assertEqual(self.checker.validate_skill(self.root, self.report()), 1)
+
+    def test_skill_unready_reference_fails(self):
+        (self.skill / "references/examples.md").write_text("| `plot` | Plot. |\n", encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "not ready"):
+            self.checker.validate_skill(self.root, self.report())
+
+    def test_skill_dead_link_fails(self):
+        with (self.skill / "SKILL.md").open("a", encoding="utf-8") as out:
+            out.write("[Missing](references/missing.md)\n")
+        with self.assertRaisesRegex(ValueError, "missing or unconfined link"):
+            self.checker.validate_skill(self.root, self.report())
+
+    def test_skill_wrong_name_fails(self):
+        path = self.skill / "SKILL.md"
+        path.write_text(path.read_text().replace("name: noon-authoring", "name: manim"), encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "skill name"):
+            self.checker.validate_skill(self.root, self.report())
+
+    def test_skill_missing_command_fails(self):
+        (self.root / "scripts/check.sh").unlink()
+        with self.assertRaisesRegex(ValueError, "missing documented command"):
+            self.checker.validate_skill(self.root, self.report())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/noon-authoring/SKILL.md
+++ b/skills/noon-authoring/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: noon-authoring
+description: Author and review Noon animation scenes using capability-qualified ManimCE-style Python or the shared Rust API. Use when a user asks to create, explain, repair, or verify a Noon animation, or when scene source imports noon. Not a generic ManimGL skill or a contract for modifying Noon internals.
+compatibility: Requires a trusted Noon repository checkout and Python 3.12+ for capability discovery. Previewing requires the repository's existing browser build and rendering environment; capability discovery alone does not render or install dependencies.
+metadata:
+  version: "0.1.0"
+---
+
+# Noon authoring
+
+Create understandable animations using the supported Noon surface, and distinguish
+source that looks plausible from output that has actually been rendered and checked.
+For engine changes, follow the repository's `AGENTS.md`; this skill is for authoring
+scenes and does not replace `docs/architecture.md`.
+
+## Discover before writing
+
+Locate the user's trusted Noon checkout. Run commands below from its root, or use
+an absolute path to its scripts. A copy of this skill alone is not an installed Noon
+runtime. Never install another package named `noon` as a substitute.
+
+```bash
+python3 -B scripts/noon-capabilities.py --symbol Circle --symbol Transform
+python3 -B scripts/noon-capabilities.py --symbol Text --symbol MathTex --symbol Axes
+```
+
+The command returns JSON from the checkout's existing inventories without importing
+Manim, importing the Python scene facade, executing scene code, or starting a renderer.
+Read `policy.reason`, `policy.dependency`, `policy.evidence`, `ready_examples`, and
+the examples' separate `parity_status` and `qualification_mode` fields. Unknown queries
+or invalid inventories fail with nonzero status; do not ignore that failure.
+
+`exported` is static discovery, not complete behavioral support. A `ready` example
+can still be a parity **candidate**. The report is a source inventory, not a guarantee
+about an installed binary, the current GPU, or a live session. See
+[capabilities](references/capabilities.md).
+
+## Author and inspect
+
+1. State the important visual states and transitions: what appears, what moves,
+   what transforms, and what disappears. Include labels, layout, and holds.
+2. Choose a relevant [existing example](references/examples.md), query its current
+   classification, and read its actual source. Retain its provenance when reusing it.
+   Prefer a narrow proven pattern to an unsupported general recipe.
+3. Write ordinary `from noon import *` Python for the supported CE-like surface, or
+   use the current shared Rust API. Keep the editable source as the deliverable.
+   Do not import `manimlib`, invoke `manim`/`manimgl`, or silently switch renderers.
+4. Use the existing playground to render the scene. Inspect the intended initial
+   state, transition interiors, completion boundaries, and final membership. A
+   final blank frame after `FadeOut` can be correct; a successful run alone is not
+   visual verification. Apply the [verification checks](references/verification.md).
+5. Revise source based on actual diagnostics and frames. Preserve the original
+   mathematical and animation semantics; never conceal an unsupported operation by
+   replacing `MathTex` with `Text` or removing an updater.
+
+## Current preview route
+
+Use an already-built playground when available. To build one explicitly:
+
+```bash
+bash scripts/build-web-demo.sh
+python3 -m http.server --bind 127.0.0.1 --directory web 8080
+```
+
+Open the local playground, paste the source into **Python scene source**, and run
+it. The build can require downloads and substantial dependencies; it is not a side
+effect of capability discovery. Do not claim the preview ran when the required
+browser/WASM environment is unavailable.
+
+There is not yet a supported `noon render` command or shipped Noon MCP preview
+server in this skill. The isolated runner and MCP adapter are tracked in #1197 and
+#1198. Do not invent their installation or tool commands.
+
+## Semantic boundaries
+
+Read [authoring constraints](references/authoring.md) before using text/math,
+updaters, seeking, or Rust live changes. ManimCE is the compatibility reference;
+ManimGL APIs are not interchangeable. An import-only change is a goal for supported
+behavior, not a promise that every Manim recipe works.
+
+Use authored scene time rather than wall-clock time. Python may continue authoring
+after a logical segment-completion barrier; arbitrary callbacks can require host
+execution. Never assume the whole future Python program was statically compiled.
+Rust shares the scene semantics, not Python's interpreter: new Rust source requires
+compilation or an explicit existing hot-reload mechanism.
+
+## Completion report
+
+Return the source, exact validation performed, observed frames/artifacts when
+available, and remaining limitations. Keep declared compatibility, tests actually
+run, and visual observations separate. No automatic fixes, hidden backend changes,
+or claims of full parity from class names or an uninspected final image.

--- a/skills/noon-authoring/references/authoring.md
+++ b/skills/noon-authoring/references/authoring.md
@@ -1,0 +1,55 @@
+# Authoring constraints
+
+## Geometry, layout, and timing
+
+Prefer the qualified relative-layout operations from a working example over
+hand-guessed coordinates. Plan contrast, label clearance, the viewing frame, and
+holds at explanatory endpoints. Do not claim every Group/VGroup method works just
+because the class is exported.
+
+Check whether an operation mutates the source object, replaces its membership,
+creates a copy, or removes it. Preserve object identity in subsequent statements.
+Distinguish `.animate` endpoint interpolation from a dedicated animation with a
+particular motion path. Obtain current restrictions through capability discovery.
+
+## Text and mathematical meaning
+
+Query Text, Tex, MathTex, Typst, or MathTypst before using them. A source-compatible
+facade is not evidence of exact LaTeX glyph, layout, timing, or term-matching parity.
+Inspect the rendered mathematical expression, including signs, fractions, subscripts,
+labels, and missing glyphs. Do not automatically substitute plain text or translate
+LaTeX syntax into Typst. A change of representation must preserve meaning and be
+explicit in the result.
+
+Plotting and 3D recipes from external Manim skills are not Noon capability evidence.
+Report a missing feature rather than installing Manim and calling its output Noon.
+
+## Continuations, callbacks, and state
+
+Python can issue semantic operations, wait for a segment-completion barrier, observe
+coherent effective state, and continue. Static playback need not involve Python;
+arbitrary callbacks have explicit host-execution requirements. Do not infer that
+arbitrary Python expressions become native reactive dependencies.
+
+Prefer a known supported deterministic pattern. Use callbacks only with a matching
+example and restrictions. Wall-clock reads, unseeded randomness, I/O, and hidden
+mutable callback state undermine repeatability. Never assume a fresh replay safely
+repeats external side effects.
+
+Seek/rewind is a capability of the actual session, not of every Noon scene. The
+current external-sampling raster harness is forward-only and fixes its sample
+schedule. Do not change a running schedule or promise reverse playback for opaque
+callbacks. An interactive continuation may have no known final duration.
+
+## Rust
+
+The shared Rust API authors directly into shared semantics. Rust source is compiled;
+mutating a live scene through compiled methods is not interpreting arbitrary new
+Rust code. Use the current README's public-API examples, not migration-era
+`noon::legacy` examples. Paired Python/Rust examples establish the common behavior
+while allowing different host control flow.
+
+Ordinary authored/base state and current effective runtime state are different
+queries. Use the documented live query/transaction surface when working with a live
+session. Do not implement a second scene store or serialized patch engine in an
+agent helper. Repository architecture and current owning issues remain authoritative.

--- a/skills/noon-authoring/references/capabilities.md
+++ b/skills/noon-authoring/references/capabilities.md
@@ -1,0 +1,40 @@
+# Reading capability evidence
+
+Run `python3 -B scripts/noon-capabilities.py` from a trusted Noon checkout to obtain
+the complete JSON report. Repeat `--symbol NAME` for focused API discovery. Repeat
+`--example ID` to restrict the example records; explicit example filters are
+independent of symbol filters. Without an explicit example filter, a symbol query
+includes its ready tutorial references. Unknown names fail rather than returning
+an empty result that could be mistaken for a supported API.
+
+Schema version 1 reports `scope: source-inventory`. It reads the existing
+`compat/manim-v0.21.0.json`, the tutorial manifest, and the coverage script's static
+export discovery. There is no separately maintained agent support matrix.
+
+`symbols.NAME.policy` preserves the explicit compatibility record, including
+restrictions and declared evidence. `classification_source: unclassified-export`
+means the name was statically discovered without a per-symbol policy entry; it is
+not promoted to supported. Upstream module rules cannot be resolved without Manim
+introspection and are explicitly not applied in this offline inventory.
+
+A supported class does not prove every method, option, family combination, callback,
+or backend. Read the policy reason and the actual example. Ready example references
+come from feature tags, not a proof that all possible calls using the symbol work.
+
+Examples retain `status`, `parity_status`, `qualification_mode`, upstream/reuse
+metadata, and a repository-relative path plus source hash for ready fixtures.
+`ready` is availability in the maintained corpus. `candidate` and `parity-qualified`
+are different declared qualification levels; neither is a fresh test run by this
+command. Blocked/deferred entries remain visible with their owning issues, but do
+not become ready evidence for a symbol.
+
+`provenance` includes Git revision/dirty state when available and SHA-256 hashes of
+report inputs, adapters, and referenced ready/upstream sources. A source archive
+has null Git metadata instead of borrowing an unrelated parent checkout's revision.
+These values identify source, not a deployed binary. In schema 1, no runtime host
+is started: renderer backend and session capabilities are null, and
+`behavioral_tests_run` / `runtime_verified` are false.
+
+Every query validates the whole inventory before applying filters. Fix malformed
+metadata or missing evidence in its owning inventory; do not suppress errors or
+modify the agent output to make an unsupported feature appear supported.

--- a/skills/noon-authoring/references/examples.md
+++ b/skills/noon-authoring/references/examples.md
@@ -1,0 +1,41 @@
+# Existing example starting points
+
+These are references into the maintained tutorial manifest, not copied recipes or
+independent support declarations. Query the current record and inspect its source:
+
+```bash
+python3 -B scripts/noon-capabilities.py --example parity-square-to-circle
+```
+
+Read the returned `repository_path` relative to the Noon checkout, not the skill's
+installation directory. Use only records currently marked ready, and preserve their
+candidate/qualified distinction. The skill validator rejects missing or unready
+entries rather than silently omitting them.
+
+| Example ID | What to study |
+| --- | --- |
+| `parity-create-circle` | Primitive creation and fill styling. |
+| `parity-square-to-circle` | Create a square, morph it into a circle, then remove it. |
+| `parity-square-and-circle` | Relative layout and parallel creation. |
+| `parity-animated-square-to-circle` | Method animation followed by a content transform. |
+| `parity-different-rotations` | Endpoint interpolation versus a rotation animation. |
+| `manim-dot-example` | Minimal static geometry. |
+| `manim-ellipse-example` | Arrangement of geometry; inspect the specific family case. |
+| `manim-show-uncreate` | Reverse reveal and removal. |
+| `parity-draw-border-then-fill-styled-square` | Outline/fill phases and intermediate appearance. |
+| `manim-succession-example` | Sequential composition and timing. |
+
+For SquareToCircle, do not demand a visible circle in the final frame: the source
+ends with FadeOut. Inspect the square after creation, the transformation interior,
+the circle before removal, and the final empty membership. A single nonblank-image
+check would miss both an incorrect starting shape and an incorrect lifecycle.
+
+For text, callbacks, and Rust, use the repository README's paired-example table
+and current capability restrictions rather than extrapolating from these geometry
+examples. Do not copy legacy Rust snapshot authoring into a new shared-API scene.
+
+This skill's instructions are first-party text. It adopts the general
+capability-discovery and preview/inspection workflow; it does not vendor external
+Manim skill code, examples, fonts, or assets. Existing fixture provenance stays in
+the tutorial manifest and upstream corpus. Review licenses separately before
+introducing additional external material.

--- a/skills/noon-authoring/references/verification.md
+++ b/skills/noon-authoring/references/verification.md
@@ -1,0 +1,41 @@
+# Verification
+
+Treat code execution, semantic correctness, rendered appearance, and mathematical
+correctness as separate checks. A scene can run successfully while displaying the
+wrong starting object, dropping a label, or using incorrect timing.
+
+Inspect frames at activation/completion boundaries and inside each significant
+transition. Check object count/membership, source-versus-target identity, endpoints,
+layout, clipping, glyphs, and explanatory pacing. Include an initial frame and the
+intended final state, but do not reject a deliberately empty frame after removal.
+
+Record the actual source, Noon revision, execution host/backend, and requested and
+observed scene times when the available tooling exposes them. Null or unavailable
+metadata is not a license to guess. Compare raster evidence only within the
+qualified backend and tolerance policy; do not require universal cross-GPU bit
+identity or widen thresholds to make a failing scene pass.
+
+For repository changes, the existing validation entrypoints are:
+
+```bash
+bash scripts/check.sh fast
+bash scripts/check.sh full
+```
+
+The fast gate is not a substitute for browser/parity checks. With the existing
+browser build and its dependencies available, the maintained tutorial corpus can
+be exercised with:
+
+```bash
+node scripts/manim-tutorial-smoke.mjs
+```
+
+This is a corpus test, not a general source-to-video CLI or a security sandbox.
+Do not claim that invoking it verifies a newly authored source file unless that
+file was actually included in the run. CI declarations and manifest labels are
+not current test results. Report the exact tests and images actually inspected.
+
+Do not execute untrusted scene code against unrestricted host files, credentials,
+or networking. AST parsing, a browser worker, local MCP transport, and a timeout
+are not by themselves sufficient isolation. The bounded agent runner is separate
+work; do not present today's repository harness as a hardened remote service.

--- a/web/ci-workflow-topology.test.mjs
+++ b/web/ci-workflow-topology.test.mjs
@@ -20,6 +20,7 @@ const exactFamilies = new Map([
   ["pages.yml", "deployment"],
   ["fuzz.yml", "fuzz"],
   ["branch-cleanup-once.yml", "maintenance"],
+  ["noon-agent-foundation.yml", "agent-authoring"],
 ]);
 
 function classifyWorkflow(name) {
@@ -54,6 +55,7 @@ const requiredFamilies = new Set([
   "platform-release",
   "manim",
   "playground",
+  "agent-authoring",
 ]);
 const presentFamilies = new Set(classified.map(({ family }) => family));
 for (const family of requiredFamilies) {


### PR DESCRIPTION
## Merged scope

First implementation slice of #1194; completes the checkout capability-export and first-party authoring-skill work in #1195 and #1196. Reviewed head: `5c7cef8ae0d130a95838a5d76e7a75af3d600894`. Merged as `2dfc65e8551b9112967afa0eb12d47ca6ff0f231`.

- `scripts/noon-capabilities.py`: versioned offline JSON using the existing compatibility policy, static export helper and tutorial manifest; no Manim installation, Noon facade import or scene execution.
- Explicit separation of API presence, declared policy/evidence, candidate versus qualified examples and runtime verification. Actual backend/session fields remain unknown in a source-only scan.
- First-party `skills/noon-authoring/` with focused references and ten maintained example IDs; no duplicated example corpus or copied third-party skill code.
- Thirty-three source-inventory/skill contract tests, read-only CI and explicit workflow topology registration. Skill/exporter changes trigger the existing product gate.

No engine or renderer code changed; no canonical test thresholds were weakened.

## Review and final-head CI

No blocking source-level finding in the review of all eleven changed files against `docs/architecture.md` and the reused coverage helper.

All seven workflows associated with head `5c7cef8` passed:

- Noon agent foundation: 33 tests, full-checkout no-site-package export, metadata/link/command and all ten example-reference checks.
- PR Fast Gate: Rust tests, formatting/lint, web preflight and browser fast checks.
- Architecture Ratchets and Layer Dependency Ratchet.
- Playground cross-browser matrix and authoring recovery.
- [Playground Product Gate](https://github.com/yongkyuns/noon/actions/runs/34162559023): both release packages, tutorial corpus, retained Text, layout/reset, renderer initialization, baseline and candidate measurement, and the actual visual/latency/FPS comparison all passed. The baseline-unavailable fallback was not used.

The earlier workflow-classification failure was fixed, not suppressed. This review relied on GitHub CI for complete checkout/Rust/browser validation; the current local environment could not clone GitHub and has no Cargo toolchain.

## Follow-on

#1202 advances the browser preview-session slice of #1197, now targeting master. Isolated process execution, complete artifacts/provenance and CLI remain #1197 work; MCP remains #1198; packaging/evaluation remains #1199. This foundation does not claim those features.