### PR TITLE
Replace callback method installation with direct facade dispatch

### DIFF
--- a/compat/semantic-ownership-v1.json
+++ b/compat/semantic-ownership-v1.json
@@ -51,6 +51,7 @@
     {"path": "web/python/_manim_rotate.py", "token": "_snapshot_for_object_at", "maximum": 0, "migration_issue": "#61"},
     {"path": "web/python/_manim_semantic_handles.py", "token": "copy.deepcopy", "maximum": 1, "migration_issue": "#61"},
     {"path": "web/python/_manim_semantic_handles.py", "token": "_ir.Mobject(", "maximum": 1, "migration_issue": "#61"},
+    {"path": "web/python/_manim_updaters.py", "token": "_ORIGINAL_", "maximum": 0, "migration_issue": "#61"},
     {"path": "web/python/_manim_updaters.py", "token": "copy.deepcopy", "maximum": 0, "migration_issue": "#61"},
     {"path": "web/python/_manim_updaters.py", "token": "_ir.Mobject(", "maximum": 0, "migration_issue": "#61"},
     {"path": "web/python/_noon_ir.py", "token": "copy.deepcopy", "maximum": 4, "migration_issue": "#61"},

--- a/web/manim-mobject-layout-ownership.test.mjs
+++ b/web/manim-mobject-layout-ownership.test.mjs
@@ -6,6 +6,8 @@ const semanticHandlesSource = readFileSync(
   new URL("./python/_manim_semantic_handles.py", import.meta.url),
   "utf8",
 );
