### PR TITLE
Preserve returning animation endpoints at shared completion barriers

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Equivalent examples run through the native Rust renderer and the Python browser 
 | Geometry and text | [shared_text.rs](crates/noon-native/examples/shared_text.rs) | [shared_text.py](web/python/examples/shared_text.py) |
 | Live membership | [live_semantic_scene.rs](crates/noon-native/examples/live_semantic_scene.rs) | [live_semantic_scene.py](web/python/examples/live_semantic_scene.py) |
 | Affine animation | [live_affine_animation.rs](crates/noon-native/examples/live_affine_animation.rs) | [live_affine_animation.py](web/python/examples/live_affine_animation.py) |
+| Returning transform completion | [returning_transform.rs](crates/noon-native/examples/returning_transform.rs) | [returning_transform.py](web/python/examples/returning_transform.py) |
 | Mixed geometry/Text family fades | [mixed_family_fade.rs](crates/noon-native/examples/mixed_family_fade.rs) | [mixed_family_fade.py](web/python/examples/mixed_family_fade.py) |
 | Live masked placement | [live_masked_placement.rs](crates/noon-native/examples/live_masked_placement.rs) | [live_masked_placement.py](web/python/examples/live_masked_placement.py) |
 | Affine completion | [live_affine_completion.rs](crates/noon-native/examples/live_affine_completion.rs) | [live_affine_completion.py](web/python/examples/live_affine_completion.py) |

--- a/crates/noon-compile/src/semantic_lowering/animation_payload/affine.rs
+++ b/crates/noon-compile/src/semantic_lowering/animation_payload/affine.rs
@@ -57,6 +57,28 @@ pub enum SemanticAnimationCompletion {
     Release,
 }
 
