### PR TITLE
Qualify more compatibility examples through shared live execution

### DIFF
--- a/scripts/manim-compat-smoke.mjs
+++ b/scripts/manim-compat-smoke.mjs
@@ -469,12 +469,12 @@ try {
   assert.ok(phaseB.metrics.presentedFrames > 0, "shared group membership must render");
 
   const defaultVmobjectStyle = await page.evaluate(
-    (pythonSource) => window.noonManimCompat.run(pythonSource),
+    (pythonSource) => window.noonManimCompat.runLive(pythonSource),
     defaultVmobjectStyleSource,
   );
-  assert.equal(defaultVmobjectStyle.kind, "scene_document");
-  assert.equal(defaultVmobjectStyle.document.objects.length, 3);
-  const defaultStyle = defaultVmobjectStyle.document.objects[0].style;
+  assert.equal(defaultVmobjectStyle.metrics.objectCount, 3);
+  assert.ok(defaultVmobjectStyle.metrics.presentedFrames > 0);
+  const defaultStyle = defaultVmobjectStyle.frame.objects[0];
   assert.equal(defaultStyle.fill.alpha, 0);
   assert.equal(defaultStyle.stroke.alpha, 1);
   assert.ok(Math.abs(defaultStyle.stroke_width - 0.04) < 1e-7);
@@ -490,11 +490,12 @@ try {
   assert.ok(animateParity.metrics.presentedFrames > 0, "shared family animate must render");
 
   const queryTransforms = await page.evaluate(
-    (pythonSource) => window.noonManimCompat.run(pythonSource),
+    (pythonSource) => window.noonManimCompat.runLive(pythonSource),
     queryTransformSource,
   );
-  assert.equal(queryTransforms.kind, "scene_document");
-  assert.equal(queryTransforms.document.objects.length, 3);
+  assert.equal(queryTransforms.metrics.objectCount, 3);
+  assert.ok(queryTransforms.metrics.presentedFrames > 0);
+  assert.ok(queryTransforms.frame.objects.every(object => object.bounds.width > 0 && object.bounds.height > 0));
 
   const sharedRates = await page.evaluate(
     (pythonSource) => window.noonManimCompat.run(pythonSource),
@@ -554,7 +555,7 @@ try {
   let zError = null;
   try {
     await page.evaluate(
-      (pythonSource) => window.noonManimCompat.run(pythonSource),
+      (pythonSource) => window.noonManimCompat.runLive(pythonSource),
       `from noon import *\nresult = Scene()\nLine((0, 0, 1), (1, 0, 0))`,
     );
   } catch (error) {

--- a/web/python/examples/manim_tutorial_manifest.json
+++ b/web/python/examples/manim_tutorial_manifest.json
@@ -113,6 +113,8 @@
     },
     {
       "id": "manim-dot-example",
+      "qualification_mode": "shared-live",
+      "expected_object_count": 3,
       "title": "DotExample",
       "summary": "ManimCE v0.21 Dot reference example, unchanged except for the import module.",
       "status": "ready",
@@ -131,6 +133,8 @@
     },
     {
       "id": "manim-ellipse-example",
+      "qualification_mode": "shared-live",
+      "expected_object_count": 2,
       "title": "EllipseExample",
       "summary": "ManimCE v0.21 Ellipse reference example, unchanged except for the import module.",
       "status": "ready",
@@ -388,6 +392,8 @@
     },
     {
       "id": "manim-lagged-start-map",
+      "qualification_mode": "shared-live",
+      "expected_object_count": 36,
       "title": "LaggedStartMapExample",
       "summary": "ManimCE v0.21 LaggedStartMap reference example, unchanged except for the import module. Text raster qualification remains separate.",
       "status": "ready",
@@ -508,6 +514,8 @@
     },
     {
       "id": "manim-example1-text",
+      "qualification_mode": "shared-live",
+      "expected_object_count": 1,
       "title": "Example1Text",
       "summary": "ManimCE v0.21 Text reference example, unchanged except for the import module, rendered through Noon's retained native Text resources.",
       "status": "ready",
@@ -526,6 +534,8 @@
     },
     {
       "id": "manim-typst-text-reference",
+      "qualification_mode": "shared-live",
+      "expected_object_count": 1,
       "title": "TypstTextReferenceExample",
       "summary": "ManimCE v0.21 Typst reference example, unchanged except for the import module, rendered through Noon's retained Typst resources.",
       "status": "ready",
@@ -544,6 +554,8 @@
     },
     {
       "id": "manim-math-typst-reference",
+      "qualification_mode": "shared-live",
+      "expected_object_count": 1,
       "title": "MathTypstReferenceExample",
       "summary": "ManimCE v0.21 MathTypst reference example, unchanged except for the import module, rendered through Noon's retained Typst math resources.",
       "status": "ready",


### PR DESCRIPTION
Six exact-source tutorial examples and the style/query probes previously qualified exported documents without executing the shared runtime. They now render through the normal semantic continuation. The unchanged tutorial sources cover Dot, Ellipse, LaggedStartMap, Text, Typst and MathTypst; style checks observe retained runtime values, and query assertions still execute in the original Python source.

Advances #959 and #961 (Phase A frontend/qualification cleanup). No engine authority, new transport, migration seam, or production complexity change. Existing paired geometry/text examples remain the direct Rust product proof. This change does not claim independent local Manim differential qualification.

Two export consumers remain intentionally tracked for subsequent shared fixes: foundation animation-target coordinate masks, and tutorial updater removal after a playback barrier. An actual sampled rate-function probe also exposed a returning-easing endpoint/completion discrepancy; its existing export check remains until that is resolved, rather than weakening the expected runtime behavior.

Validation:
- `NOON_WEB_PREFLIGHT_ONLY=1 NOON_SKIP_PLAYGROUND_TEST=1 bash scripts/check.sh web` — passed, including 199 Python tests.
- `node scripts/manim-tutorial-smoke.mjs` — 27/27 exact-source examples passed; six newly use shared live rendering.
- `node scripts/manim-compat-smoke.mjs` — passed.
- `bash scripts/architecture-ratchet.sh a17c48e7d90187eb732ec13de8d79b0bbd78db98` and `git diff --check` — passed.

JavaScript/manifest-only changes reuse the qualified #1258 WASM build.
