### PR TITLE
Remove legacy scene fixtures from the runtime crate

### DIFF
--- a/crates/noon-runtime/src/lib.rs
+++ b/crates/noon-runtime/src/lib.rs
@@ -2518,7 +2518,7 @@ mod tests {
     use noon_core::TrackId;
     use noon_core::{
         Color, CompositionTimeMap, CompositionTimeMapStep, Easing, GeometryRef, Property,
-        RateFunction, SceneDefinition, Style, TrackDefinition, TrackTiming,
+        RateFunction, Style, TrackDefinition, TrackTiming,
     };
     use noon_core::{
         FamilyAnimationMode, FamilyAnimationSpec, RetainedAnimationMembers,
@@ -2528,17 +2528,27 @@ mod tests {
     use super::*;
 
     fn compile_linear_scene() -> CompiledScene {
-        let mut scene = SceneDefinition::new();
-        let object = scene.add(GeometryRef::circle(1.0));
-        scene
-            .animate_position(
-                object,
-                Vec2::ZERO,
-                Vec2::new(10.0, 0.0),
-                TrackTiming::new(1.0, 2.0, Easing::Linear),
-            )
-            .expect("valid track");
-        CompiledScene::compile(&scene).expect("scene must compile")
+        let mut objects = Vec::new();
+        let mut tracks = Vec::new();
+        let object = ObjectId::new(objects.len() as u64);
+        objects.push(CompiledObject::new(
+            object,
+            GeometryRef::circle(1.0),
+            Transform2D::IDENTITY,
+            Style::default(),
+        ));
+        tracks.push(TrackDefinition {
+            id: TrackId::new(tracks.len() as u64),
+            object,
+            property: Property::Position,
+            values: TrackValues::Vec2 {
+                from: Vec2::ZERO,
+                to: Vec2::new(10.0, 0.0),
+            },
+            timing: TrackTiming::new(1.0, 2.0, Easing::Linear),
+            time_map: CompositionTimeMap::identity(),
+        });
+        CompiledScene::compile_objects(objects, &tracks).expect("scene must compile")
     }
 
     #[test]
@@ -2699,18 +2709,29 @@ mod tests {
 
     #[test]
     fn scale_timeline_endpoints_and_midpoint_are_exact() {
-        let mut scene = SceneDefinition::new();
-        let object = scene.add(GeometryRef::circle(1.0));
-        scene
-            .animate_scale(
-                object,
-                Vec2::ONE,
-                Vec2::new(3.0, 2.0),
-                TrackTiming::new(1.0, 2.0, Easing::Linear),
-            )
-            .expect("valid scale track");
-        let mut instance =
-            SceneInstance::new(CompiledScene::compile(&scene).expect("scene must compile"));
+        let mut objects = Vec::new();
+        let mut tracks = Vec::new();
+        let object = ObjectId::new(objects.len() as u64);
+        objects.push(CompiledObject::new(
+            object,
+            GeometryRef::circle(1.0),
+            Transform2D::IDENTITY,
+            Style::default(),
+        ));
+        tracks.push(TrackDefinition {
+            id: TrackId::new(tracks.len() as u64),
+            object,
+            property: Property::Scale,
+            values: TrackValues::Vec2 {
+                from: Vec2::ONE,
+                to: Vec2::new(3.0, 2.0),
+            },
+            timing: TrackTiming::new(1.0, 2.0, Easing::Linear),
+            time_map: CompositionTimeMap::identity(),
+        });
+        let mut instance = SceneInstance::new(
+            CompiledScene::compile_objects(objects, &tracks).expect("scene must compile"),
+        );
         assert_eq!(
             instance.seek(1.0).expect("valid time").objects[0]
                 .transform
@@ -2733,18 +2754,29 @@ mod tests {
 
     #[test]
     fn manim_smooth_rate_function_is_evaluated_by_runtime() {
-        let mut scene = SceneDefinition::new();
-        let object = scene.add(GeometryRef::circle(1.0));
-        scene
-            .animate_position(
-                object,
-                Vec2::ZERO,
-                Vec2::new(10.0, 0.0),
-                TrackTiming::new(0.0, 2.0, RateFunction::Smooth),
-            )
-            .expect("valid track");
-        let mut instance =
-            SceneInstance::new(CompiledScene::compile(&scene).expect("scene must compile"));
+        let mut objects = Vec::new();
+        let mut tracks = Vec::new();
+        let object = ObjectId::new(objects.len() as u64);
+        objects.push(CompiledObject::new(
+            object,
+            GeometryRef::circle(1.0),
+            Transform2D::IDENTITY,
+            Style::default(),
+        ));
+        tracks.push(TrackDefinition {
+            id: TrackId::new(tracks.len() as u64),
+            object,
+            property: Property::Position,
+            values: TrackValues::Vec2 {
+                from: Vec2::ZERO,
+                to: Vec2::new(10.0, 0.0),
+            },
+            timing: TrackTiming::new(0.0, 2.0, RateFunction::Smooth),
+            time_map: CompositionTimeMap::identity(),
+        });
+        let mut instance = SceneInstance::new(
+            CompiledScene::compile_objects(objects, &tracks).expect("scene must compile"),
+        );
         let quarter = instance.seek(0.5).expect("valid time").objects[0]
             .transform
             .translation
@@ -2761,26 +2793,33 @@ mod tests {
 
     #[test]
     fn nonlinear_composition_time_map_is_evaluated_before_leaf_rate() {
-        let mut scene = SceneDefinition::new();
-        let object = scene.add(GeometryRef::circle(1.0));
-        scene
-            .add_track_with_time_map(
-                object,
-                Property::Position,
-                TrackValues::Vec2 {
-                    from: Vec2::ZERO,
-                    to: Vec2::new(10.0, 0.0),
-                },
-                TrackTiming::new(0.0, 2.0, RateFunction::Linear),
-                CompositionTimeMap::from_steps(vec![CompositionTimeMapStep::new(
-                    0.0,
-                    1.0,
-                    RateFunction::Smooth,
-                )]),
-            )
-            .unwrap();
-        let mut instance =
-            SceneInstance::new(CompiledScene::compile(&scene).expect("scene must compile"));
+        let mut objects = Vec::new();
+        let mut tracks = Vec::new();
+        let object = ObjectId::new(objects.len() as u64);
+        objects.push(CompiledObject::new(
+            object,
+            GeometryRef::circle(1.0),
+            Transform2D::IDENTITY,
+            Style::default(),
+        ));
+        tracks.push(TrackDefinition {
+            id: TrackId::new(tracks.len() as u64),
+            object,
+            property: Property::Position,
+            values: TrackValues::Vec2 {
+                from: Vec2::ZERO,
+                to: Vec2::new(10.0, 0.0),
+            },
+            timing: TrackTiming::new(0.0, 2.0, RateFunction::Linear),
+            time_map: CompositionTimeMap::from_steps(vec![CompositionTimeMapStep::new(
+                0.0,
+                1.0,
+                RateFunction::Smooth,
+            )]),
+        });
+        let mut instance = SceneInstance::new(
+            CompiledScene::compile_objects(objects, &tracks).expect("scene must compile"),
+        );
         let quarter = instance.seek(0.5).unwrap().objects[0]
             .transform
             .translation
@@ -2790,28 +2829,35 @@ mod tests {
 
     #[test]
     fn mapped_succession_selects_latest_virtual_child() {
-        let mut scene = SceneDefinition::new();
-        let object = scene.add(GeometryRef::circle(1.0));
+        let mut objects = Vec::new();
+        let mut tracks = Vec::new();
+        let object = ObjectId::new(objects.len() as u64);
+        objects.push(CompiledObject::new(
+            object,
+            GeometryRef::circle(1.0),
+            Transform2D::IDENTITY,
+            Style::default(),
+        ));
         for (from, to, start) in [(0.0, 10.0, 0.0), (10.0, 20.0, 0.5)] {
-            scene
-                .add_track_with_time_map(
-                    object,
-                    Property::Position,
-                    TrackValues::Vec2 {
-                        from: Vec2::new(from, 0.0),
-                        to: Vec2::new(to, 0.0),
-                    },
-                    TrackTiming::new(0.0, 2.0, RateFunction::Linear),
-                    CompositionTimeMap::from_steps(vec![CompositionTimeMapStep::new(
-                        start,
-                        0.5,
-                        RateFunction::Linear,
-                    )]),
-                )
-                .unwrap();
+            tracks.push(TrackDefinition {
+                id: TrackId::new(tracks.len() as u64),
+                object,
+                property: Property::Position,
+                values: TrackValues::Vec2 {
+                    from: Vec2::new(from, 0.0),
+                    to: Vec2::new(to, 0.0),
+                },
+                timing: TrackTiming::new(0.0, 2.0, RateFunction::Linear),
+                time_map: CompositionTimeMap::from_steps(vec![CompositionTimeMapStep::new(
+                    start,
+                    0.5,
+                    RateFunction::Linear,
+                )]),
+            });
         }
-        let mut instance =
-            SceneInstance::new(CompiledScene::compile(&scene).expect("scene must compile"));
+        let mut instance = SceneInstance::new(
+            CompiledScene::compile_objects(objects, &tracks).expect("scene must compile"),
+        );
         assert_eq!(
             instance.seek(0.5).unwrap().objects[0]
                 .transform
@@ -2837,28 +2883,35 @@ mod tests {
 
     #[test]
     fn reversing_composition_reopens_earlier_child_then_settles_at_finish() {
-        let mut scene = SceneDefinition::new();
-        let object = scene.add(GeometryRef::circle(1.0));
+        let mut objects = Vec::new();
+        let mut tracks = Vec::new();
+        let object = ObjectId::new(objects.len() as u64);
+        objects.push(CompiledObject::new(
+            object,
+            GeometryRef::circle(1.0),
+            Transform2D::IDENTITY,
+            Style::default(),
+        ));
         for (from, to, start) in [(0.0, 10.0, 0.0), (10.0, 20.0, 0.5)] {
-            scene
-                .add_track_with_time_map(
-                    object,
-                    Property::Position,
-                    TrackValues::Vec2 {
-                        from: Vec2::new(from, 0.0),
-                        to: Vec2::new(to, 0.0),
-                    },
-                    TrackTiming::new(0.0, 2.0, RateFunction::Linear),
-                    CompositionTimeMap::from_steps(vec![CompositionTimeMapStep::new(
-                        start,
-                        0.5,
-                        RateFunction::ThereAndBack,
-                    )]),
-                )
-                .unwrap();
+            tracks.push(TrackDefinition {
+                id: TrackId::new(tracks.len() as u64),
+                object,
+                property: Property::Position,
+                values: TrackValues::Vec2 {
+                    from: Vec2::new(from, 0.0),
+                    to: Vec2::new(to, 0.0),
+                },
+                timing: TrackTiming::new(0.0, 2.0, RateFunction::Linear),
+                time_map: CompositionTimeMap::from_steps(vec![CompositionTimeMapStep::new(
+                    start,
+                    0.5,
+                    RateFunction::ThereAndBack,
+                )]),
+            });
         }
-        let mut instance =
-            SceneInstance::new(CompiledScene::compile(&scene).expect("scene must compile"));
+        let mut instance = SceneInstance::new(
+            CompiledScene::compile_objects(objects, &tracks).expect("scene must compile"),
+        );
         assert_eq!(
             instance.seek(1.0).unwrap().objects[0]
                 .transform
@@ -2882,15 +2935,39 @@ mod tests {
 
     #[test]
     fn presence_events_are_discrete_and_direct_seek_matches_forward_playback() {
-        let mut scene = SceneDefinition::new();
-        let object = scene.add(GeometryRef::circle(1.0));
-        scene
-            .set_presence_at(object, false, true, 1.0)
-            .expect("valid create event");
-        scene
-            .set_presence_at(object, true, false, 3.0)
-            .expect("valid remove event");
-        let compiled = CompiledScene::compile(&scene).expect("scene must compile");
+        let mut objects = Vec::new();
+        let mut tracks = Vec::new();
+        let object = ObjectId::new(objects.len() as u64);
+        objects.push(CompiledObject::new(
+            object,
+            GeometryRef::circle(1.0),
+            Transform2D::IDENTITY,
+            Style::default(),
+        ));
+        tracks.push(TrackDefinition {
+            id: TrackId::new(tracks.len() as u64),
+            object,
+            property: Property::Presence,
+            values: TrackValues::Bool {
+                from: false,
+                to: true,
+            },
+            timing: TrackTiming::instant(1.0),
+            time_map: CompositionTimeMap::identity(),
+        });
+        tracks.push(TrackDefinition {
+            id: TrackId::new(tracks.len() as u64),
+            object,
+            property: Property::Presence,
+            values: TrackValues::Bool {
+                from: true,
+                to: false,
+            },
+            timing: TrackTiming::instant(3.0),
+            time_map: CompositionTimeMap::identity(),
+        });
+        let compiled =
+            CompiledScene::compile_objects(objects, &tracks).expect("scene must compile");
         let mut sequential = SceneInstance::new(compiled.clone());
         let mut direct = SceneInstance::new(compiled);
         assert!(!sequential.frame().is_present(0));
@@ -2960,17 +3037,30 @@ mod tests {
 
     #[test]
     fn reveal_endpoints_midpoint_and_prestart_state_are_deterministic() {
-        let mut scene = SceneDefinition::new();
-        let object = scene.add(GeometryRef::path(
-            noon_core::VectorPath::new()
-                .move_to(Vec2::ZERO)
-                .line_to(Vec2::new(3.0, 4.0)),
+        let mut objects = Vec::new();
+        let mut tracks = Vec::new();
+        let object = ObjectId::new(objects.len() as u64);
+        objects.push(CompiledObject::new(
+            object,
+            GeometryRef::path(
+                noon_core::VectorPath::new()
+                    .move_to(Vec2::ZERO)
+                    .line_to(Vec2::new(3.0, 4.0)),
+            ),
+            Transform2D::IDENTITY,
+            Style::default(),
         ));
-        scene
-            .animate_reveal(object, 0.0, 1.0, TrackTiming::new(1.0, 2.0, Easing::Linear))
-            .expect("valid reveal track");
-        let mut instance =
-            SceneInstance::new(CompiledScene::compile(&scene).expect("scene must compile"));
+        tracks.push(TrackDefinition {
+            id: TrackId::new(tracks.len() as u64),
+            object,
+            property: Property::Reveal,
+            values: TrackValues::Scalar { from: 0.0, to: 1.0 },
+            timing: TrackTiming::new(1.0, 2.0, Easing::Linear),
+            time_map: CompositionTimeMap::identity(),
+        });
+        let mut instance = SceneInstance::new(
+            CompiledScene::compile_objects(objects, &tracks).expect("scene must compile"),
+        );
         assert_eq!(instance.seek(0.0).expect("valid time").reveal(0), 0.0);
         assert_eq!(instance.seek(1.0).expect("valid time").reveal(0), 0.0);
         assert_eq!(instance.seek(2.0).expect("valid time").reveal(0), 0.5);
@@ -2979,18 +3069,27 @@ mod tests {
 
     #[test]
     fn appearance_and_semantic_opacity_are_independent() {
-        let mut scene = SceneDefinition::new();
-        let object = scene.add(GeometryRef::circle(1.0));
-        scene
-            .object_mut(object)
-            .expect("object exists")
-            .style
-            .opacity = 0.4;
-        scene
-            .animate_appearance(object, 1.0, 0.0, TrackTiming::new(0.0, 2.0, Easing::Linear))
-            .expect("valid appearance track");
-        let mut instance =
-            SceneInstance::new(CompiledScene::compile(&scene).expect("scene must compile"));
+        let mut objects = Vec::new();
+        let mut tracks = Vec::new();
+        let object = ObjectId::new(objects.len() as u64);
+        objects.push(CompiledObject::new(
+            object,
+            GeometryRef::circle(1.0),
+            Transform2D::IDENTITY,
+            Style::default(),
+        ));
+        objects[object.get() as usize].base_style.opacity = 0.4;
+        tracks.push(TrackDefinition {
+            id: TrackId::new(tracks.len() as u64),
+            object,
+            property: Property::Appearance,
+            values: TrackValues::Scalar { from: 1.0, to: 0.0 },
+            timing: TrackTiming::new(0.0, 2.0, Easing::Linear),
+            time_map: CompositionTimeMap::identity(),
+        });
+        let mut instance = SceneInstance::new(
+            CompiledScene::compile_objects(objects, &tracks).expect("scene must compile"),
+        );
         let frame = instance.seek(1.0).expect("valid time");
         assert_eq!(frame.objects[0].style.opacity, 0.4);
         assert_eq!(frame.appearance(0), 0.5);
@@ -3004,16 +3103,34 @@ mod tests {
         let target = noon_core::VectorPath::new()
             .move_to(Vec2::new(0.0, -1.0))
             .line_to(Vec2::new(0.0, 1.0));
-        let mut scene = SceneDefinition::new();
-        let object = scene.add(GeometryRef::path(source.with_morph_target(target)));
-        scene
-            .animate_reveal(object, 0.0, 1.0, TrackTiming::new(0.0, 2.0, Easing::Linear))
-            .expect("valid reveal track");
-        scene
-            .animate_morph(object, 0.0, 1.0, TrackTiming::new(0.0, 4.0, Easing::Linear))
-            .expect("valid morph track");
-        let mut instance =
-            SceneInstance::new(CompiledScene::compile(&scene).expect("scene must compile"));
+        let mut objects = Vec::new();
+        let mut tracks = Vec::new();
+        let object = ObjectId::new(objects.len() as u64);
+        objects.push(CompiledObject::new(
+            object,
+            GeometryRef::path(source.with_morph_target(target)),
+            Transform2D::IDENTITY,
+            Style::default(),
+        ));
+        tracks.push(TrackDefinition {
+            id: TrackId::new(tracks.len() as u64),
+            object,
+            property: Property::Reveal,
+            values: TrackValues::Scalar { from: 0.0, to: 1.0 },
+            timing: TrackTiming::new(0.0, 2.0, Easing::Linear),
+            time_map: CompositionTimeMap::identity(),
+        });
+        tracks.push(TrackDefinition {
+            id: TrackId::new(tracks.len() as u64),
+            object,
+            property: Property::Morph,
+            values: TrackValues::Scalar { from: 0.0, to: 1.0 },
+            timing: TrackTiming::new(0.0, 4.0, Easing::Linear),
+            time_map: CompositionTimeMap::identity(),
+        });
+        let mut instance = SceneInstance::new(
+            CompiledScene::compile_objects(objects, &tracks).expect("scene must compile"),
+        );
         let frame = instance.seek(1.0).expect("valid time");
         assert_eq!(frame.reveal(0), 0.5);
         assert_eq!(frame.morph(0), 0.25);
@@ -3097,21 +3214,32 @@ mod tests {
 
     #[test]
     fn completed_history_is_not_rescanned_during_forward_steps() {
-        let mut scene = SceneDefinition::new();
-        let object = scene.add(GeometryRef::circle(1.0));
+        let mut objects = Vec::new();
+        let mut tracks = Vec::new();
+        let object = ObjectId::new(objects.len() as u64);
+        objects.push(CompiledObject::new(
+            object,
+            GeometryRef::circle(1.0),
+            Transform2D::IDENTITY,
+            Style::default(),
+        ));
         for index in 0..1_000 {
             let start = f64::from(index);
             let from = index as f32;
-            scene
-                .animate_position(
-                    object,
-                    Vec2::new(from, 0.0),
-                    Vec2::new(from + 1.0, 0.0),
-                    TrackTiming::new(start, 0.5, Easing::Linear),
-                )
-                .expect("valid track");
+            tracks.push(TrackDefinition {
+                id: TrackId::new(tracks.len() as u64),
+                object,
+                property: Property::Position,
+                values: TrackValues::Vec2 {
+                    from: Vec2::new(from, 0.0),
+                    to: Vec2::new(from + 1.0, 0.0),
+                },
+                timing: TrackTiming::new(start, 0.5, Easing::Linear),
+                time_map: CompositionTimeMap::identity(),
+            });
         }
-        let compiled = CompiledScene::compile(&scene).expect("scene must compile");
+        let compiled =
+            CompiledScene::compile_objects(objects, &tracks).expect("scene must compile");
         let mut instance = SceneInstance::new(compiled);
         instance.seek(999.25).expect("valid time");
         assert!(instance.last_stats().binary_search_steps < 20);
@@ -3123,18 +3251,25 @@ mod tests {
 
     #[test]
     fn scalar_properties_are_evaluated_without_renderer_state() {
-        let mut scene = SceneDefinition::new();
-        let object = scene.add(GeometryRef::circle(1.0));
-        scene
-            .animate_scalar(
-                object,
-                Property::Opacity,
-                1.0,
-                0.0,
-                TrackTiming::new(0.0, 2.0, Easing::Linear),
-            )
-            .expect("valid track");
-        let compiled = CompiledScene::compile(&scene).expect("scene must compile");
+        let mut objects = Vec::new();
+        let mut tracks = Vec::new();
+        let object = ObjectId::new(objects.len() as u64);
+        objects.push(CompiledObject::new(
+            object,
+            GeometryRef::circle(1.0),
+            Transform2D::IDENTITY,
+            Style::default(),
+        ));
+        tracks.push(TrackDefinition {
+            id: TrackId::new(tracks.len() as u64),
+            object,
+            property: Property::Opacity,
+            values: TrackValues::Scalar { from: 1.0, to: 0.0 },
+            timing: TrackTiming::new(0.0, 2.0, Easing::Linear),
+            time_map: CompositionTimeMap::identity(),
+        });
+        let compiled =
+            CompiledScene::compile_objects(objects, &tracks).expect("scene must compile");
         let mut instance = SceneInstance::new(compiled);
         let opacity = instance.seek(1.0).expect("valid time").objects[0]
             .style
@@ -3245,18 +3380,26 @@ mod tests {
 
     #[test]
     fn removing_track_restores_base_property_at_current_time() {
-        let mut definition = SceneDefinition::new();
-        let object = definition.add(GeometryRef::circle(1.0));
-        let track_id = definition
-            .animate_scalar(
-                object,
-                Property::Opacity,
-                1.0,
-                0.0,
-                TrackTiming::new(0.0, 2.0, Easing::Linear),
-            )
-            .expect("valid track");
-        let compiled = CompiledScene::compile(&definition).expect("scene must compile");
+        let mut objects = Vec::new();
+        let mut tracks = Vec::new();
+        let object = ObjectId::new(objects.len() as u64);
+        objects.push(CompiledObject::new(
+            object,
+            GeometryRef::circle(1.0),
+            Transform2D::IDENTITY,
+            Style::default(),
+        ));
+        let track_id = TrackId::new(tracks.len() as u64);
+        tracks.push(TrackDefinition {
+            id: TrackId::new(tracks.len() as u64),
+            object,
+            property: Property::Opacity,
+            values: TrackValues::Scalar { from: 1.0, to: 0.0 },
+            timing: TrackTiming::new(0.0, 2.0, Easing::Linear),
+            time_map: CompositionTimeMap::identity(),
+        });
+        let compiled =
+            CompiledScene::compile_objects(objects, &tracks).expect("scene must compile");
         let mut instance = SceneInstance::new(compiled);
         instance.seek(1.0).expect("valid time");
         assert_eq!(instance.frame().objects[0].style.opacity, 0.5);
@@ -3427,19 +3570,26 @@ mod tests {
 
     #[test]
     fn value_patch_updates_base_fields_without_overwriting_animated_values() {
-        let mut definition = SceneDefinition::new();
-        let object = definition.add(GeometryRef::circle(1.0));
-        definition
-            .animate_scalar(
-                object,
-                Property::Opacity,
-                1.0,
-                0.0,
-                TrackTiming::new(0.0, 2.0, Easing::Linear),
-            )
-            .expect("valid track");
-        let mut instance =
-            SceneInstance::new(CompiledScene::compile(&definition).expect("scene must compile"));
+        let mut objects = Vec::new();
+        let mut tracks = Vec::new();
+        let object = ObjectId::new(objects.len() as u64);
+        objects.push(CompiledObject::new(
+            object,
+            GeometryRef::circle(1.0),
+            Transform2D::IDENTITY,
+            Style::default(),
+        ));
+        tracks.push(TrackDefinition {
+            id: TrackId::new(tracks.len() as u64),
+            object,
+            property: Property::Opacity,
+            values: TrackValues::Scalar { from: 1.0, to: 0.0 },
+            timing: TrackTiming::new(0.0, 2.0, Easing::Linear),
+            time_map: CompositionTimeMap::identity(),
+        });
+        let mut instance = SceneInstance::new(
+            CompiledScene::compile_objects(objects, &tracks).expect("scene must compile"),
+        );
         instance.seek(1.0).expect("valid time");
         instance
             .apply_execution_patch(&ExecutionPatch::SetStyle {
@@ -3463,10 +3613,18 @@ mod tests {
 
     #[test]
     fn frame_changes_are_consumed_and_static_steps_stay_clean() {
-        let mut scene = SceneDefinition::new();
-        scene.add(GeometryRef::circle(1.0));
-        let mut instance =
-            SceneInstance::new(CompiledScene::compile(&scene).expect("scene must compile"));
+        let mut objects = Vec::new();
+        let tracks = Vec::new();
+        let _object = ObjectId::new(objects.len() as u64);
+        objects.push(CompiledObject::new(
+            _object,
+            GeometryRef::circle(1.0),
+            Transform2D::IDENTITY,
+            Style::default(),
+        ));
+        let mut instance = SceneInstance::new(
+            CompiledScene::compile_objects(objects, &tracks).expect("scene must compile"),
+        );
         assert!(instance.take_frame_changes().is_all());
         instance.advance_to(0.5).expect("valid time");
         assert!(instance.take_frame_changes().is_empty());
@@ -3474,19 +3632,36 @@ mod tests {
 
     #[test]
     fn frame_changes_accumulate_animation_and_patches_until_consumed() {
-        let mut scene = SceneDefinition::new();
-        let animated = scene.add(GeometryRef::circle(1.0));
-        let patched = scene.add(GeometryRef::rectangle(2.0, 1.0));
-        scene
-            .animate_position(
-                animated,
-                Vec2::ZERO,
-                Vec2::new(10.0, 0.0),
-                TrackTiming::new(0.0, 2.0, Easing::Linear),
-            )
-            .expect("valid track");
-        let mut instance =
-            SceneInstance::new(CompiledScene::compile(&scene).expect("scene must compile"));
+        let mut objects = Vec::new();
+        let mut tracks = Vec::new();
+        let animated = ObjectId::new(objects.len() as u64);
+        objects.push(CompiledObject::new(
+            animated,
+            GeometryRef::circle(1.0),
+            Transform2D::IDENTITY,
+            Style::default(),
+        ));
+        let patched = ObjectId::new(objects.len() as u64);
+        objects.push(CompiledObject::new(
+            patched,
+            GeometryRef::rectangle(2.0, 1.0),
+            Transform2D::IDENTITY,
+            Style::default(),
+        ));
+        tracks.push(TrackDefinition {
+            id: TrackId::new(tracks.len() as u64),
+            object: animated,
+            property: Property::Position,
+            values: TrackValues::Vec2 {
+                from: Vec2::ZERO,
+                to: Vec2::new(10.0, 0.0),
+            },
+            timing: TrackTiming::new(0.0, 2.0, Easing::Linear),
+            time_map: CompositionTimeMap::identity(),
+        });
+        let mut instance = SceneInstance::new(
+            CompiledScene::compile_objects(objects, &tracks).expect("scene must compile"),
+        );
         instance.take_frame_changes();
         instance.advance_to(0.5).expect("valid time");
         instance

--- a/crates/noon-runtime/tests/analytic_transform.rs
+++ b/crates/noon-runtime/tests/analytic_transform.rs
@@ -1,20 +1,21 @@
-use noon_compile::CompiledScene;
+use noon_compile::{CompiledObject, CompiledScene};
 use noon_core::{
-    Color, Easing, GeometryRef, ObjectSnapshot, SceneDefinition, Style, TrackTiming, Transform2D,
-    Vec2,
+    Color, CompositionTimeMap, Easing, GeometryRef, ObjectId, Property, Style, TrackDefinition,
+    TrackId, TrackTiming, TrackValues, Transform2D, TransformTrackEndpoint, Vec2,
 };
 use noon_runtime::SceneInstance;
 
-fn snapshot(geometry: GeometryRef, transform: Transform2D, style: Style) -> ObjectSnapshot {
-    ObjectSnapshot {
+fn snapshot(geometry: GeometryRef, transform: Transform2D, style: Style) -> TransformTrackEndpoint {
+    TransformTrackEndpoint {
         geometry,
         transform,
         style,
     }
 }
 
-fn build_scene() -> SceneDefinition {
-    let mut scene = SceneDefinition::new();
+fn build_scene() -> CompiledScene {
+    let mut objects = Vec::new();
+    let mut tracks = Vec::new();
     let style_a = Style {
         fill: Some(Color::rgb(0.2, 0.3, 0.4)),
         stroke: None,
@@ -38,58 +39,85 @@ fn build_scene() -> SceneDefinition {
         scale: Vec2::new(2.0, 0.5),
     };
 
-    let circle = scene.add(GeometryRef::circle(1.0));
-    scene.object_mut(circle).unwrap().style = style_a;
-    scene
-        .animate_transform(
-            circle,
-            snapshot(GeometryRef::circle(1.0), transform_a, style_a),
-            snapshot(GeometryRef::circle(3.0), transform_b, style_b),
-            TrackTiming::new(0.0, 2.0, Easing::Linear),
-        )
-        .unwrap();
+    let circle = ObjectId::new(objects.len() as u64);
+    objects.push(CompiledObject::new(
+        circle,
+        GeometryRef::circle(1.0),
+        Transform2D::IDENTITY,
+        Style::default(),
+    ));
+    objects[circle.get() as usize].base_style = style_a;
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object: circle,
+        property: Property::Transform,
+        values: TrackValues::Object {
+            from: snapshot(GeometryRef::circle(1.0), transform_a, style_a),
+            to: snapshot(GeometryRef::circle(3.0), transform_b, style_b),
+        },
+        timing: TrackTiming::new(0.0, 2.0, Easing::Linear),
+        time_map: CompositionTimeMap::identity(),
+    });
 
-    let rectangle = scene.add(GeometryRef::rectangle(2.0, 4.0));
-    scene
-        .animate_transform(
-            rectangle,
-            snapshot(
+    let rectangle = ObjectId::new(objects.len() as u64);
+    objects.push(CompiledObject::new(
+        rectangle,
+        GeometryRef::rectangle(2.0, 4.0),
+        Transform2D::IDENTITY,
+        Style::default(),
+    ));
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object: rectangle,
+        property: Property::Transform,
+        values: TrackValues::Object {
+            from: snapshot(
                 GeometryRef::rectangle(2.0, 4.0),
                 Transform2D::IDENTITY,
                 Style::default(),
             ),
-            snapshot(
+            to: snapshot(
                 GeometryRef::rectangle(6.0, 8.0),
                 Transform2D::IDENTITY,
                 Style::default(),
             ),
-            TrackTiming::new(0.0, 2.0, Easing::Linear),
-        )
-        .unwrap();
+        },
+        timing: TrackTiming::new(0.0, 2.0, Easing::Linear),
+        time_map: CompositionTimeMap::identity(),
+    });
 
-    let line = scene.add(GeometryRef::line(Vec2::new(-1.0, 0.0), Vec2::new(1.0, 0.0)));
-    scene
-        .animate_transform(
-            line,
-            snapshot(
+    let line = ObjectId::new(objects.len() as u64);
+    objects.push(CompiledObject::new(
+        line,
+        GeometryRef::line(Vec2::new(-1.0, 0.0), Vec2::new(1.0, 0.0)),
+        Transform2D::IDENTITY,
+        Style::default(),
+    ));
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object: line,
+        property: Property::Transform,
+        values: TrackValues::Object {
+            from: snapshot(
                 GeometryRef::line(Vec2::new(-1.0, 0.0), Vec2::new(1.0, 0.0)),
                 Transform2D::IDENTITY,
                 Style::default(),
             ),
-            snapshot(
+            to: snapshot(
                 GeometryRef::line(Vec2::new(0.0, -2.0), Vec2::new(0.0, 2.0)),
                 Transform2D::IDENTITY,
                 Style::default(),
             ),
-            TrackTiming::new(0.0, 2.0, Easing::Linear),
-        )
-        .unwrap();
-    scene
+        },
+        timing: TrackTiming::new(0.0, 2.0, Easing::Linear),
+        time_map: CompositionTimeMap::identity(),
+    });
+    CompiledScene::compile_objects(objects, &tracks).unwrap()
 }
 
 #[test]
 fn analytic_transform_has_exact_endpoints_and_midpoints() {
-    let mut instance = SceneInstance::new(CompiledScene::compile(&build_scene()).unwrap());
+    let mut instance = SceneInstance::new(build_scene());
     let frame = instance.seek(1.0).unwrap();
 
     assert_eq!(frame.objects[0].geometry(), Some(&GeometryRef::circle(2.0)));
@@ -129,7 +157,7 @@ fn analytic_transform_has_exact_endpoints_and_midpoints() {
 
 #[test]
 fn direct_seek_and_forward_playback_match_for_analytic_transform() {
-    let compiled = CompiledScene::compile(&build_scene()).unwrap();
+    let compiled = build_scene();
     let mut sequential = SceneInstance::new(compiled.clone());
     let mut direct = SceneInstance::new(compiled);
     for step in 1..=13 {
@@ -141,27 +169,41 @@ fn direct_seek_and_forward_playback_match_for_analytic_transform() {
 
 #[test]
 fn sequential_circle_transforms_are_continuous_at_boundary() {
-    let mut scene = SceneDefinition::new();
-    let object = scene.add(GeometryRef::circle(1.0));
+    let mut objects = Vec::new();
+    let mut tracks = Vec::new();
+    let object = ObjectId::new(objects.len() as u64);
+    objects.push(CompiledObject::new(
+        object,
+        GeometryRef::circle(1.0),
+        Transform2D::IDENTITY,
+        Style::default(),
+    ));
     let style = Style::default();
-    scene
-        .animate_transform(
-            object,
-            snapshot(GeometryRef::circle(1.0), Transform2D::IDENTITY, style),
-            snapshot(GeometryRef::circle(3.0), Transform2D::IDENTITY, style),
-            TrackTiming::new(0.0, 1.0, Easing::Linear),
-        )
-        .unwrap();
-    scene
-        .animate_transform(
-            object,
-            snapshot(GeometryRef::circle(3.0), Transform2D::IDENTITY, style),
-            snapshot(GeometryRef::circle(5.0), Transform2D::IDENTITY, style),
-            TrackTiming::new(1.0, 1.0, Easing::Linear),
-        )
-        .unwrap();
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object,
+        property: Property::Transform,
+        values: TrackValues::Object {
+            from: snapshot(GeometryRef::circle(1.0), Transform2D::IDENTITY, style),
+            to: snapshot(GeometryRef::circle(3.0), Transform2D::IDENTITY, style),
+        },
+        timing: TrackTiming::new(0.0, 1.0, Easing::Linear),
+        time_map: CompositionTimeMap::identity(),
+    });
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object,
+        property: Property::Transform,
+        values: TrackValues::Object {
+            from: snapshot(GeometryRef::circle(3.0), Transform2D::IDENTITY, style),
+            to: snapshot(GeometryRef::circle(5.0), Transform2D::IDENTITY, style),
+        },
+        timing: TrackTiming::new(1.0, 1.0, Easing::Linear),
+        time_map: CompositionTimeMap::identity(),
+    });
 
-    let mut instance = SceneInstance::new(CompiledScene::compile(&scene).unwrap());
+    let mut instance =
+        SceneInstance::new(CompiledScene::compile_objects(objects, &tracks).unwrap());
     assert_eq!(
         instance.seek(1.0).unwrap().objects[0].geometry(),
         Some(&GeometryRef::circle(3.0))

--- a/crates/noon-runtime/tests/appearance.rs
+++ b/crates/noon-runtime/tests/appearance.rs
@@ -1,25 +1,30 @@
-use noon_compile::CompiledScene;
-use noon_core::{Easing, GeometryRef, Property, SceneDefinition, TrackTiming};
+use noon_compile::{CompiledObject, CompiledScene};
+use noon_core::{
+    CompositionTimeMap, Easing, GeometryRef, ObjectId, Property, Style, TrackDefinition, TrackId,
+    TrackTiming, TrackValues, Transform2D,
+};
 use noon_runtime::SceneInstance;
 
 fn appearance_scene() -> CompiledScene {
-    let mut scene = SceneDefinition::new();
-    let object = scene.add(GeometryRef::circle(1.0));
-    scene
-        .object_mut(object)
-        .expect("object exists")
-        .style
-        .opacity = 0.4;
-    scene
-        .animate_scalar(
-            object,
-            Property::Appearance,
-            1.0,
-            0.0,
-            TrackTiming::new(0.0, 2.0, Easing::Linear),
-        )
-        .expect("appearance track is valid");
-    CompiledScene::compile(&scene).expect("appearance scene compiles")
+    let mut objects = Vec::new();
+    let mut tracks = Vec::new();
+    let object = ObjectId::new(objects.len() as u64);
+    objects.push(CompiledObject::new(
+        object,
+        GeometryRef::circle(1.0),
+        Transform2D::IDENTITY,
+        Style::default(),
+    ));
+    objects[object.get() as usize].base_style.opacity = 0.4;
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object,
+        property: Property::Appearance,
+        values: TrackValues::Scalar { from: 1.0, to: 0.0 },
+        timing: TrackTiming::new(0.0, 2.0, Easing::Linear),
+        time_map: CompositionTimeMap::identity(),
+    });
+    CompiledScene::compile_objects(objects, &tracks).expect("appearance scene compiles")
 }
 
 #[test]
@@ -51,18 +56,27 @@ fn appearance_seek_and_rewind_are_deterministic() {
 
 #[test]
 fn appearance_values_are_clamped_to_normalized_visibility() {
-    let mut scene = SceneDefinition::new();
-    let object = scene.add(GeometryRef::circle(1.0));
-    scene
-        .animate_scalar(
-            object,
-            Property::Appearance,
-            2.0,
-            -1.0,
-            TrackTiming::new(0.0, 1.0, Easing::Linear),
-        )
-        .expect("scalar track is structurally valid");
-    let compiled = CompiledScene::compile(&scene).expect("scene compiles");
+    let mut objects = Vec::new();
+    let mut tracks = Vec::new();
+    let object = ObjectId::new(objects.len() as u64);
+    objects.push(CompiledObject::new(
+        object,
+        GeometryRef::circle(1.0),
+        Transform2D::IDENTITY,
+        Style::default(),
+    ));
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object,
+        property: Property::Appearance,
+        values: TrackValues::Scalar {
+            from: 2.0,
+            to: -1.0,
+        },
+        timing: TrackTiming::new(0.0, 1.0, Easing::Linear),
+        time_map: CompositionTimeMap::identity(),
+    });
+    let compiled = CompiledScene::compile_objects(objects, &tracks).expect("scene compiles");
     let mut instance = SceneInstance::new(compiled);
 
     assert_eq!(instance.seek(0.0).unwrap().objects[0].appearance, 1.0);

--- a/crates/noon-runtime/tests/chained_lifecycle.rs
+++ b/crates/noon-runtime/tests/chained_lifecycle.rs
@@ -1,48 +1,120 @@
-use noon_compile::CompiledScene;
-use noon_core::{Easing, GeometryRef, ObjectSnapshot, SceneDefinition, TrackTiming};
+use noon_compile::{CompiledObject, CompiledScene};
+use noon_core::{
+    CompositionTimeMap, Easing, GeometryRef, ObjectId, Property, Style, TrackDefinition, TrackId,
+    TrackTiming, TrackValues, Transform2D, TransformTrackEndpoint,
+};
 use noon_runtime::SceneInstance;
 
 fn chained_scene() -> CompiledScene {
-    let mut scene = SceneDefinition::new();
-    let first = scene.add(GeometryRef::circle(1.0));
-    let second = scene.add(GeometryRef::circle(2.0));
-    let third = scene.add(GeometryRef::circle(3.0));
+    let mut objects = Vec::new();
+    let mut tracks = Vec::new();
+    let first = ObjectId::new(objects.len() as u64);
+    objects.push(CompiledObject::new(
+        first,
+        GeometryRef::circle(1.0),
+        Transform2D::IDENTITY,
+        Style::default(),
+    ));
+    let second = ObjectId::new(objects.len() as u64);
+    objects.push(CompiledObject::new(
+        second,
+        GeometryRef::circle(2.0),
+        Transform2D::IDENTITY,
+        Style::default(),
+    ));
+    let third = ObjectId::new(objects.len() as u64);
+    objects.push(CompiledObject::new(
+        third,
+        GeometryRef::circle(3.0),
+        Transform2D::IDENTITY,
+        Style::default(),
+    ));
 
-    let first_snapshot = ObjectSnapshot::from(scene.object(first).expect("first exists"));
-    let second_snapshot = ObjectSnapshot::from(scene.object(second).expect("second exists"));
-    let third_snapshot = ObjectSnapshot::from(scene.object(third).expect("third exists"));
+    let first_snapshot = TransformTrackEndpoint {
+        geometry: objects[first.get() as usize].geometry().unwrap().clone(),
+        transform: objects[first.get() as usize].base_transform,
+        style: objects[first.get() as usize].base_style,
+    };
+    let second_snapshot = TransformTrackEndpoint {
+        geometry: objects[second.get() as usize].geometry().unwrap().clone(),
+        transform: objects[second.get() as usize].base_transform,
+        style: objects[second.get() as usize].base_style,
+    };
+    let third_snapshot = TransformTrackEndpoint {
+        geometry: objects[third.get() as usize].geometry().unwrap().clone(),
+        transform: objects[third.get() as usize].base_transform,
+        style: objects[third.get() as usize].base_style,
+    };
 
-    scene
-        .animate_transform(
-            first,
-            first_snapshot,
-            second_snapshot.clone(),
-            TrackTiming::new(0.0, 1.0, Easing::Linear),
-        )
-        .expect("first replacement transform is valid");
-    scene
-        .set_presence_at(first, true, false, 1.0)
-        .expect("first hide is valid");
-    scene
-        .set_presence_at(second, false, true, 1.0)
-        .expect("second show is valid");
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object: first,
+        property: Property::Transform,
+        values: TrackValues::Object {
+            from: first_snapshot,
+            to: second_snapshot.clone(),
+        },
+        timing: TrackTiming::new(0.0, 1.0, Easing::Linear),
+        time_map: CompositionTimeMap::identity(),
+    });
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object: first,
+        property: Property::Presence,
+        values: TrackValues::Bool {
+            from: true,
+            to: false,
+        },
+        timing: TrackTiming::instant(1.0),
+        time_map: CompositionTimeMap::identity(),
+    });
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object: second,
+        property: Property::Presence,
+        values: TrackValues::Bool {
+            from: false,
+            to: true,
+        },
+        timing: TrackTiming::instant(1.0),
+        time_map: CompositionTimeMap::identity(),
+    });
 
-    scene
-        .animate_transform(
-            second,
-            second_snapshot,
-            third_snapshot,
-            TrackTiming::new(1.0, 1.0, Easing::Linear),
-        )
-        .expect("second replacement transform is valid");
-    scene
-        .set_presence_at(second, true, false, 2.0)
-        .expect("second hide is valid");
-    scene
-        .set_presence_at(third, false, true, 2.0)
-        .expect("third show is valid");
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object: second,
+        property: Property::Transform,
+        values: TrackValues::Object {
+            from: second_snapshot,
+            to: third_snapshot,
+        },
+        timing: TrackTiming::new(1.0, 1.0, Easing::Linear),
+        time_map: CompositionTimeMap::identity(),
+    });
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object: second,
+        property: Property::Presence,
+        values: TrackValues::Bool {
+            from: true,
+            to: false,
+        },
+        timing: TrackTiming::instant(2.0),
+        time_map: CompositionTimeMap::identity(),
+    });
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object: third,
+        property: Property::Presence,
+        values: TrackValues::Bool {
+            from: false,
+            to: true,
+        },
+        timing: TrackTiming::instant(2.0),
+        time_map: CompositionTimeMap::identity(),
+    });
 
-    CompiledScene::compile(&scene).expect("chained lifecycle scene must compile")
+    CompiledScene::compile_objects(objects, &tracks).expect("chained lifecycle scene must compile")
 }
 
 #[test]

--- a/crates/noon-runtime/tests/cross_geometry_transform.rs
+++ b/crates/noon-runtime/tests/cross_geometry_transform.rs
@@ -1,27 +1,41 @@
-use noon_compile::CompiledScene;
-use noon_core::{Easing, GeometryRef, ObjectSnapshot, SceneDefinition, TrackTiming};
+use noon_compile::{CompiledObject, CompiledScene};
+use noon_core::{
+    CompositionTimeMap, Easing, GeometryRef, ObjectId, Property, Style, TrackDefinition, TrackId,
+    TrackTiming, TrackValues, Transform2D, TransformTrackEndpoint,
+};
 use noon_runtime::SceneInstance;
 
-fn scene() -> SceneDefinition {
-    let mut scene = SceneDefinition::new();
-    let object = scene.add(GeometryRef::circle(1.0));
-    let from = ObjectSnapshot::from(scene.object(object).unwrap());
+fn scene() -> CompiledScene {
+    let mut objects = Vec::new();
+    let mut tracks = Vec::new();
+    let object = ObjectId::new(objects.len() as u64);
+    objects.push(CompiledObject::new(
+        object,
+        GeometryRef::circle(1.0),
+        Transform2D::IDENTITY,
+        Style::default(),
+    ));
+    let from = TransformTrackEndpoint {
+        geometry: objects[object.get() as usize].geometry().unwrap().clone(),
+        transform: objects[object.get() as usize].base_transform,
+        style: objects[object.get() as usize].base_style,
+    };
     let mut to = from.clone();
     to.geometry = GeometryRef::rectangle(2.0, 2.0);
-    scene
-        .animate_transform(
-            object,
-            from,
-            to,
-            TrackTiming::new(0.0, 2.0, Easing::EaseInOutCubic),
-        )
-        .unwrap();
-    scene
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object,
+        property: Property::Transform,
+        values: TrackValues::Object { from, to },
+        timing: TrackTiming::new(0.0, 2.0, Easing::EaseInOutCubic),
+        time_map: CompositionTimeMap::identity(),
+    });
+    CompiledScene::compile_objects(objects, &tracks).unwrap()
 }
 
 #[test]
 fn circle_to_rectangle_keeps_semantic_endpoints_and_renderer_only_morph() {
-    let compiled = CompiledScene::compile(&scene()).expect("cross-kind Transform must compile");
+    let compiled = scene();
     let mut instance = SceneInstance::new(compiled.clone());
 
     let start = instance.seek(0.0).unwrap().clone();

--- a/crates/noon-runtime/tests/filled_transform.rs
+++ b/crates/noon-runtime/tests/filled_transform.rs
@@ -1,7 +1,7 @@
-use noon_compile::CompiledScene;
+use noon_compile::{CompiledObject, CompiledScene};
 use noon_core::{
-    Color, Easing, GeometryRef, ObjectSnapshot, SceneDefinition, TrackTiming, Transform2D, Vec2,
-    VectorPath,
+    Color, CompositionTimeMap, Easing, GeometryRef, ObjectId, Property, Style, TrackDefinition,
+    TrackId, TrackTiming, TrackValues, Transform2D, TransformTrackEndpoint, Vec2, VectorPath,
 };
 use noon_runtime::SceneInstance;
 
@@ -23,8 +23,8 @@ fn diamond() -> VectorPath {
         .close()
 }
 
-fn filled_snapshot(path: VectorPath, fill: Color) -> ObjectSnapshot {
-    let mut snapshot = ObjectSnapshot::new(GeometryRef::path(path));
+fn filled_snapshot(path: VectorPath, fill: Color) -> TransformTrackEndpoint {
+    let mut snapshot = TransformTrackEndpoint::new(GeometryRef::path(path));
     snapshot.transform = Transform2D::IDENTITY;
     snapshot.style.fill = Some(fill);
     snapshot.style.stroke = None;
@@ -47,20 +47,31 @@ fn filled_transform_seek_forward_parity_and_exact_semantic_endpoints() {
     to.transform.rotation = 0.6;
     to.transform.scale = Vec2::new(1.4, 0.7);
 
-    let mut scene = SceneDefinition::new();
-    let object = scene.add(from.geometry.clone());
-    scene.object_mut(object).unwrap().transform = from.transform;
-    scene.object_mut(object).unwrap().style = from.style;
-    scene
-        .animate_transform(
-            object,
-            from.clone(),
-            to.clone(),
-            TrackTiming::new(0.0, 2.0, Easing::Linear),
-        )
-        .unwrap();
+    let mut objects = Vec::new();
+    let mut tracks = Vec::new();
+    let object = ObjectId::new(objects.len() as u64);
+    objects.push(CompiledObject::new(
+        object,
+        from.geometry.clone(),
+        Transform2D::IDENTITY,
+        Style::default(),
+    ));
+    objects[object.get() as usize].base_transform = from.transform;
+    objects[object.get() as usize].base_style = from.style;
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object,
+        property: Property::Transform,
+        values: TrackValues::Object {
+            from: from.clone(),
+            to: to.clone(),
+        },
+        timing: TrackTiming::new(0.0, 2.0, Easing::Linear),
+        time_map: CompositionTimeMap::identity(),
+    });
 
-    let compiled = CompiledScene::compile(&scene).expect("certified filled Transform must compile");
+    let compiled = CompiledScene::compile_objects(objects, &tracks)
+        .expect("certified filled Transform must compile");
     let mut direct = SceneInstance::new(compiled.clone());
     let mut sequential = SceneInstance::new(compiled);
 

--- a/crates/noon-runtime/tests/generic_transform.rs
+++ b/crates/noon-runtime/tests/generic_transform.rs
@@ -1,7 +1,7 @@
-use noon_compile::CompiledScene;
+use noon_compile::{CompiledObject, CompiledScene};
 use noon_core::{
-    Color, Easing, GeometryRef, ObjectSnapshot, Property, SceneDefinition, Style, TrackTiming,
-    Transform2D, Vec2, VectorPath,
+    Color, CompositionTimeMap, Easing, GeometryRef, ObjectId, Property, Style, TrackDefinition,
+    TrackId, TrackTiming, TrackValues, Transform2D, TransformTrackEndpoint, Vec2, VectorPath,
 };
 use noon_runtime::SceneInstance;
 
@@ -35,8 +35,8 @@ fn path_c() -> VectorPath {
         .line_to(Vec2::new(1.0, 1.0))
 }
 
-fn snapshot(path: VectorPath, transform: Transform2D, style: Style) -> ObjectSnapshot {
-    ObjectSnapshot {
+fn snapshot(path: VectorPath, transform: Transform2D, style: Style) -> TransformTrackEndpoint {
+    TransformTrackEndpoint {
         geometry: GeometryRef::path(path),
         transform,
         style,
@@ -56,20 +56,31 @@ fn generic_transform_has_exact_semantic_endpoints_and_detached_render_geometry()
     let from = snapshot(path_a(), transform_a, style_a);
     let to = snapshot(path_b(), transform_b, style_b);
 
-    let mut scene = SceneDefinition::new();
-    let object = scene.add(from.geometry.clone());
-    scene.object_mut(object).unwrap().transform = from.transform;
-    scene.object_mut(object).unwrap().style = from.style;
-    scene
-        .animate_transform(
-            object,
-            from.clone(),
-            to.clone(),
-            TrackTiming::new(0.0, 2.0, Easing::Linear),
-        )
-        .unwrap();
+    let mut objects = Vec::new();
+    let mut tracks = Vec::new();
+    let object = ObjectId::new(objects.len() as u64);
+    objects.push(CompiledObject::new(
+        object,
+        from.geometry.clone(),
+        Transform2D::IDENTITY,
+        Style::default(),
+    ));
+    objects[object.get() as usize].base_transform = from.transform;
+    objects[object.get() as usize].base_style = from.style;
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object,
+        property: Property::Transform,
+        values: TrackValues::Object {
+            from: from.clone(),
+            to: to.clone(),
+        },
+        timing: TrackTiming::new(0.0, 2.0, Easing::Linear),
+        time_map: CompositionTimeMap::identity(),
+    });
 
-    let mut instance = SceneInstance::new(CompiledScene::compile(&scene).unwrap());
+    let mut instance =
+        SceneInstance::new(CompiledScene::compile_objects(objects, &tracks).unwrap());
 
     let start = instance.seek(0.0).unwrap().clone();
     assert_eq!(start.objects.len(), 1);
@@ -130,14 +141,27 @@ fn steady_generic_transform_reuses_path_allocations() {
     let style = stroke_style(Color::WHITE);
     let from = snapshot(path_a(), Transform2D::IDENTITY, style);
     let to = snapshot(path_b(), Transform2D::IDENTITY, style);
-    let mut scene = SceneDefinition::new();
-    let object = scene.add(from.geometry.clone());
-    scene.object_mut(object).unwrap().style = style;
-    scene
-        .animate_transform(object, from, to, TrackTiming::new(0.0, 2.0, Easing::Linear))
-        .unwrap();
+    let mut objects = Vec::new();
+    let mut tracks = Vec::new();
+    let object = ObjectId::new(objects.len() as u64);
+    objects.push(CompiledObject::new(
+        object,
+        from.geometry.clone(),
+        Transform2D::IDENTITY,
+        Style::default(),
+    ));
+    objects[object.get() as usize].base_style = style;
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object,
+        property: Property::Transform,
+        values: TrackValues::Object { from, to },
+        timing: TrackTiming::new(0.0, 2.0, Easing::Linear),
+        time_map: CompositionTimeMap::identity(),
+    });
 
-    let mut instance = SceneInstance::new(CompiledScene::compile(&scene).unwrap());
+    let mut instance =
+        SceneInstance::new(CompiledScene::compile_objects(objects, &tracks).unwrap());
     instance.advance_to(0.25).unwrap();
     let first = path_command_buffers(instance.frame());
     instance.advance_to(0.50).unwrap();
@@ -162,18 +186,25 @@ fn direct_seek_and_forward_playback_match_for_generic_transform() {
         },
         stroke_style(Color::rgb(0.8, 0.2, 0.4)),
     );
-    let mut scene = SceneDefinition::new();
-    let object = scene.add(from.geometry.clone());
-    scene.object_mut(object).unwrap().style = from.style;
-    scene
-        .animate_transform(
-            object,
-            from,
-            to,
-            TrackTiming::new(0.0, 2.0, Easing::EaseInOutCubic),
-        )
-        .unwrap();
-    let compiled = CompiledScene::compile(&scene).unwrap();
+    let mut objects = Vec::new();
+    let mut tracks = Vec::new();
+    let object = ObjectId::new(objects.len() as u64);
+    objects.push(CompiledObject::new(
+        object,
+        from.geometry.clone(),
+        Transform2D::IDENTITY,
+        Style::default(),
+    ));
+    objects[object.get() as usize].base_style = from.style;
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object,
+        property: Property::Transform,
+        values: TrackValues::Object { from, to },
+        timing: TrackTiming::new(0.0, 2.0, Easing::EaseInOutCubic),
+        time_map: CompositionTimeMap::identity(),
+    });
+    let compiled = CompiledScene::compile_objects(objects, &tracks).unwrap();
     let mut sequential = SceneInstance::new(compiled.clone());
     let mut direct = SceneInstance::new(compiled);
 
@@ -206,27 +237,40 @@ fn sequential_transforms_are_continuous_and_choose_new_pair_at_boundary() {
         stroke_style(Color::rgb(0.2, 0.8, 0.3)),
     );
 
-    let mut scene = SceneDefinition::new();
-    let object = scene.add(a.geometry.clone());
-    scene.object_mut(object).unwrap().style = a.style;
-    scene
-        .animate_transform(
-            object,
-            a.clone(),
-            b.clone(),
-            TrackTiming::new(0.0, 1.0, Easing::Linear),
-        )
-        .unwrap();
-    scene
-        .animate_transform(
-            object,
-            b.clone(),
-            c.clone(),
-            TrackTiming::new(1.0, 1.0, Easing::Linear),
-        )
-        .unwrap();
+    let mut objects = Vec::new();
+    let mut tracks = Vec::new();
+    let object = ObjectId::new(objects.len() as u64);
+    objects.push(CompiledObject::new(
+        object,
+        a.geometry.clone(),
+        Transform2D::IDENTITY,
+        Style::default(),
+    ));
+    objects[object.get() as usize].base_style = a.style;
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object,
+        property: Property::Transform,
+        values: TrackValues::Object {
+            from: a.clone(),
+            to: b.clone(),
+        },
+        timing: TrackTiming::new(0.0, 1.0, Easing::Linear),
+        time_map: CompositionTimeMap::identity(),
+    });
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object,
+        property: Property::Transform,
+        values: TrackValues::Object {
+            from: b.clone(),
+            to: c.clone(),
+        },
+        timing: TrackTiming::new(1.0, 1.0, Easing::Linear),
+        time_map: CompositionTimeMap::identity(),
+    });
 
-    let compiled = CompiledScene::compile(&scene).unwrap();
+    let compiled = CompiledScene::compile_objects(objects, &tracks).unwrap();
     let mut direct = SceneInstance::new(compiled.clone());
     let boundary = direct.seek(1.0).unwrap().clone();
     assert_eq!(boundary.objects[0].geometry(), Some(&b.geometry));
@@ -246,35 +290,54 @@ fn sequential_transforms_are_continuous_and_choose_new_pair_at_boundary() {
 
 #[test]
 fn narrow_tracks_override_corresponding_generic_transform_channels() {
-    let mut scene = SceneDefinition::new();
-    let object = scene.add(GeometryRef::circle(1.0));
-    let from = ObjectSnapshot::from(scene.object(object).unwrap());
+    let mut objects = Vec::new();
+    let mut tracks = Vec::new();
+    let object = ObjectId::new(objects.len() as u64);
+    objects.push(CompiledObject::new(
+        object,
+        GeometryRef::circle(1.0),
+        Transform2D::IDENTITY,
+        Style::default(),
+    ));
+    let from = TransformTrackEndpoint {
+        geometry: objects[object.get() as usize].geometry().unwrap().clone(),
+        transform: objects[object.get() as usize].base_transform,
+        style: objects[object.get() as usize].base_style,
+    };
     let mut to = from.clone();
     to.transform.translation = Vec2::new(10.0, 0.0);
     to.transform.rotation = 1.0;
     to.style.opacity = 0.2;
-    scene
-        .animate_transform(object, from, to, TrackTiming::new(0.0, 2.0, Easing::Linear))
-        .unwrap();
-    scene
-        .animate_position(
-            object,
-            Vec2::ZERO,
-            Vec2::new(20.0, 0.0),
-            TrackTiming::new(0.0, 2.0, Easing::Linear),
-        )
-        .unwrap();
-    scene
-        .animate_scalar(
-            object,
-            Property::Opacity,
-            1.0,
-            0.8,
-            TrackTiming::new(0.0, 2.0, Easing::Linear),
-        )
-        .unwrap();
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object,
+        property: Property::Transform,
+        values: TrackValues::Object { from, to },
+        timing: TrackTiming::new(0.0, 2.0, Easing::Linear),
+        time_map: CompositionTimeMap::identity(),
+    });
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object,
+        property: Property::Position,
+        values: TrackValues::Vec2 {
+            from: Vec2::ZERO,
+            to: Vec2::new(20.0, 0.0),
+        },
+        timing: TrackTiming::new(0.0, 2.0, Easing::Linear),
+        time_map: CompositionTimeMap::identity(),
+    });
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object,
+        property: Property::Opacity,
+        values: TrackValues::Scalar { from: 1.0, to: 0.8 },
+        timing: TrackTiming::new(0.0, 2.0, Easing::Linear),
+        time_map: CompositionTimeMap::identity(),
+    });
 
-    let mut instance = SceneInstance::new(CompiledScene::compile(&scene).unwrap());
+    let mut instance =
+        SceneInstance::new(CompiledScene::compile_objects(objects, &tracks).unwrap());
     let frame = instance.seek(1.0).unwrap();
     assert_eq!(frame.objects[0].transform.translation, Vec2::new(10.0, 0.0));
     assert_eq!(frame.objects[0].transform.rotation, 0.5);
@@ -286,17 +349,35 @@ fn generic_path_transform_does_not_reuse_reveal_channel() {
     let style = stroke_style(Color::WHITE);
     let from = snapshot(path_a(), Transform2D::IDENTITY, style);
     let to = snapshot(path_b(), Transform2D::IDENTITY, style);
-    let mut scene = SceneDefinition::new();
-    let object = scene.add(from.geometry.clone());
-    scene.object_mut(object).unwrap().style = style;
-    scene
-        .animate_transform(object, from, to, TrackTiming::new(0.0, 2.0, Easing::Linear))
-        .unwrap();
-    scene
-        .animate_reveal(object, 0.0, 1.0, TrackTiming::new(0.0, 4.0, Easing::Linear))
-        .unwrap();
+    let mut objects = Vec::new();
+    let mut tracks = Vec::new();
+    let object = ObjectId::new(objects.len() as u64);
+    objects.push(CompiledObject::new(
+        object,
+        from.geometry.clone(),
+        Transform2D::IDENTITY,
+        Style::default(),
+    ));
+    objects[object.get() as usize].base_style = style;
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object,
+        property: Property::Transform,
+        values: TrackValues::Object { from, to },
+        timing: TrackTiming::new(0.0, 2.0, Easing::Linear),
+        time_map: CompositionTimeMap::identity(),
+    });
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object,
+        property: Property::Reveal,
+        values: TrackValues::Scalar { from: 0.0, to: 1.0 },
+        timing: TrackTiming::new(0.0, 4.0, Easing::Linear),
+        time_map: CompositionTimeMap::identity(),
+    });
 
-    let mut instance = SceneInstance::new(CompiledScene::compile(&scene).unwrap());
+    let mut instance =
+        SceneInstance::new(CompiledScene::compile_objects(objects, &tracks).unwrap());
     let frame = instance.seek(1.0).unwrap();
     assert_eq!(frame.morph(0), 0.5);
     assert_eq!(frame.reveal(0), 0.25);
@@ -304,20 +385,34 @@ fn generic_path_transform_does_not_reuse_reveal_channel() {
 
 #[test]
 fn rotation_transform_interpolates_source_and_target_points_not_angle() {
-    let mut scene = SceneDefinition::new();
-    let object = scene.add(GeometryRef::rectangle(2.0, 1.0));
-    let from = ObjectSnapshot::from(scene.object(object).unwrap());
+    let mut objects = Vec::new();
+    let mut tracks = Vec::new();
+    let object = ObjectId::new(objects.len() as u64);
+    objects.push(CompiledObject::new(
+        object,
+        GeometryRef::rectangle(2.0, 1.0),
+        Transform2D::IDENTITY,
+        Style::default(),
+    ));
+    let from = TransformTrackEndpoint {
+        geometry: objects[object.get() as usize].geometry().unwrap().clone(),
+        transform: objects[object.get() as usize].base_transform,
+        style: objects[object.get() as usize].base_style,
+    };
     let mut to = from.clone();
     to.transform.translation = Vec2::new(2.0, -1.0);
     to.transform.rotation = std::f32::consts::PI;
-    scene
-        .animate_transform(
-            object,
-            from.clone(),
-            to.clone(),
-            TrackTiming::new(0.0, 1.0, Easing::Linear),
-        )
-        .unwrap();
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object,
+        property: Property::Transform,
+        values: TrackValues::Object {
+            from: from.clone(),
+            to: to.clone(),
+        },
+        timing: TrackTiming::new(0.0, 1.0, Easing::Linear),
+        time_map: CompositionTimeMap::identity(),
+    });
 
     fn world(transform: Transform2D, point: Vec2) -> Vec2 {
         let scaled = Vec2::new(point.x * transform.scale.x, point.y * transform.scale.y);
@@ -328,7 +423,7 @@ fn rotation_transform_interpolates_source_and_target_points_not_angle() {
         )
     }
 
-    let compiled = CompiledScene::compile(&scene).unwrap();
+    let compiled = CompiledScene::compile_objects(objects, &tracks).unwrap();
     let mut instance = SceneInstance::new(compiled);
     let point = Vec2::new(1.0, 0.5);
     for progress in [0.25_f32, 0.5, 0.75] {

--- a/crates/noon-runtime/tests/instant_property_assignment.rs
+++ b/crates/noon-runtime/tests/instant_property_assignment.rs
@@ -1,8 +1,8 @@
 use noon_compile::{CompiledObject, CompiledScene};
 use noon_core::{
-    CompositionTimeMap, CompositionTimeMapStep, GeometryRef, ObjectId, Property, RateFunction,
-    RetainedObjectDefinition, SceneDefinition, TextResourceHandle, TextResourceId, TimelineError,
-    TrackDefinition, TrackId, TrackTiming, TrackValues, Vec2,
+    validate_track_definition, CompositionTimeMap, CompositionTimeMapStep, GeometryRef, ObjectId,
+    Property, RateFunction, Style, TextResourceHandle, TextResourceId, TimelineError,
+    TrackDefinition, TrackId, TrackTiming, TrackValues, Transform2D, Vec2,
 };
 use noon_runtime::SceneInstance;
 
@@ -34,66 +34,68 @@ fn track(
 
 #[test]
 fn ordinary_properties_accept_exact_instant_assignments() {
-    let mut scene = SceneDefinition::new();
-    let object = scene.add(GeometryRef::circle(1.0));
+    let object = ObjectId::new(0);
 
-    scene
-        .add_track(
-            object,
-            Property::Position,
-            TrackValues::Vec2 {
-                from: Vec2::new(4.0, -2.0),
-                to: Vec2::ZERO,
-            },
-            TrackTiming::instant(1.0),
-        )
-        .expect("ordinary property assignments must support an exact timestamp");
+    validate_track_definition(&TrackDefinition {
+        id: TrackId::new(0),
+        object,
+        property: Property::Position,
+        values: TrackValues::Vec2 {
+            from: Vec2::new(4.0, -2.0),
+            to: Vec2::ZERO,
+        },
+        timing: TrackTiming::instant(1.0),
+        time_map: CompositionTimeMap::identity(),
+    })
+    .expect("ordinary property assignments must support an exact timestamp");
 
-    let negative = scene
-        .add_track(
-            object,
-            Property::Scale,
-            TrackValues::Vec2 {
-                from: Vec2::ONE,
-                to: Vec2::ONE,
-            },
-            TrackTiming::new(2.0, -1.0, RateFunction::Linear),
-        )
-        .expect_err("negative-duration assignments must remain invalid");
+    let negative = validate_track_definition(&TrackDefinition {
+        id: TrackId::new(0),
+        object,
+        property: Property::Scale,
+        values: TrackValues::Vec2 {
+            from: Vec2::ONE,
+            to: Vec2::ONE,
+        },
+        timing: TrackTiming::new(2.0, -1.0, RateFunction::Linear),
+        time_map: CompositionTimeMap::identity(),
+    })
+    .expect_err("negative-duration assignments must remain invalid");
     assert!(matches!(negative, TimelineError::InvalidDuration(value) if value == -1.0));
 
-    let mapped_instant = scene
-        .add_track_with_time_map(
-            object,
-            Property::Scale,
-            TrackValues::Vec2 {
-                from: Vec2::new(0.5, 0.5),
-                to: Vec2::ONE,
-            },
-            TrackTiming::instant(2.0),
-            CompositionTimeMap::from_steps(vec![CompositionTimeMapStep::new(
-                0.0,
-                1.0,
-                RateFunction::Linear,
-            )]),
-        )
-        .expect_err("instant assignments cannot carry a composition time map");
+    let mapped_instant = validate_track_definition(&TrackDefinition {
+        id: TrackId::new(0),
+        object,
+        property: Property::Scale,
+        values: TrackValues::Vec2 {
+            from: Vec2::new(0.5, 0.5),
+            to: Vec2::ONE,
+        },
+        timing: TrackTiming::instant(2.0),
+        time_map: CompositionTimeMap::from_steps(vec![CompositionTimeMapStep::new(
+            0.0,
+            1.0,
+            RateFunction::Linear,
+        )]),
+    })
+    .expect_err("instant assignments cannot carry a composition time map");
     assert!(matches!(
         mapped_instant,
         TimelineError::InstantTrackCannotUseTimeMap(Property::Scale)
     ));
 
-    let positive_presence = scene
-        .add_track(
-            object,
-            Property::Presence,
-            TrackValues::Bool {
-                from: true,
-                to: false,
-            },
-            TrackTiming::new(3.0, 0.5, RateFunction::Linear),
-        )
-        .expect_err("Presence remains a discrete zero-duration channel");
+    let positive_presence = validate_track_definition(&TrackDefinition {
+        id: TrackId::new(0),
+        object,
+        property: Property::Presence,
+        values: TrackValues::Bool {
+            from: true,
+            to: false,
+        },
+        timing: TrackTiming::new(3.0, 0.5, RateFunction::Linear),
+        time_map: CompositionTimeMap::identity(),
+    })
+    .expect_err("Presence remains a discrete zero-duration channel");
     assert!(matches!(
         positive_presence,
         TimelineError::InvalidInstantDuration {
@@ -104,71 +106,103 @@ fn ordinary_properties_accept_exact_instant_assignments() {
 }
 
 #[test]
-fn legacy_cleanup_assignments_restore_canonical_state_at_the_hide_boundary() {
-    let mut scene = SceneDefinition::new();
-    let object = scene.add(GeometryRef::circle(1.0));
+fn cleanup_assignments_restore_canonical_state_at_the_hide_boundary() {
+    let object = ObjectId::new(0);
+    let objects = vec![CompiledObject::new(
+        object,
+        GeometryRef::circle(1.0),
+        Transform2D::IDENTITY,
+        Style::default(),
+    )];
+    let mut tracks = Vec::new();
     let faded_position = Vec2::new(2.0, -1.0);
     let faded_scale = Vec2::new(0.5, 0.5);
 
-    scene
-        .animate_position(
-            object,
-            Vec2::ZERO,
-            faded_position,
-            TrackTiming::new(0.0, 1.0, RateFunction::Linear),
-        )
-        .unwrap();
-    scene
-        .animate_scale(
-            object,
-            Vec2::ONE,
-            faded_scale,
-            TrackTiming::new(0.0, 1.0, RateFunction::Linear),
-        )
-        .unwrap();
-    scene
-        .animate_appearance(
-            object,
-            1.0,
-            0.0,
-            TrackTiming::new(0.0, 1.0, RateFunction::Linear),
-        )
-        .unwrap();
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object,
+        property: Property::Position,
+        values: TrackValues::Vec2 {
+            from: Vec2::ZERO,
+            to: faded_position,
+        },
+        timing: TrackTiming::new(0.0, 1.0, RateFunction::Linear),
+        time_map: CompositionTimeMap::identity(),
+    });
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object,
+        property: Property::Scale,
+        values: TrackValues::Vec2 {
+            from: Vec2::ONE,
+            to: faded_scale,
+        },
+        timing: TrackTiming::new(0.0, 1.0, RateFunction::Linear),
+        time_map: CompositionTimeMap::identity(),
+    });
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object,
+        property: Property::Appearance,
+        values: TrackValues::Scalar { from: 1.0, to: 0.0 },
+        timing: TrackTiming::new(0.0, 1.0, RateFunction::Linear),
+        time_map: CompositionTimeMap::identity(),
+    });
 
-    scene
-        .add_track(
-            object,
-            Property::Position,
-            TrackValues::Vec2 {
-                from: faded_position,
-                to: Vec2::ZERO,
-            },
-            TrackTiming::instant(1.0),
-        )
-        .unwrap();
-    scene
-        .add_track(
-            object,
-            Property::Scale,
-            TrackValues::Vec2 {
-                from: faded_scale,
-                to: Vec2::ONE,
-            },
-            TrackTiming::instant(1.0),
-        )
-        .unwrap();
-    scene
-        .add_track(
-            object,
-            Property::Appearance,
-            TrackValues::Scalar { from: 0.0, to: 1.0 },
-            TrackTiming::instant(1.0),
-        )
-        .unwrap();
-    scene.set_presence_at(object, true, false, 1.0).unwrap();
-    scene.set_presence_at(object, false, true, 2.0).unwrap();
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object,
+        property: Property::Position,
+        values: TrackValues::Vec2 {
+            from: faded_position,
+            to: Vec2::ZERO,
+        },
+        timing: TrackTiming::instant(1.0),
+        time_map: CompositionTimeMap::identity(),
+    });
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object,
+        property: Property::Scale,
+        values: TrackValues::Vec2 {
+            from: faded_scale,
+            to: Vec2::ONE,
+        },
+        timing: TrackTiming::instant(1.0),
+        time_map: CompositionTimeMap::identity(),
+    });
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object,
+        property: Property::Appearance,
+        values: TrackValues::Scalar { from: 0.0, to: 1.0 },
+        timing: TrackTiming::instant(1.0),
+        time_map: CompositionTimeMap::identity(),
+    });
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object,
+        property: Property::Presence,
+        values: TrackValues::Bool {
+            from: true,
+            to: false,
+        },
+        timing: TrackTiming::instant(1.0),
+        time_map: CompositionTimeMap::identity(),
+    });
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object,
+        property: Property::Presence,
+        values: TrackValues::Bool {
+            from: false,
+            to: true,
+        },
+        timing: TrackTiming::instant(2.0),
+        time_map: CompositionTimeMap::identity(),
+    });
 
-    let compiled = CompiledScene::compile(&scene).unwrap();
+    let compiled = CompiledScene::compile_objects(objects, &tracks).unwrap();
     let mut direct = SceneInstance::new(compiled.clone());
     let mut sequential = SceneInstance::new(compiled);
 
@@ -200,7 +234,12 @@ fn legacy_cleanup_assignments_restore_canonical_state_at_the_hide_boundary() {
 fn retained_text_cleanup_assignments_are_seekable_and_preserve_resource_identity() {
     let object = ObjectId::new(3);
     let handle = text_handle();
-    let objects = [RetainedObjectDefinition::text(object, handle)];
+    let objects = vec![CompiledObject::new(
+        object,
+        handle,
+        Transform2D::IDENTITY,
+        Style::default(),
+    )];
     let faded_position = Vec2::new(-3.0, 1.5);
     let faded_scale = Vec2::new(0.25, 0.25);
     let tracks = [
@@ -288,17 +327,6 @@ fn retained_text_cleanup_assignments_are_seekable_and_preserve_resource_identity
         ),
     ];
 
-    let objects = objects
-        .iter()
-        .map(|object| {
-            CompiledObject::new(
-                object.id,
-                object.content.clone(),
-                object.transform,
-                object.style,
-            )
-        })
-        .collect();
     let compiled = CompiledScene::compile_objects(objects, &tracks).unwrap();
     let mut direct = SceneInstance::new(compiled.clone());
     let mut sequential = SceneInstance::new(compiled);
@@ -326,38 +354,43 @@ fn retained_text_cleanup_assignments_are_seekable_and_preserve_resource_identity
 
 #[test]
 fn instant_assignment_wins_in_a_channel_that_also_has_a_composition_map() {
-    let mut scene = SceneDefinition::new();
-    let object = scene.add(GeometryRef::circle(1.0));
-
-    scene
-        .add_track_with_time_map(
+    let object = ObjectId::new(0);
+    let objects = vec![CompiledObject::new(
+        object,
+        GeometryRef::circle(1.0),
+        Transform2D::IDENTITY,
+        Style::default(),
+    )];
+    let tracks = [
+        TrackDefinition {
+            id: TrackId::new(0),
             object,
-            Property::Position,
-            TrackValues::Vec2 {
+            property: Property::Position,
+            values: TrackValues::Vec2 {
                 from: Vec2::ZERO,
                 to: Vec2::new(4.0, 0.0),
             },
-            TrackTiming::new(0.0, 2.0, RateFunction::Linear),
-            CompositionTimeMap::from_steps(vec![CompositionTimeMapStep::new(
+            timing: TrackTiming::new(0.0, 2.0, RateFunction::Linear),
+            time_map: CompositionTimeMap::from_steps(vec![CompositionTimeMapStep::new(
                 0.0,
                 1.0,
                 RateFunction::Smooth,
             )]),
-        )
-        .unwrap();
-    scene
-        .add_track(
+        },
+        TrackDefinition {
+            id: TrackId::new(1),
             object,
-            Property::Position,
-            TrackValues::Vec2 {
+            property: Property::Position,
+            values: TrackValues::Vec2 {
                 from: Vec2::new(4.0, 0.0),
                 to: Vec2::ZERO,
             },
-            TrackTiming::instant(2.0),
-        )
-        .unwrap();
+            timing: TrackTiming::instant(2.0),
+            time_map: CompositionTimeMap::identity(),
+        },
+    ];
 
-    let compiled = CompiledScene::compile(&scene).unwrap();
+    let compiled = CompiledScene::compile_objects(objects, &tracks).unwrap();
     let mut direct = SceneInstance::new(compiled.clone());
     let mut sequential = SceneInstance::new(compiled);
 

--- a/crates/noon-runtime/tests/long_sparse_timeline.rs
+++ b/crates/noon-runtime/tests/long_sparse_timeline.rs
@@ -1,27 +1,41 @@
-use noon_compile::CompiledScene;
-use noon_core::{Easing, GeometryRef, SceneDefinition, TrackTiming, Vec2};
+use noon_compile::{CompiledObject, CompiledScene};
+use noon_core::{
+    CompositionTimeMap, Easing, GeometryRef, ObjectId, Property, Style, TrackDefinition, TrackId,
+    TrackTiming, TrackValues, Transform2D, Vec2,
+};
 use noon_runtime::{EvaluationStats, SceneInstance};
 
 const HISTORICAL_TRACKS: usize = 50_000;
 
 #[test]
 fn completed_long_timeline_history_is_not_rescanned_on_forward_frames() {
-    let mut definition = SceneDefinition::new();
-    let object = definition.add(GeometryRef::circle(0.5));
+    let mut objects = Vec::new();
+    let mut tracks = Vec::new();
+    let object = ObjectId::new(objects.len() as u64);
+    objects.push(CompiledObject::new(
+        object,
+        GeometryRef::circle(0.5),
+        Transform2D::IDENTITY,
+        Style::default(),
+    ));
 
     for index in 0..HISTORICAL_TRACKS {
         let x = index as f32;
-        definition
-            .animate_position(
-                object,
-                Vec2::new(x, 0.0),
-                Vec2::new(x + 1.0, 0.0),
-                TrackTiming::new(index as f64, 0.5, Easing::Linear),
-            )
-            .expect("historical track must be valid");
+        tracks.push(TrackDefinition {
+            id: TrackId::new(tracks.len() as u64),
+            object,
+            property: Property::Position,
+            values: TrackValues::Vec2 {
+                from: Vec2::new(x, 0.0),
+                to: Vec2::new(x + 1.0, 0.0),
+            },
+            timing: TrackTiming::new(index as f64, 0.5, Easing::Linear),
+            time_map: CompositionTimeMap::identity(),
+        });
     }
 
-    let compiled = CompiledScene::compile(&definition).expect("long sparse timeline must compile");
+    let compiled = CompiledScene::compile_objects(objects, &tracks)
+        .expect("long sparse timeline must compile");
     let mut runtime = SceneInstance::new(compiled);
     let history_end = HISTORICAL_TRACKS as f64;
 

--- a/crates/noon-runtime/tests/manim_transform_correspondence.rs
+++ b/crates/noon-runtime/tests/manim_transform_correspondence.rs
@@ -1,9 +1,9 @@
-use noon_compile::CompiledScene;
+use noon_compile::{CompiledObject, CompiledScene};
 use noon_core::{
-    Color, Easing, GeometryRef, ObjectSnapshot, PathCommand, SceneDefinition, StrokeWidthMode,
-    Style, TrackTiming, Transform2D, Vec2, VectorPath,
+    Color, CompositionTimeMap, Easing, GeometryRef, ObjectId, PathCommand, Property,
+    StrokeWidthMode, Style, TrackDefinition, TrackId, TrackTiming, TrackValues, Transform2D,
+    TransformTrackEndpoint, Vec2, VectorPath,
 };
-use noon_core::{ScenePatch, TrackValues};
 use noon_runtime::SceneInstance;
 use std::sync::Arc;
 
@@ -31,14 +31,14 @@ fn screen_space_path_pair_keeps_endpoint_world_points_during_transform() {
         ..Style::default()
     };
 
-    let mut from = ObjectSnapshot::new(GeometryRef::path(source));
+    let mut from = TransformTrackEndpoint::new(GeometryRef::path(source));
     from.style = style;
     from.transform = Transform2D {
         translation: Vec2::new(1.0, 2.0),
         rotation: std::f32::consts::FRAC_PI_2,
         scale: Vec2::new(2.0, 1.5),
     };
-    let mut to = ObjectSnapshot::new(GeometryRef::path(target));
+    let mut to = TransformTrackEndpoint::new(GeometryRef::path(target));
     to.style = style;
     to.transform = Transform2D {
         translation: Vec2::new(-1.0, 0.5),
@@ -46,21 +46,33 @@ fn screen_space_path_pair_keeps_endpoint_world_points_during_transform() {
         scale: Vec2::new(1.0, 2.0),
     };
 
-    let mut scene = SceneDefinition::new();
-    let object = scene.add(from.geometry.clone());
-    scene.object_mut(object).expect("object").style = style;
-    scene.object_mut(object).expect("object").transform = from.transform;
-    scene
-        .animate_transform(
-            object,
-            from.clone(),
-            to.clone(),
-            TrackTiming::new(0.0, 2.0, Easing::Linear),
-        )
-        .expect("valid Transform");
+    let mut objects = Vec::new();
+    let mut tracks = Vec::new();
+    let object = ObjectId::new(objects.len() as u64);
+    objects.push(CompiledObject::new(
+        object,
+        from.geometry.clone(),
+        Transform2D::IDENTITY,
+        Style::default(),
+    ));
+    objects[object.get() as usize].base_style = style;
+    objects[object.get() as usize].base_transform = from.transform;
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object,
+        property: Property::Transform,
+        values: TrackValues::Object {
+            from: from.clone(),
+            to: to.clone(),
+        },
+        timing: TrackTiming::new(0.0, 2.0, Easing::Linear),
+        time_map: CompositionTimeMap::identity(),
+    });
 
-    let mut identity_scene = scene.clone();
-    let mut instance = SceneInstance::new(CompiledScene::compile(&scene).expect("compile"));
+    let mut identity_tracks = tracks.clone();
+    let mut instance = SceneInstance::new(
+        CompiledScene::compile_objects(objects.clone(), &tracks).expect("compile"),
+    );
     let frame = instance.seek(1.0).expect("seek");
     let current = frame.render_transform(0);
     assert_eq!(current, Transform2D::IDENTITY);
@@ -94,7 +106,8 @@ fn screen_space_path_pair_keeps_endpoint_world_points_during_transform() {
         to.transform.transform_point(Vec2::new(0.0, 1.0)),
     );
     let stable = instance.frame().render_geometries[0].clone().unwrap();
-    let mut retained = SceneInstance::new(CompiledScene::compile(&scene).unwrap());
+    let mut retained =
+        SceneInstance::new(CompiledScene::compile_objects(objects.clone(), &tracks).unwrap());
     for time in [0.0, 0.2, 0.7, 1.3, 2.0, 1.0] {
         let frame = instance.seek(time).unwrap();
         if time > 0.0 && time < 2.0 {
@@ -131,18 +144,22 @@ fn screen_space_path_pair_keeps_endpoint_world_points_during_transform() {
     // A later independent driver must move the already completed morph; it may
     // convert the stable world pair once into the previous semantic local frame.
     let delta = Vec2::new(3.0, -2.0);
-    scene
-        .animate_position(
-            object,
-            to.transform.translation,
-            to.transform.translation + delta,
-            TrackTiming::new(2.0, 1.0, Easing::Linear),
-        )
-        .unwrap();
-    let compiled = CompiledScene::compile(&scene).unwrap();
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object,
+        property: Property::Position,
+        values: TrackValues::Vec2 {
+            from: to.transform.translation,
+            to: to.transform.translation + delta,
+        },
+        timing: TrackTiming::new(2.0, 1.0, Easing::Linear),
+        time_map: CompositionTimeMap::identity(),
+    });
+    let compiled = CompiledScene::compile_objects(objects.clone(), &tracks).unwrap();
     let mut stepped = SceneInstance::new(compiled.clone());
     let mut direct = SceneInstance::new(compiled);
-    let mut retained = SceneInstance::new(CompiledScene::compile(&scene).unwrap());
+    let mut retained =
+        SceneInstance::new(CompiledScene::compile_objects(objects.clone(), &tracks).unwrap());
     for time in [1.0, 2.0, 2.25, 2.5, 3.0] {
         let frame = stepped.advance_to(time).unwrap();
         assert_eq!(frame, direct.seek(time).unwrap());
@@ -168,16 +185,21 @@ fn screen_space_path_pair_keeps_endpoint_world_points_during_transform() {
     }
     // A concurrent nonuniform scale driver preserves the established channel
     // order: effective TRS acts on the morph pair in the interpolated local frame.
-    scene
-        .animate_scale(
-            object,
-            Vec2::new(2.0, 0.5),
-            Vec2::new(4.0, 0.5),
-            TrackTiming::new(0.5, 1.0, Easing::Linear),
-        )
-        .unwrap();
-    let mut concurrent = SceneInstance::new(CompiledScene::compile(&scene).unwrap());
-    let mut retained = SceneInstance::new(CompiledScene::compile(&scene).unwrap());
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object,
+        property: Property::Scale,
+        values: TrackValues::Vec2 {
+            from: Vec2::new(2.0, 0.5),
+            to: Vec2::new(4.0, 0.5),
+        },
+        timing: TrackTiming::new(0.5, 1.0, Easing::Linear),
+        time_map: CompositionTimeMap::identity(),
+    });
+    let mut concurrent =
+        SceneInstance::new(CompiledScene::compile_objects(objects.clone(), &tracks).unwrap());
+    let mut retained =
+        SceneInstance::new(CompiledScene::compile_objects(objects.clone(), &tracks).unwrap());
     let frame = concurrent.seek(1.0).unwrap();
     let retained_frame = retained.seek(1.0).unwrap();
     assert_eq!(frame.render_geometry(0), retained_frame.render_geometry(0));
@@ -207,26 +229,30 @@ fn screen_space_path_pair_keeps_endpoint_world_points_during_transform() {
     // Equal point content must not hide a handoff back to the registered Arc.
     // An identity TRS and a short identity scale driver make the temporary local
     // pair exactly equal to the compiled world pair while giving it another owner.
-    let mut identity_track = identity_scene.tracks()[0].clone();
+    let mut identity_track = identity_tracks[0].clone();
     let TrackValues::Object { from, to } = &mut identity_track.values else {
         panic!("transform");
     };
     from.transform = Transform2D::IDENTITY;
     to.transform = Transform2D::IDENTITY;
-    identity_scene
-        .apply_patch(ScenePatch::ReplaceTrack(identity_track))
-        .unwrap();
-    identity_scene
-        .animate_scale(
-            object,
-            Vec2::ONE,
-            Vec2::ONE,
-            TrackTiming::new(0.25, 0.25, Easing::Linear),
-        )
-        .unwrap();
-    let mut identity_native = SceneInstance::new(CompiledScene::compile(&identity_scene).unwrap());
-    let mut identity_retained =
-        SceneInstance::new(CompiledScene::compile(&identity_scene).unwrap());
+    identity_tracks[0] = identity_track;
+    identity_tracks.push(TrackDefinition {
+        id: TrackId::new(identity_tracks.len() as u64),
+        object,
+        property: Property::Scale,
+        values: TrackValues::Vec2 {
+            from: Vec2::ONE,
+            to: Vec2::ONE,
+        },
+        timing: TrackTiming::new(0.25, 0.25, Easing::Linear),
+        time_map: CompositionTimeMap::identity(),
+    });
+    let mut identity_native = SceneInstance::new(
+        CompiledScene::compile_objects(objects.clone(), &identity_tracks).unwrap(),
+    );
+    let mut identity_retained = SceneInstance::new(
+        CompiledScene::compile_objects(objects.clone(), &identity_tracks).unwrap(),
+    );
     let native_resource = identity_native.seek(0.1).unwrap().render_geometries[0]
         .clone()
         .unwrap();

--- a/crates/noon-runtime/tests/matching_shapes.rs
+++ b/crates/noon-runtime/tests/matching_shapes.rs
@@ -1,71 +1,151 @@
-use noon_compile::CompiledScene;
-use noon_core::{Easing, GeometryRef, ObjectSnapshot, SceneDefinition, TrackTiming, Vec2};
+use noon_compile::{CompiledObject, CompiledScene};
+use noon_core::{
+    CompositionTimeMap, Easing, GeometryRef, ObjectId, Property, Style, TrackDefinition, TrackId,
+    TrackTiming, TrackValues, Transform2D, TransformTrackEndpoint, Vec2,
+};
 use noon_runtime::SceneInstance;
 
 fn matching_scene() -> CompiledScene {
-    let mut scene = SceneDefinition::new();
-    let source_circle = scene.add(GeometryRef::circle(1.0));
-    let source_rectangle = scene.add(GeometryRef::rectangle(2.0, 1.0));
-    let target_circle = scene.add(GeometryRef::circle(2.0));
-    let target_rectangle = scene.add(GeometryRef::rectangle(4.0, 2.0));
+    let mut objects = Vec::new();
+    let mut tracks = Vec::new();
+    let source_circle = ObjectId::new(objects.len() as u64);
+    objects.push(CompiledObject::new(
+        source_circle,
+        GeometryRef::circle(1.0),
+        Transform2D::IDENTITY,
+        Style::default(),
+    ));
+    let source_rectangle = ObjectId::new(objects.len() as u64);
+    objects.push(CompiledObject::new(
+        source_rectangle,
+        GeometryRef::rectangle(2.0, 1.0),
+        Transform2D::IDENTITY,
+        Style::default(),
+    ));
+    let target_circle = ObjectId::new(objects.len() as u64);
+    objects.push(CompiledObject::new(
+        target_circle,
+        GeometryRef::circle(2.0),
+        Transform2D::IDENTITY,
+        Style::default(),
+    ));
+    let target_rectangle = ObjectId::new(objects.len() as u64);
+    objects.push(CompiledObject::new(
+        target_rectangle,
+        GeometryRef::rectangle(4.0, 2.0),
+        Transform2D::IDENTITY,
+        Style::default(),
+    ));
 
-    scene
-        .object_mut(target_circle)
-        .expect("target circle exists")
-        .transform
+    objects[target_circle.get() as usize]
+        .base_transform
         .translation = Vec2::new(3.0, 1.0);
-    scene
-        .object_mut(target_rectangle)
-        .expect("target rectangle exists")
-        .transform
+    objects[target_rectangle.get() as usize]
+        .base_transform
         .translation = Vec2::new(-2.0, -1.0);
 
-    let source_circle_snapshot =
-        ObjectSnapshot::from(scene.object(source_circle).expect("source circle exists"));
-    let source_rectangle_snapshot = ObjectSnapshot::from(
-        scene
-            .object(source_rectangle)
-            .expect("source rectangle exists"),
-    );
-    let target_circle_snapshot =
-        ObjectSnapshot::from(scene.object(target_circle).expect("target circle exists"));
-    let target_rectangle_snapshot = ObjectSnapshot::from(
-        scene
-            .object(target_rectangle)
-            .expect("target rectangle exists"),
-    );
+    let source_circle_snapshot = TransformTrackEndpoint {
+        geometry: objects[source_circle.get() as usize]
+            .geometry()
+            .unwrap()
+            .clone(),
+        transform: objects[source_circle.get() as usize].base_transform,
+        style: objects[source_circle.get() as usize].base_style,
+    };
+    let source_rectangle_snapshot = TransformTrackEndpoint {
+        geometry: objects[source_rectangle.get() as usize]
+            .geometry()
+            .unwrap()
+            .clone(),
+        transform: objects[source_rectangle.get() as usize].base_transform,
+        style: objects[source_rectangle.get() as usize].base_style,
+    };
+    let target_circle_snapshot = TransformTrackEndpoint {
+        geometry: objects[target_circle.get() as usize]
+            .geometry()
+            .unwrap()
+            .clone(),
+        transform: objects[target_circle.get() as usize].base_transform,
+        style: objects[target_circle.get() as usize].base_style,
+    };
+    let target_rectangle_snapshot = TransformTrackEndpoint {
+        geometry: objects[target_rectangle.get() as usize]
+            .geometry()
+            .unwrap()
+            .clone(),
+        transform: objects[target_rectangle.get() as usize].base_transform,
+        style: objects[target_rectangle.get() as usize].base_style,
+    };
 
-    scene
-        .animate_transform(
-            source_circle,
-            source_circle_snapshot,
-            target_circle_snapshot,
-            TrackTiming::new(0.0, 2.0, Easing::Linear),
-        )
-        .expect("circle match transform is valid");
-    scene
-        .animate_transform(
-            source_rectangle,
-            source_rectangle_snapshot,
-            target_rectangle_snapshot,
-            TrackTiming::new(0.0, 2.0, Easing::Linear),
-        )
-        .expect("rectangle match transform is valid");
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object: source_circle,
+        property: Property::Transform,
+        values: TrackValues::Object {
+            from: source_circle_snapshot,
+            to: target_circle_snapshot,
+        },
+        timing: TrackTiming::new(0.0, 2.0, Easing::Linear),
+        time_map: CompositionTimeMap::identity(),
+    });
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object: source_rectangle,
+        property: Property::Transform,
+        values: TrackValues::Object {
+            from: source_rectangle_snapshot,
+            to: target_rectangle_snapshot,
+        },
+        timing: TrackTiming::new(0.0, 2.0, Easing::Linear),
+        time_map: CompositionTimeMap::identity(),
+    });
 
-    scene
-        .set_presence_at(source_circle, true, false, 2.0)
-        .expect("source circle hide is valid");
-    scene
-        .set_presence_at(target_circle, false, true, 2.0)
-        .expect("target circle show is valid");
-    scene
-        .set_presence_at(source_rectangle, true, false, 2.0)
-        .expect("source rectangle hide is valid");
-    scene
-        .set_presence_at(target_rectangle, false, true, 2.0)
-        .expect("target rectangle show is valid");
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object: source_circle,
+        property: Property::Presence,
+        values: TrackValues::Bool {
+            from: true,
+            to: false,
+        },
+        timing: TrackTiming::instant(2.0),
+        time_map: CompositionTimeMap::identity(),
+    });
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object: target_circle,
+        property: Property::Presence,
+        values: TrackValues::Bool {
+            from: false,
+            to: true,
+        },
+        timing: TrackTiming::instant(2.0),
+        time_map: CompositionTimeMap::identity(),
+    });
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object: source_rectangle,
+        property: Property::Presence,
+        values: TrackValues::Bool {
+            from: true,
+            to: false,
+        },
+        timing: TrackTiming::instant(2.0),
+        time_map: CompositionTimeMap::identity(),
+    });
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object: target_rectangle,
+        property: Property::Presence,
+        values: TrackValues::Bool {
+            from: false,
+            to: true,
+        },
+        timing: TrackTiming::instant(2.0),
+        time_map: CompositionTimeMap::identity(),
+    });
 
-    CompiledScene::compile(&scene).expect("matching-shape lowering must compile")
+    CompiledScene::compile_objects(objects, &tracks).expect("matching-shape lowering must compile")
 }
 
 #[test]

--- a/crates/noon-runtime/tests/replacement_transform.rs
+++ b/crates/noon-runtime/tests/replacement_transform.rs
@@ -1,39 +1,80 @@
-use noon_compile::CompiledScene;
+use noon_compile::{CompiledObject, CompiledScene};
 use noon_core::{
-    Easing, GeometryRef, ObjectSnapshot, SceneDefinition, TrackTiming, Transform2D, Vec2,
+    CompositionTimeMap, Easing, GeometryRef, ObjectId, Property, Style, TrackDefinition, TrackId,
+    TrackTiming, TrackValues, Transform2D, TransformTrackEndpoint, Vec2,
 };
 use noon_runtime::SceneInstance;
 
 fn replacement_scene() -> (CompiledScene, noon_core::ObjectId, noon_core::ObjectId) {
-    let mut scene = SceneDefinition::new();
-    let source = scene.add(GeometryRef::circle(1.0));
-    let target = scene.add(GeometryRef::circle(3.0));
+    let mut objects = Vec::new();
+    let mut tracks = Vec::new();
+    let source = ObjectId::new(objects.len() as u64);
+    objects.push(CompiledObject::new(
+        source,
+        GeometryRef::circle(1.0),
+        Transform2D::IDENTITY,
+        Style::default(),
+    ));
+    let target = ObjectId::new(objects.len() as u64);
+    objects.push(CompiledObject::new(
+        target,
+        GeometryRef::circle(3.0),
+        Transform2D::IDENTITY,
+        Style::default(),
+    ));
 
-    scene.object_mut(target).expect("target exists").transform = Transform2D {
+    objects[target.get() as usize].base_transform = Transform2D {
         translation: Vec2::new(4.0, -2.0),
         ..Transform2D::IDENTITY
     };
 
-    let source_snapshot = ObjectSnapshot::from(scene.object(source).expect("source exists"));
-    let target_snapshot = ObjectSnapshot::from(scene.object(target).expect("target exists"));
+    let source_snapshot = TransformTrackEndpoint {
+        geometry: objects[source.get() as usize].geometry().unwrap().clone(),
+        transform: objects[source.get() as usize].base_transform,
+        style: objects[source.get() as usize].base_style,
+    };
+    let target_snapshot = TransformTrackEndpoint {
+        geometry: objects[target.get() as usize].geometry().unwrap().clone(),
+        transform: objects[target.get() as usize].base_transform,
+        style: objects[target.get() as usize].base_style,
+    };
 
-    scene
-        .animate_transform(
-            source,
-            source_snapshot,
-            target_snapshot,
-            TrackTiming::new(0.0, 2.0, Easing::Linear),
-        )
-        .expect("replacement transform must be valid");
-    scene
-        .set_presence_at(source, true, false, 2.0)
-        .expect("source handoff must be valid");
-    scene
-        .set_presence_at(target, false, true, 2.0)
-        .expect("target handoff must be valid");
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object: source,
+        property: Property::Transform,
+        values: TrackValues::Object {
+            from: source_snapshot,
+            to: target_snapshot,
+        },
+        timing: TrackTiming::new(0.0, 2.0, Easing::Linear),
+        time_map: CompositionTimeMap::identity(),
+    });
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object: source,
+        property: Property::Presence,
+        values: TrackValues::Bool {
+            from: true,
+            to: false,
+        },
+        timing: TrackTiming::instant(2.0),
+        time_map: CompositionTimeMap::identity(),
+    });
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object: target,
+        property: Property::Presence,
+        values: TrackValues::Bool {
+            from: false,
+            to: true,
+        },
+        timing: TrackTiming::instant(2.0),
+        time_map: CompositionTimeMap::identity(),
+    });
 
     (
-        CompiledScene::compile(&scene).expect("replacement scene must compile"),
+        CompiledScene::compile_objects(objects, &tracks).expect("replacement scene must compile"),
         source,
         target,
     )

--- a/crates/noon-runtime/tests/transform_from_copy.rs
+++ b/crates/noon-runtime/tests/transform_from_copy.rs
@@ -1,50 +1,105 @@
-use noon_compile::CompiledScene;
+use noon_compile::{CompiledObject, CompiledScene};
 use noon_core::{
-    Easing, GeometryRef, ObjectId, ObjectSnapshot, SceneDefinition, TrackTiming, Transform2D, Vec2,
+    CompositionTimeMap, Easing, GeometryRef, ObjectId, Property, Style, TrackDefinition, TrackId,
+    TrackTiming, TrackValues, Transform2D, TransformTrackEndpoint, Vec2,
 };
 use noon_runtime::SceneInstance;
 
 fn copy_scene() -> (CompiledScene, ObjectId, ObjectId, ObjectId) {
-    let mut scene = SceneDefinition::new();
-    let source = scene.add(GeometryRef::circle(1.0));
-    let target = scene.add(GeometryRef::circle(3.0));
-    let copy = scene.add(GeometryRef::circle(1.0));
+    let mut objects = Vec::new();
+    let mut tracks = Vec::new();
+    let source = ObjectId::new(objects.len() as u64);
+    objects.push(CompiledObject::new(
+        source,
+        GeometryRef::circle(1.0),
+        Transform2D::IDENTITY,
+        Style::default(),
+    ));
+    let target = ObjectId::new(objects.len() as u64);
+    objects.push(CompiledObject::new(
+        target,
+        GeometryRef::circle(3.0),
+        Transform2D::IDENTITY,
+        Style::default(),
+    ));
+    let copy = ObjectId::new(objects.len() as u64);
+    objects.push(CompiledObject::new(
+        copy,
+        GeometryRef::circle(1.0),
+        Transform2D::IDENTITY,
+        Style::default(),
+    ));
 
-    scene.object_mut(source).expect("source exists").transform = Transform2D {
+    objects[source.get() as usize].base_transform = Transform2D {
         translation: Vec2::new(-2.0, 0.0),
         ..Transform2D::IDENTITY
     };
-    scene.object_mut(copy).expect("copy exists").transform = Transform2D {
+    objects[copy.get() as usize].base_transform = Transform2D {
         translation: Vec2::new(-2.0, 0.0),
         ..Transform2D::IDENTITY
     };
-    scene.object_mut(target).expect("target exists").transform = Transform2D {
+    objects[target.get() as usize].base_transform = Transform2D {
         translation: Vec2::new(4.0, -2.0),
         ..Transform2D::IDENTITY
     };
 
-    let source_snapshot = ObjectSnapshot::from(scene.object(source).expect("source exists"));
-    let target_snapshot = ObjectSnapshot::from(scene.object(target).expect("target exists"));
-    scene
-        .animate_transform(
-            copy,
-            source_snapshot,
-            target_snapshot,
-            TrackTiming::new(1.0, 2.0, Easing::Linear),
-        )
-        .expect("copy transform must be valid");
-    scene
-        .set_presence_at(copy, false, true, 1.0)
-        .expect("copy show must be valid");
-    scene
-        .set_presence_at(copy, true, false, 3.0)
-        .expect("copy hide must be valid");
-    scene
-        .set_presence_at(target, false, true, 3.0)
-        .expect("target handoff must be valid");
+    let source_snapshot = TransformTrackEndpoint {
+        geometry: objects[source.get() as usize].geometry().unwrap().clone(),
+        transform: objects[source.get() as usize].base_transform,
+        style: objects[source.get() as usize].base_style,
+    };
+    let target_snapshot = TransformTrackEndpoint {
+        geometry: objects[target.get() as usize].geometry().unwrap().clone(),
+        transform: objects[target.get() as usize].base_transform,
+        style: objects[target.get() as usize].base_style,
+    };
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object: copy,
+        property: Property::Transform,
+        values: TrackValues::Object {
+            from: source_snapshot,
+            to: target_snapshot,
+        },
+        timing: TrackTiming::new(1.0, 2.0, Easing::Linear),
+        time_map: CompositionTimeMap::identity(),
+    });
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object: copy,
+        property: Property::Presence,
+        values: TrackValues::Bool {
+            from: false,
+            to: true,
+        },
+        timing: TrackTiming::instant(1.0),
+        time_map: CompositionTimeMap::identity(),
+    });
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object: copy,
+        property: Property::Presence,
+        values: TrackValues::Bool {
+            from: true,
+            to: false,
+        },
+        timing: TrackTiming::instant(3.0),
+        time_map: CompositionTimeMap::identity(),
+    });
+    tracks.push(TrackDefinition {
+        id: TrackId::new(tracks.len() as u64),
+        object: target,
+        property: Property::Presence,
+        values: TrackValues::Bool {
+            from: false,
+            to: true,
+        },
+        timing: TrackTiming::instant(3.0),
+        time_map: CompositionTimeMap::identity(),
+    });
 
     (
-        CompiledScene::compile(&scene).expect("copy scene must compile"),
+        CompiledScene::compile_objects(objects, &tracks).expect("copy scene must compile"),
         source,
         target,
         copy,

--- a/scripts/architecture-ratchet.test.sh
+++ b/scripts/architecture-ratchet.test.sh
@@ -493,9 +493,9 @@ for symbol in SlottedSceneInstance FrameSlotId RetiredSlotCompactionPolicy Execu
 done
 git rm -q src/runtime_wrapper_probe.rs
 git commit -qm 'remove retired runtime wrapper probe'
-# Renderer fixtures must not preserve a second scene API, even when committed
+# Renderer and runtime fixtures must not preserve a second scene API, even when committed
 # before the comparison base.
-for canonical in crates/noon-render-wgpu/src/probe.rs crates/noon-render-wgpu/tests/probe.rs; do
+for canonical in crates/noon-render-wgpu/src/probe.rs crates/noon-render-wgpu/tests/probe.rs crates/noon-runtime/src/scene_probe.rs crates/noon-runtime/tests/scene_probe.rs; do
   mkdir -p "$(dirname "$canonical")"
   for symbol in SceneDefinition ObjectDefinition ObjectSnapshot ScenePatch MutationTransaction; do
     printf 'use noon_core::%s;\n' "$symbol" > "$canonical"

--- a/scripts/architecture_migration_relocations.py
+++ b/scripts/architecture_migration_relocations.py
@@ -140,10 +140,10 @@ def main() -> int:
             errors.append(f'{path}: retired runtime wrapper returned; use ExecutionSession and shared runtime slots')
         if re.search(r'\bFrontendMobjectHandle\b', source):
             errors.append(f'{path}: deleted FrontendMobjectHandle authority returned')
-        if path.startswith('crates/noon-render-wgpu/'):
+        if path.startswith(('crates/noon-render-wgpu/', 'crates/noon-runtime/')):
             code = re.sub(r'/\*.*?\*/|//[^\n]*', '', source, flags=re.S)
             if re.search(r'\b(?:SceneDefinition|ObjectDefinition|ObjectSnapshot|ScenePatch|MutationTransaction)\b', code):
-                errors.append(f'{path}: renderer code and fixtures must use typed execution data')
+                errors.append(f'{path}: renderer/runtime code and fixtures must use typed execution data')
         if path in {'crates/noon/src/scene.rs', 'crates/noon/src/semantic_mobject.rs'} or path.startswith(('crates/noon/src/scene/', 'crates/noon/src/semantic_mobject/')):
             if FORBIDDEN_CANONICAL.search(source) or any('legacy' in leaf.split(' as ', 1)[0].split('::') for _, leaf in imports(source)):
                 errors.append(f'{path}: canonical authoring regained a migration dependency')


### PR DESCRIPTION
Moves the remaining runtime timeline and transform fixtures off the legacy scene builder and onto existing `CompiledObject`, `TrackDefinition`, and `TransformTrackEndpoint` inputs. Advances Phase A4 (#959, #953) and enables deletion of the flat scene/compiler codecs without losing runtime regression coverage.

All runtime source and integration fixtures are now free of `SceneDefinition`, `ObjectDefinition`, `ObjectSnapshot`, `ScenePatch`, and `MutationTransaction`. A full-tree guard rejects their return, including when a bad reference already exists at the comparison base.

The 150 runtime tests retain their behavioral assertions: analytic/generic/cross-geometry transforms; Manim path correspondence and retained resource identity; copy/replacement/chained family visibility; appearance/reveal/morph independence; exact instant assignments; direct seek/forward/rewind agreement; sparse 50,000-track history; and local frame dirtiness. The instant-input validation test calls the existing track validator directly. No fixture scene class, identity allocator, compatibility adapter, scheduler, or engine path was introduced.

This changes fixtures and deletion guards, not shared public behavior. Existing Rust/Python examples and the native/direct Rust-WASM paths remain unchanged. `RetainedObjectDefinition` in the older family-plan builder fixtures is separate remaining #959 work; this PR does not claim every legacy type is gone.

Validation performed:
- `cargo fmt --all`
- `bash scripts/check.sh architecture`
- `bash scripts/architecture-ratchet.test.sh`
- `cargo test -p noon-runtime --lib --tests` — 150 passed
- `cargo clippy -p noon-runtime --all-targets -- -D warnings`
- `git diff --check`

Rust commands use `CARGO_TARGET_DIR=/tmp/noon-geometry-check CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0`. Hosted CI is the full qualification gate; heavy local WASM/workspace builds were not run.
