### PR TITLE
Remove legacy object payloads from the semantic store

### DIFF
--- a/compat/semantic-ownership-v1.json
+++ b/compat/semantic-ownership-v1.json
@@ -9,8 +9,6 @@
     "shared-rust"
   ],
   "duplicate_debt_budgets": [
-    {"path": "crates/noon-core/src/semantic_store.rs", "token": "ObjectDefinition", "maximum": 0, "migration_issue": "#959"},
-    {"path": "crates/noon-core/src/semantic_store.rs", "token": "from_scene_definition", "maximum": 0, "migration_issue": "#959"},
     {"path": "web/python/_manim_shared_geometry.py", "token": "_ORIGINAL_", "maximum": 0, "migration_issue": "#61"},
     {"path": "web/python/noon.py", "token": "def _bounds(", "maximum": 0, "migration_issue": "#61"},
     {"path": "web/python/noon.py", "token": "def _raw_mobject(", "maximum": 0, "migration_issue": "#61"},

--- a/compat/semantic-ownership-v1.json
+++ b/compat/semantic-ownership-v1.json
@@ -9,6 +9,8 @@
     "shared-rust"
   ],
   "duplicate_debt_budgets": [
+    {"path": "crates/noon-core/src/semantic_store.rs", "token": "ObjectDefinition", "maximum": 0, "migration_issue": "#959"},
+    {"path": "crates/noon-core/src/semantic_store.rs", "token": "from_scene_definition", "maximum": 0, "migration_issue": "#959"},
     {"path": "web/python/noon.py", "token": "def _bounds(", "maximum": 0, "migration_issue": "#61"},
     {"path": "web/python/noon.py", "token": "def _raw_mobject(", "maximum": 0, "migration_issue": "#61"},
     {"path": "web/python/_manim_semantic_handles.py", "token": "_ORIGINAL_", "maximum": 0, "migration_issue": "#61"},

--- a/crates/noon-compile/src/semantic_lowering/publication.rs
+++ b/crates/noon-compile/src/semantic_lowering/publication.rs
@@ -399,9 +399,7 @@ fn prepare_semantic_publication_with_handled_scalar_signals(
                     );
                     if !matches!(
                         kind.kind(),
-                        SemanticNodeKind::Object(_)
-                            | SemanticNodeKind::AuthoringObject
-                            | SemanticNodeKind::Family
+                        SemanticNodeKind::AuthoringObject | SemanticNodeKind::Family
                     ) {
                         return Err(SemanticPublicationLoweringError::UnsupportedNodeRemoval {
                             node,
@@ -492,7 +490,7 @@ fn collect_existing_exit_leaves(
         SemanticLoweringError::Store(noon_core::SemanticStoreError::UnknownNode(node))
     })?;
     match semantic.kind() {
-        SemanticNodeKind::Object(_) | SemanticNodeKind::AuthoringObject => {
+        SemanticNodeKind::AuthoringObject => {
             let state = semantic.semantic_object_state();
             if state.is_some_and(|state| {
                 matches!(state.role(), noon_core::SemanticObjectRole::Camera2D)

--- a/crates/noon-compile/src/semantic_lowering/reachability.rs
+++ b/crates/noon-compile/src/semantic_lowering/reachability.rs
@@ -330,9 +330,7 @@ impl SemanticExecutionReachability {
             SemanticStoreError::UnknownNode(id),
         ))?;
         let kind = match node.kind() {
-            SemanticNodeKind::Object(_) | SemanticNodeKind::AuthoringObject => {
-                ReachabilityKind::Object
-            }
+            SemanticNodeKind::AuthoringObject => ReachabilityKind::Object,
             SemanticNodeKind::Family => ReachabilityKind::Family {
                 members: HashSet::new(),
             },

--- a/crates/noon-compile/src/semantic_lowering/root_order.rs
+++ b/crates/noon-compile/src/semantic_lowering/root_order.rs
@@ -31,7 +31,7 @@ pub fn prepare_semantic_root_order(
             ))
         })?;
         match node_state.kind() {
-            SemanticNodeKind::Object(_) | SemanticNodeKind::AuthoringObject => output.push(node),
+            SemanticNodeKind::AuthoringObject => output.push(node),
             SemanticNodeKind::Family => {
                 for member in node_state.members() {
                     leaves(store, member, output)?;

--- a/crates/noon-core/src/reactive/semantic_declarations.rs
+++ b/crates/noon-core/src/reactive/semantic_declarations.rs
@@ -149,9 +149,7 @@ fn target_node_checked(
     let is_target = match node.kind() {
         SemanticNodeKind::Family => true,
         SemanticNodeKind::AuthoringObject => node.semantic_object_state().is_some(),
-        SemanticNodeKind::Object(_)
-        | SemanticNodeKind::Signal(_)
-        | SemanticNodeKind::Animation(_) => false,
+        SemanticNodeKind::Signal(_) | SemanticNodeKind::Animation(_) => false,
     };
     if !is_target {
         return Err(SemanticSceneOperationError::NotSemanticAuthoringNode(id));

--- a/crates/noon-core/src/reactive/semantic_family.rs
+++ b/crates/noon-core/src/reactive/semantic_family.rs
@@ -131,10 +131,8 @@ impl SemanticStore {
                 | (SemanticNodeKind::AuthoringObject, SemanticNodeKind::Family) => {
                     Err(SemanticFamilyPairingError::TopologyMismatch { source, target })
                 }
-                (SemanticNodeKind::Object(_), _)
-                | (SemanticNodeKind::Signal(_), _)
+                (SemanticNodeKind::Signal(_), _)
                 | (SemanticNodeKind::Animation(_), _)
-                | (_, SemanticNodeKind::Object(_))
                 | (_, SemanticNodeKind::Signal(_))
                 | (_, SemanticNodeKind::Animation(_)) => {
                     let unsupported = if !matches!(
@@ -188,7 +186,7 @@ impl SemanticStore {
                 return Ok(());
             }
             match node.kind() {
-                SemanticNodeKind::Object(_) | SemanticNodeKind::AuthoringObject => {
+                SemanticNodeKind::AuthoringObject => {
                     leaves.push(node_id);
                 }
                 SemanticNodeKind::Family => {
@@ -214,18 +212,17 @@ impl SemanticStore {
 
 #[cfg(test)]
 mod tests {
-    use crate::{GeometryRef, ObjectDefinition, ObjectId};
+    use crate::{SemanticObjectState, StoredGeometry};
 
     use super::*;
-
-    fn object(id: u64) -> ObjectDefinition {
-        ObjectDefinition::new(ObjectId::new(id), GeometryRef::circle(1.0))
-    }
 
     #[test]
     fn leaf_target_is_its_own_ordered_leaf_sequence() {
         let mut store = SemanticStore::new();
-        let object = store.insert_object(object(1));
+        let object =
+            store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+                radius: 1.0,
+            }));
         let authoring = store.insert_authoring_object();
 
         assert_eq!(store.ordered_leaf_nodes(object).unwrap(), vec![object]);

--- a/crates/noon-core/src/reactive/semantic_scene_operations.rs
+++ b/crates/noon-core/src/reactive/semantic_scene_operations.rs
@@ -128,9 +128,7 @@ impl SemanticStore {
         let is_target = match node.kind() {
             SemanticNodeKind::Family => true,
             SemanticNodeKind::AuthoringObject => node.semantic_object_state().is_some(),
-            SemanticNodeKind::Object(_)
-            | SemanticNodeKind::Signal(_)
-            | SemanticNodeKind::Animation(_) => false,
+            SemanticNodeKind::Signal(_) | SemanticNodeKind::Animation(_) => false,
         };
         if !is_target {
             return Err(SemanticSceneOperationError::NotSemanticAuthoringNode(id));

--- a/crates/noon-core/src/reactive/semantic_scene_restructure.rs
+++ b/crates/noon-core/src/reactive/semantic_scene_restructure.rs
@@ -355,9 +355,7 @@ fn target_node_checked(
     let is_target = match node.kind() {
         SemanticNodeKind::Family => true,
         SemanticNodeKind::AuthoringObject => node.semantic_object_state().is_some(),
-        SemanticNodeKind::Object(_)
-        | SemanticNodeKind::Signal(_)
-        | SemanticNodeKind::Animation(_) => false,
+        SemanticNodeKind::Signal(_) | SemanticNodeKind::Animation(_) => false,
     };
     if !is_target {
         return Err(SemanticSceneOperationError::NotSemanticAuthoringNode(id));

--- a/crates/noon-core/src/semantic_store.rs
+++ b/crates/noon-core/src/semantic_store.rs
@@ -20,7 +20,6 @@ impl std::hash::Hash for SemanticStoreIdentity {
     }
 }
 
-use crate::{ObjectDefinition, ObjectId, SceneDefinition};
 use crate::{
     SemanticAnimationState, SemanticObjectState, SemanticSignalState, SemanticUpdaterRegistration,
 };
@@ -255,8 +254,6 @@ impl OrderedFamilyMembers {
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum SemanticNodeKind {
-    /// Compatibility payload while `SceneDefinition` consumers migrate.
-    Object(ObjectDefinition),
     /// Semantic object identity. Target objects carry `SemanticObjectState`
     /// directly on the node. State-less instances exist only for the temporary
     /// frontend identity seam and are owned for migration by #61/#959.
@@ -277,8 +274,8 @@ pub struct SemanticNode {
     kind: SemanticNodeKind,
     /// Authoritative authored object payload for target semantic objects.
     ///
-    /// `None` is valid for families, signals, animations, legacy compatibility
-    /// objects, and the temporary state-less frontend identity seam only.
+    /// `None` is valid for families, signals, animations, and the temporary
+    /// state-less frontend identity seam only.
     object_state: Option<SemanticObjectState>,
     source_identity: Option<SourceIdentity>,
     scene_membership: SemanticSceneMembership,
@@ -317,26 +314,6 @@ impl SemanticNode {
         match &mut self.kind {
             SemanticNodeKind::Signal(state) => Some(state),
             _ => None,
-        }
-    }
-
-    pub fn object(&self) -> Option<&ObjectDefinition> {
-        match &self.kind {
-            SemanticNodeKind::Object(object) => Some(object),
-            SemanticNodeKind::AuthoringObject
-            | SemanticNodeKind::Family
-            | SemanticNodeKind::Signal(_)
-            | SemanticNodeKind::Animation(_) => None,
-        }
-    }
-
-    pub fn object_mut(&mut self) -> Option<&mut ObjectDefinition> {
-        match &mut self.kind {
-            SemanticNodeKind::Object(object) => Some(object),
-            SemanticNodeKind::AuthoringObject
-            | SemanticNodeKind::Family
-            | SemanticNodeKind::Signal(_)
-            | SemanticNodeKind::Animation(_) => None,
         }
     }
 
@@ -461,7 +438,6 @@ pub struct SemanticStore {
     scene_tail: Option<SemanticNodeId>,
     scene_nodes: usize,
     next_insertion_order: u64,
-    object_nodes: HashMap<ObjectId, SemanticNodeId>,
     source_nodes: HashMap<SourceIdentity, SemanticNodeId>,
     incoming_references: HashMap<SemanticNodeId, Vec<SemanticIncomingReference>>,
     last_mutation: SemanticMutationStats,
@@ -517,7 +493,6 @@ impl Clone for SemanticStore {
             scene_tail: self.scene_tail,
             scene_nodes: self.scene_nodes,
             next_insertion_order: self.next_insertion_order,
-            object_nodes: self.object_nodes.clone(),
             source_nodes: self.source_nodes.clone(),
             incoming_references: self.incoming_references.clone(),
             last_mutation: self.last_mutation,
@@ -558,29 +533,6 @@ impl SemanticStore {
 
     pub fn new() -> Self {
         Self::default()
-    }
-
-    /// Compatibility adapter for the current flat scene model.
-    ///
-    /// This adapter is migration-only and is owned for deletion by #959/A4.
-    /// Objects are attached in legacy authored order so current callers remain
-    /// coherent while the authoritative semantic authoring path replaces it.
-    pub fn from_scene_definition(scene: &SceneDefinition) -> Self {
-        let mut store = Self::new();
-        for object in scene.objects() {
-            let id = store.insert_object(object.clone());
-            store
-                .attach_to_scene(id)
-                .expect("newly inserted compatibility node exists");
-        }
-        store
-    }
-
-    pub fn insert_object(&mut self, object: ObjectDefinition) -> SemanticNodeId {
-        let legacy_id = object.id;
-        let id = self.insert_kind(SemanticNodeKind::Object(object));
-        self.object_nodes.insert(legacy_id, id);
-        id
     }
 
     /// Insert a target semantic object whose authored payload is owned directly by
@@ -695,13 +647,6 @@ impl SemanticStore {
             return None;
         }
         slot.node.as_mut()
-    }
-
-    pub fn node_for_object(&self, object: ObjectId) -> Option<SemanticNodeId> {
-        self.object_nodes
-            .get(&object)
-            .copied()
-            .filter(|id| self.node(*id).is_some())
     }
 
     pub fn node_for_source(&self, source: &SourceIdentity) -> Option<SemanticNodeId> {
@@ -1237,9 +1182,6 @@ impl SemanticStore {
                 writes += 1;
             }
         }
-        if let SemanticNodeKind::Object(object) = &node.kind {
-            self.object_nodes.remove(&object.id);
-        }
         if let Some(source) = &node.source_identity {
             self.source_nodes.remove(source);
         }
@@ -1376,7 +1318,7 @@ impl std::error::Error for SemanticStoreError {}
 
 #[cfg(test)]
 mod tests {
-    use crate::GeometryRef;
+    use crate::StoredGeometry;
 
     use super::*;
 
@@ -1471,8 +1413,8 @@ mod tests {
         ));
     }
 
-    fn object(id: u64) -> ObjectDefinition {
-        ObjectDefinition::new(ObjectId::new(id), GeometryRef::circle(1.0))
+    fn object() -> SemanticObjectState {
+        SemanticObjectState::new(StoredGeometry::Circle { radius: 1.0 })
     }
 
     #[test]
@@ -1575,7 +1517,7 @@ mod tests {
     fn deletion_does_not_renumber_unrelated_semantic_handles() {
         let mut store = SemanticStore::new();
         let ids = (0..100_000)
-            .map(|index| store.insert_object(object(index)))
+            .map(|_| store.insert_semantic_object(object()))
             .collect::<Vec<_>>();
         let tail = ids[99_999];
         store.remove_node(ids[10]).unwrap();
@@ -1675,10 +1617,10 @@ mod tests {
     #[test]
     fn reused_slot_invalidates_stale_generation_for_all_lifecycle_operations() {
         let mut store = SemanticStore::new();
-        let first = store.insert_object(object(1));
+        let first = store.insert_semantic_object(object());
         store.attach_to_scene(first).unwrap();
         store.remove_node(first).unwrap();
-        let second = store.insert_object(object(2));
+        let second = store.insert_semantic_object(object());
 
         assert_eq!(first.slot(), second.slot());
         assert_ne!(first.generation(), second.generation());
@@ -1720,7 +1662,7 @@ mod tests {
         let mut store = SemanticStore::new();
         let first_family = store.insert_family();
         let second_family = store.insert_family();
-        let child = store.insert_object(object(1));
+        let child = store.insert_semantic_object(object());
         store.add_member(first_family, child).unwrap();
         store.add_member(second_family, child).unwrap();
         assert_eq!(
@@ -1783,8 +1725,8 @@ mod tests {
     #[test]
     fn source_identity_is_unique_stable_and_released_on_delete() {
         let mut store = SemanticStore::new();
-        let first = store.insert_object(object(1));
-        let second = store.insert_object(object(2));
+        let first = store.insert_semantic_object(object());
+        let second = store.insert_semantic_object(object());
         let source = SourceIdentity::ExplicitKey("hero".into());
 
         store
@@ -1804,23 +1746,5 @@ mod tests {
             .set_source_identity(second, Some(source.clone()))
             .unwrap();
         assert_eq!(store.node_for_source(&source), Some(second));
-    }
-
-    #[test]
-    fn flat_scene_adapter_preserves_legacy_lookup_and_root_order() {
-        // Compatibility-only regression owned for deletion by #959/A4.
-        let mut scene = SceneDefinition::new();
-        let first = scene.add(GeometryRef::circle(1.0));
-        let second = scene.add(GeometryRef::rectangle(2.0, 1.0));
-        let store = SemanticStore::from_scene_definition(&scene);
-        let first_node = store.node_for_object(first).unwrap();
-        let second_node = store.node_for_object(second).unwrap();
-
-        assert!(store.node(first_node).unwrap().is_scene_owned());
-        assert!(store.node(second_node).unwrap().is_scene_owned());
-        assert_eq!(
-            store.scene_roots().collect::<Vec<_>>(),
-            vec![first_node, second_node]
-        );
     }
 }

--- a/crates/noon-core/src/semantic_store/semantic_references.rs
+++ b/crates/noon-core/src/semantic_store/semantic_references.rs
@@ -383,9 +383,7 @@ fn outgoing_references(node: &SemanticNode) -> Vec<(SemanticNodeId, SemanticRefe
                 );
             }
         },
-        SemanticNodeKind::Object(_)
-        | SemanticNodeKind::AuthoringObject
-        | SemanticNodeKind::Family => {}
+        SemanticNodeKind::AuthoringObject | SemanticNodeKind::Family => {}
     }
 
     references

--- a/crates/noon-core/tests/property_invariants.rs
+++ b/crates/noon-core/tests/property_invariants.rs
@@ -1,5 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
+use noon_core::{SemanticObjectState, StoredGeometry};
+
 use noon_core::{
     CompositionTimeMap, CompositionTimeMapStep, GeometryRef, MutationTransaction, ObjectDefinition,
     ObjectId, RateFunction, SceneDefinition, ScenePatch, SemanticNodeId, SemanticStore,
@@ -43,8 +45,8 @@ struct ModelNode {
     source: Option<String>,
 }
 
-fn object(id: u64) -> ObjectDefinition {
-    ObjectDefinition::new(ObjectId::new(id), GeometryRef::circle(1.0))
+fn object() -> SemanticObjectState {
+    SemanticObjectState::new(StoredGeometry::Circle { radius: 1.0 })
 }
 
 fn model_index(nodes: &[ModelNode], id: SemanticNodeId) -> usize {
@@ -142,7 +144,6 @@ fn semantic_store_matches_reference_model_across_seeded_mutation_sequences() {
         let mut rng = Rng::new(seed);
         let mut store = SemanticStore::new();
         let mut nodes: Vec<ModelNode> = Vec::new();
-        let mut next_object = 0_u64;
 
         for step in 0..750 {
             let live_indices = nodes
@@ -162,9 +163,7 @@ fn semantic_store_matches_reference_model_across_seeded_mutation_sequences() {
                     let id = if family {
                         store.insert_family()
                     } else {
-                        let id = store.insert_object(object(next_object));
-                        next_object += 1;
-                        id
+                        store.insert_semantic_object(object())
                     };
                     nodes.push(ModelNode {
                         id,
@@ -441,13 +440,13 @@ fn source_identity_uniqueness_survives_reassignment_and_slot_reuse() {
         let mut live = Vec::new();
         let mut expected_owner: HashMap<String, SemanticNodeId> = HashMap::new();
 
-        for object_id in 0..40_u64 {
-            live.push(store.insert_object(object(object_id)));
+        for _ in 0..40_u64 {
+            live.push(store.insert_semantic_object(object()));
         }
 
         for step in 0..300 {
             if live.is_empty() {
-                live.push(store.insert_object(object(10_000 + step)));
+                live.push(store.insert_semantic_object(object()));
             }
             let index = rng.index(live.len());
             let id = live[index];
@@ -493,7 +492,7 @@ fn source_identity_uniqueness_survives_reassignment_and_slot_reuse() {
                 }
                 store.remove_node(removed).unwrap();
                 assert!(store.node(removed).is_none(), "seed={seed} step={step}");
-                let replacement = store.insert_object(object(20_000 + step));
+                let replacement = store.insert_semantic_object(object());
                 assert_eq!(
                     replacement.slot(),
                     removed.slot(),

--- a/crates/noon-core/tests/semantic_store_generation_reuse.rs
+++ b/crates/noon-core/tests/semantic_store_generation_reuse.rs
@@ -1,14 +1,11 @@
 use noon_core::{
-    GeometryRef, ObjectDefinition, ObjectId, SemanticStore, SemanticStoreError, SourceIdentity,
+    SemanticObjectState, SemanticStore, SemanticStoreError, SourceIdentity, StoredGeometry,
 };
 
 const REUSE_CYCLES: u32 = 1_000;
 
-fn object(generation: u32) -> ObjectDefinition {
-    ObjectDefinition::new(
-        ObjectId::new(u64::from(generation)),
-        GeometryRef::circle(1.0),
-    )
+fn object() -> SemanticObjectState {
+    SemanticObjectState::new(StoredGeometry::Circle { radius: 1.0 })
 }
 
 fn source(generation: u32) -> SourceIdentity {
@@ -18,7 +15,7 @@ fn source(generation: u32) -> SourceIdentity {
 #[test]
 fn semantic_slot_reuse_stays_bounded_and_never_aliases_stale_identity() {
     let mut store = SemanticStore::new();
-    let mut current = store.insert_object(object(0));
+    let mut current = store.insert_semantic_object(object());
     let mut current_source = source(0);
     store
         .set_source_identity(current, Some(current_source.clone()))
@@ -29,21 +26,19 @@ fn semantic_slot_reuse_stays_bounded_and_never_aliases_stale_identity() {
 
     for generation in 1..=REUSE_CYCLES {
         let stale = current;
-        let stale_object = ObjectId::new(u64::from(generation - 1));
         let stale_source = current_source;
 
         store
             .remove_node(stale)
             .expect("live semantic node must remove exactly once");
         assert!(store.node(stale).is_none());
-        assert_eq!(store.node_for_object(stale_object), None);
         assert_eq!(store.node_for_source(&stale_source), None);
         assert!(matches!(
             store.remove_node(stale),
             Err(SemanticStoreError::UnknownNode(id)) if id == stale
         ));
 
-        current = store.insert_object(object(generation));
+        current = store.insert_semantic_object(object());
         current_source = source(generation);
         store
             .set_source_identity(current, Some(current_source.clone()))
@@ -54,10 +49,6 @@ fn semantic_slot_reuse_stays_bounded_and_never_aliases_stale_identity() {
         assert_ne!(current, stale);
         assert_eq!(store.len(), 1);
         assert_eq!(store.slot_capacity(), 1);
-        assert_eq!(
-            store.node_for_object(ObjectId::new(u64::from(generation))),
-            Some(current)
-        );
         assert_eq!(store.node_for_source(&current_source), Some(current));
         assert_eq!(store.node_for_source(&stale_source), None);
     }

--- a/crates/noon/src/family_copy.rs
+++ b/crates/noon/src/family_copy.rs
@@ -113,7 +113,7 @@ pub(crate) fn prepare_family_copy(
                 .ok_or("family copy contains an unknown semantic node")?;
             match node.kind() {
                 SemanticNodeKind::Family => Some(node.members_iter().collect::<Vec<_>>()),
-                SemanticNodeKind::Object(_) | SemanticNodeKind::AuthoringObject => None,
+                SemanticNodeKind::AuthoringObject => None,
                 _ => return Err("family copy contains a non-mobject member".into()),
             }
         };

--- a/scripts/architecture-ratchet.sh
+++ b/scripts/architecture-ratchet.sh
@@ -288,6 +288,18 @@ fi
 identity_authority_found=0
 canonical_identity_file='crates/noon-core/src/semantic_store.rs'
 
+# The semantic store no longer admits a second object payload or execution-ID map.
+if retired_store_payloads="$(grep -nE 'ObjectDefinition|from_scene_definition|object_nodes' "$canonical_identity_file")"; then
+  printf 'architecture ratchet: retired semantic-store payload or ID lookup:\n%s\n' "$retired_store_payloads" >&2
+  exit 1
+else
+  scan_status=$?
+  if (( scan_status != 1 )); then
+    echo 'architecture ratchet: semantic-store source scan failed' >&2
+    exit "$scan_status"
+  fi
+fi
+
 semantic_node_defs="$(git grep -nE '^[[:space:]]*(pub([[:space:]]*\([^)]*\))?[[:space:]]+)?struct[[:space:]]+SemanticNodeId([[:space:]{(;]|$)' -- '*.rs' || true)"
 semantic_store_defs="$(git grep -nE '^[[:space:]]*(pub([[:space:]]*\([^)]*\))?[[:space:]]+)?struct[[:space:]]+SemanticStore([[:space:]{(;]|$)' -- '*.rs' || true)"
 semantic_node_impls="$(git grep -nE '^[[:space:]]*impl[[:space:]]+SemanticNodeId([[:space:]{]|$)' -- '*.rs' || true)"

--- a/scripts/architecture-ratchet.test.sh
+++ b/scripts/architecture-ratchet.test.sh
@@ -540,4 +540,8 @@ if bash scripts/architecture-ratchet.sh unavailable-base-959 >/dev/null 2>&1; th
   exit 1
 fi
 
+reset_to_base
+printf '\nstruct RetiredMap { object_nodes: () }\n' >> crates/noon-core/src/semantic_store.rs
+expect_rejected 'retired semantic-store execution-ID map'
+
 echo "architecture ratchet self-test passed"


### PR DESCRIPTION
SemanticStore still accepted legacy flat object definitions as a second object payload, with an old execution-ID lookup map and scene-document import adapter. Delete that variant, its constructors/getters/map and unused import route. Compiler reachability/publication and shared family consumers now handle the remaining semantic variants directly.

Advances #957 A1 / #959 A4.2 and #61. No compatibility adapter, new identity space, serialization boundary or runtime authority replaces the removed code. Normal typed object construction remains unchanged, and local operations no longer maintain the obsolete ID map. The separate core scene/codec API and temporary identity-only constructor remain deletion work under #959; this is not a claim that all legacy core APIs are gone.

Validation: `cargo fmt --all` and `bash scripts/check-architecture.sh` passed. Existing seeded mutation/source-identity tests, 1,000-cycle generational handle reuse, family membership and 100,000-node locality fixtures now construct typed semantic objects. Only the deleted document adapter/old-ID lookup assertions are retired. The Rust architecture guard rejects reintroduction of the legacy payload/import route and old ID map; its negative self-test passes. The Python ownership inventory and its four tests also pass. Rust tests and full native/direct-WASM/Python/browser qualification await hosted CI; no local Rust/WASM build due to disk constraints.
