### PR TITLE
Query shared family bounds after callback completion

### DIFF
--- a/crates/noon/src/example_scenes.rs
+++ b/crates/noon/src/example_scenes.rs
@@ -1058,6 +1058,7 @@ pub fn ordinary_succession_program() -> Result<LiveProgram<OrdinarySuccession>, 
 /// two ordered host callbacks at every required phase.
 pub struct OrdinaryCallbackContinuation {
     circle: Mobject,
+    family: crate::MobjectFamily,
     target: Mobject,
     stage: u8,
 }
@@ -1083,6 +1084,13 @@ impl LiveContinuation for OrdinaryCallbackContinuation {
                 .map_err(|error| error.to_string())
             }
             1 => {
+                let layout = live
+                    .effective_family_layout(&self.family)
+                    .map_err(|error| error.to_string())?;
+                assert!((layout.center.0 - 2.0).abs() < 1e-6);
+                assert!((layout.center.1 - 1.0).abs() < 1e-6);
+                assert!((layout.width - 0.8).abs() < 1e-6);
+                assert!((layout.height - 0.8).abs() < 1e-6);
                 self.stage = 2;
                 Ok(crate::ContinuationStep::Finished)
             }
@@ -1110,6 +1118,9 @@ pub fn ordinary_callback_continuation_program() -> Result<
         .set_fill(0.0, 0.4, 1.0, 1.0)
         .map_err(|error| error.to_string())?;
     scene.add(&circle).map_err(|error| error.to_string())?;
+    let family = scene
+        .family(&[(&circle).into()])
+        .map_err(|error| error.to_string())?;
 
     let callbacks = ordered_affine_callbacks().map_err(|error| error.to_string())?;
     {
@@ -1132,6 +1143,7 @@ pub fn ordinary_callback_continuation_program() -> Result<
     let program = scene
         .into_live_program(OrdinaryCallbackContinuation {
             circle,
+            family,
             target,
             stage: 0,
         })

--- a/web/python/_manim_semantic_handles.py
+++ b/web/python/_manim_semantic_handles.py
@@ -1771,15 +1771,20 @@ def _group_shift(self: _compat.Group, direction: object) -> _compat.Group:
 
 
 def _group_live_layout_context(value: _compat.Group):
+    # Callback registration does not invalidate the coherent live publication.
+    # Family observations inside an ordered overlay need shared phase-local
+    # aggregation; neither the authored state nor the last publication suffices.
+    from _manim_updaters import _canonical_phase_context
+
+    leaves = _compat._leaf_mobjects(value)
+    if any(_canonical_phase_context(leaf) is not None for leaf in leaves):
+        raise NotImplementedError("family layout is unsupported during an active callback phase")
     context = _group_target_context(value)
     if context is None:
         return None
-    # Callback overlays and explicit legacy timelines keep their own qualified
-    # read path until #70/#959 migration. Ordinary layout comes from live Rust.
-    for leaf in _compat._leaf_mobjects(value):
+    for leaf in leaves:
         if (not bool(getattr(leaf, "_semantic_handle_fresh", False))
                 or getattr(leaf, "_semantic_handle", None) is None
-                or hasattr(leaf, "_noon_updaters")
                 or getattr(getattr(leaf, "_scene", None), "_legacy_geometry_materialized", False)):
             return None
     return context

--- a/web/python/examples/ordinary_affine_callback_continuation.py
+++ b/web/python/examples/ordinary_affine_callback_continuation.py
@@ -7,19 +7,27 @@ when the segment has completed and its player lease was returned.
 """
 
 import _manim_updaters
-from noon import Circle, Color, Scene, Transform, linear
+from noon import Circle, Color, Scene, Transform, VGroup, linear
 
 
 class OrdinaryAffineCallbackContinuation(Scene):
     async def construct(self):
         circle = Circle(radius=0.4).set_fill(Color(0.0, 0.4, 1.0), opacity=1.0)
         self.add(circle)
+        family = VGroup(circle)
         phase_counts: dict[float, int] = {}
 
         def lift(mobject, _dt):
             phase_time = _manim_updaters._canonical_callback_time(mobject)
             phase_counts[phase_time] = phase_counts.get(phase_time, 0) + 1
             assert phase_counts[phase_time] == 1
+            if phase_time == 0.0:
+                try:
+                    family.get_center()
+                except NotImplementedError as error:
+                    assert "active callback phase" in str(error)
+                else:
+                    raise AssertionError("family query bypassed the active callback overlay")
             center = mobject.get_center()
             mobject.move_to((center.x, 1.0, 0.0))
 
@@ -40,3 +48,11 @@ class OrdinaryAffineCallbackContinuation(Scene):
         assert len(phase_counts) >= 2
         assert self.time == 1.0
         assert circle.get_center() == (2.0, 1.0)
+        # Registered callbacks keep their Rust-owned effective values after the
+        # phase completes; family queries must not materialize raw geometry.
+        def reject_raw_projection():
+            raise AssertionError("callback family query materialized Python geometry")
+        circle._current_raw = reject_raw_projection
+        assert family.get_center() == (2.0, 1.0)
+        assert abs(family.width - 0.8) < 1e-6
+        assert abs(family.height - 0.8) < 1e-6


### PR DESCRIPTION
Families with registered updaters now read coherent live bounds from the existing shared Rust family query after a callback phase completes. Previously, callback registration permanently disqualified the family from that query and sent ordinary width/height/center reads into Python raw-geometry fallback.

The adapter distinguishes an active callback overlay from a completed publication. Family queries during an active callback phase reject explicitly instead of reading authored state or the last published frame; shared phase-local family aggregation remains unsupported. The raw-geometry guard on individual callback objects and the existing Rust placement/driver guards are unchanged.

Advances #61 shared live observations and reduces a #959 dynamic fallback consumer. Rust already owns effective_family_layout; this changes frontend eligibility, not bounds mathematics. There is no new state authority, identity, scheduling rule, transport or migration seam. Work stays proportional to the queried family.

The existing paired OrdinaryCallbackContinuation Rust program and ordinary_affine_callback_continuation.py now check family center(2,1) and size(0.8,0.8) after the same one-second transform and ordered callbacks. Python poisons raw projection to ensure the completed query reaches Rust and checks rejection during the initial callback phase. The rendered scene is unchanged.

Validation:
- CARGO_TARGET_DIR=/Users/ykshin/Dev/me/noon/target CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=2 cargo test --workspace --all-features --lib ordinary_callback_continuation_uses_ordered_shared_barriers:passed.
- NOON_WEB_PREFLIGHT_ONLY=1 NOON_SKIP_PLAYGROUND_TEST=1 bash scripts/check.sh web:199 Python API tests plus inventory and browser preflight passed.
- bash scripts/architecture-ratchet.sh b440cf1794f1375e1a0860268313feff73534f56 and git diff --check:passed.
- Full gate with shared Cargo environment and NOON_SKIP_WEB_PREFLIGHT=1 NOON_SKIP_PLAYGROUND_TEST=1 NOON_WASM_PROFILE=dev bash scripts/check.sh full:passed, including1,748 Rust tests and215 WASM package contracts.
- Focused production Python callback example sampled at0,0.5,1 seconds:passed, including active-phase rejection and post-completion shared family queries with poisoned raw projection. The existing direct Rust/WASM callback proof passed on WebGPU and WebGL2. A private report writer was corrected to encode BigInt metrics; no production fix was needed.
