### PR TITLE
fix: preserve compiler and runtime error cause chains (#1272 R2)

### DIFF
--- a/crates/noon-compile/src/lib.rs
+++ b/crates/noon-compile/src/lib.rs
@@ -479,7 +479,14 @@ impl std::fmt::Display for CompileError {
     }
 }
 
-impl std::error::Error for CompileError {}
+impl std::error::Error for CompileError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::InvalidTrack(error) => Some(error),
+            _ => None,
+        }
+    }
+}
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum CompilePatchError {
@@ -620,7 +627,15 @@ impl std::fmt::Display for CompilePatchError {
     }
 }
 
-impl std::error::Error for CompilePatchError {}
+impl std::error::Error for CompilePatchError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::InvalidTrack(error) => Some(error),
+            Self::Resource(error) => Some(error),
+            _ => None,
+        }
+    }
+}
 
 impl CompiledScene {
     /// Validate the bounded affine completion policy for newly activated tracks.

--- a/crates/noon-compile/src/semantic_lowering/animation_payload/affine.rs
+++ b/crates/noon-compile/src/semantic_lowering/animation_payload/affine.rs
@@ -483,7 +483,19 @@ impl std::fmt::Display for SemanticAffineAnimationTrackError {
     }
 }
 
-impl std::error::Error for SemanticAffineAnimationTrackError {}
+impl std::error::Error for SemanticAffineAnimationTrackError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Animation(error) => Some(error),
+            Self::Target { error, .. } => Some(error),
+            Self::InvalidSubsetDisplayTimeMap { error, .. } => Some(error),
+            Self::InvalidTargetValue { error, .. } => Some(error),
+            Self::InvalidTargetStyle { error, .. } => Some(error),
+            Self::InvalidTrack { error, .. } => Some(error),
+            _ => None,
+        }
+    }
+}
 
 /// Lower the supported transform/style payload of one resolved semantic activation.
 ///

--- a/crates/noon-compile/src/semantic_lowering/animation_payload/prepared_composition.rs
+++ b/crates/noon-compile/src/semantic_lowering/animation_payload/prepared_composition.rs
@@ -213,7 +213,19 @@ impl std::fmt::Display for PreparedSemanticAnimationLoweringError {
     }
 }
 
-impl std::error::Error for PreparedSemanticAnimationLoweringError {}
+impl std::error::Error for PreparedSemanticAnimationLoweringError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Schedule(error) => Some(error),
+            Self::TextGlyph(error) => Some(error),
+            Self::Target { error, .. } => Some(error),
+            Self::InvalidSubsetDisplayTimeMap { error, .. } => Some(error),
+            Self::InvalidTargetValue { error, .. } => Some(error),
+            Self::InvalidTargetStyle { error, .. } => Some(error),
+            _ => None,
+        }
+    }
+}
 
 /// Lower one prepared animation graph through the canonical schedule and shared payload paths.
 ///

--- a/crates/noon-compile/src/semantic_lowering/animation_payload/text_write.rs
+++ b/crates/noon-compile/src/semantic_lowering/animation_payload/text_write.rs
@@ -51,7 +51,17 @@ impl std::fmt::Display for TextGlyphLoweringError {
     }
 }
 
-impl std::error::Error for TextGlyphLoweringError {}
+impl std::error::Error for TextGlyphLoweringError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::InvalidMembers(error) => Some(error),
+            Self::InvalidPlan(error) => Some(error),
+            Self::InvalidSpec(error) => Some(error),
+            Self::InvalidTimeMap(error) => Some(error),
+            _ => None,
+        }
+    }
+}
 
 fn plan(
     store: &SemanticStore,

--- a/crates/noon-compile/src/semantic_lowering/animation_payload/transform_payload.rs
+++ b/crates/noon-compile/src/semantic_lowering/animation_payload/transform_payload.rs
@@ -64,7 +64,15 @@ impl std::fmt::Display for SemanticTransformToPayloadError {
     }
 }
 
