### PR TITLE
fix: retain semantic transaction causes through Error::source (#1272 R2)

### DIFF
--- a/crates/noon-core/src/semantic_store/semantic_transaction.rs
+++ b/crates/noon-core/src/semantic_store/semantic_transaction.rs
@@ -2746,7 +2746,19 @@ impl std::fmt::Display for SemanticMutationTransactionError {
     }
 }
 
-impl std::error::Error for SemanticMutationTransactionError {}
+impl std::error::Error for SemanticMutationTransactionError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Signal { error, .. } => Some(error),
+            Self::SignalTrack { error, .. } => Some(error),
+            Self::Object { error, .. }
+            | Self::Family { error, .. }
+            | Self::AnimationTarget { error, .. } => Some(error),
+            Self::Node { error, .. } => Some(error),
+            _ => None,
+        }
+    }
+}
 
 #[cfg(test)]
 mod base_tests;

--- a/crates/noon-core/src/semantic_store/semantic_transaction/prepared.rs
+++ b/crates/noon-core/src/semantic_store/semantic_transaction/prepared.rs
@@ -25,7 +25,14 @@ impl std::fmt::Display for SemanticTransactionReadError {
     }
 }
 
-impl std::error::Error for SemanticTransactionReadError {}
+impl std::error::Error for SemanticTransactionReadError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Existing(error) => Some(error),
+            _ => None,
+        }
+    }
+}
 
 /// A fully validated mutation batch holding the store exclusively until commit.
 ///

--- a/crates/noon-core/tests/transaction_error_causes.rs
+++ b/crates/noon-core/tests/transaction_error_causes.rs
@@ -1,0 +1,181 @@
+//! Existing transaction failures expose their typed causes without new policy.
+use std::error::Error;
+
+use noon_core::{
+    SemanticMutationTransaction, SemanticMutationTransactionError as TransactionError,
+    SemanticObjectProperty, SemanticObjectState, SemanticScalarSignalTrackError,
+    SemanticSceneOperationError, SemanticSignalError, SemanticStore, SemanticStoreError,
+    SemanticTransactionReadError, StoredGeometry,
+};
+
+fn assert_cause<T: Error + PartialEq + 'static>(error: &dyn Error, expected: &T) {
+    assert_eq!(
+        error.source().and_then(|cause| cause.downcast_ref::<T>()),
+        Some(expected)
+    );
+}
+
+#[test]
+fn every_cause_bearing_transaction_variant_returns_its_existing_error() {
+    let mut store = SemanticStore::new();
+    let id = store.insert_family();
+    let semantic = SemanticSceneOperationError::NotSemanticObject(id);
+    for error in [
+        TransactionError::Object {
+            index: 3,
+            error: semantic.clone(),
+        },
+        TransactionError::Family {
+            index: 3,
+            error: semantic.clone(),
+        },
+        TransactionError::AnimationTarget {
+            index: 3,
+            error: semantic.clone(),
+        },
+    ] {
+        assert_cause(&error, &semantic);
+    }
+    let signal = TransactionError::Signal {
+        index: 4,
+        error: SemanticSignalError::UnknownSignal(id),
+    };
+    assert_cause(&signal, &SemanticSignalError::UnknownSignal(id));
+    let track = TransactionError::SignalTrack {
+        index: 5,
+        error: SemanticScalarSignalTrackError::ZeroDuration(id),
+    };
+    assert_cause(&track, &SemanticScalarSignalTrackError::ZeroDuration(id));
+    let node = TransactionError::Node {
+        index: 6,
+        error: SemanticStoreError::UnknownNode(id),
+    };
+    assert_cause(&node, &SemanticStoreError::UnknownNode(id));
+
+    // The trait borrows the error already held by the wrapper: no cloned cause.
+    let TransactionError::Node { error: inner, .. } = &node else {
+        unreachable!()
+    };
+    assert!(std::ptr::eq(
+        node.source()
+            .unwrap()
+            .downcast_ref::<SemanticStoreError>()
+            .unwrap(),
+        inner
+    ));
+}
+
+#[test]
+fn terminal_rejections_do_not_invent_a_cause() {
+    let mut store = SemanticStore::new();
+    let id = store.insert_family();
+    for error in [
+        TransactionError::SceneRevisionExhausted,
+        TransactionError::UnknownAnimation {
+            index: 0,
+            animation: id,
+        },
+        TransactionError::InvalidAnimationRunTime { index: 0 },
+        TransactionError::InvalidStyle {
+            index: 0,
+            object: id,
+        },
+        TransactionError::UnsupportedPropertyWrite {
+            index: 0,
+            object: id.into(),
+            property: SemanticObjectProperty::RotationZ,
+        },
+    ] {
+        assert!(error.source().is_none());
+    }
+    assert!(SemanticTransactionReadError::UnknownExistingNode(id)
+        .source()
+        .is_none());
+    assert!(SemanticTransactionReadError::NotFamily(id.into())
+        .source()
+        .is_none());
+}
+
+#[test]
+fn rejected_prepare_keeps_authored_state_resources_revision_and_recovery() {
+    let mut store = SemanticStore::new();
+    let object = store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+        radius: 1.0,
+    }));
+    let family = store.insert_family();
+    let before = store.semantic_object_state_checked(object).unwrap().clone();
+    let revision = store.scene_revision();
+    let stats = store.last_mutation_stats();
+    let nodes = store.len();
+    let resources = (
+        store.geometry_resources().len(),
+        store.text_resources().len(),
+        store.font_resources().len(),
+    );
+    let mut rejected = SemanticMutationTransaction::new();
+    rejected
+        .set_property(object, SemanticObjectProperty::RotationZ, 0.5_f64)
+        .set_property(family, SemanticObjectProperty::RotationZ, 1.0_f64);
+    let error = rejected
+        .prepare(&mut store)
+        .err()
+        .expect("family is not a scalar property target");
+    assert!(
+        matches!(&error, TransactionError::Object { index: 1, error: SemanticSceneOperationError::NotSemanticObject(id) } if *id == family)
+    );
+    assert_cause(
+        &error,
+        &SemanticSceneOperationError::NotSemanticObject(family),
+    );
+    assert_eq!(
+        store.semantic_object_state_checked(object).unwrap(),
+        &before
+    );
+    assert_eq!(store.scene_revision(), revision);
+    assert_eq!(store.last_mutation_stats(), stats);
+    assert_eq!(store.len(), nodes);
+    assert_eq!(
+        (
+            store.geometry_resources().len(),
+            store.text_resources().len(),
+            store.font_resources().len()
+        ),
+        resources
+    );
+
+    let mut recovery = SemanticMutationTransaction::new();
+    recovery.set_property(object, SemanticObjectProperty::RotationZ, 0.5_f64);
+    let result = recovery.apply(&mut store).unwrap();
+    assert_eq!(result.impacts().len(), 1);
+    assert_eq!(store.scene_revision(), revision.checked_next().unwrap());
+    assert_eq!(store.last_mutation_stats().slots_written, 1);
+}
+
+#[test]
+fn staged_read_cause_is_typed_and_dropping_the_view_does_not_publish() {
+    let mut store = SemanticStore::new();
+    let object = store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+        radius: 1.0,
+    }));
+    let family = store.insert_family();
+    let revision = store.scene_revision();
+    let before = store.semantic_object_state_checked(object).unwrap().clone();
+    let prepared = SemanticMutationTransaction::new()
+        .prepare(&mut store)
+        .unwrap();
+    let error = prepared.object_state(family).unwrap_err();
+    assert!(
+        matches!(&error, SemanticTransactionReadError::Existing(SemanticSceneOperationError::NotSemanticObject(id)) if *id == family)
+    );
+    assert_cause(
+        &error,
+        &SemanticSceneOperationError::NotSemanticObject(family),
+    );
+    assert_eq!(prepared.object_state(object).unwrap(), &before);
+    drop(prepared);
+    assert_eq!(store.scene_revision(), revision);
+    assert_eq!(
+        store.semantic_object_state_checked(object).unwrap(),
+        &before
+    );
+}


