### PR TITLE
Use typed native replay tests and remove unused snapshot APIs

### DIFF
--- a/crates/noon-web/src/determinism.rs
+++ b/crates/noon-web/src/determinism.rs
@@ -1,9 +1,11 @@
 //! Renderer-independent frame snapshots used by deterministic replay tests and tools.
 
 use noon_compile::{CompileError, CompiledScene};
+#[cfg(test)]
 use noon_core::ObjectContentRef;
 use noon_ir::{decode_scene, IrError};
 use noon_runtime::{EvaluationError, FrameState, SlottedSceneInstance};
+#[cfg(test)]
 use serde_json::{json, Value};
 
 fn normalize_playhead(time: f64) -> f64 {
@@ -19,7 +21,8 @@ fn normalize_playhead(time: f64) -> f64 {
 /// The f64 playhead is rounded to picosecond precision so mathematically equivalent
 /// timestamp construction paths do not create false mismatches; evaluated scene
 /// properties remain unrounded.
-pub fn normalized_frame_value(frame: &FrameState) -> Value {
+#[cfg(test)]
+pub(crate) fn normalized_frame_value(frame: &FrameState) -> Value {
     let objects = frame
         .objects
         .iter()
@@ -57,11 +60,6 @@ pub fn normalized_frame_value(frame: &FrameState) -> Value {
     })
 }
 
-pub fn normalized_frame_json(frame: &FrameState) -> String {
-    serde_json::to_string(&normalized_frame_value(frame))
-        .expect("normalized frame contains only JSON-serializable values")
-}
-
 fn normalized_frames_equal(left: &FrameState, right: &FrameState) -> bool {
     normalize_playhead(left.time) == normalize_playhead(right.time)
         && left.objects == right.objects
@@ -69,6 +67,8 @@ fn normalized_frames_equal(left: &FrameState, right: &FrameState) -> bool {
         && left.reveals == right.reveals
         && left.morphs == right.morphs
         && left.render_geometries == right.render_geometries
+        && left.render_transforms == right.render_transforms
+        && left.family_animations == right.family_animations
 }
 
 #[derive(Debug)]
@@ -112,28 +112,6 @@ fn runtime_from_scene_json(scene_json: &str) -> Result<SlottedSceneInstance, Rep
     let definition = decode_scene(scene_json)?;
     let compiled = CompiledScene::compile(&definition)?;
     Ok(SlottedSceneInstance::new(compiled))
-}
-
-/// Evaluate a scene by seeking directly to `time` and return its normalized frame.
-pub fn scene_snapshot_json(scene_json: &str, time: f64) -> Result<String, ReplayRuntimeError> {
-    let mut runtime = runtime_from_scene_json(scene_json)?;
-    runtime.seek(time)?;
-    Ok(normalized_frame_json(runtime.frame()))
-}
-
-/// Evaluate a scene through the supplied playhead sequence and return the final frame.
-///
-/// The sequence may move backward. This intentionally exercises the same
-/// `advance_to` rewind behavior used by interactive scrubbing.
-pub fn playback_snapshot_json(
-    scene_json: &str,
-    times: &[f64],
-) -> Result<String, ReplayRuntimeError> {
-    let mut runtime = runtime_from_scene_json(scene_json)?;
-    for &time in times {
-        runtime.advance_to(time)?;
-    }
-    Ok(normalized_frame_json(runtime.frame()))
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -291,5 +269,26 @@ mod wasm {
     ) -> Result<(), JsValue> {
         let targets: Vec<f64> = serde_json::from_str(targets_json).map_err(js_error)?;
         verify_scene_replay(scene_json, &targets, forward_sample_count as usize).map_err(js_error)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalized_frames_equal;
+
+    #[test]
+    fn replay_equality_includes_the_effective_renderer_coordinate_frame() {
+        let session = noon::example_scenes::exact_property_tracks::session().unwrap();
+        let expected = session.frame();
+        let mut actual = expected.clone();
+        assert!(normalized_frames_equal(&actual, expected));
+
+        // A derived point-morph coordinate frame can differ while the semantic
+        // object transform stays unchanged. The renderer consumes this override.
+        let mut render_transform = actual.objects[0].transform;
+        render_transform.translation.x += 1.0;
+        actual.render_transforms[0] = Some(render_transform);
+        assert_eq!(actual.objects, expected.objects);
+        assert!(!normalized_frames_equal(&actual, expected));
     }
 }

--- a/crates/noon-web/tests/deterministic_replay.rs
+++ b/crates/noon-web/tests/deterministic_replay.rs
@@ -1,166 +1,83 @@
-use noon_core::{
-    Easing, GeometryRef, ObjectSnapshot, SceneDefinition, Style, TrackTiming, Transform2D, Vec2,
-};
-use noon_ir::encode_scene;
-use noon_web::{playback_snapshot_json, scene_snapshot_json, verify_scene_replay};
+use noon::ExecutionSession;
+use noon_web::{verify_scene_replay, ReplayVerificationError};
 
-fn build_scene() -> SceneDefinition {
-    let mut scene = SceneDefinition::new();
+type SessionFactory = fn() -> Result<ExecutionSession, String>;
 
-    let circle = scene.add(GeometryRef::circle(0.75));
-    scene
-        .animate_position(
-            circle,
-            Vec2::new(-2.0, -1.0),
-            Vec2::new(3.0, 1.5),
-            TrackTiming::new(0.25, 2.5, Easing::Smooth),
-        )
-        .unwrap();
-    scene
-        .animate_scalar(
-            circle,
-            noon_core::Property::Opacity,
-            1.0,
-            0.2,
-            TrackTiming::new(0.5, 1.75, Easing::ThereAndBack),
-        )
-        .unwrap();
-
-    let rectangle = scene.add(GeometryRef::rectangle(2.0, 1.0));
-    let from = ObjectSnapshot::new(GeometryRef::rectangle(2.0, 1.0));
-    let to = ObjectSnapshot::new(GeometryRef::rectangle(4.0, 2.0))
-        .shift(Vec2::new(-1.5, 2.0))
-        .rotate_by(0.8)
-        .set_opacity(0.55);
-    scene
-        .animate_transform(
-            rectangle,
-            from,
-            to,
-            TrackTiming::new(1.0, 2.0, Easing::EaseInOutCubic),
-        )
-        .unwrap();
-
-    let line = scene.add(GeometryRef::line(Vec2::new(-1.0, 0.0), Vec2::new(1.0, 0.0)));
-    scene
-        .animate_reveal(line, 0.0, 1.0, TrackTiming::new(0.0, 1.2, Easing::Linear))
-        .unwrap();
-
-    scene
+fn sessions() -> [SessionFactory; 2] {
+    [
+        noon::example_scenes::exact_property_tracks::session,
+        noon::example_scenes::specialized_geometry::session,
+    ]
 }
 
-fn scene_json(scene: &SceneDefinition) -> String {
-    encode_scene(scene).expect("test scene encodes")
+fn assert_same_execution(actual: &ExecutionSession, expected: &ExecutionSession) {
+    assert_eq!(actual.painter_order(), expected.painter_order());
+    // Compare typed runtime data directly, including derived renderer transforms,
+    // geometry, presence/reveal/morph channels and compact family animation state.
+    assert_eq!(actual.frame(), expected.frame());
 }
 
 #[test]
-fn direct_seek_incremental_playback_and_backward_scrub_have_identical_frames() {
-    let json = scene_json(&build_scene());
-    let targets = [0.0, 0.25, 0.499, 0.5, 1.0, 1.2, 1.75, 2.25, 2.75, 3.0, 4.0];
+fn typed_direct_seek_forward_playback_and_backward_scrub_have_identical_frames() {
+    for build in sessions() {
+        let mut direct = build().unwrap();
+        let mut forward = build().unwrap();
+        let mut rewind = build().unwrap();
+        for target in [0.0, 0.25, 0.499, 0.5, 1.0, 1.2, 1.75, 2.0, 2.25, 3.0, 4.0] {
+            direct.seek(target).unwrap();
+            forward.seek(0.0).unwrap();
+            for step in 0..37 {
+                forward.advance_to(target * f64::from(step) / 37.0).unwrap();
+            }
+            forward.advance_to(target).unwrap();
+            assert_same_execution(&forward, &direct);
 
-    for &target in &targets {
-        let direct = scene_snapshot_json(&json, target).unwrap();
-
-        let mut forward = Vec::new();
-        let steps = 37;
-        for step in 0..=steps {
-            forward.push(target * step as f64 / steps as f64);
+            for time in [0.1, 1.3, 2.9, 0.7, 3.4, target] {
+                rewind.advance_to(time).unwrap();
+            }
+            assert_same_execution(&rewind, &direct);
         }
-        let incremental = playback_snapshot_json(&json, &forward).unwrap();
-        assert_eq!(
-            incremental, direct,
-            "incremental playback diverged at target={target}"
-        );
-
-        let rewind = playback_snapshot_json(&json, &[0.1, 1.3, 2.9, 0.7, 3.4, target]).unwrap();
-        assert_eq!(rewind, direct, "backward scrub diverged at target={target}");
     }
 }
 
 #[test]
-fn batched_replay_verifier_preserves_full_direct_forward_and_rewind_contract() {
-    let json = scene_json(&build_scene());
-    let targets = [0.0, 0.25, 0.499, 0.5, 1.0, 1.2, 1.75, 2.25, 2.75, 3.0, 4.0];
-
-    verify_scene_replay(&json, &targets, 38).unwrap();
+fn remaining_external_replay_verifier_validates_workloads_before_decoding() {
+    assert!(matches!(
+        verify_scene_replay("", &[0.5], 1),
+        Err(ReplayVerificationError::InvalidForwardSampleCount(1))
+    ));
+    assert!(matches!(
+        verify_scene_replay("", &[f64::NAN], 38),
+        Err(ReplayVerificationError::NonFiniteTarget { index: 0, .. })
+    ));
 }
 
 #[test]
-fn batched_replay_verifier_rejects_invalid_workloads_before_evaluation() {
-    let json = scene_json(&build_scene());
-
-    assert!(verify_scene_replay(&json, &[0.5], 1).is_err());
-    assert!(verify_scene_replay(&json, &[f64::NAN], 38).is_err());
-}
-
-#[test]
-fn repeated_evaluation_is_stable_at_boundaries_and_extreme_valid_times() {
-    let json = scene_json(&build_scene());
-    for time in [
-        0.0,
-        f64::EPSILON,
-        0.25,
-        0.5,
-        1.0,
-        1.2,
-        2.25,
-        2.75,
-        3.0,
-        1.0e-9,
-        1.0e6,
-    ] {
-        let first = scene_snapshot_json(&json, time).unwrap();
-        let second = scene_snapshot_json(&json, time).unwrap();
-        assert_eq!(first, second, "fresh evaluation drifted at time={time}");
-
-        let replayed = playback_snapshot_json(&json, &[time, time, time]).unwrap();
-        assert_eq!(replayed, first, "same-frame replay drifted at time={time}");
+fn typed_repeated_evaluation_is_stable_at_boundaries_and_extreme_valid_times() {
+    for build in sessions() {
+        for time in [
+            0.0,
+            f64::EPSILON,
+            0.25,
+            0.5,
+            1.0,
+            1.2,
+            2.0,
+            2.25,
+            3.0,
+            1.0e-9,
+            1.0e6,
+        ] {
+            let mut direct = build().unwrap();
+            let mut repeated = build().unwrap();
+            direct.seek(time).unwrap();
+            for _ in 0..3 {
+                repeated.advance_to(time).unwrap();
+                assert_same_execution(&repeated, &direct);
+            }
+            repeated.take_frame_changes();
+            repeated.advance_to(time).unwrap();
+            assert!(repeated.take_frame_changes().is_empty());
+        }
     }
-}
-
-#[test]
-fn normalized_snapshot_omits_execution_bookkeeping_but_preserves_render_observables() {
-    let mut scene = build_scene();
-    let first = scene.objects()[0].id;
-    scene.object_mut(first).unwrap().transform = Transform2D {
-        translation: Vec2::new(0.5, -0.25),
-        rotation: 0.1,
-        scale: Vec2::new(1.1, 0.9),
-    };
-    scene.object_mut(first).unwrap().style = Style {
-        opacity: 0.9,
-        stroke_width: 1.25,
-        stroke_width_mode: Default::default(),
-        ..Style::default()
-    };
-    let json = scene_json(&scene);
-    let snapshot: serde_json::Value =
-        serde_json::from_str(&scene_snapshot_json(&json, 1.2).unwrap())
-            .expect("snapshot is valid JSON");
-
-    assert_eq!(snapshot["time"], 1.2);
-    let objects = snapshot["objects"].as_array().expect("objects array");
-    assert_eq!(objects.len(), 3);
-    for object in objects {
-        assert!(object.get("id").is_some());
-        let content = object
-            .get("content")
-            .and_then(serde_json::Value::as_object)
-            .expect("shared object content");
-        assert_eq!(
-            content.get("kind").and_then(serde_json::Value::as_str),
-            Some("geometry")
-        );
-        assert!(content.get("geometry").is_some());
-        assert!(object.get("transform").is_some());
-        assert!(object.get("style").is_some());
-        assert!(object.get("appearance").is_some());
-        assert!(object.get("present").is_some());
-        assert!(object.get("reveal").is_some());
-        assert!(object.get("morph").is_some());
-        assert!(object.get("render_geometry").is_some());
-    }
-    assert!(snapshot.get("groups").is_none());
-    assert!(snapshot.get("cursors").is_none());
-    assert!(snapshot.get("cache").is_none());
 }

--- a/scripts/architecture-ratchet.sh
+++ b/scripts/architecture-ratchet.sh
@@ -203,7 +203,7 @@ fi
 deleted_legacy_web_surface_found=0
 deleted_legacy_web_references="$(
   git grep -nE \
-    '(^|[^[:alnum:]_])(NoonCanvasPlayer|demoSceneJson|WasmAuthoringFamilyMemberHandle|noonCreateAuthoringFamilyMemberHandle|evaluateSceneSnapshot|evaluateScenePlaybackSnapshot)([^[:alnum:]_]|$)' \
+    '(^|[^[:alnum:]_])(NoonCanvasPlayer|demoSceneJson|WasmAuthoringFamilyMemberHandle|noonCreateAuthoringFamilyMemberHandle|evaluateSceneSnapshot|evaluateScenePlaybackSnapshot|scene_snapshot_json|playback_snapshot_json|normalized_frame_json)([^[:alnum:]_]|$)' \
     -- \
     'crates/noon-web/src' \
     'web/python-worker.source.js' \


### PR DESCRIPTION
Native replay tests still rebuilt migration documents and serialized frame snapshots even though shared typed sessions are available. Compare the existing exact-property and specialized-geometry examples directly through `ExecutionSession`: full runtime frames and painter order must match across direct seek, forward stepping, backward scrub, repeated boundaries and extreme valid times. Unchanged repeats must remain clean.

Delete the three unused native JSON snapshot APIs. The one normalization helper needed by an existing transport unit test is now crate-private and test-only. The remaining batched legacy replay checker now compares derived renderer transforms and compact family animation state; previously differing renderer coordinates could be reported equal. A focused regression protects that observable distinction.

Advances #959 A4.7/A4.8 and #961. No new engine authority, identity, scheduler, serialization boundary or migration seam. Existing paired Rust/Python exact-property and specialized-geometry examples are reused; no common semantics change. Diagnostic verification remains O(frame size) only when explicitly requested, with no ordinary-frame work added.

The remaining `verifySceneReplay` API is still used by `scripts/deterministic-replay-smoke.mjs`, including optimized-release qualification where debug-only direct example factories are unavailable. Its typed replacement remains tracked under #959; this change does not delete that coverage prematurely.

Validation: focused three native replay tests passed; full gate passed1,812 Rust tests, format/check/clippy and237 WASM contracts. `node scripts/deterministic-replay-smoke.mjs` passed all11 existing playground fixtures with32 forward samples per target against the updated WASM verifier. Architecture ratchet against35b7043e and `git diff --check` passed.


Commands: `CARGO_TARGET_DIR=/Users/ykshin/Dev/me/noon/target CARGO_INCREMENTAL=0 cargo test --workspace --all-features --test deterministic_replay`; `CARGO_TARGET_DIR=/Users/ykshin/Dev/me/noon/target CARGO_INCREMENTAL=0 NOON_SKIP_WEB_PREFLIGHT=1 NOON_SKIP_PLAYGROUND_TEST=1 NOON_WASM_PROFILE=dev bash scripts/check.sh full`; `NOON_DETERMINISM_PORT=4183 node scripts/deterministic-replay-smoke.mjs`; `bash scripts/architecture-ratchet.sh 35b7043e`; `git diff --check`.
