### PR TITLE
Use shared continuations for top-level Python source

### DIFF
--- a/scripts/shared-authoring-smoke.mjs
+++ b/scripts/shared-authoring-smoke.mjs
@@ -1073,6 +1073,65 @@ result = scene
   }
   assert.equal(rejectedFinalizations.recovered, true);
 
+  // Top-level source and helper calls share the existing wait/play continuation.
+  // Selecting result must not implicitly run its construct again.
+  const topLevelSource = `from noon import *
+class SelectedScene(Scene):
+    def construct(self):
+        raise AssertionError("prebuilt result construct ran twice")
+result = SelectedScene()
+def author(scene):
+    scene.wait(0.25)
+    assert scene.time == 0.25
+    circle = Circle(0.4).set_fill(BLUE, opacity=1)
+    scene.add(circle)
+    scene.play(circle.animate.shift(RIGHT), run_time=0.5, rate_func=linear)
+    assert abs(circle.get_center().x - 1) < 1e-6
+    assert scene.time == 0.75
+    scene.wait(0.25)
+author(result)
+`;
+  await startSampledSource(page, topLevelSource, "scene-top-level-wait-play");
+  try {
+    const result = await page.evaluate(async () => {
+      const { execution, authored } = window.sharedAuthoringSmoke.sampledProof;
+      const [, completed] = await Promise.all([execution.sampleToAuthoredTime(1), authored]);
+      return { duration: completed.duration, metrics: (await execution.metrics()).metrics };
+    });
+    assert.equal(result.duration, 1);
+    assert.equal(result.metrics.objectCount, 1);
+  } finally {
+    await stopSampledSource(page);
+  }
+
+  const topLevelExample = await readFile(
+    path.join(repoRoot, "web/python/examples/top_level_family_arrangement.py"), "utf8",
+  );
+  await startSampledSource(page, topLevelExample, "scene-top-level-family-arrangement");
+  try {
+    const result = await page.evaluate(async () => {
+      const { execution, authored } = window.sharedAuthoringSmoke.sampledProof;
+      const [, completed] = await Promise.all([execution.sampleToAuthoredTime(1), authored]);
+      return { duration: completed.duration, metrics: (await execution.metrics()).metrics };
+    });
+    assert.equal(result.duration, 1);
+    assert.equal(result.metrics.objectCount, 2);
+  } finally {
+    await stopSampledSource(page);
+  }
+
+  const topLevelExport = await page.evaluate(async () => {
+    const result = await window.sharedAuthoringSmoke.authoring.run(
+      "from noon import *\nresult = Scene()\ncircle = Circle(0.4)\nresult.add(circle)\nresult.wait(0.25)\nresult.play(circle.animate.shift(RIGHT), run_time=0.5, rate_func=linear)\nresult.wait(0.25)",
+      {}, { exportDocument: true, onSemanticContinuation() {
+        throw new Error("top-level export leased a continuation");
+      } },
+    );
+    return { duration: result.duration, objects: result.document.objects.length,
+      semantic: Object.hasOwn(result, "semanticExecution") };
+  });
+  assert.deepEqual(topLevelExport, { duration: 1, objects: 1, semantic: false });
+
   // A supported ordinary segment must fail at its JSPI capability gate instead
   // of silently using endpoint-only execution. The restore request verifies the
   // same worker-resident context never activated a player or advanced time.

--- a/scripts/shared-authoring-smoke.mjs
+++ b/scripts/shared-authoring-smoke.mjs
@@ -2977,31 +2977,31 @@ class SelectedAlignment(Scene):
     });
   }
 