### PR DESCRIPTION
## Scope

Closes the concrete lower-level cause-chain gap found during #1286 review, under #958 / #1272 R2 / #1292 R2. Coordinated as a disjoint three-file patch with the active Rust producer and WASM/Python mapper owners. Does not replace their implementation or claim all R2 is complete.

Base: `d6734d2a0626f5c9926e4043ad2017a94f5c8c5a`.
Head: `48ee4fcdd84f4444b56205524839e2f9409f270e`.

## Changes

`SemanticMutationTransactionError::source()` now borrows the existing nested Signal, SignalTrack, Object, Family, AnimationTarget or Node error. `SemanticTransactionReadError::source()` exposes its Existing scene-operation error. Leaf rejections have no invented cause. No new enum variants, diagnostic wording, allocation, validation policy, preflight, commit, publication, identity or successful-path traversal change.

Four external core integration tests cover every immediate cause-bearing variant, leaf termination, borrowing the original cause rather than cloning it, a real rejected prepare preserving state/resources/revision/counters followed by successful recovery, and a failed staged read followed by a valid read/drop without publication. Tests inspect types and values, never diagnostic substrings.

## Qualification

Hosted development run **34351140285**, attempt 1, passed before source publication:

```
cargo fmt --all
git diff --check
cargo test -p noon-core --test transaction_error_causes
cargo test -p noon-core --lib semantic_transaction
cargo clippy -p noon-core --all-targets -- -D warnings
bash scripts/check.sh architecture d6734d2a0626f5c9926e4043ad2017a94f5c8c5a
cargo test -p noon-core --test transaction_error_causes --target wasm32-unknown-unknown --no-run
```

**4/4 new tests and 139/139 existing transaction tests passed**, strict Clippy and architecture gate passed, WASM test executable compiled. Compilation is not browser execution. Final PR checks remain separately required. The editing container has no Cargo; it inspected the returned exact candidate diff and logs, not a claimed local Rust run.

## Architecture / landing

Read AGENTS and architecture; no new authority, runtime, codec, dependency or migration seam. Only existing error references are exposed. Development helpers are confined to the separate prep branch and are absent from this PR. No renderer/Python/manifest/workflow changes. The user authorized merging after successful review/qualification; no bypass or auto-merge is requested.

Other domain errors may still need their own source forwarding and producer conversion; the active R2 owner retains that work. This patch is intentionally independent of #1286 so both can land without a competing AuthoringError design.