### PR TITLE
Move centered procedural rotation into shared Rust

### DIFF
--- a/compat/semantic-ownership-v1.json
+++ b/compat/semantic-ownership-v1.json
@@ -15,7 +15,7 @@
     {"path": "web/python/_manim_compat.py", "token": "copy.deepcopy", "maximum": 1, "migration_issue": "#61"},
     {"path": "web/python/_manim_composition.py", "token": "copy.deepcopy", "maximum": 3, "migration_issue": "#61"},
     {"path": "web/python/_manim_lifecycle.py", "token": "_snapshot_for_object_at", "maximum": 1, "migration_issue": "#61"},
-    {"path": "web/python/_manim_rotate.py", "token": "_snapshot_for_object_at", "maximum": 1, "migration_issue": "#61"},
+    {"path": "web/python/_manim_rotate.py", "token": "_snapshot_for_object_at", "maximum": 0, "migration_issue": "#61"},
     {"path": "web/python/_manim_semantic_handles.py", "token": "copy.deepcopy", "maximum": 1, "migration_issue": "#61"},
     {"path": "web/python/_manim_semantic_handles.py", "token": "_ir.Mobject(", "maximum": 1, "migration_issue": "#61"},
     {"path": "web/python/_manim_updaters.py", "token": "copy.deepcopy", "maximum": 7, "migration_issue": "#61"},

--- a/crates/noon-compile/src/semantic_lowering/animation_payload/affine.rs
+++ b/crates/noon-compile/src/semantic_lowering/animation_payload/affine.rs
@@ -534,7 +534,7 @@ where
             );
             continue;
         }