-impl std::error::Error for SemanticTransformToPayloadError {}
+impl std::error::Error for SemanticTransformToPayloadError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Options(error) => Some(error),
+            Self::Target { error, .. } => Some(error),
+            _ => None,
+        }
+    }
+}
 
 impl SemanticTransformToPayloadError {
     /// Whether the source and target are valid semantic objects but request a

--- a/crates/noon-compile/src/semantic_lowering/animation_schedule.rs
+++ b/crates/noon-compile/src/semantic_lowering/animation_schedule.rs
@@ -251,6 +251,28 @@ pub enum PreparedSemanticAnimationLookupError {
     InitialObjectPropertyTrack,
 }
 
+impl std::fmt::Display for PreparedSemanticAnimationLookupError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Transaction(error) => error.fmt(formatter),
+            Self::Existing(error) => error.fmt(formatter),
+            Self::InitialObjectPropertyTrack => formatter.write_str(
+                "initial object property tracks are not prepared animation declarations",
+            ),
+        }
+    }
+}
+
+impl std::error::Error for PreparedSemanticAnimationLookupError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Transaction(error) => Some(error),
+            Self::Existing(error) => Some(error),
+            Self::InitialObjectPropertyTrack => None,
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum PreparedSemanticAnimationScheduleError {
     InvalidStartTime(f64),
@@ -311,7 +333,15 @@ impl std::fmt::Display for PreparedScalarAnimationTrackError {
     }
 }
 
-impl std::error::Error for PreparedScalarAnimationTrackError {}
+impl std::error::Error for PreparedScalarAnimationTrackError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Signal { error, .. } => Some(error),
+            Self::InvalidTimeMap { error, .. } => Some(error),
+            _ => None,
+        }
+    }
+}
 
 /// Derive authored scalar timeline tracks in the recursive scheduler's stable leaf order.
 pub fn derive_prepared_scalar_animation_tracks(
@@ -369,7 +399,16 @@ impl std::fmt::Display for PreparedSemanticAnimationScheduleError {
     }
 }
 
-impl std::error::Error for PreparedSemanticAnimationScheduleError {}
+impl std::error::Error for PreparedSemanticAnimationScheduleError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Lookup { error, .. } => Some(error),
+            Self::Options { error, .. } => Some(error),
+            Self::Composition { error, .. } => Some(error),
+            _ => None,
+        }
+    }
+}
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum SemanticAnimationScheduleError {
@@ -460,7 +499,16 @@ impl std::fmt::Display for SemanticAnimationScheduleError {
     }
 }
 
-impl std::error::Error for SemanticAnimationScheduleError {}
+impl std::error::Error for SemanticAnimationScheduleError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Animation(error) => Some(error),
+            Self::Options { error, .. } => Some(error),
+            Self::Composition { error, .. } => Some(error),
+            _ => None,
+        }
+    }
+}
 
 /// Resolve one explicitly selected semantic animation declaration into deterministic
 /// execution timing without creating another scheduler or evaluator.

--- a/crates/noon-compile/src/semantic_lowering/compiled_scene.rs
+++ b/crates/noon-compile/src/semantic_lowering/compiled_scene.rs
@@ -68,7 +68,14 @@ impl std::fmt::Display for SemanticCompiledSceneError {
     }
 }
 
-impl std::error::Error for SemanticCompiledSceneError {}
+impl std::error::Error for SemanticCompiledSceneError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Resource { error, .. } => Some(error),
+            _ => None,
+        }
+    }
+}
 
 impl CompiledScene {
     /// Materialize the already value-lowered semantic object projection into the

--- a/crates/noon-compile/src/semantic_lowering/entrypoint.rs
+++ b/crates/noon-compile/src/semantic_lowering/entrypoint.rs
@@ -134,7 +134,17 @@ impl std::fmt::Display for SemanticExecutionLoweringError {
     }
 }
 
-impl std::error::Error for SemanticExecutionLoweringError {}
+impl std::error::Error for SemanticExecutionLoweringError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Object(error) => Some(error),
+            Self::Reactive(error) => Some(error),
+            Self::Compiled(error) => Some(error),
+            Self::InitialAnimation(error) => Some(error),
+            _ => None,
+        }
+    }
+}
 
 /// Canonical A1.6 initial-scene lowering entry point.
 ///

--- a/crates/noon-compile/src/semantic_lowering/initial_animation.rs
+++ b/crates/noon-compile/src/semantic_lowering/initial_animation.rs
@@ -133,7 +133,20 @@ impl std::fmt::Display for SemanticInitialAnimationError {
     }
 }
 
-impl std::error::Error for SemanticInitialAnimationError {}
+impl std::error::Error for SemanticInitialAnimationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Schedule(error) => Some(error),
+            Self::Family(error) => Some(error),
+            Self::Animation(error) => Some(error),
+            Self::Endpoint { error, .. } => Some(error),
+            Self::EndpointValue { error, .. } => Some(error),
+            Self::EndpointGeometry { error, .. } => Some(error),
+            Self::Compiled(error) => Some(error),
+            _ => None,
+        }
+    }
+}
 
 pub(super) fn install_initial_animation_root(
     store: &SemanticStore,

--- a/crates/noon-compile/src/semantic_lowering/projection.rs
+++ b/crates/noon-compile/src/semantic_lowering/projection.rs
@@ -321,7 +321,14 @@ impl std::fmt::Display for SemanticLoweringError {
     }
 }
 
