### PR TITLE
Fix rooted publication anchors and nested alias ordering (#1292 R4)

### DIFF
--- a/crates/noon-compile/src/semantic_lowering/root_order.rs
+++ b/crates/noon-compile/src/semantic_lowering/root_order.rs
@@ -1,5 +1,7 @@
 //! Lower authored family ordering into derived execution painter-order patches.
 
+use std::collections::HashMap;
+
 use noon_core::{
     PreparedSemanticMutationTransaction, SemanticMutation, SemanticNodeId, SemanticNodeKind,
     SemanticStore, SemanticTransactionNodeRef,
@@ -9,6 +11,145 @@ use super::{
     semantic_execution_object_id, SemanticLoweringError, SemanticPublicationLoweringError,
 };
 use crate::ExecutionPatch;
+
+// Only changed root links are retained. Untouched links are read directly from
+// the authored root; this is not a second scene or a semantic validator. The
+// prepared transaction has already validated all membership operations.
+#[derive(Clone, Copy)]
+struct RootLinks {
+    previous: Option<SemanticTransactionNodeRef>,
+    next: Option<SemanticTransactionNodeRef>,
+}
+
+struct RootOrder<'a> {
+    root: &'a noon_core::SemanticNode,
+    links: HashMap<SemanticTransactionNodeRef, Option<RootLinks>>,
+    tail: Option<SemanticTransactionNodeRef>,
+}
+
+impl<'a> RootOrder<'a> {
+    fn new(root: &'a noon_core::SemanticNode) -> Self {
+        Self {
+            root,
+            links: HashMap::new(),
+            tail: root.last_member().map(Into::into),
+        }
+    }
+
+    fn links(&self, member: SemanticTransactionNodeRef) -> Option<RootLinks> {
+        self.links.get(&member).copied().unwrap_or_else(|| {
+            let member = member.existing()?;
+            self.root.contains_member(member).then(|| RootLinks {
+                previous: self.root.previous_member(member).map(Into::into),
+                next: self.root.next_member(member).map(Into::into),
+            })
+        })
+    }
+
+    fn next(&self, member: SemanticTransactionNodeRef) -> Option<SemanticTransactionNodeRef> {
+        self.links(member).and_then(|links| links.next)
+    }
+
+    fn set_next(
+        &mut self,
+        member: Option<SemanticTransactionNodeRef>,
+        next: Option<SemanticTransactionNodeRef>,
+    ) {
+        if let Some(member) = member {
+            let mut links = self
+                .links(member)
+                .expect("validated root predecessor remains present");
+            links.next = next;
+            self.links.insert(member, Some(links));
+        }
+    }
+
+    fn set_previous(
+        &mut self,
+        member: Option<SemanticTransactionNodeRef>,
+        previous: Option<SemanticTransactionNodeRef>,
+    ) {
+        if let Some(member) = member {
+            let mut links = self
+                .links(member)
+                .expect("validated root successor remains present");
+            links.previous = previous;
+            self.links.insert(member, Some(links));
+        } else {
+            self.tail = previous;
+        }
+    }
+
+    fn remove(&mut self, member: SemanticTransactionNodeRef) {
+        if let Some(links) = self.links(member) {
+            self.set_next(links.previous, links.next);
+            self.set_previous(links.next, links.previous);
+            self.links.insert(member, None);
+        }
+    }
+
+    fn insert_before(
+        &mut self,
+        member: SemanticTransactionNodeRef,
+        before: Option<SemanticTransactionNodeRef>,
+    ) {
+        if before == Some(member) || self.links(member).is_some_and(|links| links.next == before) {
+            return;
+        }
+        self.remove(member);
+        let previous = match before {
+            Some(anchor) => {
+                self.links(anchor)
+                    .expect("validated root anchor remains present")
+                    .previous
+            }
+            None => self.tail,
+        };
+        self.set_next(previous, Some(member));
+        self.set_previous(before, Some(member));
+        self.links.insert(
+            member,
+            Some(RootLinks {
+                previous,
+                next: before,
+            }),
+        );
+    }
+}
+
+fn node_for_root_order(
+    store: &SemanticStore,
+    node: SemanticNodeId,
+) -> Result<&noon_core::SemanticNode, SemanticPublicationLoweringError> {
+    #[cfg(test)]
+    tests::NODES_VISITED.with(|count| count.set(count.get() + 1));
+    store.node(node).ok_or_else(|| {
+        SemanticPublicationLoweringError::from(SemanticLoweringError::Store(
+            noon_core::SemanticStoreError::UnknownNode(node),
+        ))
+    })
+}
+
+// An anchor needs only its first visible leaf, not a snapshot of its whole
+// descendant family. Empty branches are skipped in authoritative member order.
+fn first_leaf(
+    store: &SemanticStore,
+    node: SemanticNodeId,
+) -> Result<Option<SemanticNodeId>, SemanticPublicationLoweringError> {
+    let node = node_for_root_order(store, node)?;
+    match node.kind() {
+        SemanticNodeKind::AuthoringObject => Ok(Some(node.id())),
+        SemanticNodeKind::Family => {
+            for member in node.members_iter() {
+                if let Some(leaf) = first_leaf(store, member)? {
+                    return Ok(Some(leaf));
+                }
+            }
+            Ok(None)
+        }
+        SemanticNodeKind::Signal(_) | SemanticNodeKind::Animation(_) => Ok(None),
+    }
+}
 
 /// Prepare execution order changes for an explicitly rooted authored transaction.
 ///
@@ -25,15 +166,11 @@ pub fn prepare_semantic_root_order(
         node: SemanticNodeId,
         output: &mut Vec<SemanticNodeId>,
     ) -> Result<(), SemanticPublicationLoweringError> {
-        let node_state = store.node(node).ok_or_else(|| {
-            SemanticPublicationLoweringError::from(SemanticLoweringError::Store(
-                noon_core::SemanticStoreError::UnknownNode(node),
-            ))
-        })?;
+        let node_state = node_for_root_order(store, node)?;
         match node_state.kind() {
             SemanticNodeKind::AuthoringObject => output.push(node),
             SemanticNodeKind::Family => {
-                for member in node_state.members() {
+                for member in node_state.members_iter() {
                     leaves(store, member, output)?;
                 }
             }
@@ -42,8 +179,34 @@ pub fn prepare_semantic_root_order(
         Ok(())
     }
 
+    let root_node = node_for_root_order(prepared.store(), root)?;
+    if !matches!(root_node.kind(), SemanticNodeKind::Family) {
+        return Err(
+            SemanticLoweringError::Store(noon_core::SemanticStoreError::NotFamily(root)).into(),
+        );
+    }
+
+    let mut order = RootOrder::new(root_node);
     let mut patches = Vec::new();
     for mutation in prepared.candidate_mutations() {
+        match mutation {
+            SemanticMutation::AddMember { family, member } if family.existing() == Some(root) => {
+                order.insert_before(*member, None);
+            }
+            SemanticMutation::RemoveMember { family, member }
+                if family.existing() == Some(root) =>
+            {
+                order.remove(*member);
+            }
+            SemanticMutation::ReorderMember {
+                family,
+                member,
+                before,
+            } if family.existing() == Some(root) => {
+                order.insert_before(*member, *before);
+            }
+            _ => {}
+        }
         match mutation {
             SemanticMutation::AddMember { family, member } if family.existing() == Some(root) => {
                 let Some(member) = member.existing() else {
@@ -68,17 +231,20 @@ pub fn prepare_semantic_root_order(
                 };
                 let mut member_leaves = Vec::new();
                 leaves(prepared.store(), member, &mut member_leaves)?;
-                let mut anchor =
-                    if let Some(before) = before.and_then(SemanticTransactionNodeRef::existing) {
-                        let mut anchor_leaves = Vec::new();
-                        leaves(prepared.store(), before, &mut anchor_leaves)?;
-                        anchor_leaves
-                            .first()
-                            .copied()
-                            .map(semantic_execution_object_id)
-                    } else {
-                        None
-                    };
+                let mut before = before.and_then(SemanticTransactionNodeRef::existing);
+                let mut anchor = None;
+                while let Some(candidate) = before {
+                    if let Some(leaf) = first_leaf(prepared.store(), candidate)? {
+                        anchor = Some(semantic_execution_object_id(leaf));
+                        break;
+                    }
+                    // An empty root member still marks a semantic position. Its
+                    // next staged sibling, not the execution tail or a removed
+                    // published sibling, supplies the anchor.
+                    before = order
+                        .next(candidate.into())
+                        .and_then(SemanticTransactionNodeRef::existing);
+                }
                 for leaf in member_leaves.into_iter().rev() {
                     let object = semantic_execution_object_id(leaf);
                     patches.push(ExecutionPatch::ReorderObject {
@@ -99,6 +265,10 @@ mod tests {
     use noon_core::{SemanticMutationTransaction, SemanticObjectState, StoredGeometry};
 
     use super::*;
+
+    std::thread_local! {
+        pub(super) static NODES_VISITED: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    }
 
     #[test]
     fn family_reorder_prepares_leaf_order_without_publishing_semantics() {
@@ -140,5 +310,107 @@ mod tests {
             prepared.store().node(root).unwrap().members(),
             &[nodes[0], family]
         );
+    }
+
+    #[test]
+    fn empty_anchor_uses_the_next_root_leaf_without_publishing() {
+        let mut store = SemanticStore::new();
+        let root = store.insert_family();
+        let empty = store.insert_family();
+        let nodes = (0..3)
+            .map(|_| {
+                store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+                    radius: 1.0,
+                }))
+            })
+            .collect::<Vec<_>>();
+        for member in [nodes[0], empty, nodes[1], nodes[2]] {
+            store.add_member(root, member).unwrap();
+        }
+        let revision = store.scene_revision();
+        let mutation_stats = store.last_mutation_stats();
+        let mut transaction = SemanticMutationTransaction::new();
+        transaction.reorder_member(root, nodes[2], Some(empty));
+        let prepared = transaction.prepare(&mut store).unwrap();
+        assert_eq!(
+            prepare_semantic_root_order(&prepared, root).unwrap(),
+            vec![ExecutionPatch::ReorderObject {
+                object: semantic_execution_object_id(nodes[2]),
+                before: Some(semantic_execution_object_id(nodes[1])),
+            }],
+        );
+        drop(prepared);
+        assert_eq!(store.scene_revision(), revision);
+        assert_eq!(store.last_mutation_stats(), mutation_stats);
+        assert_eq!(
+            store.node(root).unwrap().members(),
+            &[nodes[0], empty, nodes[1], nodes[2]]
+        );
+    }
+
+    #[test]
+    fn invalid_roots_are_rejected_even_without_root_mutations() {
+        let mut store = SemanticStore::new();
+        let object =
+            store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+                radius: 1.0,
+            }));
+        let unknown = SemanticNodeId::new(u32::MAX, 0);
+        let prepared = SemanticMutationTransaction::new()
+            .prepare(&mut store)
+            .unwrap();
+        for (root, expected) in [
+            (unknown, noon_core::SemanticStoreError::UnknownNode(unknown)),
+            (object, noon_core::SemanticStoreError::NotFamily(object)),
+        ] {
+            assert!(matches!(prepare_semantic_root_order(&prepared, root),
+                Err(SemanticPublicationLoweringError::Value(SemanticLoweringError::Store(error)))
+                    if error == expected));
+        }
+    }
+
+    #[test]
+    fn anchor_work_is_independent_of_unrelated_roots_and_anchor_tail() {
+        for unrelated in [0, 20_000] {
+            let mut store = SemanticStore::new();
+            let root = store.insert_family();
+            let detached = store.insert_family();
+            let anchor_family = store.insert_family();
+            let first =
+                store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+                    radius: 1.0,
+                }));
+            store.add_member(anchor_family, first).unwrap();
+            for family in [root, detached, anchor_family] {
+                for _ in 0..unrelated {
+                    let node = store.insert_semantic_object(SemanticObjectState::new(
+                        StoredGeometry::Circle { radius: 1.0 },
+                    ));
+                    store.add_member(family, node).unwrap();
+                }
+            }
+            let empty = store.insert_family();
+            let moved =
+                store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+                    radius: 1.0,
+                }));
+            for member in [empty, anchor_family, moved] {
+                store.add_member(root, member).unwrap();
+            }
+            let mut transaction = SemanticMutationTransaction::new();
+            transaction.reorder_member(root, moved, Some(empty));
+            let prepared = transaction.prepare(&mut store).unwrap();
+            NODES_VISITED.with(|count| count.set(0));
+            assert_eq!(
+                prepare_semantic_root_order(&prepared, root).unwrap(),
+                vec![ExecutionPatch::ReorderObject {
+                    object: semantic_execution_object_id(moved),
+                    before: Some(semantic_execution_object_id(first)),
+                }],
+            );
+            // Root validation + moved leaf + empty anchor + anchor family + its
+            // first leaf. No prefix, unrelated family, or anchor-tail traversal.
+            assert_eq!(NODES_VISITED.with(|count| count.get()), 5);
+        }
     }
 }

