### PR TITLE
Fix family layout ownership inventory anchors

### DIFF
--- a/compat/semantic-ownership-v1.json
+++ b/compat/semantic-ownership-v1.json
@@ -152,7 +152,7 @@
       "id": "group-layout-bounds",
       "surface": "Deterministic Group/VGroup aggregate bounds, center, width/height, and critical-point queries",
       "classification": "shared-rust",
-      "owner": {"language": "rust", "path": "crates/noon/src/family_layout.rs", "symbol": "MobjectFamily::layout/FamilyLayout; LiveSession::effective_family_layout"},
+      "owner": {"language": "rust", "path": "crates/noon/src/family_layout.rs", "symbol": "MobjectFamily::layout/FamilyLayout"},
       "adapters": [{"language": "python", "path": "web/python/_manim_semantic_handles.py", "symbol": "_compat_bounds_for"}],
       "reason": "Rust aggregates semantic family membership using authored bounds or current effective runtime transforms through LiveSession. Python only checks local wrapper eligibility; it cannot feed per-leaf bounds or construct a partial observation."
     },
@@ -168,7 +168,7 @@
       "id": "group-relative-placement",
       "surface": "Deterministic Group/VGroup next_to/align_to without explicit submobject selection",
       "classification": "shared-rust",
-      "owner": {"language": "rust", "path": "crates/noon/src/family_layout.rs", "symbol": "RelativePlacement; FamilyLayout::next_to/align_to; LiveSession::next_family_to/align_family_to"},
+      "owner": {"language": "rust", "path": "crates/noon/src/family_layout.rs", "symbol": "RelativePlacement; FamilyLayout::next_to/align_to"},
       "adapters": [{"language": "python", "path": "web/python/_manim_semantic_handles.py", "symbol": "_group_next_to/_group_align_to"}],
       "reason": "Rust resolves family/leaf/point critical points, Manim's unnormalized next_to direction and buffer, align_to axis masking, and the authoritative recursive leaf mutation order. Python only coerces host arguments and selects the target handle kind."
     },


### PR DESCRIPTION
The ownership inventory in #1229 listed live-session symbols under the shared authored-layout file, causing the inventory validator to reject browser builds before compilation. Point these two entries at symbols that actually reside in their declared file; the descriptions still document shared live behavior.

Advances #61/#959 by correcting architecture metadata. No engine or browser behavior changes and no new migration seam.

Validation: `python3 scripts/semantic_ownership_check.py` and `git diff --check` passed. The unchanged engine code already passed #1229's full local gate (1,744 Rust tests), paired runtime frames and GPU/compatibility smoke; this metadata-only fix does not rerun those builds. CI will qualify the corrected inventory.