### PR TITLE
Honor semantic raster host playback duration

### DIFF
--- a/scripts/shared-authoring-smoke.mjs
+++ b/scripts/shared-authoring-smoke.mjs
@@ -3128,6 +3128,24 @@ result = scene
       `MovingDots tracker endpoint missing: ${JSON.stringify(blueDot)}`);
     assert.ok(redLine.red > 100 && redLine.red > redLine.green,
       `MovingDots Line endpoint match missing: ${JSON.stringify(redLine)}`);
+
+    await rasterPage.reload({ waitUntil: "load" });
+    await rasterPage.waitForFunction(() => window.noonHostRaster, null, { timeout: 30_000 });
+    const rotating = await rasterPage.evaluate(async (source) => {
+      await window.noonHostRaster.ready();
+      return window.noonHostRaster.load(source, 6);
+    }, rotatingDefaultsSource);
+    assert.equal(rotating.kind, "semantic_execution");
+    assert.equal(rotating.objectCount, 1);
+    const rotationTimes = [0, 0.625, 5];
+    await rasterPage.evaluate((times) => window.noonHostRaster.renderThrough(1, times), rotationTimes);
+    const diagonal = renderedWorldPixel(await rasterPage.locator("#scene").screenshot(), 0.95, 0);
+    assert.ok(diagonal.blue > diagonal.red + 30, "raster host did not sample the five-second angular path");
+    const rotated = await rasterPage.evaluate((times) => window.noonHostRaster.renderThrough(2, times), rotationTimes);
+    assert.equal(rotated.time, 5);
+    assert.equal(rotated.authoredDuration, 5);
+    assert.equal(rotated.objectCount, 1);
+    assert.equal(rotated.presented, true);
   } finally {
     await rasterPage.close();
   }

--- a/web/manim-raster-host.js
+++ b/web/manim-raster-host.js
@@ -65,6 +65,7 @@ async function load(source, loopDurationSeconds, { mode = "semantic" } = {}) {
         execution = new AuthoringExecutionClient(canvas);
         await execution.startSemanticExecution(registration.semanticExecution, {
           authoringClient: client,
+          loopDurationSeconds: loopDuration,
           transportMode: "transferable",
           pacing: "external_samples",
         });


### PR DESCRIPTION
The semantic raster host now forwards its validated playback duration to execution. Previously it silently used the client's four-second default, so a normal first segment such as `Rotating(square)` (five seconds) failed even when the caller supplied six seconds.

Advances #959 A4.7 shared execution qualification. This is platform-host configuration only; semantic timing remains in Rust. The existing real-host browser proof now loads the centered rotation example, samples its angular path, and verifies five-second completion. No new engine, scheduler, state model or migration seam.

Validation passed:
- `CARGO_TARGET_DIR=/Users/ykshin/Dev/me/noon/target CARGO_INCREMENTAL=0 bash scripts/check.sh fast` (format/check/clippy and 1,597 workspace library tests).
- `node --check web/manim-raster-host.js` and `node --check scripts/shared-authoring-smoke.mjs`.
- `node scripts/shared-authoring-smoke.mjs` (bounded browser run), including the new actual raster-host five-second rotation and existing MovingDots callback proof.
- `git diff --check`.

No Rust/WASM changes; reused the already-qualified browser package from #1208/#1209.

