### PR TITLE
Delete obsolete Python target-state and replacement fallbacks

### DIFF
--- a/web/python/_manim_compat.py
+++ b/web/python/_manim_compat.py
@@ -403,55 +403,15 @@ class VGroup(Group):
     pass
 
 
-def _state_target(
-    self: Mobject,
-    mobject: Mobject,
-    *,
-    match_height: bool,
-    match_width: bool,
-    match_depth: bool,
-    match_center: bool,
-    stretch: bool,
-) -> Mobject:
-    if not isinstance(mobject, Mobject):
-        raise TypeError("state target must be a Mobject")
-    if match_depth:
-        raise NotImplementedError("depth matching requires the shared 2.5D family model")
-    if not (match_height or match_width or match_center or stretch):
-        return mobject
-    target = mobject.copy()
-    if stretch:
-        if target.width == 0.0 or target.height == 0.0:
-            raise ValueError("cannot stretch a zero-width or zero-height target")
-        target.scale((self.width / target.width, self.height / target.height))
-    else:
-        if match_height:
-            if target.height == 0.0:
-                raise ValueError("cannot match height from a zero-height target")
-            target.scale(self.height / target.height)
-        if match_width:
-            if target.width == 0.0:
-                raise ValueError("cannot match width from a zero-width target")
-            target.scale(self.width / target.width)
-    if match_center:
-        target.move_to(self.get_center())
-    return target
-
-
 def _mobject_generate_target(self: Mobject, use_deepcopy: bool = False) -> Mobject:
-    """Create the detached target through the installed shared target editor."""
-    # Canonical Mobjects install `_copy_for_animate_target`, which delegates target
-    # capture to Rust.  This preserves effective-state capture for a live source and
-    # avoids using `copy()` as a second target-state model.  Plain compatibility
-    # objects retain their existing copy behavior until they have a typed handle.
+    """Capture a detached target through the shared Rust target editor."""
     del use_deepcopy
-    factory = getattr(self, "_copy_for_animate_target", None)
     previous = getattr(self, "target", None)
     # A target must not recursively clone the previously generated target chain.
     # Preserve the wrapper's previous target if shared capture is rejected.
     self.target = None
     try:
-        target = factory() if callable(factory) else self.copy()
+        target = self._copy_for_animate_target()
     except BaseException:
         self.target = previous
         raise
@@ -470,48 +430,6 @@ def _mobject_restore(self: Mobject) -> Mobject:
     if not hasattr(self, "saved_state") or self.saved_state is None:
         raise Exception("Trying to restore without having saved")
     return self.become(self.saved_state)
-
-
-def _mobject_become(
-    self: Mobject,
-    mobject: Mobject,
-    match_height: bool = False,
-    match_width: bool = False,
-    match_depth: bool = False,
-    match_center: bool = False,
-    stretch: bool = False,
-) -> Mobject:
-    target = _state_target(
-        self,
-        mobject,
-        match_height=match_height,
-        match_width=match_width,
-        match_depth=match_depth,
-        match_center=match_center,
-        stretch=stretch,
-    )
-    raise RuntimeError("Mobject become requires the shared Rust authoring host")
-
-
-def _mobject_replace(
-    self: Mobject, mobject: Mobject, dim_to_match: int = 0, stretch: bool = False
-) -> Mobject:
-    if not isinstance(mobject, Mobject):
-        raise TypeError("replacement target must be a Mobject")
-    if dim_to_match not in (0, 1):
-        raise NotImplementedError("replace currently supports width (0) or height (1)")
-    if stretch:
-        if self.width == 0.0 or self.height == 0.0:
-            raise ValueError("cannot stretch-replace an object with zero width or height")
-        self.scale((mobject.width / self.width, mobject.height / self.height))
-    else:
-        source_length = self.width if dim_to_match == 0 else self.height
-        target_length = mobject.width if dim_to_match == 0 else mobject.height
-        if source_length == 0.0:
-            raise ValueError("cannot replace along a zero-length dimension")
-        self.scale(target_length / source_length)
-    self.move_to(mobject.get_center())
-    return self
 
 
 class MoveToTarget:

