### PR TITLE
Make deferred playground layout qualification deterministic

### DIFF
--- a/scripts/playground-layout-smoke.mjs
+++ b/scripts/playground-layout-smoke.mjs
@@ -127,8 +127,16 @@ try {
     if (message.type() === "error") browserErrors.push(`console: ${message.text()}`);
   });
 
+  // Hold the optional post-paint preload at its real module-load boundary so
+  // cold-layout assertions cannot race the automatic first source run.
+  let releasePreload;
+  const preloadGate = new Promise((resolve) => { releasePreload = resolve; });
+  await page.route("**/live-authoring-bootstrap.js", async (route) => {
+    await preloadGate;
+    await route.continue();
+  });
   await page.goto(`${baseUrl}/web/index.html?example=parity-square-and-circle`, {
-    waitUntil: "load",
+    waitUntil: "domcontentloaded",
   });
   await page.waitForFunction(() => window.__noonExampleGallery !== undefined);
 
@@ -154,7 +162,14 @@ try {
   assertCentered(deferredDesktop.canvas, deferredDesktop.wrap, "deferred desktop");
   assertNoOverflow(deferredDesktop, "deferred desktop");
 
-  await page.locator("#replace-scene").click();
+  releasePreload();
+  await page.waitForFunction(
+    () => ["ready", "error"].includes(document.querySelector("#status")?.dataset.liveAuthoring),
+    null,
+    { timeout: 60_000 },
+  );
+  assert.equal(await page.locator("#status").getAttribute("data-live-authoring"), "ready",
+    `automatic preload must finish after the cold layout is measured: ${await page.locator("#patch-status").textContent()}\n${browserErrors.join("\n")}`);
   await page.waitForFunction(
     () =>
       document.querySelector("#status")?.dataset.rendererBackend === "WebGL2" &&


### PR DESCRIPTION
The layout smoke sometimes observes `preparing-on-run` instead of `deferred`: #1112 intentionally starts automatic authoring after the first paint, so waiting for page load cannot reliably observe the cold state. This caused #1215's product CI failure.

Hold the optional live-authoring bootstrap at its module request while measuring the deferred gallery/layout, then release it and verify automatic preload succeeds before checking the active viewport. The test now controls the boundary it asserts. Product startup, shared semantics and rendering are unchanged; no test-only product switch is introduced.

Validation: `CARGO_TARGET_DIR=/Users/ykshin/Dev/me/noon/target CARGO_INCREMENTAL=0 bash scripts/check.sh fast` (1602 Rust tests); `node --test web/live-authoring-bootstrap.test.mjs web/playground-startup.test.mjs`; `node --check scripts/playground-layout-smoke.mjs`; `NOON_PLAYGROUND_LAYOUT_PORT=4174 node scripts/playground-layout-smoke.mjs` passed deferred and active desktop/stacked/mobile WebGL layout at DPR1.25. Regenerated the local Python worker once after concurrent #1211 added a module; no Rust/WASM rebuild was required. `git diff --check` passed.

Correctness/validation followup under #958/#961; no architecture change or migration seam.