--- a/crates/noon-core/src/semantic_store.rs
+++ b/crates/noon-core/src/semantic_store.rs
@@ -415,6 +415,11 @@ impl SemanticNode {
         self.members.head
     }
 
+    /// Return the last member without traversing or allocating sibling order.
+    pub fn last_member(&self) -> Option<SemanticNodeId> {
+        self.members.tail
+    }
+
     /// Direct successor of `member`, resolved without scanning siblings.
     pub fn next_member(&self, member: SemanticNodeId) -> Option<SemanticNodeId> {
         self.members.links.get(&member).and_then(|link| link.next)

--- a/crates/noon/tests/root_order_acceptance.rs
+++ b/crates/noon/tests/root_order_acceptance.rs
@@ -1,0 +1,420 @@
+//! Root-order acceptance coverage for #1292 / the compiler extraction in #1305.
+//! Raw fixture construction stays at the explicit integration boundary. Every
+//! live edit uses the existing typed LiveSession and atomic publication path.
+
+use std::{cell::RefCell, collections::HashSet, rc::Rc};
+
+use noon::integration::{SemanticMutationTransaction, SemanticNodeKind, SemanticStore};
+use noon::{ExecutionSession, ExecutionSessionPublicationError, LiveSession, LiveSessionError};
+use noon_compile::{
+    semantic_execution_object_id, SemanticLoweringError, SemanticPublicationLoweringError,
+};
+use noon_core::{
+    plan_semantic_scene_membership, ObjectId, SemanticNodeId, SemanticObjectProperty,
+    SemanticObjectState, SemanticSceneMembershipRequest, SemanticStoreError, SemanticVec3,
+    StoredGeometry,
+};
+
+type Owner = Rc<RefCell<SemanticStore>>;
+
+fn object(store: &mut SemanticStore) -> SemanticNodeId {
+    store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+        radius: 1.0,
+    }))
+}
+
+fn family(store: &mut SemanticStore, members: &[SemanticNodeId]) -> SemanticNodeId {
+    let family = store.insert_family();
+    for &member in members {
+        store.add_member(family, member).unwrap();
+    }
+    family
+}
+
+fn session(store: SemanticStore, root: SemanticNodeId) -> (Owner, ExecutionSession) {
+    let mut session = ExecutionSession::from_semantic_root(&store, root).unwrap();
+    session.take_frame_changes();
+    (Rc::new(RefCell::new(store)), session)
+}
+
+fn painter_order(session: &ExecutionSession) -> Vec<ObjectId> {
+    session
+        .painter_order()
+        .iter()
+        .map(|&row| session.frame().objects[row as usize].id)
+        .collect()
+}
+
+// Deliberately simple full traversal used only as a test oracle. Production
+// root-order preparation must not rebuild this whole-root projection.
+fn reference_order(store: &SemanticStore, root: SemanticNodeId) -> Vec<ObjectId> {
+    fn visit(
+        store: &SemanticStore,
+        id: SemanticNodeId,
+        seen: &mut HashSet<SemanticNodeId>,
+        result: &mut Vec<ObjectId>,
+    ) {
+        if !seen.insert(id) {
+            return;
+        }
+        let node = store.node(id).unwrap();
+        match node.kind() {
+            SemanticNodeKind::AuthoringObject => result.push(semantic_execution_object_id(id)),
+            SemanticNodeKind::Family => {
+                for child in node.members_iter() {
+                    visit(store, child, seen, result);
+                }
+            }
+            SemanticNodeKind::Signal(_) | SemanticNodeKind::Animation(_) => {}
+        }
+    }
+    let mut result = Vec::new();
+    visit(store, root, &mut HashSet::new(), &mut result);
+    result
+}
+
+fn assert_reference(owner: &Owner, session: &ExecutionSession, root: SemanticNodeId) {
+    assert_eq!(
+        painter_order(session),
+        reference_order(&owner.borrow(), root)
+    );
+    assert_eq!(session.last_patch_stats().full_seeks, 0);
+    assert_eq!(session.last_patch_stats().full_group_rebuilds, 0);
+}
+
+fn edit(
+    owner: &Owner,
+    session: &mut ExecutionSession,
+    root: SemanticNodeId,
+    request: SemanticSceneMembershipRequest<'_>,
+) {
+    let transaction = plan_semantic_scene_membership(&owner.borrow(), root, request).unwrap();
+    LiveSession::new(owner, root, session)
+        .apply(transaction)
+        .unwrap();
+    assert_reference(owner, session, root);
+}
+
+#[test]
+fn all_single_root_reorders_match_reference_with_empty_and_nested_families() {
+    for moved in 0..5 {
+        for anchor in 0..=5 {
+            let mut store = SemanticStore::new();
+            let a = object(&mut store);
+            let b = object(&mut store);
+            let c = object(&mut store);
+            let d = object(&mut store);
+            let empty = family(&mut store, &[]);
+            let group = family(&mut store, &[b, c]);
+            let nested_empty = family(&mut store, &[empty]);
+            let members = [a, empty, group, nested_empty, d];
+            let root = family(&mut store, &members);
+            let (owner, mut live) = session(store, root);
+            let rows = live
+                .frame()
+                .objects
+                .iter()
+                .map(|row| row.id)
+                .collect::<Vec<_>>();
+            let before = members.get(anchor).copied();
+            let mut transaction = SemanticMutationTransaction::new();
+            transaction.reorder_member(root, members[moved], before);
+            LiveSession::new(&owner, root, &mut live)
+                .apply(transaction)
+                .unwrap();
+            let mut expected = members.to_vec();
+            if before != Some(members[moved]) {
+                expected.remove(moved);
+                let position = before
+                    .and_then(|before| expected.iter().position(|node| *node == before))
+                    .unwrap_or(expected.len());
+                expected.insert(position, members[moved]);
+            }
+            assert_eq!(owner.borrow().node(root).unwrap().members(), expected);
+            assert_eq!(
+                painter_order(&live),
+                reference_order(&owner.borrow(), root),
+                "move {moved} before {anchor}"
+            );
+            assert_eq!(
+                live.frame()
+                    .objects
+                    .iter()
+                    .map(|row| row.id)
+                    .collect::<Vec<_>>(),
+                rows
+            );
+            assert_eq!(live.last_patch_stats().full_seeks, 0);
+            assert_eq!(live.last_patch_stats().full_group_rebuilds, 0);
+        }
+    }
+}
+
+#[test]
+fn shared_membership_remove_replace_and_add_preserve_empty_boundary_order() {
+    let mut store = SemanticStore::new();
+    let [left, removed, survivor, right, x, y] = std::array::from_fn(|_| object(&mut store));
+    let nested = family(&mut store, &[removed, survivor]);
+    let empty = family(&mut store, &[]);
+    let replacement = family(&mut store, &[x, y]);
+    let root = family(&mut store, &[left, nested, empty, right]);
+    let (owner, mut live) = session(store, root);
+    let identity = live.runtime_identity();
+    let left_slot = live.execution_slot_for_frame_index(0);
+
+    edit(
+        &owner,
+        &mut live,
+        root,
+        SemanticSceneMembershipRequest::Remove(&[removed]),
+    );
+    assert_eq!(
+        owner.borrow().node(nested).unwrap().members(),
+        &[removed, survivor]
+    );
+    edit(
+        &owner,
+        &mut live,
+        root,
+        SemanticSceneMembershipRequest::Replace {
+            old: survivor,
+            new: replacement,
+        },
+    );
+    edit(
+        &owner,
+        &mut live,
+        root,
+        SemanticSceneMembershipRequest::Add(&[y]),
+    );
+    edit(
+        &owner,
+        &mut live,
+        root,
+        SemanticSceneMembershipRequest::Remove(&[right]),
+    );
+    assert_eq!(live.runtime_identity(), identity);
+    assert_eq!(live.execution_slot_for_frame_index(0), left_slot);
+    edit(
+        &owner,
+        &mut live,
+        root,
+        SemanticSceneMembershipRequest::Clear,
+    );
+    assert!(painter_order(&live).is_empty());
+    edit(
+        &owner,
+        &mut live,
+        root,
+        SemanticSceneMembershipRequest::Add(&[nested]),
+    );
+}
+
+#[test]
+fn empty_only_reorder_is_authored_only_and_exact_noop_publishes_nothing() {
+    let mut store = SemanticStore::new();
+    let a = object(&mut store);
+    let b = object(&mut store);
+    let empty = family(&mut store, &[]);
+    let root = family(&mut store, &[a, empty, b]);
+    let (owner, mut live) = session(store, root);
+    let before = live.publication_context();
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction.reorder_member(root, empty, None);
+    LiveSession::new(&owner, root, &mut live)
+        .apply(transaction)
+        .unwrap();
+    let after = live.publication_context();
+    assert_eq!(
+        after.scene_revision(),
+        before.scene_revision().checked_next().unwrap()
+    );
+    assert_eq!(after.execution_revision(), before.execution_revision());
+    assert_eq!(
+        after.frame_epoch(),
+        before.frame_epoch().checked_next().unwrap()
+    );
+    assert!(live.take_frame_changes().is_empty());
+    let mut noop = SemanticMutationTransaction::new();
+    noop.reorder_member(root, empty, None);
+    LiveSession::new(&owner, root, &mut live)
+        .apply(noop)
+        .unwrap();
+    assert_eq!(live.publication_context(), after);
+    assert!(live.take_frame_changes().is_empty());
+}
+
+#[test]
+fn invalid_explicit_root_rejects_before_publication_and_valid_root_recovers() {
+    for wrong_kind in [false, true] {
+        let mut store = SemanticStore::new();
+        let a = object(&mut store);
+        let b = object(&mut store);
+        let root = family(&mut store, &[a, b]);
+        let invalid = if wrong_kind {
+            a
+        } else {
+            SemanticNodeId::new(root.slot(), root.generation() + 1)
+        };
+        let (owner, mut live) = session(store, root);
+        let before = live.publication_context();
+        let frame = live.frame().clone();
+        let slot = live.execution_slot_for_frame_index(0);
+        let mut transaction = SemanticMutationTransaction::new();
+        transaction.reorder_member(root, b, Some(a));
+        let error = LiveSession::new(&owner, invalid, &mut live)
+            .apply(transaction)
+            .unwrap_err();
+        let expected = if wrong_kind {
+            SemanticStoreError::NotFamily(invalid)
+        } else {
+            SemanticStoreError::UnknownNode(invalid)
+        };
+        assert!(matches!(error,
+            LiveSessionError::Publication(ExecutionSessionPublicationError::Lowering(
+                SemanticPublicationLoweringError::Value(SemanticLoweringError::Store(error))
+            )) if error == expected));
+        assert_eq!(live.publication_context(), before);
+        assert_eq!(owner.borrow().scene_revision(), before.scene_revision());
+        assert_eq!(owner.borrow().node(root).unwrap().members(), &[a, b]);
+        assert_eq!(live.frame(), &frame);
+        assert_eq!(live.execution_slot_for_frame_index(0), slot);
+        assert!(live.take_frame_changes().is_empty());
+        let mut valid = SemanticMutationTransaction::new();
+        valid.reorder_member(root, b, Some(a));
+        LiveSession::new(&owner, root, &mut live)
+            .apply(valid)
+            .unwrap();
+        assert_reference(&owner, &live, root);
+    }
+}
+
+#[test]
+fn failed_mixed_order_and_value_preparation_preserves_existing_dirty_state() {
+    let mut store = SemanticStore::new();
+    let a = object(&mut store);
+    let b = object(&mut store);
+    let root = family(&mut store, &[a, b]);
+    let (owner, mut live) = session(store, root);
+    let mut first = SemanticMutationTransaction::new();
+    first.set_property(
+        a,
+        SemanticObjectProperty::Translation,
+        SemanticVec3::new(2.0, 0.0, 0.0),
+    );
+    LiveSession::new(&owner, root, &mut live)
+        .apply(first)
+        .unwrap();
+    let before = live.publication_context();
+    let frame = live.frame().clone();
+    let mut invalid = SemanticMutationTransaction::new();
+    invalid.reorder_member(root, b, Some(a));
+    invalid.set_property(b, SemanticObjectProperty::RotationZ, f64::MAX);
+    assert!(matches!(
+        LiveSession::new(&owner, root, &mut live).apply(invalid),
+        Err(LiveSessionError::Publication(
+            ExecutionSessionPublicationError::Lowering(_)
+        ))
+    ));
+    assert_eq!(live.publication_context(), before);
+    assert_eq!(owner.borrow().scene_revision(), before.scene_revision());
+    assert_eq!(owner.borrow().node(root).unwrap().members(), &[a, b]);
+    assert_eq!(live.frame(), &frame);
+    let changes = live.take_frame_changes();
+    assert_eq!(changes.object_indices(), &[0]);
+    assert_eq!(changes.painter_order_range(), None);
+    let mut valid = SemanticMutationTransaction::new();
+    valid.reorder_member(root, b, Some(a));
+    LiveSession::new(&owner, root, &mut live)
+        .apply(valid)
+        .unwrap();
+    assert_reference(&owner, &live, root);
+}
+
+#[test]
+fn alias_membership_edits_match_first_occurrence_projection_without_identity_churn() {
+    let mut store = SemanticStore::new();
+    let shared = object(&mut store);
+    let a = object(&mut store);
+    let b = object(&mut store);
+    let left = family(&mut store, &[shared, a]);
+    let right = family(&mut store, &[shared, b]);
+    let root = family(&mut store, &[left, right]);
+    let (owner, mut live) = session(store, root);
+    assert_reference(&owner, &live, root);
+    edit(
+        &owner,
+        &mut live,
+        root,
+        SemanticSceneMembershipRequest::Remove(&[shared]),
+    );
+    edit(
+        &owner,
+        &mut live,
+        root,
+        SemanticSceneMembershipRequest::Add(&[left]),
+    );
+    edit(
+        &owner,
+        &mut live,
+        root,
+        SemanticSceneMembershipRequest::Remove(&[left]),
+    );
+    edit(
+        &owner,
+        &mut live,
+        root,
+        SemanticSceneMembershipRequest::Add(&[right]),
+    );
+    assert_eq!(owner.borrow().node(left).unwrap().members(), &[shared, a]);
+    assert_eq!(owner.borrow().node(right).unwrap().members(), &[shared, b]);
+}
+
+#[test]
+fn ordered_publication_advances_revisions_once_and_survives_forward_and_backward_seek() {
+    let mut store = SemanticStore::new();
+    let [a, b, c] = std::array::from_fn(|_| object(&mut store));
+    let root = family(&mut store, &[a, b, c]);
+    let (owner, mut live) = session(store, root);
+    let before = live.publication_context();
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction.reorder_member(root, c, Some(a));
+    LiveSession::new(&owner, root, &mut live)
+        .apply(transaction)
+        .unwrap();
+    let after = live.publication_context();
+    assert_eq!(
+        after.scene_revision(),
+        before.scene_revision().checked_next().unwrap()
+    );
+    assert_eq!(
+        after.execution_revision(),
+        before.execution_revision().checked_next().unwrap()
+    );
+    assert_eq!(
+        after.frame_epoch(),
+        before.frame_epoch().checked_next().unwrap()
+    );
+    let changes = live.take_frame_changes();
+    assert_eq!(changes.painter_order_range(), Some(0..3));
+    assert!(changes.object_indices().is_empty());
+    for time in [1.0, 2.0, 0.0, 1.0] {
+        live.seek(time).unwrap();
+        assert_eq!(painter_order(&live), reference_order(&owner.borrow(), root));
+        assert_eq!(
+            live.publication_context().scene_revision(),
+            after.scene_revision()
+        );
+        assert_eq!(
+            live.publication_context().execution_revision(),
+            after.execution_revision()
+        );
+    }
+    let context = live.publication_context();
+    let mut noop = SemanticMutationTransaction::new();
+    noop.reorder_member(root, c, Some(a));
+    LiveSession::new(&owner, root, &mut live)
+        .apply(noop)
+        .unwrap();
+    assert_eq!(live.publication_context(), context);
+}

