### PR TITLE
Retire the duplicate reactive scene construction path

### DIFF
--- a/crates/noon-core/src/reactive/native_reactive.rs
+++ b/crates/noon-core/src/reactive/native_reactive.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
-use crate::{GeometryRef, ObjectId, Property, SceneDefinition, SignalId, ValueKind, Vec2};
+use crate::{ObjectId, Property, SignalId, ValueKind, Vec2};
 
 mod compute_ir;
 pub use compute_ir::*;
@@ -245,67 +245,6 @@ impl ReactiveGraphDefinition {
     }
 }
 
-/// High-level mutable semantic scene.
-///
-/// `SceneDefinition` remains the normalized deterministic timeline/object program
-/// consumed by the existing compiler. `SemanticScene` adds native reactive
-/// dependencies without encoding them as fake timeline tracks. Future host callback
-/// slots and high-level authoring state can live beside the same definition.
-#[derive(Clone, Debug, Default, PartialEq)]
-pub struct SemanticScene {
-    definition: SceneDefinition,
-    reactive: ReactiveGraphDefinition,
-}
-
-impl SemanticScene {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    pub fn from_definition(definition: SceneDefinition) -> Self {
-        Self {
-            definition,
-            reactive: ReactiveGraphDefinition::new(),
-        }
-    }
-
-    pub fn definition(&self) -> &SceneDefinition {
-        &self.definition
-    }
-
-    pub fn definition_mut(&mut self) -> &mut SceneDefinition {
-        &mut self.definition
-    }
-
-    pub fn reactive(&self) -> &ReactiveGraphDefinition {
-        &self.reactive
-    }
-
-    pub fn reactive_mut(&mut self) -> &mut ReactiveGraphDefinition {
-        &mut self.reactive
-    }
-
-    pub fn add(&mut self, geometry: GeometryRef) -> ObjectId {
-        self.definition.add(geometry)
-    }
-
-    pub fn add_input(&mut self, value: impl Into<ReactiveValue>) -> SignalId {
-        self.reactive.add_input(value)
-    }
-
-    pub fn add_derived(&mut self, expression: ReactiveExpr) -> SignalId {
-        self.reactive.add_derived(expression)
-    }
-
-    pub fn bind(&mut self, signal: SignalId, object: ObjectId, property: Property) {
-        self.reactive.bind(signal, object, property);
-    }
-
-    pub fn compile_reactive(&self) -> Result<ReactiveProgram, ReactiveError> {
-        ReactiveProgram::compile(&self.definition, &self.reactive)
-    }
-}
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ObjectExecutionClass {
     Static,
@@ -368,25 +307,6 @@ pub struct ReactiveProgram {
 }
 
 impl ReactiveProgram {
-    /// Compile through the migration-era normalized scene wrapper.
-    ///
-    /// Target validation itself is execution-domain based so the canonical semantic
-    /// lowering path can reuse the same native reactive VM without reconstructing the
-    /// legacy authored-scene wrapper.
-    pub fn compile(
-        scene: &SceneDefinition,
-        graph: &ReactiveGraphDefinition,
-    ) -> Result<Self, ReactiveError> {
-        Self::compile_for_execution_domain(
-            scene.objects().iter().map(|object| object.id),
-            scene
-                .tracks()
-                .iter()
-                .map(|track| (track.object, track.property)),
-            graph,
-        )
-    }
-
     /// Compile the existing native reactive graph against an execution object/driver
     /// domain instead of an authored scene representation.
     ///
@@ -972,33 +892,32 @@ impl std::error::Error for ReactiveError {}
 
 #[cfg(test)]
 mod tests {
-    use crate::{RateFunction, TrackTiming};
-
     use super::*;
 
     #[test]
     fn reactive_update_evaluates_only_affected_dependency_branch() {
-        let mut scene = SemanticScene::new();
-        let first = scene.add(GeometryRef::circle(1.0));
-        let second = scene.add(GeometryRef::circle(1.0));
-        let a = scene.add_input(1.0_f32);
-        let b = scene.add_input(10.0_f32);
-        let twice_a = scene.add_derived(ReactiveExpr::Mul(
+        let mut graph = ReactiveGraphDefinition::new();
+        let first = ObjectId::new(0);
+        let second = ObjectId::new(1);
+        let a = graph.add_input(1.0_f32);
+        let b = graph.add_input(10.0_f32);
+        let twice_a = graph.add_derived(ReactiveExpr::Mul(
             Box::new(ReactiveExpr::signal(a)),
             Box::new(ReactiveExpr::scalar(2.0)),
         ));
-        let a_branch = scene.add_derived(ReactiveExpr::Add(
+        let a_branch = graph.add_derived(ReactiveExpr::Add(
             Box::new(ReactiveExpr::signal(twice_a)),
             Box::new(ReactiveExpr::scalar(3.0)),
         ));
-        let b_branch = scene.add_derived(ReactiveExpr::Add(
+        let b_branch = graph.add_derived(ReactiveExpr::Add(
             Box::new(ReactiveExpr::signal(b)),
             Box::new(ReactiveExpr::scalar(1.0)),
         ));
-        scene.bind(a_branch, first, Property::Rotation);
-        scene.bind(b_branch, second, Property::Opacity);
+        graph.bind(a_branch, first, Property::Rotation);
+        graph.bind(b_branch, second, Property::Opacity);
 
-        let program = scene.compile_reactive().expect("graph must compile");
+        let program = ReactiveProgram::compile_for_execution_domain([first, second], [], &graph)
+            .expect("graph must compile");
         let mut state = program.instantiate();
         let update = state.set_input(a, 2.0_f32).expect("input update must work");
 
@@ -1018,21 +937,20 @@ mod tests {
 
     #[test]
     fn unchanged_derived_value_stops_dirty_propagation() {
-        let mut scene = SemanticScene::new();
-        let object = scene.add(GeometryRef::circle(1.0));
-        let input = scene.add_input(1.0_f32);
-        let always_zero = scene.add_derived(ReactiveExpr::Mul(
+        let mut graph = ReactiveGraphDefinition::new();
+        let object = ObjectId::new(0);
+        let input = graph.add_input(1.0_f32);
+        let always_zero = graph.add_derived(ReactiveExpr::Mul(
             Box::new(ReactiveExpr::signal(input)),
             Box::new(ReactiveExpr::scalar(0.0)),
         ));
-        let downstream = scene.add_derived(ReactiveExpr::Add(
+        let downstream = graph.add_derived(ReactiveExpr::Add(
             Box::new(ReactiveExpr::signal(always_zero)),
             Box::new(ReactiveExpr::scalar(1.0)),
         ));
-        scene.bind(downstream, object, Property::Opacity);
+        graph.bind(downstream, object, Property::Opacity);
 
-        let mut state = scene
-            .compile_reactive()
+        let mut state = ReactiveProgram::compile_for_execution_domain([object], [], &graph)
             .expect("graph must compile")
             .instantiate();
         let update = state
@@ -1047,38 +965,31 @@ mod tests {
 
     #[test]
     fn execution_analysis_is_local_to_dynamic_objects() {
-        let mut scene = SemanticScene::new();
-        let static_object = scene.add(GeometryRef::circle(1.0));
-        let timeline_object = scene.add(GeometryRef::circle(1.0));
-        let reactive_object = scene.add(GeometryRef::circle(1.0));
-        let mixed_object = scene.add(GeometryRef::circle(1.0));
+        let mut graph = ReactiveGraphDefinition::new();
+        let static_object = ObjectId::new(0);
+        let timeline_object = ObjectId::new(1);
+        let reactive_object = ObjectId::new(2);
+        let mixed_object = ObjectId::new(3);
 
-        scene
-            .definition_mut()
-            .animate_scalar(
+        let reactive = graph.add_input(0.5_f32);
+        let mixed = graph.add_input(0.25_f32);
+        graph.bind(reactive, reactive_object, Property::Opacity);
+        graph.bind(mixed, mixed_object, Property::Rotation);
+
+        let program = ReactiveProgram::compile_for_execution_domain(
+            [
+                static_object,
                 timeline_object,
-                Property::Rotation,
-                0.0,
-                1.0,
-                TrackTiming::new(0.0, 1.0, RateFunction::Linear),
-            )
-            .expect("timeline track must be valid");
-        scene
-            .definition_mut()
-            .animate_position(
+                reactive_object,
                 mixed_object,
-                Vec2::ZERO,
-                Vec2::ONE,
-                TrackTiming::new(0.0, 1.0, RateFunction::Linear),
-            )
-            .expect("timeline track must be valid");
-
-        let reactive = scene.add_input(0.5_f32);
-        let mixed = scene.add_input(0.25_f32);
-        scene.bind(reactive, reactive_object, Property::Opacity);
-        scene.bind(mixed, mixed_object, Property::Rotation);
-
-        let program = scene.compile_reactive().expect("graph must compile");
+            ],
+            [
+                (timeline_object, Property::Rotation),
+                (mixed_object, Property::Position),
+            ],
+            &graph,
+        )
+        .expect("graph must compile");
         let analysis = program.analysis();
         assert_eq!(analysis.static_objects, 1);
         assert_eq!(analysis.timeline_only_objects, 1);
@@ -1100,39 +1011,6 @@ mod tests {
             analysis.class_for(mixed_object),
             Some(ObjectExecutionClass::TimelineAndReactive)
         );
-    }
-
-    #[test]
-    fn execution_domain_compile_matches_scene_wrapper() {
-        let mut scene = SemanticScene::new();
-        let timeline_object = scene.add(GeometryRef::circle(1.0));
-        let reactive_object = scene.add(GeometryRef::circle(1.0));
-        scene
-            .definition_mut()
-            .animate_scalar(
-                timeline_object,
-                Property::Rotation,
-                0.0,
-                1.0,
-                TrackTiming::new(0.0, 1.0, RateFunction::Linear),
-            )
-            .unwrap();
-        let signal = scene.add_input(0.5_f32);
-        scene.bind(signal, reactive_object, Property::Opacity);
-
-        let direct = ReactiveProgram::compile_for_execution_domain(
-            scene.definition().objects().iter().map(|object| object.id),
-            scene
-                .definition()
-                .tracks()
-                .iter()
-                .map(|track| (track.object, track.property)),
-            scene.reactive(),
-        )
-        .unwrap();
-        let wrapped = scene.compile_reactive().unwrap();
-
-        assert_eq!(direct, wrapped);
     }
 
     #[test]
@@ -1194,23 +1072,13 @@ mod tests {
 
     #[test]
     fn same_property_cannot_have_timeline_and_reactive_drivers() {
-        let mut scene = SemanticScene::new();
-        let object = scene.add(GeometryRef::circle(1.0));
-        scene
-            .definition_mut()
-            .animate_scalar(
-                object,
-                Property::Opacity,
-                0.0,
-                1.0,
-                TrackTiming::new(0.0, 1.0, RateFunction::Linear),
-            )
-            .expect("timeline track must be valid");
-        let signal = scene.add_input(0.5_f32);
-        scene.bind(signal, object, Property::Opacity);
+        let mut graph = ReactiveGraphDefinition::new();
+        let object = ObjectId::new(0);
+        let signal = graph.add_input(0.5_f32);
+        graph.bind(signal, object, Property::Opacity);
 
         assert!(matches!(
-            scene.compile_reactive(),
+            ReactiveProgram::compile_for_execution_domain([object], [(object, Property::Opacity)], &graph),
             Err(ReactiveError::ConflictingDriver {
                 object: conflict_object,
                 property: Property::Opacity,
@@ -1238,20 +1106,20 @@ mod tests {
         .expect("transported IDs are unique");
 
         assert!(matches!(
-            ReactiveProgram::compile(&SceneDefinition::new(), &graph),
+            ReactiveProgram::compile_for_execution_domain([], [], &graph),
             Err(ReactiveError::DependencyCycle)
         ));
     }
 
     #[test]
     fn binding_types_are_checked_before_execution() {
-        let mut scene = SemanticScene::new();
-        let object = scene.add(GeometryRef::circle(1.0));
-        let scalar = scene.add_input(1.0_f32);
-        scene.bind(scalar, object, Property::Position);
+        let mut graph = ReactiveGraphDefinition::new();
+        let object = ObjectId::new(0);
+        let scalar = graph.add_input(1.0_f32);
+        graph.bind(scalar, object, Property::Position);
 
         assert!(matches!(
-            scene.compile_reactive(),
+            ReactiveProgram::compile_for_execution_domain([object], [], &graph),
             Err(ReactiveError::BindingTypeMismatch {
                 signal,
                 property: Property::Position,

--- a/crates/noon-core/src/reactive/native_reactive/compute_ir.rs
+++ b/crates/noon-core/src/reactive/native_reactive/compute_ir.rs
@@ -1118,23 +1118,26 @@ const fn type_bug(owner: SignalId, operation: &'static str) -> ReactiveError {
 
 #[cfg(test)]
 mod tests {
-    use crate::{GeometryRef, Property, SemanticScene};
+    use crate::{ObjectId, Property, ReactiveGraphDefinition};
 
     use super::*;
 
     #[test]
     fn lowers_scalar_vector_expression_to_typed_flat_ir() {
-        let mut scene = SemanticScene::new();
-        let object = scene.add(GeometryRef::circle(1.0));
-        let scalar = scene.add_input(2.0_f32);
-        let vector = scene.add_input(Vec2::new(3.0, 4.0));
-        let result = scene.add_derived(ReactiveExpr::Mul(
+        let mut graph = ReactiveGraphDefinition::new();
+        let object = ObjectId::new(0);
+        let scalar = graph.add_input(2.0_f32);
+        let vector = graph.add_input(Vec2::new(3.0, 4.0));
+        let result = graph.add_derived(ReactiveExpr::Mul(
             Box::new(ReactiveExpr::signal(scalar)),
             Box::new(ReactiveExpr::signal(vector)),
         ));
-        scene.bind(result, object, Property::Position);
+        graph.bind(result, object, Property::Position);
 
-        let program = scene.compile_reactive().unwrap().into_compute().unwrap();
+        let program = ReactiveProgram::compile_for_execution_domain([object], [], &graph)
+            .unwrap()
+            .into_compute()
+            .unwrap();
         let kernel = program.kernel(result).expect("derived signal has a kernel");
         assert_eq!(kernel.output_kind(), ComputeValueKind::Vec2);
         assert_eq!(kernel.instructions().len(), 3);
@@ -1160,10 +1163,10 @@ mod tests {
     fn dense_vm_matches_reference_interpreter_on_generated_graphs() {
         for seed in 1_u64..=24 {
             let mut random = seed;
-            let mut scene = SemanticScene::new();
-            let object = scene.add(GeometryRef::circle(1.0));
-            let first = scene.add_input(0.25_f32);
-            let second = scene.add_input(-0.75_f32);
+            let mut graph = ReactiveGraphDefinition::new();
+            let object = ObjectId::new(0);
+            let first = graph.add_input(0.25_f32);
+            let second = graph.add_input(-0.75_f32);
             let mut signals = vec![first, second];
 
             for _ in 0..32 {
@@ -1186,11 +1189,12 @@ mod tests {
                     4 => ReactiveExpr::Sin(Box::new(ReactiveExpr::signal(lhs))),
                     _ => ReactiveExpr::Cos(Box::new(ReactiveExpr::signal(lhs))),
                 };
-                signals.push(scene.add_derived(expression));
+                signals.push(graph.add_derived(expression));
             }
-            scene.bind(*signals.last().unwrap(), object, Property::Rotation);
+            graph.bind(*signals.last().unwrap(), object, Property::Rotation);
 
-            let program = scene.compile_reactive().expect("generated graph compiles");
+            let program = ReactiveProgram::compile_for_execution_domain([object], [], &graph)
+                .expect("generated graph compiles");
             let mut reference = program.instantiate();
             let mut compute = program.into_compute().unwrap().instantiate();
 
@@ -1214,21 +1218,20 @@ mod tests {
 
     #[test]
     fn dense_vm_preserves_change_stopping() {
-        let mut scene = SemanticScene::new();
-        let object = scene.add(GeometryRef::circle(1.0));
-        let input = scene.add_input(1.0_f32);
-        let zero = scene.add_derived(ReactiveExpr::Mul(
+        let mut graph = ReactiveGraphDefinition::new();
+        let object = ObjectId::new(0);
+        let input = graph.add_input(1.0_f32);
+        let zero = graph.add_derived(ReactiveExpr::Mul(
             Box::new(ReactiveExpr::signal(input)),
             Box::new(ReactiveExpr::scalar(0.0)),
         ));
-        let downstream = scene.add_derived(ReactiveExpr::Add(
+        let downstream = graph.add_derived(ReactiveExpr::Add(
             Box::new(ReactiveExpr::signal(zero)),
             Box::new(ReactiveExpr::scalar(1.0)),
         ));
-        scene.bind(downstream, object, Property::Opacity);
+        graph.bind(downstream, object, Property::Opacity);
 
-        let mut state = scene
-            .compile_reactive()
+        let mut state = ReactiveProgram::compile_for_execution_domain([object], [], &graph)
             .unwrap()
             .into_compute()
             .unwrap()
@@ -1241,15 +1244,14 @@ mod tests {
 
     #[test]
     fn prepared_batch_stages_all_inputs_before_one_shared_closure_evaluation() {
-        let mut scene = SemanticScene::new();
-        let first = scene.add_input(0.0_f32);
-        let second = scene.add_input(0.0_f32);
-        let sum = scene.add_derived(ReactiveExpr::Add(
+        let mut graph = ReactiveGraphDefinition::new();
+        let first = graph.add_input(0.0_f32);
+        let second = graph.add_input(0.0_f32);
+        let sum = graph.add_derived(ReactiveExpr::Add(
             Box::new(ReactiveExpr::signal(first)),
             Box::new(ReactiveExpr::signal(second)),
         ));
-        let mut state = scene
-            .compile_reactive()
+        let mut state = ReactiveProgram::compile_for_execution_domain([], [], &graph)
             .unwrap()
             .into_compute()
             .unwrap()
@@ -1269,21 +1271,20 @@ mod tests {
 
     #[test]
     fn prepared_batch_failure_restores_values_and_scheduler_scratch() {
-        let mut scene = SemanticScene::new();
-        let first = scene.add_input(1.0_f32);
-        let second = scene.add_input(1.0_f32);
-        let sum = scene.add_derived(ReactiveExpr::Add(
+        let mut graph = ReactiveGraphDefinition::new();
+        let first = graph.add_input(1.0_f32);
+        let second = graph.add_input(1.0_f32);
+        let sum = graph.add_derived(ReactiveExpr::Add(
             Box::new(ReactiveExpr::signal(first)),
             Box::new(ReactiveExpr::signal(second)),
         ));
-        let square = scene.add_derived(ReactiveExpr::Mul(
+        let square = graph.add_derived(ReactiveExpr::Mul(
             Box::new(ReactiveExpr::signal(sum)),
             Box::new(ReactiveExpr::signal(sum)),
         ));
         let downstream =
-            scene.add_derived(ReactiveExpr::Sin(Box::new(ReactiveExpr::signal(square))));
-        let mut state = scene
-            .compile_reactive()
+            graph.add_derived(ReactiveExpr::Sin(Box::new(ReactiveExpr::signal(square))));
+        let mut state = ReactiveProgram::compile_for_execution_domain([], [], &graph)
             .unwrap()
             .into_compute()
             .unwrap()
@@ -1319,9 +1320,12 @@ mod tests {
 
     #[test]
     fn prepared_batches_are_bound_to_one_compute_incarnation_and_revision() {
-        let mut scene = SemanticScene::new();
-        let input = scene.add_input(0.0_f32);
-        let program = scene.compile_reactive().unwrap().into_compute().unwrap();
+        let mut graph = ReactiveGraphDefinition::new();
+        let input = graph.add_input(0.0_f32);
+        let program = ReactiveProgram::compile_for_execution_domain([], [], &graph)
+            .unwrap()
+            .into_compute()
+            .unwrap();
         let mut first = program.clone().instantiate();
         let mut second = program.instantiate();
         let foreign = first
@@ -1347,9 +1351,8 @@ mod tests {
 
     #[test]
     fn prepared_enrollment_rejects_a_different_signal_without_mutation() {
-        let scene = SemanticScene::new();
-        let mut state = scene
-            .compile_reactive()
+        let graph = ReactiveGraphDefinition::new();
+        let mut state = ReactiveProgram::compile_for_execution_domain([], [], &graph)
             .unwrap()
             .into_compute()
             .unwrap()
@@ -1370,10 +1373,9 @@ mod tests {
 
     #[test]
     fn prepared_enrollment_rejects_an_existing_signal_without_mutation() {
-        let mut scene = SemanticScene::new();
-        let existing = scene.add_input(1.0_f32);
-        let mut state = scene
-            .compile_reactive()
+        let mut graph = ReactiveGraphDefinition::new();
+        let existing = graph.add_input(1.0_f32);
+        let mut state = ReactiveProgram::compile_for_execution_domain([], [], &graph)
             .unwrap()
             .into_compute()
             .unwrap()
@@ -1391,9 +1393,8 @@ mod tests {
 
     #[test]
     fn prepared_enrollment_batch_commits_two_inputs_at_one_revision() {
-        let scene = SemanticScene::new();
-        let mut state = scene
-            .compile_reactive()
+        let graph = ReactiveGraphDefinition::new();
+        let mut state = ReactiveProgram::compile_for_execution_domain([], [], &graph)
             .unwrap()
             .into_compute()
             .unwrap()
@@ -1416,9 +1417,8 @@ mod tests {
 
     #[test]
     fn enrollment_batch_rejects_duplicates_and_stale_preflight_without_mutation() {
-        let scene = SemanticScene::new();
-        let mut state = scene
-            .compile_reactive()
+        let graph = ReactiveGraphDefinition::new();
+        let mut state = ReactiveProgram::compile_for_execution_domain([], [], &graph)
             .unwrap()
             .into_compute()
             .unwrap()

--- a/crates/noon-runtime/src/prepared_frame.rs
+++ b/crates/noon-runtime/src/prepared_frame.rs
@@ -577,10 +577,14 @@ impl SceneInstance {
 
 #[cfg(test)]
 mod tests {
-    use noon_compile::{CompilePatchError, CompiledObject, CompiledScene};
+    use noon_compile::{
+        lower_semantic_execution, CompilePatchError, CompiledObject, CompiledScene,
+        SemanticExecutionIndex,
+    };
     use noon_core::{
-        CompositionTimeMap, Easing, GeometryRef, ObjectId, Property, SemanticScene, Style,
-        TrackDefinition, TrackId, TrackTiming, TrackValues, Transform2D, Vec2,
+        CompositionTimeMap, Easing, GeometryRef, ObjectId, Property, SemanticObjectProperty,
+        SemanticObjectState, SemanticStore, SemanticVec3, StoredGeometry, Style, TrackDefinition,
+        TrackId, TrackTiming, TrackValues, Transform2D, Vec2,
     };
 
     use super::*;
@@ -711,11 +715,22 @@ mod tests {
 
     #[test]
     fn native_owned_component_is_reapplied_before_next_host_phase() {
-        let mut scene = SemanticScene::new();
-        let object = scene.add(GeometryRef::circle(1.0));
-        let position = scene.add_input(Vec2::new(3.0, -1.0));
-        scene.bind(position, object, Property::Position);
-        let mut instance = SceneInstance::from_semantic(&scene).unwrap();
+        let mut store = SemanticStore::new();
+        let object =
+            store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+                radius: 1.0,
+            }));
+        store.attach_to_scene(object).unwrap();
+        let position = store
+            .insert_semantic_input_signal(SemanticVec3::new(3.0, -1.0, 0.0))
+            .unwrap();
+        store
+            .bind_semantic_signal(position, object, SemanticObjectProperty::Translation)
+            .unwrap();
+        let mut index = SemanticExecutionIndex::new();
+        let lowered = lower_semantic_execution(&store, &mut index).unwrap();
+        let object = index.execution_object_id(object).unwrap();
+        let mut instance = SceneInstance::from_semantic_execution(lowered);
         instance.take_frame_changes();
 
         let prepared = instance.prepare_advance_to(0.5).unwrap();

--- a/crates/noon-runtime/src/reactive.rs
+++ b/crates/noon-runtime/src/reactive.rs
@@ -4,7 +4,6 @@ pub(crate) use runtime::{
 };
 pub use runtime::{
     PreparedReactiveSignalEnrollment, PreparedReactiveSignalEnrollmentBatch, ReactiveRuntimeStats,
-    SceneBuildError,
 };
 
 mod host_policy;

--- a/crates/noon-runtime/src/reactive/runtime.rs
+++ b/crates/noon-runtime/src/reactive/runtime.rs
@@ -1,43 +1,14 @@
 use std::collections::BTreeMap;
 
-use noon_compile::{CompileError, CompiledScene, SemanticExecutionLoweringOutput};
+use noon_compile::{CompiledScene, SemanticExecutionLoweringOutput};
 use noon_core::{
     ComputeProgram, ComputeState, ObjectId, PreparedComputeInputBatch,
     PreparedComputeInputEnrollment, PreparedComputeInputEnrollmentBatch, Property,
-    PublicationContext, ReactiveBinding, ReactiveError, ReactiveEvaluationStats, ReactiveProgram,
-    ReactiveValue, SemanticScene, SignalId,
+    PublicationContext, ReactiveBinding, ReactiveError, ReactiveEvaluationStats, ReactiveValue,
+    SignalId,
 };
 
 use crate::{frame_row_mut, FrameRowMut, FrameState, SceneInstance};
-
-#[derive(Clone, Debug, PartialEq)]
-pub enum SceneBuildError {
-    Compile(CompileError),
-    Reactive(ReactiveError),
-}
-
-impl std::fmt::Display for SceneBuildError {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Compile(error) => write!(formatter, "scene compilation failed: {error}"),
-            Self::Reactive(error) => write!(formatter, "reactive compilation failed: {error}"),
-        }
-    }
-}
-
-impl std::error::Error for SceneBuildError {}
-
-impl From<CompileError> for SceneBuildError {
-    fn from(value: CompileError) -> Self {
-        Self::Compile(value)
-    }
-}
-
-impl From<ReactiveError> for SceneBuildError {
-    fn from(value: ReactiveError) -> Self {
-        Self::Reactive(value)
-    }
-}
 
 /// Work performed by the most recent native reactive input update.
 ///
@@ -321,37 +292,6 @@ impl SceneInstance {
         instance.reactive = Some(reactive);
         instance.reapply_reactive();
         instance
-    }
-
-    /// Compile a high-level semantic scene once and attach its validated native
-    /// reactive program to this runtime instance.
-    ///
-    /// Reactive expressions are flattened into typed compute kernels and bindings
-    /// are lowered to dense frame object indices here. Later input updates therefore
-    /// do not recurse through authoring ASTs, rebuild `SceneDefinition`, recompile
-    /// the timeline, or scan unrelated objects.
-    pub fn from_semantic(scene: &SemanticScene) -> Result<Self, SceneBuildError> {
-        let compiled = CompiledScene::compile(scene.definition())?;
-        let program = ReactiveProgram::compile_for_execution_domain(
-            compiled
-                .objects()
-                .iter()
-                .filter(|object| object.live)
-                .map(|object| object.id),
-            compiled.tracks_iter().map(|track| {
-                let object = compiled
-                    .object_id_at_slot(track.object_index)
-                    .expect("compiled timeline track must reference a live object slot");
-                (object, track.property)
-            }),
-            scene.reactive(),
-        )?
-        .into_compute()?;
-        let reactive = ReactiveRuntime::new(&compiled, scene.reactive().bindings(), program);
-        let mut instance = Self::new(compiled);
-        instance.reactive = Some(reactive);
-        instance.reapply_reactive();
-        Ok(instance)
     }
 
     /// Exact authored/executable/effective publication context of this runtime view.
@@ -670,18 +610,33 @@ pub(crate) fn apply_reactive_value_to_row(
 
 #[cfg(test)]
 mod tests {
-    use noon_core::{GeometryRef, RateFunction, ReactiveExpr, TrackTiming, Vec2};
+    use noon_compile::{lower_semantic_execution, ExecutionPatch, SemanticExecutionIndex};
+    use noon_core::{
+        CompositionTimeMap, GeometryRef, RateFunction, SemanticObjectProperty, SemanticObjectState,
+        SemanticSignalExpr, SemanticStore, SemanticVec3, StoredGeometry, TrackDefinition, TrackId,
+        TrackTiming, TrackValues, Vec2,
+    };
 
     use super::*;
 
     #[test]
     fn initial_reactive_values_are_lowered_into_frame_state() {
-        let mut scene = SemanticScene::new();
-        let object = scene.add(GeometryRef::circle(1.0));
-        let position = scene.add_input(Vec2::new(3.0, -2.0));
-        scene.bind(position, object, Property::Position);
+        let mut scene = SemanticStore::new();
+        let object =
+            scene.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+                radius: 1.0,
+            }));
+        scene.attach_to_scene(object).unwrap();
+        let position = scene
+            .insert_semantic_input_signal(SemanticVec3::new(3.0, -2.0, 0.0))
+            .unwrap();
+        scene
+            .bind_semantic_signal(position, object, SemanticObjectProperty::Translation)
+            .unwrap();
 
-        let instance = SceneInstance::from_semantic(&scene).expect("semantic scene must compile");
+        let mut index = SemanticExecutionIndex::new();
+        let lowered = lower_semantic_execution(&scene, &mut index).unwrap();
+        let instance = SceneInstance::from_semantic_execution(lowered);
         assert_eq!(
             instance.frame().objects[0].transform.translation,
             Vec2::new(3.0, -2.0)
@@ -690,13 +645,23 @@ mod tests {
 
     #[test]
     fn reactive_scale_updates_transform_without_touching_geometry() {
-        let mut scene = SemanticScene::new();
-        let object = scene.add(GeometryRef::circle(1.0));
-        let scale = scene.add_input(Vec2::ONE);
-        scene.bind(scale, object, Property::Scale);
+        let mut scene = SemanticStore::new();
+        let object =
+            scene.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+                radius: 1.0,
+            }));
+        scene.attach_to_scene(object).unwrap();
+        let scale = scene
+            .insert_semantic_input_signal(SemanticVec3::new(1.0, 1.0, 1.0))
+            .unwrap();
+        scene
+            .bind_semantic_signal(scale, object, SemanticObjectProperty::Scale)
+            .unwrap();
 
-        let mut instance =
-            SceneInstance::from_semantic(&scene).expect("semantic scene must compile");
+        let mut index = SemanticExecutionIndex::new();
+        let lowered = lower_semantic_execution(&scene, &mut index).unwrap();
+        let scale = lowered.reactive().execution_signal_id(scale).unwrap();
+        let mut instance = SceneInstance::from_semantic_execution(lowered);
         assert_eq!(instance.frame().objects[0].transform.scale, Vec2::ONE);
         assert_eq!(
             instance.frame().objects[0].geometry(),
@@ -718,18 +683,34 @@ mod tests {
 
     #[test]
     fn input_update_mutates_only_lowered_dense_target() {
-        let mut scene = SemanticScene::new();
-        let untouched = scene.add(GeometryRef::circle(1.0));
-        let target = scene.add(GeometryRef::circle(1.0));
-        let input = scene.add_input(1.0_f32);
-        let doubled = scene.add_derived(ReactiveExpr::Mul(
-            Box::new(ReactiveExpr::signal(input)),
-            Box::new(ReactiveExpr::scalar(2.0)),
-        ));
-        scene.bind(doubled, target, Property::Rotation);
+        let mut scene = SemanticStore::new();
+        let untouched =
+            scene.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+                radius: 1.0,
+            }));
+        scene.attach_to_scene(untouched).unwrap();
+        let target =
+            scene.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+                radius: 1.0,
+            }));
+        scene.attach_to_scene(target).unwrap();
+        let input = scene.insert_semantic_input_signal(1.0_f64).unwrap();
+        let doubled = scene
+            .insert_semantic_derived_signal(SemanticSignalExpr::Mul(
+                Box::new(SemanticSignalExpr::signal(input)),
+                Box::new(SemanticSignalExpr::scalar(2.0)),
+            ))
+            .unwrap();
+        scene
+            .bind_semantic_signal(doubled, target, SemanticObjectProperty::RotationZ)
+            .unwrap();
 
-        let mut instance =
-            SceneInstance::from_semantic(&scene).expect("semantic scene must compile");
+        let mut index = SemanticExecutionIndex::new();
+        let lowered = lower_semantic_execution(&scene, &mut index).unwrap();
+        let untouched = index.execution_object_id(untouched).unwrap();
+        let target = index.execution_object_id(target).unwrap();
+        let input = lowered.reactive().execution_signal_id(input).unwrap();
+        let mut instance = SceneInstance::from_semantic_execution(lowered);
         instance.take_frame_changes();
         instance
             .set_reactive_input(input, 2.0_f32)
@@ -753,11 +734,21 @@ mod tests {
 
     #[test]
     fn signal_only_reactive_update_publishes_frame_epoch_without_frame_dirtiness() {
-        let mut scene = SemanticScene::new();
-        scene.add(GeometryRef::circle(1.0));
-        let input = scene.add_input(1.0_f32);
-        let mut instance =
-            SceneInstance::from_semantic(&scene).expect("semantic scene must compile");
+        let mut scene = SemanticStore::new();
+        let node = scene.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+            radius: 1.0,
+        }));
+        scene.attach_to_scene(node).unwrap();
+        let mut index = SemanticExecutionIndex::new();
+        let lowered = lower_semantic_execution(&scene, &mut index).unwrap();
+        let mut instance = SceneInstance::from_semantic_execution(lowered);
+        // Unbound semantic inputs are pruned by initial lowering. Exercise the
+        // runtime's explicit enrollment used when a live input enters execution.
+        let input = SignalId::new(0);
+        let enrollment = instance
+            .prepare_reactive_signal_enrollment(Some(input), ReactiveValue::Scalar(1.0))
+            .unwrap();
+        instance.commit_reactive_signal_enrollment(enrollment, input);
         instance.take_frame_changes();
         let before = instance.publication_context();
 
@@ -786,22 +777,35 @@ mod tests {
 
     #[test]
     fn seeks_reapply_reactive_values_after_timeline_evaluation() {
-        let mut scene = SemanticScene::new();
-        let object = scene.add(GeometryRef::circle(1.0));
+        let mut scene = SemanticStore::new();
+        let object =
+            scene.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+                radius: 1.0,
+            }));
+        scene.attach_to_scene(object).unwrap();
+        let rotation = scene.insert_semantic_input_signal(0.25_f64).unwrap();
         scene
-            .definition_mut()
-            .animate_position(
-                object,
-                Vec2::ZERO,
-                Vec2::new(10.0, 0.0),
-                TrackTiming::new(0.0, 2.0, RateFunction::Linear),
-            )
-            .expect("timeline must be valid");
-        let rotation = scene.add_input(0.25_f32);
-        scene.bind(rotation, object, Property::Rotation);
+            .bind_semantic_signal(rotation, object, SemanticObjectProperty::RotationZ)
+            .unwrap();
 
-        let mut instance =
-            SceneInstance::from_semantic(&scene).expect("semantic scene must compile");
+        let mut index = SemanticExecutionIndex::new();
+        let lowered = lower_semantic_execution(&scene, &mut index).unwrap();
+        let object = index.execution_object_id(object).unwrap();
+        let rotation = lowered.reactive().execution_signal_id(rotation).unwrap();
+        let mut instance = SceneInstance::from_semantic_execution(lowered);
+        instance
+            .apply_execution_patch(&ExecutionPatch::AddTrack(TrackDefinition {
+                id: TrackId::new(0),
+                object,
+                property: Property::Position,
+                values: TrackValues::Vec2 {
+                    from: Vec2::ZERO,
+                    to: Vec2::new(10.0, 0.0),
+                },
+                timing: TrackTiming::new(0.0, 2.0, RateFunction::Linear),
+                time_map: CompositionTimeMap::identity(),
+            }))
+            .unwrap();
         instance
             .set_reactive_input(rotation, 1.25_f32)
             .expect("input update must work");
@@ -816,24 +820,41 @@ mod tests {
 
     #[test]
     fn reactive_update_cost_does_not_scale_with_static_object_count() {
-        let mut scene = SemanticScene::new();
+        let mut scene = SemanticStore::new();
         for _ in 0..50_000 {
-            scene.add(GeometryRef::circle(1.0));
+            let node =
+                scene.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+                    radius: 1.0,
+                }));
+            scene.attach_to_scene(node).unwrap();
         }
-        let target = scene.add(GeometryRef::circle(1.0));
-        let input = scene.add_input(1.0_f32);
-        let doubled = scene.add_derived(ReactiveExpr::Mul(
-            Box::new(ReactiveExpr::signal(input)),
-            Box::new(ReactiveExpr::scalar(2.0)),
-        ));
-        let shifted = scene.add_derived(ReactiveExpr::Add(
-            Box::new(ReactiveExpr::signal(doubled)),
-            Box::new(ReactiveExpr::scalar(1.0)),
-        ));
-        scene.bind(shifted, target, Property::Rotation);
+        let target =
+            scene.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+                radius: 1.0,
+            }));
+        scene.attach_to_scene(target).unwrap();
+        let input = scene.insert_semantic_input_signal(1.0_f64).unwrap();
+        let doubled = scene
+            .insert_semantic_derived_signal(SemanticSignalExpr::Mul(
+                Box::new(SemanticSignalExpr::signal(input)),
+                Box::new(SemanticSignalExpr::scalar(2.0)),
+            ))
+            .unwrap();
+        let shifted = scene
+            .insert_semantic_derived_signal(SemanticSignalExpr::Add(
+                Box::new(SemanticSignalExpr::signal(doubled)),
+                Box::new(SemanticSignalExpr::scalar(1.0)),
+            ))
+            .unwrap();
+        scene
+            .bind_semantic_signal(shifted, target, SemanticObjectProperty::RotationZ)
+            .unwrap();
 
-        let mut instance =
-            SceneInstance::from_semantic(&scene).expect("semantic scene must compile");
+        let mut index = SemanticExecutionIndex::new();
+        let lowered = lower_semantic_execution(&scene, &mut index).unwrap();
+        let target = index.execution_object_id(target).unwrap();
+        let input = lowered.reactive().execution_signal_id(input).unwrap();
+        let mut instance = SceneInstance::from_semantic_execution(lowered);
         instance.take_frame_changes();
         let timeline_stats_before = instance.last_stats();
         instance
@@ -857,13 +878,22 @@ mod tests {
 
     #[test]
     fn removed_reactive_target_stays_hidden_and_rebinds_on_same_id_recreate() {
-        let mut scene = SemanticScene::new();
-        let object = scene.add(GeometryRef::circle(1.0));
-        let visible = scene.add_input(true);
-        scene.bind(visible, object, Property::Presence);
+        let mut scene = SemanticStore::new();
+        let object =
+            scene.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+                radius: 1.0,
+            }));
+        scene.attach_to_scene(object).unwrap();
+        let visible = scene.insert_semantic_input_signal(true).unwrap();
+        scene
+            .bind_semantic_signal(visible, object, SemanticObjectProperty::Presence)
+            .unwrap();
 
-        let mut instance =
-            SceneInstance::from_semantic(&scene).expect("semantic scene must compile");
+        let mut index = SemanticExecutionIndex::new();
+        let lowered = lower_semantic_execution(&scene, &mut index).unwrap();
+        let object = index.execution_object_id(object).unwrap();
+        let visible = lowered.reactive().execution_signal_id(visible).unwrap();
+        let mut instance = SceneInstance::from_semantic_execution(lowered);
         instance
             .apply_execution_patch(&noon_compile::ExecutionPatch::RemoveObject(object))
             .expect("remove must compile");

--- a/crates/noon-runtime/tests/reactive_dirty_closure.rs
+++ b/crates/noon-runtime/tests/reactive_dirty_closure.rs
@@ -1,28 +1,43 @@
-use noon_core::{GeometryRef, Property, ReactiveExpr, SemanticScene};
+use noon_compile::{lower_semantic_execution, SemanticExecutionIndex};
+use noon_core::{
+    SemanticObjectProperty, SemanticObjectState, SemanticSignalExpr, SemanticStore, StoredGeometry,
+};
 use noon_runtime::{ReactiveRuntimeStats, SceneInstance};
 
 const BRANCH_COUNT: usize = 10_000;
 
 #[test]
 fn one_input_update_only_evaluates_its_reactive_branch_in_large_graph() {
-    let mut scene = SemanticScene::new();
+    let mut scene = SemanticStore::new();
     let mut inputs = Vec::with_capacity(BRANCH_COUNT);
 
     for _ in 0..BRANCH_COUNT {
-        let object = scene.add(GeometryRef::circle(1.0));
-        let input = scene.add_input(0.0_f32);
-        let derived = scene.add_derived(ReactiveExpr::Add(
-            Box::new(ReactiveExpr::signal(input)),
-            Box::new(ReactiveExpr::scalar(1.0)),
-        ));
-        scene.bind(derived, object, Property::Rotation);
+        let object =
+            scene.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+                radius: 1.0,
+            }));
+        scene.attach_to_scene(object).unwrap();
+        let input = scene.insert_semantic_input_signal(0.0_f64).unwrap();
+        let derived = scene
+            .insert_semantic_derived_signal(SemanticSignalExpr::Add(
+                Box::new(SemanticSignalExpr::signal(input)),
+                Box::new(SemanticSignalExpr::scalar(1.0)),
+            ))
+            .unwrap();
+        scene
+            .bind_semantic_signal(derived, object, SemanticObjectProperty::RotationZ)
+            .unwrap();
         inputs.push(input);
     }
 
     let target_index = BRANCH_COUNT / 2;
     let target_input = inputs[target_index];
-    let mut instance =
-        SceneInstance::from_semantic(&scene).expect("large reactive graph must compile");
+    let lowered = lower_semantic_execution(&scene, &mut SemanticExecutionIndex::new()).unwrap();
+    let target_input = lowered
+        .reactive()
+        .execution_signal_id(target_input)
+        .unwrap();
+    let mut instance = SceneInstance::from_semantic_execution(lowered);
     instance.take_frame_changes();
 
     instance

--- a/crates/noon-runtime/tests/semantic_execution_lowering.rs
+++ b/crates/noon-runtime/tests/semantic_execution_lowering.rs
@@ -3,10 +3,9 @@ use std::sync::Arc;
 use noon_compile::{lower_semantic_execution, SemanticExecutionIndex};
 use noon_core::{
     Color, CompositionTimeMap, FontResourceArena, GeometryRef, GeometryResourceArena, Property,
-    RateFunction, Rect, ScenePatch, SemanticObjectProperty, SemanticObjectState, SemanticPaint,
-    SemanticScene, SemanticStore, SemanticVec3, StoredGeometry, StrokeCap, StrokeJoin, Style,
-    TextResource, TextSourceKind, TrackDefinition, TrackId, TrackTiming, TrackValues, Transform2D,
-    Vec2,
+    RateFunction, Rect, SemanticObjectProperty, SemanticObjectState, SemanticPaint, SemanticStore,
+    SemanticVec3, StoredGeometry, StrokeCap, StrokeJoin, Style, TextResource, TextSourceKind,
+    TrackDefinition, TrackId, TrackTiming, TrackValues, Transform2D, Vec2,
 };
 use noon_runtime::{frame_object_conservative_bounds, SceneInstance};
 
@@ -113,7 +112,7 @@ fn canonical_text_and_geometry_share_timeline_updates_and_spatial_bounds() {
         (TrackId::new(1), circle_id, Vec2::new(-2.0, 6.0)),
     ] {
         compiled
-            .apply_patch(&ScenePatch::AddTrack(TrackDefinition {
+            .apply_execution_patch(&noon_compile::ExecutionPatch::AddTrack(TrackDefinition {
                 id: track,
                 object,
                 property: Property::Position,
@@ -156,42 +155,7 @@ fn canonical_text_and_geometry_share_timeline_updates_and_spatial_bounds() {
 }
 
 #[test]
-fn representative_legacy_and_semantic_authoring_lower_to_equivalent_runtime_observables() {
-    // Exercise the already-owned migration constructor rather than importing its
-    // underlying flat authored representation into this new canonical-path fixture.
-    let mut legacy_scene = SemanticScene::new();
-    let legacy_circle = legacy_scene.add(GeometryRef::circle(2.0));
-    {
-        let object = legacy_scene
-            .definition_mut()
-            .object_mut(legacy_circle)
-            .unwrap();
-        object.transform = Transform2D {
-            translation: Vec2::new(4.5, -3.25),
-            rotation: 0.75,
-            scale: Vec2::new(2.0, 0.5),
-        };
-        object.style = Style {
-            fill: Some(Color::rgba(0.2, 0.4, 0.6, 0.25)),
-            stroke: Some(Color::rgba(0.8, 0.1, 0.3, 0.5)),
-            stroke_width: 3.5,
-            stroke_join: StrokeJoin::Bevel,
-            stroke_cap: StrokeCap::Square,
-            opacity: 0.6,
-            ..Style::default()
-        };
-    }
-    let legacy_rectangle = legacy_scene.add(GeometryRef::rectangle(3.0, 1.5));
-    {
-        let object = legacy_scene
-            .definition_mut()
-            .object_mut(legacy_rectangle)
-            .unwrap();
-        object.transform.translation = Vec2::new(-1.0, 2.0);
-        object.style.stroke_width = 0.0;
-    }
-    let legacy_instance = SceneInstance::from_semantic(&legacy_scene).unwrap();
-
+fn canonical_lowering_preserves_painter_order_transform_and_paint() {
     let mut semantic_store = SemanticStore::new();
     let mut semantic_circle = SemanticObjectState::new(StoredGeometry::Circle { radius: 2.0 });
     semantic_circle.transform.translation = SemanticVec3::new(4.5, -3.25, 0.0);
@@ -220,19 +184,41 @@ fn representative_legacy_and_semantic_authoring_lower_to_equivalent_runtime_obse
     let lowered = lower_semantic_execution(&semantic_store, &mut index).unwrap();
     let semantic_instance = SceneInstance::from_semantic_execution(lowered);
 
-    assert_eq!(legacy_instance.frame().objects.len(), 2);
-    assert_eq!(semantic_instance.frame().objects.len(), 2);
-    for (legacy, semantic) in legacy_instance
-        .frame()
-        .objects
-        .iter()
-        .zip(&semantic_instance.frame().objects)
-    {
-        // Identity representations intentionally remain migration-specific; compare
-        // only the observable execution state and authored painter order.
-        assert_eq!(legacy.content, semantic.content);
-        assert_eq!(legacy.transform, semantic.transform);
-        assert_eq!(legacy.style, semantic.style);
-        assert_eq!(legacy.appearance, semantic.appearance);
-    }
+    let objects = &semantic_instance.frame().objects;
+    assert_eq!(objects.len(), 2);
+    assert_eq!(
+        objects[0].id,
+        index.execution_object_id(semantic_circle).unwrap()
+    );
+    assert_eq!(
+        objects[1].id,
+        index.execution_object_id(semantic_rectangle).unwrap()
+    );
+    assert_eq!(objects[0].geometry(), Some(&GeometryRef::circle(2.0)));
+    assert_eq!(
+        objects[1].geometry(),
+        Some(&GeometryRef::rectangle(3.0, 1.5))
+    );
+    assert_eq!(
+        objects[0].transform,
+        Transform2D {
+            translation: Vec2::new(4.5, -3.25),
+            rotation: 0.75,
+            scale: Vec2::new(2.0, 0.5),
+        }
+    );
+    assert_eq!(
+        objects[0].style,
+        Style {
+            fill: Some(Color::rgba(0.2, 0.4, 0.6, 0.25)),
+            stroke: Some(Color::rgba(0.8, 0.1, 0.3, 0.5)),
+            stroke_width: 3.5,
+            stroke_join: StrokeJoin::Bevel,
+            stroke_cap: StrokeCap::Square,
+            opacity: 0.6,
+            ..Style::default()
+        }
+    );
+    assert_eq!(objects[1].transform.translation, Vec2::new(-1.0, 2.0));
+    assert_eq!(objects[1].style.stroke_width, 0.0);
 }

--- a/scripts/architecture-ratchet.test.sh
+++ b/scripts/architecture-ratchet.test.sh
@@ -482,7 +482,7 @@ for canonical in crates/noon/src/semantic_mobject.rs crates/noon/src/scene.rs cr
 done
 # The unconsumed slotted runtime wrapper must stay deleted even if a regression
 # already exists at the comparison base.
-for symbol in SlottedSceneInstance FrameSlotId RetiredSlotCompactionPolicy ExecutionCompactionStats ExecutionCompactionError TimedSceneInstance TimedSceneRuntimeError TimedSemanticScene SignalTimelineDefinition SignalTrackDefinition SignalTimelineError; do
+for symbol in SlottedSceneInstance FrameSlotId RetiredSlotCompactionPolicy ExecutionCompactionStats ExecutionCompactionError TimedSceneInstance TimedSceneRuntimeError TimedSemanticScene SignalTimelineDefinition SignalTrackDefinition SignalTimelineError SemanticScene SceneBuildError; do
   printf 'pub struct %s;\n' "$symbol" > src/runtime_wrapper_probe.rs
   git add src/runtime_wrapper_probe.rs
   git commit -qm 'restore retired runtime wrapper'

--- a/scripts/architecture_migration_relocations.py
+++ b/scripts/architecture_migration_relocations.py
@@ -136,7 +136,7 @@ def main() -> int:
             errors.append(f'{path}: deleted reactive runtime symbol returned; use the canonical execution session')
         if not path.endswith('.rs'):
             continue
-        if re.search(r'\b(?:SlottedSceneInstance|FrameSlotId|RetiredSlotCompactionPolicy|ExecutionCompactionStats|ExecutionCompactionError|TimedSceneInstance|TimedSceneRuntimeError|TimedSemanticScene|SignalTimelineDefinition|SignalTrackDefinition|SignalTimelineError)\b', source):
+        if re.search(r'\b(?:SlottedSceneInstance|FrameSlotId|RetiredSlotCompactionPolicy|ExecutionCompactionStats|ExecutionCompactionError|TimedSceneInstance|TimedSceneRuntimeError|TimedSemanticScene|SignalTimelineDefinition|SignalTrackDefinition|SignalTimelineError|SemanticScene|SceneBuildError)\b', source):
             errors.append(f'{path}: retired runtime wrapper returned; use ExecutionSession and shared runtime slots')
         if re.search(r'\bFrontendMobjectHandle\b', source):
             errors.append(f'{path}: deleted FrontendMobjectHandle authority returned')


### PR DESCRIPTION
Removes the unused `noon-core::SemanticScene` wrapper and `SceneInstance::from_semantic` constructor. Runtime creation now consumes the shared semantic lowering handoff; reactive compilation uses the existing typed execution domain. Advances Phase A4 (#959, #953).

- Delete the legacy scene wrapper, `ReactiveProgram::compile(SceneDefinition, ...)`, and constructor-only `SceneBuildError`. No replacement adapter, scene builder, ID allocator, or migration seam.
- Move VM unit fixtures to explicit normalized graph/domain inputs. Preserve generated VM/reference agreement, type/driver/cycle rejection, atomic batch rollback and dirty propagation. Remove only the wrapper-equivalence test.
- Move runtime fixtures and the 10,000-branch integration proof to `SemanticStore` and `lower_semantic_execution`. Preserve 50,000-static-object locality, stale target rebind, scale/geometry independence, seek/reapply behavior, and callback-phase ownership. Explicitly enroll an unbound runtime input for the publication/no-dirtiness test because initial semantic lowering correctly prunes unused inputs.
- Replace the legacy-vs-current visual-state oracle with explicit expected painter order, geometry, transforms and paint. Its text/geometry timeline case now also uses `ExecutionPatch`.
- Extend the full-tree deletion guard and negative fixtures. Engine hot-path behavior is unchanged; local reactive work stays proportional to the affected closure and dense targets.

This removes an unused route, not new public semantics. Existing paired `ordinary_value_tracker_continuation` and `ordinary_mixed_scalar_composition` Rust/Python examples continue through the shared path; hosted product/parity checks qualify that path.

Validation performed locally:
- `cargo fmt --all`
- `bash scripts/check.sh architecture`
- `bash scripts/architecture-ratchet.test.sh`
- `cargo test -p noon-core --lib native_reactive` — 19 passed
- `cargo test -p noon-runtime --lib --tests` — 150 passed
- `cargo clippy -p noon-core -p noon-runtime --all-targets -- -D warnings`
- `cargo check -p noon --no-default-features --all-targets`
- `git diff --check`

Rust commands use `CARGO_TARGET_DIR=/tmp/noon-geometry-check CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0`. Full CI and the native/browser/product gates qualify the exact candidate before merge; heavy local WASM/full-workspace builds were not run.

Stacked on #1312; retarget to master once that prerequisite lands. Remaining #959 work is deletion of the underlying flat scene/patch codecs and migration of their remaining compiler/runtime fixtures.