-impl std::error::Error for SemanticLoweringError {}
+impl std::error::Error for SemanticLoweringError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Store(error) => Some(error),
+            _ => None,
+        }
+    }
+}
 
 #[derive(Clone, Debug, PartialEq)]
 struct LoweredObjectState {

--- a/crates/noon-compile/src/semantic_lowering/publication.rs
+++ b/crates/noon-compile/src/semantic_lowering/publication.rs
@@ -110,7 +110,18 @@ impl std::fmt::Display for SemanticPublicationLoweringError {
         }
     }
 }
-impl std::error::Error for SemanticPublicationLoweringError {}
+impl std::error::Error for SemanticPublicationLoweringError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::PreparedValue { error, .. } => Some(error),
+            Self::PreparedGeometry { error, .. } => Some(error),
+            Self::PreparedContent { error, .. } => Some(error),
+            Self::Read(error) => Some(error),
+            Self::Value(error) => Some(error),
+            _ => None,
+        }
+    }
+}
 impl From<SemanticLoweringError> for SemanticPublicationLoweringError {
     fn from(error: SemanticLoweringError) -> Self {
         Self::Value(error)

--- a/crates/noon-compile/src/semantic_lowering/reactive.rs
+++ b/crates/noon-compile/src/semantic_lowering/reactive.rs
@@ -318,7 +318,14 @@ impl std::fmt::Display for PreparedScalarSignalTimelineError {
     }
 }
 
-impl std::error::Error for PreparedScalarSignalTimelineError {}
+impl std::error::Error for PreparedScalarSignalTimelineError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Lowering(error) => Some(error),
+            _ => None,
+        }
+    }
+}
 
 impl From<SemanticReactiveLoweringError> for PreparedScalarSignalTimelineError {
     fn from(value: SemanticReactiveLoweringError) -> Self {
@@ -490,7 +497,15 @@ impl std::fmt::Display for SemanticReactiveLoweringError {
     }
 }
 
-impl std::error::Error for SemanticReactiveLoweringError {}
+impl std::error::Error for SemanticReactiveLoweringError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Signal(error) => Some(error),
+            Self::Reactive(error) => Some(error),
+            _ => None,
+        }
+    }
+}
 
 /// Lower only the native-reactive dependency closure reachable from visible object
 /// bindings in one semantic execution projection.

