### PR TITLE
fix: support shared Rust path morphs and typed renderer qualification (#959)

### DIFF
--- a/crates/noon-compile/src/semantic_lowering/animation_payload/affine.rs
+++ b/crates/noon-compile/src/semantic_lowering/animation_payload/affine.rs
@@ -19,8 +19,8 @@ use super::super::{
     SemanticScheduledAnimationPayload,
 };
 use super::transform_payload::{
-    is_supported_analytic_content_morph, validate_transform_payload_shape,
-    SemanticAffineAnimationField, TransformPayloadValidationIssue,
+    is_supported_content_morph, validate_transform_payload_shape, SemanticAffineAnimationField,
+    TransformPayloadValidationIssue,
 };
 
 /// The activation-time effective domains consumed by the shared animation lowerer.
@@ -728,7 +728,7 @@ where
             captures.insert(leaf.execution_object_id, captured);
             captured
         };
-        let channels = lower_transform_channels(source, target, from, interpolation)
+        let channels = lower_transform_channels(store, source, target, from, interpolation)
             .map_err(|issue| existing_payload_error(leaf, target_state, issue))?;
         for channel in channels {
             push_published_channel(leaf, channel, &mut driven, &mut tracks)?;
@@ -1856,12 +1856,13 @@ pub(super) fn lower_indicate_channels(
 }
 
 pub(super) fn lower_transform_channels(
+    store: &SemanticStore,
     source: &noon_core::SemanticObjectState,
     target: &noon_core::SemanticObjectState,
     from: EffectiveAnimationProperties,
     interpolation: noon_core::SemanticTransformInterpolation,
 ) -> Result<Vec<LoweredAffineChannel>, AffinePayloadIssue> {
-    let analytic_point_transform = matches!(
+    let point_transform = matches!(
         (source.content.geometry(), target.content.geometry()),
         (
             Some(StoredGeometry::Circle { .. }),
@@ -1869,17 +1870,20 @@ pub(super) fn lower_transform_channels(
         ) | (
             Some(StoredGeometry::Rectangle { .. }),
             Some(StoredGeometry::Rectangle { .. })
+        ) | (
+            Some(StoredGeometry::Resource(_)),
+            Some(StoredGeometry::Resource(_))
         )
     );
     if source.content == target.content {
         if interpolation == noon_core::SemanticTransformInterpolation::Affine {
             return lower_affine_channels(source, target, from);
         }
-        if !analytic_point_transform {
+        if !point_transform {
             return Err(AffinePayloadIssue::UnsupportedPointCorrespondence);
         }
     }
-    if !analytic_point_transform && !is_supported_analytic_content_morph(source, target) {
+    if !point_transform && !is_supported_content_morph(source, target) {
         return Err(AffinePayloadIssue::UnsupportedContentChange);
     }
     if let Some(binding) = source.signal_bindings().first() {
@@ -1894,16 +1898,18 @@ pub(super) fn lower_transform_channels(
         return Err(AffinePayloadIssue::InvalidEffectiveStyle);
     }
 
-    let geometry = |content: SemanticObjectContent| match content.geometry() {
-        Some(StoredGeometry::Circle { radius }) => Ok(noon_core::GeometryRef::circle(radius)),
-        Some(StoredGeometry::Rectangle { size }) => Ok(noon_core::GeometryRef::Rectangle { size }),
-        _ => Err(AffinePayloadIssue::UnsupportedContentChange),
+    let geometry = |content: SemanticObjectContent| {
+        let geometry = content
+            .geometry()
+            .ok_or(AffinePayloadIssue::UnsupportedContentChange)?;
+        super::super::compiled_scene::lower_semantic_geometry_value(geometry, Some(store))
+            .map_err(|_| AffinePayloadIssue::UnsupportedContentChange)
     };
     let target_transform = lower_semantic_transform_value(target)
         .map_err(|_| AffinePayloadIssue::InvalidEffectiveTransform)?;
     let target_style =
         lower_semantic_style_value(target).map_err(AffinePayloadIssue::InvalidTargetStyle)?;
-    let (prepared, render_transform) = crate::transform::compile_analytic_content_morph(
+    let (prepared, render_transform) = crate::transform::compile_content_morph(
         &geometry(source.content)?,
         &geometry(target.content)?,
         from.style,

--- a/crates/noon-compile/src/semantic_lowering/animation_payload/prepared_composition.rs
+++ b/crates/noon-compile/src/semantic_lowering/animation_payload/prepared_composition.rs
@@ -347,8 +347,9 @@ where
                     &mut captures,
                     &mut effective_properties,
                 )?;
-                let channels = lower_transform_channels(source, target, from, interpolation)
-                    .map_err(|issue| prepared_payload_error(leaf, target_state, issue))?;
+                let channels =
+                    lower_transform_channels(prepared.store(), source, target, from, interpolation)
+                        .map_err(|issue| prepared_payload_error(leaf, target_state, issue))?;
                 for channel in channels {
                     push_prepared_channel(leaf, channel, &mut driven, &mut tracks)?;
                 }

--- a/crates/noon-compile/src/semantic_lowering/animation_payload/transform_payload.rs
+++ b/crates/noon-compile/src/semantic_lowering/animation_payload/transform_payload.rs
@@ -142,7 +142,7 @@ pub(super) fn validate_transform_payload_shape(
             introducer: options.introducer,
         });
     }
-    if source.content != target.content && !is_supported_analytic_content_morph(source, target) {
+    if source.content != target.content && !is_supported_content_morph(source, target) {
         return Err(TransformPayloadValidationIssue::ContentChange);
     }
     if source.style.stroke_width != target.style.stroke_width
@@ -171,7 +171,7 @@ pub(super) fn validate_transform_payload_shape(
     Ok(())
 }
 
-pub(super) fn is_supported_analytic_content_morph(
+pub(super) fn is_supported_content_morph(
     source: &noon_core::SemanticObjectState,
     target: &noon_core::SemanticObjectState,
 ) -> bool {
@@ -185,6 +185,9 @@ pub(super) fn is_supported_analytic_content_morph(
         ) | (
             Some(StoredGeometry::Rectangle { .. }),
             Some(StoredGeometry::Circle { .. })
+        ) | (
+            Some(StoredGeometry::Resource(_)),
+            Some(StoredGeometry::Resource(_))
         )
     )
 }

--- a/crates/noon-compile/src/transform.rs
+++ b/crates/noon-compile/src/transform.rs
@@ -133,9 +133,9 @@ pub(crate) fn compile_transform_geometry_plan(
         (GeometryRef::Circle { .. }, GeometryRef::Rectangle { .. })
         | (GeometryRef::Rectangle { .. }, GeometryRef::Circle { .. }) => {
             let source = noon_geometry::canonical_outline_path(&from.geometry)
-                .expect("closed analytic source geometry must convert to a path");
+                .expect("supported source geometry must convert to a path");
             let target = noon_geometry::canonical_outline_path(&to.geometry)
-                .expect("closed analytic target geometry must convert to a path");
+                .expect("supported target geometry must convert to a path");
             compile_path_pair(
                 from.style,
                 to.style,
@@ -150,10 +150,10 @@ pub(crate) fn compile_transform_geometry_plan(
     Ok(Some(plan))
 }
 
-/// Compile a typed analytic point-correspondence transform without constructing
+/// Compile a typed analytic or resource-path point-correspondence transform without constructing
 /// an authored object endpoint. The returned resource is execution-owned and may
 /// use a fixed render frame while semantic affine channels remain independently visible.
-pub(crate) fn compile_analytic_content_morph(
+pub(crate) fn compile_content_morph(
     from_geometry: &GeometryRef,
     to_geometry: &GeometryRef,
     from_style: Style,
@@ -167,14 +167,15 @@ pub(crate) fn compile_analytic_content_morph(
             | (GeometryRef::Rectangle { .. }, GeometryRef::Circle { .. })
             | (GeometryRef::Circle { .. }, GeometryRef::Circle { .. })
             | (GeometryRef::Rectangle { .. }, GeometryRef::Rectangle { .. })
+            | (GeometryRef::VectorPath(_), GeometryRef::VectorPath(_))
     );
     if !supported {
         return Err(TransformCompileFailure::UnsupportedGeometry);
     }
     let source = noon_geometry::canonical_outline_path(from_geometry)
-        .expect("closed analytic source geometry must convert to a path");
+        .expect("supported source geometry must convert to a path");
     let target = noon_geometry::canonical_outline_path(to_geometry)
-        .expect("closed analytic target geometry must convert to a path");
+        .expect("supported target geometry must convert to a path");
     let TransformGeometryPlan::PathPair {
         geometry,
         render_transform,
@@ -187,7 +188,7 @@ pub(crate) fn compile_analytic_content_morph(
         target,
     )?
     else {
-        unreachable!("analytic point transform compiles to a path pair")
+        unreachable!("point transform compiles to a path pair")
     };
     if from_style.stroke_width_mode == StrokeWidthMode::ScreenSpace && render_transform.is_none() {
         return Err(TransformCompileFailure::RequiresRetessellation);
@@ -365,7 +366,7 @@ mod tests {
             rotation: std::f32::consts::FRAC_PI_4,
             ..Transform2D::IDENTITY
         };
-        let (geometry, render_transform) = compile_analytic_content_morph(
+        let (geometry, render_transform) = compile_content_morph(
             &GeometryRef::rectangle(2.0, 2.0),
             &GeometryRef::circle(1.0),
             style,
@@ -398,7 +399,7 @@ mod tests {
         };
 
         assert_eq!(
-            compile_analytic_content_morph(
+            compile_content_morph(
                 &GeometryRef::rectangle(2.0, 2.0),
                 &GeometryRef::circle(1.0),
                 style,

--- a/crates/noon-native/examples/create_shapes.rs
+++ b/crates/noon-native/examples/create_shapes.rs
@@ -1,0 +1,5 @@
+//! Direct native Rust example, paired with the ordinary Python create_shapes scene.
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    noon_native::run(noon::example_scenes::renderer_fixtures::create_shapes()?)?;
+    Ok(())
+}

--- a/crates/noon-native/examples/filled_path_transform.rs
+++ b/crates/noon-native/examples/filled_path_transform.rs
@@ -1,0 +1,5 @@
+//! Direct native Rust example, paired with the ordinary Python filled_path_transform scene.
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    noon_native::run(noon::example_scenes::renderer_fixtures::filled_path_transform()?)?;
+    Ok(())
+}

--- a/crates/noon-native/examples/morph_stress.rs
+++ b/crates/noon-native/examples/morph_stress.rs
@@ -1,0 +1,12 @@
+//! Shared typed path-morph stress workload; optional first argument is object count.
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let count = std::env::args()
+        .nth(1)
+        .map(|value| value.parse())
+        .transpose()?
+        .unwrap_or(1000);
+    noon_native::run(noon::example_scenes::renderer_fixtures::morph_stress(
+        count,
+    )?)?;
+    Ok(())
+}

--- a/crates/noon-web/src/direct_execution_smoke.rs
+++ b/crates/noon-web/src/direct_execution_smoke.rs
@@ -27,6 +27,34 @@ pub async fn create_direct_analytic_profile_renderer(
     WasmExecutionCanvasRenderer::create_from_execution_session(canvas, session).await
 }
 
+/// Filled path interpolation uses the shared native renderer qualification scene.
+#[wasm_bindgen(js_name = createDirectFilledPathTransformRenderer)]
+pub async fn create_direct_filled_path_transform_renderer(
+    canvas: OffscreenCanvas,
+) -> Result<WasmExecutionCanvasRenderer, JsValue> {
+    let session =
+        noon::example_scenes::renderer_fixtures::filled_path_transform().map_err(js_error)?;
+    WasmExecutionCanvasRenderer::create_from_execution_session(canvas, session).await
+}
+
+/// Analytic and vector-path Create endpoints use the same typed native scene.
+#[wasm_bindgen(js_name = createDirectCreateShapesRenderer)]
+pub async fn create_direct_create_shapes_renderer(
+    canvas: OffscreenCanvas,
+) -> Result<WasmExecutionCanvasRenderer, JsValue> {
+    let session = noon::example_scenes::renderer_fixtures::create_shapes().map_err(js_error)?;
+    WasmExecutionCanvasRenderer::create_from_execution_session(canvas, session).await
+}
+
+/// Repeated filled-path topology changes use the same typed workload as native.
+#[wasm_bindgen(js_name = createDirectMorphStressRenderer)]
+pub async fn create_direct_morph_stress_renderer(
+    canvas: OffscreenCanvas,
+) -> Result<WasmExecutionCanvasRenderer, JsValue> {
+    let session = noon::example_scenes::renderer_fixtures::morph_stress(1000).map_err(js_error)?;
+    WasmExecutionCanvasRenderer::create_from_execution_session(canvas, session).await
+}
+
 /// The native membership example runs unchanged inside the direct WASM engine.
 #[wasm_bindgen(js_name = createDirectOrdinaryMembershipSmokeRenderer)]
 pub async fn create_direct_ordinary_membership_smoke_renderer(

--- a/crates/noon/src/example_scenes.rs
+++ b/crates/noon/src/example_scenes.rs
@@ -19,6 +19,7 @@ pub mod ordinary_membership;
 pub mod ordinary_subset_display;
 pub mod ordinary_uncreate_options;
 pub mod painter_order_overlap;
+pub mod renderer_fixtures;
 pub mod specialized_geometry;
 #[cfg(all(feature = "native-text", feature = "bundled-fonts"))]
 pub mod text_family_fade;

--- a/crates/noon/src/example_scenes/renderer_fixtures.rs
+++ b/crates/noon/src/example_scenes/renderer_fixtures.rs
@@ -1,0 +1,227 @@
+//! Filled morph and reveal-continuity examples shared by native and direct WASM.
+use crate::{
+    AnimationCompositionRequest, AnimationOptions, Color, ExecutionSession, Mobject, RateFunction,
+    Scene, SemanticPaint, SemanticStyle, TransformToRequest, Vec2, VectorPath, BLUE, PINK, PURPLE,
+    WHITE,
+};
+
+fn style(fill: Option<Color>, stroke: Color, width: f64) -> SemanticStyle {
+    SemanticStyle {
+        fill: fill.map(SemanticPaint::Solid),
+        stroke: Some(SemanticPaint::Solid(stroke)),
+        stroke_width: width,
+        stroke_width_mode: crate::StrokeWidthMode::ScreenSpace,
+        stroke_join: crate::StrokeJoin::Miter,
+        stroke_cap: crate::StrokeCap::Butt,
+        ..SemanticStyle::default()
+    }
+}
+
+fn paint(
+    object: &mut Mobject,
+    fill: Option<Color>,
+    stroke: Color,
+    width: f64,
+) -> Result<(), String> {
+    let mut state = object.state()?;
+    state.style = style(fill, stroke, width);
+    object.commit_state(state)
+}
+
+fn options() -> AnimationOptions {
+    AnimationOptions::new()
+        .run_time(3.2)
+        .rate_func(RateFunction::EaseInOutCubic)
+}
+
+fn rounded_loop(radius: f32) -> VectorPath {
+    let handle = radius * 0.58;
+    VectorPath::new()
+        .move_to(Vec2::new(0.0, radius))
+        .cubic_to(
+            Vec2::new(handle, radius),
+            Vec2::new(radius, handle),
+            Vec2::new(radius, 0.0),
+        )
+        .cubic_to(
+            Vec2::new(radius, -handle),
+            Vec2::new(handle, -radius),
+            Vec2::new(0.0, -radius),
+        )
+        .cubic_to(
+            Vec2::new(-handle, -radius),
+            Vec2::new(-radius, -handle),
+            Vec2::new(-radius, 0.0),
+        )
+        .cubic_to(
+            Vec2::new(-radius, handle),
+            Vec2::new(-handle, radius),
+            Vec2::new(0.0, radius),
+        )
+        .close()
+}
+
+fn star(outer: f32, inner: f32, phase: f32) -> VectorPath {
+    let mut star = VectorPath::new();
+    for index in 0..10 {
+        let angle = phase + std::f32::consts::FRAC_PI_2 - index as f32 * std::f32::consts::PI / 5.0;
+        let radius = if index % 2 == 0 { outer } else { inner };
+        let point = Vec2::new(angle.cos() * radius, angle.sin() * radius);
+        star = if index == 0 {
+            star.move_to(point)
+        } else {
+            star.line_to(point)
+        };
+    }
+    star.close()
+}
+
+/// Pair: `web/python/examples/ordinary_filled_path_transform.py`.
+pub fn filled_path_transform() -> Result<ExecutionSession, String> {
+    let mut scene = Scene::new();
+    let shape = scene.path(rounded_loop(1.35), style(Some(BLUE), WHITE, 0.08))?;
+    let target = scene.path(star(1.7, 0.7, 0.0), style(Some(PURPLE), WHITE, 0.08))?;
+    scene.add(&shape)?;
+    let mut session = scene
+        .execution_session()
+        .map_err(|error| error.to_string())?;
+    scene
+        .live(&mut session)
+        .declare_and_activate_composition(
+            &AnimationCompositionRequest::TransformTo(TransformToRequest::point_correspondence(
+                &shape,
+                &target,
+                options(),
+            )),
+            AnimationOptions::new(),
+        )
+        .map_err(|error| error.to_string())?;
+    Ok(session)
+}
+
+/// Pair: `web/python/examples/ordinary_create_shapes.py`.
+pub fn create_shapes() -> Result<ExecutionSession, String> {
+    let scene = Scene::new();
+    let mut circle = scene.circle(0.9)?;
+    circle.set_translation(-3.0, 1.0)?;
+    paint(&mut circle, Some(BLUE), WHITE, 0.055)?;
+    let mut square = scene.square(1.7)?;
+    square.set_translation(0.0, 1.0)?;
+    paint(&mut square, Some(PINK), WHITE, 0.055)?;
+    let mut line = scene.line((1.75, 1.0), (4.25, 1.0))?;
+    paint(&mut line, None, BLUE, 0.055)?;
+    let wave = VectorPath::new().move_to(Vec2::new(-2.4, -1.6)).cubic_to(
+        Vec2::new(-1.2, -2.6),
+        Vec2::new(1.2, -0.6),
+        Vec2::new(2.4, -1.6),
+    );
+    let wave = scene.path(wave, style(None, PINK, 0.05))?;
+    let mut session = scene
+        .execution_session()
+        .map_err(|error| error.to_string())?;
+    scene
+        .live(&mut session)
+        .declare_and_activate_create_parallel(
+            &[
+                (&circle, options()),
+                (&square, options()),
+                (&line, options()),
+                (&wave, options()),
+            ],
+            AnimationOptions::new(),
+        )
+        .map_err(|error| error.to_string())?;
+    Ok(session)
+}
+
+/// A bounded, repeated path-morph workload. Python uses 96 objects in the shared
+/// authoring gate; the native/WASM renderer gate uses 1,000 with the same semantics.
+/// Pair: `web/python/examples/ordinary_morph_stress.py`.
+pub fn morph_stress(count: usize) -> Result<ExecutionSession, String> {
+    if !(12..=10_000).contains(&count) {
+        return Err("morph object count must be between 12 and 10000".into());
+    }
+    let mut scene = Scene::new();
+    let columns = (count as f64 * 1.5).sqrt().ceil() as usize;
+    let rows = count.div_ceil(columns);
+    let dx = 5.8 / (columns - 1).max(1) as f64;
+    let dy = 3.8 / (rows - 1).max(1) as f64;
+    let radius = (dx.min(dy) * 0.37) as f32;
+    let width = f64::from(radius * 0.24).max(0.0025);
+    let colors = [
+        BLUE,
+        crate::TEAL,
+        crate::GREEN,
+        crate::YELLOW,
+        crate::ORANGE,
+        crate::RED,
+        PINK,
+        PURPLE,
+    ];
+    let source = rounded_loop(radius);
+    let targets: Vec<_> = (0..12)
+        .map(|variant| {
+            let outer = radius * (1.18 + 0.08 * (variant as f32 * 1.7).sin());
+            let inner = outer * (0.42 + 0.05 * (variant as f32 * 0.9).cos());
+            star(
+                outer,
+                inner,
+                variant as f32 / 12.0 * std::f32::consts::PI * 0.36,
+            )
+        })
+        .collect();
+    let mut requests = Vec::with_capacity(count);
+    for index in 0..count {
+        let paint = style(None, colors[index % colors.len()], width);
+        let mut shape = scene.path(source.clone(), paint.clone())?;
+        let mut target = scene.path(targets[index % targets.len()].clone(), paint)?;
+        let x = -2.9 + (index % columns) as f64 * dx;
+        let y = 1.9 - (index / columns) as f64 * dy;
+        shape.set_translation(x, y)?;
+        target.set_translation(x, y)?;
+        scene.add(&shape)?;
+        requests.push(AnimationCompositionRequest::TransformTo(
+            TransformToRequest::point_correspondence(&shape, &target, options().run_time(3.4)),
+        ));
+    }
+    let mut session = scene
+        .execution_session()
+        .map_err(|error| error.to_string())?;
+    scene
+        .live(&mut session)
+        .declare_and_activate_composition(
+            &AnimationCompositionRequest::Parallel(requests),
+            AnimationOptions::new(),
+        )
+        .map_err(|error| error.to_string())?;
+    Ok(session)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn renderer_fixtures_advance_seek_and_keep_static_frames_clean() {
+        for (build, count) in [
+            (
+                filled_path_transform as fn() -> Result<ExecutionSession, String>,
+                1,
+            ),
+            (create_shapes, 4),
+            (|| morph_stress(96), 96),
+        ] {
+            let mut forward = build().unwrap();
+            let mut direct = build().unwrap();
+            for time in [0.0, 0.8, 1.6, 3.199, 3.2, 3.4] {
+                forward.advance_to(time).unwrap();
+                direct.seek(time).unwrap();
+                assert_eq!(forward.frame(), direct.frame());
+                assert_eq!(forward.painter_order().len(), count);
+                forward.take_frame_changes();
+                forward.advance_to(time).unwrap();
+                assert!(forward.take_frame_changes().is_empty());
+            }
+        }
+    }
+}

--- a/crates/noon/src/example_scenes/renderer_fixtures.rs
+++ b/crates/noon/src/example_scenes/renderer_fixtures.rs
@@ -170,7 +170,7 @@ pub fn morph_stress(count: usize) -> Result<ExecutionSession, String> {
             )
         })
         .collect();
-    let mut requests = Vec::with_capacity(count);
+    let mut pairs = Vec::with_capacity(count);
     for index in 0..count {
         let paint = style(None, colors[index % colors.len()], width);
         let mut shape = scene.path(source.clone(), paint.clone())?;
@@ -180,9 +180,7 @@ pub fn morph_stress(count: usize) -> Result<ExecutionSession, String> {
         shape.set_translation(x, y)?;
         target.set_translation(x, y)?;
         scene.add(&shape)?;
-        requests.push(AnimationCompositionRequest::TransformTo(
-            TransformToRequest::point_correspondence(&shape, &target, options().run_time(3.4)),
-        ));
+        pairs.push((shape, target));
     }
     let mut session = scene
         .execution_session()
@@ -190,7 +188,22 @@ pub fn morph_stress(count: usize) -> Result<ExecutionSession, String> {
     scene
         .live(&mut session)
         .declare_and_activate_composition(
-            &AnimationCompositionRequest::Parallel(requests),
+            &AnimationCompositionRequest::Composition {
+                kind: crate::SemanticAnimationCompositionKind::Parallel,
+                children: pairs
+                    .iter()
+                    .map(|(shape, target)| {
+                        AnimationCompositionRequest::TransformTo(
+                            TransformToRequest::point_correspondence(
+                                shape,
+                                target,
+                                options().run_time(3.4),
+                            ),
+                        )
+                    })
+                    .collect(),
+                options: AnimationOptions::new(),
+            },
             AnimationOptions::new(),
         )
         .map_err(|error| error.to_string())?;

--- a/crates/noon/src/example_scenes/renderer_fixtures.rs
+++ b/crates/noon/src/example_scenes/renderer_fixtures.rs
@@ -215,6 +215,38 @@ mod tests {
     use super::*;
 
     #[test]
+    fn path_morph_completion_publishes_target_content_without_replacing_identity() {
+        let mut scene = Scene::new();
+        let source = scene
+            .path(rounded_loop(1.35), style(Some(BLUE), WHITE, 0.08))
+            .unwrap();
+        let target = scene
+            .path(star(1.7, 0.7, 0.0), style(Some(PURPLE), WHITE, 0.08))
+            .unwrap();
+        scene.add(&source).unwrap();
+        let identity = source.node_id();
+        let mut session = scene.execution_session().unwrap();
+        let mut live = scene.live(&mut session);
+        let segment = live
+            .declare_and_activate_composition(
+                &AnimationCompositionRequest::TransformTo(
+                    TransformToRequest::point_correspondence(&source, &target, options()),
+                ),
+                AnimationOptions::new(),
+            )
+            .unwrap();
+        live.advance_segment_to(segment, segment.end_time())
+            .unwrap();
+        live.complete_segment(segment).unwrap();
+        assert_eq!(source.node_id(), identity);
+        assert_eq!(
+            source.state().unwrap().content,
+            target.state().unwrap().content
+        );
+        assert_eq!(source.state().unwrap().style, target.state().unwrap().style);
+    }
+
+    #[test]
     fn renderer_fixtures_advance_seek_and_keep_static_frames_clean() {
         for (build, count) in [
             (

--- a/scripts/browser-smoke.mjs
+++ b/scripts/browser-smoke.mjs
@@ -1,7 +1,6 @@
 import assert from "node:assert/strict";
-import { spawn, spawnSync } from "node:child_process";
-import { mkdtemp, mkdir, readFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { spawn } from "node:child_process";
+import { mkdir, readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -13,7 +12,6 @@ const { PNG } = pngjs;
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, "..");
-const sceneDir = await mkdtemp(path.join(tmpdir(), "noon-browser-scenes-"));
 const artifactDir = path.resolve(
   repoRoot,
   process.env.NOON_BROWSER_SMOKE_ARTIFACTS ?? "browser-smoke-artifacts",
@@ -29,38 +27,14 @@ const expectedRendererBackend = backendMode === "webgpu" ? "WebGPU" : "WebGL2";
 
 await mkdir(artifactDir, { recursive: true });
 
-const generated = spawnSync(
-  "python3",
-  ["web/python/playground_examples.py", sceneDir],
-  {
-    cwd: repoRoot,
-    encoding: "utf8",
-    env: {
-      ...process.env,
-      PYTHONDONTWRITEBYTECODE: "1",
-    },
-  },
-);
-if (generated.status !== 0) {
-  throw new Error(
-    `Unable to generate playground scenes:\n${generated.stdout}\n${generated.stderr}`,
-  );
-}
-
-const examples = generated.stdout
-  .trim()
-  .split("\n")
-  .filter(Boolean)
-  .map((line) => {
-    const separator = line.indexOf("\t");
-    if (separator === -1) {
-      throw new Error(`Unexpected playground generator output: ${line}`);
-    }
-    return {
-      name: line.slice(0, separator),
-      file: line.slice(separator + 1),
-    };
-  });
+// Remaining generic authoring/lifecycle cases run in directExecutionProof and
+// the shared Python corpus. These fixtures protect renderer-specific raster work.
+const examples = [
+  { name: "Filled path Transform", factory: "createDirectFilledPathTransformRenderer", objectCount: 1, duration: 3.2 },
+  { name: "Create shapes", factory: "createDirectCreateShapesRenderer", objectCount: 4, duration: 3.2 },
+  { name: "Morph stress · 1,000", factory: "createDirectMorphStressRenderer", objectCount: 1000, duration: 3.4 },
+  { name: "Instanced field · 1,000", factory: "createDirectAnalyticProfileRenderer", args: [1000, "fit", 16 / 9, 3.4], objectCount: 1001, duration: 3.4 },
+];
 
 const gallerySource = await readFile(path.join(repoRoot, "web/main.js"), "utf8");
 assert.ok(
@@ -205,28 +179,52 @@ function pixelDistance(left, right) {
   return left.reduce((distance, channel, index) => distance + Math.abs(channel - right[index]), 0);
 }
 
-function latestSceneEnd(document) {
-  assert.ok(document.tracks.length > 0, "playground scene must contain at least one track");
-  return Math.max(
-    ...document.tracks.map(
-      (track) => track.timing.start_time + track.timing.duration,
-    ),
-  );
-}
-
 function sampleTimes(latestEnd) {
   assert.ok(Number.isFinite(latestEnd) && latestEnd > 0, "scene timeline must have positive duration");
   assert.ok(latestEnd < 4.0, "scene timeline must fit the four-second playground loop");
   return [0.35, 0.60, 0.85, 1.0].map((fraction) => latestEnd * fraction);
 }
 
+async function loadDirectFixture(page, example) {
+  return page.evaluate(async ({ factory, args = [] }) => {
+    const wasm = await import("./pkg/noon_web.js");
+    window.qualifiedRenderer?.free();
+    document.querySelector("#qualified-scene")?.remove();
+    document.querySelector("#scene").style.display = "none";
+    const canvas = document.createElement("canvas");
+    canvas.id = "qualified-scene";
+    canvas.width = 960;
+    canvas.height = 540;
+    document.body.append(canvas);
+    const renderer = await wasm[factory](canvas.transferControlToOffscreen(), ...args);
+    renderer.resize(960, 540);
+    window.qualifiedRenderer = renderer;
+    return { backend: renderer.rendererBackend(), objectCount: renderer.objectCount() };
+  }, example);
+}
+
 async function renderAndCapture(page, time, screenshotPath) {
-  const metrics = await page.evaluate(
-    (sceneTime) => window.noonSmoke.renderAt(sceneTime),
-    time,
-  );
-  await page.evaluate(() => new Promise((resolve) => requestAnimationFrame(() => resolve())));
-  const screenshot = await page.locator("#scene").screenshot({ path: screenshotPath });
+  const metrics = await page.evaluate(async (sceneTime) => {
+    const renderer = window.qualifiedRenderer;
+    const pending = renderer.seekDirect(sceneTime);
+    if (pending) {
+      let presented = false;
+      for (let attempt = 0; attempt < 60; attempt += 1) {
+        if (renderer.render()) { presented = true; break; }
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      if (!presented) throw new Error(`direct fixture did not present at ${sceneTime}`);
+    }
+    return {
+      error: null,
+      time: renderer.time(),
+      objectCount: renderer.objectCount(),
+      drawCalls: renderer.lastDrawCalls(),
+      instances: renderer.lastInstancesDrawn(),
+    };
+  }, time);
+  await page.evaluate(() => new Promise((resolve) => requestAnimationFrame(resolve)));
+  const screenshot = await page.locator("#qualified-scene").screenshot({ path: screenshotPath });
   return { metrics, screenshot };
 }
 
@@ -641,21 +639,10 @@ try {
   const directMetrics = await directExecutionProof(page, expectedRendererBackend);
 
   for (const [index, example] of examples.entries()) {
-    const sceneJson = await readFile(example.file, "utf8");
-    const document = JSON.parse(sceneJson);
-    const expectedObjects = document.objects.length;
-    const latestEnd = latestSceneEnd(document);
-    assert.ok(expectedObjects > 0, `${example.name}: scene has no semantic objects`);
-
-    const loaded = await page.evaluate(
-      (json) => window.noonSmoke.loadScene(json),
-      sceneJson,
-    );
-    assert.equal(
-      loaded.objectCount,
-      expectedObjects,
-      `${example.name}: browser object count after load`,
-    );
+    const expectedObjects = example.objectCount;
+    const latestEnd = example.duration;
+    const loaded = await loadDirectFixture(page, example);
+    assert.equal(loaded.backend, expectedRendererBackend, `${example.name}: renderer backend`);
 
     for (const [checkpointIndex, time] of sampleTimes(latestEnd).entries()) {
       const screenshotPath = path.join(
@@ -664,7 +651,6 @@ try {
       );
       const { metrics, screenshot } = await renderAndCapture(page, time, screenshotPath);
       assert.equal(metrics.error, null, `${example.name}: browser runtime error`);
-      assert.equal(metrics.revision, loaded.revision, `${example.name}: scene revision drifted`);
       assert.equal(metrics.objectCount, expectedObjects, `${example.name}: object count drifted`);
       assert.ok(Math.abs(metrics.time - time) < 1e-6, `${example.name}: deterministic seek time drifted`);
       assert.ok(metrics.drawCalls > 0, `${example.name}: renderer emitted no draw calls at t=${time}`);
@@ -806,7 +792,7 @@ try {
     `browser visual smoke failures:\n${visualFailures.join("\n")}`,
   );
   console.log(
-    `Browser ${expectedRendererBackend} smoke passed for ${examples.length} internal renderer fixtures at four semantic checkpoints each; direct Rust/WASM execution presented ${directMetrics.drawCalls} draw calls on ${directMetrics.backend}; ${browserAuthoredManimCount} public source-equivalent Manim scenes are validated by the browser authoring corpus.`,
+    `Browser ${expectedRendererBackend} smoke passed for ${examples.length} typed Rust renderer fixtures at four semantic checkpoints each; direct Rust/WASM execution presented ${directMetrics.drawCalls} draw calls on ${directMetrics.backend}; ${browserAuthoredManimCount} public source-equivalent Manim scenes are validated by the browser authoring corpus.`,
   );
 } finally {
   await browser?.close();

--- a/scripts/browser-smoke.mjs
+++ b/scripts/browser-smoke.mjs
@@ -199,6 +199,14 @@ async function loadDirectFixture(page, example) {
     const renderer = await wasm[factory](canvas.transferControlToOffscreen(), ...args);
     renderer.resize(960, 540);
     window.qualifiedRenderer = renderer;
+    // Drain the initial resource/frame publication before the first seek. The
+    // host must present every pending publication before advancing its session.
+    let presented = false;
+    for (let attempt = 0; attempt < 60; attempt += 1) {
+      if (renderer.render()) { presented = true; break; }
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    if (!presented) throw new Error(`${factory}: initial publication did not present`);
     return { backend: renderer.rendererBackend(), objectCount: renderer.objectCount() };
   }, example);
 }

--- a/scripts/check-web-package.mjs
+++ b/scripts/check-web-package.mjs
@@ -455,6 +455,10 @@ if (process.env.NOON_WASM_PROFILE === "dev"
     "export function createDirectOrdinarySuccessionSmokeRenderer(canvas: OffscreenCanvas): Promise<ExecutionCanvasRenderer>",
     "export function createDirectOrdinaryPaintPlaySmokeRenderer(canvas: OffscreenCanvas): Promise<ExecutionCanvasRenderer>",
     "export function createDirectOrdinaryStylePlaySmokeRenderer(canvas: OffscreenCanvas): Promise<ExecutionCanvasRenderer>",
+    "export function createDirectFilledPathTransformRenderer(canvas: OffscreenCanvas): Promise<ExecutionCanvasRenderer>",
+    "export function createDirectCreateShapesRenderer(canvas: OffscreenCanvas): Promise<ExecutionCanvasRenderer>",
+    "export function createDirectMorphStressRenderer(canvas: OffscreenCanvas): Promise<ExecutionCanvasRenderer>",
+
   );
 }
 

--- a/scripts/shared-authoring-smoke.mjs
+++ b/scripts/shared-authoring-smoke.mjs
@@ -764,6 +764,9 @@ try {
       expectedDuration: 4,
       endpointTime: null,
     },
+    { filename: "ordinary_filled_path_transform.py", objectCount: 1, expectedDuration: 3.2, endpointTime: null },
+    { filename: "ordinary_create_shapes.py", objectCount: 4, expectedDuration: 3.2, endpointTime: null },
+    { filename: "ordinary_morph_stress.py", objectCount: 96, expectedDuration: 3.4, endpointTime: null },
     {
       filename: "ordinary_composition_play.py",
       objectCount: 2,

--- a/web/python/examples/ordinary_create_shapes.py
+++ b/web/python/examples/ordinary_create_shapes.py
@@ -1,0 +1,14 @@
+"""Reveal endpoints, paired with the direct native Rust create_shapes example."""
+from noon import BLUE, PINK, WHITE, Circle, Create, Line, Path, Scene, Square, VectorPath
+
+
+class CreateShapes(Scene):
+    def construct(self):
+        circle = Circle(0.9).set_fill(BLUE, opacity=1).set_stroke(WHITE, width=5.5).move_to((-3, 1))
+        square = Square(1.7).set_fill(PINK, opacity=1).set_stroke(WHITE, width=5.5).move_to((0, 1))
+        line = Line((1.75, 1), (4.25, 1)).set_stroke(BLUE, width=5.5)
+        wave = Path(VectorPath().move_to((-2.4, -1.6)).cubic_to(
+            (-1.2, -2.6), (1.2, -0.6), (2.4, -1.6),
+        ), fill=None, stroke=PINK, stroke_width=5.0)
+        self.play(Create(circle), Create(square), Create(line), Create(wave),
+                  run_time=3.2, easing="ease_in_out_cubic")

--- a/web/python/examples/ordinary_filled_path_transform.py
+++ b/web/python/examples/ordinary_filled_path_transform.py
@@ -1,0 +1,35 @@
+"""Filled point morph, paired with the direct native Rust example."""
+import math
+from noon import BLUE, PURPLE, WHITE, DOWN, LEFT, RIGHT, UP, Path, Scene, Transform, Vec2, VectorPath
+
+def rounded_loop(radius: float) -> VectorPath:
+    handle = radius * 0.58
+    return (
+        VectorPath()
+        .move_to(UP * radius)
+        .cubic_to(Vec2(handle, radius), Vec2(radius, handle), RIGHT * radius)
+        .cubic_to(Vec2(radius, -handle), Vec2(handle, -radius), DOWN * radius)
+        .cubic_to(Vec2(-handle, -radius), Vec2(-radius, -handle), LEFT * radius)
+        .cubic_to(Vec2(-radius, handle), Vec2(-handle, radius), UP * radius)
+        .close()
+    )
+
+
+def five_point_star(outer_radius: float, inner_radius: float) -> VectorPath:
+    points = []
+    for index in range(10):
+        angle = math.pi / 2.0 - index * math.pi / 5.0
+        radius = outer_radius if index % 2 == 0 else inner_radius
+        points.append(Vec2(math.cos(angle) * radius, math.sin(angle) * radius))
+    path = VectorPath().move_to(points[0])
+    for point in points[1:]:
+        path.line_to(point)
+    return path.close()
+
+
+class FilledPathTransform(Scene):
+    def construct(self):
+        shape = Path(rounded_loop(1.35), fill=BLUE, stroke=WHITE, stroke_width=8.0)
+        target = Path(five_point_star(1.7, 0.7), fill=PURPLE, stroke=WHITE, stroke_width=8.0)
+        self.add(shape)
+        self.play(Transform(shape, target), run_time=3.2, easing="ease_in_out_cubic")

--- a/web/python/examples/ordinary_morph_stress.py
+++ b/web/python/examples/ordinary_morph_stress.py
@@ -1,0 +1,56 @@
+"""Paired with native morph_stress; context.object_count selects 12–10,000 paths."""
+import math
+from noon import (BLUE, TEAL, GREEN, YELLOW, ORANGE, RED, PINK, PURPLE,
+                  DOWN, LEFT, RIGHT, UP, Path, Scene, Transform, Vec2, VectorPath)
+
+def rounded_loop(radius: float) -> VectorPath:
+    handle = radius * 0.58
+    return (
+        VectorPath()
+        .move_to(UP * radius)
+        .cubic_to(Vec2(handle, radius), Vec2(radius, handle), RIGHT * radius)
+        .cubic_to(Vec2(radius, -handle), Vec2(handle, -radius), DOWN * radius)
+        .cubic_to(Vec2(-handle, -radius), Vec2(-radius, -handle), LEFT * radius)
+        .cubic_to(Vec2(-radius, handle), Vec2(-handle, radius), UP * radius)
+        .close()
+    )
+
+
+def five_point_star(outer_radius: float, inner_radius: float, phase: float = 0) -> VectorPath:
+    points = []
+    for index in range(10):
+        angle = phase + math.pi / 2.0 - index * math.pi / 5.0
+        radius = outer_radius if index % 2 == 0 else inner_radius
+        points.append(Vec2(math.cos(angle) * radius, math.sin(angle) * radius))
+    path = VectorPath().move_to(points[0])
+    for point in points[1:]:
+        path.line_to(point)
+    return path.close()
+
+
+class MorphStress(Scene):
+    def construct(self):
+        count = globals().get("context", {}).get("object_count", 96)
+        if isinstance(count, bool) or not isinstance(count, int) or not 12 <= count <= 10000:
+            raise ValueError("morph object count must be between 12 and 10000")
+        columns = math.ceil(math.sqrt(count * 1.5))
+        rows = math.ceil(count / columns)
+        dx, dy = 5.8 / max(columns - 1, 1), 3.8 / max(rows - 1, 1)
+        radius = min(dx, dy) * 0.37
+        width = max(radius * 0.24, 0.0025)
+        colors = (BLUE, TEAL, GREEN, YELLOW, ORANGE, RED, PINK, PURPLE)
+        source = rounded_loop(radius)
+        targets = []
+        for variant in range(12):
+            outer = radius * (1.18 + 0.08 * math.sin(variant * 1.7))
+            inner = outer * (0.42 + 0.05 * math.cos(variant * 0.9))
+            targets.append(five_point_star(outer, inner, variant / 12 * math.pi * 0.36))
+        animations = []
+        for index in range(count):
+            paint = dict(fill=None, stroke=colors[index % len(colors)], stroke_width=width * 100)
+            position = (-2.9 + index % columns * dx, 1.9 - index // columns * dy)
+            shape = Path(source, **paint).shift(position)
+            target = Path(targets[index % 12], **paint).shift(position)
+            self.add(shape)
+            animations.append(Transform(shape, target))
+        self.play(*animations, run_time=3.4, easing="ease_in_out_cubic")


### PR DESCRIPTION
Shared Rust Transform lowering rejected resource-backed path pairs, leaving the old CPython document route as the only way to run the filled-path renderer fixtures. This change resolves existing geometry resource handles during shared lowering and reuses the existing guarded path-pair compiler. Both prepared and published animation lowering support path pairs; ordinary semantic identity, completion, and dirty-frame behavior remain shared. This advances #959/#61 under Phase A (#953).

The renderer raster gate moves from CPython-generated documents to typed Rust execution sessions. Filled path Transform, Create shape endpoints, a 1,000-path morph workload, and 1,000 analytic objects now reach the same native/direct-WASM runtime and renderer. Existing direct execution and public/shared Python authoring suites retain general animation, lifecycle, composition, and geometry coverage; this is a replacement qualification corpus, not a claim of identical legacy fixture output.

Three executable native Rust examples and corresponding Python examples demonstrate the new fixture semantics. Python uses 96 morph objects for authoring qualification; native/browser rendering exercises 1,000 and 12 target variants. Native fixture tests check deterministic seek/forward agreement, clean repeated frames, and logical completion publishing target content/style while preserving semantic identity. Existing fill visibility/color, endpoint continuity, visible-pixel, and backend-parity thresholds are unchanged.

Ownership: fixture authoring is shared Rust semantic code; sessions use normal lowering/runtime/renderer paths. Debug WASM factories only bootstrap canvases. No engine boundary, scheduler, compatibility adapter, or migration seam is added. Workload setup is proportional to authored objects; repeated frames use the existing dirty runtime path. The existing explicit transport/recovery harness is retained for genuine codec tests. The legacy generator's remaining native integration test is still owned by #959 and will be retired separately.

Validation: `cargo fmt --all`; `bash scripts/check.sh architecture HEAD`; `node --check scripts/browser-smoke.mjs`; `node --check scripts/shared-authoring-smoke.mjs`; `node --check scripts/check-web-package.mjs`; Python AST parsing of the three examples; `git diff --check`. Current full CI is https://github.com/yongkyuns/noon/actions/runs/34303555990. Earlier runs exposed a fixture constructor mistake and the actual resource-path lowering gap; both were corrected. Local Rust/browser compilation and `scripts/check.sh full` were not run because the local disk is exhausted; full hosted Rust, package, browser, parity, and authoring gates must pass before merge.

Merged as d20463c878ee59a92c26de3b182feaf463575cb4 after full CI and every applicable PR check passed at d385bfddceffb41844a00a2e47096b3d29b693d0, including mobile WebKit. Typed renderer fixtures present their initial publication before seeking.
