### PR TITLE
Unify normal Scene.play through shared composition admission

### DIFF
--- a/compat/semantic-ownership-v1.json
+++ b/compat/semantic-ownership-v1.json
@@ -220,7 +220,7 @@
       "surface": "Typed leaf FadeIn/FadeOut with scale, shift, or target_position",
       "classification": "shared-rust",
       "owner": {"language": "rust", "path": "crates/noon/src/live_session.rs", "symbol": "LiveSession::declare_and_activate_fade_with_endpoint"},
-      "adapters": [{"language": "python", "path": "web/python/_manim_canonical_scene.py", "symbol": "_canonical_fade_endpoint/_play_canonical_fade"}],
+      "adapters": [{"language": "python", "path": "web/python/_manim_canonical_scene.py", "symbol": "_canonical_fade_endpoint/_build_canonical_composition_candidate"}],
       "reason": "Python coerces the Manim call into scale plus a shift or point value. Rust resolves effective endpoint layout, authors the affine and appearance tracks, owns lifecycle membership, and schedules composition timing."
     },
     {

--- a/crates/noon-web/src/canonical_authoring_scene.rs
+++ b/crates/noon-web/src/canonical_authoring_scene.rs
@@ -190,6 +190,11 @@ enum OrdinaryCompositionChild {
         target: noon::Mobject,
         options: noon_core::AnimationOptions,
     },
+    Uncreate {
+        entering_id: Option<ObjectId>,
+        target: noon::Mobject,
+        options: noon_core::AnimationOptions,
+    },
     AffineLifecycle {
         entering_id: Option<ObjectId>,
         target: noon::Mobject,
@@ -1650,6 +1655,12 @@ impl CanonicalAuthoringScene {
                     target,
                     options: *options,
                 },
+                OrdinaryCompositionChild::Uncreate {
+                    target, options, ..
+                } => noon::AnimationCompositionRequest::Uncreate {
+                    target,
+                    options: *options,
+                },
                 OrdinaryCompositionChild::AffineLifecycle {
                     target,
                     direction,
@@ -1721,6 +1732,11 @@ impl CanonicalAuthoringScene {
                     ..
                 }
                 | OrdinaryCompositionChild::Create {
+                    entering_id,
+                    target,
+                    ..
+                }
+                | OrdinaryCompositionChild::Uncreate {
                     entering_id,
                     target,
                     ..
@@ -2210,6 +2226,11 @@ impl CanonicalAuthoringScene {
                     target,
                     options,
                 }
+                | OrdinaryCompositionChild::Uncreate {
+                    entering_id,
+                    target,
+                    options,
+                }
                 | OrdinaryCompositionChild::AffineLifecycle {
                     entering_id,
                     target,
@@ -2237,6 +2258,7 @@ impl CanonicalAuthoringScene {
                         child,
                         OrdinaryCompositionChild::TextWrite { .. }
                             | OrdinaryCompositionChild::TextReveal { .. }
+                            | OrdinaryCompositionChild::Uncreate { .. }
                     ) {
                         // Glyph realization owns reversal; keep the original child
                         // options for shared schedule lowering after shape validation.
@@ -4321,6 +4343,31 @@ mod wasm {
                     options,
                 },
             )
+        }
+
+        #[wasm_bindgen(js_name = appendUncreate)]
+        pub fn append_uncreate(
+            &mut self,
+            object_id: &str,
+            target: &crate::WasmAuthoringMobjectHandle,
+            child_run_time: f64,
+            rate_function: &str,
+            remover: bool,
+            reverse_rate_function: bool,
+        ) -> Result<(), JsValue> {
+            let entering_id = if object_id.is_empty() {
+                None
+            } else {
+                Some(parse_object_id("Uncreate object ID", object_id)?)
+            };
+            self.children.push(OrdinaryCompositionChild::Uncreate {
+                entering_id,
+                target: target.semantic_mobject().clone(),
+                options: Self::options(child_run_time, rate_function)?
+                    .remover(remover)
+                    .reverse_rate_function(reverse_rate_function),
+            });
+            Ok(())
         }
 
         #[wasm_bindgen(js_name = appendAffineLifecycle)]
@@ -8510,6 +8557,11 @@ mod tests {
             .rate_func(RateFunction::Linear);
         let children = vec![
             OrdinaryCompositionChild::Wait { duration: 0.25 },
+            OrdinaryCompositionChild::Uncreate {
+                entering_id: None,
+                target: bound.clone(),
+                options: options.remover(true).reverse_rate_function(true),
+            },
             OrdinaryCompositionChild::Add {
                 entering_id: ObjectId::new(1),
                 target: add_target.clone(),
@@ -8557,6 +8609,7 @@ mod tests {
             )
             .unwrap();
         assert!(end > 0.0);
+        assert!(!context.live_contains_mobject(&bound).unwrap());
         assert!(context.live_contains_mobject(&add_target).unwrap());
         assert!(context.live_contains_mobject(&create_target).unwrap());
         assert!(context.live_contains_mobject(&fade_target).unwrap());

--- a/crates/noon/src/example_scenes/ordinary_uncreate_options.rs
+++ b/crates/noon/src/example_scenes/ordinary_uncreate_options.rs
@@ -1,8 +1,9 @@
 //! Uncreate easing, retained membership, and forward reveal on the shared runtime.
 
 use crate::{
-    AnimationOptions, Color, ContinuationStep, LiveContinuation, LiveProgram, LiveSession, Mobject,
-    MobjectFamilyMember, RateFunction, Scene,
+    AnimationCompositionRequest, AnimationOptions, Color, ContinuationStep, LiveContinuation,
+    LiveProgram, LiveSession, Mobject, MobjectFamilyMember, RateFunction, Scene,
+    SemanticAnimationCompositionKind,
 };
 
 pub struct UncreateOptions {
@@ -69,9 +70,19 @@ impl LiveContinuation for UncreateOptions {
             }
             _ => return Err("Uncreate continuation resumed after completion".into()),
         };
-        let segment = live
-            .declare_and_activate_uncreate(target, options)
-            .map_err(|error| error.to_string())?;
+        let segment = if self.stage == 0 {
+            live.declare_and_activate_composition(
+                &AnimationCompositionRequest::Composition {
+                    kind: SemanticAnimationCompositionKind::Parallel,
+                    children: vec![AnimationCompositionRequest::Uncreate { target, options }],
+                    options: AnimationOptions::new().rate_func(RateFunction::Linear),
+                },
+                AnimationOptions::new(),
+            )
+        } else {
+            live.declare_and_activate_uncreate(target, options)
+        }
+        .map_err(|error| error.to_string())?;
         self.stage += 1;
         Ok(ContinuationStep::Await(segment))
     }

--- a/crates/noon/src/execution_session.rs
+++ b/crates/noon/src/execution_session.rs
@@ -183,6 +183,10 @@ pub(crate) enum SemanticCompositionRequest {
         target: SemanticNodeId,
         options: AnimationOptions,
     },
+    Uncreate {
+        target: SemanticNodeId,
+        options: AnimationOptions,
+    },
     AffineLifecycle {
         target: SemanticNodeId,
         direction: SemanticAffineLifecycleDirection,
@@ -2150,6 +2154,19 @@ impl ExecutionSession {
                 admit(*target, declaration, admitted)?;
                 Ok(declaration.create_create_animation(*target, *options))
             }
+            SemanticCompositionRequest::Uncreate { target, options } => {
+                if self.require_uncreate_target(store, root, *target)? {
+                    admit(*target, declaration, admitted)?;
+                }
+                // The reveal track completion owns leaf removal. Explicit
+                // composition removals are for families and non-track effects.
+                Ok(declaration.create_create_animation(
+                    *target,
+                    options
+                        .remover(options.remover.unwrap_or(true))
+                        .reverse_rate_function(options.reverse_rate_function.unwrap_or(true)),
+                ))
+            }
             SemanticCompositionRequest::AffineLifecycle {
                 target,
                 direction,
@@ -2360,30 +2377,11 @@ impl ExecutionSession {
         target: SemanticNodeId,
         options: AnimationOptions,
     ) -> Result<ExecutionSegment, ExecutionSessionAnimationError> {
-        self.require_animation_declaration_context(store)?;
-        let admitted = self.require_uncreate_target(store, root, target)?;
-        let remover = options.remover.unwrap_or(true);
-        let reverse_rate_function = options.reverse_rate_function.unwrap_or(true);
-        let mut declaration = SemanticMutationTransaction::new();
-        if admitted {
-            declaration.add_member(root, target);
-        }
-        let animation = declaration.create_create_animation(
-            target,
-            options
-                .remover(remover)
-                .reverse_rate_function(reverse_rate_function),
-        );
-        self.declare_and_activate_prepared_animation(
+        self.declare_and_activate_composition(
             store,
-            declaration,
-            animation,
+            root,
+            &SemanticCompositionRequest::Uncreate { target, options },
             AnimationOptions::new(),
-            Some(if admitted {
-                PreparedAnimationLifecycle::Introduce(root)
-            } else {
-                PreparedAnimationLifecycle::FadeOut(root)
-            }),
         )
     }
 

--- a/crates/noon/src/live_session.rs
+++ b/crates/noon/src/live_session.rs
@@ -351,6 +351,10 @@ pub enum AnimationCompositionRequest<'a> {
         target: &'a Mobject,
         options: AnimationOptions,
     },
+    Uncreate {
+        target: &'a Mobject,
+        options: AnimationOptions,
+    },
     AffineLifecycle {
         target: &'a Mobject,
         direction: AffineLifecycleDirection,
@@ -1733,6 +1737,13 @@ impl<'a> LiveSession<'a> {
             AnimationCompositionRequest::Create { target, options } => {
                 self.require_mobject(target)?;
                 Request::Create {
+                    target: target.node_id(),
+                    options: *options,
+                }
+            }
+            AnimationCompositionRequest::Uncreate { target, options } => {
+                self.require_mobject(target)?;
+                Request::Uncreate {
                     target: target.node_id(),
                     options: *options,
                 }

--- a/crates/noon/tests/composition_admission.rs
+++ b/crates/noon/tests/composition_admission.rs
@@ -1,0 +1,154 @@
+use noon::{
+    AnimationCompositionRequest as Request, AnimationOptions, RateFunction, Scene,
+    SemanticAnimationCompositionKind as Kind,
+};
+
+#[test]
+fn singleton_and_grouped_uncreate_share_reversal_and_membership() {
+    for mounted in [false, true] {
+        for reverse in [false, true] {
+            let mut traces = Vec::new();
+            for grouped in [false, true] {
+                let mut scene = Scene::new();
+                let square = scene.square(1.0).unwrap();
+                if mounted {
+                    scene.add(&square).unwrap();
+                }
+                let mut execution = scene.execution_session().unwrap();
+                let options = AnimationOptions::new()
+                    .run_time(1.0)
+                    .rate_func(RateFunction::RushInto)
+                    .remover(false)
+                    .reverse_rate_function(reverse);
+                let segment = if grouped {
+                    scene
+                        .live(&mut execution)
+                        .declare_and_activate_composition(
+                            &Request::Composition {
+                                kind: Kind::Parallel,
+                                children: vec![Request::Uncreate {
+                                    target: &square,
+                                    options,
+                                }],
+                                options: AnimationOptions::new().rate_func(RateFunction::Linear),
+                            },
+                            AnimationOptions::new(),
+                        )
+                        .unwrap()
+                } else {
+                    scene
+                        .live(&mut execution)
+                        .declare_and_activate_uncreate(&square, options)
+                        .unwrap()
+                };
+                let mut samples = Vec::new();
+                for time in [0.0, 0.25, 0.5, 1.0] {
+                    scene
+                        .live(&mut execution)
+                        .advance_segment_to(segment, time)
+                        .unwrap();
+                    let reveal = execution.frame().reveal(0);
+                    let expected = RateFunction::RushInto.evaluate(if reverse {
+                        1.0 - time as f32
+                    } else {
+                        time as f32
+                    });
+                    assert!((reveal - expected).abs() < 1e-6);
+                    samples.push(reveal);
+                }
+                scene
+                    .live(&mut execution)
+                    .complete_segment(segment)
+                    .unwrap();
+                assert!(scene.live(&mut execution).contains(&square).unwrap());
+                traces.push(samples);
+            }
+            assert_eq!(traces[0], traces[1]);
+        }
+    }
+}
+
+#[test]
+fn mixed_create_uncreate_publishes_one_coherent_completion() {
+    let mut scene = Scene::new();
+    let leaving = scene.square(1.0).unwrap();
+    let entering = scene.square(0.5).unwrap();
+    scene.add(&leaving).unwrap();
+    let mut execution = scene.execution_session().unwrap();
+    let options = AnimationOptions::new()
+        .run_time(1.0)
+        .rate_func(RateFunction::Linear);
+    let segment = scene
+        .live(&mut execution)
+        .declare_and_activate_composition(
+            &Request::Composition {
+                kind: Kind::Parallel,
+                children: vec![
+                    Request::Uncreate {
+                        target: &leaving,
+                        options,
+                    },
+                    Request::Create {
+                        target: &entering,
+                        options,
+                    },
+                ],
+                options,
+            },
+            AnimationOptions::new(),
+        )
+        .unwrap();
+    assert!(scene.live(&mut execution).contains(&entering).unwrap());
+    scene
+        .live(&mut execution)
+        .advance_segment_to(segment, 0.5)
+        .unwrap();
+    assert_eq!(execution.frame().reveal(0), 0.5);
+    assert_eq!(execution.frame().reveal(1), 0.5);
+    scene
+        .live(&mut execution)
+        .advance_segment_to(segment, 1.0)
+        .unwrap();
+    scene
+        .live(&mut execution)
+        .complete_segment(segment)
+        .unwrap();
+    assert!(!scene.live(&mut execution).contains(&leaving).unwrap());
+    assert!(scene.live(&mut execution).contains(&entering).unwrap());
+}
+
+#[test]
+fn rejected_composition_cannot_partially_admit_uncreate() {
+    let scene = Scene::new();
+    let target = scene.square(1.0).unwrap();
+    let foreign = Scene::new().square(1.0).unwrap();
+    let mut execution = scene.execution_session().unwrap();
+    let before = execution.publication_context();
+    let options = AnimationOptions::new();
+    assert!(scene
+        .live(&mut execution)
+        .declare_and_activate_composition(
+            &Request::Composition {
+                kind: Kind::Parallel,
+                children: vec![
+                    Request::Uncreate {
+                        target: &target,
+                        options
+                    },
+                    Request::Create {
+                        target: &foreign,
+                        options
+                    }
+                ],
+                options,
+            },
+            options,
+        )
+        .is_err());
+    assert_eq!(execution.publication_context(), before);
+    assert_eq!(
+        scene.store().borrow().scene_revision(),
+        before.scene_revision()
+    );
+    assert!(!scene.live(&mut execution).contains(&target).unwrap());
+}

--- a/scripts/check-web-package.mjs
+++ b/scripts/check-web-package.mjs
@@ -303,6 +303,7 @@ const expectedTypeSurface = [
   "beginOrdinaryCreate(",
   "export class WasmOrdinaryCreateParallelBuilder",
   "appendCreate(object_id: string, target: WasmAuthoringMobjectHandle, child_run_time: number, rate_function: string): void",
+  "appendUncreate(object_id: string, target: WasmAuthoringMobjectHandle, child_run_time: number, rate_function: string, remover: boolean, reverse_rate_function: boolean): void",
   "beginOrdinaryCreateParallel(play_run_time: number | null | undefined, rate_function: string): WasmOrdinaryCreateParallelBuilder",
   "ordinaryPlayCreateParallel(candidate: WasmOrdinaryCreateParallelBuilder): number",
   "beginOrdinaryCreateParallelSegment(candidate: WasmOrdinaryCreateParallelBuilder): number",

--- a/scripts/shared-authoring-smoke.mjs
+++ b/scripts/shared-authoring-smoke.mjs
@@ -3177,6 +3177,31 @@ result = scene
     await rasterPage.evaluate(async () => {
       await window.noonHostRaster.ready();
       await window.noonHostRaster.load(`from noon import *
+class RejectedAdmission(Scene):
+    def construct(self):
+        entering = Square()
+        try:
+            self.play(Create(entering), object())
+            raise AssertionError("unsupported composition was accepted")
+        except NotImplementedError:
+            pass
+        assert entering not in self.mobjects
+        assert not getattr(self, "_legacy_geometry_materialized", False)
+        self.play(Create(entering), run_time=0.1)
+        self.play(Uncreate(entering), run_time=0.1)
+        assert entering not in self.mobjects
+`, 1);
+    });
+    const admitted = await rasterPage.evaluate(() => window.noonHostRaster.renderThrough(2, [0, 0.1, 0.2]));
+    assert.equal(admitted.time, 0.2);
+    assert.equal(admitted.objectCount, 0);
+    assert.equal(admitted.authoredDuration, 0.2);
+
+    await rasterPage.reload({ waitUntil: "load" });
+    await rasterPage.waitForFunction(() => window.noonHostRaster, null, { timeout: 30_000 });
+    await rasterPage.evaluate(async () => {
+      await window.noonHostRaster.ready();
+      await window.noonHostRaster.load(`from noon import *
 class LateFailure(Scene):
     def construct(self):
         self.add(Circle())

--- a/scripts/shared-authoring-smoke.mjs
+++ b/scripts/shared-authoring-smoke.mjs
@@ -2800,7 +2800,7 @@ result = scene
   });
   assert.match(
     mixedTimingError,
-    /canonical ValueTracker\.play cannot follow legacy Scene timing/u,
+    /cannot follow legacy Scene timing/u,
     "real worker must reject a legacy timing prefix before canonical scalar authoring",
   );
 

--- a/web/python/_manim_canonical_scene.py
+++ b/web/python/_manim_canonical_scene.py
@@ -855,79 +855,6 @@ def _declare_wait(scene: _base.Scene, duration: float = 1.0) -> _base.Scene:
     return scene
 
 
-def _play_canonical_tracker(
-    self: _base.Scene,
-    builder: _reactive._ValueAnimationBuilder,
-    *,
-    duration: float | None,
-    run_time: float | None,
-    start_time: float | None,
-    easing: str | None,
-    rate_func: object | None,
-    lag_ratio: float | None,
-    kwargs: dict[str, object],
-) -> _base.Scene | _SemanticContinuationAwaitable:
-    if duration is not None and run_time is not None:
-        raise ValueError("use either duration or run_time, not both")
-    if easing is not None and rate_func is not None:
-        raise ValueError("use either rate_func or the low-level easing alias, not both")
-    if start_time is not None:
-        raise NotImplementedError(
-            "canonical ValueTracker.play uses the shared Scene authoring cursor"
-        )
-    if kwargs:
-        unsupported = ", ".join(sorted(kwargs))
-        raise NotImplementedError(f"unsupported Manim Scene.play option(s): {unsupported}")
-    if builder.target_value is None:
-        raise ValueError("ValueTracker.animate must call set_value or increment_value")
-    resolved = _options.resolve(
-        builder_args=_options.builder_args(builder),
-        default_lag_ratio=0.0,
-        play_run_time=(run_time if run_time is not None else duration),
-        play_easing=easing,
-        play_rate_func=rate_func,
-        play_lag_ratio=lag_ratio,
-    )
-    if resolved.lag_ratio != 0.0:
-        raise NotImplementedError(
-            "canonical ValueTracker.play currently supports one scalar track at a time"
-        )
-    authority, _ = _timing_authority(self)
-    if authority != "canonical" and _legacy_authored_time(self) != 0.0:
-        raise NotImplementedError(
-            "canonical ValueTracker.play cannot follow legacy Scene timing"
-        )
-    try:
-        _start_default_synchronous_continuation(self)
-        _require_semantic_continuation_active(self)
-        _associate_tracker(self, builder.tracker)
-        if builder.tracker._scene is not self:
-            raise ValueError("ValueTracker belongs to another Scene")
-        context, handle = builder.tracker._canonical_context_handle()
-        if context is not _context(self):
-            raise ValueError("ValueTracker belongs to another canonical Scene context")
-        if _semantic_continuation_active(self):
-            _prepare_semantic_continuation_callbacks(self, context)
-        method = (
-            context.beginOrdinaryValueTrackerPlay
-            if _semantic_continuation_active(self)
-            else context.declareValueTrackerPlay
-        )
-        method(
-            handle,
-            float(builder.target_value),
-            float(resolved.run_time),
-            str(resolved.rate_func),
-        )
-    except Exception as error:
-        raise ValueError(str(error)) from None
-    if _async_continuation_active(self):
-        return _continuation_awaitable(self)
-    if _synchronous_continuation_active(self):
-        return _synchronous_continuation_wait(self)
-    return self
-
-
 def _canonical_affine_animation(
     scene: _base.Scene, animation: object
 ) -> tuple[_base.Mobject, _base.Mobject, object] | None:
@@ -1009,25 +936,6 @@ def _canonical_affine_options(
     ):
         return None
     return resolved
-
-
-def _canonical_affine_payload_is_supported(
-    scene: _base.Scene,
-    source: _base.Mobject,
-    target: _base.Mobject,
-    animation: object,
-    kwargs: dict[str, object],
-) -> bool:
-    """Ask the shared compiler whether this inert payload can enter live execution."""
-    resolved = _canonical_affine_options(animation, kwargs)
-    if resolved is None:
-        return False
-    return bool(_context(scene).ordinaryCanPlayTransformTo(
-        getattr(source, "_semantic_handle"),
-        getattr(target, "_semantic_handle"),
-        float(resolved.run_time),
-        str(resolved.rate_func),
-    ))
 
 
 def _canonical_affine_lifecycle_animation(
@@ -1135,7 +1043,9 @@ def _play_canonical_affine_lifecycle(
 
 
 def _play_legacy_compatibility(self: _base.Scene, *args, **kwargs):
-    """Use the one existing #959 legacy play/export boundary when it is safe."""
+    """Author the explicitly requested #959 external document."""
+    if not getattr(self, _EXPORT_DOCUMENT_CONSTRUCT, False):
+        raise NotImplementedError("legacy play is available only for explicit document export")
     authority, _ = _timing_authority(self)
     if authority == "canonical":
         raise NotImplementedError(
@@ -1152,78 +1062,6 @@ def _play_legacy_compatibility(self: _base.Scene, *args, **kwargs):
     # not force it through a geometry-only legacy document.
     materialize_legacy_geometry(self)
     return _ORIGINAL_PLAY(self, *args, **kwargs)
-
-
-def _play_canonical_affine(
-    self: _base.Scene,
-    source: _base.Mobject,
-    target: _base.Mobject,
-    animation: object,
-    *,
-    duration: float | None,
-    run_time: float | None,
-    start_time: float | None,
-    easing: str | None,
-    rate_func: object | None,
-    lag_ratio: float | None,
-    kwargs: dict[str, object],
-) -> _base.Scene | _SemanticContinuationAwaitable:
-    if duration is not None and run_time is not None:
-        raise ValueError("use either duration or run_time, not both")
-    if easing is not None and rate_func is not None:
-        raise ValueError("use either rate_func or the low-level easing alias, not both")
-    if start_time is not None:
-        raise NotImplementedError(
-            "canonical ordinary Scene.play uses the shared session cursor"
-        )
-    if kwargs:
-        unsupported = ", ".join(sorted(kwargs))
-        raise NotImplementedError(f"unsupported Manim Scene.play option(s): {unsupported}")
-    if getattr(self, "_legacy_geometry_materialized", False):
-        raise NotImplementedError(
-            "canonical ordinary animation cannot follow legacy geometry materialization"
-        )
-    if _legacy_authored_time(self) != 0.0:
-        raise NotImplementedError(
-            "canonical ordinary Scene.play cannot follow legacy Scene timing"
-        )
-
-    resolved = _options.resolve(
-        builder_args=_options.builder_args(animation),
-        default_lag_ratio=0.0,
-        play_run_time=(run_time if run_time is not None else duration),
-        play_easing=easing,
-        play_rate_func=rate_func,
-        play_lag_ratio=lag_ratio,
-    )
-    if resolved.lag_ratio != 0.0 or resolved.path_arc != 0.0 or resolved.reverse_rate_function:
-        raise NotImplementedError(
-            "canonical ordinary Scene.play currently supports one affine transform without path or lag options"
-        )
-    _start_default_synchronous_continuation(self)
-    context = _context(self)
-    try:
-        _require_semantic_continuation_active(self)
-        if _semantic_continuation_active(self):
-            _prepare_semantic_continuation_callbacks(self, context)
-        method = (
-            context.beginOrdinaryTransformTo
-            if _semantic_continuation_active(self)
-            else context.ordinaryPlayTransformTo
-        )
-        method(
-            getattr(source, "_semantic_handle"),
-            getattr(target, "_semantic_handle"),
-            float(resolved.run_time),
-            str(resolved.rate_func),
-        )
-    except Exception as error:
-        raise ValueError(str(error)) from None
-    if _async_continuation_active(self):
-        return _continuation_awaitable(self)
-    if _synchronous_continuation_active(self):
-        return _synchronous_continuation_wait(self)
-    return self
 
 
 def _canonical_fade_animation(
@@ -1342,102 +1180,6 @@ def _canonical_uncreate_options(animation: object, kwargs: dict[str, object]) ->
     return _canonical_affine_options(animation, kwargs)
 
 
-def _play_canonical_create(
-    self: _base.Scene,
-    target: _base.Mobject,
-    animation: object,
-    *,
-    remove: bool = False,
-    **kwargs: object,
-) -> _base.Scene | _SemanticContinuationAwaitable:
-    duration = kwargs.pop("duration", None)
-    run_time = kwargs.pop("run_time", None)
-    start_time = kwargs.pop("start_time", None)
-    easing = kwargs.pop("easing", None)
-    rate_func = kwargs.pop("rate_func", None)
-    lag_ratio = kwargs.pop("lag_ratio", None)
-    if duration is not None and run_time is not None:
-        raise ValueError("use either duration or run_time, not both")
-    if easing is not None and rate_func is not None:
-        raise ValueError("use either rate_func or the low-level easing alias, not both")
-    if start_time is not None:
-        raise NotImplementedError("canonical ordinary Scene.play uses the shared session cursor")
-    if kwargs:
-        unsupported = ", ".join(sorted(kwargs))
-        raise NotImplementedError(f"unsupported Manim Scene.play option(s): {unsupported}")
-    if _legacy_authored_time(self) != 0.0:
-        raise NotImplementedError("canonical ordinary Create cannot follow legacy Scene timing")
-    option_kwargs = {
-        "duration": duration,
-        "run_time": run_time,
-        "start_time": start_time,
-        "easing": easing,
-        "rate_func": rate_func,
-        "lag_ratio": lag_ratio,
-    }
-    resolved = (
-        _canonical_uncreate_options(animation, option_kwargs)
-        if remove
-        else _canonical_create_options(animation, option_kwargs)
-    )
-    if resolved is None:
-        raise NotImplementedError(
-            "canonical ordinary Create currently supports one basic detached leaf"
-        )
-    _start_default_synchronous_continuation(self)
-    handle = getattr(target, "_semantic_handle")
-    reservation = None
-    if target._scene is None:
-        reservation = _reserve_typed_binding(target, self, handle, None)
-        object_id = str(reservation.object.id)
-    elif remove and target._scene is self and target._object is not None:
-        object_id = str(target._object.id)
-    else:
-        raise ValueError("canonical Create target must be detached")
-    context = _context(self)
-    try:
-        _require_semantic_continuation_active(self)
-        method = (
-            (context.beginOrdinaryUncreate if remove else context.beginOrdinaryCreate)
-            if _semantic_continuation_active(self)
-            else (context.ordinaryPlayUncreate if remove else context.ordinaryPlayCreate)
-        )
-        arguments = [
-            object_id,
-            handle,
-            float(resolved.run_time),
-            str(resolved.rate_func),
-        ]
-        if remove:
-            arguments.extend(
-                [
-                    bool(getattr(animation, "remover", True)),
-                    bool(getattr(animation, "reverse_rate_function", True)),
-                ]
-            )
-        method(*arguments)
-    except Exception as error:
-        raise ValueError(str(error)) from None
-    if reservation is not None:
-        _commit_typed_binding(target, self, reservation, handle)
-        register = getattr(self, "_register_top_level", None)
-        if register is not None:
-            register(target)
-
-    def completed() -> None:
-        if remove and bool(getattr(animation, "remover", True)):
-            _reconcile_fade_membership(self, target, "out")
-
-    if _async_continuation_active(self):
-        return _continuation_awaitable(self, completed)
-    if _synchronous_continuation_active(self):
-        _synchronous_continuation_wait(self)
-        completed()
-        return self
-    completed()
-    return self
-
-
 def _canonical_fade_endpoint(animation: object) -> tuple[float, str, float, float] | None:
     """Return the inert endpoint values that Rust resolves at activation."""
     shift = getattr(animation, "_fade_shift_vector", None)
@@ -1476,19 +1218,6 @@ def _canonical_fade_options(
     )
 
 
-def _fade_object_id(
-    scene: _base.Scene, target: _base.Mobject, direction: str
-) -> tuple[str, _TypedBindingReservation | None]:
-    """Reserve only derived wrapper identity; Rust owns fade membership."""
-    handle = getattr(target, "_semantic_handle")
-    if direction == "in":
-        reservation = _reserve_typed_binding(target, scene, handle, None)
-        return str(reservation.object.id), reservation
-    if target._object is None:
-        raise ValueError("canonical FadeOut target has no wrapper object identity")
-    return str(target._object.id), None
-
-
 def _reconcile_fade_membership(
     scene: _base.Scene, target: _base.Mobject, direction: str
 ) -> None:
@@ -1503,144 +1232,6 @@ def _reconcile_fade_membership(
     # Preserve ObjectId/key/opaque handle for a same-handle `Scene.add` re-entry.
     # The context's membership query is authoritative; this is only wrapper state.
     target._scene = None
-
-
-def _play_canonical_fade(
-    self: _base.Scene,
-    target: _base.Mobject,
-    direction: str,
-    animation: object,
-    *,
-    duration: float | None,
-    run_time: float | None,
-    start_time: float | None,
-    easing: str | None,
-    rate_func: object | None,
-    lag_ratio: float | None,
-    kwargs: dict[str, object],
-) -> _base.Scene | _SemanticContinuationAwaitable:
-    if duration is not None and run_time is not None:
-        raise ValueError("use either duration or run_time, not both")
-    if easing is not None and rate_func is not None:
-        raise ValueError("use either rate_func or the low-level easing alias, not both")
-    if start_time is not None:
-        raise NotImplementedError("canonical ordinary Scene.play uses the shared session cursor")
-    if kwargs:
-        unsupported = ", ".join(sorted(kwargs))
-        raise NotImplementedError(f"unsupported Manim Scene.play option(s): {unsupported}")
-    if getattr(self, "_legacy_geometry_materialized", False):
-        raise NotImplementedError("canonical ordinary Fade cannot follow legacy geometry materialization")
-    if _legacy_authored_time(self) != 0.0:
-        raise NotImplementedError("canonical ordinary Fade cannot follow legacy Scene timing")
-
-    resolved = _canonical_fade_options(
-        animation,
-        {
-            "duration": duration,
-            "run_time": run_time,
-            "start_time": start_time,
-            "easing": easing,
-            "rate_func": rate_func,
-            "lag_ratio": lag_ratio,
-        },
-    )
-    if resolved is None:
-        raise NotImplementedError(
-            "canonical ordinary Fade requires one finite typed leaf endpoint"
-        )
-    endpoint = _canonical_fade_endpoint(animation)
-    assert endpoint is not None
-    scale_factor, translation, x, y = endpoint
-    _start_default_synchronous_continuation(self)
-    object_id, reservation = _fade_object_id(self, target, direction)
-    context = _context(self)
-    try:
-        _require_semantic_continuation_active(self)
-        method = (
-            context.beginOrdinaryFade
-            if _semantic_continuation_active(self)
-            else context.ordinaryPlayFade
-        )
-        method(
-            object_id,
-            getattr(target, "_semantic_handle"),
-            direction,
-            scale_factor,
-            translation,
-            x,
-            y,
-            float(resolved.run_time),
-            str(resolved.rate_func),
-        )
-    except Exception as error:
-        raise ValueError(str(error)) from None
-    if reservation is not None:
-        _commit_typed_binding(target, self, reservation, getattr(target, "_semantic_handle"))
-        register = getattr(self, "_register_top_level", None)
-        if register is not None:
-            register(target)
-
-    def completed() -> None:
-        _reconcile_fade_membership(self, target, direction)
-
-    if _async_continuation_active(self):
-        return _continuation_awaitable(self, completed)
-    if _synchronous_continuation_active(self):
-        _synchronous_continuation_wait(self)
-        completed()
-        return self
-    completed()
-    return self
-
-
-def _canonical_composition_shape(scene: _base.Scene, args: tuple[object, ...]):
-    """Return one recursive Rust composition request shape without scheduling it."""
-    if len(args) == 1 and isinstance(args[0], _composition.AnimationGroup):
-        group = args[0]
-        kind = "sequence" if isinstance(group, _composition.Succession) else "parallel"
-        return kind, tuple(group.animations), group
-    if len(args) > 1:
-        return "parallel", args, None
-    if len(args) == 1:
-        import _manim_rotate as _rotate
-
-        animation = args[0]
-        if _canonical_passing_flash_animation(scene, animation) is not None:
-            return "parallel", args, None
-        if _canonical_family_reveal_animation(scene, animation) is not None:
-            return "parallel", args, None
-        if _canonical_text_reveal_animation(scene, animation) is not None:
-            return "parallel", args, None
-        if _canonical_text_family_fade_animation(scene, animation) is not None:
-            return "parallel", args, None
-        if _canonical_text_family_write_animation(scene, animation) is not None:
-            return "parallel", args, None
-        if _canonical_text_write_animation(scene, animation) is not None:
-            return "parallel", args, None
-        if _canonical_subset_display_animation(scene, animation) is not None:
-            return "parallel", args, None
-        if _canonical_draw_border_then_fill_animation(scene, animation) is not None:
-            return "parallel", args, None
-        if isinstance(animation, (_animate._AlignedGroupAnimationBuilder, _animate.Indicate)):
-            return "parallel", args, None
-        if type(animation) in (_rotate.Rotate, _rotate.Rotating, _rotate.FocusOn, _options.ScaleInPlace):
-            return "parallel", args, None
-        affine = _canonical_affine_animation(scene, animation)
-        if affine is not None and affine[0]._scene is None:
-            # Detached affine leaves use the same atomic admission as mixed plays.
-            return "parallel", args, None
-        if affine is not None and type(animation) in (
-            _base._AnimationBuilder,
-            _compat._CompatAnimationBuilder,
-        ):
-            source, target, _ = affine
-            if not math.isclose(
-                float(getattr(source, "_semantic_handle").wireRotation),
-                float(getattr(target, "_semantic_handle").wireRotation),
-                abs_tol=1e-12,
-            ):
-                return "parallel", args, None
-    return None
 
 
 def _canonical_play_options(kwargs: dict[str, object]) -> float | None:
@@ -1661,10 +1252,8 @@ def _canonical_play_options(kwargs: dict[str, object]) -> float | None:
     if kwargs:
         unsupported = ", ".join(sorted(kwargs))
         raise NotImplementedError(f"unsupported Manim Scene.play option(s): {unsupported}")
-    if lag_ratio is not None:
-        raise NotImplementedError(
-            "canonical ordinary composition does not yet support a Scene.play lag_ratio override"
-        )
+    if lag_ratio is not None and float(lag_ratio) != 0.0:
+        raise NotImplementedError("Scene.play lag_ratio overrides are not supported")
     value = run_time if run_time is not None else duration
     return None if value is None else float(value)
 
@@ -1683,10 +1272,8 @@ def _canonical_composition_rate_id(kwargs: dict[str, object]) -> str | None:
 
 def _canonical_composition_child_options(animation: object, kwargs: dict[str, object]):
     resolved = _canonical_affine_options(animation, kwargs)
-    if resolved is None or resolved.rate_func not in ("linear", "smooth"):
-        raise NotImplementedError(
-            "canonical ordinary composition currently requires linear or smooth affine leaves"
-        )
+    if resolved is None:
+        raise NotImplementedError("unsupported shared animation options")
     return resolved
 
 
@@ -2474,6 +2061,22 @@ def _build_canonical_composition_candidate(
                 str(child.rate_func),
             )
             return
+        uncreated = _canonical_uncreate_animation(self, animation)
+        if uncreated is not None:
+            child = _canonical_uncreate_options(animation, child_kwargs)
+            if child is None:
+                raise NotImplementedError("unsupported shared Uncreate options")
+            reservation = reserve(uncreated) if uncreated._scene is None else None
+            entering_id = "" if reservation is None or reservation.reuse_existing_identity else str(reservation.object.id)
+            remover = bool(getattr(animation, "remover", True))
+            builder.appendUncreate(
+                entering_id, uncreated._semantic_handle,
+                float(child.run_time), str(child.rate_func),
+                remover, bool(getattr(animation, "reverse_rate_function", True)),
+            )
+            if remover:
+                removals.append(uncreated)
+            return
         created = _canonical_create_animation(self, animation)
         if created is not None:
             child = _canonical_create_options(animation, child_kwargs)
@@ -2618,232 +2221,35 @@ def _play_canonical_composition(
 
 def _play(self, *args, **kwargs):
     _require_portable_barrier_admission(self)
-    # Grow/Spin/Shrink are shared Rust lifecycle operations even while an
-    # explicit export document is being authored. Only the other compatibility
-    # animations use the document codec below.
-    # Single-leaf Grow/Spin/Shrink retain the export-friendly shared lifecycle
-    # route. Mixed and grouped lifecycle requests are classified by the shared
-    # composition builder below so sibling order and admission stay atomic.
-    if len(args) == 1:
-        classified = _canonical_affine_lifecycle_animation(self, args[0])
-        if classified is not None:
-            target, animation = classified
-            return _play_canonical_affine_lifecycle(
-                self,
-                target,
-                animation,
-                duration=kwargs.pop("duration", None),
-                run_time=kwargs.pop("run_time", None),
-                start_time=kwargs.pop("start_time", None),
-                easing=kwargs.pop("easing", None),
-                rate_func=kwargs.pop("rate_func", None),
-                lag_ratio=kwargs.pop("lag_ratio", None),
-                kwargs=kwargs,
-            )
-    # An explicit document request authors tracks for its external artifact.
-    # Completing a live segment here would discard the exported animation and
-    # mix runtime completion with the codec's authored-time cursor.
     if getattr(self, _EXPORT_DOCUMENT_CONSTRUCT, False):
+        # The requested external artifact still uses the #959 export codec.
+        if len(args) == 1:
+            classified = _canonical_affine_lifecycle_animation(self, args[0])
+            if classified is not None:
+                target, animation = classified
+                return _play_canonical_affine_lifecycle(
+                    self,
+                    target,
+                    animation,
+                    duration=kwargs.pop("duration", None),
+                    run_time=kwargs.pop("run_time", None),
+                    start_time=kwargs.pop("start_time", None),
+                    easing=kwargs.pop("easing", None),
+                    rate_func=kwargs.pop("rate_func", None),
+                    lag_ratio=kwargs.pop("lag_ratio", None),
+                    kwargs=kwargs,
+                )
         return _play_legacy_compatibility(self, *args, **kwargs)
-    # Once an unsupported compatibility animation has selected the explicit
-    # #959 export/materialization boundary, its timing and lowering remain on
-    # that path.  Typed handles deliberately survive materialization for
-    # identity/export purposes, so they must not reclassify a later ordinary
-    # compatibility play as a canonical live animation.
     if getattr(self, "_legacy_geometry_materialized", False):
-        if _semantic_continuation_active(self):
-            raise NotImplementedError(
-                "realtime construct supports only canonical affine Scene.play and Scene.wait"
-            )
-        return _play_legacy_compatibility(self, *args, **kwargs)
+        raise NotImplementedError("shared Scene.play cannot follow legacy geometry materialization")
 
-    # Classify every recursive composition before the single-leaf classifiers:
-    # multiple arguments and grouped children must share one Rust admission
-    # transaction, including mixed Create/Fade/lifecycle/Wait siblings.
-    if (shape := _canonical_composition_shape(self, args)) is not None:
-        kind, animations, group = shape
-        try:
-            candidate = _build_canonical_composition_candidate(
-                self, kind, animations, group, kwargs
-            )
-        except NotImplementedError:
-            context = getattr(self, "_canonical_authoring_context", None)
-            ownership = getattr(context, "liveExecutionOwnership", None)
-            if callable(ownership) and str(ownership()) != "none":
-                raise
-            return _play_legacy_compatibility(self, *args, **kwargs)
-        if candidate is False:
-            context = _context(self)
-            if str(context.liveExecutionOwnership()) != "none":
-                raise NotImplementedError(
-                    "active canonical execution cannot fall back to the legacy composition scheduler"
-                )
-            return _play_legacy_compatibility(self, *args, **kwargs)
-        if candidate is not None:
-            return _play_canonical_composition(self, *candidate)
-
-    canonical_uncreates = [
-        target
-        for argument in args
-        if (target := _canonical_uncreate_animation(self, argument)) is not None
-    ]
-    if canonical_uncreates:
-        if len(canonical_uncreates) != 1 or len(args) != 1:
-            if _semantic_continuation_active(self):
-                raise NotImplementedError(
-                    "realtime construct supports one canonical Uncreate per play"
-                )
-            return _play_legacy_compatibility(self, *args, **kwargs)
-        if _canonical_uncreate_options(args[0], kwargs) is None:
-            if _semantic_continuation_active(self):
-                raise NotImplementedError(
-                    "realtime construct Uncreate is outside the canonical leaf subset"
-                )
-            return _play_legacy_compatibility(self, *args, **kwargs)
-        return _play_canonical_create(
-            self, canonical_uncreates[0], args[0], remove=True, **kwargs
-        )
-
-    canonical_creates = [
-        target
-        for argument in args
-        if (target := _canonical_create_animation(self, argument)) is not None
-    ]
-    if canonical_creates:
-        if len(canonical_creates) != 1 or len(args) != 1:
-            if _semantic_continuation_active(self):
-                raise NotImplementedError(
-                    "realtime construct supports only flat parallel canonical Create leaves"
-                )
-            return _play_legacy_compatibility(self, *args, **kwargs)
-        if _canonical_create_options(args[0], kwargs) is None:
-            if _semantic_continuation_active(self):
-                raise NotImplementedError("realtime construct Create is outside the canonical leaf subset")
-            context = getattr(self, "_canonical_authoring_context", None)
-            ownership = getattr(context, "liveExecutionOwnership", None)
-            if callable(ownership) and str(ownership()) in {"active", "transferred", "returned"}:
-                raise NotImplementedError(
-                    "active canonical execution cannot fall back to the legacy Create scheduler"
-                )
-            return _play_legacy_compatibility(self, *args, **kwargs)
-        return _play_canonical_create(self, canonical_creates[0], args[0], **kwargs)
-
-    canonical_fades = [
-        classified
-        for argument in args
-        if (classified := _canonical_fade_animation(self, argument)) is not None
-    ]
-    if canonical_fades:
-        if len(canonical_fades) != 1 or len(args) != 1:
-            if _semantic_continuation_active(self):
-                raise NotImplementedError(
-                    "realtime construct supports one canonical FadeIn/FadeOut per play"
-                )
-            return _play_legacy_compatibility(self, *args, **kwargs)
-        target, direction = canonical_fades[0]
-        if _canonical_fade_options(args[0], kwargs) is None:
-            if _semantic_continuation_active(self):
-                raise NotImplementedError(
-                    "realtime construct fade is outside the canonical lifecycle subset"
-                )
-            context = getattr(self, "_canonical_authoring_context", None)
-            ownership = getattr(context, "liveExecutionOwnership", None)
-            if callable(ownership) and str(ownership()) in {"active", "transferred", "returned"}:
-                raise NotImplementedError(
-                    "active canonical execution cannot fall back to the legacy fade scheduler"
-                )
-            return _play_legacy_compatibility(self, *args, **kwargs)
-        return _play_canonical_fade(
-            self,
-            target,
-            direction,
-            args[0],
-            duration=kwargs.pop("duration", None),
-            run_time=kwargs.pop("run_time", None),
-            start_time=kwargs.pop("start_time", None),
-            easing=kwargs.pop("easing", None),
-            rate_func=kwargs.pop("rate_func", None),
-            lag_ratio=kwargs.pop("lag_ratio", None),
-            kwargs=kwargs,
-        )
-
-    canonical_lifecycles = [
-        classified
-        for argument in args
-        if (classified := _canonical_affine_lifecycle_animation(self, argument)) is not None
-    ]
-    if canonical_lifecycles:
-        if len(canonical_lifecycles) != 1 or len(args) != 1:
-            if _semantic_continuation_active(self):
-                raise NotImplementedError(
-                    "canonical ordinary affine lifecycle currently supports one leaf per play"
-                )
-            return _play_legacy_compatibility(self, *args, **kwargs)
-        target, animation = canonical_lifecycles[0]
-        return _play_canonical_affine_lifecycle(
-            self,
-            target,
-            animation,
-            duration=kwargs.pop("duration", None),
-            run_time=kwargs.pop("run_time", None),
-            start_time=kwargs.pop("start_time", None),
-            easing=kwargs.pop("easing", None),
-            rate_func=kwargs.pop("rate_func", None),
-            lag_ratio=kwargs.pop("lag_ratio", None),
-            kwargs=kwargs,
-        )
-
-    canonical_affine = [
-        classified
-        for argument in args
-        if (classified := _canonical_affine_animation(self, argument)) is not None
-    ]
-    if canonical_affine:
-        if len(canonical_affine) != 1 or len(args) != 1:
-            if _semantic_continuation_active(self):
-                raise NotImplementedError(
-                    "realtime construct supports one canonical affine animation per play"
-                )
-            return _play_legacy_compatibility(self, *args, **kwargs)
-        source, target, animation = canonical_affine[0]
-        if not _canonical_affine_payload_is_supported(
-            self, source, target, animation, kwargs
-        ):
-            if _semantic_continuation_active(self):
-                raise NotImplementedError(
-                    "realtime construct animation is outside the canonical affine subset"
-                )
-            return _play_legacy_compatibility(self, *args, **kwargs)
-        return _play_canonical_affine(
-            self,
-            source,
-            target,
-            animation,
-            duration=kwargs.pop("duration", None),
-            run_time=kwargs.pop("run_time", None),
-            start_time=kwargs.pop("start_time", None),
-            easing=kwargs.pop("easing", None),
-            rate_func=kwargs.pop("rate_func", None),
-            lag_ratio=kwargs.pop("lag_ratio", None),
-            kwargs=kwargs,
-        )
-    if len(args) == 1 and _canonical_tracker_builder(args[0]):
-        return _play_canonical_tracker(
-            self,
-            args[0],
-            duration=kwargs.pop("duration", None),
-            run_time=kwargs.pop("run_time", None),
-            start_time=kwargs.pop("start_time", None),
-            easing=kwargs.pop("easing", None),
-            rate_func=kwargs.pop("rate_func", None),
-            lag_ratio=kwargs.pop("lag_ratio", None),
-            kwargs=kwargs,
-        )
-    if _semantic_continuation_active(self):
-        raise NotImplementedError(
-            "realtime construct supports only canonical affine Scene.play and Scene.wait"
-        )
-    return _play_legacy_compatibility(self, *args, **kwargs)
+    group = args[0] if len(args) == 1 and isinstance(args[0], _composition.AnimationGroup) else None
+    kind = "sequence" if isinstance(group, _composition.Succession) else "parallel"
+    animations = tuple(group.animations) if group is not None else args
+    candidate = _build_canonical_composition_candidate(self, kind, animations, group, kwargs)
+    if candidate is False:
+        raise NotImplementedError("Scene.play request is unsupported by the shared Rust engine")
+    return _play_canonical_composition(self, *candidate)
 
 
 def _canonical_value_tracker(self: _base.Scene, value: float = 0.0) -> _reactive.ValueTracker:

--- a/web/python/examples/ordinary_uncreate_options.py
+++ b/web/python/examples/ordinary_uncreate_options.py
@@ -8,7 +8,9 @@ class OrdinaryUncreateOptions(Scene):
         forward = Square(side_length=0.4, color=GREEN)
         self.add(first, kept, forward)
 
-        self.play(Uncreate(first), run_time=2.0, rate_func=rush_into)
+        self.play(AnimationGroup(
+            Uncreate(first, run_time=2.0, rate_func=rush_into), rate_func=linear,
+        ))
         assert first not in self.mobjects
         assert kept in self.mobjects and forward in self.mobjects
 


### PR DESCRIPTION
Normal Python `Scene.play()` now sends singleton and recursive animation requests through the existing shared Rust composition admission and completion path. This removes the separate affine/Create/Uncreate/Fade/tracker Python dispatch, preflight and barrier helpers (over 600 deleted lines). Unsupported normal requests report an explicit error before selecting another scheduler; an explicit document-export request retains the existing #959 codec path.

Advances #958/#61/#959, especially A3.4/A3.5/A3.7. Shared Rust now admits ordinary Uncreate as a composition child, including detached entry, asymmetric easing, independent reverse/remover options and completion-owned removal. The direct Uncreate convenience delegates that same operation. Python's unnecessary linear/smooth restriction on ordinary composition leaves is removed; Rust validates supported deterministic rates. The WASM builder only transfers typed request arguments.

The paired Rust/Python Uncreate examples now exercise a grouped RushInto Uncreate followed by ordinary keep/forward variants, preserving their four-second output. Native regressions cover singleton/grouped equivalence, mixed Create/Uncreate completion and rejection without partial admission; the existing frontend-context integration test covers the new typed child. A production browser regression rejects a mixed unsupported request, verifies no membership/materialization occurred, and then executes normal Create/Uncreate on the same scene.

No new semantic/runtime/identity authority, transport boundary or migration adapter. Python classification visits the request tree; shared activation/publication retains its existing locality contracts. Phase A remains open: old unused singleton WASM exports/context conveniences and explicit export machinery still need deletion as their native context tests/callers migrate to the common request path. They are existing #61/#959 debt, not a new fallback for normal play.

Final full gate passed: `CARGO_TARGET_DIR=/Users/ykshin/Dev/me/noon/target CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=2 NOON_SKIP_WEB_PREFLIGHT=1 NOON_SKIP_PLAYGROUND_TEST=1 NOON_WASM_PROFILE=dev bash scripts/check.sh full` (1,749 Rust tests; 221 browser API contracts). `node scripts/manim-compat-smoke.mjs` passed, including the updated grouped Uncreate options example and supported rate functions. Focused direct Uncreate/composition/scalar probes passed on WebGPU and WebGL2. The complete current-runtime parity corpus passed all 11 fixtures / 83 Rust-Python frames (maximum effective absolute error 7.450580596923828e-09, below the existing 1e-6 tolerance). `node scripts/shared-authoring-smoke.mjs` passed the complete production authoring/worker/raster-host suite, including the new rejection-and-recovery case. The timing rejection assertion follows the shared boundary rather than the deleted singleton helper name; no production code changed after the full/parity/compatibility/direct passes. Focused `cargo test --workspace --all-features --test composition_admission` passed 3 tests. `NOON_WEB_PREFLIGHT_ONLY=1 NOON_SKIP_PLAYGROUND_TEST=1 bash scripts/check.sh web` passed 197 Python API tests plus 3 inventory checks. Architecture ratchet against fdc98a31705eb6e290cf702bd33764d63c9e1836 and diff check passed.