-        if let SemanticScheduledAnimationPayload::Rotate { angle } = leaf.payload {
+        if let SemanticScheduledAnimationPayload::Rotate { angle, hold_origin } = leaf.payload {
             let source = object_state(store, leaf, leaf.target)?;
             let from = if let Some(captured) = captures.get(&leaf.execution_object_id).copied() {
                 captured
@@ -549,9 +549,11 @@ where
                 captures.insert(leaf.execution_object_id, captured);
                 captured
             };
-            let channel = lower_rotation_channel(source, from, angle)
+            let channels = lower_rotation_channels(source, from, angle, hold_origin)
                 .map_err(|issue| rotation_payload_error(leaf, issue))?;
-            push_published_channel(leaf, channel, &mut driven, &mut tracks)?;
+            for channel in channels {
+                push_published_channel(leaf, channel, &mut driven, &mut tracks)?;
+            }
             continue;
         }
         if let SemanticScheduledAnimationPayload::PassingFlash { time_width } = leaf.payload {
@@ -735,9 +737,16 @@ fn validate_leaf_matches_declaration(
         {
             Ok(())
         }
-        SemanticAnimationIntent::Rotate { target, angle }
-            if *target == leaf.target
-                && leaf.payload == SemanticScheduledAnimationPayload::Rotate { angle: *angle } =>
+        SemanticAnimationIntent::Rotate {
+            target,
+            angle,
+            hold_origin,
+        } if *target == leaf.target
+            && leaf.payload
+                == SemanticScheduledAnimationPayload::Rotate {
+                    angle: *angle,
+                    hold_origin: *hold_origin,
+                } =>
         {
             Ok(())
         }
@@ -1898,11 +1907,12 @@ pub(super) fn lower_transform_channels(
     Ok(channels)
 }
 
-pub(super) fn lower_rotation_channel(
+pub(super) fn lower_rotation_channels(
     source: &noon_core::SemanticObjectState,
     from: EffectiveAnimationProperties,
     angle: f64,
-) -> Result<LoweredAffineChannel, AffinePayloadIssue> {
+    hold_origin: bool,
+) -> Result<Vec<LoweredAffineChannel>, AffinePayloadIssue> {
     if !transform_is_finite(from.transform) {
         return Err(AffinePayloadIssue::InvalidEffectiveTransform);
     }
@@ -1922,7 +1932,7 @@ pub(super) fn lower_rotation_channel(
             SemanticAffineAnimationField::RotationZ,
         ));
     }
-    Ok(LoweredAffineChannel {
+    let mut channels = vec![LoweredAffineChannel {
         property: Property::Rotation,
         conflict_property: SemanticObjectProperty::RotationZ,
         completion: SemanticAnimationCompletion::Property {
@@ -1933,7 +1943,22 @@ pub(super) fn lower_rotation_channel(
             from: from.transform.rotation,
             to: endpoint as f32,
         },
-    })
+    }];
+    if hold_origin {
+        push_affine_channel(
+            source,
+            SemanticObjectProperty::Translation,
+            Property::Position,
+            TrackValues::Vec2 {
+                from: from.transform.translation,
+                to: from.transform.translation,
+            },
+            SemanticAnimationCompletion::Release,
+            true,
+            &mut channels,
+        )?;
+    }
+    Ok(channels)
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/noon-compile/src/semantic_lowering/animation_payload/prepared_composition.rs
+++ b/crates/noon-compile/src/semantic_lowering/animation_payload/prepared_composition.rs
@@ -350,7 +350,7 @@ where
                 }
                 continue;
             }
-            PreparedSemanticScheduledAnimationPayload::Rotate { angle } => {
+            PreparedSemanticScheduledAnimationPayload::Rotate { angle, hold_origin } => {
                 if leaf.options.lag_ratio != 0.0
                     || leaf.options.path_arc != 0.0
                     || leaf.options.remover
@@ -372,8 +372,13 @@ where
                     &mut captures,
                     &mut effective_properties,
                 )?;
-                super::affine::lower_rotation_channel(source, from, angle)
-                    .map_err(|issue| prepared_payload_error(leaf, leaf.target, issue))?
+                let channels =
+                    super::affine::lower_rotation_channels(source, from, angle, hold_origin)
+                        .map_err(|issue| prepared_payload_error(leaf, leaf.target, issue))?;
+                for channel in channels {
+                    push_prepared_channel(leaf, channel, &mut driven, &mut tracks)?;
+                }
+                continue;
             }
             PreparedSemanticScheduledAnimationPayload::Indicate {
                 scale_factor,

--- a/crates/noon-compile/src/semantic_lowering/animation_schedule.rs
+++ b/crates/noon-compile/src/semantic_lowering/animation_schedule.rs
@@ -92,6 +92,7 @@ pub enum SemanticScheduledAnimationPayload {
     },
     Rotate {
         angle: f64,
+        hold_origin: bool,
     },
     Fade {
         direction: SemanticFadeDirection,
@@ -207,6 +208,7 @@ pub enum PreparedSemanticScheduledAnimationPayload {
     },
     Rotate {
         angle: f64,
+        hold_origin: bool,
     },
     Fade {
         direction: SemanticFadeDirection,
@@ -611,8 +613,8 @@ fn published_payload(
         ScheduledAnimationPayload::PassingFlash { time_width } => {
             SemanticScheduledAnimationPayload::PassingFlash { time_width }
         }
-        ScheduledAnimationPayload::Rotate { angle } => {
-            SemanticScheduledAnimationPayload::Rotate { angle }
+        ScheduledAnimationPayload::Rotate { angle, hold_origin } => {
+            SemanticScheduledAnimationPayload::Rotate { angle, hold_origin }
         }
         ScheduledAnimationPayload::Indicate {
             scale_factor,
@@ -677,8 +679,8 @@ fn prepared_payload(
         ScheduledAnimationPayload::PassingFlash { time_width } => {
             PreparedSemanticScheduledAnimationPayload::PassingFlash { time_width }
         }
-        ScheduledAnimationPayload::Rotate { angle } => {
-            PreparedSemanticScheduledAnimationPayload::Rotate { angle }
+        ScheduledAnimationPayload::Rotate { angle, hold_origin } => {
+            PreparedSemanticScheduledAnimationPayload::Rotate { angle, hold_origin }
         }
         ScheduledAnimationPayload::Indicate {
             scale_factor,
@@ -773,6 +775,7 @@ enum AnimationDeclarationIntent<R> {
     Rotate {
         target: R,
         angle: f64,
+        hold_origin: bool,
     },
     Fade {
         target: R,
@@ -975,13 +978,18 @@ impl AnimationScheduleLookup for PublishedAnimationLookup<'_> {
                     time_width: *time_width,
                 }
             }
-            SemanticAnimationIntent::Rotate { target, angle } => {
+            SemanticAnimationIntent::Rotate {
+                target,
+                angle,
+                hold_origin,
+            } => {
                 self.store
                     .semantic_object_state_checked(*target)
                     .map_err(SemanticAnimationError::Target)?;
                 AnimationDeclarationIntent::Rotate {
                     target: *target,
                     angle: *angle,
+                    hold_origin: *hold_origin,
                 }
             }
             SemanticAnimationIntent::Fade {
@@ -1175,12 +1183,15 @@ impl AnimationScheduleLookup for PreparedAnimationLookup<'_, '_> {
                             time_width: *time_width,
                         }
                     }
-                    SemanticAnimationIntent::Rotate { target, angle } => {
-                        AnimationDeclarationIntent::Rotate {
-                            target: (*target).into(),
-                            angle: *angle,
-                        }
-                    }
+                    SemanticAnimationIntent::Rotate {
+                        target,
+                        angle,
+                        hold_origin,
+                    } => AnimationDeclarationIntent::Rotate {
+                        target: (*target).into(),
+                        angle: *angle,
+                        hold_origin: *hold_origin,
+                    },
                     SemanticAnimationIntent::Fade {
                         target,
                         direction,
@@ -1293,12 +1304,15 @@ impl AnimationScheduleLookup for PreparedAnimationLookup<'_, '_> {
                             time_width: *time_width,
                         }
                     }
-                    SemanticTransactionAnimationIntent::Rotate { target, angle } => {
-                        AnimationDeclarationIntent::Rotate {
-                            target: *target,
-                            angle: *angle,
-                        }
-                    }
+                    SemanticTransactionAnimationIntent::Rotate {
+                        target,
+                        angle,
+                        hold_origin,
+                    } => AnimationDeclarationIntent::Rotate {
+                        target: *target,
+                        angle: *angle,
+                        hold_origin: *hold_origin,
+                    },
                     SemanticTransactionAnimationIntent::Fade {
                         target,
                         direction,
@@ -1488,6 +1502,7 @@ enum ScheduledAnimationPayload<R> {
     },
     Rotate {
         angle: f64,
+        hold_origin: bool,
     },
     Fade {
         direction: SemanticFadeDirection,
@@ -1871,7 +1886,11 @@ where
                 },
             })
         }
-        AnimationDeclarationIntent::Rotate { target, angle } => {
+        AnimationDeclarationIntent::Rotate {
+            target,
+            angle,
+            hold_origin,
+        } => {
             let execution_object_id = lookup
                 .execution_object_id(target)
                 .or_else(|| lookup.entering_execution_object_id(target))
@@ -1885,7 +1904,7 @@ where
                 kind: PlannedAnimationKind::Leaf {
                     target,
                     execution_object_id,
-                    payload: ScheduledAnimationPayload::Rotate { angle },
+                    payload: ScheduledAnimationPayload::Rotate { angle, hold_origin },
                     options,
                 },
             })

--- a/crates/noon-core/src/reactive/semantic_animations.rs
+++ b/crates/noon-core/src/reactive/semantic_animations.rs
@@ -309,7 +309,11 @@ pub enum SemanticAnimationIntent {
     },
     /// Rotate one centered 2D object along an angular path. This remains distinct
     /// from TransformTo point correspondence even when both share affine endpoints.
-    Rotate { target: SemanticNodeId, angle: f64 },
+    Rotate {
+        target: SemanticNodeId,
+        angle: f64,
+        hold_origin: bool,
+    },
     /// Fade one semantic leaf through the shared runtime appearance channel.
     /// Membership entry/exit is applied atomically by live activation/completion.
     Fade {
@@ -1003,6 +1007,17 @@ impl SemanticStore {
         angle: f64,
         options: AnimationOptions,
     ) -> Result<SemanticNodeId, SemanticAnimationError> {
+        self.insert_semantic_rotate_animation_with_origin_constraint(target, angle, false, options)
+    }
+
+    /// Hold the activation-time world origin while following the angular path.
+    pub fn insert_semantic_rotate_animation_with_origin_constraint(
+        &mut self,
+        target: SemanticNodeId,
+        angle: f64,
+        hold_origin: bool,
+        options: AnimationOptions,
+    ) -> Result<SemanticNodeId, SemanticAnimationError> {
         self.set_last_mutation_writes(0);
         self.semantic_object_state_checked(target)?;
         if !angle.is_finite() {
@@ -1011,7 +1026,11 @@ impl SemanticStore {
         validate_authored_animation_options(options)?;
         Ok(
             self.insert_semantic_animation_state(SemanticAnimationState::new(
-                SemanticAnimationIntent::Rotate { target, angle },
+                SemanticAnimationIntent::Rotate {
+                    target,
+                    angle,
+                    hold_origin,
+                },
                 options,
             )),
         )

--- a/crates/noon-core/src/reactive/semantic_transaction.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction.rs
@@ -725,6 +725,17 @@ impl SemanticMutationTransaction {
         angle: f64,
         options: AnimationOptions,
     ) -> SemanticLocalNodeToken {
+        self.create_rotate_animation_with_origin_constraint(target, angle, false, options)
+    }
+
+    /// Stage an angular path that optionally holds its activation-time world origin.
+    pub fn create_rotate_animation_with_origin_constraint(
+        &mut self,
+        target: impl Into<SemanticTransactionNodeRef>,
+        angle: f64,
+        hold_origin: bool,
+        options: AnimationOptions,
+    ) -> SemanticLocalNodeToken {
         let token = self.allocate_local_node_token();
         self.mutations.push(SemanticMutation::AddAnimation {
             token,
@@ -732,6 +743,7 @@ impl SemanticMutationTransaction {
                 SemanticTransactionAnimationIntent::Rotate {
                     target: target.into(),
                     angle,
+                    hold_origin,
                 },
                 options,
             ),

--- a/crates/noon-core/src/reactive/semantic_transaction/animation_addition.rs
+++ b/crates/noon-core/src/reactive/semantic_transaction/animation_addition.rs
@@ -65,6 +65,7 @@ pub enum SemanticTransactionAnimationIntent {
     Rotate {
         target: SemanticTransactionNodeRef,
         angle: f64,
+        hold_origin: bool,
     },
     Fade {
         target: SemanticTransactionNodeRef,
@@ -200,12 +201,15 @@ impl SemanticTransactionAnimation {
                 target_state: (*target_state).into(),
                 interpolation: *interpolation,
             },
-            SemanticAnimationIntent::Rotate { target, angle } => {
-                SemanticTransactionAnimationIntent::Rotate {
-                    target: (*target).into(),
-                    angle: *angle,
-                }
-            }
+            SemanticAnimationIntent::Rotate {
+                target,
+                angle,
+                hold_origin,
+            } => SemanticTransactionAnimationIntent::Rotate {
+                target: (*target).into(),
+                angle: *angle,
+                hold_origin: *hold_origin,
+            },
             SemanticAnimationIntent::Indicate {
                 target,
                 scale_factor,
@@ -326,12 +330,15 @@ impl SemanticTransactionAnimation {
                 target_state: resolve_node_ref(*target_state, committed),
                 interpolation: *interpolation,
             },
-            SemanticTransactionAnimationIntent::Rotate { target, angle } => {
-                SemanticAnimationIntent::Rotate {
-                    target: resolve_node_ref(*target, committed),
-                    angle: *angle,
-                }
-            }
+            SemanticTransactionAnimationIntent::Rotate {
+                target,
+                angle,
+                hold_origin,
+            } => SemanticAnimationIntent::Rotate {
+                target: resolve_node_ref(*target, committed),
+                angle: *angle,
+                hold_origin: *hold_origin,
+            },
             SemanticTransactionAnimationIntent::Indicate {
                 target,
                 scale_factor,
@@ -549,7 +556,7 @@ pub(super) fn preflight_transaction_animation(
                 });
             }
         }
-        SemanticTransactionAnimationIntent::Rotate { target, angle } => {
+        SemanticTransactionAnimationIntent::Rotate { target, angle, .. } => {
             catalog.ensure_animation_target(*target, index)?;
             catalog.staged_object_state(staged_objects, staged_object_order, *target, index)?;
             if !angle.is_finite() {
@@ -772,8 +779,8 @@ pub(super) fn commit_add_animation(
                 options,
             )
             .expect("preflighted semantic animation insertion must remain valid while transaction owns the store"),
-        SemanticAnimationIntent::Rotate { target, angle } => store
-            .insert_semantic_rotate_animation(*target, *angle, options)
+        SemanticAnimationIntent::Rotate { target, angle, hold_origin } => store
+            .insert_semantic_rotate_animation_with_origin_constraint(*target, *angle, *hold_origin, options)
             .expect("preflighted semantic Rotate insertion must remain valid while transaction owns the store"),
         SemanticAnimationIntent::Indicate {
             target,

--- a/crates/noon-native/examples/ordinary_rotating.rs
+++ b/crates/noon-native/examples/ordinary_rotating.rs
@@ -1,0 +1,4 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    noon_native::run_live_program(noon::example_scenes::ordinary_rotating::program()?)?;
+    Ok(())
+}

--- a/crates/noon-web/src/canonical_authoring_scene.rs
+++ b/crates/noon-web/src/canonical_authoring_scene.rs
@@ -114,6 +114,7 @@ enum OrdinaryCompositionChild {
         entering_id: Option<ObjectId>,
         target: noon::Mobject,
         angle: f64,
+        pivot: Option<noon::ManimRotationPivot>,
         options: noon_core::AnimationOptions,
     },
     ValueTracker {
@@ -1543,12 +1544,21 @@ impl CanonicalAuthoringScene {
                 OrdinaryCompositionChild::Rotate {
                     target,
                     angle,
+                    pivot,
                     options,
                     ..
-                } => noon::AnimationCompositionRequest::Rotate {
-                    target,
-                    angle: *angle,
-                    options: *options,
+                } => match pivot {
+                    Some(pivot) => noon::AnimationCompositionRequest::ManimRotate {
+                        target,
+                        angle: *angle,
+                        pivot: *pivot,
+                        options: *options,
+                    },
+                    None => noon::AnimationCompositionRequest::Rotate {
+                        target,
+                        angle: *angle,
+                        options: *options,
+                    },
                 },
                 OrdinaryCompositionChild::ValueTracker {
                     tracker,
@@ -2123,6 +2133,7 @@ impl CanonicalAuthoringScene {
                     target,
                     angle,
                     options,
+                    ..
                 } => {
                     if !angle.is_finite() {
                         return Err("ordinary Rotate angle must be finite".into());
@@ -3402,6 +3413,7 @@ mod wasm {
                 entering_id,
                 target: target.semantic_mobject().clone(),
                 angle,
+                pivot: None,
                 options: noon_core::AnimationOptions::new()
                     .run_time(child_run_time)
                     .rate_func(rate_function),
@@ -3653,6 +3665,39 @@ mod wasm {
             rate_function: &str,
         ) -> Result<(), JsValue> {
             self.push_rotate(None, target, angle, child_run_time, rate_function)
+        }
+
+        /// Inert request: the native live session validates the effective pivot.
+        #[allow(clippy::too_many_arguments)]
+        #[wasm_bindgen(js_name = appendManimRotate)]
+        pub fn append_manim_rotate(
+            &mut self,
+            object_id: Option<String>,
+            target: &crate::WasmAuthoringMobjectHandle,
+            angle: f64,
+            pivot_kind: &str,
+            pivot_x: f64,
+            pivot_y: f64,
+            child_run_time: Option<f64>,
+            rate_function: Option<String>,
+        ) -> Result<(), JsValue> {
+            let pivot = match pivot_kind {
+                "center" => noon::ManimRotationPivot::Center,
+                "point" => noon::ManimRotationPivot::Point(pivot_x, pivot_y),
+                "edge" => noon::ManimRotationPivot::Edge(pivot_x, pivot_y),
+                _ => return Err(js_error("unknown procedural rotation pivot kind")),
+            };
+            self.children.push(OrdinaryCompositionChild::Rotate {
+                entering_id: object_id
+                    .as_deref()
+                    .map(|id| parse_object_id("object ID", id))
+                    .transpose()?,
+                target: target.semantic_mobject().clone(),
+                angle,
+                pivot: Some(pivot),
+                options: Self::optional_options(child_run_time, rate_function)?,
+            });
+            Ok(())
         }
 
         #[wasm_bindgen(js_name = appendWait)]
@@ -8256,6 +8301,7 @@ mod tests {
                 entering_id: None,
                 target: square.clone(),
                 angle: std::f64::consts::PI,
+                pivot: None,
                 options,
             },
             OrdinaryCompositionChild::ValueTracker {
@@ -8281,6 +8327,7 @@ mod tests {
                 entering_id: None,
                 target: square.clone(),
                 angle: std::f64::consts::PI,
+                pivot: None,
                 options,
             },
             OrdinaryCompositionChild::ValueTracker {
@@ -8326,6 +8373,7 @@ mod tests {
                 entering_id: None,
                 target: rotating.clone(),
                 angle: std::f64::consts::PI,
+                pivot: None,
                 options: child,
             },
             bound_transform_child(&moving, moving_target, child),

--- a/crates/noon-web/src/direct_execution_smoke.rs
+++ b/crates/noon-web/src/direct_execution_smoke.rs
@@ -588,3 +588,12 @@ pub async fn create_direct_focus_on_smoke_renderer(
     let program = noon::example_scenes::ordinary_focus_on::program().map_err(js_error)?;
     WasmExecutionCanvasRenderer::create_from_live_program(canvas, program).await
 }
+
+/// Centered procedural angular paths executed by the normal direct Rust host.
+#[wasm_bindgen(js_name = createDirectRotatingSmokeRenderer)]
+pub async fn create_direct_rotating_smoke_renderer(
+    canvas: OffscreenCanvas,
+) -> Result<WasmExecutionCanvasRenderer, JsValue> {
+    let program = noon::example_scenes::ordinary_rotating::program().map_err(js_error)?;
+    WasmExecutionCanvasRenderer::create_from_live_program(canvas, program).await
+}

--- a/crates/noon/src/example_scenes.rs
+++ b/crates/noon/src/example_scenes.rs
@@ -3000,3 +3000,5 @@ mod line_callback_tests {
 }
 
 pub mod ordinary_focus_on;
+
+pub mod ordinary_rotating;

--- a/crates/noon/src/example_scenes/ordinary_rotating.rs
+++ b/crates/noon/src/example_scenes/ordinary_rotating.rs
@@ -1,0 +1,63 @@
+//! A centered full turn, then a signed quarter turn through one shared runtime.
+use crate::{
+    AnimationCompositionRequest, AnimationOptions, ContinuationStep, LiveContinuation, LiveProgram,
+    LiveSession, ManimRotationPivot, Mobject, RateFunction, Scene,
+};
+
+pub struct OrdinaryRotating {
+    rectangle: Mobject,
+    stage: u8,
+}
+impl LiveContinuation for OrdinaryRotating {
+    type Error = String;
+    fn resume(&mut self, live: &mut LiveSession<'_>) -> Result<ContinuationStep, String> {
+        let result = match self.stage {
+            0 => live.wait_segment(0.25),
+            1 | 2 => live.declare_and_activate_composition(
+                &AnimationCompositionRequest::ManimRotate {
+                    target: &self.rectangle,
+                    angle: if self.stage == 1 {
+                        std::f64::consts::TAU
+                    } else {
+                        -std::f64::consts::FRAC_PI_2
+                    },
+                    pivot: if self.stage == 1 {
+                        ManimRotationPivot::Center
+                    } else {
+                        ManimRotationPivot::Point(2.0, 1.0)
+                    },
+                    options: AnimationOptions::new()
+                        .run_time(if self.stage == 1 { 2.0 } else { 1.0 })
+                        .rate_func(RateFunction::Linear),
+                },
+                AnimationOptions::new(),
+            ),
+            3 => live.wait_segment(0.25),
+            4 => {
+                self.stage = 5;
+                return Ok(ContinuationStep::Finished);
+            }
+            _ => return Err("rotation continuation resumed after completion".into()),
+        };
+        self.stage += 1;
+        result
+            .map(ContinuationStep::Await)
+            .map_err(|error| error.to_string())
+    }
+}
+
+pub fn program() -> Result<LiveProgram<OrdinaryRotating>, String> {
+    let mut scene = Scene::new();
+    let mut rectangle = scene.rectangle(3.0, 0.6)?;
+    rectangle.set_translation(2.0, 1.0)?;
+    rectangle.set_fill_color(0.0, 1.0, 1.0, 1.0)?;
+    rectangle.set_fill_opacity(1.0)?;
+    rectangle.disable_stroke()?;
+    scene.add(&rectangle)?;
+    scene
+        .into_live_program(OrdinaryRotating {
+            rectangle,
+            stage: 0,
+        })
+        .map_err(|error| error.to_string())
+}

--- a/crates/noon/src/execution_session.rs
+++ b/crates/noon/src/execution_session.rs
@@ -158,6 +158,7 @@ pub(crate) enum SemanticCompositionRequest {
     Rotate {
         target: SemanticNodeId,
         angle: f64,
+        hold_origin: bool,
         options: AnimationOptions,
     },
     ValueTracker {
@@ -2098,10 +2099,16 @@ impl ExecutionSession {
             SemanticCompositionRequest::Rotate {
                 target,
                 angle,
+                hold_origin,
                 options,
             } => {
                 admit(*target, declaration, admitted)?;
-                Ok(declaration.create_rotate_animation(*target, *angle, *options))
+                Ok(declaration.create_rotate_animation_with_origin_constraint(
+                    *target,
+                    *angle,
+                    *hold_origin,
+                    *options,
+                ))
             }
             SemanticCompositionRequest::ValueTracker {
                 signal,
@@ -2203,11 +2210,11 @@ impl ExecutionSession {
                 let target_state = self.stage_animation_target_state(store, declaration, *target_state)?;
                 Ok(declaration.create_transform_animation_with_interpolation(*source, target_state, *interpolation, *options))
             }
-            SemanticCompositionRequest::Rotate { target, angle, options } => {
+            SemanticCompositionRequest::Rotate { target, angle, hold_origin, options } => {
                 if !self.reachability.is_object_reachable(*target) {
                     return Err(ExecutionSessionAnimationError::CreateTarget { target: *target, error: ExecutionSessionCreateError::TargetIsNotDetached });
                 }
-                Ok(declaration.create_rotate_animation(*target, *angle, *options))
+                Ok(declaration.create_rotate_animation_with_origin_constraint(*target, *angle, *hold_origin, *options))
             }
             SemanticCompositionRequest::ValueTracker { signal, target, options } => {
                 Ok(declaration.create_scalar_animation(*signal, *target, *options))

--- a/crates/noon/src/lib.rs
+++ b/crates/noon/src/lib.rs
@@ -17,6 +17,8 @@ mod execution_segment;
 mod execution_session;
 mod family_authoring;
 mod focus_on_authoring;
+mod rotation_authoring;
+pub use rotation_authoring::ManimRotationPivot;
 mod geometry_authoring;
 mod host_callbacks;
 pub mod legacy;

--- a/crates/noon/src/live_session.rs
+++ b/crates/noon/src/live_session.rs
@@ -317,6 +317,13 @@ pub enum AnimationCompositionRequest<'a> {
         angle: f64,
         options: AnimationOptions,
     },
+    /// Exact centered 2D procedural rotation, with shared Manim pivot validation.
+    ManimRotate {
+        target: &'a Mobject,
+        angle: f64,
+        pivot: crate::ManimRotationPivot,
+        options: AnimationOptions,
+    },
     /// Animate one borrowed scalar tracker through the shared composition scheduler.
     ValueTracker {
         tracker: &'a ValueTracker,
@@ -825,6 +832,40 @@ impl<'a> LiveSession<'a> {
         let publication = observed.publication;
         drop(store);
         self.layout_at_transform(mobject, transform, publication)
+    }
+
+    fn validate_manim_rotation_pivot(
+        &self,
+        target: &Mobject,
+        pivot: crate::ManimRotationPivot,
+    ) -> Result<(), LiveSessionError> {
+        let (bounds, origin) = if self.session.semantic_object_is_reachable(target.node_id()) {
+            let store = self.store.borrow();
+            let observed = self
+                .session
+                .effective_semantic_object(&store, target.node_id())?;
+            if !observed.authored_content_layout_applicable() {
+                return Err(LiveSessionError::Mobject("procedural rotation requires effective authored content without reveal or morph overrides".into()));
+            }
+            let transform = observed.object.transform;
+            drop(store);
+            (
+                target.layout_bounds_at(transform),
+                (
+                    f64::from(transform.translation.x),
+                    f64::from(transform.translation.y),
+                ),
+            )
+        } else {
+            let state = target.state().map_err(LiveSessionError::Mobject)?;
+            (
+                target.layout_bounds(),
+                (state.transform.translation.x, state.transform.translation.y),
+            )
+        };
+        pivot
+            .validate(bounds.map_err(LiveSessionError::Mobject)?, origin)
+            .map_err(LiveSessionError::Mobject)
     }
 
     /// Read one analytic Line's world endpoints at the current publication.
@@ -1577,6 +1618,22 @@ impl<'a> LiveSession<'a> {
                 Request::Rotate {
                     target: target.node_id(),
                     angle: *angle,
+                    hold_origin: false,
+                    options: *options,
+                }
+            }
+            AnimationCompositionRequest::ManimRotate {
+                target,
+                angle,
+                pivot,
+                options,
+            } => {
+                self.require_mobject(target)?;
+                self.validate_manim_rotation_pivot(target, *pivot)?;
+                Request::Rotate {
+                    target: target.node_id(),
+                    angle: *angle,
+                    hold_origin: true,
                     options: *options,
                 }
             }

--- a/crates/noon/src/rotation_authoring.rs
+++ b/crates/noon/src/rotation_authoring.rs
@@ -1,0 +1,208 @@
+//! Exact centered 2D procedural rotation over the shared angular-path intent.
+use noon_core::Bounds2D64;
+
+/// Python may eagerly capture a point or defer its center/edge choice. Rust owns
+/// resolution and support checks against coherent authored/effective geometry.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub enum ManimRotationPivot {
+    #[default]
+    Center,
+    Point(f64, f64),
+    Edge(f64, f64),
+}
+
+impl ManimRotationPivot {
+    pub(crate) fn validate(
+        self,
+        bounds: Option<Bounds2D64>,
+        origin: (f64, f64),
+    ) -> Result<(), String> {
+        let center = bounds.map_or(origin, |b| {
+            ((b.min_x + b.max_x) * 0.5, (b.min_y + b.max_y) * 0.5)
+        });
+        // Layout and authored values are f64; runtime transforms are f32. Compare
+        // at the rendering precision so an unchanged captured pivot stays valid.
+        let close = |a: f64, b: f64| {
+            a.is_finite()
+                && b.is_finite()
+                && (a - b).abs() <= 4.0 * f64::from(f32::EPSILON) * a.abs().max(b.abs()).max(1.0)
+        };
+        if !close(center.0, origin.0) || !close(center.1, origin.1) {
+            return Err(
+                "procedural rotation requires geometry centered on its transform origin".into(),
+            );
+        }
+        let point = match self {
+            Self::Center => center,
+            Self::Point(x, y) => (x, y),
+            Self::Edge(x, y) => {
+                if !x.is_finite() || !y.is_finite() {
+                    return Err("rotation edge direction must be finite".into());
+                }
+                bounds.map_or(center, |b| {
+                    (
+                        if x < 0.0 {
+                            b.min_x
+                        } else if x > 0.0 {
+                            b.max_x
+                        } else {
+                            center.0
+                        },
+                        if y < 0.0 {
+                            b.min_y
+                        } else if y > 0.0 {
+                            b.max_y
+                        } else {
+                            center.1
+                        },
+                    )
+                })
+            }
+        };
+        if !close(point.0, center.0) || !close(point.1, center.1) {
+            return Err("rotation about an external point/edge requires curved translation and is not yet supported".into());
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        AnimationCompositionRequest as Request, AnimationOptions, RateFunction, Scene,
+        SemanticAnimationCompositionKind, TransformToRequest,
+    };
+
+    #[test]
+    fn procedural_rotation_rejects_stale_external_edge_and_offset_pivots_atomically() {
+        let scene = Scene::new();
+        let mut square = scene.square(2.0).unwrap();
+        let captured = square.center().unwrap();
+        square.shift(2.0, 1.0).unwrap();
+        let line = scene.line((0.0, 0.0), (2.0, 0.0)).unwrap();
+        let mut session = scene.execution_session().unwrap();
+        session.take_frame_changes();
+        let before = session.publication_context();
+        let nodes = square.store().borrow().len();
+        for (target, pivot) in [
+            (&square, ManimRotationPivot::Point(captured.0, captured.1)),
+            (&square, ManimRotationPivot::Edge(1.0, 0.0)),
+            (&square, ManimRotationPivot::Point(f64::NAN, 1.0)),
+            (&line, ManimRotationPivot::Center),
+        ] {
+            let result = scene.live(&mut session).declare_and_activate_composition(
+                &Request::ManimRotate {
+                    target,
+                    angle: 1.0,
+                    pivot,
+                    options: AnimationOptions::new(),
+                },
+                AnimationOptions::new(),
+            );
+            assert!(result.is_err(), "unsupported pivot accepted");
+            assert_eq!(session.publication_context(), before);
+            assert_eq!(square.store().borrow().len(), nodes);
+            assert!(session.frame().objects.is_empty());
+            assert!(session.take_frame_changes().is_empty());
+        }
+    }
+
+    #[test]
+    fn procedural_rotation_captures_effective_center_and_holds_it_through_samples() {
+        let mut scene = Scene::new();
+        let mut square = scene.square(2.0).unwrap();
+        square.set_translation(0.1, -0.2).unwrap();
+        let eager = square.center().unwrap();
+        scene.add(&square).unwrap();
+        let mut session = scene.execution_session().unwrap();
+        let mut live = scene.live(&mut session);
+        for pivot in [
+            ManimRotationPivot::Point(eager.0, eager.1),
+            ManimRotationPivot::Center,
+            ManimRotationPivot::Edge(0.0, 0.0),
+        ] {
+            let start = live.effective(&square).unwrap().transform;
+            let segment = live
+                .declare_and_activate_composition(
+                    &Request::ManimRotate {
+                        target: &square,
+                        angle: std::f64::consts::TAU,
+                        pivot,
+                        options: AnimationOptions::new()
+                            .run_time(2.0)
+                            .rate_func(RateFunction::Linear),
+                    },
+                    AnimationOptions::new(),
+                )
+                .unwrap();
+            live.advance_segment_to(segment, segment.start_time() + 1.0)
+                .unwrap();
+            let middle = live.effective(&square).unwrap().transform;
+            assert_eq!(middle.translation, start.translation);
+            assert!((middle.rotation - start.rotation - std::f32::consts::PI).abs() < 2e-6);
+            live.advance_segment_to(segment, segment.end_time())
+                .unwrap();
+            live.complete_segment(segment).unwrap();
+            assert_eq!(
+                live.effective(&square).unwrap().transform.translation,
+                start.translation
+            );
+        }
+    }
+
+    #[test]
+    fn procedural_rotation_conflicts_with_motion_on_the_same_target_in_either_order() {
+        for reverse in [false, true] {
+            let mut scene = Scene::new();
+            let square = scene.square(2.0).unwrap();
+            let mut target = square.target_editor().unwrap();
+            target.set_translation(2.0, 0.0).unwrap();
+            scene.add(&square).unwrap();
+            let mut session = scene.execution_session().unwrap();
+            session.take_frame_changes();
+            let before = session.publication_context();
+            let before_frame = session.frame().clone();
+            let nodes = square.store().borrow().len();
+            let mut children = vec![
+                Request::ManimRotate {
+                    target: &square,
+                    angle: 1.0,
+                    pivot: ManimRotationPivot::Center,
+                    options: AnimationOptions::new(),
+                },
+                Request::TransformTo(TransformToRequest::new(
+                    &square,
+                    &target,
+                    AnimationOptions::new(),
+                )),
+            ];
+            if reverse {
+                children.reverse();
+            }
+            let result = scene.live(&mut session).declare_and_activate_composition(
+                &Request::Composition {
+                    kind: SemanticAnimationCompositionKind::Parallel,
+                    children,
+                    options: AnimationOptions::new(),
+                },
+                AnimationOptions::new(),
+            );
+            assert!(
+                matches!(
+                    &result,
+                    Err(crate::LiveSessionError::Activation(
+                        crate::ExecutionSessionAnimationError::PreparedAnimation(
+                            noon_compile::PreparedSemanticAnimationLoweringError::MultipleDrivers { .. }
+                        )
+                    ))
+                ),
+                "unexpected rejection: {result:?}"
+            );
+            assert_eq!(session.publication_context(), before);
+            assert_eq!(square.store().borrow().len(), nodes);
+            assert_eq!(session.frame(), &before_frame);
+            assert!(session.take_frame_changes().is_empty());
+        }
+    }
+}

--- a/scripts/shared-authoring-smoke.mjs
+++ b/scripts/shared-authoring-smoke.mjs
@@ -1226,6 +1226,30 @@ try {
     await stopSampledSource(page);
   }
 
+  const rotatingSource = await readFile(
+    path.join(repoRoot, "web/python/examples/ordinary_rotating.py"), "utf8",
+  );
+  await startSampledSource(page, rotatingSource, "scene-shared-rotating", 960, 540);
+  try {
+    await page.evaluate(async () =>
+      window.sharedAuthoringSmoke.sampledProof.execution.sampleToAuthoredTime(0.75));
+    const canvas = page.locator("#scene-shared-rotating");
+    const screenshot = await canvas.screenshot();
+    const cyan = (pixel) => pixel.green > pixel.red + 30 && pixel.blue > pixel.red + 30;
+    assert.ok(cyan(renderedWorldPixel(screenshot, 2, 2)) && !cyan(renderedWorldPixel(screenshot, 3, 1)),
+      "shared Rotating lost its deferred pivot or linear angular path");
+    const duration = await page.evaluate(async () => {
+      const { execution, authored } = window.sharedAuthoringSmoke.sampledProof;
+      const [, completed] = await Promise.all([execution.sampleToAuthoredTime(3.5), authored]);
+      return completed.duration;
+    });
+    assert.equal(duration, 3.5);
+    assert.ok(cyan(renderedWorldPixel(await canvas.screenshot(), 2, 2)),
+      "shared Rotate lost its signed quarter-turn endpoint");
+  } finally {
+    await stopSampledSource(page);
+  }
+
   const focusSource = await readFile(
     path.join(repoRoot, "web/python/examples/ordinary_focus_on.py"), "utf8",
   );

--- a/web/direct-execution-smoke-probe.js
+++ b/web/direct-execution-smoke-probe.js
@@ -10,6 +10,7 @@ const {
   createDirectOrdinaryAffinePlaySmokeRenderer,
   createDirectOrdinaryCallbackSparseReadsSmokeRenderer,
   createDirectFocusOnSmokeRenderer,
+  createDirectRotatingSmokeRenderer,
   createDirectLinePassingFlashSmokeRenderer,
   createDirectOrdinaryBecomeSemanticsSmokeRenderer,
   createDirectOrdinaryCompositionContinuationSmokeRenderer,
@@ -130,6 +131,37 @@ async function directLiveGeometryConstructionProof(expectedBackend) {
         dot.red <= dot.green + 30 || annulus.red <= annulus.blue + 30 ||
         annulus.green <= annulus.blue + 30 || Math.min(underline.red, underline.green, underline.blue) <= 150) {
       throw new Error(`typed live geometry did not publish coherent initial/final frames: ${JSON.stringify(metrics)}`);
+    }
+    return metrics;
+  } finally {
+    renderer.free();
+    if (expectedBackend === "WebGL2") {
+      canvas.getContext("webgl2")?.getExtension("WEBGL_lose_context")?.loseContext();
+    }
+  }
+}
+
+async function directRotatingProof(expectedBackend) {
+  const canvas = new OffscreenCanvas(960, 540);
+  const renderer = await createDirectRotatingSmokeRenderer(canvas);
+  try {
+    renderer.resize(canvas.width, canvas.height);
+    await settleDirectPublication(renderer, 0);
+    for (const time of [250, 750]) {
+      renderer.advanceDirectRealtime(time);
+      await settleDirectPublication(renderer, time);
+    }
+    const vertical = await sampleRenderedColor(canvas, 2, 2);
+    const horizontal = await sampleRenderedColor(canvas, 3, 1);
+    for (const time of [2250, 3250, 3500]) {
+      renderer.advanceDirectRealtime(time);
+      await settleDirectPublication(renderer, time);
+    }
+    const final = await sampleRenderedColor(canvas, 2, 2);
+    const cyan = (pixel) => pixel.green > pixel.red + 30 && pixel.blue > pixel.red + 30;
+    const metrics = { backend: renderer.rendererBackend(), time: renderer.time(), vertical, horizontal, final };
+    if (metrics.backend !== expectedBackend || metrics.time !== 3.5 || !cyan(vertical) || cyan(horizontal) || !cyan(final)) {
+      throw new Error(`direct procedural rotation was incorrect: ${JSON.stringify(metrics)}`);
     }
     return metrics;
   } finally {
@@ -2302,6 +2334,7 @@ async function start() {
   metrics.specializedGeometry = await directSpecializedGeometryProof(expectedBackend);
   metrics.liveGeometryConstruction = await directLiveGeometryConstructionProof(expectedBackend);
   metrics.focusOn = await directFocusOnProof(expectedBackend);
+  metrics.rotating = await directRotatingProof(expectedBackend);
   metrics.linePassingFlash = await directLinePassingFlashProof(expectedBackend);
   metrics.ordinaryBecomeSemantics = await directOrdinaryBecomeSemanticsProof(expectedBackend);
   metrics.automaticWaitText = await directAutomaticWaitTextProof(expectedBackend);

--- a/web/python/_manim_canonical_scene.py
+++ b/web/python/_manim_canonical_scene.py
@@ -1569,7 +1569,7 @@ def _canonical_composition_shape(scene: _base.Scene, args: tuple[object, ...]):
             return "parallel", args, None
         if isinstance(animation, (_animate._AlignedGroupAnimationBuilder, _animate.Indicate)):
             return "parallel", args, None
-        if type(animation) in (_rotate.Rotate, _rotate.FocusOn):
+        if type(animation) in (_rotate.Rotate, _rotate.Rotating, _rotate.FocusOn):
             return "parallel", args, None
         affine = _canonical_affine_animation(scene, animation)
         if affine is not None and affine[0]._scene is None:
@@ -2436,17 +2436,26 @@ def _build_canonical_composition_candidate(
                 method = builder.appendPointTransformTo if point_correspondence else builder.appendTransformTo
                 method(source_handle, target_handle, float(child.run_time), str(child.rate_func))
             return
-        if type(animation) is _rotate.Rotate:
+        if type(animation) in (_rotate.Rotate, _rotate.Rotating):
             target = animation.mobject
             if not isinstance(target, _base.Mobject) or getattr(target, "_semantic_handle", None) is None:
                 raise NotImplementedError("canonical Rotate requires a typed Mobject")
             child = _canonical_composition_child_options(animation, child_kwargs)
             angle = float(animation.angle) * _rotate._axis_sign(animation.axis)
-            if target._scene is None:
-                reservation = reserve(target)
-                builder.appendRotate(str(reservation.object.id), target._semantic_handle, angle, float(child.run_time), str(child.rate_func))
+            if animation.about_point is not None:
+                point = _compat._as_vec2(animation.about_point)
+                pivot_kind, pivot_x, pivot_y = "point", point.x, point.y
+            elif animation.about_edge is not None:
+                edge = _compat._as_vec2(animation.about_edge)
+                pivot_kind, pivot_x, pivot_y = "edge", edge.x, edge.y
             else:
-                builder.appendBoundRotate(target._semantic_handle, angle, float(child.run_time), str(child.rate_func))
+                pivot_kind, pivot_x, pivot_y = "center", 0.0, 0.0
+            entering_id = str(reserve(target).object.id) if target._scene is None else None
+            builder.appendManimRotate(
+                entering_id, target._semantic_handle, angle,
+                pivot_kind, float(pivot_x), float(pivot_y),
+                float(child.run_time), str(child.rate_func),
+            )
             return
         raise NotImplementedError(f"canonical composition does not support {type(animation).__name__}")
 

--- a/web/python/_manim_rotate.py
+++ b/web/python/_manim_rotate.py
@@ -19,15 +19,12 @@ import math
 from typing import Any
 
 import noon as _base
-import _manim_animation_options as _options
 import _manim_animate as _animate
 import _manim_compat as _compat
 import _manim_rate_functions as _rate_functions
 
 
 _INSTALLED = False
-_ORIGINAL_SCENE_PLAY = _compat.Scene.play
-_ORIGINAL_BUILDER_SOURCE = _animate._builder_source
 _UNSUPPORTED_PATH_OPTIONS = {
     "path_arc",
     "path_arc_axis",
@@ -195,223 +192,8 @@ def _axis_sign(axis: object) -> float:
     return 1.0 if z > 0.0 else -1.0
 
 
-def _points_close(left: _base.Vec2, right: _base.Vec2) -> bool:
-    return math.isclose(left.x, right.x, abs_tol=1e-9) and math.isclose(
-        left.y, right.y, abs_tol=1e-9
-    )
-
-
-def _validate_exact_pivot(
-    scene: _compat.Scene,
-    animation: Rotate,
-    *,
-    start_time: float,
-) -> tuple[object, dict[str, Any]]:
-    mobject = animation.mobject
-    animation_name = type(animation).__name__
-    if mobject._scene is not scene or mobject._object is None:
-        raise ValueError(f"{animation_name} target must belong to this Scene")
-    obj = mobject._object
-    snapshot = scene._snapshot_for_object_at(obj, start_time)
-    detached = _animate._snapshot_mobject(snapshot)
-    center = detached.get_center()
-    translation = snapshot["transform"]["translation"]
-    transform_origin = _base.Vec2(
-        float(translation["x"]),
-        float(translation["y"]),
-    )
-
-    # A scalar Noon rotation is around the object's transform origin. For centered
-    # analytic geometry (including the quickstart Square), that is exactly Manim's
-    # default rotation pivot. Offset local geometry would need a circular translation
-    # path to keep its center fixed, so do not approximate it with linear motion.
-    if not _points_close(center, transform_origin):
-        raise NotImplementedError(
-            f"{animation_name} currently requires geometry centered on its transform origin"
-        )
-
-    if animation.about_point is not None:
-        about_point = _compat._as_vec2(animation.about_point)
-    elif animation.about_edge is not None:
-        about_point = _compat._critical_for(
-            detached,
-            _compat._as_vec2(animation.about_edge),
-        )
-    else:
-        # Manim Mobject.rotate(..., about_point=None) rotates around the current center.
-        about_point = center
-
-    if not _points_close(about_point, center):
-        raise NotImplementedError(
-            f"{animation_name} about an external point/edge requires curved translation and is not yet supported"
-        )
-
-    # Rotate eagerly defaults about_point to mobject.get_center(), so about_edge is
-    # ignored there exactly as in Manim. Rotating keeps about_point=None and therefore
-    # resolves about_edge above, rejecting it unless the requested edge is the center.
-    return obj, snapshot
-
-
-def _ensure_rotation_interval_available(
-    scene: _compat.Scene,
-    obj: object,
-    *,
-    start_time: float,
-    duration: float,
-) -> None:
-    end_time = start_time + duration
-    object_id = obj.id  # type: ignore[attr-defined]
-    for track in scene._tracks:
-        if track["object"] != object_id or track["property"] not in {
-            "rotation",
-            "transform",
-        }:
-            continue
-        track_start = float(track["timing"]["start_time"])
-        track_end = track_start + float(track["timing"]["duration"])
-        if track_start < end_time and start_time < track_end:
-            raise ValueError(
-                "rotation animation cannot overlap another rotation/generic Transform on the same object"
-            )
-
-
-def _schedule_rotate(
-    scene: _compat.Scene,
-    animation: Rotate,
-    *,
-    start_time: float,
-    duration: float,
-    easing: str,
-) -> None:
-    obj, snapshot = _validate_exact_pivot(scene, animation, start_time=start_time)
-    _ensure_rotation_interval_available(
-        scene,
-        obj,
-        start_time=start_time,
-        duration=duration,
-    )
-
-    from_rotation = float(snapshot["transform"]["rotation"])
-    to_rotation = from_rotation + _axis_sign(animation.axis) * animation.angle
-    object_key = scene._object_keys[obj.id]
-    scene._add_scalar_track(
-        obj,
-        "rotation",
-        from_rotation,
-        to_rotation,
-        start_time,
-        duration,
-        easing,
-        f"@rotate:{object_key}:{start_time:g}",
-    )
-
-
-def _builder_source(animation: object) -> object | None:
-    if isinstance(animation, Rotate):
-        return animation.mobject
-    return _ORIGINAL_BUILDER_SOURCE(animation)
-
-
-def _procedural_scene_play(
-    self: _compat.Scene,
-    *animations: Any,
-    duration: float | None = None,
-    run_time: float | None = None,
-    start_time: float | None = None,
-    easing: str | None = None,
-    rate_func: object | None = None,
-    lag_ratio: float | None = None,
-    **kwargs: Any,
-) -> _compat.Scene:
-    if not any(isinstance(animation, Rotate) for animation in animations):
-        return _ORIGINAL_SCENE_PLAY(
-            self,
-            *animations,
-            duration=duration,
-            run_time=run_time,
-            start_time=start_time,
-            easing=easing,
-            rate_func=rate_func,
-            lag_ratio=lag_ratio,
-            **kwargs,
-        )
-    if not animations:
-        raise ValueError("play requires at least one animation")
-    if duration is not None and run_time is not None:
-        raise ValueError("use either duration or run_time, not both")
-    if easing is not None and rate_func is not None:
-        raise ValueError("use either rate_func or the low-level easing alias, not both")
-    if kwargs:
-        unsupported = ", ".join(sorted(kwargs))
-        raise NotImplementedError(f"unsupported Manim Scene.play option(s): {unsupported}")
-    play_run_time = run_time if run_time is not None else duration
-    if play_run_time is not None:
-        play_run_time = float(play_run_time)
-    if lag_ratio is not None:
-        lag_ratio = float(lag_ratio)
-    base_start = self._cursor if start_time is None else float(start_time)
-    if not math.isfinite(base_start) or base_start < 0.0:
-        raise ValueError("start_time must be finite and non-negative")
-
-    checkpoint = self._authoring_checkpoint()
-    cursor_before = self._cursor
-    top_level_before = list(self._compat_top_level)
-    wrapper_states: dict[int, tuple[_base.Mobject, object, object]] = {}
-    for animation in animations:
-        source = _builder_source(animation)
-        if source is not None:
-            _animate._record_wrapper_state(source, wrapper_states)
-        if isinstance(animation, (_base.Create, _base.FadeIn, _base.FadeOut)):
-            _animate._record_wrapper_state(animation.target, wrapper_states)
-
-    max_end = base_start
-    try:
-        for animation in animations:
-            if isinstance(animation, Rotate):
-                _animate._bind_for_animation(
-                    self,
-                    animation.mobject,
-                    start_time=base_start,
-                )
-                resolved = _options.resolve(
-                    builder_args=_options.builder_args(animation),
-                    default_lag_ratio=0.0,
-                    play_run_time=play_run_time,
-                    play_easing=easing,
-                    play_rate_func=rate_func,
-                    play_lag_ratio=lag_ratio,
-                )
-                _schedule_rotate(
-                    self,
-                    animation,
-                    start_time=base_start,
-                    duration=resolved.run_time,
-                    easing=resolved.rate_func,
-                )
-                end = base_start + resolved.run_time
-            else:
-                _ORIGINAL_SCENE_PLAY(
-                    self,
-                    animation,
-                    run_time=play_run_time,
-                    start_time=base_start,
-                    easing=easing,
-                    rate_func=rate_func,
-                    lag_ratio=lag_ratio,
-                )
-                end = self._cursor
-            max_end = max(max_end, end)
-
-        self._cursor = max(cursor_before, max_end)
-        return self
-    except Exception:
-        self._restore_authoring_checkpoint(checkpoint)
-        self._cursor = cursor_before
-        self._compat_top_level = top_level_before
-        for member, old_scene, old_object in wrapper_states.values():
-            member._scene = old_scene
-            member._object = old_object
-        raise
+def _points_close(left: object, right: object) -> bool:
+    return all(math.isclose(float(a), float(b), abs_tol=1e-9) for a, b in zip(left, right))
 
 
 def install() -> None:
@@ -431,9 +213,3 @@ def install() -> None:
         if name not in exports:
             exports.append(name)
     _base.__all__ = exports
-
-    # Composition imports this module before capturing Scene.play, so nested Rotate
-    # and Rotating leaves share the same timing resolver and rollback path as top-level
-    # plays. FocusOn uses the ordinary shared composition path.
-    _animate._builder_source = _builder_source
-    _compat.Scene.play = _procedural_scene_play

--- a/web/python/_manim_updaters.py
+++ b/web/python/_manim_updaters.py
@@ -1431,6 +1431,13 @@ def _install_rotating_breadth() -> None:
     original_scene_play = compat.Scene.play
 
     class Rotating:
+        def __new__(cls, mobject: object, *args: Any, **kwargs: Any):
+            # Leaf requests use the shared Rust path. #959 owns deletion of the
+            # remaining family/projection source-execution implementation below.
+            if not isinstance(mobject, compat.Group):
+                return rotate.Rotating(mobject, *args, **kwargs)
+            return super().__new__(cls)
+
         def __init__(
             self,
             mobject: object,
@@ -1648,24 +1655,6 @@ def _install_rotating_breadth() -> None:
         duration: float,
         easing: str,
     ) -> list[tuple[_base.Mobject, _base.Mobject]]:
-        if not isinstance(animation.mobject, compat.Group):
-            exact = rotate.Rotating(
-                animation.mobject,
-                angle=animation.angle,
-                axis=animation.axis,
-                about_point=animation.about_point,
-                about_edge=animation.about_edge,
-                run_time=duration,
-                rate_func=rates.linear,
-            )
-            rotate._schedule_rotate(
-                scene,
-                exact,
-                start_time=start_time,
-                duration=duration,
-                easing=easing,
-            )
-            return []
         return schedule_family(
             scene,
             animation,

--- a/web/python/examples/manim_tutorial_manifest.json
+++ b/web/python/examples/manim_tutorial_manifest.json
@@ -359,6 +359,8 @@
       "reuse": "source-equivalent-manim-v0.21",
       "parity_status": "candidate",
       "expected_duration": 3,
+      "qualification_mode": "shared-live",
+      "expected_object_count": 2,
       "thumbnail": "thumbnails/manim/generated/using-focus-on.png",
       "thumbnail_alt": "Exact-source Manim UsingFocusOn",
       "thumbnail_time": 2.5,

--- a/web/python/examples/ordinary_rotating.py
+++ b/web/python/examples/ordinary_rotating.py
@@ -1,0 +1,14 @@
+from noon import *
+
+
+class OrdinaryRotating(Scene):
+    def construct(self):
+        rectangle = Rectangle(width=3.0, height=0.6, color=Color(0.0, 1.0, 1.0), fill_opacity=1.0, stroke_width=0)
+        # Rotating defers its center; moving after construction remains valid.
+        turn = Rotating(rectangle, run_time=2.0)
+        rectangle.shift(2 * RIGHT + UP)
+        self.add(rectangle)
+        self.wait(0.25)
+        self.play(turn)
+        self.play(Rotate(rectangle, angle=PI / 2, axis=IN, rate_func=linear))
+        self.wait(0.25)

--- a/web/python/test_manim_rotate_animation.py
+++ b/web/python/test_manim_rotate_animation.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 
 class ManimRotateAnimationTests(unittest.TestCase):
-    def test_centered_2d_rotate_uses_procedural_rotation_track(self) -> None:
+    def test_public_request_preserves_pivot_capture_and_timing(self) -> None:
         python_dir = Path(__file__).resolve().parent
         env = os.environ.copy()
         existing_pythonpath = env.get("PYTHONPATH")
@@ -25,49 +25,8 @@ class ManimRotateAnimationTests(unittest.TestCase):
 
             fake_js = types.ModuleType("js")
 
-            class Result:
-                ok = True
-                errorKind = ""
-                message = ""
-
-            def resolve_animation_options(
-                default_lag_ratio,
-                animation_run_time,
-                animation_rate_func,
-                animation_lag_ratio,
-                path_arc,
-                reverse_rate_function,
-                play_run_time,
-                play_rate_func,
-                play_lag_ratio,
-            ):
-                result = Result()
-                result.runTime = (
-                    play_run_time
-                    if math.isfinite(play_run_time)
-                    else animation_run_time
-                    if math.isfinite(animation_run_time)
-                    else 1.0
-                )
-                result.rateFunc = play_rate_func or animation_rate_func or "smooth"
-                result.lagRatio = (
-                    play_lag_ratio
-                    if math.isfinite(play_lag_ratio)
-                    else animation_lag_ratio
-                    if math.isfinite(animation_lag_ratio)
-                    else default_lag_ratio
-                )
-                result.pathArc = path_arc if math.isfinite(path_arc) else 0.0
-                result.reverseRateFunction = reverse_rate_function == 1
-                return result
-
-            def resolve_uniform_schedule(child_count, lag_ratio, run_time):
-                result = Result()
-                result.intervals = []
-                return result
-
-            fake_js.noonResolveAnimationOptions = resolve_animation_options
-            fake_js.noonResolveUniformCompositionSchedule = resolve_uniform_schedule
+            fake_js.noonResolveAnimationOptions = lambda *args: None
+            fake_js.noonResolveUniformCompositionSchedule = lambda *args: None
             sys.modules["js"] = fake_js
 
             import _manim_compat
@@ -79,146 +38,19 @@ class ManimRotateAnimationTests(unittest.TestCase):
             import _manim_rotate
             _manim_rotate.install()
 
-            from noon import IN, LEFT, ORIGIN, PI, RIGHT, Line, Rotate, Scene, Square, linear, smooth
-
-            # Canonical quickstart subset: a shifted Square is still centered on its
-            # transform origin, so explicit Rotate is a true angular path rather than
-            # the target-state interpolation used by square.animate.rotate(...).
-            scene = Scene()
-            square = Square().shift(2 * RIGHT)
-            scene.play(Rotate(square, angle=PI, rate_func=linear), run_time=2.0)
-            assert abs(scene.time - 2.0) < 1e-12
-            document = scene.to_document()
-            rotation = next(
-                track
-                for track in document["tracks"]
-                if track["object"] == square.id and track["property"] == "rotation"
-            )
-            values = rotation["values"]["scalar"]
-            assert abs(values["from"] - 0.0) < 1e-12
-            assert abs(values["to"] - PI) < 1e-12
-            assert abs(rotation["timing"]["duration"] - 2.0) < 1e-12
-            assert rotation["timing"]["easing"] == "linear"
-            authored = next(obj for obj in document["objects"] if obj["id"] == square.id)
-            assert abs(authored["transform"]["translation"]["x"] - 2.0) < 1e-12
-            assert abs(authored["transform"]["translation"]["y"]) < 1e-12
-
-            # The upstream DifferentRotations shape is one concurrent Scene.play.
-            # Keep the two semantics structurally different while sharing the same
-            # play start/end interval.
-            mixed_scene = Scene()
-            left_square = Square().shift(2 * LEFT)
-            right_square = Square().shift(2 * RIGHT)
-            mixed_scene.play(
-                left_square.animate.rotate(PI),
-                Rotate(right_square, angle=PI),
-                run_time=2.0,
-                rate_func=linear,
-            )
-            assert abs(mixed_scene.time - 2.0) < 1e-12
-            mixed_document = mixed_scene.to_document()
-            left_tracks = [
-                track
-                for track in mixed_document["tracks"]
-                if track["object"] == left_square.id
-            ]
-            right_tracks = [
-                track
-                for track in mixed_document["tracks"]
-                if track["object"] == right_square.id
-            ]
-            left_transform = next(track for track in left_tracks if track["property"] == "transform")
-            right_rotation = next(track for track in right_tracks if track["property"] == "rotation")
-            assert not any(track["property"] == "rotation" for track in left_tracks)
-            assert not any(track["property"] == "transform" for track in right_tracks)
-            for track in (left_transform, right_rotation):
-                assert abs(track["timing"]["start_time"] - 0.0) < 1e-12
-                assert abs(track["timing"]["duration"] - 2.0) < 1e-12
-                assert track["timing"]["easing"] == "linear"
-
-            # Constructor defaults and Scene.play override precedence are shared with
-            # every other Manim animation through the common Rust option resolver.
-            default_scene = Scene()
-            default_square = Square()
-            default_scene.play(Rotate(default_square))
-            default_track = next(
-                track
-                for track in default_scene.to_document()["tracks"]
-                if track["property"] == "rotation"
-            )
-            assert abs(default_scene.time - 1.0) < 1e-12
-            assert default_track["timing"]["easing"] == "smooth"
-
-            override_scene = Scene()
-            override_square = Square()
-            override_scene.play(
-                Rotate(override_square, run_time=3.0, rate_func=linear),
-                run_time=0.75,
-                rate_func=smooth,
-            )
-            override_track = next(
-                track
-                for track in override_scene.to_document()["tracks"]
-                if track["property"] == "rotation"
-            )
-            assert abs(override_scene.time - 0.75) < 1e-12
-            assert abs(override_track["timing"]["duration"] - 0.75) < 1e-12
-            assert override_track["timing"]["easing"] == "smooth"
-
-            # IN reverses the 2D angular direction exactly; non-z axes are outside the
-            # supported 2D subset and must fail instead of being projected silently.
-            in_scene = Scene()
-            in_square = Square()
-            in_scene.play(Rotate(in_square, angle=PI / 2, axis=IN), rate_func=linear)
-            in_track = next(
-                track
-                for track in in_scene.to_document()["tracks"]
-                if track["property"] == "rotation"
-            )
-            assert abs(in_track["values"]["scalar"]["to"] + PI / 2) < 1e-12
-
-            axis_scene = Scene()
-            try:
-                axis_scene.play(Rotate(Square(), axis=(1.0, 0.0, 0.0)))
-            except NotImplementedError:
-                pass
-            else:
-                raise AssertionError("non-z Rotate axis should be rejected")
-            assert axis_scene.time == 0.0
-            assert axis_scene.to_document()["objects"] == []
-
-            # External pivots and offset-local geometry require a circular translation
-            # path that the scalar rotation channel cannot encode yet. Both cases are
-            # rejected atomically rather than approximated with linear translation.
-            pivot_scene = Scene()
-            pivot_square = Square().shift(2 * RIGHT)
-            try:
-                pivot_scene.play(Rotate(pivot_square, about_point=ORIGIN))
-            except NotImplementedError:
-                pass
-            else:
-                raise AssertionError("external Rotate pivot should be rejected")
-            assert pivot_scene.time == 0.0
-            assert pivot_scene.to_document()["objects"] == []
-            assert pivot_square._scene is None and pivot_square._object is None
-
-            line_scene = Scene()
-            offset_line = Line(ORIGIN, RIGHT)
-            try:
-                line_scene.play(Rotate(offset_line))
-            except NotImplementedError:
-                pass
-            else:
-                raise AssertionError("offset-local Rotate should be rejected")
-            assert line_scene.time == 0.0
-            assert line_scene.to_document()["objects"] == []
-
-            try:
-                Rotate(Square(), path_arc=0.0)
-            except NotImplementedError:
-                pass
-            else:
-                raise AssertionError("explicit Rotate path overrides should be rejected")
+            from noon import Rotate, Mobject, RIGHT, IN, PI
+            target = Mobject.__new__(Mobject)
+            target.get_center = lambda: (2.0, 1.0)
+            animation = Rotate(target, about_edge=RIGHT)
+            target.get_center = lambda: (3.0, 1.0)
+            assert animation.about_point == (2.0, 1.0)
+            assert animation.about_edge is RIGHT
+            assert animation.angle == PI
+            explicit = Rotate(target, about_point=(0.0, 0.0), axis=IN, run_time=2.0)
+            assert explicit.about_point == (0.0, 0.0)
+            assert explicit.axis is IN
+            assert explicit.anim_args == {"run_time": 2.0}
+            assert not hasattr(animation, "target")
             """
         )
 

--- a/web/python/test_manim_rotating_animation.py
+++ b/web/python/test_manim_rotating_animation.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 
 class ManimRotatingAnimationTests(unittest.TestCase):
-    def test_centered_2d_rotating_matches_manim_defaults_and_options(self) -> None:
+    def test_public_request_preserves_pivot_capture_and_timing(self) -> None:
         python_dir = Path(__file__).resolve().parent
         env = os.environ.copy()
         existing_pythonpath = env.get("PYTHONPATH")
@@ -25,55 +25,12 @@ class ManimRotatingAnimationTests(unittest.TestCase):
 
             fake_js = types.ModuleType("js")
 
-            class Result:
-                ok = True
-                errorKind = ""
-                message = ""
-
-            def resolve_animation_options(
-                default_lag_ratio,
-                animation_run_time,
-                animation_rate_func,
-                animation_lag_ratio,
-                path_arc,
-                reverse_rate_function,
-                play_run_time,
-                play_rate_func,
-                play_lag_ratio,
-            ):
-                result = Result()
-                result.runTime = (
-                    play_run_time
-                    if math.isfinite(play_run_time)
-                    else animation_run_time
-                    if math.isfinite(animation_run_time)
-                    else 1.0
-                )
-                result.rateFunc = play_rate_func or animation_rate_func or "smooth"
-                result.lagRatio = (
-                    play_lag_ratio
-                    if math.isfinite(play_lag_ratio)
-                    else animation_lag_ratio
-                    if math.isfinite(animation_lag_ratio)
-                    else default_lag_ratio
-                )
-                result.pathArc = path_arc if math.isfinite(path_arc) else 0.0
-                result.reverseRateFunction = reverse_rate_function == 1
-                return result
-
-            def resolve_uniform_schedule(child_count, lag_ratio, run_time):
-                result = Result()
-                result.intervals = []
-                return result
-
-            fake_js.noonResolveAnimationOptions = resolve_animation_options
-            fake_js.noonResolveUniformCompositionSchedule = resolve_uniform_schedule
+            fake_js.noonResolveAnimationOptions = lambda *args: None
+            fake_js.noonResolveUniformCompositionSchedule = lambda *args: None
             sys.modules["js"] = fake_js
 
             import _manim_compat
             _manim_compat.install()
-            from _test_manim_membership import install_test_membership
-            install_test_membership(_manim_compat)
             import _manim_rate_functions
             _manim_rate_functions.install()
             import _manim_phase_b  # noqa: F401
@@ -81,105 +38,23 @@ class ManimRotatingAnimationTests(unittest.TestCase):
             import _manim_rotate
             _manim_rotate.install()
 
-            from noon import IN, ORIGIN, PI, RIGHT, TAU, Rotating, Scene, Square, linear, smooth
-
-            # ManimCE v0.21 Rotating defaults: one full turn, five seconds, linear.
-            scene = Scene()
-            square = Square()
-            scene.add(square)
-            animation = Rotating(square)
+            from noon import Rotating, Mobject, RIGHT, TAU, linear
+            target = Mobject.__new__(Mobject)
+            def forbidden():
+                raise AssertionError("Rotating eagerly captured its pivot")
+            target.get_center = forbidden
+            animation = Rotating(target)
             assert animation.about_point is None
-            assert abs(animation.angle - TAU) < 1e-12
-            scene.play(animation)
-            assert abs(scene.time - 5.0) < 1e-12
-            document = scene.to_document()
-            rotation = next(
-                track
-                for track in document["tracks"]
-                if track["object"] == square.id and track["property"] == "rotation"
-            )
-            values = rotation["values"]["scalar"]
-            assert abs(values["from"] - 0.0) < 1e-12
-            assert abs(values["to"] - TAU) < 1e-12
-            assert abs(rotation["timing"]["duration"] - 5.0) < 1e-12
-            assert rotation["timing"]["easing"] == "linear"
-
-            # Animation-local options are accepted, while Scene.play overrides retain
-            # the same precedence shared by the rest of the Manim compatibility layer.
-            override_scene = Scene()
-            override_square = Square()
-            override_scene.add(override_square)
-            override_scene.play(
-                Rotating(
-                    override_square,
-                    angle=PI / 2,
-                    run_time=3.0,
-                    rate_func=smooth,
-                ),
-                run_time=0.75,
-                rate_func=linear,
-            )
-            override_track = next(
-                track
-                for track in override_scene.to_document()["tracks"]
-                if track["object"] == override_square.id and track["property"] == "rotation"
-            )
-            assert abs(override_scene.time - 0.75) < 1e-12
-            assert abs(override_track["values"]["scalar"]["to"] - PI / 2) < 1e-12
-            assert abs(override_track["timing"]["duration"] - 0.75) < 1e-12
-            assert override_track["timing"]["easing"] == "linear"
-
-            # OUT/IN z-axis behavior maps directly to the scalar rotation channel.
-            in_scene = Scene()
-            in_square = Square()
-            in_scene.add(in_square)
-            in_scene.play(Rotating(in_square, angle=PI / 2, axis=IN, run_time=1.0))
-            in_track = next(
-                track
-                for track in in_scene.to_document()["tracks"]
-                if track["property"] == "rotation"
-            )
-            assert abs(in_track["values"]["scalar"]["to"] + PI / 2) < 1e-12
-
-            # An explicit center pivot is representable and remains exact.
-            centered_scene = Scene()
-            centered_square = Square()
-            centered_scene.add(centered_square)
-            centered_scene.play(
-                Rotating(centered_square, angle=PI, about_point=ORIGIN, run_time=1.0)
-            )
-            centered_track = next(
-                track
-                for track in centered_scene.to_document()["tracks"]
-                if track["property"] == "rotation"
-            )
-            assert abs(centered_track["values"]["scalar"]["to"] - PI) < 1e-12
-
-            # External pivots/edges and non-z axes need curved translation/3D state.
-            # They must fail atomically rather than silently approximating Manim.
-            edge_scene = Scene()
-            edge_square = Square()
-            try:
-                edge_scene.play(Rotating(edge_square, about_edge=RIGHT))
-            except NotImplementedError:
-                pass
-            else:
-                raise AssertionError("external Rotating about_edge should be rejected")
-            assert edge_scene.time == 0.0
-            assert edge_scene.to_document()["objects"] == []
-            assert edge_square._scene is None and edge_square._object is None
-
-            axis_scene = Scene()
-            axis_square = Square()
-            try:
-                axis_scene.play(Rotating(axis_square, axis=(1.0, 0.0, 0.0)))
-            except NotImplementedError:
-                pass
-            else:
-                raise AssertionError("non-z Rotating axis should be rejected")
-            assert axis_scene.time == 0.0
-            assert axis_scene.to_document()["objects"] == []
-            assert axis_square._scene is None and axis_square._object is None
+            assert animation.about_edge is None
+            assert animation.angle == TAU
+            assert animation.anim_args == {"run_time": 5.0, "rate_func": linear}
+            edge = Rotating(target, about_edge=RIGHT, run_time=2.0)
+            assert edge.about_point is None and edge.about_edge is RIGHT
+            assert edge.anim_args["run_time"] == 2.0
+            import _manim_updaters
+            _manim_updaters.install()
+            import noon
+            assert type(noon.Rotating(target)) is Rotating
             """
         )
 


### PR DESCRIPTION
Centered `Rotating` now reaches the shared Rust composition path, and `Rotate` validates its requested pivot instead of silently ignoring it. Rust resolves eager points or deferred center/edge requests against coherent effective geometry, rejects unsupported external pivots and offset geometry before committing, and holds the activation-time origin using the existing position channel alongside angular rotation. Existing driver conflicts, atomic publication, and completion own the operation.

Advances #958 / #959 (Phase A frontend consolidation). Semantic Scene owns the origin constraint; shared Rust authoring owns pivot/layout behavior; the compiler lowers ordinary channels. No new scheduler, renderer state, identity space, or transport boundary. Work is bounded to the affected object's layout and channels. Python retains signatures, timing defaults, argument coercion and eager/deferred capture ergonomics. Its procedural snapshot scheduler and rollback hooks are deleted, and the corresponding debt budget drops to zero. The already-existing family/principal-axis source-execution path remains owned for deletion by #959; this change adds no broad 3D support.

`ordinary_rotating` is an equivalent executable Rust/native/direct-WASM/Python example. Tests protect deferred/eager pivots, f32 capture precision, unsupported-pivot atomicity and same-target motion conflicts in both orders. The FocusOn tutorial now uses the existing shared-live qualification mode: final CI for #1206 exposed its stale export-mode setting after deletion of the Python spotlight scheduler.

Validation:
- `CARGO_TARGET_DIR=/Users/ykshin/Dev/me/noon/target CARGO_INCREMENTAL=0 NOON_SKIP_WEB_PREFLIGHT=1 NOON_SKIP_PLAYGROUND_TEST=1 NOON_WASM_PROFILE=dev bash scripts/check.sh full`: format/check/clippy passed; 1,807 Rust tests passed. One new test initially hit detached duplicate-admission validation before the intended channel-conflict check; corrected it to use a mounted object.
- `CARGO_TARGET_DIR=/Users/ykshin/Dev/me/noon/target CARGO_INCREMENTAL=0 cargo test --workspace --all-features --lib procedural_rotation`: all three focused tests passed after that fixture correction (1,808 qualified Rust tests overall).
- `NOON_WEB_PREFLIGHT_ONLY=1 NOON_SKIP_PLAYGROUND_TEST=1 bash scripts/check.sh web`: 188 Python tests and Node checks passed.
- `CARGO_TARGET_DIR=/Users/ykshin/Dev/me/noon/target CARGO_INCREMENTAL=0 NOON_SKIP_WEB_PREFLIGHT=1 NOON_SKIP_PLAYGROUND_TEST=1 NOON_WASM_PROFILE=dev bash scripts/check.sh web`: WASM build and 236 API contracts passed.
- `bash scripts/architecture-ratchet.sh d531890ed4b41376cb790ea571b0407cd90e6720`, `cargo fmt --all -- --check`, `git diff --check`, and `node --test web/example-gallery.test.mjs`: passed.
- `node scripts/manim-tutorial-smoke.mjs`, `node scripts/shared-authoring-smoke.mjs`, and `NOON_BROWSER_SMOKE_BACKEND=webgpu` / `webgl node scripts/browser-smoke.mjs`: passed. `node scripts/manim-compat-smoke.mjs` also passed. All five bounded browser cases exited successfully.


Final GitHub CI is green, including the product gate and cross-browser matrix. This confirms the FocusOn tutorial follow-up from #1206.