+/// A returning leaf releases its driver at the captured source rather than
+/// committing its destination. Group finish completes each child at its own
+/// alpha one, independently of the outer composition's rate function.
+pub(super) fn completion_at_endpoint(
+    completion: SemanticAnimationCompletion,
+    easing: RateFunction,
+) -> SemanticAnimationCompletion {
+    if easing.evaluate(1.0) == 0.0
+        && matches!(
+            completion,
+            SemanticAnimationCompletion::Property { .. }
+                | SemanticAnimationCompletion::Fill { .. }
+                | SemanticAnimationCompletion::Stroke { .. }
+                | SemanticAnimationCompletion::ContentMorph { .. }
+        )
+    {
+        SemanticAnimationCompletion::Release
+    } else {
+        completion
+    }
+}
+
 /// One existing execution-timeline channel lowered from an activated semantic animation.
 #[derive(Clone, Debug, PartialEq)]
 pub struct SemanticAffineAnimationTrack {
@@ -913,7 +935,7 @@ fn push_published_channel(
         target: leaf.target,
         execution_object_id: leaf.execution_object_id,
         property: channel.property,
-        completion: channel.completion,
+        completion: completion_at_endpoint(channel.completion, leaf.timing.easing),
         values: channel.values,
         timing: leaf.timing,
         time_map: leaf.time_map.clone(),

--- a/crates/noon-compile/src/semantic_lowering/animation_payload/prepared_composition.rs
+++ b/crates/noon-compile/src/semantic_lowering/animation_payload/prepared_composition.rs
@@ -872,7 +872,7 @@ fn push_prepared_channel(
         target: leaf.target,
         execution_object_id: leaf.execution_object_id,
         property: channel.property,
-        completion: channel.completion,
+        completion: super::affine::completion_at_endpoint(channel.completion, leaf.timing.easing),
         values: channel.values,
         timing: leaf.timing,
         time_map: leaf.time_map.clone(),

--- a/crates/noon-native/examples/returning_transform.rs
+++ b/crates/noon-native/examples/returning_transform.rs
@@ -1,0 +1,61 @@
+//! Paired with web/python/examples/returning_transform.py.
+use noon::{
+    AnimationOptions, ContinuationStep, LiveContinuation, LiveSession, Mobject, RateFunction,
+    Scene, SemanticAnimationCompositionKind, TransformToRequest,
+};
+
+struct ReturningTargets {
+    circle: Mobject,
+    first: Mobject,
+    second: Mobject,
+    activated: bool,
+}
+
+impl LiveContinuation for ReturningTargets {
+    type Error = String;
+
+    fn resume(&mut self, live: &mut LiveSession<'_>) -> Result<ContinuationStep, String> {
+        if self.activated {
+            return Ok(ContinuationStep::Finished);
+        }
+        self.activated = true;
+        let options = AnimationOptions::new()
+            .run_time(1.0)
+            .rate_func(RateFunction::Linear);
+        let children = [
+            TransformToRequest::new(&self.circle, &self.first, options),
+            TransformToRequest::new(
+                &self.circle,
+                &self.second,
+                options.rate_func(RateFunction::ThereAndBack),
+            ),
+        ];
+        let segment = live
+            .declare_and_activate_transform_composition(
+                SemanticAnimationCompositionKind::Sequence,
+                &children,
+                AnimationOptions::new().rate_func(RateFunction::Linear),
+                AnimationOptions::new(),
+            )
+            .map_err(|error| error.to_string())?;
+        Ok(ContinuationStep::Await(segment))
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut scene = Scene::new();
+    let mut circle = scene.circle(0.4)?;
+    circle.set_fill(1.0, 1.0, 1.0, 1.0)?;
+    let mut first = circle.target_editor()?;
+    first.set_translation(2.0, 1.0)?;
+    let mut second = circle.target_editor()?;
+    second.set_translation(4.0, 3.0)?;
+    scene.add(&circle)?;
+    noon_native::run_live_program(scene.into_live_program(ReturningTargets {
+        circle,
+        first,
+        second,
+        activated: false,
+    })?)?;
+    Ok(())
+}

--- a/crates/noon/src/execution_session/completion.rs
+++ b/crates/noon/src/execution_session/completion.rs
@@ -562,62 +562,79 @@ mod tests {
 
     #[test]
     fn analytic_content_morph_replaces_authored_endpoint_and_releases_render_pair() {
-        let mut store = SemanticStore::new();
-        let object =
-            store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
-                radius: 1.0,
-            }));
-        store.attach_to_scene(object).unwrap();
-        let mut target_state = SemanticObjectState::new(StoredGeometry::Rectangle {
-            size: Vec2::new(2.0, 2.0),
-        });
-        target_state.transform.translation = SemanticVec3::new(3.0, -1.0, 0.0);
-        target_state.style.fill = Some(SemanticPaint::Solid(Color::RED));
-        target_state.style.fill_opacity = 0.5;
-        let expected = target_state.clone();
-        let target = store.insert_semantic_object(target_state);
-        let animation = store
-            .insert_semantic_transform_animation(object, target, AnimationOptions::new())
-            .unwrap();
-        let mut session = ExecutionSession::from_semantic_store(&store).unwrap();
-        let segment = session
-            .activate_animation_segment(
-                &store,
-                animation,
-                AnimationOptions::new()
-                    .run_time(2.0)
-                    .rate_func(RateFunction::Linear),
-            )
-            .unwrap();
+        for returning in [false, true] {
+            let mut store = SemanticStore::new();
+            let object =
+                store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+                    radius: 1.0,
+                }));
+            store.attach_to_scene(object).unwrap();
+            let mut target_state = SemanticObjectState::new(StoredGeometry::Rectangle {
+                size: Vec2::new(2.0, 2.0),
+            });
+            target_state.transform.translation = SemanticVec3::new(3.0, -1.0, 0.0);
+            target_state.style.fill = Some(SemanticPaint::Solid(Color::RED));
+            target_state.style.fill_opacity = 0.5;
+            let expected = if returning {
+                store.semantic_object_state_checked(object).unwrap().clone()
+            } else {
+                target_state.clone()
+            };
+            let target = store.insert_semantic_object(target_state);
+            let animation = store
+                .insert_semantic_transform_animation(object, target, AnimationOptions::new())
+                .unwrap();
+            let mut session = ExecutionSession::from_semantic_store(&store).unwrap();
+            let segment = session
+                .activate_animation_segment(
+                    &store,
+                    animation,
+                    AnimationOptions::new()
+                        .run_time(2.0)
+                        .rate_func(if returning {
+                            RateFunction::ThereAndBack
+                        } else {
+                            RateFunction::Linear
+                        }),
+                )
+                .unwrap();
 
-        session.advance_segment_to(segment, 1.0).unwrap();
-        assert!((session.frame().morph(0) - 0.5).abs() < 1e-6);
-        assert!(matches!(
-            session.frame().render_geometry(0),
-            Some(noon_core::GeometryRef::VectorPath(path)) if path.morph_target().is_some()
-        ));
-        assert!(matches!(
-            store
-                .semantic_object_state_checked(object)
-                .unwrap()
-                .content
-                .geometry(),
-            Some(StoredGeometry::Circle { .. })
-        ));
+            session.advance_segment_to(segment, 1.0).unwrap();
+            assert!((session.frame().morph(0) - if returning { 1.0 } else { 0.5 }).abs() < 1e-6);
+            assert!(matches!(
+                session.frame().render_geometry(0),
+                Some(noon_core::GeometryRef::VectorPath(path)) if path.morph_target().is_some()
+            ));
+            assert!(matches!(
+                store
+                    .semantic_object_state_checked(object)
+                    .unwrap()
+                    .content
+                    .geometry(),
+                Some(StoredGeometry::Circle { .. })
+            ));
 
-        session.advance_segment_to(segment, 2.0).unwrap();
-        session.complete_segment(&mut store, segment).unwrap();
-        let authored = store.semantic_object_state_checked(object).unwrap();
-        assert_eq!(authored.content, expected.content);
-        assert_eq!(authored.transform, expected.transform);
-        assert_eq!(authored.style, expected.style);
-        assert_eq!(session.frame().morph(0), 0.0);
-        assert!(session.frame().render_geometries[0].is_none());
-        assert!(session.frame().render_transforms[0].is_none());
-        assert!(matches!(
-            session.frame().render_geometry(0),
-            Some(noon_core::GeometryRef::Rectangle { .. })
-        ));
+            session.advance_segment_to(segment, 2.0).unwrap();
+            session.complete_segment(&mut store, segment).unwrap();
+            let authored = store.semantic_object_state_checked(object).unwrap();
+            assert_eq!(authored.content, expected.content);
+            assert_eq!(authored.transform, expected.transform);
+            assert_eq!(authored.style, expected.style);
+            assert_eq!(session.frame().morph(0), 0.0);
+            assert!(session.frame().render_geometries[0].is_none());
+            assert!(session.frame().render_transforms[0].is_none());
+            if returning {
+                assert!(matches!(
+                    session.frame().render_geometry(0),
+                    Some(noon_core::GeometryRef::Circle { .. })
+                ));
+            } else {
+                assert!(matches!(
+                    session.frame().render_geometry(0),
+                    Some(noon_core::GeometryRef::Rectangle { .. })
+                ));
+            }
+        }
     }
 
     #[test]

