### PR TITLE
Replace final Python Scene installation with direct facade methods

### DIFF
--- a/compat/semantic-ownership-v1.json
+++ b/compat/semantic-ownership-v1.json
@@ -19,23 +19,23 @@
     {"path": "web/python/noon.py", "token": "_cursor", "maximum": 0, "migration_issue": "#61"},
     {"path": "web/python/noon.py", "token": "_next_painter_order", "maximum": 0, "migration_issue": "#61"},
     {"path": "web/python/_manim_semantic_handles.py", "token": "_tracks", "maximum": 0, "migration_issue": "#61"},
-    {"path": "web/python/_manim_canonical_scene.py", "token": "_tracks", "maximum": 0, "migration_issue": "#61"},
+    {"path": "web/python/_manim_scene.py", "token": "_tracks", "maximum": 0, "migration_issue": "#61"},
     {"path": "web/python/_manim_reactive.py", "token": "_reactive_signals", "maximum": 0, "migration_issue": "#61"},
     {"path": "web/python/_manim_reactive.py", "token": "_reactive_signal_tracks", "maximum": 0, "migration_issue": "#61"},
     {"path": "web/python/_manim_reactive.py", "token": "_signal_id", "maximum": 0, "migration_issue": "#61"},
     {"path": "web/python/_manim_reactive.py", "token": "self._value", "maximum": 0, "migration_issue": "#61"},
     {"path": "web/python/_manim_reactive.py", "token": "_ORIGINAL_SCENE_PLAY", "maximum": 0, "migration_issue": "#61"},
-    {"path": "web/python/_manim_canonical_scene.py", "token": "_ORIGINAL_AUTHORING_CHECKPOINT", "maximum": 0, "migration_issue": "#61"},
-    {"path": "web/python/_manim_canonical_scene.py", "token": "_ORIGINAL_RESTORE_AUTHORING_CHECKPOINT", "maximum": 0, "migration_issue": "#61"},
-    {"path": "web/python/_manim_canonical_scene.py", "token": "_CHECKPOINT_TAG", "maximum": 0, "migration_issue": "#61"},
+    {"path": "web/python/_manim_scene.py", "token": "_ORIGINAL_AUTHORING_CHECKPOINT", "maximum": 0, "migration_issue": "#61"},
+    {"path": "web/python/_manim_scene.py", "token": "_ORIGINAL_RESTORE_AUTHORING_CHECKPOINT", "maximum": 0, "migration_issue": "#61"},
+    {"path": "web/python/_manim_scene.py", "token": "_CHECKPOINT_TAG", "maximum": 0, "migration_issue": "#61"},
     {"path": "web/python/_manim_composition.py", "token": "_schedule_composition", "maximum": 0, "migration_issue": "#61"},
     {"path": "web/python/_manim_composition.py", "token": "_tracks", "maximum": 0, "migration_issue": "#61"},
     {"path": "web/python/_manim_composition.py", "token": "_cursor", "maximum": 0, "migration_issue": "#61"},
-    {"path": "web/python/_manim_canonical_scene.py", "token": "_timing_authority", "maximum": 0, "migration_issue": "#61"},
-    {"path": "web/python/_manim_canonical_scene.py", "token": "_legacy_authored_time", "maximum": 0, "migration_issue": "#61"},
-    {"path": "web/python/_manim_canonical_scene.py", "token": "_ORIGINAL_WAIT", "maximum": 0, "migration_issue": "#61"},
-    {"path": "web/python/_manim_canonical_scene.py", "token": "_ORIGINAL_TIME", "maximum": 0, "migration_issue": "#61"},
-    {"path": "web/python/_manim_canonical_scene.py", "token": "_ORIGINAL_BIND_", "maximum": 0, "migration_issue": "#61"},
+    {"path": "web/python/_manim_scene.py", "token": "_timing_authority", "maximum": 0, "migration_issue": "#61"},
+    {"path": "web/python/_manim_scene.py", "token": "_legacy_authored_time", "maximum": 0, "migration_issue": "#61"},
+    {"path": "web/python/_manim_scene.py", "token": "_ORIGINAL_WAIT", "maximum": 0, "migration_issue": "#61"},
+    {"path": "web/python/_manim_scene.py", "token": "_ORIGINAL_TIME", "maximum": 0, "migration_issue": "#61"},
+    {"path": "web/python/_manim_scene.py", "token": "_ORIGINAL_BIND_", "maximum": 0, "migration_issue": "#61"},
     {"path": "web/python/_manim_animate.py", "token": "_tracks", "maximum": 0, "migration_issue": "#61"},
     {"path": "web/python/_manim_animate.py", "token": "_cursor", "maximum": 0, "migration_issue": "#61"},
     {"path": "web/python/_manim_animate.py", "token": "_aligned_scene_play", "maximum": 0, "migration_issue": "#61"},