-  // A legacy wait before the first canonical scalar play must fail in the real
-  // authoring worker. The #959 bridge may select one cursor, never merge them.
-  const mixedTimingError = await page.evaluate(async () => {
-    const source = `from noon import Circle, RIGHT, Scene, linear
-
+  // A top-level wait and later scalar play use the same shared Rust cursor.
+  const topLevelScalarSource = `from noon import Circle, Scene, linear
 scene = Scene()
 circle = Circle(radius=0.4)
 scene.add(circle)
 progress = scene.value_tracker(0.0)
 scene.wait(1.0)
+assert scene.time == 1.0
 scene.play(progress.animate(run_time=2.0, rate_func=linear).set_value(4.0))
+assert scene.time == 3.0
+assert progress.get_value() == 4.0
 result = scene
 `;
-    try {
-      await window.sharedAuthoringSmoke.authoring.run(source, {});
-    } catch (error) {
-      return String(error);
-    }
-    throw new Error("mixed legacy/canonical timing unexpectedly authored a scene");
-  });
-  assert.match(
-    mixedTimingError,
-    /cannot follow legacy Scene timing/u,
-    "real worker must reject a legacy timing prefix before canonical scalar authoring",
-  );
+  await startSampledSource(page, topLevelScalarSource, "scene-top-level-wait-scalar");
+  try {
+    const result = await page.evaluate(async () => {
+      const { execution, authored } = window.sharedAuthoringSmoke.sampledProof;
+      const [, completed] = await Promise.all([execution.sampleToAuthoredTime(3), authored]);
+      return { duration: completed.duration, metrics: (await execution.metrics()).metrics };
+    });
+    assert.equal(result.duration, 3);
+    assert.equal(result.metrics.objectCount, 1);
+  } finally {
+    await stopSampledSource(page);
+  }
 
   // Opaque callbacks must progress forward through the required Rust barrier.
   // The exact callback publication for the first ordered target is observed

--- a/web/python-worker.source.js
+++ b/web/python-worker.source.js
@@ -797,7 +797,7 @@ from _manim_canonical_scene import (
     materialize_legacy_geometry,
 )
 from _manim_source_execution import (
-    BARRIER_GLOBAL, compile_authoring_source,
+    BARRIER_GLOBAL, compile_authoring_source, authoring_source_scope,
 )
 from noon import PatchBatch, Scene
 
@@ -810,7 +810,8 @@ __noon_code, __noon_portable_constructs = compile_authoring_source(
 )
 if __noon_portable_constructs:
     __noon_namespace[BARRIER_GLOBAL] = await_source_barrier
-exec(__noon_code, __noon_namespace)
+with authoring_source_scope(export_document=bool(__noon_export_document)):
+    exec(__noon_code, __noon_namespace)
 
 if "result" in __noon_namespace:
     __noon_result = __noon_namespace["result"]

--- a/web/python/_manim_canonical_scene.py
+++ b/web/python/_manim_canonical_scene.py
@@ -28,6 +28,7 @@ import _manim_phase_b as _phase_b
 import _manim_rate_functions as _rate_functions
 import _manim_reactive as _reactive
 import _manim_semantic_handles as _semantic_handles
+from _manim_source_execution import current_source_invocation
 import _noon_ir as _ir
 import noon as _base
 
@@ -62,6 +63,14 @@ _EXPORT_DOCUMENT_CONSTRUCT = "_noon_export_document_construct"
 _DEFAULT_SYNCHRONOUS_CONTINUATION_CANDIDATE = (
     "_noon_default_synchronous_continuation_candidate"
 )
+
+
+def _export_document_active(scene: _base.Scene) -> bool:
+    invocation = current_source_invocation()
+    return bool(
+        getattr(scene, _EXPORT_DOCUMENT_CONSTRUCT, False)
+        or (invocation is not None and invocation.export_document)
+    )
 
 
 def _json(value: object) -> str:
@@ -525,15 +534,20 @@ def _async_continuation_active(scene: _base.Scene) -> bool:
 
 
 def _default_synchronous_continuation_candidate(scene: _base.Scene) -> bool:
-    """Whether this ordinary construct may enter one supported JSPI barrier."""
-    return bool(getattr(scene, _DEFAULT_SYNCHRONOUS_CONTINUATION_CANDIDATE, False))
+    """Whether this ordinary host stack may enter a supported JSPI barrier."""
+    invocation = current_source_invocation()
+    return bool(
+        getattr(scene, _DEFAULT_SYNCHRONOUS_CONTINUATION_CANDIDATE, False)
+        or (invocation is not None and not invocation.export_document
+            and not _async_continuation_active(scene))
+    )
 
 
 def _start_default_synchronous_continuation(scene: _base.Scene) -> None:
     """Enter the existing synchronous continuation only before Rust mutation."""
     if (
         not _default_synchronous_continuation_candidate(scene)
-        or getattr(scene, _EXPORT_DOCUMENT_CONSTRUCT, False)
+        or _export_document_active(scene)
     ):
         return
     if _synchronous_continuation_active(scene):
@@ -548,6 +562,12 @@ def _start_default_synchronous_continuation(scene: _base.Scene) -> None:
             "Integration in this browser; use async construct or a JSPI-capable browser"
         )
     setattr(scene, _SYNCHRONOUS_CONTINUATION_MODE, True)
+    invocation = current_source_invocation()
+    if invocation is not None:
+        invocation.cleanup.callback(_finish_synchronous_continuation_construct, scene)
+        if _reactive._current_authoring_scene() is not scene:
+            token = _reactive._enter_authoring_scene(scene)
+            invocation.cleanup.callback(_reactive._leave_authoring_scene, token)
 
 
 def _finish_synchronous_continuation_construct(scene: _base.Scene) -> None:
@@ -807,7 +827,7 @@ def _canonical_wait(
     scene: _base.Scene, duration: float = 1.0
 ) -> _base.Scene | _SemanticContinuationAwaitable:
     _require_portable_barrier_admission(scene)
-    if getattr(scene, _EXPORT_DOCUMENT_CONSTRUCT, False):
+    if _export_document_active(scene):
         authority, _ = _timing_authority(scene)
         if authority == "canonical":
             try:
@@ -822,8 +842,9 @@ def _canonical_wait(
             _create_context is not None
             or getattr(scene, "_canonical_authoring_context", None) is not None
         )
-        and execution_context(scene) is not None
     ):
+        if execution_context(scene) is None:
+            raise NotImplementedError("Scene.wait request is unsupported by the shared Rust engine")
         _start_default_synchronous_continuation(scene)
     if _semantic_continuation_active(scene):
         try:
@@ -1044,7 +1065,7 @@ def _play_canonical_affine_lifecycle(
 
 def _play_legacy_compatibility(self: _base.Scene, *args, **kwargs):
     """Author the explicitly requested #959 external document."""
-    if not getattr(self, _EXPORT_DOCUMENT_CONSTRUCT, False):
+    if not _export_document_active(self):
         raise NotImplementedError("legacy play is available only for explicit document export")
     authority, _ = _timing_authority(self)
     if authority == "canonical":
@@ -2221,7 +2242,7 @@ def _play_canonical_composition(
 
 def _play(self, *args, **kwargs):
     _require_portable_barrier_admission(self)
-    if getattr(self, _EXPORT_DOCUMENT_CONSTRUCT, False):
+    if _export_document_active(self):
         # The requested external artifact still uses the #959 export codec.
         if len(args) == 1:
             classified = _canonical_affine_lifecycle_animation(self, args[0])

--- a/web/python/_manim_source_execution.py
+++ b/web/python/_manim_source_execution.py
@@ -15,9 +15,40 @@ from __future__ import annotations
 import ast
 import copy
 import inspect
+from contextlib import ExitStack, contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
 from types import CodeType, FunctionType, MethodType
 
 BARRIER_GLOBAL = "_noon_await_source_barrier"
+
+
+@dataclass
+class _SourceInvocation:
+    export_document: bool
+    cleanup: ExitStack
+
+
+_SOURCE_INVOCATION: ContextVar[_SourceInvocation | None] = ContextVar(
+    "noon_source_invocation", default=None
+)
+
+
+def current_source_invocation():
+    return _SOURCE_INVOCATION.get()
+
+
+@contextmanager
+def authoring_source_scope(*, export_document: bool = False):
+    """Scope top-level host execution and restore continuation flags on exit.
+
+    Scene state and timing stay in Rust. The scope carries invocation mode and
+    host cleanup only; construct dispatch retains its portable/async handling.
+    """
+    with ExitStack() as cleanup:
+        token = _SOURCE_INVOCATION.set(_SourceInvocation(export_document, cleanup))
+        cleanup.callback(_SOURCE_INVOCATION.reset, token)
+        yield
 
 # Calls on the scene that cannot suspend the authoring continuation. Unknown
 # methods (including super().construct()) are not silently converted.

--- a/web/python/examples/top_level_family_arrangement.py
+++ b/web/python/examples/top_level_family_arrangement.py
@@ -1,0 +1,30 @@
+"""Top-level host form of ordinary_family_arrangement.
+
+The paired Rust program is noon::example_scenes::family_arrangement::program.
+Top-level play/wait suspends this Python stack using the existing JSPI host path.
+"""
+from noon import *
+
+result = Scene()
+first = Circle(radius=0.2).set_fill(BLUE, opacity=1).set_stroke(width=0)
+second = Circle(radius=0.2).set_fill(YELLOW, opacity=1).set_stroke(width=0)
+second.shift(2 * RIGHT)
+# One semantic leaf participates in both a direct and a nested member.
+nested = VGroup(first, second)
+family = VGroup(first, nested)
+assert abs(family.width - 2.4) < 1e-6
+assert abs(family.height - 0.4) < 1e-6
+family.arrange(RIGHT, buff=0.2)
+result.add(first, second)
+result.wait(0.5)
+family = VGroup(first, nested)
+family.remove(nested)
+family.add(nested)
+family.arrange(UP, buff=0.3, center=False, aligned_edge=LEFT)
+assert abs(nested.width - 2.4) < 1e-5
+assert abs(nested.get_center().x) < 1e-5
+nested.move_to(ORIGIN, coor_mask=(1, 0, 0))
+nested.next_to(ORIGIN, direction=2 * UP, buff=0.25, coor_mask=(0, 1, 0),
+               index_of_submobject_to_align=-1)
+nested.align_to(first, UP)
+result.wait(0.5)

--- a/web/python/test_manim_source_execution.py
+++ b/web/python/test_manim_source_execution.py
@@ -7,10 +7,38 @@ import unittest
 from _manim_source_execution import (
     BARRIER_GLOBAL, bind_portable_construct, compile_authoring_source,
     has_portable_scene_methods,
+    authoring_source_scope, current_source_invocation,
 )
 
 
 class SourceExecutionTests(unittest.IsolatedAsyncioTestCase):
+    async def test_source_invocation_restores_mode_and_cleanup_after_failure(self):
+        cleanups = []
+        self.assertIsNone(current_source_invocation())
+        with authoring_source_scope():
+            ordinary = current_source_invocation()
+            self.assertFalse(ordinary.export_document)
+            ordinary.cleanup.callback(cleanups.append, "ordinary")
+            with self.assertRaisesRegex(RuntimeError, "source failed"):
+                with authoring_source_scope(export_document=True):
+                    exported = current_source_invocation()
+                    self.assertTrue(exported.export_document)
+                    exported.cleanup.callback(cleanups.append, "export")
+                    await asyncio.sleep(0)
+                    raise RuntimeError("source failed")
+            self.assertIs(current_source_invocation(), ordinary)
+            self.assertEqual(cleanups, ["export"])
+        self.assertEqual(cleanups, ["export", "ordinary"])
+        self.assertIsNone(current_source_invocation())
+
+    async def test_source_invocation_modes_are_isolated_between_tasks(self):
+        async def observe(export_document):
+            with authoring_source_scope(export_document=export_document):
+                await asyncio.sleep(0)
+                return current_source_invocation().export_document
+        self.assertEqual(await asyncio.gather(observe(True), observe(False)), [True, False])
+        self.assertIsNone(current_source_invocation())
+
     def compile_scene(self, source, namespace=None):
         namespace = {} if namespace is None else namespace
         code, pairs = compile_authoring_source(textwrap.dedent(source))


### PR DESCRIPTION
Top-level Python source now uses the existing shared Rust play/wait continuation. Previously, an initial top-level Scene.wait could advance the Python cursor and make the following shared Scene.play fail; source helper calls now receive the same invocation mode as construct calls. Late construction uses the existing authoring-scene context after the first barrier. Selecting a prebuilt result still does not run its construct implicitly.

Explicit exportDocument applies during module execution as well as construct dispatch, so top-level export uses the existing external codec without leasing a renderer continuation. Invocation mode is task-local and cleanup restores host continuation flags and authoring context on both success and failure. Python owns only this host invocation bookkeeping; Rust retains timing, scene state and the current session. The existing JSPI capability gate remains in force for arbitrary synchronous stacks; portable/async construct handling is unchanged.

Advances #61 and #959. No new scheduler, identity, transport or migration seam. There is constant-time scope lookup at host barriers and cleanup proportional to the invoked scenes, with no per-frame or whole-scene work. Existing no-context document-only fallback and remaining export/dynamic migration code are still owned by #959.

The new top_level_family_arrangement.py demonstrates the same semantics as the existing noon::example_scenes::family_arrangement::program through a different Python host form; the normal class-based paired example remains available.

Validation:
- python3 -m unittest discover -s web/python -p test_manim_source_execution.py:13 passed, including nested scope failure cleanup and async task isolation.
- NOON_WEB_PREFLIGHT_ONLY=1 NOON_SKIP_PLAYGROUND_TEST=1 bash scripts/check.sh web:199 Python API tests plus inventory/JS/browser preflight passed; generated the updated Python worker.
- Current-runtime parity against the existing native Rust family arrangement program:5 frames, zero effective-state error.
- bash scripts/architecture-ratchet.sh a1aa3921bb3463c2f2c76de473af59a766e64490 and git diff --check:passed.
- node scripts/shared-authoring-smoke.mjs:passed, including initial top-level wait -> late construction -> play -> wait, wait -> scalar play with shared time/value assertions, prebuilt result selection, top-level paired arrangement, explicit top-level export and existing callback/native-signal/continuation coverage. The first run found an old regression that expected the former legacy top-level wait; updated that test to prove the now-supported shared wait/scalar sequence and reran the browser smoke. No production edits followed the Python preflight/parity pass.

No Rust production code or WASM API changed, so the current package and Rust gates were reused. Browser/runtime parity is not an independent Manim differential run.
