### PR TITLE
Cache pinned Pyodide resources across isolated gallery cases

### DIFF
--- a/scripts/build-web-demo.sh
+++ b/scripts/build-web-demo.sh
@@ -73,6 +73,7 @@ if [[ "$skip_web_preflight" != "1" ]]; then
   node --check scripts/updater-callback-smoke.mjs
   node --check scripts/manim-host-updater-diagnostics.mjs
   node --check scripts/pr-risk-classifier.mjs
+  node --test scripts/pyodide-resource-cache.test.mjs
   node --test scripts/manim-raster-support.test.mjs
   node --test scripts/browser-visual-parity-lib.test.mjs
   node --test scripts/manim-reference-inventory.test.mjs

--- a/scripts/playground-gallery-runtime-smoke.mjs
+++ b/scripts/playground-gallery-runtime-smoke.mjs
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import playwright from 'playwright';
 import { playgroundLaunchOptions } from './playground-browser-support.mjs';
+import { createPyodideResourceCache } from './pyodide-resource-cache.mjs';
 import { AUTHORING_CHANNEL, AUTHORING_PROTOCOL_VERSION, parseAuthoringResult } from '../web/authoring-client.js';
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
@@ -18,7 +19,8 @@ const artifacts = path.resolve(root, process.env.NOON_PLAYGROUND_MATRIX_ARTIFACT
 const stringify = value => JSON.stringify(value, (_, v) => typeof v === 'bigint' ? String(v) : v, 2);
 const affected = ['manim-lagged-start-map', 'parity-moving-dots', 'parity-rotation-updater', 'compatible-indicate-square'];
 await mkdir(artifacts, { recursive: true });
-let server, browser;
+let server, browser, runtimeCache;
+const startedAt = performance.now();
 const results = [];
 async function json(relative) {
   const response = await fetch(new URL(relative, base), { signal: AbortSignal.timeout(20000), headers: { 'Cache-Control': 'no-cache' } });
@@ -36,6 +38,9 @@ try {
     }
     assert.ok(ready, 'gallery HTTP server did not start');
   }
+  const workerResponse = await fetch(new URL('python-worker.js', base), { signal: AbortSignal.timeout(20000) });
+  assert.ok(workerResponse.ok, 'gallery worker source is unavailable');
+  runtimeCache = createPyodideResourceCache(await workerResponse.text());
   const revision = external ? await json(`build-info.json?t=${Date.now()}`) : null;
   if (process.env.NOON_GALLERY_REVISION) assert.equal(revision?.commit, process.env.NOON_GALLERY_REVISION);
   const entries = [];
@@ -56,7 +61,9 @@ try {
   if (browserName !== 'firefox') for (const id of affected) queue.push({ entry: entries.find(e => e.id === id), noJspi: true });
   let next = 0;
   async function check({ entry, noJspi }) {
+    const caseStartedAt = performance.now();
     const context = await browser.newContext({ ...options });
+    await runtimeCache.install(context);
     // Observe the existing result envelope without guessing its payload shape.
     // The production parser below validates the semantic descriptor and duration;
     // semantic_execution is an object, not the boolean true.
@@ -141,6 +148,7 @@ try {
     } finally {
       await page.screenshot({ path: path.join(artifacts, `${name}.png`), timeout: 5000 }).catch(() => {});
       await context.close();
+      result.elapsedMs = performance.now() - caseStartedAt;
       results.push(result);
       await writeFile(path.join(artifacts, `${name}.json`), stringify(result));
       console.log(`${result.outcome}: ${name}${result.failure ? `: ${result.failure}` : ''}`);
@@ -153,5 +161,8 @@ try {
   console.log(`All ${entries.length} selectable examples and ${queue.length - entries.length} no-JSPI controls passed.`);
 } finally {
   await writeFile(path.join(artifacts, 'results.json'), stringify(results));
+  const runtimeResources = { elapsedMs: performance.now() - startedAt, ...runtimeCache?.stats() };
+  await writeFile(path.join(artifacts, 'runtime-resources.json'), stringify(runtimeResources));
+  console.log('Gallery runtime resources:', stringify(runtimeResources));
   await browser?.close(); server?.kill('SIGTERM');
 }

--- a/scripts/pyodide-resource-cache.mjs
+++ b/scripts/pyodide-resource-cache.mjs
@@ -1,0 +1,63 @@
+// Job-local byte reuse for immutable Pyodide assets. Scene/worker sources and
+// browser state remain isolated; this does not retry a failed gallery case.
+export function createPyodideResourceCache(workerSource, maxBytes = 64 * 1024 * 1024) {
+  const moduleUrl = workerSource.match(
+    /from\s+["'](https:\/\/cdn\.jsdelivr\.net\/pyodide\/v\d+\.\d+\.\d+\/full\/pyodide\.mjs)["']/,
+  )?.[1];
+  if (!moduleUrl) throw new Error('Gallery cache requires the worker to pin a Pyodide release');
+  const baseUrl = new URL('.', moduleUrl).href;
+  const entries = new Map();
+  const counts = { requests: 0, hits: 0, upstreamRequests: 0, upstreamFailures: 0, retainedBytes: 0 };
+
+  async function read(route, url) {
+    counts.upstreamRequests++;
+    let response;
+    try {
+      response = await route.fetch();
+      const body = await response.body();
+      const headers = { ...response.headers() };
+      // APIResponse exposes decoded bytes. Do not reuse compressed lengths or
+      // propagate response cookies between otherwise independent contexts.
+      delete headers['content-encoding'];
+      delete headers['content-length'];
+      delete headers['set-cookie'];
+      const value = { status: response.status(), headers, body };
+      if (value.status === 200 && counts.retainedBytes + body.length <= maxBytes) {
+        counts.retainedBytes += body.length;
+      } else {
+        entries.delete(url);
+      }
+      return value;
+    } catch (error) {
+      counts.upstreamFailures++;
+      entries.delete(url);
+      throw error;
+    } finally {
+      await response?.dispose();
+    }
+  }
+
+  return {
+    async install(context) {
+      await context.route(`${baseUrl}**`, async route => {
+        if (route.request().method() !== 'GET') return route.continue();
+        counts.requests++;
+        const url = route.request().url();
+        let value = entries.get(url);
+        if (value) counts.hits++;
+        else {
+          value = read(route, url);
+          entries.set(url, value);
+        }
+        try {
+          await route.fulfill(await value);
+        } catch {
+          // Preserve the failing request. A subsequent case may make a fresh
+          // request, but this case is neither retried nor reported as successful.
+          await route.abort('failed').catch(() => {});
+        }
+      });
+    },
+    stats() { return { baseUrl, ...counts }; },
+  };
+}

--- a/scripts/pyodide-resource-cache.test.mjs
+++ b/scripts/pyodide-resource-cache.test.mjs
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createPyodideResourceCache } from './pyodide-resource-cache.mjs';
+
+const source = 'import { loadPyodide } from "https://cdn.jsdelivr.net/pyodide/v314.0.5/full/pyodide.mjs";';
+const url = 'https://cdn.jsdelivr.net/pyodide/v314.0.5/full/pyodide.asm.wasm';
+async function attach(cache) {
+  let handler;
+  await cache.install({ async route(pattern, callback) {
+    assert.equal(pattern, 'https://cdn.jsdelivr.net/pyodide/v314.0.5/full/**');
+    handler = callback;
+  } });
+  return handler;
+}
+function request(fetch, method = 'GET') {
+  const result = {};
+  return {
+    result,
+    request: () => ({ url: () => url, method: () => method }),
+    fetch,
+    async fulfill(value) { result.response = value; },
+    async abort(reason) { result.aborted = reason; },
+    async continue() { result.continued = true; },
+  };
+}
+function response(body, status = 200) {
+  return {
+    status: () => status,
+    headers: () => ({ 'content-type': 'application/wasm', 'content-encoding': 'gzip', 'content-length': '999', 'set-cookie': 'private=value', 'access-control-allow-origin': '*' }),
+    async body() { return body; },
+    async dispose() {},
+  };
+}
+
+test('independent contexts share one in-flight fetch and identical resource bytes', async () => {
+  const cache = createPyodideResourceCache(source);
+  const first = await attach(cache), second = await attach(cache);
+  let fetches = 0;
+  const bytes = Buffer.from([0, 97, 115, 109]);
+  const upstream = async () => { fetches++; return response(bytes); };
+  const a = request(upstream), b = request(upstream);
+  await Promise.all([first(a), second(b)]);
+  assert.equal(fetches, 1);
+  for (const route of [a, b]) {
+    assert.deepEqual(route.result.response.body, bytes);
+    assert.deepEqual(route.result.response.headers, { 'content-type': 'application/wasm', 'access-control-allow-origin': '*' });
+  }
+  assert.equal(cache.stats().hits, 1);
+  assert.equal(cache.stats().retainedBytes, bytes.length);
+});
+
+test('failed fetches still fail their cases and do not poison later requests', async () => {
+  const cache = createPyodideResourceCache(source);
+  const handler = await attach(cache);
+  const failed = request(async () => { throw new Error('network failure'); });
+  await handler(failed);
+  assert.equal(failed.result.aborted, 'failed');
+  assert.equal(failed.result.response, undefined);
+  const later = request(async () => response(Buffer.from('ok')));
+  await handler(later);
+  assert.equal(later.result.response.body.toString(), 'ok');
+  assert.equal(cache.stats().upstreamRequests, 2);
+  assert.equal(cache.stats().upstreamFailures, 1);
+});
+
+test('HTTP errors are delivered unchanged and not cached', async () => {
+  const cache = createPyodideResourceCache(source);
+  const handler = await attach(cache);
+  const failed = request(async () => response(Buffer.from('unavailable'), 503));
+  await handler(failed);
+  assert.equal(failed.result.response.status, 503);
+  const later = request(async () => response(Buffer.from('ok')));
+  await handler(later);
+  assert.equal(later.result.response.status, 200);
+  assert.equal(cache.stats().upstreamRequests, 2);
+});
+
+test('retained bytes are bounded and non-GET requests bypass the cache', async () => {
+  const cache = createPyodideResourceCache(source, 2);
+  const handler = await attach(cache);
+  for (let i = 0; i < 2; i++) await handler(request(async () => response(Buffer.from('large'))));
+  assert.equal(cache.stats().retainedBytes, 0);
+  assert.equal(cache.stats().upstreamRequests, 2);
+  const post = request(() => { throw new Error('must not fetch'); }, 'POST');
+  await handler(post);
+  assert.equal(post.result.continued, true);
+});
+
+test('unpinned or different-origin runtimes cannot opt into resource reuse', () => {
+  assert.throws(() => createPyodideResourceCache(source.replace('v314.0.5', 'latest')), /pin a Pyodide release/);
+  assert.throws(() => createPyodideResourceCache(source.replace('cdn.jsdelivr.net', 'example.com')), /pin a Pyodide release/);
+});


### PR DESCRIPTION
Every gallery case uses a fresh browser context, so contexts repeatedly fetch the same pinned Pyodide runtime. A failed CDN request caused the Firefox-only Uncreate failure recorded in #1303. Reuse successful resource bytes within one gallery job while keeping independent contexts and every scene/runtime assertion.

Advances #1265. The cache derives its exact pinned jsDelivr release from the candidate worker source, coalesces concurrent requests, and retains at most 64 MiB. It does not cache candidate engine/worker sources, retry failed cases, retain HTTP error responses, or propagate response cookies between contexts. The report records requests/hits/upstream failures/retained bytes and total/per-case elapsed time. No speedup is claimed before hosted measurements.

Validation: `node --test scripts/pyodide-resource-cache.test.mjs` passed five tests covering shared in-flight byte identity, failed fetches, HTTP errors, capacity bounds, method bypass and version/origin pinning; `node --check scripts/playground-gallery-runtime-smoke.mjs` and `bash scripts/check-architecture.sh` passed. Hosted Chromium/Firefox/mobile-WebKit gallery runs will prove the real worker request path and provide cache/elapsed evidence. This harness-only change uses the existing PR browser/product gates; no extra full engine workflow is dispatched.

Hosted qualification on `d0beedcdb4c16ad43639e73d932c120ef7fb25f3`: all 12 required PR/product/recovery/cross-browser checks passed. Gallery artifact metrics from run 34321829730:

| Browser | Requests | Cache hits | Upstream fetches | Retained bytes |
| --- | ---: | ---: | ---: | ---: |
| Chromium desktop DPR1 | 215 | 210 | 5 | 13,525,523 |
| Firefox desktop DPR2 | 117 | 114 | 3 | 12,257,835 |
| WebKit mobile DPR2 | 215 | 210 | 5 | 13,525,523 |

Every gallery case passed and all three runs reported zero upstream failures. This demonstrates over 97% fewer upstream resource fetches within each job. There was no controlled baseline timing run, so this PR does not claim a measured total CI speedup.
