### PR TITLE
Reuse compiler outputs between product-gate builds

### DIFF
--- a/.github/workflows/playground-product-gate.yml
+++ b/.github/workflows/playground-product-gate.yml
@@ -44,7 +44,7 @@ jobs:
       # Reuse dependency compilations between these two isolated source builds.
       # The cache lives only in this job; no executable or cross-PR seed is restored.
       SCCACHE_GHA_ENABLED: "false"
-      SCCACHE_DIR: ${{ runner.temp }}/noon-product-sccache
+      SCCACHE_DIR: ${{ github.workspace }}/.product-sccache
       SCCACHE_CACHE_SIZE: "1G"
       SCCACHE_LOCAL_RW_MODE: "READ_WRITE"
       NOON_SKIP_WEB_PREFLIGHT: "1"

--- a/.github/workflows/playground-product-gate.yml
+++ b/.github/workflows/playground-product-gate.yml
@@ -14,7 +14,7 @@ on:
       - "crates/noon-runtime/**"
       - "crates/noon-web/**"
       - "crates/noon-render-wgpu/**"
-      - "crates/noon-text-*/**"
+      - "crates/noon-text/**"
       - "scripts/build-web-demo.sh"
       - "scripts/build-python-worker.mjs"
       - "scripts/manim-tutorial-smoke.mjs"
@@ -40,6 +40,13 @@ jobs:
     env:
       CARGO_INCREMENTAL: "0"
       CARGO_PROFILE_DEV_DEBUG: "0"
+      RUSTC_WRAPPER: sccache
+      # Reuse dependency compilations between these two isolated source builds.
+      # The cache lives only in this job; no executable or cross-PR seed is restored.
+      SCCACHE_GHA_ENABLED: "false"
+      SCCACHE_DIR: ${{ runner.temp }}/noon-product-sccache
+      SCCACHE_CACHE_SIZE: "1G"
+      SCCACHE_LOCAL_RW_MODE: "READ_WRITE"
       NOON_SKIP_WEB_PREFLIGHT: "1"
       NOON_WASM_PROFILE: "release"
       NOON_WASM_SKIP_OPT: "1"
@@ -55,10 +62,15 @@ jobs:
           ref: ${{ github.event.pull_request.base.sha }}
           path: baseline
 
-      - name: Use stable Rust and WASM target
+      - name: Use each checkout's pinned Rust and WASM target
         run: |
-          rustup default stable
-          rustup target add wasm32-unknown-unknown
+          for noon_checkout in baseline candidate; do
+            (
+              cd "$noon_checkout"
+              rustup show active-toolchain
+              rustup target add wasm32-unknown-unknown
+            )
+          done
 
       - name: Cache Cargo sources
         uses: actions/cache@v6
@@ -70,6 +82,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-sources-
 
+      - name: Use pinned sccache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+        with:
+          version: v0.16.0
+
       - name: Install pinned wasm-pack
         uses: taiki-e/install-action@e67fa11c4b9316fa714ddf0abed07a0c3143b95b # v2.87.4
         with:
@@ -80,7 +97,12 @@ jobs:
         working-directory: baseline
         env:
           CARGO_TARGET_DIR: ${{ github.workspace }}/.product-target/baseline
-        run: bash scripts/build-web-demo.sh
+        run: |
+          sccache --zero-stats
+          noon_build_started=$SECONDS
+          bash scripts/build-web-demo.sh
+          printf 'Baseline release build: %s seconds.\n' "$((SECONDS - noon_build_started))" >> "$GITHUB_STEP_SUMMARY"
+          sccache --show-stats
 
       - name: Build candidate production package
         working-directory: candidate
@@ -89,7 +111,12 @@ jobs:
           CARGO_TARGET_DIR: ${{ github.workspace }}/.product-target/candidate
           # Exercise release code with only the typed recovery fixture exported.
           NOON_RENDERER_SMOKE: "1"
-        run: bash scripts/build-web-demo.sh
+        run: |
+          sccache --zero-stats
+          noon_build_started=$SECONDS
+          bash scripts/build-web-demo.sh
+          printf 'Candidate release build: %s seconds.\n' "$((SECONDS - noon_build_started))" >> "$GITHUB_STEP_SUMMARY"
+          sccache --show-stats
 
       - name: Cache Playwright Chromium
         uses: actions/cache@v6

--- a/.github/workflows/playground-product-gate.yml
+++ b/.github/workflows/playground-product-gate.yml
@@ -41,7 +41,7 @@ jobs:
       CARGO_INCREMENTAL: "0"
       CARGO_PROFILE_DEV_DEBUG: "0"
       RUSTC_WRAPPER: sccache
