### PR TITLE
fix: record direct Rust/WASM GPU timestamps (#1269)

### DIFF
--- a/crates/noon-native/src/lib.rs
+++ b/crates/noon-native/src/lib.rs
@@ -552,7 +552,14 @@ impl NativeApp {
             });
         let _draw = gpu
             .renderer
-            .encode_retained(&mut encoder, &view, &prepared, &gpu.text_state, CLEAR_COLOR)
+            .encode_retained(
+                &mut encoder,
+                &view,
+                &prepared,
+                &gpu.text_state,
+                CLEAR_COLOR,
+                None,
+            )
             .map_err(|error| NativeHostError::Gpu(error.to_string()))?;
         #[cfg(test)]
         {

--- a/crates/noon-render-wgpu/src/gpu/retained_text.rs
+++ b/crates/noon-render-wgpu/src/gpu/retained_text.rs
@@ -2699,6 +2699,8 @@ impl GpuRenderer {
         RetainedUploadStats { geometry, text }
     }
 
+    /// Encode the normal retained painter-order pass, optionally recording its
+    /// beginning/end into a host-owned two-entry timestamp query set.
     pub fn encode_retained(
         &self,
         encoder: &mut wgpu::CommandEncoder,
@@ -2706,10 +2708,14 @@ impl GpuRenderer {
         prepared: &PreparedRetainedGpuFrame<'_>,
         text_state: &RetainedTextGpuState,
         clear_color: wgpu::Color,
+        query_set: Option<&wgpu::QuerySet>,
     ) -> Result<RetainedDrawStats, TextGpuDrawError> {
         if prepared.geometry_only {
             return Ok(RetainedDrawStats {
-                geometry: self.encode(encoder, view, &prepared.geometry, clear_color),
+                geometry: match query_set {
+                    Some(queries) => self.encode_profiled(encoder, view, &prepared.geometry, clear_color, queries),
+                    None => self.encode(encoder, view, &prepared.geometry, clear_color),
+                },
                 text: TextGpuDrawStats::default(),
             });
         }
@@ -2740,7 +2746,11 @@ impl GpuRenderer {
             label: Some("Noon retained geometry/text painter-order pass"),
             color_attachments: &color_attachments,
             depth_stencil_attachment: None,
-            timestamp_writes: None,
+            timestamp_writes: query_set.map(|query_set| wgpu::RenderPassTimestampWrites {
+                query_set,
+                beginning_of_pass_write_index: Some(0),
+                end_of_pass_write_index: Some(1),
+            }),
             occlusion_query_set: None,
             multiview_mask: None,
         });
@@ -3541,6 +3551,7 @@ mod tests {
                 &prepared,
                 &text_state,
                 wgpu::Color::TRANSPARENT,
+                None,
             )
             .unwrap();
         queue.submit(Some(encoder.finish()));

--- a/crates/noon-web/src/execution_canvas.rs
+++ b/crates/noon-web/src/execution_canvas.rs
@@ -1338,17 +1338,37 @@ mod wasm {
                         .create_command_encoder(&wgpu::CommandEncoderDescriptor {
                             label: Some("Noon direct execution render frame"),
                         });
-                let draw = self
-                    .renderer
-                    .encode_retained(
-                        &mut encoder,
-                        &view,
-                        &prepared,
-                        &self.direct_text_gpu,
-                        self.clear_color,
-                    )
-                    .map_err(js_error)?;
+                let timestamp_slot = self
+                    .timestamp_profiler
+                    .as_mut()
+                    .and_then(GpuTimestampProfiler::reserve_slot);
+                let profiler = self.timestamp_profiler.as_ref();
+                let draw = self.renderer.encode_retained(
+                    &mut encoder,
+                    &view,
+                    &prepared,
+                    &self.direct_text_gpu,
+                    self.clear_color,
+                    timestamp_slot.map(|slot| profiler.expect("reserved profiler").query_set(slot)),
+                );
+                let draw = match draw {
+                    Ok(draw) => draw,
+                    Err(error) => {
+                        if let Some(slot) = timestamp_slot {
+                            profiler.expect("reserved profiler").cancel_slot(slot);
+                        }
+                        return Err(js_error(error));
+                    }
+                };
+                if let Some(slot) = timestamp_slot {
+                    profiler
+                        .expect("reserved profiler")
+                        .resolve(&mut encoder, slot);
+                }
                 self.queue.submit(Some(encoder.finish()));
+                if let Some(slot) = timestamp_slot {
+                    profiler.expect("reserved profiler").map_after_submit(slot);
+                }
                 draw
             };
             self.queue.present(surface_texture);

--- a/crates/noon-web/src/gpu_timestamps.rs
+++ b/crates/noon-web/src/gpu_timestamps.rs
@@ -92,6 +92,14 @@ impl GpuTimestampProfiler {
         None
     }
 
+    /// Release a reservation whose encoder will be discarded before submission.
+    /// No sample or mapping exists for this frame.
+    pub(crate) fn cancel_slot(&self, slot: usize) {
+        self.slots[slot].mapping.set(false);
+        let mut metrics = self.metrics.borrow_mut();
+        metrics.failed = metrics.failed.saturating_add(1);
+    }
+
     pub(crate) fn query_set(&self, slot: usize) -> &wgpu::QuerySet {
         &self.slots[slot].query_set
     }

--- a/crates/noon-web/src/retained_execution_canvas.rs
+++ b/crates/noon-web/src/retained_execution_canvas.rs
@@ -375,7 +375,14 @@ mod wasm {
                 });
             let draw = self
                 .renderer
-                .encode_retained(&mut encoder, &view, &prepared, &self.text_gpu, CLEAR_COLOR)
+                .encode_retained(
+                    &mut encoder,
+                    &view,
+                    &prepared,
+                    &self.text_gpu,
+                    CLEAR_COLOR,
+                    None,
+                )
                 .map_err(js_error)?;
             self.queue.submit(Some(encoder.finish()));
             self.queue.present(surface_texture);

--- a/crates/noon-web/src/retained_typst_canvas.rs
+++ b/crates/noon-web/src/retained_typst_canvas.rs
@@ -159,7 +159,14 @@ mod wasm {
                 });
             let draw = self
                 .renderer
