### PR TITLE
Use direct Python geometry constructors and observations

### DIFF
--- a/compat/semantic-ownership-v1.json
+++ b/compat/semantic-ownership-v1.json
@@ -9,6 +9,7 @@
     "shared-rust"
   ],
   "duplicate_debt_budgets": [
+    {"path": "web/python/_manim_shared_geometry.py", "token": "_ORIGINAL_", "maximum": 0, "migration_issue": "#61"},
     {"path": "web/python/noon.py", "token": "def _bounds(", "maximum": 0, "migration_issue": "#61"},
     {"path": "web/python/noon.py", "token": "def _raw_mobject(", "maximum": 0, "migration_issue": "#61"},
     {"path": "web/python/_manim_semantic_handles.py", "token": "_ORIGINAL_", "maximum": 0, "migration_issue": "#61"},

--- a/web/python/_manim_compat.py
+++ b/web/python/_manim_compat.py
@@ -202,6 +202,14 @@ class Line(VMobject):
         from _manim_semantic_handles import _line_init
         _line_init(self, start, end, color=color, **kwargs)
 
+    def get_start(self) -> _base.Vec2:
+        from _manim_geometry import _line_get_start
+        return _line_get_start(self)
+
+    def get_end(self) -> _base.Vec2:
+        from _manim_geometry import _line_get_end
+        return _line_get_end(self)
+
 
 class Path(VMobject):
     def __init__(
@@ -479,6 +487,10 @@ class Group(_base.Group, _BaseMobject):
 
     def __deepcopy__(self, memo):
         return deepcopy_semantic_wrapper(self, memo)
+
+    def get_color(self) -> _base.Color:
+        from _manim_geometry import _group_get_color
+        return _group_get_color(self)
 
 
 class VGroup(Group):

--- a/web/python/_manim_geometry.py
+++ b/web/python/_manim_geometry.py
@@ -30,45 +30,24 @@ class Dot(_compat.Circle):
         color: _base.Color = _base.WHITE,
         **kwargs: Any,
     ) -> None:
-        super().__init__(
-            radius=radius,
-            stroke_width=stroke_width,
-            fill_opacity=fill_opacity,
-            color=color,
-            **kwargs,
-        )
-        self.move_to(_compat._as_vec2(point))
+        from _manim_shared_geometry import _dot_init
+        _dot_init(self, point, radius, stroke_width, fill_opacity, color, **kwargs)
 
 
 class Ellipse(_compat.Circle):
-    """Manim-compatible ellipse.
-
-    The browser bridge replaces this initializer with shared Rust geometry and
-    layout semantics. This constructor remains only for the retained-only fallback
-    owned for deletion by #959.
-    """
+    """Manim-compatible ellipse backed by the shared Rust constructor."""
 
     def __init__(self, width: float = 2.0, height: float = 1.0, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
-        self.stretch_to_fit_width(float(width))
-        self.stretch_to_fit_height(float(height))
+        from _manim_shared_geometry import _ellipse_init
+        _ellipse_init(self, width, height, **kwargs)
 
 
 class Triangle(_compat.Path):
     """Manim-compatible equilateral ``Triangle`` with RegularPolygon defaults."""
 
     def __init__(self, **kwargs: Any) -> None:
-        points = [
-            _base.Vec2(
-                math.cos(math.pi / 2.0 + index * _base.TAU / 3.0),
-                math.sin(math.pi / 2.0 + index * _base.TAU / 3.0),
-            )
-            for index in range(3)
-        ]
-        path = _base.VectorPath().move_to(points[0])
-        for point in points[1:]:
-            path.line_to(point)
-        super().__init__(path.close(), **kwargs)
+        from _manim_shared_geometry import _triangle_init
+        _triangle_init(self, **kwargs)
 
 
 def _line_get_start(self: _compat.Line) -> _base.Vec2:
@@ -307,12 +286,7 @@ def install() -> None:
         if name not in {"DEFAULT_DOT_RADIUS", "PURE_YELLOW"}:
             setattr(_compat, name, value)
 
-    _compat.Line.get_start = _line_get_start
-    _compat.Line.get_end = _line_get_end
-    _base.Mobject.get_color = _mobject_get_color
-    _compat.Group.get_color = _group_get_color
 
-    _base.Mobject.match_points = match_points
 
     exports = list(_base.__all__)
     for name in public:

--- a/web/python/_manim_shared_geometry.py
+++ b/web/python/_manim_shared_geometry.py
@@ -15,9 +15,6 @@ import _manim_compat as _compat
 import _manim_geometry as _geometry
 import _manim_semantic_handles as _shared
 
-_ORIGINAL_DOT_INIT = _geometry.Dot.__init__
-_ORIGINAL_ELLIPSE_INIT = _geometry.Ellipse.__init__
-_ORIGINAL_TRIANGLE_INIT = _geometry.Triangle.__init__
 _INSTALLED = False
 
 
@@ -139,16 +136,7 @@ def _dot_init(
     **kwargs: Any,
 ) -> None:
     if _shared._create_geometry_handle is None:
-        _ORIGINAL_DOT_INIT(
-            self,
-            point=point,
-            radius=radius,
-            stroke_width=stroke_width,
-            fill_opacity=fill_opacity,
-            color=color,
-            **kwargs,
-        )
-        return
+        raise RuntimeError("Geometry construction requires the shared Rust authoring host")
 
     point_value = _compat._as_vec2(point)
     radius_value = _shared._ir._positive_number("radius", radius)
@@ -166,8 +154,7 @@ def _dot_init(
 
 def _triangle_init(self: _geometry.Triangle, **kwargs: Any) -> None:
     if _shared._create_geometry_handle is None:
-        _ORIGINAL_TRIANGLE_INIT(self, **kwargs)
-        return
+        raise RuntimeError("Geometry construction requires the shared Rust authoring host")
 
     options = dict(kwargs)
     color = options.pop("color", None)
@@ -184,8 +171,7 @@ def _ellipse_init(
     **kwargs: Any,
 ) -> None:
     if _shared._create_geometry_handle is None:
-        _ORIGINAL_ELLIPSE_INIT(self, width=width, height=height, **kwargs)
-        return
+        raise RuntimeError("Geometry construction requires the shared Rust authoring host")
 
     width_value = _shared._ir._positive_number("width", width)
     height_value = _shared._ir._positive_number("height", height)
@@ -560,10 +546,6 @@ def install() -> None:
     _base.Mobject.match_x = _match_x
     _base.Mobject.match_y = _match_y
     _base.Mobject.rotate_about_origin = _rotate_about_origin
-    if _shared._create_geometry_handle is not None:
-        _geometry.Dot.__init__ = _dot_init
-        _geometry.Ellipse.__init__ = _ellipse_init
-        _geometry.Triangle.__init__ = _triangle_init
 
     public = {
         "Elbow": Elbow,

--- a/web/python/noon.py
+++ b/web/python/noon.py
@@ -251,6 +251,14 @@ class Mobject:
     def _apply(self, raw: object) -> Mobject:
         return _callback_operations()._canonical_apply(self, raw)
 
+    def get_color(self) -> Color:
+        from _manim_geometry import _mobject_get_color
+        return _mobject_get_color(self)
+
+    def match_points(self, mobject: object) -> Mobject:
+        from _manim_geometry import match_points
+        return match_points(self, mobject)
+
     def get_center(self) -> Vec2:
         return _callback_operations()._canonical_get_center(self)
 

--- a/web/python/test_manim_shared_geometry.py
+++ b/web/python/test_manim_shared_geometry.py
@@ -116,8 +116,13 @@ class ManimSharedGeometryTests(unittest.TestCase):
                 AssertionError("Python Path geometry constructor was called")
             )
 
+            constructors = tuple(cls.__init__ for cls in
+                                 (_manim_geometry.Dot, _manim_geometry.Ellipse, _manim_geometry.Triangle))
             import _manim_shared_geometry
             _manim_shared_geometry.install()
+            assert constructors == tuple(cls.__init__ for cls in
+                                         (_manim_geometry.Dot, _manim_geometry.Ellipse, _manim_geometry.Triangle))
+            assert not any(name.startswith("_ORIGINAL_") for name in vars(_manim_shared_geometry))
             from noon import Dot, Triangle
 
             dot_obj = Dot((2.0, -3.0, 0.0), radius=0.2)


### PR DESCRIPTION
Dot, Ellipse and Triangle previously depended on a later installer replacing their constructors, retaining separate Python construction paths. Their stable constructors now invoke the shared Rust geometry adapters directly. Line endpoint queries, color observation and line matching are explicit public methods rather than import-time assignments. The obsolete constructor fallbacks and captured initializers are deleted.

Advances #61 A3.1/A3.7 and #959. Python owns signatures and coercion; Rust continues to own construction and observation. No new migration seam, authority, transport or scheduling behavior. Existing locality and paired Rust/Python semantics are unchanged. Other legacy raw/export shapes remain tracked in #61.

Validation: `NOON_WEB_PREFLIGHT_ONLY=1 bash scripts/build-web-demo.sh` passed all frontend checks and 146 Python tests; `bash scripts/check-architecture.sh` passed. Existing typed-constructor tests now also protect stable constructor identity across adapter installation. The ownership ratchet rejects captured initializers. Hosted full/native/direct-WASM/Python and browser qualification is required before merge; no local Rust/WASM build due to disk constraints.
