### PR TITLE
test: qualify Dot and Ellipse through shared Rust semantics

### DIFF
--- a/crates/noon/examples/manim_dot_ellipse_oracle.rs
+++ b/crates/noon/examples/manim_dot_ellipse_oracle.rs
@@ -1,0 +1,31 @@
+//! Explicit differential observations from shared Rust authoring and execution.
+use noon::{Mobject, Scene};
+use serde_json::{json, Value};
+use std::rc::Rc;
+
+fn observe(object: &Mobject) -> Value {
+    let (x, y) = object.center().unwrap();
+    json!({ "center": [x, y], "width": object.width().unwrap(),
+        "height": object.height().unwrap() })
+}
+
+fn main() {
+    let mut scene = Scene::new();
+    let dot = Mobject::manim_dot(Rc::clone(scene.store()), 0.0, 0.0, 0.08).unwrap();
+    let shifted = Mobject::manim_dot(Rc::clone(scene.store()), -2.0, 0.75, 0.18).unwrap();
+    let ellipse = Mobject::manim_ellipse(Rc::clone(scene.store()), 2.0, 1.0).unwrap();
+    let mut transformed = Mobject::manim_ellipse(Rc::clone(scene.store()), 4.0, 1.5).unwrap();
+    transformed.rotate(std::f64::consts::PI / 6.0).unwrap();
+    transformed.shift(1.25, -0.5).unwrap();
+    for object in [&dot, &shifted, &ellipse, &transformed] {
+        scene.add(object).unwrap();
+    }
+    let _session = scene.execution_session().unwrap();
+    println!(
+        "{}",
+        json!({
+            "dot_geometry": { "default": observe(&dot), "shifted": observe(&shifted) },
+            "ellipse_geometry": { "default": observe(&ellipse), "transformed": observe(&transformed) }
+        })
+    );
+}

--- a/scripts/manim-dot-ellipse-differential.py
+++ b/scripts/manim-dot-ellipse-differential.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python3
-"""Focused #76 fixtures using the shared Manim differential normalizers/comparator."""
+"""Compare shared Rust Dot/Ellipse semantics using the Manim differential helpers."""
 
 from __future__ import annotations
 
 import importlib.util
+import json
 import math
+import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -17,11 +20,17 @@ base = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = base
 spec.loader.exec_module(base)
 
-import _manim_phase_b  # noqa: E402,F401 - match browser compatibility stack
-import _manim_geometry  # noqa: E402,F401 - installs Dot/Ellipse public surface
-
-noon = base.noon
 manim = base.manim
+
+
+def noon_observations():
+    subprocess.run(
+        ["cargo", "build", "--quiet", "--workspace", "--all-features", "--example", "manim_dot_ellipse_oracle"],
+        cwd=ROOT, check=True,
+    )
+    binary = ROOT / os.environ.get("CARGO_TARGET_DIR", "target") / "debug/examples/manim_dot_ellipse_oracle"
+    result = subprocess.run([str(binary)], cwd=ROOT, check=True, capture_output=True, text=True)
+    return json.loads(result.stdout)
 
 
 def dot_probe(module):
@@ -46,10 +55,16 @@ def ellipse_probe(module):
     }
 
 
+if manim.__version__ != base.PINNED_MANIM_VERSION:
+    raise SystemExit(
+        f"expected ManimCE {base.PINNED_MANIM_VERSION}, got {manim.__version__}"
+    )
+
+noon = noon_observations()
 fixtures = [
-    base.Fixture("dot_geometry", lambda: dot_probe(noon), lambda: dot_probe(manim)),
+    base.Fixture("dot_geometry", lambda: noon["dot_geometry"], lambda: dot_probe(manim)),
     base.Fixture(
-        "ellipse_geometry", lambda: ellipse_probe(noon), lambda: ellipse_probe(manim)
+        "ellipse_geometry", lambda: noon["ellipse_geometry"], lambda: ellipse_probe(manim)
     ),
 ]
 


### PR DESCRIPTION
The Dot/Ellipse differential job measured the obsolete standalone Python fallback, whose rotated ellipse bounds disagree with Manim. Its Noon probes now use typed Rust semantic objects and an ordinary execution session, following the existing sector/elbow oracles. All four objects and the 1e-6 comparison tolerance are preserved; the harness also enforces the pinned Manim version.

Advances #961 and Phase A qualification. Shared Rust semantics already match the reference; no engine behavior, authority, transport seam, or locality cost changes. JSON is only differential-test output. The broader standalone Python differential migration remains open.

Validation:
- `cargo build --quiet --workspace --all-features --example manim_dot_ellipse_oracle` and native oracle execution.
- Four native observations compared with recorded Manim values at 1e-6; the prior shared Rust/WASM Python ellipse probe returned the same exact transformed bounds.
- `bash scripts/check.sh fast` passed (shared target, incremental disabled, two build jobs).
- `bash scripts/architecture-ratchet.sh c650c5522213dce1bebef5541fa862d55ac69dac`, Python AST parse, and `git diff --check` passed.
- Independent Manim is unavailable locally; the pinned GitHub differential workflow performs that comparison. Production WASM is unchanged.
