### PR TITLE
Remove unused identity-only family frontend handles

### DIFF
--- a/crates/noon-web/src/authoring_mobject.rs
+++ b/crates/noon-web/src/authoring_mobject.rs
@@ -179,14 +179,6 @@ mod wasm {
         semantics: SharedSemanticStore,
     }
 
-    /// Content-agnostic semantic identity for authoring objects whose mutable
-    /// presentation state is owned by another retained/resource-specific handle.
-    #[wasm_bindgen]
-    pub struct WasmAuthoringFamilyMemberHandle {
-        semantics: SharedSemanticStore,
-        id: SemanticNodeId,
-    }
-
     #[wasm_bindgen]
     impl WasmAuthoringStore {
         #[wasm_bindgen(constructor)]
@@ -309,16 +301,6 @@ mod wasm {
                 .map_err(|error| js_error(error.to_string()))
         }
 
-        /// Allocate stable semantic identity for a non-geometry authoring object.
-        #[wasm_bindgen(js_name = createFamilyMember)]
-        pub fn create_family_member(&self) -> WasmAuthoringFamilyMemberHandle {
-            let id = self.semantics.borrow_mut().insert_authoring_object();
-            WasmAuthoringFamilyMemberHandle {
-                semantics: Rc::clone(&self.semantics),
-                id,
-            }
-        }
-
         #[wasm_bindgen(js_name = createFamily)]
         pub fn create_family(&self) -> WasmAuthoringFamilyHandle {
             let id = self.semantics.borrow_mut().insert_family();
@@ -326,19 +308,6 @@ mod wasm {
                 semantics: Rc::clone(&self.semantics),
                 id,
             }
-        }
-    }
-
-    #[wasm_bindgen]
-    impl WasmAuthoringFamilyMemberHandle {
-        #[wasm_bindgen(getter, js_name = semanticSlot)]
-        pub fn semantic_slot(&self) -> u32 {
-            self.id.slot()
-        }
-
-        #[wasm_bindgen(getter, js_name = semanticGeneration)]
-        pub fn semantic_generation(&self) -> u32 {
-            self.id.generation()
         }
     }
 
@@ -888,18 +857,6 @@ mod wasm {
             member.id_in_store(&self.semantics, "family target editor")
         }
 
