### PR TITLE
Remove raw Mobject construction and unused Python factories

### DIFF
--- a/compat/semantic-ownership-v1.json
+++ b/compat/semantic-ownership-v1.json
@@ -56,7 +56,7 @@
     {"path": "web/python/_manim_updaters.py", "token": "_ORIGINAL_", "maximum": 0, "migration_issue": "#61"},
     {"path": "web/python/_manim_updaters.py", "token": "copy.deepcopy", "maximum": 0, "migration_issue": "#61"},
     {"path": "web/python/_manim_updaters.py", "token": "_ir.Mobject(", "maximum": 0, "migration_issue": "#61"},
-    {"path": "web/python/_noon_ir.py", "token": "copy.deepcopy", "maximum": 4, "migration_issue": "#61"},
+    {"path": "web/python/_noon_ir.py", "token": "copy.deepcopy", "maximum": 3, "migration_issue": "#61"},
     {"path": "web/python/_noon_ir.py", "token": "_snapshot_for_object_at", "maximum": 0, "migration_issue": "#61"},
     {"path": "web/python/noon.py", "token": "copy.deepcopy", "maximum": 0, "migration_issue": "#61"},
     {"path": "web/python/noon.py", "token": "_snapshot_for_object_at", "maximum": 0, "migration_issue": "#61"},

--- a/scripts/manim-compat-smoke.mjs
+++ b/scripts/manim-compat-smoke.mjs
@@ -53,12 +53,8 @@ class Demo(Scene):
         assert abs(there_and_back(0.25) - smooth(0.5)) < 1e-12
 
         import _manim_compat as _compat_impl
-        original_circle_ir = _compat_impl._ir.Circle
-        _compat_impl._ir.Circle = lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("shared Circle constructor must bypass Python IR"))
-        try:
-            shared_constructed = Circle(radius=0.33)
-        finally:
-            _compat_impl._ir.Circle = original_circle_ir
+        assert not hasattr(_compat_impl._ir, "Circle")
+        shared_constructed = Circle(radius=0.33)
         assert abs(shared_constructed.radius - 0.33) < 1e-12
 
         circle = Circle(radius=0.6, color=BLUE)

--- a/web/manim-mobject-layout-ownership.test.mjs
+++ b/web/manim-mobject-layout-ownership.test.mjs
@@ -13,28 +13,28 @@ const rustHandleSource = readFileSync(
   "utf8",
 );
 
