### PR TITLE
Require shared Rust execution for normal Python scenes

### DIFF
--- a/scripts/shared-authoring-smoke.mjs
+++ b/scripts/shared-authoring-smoke.mjs
@@ -1031,8 +1031,8 @@ try {
   );
   assert.equal(exportBoundary.sentinelObjectCount, 0);
 
-  // A Rust-owned Scene must never silently switch to the Python document
-  // engine when finalization finds incompatible migration state. Explicit
+  // Normal Scene execution must never silently select the Python document
+  // engine, including before a Rust context exists. Explicit
   // export above is the codec boundary; each rejected run uses the same worker.
   const rejectedFinalizations = await page.evaluate(async () => {
     const failures = [];
@@ -1041,6 +1041,8 @@ try {
       'scene._reactive_signals.append({"legacy": True})',
       'scene._semantic_geometry_handles.clear()',
       'scene._tracks.append({"property": "position"})',
+      'scene = Scene()\nassert getattr(scene, "_canonical_authoring_context", None) is None\nscene._legacy_geometry_materialized = True',
+      'scene = Scene()\nassert getattr(scene, "_canonical_authoring_context", None) is None\nscene._reactive_signals.append({"legacy": True})',
     ];
     for (const corruption of corruptions) {
       const source = `from noon import Circle, Scene

--- a/web/python-worker.source.js
+++ b/web/python-worker.source.js
@@ -864,8 +864,7 @@ if isinstance(__noon_result, Scene):
         __noon_document = None
         __noon_identities = None
     else:
-        if (not __noon_export_document and
-                getattr(__noon_result, "_canonical_authoring_context", None) is not None):
+        if not __noon_export_document:
             raise RuntimeError(
                 "shared Scene cannot fall back to scene-document execution; "
                 "remove incompatible legacy declarations or request exportDocument explicitly"
@@ -878,7 +877,7 @@ if isinstance(__noon_result, Scene):
             )
         # A native Text timeline/export remains in the canonical context so its
         # temporary #959 codec is derived from the Rust store at finalization.
-        # Geometry-only fallback retains the existing legacy materialization.
+        # Explicit geometry-only export retains the existing materialization.
         if not getattr(__noon_result, "_semantic_text_handles", {}):
             materialize_legacy_geometry(__noon_result)
         __noon_scene_spec = __noon_result.to_scene_spec()


### PR DESCRIPTION
Normal Python Scene requests now require shared Rust execution even when no Rust context was previously created. Previously, a scene rejected by execution_context before context creation could silently select the Python document engine. Refusal now happens before document exporters or callback/export materialization run. Explicit exportDocument and PatchBatch retain their external-boundary behavior.

Advances #959 A4.2/A4.3 and #61. The preceding top-level wait/play migration (#1238) removes the old cursor entry point. Scene shape/path convenience methods already use typed handles, and the actual mixed/legacy router and Typst export consumers already request exportDocument explicitly. Unsupported raw/declaration contracts remain implementation work under #61; this change does not claim that every Phase A requirement is complete.

The Python worker owns request routing only. No new semantic authority, scheduler, transport, compatibility seam or whole-scene work is introduced. Existing typed/native/direct-WASM semantics and paired examples are unchanged.

Validation:
- NOON_WEB_PREFLIGHT_ONLY=1 NOON_SKIP_PLAYGROUND_TEST=1 bash scripts/check.sh web:199 Python API tests plus inventory and JS/browser preflight passed; regenerated the Python worker.
- bash scripts/architecture-ratchet.sh 05419ba18a3c836c890f6c2cdb9a91dbbc28e575; git diff --check:passed.
- Focused production PythonAuthoringClient/worker browser check:6 refusal cases with poisoned exporters, empty/typed same-worker recovery, and explicit top-level export (duration1, one object, no continuation):passed. The two new no-context cases are also retained in scripts/shared-authoring-smoke.mjs.

This is a worker-routing change with no Rust/WASM API or rendering changes. The focused worker check did not create a renderer; no redundant full GPU suite or Rust rebuild was needed.
