### PR TITLE
Compare semantic state from the shared raster captures

### DIFF
--- a/crates/noon-web/src/canonical_authoring_scene.rs
+++ b/crates/noon-web/src/canonical_authoring_scene.rs
@@ -5206,6 +5206,15 @@ mod wasm {
                 .map_err(js_error)
         }
 
+        /// Read the returned owner's current frame without creating or advancing a player.
+        #[wasm_bindgen(js_name = liveDebugFrameJson)]
+        pub fn live_debug_frame_json(&mut self) -> Result<String, JsValue> {
+            self.inner
+                .active_live_player()
+                .map(|player| player.debug_frame_json())
+                .map_err(js_error)
+        }
+
         #[wasm_bindgen(js_name = liveHandoffDuration)]
         pub fn live_handoff_duration(&self) -> Option<f64> {
             self.inner.live_handoff_duration()

--- a/crates/noon-web/src/lib.rs
+++ b/crates/noon-web/src/lib.rs
@@ -77,4 +77,3 @@ pub use retained_text_family_transport::*;
 #[cfg(all(feature = "renderer", target_arch = "wasm32"))]
 pub use retained_typst_canvas::*;
 pub use semantic_execution_player::*;
-pub use semantic_snapshot::*;

--- a/crates/noon-web/src/semantic_execution_player.rs
+++ b/crates/noon-web/src/semantic_execution_player.rs
@@ -2375,6 +2375,12 @@ impl SemanticExecutionPlayer {
             .ok_or_else(|| "initial snapshot missing".into())
     }
 
+    /// Explicit read-only diagnostics; never used to drive or reconstruct execution.
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen(js_name = debugFrameJson))]
+    pub fn debug_frame_json(&self) -> String {
+        crate::semantic_snapshot::execution_frame_value(&self.session).to_string()
+    }
+
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen(js_name = resourceBundleBytes))]
     pub fn resource_bundle_bytes(&self) -> Vec<u8> {
         self.resource_bundle.clone()

--- a/crates/noon-web/src/semantic_snapshot.rs
+++ b/crates/noon-web/src/semantic_snapshot.rs
@@ -1,7 +1,6 @@
-use noon_compile::{CompileError, CompiledScene};
-use noon_core::{Color, Rect};
-use noon_ir::{decode_scene, IrError};
-use noon_runtime::{EvaluationError, FrameState, SlottedSceneInstance};
+//! Explicit diagnostic codec over the current shared execution frame.
+use noon::ExecutionSession;
+use noon_core::{Color, GeometryRef, GeometryResource, GeometryResourceLookup, Rect, Vec2};
 use serde_json::{json, Value};
 
 fn paint_json(color: Option<Color>, opacity: f32) -> Value {
@@ -28,149 +27,118 @@ fn bounds_json(bounds: Option<Rect>) -> Value {
     }
 }
 
-#[derive(Debug)]
-pub enum SemanticSnapshotError {
-    Ir(IrError),
-    Compile(CompileError),
-    Evaluation(EvaluationError),
-}
-
-impl std::fmt::Display for SemanticSnapshotError {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Ir(error) => error.fmt(formatter),
-            Self::Compile(error) => error.fmt(formatter),
-            Self::Evaluation(error) => error.fmt(formatter),
-        }
-    }
-}
-
-impl std::error::Error for SemanticSnapshotError {}
-
-impl From<IrError> for SemanticSnapshotError {
-    fn from(value: IrError) -> Self {
-        Self::Ir(value)
-    }
-}
-
-impl From<CompileError> for SemanticSnapshotError {
-    fn from(value: CompileError) -> Self {
-        Self::Compile(value)
-    }
-}
-
-impl From<EvaluationError> for SemanticSnapshotError {
-    fn from(value: EvaluationError) -> Self {
-        Self::Evaluation(value)
-    }
-}
-
-pub fn semantic_frame_value(frame: &FrameState) -> Value {
-    let objects = frame
-        .objects
+pub(crate) fn execution_frame_value(session: &ExecutionSession) -> Value {
+    let frame = session.frame();
+    let objects = session
+        .painter_order()
         .iter()
-        .enumerate()
-        .map(|(index, object)| {
-            let geometry = frame.render_geometry(index).cloned();
+        .map(|&index| {
+            let index = index as usize;
+            let object = &frame.objects[index];
+            let transform = frame.render_transform(index);
+            // Resource resolution is diagnostic work only. Engine layers continue
+            // sharing immutable typed resources; this snapshot cannot update them.
+            let geometry = match frame.render_geometry(index) {
+                Some(GeometryRef::External(id)) => session
+                    .geometry_resources()
+                    .current_handle(*id)
+                    .and_then(|handle| session.geometry_resources().get(handle))
+                    .map(|resource| match resource {
+                        GeometryResource::VectorPath(path) => {
+                            GeometryRef::VectorPath((**path).clone())
+                        }
+                    }),
+                geometry => geometry.cloned(),
+            };
             let bounds = geometry
                 .as_ref()
-                .and_then(|geometry| geometry.world_bounds(object.transform));
-            let center = bounds
-                .map(Rect::center)
-                .unwrap_or(object.transform.translation);
-            let effective_opacity = object.style.opacity * object.appearance;
+                .and_then(|geometry| geometry.world_bounds(transform))
+                .or_else(|| {
+                    object.text_bounds.and_then(|bounds| {
+                        Rect::from_points(
+                            [
+                                bounds.min,
+                                Vec2::new(bounds.max.x, bounds.min.y),
+                                bounds.max,
+                                Vec2::new(bounds.min.x, bounds.max.y),
+                            ]
+                            .map(|point| transform.transform_point(point)),
+                        )
+                    })
+                });
+            let center = bounds.map(Rect::center).unwrap_or(transform.translation);
+            let opacity = object.style.opacity * object.appearance;
             json!({
-                "id": object.id.get(),
-                "present": frame.is_present(index),
-                "center": [center.x, center.y],
-                "bounds": bounds_json(bounds),
-                "geometry": geometry,
-                "transform": object.transform,
-                "fill": paint_json(object.style.fill, effective_opacity),
-                "stroke": paint_json(object.style.stroke, effective_opacity),
+                "id": object.id.get(), "present": frame.is_present(index),
+                "center": [center.x, center.y], "bounds": bounds_json(bounds),
+                "transform": transform,
+                "fill": paint_json(object.style.fill, opacity),
+                "stroke": paint_json(object.style.stroke, opacity),
                 "stroke_width": object.style.stroke_width,
                 "stroke_width_mode": object.style.stroke_width_mode,
-                "stroke_join": object.style.stroke_join,
-                "stroke_cap": object.style.stroke_cap,
-                "style_opacity": object.style.opacity,
-                "appearance": object.appearance,
-                "reveal": frame.reveal(index),
-                "morph": frame.morph(index),
+                "stroke_join": object.style.stroke_join, "stroke_cap": object.style.stroke_cap,
+                "style_opacity": object.style.opacity, "appearance": object.appearance,
+                "reveal": frame.reveal(index), "morph": frame.morph(index),
             })
         })
         .collect::<Vec<_>>();
-
     json!({
-        "engine": "noon",
-        "time": frame.time,
-        "present_object_count": frame
-            .presences
-            .iter()
-            .copied()
-            .filter(|present| *present)
-            .count(),
+        "engine": "noon", "time": frame.time,
+        "publication": session.publication_context(),
+        "present_object_count": objects.iter().filter(|object| object["present"] == true).count(),
         "objects": objects,
     })
 }
 
-pub fn semantic_frame_json(scene_json: &str, time: f64) -> Result<String, SemanticSnapshotError> {
-    let definition = decode_scene(scene_json)?;
-    let compiled = CompiledScene::compile(&definition)?;
-    let mut runtime = SlottedSceneInstance::new(compiled);
-    runtime.seek(time)?;
-    Ok(semantic_frame_value(runtime.frame()).to_string())
-}
-
-#[cfg(target_arch = "wasm32")]
-mod wasm {
-    use wasm_bindgen::prelude::*;
-
-    #[wasm_bindgen(js_name = semanticFrameJson)]
-    pub fn wasm_semantic_frame_json(scene_json: &str, time: f64) -> Result<String, JsValue> {
-        super::semantic_frame_json(scene_json, time)
-            .map_err(|error| JsValue::from_str(&error.to_string()))
-    }
-}
-
-#[cfg(target_arch = "wasm32")]
-pub use wasm::*;
-
 #[cfg(test)]
 mod tests {
-    use noon_core::{Color, GeometryRef, Transform2D, Vec2};
-    use noon_ir::encode_scene;
-
     use super::*;
+    use noon::{AnimationOptions, LiveProgramStatus, RateFunction, RustHostCallbackTable, Scene};
 
     #[test]
-    fn semantic_snapshot_reports_runtime_state_used_by_rendering() {
-        let mut scene = noon_core::SceneDefinition::new();
-        let circle = scene.add(GeometryRef::circle(1.0));
-        let object = scene.object_mut(circle).expect("circle exists");
-        object.transform = Transform2D {
-            translation: Vec2::new(2.0, -1.0),
-            scale: Vec2::new(1.5, 0.5),
-            ..Transform2D::IDENTITY
-        };
-        object.style.fill = Some(Color::rgba(0.25, 0.5, 0.75, 0.4));
-        object.style.stroke = Some(Color::rgba(1.0, 0.0, 0.0, 0.8));
-        object.style.opacity = 0.5;
-        object.style.stroke_width = 0.04;
-
-        let scene_json = encode_scene(&scene).expect("scene serializes");
-        let snapshot = semantic_frame_json(&scene_json, 0.0).expect("snapshot succeeds");
-        let value: Value = serde_json::from_str(&snapshot).expect("snapshot is JSON");
-
-        assert_eq!(value["engine"], "noon");
+    fn debug_capture_reads_the_current_shared_frame_without_advancing_it() {
+        let mut program = noon::example_scenes::scale_in_place::program().unwrap();
+        let mut callbacks = RustHostCallbackTable::new();
+        assert!(matches!(
+            program.resume().unwrap(),
+            LiveProgramStatus::Awaiting(_)
+        ));
+        program.drive_to(&mut callbacks, 0.125).unwrap();
+        let before = program.session().publication_context();
+        let value = execution_frame_value(program.session());
+        assert_eq!(value["time"], 0.125);
         assert_eq!(value["present_object_count"], 1);
-        assert_eq!(value["objects"][0]["present"], true);
-        assert_eq!(value["objects"][0]["center"][0], 2.0);
-        assert_eq!(value["objects"][0]["center"][1], -1.0);
-        assert_eq!(value["objects"][0]["bounds"]["width"], 3.0);
-        assert_eq!(value["objects"][0]["bounds"]["height"], 1.0);
+        assert_eq!(value["objects"][0]["center"][0], 0.25);
+        assert_eq!(value["objects"][0]["center"][1], 0.125);
+        assert_eq!(program.session().publication_context(), before);
+    }
+
+    #[test]
+    fn debug_capture_resolves_retained_paths_and_effective_transforms() {
+        let mut scene = Scene::new();
+        let mut shape =
+            noon::Mobject::manim_square(std::rc::Rc::clone(scene.store()), 2.0).unwrap();
+        shape.set_fill_color(0.25, 0.5, 0.75, 0.4).unwrap();
+        shape.set_fill_opacity(0.4).unwrap();
+        shape.set_object_opacity(0.5).unwrap();
+        scene.add(&shape).unwrap();
+        let mut target = shape.target_editor().unwrap();
+        target.set_translation(2.0, -1.0).unwrap();
+        let mut session = scene.execution_session().unwrap();
+        let mut live = scene.live(&mut session);
+        let segment = live
+            .declare_and_activate_transform_to(
+                &shape,
+                &target,
+                AnimationOptions::new()
+                    .run_time(1.0)
+                    .rate_func(RateFunction::Linear),
+            )
+            .unwrap();
+        live.advance_segment_to(segment, 0.5).unwrap();
+        let value = execution_frame_value(&session);
+        assert_eq!(value["objects"][0]["center"], json!([1.0, -0.5]));
+        assert_eq!(value["objects"][0]["bounds"]["width"], 2.0);
         assert!((value["objects"][0]["fill"]["alpha"].as_f64().unwrap() - 0.2).abs() < 1e-6);
-        assert!((value["objects"][0]["stroke"]["alpha"].as_f64().unwrap() - 0.4).abs() < 1e-6);
-        assert!((value["objects"][0]["stroke_width"].as_f64().unwrap() - 0.04).abs() < 1e-6);
-        assert_eq!(value["objects"][0]["reveal"], 1.0);
     }
 }

--- a/scripts/check-web-package.mjs
+++ b/scripts/check-web-package.mjs
@@ -138,6 +138,8 @@ const expectedJavascriptSurface = [
   "ordinaryWait(",
   "beginOrdinaryWait(",
   "liveExecutionOwnership(",
+  "liveDebugFrameJson(",
+  "debugFrameJson(",
   "liveTargetEditor(",
   "beginLiveFamilyTarget(",
   "finishLiveFamilyTarget(",

--- a/scripts/manim-raster-differential.mjs
+++ b/scripts/manim-raster-differential.mjs
@@ -269,7 +269,9 @@ async function captureHostFixture(page, fixture, referenceResult, fixtureDir, ex
     await page.evaluate(() => new Promise((resolve) => requestAnimationFrame(resolve)));
     const outputPath = path.join(fixtureDir, `${sample.label}.png`);
     await page.locator("#scene").screenshot({ path: outputPath });
-    captures.push({ ...sample, noonPath: outputPath, metrics });
+    const debugFrame = await page.evaluate(() => window.noonHostRaster.debugFrame());
+    assert.equal(debugFrame.time, metrics.time, `${fixture.id}: diagnostic/raster time`);
+    captures.push({ ...sample, noonPath: outputPath, metrics, debugFrame });
   }
   const completed = await page.evaluate((times) =>
     window.noonHostRaster.renderThrough(times.length - 1, times), frameTimes);
@@ -474,6 +476,7 @@ async function compareAll(references, backendResults) {
           time: capture.time,
           reference: referenceStats,
           noon: noonStats,
+          debugFrame: capture.debugFrame,
           boundsDelta: bboxDelta(referenceStats, noonStats),
           diff: {
             differingPixels: diff.differingPixels,

--- a/scripts/manim-raster-semantic-state.mjs
+++ b/scripts/manim-raster-semantic-state.mjs
@@ -1,64 +1,21 @@
 import assert from "node:assert/strict";
-import { spawn, spawnSync } from "node:child_process";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import playwright from "playwright";
-
-const { chromium } = playwright;
-const scriptDir = path.dirname(fileURLToPath(import.meta.url));
-const repoRoot = path.resolve(scriptDir, "..");
-const manifestPath = path.join(repoRoot, "parity", "manim-v0.21", "manifest.json");
-const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
-const reference = manifest.reference;
-const fixtureSources = new Map();
-for (const fixture of manifest.fixtures) {
-  const relativeSource = fixture.source ?? reference.source;
-  if (!fixtureSources.has(relativeSource)) {
-    fixtureSources.set(relativeSource, await readFile(path.join(repoRoot, relativeSource), "utf8"));
-  }
-}
-
-function fixtureSourceFor(fixture) {
-  const relativeSource = fixture.source ?? reference.source;
-  const source = fixtureSources.get(relativeSource);
-  assert.ok(source, `${fixture.id}: missing canonical source ${relativeSource}`);
-  return source;
-}
-
-function fixtureSourcePathFor(fixture) {
-  return path.join(repoRoot, fixture.source ?? reference.source);
-}
-const artifactRoot = path.resolve(
-  repoRoot,
-  process.env.NOON_MANIM_RASTER_ARTIFACTS ?? "manim-raster-artifacts",
-);
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const artifactRoot = path.resolve(repoRoot, process.env.NOON_MANIM_RASTER_ARTIFACTS ?? "manim-raster-artifacts");
 const reportPath = path.join(artifactRoot, "report.json");
 const semanticRoot = path.join(artifactRoot, "semantic");
-const manimSemanticPath = path.join(semanticRoot, "manim-all-frames.json");
-const semanticIndexPath = path.join(semanticRoot, "index.json");
-const port = Number(process.env.NOON_MANIM_SEMANTIC_PORT ?? "4193");
-const baseUrl = `http://127.0.0.1:${port}`;
-
-function runChecked(command, args) {
-  const result = spawnSync(command, args, {
-    cwd: repoRoot,
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"],
-  });
-  if (result.status !== 0) {
-    throw new Error(
-      `${command} ${args.join(" ")} failed (${result.status})\n${result.stdout}\n${result.stderr}`,
-    );
-  }
-  return result;
-}
-
-function noonSourceFor(fixture) {
-  const adapted = fixtureSourceFor(fixture).replace("from manim import *", "from noon import *");
-  return `${adapted}\n\nresult = ${fixture.scene}()\nresult.setup()\ntry:\n    result.construct()\nfinally:\n    result.tear_down()\n`;
-}
+const manifest = JSON.parse(await readFile(path.join(repoRoot, "parity/manim-v0.21/manifest.json"), "utf8"));
+const reference = manifest.reference;
+const report = JSON.parse(await readFile(reportPath, "utf8"));
+// The raster pass already generated this oracle and captured the shared runtime
+// at each screenshot. This step only compares artifacts; it never runs a scene.
+const manimSemantic = JSON.parse(await readFile(path.join(semanticRoot, "manim-all-frames.json"), "utf8"));
+assert.equal(manimSemantic.manim_version, reference.version);
+assert.equal(manimSemantic.frame_rate, reference.frame_rate);
+const semanticByFixture = new Map(manimSemantic.fixtures.map(fixture => [fixture.id, fixture]));
 
 function maxAbs(values) {
   return values.length === 0 ? 0 : Math.max(...values.map((value) => Math.abs(value)));
@@ -155,162 +112,54 @@ function compareSemanticStates(referenceState, noonState) {
   };
 }
 
-let serverOutput = "";
-const server = spawn(
-  "python3",
-  ["-m", "http.server", String(port), "--bind", "127.0.0.1", "--directory", repoRoot],
-  { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] },
-);
-server.stdout.on("data", (chunk) => (serverOutput += chunk));
-server.stderr.on("data", (chunk) => (serverOutput += chunk));
-
-async function waitForServer() {
-  let lastError = null;
-  for (let attempt = 0; attempt < 80; attempt += 1) {
-    try {
-      const response = await fetch(`${baseUrl}/web/manim-compat-smoke.html`);
-      if (response.ok) return;
-      lastError = new Error(`HTTP ${response.status}`);
-    } catch (error) {
-      lastError = error;
+const index = [];
+for (const fixtureReport of report.fixtures) {
+  const fixture = manifest.fixtures.find(entry => entry.id === fixtureReport.id);
+  assert.ok(fixture, `${fixtureReport.id}: raster fixture missing from manifest`);
+  const manimFixture = semanticByFixture.get(fixture.id);
+  assert.ok(manimFixture, `${fixture.id}: missing Manim semantic fixture`);
+  assert.equal(manimFixture.frame_count, fixtureReport.manim.frameCount);
+  const entries = [];
+  for (const [backend, backendReport] of Object.entries(fixtureReport.backends)) {
+    assert.ok(!backendReport.error, `${fixture.id}/${backend}: raster execution failed`);
+    for (const sample of backendReport.samples) {
+      const referenceState = manimFixture.frames[sample.frameIndex];
+      const noonState = sample.debugFrame;
+      assert.ok(referenceState, `${fixture.id}: missing reference frame ${sample.frameIndex}`);
+      assert.ok(noonState?.publication, `${fixture.id}/${backend}: missing shared runtime capture`);
+      assert.ok(Math.abs(Number(referenceState.time) - Number(sample.time)) < 1e-9);
+      assert.ok(Math.abs(Number(noonState.time) - Number(sample.time)) < 1e-9);
+      const comparison = compareSemanticStates(referenceState, noonState);
+      const label = `frame-${String(sample.frameIndex).padStart(4, "0")}`;
+      const relativePath = path.join("semantic", backend, fixture.id, `${label}.json`);
+      const outputPath = path.join(artifactRoot, relativePath);
+      await mkdir(path.dirname(outputPath), { recursive: true });
+      await writeFile(outputPath, `${JSON.stringify({
+        fixture: fixture.id, scene: fixture.scene, backend,
+        frameIndex: sample.frameIndex, time: sample.time,
+        manim: referenceState, noon: noonState, comparison,
+      }, null, 2)}\n`);
+      const summary = {
+        path: relativePath.split(path.sep).join("/"), pairing: comparison.pairing,
+        objectCountDelta: comparison.objectCountDelta,
+        maxCenterDelta: comparison.maxCenterDelta, maxBoundsDelta: comparison.maxBoundsDelta,
+        maxFillRgbaDelta: comparison.maxFillRgbaDelta, maxStrokeRgbaDelta: comparison.maxStrokeRgbaDelta,
+        maxStrokeWidthDelta: comparison.maxStrokeWidthDelta,
+        paintPresenceMismatches: comparison.paintPresenceMismatches,
+      };
+      sample.semantic = summary;
+      entries.push({ backend, frameIndex: sample.frameIndex, time: sample.time, ...summary });
     }
-    await new Promise((resolve) => setTimeout(resolve, 100));
   }
-  throw new Error(`semantic-state server did not start: ${lastError}\n${serverOutput}`);
+  index.push({ id: fixture.id, scene: fixture.scene, samples: entries });
 }
-
-await mkdir(semanticRoot, { recursive: true });
-runChecked("python3", [
-  path.join("scripts", "manim-raster-semantic-reference.py"),
-  "--manifest",
-  manifestPath,
-  "--output",
-  manimSemanticPath,
-]);
-
-try {
-  await waitForServer();
-  const report = JSON.parse(await readFile(reportPath, "utf8"));
-  const manimSemantic = JSON.parse(await readFile(manimSemanticPath, "utf8"));
-  assert.equal(manimSemantic.manim_version, reference.version, "semantic Manim version");
-  assert.equal(manimSemantic.frame_rate, reference.frame_rate, "semantic Manim frame rate");
-  const semanticByFixture = new Map(
-    manimSemantic.fixtures.map((fixture) => [fixture.id, fixture]),
-  );
-
-  const browser = await chromium.launch({
-    channel: "chromium",
-    headless: true,
-    args: ["--disable-dev-shm-usage"],
-  });
-  const index = [];
-  try {
-    const page = await browser.newPage();
-    await page.goto(`${baseUrl}/web/manim-compat-smoke.html`, { waitUntil: "load" });
-    await page.waitForFunction(() => window.noonManimCompat, null, { timeout: 30_000 });
-    await page.evaluate(() => window.noonManimCompat.ready());
-
-    for (const fixtureReport of report.fixtures) {
-      const fixture = manifest.fixtures.find((entry) => entry.id === fixtureReport.id);
-      assert.ok(fixture, `${fixtureReport.id}: raster fixture missing from manifest`);
-      const authored = await page.evaluate(
-        (source) => window.noonManimCompat.run(source),
-        noonSourceFor(fixture),
-      );
-      assert.equal(authored.kind, "scene_document", `${fixture.id}: Noon semantic authoring result`);
-      assert.equal(authored.duration, fixture.expected_duration, `${fixture.id}: Noon semantic duration`);
-      const sceneJson = JSON.stringify(authored.document);
-      const manimFixture = semanticByFixture.get(fixture.id);
-      assert.ok(manimFixture, `${fixture.id}: missing Manim semantic fixture`);
-      assert.equal(
-        manimFixture.frame_count,
-        fixtureReport.manim.frameCount,
-        `${fixture.id}: semantic/raster Manim frame count`,
-      );
-
-      const firstBackend = Object.values(fixtureReport.backends)[0];
-      const entries = [];
-      for (const sample of firstBackend.samples) {
-        const referenceState = manimFixture.frames[sample.frameIndex];
-        assert.ok(referenceState, `${fixture.id}: missing semantic frame ${sample.frameIndex}`);
-        assert.ok(
-          Math.abs(Number(referenceState.time) - Number(sample.time)) < 1e-9,
-          `${fixture.id}: semantic/raster time mismatch at frame ${sample.frameIndex}`,
-        );
-        const noonState = await page.evaluate(
-          ({ json, time }) => window.noonManimCompat.semanticFrame(json, time),
-          { json: sceneJson, time: sample.time },
-        );
-        const comparison = compareSemanticStates(referenceState, noonState);
-        const label = `frame-${String(sample.frameIndex).padStart(4, "0")}`;
-        const relativePath = path.join("semantic", fixture.id, `${label}.json`);
-        const outputPath = path.join(artifactRoot, relativePath);
-        await mkdir(path.dirname(outputPath), { recursive: true });
-        await writeFile(
-          outputPath,
-          `${JSON.stringify(
-            {
-              fixture: fixture.id,
-              scene: fixture.scene,
-              frameIndex: sample.frameIndex,
-              time: sample.time,
-              manim: referenceState,
-              noon: noonState,
-              comparison,
-            },
-            null,
-            2,
-          )}\n`,
-        );
-        const summary = {
-          path: relativePath.split(path.sep).join("/"),
-          pairing: comparison.pairing,
-          objectCountDelta: comparison.objectCountDelta,
-          maxCenterDelta: comparison.maxCenterDelta,
-          maxBoundsDelta: comparison.maxBoundsDelta,
-          maxFillRgbaDelta: comparison.maxFillRgbaDelta,
-          maxStrokeRgbaDelta: comparison.maxStrokeRgbaDelta,
-          maxStrokeWidthDelta: comparison.maxStrokeWidthDelta,
-          paintPresenceMismatches: comparison.paintPresenceMismatches,
-        };
-        for (const backendReport of Object.values(fixtureReport.backends)) {
-          const backendSample = backendReport.samples.find(
-            (entry) => entry.frameIndex === sample.frameIndex,
-          );
-          assert.ok(backendSample, `${fixture.id}: backend missing frame ${sample.frameIndex}`);
-          backendSample.semantic = summary;
-        }
-        entries.push({ frameIndex: sample.frameIndex, time: sample.time, ...summary });
-      }
-      index.push({ id: fixture.id, scene: fixture.scene, samples: entries });
-    }
-  } finally {
-    await browser.close();
-  }
-
-  report.semantic = {
-    schemaVersion: 1,
-    pairing: "top-level-render-order",
-    manimAllFrames: "semantic/manim-all-frames.json",
-    index: "semantic/index.json",
-    note:
-      "Semantic deltas are diagnostic. Existing Manim semantic differential tests and raster tolerances remain the blocking compatibility gates.",
-  };
-  await writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`);
-  await writeFile(
-    semanticIndexPath,
-    `${JSON.stringify(
-      {
-        schemaVersion: 1,
-        manimVersion: reference.version,
-        frameRate: reference.frame_rate,
-        fixtures: index,
-      },
-      null,
-      2,
-    )}\n`,
-  );
-  console.log(`Attached semantic state to ${index.length} Manim raster fixtures`);
-} finally {
-  server.kill("SIGTERM");
-}
+report.semantic = {
+  schemaVersion: 2, pairing: "top-level-render-order",
+  manimAllFrames: "semantic/manim-all-frames.json", index: "semantic/index.json",
+  note: "Read-only shared runtime captures from the raster checkpoints. Semantic deltas are diagnostic; existing raster tolerances remain the blocking gate.",
+};
+await writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`);
+await writeFile(path.join(semanticRoot, "index.json"), `${JSON.stringify({
+  schemaVersion: 2, manimVersion: reference.version, frameRate: reference.frame_rate, fixtures: index,
+}, null, 2)}\n`);
+console.log(`Attached captured semantic state to ${index.length} Manim raster fixtures`);

--- a/scripts/shared-authoring-smoke.mjs
+++ b/scripts/shared-authoring-smoke.mjs
@@ -3156,6 +3156,11 @@ result = scene
     assert.equal(rotating.objectCount, 1);
     const rotationTimes = [0, 0.625, 5];
     await rasterPage.evaluate((times) => window.noonHostRaster.renderThrough(1, times), rotationTimes);
+    const angularCapture = await rasterPage.evaluate(() => window.noonHostRaster.debugFrame());
+    assert.equal(angularCapture.time, 0.625);
+    assert.ok(angularCapture.publication);
+    assert.equal(angularCapture.objects.length, 1);
+    assert.ok(Math.abs(angularCapture.objects[0].transform.rotation - Math.PI / 4) < 1e-6);
     const diagonal = renderedWorldPixel(await rasterPage.locator("#scene").screenshot(), 0.95, 0);
     assert.ok(diagonal.blue > diagonal.red + 30, "raster host did not sample the five-second angular path");
     const rotated = await rasterPage.evaluate((times) => window.noonHostRaster.renderThrough(2, times), rotationTimes);
@@ -3163,6 +3168,9 @@ result = scene
     assert.equal(rotated.authoredDuration, 5);
     assert.equal(rotated.objectCount, 1);
     assert.equal(rotated.presented, true);
+    const completedCapture = await rasterPage.evaluate(() => window.noonHostRaster.debugFrame());
+    assert.equal(completedCapture.time, 5);
+    assert.equal(completedCapture.present_object_count, 1);
 
     await rasterPage.reload({ waitUntil: "load" });
     await rasterPage.waitForFunction(() => window.noonHostRaster, null, { timeout: 30_000 });

--- a/web/authoring-execution-client.js
+++ b/web/authoring-execution-client.js
@@ -387,6 +387,15 @@ export class AuthoringExecutionClient {
     });
   }
 
+  async debugFrame() {
+    return this.#withStablePlayer((player, mode) => {
+      if (mode !== AUTHORING_EXECUTION_SEMANTIC) {
+        throw new Error("shared execution diagnostics require semantic execution mode");
+      }
+      return player.debugFrame();
+    });
+  }
+
   async sampleToAuthoredTime(timeSeconds) {
     return this.#withStablePlayer((player, mode) => {
       if (mode !== AUTHORING_EXECUTION_SEMANTIC) {

--- a/web/execution-worker-client.js
+++ b/web/execution-worker-client.js
@@ -1049,6 +1049,12 @@ export class ExecutionWorkerClient {
     return result;
   }
 
+  async debugFrame() {
+    this.#requireSemanticMode("shared execution diagnostics");
+    const result = await this.#requestEngine("debug_frame", {});
+    return result.debugFrame;
+  }
+
   async sampleToAuthoredTime(timeSeconds) {
     this.#requireSemanticMode("external authored-time sampling");
     if (this.#semanticPacing !== SEMANTIC_PACING_EXTERNAL_SAMPLES) {

--- a/web/manim-compat-smoke.html
+++ b/web/manim-compat-smoke.html
@@ -8,7 +8,7 @@
   <body>
     <canvas id="retained-write-smoke" width="640" height="360"></canvas>
     <script type="module">
-      import init, { semanticFrameJson } from "./pkg/noon_web.js";
+      import init from "./pkg/noon_web.js";
       import { PythonAuthoringClient } from "./authoring-client.js";
 
       const client = new PythonAuthoringClient();
@@ -282,7 +282,6 @@ class RetainedSequentialFamilySmoke(Scene):
         run: runForExport,
         runLive,
         runLiveSources,
-        semanticFrame: (sceneJson, time) => JSON.parse(semanticFrameJson(sceneJson, time)),
       };
     </script>
   </body>

--- a/web/manim-raster-host.js
+++ b/web/manim-raster-host.js
@@ -148,4 +148,5 @@ window.noonHostRaster = {
   ready: () => readyPromise,
   load,
   renderThrough,
+  debugFrame: () => execution.debugFrame(),
 };

--- a/web/semantic-engine-endpoint.js
+++ b/web/semantic-engine-endpoint.js
@@ -611,6 +611,7 @@ export async function attachSemanticEngine(
       while (controls.length && writable()) {
       const message = controls.shift();
       let rendererObservation = null;
+      let debugFrame;
       try {
         switch (message.type) {
           case "pause":
@@ -656,6 +657,11 @@ export async function attachSemanticEngine(
             observeExecutionWake(performance.now());
             break;
           }
+          case "debug_frame":
+            debugFrame = JSON.parse(player === null
+              ? context.liveDebugFrameJson()
+              : player.debugFrameJson());
+            break;
           case "sample_to_authored_time": {
             if (callbackFault !== null) throw callbackFault;
             latestTick = null;
@@ -676,6 +682,7 @@ export async function attachSemanticEngine(
           requestId: message.requestId,
           ...state(message.type),
           ...(rendererObservation === null ? {} : { rendererObservation }),
+          ...(debugFrame === undefined ? {} : { debugFrame }),
         });
       } catch (error) {
         if (message.type === "sample_to_authored_time" && continuation !== null) {
@@ -793,7 +800,7 @@ export async function attachSemanticEngine(
         }
         if (![
           "pause", "resume", "seek", "restart_playback", "set_loop_duration", "advance_to",
-          "sample_to_authored_time",
+          "sample_to_authored_time", "debug_frame",
           "native_state_input", "native_event",
         ].includes(message.type)) {
           throw new Error(`unsupported semantic execution command ${message.type}`);

--- a/web/semantic-engine-endpoint.test.mjs
+++ b/web/semantic-engine-endpoint.test.mjs
@@ -39,6 +39,7 @@ function fixture(
   const json = () => JSON.stringify({ channel: "noon.execution.retained", protocol_version: 4, session: 7, sequence: sequence++, snapshot: sequence === 1, time, objects: [] });
   const player = {
     initialDeltaJson: () => { initialSnapshots += 1; return json(); },
+    debugFrameJson: () => JSON.stringify({ time, source: "active" }),
     initialCallbackPhaseJson: () => null,
     resourceBundleBytes: () => { resourceBundles += 1; return new Uint8Array([1]); },
     tickCallbackPhaseJson: () => null,
@@ -95,6 +96,7 @@ function fixture(
     resumeExecutionPlayer: () => { resumed += 1; return player; },
     returnExecutionPlayer: (value) => { returned += 1; returnedPlayer = value; },
     liveHandoffDuration: () => Math.max(time, 1),
+    liveDebugFrameJson: () => JSON.stringify({ time, source: "returned" }),
     drainReturnedPublicationJson: () => player.drainDeltaJson(),
   };
   return { control, render, player, stats: () => ({
@@ -533,6 +535,10 @@ test("external sample pacing ignores render ticks and resolves after exact prese
     });
     assert.equal((await sampled).time, 0.5);
     assert.deepEqual(f.stats().authoredSampleTimes, [0.5]);
+    const beforeDebug = f.stats();
+    const debug = await request(f.control.port2, "debug_frame", 63);
+    assert.deepEqual(debug.debugFrame, { time: 0.5, source: "active" });
+    assert.deepEqual(f.stats(), beforeDebug, "diagnostics must not seek, publish, or replace execution");
 
     const backward = await request(
       f.control.port2, "sample_to_authored_time", 62, { time: 0.25 },
@@ -628,6 +634,10 @@ test("external sampling acknowledges source completion after a clean segment bou
     assert.equal(result.playing, false);
     assert.equal(f.stats().completedSegments, 2);
     assert.equal(f.stats().resumed, 1);
+    const beforeDebug = f.stats();
+    const debug = await request(f.control.port2, "debug_frame", 65);
+    assert.deepEqual(debug.debugFrame, { time: 2, source: "returned" });
+    assert.deepEqual(f.stats(), beforeDebug, "completed-source diagnostics use the returned owner");
   } finally { endpoint?.stop(); f.close(); }
 });
 


### PR DESCRIPTION
Semantic comparisons now read the shared runtime frames captured at raster checkpoints. Previously the comparison step constructed the Python scene again, exported it, and compiled a separate runtime for each sampled frame; callback and live continuation behavior could therefore diverge from the screenshot being explained.

This advances #959 A4.7/A4.8 and #958:
- An explicit read-only debug codec observes the current ExecutionSession in painter order, with effective transforms and resolved geometry/text bounds. It includes the publication context and cannot drive or reconstruct execution.
- The existing genuine worker boundary handles a queued debug request using the current player or its returned authoring owner. Normal rendering and native/direct-WASM engine boundaries remain typed and unchanged.
- Raster capture saves that observation at each existing screenshot checkpoint. The semantic comparison step uses each backend's own capture and the already-generated pinned Manim reference; it no longer starts a browser, reruns source, generates another oracle, or creates another runtime.
- Removed the old decode/compile/seek snapshot API and unused browser hook. No compatibility alias or temporary migration seam.

Diagnostics deliberately scan the captured frame when explicitly requested. There is no added work on ordinary frames, mutations, or renderer uploads. JSON is only the debug artifact and genuine cross-context egress.

Validation:
- `CARGO_TARGET_DIR=/Users/ykshin/Dev/me/noon/target CARGO_INCREMENTAL=0 NOON_SKIP_WEB_PREFLIGHT=1 NOON_SKIP_PLAYGROUND_TEST=1 NOON_WASM_PROFILE=dev bash scripts/check.sh full`: 1,813 Rust tests and 238 browser API contracts passed.
- `NOON_WEB_PREFLIGHT_ONLY=1 NOON_SKIP_PLAYGROUND_TEST=1 bash scripts/check.sh web`: 186 Python tests plus Node checks passed. All 38 endpoint tests passed, including active and returned owner diagnostics without engine advancement/publication/replacement.
- `node scripts/shared-authoring-smoke.mjs`: passed, including current angular state and the completed source's returned owner snapshot.
- All 43 WebGPU fixtures captured runtime state at their raster checkpoints. A local harness port collision interrupted the first batch after 27 successful captures; only the remaining 16 were rerun on an isolated port, with no source change. Four representative WebGL fixtures passed: centered rotation, lagged Add/Wait/FadeIn, ScaleInPlace, and MovingDots callbacks.
- `NOON_MANIM_RASTER_ARTIFACTS=<capture-directory> node scripts/manim-raster-semantic-state.mjs`: passed for the 43-fixture GPU report and four-fixture GL report, using only saved artifacts. Semantic deltas remain diagnostic, including positional-pairing/count differences for lifecycle/tracker cases.
- `NOON_MANIM_RASTER_ARTIFACTS=<qualified-gpu-directory> node scripts/manim-raster-enforce.mjs`: all 43 fixtures meet existing raster thresholds. No tolerances changed.
- Local capture used a private runner copy with the repository path and cached reference loader changed; the GL and infrastructure-retry copies filter only the named fixtures. References are genuine pinned Cairo CI run34173869732/artifact10036732269 output, with unchanged fixture sources verified against d00cb08e. Public CI reference generation is unchanged.
- Architecture ratchet passed against85cbf71bcea286e76a952c7fb9752b79030819f3; native/direct-WASM engine paths remain typed.

Remaining #959 work includes other migration-only qualification consumers, notably the separate old seek/playback corpus path. PhaseA and complete semantic/visual parity are not claimed complete.
