### PR TITLE
refactor: separate ordinary authoring from explicit integration (#1272 R2)

### DIFF
--- a/.github/ci/README.md
+++ b/.github/ci/README.md
@@ -1,7 +1,7 @@
 # CI evidence tooling
 
-Implementation tooling for #1265, not another architecture or roadmap. The engine
-contract remains `docs/architecture.md`.
+Development qualification and CI evidence tooling, not another architecture or
+roadmap. The engine contract remains `docs/architecture.md`.
 
 ## Local architecture and iteration gate
 
@@ -88,6 +88,28 @@ clean/staged/untracked edit-to-result timings. Record checkout, toolchain, comma
 candidate and cache state when comparing development latency. Fixture times measure
 guard feedback, not Rust recompilation or a claimed speedup. Cold/warm compiler and
 mixed-change measurements remain #1265 work; no checks are omitted to claim faster CI.
+
+### Public facade qualification
+
+The R2 public-surface checks reuse `fixtures/provider-consumer` rather than adding
+another harness. Its `public_facade` target tests ordinary construction, authored
+versus effective observations, coherent live edits/completion, and typed rejection
+of stale publication after explicitly opted-in raw integration. Provider CI runs
+the consumer in native cells and compile-checks it in WASM cells. Only the
+minimal/native cell additionally runs the facade's compile-fail documentation and
+the paired `shared_authoring` Rust example:
+
+```sh
+cargo test --manifest-path fixtures/provider-consumer/Cargo.toml --test public_facade
+cargo test -p noon --no-default-features --doc
+cargo run -p noon --no-default-features --example shared_authoring
+```
+
+WASM compilation is not browser execution; existing product/browser and paired
+Python tests still qualify the host path. See the consumer README for the public
+versus integration boundary and the unchanged historical geometry-cost workload.
+These tests do not claim all authoring error producers or Python exception mapping
+have been converted; remaining R2 ownership stays with #958/#61.
 
 ## Completed-attempt timings
 

--- a/.github/workflows/provider-features.yml
+++ b/.github/workflows/provider-features.yml
@@ -84,6 +84,11 @@ jobs:
           --config '${{ matrix.config }}'
           --target '${{ matrix.target }}'
           --output '${{ runner.temp }}/provider-results'
+      - name: Qualify the minimal public facade documentation and example
+        if: matrix.config == 'minimal' && matrix.target == 'x86_64-unknown-linux-gnu'
+        run: |
+          cargo test -p noon --no-default-features --doc
+          cargo run -p noon --no-default-features --example shared_authoring
       - name: Publish evidence
         if: always()
         uses: actions/upload-artifact@v7

--- a/README.md
+++ b/README.md
@@ -83,7 +83,33 @@ assert_eq!(session.frame().objects.len(), 2);
 
 Constructors are scene-bound factories, `Scene::add` attaches the existing node, and handle queries return errors for stale identities. Copies allocate independent nodes in the same store. See [`shared_authoring.rs`](crates/noon/examples/shared_authoring.rs) for typed lowering and runtime execution.
 
-The older fluent snapshot authoring API is available explicitly through `noon::legacy`, including `noon::legacy::prelude`; it is migration code owned for deletion by #959. Its advanced animation examples have not yet all moved to the canonical public API. Initial membership changes prepare subsequent sessions; they do not implicitly mutate an already running session.
+### Ordinary API versus integration
+
+The crate root and `noon::prelude` deliberately export authoring handles, values,
+live operations, completion and errors. Implementation modules and blanket
+lower-layer exports are not public authoring APIs. `noon::integration` explicitly
+exposes the raw semantic/resource types and host/callback/renderer plumbing needed
+by adapters. `noon::diagnostics` is feature-gated debug/export access. None of these
+namespaces introduces another scene, runtime, scheduler or integration crate.
+
+`Scene::revision()` reads the authored revision without mutable arena access.
+`Scene::geometry(ManimGeometryOptions)` constructs a detached specialized shape;
+after lowering, use `LiveSession::create_manim_geometry` instead. The
+[`shared_authoring` example](crates/noon/examples/shared_authoring.rs) shows
+construction, authored/effective queries, live edits and two logical completions
+using only ordinary public APIs. It is the direct Rust counterpart of
+[`live_affine_completion.py`](web/python/examples/live_affine_completion.py), which
+remains in the browser authoring qualification suite.
+
+Raw integration is deliberately named: `Scene::with_integration_store` accepts a
+shared arena; `Scene`, `Mobject` and `MobjectFamily` expose it through
+`integration_store()`. This is not a snapshot or a live-mutation shortcut. Release
+RefCell borrows before calling authoring/session APIs. Edits made outside coherent
+publication can stale the existing session; its identity/revision checks still
+reject them. A consumer that already made such an edit must explicitly discard
+and rebuild that session, not alter its revision bookkeeping. No old-name aliases
+are retained. The `RetainedScene` text adapter in `noon::integration` remains a
+transport-consumer facility owned for deletion by #959, not the ordinary Scene API.
 
 After creating a session, use `scene.live(&mut session)` for shared property edits, append-compatible membership changes, predeclared affine animations, and replacement with content already owned by the semantic store. Property and structural edits use `ExecutionSession::apply_semantic_transaction` to prepare semantic changes and typed execution publication together, so a failed edit leaves authored and live states unchanged.
 

--- a/crates/noon-native/src/execution_source.rs
+++ b/crates/noon-native/src/execution_source.rs
@@ -1,6 +1,6 @@
+use noon::integration::{ExecutionViewportQuery, RendererPublication, TimelineWakeState};
 use noon::{
-    ExecutionSession, ExecutionViewportQuery, LiveContinuation, LiveProgram, LiveProgramStatus,
-    RendererPublication, RustHostCallbackTable, TimelineWakeState,
+    ExecutionSession, LiveContinuation, LiveProgram, LiveProgramStatus, RustHostCallbackTable,
 };
 use noon_core::{
     Camera2DState, NativeEventOccurrence, NativeInputValue, NativeStateSource, PublicationContext,

--- a/crates/noon-native/src/lib.rs
+++ b/crates/noon-native/src/lib.rs
@@ -12,10 +12,10 @@ mod execution_source;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use noon::integration::{RendererPublication, TimelineWakeState};
 use noon::{
     EvaluationError, ExecutionSession, ExecutionSessionCameraError, ExecutionSessionInputError,
-    LiveContinuation, LiveProgram, RendererPublication, RustHostCallbackError,
-    RustHostCallbackTable, TimelineWakeState,
+    LiveContinuation, LiveProgram, RustHostCallbackError, RustHostCallbackTable,
 };
 use noon_core::{
     Camera2DState, NativeEventOccurrence, NativeEventSource, NativeInputValue, NativeStateSource,
@@ -1220,7 +1220,8 @@ mod tests {
         use std::cell::Cell;
         use std::rc::Rc;
 
-        use noon::{HostCallbackId, RustHostCallbackTable};
+        use noon::RustHostCallbackTable;
+        use noon_core::HostCallbackId;
         use noon_core::{
             SemanticMutationTransaction, SemanticObjectState, SemanticStore, StoredGeometry,
         };
@@ -1272,7 +1273,8 @@ mod tests {
 
     #[test]
     fn native_callback_completion_reanchors_the_next_authored_interval() {
-        use noon::{HostCallbackId, RustHostCallbackTable};
+        use noon::RustHostCallbackTable;
+        use noon_core::HostCallbackId;
         use noon_core::{
             AnimationOptions, RateFunction, SemanticMutationTransaction, SemanticObjectState,
             SemanticStore, SemanticVec3, StoredGeometry,

--- a/crates/noon-web/src/authoring_geometry.rs
+++ b/crates/noon-web/src/authoring_geometry.rs
@@ -312,7 +312,7 @@ pub struct WasmAuthoringVectorPath {
 }
 
 fn point(x: f64, y: f64) -> Result<Vec2, JsValue> {
-    let value = noon::semantic_mobject::authoring_xy_f64(x, y).map_err(js_error)?;
+    let value = noon::integration::authoring_xy_f64(x, y).map_err(js_error)?;
     Ok(Vec2::new(value.x as f32, value.y as f32))
 }
 

--- a/crates/noon-web/src/authoring_mobject.rs
+++ b/crates/noon-web/src/authoring_mobject.rs
@@ -1,6 +1,6 @@
 #[cfg(target_arch = "wasm32")]
-use noon::semantic_mobject::authoring_render_f64 as render_f64;
-pub use noon::semantic_mobject::{ManimNextToArgs, Mobject};
+use noon::integration::authoring_render_f64 as render_f64;
+pub use noon::{ManimNextToArgs, Mobject};
 #[cfg(target_arch = "wasm32")]
 use noon_core::SemanticNodeId;
 #[cfg(any(target_arch = "wasm32", test))]
@@ -234,7 +234,7 @@ mod wasm {
                 .next_to_aligned(
                     noon::FamilyLayoutTarget::Anchor(&target.anchor),
                     &aligner.anchor,
-                    noon::semantic_mobject::ManimNextToArgs {
+                    noon::ManimNextToArgs {
                         direction: (direction_x, direction_y),
                         buff,
                         aligned_edge: (edge_x, edge_y),
@@ -262,7 +262,7 @@ mod wasm {
                 .next_to_aligned(
                     noon::FamilyLayoutTarget::Point(x, y),
                     &aligner.anchor,
-                    noon::semantic_mobject::ManimNextToArgs {
+                    noon::ManimNextToArgs {
                         direction: (direction_x, direction_y),
                         buff,
                         aligned_edge: (edge_x, edge_y),
@@ -467,7 +467,7 @@ mod wasm {
     impl WasmAuthoringFamilyHandle {
         pub(crate) fn from_semantic_family(family: noon::MobjectFamily) -> Self {
             Self {
-                semantics: Rc::clone(family.store()),
+                semantics: Rc::clone(family.integration_store()),
                 id: family.node_id(),
             }
         }
@@ -691,7 +691,7 @@ mod wasm {
             semantics: &SharedSemanticStore,
             context: &str,
         ) -> Result<SemanticNodeId, JsValue> {
-            if !Rc::ptr_eq(semantics, self.handle.store()) {
+            if !Rc::ptr_eq(semantics, self.handle.integration_store()) {
                 return Err(js_error(format!(
                     "{context} and mobject belong to different authoring stores"
                 )));
@@ -1546,7 +1546,7 @@ mod tests {
     #[test]
     fn wire_projection_matches_typed_runtime_after_shared_edits() {
         let mut scene = noon::Scene::new();
-        let authoring_store = std::rc::Rc::clone(scene.store());
+        let authoring_store = std::rc::Rc::clone(scene.integration_store());
         let mut options = ManimGeometryOptions::rectangle(2.0, 1.0).unwrap();
         options.set_fill(0.2, 0.3, 0.4, 0.5).unwrap();
         options.set_stroke(0.6, 0.7, 0.8, 0.9).unwrap();

--- a/crates/noon-web/src/canonical_authoring_scene.rs
+++ b/crates/noon-web/src/canonical_authoring_scene.rs
@@ -234,7 +234,7 @@ impl CanonicalAuthoringScene {
     pub fn with_store(
         semantics: std::rc::Rc<std::cell::RefCell<noon_core::SemanticStore>>,
     ) -> Self {
-        let scene = noon::Scene::with_store(semantics);
+        let scene = noon::Scene::with_integration_store(semantics);
         Self {
             scene,
             bindings: BTreeMap::new(),
@@ -274,7 +274,7 @@ impl CanonicalAuthoringScene {
     #[cfg(test)]
     fn members(&self) -> Result<Vec<noon_core::SemanticNodeId>, String> {
         self.scene
-            .store()
+            .integration_store()
             .borrow()
             .node(self.scene.root())
             .map(|node| node.members().to_vec())
@@ -343,14 +343,14 @@ impl CanonicalAuthoringScene {
             return player.live_edit_updaters(transaction);
         }
         transaction
-            .apply(&mut self.scene.store().borrow_mut())
+            .apply(&mut self.scene.integration_store().borrow_mut())
             .map(|_| ())
             .map_err(|error| error.to_string())
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
     fn require_updater_target(&self, handle: &noon::Mobject) -> Result<(), String> {
-        if !std::rc::Rc::ptr_eq(self.scene.store(), handle.store()) {
+        if !std::rc::Rc::ptr_eq(self.scene.integration_store(), handle.integration_store()) {
             return Err("mobject belongs to another authoring store".into());
         }
         handle.validate()?;
@@ -385,7 +385,7 @@ impl CanonicalAuthoringScene {
     ) -> Result<crate::SemanticExecutionPlayer, String> {
         crate::SemanticExecutionPlayer::from_live_session(
             self.lower_execution()?,
-            std::rc::Rc::clone(self.scene.store()),
+            std::rc::Rc::clone(self.scene.integration_store()),
             self.scene.root(),
             duration,
             transport_session,
@@ -398,13 +398,13 @@ impl CanonicalAuthoringScene {
     #[cfg(any(target_arch = "wasm32", test))]
     fn prepare_local_player_for_run(&mut self) -> Result<(), String> {
         self.player_ownership
-            .prepare_for_run(self.scene.store().borrow().scene_revision())
+            .prepare_for_run(self.scene.integration_store().borrow().scene_revision())
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
     fn returned_player_is_stale(&self) -> bool {
         self.player_ownership
-            .returned_is_stale(self.scene.store().borrow().scene_revision())
+            .returned_is_stale(self.scene.integration_store().borrow().scene_revision())
     }
 
     /// Begin an explicit authoring-run publication boundary.
@@ -462,7 +462,7 @@ impl CanonicalAuthoringScene {
         if self.player_ownership.is_transferred() {
             return Err("live execution session is running in the semantic engine".into());
         }
-        if !std::rc::Rc::ptr_eq(self.scene.store(), handle.store()) {
+        if !std::rc::Rc::ptr_eq(self.scene.integration_store(), handle.integration_store()) {
             return Err("mobject belongs to another authoring store".into());
         }
         handle.validate()?;
@@ -540,7 +540,7 @@ impl CanonicalAuthoringScene {
         if self.player_ownership.is_transferred() {
             return Err("live execution session is running in the semantic engine".into());
         }
-        if !std::rc::Rc::ptr_eq(self.scene.store(), handle.store()) {
+        if !std::rc::Rc::ptr_eq(self.scene.integration_store(), handle.integration_store()) {
             return Err("mobject belongs to another authoring store".into());
         }
         handle.validate()?;
@@ -824,7 +824,7 @@ impl CanonicalAuthoringScene {
     /// FadeOut without storing lifecycle state or adding metadata to the player receipt.
     #[cfg(any(target_arch = "wasm32", test))]
     fn live_contains_mobject(&mut self, target: &noon::Mobject) -> Result<bool, String> {
-        if !std::rc::Rc::ptr_eq(self.scene.store(), target.store()) {
+        if !std::rc::Rc::ptr_eq(self.scene.integration_store(), target.integration_store()) {
             return Err("mobject belongs to another authoring store".into());
         }
         target.validate()?;
@@ -882,7 +882,7 @@ impl CanonicalAuthoringScene {
             .live_handoff_duration()
             .unwrap_or_else(|| self.scene.time())
             .max(options.run_time.unwrap_or(1.0));
-        if !std::rc::Rc::ptr_eq(self.scene.store(), target.store()) {
+        if !std::rc::Rc::ptr_eq(self.scene.integration_store(), target.integration_store()) {
             return Err(
                 "ordinary affine lifecycle mobject belongs to another authoring store".into(),
             );
@@ -1373,14 +1373,14 @@ impl CanonicalAuthoringScene {
                     target,
                     options,
                 } => {
-                    if !tracker.is_in_store(self.scene.store()) {
+                    if !tracker.is_in_store(self.scene.integration_store()) {
                         return Err(
                             "ordinary composition ValueTracker belongs to another authoring store"
                                 .into(),
                         );
                     }
                     self.scene
-                        .store()
+                        .integration_store()
                         .borrow()
                         .semantic_signal_state(tracker.node_id())
                         .map_err(|error| error.to_string())?;
@@ -1403,7 +1403,10 @@ impl CanonicalAuthoringScene {
                     options,
                     ..
                 } => {
-                    if !std::rc::Rc::ptr_eq(self.scene.store(), target.store()) {
+                    if !std::rc::Rc::ptr_eq(
+                        self.scene.integration_store(),
+                        target.integration_store(),
+                    ) {
                         return Err(
                             "ordinary subset-display family belongs to another authoring store"
                                 .into(),
@@ -1412,7 +1415,7 @@ impl CanonicalAuthoringScene {
                     target.validate()?;
                     let direct_members = self
                         .scene
-                        .store()
+                        .integration_store()
                         .borrow()
                         .semantic_family_members_checked(target.node_id())
                         .map_err(|error| error.to_string())?
@@ -1436,7 +1439,10 @@ impl CanonicalAuthoringScene {
                     )
                     .map_err(|error| error.to_string())?;
                     for (id, member) in entering {
-                        if !std::rc::Rc::ptr_eq(self.scene.store(), member.store()) {
+                        if !std::rc::Rc::ptr_eq(
+                            self.scene.integration_store(),
+                            member.integration_store(),
+                        ) {
                             return Err(
                                 "ordinary subset-display member belongs to another authoring store"
                                     .into(),
@@ -1473,7 +1479,10 @@ impl CanonicalAuthoringScene {
                     options,
                     ..
                 } => {
-                    if !std::rc::Rc::ptr_eq(self.scene.store(), target.store()) {
+                    if !std::rc::Rc::ptr_eq(
+                        self.scene.integration_store(),
+                        target.integration_store(),
+                    ) {
                         return Err(
                             "ordinary family animation belongs to another authoring store".into(),
                         );
@@ -1481,7 +1490,7 @@ impl CanonicalAuthoringScene {
                     target.validate()?;
                     let family_leaves = self
                         .scene
-                        .store()
+                        .integration_store()
                         .borrow()
                         .ordered_leaf_nodes(target.node_id())
                         .map_err(|e| e.to_string())?;
@@ -1517,7 +1526,10 @@ impl CanonicalAuthoringScene {
                     )
                     .map_err(|error| error.to_string())?;
                     for (id, member) in entering {
-                        if !std::rc::Rc::ptr_eq(self.scene.store(), member.store()) {
+                        if !std::rc::Rc::ptr_eq(
+                            self.scene.integration_store(),
+                            member.integration_store(),
+                        ) {
                             return Err(
                                 "ordinary family member belongs to another authoring store".into(),
                             );
@@ -1539,7 +1551,10 @@ impl CanonicalAuthoringScene {
                     options,
                     ..
                 } => {
-                    if !std::rc::Rc::ptr_eq(self.scene.store(), target.store()) {
+                    if !std::rc::Rc::ptr_eq(
+                        self.scene.integration_store(),
+                        target.integration_store(),
+                    ) {
                         return Err(
                             "ordinary family DrawBorderThenFill belongs to another authoring store"
                                 .into(),
@@ -1548,7 +1563,7 @@ impl CanonicalAuthoringScene {
                     target.validate()?;
                     let family_leaves = self
                         .scene
-                        .store()
+                        .integration_store()
                         .borrow()
                         .ordered_leaf_nodes(target.node_id())
                         .map_err(|e| e.to_string())?;
@@ -1571,7 +1586,10 @@ impl CanonicalAuthoringScene {
                     )
                     .map_err(|error| error.to_string())?;
                     for (id, member) in entering {
-                        if !std::rc::Rc::ptr_eq(self.scene.store(), member.store()) {
+                        if !std::rc::Rc::ptr_eq(
+                            self.scene.integration_store(),
+                            member.integration_store(),
+                        ) {
                             return Err("ordinary family DrawBorderThenFill member belongs to another authoring store".into());
                         }
                         member.validate()?;
@@ -1590,9 +1608,13 @@ impl CanonicalAuthoringScene {
                     target_state,
                     options,
                 } => {
-                    if !std::rc::Rc::ptr_eq(self.scene.store(), source.store())
-                        || !std::rc::Rc::ptr_eq(self.scene.store(), target_state.store())
-                    {
+                    if !std::rc::Rc::ptr_eq(
+                        self.scene.integration_store(),
+                        source.integration_store(),
+                    ) || !std::rc::Rc::ptr_eq(
+                        self.scene.integration_store(),
+                        target_state.integration_store(),
+                    ) {
                         return Err(
                             "ordinary family Transform belongs to another authoring store".into(),
                         );
@@ -1610,7 +1632,10 @@ impl CanonicalAuthoringScene {
                 OrdinaryCompositionChild::FamilyIndicate {
                     target, options, ..
                 } => {
-                    if !std::rc::Rc::ptr_eq(self.scene.store(), target.store()) {
+                    if !std::rc::Rc::ptr_eq(
+                        self.scene.integration_store(),
+                        target.integration_store(),
+                    ) {
                         return Err(
                             "ordinary family Indicate belongs to another authoring store".into(),
                         );
@@ -1643,7 +1668,10 @@ impl CanonicalAuthoringScene {
                     options,
                     ..
                 } => {
-                    if !std::rc::Rc::ptr_eq(self.scene.store(), target.store()) {
+                    if !std::rc::Rc::ptr_eq(
+                        self.scene.integration_store(),
+                        target.integration_store(),
+                    ) {
                         return Err(
                             "ordinary composition target belongs to another authoring store".into(),
                         );
@@ -1723,7 +1751,7 @@ impl CanonicalAuthoringScene {
                     ..
                 } => (*entering_id, target, *options),
             };
-            if !std::rc::Rc::ptr_eq(self.scene.store(), target.store()) {
+            if !std::rc::Rc::ptr_eq(self.scene.integration_store(), target.integration_store()) {
                 return Err(
                     "ordinary composition target belongs to another authoring store".into(),
                 );
@@ -1783,7 +1811,7 @@ impl CanonicalAuthoringScene {
 
     #[cfg(any(target_arch = "wasm32", test))]
     fn live_target_editor(&mut self, source: &noon::Mobject) -> Result<noon::Mobject, String> {
-        if !std::rc::Rc::ptr_eq(self.scene.store(), source.store()) {
+        if !std::rc::Rc::ptr_eq(self.scene.integration_store(), source.integration_store()) {
             return Err("mobject belongs to another authoring store".into());
         }
         source.validate()?;
@@ -1852,7 +1880,7 @@ impl CanonicalAuthoringScene {
         &mut self,
         family: &noon::MobjectFamily,
     ) -> Result<(), String> {
-        if !std::rc::Rc::ptr_eq(self.scene.store(), family.store()) {
+        if !std::rc::Rc::ptr_eq(self.scene.integration_store(), family.integration_store()) {
             return Err("subset-display family belongs to another authoring store".into());
         }
         match &mut self.player_ownership {
@@ -1874,7 +1902,7 @@ impl CanonicalAuthoringScene {
         options: noon::ManimBecomeOptions,
     ) -> Result<(), String> {
         for object in [target, other] {
-            if !std::rc::Rc::ptr_eq(self.scene.store(), object.store()) {
+            if !std::rc::Rc::ptr_eq(self.scene.integration_store(), object.integration_store()) {
                 return Err(
                     "become objects and canonical context belong to different authoring stores"
                         .into(),
@@ -1974,7 +2002,7 @@ impl CanonicalAuthoringScene {
         let mut seen_ids = BTreeSet::new();
         let mut seen_nodes = BTreeSet::new();
         for (wrapper_id, handle) in &batch.bindings {
-            if !std::rc::Rc::ptr_eq(self.scene.store(), handle.store()) {
+            if !std::rc::Rc::ptr_eq(self.scene.integration_store(), handle.integration_store()) {
                 return Err("membership mobject belongs to another authoring store".into());
             }
             handle.validate()?;
@@ -2005,7 +2033,10 @@ impl CanonicalAuthoringScene {
         for member in &batch.members {
             match member {
                 OwnedSceneMembershipMember::Mobject { wrapper_id, handle } => {
-                    if !std::rc::Rc::ptr_eq(self.scene.store(), handle.store()) {
+                    if !std::rc::Rc::ptr_eq(
+                        self.scene.integration_store(),
+                        handle.integration_store(),
+                    ) {
                         return Err("membership mobject belongs to another authoring store".into());
                     }
                     handle.validate()?;
@@ -2030,7 +2061,10 @@ impl CanonicalAuthoringScene {
                     borrowed.push(noon::MobjectFamilyMember::Mobject(handle));
                 }
                 OwnedSceneMembershipMember::Family(family) => {
-                    if !std::rc::Rc::ptr_eq(self.scene.store(), family.store()) {
+                    if !std::rc::Rc::ptr_eq(
+                        self.scene.integration_store(),
+                        family.integration_store(),
+                    ) {
                         return Err("membership family belongs to another authoring store".into());
                     }
                     family.validate()?;
@@ -2087,7 +2121,7 @@ impl CanonicalAuthoringScene {
     #[cfg(any(target_arch = "wasm32", test))]
     fn root_membership_keys(&self) -> Result<Vec<String>, String> {
         self.scene
-            .store()
+            .integration_store()
             .borrow()
             .semantic_family_members_checked(self.scene.root())
             .map(|members| {
@@ -2101,12 +2135,12 @@ impl CanonicalAuthoringScene {
 
     #[cfg(any(target_arch = "wasm32", test))]
     fn contains_mobject(&self, target: &noon::Mobject) -> Result<bool, String> {
-        if !std::rc::Rc::ptr_eq(self.scene.store(), target.store()) {
+        if !std::rc::Rc::ptr_eq(self.scene.integration_store(), target.integration_store()) {
             return Err("mobject belongs to another authoring store".into());
         }
         target.validate()?;
         noon_core::semantic_scene_root_contains(
-            &self.scene.store().borrow(),
+            &self.scene.integration_store().borrow(),
             self.scene.root(),
             target.node_id(),
         )
@@ -2115,7 +2149,7 @@ impl CanonicalAuthoringScene {
 
     #[cfg(any(target_arch = "wasm32", test))]
     fn live_remove_mobject(&mut self, handle: &noon::Mobject) -> Result<(), String> {
-        if !std::rc::Rc::ptr_eq(self.scene.store(), handle.store()) {
+        if !std::rc::Rc::ptr_eq(self.scene.integration_store(), handle.integration_store()) {
             return Err("mobject belongs to another authoring store".into());
         }
         let node = handle.node_id();
@@ -2139,8 +2173,8 @@ impl CanonicalAuthoringScene {
         target: &noon::Mobject,
         source: &noon::Mobject,
     ) -> Result<(), String> {
-        if !std::rc::Rc::ptr_eq(self.scene.store(), target.store())
-            || !std::rc::Rc::ptr_eq(self.scene.store(), source.store())
+        if !std::rc::Rc::ptr_eq(self.scene.integration_store(), target.integration_store())
+            || !std::rc::Rc::ptr_eq(self.scene.integration_store(), source.integration_store())
         {
             return Err("mobject belongs to another authoring store".into());
         }
@@ -2188,8 +2222,11 @@ impl CanonicalAuthoringScene {
         &self,
         player: &crate::SemanticExecutionPlayer,
     ) -> Result<(), PlayerReturnError> {
-        self.player_ownership
-            .validate_return(player, self.scene.store(), self.scene.root())
+        self.player_ownership.validate_return(
+            player,
+            self.scene.integration_store(),
+            self.scene.root(),
+        )
     }
 
     /// Resume the exact returned player for a newly-authored continuation segment.
@@ -3339,7 +3376,10 @@ mod wasm {
                     "family entering member must follow FamilyDrawBorderThenFill",
                 ));
             };
-            if !std::rc::Rc::ptr_eq(target.store(), member.semantic_mobject().store()) {
+            if !std::rc::Rc::ptr_eq(
+                target.integration_store(),
+                member.semantic_mobject().integration_store(),
+            ) {
                 return Err(js_error(
                     "family entering member belongs to another authoring store",
                 ));
@@ -3388,7 +3428,10 @@ mod wasm {
                     "family entering member must follow FamilySubsetDisplay",
                 ));
             };
-            if !std::rc::Rc::ptr_eq(target.store(), member.semantic_mobject().store()) {
+            if !std::rc::Rc::ptr_eq(
+                target.integration_store(),
+                member.semantic_mobject().integration_store(),
+            ) {
                 return Err(js_error(
                     "family entering member belongs to another authoring store",
                 ));
@@ -3476,7 +3519,10 @@ mod wasm {
                     "family entering member must follow FamilyTextWrite",
                 ));
             };
-            if !std::rc::Rc::ptr_eq(target.store(), member.semantic_mobject().store()) {
+            if !std::rc::Rc::ptr_eq(
+                target.integration_store(),
+                member.semantic_mobject().integration_store(),
+            ) {
                 return Err(js_error(
                     "Text family entering member belongs to another authoring store",
                 ));
@@ -3574,7 +3620,10 @@ mod wasm {
             else {
                 return Err(js_error("family entering member must follow FamilyReveal"));
             };
-            if !std::rc::Rc::ptr_eq(target.store(), member.semantic_mobject().store()) {
+            if !std::rc::Rc::ptr_eq(
+                target.integration_store(),
+                member.semantic_mobject().integration_store(),
+            ) {
                 return Err(js_error(
                     "family reveal member belongs to another authoring store",
                 ));
@@ -3669,7 +3718,10 @@ mod wasm {
             else {
                 return Err(js_error("family entering member must follow FamilyFade"));
             };
-            if !std::rc::Rc::ptr_eq(target.store(), member.semantic_mobject().store()) {
+            if !std::rc::Rc::ptr_eq(
+                target.integration_store(),
+                member.semantic_mobject().integration_store(),
+            ) {
                 return Err(js_error(
                     "fade family entering member belongs to another authoring store",
                 ));
@@ -3926,7 +3978,10 @@ mod wasm {
             &self,
             target: &crate::WasmAuthoringMobjectHandle,
         ) -> Result<bool, JsValue> {
-            target.id_in_store(self.inner.scene.store(), "scene membership query")?;
+            target.id_in_store(
+                self.inner.scene.integration_store(),
+                "scene membership query",
+            )?;
             self.inner
                 .contains_mobject(target.semantic_mobject())
                 .map_err(js_error)
@@ -3946,7 +4001,7 @@ mod wasm {
             pivot_x: f64,
             pivot_y: f64,
         ) -> Result<WasmCallbackTransform, JsValue> {
-            let transform = noon::rotate_effective_transform_about_point(
+            let transform = noon::integration::rotate_effective_transform_about_point(
                 Transform2D {
                     translation: Vec2::new(translation_x as f32, translation_y as f32),
                     rotation: rotation as f32,
@@ -3988,7 +4043,7 @@ mod wasm {
                 )?,
             );
             Ok(callback_paint_result(
-                noon::effective_style_with_color(style, red, green, blue, alpha)
+                noon::integration::effective_style_with_color(style, red, green, blue, alpha)
                     .map_err(js_error)?,
             ))
         }
@@ -4030,21 +4085,23 @@ mod wasm {
             )?;
             let style = callback_paint_style(fill, stroke);
             let style = match (color, opacity) {
-                (Some(color), Some(opacity)) => noon::effective_style_with_fill(
+                (Some(color), Some(opacity)) => noon::integration::effective_style_with_fill(
                     style,
                     f64::from(color.red),
                     f64::from(color.green),
                     f64::from(color.blue),
                     opacity,
                 ),
-                (Some(color), None) => noon::effective_style_with_fill_color(
+                (Some(color), None) => noon::integration::effective_style_with_fill_color(
                     style,
                     f64::from(color.red),
                     f64::from(color.green),
                     f64::from(color.blue),
                     f64::from(color.alpha),
                 ),
-                (None, Some(opacity)) => noon::effective_style_with_fill_opacity(style, opacity),
+                (None, Some(opacity)) => {
+                    noon::integration::effective_style_with_fill_opacity(style, opacity)
+                }
                 (None, None) => Ok(style),
             }
             .map_err(js_error)?;
@@ -4080,7 +4137,7 @@ mod wasm {
                 )?,
             );
             Ok(callback_paint_result(
-                noon::effective_style_with_stroke_color(
+                noon::integration::effective_style_with_stroke_color(
                     style,
                     color_red,
                     color_green,
@@ -4114,7 +4171,7 @@ mod wasm {
             Ok(WasmCallbackLineTarget {
                 start: point("start", start_x, start_y)?,
                 end: point("end", end_x, end_y)?,
-                store: std::rc::Rc::clone(self.inner.scene.store()),
+                store: std::rc::Rc::clone(self.inner.scene.integration_store()),
             })
         }
 
@@ -4124,8 +4181,11 @@ mod wasm {
             source: &crate::WasmAuthoringMobjectHandle,
             target: &WasmCallbackLineTarget,
         ) -> Result<WasmCallbackTransform, JsValue> {
-            source.id_in_store(self.inner.scene.store(), "Line.match_points source")?;
-            if !std::rc::Rc::ptr_eq(self.inner.scene.store(), &target.store) {
+            source.id_in_store(
+                self.inner.scene.integration_store(),
+                "Line.match_points source",
+            )?;
+            if !std::rc::Rc::ptr_eq(self.inner.scene.integration_store(), &target.store) {
                 return Err(js_error(
                     "Line.match_points target belongs to another callback context",
                 ));
@@ -4170,7 +4230,7 @@ mod wasm {
             let tracker = self.inner.create_value_tracker(initial).map_err(js_error)?;
             Ok(WasmValueTrackerHandle::from_tracker(
                 tracker,
-                std::rc::Rc::clone(self.inner.scene.store()),
+                std::rc::Rc::clone(self.inner.scene.integration_store()),
             ))
         }
 
@@ -4179,7 +4239,7 @@ mod wasm {
             &mut self,
             tracker: &WasmValueTrackerHandle,
         ) -> Result<(), JsValue> {
-            let tracker = tracker.tracker_in(self.inner.scene.store())?;
+            let tracker = tracker.tracker_in(self.inner.scene.integration_store())?;
             self.inner
                 .associate_value_tracker(tracker)
                 .map_err(js_error)
@@ -4190,7 +4250,7 @@ mod wasm {
             let signal = self.inner.pointer_position_signal().map_err(js_error)?;
             Ok(WasmNativeVectorSignalHandle {
                 signal,
-                store: std::rc::Rc::clone(self.inner.scene.store()),
+                store: std::rc::Rc::clone(self.inner.scene.integration_store()),
             })
         }
 
@@ -4199,7 +4259,7 @@ mod wasm {
             let signal = self.inner.viewport_size_signal().map_err(js_error)?;
             Ok(WasmNativeVectorSignalHandle {
                 signal,
-                store: std::rc::Rc::clone(self.inner.scene.store()),
+                store: std::rc::Rc::clone(self.inner.scene.integration_store()),
             })
         }
 
@@ -4208,7 +4268,7 @@ mod wasm {
             let signal = self.inner.wheel_delta_signal().map_err(js_error)?;
             Ok(WasmNativeVectorSignalHandle {
                 signal,
-                store: std::rc::Rc::clone(self.inner.scene.store()),
+                store: std::rc::Rc::clone(self.inner.scene.integration_store()),
             })
         }
 
@@ -4224,7 +4284,7 @@ mod wasm {
                 .map_err(js_error)?;
             Ok(WasmNativeBoolSignalHandle {
                 signal,
-                store: std::rc::Rc::clone(self.inner.scene.store()),
+                store: std::rc::Rc::clone(self.inner.scene.integration_store()),
             })
         }
 
@@ -4237,7 +4297,7 @@ mod wasm {
             let tracker = self.inner.control_signal(name, initial).map_err(js_error)?;
             Ok(WasmValueTrackerHandle {
                 tracker,
-                store: std::rc::Rc::clone(self.inner.scene.store()),
+                store: std::rc::Rc::clone(self.inner.scene.integration_store()),
             })
         }
 
@@ -4252,7 +4312,7 @@ mod wasm {
                 .map_err(js_error)?;
             Ok(WasmValueTrackerHandle {
                 tracker,
-                store: std::rc::Rc::clone(self.inner.scene.store()),
+                store: std::rc::Rc::clone(self.inner.scene.integration_store()),
             })
         }
 
@@ -4261,7 +4321,7 @@ mod wasm {
             let tracker = self.inner.wheel_events().map_err(js_error)?;
             Ok(WasmValueTrackerHandle {
                 tracker,
-                store: std::rc::Rc::clone(self.inner.scene.store()),
+                store: std::rc::Rc::clone(self.inner.scene.integration_store()),
             })
         }
 
@@ -4273,7 +4333,7 @@ mod wasm {
             let tracker = self.inner.control_commit_events(name).map_err(js_error)?;
             Ok(WasmValueTrackerHandle {
                 tracker,
-                store: std::rc::Rc::clone(self.inner.scene.store()),
+                store: std::rc::Rc::clone(self.inner.scene.integration_store()),
             })
         }
 
@@ -4283,8 +4343,11 @@ mod wasm {
             object: &crate::WasmAuthoringMobjectHandle,
             signal: &WasmNativeVectorSignalHandle,
         ) -> Result<(), JsValue> {
-            object.id_in_store(self.inner.scene.store(), "native translation binding")?;
-            let signal = signal.signal_in(self.inner.scene.store())?;
+            object.id_in_store(
+                self.inner.scene.integration_store(),
+                "native translation binding",
+            )?;
+            let signal = signal.signal_in(self.inner.scene.integration_store())?;
             self.inner
                 .bind_native_translation(object.semantic_mobject(), signal)
                 .map_err(js_error)
@@ -4296,8 +4359,8 @@ mod wasm {
             object: &crate::WasmAuthoringMobjectHandle,
             signal: &WasmValueTrackerHandle,
         ) -> Result<(), JsValue> {
-            object.id_in_store(self.inner.scene.store(), "rotation binding")?;
-            let signal = signal.tracker_in(self.inner.scene.store())?;
+            object.id_in_store(self.inner.scene.integration_store(), "rotation binding")?;
+            let signal = signal.tracker_in(self.inner.scene.integration_store())?;
             self.inner
                 .bind_rotation(object.semantic_mobject(), signal)
                 .map_err(js_error)
@@ -4309,8 +4372,8 @@ mod wasm {
             object: &crate::WasmAuthoringMobjectHandle,
             signal: &WasmValueTrackerHandle,
         ) -> Result<(), JsValue> {
-            object.id_in_store(self.inner.scene.store(), "opacity binding")?;
-            let signal = signal.tracker_in(self.inner.scene.store())?;
+            object.id_in_store(self.inner.scene.integration_store(), "opacity binding")?;
+            let signal = signal.tracker_in(self.inner.scene.integration_store())?;
             self.inner
                 .bind_opacity(object.semantic_mobject(), signal)
                 .map_err(js_error)
@@ -4322,8 +4385,8 @@ mod wasm {
             object: &crate::WasmAuthoringMobjectHandle,
             signal: &WasmNativeBoolSignalHandle,
         ) -> Result<(), JsValue> {
-            object.id_in_store(self.inner.scene.store(), "presence binding")?;
-            let signal = signal.signal_in(self.inner.scene.store())?;
+            object.id_in_store(self.inner.scene.integration_store(), "presence binding")?;
+            let signal = signal.signal_in(self.inner.scene.integration_store())?;
             self.inner
                 .bind_presence(object.semantic_mobject(), signal)
                 .map_err(js_error)
@@ -4338,7 +4401,7 @@ mod wasm {
             offset_x: f64,
             offset_y: f64,
         ) -> Result<WasmTrackerPositionHandle, JsValue> {
-            let tracker = tracker.tracker_in(self.inner.scene.store())?;
+            let tracker = tracker.tracker_in(self.inner.scene.integration_store())?;
             let position = self
                 .inner
                 .tracker_position(
@@ -4349,7 +4412,7 @@ mod wasm {
                 .map_err(js_error)?;
             Ok(WasmTrackerPositionHandle {
                 position,
-                store: std::rc::Rc::clone(self.inner.scene.store()),
+                store: std::rc::Rc::clone(self.inner.scene.integration_store()),
             })
         }
 
@@ -4359,8 +4422,11 @@ mod wasm {
             object: &crate::WasmAuthoringMobjectHandle,
             position: &WasmTrackerPositionHandle,
         ) -> Result<(), JsValue> {
-            object.id_in_store(self.inner.scene.store(), "tracker position binding")?;
-            let position = position.position_in(self.inner.scene.store())?;
+            object.id_in_store(
+                self.inner.scene.integration_store(),
+                "tracker position binding",
+            )?;
+            let position = position.position_in(self.inner.scene.integration_store())?;
             self.inner
                 .bind_tracker_position(object.semantic_mobject(), position)
                 .map_err(js_error)
@@ -4371,7 +4437,7 @@ mod wasm {
             &mut self,
             tracker: &WasmValueTrackerHandle,
         ) -> Result<f64, JsValue> {
-            let tracker = tracker.tracker_in(self.inner.scene.store())?;
+            let tracker = tracker.tracker_in(self.inner.scene.integration_store())?;
             self.inner.tracker_value(tracker).map_err(js_error)
         }
 
@@ -4381,7 +4447,7 @@ mod wasm {
             tracker: &WasmValueTrackerHandle,
             value: f64,
         ) -> Result<(), JsValue> {
-            let tracker = tracker.tracker_in(self.inner.scene.store())?;
+            let tracker = tracker.tracker_in(self.inner.scene.integration_store())?;
             self.inner
                 .set_tracker_value(tracker, value)
                 .map_err(js_error)
@@ -4716,7 +4782,7 @@ mod wasm {
                     &source.anchor,
                     noon::LiveLayoutTarget::Anchor(&target.anchor),
                     &aligner.anchor,
-                    noon::semantic_mobject::ManimNextToArgs {
+                    noon::ManimNextToArgs {
                         direction: (direction_x, direction_y),
                         buff,
                         aligned_edge: (edge_x, edge_y),
@@ -4749,7 +4815,7 @@ mod wasm {
                     &source.anchor,
                     noon::LiveLayoutTarget::Point(x, y),
                     &aligner.anchor,
-                    noon::semantic_mobject::ManimNextToArgs {
+                    noon::ManimNextToArgs {
                         direction: (direction_x, direction_y),
                         buff,
                         aligned_edge: (edge_x, edge_y),
@@ -4876,8 +4942,14 @@ mod wasm {
             run_time: f64,
             rate_function: &str,
         ) -> Result<WasmDeclaredAnimationHandle, JsValue> {
-            source.id_in_store(self.inner.scene.store(), "animation declaration")?;
-            target.id_in_store(self.inner.scene.store(), "animation declaration")?;
+            source.id_in_store(
+                self.inner.scene.integration_store(),
+                "animation declaration",
+            )?;
+            target.id_in_store(
+                self.inner.scene.integration_store(),
+                "animation declaration",
+            )?;
             let rate_function = noon_core::RateFunction::from_semantic_id(rate_function)
                 .ok_or_else(|| {
                     js_error(format!(
@@ -4897,7 +4969,7 @@ mod wasm {
                 .map_err(js_error)?;
             Ok(WasmDeclaredAnimationHandle {
                 declaration,
-                store: std::rc::Rc::clone(self.inner.scene.store()),
+                store: std::rc::Rc::clone(self.inner.scene.integration_store()),
             })
         }
 
@@ -4919,7 +4991,10 @@ mod wasm {
             rate_function: &str,
         ) -> Result<f64, JsValue> {
             let id = parse_object_id("object ID", object_id)?;
-            target.id_in_store(self.inner.scene.store(), "ordinary affine lifecycle")?;
+            target.id_in_store(
+                self.inner.scene.integration_store(),
+                "ordinary affine lifecycle",
+            )?;
             let direction = parse_affine_lifecycle_direction(direction)?;
             let endpoint = parse_affine_lifecycle_endpoint(
                 endpoint,
@@ -4972,7 +5047,10 @@ mod wasm {
             rate_function: &str,
         ) -> Result<f64, JsValue> {
             let id = parse_object_id("object ID", object_id)?;
-            target.id_in_store(self.inner.scene.store(), "ordinary affine lifecycle")?;
+            target.id_in_store(
+                self.inner.scene.integration_store(),
+                "ordinary affine lifecycle",
+            )?;
             let direction = parse_affine_lifecycle_direction(direction)?;
             let endpoint = parse_affine_lifecycle_endpoint(
                 endpoint,
@@ -5014,7 +5092,10 @@ mod wasm {
             &mut self,
             target: &crate::WasmAuthoringMobjectHandle,
         ) -> Result<bool, JsValue> {
-            target.id_in_store(self.inner.scene.store(), "live execution context")?;
+            target.id_in_store(
+                self.inner.scene.integration_store(),
+                "live execution context",
+            )?;
             self.inner
                 .live_contains_mobject(target.semantic_mobject())
                 .map_err(js_error)
@@ -5025,7 +5106,7 @@ mod wasm {
             &mut self,
             source: &crate::WasmAuthoringMobjectHandle,
         ) -> Result<crate::WasmAuthoringMobjectHandle, JsValue> {
-            source.id_in_store(self.inner.scene.store(), "live target editor")?;
+            source.id_in_store(self.inner.scene.integration_store(), "live target editor")?;
             self.inner
                 .live_target_editor(source.semantic_mobject())
                 .map(crate::WasmAuthoringMobjectHandle::from_semantic_mobject)
@@ -5165,7 +5246,7 @@ mod wasm {
             &mut self,
             animation: &WasmDeclaredAnimationHandle,
         ) -> Result<f64, JsValue> {
-            let declaration = animation.declaration_in(self.inner.scene.store())?;
+            let declaration = animation.declaration_in(self.inner.scene.integration_store())?;
             self.inner
                 .active_live_player()
                 .map_err(js_error)?
@@ -5231,7 +5312,10 @@ mod wasm {
             x: f64,
             y: f64,
         ) -> Result<(), JsValue> {
-            handle.id_in_store(self.inner.scene.store(), "live execution context")?;
+            handle.id_in_store(
+                self.inner.scene.integration_store(),
+                "live execution context",
+            )?;
             self.inner
                 .active_live_player()
                 .map_err(js_error)?
@@ -5251,7 +5335,10 @@ mod wasm {
             mask_x: f64,
             mask_y: f64,
         ) -> Result<(), JsValue> {
-            handle.id_in_store(self.inner.scene.store(), "live execution context")?;
+            handle.id_in_store(
+                self.inner.scene.integration_store(),
+                "live execution context",
+            )?;
             self.inner
                 .active_live_player()
                 .map_err(js_error)?
@@ -5274,8 +5361,14 @@ mod wasm {
             mask_x: f64,
             mask_y: f64,
         ) -> Result<(), JsValue> {
-            handle.id_in_store(self.inner.scene.store(), "live execution context")?;
-            target.id_in_store(self.inner.scene.store(), "live execution context")?;
+            handle.id_in_store(
+                self.inner.scene.integration_store(),
+                "live execution context",
+            )?;
+            target.id_in_store(
+                self.inner.scene.integration_store(),
+                "live execution context",
+            )?;
             self.inner
                 .active_live_player()
                 .map_err(js_error)?
@@ -5297,7 +5390,10 @@ mod wasm {
             blue: f64,
             opacity: f64,
         ) -> Result<(), JsValue> {
-            handle.id_in_store(self.inner.scene.store(), "live execution context")?;
+            handle.id_in_store(
+                self.inner.scene.integration_store(),
+                "live execution context",
+            )?;
             self.inner
                 .active_live_player()
                 .map_err(js_error)?
@@ -5314,7 +5410,10 @@ mod wasm {
             blue: f64,
             alpha: f64,
         ) -> Result<(), JsValue> {
-            handle.id_in_store(self.inner.scene.store(), "live execution context")?;
+            handle.id_in_store(
+                self.inner.scene.integration_store(),
+                "live execution context",
+            )?;
             self.inner
                 .active_live_player()
                 .map_err(js_error)?
@@ -5327,7 +5426,10 @@ mod wasm {
             &mut self,
             handle: &crate::WasmAuthoringMobjectHandle,
         ) -> Result<(), JsValue> {
-            handle.id_in_store(self.inner.scene.store(), "live execution context")?;
+            handle.id_in_store(
+                self.inner.scene.integration_store(),
+                "live execution context",
+            )?;
             self.inner
                 .active_live_player()
                 .map_err(js_error)?
@@ -5341,7 +5443,10 @@ mod wasm {
             handle: &crate::WasmAuthoringMobjectHandle,
             opacity: f64,
         ) -> Result<(), JsValue> {
-            handle.id_in_store(self.inner.scene.store(), "live execution context")?;
+            handle.id_in_store(
+                self.inner.scene.integration_store(),
+                "live execution context",
+            )?;
             self.inner
                 .active_live_player()
                 .map_err(js_error)?
@@ -5358,7 +5463,10 @@ mod wasm {
             blue: f64,
             alpha: f64,
         ) -> Result<(), JsValue> {
-            handle.id_in_store(self.inner.scene.store(), "live execution context")?;
+            handle.id_in_store(
+                self.inner.scene.integration_store(),
+                "live execution context",
+            )?;
             self.inner
                 .active_live_player()
                 .map_err(js_error)?
@@ -5375,7 +5483,10 @@ mod wasm {
             blue: f64,
             opacity: f64,
         ) -> Result<(), JsValue> {
-            handle.id_in_store(self.inner.scene.store(), "live execution context")?;
+            handle.id_in_store(
+                self.inner.scene.integration_store(),
+                "live execution context",
+            )?;
             self.inner
                 .active_live_player()
                 .map_err(js_error)?
@@ -5392,7 +5503,10 @@ mod wasm {
             blue: f64,
             alpha: f64,
         ) -> Result<(), JsValue> {
-            handle.id_in_store(self.inner.scene.store(), "live execution context")?;
+            handle.id_in_store(
+                self.inner.scene.integration_store(),
+                "live execution context",
+            )?;
             self.inner
                 .active_live_player()
                 .map_err(js_error)?
@@ -5405,7 +5519,10 @@ mod wasm {
             &mut self,
             handle: &crate::WasmAuthoringMobjectHandle,
         ) -> Result<(), JsValue> {
-            handle.id_in_store(self.inner.scene.store(), "live execution context")?;
+            handle.id_in_store(
+                self.inner.scene.integration_store(),
+                "live execution context",
+            )?;
             self.inner
                 .active_live_player()
                 .map_err(js_error)?
@@ -5419,7 +5536,10 @@ mod wasm {
             handle: &crate::WasmAuthoringMobjectHandle,
             opacity: f64,
         ) -> Result<(), JsValue> {
-            handle.id_in_store(self.inner.scene.store(), "live execution context")?;
+            handle.id_in_store(
+                self.inner.scene.integration_store(),
+                "live execution context",
+            )?;
             self.inner
                 .active_live_player()
                 .map_err(js_error)?
@@ -5433,7 +5553,10 @@ mod wasm {
             handle: &crate::WasmAuthoringMobjectHandle,
             opacity: f64,
         ) -> Result<(), JsValue> {
-            handle.id_in_store(self.inner.scene.store(), "live execution context")?;
+            handle.id_in_store(
+                self.inner.scene.integration_store(),
+                "live execution context",
+            )?;
             self.inner
                 .active_live_player()
                 .map_err(js_error)?
@@ -5447,7 +5570,10 @@ mod wasm {
             handle: &crate::WasmAuthoringMobjectHandle,
             opacity: f64,
         ) -> Result<(), JsValue> {
-            handle.id_in_store(self.inner.scene.store(), "live execution context")?;
+            handle.id_in_store(
+                self.inner.scene.integration_store(),
+                "live execution context",
+            )?;
             self.inner
                 .active_live_player()
                 .map_err(js_error)?
@@ -5462,7 +5588,10 @@ mod wasm {
             handle: &crate::WasmAuthoringMobjectHandle,
         ) -> Result<(), JsValue> {
             let id = parse_object_id("object ID", object_id)?;
-            handle.id_in_store(self.inner.scene.store(), "live execution context")?;
+            handle.id_in_store(
+                self.inner.scene.integration_store(),
+                "live execution context",
+            )?;
             self.inner
                 .live_add_mobject(id, handle.semantic_mobject())
                 .map_err(js_error)
@@ -5473,7 +5602,10 @@ mod wasm {
             &mut self,
             handle: &crate::WasmAuthoringMobjectHandle,
         ) -> Result<(), JsValue> {
-            handle.id_in_store(self.inner.scene.store(), "live execution context")?;
+            handle.id_in_store(
+                self.inner.scene.integration_store(),
+                "live execution context",
+            )?;
             self.inner
                 .live_remove_mobject(handle.semantic_mobject())
                 .map_err(js_error)
@@ -5485,8 +5617,14 @@ mod wasm {
             target: &crate::WasmAuthoringMobjectHandle,
             source: &crate::WasmAuthoringMobjectHandle,
         ) -> Result<(), JsValue> {
-            target.id_in_store(self.inner.scene.store(), "live execution context")?;
-            source.id_in_store(self.inner.scene.store(), "live execution context")?;
+            target.id_in_store(
+                self.inner.scene.integration_store(),
+                "live execution context",
+            )?;
+            source.id_in_store(
+                self.inner.scene.integration_store(),
+                "live execution context",
+            )?;
             self.inner
                 .live_replace_content(target.semantic_mobject(), source.semantic_mobject())
                 .map_err(js_error)
@@ -5499,7 +5637,10 @@ mod wasm {
             x: f64,
             y: f64,
         ) -> Result<(), JsValue> {
-            handle.id_in_store(self.inner.scene.store(), "live execution context")?;
+            handle.id_in_store(
+                self.inner.scene.integration_store(),
+                "live execution context",
+            )?;
             self.inner
                 .active_live_player()
                 .map_err(js_error)?
@@ -5553,7 +5694,10 @@ mod wasm {
             y: f64,
         ) -> Result<(), JsValue> {
             let family = handle.semantic_family()?;
-            if !std::rc::Rc::ptr_eq(self.inner.scene.store(), family.store()) {
+            if !std::rc::Rc::ptr_eq(
+                self.inner.scene.integration_store(),
+                family.integration_store(),
+            ) {
                 return Err(js_error(
                     "family and canonical context belong to different authoring stores",
                 ));
@@ -5582,7 +5726,10 @@ mod wasm {
             x: f64,
             y: f64,
         ) -> Result<(), JsValue> {
-            handle.id_in_store(self.inner.scene.store(), "live execution context")?;
+            handle.id_in_store(
+                self.inner.scene.integration_store(),
+                "live execution context",
+            )?;
             self.inner
                 .active_live_player()
                 .map_err(js_error)?
@@ -5597,7 +5744,10 @@ mod wasm {
             x: f64,
             y: f64,
         ) -> Result<(), JsValue> {
-            handle.id_in_store(self.inner.scene.store(), "live execution context")?;
+            handle.id_in_store(
+                self.inner.scene.integration_store(),
+                "live execution context",
+            )?;
             self.inner
                 .active_live_player()
                 .map_err(js_error)?
@@ -5611,7 +5761,10 @@ mod wasm {
             handle: &crate::WasmAuthoringMobjectHandle,
             angle: f64,
         ) -> Result<(), JsValue> {
-            handle.id_in_store(self.inner.scene.store(), "live execution context")?;
+            handle.id_in_store(
+                self.inner.scene.integration_store(),
+                "live execution context",
+            )?;
             self.inner
                 .active_live_player()
                 .map_err(js_error)?
@@ -5625,7 +5778,10 @@ mod wasm {
             handle: &crate::WasmAuthoringMobjectHandle,
             angle: f64,
         ) -> Result<(), JsValue> {
-            handle.id_in_store(self.inner.scene.store(), "live execution context")?;
+            handle.id_in_store(
+                self.inner.scene.integration_store(),
+                "live execution context",
+            )?;
             self.inner
                 .active_live_player()
                 .map_err(js_error)?
@@ -5638,7 +5794,10 @@ mod wasm {
             &mut self,
             handle: &crate::WasmAuthoringMobjectHandle,
         ) -> Result<WasmLiveMobjectState, JsValue> {
-            handle.id_in_store(self.inner.scene.store(), "live execution context")?;
+            handle.id_in_store(
+                self.inner.scene.integration_store(),
+                "live execution context",
+            )?;
             Ok(WasmLiveMobjectState {
                 state: self
                     .inner
@@ -5786,7 +5945,7 @@ mod tests {
     fn family_argument_batches_reject_scene_binding_metadata() {
         let scene = noon::Scene::new();
         let object = scene.circle(0.2).unwrap();
-        let revision = scene.store().borrow().scene_revision();
+        let revision = scene.integration_store().borrow().scene_revision();
         let mut batch = SceneMembershipBatch {
             kind: SceneMembershipBatchKind::Add,
             members: vec![OwnedSceneMembershipMember::Mobject {
@@ -5797,25 +5956,28 @@ mod tests {
         };
         assert_eq!(batch.family_members().unwrap().len(), 1);
         let family = batch
-            .create_family(std::rc::Rc::clone(scene.store()))
+            .create_family(std::rc::Rc::clone(scene.integration_store()))
             .unwrap();
-        let committed = scene.store().borrow().scene_revision();
+        let committed = scene.integration_store().borrow().scene_revision();
         assert_eq!(committed, revision.checked_next().unwrap());
         assert_eq!(batch.edit_family(&family).unwrap(), vec![false]);
         batch.kind = SceneMembershipBatchKind::Remove;
         assert!(batch
-            .create_family(std::rc::Rc::clone(scene.store()))
+            .create_family(std::rc::Rc::clone(scene.integration_store()))
             .is_err());
         assert_eq!(batch.edit_family(&family).unwrap(), vec![true]);
         batch.kind = SceneMembershipBatchKind::Clear;
-        let revision = scene.store().borrow().scene_revision();
+        let revision = scene.integration_store().borrow().scene_revision();
         assert!(batch.edit_family(&family).is_err());
         batch.bindings.push((ObjectId::new(1), object.clone()));
         assert!(batch.family_members().is_err());
         batch.bindings.clear();
         batch.members = vec![membership_mobject(1, &object)];
         assert!(batch.family_members().is_err());
-        assert_eq!(scene.store().borrow().scene_revision(), revision);
+        assert_eq!(
+            scene.integration_store().borrow().scene_revision(),
+            revision
+        );
     }
 
     #[test]
@@ -5989,10 +6151,13 @@ mod tests {
         let local = first.scene.circle(1.0).unwrap();
         let foreign = second.scene.circle(2.0).unwrap();
         assert_eq!(local.node_id(), foreign.node_id());
-        let revision = first.scene.store().borrow().scene_revision();
+        let revision = first.scene.integration_store().borrow().scene_revision();
         assert!(first.bind_mobject(ObjectId::new(0), &foreign).is_err());
         assert!(first.members().unwrap().is_empty());
-        assert_eq!(first.scene.store().borrow().scene_revision(), revision);
+        assert_eq!(
+            first.scene.integration_store().borrow().scene_revision(),
+            revision
+        );
         first.bind_mobject(ObjectId::new(0), &local).unwrap();
     }
 
@@ -6013,11 +6178,14 @@ mod tests {
         assert_eq!(context.ordinary_wait(0.3).unwrap(), 0.3);
         // New detached state must publish through the active session as well.
         let collision = context.live_target_editor(&anchor).unwrap();
-        let revision = context.scene.store().borrow().scene_revision();
+        let revision = context.scene.integration_store().borrow().scene_revision();
         assert!(context
             .live_add_mobject(ObjectId::new(0), &collision)
             .is_err());
-        assert_eq!(context.scene.store().borrow().scene_revision(), revision);
+        assert_eq!(
+            context.scene.integration_store().borrow().scene_revision(),
+            revision
+        );
         assert!(context
             .active_live_player()
             .unwrap()
@@ -6146,7 +6314,7 @@ mod tests {
         );
         assert!(execution.frame().objects[1].text().is_some());
         let resource = label.state().unwrap().content.text().unwrap();
-        let store = context.scene.store().borrow();
+        let store = context.scene.integration_store().borrow();
         let text = store.text_resources().get(resource).unwrap();
         assert_eq!(text.kind, noon_core::TextSourceKind::Plain);
         assert_eq!(text.source.as_ref(), "A");
@@ -6204,7 +6372,7 @@ mod tests {
             Vec2::new(2.0, -1.0)
         );
         let state = label.state().unwrap();
-        let store = context.scene.store().borrow();
+        let store = context.scene.integration_store().borrow();
         let text = store
             .text_resources()
             .get(state.content.text().unwrap())
@@ -6215,7 +6383,7 @@ mod tests {
         assert!((text.runs[0].transform.ty - text.runs[1].transform.ty - 54.0).abs() < 1e-6);
         assert_eq!(
             state.transform.scale.x,
-            f64::from(noon::NATIVE_POINT_TO_SCENE_SCALE)
+            f64::from(noon::integration::NATIVE_POINT_TO_SCENE_SCALE)
         );
     }
 
@@ -6261,7 +6429,7 @@ mod tests {
             Some(noon_core::SemanticPaint::Solid(noon_core::YELLOW))
         );
         assert_eq!(equation.state().unwrap().style.object_opacity, 0.5);
-        let store = context.scene.store().borrow();
+        let store = context.scene.integration_store().borrow();
         for (handle, kind, source) in [
             (&label, noon_core::TextSourceKind::Typst, "*Noon*"),
             (
@@ -6290,7 +6458,7 @@ mod tests {
         let animation = context
             .declare_live_transform_to(&circle, &target, options)
             .unwrap();
-        let store = std::rc::Rc::clone(context.scene.store());
+        let store = std::rc::Rc::clone(context.scene.integration_store());
 
         {
             let player = context.live_player(2.0).unwrap();
@@ -6375,14 +6543,20 @@ mod tests {
         context
             .add_updater(&circle, HostCallbackId::new(9), 0.0, None)
             .unwrap();
-        let revision = context.scene.store().borrow().scene_revision();
+        let revision = context.scene.integration_store().borrow().scene_revision();
 
         let mut target = context.live_target_editor(&circle).unwrap();
         target.set_translation(2.0, -1.0).unwrap();
 
         assert!(context.player_ownership.is_unstarted());
         assert!(
-            context.scene.store().borrow().scene_revision().get() > revision.get(),
+            context
+                .scene
+                .integration_store()
+                .borrow()
+                .scene_revision()
+                .get()
+                > revision.get(),
             "the detached authored target must be published without bootstrapping a player"
         );
         assert_eq!(
@@ -6418,13 +6592,16 @@ mod tests {
         assert_eq!(target.state().unwrap(), target_before);
 
         let handed_off = context.take_execution_player(1.0, 41).unwrap();
-        let revision = context.scene.store().borrow().scene_revision();
+        let revision = context.scene.integration_store().borrow().scene_revision();
         let before = source.state().unwrap();
         assert!(context
             .live_become_mobject(&source, &target, Default::default())
             .unwrap_err()
             .contains("semantic engine"));
-        assert_eq!(context.scene.store().borrow().scene_revision(), revision);
+        assert_eq!(
+            context.scene.integration_store().borrow().scene_revision(),
+            revision
+        );
         assert_eq!(source.state().unwrap(), before);
         context.return_execution_player(handed_off).unwrap();
         context
@@ -6451,18 +6628,21 @@ mod tests {
         assert_eq!(
             context
                 .scene
-                .store()
+                .integration_store()
                 .borrow()
                 .semantic_family_members_checked(nested.node_id())
                 .unwrap(),
             &[family.node_id()]
         );
         let foreign = noon::Scene::new().circle(0.2).unwrap();
-        let revision = context.scene.store().borrow().scene_revision();
+        let revision = context.scene.integration_store().borrow().scene_revision();
         assert!(context
             .live_family(&[noon::MobjectFamilyMember::Mobject(&foreign)])
             .is_err());
-        assert_eq!(context.scene.store().borrow().scene_revision(), revision);
+        assert_eq!(
+            context.scene.integration_store().borrow().scene_revision(),
+            revision
+        );
         // Another owner-mediated mutation remains valid after both publications
         // and the rejected foreign member: no stale execution revision is hidden.
         context.live_target_editor(&circle).unwrap();
@@ -6561,7 +6741,7 @@ mod tests {
                 &placement,
                 noon::LiveLayoutTarget::Point(before.center.0, before.center.1),
                 &placement,
-                noon::semantic_mobject::ManimNextToArgs {
+                noon::ManimNextToArgs {
                     direction: (0.0, 0.0),
                     buff: 0.0,
                     aligned_edge: (0.0, 0.0),
@@ -6670,10 +6850,13 @@ mod tests {
         context.bind_mobject(ObjectId::new(0), &circle).unwrap();
         context.live_player(1.0).unwrap();
         let player = context.take_execution_player(1.0, 17).unwrap();
-        let revision = context.scene.store().borrow().scene_revision();
+        let revision = context.scene.integration_store().borrow().scene_revision();
 
         assert!(context.live_target_editor(&circle).is_err());
-        assert_eq!(context.scene.store().borrow().scene_revision(), revision);
+        assert_eq!(
+            context.scene.integration_store().borrow().scene_revision(),
+            revision
+        );
         assert_eq!(context.live_execution_ownership(), "transferred");
 
         context.return_execution_player(player).unwrap();
@@ -6787,18 +6970,21 @@ mod tests {
             .lag_ratio(0.0)
             .rate_func(RateFunction::Linear);
         let play = AnimationOptions::new().rate_func(RateFunction::Linear);
-        let revision = context.scene.store().borrow().scene_revision();
+        let revision = context.scene.integration_store().borrow().scene_revision();
 
         context
             .validate_ordinary_mixed_composition(&children, composition, play)
             .unwrap();
         assert!(context.player_ownership.is_unstarted());
-        assert_eq!(context.scene.store().borrow().scene_revision(), revision);
+        assert_eq!(
+            context.scene.integration_store().borrow().scene_revision(),
+            revision
+        );
 
         let mut unsupported_target = right.target_editor().unwrap();
         unsupported_target.set_stroke_width(3.0).unwrap();
         let unsupported = [bound_transform_child(&right, unsupported_target, child)];
-        let revision = context.scene.store().borrow().scene_revision();
+        let revision = context.scene.integration_store().borrow().scene_revision();
         assert!(context
             .ordinary_play_mixed_composition(
                 noon_core::SemanticAnimationCompositionKind::Parallel,
@@ -6808,7 +6994,10 @@ mod tests {
             )
             .is_err());
         assert!(context.player_ownership.is_unstarted());
-        assert_eq!(context.scene.store().borrow().scene_revision(), revision);
+        assert_eq!(
+            context.scene.integration_store().borrow().scene_revision(),
+            revision
+        );
 
         assert_eq!(
             context
@@ -6893,7 +7082,7 @@ mod tests {
     #[test]
     fn focus_on_creates_and_removes_a_spotlight_without_wrapper_identity() {
         let mut context = CanonicalAuthoringScene::default();
-        let revision = context.scene.store().borrow().scene_revision();
+        let revision = context.scene.integration_store().borrow().scene_revision();
         let options = AnimationOptions::new().rate_func(RateFunction::Linear);
         let child = |opacity| OrdinaryCompositionChild::FocusOn {
             focus: noon::FocusOnOptions {
@@ -6910,7 +7099,10 @@ mod tests {
                 AnimationOptions::new()
             )
             .is_err());
-        assert_eq!(context.scene.store().borrow().scene_revision(), revision);
+        assert_eq!(
+            context.scene.integration_store().borrow().scene_revision(),
+            revision
+        );
         assert_eq!(
             context
                 .ordinary_play_mixed_composition(
@@ -6937,7 +7129,7 @@ mod tests {
             .introducer(true)
             .remover(true);
         let composition = AnimationOptions::new().rate_func(RateFunction::Linear);
-        let revision = context.scene.store().borrow().scene_revision();
+        let revision = context.scene.integration_store().borrow().scene_revision();
         let invalid = OrdinaryCompositionChild::PassingFlash {
             entering_id: Some(id),
             target: line.clone(),
@@ -6953,7 +7145,10 @@ mod tests {
             )
             .is_err());
         assert!(context.bindings.is_empty());
-        assert_eq!(context.scene.store().borrow().scene_revision(), revision);
+        assert_eq!(
+            context.scene.integration_store().borrow().scene_revision(),
+            revision
+        );
 
         let valid = OrdinaryCompositionChild::PassingFlash {
             entering_id: Some(id),
@@ -7003,7 +7198,7 @@ mod tests {
             outline,
             options,
         }];
-        let revision = context.scene.store().borrow().scene_revision();
+        let revision = context.scene.integration_store().borrow().scene_revision();
         assert!(context
             .ordinary_play_mixed_composition(
                 noon_core::SemanticAnimationCompositionKind::Parallel,
@@ -7014,7 +7209,10 @@ mod tests {
             .is_err());
         assert!(context.player_ownership.is_unstarted());
         assert!(context.bindings.is_empty());
-        assert_eq!(context.scene.store().borrow().scene_revision(), revision);
+        assert_eq!(
+            context.scene.integration_store().borrow().scene_revision(),
+            revision
+        );
 
         let valid = [
             OrdinaryCompositionChild::DrawBorderThenFill {
@@ -7152,7 +7350,7 @@ mod tests {
                 options,
             },
         ];
-        let revision = rejected.scene.store().borrow().scene_revision();
+        let revision = rejected.scene.integration_store().borrow().scene_revision();
         assert!(rejected
             .ordinary_play_mixed_composition(
                 noon_core::SemanticAnimationCompositionKind::Parallel,
@@ -7163,7 +7361,10 @@ mod tests {
             .is_err());
         assert!(rejected.player_ownership.is_unstarted());
         assert!(rejected.bindings.is_empty());
-        assert_eq!(rejected.scene.store().borrow().scene_revision(), revision);
+        assert_eq!(
+            rejected.scene.integration_store().borrow().scene_revision(),
+            revision
+        );
     }
 
     #[test]
@@ -7414,7 +7615,7 @@ mod tests {
             mode: noon::SubsetDisplayMode::IncreasingFloor,
             options,
         }];
-        let revision = context.scene.store().borrow().scene_revision();
+        let revision = context.scene.integration_store().borrow().scene_revision();
         assert!(context
             .ordinary_play_mixed_composition(
                 noon_core::SemanticAnimationCompositionKind::Parallel,
@@ -7425,7 +7626,10 @@ mod tests {
             .is_err());
         assert!(context.player_ownership.is_unstarted());
         assert!(context.bindings.is_empty());
-        assert_eq!(context.scene.store().borrow().scene_revision(), revision);
+        assert_eq!(
+            context.scene.integration_store().borrow().scene_revision(),
+            revision
+        );
 
         let valid = [OrdinaryCompositionChild::FamilySubsetDisplay {
             target: family,
@@ -7571,7 +7775,7 @@ mod tests {
         assert!(context.live_contains_mobject(&fade_target).unwrap());
         assert!(context.live_contains_mobject(&lifecycle_target).unwrap());
 
-        let revision = context.scene.store().borrow().scene_revision();
+        let revision = context.scene.integration_store().borrow().scene_revision();
         let foreign = CanonicalAuthoringScene::default();
         let foreign_target = foreign.scene.circle(0.2).unwrap();
         let invalid = [OrdinaryCompositionChild::Add {
@@ -7587,7 +7791,10 @@ mod tests {
                 play,
             )
             .is_err());
-        assert_eq!(context.scene.store().borrow().scene_revision(), revision);
+        assert_eq!(
+            context.scene.integration_store().borrow().scene_revision(),
+            revision
+        );
     }
 
     #[test]
@@ -7622,7 +7829,7 @@ mod tests {
             target_state: invalid_target,
             options: transform_options,
         }];
-        let revision = context.scene.store().borrow().scene_revision();
+        let revision = context.scene.integration_store().borrow().scene_revision();
         assert!(context
             .ordinary_play_mixed_composition(
                 noon_core::SemanticAnimationCompositionKind::Parallel,
@@ -7632,7 +7839,10 @@ mod tests {
             )
             .is_err());
         assert!(context.player_ownership.is_unstarted());
-        assert_eq!(context.scene.store().borrow().scene_revision(), revision);
+        assert_eq!(
+            context.scene.integration_store().borrow().scene_revision(),
+            revision
+        );
 
         let children = [
             OrdinaryCompositionChild::FamilyTransformTo {
@@ -7660,7 +7870,10 @@ mod tests {
             )
             .is_err());
         assert!(context.player_ownership.is_unstarted());
-        assert_eq!(context.scene.store().borrow().scene_revision(), revision);
+        assert_eq!(
+            context.scene.integration_store().borrow().scene_revision(),
+            revision
+        );
         // Completion barriers publish the preceding transform before Indicate
         // captures its effective source and shared family center.
         for (index, child) in children.iter().enumerate() {
@@ -7713,7 +7926,7 @@ mod tests {
                 options,
             },
         ];
-        let revision = context.scene.store().borrow().scene_revision();
+        let revision = context.scene.integration_store().borrow().scene_revision();
         assert!(context
             .begin_ordinary_mixed_composition(
                 noon_core::SemanticAnimationCompositionKind::Parallel,
@@ -7723,7 +7936,10 @@ mod tests {
             )
             .is_err());
         assert!(context.player_ownership.is_unstarted());
-        assert_eq!(context.scene.store().borrow().scene_revision(), revision);
+        assert_eq!(
+            context.scene.integration_store().borrow().scene_revision(),
+            revision
+        );
 
         let valid = [
             OrdinaryCompositionChild::Rotate {
@@ -7838,7 +8054,7 @@ mod tests {
         callbacks.add_updater(left.node_id(), HostCallbackId::new(7), 0.0, None);
         callbacks.add_updater(left.node_id(), HostCallbackId::new(8), 0.0, None);
         callbacks
-            .apply(&mut context.scene.store().borrow_mut())
+            .apply(&mut context.scene.integration_store().borrow_mut())
             .unwrap();
         let child = AnimationOptions::new()
             .run_time(2.0)
@@ -7852,7 +8068,7 @@ mod tests {
             .rate_func(RateFunction::Linear);
         let play = AnimationOptions::new().rate_func(RateFunction::Linear);
 
-        let revision = context.scene.store().borrow().scene_revision();
+        let revision = context.scene.integration_store().borrow().scene_revision();
         let endpoint_only_error = context
             .ordinary_play_mixed_composition(
                 noon_core::SemanticAnimationCompositionKind::Parallel,
@@ -7863,7 +8079,10 @@ mod tests {
             .unwrap_err();
         assert!(endpoint_only_error.contains("needs an asynchronous continuation"));
         assert!(context.player_ownership.is_unstarted());
-        assert_eq!(context.scene.store().borrow().scene_revision(), revision);
+        assert_eq!(
+            context.scene.integration_store().borrow().scene_revision(),
+            revision
+        );
 
         let end_time = context
             .begin_ordinary_mixed_composition(
@@ -7960,7 +8179,7 @@ mod tests {
             .lag_ratio(0.0)
             .rate_func(RateFunction::Linear);
         let play = AnimationOptions::new().rate_func(RateFunction::Linear);
-        let revision = context.scene.store().borrow().scene_revision();
+        let revision = context.scene.integration_store().borrow().scene_revision();
 
         assert!(context
             .begin_ordinary_mixed_composition(
@@ -7970,7 +8189,10 @@ mod tests {
                 play,
             )
             .is_err());
-        assert_eq!(context.scene.store().borrow().scene_revision(), revision);
+        assert_eq!(
+            context.scene.integration_store().borrow().scene_revision(),
+            revision
+        );
         assert!(context.player_ownership.is_unstarted());
         assert_eq!(context.live_execution_ownership(), "none");
 
@@ -8025,7 +8247,7 @@ mod tests {
             .lag_ratio(0.0)
             .rate_func(RateFunction::Linear);
         let play = AnimationOptions::new().rate_func(RateFunction::Linear);
-        let revision = context.scene.store().borrow().scene_revision();
+        let revision = context.scene.integration_store().borrow().scene_revision();
         let (publication, frame, handoff_duration) = {
             let player = context.player_ownership.local_mut().unwrap();
             let handoff_duration = player.live_handoff_duration();
@@ -8049,7 +8271,10 @@ mod tests {
             )
             .is_err());
         assert_eq!(context.live_execution_ownership(), "returned");
-        assert_eq!(context.scene.store().borrow().scene_revision(), revision);
+        assert_eq!(
+            context.scene.integration_store().borrow().scene_revision(),
+            revision
+        );
         let player = context.player_ownership.local_mut().unwrap();
         assert_eq!(player.live_handoff_duration(), handoff_duration);
         assert!(!player.has_pending_live_segment());
@@ -8086,7 +8311,7 @@ mod tests {
             )
             .unwrap();
         {
-            let store = context.scene.store().borrow();
+            let store = context.scene.integration_store().borrow();
             let node = store.node(pulse.node_id()).unwrap();
             assert_eq!(node.residency(), noon_core::SemanticNodeResidency::Detached);
             assert!(node.parents().is_empty());
@@ -8116,7 +8341,7 @@ mod tests {
         context.return_execution_player(player).unwrap();
 
         {
-            let store = context.scene.store().borrow();
+            let store = context.scene.integration_store().borrow();
             let node = store.node(pulse.node_id()).unwrap();
             assert_eq!(node.residency(), noon_core::SemanticNodeResidency::Detached);
             assert!(node.parents().is_empty());
@@ -8184,7 +8409,7 @@ mod tests {
         let mut removal = SemanticMutationTransaction::new();
         removal.remove_node(stale.node_id());
         removal
-            .apply(&mut context.scene.store().borrow_mut())
+            .apply(&mut context.scene.integration_store().borrow_mut())
             .unwrap();
         assert!(context
             .validate_ordinary_mixed_composition(
@@ -8646,7 +8871,7 @@ mod tests {
         let mut callbacks = SemanticMutationTransaction::new();
         callbacks.add_updater(circle.node_id(), HostCallbackId::new(7), 0.0, None);
         callbacks
-            .apply(&mut context.scene.store().borrow_mut())
+            .apply(&mut context.scene.integration_store().borrow_mut())
             .unwrap();
 
         context.begin_ordinary_wait(0.25).unwrap();
@@ -8781,7 +9006,7 @@ mod tests {
             .unwrap();
         let registrations = context
             .scene
-            .store()
+            .integration_store()
             .borrow()
             .semantic_updater_registrations(circle.node_id())
             .unwrap()
@@ -8800,7 +9025,7 @@ mod tests {
         context.clear_updaters(&circle, 1.0).unwrap();
         let registrations = context
             .scene
-            .store()
+            .integration_store()
             .borrow()
             .semantic_updater_registrations(circle.node_id())
             .unwrap()
@@ -8878,13 +9103,16 @@ mod tests {
         assert_eq!(context.tracker_value(&tracker).unwrap(), 1.25);
         assert!(context
             .scene
-            .store()
+            .integration_store()
             .borrow()
             .is_semantic_signal_scoped(context.scene.root(), tracker.node_id()));
 
-        let revision = context.scene.store().borrow().scene_revision();
+        let revision = context.scene.integration_store().borrow().scene_revision();
         assert!(context.create_value_tracker(f64::MAX).is_err());
-        assert_eq!(context.scene.store().borrow().scene_revision(), revision);
+        assert_eq!(
+            context.scene.integration_store().borrow().scene_revision(),
+            revision
+        );
         assert_eq!(context.tracker_value(&tracker).unwrap(), 1.25);
 
         let leased = context.take_execution_player(1.0, 91).unwrap();
@@ -8897,28 +9125,42 @@ mod tests {
     #[test]
     fn detached_tracker_association_uses_authored_and_live_publication_paths() {
         let mut context = CanonicalAuthoringScene::default();
-        let tracker =
-            noon::ValueTracker::detached(std::rc::Rc::clone(context.scene.store()), 1.25).unwrap();
+        let tracker = noon::ValueTracker::detached(
+            std::rc::Rc::clone(context.scene.integration_store()),
+            1.25,
+        )
+        .unwrap();
         context.associate_value_tracker(&tracker).unwrap();
         assert_eq!(context.tracker_value(&tracker).unwrap(), 1.25);
 
         context.live_player(1.0).unwrap();
-        let live_tracker =
-            noon::ValueTracker::detached(std::rc::Rc::clone(context.scene.store()), 2.5).unwrap();
+        let live_tracker = noon::ValueTracker::detached(
+            std::rc::Rc::clone(context.scene.integration_store()),
+            2.5,
+        )
+        .unwrap();
         context.associate_value_tracker(&live_tracker).unwrap();
         assert_eq!(context.tracker_value(&live_tracker).unwrap(), 2.5);
 
-        let invalid =
-            noon::ValueTracker::detached(std::rc::Rc::clone(context.scene.store()), f64::MAX)
-                .unwrap();
-        let revision = context.scene.store().borrow().scene_revision();
+        let invalid = noon::ValueTracker::detached(
+            std::rc::Rc::clone(context.scene.integration_store()),
+            f64::MAX,
+        )
+        .unwrap();
+        let revision = context.scene.integration_store().borrow().scene_revision();
         assert!(context.associate_value_tracker(&invalid).is_err());
-        assert_eq!(context.scene.store().borrow().scene_revision(), revision);
+        assert_eq!(
+            context.scene.integration_store().borrow().scene_revision(),
+            revision
+        );
         assert_eq!(invalid.detached_value().unwrap(), f64::MAX);
 
         let foreign = CanonicalAuthoringScene::default();
-        let foreign_tracker =
-            noon::ValueTracker::detached(std::rc::Rc::clone(foreign.scene.store()), 3.0).unwrap();
+        let foreign_tracker = noon::ValueTracker::detached(
+            std::rc::Rc::clone(foreign.scene.integration_store()),
+            3.0,
+        )
+        .unwrap();
         assert!(context.associate_value_tracker(&foreign_tracker).is_err());
         assert_eq!(foreign_tracker.detached_value().unwrap(), 3.0);
     }
@@ -8946,7 +9188,7 @@ mod tests {
         );
         let timeline = context
             .scene
-            .store()
+            .integration_store()
             .borrow()
             .semantic_signal_state(tracker.node_id())
             .unwrap()
@@ -8973,7 +9215,7 @@ mod tests {
             )
             .unwrap();
         context.bind_tracker_position(&circle, &position).unwrap();
-        let revision = context.scene.store().borrow().scene_revision();
+        let revision = context.scene.integration_store().borrow().scene_revision();
 
         assert!(begin_request(
             &mut context,
@@ -8987,7 +9229,10 @@ mod tests {
         )
         .is_err());
         assert!(context.player_ownership.is_unstarted());
-        assert_eq!(context.scene.store().borrow().scene_revision(), revision);
+        assert_eq!(
+            context.scene.integration_store().borrow().scene_revision(),
+            revision
+        );
 
         let end = begin_request(
             &mut context,
@@ -9029,7 +9274,7 @@ mod tests {
         assert_eq!(
             context
                 .scene
-                .store()
+                .integration_store()
                 .borrow()
                 .semantic_input_scalar_value_at(tracker.node_id(), 1.0)
                 .unwrap(),
@@ -9051,7 +9296,7 @@ mod tests {
             .rate_func(RateFunction::Linear)
             .run_time(2.0)
             .unwrap();
-        let revision = context.scene.store().borrow().scene_revision();
+        let revision = context.scene.integration_store().borrow().scene_revision();
 
         let error = play_request(
             &mut context,
@@ -9067,7 +9312,10 @@ mod tests {
         assert!(error.contains("cannot follow pre-execution canonical timing"));
         assert!(context.player_ownership.is_unstarted());
         assert_eq!(context.authored_duration(), 2.0);
-        assert_eq!(context.scene.store().borrow().scene_revision(), revision);
+        assert_eq!(
+            context.scene.integration_store().borrow().scene_revision(),
+            revision
+        );
     }
 
     #[test]
@@ -9152,7 +9400,7 @@ mod tests {
     fn ordinary_create_is_atomic_and_rejects_foreign_or_second_membership() {
         let mut context = CanonicalAuthoringScene::default();
         let circle = context.scene.circle(0.4).unwrap();
-        let revision = context.scene.store().borrow().scene_revision();
+        let revision = context.scene.integration_store().borrow().scene_revision();
         assert!(begin_request(
             &mut context,
             create_request(
@@ -9165,7 +9413,10 @@ mod tests {
         assert!(context.player_ownership.is_unstarted());
         assert!(context.bindings.is_empty());
         assert!(context.identities.is_empty());
-        assert_eq!(context.scene.store().borrow().scene_revision(), revision);
+        assert_eq!(
+            context.scene.integration_store().borrow().scene_revision(),
+            revision
+        );
 
         let foreign = CanonicalAuthoringScene::default()
             .scene
@@ -9181,7 +9432,10 @@ mod tests {
         )
         .is_err());
         assert!(context.player_ownership.is_unstarted());
-        assert_eq!(context.scene.store().borrow().scene_revision(), revision);
+        assert_eq!(
+            context.scene.integration_store().borrow().scene_revision(),
+            revision
+        );
 
         let end = begin_request(
             &mut context,
@@ -9310,7 +9564,7 @@ mod tests {
         let mut context = CanonicalAuthoringScene::default();
         let circle = context.scene.circle(0.4).unwrap();
         let square = context.scene.square(0.8).unwrap();
-        let revision = context.scene.store().borrow().scene_revision();
+        let revision = context.scene.integration_store().borrow().scene_revision();
 
         assert!(context
             .begin_ordinary_mixed_composition(
@@ -9334,14 +9588,17 @@ mod tests {
         assert!(context.player_ownership.is_unstarted());
         assert!(context.bindings.is_empty());
         assert!(context.identities.is_empty());
-        assert_eq!(context.scene.store().borrow().scene_revision(), revision);
+        assert_eq!(
+            context.scene.integration_store().borrow().scene_revision(),
+            revision
+        );
     }
 
     #[test]
     fn failed_first_fade_does_not_install_a_player_or_derived_binding() {
         let mut context = CanonicalAuthoringScene::default();
         let circle = context.scene.circle(0.4).unwrap();
-        let before = context.scene.store().borrow().scene_revision();
+        let before = context.scene.integration_store().borrow().scene_revision();
         let id = ObjectId::new(0);
 
         assert!(begin_request(
@@ -9363,7 +9620,10 @@ mod tests {
         assert!(!context.player_ownership.is_transferred());
         assert!(!context.bindings.contains_key(&id));
         assert!(!context.identities.contains_key(&circle.node_id()));
-        assert_eq!(context.scene.store().borrow().scene_revision(), before);
+        assert_eq!(
+            context.scene.integration_store().borrow().scene_revision(),
+            before
+        );
 
         // The failed provisional player did not poison the ordinary path.
         begin_request(
@@ -9390,7 +9650,7 @@ mod tests {
             .scene
             .text(noon::Text::new("resource entry"))
             .unwrap();
-        let before = context.scene.store().borrow().scene_revision();
+        let before = context.scene.integration_store().borrow().scene_revision();
         let id = ObjectId::new(0);
 
         assert!(begin_request(
@@ -9409,7 +9669,10 @@ mod tests {
         assert!(context.player_ownership.is_unstarted());
         assert!(!context.bindings.contains_key(&id));
         assert!(!context.identities.contains_key(&text.node_id()));
-        assert_eq!(context.scene.store().borrow().scene_revision(), before);
+        assert_eq!(
+            context.scene.integration_store().borrow().scene_revision(),
+            before
+        );
     }
 
     #[test]

--- a/crates/noon-web/src/canonical_authoring_scene/ownership_tests.rs
+++ b/crates/noon-web/src/canonical_authoring_scene/ownership_tests.rs
@@ -52,7 +52,7 @@ fn transferred_context_cannot_drive_query_publish_or_take_again() {
     let (mut scene, circle) = scene_with_circle();
     let player = scene.take_execution_player(1.0, 41).unwrap();
     let identity = player.ownership_identity();
-    let revision = scene.scene.store().borrow().scene_revision();
+    let revision = scene.scene.integration_store().borrow().scene_revision();
     assert!(scene.mobject_layout(&circle).is_err());
     assert!(scene.live_contains_mobject(&circle).is_err());
     assert!(scene.active_live_player().is_err());
@@ -62,7 +62,10 @@ fn transferred_context_cannot_drive_query_publish_or_take_again() {
     assert!(scene
         .add_updater(&circle, HostCallbackId::new(3), 0.0, None)
         .is_err());
-    assert_eq!(scene.scene.store().borrow().scene_revision(), revision);
+    assert_eq!(
+        scene.scene.integration_store().borrow().scene_revision(),
+        revision
+    );
     assert_eq!(scene.live_execution_ownership(), "transferred");
     scene.return_execution_player(player).unwrap();
     assert_eq!(
@@ -105,7 +108,7 @@ fn foreign_store_return_does_not_replace_either_contexts_lease() {
 fn different_root_in_the_same_store_is_not_the_leased_scene() {
     let (mut scene, _) = scene_with_circle();
     let mut other_scene =
-        CanonicalAuthoringScene::with_store(std::rc::Rc::clone(scene.scene.store()));
+        CanonicalAuthoringScene::with_store(std::rc::Rc::clone(scene.scene.integration_store()));
     let expected = scene.take_execution_player(1.0, 41).unwrap();
     let other = other_scene.take_execution_player(1.0, 41).unwrap();
     let rejection = scene.return_execution_player(other).unwrap_err();

--- a/crates/noon-web/src/execution_canvas.rs
+++ b/crates/noon-web/src/execution_canvas.rs
@@ -13,9 +13,9 @@ const MANIM_DEFAULT_CLEAR_COLOR: wgpu::Color = wgpu::Color {
 mod wasm {
     use std::{cell::Cell, mem, rc::Rc};
 
+    use noon::integration::RendererPublication;
     use noon::{
-        ExecutionSession, LiveContinuation, LiveProgram, LiveProgramStatus, RendererPublication,
-        RustHostCallbackTable,
+        ExecutionSession, LiveContinuation, LiveProgram, LiveProgramStatus, RustHostCallbackTable,
     };
     use noon_core::{
         Camera2DState, NativeEventOccurrence, NativeEventSource, NativeInputValue,
@@ -80,7 +80,7 @@ mod wasm {
     trait DirectLiveProgram {
         fn session(&self) -> &ExecutionSession;
         fn wake_plan(&self) -> BrowserExecutionWakePlan;
-        fn query_viewport(&mut self, bounds: Rect) -> noon::ExecutionViewportQuery;
+        fn query_viewport(&mut self, bounds: Rect) -> noon::integration::ExecutionViewportQuery;
         /// Returns whether this operation resumed a subsequent continuation stage.
         fn drive_to(&mut self, requested_time: f64) -> Result<DirectDriveOutcome, JsValue>;
         fn take_renderer_publication(&mut self) -> RendererPublication<'_>;
@@ -152,7 +152,7 @@ mod wasm {
             BrowserExecutionWakePlan::from_runtime(self.program.wake_state())
         }
 
-        fn query_viewport(&mut self, bounds: Rect) -> noon::ExecutionViewportQuery {
+        fn query_viewport(&mut self, bounds: Rect) -> noon::integration::ExecutionViewportQuery {
             self.program.query_viewport(bounds)
         }
 
@@ -265,7 +265,7 @@ mod wasm {
             }
         }
 
-        fn query_viewport(&mut self, bounds: Rect) -> noon::ExecutionViewportQuery {
+        fn query_viewport(&mut self, bounds: Rect) -> noon::integration::ExecutionViewportQuery {
             match &mut self.authority {
                 DirectSourceAuthority::Session { session, .. } => session.query_viewport(bounds),
                 DirectSourceAuthority::Program(program) => program.query_viewport(bounds),

--- a/crates/noon-web/src/geometry_export.rs
+++ b/crates/noon-web/src/geometry_export.rs
@@ -18,7 +18,7 @@ pub(crate) fn mobject_fields(
         StoredGeometry::Rectangle { size } => GeometryRef::Rectangle { size },
         StoredGeometry::Line { start, end } => GeometryRef::Line { start, end },
         StoredGeometry::Resource(handle) => match object
-            .store()
+            .integration_store()
             .borrow()
             .geometry_resources()
             .get(handle)
@@ -77,7 +77,7 @@ mod tests {
         let scene = noon::Scene::new();
         let object = scene.circle(1.0).unwrap();
         scene
-            .store()
+            .integration_store()
             .borrow_mut()
             .remove_node(object.node_id())
             .unwrap();

--- a/crates/noon-web/src/renderer_observation.rs
+++ b/crates/noon-web/src/renderer_observation.rs
@@ -1,4 +1,6 @@
-use noon::{CallbackRendererDirtyClassification, CommittedCallbackRendererObservation};
+use noon::integration::{
+    CallbackRendererDirtyClassification, CommittedCallbackRendererObservation,
+};
 use noon_core::{ObjectId, Style, Transform2D};
 use serde::{Deserialize, Serialize};
 

--- a/crates/noon-web/src/retained_execution_resources/morph_tests.rs
+++ b/crates/noon-web/src/retained_execution_resources/morph_tests.rs
@@ -46,7 +46,9 @@ fn morph_endpoint_publishes_geometry_after_clearing_render_override() {
         TrackTiming::new(1.0, 1.0, RateFunction::Linear),
         CompositionTimeMap::identity(),
     );
-    let committed = transaction.apply(&mut scene.store().borrow_mut()).unwrap();
+    let committed = transaction
+        .apply(&mut scene.integration_store().borrow_mut())
+        .unwrap();
     let root = scene
         .declare_animation(
             SemanticAnimationIntent::Composition {

--- a/crates/noon-web/src/retained_resource_transport.rs
+++ b/crates/noon-web/src/retained_resource_transport.rs
@@ -1523,7 +1523,8 @@ impl TransportTextLayoutBackendKind {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use noon::{MathTypst, RetainedScene, Typst};
+    use noon::integration::RetainedScene;
+    use noon::{MathTypst, Typst};
     use noon_core::TextSourceKind;
 
     fn text_handles(scene: &RetainedScene) -> Vec<TextResourceHandle> {

--- a/crates/noon-web/src/retained_typst_canvas.rs
+++ b/crates/noon-web/src/retained_typst_canvas.rs
@@ -1,6 +1,7 @@
 #[cfg(target_arch = "wasm32")]
 mod wasm {
-    use noon::{MathTypst, RetainedScene, Typst};
+    use noon::integration::RetainedScene;
+    use noon::{MathTypst, Typst};
     use noon_core::Vec2;
     use noon_render_wgpu::{Camera2D, GpuRenderer, RetainedFramePreparer, RetainedTextGpuState};
     use noon_runtime::SceneInstance;

--- a/crates/noon-web/src/semantic_execution_player.rs
+++ b/crates/noon-web/src/semantic_execution_player.rs
@@ -1,10 +1,11 @@
 //! Transport adapter for an already-lowered semantic session; never parses authoring JSON.
 #[cfg(any(target_arch = "wasm32", test))]
-use noon::TimelineWakeState;
-use noon::{
+use noon::integration::TimelineWakeState;
+use noon::integration::{
     CallbackAdvance, CallbackPhaseToken, CallbackReadRequest, CallbackReadValue,
-    EffectivePropertyBatch, EffectiveSemanticPropertyWrite, ExecutionSession, RuntimeIdentity,
+    EffectivePropertyBatch, EffectiveSemanticPropertyWrite, RuntimeIdentity,
 };
+use noon::ExecutionSession;
 use noon_core::{
     ExecutionRevision, FrameEpoch, PublicationContext, Rect, SceneRevision, SemanticNodeId, Style,
     Transform2D,
@@ -192,8 +193,8 @@ impl SemanticExecutionPlayer {
 
     fn retain_callback_phase(
         &mut self,
-        invocations: Vec<noon::RequiredCallbackInvocation>,
-        overlay: noon::CallbackPhaseOverlay,
+        invocations: Vec<noon::integration::RequiredCallbackInvocation>,
+        overlay: noon::integration::CallbackPhaseOverlay,
     ) -> Result<String, String> {
         let token = overlay.token();
         let phase_time = overlay.time();
@@ -749,7 +750,7 @@ impl SemanticExecutionPlayer {
         source: &noon::LayoutAnchor,
         target: noon::LiveLayoutTarget<'_>,
         aligner: &noon::LayoutAnchor,
-        args: noon::semantic_mobject::ManimNextToArgs,
+        args: noon::ManimNextToArgs,
     ) -> Result<(), String> {
         self.with_live_session(|live| live.next_layout_to_aligned(source, target, aligner, args))
             .map(|_| ())
@@ -1740,7 +1741,7 @@ impl TryFrom<CallbackTokenWire> for CallbackPhaseToken {
                 )?),
                 FrameEpoch::new(parse("frame epoch", token.publication.frame_epoch)?),
             ),
-            noon::CallbackSequence::new(parse("sequence", token.sequence)?),
+            noon::integration::CallbackSequence::new(parse("sequence", token.sequence)?),
         ))
     }
 }
@@ -1928,8 +1929,8 @@ fn decode_callback_batch(json: &str) -> Result<EffectivePropertyBatch, String> {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen)]
 impl SemanticExecutionPlayer {
     fn callback_phase_json(
-        overlay: &noon::CallbackPhaseOverlay,
-        invocations: &[noon::RequiredCallbackInvocation],
+        overlay: &noon::integration::CallbackPhaseOverlay,
+        invocations: &[noon::integration::RequiredCallbackInvocation],
     ) -> Result<String, String> {
         let phase = CallbackPhaseWire {
             token: overlay.token().into(),
@@ -2186,8 +2187,8 @@ impl SemanticExecutionPlayer {
             .callback_termination()
             .map(|termination| {
                 let kind = match termination.kind() {
-                    noon::CallbackTerminationKind::Failed => "failed",
-                    noon::CallbackTerminationKind::Interrupted => "interrupted",
+                    noon::integration::CallbackTerminationKind::Failed => "failed",
+                    noon::integration::CallbackTerminationKind::Interrupted => "interrupted",
                 };
                 serde_json::to_string(&CallbackTerminationWire {
                     token: termination.token().into(),
@@ -2240,14 +2241,16 @@ impl SemanticExecutionPlayer {
             .session
             .committed_callback_renderer_observation(token, target)
         {
-            noon::CallbackRendererObservationOutcome::Committed(observation) => observation,
-            noon::CallbackRendererObservationOutcome::StaleCallback { .. } => {
+            noon::integration::CallbackRendererObservationOutcome::Committed(observation) => {
+                observation
+            }
+            noon::integration::CallbackRendererObservationOutcome::StaleCallback { .. } => {
                 return Err("callback renderer observation token is stale".into());
             }
-            noon::CallbackRendererObservationOutcome::StalePublication { .. } => {
+            noon::integration::CallbackRendererObservationOutcome::StalePublication { .. } => {
                 return Err("callback renderer observation publication is stale".into());
             }
-            noon::CallbackRendererObservationOutcome::Absent { .. } => {
+            noon::integration::CallbackRendererObservationOutcome::Absent { .. } => {
                 return Err("callback renderer observation target is absent".into());
             }
         };
@@ -2376,7 +2379,7 @@ mod tests {
         let session = scene.execution_session().unwrap();
         let mut player = SemanticExecutionPlayer::from_live_session(
             session,
-            std::rc::Rc::clone(scene.store()),
+            std::rc::Rc::clone(scene.integration_store()),
             scene.root(),
             1.0,
             1,
@@ -2429,7 +2432,7 @@ mod tests {
         let mut target = circle.target_editor().unwrap();
         target.shift(4.0, 0.0).unwrap();
         let animation = scene
-            .store()
+            .integration_store()
             .borrow_mut()
             .insert_semantic_transform_animation(
                 circle.node_id(),
@@ -2440,7 +2443,7 @@ mod tests {
         let mut session = scene.execution_session().unwrap();
         session
             .activate_animation(
-                &scene.store().borrow(),
+                &scene.integration_store().borrow(),
                 animation,
                 AnimationOptions::new()
                     .run_time(1.0)
@@ -2535,7 +2538,7 @@ mod tests {
         let session = scene.execution_session().unwrap();
         let mut player = SemanticExecutionPlayer::from_live_session(
             session,
-            std::rc::Rc::clone(scene.store()),
+            std::rc::Rc::clone(scene.integration_store()),
             scene.root(),
             2.0,
             63,
@@ -2615,7 +2618,7 @@ mod tests {
         let session = scene.execution_session().unwrap();
         let mut player = SemanticExecutionPlayer::from_live_session(
             session,
-            std::rc::Rc::clone(scene.store()),
+            std::rc::Rc::clone(scene.integration_store()),
             scene.root(),
             4.0,
             67,
@@ -2676,11 +2679,13 @@ mod tests {
         let mut transaction = SemanticMutationTransaction::new();
         transaction.add_updater(circle.node_id(), HostCallbackId::new(7), 0.0, None);
         transaction.add_updater(circle.node_id(), HostCallbackId::new(8), 0.0, None);
-        transaction.apply(&mut scene.store().borrow_mut()).unwrap();
+        transaction
+            .apply(&mut scene.integration_store().borrow_mut())
+            .unwrap();
         let session = scene.execution_session().unwrap();
         let mut player = SemanticExecutionPlayer::from_live_session(
             session,
-            std::rc::Rc::clone(scene.store()),
+            std::rc::Rc::clone(scene.integration_store()),
             scene.root(),
             1.0,
             64,
@@ -2843,11 +2848,13 @@ mod tests {
         transaction.add_updater(source.node_id(), HostCallbackId::new(9), 0.0, None);
         transaction.add_updater(source.node_id(), HostCallbackId::new(4), 0.0, None);
         transaction.add_updater(drift.node_id(), HostCallbackId::new(2), 0.0, None);
-        transaction.apply(&mut scene.store().borrow_mut()).unwrap();
+        transaction
+            .apply(&mut scene.integration_store().borrow_mut())
+            .unwrap();
         let session = scene.execution_session().unwrap();
         let mut player = SemanticExecutionPlayer::from_live_session(
             session,
-            std::rc::Rc::clone(scene.store()),
+            std::rc::Rc::clone(scene.integration_store()),
             scene.root(),
             2.0,
             12,
@@ -2950,11 +2957,13 @@ mod tests {
         scene.add(&circle).unwrap();
         let mut transaction = SemanticMutationTransaction::new();
         transaction.add_updater(circle.node_id(), HostCallbackId::new(1), 0.0, None);
-        transaction.apply(&mut scene.store().borrow_mut()).unwrap();
+        transaction
+            .apply(&mut scene.integration_store().borrow_mut())
+            .unwrap();
         let session = scene.execution_session().unwrap();
         let mut player = SemanticExecutionPlayer::from_live_session(
             session,
-            std::rc::Rc::clone(scene.store()),
+            std::rc::Rc::clone(scene.integration_store()),
             scene.root(),
             1.0,
             13,
@@ -3000,11 +3009,13 @@ mod tests {
         scene.add(&circle).unwrap();
         let mut transaction = SemanticMutationTransaction::new();
         transaction.add_updater(circle.node_id(), HostCallbackId::new(1), 0.0, None);
-        transaction.apply(&mut scene.store().borrow_mut()).unwrap();
+        transaction
+            .apply(&mut scene.integration_store().borrow_mut())
+            .unwrap();
         let session = scene.execution_session().unwrap();
         let mut player = SemanticExecutionPlayer::from_live_session(
             session,
-            std::rc::Rc::clone(scene.store()),
+            std::rc::Rc::clone(scene.integration_store()),
             scene.root(),
             2.0,
             13,
@@ -3025,11 +3036,13 @@ mod tests {
         scene.add(&circle).unwrap();
         let mut transaction = SemanticMutationTransaction::new();
         transaction.add_updater(circle.node_id(), HostCallbackId::new(1), 0.0, None);
-        transaction.apply(&mut scene.store().borrow_mut()).unwrap();
+        transaction
+            .apply(&mut scene.integration_store().borrow_mut())
+            .unwrap();
         let session = scene.execution_session().unwrap();
         let mut player = SemanticExecutionPlayer::from_live_session(
             session,
-            std::rc::Rc::clone(scene.store()),
+            std::rc::Rc::clone(scene.integration_store()),
             scene.root(),
             2.0,
             14,
@@ -3154,7 +3167,9 @@ mod tests {
         let mut transaction = SemanticMutationTransaction::new();
         transaction.add_updater(circle.node_id(), HostCallbackId::new(1), 0.0, None);
         transaction.remove_updater(circle.node_id(), HostCallbackId::new(1), 0.5);
-        transaction.apply(&mut scene.store().borrow_mut()).unwrap();
+        transaction
+            .apply(&mut scene.integration_store().borrow_mut())
+            .unwrap();
         let mut player =
             SemanticExecutionPlayer::from_session(scene.execution_session().unwrap(), 2.0, 7)
                 .unwrap();
@@ -3185,7 +3200,7 @@ mod tests {
         let scene = noon::Scene::new();
         let mut player = SemanticExecutionPlayer::from_live_session(
             scene.execution_session().unwrap(),
-            std::rc::Rc::clone(scene.store()),
+            std::rc::Rc::clone(scene.integration_store()),
             scene.root(),
             2.0,
             81,

--- a/crates/noon-web/tests/host_callback_locality.rs
+++ b/crates/noon-web/tests/host_callback_locality.rs
@@ -1,9 +1,12 @@
-use noon::{
+use noon::integration::{
     CallbackAdvance, CallbackTerminationKind, EffectivePropertyBatch,
-    EffectiveSemanticPropertyWrite, ExecutionSession, ExecutionSessionCallbackError,
-    HostCallbackId, SemanticMutationTransaction, SemanticNodeId, SemanticObjectState,
-    SemanticStore, StoredGeometry, Style, Transform2D, Vec2,
+    EffectiveSemanticPropertyWrite,
 };
+use noon::{
+    ExecutionSession, ExecutionSessionCallbackError, SemanticNodeId, SemanticObjectState,
+    StoredGeometry, Style, Transform2D, Vec2,
+};
+use noon_core::{HostCallbackId, SemanticMutationTransaction, SemanticStore};
 
 const SCENE_OBJECTS: usize = 10_000;
 const HOST_OBJECT_INDEX: usize = SCENE_OBJECTS / 2;

--- a/crates/noon/examples/manim_dot_ellipse_oracle.rs
+++ b/crates/noon/examples/manim_dot_ellipse_oracle.rs
@@ -11,10 +11,12 @@ fn observe(object: &Mobject) -> Value {
 
 fn main() {
     let mut scene = Scene::new();
-    let dot = Mobject::manim_dot(Rc::clone(scene.store()), 0.0, 0.0, 0.08).unwrap();
-    let shifted = Mobject::manim_dot(Rc::clone(scene.store()), -2.0, 0.75, 0.18).unwrap();
-    let ellipse = Mobject::manim_ellipse(Rc::clone(scene.store()), 2.0, 1.0).unwrap();
-    let mut transformed = Mobject::manim_ellipse(Rc::clone(scene.store()), 4.0, 1.5).unwrap();
+    let dot = Mobject::manim_dot(Rc::clone(scene.integration_store()), 0.0, 0.0, 0.08).unwrap();
+    let shifted =
+        Mobject::manim_dot(Rc::clone(scene.integration_store()), -2.0, 0.75, 0.18).unwrap();
+    let ellipse = Mobject::manim_ellipse(Rc::clone(scene.integration_store()), 2.0, 1.0).unwrap();
+    let mut transformed =
+        Mobject::manim_ellipse(Rc::clone(scene.integration_store()), 4.0, 1.5).unwrap();
     transformed.rotate(std::f64::consts::PI / 6.0).unwrap();
     transformed.shift(1.25, -0.5).unwrap();
     for object in [&dot, &shifted, &ellipse, &transformed] {

--- a/crates/noon/examples/manim_elbow_oracle.rs
+++ b/crates/noon/examples/manim_elbow_oracle.rs
@@ -1,15 +1,13 @@
 //! Explicit differential-test observations from a normal typed Rust session.
-use noon::{
-    GeometryRef, GeometryResource, GeometryResourceLookup, ManimGeometryOptions, Mobject,
-    PathCommand, Scene,
-};
+use noon::{GeometryRef, ManimGeometryOptions, Mobject, PathCommand, Scene};
+use noon_core::{GeometryResource, GeometryResourceLookup};
 use serde_json::{json, Map, Value};
 use std::rc::Rc;
 
 fn observation(width: f32, angle: f32) -> Value {
     let mut scene = Scene::new();
     let elbow = Mobject::from_manim_geometry(
-        Rc::clone(scene.store()),
+        Rc::clone(scene.integration_store()),
         ManimGeometryOptions::elbow(width.into(), angle.into()).unwrap(),
     )
     .unwrap();

--- a/crates/noon/examples/shared_authoring.rs
+++ b/crates/noon/examples/shared_authoring.rs
@@ -1,90 +1,62 @@
-//! Direct Rust proof for the generic shared authoring path, without serialization.
-use noon::{
-    AnimationOptions, RateFunction, Scene, SemanticAnimationIntent, SemanticAnimationState,
-    SemanticMutationImpact, SemanticMutationTransaction, SemanticObjectProperty, SemanticVec3,
-    Vec2,
-};
+//! Direct public-API counterpart of web/python/examples/live_affine_completion.py.
+//! Construction, authored/effective queries, live edits and logical completion
+//! need no raw store, compiler transaction, or host ownership knowledge.
+use noon::{AnimationOptions, RateFunction, Scene, Vec2};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut scene = Scene::new();
-    let mut circle = scene.circle(1.0)?;
-    circle.shift(2.0, -1.0)?;
-    circle.set_fill(0.0, 1.0, 0.0, 0.5)?;
-    assert_eq!(circle.center()?, (2.0, -1.0));
-    assert_eq!(circle.width()?, 2.0);
-    assert_eq!(circle.fill_opacity()?, 0.5);
+    let circle = scene.circle(1.0)?;
     scene.add(&circle)?;
-
-    let mut target = circle.target_editor()?;
-    target.shift(4.0, 0.0)?;
-    target.manim_scale(2.0, 2.0)?;
+    let mut first_target = circle.target_editor()?;
+    first_target.shift(2.0, -2.0)?;
+    let mut second_target = circle.target_editor()?;
+    second_target.shift(5.0, -2.0)?;
     let options = AnimationOptions::new()
-        .run_time(1.0)
+        .run_time(2.0)
         .rate_func(RateFunction::Linear);
-    let mut transaction = SemanticMutationTransaction::new();
-    transaction.add_animation(SemanticAnimationState::new(
-        SemanticAnimationIntent::TransformTo {
-            target: circle.node_id(),
-            target_state: target.node_id(),
-            interpolation: noon_core::SemanticTransformInterpolation::Affine,
-        },
-        options,
-    ));
+    let first = scene.declare_transform_to(&circle, &first_target, options)?;
+    let second = scene.declare_transform_to(&circle, &second_target, options)?;
     let mut session = scene.execution_session()?;
-    let result =
-        session.apply_semantic_transaction(&mut scene.store().borrow_mut(), transaction)?;
-    let [SemanticMutationImpact::AnimationAdded { animation }] = result.impacts() else {
-        unreachable!()
-    };
-    session.activate_animation_segment(&scene.store().borrow(), *animation, options)?;
-    session.seek(0.5)?;
-    assert_eq!(session.frame().objects.len(), 1);
+    let mut live = scene.live(&mut session);
+    let segment = live.play_animation(&first)?;
+    live.advance_segment_to(segment, 1.0)?;
     assert_eq!(
-        session.frame().objects[0].transform.translation,
-        Vec2::new(4.0, -1.0)
+        live.effective(&circle)?.transform.translation,
+        Vec2::new(1.0, -1.0)
     );
+    assert_eq!(live.authored(&circle)?.transform.translation.x, 0.0);
+    live.advance_segment_to(segment, segment.end_time())?;
+    assert!(!live.segment_state(segment).is_complete());
+    live.complete_segment(segment)?;
+    assert!(live.segment_state(segment).is_complete());
     assert_eq!(
-        session.frame().objects[0].transform.scale,
-        Vec2::new(1.5, 1.5)
+        live.effective(&circle)?.transform.translation,
+        Vec2::new(2.0, -2.0)
     );
-    session.seek(1.0)?;
+    assert_eq!(live.authored(&circle)?.transform.translation.x, 2.0);
+    live.set_translation(&circle, 3.0, -2.0)?;
+    let wait = live.wait_segment(0.25)?;
+    live.advance_segment_to(wait, wait.end_time())?;
+    live.complete_segment(wait)?;
     assert_eq!(
-        session.frame().objects[0].transform.translation,
-        Vec2::new(6.0, -1.0)
+        live.effective(&circle)?.transform.translation,
+        Vec2::new(3.0, -2.0)
     );
-    assert_eq!(circle.center()?, (2.0, -1.0));
-
-    // Continuation reads the published effective endpoint, then prepares the next
-    // target and a persistent base edit through the same atomic publication path.
-    let endpoint = session
-        .effective_semantic_object(&scene.store().borrow(), circle.node_id())?
-        .object
-        .transform
-        .translation;
-    let mut next = SemanticMutationTransaction::new();
-    next.set_property(
-        circle.node_id(),
-        SemanticObjectProperty::Translation,
-        SemanticVec3::new(endpoint.x as f64, endpoint.y as f64, 0.0),
-    );
-    next.set_property(
-        target.node_id(),
-        SemanticObjectProperty::Translation,
-        SemanticVec3::new(endpoint.x as f64 + 4.0, endpoint.y as f64, 0.0),
-    );
-    session.apply_semantic_transaction(&mut scene.store().borrow_mut(), next)?;
-    let segment =
-        session.activate_animation_segment(&scene.store().borrow(), *animation, options)?;
-    session.advance_segment_to(segment, segment.end_time())?;
-    assert!(session.segment_state(segment).is_complete());
+    // Activation reads the edited effective value, not the declaration-time base.
+    let segment = live.play_animation(&second)?;
+    live.advance_segment_to(segment, segment.end_time() - 1.0)?;
     assert_eq!(
-        session
-            .effective_semantic_object(&scene.store().borrow(), circle.node_id())?
-            .object
-            .transform
-            .translation,
-        Vec2::new(10.0, -1.0)
+        live.effective(&circle)?.transform.translation,
+        Vec2::new(4.0, -2.0)
     );
-    assert_eq!(circle.center()?, (6.0, -1.0));
+    assert_eq!(live.authored(&circle)?.transform.translation.x, 3.0);
+    live.advance_segment_to(segment, segment.end_time())?;
+    live.complete_segment(segment)?;
+    assert_eq!(
+        live.effective(&circle)?.transform.translation,
+        Vec2::new(5.0, -2.0)
+    );
+    assert_eq!(live.authored(&circle)?.transform.translation.x, 5.0);
+    assert!(live.segment_state(segment).is_complete());
     Ok(())
 }

--- a/crates/noon/src/animation_authoring.rs
+++ b/crates/noon/src/animation_authoring.rs
@@ -69,12 +69,15 @@ impl crate::Scene {
         let mut transaction = SemanticMutationTransaction::new();
         transaction.add_animation(SemanticAnimationState::new(intent, options));
         let result = transaction
-            .apply(&mut self.store().borrow_mut())
+            .apply(&mut self.integration_store().borrow_mut())
             .map_err(|error| error.to_string())?;
         let [SemanticMutationImpact::AnimationAdded { animation }] = result.impacts() else {
             return Err("animation declaration did not produce one animation identity".into());
         };
-        Ok(DeclaredAnimation::new(Rc::clone(self.store()), *animation))
+        Ok(DeclaredAnimation::new(
+            Rc::clone(self.integration_store()),
+            *animation,
+        ))
     }
 
     /// Declare a shared affine transform between two store-scoped mobjects.
@@ -188,12 +191,15 @@ mod tests {
         let circle = scene.circle(1.0).unwrap();
         scene.add(&circle).unwrap();
         let foreign = crate::Scene::new().circle(1.0).unwrap();
-        let revision = scene.store().borrow().scene_revision();
+        let revision = scene.integration_store().borrow().scene_revision();
 
         assert!(scene
             .declare_transform_to(&circle, &foreign, AnimationOptions::new())
             .is_err());
-        assert_eq!(scene.store().borrow().scene_revision(), revision);
+        assert_eq!(
+            scene.integration_store().borrow().scene_revision(),
+            revision
+        );
     }
 
     #[test]

--- a/crates/noon/src/camera_authoring.rs
+++ b/crates/noon/src/camera_authoring.rs
@@ -14,7 +14,7 @@ impl Scene {
     /// transformable Mobject; its role only tells lowering which effective transform supplies the
     /// renderer viewport.
     pub fn camera_frame(&mut self) -> Result<Mobject, String> {
-        let store = self.store().borrow();
+        let store = self.integration_store().borrow();
         let root_is_empty = store
             .node(self.root())
             .ok_or("scene root is unavailable")?
@@ -38,7 +38,7 @@ impl Scene {
         let frame = transaction.create_node(SemanticNodeCreation::object(state));
         transaction.add_member(self.root(), frame);
         let result = transaction
-            .apply(&mut self.store().borrow_mut())
+            .apply(&mut self.integration_store().borrow_mut())
             .map_err(|error| error.to_string())?;
         let id = result
             .resolve(frame)
@@ -50,7 +50,7 @@ impl Scene {
                 SemanticMutationImpact::FamilyMemberAdded { .. }
             ]
         ));
-        Mobject::from_node(std::rc::Rc::clone(self.store()), id)
+        Mobject::from_node(std::rc::Rc::clone(self.integration_store()), id)
     }
 }
 
@@ -66,23 +66,31 @@ mod tests {
     #[test]
     fn camera_creation_is_atomic_unique_and_uses_the_scene_identity_space() {
         let mut scene = Scene::new();
-        let revision = scene.store().borrow().scene_revision();
+        let revision = scene.integration_store().borrow().scene_revision();
         let frame = scene.camera_frame().unwrap();
         let state = frame.state().unwrap();
         assert_eq!(state.role(), SemanticObjectRole::Camera2D);
         assert_eq!(state.style.object_opacity, 0.0);
         assert_eq!(
-            scene.store().borrow().node(scene.root()).unwrap().members(),
+            scene
+                .integration_store()
+                .borrow()
+                .node(scene.root())
+                .unwrap()
+                .members(),
             [frame.node_id()]
         );
-        assert_ne!(scene.store().borrow().scene_revision(), revision);
+        assert_ne!(
+            scene.integration_store().borrow().scene_revision(),
+            revision
+        );
 
-        let before = scene.store().borrow().scene_revision();
+        let before = scene.integration_store().borrow().scene_revision();
         assert_eq!(
             scene.camera_frame().unwrap_err(),
             "2D camera frame must be created before scene content"
         );
-        assert_eq!(scene.store().borrow().scene_revision(), before);
+        assert_eq!(scene.integration_store().borrow().scene_revision(), before);
     }
 
     #[test]
@@ -90,15 +98,20 @@ mod tests {
         let mut scene = Scene::new();
         let square = scene.square(2.0).unwrap();
         scene.add(&square).unwrap();
-        let before = scene.store().borrow().scene_revision();
+        let before = scene.integration_store().borrow().scene_revision();
 
         assert_eq!(
             scene.camera_frame().unwrap_err(),
             "2D camera frame must be created before scene content"
         );
-        assert_eq!(scene.store().borrow().scene_revision(), before);
+        assert_eq!(scene.integration_store().borrow().scene_revision(), before);
         assert_eq!(
-            scene.store().borrow().node(scene.root()).unwrap().members(),
+            scene
+                .integration_store()
+                .borrow()
+                .node(scene.root())
+                .unwrap()
+                .members(),
             [square.node_id()]
         );
     }

--- a/crates/noon/src/diagnostics.rs
+++ b/crates/noon/src/diagnostics.rs
@@ -120,7 +120,8 @@ mod tests {
     fn debug_capture_resolves_retained_paths_and_effective_transforms() {
         let mut scene = Scene::new();
         let mut shape =
-            crate::Mobject::manim_square(std::rc::Rc::clone(scene.store()), 2.0).unwrap();
+            crate::Mobject::manim_square(std::rc::Rc::clone(scene.integration_store()), 2.0)
+                .unwrap();
         shape.set_fill_color(0.25, 0.5, 0.75, 0.4).unwrap();
         shape.set_fill_opacity(0.4).unwrap();
         shape.set_object_opacity(0.5).unwrap();

--- a/crates/noon/src/example_scenes.rs
+++ b/crates/noon/src/example_scenes.rs
@@ -36,12 +36,13 @@ use std::{error::Error, rc::Rc};
 
 use crate::{
     AffineLifecycleDirection, AffineLifecycleEndpoint, AnimationCompositionRequest,
-    AnimationOptions, Color, ExecutionSession, HostCallbackId, LiveContinuation, LiveProgram,
-    LiveSession, Mobject, RateFunction, RustHostCallbackTable, Scene,
-    SemanticAnimationCompositionKind, SemanticFadeDirection, SemanticNodeId, SemanticPaint,
-    SemanticStyle, SemanticVec3, StoredGeometry, StrokeCap, StrokeJoin, StrokeWidthMode,
-    TransformToRequest, ValueTracker, Vec2, VectorPath,
+    AnimationOptions, Color, ExecutionSession, LiveContinuation, LiveProgram, LiveSession, Mobject,
+    RateFunction, RustHostCallbackTable, Scene, SemanticAnimationCompositionKind,
+    SemanticFadeDirection, SemanticNodeId, SemanticPaint, SemanticStyle, SemanticVec3,
+    StoredGeometry, StrokeCap, StrokeJoin, StrokeWidthMode, TransformToRequest, ValueTracker, Vec2,
+    VectorPath,
 };
+use noon_core::HostCallbackId;
 
 /// Direct counterpart of Manim's DifferentRotations example.
 pub struct OrdinaryDifferentRotations {
@@ -235,7 +236,7 @@ pub fn live_affine_callbacks() -> Result<(ExecutionSession, RustHostCallbackTabl
     })?;
 
     {
-        let mut store = scene.store().borrow_mut();
+        let mut store = scene.integration_store().borrow_mut();
         callbacks.add_updater(&mut store, label.node_id(), ACCUMULATE_TEXT_DT, 0.0, None)?;
         callbacks.add_updater(&mut store, source.node_id(), SET_Y, 0.0, None)?;
         callbacks.add_updater(&mut store, source.node_id(), SET_OPACITY, 0.0, None)?;
@@ -304,7 +305,7 @@ pub fn live_callback_paint() -> Result<(ExecutionSession, RustHostCallbackTable)
             .map_err(|error| std::io::Error::other(error.to_string()))
     })?;
     {
-        let mut store = scene.store().borrow_mut();
+        let mut store = scene.integration_store().borrow_mut();
         callbacks.add_updater(&mut store, source.node_id(), RECOLOR_PAINT, 0.0, None)?;
         callbacks.add_updater(
             &mut store,
@@ -361,7 +362,7 @@ pub fn live_line_callback_rotation(
             .map_err(|error| std::io::Error::other(error.to_string()))
     })?;
     {
-        let mut store = scene.store().borrow_mut();
+        let mut store = scene.integration_store().borrow_mut();
         callbacks.add_updater(&mut store, moving.node_id(), ROTATE_LINE_FORWARD, 0.0, None)?;
         callbacks.add_updater(
             &mut store,
@@ -435,7 +436,7 @@ pub fn live_line_match_callback(
             .map_err(|error| std::io::Error::other(error.to_string()))
     })?;
     {
-        let mut store = scene.store().borrow_mut();
+        let mut store = scene.integration_store().borrow_mut();
         callbacks.add_updater(&mut store, left_id, MOVE_MATCH_DOT, 0.0, None)?;
         callbacks.add_updater(&mut store, line.node_id(), MATCH_LINE_ENDPOINTS, 0.0, None)?;
     }
@@ -872,7 +873,7 @@ pub fn ordinary_value_tracker_continuation_program(
     // Model a host-language tracker constructed before its eventual Scene body:
     // the shared store owns its identity/value while it is detached. The first
     // continuation step enrolls this same handle through LiveSession.
-    let tracker = ValueTracker::detached(Rc::clone(scene.store()), 0.0)?;
+    let tracker = ValueTracker::detached(Rc::clone(scene.integration_store()), 0.0)?;
     let position = scene
         .position_from_tracker(
             &tracker,
@@ -1211,7 +1212,7 @@ pub fn ordinary_callback_continuation_program() -> Result<
 
     let callbacks = ordered_affine_callbacks(Some(0.75)).map_err(|error| error.to_string())?;
     {
-        let mut store = scene.store().borrow_mut();
+        let mut store = scene.integration_store().borrow_mut();
         callbacks
             .add_updater(&mut store, circle.node_id(), SET_Y, 0.0, None)
             .map_err(|error| error.to_string())?;
@@ -1361,7 +1362,7 @@ pub fn ordinary_callback_sparse_reads_program() -> Result<
         .map_err(|error| error.to_string())?;
     callbacks
         .add_updater(
-            &mut scene.store().borrow_mut(),
+            &mut scene.integration_store().borrow_mut(),
             circle.node_id(),
             FOLLOW_SPARSE_READS,
             0.0,
@@ -1663,7 +1664,7 @@ impl LiveContinuation for OrdinaryAffineLifecycleContinuation {
 pub fn ordinary_affine_lifecycle_program(
 ) -> Result<LiveProgram<OrdinaryAffineLifecycleContinuation>, String> {
     let scene = Scene::new();
-    let mut square = Mobject::manim_square(Rc::clone(scene.store()), 1.0)?;
+    let mut square = Mobject::manim_square(Rc::clone(scene.integration_store()), 1.0)?;
     square.set_fill(
         f64::from(Color::BLUE.red),
         f64::from(Color::BLUE.green),
@@ -2390,7 +2391,8 @@ pub fn live_native_signals() -> Result<ExecutionSession, Box<dyn Error>> {
 #[cfg(test)]
 mod continuation_tests {
     use super::*;
-    use crate::{LiveProgramStatus, TimelineWakeState};
+    use crate::LiveProgramStatus;
+    use noon_runtime::TimelineWakeState;
 
     #[test]
     fn different_rotations_keeps_point_transform_distinct_from_angular_path() {

--- a/crates/noon/src/example_scenes/affine_fade.rs
+++ b/crates/noon/src/example_scenes/affine_fade.rs
@@ -71,7 +71,7 @@ impl LiveContinuation for AffineFade {
 
 pub fn program() -> Result<LiveProgram<AffineFade>, String> {
     let scene = Scene::new();
-    let mut circle = Mobject::manim_circle(Rc::clone(scene.store()), 0.4)?;
+    let mut circle = Mobject::manim_circle(Rc::clone(scene.integration_store()), 0.4)?;
     circle.set_fill(
         f64::from(Color::BLUE.red),
         f64::from(Color::BLUE.green),

--- a/crates/noon/src/example_scenes/analytic_profile.rs
+++ b/crates/noon/src/example_scenes/analytic_profile.rs
@@ -1,9 +1,12 @@
 //! Analytic workloads for native/direct-WASM profiling, paired with `analytic_profile.py`.
 
 use crate::{
-    AnimationOptions, CompositionTimeMap, ExecutionSession, MobjectFamilyMember, RateFunction,
-    Scene, SemanticAnimationCompositionKind, SemanticAnimationIntent, SemanticMutationTransaction,
-    SemanticObjectTrackProperty, SemanticObjectTrackValues, SemanticVec3, TrackTiming,
+    AnimationOptions, ExecutionSession, MobjectFamilyMember, RateFunction, Scene,
+    SemanticAnimationCompositionKind, SemanticVec3,
+};
+use noon_core::{
+    CompositionTimeMap, SemanticAnimationIntent, SemanticMutationTransaction,
+    SemanticObjectTrackProperty, SemanticObjectTrackValues, TrackTiming,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -108,7 +111,7 @@ pub fn session(
         CompositionTimeMap::identity(),
     );
     let committed = transaction
-        .apply(&mut scene.store().borrow_mut())
+        .apply(&mut scene.integration_store().borrow_mut())
         .map_err(|error| error.to_string())?;
     let root = scene.declare_animation(
         SemanticAnimationIntent::Composition {

--- a/crates/noon/src/example_scenes/draw_border_then_fill.rs
+++ b/crates/noon/src/example_scenes/draw_border_then_fill.rs
@@ -50,7 +50,7 @@ impl LiveContinuation for DrawBorderThenFill {
 
 pub fn program() -> Result<LiveProgram<DrawBorderThenFill>, String> {
     let scene = Scene::new();
-    let mut square = Mobject::manim_square(Rc::clone(scene.store()), 0.8)?;
+    let mut square = Mobject::manim_square(Rc::clone(scene.integration_store()), 0.8)?;
     square.set_fill(
         f64::from(Color::ORANGE.red),
         f64::from(Color::ORANGE.green),
@@ -64,7 +64,7 @@ pub fn program() -> Result<LiveProgram<DrawBorderThenFill>, String> {
         1.0,
     )?;
     square.set_stroke_width(0.06)?;
-    let mut circle = Mobject::manim_circle(Rc::clone(scene.store()), 0.4)?;
+    let mut circle = Mobject::manim_circle(Rc::clone(scene.integration_store()), 0.4)?;
     circle.set_fill(
         f64::from(Color::PINK.red),
         f64::from(Color::PINK.green),

--- a/crates/noon/src/example_scenes/exact_property_tracks.rs
+++ b/crates/noon/src/example_scenes/exact_property_tracks.rs
@@ -1,9 +1,12 @@
 //! Exact authored channels lower once into the shared runtime on native and WASM.
 
 use crate::{
-    AnimationOptions, CompositionTimeMap, ExecutionSession, RateFunction, Scene,
-    SemanticAnimationCompositionKind, SemanticAnimationIntent, SemanticMutationTransaction,
-    SemanticObjectTrackProperty, SemanticObjectTrackValues, SemanticVec3, TrackTiming,
+    AnimationOptions, ExecutionSession, RateFunction, Scene, SemanticAnimationCompositionKind,
+    SemanticVec3,
+};
+use noon_core::{
+    CompositionTimeMap, SemanticAnimationIntent, SemanticMutationTransaction,
+    SemanticObjectTrackProperty, SemanticObjectTrackValues, TrackTiming,
 };
 
 /// A moving, fading red circle above an independently rotating blue square.
@@ -54,7 +57,7 @@ pub fn session() -> Result<ExecutionSession, String> {
         CompositionTimeMap::identity(),
     );
     let result = transaction
-        .apply(&mut scene.store().borrow_mut())
+        .apply(&mut scene.integration_store().borrow_mut())
         .map_err(|error| error.to_string())?;
     let root = scene.declare_animation(
         SemanticAnimationIntent::Composition {

--- a/crates/noon/src/example_scenes/family_arrangement.rs
+++ b/crates/noon/src/example_scenes/family_arrangement.rs
@@ -109,8 +109,8 @@ impl LiveContinuation for FamilyArrangement {
 
 pub fn program() -> Result<LiveProgram<FamilyArrangement>, String> {
     let mut scene = Scene::new();
-    let mut first = Mobject::manim_circle(Rc::clone(scene.store()), 0.2)?;
-    let mut second = Mobject::manim_circle(Rc::clone(scene.store()), 0.2)?;
+    let mut first = Mobject::manim_circle(Rc::clone(scene.integration_store()), 0.2)?;
+    let mut second = Mobject::manim_circle(Rc::clone(scene.integration_store()), 0.2)?;
     for (object, color) in [(&mut first, Color::BLUE), (&mut second, Color::YELLOW)] {
         object.set_fill(
             f64::from(color.red),

--- a/crates/noon/src/example_scenes/family_placement.rs
+++ b/crates/noon/src/example_scenes/family_placement.rs
@@ -7,9 +7,9 @@ use std::rc::Rc;
 
 pub fn session() -> Result<ExecutionSession, String> {
     let mut scene = Scene::new();
-    let mut first = Mobject::manim_circle(Rc::clone(scene.store()), 0.2)?;
-    let mut second = Mobject::manim_circle(Rc::clone(scene.store()), 0.2)?;
-    let mut anchor = Mobject::manim_square(Rc::clone(scene.store()), 1.0)?;
+    let mut first = Mobject::manim_circle(Rc::clone(scene.integration_store()), 0.2)?;
+    let mut second = Mobject::manim_circle(Rc::clone(scene.integration_store()), 0.2)?;
+    let mut anchor = Mobject::manim_square(Rc::clone(scene.integration_store()), 1.0)?;
     for (object, color) in [
         (&mut first, Color::BLUE),
         (&mut second, Color::YELLOW),

--- a/crates/noon/src/example_scenes/family_transform_indicate.rs
+++ b/crates/noon/src/example_scenes/family_transform_indicate.rs
@@ -112,8 +112,8 @@ impl FamilyTransformIndicate {
 
 pub fn program() -> Result<LiveProgram<FamilyTransformIndicate>, String> {
     let mut scene = Scene::new();
-    let mut left = Mobject::manim_square(Rc::clone(scene.store()), 0.6)?;
-    let mut right = Mobject::manim_circle(Rc::clone(scene.store()), 0.3)?;
+    let mut left = Mobject::manim_square(Rc::clone(scene.integration_store()), 0.6)?;
+    let mut right = Mobject::manim_circle(Rc::clone(scene.integration_store()), 0.3)?;
     left.set_translation(-2.0, 0.0)?;
     right.set_translation(0.0, 0.0)?;
     for (object, color) in [(&mut left, Color::PINK), (&mut right, Color::BLUE)] {

--- a/crates/noon/src/example_scenes/line_passing_flash.rs
+++ b/crates/noon/src/example_scenes/line_passing_flash.rs
@@ -91,7 +91,7 @@ pub fn program() -> Result<LiveProgram<LinePassingFlash>, String> {
     options.disable_fill();
     options.set_stroke_color(0.0, 1.0, 1.0, 1.0)?;
     options.set_stroke_width(0.08)?;
-    let line = Mobject::from_manim_geometry(Rc::clone(scene.store()), options)?;
+    let line = Mobject::from_manim_geometry(Rc::clone(scene.integration_store()), options)?;
     let identity = line.node_id();
     scene
         .into_live_program(LinePassingFlash {

--- a/crates/noon/src/example_scenes/live_geometry_construction.rs
+++ b/crates/noon/src/example_scenes/live_geometry_construction.rs
@@ -205,18 +205,18 @@ pub fn program() -> Result<LiveProgram<LiveGeometryConstruction>, String> {
     options.set_translation(-2.0, 0.0)?;
     options.set_fill(0.0, 0.0, 1.0, 1.0)?;
     options.disable_stroke();
-    let path = Mobject::from_manim_geometry(Rc::clone(scene.store()), options)?;
+    let path = Mobject::from_manim_geometry(Rc::clone(scene.integration_store()), options)?;
     let bounds = path.layout_bounds()?.ok_or("path has no bounds")?;
     let family_bounds = scene
         .family(&[(&path).into()])?
         .layout_bounds()?
         .ok_or("path family has no bounds")?;
     let outline = Mobject::from_manim_geometry(
-        Rc::clone(scene.store()),
+        Rc::clone(scene.integration_store()),
         ManimGeometryOptions::surrounding_rectangle(bounds, 0.15, 0.15, 0.1)?,
     )?;
     let background = Mobject::from_manim_geometry(
-        Rc::clone(scene.store()),
+        Rc::clone(scene.integration_store()),
         ManimGeometryOptions::background_rectangle(family_bounds, 0.25, 0.25, 0.1, 0.5)?,
     )?;
     scene.add_many(&[

--- a/crates/noon/src/example_scenes/live_updater_lifecycle.rs
+++ b/crates/noon/src/example_scenes/live_updater_lifecycle.rs
@@ -1,8 +1,9 @@
 //! Sequential counterpart of the exact Python RotationUpdater gallery source.
 use crate::{
-    ContinuationStep, HostCallbackId, LiveContinuation, LiveProgram, LiveSession, Mobject,
-    RustHostCallbackTable, Scene, SemanticMutationTransaction, Vec2,
+    ContinuationStep, LiveContinuation, LiveProgram, LiveSession, Mobject, RustHostCallbackTable,
+    Scene, Vec2,
 };
+use noon_core::{HostCallbackId, SemanticMutationTransaction};
 
 const FORTH: HostCallbackId = HostCallbackId::new(1);
 const BACK: HostCallbackId = HostCallbackId::new(2);
@@ -62,7 +63,7 @@ pub fn program() -> Result<(LiveProgram<RotationUpdater>, RustHostCallbackTable)
     }
     callbacks
         .add_updater(
-            &mut scene.store().borrow_mut(),
+            &mut scene.integration_store().borrow_mut(),
             moving.node_id(),
             FORTH,
             0.0,

--- a/crates/noon/src/example_scenes/mixed_scalar_composition.rs
+++ b/crates/noon/src/example_scenes/mixed_scalar_composition.rs
@@ -89,8 +89,8 @@ impl LiveContinuation for MixedScalarComposition {
 
 pub fn program() -> Result<LiveProgram<MixedScalarComposition>, String> {
     let mut scene = Scene::new();
-    let mut circle = Mobject::manim_circle(Rc::clone(scene.store()), 0.3)?;
-    let mut square = Mobject::manim_square(Rc::clone(scene.store()), 1.0)?;
+    let mut circle = Mobject::manim_circle(Rc::clone(scene.integration_store()), 0.3)?;
+    let mut square = Mobject::manim_square(Rc::clone(scene.integration_store()), 1.0)?;
     for (object, color) in [(&mut circle, Color::BLUE), (&mut square, Color::PINK)] {
         object.set_fill(
             f64::from(color.red),

--- a/crates/noon/src/example_scenes/ordinary_become_semantics.rs
+++ b/crates/noon/src/example_scenes/ordinary_become_semantics.rs
@@ -153,7 +153,7 @@ fn rectangle(
     options.set_translation(x, 0.0)?;
     options.set_fill(red, green, blue, 1.0)?;
     options.disable_stroke();
-    Mobject::from_manim_geometry(Rc::clone(scene.store()), options)
+    Mobject::from_manim_geometry(Rc::clone(scene.integration_store()), options)
 }
 
 pub fn program() -> Result<LiveProgram<OrdinaryBecomeSemantics>, String> {
@@ -167,15 +167,17 @@ pub fn program() -> Result<LiveProgram<OrdinaryBecomeSemantics>, String> {
     stretched_target_options.set_translation(-3.5, 0.0)?;
     stretched_target_options.set_fill(1.0, 0.0, 1.0, 1.0)?;
     stretched_target_options.disable_stroke();
-    let stretched_target =
-        Mobject::from_manim_geometry(Rc::clone(scene.store()), stretched_target_options)?;
+    let stretched_target = Mobject::from_manim_geometry(
+        Rc::clone(scene.integration_store()),
+        stretched_target_options,
+    )?;
     let mut ellipse_target_options = ManimGeometryOptions::ellipse(4.0, 1.5)?;
     ellipse_target_options.set_translation(0.0, 2.5)?;
     ellipse_target_options.set_rotation(std::f64::consts::PI / 6.0)?;
     ellipse_target_options.set_fill(0.0, 1.0, 1.0, 1.0)?;
     ellipse_target_options.disable_stroke();
     let ellipse_target =
-        Mobject::from_manim_geometry(Rc::clone(scene.store()), ellipse_target_options)?;
+        Mobject::from_manim_geometry(Rc::clone(scene.integration_store()), ellipse_target_options)?;
     let ellipse_target_bounds = ellipse_target
         .layout_bounds()?
         .ok_or("ellipse target has no authored layout bounds")?;

--- a/crates/noon/src/example_scenes/ordinary_membership.rs
+++ b/crates/noon/src/example_scenes/ordinary_membership.rs
@@ -4,8 +4,9 @@ use std::{cell::RefCell, rc::Rc};
 use crate::{
     ContinuationStep, LiveContinuation, LiveProgram, LiveSession, Mobject, MobjectFamily,
     MobjectFamilyMember::{Family, Mobject as Leaf},
-    Scene, SemanticNodeId, SemanticStore,
+    Scene, SemanticNodeId,
 };
+use noon_core::SemanticStore;
 
 pub struct OrdinaryMembership {
     red: Mobject,
@@ -95,7 +96,7 @@ pub fn program() -> Result<LiveProgram<OrdinaryMembership>, String> {
         blue,
         green,
         family,
-        store: Rc::clone(scene.store()),
+        store: Rc::clone(scene.integration_store()),
         root: scene.root(),
         stage: 0,
     };

--- a/crates/noon/src/example_scenes/ordinary_subset_display.rs
+++ b/crates/noon/src/example_scenes/ordinary_subset_display.rs
@@ -57,7 +57,7 @@ impl LiveContinuation for OrdinarySubsetDisplay {
 }
 
 fn colored_circle(scene: &Scene, x: f64, y: f64, color: Color) -> Result<Mobject, String> {
-    let mut circle = Mobject::manim_circle(Rc::clone(scene.store()), 0.3)?;
+    let mut circle = Mobject::manim_circle(Rc::clone(scene.integration_store()), 0.3)?;
     circle.set_translation(x, y)?;
     circle.set_fill(
         f64::from(color.red),

--- a/crates/noon/src/example_scenes/specialized_geometry.rs
+++ b/crates/noon/src/example_scenes/specialized_geometry.rs
@@ -7,7 +7,7 @@ use crate::{ExecutionSession, Mobject, MobjectFamilyMember, Scene};
 /// A grid of nine geometry constructors, paired with `specialized_geometry.py`.
 pub fn session() -> Result<ExecutionSession, String> {
     let mut scene = Scene::new();
-    let store = || Rc::clone(scene.store());
+    let store = || Rc::clone(scene.integration_store());
     let dot = Mobject::manim_dot(store(), -4.0, 2.0, 0.3)?;
     let mut triangle = Mobject::manim_triangle(store())?;
     triangle.shift(0.0, 2.0)?;

--- a/crates/noon/src/example_scenes/text_family_fade.rs
+++ b/crates/noon/src/example_scenes/text_family_fade.rs
@@ -57,7 +57,7 @@ impl LiveContinuation for TextFamilyFade {
                     return Err("Text Write did not admit its direct scene root".into());
                 }
                 {
-                    let store = self.family.store().borrow();
+                    let store = self.family.integration_store().borrow();
                     let family = store
                         .node(self.family.node_id())
                         .ok_or("Text family identity disappeared after FadeIn")?;
@@ -95,7 +95,7 @@ impl LiveContinuation for TextFamilyFade {
                     );
                 }
                 {
-                    let store = self.family.store().borrow();
+                    let store = self.family.integration_store().borrow();
                     let family = store
                         .node(self.family.node_id())
                         .ok_or("Text family identity disappeared after FadeOut")?;

--- a/crates/noon/src/example_scenes/text_family_reveal.rs
+++ b/crates/noon/src/example_scenes/text_family_reveal.rs
@@ -48,7 +48,7 @@ impl LiveContinuation for TextFamilyReveal {
                 );
                 if rejected.is_ok()
                     || noon_core::semantic_scene_root_contains(
-                        &self.family.store().borrow(),
+                        &self.family.integration_store().borrow(),
                         self.root,
                         self.left.node_id(),
                     )
@@ -111,7 +111,7 @@ impl LiveContinuation for TextFamilyReveal {
                 {
                     return Err("Text Create did not complete its disjoint composition".into());
                 }
-                let store = self.family.store().borrow();
+                let store = self.family.integration_store().borrow();
                 let family = store
                     .node(self.family.node_id())
                     .ok_or("Text family identity disappeared after Create")?;
@@ -162,7 +162,7 @@ impl LiveContinuation for TextFamilyReveal {
                 .map_err(|error| error.to_string())
             }
             2 => {
-                let store = self.family.store().borrow();
+                let store = self.family.integration_store().borrow();
                 let family = store
                     .node(self.family.node_id())
                     .ok_or("Text family identity disappeared after Uncreate")?;

--- a/crates/noon/src/example_scenes/text_family_write.rs
+++ b/crates/noon/src/example_scenes/text_family_write.rs
@@ -47,7 +47,7 @@ impl LiveContinuation for TextFamilyWrite {
                 if rejected.is_ok()
                     || !self
                         .family
-                        .store()
+                        .integration_store()
                         .borrow()
                         .node(self.family.node_id())
                         .unwrap()
@@ -102,7 +102,7 @@ impl LiveContinuation for TextFamilyWrite {
                 {
                     return Err("family Write did not complete its disjoint transform".into());
                 }
-                let store = self.family.store().borrow();
+                let store = self.family.integration_store().borrow();
                 let family = store
                     .node(self.family.node_id())
                     .ok_or("Text family identity disappeared after Write")?;
@@ -132,7 +132,7 @@ impl LiveContinuation for TextFamilyWrite {
                 .map_err(|error| error.to_string())
             }
             2 => {
-                let store = self.family.store().borrow();
+                let store = self.family.integration_store().borrow();
                 let family = store
                     .node(self.family.node_id())
                     .ok_or("Text family identity disappeared after Unwrite")?;

--- a/crates/noon/src/example_scenes/timed_composition.rs
+++ b/crates/noon/src/example_scenes/timed_composition.rs
@@ -115,9 +115,9 @@ impl LiveContinuation for TimedComposition {
 pub fn program() -> Result<LiveProgram<TimedComposition>, String> {
     let scene = Scene::new();
     let mut squares = [
-        Mobject::manim_square(Rc::clone(scene.store()), 1.0)?,
-        Mobject::manim_square(Rc::clone(scene.store()), 1.0)?,
-        Mobject::manim_square(Rc::clone(scene.store()), 1.0)?,
+        Mobject::manim_square(Rc::clone(scene.integration_store()), 1.0)?,
+        Mobject::manim_square(Rc::clone(scene.integration_store()), 1.0)?,
+        Mobject::manim_square(Rc::clone(scene.integration_store()), 1.0)?,
     ];
     for (square, x) in squares.iter_mut().zip([-2.0, 0.0, 2.0]) {
         square.set_translation(x, 0.0)?;

--- a/crates/noon/src/execution_segment.rs
+++ b/crates/noon/src/execution_segment.rs
@@ -1,9 +1,8 @@
-use crate::{
-    CallbackAdvance, EvaluationError, ExecutionSession, ExecutionSessionCallbackError, FrameState,
-    RuntimeIdentity, TimelineWakeState,
-};
+use crate::execution_session::CallbackAdvance;
+use crate::{EvaluationError, ExecutionSession, ExecutionSessionCallbackError};
 use noon_compile::SemanticAnimationCompletion;
 use noon_core::{ObjectId, Property, SemanticNodeId, TrackId};
+use noon_runtime::{FrameState, RuntimeIdentity, TimelineWakeState};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct ExecutionSegmentSequence(u64);

--- a/crates/noon/src/execution_session.rs
+++ b/crates/noon/src/execution_session.rs
@@ -3028,7 +3028,7 @@ impl ExecutionSession {
                 continue;
             }
             let initial = match prepared
-                .integration_store()
+                .store()
                 .semantic_signal_state(leaf.signal)
                 .map_err(|error| {
                     ExecutionSessionAnimationError::AuthoredPublication(

--- a/crates/noon/src/execution_session.rs
+++ b/crates/noon/src/execution_session.rs
@@ -2,9 +2,17 @@ mod callback;
 mod completion;
 mod publication;
 mod signal_timeline;
-pub use callback::*;
-pub use completion::*;
-pub use publication::*;
+pub use callback::{
+    CallbackAdvance, CallbackPhaseOverlay, CallbackPhaseToken, CallbackReadRequest,
+    CallbackReadValue, CallbackRendererDirtyClassification, CallbackRendererObservationOutcome,
+    CallbackSequence, CallbackTermination, CallbackTerminationKind,
+    CommittedCallbackRendererObservation, EffectivePropertyBatch, EffectiveSemanticPropertyWrite,
+    ExecutionSessionCallbackError, ExecutionSessionCallbackReadError, RequiredCallbackInvocation,
+};
+pub use completion::ExecutionSegmentCompletionError;
+pub use publication::{
+    EffectiveSemanticObject, ExecutionSessionPublicationError, StructuralPublicationStats,
+};
 pub use signal_timeline::SignalTimelineAppendError;
 
 use callback::{CallbackPublicationReceipt, CallbackSchedule, PendingCallbackPhase};
@@ -3020,7 +3028,7 @@ impl ExecutionSession {
                 continue;
             }
             let initial = match prepared
-                .store()
+                .integration_store()
                 .semantic_signal_state(leaf.signal)
                 .map_err(|error| {
                     ExecutionSessionAnimationError::AuthoredPublication(

--- a/crates/noon/src/execution_session/callback.rs
+++ b/crates/noon/src/execution_session/callback.rs
@@ -1162,10 +1162,13 @@ mod tests {
             .unwrap();
         let mut hold = SemanticMutationTransaction::new();
         hold.set_scalar_signal_at(tracker.node_id(), 3.0, 1.0);
-        hold.apply(&mut scene.store().borrow_mut()).unwrap();
+        hold.apply(&mut scene.integration_store().borrow_mut())
+            .unwrap();
         let mut callbacks = SemanticMutationTransaction::new();
         callbacks.add_updater(active.node_id(), HostCallbackId::new(7), 0.0, None);
-        callbacks.apply(&mut scene.store().borrow_mut()).unwrap();
+        callbacks
+            .apply(&mut scene.integration_store().borrow_mut())
+            .unwrap();
         let mut session = scene.execution_session().unwrap();
 
         let CallbackAdvance::HostRequired { overlay, .. } =

--- a/crates/noon/src/execution_session/completion.rs
+++ b/crates/noon/src/execution_session/completion.rs
@@ -9,10 +9,9 @@ use noon_core::{
 };
 use noon_runtime::{EffectivePropertyWrite, FrameState, RuntimeIdentity};
 
-use crate::{
-    CallbackTermination, ExecutionSegment, ExecutionSegmentToken, ExecutionSession,
-    ExecutionSessionPublicationError,
-};
+use crate::execution_segment::ExecutionSegmentToken;
+use crate::execution_session::CallbackTermination;
+use crate::{ExecutionSegment, ExecutionSession, ExecutionSessionPublicationError};
 
 use super::callback::{CALLBACK_STYLE_DOMAIN, CALLBACK_TRANSFORM_DOMAIN};
 
@@ -1233,8 +1232,10 @@ mod tests {
             ExecutionSegmentCompletionError::CallbackNotCoherent,
         );
         let overlay = match session.advance_to_callback_barrier(0.0).unwrap() {
-            crate::CallbackAdvance::HostRequired { overlay, .. } => overlay,
-            crate::CallbackAdvance::Ready(_) => panic!("time-zero callback phase is required"),
+            crate::execution_session::CallbackAdvance::HostRequired { overlay, .. } => overlay,
+            crate::execution_session::CallbackAdvance::Ready(_) => {
+                panic!("time-zero callback phase is required")
+            }
         };
         assert_eq!(
             session.complete_segment(&mut store, wait).unwrap_err(),
@@ -1276,15 +1277,19 @@ mod tests {
             .unwrap();
 
         let initial = match session.advance_to_callback_barrier(1.0).unwrap() {
-            crate::CallbackAdvance::HostRequired { overlay, .. } => overlay,
-            crate::CallbackAdvance::Ready(_) => panic!("time-zero callback phase is required"),
+            crate::execution_session::CallbackAdvance::HostRequired { overlay, .. } => overlay,
+            crate::execution_session::CallbackAdvance::Ready(_) => {
+                panic!("time-zero callback phase is required")
+            }
         };
         session
             .commit_required_callback_phase(initial.finish())
             .unwrap();
         let mut endpoint = match session.advance_to_callback_barrier(1.0).unwrap() {
-            crate::CallbackAdvance::HostRequired { overlay, .. } => overlay,
-            crate::CallbackAdvance::Ready(_) => panic!("endpoint callback phase is required"),
+            crate::execution_session::CallbackAdvance::HostRequired { overlay, .. } => overlay,
+            crate::execution_session::CallbackAdvance::Ready(_) => {
+                panic!("endpoint callback phase is required")
+            }
         };
         endpoint
             .set_transform(
@@ -1315,7 +1320,7 @@ mod tests {
         assert!(session.segment_state(segment).is_complete());
         assert!(matches!(
             session.advance_to_callback_barrier(1.0).unwrap(),
-            crate::CallbackAdvance::Ready(_)
+            crate::execution_session::CallbackAdvance::Ready(_)
         ));
     }
 

--- a/crates/noon/src/execution_session/publication/tests.rs
+++ b/crates/noon/src/execution_session/publication/tests.rs
@@ -599,7 +599,8 @@ fn authored_publication_is_rejected_while_required_callback_is_pending() {
 
 #[test]
 fn live_updater_removal_replacement_and_freeze_keep_one_runtime() {
-    use crate::{HostCallbackId, RustHostCallbackTable};
+    use crate::RustHostCallbackTable;
+    use noon_core::HostCallbackId;
     let mut store = SemanticStore::new();
     let node = store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
         radius: 1.0,
@@ -684,7 +685,8 @@ fn live_updater_removal_replacement_and_freeze_keep_one_runtime() {
 
 #[test]
 fn live_updater_edits_reject_pending_phases_retroactivity_and_unindexed_targets_atomically() {
-    use crate::{CallbackAdvance, HostCallbackId};
+    use crate::execution_session::CallbackAdvance;
+    use noon_core::HostCallbackId;
     let mut store = SemanticStore::new();
     let node = store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
         radius: 1.0,
@@ -745,7 +747,8 @@ fn live_updater_edits_reject_pending_phases_retroactivity_and_unindexed_targets_
 
 #[test]
 fn live_updater_revision_preserves_target_preorder_and_future_barriers() {
-    use crate::{CallbackAdvance, HostCallbackId};
+    use crate::execution_session::CallbackAdvance;
+    use noon_core::HostCallbackId;
     let mut store = SemanticStore::new();
     let nodes = (0..2)
         .map(|_| {

--- a/crates/noon/src/family_arrangement.rs
+++ b/crates/noon/src/family_arrangement.rs
@@ -6,9 +6,9 @@ use crate::{
     family_authoring::translation_transaction,
     family_layout::{bounds_critical_point, RelativePlacement},
     semantic_mobject::ManimNextToArgs,
-    Bounds2D64, LayoutAnchor, Mobject, MobjectFamily, SemanticMutationTransaction, SemanticNodeId,
-    SemanticVec3,
+    Bounds2D64, LayoutAnchor, Mobject, MobjectFamily, SemanticNodeId, SemanticVec3,
 };
+use noon_core::SemanticMutationTransaction;
 use std::{
     collections::{BTreeMap, BTreeSet},
     rc::Rc,
@@ -48,16 +48,18 @@ impl MobjectFamily {
     pub fn arrange_with_options(&self, options: &FamilyArrangeOptions) -> Result<(), String> {
         let mut plan = FamilyArrangePlan::begin(self, options)?;
         plan.observe_leaf_bounds(|leaf| {
-            Mobject::from_node(Rc::clone(self.store()), leaf)?.layout_bounds()
+            Mobject::from_node(Rc::clone(self.integration_store()), leaf)?.layout_bounds()
         })?;
         let transaction = plan.transaction(|leaf| {
-            Ok(Mobject::from_node(Rc::clone(self.store()), leaf)?
-                .state()?
-                .transform
-                .translation)
+            Ok(
+                Mobject::from_node(Rc::clone(self.integration_store()), leaf)?
+                    .state()?
+                    .transform
+                    .translation,
+            )
         })?;
         transaction
-            .apply(&mut self.store().borrow_mut())
+            .apply(&mut self.integration_store().borrow_mut())
             .map(|_| ())
             .map_err(|e| e.to_string())
     }
@@ -88,25 +90,25 @@ impl FamilyArrangePlan {
         // Normalize/check even an empty request without publishing anything.
         RelativePlacement::Next(options.placement).delta(None, |_, _| Ok((0.0, 0.0)))?;
         let ids = family
-            .store()
+            .integration_store()
             .borrow()
             .node(family.node_id())
             .unwrap()
             .members()
             .to_vec();
         let leaves = |anchor: LayoutAnchor| -> Result<Vec<SemanticNodeId>, String> {
-            if !Rc::ptr_eq(family.store(), anchor.store()) {
+            if !Rc::ptr_eq(family.integration_store(), anchor.integration_store()) {
                 return Err("arrangement anchors belong to different authoring stores".into());
             }
             let node = anchor.resolve()?;
             family
-                .store()
+                .integration_store()
                 .borrow()
                 .ordered_leaf_nodes(node)
                 .map_err(|e| e.to_string())
         };
         let selected = |node| {
-            let anchor = LayoutAnchor::from_node(Rc::clone(family.store()), node);
+            let anchor = LayoutAnchor::from_node(Rc::clone(family.integration_store()), node);
             match options.member_index {
                 Some(index) => anchor.member(index),
                 None => anchor,
@@ -120,7 +122,10 @@ impl FamilyArrangePlan {
             let target = leaves(selected(pair[0]))?;
             required.extend(source.iter().chain(&target).copied());
             steps.push(PlacementStep {
-                moved: leaves(LayoutAnchor::from_node(Rc::clone(family.store()), pair[1]))?,
+                moved: leaves(LayoutAnchor::from_node(
+                    Rc::clone(family.integration_store()),
+                    pair[1],
+                ))?,
                 source,
                 target,
             });

--- a/crates/noon/src/family_authoring.rs
+++ b/crates/noon/src/family_authoring.rs
@@ -132,16 +132,16 @@ impl<'a> From<&'a MobjectFamily> for MobjectFamilyMember<'a> {
 
 impl MobjectFamilyMember<'_> {
     fn require_store(&self, store: &Rc<RefCell<SemanticStore>>) -> Result<(), String> {
-        if !Rc::ptr_eq(self.store(), store) {
+        if !Rc::ptr_eq(self.integration_store(), store) {
             return Err("family members belong to different authoring stores".into());
         }
         self.validate()
     }
 
-    pub(crate) fn store(&self) -> &Rc<RefCell<SemanticStore>> {
+    pub(crate) fn integration_store(&self) -> &Rc<RefCell<SemanticStore>> {
         match self {
-            Self::Mobject(member) => member.store(),
-            Self::Family(member) => member.store(),
+            Self::Mobject(member) => member.integration_store(),
+            Self::Family(member) => member.integration_store(),
         }
     }
 
@@ -193,9 +193,9 @@ pub(crate) fn family_membership_transaction(
 ) -> Result<(SemanticMutationTransaction, Vec<bool>), String> {
     family.validate()?;
     for member in members {
-        member.require_store(family.store())?;
+        member.require_store(family.integration_store())?;
     }
-    let store = family.store().borrow();
+    let store = family.integration_store().borrow();
     let node = store
         .semantic_family_checked(family.node_id())
         .map_err(|e| e.to_string())?;
@@ -277,7 +277,13 @@ impl MobjectFamily {
         Ok(Self { store, node })
     }
 
-    pub fn store(&self) -> &Rc<RefCell<SemanticStore>> {
+    /// Raw shared arena access for explicit integration, not live mutation.
+    ///
+    /// External edits can invalidate generational handles and leave an existing
+    /// execution session on a stale scene revision. Use `Scene::live` and its
+    /// coherent publication operations for edits after lowering. No revision
+    /// validation is bypassed by this accessor; see [`crate::integration`].
+    pub fn integration_store(&self) -> &Rc<RefCell<SemanticStore>> {
         &self.store
     }
 
@@ -345,14 +351,14 @@ mod tests {
         let first = scene.square(0.4).unwrap();
         let second = scene.circle(0.2).unwrap();
         let family = scene.family(&[(&first).into(), (&second).into()]).unwrap();
-        let before = scene.store().borrow().scene_revision();
+        let before = scene.integration_store().borrow().scene_revision();
 
         family.arrange(1.0, 0.0, 0.2, true).unwrap();
 
         let first_center = first.center().unwrap();
         let second_center = second.center().unwrap();
         assert_eq!(
-            scene.store().borrow().scene_revision(),
+            scene.integration_store().borrow().scene_revision(),
             before.checked_next().unwrap()
         );
         assert!((second_center.0 - first_center.0 - 0.6).abs() < 1e-6);
@@ -370,20 +376,20 @@ mod tests {
         let nested = scene.family(&[(&first).into(), (&second).into()]).unwrap();
         let outer = scene.family(&[(&first).into()]).unwrap();
         scene
-            .store()
+            .integration_store()
             .borrow_mut()
             .add_member(outer.node_id(), nested.node_id())
             .unwrap();
-        let before = scene.store().borrow().scene_revision();
+        let before = scene.integration_store().borrow().scene_revision();
 
         assert!(outer.arrange(1.0, 0.0, f64::NAN, true).is_err());
-        assert_eq!(scene.store().borrow().scene_revision(), before);
+        assert_eq!(scene.integration_store().borrow().scene_revision(), before);
         assert_eq!(first.center().unwrap(), (0.0, 0.0));
         assert_eq!(second.center().unwrap(), (2.0, 0.0));
 
         outer.arrange(1.0, 0.0, 0.2, true).unwrap();
         assert_eq!(
-            scene.store().borrow().scene_revision(),
+            scene.integration_store().borrow().scene_revision(),
             before.checked_next().unwrap()
         );
         assert!((first.center().unwrap().0 + 1.0).abs() < 1e-6);
@@ -400,7 +406,7 @@ mod tests {
         second.shift(2.0, 1.0).unwrap();
 
         let outer = {
-            let mut store = scene.store().borrow_mut();
+            let mut store = scene.integration_store().borrow_mut();
             let nested = store.insert_family();
             store.add_member(nested, first.node_id()).unwrap();
             store.add_member(nested, second.node_id()).unwrap();
@@ -409,7 +415,7 @@ mod tests {
             store.add_member(outer, nested).unwrap();
             outer
         };
-        let family = MobjectFamily::from_node(Rc::clone(scene.store()), outer).unwrap();
+        let family = MobjectFamily::from_node(Rc::clone(scene.integration_store()), outer).unwrap();
 
         assert_eq!(
             family.layout_bounds().unwrap(),

--- a/crates/noon/src/family_copy.rs
+++ b/crates/noon/src/family_copy.rs
@@ -20,25 +20,25 @@ impl FamilyCopy {
     }
 
     pub fn mobject(&self, source: &Mobject) -> Result<Mobject, String> {
-        self.require_store(source.store())?;
+        self.require_store(source.integration_store())?;
         source.validate()?;
         Mobject::from_node(
-            Rc::clone(self.root.store()),
+            Rc::clone(self.root.integration_store()),
             self.copied_id(source.node_id())?,
         )
     }
 
     pub fn family(&self, source: &MobjectFamily) -> Result<MobjectFamily, String> {
-        self.require_store(source.store())?;
+        self.require_store(source.integration_store())?;
         source.validate()?;
         MobjectFamily::from_node(
-            Rc::clone(self.root.store()),
+            Rc::clone(self.root.integration_store()),
             self.copied_id(source.node_id())?,
         )
     }
 
     fn require_store(&self, store: &Rc<RefCell<SemanticStore>>) -> Result<(), String> {
-        if Rc::ptr_eq(self.root.store(), store) {
+        if Rc::ptr_eq(self.root.integration_store(), store) {
             Ok(())
         } else {
             Err("family copy source belongs to another semantic store".into())
@@ -89,13 +89,13 @@ pub(crate) fn prepare_family_copy(
     mut capture: impl FnMut(&Mobject) -> Result<SemanticObjectState, String>,
 ) -> Result<(SemanticMutationTransaction, PendingFamilyCopy), String> {
     source.validate()?;
-    let store = source.store();
+    let store = source.integration_store();
     let mut transaction = SemanticMutationTransaction::new();
     let mut copied = BTreeMap::new();
     let mut edges = Vec::new();
     let mut queue = Vec::with_capacity(references.len() + 1);
     for member in references {
-        if !Rc::ptr_eq(store, member.store()) {
+        if !Rc::ptr_eq(store, member.integration_store()) {
             return Err("family copy reference belongs to another semantic store".into());
         }
         member.validate()?;
@@ -157,7 +157,7 @@ impl MobjectFamily {
     ) -> Result<FamilyCopy, String> {
         let (transaction, pending) = prepare_family_copy(self, references, Mobject::state)?;
         let result = transaction
-            .apply(&mut self.store().borrow_mut())
+            .apply(&mut self.integration_store().borrow_mut())
             .map_err(|e| e.to_string())?;
         pending.resolve(&result)
     }

--- a/crates/noon/src/family_layout.rs
+++ b/crates/noon/src/family_layout.rs
@@ -4,8 +4,9 @@ use std::{cell::RefCell, rc::Rc};
 use crate::{
     family_authoring::FamilyTranslation,
     semantic_mobject::{authoring_render_f64, authoring_xy_f64, ManimNextToArgs},
-    Bounds2D64, Mobject, MobjectFamily, SemanticNodeId, SemanticStore,
+    Bounds2D64, Mobject, MobjectFamily, SemanticNodeId,
 };
+use noon_core::SemanticStore;
 
 /// Bounds and ordered leaf identities observed at one authored point in time.
 ///
@@ -41,7 +42,7 @@ pub struct LayoutAnchor {
 impl From<&Mobject> for LayoutAnchor {
     fn from(object: &Mobject) -> Self {
         Self {
-            store: Rc::clone(object.store()),
+            store: Rc::clone(object.integration_store()),
             node: object.node_id(),
             index: None,
         }
@@ -51,7 +52,7 @@ impl From<&Mobject> for LayoutAnchor {
 impl From<&MobjectFamily> for LayoutAnchor {
     fn from(family: &MobjectFamily) -> Self {
         Self {
-            store: Rc::clone(family.store()),
+            store: Rc::clone(family.integration_store()),
             node: family.node_id(),
             index: None,
         }
@@ -73,7 +74,7 @@ impl LayoutAnchor {
         }
     }
 
-    pub(crate) fn store(&self) -> &Rc<RefCell<SemanticStore>> {
+    pub(crate) fn integration_store(&self) -> &Rc<RefCell<SemanticStore>> {
         &self.store
     }
 
@@ -85,7 +86,7 @@ impl LayoutAnchor {
         let Some(index) = self.index else {
             return Ok(self.node);
         };
-        if !matches!(node.kind(), crate::SemanticNodeKind::Family) {
+        if !matches!(node.kind(), noon_core::SemanticNodeKind::Family) {
             return Err("alignment submobject index requires a semantic family".into());
         }
         let members = node.members();
@@ -104,7 +105,7 @@ impl LayoutAnchor {
         let node = self.resolve()?;
         if matches!(
             self.store.borrow().node(node).map(|n| n.kind()),
-            Some(crate::SemanticNodeKind::Family)
+            Some(noon_core::SemanticNodeKind::Family)
         ) {
             MobjectFamily::from_node(Rc::clone(&self.store), node)?.layout()
         } else {
@@ -147,13 +148,14 @@ impl MobjectFamily {
     pub fn layout(&self) -> Result<FamilyLayout, String> {
         self.validate()?;
         let leaves = self
-            .store()
+            .integration_store()
             .borrow()
             .ordered_leaf_nodes(self.node_id())
             .map_err(|e| e.to_string())?;
         let mut bounds: Option<Bounds2D64> = None;
         for &leaf in &leaves {
-            let Some(next) = Mobject::from_node(Rc::clone(self.store()), leaf)?.layout_bounds()?
+            let Some(next) =
+                Mobject::from_node(Rc::clone(self.integration_store()), leaf)?.layout_bounds()?
             else {
                 continue;
             };
@@ -165,7 +167,7 @@ impl MobjectFamily {
             }
         }
         Ok(FamilyLayout {
-            store: Rc::clone(self.store()),
+            store: Rc::clone(self.integration_store()),
             leaves,
             bounds,
         })
@@ -173,8 +175,9 @@ impl MobjectFamily {
 
     /// Shift each semantic leaf once without querying its geometry.
     pub fn shift(&self, x: f64, y: f64) -> Result<(), String> {
-        let translation = FamilyTranslation::begin(&self.store().borrow(), self.node_id(), x, y)?;
-        translation.apply(&mut self.store().borrow_mut())
+        let translation =
+            FamilyTranslation::begin(&self.integration_store().borrow(), self.node_id(), x, y)?;
+        translation.apply(&mut self.integration_store().borrow_mut())
     }
 }
 
@@ -249,9 +252,9 @@ impl FamilyLayout {
                 let point = authoring_xy_f64(px, py)?;
                 return Ok((point.x, point.y));
             }
-            FamilyLayoutTarget::Mobject(object) => object.store(),
+            FamilyLayoutTarget::Mobject(object) => object.integration_store(),
             FamilyLayoutTarget::Family(family) => &family.store,
-            FamilyLayoutTarget::Anchor(anchor) => anchor.store(),
+            FamilyLayoutTarget::Anchor(anchor) => anchor.integration_store(),
         };
         if !Rc::ptr_eq(&self.store, target_store) {
             return Err(

--- a/crates/noon/src/host_callbacks.rs
+++ b/crates/noon/src/host_callbacks.rs
@@ -3,13 +3,18 @@
 use std::collections::BTreeMap;
 use std::error::Error;
 
-use crate::{
+use crate::execution_session::{
     CallbackAdvance, CallbackPhaseOverlay, CallbackReadRequest, CallbackReadValue,
-    EffectiveObjectProperties, ExecutionSegment, ExecutionSegmentAdvanceError, ExecutionSession,
-    ExecutionSessionCallbackError, FrameState, HostCallbackId, SemanticMutationTransaction,
-    SemanticMutationTransactionError, SemanticMutationTransactionResult, SemanticNodeId,
-    SemanticStore, Style, Transform2D, Vec2,
 };
+use crate::{
+    ExecutionSegment, ExecutionSegmentAdvanceError, ExecutionSession,
+    ExecutionSessionCallbackError, SemanticNodeId, Style, Transform2D, Vec2,
+};
+use noon_core::{
+    HostCallbackId, SemanticMutationTransaction, SemanticMutationTransactionError,
+    SemanticMutationTransactionResult, SemanticStore,
+};
+use noon_runtime::{EffectiveObjectProperties, FrameState};
 
 type BoxedCallbackError = Box<dyn Error + 'static>;
 type RustHostCallback =
@@ -679,7 +684,7 @@ mod tests {
             .unwrap();
         callbacks
             .add_updater(
-                &mut scene.store().borrow_mut(),
+                &mut scene.integration_store().borrow_mut(),
                 active.node_id(),
                 SET_Y,
                 0.0,
@@ -688,7 +693,7 @@ mod tests {
             .unwrap();
         let mut session = scene.execution_session().unwrap();
         callbacks.advance_to(&mut session, 0.0).unwrap();
-        let store = scene.store().borrow();
+        let store = scene.integration_store().borrow();
         let effective = session
             .effective_semantic_object(&store, active.node_id())
             .unwrap();
@@ -754,7 +759,7 @@ mod tests {
             })
             .unwrap();
         {
-            let mut store = scene.store().borrow_mut();
+            let mut store = scene.integration_store().borrow_mut();
             callbacks
                 .add_updater(&mut store, source.node_id(), SET_Y, 0.0, None)
                 .unwrap();
@@ -817,7 +822,7 @@ mod tests {
             .unwrap();
         authoring_table
             .add_updater(
-                &mut scene.store().borrow_mut(),
+                &mut scene.integration_store().borrow_mut(),
                 target.node_id(),
                 SET_Y,
                 0.0,
@@ -856,7 +861,7 @@ mod tests {
             .unwrap();
         callbacks
             .add_updater(
-                &mut scene.store().borrow_mut(),
+                &mut scene.integration_store().borrow_mut(),
                 target.node_id(),
                 SET_Y,
                 0.0,
@@ -898,7 +903,7 @@ mod tests {
             .unwrap();
         callbacks
             .add_updater(
-                &mut scene.store().borrow_mut(),
+                &mut scene.integration_store().borrow_mut(),
                 target.node_id(),
                 SET_OPACITY,
                 0.0,
@@ -927,7 +932,7 @@ mod tests {
         source: &crate::Mobject,
         drift: &crate::Mobject,
     ) -> ((Vec2, f32), (Vec2, f32)) {
-        let store = scene.store().borrow();
+        let store = scene.integration_store().borrow();
         let source = session
             .effective_semantic_object(&store, source.node_id())
             .unwrap()

--- a/crates/noon/src/integration.rs
+++ b/crates/noon/src/integration.rs
@@ -1,0 +1,59 @@
+//! Explicit low-level integration with Noon's existing authorities.
+//!
+//! Ordinary authoring uses [`Scene`](crate::Scene), [`Mobject`](crate::Mobject),
+//! and [`LiveSession`](crate::LiveSession). This module exposes only the specific
+//! types needed by language wrappers, platform hosts, resource adapters and
+//! diagnostics; it owns no scene, runtime, registry or scheduler.
+//!
+//! # Raw semantic access
+//!
+//! [`Scene::with_integration_store`](crate::Scene::with_integration_store) accepts
+//! an existing arena. The `integration_store()` accessors on Scene, Mobject and
+//! MobjectFamily return the same arena, not a snapshot. Keep RefCell borrows short
+//! and release them before calling authoring/session operations.
+//!
+//! Mutating the arena (including through an authored handle) after lowering does
+//! **not** publish that change into a live session. Existing revision and identity
+//! checks reject the resulting stale or foreign context. They are never disabled
+//! by using this module. Prefer `scene.live(&mut session)` for live mutation; raw
+//! callers must use the session's coherent semantic-transaction publication API.
+//! If raw edits have already invalidated a session, explicitly discard/rebuild it
+//! rather than overwriting its publication revision or treating old frames as new.
+//!
+//! The retained text adapter below is still needed by explicit transport callers
+//! and is deletion-owned by #959. It is not the ordinary Scene authoring API.
+
+pub use crate::compact_value_authoring::semantic_object_state_from_compact;
+pub use crate::execution_segment::{ExecutionSegmentSequence, ExecutionSegmentToken};
+pub use crate::execution_session::{
+    CallbackAdvance, CallbackPhaseOverlay, CallbackPhaseToken, CallbackReadRequest,
+    CallbackReadValue, CallbackRendererDirtyClassification, CallbackRendererObservationOutcome,
+    CallbackSequence, CallbackTermination, CallbackTerminationKind,
+    CommittedCallbackRendererObservation, EffectivePropertyBatch, EffectiveSemanticObject,
+    EffectiveSemanticPropertyWrite, ExecutionViewportQuery, RequiredCallbackInvocation,
+    StructuralPublicationStats,
+};
+pub use crate::host_callbacks::{
+    effective_style_with_color, effective_style_with_fill, effective_style_with_fill_color,
+    effective_style_with_fill_opacity, effective_style_with_stroke_color,
+    rotate_effective_transform_about_point,
+};
+pub use crate::semantic_mobject::{authoring_render_f64, authoring_xy_f64, line_match_transform};
+#[cfg(feature = "native-text")]
+pub use crate::text_authoring::NATIVE_POINT_TO_SCENE_SCALE;
+#[cfg(feature = "typst")]
+pub use crate::text_authoring::SCALE_FACTOR_PER_FONT_POINT;
+#[cfg(any(feature = "native-text", feature = "typst"))]
+pub use crate::text_authoring::{RetainedMobject, RetainedScene};
+pub use noon_core::{
+    GeometryResource, GeometryResourceArena, GeometryResourceHandle, GeometryResourceLookup,
+    HostCallbackId, SemanticMutationImpact, SemanticMutationTransaction,
+    SemanticMutationTransactionError, SemanticMutationTransactionResult, SemanticNodeCreation,
+    SemanticNodeKind, SemanticSceneOperationError, SemanticStore, SemanticStoreError,
+    SemanticStoreIdentity, SemanticTransactionNodeRef, TextResource, TextResourceArena,
+    TextResourceHandle,
+};
+pub use noon_runtime::{
+    EffectiveObjectProperties, FrameChanges, FrameObjectState, FrameState, RendererPublication,
+    RuntimeIdentity, RuntimeWakeState, TimelineWakeState,
+};

--- a/crates/noon/src/lib.rs
+++ b/crates/noon/src/lib.rs
@@ -1,7 +1,52 @@
-//! Ergonomic Rust authoring facade for Noon.
+//! Direct Rust authoring and coherent live execution for Noon.
 //!
-//! `Scene` and `Mobject` author directly into the shared semantic store and
-//! lower through `ExecutionSession` using typed in-process Rust boundaries.
+//! Start with [`Scene`] and [`Mobject`]. Before execution, their edits author the
+//! scene. After lowering, use [`Scene::live`] for edits and effective observations:
+//! it publishes through the existing [`ExecutionSession`], not a second scene.
+//!
+//! # Public surface
+//!
+//! - The crate root and [`prelude`] contain explicit authoring values, handles,
+//!   live operations, logical completion, and their errors.
+//! - [`integration`] contains raw arena access types, host/callback plumbing and
+//!   renderer observations. These are advanced facilities, not ordinary authoring.
+//! - `diagnostics` (feature gated) provides explicit debug/export observations.
+//!
+//! Use [`LiveSession::authored`] for base state and [`LiveSession::effective`] for
+//! the current published value. Complete a segment with
+//! [`LiveSession::complete_segment`] before resuming dependent authoring. Ordinary
+//! completion is not a GPU-retirement fence. See the `shared_authoring` example.
+//!
+//! A glob import cannot accidentally expose raw semantic storage or frame plumbing:
+//!
+//! ```compile_fail,E0433
+//! use noon::*;
+//! let _ = SemanticStore::new();
+//! ```
+//!
+//! ```compile_fail,E0432
+//! use noon::FrameState;
+//! ```
+//!
+//! Implementation modules are not an alternative public facade:
+//!
+//! ```compile_fail,E0603
+//! use noon::semantic_mobject::Mobject;
+//! ```
+//!
+//! Raw mutable storage requires the explicitly named integration accessors:
+//!
+//! ```compile_fail,E0599
+//! let _ = noon::Scene::new().store();
+//! ```
+//!
+//! ```compile_fail,E0599
+//! fn raw(object: &noon::Mobject) { let _ = object.store(); }
+//! ```
+//!
+//! ```compile_fail,E0599
+//! fn raw(family: &noon::MobjectFamily) { let _ = family.store(); }
+//! ```
 
 #![forbid(unsafe_code)]
 
@@ -18,34 +63,44 @@ mod execution_segment;
 mod execution_session;
 mod family_arrangement;
 mod family_authoring;
-pub use family_arrangement::FamilyArrangeOptions;
 mod family_copy;
-pub use family_copy::FamilyCopy;
 mod family_layout;
-pub use family_layout::{FamilyLayout, FamilyLayoutTarget, LayoutAnchor};
 mod focus_on_authoring;
-mod rotation_authoring;
-pub use rotation_authoring::ManimRotationPivot;
 mod geometry_authoring;
 mod host_callbacks;
+pub mod integration;
 mod live_program;
 mod live_session;
 mod native_signal_authoring;
+mod rotation_authoring;
 mod rounded_rectangle_authoring;
 mod scalar_authoring;
+mod scene;
+mod scene_membership;
 mod sector_authoring;
-pub mod semantic_mobject;
+mod semantic_mobject;
 #[cfg(any(feature = "native-text", feature = "typst"))]
 mod text_authoring;
 
 pub use animation_authoring::DeclaredAnimation;
-pub use compact_value_authoring::semantic_object_state_from_compact;
-pub use execution_segment::*;
-pub use execution_session::*;
+pub use execution_segment::{
+    ExecutionSegment, ExecutionSegmentAdvanceError, ExecutionSegmentError, ExecutionSegmentState,
+};
+pub use execution_session::{
+    ExecutionSegmentCompletionError, ExecutionSession, ExecutionSessionAnimationError,
+    ExecutionSessionCallbackError, ExecutionSessionCallbackReadError, ExecutionSessionCameraError,
+    ExecutionSessionCreateError, ExecutionSessionFadeError, ExecutionSessionInputError,
+    ExecutionSessionPublicationError, SignalTimelineAppendError,
+};
+pub use family_arrangement::FamilyArrangeOptions;
 pub use family_authoring::{MobjectFamily, MobjectFamilyMember};
+pub use family_copy::FamilyCopy;
+pub use family_layout::{FamilyLayout, FamilyLayoutTarget, LayoutAnchor};
 pub use focus_on_authoring::FocusOnOptions;
-pub use host_callbacks::*;
-pub use live_program::*;
+pub use host_callbacks::{RustHostCallbackContext, RustHostCallbackError, RustHostCallbackTable};
+pub use live_program::{
+    ContinuationStep, LiveContinuation, LiveProgram, LiveProgramError, LiveProgramStatus,
+};
 pub use live_session::{
     AffineLifecycleDirection, AffineLifecycleEndpoint, AnimationCompositionRequest,
     DrawBorderThenFillOptions, EffectiveMobjectLayout, EffectiveMobjectState, FadeEndpoint,
@@ -53,29 +108,46 @@ pub use live_session::{
     SubsetDisplayMode, TransformToRequest,
 };
 pub use native_signal_authoring::{NativeBoolSignal, NativeVectorSignal};
-pub use noon_core::*;
-pub use noon_runtime::{
-    EffectiveObjectProperties, EvaluationError, FrameChanges, FrameObjectState, FrameState,
-    RendererPublication, RuntimeIdentity, RuntimeWakeState, TimelineWakeState,
+pub use noon_core::{
+    AnimationOptions, Bounds2D64, Color, ExecutionRevision, FrameEpoch, GeometryRef, PathCommand,
+    PublicationContext, RateFunction, Rect, SceneRevision, SemanticAnimationCompositionKind,
+    SemanticFadeDirection, SemanticNodeId, SemanticObjectProperty, SemanticObjectState,
+    SemanticPaint, SemanticSignalValue, SemanticStyle, SemanticTransform2_5D,
+    SemanticTransformInterpolation, SemanticVec3, StoredGeometry, StrokeCap, StrokeJoin,
+    StrokeWidthMode, Style, Transform2D, Vec2, VectorPath, BLACK, BLUE, BLUE_A, BLUE_B, BLUE_C,
+    BLUE_D, BLUE_E, DEFAULT_FRAME_HEIGHT, DEFAULT_FRAME_WIDTH, DEFAULT_MOBJECT_TO_EDGE_BUFFER,
+    DEFAULT_MOBJECT_TO_MOBJECT_BUFFER, DEGREES, DL, DOWN, DR, GOLD, GRAY, GREEN, GREEN_A, GREEN_B,
+    GREEN_C, GREEN_D, GREEN_E, GREY, LARGE_BUFF, LEFT, LIGHT_PINK, MAROON, MED_LARGE_BUFF,
+    MED_SMALL_BUFF, ORANGE, ORIGIN, PI, PINK, PURPLE, PURPLE_A, PURPLE_B, PURPLE_C, PURPLE_D,
+    PURPLE_E, RED, RED_A, RED_B, RED_C, RED_D, RED_E, RIGHT, SMALL_BUFF, TAU, TEAL, TEAL_A, TEAL_B,
+    TEAL_C, TEAL_D, TEAL_E, UL, UP, UR, WHITE, YELLOW, YELLOW_A, YELLOW_B, YELLOW_C, YELLOW_D,
+    YELLOW_E,
 };
+pub use noon_runtime::EvaluationError;
+pub use rotation_authoring::ManimRotationPivot;
 pub use scalar_authoring::{TrackerPosition, ValueTracker, ValueTrackerPlay};
-pub use semantic_mobject::{ManimBecomeOptions, ManimGeometryOptions, ManimLineEndpoints, Mobject};
-mod scene;
-mod scene_membership;
 pub use scene::Scene;
 pub use scene_membership::SceneMembershipRequest;
+pub use semantic_mobject::{
+    ManimBecomeOptions, ManimGeometryOptions, ManimLineEndpoints, ManimNextToArgs, Mobject,
+};
 #[cfg(any(feature = "native-text", feature = "typst"))]
-pub use text_authoring::*;
+pub use text_authoring::TextAuthoringError;
+#[cfg(feature = "typst")]
+pub use text_authoring::{MathTypst, Typst, TypstBackendError, DEFAULT_TYPST_FONT_SIZE};
+#[cfg(feature = "native-text")]
+pub use text_authoring::{
+    NativeFontFace, Text, DEFAULT_NATIVE_TEXT_FONT_FAMILY, DEFAULT_NATIVE_TEXT_FONT_SIZE,
+};
 
-/// Common imports for direct typed semantic authoring.
+/// Common imports for direct typed semantic authoring and live publication.
+/// Host integration and mutable arena access must be imported explicitly.
 pub mod prelude {
     pub use crate::{
-        ContinuationStep, DeclaredAnimation, DrawBorderThenFillOptions, EffectiveMobjectState,
-        ExecutionSession, FadeEndpoint, FadeTranslation, LiveContinuation, LiveProgram,
-        LiveSession, Mobject, MobjectFamily, MobjectFamilyMember, NativeBoolSignal,
-        NativeVectorSignal, Scene, TrackerPosition, ValueTracker,
-    };
-    pub use noon_core::{
-        Color, SemanticObjectState, SemanticStyle, StoredGeometry, Vec2, VectorPath,
+        AnimationOptions, Color, ContinuationStep, DeclaredAnimation, DrawBorderThenFillOptions,
+        EffectiveMobjectState, ExecutionSession, FadeEndpoint, FadeTranslation, LiveContinuation,
+        LiveProgram, LiveSession, LiveSessionError, Mobject, MobjectFamily, MobjectFamilyMember,
+        NativeBoolSignal, NativeVectorSignal, RateFunction, Scene, SemanticObjectState,
+        SemanticStyle, StoredGeometry, TrackerPosition, ValueTracker, Vec2, VectorPath,
     };
 }

--- a/crates/noon/src/live_program.rs
+++ b/crates/noon/src/live_program.rs
@@ -12,11 +12,12 @@ use noon_core::{
     NativeEventOccurrence, NativeInputValue, NativeStateSource, PublicationContext, Rect,
 };
 
+use crate::execution_session::ExecutionViewportQuery;
 use crate::{
     ExecutionSegment, ExecutionSegmentAdvanceError, ExecutionSegmentState, ExecutionSession,
-    ExecutionSessionInputError, ExecutionViewportQuery, FrameState, LiveSession,
-    RendererPublication, RustHostCallbackError, RustHostCallbackTable, Scene,
+    ExecutionSessionInputError, LiveSession, RustHostCallbackError, RustHostCallbackTable, Scene,
 };
+use noon_runtime::{FrameState, RendererPublication};
 
 /// One application-authored continuation result.
 ///
@@ -170,7 +171,7 @@ impl<C: LiveContinuation> LiveProgram<C> {
     /// An already-at-end segment still requests one immediate drive so exact-time
     /// callbacks and shared completion cannot be skipped merely because the
     /// underlying tokenless wait already reports a complete interval.
-    pub fn wake_state(&self) -> crate::RuntimeWakeState {
+    pub fn wake_state(&self) -> noon_runtime::RuntimeWakeState {
         let wake = self.session.wake_state();
         let LiveProgramPhase::Awaiting(segment) = self.phase else {
             // Only an awaited segment authorizes authored-time advancement.
@@ -180,7 +181,7 @@ impl<C: LiveContinuation> LiveProgram<C> {
             return wake.without_timeline_wake();
         };
         let timeline = if self.session.frame().time >= segment.end_time() {
-            crate::TimelineWakeState::Deadline(self.session.frame().time)
+            noon_runtime::TimelineWakeState::Deadline(self.session.frame().time)
         } else {
             self.session.segment_state(segment).timeline()
         };
@@ -377,7 +378,7 @@ mod tests {
     };
 
     use super::*;
-    use crate::TimelineWakeState;
+    use noon_runtime::TimelineWakeState;
 
     struct AnimatedContinuation {
         source: crate::Mobject,
@@ -568,12 +569,12 @@ mod tests {
 
         let (scene, session, pending) = scene_with_pending_segment();
         let pending_token = pending.token().unwrap();
-        let stale_sequence = crate::ExecutionSegmentSequence::new(
+        let stale_sequence = crate::execution_segment::ExecutionSegmentSequence::new(
             pending_token.sequence().get().checked_add(1).unwrap(),
         );
         let stale = ExecutionSegment::from_duration(pending.start_time(), pending.duration())
             .unwrap()
-            .with_completion_token(crate::ExecutionSegmentToken::new(
+            .with_completion_token(crate::execution_segment::ExecutionSegmentToken::new(
                 session.runtime_identity(),
                 stale_sequence,
             ));
@@ -623,7 +624,10 @@ mod tests {
         let LiveProgramStatus::Awaiting(waiting) = program.status() else {
             panic!("wait continuation must expose its shared deadline")
         };
-        assert_eq!(waiting.timeline(), crate::TimelineWakeState::Deadline(1.0));
+        assert_eq!(
+            waiting.timeline(),
+            noon_runtime::TimelineWakeState::Deadline(1.0)
+        );
         program
             .drive_to(&mut RustHostCallbackTable::new(), 0.5)
             .unwrap();
@@ -678,7 +682,7 @@ mod tests {
         assert!(state.is_complete());
         assert_eq!(
             program.wake_state().timeline(),
-            crate::TimelineWakeState::Deadline(0.0)
+            noon_runtime::TimelineWakeState::Deadline(0.0)
         );
         assert_eq!(*resumes.borrow(), 1);
         assert_eq!(
@@ -699,7 +703,9 @@ mod tests {
         scene.add(&object).unwrap();
         let mut registration = SemanticMutationTransaction::new();
         registration.add_updater(object.node_id(), CALLBACK, 0.0, None);
-        registration.apply(&mut scene.store().borrow_mut()).unwrap();
+        registration
+            .apply(&mut scene.integration_store().borrow_mut())
+            .unwrap();
         let resumes = Rc::new(RefCell::new(0));
         let mut program = scene
             .into_live_program(WaitContinuation {
@@ -734,7 +740,9 @@ mod tests {
         scene.add(&object).unwrap();
         let mut registration = SemanticMutationTransaction::new();
         registration.add_updater(object.node_id(), CALLBACK, 0.0, None);
-        registration.apply(&mut scene.store().borrow_mut()).unwrap();
+        registration
+            .apply(&mut scene.integration_store().borrow_mut())
+            .unwrap();
         let callback_count = Rc::new(RefCell::new(0));
         let mut callbacks = RustHostCallbackTable::new();
         let observed_count = Rc::clone(&callback_count);

--- a/crates/noon/src/live_session.rs
+++ b/crates/noon/src/live_session.rs
@@ -9,6 +9,7 @@
 mod family_layout;
 pub use family_layout::LiveLayoutTarget;
 
+use crate::execution_session::EffectiveSemanticObject;
 use crate::{
     family_arrangement::FamilyArrangePlan,
     semantic_mobject::{authoring_render_f64, prepare_become_state, stage_state_changes},
@@ -17,7 +18,7 @@ use crate::{
         edit_fill_opacity, edit_manim_opacity, edit_object_opacity, edit_stroke, edit_stroke_color,
         edit_stroke_opacity,
     },
-    DeclaredAnimation, EffectiveSemanticObject, ExecutionSegment, ExecutionSegmentAdvanceError,
+    DeclaredAnimation, ExecutionSegment, ExecutionSegmentAdvanceError,
     ExecutionSegmentCompletionError, ExecutionSegmentError, ExecutionSegmentState,
     ExecutionSession, ExecutionSessionAnimationError, ExecutionSessionPublicationError,
     ManimBecomeOptions, ManimLineEndpoints, Mobject, MobjectFamily, MobjectFamilyMember,
@@ -2280,14 +2281,14 @@ impl<'a> LiveSession<'a> {
     }
 
     fn require_mobject(&self, mobject: &Mobject) -> Result<(), LiveSessionError> {
-        if !Rc::ptr_eq(self.store, mobject.store()) {
+        if !Rc::ptr_eq(self.store, mobject.integration_store()) {
             return Err(LiveSessionError::ForeignMobjectStore);
         }
         mobject.validate().map_err(LiveSessionError::Mobject)
     }
 
     fn require_family(&self, family: &MobjectFamily) -> Result<(), LiveSessionError> {
-        if !Rc::ptr_eq(self.store, family.store()) {
+        if !Rc::ptr_eq(self.store, family.integration_store()) {
             return Err(LiveSessionError::ForeignMobjectStore);
         }
         family.validate().map_err(LiveSessionError::Mobject)
@@ -2297,7 +2298,8 @@ impl<'a> LiveSession<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{CallbackAdvance, ExecutionSessionCreateError, Scene};
+    use crate::execution_session::CallbackAdvance;
+    use crate::{ExecutionSessionCreateError, Scene};
     use noon_core::{
         AnimationOptions, Color, HostCallbackId, RateFunction, SemanticPaint, SemanticVec3,
     };
@@ -2398,7 +2400,9 @@ mod tests {
         scene.add(&circle).unwrap();
         let mut callbacks = SemanticMutationTransaction::new();
         callbacks.add_updater(circle.node_id(), HostCallbackId::new(9), 0.0, None);
-        callbacks.apply(&mut scene.store().borrow_mut()).unwrap();
+        callbacks
+            .apply(&mut scene.integration_store().borrow_mut())
+            .unwrap();
 
         let mut session = scene.execution_session().unwrap();
         let mut live = scene.live(&mut session);
@@ -2900,7 +2904,11 @@ mod tests {
         let anchor = scene.circle(0.5).unwrap();
         scene.add(&anchor).unwrap();
         let mut session = scene.execution_session().unwrap();
-        let before_resources = scene.store().borrow().geometry_resources().len();
+        let before_resources = scene
+            .integration_store()
+            .borrow()
+            .geometry_resources()
+            .len();
         let path = crate::ManimGeometryOptions::path(
             VectorPath::new()
                 .move_to(Vec2::ZERO)
@@ -2908,7 +2916,7 @@ mod tests {
         )
         .unwrap();
 
-        Mobject::manim_circle(Rc::clone(scene.store()), 0.1).unwrap();
+        Mobject::manim_circle(Rc::clone(scene.integration_store()), 0.1).unwrap();
         let mut live = scene.live(&mut session);
         assert!(matches!(
             live.create_manim_geometry(path),
@@ -2917,7 +2925,11 @@ mod tests {
             ))
         ));
         assert_eq!(
-            scene.store().borrow().geometry_resources().len(),
+            scene
+                .integration_store()
+                .borrow()
+                .geometry_resources()
+                .len(),
             before_resources
         );
     }
@@ -3160,7 +3172,7 @@ mod tests {
         let mut session = scene.execution_session().unwrap();
         session.take_frame_changes();
         let before = session.publication_context();
-        let before_nodes = circle.store().borrow().len();
+        let before_nodes = circle.integration_store().borrow().len();
         let options = AnimationOptions::new()
             .run_time(1.0)
             .rate_func(RateFunction::Smooth);
@@ -3182,7 +3194,7 @@ mod tests {
             before.scene_revision().checked_next().unwrap()
         );
         // Two Create leaves and one Parallel root share one semantic publication.
-        assert_eq!(circle.store().borrow().len(), before_nodes + 3);
+        assert_eq!(circle.integration_store().borrow().len(), before_nodes + 3);
         assert!(live.contains(&circle).unwrap());
         assert!(live.contains(&square).unwrap());
         assert_eq!(live.session.frame().objects.len(), 2);
@@ -3202,7 +3214,7 @@ mod tests {
         let mut session = scene.execution_session().unwrap();
         session.take_frame_changes();
         let before = session.publication_context();
-        let before_nodes = circle.store().borrow().len();
+        let before_nodes = circle.integration_store().borrow().len();
         let options = AnimationOptions::new()
             .run_time(1.0)
             .rate_func(RateFunction::Linear);
@@ -3224,7 +3236,7 @@ mod tests {
             ))
         ));
         assert_eq!(session.publication_context(), before);
-        assert_eq!(circle.store().borrow().len(), before_nodes);
+        assert_eq!(circle.integration_store().borrow().len(), before_nodes);
         assert!(session.frame().objects.is_empty());
         assert!(session.take_frame_changes().is_empty());
     }
@@ -3283,7 +3295,7 @@ mod tests {
         let mut square = scene.square(1.0).unwrap();
         square.set_translation(2.0, -1.0).unwrap();
         let detached_family = {
-            let mut store = scene.store().borrow_mut();
+            let mut store = scene.integration_store().borrow_mut();
             let family = store.insert_family();
             store.add_member(family, square.node_id()).unwrap();
             family
@@ -3320,7 +3332,7 @@ mod tests {
         assert!(!live.contains(&square).unwrap());
         assert_eq!(square.node_id(), semantic_id);
         assert_eq!(square.state().unwrap(), authored);
-        let store = square.store().borrow();
+        let store = square.integration_store().borrow();
         let parents = store.node(square.node_id()).unwrap().parents();
         assert_eq!(parents.len(), 1);
         assert!(parents.contains(&detached_family));
@@ -3331,7 +3343,7 @@ mod tests {
         let scene = Scene::new();
         let square = scene.square(1.0).unwrap();
         let detached_family = {
-            let mut store = scene.store().borrow_mut();
+            let mut store = scene.integration_store().borrow_mut();
             let family = store.insert_family();
             store.add_member(family, square.node_id()).unwrap();
             family
@@ -3363,7 +3375,7 @@ mod tests {
         live.complete_segment(segment).unwrap();
         assert_eq!(square.node_id(), semantic_id);
         {
-            let store = square.store().borrow();
+            let store = square.integration_store().borrow();
             let parents = store.node(square.node_id()).unwrap().parents();
             assert_eq!(parents.len(), 2);
             assert!(parents.contains(&detached_family));
@@ -3411,7 +3423,7 @@ mod tests {
         live.advance_segment_to(shrink, shrink.end_time()).unwrap();
         live.complete_segment(shrink).unwrap();
         assert!(!live.contains(&square).unwrap());
-        let store = square.store().borrow();
+        let store = square.integration_store().borrow();
         let parents = store.node(square.node_id()).unwrap().parents();
         assert_eq!(parents.len(), 1);
         assert!(parents.contains(&detached_family));
@@ -3422,7 +3434,7 @@ mod tests {
         let scene = Scene::new();
         let square = scene.square(1.0).unwrap();
         let live_family = {
-            let mut store = scene.store().borrow_mut();
+            let mut store = scene.integration_store().borrow_mut();
             let family = store.insert_family();
             store.add_member(family, square.node_id()).unwrap();
             family
@@ -3432,7 +3444,9 @@ mod tests {
         let mut membership = SemanticMutationTransaction::new();
         membership.add_member(scene.root(), live_family);
         membership.add_member(scene.root(), square.node_id());
-        membership.apply(&mut scene.store().borrow_mut()).unwrap();
+        membership
+            .apply(&mut scene.integration_store().borrow_mut())
+            .unwrap();
         let mut session = scene.execution_session().unwrap();
         session.take_frame_changes();
         let before = session.publication_context();
@@ -3464,7 +3478,7 @@ mod tests {
         let mut session = scene.execution_session().unwrap();
         session.take_frame_changes();
         let before = session.publication_context();
-        let before_nodes = square.store().borrow().len();
+        let before_nodes = square.integration_store().borrow().len();
 
         let result = scene
             .live(&mut session)
@@ -3482,7 +3496,7 @@ mod tests {
 
         assert!(matches!(result, Err(LiveSessionError::Activation(_))));
         assert_eq!(session.publication_context(), before);
-        assert_eq!(square.store().borrow().len(), before_nodes);
+        assert_eq!(square.integration_store().borrow().len(), before_nodes);
         assert!(session.frame().objects.is_empty());
         assert!(session.take_frame_changes().is_empty());
     }
@@ -3612,7 +3626,7 @@ mod tests {
         let mut session = scene.execution_session().unwrap();
         session.take_frame_changes();
         let before = session.publication_context();
-        let before_nodes = left.store().borrow().len();
+        let before_nodes = left.integration_store().borrow().len();
 
         let children = [
             TransformToRequest::new(
@@ -3645,7 +3659,7 @@ mod tests {
             before.scene_revision().checked_next().unwrap()
         );
         // Two immutable target snapshots, two leaves, and one root share that commit.
-        assert_eq!(left.store().borrow().len(), before_nodes + 5);
+        assert_eq!(left.integration_store().borrow().len(), before_nodes + 5);
         let publication = live.session.last_structural_publication_stats();
         assert_eq!(publication.preparation.object_states_lowered, 0);
         assert_eq!(publication.entered_objects, 0);
@@ -3793,7 +3807,7 @@ mod tests {
         session.take_frame_changes();
         let before = session.publication_context();
         let before_frame = session.frame().clone();
-        let before_nodes = circle.store().borrow().len();
+        let before_nodes = circle.integration_store().borrow().len();
         let children = [
             TransformToRequest::new(&circle, &first_target, AnimationOptions::new()),
             TransformToRequest::new(&circle, &second_target, AnimationOptions::new()),
@@ -3818,7 +3832,7 @@ mod tests {
         ));
         assert_eq!(session.publication_context(), before);
         assert_eq!(session.frame(), &before_frame);
-        assert_eq!(circle.store().borrow().len(), before_nodes);
+        assert_eq!(circle.integration_store().borrow().len(), before_nodes);
         assert!(session.take_frame_changes().is_empty());
     }
 
@@ -3833,7 +3847,7 @@ mod tests {
         session.take_frame_changes();
         let before = session.publication_context();
         let before_frame = session.frame().clone();
-        let before_nodes = square.store().borrow().len();
+        let before_nodes = square.integration_store().borrow().len();
         let children = [
             AnimationCompositionRequest::TransformTo(TransformToRequest::new(
                 &square,
@@ -3859,7 +3873,7 @@ mod tests {
         assert!(matches!(result, Err(LiveSessionError::ForeignMobjectStore)));
         assert_eq!(session.publication_context(), before);
         assert_eq!(session.frame(), &before_frame);
-        assert_eq!(square.store().borrow().len(), before_nodes);
+        assert_eq!(square.integration_store().borrow().len(), before_nodes);
         assert!(session.take_frame_changes().is_empty());
     }
 
@@ -3872,7 +3886,7 @@ mod tests {
         let mut session = scene.execution_session().unwrap();
         session.take_frame_changes();
         let before = session.publication_context();
-        let before_nodes = line.store().borrow().len();
+        let before_nodes = line.integration_store().borrow().len();
 
         let result = scene
             .live(&mut session)
@@ -3898,7 +3912,7 @@ mod tests {
             ))
         ), "unexpected rejection: {result:?}");
         assert_eq!(session.publication_context(), before);
-        assert_eq!(line.store().borrow().len(), before_nodes);
+        assert_eq!(line.integration_store().borrow().len(), before_nodes);
         assert!(session.frame().objects.is_empty());
         assert!(session.take_frame_changes().is_empty());
     }
@@ -4209,7 +4223,7 @@ mod tests {
             live.complete_segment(segment).unwrap();
             assert_eq!(live.effective(&shape).unwrap().appearance, 1.0);
             assert!(!scene
-                .store()
+                .integration_store()
                 .borrow()
                 .semantic_family_members_checked(scene.root())
                 .unwrap()
@@ -4387,7 +4401,7 @@ mod recursive_composition_tests {
         let mut session = scene.execution_session().unwrap();
         session.take_frame_changes();
         let before = session.publication_context();
-        let before_nodes = first.store().borrow().len();
+        let before_nodes = first.integration_store().borrow().len();
         let request = AnimationCompositionRequest::Composition {
             kind: SemanticAnimationCompositionKind::Sequence,
             options: AnimationOptions::new().rate_func(RateFunction::Smooth),
@@ -4419,7 +4433,7 @@ mod recursive_composition_tests {
             live.session.publication_context().scene_revision(),
             before.scene_revision().checked_next().unwrap()
         );
-        assert_eq!(first.store().borrow().len(), before_nodes + 5);
+        assert_eq!(first.integration_store().borrow().len(), before_nodes + 5);
         assert!(live.contains(&first).unwrap());
         assert!(live.contains(&second).unwrap());
         live.advance_segment_to(segment, segment.end_time())
@@ -4542,7 +4556,7 @@ mod recursive_composition_tests {
         assert!(!live.contains(&fading).unwrap());
         assert!(!live.contains(&companion).unwrap());
         assert!(fading
-            .store()
+            .integration_store()
             .borrow()
             .node(fading.node_id())
             .unwrap()
@@ -4657,7 +4671,7 @@ mod recursive_composition_tests {
         );
         assert_eq!(
             scene
-                .store()
+                .integration_store()
                 .borrow()
                 .semantic_signal_state(tracker.node_id())
                 .unwrap()
@@ -4695,7 +4709,7 @@ mod recursive_composition_tests {
         );
         assert_eq!(
             scene
-                .store()
+                .integration_store()
                 .borrow()
                 .semantic_signal_state(tracker.node_id())
                 .unwrap()
@@ -4705,7 +4719,7 @@ mod recursive_composition_tests {
         );
         assert_eq!(
             scene
-                .store()
+                .integration_store()
                 .borrow()
                 .semantic_input_scalar_value_at(tracker.node_id(), segment.end_time()),
             Ok(4.0)
@@ -4725,10 +4739,10 @@ mod recursive_composition_tests {
     fn invalid_mixed_sibling_rolls_back_tracker_scope_and_object_admission() {
         let scene = Scene::new();
         let square = scene.square(1.0).unwrap();
-        let tracker = ValueTracker::detached(Rc::clone(scene.store()), 0.0).unwrap();
+        let tracker = ValueTracker::detached(Rc::clone(scene.integration_store()), 0.0).unwrap();
         let mut session = scene.execution_session().unwrap();
         let before = session.publication_context();
-        let before_nodes = scene.store().borrow().len();
+        let before_nodes = scene.integration_store().borrow().len();
         let request = AnimationCompositionRequest::Composition {
             kind: SemanticAnimationCompositionKind::Parallel,
             options: AnimationOptions::new(),
@@ -4750,9 +4764,9 @@ mod recursive_composition_tests {
             .declare_and_activate_composition(&request, AnimationOptions::new())
             .is_err());
         assert_eq!(session.publication_context(), before);
-        assert_eq!(scene.store().borrow().len(), before_nodes);
+        assert_eq!(scene.integration_store().borrow().len(), before_nodes);
         assert!(!scene
-            .store()
+            .integration_store()
             .borrow()
             .has_semantic_signal_scope(tracker.node_id()));
         assert!(session.frame().objects.is_empty());
@@ -4761,8 +4775,8 @@ mod recursive_composition_tests {
     #[test]
     fn two_detached_trackers_enroll_in_one_mixed_publication() {
         let scene = Scene::new();
-        let first = ValueTracker::detached(Rc::clone(scene.store()), 1.0).unwrap();
-        let second = ValueTracker::detached(Rc::clone(scene.store()), -2.0).unwrap();
+        let first = ValueTracker::detached(Rc::clone(scene.integration_store()), 1.0).unwrap();
+        let second = ValueTracker::detached(Rc::clone(scene.integration_store()), -2.0).unwrap();
         let mut session = scene.execution_session().unwrap();
         let before = session.publication_context();
         let request = AnimationCompositionRequest::Composition {
@@ -4793,11 +4807,11 @@ mod recursive_composition_tests {
             before.scene_revision().checked_next().unwrap()
         );
         assert!(scene
-            .store()
+            .integration_store()
             .borrow()
             .has_semantic_signal_scope(first.node_id()));
         assert!(scene
-            .store()
+            .integration_store()
             .borrow()
             .has_semantic_signal_scope(second.node_id()));
         assert_eq!(
@@ -4813,8 +4827,8 @@ mod recursive_composition_tests {
     #[test]
     fn invalid_second_detached_tracker_rolls_back_both_enrollments() {
         let scene = Scene::new();
-        let first = ValueTracker::detached(Rc::clone(scene.store()), 1.0).unwrap();
-        let second = ValueTracker::detached(Rc::clone(scene.store()), -2.0).unwrap();
+        let first = ValueTracker::detached(Rc::clone(scene.integration_store()), 1.0).unwrap();
+        let second = ValueTracker::detached(Rc::clone(scene.integration_store()), -2.0).unwrap();
         let mut session = scene.execution_session().unwrap();
         let before = session.publication_context();
         let request = AnimationCompositionRequest::Composition {
@@ -4840,11 +4854,11 @@ mod recursive_composition_tests {
             .is_err());
         assert_eq!(session.publication_context(), before);
         assert!(!scene
-            .store()
+            .integration_store()
             .borrow()
             .has_semantic_signal_scope(first.node_id()));
         assert!(!scene
-            .store()
+            .integration_store()
             .borrow()
             .has_semantic_signal_scope(second.node_id()));
         assert_eq!(session.effective_signal_value(first.node_id()), None);
@@ -4923,7 +4937,7 @@ mod recursive_composition_tests {
             let nested = scene.family(&[(&first).into(), (&second).into()]).unwrap();
             let outer = scene.family(&[(&first).into()]).unwrap();
             scene
-                .store()
+                .integration_store()
                 .borrow_mut()
                 .add_member(outer.node_id(), nested.node_id())
                 .unwrap();
@@ -4984,7 +4998,7 @@ mod recursive_composition_tests {
             .unwrap();
         assert_eq!(
             scene
-                .store()
+                .integration_store()
                 .borrow()
                 .semantic_family_members_checked(scene.root())
                 .unwrap(),
@@ -5017,7 +5031,7 @@ mod recursive_composition_tests {
             .unwrap();
         live.complete_segment(segment).unwrap();
 
-        let store = scene.store().borrow();
+        let store = scene.integration_store().borrow();
         assert!(store
             .semantic_family_members_checked(scene.root())
             .unwrap()
@@ -5068,7 +5082,7 @@ mod recursive_composition_tests {
             .unwrap();
         live.complete_segment(segment).unwrap();
 
-        let store = scene.store().borrow();
+        let store = scene.integration_store().borrow();
         assert_eq!(
             store.semantic_family_members_checked(scene.root()).unwrap(),
             [written.node_id()]
@@ -5110,7 +5124,7 @@ mod recursive_composition_tests {
         assert_eq!(session.publication_context(), before);
         assert_eq!(
             scene
-                .store()
+                .integration_store()
                 .borrow()
                 .semantic_family_members_checked(scene.root())
                 .unwrap(),
@@ -5133,20 +5147,25 @@ mod recursive_composition_tests {
             transaction.add_member(inner, target.node_id());
             let outer = transaction.create_node(noon_core::SemanticNodeCreation::family());
             transaction.add_member(outer, inner);
-            let result = transaction.apply(&mut scene.store().borrow_mut()).unwrap();
-            MobjectFamily::from_node(Rc::clone(scene.store()), result.resolve(outer).unwrap())
-                .unwrap()
+            let result = transaction
+                .apply(&mut scene.integration_store().borrow_mut())
+                .unwrap();
+            MobjectFamily::from_node(
+                Rc::clone(scene.integration_store()),
+                result.resolve(outer).unwrap(),
+            )
+            .unwrap()
         };
         let mut session = scene.execution_session().unwrap();
         let before = session.publication_context();
-        let before_nodes = scene.store().borrow().len();
+        let before_nodes = scene.integration_store().borrow().len();
 
         assert!(scene
             .live(&mut session)
             .declare_and_activate_family_transform_to(&source, &nested, AnimationOptions::new(),)
             .is_err());
         assert_eq!(session.publication_context(), before);
-        assert_eq!(scene.store().borrow().len(), before_nodes);
+        assert_eq!(scene.integration_store().borrow().len(), before_nodes);
     }
 
     #[test]
@@ -5650,10 +5669,14 @@ mod recursive_composition_tests {
         let outer = transaction.create_node(noon_core::SemanticNodeCreation::family());
         transaction.add_member(outer, first.node_id());
         transaction.add_member(outer, nested.node_id());
-        let result = transaction.apply(&mut scene.store().borrow_mut()).unwrap();
-        let outer =
-            MobjectFamily::from_node(Rc::clone(scene.store()), result.resolve(outer).unwrap())
-                .unwrap();
+        let result = transaction
+            .apply(&mut scene.integration_store().borrow_mut())
+            .unwrap();
+        let outer = MobjectFamily::from_node(
+            Rc::clone(scene.integration_store()),
+            result.resolve(outer).unwrap(),
+        )
+        .unwrap();
 
         assert!(outer.prepare_subset_display().is_err());
         assert_eq!(first.state().unwrap().style.fill_opacity, 1.0);
@@ -5670,7 +5693,7 @@ mod recursive_composition_tests {
             .is_err());
         assert_eq!(session.publication_context(), before);
         assert!(scene
-            .store()
+            .integration_store()
             .borrow()
             .semantic_family_members_checked(scene.root())
             .unwrap()
@@ -5709,7 +5732,7 @@ mod recursive_composition_tests {
             .is_err());
         assert_eq!(session.publication_context(), before);
         assert!(scene
-            .store()
+            .integration_store()
             .borrow()
             .node(family.node_id())
             .unwrap()
@@ -5724,7 +5747,7 @@ mod recursive_composition_tests {
         live.complete_segment(write).unwrap();
         for member in [&left, &right] {
             assert!(noon_core::semantic_scene_root_contains(
-                &scene.store().borrow(),
+                &scene.integration_store().borrow(),
                 scene.root(),
                 member.node_id(),
             )
@@ -5743,13 +5766,13 @@ mod recursive_composition_tests {
         live.complete_segment(unwrite).unwrap();
         for member in [&left, &right] {
             assert!(!noon_core::semantic_scene_root_contains(
-                &scene.store().borrow(),
+                &scene.integration_store().borrow(),
                 scene.root(),
                 member.node_id(),
             )
             .unwrap());
         }
-        let store = family.store().borrow();
+        let store = family.integration_store().borrow();
         assert!(store.node(family.node_id()).is_some());
         assert_eq!(
             store

--- a/crates/noon/src/live_session/family_layout.rs
+++ b/crates/noon/src/live_session/family_layout.rs
@@ -143,7 +143,7 @@ impl LiveSession<'_> {
         &self,
         anchor: &crate::LayoutAnchor,
     ) -> Result<(Vec<SemanticNodeId>, Option<Bounds2D64>), LiveSessionError> {
-        if !Rc::ptr_eq(self.store, anchor.store()) {
+        if !Rc::ptr_eq(self.store, anchor.integration_store()) {
             return Err(LiveSessionError::Mobject(
                 "layout anchors belong to different authoring stores".into(),
             ));

--- a/crates/noon/src/native_signal_authoring.rs
+++ b/crates/noon/src/native_signal_authoring.rs
@@ -134,7 +134,7 @@ impl Scene {
         signal: &NativeVectorSignal,
     ) -> Result<(), String> {
         self.require_object(object)?;
-        signal.0.require_store(self.store())?;
+        signal.0.require_store(self.integration_store())?;
         self.bind_signal(
             object,
             signal.node_id(),
@@ -144,14 +144,14 @@ impl Scene {
 
     /// Bind a scalar input/event counter to rotation around the semantic z axis.
     pub fn bind_rotation(&self, object: &Mobject, signal: &ValueTracker) -> Result<(), String> {
-        signal.require_store(self.store())?;
+        signal.require_store(self.integration_store())?;
         self.require_object(object)?;
         self.bind_signal(object, signal.node_id(), SemanticObjectProperty::RotationZ)
     }
 
     /// Bind a scalar input to the object's composed opacity.
     pub fn bind_opacity(&self, object: &Mobject, signal: &ValueTracker) -> Result<(), String> {
-        signal.require_store(self.store())?;
+        signal.require_store(self.integration_store())?;
         self.require_object(object)?;
         self.bind_signal(
             object,
@@ -162,7 +162,7 @@ impl Scene {
 
     /// Bind a native bool state to whether the object participates in rendering.
     pub fn bind_presence(&self, object: &Mobject, signal: &NativeBoolSignal) -> Result<(), String> {
-        signal.0.require_store(self.store())?;
+        signal.0.require_store(self.integration_store())?;
         self.require_object(object)?;
         self.bind_signal(object, signal.node_id(), SemanticObjectProperty::Presence)
     }
@@ -195,7 +195,7 @@ impl Scene {
         initial: SemanticSignalValue,
         source: SemanticNativeInputSource,
     ) -> Result<(Rc<RefCell<SemanticStore>>, SemanticNodeId), String> {
-        let store = Rc::clone(self.store());
+        let store = Rc::clone(self.integration_store());
         let creation = noon_core::SemanticNodeCreation::native_input_signal(initial, source)
             .map_err(|error| error.to_string())?;
         let mut transaction = SemanticMutationTransaction::new();
@@ -216,7 +216,7 @@ impl Scene {
         signal: SemanticNodeId,
         property: SemanticObjectProperty,
     ) -> Result<(), String> {
-        self.store()
+        self.integration_store()
             .borrow_mut()
             .bind_semantic_signal(signal, object.node_id(), property)
             .map(|_| ())
@@ -244,16 +244,16 @@ mod tests {
     fn stale_scene_rejects_native_input_creation_without_allocating_a_signal() {
         let scene = Scene::new();
         scene
-            .store()
+            .integration_store()
             .borrow_mut()
             .remove_node(scene.root())
             .unwrap();
         let before = {
-            let store = scene.store().borrow();
+            let store = scene.integration_store().borrow();
             (store.len(), store.scene_revision())
         };
         assert!(scene.control_signal("gain", 1.0).is_err());
-        let store = scene.store().borrow();
+        let store = scene.integration_store().borrow();
         assert_eq!((store.len(), store.scene_revision()), before);
     }
 
@@ -277,7 +277,7 @@ mod tests {
         let wheel = scene.wheel_events().unwrap();
         let commit = scene.control_commit_events("opacity").unwrap();
 
-        let store = scene.store().borrow();
+        let store = scene.integration_store().borrow();
         assert_eq!(
             store
                 .semantic_signal_state(key.node_id())
@@ -348,11 +348,11 @@ mod tests {
     #[test]
     fn invalid_names_and_foreign_handles_fail_before_semantic_mutation() {
         let scene = Scene::new();
-        let before = scene.store().borrow().slot_capacity();
+        let before = scene.integration_store().borrow().slot_capacity();
         assert!(scene.key_state_signal(" ", false).is_err());
         assert!(scene.control_signal("", 1.0).is_err());
         assert!(scene.control_commit_events("\t").is_err());
-        assert_eq!(scene.store().borrow().slot_capacity(), before);
+        assert_eq!(scene.integration_store().borrow().slot_capacity(), before);
 
         let mut foreign = Scene::new();
         let object = foreign.square(1.0).unwrap();
@@ -360,7 +360,7 @@ mod tests {
         let pointer = scene.pointer_position_signal().unwrap();
         assert!(foreign.bind_native_translation(&object, &pointer).is_err());
         assert!(foreign
-            .store()
+            .integration_store()
             .borrow()
             .semantic_object_signal_bindings(object.node_id())
             .unwrap()

--- a/crates/noon/src/rotation_authoring.rs
+++ b/crates/noon/src/rotation_authoring.rs
@@ -84,7 +84,7 @@ mod tests {
         let mut session = scene.execution_session().unwrap();
         session.take_frame_changes();
         let before = session.publication_context();
-        let nodes = square.store().borrow().len();
+        let nodes = square.integration_store().borrow().len();
         for (target, pivot) in [
             (&square, ManimRotationPivot::Point(captured.0, captured.1)),
             (&square, ManimRotationPivot::Edge(1.0, 0.0)),
@@ -102,7 +102,7 @@ mod tests {
             );
             assert!(result.is_err(), "unsupported pivot accepted");
             assert_eq!(session.publication_context(), before);
-            assert_eq!(square.store().borrow().len(), nodes);
+            assert_eq!(square.integration_store().borrow().len(), nodes);
             assert!(session.frame().objects.is_empty());
             assert!(session.take_frame_changes().is_empty());
         }
@@ -163,7 +163,7 @@ mod tests {
             session.take_frame_changes();
             let before = session.publication_context();
             let before_frame = session.frame().clone();
-            let nodes = square.store().borrow().len();
+            let nodes = square.integration_store().borrow().len();
             let mut children = vec![
                 Request::ManimRotate {
                     target: &square,
@@ -200,7 +200,7 @@ mod tests {
                 "unexpected rejection: {result:?}"
             );
             assert_eq!(session.publication_context(), before);
-            assert_eq!(square.store().borrow().len(), nodes);
+            assert_eq!(square.integration_store().borrow().len(), nodes);
             assert_eq!(session.frame(), &before_frame);
             assert!(session.take_frame_changes().is_empty());
         }

--- a/crates/noon/src/scalar_authoring.rs
+++ b/crates/noon/src/scalar_authoring.rs
@@ -152,10 +152,10 @@ impl ValueTrackerPlay<'_> {
         if !(start + duration).is_finite() {
             return Err("ValueTracker track end time must be finite".into());
         }
-        self.tracker.require_store(self.scene.store())?;
+        self.tracker.require_store(self.scene.integration_store())?;
         if !self
             .scene
-            .store()
+            .integration_store()
             .borrow()
             .is_semantic_signal_scoped(self.scene.root(), self.tracker.node)
         {
@@ -170,7 +170,7 @@ impl ValueTrackerPlay<'_> {
             TrackTiming::new(start, duration, self.rate_function),
         );
         transaction
-            .apply(&mut self.scene.store().borrow_mut())
+            .apply(&mut self.scene.integration_store().borrow_mut())
             .map_err(|error| error.to_string())?;
         // The same conditions were checked above; this cannot fail after the
         // declaration commits, avoiding a divergent facade-owned cursor.
@@ -190,24 +190,24 @@ impl Scene {
         let pending = transaction.create_node(creation);
         transaction.scope_signal(self.root(), pending);
         let result = transaction
-            .apply(&mut self.store().borrow_mut())
+            .apply(&mut self.integration_store().borrow_mut())
             .map_err(|error| error.to_string())?;
         let node = result
             .resolve(pending)
             .expect("committed tracker creation resolves its transaction-local token");
         Ok(ValueTracker {
-            store: Rc::clone(self.store()),
+            store: Rc::clone(self.integration_store()),
             node,
         })
     }
 
     /// Associate an existing detached signal with this Scene's execution scope.
     pub fn associate_value_tracker(&self, tracker: &ValueTracker) -> Result<(), String> {
-        tracker.require_store(self.store())?;
+        tracker.require_store(self.integration_store())?;
         let mut transaction = SemanticMutationTransaction::new();
         transaction.scope_signal(self.root(), tracker.node_id());
         transaction
-            .apply(&mut self.store().borrow_mut())
+            .apply(&mut self.integration_store().borrow_mut())
             .map(|_| ())
             .map_err(|error| error.to_string())
     }
@@ -219,7 +219,7 @@ impl Scene {
         direction: SemanticVec3,
         offset: SemanticVec3,
     ) -> Result<TrackerPosition, String> {
-        tracker.require_store(self.store())?;
+        tracker.require_store(self.integration_store())?;
         if !direction.is_finite() || !offset.is_finite() {
             return Err("tracker direction and offset must be finite".into());
         }
@@ -235,12 +235,12 @@ impl Scene {
             )),
         );
         let node = self
-            .store()
+            .integration_store()
             .borrow_mut()
             .insert_semantic_derived_signal(expression)
             .map_err(|error| error.to_string())?;
         Ok(TrackerPosition {
-            store: Rc::clone(self.store()),
+            store: Rc::clone(self.integration_store()),
             node,
         })
     }
@@ -252,8 +252,8 @@ impl Scene {
         position: &TrackerPosition,
     ) -> Result<(), String> {
         self.require_object(object)?;
-        position.require_store(self.store())?;
-        self.store()
+        position.require_store(self.integration_store())?;
+        self.integration_store()
             .borrow_mut()
             .bind_semantic_signal(
                 position.node,
@@ -266,11 +266,11 @@ impl Scene {
 
     /// Set a non-timeline-owned tracker through the shared mutation transaction.
     pub fn set_value(&self, tracker: &ValueTracker, value: f64) -> Result<(), String> {
-        tracker.require_store(self.store())?;
+        tracker.require_store(self.integration_store())?;
         let mut transaction = SemanticMutationTransaction::new();
         transaction.set_signal(tracker.node, value);
         transaction
-            .apply(&mut self.store().borrow_mut())
+            .apply(&mut self.integration_store().borrow_mut())
             .map(|_| ())
             .map_err(|error| error.to_string())
     }
@@ -281,8 +281,8 @@ impl Scene {
     /// does not retain a value, evaluate an expression, or interpolate in a
     /// language wrapper.
     pub fn value_tracker_value(&self, tracker: &ValueTracker) -> Result<f64, String> {
-        tracker.require_store(self.store())?;
-        self.store()
+        tracker.require_store(self.integration_store())?;
+        self.integration_store()
             .borrow()
             .semantic_input_scalar_value_at(tracker.node, self.time())
             .map_err(|error| error.to_string())
@@ -343,7 +343,7 @@ mod tests {
 
         assert_eq!(scene.time(), 2.0);
         let signal = scene
-            .store()
+            .integration_store()
             .borrow()
             .semantic_signal_state(tracker.node_id())
             .unwrap()
@@ -384,7 +384,7 @@ mod tests {
             before.scene_revision().get() + 1
         );
         assert!(scene
-            .store()
+            .integration_store()
             .borrow()
             .semantic_scoped_signals(scene.root())
             .unwrap()
@@ -395,11 +395,14 @@ mod tests {
     fn live_tracker_creation_failure_leaves_store_and_runtime_unchanged() {
         let scene = Scene::new();
         let mut session = scene.execution_session().unwrap();
-        let revision = scene.store().borrow().scene_revision();
+        let revision = scene.integration_store().borrow().scene_revision();
         let publication = session.publication_context();
         let frame = session.frame().clone();
         assert!(scene.live(&mut session).value_tracker(f64::MAX).is_err());
-        assert_eq!(scene.store().borrow().scene_revision(), revision);
+        assert_eq!(
+            scene.integration_store().borrow().scene_revision(),
+            revision
+        );
         assert_eq!(session.publication_context(), publication);
         assert_eq!(session.frame(), &frame);
     }
@@ -408,11 +411,12 @@ mod tests {
     fn detached_tracker_play_scopes_and_enrolls_with_its_activation() {
         let scene = Scene::new();
         let detached = scene
-            .store()
+            .integration_store()
             .borrow_mut()
             .insert_semantic_input_signal(4.0_f64)
             .unwrap();
-        let tracker = ValueTracker::from_semantic_node(Rc::clone(scene.store()), detached);
+        let tracker =
+            ValueTracker::from_semantic_node(Rc::clone(scene.integration_store()), detached);
         let mut session = scene.execution_session().unwrap();
         assert!(session.effective_signal_value(detached).is_none());
         let before = session.publication_context().scene_revision();
@@ -425,7 +429,7 @@ mod tests {
             before.checked_next().unwrap()
         );
         assert!(scene
-            .store()
+            .integration_store()
             .borrow()
             .is_semantic_signal_scoped(scene.root(), tracker.node_id()));
         assert_eq!(
@@ -442,7 +446,7 @@ mod tests {
     #[test]
     fn detached_tracker_value_stays_store_owned_before_scene_association() {
         let scene = Scene::new();
-        let tracker = ValueTracker::detached(Rc::clone(scene.store()), 1.25).unwrap();
+        let tracker = ValueTracker::detached(Rc::clone(scene.integration_store()), 1.25).unwrap();
 
         assert_eq!(tracker.detached_value().unwrap(), 1.25);
         tracker.set_detached_value(2.5).unwrap();
@@ -458,12 +462,12 @@ mod tests {
     fn foreign_scene_rejects_detached_tracker_without_scoping_it() {
         let scene = Scene::new();
         let foreign = Scene::new();
-        let tracker = ValueTracker::detached(Rc::clone(scene.store()), 1.0).unwrap();
+        let tracker = ValueTracker::detached(Rc::clone(scene.integration_store()), 1.0).unwrap();
 
         assert!(foreign.associate_value_tracker(&tracker).is_err());
         assert_eq!(tracker.detached_value().unwrap(), 1.0);
         assert!(!scene
-            .store()
+            .integration_store()
             .borrow()
             .is_semantic_signal_scoped(scene.root(), tracker.node_id()));
     }
@@ -472,13 +476,14 @@ mod tests {
     fn invalid_detached_tracker_association_rolls_back_scope_and_runtime() {
         let scene = Scene::new();
         let detached = scene
-            .store()
+            .integration_store()
             .borrow_mut()
             .insert_semantic_input_signal(f64::MAX)
             .unwrap();
-        let tracker = ValueTracker::from_semantic_node(Rc::clone(scene.store()), detached);
+        let tracker =
+            ValueTracker::from_semantic_node(Rc::clone(scene.integration_store()), detached);
         let mut session = scene.execution_session().unwrap();
-        let revision = scene.store().borrow().scene_revision();
+        let revision = scene.integration_store().borrow().scene_revision();
         let publication = session.publication_context();
         let frame = session.frame().clone();
 
@@ -487,7 +492,7 @@ mod tests {
             .associate_value_tracker(&tracker)
             .is_err());
 
-        let store = scene.store().borrow();
+        let store = scene.integration_store().borrow();
         assert_eq!(store.scene_revision(), revision);
         assert!(!store
             .semantic_scoped_signals(scene.root())
@@ -528,7 +533,7 @@ mod tests {
             .run_time(1.0)
             .unwrap();
 
-        let store = scene.store().borrow();
+        let store = scene.integration_store().borrow();
         let timeline = store
             .semantic_signal_state(tracker.node_id())
             .unwrap()

--- a/crates/noon/src/scene.rs
+++ b/crates/noon/src/scene.rs
@@ -26,10 +26,13 @@ impl Default for Scene {
 }
 impl Scene {
     pub fn new() -> Self {
-        Self::with_store(Rc::new(RefCell::new(SemanticStore::new())))
+        Self::with_integration_store(Rc::new(RefCell::new(SemanticStore::new())))
     }
     /// Integration entry point for language wrappers sharing one semantic arena.
-    pub fn with_store(store: Rc<RefCell<SemanticStore>>) -> Self {
+    ///
+    /// Creates a new root in the existing arena. It does not attach an existing
+    /// session or publish changes into one; see [`crate::integration`].
+    pub fn with_integration_store(store: Rc<RefCell<SemanticStore>>) -> Self {
         let mut transaction = SemanticMutationTransaction::new();
         transaction.add_node(SemanticNodeCreation::family());
         let result = transaction
@@ -44,10 +47,26 @@ impl Scene {
             cursor: 0.0,
         }
     }
-    /// Integration access; handles reject stale identities after external edits.
-    pub fn store(&self) -> &Rc<RefCell<SemanticStore>> {
+    /// Raw shared arena access for explicit integration, not live mutation.
+    ///
+    /// External edits can invalidate generational handles and leave an existing
+    /// execution session on a stale scene revision. Use `Scene::live` and its
+    /// coherent publication operations for edits after lowering. No revision
+    /// validation is bypassed by this accessor; see [`crate::integration`].
+    pub fn integration_store(&self) -> &Rc<RefCell<SemanticStore>> {
         &self.store
     }
+    /// Current authored revision without exposing mutable arena access.
+    pub fn revision(&self) -> noon_core::SceneRevision {
+        self.store.borrow().scene_revision()
+    }
+
+    /// Construct detached geometry through the shared authoring implementation.
+    /// Use `LiveSession::create_manim_geometry` after initial lowering instead.
+    pub fn geometry(&self, options: crate::ManimGeometryOptions) -> Result<Mobject, String> {
+        Mobject::from_manim_geometry(Rc::clone(&self.store), options)
+    }
+
     pub fn root(&self) -> SemanticNodeId {
         self.root
     }
@@ -129,7 +148,7 @@ impl Scene {
         .map(|_| ())
     }
     pub(crate) fn require_object(&self, object: &Mobject) -> Result<(), String> {
-        if !Rc::ptr_eq(&self.store, object.store()) {
+        if !Rc::ptr_eq(&self.store, object.integration_store()) {
             return Err("mobject belongs to another scene store".into());
         }
         object.validate()

--- a/crates/noon/src/scene/tests.rs
+++ b/crates/noon/src/scene/tests.rs
@@ -11,41 +11,53 @@ fn ordinary_transform_preflight_is_read_only_and_shares_affine_payload_validatio
     let options = AnimationOptions::new()
         .run_time(1.0)
         .rate_func(RateFunction::Linear);
-    let revision = scene.store().borrow().scene_revision();
+    let revision = scene.integration_store().borrow().scene_revision();
     assert!(scene
         .can_ordinary_transform_to(&circle, &affine_target, options)
         .unwrap());
-    assert_eq!(scene.store().borrow().scene_revision(), revision);
+    assert_eq!(
+        scene.integration_store().borrow().scene_revision(),
+        revision
+    );
     for rate_func in [None, Some(RateFunction::Smooth)] {
         let mut smooth = options;
         smooth.rate_func = rate_func;
         assert!(scene
             .can_ordinary_transform_to(&circle, &affine_target, smooth)
             .unwrap());
-        assert_eq!(scene.store().borrow().scene_revision(), revision);
+        assert_eq!(
+            scene.integration_store().borrow().scene_revision(),
+            revision
+        );
     }
 
     let mut style_target = circle.target_editor().unwrap();
     style_target.set_fill_opacity(0.5).unwrap();
-    let revision = scene.store().borrow().scene_revision();
+    let revision = scene.integration_store().borrow().scene_revision();
     assert!(scene
         .can_ordinary_transform_to(&circle, &style_target, options)
         .unwrap());
-    assert_eq!(scene.store().borrow().scene_revision(), revision);
+    assert_eq!(
+        scene.integration_store().borrow().scene_revision(),
+        revision
+    );
 
     style_target.set_stroke_width(3.0).unwrap();
-    let revision = scene.store().borrow().scene_revision();
+    let revision = scene.integration_store().borrow().scene_revision();
     assert!(!scene
         .can_ordinary_transform_to(&circle, &style_target, options)
         .unwrap());
-    assert_eq!(scene.store().borrow().scene_revision(), revision);
+    assert_eq!(
+        scene.integration_store().borrow().scene_revision(),
+        revision
+    );
 
     let foreign = Scene::new().circle(1.0).unwrap();
     assert!(scene
         .can_ordinary_transform_to(&circle, &foreign, options)
         .is_err());
     scene
-        .store()
+        .integration_store()
         .borrow_mut()
         .remove_node(style_target.node_id())
         .unwrap();
@@ -57,8 +69,8 @@ fn ordinary_transform_preflight_is_read_only_and_shares_affine_payload_validatio
 #[test]
 fn membership_preserves_identity_isolates_roots_and_rejects_foreign_stores() {
     let store = Rc::new(RefCell::new(SemanticStore::new()));
-    let mut first = Scene::with_store(Rc::clone(&store));
-    let mut second = Scene::with_store(Rc::clone(&store));
+    let mut first = Scene::with_integration_store(Rc::clone(&store));
+    let mut second = Scene::with_integration_store(Rc::clone(&store));
     let object = first.circle(1.0).unwrap();
     let id = object.node_id();
     first.add(&object).unwrap();
@@ -103,7 +115,7 @@ fn batch_membership_uses_authoritative_root_order_and_one_revision() {
     let first = scene.circle(1.0).unwrap();
     let second = scene.square(1.0).unwrap();
     let replacement = scene.rectangle(2.0, 1.0).unwrap();
-    let before = scene.store().borrow().scene_revision();
+    let before = scene.integration_store().borrow().scene_revision();
     scene
         .add_many(&[
             MobjectFamilyMember::Mobject(&first),
@@ -111,11 +123,16 @@ fn batch_membership_uses_authoritative_root_order_and_one_revision() {
         ])
         .unwrap();
     assert_eq!(
-        scene.store().borrow().scene_revision().get(),
+        scene.integration_store().borrow().scene_revision().get(),
         before.get() + 1
     );
     assert_eq!(
-        scene.store().borrow().node(scene.root()).unwrap().members(),
+        scene
+            .integration_store()
+            .borrow()
+            .node(scene.root())
+            .unwrap()
+            .members(),
         &[first.node_id(), second.node_id()]
     );
 
@@ -126,12 +143,17 @@ fn batch_membership_uses_authoritative_root_order_and_one_revision() {
         )
         .unwrap();
     assert_eq!(
-        scene.store().borrow().node(scene.root()).unwrap().members(),
+        scene
+            .integration_store()
+            .borrow()
+            .node(scene.root())
+            .unwrap()
+            .members(),
         &[replacement.node_id(), second.node_id()]
     );
     scene.clear().unwrap();
     assert!(scene
-        .store()
+        .integration_store()
         .borrow()
         .node(scene.root())
         .unwrap()
@@ -162,7 +184,7 @@ fn initial_animation_root_rejects_foreign_and_stale_declaration_handles() {
         .execution_session_with_animation_root(&foreign_root)
         .is_err());
     local
-        .store()
+        .integration_store()
         .borrow_mut()
         .remove_node(local_root.node_id())
         .unwrap();

--- a/crates/noon/src/scene_membership.rs
+++ b/crates/noon/src/scene_membership.rs
@@ -25,7 +25,7 @@ pub(crate) fn prepare_scene_membership(
     request: SceneMembershipRequest<'_>,
 ) -> Result<SemanticMutationTransaction, String> {
     let validate = |member: MobjectFamilyMember<'_>| -> Result<SemanticNodeId, String> {
-        if !Rc::ptr_eq(owner, member.store()) {
+        if !Rc::ptr_eq(owner, member.integration_store()) {
             return Err("membership target belongs to another scene store".into());
         }
         member.validate()?;

--- a/crates/noon/src/semantic_mobject.rs
+++ b/crates/noon/src/semantic_mobject.rs
@@ -362,7 +362,13 @@ impl Mobject {
         Ok(handle)
     }
 
-    pub fn store(&self) -> &Rc<RefCell<SemanticStore>> {
+    /// Raw shared arena access for explicit integration, not live mutation.
+    ///
+    /// External edits can invalidate generational handles and leave an existing
+    /// execution session on a stale scene revision. Use `Scene::live` and its
+    /// coherent publication operations for edits after lowering. No revision
+    /// validation is bypassed by this accessor; see [`crate::integration`].
+    pub fn integration_store(&self) -> &Rc<RefCell<SemanticStore>> {
         &self.store
     }
     pub fn node_id(&self) -> SemanticNodeId {

--- a/crates/noon/src/semantic_mobject/manim_geometry.rs
+++ b/crates/noon/src/semantic_mobject/manim_geometry.rs
@@ -282,7 +282,7 @@ impl Mobject {
             .layout_bounds()?
             .ok_or("underline target has no finite bounds")?;
         Self::from_manim_geometry(
-            Rc::clone(target.store()),
+            Rc::clone(target.integration_store()),
             ManimGeometryOptions::underline(bounds, buff)?,
         )
     }

--- a/crates/noon/src/semantic_mobject/tests.rs
+++ b/crates/noon/src/semantic_mobject/tests.rs
@@ -9,14 +9,17 @@ fn aliases_and_copies_share_the_arena_but_only_aliases_share_state() {
     let mut copy = circle.copy_handle().unwrap();
     assert_eq!(circle.node_id(), alias.node_id());
     assert_ne!(circle.node_id(), copy.node_id());
-    assert!(Rc::ptr_eq(circle.store(), copy.store()));
+    assert!(Rc::ptr_eq(
+        circle.integration_store(),
+        copy.integration_store()
+    ));
     circle.shift(3.0, 1.0).unwrap();
     assert_eq!(alias.center().unwrap(), (3.0, 1.0));
     assert_eq!(copy.center().unwrap(), (0.0, 0.0));
     copy.set_fill_opacity(0.25).unwrap();
     assert_eq!(circle.fill_opacity().unwrap(), 0.0);
     let state = scene
-        .store()
+        .integration_store()
         .borrow()
         .semantic_object_state_checked(circle.node_id())
         .unwrap()
@@ -35,17 +38,23 @@ fn aliases_and_copies_share_the_arena_but_only_aliases_share_state() {
 fn no_op_edits_do_not_publish_and_invalid_compound_edits_roll_back() {
     let scene = Scene::new();
     let mut circle = scene.circle(1.0).unwrap();
-    let revision = scene.store().borrow().scene_revision();
+    let revision = scene.integration_store().borrow().scene_revision();
     circle.shift(0.0, 0.0).unwrap();
     circle.set_fill_opacity(0.0).unwrap();
-    assert_eq!(scene.store().borrow().scene_revision(), revision);
+    assert_eq!(
+        scene.integration_store().borrow().scene_revision(),
+        revision
+    );
     let before = circle.state().unwrap();
     let mut invalid = before.clone();
     invalid.transform.translation.x = 9.0;
     invalid.style.stroke_width = f64::NAN;
     assert!(circle.commit_state(invalid).is_err());
     assert_eq!(circle.state().unwrap(), before);
-    assert_eq!(scene.store().borrow().scene_revision(), revision);
+    assert_eq!(
+        scene.integration_store().borrow().scene_revision(),
+        revision
+    );
 }
 
 #[test]
@@ -62,7 +71,11 @@ fn become_matches_dimensions_in_manim_order_and_reuses_target_content() {
     let target_state = target.state().unwrap();
     let target_content = target_state.content;
     let source_id = source.node_id();
-    let resources = scene.store().borrow().geometry_resources().len();
+    let resources = scene
+        .integration_store()
+        .borrow()
+        .geometry_resources()
+        .len();
 
     source
         .become_handle(
@@ -83,13 +96,21 @@ fn become_matches_dimensions_in_manim_order_and_reuses_target_content() {
     assert!((source.width().unwrap() - 4.0).abs() < 1e-9);
     // Height matching occurs first; subsequent uniform width matching scales it again.
     assert!((source.height().unwrap() - 12.0).abs() < 1e-9);
-    assert_eq!(scene.store().borrow().geometry_resources().len(), resources);
+    assert_eq!(
+        scene
+            .integration_store()
+            .borrow()
+            .geometry_resources()
+            .len(),
+        resources
+    );
 }
 
 #[test]
 fn ellipse_layout_is_shared_by_queries_live_admission_and_become() {
     let mut scene = Scene::new();
-    let mut ellipse = Mobject::manim_ellipse(Rc::clone(scene.store()), 4.0, 1.5).unwrap();
+    let mut ellipse =
+        Mobject::manim_ellipse(Rc::clone(scene.integration_store()), 4.0, 1.5).unwrap();
     ellipse.rotate(std::f64::consts::PI / 6.0).unwrap();
     let expected_width = 3.663_013_982_517_412_6;
     let expected_height = 2.464_228_071_008_26;
@@ -106,7 +127,11 @@ fn ellipse_layout_is_shared_by_queries_live_admission_and_become() {
     );
 
     let mut source = scene.rectangle(6.0, 2.0).unwrap();
-    let resource_count = scene.store().borrow().geometry_resources().len();
+    let resource_count = scene
+        .integration_store()
+        .borrow()
+        .geometry_resources()
+        .len();
     source
         .become_handle(
             &ellipse,
@@ -126,7 +151,11 @@ fn ellipse_layout_is_shared_by_queries_live_admission_and_become() {
         SemanticGeometryLayout::ManimEllipseControlHull
     );
     assert_eq!(
-        scene.store().borrow().geometry_resources().len(),
+        scene
+            .integration_store()
+            .borrow()
+            .geometry_resources()
+            .len(),
         resource_count
     );
 
@@ -152,8 +181,12 @@ fn become_stretch_is_atomic_for_zero_dimension_targets() {
         .path(VectorPath::new(), SemanticStyle::default())
         .unwrap();
     let before = source.state().unwrap();
-    let revision = scene.store().borrow().scene_revision();
-    let resources = scene.store().borrow().geometry_resources().len();
+    let revision = scene.integration_store().borrow().scene_revision();
+    let resources = scene
+        .integration_store()
+        .borrow()
+        .geometry_resources()
+        .len();
 
     assert!(source
         .become_handle(
@@ -165,8 +198,18 @@ fn become_stretch_is_atomic_for_zero_dimension_targets() {
         )
         .is_err());
     assert_eq!(source.state().unwrap(), before);
-    assert_eq!(scene.store().borrow().scene_revision(), revision);
-    assert_eq!(scene.store().borrow().geometry_resources().len(), resources);
+    assert_eq!(
+        scene.integration_store().borrow().scene_revision(),
+        revision
+    );
+    assert_eq!(
+        scene
+            .integration_store()
+            .borrow()
+            .geometry_resources()
+            .len(),
+        resources
+    );
 }
 
 #[test]
@@ -183,7 +226,7 @@ fn foreign_operands_and_stale_handles_fail_without_mutation_or_query_panics() {
     assert!(circle.next_to_handle(&foreign, 1.0, 0.0, 0.25).is_err());
     assert_eq!(circle.state().unwrap(), before);
     scene
-        .store()
+        .integration_store()
         .borrow_mut()
         .remove_node(circle.node_id())
         .unwrap();
@@ -225,14 +268,18 @@ fn resource_geometry_is_store_owned_and_lowers_from_the_same_node() {
     assert!(session.execution_object_id(object.node_id()).is_some());
     assert_eq!(session.frame().objects.len(), 1);
     let foreign_scene = Scene::new();
-    assert!(Mobject::new(Rc::clone(foreign_scene.store()), object.state().unwrap()).is_err());
+    assert!(Mobject::new(
+        Rc::clone(foreign_scene.integration_store()),
+        object.state().unwrap()
+    )
+    .is_err());
 }
 
 #[test]
 fn typed_manim_geometry_preserves_semantic_precision_and_matcher_defaults() {
     let scene = Scene::new();
-    let before_revision = scene.store().borrow().scene_revision();
-    let before_nodes = scene.store().borrow().len();
+    let before_revision = scene.integration_store().borrow().scene_revision();
+    let before_nodes = scene.integration_store().borrow().len();
     let precise_x = 0.123_456_789_012_345;
     let mut path = ManimGeometryOptions::path(
         VectorPath::new()
@@ -242,11 +289,11 @@ fn typed_manim_geometry_preserves_semantic_precision_and_matcher_defaults() {
     .unwrap();
     path.set_translation(precise_x, -2.0).unwrap();
     path.set_fill(0.2, 0.4, 0.6, 0.75).unwrap();
-    let object = Mobject::from_manim_geometry(Rc::clone(scene.store()), path).unwrap();
+    let object = Mobject::from_manim_geometry(Rc::clone(scene.integration_store()), path).unwrap();
 
-    assert_eq!(scene.store().borrow().len(), before_nodes + 1);
+    assert_eq!(scene.integration_store().borrow().len(), before_nodes + 1);
     assert_eq!(
-        scene.store().borrow().scene_revision(),
+        scene.integration_store().borrow().scene_revision(),
         before_revision.checked_next().unwrap()
     );
     assert_eq!(object.state().unwrap().transform.translation.x, precise_x);
@@ -257,7 +304,7 @@ fn typed_manim_geometry_preserves_semantic_precision_and_matcher_defaults() {
 
     let point = Bounds2D64::point(3.0, -1.0);
     let surround = Mobject::from_manim_geometry(
-        Rc::clone(scene.store()),
+        Rc::clone(scene.integration_store()),
         ManimGeometryOptions::surrounding_rectangle(point, 0.25, 0.5, 0.1).unwrap(),
     )
     .unwrap();
@@ -267,7 +314,7 @@ fn typed_manim_geometry_preserves_semantic_precision_and_matcher_defaults() {
     assert_eq!(surround.fill_opacity().unwrap(), 0.0);
 
     let background = Mobject::from_manim_geometry(
-        Rc::clone(scene.store()),
+        Rc::clone(scene.integration_store()),
         ManimGeometryOptions::background_rectangle(point, 0.25, 0.5, 0.0, 0.4).unwrap(),
     )
     .unwrap();
@@ -280,9 +327,13 @@ fn typed_manim_geometry_preserves_semantic_precision_and_matcher_defaults() {
 #[test]
 fn invalid_typed_geometry_and_matcher_bounds_are_inert() {
     let scene = Scene::new();
-    let revision = scene.store().borrow().scene_revision();
-    let nodes = scene.store().borrow().len();
-    let resources = scene.store().borrow().geometry_resources().len();
+    let revision = scene.integration_store().borrow().scene_revision();
+    let nodes = scene.integration_store().borrow().len();
+    let resources = scene
+        .integration_store()
+        .borrow()
+        .geometry_resources()
+        .len();
 
     assert!(
         ManimGeometryOptions::path(VectorPath::new().move_to(Vec2::new(f32::NAN, 0.0))).is_err()
@@ -315,19 +366,35 @@ fn invalid_typed_geometry_and_matcher_bounds_are_inert() {
     )
     .unwrap();
     invalid_style.style.stroke_width = f64::NAN;
-    assert!(Mobject::from_manim_geometry(Rc::clone(scene.store()), invalid_style).is_err());
+    assert!(
+        Mobject::from_manim_geometry(Rc::clone(scene.integration_store()), invalid_style).is_err()
+    );
 
-    assert_eq!(scene.store().borrow().scene_revision(), revision);
-    assert_eq!(scene.store().borrow().len(), nodes);
-    assert_eq!(scene.store().borrow().geometry_resources().len(), resources);
+    assert_eq!(
+        scene.integration_store().borrow().scene_revision(),
+        revision
+    );
+    assert_eq!(scene.integration_store().borrow().len(), nodes);
+    assert_eq!(
+        scene
+            .integration_store()
+            .borrow()
+            .geometry_resources()
+            .len(),
+        resources
+    );
 }
 
 #[test]
 fn invalid_geometry_or_paint_does_not_allocate_or_publish() {
     let scene = Scene::new();
-    let revision = scene.store().borrow().scene_revision();
-    let nodes = scene.store().borrow().len();
-    let resources = scene.store().borrow().geometry_resources().len();
+    let revision = scene.integration_store().borrow().scene_revision();
+    let nodes = scene.integration_store().borrow().len();
+    let resources = scene
+        .integration_store()
+        .borrow()
+        .geometry_resources()
+        .len();
     let invalid_path = VectorPath::new().move_to(Vec2::new(f32::NAN, 0.0));
     assert!(scene.path(invalid_path, SemanticStyle::default()).is_err());
     let morph = VectorPath::new()
@@ -340,7 +407,7 @@ fn invalid_geometry_or_paint_does_not_allocate_or_publish() {
         GeometryRef::line(Vec2::ZERO, Vec2::new(f32::NAN, 0.0)),
     ] {
         assert!(Mobject::from_geometry(
-            Rc::clone(scene.store()),
+            Rc::clone(scene.integration_store()),
             geometry,
             SemanticStyle::default()
         )
@@ -356,9 +423,11 @@ fn invalid_geometry_or_paint_does_not_allocate_or_publish() {
             end: Vec2::new(f32::NAN, 0.0),
         },
     ] {
-        assert!(
-            Mobject::new(Rc::clone(scene.store()), SemanticObjectState::new(geometry)).is_err()
-        );
+        assert!(Mobject::new(
+            Rc::clone(scene.integration_store()),
+            SemanticObjectState::new(geometry)
+        )
+        .is_err());
     }
     let invalid_style = SemanticStyle {
         fill: Some(SemanticPaint::Solid(Color::rgba(f32::NAN, 1.0, 1.0, 1.0))),
@@ -369,10 +438,20 @@ fn invalid_geometry_or_paint_does_not_allocate_or_publish() {
         .is_err());
     let mut state = SemanticObjectState::new(StoredGeometry::Circle { radius: 1.0 });
     state.style = invalid_style;
-    assert!(Mobject::new(Rc::clone(scene.store()), state).is_err());
-    assert_eq!(scene.store().borrow().scene_revision(), revision);
-    assert_eq!(scene.store().borrow().len(), nodes);
-    assert_eq!(scene.store().borrow().geometry_resources().len(), resources);
+    assert!(Mobject::new(Rc::clone(scene.integration_store()), state).is_err());
+    assert_eq!(
+        scene.integration_store().borrow().scene_revision(),
+        revision
+    );
+    assert_eq!(scene.integration_store().borrow().len(), nodes);
+    assert_eq!(
+        scene
+            .integration_store()
+            .borrow()
+            .geometry_resources()
+            .len(),
+        resources
+    );
 }
 
 #[test]
@@ -486,17 +565,22 @@ fn analytic_line_match_rejects_invalid_operands_before_mutation() {
 #[test]
 fn specialized_manim_geometry_uses_one_semantic_identity_per_constructor() {
     let scene = Scene::new();
-    let before = scene.store().borrow().scene_revision();
-    let before_nodes = scene.store().borrow().len();
+    let before = scene.integration_store().borrow().scene_revision();
+    let before_nodes = scene.integration_store().borrow().len();
 
-    let dot = Mobject::manim_dot(Rc::clone(scene.store()), 1.25, -0.75, 0.08).unwrap();
-    let triangle = Mobject::manim_triangle(Rc::clone(scene.store())).unwrap();
-    let elbow =
-        Mobject::manim_elbow(Rc::clone(scene.store()), 0.2, std::f64::consts::FRAC_PI_4).unwrap();
+    let dot = Mobject::manim_dot(Rc::clone(scene.integration_store()), 1.25, -0.75, 0.08).unwrap();
+    let triangle = Mobject::manim_triangle(Rc::clone(scene.integration_store())).unwrap();
+    let elbow = Mobject::manim_elbow(
+        Rc::clone(scene.integration_store()),
+        0.2,
+        std::f64::consts::FRAC_PI_4,
+    )
+    .unwrap();
     let rounded =
-        Mobject::manim_rounded_rectangle(Rc::clone(scene.store()), 4.0, 2.0, 0.5).unwrap();
+        Mobject::manim_rounded_rectangle(Rc::clone(scene.integration_store()), 4.0, 2.0, 0.5)
+            .unwrap();
     let annular = Mobject::manim_annular_sector(
-        Rc::clone(scene.store()),
+        Rc::clone(scene.integration_store()),
         1.0,
         2.0,
         std::f64::consts::FRAC_PI_2,
@@ -507,7 +591,7 @@ fn specialized_manim_geometry_uses_one_semantic_identity_per_constructor() {
     )
     .unwrap();
     let sector = Mobject::manim_sector(
-        Rc::clone(scene.store()),
+        Rc::clone(scene.integration_store()),
         1.0,
         std::f64::consts::FRAC_PI_2,
         0.0,
@@ -516,10 +600,19 @@ fn specialized_manim_geometry_uses_one_semantic_identity_per_constructor() {
         0.0,
     )
     .unwrap();
-    let annulus = Mobject::manim_annulus(Rc::clone(scene.store()), 1.0, 2.0, 9, 0.0, 0.0).unwrap();
-    let dashed =
-        Mobject::manim_dashed_line(Rc::clone(scene.store()), -1.0, 0.0, 1.0, 0.0, 0.05, 0.5)
+    let annulus =
+        Mobject::manim_annulus(Rc::clone(scene.integration_store()), 1.0, 2.0, 9, 0.0, 0.0)
             .unwrap();
+    let dashed = Mobject::manim_dashed_line(
+        Rc::clone(scene.integration_store()),
+        -1.0,
+        0.0,
+        1.0,
+        0.0,
+        0.05,
+        0.5,
+    )
+    .unwrap();
     let underline = Mobject::manim_underline(&rounded, 0.25).unwrap();
 
     assert_eq!(dot.center().unwrap(), (1.25, -0.75));
@@ -538,9 +631,9 @@ fn specialized_manim_geometry_uses_one_semantic_identity_per_constructor() {
             Some(StoredGeometry::Resource(_))
         ));
     }
-    assert_eq!(scene.store().borrow().len(), before_nodes + 9);
+    assert_eq!(scene.integration_store().borrow().len(), before_nodes + 9);
     assert_eq!(
-        scene.store().borrow().scene_revision().get(),
+        scene.integration_store().borrow().scene_revision().get(),
         before.get() + 9
     );
 }
@@ -602,9 +695,13 @@ fn specialized_options_admit_through_one_live_geometry_path_after_wait() {
 #[test]
 fn invalid_specialized_geometry_does_not_allocate_or_publish() {
     let scene = Scene::new();
-    let before_revision = scene.store().borrow().scene_revision();
-    let before_nodes = scene.store().borrow().len();
-    let before_resources = scene.store().borrow().geometry_resources().len();
+    let before_revision = scene.integration_store().borrow().scene_revision();
+    let before_nodes = scene.integration_store().borrow().len();
+    let before_resources = scene
+        .integration_store()
+        .borrow()
+        .geometry_resources()
+        .len();
 
     assert!(ManimGeometryOptions::rounded_rectangle(0.0, 2.0, 0.5).is_err());
     assert!(ManimGeometryOptions::sector(1.0, 1.0, 0.0, 1, 0.0, 0.0).is_err());
@@ -620,7 +717,7 @@ fn invalid_specialized_geometry_does_not_allocate_or_publish() {
     )
     .is_err());
 
-    let store = scene.store().borrow();
+    let store = scene.integration_store().borrow();
     assert_eq!(store.scene_revision(), before_revision);
     assert_eq!(store.len(), before_nodes);
     assert_eq!(store.geometry_resources().len(), before_resources);

--- a/crates/noon/src/text_authoring/semantic.rs
+++ b/crates/noon/src/text_authoring/semantic.rs
@@ -52,19 +52,19 @@ impl crate::Scene {
     /// Create an ordinary detached native text Mobject in this scene's shared store.
     #[cfg(feature = "native-text")]
     pub fn text(&self, text: impl Into<Text>) -> Result<crate::Mobject, TextAuthoringError> {
-        crate::Mobject::from_text(std::rc::Rc::clone(self.store()), text)
+        crate::Mobject::from_text(std::rc::Rc::clone(self.integration_store()), text)
     }
 
     /// Create an ordinary detached Typst Mobject in this scene's shared store.
     #[cfg(feature = "typst")]
     pub fn typst(&self, text: Typst) -> Result<crate::Mobject, TextAuthoringError> {
-        crate::Mobject::from_typst(std::rc::Rc::clone(self.store()), text)
+        crate::Mobject::from_typst(std::rc::Rc::clone(self.integration_store()), text)
     }
 
     /// Create an ordinary detached MathTypst Mobject in this scene's shared store.
     #[cfg(feature = "typst")]
     pub fn math_typst(&self, text: MathTypst) -> Result<crate::Mobject, TextAuthoringError> {
-        crate::Mobject::from_math_typst(std::rc::Rc::clone(self.store()), text)
+        crate::Mobject::from_math_typst(std::rc::Rc::clone(self.integration_store()), text)
     }
 }
 
@@ -205,9 +205,9 @@ mod tests {
         assert!(session.frame().objects[0].geometry().is_some());
         assert!(session.frame().objects[1].text().is_some());
         let resource = label.state().unwrap().content.text().unwrap();
-        let before = scene.store().borrow().text_resources().stats();
+        let before = scene.integration_store().borrow().text_resources().stats();
         assert!(scene
-            .store()
+            .integration_store()
             .borrow()
             .text_resources()
             .get(resource)
@@ -232,7 +232,10 @@ mod tests {
             live.effective(&label).unwrap().style.fill,
             Some(noon_core::RED)
         );
-        assert_eq!(scene.store().borrow().text_resources().stats(), before);
+        assert_eq!(
+            scene.integration_store().borrow().text_resources().stats(),
+            before
+        );
     }
 
     #[test]
@@ -255,7 +258,7 @@ mod tests {
         assert_ne!(label.node_id(), equation.node_id());
         assert_eq!(
             scene
-                .store()
+                .integration_store()
                 .borrow()
                 .text_resources()
                 .get(label_resource)
@@ -265,7 +268,7 @@ mod tests {
         );
         assert_eq!(
             scene
-                .store()
+                .integration_store()
                 .borrow()
                 .text_resources()
                 .get(equation_resource)
@@ -289,16 +292,19 @@ mod tests {
     #[test]
     fn invalid_text_presentation_registers_neither_resources_nor_semantic_nodes() {
         let scene = crate::Scene::new();
-        let before = scene.store().borrow().scene_revision();
-        let resources = scene.store().borrow().text_resources().stats();
+        let before = scene.integration_store().borrow().scene_revision();
+        let resources = scene.integration_store().borrow().text_resources().stats();
         assert!(scene
             .text(super::Text::new("Noon").scale(f32::NAN))
             .is_err());
         assert!(scene
             .text(super::Text::new("Noon").color(noon_core::Color::rgba(f32::NAN, 1.0, 1.0, 1.0)))
             .is_err());
-        assert_eq!(scene.store().borrow().scene_revision(), before);
-        assert_eq!(scene.store().borrow().text_resources().stats(), resources);
+        assert_eq!(scene.integration_store().borrow().scene_revision(), before);
+        assert_eq!(
+            scene.integration_store().borrow().text_resources().stats(),
+            resources
+        );
     }
 
     #[test]
@@ -320,7 +326,7 @@ mod tests {
         assert!(session.take_frame_changes().is_empty());
         assert!(session.text_resources().get(resource).is_none());
         assert_eq!(
-            scene.store().borrow().scene_revision(),
+            scene.integration_store().borrow().scene_revision(),
             session.publication_context().scene_revision()
         );
 
@@ -363,8 +369,8 @@ mod tests {
             live.advance_segment_to(wait, wait.end_time()).unwrap();
             live.complete_segment(wait).unwrap();
         }
-        let revision = scene.store().borrow().scene_revision();
-        let resources = scene.store().borrow().text_resources().stats();
+        let revision = scene.integration_store().borrow().scene_revision();
+        let resources = scene.integration_store().borrow().text_resources().stats();
         let publication = session.publication_context();
         let frame = session.frame().clone();
 
@@ -378,8 +384,14 @@ mod tests {
                 .is_err());
         }
 
-        assert_eq!(scene.store().borrow().scene_revision(), revision);
-        assert_eq!(scene.store().borrow().text_resources().stats(), resources);
+        assert_eq!(
+            scene.integration_store().borrow().scene_revision(),
+            revision
+        );
+        assert_eq!(
+            scene.integration_store().borrow().text_resources().stats(),
+            resources
+        );
         assert_eq!(session.publication_context(), publication);
         assert_eq!(session.frame(), &frame);
         assert!(session.take_frame_changes().is_empty());
@@ -408,7 +420,7 @@ mod tests {
         assert!(session.text_resources().get(label_resource).is_none());
         assert!(session.text_resources().get(equation_resource).is_none());
         assert_eq!(
-            scene.store().borrow().scene_revision(),
+            scene.integration_store().borrow().scene_revision(),
             session.publication_context().scene_revision()
         );
 
@@ -437,8 +449,8 @@ mod tests {
         let scene = crate::Scene::new();
         let mut session = scene.execution_session().unwrap();
         session.take_frame_changes();
-        let revision = scene.store().borrow().scene_revision();
-        let resources = scene.store().borrow().text_resources().stats();
+        let revision = scene.integration_store().borrow().scene_revision();
+        let resources = scene.integration_store().borrow().text_resources().stats();
         let publication = session.publication_context();
 
         {
@@ -458,8 +470,14 @@ mod tests {
                 .is_err());
         }
 
-        assert_eq!(scene.store().borrow().scene_revision(), revision);
-        assert_eq!(scene.store().borrow().text_resources().stats(), resources);
+        assert_eq!(
+            scene.integration_store().borrow().scene_revision(),
+            revision
+        );
+        assert_eq!(
+            scene.integration_store().borrow().text_resources().stats(),
+            resources
+        );
         assert_eq!(session.publication_context(), publication);
         assert!(session.frame().objects.is_empty());
         assert!(session.take_frame_changes().is_empty());
@@ -571,7 +589,7 @@ mod tests {
         // Construct the malformed detached state directly so the publication
         // boundary, rather than authoring validation, proves its atomicity.
         let missing = scene
-            .store()
+            .integration_store()
             .borrow_mut()
             .insert_semantic_object(noon_core::SemanticObjectState::new(missing_resource));
         let mut session = scene.execution_session().unwrap();
@@ -579,7 +597,7 @@ mod tests {
         let before = session.publication_context();
 
         let result = session.declare_and_activate_affine_lifecycle(
-            &mut scene.store().borrow_mut(),
+            &mut scene.integration_store().borrow_mut(),
             scene.root(),
             missing,
             noon_core::SemanticAffineLifecycleDirection::RemoveTo,
@@ -594,7 +612,7 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(session.publication_context(), before);
         assert!(!scene
-            .store()
+            .integration_store()
             .borrow()
             .is_direct_member(scene.root(), missing)
             .unwrap());

--- a/crates/noon/tests/composition_admission.rs
+++ b/crates/noon/tests/composition_admission.rs
@@ -147,7 +147,7 @@ fn rejected_composition_cannot_partially_admit_uncreate() {
         .is_err());
     assert_eq!(execution.publication_context(), before);
     assert_eq!(
-        scene.store().borrow().scene_revision(),
+        scene.integration_store().borrow().scene_revision(),
         before.scene_revision()
     );
     assert!(!scene.live(&mut execution).contains(&target).unwrap());

--- a/crates/noon/tests/family_alignment.rs
+++ b/crates/noon/tests/family_alignment.rs
@@ -1,4 +1,4 @@
-use noon::semantic_mobject::ManimNextToArgs;
+use noon::ManimNextToArgs;
 use noon::{
     FamilyLayoutTarget as AuthoredTarget, LayoutAnchor, LiveLayoutTarget, Scene, SemanticVec3,
 };
@@ -50,7 +50,7 @@ fn invalid_alignment_does_not_publish_or_partially_move_members() {
     let source = LayoutAnchor::from(&family);
     let foreign_scene = Scene::new();
     let foreign = LayoutAnchor::from(&foreign_scene.square(1.0).unwrap());
-    let before = scene.store().borrow().scene_revision();
+    let before = scene.integration_store().borrow().scene_revision();
     for invalid in [
         source.clone().member(-2),
         source.clone().member(1),
@@ -60,7 +60,7 @@ fn invalid_alignment_does_not_publish_or_partially_move_members() {
         assert!(source
             .next_to_aligned(AuthoredTarget::Point(9.0, 0.0), &invalid, args())
             .is_err());
-        assert_eq!(scene.store().borrow().scene_revision(), before);
+        assert_eq!(scene.integration_store().borrow().scene_revision(), before);
         assert_eq!(object.center().unwrap(), (0.0, 0.0));
     }
 }
@@ -93,7 +93,7 @@ fn live_alignment_uses_effective_target_bounds_and_one_local_publication() {
     let source = LayoutAnchor::from(&source_family);
     let aligner = source.clone().member(-1);
     let destination = LayoutAnchor::from(&target_family).member(0);
-    let before = scene.store().borrow().scene_revision();
+    let before = scene.integration_store().borrow().scene_revision();
     let result = live
         .next_layout_to_aligned(
             &source,
@@ -104,13 +104,13 @@ fn live_alignment_uses_effective_target_bounds_and_one_local_publication() {
         .unwrap();
     assert_eq!(result.impacts().len(), 2);
     assert_eq!(
-        scene.store().borrow().scene_revision(),
+        scene.integration_store().borrow().scene_revision(),
         before.checked_next().unwrap()
     );
     assert_eq!(live.effective_layout(&first).unwrap().center, (7.75, 0.0));
     assert_eq!(live.effective_layout(&second).unwrap().center, (9.75, 0.0));
     assert_eq!(target.center().unwrap(), (6.0, 0.0));
-    let before = scene.store().borrow().scene_revision();
+    let before = scene.integration_store().borrow().scene_revision();
     assert!(live
         .next_layout_to_aligned(
             &source,
@@ -119,6 +119,6 @@ fn live_alignment_uses_effective_target_bounds_and_one_local_publication() {
             args()
         )
         .is_err());
-    assert_eq!(scene.store().borrow().scene_revision(), before);
+    assert_eq!(scene.integration_store().borrow().scene_revision(), before);
     assert_eq!(live.effective_layout(&first).unwrap().center, (7.75, 0.0));
 }

--- a/crates/noon/tests/family_arrangement.rs
+++ b/crates/noon/tests/family_arrangement.rs
@@ -33,13 +33,13 @@ fn aliased_members_observe_preceding_moves_and_center_unique_leaves_once() {
     second.shift(2.0, 0.0).unwrap();
     let nested = scene.family(&[(&first).into(), (&second).into()]).unwrap();
     let family = scene.family(&[(&first).into(), (&nested).into()]).unwrap();
-    let before = scene.store().borrow().scene_revision();
+    let before = scene.integration_store().borrow().scene_revision();
     family.arrange(1.0, 0.0, 0.2, true).unwrap();
     close(first.center().unwrap(), (-1.0, 0.0));
     close(second.center().unwrap(), (1.0, 0.0));
     close(family.layout().unwrap().center(), (0.0, 0.0));
     assert_eq!(
-        scene.store().borrow().scene_revision(),
+        scene.integration_store().borrow().scene_revision(),
         before.checked_next().unwrap()
     );
     family.shift(0.25, 0.5).unwrap();
@@ -100,22 +100,22 @@ fn late_invalid_selection_and_foreign_aligner_never_publish_a_prefix() {
         .unwrap();
     let mut options = FamilyArrangeOptions::new(1.0, 0.0, 0.25, false);
     options.member_index = Some(0);
-    let before = scene.store().borrow().scene_revision();
+    let before = scene.integration_store().borrow().scene_revision();
     assert!(family.arrange_with_options(&options).is_err());
-    assert_eq!(scene.store().borrow().scene_revision(), before);
+    assert_eq!(scene.integration_store().borrow().scene_revision(), before);
     close(second.center().unwrap(), (0.0, 0.0));
     for object in [&first, &second] {
         scene.add(object).unwrap();
     }
     let mut execution = scene.execution_session().unwrap();
     let mut live = scene.live(&mut execution);
-    let before = scene.store().borrow().scene_revision();
+    let before = scene.integration_store().borrow().scene_revision();
     assert!(live.arrange_family_with_options(&family, &options).is_err());
-    assert_eq!(scene.store().borrow().scene_revision(), before);
+    assert_eq!(scene.integration_store().borrow().scene_revision(), before);
     close(live.effective_layout(&second).unwrap().center, (0.0, 0.0));
     let other = Scene::new();
     options.member_index = None;
     options.aligner = Some(LayoutAnchor::from(&other.square(1.0).unwrap()));
     assert!(live.arrange_family_with_options(&family, &options).is_err());
-    assert_eq!(scene.store().borrow().scene_revision(), before);
+    assert_eq!(scene.integration_store().borrow().scene_revision(), before);
 }

--- a/crates/noon/tests/family_construction.rs
+++ b/crates/noon/tests/family_construction.rs
@@ -8,17 +8,17 @@ fn nested_creation_and_membership_edits_preserve_identity_order_and_atomicity() 
     let empty = scene.family(&[]).unwrap();
     assert_eq!(empty.layout_bounds().unwrap(), None);
     let nested = scene.family(&[(&first).into(), (&second).into()]).unwrap();
-    let before = scene.store().borrow().scene_revision();
+    let before = scene.integration_store().borrow().scene_revision();
     let root = scene
         .family(&[(&first).into(), (&nested).into(), (&first).into()])
         .unwrap();
     assert_eq!(
-        scene.store().borrow().scene_revision(),
+        scene.integration_store().borrow().scene_revision(),
         before.checked_next().unwrap()
     );
     assert_eq!(
         scene
-            .store()
+            .integration_store()
             .borrow()
             .semantic_family_members_checked(root.node_id())
             .unwrap(),
@@ -26,23 +26,29 @@ fn nested_creation_and_membership_edits_preserve_identity_order_and_atomicity() 
     );
     assert_eq!(
         scene
-            .store()
+            .integration_store()
             .borrow()
             .ordered_leaf_nodes(root.node_id())
             .unwrap(),
         vec![first.node_id(), second.node_id()]
     );
-    let revision = scene.store().borrow().scene_revision();
+    let revision = scene.integration_store().borrow().scene_revision();
     assert!(!root.add((&first).into()).unwrap());
-    assert_eq!(scene.store().borrow().scene_revision(), revision);
+    assert_eq!(
+        scene.integration_store().borrow().scene_revision(),
+        revision
+    );
     assert!(nested.add((&root).into()).is_err()); // Cycle rejected before commit.
-    assert_eq!(scene.store().borrow().scene_revision(), revision);
+    assert_eq!(
+        scene.integration_store().borrow().scene_revision(),
+        revision
+    );
     assert!(root.remove((&nested).into()).unwrap());
     assert!(!root.remove((&nested).into()).unwrap());
     assert!(root.add((&nested).into()).unwrap());
     assert_eq!(
         scene
-            .store()
+            .integration_store()
             .borrow()
             .ordered_leaf_nodes(root.node_id())
             .unwrap(),
@@ -60,20 +66,23 @@ fn foreign_and_stale_members_cannot_create_or_edit_a_family() {
     let foreign = other.square(1.0).unwrap();
     let stale = scene.square(1.0).unwrap();
     scene
-        .store()
+        .integration_store()
         .borrow_mut()
         .remove_node(stale.node_id())
         .unwrap();
-    let revision = scene.store().borrow().scene_revision();
+    let revision = scene.integration_store().borrow().scene_revision();
     for member in [MobjectFamilyMember::from(&foreign), (&stale).into()] {
         assert!(scene.family(&[(&local).into(), member]).is_err());
         assert!(root.add(member).is_err());
         assert!(root.remove(member).is_err());
     }
-    assert_eq!(scene.store().borrow().scene_revision(), revision);
+    assert_eq!(
+        scene.integration_store().borrow().scene_revision(),
+        revision
+    );
     assert_eq!(
         scene
-            .store()
+            .integration_store()
             .borrow()
             .ordered_leaf_nodes(root.node_id())
             .unwrap(),
@@ -111,7 +120,7 @@ fn live_member_batch_rejects_a_late_cycle_without_partial_publication() {
     let root = scene.family(&[(&nested).into()]).unwrap();
     scene.add_many(&[(&root).into()]).unwrap();
     let mut execution = scene.execution_session().unwrap();
-    let store = std::rc::Rc::clone(scene.store());
+    let store = std::rc::Rc::clone(scene.integration_store());
     {
         let mut live = scene.live(&mut execution);
         let wait = live.wait_segment(0.5).unwrap();
@@ -154,14 +163,17 @@ fn authored_member_batches_roll_back_cycles_and_late_invalid_handles() {
     let second = scene.square(0.4).unwrap();
     let nested = scene.family(&[(&first).into()]).unwrap();
     let outer = scene.family(&[(&nested).into()]).unwrap();
-    let revision = scene.store().borrow().scene_revision();
+    let revision = scene.integration_store().borrow().scene_revision();
     assert!(nested
         .add_many(&[(&second).into(), (&outer).into()])
         .is_err());
-    assert_eq!(scene.store().borrow().scene_revision(), revision);
+    assert_eq!(
+        scene.integration_store().borrow().scene_revision(),
+        revision
+    );
     assert_eq!(
         scene
-            .store()
+            .integration_store()
             .borrow()
             .ordered_leaf_nodes(nested.node_id())
             .unwrap(),
@@ -172,7 +184,10 @@ fn authored_member_batches_roll_back_cycles_and_late_invalid_handles() {
     assert!(nested
         .remove_many(&[(&first).into(), (&foreign).into()])
         .is_err());
-    assert_eq!(scene.store().borrow().scene_revision(), revision);
+    assert_eq!(
+        scene.integration_store().borrow().scene_revision(),
+        revision
+    );
     assert_eq!(
         nested
             .add_many(&[(&second).into(), (&second).into()])
@@ -180,7 +195,7 @@ fn authored_member_batches_roll_back_cycles_and_late_invalid_handles() {
         vec![true, false]
     );
     assert_eq!(
-        scene.store().borrow().scene_revision(),
+        scene.integration_store().borrow().scene_revision(),
         revision.checked_next().unwrap()
     );
     assert_eq!(
@@ -190,7 +205,7 @@ fn authored_member_batches_roll_back_cycles_and_late_invalid_handles() {
         vec![true, true, false]
     );
     assert!(scene
-        .store()
+        .integration_store()
         .borrow()
         .ordered_leaf_nodes(nested.node_id())
         .unwrap()

--- a/crates/noon/tests/family_copy.rs
+++ b/crates/noon/tests/family_copy.rs
@@ -7,10 +7,10 @@ fn authored_copy_preserves_dag_aliases_order_resources_and_source_state_in_one_c
     let leaf = scene.square(0.5).unwrap();
     let nested = scene.family(&[(&leaf).into()]).unwrap();
     let source = scene.family(&[(&leaf).into(), (&nested).into()]).unwrap();
-    let before = scene.store().borrow().scene_revision();
+    let before = scene.integration_store().borrow().scene_revision();
     let copied = source.copy_family().unwrap();
     assert_eq!(
-        scene.store().borrow().scene_revision(),
+        scene.integration_store().borrow().scene_revision(),
         before.checked_next().unwrap()
     );
     let mut copy_leaf = copied.mobject(&leaf).unwrap();
@@ -32,7 +32,7 @@ fn authored_copy_preserves_dag_aliases_order_resources_and_source_state_in_one_c
     );
     assert_eq!(
         scene
-            .store()
+            .integration_store()
             .borrow()
             .semantic_family_members_checked(copied.root().node_id())
             .unwrap(),
@@ -40,7 +40,7 @@ fn authored_copy_preserves_dag_aliases_order_resources_and_source_state_in_one_c
     );
     assert_eq!(
         scene
-            .store()
+            .integration_store()
             .borrow()
             .semantic_family_members_checked(copy_nested.node_id())
             .unwrap(),
@@ -58,7 +58,7 @@ fn authored_copy_preserves_dag_aliases_order_resources_and_source_state_in_one_c
     let foreign = Scene::new().square(1.0).unwrap();
     assert!(copied.mobject(&foreign).is_err());
     scene
-        .store()
+        .integration_store()
         .borrow_mut()
         .remove_node(leaf.node_id())
         .unwrap();
@@ -99,7 +99,7 @@ fn live_copy_obeys_completion_and_captures_completed_state_without_changing_sour
     assert_eq!(leaf.center().unwrap(), (4.0, 0.0));
     assert_eq!(live.effective(&leaf).unwrap().transform, before.transform);
     assert_eq!(
-        scene.store().borrow().scene_revision(),
+        scene.integration_store().borrow().scene_revision(),
         before.publication.scene_revision().checked_next().unwrap()
     );
     live.shift(&copy_leaf, 1.0, 0.0).unwrap();
@@ -113,12 +113,12 @@ fn a_late_uncapturable_member_rejects_the_entire_live_copy() {
     let first = scene.square(0.5).unwrap();
     let reactive = scene.square(0.5).unwrap();
     let signal = scene
-        .store()
+        .integration_store()
         .borrow_mut()
         .insert_semantic_input_signal(SemanticVec3::ZERO)
         .unwrap();
     scene
-        .store()
+        .integration_store()
         .borrow_mut()
         .bind_semantic_signal(
             signal,
@@ -134,7 +134,7 @@ fn a_late_uncapturable_member_rejects_the_entire_live_copy() {
     assert!(scene.live(&mut execution).copy_family(&source).is_err());
     assert_eq!(execution.publication_context(), before);
     assert_eq!(
-        scene.store().borrow().scene_revision(),
+        scene.integration_store().borrow().scene_revision(),
         before.scene_revision()
     );
     assert_eq!(first.center().unwrap(), (0.0, 0.0));
@@ -147,17 +147,17 @@ fn detached_references_copy_atomically_without_changing_family_membership() {
     let saved = leaf.target_editor().unwrap();
     let source = scene.family(&[(&leaf).into()]).unwrap();
     let referenced_family = scene.family(&[(&saved).into(), (&leaf).into()]).unwrap();
-    let before = scene.store().borrow().scene_revision();
+    let before = scene.integration_store().borrow().scene_revision();
     let copied = source
         .copy_with_references(&[(&saved).into(), (&referenced_family).into(), (&leaf).into()])
         .unwrap();
     assert_eq!(
-        scene.store().borrow().scene_revision(),
+        scene.integration_store().borrow().scene_revision(),
         before.checked_next().unwrap()
     );
     let copied_leaf = copied.mobject(&leaf).unwrap();
     let mut copied_saved = copied.mobject(&saved).unwrap();
-    let store = scene.store().borrow();
+    let store = scene.integration_store().borrow();
     assert_eq!(
         store
             .semantic_family_members_checked(copied.root().node_id())
@@ -174,9 +174,9 @@ fn detached_references_copy_atomically_without_changing_family_membership() {
     copied_saved.shift(3.0, 0.0).unwrap();
     assert_eq!(saved.center().unwrap(), (0.0, 0.0));
     let foreign = Scene::new().square(1.0).unwrap();
-    let before = scene.store().borrow().scene_revision();
+    let before = scene.integration_store().borrow().scene_revision();
     assert!(source
         .copy_with_references(&[(&saved).into(), (&foreign).into()])
         .is_err());
-    assert_eq!(scene.store().borrow().scene_revision(), before);
+    assert_eq!(scene.integration_store().borrow().scene_revision(), before);
 }

--- a/crates/noon/tests/family_layout.rs
+++ b/crates/noon/tests/family_layout.rs
@@ -1,4 +1,4 @@
-use noon::{semantic_mobject::ManimNextToArgs, FamilyLayoutTarget as Target, Scene};
+use noon::{FamilyLayoutTarget as Target, ManimNextToArgs, Scene};
 
 #[test]
 fn placement_shares_object_family_and_point_targets_with_masks_and_nonunit_directions() {
@@ -60,7 +60,7 @@ fn invalid_or_foreign_placement_targets_do_not_publish() {
         .layout()
         .unwrap();
     let observation = family.layout().unwrap();
-    let before = scene.store().borrow().scene_revision();
+    let before = scene.integration_store().borrow().scene_revision();
     for target in [
         Target::Mobject(&foreign),
         Target::Family(&foreign_family),
@@ -79,7 +79,7 @@ fn invalid_or_foreign_placement_targets_do_not_publish() {
             }
         )
         .is_err());
-    assert_eq!(scene.store().borrow().scene_revision(), before);
+    assert_eq!(scene.integration_store().borrow().scene_revision(), before);
     assert_eq!(object.center().unwrap(), (0.0, 0.0));
 }
 
@@ -87,11 +87,11 @@ fn invalid_or_foreign_placement_targets_do_not_publish() {
 fn empty_family_observation_has_origin_bounds_without_scene_changes() {
     let scene = Scene::new();
     let family = scene.family(&[]).unwrap();
-    let before = scene.store().borrow().scene_revision();
+    let before = scene.integration_store().borrow().scene_revision();
     let observation = family.layout().unwrap();
     assert_eq!(observation.bounds(), None);
     assert_eq!(observation.critical_point(1.0, -1.0), (0.0, 0.0));
     assert_eq!((observation.width(), observation.height()), (0.0, 0.0));
     observation.shift(3.0, 4.0).unwrap();
-    assert_eq!(scene.store().borrow().scene_revision(), before);
+    assert_eq!(scene.integration_store().borrow().scene_revision(), before);
 }

--- a/crates/noon/tests/family_translation.rs
+++ b/crates/noon/tests/family_translation.rs
@@ -13,7 +13,7 @@ fn nested_family() -> (Scene, MobjectFamily, [Mobject; 3]) {
 #[test]
 fn nested_translation_commits_all_authoritative_leaves_once() {
     let (scene, root, members) = nested_family();
-    let store = scene.store();
+    let store = scene.integration_store();
     assert_eq!(
         store.borrow().ordered_leaf_nodes(root.node_id()).unwrap(),
         members.iter().map(Mobject::node_id).collect::<Vec<_>>()
@@ -32,7 +32,7 @@ fn nested_translation_commits_all_authoritative_leaves_once() {
 #[test]
 fn stale_late_leaf_rejects_the_entire_translation() {
     let (scene, root, members) = nested_family();
-    let store = scene.store();
+    let store = scene.integration_store();
     let observation = root.layout().unwrap();
     store
         .borrow_mut()
@@ -50,7 +50,7 @@ fn stale_late_leaf_rejects_the_entire_translation() {
 #[test]
 fn aliased_references_shift_one_identity_once_without_touching_other_objects() {
     let (scene, root, members) = nested_family();
-    let store = scene.store();
+    let store = scene.integration_store();
     store
         .borrow_mut()
         .add_member(root.node_id(), members[2].node_id())

--- a/crates/noon/tests/geometry_matchers.rs
+++ b/crates/noon/tests/geometry_matchers.rs
@@ -17,7 +17,7 @@ fn family_surrounding_rectangle_uses_the_authoritative_bounds_union() {
     let bounds = family.layout_bounds().unwrap().unwrap();
 
     let surround = Mobject::from_manim_geometry(
-        Rc::clone(scene.store()),
+        Rc::clone(scene.integration_store()),
         ManimGeometryOptions::surrounding_rectangle(bounds, 0.25, 0.5, 0.0).unwrap(),
     )
     .unwrap();
@@ -36,7 +36,7 @@ fn family_background_rectangle_preserves_union_style() {
     let bounds = family.layout_bounds().unwrap().unwrap();
 
     let background = Mobject::from_manim_geometry(
-        Rc::clone(scene.store()),
+        Rc::clone(scene.integration_store()),
         ManimGeometryOptions::background_rectangle(bounds, 0.0, 0.0, 0.0, 0.75).unwrap(),
     )
     .unwrap();
@@ -68,12 +68,12 @@ fn one_leaf_family_matcher_matches_the_object_bounds_route() {
     assert_eq!(family_bounds, object_bounds);
 
     let object_matcher = Mobject::from_manim_geometry(
-        Rc::clone(scene.store()),
+        Rc::clone(scene.integration_store()),
         ManimGeometryOptions::surrounding_rectangle(object_bounds, 0.25, 0.5, 0.1).unwrap(),
     )
     .unwrap();
     let family_matcher = Mobject::from_manim_geometry(
-        Rc::clone(scene.store()),
+        Rc::clone(scene.integration_store()),
         ManimGeometryOptions::surrounding_rectangle(family_bounds, 0.25, 0.5, 0.1).unwrap(),
     )
     .unwrap();

--- a/crates/noon/tests/live_family_layout.rs
+++ b/crates/noon/tests/live_family_layout.rs
@@ -1,4 +1,4 @@
-use noon::semantic_mobject::ManimNextToArgs;
+use noon::ManimNextToArgs;
 use noon::{AnimationOptions, LiveLayoutTarget as Target, RateFunction, Scene};
 
 fn close(actual: f64, expected: f64) {
@@ -34,7 +34,7 @@ fn family_queries_mix_effective_and_detached_bounds_without_mutation() {
     let mut live = scene.live(&mut execution);
     let segment = live.play_animation(&animation).unwrap();
     live.advance_segment_to(segment, 1.0).unwrap();
-    let revision = scene.store().borrow().scene_revision();
+    let revision = scene.integration_store().borrow().scene_revision();
     let halfway = live.effective_family_layout(&aliases).unwrap();
     close(halfway.center.0, 6.0);
     close(halfway.width, 9.0);
@@ -43,7 +43,10 @@ fn family_queries_mix_effective_and_detached_bounds_without_mutation() {
         live.effective_family_layout(&empty).unwrap().center,
         (0.0, 0.0)
     );
-    assert_eq!(scene.store().borrow().scene_revision(), revision);
+    assert_eq!(
+        scene.integration_store().borrow().scene_revision(),
+        revision
+    );
     assert!(live
         .move_family_to(&aliases, Target::Point(0.0, 0.0), (0.0, 0.0), (1.0, 1.0))
         .is_err());
@@ -74,13 +77,13 @@ fn relative_placement_uses_shared_masks_targets_and_one_local_publication() {
     execution.take_frame_changes();
     {
         let mut live = scene.live(&mut execution);
-        let before = scene.store().borrow().scene_revision();
+        let before = scene.integration_store().borrow().scene_revision();
         let result = live
             .move_family_to(&family, Target::Point(4.0, 9.0), (1.0, 0.0), (1.0, 0.0))
             .unwrap();
         assert_eq!(result.impacts().len(), 2);
         assert_eq!(
-            scene.store().borrow().scene_revision(),
+            scene.integration_store().borrow().scene_revision(),
             before.checked_next().unwrap()
         );
         live.next_family_to(
@@ -112,7 +115,7 @@ fn empty_foreign_stale_and_unpublished_families_obey_query_and_mutation_validati
     let foreign = other.family(&[]).unwrap();
     let stale = scene.family(&[]).unwrap();
     scene
-        .store()
+        .integration_store()
         .borrow_mut()
         .remove_node(stale.node_id())
         .unwrap();

--- a/crates/noon/tests/specialized_geometry_inputs.rs
+++ b/crates/noon/tests/specialized_geometry_inputs.rs
@@ -1,13 +1,14 @@
 //! Geometry boundary regressions exercise shared handles and their typed lowering.
 use noon::{
-    GeometryRef, GeometryResource, GeometryResourceLookup, ManimGeometryOptions as Options,
-    Mobject, PathCommand, Scene, Vec2, VectorPath,
+    GeometryRef, ManimGeometryOptions as Options, Mobject, PathCommand, Scene, Vec2, VectorPath,
 };
+use noon_core::{GeometryResource, GeometryResourceLookup};
 use std::rc::Rc;
 
 fn path(options: Options) -> (Mobject, VectorPath) {
     let mut scene = Scene::new();
-    let object = Mobject::from_manim_geometry(Rc::clone(scene.store()), options).unwrap();
+    let object =
+        Mobject::from_manim_geometry(Rc::clone(scene.integration_store()), options).unwrap();
     scene.add(&object).unwrap();
     let session = scene.execution_session().unwrap();
     let geometry = match session.frame().render_geometry(0).unwrap() {

--- a/fixtures/provider-consumer/README.md
+++ b/fixtures/provider-consumer/README.md
@@ -84,3 +84,22 @@ table, graph/cache-mode expectations, provider-input tests and ten isolated comp
 cells. Existing all-feature Rust and normal browser/native checks remain in place.
 Artifacts distinguish `qualification.json` from opt-in `measurements.json`; no
 fixed speed/size promise is encoded here.
+
+## Public authoring boundary
+
+The `public_facade` target depends on `noon` alone. It qualifies the ordinary
+constructor/live-query/edit/completion path, immutable effective observations, and
+an explicitly opted-in raw integration edit that must retain typed stale-publication
+rejection and leave the old runtime/frame unchanged. It runs in the existing
+native provider cells and is compiled (not executed) in WASM cells.
+
+```sh
+cargo test --manifest-path fixtures/provider-consumer/Cargo.toml --test public_facade
+cargo test -p noon --no-default-features --doc
+cargo run -p noon --no-default-features --example shared_authoring
+```
+
+The doc tests reject accidental root exports, the private implementation module,
+and unqualified raw-store access. These boundary checks complement typed membership
+and provider qualification; they do not claim all geometry/animation errors or
+Python exception producers have been converted to structured errors.

--- a/fixtures/provider-consumer/README.md
+++ b/fixtures/provider-consumer/README.md
@@ -103,3 +103,8 @@ The doc tests reject accidental root exports, the private implementation module,
 and unqualified raw-store access. These boundary checks complement typed membership
 and provider qualification; they do not claim all geometry/animation errors or
 Python exception producers have been converted to structured errors.
+
+The geometry program copied by `--baseline` uses the ordinary geometry API common
+to both revisions. Shared text-contract visibility and arena assertions live in
+`public_facade` rather than adding a dependency on new integration accessor names
+to the historical-build workload. No historical baseline code is rewritten.

--- a/fixtures/provider-consumer/src/main.rs
+++ b/fixtures/provider-consumer/src/main.rs
@@ -1,5 +1,6 @@
 //! Identical geometry workload for every measured provider configuration.
-use noon::{Scene, TextResource, Vec2};
+use noon::integration::TextResource;
+use noon::{Scene, Vec2};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut scene = Scene::new();
@@ -18,7 +19,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
     assert_eq!(session.frame().objects.len(), 1);
     assert!(session.frame().objects[0].geometry().is_some());
-    assert!(scene.store().borrow().text_resources().is_empty());
+    assert!(scene
+        .integration_store()
+        .borrow()
+        .text_resources()
+        .is_empty());
     // Shared text contracts remain available even when no provider is selected.
     let _: Option<TextResource> = None;
     std::hint::black_box(session.frame().objects.len());

--- a/fixtures/provider-consumer/src/main.rs
+++ b/fixtures/provider-consumer/src/main.rs
@@ -1,5 +1,4 @@
 //! Identical geometry workload for every measured provider configuration.
-use noon::integration::TextResource;
 use noon::{Scene, Vec2};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -19,13 +18,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
     assert_eq!(session.frame().objects.len(), 1);
     assert!(session.frame().objects[0].geometry().is_some());
-    assert!(scene
-        .integration_store()
-        .borrow()
-        .text_resources()
-        .is_empty());
-    // Shared text contracts remain available even when no provider is selected.
-    let _: Option<TextResource> = None;
     std::hint::black_box(session.frame().objects.len());
     Ok(())
 }

--- a/fixtures/provider-consumer/tests/providers.rs
+++ b/fixtures/provider-consumer/tests/providers.rs
@@ -22,7 +22,7 @@ fn assert_shared_resource_path(mut scene: Scene, label: noon::Mobject) {
     scene.add(&circle).unwrap();
     scene.add(&label).unwrap();
     let resource = label.state().unwrap().content.text().unwrap();
-    let stats = scene.store().borrow().text_resources().stats();
+    let stats = scene.integration_store().borrow().text_resources().stats();
     let mut session = scene.execution_session().unwrap();
     assert!(session.frame().objects[0].geometry().is_some());
     assert_eq!(session.frame().objects[1].text(), Some(resource));
@@ -37,7 +37,10 @@ fn assert_shared_resource_path(mut scene: Scene, label: noon::Mobject) {
         live.authored(&label).unwrap().content.text(),
         Some(resource)
     );
-    assert_eq!(scene.store().borrow().text_resources().stats(), stats);
+    assert_eq!(
+        scene.integration_store().borrow().text_resources().stats(),
+        stats
+    );
 }
 
 #[cfg(feature = "native-text")]
@@ -58,8 +61,8 @@ fn missing_native_fonts_do_not_mutate_resources_or_identity() {
     let circle = scene.circle(1.0).unwrap();
     scene.add(&circle).unwrap();
     let mut session = scene.execution_session().unwrap();
-    let revision = scene.store().borrow().scene_revision();
-    let stats = scene.store().borrow().text_resources().stats();
+    let revision = scene.integration_store().borrow().scene_revision();
+    let stats = scene.integration_store().borrow().text_resources().stats();
     assert!(matches!(
         scene.text("No font"),
         Err(TextAuthoringError::FontUnavailable(_))
@@ -73,8 +76,14 @@ fn missing_native_fonts_do_not_mutate_resources_or_identity() {
         scene.text(text),
         Err(TextAuthoringError::FontUnavailable(_))
     ));
-    assert_eq!(scene.store().borrow().scene_revision(), revision);
-    assert_eq!(scene.store().borrow().text_resources().stats(), stats);
+    assert_eq!(
+        scene.integration_store().borrow().scene_revision(),
+        revision
+    );
+    assert_eq!(
+        scene.integration_store().borrow().text_resources().stats(),
+        stats
+    );
     let mut live = scene.live(&mut session);
     assert!(live.create_text(noon::Text::new("No font")).is_err());
     live.set_translation(&circle, 3.0, 0.0).unwrap();
@@ -82,7 +91,10 @@ fn missing_native_fonts_do_not_mutate_resources_or_identity() {
         live.effective(&circle).unwrap().transform.translation.x,
         3.0
     );
-    assert_eq!(scene.store().borrow().text_resources().stats(), stats);
+    assert_eq!(
+        scene.integration_store().borrow().text_resources().stats(),
+        stats
+    );
 }
 
 #[cfg(feature = "typst")]
@@ -98,8 +110,8 @@ fn typst_with_explicit_fonts_uses_the_shared_store() {
 #[test]
 fn invalid_or_empty_explicit_typst_fonts_never_fall_back() {
     let scene = Scene::new();
-    let revision = scene.store().borrow().scene_revision();
-    let stats = scene.store().borrow().text_resources().stats();
+    let revision = scene.integration_store().borrow().scene_revision();
+    let stats = scene.integration_store().borrow().text_resources().stats();
     let error = scene
         .typst(noon::Typst::new("Noon").with_fonts([]))
         .unwrap_err();
@@ -121,8 +133,14 @@ fn invalid_or_empty_explicit_typst_fonts_never_fall_back() {
         error,
         TextAuthoringError::Typst(noon::TypstBackendError::FontsUnavailable)
     );
-    assert_eq!(scene.store().borrow().scene_revision(), revision);
-    assert_eq!(scene.store().borrow().text_resources().stats(), stats);
+    assert_eq!(
+        scene.integration_store().borrow().scene_revision(),
+        revision
+    );
+    assert_eq!(
+        scene.integration_store().borrow().text_resources().stats(),
+        stats
+    );
 }
 
 #[cfg(all(feature = "typst", not(feature = "bundled-fonts")))]
@@ -132,12 +150,15 @@ fn unavailable_typst_fonts_leave_the_live_session_usable() {
     let circle = scene.circle(1.0).unwrap();
     scene.add(&circle).unwrap();
     let mut session = scene.execution_session().unwrap();
-    let revision = scene.store().borrow().scene_revision();
+    let revision = scene.integration_store().borrow().scene_revision();
     assert_eq!(
         scene.typst(noon::Typst::new("Noon")).unwrap_err(),
         TextAuthoringError::Typst(noon::TypstBackendError::FontsUnavailable)
     );
-    assert_eq!(scene.store().borrow().scene_revision(), revision);
+    assert_eq!(
+        scene.integration_store().borrow().scene_revision(),
+        revision
+    );
     let mut live = scene.live(&mut session);
     assert!(live.create_typst(noon::Typst::new("Noon")).is_err());
     assert!(live.create_math_typst(noon::MathTypst::new("x")).is_err());
@@ -146,7 +167,11 @@ fn unavailable_typst_fonts_leave_the_live_session_usable() {
         live.effective(&circle).unwrap().transform.translation.x,
         3.0
     );
-    assert!(scene.store().borrow().text_resources().is_empty());
+    assert!(scene
+        .integration_store()
+        .borrow()
+        .text_resources()
+        .is_empty());
 }
 
 #[cfg(all(feature = "native-text", feature = "bundled-fonts"))]

--- a/fixtures/provider-consumer/tests/public_facade.rs
+++ b/fixtures/provider-consumer/tests/public_facade.rs
@@ -1,0 +1,94 @@
+//! Compile and exercise the public facade as an independent consumer of only noon.
+//! Provider-feature CI runs these tests natively and compiles them for WASM.
+use noon::{
+    AnimationOptions, ExecutionSessionPublicationError, LiveSessionError, ManimGeometryOptions,
+    MobjectFamilyMember, RateFunction, Scene, Vec2,
+};
+
+#[test]
+fn public_authoring_live_queries_and_completion() -> Result<(), Box<dyn std::error::Error>> {
+    let mut scene = Scene::new();
+    let before = scene.revision();
+    let circle = scene.geometry(ManimGeometryOptions::circle(1.0)?)?;
+    assert!(scene.revision().get() > before.get());
+    scene.add(&circle)?;
+    let mut session = scene.execution_session()?;
+    let mut live = scene.live(&mut session);
+    let target = live.target_editor(&circle)?;
+    live.shift(&target, 4.0, -2.0)?;
+    let segment = live.declare_and_activate_transform_to(
+        &circle,
+        &target,
+        AnimationOptions::new()
+            .run_time(2.0)
+            .rate_func(RateFunction::Linear),
+    )?;
+    live.advance_segment_to(segment, 1.0)?;
+    let halfway = live.effective(&circle)?;
+    assert_eq!(halfway.transform.translation, Vec2::new(2.0, -1.0));
+    assert_eq!(live.authored(&circle)?.transform.translation.x, 0.0);
+    live.advance_segment_to(segment, segment.end_time())?;
+    assert!(!live.segment_state(segment).is_complete());
+    live.complete_segment(segment)?;
+    assert!(live.segment_state(segment).is_complete());
+    assert_eq!(live.authored(&circle)?.transform.translation.x, 4.0);
+    live.shift(&circle, 1.0, 0.0)?;
+    let after = live.effective(&circle)?;
+    assert_eq!(after.transform.translation, Vec2::new(5.0, -2.0));
+    assert_eq!(after.publication.scene_revision(), scene.revision());
+    assert_eq!(halfway.transform.translation, Vec2::new(2.0, -1.0));
+    let added = live.create_manim_geometry(ManimGeometryOptions::square(0.5)?)?;
+    live.add(&added)?;
+    assert!(live.contains(&added)?);
+    let wait = live.wait_segment(0.25)?;
+    live.advance_segment_to(wait, wait.end_time())?;
+    live.complete_segment(wait)?;
+    assert!(live.segment_state(wait).is_complete());
+    Ok(())
+}
+
+#[test]
+fn integration_access_keeps_one_arena_and_stale_publication_protection(
+) -> Result<(), Box<dyn std::error::Error>> {
+    use noon::integration::{SemanticMutationTransaction, SemanticStore};
+    use std::{cell::RefCell, rc::Rc};
+    let arena = Rc::new(RefCell::new(SemanticStore::new()));
+    let mut scene = Scene::with_integration_store(Rc::clone(&arena));
+    let circle = scene.circle(1.0)?;
+    let family = scene.family(&[MobjectFamilyMember::Mobject(&circle)])?;
+    assert!(Rc::ptr_eq(scene.integration_store(), &arena));
+    assert!(Rc::ptr_eq(circle.integration_store(), &arena));
+    assert!(Rc::ptr_eq(family.integration_store(), &arena));
+    scene.add(&circle)?;
+    let mut session = scene.execution_session()?;
+    session.take_frame_changes();
+    let published = session.publication_context();
+    let original_transform = session.frame().objects[0].transform;
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction.set_property(
+        circle.node_id(),
+        noon::SemanticObjectProperty::Translation,
+        noon::SemanticVec3::new(9.0, 0.0, 0.0),
+    );
+    transaction.apply(&mut scene.integration_store().borrow_mut())?;
+    let raw_revision = scene.revision();
+    assert_ne!(raw_revision, published.scene_revision());
+    {
+        let mut live = scene.live(&mut session);
+        let error = live.shift(&circle, 1.0, 0.0).unwrap_err();
+        assert!(matches!(error, LiveSessionError::Publication(
+            ExecutionSessionPublicationError::StaleSceneRevision { expected, actual }
+        ) if expected == published.scene_revision() && actual == raw_revision));
+        assert!(matches!(
+            live.effective(&circle),
+            Err(LiveSessionError::Publication(
+                ExecutionSessionPublicationError::StaleSceneRevision { .. }
+            ))
+        ));
+    }
+    assert_eq!(scene.revision(), raw_revision);
+    assert_eq!(session.publication_context(), published);
+    assert_eq!(session.frame().objects[0].transform, original_transform);
+    assert!(session.take_frame_changes().is_empty());
+    Ok(())
+}

--- a/fixtures/provider-consumer/tests/public_facade.rs
+++ b/fixtures/provider-consumer/tests/public_facade.rs
@@ -50,8 +50,10 @@ fn public_authoring_live_queries_and_completion() -> Result<(), Box<dyn std::err
 #[test]
 fn integration_access_keeps_one_arena_and_stale_publication_protection(
 ) -> Result<(), Box<dyn std::error::Error>> {
-    use noon::integration::{SemanticMutationTransaction, SemanticStore};
+    use noon::integration::{SemanticMutationTransaction, SemanticStore, TextResource};
     use std::{cell::RefCell, rc::Rc};
+    // Shared semantic text/resource contracts remain available without providers.
+    let _: Option<TextResource> = None;
     let arena = Rc::new(RefCell::new(SemanticStore::new()));
     let mut scene = Scene::with_integration_store(Rc::clone(&arena));
     let circle = scene.circle(1.0)?;
@@ -60,6 +62,7 @@ fn integration_access_keeps_one_arena_and_stale_publication_protection(
     assert!(Rc::ptr_eq(circle.integration_store(), &arena));
     assert!(Rc::ptr_eq(family.integration_store(), &arena));
     scene.add(&circle)?;
+    assert!(arena.borrow().text_resources().is_empty());
     let mut session = scene.execution_session()?;
     session.take_frame_changes();
     let published = session.publication_context();
@@ -86,6 +89,7 @@ fn integration_access_keeps_one_arena_and_stale_publication_protection(
             ))
         ));
     }
+    assert_eq!(circle.state()?.transform.translation.x, 9.0);
     assert_eq!(scene.revision(), raw_revision);
     assert_eq!(session.publication_context(), published);
     assert_eq!(session.frame().objects[0].transform, original_transform);


### PR DESCRIPTION
## Scope and current status

**R2 public-facade implementation under #958 / #1272**, complementary to the existing typed handle/membership PR #1286. This is a complete public-surface slice, **not completion of all R2 error producers or Python exception mapping**. No merge or auto-merge is requested.

- Source head: **`4e7db8dccd077ce3ac1eeb1f31ec54241607e759`**.
- Original branch point: `1641398818b6817678ae178faf2887e4ac1e730f`.
- Current PR base: **`d20463c878ee59a92c26de3b182feaf463575cb4`**.
- Verified PR test-merge checkout: **`6855c9dd28d25cad4da05d7df850f8a01944c3bc`**, read from the final-head provider job log.
- Four commits / 82 files. Most files contain only direct import/accessor migration and resulting Rust formatting. The substantive API changes are the explicit exports/integration module, three deliberately named raw-store accessors and constructor, two ordinary Scene conveniences, the public example, consumer tests and documentation.

Implementation and focused qualification are complete for this slice. Broader product/full-CI checks and the requested review reconsideration remain as reported below; no pending check is counted as passed.

## What changed

### Deliberate public surface

Replace blanket `noon_core`, session/segment, callback, live-program and provider exports with explicit ordinary authoring handles, values, live operations, logical completion and existing errors. Make `semantic_mobject` an implementation module rather than a second public import surface. Update callers directly; no deprecated or compatibility aliases.

Add **`noon::integration` in the existing crate**, containing specific raw semantic/resource types and host/callback/renderer facilities. It introduces no crate, state authority or runtime. Existing workspaces import their actual lower-layer owner directly where appropriate; independent consumers can explicitly opt into the integration surface. Diagnostics remain feature gated.

### Explicit raw access, unchanged publication protection

Rename `Scene::with_store` to `Scene::with_integration_store`; `Scene`, `Mobject` and `MobjectFamily` expose raw mutable arena access through `integration_store()`. The old names are absent. Documentation explains borrow lifetime, stale handles/revisions and why raw post-bootstrap mutation does not publish into an existing session.

Ordinary callers use `Scene::revision()` without arena access, `Scene::geometry(ManimGeometryOptions)` for detached pre-bootstrap construction, and the existing `Scene::live` / `LiveSession` for coherent live operations. Existing identity/revision checks remain authoritative. A deliberately invalid raw edit must still produce the typed stale-publication category and leave the prior runtime/frame publication unchanged.

### Public examples and regression coverage

Rewrite the existing `shared_authoring` Rust example around ordinary Scene/LiveSession calls: construction, authored/effective observations, live edits, waiting and sequential logical completion. It remains paired with the existing `live_affine_completion.py` browser example. No raw compiler transactions or host ownership knowledge are needed by the example.

Add two tests to the independent defaults-disabled provider consumer: the ordinary authoring/live path and explicit raw-integration stale-publication/atomicity protection. Add six compile-fail doc tests rejecting accidental root exports, the private implementation module and retired unqualified accessors. Reuse the existing five-configuration native/WASM provider matrix; only minimal/native additionally executes the docs and example.

Preserve the ordinary geometry workload copied into historical provider-cost baseline builds. Shared text-contract/arena assertions now live in the consumer tests, so an old baseline does not need new integration accessor names. No controlled cold/warm measurement was run for this PR.

## Architecture and locality

- [x] Read `AGENTS.md` and the relevant `docs/architecture.md` contracts.
- [x] No new scene, identity allocator, registry, scheduler, runtime, renderer or mutation authority.
- [x] Native and direct-WASM boundaries remain typed and in-process.
- [x] No publication checks, successful mutation ordering, provider features or dependency edges are changed.
- [x] Local operations retain their existing shared implementation and complexity.
- [x] No compatibility aliases retained solely for previous internal callers.

The existing retained text adapter is exposed explicitly for genuine transport consumers and remains deletion-owned by #959. It is not a new ordinary Scene API or a newly introduced migration seam.

## Final-head validation

| Workflow | Verified status |
| --- | --- |
| [Architecture Ratchets 34306609184](https://github.com/yongkyuns/noon/actions/runs/34306609184) | **Passed** |
| [Layer Dependency Ratchet 34306609126](https://github.com/yongkyuns/noon/actions/runs/34306609126) | **Passed** |
| [PR Fast Gate 34306609159](https://github.com/yongkyuns/noon/actions/runs/34306609159) | **Passed** |
| [Native Host Smoke 34306609027](https://github.com/yongkyuns/noon/actions/runs/34306609027) | **Passed** |
| [Provider feature isolation 34306609115](https://github.com/yongkyuns/noon/actions/runs/34306609115) | **Passed: all ten native/WASM configurations** |
| [Shared text authoring 34306609074](https://github.com/yongkyuns/noon/actions/runs/34306609074) | **Passed** |
| [Playground authoring recovery 34306609177](https://github.com/yongkyuns/noon/actions/runs/34306609177) | **Passed** |
| [CI 34306609200](https://github.com/yongkyuns/noon/actions/runs/34306609200) | Rust, web package, WebGL and WebGPU rendering jobs passed; remaining browser/renderer-parity work still running/queued at last observation |
| [Playground Product Gate 34306609137](https://github.com/yongkyuns/noon/actions/runs/34306609137) | Still running; not claimed passed |
| [Playground cross-browser matrix 34306609108](https://github.com/yongkyuns/noon/actions/runs/34306609108) | Still running/queued; not claimed passed |

Provider run **34306609115**, minimal/native job **102324577983**, attempt **1**, was inspected in full. Checkout `6855c9dd...` combines head `4e7db8dc...` and base `d20463c8...`; Ubuntu 24.04.4 / Linux 6.17.0-1022-azure / Rust 1.98.0. It proves:

- **2/2** public-facade consumer tests, no skips/failures;
- **6/6** compile-fail documentation tests, no skips/failures;
- successful ordinary `shared_authoring` execution;
- independent minimal build, execution, all-target Clippy and package checks;
- existing graph/cache-mode regressions and fixture formatting.

WASM cells compile-check the consumer rather than executing a browser. Actual browser behavior remains qualified by the separate product/host workflows. The historical baseline measurement job and non-minimal doc/example steps are intentionally skipped, not claimed as additional evidence.

### Earlier focused development check

Hosted run **34306248100**, job **102323437878**, passed on source candidate `297937b7...`:
```
cargo fmt --all
cargo fmt --manifest-path fixtures/provider-consumer/Cargo.toml
git diff --check
cargo check --workspace --all-targets --all-features
cargo test --manifest-path fixtures/provider-consumer/Cargo.toml --test public_facade
cargo test -p noon --no-default-features --doc
cargo run -p noon --no-default-features --example shared_authoring
bash scripts/check.sh architecture 1641398818b6817678ae178faf2887e4ac1e730f
```
The later `4e7db8dc` commit changes only the CI guide. The initial build caught an incorrectly renamed multiline compiler prepared-transaction accessor; the correction restored that separate read-only `.store()` API, without a semantic workaround.

Rust was executed in hosted checkouts because the editing environment lacks Cargo. No local Rust/browser/full-gate pass is claimed. Temporary development helper files are confined to `codex/1272-r2-public-facade-prep`, outside this PR; its source-publishing run is completed and must not be rerun unchanged against a moved head.

## Review disposition

The initial automated review on `297937b7` alleged that this PR rolled back #1287's renderer fixture conversion. [The exact-blob and test-merge comparison](https://github.com/yongkyuns/noon/pull/1290#issuecomment-5595340848) shows that the cited native unit files are unchanged in the specified base and merge; #1287's actual typed browser fixtures are retained in the merge. No source correction is warranted for that claim. The review has not been deleted or administratively dismissed; independent reconsideration was requested on the final head. This is not a formal approval or a no-findings claim.

## Remaining R2 / landing coordination

#1286 owns typed handle/membership errors and cause chains and was not modified here. When the two slices are combined, preserve `AuthoringError` and typed returns, explicitly export it, and migrate its consumer imports/accessor names; do not restore broad exports or stringify errors to resolve conflicts.

The remaining geometry/animation String producers, final removal of string-backed live error variants after producer conversion, and Python-wide typed exception mapping stay open under #958/#61. This PR covers the public-surface/raw-access/example acceptance, not the whole R2 error-conversion program. Full exact-head qualification and final review disposition remain prerequisites for merge.