### PR TITLE
Observe paint opacity through shared authored and live state

### DIFF
--- a/crates/noon-web/src/canonical_authoring_scene.rs
+++ b/crates/noon-web/src/canonical_authoring_scene.rs
@@ -596,6 +596,24 @@ impl CanonicalAuthoringScene {
         )
     }
 
+    #[cfg(any(target_arch = "wasm32", test))]
+    fn mobject_fill_opacity(&mut self, handle: &noon::Mobject) -> Result<f64, String> {
+        self.mobject_observation(handle, noon::Mobject::fill_opacity, |player, handle| {
+            // Reject resource paints before reading their lowered scalar projection.
+            handle.fill_opacity()?;
+            Ok(player.live_effective(handle)?.fill_opacity())
+        })
+    }
+
+    #[cfg(any(target_arch = "wasm32", test))]
+    fn mobject_stroke_opacity(&mut self, handle: &noon::Mobject) -> Result<f64, String> {
+        self.mobject_observation(handle, noon::Mobject::stroke_opacity, |player, handle| {
+            // Reject resource paints before reading their lowered scalar projection.
+            handle.stroke_opacity()?;
+            Ok(player.live_effective(handle)?.stroke_opacity())
+        })
+    }
+
     /// Inert bounds-dependent construction observes this runtime for bound targets,
     /// while fresh detached targets retain their shared authored layout.
     #[cfg(any(target_arch = "wasm32", test))]
@@ -5020,6 +5038,26 @@ mod wasm {
                 .map_err(js_error)
         }
 
