### PR TITLE
refactor: delete Python scene materialization fallback (#959)

### DIFF
--- a/scripts/architecture-ratchet.sh
+++ b/scripts/architecture-ratchet.sh
@@ -203,10 +203,11 @@ fi
 deleted_legacy_web_surface_found=0
 deleted_legacy_web_references="$(
   git grep -nE \
-    '(^|[^[:alnum:]_])(NoonCanvasPlayer|demoSceneJson|WasmAuthoringFamilyMemberHandle|FrontendFamilyBoundsPlan|noonCreateAuthoringFamilyMemberHandle|evaluateSceneSnapshot|evaluateScenePlaybackSnapshot|scene_snapshot_json|playback_snapshot_json|normalized_frame_json)([^[:alnum:]_]|$)' \
+    '(^|[^[:alnum:]_])(NoonCanvasPlayer|demoSceneJson|WasmAuthoringFamilyMemberHandle|FrontendFamilyBoundsPlan|noonCreateAuthoringFamilyMemberHandle|evaluateSceneSnapshot|evaluateScenePlaybackSnapshot|scene_snapshot_json|playback_snapshot_json|normalized_frame_json|materialize_legacy_geometry|_legacy_geometry_materialized)([^[:alnum:]_]|$)' \
     -- \
     'crates/noon-web/src' \
     'web/python-worker.source.js' \
+    'web/python' \
     'web/browser-smoke.js' \
     'web/execution-renderer-smoke.js' \
     'scripts/check-web-package.mjs' \

--- a/scripts/architecture-ratchet.test.sh
+++ b/scripts/architecture-ratchet.test.sh
@@ -99,6 +99,7 @@ expect_rejected() {
 
 reset_to_base() {
   git reset -q --hard "$BASE"
+  mkdir -p web
   rm -f src/new_hidden.rs src/duplicate_identity.rs src/runtime_structural_probe.rs src/web_tool_structural_probe.rs src/scene_player_spread_probe.rs src/deleted_legacy_web_probe.rs src/duplicate_clock_probe.rs src/legacy_clock_probe.rs
   rm -f web/browser-smoke.js crates/noon-web/src/duplicate_clock.rs crates/noon-web/src/legacy/clock.rs
   rm -f crates/noon/src/lib.rs crates/noon-web/src/authoring_mobject.rs
@@ -256,6 +257,18 @@ git add src/scene_player_spread_probe.rs
 git commit -qm "unrelated change after ScenePlayer spread"
 if bash scripts/architecture-ratchet.sh "$SCENE_PLAYER_SPREAD_BASE" >/dev/null 2>&1; then
   echo "architecture ratchet test failed: accepted ScenePlayer consumer outside migration allowlist" >&2
+  exit 1
+fi
+
+# A shared binding must never revive a Python-owned scene, even if the bridge
+# predates the current comparison base.
+reset_to_base
+mkdir -p web/python
+printf 'def materialize_legacy_geometry(scene): pass\n' > web/python/geometry_bridge.py
+git add web/python/geometry_bridge.py
+git commit -qm "model deleted Python scene materialization returning"
+if bash scripts/architecture-ratchet.sh HEAD >/dev/null 2>&1; then
+  echo "architecture ratchet test failed: accepted Python scene materialization" >&2
   exit 1
 fi
 

--- a/scripts/shared-authoring-smoke.mjs
+++ b/scripts/shared-authoring-smoke.mjs
@@ -111,6 +111,23 @@ import builtins
 scene = Scene()
 circle = Circle(radius=1.0)
 scene.add(circle)
+# A handle-less wrapper must fail before binding can project existing geometry
+# into Python state. The same scene must remain usable afterward.
+objects_before = [dict(row) for row in scene._objects]
+next_id = scene._next_object_id
+untyped = Circle(radius=0.2)
+untyped._semantic_handle = None
+try:
+    untyped._bind_to_scene(scene)
+except NotImplementedError as error:
+    assert "requires a typed semantic Mobject" in str(error)
+else:
+    raise AssertionError("shared binding admitted a handle-less wrapper")
+assert untyped._scene is None
+assert scene._objects == objects_before
+assert scene._next_object_id == next_id
+assert len(scene._semantic_geometry_handles) == 1
+assert circle.get_center() == (0.0, 0.0)
 builtins.__noon_persisted_scene = scene
 builtins.__noon_persisted_circle = circle
 result = scene
@@ -971,11 +988,9 @@ try {
   const rejectedFinalizations = await page.evaluate(async () => {
     const failures = [];
     const corruptions = [
-      'scene._legacy_geometry_materialized = True',
       'scene._reactive_signals.append({"legacy": True})',
       'scene._semantic_geometry_handles.clear()',
       'scene._tracks.append({"property": "position"})',
-      'scene = Scene()\nassert getattr(scene, "_canonical_authoring_context", None) is None\nscene._legacy_geometry_materialized = True',
       'scene = Scene()\nassert getattr(scene, "_canonical_authoring_context", None) is None\nscene._reactive_signals.append({"legacy": True})',
     ];
     for (const corruption of corruptions) {
@@ -3309,7 +3324,6 @@ class RejectedAdmission(Scene):
         except NotImplementedError:
             pass
         assert entering not in self.mobjects
-        assert not getattr(self, "_legacy_geometry_materialized", False)
         self.play(Create(entering), run_time=0.1)
         self.play(Uncreate(entering), run_time=0.1)
         assert entering not in self.mobjects

--- a/web/python/_manim_canonical_scene.py
+++ b/web/python/_manim_canonical_scene.py
@@ -1,8 +1,8 @@
 """Bind geometry handles directly into the shared Rust Scene.
 
 Static geometry lowers to one ExecutionSession in the authoring worker. Python
-keeps identity metadata; geometry values are projected only for explicit exports
-or the remaining legacy geometry adapter owned for deletion by #959.
+keeps derived identity metadata; geometry values are projected only for explicit
+diagnostic exports. Binding never materializes a Python-owned scene.
 """
 
 from __future__ import annotations
@@ -41,7 +41,6 @@ _INSTALLED = False
 _CHECKPOINT_TAG = object()
 _ORIGINAL_AUTHORING_CHECKPOINT = _ir.Scene._authoring_checkpoint
 _ORIGINAL_RESTORE_AUTHORING_CHECKPOINT = _ir.Scene._restore_authoring_checkpoint
-_ORIGINAL_BIND = _base.Mobject._bind_to_scene
 _ORIGINAL_BIND_POSITION = _base.Scene.bind_position
 _ORIGINAL_BIND_ROTATION = _base.Scene.bind_rotation
 _ORIGINAL_BIND_OPACITY = _base.Scene.bind_opacity
@@ -85,7 +84,6 @@ def _context(scene: _ir.Scene):
 class _TypedBindingReservation:
     object: _ir.Object
     key: str
-    legacy_snapshot: dict[str, Any] | None
     reuse_existing_identity: bool = False
 
 
@@ -115,7 +113,7 @@ def _reserve_typed_binding(
             if key is not None and _ir._authoring_key("key", key, prior_key) != prior_key:
                 raise ValueError("a re-added canonical Mobject keeps its existing key")
             return _TypedBindingReservation(
-                prior, prior_key, None, reuse_existing_identity=True
+                prior, prior_key, reuse_existing_identity=True
             )
 
     object_id = scene._next_object_id if object_id is None else object_id
@@ -125,14 +123,8 @@ def _reserve_typed_binding(
     if authoring_key in scene._object_key_ids:
         raise ValueError(f"duplicate object key: {authoring_key}")
 
-    legacy_snapshot = None
-    if getattr(scene, "_legacy_geometry_materialized", False) and not isinstance(
-        mobject, _typst._RetainedTextMobject
-    ):
-        legacy_snapshot = json.loads(str(handle.snapshotJson()))
-        legacy_snapshot["id"] = object_id
     return _TypedBindingReservation(
-        _ir.Object(object_id, scene._owner), authoring_key, legacy_snapshot
+        _ir.Object(object_id, scene._owner), authoring_key
     )
 
 
@@ -151,15 +143,14 @@ def _commit_typed_binding(
     scene._object_key_ids[reservation.key] = obj.id
     scene._next_object_id = obj.id + 1
     scene._next_painter_order += 1
-    _record_mobject_binding(mobject, scene, obj, handle, reservation.legacy_snapshot)
+    _record_mobject_binding(mobject, scene, obj, handle)
     return obj
 
 
 def _bind_mobject(self: _base.Mobject, scene: _base.Scene, *, key=None):
     handle = getattr(self, "_semantic_handle", None)
     if handle is None:
-        materialize_legacy_geometry(scene)
-        return _ORIGINAL_BIND(self, scene, key=key)
+        raise NotImplementedError("shared Scene binding requires a typed semantic Mobject")
     reservation = _reserve_typed_binding(self, scene, handle, key)
     context = _context(scene)
     if reservation.reuse_existing_identity:
@@ -390,16 +381,12 @@ def _bind_camera_frame(scene: _base.Scene, mobject: _base.Mobject) -> _ir.Object
     """Bind one context-created semantic camera without constructing Python geometry state."""
     if getattr(mobject, "_scene", None) is not None:
         raise ValueError("camera frame is already bound")
-    if getattr(scene, "_legacy_geometry_materialized", False):
-        raise NotImplementedError(
-            "moving camera construction cannot follow legacy geometry materialization"
-        )
     object_id = scene._next_object_id
     authoring_key = _ir._authoring_key("key", None, f"@object:{object_id}")
     if object_id in scene._object_keys or authoring_key in scene._object_key_ids:
         raise ValueError("camera frame wrapper identity is already bound")
     reservation = _TypedBindingReservation(
-        _ir.Object(object_id, scene._owner), authoring_key, None
+        _ir.Object(object_id, scene._owner), authoring_key
     )
     handle = _context(scene).createCameraFrame(str(object_id))
     _semantic_handles._attach_shared_handle(mobject, handle)
@@ -411,7 +398,6 @@ def _record_mobject_binding(
     scene: _base.Scene,
     obj: _ir.Object,
     handle: object,
-    legacy_snapshot: dict[str, Any] | None = None,
 ) -> None:
     scene._object_positions[obj.id] = len(scene._objects)
     # The compatibility table retains identity only on the shared path.
@@ -425,20 +411,7 @@ def _record_mobject_binding(
         if handles is None:
             handles = scene._semantic_geometry_handles = {}
     handles[obj.id] = handle
-    if legacy_snapshot is not None:
-        scene._objects[-1] = legacy_snapshot
     mobject._bind(scene, obj)
-
-
-def materialize_legacy_geometry(scene):
-    """Enter the explicit legacy animation/export adapter once (#959)."""
-    if getattr(scene, "_legacy_geometry_materialized", False):
-        return
-    for object_id, handle in getattr(scene, "_semantic_geometry_handles", {}).items():
-        snapshot = json.loads(str(handle.snapshotJson()))
-        snapshot["id"] = object_id
-        scene._objects[scene._object_positions[object_id]] = snapshot
-    scene._legacy_geometry_materialized = True
 
 
 def _canonical_tracker_builder(builder: object) -> bool:
@@ -2097,10 +2070,6 @@ def _play_canonical_composition(
     removals: list[_base.Mobject],
     tracker_associations: list[_reactive.ValueTracker],
 ) -> _base.Scene | _SemanticContinuationAwaitable:
-    if getattr(self, "_legacy_geometry_materialized", False):
-        raise NotImplementedError(
-            "canonical ordinary composition cannot follow legacy geometry materialization"
-        )
     if _legacy_authored_time(self) != 0.0:
         raise NotImplementedError(
             "canonical ordinary composition cannot follow legacy Scene timing"
@@ -2144,9 +2113,6 @@ def _play_canonical_composition(
 
 def _play(self, *args, **kwargs):
     _require_portable_barrier_admission(self)
-    if getattr(self, "_legacy_geometry_materialized", False):
-        raise NotImplementedError("shared Scene.play cannot follow legacy geometry materialization")
-
     group = args[0] if len(args) == 1 and isinstance(args[0], _composition.AnimationGroup) else None
     kind = "sequence" if isinstance(group, _composition.Succession) else "parallel"
     animations = tuple(group.animations) if group is not None else args
@@ -2157,10 +2123,6 @@ def _play(self, *args, **kwargs):
 
 
 def _canonical_value_tracker(self: _base.Scene, value: float = 0.0) -> _reactive.ValueTracker:
-    if getattr(self, "_legacy_geometry_materialized", False):
-        raise RuntimeError(
-            "canonical ValueTracker cannot be authored after legacy geometry materialization"
-        )
     context = _context(self)
     return _reactive.ValueTracker._from_canonical(
         self, context, context.createValueTracker(float(value))
@@ -2168,10 +2130,6 @@ def _canonical_value_tracker(self: _base.Scene, value: float = 0.0) -> _reactive
 
 
 def _canonical_native_context(scene: _base.Scene) -> object:
-    if getattr(scene, "_legacy_geometry_materialized", False):
-        raise RuntimeError(
-            "canonical native input cannot be authored after legacy geometry materialization"
-        )
     return _context(scene)
 
 
@@ -2462,14 +2420,13 @@ def _canonical_bind_position(
 
 def _to_document(self):
     # Explicit export may project values; it does not provide execution input on
-    # the shared path. Legacy animation retains this adapter until #959.
+    # the shared path. #959 owns the remaining geometry diagnostic codec.
     document = _ORIGINAL_TO_DOCUMENT(self)
     objects = document["objects"]
-    if not getattr(self, "_legacy_geometry_materialized", False):
-        for object_id, handle in getattr(self, "_semantic_geometry_handles", {}).items():
-            snapshot = json.loads(str(handle.snapshotJson()))
-            snapshot["id"] = object_id
-            objects[self._object_positions[object_id]] = snapshot
+    for object_id, handle in getattr(self, "_semantic_geometry_handles", {}).items():
+        snapshot = json.loads(str(handle.snapshotJson()))
+        snapshot["id"] = object_id
+        objects[self._object_positions[object_id]] = snapshot
     # Native/Typst Text has no geometry projection. The legacy document remains
     # an explicit geometry-only diagnostic, so omit identity-only text rows
     # and their legacy tracks here.
@@ -2505,8 +2462,6 @@ def _identity_document(self: _ir.Scene) -> dict[str, list[dict[str, Any]]]:
 def execution_context(scene, callbacks=None):
     """Select typed geometry/native-Text execution; unsupported contracts stay explicit."""
     del callbacks  # Callback declarations now lower through the canonical context.
-    if getattr(scene, "_legacy_geometry_materialized", False):
-        return None
     # The canonical static context does not yet lower the legacy reactive/native
     # declarations.  Reject them here rather than silently constructing a live
     # session that omits their drivers; #61 owns their shared-semantic migration.

--- a/web/python/_manim_canonical_scene.py
+++ b/web/python/_manim_canonical_scene.py
@@ -233,7 +233,6 @@ def _membership_leaf_bindings(
             reservation = _TypedBindingReservation(
                 member._object,
                 scene._object_keys[member._object.id],
-                None,
                 reuse_existing_identity=True,
             )
         else:

--- a/web/python/_manim_rate_functions.py
+++ b/web/python/_manim_rate_functions.py
@@ -178,12 +178,7 @@ def _set_color_preserving_opacity(
         handle = shared._handle_for(self)
         if handle is not None:
             return shared._set_color(self, color)
-        if (
-            getattr(self, "_semantic_handle", None) is not None
-            and not bool(
-                getattr(getattr(self, "_scene", None), "_legacy_geometry_materialized", False)
-            )
-        ):
+        if getattr(self, "_semantic_handle", None) is not None:
             raise NotImplementedError(
                 "typed set_color requires the shared semantic mutation path"
             )

--- a/web/python/_manim_semantic_handles.py
+++ b/web/python/_manim_semantic_handles.py
@@ -293,12 +293,9 @@ def _typed_manim_observation(
     """Read one narrow Manim observation from its current Rust authority.
 
     Bound live objects use the execution publication; detached objects use their
-    authored semantic handle. Explicit legacy materialization remains the only
-    typed-wrapper case allowed to fall through to a raw projection.
+    authored semantic handle. A typed wrapper never falls through to a Python
+    scene projection.
     """
-    scene = getattr(value, "_scene", None)
-    if bool(getattr(scene, "_legacy_geometry_materialized", False)):
-        return None
     semantic_handle = getattr(value, "_semantic_handle", None)
     if semantic_handle is None:
         return None
@@ -336,9 +333,6 @@ def _manim_color_observation(value: object):
 
 def _require_typed_manim_line(value: object) -> bool:
     """Validate exact Line content through the current Rust observation owner."""
-    scene = getattr(value, "_scene", None)
-    if bool(getattr(scene, "_legacy_geometry_materialized", False)):
-        return False
     semantic_handle = getattr(value, "_semantic_handle", None)
     if semantic_handle is None:
         return False
@@ -433,7 +427,6 @@ def _bound_layout_observation(value: _base.Mobject):
 
     if (
         not _is_bound(value)
-        or getattr(value._scene, "_legacy_geometry_materialized", False)
         or not bool(getattr(value, "_semantic_handle_fresh", False))
     ):
         return None
@@ -800,16 +793,14 @@ def _current_raw(self: _base.Mobject) -> _ir.Mobject:
         raise RuntimeError(
             "callback-local Line operands cannot escape into scene, layout, or animation APIs"
         )
-    handle = (_handle_for(self) if not getattr(self._scene, "_legacy_geometry_materialized", False)
-              else _detached_handle_for(self))
+    handle = _handle_for(self)
     if handle is not None:
         return _raw_from_json(str(handle.snapshotJson()))
     return _ORIGINAL_CURRENT_RAW(self)
 
 
 def _apply(self: _base.Mobject, raw: _ir.Mobject) -> _base.Mobject:
-    handle = (_handle_for(self) if not getattr(self._scene, "_legacy_geometry_materialized", False)
-              else _detached_handle_for(self))
+    handle = _handle_for(self)
     if handle is not None:
         del raw
         raise NotImplementedError(
@@ -995,8 +986,7 @@ def _mutation_handle_for(value: _base.Mobject):
 
 def _sync_bound_transform(value: _base.Mobject, handle: object) -> None:
     if (not _is_bound(value) or
-            hasattr(value._scene, "_semantic_geometry_handles") and
-            not getattr(value._scene, "_legacy_geometry_materialized", False)):
+            hasattr(value._scene, "_semantic_geometry_handles")):
         return
     scene = value._scene
     obj = value._object
@@ -1022,8 +1012,7 @@ def _wire_color(handle: object, prefix: str) -> dict[str, float] | None:
 
 def _sync_bound_style(value: _base.Mobject, handle: object) -> None:
     if (not _is_bound(value) or
-            hasattr(value._scene, "_semantic_geometry_handles") and
-            not getattr(value._scene, "_legacy_geometry_materialized", False)):
+            hasattr(value._scene, "_semantic_geometry_handles")):
         return
     scene = value._scene
     obj = value._object
@@ -1307,11 +1296,7 @@ def _become(
         getattr(value, "_semantic_handle", None) is not None
         for value in (self, mobject)
     )
-    legacy_materialized = any(
-        bool(getattr(getattr(value, "_scene", None), "_legacy_geometry_materialized", False))
-        for value in (self, mobject)
-    )
-    if has_typed_operand and not legacy_materialized:
+    if has_typed_operand:
         raise NotImplementedError(
             "become requires valid shared semantic handles for both Mobjects"
         )
@@ -1370,8 +1355,7 @@ def _layout_reference_handle(value):
     if handle is None or not hasattr(handle, "layoutAnchor"):
         return None
     scene = getattr(value, "_scene", None)
-    if (not bool(getattr(value, "_semantic_handle_fresh", False))
-            or getattr(scene, "_legacy_geometry_materialized", False)):
+    if not bool(getattr(value, "_semantic_handle_fresh", False)):
         return None
     # Only legacy/fixture scenes can have geometry tracks outside the Rust store.
     if (getattr(scene, "_canonical_authoring_context", None) is None
@@ -1400,8 +1384,6 @@ def _layout_anchor(value, index=None):
 def _shared_next_to(self, target, direction, buff, aligned_edge,
                       submobject_to_align, index, coor_mask):
     """Pass selection intent; Rust resolves members, observes bounds and places."""
-    if getattr(getattr(self, "_scene", None), "_legacy_geometry_materialized", False):
-        return False
     source = _layout_anchor(self)
     aligner = (_layout_anchor(submobject_to_align) if submobject_to_align is not None
                else _layout_anchor(self, index))
@@ -1746,8 +1728,7 @@ def _group_live_layout_context(value: _compat.Group):
         return None
     for leaf in leaves:
         if (not bool(getattr(leaf, "_semantic_handle_fresh", False))
-                or getattr(leaf, "_semantic_handle", None) is None
-                or getattr(getattr(leaf, "_scene", None), "_legacy_geometry_materialized", False)):
+                or getattr(leaf, "_semantic_handle", None) is None):
             return None
     return context
 

--- a/web/python/_manim_updaters.py
+++ b/web/python/_manim_updaters.py
@@ -106,7 +106,7 @@ def _registration_end_time(
 
 def _canonical_context(mobject: _base.Mobject) -> object | None:
     scene = getattr(mobject, "_scene", None)
-    if scene is None or getattr(scene, "_legacy_geometry_materialized", False):
+    if scene is None:
         return None
     return getattr(scene, "_canonical_authoring_context", None)
 

--- a/web/python/test_manim_group_animate_shared_target.py
+++ b/web/python/test_manim_group_animate_shared_target.py
@@ -194,7 +194,6 @@ class ManimGroupAnimateSharedTargetTests(unittest.TestCase):
             context = FakeCanonicalContext()
             scene = types.SimpleNamespace(
                 _canonical_authoring_context=context,
-                _legacy_geometry_materialized=False,
                 _tracks=[],
             )
             first._scene = scene

--- a/web/python/test_manim_scene_bound_semantic_handles.py
+++ b/web/python/test_manim_scene_bound_semantic_handles.py
@@ -301,11 +301,6 @@ class ManimSceneBoundSemanticHandleTests(unittest.TestCase):
             assert square.height == 4.0
             assert context.queries == [handle, handle, handle]
 
-            # The explicit legacy materialization boundary keeps its existing raw
-            # fallback rather than consulting an unrelated canonical runtime.
-            scene._legacy_geometry_materialized = True
-            assert square.get_center() == (1.0, 0.0)
-            del scene._legacy_geometry_materialized
             del square._noon_updaters
 
             context.transferred = True


### PR DESCRIPTION
Full CI [34292561203](https://github.com/yongkyuns/noon/actions/runs/34292561203) passed all seven jobs, and every applicable PR check passed, including Chromium, Firefox and mobile WebKit. Merged after exact-head qualification of `5a35daf5661d01993c5c61b0aede049c40a48d2f`.

Binding a handle-less Mobject could project every existing shared geometry handle into Python `_objects` and switch the scene into a legacy materialization mode. That mode was incompatible with normal shared execution. Reject the unsupported binding before any scene mutation, delete the whole-scene projection and reservation snapshot field, and remove the dead mode branches from observations, layout, color, updaters, animation and finalization.

Advances #959/#61 in the Python wrapper over shared Rust semantics. No new authority, runtime, scheduler, identity space, transport or temporary seam. A failed bind no longer performs O(scene) snapshot work; normal shared mutations remain local. Explicit geometry diagnostic exports and fixture-only raw adapters still have callers and remain under #959.

The existing shared-authoring browser proof now attempts a handle-less bind, verifies unchanged object/identity bookkeeping, and continues rendering/reusing the same scene. Existing paired Rust/Python examples cover the affected shared semantics. Remove the obsolete test that asserted entry into materialization mode, retain the other corruption/recovery checks, and ratchet absence of the deleted bridge even when it predates the comparison base.

Validation:
- Python compilation, JavaScript syntax and `git diff --check` passed.
- `NOON_WEB_PREFLIGHT_ONLY=1 NOON_SKIP_PLAYGROUND_TEST=1 bash scripts/check.sh web` passed, including 215 Python tests and JS/worker contracts.
- `bash scripts/architecture-ratchet.test.sh` passed.
- After integrating #1276, `bash scripts/check.sh architecture origin/master` passed against `0b1e4bba26ef4ff7b3299a7b5bb0e33e085411ed`.
- Hosted CI will qualify the actual Rust/WASM/browser path before merge. No local Rust/full gate pass is claimed with constrained disk space.
