### PR TITLE
Require shared Rust placement and remove Python fallbacks

### DIFF
--- a/compat/semantic-ownership-v1.json
+++ b/compat/semantic-ownership-v1.json
@@ -111,6 +111,14 @@
       "reason": "Python coerces Manim vector arguments; Rust chooses aligned critical points, applies coordinate masks, and performs the translation."
     },
     {
+      "id": "mobject.family-target-placement",
+      "surface": "Object move_to/align_to with family targets; live object move_to with family targets",
+      "classification": "shared-rust",
+      "owner": {"language": "rust", "path": "crates/noon/src/family_layout.rs", "symbol": "LayoutAnchor::layout; FamilyLayout::move_to/align_to"},
+      "adapters": [{"language": "python", "path": "web/python/_manim_semantic_handles.py", "symbol": "_move_to/_align_to"}],
+      "reason": "Python forwards typed anchors. Rust observes authored or live effective bounds and commits one local translation. Invalid handles cannot fall back to Python critical-point arithmetic; live align_to remains unsupported."
+    },
+    {
       "id": "mobject.scale",
       "surface": "Detached and animate-target Mobject.scale",
       "classification": "shared-rust",

--- a/crates/noon-web/src/authoring_mobject.rs
+++ b/crates/noon-web/src/authoring_mobject.rs
@@ -241,6 +241,43 @@ mod wasm {
 
     #[wasm_bindgen]
     impl WasmLayoutAnchor {
+        #[wasm_bindgen(js_name = moveTo)]
+        pub fn move_to(
+            &self,
+            target: &WasmLayoutAnchor,
+            edge_x: f64,
+            edge_y: f64,
+            mask_x: f64,
+            mask_y: f64,
+        ) -> Result<(), JsValue> {
+            self.anchor
+                .layout()
+                .map_err(js_error)?
+                .move_to(
+                    noon::FamilyLayoutTarget::Anchor(&target.anchor),
+                    (edge_x, edge_y),
+                    (mask_x, mask_y),
+                )
+                .map_err(js_error)
+        }
+
+        #[wasm_bindgen(js_name = alignTo)]
+        pub fn align_to(
+            &self,
+            target: &WasmLayoutAnchor,
+            axis_x: f64,
+            axis_y: f64,
+        ) -> Result<(), JsValue> {
+            self.anchor
+                .layout()
+                .map_err(js_error)?
+                .align_to(
+                    noon::FamilyLayoutTarget::Anchor(&target.anchor),
+                    (axis_x, axis_y),
+                )
+                .map_err(js_error)
+        }
+
         #[wasm_bindgen(js_name = rescaleToFit)]
         pub fn rescale_to_fit(
             &self,

--- a/crates/noon-web/src/canonical_authoring_scene.rs
+++ b/crates/noon-web/src/canonical_authoring_scene.rs
@@ -5358,6 +5358,32 @@ mod wasm {
                 .map_err(js_error)
         }
 
+        #[wasm_bindgen(js_name = liveMoveToLayout)]
+        pub fn live_move_to_layout(
+            &mut self,
+            handle: &crate::WasmAuthoringMobjectHandle,
+            target: &crate::authoring_mobject::WasmLayoutAnchor,
+            edge_x: f64,
+            edge_y: f64,
+            mask_x: f64,
+            mask_y: f64,
+        ) -> Result<(), JsValue> {
+            handle.id_in_store(
+                self.inner.scene.integration_store(),
+                "live execution context",
+            )?;
+            self.inner
+                .active_live_player()
+                .map_err(js_error)?
+                .live_move_to(
+                    handle.semantic_mobject(),
+                    noon::LiveLayoutTarget::Anchor(&target.anchor),
+                    (edge_x, edge_y),
+                    (mask_x, mask_y),
+                )
+                .map_err(js_error)
+        }
+
         #[wasm_bindgen(js_name = liveMoveToPoint)]
         #[allow(clippy::too_many_arguments)]
         pub fn live_move_to_point(

--- a/crates/noon/src/example_scenes/family_placement.rs
+++ b/crates/noon/src/example_scenes/family_placement.rs
@@ -30,6 +30,20 @@ pub fn session() -> Result<ExecutionSession, String> {
     family.remove_many(&[(&first).into(), (&nested).into()])?;
     family.add_many(&[(&first).into(), (&nested).into()])?;
     let target = scene.family(&[(&anchor).into()])?;
+    let first_anchor = crate::LayoutAnchor::from(&first);
+    let target_anchor = crate::LayoutAnchor::from(&target);
+    first_anchor
+        .layout()?
+        .move_to(Target::Anchor(&target_anchor), (0.0, 1.0), (1.0, 1.0))?;
+    first_anchor
+        .layout()?
+        .align_to(Target::Anchor(&target_anchor), (0.0, -1.0))?;
+    assert!(
+        (first_anchor.layout()?.critical_point(0.0, -1.0).1
+            - target.layout()?.critical_point(0.0, -1.0).1)
+            .abs()
+            < 1e-6
+    );
     let source = crate::LayoutAnchor::from(&family);
     let target_member = crate::LayoutAnchor::from(&target).member(0);
     source.next_to_aligned(

--- a/crates/noon/tests/family_layout.rs
+++ b/crates/noon/tests/family_layout.rs
@@ -113,3 +113,44 @@ fn object_next_to_and_frame_corner_use_shared_bounds_and_buffers() {
     assert!((corner.0 - (f64::from(noon_core::DEFAULT_FRAME_WIDTH) * 0.5 - buffer)).abs() < 1e-5);
     assert!((corner.1 - (f64::from(noon_core::DEFAULT_FRAME_HEIGHT) * 0.5 - buffer)).abs() < 1e-5);
 }
+
+#[test]
+fn object_placement_to_family_anchor_is_shared_and_rejects_foreign_targets() {
+    let scene = Scene::new();
+    let object = scene.square(1.0).unwrap();
+    let mut reference = scene.square(2.0).unwrap();
+    reference.shift(5.0, 3.0).unwrap();
+    let family = scene.family(&[(&reference).into()]).unwrap();
+    let source = noon::LayoutAnchor::from(&object);
+    let target = noon::LayoutAnchor::from(&family);
+    source
+        .layout()
+        .unwrap()
+        .move_to(Target::Anchor(&target), (0.0, 1.0), (0.5, 1.0))
+        .unwrap();
+    assert_eq!(object.center().unwrap(), (2.5, 3.5));
+    source
+        .layout()
+        .unwrap()
+        .align_to(Target::Anchor(&target), (0.0, -1.0))
+        .unwrap();
+    assert_eq!(object.center().unwrap(), (2.5, 2.5));
+    let other = Scene::new();
+    let foreign = noon::LayoutAnchor::from(&other.family(&[]).unwrap());
+    let revision = scene.integration_store().borrow().scene_revision();
+    assert!(source
+        .layout()
+        .unwrap()
+        .move_to(Target::Anchor(&foreign), (0.0, 0.0), (1.0, 1.0))
+        .is_err());
+    assert!(source
+        .layout()
+        .unwrap()
+        .align_to(Target::Anchor(&foreign), (1.0, 1.0))
+        .is_err());
+    assert_eq!(
+        scene.integration_store().borrow().scene_revision(),
+        revision
+    );
+    assert_eq!(object.center().unwrap(), (2.5, 2.5));
+}

--- a/crates/noon/tests/live_family_layout.rs
+++ b/crates/noon/tests/live_family_layout.rs
@@ -134,3 +134,44 @@ fn empty_foreign_stale_and_unpublished_families_obey_query_and_mutation_validati
     let _unpublished = scene.family(&[]).unwrap();
     assert!(live.effective_family_layout(&empty).is_err());
 }
+
+#[test]
+fn object_move_to_family_anchor_reads_effective_bounds_and_stays_local() {
+    let mut scene = Scene::new();
+    let source = scene.square(1.0).unwrap();
+    let reference = scene.square(2.0).unwrap();
+    let family = scene.family(&[(&reference).into()]).unwrap();
+    let target = noon::LayoutAnchor::from(&family);
+    let mut editor = reference.target_editor().unwrap();
+    editor.shift(6.0, 4.0).unwrap();
+    scene.add(&source).unwrap();
+    scene.add(&reference).unwrap();
+    let animation = scene
+        .declare_transform_to(
+            &reference,
+            &editor,
+            AnimationOptions::new()
+                .run_time(2.0)
+                .rate_func(RateFunction::Linear),
+        )
+        .unwrap();
+    let mut execution = scene.execution_session().unwrap();
+    {
+        let mut live = scene.live(&mut execution);
+        let segment = live.play_animation(&animation).unwrap();
+        live.advance_segment_to(segment, 2.0).unwrap();
+        live.complete_segment(segment).unwrap();
+    }
+    execution.take_frame_changes();
+    {
+        let mut live = scene.live(&mut execution);
+        let result = live
+            .move_to(&source, Target::Anchor(&target), (0.0, 1.0), (1.0, 0.5))
+            .unwrap();
+        assert_eq!(result.impacts().len(), 1);
+        let center = live.effective_layout(&source).unwrap().center;
+        close(center.0, 6.0);
+        close(center.1, 2.25);
+    }
+    assert_eq!(execution.take_frame_changes().object_indices(), &[0]);
+}

--- a/scripts/shared-authoring-smoke.mjs
+++ b/scripts/shared-authoring-smoke.mjs
@@ -771,6 +771,7 @@ try {
       endpointTime: null,
     },
     { filename: "ordinary_filled_path_transform.py", objectCount: 1, expectedDuration: 3.2, endpointTime: null },
+    { filename: "ordinary_family_placement.py", objectCount: 3, expectedDuration: 1, endpointTime: null },
     { filename: "ordinary_dimension_fitting.py", objectCount: 2, expectedDuration: 0.2, endpointTime: null },
     { filename: "ordinary_family_affine.py", objectCount: 2, expectedDuration: 0.2, endpointTime: null },
     { filename: "ordinary_family_paint.py", objectCount: 2, expectedDuration: 0.2, endpointTime: null },

--- a/web/direct-execution-smoke-probe.js
+++ b/web/direct-execution-smoke-probe.js
@@ -1405,7 +1405,7 @@ async function directFamilyPlacementProof(expectedBackend) {
   try {
     renderer.resize(canvas.width, canvas.height);
     const wake = await settleDirectPublication(renderer, 0);
-    const blue = await sampleRenderedColor(canvas, -0.4, 1);
+    const blue = await sampleRenderedColor(canvas, -0.4, 0.7);
     const yellow = await sampleRenderedColor(canvas, 0.4, 1);
     const red = await sampleRenderedColor(canvas, 0, 0);
     const metrics = { backend: renderer.rendererBackend(), objects: renderer.objectCount(), blue, yellow, red };

--- a/web/python/_manim_semantic_handles.py
+++ b/web/python/_manim_semantic_handles.py
@@ -32,115 +32,6 @@ def _alignment_is_mobject(value: object) -> bool:
     return isinstance(value, _base.Mobject)
 
 
-def _alignment_critical(value: object, direction: _base.Vec2) -> _base.Vec2:
-    if not _alignment_is_mobject(value):
-        raise TypeError("critical-point target must be a Mobject")
-    return value.get_critical_point(direction)  # type: ignore[union-attr]
-
-
-def _alignment_indexed(value: object, index: int | None) -> object:
-    if index is None:
-        return value
-    try:
-        return value[index]  # type: ignore[index]
-    except (TypeError, AttributeError, IndexError) as error:
-        raise IndexError("alignment submobject index is unavailable") from error
-
-
-def _manim_move_to(
-    self: _base.Mobject,
-    point_or_mobject: object,
-    aligned_edge: object = _base.ORIGIN,
-    coor_mask: object = (1.0, 1.0, 1.0),
-) -> _base.Mobject:
-    """Pinned ManimCE v0.21.0 ``Mobject.move_to`` in Noon's x/y plane."""
-
-    edge = _base._as_vec2(aligned_edge)
-    if _alignment_is_mobject(point_or_mobject):
-        target = _alignment_critical(point_or_mobject, edge)
-    else:
-        target = _base._as_vec2(point_or_mobject)
-    source = _alignment_critical(self, edge)
-    mask = _alignment_mask2(coor_mask)
-    delta = target - source
-    return self.shift(_base.Vec2(delta.x * mask.x, delta.y * mask.y))
-
-
-def _manim_next_to(
-    self: _base.Mobject,
-    mobject_or_point: object,
-    direction: object = _base.RIGHT,
-    buff: float = _base.DEFAULT_MOBJECT_TO_MOBJECT_BUFFER,
-    aligned_edge: object = _base.ORIGIN,
-    submobject_to_align: object | None = None,
-    index_of_submobject_to_align: int | None = None,
-    coor_mask: object = (1.0, 1.0, 1.0),
-) -> _base.Mobject:
-    """Pinned Manim ``next_to`` semantics, including unnormalized direction."""
-
-    vector = _base._as_vec2(direction)
-    edge = _base._as_vec2(aligned_edge)
-
-    if _alignment_is_mobject(mobject_or_point):
-        target_aligner = _alignment_indexed(
-            mobject_or_point, index_of_submobject_to_align
-        )
-        target = _alignment_critical(target_aligner, edge + vector)
-    else:
-        target = _base._as_vec2(mobject_or_point)
-
-    if submobject_to_align is not None:
-        aligner = submobject_to_align
-    elif index_of_submobject_to_align is not None:
-        aligner = _alignment_indexed(self, index_of_submobject_to_align)
-    else:
-        aligner = self
-    source = _alignment_critical(aligner, edge - vector)
-
-    mask = _alignment_mask2(coor_mask)
-    delta = target - source + vector * float(buff)
-    return self.shift(_base.Vec2(delta.x * mask.x, delta.y * mask.y))
-
-
-def _manim_align_to(
-    self: _base.Mobject,
-    mobject_or_point: object,
-    direction: object = _base.ORIGIN,
-) -> _base.Mobject:
-    """Pinned Manim ``align_to`` semantics for Mobject and point targets."""
-
-    axis = _base._as_vec2(direction)
-    target = (
-        _alignment_critical(mobject_or_point, axis)
-        if _alignment_is_mobject(mobject_or_point)
-        else _base._as_vec2(mobject_or_point)
-    )
-    source = _alignment_critical(self, axis)
-    return self.shift(
-        _base.Vec2(
-            target.x - source.x if axis.x != 0.0 else 0.0,
-            target.y - source.y if axis.y != 0.0 else 0.0,
-        )
-    )
-
-
-def _manim_arrange(
-    self: _compat.Group,
-    direction: object = _base.RIGHT,
-    buff: float = _base.DEFAULT_MOBJECT_TO_MOBJECT_BUFFER,
-    center: bool = True,
-    **kwargs: Any,
-) -> _compat.Group:
-    """Pinned Manim ``arrange`` forwarding placement kwargs to ``next_to``."""
-
-    vector = _base.RIGHT if direction is None else direction
-    for previous, current in zip(self.submobjects, self.submobjects[1:]):
-        current.next_to(previous, vector, buff, **kwargs)
-    if center:
-        self.center()
-    return self
-
-
 _ir = _base._ir
 
 try:
@@ -848,53 +739,33 @@ def _move_to(
 ) -> _base.Mobject:
     handle = _handle_for(self)
     if handle is None:
-        return _manim_move_to(
-            self,
-            point_or_mobject,
-            aligned_edge=aligned_edge,
-            coor_mask=coor_mask,
-        )
-
-    context = _live_mutation_context(self)
-    if context is not None:
-        edge = _base._as_vec2(aligned_edge)
-        mask = _alignment_mask2(coor_mask)
-        try:
-            if _alignment_is_mobject(point_or_mobject):
-                target_handle = _handle_for(point_or_mobject)
-                if target_handle is None:
-                    raise ValueError("live move_to requires a shared semantic target")
-                context.liveMoveToMobject(handle, target_handle, edge.x, edge.y, mask.x, mask.y)
-            else:
-                point = _base._as_vec2(point_or_mobject)
-                context.liveMoveToPoint(handle, point.x, point.y, edge.x, edge.y, mask.x, mask.y)
-        except Exception as error:
-            raise ValueError(str(error)) from None
-        return self
-
+        raise RuntimeError("Mobject placement requires a current shared Rust semantic handle")
     edge = _base._as_vec2(aligned_edge)
-    if _alignment_is_mobject(point_or_mobject):
-        target_handle = _handle_for(point_or_mobject)
-        if target_handle is None or not hasattr(handle, "manimMoveToHandle"):
-            return _manim_move_to(
-                self,
-                point_or_mobject,
-                aligned_edge=aligned_edge,
-                coor_mask=coor_mask,
-            )
-        mask = _alignment_mask2(coor_mask)
-        handle.manimMoveToHandle(target_handle, edge.x, edge.y, mask.x, mask.y)
+    mask = _alignment_mask2(coor_mask)
+    args = (edge.x, edge.y, mask.x, mask.y)
+    context = _live_mutation_context(self)
+    if isinstance(point_or_mobject, _compat.Group):
+        target = _layout_anchor(point_or_mobject)
+        if target is None:
+            raise RuntimeError("placement target requires a current shared Rust semantic handle")
+        if context is None:
+            handle.layoutAnchor(None).moveTo(target, *args)
+        else:
+            context.liveMoveToLayout(handle, target, *args)
+    elif _alignment_is_mobject(point_or_mobject):
+        target = _handle_for(point_or_mobject)
+        if target is None:
+            raise RuntimeError("placement target requires a current shared Rust semantic handle")
+        if context is None:
+            handle.manimMoveToHandle(target, *args)
+        else:
+            context.liveMoveToMobject(handle, target, *args)
     else:
-        if not hasattr(handle, "manimMoveToPoint"):
-            return _manim_move_to(
-                self,
-                point_or_mobject,
-                aligned_edge=aligned_edge,
-                coor_mask=coor_mask,
-            )
         point = _base._as_vec2(point_or_mobject)
-        mask = _alignment_mask2(coor_mask)
-        handle.manimMoveToPoint(point.x, point.y, edge.x, edge.y, mask.x, mask.y)
+        if context is None:
+            handle.manimMoveToPoint(point.x, point.y, *args)
+        else:
+            context.liveMoveToPoint(handle, point.x, point.y, *args)
     return self
 
 
@@ -1169,12 +1040,12 @@ def _shared_next_to(self, target, direction, buff, aligned_edge,
     aligner = (_layout_anchor(submobject_to_align) if submobject_to_align is not None
                else _layout_anchor(self, index))
     if source is None or aligner is None:
-        return False
+        raise RuntimeError("placement requires current shared Rust source and aligner handles")
     target_anchor = None
     if isinstance(target, (_base.Mobject, _compat.Group)):
         target_anchor = _layout_anchor(target, index)
         if target_anchor is None:
-            return False
+            raise RuntimeError("placement target requires a current shared Rust semantic handle")
     vector = _base._as_vec2(direction)
     edge = _base._as_vec2(aligned_edge)
     mask = _alignment_mask2(coor_mask)
@@ -1197,7 +1068,6 @@ def _shared_next_to(self, target, direction, buff, aligned_edge,
         if "alignment submobject index" in str(error):
             raise IndexError(str(error)) from None
         raise ValueError(str(error)) from None
-    return True
 
 
 def _next_to(
@@ -1210,14 +1080,9 @@ def _next_to(
     index_of_submobject_to_align: int | None = None,
     coor_mask: object = (1.0, 1.0, 1.0),
 ) -> _base.Mobject | _compat.Group:
-    if _shared_next_to(self, mobject_or_point, direction, buff, aligned_edge,
-                       submobject_to_align, index_of_submobject_to_align, coor_mask):
-        return self
-    return _manim_next_to(
-        self, mobject_or_point, direction, buff,
-        aligned_edge=aligned_edge, submobject_to_align=submobject_to_align,
-        index_of_submobject_to_align=index_of_submobject_to_align, coor_mask=coor_mask,
-    )
+    _shared_next_to(self, mobject_or_point, direction, buff, aligned_edge,
+                    submobject_to_align, index_of_submobject_to_align, coor_mask)
+    return self
 
 
 def _align_to(
@@ -1227,20 +1092,23 @@ def _align_to(
 ) -> _base.Mobject:
     handle = _handle_for(self)
     if handle is None:
-        return _manim_align_to(self, mobject_or_point, direction)
+        raise RuntimeError("alignment requires current shared Rust semantic handles")
     if _live_mutation_context(self) is not None:
         raise NotImplementedError(
             "canonical live affine targets do not support layout alignment"
         )
     axis = _base._as_vec2(direction)
-    if _alignment_is_mobject(mobject_or_point):
+    if isinstance(mobject_or_point, _compat.Group):
+        target = _layout_anchor(mobject_or_point)
+        if target is None:
+            raise RuntimeError("alignment requires current shared Rust semantic handles")
+        handle.layoutAnchor(None).alignTo(target, axis.x, axis.y)
+    elif _alignment_is_mobject(mobject_or_point):
         target_handle = _handle_for(mobject_or_point)
-        if target_handle is None or not hasattr(handle, "alignToHandle"):
-            return _manim_align_to(self, mobject_or_point, direction)
+        if target_handle is None:
+            raise RuntimeError("alignment requires current shared Rust semantic handles")
         handle.alignToHandle(target_handle, axis.x, axis.y)
     else:
-        if not hasattr(handle, "alignToPoint"):
-            return _manim_align_to(self, mobject_or_point, direction)
         point = _base._as_vec2(mobject_or_point)
         handle.alignToPoint(point.x, point.y, axis.x, axis.y)
     return self
@@ -1640,36 +1508,25 @@ def _group_move_to(
         return self
     shared = _shared_family_layout(self, mutation=True)
     if shared is None:
-        return _manim_move_to(self, point_or_mobject, aligned_edge, coor_mask)
+        raise RuntimeError("placement requires current shared Rust semantic handles")
     session = shared
     edge = _base._as_vec2(aligned_edge)
     mask = _alignment_mask2(coor_mask)
 
-    applied = False
     if isinstance(point_or_mobject, _compat.Group):
-        target_shared = _shared_family_layout(point_or_mobject)
-        if target_shared is not None and hasattr(session, "moveToFamily"):
-            target_session = target_shared
-            session.moveToFamily(
-                target_session, edge.x, edge.y, mask.x, mask.y
-            )
-            applied = True
+        target = _shared_family_layout(point_or_mobject)
+        if target is None:
+            raise RuntimeError("placement target requires a current shared Rust semantic handle")
+        session.moveToFamily(target, edge.x, edge.y, mask.x, mask.y)
     elif _alignment_is_mobject(point_or_mobject):
-        target_adapter = _family_layout_leaf_adapter(point_or_mobject)
-        if target_adapter is not None and hasattr(session, "moveToMobject"):
-            session.moveToMobject(
-                target_adapter, edge.x, edge.y, mask.x, mask.y
-            )
-            applied = True
-    elif hasattr(session, "moveToPoint"):
+        target = _family_layout_leaf_adapter(point_or_mobject)
+        if target is None:
+            raise RuntimeError("placement target requires a current shared Rust semantic handle")
+        session.moveToMobject(target, edge.x, edge.y, mask.x, mask.y)
+    else:
         point = _base._as_vec2(point_or_mobject)
-        session.moveToPoint(
-            point.x, point.y, edge.x, edge.y, mask.x, mask.y
-        )
-        applied = True
+        session.moveToPoint(point.x, point.y, edge.x, edge.y, mask.x, mask.y)
 
-    if not applied:
-        return _manim_move_to(self, point_or_mobject, aligned_edge, coor_mask)
     return self
 
 
@@ -1687,28 +1544,24 @@ def _group_align_to(
         return self
     shared = _shared_family_layout(self, mutation=True)
     if shared is None:
-        return _manim_align_to(self, mobject_or_point, direction)
+        raise RuntimeError("alignment requires current shared Rust semantic handles")
     session = shared
     axis = _base._as_vec2(direction)
 
-    applied = False
     if isinstance(mobject_or_point, _compat.Group):
-        target_shared = _shared_family_layout(mobject_or_point)
-        if target_shared is not None and hasattr(session, "alignToFamily"):
-            session.alignToFamily(target_shared, axis.x, axis.y)
-            applied = True
+        target = _shared_family_layout(mobject_or_point)
+        if target is None:
+            raise RuntimeError("alignment target requires a current shared Rust semantic handle")
+        session.alignToFamily(target, axis.x, axis.y)
     elif _alignment_is_mobject(mobject_or_point):
-        target_adapter = _family_layout_leaf_adapter(mobject_or_point)
-        if target_adapter is not None and hasattr(session, "alignToMobject"):
-            session.alignToMobject(target_adapter, axis.x, axis.y)
-            applied = True
-    elif hasattr(session, "alignToPoint"):
+        target = _family_layout_leaf_adapter(mobject_or_point)
+        if target is None:
+            raise RuntimeError("alignment target requires a current shared Rust semantic handle")
+        session.alignToMobject(target, axis.x, axis.y)
+    else:
         point = _base._as_vec2(mobject_or_point)
         session.alignToPoint(point.x, point.y, axis.x, axis.y)
-        applied = True
 
-    if not applied:
-        return _manim_align_to(self, mobject_or_point, direction)
     return self
 
 
@@ -1722,7 +1575,7 @@ def _group_arrange(
 ) -> _compat.Group:
     family_handle = getattr(self, "_semantic_family_handle", None)
     if family_handle is None or not hasattr(family_handle, "arrangeOptions"):
-        return _manim_arrange(self, direction=direction, buff=buff, center=center, **kwargs)
+        raise RuntimeError("arrange requires current shared Rust semantic handles")
     if not self.submobjects:
         return self
     unknown = set(kwargs) - {"aligned_edge", "coor_mask", "submobject_to_align", "index_of_submobject_to_align"}
@@ -1738,9 +1591,9 @@ def _group_arrange(
     if aligner is not None:
         anchor = _layout_anchor(aligner)
         if anchor is None:
-            return _manim_arrange(self, direction=direction, buff=buff, center=center, **kwargs)
+            raise RuntimeError("arrange requires current shared Rust semantic handles")
         options.setAligner(anchor)
-    context = _group_target_context(self)
+    context = _group_live_layout_context(self)
     try:
         if context is not None:
             context.liveArrangeFamily(family_handle, options)
@@ -1748,7 +1601,7 @@ def _group_arrange(
         leaves = _compat._leaf_mobjects(self)
         leaf_handles = [_family_layout_leaf_adapter(member, mutation=True) for member in leaves]
         if any(handle is None for handle in leaf_handles):
-            return _manim_arrange(self, direction=direction, buff=buff, center=center, **kwargs)
+            raise RuntimeError("arrange requires current shared Rust semantic handles")
         family_handle.arrange(options)
     except Exception as error:
         if "alignment submobject index" in str(error):

--- a/web/python/examples/ordinary_family_placement.py
+++ b/web/python/examples/ordinary_family_placement.py
@@ -13,6 +13,9 @@ class OrdinaryFamilyPlacement(Scene):
         family.remove(first, nested)
         family.add(first, nested)
         target = VGroup(anchor)
+        first.move_to(target, aligned_edge=UP)
+        first.align_to(target, DOWN)
+        assert abs(first.get_bottom().y - target.get_bottom().y) < 1e-6
         family.next_to(target, direction=2 * RIGHT, buff=0.25,
                        index_of_submobject_to_align=0)
         family.align_to(UP, UP)
@@ -20,3 +23,8 @@ class OrdinaryFamilyPlacement(Scene):
         family.shift(0.2 * UP)
         self.add(first, second, anchor)
         self.wait(1)
+        # After the barrier, the same typed target observes live effective bounds.
+        before = first.get_center()
+        first.move_to(target, coor_mask=(0, 0, 0))
+        assert abs(first.get_center().x - before.x) < 1e-6
+        assert abs(first.get_center().y - before.y) < 1e-6

--- a/web/python/test_manim_shared_family_relative_placement.py
+++ b/web/python/test_manim_shared_family_relative_placement.py
@@ -181,6 +181,23 @@ class ManimSharedFamilyRelativePlacementTests(unittest.TestCase):
             assert store.applied[before:] == ids
             assert first._semantic_handle.shift_calls[-1] == (-2.0, 0.0)
             assert store.finishes == 4
+
+            # A stale member must not leave a partially translated family.
+            first._semantic_handle_fresh = False
+            before = list(store.applied)
+            for operation in (
+                lambda: family.move_to((1, 2)),
+                lambda: family.align_to((1, 2)),
+                lambda: family.next_to((1, 2)),
+                lambda: family.arrange(),
+            ):
+                try:
+                    operation()
+                except RuntimeError:
+                    pass
+                else:
+                    raise AssertionError("invalid family placement must reject")
+            assert store.applied == before
             """
         )
         completed = subprocess.run(

--- a/web/python/test_manim_shared_placement_handles.py
+++ b/web/python/test_manim_shared_placement_handles.py
@@ -116,6 +116,31 @@ class ManimSharedPlacementHandleTests(unittest.TestCase):
             assert aligned._semantic_handle.calls[-1] == "alignToHandle"
             assert abs(aligned.get_right().x - reference.get_right().x) < 1e-12
             assert abs(aligned.get_center().y + 1.0) < 1e-12
+
+            # Invalid identities must reject before any Python-derived edit.
+            invalid = Square(1.0)
+            invalid._semantic_handle_fresh = False
+            def unexpected(*args, **kwargs):
+                raise AssertionError("placement fallback must not query or shift in Python")
+            for item in (invalid, moved):
+                item.get_critical_point = unexpected
+                item.shift = unexpected
+            before = json.dumps(moved._semantic_handle.snapshot, sort_keys=True)
+            for operation in (
+                lambda: invalid.move_to(reference),
+                lambda: invalid.align_to(reference, RIGHT),
+                lambda: invalid.next_to(reference),
+                lambda: moved.move_to(invalid),
+                lambda: moved.align_to(invalid, RIGHT),
+                lambda: moved.next_to(invalid),
+            ):
+                try:
+                    operation()
+                except RuntimeError:
+                    pass
+                else:
+                    raise AssertionError("invalid placement must reject")
+            assert json.dumps(moved._semantic_handle.snapshot, sort_keys=True) == before
             """
         )
         completed = subprocess.run(


### PR DESCRIPTION
Advances #61 (Phase A3). Missing placement handles previously fell back to Python critical-point arithmetic or a sequence of family edits. Delete those move_to/next_to/align_to/arrange fallbacks and require the existing shared Rust operations. Object-to-family move/alignment now forwards typed layout anchors, including live move_to through the current execution session.

Semantic layout and atomic translation remain owned by Rust; no new engine model, migration seam, or transport boundary. Work is proportional to source/target leaves, with one transaction and no unrelated-scene traversal. Live object align_to and family layout during callback phases remain explicitly unsupported.

Extend the executable Rust/native/direct-WASM and Python family-placement examples. Add Python regressions rejecting stale operands before edits, plus Rust coverage for object/family anchors, foreign-store rollback, effective target bounds and a one-object dirty publication.

Validation:
- `python3 -m unittest discover -s web/python -p 'test_*.py'` (151 passed; also run by web preflight)
- `cargo test -p noon --no-default-features --test family_layout --test live_family_layout` (9 passed)
- `cargo clippy -p noon --no-default-features --lib --test family_layout --test live_family_layout -- -D warnings`
- `NOON_WEB_PREFLIGHT_ONLY=1 bash scripts/build-web-demo.sh`
- `bash scripts/check.sh architecture`
- `cargo fmt --all` and `git diff --check`

Full Rust/WASM/browser qualification runs in hosted CI. Full local gate was not run; local disk is about 4 GiB free. Hosted checks must pass before merge.