--- a/crates/noon-compile/tests/error_causes.rs
+++ b/crates/noon-compile/tests/error_causes.rs
@@ -1,0 +1,423 @@
+//! Typed causes survive compiler wrappers without changing rejection policy.
+use noon_compile::*;
+use noon_core::{SemanticNodeId, SemanticObjectState, SemanticStore, StoredGeometry};
+use std::error::Error;
+
+fn assert_cause<C: Error + Clone + PartialEq + 'static, E: Error>(
+    cause: C,
+    wrap: impl FnOnce(C) -> E,
+) {
+    let expected = cause.clone();
+    let error = wrap(cause);
+    assert_eq!(
+        error.source().and_then(|source| source.downcast_ref::<C>()),
+        Some(&expected)
+    );
+    assert!(!error.source().unwrap().to_string().is_empty());
+}
+fn node() -> SemanticNodeId {
+    SemanticStore::new().insert_family()
+}
+fn resource() -> CompiledResourceError {
+    CompiledResourceError::MissingFont(noon_core::FontResourceKey {
+        face_key: "missing-font".into(),
+        face_index: 0,
+    })
+}
+fn scene_error(id: SemanticNodeId) -> noon_core::SemanticSceneOperationError {
+    noon_core::SemanticSceneOperationError::NotSemanticObject(id)
+}
+fn value_error(id: SemanticNodeId) -> SemanticLoweringError {
+    SemanticLoweringError::ValueOutOfRange {
+        node: id,
+        field: SemanticExecutionField::Translation,
+    }
+}
+fn compact_error() -> SemanticExecutionValueError {
+    SemanticExecutionValueError::ValueOutOfRange {
+        field: SemanticExecutionField::Translation,
+    }
+}
+fn time_map() -> noon_core::CompositionTimeMapError {
+    noon_core::CompositionTimeMapError::IntervalOutsideParent { index: 0 }
+}
+
+#[test]
+fn compiled_errors() {
+    let id = node();
+    assert_cause(
+        noon_core::TimelineError::InvalidDuration(-1.0),
+        CompileError::InvalidTrack,
+    );
+    assert_cause(
+        noon_core::TimelineError::InvalidDuration(-1.0),
+        CompilePatchError::InvalidTrack,
+    );
+    assert_cause(resource(), CompilePatchError::Resource);
+    assert_cause(resource(), |error| SemanticCompiledSceneError::Resource {
+        node: id,
+        error,
+    });
+}
+
+#[test]
+fn scheduled_errors() {
+    let id = node();
+    assert_cause(
+        noon_core::SemanticAnimationError::UnknownAnimation(id),
+        SemanticAnimationScheduleError::Animation,
+    );
+    assert_cause(
+        noon_core::AnimationOptionsError::InvalidRunTime(-1.0),
+        |error| SemanticAnimationScheduleError::Options {
+            animation: id,
+            error,
+        },
+    );
+    assert_cause(noon_core::CompositionError::Empty, |error| {
+        SemanticAnimationScheduleError::Composition {
+            animation: id,
+            error,
+        }
+    });
+    assert_cause(
+        noon_core::SemanticTransactionReadError::UnknownExistingNode(id),
+        PreparedSemanticAnimationLookupError::Transaction,
+    );
+    assert_cause(
+        noon_core::SemanticAnimationError::UnknownAnimation(id),
+        PreparedSemanticAnimationLookupError::Existing,
+    );
+    assert_cause(
+        PreparedSemanticAnimationLookupError::InitialObjectPropertyTrack,
+        |error| PreparedSemanticAnimationScheduleError::Lookup {
+            animation: id.into(),
+            error,
+        },
+    );
+    assert_cause(
+        noon_core::AnimationOptionsError::InvalidRunTime(-1.0),
+        |error| PreparedSemanticAnimationScheduleError::Options {
+            animation: id.into(),
+            error,
+        },
+    );
+    assert_cause(noon_core::CompositionError::Empty, |error| {
+        PreparedSemanticAnimationScheduleError::Composition {
+            animation: id.into(),
+            error,
+        }
+    });
+    assert_cause(
+        noon_core::SemanticScalarSignalQueryError::InvalidTime,
+        |error| PreparedScalarAnimationTrackError::Signal { signal: id, error },
+    );
+    assert_cause(time_map(), |error| {
+        PreparedScalarAnimationTrackError::InvalidTimeMap {
+            animation: id.into(),
+            error,
+        }
+    });
+}
+
+#[test]
+fn affine_errors() {
+    let id = node();
+    assert_cause(
+        noon_core::SemanticAnimationError::UnknownAnimation(id),
+        SemanticAffineAnimationTrackError::Animation,
+    );
+    assert_cause(scene_error(id), |error| {
+        SemanticAffineAnimationTrackError::Target {
+            animation: id,
+            node: id,
+            error,
+        }
+    });
+    assert_cause(time_map(), |error| {
+        SemanticAffineAnimationTrackError::InvalidSubsetDisplayTimeMap {
+            animation: id,
+            error,
+        }
+    });
+    assert_cause(
+        noon_core::SemanticLoweringError::CoordinateOutOfRange(noon_core::SemanticVec3::new(
+            f64::MAX,
+            0.0,
+            0.0,
+        )),
+        |error| SemanticAffineAnimationTrackError::InvalidTargetValue {
+            animation: id,
+            target_state: id,
+            field: SemanticAffineAnimationField::Translation,
+            error,
+        },
+    );
+    assert_cause(value_error(id), |error| {
+        SemanticAffineAnimationTrackError::InvalidTargetStyle {
+            animation: id,
+            target_state: id,
+            error,
+        }
+    });
+    assert_cause(noon_core::TimelineError::InvalidDuration(-1.0), |error| {
+        SemanticAffineAnimationTrackError::InvalidTrack {
+            animation: id,
+            error,
+        }
+    });
+    assert_cause(
+        noon_core::AnimationOptionsError::UnsupportedPathArc(1.0),
+        SemanticTransformToPayloadError::Options,
+    );
+    assert_cause(scene_error(id), |error| {
+        SemanticTransformToPayloadError::Target { node: id, error }
+    });
+}
+
+#[test]
+fn prepared_animation_errors() {
+    let id = node();
+    assert_cause(
+        PreparedSemanticAnimationScheduleError::InvalidStartTime(-1.0),
+        PreparedSemanticAnimationLoweringError::Schedule,
+    );
+    assert_cause(
+        TextGlyphLoweringError::MissingSemanticTarget(id.into()),
+        PreparedSemanticAnimationLoweringError::TextGlyph,
+    );
+    assert_cause(
+        noon_core::SemanticTransactionReadError::UnknownExistingNode(id),
+        |error| PreparedSemanticAnimationLoweringError::Target {
+            animation: id.into(),
+            node: id.into(),
+            error,
+        },
+    );
+    assert_cause(time_map(), |error| {
+        PreparedSemanticAnimationLoweringError::InvalidSubsetDisplayTimeMap {
+            animation: id.into(),
+            error,
+        }
+    });
+    assert_cause(
+        noon_core::SemanticLoweringError::CoordinateOutOfRange(noon_core::SemanticVec3::new(
+            f64::MAX,
+            0.0,
+            0.0,
+        )),
+        |error| PreparedSemanticAnimationLoweringError::InvalidTargetValue {
+            animation: id.into(),
+            target_state: id.into(),
+            field: SemanticAffineAnimationField::Translation,
+            error,
+        },
+    );
+    assert_cause(compact_error(), |error| {
+        PreparedSemanticAnimationLoweringError::InvalidTargetStyle {
+            animation: id.into(),
+            target_state: id.into(),
+            error,
+        }
+    });
+    assert_cause(
+        noon_core::RetainedAnimationMemberError::TooManyMembers(usize::MAX),
+        TextGlyphLoweringError::InvalidMembers,
+    );
+    assert_cause(
+        noon_core::RetainedFamilyAnimationMemberPlanError::Members(
+            noon_core::RetainedAnimationMemberError::TooManyMembers(usize::MAX),
+        ),
+        TextGlyphLoweringError::InvalidPlan,
+    );
+    assert_cause(
+        noon_core::FamilyAnimationError::InvalidDuration(-1.0),
+        TextGlyphLoweringError::InvalidSpec,
+    );
+    assert_cause(time_map(), TextGlyphLoweringError::InvalidTimeMap);
+}
+
+#[test]
+fn initial_animation_errors() {
+    let id = node();
+    assert_cause(
+        SemanticAnimationScheduleError::InvalidStartTime(-1.0),
+        SemanticInitialAnimationError::Schedule,
+    );
+    assert_cause(
+        TextGlyphLoweringError::MissingSemanticTarget(id.into()),
+        SemanticInitialAnimationError::Family,
+    );
+    assert_cause(
+        noon_core::SemanticAnimationError::UnknownAnimation(id),
+        SemanticInitialAnimationError::Animation,
+    );
+    assert_cause(scene_error(id), |error| {
+        SemanticInitialAnimationError::Endpoint {
+            animation: id,
+            node: id,
+            error,
+        }
+    });
+    assert_cause(value_error(id), |error| {
+        SemanticInitialAnimationError::EndpointValue {
+            animation: id,
+            node: id,
+            error,
+        }
+    });
+    assert_cause(
+        SemanticGeometryValueError::InvalidAnalyticGeometry,
+        |error| SemanticInitialAnimationError::EndpointGeometry {
+            animation: id,
+            node: id,
+            error,
+        },
+    );
+    assert_cause(
+        CompilePatchError::InvalidTrack(noon_core::TimelineError::InvalidDuration(-1.0)),
+        SemanticInitialAnimationError::Compiled,
+    );
+}
+
+#[test]
+fn publication_and_reactive_errors() {
+    let id = node();
+    assert_cause(
+        noon_core::SemanticStoreError::UnknownNode(id),
+        SemanticLoweringError::Store,
+    );
+    assert_cause(compact_error(), |error| {
+        SemanticPublicationLoweringError::PreparedValue {
+            object: id.into(),
+            error,
+        }
+    });
+    assert_cause(
+        SemanticGeometryValueError::InvalidAnalyticGeometry,
+        |error| SemanticPublicationLoweringError::PreparedGeometry {
+            object: id.into(),
+            error,
+        },
+    );
+    assert_cause(
+        SemanticCompiledSceneError::InvalidAnalyticGeometry { node: id },
+        |error| SemanticPublicationLoweringError::PreparedContent {
+            object: id.into(),
+            error,
+        },
+    );
+    assert_cause(
+        noon_core::SemanticTransactionReadError::UnknownExistingNode(id),
+        SemanticPublicationLoweringError::Read,
+    );
+    assert_cause(value_error(id), SemanticPublicationLoweringError::Value);
+    assert_cause(
+        noon_core::SemanticSignalError::UnknownSignal(id),
+        SemanticReactiveLoweringError::Signal,
+    );
+    assert_cause(
+        noon_core::ReactiveError::DependencyCycle,
+        SemanticReactiveLoweringError::Reactive,
+    );
+    assert_cause(
+        SemanticReactiveLoweringError::DependencyCycle(id),
+        PreparedScalarSignalTimelineError::Lowering,
+    );
+    assert_cause(value_error(id), SemanticExecutionLoweringError::Object);
+    assert_cause(
+        SemanticReactiveLoweringError::DependencyCycle(id),
+        SemanticExecutionLoweringError::Reactive,
+    );
+    assert_cause(
+        SemanticCompiledSceneError::InvalidAnalyticGeometry { node: id },
+        SemanticExecutionLoweringError::Compiled,
+    );
+    assert_cause(
+        SemanticInitialAnimationError::InvalidOrigin(-1.0),
+        SemanticExecutionLoweringError::InitialAnimation,
+    );
+}
+
+#[test]
+fn prepared_lookup_preserves_a_multilevel_chain_and_leaf_termination() {
+    let id = node();
+    let error = PreparedSemanticAnimationLoweringError::Schedule(
+        PreparedSemanticAnimationScheduleError::Lookup {
+            animation: id.into(),
+            error: PreparedSemanticAnimationLookupError::Transaction(
+                noon_core::SemanticTransactionReadError::UnknownExistingNode(id),
+            ),
+        },
+    );
+    let schedule = error
+        .source()
+        .unwrap()
+        .downcast_ref::<PreparedSemanticAnimationScheduleError>()
+        .unwrap();
+    let lookup = schedule
+        .source()
+        .unwrap()
+        .downcast_ref::<PreparedSemanticAnimationLookupError>()
+        .unwrap();
+    let read = lookup
+        .source()
+        .unwrap()
+        .downcast_ref::<noon_core::SemanticTransactionReadError>()
+        .unwrap();
+    assert_eq!(
+        read,
+        &noon_core::SemanticTransactionReadError::UnknownExistingNode(id)
+    );
+    assert!(read.source().is_none());
+    assert!(
+        PreparedSemanticAnimationLookupError::InitialObjectPropertyTrack
+            .source()
+            .is_none()
+    );
+    assert!(
+        SemanticExecutionLoweringError::InvalidCameraObject { node: id }
+            .source()
+            .is_none()
+    );
+    assert!(value_error(id).source().is_none());
+}
+
+#[test]
+fn actual_invalid_root_keeps_index_and_semantics_then_recovers() {
+    let mut store = SemanticStore::new();
+    let object = store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+        radius: 1.0,
+    }));
+    let root = store.insert_family();
+    store.add_member(root, object).unwrap();
+    let mut index = SemanticExecutionIndex::new();
+    let revision = store.scene_revision();
+    let nodes = store.len();
+    let state = store.semantic_object_state_checked(object).unwrap().clone();
+    let error = lower_semantic_execution_root(&store, object, &mut index).unwrap_err();
+    let SemanticExecutionLoweringError::Object(inner) = &error else {
+        panic!("unexpected error category");
+    };
+    let observed = error
+        .source()
+        .unwrap()
+        .downcast_ref::<SemanticLoweringError>()
+        .unwrap();
+    assert!(std::ptr::eq(inner, observed));
+    assert_eq!(
+        observed
+            .source()
+            .unwrap()
+            .downcast_ref::<noon_core::SemanticStoreError>(),
+        Some(&noon_core::SemanticStoreError::NotFamily(object))
+    );
+    assert!(index.is_empty());
+    assert_eq!(store.scene_revision(), revision);
+    assert_eq!(store.len(), nodes);
+    assert_eq!(store.semantic_object_state_checked(object).unwrap(), &state);
+    let output = lower_semantic_execution_root(&store, root, &mut index).unwrap();
+    assert_eq!(index.len(), 1);
+    assert_eq!(output.publication_context().scene_revision(), revision);
+    assert_eq!(store.scene_revision(), revision);
+}