--- a/crates/noon/tests/root_order_transaction_regressions.rs
+++ b/crates/noon/tests/root_order_transaction_regressions.rs
@@ -1,0 +1,119 @@
+use std::{cell::RefCell, rc::Rc};
+
+use noon::integration::{SemanticMutationTransaction, SemanticStore};
+use noon::{ExecutionSession, LiveSession};
+use noon_compile::semantic_execution_object_id;
+use noon_core::{
+    plan_semantic_scene_membership, SemanticNodeId, SemanticObjectState,
+    SemanticSceneMembershipRequest, StoredGeometry,
+};
+
+fn object(store: &mut SemanticStore) -> SemanticNodeId {
+    store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+        radius: 1.0,
+    }))
+}
+
+fn family(store: &mut SemanticStore, members: &[SemanticNodeId]) -> SemanticNodeId {
+    let family = store.insert_family();
+    for &member in members {
+        store.add_member(family, member).unwrap();
+    }
+    family
+}
+
+fn assert_order(store: &SemanticStore, root: SemanticNodeId, session: &ExecutionSession) {
+    let actual = session
+        .painter_order()
+        .iter()
+        .map(|&index| session.frame().objects[index as usize].id)
+        .collect::<Vec<_>>();
+    let expected = store
+        .ordered_leaf_nodes(root)
+        .unwrap()
+        .into_iter()
+        .map(semantic_execution_object_id)
+        .collect::<Vec<_>>();
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn shared_remove_preserves_promoted_empty_anchors() {
+    let mut store = SemanticStore::new();
+    let [a, b, c, right] = std::array::from_fn(|_| object(&mut store));
+    let empty = family(&mut store, &[]);
+    let nested = family(&mut store, &[a, b, empty, c]);
+    let root = family(&mut store, &[nested, right]);
+    let mut session = ExecutionSession::from_semantic_root(&store, root).unwrap();
+    let transaction =
+        plan_semantic_scene_membership(&store, root, SemanticSceneMembershipRequest::Remove(&[a]))
+            .unwrap();
+    let owner = Rc::new(RefCell::new(store));
+    LiveSession::new(&owner, root, &mut session)
+        .apply(transaction)
+        .unwrap();
+    assert_order(&owner.borrow(), root, &session);
+}
+
+#[test]
+fn shared_remove_skips_removed_successor_of_empty_anchor() {
+    let mut store = SemanticStore::new();
+    let [a, b, removed, right] = std::array::from_fn(|_| object(&mut store));
+    let nested = family(&mut store, &[a, b]);
+    let empty = family(&mut store, &[]);
+    let root = family(&mut store, &[nested, empty, removed, right]);
+    let mut session = ExecutionSession::from_semantic_root(&store, root).unwrap();
+    let transaction = plan_semantic_scene_membership(
+        &store,
+        root,
+        SemanticSceneMembershipRequest::Remove(&[a, removed]),
+    )
+    .unwrap();
+    let owner = Rc::new(RefCell::new(store));
+    LiveSession::new(&owner, root, &mut session)
+        .apply(transaction)
+        .unwrap();
+    assert_order(&owner.borrow(), root, &session);
+}
+
+#[test]
+fn compound_reorder_uses_staged_empty_anchor_successor() {
+    let mut store = SemanticStore::new();
+    let [a, b, c] = std::array::from_fn(|_| object(&mut store));
+    let empty = family(&mut store, &[]);
+    let root = family(&mut store, &[empty, a, b, c]);
+    let mut session = ExecutionSession::from_semantic_root(&store, root).unwrap();
+    let owner = Rc::new(RefCell::new(store));
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction.reorder_member(root, a, Some(c));
+    transaction.reorder_member(root, c, Some(empty));
+    LiveSession::new(&owner, root, &mut session)
+        .apply(transaction)
+        .unwrap();
+    assert_order(&owner.borrow(), root, &session);
+}
+
+#[test]
+fn terminal_removal_of_reordered_leaf_never_half_publishes() {
+    let mut store = SemanticStore::new();
+    let [a, b, c] = std::array::from_fn(|_| object(&mut store));
+    let root = family(&mut store, &[a, b, c]);
+    let mut session = ExecutionSession::from_semantic_root(&store, root).unwrap();
+    session.take_frame_changes();
+    let before = session.publication_context();
+    let frame = session.frame().clone();
+    let owner = Rc::new(RefCell::new(store));
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction.reorder_member(root, c, Some(a));
+    transaction.remove_node(c);
+    match LiveSession::new(&owner, root, &mut session).apply(transaction) {
+        Ok(_) => assert_order(&owner.borrow(), root, &session),
+        Err(_) => {
+            assert_eq!(session.publication_context(), before);
+            assert_eq!(owner.borrow().scene_revision(), before.scene_revision());
+            assert_eq!(owner.borrow().node(root).unwrap().members(), &[a, b, c]);
+            assert_eq!(session.frame(), &frame);
+            assert!(session.take_frame_changes().is_empty());
+        }
+    }
+}


### PR DESCRIPTION
## Scope and current verdict

Bounded verification/correction of merged #1305 against **#1292 R4**. Reuses the existing compiler-owned root-order extraction; no repeated extraction or general `ExecutionSession` rewrite.

**Current head: `a74343c97039e2322a23bb45582f49c829843aeb`. Exact-head focused tests, full fast gate and direct WASM compilation pass.** The provisional-empty-anchor review is addressed, and the formerly failing nested-alias append is repaired. **R4 remains open for one demonstrated cross-root alias-order failure**, described below. No full-R4 closure, merge, auto-merge or independent approval is claimed.

The complete PR changes four files: the existing compiler root-order module/tests, the five-line constant-time `SemanticNode::last_member()` accessor, and two external regression files. This continuation changes only the compiler file and existing compound-regression file. No session production, Python/WASM boundary mapper, semantic error framework, provider/module ownership, new patch vocabulary or serialization boundary. Qualification helpers remain outside the product diff.

## Revision ledger and coordination

Read `AGENTS.md`, `docs/architecture.md`, #1292, #1305, #1286/#1290 boundaries, active work and the [new review](https://github.com/yongkyuns/noon/pull/1340#issuecomment-5602383291). The existing architecture remains authoritative.

| Item | Exact revision |
|---|---|
| #1305 original head / merge | `32c1411627da3efba7f16077bfc4dcf4bf698f3a` / `7807a1e944b34054964240f65a578ecc820b44e7` |
| Original production baseline | `d6734d2a0626f5c9926e4043ad2017a94f5c8c5a` |
| Previous PR head, retained as first parent | `9c429f36330b969968c0fc91f244bfbd6e9c8b9c` |
| Integrated master, second parent | `100228bd97fee5d7e44aab3a0cf9736808c04858` |
| Current product head | **`a74343c97039e2322a23bb45582f49c829843aeb`** |
| Current product tree | `2da254e1d20d0b46f9f1d0cd4b5b7d039113a1c1` |

The branch was advanced without force, preserving previous PR history and all intervening R1/R2/R5/R6 work. Master was reread after qualification and remained `100228bd…`. New source blobs match both locally tested and hosted archived bytes: compiler `aca8b3b2c8caf0b690a28e775833c8f0b0f5e6c4`, compound tests `bc22bfcc32632db38cf9f18a361b4636df851637`. Existing accessor and acceptance blobs remain `d7b68f1a9fd00aa9d939cdb4d1c37402bb741346` and `bb8f1503ea47d741c748130a42733fca98cacee7`.

## Demonstrated failures and correction

Original [baseline run 34351143794](https://github.com/yongkyuns/noon/actions/runs/34351143794) on unchanged production had **4 passing / 3 failing** acceptance tests: a nonempty reorder before an empty family moved to the painter tail, shared removal misplaced a promoted survivor across an empty boundary, and a stale explicit root could publish semantic order without corresponding execution order. The earlier correction added typed root validation, sparse transaction-touched root links and early-stopping anchor lookup. Compound probes rejected an insufficient intermediate implementation before it became the product PR; the previous handoff retains those diagnostics.

The [reviewed provisional-anchor case](https://github.com/yongkyuns/noon/pull/1340#issuecomment-5602383291) exposed a further defect in the previous head: conversion to `existing()` discarded a transaction-created empty family before successor lookup. The continuation preserves `SemanticTransactionNodeRef` through traversal and resolves only actual leaves using the existing prepared transaction's allocator proof. The same private visitor now serves moved blocks and anchors, deduplicating both objects and family DAG nodes in first-occurrence order. No authored allocation or publication happens during this traversal.

Local red/green on master `3b9afa397…` plus previous PR files:
- New compound regressions against old production: **4 previous passed / all 4 new failed**.
- New compiler regressions against old production: **4 previous passed / both 2 new failed**.
- Corrected production: **15 external tests and 6 compiler tests passed**.

One initial test draft had a Rust temporary-borrow compilation error, corrected before the executable baseline; it is retained separately and not described as an engine failure. The old DAG case emitted 4,096 duplicate reorder patches. The corrected first-occurrence visitor emits one.

## Acceptance → evidence

| #1292 R4 criterion | Evidence and limitation |
|---|---|
| One compiler owner; session only coordinates | `prepare_semantic_root_order` remains the sole lowerer. The session publication implementation is unchanged. Existing typed `ReorderObject` patches and error causes remain the boundary; architecture/dependency guards pass. |
| Supported add/remove/reorder/replace | Existing external acceptance exercises shared Add/Remove/Replace/Clear, nested promotion, stable rows and slots. Thirty single-root reorder arrangements match an independent reference traversal. Compound/promoted/removed empty-anchor tests pass. |
| Provisional references and nested aliases | New tests cover provisional empty anchors, provisional object/nested-family position, and nested repeated-leaf append/reorder. The exact reviewed compiler reproduction now passes. Duplicate family DAG paths no longer duplicate leaf patches. |
| Cross-root aliases | **Partial.** Shared-planner alias cases and nested-alias append pass. Raw reorder of two distinct root families sharing a leaf still misorders that leaf. This is not an explicit unsupported-operation rejection. |
| Failure atomicity and recovery | Stale/wrong-kind roots and invalid mixed order/value batches preserve authored membership/revision, publication context, effective frame, execution slot and dirty output. New provisional rejection/recovery proves that rejected preparation consumes no semantic identity. Existing resource/slot/spatial/pending/stale publication tests rerun in the full library gate. Renderer-facing dirty output is observed; no new GPU-failure injection test is claimed. |
| Revision rules and forward/seek | Actual reorder advances S/E/F once; empty-only authored edit advances S/F without E; exact no-op/rejection advances none. Forward/backward seek preserves accepted painter order and S/E. Provisional empty-anchor insertion preserves effective rows and execution slots. |
| Locality | Existing lookup test remains **5 visits with 0 or 60,000 extra objects** across unrelated prefix/detached/anchor-tail content. New 12-level diamond DAG tests assert **39/40 node lookups** and one patch, rather than 4,096 duplicate paths. No whole-root vector/store clone is added. This is not a universal allocation-byte, pending-tree or cross-root-DAG complexity qualification. |
| Native/direct-WASM/paired frontend | Exact-head native regressions and full fast gate pass; direct WASM compilation passes. Normal Native Host, Provider, PR Fast, Architecture and Dependency workflows pass. Product and cross-browser workflows were still running at the latest recorded snapshot; their complete result is not inferred from compile-only WASM. No new Python-specific fixture is claimed. |

## Exact-head hosted qualification

**[Run 34359198597](https://github.com/yongkyuns/noon/actions/runs/34359198597), job `102491521714`, completed successfully.** The read-only helper workflow at `defa45b1b5c070bc8c993c211908c6635e7c1675` explicitly checked out product `a74343c…`, checked its integrated-master parent, and left tracked source unmodified. Rust/Cargo **1.98.0**.

```sh
cargo fmt --all -- --check
cargo test -p noon-compile --no-default-features --lib root_order -- --nocapture
cargo test -p noon --no-default-features \
  --test root_order_acceptance --test root_order_transaction_regressions \
  --no-fail-fast -- --nocapture
bash scripts/check.sh fast 100228bd97fee5d7e44aab3a0cf9736808c04858
cargo check -p noon-web --all-features --target wasm32-unknown-unknown
```

Results: **6 focused compiler tests, 15 external tests, 1,400 full-workspace library tests passed; 3 pre-existing ignored tests.** Architecture, formatting, all-target/all-feature workspace check, strict Clippy and direct-WASM compile passed. The six focused compiler tests overlap the library suite and are not independent extra coverage. WASM compilation is not browser execution.

Artifact **10107278915**, `r4-continuation-qualification`, retains exact revisions/parents/tree, source blobs, hashes, Cargo.lock, patches and logs. ZIP SHA-256 **`42dcc8307f3021b6816e4e016c3660c3ef363dbc42b3a484051f53983ec90a79`** was independently checked after download; archived source matches the locally tested/uploaded blobs. The only untracked path was the evidence directory.

Additional local native qualification: **399 minimal library tests** (247 noon + 152 compiler) passed, no failures/skips. Local `scripts/check.sh fast HEAD` on the source snapshot passed architecture but hit its command deadline during all-feature dependency compilation; **it is not counted as a full local-gate pass**. The successful full gate above is actual exact-head hosted execution, not substitution of previous-head CI.

Normal PR runs: [Fast](https://github.com/yongkyuns/noon/actions/runs/34359144948), [Provider](https://github.com/yongkyuns/noon/actions/runs/34359145073), [Native Host](https://github.com/yongkyuns/noon/actions/runs/34359144942), [Architecture](https://github.com/yongkyuns/noon/actions/runs/34359144925), [Dependencies](https://github.com/yongkyuns/noon/actions/runs/34359144861) are green. [Product](https://github.com/yongkyuns/noon/actions/runs/34359144871) and [Cross-browser](https://github.com/yongkyuns/noon/actions/runs/34359144805) were still running at this snapshot.

## Remaining R4 work

The exact two earlier raw-alias probes were rerun locally against the corrected source: **nested repeated-leaf append now passes; cross-root shared-leaf reorder still fails**. The original source/baseline comparison remains in [run 34353423930](https://github.com/yongkyuns/noon/actions/runs/34353423930) and [its retained reproducer](https://github.com/yongkyuns/noon/blob/5f14be5b1ae50c5793104173137fb018bab69ca8/.github/workflows/r4-alias-evidence.yml).

Remaining reproducer: root `[left(shared,A), right(shared,B)]`; raw `ReorderMember(root,left,None)` succeeds. Authored first-occurrence order is `[shared,B,A]`; painter order is `[B,shared,A]`. Deduplicating one moved family's traversal does not repair first occurrence across distinct root families. Keep this under #1292 R4/#957/#969 with a non-ignored regression in its eventual repair, atomicity/revision tests and unrelated-root/dependency locality evidence. Do not relabel success as unsupported, add a whole-root fallback, or expand into a general session rewrite.

Broader arbitrary mixed structural transactions, new semantic capability, and full Phase A/R4 completion are not claimed. This PR is a separately reviewable correction; merge and independent approval remain separate.