### PR TITLE
Make Python semantic and callback facade explicit

### DIFF
--- a/compat/semantic-ownership-v1.json
+++ b/compat/semantic-ownership-v1.json
@@ -11,6 +11,7 @@
   "duplicate_debt_budgets": [
     {"path": "web/python/noon.py", "token": "def _bounds(", "maximum": 0, "migration_issue": "#61"},
     {"path": "web/python/noon.py", "token": "def _raw_mobject(", "maximum": 0, "migration_issue": "#61"},
+    {"path": "web/python/_manim_semantic_handles.py", "token": "_ORIGINAL_", "maximum": 0, "migration_issue": "#61"},
     {"path": "web/python/_manim_semantic_handles.py", "token": "_ORIGINAL_CURRENT_RAW", "maximum": 0, "migration_issue": "#61"},
     {"path": "web/python/_manim_geometry.py", "token": "_legacy_world_point", "maximum": 0, "migration_issue": "#61"},
     {"path": "web/python/_noon_ir.py", "token": "class Scene", "maximum": 0, "migration_issue": "#61"},

--- a/compat/semantic-ownership-v1.json
+++ b/compat/semantic-ownership-v1.json
@@ -51,6 +51,7 @@
     {"path": "web/python/_manim_rotate.py", "token": "_snapshot_for_object_at", "maximum": 0, "migration_issue": "#61"},
     {"path": "web/python/_manim_semantic_handles.py", "token": "copy.deepcopy", "maximum": 1, "migration_issue": "#61"},
     {"path": "web/python/_manim_semantic_handles.py", "token": "_ir.Mobject(", "maximum": 1, "migration_issue": "#61"},
+    {"path": "web/python/_manim_updaters.py", "token": "_ORIGINAL_", "maximum": 0, "migration_issue": "#61"},
     {"path": "web/python/_manim_updaters.py", "token": "copy.deepcopy", "maximum": 0, "migration_issue": "#61"},
     {"path": "web/python/_manim_updaters.py", "token": "_ir.Mobject(", "maximum": 0, "migration_issue": "#61"},
     {"path": "web/python/_noon_ir.py", "token": "copy.deepcopy", "maximum": 4, "migration_issue": "#61"},

--- a/web/manim-mobject-layout-ownership.test.mjs
+++ b/web/manim-mobject-layout-ownership.test.mjs
@@ -38,19 +38,15 @@ test("detached Mobject layout queries stay owned by the shared semantic handle",
   assert.match(height, /handle\.height/);
 
   assert.match(facadeSource, /return _callback_operations\(\)\._canonical_get_center\(self\)/);
-  assert.match(callbackSource, /return _semantic_operations\(\)\._get_center\(self\)/);
+  assert.match(callbackSource, /return _base\._semantic_operations\(\)\._get_center\(self\)/);
   assert.doesNotMatch(callbackSource, /def install\(|_ORIGINAL_/);
 
-  assert.match(
-    semanticHandlesSource,
-    /_base\.Mobject\.width = property\(_width, _set_width_property\)/,
-    "install() must keep width on the semantic-handle adapter",
-  );
-  assert.match(
-    semanticHandlesSource,
-    /_base\.Mobject\.height = property\(_height, _set_height_property\)/,
-    "install() must keep height on the semantic-handle adapter",
-  );
+  for (const property of ["width", "height"]) {
+    assert.ok(facadeSource.includes(`return _semantic_operations()._${property}(self)`));
+    assert.ok(facadeSource.includes(`_semantic_operations()._set_${property}_property(self, value)`));
+  }
+  assert.doesNotMatch(semanticHandlesSource, /def install\(|_ORIGINAL_|^_base\.Mobject\.[a-z_]+ =/m);
+
 });
 
 test("Rust semantic handle remains the layout-query source of truth", () => {

--- a/web/manim-mobject-layout-ownership.test.mjs
+++ b/web/manim-mobject-layout-ownership.test.mjs
@@ -6,6 +6,8 @@ const semanticHandlesSource = readFileSync(
   new URL("./python/_manim_semantic_handles.py", import.meta.url),
   "utf8",
 );
+const facadeSource = readFileSync(new URL("./python/noon.py", import.meta.url), "utf8");
+const callbackSource = readFileSync(new URL("./python/_manim_updaters.py", import.meta.url), "utf8");
 const rustHandleSource = readFileSync(
   new URL("../crates/noon/src/semantic_mobject.rs", import.meta.url),
   "utf8",
@@ -35,11 +37,10 @@ test("detached Mobject layout queries stay owned by the shared semantic handle",
   const height = functionBody(semanticHandlesSource, "_height", "_set_width_property");
   assert.match(height, /handle\.height/);
 
-  assert.match(
-    semanticHandlesSource,
-    /_base\.Mobject\.get_center = _get_center/,
-    "install() must keep get_center on the semantic-handle adapter",
-  );
+  assert.match(facadeSource, /return _callback_operations\(\)\._canonical_get_center\(self\)/);
+  assert.match(callbackSource, /return _semantic_operations\(\)\._get_center\(self\)/);
+  assert.doesNotMatch(callbackSource, /def install\(|_ORIGINAL_/);
+
   assert.match(
     semanticHandlesSource,
     /_base\.Mobject\.width = property\(_width, _set_width_property\)/,

--- a/web/python-worker.source.js
+++ b/web/python-worker.source.js
@@ -170,7 +170,7 @@ import _manim_indication
 _manim_indication.install()
 import _manim_reactive
 import _manim_updaters
-_manim_updaters.install()
+
 import _manim_camera
 _manim_camera.install()
 `);

--- a/web/python-worker.source.js
+++ b/web/python-worker.source.js
@@ -148,7 +148,7 @@ import _manim_rate_functions
 _manim_rate_functions.install()
 import _manim_geometry
 import _manim_semantic_handles
-_manim_semantic_handles.install()
+
 import _manim_shared_geometry
 _manim_shared_geometry.install()
 import _manim_dashed_line

--- a/web/python/_manim_compat.py
+++ b/web/python/_manim_compat.py
@@ -14,7 +14,6 @@ import noon as _base
 
 _BaseMobject = _base.Mobject
 _BaseScene = _base.Scene
-_NATIVE_MOBJECT_ROTATE = _BaseMobject.rotate
 _ir = _base._ir
 
 OUT = (0.0, 0.0, 1.0)
@@ -131,7 +130,13 @@ class VMobject(_BaseMobject):
         from _manim_updaters import _canonical_vmobject_set_fill
         return _canonical_vmobject_set_fill(self, color=color, opacity=opacity, family=family)
 
-    def set_stroke(self, color: object = None, width: float | None = None, opacity: float | None = None, family: bool = True) -> VMobject:
+    def set_stroke(
+        self,
+        color: object = None,
+        width: float | None = None,
+        opacity: float | None = None,
+        family: bool = True,
+    ) -> VMobject:
         from _manim_updaters import _canonical_vmobject_set_stroke
         return _canonical_vmobject_set_stroke(self, color=color, width=width, opacity=opacity, family=family)
 
@@ -222,7 +227,7 @@ def _leaf_mobjects(value: object) -> list[_BaseMobject]:
 
 
 def _bounds_for(value: object) -> tuple[_base.Vec2, _base.Vec2] | None:
-    raise RuntimeError("family layout requires the shared Rust authoring host")
+    return _base._semantic_operations()._compat_bounds_for(value)
 
 
 def _critical_for(value: object, direction: _base.Vec2) -> _base.Vec2:
@@ -258,34 +263,6 @@ def _rotation_angle_2d(angle: float, axis: object = OUT) -> float:
     return -value if z < 0.0 else value
 
 
-def _mobject_rotate(
-    self: _BaseMobject,
-    angle: float,
-    axis: object = OUT,
-    *,
-    about_point: object | None = None,
-    about_edge: object | None = None,
-    **kwargs: Any,
-) -> _BaseMobject:
-    if kwargs:
-        unsupported = ", ".join(sorted(kwargs))
-        raise NotImplementedError(f"unsupported Manim rotate option(s): {unsupported}")
-    signed_angle = _rotation_angle_2d(angle, axis)
-    if about_point is not None:
-        pivot = _as_vec2(about_point)
-    else:
-        edge = _base.ORIGIN if about_edge is None else _as_vec2(about_edge)
-        pivot = self.get_critical_point(edge)
-    center = self.get_center()
-    relative = center - pivot
-    cosine = math.cos(signed_angle)
-    sine = math.sin(signed_angle)
-    target_center = pivot + _base.Vec2(
-        relative.x * cosine - relative.y * sine,
-        relative.x * sine + relative.y * cosine,
-    )
-    _NATIVE_MOBJECT_ROTATE(self, signed_angle)
-    return self.move_to(target_center)
 
 
 class _GroupAnimationBuilder:
@@ -375,13 +352,15 @@ class Group(_base.Group, _BaseMobject):
         return 0.0 if bounds is None else bounds[1].y - bounds[0].y
 
     def shift(self, direction: object) -> Group:
-        offset = _as_vec2(direction)
-        for member in self.submobjects:
-            member.shift(offset)
-        return self
+        return _base._semantic_operations()._group_shift(self, direction)
 
-    def move_to(self, point: object) -> Group:
-        return self.shift(_as_vec2(point) - self.get_center())
+    def move_to(
+        self,
+        point_or_mobject: object,
+        aligned_edge: object = _base.ORIGIN,
+        coor_mask: object = (1.0, 1.0, 1.0),
+    ) -> Group:
+        return _base._semantic_operations()._group_move_to(self, point_or_mobject, aligned_edge, coor_mask)
 
     def center(self) -> Group:
         return self.move_to(_base.ORIGIN)
@@ -429,21 +408,18 @@ class Group(_base.Group, _BaseMobject):
 
     def next_to(
         self,
-        other: object,
-        direction: object = None,
+        mobject_or_point: object,
+        direction: object = _base.RIGHT,
         buff: float = _base.DEFAULT_MOBJECT_TO_MOBJECT_BUFFER,
-    ) -> Group:
-        axis = _as_vec2(_base.RIGHT if direction is None else direction).normalized()
-        self_point = _critical_for(self, -axis)
-        target_point = _critical_for(other, axis) if isinstance(other, (_BaseMobject, Group)) else _as_vec2(other)
-        return self.shift(target_point - self_point + axis * float(buff))
+        aligned_edge: object = _base.ORIGIN,
+        submobject_to_align: object | None = None,
+        index_of_submobject_to_align: int | None = None,
+        coor_mask: object = (1.0, 1.0, 1.0),
+    ) -> _base.Mobject | Group:
+        return _base._semantic_operations()._next_to(self, mobject_or_point, direction, buff, aligned_edge, submobject_to_align, index_of_submobject_to_align, coor_mask)
 
-    def align_to(self, other: object, direction: object = None) -> Group:
-        axis = _as_vec2(_base.ORIGIN if direction is None else direction)
-        delta = _critical_for(other, axis) - _critical_for(self, axis)
-        return self.shift(
-            _base.Vec2(delta.x if axis.x else 0.0, delta.y if axis.y else 0.0)
-        )
+    def align_to(self, mobject_or_point: object, direction: object = _base.ORIGIN) -> Group:
+        return _base._semantic_operations()._group_align_to(self, mobject_or_point, direction)
 
     def to_edge(
         self,
@@ -478,18 +454,12 @@ class Group(_base.Group, _BaseMobject):
 
     def arrange(
         self,
-        direction: object = None,
+        direction: object = _base.RIGHT,
         buff: float = _base.DEFAULT_MOBJECT_TO_MOBJECT_BUFFER,
         center: bool = True,
+        **kwargs: Any,
     ) -> Group:
-        if not self.submobjects:
-            return self
-        axis = _as_vec2(_base.RIGHT if direction is None else direction)
-        for previous, current in zip(self.submobjects, self.submobjects[1:]):
-            current.next_to(previous, axis, buff)
-        if center:
-            self.shift(-self.get_center())
-        return self
+        return _base._semantic_operations()._group_arrange(self, direction, buff, center, **kwargs)
 
     def arrange_in_grid(
         self,
@@ -503,6 +473,12 @@ class Group(_base.Group, _BaseMobject):
     @property
     def animate(self) -> _GroupAnimationBuilder:
         return _GroupAnimationBuilder(self)
+
+    def _copy_for_animate_target(self) -> Group:
+        return _base._semantic_operations()._group_copy(self)
+
+    def __deepcopy__(self, memo):
+        return deepcopy_semantic_wrapper(self, memo)
 
 
 class VGroup(Group):
@@ -568,10 +544,6 @@ class Scene(_BaseScene):
 
 
 
-def _mobject_get_critical_point(
-    self: _BaseMobject, direction: object
-) -> _base.Vec2:
-    return _critical_for(self, _as_vec2(direction))
 
 
 def _mobject_get_edge_center(self: _BaseMobject, direction: object) -> _base.Vec2:
@@ -739,15 +711,20 @@ def _mobject_rotate_about_origin(
     )
 
 
-def _set_width_property(self: _BaseMobject, width: float) -> None:
-    self.scale_to_fit_width(float(width))
 
 
-def _set_height_property(self: _BaseMobject, height: float) -> None:
-    self.scale_to_fit_height(float(height))
 
 
-def _state_target(self: _BaseMobject, mobject: _BaseMobject, *, match_height: bool, match_width: bool, match_depth: bool, match_center: bool, stretch: bool) -> _BaseMobject:
+def _state_target(
+    self: _BaseMobject,
+    mobject: _BaseMobject,
+    *,
+    match_height: bool,
+    match_width: bool,
+    match_depth: bool,
+    match_center: bool,
+    stretch: bool,
+) -> _BaseMobject:
     if not isinstance(mobject, _BaseMobject):
         raise TypeError("state target must be a Mobject")
     if match_depth:
@@ -886,7 +863,6 @@ def install() -> None:
     # so replacing that helper makes inherited transforms/layout accept z=0 vectors.
     _base._as_vec2 = _as_vec2
     _BaseMobject.animate = property(lambda self: _CompatAnimationBuilder(self))
-    _BaseMobject.get_critical_point = _mobject_get_critical_point
     _BaseMobject.get_edge_center = _mobject_get_edge_center
     _BaseMobject.get_corner = _mobject_get_corner
     _BaseMobject.get_left = _mobject_get_left
@@ -909,13 +885,9 @@ def install() -> None:
     _BaseMobject.match_x = _mobject_match_x
     _BaseMobject.match_y = _mobject_match_y
     _BaseMobject.rotate_about_origin = _mobject_rotate_about_origin
-    _BaseMobject.width = property(_BaseMobject.width.fget, _set_width_property)
-    _BaseMobject.height = property(_BaseMobject.height.fget, _set_height_property)
     _BaseMobject.generate_target = _mobject_generate_target
     _BaseMobject.save_state = _mobject_save_state
     _BaseMobject.restore = _mobject_restore
-    _BaseMobject.become = _mobject_become
-    _BaseMobject.replace = _mobject_replace
 
     public = {
         "VMobject": VMobject,
@@ -992,3 +964,12 @@ def copy_wrapper_attributes(source, target, memo=None, excluded=()):
     for name, value in source.__dict__.items():
         if name not in excluded:
             setattr(target, name, copy.deepcopy(value, memo))
+
+
+def _shift_group_members(self: Group, direction: object) -> Group:
+    # Existing per-member callback fallback; shared callback family operations
+    # in #955 own its retirement. Ordinary typed family shifts stay in Rust.
+    offset = _as_vec2(direction)
+    for member in self.submobjects:
+        member.shift(offset)
+    return self

--- a/web/python/_manim_compat.py
+++ b/web/python/_manim_compat.py
@@ -124,20 +124,20 @@ class VMobject(_BaseMobject):
         return _copy_mobject(self)
 
     def set_color(self, color: object, family: bool = True) -> VMobject:
-        from _manim_semantic_handles import _set_vmobject_color
-        return _set_vmobject_color(self, color, family=family)
+        from _manim_updaters import _canonical_vmobject_set_color
+        return _canonical_vmobject_set_color(self, color, family=family)
 
     def set_fill(self, color: object = None, opacity: float | None = None, family: bool = True) -> VMobject:
-        from _manim_semantic_handles import _set_fill
-        return _set_fill(self, color=color, opacity=opacity, family=family)
+        from _manim_updaters import _canonical_vmobject_set_fill
+        return _canonical_vmobject_set_fill(self, color=color, opacity=opacity, family=family)
 
     def set_stroke(self, color: object = None, width: float | None = None, opacity: float | None = None, family: bool = True) -> VMobject:
-        from _manim_semantic_handles import _set_stroke
-        return _set_stroke(self, color=color, width=width, opacity=opacity, family=family)
+        from _manim_updaters import _canonical_vmobject_set_stroke
+        return _canonical_vmobject_set_stroke(self, color=color, width=width, opacity=opacity, family=family)
 
     def set_opacity(self, opacity: float, family: bool = True) -> VMobject:
-        from _manim_semantic_handles import _set_opacity
-        return _set_opacity(self, opacity, family=family)
+        from _manim_updaters import _canonical_vmobject_set_opacity
+        return _canonical_vmobject_set_opacity(self, opacity, family=family)
 
     def get_fill_opacity(self) -> float:
         from _manim_semantic_handles import _get_fill_opacity
@@ -897,8 +897,6 @@ def install() -> None:
     _BaseMobject.get_x = _mobject_get_x
     _BaseMobject.get_y = _mobject_get_y
     _BaseMobject.set_coord = _mobject_set_coord
-    _BaseMobject.set_x = _mobject_set_x
-    _BaseMobject.set_y = _mobject_set_y
     _BaseMobject.rescale_to_fit = _mobject_rescale_to_fit
     _BaseMobject.scale_to_fit_width = _mobject_scale_to_fit_width
     _BaseMobject.scale_to_fit_height = _mobject_scale_to_fit_height
@@ -910,7 +908,6 @@ def install() -> None:
     _BaseMobject.match_coord = _mobject_match_coord
     _BaseMobject.match_x = _mobject_match_x
     _BaseMobject.match_y = _mobject_match_y
-    _BaseMobject.rotate = _mobject_rotate
     _BaseMobject.rotate_about_origin = _mobject_rotate_about_origin
     _BaseMobject.width = property(_BaseMobject.width.fget, _set_width_property)
     _BaseMobject.height = property(_BaseMobject.height.fget, _set_height_property)

--- a/web/python/_manim_geometry.py
+++ b/web/python/_manim_geometry.py
@@ -250,10 +250,6 @@ class ApplyMethod:
         return builder
 
 
-def _bounds_for(value: object) -> tuple[_base.Vec2, _base.Vec2] | None:
-    raise RuntimeError("family layout requires the shared Rust authoring host")
-
-
 def match_points(self: _base.Mobject, mobject: object) -> _base.Mobject:
     if not isinstance(self, _compat.Line) or not isinstance(mobject, _compat.Line):
         raise NotImplementedError(
@@ -316,9 +312,6 @@ def install() -> None:
     _base.Mobject.get_color = _mobject_get_color
     _compat.Group.get_color = _group_get_color
 
-    # Existing compatibility layout methods resolve this module global at call time,
-    # so the hook affects only Manim-facing authoring/layout and never renderer bounds.
-    _compat._bounds_for = _bounds_for
     _base.Mobject.match_points = match_points
 
     exports = list(_base.__all__)

--- a/web/python/_manim_rate_functions.py
+++ b/web/python/_manim_rate_functions.py
@@ -111,27 +111,6 @@ def evaluate_rate_function(semantic_id: str, progress: float) -> float:
     return function(value)
 
 
-def _set_color_preserving_opacity(
-    self: _base.Mobject, color: _base.Color
-) -> _base.Mobject:
-    """Match Manim ``set_color`` without coupling RGB to fill/stroke opacity."""
-
-    try:
-        import _manim_semantic_handles as shared
-    except ImportError:
-        shared = None
-    if shared is not None:
-        handle = shared._handle_for(self)
-        if handle is not None:
-            return shared._set_color(self, color)
-        if getattr(self, "_semantic_handle", None) is not None:
-            raise NotImplementedError(
-                "typed set_color requires the shared semantic mutation path"
-            )
-
-    raise RuntimeError("Mobject paint requires the shared Rust authoring host")
-
-
 def install() -> None:
     """Install thin public adapters without creating a second playback engine."""
 
@@ -152,11 +131,6 @@ def install() -> None:
         setattr(_base, name, value)
 
     _compat._easing_from_rate_func = easing_from_rate_func
-
-    # Manim's set_color changes fill/stroke RGB while preserving each channel's
-    # independent opacity. This matters for Transform-style effects such as Indicate:
-    # a transparent stroke must not become visible while the color interpolates.
-    _base.Mobject.set_color = _set_color_preserving_opacity
 
     exports = list(_base.__all__)
     for name in public:

--- a/web/python/_manim_semantic_handles.py
+++ b/web/python/_manim_semantic_handles.py
@@ -145,7 +145,6 @@ def _manim_arrange(
 # Install compatibility placement before capturing fallbacks below. The generic
 # formulas use dynamic ``shift``/query dispatch, so after semantic-handle install
 # the same code mutates Rust/WASM-owned detached objects and ordinary scene objects.
-_base.Mobject.move_to = _manim_move_to
 _base.Mobject.next_to = _manim_next_to
 _base.Mobject.align_to = _manim_align_to
 _compat.Group.move_to = _manim_move_to
@@ -172,17 +171,13 @@ except ImportError:  # Native CPython tests install explicit bridge fixtures.
     _new_membership_batch = None
 
 _INSTALLED = False
-_ORIGINAL_SHIFT = _base.Mobject.shift
-_ORIGINAL_MOVE_TO = _base.Mobject.move_to
-_ORIGINAL_SCALE = _base.Mobject.scale
-_ORIGINAL_ROTATE = _base.Mobject.rotate
-_ORIGINAL_SET_COLOR = _base.Mobject.set_color
+_ORIGINAL_MOVE_TO = _manim_move_to
 _ORIGINAL_SET_OBJECT_OPACITY = _base.Mobject.set_object_opacity
 _ORIGINAL_NEXT_TO = _base.Mobject.next_to
 _ORIGINAL_ALIGN_TO = _base.Mobject.align_to
 _ORIGINAL_ALIGN_ON_FRAME = _base.Mobject._align_on_frame
-_ORIGINAL_BECOME = _base.Mobject.become
-_ORIGINAL_REPLACE = _base.Mobject.replace
+_ORIGINAL_BECOME = _compat._mobject_become
+_ORIGINAL_REPLACE = _compat._mobject_replace
 
 _ORIGINAL_GROUP_SHIFT = _compat.Group.shift
 _ORIGINAL_GROUP_MOVE_TO = _compat.Group.move_to
@@ -884,7 +879,7 @@ def _set_height_property(self: _base.Mobject, height: float) -> None:
 def _shift(self: _base.Mobject, direction: object) -> _base.Mobject:
     handle = _handle_for(self)
     if handle is None:
-        return _ORIGINAL_SHIFT(self, direction)
+        raise RuntimeError("Mobject edits require a current shared Rust semantic handle")
     offset = _base._as_vec2(direction)
     context = _live_mutation_context(self)
     if context is not None:
@@ -958,7 +953,7 @@ def _move_to(
 def _scale(self: _base.Mobject, factor: object) -> _base.Mobject:
     handle = _handle_for(self)
     if handle is None:
-        return _ORIGINAL_SCALE(self, factor)
+        raise RuntimeError("Mobject edits require a current shared Rust semantic handle")
     if isinstance(factor, (tuple, list, _base.Vec2)):
         value = _base._as_vec2(factor)
     else:
@@ -1002,14 +997,7 @@ def _rotate(
 
     handle = _handle_for(self)
     if handle is None:
-        return _ORIGINAL_ROTATE(
-            self,
-            angle,
-            axis,
-            about_point=about_point,
-            about_edge=about_edge,
-            **kwargs,
-        )
+        raise RuntimeError("Mobject edits require a current shared Rust semantic handle")
     context = _live_mutation_context(self)
     if context is not None:
         if kwargs or about_point is not None or about_edge is not None:
@@ -1042,7 +1030,7 @@ def _rotate(
 def _set_color(self: _base.Mobject, color: _base.Color) -> _base.Mobject:
     handle = _handle_for(self)
     if handle is None:
-        return _ORIGINAL_SET_COLOR(self, color)
+        raise RuntimeError("Mobject edits require a current shared Rust semantic handle")
     if not isinstance(color, _base.Color):
         raise TypeError("color must be a Color")
     live_context = _live_mutation_context(self)
@@ -1997,21 +1985,13 @@ def install() -> None:
     _INSTALLED = True
 
     _base.Mobject.__init__ = _init
-    _base.Mobject._current_raw = _current_raw
-    _base.Mobject._apply = _apply
     _base.Mobject.copy = _copy_mobject
     _base.Mobject.__deepcopy__ = _compat.deepcopy_semantic_wrapper
     _compat.Group.__deepcopy__ = _compat.deepcopy_semantic_wrapper
     _base.Mobject._copy_for_animate_target = _target_mobject
-    _base.Mobject.get_center = _get_center
     _base.Mobject.get_critical_point = _get_critical_point
     _base.Mobject.width = property(_width, _set_width_property)
     _base.Mobject.height = property(_height, _set_height_property)
-    _base.Mobject.shift = _shift
-    _base.Mobject.move_to = _move_to
-    _base.Mobject.scale = _scale
-    _base.Mobject.rotate = _rotate
-    _base.Mobject.set_color = _set_color
     _base.Mobject.set_object_opacity = _set_object_opacity
     _base.Mobject.become = _become
     _base.Mobject.replace = _replace

--- a/web/python/_manim_semantic_handles.py
+++ b/web/python/_manim_semantic_handles.py
@@ -1,8 +1,7 @@
-"""Shared semantic-handle migration for the Manim-compatible Python facade.
+"""Shared semantic operations for the Manim-compatible Python facade.
 
-Detached objects and `.animate` target-state copies live in Rust/WASM rather than in
-Python-owned deep-copied snapshots. Scene-owned objects continue through the existing
-scene adapter until the stable execution-slot integration is complete.
+Detached, scene-owned and live targets use typed Rust handles. Callback execution
+uses its explicit staged property view; this module installs no public methods.
 """
 
 from __future__ import annotations
@@ -142,16 +141,6 @@ def _manim_arrange(
     return self
 
 
-# Install compatibility placement before capturing fallbacks below. The generic
-# formulas use dynamic ``shift``/query dispatch, so after semantic-handle install
-# the same code mutates Rust/WASM-owned detached objects and ordinary scene objects.
-_base.Mobject.next_to = _manim_next_to
-_base.Mobject.align_to = _manim_align_to
-_compat.Group.move_to = _manim_move_to
-_compat.Group.next_to = _manim_next_to
-_compat.Group.align_to = _manim_align_to
-_compat.Group.arrange = _manim_arrange
-
 _ir = _base._ir
 
 try:
@@ -170,20 +159,7 @@ except ImportError:  # Native CPython tests install explicit bridge fixtures.
     _create_family_handle = None
     _new_membership_batch = None
 
-_INSTALLED = False
-_ORIGINAL_MOVE_TO = _manim_move_to
-_ORIGINAL_SET_OBJECT_OPACITY = _base.Mobject.set_object_opacity
-_ORIGINAL_NEXT_TO = _base.Mobject.next_to
-_ORIGINAL_ALIGN_TO = _base.Mobject.align_to
-_ORIGINAL_ALIGN_ON_FRAME = _base.Mobject._align_on_frame
-_ORIGINAL_BECOME = _compat._mobject_become
-_ORIGINAL_REPLACE = _compat._mobject_replace
 
-_ORIGINAL_GROUP_SHIFT = _compat.Group.shift
-_ORIGINAL_GROUP_MOVE_TO = _compat.Group.move_to
-_ORIGINAL_GROUP_NEXT_TO = _compat.Group.next_to
-_ORIGINAL_GROUP_ALIGN_TO = _compat.Group.align_to
-_ORIGINAL_GROUP_ARRANGE = _compat.Group.arrange
 
 
 def _raw_from_json(value: str) -> _ir.Mobject:
@@ -900,7 +876,7 @@ def _move_to(
 ) -> _base.Mobject:
     handle = _handle_for(self)
     if handle is None:
-        return _ORIGINAL_MOVE_TO(
+        return _manim_move_to(
             self,
             point_or_mobject,
             aligned_edge=aligned_edge,
@@ -928,7 +904,7 @@ def _move_to(
     if _alignment_is_mobject(point_or_mobject):
         target_handle = _handle_for(point_or_mobject)
         if target_handle is None or not hasattr(handle, "manimMoveToHandle"):
-            return _ORIGINAL_MOVE_TO(
+            return _manim_move_to(
                 self,
                 point_or_mobject,
                 aligned_edge=aligned_edge,
@@ -938,7 +914,7 @@ def _move_to(
         handle.manimMoveToHandle(target_handle, edge.x, edge.y, mask.x, mask.y)
     else:
         if not hasattr(handle, "manimMoveToPoint"):
-            return _ORIGINAL_MOVE_TO(
+            return _manim_move_to(
                 self,
                 point_or_mobject,
                 aligned_edge=aligned_edge,
@@ -1105,7 +1081,7 @@ def _become(
         raise NotImplementedError(
             "become requires valid shared semantic handles for both Mobjects"
         )
-    return _ORIGINAL_BECOME(
+    return _compat._mobject_become(
         self,
         mobject,
         match_height=match_height,
@@ -1131,7 +1107,7 @@ def _replace(
             raise NotImplementedError("replace currently supports width (0) or height (1)")
         handle.replaceHandle(other_handle, int(dim_to_match), bool(stretch))
         return self
-    return _ORIGINAL_REPLACE(self, mobject, dim_to_match=dim_to_match, stretch=stretch)
+    return _compat._mobject_replace(self, mobject, dim_to_match=dim_to_match, stretch=stretch)
 
 
 def _critical(value: _base.Mobject, direction: _base.Vec2) -> _base.Vec2:
@@ -1232,8 +1208,7 @@ def _next_to(
     if _shared_next_to(self, mobject_or_point, direction, buff, aligned_edge,
                        submobject_to_align, index_of_submobject_to_align, coor_mask):
         return self
-    fallback = _ORIGINAL_GROUP_NEXT_TO if isinstance(self, _compat.Group) else _ORIGINAL_NEXT_TO
-    return fallback(
+    return _manim_next_to(
         self, mobject_or_point, direction, buff,
         aligned_edge=aligned_edge, submobject_to_align=submobject_to_align,
         index_of_submobject_to_align=index_of_submobject_to_align, coor_mask=coor_mask,
@@ -1247,7 +1222,7 @@ def _align_to(
 ) -> _base.Mobject:
     handle = _handle_for(self)
     if handle is None:
-        return _ORIGINAL_ALIGN_TO(self, mobject_or_point, direction)
+        return _manim_align_to(self, mobject_or_point, direction)
     if _live_mutation_context(self) is not None:
         raise NotImplementedError(
             "canonical live affine targets do not support layout alignment"
@@ -1256,11 +1231,11 @@ def _align_to(
     if _alignment_is_mobject(mobject_or_point):
         target_handle = _handle_for(mobject_or_point)
         if target_handle is None or not hasattr(handle, "alignToHandle"):
-            return _ORIGINAL_ALIGN_TO(self, mobject_or_point, direction)
+            return _manim_align_to(self, mobject_or_point, direction)
         handle.alignToHandle(target_handle, axis.x, axis.y)
     else:
         if not hasattr(handle, "alignToPoint"):
-            return _ORIGINAL_ALIGN_TO(self, mobject_or_point, direction)
+            return _manim_align_to(self, mobject_or_point, direction)
         point = _base._as_vec2(mobject_or_point)
         handle.alignToPoint(point.x, point.y, axis.x, axis.y)
     return self
@@ -1273,7 +1248,7 @@ def _align_on_frame(
 ) -> _base.Mobject:
     handle = _handle_for(self)
     if handle is None or not hasattr(handle, "alignOnFrame"):
-        return _ORIGINAL_ALIGN_ON_FRAME(self, direction, buff)
+        raise RuntimeError("Mobject frame alignment requires a current shared Rust semantic handle")
     if _live_mutation_context(self) is not None:
         raise NotImplementedError(
             "canonical live affine targets do not support frame alignment"
@@ -1415,7 +1390,7 @@ def _set_object_opacity(
 
     handle = _handle_for(self)
     if handle is None:
-        return _ORIGINAL_SET_OBJECT_OPACITY(self, opacity)
+        raise NotImplementedError("set_object_opacity requires the shared semantic authoring handle")
     alpha = _compat._opacity("object opacity", opacity)
     live_context = _live_mutation_context(self)
     try:
@@ -1604,10 +1579,10 @@ def _group_shift(self: _compat.Group, direction: object) -> _compat.Group:
         return self
     shared = _shared_family_layout(self, mutation=True)
     if shared is None:
-        return _ORIGINAL_GROUP_SHIFT(self, direction)
+        return _compat._shift_group_members(self, direction)
     session = shared
     if not hasattr(session, "shiftBy"):
-        return _ORIGINAL_GROUP_SHIFT(self, direction)
+        return _compat._shift_group_members(self, direction)
     offset = _base._as_vec2(direction)
     session.shiftBy(offset.x, offset.y)
     return self
@@ -1660,7 +1635,7 @@ def _group_move_to(
         return self
     shared = _shared_family_layout(self, mutation=True)
     if shared is None:
-        return _ORIGINAL_GROUP_MOVE_TO(self, point_or_mobject, aligned_edge, coor_mask)
+        return _manim_move_to(self, point_or_mobject, aligned_edge, coor_mask)
     session = shared
     edge = _base._as_vec2(aligned_edge)
     mask = _alignment_mask2(coor_mask)
@@ -1689,7 +1664,7 @@ def _group_move_to(
         applied = True
 
     if not applied:
-        return _ORIGINAL_GROUP_MOVE_TO(self, point_or_mobject, aligned_edge, coor_mask)
+        return _manim_move_to(self, point_or_mobject, aligned_edge, coor_mask)
     return self
 
 
@@ -1707,7 +1682,7 @@ def _group_align_to(
         return self
     shared = _shared_family_layout(self, mutation=True)
     if shared is None:
-        return _ORIGINAL_GROUP_ALIGN_TO(self, mobject_or_point, direction)
+        return _manim_align_to(self, mobject_or_point, direction)
     session = shared
     axis = _base._as_vec2(direction)
 
@@ -1728,7 +1703,7 @@ def _group_align_to(
         applied = True
 
     if not applied:
-        return _ORIGINAL_GROUP_ALIGN_TO(self, mobject_or_point, direction)
+        return _manim_align_to(self, mobject_or_point, direction)
     return self
 
 
@@ -1742,7 +1717,7 @@ def _group_arrange(
 ) -> _compat.Group:
     family_handle = getattr(self, "_semantic_family_handle", None)
     if family_handle is None or not hasattr(family_handle, "arrangeOptions"):
-        return _ORIGINAL_GROUP_ARRANGE(self, direction=direction, buff=buff, center=center, **kwargs)
+        return _manim_arrange(self, direction=direction, buff=buff, center=center, **kwargs)
     if not self.submobjects:
         return self
     unknown = set(kwargs) - {"aligned_edge", "coor_mask", "submobject_to_align", "index_of_submobject_to_align"}
@@ -1758,7 +1733,7 @@ def _group_arrange(
     if aligner is not None:
         anchor = _layout_anchor(aligner)
         if anchor is None:
-            return _ORIGINAL_GROUP_ARRANGE(self, direction=direction, buff=buff, center=center, **kwargs)
+            return _manim_arrange(self, direction=direction, buff=buff, center=center, **kwargs)
         options.setAligner(anchor)
     context = _group_target_context(self)
     try:
@@ -1768,7 +1743,7 @@ def _group_arrange(
         leaves = _compat._leaf_mobjects(self)
         leaf_handles = [_family_layout_leaf_adapter(member, mutation=True) for member in leaves]
         if any(handle is None for handle in leaf_handles):
-            return _ORIGINAL_GROUP_ARRANGE(self, direction=direction, buff=buff, center=center, **kwargs)
+            return _manim_arrange(self, direction=direction, buff=buff, center=center, **kwargs)
         family_handle.arrange(options)
     except Exception as error:
         if "alignment submobject index" in str(error):
@@ -1976,37 +1951,3 @@ def _group_copy(self: _compat.Group) -> _compat.Group:
             if context is not None:
                 target._canonical_live_target_context = context
     return clone
-
-
-def install() -> None:
-    global _INSTALLED
-    if _INSTALLED or _create_geometry_handle is None:
-        return
-    _INSTALLED = True
-
-    _base.Mobject.__init__ = _init
-    _base.Mobject.copy = _copy_mobject
-    _base.Mobject.__deepcopy__ = _compat.deepcopy_semantic_wrapper
-    _compat.Group.__deepcopy__ = _compat.deepcopy_semantic_wrapper
-    _base.Mobject._copy_for_animate_target = _target_mobject
-    _base.Mobject.get_critical_point = _get_critical_point
-    _base.Mobject.width = property(_width, _set_width_property)
-    _base.Mobject.height = property(_height, _set_height_property)
-    _base.Mobject.set_object_opacity = _set_object_opacity
-    _base.Mobject.become = _become
-    _base.Mobject.replace = _replace
-    _base.Mobject.next_to = _next_to
-    _base.Mobject.align_to = _align_to
-    _base.Mobject._align_on_frame = _align_on_frame
-
-    _compat.VMobject._copy_for_animate_target = _target_mobject
-    _compat._bounds_for = _compat_bounds_for
-
-
-    if _create_family_handle is not None:
-        _compat.Group.shift = _group_shift
-        _compat.Group.move_to = _group_move_to
-        _compat.Group.next_to = _next_to
-        _compat.Group.align_to = _group_align_to
-        _compat.Group.arrange = _group_arrange
-        _compat.Group._copy_for_animate_target = _group_copy

--- a/web/python/_manim_shared_geometry.py
+++ b/web/python/_manim_shared_geometry.py
@@ -556,8 +556,6 @@ def install() -> None:
         return
     _INSTALLED = True
     _base.Mobject.set_coord = _set_coord
-    _base.Mobject.set_x = _set_x
-    _base.Mobject.set_y = _set_y
     _base.Mobject.match_coord = _match_coord
     _base.Mobject.match_x = _match_x
     _base.Mobject.match_y = _match_y

--- a/web/python/_manim_updaters.py
+++ b/web/python/_manim_updaters.py
@@ -31,9 +31,9 @@ def _semantic_operations():
     return _manim_semantic_handles
 
 
-def _compat_operations():
-    import _manim_compat
-    return _manim_compat
+def _coordinate_operations():
+    import _manim_shared_geometry
+    return _manim_shared_geometry
 
 
 def _track(mobject: _base.Mobject) -> None:
@@ -985,18 +985,22 @@ def _canonical_move_to(self: _base.Mobject, point: object, *args: object, **kwar
     return _canonical_shift(self, _base._as_vec2(point) - row.center())
 
 
-def _canonical_set_x(self: _base.Mobject, x: float) -> _base.Mobject:
+def _canonical_set_x(self: _base.Mobject, x: float, direction: object = _base.ORIGIN) -> _base.Mobject:
     value = _canonical_row(self)
     if value is None:
-        return _compat_operations()._mobject_set_x(self, x)
+        return _coordinate_operations()._set_x(self, x, direction)
+    if _base._as_vec2(direction) != _base.ORIGIN:
+        raise NotImplementedError("callback coordinate placement supports center coordinates only")
     _, _, row = value
     return _canonical_shift(self, _base.Vec2(float(x) - row.center().x, 0.0))
 
 
-def _canonical_set_y(self: _base.Mobject, y: float) -> _base.Mobject:
+def _canonical_set_y(self: _base.Mobject, y: float, direction: object = _base.ORIGIN) -> _base.Mobject:
     value = _canonical_row(self)
     if value is None:
-        return _compat_operations()._mobject_set_y(self, y)
+        return _coordinate_operations()._set_y(self, y, direction)
+    if _base._as_vec2(direction) != _base.ORIGIN:
+        raise NotImplementedError("callback coordinate placement supports center coordinates only")
     _, _, row = value
     return _canonical_shift(self, _base.Vec2(0.0, float(y) - row.center().y))
 

--- a/web/python/_manim_updaters.py
+++ b/web/python/_manim_updaters.py
@@ -16,7 +16,6 @@ from typing import Any, Callable
 
 import noon as _base
 
-_INSTALLED = False
 _NEXT_SESSION_ID = 0
 _TRACKED_MOBJECTS: list[_base.Mobject] = []
 _CANONICAL_SESSIONS: dict[int, "_CanonicalCallbackSession"] = {}
@@ -25,23 +24,16 @@ _ACTIVE_CANONICAL_CONTEXT: ContextVar["_CanonicalCallbackContext | None"] = Cont
     "noon_active_canonical_callback", default=None
 )
 
-_ORIGINAL_CURRENT_RAW = _base.Mobject._current_raw
-_ORIGINAL_APPLY = _base.Mobject._apply
-_ORIGINAL_GET_CENTER = _base.Mobject.get_center
-_ORIGINAL_SHIFT = _base.Mobject.shift
-_ORIGINAL_MOVE_TO = _base.Mobject.move_to
-_ORIGINAL_SET_X = _base.Mobject.set_x
-_ORIGINAL_SET_Y = _base.Mobject.set_y
-_ORIGINAL_SCALE = _base.Mobject.scale
-_ORIGINAL_ROTATE = _base.Mobject.rotate
-_ORIGINAL_SET_COLOR = _base.Mobject.set_color
-_ORIGINAL_SET_FILL = _base.Mobject.set_fill
-_ORIGINAL_SET_STROKE = _base.Mobject.set_stroke
-_ORIGINAL_SET_OPACITY = _base.Mobject.set_opacity
-_ORIGINAL_VMOBJECT_SET_COLOR: Callable[..., _base.Mobject] | None = None
-_ORIGINAL_VMOBJECT_SET_FILL: Callable[..., _base.Mobject] | None = None
-_ORIGINAL_VMOBJECT_SET_STROKE: Callable[..., _base.Mobject] | None = None
-_ORIGINAL_VMOBJECT_SET_OPACITY: Callable[..., _base.Mobject] | None = None
+
+
+def _semantic_operations():
+    import _manim_semantic_handles
+    return _manim_semantic_handles
+
+
+def _compat_operations():
+    import _manim_compat
+    return _manim_compat
 
 
 def _track(mobject: _base.Mobject) -> None:
@@ -953,7 +945,7 @@ def _canonical_current_raw(self: _base.Mobject):
         raise NotImplementedError(
             "canonical callback raw geometry access is not supported; use property operations"
         )
-    return _ORIGINAL_CURRENT_RAW(self)
+    return _semantic_operations()._current_raw(self)
 
 
 def _canonical_apply(self: _base.Mobject, raw: object) -> _base.Mobject:
@@ -961,13 +953,13 @@ def _canonical_apply(self: _base.Mobject, raw: object) -> _base.Mobject:
         raise NotImplementedError(
             "canonical callbacks support property operations only; raw replacement is unsupported"
         )
-    return _ORIGINAL_APPLY(self, raw)
+    return _semantic_operations()._apply(self, raw)
 
 
 def _canonical_get_center(self: _base.Mobject) -> _base.Vec2:
     value = _canonical_row(self)
     if value is None:
-        return _ORIGINAL_GET_CENTER(self)
+        return _semantic_operations()._get_center(self)
     _, _, row = value
     return row.center()
 
@@ -975,7 +967,7 @@ def _canonical_get_center(self: _base.Mobject) -> _base.Vec2:
 def _canonical_shift(self: _base.Mobject, direction: object) -> _base.Mobject:
     value = _canonical_row(self)
     if value is None:
-        return _ORIGINAL_SHIFT(self, direction)
+        return _semantic_operations()._shift(self, direction)
     context, key, row = value
     before = row.transform
     row.shift(_base._as_vec2(direction))
@@ -986,7 +978,7 @@ def _canonical_shift(self: _base.Mobject, direction: object) -> _base.Mobject:
 def _canonical_move_to(self: _base.Mobject, point: object, *args: object, **kwargs: object) -> _base.Mobject:
     value = _canonical_row(self)
     if value is None:
-        return _ORIGINAL_MOVE_TO(self, point, *args, **kwargs)
+        return _semantic_operations()._move_to(self, point, *args, **kwargs)
     if args or kwargs:
         raise NotImplementedError("callback move_to currently supports center point placement only")
     _, _, row = value
@@ -996,7 +988,7 @@ def _canonical_move_to(self: _base.Mobject, point: object, *args: object, **kwar
 def _canonical_set_x(self: _base.Mobject, x: float) -> _base.Mobject:
     value = _canonical_row(self)
     if value is None:
-        return _ORIGINAL_SET_X(self, x)
+        return _compat_operations()._mobject_set_x(self, x)
     _, _, row = value
     return _canonical_shift(self, _base.Vec2(float(x) - row.center().x, 0.0))
 
@@ -1004,7 +996,7 @@ def _canonical_set_x(self: _base.Mobject, x: float) -> _base.Mobject:
 def _canonical_set_y(self: _base.Mobject, y: float) -> _base.Mobject:
     value = _canonical_row(self)
     if value is None:
-        return _ORIGINAL_SET_Y(self, y)
+        return _compat_operations()._mobject_set_y(self, y)
     _, _, row = value
     return _canonical_shift(self, _base.Vec2(0.0, float(y) - row.center().y))
 
@@ -1014,13 +1006,13 @@ def _canonical_scale(self: _base.Mobject, *args: object, **kwargs: object) -> _b
         raise NotImplementedError(
             "canonical callback scale is not supported; use shared semantic operations"
         )
-    return _ORIGINAL_SCALE(self, *args, **kwargs)
+    return _semantic_operations()._scale(self, *args, **kwargs)
 
 
 def _canonical_rotate(self: _base.Mobject, *args: object, **kwargs: object) -> _base.Mobject:
     value = _canonical_row(self)
     if value is None:
-        return _ORIGINAL_ROTATE(self, *args, **kwargs)
+        return _semantic_operations()._rotate(self, *args, **kwargs)
     context, key, row = value
     if not args or len(args) > 2:
         raise TypeError("canonical callback rotate expects angle and optional axis")
@@ -1052,7 +1044,7 @@ def _canonical_rotate(self: _base.Mobject, *args: object, **kwargs: object) -> _
 def _canonical_set_color(self: _base.Mobject, color: _base.Color) -> _base.Mobject:
     value = _canonical_row(self)
     if value is None:
-        return _ORIGINAL_SET_COLOR(self, color)
+        return _semantic_operations()._set_color(self, color)
     context, key, row = value
     color_value = _phase_color("set_color", color.to_ir())
     assert color_value is not None
@@ -1068,7 +1060,7 @@ def _canonical_set_fill(
 ) -> _base.Mobject:
     value = _canonical_row(self)
     if value is None:
-        return _ORIGINAL_SET_FILL(self, color, opacity)
+        return _semantic_operations()._set_fill(self, color, opacity)
     context, key, row = value
     before = row.style
     fill = None if color is None else _phase_color("set_fill", color.to_ir())
@@ -1085,7 +1077,7 @@ def _canonical_set_stroke(
 ) -> _base.Mobject:
     value = _canonical_row(self)
     if value is None:
-        return _ORIGINAL_SET_STROKE(self, color, width)
+        return _semantic_operations()._set_stroke(self, color, width)
     context, key, row = value
     if width is not None:
         raise NotImplementedError(
@@ -1109,7 +1101,7 @@ def _canonical_set_stroke(
 def _canonical_set_opacity(self: _base.Mobject, opacity: float) -> _base.Mobject:
     value = _canonical_row(self)
     if value is None:
-        return _ORIGINAL_SET_OPACITY(self, opacity)
+        return _semantic_operations()._set_object_opacity(self, opacity)
     context, key, row = value
     before = row.style
     row.style = replace(row.style, opacity=float(opacity))
@@ -1127,8 +1119,7 @@ def _canonical_vmobject_set_color(
         from _manim_compat import _as_color
 
         return _canonical_set_color(self, _as_color("color", color))
-    assert _ORIGINAL_VMOBJECT_SET_COLOR is not None
-    return _ORIGINAL_VMOBJECT_SET_COLOR(self, color, family=family)
+    return _semantic_operations()._set_vmobject_color(self, color, family=family)
 
 
 def _canonical_vmobject_set_fill(
@@ -1144,8 +1135,7 @@ def _canonical_vmobject_set_fill(
 
             color = _as_color("fill color", color)
         return _canonical_set_fill(self, color, opacity)
-    assert _ORIGINAL_VMOBJECT_SET_FILL is not None
-    return _ORIGINAL_VMOBJECT_SET_FILL(self, color=color, opacity=opacity, family=family)
+    return _semantic_operations()._set_fill(self, color=color, opacity=opacity, family=family)
 
 
 def _canonical_vmobject_set_stroke(
@@ -1166,8 +1156,7 @@ def _canonical_vmobject_set_stroke(
 
             color = _as_color("stroke color", color)
         return _canonical_set_stroke(self, color, width)
-    assert _ORIGINAL_VMOBJECT_SET_STROKE is not None
-    return _ORIGINAL_VMOBJECT_SET_STROKE(
+    return _semantic_operations()._set_stroke(
         self, color=color, width=width, opacity=opacity, family=family
     )
 
@@ -1182,8 +1171,7 @@ def _canonical_vmobject_set_opacity(
         from _manim_compat import _opacity
 
         return _canonical_set_opacity(self, _opacity("opacity", opacity))
-    assert _ORIGINAL_VMOBJECT_SET_OPACITY is not None
-    return _ORIGINAL_VMOBJECT_SET_OPACITY(self, opacity, family=family)
+    return _semantic_operations()._set_opacity(self, opacity, family=family)
 
 
 async def prepare_canonical_callback_phase(session_id: int, frame: dict[str, Any]):
@@ -1268,51 +1256,3 @@ def _json_phase(value: object) -> str:
 
 def release_session(session_id: int) -> None:
     _CANONICAL_SESSIONS.pop(int(session_id), None)
-
-
-def install() -> None:
-    global _INSTALLED
-    if _INSTALLED:
-        return
-    _base.Mobject.add_updater = add_updater
-    _base.Mobject.remove_updater = remove_updater
-    _base.Mobject.clear_updaters = clear_updaters
-    _base.Mobject.get_updaters = get_updaters
-    _base.Mobject.has_updaters = has_updaters
-    _base.Mobject._current_raw = _canonical_current_raw
-    _base.Mobject._apply = _canonical_apply
-    _base.Mobject.get_center = _canonical_get_center
-    _base.Mobject.shift = _canonical_shift
-    _base.Mobject.move_to = _canonical_move_to
-    _base.Mobject.set_x = _canonical_set_x
-    _base.Mobject.set_y = _canonical_set_y
-    _base.Mobject.scale = _canonical_scale
-    _base.Mobject.rotate = _canonical_rotate
-    _base.Mobject.set_color = _canonical_set_color
-    _base.Mobject.set_fill = _canonical_set_fill
-    _base.Mobject.set_stroke = _canonical_set_stroke
-    _base.Mobject.set_opacity = _canonical_set_opacity
-    # Semantic-handle installation gives VMobject its own final public style
-    # methods. Reinstall the phase dispatch at that public boundary so it cannot
-    # fall through to raw snapshot mutation while a canonical callback is active.
-    import _manim_compat as _compat
-
-    global _ORIGINAL_VMOBJECT_SET_COLOR
-    global _ORIGINAL_VMOBJECT_SET_FILL
-    global _ORIGINAL_VMOBJECT_SET_STROKE
-    global _ORIGINAL_VMOBJECT_SET_OPACITY
-    # Inherited methods already use the Mobject phase dispatcher above. Wrap
-    # only VMobject's own overrides, preserving the inherited base signatures.
-    if "set_color" in _compat.VMobject.__dict__:
-        _ORIGINAL_VMOBJECT_SET_COLOR = _compat.VMobject.set_color
-        _compat.VMobject.set_color = _canonical_vmobject_set_color
-    if "set_fill" in _compat.VMobject.__dict__:
-        _ORIGINAL_VMOBJECT_SET_FILL = _compat.VMobject.set_fill
-        _compat.VMobject.set_fill = _canonical_vmobject_set_fill
-    if "set_stroke" in _compat.VMobject.__dict__:
-        _ORIGINAL_VMOBJECT_SET_STROKE = _compat.VMobject.set_stroke
-        _compat.VMobject.set_stroke = _canonical_vmobject_set_stroke
-    if "set_opacity" in _compat.VMobject.__dict__:
-        _ORIGINAL_VMOBJECT_SET_OPACITY = _compat.VMobject.set_opacity
-        _compat.VMobject.set_opacity = _canonical_vmobject_set_opacity
-    _INSTALLED = True

--- a/web/python/_manim_updaters.py
+++ b/web/python/_manim_updaters.py
@@ -26,11 +26,6 @@ _ACTIVE_CANONICAL_CONTEXT: ContextVar["_CanonicalCallbackContext | None"] = Cont
 
 
 
-def _semantic_operations():
-    import _manim_semantic_handles
-    return _manim_semantic_handles
-
-
 def _compat_operations():
     import _manim_compat
     return _manim_compat
@@ -945,7 +940,7 @@ def _canonical_current_raw(self: _base.Mobject):
         raise NotImplementedError(
             "canonical callback raw geometry access is not supported; use property operations"
         )
-    return _semantic_operations()._current_raw(self)
+    return _base._semantic_operations()._current_raw(self)
 
 
 def _canonical_apply(self: _base.Mobject, raw: object) -> _base.Mobject:
@@ -953,13 +948,13 @@ def _canonical_apply(self: _base.Mobject, raw: object) -> _base.Mobject:
         raise NotImplementedError(
             "canonical callbacks support property operations only; raw replacement is unsupported"
         )
-    return _semantic_operations()._apply(self, raw)
+    return _base._semantic_operations()._apply(self, raw)
 
 
 def _canonical_get_center(self: _base.Mobject) -> _base.Vec2:
     value = _canonical_row(self)
     if value is None:
-        return _semantic_operations()._get_center(self)
+        return _base._semantic_operations()._get_center(self)
     _, _, row = value
     return row.center()
 
@@ -967,7 +962,7 @@ def _canonical_get_center(self: _base.Mobject) -> _base.Vec2:
 def _canonical_shift(self: _base.Mobject, direction: object) -> _base.Mobject:
     value = _canonical_row(self)
     if value is None:
-        return _semantic_operations()._shift(self, direction)
+        return _base._semantic_operations()._shift(self, direction)
     context, key, row = value
     before = row.transform
     row.shift(_base._as_vec2(direction))
@@ -978,7 +973,7 @@ def _canonical_shift(self: _base.Mobject, direction: object) -> _base.Mobject:
 def _canonical_move_to(self: _base.Mobject, point: object, *args: object, **kwargs: object) -> _base.Mobject:
     value = _canonical_row(self)
     if value is None:
-        return _semantic_operations()._move_to(self, point, *args, **kwargs)
+        return _base._semantic_operations()._move_to(self, point, *args, **kwargs)
     if args or kwargs:
         raise NotImplementedError("callback move_to currently supports center point placement only")
     _, _, row = value
@@ -1006,13 +1001,13 @@ def _canonical_scale(self: _base.Mobject, *args: object, **kwargs: object) -> _b
         raise NotImplementedError(
             "canonical callback scale is not supported; use shared semantic operations"
         )
-    return _semantic_operations()._scale(self, *args, **kwargs)
+    return _base._semantic_operations()._scale(self, *args, **kwargs)
 
 
 def _canonical_rotate(self: _base.Mobject, *args: object, **kwargs: object) -> _base.Mobject:
     value = _canonical_row(self)
     if value is None:
-        return _semantic_operations()._rotate(self, *args, **kwargs)
+        return _base._semantic_operations()._rotate(self, *args, **kwargs)
     context, key, row = value
     if not args or len(args) > 2:
         raise TypeError("canonical callback rotate expects angle and optional axis")
@@ -1044,7 +1039,7 @@ def _canonical_rotate(self: _base.Mobject, *args: object, **kwargs: object) -> _
 def _canonical_set_color(self: _base.Mobject, color: _base.Color) -> _base.Mobject:
     value = _canonical_row(self)
     if value is None:
-        return _semantic_operations()._set_color(self, color)
+        return _base._semantic_operations()._set_color(self, color)
     context, key, row = value
     color_value = _phase_color("set_color", color.to_ir())
     assert color_value is not None
@@ -1060,7 +1055,7 @@ def _canonical_set_fill(
 ) -> _base.Mobject:
     value = _canonical_row(self)
     if value is None:
-        return _semantic_operations()._set_fill(self, color, opacity)
+        return _base._semantic_operations()._set_fill(self, color, opacity)
     context, key, row = value
     before = row.style
     fill = None if color is None else _phase_color("set_fill", color.to_ir())
@@ -1077,7 +1072,7 @@ def _canonical_set_stroke(
 ) -> _base.Mobject:
     value = _canonical_row(self)
     if value is None:
-        return _semantic_operations()._set_stroke(self, color, width)
+        return _base._semantic_operations()._set_stroke(self, color, width)
     context, key, row = value
     if width is not None:
         raise NotImplementedError(
@@ -1101,7 +1096,7 @@ def _canonical_set_stroke(
 def _canonical_set_opacity(self: _base.Mobject, opacity: float) -> _base.Mobject:
     value = _canonical_row(self)
     if value is None:
-        return _semantic_operations()._set_object_opacity(self, opacity)
+        return _base._semantic_operations()._set_object_opacity(self, opacity)
     context, key, row = value
     before = row.style
     row.style = replace(row.style, opacity=float(opacity))
@@ -1119,7 +1114,7 @@ def _canonical_vmobject_set_color(
         from _manim_compat import _as_color
 
         return _canonical_set_color(self, _as_color("color", color))
-    return _semantic_operations()._set_vmobject_color(self, color, family=family)
+    return _base._semantic_operations()._set_vmobject_color(self, color, family=family)
 
 
 def _canonical_vmobject_set_fill(
@@ -1135,7 +1130,7 @@ def _canonical_vmobject_set_fill(
 
             color = _as_color("fill color", color)
         return _canonical_set_fill(self, color, opacity)
-    return _semantic_operations()._set_fill(self, color=color, opacity=opacity, family=family)
+    return _base._semantic_operations()._set_fill(self, color=color, opacity=opacity, family=family)
 
 
 def _canonical_vmobject_set_stroke(
@@ -1156,7 +1151,7 @@ def _canonical_vmobject_set_stroke(
 
             color = _as_color("stroke color", color)
         return _canonical_set_stroke(self, color, width)
-    return _semantic_operations()._set_stroke(
+    return _base._semantic_operations()._set_stroke(
         self, color=color, width=width, opacity=opacity, family=family
     )
 
@@ -1171,7 +1166,7 @@ def _canonical_vmobject_set_opacity(
         from _manim_compat import _opacity
 
         return _canonical_set_opacity(self, _opacity("opacity", opacity))
-    return _semantic_operations()._set_opacity(self, opacity, family=family)
+    return _base._semantic_operations()._set_opacity(self, opacity, family=family)
 
 
 async def prepare_canonical_callback_phase(session_id: int, frame: dict[str, Any]):

--- a/web/python/noon.py
+++ b/web/python/noon.py
@@ -195,6 +195,11 @@ GRAY_E = GREY_E = _hex_color(0x222222)
 GRAY = GREY = GRAY_C
 
 
+def _semantic_operations():
+    import _manim_semantic_handles
+    return _manim_semantic_handles
+
+
 def _callback_operations():
     # The adapter selects a staged callback view or the normal semantic handle.
     import _manim_updaters
@@ -205,7 +210,7 @@ class Mobject:
     """Python identity wrapper; shared Rust handles own all semantic state."""
 
     def __init__(self, raw: _ir.Mobject) -> None:
-        raise RuntimeError("Mobject construction requires the shared Rust authoring host")
+        return _semantic_operations()._init(self, raw)
 
     @property
     def geometry(self) -> dict[str, Any]:
@@ -229,7 +234,7 @@ class Mobject:
         return self._current_raw().to_ir()
 
     def copy(self) -> Mobject:
-        raise RuntimeError("Mobject copy requires the shared Rust authoring host")
+        return _semantic_operations()._copy_mobject(self)
 
     def _bind(self, scene: Scene, obj: _ir.Object) -> None:
         if self._scene is not None and self._scene is not scene:
@@ -251,11 +256,19 @@ class Mobject:
 
     @property
     def width(self) -> float:
-        raise RuntimeError("Mobject layout requires the shared Rust authoring host")
+        return _semantic_operations()._width(self)
+
+    @width.setter
+    def width(self, value: float) -> None:
+        _semantic_operations()._set_width_property(self, value)
 
     @property
     def height(self) -> float:
-        raise RuntimeError("Mobject layout requires the shared Rust authoring host")
+        return _semantic_operations()._height(self)
+
+    @height.setter
+    def height(self, value: float) -> None:
+        _semantic_operations()._set_height_property(self, value)
 
     def shift(self, direction: object) -> Mobject:
         return _callback_operations()._canonical_shift(self, direction)
@@ -291,31 +304,23 @@ class Mobject:
         return _callback_operations()._canonical_set_opacity(self, opacity)
 
     def set_object_opacity(self, opacity: float) -> Mobject:
-        """Set Noon's object-composite opacity independently of paint opacity.
-
-        Manim ``VMobject.set_opacity`` controls the enabled fill and stroke paint
-        alpha channels. This explicit Noon operation controls the separate opacity
-        multiplier applied to the complete object through the shared semantic handle.
-        """
-        del opacity
-        raise NotImplementedError(
-            "set_object_opacity requires Noon's shared semantic authoring handle"
-        )
+        """Set whole-object opacity independently of fill/stroke paint alpha."""
+        return _semantic_operations()._set_object_opacity(self, opacity)
 
     def next_to(
         self,
-        other: Mobject | Vec2 | tuple[float, float],
-        direction: Vec2 | tuple[float, float] = RIGHT,
+        mobject_or_point: object,
+        direction: object = RIGHT,
         buff: float = DEFAULT_MOBJECT_TO_MOBJECT_BUFFER,
-    ) -> Mobject:
-        raise RuntimeError("Mobject layout requires the shared Rust authoring host")
+        aligned_edge: object = ORIGIN,
+        submobject_to_align: object | None = None,
+        index_of_submobject_to_align: int | None = None,
+        coor_mask: object = (1.0, 1.0, 1.0),
+    ) -> Mobject | Group:
+        return _semantic_operations()._next_to(self, mobject_or_point, direction, buff, aligned_edge, submobject_to_align, index_of_submobject_to_align, coor_mask)
 
-    def align_to(
-        self,
-        other: Mobject,
-        direction: Vec2 | tuple[float, float] = ORIGIN,
-    ) -> Mobject:
-        raise RuntimeError("Mobject layout requires the shared Rust authoring host")
+    def align_to(self, mobject_or_point: object, direction: object = ORIGIN) -> Mobject:
+        return _semantic_operations()._align_to(self, mobject_or_point, direction)
 
     def to_edge(
         self,
@@ -332,14 +337,19 @@ class Mobject:
         return self._align_on_frame(_as_vec2(corner), float(buff))
 
     def _align_on_frame(self, direction: Vec2, buff: float) -> Mobject:
-        raise RuntimeError("Mobject layout requires the shared Rust authoring host")
+        return _semantic_operations()._align_on_frame(self, direction, buff)
 
     @property
     def animate(self) -> _AnimationBuilder:
         return _AnimationBuilder(self)
 
 
-    def add_updater(self, update_function: Callable[..., Any], index: int | None = None, call_updater: bool = False) -> Mobject:
+    def add_updater(
+        self,
+        update_function: Callable[..., Any],
+        index: int | None = None,
+        call_updater: bool = False,
+    ) -> Mobject:
         return _callback_operations().add_updater(self, update_function, index, call_updater)
 
     def remove_updater(self, update_function: Callable[..., Any]) -> Mobject:
@@ -353,6 +363,30 @@ class Mobject:
 
     def has_updaters(self) -> bool:
         return _callback_operations().has_updaters(self)
+
+    def _copy_for_animate_target(self) -> Mobject:
+        return _semantic_operations()._target_mobject(self)
+
+    def get_critical_point(self, direction: object) -> Vec2:
+        return _semantic_operations()._get_critical_point(self, direction)
+
+    def become(
+        self,
+        mobject: Mobject,
+        match_height: bool = False,
+        match_width: bool = False,
+        match_depth: bool = False,
+        match_center: bool = False,
+        stretch: bool = False,
+    ) -> Mobject:
+        return _semantic_operations()._become(self, mobject, match_height, match_width, match_depth, match_center, stretch)
+
+    def replace(self, mobject: Mobject, dim_to_match: int = 0, stretch: bool = False) -> Mobject:
+        return _semantic_operations()._replace(self, mobject, dim_to_match, stretch)
+
+    def __deepcopy__(self, memo):
+        from _manim_compat import deepcopy_semantic_wrapper
+        return deepcopy_semantic_wrapper(self, memo)
 
 
 class Group:

--- a/web/python/noon.py
+++ b/web/python/noon.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import json
 import math
 from dataclasses import dataclass
-from typing import Any, Iterable, Iterator
+from typing import Any, Callable, Iterable, Iterator
 
 import _noon_ir as _ir
 
@@ -195,6 +195,12 @@ GRAY_E = GREY_E = _hex_color(0x222222)
 GRAY = GREY = GRAY_C
 
 
+def _callback_operations():
+    # The adapter selects a staged callback view or the normal semantic handle.
+    import _manim_updaters
+    return _manim_updaters
+
+
 class Mobject:
     """Python identity wrapper; shared Rust handles own all semantic state."""
 
@@ -234,14 +240,14 @@ class Mobject:
     def _bind_to_scene(self, scene: Scene, *, key: str | None = None) -> _ir.Object:
         return _scene_operations()._bind_mobject(self, scene, key=key)
 
-    def _current_raw(self) -> _ir.Mobject:
-        raise RuntimeError("Mobject queries require the shared Rust authoring host")
+    def _current_raw(self):
+        return _callback_operations()._canonical_current_raw(self)
 
-    def _apply(self, raw: _ir.Mobject) -> Mobject:
-        raise NotImplementedError("raw replacement is unsupported; use a shared semantic operation")
+    def _apply(self, raw: object) -> Mobject:
+        return _callback_operations()._canonical_apply(self, raw)
 
     def get_center(self) -> Vec2:
-        raise RuntimeError("Mobject layout requires the shared Rust authoring host")
+        return _callback_operations()._canonical_get_center(self)
 
     @property
     def width(self) -> float:
@@ -251,42 +257,38 @@ class Mobject:
     def height(self) -> float:
         raise RuntimeError("Mobject layout requires the shared Rust authoring host")
 
-    def shift(self, direction: Vec2 | tuple[float, float]) -> Mobject:
-        raise RuntimeError("Mobject edits require the shared Rust authoring host")
+    def shift(self, direction: object) -> Mobject:
+        return _callback_operations()._canonical_shift(self, direction)
 
-    def move_to(self, point: Vec2 | tuple[float, float]) -> Mobject:
-        return self.shift(_as_vec2(point) - self.get_center())
+    def move_to(self, point: object, *args: object, **kwargs: object) -> Mobject:
+        return _callback_operations()._canonical_move_to(self, point, *args, **kwargs)
 
     def center(self) -> Mobject:
         return self.move_to(ORIGIN)
 
     def set_x(self, x: float) -> Mobject:
-        center = self.get_center()
-        return self.shift(Vec2(float(x) - center.x, 0.0))
+        return _callback_operations()._canonical_set_x(self, x)
 
     def set_y(self, y: float) -> Mobject:
-        center = self.get_center()
-        return self.shift(Vec2(0.0, float(y) - center.y))
+        return _callback_operations()._canonical_set_y(self, y)
 
-    def scale(self, factor: float | tuple[float, float]) -> Mobject:
-        raise RuntimeError("Mobject edits require the shared Rust authoring host")
+    def scale(self, *args: object, **kwargs: object) -> Mobject:
+        return _callback_operations()._canonical_scale(self, *args, **kwargs)
 
-    def rotate(self, angle: float) -> Mobject:
-        raise RuntimeError("Mobject edits require the shared Rust authoring host")
+    def rotate(self, *args: object, **kwargs: object) -> Mobject:
+        return _callback_operations()._canonical_rotate(self, *args, **kwargs)
 
     def set_color(self, color: Color) -> Mobject:
-        raise RuntimeError("Mobject edits require the shared Rust authoring host")
+        return _callback_operations()._canonical_set_color(self, color)
 
     def set_fill(self, color: Color | None = None, opacity: float | None = None) -> Mobject:
-        raise RuntimeError("Mobject edits require the shared Rust authoring host")
+        return _callback_operations()._canonical_set_fill(self, color, opacity)
 
-    def set_stroke(
-        self, color: Color | None = None, width: float | None = None
-    ) -> Mobject:
-        raise RuntimeError("Mobject edits require the shared Rust authoring host")
+    def set_stroke(self, color: Color | None = None, width: float | None = None) -> Mobject:
+        return _callback_operations()._canonical_set_stroke(self, color, width)
 
     def set_opacity(self, opacity: float) -> Mobject:
-        raise RuntimeError("Mobject edits require the shared Rust authoring host")
+        return _callback_operations()._canonical_set_opacity(self, opacity)
 
     def set_object_opacity(self, opacity: float) -> Mobject:
         """Set Noon's object-composite opacity independently of paint opacity.
@@ -335,6 +337,22 @@ class Mobject:
     @property
     def animate(self) -> _AnimationBuilder:
         return _AnimationBuilder(self)
+
+
+    def add_updater(self, update_function: Callable[..., Any], index: int | None = None, call_updater: bool = False) -> Mobject:
+        return _callback_operations().add_updater(self, update_function, index, call_updater)
+
+    def remove_updater(self, update_function: Callable[..., Any]) -> Mobject:
+        return _callback_operations().remove_updater(self, update_function)
+
+    def clear_updaters(self, recursive: bool = True) -> Mobject:
+        return _callback_operations().clear_updaters(self, recursive)
+
+    def get_updaters(self) -> list[Callable[..., Any]]:
+        return _callback_operations().get_updaters(self)
+
+    def has_updaters(self) -> bool:
+        return _callback_operations().has_updaters(self)
 
 
 class Group:

--- a/web/python/noon.py
+++ b/web/python/noon.py
@@ -266,11 +266,11 @@ class Mobject:
     def center(self) -> Mobject:
         return self.move_to(ORIGIN)
 
-    def set_x(self, x: float) -> Mobject:
-        return _callback_operations()._canonical_set_x(self, x)
+    def set_x(self, x: float, direction: object = ORIGIN) -> Mobject:
+        return _callback_operations()._canonical_set_x(self, x, direction)
 
-    def set_y(self, y: float) -> Mobject:
-        return _callback_operations()._canonical_set_y(self, y)
+    def set_y(self, y: float, direction: object = ORIGIN) -> Mobject:
+        return _callback_operations()._canonical_set_y(self, y, direction)
 
     def scale(self, *args: object, **kwargs: object) -> Mobject:
         return _callback_operations()._canonical_scale(self, *args, **kwargs)

--- a/web/python/test_canonical_line_match.py
+++ b/web/python/test_canonical_line_match.py
@@ -50,7 +50,7 @@ class CanonicalLineMatchTests(unittest.TestCase):
             assert manim.Line.__init__.__module__ == "_manim_compat"
             import _manim_geometry  # installs match_points
             import _manim_updaters as updaters
-            updaters.install()
+
 
             line = manim.Line((-1.0, 0.0), (1.0, 0.0))
             assert len(allocations) == 1, len(allocations)

--- a/web/python/test_canonical_line_match.py
+++ b/web/python/test_canonical_line_match.py
@@ -45,7 +45,7 @@ class CanonicalLineMatchTests(unittest.TestCase):
             import _manim_compat as manim
             manim.install()
             import _manim_semantic_handles as handles
-            handles.install()
+
             assert handles._create_geometry_handle is not None
             assert manim.Line.__init__.__module__ == "_manim_compat"
             import _manim_geometry  # installs match_points

--- a/web/python/test_manim_animate_semantic_handles.py
+++ b/web/python/test_manim_animate_semantic_handles.py
@@ -132,7 +132,7 @@ class ManimAnimateSemanticHandleTests(unittest.TestCase):
             import _manim_semantic_handles as handles
             import _typed_geometry_test_support as _geometry_test
             _geometry_test.install_module_bridge(handles, FakeHandle)
-            handles.install()
+
             import _manim_animate as animate
 
             from noon import BLUE, LEFT, ORANGE, Scene, Square, VGroup

--- a/web/python/test_manim_dot_ellipse.py
+++ b/web/python/test_manim_dot_ellipse.py
@@ -89,7 +89,7 @@ class ManimDotEllipseTests(unittest.TestCase):
             _manim_compat.install()
             import _manim_geometry
             import _manim_semantic_handles as handles
-            handles.install()
+
             import _manim_shared_geometry
             _manim_shared_geometry.install()
 

--- a/web/python/test_manim_group_animate_shared_target.py
+++ b/web/python/test_manim_group_animate_shared_target.py
@@ -122,7 +122,7 @@ class ManimGroupAnimateSharedTargetTests(unittest.TestCase):
             _manim_rate_functions.install()
             import _manim_geometry  # installs constructor-free custom Group copy
             import _manim_semantic_handles as handles
-            handles.install()
+
             import _manim_animate  # noqa: F401
 
             from noon import ORANGE, RIGHT, Square, VGroup

--- a/web/python/test_manim_live_text_constructor.py
+++ b/web/python/test_manim_live_text_constructor.py
@@ -23,7 +23,7 @@ class ManimLiveTextConstructorTests(unittest.TestCase):
             import _manim_semantic_handles as handles
             import _typed_geometry_test_support as _geometry_test
             _geometry_test.install_module_bridge(handles, lambda *args: object())
-            handles.install()
+
             import _manim_typst as typst
             import noon
 

--- a/web/python/test_manim_rotate_semantics.py
+++ b/web/python/test_manim_rotate_semantics.py
@@ -83,7 +83,7 @@ class ManimRotateSemanticsTests(unittest.TestCase):
   import _typed_geometry_test_support as _geometry_test
 
   _geometry_test.install_module_bridge(handles, FakeHandle)
-  handles.install()
+
   semantic = Line(ORIGIN, RIGHT).shift(2 * RIGHT)
   before = semantic.get_center()
   semantic.rotate(PI / 2)

--- a/web/python/test_manim_rotating_animation.py
+++ b/web/python/test_manim_rotating_animation.py
@@ -50,7 +50,7 @@ class ManimRotatingAnimationTests(unittest.TestCase):
             assert edge.about_point is None and edge.about_edge is RIGHT
             assert edge.anim_args["run_time"] == 2.0
             import _manim_updaters
-            _manim_updaters.install()
+
             import noon
             assert noon.Rotating is Rotating
             from noon import Group, Rotate

--- a/web/python/test_manim_scene_bound_semantic_handles.py
+++ b/web/python/test_manim_scene_bound_semantic_handles.py
@@ -234,7 +234,7 @@ class ManimSceneBoundSemanticHandleTests(unittest.TestCase):
             import _manim_semantic_handles as handles
             import _typed_geometry_test_support as _geometry_test
             _geometry_test.install_module_bridge(handles, FakeHandle)
-            handles.install()
+
             import _manim_animate as animate
 
             from noon import BLUE, GREEN, RIGHT, Circle, Scene, Square

--- a/web/python/test_manim_semantic_handle_color.py
+++ b/web/python/test_manim_semantic_handle_color.py
@@ -102,7 +102,7 @@ class ManimSemanticHandleColorTests(unittest.TestCase):
             import _manim_rate_functions
             _manim_rate_functions.install()
             import _manim_semantic_handles
-            _manim_semantic_handles.install()
+
 
             import _noon_ir as _ir
             import noon as _base

--- a/web/python/test_manim_shared_constructors.py
+++ b/web/python/test_manim_shared_constructors.py
@@ -99,8 +99,15 @@ class ManimSharedConstructorTests(unittest.TestCase):
 
             import _manim_compat
             _manim_compat.install()
+            public_methods = tuple(getattr(_manim_compat._base.Mobject, name)
+                                   for name in ("__init__", "copy", "next_to", "width"))
+            group_shift = _manim_compat.Group.shift
             import _manim_semantic_handles as handles
-            handles.install()
+            assert not hasattr(handles, "install")
+            assert public_methods == tuple(getattr(_manim_compat._base.Mobject, name)
+                                           for name in ("__init__", "copy", "next_to", "width"))
+            assert group_shift is _manim_compat.Group.shift
+
 
             for name in ("Circle", "Rectangle", "Line", "Path"):
                 setattr(_manim_compat._ir, name, lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("Python IR constructor was called")))

--- a/web/python/test_manim_shared_constructors.py
+++ b/web/python/test_manim_shared_constructors.py
@@ -102,6 +102,9 @@ class ManimSharedConstructorTests(unittest.TestCase):
             public_methods = tuple(getattr(_manim_compat._base.Mobject, name)
                                    for name in ("__init__", "copy", "next_to", "width"))
             group_shift = _manim_compat.Group.shift
+            shared_bounds = _manim_compat._bounds_for
+            import _manim_geometry
+            assert _manim_compat._bounds_for is shared_bounds
             import _manim_semantic_handles as handles
             assert not hasattr(handles, "install")
             assert public_methods == tuple(getattr(_manim_compat._base.Mobject, name)

--- a/web/python/test_manim_shared_coordinate_placement.py
+++ b/web/python/test_manim_shared_coordinate_placement.py
@@ -84,7 +84,7 @@ class ManimSharedCoordinatePlacementTests(unittest.TestCase):
             _manim_compat.install()
             import _manim_geometry
             import _manim_semantic_handles as handles
-            handles.install()
+
             import _manim_shared_geometry
             _manim_shared_geometry.install()
 

--- a/web/python/test_manim_shared_dashed_line.py
+++ b/web/python/test_manim_shared_dashed_line.py
@@ -66,7 +66,7 @@ class ManimSharedDashedLineTests(unittest.TestCase):
             _manim_compat.install()
             import _manim_geometry
             import _manim_semantic_handles as handles
-            handles.install()
+
 
             _manim_compat._ir.Path = lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("Python path reconstruction was called"))
 

--- a/web/python/test_manim_shared_elbow.py
+++ b/web/python/test_manim_shared_elbow.py
@@ -112,7 +112,7 @@ class ManimSharedElbowTests(unittest.TestCase):
             _manim_compat.install()
             import _manim_geometry
             import _manim_semantic_handles as handles
-            handles.install()
+
 
             _manim_compat._ir.Path = lambda *args, **kwargs: (_ for _ in ()).throw(
                 AssertionError("Python Path geometry constructor was called")

--- a/web/python/test_manim_shared_family_arrange.py
+++ b/web/python/test_manim_shared_family_arrange.py
@@ -102,7 +102,7 @@ class ManimSharedFamilyArrangeTests(unittest.TestCase):
             _geometry_test.install_module_bridge(handles, store.createMobject)
             import _typed_family_test_support as _family_test
             _family_test.install_bridge(handles, store.createFamily, FakeFamilyHandle, FakeObjectHandle)
-            handles.install()
+
 
             def forbidden_fallback(*args, **kwargs):
                 raise AssertionError(\"Python arrange fallback must not run on shared path\")

--- a/web/python/test_manim_shared_family_identity.py
+++ b/web/python/test_manim_shared_family_identity.py
@@ -103,7 +103,7 @@ class ManimSharedFamilyIdentityTests(unittest.TestCase):
             _geometry_test.install_module_bridge(handles, store.createMobject)
             import _typed_family_test_support as _family_test
             _family_test.install_bridge(handles, store.createFamily, FakeFamilyHandle, FakeObjectHandle)
-            handles.install()
+
 
             from noon import Circle, Square, VGroup
 

--- a/web/python/test_manim_shared_family_relative_placement.py
+++ b/web/python/test_manim_shared_family_relative_placement.py
@@ -147,7 +147,7 @@ class ManimSharedFamilyRelativePlacementTests(unittest.TestCase):
             _geometry_test.install_module_bridge(handles, store.createMobject)
             import _typed_family_test_support as _family_test
             _family_test.install_bridge(handles, store.createFamily, FakeFamilyHandle, FakeObjectHandle)
-            handles.install()
+
 
             from noon import Circle, RIGHT, Square, UP, VGroup
 

--- a/web/python/test_manim_shared_family_translation.py
+++ b/web/python/test_manim_shared_family_translation.py
@@ -137,7 +137,7 @@ class ManimSharedFamilyTranslationTests(unittest.TestCase):
             _geometry_test.install_module_bridge(handles, store.createMobject)
             import _typed_family_test_support as _family_test
             _family_test.install_bridge(handles, store.createFamily, FakeFamilyHandle, FakeObjectHandle)
-            handles.install()
+
 
             from noon import Circle, RIGHT, Square, VGroup
 

--- a/web/python/test_manim_shared_geometry.py
+++ b/web/python/test_manim_shared_geometry.py
@@ -107,7 +107,7 @@ class ManimSharedGeometryTests(unittest.TestCase):
             _manim_compat.install()
             import _manim_geometry
             import _manim_semantic_handles as handles
-            handles.install()
+
 
             _manim_compat._ir.Circle = lambda *args, **kwargs: (_ for _ in ()).throw(
                 AssertionError("Python Circle geometry constructor was called")

--- a/web/python/test_manim_shared_match_xy.py
+++ b/web/python/test_manim_shared_match_xy.py
@@ -66,7 +66,7 @@ class ManimSharedMatchXYTests(unittest.TestCase):
             _manim_compat.install()
             import _manim_geometry
             import _manim_semantic_handles as handles
-            handles.install()
+
             import _manim_shared_geometry
             _manim_shared_geometry.install()
 

--- a/web/python/test_manim_shared_object_observations.py
+++ b/web/python/test_manim_shared_object_observations.py
@@ -56,7 +56,7 @@ class ManimSharedObjectObservationTests(unittest.TestCase):
             rate_functions.install()
             import _manim_geometry
             import _manim_semantic_handles as handles
-            handles.install()
+
 
             from noon import BLUE, Line, Square
 

--- a/web/python/test_manim_shared_object_observations.py
+++ b/web/python/test_manim_shared_object_observations.py
@@ -172,7 +172,7 @@ class ManimSharedObjectObservationTests(unittest.TestCase):
             original_set_color = handles._set_color
             handles._set_color = lambda target, color: calls.append((target, color)) or target
             try:
-                assert rate_functions._set_color_preserving_opacity(line, BLUE) is line
+                assert line.set_color(BLUE) is line
             finally:
                 handles._set_color = original_set_color
             assert calls == [(line, BLUE)]

--- a/web/python/test_manim_shared_placement_handles.py
+++ b/web/python/test_manim_shared_placement_handles.py
@@ -91,7 +91,7 @@ class ManimSharedPlacementHandleTests(unittest.TestCase):
             import _manim_semantic_handles as handles
             import _typed_geometry_test_support as _geometry_test
             _geometry_test.install_module_bridge(handles, FakeHandle)
-            handles.install()
+
 
             from noon import LEFT, RIGHT, Square, UP, UR
 

--- a/web/python/test_manim_shared_rotate_about_origin.py
+++ b/web/python/test_manim_shared_rotate_about_origin.py
@@ -57,7 +57,7 @@ class ManimSharedRotateAboutOriginTests(unittest.TestCase):
             _manim_compat.install()
             import _manim_geometry
             import _manim_semantic_handles as handles
-            handles.install()
+
             import _manim_shared_geometry
             _manim_shared_geometry.install()
 

--- a/web/python/test_manim_shared_rounded_rectangle.py
+++ b/web/python/test_manim_shared_rounded_rectangle.py
@@ -116,7 +116,7 @@ class ManimSharedRoundedRectangleTests(unittest.TestCase):
             _manim_compat.install()
             import _manim_geometry
             import _manim_semantic_handles as handles
-            handles.install()
+
 
             # Any Python-side path construction would violate the shared-geometry boundary.
             _manim_compat._ir.Path = lambda *args, **kwargs: (_ for _ in ()).throw(

--- a/web/python/test_manim_shared_sectors.py
+++ b/web/python/test_manim_shared_sectors.py
@@ -114,7 +114,7 @@ class ManimSharedSectorTests(unittest.TestCase):
             _manim_compat.install()
             import _manim_geometry
             import _manim_semantic_handles as handles
-            handles.install()
+
 
             _manim_compat._ir.Path = lambda *args, **kwargs: (_ for _ in ()).throw(
                 AssertionError("Python Path geometry constructor was called")

--- a/web/python/test_manim_shared_shape_matchers.py
+++ b/web/python/test_manim_shared_shape_matchers.py
@@ -267,7 +267,7 @@ class ManimSharedShapeMatcherTests(unittest.TestCase):
             _geometry_test.install_module_bridge(handles, store.createMobject)
             import _typed_family_test_support as _family_test
             _family_test.install_bridge(handles, store.createFamily, FakeFamilyHandle, FakeHandle)
-            handles.install()
+
 
             import noon as _base
             _base._bounds = lambda *args, **kwargs: (_ for _ in ()).throw(

--- a/web/python/test_manim_shared_underline.py
+++ b/web/python/test_manim_shared_underline.py
@@ -135,7 +135,7 @@ class ManimSharedUnderlineTests(unittest.TestCase):
             _manim_compat.install()
             import _manim_geometry
             import _manim_semantic_handles as handles
-            handles.install()
+
 
             # Underline geometry and placement must stay below the Python facade.
             _manim_compat._ir.Line = lambda *args, **kwargs: (_ for _ in ()).throw(

--- a/web/python/test_manim_show_passing_flash.py
+++ b/web/python/test_manim_show_passing_flash.py
@@ -56,7 +56,7 @@ class ManimShowPassingFlashTests(unittest.TestCase):
             _manim_composition.install()
             assert _manim_compat.Scene.play is play_before_composition
             import _manim_semantic_handles as handles
-            handles.install()
+
             import _manim_indication
 
             play_before = _manim_compat.Scene.play

--- a/web/python/test_moving_dots_primitives.py
+++ b/web/python/test_moving_dots_primitives.py
@@ -34,7 +34,6 @@ class MovingDotsPrimitiveTests(unittest.TestCase):
             import _manim_updaters as updaters
             import noon as api
 
-            updaters.install()
 
             # Read the pinned callback view during the ordered phase and the
             # shared published value afterwards; Python owns neither value.

--- a/web/python/test_updater_snapshot.py
+++ b/web/python/test_updater_snapshot.py
@@ -52,14 +52,10 @@ class CanonicalCallbackPropertyRowTests(unittest.TestCase):
     def _mobject_and_context() -> tuple[object, object, object]:
         compat.install()
         install_test_membership(compat)
-        import _manim_semantic_handles as semantic_handles
+        # Public paint methods always enter the phase dispatcher; no final
+        # installer is needed to reclaim VMobject's overrides.
+        assert not hasattr(updaters, "install")
 
-        if not updaters._INSTALLED:
-            # Mirror the production final method that otherwise bypasses the
-            # base Mobject patch. Updater installation must reclaim it.
-
-            compat.VMobject.set_opacity = semantic_handles._set_opacity
-            updaters.install()
         scene = updaters._base.Scene()
         mobject = identity_only_wrapper(compat.Circle)
         scene.add(mobject)
@@ -287,7 +283,7 @@ class CanonicalCallbackPropertyRowTests(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             updaters._canonical_callback_time(mobject)
 
-        self.assertIs(compat.VMobject.set_opacity, updaters._canonical_vmobject_set_opacity)
+        self.assertEqual(compat.VMobject.set_opacity.__module__, "_manim_compat")
         self.assertEqual(
             [write["kind"] for write in writes],
             ["transform", "style", "style", "transform"],

--- a/web/python/test_updater_snapshot.py
+++ b/web/python/test_updater_snapshot.py
@@ -36,7 +36,11 @@ class CanonicalCallbackPropertyRowTests(unittest.TestCase):
         scene, mobject, context = self._mobject_and_context()
         public_set_x = updaters._base.Mobject.set_x
         public_set_y = updaters._base.Mobject.set_y
+        public_set_color = updaters._base.Mobject.set_color
+        import _manim_rate_functions as rates
+        rates.install()
         geometry.install()
+        self.assertIs(updaters._base.Mobject.set_color, public_set_color)
         self.assertIs(updaters._base.Mobject.set_x, public_set_x)
         self.assertIs(updaters._base.Mobject.set_y, public_set_y)
         updaters._ACTIVE_CONTEXTS[id(scene)] = context

--- a/web/python/test_updater_snapshot.py
+++ b/web/python/test_updater_snapshot.py
@@ -30,6 +30,23 @@ def _object(index: int) -> dict:
 
 
 class CanonicalCallbackPropertyRowTests(unittest.TestCase):
+    def test_geometry_adapter_keeps_coordinate_writes_in_callback_phase(self) -> None:
+        import _manim_shared_geometry as geometry
+
+        scene, mobject, context = self._mobject_and_context()
+        public_set_x = updaters._base.Mobject.set_x
+        public_set_y = updaters._base.Mobject.set_y
+        geometry.install()
+        self.assertIs(updaters._base.Mobject.set_x, public_set_x)
+        self.assertIs(updaters._base.Mobject.set_y, public_set_y)
+        updaters._ACTIVE_CONTEXTS[id(scene)] = context
+        try:
+            self.assertIs(mobject.set_x(5.0).set_y(4.0), mobject)
+            self.assertEqual(mobject.get_center(), updaters._base.Vec2(5.0, 4.0))
+            self.assertTrue(context.effective_batch()["writes"])
+        finally:
+            updaters._ACTIVE_CONTEXTS.pop(id(scene), None)
+
     def test_style_wire_uses_rust_default_and_preserves_explicit_mode(self) -> None:
         omitted_default = _object(0)["style"]
         self.assertNotIn("stroke_width_mode", omitted_default)


### PR DESCRIPTION
Python constructor, copy/layout and callback operations depended on import-time assignments, captured methods and final installers. Make those public facade methods explicit, retaining Rust semantic ownership and the existing staged callback view. Delete the semantic-handle and updater installers, captured-method globals, stale geometry bounds override, and geometry/rate-function assignments that could bypass callback dispatch.

This PR includes the callback-dispatch work from #1303. Advances #61 A3.1/A3.6/A3.7 and #959. No new semantic authority, scheduler, transport or mutation protocol; constant-time dispatch and existing family locality remain unchanged. Existing placement/per-member callback fallbacks and raw/export constructor inputs remain owned by #61/#955.

Validation at `83055b2e06f3e9b7e0dc7a0408869cc2e8885e29`: full hosted CI run 34317971258 passed all seven jobs; every PR check passed, including Chromium, Firefox, mobile WebKit, shared Python text, recovery, and product visual/latency/FPS regression. Local frontend preflight and all 146 Python tests passed, as did the architecture gate. Import-order regressions protect constructor/layout/bounds/coordinate/color dispatch and staged callback writes. Existing paired native Rust/direct-WASM/Python examples qualify unchanged semantics. No local Rust/WASM build due to disk constraints.

Qualification consolidation: #1303 also passed full CI, product regression, Chromium and mobile WebKit. Its sole Firefox failure was a failed CDN/CORS fetch of `pyodide.mjs` in Uncreate before any execution revision or samples; MovingDots passed. This combined exact head passed the entire Firefox gallery. Merge this fully qualified superset rather than rerunning the superseded smaller head; thresholds are unchanged.