--- a/crates/noon-runtime/src/execution_slots/runtime_transaction.rs
+++ b/crates/noon-runtime/src/execution_slots/runtime_transaction.rs
@@ -102,7 +102,16 @@ impl std::fmt::Display for AuthoredPublicationError {
     }
 }
 
-impl std::error::Error for AuthoredPublicationError {}
+impl std::error::Error for AuthoredPublicationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Evaluation(error) => Some(error),
+            Self::PreparedFrame(error) => Some(error),
+            Self::Compile(error) => Some(error),
+            _ => None,
+        }
+    }
+}
 
 impl From<CompilePatchError> for AuthoredPublicationError {
     fn from(value: CompilePatchError) -> Self {

--- a/crates/noon-runtime/src/lib.rs
+++ b/crates/noon-runtime/src/lib.rs
@@ -76,7 +76,14 @@ impl std::fmt::Display for EvaluationError {
     }
 }
 
-impl std::error::Error for EvaluationError {}
+impl std::error::Error for EvaluationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Reactive(error) => Some(error),
+            _ => None,
+        }
+    }
+}
 
 #[derive(Clone, Debug)]
 struct TrackGroup {

--- a/crates/noon-runtime/src/reactive/family_plan_frame.rs
+++ b/crates/noon-runtime/src/reactive/family_plan_frame.rs
@@ -41,7 +41,14 @@ impl std::fmt::Display for RetainedFamilyFramePlanError {
     }
 }
 