+const facadeSource = readFileSync(new URL("./python/noon.py", import.meta.url), "utf8");
+const callbackSource = readFileSync(new URL("./python/_manim_updaters.py", import.meta.url), "utf8");
 const rustHandleSource = readFileSync(
   new URL("../crates/noon/src/semantic_mobject.rs", import.meta.url),
   "utf8",
@@ -35,11 +37,10 @@ test("detached Mobject layout queries stay owned by the shared semantic handle",
   const height = functionBody(semanticHandlesSource, "_height", "_set_width_property");
   assert.match(height, /handle\.height/);
 
-  assert.match(
-    semanticHandlesSource,
-    /_base\.Mobject\.get_center = _get_center/,
-    "install() must keep get_center on the semantic-handle adapter",
-  );
+  assert.match(facadeSource, /return _callback_operations\(\)\._canonical_get_center\(self\)/);
+  assert.match(callbackSource, /return _semantic_operations\(\)\._get_center\(self\)/);
+  assert.doesNotMatch(callbackSource, /def install\(|_ORIGINAL_/);
+
   assert.match(
     semanticHandlesSource,
     /_base\.Mobject\.width = property\(_width, _set_width_property\)/,

--- a/web/python-worker.source.js
+++ b/web/python-worker.source.js
@@ -170,7 +170,7 @@ import _manim_indication
 _manim_indication.install()
 import _manim_reactive
 import _manim_updaters
-_manim_updaters.install()
+
 import _manim_camera
 _manim_camera.install()
 `);

--- a/web/python/_manim_compat.py
+++ b/web/python/_manim_compat.py
@@ -124,20 +124,20 @@ class VMobject(_BaseMobject):
         return _copy_mobject(self)
 
     def set_color(self, color: object, family: bool = True) -> VMobject:
-        from _manim_semantic_handles import _set_vmobject_color
-        return _set_vmobject_color(self, color, family=family)
+        from _manim_updaters import _canonical_vmobject_set_color
+        return _canonical_vmobject_set_color(self, color, family=family)
 
     def set_fill(self, color: object = None, opacity: float | None = None, family: bool = True) -> VMobject:
-        from _manim_semantic_handles import _set_fill
-        return _set_fill(self, color=color, opacity=opacity, family=family)
+        from _manim_updaters import _canonical_vmobject_set_fill
+        return _canonical_vmobject_set_fill(self, color=color, opacity=opacity, family=family)
 
     def set_stroke(self, color: object = None, width: float | None = None, opacity: float | None = None, family: bool = True) -> VMobject:
-        from _manim_semantic_handles import _set_stroke
-        return _set_stroke(self, color=color, width=width, opacity=opacity, family=family)
+        from _manim_updaters import _canonical_vmobject_set_stroke
+        return _canonical_vmobject_set_stroke(self, color=color, width=width, opacity=opacity, family=family)
 
     def set_opacity(self, opacity: float, family: bool = True) -> VMobject:
-        from _manim_semantic_handles import _set_opacity
-        return _set_opacity(self, opacity, family=family)
+        from _manim_updaters import _canonical_vmobject_set_opacity
+        return _canonical_vmobject_set_opacity(self, opacity, family=family)
 
     def get_fill_opacity(self) -> float:
         from _manim_semantic_handles import _get_fill_opacity
@@ -897,8 +897,6 @@ def install() -> None:
     _BaseMobject.get_x = _mobject_get_x
     _BaseMobject.get_y = _mobject_get_y
     _BaseMobject.set_coord = _mobject_set_coord
-    _BaseMobject.set_x = _mobject_set_x
-    _BaseMobject.set_y = _mobject_set_y
     _BaseMobject.rescale_to_fit = _mobject_rescale_to_fit
     _BaseMobject.scale_to_fit_width = _mobject_scale_to_fit_width
     _BaseMobject.scale_to_fit_height = _mobject_scale_to_fit_height
@@ -910,7 +908,6 @@ def install() -> None:
     _BaseMobject.match_coord = _mobject_match_coord
     _BaseMobject.match_x = _mobject_match_x
     _BaseMobject.match_y = _mobject_match_y
-    _BaseMobject.rotate = _mobject_rotate
     _BaseMobject.rotate_about_origin = _mobject_rotate_about_origin
     _BaseMobject.width = property(_BaseMobject.width.fget, _set_width_property)
     _BaseMobject.height = property(_BaseMobject.height.fget, _set_height_property)

--- a/web/python/_manim_rate_functions.py
+++ b/web/python/_manim_rate_functions.py
@@ -111,27 +111,6 @@ def evaluate_rate_function(semantic_id: str, progress: float) -> float:
     return function(value)
 
 
-def _set_color_preserving_opacity(
-    self: _base.Mobject, color: _base.Color
-) -> _base.Mobject:
-    """Match Manim ``set_color`` without coupling RGB to fill/stroke opacity."""
-
-    try:
-        import _manim_semantic_handles as shared
-    except ImportError:
-        shared = None
-    if shared is not None:
-        handle = shared._handle_for(self)
-        if handle is not None:
-            return shared._set_color(self, color)
-        if getattr(self, "_semantic_handle", None) is not None:
-            raise NotImplementedError(
-                "typed set_color requires the shared semantic mutation path"
-            )
-
-    raise RuntimeError("Mobject paint requires the shared Rust authoring host")
-
-
 def install() -> None:
     """Install thin public adapters without creating a second playback engine."""
 
@@ -152,11 +131,6 @@ def install() -> None:
         setattr(_base, name, value)
 
     _compat._easing_from_rate_func = easing_from_rate_func
-
-    # Manim's set_color changes fill/stroke RGB while preserving each channel's
-    # independent opacity. This matters for Transform-style effects such as Indicate:
-    # a transparent stroke must not become visible while the color interpolates.
-    _base.Mobject.set_color = _set_color_preserving_opacity
 
     exports = list(_base.__all__)
     for name in public:

--- a/web/python/_manim_semantic_handles.py
+++ b/web/python/_manim_semantic_handles.py
@@ -145,7 +145,6 @@ def _manim_arrange(
 # Install compatibility placement before capturing fallbacks below. The generic
 # formulas use dynamic ``shift``/query dispatch, so after semantic-handle install
 # the same code mutates Rust/WASM-owned detached objects and ordinary scene objects.
-_base.Mobject.move_to = _manim_move_to
 _base.Mobject.next_to = _manim_next_to
 _base.Mobject.align_to = _manim_align_to
 _compat.Group.move_to = _manim_move_to
@@ -172,17 +171,13 @@ except ImportError:  # Native CPython tests install explicit bridge fixtures.
     _new_membership_batch = None
 
 _INSTALLED = False
-_ORIGINAL_SHIFT = _base.Mobject.shift
-_ORIGINAL_MOVE_TO = _base.Mobject.move_to
-_ORIGINAL_SCALE = _base.Mobject.scale
-_ORIGINAL_ROTATE = _base.Mobject.rotate
-_ORIGINAL_SET_COLOR = _base.Mobject.set_color
+_ORIGINAL_MOVE_TO = _manim_move_to
 _ORIGINAL_SET_OBJECT_OPACITY = _base.Mobject.set_object_opacity
 _ORIGINAL_NEXT_TO = _base.Mobject.next_to
 _ORIGINAL_ALIGN_TO = _base.Mobject.align_to
 _ORIGINAL_ALIGN_ON_FRAME = _base.Mobject._align_on_frame
-_ORIGINAL_BECOME = _base.Mobject.become
-_ORIGINAL_REPLACE = _base.Mobject.replace
+_ORIGINAL_BECOME = _compat._mobject_become
+_ORIGINAL_REPLACE = _compat._mobject_replace
 
 _ORIGINAL_GROUP_SHIFT = _compat.Group.shift
 _ORIGINAL_GROUP_MOVE_TO = _compat.Group.move_to
@@ -884,7 +879,7 @@ def _set_height_property(self: _base.Mobject, height: float) -> None:
 def _shift(self: _base.Mobject, direction: object) -> _base.Mobject:
     handle = _handle_for(self)
     if handle is None:
-        return _ORIGINAL_SHIFT(self, direction)
+        raise RuntimeError("Mobject edits require a current shared Rust semantic handle")
     offset = _base._as_vec2(direction)
     context = _live_mutation_context(self)
     if context is not None:
@@ -958,7 +953,7 @@ def _move_to(
 def _scale(self: _base.Mobject, factor: object) -> _base.Mobject:
     handle = _handle_for(self)
     if handle is None:
-        return _ORIGINAL_SCALE(self, factor)
+        raise RuntimeError("Mobject edits require a current shared Rust semantic handle")
     if isinstance(factor, (tuple, list, _base.Vec2)):
         value = _base._as_vec2(factor)
     else:
@@ -1002,14 +997,7 @@ def _rotate(
 
     handle = _handle_for(self)
     if handle is None:
-        return _ORIGINAL_ROTATE(
-            self,
-            angle,
-            axis,
-            about_point=about_point,
-            about_edge=about_edge,
-            **kwargs,
-        )
+        raise RuntimeError("Mobject edits require a current shared Rust semantic handle")
     context = _live_mutation_context(self)
     if context is not None:
         if kwargs or about_point is not None or about_edge is not None:
@@ -1042,7 +1030,7 @@ def _rotate(
 def _set_color(self: _base.Mobject, color: _base.Color) -> _base.Mobject:
     handle = _handle_for(self)
     if handle is None:
-        return _ORIGINAL_SET_COLOR(self, color)
+        raise RuntimeError("Mobject edits require a current shared Rust semantic handle")
     if not isinstance(color, _base.Color):
         raise TypeError("color must be a Color")
     live_context = _live_mutation_context(self)
@@ -1997,21 +1985,13 @@ def install() -> None:
     _INSTALLED = True
 
     _base.Mobject.__init__ = _init
-    _base.Mobject._current_raw = _current_raw
-    _base.Mobject._apply = _apply
     _base.Mobject.copy = _copy_mobject
     _base.Mobject.__deepcopy__ = _compat.deepcopy_semantic_wrapper
     _compat.Group.__deepcopy__ = _compat.deepcopy_semantic_wrapper
     _base.Mobject._copy_for_animate_target = _target_mobject
-    _base.Mobject.get_center = _get_center
     _base.Mobject.get_critical_point = _get_critical_point
     _base.Mobject.width = property(_width, _set_width_property)
     _base.Mobject.height = property(_height, _set_height_property)
-    _base.Mobject.shift = _shift
-    _base.Mobject.move_to = _move_to
-    _base.Mobject.scale = _scale
-    _base.Mobject.rotate = _rotate
-    _base.Mobject.set_color = _set_color
     _base.Mobject.set_object_opacity = _set_object_opacity
     _base.Mobject.become = _become
     _base.Mobject.replace = _replace

--- a/web/python/_manim_shared_geometry.py
+++ b/web/python/_manim_shared_geometry.py
@@ -556,8 +556,6 @@ def install() -> None:
         return
     _INSTALLED = True
     _base.Mobject.set_coord = _set_coord
-    _base.Mobject.set_x = _set_x
-    _base.Mobject.set_y = _set_y
     _base.Mobject.match_coord = _match_coord
     _base.Mobject.match_x = _match_x
     _base.Mobject.match_y = _match_y

--- a/web/python/_manim_updaters.py
+++ b/web/python/_manim_updaters.py
@@ -31,9 +31,9 @@ def _semantic_operations():
     return _manim_semantic_handles
 
 
-def _compat_operations():
-    import _manim_compat
-    return _manim_compat
+def _coordinate_operations():
+    import _manim_shared_geometry
+    return _manim_shared_geometry
 
 
 def _track(mobject: _base.Mobject) -> None:
@@ -985,18 +985,22 @@ def _canonical_move_to(self: _base.Mobject, point: object, *args: object, **kwar
     return _canonical_shift(self, _base._as_vec2(point) - row.center())
 
 
-def _canonical_set_x(self: _base.Mobject, x: float) -> _base.Mobject:
+def _canonical_set_x(self: _base.Mobject, x: float, direction: object = _base.ORIGIN) -> _base.Mobject:
     value = _canonical_row(self)
     if value is None:
-        return _compat_operations()._mobject_set_x(self, x)
+        return _coordinate_operations()._set_x(self, x, direction)
+    if _base._as_vec2(direction) != _base.ORIGIN:
+        raise NotImplementedError("callback coordinate placement supports center coordinates only")
     _, _, row = value
     return _canonical_shift(self, _base.Vec2(float(x) - row.center().x, 0.0))
 
 
-def _canonical_set_y(self: _base.Mobject, y: float) -> _base.Mobject:
+def _canonical_set_y(self: _base.Mobject, y: float, direction: object = _base.ORIGIN) -> _base.Mobject:
     value = _canonical_row(self)
     if value is None:
-        return _compat_operations()._mobject_set_y(self, y)
+        return _coordinate_operations()._set_y(self, y, direction)
+    if _base._as_vec2(direction) != _base.ORIGIN:
+        raise NotImplementedError("callback coordinate placement supports center coordinates only")
     _, _, row = value
     return _canonical_shift(self, _base.Vec2(0.0, float(y) - row.center().y))
 

--- a/web/python/_manim_updaters.py
+++ b/web/python/_manim_updaters.py
@@ -16,7 +16,6 @@ from typing import Any, Callable
 
 import noon as _base
 
-_INSTALLED = False
 _NEXT_SESSION_ID = 0
 _TRACKED_MOBJECTS: list[_base.Mobject] = []
 _CANONICAL_SESSIONS: dict[int, "_CanonicalCallbackSession"] = {}
@@ -25,23 +24,16 @@ _ACTIVE_CANONICAL_CONTEXT: ContextVar["_CanonicalCallbackContext | None"] = Cont
     "noon_active_canonical_callback", default=None
 )
 
-_ORIGINAL_CURRENT_RAW = _base.Mobject._current_raw
-_ORIGINAL_APPLY = _base.Mobject._apply
-_ORIGINAL_GET_CENTER = _base.Mobject.get_center
-_ORIGINAL_SHIFT = _base.Mobject.shift
-_ORIGINAL_MOVE_TO = _base.Mobject.move_to
-_ORIGINAL_SET_X = _base.Mobject.set_x
-_ORIGINAL_SET_Y = _base.Mobject.set_y
-_ORIGINAL_SCALE = _base.Mobject.scale
-_ORIGINAL_ROTATE = _base.Mobject.rotate
-_ORIGINAL_SET_COLOR = _base.Mobject.set_color
-_ORIGINAL_SET_FILL = _base.Mobject.set_fill
-_ORIGINAL_SET_STROKE = _base.Mobject.set_stroke
-_ORIGINAL_SET_OPACITY = _base.Mobject.set_opacity
-_ORIGINAL_VMOBJECT_SET_COLOR: Callable[..., _base.Mobject] | None = None
-_ORIGINAL_VMOBJECT_SET_FILL: Callable[..., _base.Mobject] | None = None
-_ORIGINAL_VMOBJECT_SET_STROKE: Callable[..., _base.Mobject] | None = None
-_ORIGINAL_VMOBJECT_SET_OPACITY: Callable[..., _base.Mobject] | None = None
+
+
+def _semantic_operations():
+    import _manim_semantic_handles
+    return _manim_semantic_handles
+
+
+def _compat_operations():
+    import _manim_compat
+    return _manim_compat
 
 
 def _track(mobject: _base.Mobject) -> None:
@@ -953,7 +945,7 @@ def _canonical_current_raw(self: _base.Mobject):
         raise NotImplementedError(
             "canonical callback raw geometry access is not supported; use property operations"
         )
-    return _ORIGINAL_CURRENT_RAW(self)
+    return _semantic_operations()._current_raw(self)
 
 
 def _canonical_apply(self: _base.Mobject, raw: object) -> _base.Mobject:
@@ -961,13 +953,13 @@ def _canonical_apply(self: _base.Mobject, raw: object) -> _base.Mobject:
         raise NotImplementedError(
             "canonical callbacks support property operations only; raw replacement is unsupported"
         )
-    return _ORIGINAL_APPLY(self, raw)
+    return _semantic_operations()._apply(self, raw)
 
 
 def _canonical_get_center(self: _base.Mobject) -> _base.Vec2:
     value = _canonical_row(self)
     if value is None:
-        return _ORIGINAL_GET_CENTER(self)
+        return _semantic_operations()._get_center(self)
     _, _, row = value
     return row.center()
 
@@ -975,7 +967,7 @@ def _canonical_get_center(self: _base.Mobject) -> _base.Vec2:
 def _canonical_shift(self: _base.Mobject, direction: object) -> _base.Mobject:
     value = _canonical_row(self)
     if value is None:
-        return _ORIGINAL_SHIFT(self, direction)
+        return _semantic_operations()._shift(self, direction)
     context, key, row = value
     before = row.transform
     row.shift(_base._as_vec2(direction))
@@ -986,7 +978,7 @@ def _canonical_shift(self: _base.Mobject, direction: object) -> _base.Mobject:
 def _canonical_move_to(self: _base.Mobject, point: object, *args: object, **kwargs: object) -> _base.Mobject:
     value = _canonical_row(self)
     if value is None:
-        return _ORIGINAL_MOVE_TO(self, point, *args, **kwargs)
+        return _semantic_operations()._move_to(self, point, *args, **kwargs)
     if args or kwargs:
         raise NotImplementedError("callback move_to currently supports center point placement only")
     _, _, row = value
@@ -996,7 +988,7 @@ def _canonical_move_to(self: _base.Mobject, point: object, *args: object, **kwar
 def _canonical_set_x(self: _base.Mobject, x: float) -> _base.Mobject:
     value = _canonical_row(self)
     if value is None:
-        return _ORIGINAL_SET_X(self, x)
+        return _compat_operations()._mobject_set_x(self, x)
     _, _, row = value
     return _canonical_shift(self, _base.Vec2(float(x) - row.center().x, 0.0))
 
@@ -1004,7 +996,7 @@ def _canonical_set_x(self: _base.Mobject, x: float) -> _base.Mobject:
 def _canonical_set_y(self: _base.Mobject, y: float) -> _base.Mobject:
     value = _canonical_row(self)
     if value is None:
-        return _ORIGINAL_SET_Y(self, y)
+        return _compat_operations()._mobject_set_y(self, y)
     _, _, row = value
     return _canonical_shift(self, _base.Vec2(0.0, float(y) - row.center().y))
 
@@ -1014,13 +1006,13 @@ def _canonical_scale(self: _base.Mobject, *args: object, **kwargs: object) -> _b
         raise NotImplementedError(
             "canonical callback scale is not supported; use shared semantic operations"
         )
-    return _ORIGINAL_SCALE(self, *args, **kwargs)
+    return _semantic_operations()._scale(self, *args, **kwargs)
 
 
 def _canonical_rotate(self: _base.Mobject, *args: object, **kwargs: object) -> _base.Mobject:
     value = _canonical_row(self)
     if value is None:
-        return _ORIGINAL_ROTATE(self, *args, **kwargs)
+        return _semantic_operations()._rotate(self, *args, **kwargs)
     context, key, row = value
     if not args or len(args) > 2:
         raise TypeError("canonical callback rotate expects angle and optional axis")
@@ -1052,7 +1044,7 @@ def _canonical_rotate(self: _base.Mobject, *args: object, **kwargs: object) -> _
 def _canonical_set_color(self: _base.Mobject, color: _base.Color) -> _base.Mobject:
     value = _canonical_row(self)
     if value is None:
-        return _ORIGINAL_SET_COLOR(self, color)
+        return _semantic_operations()._set_color(self, color)
     context, key, row = value
     color_value = _phase_color("set_color", color.to_ir())
     assert color_value is not None
@@ -1068,7 +1060,7 @@ def _canonical_set_fill(
 ) -> _base.Mobject:
     value = _canonical_row(self)
     if value is None:
-        return _ORIGINAL_SET_FILL(self, color, opacity)
+        return _semantic_operations()._set_fill(self, color, opacity)
     context, key, row = value
     before = row.style
     fill = None if color is None else _phase_color("set_fill", color.to_ir())
@@ -1085,7 +1077,7 @@ def _canonical_set_stroke(
 ) -> _base.Mobject:
     value = _canonical_row(self)
     if value is None:
-        return _ORIGINAL_SET_STROKE(self, color, width)
+        return _semantic_operations()._set_stroke(self, color, width)
     context, key, row = value
     if width is not None:
         raise NotImplementedError(
@@ -1109,7 +1101,7 @@ def _canonical_set_stroke(
 def _canonical_set_opacity(self: _base.Mobject, opacity: float) -> _base.Mobject:
     value = _canonical_row(self)
     if value is None:
-        return _ORIGINAL_SET_OPACITY(self, opacity)
+        return _semantic_operations()._set_object_opacity(self, opacity)
     context, key, row = value
     before = row.style
     row.style = replace(row.style, opacity=float(opacity))
@@ -1127,8 +1119,7 @@ def _canonical_vmobject_set_color(
         from _manim_compat import _as_color
 
         return _canonical_set_color(self, _as_color("color", color))
-    assert _ORIGINAL_VMOBJECT_SET_COLOR is not None
-    return _ORIGINAL_VMOBJECT_SET_COLOR(self, color, family=family)
+    return _semantic_operations()._set_vmobject_color(self, color, family=family)
 
 
 def _canonical_vmobject_set_fill(
@@ -1144,8 +1135,7 @@ def _canonical_vmobject_set_fill(
 
             color = _as_color("fill color", color)
         return _canonical_set_fill(self, color, opacity)
-    assert _ORIGINAL_VMOBJECT_SET_FILL is not None
-    return _ORIGINAL_VMOBJECT_SET_FILL(self, color=color, opacity=opacity, family=family)
+    return _semantic_operations()._set_fill(self, color=color, opacity=opacity, family=family)
 
 
 def _canonical_vmobject_set_stroke(
@@ -1166,8 +1156,7 @@ def _canonical_vmobject_set_stroke(
 
             color = _as_color("stroke color", color)
         return _canonical_set_stroke(self, color, width)
-    assert _ORIGINAL_VMOBJECT_SET_STROKE is not None
-    return _ORIGINAL_VMOBJECT_SET_STROKE(
+    return _semantic_operations()._set_stroke(
         self, color=color, width=width, opacity=opacity, family=family
     )
 
@@ -1182,8 +1171,7 @@ def _canonical_vmobject_set_opacity(
         from _manim_compat import _opacity
 
         return _canonical_set_opacity(self, _opacity("opacity", opacity))
-    assert _ORIGINAL_VMOBJECT_SET_OPACITY is not None
-    return _ORIGINAL_VMOBJECT_SET_OPACITY(self, opacity, family=family)
+    return _semantic_operations()._set_opacity(self, opacity, family=family)
 
 
 async def prepare_canonical_callback_phase(session_id: int, frame: dict[str, Any]):
@@ -1268,51 +1256,3 @@ def _json_phase(value: object) -> str:
 
 def release_session(session_id: int) -> None:
     _CANONICAL_SESSIONS.pop(int(session_id), None)
-
-
-def install() -> None:
-    global _INSTALLED
-    if _INSTALLED:
-        return
-    _base.Mobject.add_updater = add_updater
-    _base.Mobject.remove_updater = remove_updater
-    _base.Mobject.clear_updaters = clear_updaters
-    _base.Mobject.get_updaters = get_updaters
-    _base.Mobject.has_updaters = has_updaters
-    _base.Mobject._current_raw = _canonical_current_raw
-    _base.Mobject._apply = _canonical_apply
-    _base.Mobject.get_center = _canonical_get_center
-    _base.Mobject.shift = _canonical_shift
-    _base.Mobject.move_to = _canonical_move_to
-    _base.Mobject.set_x = _canonical_set_x
-    _base.Mobject.set_y = _canonical_set_y
-    _base.Mobject.scale = _canonical_scale
-    _base.Mobject.rotate = _canonical_rotate
-    _base.Mobject.set_color = _canonical_set_color
-    _base.Mobject.set_fill = _canonical_set_fill
-    _base.Mobject.set_stroke = _canonical_set_stroke
-    _base.Mobject.set_opacity = _canonical_set_opacity
-    # Semantic-handle installation gives VMobject its own final public style
-    # methods. Reinstall the phase dispatch at that public boundary so it cannot
-    # fall through to raw snapshot mutation while a canonical callback is active.
-    import _manim_compat as _compat
-
-    global _ORIGINAL_VMOBJECT_SET_COLOR
-    global _ORIGINAL_VMOBJECT_SET_FILL
-    global _ORIGINAL_VMOBJECT_SET_STROKE
-    global _ORIGINAL_VMOBJECT_SET_OPACITY
-    # Inherited methods already use the Mobject phase dispatcher above. Wrap
-    # only VMobject's own overrides, preserving the inherited base signatures.
-    if "set_color" in _compat.VMobject.__dict__:
-        _ORIGINAL_VMOBJECT_SET_COLOR = _compat.VMobject.set_color
-        _compat.VMobject.set_color = _canonical_vmobject_set_color
-    if "set_fill" in _compat.VMobject.__dict__:
-        _ORIGINAL_VMOBJECT_SET_FILL = _compat.VMobject.set_fill
-        _compat.VMobject.set_fill = _canonical_vmobject_set_fill
-    if "set_stroke" in _compat.VMobject.__dict__:
-        _ORIGINAL_VMOBJECT_SET_STROKE = _compat.VMobject.set_stroke
-        _compat.VMobject.set_stroke = _canonical_vmobject_set_stroke
-    if "set_opacity" in _compat.VMobject.__dict__:
-        _ORIGINAL_VMOBJECT_SET_OPACITY = _compat.VMobject.set_opacity
-        _compat.VMobject.set_opacity = _canonical_vmobject_set_opacity
-    _INSTALLED = True

--- a/web/python/noon.py
+++ b/web/python/noon.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import json
 import math
 from dataclasses import dataclass
-from typing import Any, Iterable, Iterator
+from typing import Any, Callable, Iterable, Iterator
 
 import _noon_ir as _ir
 
@@ -195,6 +195,12 @@ GRAY_E = GREY_E = _hex_color(0x222222)
 GRAY = GREY = GRAY_C
 
 
+def _callback_operations():
+    # The adapter selects a staged callback view or the normal semantic handle.
+    import _manim_updaters
+    return _manim_updaters
+
+
 class Mobject:
     """Python identity wrapper; shared Rust handles own all semantic state."""
 
@@ -234,14 +240,14 @@ class Mobject:
     def _bind_to_scene(self, scene: Scene, *, key: str | None = None) -> _ir.Object:
         return _scene_operations()._bind_mobject(self, scene, key=key)
 
-    def _current_raw(self) -> _ir.Mobject:
-        raise RuntimeError("Mobject queries require the shared Rust authoring host")
+    def _current_raw(self):
+        return _callback_operations()._canonical_current_raw(self)
 
-    def _apply(self, raw: _ir.Mobject) -> Mobject:
-        raise NotImplementedError("raw replacement is unsupported; use a shared semantic operation")
+    def _apply(self, raw: object) -> Mobject:
+        return _callback_operations()._canonical_apply(self, raw)
 
     def get_center(self) -> Vec2:
-        raise RuntimeError("Mobject layout requires the shared Rust authoring host")
+        return _callback_operations()._canonical_get_center(self)
 
     @property
     def width(self) -> float:
@@ -251,42 +257,38 @@ class Mobject:
     def height(self) -> float:
         raise RuntimeError("Mobject layout requires the shared Rust authoring host")
 
-    def shift(self, direction: Vec2 | tuple[float, float]) -> Mobject:
-        raise RuntimeError("Mobject edits require the shared Rust authoring host")
+    def shift(self, direction: object) -> Mobject:
+        return _callback_operations()._canonical_shift(self, direction)
 
-    def move_to(self, point: Vec2 | tuple[float, float]) -> Mobject:
-        return self.shift(_as_vec2(point) - self.get_center())
+    def move_to(self, point: object, *args: object, **kwargs: object) -> Mobject:
+        return _callback_operations()._canonical_move_to(self, point, *args, **kwargs)
 
     def center(self) -> Mobject:
         return self.move_to(ORIGIN)
 
     def set_x(self, x: float) -> Mobject:
-        center = self.get_center()
-        return self.shift(Vec2(float(x) - center.x, 0.0))
+        return _callback_operations()._canonical_set_x(self, x)
 
     def set_y(self, y: float) -> Mobject:
-        center = self.get_center()
-        return self.shift(Vec2(0.0, float(y) - center.y))
+        return _callback_operations()._canonical_set_y(self, y)
 
-    def scale(self, factor: float | tuple[float, float]) -> Mobject:
-        raise RuntimeError("Mobject edits require the shared Rust authoring host")
+    def scale(self, *args: object, **kwargs: object) -> Mobject:
+        return _callback_operations()._canonical_scale(self, *args, **kwargs)
 
-    def rotate(self, angle: float) -> Mobject:
-        raise RuntimeError("Mobject edits require the shared Rust authoring host")
+    def rotate(self, *args: object, **kwargs: object) -> Mobject:
+        return _callback_operations()._canonical_rotate(self, *args, **kwargs)
 
     def set_color(self, color: Color) -> Mobject:
-        raise RuntimeError("Mobject edits require the shared Rust authoring host")
+        return _callback_operations()._canonical_set_color(self, color)
 
     def set_fill(self, color: Color | None = None, opacity: float | None = None) -> Mobject:
-        raise RuntimeError("Mobject edits require the shared Rust authoring host")
+        return _callback_operations()._canonical_set_fill(self, color, opacity)
 
-    def set_stroke(
-        self, color: Color | None = None, width: float | None = None
-    ) -> Mobject:
-        raise RuntimeError("Mobject edits require the shared Rust authoring host")
+    def set_stroke(self, color: Color | None = None, width: float | None = None) -> Mobject:
+        return _callback_operations()._canonical_set_stroke(self, color, width)
 
     def set_opacity(self, opacity: float) -> Mobject:
-        raise RuntimeError("Mobject edits require the shared Rust authoring host")
+        return _callback_operations()._canonical_set_opacity(self, opacity)
 
     def set_object_opacity(self, opacity: float) -> Mobject:
         """Set Noon's object-composite opacity independently of paint opacity.
@@ -335,6 +337,22 @@ class Mobject:
     @property
     def animate(self) -> _AnimationBuilder:
         return _AnimationBuilder(self)
+
+
+    def add_updater(self, update_function: Callable[..., Any], index: int | None = None, call_updater: bool = False) -> Mobject:
+        return _callback_operations().add_updater(self, update_function, index, call_updater)
+
+    def remove_updater(self, update_function: Callable[..., Any]) -> Mobject:
+        return _callback_operations().remove_updater(self, update_function)
+
+    def clear_updaters(self, recursive: bool = True) -> Mobject:
+        return _callback_operations().clear_updaters(self, recursive)
+
+    def get_updaters(self) -> list[Callable[..., Any]]:
+        return _callback_operations().get_updaters(self)
+
+    def has_updaters(self) -> bool:
+        return _callback_operations().has_updaters(self)
 
 
 class Group:

--- a/web/python/noon.py
+++ b/web/python/noon.py
@@ -266,11 +266,11 @@ class Mobject:
     def center(self) -> Mobject:
         return self.move_to(ORIGIN)
 
-    def set_x(self, x: float) -> Mobject:
-        return _callback_operations()._canonical_set_x(self, x)
+    def set_x(self, x: float, direction: object = ORIGIN) -> Mobject:
+        return _callback_operations()._canonical_set_x(self, x, direction)
 
-    def set_y(self, y: float) -> Mobject:
-        return _callback_operations()._canonical_set_y(self, y)
+    def set_y(self, y: float, direction: object = ORIGIN) -> Mobject:
+        return _callback_operations()._canonical_set_y(self, y, direction)
 
     def scale(self, *args: object, **kwargs: object) -> Mobject:
         return _callback_operations()._canonical_scale(self, *args, **kwargs)

--- a/web/python/test_canonical_line_match.py
+++ b/web/python/test_canonical_line_match.py
@@ -50,7 +50,7 @@ class CanonicalLineMatchTests(unittest.TestCase):
             assert manim.Line.__init__.__module__ == "_manim_compat"
             import _manim_geometry  # installs match_points
             import _manim_updaters as updaters
-            updaters.install()
+
 
             line = manim.Line((-1.0, 0.0), (1.0, 0.0))
             assert len(allocations) == 1, len(allocations)

--- a/web/python/test_manim_rotating_animation.py
+++ b/web/python/test_manim_rotating_animation.py
@@ -50,7 +50,7 @@ class ManimRotatingAnimationTests(unittest.TestCase):
             assert edge.about_point is None and edge.about_edge is RIGHT
             assert edge.anim_args["run_time"] == 2.0
             import _manim_updaters
-            _manim_updaters.install()
+
             import noon
             assert noon.Rotating is Rotating
             from noon import Group, Rotate

--- a/web/python/test_manim_shared_object_observations.py
+++ b/web/python/test_manim_shared_object_observations.py
@@ -172,7 +172,7 @@ class ManimSharedObjectObservationTests(unittest.TestCase):
             original_set_color = handles._set_color
             handles._set_color = lambda target, color: calls.append((target, color)) or target
             try:
-                assert rate_functions._set_color_preserving_opacity(line, BLUE) is line
+                assert line.set_color(BLUE) is line
             finally:
                 handles._set_color = original_set_color
             assert calls == [(line, BLUE)]

--- a/web/python/test_moving_dots_primitives.py
+++ b/web/python/test_moving_dots_primitives.py
@@ -34,7 +34,6 @@ class MovingDotsPrimitiveTests(unittest.TestCase):
             import _manim_updaters as updaters
             import noon as api
 
-            updaters.install()
 
             # Read the pinned callback view during the ordered phase and the
             # shared published value afterwards; Python owns neither value.

--- a/web/python/test_updater_snapshot.py
+++ b/web/python/test_updater_snapshot.py
@@ -52,14 +52,10 @@ class CanonicalCallbackPropertyRowTests(unittest.TestCase):
     def _mobject_and_context() -> tuple[object, object, object]:
         compat.install()
         install_test_membership(compat)
-        import _manim_semantic_handles as semantic_handles
+        # Public paint methods always enter the phase dispatcher; no final
+        # installer is needed to reclaim VMobject's overrides.
+        assert not hasattr(updaters, "install")
 
-        if not updaters._INSTALLED:
-            # Mirror the production final method that otherwise bypasses the
-            # base Mobject patch. Updater installation must reclaim it.
-
-            compat.VMobject.set_opacity = semantic_handles._set_opacity
-            updaters.install()
         scene = updaters._base.Scene()
         mobject = identity_only_wrapper(compat.Circle)
         scene.add(mobject)
@@ -287,7 +283,7 @@ class CanonicalCallbackPropertyRowTests(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             updaters._canonical_callback_time(mobject)
 
-        self.assertIs(compat.VMobject.set_opacity, updaters._canonical_vmobject_set_opacity)
+        self.assertEqual(compat.VMobject.set_opacity.__module__, "_manim_compat")
         self.assertEqual(
             [write["kind"] for write in writes],
             ["transform", "style", "style", "transform"],

--- a/web/python/test_updater_snapshot.py
+++ b/web/python/test_updater_snapshot.py
@@ -36,7 +36,11 @@ class CanonicalCallbackPropertyRowTests(unittest.TestCase):
         scene, mobject, context = self._mobject_and_context()
         public_set_x = updaters._base.Mobject.set_x
         public_set_y = updaters._base.Mobject.set_y
+        public_set_color = updaters._base.Mobject.set_color
+        import _manim_rate_functions as rates
+        rates.install()
         geometry.install()
+        self.assertIs(updaters._base.Mobject.set_color, public_set_color)
         self.assertIs(updaters._base.Mobject.set_x, public_set_x)
         self.assertIs(updaters._base.Mobject.set_y, public_set_y)
         updaters._ACTIVE_CONTEXTS[id(scene)] = context

--- a/web/python/test_updater_snapshot.py
+++ b/web/python/test_updater_snapshot.py
@@ -30,6 +30,23 @@ def _object(index: int) -> dict:
 
 
 class CanonicalCallbackPropertyRowTests(unittest.TestCase):
+    def test_geometry_adapter_keeps_coordinate_writes_in_callback_phase(self) -> None:
+        import _manim_shared_geometry as geometry
+
+        scene, mobject, context = self._mobject_and_context()
+        public_set_x = updaters._base.Mobject.set_x
+        public_set_y = updaters._base.Mobject.set_y
+        geometry.install()
+        self.assertIs(updaters._base.Mobject.set_x, public_set_x)
+        self.assertIs(updaters._base.Mobject.set_y, public_set_y)
+        updaters._ACTIVE_CONTEXTS[id(scene)] = context
+        try:
+            self.assertIs(mobject.set_x(5.0).set_y(4.0), mobject)
+            self.assertEqual(mobject.get_center(), updaters._base.Vec2(5.0, 4.0))
+            self.assertTrue(context.effective_batch()["writes"])
+        finally:
+            updaters._ACTIVE_CONTEXTS.pop(id(scene), None)
+
     def test_style_wire_uses_rust_default_and_preserves_explicit_mode(self) -> None:
         omitted_default = _object(0)["style"]
         self.assertNotIn("stroke_width_mode", omitted_default)


### PR DESCRIPTION
Callback behavior depended on a final installer replacing Mobject/VMobject methods and capturing the methods installed earlier. Public methods now enter the callback adapter directly. An active callback uses its existing staged property view; otherwise the adapter calls the concrete shared semantic helper. Delete the callback installer and all of its captured-method globals, and remove earlier assignments that would override the stable facade.

Advances #61 A3.6/A3.7. The existing Rust callback ordering, registration, effective batch, and publication protocol are unchanged; Python still owns callable identity and invocation. No new scene, scheduler, mutation protocol, serialization boundary, or migration seam is introduced. Dispatch checks are constant-time; operations retain their existing locality. The semantic-handle installer still owns constructor/layout setup and is tracked by #61 for the next deletion.

Validation: `NOON_WEB_PREFLIGHT_ONLY=1 bash scripts/build-web-demo.sh` passed (145 Python tests, all frontend checks); `bash scripts/check-architecture.sh` and `python3 scripts/semantic_ownership_check.py` passed. All 17 callback tests now run without an installer, including ordered writes, sparse reads, paint operations, copying callback-bound targets, and rejection before mutation. Existing ordinary affine/callback/paint paired Rust/Python examples qualify through hosted full browser CI. No local Rust/WASM build due to disk constraints.
