### PR TITLE
Support live masked placement through shared Rust layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Equivalent examples run through the native Rust renderer and the Python browser 
 | Geometry and text | [shared_text.rs](crates/noon-native/examples/shared_text.rs) | [shared_text.py](web/python/examples/shared_text.py) |
 | Live membership | [live_semantic_scene.rs](crates/noon-native/examples/live_semantic_scene.rs) | [live_semantic_scene.py](web/python/examples/live_semantic_scene.py) |
 | Affine animation | [live_affine_animation.rs](crates/noon-native/examples/live_affine_animation.rs) | [live_affine_animation.py](web/python/examples/live_affine_animation.py) |
+| Live masked placement | [live_masked_placement.rs](crates/noon-native/examples/live_masked_placement.rs) | [live_masked_placement.py](web/python/examples/live_masked_placement.py) |
 | Affine completion | [live_affine_completion.rs](crates/noon-native/examples/live_affine_completion.rs) | [live_affine_completion.py](web/python/examples/live_affine_completion.py) |
 | Sequential ordinary affine play | [ordinary_affine_play.rs](crates/noon-native/examples/ordinary_affine_play.rs) | [ordinary_affine_play.py](web/python/examples/ordinary_affine_play.py) |
 | Ordinary FadeIn/FadeOut lifecycle | [ordinary_fade_play.rs](crates/noon-native/examples/ordinary_fade_play.rs) | [ordinary_fade_synchronous_continuation.py](web/python/examples/ordinary_fade_synchronous_continuation.py) |

