### PR TITLE
refactor: consolidate Python family construction and copying (#61)

### DIFF
--- a/web/python/_manim_compat.py
+++ b/web/python/_manim_compat.py
@@ -318,15 +318,11 @@ class _GroupAnimationBuilder:
 
 
 class Group(_base.Group, _BaseMobject):
-    """Authoring-time Mobject-family group lowered to operations on member objects.
-
-    Noon intentionally keeps runtime hierarchy flat. The group therefore has no single
-    serialized object ID; its transforms and animations lower to its leaf members.
-    """
+    """Python identities and ergonomics over a shared Rust semantic family."""
 
     def __init__(self, *mobjects: object) -> None:
-        self.submobjects: list[object] = []
-        self.add(*mobjects)
+        from _manim_semantic_handles import _group_init
+        _group_init(self, *mobjects)
 
     @property
     def id(self) -> int:
@@ -354,23 +350,16 @@ class Group(_base.Group, _BaseMobject):
         return self.submobjects[index]
 
     def add(self, *mobjects: object) -> Group:
-        for mobject in mobjects:
-            if not isinstance(mobject, (_BaseMobject, Group)):
-                raise TypeError("Group members must be Mobjects or Groups")
-            if mobject is self:
-                raise ValueError("Group cannot contain itself")
-            self.submobjects.append(mobject)
-        return self
+        from _manim_semantic_handles import _group_add
+        return _group_add(self, *mobjects)
 
     def remove(self, *mobjects: object) -> Group:
-        identities = {id(mobject) for mobject in mobjects}
-        self.submobjects = [
-            mobject for mobject in self.submobjects if id(mobject) not in identities
-        ]
-        return self
+        from _manim_semantic_handles import _group_remove
+        return _group_remove(self, *mobjects)
 
     def copy(self) -> Group:
-        return type(self)(*(mobject.copy() for mobject in self.submobjects))
+        from _manim_semantic_handles import _group_copy
+        return _group_copy(self)
 
     def get_center(self) -> _base.Vec2:
         bounds = _bounds_for(self)

--- a/web/python/_manim_geometry.py
+++ b/web/python/_manim_geometry.py
@@ -108,37 +108,6 @@ def _group_get_color(self: _compat.Group) -> _base.Color:
     return _base.WHITE if not leaves else _mobject_get_color(leaves[0])
 
 
-def _copy_group_without_constructor(self: _compat.Group) -> _compat.Group:
-    """Clone retained families without re-running arbitrary subclass constructors.
-
-    Manim group subclasses commonly keep named references to children (for example,
-    ``Arrow._shaft`` and ``Arrow._tip``). Reconstructing ``type(self)(*children)`` is
-    incorrect for such classes because their constructor arguments need not be child
-    mobjects. Seed ``deepcopy`` with the cloned family tree so subclass attributes are
-    remapped to the corresponding detached children while runtime/Scene ownership is
-    left behind by each leaf's normal ``copy`` implementation.
-    """
-
-    clone = object.__new__(type(self))
-    cloned_members = [member.copy() for member in self.submobjects]
-    clone.submobjects = cloned_members
-    memo: dict[int, object] = {id(self): clone}
-
-    def map_family(original: object, copied: object) -> None:
-        memo[id(original)] = copied
-        if isinstance(original, _compat.Group) and isinstance(copied, _compat.Group):
-            for original_child, copied_child in zip(
-                original.submobjects, copied.submobjects, strict=True
-            ):
-                map_family(original_child, copied_child)
-
-    for original, copied in zip(self.submobjects, cloned_members, strict=True):
-        map_family(original, copied)
-
-    _compat.copy_wrapper_attributes(self, clone, memo, {"submobjects"})
-    return clone
-
-
 class Arrow(_compat.Group):
     """2D Manim-style arrow composed from a Line and a triangular tip.
 
@@ -346,7 +315,6 @@ def install() -> None:
     _compat.Line.get_end = _line_get_end
     _base.Mobject.get_color = _mobject_get_color
     _compat.Group.get_color = _group_get_color
-    _compat.Group.copy = _copy_group_without_constructor
 
     # Existing compatibility layout methods resolve this module global at call time,
     # so the hook affects only Manim-facing authoring/layout and never renderer bounds.

--- a/web/python/_manim_semantic_handles.py
+++ b/web/python/_manim_semantic_handles.py
@@ -184,8 +184,6 @@ _ORIGINAL_ALIGN_ON_FRAME = _base.Mobject._align_on_frame
 _ORIGINAL_BECOME = _base.Mobject.become
 _ORIGINAL_REPLACE = _base.Mobject.replace
 
-_ORIGINAL_GROUP_ADD = _compat.Group.add
-_ORIGINAL_GROUP_REMOVE = _compat.Group.remove
 _ORIGINAL_GROUP_SHIFT = _compat.Group.shift
 _ORIGINAL_GROUP_MOVE_TO = _compat.Group.move_to
 _ORIGINAL_GROUP_NEXT_TO = _compat.Group.next_to
@@ -1744,6 +1742,8 @@ def _family_membership_batch(context: object, kind: str, mobjects: tuple[object,
 
 
 def _group_init(self: _compat.Group, *mobjects: object) -> None:
+    if _create_family_handle is None or _new_membership_batch is None:
+        raise RuntimeError("Group construction requires the shared Rust authoring host")
     _validate_group_members(self, mobjects)
     context = _live_constructor_context("family")
     batch = _family_membership_batch(context, "add", mobjects)
@@ -1776,7 +1776,7 @@ def _group_add(self: _compat.Group, *mobjects: object) -> _compat.Group:
     )
     accepted = tuple(value for value, changed in zip(mobjects, changed) if changed)
     if accepted:
-        _ORIGINAL_GROUP_ADD(self, *accepted)
+        self.submobjects.extend(accepted)
     return self
 
 
@@ -1793,7 +1793,8 @@ def _group_remove(self: _compat.Group, *mobjects: object) -> _compat.Group:
     )
     accepted = tuple(value for value, changed in zip(mobjects, changed) if changed)
     if accepted:
-        _ORIGINAL_GROUP_REMOVE(self, *accepted)
+        removed = {id(value) for value in accepted}
+        self.submobjects = [value for value in self.submobjects if id(value) not in removed]
     return self
 
 
@@ -1905,13 +1906,9 @@ def install() -> None:
 
 
     if _create_family_handle is not None:
-        _compat.Group.__init__ = _group_init
-        _compat.Group.add = _group_add
-        _compat.Group.remove = _group_remove
         _compat.Group.shift = _group_shift
         _compat.Group.move_to = _group_move_to
         _compat.Group.next_to = _next_to
         _compat.Group.align_to = _group_align_to
         _compat.Group.arrange = _group_arrange
-        _compat.Group.copy = _group_copy
         _compat.Group._copy_for_animate_target = _group_copy

--- a/web/python/test_manim_animate_semantic_handles.py
+++ b/web/python/test_manim_animate_semantic_handles.py
@@ -211,13 +211,14 @@ class ManimAnimateSemanticHandleTests(unittest.TestCase):
             assert square.get_center().x == 0.0
             assert square.get_center().y == 0.0
 
-            # Group wrapper identity remains Python metadata while the installed
-            # shared-family adapter owns membership and target topology in browsers.
-            group = VGroup(Square(), Square().shift(LEFT))
-            group_builder = group.animate
-            assert isinstance(group_builder.target, VGroup)
-            assert group_builder.target is not group
-            assert len(group_builder.target.submobjects) == 2
+            # A geometry-only host cannot create a valid family in Python.
+            # Shared family target behavior is covered by the family bridge tests.
+            try:
+                VGroup(Square(), Square().shift(LEFT))
+            except RuntimeError as error:
+                assert "Group construction requires the shared Rust authoring host" in str(error)
+            else:
+                raise AssertionError("Group construction bypassed shared Rust")
             """
         )
         completed = subprocess.run(

--- a/web/python/test_unified_scene_binding.py
+++ b/web/python/test_unified_scene_binding.py
@@ -11,6 +11,12 @@ class SharedBindingTests(unittest.TestCase):
     def test_phase_specific_installation_layer_is_removed(self):
         self.assertFalse((Path(__file__).parent / "_manim_phase_b.py").exists())
 
+    def test_empty_family_construction_requires_shared_rust(self):
+        for family_type in (compat.Group, compat.VGroup):
+            with self.subTest(family_type=family_type.__name__):
+                with self.assertRaisesRegex(RuntimeError, "Group construction requires the shared Rust authoring host"):
+                    family_type()
+
     def test_text_construction_requires_shared_rust(self):
         compat.install()
         typst.install()


### PR DESCRIPTION
Python Group/VGroup now defines construction, membership editing and copying as ordinary methods forwarding to the existing shared Rust family operations. A host without family support fails explicitly, including for empty groups. Delete the alternate Python copy implementation and saved-method installation; wrapper membership updates only reflect decisions returned by Rust.

Advances #61 / Phase A3 under #953. Ownership remains in the Semantic Scene; this adds no authority, compatibility layer or migration seam. Existing family-local membership/copy complexity is unchanged. Remaining transform/layout and Scene installation cleanup stays in #61.

Validation: `NOON_WEB_PREFLIGHT_ONLY=1 bash scripts/build-web-demo.sh` passed, including 137 Python tests; `bash scripts/architecture-ratchet.sh` and `git diff --check` passed. The existing shared family membership, alias/copy and animation-target tests protect shared behavior; missing-family-host tests reject Python fallback construction. Existing paired family examples remain unchanged. Rust/browser qualification uses hosted CI because local disk space precludes compilation; no local full-gate pass is claimed.
