### PR TITLE
Fix stale source notifications from the Python editor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,9 @@ jobs:
       - name: Test required slow callbacks preserve shared execution order
         run: node scripts/execution-worker-host-smoke.mjs
       - name: Test Python editor highlighting and linting
-        run: node scripts/python-editor-smoke.mjs
+        run: |
+          node scripts/python-editor-input-smoke.mjs
+          node scripts/python-editor-smoke.mjs
 
   browser-rendering:
     name: Browser rendering (${{ matrix.backend }})

--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -147,6 +147,9 @@ jobs:
           npm install --no-save --ignore-scripts playwright@1.62.1 pngjs@7.0.0
           npx playwright install chromium
 
+      - name: Check editor input and Reset without engine startup
+        run: node scripts/python-editor-input-smoke.mjs
+
       - name: Check preloaded cold-start footprint
         if: steps.browser-risk.outputs.cold_start == 'true'
         id: cold-start

--- a/scripts/build-web-demo.sh
+++ b/scripts/build-web-demo.sh
@@ -63,6 +63,7 @@ if [[ "$skip_web_preflight" != "1" ]]; then
   node --check scripts/cross-language-parity.mjs
   node --check scripts/manim-compat-smoke.mjs
   node --check scripts/manim-tutorial-smoke.mjs
+  node --check scripts/python-editor-input-smoke.mjs
   node --check scripts/playground-layout-smoke.mjs
   node --check scripts/composition-authoring-smoke.mjs
   node --check scripts/reactive-authoring-smoke.mjs

--- a/scripts/python-editor-input-smoke.mjs
+++ b/scripts/python-editor-input-smoke.mjs
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { chromium } from "playwright";
+
+// Exercise the real enhanced editor without loading Python, WASM or a renderer.
+const editorSource = await readFile(new URL("../web/python-editor.js", import.meta.url), "utf8");
+const browser = await chromium.launch({ headless: true });
+try {
+  const page = await browser.newPage();
+  const errors = [];
+  const ruffRequests = [];
+  page.on("pageerror", (error) => errors.push(String(error)));
+  page.on("request", (request) => {
+    if (request.url().includes("ruff-wasm")) ruffRequests.push(request.url());
+  });
+  await page.route("http://editor.test/**", (route) => {
+    const isModule = route.request().url().endsWith("/editor.js");
+    return route.fulfill({
+      contentType: isModule ? "text/javascript" : "text/html",
+      body: isModule ? editorSource : `<!doctype html>
+        <textarea id="python-scene-source">original</textarea>
+        <button id="reset" disabled>Reset</button>
+        <script>
+          const textarea = document.querySelector("textarea");
+          const reset = document.querySelector("button");
+          window.observedSources = [];
+          textarea.addEventListener("input", () => {
+            observedSources.push(textarea.value);
+            reset.disabled = textarea.value === "original";
+          });
+          reset.onclick = () => {
+            textarea.value = "original";
+            reset.disabled = true;
+          };
+        </script>
+        <script type="module" src="/editor.js"></script>`,
+    });
+  });
+  await page.goto("http://editor.test/");
+  await page.waitForSelector(".python-code-editor[data-editor-ready='true']");
+  const snapshot = () => page.evaluate(() => ({
+    source: document.querySelector("textarea").value,
+    observed: window.observedSources.slice(),
+    resetDisabled: document.querySelector("button").disabled,
+  }));
+
+  // Gallery loads and Reset project source without scheduling a user edit.
+  await page.evaluate(() => { document.querySelector("textarea").value = "loaded"; });
+  assert.deepEqual(await snapshot(), { source: "loaded", observed: [], resetDisabled: true });
+  assert.equal(ruffRequests.length, 0, "programmatic source loads must not activate Ruff");
+
+  const content = page.locator(".cm-content");
+  await content.fill("draft");
+  assert.deepEqual(await snapshot(), {
+    source: "draft", observed: ["draft"], resetDisabled: false,
+  }, "the first input must publish the committed document and enable Reset");
+
+  await content.press("End");
+  await content.press("x");
+  let state = await snapshot();
+  assert.equal(state.source, "draftx");
+  assert.equal(state.observed.at(-1), "draftx", "keyboard edits must not publish the previous value");
+
+  for (const key of ["ControlOrMeta+z", "ControlOrMeta+Shift+z"]) {
+    const previous = state;
+    await content.press(key);
+    state = await snapshot();
+    assert.notEqual(state.source, previous.source, `${key} must change the document`);
+    assert.equal(state.observed.length, previous.observed.length + 1);
+    assert.equal(state.observed.at(-1), state.source, `${key} must publish its committed source`);
+  }
+  assert.equal(state.source, "draftx", "redo must restore the edited source");
+
+  await page.locator("#reset").click();
+  assert.deepEqual(await snapshot(), {
+    source: "original", observed: state.observed, resetDisabled: true,
+  }, "Reset must restore source without generating another user edit");
+  assert.deepEqual(errors, []);
+  console.log("Python editor input smoke passed: committed edits, undo/redo, Reset and source projection.");
+} finally {
+  await browser.close();
+}

