### PR TITLE
test: qualify painter order through shared Rust/Python execution (#959)

### DIFF
--- a/crates/noon-native/examples/painter_order_overlap.rs
+++ b/crates/noon-native/examples/painter_order_overlap.rs
@@ -1,0 +1,5 @@
+//! Native counterpart of the shared Python/WebGPU painter-order proof.
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    noon_native::run(noon::example_scenes::painter_order_overlap::session()?)?;
+    Ok(())
+}

--- a/crates/noon-web/src/direct_execution_smoke.rs
+++ b/crates/noon-web/src/direct_execution_smoke.rs
@@ -45,6 +45,15 @@ pub async fn create_direct_exact_property_tracks_smoke_renderer(
     WasmExecutionCanvasRenderer::create_from_execution_session(canvas, session).await
 }
 
+/// The native painter-order scene reaches WebGPU without a scene document.
+#[wasm_bindgen(js_name = createDirectPainterOrderSmokeRenderer)]
+pub async fn create_direct_painter_order_smoke_renderer(
+    canvas: OffscreenCanvas,
+) -> Result<WasmExecutionCanvasRenderer, JsValue> {
+    let session = noon::example_scenes::painter_order_overlap::session().map_err(js_error)?;
+    WasmExecutionCanvasRenderer::create_from_execution_session(canvas, session).await
+}
+
 /// Shared native family placement reaches the direct browser renderer unchanged.
 #[wasm_bindgen(js_name = createDirectFamilyPlacementSmokeRenderer)]
 pub async fn create_direct_family_placement_smoke_renderer(

--- a/crates/noon/src/example_scenes.rs
+++ b/crates/noon/src/example_scenes.rs
@@ -17,6 +17,7 @@ pub mod ordinary_become_semantics;
 pub mod ordinary_membership;
 pub mod ordinary_subset_display;
 pub mod ordinary_uncreate_options;
+pub mod painter_order_overlap;
 pub mod specialized_geometry;
 pub mod text_family_fade;
 pub mod text_family_reveal;

--- a/crates/noon/src/example_scenes/painter_order_overlap.rs
+++ b/crates/noon/src/example_scenes/painter_order_overlap.rs
@@ -44,7 +44,7 @@ pub fn session() -> Result<ExecutionSession, String> {
             .run_time(1.0)
             .rate_func(RateFunction::Linear),
     )?;
-    let mut session = scene.execution_session()?;
+    let mut session = scene.execution_session().map_err(|e| e.to_string())?;
     let mut live = scene.live(&mut session);
     let segment = live.play_animation(&rotation).map_err(|e| e.to_string())?;
     live.advance_segment_to(segment, segment.end_time())

--- a/crates/noon/src/example_scenes/painter_order_overlap.rs
+++ b/crates/noon/src/example_scenes/painter_order_overlap.rs
@@ -1,0 +1,63 @@
+//! Filled analytic and path geometry share one semantic painter order.
+use crate::{
+    AnimationOptions, ExecutionSession, RateFunction, Scene, SemanticPaint, SemanticStyle, Vec2,
+    VectorPath, BLUE, GREEN, RED,
+};
+
+/// Paired with `web/python/examples/painter_order_overlap.py` on native and WASM.
+pub fn session() -> Result<ExecutionSession, String> {
+    let mut scene = Scene::new();
+    let mut circle = scene.circle(1.25)?;
+    let mut rectangle = scene.rectangle(2.1, 2.1)?;
+    for (object, color) in [(&mut circle, RED), (&mut rectangle, BLUE)] {
+        object.set_fill(
+            f64::from(color.red),
+            f64::from(color.green),
+            f64::from(color.blue),
+            1.0,
+        )?;
+        object.disable_stroke()?;
+    }
+    scene.add(&circle)?;
+    scene.add(&rectangle)?;
+    let path = scene.path(
+        VectorPath::new()
+            .move_to(Vec2::new(-0.8, -0.8))
+            .line_to(Vec2::new(0.8, -0.8))
+            .line_to(Vec2::new(0.8, 0.8))
+            .line_to(Vec2::new(-0.8, 0.8))
+            .close(),
+        SemanticStyle {
+            fill: Some(SemanticPaint::Solid(GREEN)),
+            fill_opacity: 1.0,
+            stroke: None,
+            ..SemanticStyle::default()
+        },
+    )?;
+    scene.add(&path)?;
+    let mut target = rectangle.target_editor()?;
+    target.rotate(std::f64::consts::FRAC_PI_2)?;
+    let rotation = scene.declare_transform_to(
+        &rectangle,
+        &target,
+        AnimationOptions::new()
+            .run_time(1.0)
+            .rate_func(RateFunction::Linear),
+    )?;
+    scene.execution_session_with_animation_root(&rotation)
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn painter_order_and_rotation_survive_direct_seek() {
+        let mut session = super::session().unwrap();
+        session.seek(0.5).unwrap();
+        let objects = &session.frame().objects;
+        assert_eq!(objects.len(), 3);
+        assert_eq!(objects[0].style.fill, Some(crate::RED));
+        assert_eq!(objects[1].style.fill, Some(crate::BLUE));
+        assert_eq!(objects[2].style.fill, Some(crate::GREEN));
+        assert!((objects[1].transform.rotation - std::f32::consts::FRAC_PI_4).abs() < 1e-6);
+    }
+}

--- a/crates/noon/src/example_scenes/painter_order_overlap.rs
+++ b/crates/noon/src/example_scenes/painter_order_overlap.rs
@@ -44,7 +44,13 @@ pub fn session() -> Result<ExecutionSession, String> {
             .run_time(1.0)
             .rate_func(RateFunction::Linear),
     )?;
-    scene.execution_session_with_animation_root(&rotation)
+    let mut session = scene.execution_session()?;
+    let mut live = scene.live(&mut session);
+    let segment = live.play_animation(&rotation).map_err(|e| e.to_string())?;
+    live.advance_segment_to(segment, segment.end_time())
+        .map_err(|e| e.to_string())?;
+    live.complete_segment(segment).map_err(|e| e.to_string())?;
+    Ok(session)
 }
 
 #[cfg(test)]

