### PR TITLE
Route geometry and mixed family fades through shared execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Equivalent examples run through the native Rust renderer and the Python browser 
 | Geometry and text | [shared_text.rs](crates/noon-native/examples/shared_text.rs) | [shared_text.py](web/python/examples/shared_text.py) |
 | Live membership | [live_semantic_scene.rs](crates/noon-native/examples/live_semantic_scene.rs) | [live_semantic_scene.py](web/python/examples/live_semantic_scene.py) |
 | Affine animation | [live_affine_animation.rs](crates/noon-native/examples/live_affine_animation.rs) | [live_affine_animation.py](web/python/examples/live_affine_animation.py) |
+| Mixed geometry/Text family fades | [mixed_family_fade.rs](crates/noon-native/examples/mixed_family_fade.rs) | [mixed_family_fade.py](web/python/examples/mixed_family_fade.py) |
 | Live masked placement | [live_masked_placement.rs](crates/noon-native/examples/live_masked_placement.rs) | [live_masked_placement.py](web/python/examples/live_masked_placement.py) |
 | Affine completion | [live_affine_completion.rs](crates/noon-native/examples/live_affine_completion.rs) | [live_affine_completion.py](web/python/examples/live_affine_completion.py) |
 | Sequential ordinary affine play | [ordinary_affine_play.rs](crates/noon-native/examples/ordinary_affine_play.rs) | [ordinary_affine_play.py](web/python/examples/ordinary_affine_play.py) |

--- a/compat/semantic-ownership-v1.json
+++ b/compat/semantic-ownership-v1.json
@@ -224,7 +224,7 @@
       "surface": "Typed Group/VGroup FadeIn/FadeOut opacity and lifecycle, including compositions with Text Write",
       "classification": "shared-rust",
       "owner": {"language": "rust", "path": "crates/noon/src/execution_session.rs", "symbol": "SemanticCompositionRequest::FamilyFade"},