--- a/scripts/python-editor-input-smoke.mjs
+++ b/scripts/python-editor-input-smoke.mjs
@@ -61,7 +61,8 @@ try {
   assert.equal(state.source, "draftx");
   assert.equal(state.observed.at(-1), "draftx", "keyboard edits must not publish the previous value");
 
-  for (const key of ["ControlOrMeta+z", "ControlOrMeta+Shift+z"]) {
+  const redo = process.platform === "darwin" ? "Meta+Shift+z" : "Control+y";
+  for (const key of ["ControlOrMeta+z", redo]) {
     const previous = state;
     await content.press(key);
     state = await snapshot();

--- a/web/python-editor.js
+++ b/web/python-editor.js
@@ -41,7 +41,7 @@ async function enhancePythonEditors() {
     return;
   }
 
-  const [{ EditorView, basicSetup }, { python }, { linter, lintGutter, forceLinting }, { oneDark }] =
+  const [{ EditorView, basicSetup }, { python }, { linter, lintGutter }, { oneDark }] =
     await Promise.all([
       import(CODEMIRROR_URL),
       import(PYTHON_URL),
@@ -85,6 +85,7 @@ async function enhancePythonEditors() {
     host.className = "python-code-editor";
     textarea.before(host);
 
+    let projectingSource = false;
     const view = new EditorView({
       doc: textarea.value,
       parent: host,
@@ -96,6 +97,14 @@ async function enhancePythonEditors() {
         lintGutter(),
         linter(runRuff, { delay: 300 }),
         EditorView.lineWrapping,
+        EditorView.updateListener.of((update) => {
+          if (!update.docChanged || projectingSource) return;
+          // DOM input fires before CodeMirror commits its document. Publish
+          // only committed edits, including undo/redo, so draft and live-run
+          // consumers read the source that actually triggered the notification.
+          ruffEnabledViews.add(update.view);
+          textarea.dispatchEvent(new Event("input", { bubbles: true }));
+        }),
       ],
     });
 
@@ -113,12 +122,6 @@ async function enhancePythonEditors() {
     // draft/reset state and any other existing consumers. Ruff is intentionally
     // activated by the first real editor input so merely inspecting source does
     // not allocate its additional WASM runtime.
-    view.contentDOM.addEventListener("input", () => {
-      ruffEnabledViews.add(view);
-      forceLinting(view);
-      textarea.dispatchEvent(new Event("input", { bubbles: true }));
-    });
-
     Object.defineProperty(textarea, "value", {
       configurable: true,
       get() {
@@ -130,9 +133,14 @@ async function enhancePythonEditors() {
         if (next === current) {
           return;
         }
-        view.dispatch({
-          changes: { from: 0, to: view.state.doc.length, insert: next },
-        });
+        projectingSource = true;
+        try {
+          view.dispatch({
+            changes: { from: 0, to: view.state.doc.length, insert: next },
+          });
+        } finally {
+          projectingSource = false;
+        }
       },
     });
 


### PR DESCRIPTION
The enhanced Python editor dispatched textarea input events before CodeMirror committed its document. A first edit could publish the previous source to draft, Reset and live authoring listeners. The focused browser reproduction observes `loaded` when the editor already displays `draft`.

Publish document changes through CodeMirror's update listener, including undo/redo. Programmatic source loads and Reset stay silent through a scoped projection guard. Ruff still activates only after an edit and uses its existing delayed linter. No scene/runtime or transport change; this fixes browser host correctness under #953/#955.

Add an engine-independent browser regression for first edit, keyboard input, undo/redo, Reset and source projection. Run it in PR Fast and full CI before the existing editor/runtime smoke. The regression fails on the old implementation and passes on the fix. Existing full editor smoke retains actual Ruff and Python/render integration coverage.

Validation:
- `node scripts/python-editor-input-smoke.mjs` — passed; confirmed failure on original source
- `node --test web/python-editor.test.mjs web/editor-runtime-boundary.test.mjs web/live-authoring-bootstrap.test.mjs web/playground-startup.test.mjs` — four passed
- `node --check scripts/python-editor-input-smoke.mjs`
- `bash scripts/check.sh architecture`
- `git diff --check`

This was found investigating the Reset failure in #1314's product gate. #1315's fully passing qualification includes #1314 and both have landed together. No fixed sleeps or relaxed Reset assertion were added. Hosted CI supplies the broader integration qualification; no local Rust/WASM rebuild was needed to reproduce this editor bug.