--- a/scripts/painter-order-browser-smoke.mjs
+++ b/scripts/painter-order-browser-smoke.mjs
@@ -1,127 +1,107 @@
 import assert from "node:assert/strict";
-import { spawn, spawnSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-
 import playwright from "playwright";
-import pngjs from "pngjs";
+import { PNG } from "pngjs";
+import { serveRepository } from "./browser-test-server.mjs";
+import { browserArgs } from "./manim-raster-support.mjs";
 
-const { chromium } = playwright;
-const { PNG } = pngjs;
-const scriptDir = path.dirname(fileURLToPath(import.meta.url));
-const repoRoot = path.resolve(scriptDir, "..");
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const port = Number(process.env.NOON_PAINTER_ORDER_PORT ?? "4197");
-const baseUrl = `http://127.0.0.1:${port}`;
-
-const generated = spawnSync(
-  "python3",
-  [
-    "-c",
-    [
-      "import sys",
-      "sys.path.insert(0, 'web/python')",
-      "namespace = {}",
-      "source_path = 'web/python/examples/painter_order_overlap.py'",
-      "source = open(source_path, encoding='utf-8').read()",
-      "exec(compile(source, source_path, 'exec'), namespace)",
-      "print(namespace['result'].to_json())",
-    ].join("; "),
-  ],
-  { cwd: repoRoot, encoding: "utf8" },
-);
-if (generated.status !== 0) {
-  throw new Error(`Unable to generate painter-order scene:\n${generated.stdout}\n${generated.stderr}`);
-}
-const sceneJson = generated.stdout.trim();
-assert.ok(sceneJson.length > 0, "painter-order scene JSON is empty");
-
-let serverOutput = "";
-const server = spawn(
-  "python3",
-  ["-m", "http.server", String(port), "--bind", "127.0.0.1", "--directory", repoRoot],
-  { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] },
-);
-server.stdout.on("data", (chunk) => { serverOutput += chunk; });
-server.stderr.on("data", (chunk) => { serverOutput += chunk; });
-
-async function waitForServer() {
-  let lastError = null;
-  for (let attempt = 0; attempt < 80; attempt += 1) {
-    try {
-      const response = await fetch(`${baseUrl}/web/browser-smoke.html`);
-      if (response.ok) return;
-      lastError = new Error(`HTTP ${response.status}`);
-    } catch (error) {
-      lastError = error;
-    }
-    await new Promise((resolve) => setTimeout(resolve, 100));
-  }
-  throw new Error(`Painter-order server did not start: ${lastError}\n${serverOutput}`);
-}
-
-let browser = null;
+const source = await readFile(path.join(repoRoot, "web/python/examples/painter_order_overlap.py"), "utf8");
+const server = await serveRepository(repoRoot, port, { crossOriginIsolated: true });
+let browser;
 try {
-  await waitForServer();
-  browser = await chromium.launch({
-    channel: "chromium",
-    headless: true,
-    args: [
-      "--enable-unsafe-webgpu",
-      "--enable-unsafe-swiftshader",
-      "--use-webgpu-adapter=swiftshader",
-      "--use-gpu-in-tests",
-      "--ignore-gpu-blocklist",
-      "--enable-features=Vulkan",
-      "--use-gl=angle",
-      "--use-angle=swiftshader",
-      "--use-vulkan=swiftshader",
-      "--disable-gpu-sandbox",
-      "--disable-dev-shm-usage",
-    ],
-  });
-  const page = await browser.newPage({ viewport: { width: 1000, height: 600 } });
-  await page.goto(`${baseUrl}/web/browser-smoke.html`, { waitUntil: "load" });
-  await page.waitForFunction(() => window.noonSmoke?.state.ready === true, null, {
-    timeout: 30_000,
-  });
-
-  const initial = await page.evaluate(() => window.noonSmoke.metrics());
-  assert.equal(initial.error, null, `WebGPU harness initialization failed: ${initial.error}`);
-  assert.equal(initial.rendererBackend, "WebGPU", "painter-order smoke must exercise WebGPU");
-
-  const loaded = await page.evaluate((json) => window.noonSmoke.loadScene(json), sceneJson);
-  assert.equal(loaded.objectCount, 3, "painter-order fixture must contain exactly three objects");
-  const metrics = await page.evaluate(() => window.noonSmoke.renderAt(0.5));
-  assert.equal(metrics.error, null, `painter-order runtime error: ${metrics.error}`);
-  assert.ok(metrics.drawCalls >= 3, "mixed painter-order fixture should cross renderer pipelines");
-
-  await page.evaluate(() => new Promise((resolve) => requestAnimationFrame(() => resolve())));
-  const screenshot = await page.locator("#scene").screenshot();
-  const png = PNG.sync.read(screenshot);
-  const centerX = Math.floor(png.width / 2);
-  const centerY = Math.floor(png.height / 2);
-  const samples = [];
-  for (let dy = -2; dy <= 2; dy += 1) {
-    for (let dx = -2; dx <= 2; dx += 1) {
-      const offset = ((centerY + dy) * png.width + centerX + dx) * 4;
-      samples.push([png.data[offset], png.data[offset + 1], png.data[offset + 2]]);
+  browser = await playwright.chromium.launch({ channel: "chromium", headless: true, args: browserArgs("webgpu") });
+  for (const label of ["Rust", "Python"]) {
+    const page = await browser.newPage({ viewport: { width: 1000, height: 600 } });
+    const errors = [];
+    page.on("pageerror", error => errors.push(String(error)));
+    page.on("console", message => { if (message.type() === "error") errors.push(message.text()); });
+    await page.goto(`${server.baseUrl}/web/execution-worker-smoke.html`, { waitUntil: "load" });
+    const metrics = await page.evaluate(async ({ label, source }) => {
+      const canvas = document.querySelector("#scene");
+      canvas.width = 960; canvas.height = 540;
+      canvas.style.width = "960px"; canvas.style.height = "540px";
+      if (label === "Rust") {
+        const wasm = await import("./pkg/noon_web.js");
+        await wasm.default();
+        const renderer = await wasm.createDirectPainterOrderSmokeRenderer(canvas.transferControlToOffscreen());
+        window.painterRenderer = renderer;
+        renderer.seekDirect(0.5);
+        let presented = false;
+        for (let attempt = 0; attempt < 60 && !presented; attempt++) {
+          presented = renderer.render();
+          if (!presented) await new Promise(resolve => requestAnimationFrame(resolve));
+        }
+        if (!presented) throw new Error("direct painter-order frame was not presented");
+        return { objectCount: renderer.objectCount(), drawCalls: renderer.lastDrawCalls(),
+          rendererBackend: renderer.rendererBackend(), time: renderer.time() };
+      }
+      const { PythonAuthoringClient } = await import("./authoring-client.js");
+      const { AuthoringExecutionClient } = await import("./authoring-execution-client.js");
+      const authoring = new PythonAuthoringClient();
+      const execution = new AuthoringExecutionClient(canvas);
+      window.painterExecution = execution; window.painterAuthoring = authoring;
+      const authored = await authoring.run(source, {});
+      if (!authored.semanticExecution || authored.duration !== 1) throw new Error("missing shared painter-order execution");
+      await execution.startSemanticExecution(authored.semanticExecution, {
+        authoringClient: authoring, initiallyPaused: true, transportMode: "transferable",
+        loopDurationSeconds: authored.duration,
+      });
+      await execution.pause();
+      const before = (await execution.metrics()).metrics.presentedFrames;
+      await execution.seek(0.5);
+      let metrics;
+      for (let attempt = 0; attempt < 60; attempt++) {
+        metrics = (await execution.metrics()).metrics;
+        if (metrics.presentedFrames > before) break;
+        await new Promise(resolve => requestAnimationFrame(resolve));
+      }
+      if (metrics.presentedFrames <= before) throw new Error("Python painter-order seek was not presented");
+      return { ...metrics, rendererBackend: execution.rendererBackend };
+    }, { label, source });
+    assert.equal(metrics.rendererBackend, "WebGPU", `${label} must exercise WebGPU`);
+    assert.equal(metrics.objectCount, 3, `${label} must retain all three objects`);
+    assert.ok(Math.abs(metrics.time - 0.5) < 1e-6, `${label} must sample the animation midpoint`);
+    assert.ok(metrics.drawCalls >= 3, `${label} must cross renderer pipelines`);
+    await page.evaluate(() => new Promise((resolve) => requestAnimationFrame(() => resolve())));
+    const screenshot = await page.locator("#scene").screenshot();
+    const png = PNG.sync.read(screenshot);
+    const centerX = Math.floor(png.width / 2);
+    const centerY = Math.floor(png.height / 2);
+    const samples = [];
+    for (let dy = -2; dy <= 2; dy += 1) {
+      for (let dx = -2; dx <= 2; dx += 1) {
+        const offset = ((centerY + dy) * png.width + centerX + dx) * 4;
+        samples.push([png.data[offset], png.data[offset + 1], png.data[offset + 2]]);
+      }
     }
+    const mean = samples.reduce(
+      (sum, rgb) => [sum[0] + rgb[0], sum[1] + rgb[1], sum[2] + rgb[2]],
+      [0, 0, 0],
+    ).map((value) => value / samples.length);
+    const [red, green, blue] = mean;
+    assert.ok(
+      green > red + 25 && green > blue + 25,
+      `center pixel is not green-top painter order: rgb=${mean.map((value) => value.toFixed(1)).join(",")}`,
+    );
+    console.log(
+      `${label} WebGPU painter-order pixel oracle passed: center rgb=${mean.map((value) => value.toFixed(1)).join(",")}`,
+    );
+    assert.deepEqual(errors, [], `${label} browser errors`);
+    await page.evaluate(() => {
+      window.painterExecution?.terminate();
+      window.painterAuthoring?.terminate();
+      window.painterRenderer?.free();
+    });
+    await page.close();
   }
-  const mean = samples.reduce(
-    (sum, rgb) => [sum[0] + rgb[0], sum[1] + rgb[1], sum[2] + rgb[2]],
-    [0, 0, 0],
-  ).map((value) => value / samples.length);
-  const [red, green, blue] = mean;
-  assert.ok(
-    green > red + 25 && green > blue + 25,
-    `center pixel is not green-top painter order: rgb=${mean.map((value) => value.toFixed(1)).join(",")}`,
-  );
-  console.log(
-    `WebGPU painter-order pixel oracle passed: center rgb=${mean.map((value) => value.toFixed(1)).join(",")}`,
-  );
 } finally {
   await browser?.close();
-  server.kill("SIGTERM");
+  await server.close();
 }
 
 // Keep a compact sustained timestamp-query regression in the existing WebGPU

--- a/scripts/painter-order-browser-smoke.mjs
+++ b/scripts/painter-order-browser-smoke.mjs
@@ -30,13 +30,17 @@ try {
         await wasm.default();
         const renderer = await wasm.createDirectPainterOrderSmokeRenderer(canvas.transferControlToOffscreen());
         window.painterRenderer = renderer;
-        renderer.seekDirect(0.5);
-        let presented = false;
-        for (let attempt = 0; attempt < 60 && !presented; attempt++) {
-          presented = renderer.render();
-          if (!presented) await new Promise(resolve => requestAnimationFrame(resolve));
+        async function presentFrame() {
+          for (let attempt = 0; attempt < 60; attempt++) {
+            if (renderer.render()) return;
+            await new Promise(resolve => requestAnimationFrame(resolve));
+          }
+          throw new Error("direct painter-order frame was not presented");
         }
-        if (!presented) throw new Error("direct painter-order frame was not presented");
+        // Admit the bootstrap publication before requesting another runtime frame.
+        await presentFrame();
+        renderer.seekDirect(0.5);
+        await presentFrame();
         return { objectCount: renderer.objectCount(), drawCalls: renderer.lastDrawCalls(),
           rendererBackend: renderer.rendererBackend(), time: renderer.time() };
       }

--- a/web/python/examples/painter_order_overlap.py
+++ b/web/python/examples/painter_order_overlap.py
@@ -1,12 +1,18 @@
-from noon import BLUE, GREEN, RED, Circle, Rectangle, Scene, Vec2, VectorPath
+"""Shared painter-order proof for the Noon browser/Pyodide authoring environment.
+
+Rust counterpart: `cargo run -p noon-native --example painter_order_overlap`.
+Both predeclare the same animation and permit deterministic midpoint sampling.
+"""
+
+from noon import BLUE, GREEN, RED, Circle, Rectangle, Scene, Vec2, VectorPath, linear
 
 scene = Scene()
 
 # Deliberately cross renderer pipelines at the same canvas location. Semantic
 # insertion order requires the filled green vector path to remain above the
 # analytic red circle and blue rectangle.
-circle = Circle(1.25, color=RED).set_stroke(None)
-rectangle = Rectangle(2.1, 2.1, color=BLUE).set_stroke(None)
+circle = Circle(1.25, color=RED).set_fill(RED, opacity=1.0).set_stroke(None)
+rectangle = Rectangle(2.1, 2.1, color=BLUE).set_fill(BLUE, opacity=1.0).set_stroke(None)
 scene.add(circle, key="painter.circle")
 scene.add(rectangle, key="painter.rectangle")
 
@@ -26,8 +32,13 @@ scene.path(
     key="painter.path",
 )
 
-# Give the fixture a deterministic non-zero timeline while preserving the
-# center overlap at every sample.
-scene.play(rectangle.animate.rotate(1.5707963267948966), run_time=1.0, easing="linear")
+# Predeclare the shared affine animation so either host can seek deterministically
+# without keeping a Python source continuation on the playback path.
+target = rectangle.copy().rotate(1.5707963267948966)
+animation = scene.declare_live_transform_to(rectangle, target, run_time=1.0, rate_func=linear)
+live = scene.live_execution()
+end = live.play(animation)
+live.advance_to(end)
+live.complete()
 
 result = scene


### PR DESCRIPTION
All applicable PR checks passed, including Chromium, Firefox and mobile WebKit. Merged as `0d9cd310b0ebee5a6957e3c1bdff59fdff51f061`.

The painter-order pixel regression generated a legacy scene document in standalone CPython and fed it to `loadScene`. It now runs the public Python example through the shared Rust-backed authoring/session path and runs its paired Rust example directly in the same WASM/WebGPU renderer.

Both versions contain a red analytic circle, a blue analytic rectangle rotating 90 degrees over one second, and a green vector path inserted last. They predeclare the same affine animation so the harness can seek both to 0.5 without taking playback control away from an active Python continuation. Explicit opaque fills keep the covered-pipeline ordering observable. The existing three-draw-call requirement and green-top pixel threshold are unchanged, and the sustained 64-frame GPU timestamp regression still runs once.

Advances #959 A4.7 / #61 paired semantics. Ownership remains shared Rust semantics and normal compiler/runtime/renderer execution. The Python test uses the genuine worker transport; the Rust path stays typed in one WASM context. No new compatibility layer, migration seam or per-frame semantic work. The test reuses the existing file-server, launch flags and empty canvas harness.

Executable examples:
- Rust native: `cargo run -p noon-native --example painter_order_overlap`
- Rust direct WASM: `createDirectPainterOrderSmokeRenderer`, exercised by the same pixel test.
- Python: `web/python/examples/painter_order_overlap.py` in the normal browser/Pyodide authoring environment.

Validation:
- Rust formatting, JavaScript syntax, whitespace and the architecture ratchet passed.
- Web preflight with `NOON_WEB_PREFLIGHT_ONLY=1 NOON_SKIP_PLAYGROUND_TEST=1 bash scripts/check.sh web` passed all 215 Python tests and web/worker contracts.
- Focused Python/WebGPU execution passed the real midpoint pixel oracle: RGB 131/193/103, three objects and at least three draw calls. This used the verified #1248 WASM with current Python/JS sources; it does not qualify the new Rust factory.
- Hosted CI will build and qualify both final-source frontends and the unchanged timestamp test. No full local Rust gate pass is claimed with limited disk space.


Final implementation head `b028ce900548a69af186348340253efbb14d90d4`: [full CI 34292501561](https://github.com/yongkyuns/noon/actions/runs/34292501561) passed all seven Rust/browser jobs. The direct example uses the shared live-session activation/completion flow and presents its bootstrap publication before seeking. Both Rust/Python actual WebGPU pixel oracles and the unchanged 64-frame timestamp regression also passed locally using the hosted WASM build. Remaining PR cross-browser checks are pending before merge.
