### PR TITLE
Reject document execution fallback for shared scenes

### DIFF
--- a/scripts/shared-authoring-smoke.mjs
+++ b/scripts/shared-authoring-smoke.mjs
@@ -1031,6 +1031,48 @@ try {
   );
   assert.equal(exportBoundary.sentinelObjectCount, 0);
 
+  // A Rust-owned Scene must never silently switch to the Python document
+  // engine when finalization finds incompatible migration state. Explicit
+  // export above is the codec boundary; each rejected run uses the same worker.
+  const rejectedFinalizations = await page.evaluate(async () => {
+    const failures = [];
+    const corruptions = [
+      'scene._legacy_geometry_materialized = True',
+      'scene._reactive_signals.append({"legacy": True})',
+      'scene._semantic_geometry_handles.clear()',
+      'scene._tracks.append({"property": "position"})',
+    ];
+    for (const corruption of corruptions) {
+      const source = `from noon import Circle, Scene
+scene = Scene()
+scene.add(Circle(radius=0.4))
+assert scene._canonical_authoring_context is not None
+${corruption}
+def reject_export(*args, **kwargs):
+    raise AssertionError("normal shared finalization invoked the document exporter")
+scene.to_document = reject_export
+scene.to_scene_spec = reject_export
+result = scene
+`;
+      try {
+        await window.sharedAuthoringSmoke.authoring.run(source, {});
+        failures.push("unexpected success");
+      } catch (error) {
+        failures.push(String(error));
+      }
+    }
+    const recovered = await window.sharedAuthoringSmoke.authoring.run(
+      'from noon import Circle, Scene\nscene = Scene()\nscene.add(Circle(radius=0.4))\nresult = scene',
+      {},
+    );
+    return { failures, recovered: Object.hasOwn(recovered, "semanticExecution") };
+  });
+  for (const failure of rejectedFinalizations.failures) {
+    assert.match(failure, /shared Scene cannot fall back to scene-document execution/u);
+    assert.doesNotMatch(failure, /invoked the document exporter/u);
+  }
+  assert.equal(rejectedFinalizations.recovered, true);
+
   // A supported ordinary segment must fail at its JSPI capability gate instead
   // of silently using endpoint-only execution. The restore request verifies the
   // same worker-resident context never activated a player or advanced time.

--- a/web/python-worker.source.js
+++ b/web/python-worker.source.js
@@ -863,6 +863,12 @@ if isinstance(__noon_result, Scene):
         __noon_document = None
         __noon_identities = None
     else:
+        if (not __noon_export_document and
+                getattr(__noon_result, "_canonical_authoring_context", None) is not None):
+            raise RuntimeError(
+                "shared Scene cannot fall back to scene-document execution; "
+                "remove incompatible legacy declarations or request exportDocument explicitly"
+            )
         __noon_callbacks = _manim_updaters.register_scene(__noon_result)
         if __noon_callbacks and getattr(__noon_result, "_semantic_text_handles", {}):
             raise RuntimeError(


### PR DESCRIPTION
When a shared Rust Scene contained incompatible migration state, worker finalization could silently fall back to the Python scene-document engine. Normal finalization now rejects that switch before legacy materialization or export. Explicit `exportDocument` retains the existing codec boundary.

Advances #61 A3.7 and #959 A4.2. This is a worker ownership guard, with no new semantic authority, scheduler, transport, or compatibility adapter. The guard reads the existing context reference in constant time; semantic operations and Rust/Python examples are unchanged. Remaining document-only migration consumers and exporter internals stay under #959.

A production browser regression exercises materialized legacy state, reactive declarations, missing typed handle coverage and incompatible tracks. All four must reject without invoking the exporter, then the same worker must accept a valid typed scene. The existing smoke also covers explicit export, sequential continuations, callbacks, native signals and persisted scenes.

Validation:
- `CARGO_TARGET_DIR=/Users/ykshin/Dev/me/noon/target CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=2 bash scripts/check.sh fast`: passed.
- `NOON_WEB_PREFLIGHT_ONLY=1 NOON_SKIP_PLAYGROUND_TEST=1 bash scripts/check.sh web`: passed.
- `bash scripts/architecture-ratchet.sh 6a5ce8b494cb3a70628905a4f822e4a4c974586e`, `git diff --check`, worker generation and smoke syntax check: passed.
- `node scripts/shared-authoring-smoke.mjs`: passed, including the four refusal cases and same-worker recovery.