-      # Reuse dependency compilations between these two isolated source builds.
+      # Reuse dependency compilations between two fresh builds at one stable path.
       # The cache lives only in this job; no executable or cross-PR seed is restored.
       SCCACHE_GHA_ENABLED: "false"
       SCCACHE_DIR: ${{ github.workspace }}/.product-sccache
@@ -94,27 +94,33 @@ jobs:
           fallback: none
 
       - name: Build baseline production package
-        working-directory: baseline
         env:
-          CARGO_TARGET_DIR: ${{ github.workspace }}/.product-target/baseline
+          CARGO_TARGET_DIR: ${{ github.workspace }}/.product-target
         run: |
+          # Rust cache keys include cwd and CARGO_TARGET_DIR. Keep both stable,
+          # but discard all Cargo fingerprints/artifacts before each source build.
+          mv baseline .product-source
+          trap 'mv .product-source baseline' EXIT
+          rm -rf .product-target
           sccache --zero-stats
           noon_build_started=$SECONDS
-          bash scripts/build-web-demo.sh
+          (cd .product-source && bash scripts/build-web-demo.sh)
           printf 'Baseline release build: %s seconds.\n' "$((SECONDS - noon_build_started))" >> "$GITHUB_STEP_SUMMARY"
           sccache --show-stats
 
       - name: Build candidate production package
-        working-directory: candidate
         env:
-          # Separate checkout mtimes must not reuse baseline workspace artifacts.
-          CARGO_TARGET_DIR: ${{ github.workspace }}/.product-target/candidate
+          # Compiler results are content-keyed; Cargo outputs are never reused.
+          CARGO_TARGET_DIR: ${{ github.workspace }}/.product-target
           # Exercise release code with only the typed recovery fixture exported.
           NOON_RENDERER_SMOKE: "1"
         run: |
+          mv candidate .product-source
+          trap 'mv .product-source candidate' EXIT
+          rm -rf .product-target
           sccache --zero-stats
           noon_build_started=$SECONDS
-          bash scripts/build-web-demo.sh
+          (cd .product-source && bash scripts/build-web-demo.sh)
           printf 'Candidate release build: %s seconds.\n' "$((SECONDS - noon_build_started))" >> "$GITHUB_STEP_SUMMARY"
           sccache --show-stats
 


### PR DESCRIPTION
Advances #1265: reuse matching Rust compiler results between the product gate's baseline and candidate release builds. The first trial exposed zero cache hits because sccache 0.16.0 includes the Rust working directory and CARGO_TARGET_DIR in its keys.

Both exact source checkouts now build sequentially at `.product-source` with the same `.product-target` path. Each build first removes all Cargo target outputs/fingerprints; an EXIT trap restores its checkout, including the freshly generated package, to baseline/candidate. Only a 1 GiB job-local, content-keyed sccache survives between builds. No cross-PR compiler seed or executable package is restored or published. Different source/compiler/features remain distinct cache inputs.

Use each checkout's pinned Rust compiler and WASM target, keep the existing production release settings and candidate renderer-smoke feature, and report each build's seconds/cache statistics. Browser/visual/latency/FPS checks and thresholds are unchanged. Also correct the product path filter to the consolidated `noon-text` crate.

Validation: YAML parsed; every inline run block passed `bash -n`; `git diff --check` passed. The architecture gate passed for the initial workflow change. Qualification uses the actual PR product job and existing applicable PR gates; no redundant local/full Rust build was launched.

Earlier trial 34353385466 at b264a5dc built successfully but reported 0/311 candidate cache hits (baseline344s, candidate333s), then failed FPS52.2→41.4 against floor41.7. That head is not qualified and no acceleration is claimed from it. The current stable-path correction is a source change addressing the measured cache-key mismatch, not a retry that changes the performance threshold. Its replacement head qualified as recorded below.

The initial runner.temp job-context syntax issue was corrected before that trial. This PR changes one workflow only, introduces no engine authority or migration seam, and leaves the native/direct-WASM engine boundaries intact.


Final qualification: exact head9e7ac575dbead7011d303c8771189b716db27aeb passed all seven applicable PR gates. Product run34355013854 passed on its first attempt: baseline build338s, candidate78s; candidate303cachehits/8misses (97.43%), cache352MiB. Visual/latency/FPS comparisons passed (43.8→45.5FPS). This is one within-job baseline/candidate observation, not a controlled estimate for every future PR or overall CI wall time. Compared with the preceding zero-hit trial's333s candidate build, the observed candidate build is255s shorter. PR merged after this qualification.
