### PR TITLE
Run the Manim raster corpus through shared execution

### DIFF
--- a/crates/noon-native/examples/ordinary_scale_in_place.rs
+++ b/crates/noon-native/examples/ordinary_scale_in_place.rs
@@ -1,0 +1,4 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    noon_native::run_live_program(noon::example_scenes::scale_in_place::program()?)?;
+    Ok(())
+}

--- a/crates/noon-render-wgpu/src/gpu/retained_text.rs
+++ b/crates/noon-render-wgpu/src/gpu/retained_text.rs
@@ -828,6 +828,7 @@ pub struct RetainedFramePreparer {
     scratch_ready: bool,
     scratch_object_count: usize,
     geometry_only_classification: Option<bool>,
+    geometry_uses_source_indices: bool,
     scratch_slots: Vec<Option<usize>>,
     incremental_stats: RetainedFrameIncrementalStats,
     sources: Vec<SourceItem>,
@@ -879,6 +880,7 @@ impl Default for RetainedFramePreparer {
             scratch_ready: false,
             scratch_object_count: 0,
             geometry_only_classification: None,
+            geometry_uses_source_indices: false,
             scratch_slots: Vec::new(),
             incremental_stats: RetainedFrameIncrementalStats::default(),
             sources: Vec::new(),
@@ -1140,9 +1142,6 @@ impl RetainedFramePreparer {
         allow_geometry_only: bool,
         visible_object_indices: Option<&[usize]>,
     ) -> Result<PreparedRetainedGpuFrame<'a>, RetainedPrepareError> {
-        // Mixed preparation indexes a compact scratch frame. Its child order
-        // cannot receive a source-frame range until that index domain is reset.
-        let reset_geometry_order = self.geometry_only_classification != Some(true);
         if changes.is_all() || changes.is_structural() {
             self.geometry_only_classification = None;
         }
@@ -1154,7 +1153,6 @@ impl RetainedFramePreparer {
                         changes,
                         metrics,
                         visible_object_indices,
-                        reset_geometry_order,
                     );
                 }
                 Some(false) => {}
@@ -1166,13 +1164,18 @@ impl RetainedFramePreparer {
                         changes,
                         metrics,
                         visible_object_indices,
-                        reset_geometry_order,
                     );
                 }
                 None => self.geometry_only_classification = Some(false),
             }
         } else {
             self.geometry_only_classification = Some(false);
+        }
+        // Eligibility can become geometry-only while this call still prepares
+        // scratch rows. Track the actual child index domain separately.
+        if self.geometry_uses_source_indices {
+            self.geometry.clear_painter_order();
+            self.geometry_uses_source_indices = false;
         }
         if self.can_update_mixed_properties_locally(frame, changes, texts, metrics)? {
             return self.prepare_mixed_properties_locally(
@@ -1457,10 +1460,9 @@ impl RetainedFramePreparer {
         changes: &FrameChanges,
         metrics: TextDeviceMetrics,
         visible_object_indices: Option<&[usize]>,
-        reset_order: bool,
     ) -> Result<PreparedRetainedGpuFrame<'a>, RetainedPrepareError> {
         self.prepared_generation_ready = false;
-        if changes.is_all() || reset_order {
+        if changes.is_all() || !self.geometry_uses_source_indices {
             self.geometry
                 .set_painter_order(frame, &self.painter_order_indices);
         } else if let Some(range) = changes.painter_order_range() {
@@ -1476,6 +1478,8 @@ impl RetainedFramePreparer {
                 .prepare_incremental_visible(frame, changes, indices)?,
             None => self.geometry.prepare_incremental(frame, changes),
         };
+        self.geometry_uses_source_indices = true;
+        self.scratch_ready = false;
         let stats = RetainedPrepareStats {
             semantic_objects: frame.objects.len(),
             geometry_slots: frame.objects.len(),
@@ -3606,9 +3610,15 @@ mod tests {
 
         frame.presences[1] = true;
         preparer.set_painter_order_range(&[0, 1], 1..2);
-        let changes = FrameChanges::structural(vec![1], vec![]).with_painter_order(1..2);
-        assert!(preparer.prepare_with_changes(
+        let changes = FrameChanges::objects(vec![1]).with_painter_order(1..2);
+        assert!(!preparer.prepare_with_changes(
             &device, &queue, &frame, &changes,
+            &texts, &fonts, &geometries, metrics,
+        ).unwrap().geometry_only);
+        assert_eq!(preparer.geometry_only_classification, Some(true));
+        preparer.set_painter_order_range(&[0, 1], 0..1);
+        assert!(preparer.prepare_with_changes(
+            &device, &queue, &frame, &FrameChanges::painter_order(0..1),
             &texts, &fonts, &geometries, metrics,
         ).unwrap().geometry_only);
         assert_eq!(preparer.geometry.painter_order_indices, [0, 1]);
@@ -3619,6 +3629,16 @@ mod tests {
             &texts, &fonts, &geometries, metrics,
         ).unwrap();
         assert_eq!(preparer.geometry.painter_order_indices, [1, 0]);
+
+        frame.presences[1] = false;
+        preparer.set_painter_order_range(&[0], 0..2);
+        let prepared = preparer.prepare_with_changes(
+            &device, &queue, &frame,
+            &FrameChanges::structural(vec![], vec![1]).with_painter_order(0..2),
+            &texts, &fonts, &geometries, metrics,
+        ).unwrap();
+        assert!(!prepared.geometry_only);
+        assert_eq!(prepared.geometry.ordered_render_batches().count(), 1);
     }
 
     #[test]

--- a/crates/noon-render-wgpu/src/gpu/retained_text.rs
+++ b/crates/noon-render-wgpu/src/gpu/retained_text.rs
@@ -1140,6 +1140,9 @@ impl RetainedFramePreparer {
         allow_geometry_only: bool,
         visible_object_indices: Option<&[usize]>,
     ) -> Result<PreparedRetainedGpuFrame<'a>, RetainedPrepareError> {
+        // Mixed preparation indexes a compact scratch frame. Its child order
+        // cannot receive a source-frame range until that index domain is reset.
+        let reset_geometry_order = self.geometry_only_classification != Some(true);
         if changes.is_all() || changes.is_structural() {
             self.geometry_only_classification = None;
         }
@@ -1151,6 +1154,7 @@ impl RetainedFramePreparer {
                         changes,
                         metrics,
                         visible_object_indices,
+                        reset_geometry_order,
                     );
                 }
                 Some(false) => {}
@@ -1162,6 +1166,7 @@ impl RetainedFramePreparer {
                         changes,
                         metrics,
                         visible_object_indices,
+                        reset_geometry_order,
                     );
                 }
                 None => self.geometry_only_classification = Some(false),
@@ -1452,9 +1457,10 @@ impl RetainedFramePreparer {
         changes: &FrameChanges,
         metrics: TextDeviceMetrics,
         visible_object_indices: Option<&[usize]>,
+        reset_order: bool,
     ) -> Result<PreparedRetainedGpuFrame<'a>, RetainedPrepareError> {
         self.prepared_generation_ready = false;
-        if changes.is_all() {
+        if changes.is_all() || reset_order {
             self.geometry
                 .set_painter_order(frame, &self.painter_order_indices);
         } else if let Some(range) = changes.painter_order_range() {
@@ -3580,6 +3586,39 @@ mod tests {
             prepared.observe_object(0, ObjectId::new(1)),
             Err(RetainedPreparedObjectOutcome::MegaPathMappingUnavailable)
         ));
+    }
+
+    #[test]
+    fn geometry_reentry_resets_compact_painter_order_before_partial_updates() {
+        let mut frame = geometry_only_mega_path_frame();
+        frame.presences[1] = false;
+        let texts = TextResourceArena::new();
+        let fonts = FontResourceArena::new();
+        let geometries = GeometryResourceArena::new();
+        let metrics = TextDeviceMetrics::uniform(100.0).unwrap();
+        let (device, queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
+        let mut preparer = RetainedFramePreparer::new();
+        preparer.set_painter_order(&[0]);
+        assert!(!preparer.prepare_with_changes(
+            &device, &queue, &frame, &FrameChanges::all(),
+            &texts, &fonts, &geometries, metrics,
+        ).unwrap().geometry_only);
+
+        frame.presences[1] = true;
+        preparer.set_painter_order_range(&[0, 1], 1..2);
+        let changes = FrameChanges::structural(vec![1], vec![]).with_painter_order(1..2);
+        assert!(preparer.prepare_with_changes(
+            &device, &queue, &frame, &changes,
+            &texts, &fonts, &geometries, metrics,
+        ).unwrap().geometry_only);
+        assert_eq!(preparer.geometry.painter_order_indices, [0, 1]);
+
+        preparer.set_painter_order_range(&[1, 0], 0..2);
+        preparer.prepare_with_changes(
+            &device, &queue, &frame, &FrameChanges::painter_order(0..2),
+            &texts, &fonts, &geometries, metrics,
+        ).unwrap();
+        assert_eq!(preparer.geometry.painter_order_indices, [1, 0]);
     }
 
     #[test]

--- a/crates/noon-render-wgpu/src/render_order.rs
+++ b/crates/noon-render-wgpu/src/render_order.rs
@@ -116,6 +116,12 @@ impl FramePreparer {
         self.painter_order_installed = true;
     }
 
+    /// Return to storage order when a parent switches to compact scratch rows.
+    pub(crate) fn clear_painter_order(&mut self) {
+        self.painter_order_indices.clear();
+        self.painter_order_installed = false;
+    }
+
     /// Update only the changed portion of the runtime-derived painter permutation.
     pub fn set_painter_order_range(
         &mut self,

--- a/crates/noon-web/src/direct_execution_smoke.rs
+++ b/crates/noon-web/src/direct_execution_smoke.rs
@@ -597,3 +597,12 @@ pub async fn create_direct_rotating_smoke_renderer(
     let program = noon::example_scenes::ordinary_rotating::program().map_err(js_error)?;
     WasmExecutionCanvasRenderer::create_from_live_program(canvas, program).await
 }
+
+/// Shared play-begin scaling through the normal direct Rust host.
+#[wasm_bindgen(js_name = createDirectScaleInPlaceSmokeRenderer)]
+pub async fn create_direct_scale_in_place_smoke_renderer(
+    canvas: OffscreenCanvas,
+) -> Result<WasmExecutionCanvasRenderer, JsValue> {
+    let program = noon::example_scenes::scale_in_place::program().map_err(js_error)?;
+    WasmExecutionCanvasRenderer::create_from_live_program(canvas, program).await
+}

--- a/crates/noon/src/example_scenes.rs
+++ b/crates/noon/src/example_scenes.rs
@@ -3002,3 +3002,5 @@ mod line_callback_tests {
 pub mod ordinary_focus_on;
 
 pub mod ordinary_rotating;
+
+pub mod scale_in_place;

--- a/crates/noon/src/example_scenes/scale_in_place.rs
+++ b/crates/noon/src/example_scenes/scale_in_place.rs
@@ -1,0 +1,90 @@
+//! Play-begin target capture for the paired Python ScaleInPlace example.
+use crate::{
+    AnimationOptions, ContinuationStep, LiveContinuation, LiveProgram, LiveSession, Mobject,
+    RateFunction, Scene,
+};
+
+pub struct ScaleInPlace {
+    square: Mobject,
+    stage: u8,
+}
+
+impl LiveContinuation for ScaleInPlace {
+    type Error = String;
+
+    fn resume(&mut self, live: &mut LiveSession<'_>) -> Result<ContinuationStep, String> {
+        if self.stage == 2 {
+            let state = live.effective(&self.square).map_err(|e| e.to_string())?;
+            if state.transform.translation != noon_core::Vec2::new(1.0, 0.0)
+                || state.transform.scale != noon_core::Vec2::new(2.0, 2.0)
+            {
+                return Err("scaled target did not capture the completed movement".into());
+            }
+            self.stage = 3;
+            return Ok(ContinuationStep::Finished);
+        }
+        if self.stage > 2 {
+            return Err("scale continuation resumed after completion".into());
+        }
+        let target = live
+            .target_editor(&self.square)
+            .map_err(|e| e.to_string())?;
+        let duration = if self.stage == 0 {
+            live.set_translation(&target, 1.0, 0.0)
+                .map_err(|e| e.to_string())?;
+            0.25
+        } else {
+            live.scale(&target, 2.0, 2.0).map_err(|e| e.to_string())?;
+            0.75
+        };
+        self.stage += 1;
+        live.declare_and_activate_transform_to(
+            &self.square,
+            &target,
+            AnimationOptions::new()
+                .run_time(duration)
+                .rate_func(RateFunction::Linear),
+        )
+        .map(ContinuationStep::Await)
+        .map_err(|e| e.to_string())
+    }
+}
+
+pub fn program() -> Result<LiveProgram<ScaleInPlace>, String> {
+    let mut scene = Scene::new();
+    let mut square = scene.square(1.0)?;
+    square.set_translation(-0.5, 0.25)?;
+    square.set_fill_color(0.0, 0.0, 1.0, 1.0)?;
+    square.set_fill_opacity(1.0)?;
+    square.disable_stroke()?;
+    scene.add(&square)?;
+    scene
+        .into_live_program(ScaleInPlace { square, stage: 0 })
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{LiveProgramStatus, RustHostCallbackTable};
+
+    #[test]
+    fn scale_target_captures_the_previous_segment_endpoint() {
+        let mut program = program().unwrap();
+        let mut callbacks = RustHostCallbackTable::new();
+        for end in [0.25, 1.0] {
+            assert!(matches!(
+                program.resume().unwrap(),
+                LiveProgramStatus::Awaiting(_)
+            ));
+            if let LiveProgramStatus::PublicationPending(expected) =
+                program.drive_to(&mut callbacks, end).unwrap()
+            {
+                let publication = program.take_renderer_publication().context();
+                assert_eq!(publication, expected);
+                program.admit_publication(publication).unwrap();
+            }
+        }
+        assert_eq!(program.resume().unwrap(), LiveProgramStatus::Finished);
+    }
+}

--- a/crates/noon/src/execution_session.rs
+++ b/crates/noon/src/execution_session.rs
@@ -2527,10 +2527,7 @@ impl ExecutionSession {
             .expect("validated semantic object has a live node");
         match direction {
             SemanticFadeDirection::In => {
-                if node.is_scene_owned()
-                    || !node.parents().is_empty()
-                    || self.reachability.is_object_reachable(target)
-                {
+                if node.is_scene_owned() || self.reachability.is_object_reachable(target) {
                     return Err(ExecutionSessionAnimationError::FadeTarget {
                         target,
                         error: ExecutionSessionFadeError::TargetIsNotDetached,
@@ -2737,10 +2734,7 @@ impl ExecutionSession {
         }
         match direction {
             SemanticFadeDirection::In => {
-                if node.is_scene_owned()
-                    || !node.parents().is_empty()
-                    || self.reachability.is_reachable(target)
-                {
+                if node.is_scene_owned() || self.reachability.is_reachable(target) {
                     return Err(ExecutionSessionAnimationError::FadeTarget {
                         target,
                         error: ExecutionSessionFadeError::TargetIsNotDetached,

--- a/crates/noon/src/live_session.rs
+++ b/crates/noon/src/live_session.rs
@@ -3794,6 +3794,122 @@ mod tests {
     }
 
     #[test]
+    fn raster_lagged_fades_of_late_detached_family_members() {
+        let mut scene = Scene::new();
+        let anchor = scene.circle(0.3).unwrap();
+        scene.add(&anchor).unwrap();
+        let mut session = scene.execution_session().unwrap();
+        let mut live = scene.live(&mut session);
+        let wait = live.wait_segment(1.0).unwrap();
+        live.advance_segment_to(wait, 1.0).unwrap();
+        live.complete_segment(wait).unwrap();
+        let first = live
+            .create_manim_geometry(crate::ManimGeometryOptions::square(0.7).unwrap())
+            .unwrap();
+        let second = live
+            .create_manim_geometry(crate::ManimGeometryOptions::square(0.7).unwrap())
+            .unwrap();
+        let _family = live
+            .family(&[
+                MobjectFamilyMember::Mobject(&first),
+                MobjectFamilyMember::Mobject(&second),
+            ])
+            .unwrap();
+        let request = AnimationCompositionRequest::Composition {
+            kind: SemanticAnimationCompositionKind::Parallel,
+            options: AnimationOptions::new()
+                .run_time(2.2)
+                .rate_func(RateFunction::Linear)
+                .lag_ratio(0.1),
+            children: [&first, &second]
+                .into_iter()
+                .map(|target| AnimationCompositionRequest::Fade {
+                    target,
+                    direction: SemanticFadeDirection::In,
+                    endpoint: FadeEndpoint::default(),
+                    options: AnimationOptions::new()
+                        .run_time(1.0)
+                        .rate_func(RateFunction::Linear),
+                })
+                .collect(),
+        };
+        let segment = live
+            .declare_and_activate_composition(&request, AnimationOptions::new())
+            .unwrap();
+        for index in 30..=96 {
+            live.advance_segment_to(segment, f64::from(index) / 30.0)
+                .unwrap();
+        }
+        live.complete_segment(segment).unwrap();
+        assert_eq!(live.effective(&first).unwrap().appearance, 1.0);
+        assert_eq!(live.effective(&second).unwrap().appearance, 1.0);
+    }
+
+    #[test]
+    fn fade_in_accepts_detached_family_members_but_rejects_reachable_targets() {
+        for nested_family in [false, true] {
+            let scene = Scene::new();
+            let shape = scene.circle(0.5).unwrap();
+            let family = scene.family(&[&shape]).unwrap();
+            let mut session = scene.execution_session().unwrap();
+            let mut live = scene.live(&mut session);
+            let outer = live
+                .family(&[MobjectFamilyMember::Family(&family)])
+                .unwrap();
+            let segment = if nested_family {
+                live.declare_and_activate_family_fade(
+                    &family,
+                    SemanticFadeDirection::In,
+                    AnimationOptions::new()
+                        .run_time(1.0)
+                        .rate_func(RateFunction::Linear)
+                        .introducer(true),
+                )
+            } else {
+                live.declare_and_activate_fade(
+                    &shape,
+                    SemanticFadeDirection::In,
+                    AnimationOptions::new()
+                        .run_time(1.0)
+                        .rate_func(RateFunction::Linear),
+                )
+            }
+            .unwrap();
+            live.advance_segment_to(segment, segment.end_time())
+                .unwrap();
+            live.complete_segment(segment).unwrap();
+            assert_eq!(live.effective(&shape).unwrap().appearance, 1.0);
+            assert!(!scene
+                .store()
+                .borrow()
+                .semantic_family_members_checked(scene.root())
+                .unwrap()
+                .contains(&outer.node_id()));
+            let before = live.session.publication_context();
+            let rejected = if nested_family {
+                live.declare_and_activate_family_fade(
+                    &family,
+                    SemanticFadeDirection::In,
+                    AnimationOptions::new()
+                        .run_time(1.0)
+                        .rate_func(RateFunction::Linear)
+                        .introducer(true),
+                )
+            } else {
+                live.declare_and_activate_fade(
+                    &shape,
+                    SemanticFadeDirection::In,
+                    AnimationOptions::new()
+                        .run_time(1.0)
+                        .rate_func(RateFunction::Linear),
+                )
+            };
+            assert!(rejected.is_err());
+            assert_eq!(live.session.publication_context(), before);
+        }
+    }
+
+    #[test]
     fn single_leaf_fade_enters_exits_and_readds_the_same_handle_locally() {
         let mut scene = Scene::new();
         let anchor = scene.circle(0.5).unwrap();

--- a/scripts/manim-raster-differential.mjs
+++ b/scripts/manim-raster-differential.mjs
@@ -203,47 +203,11 @@ async function renderManimReferences() {
   return results;
 }
 
-function noonSourceFor(fixture, { semantic = false } = {}) {
+function noonSourceFor(fixture) {
   const adapted = fixtureSourceFor(fixture).replace("from manim import *", "from noon import *");
-  if (semantic) {
-    // Leave construction to the normal async authoring runner. Class metadata
-    // selects the fixture without rewriting its construct method or callbacks.
-    return `${adapted}\nfor _name, _cls in tuple(globals().items()):\n    if isinstance(_cls, type) and issubclass(_cls, Scene) and _cls is not ${fixture.scene}:\n        _cls.__module__ = "raster_fixture_library"\ndel _cls\n`;
-  }
-  return `${adapted}\n\nresult = ${fixture.scene}()\nresult.setup()\ntry:\n    result.construct()\nfinally:\n    result.tear_down()\n`;
-}
-
-async function authorNoonScenes() {
-  const browser = await chromium.launch({
-    channel: "chromium",
-    headless: true,
-    args: ["--disable-dev-shm-usage"],
-  });
-  try {
-    const page = await browser.newPage();
-    await page.goto(`${baseUrl}/web/manim-compat-smoke.html`, { waitUntil: "load" });
-    await page.waitForFunction(() => window.noonManimCompat, null, { timeout: 30_000 });
-    await page.evaluate(() => window.noonManimCompat.ready());
-    const scenes = new Map();
-    for (const fixture of manifest.fixtures) {
-      const result = await page.evaluate(
-        (source) => window.noonManimCompat.run(source),
-        noonSourceFor(fixture),
-      );
-      assert.equal(result.kind, "scene_document", `${fixture.id}: Noon authoring result kind`);
-      assert.ok(result.document.objects.length > 0, `${fixture.id}: Noon scene has no objects`);
-      assert.equal(result.duration, fixture.expected_duration, `${fixture.id}: authored Noon duration`);
-      scenes.set(fixture.id, {
-        document: result.document,
-        duration: Number(result.duration),
-        hasCallbacks: result.callbacks !== null,
-        hasSemanticCamera: Number.isInteger(result.document.camera_object),
-      });
-    }
-    return scenes;
-  } finally {
-    await browser.close();
-  }
+  // Selection is host bootstrap. The normal source runner owns construct and
+  // continuation; authored semantics and callbacks remain unchanged.
+  return `${adapted}\nfor _name, _cls in tuple(globals().items()):\n    if isinstance(_cls, type) and issubclass(_cls, Scene) and _cls is not ${fixture.scene}:\n        _cls.__module__ = "raster_fixture_library"\ndel _cls\n`;
 }
 
 function browserArgs(backend) {
@@ -273,153 +237,80 @@ function browserArgs(backend) {
   ];
 }
 
-async function createDeterministicCapturePage(browser, expectedBackend, backend) {
-  const page = await browser.newPage({
-    viewport: { width: reference.pixel_width + 40, height: reference.pixel_height + 40 },
-  });
-  await page.goto(`${baseUrl}/web/browser-smoke.html`, { waitUntil: "load" });
-  await page.waitForFunction(() => window.noonSmoke?.state.ready === true, null, {
-    timeout: 30_000,
-  });
-  const initial = await page.evaluate(() => window.noonSmoke.metrics());
-  assert.equal(initial.rendererBackend, expectedBackend, `${backend}: selected renderer backend`);
-  return page;
-}
-
-async function createHostCapturePage(browser) {
-  const page = await browser.newPage({
-    viewport: { width: reference.pixel_width + 40, height: reference.pixel_height + 40 },
-  });
+async function prepareHostCapturePage(page) {
   await page.goto(`${baseUrl}/web/manim-raster-host.html`, { waitUntil: "load" });
   await page.waitForFunction(() => window.noonHostRaster, null, { timeout: 30_000 });
   await page.evaluate(() => window.noonHostRaster.ready());
-  return page;
 }
 
-async function captureDeterministicFixture(
-  page,
-  fixture,
-  authored,
-  referenceResult,
-  fixtureDir,
-) {
+async function captureHostFixture(page, fixture, referenceResult, fixtureDir, expectedBackend) {
   const loaded = await page.evaluate(
-    (json) => window.noonSmoke.loadScene(json),
-    JSON.stringify(authored.document),
+    ({ source, loopDuration }) => window.noonHostRaster.load(source, loopDuration),
+    { source: noonSourceFor(fixture), loopDuration: Math.max(1, fixture.expected_duration + 1) },
   );
-  assert.equal(loaded.objectCount, authored.document.objects.length, `${fixture.id}: loaded object count`);
-  const captures = [];
-  for (const sample of referenceResult.samples) {
-    const metrics = await page.evaluate(
-      (time) => window.noonSmoke.renderAt(time),
-      sample.time,
-    );
-    assert.equal(metrics.error, null, `${fixture.id}: Noon render error at ${sample.time}`);
-    assert.equal(metrics.presented, true, `${fixture.id}: frame was not presented at ${sample.time}`);
-    await page.evaluate(() => new Promise((resolve) => requestAnimationFrame(resolve)));
-    const outputPath = path.join(fixtureDir, `${sample.label}.png`);
-    await page.locator("#scene").screenshot({ path: outputPath });
-    captures.push({ ...sample, noonPath: outputPath, metrics });
-  }
-  return {
-    duration: authored.duration,
-    objectCount: authored.document.objects.length,
-    captures,
-  };
-}
+  assert.equal(loaded.kind, "semantic_execution", `${fixture.id}: shared source execution`);
+  assert.equal(loaded.rendererBackend, expectedBackend, `${fixture.id}: host renderer backend`);
 
-async function captureHostFixture(
-  page,
-  fixture,
-  authored,
-  referenceResult,
-  fixtureDir,
-  expectedBackend,
-  backend,
-) {
-  const loaded = await page.evaluate(
-    ({ source, loopDuration, mode }) => window.noonHostRaster.load(source, loopDuration, { mode }),
-    {
-      source: noonSourceFor(fixture, { semantic: authored.hasCallbacks }),
-      loopDuration: Math.max(1, fixture.expected_duration + 1),
-      mode: authored.hasCallbacks ? "semantic" : "document",
-    },
-  );
-  if (authored.hasCallbacks) {
-    assert.equal(loaded.kind, "semantic_execution", `${fixture.id}: canonical callback execution`);
-  } else {
-    assert.equal(loaded.duration, fixture.expected_duration, `${fixture.id}: host authored duration`);
-  }
-  assert.equal(loaded.objectCount, authored.document.objects.length, `${fixture.id}: host object count`);
-  assert.equal(loaded.rendererBackend, expectedBackend, `${backend}: host renderer backend`);
-
+  // Manim's final materialized frame may precede its logical endpoint. Sample
+  // those exact frame times, then complete the normal source continuation to
+  // verify duration/lifecycle without changing any reference screenshot.
+  const frameTimes = [...referenceResult.frameTimes, fixture.expected_duration];
   const captures = [];
   for (const sample of referenceResult.samples) {
     const metrics = await page.evaluate(
       ({ frameIndex, frameTimes }) => window.noonHostRaster.renderThrough(frameIndex, frameTimes),
-      { frameIndex: sample.frameIndex, frameTimes: referenceResult.frameTimes },
+      { frameIndex: sample.frameIndex, frameTimes },
     );
     assert.equal(metrics.error, null, `${fixture.id}: host render error at frame ${sample.frameIndex}`);
     assert.equal(metrics.presented, true, `${fixture.id}: host frame ${sample.frameIndex} not presented`);
     assert.equal(metrics.frameIndex, sample.frameIndex, `${fixture.id}: host frame index`);
-    assert.ok(
-      Math.abs(Number(metrics.time) - Number(sample.time)) < 1e-9,
-      `${fixture.id}: host logical time mismatch at frame ${sample.frameIndex}`,
-    );
-    // Match the deterministic capture path: rendering/present submits GPU work,
-    // while the browser compositor owns when that surface becomes screenshot-visible.
-    // Waiting one paint prevents callback-heavy scenes from being captured mid-present.
+    assert.ok(Math.abs(Number(metrics.time) - Number(sample.time)) < 1e-9,
+      `${fixture.id}: host logical time mismatch at frame ${sample.frameIndex}`);
     await page.evaluate(() => new Promise((resolve) => requestAnimationFrame(resolve)));
     const outputPath = path.join(fixtureDir, `${sample.label}.png`);
     await page.locator("#scene").screenshot({ path: outputPath });
     captures.push({ ...sample, noonPath: outputPath, metrics });
   }
-  return {
-    duration: authored.duration,
-    objectCount: authored.document.objects.length,
-    captures,
-  };
+  const completed = await page.evaluate((times) =>
+    window.noonHostRaster.renderThrough(times.length - 1, times), frameTimes);
+  assert.equal(completed.authoredDuration, fixture.expected_duration,
+    `${fixture.id}: shared source duration`);
+  return { duration: completed.authoredDuration, objectCount: completed.objectCount, captures };
 }
 
-async function captureNoonBackend(backend, authoredScenes, references) {
-  const browser = await chromium.launch({
-    channel: "chromium",
-    headless: true,
-    args: browserArgs(backend),
-  });
+async function captureNoonBackend(backend, references) {
+  const browser = await chromium.launch({ channel: "chromium", headless: true, args: browserArgs(backend) });
   const expectedBackend = backend === "webgpu" ? "WebGPU" : "WebGL2";
   try {
+    // Share the browser cache, while each source gets a fresh page and workers.
+    const context = await browser.newContext({
+      viewport: { width: reference.pixel_width + 40, height: reference.pixel_height + 40 },
+    });
     const output = new Map();
     for (const fixture of manifest.fixtures) {
       let page = null;
+      let deadline;
       try {
-        const authored = authoredScenes.get(fixture.id);
-        const referenceResult = references.get(fixture.id);
         const fixtureDir = path.join(artifactRoot, backend, fixture.id);
         await mkdir(fixtureDir, { recursive: true });
-
-        if (authored.hasCallbacks || authored.hasSemanticCamera) {
-          page = await createHostCapturePage(browser);
-          output.set(
-            fixture.id,
-            await captureHostFixture(
-              page,
-              fixture,
-              authored,
-              referenceResult,
-              fixtureDir,
-              expectedBackend,
-              backend,
-            ),
-          );
-        } else {
-          page = await createDeterministicCapturePage(browser, expectedBackend, backend);
-          output.set(
-            fixture.id,
-            await captureDeterministicFixture(page, fixture, authored, referenceResult, fixtureDir),
-          );
-        }
+        page = await context.newPage();
+        const result = await Promise.race([
+          (async () => {
+            await prepareHostCapturePage(page);
+            return captureHostFixture(page, fixture, references.get(fixture.id), fixtureDir, expectedBackend);
+          })(),
+          new Promise((_, reject) => {
+            deadline = setTimeout(() => reject(new Error("shared fixture exceeded 60 seconds")), 60_000);
+          }),
+        ]);
+        output.set(fixture.id, result);
+        console.log(`[PASS] ${fixture.id}/${backend}: shared execution completed`);
+      } catch (error) {
+        const detail = error instanceof Error ? error.stack ?? error.message : String(error);
+        output.set(fixture.id, { error: detail });
+        console.error(`[FAIL] ${fixture.id}/${backend}: ${detail}`);
       } finally {
+        clearTimeout(deadline);
         await page?.close();
       }
     }
@@ -550,12 +441,18 @@ async function compareAll(references, backendResults) {
     fixtures: [],
   };
   const enforcementFailures = [];
+  const executionFailures = [];
 
   for (const fixture of manifest.fixtures) {
     const referenceResult = references.get(fixture.id);
     const backendEntries = {};
     for (const backend of backends) {
       const actualResult = backendResults.get(backend).get(fixture.id);
+      if (actualResult.error) {
+        backendEntries[backend] = { error: actualResult.error };
+        executionFailures.push(`${fixture.id}/${backend}: ${actualResult.error}`);
+        continue;
+      }
       const timingDelta = actualResult.duration - referenceResult.frames.duration;
       const samples = [];
       for (const capture of actualResult.captures) {
@@ -615,6 +512,7 @@ async function compareAll(references, backendResults) {
   for (const fixture of report.fixtures) {
     for (const backend of backends) {
       const entry = fixture.backends[backend];
+      if (entry.error) continue;
       const categories = [...new Set(entry.samples.flatMap((sample) => sample.categories))];
       const worstRatio = Math.max(...entry.samples.map((sample) => sample.diff.differingRatio));
       console.log(
@@ -623,6 +521,9 @@ async function compareAll(references, backendResults) {
           `categories=${categories.join("|") || "none"}`,
       );
     }
+  }
+  if (executionFailures.length > 0) {
+    throw new Error(`Shared raster execution failures (report: ${reportPath}):\n${executionFailures.join("\n")}`);
   }
   if (enforcementFailures.length > 0) {
     throw new Error(`Manim raster parity failures:\n${enforcementFailures.join("\n")}`);
@@ -657,10 +558,9 @@ async function waitForServer() {
 try {
   const references = await renderManimReferences();
   await waitForServer();
-  const authoredScenes = await authorNoonScenes();
   const backendResults = new Map();
   for (const backend of backends) {
-    backendResults.set(backend, await captureNoonBackend(backend, authoredScenes, references));
+    backendResults.set(backend, await captureNoonBackend(backend, references));
   }
   const reportPath = await compareAll(references, backendResults);
   console.log(`ManimCE raster differential report: ${reportPath}`);

--- a/scripts/shared-authoring-smoke.mjs
+++ b/scripts/shared-authoring-smoke.mjs
@@ -1227,6 +1227,23 @@ try {
     await stopSampledSource(page);
   }
 
+  const scaleSource = await readFile(
+    path.join(repoRoot, "web/python/examples/ordinary_scale_in_place.py"), "utf8",
+  );
+  await startSampledSource(page, scaleSource, "scene-shared-scale-in-place", 960, 540);
+  try {
+    const duration = await page.evaluate(async () => {
+      const { execution, authored } = window.sharedAuthoringSmoke.sampledProof;
+      const [, completed] = await Promise.all([execution.sampleToAuthoredTime(1), authored]);
+      return completed.duration;
+    });
+    assert.equal(duration, 1);
+    const edge = renderedWorldPixel(await page.locator("#scene-shared-scale-in-place").screenshot(), 1.8, 0);
+    assert.ok(edge.blue > edge.red + 30, "ScaleInPlace did not capture the completed translation");
+  } finally {
+    await stopSampledSource(page);
+  }
+
   const rotatingSource = await readFile(
     path.join(repoRoot, "web/python/examples/ordinary_rotating.py"), "utf8",
   );
@@ -3146,6 +3163,24 @@ result = scene
     assert.equal(rotated.authoredDuration, 5);
     assert.equal(rotated.objectCount, 1);
     assert.equal(rotated.presented, true);
+
+    await rasterPage.reload({ waitUntil: "load" });
+    await rasterPage.waitForFunction(() => window.noonHostRaster, null, { timeout: 30_000 });
+    await rasterPage.evaluate(async () => {
+      await window.noonHostRaster.ready();
+      await window.noonHostRaster.load(`from noon import *
+class LateFailure(Scene):
+    def construct(self):
+        self.add(Circle())
+        self.wait(0.1)
+        raise ValueError("intentional raster continuation failure")
+`, 1);
+    });
+    await assert.rejects(
+      rasterPage.evaluate(() => window.noonHostRaster.renderThrough(1, [0, 0.1])),
+      /intentional raster continuation failure/,
+      "a failed source continuation must reject its pending sample with the original error",
+    );
   } finally {
     await rasterPage.close();
   }

--- a/web/direct-execution-smoke-probe.js
+++ b/web/direct-execution-smoke-probe.js
@@ -11,6 +11,7 @@ const {
   createDirectOrdinaryCallbackSparseReadsSmokeRenderer,
   createDirectFocusOnSmokeRenderer,
   createDirectRotatingSmokeRenderer,
+  createDirectScaleInPlaceSmokeRenderer,
   createDirectLinePassingFlashSmokeRenderer,
   createDirectOrdinaryBecomeSemanticsSmokeRenderer,
   createDirectOrdinaryCompositionContinuationSmokeRenderer,
@@ -131,6 +132,30 @@ async function directLiveGeometryConstructionProof(expectedBackend) {
         dot.red <= dot.green + 30 || annulus.red <= annulus.blue + 30 ||
         annulus.green <= annulus.blue + 30 || Math.min(underline.red, underline.green, underline.blue) <= 150) {
       throw new Error(`typed live geometry did not publish coherent initial/final frames: ${JSON.stringify(metrics)}`);
+    }
+    return metrics;
+  } finally {
+    renderer.free();
+    if (expectedBackend === "WebGL2") {
+      canvas.getContext("webgl2")?.getExtension("WEBGL_lose_context")?.loseContext();
+    }
+  }
+}
+
+async function directScaleInPlaceProof(expectedBackend) {
+  const canvas = new OffscreenCanvas(960, 540);
+  const renderer = await createDirectScaleInPlaceSmokeRenderer(canvas);
+  try {
+    renderer.resize(canvas.width, canvas.height);
+    await settleDirectPublication(renderer, 0);
+    for (const time of [250, 1000]) {
+      renderer.advanceDirectRealtime(time);
+      await settleDirectPublication(renderer, time);
+    }
+    const edge = await sampleRenderedColor(canvas, 1.8, 0);
+    const metrics = { backend: renderer.rendererBackend(), time: renderer.time(), edge };
+    if (metrics.backend !== expectedBackend || metrics.time !== 1 || edge.blue < edge.red + 30) {
+      throw new Error(`direct scale-in-place mismatch: ${JSON.stringify(metrics)}`);
     }
     return metrics;
   } finally {
@@ -2335,6 +2360,7 @@ async function start() {
   metrics.liveGeometryConstruction = await directLiveGeometryConstructionProof(expectedBackend);
   metrics.focusOn = await directFocusOnProof(expectedBackend);
   metrics.rotating = await directRotatingProof(expectedBackend);
+  metrics.scaleInPlace = await directScaleInPlaceProof(expectedBackend);
   metrics.linePassingFlash = await directLinePassingFlashProof(expectedBackend);
   metrics.ordinaryBecomeSemantics = await directOrdinaryBecomeSemanticsProof(expectedBackend);
   metrics.automaticWaitText = await directAutomaticWaitTextProof(expectedBackend);

--- a/web/manim-raster-host.js
+++ b/web/manim-raster-host.js
@@ -1,18 +1,12 @@
-import initNoonWeb, {
-  EngineScenePlayer,
-  ExecutionCanvasRenderer,
-} from "./pkg/noon_web.js";
 import { PythonAuthoringClient } from "./authoring-client.js";
 import { AuthoringExecutionClient } from "./authoring-execution-client.js";
 
 const canvas = document.querySelector("#scene");
 const client = new PythonAuthoringClient();
-const readyPromise = Promise.all([initNoonWeb(), client.ready()]);
+const readyPromise = client.ready();
 
-let engine = null;
 let execution = null;
 let sourceFailure = null;
-let renderer = null;
 let currentFrameIndex = -1;
 let currentLogicalTime = 0;
 let activeFrameTimes = null;
@@ -24,22 +18,7 @@ function waitForPaint() {
   });
 }
 
-async function presentDelta(deltaJson) {
-  if (deltaJson === undefined || deltaJson === null) return false;
-  const applied = renderer.applyDeltaJson(deltaJson);
-  if (!applied) return false;
-  let presented = false;
-  for (let attempt = 0; attempt < 4 && !presented; attempt += 1) {
-    presented = renderer.render();
-  }
-  if (!presented) {
-    throw new Error("host raster renderer could not present an applied execution delta");
-  }
-  await waitForPaint();
-  return true;
-}
-
-async function load(source, loopDurationSeconds, { mode = "semantic" } = {}) {
+async function load(source, loopDurationSeconds) {
   await readyPromise;
   if (typeof source !== "string" || source.trim() === "") {
     throw new TypeError("host raster source must be non-empty");
@@ -48,96 +27,60 @@ async function load(source, loopDurationSeconds, { mode = "semantic" } = {}) {
   if (!Number.isFinite(loopDuration) || loopDuration <= 0) {
     throw new RangeError("host raster loop duration must be positive and finite");
   }
-  if (renderer !== null || engine !== null || execution !== null) {
+  if (execution !== null) {
     throw new Error("host raster page supports one authored scene per page");
   }
 
-  if (mode === "semantic") {
-    let resolveAttached;
-    let rejectAttached;
-    const attached = new Promise((resolve, reject) => {
-      resolveAttached = resolve;
-      rejectAttached = reject;
-    });
-    const sourceRun = client.run(source, {}, {
-      async onSemanticContinuation(registration) {
-        if (execution !== null) throw new Error("raster source registered a second execution context");
-        execution = new AuthoringExecutionClient(canvas);
-        await execution.startSemanticExecution(registration.semanticExecution, {
-          authoringClient: client,
-          loopDurationSeconds: loopDuration,
-          transportMode: "transferable",
-          pacing: "external_samples",
-        });
-        resolveAttached();
-      },
-    });
-    sourceRun.then((result) => {
-      authoredDuration = result.duration;
-      if (execution === null) rejectAttached(new Error("raster source produced no continuation"));
-    }, (error) => {
-      sourceFailure = error;
-      rejectAttached(error);
-    });
-    await attached;
-    await execution.sampleToAuthoredTime(0);
-    const metrics = (await execution.metrics()).metrics;
-    return {
-      kind: "semantic_execution",
-      duration: authoredDuration,
-      objectCount: metrics.objectCount,
-      rendererBackend: metrics.backend,
-    };
-  }
-  if (mode !== "document") throw new Error(`unsupported raster mode ${mode}`);
-
-  // This #959-owned codec/renderer diagnostic explicitly consumes a scene
-  // document. Canonical callback execution is qualified by the shared-authoring
-  // and direct Rust/WASM proofs without this legacy document adapter.
-  const result = await client.run(source, {}, { exportDocument: true });
-  if (result.kind !== "scene_document") {
-    throw new Error("host raster harness requires a scene document");
-  }
-
-  const sceneJson = JSON.stringify(result.document);
-  engine = new EngineScenePlayer(sceneJson, loopDuration, 1);
-  if (result.callbacks !== null) {
-    throw new Error("document raster fixtures cannot execute host callbacks");
-  }
-  authoredDuration = Number(result.duration);
-
-  // The initial execution delta already carries either the scene's semantic camera
-  // state or the shared default camera. Do not overwrite it with a harness-local
-  // fixed camera; moving-camera fixtures must exercise the production camera role.
-  const initialDelta = engine.initialDeltaJson();
-  renderer = await ExecutionCanvasRenderer.create(canvas.transferControlToOffscreen(), initialDelta);
-  renderer.resize(canvas.width, canvas.height);
-  let presented = false;
-  for (let attempt = 0; attempt < 4 && !presented; attempt += 1) {
-    presented = renderer.render();
-  }
-  if (!presented) {
-    throw new Error("host raster renderer could not present its initial snapshot");
-  }
-  await waitForPaint();
-
+  let resolveAttached;
+  let rejectAttached;
+  const attached = new Promise((resolve, reject) => {
+    resolveAttached = resolve;
+    rejectAttached = reject;
+  });
+  const sourceRun = client.run(source, {}, {
+    async onSemanticContinuation(registration) {
+      if (execution !== null) throw new Error("raster source registered a second execution context");
+      execution = new AuthoringExecutionClient(canvas);
+      await execution.startSemanticExecution(registration.semanticExecution, {
+        authoringClient: client,
+        loopDurationSeconds: loopDuration,
+        transportMode: "transferable",
+        pacing: "external_samples",
+      });
+      resolveAttached();
+    },
+  });
+  sourceRun.then((result) => {
+    authoredDuration = result.duration;
+    if (execution === null) rejectAttached(new Error("raster source produced no continuation"));
+  }, (error) => {
+    sourceFailure = error;
+    rejectAttached(error);
+    execution?.terminate();
+  });
+  await attached;
+  await sampleSharedSource(0);
+  const metrics = (await execution.metrics()).metrics;
   return {
-    kind: result.kind,
+    kind: "semantic_execution",
     duration: authoredDuration,
-    objectCount: result.document.objects.length,
-    rendererBackend: renderer.rendererBackend(),
+    objectCount: metrics.objectCount,
+    rendererBackend: metrics.backend,
   };
 }
 
-async function advanceOneFrame(frameIndex, time) {
+async function sampleSharedSource(time) {
   if (sourceFailure !== null) throw sourceFailure;
-  if (execution !== null) {
-    const sampled = await execution.sampleToAuthoredTime(time);
-    currentLogicalTime = sampled.time;
-  } else {
-    await presentDelta(engine.tickDeltaJson(time * 1000));
-    currentLogicalTime = time;
+  try {
+    return await execution.sampleToAuthoredTime(time);
+  } catch (error) {
+    throw sourceFailure ?? error;
   }
+}
+
+async function advanceOneFrame(frameIndex, time) {
+  const sampled = await sampleSharedSource(time);
+  currentLogicalTime = sampled.time;
   currentFrameIndex = frameIndex;
 }
 
@@ -159,7 +102,7 @@ function normalizeFrameTimes(frameTimes, targetFrame) {
 }
 
 async function renderThrough(frameIndex, frameTimes) {
-  if (execution === null && (renderer === null || engine === null)) {
+  if (execution === null) {
     throw new Error("host raster scene has not been loaded");
   }
   const targetFrame = Number(frameIndex);
@@ -188,35 +131,14 @@ async function renderThrough(frameIndex, frameTimes) {
   }
   await waitForPaint();
 
-  if (execution !== null) {
-    const metrics = (await execution.metrics()).metrics;
-    return {
-      error: null,
-      presented: true,
-      time: currentLogicalTime,
-      objectCount: metrics.objectCount,
-      rendererBackend: metrics.backend,
-      drawCalls: metrics.drawCalls,
-      authoredDuration,
-      frameIndex: currentFrameIndex,
-    };
-  }
-
+  const metrics = (await execution.metrics()).metrics;
   return {
     error: null,
     presented: true,
-    // Logical scene time advances every reference frame even when the execution
-    // transport correctly emits no visual delta (for example a zero-dt updater
-    // activation boundary). Keep the renderer's last-delta time separately for
-    // diagnostics instead of treating it as the authoritative playhead.
     time: currentLogicalTime,
-    rendererTime: renderer.time(),
-    objectCount: renderer.objectCount(),
-    rendererBackend: renderer.rendererBackend(),
-    drawCalls: renderer.lastDrawCalls(),
-    instances: renderer.lastInstancesDrawn(),
-    uploadBytes: renderer.lastBytesUploaded(),
-    geometryCacheMisses: renderer.lastGeometryCacheMisses(),
+    objectCount: metrics.objectCount,
+    rendererBackend: metrics.backend,
+    drawCalls: metrics.drawCalls,
     authoredDuration,
     frameIndex: currentFrameIndex,
   };

--- a/web/python/_manim_animation_options.py
+++ b/web/python/_manim_animation_options.py
@@ -104,91 +104,19 @@ def resolve(
     )
 
 
-def _scale_in_place_builder(
-    mobject: object,
-    scale_factor: float,
-    animation_kwargs: dict[str, Any],
-) -> object:
-    """Lower Manim's ApplyMethod-based scale helpers to a deferred target builder.
+class ScaleInPlace:
+    """Defer shared target construction until play begins, like Manim ApplyMethod."""
 
-    ManimCE v0.21 implements ``ScaleInPlace`` as ``ApplyMethod(mobject.scale, factor)``.
-    ``ApplyMethod.create_target``
-    runs from ``Transform.begin()``, so the target must be copied from the mobject state
-    that exists when ``Scene.play`` begins rather than when the animation is constructed.
-    For a single 2D leaf, Noon's authored scene state plus the ordinary target-state
-    Transform path represents the same endpoint/interpolation without a new playback path.
-    """
-
-    if not isinstance(mobject, (_base.Mobject, _compat.Group)):
-        raise TypeError("ScaleInPlace target must be a Mobject or Group")
-
-    factor = float(scale_factor)
-    if not math.isfinite(factor):
-        raise ValueError("scale factor must be finite")
-
-    # Import lazily to avoid a cycle: this adapter is imported by _manim_animate.
-    # Calls happen only after the animation module has finished installing its aligned
-    # builder. Subclassing that builder keeps implicit binding, rollback, shared option
-    # resolution, and shared Transform lowering unchanged while deferring only target
-    # materialization to the point where the scheduler asks for ``animation.target``.
-    import _manim_animate as _animate
-
-    builder_base = (
-        _animate._AlignedGroupAnimationBuilder
-        if isinstance(mobject, _compat.Group)
-        else _animate._AlignedAnimationBuilder
-    )
-
-    class _DeferredScaleBuilder(builder_base):
-        def __init__(self) -> None:
-            # Do not call _AlignedAnimationBuilder.__init__: its normal .animate path
-            # eagerly copies the source because chained methods are authored immediately.
-            # ApplyMethod-family wrappers instead copy at Transform.begin/play time.
-            self.source = mobject
-            self.mobject = mobject
-            self.scale_factor = factor
-            self.anim_args = dict(animation_kwargs)
-            self.cannot_pass_args = True
-            self.is_chaining = False
-
-        @property
-        def target(self) -> object:
-            source = self.source
-            if isinstance(source, _compat.Group):
-                target = source._copy_for_animate_target()
-                target.scale(self.scale_factor)
-                return target
-            if (
-                getattr(source, "_semantic_handle", None) is not None
-                and getattr(source, "_semantic_handle_fresh", False)
-                and getattr(getattr(source, "_scene", None), "_canonical_authoring_context", None)
-                is not None
-            ):
-                target = source._copy_for_animate_target()
-                target.scale(self.scale_factor)
-                return target
-            scene = source._scene
-            obj = source._object
-            if scene is not None and obj is not None:
-                # _aligned_scene_play binds method-animation sources before expanding
-                # them. The cursor is therefore the Manim-compatible play-begin time and
-                # the snapshot includes all earlier authored animations.
-                snapshot = scene._snapshot_for_object_at(obj, scene._cursor)
-                target = _animate._snapshot_mobject(snapshot)
-            else:
-                # This fallback is mainly useful for introspection outside Scene.play;
-                # normal scheduling reaches the bound snapshot branch above.
-                target = source.copy()
-            target.scale(self.scale_factor)
-            return target
-
-    return _DeferredScaleBuilder()
-
-
-def ScaleInPlace(mobject: object, scale_factor: float, **kwargs: Any) -> object:
-    """Scale one detached or bound 2D leaf in place using Manim timing options."""
-
-    return _scale_in_place_builder(mobject, scale_factor, kwargs)
+    def __init__(self, mobject: object, scale_factor: float, **kwargs: Any) -> None:
+        if not isinstance(mobject, (_base.Mobject, _compat.Group)):
+            raise TypeError("ScaleInPlace target must be a Mobject or Group")
+        factor = float(scale_factor)
+        if not math.isfinite(factor):
+            raise ValueError("scale factor must be finite")
+        self.source = mobject
+        self.mobject = mobject
+        self.scale_factor = factor
+        self.anim_args = dict(kwargs)
 
 
 class ShrinkToCenter:

--- a/web/python/_manim_canonical_scene.py
+++ b/web/python/_manim_canonical_scene.py
@@ -1569,7 +1569,7 @@ def _canonical_composition_shape(scene: _base.Scene, args: tuple[object, ...]):
             return "parallel", args, None
         if isinstance(animation, (_animate._AlignedGroupAnimationBuilder, _animate.Indicate)):
             return "parallel", args, None
-        if type(animation) in (_rotate.Rotate, _rotate.Rotating, _rotate.FocusOn):
+        if type(animation) in (_rotate.Rotate, _rotate.Rotating, _rotate.FocusOn, _options.ScaleInPlace):
             return "parallel", args, None
         affine = _canonical_affine_animation(scene, animation)
         if affine is not None and affine[0]._scene is None:
@@ -1998,6 +1998,23 @@ def _build_canonical_composition_candidate(
             nested_kind = "sequence" if isinstance(animation, _composition.Succession) else "parallel"
             nested = build(nested_kind, tuple(animation.animations), animation, {})
             builder.appendComposition(nested)
+            return
+        if type(animation) is _options.ScaleInPlace:
+            # Resolve options before creating a target. Copy/scale and effective
+            # play-begin state belong to the shared semantic operations.
+            _canonical_composition_child_options(animation, child_kwargs)
+            source = animation.source
+            if isinstance(source, _compat.Group):
+                if not _compat._leaf_mobjects(source) or any(
+                    member._scene is not self for member in _compat._leaf_mobjects(source)
+                ):
+                    raise NotImplementedError("ScaleInPlace family must belong to this Scene")
+            elif source._scene not in (None, self):
+                raise ValueError("ScaleInPlace target belongs to another Scene")
+            target = source._copy_for_animate_target()
+            target.scale(animation.scale_factor)
+            transform = _base.Transform(source, target, **animation.anim_args)
+            append_leaf(builder, transform, child_kwargs)
             return
         if _canonical_tracker_builder(animation):
             tracker = animation.tracker

--- a/web/python/examples/manim_parity_scale_in_place.py
+++ b/web/python/examples/manim_parity_scale_in_place.py
@@ -6,12 +6,12 @@
 
 from noon import *
 
-scene = Scene()
-square = Square(
-    side_length=1.5,
-    fill_color=BLUE,
-    fill_opacity=1.0,
-    stroke_opacity=0.0,
-).shift(LEFT * 1.25)
-scene.play(ScaleInPlace(square, 1.75))
-result = scene
+class ScaleInPlaceSquare(Scene):
+    def construct(self):
+        square = Square(
+            side_length=1.5,
+            fill_color=BLUE,
+            fill_opacity=1.0,
+            stroke_opacity=0.0,
+        ).shift(LEFT * 1.25)
+        self.play(ScaleInPlace(square, 1.75))

--- a/web/python/examples/ordinary_scale_in_place.py
+++ b/web/python/examples/ordinary_scale_in_place.py
@@ -1,0 +1,14 @@
+"""Paired with Rust scale_in_place: capture the target after the earlier play."""
+from noon import Color, Scene, ScaleInPlace, Square, linear
+
+
+class OrdinaryScaleInPlace(Scene):
+    def construct(self):
+        square = Square(side_length=1.0, fill_color=Color(0, 0, 1),
+                        fill_opacity=1.0, stroke_opacity=0.0).shift((-0.5, 0.25))
+        self.add(square)
+        deferred = ScaleInPlace(square, 2.0, run_time=0.75, rate_func=linear)
+        self.play(square.animate.shift((1.5, -0.25)), run_time=0.25, rate_func=linear)
+        self.play(deferred)
+        assert tuple(square.get_center()) == (1.0, 0.0)
+        assert abs(square.width - 2.0) < 1e-6

--- a/web/python/test_manim_scale_in_place.py
+++ b/web/python/test_manim_scale_in_place.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 
 class ManimScaleInPlaceTests(unittest.TestCase):
-    def test_scale_in_place_uses_retained_target_state_transform(self) -> None:
+    def test_scale_in_place_is_inert_until_shared_play(self) -> None:
         python_dir = Path(__file__).resolve().parent
         env = os.environ.copy()
         existing_pythonpath = env.get("PYTHONPATH")
@@ -87,80 +87,17 @@ class ManimScaleInPlaceTests(unittest.TestCase):
                 linear,
             )
 
-            scene = Scene()
-            rect = Rectangle(
-                width=2.0,
-                height=1.0,
-                fill_color=BLUE,
-                fill_opacity=1.0,
-                stroke_opacity=0.0,
-            ).shift((1.25, -0.75)).rotate(0.2)
+            rect = Rectangle(width=2.0, height=1.0)
             animation = ScaleInPlace(rect, 1.75, run_time=2.0, rate_func=linear)
+            assert type(animation) is ScaleInPlace
             assert animation.source is rect
-            assert animation.anim_args["run_time"] == 2.0
-            assert animation.anim_args["rate_func"] is linear
-
-            # Manim ApplyMethod creates its target in Transform.begin(), not in the
-            # animation constructor. Mutations after construction must therefore be
-            # reflected in both the source and scaled target when Scene.play begins.
-            rect.shift((0.5, 0.25)).scale(1.2)
-            scene.play(animation)
-            assert abs(scene.time - 2.0) < 1e-12
-            assert rect._scene is scene
-            tracks = [
-                track
-                for track in scene.to_document()["tracks"]
-                if track["object"] == rect.id and track["property"] == "transform"
-            ]
-            assert len(tracks) == 1
-            track = tracks[0]
-            assert abs(track["timing"]["duration"] - 2.0) < 1e-12
-            assert track["timing"]["easing"] == "linear"
-            start = track["values"]["object"]["from"]["transform"]
-            target = track["values"]["object"]["to"]["transform"]
-            assert start["translation"] == {"x": 1.75, "y": -0.5}
-            assert target["translation"] == start["translation"]
-            assert abs(start["rotation"] - 0.2) < 1e-12
-            assert abs(target["rotation"] - 0.2) < 1e-12
-            assert abs(target["scale"]["x"] - 1.75 * start["scale"]["x"]) < 1e-12
-            assert abs(target["scale"]["y"] - 1.75 * start["scale"]["y"]) < 1e-12
-
-            # A retained animation authored after the ScaleInPlace object was created
-            # must also be visible. This proves target construction uses the retained
-            # play-begin snapshot rather than merely copying the Python wrapper lazily.
-            retained_scene = Scene()
-            retained = Square(
-                side_length=1.0,
-                fill_color=BLUE,
-                fill_opacity=1.0,
-                stroke_opacity=0.0,
-            ).shift((-0.5, 0.25))
-            deferred = ScaleInPlace(retained, 2.0, run_time=0.75, rate_func=linear)
-            retained_scene.play(
-                retained.animate(rate_func=linear).shift((1.5, -0.25)),
-                run_time=0.25,
-            )
-            retained_scene.play(deferred)
-            assert abs(retained_scene.time - 1.0) < 1e-12
-            retained_tracks = [
-                track
-                for track in retained_scene.to_document()["tracks"]
-                if track["object"] == retained.id and track["property"] == "transform"
-            ]
-            assert len(retained_tracks) == 2
-            scale_track = max(retained_tracks, key=lambda item: item["timing"]["start_time"])
-            assert abs(scale_track["timing"]["start_time"] - 0.25) < 1e-12
-            retained_start = scale_track["values"]["object"]["from"]["transform"]
-            retained_target = scale_track["values"]["object"]["to"]["transform"]
-            assert retained_start["translation"] == {"x": 1.0, "y": 0.0}
-            assert retained_target["translation"] == retained_start["translation"]
-            assert abs(retained_target["scale"]["x"] - 2.0 * retained_start["scale"]["x"]) < 1e-12
-            assert abs(retained_target["scale"]["y"] - 2.0 * retained_start["scale"]["y"]) < 1e-12
-
+            assert animation.scale_factor == 1.75
+            assert animation.anim_args == {"run_time": 2.0, "rate_func": linear}
+            # Construction is metadata only; shared play owns target creation.
+            assert not hasattr(animation, "target")
+            assert rect._scene is None
             family = VGroup(Square(), Square())
-            family_animation = ScaleInPlace(family, 2.0)
-            assert family_animation.source is family
-            assert family_animation.scale_factor == 2.0
+            assert ScaleInPlace(family, 2.0).source is family
 
             try:
                 ScaleInPlace(Square(), float("nan"))


### PR DESCRIPTION
The raster differential corpus previously authored most fixtures through a separate export/manual-construct path. All 43 fixtures now use the normal Python continuation and shared Rust execution host, sampling the unchanged pinned Manim frame times before completing the logical endpoint.

This advances #959 A4.7/A4.8 and #958. The switch exposed and fixes three correctness problems:
- `FadeIn` now treats leaves and nested families with unmounted ancestors as detached, using shared scene reachability. Mounted targets remain rejected before publication.
- `ScaleInPlace` is an inert Python facade over shared play-begin target copy, scale, and Transform operations. The Python snapshot fallback is deleted. Equivalent executable Rust/native, direct Rust/WASM, and Python examples capture a preceding movement before scaling.
- The retained renderer resets its painter-order cache when returning from compact mixed-frame indices to source-frame geometry indices. Subsequent updates still apply only changed ranges.

The raster host propagates late Python failures to pending samples and deletes its unused document-renderer path and duplicate main-thread WASM initialization. The runner bounds startup/capture, preserves per-fixture errors in its report, and shares only browser cache between isolated pages. Existing visual thresholds and report-only raster policy are unchanged; execution failures are fatal.

Ownership remains shared Rust semantics/runtime and derived renderer caches. No new migration seam, semantic authority, scheduler, or in-process serialization boundary. The renderer resets order only when its index representation changes; ordinary property/order updates retain their local path.

Validation:
- Full local gate: `CARGO_TARGET_DIR=/Users/ykshin/Dev/me/noon/target CARGO_INCREMENTAL=0 NOON_SKIP_WEB_PREFLIGHT=1 NOON_SKIP_PLAYGROUND_TEST=1 NOON_WASM_PROFILE=dev bash scripts/check.sh full` — 1,812 Rust tests and browser package validation passed.
- After the final renderer correction: same Cargo environment with `bash scripts/check.sh fmt-lint`, `cargo test --workspace --all-features --lib gpu::` (68 passed), and the same web environment with `bash scripts/check.sh web` passed.
- `NOON_WEB_PREFLIGHT_ONLY=1 NOON_SKIP_PLAYGROUND_TEST=1 bash scripts/check.sh web` — 186 Python tests plus Node checks passed. `bash scripts/architecture-ratchet.sh 7dc4c659d8ba96441443fac007d4c12b2729ea28` passed.
- `node scripts/shared-authoring-smoke.mjs` passed, including the paired deferred-scale example and pending-sample rejection after a source error.
- All 43 fixtures qualified on WebGPU and WebGL: a full batch covered 42, followed by the failed lagged-fade fixture after the renderer correction. Its worst pixel difference is 0.09%; ScaleInPlace is 0.10%. `node scripts/manim-raster-enforce.mjs` passed all 43 fixtures using the combined evidence report, with provenance identifying the follow-up. No thresholds changed. MixedObjectParityStress remains about 8.01% different, within its existing 12% fixture budget.
- Local raster runs used a private copy of the public runner with only the repository root and reference loader changed, plus a one-fixture filter for the follow-up. References are genuine pinned Cairo output from CI run 34173869732/artifact 10036732269; fixture sources are unchanged from d00cb08e. The public CI runner still generates references normally.
- `NOON_BROWSER_SMOKE_BACKEND=webgpu node scripts/browser-smoke.mjs` and `NOON_BROWSER_SMOKE_BACKEND=webgl node scripts/browser-smoke.mjs` passed, including direct Rust/WASM deferred scaling and the broader mixed renderer proofs.

Remaining #959 work: the separate semantic-state comparison script still uses its old authoring/replay path. The next slice will consume debug snapshots from these same shared runtime captures and delete that duplicate pass. This PR does not claim Phase A or full visual parity complete.
