### PR TITLE
Qualify text authoring through shared runtime and glyph rendering

### DIFF
--- a/.github/workflows/retained-typst-authoring.yml
+++ b/.github/workflows/retained-typst-authoring.yml
@@ -1,11 +1,17 @@
-name: Retained Typst authoring
+name: Shared text authoring
 
 on:
   push:
     branches:
       - master
     paths:
-      - "crates/noon-web/src/retained_authoring.rs"
+      - "crates/noon-web/src/authoring_mobject.rs"
+      - "crates/noon-web/src/canonical_authoring_scene.rs"
+      - "crates/noon-web/src/semantic_execution_player.rs"
+      - "web/authoring-client.js"
+      - "web/authoring-execution-client.js"
+      - "web/execution-worker-client.js"
+      - "scripts/browser-test-server.mjs"
       - "web/python-worker.source.js"
       - "web/python-compat-modules.js"
       - "web/python/_manim_typst.py"
@@ -14,7 +20,13 @@ on:
       - ".github/workflows/retained-typst-authoring.yml"
   pull_request:
     paths:
-      - "crates/noon-web/src/retained_authoring.rs"
+      - "crates/noon-web/src/authoring_mobject.rs"
+      - "crates/noon-web/src/canonical_authoring_scene.rs"
+      - "crates/noon-web/src/semantic_execution_player.rs"
+      - "web/authoring-client.js"
+      - "web/authoring-execution-client.js"
+      - "web/execution-worker-client.js"
+      - "scripts/browser-test-server.mjs"
       - "web/python-worker.source.js"
       - "web/python-compat-modules.js"
       - "web/python/_manim_typst.py"
@@ -32,7 +44,7 @@ concurrency:
 
 jobs:
   browser-authoring:
-    name: Python retained Typst
+    name: Python shared text
     runs-on: ubuntu-latest
     env:
       CARGO_INCREMENTAL: "0"

--- a/scripts/manim-typst-authoring-smoke.mjs
+++ b/scripts/manim-typst-authoring-smoke.mjs
@@ -1,40 +1,12 @@
 import assert from "node:assert/strict";
-import { spawn } from "node:child_process";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-
 import playwright from "playwright";
+import { serveRepository } from "./browser-test-server.mjs";
+import { browserArgs } from "./manim-raster-support.mjs";
 
-const { chromium } = playwright;
-const scriptDir = path.dirname(fileURLToPath(import.meta.url));
-const repoRoot = path.resolve(scriptDir, "..");
-const port = 4187;
-const baseUrl = `http://127.0.0.1:${port}`;
-
-let serverOutput = "";
-const server = spawn(
-  "python3",
-  ["-m", "http.server", String(port), "--bind", "127.0.0.1", "--directory", repoRoot],
-  { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] },
-);
-server.stdout.on("data", (chunk) => (serverOutput += chunk));
-server.stderr.on("data", (chunk) => (serverOutput += chunk));
-
-async function waitForServer() {
-  let lastError = null;
-  for (let attempt = 0; attempt < 80; attempt += 1) {
-    try {
-      const response = await fetch(`${baseUrl}/web/`);
-      if (response.ok) return;
-      lastError = new Error(`HTTP ${response.status}`);
-    } catch (error) {
-      lastError = error;
-    }
-    await new Promise((resolve) => setTimeout(resolve, 100));
-  }
-  throw new Error(`typed text authoring smoke server did not start: ${lastError}\n${serverOutput}`);
-}
-
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 // Pinned ManimCE v0.21 Typst examples plus the native Text surface that replaces
 // Noon's temporary geometry-backed demo labels. Only the import is substituted.
 const helloTextSource = `from noon import *
@@ -75,6 +47,9 @@ const helloTypstSource = `from noon import *
 class HelloTypst(Scene):
     def construct(self):
         text = Typst(r"*Hello* from _Typst!_", font_size=96)