-        fn identity_member_id(
-            &self,
-            member: &WasmAuthoringFamilyMemberHandle,
-        ) -> Result<SemanticNodeId, JsValue> {
-            if !Rc::ptr_eq(&self.semantics, &member.semantics) {
-                return Err(JsValue::from_str(
-                    "family target editor and member belong to different authoring stores",
-                ));
-            }
-            Ok(member.id)
-        }
-
         fn family_member_id(
             &self,
             member: &WasmAuthoringFamilyHandle,
@@ -923,19 +880,6 @@ mod wasm {
         ) -> Result<(), JsValue> {
             let source_id = self.mobject_member_id(source)?;
             let target_id = self.mobject_member_id(target)?;
-            self.editor
-                .accept_member(source_id, target_id)
-                .map_err(js_error)
-        }
-
-        #[wasm_bindgen(js_name = acceptMember)]
-        pub fn accept_member_identity(
-            &mut self,
-            source: &WasmAuthoringFamilyMemberHandle,
-            target: &WasmAuthoringFamilyMemberHandle,
-        ) -> Result<(), JsValue> {
-            let source_id = self.identity_member_id(source)?;
-            let target_id = self.identity_member_id(target)?;
             self.editor
                 .accept_member(source_id, target_id)
                 .map_err(js_error)
@@ -983,18 +927,6 @@ mod wasm {
             member: &WasmAuthoringMobjectHandle,
         ) -> Result<SemanticNodeId, JsValue> {
             member.id_in_store(&self.semantics, "family")
-        }
-
-        fn identity_member_id(
-            &self,
-            member: &WasmAuthoringFamilyMemberHandle,
-        ) -> Result<SemanticNodeId, JsValue> {
-            if !Rc::ptr_eq(&self.semantics, &member.semantics) {
-                return Err(JsValue::from_str(
-                    "family and member belong to different authoring stores",
-                ));
-            }
-            Ok(member.id)
         }
 
         fn family_member_id(
@@ -1148,15 +1080,6 @@ mod wasm {
             self.add_id(id)
         }
 
-        #[wasm_bindgen(js_name = addMember)]
-        pub fn add_member_identity(
-            &mut self,
-            member: &WasmAuthoringFamilyMemberHandle,
-        ) -> Result<bool, JsValue> {
-            let id = self.identity_member_id(member)?;
-            self.add_id(id)
-        }
-
         #[wasm_bindgen(js_name = addFamily)]
         pub fn add_family(&mut self, member: &WasmAuthoringFamilyHandle) -> Result<bool, JsValue> {
             let id = self.family_member_id(member)?;
@@ -1169,15 +1092,6 @@ mod wasm {
             member: &WasmAuthoringMobjectHandle,
         ) -> Result<bool, JsValue> {
             let id = self.object_member_id(member)?;
-            self.remove_id(id)
-        }
-
-        #[wasm_bindgen(js_name = removeMember)]
-        pub fn remove_member_identity(
-            &mut self,
-            member: &WasmAuthoringFamilyMemberHandle,
-        ) -> Result<bool, JsValue> {
-            let id = self.identity_member_id(member)?;
             self.remove_id(id)
         }
 

--- a/web/python-worker.source.js
+++ b/web/python-worker.source.js
@@ -118,8 +118,6 @@ async function initializePyodide() {
   self.noonCreateAuthoringTypstHandle = (source, math, fontSize) =>
     authoringStore.createManimTypst(source, math, fontSize);
   self.noonCreateAuthoringFamilyHandle = () => authoringStore.createFamily();
-  self.noonCreateAuthoringFamilyMemberHandle = () =>
-    authoringStore.createFamilyMember();
   self.noonResolveAnimationOptions = resolveAnimationOptionsPlain;
   self.noonResolveCompositionSchedule = resolveCompositionSchedulePlain;
   self.noonResolveUniformCompositionSchedule = resolveUniformCompositionSchedulePlain;


### PR DESCRIPTION
Python families already use real shared Rust Mobject and Family handles. Remove the unused identity-only family handle, its factory, and its add/remove/target-editor bindings, including the dead Python-worker factory. This deletes 88 lines and creates no replacement abstraction.

Advances #959 A4.8 and #958 frontend consolidation. Ownership remains in shared Rust semantics; no new authority, migration seam, serialization boundary, or per-frame work. Shared core placeholder nodes still have other migration consumers and remain owned by #959. Existing native/Python family examples cover the supported handle path.

Validation passed:
- `CARGO_TARGET_DIR=/Users/ykshin/Dev/me/noon/target CARGO_INCREMENTAL=0 NOON_SKIP_WEB_PREFLIGHT=1 NOON_SKIP_PLAYGROUND_TEST=1 NOON_WASM_PROFILE=dev bash scripts/check.sh full`: 1,813 Rust tests and238 WASM contracts.
- `NOON_WEB_PREFLIGHT_ONLY=1 NOON_SKIP_PLAYGROUND_TEST=1 bash scripts/check.sh web`: Python/Node preflight passed.
- `NOON_SHARED_AUTHORING_SMOKE_PORT=4189 node scripts/shared-authoring-smoke.mjs`: shared browser passed, including family transform/target operations and text families.
- `bash scripts/architecture-ratchet.sh a7faae7a4352f4b9aa9715dcc9e855e9118538b3` and `git diff --check` passed. Tracked source search found no remaining consumers of the removed bindings.

No new tests for dead bindings; existing shared behavior proofs exercise their supported replacements.