--- a/crates/noon/src/live_session.rs
+++ b/crates/noon/src/live_session.rs
@@ -2920,6 +2920,138 @@ mod tests {
     }
 
     #[test]
+    fn returning_transform_completion_preserves_the_source_across_activation_paths_and_nested_timing(
+    ) {
+        for mode in ["predeclared", "prepared", "mapped"] {
+            let mut scene = Scene::new();
+            let mut source = scene.circle(0.4).unwrap();
+            source.set_translation(1.25, -0.75).unwrap();
+            source.set_fill(0.1, 0.2, 0.3, 0.4).unwrap();
+            let mut target = source.target_editor().unwrap();
+            target.set_translation(3.25, 1.25).unwrap();
+            target.set_fill(0.8, 0.7, 0.6, 0.9).unwrap();
+            scene.add(&source).unwrap();
+            let original = source.state().unwrap();
+            let options = AnimationOptions::new()
+                .run_time(1.0)
+                .rate_func(RateFunction::ThereAndBack);
+            let animation = if mode != "predeclared" {
+                None
+            } else {
+                Some(
+                    scene
+                        .declare_transform_to(&source, &target, options)
+                        .unwrap(),
+                )
+            };
+            let mut session = scene.execution_session().unwrap();
+            let mut live = scene.live(&mut session);
+            let segment = if let Some(animation) = animation {
+                live.play_animation(&animation).unwrap()
+            } else if mode == "mapped" {
+                live.declare_and_activate_transform_composition(
+                    SemanticAnimationCompositionKind::Parallel,
+                    &[TransformToRequest::new(
+                        &source,
+                        &target,
+                        AnimationOptions::new()
+                            .run_time(1.0)
+                            .rate_func(RateFunction::Linear),
+                    )],
+                    options,
+                    AnimationOptions::new(),
+                )
+                .unwrap()
+            } else {
+                live.declare_and_activate_transform_to(&source, &target, options)
+                    .unwrap()
+            };
+            live.advance_segment_to(segment, 0.5).unwrap();
+            assert_eq!(
+                live.effective(&source).unwrap().transform.translation,
+                noon_core::Vec2::new(3.25, 1.25)
+            );
+            live.advance_segment_to(segment, 1.0).unwrap();
+            let before_completion = live.effective(&source).unwrap();
+            live.complete_segment(segment).unwrap();
+            let mut expected = original;
+            if mode == "mapped" {
+                let target_state = target.state().unwrap();
+                expected.transform = target_state.transform;
+                expected.style = target_state.style;
+            }
+            assert_eq!(live.authored(&source).unwrap(), expected);
+            let after_completion = live.effective(&source).unwrap();
+            assert_eq!(after_completion.transform, before_completion.transform);
+            assert_eq!(after_completion.style, before_completion.style);
+            live.set_translation(&source, -2.0, 0.0).unwrap();
+            assert_eq!(
+                live.effective(&source).unwrap().transform.translation.x,
+                -2.0
+            );
+        }
+    }
+
+    #[test]
+    fn returning_sequence_completion_keeps_the_preceding_leaf_endpoint() {
+        let mut scene = Scene::new();
+        let source = scene.circle(0.4).unwrap();
+        let mut first = source.target_editor().unwrap();
+        first.set_translation(2.0, 1.0).unwrap();
+        first.set_fill(0.2, 0.3, 0.4, 0.5).unwrap();
+        let mut second = first.target_editor().unwrap();
+        second.set_translation(4.0, 3.0).unwrap();
+        second.set_fill(0.8, 0.7, 0.6, 0.9).unwrap();
+        scene.add(&source).unwrap();
+        let mut session = scene.execution_session().unwrap();
+        let mut live = scene.live(&mut session);
+        let segment = live
+            .declare_and_activate_transform_composition(
+                SemanticAnimationCompositionKind::Sequence,
+                &[
+                    TransformToRequest::new(
+                        &source,
+                        &first,
+                        AnimationOptions::new()
+                            .run_time(1.0)
+                            .rate_func(RateFunction::Linear),
+                    ),
+                    TransformToRequest::new(
+                        &source,
+                        &second,
+                        AnimationOptions::new()
+                            .run_time(1.0)
+                            .rate_func(RateFunction::ThereAndBack),
+                    ),
+                ],
+                AnimationOptions::new()
+                    .run_time(2.0)
+                    .rate_func(RateFunction::Linear),
+                AnimationOptions::new(),
+            )
+            .unwrap();
+        live.advance_segment_to(segment, 1.5).unwrap();
+        assert_eq!(
+            live.effective(&source).unwrap().transform.translation,
+            noon_core::Vec2::new(4.0, 3.0)
+        );
+        live.advance_segment_to(segment, 2.0).unwrap();
+        live.complete_segment(segment).unwrap();
+        assert_eq!(
+            live.authored(&source).unwrap().transform,
+            first.state().unwrap().transform
+        );
+        assert_eq!(
+            live.authored(&source).unwrap().style,
+            first.state().unwrap().style
+        );
+        assert_eq!(
+            live.effective(&source).unwrap().transform.translation,
+            noon_core::Vec2::new(2.0, 1.0)
+        );
+    }
+
+    #[test]
     fn completion_reconciles_the_endpoint_before_the_next_live_segment() {
         let mut scene = Scene::new();
         let circle = scene.circle(1.0).unwrap();

--- a/scripts/manim-compat-smoke.mjs
+++ b/scripts/manim-compat-smoke.mjs
@@ -500,18 +500,30 @@ try {
   assert.ok(queryTransforms.metrics.presentedFrames > 0);
   assert.ok(queryTransforms.frame.objects.every(object => object.bounds.width > 0 && object.bounds.height > 0));
 
-  const sharedRates = await page.evaluate(
-    (pythonSource) => window.noonManimCompat.run(pythonSource),
-    rateFunctionSource,
-  );
-  const rateTracks = sharedRates.document.tracks.filter(
-    (track) => track.property === "transform",
-  );
-  assert.deepEqual(
-    rateTracks.map((track) => track.timing.easing),
-    ["smooth", "rush_into", "rush_from", "there_and_back"],
-    "known Python callables should lower directly to shared Rust semantic IDs",
-  );
+  // Runtime samples qualify both easing interiors and the returning endpoint.
+  const ratePage = await browser.newPage();
+  ratePage.on("pageerror", error => errors.push(String(error)));
+  const times = [0.05, 0.1, 0.15, 0.2, 0.3, 0.5, 0.65, 0.7, 0.75, 0.8];
+  await ratePage.goto(`${baseUrl}/web/manim-raster-host.html`);
+  const sharedRates = await ratePage.evaluate(async ({ source, times }) => {
+    await window.noonHostRaster.ready();
+    await window.noonHostRaster.load(source, 1);
+    const samples = [];
+    for (let index = 0; index < times.length; index += 1) {
+      const metrics = await window.noonHostRaster.renderThrough(index, times);
+      samples.push({ metrics, frame: await window.noonHostRaster.debugFrame() });
+    }
+    return samples;
+  }, { source: rateFunctionSource, times });
+  const expectedX = [0.070103716545108, 0.5, 0.929896283454892, 1,
+    0.859792566910216, 0.859792566910216, 0.5, 0, 0.5, 1];
+  for (const [index, { frame, metrics }] of sharedRates.entries()) {
+    assert.ok(Math.abs(frame.objects[0].center[0] - expectedX[index]) < 1e-5,
+      `shared rate function at ${times[index]}s: ${frame.objects[0].center[0]} != ${expectedX[index]}`);
+    assert.ok(metrics.presented && metrics.drawCalls > 0);
+    assert.ok(Math.abs(metrics.time - times[index]) < 1e-9);
+  }
+  await ratePage.close();
 
   let overlapError = null;
   try {

--- a/web/python/examples/returning_transform.py
+++ b/web/python/examples/returning_transform.py
@@ -1,0 +1,15 @@
+from noon import *
+
+
+class ReturningTransform(Scene):
+    def construct(self):
+        circle = Circle(radius=0.4, color=WHITE, fill_opacity=1)
+        first = circle.copy().move_to((2, 1, 0))
+        second = circle.copy().move_to((4, 3, 0))
+        self.add(circle)
+        self.play(Succession(
+            Transform(circle, first, run_time=1, rate_func=linear),
+            Transform(circle, second, run_time=1, rate_func=there_and_back),
+        ), rate_func=linear)
+        assert abs(circle.get_x() - 2) < 1e-6
+        assert abs(circle.get_y() - 1) < 1e-6


### PR DESCRIPTION
A returning Transform could render its source correctly at the endpoint and then jump to its destination when the playback barrier completed. Completion lowering now observes the leaf rate function at alpha one: a returning channel releases its driver without committing the destination. Group finish continues to finish each child independently of its outer rate function. Earlier sequential leaves still publish their endpoints, preserving the returning leaf's captured start. Introducer/remover lifecycle semantics remain explicit.

Advances #959/#961 and shared 2D semantics in #954. The compiler owns completion intent; the existing runtime publication transaction owns the coherent barrier. This adds constant work per lowered track, no scene scans, transport, frontend state, or migration seam.

Native regression coverage exercises predeclared and prepared transforms, nested returning timing, a returning second leaf in Succession, paint precision, subsequent live setters, and content-morph cleanup. Paired Rust/Python returning-transform examples use the normal shared runtime/renderer. The compatibility rate-function check now samples ten real runtime states instead of exported easing names.

Validation:
- Focused returning transform test — passed for the initial predeclared/prepared regression; expanded cases are covered by the final gate below.
- `CARGO_TARGET_DIR=/Users/ykshin/Dev/me/noon/target CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=2 NOON_SKIP_PLAYGROUND_TEST=1 NOON_WASM_PROFILE=dev bash scripts/check.sh full` — passed: 1,747 Rust tests, 199 Python tests, rebuilt WASM and 211 API contracts.
- `CARGO_TARGET_DIR=/Users/ykshin/Dev/me/noon/target CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=2 cargo test --workspace --all-features --lib analytic_content_morph_replaces_authored_endpoint` — passed, including the added returning branch and renderer-pair cleanup.
- Paired WebGPU/WebGL2 browser samples and `node scripts/manim-compat-smoke.mjs` — passed; four paired samples per backend and ten rate-function samples include the formerly incorrect returning endpoint.
- `bash scripts/architecture-ratchet.sh 0403c86d38ea59b04bbeba2027e3139e3e56fbed` and `git diff --check` — passed.

No independent local Manim differential or native window run is claimed. Live updater registration publication remains the final tutorial export blocker.

Reference: [Manim v0.21 group completion](https://github.com/ManimCommunity/manim/blob/v0.21.0/manim/animation/composition.py) invokes each child’s finish method independently.
