### PR TITLE
Preserve captured paint alpha through shared style edits

### DIFF
--- a/crates/noon/src/example_scenes.rs
+++ b/crates/noon/src/example_scenes.rs
@@ -156,18 +156,23 @@ const FILL_AND_COMPOSITE_OPACITY: HostCallbackId = HostCallbackId::new(9);
 const MOVE_MATCH_DOT: HostCallbackId = HostCallbackId::new(10);
 const MATCH_LINE_ENDPOINTS: HostCallbackId = HostCallbackId::new(11);
 
-fn ordered_affine_callbacks() -> Result<RustHostCallbackTable, Box<dyn Error>> {
+fn ordered_affine_callbacks(
+    fill_opacity: Option<f32>,
+) -> Result<RustHostCallbackTable, Box<dyn Error>> {
     let mut callbacks = RustHostCallbackTable::new();
     callbacks.insert(SET_Y, |context| {
         let mut transform = context.target_state().transform;
         transform.translation.y = 1.0;
         context.set_target_transform(transform)
     })?;
-    callbacks.insert(SET_OPACITY, |context| {
+    callbacks.insert(SET_OPACITY, move |context| {
         let prior_y = context.target_state().transform.translation.y;
         let mut style = context.target_state().style;
         // The visible result depends on reading SET_Y from this same phase overlay.
         style.opacity = if prior_y == 1.0 { 0.5 } else { 0.0 };
+        if let (Some(fill), Some(alpha)) = (style.fill.as_mut(), fill_opacity) {
+            fill.alpha = alpha;
+        }
         context.set_target_style(style)
     })?;
     Ok(callbacks)
@@ -202,7 +207,7 @@ pub fn live_affine_callbacks() -> Result<(ExecutionSession, RustHostCallbackTabl
             .rate_func(RateFunction::Linear),
     )?;
 
-    let mut callbacks = ordered_affine_callbacks()?;
+    let mut callbacks = ordered_affine_callbacks(None)?;
     callbacks.insert(ACCUMULATE_DT, |context| {
         let mut transform = context.target_state().transform;
         transform.translation.y += context.delta_time() as f32;
@@ -1089,8 +1094,27 @@ impl LiveContinuation for OrdinaryCallbackContinuation {
                 let paint = live
                     .effective(&self.circle)
                     .map_err(|error| error.to_string())?;
-                assert_eq!(paint.fill_opacity(), 1.0);
+                assert_eq!(paint.fill_opacity(), 0.75);
                 assert_eq!(paint.stroke_opacity(), 1.0);
+                // Captured callback alpha must survive RGB edits; absolute
+                // opacity edits must not multiply its intrinsic alpha again.
+                let copied = live
+                    .target_editor(&self.circle)
+                    .map_err(|error| error.to_string())?;
+                live.set_color(&copied, 1.0, 0.0, 0.0, 1.0)
+                    .map_err(|error| error.to_string())?;
+                assert_eq!(copied.fill_opacity()?, 0.75);
+                live.set_fill_opacity(&copied, 0.5)
+                    .map_err(|error| error.to_string())?;
+                assert_eq!(copied.fill_opacity()?, 0.5);
+                live.set_stroke_opacity(&copied, 0.25)
+                    .map_err(|error| error.to_string())?;
+                assert_eq!(copied.stroke_opacity()?, 0.25);
+                live.set_opacity(&copied, 0.4)
+                    .map_err(|error| error.to_string())?;
+                assert_eq!(copied.fill_opacity()?, 0.4);
+                assert_eq!(copied.stroke_opacity()?, 0.4);
+                assert_eq!(copied.state()?.style.object_opacity, 0.5);
                 let layout = live
                     .effective_family_layout(&self.family)
                     .map_err(|error| error.to_string())?;
@@ -1148,7 +1172,7 @@ impl LiveContinuation for OrdinaryCallbackContinuation {
 ///
 /// The blue circle moves to `(2, 0)` over one second. At each compiler-selected
 /// phase, callback A moves the effective row to `y=1`; callback B observes A's
-/// write and sets object opacity to `0.5`. The returned callable table owns only
+/// write, sets fill alpha to `0.75`, and sets object opacity to `0.5`. The returned callable table owns only
 /// opaque Rust functions; the program/session retains schedule and timeline state.
 pub fn ordinary_callback_continuation_program() -> Result<
     (
@@ -1167,7 +1191,7 @@ pub fn ordinary_callback_continuation_program() -> Result<
         .family(&[(&circle).into()])
         .map_err(|error| error.to_string())?;
 
-    let callbacks = ordered_affine_callbacks().map_err(|error| error.to_string())?;
+    let callbacks = ordered_affine_callbacks(Some(0.75)).map_err(|error| error.to_string())?;
     {
         let mut store = scene.store().borrow_mut();
         callbacks

--- a/crates/noon/src/semantic_mobject/style.rs
+++ b/crates/noon/src/semantic_mobject/style.rs
@@ -44,6 +44,30 @@ pub(crate) trait PaintStyleEdit {
     fn set_fill_opacity(&mut self, opacity: f64);
 }
 
+// A captured effective solid paint can carry alpha in its color as well as
+// its semantic multiplier. Preserve their product on RGB edits; absolute
+// Manim opacity writes normalize the intrinsic alpha before setting it.
+fn replace_paint_color(
+    paint: &mut Option<SemanticPaint>,
+    opacity: &mut f64,
+    color: Color,
+    opacity_when_enabled: f64,
+) {
+    *opacity = match paint {
+        None => opacity_when_enabled,
+        Some(SemanticPaint::Solid(previous)) => f64::from(previous.alpha) * *opacity,
+        Some(SemanticPaint::Resource(_)) => *opacity,
+    };
+    *paint = Some(SemanticPaint::Solid(color));
+}
+
+fn set_paint_opacity(paint: &mut Option<SemanticPaint>, multiplier: &mut f64, opacity: f64) {
+    if let SemanticPaint::Solid(color) = paint.get_or_insert(SemanticPaint::Solid(Color::WHITE)) {
+        color.alpha = 1.0;
+    }
+    *multiplier = opacity;
+}
+
 impl PaintStyleEdit for SemanticStyle {
     fn has_fill(&self) -> bool {
         self.fill.is_some()
@@ -54,24 +78,25 @@ impl PaintStyleEdit for SemanticStyle {
     }
 
     fn set_fill_color(&mut self, color: Color, opacity_when_enabled: f64) {
-        if self.fill.is_none() {
-            self.fill_opacity = opacity_when_enabled;
-        }
-        self.fill = Some(SemanticPaint::Solid(color));
+        replace_paint_color(
+            &mut self.fill,
+            &mut self.fill_opacity,
+            color,
+            opacity_when_enabled,
+        );
     }
 
     fn set_stroke_color(&mut self, color: Color, opacity_when_enabled: f64) {
-        if self.stroke.is_none() {
-            self.stroke_opacity = opacity_when_enabled;
-        }
-        self.stroke = Some(SemanticPaint::Solid(color));
+        replace_paint_color(
+            &mut self.stroke,
+            &mut self.stroke_opacity,
+            color,
+            opacity_when_enabled,
+        );
     }
 
     fn set_fill_opacity(&mut self, opacity: f64) {
-        if self.fill.is_none() {
-            self.fill = Some(SemanticPaint::Solid(Color::WHITE));
-        }
-        self.fill_opacity = opacity;
+        set_paint_opacity(&mut self.fill, &mut self.fill_opacity, opacity);
     }
 }
 
@@ -177,10 +202,10 @@ pub(crate) fn edit_fill<S: PaintStyleEdit>(
 pub(crate) fn edit_manim_opacity(style: &mut SemanticStyle, opacity: f64) -> Result<(), String> {
     let opacity = unit_opacity("opacity", opacity)?;
     if style.fill.is_some() {
-        style.fill_opacity = opacity;
+        set_paint_opacity(&mut style.fill, &mut style.fill_opacity, opacity);
     }
     if style.stroke.is_some() {
-        style.stroke_opacity = opacity;
+        set_paint_opacity(&mut style.stroke, &mut style.stroke_opacity, opacity);
     }
     Ok(())
 }
@@ -204,10 +229,7 @@ pub(crate) fn edit_stroke_color<S: PaintStyleEdit>(
 
 pub(crate) fn edit_stroke_opacity(style: &mut SemanticStyle, opacity: f64) -> Result<(), String> {
     let opacity = unit_opacity("stroke opacity", opacity)?;
-    if style.stroke.is_none() {
-        style.stroke = Some(SemanticPaint::Solid(Color::WHITE));
-    }
-    style.stroke_opacity = opacity;
+    set_paint_opacity(&mut style.stroke, &mut style.stroke_opacity, opacity);
     Ok(())
 }
 
@@ -376,6 +398,89 @@ impl Mobject {
 #[cfg(test)]
 mod opacity_tests {
     use super::*;
+
+    #[test]
+    fn authored_paint_edits_agree_with_effective_edits_for_intrinsic_alpha() {
+        let mut authored = SemanticStyle {
+            fill: Some(SemanticPaint::Solid(Color::rgba(0.1, 0.2, 0.3, 0.5))),
+            fill_opacity: 0.25,
+            stroke: Some(SemanticPaint::Solid(Color::rgba(0.4, 0.5, 0.6, 0.0))),
+            stroke_opacity: 0.75,
+            object_opacity: 0.3,
+            ..SemanticStyle::default()
+        };
+        let mut absolute = authored.clone();
+        edit_fill_opacity(&mut absolute, 0.6).unwrap();
+        edit_stroke_opacity(&mut absolute, 0.4).unwrap();
+        assert_eq!(
+            manim_paint_opacity(absolute.fill.as_ref(), absolute.fill_opacity).unwrap(),
+            0.6
+        );
+        assert_eq!(
+            manim_paint_opacity(absolute.stroke.as_ref(), absolute.stroke_opacity).unwrap(),
+            0.4
+        );
+        let mut combined = authored.clone();
+        edit_manim_opacity(&mut combined, 0.2).unwrap();
+        assert_eq!(
+            manim_paint_opacity(combined.fill.as_ref(), combined.fill_opacity).unwrap(),
+            0.2
+        );
+        assert_eq!(
+            manim_paint_opacity(combined.stroke.as_ref(), combined.stroke_opacity).unwrap(),
+            0.2
+        );
+        let mut effective = Style {
+            fill: solid_color_with_opacity(authored.fill.as_ref(), authored.fill_opacity),
+            stroke: solid_color_with_opacity(authored.stroke.as_ref(), authored.stroke_opacity),
+            opacity: authored.object_opacity as f32,
+            ..Style::default()
+        };
+        edit_color(&mut authored, 0.8, 0.4, 0.2, 0.9).unwrap();
+        edit_color(&mut effective, 0.8, 0.4, 0.2, 0.9).unwrap();
+        assert_eq!(
+            solid_color_with_opacity(authored.fill.as_ref(), authored.fill_opacity),
+            effective.fill
+        );
+        assert_eq!(
+            solid_color_with_opacity(authored.stroke.as_ref(), authored.stroke_opacity),
+            effective.stroke
+        );
+        assert_eq!(authored.fill_opacity, 0.125);
+        assert_eq!(authored.stroke_opacity, 0.0);
+
+        edit_fill_opacity(&mut authored, 0.6).unwrap();
+        edit_fill_opacity(&mut effective, 0.6).unwrap();
+        assert_eq!(
+            solid_color_with_opacity(authored.fill.as_ref(), authored.fill_opacity),
+            effective.fill
+        );
+        edit_stroke_opacity(&mut authored, 0.4).unwrap();
+        assert_eq!(
+            manim_paint_opacity(authored.stroke.as_ref(), authored.stroke_opacity).unwrap(),
+            0.4
+        );
+        edit_manim_opacity(&mut authored, 0.2).unwrap();
+        assert_eq!(
+            manim_paint_opacity(authored.fill.as_ref(), authored.fill_opacity).unwrap(),
+            0.2
+        );
+        assert_eq!(
+            manim_paint_opacity(authored.stroke.as_ref(), authored.stroke_opacity).unwrap(),
+            0.2
+        );
+        assert_eq!(authored.object_opacity, 0.3);
+
+        let mut resource = SemanticStyle {
+            fill: Some(SemanticPaint::Resource(7)),
+            stroke: None,
+            ..SemanticStyle::default()
+        };
+        edit_manim_opacity(&mut resource, 0.4).unwrap();
+        assert_eq!(resource.fill, Some(SemanticPaint::Resource(7)));
+        assert_eq!(resource.fill_opacity, 0.4);
+        assert_eq!(resource.stroke, None);
+    }
 
     #[test]
     fn paint_opacity_observes_intrinsic_alpha_and_disabled_paints() {

--- a/web/python/examples/ordinary_affine_callback_continuation.py
+++ b/web/python/examples/ordinary_affine_callback_continuation.py
@@ -34,6 +34,7 @@ class OrdinaryAffineCallbackContinuation(Scene):
 
         def dim_after_lift(mobject, _dt):
             assert mobject.get_center().y == 1.0
+            mobject.set_fill(opacity=0.75)
             mobject.set_opacity(0.5)
 
         circle.add_updater(lift)
@@ -55,8 +56,19 @@ class OrdinaryAffineCallbackContinuation(Scene):
             raise AssertionError("callback family query materialized Python geometry")
         circle._current_raw = reject_raw_projection
         # Object-composite dimming must not alter observed fill/stroke alpha.
-        assert circle.get_fill_opacity() == 1.0
+        assert circle.get_fill_opacity() == 0.75
         assert circle.get_stroke_opacity() == 1.0
+        copied = circle.copy()
+        copied._current_raw = reject_raw_projection
+        copied.set_color(Color(1.0, 0.0, 0.0))
+        assert copied.get_fill_opacity() == 0.75
+        copied.set_fill(opacity=0.5)
+        assert copied.get_fill_opacity() == 0.5
+        copied.set_stroke(opacity=0.25)
+        assert copied.get_stroke_opacity() == 0.25
+        copied.set_opacity(0.4)
+        assert abs(copied.get_fill_opacity() - 0.4) < 1e-6
+        assert abs(copied.get_stroke_opacity() - 0.4) < 1e-6
         assert family.get_center() == (2.0, 1.0)
         assert abs(family.width - 0.8) < 1e-6
         assert abs(family.height - 0.8) < 1e-6


### PR DESCRIPTION
Recoloring a copy of a translucent callback result now preserves its paint alpha. Setting its fill, stroke, or combined Manim opacity sets the requested alpha instead of multiplying the old intrinsic alpha again. Previously effective-state copies could store alpha in the solid color with a unit semantic multiplier, while authored edits assumed the color was opaque.

The existing SemanticStyle paint edit implementation now folds intrinsic solid alpha into the multiplier when replacing RGB, and normalizes it when setting absolute opacity. Fill/stroke reuse two small helpers. Object-composite opacity stays separate; opacity edits preserve resource paint identity and leave disabled channels disabled for the combined operation.

Advances #61/#958 shared style semantics. Semantic Scene owns persistent edits; the existing effective Style operations remain the callback counterpart. No new scene/style authority, cache, transport, or migration seam. Each edit remains local and uses the existing atomic mutation publication path.

The paired ordinary callback continuation now sets fill alpha to 0.75, captures a detached effective copy after completion, recolors it, and changes fill/stroke/combined opacity. Rust and Python assert the same results through their normal live operations. The copy stays detached. Shared tests compare authored and effective edits with intrinsic alpha, including initially transparent stroke, separate object opacity, and resource-paint preservation.

Validation:
- CARGO_TARGET_DIR=/Users/ykshin/Dev/me/noon/target CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=2 cargo test --workspace --all-features --lib ordinary_callback_continuation_uses_ordered_shared_barriers:passed.
- NOON_WEB_PREFLIGHT_ONLY=1 NOON_SKIP_PLAYGROUND_TEST=1 bash scripts/check.sh web:199 Python API tests and static/inventory checks passed.
- bash scripts/architecture-ratchet.sh 84b251d696c1790a7aa93ce07647e6f3e5442b38; git diff --check:passed.
- CARGO_TARGET_DIR=/Users/ykshin/Dev/me/noon/target CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=2 NOON_SKIP_WEB_PREFLIGHT=1 NOON_SKIP_PLAYGROUND_TEST=1 NOON_WASM_PROFILE=dev bash scripts/check.sh full:passed, 1,750 Rust tests and 211 package contracts.
- Focused production Python callback-copy source and direct Rust/WASM WebGPU+WebGL2 proof:passed. No production changes after the full gate began.

Phase A remains incomplete. Browser/runtime evidence is not an independent Manim differential run.