--- a/web/python/_manim_semantic_handles.py
+++ b/web/python/_manim_semantic_handles.py
@@ -1117,22 +1117,8 @@ def _become(
             handle.becomeHandle(other_handle, *flags)
         return self
 
-    has_typed_operand = any(
-        getattr(value, "_semantic_handle", None) is not None
-        for value in (self, mobject)
-    )
-    if has_typed_operand:
-        raise NotImplementedError(
-            "become requires valid shared semantic handles for both Mobjects"
-        )
-    return _compat._mobject_become(
-        self,
-        mobject,
-        match_height=match_height,
-        match_width=match_width,
-        match_depth=match_depth,
-        match_center=match_center,
-        stretch=stretch,
+    raise NotImplementedError(
+        "become requires valid shared semantic handles for both Mobjects"
     )
 
 
@@ -1142,16 +1128,19 @@ def _replace(
     dim_to_match: int = 0,
     stretch: bool = False,
 ) -> _base.Mobject:
-    if _live_mutation_context(self) is not None:
+    if not isinstance(mobject, _base.Mobject):
+        raise TypeError("replacement target must be a Mobject")
+    if dim_to_match not in (0, 1):
+        raise NotImplementedError("replace currently supports width (0) or height (1)")
+    if (_live_mutation_context(self) is not None
+            or _live_mutation_context(mobject) is not None):
         raise NotImplementedError("canonical live affine targets do not support replace")
-    handle = _detached_handle_for(self)
-    other_handle = _detached_handle_for(mobject)
-    if handle is not None and other_handle is not None:
-        if dim_to_match not in (0, 1):
-            raise NotImplementedError("replace currently supports width (0) or height (1)")
-        handle.replaceHandle(other_handle, int(dim_to_match), bool(stretch))
-        return self
-    return _compat._mobject_replace(self, mobject, dim_to_match=dim_to_match, stretch=stretch)
+    handle = _handle_for(self)
+    other_handle = _handle_for(mobject)
+    if handle is None or other_handle is None:
+        raise NotImplementedError("replace requires valid shared semantic handles for both Mobjects")
+    handle.replaceHandle(other_handle, int(dim_to_match), bool(stretch))
+    return self
 
 
 def _critical(value: _base.Mobject, direction: _base.Vec2) -> _base.Vec2:

--- a/web/python/test_manim_scene_bound_semantic_handles.py
+++ b/web/python/test_manim_scene_bound_semantic_handles.py
@@ -394,6 +394,19 @@ class ManimSceneBoundSemanticHandleTests(unittest.TestCase):
             else:
                 raise AssertionError("half-typed become fell back through raw geometry")
 
+            # Unsupported operands must fail before copying/scaling a target.
+            for operand in (half_typed, detached_source):
+                operand._semantic_handle_fresh = False
+                operand.copy = lambda: (_ for _ in ()).throw(AssertionError("untyped target was copied"))
+                operand.scale = lambda *args: (_ for _ in ()).throw(AssertionError("untyped target was scaled"))
+            for operation in ("become", "replace"):
+                try:
+                    getattr(detached_source, operation)(half_typed, stretch=True)
+                except NotImplementedError as error:
+                    assert "both Mobjects" in str(error)
+                else:
+                    raise AssertionError(operation + " admitted untyped operands")
+
             bindings_before = dict(scene._binding_handles)
             square.set_fill(GREEN, opacity=0.25)
             assert handle.snapshot_requests == 0


### PR DESCRIPTION
Advances #61 / #959 after #1329. Delete Python target-state arithmetic and obsolete become/replace fallbacks. The become fallback only copied/resized a target before unconditionally raising; unsupported operands now reject before any copy or mutation. Authored replace uses its existing shared Rust operation for both detached and scene-bound wrappers; live replace remains explicitly unsupported. Generate-target calls the shared target editor directly and retains rollback of the previous target if capture fails.

No new authority, protocol, adapter or algorithm. Delete unreachable target matching math instead of keeping a second implementation. Existing paired become/target examples remain qualification evidence. Focused dispatch regression poisons copy/scale on invalid operands and requires both become and replace to reject without touching them.

Validation: all 151 Python tests passed after integrating merged #1328/#1329; `NOON_WEB_PREFLIGHT_ONLY=1 bash scripts/build-web-demo.sh`, `bash scripts/check.sh architecture` and `git diff --check` passed. Hosted browser qualification is required before merge.