--- a/crates/noon-native/examples/live_masked_placement.rs
+++ b/crates/noon-native/examples/live_masked_placement.rs
@@ -1,0 +1,68 @@
+//! Paired with web/python/examples/live_masked_placement.py.
+use noon::{
+    AnimationOptions, ContinuationStep, LiveContinuation, LiveLayoutTarget, LiveSession, Mobject,
+    RateFunction, Scene,
+};
+
+struct Placement {
+    source: Mobject,
+    reference: Mobject,
+    stage: u8,
+}
+
+impl LiveContinuation for Placement {
+    type Error = String;
+
+    fn resume(&mut self, live: &mut LiveSession<'_>) -> Result<ContinuationStep, String> {
+        if self.stage == 0 {
+            self.stage = 1;
+            return live
+                .wait_segment(0.25)
+                .map(ContinuationStep::Await)
+                .map_err(|error| error.to_string());
+        }
+        if self.stage > 2 {
+            return Ok(ContinuationStep::Finished);
+        }
+        let target = live
+            .target_editor(&self.source)
+            .map_err(|error| error.to_string())?;
+        let (destination, mask) = if self.stage == 1 {
+            (LiveLayoutTarget::Point(99.0, 5.0), (0.0, 1.0))
+        } else {
+            (LiveLayoutTarget::Mobject(&self.reference), (0.5, 1.0))
+        };
+        live.move_to(&target, destination, (0.0, 1.0), mask)
+            .map_err(|error| error.to_string())?;
+        self.stage += 1;
+        live.declare_and_activate_transform_to(
+            &self.source,
+            &target,
+            AnimationOptions::new()
+                .run_time(0.5)
+                .rate_func(RateFunction::Linear),
+        )
+        .map(ContinuationStep::Await)
+        .map_err(|error| error.to_string())
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut scene = Scene::new();
+    let mut source = scene.rectangle(4.0, 2.0)?;
+    source.set_translation(2.0, -1.0)?;
+    let mut reference = scene.rectangle(2.0, 4.0)?;
+    reference.set_translation(-3.0, 3.0)?;
+    for object in [&mut source, &mut reference] {
+        object.set_color(1.0, 1.0, 1.0, 1.0)?;
+        object.set_fill(1.0, 1.0, 1.0, 0.0)?;
+    }
+    scene.add(&source)?;
+    scene.add(&reference)?;
+    noon_native::run_live_program(scene.into_live_program(Placement {
+        source,
+        reference,
+        stage: 0,
+    })?)?;
+    Ok(())
+}

--- a/crates/noon-web/src/canonical_authoring_scene.rs
+++ b/crates/noon-web/src/canonical_authoring_scene.rs
@@ -5441,17 +5441,51 @@ mod wasm {
         }
 
         #[wasm_bindgen(js_name = liveMoveToPoint)]
+        #[allow(clippy::too_many_arguments)]
         pub fn live_move_to_point(
             &mut self,
             handle: &crate::WasmAuthoringMobjectHandle,
             x: f64,
             y: f64,
+            edge_x: f64,
+            edge_y: f64,
+            mask_x: f64,
+            mask_y: f64,
         ) -> Result<(), JsValue> {
             handle.id_in_store(self.inner.scene.store(), "live execution context")?;
             self.inner
                 .active_live_player()
                 .map_err(js_error)?
-                .live_move_to_point(handle.semantic_mobject(), x, y)
+                .live_move_to(
+                    handle.semantic_mobject(),
+                    noon::LiveLayoutTarget::Point(x, y),
+                    (edge_x, edge_y),
+                    (mask_x, mask_y),
+                )
+                .map_err(js_error)
+        }
+
+        #[wasm_bindgen(js_name = liveMoveToMobject)]
+        pub fn live_move_to_mobject(
+            &mut self,
+            handle: &crate::WasmAuthoringMobjectHandle,
+            target: &crate::WasmAuthoringMobjectHandle,
+            edge_x: f64,
+            edge_y: f64,
+            mask_x: f64,
+            mask_y: f64,
+        ) -> Result<(), JsValue> {
+            handle.id_in_store(self.inner.scene.store(), "live execution context")?;
+            target.id_in_store(self.inner.scene.store(), "live execution context")?;
+            self.inner
+                .active_live_player()
+                .map_err(js_error)?
+                .live_move_to(
+                    handle.semantic_mobject(),
+                    noon::LiveLayoutTarget::Mobject(target.semantic_mobject()),
+                    (edge_x, edge_y),
+                    (mask_x, mask_y),
+                )
                 .map_err(js_error)
         }
 
@@ -8373,7 +8407,12 @@ mod tests {
         context
             .active_live_player()
             .unwrap()
-            .live_move_to_point(&pulse, 2.0, -1.0)
+            .live_move_to(
+                &pulse,
+                noon::LiveLayoutTarget::Point(2.0, -1.0),
+                (0.0, 0.0),
+                (1.0, 1.0),
+            )
             .unwrap();
         {
             let store = context.scene.store().borrow();

--- a/crates/noon-web/src/semantic_execution_player.rs
+++ b/crates/noon-web/src/semantic_execution_player.rs
@@ -382,25 +382,15 @@ impl SemanticExecutionPlayer {
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
-    pub(crate) fn live_move_to_point(
+    pub(crate) fn live_move_to(
         &mut self,
         mobject: &noon::Mobject,
-        x: f64,
-        y: f64,
+        target: noon::LiveLayoutTarget<'_>,
+        edge: (f64, f64),
+        mask: (f64, f64),
     ) -> Result<(), String> {
-        let semantics = self
-            .semantics
-            .clone()
-            .ok_or("execution player has no live semantic store")?;
-        noon::LiveSession::new(
-            &semantics,
-            self.semantic_root
-                .expect("live semantic store has one scene root"),
-            &mut self.session,
-        )
-        .move_to_point(mobject, x, y)
-        .map(|_| ())
-        .map_err(|error| error.to_string())
+        self.with_live_session(|live| live.move_to(mobject, target, edge, mask))
+            .map(|_| ())
     }
 
     #[cfg(any(target_arch = "wasm32", test))]

--- a/crates/noon/src/live_session.rs
+++ b/crates/noon/src/live_session.rs
@@ -2029,20 +2029,12 @@ impl<'a> LiveSession<'a> {
         x: f64,
         y: f64,
     ) -> Result<SemanticMutationTransactionResult, LiveSessionError> {
-        let x = authoring_render_f64("move_to.x", x).map_err(LiveSessionError::Mobject)?;
-        let y = authoring_render_f64("move_to.y", y).map_err(LiveSessionError::Mobject)?;
-        let authored = self.authored(mobject)?;
-        let authored_transform = self.placement_authored_transform(mobject)?;
-        let publication = self.session.publication_context();
-        let layout = self.layout_at_transform(mobject, authored_transform, publication)?;
-        let mut translation = authored.transform.translation;
-        translation.x =
-            authoring_render_f64("move_to translation.x", translation.x + x - layout.center.0)
-                .map_err(LiveSessionError::Mobject)?;
-        translation.y =
-            authoring_render_f64("move_to translation.y", translation.y + y - layout.center.1)
-                .map_err(LiveSessionError::Mobject)?;
-        self.set_property(mobject, SemanticObjectProperty::Translation, translation)
+        self.move_to(
+            mobject,
+            LiveLayoutTarget::Point(x, y),
+            (0.0, 0.0),
+            (1.0, 1.0),
+        )
     }
 
     fn placement_authored_transform(
@@ -2731,6 +2723,66 @@ mod tests {
         ));
         assert_eq!(live.session.frame().objects.len(), 1);
         assert!(live.session.take_frame_changes().is_empty());
+    }
+
+    #[test]
+    fn move_to_uses_shared_edges_masks_and_atomic_detached_target_edits() {
+        let mut scene = Scene::new();
+        let mut source = scene.rectangle(4.0, 2.0).unwrap();
+        source.set_translation(2.0, -1.0).unwrap();
+        let mut reference = scene.rectangle(2.0, 4.0).unwrap();
+        reference.set_translation(-3.0, 3.0).unwrap();
+        scene.add(&source).unwrap();
+        scene.add(&reference).unwrap();
+        let mut session = scene.execution_session().unwrap();
+        let mut live = scene.live(&mut session);
+        live.session.take_frame_changes();
+        let result = live
+            .move_to(
+                &source,
+                LiveLayoutTarget::Point(99.0, 5.0),
+                (0.0, 1.0),
+                (0.0, 1.0),
+            )
+            .unwrap();
+        assert_eq!(result.impacts().len(), 1);
+        assert_eq!(live.effective_layout(&source).unwrap().center, (2.0, 4.0));
+        assert_eq!(
+            live.effective_layout(&reference).unwrap().center,
+            (-3.0, 3.0)
+        );
+        let target = live.target_editor(&source).unwrap();
+        live.session.take_frame_changes();
+        live.move_to(
+            &target,
+            LiveLayoutTarget::Mobject(&reference),
+            (0.0, 1.0),
+            (0.5, 1.0),
+        )
+        .unwrap();
+        assert_eq!(target.center().unwrap(), (-0.5, 4.0));
+        assert_eq!(live.effective_layout(&source).unwrap().center, (2.0, 4.0));
+        assert!(live.session.take_frame_changes().is_empty());
+        let publication = live.session.publication_context();
+        assert!(live
+            .move_to(
+                &target,
+                LiveLayoutTarget::Point(1.0, 2.0),
+                (0.0, 0.0),
+                (f64::NAN, 1.0)
+            )
+            .is_err());
+        let foreign = Scene::new().circle(1.0).unwrap();
+        assert!(live
+            .move_to(
+                &target,
+                LiveLayoutTarget::Mobject(&foreign),
+                (0.0, 0.0),
+                (1.0, 1.0)
+            )
+            .is_err());
+        assert_eq!(live.session.publication_context(), publication);
+        assert_eq!(target.center().unwrap(), (-0.5, 4.0));
     }
 
     #[test]

--- a/crates/noon/src/live_session/family_layout.rs
+++ b/crates/noon/src/live_session/family_layout.rs
@@ -84,6 +84,33 @@ impl LiveSession<'_> {
             .map_err(LiveSessionError::Mobject)
     }
 
+    /// Move one live object or detached target using shared edge/mask semantics.
+    /// Reads only the source and destination bounds and publishes one translation.
+    pub fn move_to(
+        &mut self,
+        mobject: &Mobject,
+        target: LiveLayoutTarget<'_>,
+        edge: (f64, f64),
+        mask: (f64, f64),
+    ) -> Result<SemanticMutationTransactionResult, LiveSessionError> {
+        let transform = self.placement_authored_transform(mobject)?;
+        let bounds = mobject
+            .layout_bounds_at(transform)
+            .map_err(LiveSessionError::Mobject)?
+            .unwrap_or_else(|| {
+                Bounds2D64::point(
+                    f64::from(transform.translation.x),
+                    f64::from(transform.translation.y),
+                )
+            });
+        self.place_layout_members(
+            vec![mobject.node_id()],
+            Some(bounds),
+            target,
+            RelativePlacement::Move { edge, mask },
+        )
+    }
+
     pub fn move_family_to(
         &mut self,
         family: &MobjectFamily,

--- a/scripts/manim-compat-smoke.mjs
+++ b/scripts/manim-compat-smoke.mjs
@@ -78,11 +78,17 @@ class Demo(Scene):
             run_time=0.75,
             rate_func=linear,
         )
-        # Masked target edits remain explicit export coverage during #959 migration.
         self.play(circle.animate.set_y(1.5), run_time=0.4, rate_func=linear)
         self.play(FadeIn(Circle(radius=0.2, color=GREEN)), run_time=0.25)
 
-        # Group fades remain explicit export coverage until shared lifecycle migration (#959).
+`;
+
+// Group fades still require incremental shared lifecycle support (#959).
+const groupFadeExportSource = `
+from noon import *
+
+class GroupFadeExport(Scene):
+    def construct(self):
         intro = VGroup(
             Circle(radius=0.18, color=BLUE),
             Square(side_length=0.36, color=PINK),
@@ -433,24 +439,21 @@ try {
   assert.equal(handleOwnership.memberCount, 3, "failed cross-store operations leave membership intact");
 
   const foundation = await page.evaluate(
-    (pythonSource) => window.noonManimCompat.run(pythonSource),
+    (pythonSource) => window.noonManimCompat.runLive(pythonSource),
     foundationSource,
   );
-  assert.equal(foundation.kind, "scene_document");
-  assert.equal(foundation.document.objects.length, 5, "introducer animations should auto-bind objects");
+  assert.ok(Math.abs(foundation.duration - 2.65) < 1e-9);
+  assert.equal(foundation.metrics.objectCount, 3, "introducer animations bind objects through shared membership");
+  assert.ok(foundation.metrics.presentedFrames > 0);
+  assert.ok(Math.abs(foundation.frame.objects[0].center[1] - 1.5) < 1e-6);
+  assert.ok(foundation.frame.objects.slice(0, 2).every(object => object.reveal === 1));
 
-  const foundationProperties = foundation.document.tracks.map((track) => track.property);
-  assert.equal(foundationProperties.filter((property) => property === "presence").length, 7);
-  assert.equal(foundationProperties.filter((property) => property === "reveal").length, 2);
-  assert.ok(foundationProperties.includes("transform"), "animate.shift should lower to transform");
-
-  const revealTracks = foundation.document.tracks.filter((track) => track.property === "reveal");
-  assert.ok(
-    revealTracks.every((track) => track.timing.easing === "smooth"),
-    "rate_func=smooth should lower to the shared smooth semantic ID",
+  const groupFades = await page.evaluate(
+    pythonSource => window.noonManimCompat.run(pythonSource), groupFadeExportSource,
   );
-  const transform = foundation.document.tracks.find((track) => track.property === "transform");
-  assert.equal(transform.timing.easing, "linear");
+  assert.equal(groupFades.document.objects.length, 2);
+  assert.equal(groupFades.document.tracks.filter(track => track.property === "presence").length, 4);
+  assert.equal(groupFades.duration, 0.5);
 
   const uncreate = await page.evaluate(
     (pythonSource) => window.noonManimCompat.runLive(pythonSource),

--- a/web/python/_manim_semantic_handles.py
+++ b/web/python/_manim_semantic_handles.py
@@ -1088,23 +1088,17 @@ def _move_to(
 
     context = _live_mutation_context(self)
     if context is not None:
-        if _alignment_is_mobject(point_or_mobject):
-            raise NotImplementedError(
-                "canonical live move_to currently supports point targets only"
-            )
         edge = _base._as_vec2(aligned_edge)
         mask = _alignment_mask2(coor_mask)
-        if edge.x != 0.0 or edge.y != 0.0:
-            raise NotImplementedError(
-                "canonical live move_to currently supports center alignment only"
-            )
-        if mask.x != 1.0 or mask.y != 1.0:
-            raise NotImplementedError(
-                "canonical live move_to currently supports the default coordinate mask only"
-            )
-        point = _base._as_vec2(point_or_mobject)
         try:
-            context.liveMoveToPoint(handle, point.x, point.y)
+            if _alignment_is_mobject(point_or_mobject):
+                target_handle = _handle_for(point_or_mobject)
+                if target_handle is None:
+                    raise ValueError("live move_to requires a shared semantic target")
+                context.liveMoveToMobject(handle, target_handle, edge.x, edge.y, mask.x, mask.y)
+            else:
+                point = _base._as_vec2(point_or_mobject)
+                context.liveMoveToPoint(handle, point.x, point.y, edge.x, edge.y, mask.x, mask.y)
         except Exception as error:
             raise ValueError(str(error)) from None
         return self

--- a/web/python/_manim_updaters.py
+++ b/web/python/_manim_updaters.py
@@ -1032,10 +1032,12 @@ def _canonical_shift(self: _base.Mobject, direction: object) -> _base.Mobject:
     return self
 
 
-def _canonical_move_to(self: _base.Mobject, point: object) -> _base.Mobject:
+def _canonical_move_to(self: _base.Mobject, point: object, *args: object, **kwargs: object) -> _base.Mobject:
     value = _canonical_row(self)
     if value is None:
-        return _ORIGINAL_MOVE_TO(self, point)
+        return _ORIGINAL_MOVE_TO(self, point, *args, **kwargs)
+    if args or kwargs:
+        raise NotImplementedError("callback move_to currently supports center point placement only")
     _, _, row = value
     return _canonical_shift(self, _base._as_vec2(point) - row.center())
 

--- a/web/python/examples/live_masked_placement.py
+++ b/web/python/examples/live_masked_placement.py
@@ -1,0 +1,19 @@
+from noon import *
+
+
+class LiveMaskedPlacement(Scene):
+    def construct(self):
+        source = Rectangle(width=4, height=2).move_to((2, -1, 0))
+        reference = Rectangle(width=2, height=4).move_to((-3, 3, 0))
+        self.add(source, reference)
+        self.wait(0.25)
+        self.play(source.animate.move_to((99, 5, 0), aligned_edge=UP,
+                                        coor_mask=(0, 1, 0)),
+                  run_time=0.5, rate_func=linear)
+        assert abs(source.get_x() - 2) < 1e-6
+        assert abs(source.get_top().y - 5) < 1e-6
+        self.play(source.animate.move_to(reference, aligned_edge=UP,
+                                        coor_mask=(0.5, 1, 0)),
+                  run_time=0.5, rate_func=linear)
+        assert abs(source.get_x() + 0.5) < 1e-6
+        assert abs(source.get_top().y - reference.get_top().y) < 1e-6


### PR DESCRIPTION
Animation targets using `set_y`, masked `move_to`, or aligned object destinations failed after the first playback barrier. Live placement now delegates to the same Rust relative-placement calculation and atomic translation publication used by family layout. Python only normalizes arguments and forwards typed semantic handles.

Advances #959/#961 and common 2D semantics in #954. The shared Rust LiveSession owns layout and mutations; WASM remains a typed adapter. Source and destination bounds are local, and a single-object move publishes one translation. Detached target edits stay detached and leave renderer work clean. No migration seam or new authority is introduced.

The Rust and Python `live_masked_placement` examples demonstrate a Y-only edge alignment followed by a fractional mask against another object. The foundation compatibility probe now runs through shared live execution, checking completed placement, introducer membership, and presentation instead of exported track counts. Group fades remain an explicit export probe until their shared lifecycle support lands.

Validation:
- `CARGO_TARGET_DIR=/Users/ykshin/Dev/me/noon/target CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=2 cargo test --workspace --all-features --lib move_to_` — four focused tests passed, including invalid-mask and foreign-target atomicity, detached target locality, and active-driver rejection.
- `CARGO_TARGET_DIR=/Users/ykshin/Dev/me/noon/target CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=2 NOON_SKIP_PLAYGROUND_TEST=1 NOON_WASM_PROFILE=dev bash scripts/check.sh full` — passed: 1,745 Rust tests, 199 Python tests, WASM build and 211 API contracts.
- `NOON_WEB_PREFLIGHT_ONLY=1 NOON_SKIP_PLAYGROUND_TEST=1 bash scripts/check.sh web` after the final Python forwarding fix — passed.
- Paired live browser samples on WebGPU and WebGL2 — passed.
- `node scripts/manim-compat-smoke.mjs` — passed.
- `bash scripts/architecture-ratchet.sh 14126a5cab57ea8b0faf74fe5ca9ea8ffcc25ce2` and `git diff --check` — passed.

Native example compilation and shared semantic tests are the Rust evidence; no native window or independent local Manim differential run is claimed. Returning-easing completion and incremental callback-registration publication remain separate tracked work.