-function functionBody(source, name, nextName) {
+function functionBody(source, name) {
   const start = source.indexOf(`def ${name}(`);
   assert.notEqual(start, -1, `missing Python function ${name}`);
-  const end = source.indexOf(`\ndef ${nextName}(`, start);
+  const end = source.indexOf("\ndef ", start);
   assert.notEqual(end, -1, `missing Python function boundary after ${name}`);
   return source.slice(start, end);
 }
 
 test("detached Mobject layout queries stay owned by the shared semantic handle", () => {
-  const layoutCenter = functionBody(semanticHandlesSource, "_layout_center", "_init");
+  const layoutCenter = functionBody(semanticHandlesSource, "_layout_center");
   assert.match(layoutCenter, /_handle_for\(value\)/);
   assert.match(layoutCenter, /handle\.centerX/);
   assert.match(layoutCenter, /handle\.centerY/);
 
-  const getCenter = functionBody(semanticHandlesSource, "_get_center", "_width");
+  const getCenter = functionBody(semanticHandlesSource, "_get_center");
   assert.match(getCenter, /_handle_for\(self\)/);
   assert.match(getCenter, /return _layout_center\(self\)/);
 
-  const width = functionBody(semanticHandlesSource, "_width", "_height");
+  const width = functionBody(semanticHandlesSource, "_width");
   assert.match(width, /handle\.width/);
 
-  const height = functionBody(semanticHandlesSource, "_height", "_set_width_property");
+  const height = functionBody(semanticHandlesSource, "_height");
   assert.match(height, /handle\.height/);
 
   assert.match(facadeSource, /return _callback_operations\(\)\._canonical_get_center\(self\)/);

--- a/web/python/_manim_indication.py
+++ b/web/python/_manim_indication.py
@@ -26,13 +26,7 @@ class ShowPassingFlash:
             )
         if not isinstance(mobject, _compat.VMobject):
             raise TypeError("ShowPassingFlash only works for VMobjects")
-        if not _semantic_handles._require_typed_manim_line(mobject):
-            raw = mobject._current_raw()
-            if "line" not in raw.geometry:
-                raise NotImplementedError(
-                    "ShowPassingFlash currently qualifies the exact Line subset; "
-                    "general VMobject path windows remain partial"
-                )
+        _semantic_handles._require_typed_manim_line(mobject)
         width = float(time_width)
         if not math.isfinite(width) or width <= 0.0:
             raise NotImplementedError(

--- a/web/python/_manim_semantic_handles.py
+++ b/web/python/_manim_semantic_handles.py
@@ -269,9 +269,7 @@ def _manim_color_observation(value: object):
 def _require_typed_manim_line(value: object) -> bool:
     """Validate exact Line content through the current Rust observation owner."""
     semantic_handle = getattr(value, "_semantic_handle", None)
-    if semantic_handle is None:
-        return False
-    if not bool(getattr(value, "_semantic_handle_fresh", False)):
+    if semantic_handle is None or not bool(getattr(value, "_semantic_handle_fresh", False)):
         raise NotImplementedError("exact Line admission requires a valid semantic handle")
     try:
         _manim_line_endpoints_observation(value)
@@ -490,60 +488,6 @@ def _vector_path_options(path: dict[str, Any]):
     return _geometry_options.path(candidate)
 
 
-def _geometry_options_from_raw(raw: _ir.Mobject):
-    geometry = raw.geometry
-    if len(geometry) != 1:
-        raise ValueError("shared geometry must contain exactly one geometry variant")
-    if "circle" in geometry:
-        options = _geometry_options.circle(float(geometry["circle"]["radius"]))
-    elif "rectangle" in geometry:
-        size = geometry["rectangle"]["size"]
-        options = _geometry_options.rectangle(float(size["x"]), float(size["y"]))
-    elif "line" in geometry:
-        line = geometry["line"]
-        start, end = line["start"], line["end"]
-        options = _geometry_options.line(
-            float(start["x"]), float(start["y"]),
-            float(end["x"]), float(end["y"]),
-        )
-    elif "vector_path" in geometry:
-        options = _vector_path_options(geometry["vector_path"])
-    else:
-        raise ValueError("shared geometry supports circle, rectangle, line, or vector path")
-
-    transform = raw.transform
-    translation, scale = transform["translation"], transform["scale"]
-    options.setTranslation(float(translation["x"]), float(translation["y"]))
-    options.setRotation(float(transform["rotation"]))
-    options.setScale(float(scale["x"]), float(scale["y"]))
-
-    style = raw.style
-    # Width editing intentionally materializes a default stroke in shared Rust.
-    # Apply it before the authored paints so an explicit absent stroke stays absent.
-    options.setStrokeWidth(float(style["stroke_width"]))
-    options.setStrokeWidthMode(style["stroke_width_mode"])
-    options.setStrokeJoin(style["stroke_join"])
-    options.setStrokeCap(style["stroke_cap"])
-    fill = style["fill"]
-    if fill is None:
-        options.disableFill()
-    else:
-        options.setFill(
-            float(fill["red"]), float(fill["green"]),
-            float(fill["blue"]), float(fill["alpha"]),
-        )
-    stroke = style["stroke"]
-    if stroke is None:
-        options.disableStroke()
-    else:
-        options.setStroke(
-            float(stroke["red"]), float(stroke["green"]),
-            float(stroke["blue"]), float(stroke["alpha"]),
-        )
-    options.setObjectOpacity(float(style["opacity"]))
-    return options
-
-
 def _consume_geometry_options(options: object, kind: str = "geometry"):
     context = _live_constructor_context(kind)
     if context is None:
@@ -679,15 +623,6 @@ def _line_init(
     _attach_geometry_options(self, options, "Line")
     self.start = start_value
     self.end = end_value
-
-
-def _init(self: _base.Mobject, raw: _ir.Mobject) -> None:
-    if _create_geometry_handle is None:
-        raise RuntimeError("Mobject construction requires the shared Rust authoring host")
-    handle, context = _consume_geometry_options(_geometry_options_from_raw(raw))
-    _attach_shared_handle(self, handle)
-    if context is not None:
-        self._canonical_live_target_context = context
 
 
 def _current_raw(self: _base.Mobject) -> _ir.Mobject:

--- a/web/python/_noon_ir.py
+++ b/web/python/_noon_ir.py
@@ -1,7 +1,7 @@
-"""Inert Python values and legacy constructor/export argument shapes.
+"""Inert Python value coercion, path input and explicit inspection/export shapes.
 
-No Scene, timeline, detached semantic state, or execution lives here. The remaining
-constructor/export shape adapter is deletion-owned by #61.
+No Scene, timeline, detached semantic state, or execution lives here. Snapshots
+cannot be passed back into authoring constructors. Remaining export cleanup is #61.
 """
 
 from __future__ import annotations
@@ -105,7 +105,7 @@ class Color:
 
 @dataclass(frozen=True, slots=True)
 class Mobject:
-    """Detached semantic object snapshot usable as a Transform target."""
+    """Inert shared-handle inspection snapshot; never an authoring or Transform target."""
 
     geometry: dict[str, Any]
     transform: dict[str, Any]
@@ -183,85 +183,3 @@ def _stroke_width_mode(value: object) -> str:
     if value not in {"scale_with_object", "screen_space"}:
         raise ValueError("stroke_width_mode must be scale_with_object or screen_space")
     return str(value)
-
-
-def _make_mobject(
-    geometry: dict[str, Any],
-    *,
-    position: tuple[float, float] = (0.0, 0.0),
-    rotation: float = 0.0,
-    scale: tuple[float, float] = (1.0, 1.0),
-    fill: Color | None = Color(1.0, 1.0, 1.0),
-    stroke: Color | None = None,
-    stroke_width: float = 1.0,
-    stroke_width_mode: str = "scale_with_object",
-    stroke_join: str = "round",
-    stroke_cap: str = "round",
-    opacity: float = 1.0,
-) -> Mobject:
-    if fill is not None and not isinstance(fill, Color):
-        raise TypeError("fill must be a Color or None")
-    if stroke is not None and not isinstance(stroke, Color):
-        raise TypeError("stroke must be a Color or None")
-    width = _finite_number("stroke_width", stroke_width)
-    if width < 0.0:
-        raise ValueError("stroke_width must be non-negative")
-    return Mobject(
-        geometry=copy.deepcopy(geometry),
-        transform={
-            "translation": _vec2("position", position),
-            "rotation": _finite_number("rotation", rotation),
-            "scale": _vec2("scale", scale),
-        },
-        style={
-            "fill": None if fill is None else fill.to_ir(),
-            "stroke": None if stroke is None else stroke.to_ir(),
-            "stroke_width": width,
-            "stroke_width_mode": _stroke_width_mode(stroke_width_mode),
-            "stroke_join": _stroke_join(stroke_join),
-            "stroke_cap": _stroke_cap(stroke_cap),
-            "opacity": _finite_number("opacity", opacity),
-        },
-    )
-
-
-def Circle(radius: float, **kwargs: Any) -> Mobject:
-    return _make_mobject(
-        {"circle": {"radius": _positive_number("radius", radius)}},
-        **kwargs,
-    )
-
-
-def Rectangle(width: float, height: float, **kwargs: Any) -> Mobject:
-    return _make_mobject(
-        {
-            "rectangle": {
-                "size": {
-                    "x": _positive_number("width", width),
-                    "y": _positive_number("height", height),
-                }
-            }
-        },
-        **kwargs,
-    )
-
-
-def Line(
-    start: tuple[float, float],
-    end: tuple[float, float],
-    **kwargs: Any,
-) -> Mobject:
-    kwargs.setdefault("fill", None)
-    kwargs.setdefault("stroke", Color(1.0, 1.0, 1.0))
-    kwargs.setdefault("stroke_width", 0.1)
-    return _make_mobject(
-        {"line": {"start": _vec2("start", start), "end": _vec2("end", end)}},
-        **kwargs,
-    )
-
-
-def Path(path: VectorPath, **kwargs: Any) -> Mobject:
-    if not isinstance(path, VectorPath):
-        raise TypeError("path must be a VectorPath")
-    kwargs.setdefault("stroke_width", 0.1)
-    return _make_mobject({"vector_path": path.to_ir()}, **kwargs)

--- a/web/python/noon.py
+++ b/web/python/noon.py
@@ -232,8 +232,8 @@ def _callback_operations():
 class Mobject:
     """Python identity wrapper; shared Rust handles own all semantic state."""
 
-    def __init__(self, raw: _ir.Mobject) -> None:
-        return _semantic_operations()._init(self, raw)
+    def __init__(self) -> None:
+        raise TypeError("Mobject is a base type; construct a Circle, Rectangle, Line, or Path")
 
     @property
     def geometry(self) -> dict[str, Any]:

--- a/web/python/test_manim_semantic_handle_color.py
+++ b/web/python/test_manim_semantic_handle_color.py
@@ -94,26 +94,21 @@ class ManimSemanticHandleColorTests(unittest.TestCase):
             _geometry_test.install_js_bridge(fake_js, create_handle)
             sys.modules["js"] = fake_js
 
-            # Match the relevant python-worker bootstrap order exactly: the rate-function
-            # adapter installs first, then semantic handles take ownership of detached
-            # authoring objects.
+            # Exercise the public facade over the typed geometry bridge.
             import _manim_compat
 
             import _manim_rate_functions
             import _manim_semantic_handles
 
 
-            import _noon_ir as _ir
             import noon as _base
 
-            raw = _ir.Rectangle(
-                1.0,
-                1.0,
-                fill=_ir.Color(0.0, 0.0, 1.0, 0.35),
-                stroke=_ir.Color(0.0, 0.0, 1.0, 0.0),
+            mobject = _base.Rectangle(
+                width=1.0, height=1.0,
+                fill=_base.Color(0.0, 0.0, 1.0, 0.35),
+                stroke=_base.Color(0.0, 0.0, 1.0, 0.0),
                 stroke_width=4.0,
             )
-            mobject = _base.Mobject(raw)
             handle = mobject._semantic_handle
             mobject.set_color(_base.GREEN)
 
@@ -128,11 +123,8 @@ class ManimSemanticHandleColorTests(unittest.TestCase):
             assert abs(style["stroke"]["blue"] - _base.GREEN.blue) < 1e-12
             assert abs(style["stroke"]["alpha"] - 0.0) < 1e-12
 
-            # Preserve the base Mobject fallback: if neither channel exists, set_color
-            # creates a fill using the requested color alpha.
-            empty = _base.Mobject(
-                _ir.Rectangle(1.0, 1.0, fill=None, stroke=None, stroke_width=0.0)
-            )
+            # Shared recoloring enables fill when neither paint channel exists.
+            empty = _base.Rectangle(width=1.0, height=1.0, fill=None, stroke=None, stroke_width=0.0)
             empty.set_color(_base.GREEN)
             empty_style = empty.style
             assert empty_style["fill"] is not None

--- a/web/python/test_noon.py
+++ b/web/python/test_noon.py
@@ -18,13 +18,22 @@ class SceneBoundaryTests(unittest.TestCase):
                 operation()
 
     def test_detached_geometry_requires_shared_rust(self):
-        from noon import Mobject, Path, Line, Rectangle
-        for construct in (Circle, Line, Rectangle, lambda: Path(VectorPath()),
-                          lambda: Mobject(object())):
+        from noon import Path, Line, Rectangle
+        for construct in (Circle, Line, Rectangle, lambda: Path(VectorPath())):
             with self.subTest(construct=construct):
                 with self.assertRaisesRegex(RuntimeError, "shared Rust"):
                     construct()
         self.assertFalse(hasattr(__import__("noon"), "_bounds"))
+
+    def test_raw_snapshots_are_inspection_only(self):
+        from noon import Mobject, VMobject
+        for constructor in (Mobject, VMobject):
+            with self.assertRaises(TypeError):
+                constructor(object())
+            with self.assertRaisesRegex(TypeError, "base type"):
+                constructor()
+        for name in ("_make_mobject", "Circle", "Rectangle", "Line", "Path"):
+            self.assertFalse(hasattr(_noon_ir, name), name)
 
     def test_non_finite_color_is_rejected(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Advances #61 (Phase A3). Public shape constructors already use typed shared Rust options, but the base Mobject still accepted the obsolete raw geometry/transform/style snapshot constructor. Its only remaining callers were two color test fixtures. Remove that entry point, its raw-to-options adapter, and the now-unused `_noon_ir` shape factories. Mobject/VMobject are base types; callers construct concrete shared shapes such as Circle, Rectangle, Line or Path.

Also remove ShowPassingFlash's unreachable snapshot-geometry fallback: admission now requires the existing typed Line observation. Explicit inspection/export snapshots remain inert and cannot be fed back through the removed constructor. No replacement scene representation, compatibility adapter, or new serialization boundary is introduced.

The color fixtures now use the public typed Rectangle constructor while retaining independent fill/stroke opacity assertions. A boundary regression protects absence of the raw constructors. The ownership test now detects the next Python function directly rather than naming a deleted neighboring function; its Rust ownership assertions are preserved.

Validation: `NOON_WEB_PREFLIGHT_ONLY=1 bash scripts/build-web-demo.sh` (including the Python suite and JS structural/unit checks), `bash scripts/check.sh architecture`, and `git diff --check`. No Rust implementation changed, so no additional local Rust build was run. Existing paired shape/color examples continue to use unchanged shared Rust operations. Normal PR browser/product checks qualify this Python-only deletion; no redundant manual full Rust workflow is requested.

The browser authoring smoke also asserts raw factory absence instead of saving/poisoning the deleted factory. `node scripts/manim-compat-smoke.mjs` passed locally against the CI-built package from 34347774147 (Rust source is unchanged) with the current Python worker. Python suite: 152 passed.
