### PR TITLE
test: qualify browser replay through typed Rust execution (#959)

### DIFF
--- a/crates/noon-web/src/determinism.rs
+++ b/crates/noon-web/src/determinism.rs
@@ -182,48 +182,51 @@ pub fn verify_example_replay(
 
 fn create_morph_fade_session() -> Result<ExecutionSession, String> {
     use noon::{
-        AnimationOptions, RateFunction, Scene, SemanticAnimationCompositionKind,
-        SemanticAnimationIntent, SemanticFadeDirection, SemanticFadeEndpoint,
-        SemanticTransformInterpolation,
+        AnimationCompositionRequest as Request, AnimationOptions, FadeEndpoint, RateFunction,
+        Scene, SemanticAnimationCompositionKind, SemanticFadeDirection, TransformToRequest,
     };
     let mut scene = Scene::new();
-    let circle = scene.circle(0.75)?;
-    let mut square = scene.square(1.5)?;
-    square.set_translation(2.0, 0.0)?;
-    scene.add(&circle)?;
+    let mut entering = scene.circle(0.75)?;
+    entering.set_translation(-2.0, 0.0)?;
+    let source = scene.square(1.5)?;
+    let target = scene.circle(0.75)?;
+    let mut leaving = scene.circle(0.75)?;
+    leaving.set_translation(2.0, 0.0)?;
+    scene.add(&source)?;
+    scene.add(&leaving)?;
+    let mut session = scene
+        .execution_session()
+        .map_err(|error| error.to_string())?;
     let options = AnimationOptions::new()
-        .run_time(1.0)
+        .run_time(2.0)
         .rate_func(RateFunction::Linear);
-    let create = scene.declare_animation(
-        SemanticAnimationIntent::Create {
-            target: circle.node_id(),
-        },
-        options,
-    )?;
-    let morph = scene.declare_animation(
-        SemanticAnimationIntent::TransformTo {
-            target: circle.node_id(),
-            target_state: square.node_id(),
-            interpolation: SemanticTransformInterpolation::PointCorrespondence,
-        },
-        options,
-    )?;
-    let fade = scene.declare_animation(
-        SemanticAnimationIntent::Fade {
-            target: circle.node_id(),
-            direction: SemanticFadeDirection::Out,
-            endpoint: SemanticFadeEndpoint::identity(),
-        },
-        options,
-    )?;
-    let root = scene.declare_animation(
-        SemanticAnimationIntent::Composition {
-            kind: SemanticAnimationCompositionKind::Sequence,
-            children: vec![create.node_id(), morph.node_id(), fade.node_id()],
-        },
-        AnimationOptions::new(),
-    )?;
-    scene.execution_session_with_animation_root(&root)
+    let request = Request::Composition {
+        kind: SemanticAnimationCompositionKind::Parallel,
+        children: vec![
+            Request::Create {
+                target: &entering,
+                options,
+            },
+            Request::TransformTo(TransformToRequest::point_correspondence(
+                &source, &target, options,
+            )),
+            Request::Fade {
+                target: &leaving,
+                direction: SemanticFadeDirection::Out,
+                endpoint: FadeEndpoint::default(),
+                options,
+            },
+        ],
+        options: AnimationOptions::new(),
+    };
+    // Activate through the ordinary live API: initial exact-track lowering is
+    // intentionally narrower. Replay compares the activated execution channels;
+    // logical segment completion/publication has its own shared live tests.
+    scene
+        .live(&mut session)
+        .declare_and_activate_composition(&request, AnimationOptions::new())
+        .map_err(|error| error.to_string())?;
+    Ok(session)
 }
 
 #[cfg(all(target_arch = "wasm32", debug_assertions))]

--- a/crates/noon-web/src/determinism.rs
+++ b/crates/noon-web/src/determinism.rs
@@ -1,8 +1,7 @@
 //! Renderer-independent frame snapshots used by deterministic replay tests and tools.
 
-use noon_compile::{CompileError, CompiledScene};
-use noon_ir::{decode_scene, IrError};
-use noon_runtime::{EvaluationError, FrameState, SlottedSceneInstance};
+use noon::ExecutionSession;
+use noon_runtime::{EvaluationError, FrameState};
 
 fn normalize_playhead(time: f64) -> f64 {
     const SCALE: f64 = 1_000_000_000_000.0;
@@ -18,49 +17,6 @@ fn normalized_frames_equal(left: &FrameState, right: &FrameState) -> bool {
         && left.render_geometries == right.render_geometries
         && left.render_transforms == right.render_transforms
         && left.family_animations == right.family_animations
-}
-
-#[derive(Debug)]
-pub enum ReplayRuntimeError {
-    Ir(IrError),
-    Compile(CompileError),
-    Evaluation(EvaluationError),
-}
-
-impl std::fmt::Display for ReplayRuntimeError {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Ir(error) => error.fmt(formatter),
-            Self::Compile(error) => error.fmt(formatter),
-            Self::Evaluation(error) => error.fmt(formatter),
-        }
-    }
-}
-
-impl std::error::Error for ReplayRuntimeError {}
-
-impl From<IrError> for ReplayRuntimeError {
-    fn from(value: IrError) -> Self {
-        Self::Ir(value)
-    }
-}
-
-impl From<CompileError> for ReplayRuntimeError {
-    fn from(value: CompileError) -> Self {
-        Self::Compile(value)
-    }
-}
-
-impl From<EvaluationError> for ReplayRuntimeError {
-    fn from(value: EvaluationError) -> Self {
-        Self::Evaluation(value)
-    }
-}
-
-fn runtime_from_scene_json(scene_json: &str) -> Result<SlottedSceneInstance, ReplayRuntimeError> {
-    let definition = decode_scene(scene_json)?;
-    let compiled = CompiledScene::compile(&definition)?;
-    Ok(SlottedSceneInstance::new(compiled))
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -80,7 +36,8 @@ impl std::fmt::Display for ReplayVerificationMode {
 
 #[derive(Debug)]
 pub enum ReplayVerificationError {
-    Runtime(ReplayRuntimeError),
+    Evaluation(EvaluationError),
+    Fixture(String),
     InvalidForwardSampleCount(usize),
     NonFiniteTarget {
         index: usize,
@@ -99,7 +56,8 @@ pub enum ReplayVerificationError {
 impl std::fmt::Display for ReplayVerificationError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Runtime(error) => error.fmt(formatter),
+            Self::Evaluation(error) => error.fmt(formatter),
+            Self::Fixture(error) => formatter.write_str(error),
             Self::InvalidForwardSampleCount(count) => {
                 write!(
                     formatter,
@@ -128,26 +86,18 @@ impl std::fmt::Display for ReplayVerificationError {
 
 impl std::error::Error for ReplayVerificationError {}
 
-impl From<ReplayRuntimeError> for ReplayVerificationError {
-    fn from(value: ReplayRuntimeError) -> Self {
-        Self::Runtime(value)
-    }
-}
-
 impl From<EvaluationError> for ReplayVerificationError {
     fn from(value: EvaluationError) -> Self {
-        Self::Runtime(ReplayRuntimeError::Evaluation(value))
+        Self::Evaluation(value)
     }
 }
 
-/// Verify direct seek, incremental playback, and rewind equivalence for one scene.
+/// Compare direct seek, incremental playback and rewind on independent runtime copies.
 ///
-/// The scene is decoded and compiled once. Three persistent runtime instances then
-/// exercise the independent direct, forward, and rewind paths for every target.
-/// Observable frame state is compared in Rust instead of serializing large snapshots
-/// through the WASM boundary merely to compare them in JavaScript.
-pub fn verify_scene_replay(
-    scene_json: &str,
+/// Cloning is qualification work only; the product still owns one mutable runtime.
+/// Construction and lowering are typed Rust. No scene or frame data crosses a codec.
+pub fn verify_execution_replay(
+    session: &ExecutionSession,
     targets: &[f64],
     forward_sample_count: usize,
 ) -> Result<(), ReplayVerificationError> {
@@ -162,7 +112,7 @@ pub fn verify_scene_replay(
         }
     }
 
-    let mut direct = runtime_from_scene_json(scene_json)?;
+    let mut direct = session.clone();
     let mut forward = direct.clone();
     let mut rewind = direct.clone();
     let denominator = (forward_sample_count - 1) as f64;
@@ -178,7 +128,9 @@ pub fn verify_scene_replay(
         for sample in 0..forward_sample_count {
             forward.advance_to(target * sample as f64 / denominator)?;
         }
-        if !normalized_frames_equal(direct.frame(), forward.frame()) {
+        if !normalized_frames_equal(direct.frame(), forward.frame())
+            || direct.painter_order() != forward.painter_order()
+        {
             return Err(ReplayVerificationError::Diverged {
                 mode: ReplayVerificationMode::Forward,
                 target,
@@ -189,7 +141,9 @@ pub fn verify_scene_replay(
         for time in [0.0, target.max(0.25) + 0.4, 0.1, target] {
             rewind.advance_to(time)?;
         }
-        if !normalized_frames_equal(direct.frame(), rewind.frame()) {
+        if !normalized_frames_equal(direct.frame(), rewind.frame())
+            || direct.painter_order() != rewind.painter_order()
+        {
             return Err(ReplayVerificationError::Diverged {
                 mode: ReplayVerificationMode::Rewind,
                 target,
@@ -200,24 +154,97 @@ pub fn verify_scene_replay(
     Ok(())
 }
 
-#[cfg(target_arch = "wasm32")]
+/// Qualify the same Rust-authored fixtures on native and direct WASM.
+pub fn verify_example_replay(
+    example: &str,
+    targets: &[f64],
+    forward_sample_count: usize,
+    stress_count: usize,
+) -> Result<(), ReplayVerificationError> {
+    use noon::example_scenes;
+    let session = match example {
+        "exact-property-tracks" => example_scenes::exact_property_tracks::session(),
+        "specialized-geometry" => example_scenes::specialized_geometry::session(),
+        "family-placement" => example_scenes::family_placement::session(),
+        "painter-order" => example_scenes::painter_order_overlap::session(),
+        "analytic-stress" => example_scenes::analytic_profile::session(
+            stress_count,
+            example_scenes::analytic_profile::Layout::Fit,
+            16.0 / 9.0,
+            2.0,
+        ),
+        "create-morph-fade" => create_morph_fade_session(),
+        _ => Err(format!("unknown direct replay example: {example}")),
+    }
+    .map_err(ReplayVerificationError::Fixture)?;
+    verify_execution_replay(&session, targets, forward_sample_count)
+}
+
+fn create_morph_fade_session() -> Result<ExecutionSession, String> {
+    use noon::{
+        AnimationOptions, RateFunction, Scene, SemanticAnimationCompositionKind,
+        SemanticAnimationIntent, SemanticFadeDirection, SemanticFadeEndpoint,
+        SemanticTransformInterpolation,
+    };
+    let mut scene = Scene::new();
+    let circle = scene.circle(0.75)?;
+    let mut square = scene.square(1.5)?;
+    square.set_translation(2.0, 0.0)?;
+    scene.add(&circle)?;
+    let options = AnimationOptions::new()
+        .run_time(1.0)
+        .rate_func(RateFunction::Linear);
+    let create = scene.declare_animation(
+        SemanticAnimationIntent::Create {
+            target: circle.node_id(),
+        },
+        options,
+    )?;
+    let morph = scene.declare_animation(
+        SemanticAnimationIntent::TransformTo {
+            target: circle.node_id(),
+            target_state: square.node_id(),
+            interpolation: SemanticTransformInterpolation::PointCorrespondence,
+        },
+        options,
+    )?;
+    let fade = scene.declare_animation(
+        SemanticAnimationIntent::Fade {
+            target: circle.node_id(),
+            direction: SemanticFadeDirection::Out,
+            endpoint: SemanticFadeEndpoint::identity(),
+        },
+        options,
+    )?;
+    let root = scene.declare_animation(
+        SemanticAnimationIntent::Composition {
+            kind: SemanticAnimationCompositionKind::Sequence,
+            children: vec![create.node_id(), morph.node_id(), fade.node_id()],
+        },
+        AnimationOptions::new(),
+    )?;
+    scene.execution_session_with_animation_root(&root)
+}
+
+#[cfg(all(target_arch = "wasm32", debug_assertions))]
 mod wasm {
     use wasm_bindgen::prelude::*;
 
-    use super::verify_scene_replay;
-
-    fn js_error(error: impl std::fmt::Display) -> JsValue {
-        JsValue::from_str(&error.to_string())
-    }
-
-    #[wasm_bindgen(js_name = verifySceneReplay)]
-    pub fn verify_scene_replay_wasm(
-        scene_json: &str,
-        targets_json: &str,
+    /// Only fixture selection and sample times cross the test-harness boundary.
+    #[wasm_bindgen(js_name = verifyDirectExecutionReplay)]
+    pub fn verify_direct_execution_replay(
+        example: &str,
+        targets: &[f64],
         forward_sample_count: u32,
+        stress_count: u32,
     ) -> Result<(), JsValue> {
-        let targets: Vec<f64> = serde_json::from_str(targets_json).map_err(js_error)?;
-        verify_scene_replay(scene_json, &targets, forward_sample_count as usize).map_err(js_error)
+        super::verify_example_replay(
+            example,
+            targets,
+            forward_sample_count as usize,
+            stress_count as usize,
+        )
+        .map_err(|error| JsValue::from_str(&error.to_string()))
     }
 }
 

--- a/crates/noon-web/tests/deterministic_replay.rs
+++ b/crates/noon-web/tests/deterministic_replay.rs
@@ -1,5 +1,5 @@
 use noon::ExecutionSession;
-use noon_web::{verify_scene_replay, ReplayVerificationError};
+use noon_web::{verify_example_replay, verify_execution_replay, ReplayVerificationError};
 
 type SessionFactory = fn() -> Result<ExecutionSession, String>;
 
@@ -41,13 +41,14 @@ fn typed_direct_seek_forward_playback_and_backward_scrub_have_identical_frames()
 }
 
 #[test]
-fn remaining_external_replay_verifier_validates_workloads_before_decoding() {
+fn typed_replay_verifier_rejects_invalid_sampling() {
+    let session = sessions()[0]().unwrap();
     assert!(matches!(
-        verify_scene_replay("", &[0.5], 1),
+        verify_execution_replay(&session, &[0.5], 1),
         Err(ReplayVerificationError::InvalidForwardSampleCount(1))
     ));
     assert!(matches!(
-        verify_scene_replay("", &[f64::NAN], 38),
+        verify_execution_replay(&session, &[f64::NAN], 38),
         Err(ReplayVerificationError::NonFiniteTarget { index: 0, .. })
     ));
 }
@@ -79,5 +80,25 @@ fn typed_repeated_evaluation_is_stable_at_boundaries_and_extreme_valid_times() {
             repeated.advance_to(time).unwrap();
             assert!(repeated.take_frame_changes().is_empty());
         }
+    }
+}
+
+#[test]
+fn direct_wasm_corpus_also_qualifies_on_native_rust() {
+    for example in [
+        "exact-property-tracks",
+        "specialized-geometry",
+        "family-placement",
+        "painter-order",
+        "analytic-stress",
+        "create-morph-fade",
+    ] {
+        verify_example_replay(
+            example,
+            &[0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.75],
+            32,
+            1000,
+        )
+        .unwrap_or_else(|error| panic!("{example}: {error}"));
     }
 }

--- a/scripts/check-web-package.mjs
+++ b/scripts/check-web-package.mjs
@@ -175,7 +175,6 @@ const expectedJavascriptSurface = [
   "appendCreate(",
   "appendRotate(",
   "sceneJson(",
-  "export function verifySceneReplay(",
   "export function resolveAnimationOptions(",
 ];
 const expectedTypeSurface = [
@@ -369,7 +368,6 @@ const expectedTypeSurface = [
   "setObjectOpacity(opacity: number): void",
   "manimMoveToHandle(",
   "manimMoveToPoint(",
-  "export function verifySceneReplay(scene_json: string, targets_json: string, forward_sample_count: number): void",
   "export function resolveAnimationOptions(",
 ];
 
@@ -379,6 +377,7 @@ const expectedTypeSurface = [
 if (process.env.NOON_WASM_PROFILE === "dev"
     || javascript.includes("export function createDirectExecutionSmokeRenderer(")) {
   expectedJavascriptSurface.push(
+    "export function verifyDirectExecutionReplay(",
     "export function createDirectTypstTextSmokeRenderer(",
     "export function createDirectMathTypstTextSmokeRenderer(",
     "export function createDirectOrdinaryAffinePlaySmokeRenderer(",
@@ -418,6 +417,7 @@ if (process.env.NOON_WASM_PROFILE === "dev"
     "export function createDirectOrdinaryStylePlaySmokeRenderer(",
   );
   expectedTypeSurface.push(
+    "export function verifyDirectExecutionReplay(",
     "recoverWebGlContext(): Promise<boolean>",
     "export function createDirectTypstTextSmokeRenderer(canvas: OffscreenCanvas): Promise<ExecutionCanvasRenderer>",
     "export function createDirectMathTypstTextSmokeRenderer(canvas: OffscreenCanvas): Promise<ExecutionCanvasRenderer>",
@@ -475,6 +475,7 @@ for (const retired of ["ReactiveScenePlayer", "ReactiveCanvasPlayer",
   }
 }
 for (const retired of [
+  "export function verifySceneReplay(",
   "export function resolveUniformCompositionSchedule(",
   "export function resolveLifecyclePlan(",
   "export function validatePresenceTransition(",

--- a/scripts/deterministic-replay-smoke.mjs
+++ b/scripts/deterministic-replay-smoke.mjs
@@ -1,7 +1,5 @@
 import assert from "node:assert/strict";
-import { spawn, spawnSync } from "node:child_process";
-import { mkdtemp, readFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { spawn } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -10,37 +8,17 @@ import playwright from "playwright";
 const { chromium } = playwright;
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, "..");
-const sceneDir = await mkdtemp(path.join(tmpdir(), "noon-determinism-scenes-"));
 const port = Number(process.env.NOON_DETERMINISM_PORT ?? "4183");
 const baseUrl = `http://127.0.0.1:${port}`;
 const forwardSampleCount = 32;
-const morphStressCount = process.env.NOON_DETERMINISM_MORPH_STRESS_COUNT;
-const generatorArgs = ["web/python/playground_examples.py", sceneDir];
-if (morphStressCount !== undefined) {
-  if (!/^\d+$/.test(morphStressCount) || Number(morphStressCount) < 12) {
-    throw new Error("NOON_DETERMINISM_MORPH_STRESS_COUNT must be an integer >= 12");
-  }
-  generatorArgs.push("--morph-stress-count", morphStressCount);
-}
-
-const generated = spawnSync("python3", generatorArgs, {
-  cwd: repoRoot,
-  encoding: "utf8",
-  env: { ...process.env, PYTHONDONTWRITEBYTECODE: "1" },
-});
-if (generated.status !== 0) {
-  throw new Error(`Unable to generate deterministic scenes:\n${generated.stdout}\n${generated.stderr}`);
-}
-const examples = generated.stdout
-  .trim()
-  .split("\n")
-  .filter(Boolean)
-  .map((line) => {
-    const separator = line.indexOf("\t");
-    assert.notEqual(separator, -1, `unexpected playground generator output: ${line}`);
-    return { name: line.slice(0, separator), file: line.slice(separator + 1) };
-  });
-assert.ok(examples.length > 0, "determinism corpus must contain playground scenes");
+const stressCount = Number(process.env.NOON_DETERMINISM_STRESS_COUNT ?? "1000");
+assert.ok(Number.isInteger(stressCount) && stressCount >= 1 && stressCount <= 100_000,
+  "NOON_DETERMINISM_STRESS_COUNT must be an integer in 1..100000");
+const examples = [
+  "exact-property-tracks", "specialized-geometry", "family-placement",
+  "painter-order", "analytic-stress", "create-morph-fade",
+];
+const targets = [0, 0.25, 0.5, 0.999, 1, 1.001, 1.5, 2, 2.5, 3, 3.75];
 
 let serverOutput = "";
 const server = spawn(
@@ -66,13 +44,6 @@ async function waitForServer() {
   throw new Error(`determinism smoke server did not start: ${lastError}\n${serverOutput}`);
 }
 
-function sceneEnd(document) {
-  if (document.tracks.length === 0) return 0;
-  return Math.max(
-    ...document.tracks.map((track) => track.timing.start_time + track.timing.duration),
-  );
-}
-
 let browser = null;
 try {
   await waitForServer();
@@ -88,28 +59,23 @@ try {
   await page.evaluate(async () => {
     const wasm = await import("./pkg/noon_web.js");
     await wasm.default();
-    window.noonDeterminism = { verify: wasm.verifySceneReplay };
+    if ("verifySceneReplay" in wasm) throw new Error("legacy scene-document replay API returned");
+    window.noonDeterminism = { verify: wasm.verifyDirectExecutionReplay };
   });
 
   for (const example of examples) {
-    const sceneJson = await readFile(example.file, "utf8");
-    const document = JSON.parse(sceneJson);
-    const end = sceneEnd(document);
-    const targets =
-      end > 0 ? [0, end * 0.125, end * 0.5, end * 0.875, end, end + 0.75] : [0, 0.5];
-
     await page.evaluate(
-      ({ json, targetTimes, sampleCount }) => {
-        window.noonDeterminism.verify(json, JSON.stringify(targetTimes), sampleCount);
+      ({ example, targetTimes, sampleCount, count }) => {
+        window.noonDeterminism.verify(example, new Float64Array(targetTimes), sampleCount, count);
       },
-      { json: sceneJson, targetTimes: targets, sampleCount: forwardSampleCount },
+      { example, targetTimes: targets, sampleCount: forwardSampleCount, count: stressCount },
     );
-    console.log(`✓ ${example.name}: direct/playback/rewind WASM snapshots agree`);
+    console.log(`✓ ${example}: typed direct/playback/rewind WASM state agrees`);
   }
 
   assert.deepEqual(browserErrors, [], `unexpected browser errors:\n${browserErrors.join("\n")}`);
   console.log(
-    `Deterministic replay smoke passed for ${examples.length} playground scenes ` +
+    `Deterministic replay smoke passed for ${examples.length} shared Rust scenes ` +
       `with ${forwardSampleCount} forward samples per target.`,
   );
 } finally {


### PR DESCRIPTION
## Change

Advances #959 A4.7/A4.8 and #961 replay qualification. The browser replay gate still spawned a CPython scene-document generator and decoded those documents into the legacy compiled/runtime path. It now selects Rust fixtures and supplies sample times to direct WASM. Rust constructs Semantic Scene → Execution Plan → ExecutionSession and compares direct seek, forward playback and rewind entirely in process.

Replace `verify_scene_replay` / `verifySceneReplay` with a typed `verify_execution_replay` utility and a debug-only direct WASM fixture entrypoint. Remove the verifier's `noon-ir` decoding and legacy runtime dependency. Verify renderer-coordinate frame state and painter order as well as object/presence/reveal/morph state. The native test exercises the same six-case corpus: exact property tracks, specialized geometry, family placement, painter order, analytic stress, and a shared live activation with Create, content morph and Fade in parallel.

This is a test utility, not a new engine authority or scene API. Three runtime clones exist only to compare independent replay paths. No new migration seam or ordinary-path work is introduced. Existing paired Rust/Python examples and the shared authoring suite retain frontend evidence; this change adds no frontend feature semantics.

The old `playground_examples.py` generator is **not deleted yet**: the separate renderer smoke and legacy playground fixture integration test still consume it. Their migration remains #959. The replay corpus now qualifies current shared semantics; it does not claim implementation of legacy-only matching/replacement APIs. Renderer visual/continuity checks remain in the existing gate.

## Validation

- `cargo fmt --all -- --check`
- `node --check scripts/deterministic-replay-smoke.mjs`
- `node --check scripts/check-web-package.mjs`
- `bash scripts/check.sh architecture HEAD`
- `git diff --check`

These local structural checks passed. Full hosted Rust/WASM/browser CI is required; no local compilation or browser pass is claimed with the disk constraint. The sampling count remains 32 per target, and thresholds are unchanged. `NOON_DETERMINISM_STRESS_COUNT` controls the direct analytic workload (default 1,000).

The first full run caught a fixture using the restricted initial-track API for lifecycle composition. The fixture now uses the ordinary shared live activation API. No compiler contract or comparison threshold was changed.