+        #[wasm_bindgen(js_name = queryMobjectFillOpacity)]
+        pub fn query_mobject_fill_opacity(
+            &mut self,
+            handle: &crate::WasmAuthoringMobjectHandle,
+        ) -> Result<f64, JsValue> {
+            self.inner
+                .mobject_fill_opacity(handle.semantic_mobject())
+                .map_err(js_error)
+        }
+
+        #[wasm_bindgen(js_name = queryMobjectStrokeOpacity)]
+        pub fn query_mobject_stroke_opacity(
+            &mut self,
+            handle: &crate::WasmAuthoringMobjectHandle,
+        ) -> Result<f64, JsValue> {
+            self.inner
+                .mobject_stroke_opacity(handle.semantic_mobject())
+                .map_err(js_error)
+        }
+
         #[wasm_bindgen(js_name = queryMobjectColor)]
         pub fn query_mobject_color(
             &mut self,
@@ -8495,7 +8533,7 @@ mod tests {
     }
 
     #[test]
-    fn ordinary_line_and_color_queries_follow_runtime_ownership() {
+    fn ordinary_line_and_paint_queries_follow_runtime_ownership() {
         let mut context = CanonicalAuthoringScene::default();
         let mut line = context.scene.line((-1.0, 0.0), (1.0, 0.0)).unwrap();
         line.set_fill(0.0, 1.0, 0.0, 0.2).unwrap();
@@ -8503,6 +8541,8 @@ mod tests {
         line.set_stroke_opacity(0.8).unwrap();
         line.set_object_opacity(0.3).unwrap();
         assert!(context.mobject_line_endpoints(&line).is_err());
+        assert!(context.mobject_fill_opacity(&line).is_err());
+        assert!(context.mobject_stroke_opacity(&line).is_err());
         context.bind_mobject(ObjectId::new(0), &line).unwrap();
         let mut target = line.target_editor().unwrap();
         target.set_translation(4.0, -2.0).unwrap();
@@ -8534,6 +8574,9 @@ mod tests {
         assert_eq!(observed.start, (1.0, -1.0));
         assert_eq!(observed.end, (3.0, -1.0));
         let color = context.mobject_color(&line).unwrap();
+        assert!((context.mobject_fill_opacity(&line).unwrap() - 0.2).abs() < 1e-6);
+        assert!((context.mobject_stroke_opacity(&line).unwrap() - 0.6).abs() < 1e-6);
+        assert_eq!(line.stroke_opacity().unwrap(), 0.8);
         assert!((color.red - 0.5).abs() < 1.0e-6);
         assert!((color.blue - 0.5).abs() < 1.0e-6);
         assert!((color.alpha - 0.6).abs() < 1.0e-6);
@@ -8548,9 +8591,18 @@ mod tests {
             .mobject_color(&line)
             .unwrap_err()
             .contains("running in the semantic engine"));
+        assert!(context
+            .mobject_fill_opacity(&line)
+            .unwrap_err()
+            .contains("running in the semantic engine"));
+        assert!(context
+            .mobject_stroke_opacity(&line)
+            .unwrap_err()
+            .contains("running in the semantic engine"));
         context.return_execution_player(player).unwrap();
         assert_eq!(context.mobject_line_endpoints(&line).unwrap(), observed);
         assert_eq!(context.mobject_color(&line).unwrap(), color);
+        assert!((context.mobject_stroke_opacity(&line).unwrap() - 0.6).abs() < 1e-6);
 
         // A stale returned player must not shadow later direct authored edits.
         line.shift(1.0, 2.0).unwrap();
@@ -8564,6 +8616,7 @@ mod tests {
             context.mobject_color(&line).unwrap(),
             Color::rgba(1.0, 1.0, 0.0, 0.7)
         );
+        assert_eq!(context.mobject_stroke_opacity(&line).unwrap(), 0.7);
     }
 
     #[test]

--- a/crates/noon/src/example_scenes.rs
+++ b/crates/noon/src/example_scenes.rs
@@ -242,6 +242,8 @@ pub fn live_callback_paint() -> Result<(ExecutionSession, RustHostCallbackTable)
     source.set_stroke_color(0.9, 0.9, 0.9, 0.75)?;
     source.set_stroke_opacity(0.75)?;
     source.set_stroke_width(0.12)?;
+    assert_eq!(source.fill_opacity()?, 0.25);
+    assert_eq!(source.stroke_opacity()?, 0.75);
     scene.add(&source)?;
 
     let mut target = source.target_editor()?;
@@ -1084,6 +1086,11 @@ impl LiveContinuation for OrdinaryCallbackContinuation {
                 .map_err(|error| error.to_string())
             }
             1 => {
+                let paint = live
+                    .effective(&self.circle)
+                    .map_err(|error| error.to_string())?;
+                assert_eq!(paint.fill_opacity(), 1.0);
+                assert_eq!(paint.stroke_opacity(), 1.0);
                 let layout = live
                     .effective_family_layout(&self.family)
                     .map_err(|error| error.to_string())?;

--- a/crates/noon/src/live_session.rs
+++ b/crates/noon/src/live_session.rs
@@ -44,6 +44,20 @@ pub struct EffectiveMobjectState {
     pub publication: PublicationContext,
 }
 
+impl EffectiveMobjectState {
+    /// Current fill alpha, excluding the separate object-composite multiplier.
+    pub fn fill_opacity(&self) -> f64 {
+        self.style.fill.map_or(0.0, |color| f64::from(color.alpha))
+    }
+
+    /// Current stroke alpha, excluding the separate object-composite multiplier.
+    pub fn stroke_opacity(&self) -> f64 {
+        self.style
+            .stroke
+            .map_or(0.0, |color| f64::from(color.alpha))
+    }
+}
+
 /// One object's exact layout observation at a coherent runtime publication.
 ///
 /// These bounds retain authored layout semantics and therefore exclude the
@@ -2414,7 +2428,7 @@ mod tests {
         transform.rotation = 0.25;
         overlay.set_transform(circle.node_id(), transform).unwrap();
         let mut style = overlay.object(circle.node_id()).unwrap().style;
-        style.fill = Some(Color::rgb(1.0, 0.0, 0.0));
+        style.fill = Some(Color::rgba(1.0, 0.0, 0.0, 0.25));
         style.opacity = 0.5;
         overlay.set_style(circle.node_id(), style).unwrap();
         live.session
@@ -2423,6 +2437,9 @@ mod tests {
 
         live.session.take_frame_changes();
         let target = live.target_editor(&circle).unwrap();
+        assert_eq!(live.effective(&circle).unwrap().fill_opacity(), 0.25);
+        assert_eq!(target.fill_opacity().unwrap(), 0.25);
+        assert_eq!(target.stroke_opacity().unwrap(), 1.0);
         let target_state = live.authored(&target).unwrap();
         assert_eq!(
             target_state.transform.translation,
@@ -2571,7 +2588,7 @@ mod tests {
     }
 
     #[test]
-    fn live_line_and_color_queries_observe_active_drivers_without_changing_authored_state() {
+    fn live_line_and_paint_queries_observe_active_drivers_without_changing_authored_state() {
         let mut scene = Scene::new();
         let mut line = scene.line((-1.0, 0.0), (1.0, 0.0)).unwrap();
         line.set_stroke_color(0.0, 0.0, 1.0, 1.0).unwrap();
@@ -2617,6 +2634,10 @@ mod tests {
             live.effective_manim_color(&line).unwrap(),
             Color::rgba(0.5, 0.0, 0.5, 0.5)
         );
+        let effective = live.effective(&line).unwrap();
+        assert_eq!(effective.fill_opacity(), 0.0);
+        assert_eq!(effective.stroke_opacity(), 0.5);
+        assert_eq!(line.stroke_opacity().unwrap(), 0.25);
     }
 
     #[test]

--- a/crates/noon/src/semantic_mobject/style.rs
+++ b/crates/noon/src/semantic_mobject/style.rs
@@ -19,6 +19,19 @@ pub(super) fn manim_color_from_semantic(style: &SemanticStyle) -> Result<Color, 
     }
 }
 
+/// Observable paint alpha is the solid color alpha times its authored multiplier.
+/// Object-composite opacity is a separate domain. A resource paint has no single
+/// scalar color alpha and cannot be represented by a Manim opacity getter.
+fn manim_paint_opacity(paint: Option<&SemanticPaint>, opacity: f64) -> Result<f64, String> {
+    match paint {
+        Some(SemanticPaint::Solid(color)) => Ok(f64::from(color.alpha) * opacity),
+        Some(SemanticPaint::Resource(_)) => {
+            Err("Manim opacity queries do not support resource paints".into())
+        }
+        None => Ok(0.0),
+    }
+}
+
 pub(crate) fn manim_color_from_effective(style: &Style) -> Color {
     style.stroke.or(style.fill).unwrap_or(Color::WHITE)
 }
@@ -316,11 +329,7 @@ impl Mobject {
     }
     pub fn fill_opacity(&self) -> Result<f64, String> {
         let state = self.state()?;
-        Ok(if state.style.fill.is_some() {
-            state.style.fill_opacity
-        } else {
-            0.0
-        })
+        manim_paint_opacity(state.style.fill.as_ref(), state.style.fill_opacity)
     }
     pub fn disable_stroke(&mut self) -> Result<(), String> {
         self.validate()?;
@@ -354,16 +363,28 @@ impl Mobject {
     }
     pub fn stroke_opacity(&self) -> Result<f64, String> {
         let state = self.state()?;
-        Ok(if state.style.stroke.is_some() {
-            state.style.stroke_opacity
-        } else {
-            0.0
-        })
+        manim_paint_opacity(state.style.stroke.as_ref(), state.style.stroke_opacity)
     }
     pub fn set_opacity(&mut self, opacity: f64) -> Result<(), String> {
         self.validate()?;
         let mut state = self.state()?;
         edit_manim_opacity(&mut state.style, opacity)?;
         self.commit_state(state)
+    }
+}
+
+#[cfg(test)]
+mod opacity_tests {
+    use super::*;
+
+    #[test]
+    fn paint_opacity_observes_intrinsic_alpha_and_disabled_paints() {
+        let solid = SemanticPaint::Solid(Color::rgba(0.2, 0.4, 0.8, 0.5));
+        assert_eq!(manim_paint_opacity(Some(&solid), 0.25).unwrap(), 0.125);
+        assert_eq!(manim_paint_opacity(Some(&solid), 1.0).unwrap(), 0.5);
+        assert_eq!(manim_paint_opacity(None, 1.0).unwrap(), 0.0);
+        assert!(manim_paint_opacity(Some(&SemanticPaint::Resource(7)), 0.5)
+            .unwrap_err()
+            .contains("resource paints"));
     }
 }

--- a/scripts/check-web-package.mjs
+++ b/scripts/check-web-package.mjs
@@ -242,6 +242,8 @@ const expectedTypeSurface = [
   "manimColor(): WasmManimColor",
   "queryMobjectLineEndpoints(handle: WasmAuthoringMobjectHandle): WasmManimLineEndpoints",
   "queryMobjectColor(handle: WasmAuthoringMobjectHandle): WasmManimColor",
+  "queryMobjectFillOpacity(handle: WasmAuthoringMobjectHandle): number",
+  "queryMobjectStrokeOpacity(handle: WasmAuthoringMobjectHandle): number",
 
   "resumeExecutionPlayer(): SemanticExecutionPlayer",
   "export class WasmMobjectLayoutObservation",

--- a/web/python/_manim_semantic_handles.py
+++ b/web/python/_manim_semantic_handles.py
@@ -287,6 +287,8 @@ def _typed_manim_observation(
     value: object,
     handle_method: str,
     context_method: str,
+    *,
+    handle_property: bool = False,
 ):
     """Read one narrow Manim observation from its current Rust authority.
 
@@ -316,7 +318,8 @@ def _typed_manim_observation(
     handle = _handle_for(value)
     if handle is None:
         raise NotImplementedError("typed Mobject observation is unavailable in this authoring phase")
-    return getattr(handle, handle_method)()
+    observation = getattr(handle, handle_method)
+    return observation if handle_property else observation()
 
 
 def _manim_line_endpoints_observation(value: object):
@@ -1661,19 +1664,28 @@ def _set_object_opacity(
     return self
 
 
+def _paint_opacity_observation(value: object, layer: str):
+    # The callback row is Rust-published state plus preceding ordered writes.
+    # Reading it is a scalar projection, with no geometry or extra WASM call.
+    from _manim_updaters import _canonical_row
+
+    phase = _canonical_row(value)
+    if phase is not None:
+        paint = getattr(phase[2].style, layer)
+        return 0.0 if paint is None else float(paint[3])
+    return _typed_manim_observation(
+        value, f"{layer}Opacity", f"queryMobject{layer.title()}Opacity", handle_property=True
+    )
+
+
 def _get_fill_opacity(self: _compat.VMobject) -> float:
-    handle = _handle_for(self)
-    if handle is None:
-        return _ORIGINAL_GET_FILL_OPACITY(self)
-    return float(handle.fillOpacity)
+    observed = _paint_opacity_observation(self, "fill")
+    return _ORIGINAL_GET_FILL_OPACITY(self) if observed is None else float(observed)
 
 
 def _get_stroke_opacity(self: _compat.VMobject) -> float:
-    handle = _handle_for(self)
-    if handle is None:
-        return _ORIGINAL_GET_STROKE_OPACITY(self)
-    return float(handle.strokeOpacity)
-
+    observed = _paint_opacity_observation(self, "stroke")
+    return _ORIGINAL_GET_STROKE_OPACITY(self) if observed is None else float(observed)
 
 
 def _family_layout_leaf_adapter(value: object, *, mutation: bool = False):

--- a/web/python/examples/live_callback_paint.py
+++ b/web/python/examples/live_callback_paint.py
@@ -14,6 +14,8 @@ class LiveCallbackPaint(Scene):
             .set_fill(Color(0.1, 0.2, 0.8), opacity=0.25)
             .set_stroke(Color(0.9, 0.9, 0.9), width=0.12, opacity=0.75)
         )
+        assert circle.get_fill_opacity() == 0.25
+        assert circle.get_stroke_opacity() == 0.75
         self.add(circle)
         target = circle.copy().shift((2.0, 0.0, 0.0))
         animation = self.declare_live_transform_to(
@@ -24,10 +26,15 @@ class LiveCallbackPaint(Scene):
         )
 
         def recolor(mobject, _dt):
+            before_fill = mobject.get_fill_opacity()
             mobject.set_color(Color(0.8, 0.4, 0.2, 0.9))
+            assert mobject.get_fill_opacity() == before_fill
+            assert mobject.get_stroke_opacity() == 0.75
 
         def fill_and_composite_opacity(mobject, _dt):
+            assert mobject.get_stroke_opacity() == 0.75
             mobject.set_fill(opacity=0.4)
+            assert abs(mobject.get_fill_opacity() - 0.4) < 1e-6
             # Callback set_opacity remains the separately qualified object
             # composite domain rather than Manim's ordinary paint-alpha edit.
             mobject.set_opacity(0.5)

--- a/web/python/examples/live_callback_paint.py
+++ b/web/python/examples/live_callback_paint.py
@@ -28,7 +28,7 @@ class LiveCallbackPaint(Scene):
         def recolor(mobject, _dt):
             before_fill = mobject.get_fill_opacity()
             mobject.set_color(Color(0.8, 0.4, 0.2, 0.9))
-            assert mobject.get_fill_opacity() == before_fill
+            assert abs(mobject.get_fill_opacity() - before_fill) < 1e-6
             assert mobject.get_stroke_opacity() == 0.75
 
         def fill_and_composite_opacity(mobject, _dt):

--- a/web/python/examples/ordinary_affine_callback_continuation.py
+++ b/web/python/examples/ordinary_affine_callback_continuation.py
@@ -54,6 +54,9 @@ class OrdinaryAffineCallbackContinuation(Scene):
         def reject_raw_projection():
             raise AssertionError("callback family query materialized Python geometry")
         circle._current_raw = reject_raw_projection
+        # Object-composite dimming must not alter observed fill/stroke alpha.
+        assert circle.get_fill_opacity() == 1.0
+        assert circle.get_stroke_opacity() == 1.0
         assert family.get_center() == (2.0, 1.0)
         assert abs(family.width - 0.8) < 1e-6
         assert abs(family.height - 0.8) < 1e-6

--- a/web/python/test_manim_shared_object_observations.py
+++ b/web/python/test_manim_shared_object_observations.py
@@ -42,6 +42,11 @@ class ManimSharedObjectObservationTests(unittest.TestCase):
                         raise ValueError("mobject content is not an analytic Line")
                     return SimpleNamespace(startX=1.25, startY=-2.5, endX=4.5, endY=3.75)
 
+                @property
+                def fillOpacity(self): return 0.25
+                @property
+                def strokeOpacity(self): return 0.75
+
                 def manimColor(self):
                     return SimpleNamespace(red=0.1, green=0.2, blue=0.3, alpha=0.4)
 
@@ -66,6 +71,8 @@ class ManimSharedObjectObservationTests(unittest.TestCase):
             )
             assert line.get_start() == (1.25, -2.5)
             assert line.get_end() == (4.5, 3.75)
+            assert line.get_fill_opacity() == 0.25
+            assert line.get_stroke_opacity() == 0.75
             authored_color = line.get_color()
             assert (
                 authored_color.red,
@@ -104,6 +111,14 @@ class ManimSharedObjectObservationTests(unittest.TestCase):
                         raise RuntimeError("live execution session is running")
                     assert handle is line._semantic_handle
                     return SimpleNamespace(startX=10.0, startY=20.0, endX=30.0, endY=40.0)
+                def queryMobjectFillOpacity(self, handle):
+                    if self.ownership == "transferred":
+                        raise RuntimeError("live execution session is running")
+                    assert handle is line._semantic_handle
+                    return 0.4
+                def queryMobjectStrokeOpacity(self, handle):
+                    assert handle is line._semantic_handle
+                    return 0.6
                 def queryMobjectColor(self, handle):
                     assert handle is line._semantic_handle
                     return SimpleNamespace(red=0.8, green=0.7, blue=0.6, alpha=0.5)
@@ -116,6 +131,9 @@ class ManimSharedObjectObservationTests(unittest.TestCase):
             line._object = SimpleNamespace(id="line")
             assert line.get_start() == (10.0, 20.0)
             assert line.get_end() == (30.0, 40.0)
+            line._noon_updaters = [lambda *_: None]
+            assert line.get_fill_opacity() == 0.4
+            assert line.get_stroke_opacity() == 0.6
             effective_color = line.get_color()
             assert (
                 effective_color.red,
@@ -124,7 +142,28 @@ class ManimSharedObjectObservationTests(unittest.TestCase):
                 effective_color.alpha,
             ) == (0.8, 0.7, 0.6, 0.5)
 
+            # Callback reads use the current ordered row and never query the
+            # transferred player or authored handle. Reads see prior writes.
+            import _manim_updaters as updaters
+            phase = object.__new__(updaters._CanonicalCallbackContext)
+            row = SimpleNamespace(style=SimpleNamespace(fill=None, stroke=(1, 1, 1, 0.125)))
+            phase.row = lambda value: ((0, 0), row)
+            updaters._ACTIVE_CONTEXTS[id(line._scene)] = phase
+            try:
+                assert line.get_fill_opacity() == 0.0
+                assert line.get_stroke_opacity() == 0.125
+                row.style.fill = (0, 1, 0, 0.375)
+                assert line.get_fill_opacity() == 0.375
+            finally:
+                del updaters._ACTIVE_CONTEXTS[id(line._scene)]
+
             context.ownership = "transferred"
+            try:
+                line.get_fill_opacity()
+            except RuntimeError as error:
+                assert "execution session is running" in str(error)
+            else:
+                raise AssertionError("paint getter bypassed transferred ownership")
             try:
                 _manim_indication.ShowPassingFlash(line)
             except RuntimeError as error:
@@ -133,6 +172,7 @@ class ManimSharedObjectObservationTests(unittest.TestCase):
                 raise AssertionError("ShowPassingFlash bypassed transferred ownership")
             context.ownership = "returned"
 
+            del line._noon_updaters
             calls = []
             original_set_color = handles._set_color
             handles._set_color = lambda target, color: calls.append((target, color)) or target
@@ -143,6 +183,12 @@ class ManimSharedObjectObservationTests(unittest.TestCase):
             assert calls == [(line, BLUE)]
 
             line._semantic_handle_fresh = False
+            try:
+                line.get_fill_opacity()
+            except NotImplementedError as error:
+                assert "valid semantic handle" in str(error)
+            else:
+                raise AssertionError("half-typed paint getter fell back to raw geometry")
             try:
                 line.get_start()
             except NotImplementedError as error:


### PR DESCRIPTION
Fill/stroke opacity getters now follow the existing shared observation path: authored Rust handles before execution, coherent Rust runtime state during live authoring, and the ordered callback row during an active Python callback. Previously live getters could return authored values, and callback-bearing wrappers could fall back to raw geometry. Callback getters read the existing phase row directly without a per-getter WASM call.

Authored Manim opacity getters now include intrinsic solid-color alpha. This also fixes getters on effective-state copies, where a translucent runtime paint can be captured with a unit semantic multiplier. Disabled paint returns zero; resource paints reject scalar Manim queries. Object-composite opacity remains a separate domain.

Advances #958 A2.5 and #61. Shared Rust semantic code owns authored alpha interpretation; Runtime owns effective values. Browser bindings reuse the existing observation ownership checks and live state access. No new identity, style authority, cache, scheduler, serializer, or migration seam. Explicit legacy/export fallback remains owned by #959. Queries stay local to one object; callback reads reuse the existing ordered read set/overlay.

Paired Rust/Python callback paint examples exercise preserved fill/stroke alpha and ordered read-after-write. The ordinary callback continuation also verifies paint opacity after execution returns, with Python raw projection poisoned. Native coverage verifies interpolation, disabled paints, captured callback opacity, and unchanged authored values; browser-context coverage verifies transferred ownership and stale-player routing.

Validation:
- CARGO_TARGET_DIR=/Users/ykshin/Dev/me/noon/target CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=2 cargo test --workspace --all-features --lib paint_:16 passed.
- python3 -m unittest discover -s web/python -p 'test_manim_shared_object_observations.py':passed.
- NOON_WEB_PREFLIGHT_ONLY=1 NOON_SKIP_PLAYGROUND_TEST=1 bash scripts/check.sh web:199 Python API tests and static/inventory checks passed.
- bash scripts/architecture-ratchet.sh 5c7e1df4b4be242daeab375e2531cd5d71878d28; git diff --check:passed.
- CARGO_TARGET_DIR=/Users/ykshin/Dev/me/noon/target CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=2 NOON_SKIP_WEB_PREFLIGHT=1 NOON_SKIP_PLAYGROUND_TEST=1 NOON_WASM_PROFILE=dev bash scripts/check.sh full:passed, 1,749 Rust tests and 211 package contracts.
- Focused production Python callback/paint examples and direct Rust/WASM WebGPU+WebGL2 proofs:passed. The first Python run caught an exact-equality assertion across f32 conversion; the example now uses a tolerance, and the focused browser check passed after that example-only correction.

Phase A remains incomplete. These checks are not an independent Manim differential run.