-                .encode_retained(&mut encoder, &view, &prepared, &self.text_gpu, CLEAR_COLOR)
+                .encode_retained(
+                    &mut encoder,
+                    &view,
+                    &prepared,
+                    &self.text_gpu,
+                    CLEAR_COLOR,
+                    None,
+                )
                 .map_err(js_error)?;
             self.queue.submit(Some(encoder.finish()));
             self.queue.present(surface_texture);


### PR DESCRIPTION
Enabling GPU timestamp profiling on direct Rust/WASM rendering reported support but produced zero samples. The direct retained pass now writes, resolves and asynchronously reads the same bounded timestamp queries already used by the browser host. Profiling covers both the geometry-only fast path and mixed geometry/text pass. Encoding failure releases the reserved slot without submitting a fabricated sample; disabled profiling keeps the existing path and allocates no query resources.

Fixes #1269; advances #969 and unblocks qualification of #1267/#1265. The reusable renderer accepts an optional host-owned query set; scene/runtime state stays typed in process. No new authority, transport boundary or migration seam. Per-frame profiling uses the existing four-slot bounded readback pool.

Validation: all current PR checks passed. Full hosted CI 34272240241 passed Rust, WebGPU, WebGL and rendering parity. The unchanged 64-frame sustained WebGPU timestamp regression now passes its minimum-eight-samples, finite-p95, zero-failures and frame-accounting assertions. Painter-order pixels and ordinary direct rendering pass.

That full run's reactive job fails an existing Python f32 endpoint assertion on the base branch; #1267 fixes that assertion without changing its tolerance. The combined #1267 run progressed beyond it and identified separate routing/module-context defects now addressed there. Local full builds are constrained by host storage; no full-local or physical-device performance claim.