+        baseline = Typst(r"*Hello* from _Typst!_", font_size=48)
+        assert abs(text.width / baseline.width - 2) < 1e-5
+        assert abs(text.height / baseline.height - 2) < 1e-5
         self.add(text)
 `;
 
@@ -84,6 +59,9 @@ const helloMathTypstSource = `from noon import *
 class HelloMathTypst(Scene):
     def construct(self):
         equation = MathTypst(r"sum_(k=1)^n k = (n(n + 1)) / 2", font_size=72)
+        baseline = MathTypst(r"sum_(k=1)^n k = (n(n + 1)) / 2", font_size=48)
+        assert abs(equation.width / baseline.width - 1.5) < 1e-5
+        assert abs(equation.height / baseline.height - 1.5) < 1e-5
         self.add(equation)
 `;
 
@@ -92,256 +70,96 @@ const mixedPainterSource = `from noon import *
 
 class MixedPainterOrder(Scene):
     def construct(self):
-        self.add(Circle(radius=0.25))
+        self.add(Circle(radius=0.25).shift(LEFT))
         self.add(Text("middle", font_size=48))
-        self.add(Square(side_length=0.5))
+        self.add(Square(side_length=0.5).shift(RIGHT))
 `;
 
-function canonicalTextObject(result, {
-  source,
-  fontSize,
-  effectiveFontSize = null,
-  order,
-  objectId,
-}) {
-  assert.equal(result.kind, "scene_document");
-  assert.equal("retained_document" in result, false, "mixed content needs no text sidecar");
-  assert.ok(result.scene_spec, "scene result must include canonical SceneSpec");
-  const object = result.scene_spec.objects[order];
-  assert.equal(object.id, objectId, "text must use the scene-global object ID allocator");
-  assert.equal(object.content.kind, "text");
-  const text = object.content.value;
-  assert.equal(text.source, source);
-  assert.equal(text.font_size, fontSize);
-  if (effectiveFontSize !== null) {
-    assert.ok(
-      Math.abs(text.font_size * object.transform.scale.x - effectiveFontSize) < 1e-5,
-      "canonical text font size and transform scale must preserve the effective X presentation",
-    );
-    assert.ok(
-      Math.abs(text.font_size * object.transform.scale.y - effectiveFontSize) < 1e-5,
-      "canonical text font size and transform scale must preserve the effective Y presentation",
-    );
-  }
-
-  const wire = JSON.stringify(text);
-  for (const forbidden of ["glyph", "font_bytes", "svg", "geometry", "atlas"]) {
-    assert.ok(!wire.includes(forbidden), `canonical text source must not contain ${forbidden}`);
-  }
-  return { object, text };
-}
-
-function assertNativeText(result, expected) {
-  const text = canonicalTextObject(result, expected);
-  assert.equal(text.text.kind, "plain");
-  assert.equal(text.text.options.kind, "native_plain");
-  assert.equal(text.text.options.font_family, expected.fontFamily ?? "DejaVu Sans Mono");
-  assert.equal(text.text.options.line_spacing, expected.lineSpacing ?? -1);
-  return text;
-}
-
-function assertTypst(result, expected) {
-  const text = canonicalTextObject(result, expected);
-  assert.equal(text.text.kind, expected.math ? "math_typst" : "typst");
-  assert.deepEqual(text.object.style.fill, { red: 1, green: 1, blue: 1, alpha: 1 });
-  assert.equal(text.object.style.opacity, 1);
-}
-
-let browser = null;
+const cases = [
+  { name: "native-text", source: helloTextSource, count: 1 },
+  { name: "multiline", source: multilineTextSource, count: 1 },
+  { name: "native-layout", source: nativeTextLayoutSource, count: 2 },
+  { name: "typst", source: helloTypstSource, count: 1 },
+  { name: "math-typst", source: helloMathTypstSource, count: 1 },
+  { name: "mixed-painter-order", source: mixedPainterSource, count: 3 },
+];
+const server = await serveRepository(root, Number(process.env.NOON_TEXT_AUTHORING_PORT ?? 4187));
+let browser;
+const reports = [];
 try {
-  await waitForServer();
-  browser = await chromium.launch({
-    channel: "chromium",
-    headless: true,
-    args: ["--disable-dev-shm-usage"],
-  });
-  const page = await browser.newPage();
+  browser = await playwright.chromium.launch({ channel: "chromium", headless: true, args: browserArgs("webgpu") });
+  const page = await browser.newPage({ viewport: { width: 1200, height: 800 } });
   const errors = [];
-  page.on("pageerror", (error) => errors.push(`pageerror: ${error}`));
-  page.on("console", (message) => {
-    if (message.type() === "error") errors.push(`console: ${message.text()}`);
-  });
-
-  await page.goto(`${baseUrl}/web/`, { waitUntil: "load" });
-  await page.evaluate(() => {
-    const worker = new Worker(new URL("./python-worker.js", location.href), {
-      name: "noon-typed-text-authoring-smoke",
-      type: "module",
-    });
-    let nextRequestId = 0;
-    const pending = new Map();
-    let resolveReady;
-    let rejectReady;
-    const ready = new Promise((resolve, reject) => {
-      resolveReady = resolve;
-      rejectReady = reject;
-    });
-
-    worker.addEventListener("error", (event) => {
-      const error = new Error(event.message || "typed text worker crashed");
-      rejectReady(error);
-      for (const { reject } of pending.values()) reject(error);
-      pending.clear();
-    });
-    worker.addEventListener("message", (event) => {
-      const message = event.data;
-      if (message?.channel !== "noon.authoring" || message?.protocolVersion !== 6) {
-        const error = new Error("invalid typed text worker envelope");
-        rejectReady(error);
-        for (const { reject } of pending.values()) reject(error);
-        pending.clear();
-        return;
-      }
-      if (message.type === "ready") {
-        resolveReady();
-        return;
-      }
-      if (message.type === "error") {
-        const error = new Error(String(message.message || "typed text authoring failed"));
-        if (message.requestId === null) {
-          rejectReady(error);
-          for (const { reject } of pending.values()) reject(error);
-          pending.clear();
-          return;
-        }
-        const request = pending.get(message.requestId);
-        if (request) {
-          pending.delete(message.requestId);
-          request.reject(error);
-        }
-        return;
-      }
-      if (message.type === "result") {
-        const request = pending.get(message.requestId);
-        if (!request) return;
-        pending.delete(message.requestId);
-        request.resolve(JSON.parse(message.resultJson));
-      }
-    });
-
-    window.noonTypedTextSmoke = {
-      ready: () => ready,
-      run: async (source) => {
-        await ready;
-        const requestId = nextRequestId++;
-        const result = new Promise((resolve, reject) => pending.set(requestId, { resolve, reject }));
-        worker.postMessage({
-          channel: "noon.authoring",
-          protocolVersion: 6,
-          type: "run",
-          requestId,
-          source,
-          context: {},
-          exportDocument: true,
-        });
-        return result;
+  page.on("pageerror", error => errors.push(String(error)));
+  page.on("console", message => { if (message.type() === "error") errors.push(message.text()); });
+  await page.goto(`${server.baseUrl}/web/execution-worker-smoke.html`);
+  await page.evaluate(async () => {
+    const { PythonAuthoringClient } = await import("./authoring-client.js");
+    const { AuthoringExecutionClient } = await import("./authoring-execution-client.js");
+    const authoring = new PythonAuthoringClient();
+    await authoring.ready();
+    window.textAuthoringSmoke = {
+      async run(source) {
+        const canvas = document.createElement("canvas");
+        canvas.width = 960; canvas.height = 540;
+        canvas.style.width = "960px"; canvas.style.height = "540px";
+        document.body.replaceChildren(canvas);
+        const execution = new AuthoringExecutionClient(canvas);
+        try {
+          const authored = await authoring.run(source, {});
+          if (!authored.semanticExecution) throw new Error("text scene did not use shared semantics");
+          await execution.startSemanticExecution(authored.semanticExecution, {
+            authoringClient: authoring, initiallyPaused: true, transportMode: "transferable",
+          });
+          await execution.advanceTo(0);
+          return { kind: authored.kind, mode: execution.mode, backend: execution.rendererBackend,
+            frame: await execution.debugFrame(), metrics: (await execution.metrics()).metrics };
+        } finally { execution.terminate(); }
       },
-      stop: () => worker.terminate(),
+      stop() { authoring.terminate(); },
     };
   });
-  await page.evaluate(() => window.noonTypedTextSmoke.ready());
-
-  const helloText = await page.evaluate(
-    (source) => window.noonTypedTextSmoke.run(source),
-    helloTextSource,
-  );
-  assert.equal(helloText.document.objects.length, 0, "Text must not create placeholder geometry");
-  assertNativeText(helloText, {
-    source: "Native Noon",
-    fontSize: 48,
-    order: 0,
-    objectId: 0,
-  });
-
-  const multilineText = await page.evaluate(
-    (source) => window.noonTypedTextSmoke.run(source),
-    multilineTextSource,
-  );
-  assert.equal(
-    multilineText.document.objects.length,
-    0,
-    "multiline Text must not create placeholder geometry",
-  );
-  assertNativeText(multilineText, {
-    source: "first\nsecond",
-    fontSize: 36,
-    lineSpacing: 0.5,
-    order: 0,
-    objectId: 0,
-  });
-
-  const nativeLayout = await page.evaluate(
-    (source) => window.noonTypedTextSmoke.run(source),
-    nativeTextLayoutSource,
-  );
-  assert.equal(nativeLayout.document.objects.length, 1, "layout scene must retain only the Square as geometry");
-  assert.equal(nativeLayout.document.objects[0].id, 0);
-  const nativeLayoutText = assertNativeText(nativeLayout, {
-    source: "Native Noon",
-    fontSize: 48,
-    order: 1,
-    objectId: 1,
-  });
-  assert.ok(
-    Math.abs(nativeLayoutText.object.transform.translation.x - 2.25) < 1e-4,
-    "Text.next_to must use Rust-owned width/critical-point metrics",
-  );
-  assert.ok(Math.abs(nativeLayoutText.object.transform.translation.y) < 1e-5);
-  assert.ok(Math.abs(nativeLayoutText.object.transform.scale.x - nativeLayoutText.object.transform.scale.y) < 1e-6);
-  assert.ok(nativeLayoutText.object.transform.scale.x > 0);
-
-  const helloTypst = await page.evaluate(
-    (source) => window.noonTypedTextSmoke.run(source),
-    helloTypstSource,
-  );
-  assert.equal(helloTypst.document.objects.length, 0, "Typst must not create placeholder geometry");
-  assertTypst(helloTypst, {
-    source: "*Hello* from _Typst!_",
-    math: false,
-    fontSize: 48,
-    effectiveFontSize: 96,
-    order: 0,
-    objectId: 0,
-  });
-
-  const helloMathTypst = await page.evaluate(
-    (source) => window.noonTypedTextSmoke.run(source),
-    helloMathTypstSource,
-  );
-  assert.equal(
-    helloMathTypst.document.objects.length,
-    0,
-    "MathTypst must not create placeholder geometry",
-  );
-  assertTypst(helloMathTypst, {
-    source: "sum_(k=1)^n k = (n(n + 1)) / 2",
-    math: true,
-    fontSize: 48,
-    effectiveFontSize: 72,
-    order: 0,
-    objectId: 0,
-  });
-
-  const mixed = await page.evaluate(
-    (source) => window.noonTypedTextSmoke.run(source),
-    mixedPainterSource,
-  );
-  assert.equal(mixed.document.objects.length, 2, "only the circle and square belong to legacy geometry");
-  assert.equal(mixed.document.objects[0].id, 0);
-  assert.equal(mixed.document.objects[1].id, 2);
-  assertNativeText(mixed, {
-    source: "middle",
-    fontSize: 48,
-    order: 1,
-    objectId: 1,
-  });
-
-  await page.evaluate(() => window.noonTypedTextSmoke.stop());
-  assert.deepEqual(errors, [], `browser errors while testing typed text authoring:\n${errors.join("\n")}`);
-  console.log(
-    "Text authoring smoke passed: native Text layout/placement and pinned Manim v0.21 Typst/MathTypst sources emit canonical source-only mixed content with zero placeholder geometry, exact JS-safe identities, and deterministic mixed painter order.",
-  );
-} finally {
-  await browser?.close();
-  server.kill("SIGTERM");
-}
+  for (const spec of cases) {
+    let timer;
+    try {
+      const result = await Promise.race([
+        page.evaluate(source => window.textAuthoringSmoke.run(source), spec.source),
+        new Promise((_, reject) => { timer = setTimeout(() => reject(new Error(`${spec.name} timed out`)), 60000); }),
+      ]);
+      assert.equal(result.mode, "semantic");
+      assert.equal(result.backend, "WebGPU");
+      assert.equal(result.metrics.objectCount, spec.count, spec.name);
+      assert.equal(result.frame.objects.length, spec.count, spec.name);
+      assert.equal(result.frame.present_object_count, spec.count);
+      assert.equal(new Set(result.frame.objects.map(object => object.id)).size, spec.count);
+      assert.ok(result.metrics.drawCalls > 0 && result.metrics.presentedFrames > 0);
+      assert.ok(result.metrics.instancesDrawn > spec.count, "text must render glyphs, not placeholder geometry");
+      for (const object of result.frame.objects) {
+        assert.ok(object.bounds.width > 0 && object.bounds.height > 0, "shared text layout must have positive bounds");
+      }
+      if (spec.name === "typst" || spec.name === "math-typst") {
+        assert.deepEqual(result.frame.objects[0].fill, { red: 1, green: 1, blue: 1, alpha: 1 });
+        assert.equal(result.frame.objects[0].style_opacity, 1);
+      }
+      if (spec.name === "native-layout") {
+        const label = result.frame.objects[1];
+        assert.ok(Math.abs(label.bounds.width - 2) < 1e-4);
+        assert.ok(Math.abs(label.center[0] - 2.25) < 1e-4);
+        assert.ok(Math.abs(label.center[1]) < 1e-5);
+        assert.ok(Math.abs(label.transform.scale.x - label.transform.scale.y) < 1e-6);
+      }
+      if (spec.name === "mixed-painter-order") {
+        assert.deepEqual(result.frame.objects.map(object => object.center[0]), [-1, 0, 1]);
+      }
+      reports.push({ name: spec.name, ...result });
+      console.log(`PASS ${spec.name}: ${spec.count} shared objects, ${result.metrics.instancesDrawn} rendered instances`);
+    } finally { clearTimeout(timer); }
+  }
+  await page.evaluate(() => window.textAuthoringSmoke.stop());
+  assert.deepEqual(errors, []);
+  if (process.env.NOON_TEXT_AUTHORING_REPORT) {
+    const artifact = path.resolve(process.env.NOON_TEXT_AUTHORING_REPORT);
+    await mkdir(path.dirname(artifact), { recursive: true });
+    await writeFile(artifact, JSON.stringify(reports, (_key, value) => typeof value === "bigint" ? value.toString() : value, 2));
+  }
+} finally { await browser?.close(); await server.close(); }

--- a/scripts/retained-typst-workflow-policy.test.mjs
+++ b/scripts/retained-typst-workflow-policy.test.mjs
@@ -9,7 +9,7 @@ function triggerBlock(name) {
   const lines = workflow.split(/\r?\n/);
   const header = `  ${name}:`;
   const start = lines.findIndex((line) => line === header);
-  assert.notEqual(start, -1, `retained Typst workflow must define ${name}`);
+  assert.notEqual(start, -1, `shared text workflow must define ${name}`);
 
   const block = [];
   for (let index = start + 1; index < lines.length; index += 1) {
@@ -23,7 +23,7 @@ function triggerBlock(name) {
 function pathsForTrigger(name) {
   const block = triggerBlock(name);
   const pathsIndex = block.findIndex((line) => line === "    paths:");
-  assert.notEqual(pathsIndex, -1, `${name} must define a retained Typst path filter`);
+  assert.notEqual(pathsIndex, -1, `${name} must define a shared text path filter`);
 
   const paths = [];
   for (let index = pathsIndex + 1; index < block.length; index += 1) {
@@ -34,23 +34,25 @@ function pathsForTrigger(name) {
   return paths;
 }
 
-test("retained Typst regressions gate matching pull-request and master paths", () => {
+test("shared text regressions gate matching pull-request and master paths", () => {
   const pushPaths = pathsForTrigger("push");
   const pullRequestPaths = pathsForTrigger("pull_request");
 
-  assert.ok(pushPaths.length > 0, "retained Typst workflow must own at least one path");
+  assert.ok(pushPaths.length > 0, "shared text workflow must own at least one path");
   assert.deepEqual(
     pullRequestPaths,
     pushPaths,
-    "pull requests and master pushes must exercise the same retained Typst ownership boundary",
+    "pull requests and master pushes must exercise the same shared text ownership boundary",
   );
 
   assert.ok(pushPaths.includes("web/python-worker.source.js"));
+  assert.ok(pushPaths.includes("crates/noon-web/src/semantic_execution_player.rs"));
+  assert.ok(pushPaths.includes("web/authoring-execution-client.js"));
   assert.ok(pushPaths.includes("scripts/manim-typst-authoring-smoke.mjs"));
   assert.ok(pushPaths.includes(".github/workflows/retained-typst-authoring.yml"));
 });
 
-test("post-merge retained Typst validation remains scoped to master", () => {
+test("post-merge shared text validation remains scoped to master", () => {
   const push = triggerBlock("push").join("\n");
   assert.match(push, /^    branches:\n      - master(?:\n|$)/m);
 });

--- a/web/README.md
+++ b/web/README.md
@@ -78,6 +78,8 @@ Sequential `.animate` operations are evaluated at semantic scene time. A later a
 
 Transform semantics are authored in Rust and lowered into renderer-independent execution data. Analytic primitives and fixed path geometry remain distinct execution representations.
 
+`node scripts/manim-typst-authoring-smoke.mjs` qualifies native Text, multiline text, Rust-owned layout, Typst/MathTypst font scaling, and mixed painter order through shared execution and actual glyph rendering. Its optional `NOON_TEXT_AUTHORING_REPORT` contains read-only runtime observations; the harness does not export an authored scene document.
+
 ## Live authoring
 
 Edit **Python scene source** and click **Run** to author and attach a shared semantic execution session. A rerun replaces the session; it does not currently qualify incremental hot reload or identity preservation between independently authored scenes. Within a running session, shared Rust semantics own object identity and mutations.


### PR DESCRIPTION
Qualify native Text, multiline text, layout, Typst, MathTypst, and mixed painter order through the normal shared runtime and renderer. The harness no longer requests document export or asserts a legacy geometry/text partition. It observes shared bounds, transforms, paint, unique runtime identities, and rendered glyph instances; Typst font scaling is checked through shared layout measurements.

Advances #959/#961. Reuses PythonAuthoringClient, AuthoringExecutionClient, and the repository server; deletes the raw worker protocol and server copies. No Rust or common semantic implementation changes, no new migration seam or engine authority. Diagnostic frame capture is opt-in O(scene size) test work, outside normal frame scheduling. Existing equivalent Rust/Python text examples remain unchanged. Update the existing CI workflow to watch current shared authoring/runtime owners.

Validation:
- `NOON_TEXT_AUTHORING_REPORT=<private report path> node scripts/manim-typst-authoring-smoke.mjs` — all six browser cases pass on the fully qualified #1254 WASM. The final white-paint assertions were also checked against those captured frames.
- `node --test scripts/retained-typst-workflow-policy.test.mjs web/ci-workflow-topology.test.mjs` — three tests pass.
- `NOON_WEB_PREFLIGHT_ONLY=1 NOON_SKIP_PLAYGROUND_TEST=1 bash scripts/check.sh web` — complete web preflight.
- `bash scripts/architecture-ratchet.sh 4e330d816ab903b6c2bb0937b0cf2a7307787ae7` and `git diff --check` — pass.

This qualifies current shared text behavior; it is not an independent Manim raster comparison. Remaining export-only fixtures and unused document machinery are the next #959 deletion work. Phase A remains open.
