### PR TITLE
Retire renderer legacy scene fixtures

### DIFF
--- a/crates/noon-render-wgpu/tests/analytic_transform.rs
+++ b/crates/noon-render-wgpu/tests/analytic_transform.rs
@@ -1,13 +1,13 @@
-use noon_compile::CompiledScene;
+use noon_compile::{CompiledObject, CompiledScene, ExecutionPatch};
 use noon_core::{
-    Easing, GeometryRef, ObjectSnapshot, SceneDefinition, ScenePatch, Style, TrackTiming,
-    Transform2D, Vec2,
+    Easing, GeometryRef, ObjectId, Property, Style, TrackDefinition, TrackId, TrackTiming,
+    TrackValues, Transform2D, TransformTrackEndpoint, Vec2,
 };
 use noon_render_wgpu::FramePreparer;
 use noon_runtime::SceneInstance;
 
-fn snapshot(geometry: GeometryRef, style: Style) -> ObjectSnapshot {
-    ObjectSnapshot {
+fn endpoint(geometry: GeometryRef, style: Style) -> TransformTrackEndpoint {
+    TransformTrackEndpoint {
         geometry,
         transform: Transform2D::IDENTITY,
         style,
@@ -16,19 +16,29 @@ fn snapshot(geometry: GeometryRef, style: Style) -> ObjectSnapshot {
 
 #[test]
 fn analytic_geometry_transform_dirties_only_one_instance_without_path_work() {
-    let mut scene = SceneDefinition::new();
-    let object = scene.add(GeometryRef::circle(1.0));
+    let object = ObjectId::new(0);
     let style = Style::default();
-    scene
-        .animate_transform(
+    let compiled = CompiledScene::compile_objects(
+        vec![CompiledObject::new(
             object,
-            snapshot(GeometryRef::circle(1.0), style),
-            snapshot(GeometryRef::circle(3.0), style),
-            TrackTiming::new(0.0, 2.0, Easing::Linear),
-        )
-        .unwrap();
-
-    let mut instance = SceneInstance::new(CompiledScene::compile(&scene).unwrap());
+            GeometryRef::circle(1.0),
+            Transform2D::IDENTITY,
+            style,
+        )],
+        &[TrackDefinition {
+            id: TrackId::new(0),
+            object,
+            property: Property::Transform,
+            values: TrackValues::Object {
+                from: endpoint(GeometryRef::circle(1.0), style),
+                to: endpoint(GeometryRef::circle(3.0), style),
+            },
+            timing: TrackTiming::new(0.0, 2.0, Easing::Linear),
+            time_map: Default::default(),
+        }],
+    )
+    .unwrap();
+    let mut instance = SceneInstance::new(compiled);
     let mut preparer = FramePreparer::new();
     let initial_changes = instance.take_frame_changes();
     let initial = preparer.prepare_incremental(instance.frame(), &initial_changes);
@@ -49,36 +59,49 @@ fn analytic_geometry_transform_dirties_only_one_instance_without_path_work() {
 
 #[test]
 fn rectangle_and_line_geometry_transforms_stay_on_analytic_instance_paths() {
-    let mut scene = SceneDefinition::new();
     let style = Style::default();
-
-    let rectangle = scene.add(GeometryRef::rectangle(2.0, 4.0));
-    scene
-        .animate_transform(
+    let rectangle = ObjectId::new(0);
+    let line = ObjectId::new(1);
+    let rectangle_from = GeometryRef::rectangle(2.0, 4.0);
+    let line_from = GeometryRef::line(Vec2::new(-1.0, 0.0), Vec2::new(1.0, 0.0));
+    let objects = vec![
+        CompiledObject::new(
             rectangle,
-            snapshot(GeometryRef::rectangle(2.0, 4.0), style),
-            snapshot(GeometryRef::rectangle(6.0, 8.0), style),
-            TrackTiming::new(0.0, 2.0, Easing::Linear),
-        )
-        .unwrap();
-
-    let line = scene.add(GeometryRef::line(Vec2::new(-1.0, 0.0), Vec2::new(1.0, 0.0)));
-    scene
-        .animate_transform(
-            line,
-            snapshot(
-                GeometryRef::line(Vec2::new(-1.0, 0.0), Vec2::new(1.0, 0.0)),
-                style,
-            ),
-            snapshot(
-                GeometryRef::line(Vec2::new(0.0, -2.0), Vec2::new(0.0, 2.0)),
-                style,
-            ),
-            TrackTiming::new(0.0, 2.0, Easing::Linear),
-        )
-        .unwrap();
-
-    let mut instance = SceneInstance::new(CompiledScene::compile(&scene).unwrap());
+            rectangle_from.clone(),
+            Transform2D::IDENTITY,
+            style,
+        ),
+        CompiledObject::new(line, line_from.clone(), Transform2D::IDENTITY, style),
+    ];
+    let tracks = [
+        TrackDefinition {
+            id: TrackId::new(0),
+            object: rectangle,
+            property: Property::Transform,
+            values: TrackValues::Object {
+                from: endpoint(rectangle_from, style),
+                to: endpoint(GeometryRef::rectangle(6.0, 8.0), style),
+            },
+            timing: TrackTiming::new(0.0, 2.0, Easing::Linear),
+            time_map: Default::default(),
+        },
+        TrackDefinition {
+            id: TrackId::new(1),
+            object: line,
+            property: Property::Transform,
+            values: TrackValues::Object {
+                from: endpoint(line_from, style),
+                to: endpoint(
+                    GeometryRef::line(Vec2::new(0.0, -2.0), Vec2::new(0.0, 2.0)),
+                    style,
+                ),
+            },
+            timing: TrackTiming::new(0.0, 2.0, Easing::Linear),
+            time_map: Default::default(),
+        },
+    ];
+    let mut instance =
+        SceneInstance::new(CompiledScene::compile_objects(objects, &tracks).unwrap());
     let mut preparer = FramePreparer::new();
     let initial_changes = instance.take_frame_changes();
     preparer.prepare_incremental(instance.frame(), &initial_changes);
@@ -103,11 +126,18 @@ fn repeated_line_transform_patches_keep_preparation_bounded_and_local() {
     const STATIC_INDEX: usize = 0;
     const MOVING_INDEX: usize = 1;
 
-    let mut scene = SceneDefinition::new();
-    let _static_line = scene.add(GeometryRef::line(Vec2::new(-1.0, 0.0), Vec2::new(1.0, 0.0)));
-    let moving_line = scene.add(GeometryRef::line(Vec2::new(-1.0, 0.0), Vec2::new(1.0, 0.0)));
-
-    let mut instance = SceneInstance::new(CompiledScene::compile(&scene).unwrap());
+    let moving_line = ObjectId::new(MOVING_INDEX as u64);
+    let objects = (0..2)
+        .map(|index| {
+            CompiledObject::new(
+                ObjectId::new(index),
+                GeometryRef::line(Vec2::new(-1.0, 0.0), Vec2::new(1.0, 0.0)),
+                Transform2D::IDENTITY,
+                Style::default(),
+            )
+        })
+        .collect();
+    let mut instance = SceneInstance::new(CompiledScene::compile_objects(objects, &[]).unwrap());
     let static_before = instance.frame().objects[STATIC_INDEX].clone();
     let mut preparer = FramePreparer::new();
     let initial_changes = instance.take_frame_changes();
@@ -123,7 +153,7 @@ fn repeated_line_transform_patches_keep_preparation_bounded_and_local() {
             ..Transform2D::IDENTITY
         };
         instance
-            .apply_patch(&ScenePatch::SetTransform {
+            .apply_execution_patch(&ExecutionPatch::SetTransform {
                 object: moving_line,
                 transform,
             })

--- a/crates/noon-render-wgpu/tests/appearance.rs
+++ b/crates/noon-render-wgpu/tests/appearance.rs
@@ -1,28 +1,34 @@
-use noon_compile::CompiledScene;
-use noon_core::{Easing, GeometryRef, Property, SceneDefinition, TrackTiming};
+use noon_compile::{CompiledObject, CompiledScene};
+use noon_core::{
+    Easing, GeometryRef, ObjectId, Property, Style, TrackDefinition, TrackId, TrackTiming,
+    TrackValues, Transform2D,
+};
 use noon_render_wgpu::FramePreparer;
 use noon_runtime::SceneInstance;
 
 #[test]
 fn appearance_multiplies_semantic_opacity_in_packed_instances() {
-    let mut scene = SceneDefinition::new();
-    let object = scene.add(GeometryRef::circle(1.0));
-    scene
-        .object_mut(object)
-        .expect("object exists")
-        .style
-        .opacity = 0.4;
-    scene
-        .animate_scalar(
+    let object = ObjectId::new(0);
+    let compiled = CompiledScene::compile_objects(
+        vec![CompiledObject::new(
             object,
-            Property::Appearance,
-            1.0,
-            0.0,
-            TrackTiming::new(0.0, 2.0, Easing::Linear),
-        )
-        .expect("appearance track is valid");
-
-    let compiled = CompiledScene::compile(&scene).expect("scene compiles");
+            GeometryRef::circle(1.0),
+            Transform2D::IDENTITY,
+            Style {
+                opacity: 0.4,
+                ..Style::default()
+            },
+        )],
+        &[TrackDefinition {
+            id: TrackId::new(0),
+            object,
+            property: Property::Appearance,
+            values: TrackValues::Scalar { from: 1.0, to: 0.0 },
+            timing: TrackTiming::new(0.0, 2.0, Easing::Linear),
+            time_map: Default::default(),
+        }],
+    )
+    .expect("execution data compiles");
     let mut instance = SceneInstance::new(compiled);
     instance.seek(1.0).expect("valid time");
     let mut preparer = FramePreparer::new();

--- a/crates/noon-render-wgpu/tests/generic_transform.rs
+++ b/crates/noon-render-wgpu/tests/generic_transform.rs
@@ -1,7 +1,7 @@
-use noon_compile::CompiledScene;
+use noon_compile::{CompiledObject, CompiledScene};
 use noon_core::{
-    Color, Easing, GeometryRef, ObjectSnapshot, SceneDefinition, Style, TrackTiming, Transform2D,
-    Vec2, VectorPath,
+    Color, Easing, GeometryRef, ObjectId, Property, Style, TrackDefinition, TrackId, TrackTiming,
+    TrackValues, Transform2D, TransformTrackEndpoint, Vec2, VectorPath,
 };
 use noon_render_wgpu::FramePreparer;
 use noon_runtime::SceneInstance;
@@ -36,8 +36,8 @@ fn path_c() -> VectorPath {
         .line_to(Vec2::new(1.0, 1.0))
 }
 
-fn snapshot(path: VectorPath) -> ObjectSnapshot {
-    ObjectSnapshot {
+fn endpoint(path: VectorPath) -> TransformTrackEndpoint {
+    TransformTrackEndpoint {
         geometry: GeometryRef::path(path),
         transform: Transform2D::IDENTITY,
         style: style(),
@@ -51,8 +51,8 @@ fn steady_generic_path_transform_updates_instance_without_retessellation() {
 }
 
 fn assert_steady_transform(stroke_mode: noon_core::StrokeWidthMode) {
-    let mut from = snapshot(path_a());
-    let mut to = snapshot(path_b());
+    let mut from = endpoint(path_a());
+    let mut to = endpoint(path_b());
     from.style.stroke_width_mode = stroke_mode;
     to.style.stroke_width_mode = stroke_mode;
     to.style.stroke = Some(Color::rgb(0.2, 0.7, 0.9));
@@ -62,14 +62,23 @@ fn assert_steady_transform(stroke_mode: noon_core::StrokeWidthMode) {
     to.transform.translation = Vec2::new(3.0, -1.0);
     to.transform.scale = Vec2::new(0.6, 1.9);
 
-    let mut scene = SceneDefinition::new();
-    let object = scene.add(from.geometry.clone());
-    scene.object_mut(object).unwrap().style = from.style;
-    scene
-        .animate_transform(object, from, to, TrackTiming::new(0.0, 2.0, Easing::Linear))
-        .unwrap();
-
-    let mut instance = SceneInstance::new(CompiledScene::compile(&scene).unwrap());
+    let object = ObjectId::new(0);
+    let objects = vec![CompiledObject::new(
+        object,
+        from.geometry.clone(),
+        Transform2D::IDENTITY,
+        from.style,
+    )];
+    let tracks = [TrackDefinition {
+        id: TrackId::new(0),
+        object,
+        property: Property::Transform,
+        values: TrackValues::Object { from, to },
+        timing: TrackTiming::new(0.0, 2.0, Easing::Linear),
+        time_map: Default::default(),
+    }];
+    let mut instance =
+        SceneInstance::new(CompiledScene::compile_objects(objects, &tracks).unwrap());
     let mut preparer = FramePreparer::new();
     instance.seek(0.1).unwrap();
 
@@ -97,25 +106,39 @@ fn assert_steady_transform(stroke_mode: noon_core::StrokeWidthMode) {
 
 #[test]
 fn sequential_path_pair_transition_prepares_new_geometry_once() {
-    let a = snapshot(path_a());
-    let b = snapshot(path_b());
-    let c = snapshot(path_c());
-    let mut scene = SceneDefinition::new();
-    let object = scene.add(a.geometry.clone());
-    scene.object_mut(object).unwrap().style = a.style;
-    scene
-        .animate_transform(
+    let a = endpoint(path_a());
+    let b = endpoint(path_b());
+    let c = endpoint(path_c());
+    let object = ObjectId::new(0);
+    let objects = vec![CompiledObject::new(
+        object,
+        a.geometry.clone(),
+        Transform2D::IDENTITY,
+        a.style,
+    )];
+    let tracks = [
+        TrackDefinition {
+            id: TrackId::new(0),
             object,
-            a,
-            b.clone(),
-            TrackTiming::new(0.0, 1.0, Easing::Linear),
-        )
-        .unwrap();
-    scene
-        .animate_transform(object, b, c, TrackTiming::new(1.0, 1.0, Easing::Linear))
-        .unwrap();
-
-    let mut instance = SceneInstance::new(CompiledScene::compile(&scene).unwrap());
+            property: Property::Transform,
+            values: TrackValues::Object {
+                from: a,
+                to: b.clone(),
+            },
+            timing: TrackTiming::new(0.0, 1.0, Easing::Linear),
+            time_map: Default::default(),
+        },
+        TrackDefinition {
+            id: TrackId::new(1),
+            object,
+            property: Property::Transform,
+            values: TrackValues::Object { from: b, to: c },
+            timing: TrackTiming::new(1.0, 1.0, Easing::Linear),
+            time_map: Default::default(),
+        },
+    ];
+    let mut instance =
+        SceneInstance::new(CompiledScene::compile_objects(objects, &tracks).unwrap());
     let mut preparer = FramePreparer::new();
     let changes = instance.take_frame_changes();
     let first = preparer.prepare_incremental(instance.frame(), &changes);

--- a/crates/noon-render-wgpu/tests/path_cache_lifecycle.rs
+++ b/crates/noon-render-wgpu/tests/path_cache_lifecycle.rs
@@ -1,5 +1,5 @@
-use noon_compile::CompiledScene;
-use noon_core::{Color, GeometryRef, SceneDefinition, Style, Vec2, VectorPath};
+use noon_compile::{CompiledObject, CompiledScene};
+use noon_core::{Color, GeometryRef, ObjectId, Style, Transform2D, Vec2, VectorPath};
 use noon_render_wgpu::FramePreparer;
 use noon_runtime::SceneInstance;
 
@@ -11,18 +11,27 @@ fn path(seed: f32) -> VectorPath {
 }
 
 fn path_scene(paths: &[VectorPath]) -> SceneInstance {
-    let mut scene = SceneDefinition::new();
-    for path in paths {
-        let object = scene.add(GeometryRef::path(path.clone()));
-        scene.object_mut(object).expect("path object exists").style = Style {
-            fill: None,
-            stroke: Some(Color::WHITE),
-            stroke_width: 0.2,
-            stroke_width_mode: Default::default(),
-            ..Style::default()
-        };
-    }
-    SceneInstance::new(CompiledScene::compile(&scene).expect("path scene compiles"))
+    let objects = paths
+        .iter()
+        .enumerate()
+        .map(|(index, path)| {
+            CompiledObject::new(
+                ObjectId::new(index as u64),
+                GeometryRef::path(path.clone()),
+                Transform2D::IDENTITY,
+                Style {
+                    fill: None,
+                    stroke: Some(Color::WHITE),
+                    stroke_width: 0.2,
+                    stroke_width_mode: Default::default(),
+                    ..Style::default()
+                },
+            )
+        })
+        .collect();
+    SceneInstance::new(
+        CompiledScene::compile_objects(objects, &[]).expect("path execution data compiles"),
+    )
 }
 
 #[test]

--- a/crates/noon-render-wgpu/tests/stroke_style_cache.rs
+++ b/crates/noon-render-wgpu/tests/stroke_style_cache.rs
@@ -1,6 +1,6 @@
-use noon_compile::CompiledScene;
+use noon_compile::{CompiledObject, CompiledScene};
 use noon_core::{
-    Color, GeometryRef, SceneDefinition, StrokeCap, StrokeJoin, Style, Vec2, VectorPath,
+    Color, GeometryRef, ObjectId, StrokeCap, StrokeJoin, Style, Transform2D, Vec2, VectorPath,
 };
 use noon_render_wgpu::FramePreparer;
 use noon_runtime::SceneInstance;
@@ -29,12 +29,19 @@ fn path_cache_key_includes_join_and_cap_policy() {
         style(StrokeJoin::Round, StrokeCap::Butt),
         style(StrokeJoin::Round, StrokeCap::Round),
     ];
-    let mut scene = SceneDefinition::new();
-    for path_style in styles {
-        let object = scene.add(GeometryRef::path(path.clone()));
-        scene.object_mut(object).unwrap().style = path_style;
-    }
-    let instance = SceneInstance::new(CompiledScene::compile(&scene).unwrap());
+    let objects = styles
+        .into_iter()
+        .enumerate()
+        .map(|(index, path_style)| {
+            CompiledObject::new(
+                ObjectId::new(index as u64),
+                GeometryRef::path(path.clone()),
+                Transform2D::IDENTITY,
+                path_style,
+            )
+        })
+        .collect();
+    let instance = SceneInstance::new(CompiledScene::compile_objects(objects, &[]).unwrap());
     let mut preparer = FramePreparer::new();
     let prepared = preparer.prepare(instance.frame());
     assert_eq!(prepared.stats.geometry_cache_misses, 3);

--- a/crates/noon-render-wgpu/tests/transform_from_copy_presence.rs
+++ b/crates/noon-render-wgpu/tests/transform_from_copy_presence.rs
@@ -1,50 +1,82 @@
-use noon_compile::CompiledScene;
+use noon_compile::{CompiledObject, CompiledScene};
 use noon_core::{
-    Easing, GeometryRef, ObjectSnapshot, SceneDefinition, TrackTiming, Transform2D, Vec2,
+    Easing, GeometryRef, ObjectId, Property, Style, TrackDefinition, TrackId, TrackTiming,
+    TrackValues, Transform2D, TransformTrackEndpoint, Vec2,
 };
 use noon_render_wgpu::FramePreparer;
 use noon_runtime::SceneInstance;
 
 fn copy_scene() -> SceneInstance {
-    let mut scene = SceneDefinition::new();
-    let source = scene.add(GeometryRef::circle(1.0));
-    let target = scene.add(GeometryRef::circle(3.0));
-    let copy = scene.add(GeometryRef::circle(1.0));
-
-    scene.object_mut(source).expect("source exists").transform = Transform2D {
-        translation: Vec2::new(-2.0, 0.0),
-        ..Transform2D::IDENTITY
+    let source = ObjectId::new(0);
+    let target = ObjectId::new(1);
+    let copy = ObjectId::new(2);
+    let from = TransformTrackEndpoint {
+        geometry: GeometryRef::circle(1.0),
+        transform: Transform2D {
+            translation: Vec2::new(-2.0, 0.0),
+            ..Transform2D::IDENTITY
+        },
+        style: Style::default(),
     };
-    scene.object_mut(copy).expect("copy exists").transform = Transform2D {
-        translation: Vec2::new(-2.0, 0.0),
-        ..Transform2D::IDENTITY
+    let to = TransformTrackEndpoint {
+        geometry: GeometryRef::circle(3.0),
+        transform: Transform2D {
+            translation: Vec2::new(4.0, -2.0),
+            ..Transform2D::IDENTITY
+        },
+        style: Style::default(),
     };
-    scene.object_mut(target).expect("target exists").transform = Transform2D {
-        translation: Vec2::new(4.0, -2.0),
-        ..Transform2D::IDENTITY
-    };
-
-    let source_snapshot = ObjectSnapshot::from(scene.object(source).expect("source exists"));
-    let target_snapshot = ObjectSnapshot::from(scene.object(target).expect("target exists"));
-    scene
-        .animate_transform(
-            copy,
-            source_snapshot,
-            target_snapshot,
-            TrackTiming::new(1.0, 2.0, Easing::Linear),
-        )
-        .expect("copy transform must be valid");
-    scene
-        .set_presence_at(copy, false, true, 1.0)
-        .expect("copy show must be valid");
-    scene
-        .set_presence_at(copy, true, false, 3.0)
-        .expect("copy hide must be valid");
-    scene
-        .set_presence_at(target, false, true, 3.0)
-        .expect("target show must be valid");
-
-    SceneInstance::new(CompiledScene::compile(&scene).expect("scene must compile"))
+    let objects = vec![
+        CompiledObject::new(source, from.geometry.clone(), from.transform, from.style),
+        CompiledObject::new(target, to.geometry.clone(), to.transform, to.style),
+        CompiledObject::new(copy, from.geometry.clone(), from.transform, from.style),
+    ];
+    let tracks = [
+        TrackDefinition {
+            id: TrackId::new(0),
+            object: copy,
+            property: Property::Transform,
+            values: TrackValues::Object { from, to },
+            timing: TrackTiming::new(1.0, 2.0, Easing::Linear),
+            time_map: Default::default(),
+        },
+        TrackDefinition {
+            id: TrackId::new(1),
+            object: copy,
+            property: Property::Presence,
+            values: TrackValues::Bool {
+                from: false,
+                to: true,
+            },
+            timing: TrackTiming::instant(1.0),
+            time_map: Default::default(),
+        },
+        TrackDefinition {
+            id: TrackId::new(2),
+            object: copy,
+            property: Property::Presence,
+            values: TrackValues::Bool {
+                from: true,
+                to: false,
+            },
+            timing: TrackTiming::instant(3.0),
+            time_map: Default::default(),
+        },
+        TrackDefinition {
+            id: TrackId::new(3),
+            object: target,
+            property: Property::Presence,
+            values: TrackValues::Bool {
+                from: false,
+                to: true,
+            },
+            timing: TrackTiming::instant(3.0),
+            time_map: Default::default(),
+        },
+    ];
+    SceneInstance::new(
+        CompiledScene::compile_objects(objects, &tracks).expect("execution data compiles"),
+    )
 }
 
 fn prepared_ids(instance: &mut SceneInstance, preparer: &mut FramePreparer, time: f64) -> Vec<u64> {

--- a/crates/noon-runtime/tests/static_frame_locality.rs
+++ b/crates/noon-runtime/tests/static_frame_locality.rs
@@ -1,17 +1,23 @@
-use noon_compile::CompiledScene;
-use noon_core::{GeometryRef, SceneDefinition};
+use noon_compile::{CompiledObject, CompiledScene};
+use noon_core::{GeometryRef, ObjectId, Style, Transform2D};
 use noon_runtime::{EvaluationStats, SceneInstance};
 
 const STATIC_OBJECTS: usize = 100_000;
 
 #[test]
 fn hundred_thousand_static_objects_do_zero_timeline_work_on_unchanged_frame() {
-    let mut scene = SceneDefinition::new();
-    for _ in 0..STATIC_OBJECTS {
-        scene.add(GeometryRef::circle(1.0));
-    }
-
-    let compiled = CompiledScene::compile(&scene).expect("static scene must compile");
+    let objects = (0..STATIC_OBJECTS)
+        .map(|index| {
+            CompiledObject::new(
+                ObjectId::new(index as u64),
+                GeometryRef::circle(1.0),
+                Transform2D::IDENTITY,
+                Style::default(),
+            )
+        })
+        .collect();
+    let compiled =
+        CompiledScene::compile_objects(objects, &[]).expect("static execution data must compile");
     let mut runtime = SceneInstance::new(compiled);
     assert_eq!(runtime.frame().objects.len(), STATIC_OBJECTS);
     assert!(runtime.take_frame_changes().is_all());

--- a/scripts/architecture-ratchet.test.sh
+++ b/scripts/architecture-ratchet.test.sh
@@ -480,6 +480,22 @@ for canonical in crates/noon/src/semantic_mobject.rs crates/noon/src/scene.rs cr
   git rm -q "$canonical"
   git commit -qm "remove canonical poison"
 done
+# Renderer fixtures must not preserve a second scene API, even when committed
+# before the comparison base.
+for canonical in crates/noon-render-wgpu/src/probe.rs crates/noon-render-wgpu/tests/probe.rs; do
+  mkdir -p "$(dirname "$canonical")"
+  for symbol in SceneDefinition ObjectDefinition ObjectSnapshot ScenePatch MutationTransaction; do
+    printf 'use noon_core::%s;\n' "$symbol" > "$canonical"
+    git add "$canonical"
+    git commit -qm 'poison renderer execution boundary'
+    if bash scripts/architecture-ratchet.sh HEAD >/dev/null 2>&1; then
+      echo "architecture ratchet test failed: accepted $symbol in $canonical" >&2
+      exit 1
+    fi
+  done
+  git rm -q "$canonical"
+  git commit -qm 'remove renderer boundary poison'
+done
 # Lowering and live publication must stay typed even when an old patch-codec
 # dependency already exists at the comparison base.
 for canonical in crates/noon-compile/src/semantic_lowering.rs crates/noon-compile/src/semantic_lowering/publication.rs crates/noon/src/execution_session.rs crates/noon/src/execution_session/publication.rs crates/noon/src/live_session.rs; do

--- a/scripts/architecture_migration_relocations.py
+++ b/scripts/architecture_migration_relocations.py
@@ -138,6 +138,10 @@ def main() -> int:
             continue
         if re.search(r'\bFrontendMobjectHandle\b', source):
             errors.append(f'{path}: deleted FrontendMobjectHandle authority returned')
+        if path.startswith('crates/noon-render-wgpu/'):
+            code = re.sub(r'/\*.*?\*/|//[^\n]*', '', source, flags=re.S)
+            if re.search(r'\b(?:SceneDefinition|ObjectDefinition|ObjectSnapshot|ScenePatch|MutationTransaction)\b', code):
+                errors.append(f'{path}: renderer code and fixtures must use typed execution data')
         if path in {'crates/noon/src/scene.rs', 'crates/noon/src/semantic_mobject.rs'} or path.startswith(('crates/noon/src/scene/', 'crates/noon/src/semantic_mobject/')):
             if FORBIDDEN_CANONICAL.search(source) or any('legacy' in leaf.split(' as ', 1)[0].split('::') for _, leaf in imports(source)):
                 errors.append(f'{path}: canonical authoring regained a migration dependency')


### PR DESCRIPTION
Advances #959/#960/#961: remove the renderer's last dependency on the retired authored scene model. Six renderer integration fixtures now construct existing typed `CompiledObject`/`TrackDefinition` execution data directly, and the live transform locality test uses `ExecutionPatch`. The 100,000-object static runtime test follows the same path.

All existing renderer/cache/lifecycle/locality assertions remain: analytic dirty ranges, no steady retessellation, bounded path cache, copy visibility phases, stroke policy cache keys, appearance multiplication, and static zero-work frames. There is no new fixture scene class, identity allocator, transport, or migration adapter. This only changes qualification setup; public Rust/Python semantics and paired examples remain unchanged.

The full-tree architecture guard now rejects legacy scene/object/patch types anywhere in the renderer crate, including tests and regressions committed before the comparison base. Negative guard tests cover all five types in source and integration-test paths.

Validation: `cargo fmt --all`; `bash scripts/check.sh architecture`; `bash scripts/architecture-ratchet.test.sh`; `git diff --check`. Rust integration execution is delegated to hosted CI to avoid another large local build. Merge only after the hosted Rust integration gate and required PR checks pass.