@@ -219,7 +219,7 @@
       "surface": "Canonical Group.animate/ApplyMethod/ScaleInPlace over ordinary semantic leaves",
       "classification": "shared-rust",
       "owner": {"language": "rust", "path": "crates/noon/src/execution_session.rs", "symbol": "SemanticCompositionRequest::FamilyTransformTo"},
-      "adapters": [{"language": "python", "path": "web/python/_manim_canonical_scene.py", "symbol": "_canonical_family_transform_animation"}],
+      "adapters": [{"language": "python", "path": "web/python/_manim_scene.py", "symbol": "_canonical_family_transform_animation"}],
       "reason": "Rust validates authoritative family topology/order and lowers one shared composition. Live target families publish through the existing session; Python retains wrapper identity and call coercion."
     },
     {
@@ -253,7 +253,7 @@
       "surface": "Typed leaf FadeIn/FadeOut with scale, shift, or target_position",
       "classification": "shared-rust",
       "owner": {"language": "rust", "path": "crates/noon/src/live_session.rs", "symbol": "LiveSession::declare_and_activate_fade_with_endpoint"},
-      "adapters": [{"language": "python", "path": "web/python/_manim_canonical_scene.py", "symbol": "_canonical_fade_endpoint/_build_canonical_composition_candidate"}],
+      "adapters": [{"language": "python", "path": "web/python/_manim_scene.py", "symbol": "_canonical_fade_endpoint/_build_canonical_composition_candidate"}],
       "reason": "Python coerces the Manim call into scale plus a shift or point value. Rust resolves effective endpoint layout, authors the affine and appearance tracks, owns lifecycle membership, and schedules composition timing."
     },
     {
@@ -261,7 +261,7 @@
       "surface": "Typed Group/VGroup FadeIn/FadeOut opacity and lifecycle, including compositions with Text Write",
       "classification": "shared-rust",
       "owner": {"language": "rust", "path": "crates/noon/src/execution_session.rs", "symbol": "SemanticCompositionRequest::FamilyFade"},
-      "adapters": [{"language": "python", "path": "web/python/_manim_canonical_scene.py", "symbol": "_canonical_family_fade_animation"}],
+      "adapters": [{"language": "python", "path": "web/python/_manim_scene.py", "symbol": "_canonical_family_fade_animation"}],
       "reason": "Rust traverses authoritative family leaves, applies shared composition timing, validates conflicts atomically and owns family root introduction/removal. Python passes handles and coerced options; affine family fade endpoints remain unsupported."
     },
     {
@@ -269,7 +269,7 @@
       "surface": "Typed leaf DrawBorderThenFill and forward ordinary-vector Write families",
       "classification": "shared-rust",
       "owner": {"language": "rust", "path": "crates/noon/src/live_session.rs", "symbol": "LiveSession::declare_and_activate_draw_border_then_fill/declare_and_activate_family_draw_border_then_fill"},
-      "adapters": [{"language": "python", "path": "web/python/_manim_canonical_scene.py", "symbol": "_canonical_draw_border_then_fill_animation"}],
+      "adapters": [{"language": "python", "path": "web/python/_manim_scene.py", "symbol": "_canonical_draw_border_then_fill_animation"}],
       "reason": "Python coerces Manim outline options and wrapper identity. Rust derives the activation-effective outline and final style, owns both phases and family lag scheduling, and publishes detached families atomically."
     },
     {
@@ -277,7 +277,7 @@
       "surface": "Plain Text and Group/VGroup Text Write/Unwrite, including mixed ordinary compositions",
       "classification": "shared-rust",
       "owner": {"language": "rust", "path": "crates/noon/src/live_session.rs", "symbol": "LiveSession::declare_and_activate_text_write/declare_and_activate_family_text_write"},
-      "adapters": [{"language": "python", "path": "web/python/_manim_canonical_scene.py", "symbol": "_canonical_text_write_animation/_canonical_text_family_write_animation"}],
+      "adapters": [{"language": "python", "path": "web/python/_manim_scene.py", "symbol": "_canonical_text_write_animation/_canonical_text_family_write_animation"}],
       "reason": "Python passes typed Text/family handles and explicit options. Rust derives global glyph order and count-dependent defaults, validates composition conflicts and membership atomically, and publishes compact per-leaf global spans with immutable glyph plans to the common renderer."
     },
     {
@@ -285,7 +285,7 @@
       "surface": "Plain Text and Text/geometry Group/VGroup Create/Uncreate, including mixed ordinary compositions",
       "classification": "shared-rust",
       "owner": {"language": "rust", "path": "crates/noon/src/live_session.rs", "symbol": "LiveSession::declare_and_activate_text_reveal/declare_and_activate_family_reveal"},
-      "adapters": [{"language": "python", "path": "web/python/_manim_canonical_scene.py", "symbol": "_canonical_text_reveal_animation/_canonical_family_reveal_animation"}],
+      "adapters": [{"language": "python", "path": "web/python/_manim_scene.py", "symbol": "_canonical_text_reveal_animation/_canonical_family_reveal_animation"}],
       "reason": "Python passes typed handles and explicit options. Rust owns global glyph ordering, Reveal defaults, local rate reversal, atomic family membership and conflicting-driver validation. The existing compact glyph plans and common retained renderer realize both Create/Uncreate and Write/Unwrite."
     },
     {
@@ -334,7 +334,7 @@
       "surface": "Single-leaf GrowFromPoint/Center/Edge, SpinInFromNothing and ShrinkToCenter",
       "classification": "shared-rust",
       "owner": {"language": "rust", "path": "crates/noon/src/live_session.rs", "symbol": "declare_and_activate_affine_lifecycle"},
-      "adapters": [{"language": "python", "path": "web/python/_manim_canonical_scene.py", "symbol": "_canonical_affine_lifecycle_animation"}]
+      "adapters": [{"language": "python", "path": "web/python/_manim_scene.py", "symbol": "_canonical_affine_lifecycle_animation"}]
     },
     {
       "id": "animate.target-state",
@@ -404,7 +404,7 @@
       "surface": "Scene.add/play/wait cursor and lifecycle authoring",
       "classification": "shared-rust",
       "owner": {"language": "rust", "path": "crates/noon/src/live_session.rs", "symbol": "LiveSession::add/declare_and_activate_composition/wait_segment"},
-      "adapters": [{"language": "python", "path": "web/python/_manim_canonical_scene.py", "symbol": "_play/_canonical_wait/_canonical_scene_time"}],
+      "adapters": [{"language": "python", "path": "web/python/_manim_scene.py", "symbol": "_play/_canonical_wait/_canonical_scene_time"}],
       "reason": "All valid scene operations use shared Rust continuations; the Python Scene/document engine, cursor, tracks, snapshots and scheduling have been deleted. Derived wrapper identities remain Python metadata."
     },
     {
@@ -412,7 +412,7 @@
       "surface": "Scene.remove/replace/clear and top-level ordering",
       "classification": "shared-rust",
       "owner": {"language": "rust", "path": "crates/noon-core/src/reactive/semantic_scene_restructure.rs", "symbol": "plan_semantic_scene_membership"},
-      "adapters": [{"language": "python", "path": "web/python/_manim_canonical_scene.py", "symbol": "_canonical_edit_membership/_canonical_scene_mobjects"}],
+      "adapters": [{"language": "python", "path": "web/python/_manim_scene.py", "symbol": "_canonical_edit_membership/_canonical_scene_mobjects"}],
       "reason": "One shared Rust planner validates and atomically applies family-aware add/remove/clear/replace requests and owns authoritative root painter order. Python reserves derived wrapper identities, submits one typed request, and maps the ordered Rust projection back to public wrappers after success."
     },
     {
@@ -452,7 +452,7 @@
       "surface": "Reactive graph validation, evaluation, invalidation, and native input dispatch",
       "classification": "shared-rust",
       "owner": {"language": "rust", "path": "crates/noon-core/src/reactive/native_reactive.rs", "symbol": "ReactiveProgram/ReactiveState"},
-      "adapters": [{"language": "python", "path": "web/python/_manim_canonical_scene.py", "symbol": "_canonical_value_tracker/_canonical_bind_position"}]
+      "adapters": [{"language": "python", "path": "web/python/_manim_scene.py", "symbol": "_canonical_value_tracker/_canonical_bind_position"}]
     },
     {
       "id": "group-authored-paint-mutation",

--- a/scripts/architecture-ratchet.sh
+++ b/scripts/architecture-ratchet.sh
@@ -243,6 +243,7 @@ deleted_legacy_validation_paths=(
   'scripts/explicit-transport-scene-fixture.js'
   'web/fixtures/execution-transport.json'
   'crates/noon-ir'
+  'web/python/_manim_canonical_scene.py'
   'crates/noon-web/src/legacy.rs'
   'crates/noon/src/legacy.rs'
   'crates/noon/src/legacy/semantic_snapshot.rs'

--- a/scripts/architecture_migration_relocations.json
+++ b/scripts/architecture_migration_relocations.json
@@ -5,9 +5,6 @@
     "crates/noon-core/src/patch.rs": {
       "ObjectDefinition": 12,
       "SceneDefinition": 17
-    },
-    "web/python-worker.source.js": {
-      "_manim_canonical_scene": 5
     }
   },
   "regression_fixtures": {

--- a/web/python-compat-modules.js
+++ b/web/python-compat-modules.js
@@ -22,5 +22,5 @@ export const PYTHON_COMPAT_MODULES = Object.freeze([
   { sourcePath: "python/_manim_updaters.py", runtimePath: "/tmp/_manim_updaters.py", label: "Noon Manim updater layer" },
   { sourcePath: "python/_manim_camera.py", runtimePath: "/tmp/_manim_camera.py", label: "Noon Manim moving-camera adapter" },
   { sourcePath: "python/_manim_source_execution.py", runtimePath: "/tmp/_manim_source_execution.py", label: "Noon Python source continuation compiler" },
-  { sourcePath: "python/_manim_canonical_scene.py", runtimePath: "/tmp/_manim_canonical_scene.py", label: "Noon canonical SceneSpec authoring context" },
+  { sourcePath: "python/_manim_scene.py", runtimePath: "/tmp/_manim_scene.py", label: "Noon shared Scene host adapter" },
 ].map((module) => Object.freeze(module)));

--- a/web/python-worker.source.js
+++ b/web/python-worker.source.js
@@ -173,10 +173,6 @@ import _manim_updaters
 _manim_updaters.install()
 import _manim_camera
 _manim_camera.install()
-# Final production SceneSpec ownership: after all content/lifecycle adapters have
-# installed, bind their events into one per-scene Rust canonical authoring context.
-import _manim_canonical_scene
-_manim_canonical_scene.install()
 `);
   const importsReadyAt = performance.now();
   self.__noonAuthoringStartupMetrics = Object.freeze({
@@ -686,7 +682,7 @@ async function runAuthoringSource(pyodide, source, context) {
       `
 import json
 import _manim_updaters
-from _manim_canonical_scene import (
+from _manim_scene import (
     execute_construct,
     await_source_barrier,
     await_module_source_barrier,

--- a/web/python/_manim_compat.py
+++ b/web/python/_manim_compat.py
@@ -21,9 +21,6 @@ OUT = (0.0, 0.0, 1.0)
 IN = (0.0, 0.0, -1.0)
 
 _INSTALLED = False
-_STANDARD_MEMBERSHIP_EDIT = None
-_STANDARD_MEMBERSHIP_VIEW = None
-_STANDARD_MEMBERSHIP_REGISTER = None
 
 
 # Pinned ManimCE v0.21.0 Cairo presentation contract. Cairo converts
@@ -531,27 +528,26 @@ class Scene(_BaseScene):
         pass
 
     def _register_top_level(self, value: object) -> None:
-        if _STANDARD_MEMBERSHIP_REGISTER is not None and (
+        if (
             getattr(value, "_semantic_handle", None) is not None
             or getattr(value, "_semantic_family_handle", None) is not None
         ):
-            _STANDARD_MEMBERSHIP_REGISTER(self, value)
+            _base._scene_operations()._register_membership_wrappers(self, value)
             return
         if not any(existing is value for existing in self._compat_top_level):
             self._compat_top_level.append(value)
 
     @property
     def mobjects(self) -> list[object]:
-        if _STANDARD_MEMBERSHIP_VIEW is None:
-            raise RuntimeError("typed Scene membership is not installed")
-        return _STANDARD_MEMBERSHIP_VIEW(self)
+        return _base._scene_operations()._canonical_scene_mobjects(self)
+
+    def _edit_membership(self, kind: str, values: tuple[object, ...] = (), *, key=None) -> None:
+        _base._scene_operations()._canonical_edit_membership(self, kind, values, key=key)
 
     def add(self, *mobjects: object, key: str | None = None) -> _BaseMobject | Scene:
         if not mobjects:
             return self
-        if _STANDARD_MEMBERSHIP_EDIT is None:
-            raise RuntimeError("typed Scene membership is not installed")
-        _STANDARD_MEMBERSHIP_EDIT(self, "add", mobjects, key=key)
+        self._edit_membership("add", mobjects, key=key)
 
         # Preserve Noon's established one-object return as a backwards-compatible
         # extension. Typical Manim source ignores Scene.add's return value.
@@ -559,21 +555,15 @@ class Scene(_BaseScene):
         return leaves[0] if len(leaves) == 1 else self
 
     def remove(self, *mobjects: object) -> Scene:
-        if _STANDARD_MEMBERSHIP_EDIT is None:
-            raise RuntimeError("typed Scene membership is not installed")
-        _STANDARD_MEMBERSHIP_EDIT(self, "remove", mobjects)
+        self._edit_membership("remove", mobjects)
         return self
 
     def clear(self) -> Scene:
-        if _STANDARD_MEMBERSHIP_EDIT is None:
-            raise RuntimeError("typed Scene membership is not installed")
-        _STANDARD_MEMBERSHIP_EDIT(self, "clear")
+        self._edit_membership("clear")
         return self
 
     def replace(self, old_mobject: object, new_mobject: object) -> Scene:
-        if _STANDARD_MEMBERSHIP_EDIT is None:
-            raise RuntimeError("typed Scene membership is not installed")
-        _STANDARD_MEMBERSHIP_EDIT(self, "replace", (old_mobject, new_mobject))
+        self._edit_membership("replace", (old_mobject, new_mobject))
         return self
 
 

--- a/web/python/_manim_scene.py
+++ b/web/python/_manim_scene.py
@@ -36,7 +36,6 @@ try:
 except ImportError:  # pragma: no cover - native import smoke only
     _create_context = None
 
-_INSTALLED = False
 _ASYNC_CONTINUATION_MODE = "_noon_async_continuation_mode"
 _ASYNC_CONTINUATION_PENDING = "_noon_async_continuation_pending"
 _SYNCHRONOUS_CONTINUATION_MODE = "_noon_synchronous_continuation_mode"
@@ -513,7 +512,7 @@ async def execute_construct(
                 # Inspect the instance after setup(), without executing getters.
                 # Overrides and dynamic lookup retain the original call path.
                 if has_portable_scene_methods(
-                    scene, play=_play, wait=_canonical_wait,
+                    scene, play=_base.Scene.play, wait=_base.Scene.wait,
                     add=_base.Scene.add, remove=_base.Scene.remove, clear=_base.Scene.clear,
                 ):
                     portable_construct = bind_portable_construct(
@@ -565,7 +564,7 @@ async def await_source_barrier(method, /, *args, **kwargs):
     scene = getattr(method, "__self__", None)
     if (not isinstance(scene, _base.Scene)
             or not getattr(scene, _PORTABLE_CONSTRUCT_MODE, False)
-            or getattr(method, "__func__", None) not in (_play, _canonical_wait)):
+            or getattr(method, "__func__", None) not in (_base.Scene.play, _base.Scene.wait)):
         raise RuntimeError("portable barrier must be the current Scene's canonical play/wait")
     setattr(scene, _PORTABLE_BARRIER_CALL, True)
     try:
@@ -588,9 +587,9 @@ async def await_module_source_barrier(method, /, *args, **kwargs):
 
     if (invocation is None
             or not isinstance(scene, _base.Scene)
-            or getattr(method, "__func__", None) not in (_play, _canonical_wait)
+            or getattr(method, "__func__", None) not in (_base.Scene.play, _base.Scene.wait)
             or not has_portable_scene_methods(
-                scene, play=_play, wait=_canonical_wait,
+                scene, play=_base.Scene.play, wait=_base.Scene.wait,
                 add=_base.Scene.add, remove=_base.Scene.remove, clear=_base.Scene.clear,
             )
             or (_create_context is None
@@ -2507,58 +2506,3 @@ def _live_execution(
 ) -> LiveExecution:
     """Create an explicit typed live session for the currently supported subset."""
     return LiveExecution(self, duration)
-
-
-def _bind_text(
-    self: _typst._RetainedTextMobject,
-    scene: _base.Scene,
-    *,
-    key: str | None = None,
-) -> object:
-    if self._scene is scene and self._object is not None:
-        return self._object
-    return _bind_mobject(self, scene, key=key)
-
-
-def install() -> None:
-    """Install the canonical per-scene Rust authoring context as the production path."""
-
-    global _INSTALLED
-    if _INSTALLED:
-        return
-    _INSTALLED = True
-    _compat._STANDARD_MEMBERSHIP_EDIT = _canonical_edit_membership
-    _compat._STANDARD_MEMBERSHIP_VIEW = _canonical_scene_mobjects
-    _compat._STANDARD_MEMBERSHIP_REGISTER = _register_membership_wrappers
-
-    _typst._RetainedTextMobject._bind_to_scene = _bind_text
-    _base.Mobject._bind_to_scene = _bind_mobject
-    _base.Scene._bind_camera_frame = _bind_camera_frame
-    _base.Scene.play = _play
-    _base.Scene.wait = _canonical_wait
-    _base.Scene.declare_wait = _declare_wait
-    _base.Scene.time = property(_canonical_scene_time)
-    _base.Scene.value_tracker = _canonical_value_tracker
-    _base.Scene.bind_position = _canonical_bind_position
-    _base.Scene.pointer_position_signal = _canonical_pointer_position_signal
-    _base.Scene.pointer_button_signal = _canonical_pointer_button_signal
-    _base.Scene.key_state_signal = _canonical_key_state_signal
-    _base.Scene.viewport_size_signal = _canonical_viewport_size_signal
-    _base.Scene.wheel_delta_signal = _canonical_wheel_delta_signal
-    _base.Scene.gesture_delta_signal = _canonical_gesture_delta_signal
-    _base.Scene.control_signal = _canonical_control_signal
-    _base.Scene.pointer_down_events = _canonical_pointer_down_events
-    _base.Scene.pointer_up_events = _canonical_pointer_up_events
-    _base.Scene.key_press_events = _canonical_key_press_events
-    _base.Scene.key_release_events = _canonical_key_release_events
-    _base.Scene.wheel_events = _canonical_wheel_events
-    _base.Scene.gesture_events = _canonical_gesture_events
-    _base.Scene.control_commit_events = _canonical_control_commit_events
-    _base.Scene.bind_rotation = _canonical_bind_rotation_dispatch
-    _base.Scene.bind_opacity = _canonical_bind_opacity_dispatch
-    _base.Scene.bind_presence = _canonical_bind_presence_dispatch
-    _base.Scene.bind_appearance = _canonical_bind_appearance_dispatch
-    _base.Scene.bind_reveal = _canonical_bind_reveal_dispatch
-    _base.Scene.bind_morph = _canonical_bind_morph_dispatch
-    _base.Scene.live_execution = _live_execution
-    _base.Scene.declare_live_transform_to = _declare_live_transform_to

--- a/web/python/_manim_typst.py
+++ b/web/python/_manim_typst.py
@@ -119,6 +119,11 @@ def _in_canonical_callback_phase(mobject: _base.Mobject) -> bool:
 class _RetainedTextMobject(_base.Mobject):
     """Python wrapper for one shared semantic resource-backed text object."""
 
+    def _bind_to_scene(self, scene: _base.Scene, *, key: str | None = None) -> object:
+        if self._scene is scene and self._object is not None:
+            return self._object
+        return super()._bind_to_scene(scene, key=key)
+
     def _initialize_text(
         self,
         source: str,

--- a/web/python/_test_manim_membership.py
+++ b/web/python/_test_manim_membership.py
@@ -1,6 +1,6 @@
 """Minimal membership hooks for isolated Python adapter tests.
 
-Production installs the shared Rust membership implementation. Tests that load
+Production calls the shared Rust membership implementation directly. Tests that load
 only the Python ergonomics modules use this stand-in to bind wrappers without
 installing another production membership path.
 """
@@ -60,5 +60,10 @@ def install_test_membership(compat: Any) -> None:
             return
         raise ValueError(f"unknown test membership operation {kind!r}")
 
-    compat._STANDARD_MEMBERSHIP_EDIT = edit
-    compat._STANDARD_MEMBERSHIP_VIEW = lambda scene: list(scene._compat_top_level)
+    def register(scene, value):
+        if not any(existing is value for existing in scene._compat_top_level):
+            scene._compat_top_level.append(value)
+
+    compat.Scene._edit_membership = edit
+    compat.Scene._register_top_level = register
+    compat.Scene.mobjects = property(lambda scene: list(scene._compat_top_level))

--- a/web/python/noon.py
+++ b/web/python/noon.py
@@ -232,7 +232,7 @@ class Mobject:
         self._object = obj
 
     def _bind_to_scene(self, scene: Scene, *, key: str | None = None) -> _ir.Object:
-        raise RuntimeError("Scene membership requires the shared Rust authoring host")
+        return _scene_operations()._bind_mobject(self, scene, key=key)
 
     def _current_raw(self) -> _ir.Mobject:
         raise RuntimeError("Mobject queries require the shared Rust authoring host")
@@ -531,6 +531,17 @@ class _AnimationBuilder:
         return self
 
 
+def _scene_operations():
+    """Load the shared host adapter lazily, after public wrapper classes exist."""
+    try:
+        import _manim_scene
+    except ModuleNotFoundError as error:
+        if error.name != "js":
+            raise
+        raise RuntimeError("Scene operations require the shared Rust authoring host") from None
+    return _manim_scene
+
+
 class Scene:
     """Python authoring facade; semantic operations require the shared Rust host."""
 
@@ -544,19 +555,104 @@ class Scene:
         self._object_positions: dict[int, int] = {}
         self._next_object_id = 0
 
-    @property
-    def time(self) -> float:
-        raise RuntimeError("Scene time requires the shared Rust authoring host")
-
     def add(self, *mobjects: Mobject, **kwargs: Any) -> Scene:
         raise RuntimeError("Scene membership requires the shared Rust authoring host")
 
-    def play(self, *animations: Any, **kwargs: Any) -> Scene:
-        raise RuntimeError("Scene playback requires the shared Rust authoring host")
+    def _bind_camera_frame(self, mobject: Mobject) -> Any:
+        return _scene_operations()._bind_camera_frame(self, mobject)
 
-    def wait(self, duration: float = 1.0) -> Scene:
-        raise RuntimeError("Scene playback requires the shared Rust authoring host")
+    def play(self, *args, **kwargs) -> Any:
+        return _scene_operations()._play(self, *args, **kwargs)
 
+    def wait(self, duration: float = 1.0) -> Any:
+        return _scene_operations()._canonical_wait(self, duration)
+
+    def declare_wait(self, duration: float = 1.0) -> Scene:
+        return _scene_operations()._declare_wait(self, duration)
+
+    @property
+    def time(self) -> float:
+        return _scene_operations()._canonical_scene_time(self)
+
+    def value_tracker(self, value: float = 0.0) -> Any:
+        return _scene_operations()._canonical_value_tracker(self, value)
+
+    def bind_position(
+        self, mobject: object, tracker: object,
+        direction: object = None, offset: object = None,
+    ) -> Scene:
+        return _scene_operations()._canonical_bind_position(self, mobject, tracker, direction, offset)
+
+    def pointer_position_signal(self) -> Any:
+        return _scene_operations()._canonical_pointer_position_signal(self)
+
+    def pointer_button_signal(self, button: int = 0, initial: bool = False) -> Any:
+        return _scene_operations()._canonical_pointer_button_signal(self, button, initial)
+
+    def key_state_signal(self, code: str, initial: bool = False) -> Any:
+        return _scene_operations()._canonical_key_state_signal(self, code, initial)
+
+    def viewport_size_signal(self) -> Any:
+        return _scene_operations()._canonical_viewport_size_signal(self)
+
+    def wheel_delta_signal(self) -> Any:
+        return _scene_operations()._canonical_wheel_delta_signal(self)
+
+    def gesture_delta_signal(self, name: str) -> Any:
+        return _scene_operations()._canonical_gesture_delta_signal(self, name)
+
+    def control_signal(self, name: str, value: float = 0.0) -> Any:
+        return _scene_operations()._canonical_control_signal(self, name, value)
+
+    def pointer_down_events(self, button: int = 0) -> Any:
+        return _scene_operations()._canonical_pointer_down_events(self, button)
+
+    def pointer_up_events(self, button: int = 0) -> Any:
+        return _scene_operations()._canonical_pointer_up_events(self, button)
+
+    def key_press_events(self, code: str) -> Any:
+        return _scene_operations()._canonical_key_press_events(self, code)
+
+    def key_release_events(self, code: str) -> Any:
+        return _scene_operations()._canonical_key_release_events(self, code)
+
+    def wheel_events(self) -> Any:
+        return _scene_operations()._canonical_wheel_events(self)
+
+    def gesture_events(self, name: str) -> Any:
+        return _scene_operations()._canonical_gesture_events(self, name)
+
+    def control_commit_events(self, name: str) -> Any:
+        return _scene_operations()._canonical_control_commit_events(self, name)
+
+    def bind_rotation(self, mobject: object, tracker: object) -> Any:
+        return _scene_operations()._canonical_bind_rotation_dispatch(self, mobject, tracker)
+
+    def bind_opacity(self, mobject: object, tracker: object) -> Any:
+        return _scene_operations()._canonical_bind_opacity_dispatch(self, mobject, tracker)
+
+    def bind_presence(self, mobject: object, signal: object) -> Any:
+        return _scene_operations()._canonical_bind_presence_dispatch(self, mobject, signal)
+
+    def bind_appearance(self, mobject: object, tracker: object) -> Any:
+        return _scene_operations()._canonical_bind_appearance_dispatch(self, mobject, tracker)
+
+    def bind_reveal(self, mobject: object, tracker: object) -> Any:
+        return _scene_operations()._canonical_bind_reveal_dispatch(self, mobject, tracker)
+
+    def bind_morph(self, mobject: object, tracker: object) -> Any:
+        return _scene_operations()._canonical_bind_morph_dispatch(self, mobject, tracker)
+
+    def live_execution(self, duration: float | None = None) -> Any:
+        return _scene_operations()._live_execution(self, duration)
+
+    def declare_live_transform_to(
+        self, source: Mobject, target: Mobject, *,
+        run_time: float = 1.0, rate_func: object = "smooth",
+    ) -> Any:
+        return _scene_operations()._declare_live_transform_to(
+            self, source, target, run_time=run_time, rate_func=rate_func,
+        )
 
 
 Object = Mobject

--- a/web/python/test_scene_facade.py
+++ b/web/python/test_scene_facade.py
@@ -1,0 +1,72 @@
+"""Public Scene methods bind to the shared host without a final installer."""
+import os
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
+import unittest
+
+
+class SceneFacadeTests(unittest.TestCase):
+    def test_cursor_and_portable_barriers_use_stable_public_methods(self):
+        source = textwrap.dedent("""
+            import asyncio
+            import sys
+            from types import ModuleType
+
+            bridge = ModuleType("js")
+            bridge.noonResolveAnimationOptions = lambda *args: None
+            sys.modules["js"] = bridge
+            import noon
+            original_play, original_wait = noon.Scene.play, noon.Scene.wait
+            import _manim_compat as compat
+            compat.install()
+            import _manim_scene as canonical
+            from _manim_source_execution import has_portable_scene_methods
+            assert noon.Scene.play is original_play
+            assert noon.Scene.wait is original_wait
+            assert not hasattr(canonical, "install")
+
+            class Context:
+                def __init__(self):
+                    self.time = 0.0
+                    self.waits = []
+                def authoredDuration(self): return self.time
+                def ordinaryWait(self, duration):
+                    self.waits.append(duration)
+                    self.time += duration
+                def authoredWait(self, duration): self.time += duration
+
+            scene = noon.Scene()
+            context = Context()
+            scene._canonical_authoring_context = context
+            assert scene.time == 0.0
+            assert scene.wait(0.5) is scene
+            assert scene.declare_wait(0.25) is scene
+            assert scene.time == 0.75
+            assert has_portable_scene_methods(scene, play=original_play, wait=original_wait)
+            setattr(scene, canonical._PORTABLE_CONSTRUCT_MODE, True)
+            assert asyncio.run(canonical.await_source_barrier(scene.wait, 0.5)) is scene
+            assert scene.time == 1.25
+            assert context.waits == [0.5, 0.5]
+            assert not getattr(scene, canonical._PORTABLE_BARRIER_CALL)
+
+            class Override(noon.Scene):
+                def wait(self, duration=1.0): return "custom"
+            overridden = Override()
+            assert not has_portable_scene_methods(overridden, play=original_play, wait=original_wait)
+            setattr(overridden, canonical._PORTABLE_CONSTRUCT_MODE, True)
+            try:
+                asyncio.run(canonical.await_source_barrier(overridden.wait, 1.0))
+            except RuntimeError as error:
+                assert "canonical play/wait" in str(error)
+            else:
+                raise AssertionError("custom wait must retain its original execution path")
+        """)
+        python_dir = Path(__file__).resolve().parent
+        result = subprocess.run(
+            [sys.executable, "-c", source], cwd=python_dir,
+            env={**os.environ, "PYTHONPATH": str(python_dir)},
+            capture_output=True, text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)

--- a/web/retained-family-fade-batch.test.mjs
+++ b/web/retained-family-fade-batch.test.mjs
@@ -3,7 +3,7 @@ import { existsSync, readFileSync } from "node:fs";
 import test from "node:test";
 
 const cameraSource = readFileSync("web/python/_manim_camera.py", "utf8");
-const canonicalSource = readFileSync("web/python/_manim_canonical_scene.py", "utf8");
+const canonicalSource = readFileSync("web/python/_manim_scene.py", "utf8");
 const manifestSource = readFileSync("web/python-compat-modules.js", "utf8");
 
 test("obsolete retained family fade coordinator stays deleted", () => {


### PR DESCRIPTION
Python Scene operations depended on a final installer replacing public methods and wiring optional membership globals. Public methods now call the shared host adapter directly; geometry/text binding and membership also resolve their normal implementation directly. Delete the installer and hook globals, then rename the remaining adapter to `_manim_scene.py` and remove its old migration-token allowance.

Advances #61 A3.1/A3.7 and #959. Python continues to own only host ergonomics and callable/wrapper identity. Semantic state, mutation, scheduling and execution remain in Rust. No new authority, migration seam, or per-operation scene scan is introduced. Portable source continuation checks recognize the stable public `play`/`wait` methods and still reject user overrides.

Validation: `NOON_WEB_PREFLIGHT_ONLY=1 bash scripts/build-web-demo.sh` passed (145 Python tests and all frontend checks); `bash scripts/check-architecture.sh`, `bash scripts/architecture-ratchet.test.sh`, and `bash scripts/check-architecture.test.sh` passed. The new regression exercises the real host adapter with an isolated fake host, cursor/wait/declare-wait calls, portable barrier admission, and override rejection without any Scene installer. Existing paired Rust/Python examples qualify unchanged semantics through browser CI. No local Rust/WASM build due to disk constraints; hosted browser/full CI remains required before merge.

Remaining #61 work includes Mobject installation/legacy export shapes, callback dispatch, and structured exception mapping; this does not declare Phase A complete.