-      "adapters": [{"language": "python", "path": "web/python/_manim_canonical_scene.py", "symbol": "_canonical_text_family_fade_animation"}],
+      "adapters": [{"language": "python", "path": "web/python/_manim_canonical_scene.py", "symbol": "_canonical_family_fade_animation"}],
       "reason": "Rust traverses authoritative family leaves, applies shared composition timing, validates conflicts atomically and owns family root introduction/removal. Python passes handles and coerced options; affine family fade endpoints remain unsupported."
     },
     {

--- a/crates/noon-native/examples/mixed_family_fade.rs
+++ b/crates/noon-native/examples/mixed_family_fade.rs
@@ -1,0 +1,55 @@
+//! Paired with web/python/examples/mixed_family_fade.py.
+use noon::{
+    AnimationOptions, ContinuationStep, LiveContinuation, LiveSession, MobjectFamily, RateFunction,
+    Scene, SemanticFadeDirection,
+};
+
+struct MixedFade {
+    family: MobjectFamily,
+    stage: u8,
+}
+
+impl LiveContinuation for MixedFade {
+    type Error = String;
+    fn resume(&mut self, live: &mut LiveSession<'_>) -> Result<ContinuationStep, String> {
+        let direction = match self.stage {
+            0 => SemanticFadeDirection::In,
+            1 => SemanticFadeDirection::Out,
+            2 => {
+                self.stage += 1;
+                return live
+                    .wait_segment(0.25)
+                    .map(ContinuationStep::Await)
+                    .map_err(|e| e.to_string());
+            }
+            _ => return Ok(ContinuationStep::Finished),
+        };
+        self.stage += 1;
+        live.declare_and_activate_family_fade(
+            &self.family,
+            direction,
+            AnimationOptions::new()
+                .run_time(1.0)
+                .rate_func(RateFunction::Linear)
+                .lag_ratio(0.25),
+        )
+        .map(ContinuationStep::Await)
+        .map_err(|e| e.to_string())
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let scene = Scene::new();
+    let mut circle = scene.circle(0.4)?;
+    circle.set_translation(-2.0, 0.0)?;
+    let mut square = scene.rectangle(0.8, 0.8)?;
+    for object in [&mut circle, &mut square] {
+        object.set_color(1.0, 1.0, 1.0, 1.0)?;
+        object.set_fill(1.0, 1.0, 1.0, 0.0)?;
+    }
+    let mut text = scene.text("TEXT")?;
+    text.set_translation(2.0, 0.0)?;
+    let family = scene.family(&[(&circle).into(), (&square).into(), (&text).into()])?;
+    noon_native::run_live_program(scene.into_live_program(MixedFade { family, stage: 0 })?)?;
+    Ok(())
+}

--- a/scripts/manim-compat-smoke.mjs
+++ b/scripts/manim-compat-smoke.mjs
@@ -83,11 +83,11 @@ class Demo(Scene):
 
 `;
 
-// Group fades still require incremental shared lifecycle support (#959).
-const groupFadeExportSource = `
+// Ordinary groups use the same shared family lifecycle as Text families.
+const groupFadeSource = `
 from noon import *
 
-class GroupFadeExport(Scene):
+class GroupFadeLive(Scene):
     def construct(self):
         intro = VGroup(
             Circle(radius=0.18, color=BLUE),
@@ -449,10 +449,10 @@ try {
   assert.ok(foundation.frame.objects.slice(0, 2).every(object => object.reveal === 1));
 
   const groupFades = await page.evaluate(
-    pythonSource => window.noonManimCompat.run(pythonSource), groupFadeExportSource,
+    pythonSource => window.noonManimCompat.runLive(pythonSource), groupFadeSource,
   );
-  assert.equal(groupFades.document.objects.length, 2);
-  assert.equal(groupFades.document.tracks.filter(track => track.property === "presence").length, 4);
+  assert.equal(groupFades.metrics.objectCount, 0, "family FadeOut detaches the shared root");
+  assert.ok(groupFades.metrics.presentedFrames > 0);
   assert.equal(groupFades.duration, 0.5);
 
   const uncreate = await page.evaluate(

--- a/web/python/_manim_canonical_scene.py
+++ b/web/python/_manim_canonical_scene.py
@@ -1117,10 +1117,10 @@ def _canonical_fade_animation(
     return target, direction
 
 
-def _canonical_text_family_fade_animation(
+def _canonical_family_fade_animation(
     scene: _base.Scene, animation: object
-) -> tuple[_compat.Group, list[_typst.Text], str] | None:
-    """Classify one plain-Text family fade without expanding its leaves."""
+) -> tuple[_compat.Group, list[_base.Mobject], str] | None:
+    """Classify one shared geometry/Text family fade without expanding animations."""
     if type(animation) is _base.FadeIn:
         direction = "in"
     elif type(animation) is _base.FadeOut:
@@ -1132,25 +1132,24 @@ def _canonical_text_family_fade_animation(
         return None
     leaves = _compat._leaf_mobjects(family)
     if not leaves:
-        raise ValueError("canonical Text family Fade requires at least one leaf")
-    if not all(isinstance(member, _typst.Text) for member in leaves):
-        if any(isinstance(member, _typst._RetainedTextMobject) for member in leaves):
-            raise NotImplementedError(
-                "canonical family Fade supports plain Text; Typst and MathTypst remain #959"
-            )
-        return None
+        raise ValueError("canonical family Fade requires at least one leaf")
+    if any(isinstance(member, _typst._RetainedTextMobject) and not isinstance(member, _typst.Text)
+           for member in leaves):
+        raise NotImplementedError("canonical family Fade does not yet support Typst or MathTypst")
+    if any(getattr(member, "_semantic_handle", None) is None for member in leaves):
+        raise NotImplementedError("canonical family Fade requires shared semantic leaves")
     if getattr(family, "_semantic_family_handle", None) is None:
-        raise NotImplementedError("canonical Text family Fade requires a shared family handle")
+        raise NotImplementedError("canonical family Fade requires a shared family handle")
     endpoint = _canonical_fade_endpoint(animation)
     if endpoint != (1.0, "shift", 0.0, 0.0):
         raise NotImplementedError(
-            "canonical Text family Fade does not support shift, scale, or target_position"
+            "canonical family Fade does not support shift, scale, or target_position"
         )
     if direction == "in":
         if any(member._scene is not None for member in leaves):
-            raise ValueError("Text family FadeIn requires a detached family")
+            raise ValueError("family FadeIn requires a detached family")
     elif any(member._scene is not scene for member in leaves):
-        raise ValueError("Text family FadeOut requires a family in this Scene")
+        raise ValueError("family FadeOut requires a family in this Scene")
     return family, leaves, direction
 
 
@@ -1801,14 +1800,14 @@ def _build_canonical_composition_candidate(
             if removes:
                 removals.append(target)
             return
-        family_fade = _canonical_text_family_fade_animation(self, animation)
+        family_fade = _canonical_family_fade_animation(self, animation)
         if family_fade is not None:
             family, leaves, direction = family_fade
             child = _canonical_fade_options(
                 animation, child_kwargs, allow_family_lag=True
             )
             if child is None:
-                raise NotImplementedError("unsupported canonical Text family Fade options")
+                raise NotImplementedError("unsupported canonical family Fade options")
             builder.appendFamilyFade(
                 family._semantic_family_handle,
                 direction,

--- a/web/python/examples/mixed_family_fade.py
+++ b/web/python/examples/mixed_family_fade.py
@@ -1,0 +1,12 @@
+from noon import *
+
+
+class MixedFamilyFade(Scene):
+    def construct(self):
+        family = VGroup(Circle(radius=0.4).shift(2 * LEFT),
+                        Square(side_length=0.8), Text("TEXT").shift(2 * RIGHT))
+        self.play(FadeIn(family, lag_ratio=0.25), run_time=1, rate_func=linear)
+        assert family in self.mobjects
+        self.play(FadeOut(family, lag_ratio=0.25), run_time=1, rate_func=linear)
+        assert family not in self.mobjects
+        self.wait(0.25)

--- a/web/retained-family-fade-batch.test.mjs
+++ b/web/retained-family-fade-batch.test.mjs
@@ -13,7 +13,7 @@ test("obsolete retained family fade coordinator stays deleted", () => {
   assert.equal(existsSync("web/python/_manim_retained_animate.py"), false);
   assert.equal(existsSync("web/python/_manim_retained_state.py"), false);
   assert.doesNotMatch(manifestSource, /_manim_retained_animate|_manim_retained_state/);
-  assert.match(canonicalSource, /def _canonical_text_family_fade_animation/);
+  assert.match(canonicalSource, /def _canonical_family_fade_animation/);
   assert.match(canonicalSource, /appendFamilyFade/);
   assert.match(canonicalSource, /appendFamilyFadeEntering/);
 });


### PR DESCRIPTION
`FadeIn(VGroup(Circle(...), Square(...)))` failed on the shared execution path even though Rust already supported family fades. The Python classifier now accepts ordinary geometry and mixed geometry/plain-Text families and forwards them to the existing atomic family fade operation. It does not expand a group into a Python animation schedule.

Advances #959/#961 and the common 2D wrapper coverage in #954. Rust retains family traversal, timing, identity, conflict validation and root lifecycle ownership. No engine change or new migration seam; work remains proportional to the affected family. Existing unsupported affine family fade endpoints and Typst/MathTypst family restrictions remain explicit.

The ordinary group compatibility probe now renders through shared live execution. New paired Rust/Python examples demonstrate a staggered Circle/Square/Text family fading in and out through the normal runtime/renderer. Existing Rust semantic tests cover mixed-family membership, lag and atomic conflict rejection.

Validation:
- `NOON_WEB_PREFLIGHT_ONLY=1 NOON_SKIP_PLAYGROUND_TEST=1 bash scripts/check.sh web` — passed, including 199 Python tests and the updated ownership inventory.
- `CARGO_TARGET_DIR=/Users/ykshin/Dev/me/noon/target CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=2 NOON_SKIP_WEB_PREFLIGHT=1 NOON_SKIP_PLAYGROUND_TEST=1 NOON_WASM_PROFILE=dev bash scripts/check.sh full` — passed.
- Paired shared browser samples on WebGPU and WebGL2 — passed.
- `node scripts/manim-compat-smoke.mjs` — passed.
- `bash scripts/architecture-ratchet.sh 941914e493a6ca8667f598d3f89c3c874a14517b` and `git diff --check` — passed.

The native example is compiled; no native window or independent local Manim differential run is claimed. Export retirement still depends on returning-easing completion and live updater registration publication.