-impl std::error::Error for RetainedFamilyFramePlanError {}
+impl std::error::Error for RetainedFamilyFramePlanError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Evaluation(error) => Some(error),
+            _ => None,
+        }
+    }
+}
 
 impl From<RetainedFamilyAnimationEvaluationError> for RetainedFamilyFramePlanError {
     fn from(value: RetainedFamilyAnimationEvaluationError) -> Self {

--- a/crates/noon-runtime/src/reactive/family_plan_set_frame.rs
+++ b/crates/noon-runtime/src/reactive/family_plan_set_frame.rs
@@ -130,7 +130,14 @@ impl std::fmt::Display for RetainedPlannedFamilyFrameError {
     }
 }
 
-impl std::error::Error for RetainedPlannedFamilyFrameError {}
+impl std::error::Error for RetainedPlannedFamilyFrameError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Plan(error) => Some(error),
+            _ => None,
+        }
+    }
+}
 
 impl From<RetainedFamilyFramePlanError> for RetainedPlannedFamilyFrameError {
     fn from(value: RetainedFamilyFramePlanError) -> Self {

--- a/crates/noon-runtime/tests/error_causes.rs
+++ b/crates/noon-runtime/tests/error_causes.rs
@@ -1,0 +1,88 @@
+//! Runtime wrappers retain existing typed failures for facade/boundary mapping.
+use noon_compile::CompilePatchError;
+use noon_runtime::{
+    AuthoredPublicationError, EvaluationError, PreparedFrameCommitError,
+    RetainedFamilyFramePlanError, RetainedPlannedFamilyFrameError,
+};
+use std::error::Error;
+
+fn assert_cause<C: Error + Clone + PartialEq + 'static, E: Error>(
+    cause: C,
+    wrap: impl FnOnce(C) -> E,
+) {
+    let expected = cause.clone();
+    let error = wrap(cause);
+    assert_eq!(
+        error.source().and_then(|source| source.downcast_ref::<C>()),
+        Some(&expected)
+    );
+}
+
+#[test]
+fn publication_and_evaluation_wrappers_expose_immediate_causes() {
+    assert_cause(
+        noon_core::ReactiveError::DependencyCycle,
+        EvaluationError::Reactive,
+    );
+    assert_cause(
+        EvaluationError::RequiredCallbackPending,
+        AuthoredPublicationError::Evaluation,
+    );
+    assert_cause(
+        PreparedFrameCommitError::StaleTime {
+            expected: 1.0,
+            actual: 2.0,
+        },
+        AuthoredPublicationError::PreparedFrame,
+    );
+    assert_cause(
+        CompilePatchError::InvalidTrack(noon_core::TimelineError::InvalidDuration(-1.0)),
+        AuthoredPublicationError::Compile,
+    );
+    assert!(EvaluationError::RequiredCallbackPending.source().is_none());
+    assert!(AuthoredPublicationError::StaleEffectiveCarryForward
+        .source()
+        .is_none());
+}
+
+#[test]
+fn renderer_independent_family_wrappers_preserve_plan_failures() {
+    let id = noon_core::SemanticStore::new().insert_family();
+    assert_cause(
+        noon_core::RetainedFamilyAnimationEvaluationError::MissingLeafDescriptor(id),
+        RetainedFamilyFramePlanError::Evaluation,
+    );
+    assert_cause(
+        RetainedFamilyFramePlanError::ObjectIndexOutOfBounds {
+            index: 2,
+            object_count: 1,
+        },
+        RetainedPlannedFamilyFrameError::Plan,
+    );
+    assert!(RetainedPlannedFamilyFrameError::FrameShapeMismatch
+        .source()
+        .is_none());
+}
+
+#[test]
+fn publication_chain_reaches_original_compiler_timeline_failure_by_reference() {
+    let error = AuthoredPublicationError::Compile(CompilePatchError::InvalidTrack(
+        noon_core::TimelineError::InvalidDuration(-1.0),
+    ));
+    let AuthoredPublicationError::Compile(inner) = &error else {
+        unreachable!()
+    };
+    let source = error
+        .source()
+        .unwrap()
+        .downcast_ref::<CompilePatchError>()
+        .unwrap();
+    assert!(std::ptr::eq(source, inner));
+    let timeline = source
+        .source()
+        .unwrap()
+        .downcast_ref::<noon_core::TimelineError>()
+        .unwrap();
+    assert_eq!(timeline, &noon_core::TimelineError::InvalidDuration(-1.0));
+    assert!(timeline.source().is_none());
+}


### PR DESCRIPTION
## Scope and ownership

A disjoint cause-propagation part of #958 / #1272 R2 / #1292 R2, coordinated with the active object/animation producer and WASM/Python mapper owners. Their enums, producer signatures, policy, and language mapping are not changed by this PR. Complements #1336's semantic transaction cause fix and the #1286 typed foundation; does not claim whole R2 completion.

Base: `d6734d2a0626f5c9926e4043ad2017a94f5c8c5a`.
Source head: **`faffdd857398a62c2056e00659b98e1629ce74d8`**.
18 files: 16 existing compiler/runtime implementations and two focused integration test files.

## Change

Expose existing immediate error fields through `std::error::Error::source` in compiler value/resource, animation schedule/payload, initial-scene/reactive/publication wrappers and runtime evaluation/publication/family-frame wrappers. Every return is a reference to the error already stored by the variant; no clone, allocation, new category, new validation, or human-message classification.

The already-existing `PreparedSemanticAnimationLookupError` lacked Display/Error entirely. Add those traits, forwarding its existing Transaction/Existing variants and leaving InitialObjectPropertyTrack terminal. Existing enclosing diagnostic formatting remains unchanged. No new universal error abstraction or compatibility alias.

This makes existing chains such as runtime publication -> compile patch -> timeline validation and prepared animation -> schedule -> lookup -> staged read traversable. Core domain causes remain with their owning producer work; #1336 separately handles transaction/read causes.

## Tests and qualification

Added **8 compiler and 3 runtime tests**. They exercise every newly forwarded immediate variant, leaf termination, useful diagnostics, multilevel cause traversal and identity of borrowed causes. A real invalid-root lowering test verifies unchanged store state/revision and no partial execution-index entry, then successful lowering/recovery. Existing production preflight/commit implementations are untouched.

Hosted run **34352521525**, attempt 1, passed before source publication:

```
cargo fmt --all
git diff --check
cargo test -p noon-compile -p noon-runtime --test error_causes
cargo test -p noon-compile -p noon-runtime --all-features
cargo clippy -p noon-compile -p noon-runtime --all-targets --all-features -- -D warnings
bash scripts/check.sh architecture d6734d2a0626f5c9926e4043ad2017a94f5c8c5a
cargo test -p noon-compile -p noon-runtime --test error_causes --target wasm32-unknown-unknown --no-run
```

**11/11 new tests passed. Full compiler/runtime qualification: 314 tests passed, zero failed or ignored**, including the new tests (not an additional 314 distinct new cases). Strict Clippy and architecture gate passed; both new WASM executables compiled. WASM compilation is not a browser-execution claim. Final applicable PR checks and review remain required before merge.

The exact source-only candidate, patch and complete hosted log were downloaded and inspected. Rust execution was hosted because the editing container lacks Cargo. No local Rust/full-browser/performance pass is claimed. Development generation/workflow helpers remain exclusively on a separate prep branch, absent from this PR.

## Architecture

Read AGENTS and the authoritative architecture. No authored/runtime/renderer authority, new crate, scheduler, codec, provider dependency or migration seam. Semantic behavior, error variant fields, traversal complexity, allocation and commit ordering are unchanged. There are no core/facade/Python/renderer/manifest/production-workflow edits in this diff.

The user authorized merging after sound review and tests. No bypass or auto-merge is requested. Remaining producer and language-boundary conversions stay tracked under #1292 and are not marked complete by this cause-only change.