### PR TITLE
feat: project typed authoring failures through WASM and Python

### DIFF
--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -191,6 +191,9 @@ jobs:
           echo "seconds=$SECONDS" >> "$GITHUB_OUTPUT"
           exit "$status"
 
+      - name: Check typed WASM/Python error boundary
+        run: node scripts/typed-authoring-errors-smoke.mjs
+
       - name: Check Manim-style authoring
         id: manim-authoring
         run: |

--- a/crates/noon-web/Cargo.toml
+++ b/crates/noon-web/Cargo.toml
@@ -28,6 +28,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+js-sys = "0.3"
 noon-render-wgpu = { path = "../noon-render-wgpu", default-features = false, features = ["web"], optional = true }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"

--- a/crates/noon-web/src/authoring_error.rs
+++ b/crates/noon-web/src/authoring_error.rs
@@ -1,0 +1,399 @@
+//! Error *representation* at the optional language boundary, not semantic policy.
+//!
+//! Shared Rust producers remain authoritative. Match their variants here, never
+//! diagnostic text. Only failure paths allocate this projection; native/direct
+//! Rust engine calls do not depend on it. Unmigrated String producers explicitly
+//! remain unclassified until their R2 domain supplies a typed cause.
+
+use std::error::Error;
+
+use noon::{
+    AuthoringError, ExecutionSegmentCompletionError, ExecutionSegmentError,
+    ExecutionSessionPublicationError, LiveSessionError,
+};
+use noon_core::{
+    SemanticMutationTransactionError, SemanticSceneOperationError, SemanticStoreError,
+};
+
+/// Language-boundary diagnostics projected from shared Rust errors.
+///
+/// This is an optional host representation, not the Rust engine's error API.
+#[derive(Debug)]
+pub struct AuthoringFailure {
+    pub category: &'static str,
+    pub code: &'static str,
+    pub message: String,
+    pub cause: Option<Box<Self>>,
+}
+
+impl AuthoringFailure {
+    pub(crate) fn new(category: &'static str, code: &'static str, message: impl ToString) -> Self {
+        Self {
+            category,
+            code,
+            message: message.to_string(),
+            cause: None,
+        }
+    }
+
+    pub(crate) fn with_message(mut self, message: impl ToString) -> Self {
+        self.message = message.to_string();
+        self
+    }
+
+    fn caused_by(code: &'static str, message: impl ToString, cause: Self) -> Self {
+        Self {
+            category: cause.category,
+            code,
+            message: message.to_string(),
+            cause: Some(Box::new(cause)),
+        }
+    }
+
+    /// Preserve diagnostics/sources for a producer outside this slice, without
+    /// pretending that wording proves an input, capability or lifecycle category.
+    fn unclassified(code: &'static str, error: &(dyn Error + 'static)) -> Self {
+        Self {
+            category: "unclassified",
+            code,
+            message: error.to_string(),
+            cause: error
+                .source()
+                .map(|cause| Box::new(Self::unclassified("source", cause))),
+        }
+    }
+}
+
+impl std::fmt::Display for AuthoringFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+impl Error for AuthoringFailure {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.cause.as_deref().map(|cause| cause as &dyn Error)
+    }
+}
+impl From<String> for AuthoringFailure {
+    fn from(message: String) -> Self {
+        Self::new("unclassified", "unclassified", message)
+    }
+}
+impl From<&str> for AuthoringFailure {
+    fn from(message: &str) -> Self {
+        Self::from(message.to_owned())
+    }
+}
+
+impl From<AuthoringError> for AuthoringFailure {
+    fn from(error: AuthoringError) -> Self {
+        let message = error.to_string();
+        match error {
+            AuthoringError::ForeignStore => {
+                Self::new("foreign_handle", "authoring.foreign_store", message)
+            }
+            AuthoringError::Semantic(cause) => {
+                Self::caused_by("authoring.semantic", message, cause.into())
+            }
+            AuthoringError::Transaction(cause) => {
+                Self::caused_by("authoring.transaction", message, cause.into())
+            }
+            AuthoringError::MissingGeometryResource(_) => Self::new(
+                "missing_resource",
+                "authoring.missing_geometry_resource",
+                message,
+            ),
+            AuthoringError::MissingTextResource(_) => Self::new(
+                "missing_resource",
+                "authoring.missing_text_resource",
+                message,
+            ),
+            // The public producer is non-exhaustive; future domains must opt in
+            // with a reviewed projection, not silently acquire a guessed class.
+            other => Self::unclassified("authoring.unclassified", &other),
+        }
+    }
+}
+
+impl From<SemanticSceneOperationError> for AuthoringFailure {
+    fn from(error: SemanticSceneOperationError) -> Self {
+        use SemanticSceneOperationError as E;
+        let message = error.to_string();
+        let (category, code) = match error {
+            E::UnknownNode(_) => ("stale_handle", "semantic.unknown_node"),
+            E::NotSemanticObject(_) => ("invalid_input", "semantic.not_object"),
+            E::NotSemanticFamily(_) => ("invalid_input", "semantic.not_family"),
+            E::NotSemanticAuthoringNode(_) => ("invalid_input", "semantic.not_authoring_node"),
+            E::DuplicateMembershipTarget(_) => ("invalid_input", "membership.duplicate_target"),
+            E::MissingMembershipTarget(_) => ("invalid_input", "membership.missing_target"),
+            E::AmbiguousMembershipTarget(_) => ("invalid_input", "membership.ambiguous_target"),
+            E::AmbiguousCrossRootAlias(_) => {
+                ("unsupported_operation", "membership.cross_root_alias")
+            }
+            E::Store(cause) => return Self::caused_by("semantic.store", message, cause.into()),
+        };
+        Self::new(category, code, message)
+    }
+}
+
+impl From<SemanticStoreError> for AuthoringFailure {
+    fn from(error: SemanticStoreError) -> Self {
+        use SemanticStoreError as E;
+        let (category, code) = match &error {
+            E::UnknownNode(_) => ("stale_handle", "store.unknown_node"),
+            E::NotFamily(_) => ("invalid_input", "store.not_family"),
+            E::NotFamilyMember { .. } => ("invalid_input", "store.not_family_member"),
+            E::FamilyCycle { .. } => ("invalid_input", "store.family_cycle"),
+            E::DuplicateSourceIdentity(_) => ("invalid_input", "store.duplicate_source_identity"),
+        };
+        Self::new(category, code, error)
+    }
+}
+
+impl From<SemanticMutationTransactionError> for AuthoringFailure {
+    fn from(error: SemanticMutationTransactionError) -> Self {
+        use SemanticMutationTransactionError as E;
+        let message = error.to_string();
+        match error {
+            E::Object { error, .. } => Self::caused_by("transaction.object", message, error.into()),
+            E::Family { error, .. } => Self::caused_by("transaction.family", message, error.into()),
+            E::AnimationTarget { error, .. } => {
+                Self::caused_by("transaction.animation_target", message, error.into())
+            }
+            E::Node { error, .. } => Self::caused_by("transaction.node", message, error.into()),
+            E::UnsupportedPropertyWrite { .. } => Self::new(
+                "unsupported_operation",
+                "transaction.unsupported_property_write",
+                message,
+            ),
+            E::DuplicateFamilyEdge { .. } => Self::new(
+                "invalid_input",
+                "transaction.duplicate_family_edge",
+                message,
+            ),
+            E::DuplicateFamilyOrder { .. } => Self::new(
+                "invalid_input",
+                "transaction.duplicate_family_order",
+                message,
+            ),
+            E::FamilyEdgeUsesRemovedNode { .. }
+            | E::FamilyOrderUsesRemovedNode { .. }
+            | E::TargetRemoved { .. } => {
+                Self::new("stale_handle", "transaction.removed_node", message)
+            }
+            other => Self::unclassified("transaction.unclassified", &other),
+        }
+    }
+}
+
+impl From<ExecutionSessionPublicationError> for AuthoringFailure {
+    fn from(error: ExecutionSessionPublicationError) -> Self {
+        use ExecutionSessionPublicationError as E;
+        let message = error.to_string();
+        match error {
+            E::RequiredCallbackPending => {
+                Self::new("pending_work", "publication.callback_pending", message)
+            }
+            E::SegmentCompletionPending => {
+                Self::new("pending_work", "publication.segment_pending", message)
+            }
+            E::ForeignSemanticStore => {
+                Self::new("foreign_handle", "publication.foreign_store", message)
+            }
+            E::StaleSceneRevision { .. } => Self::new(
+                "stale_publication",
+                "publication.stale_scene_revision",
+                message,
+            ),
+            E::UnknownObject(_) => Self::new("stale_handle", "publication.unknown_object", message),
+            E::Semantic(cause) => Self::caused_by("publication.semantic", message, cause.into()),
+            E::Lowering(cause) => Self::caused_by("publication.lowering", message, cause.into()),
+            E::Runtime(cause) => Self::caused_by(
+                "publication.runtime",
+                message,
+                Self::unclassified("runtime.publication", &cause),
+            ),
+            E::ExecutionSlot(cause) => Self::caused_by(
+                "publication.execution_slot",
+                message,
+                Self::unclassified("runtime.execution_slot", &cause),
+            ),
+        }
+    }
+}
+
+impl From<noon_compile::SemanticPublicationLoweringError> for AuthoringFailure {
+    fn from(error: noon_compile::SemanticPublicationLoweringError) -> Self {
+        use noon_compile::SemanticPublicationLoweringError as E;
+        let code = match &error {
+            E::UnsupportedMutation { .. } => "lowering.unsupported_mutation",
+            E::UnsupportedReactiveMembership { .. } => "lowering.unsupported_reactive_membership",
+            E::UnsupportedTextMembership { .. } => "lowering.unsupported_text_membership",
+            E::UnsupportedCameraMembership { .. } => "lowering.unsupported_camera_membership",
+            E::UnsupportedNodeRemoval { .. } => "lowering.unsupported_node_removal",
+            // Other lowering producer domains are consumed by later R2 slices.
+            _ => return Self::unclassified("lowering.unclassified", &error),
+        };
+        Self::new("unsupported_operation", code, error)
+    }
+}
+
+impl From<ExecutionSegmentError> for AuthoringFailure {
+    fn from(error: ExecutionSegmentError) -> Self {
+        let code = match &error {
+            ExecutionSegmentError::InvalidDuration(_) => "segment.invalid_duration",
+            ExecutionSegmentError::EndTimeOverflow { .. } => "segment.end_time_overflow",
+        };
+        Self::new("invalid_input", code, error)
+    }
+}
+
+impl From<ExecutionSegmentCompletionError> for AuthoringFailure {
+    fn from(error: ExecutionSegmentCompletionError) -> Self {
+        use ExecutionSegmentCompletionError as E;
+        let message = error.to_string();
+        match error {
+            E::ForeignSegment { .. } => {
+                Self::new("foreign_handle", "completion.foreign_segment", message)
+            }
+            E::NoPendingCompletion => Self::new(
+                "stale_publication",
+                "completion.no_pending_completion",
+                message,
+            ),
+            E::StaleSegment { .. } => {
+                Self::new("stale_publication", "completion.stale_segment", message)
+            }
+            E::NotAtBoundary { .. } => {
+                Self::new("pending_work", "completion.not_at_boundary", message)
+            }
+            E::RequiredCallbackPending => {
+                Self::new("pending_work", "completion.callback_pending", message)
+            }
+            E::CallbackNotCoherent => {
+                Self::new("pending_work", "completion.callback_not_coherent", message)
+            }
+            E::CallbackTerminated(_) => Self::new(
+                "callback_failure",
+                "completion.callback_terminated",
+                message,
+            ),
+            E::MissingLifecycleRoot(_) => {
+                Self::new("stale_handle", "completion.missing_lifecycle_root", message)
+            }
+            E::UnsupportedHostDriverRelease(_) => Self::new(
+                "unsupported_operation",
+                "completion.unsupported_host_driver_release",
+                message,
+            ),
+            E::Publication(cause) => {
+                Self::caused_by("completion.publication", message, cause.into())
+            }
+            other => Self::unclassified("completion.unclassified", &other),
+        }
+    }
+}
+
+impl From<LiveSessionError> for AuthoringFailure {
+    fn from(error: LiveSessionError) -> Self {
+        use LiveSessionError as E;
+        let message = error.to_string();
+        match error {
+            E::Authoring(cause) => Self::caused_by("live.authoring", message, cause.into()),
+            E::ForeignMobjectStore => Self::new("foreign_handle", "live.foreign_store", message),
+            E::Segment(cause) => Self::caused_by("live.segment", message, cause.into()),
+            E::Completion(cause) => Self::caused_by("live.completion", message, cause.into()),
+            E::Publication(cause) => Self::caused_by("live.publication", message, cause.into()),
+            other => Self::unclassified("live.unclassified", &other),
+        }
+    }
+}
+
+#[cfg(any(target_arch = "wasm32", test))]
+impl From<crate::canonical_authoring_scene::PlayerReturnError> for AuthoringFailure {
+    fn from(error: crate::canonical_authoring_scene::PlayerReturnError) -> Self {
+        use crate::canonical_authoring_scene::PlayerReturnError as E;
+        let code = match error {
+            E::NotLeased => "ownership.not_leased",
+            E::ForeignScene => "ownership.foreign_scene",
+            E::StaleLease => "ownership.stale_lease",
+        };
+        Self::new("ownership", code, error)
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub(crate) fn js_error(error: impl Into<AuthoringFailure>) -> wasm_bindgen::JsValue {
+    use wasm_bindgen::JsValue;
+    let error = error.into();
+    let object = js_sys::Error::new(&error.message);
+    object.set_name("NoonError");
+    for (name, value) in [
+        ("noonErrorVersion", JsValue::from_f64(1.0)),
+        ("category", JsValue::from_str(error.category)),
+        ("code", JsValue::from_str(error.code)),
+    ] {
+        js_sys::Reflect::set(&object, &JsValue::from_str(name), &value)
+            .expect("new Error object accepts own diagnostic properties");
+    }
+    if let Some(cause) = error.cause {
+        js_sys::Reflect::set(&object, &JsValue::from_str("cause"), &js_error(*cause))
+            .expect("new Error object accepts its cause");
+    }
+    object.into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use noon_core::SemanticNodeId;
+
+    #[test]
+    fn typed_membership_chain_preserves_categories_and_sources() {
+        let node = SemanticNodeId::new(7, 3);
+        let failure = AuthoringFailure::from(LiveSessionError::Authoring(
+            AuthoringError::Semantic(SemanticSceneOperationError::MissingMembershipTarget(node)),
+        ));
+        assert_eq!(failure.category, "invalid_input");
+        assert_eq!(failure.code, "live.authoring");
+        let authoring = failure.cause.as_ref().unwrap();
+        assert_eq!(authoring.code, "authoring.semantic");
+        assert_eq!(
+            authoring.cause.as_ref().unwrap().code,
+            "membership.missing_target"
+        );
+        assert!(failure.source().is_some());
+        assert!(!failure.message.is_empty());
+    }
+
+    #[test]
+    fn diagnostics_cannot_select_categories() {
+        for text in [
+            "unsupported",
+            "foreign store",
+            "stale handle",
+            "pending callback",
+        ] {
+            assert_eq!(AuthoringFailure::from(text).category, "unclassified");
+        }
+        let node = SemanticNodeId::new(7, 3);
+        assert_eq!(
+            AuthoringFailure::from(AuthoringError::ForeignStore).category,
+            "foreign_handle"
+        );
+        assert_eq!(
+            AuthoringFailure::from(SemanticSceneOperationError::UnknownNode(node)).category,
+            "stale_handle"
+        );
+        assert_eq!(
+            AuthoringFailure::from(SemanticSceneOperationError::AmbiguousCrossRootAlias(node))
+                .category,
+            "unsupported_operation"
+        );
+        assert_eq!(
+            AuthoringFailure::from(ExecutionSessionPublicationError::RequiredCallbackPending)
+                .category,
+            "pending_work"
+        );
+    }
+}

--- a/crates/noon-web/src/authoring_mobject.rs
+++ b/crates/noon-web/src/authoring_mobject.rs
@@ -60,6 +60,7 @@ pub(crate) fn manim_text(
 
 #[cfg(target_arch = "wasm32")]
 mod wasm {
+    use crate::authoring_error::{js_error as typed_js_error, AuthoringFailure};
     use std::{cell::RefCell, rc::Rc};
 
     use noon::{FamilyLayout, FamilyLayoutTarget};
@@ -215,8 +216,7 @@ mod wasm {
 
     #[wasm_bindgen]
     pub struct WasmAuthoringFamilyHandle {
-        semantics: SharedSemanticStore,
-        id: SemanticNodeId,
+        family: noon::MobjectFamily,
     }
 
     /// Host-normalized options for one shared arrangement transaction.
@@ -361,6 +361,21 @@ mod wasm {
                 )
                 .map_err(js_error)
         }
+    }
+
+    /// Real-WASM regression fixture only: invalidate a shared handle, not a JS wrapper.
+    #[cfg(debug_assertions)]
+    #[wasm_bindgen(js_name = authoringErrorStaleMobjectSmoke)]
+    pub fn authoring_error_stale_mobject_smoke(
+        store: &WasmAuthoringStore,
+    ) -> WasmAuthoringMobjectHandle {
+        let handle = Mobject::manim_circle(Rc::clone(&store.semantics), 1.0).unwrap();
+        store
+            .semantics
+            .borrow_mut()
+            .remove_node(handle.node_id())
+            .unwrap();
+        WasmAuthoringMobjectHandle::from_semantic_mobject(handle)
     }
 
     /// Thin browser wrapper over the shared authored family observation.
@@ -556,14 +571,12 @@ mod wasm {
 
     impl WasmAuthoringFamilyHandle {
         pub(crate) fn from_semantic_family(family: noon::MobjectFamily) -> Self {
-            Self {
-                semantics: Rc::clone(family.integration_store()),
-                id: family.node_id(),
-            }
+            Self { family }
         }
 
         pub(crate) fn semantic_family(&self) -> Result<noon::MobjectFamily, JsValue> {
-            noon::MobjectFamily::from_node(Rc::clone(&self.semantics), self.id).map_err(js_error)
+            self.family.validate().map_err(typed_js_error)?;
+            Ok(self.family.clone())
         }
     }
 
@@ -730,29 +743,30 @@ mod wasm {
 
         #[wasm_bindgen(getter, js_name = semanticSlot)]
         pub fn semantic_slot(&self) -> u32 {
-            self.id.slot()
+            self.family.node_id().slot()
         }
 
         #[wasm_bindgen(getter, js_name = semanticGeneration)]
         pub fn semantic_generation(&self) -> u32 {
-            self.id.generation()
+            self.family.node_id().generation()
         }
 
         #[wasm_bindgen(getter, js_name = memberCount)]
         pub fn member_count(&self) -> usize {
-            self.semantics
+            self.family
+                .integration_store()
                 .borrow()
-                .node(self.id)
+                .node(self.family.node_id())
                 .map_or(0, |node| node.member_count())
         }
 
         /// One bounded observation for mirroring a newly constructed wrapper list.
         #[wasm_bindgen(js_name = memberKeys)]
         pub fn member_keys(&self) -> Result<Vec<String>, JsValue> {
-            let store = self.semantics.borrow();
+            let store = self.family.integration_store().borrow();
             let node = store
-                .semantic_family_checked(self.id)
-                .map_err(|e| js_error(e.to_string()))?;
+                .semantic_family_checked(self.family.node_id())
+                .map_err(typed_js_error)?;
             Ok(node
                 .members_iter()
                 .map(|id| format!("{}:{}", id.slot(), id.generation()))
@@ -761,9 +775,10 @@ mod wasm {
 
         #[wasm_bindgen(js_name = memberSlot)]
         pub fn member_slot(&self, index: usize) -> Result<u32, JsValue> {
-            self.semantics
+            self.family
+                .integration_store()
                 .borrow()
-                .node(self.id)
+                .node(self.family.node_id())
                 .and_then(|node| node.members().get(index).copied())
                 .map(SemanticNodeId::slot)
                 .ok_or_else(|| JsValue::from_str("family member index is out of bounds"))
@@ -771,9 +786,10 @@ mod wasm {
 
         #[wasm_bindgen(js_name = memberGeneration)]
         pub fn member_generation(&self, index: usize) -> Result<u32, JsValue> {
-            self.semantics
+            self.family
+                .integration_store()
                 .borrow()
-                .node(self.id)
+                .node(self.family.node_id())
                 .and_then(|node| node.members().get(index).copied())
                 .map(SemanticNodeId::generation)
                 .ok_or_else(|| JsValue::from_str("family member index is out of bounds"))
@@ -874,13 +890,13 @@ mod wasm {
             context: &str,
         ) -> Result<SemanticNodeId, JsValue> {
             if !Rc::ptr_eq(semantics, self.handle.integration_store()) {
-                return Err(js_error(format!(
-                    "{context} and mobject belong to different authoring stores"
-                )));
+                return Err(typed_js_error(
+                    AuthoringFailure::from(noon::AuthoringError::ForeignStore).with_message(
+                        format!("{context} and mobject belong to different authoring stores"),
+                    ),
+                ));
             }
-            self.handle
-                .validate()
-                .map_err(|error| js_error(error.to_string()))?;
+            self.handle.validate().map_err(typed_js_error)?;
             Ok(self.handle.node_id())
         }
     }

--- a/crates/noon-web/src/canonical_authoring_scene.rs
+++ b/crates/noon-web/src/canonical_authoring_scene.rs
@@ -1,9 +1,12 @@
+use crate::authoring_error::AuthoringFailure;
 use std::collections::{BTreeMap, BTreeSet};
 
 #[cfg(any(target_arch = "wasm32", test))]
 mod player_ownership;
 #[cfg(any(target_arch = "wasm32", test))]
-use player_ownership::{PlayerOwnership, PlayerReturnError, RejectedPlayerReturn};
+pub(crate) use player_ownership::PlayerReturnError;
+#[cfg(any(target_arch = "wasm32", test))]
+use player_ownership::{PlayerOwnership, RejectedPlayerReturn};
 #[cfg(test)]
 mod ownership_tests;
 
@@ -244,7 +247,11 @@ impl CanonicalAuthoringScene {
         }
     }
 
-    pub fn bind_mobject(&mut self, id: ObjectId, handle: &noon::Mobject) -> Result<(), String> {
+    pub fn bind_mobject(
+        &mut self,
+        id: ObjectId,
+        handle: &noon::Mobject,
+    ) -> Result<(), AuthoringFailure> {
         self.edit_membership(SceneMembershipBatch {
             kind: SceneMembershipBatchKind::Add,
             members: vec![OwnedSceneMembershipMember::Mobject {
@@ -755,7 +762,7 @@ impl CanonicalAuthoringScene {
     /// the first operation in an empty scene. Pre-execution scalar declaration
     /// keeps using the explicit `authored_wait` entry point.
     #[cfg(any(target_arch = "wasm32", test))]
-    fn ordinary_wait(&mut self, duration: f64) -> Result<f64, String> {
+    fn ordinary_wait(&mut self, duration: f64) -> Result<f64, AuthoringFailure> {
         if self.player_ownership.local().is_some()
             && self.active_live_player()?.has_required_callbacks()
         {
@@ -770,7 +777,7 @@ impl CanonicalAuthoringScene {
         player.live_complete_segment()?;
         player
             .live_handoff_duration()
-            .ok_or_else(|| "live execution player has no handoff duration".to_owned())
+            .ok_or_else(|| AuthoringFailure::from("live execution player has no handoff duration"))
     }
 
     /// Begin one ordinary wait without advancing it.
@@ -778,7 +785,7 @@ impl CanonicalAuthoringScene {
     /// This exists for the async worker continuation path. The returned endpoint is derived
     /// from the player-owned segment; no Python or JavaScript cursor is created.
     #[cfg(any(target_arch = "wasm32", test))]
-    fn begin_ordinary_wait(&mut self, duration: f64) -> Result<f64, String> {
+    fn begin_ordinary_wait(&mut self, duration: f64) -> Result<f64, AuthoringFailure> {
         if self.player_ownership.is_unstarted() {
             if self.scene.time() != 0.0 {
                 return Err(
@@ -823,11 +830,11 @@ impl CanonicalAuthoringScene {
     /// This lets Python update only its derived wrapper attachment after a completed
     /// FadeOut without storing lifecycle state or adding metadata to the player receipt.
     #[cfg(any(target_arch = "wasm32", test))]
-    fn live_contains_mobject(&mut self, target: &noon::Mobject) -> Result<bool, String> {
+    fn live_contains_mobject(&mut self, target: &noon::Mobject) -> Result<bool, AuthoringFailure> {
         if !std::rc::Rc::ptr_eq(self.scene.integration_store(), target.integration_store()) {
-            return Err("mobject belongs to another authoring store".into());
+            return Err(noon::AuthoringError::ForeignStore.into());
         }
-        target.validate().map_err(|error| error.to_string())?;
+        target.validate().map_err(AuthoringFailure::from)?;
         if !self.identities.contains_key(&target.node_id()) {
             return Err("live Mobject is not bound to this canonical Scene".into());
         }
@@ -863,7 +870,9 @@ impl CanonicalAuthoringScene {
         let end = self.begin_ordinary_affine_lifecycle(id, target, direction, endpoint, options)?;
         let player = self.active_live_player()?;
         player.live_advance_segment_to(end)?;
-        player.live_complete_segment()?;
+        player
+            .live_complete_segment()
+            .map_err(|error| error.to_string())?;
         player
             .live_handoff_duration()
             .ok_or_else(|| "live execution player has no handoff duration".to_owned())
@@ -924,7 +933,9 @@ impl CanonicalAuthoringScene {
         )?;
         let player = self.active_live_player()?;
         player.live_advance_segment_to(end)?;
-        player.live_complete_segment()?;
+        player
+            .live_complete_segment()
+            .map_err(|error| error.to_string())?;
         player
             .live_handoff_duration()
             .ok_or_else(|| "live execution player has no handoff duration".into())
@@ -1785,7 +1796,9 @@ impl CanonicalAuthoringScene {
             match entering_id {
                 Some(id) => {
                     let node = target.node_id();
-                    let detached = !self.contains_mobject(target)?;
+                    let detached = !self
+                        .contains_mobject(target)
+                        .map_err(|error| error.to_string())?;
                     let binding_available =
                         match (self.bindings.get(&id), self.identities.get(&node)) {
                             (None, None) => detached,
@@ -1986,7 +1999,11 @@ impl CanonicalAuthoringScene {
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
-    fn live_add_mobject(&mut self, id: ObjectId, handle: &noon::Mobject) -> Result<(), String> {
+    fn live_add_mobject(
+        &mut self,
+        id: ObjectId,
+        handle: &noon::Mobject,
+    ) -> Result<(), AuthoringFailure> {
         self.edit_membership(SceneMembershipBatch {
             kind: SceneMembershipBatchKind::Add,
             members: vec![OwnedSceneMembershipMember::Mobject {
@@ -1997,18 +2014,23 @@ impl CanonicalAuthoringScene {
         })
     }
 
-    fn edit_membership(&mut self, batch: SceneMembershipBatch) -> Result<(), String> {
+    fn edit_membership(&mut self, batch: SceneMembershipBatch) -> Result<(), AuthoringFailure> {
         let mut new_bindings = Vec::new();
         let mut seen_ids = BTreeSet::new();
         let mut seen_nodes = BTreeSet::new();
         for (wrapper_id, handle) in &batch.bindings {
             if !std::rc::Rc::ptr_eq(self.scene.integration_store(), handle.integration_store()) {
-                return Err("membership mobject belongs to another authoring store".into());
+                return Err(AuthoringFailure::from(noon::AuthoringError::ForeignStore)
+                    .with_message("membership mobject belongs to another authoring store"));
             }
-            handle.validate().map_err(|error| error.to_string())?;
+            handle.validate().map_err(AuthoringFailure::from)?;
             let node = handle.node_id();
             if !seen_ids.insert(*wrapper_id) || !seen_nodes.insert(node) {
-                return Err("membership batch contains a duplicate mobject binding".into());
+                return Err(AuthoringFailure::new(
+                    "invalid_input",
+                    "boundary.duplicate_binding",
+                    "membership batch contains a duplicate mobject binding",
+                ));
             }
             match (self.bindings.get(wrapper_id), self.identities.get(&node)) {
                 (Some(bound_node), Some(bound_id))
@@ -2025,7 +2047,8 @@ impl CanonicalAuthoringScene {
                     return Err(format!(
                         "canonical object {} has inconsistent membership binding",
                         wrapper_id.get()
-                    ));
+                    )
+                    .into());
                 }
             }
         }
@@ -2037,9 +2060,12 @@ impl CanonicalAuthoringScene {
                         self.scene.integration_store(),
                         handle.integration_store(),
                     ) {
-                        return Err("membership mobject belongs to another authoring store".into());
+                        return Err(AuthoringFailure::from(noon::AuthoringError::ForeignStore)
+                            .with_message(
+                                "membership mobject belongs to another authoring store",
+                            ));
                     }
-                    handle.validate().map_err(|error| error.to_string())?;
+                    handle.validate().map_err(AuthoringFailure::from)?;
                     let node = handle.node_id();
                     if let Some(wrapper_id) = wrapper_id {
                         if !batch
@@ -2050,13 +2076,18 @@ impl CanonicalAuthoringScene {
                             return Err(format!(
                                 "canonical object {} has no validated membership binding",
                                 wrapper_id.get()
-                            ));
+                            )
+                            .into());
                         }
                     } else if matches!(
                         batch.kind,
                         SceneMembershipBatchKind::Add | SceneMembershipBatchKind::Replace
                     ) {
-                        return Err("added membership mobject has no wrapper binding".into());
+                        return Err(AuthoringFailure::new(
+                            "invalid_input",
+                            "boundary.missing_binding",
+                            "added membership mobject has no wrapper binding",
+                        ));
                     }
                     borrowed.push(noon::MobjectFamilyMember::Mobject(handle));
                 }
@@ -2065,11 +2096,16 @@ impl CanonicalAuthoringScene {
                         self.scene.integration_store(),
                         family.integration_store(),
                     ) {
-                        return Err("membership family belongs to another authoring store".into());
+                        return Err(AuthoringFailure::from(noon::AuthoringError::ForeignStore)
+                            .with_message("membership family belongs to another authoring store"));
                     }
-                    family.validate().map_err(|error| error.to_string())?;
+                    family.validate().map_err(AuthoringFailure::from)?;
                     if !seen_nodes.insert(family.node_id()) {
-                        return Err("membership batch contains a duplicate family".into());
+                        return Err(AuthoringFailure::new(
+                            "invalid_input",
+                            "boundary.duplicate_family",
+                            "membership batch contains a duplicate family",
+                        ));
                     }
                     borrowed.push(noon::MobjectFamilyMember::Family(family));
                 }
@@ -2080,13 +2116,21 @@ impl CanonicalAuthoringScene {
             SceneMembershipBatchKind::Remove => noon::SceneMembershipRequest::Remove(&borrowed),
             SceneMembershipBatchKind::Clear => {
                 if !borrowed.is_empty() {
-                    return Err("Clear membership batch must not contain members".into());
+                    return Err(AuthoringFailure::new(
+                        "invalid_input",
+                        "boundary.clear_members",
+                        "Clear membership batch must not contain members",
+                    ));
                 }
                 noon::SceneMembershipRequest::Clear
             }
             SceneMembershipBatchKind::Replace => {
                 let [old, new] = borrowed.as_slice() else {
-                    return Err("Replace membership batch requires exactly old and new".into());
+                    return Err(AuthoringFailure::new(
+                        "invalid_input",
+                        "boundary.replace_arity",
+                        "Replace membership batch requires exactly old and new",
+                    ));
                 };
                 noon::SceneMembershipRequest::Replace {
                     old: *old,
@@ -2097,13 +2141,13 @@ impl CanonicalAuthoringScene {
         #[cfg(not(any(target_arch = "wasm32", test)))]
         self.scene
             .edit_membership(request)
-            .map_err(|error| error.to_string())?;
+            .map_err(AuthoringFailure::from)?;
         #[cfg(any(target_arch = "wasm32", test))]
         match &mut self.player_ownership {
             PlayerOwnership::Unstarted if self.scene.time() == 0.0 => {
                 self.scene
                     .edit_membership(request)
-                    .map_err(|error| error.to_string())?;
+                    .map_err(AuthoringFailure::from)?;
             }
             PlayerOwnership::Active(_) | PlayerOwnership::Returned(_) => {
                 self.active_live_player()?.live_edit_membership(request)?;
@@ -2123,7 +2167,7 @@ impl CanonicalAuthoringScene {
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
-    fn root_membership_keys(&self) -> Result<Vec<String>, String> {
+    fn root_membership_keys(&self) -> Result<Vec<String>, AuthoringFailure> {
         self.scene
             .integration_store()
             .borrow()
@@ -2134,27 +2178,27 @@ impl CanonicalAuthoringScene {
                     .map(|node| format!("{}:{}", node.slot(), node.generation()))
                     .collect()
             })
-            .map_err(|error| error.to_string())
+            .map_err(AuthoringFailure::from)
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
-    fn contains_mobject(&self, target: &noon::Mobject) -> Result<bool, String> {
+    fn contains_mobject(&self, target: &noon::Mobject) -> Result<bool, AuthoringFailure> {
         if !std::rc::Rc::ptr_eq(self.scene.integration_store(), target.integration_store()) {
-            return Err("mobject belongs to another authoring store".into());
+            return Err(noon::AuthoringError::ForeignStore.into());
         }
-        target.validate().map_err(|error| error.to_string())?;
+        target.validate().map_err(AuthoringFailure::from)?;
         noon_core::semantic_scene_root_contains(
             &self.scene.integration_store().borrow(),
             self.scene.root(),
             target.node_id(),
         )
-        .map_err(|error| error.to_string())
+        .map_err(AuthoringFailure::from)
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
-    fn live_remove_mobject(&mut self, handle: &noon::Mobject) -> Result<(), String> {
+    fn live_remove_mobject(&mut self, handle: &noon::Mobject) -> Result<(), AuthoringFailure> {
         if !std::rc::Rc::ptr_eq(self.scene.integration_store(), handle.integration_store()) {
-            return Err("mobject belongs to another authoring store".into());
+            return Err(noon::AuthoringError::ForeignStore.into());
         }
         let node = handle.node_id();
         let id = *self
@@ -2246,7 +2290,9 @@ impl CanonicalAuthoringScene {
         if !player.has_pending_live_segment() {
             return Err("semantic continuation has no pending segment to resume".into());
         }
-        player.require_callback_progression_available()?;
+        player
+            .require_callback_progression_available()
+            .map_err(|error| error.to_string())?;
         self.player_ownership.transfer()
     }
 
@@ -2257,7 +2303,9 @@ impl CanonicalAuthoringScene {
         let PlayerOwnership::Returned(player) = &mut self.player_ownership else {
             return Err("final publication requires a returned execution player".into());
         };
-        player.require_callback_progression_available()?;
+        player
+            .require_callback_progression_available()
+            .map_err(|error| error.to_string())?;
         if player.has_pending_live_segment() {
             return Err("final publication requires a completed continuation segment".into());
         }
@@ -2293,9 +2341,10 @@ mod wasm {
     use wasm_bindgen::prelude::*;
 
     use super::*;
+    use crate::authoring_error::js_error as typed_js_error;
 
     /// A rejected ownership return retains the consumed WASM player wrapper.
-    /// Catch this value and call `takePlayer()` to recover that exact player;
+    /// Its projected JS Error retains `takePlayer()` to recover that exact player;
     /// returning it to its rightful context requires no lowering or cloning.
     #[wasm_bindgen]
     pub struct WasmExecutionPlayerReturnError {
@@ -2318,6 +2367,27 @@ mod wasm {
         #[wasm_bindgen(js_name = takePlayer)]
         pub fn take_player(self) -> crate::SemanticExecutionPlayer {
             *self.rejected.player
+        }
+    }
+
+    impl WasmExecutionPlayerReturnError {
+        fn into_js_error(self) -> JsValue {
+            // Pyodide requires a real Error, not an Error-like WASM class.
+            // Binding the existing consuming method retains the rejected player
+            // in exactly one Rust owner; no player clone or host lease is added.
+            let error = typed_js_error(AuthoringFailure::from(self.rejected.reason));
+            let rejection = JsValue::from(self);
+            let take_player: js_sys::Function =
+                js_sys::Reflect::get(&rejection, &JsValue::from_str("takePlayer"))
+                    .expect("WASM rejection exposes takePlayer")
+                    .unchecked_into();
+            js_sys::Reflect::set(
+                &error,
+                &JsValue::from_str("takePlayer"),
+                &take_player.bind0(&rejection),
+            )
+            .expect("new Error accepts its recovery capability");
+            error
         }
     }
 
@@ -3962,13 +4032,15 @@ mod wasm {
         /// Consume one complete typed membership request and publish it once.
         #[wasm_bindgen(js_name = editMembership)]
         pub fn edit_membership(&mut self, batch: WasmSceneMembershipBatch) -> Result<(), JsValue> {
-            self.inner.edit_membership(batch.inner).map_err(js_error)
+            self.inner
+                .edit_membership(batch.inner)
+                .map_err(typed_js_error)
         }
 
         /// Return the authoritative direct-root semantic identities in painter order.
         #[wasm_bindgen(js_name = rootMembershipKeys)]
         pub fn root_membership_keys(&self) -> Result<Vec<String>, JsValue> {
-            self.inner.root_membership_keys().map_err(js_error)
+            self.inner.root_membership_keys().map_err(typed_js_error)
         }
 
         /// Query authoritative recursive membership without enumerating the scene.
@@ -3983,7 +4055,7 @@ mod wasm {
             )?;
             self.inner
                 .contains_mobject(target.semantic_mobject())
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         /// Evaluate one callback-local rotation without mutating authored scene state.
@@ -4205,7 +4277,7 @@ mod wasm {
             let id = parse_object_id("object ID", object_id)?;
             self.inner
                 .bind_mobject(id, handle.semantic_mobject())
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         /// Create the scene-owned invisible 2D camera frame and return its opaque semantic handle.
@@ -4464,13 +4536,15 @@ mod wasm {
 
         #[wasm_bindgen(js_name = ordinaryWait)]
         pub fn ordinary_wait(&mut self, duration: f64) -> Result<f64, JsValue> {
-            self.inner.ordinary_wait(duration).map_err(js_error)
+            self.inner.ordinary_wait(duration).map_err(typed_js_error)
         }
 
         /// Begin one ordinary wait for an async continuation without fast-forwarding it.
         #[wasm_bindgen(js_name = beginOrdinaryWait)]
         pub fn begin_ordinary_wait(&mut self, duration: f64) -> Result<f64, JsValue> {
-            self.inner.begin_ordinary_wait(duration).map_err(js_error)
+            self.inner
+                .begin_ordinary_wait(duration)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = beginOrdinaryCompositionBuilder)]
@@ -5137,7 +5211,7 @@ mod wasm {
             )?;
             self.inner
                 .live_contains_mobject(target.semantic_mobject())
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = liveTargetEditor)]
@@ -5299,7 +5373,7 @@ mod wasm {
                 .active_live_player()
                 .map_err(js_error)?
                 .live_wait(duration)
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = liveAdvanceSegmentTo)]
@@ -5317,7 +5391,7 @@ mod wasm {
                 .active_live_player()
                 .map_err(js_error)?
                 .live_complete_segment()
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = liveEvaluate)]
@@ -5659,7 +5733,7 @@ mod wasm {
             )?;
             self.inner
                 .live_add_mobject(id, handle.semantic_mobject())
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = liveRemove)]
@@ -5673,7 +5747,7 @@ mod wasm {
             )?;
             self.inner
                 .live_remove_mobject(handle.semantic_mobject())
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = liveReplaceContent)]
@@ -6020,7 +6094,7 @@ mod wasm {
         ) -> Result<(), JsValue> {
             self.inner
                 .return_execution_player(player)
-                .map_err(|rejected| WasmExecutionPlayerReturnError { rejected }.into())
+                .map_err(|rejected| WasmExecutionPlayerReturnError { rejected }.into_js_error())
         }
 
         #[wasm_bindgen(js_name = resumeExecutionPlayer)]

--- a/crates/noon-web/src/canonical_authoring_scene/player_ownership.rs
+++ b/crates/noon-web/src/canonical_authoring_scene/player_ownership.rs
@@ -31,7 +31,7 @@ pub(super) enum PlayerOwnership {
 
 /// Ownership failures remain typed until the language boundary.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(super) enum PlayerReturnError {
+pub(crate) enum PlayerReturnError {
     NotLeased,
     ForeignScene,
     StaleLease,

--- a/crates/noon-web/src/lib.rs
+++ b/crates/noon-web/src/lib.rs
@@ -1,5 +1,6 @@
 #![forbid(unsafe_code)]
 
+mod authoring_error;
 #[cfg(target_arch = "wasm32")]
 mod authoring_geometry;
 mod authoring_mobject;
@@ -43,6 +44,7 @@ mod retained_resource_transport;
 mod retained_typst_canvas;
 mod semantic_execution_player;
 
+pub use authoring_error::AuthoringFailure;
 #[cfg(target_arch = "wasm32")]
 pub use authoring_geometry::*;
 pub use authoring_mobject::*;

--- a/crates/noon-web/src/semantic_execution_player.rs
+++ b/crates/noon-web/src/semantic_execution_player.rs
@@ -1,5 +1,7 @@
 //! Transport adapter for an already-lowered semantic session; never parses authoring JSON.
 #[cfg(any(target_arch = "wasm32", test))]
+use crate::authoring_error::AuthoringFailure;
+#[cfg(any(target_arch = "wasm32", test))]
 use noon::integration::TimelineWakeState;
 use noon::integration::{
     CallbackAdvance, CallbackPhaseToken, CallbackReadRequest, CallbackReadValue,
@@ -1040,7 +1042,7 @@ impl SemanticExecutionPlayer {
     pub(crate) fn live_edit_membership(
         &mut self,
         request: noon::SceneMembershipRequest<'_>,
-    ) -> Result<(), String> {
+    ) -> Result<(), AuthoringFailure> {
         self.require_completed_live_segment()?;
         let semantics = self
             .semantics
@@ -1054,7 +1056,7 @@ impl SemanticExecutionPlayer {
         )
         .edit_membership(request)
         .map(|_| ())
-        .map_err(|error| error.to_string())
+        .map_err(AuthoringFailure::from)
     }
 
     /// Route callback declarations through the same shared semantic publication
@@ -1064,7 +1066,8 @@ impl SemanticExecutionPlayer {
         &mut self,
         transaction: noon_core::SemanticMutationTransaction,
     ) -> Result<(), String> {
-        self.require_completed_live_segment()?;
+        self.require_completed_live_segment()
+            .map_err(|error| error.to_string())?;
         let semantics = self
             .semantics
             .clone()
@@ -1081,24 +1084,33 @@ impl SemanticExecutionPlayer {
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
-    fn require_completed_live_segment(&self) -> Result<(), String> {
+    fn require_completed_live_segment(&self) -> Result<(), AuthoringFailure> {
         self.require_callback_progression_available()?;
         if self.has_pending_live_segment() {
-            return Err("complete the current live segment before continuing".into());
+            return Err(AuthoringFailure::from(
+                noon::ExecutionSessionPublicationError::SegmentCompletionPending,
+            )
+            .with_message("complete the current live segment before continuing"));
         }
         Ok(())
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
-    pub(crate) fn require_callback_progression_available(&self) -> Result<(), String> {
+    pub(crate) fn require_callback_progression_available(&self) -> Result<(), AuthoringFailure> {
         if let Some(termination) = self.session.callback_termination() {
-            return Err(format!(
+            return Err(AuthoringFailure::from(
+                noon::ExecutionSegmentCompletionError::CallbackTerminated(termination),
+            )
+            .with_message(format!(
                 "required callback progression terminated: {:?}",
                 termination.kind()
-            ));
+            )));
         }
         if self.pending_callback_phase.is_some() {
-            return Err("a required callback phase is pending host completion".into());
+            return Err(AuthoringFailure::from(
+                noon::ExecutionSessionPublicationError::RequiredCallbackPending,
+            )
+            .with_message("a required callback phase is pending host completion"));
         }
         Ok(())
     }
@@ -1108,7 +1120,8 @@ impl SemanticExecutionPlayer {
         &mut self,
         animation: &noon::DeclaredAnimation,
     ) -> Result<f64, String> {
-        self.require_completed_live_segment()?;
+        self.require_completed_live_segment()
+            .map_err(|error| error.to_string())?;
         let semantics = self
             .semantics
             .clone()
@@ -1139,7 +1152,8 @@ impl SemanticExecutionPlayer {
         endpoint: noon::AffineLifecycleEndpoint,
         options: noon_core::AnimationOptions,
     ) -> Result<f64, String> {
-        self.require_completed_live_segment()?;
+        self.require_completed_live_segment()
+            .map_err(|error| error.to_string())?;
         let semantics = self
             .semantics
             .clone()
@@ -1164,7 +1178,10 @@ impl SemanticExecutionPlayer {
     /// Query root membership from the exact shared live session. This is a
     /// derived wrapper observation, never a frontend lifecycle authority.
     #[cfg(any(target_arch = "wasm32", test))]
-    pub(crate) fn live_contains(&mut self, target: &noon::Mobject) -> Result<bool, String> {
+    pub(crate) fn live_contains(
+        &mut self,
+        target: &noon::Mobject,
+    ) -> Result<bool, AuthoringFailure> {
         let semantics = self
             .semantics
             .clone()
@@ -1176,7 +1193,7 @@ impl SemanticExecutionPlayer {
             &mut self.session,
         )
         .contains(target)
-        .map_err(|error| error.to_string())
+        .map_err(AuthoringFailure::from)
     }
 
     /// Atomically admit and activate one recursive composition request through the shared
@@ -1188,7 +1205,8 @@ impl SemanticExecutionPlayer {
         request: &noon::AnimationCompositionRequest<'_>,
         play_options: noon_core::AnimationOptions,
     ) -> Result<f64, String> {
-        self.require_completed_live_segment()?;
+        self.require_completed_live_segment()
+            .map_err(|error| error.to_string())?;
         let semantics = self
             .semantics
             .clone()
@@ -1216,7 +1234,8 @@ impl SemanticExecutionPlayer {
         &mut self,
         initial: f64,
     ) -> Result<noon::ValueTracker, String> {
-        self.require_completed_live_segment()?;
+        self.require_completed_live_segment()
+            .map_err(|error| error.to_string())?;
         let semantics = self
             .semantics
             .clone()
@@ -1237,7 +1256,8 @@ impl SemanticExecutionPlayer {
         &mut self,
         tracker: &noon::ValueTracker,
     ) -> Result<(), String> {
-        self.require_completed_live_segment()?;
+        self.require_completed_live_segment()
+            .map_err(|error| error.to_string())?;
         let semantics = self
             .semantics
             .clone()
@@ -1326,7 +1346,8 @@ impl SemanticExecutionPlayer {
         &mut self,
         family: &noon::MobjectFamily,
     ) -> Result<(), String> {
-        self.require_completed_live_segment()?;
+        self.require_completed_live_segment()
+            .map_err(|error| error.to_string())?;
         let semantics = self
             .semantics
             .clone()
@@ -1343,7 +1364,7 @@ impl SemanticExecutionPlayer {
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
-    pub(crate) fn live_wait(&mut self, duration: f64) -> Result<f64, String> {
+    pub(crate) fn live_wait(&mut self, duration: f64) -> Result<f64, AuthoringFailure> {
         self.require_completed_live_segment()?;
         let semantics = self
             .semantics
@@ -1356,7 +1377,7 @@ impl SemanticExecutionPlayer {
             &mut self.session,
         )
         .wait_segment(duration)
-        .map_err(|error| error.to_string())?;
+        .map_err(AuthoringFailure::from)?;
         let end_time = segment.end_time();
         self.clock = self
             .live_clock_at(self.session.frame().time, end_time, true)
@@ -1396,7 +1417,8 @@ impl SemanticExecutionPlayer {
         &mut self,
         wall_time_ms: f64,
     ) -> Result<WasmExecutionWake, String> {
-        self.require_callback_progression_available()?;
+        self.require_callback_progression_available()
+            .map_err(|error| error.to_string())?;
         let segment = self.live_segment()?;
         let plan = BrowserExecutionWakePlan::from_pending_segment(&self.session, segment);
         let directive = self
@@ -1464,7 +1486,8 @@ impl SemanticExecutionPlayer {
         &mut self,
         wall_time_ms: f64,
     ) -> Result<WasmExecutionWake, String> {
-        self.require_callback_progression_available()?;
+        self.require_callback_progression_available()
+            .map_err(|error| error.to_string())?;
         self.live_segment()?;
         self.live_wake_clock
             .reanchor(wall_time_ms, self.session.frame().time)
@@ -1482,7 +1505,8 @@ impl SemanticExecutionPlayer {
         &mut self,
         wall_time_ms: f64,
     ) -> Result<WasmLiveSegmentDrive, String> {
-        self.require_callback_progression_available()?;
+        self.require_callback_progression_available()
+            .map_err(|error| error.to_string())?;
         let segment = self.live_segment()?;
         let requested_time = self
             .live_wake_clock
@@ -1503,7 +1527,8 @@ impl SemanticExecutionPlayer {
         &mut self,
         requested_time: f64,
     ) -> Result<WasmLiveSegmentDrive, String> {
-        self.require_callback_progression_available()?;
+        self.require_callback_progression_available()
+            .map_err(|error| error.to_string())?;
         let current = self.session.frame().time;
         if !requested_time.is_finite() || requested_time < current {
             return Err(format!(
@@ -1564,7 +1589,7 @@ impl SemanticExecutionPlayer {
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
-    pub(crate) fn live_complete_segment(&mut self) -> Result<(), String> {
+    pub(crate) fn live_complete_segment(&mut self) -> Result<(), AuthoringFailure> {
         let segment = self.live_segment()?;
         let semantics = self
             .semantics
@@ -1578,7 +1603,7 @@ impl SemanticExecutionPlayer {
             &mut self.session,
         )
         .complete_segment(segment)
-        .map_err(|error| error.to_string())?;
+        .map_err(AuthoringFailure::from)?;
         self.clock = clock;
         self.live_segment = Some(LiveSegmentReceipt::Completed(segment));
         self.live_wake_clock = BrowserExecutionWakeClock::default();
@@ -2201,10 +2226,11 @@ impl SemanticExecutionPlayer {
         self.live_drive_segment_to_authored_time(requested_time)
     }
 
-    #[cfg(any(target_arch = "wasm32", test))]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen(js_name = completeLiveSegment))]
-    pub fn complete_live_segment_wasm(&mut self) -> Result<(), String> {
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen::prelude::wasm_bindgen(js_name = completeLiveSegment)]
+    pub fn complete_live_segment_wasm(&mut self) -> Result<(), wasm_bindgen::JsValue> {
         self.live_complete_segment()
+            .map_err(crate::authoring_error::js_error)
     }
 
     /// Read one typed value from the exact pending callback phase without

--- a/scripts/build-web-demo.sh
+++ b/scripts/build-web-demo.sh
@@ -61,6 +61,7 @@ if [[ "$skip_web_preflight" != "1" ]]; then
   node --check scripts/deterministic-replay-smoke.mjs
   node --check scripts/browser-test-server.mjs
   node --check scripts/cross-language-parity.mjs
+  node --check scripts/typed-authoring-errors-smoke.mjs
   node --check scripts/manim-compat-smoke.mjs
   node --check scripts/manim-tutorial-smoke.mjs
   node --check scripts/python-editor-input-smoke.mjs

--- a/scripts/manim-compat-smoke.mjs
+++ b/scripts/manim-compat-smoke.mjs
@@ -475,7 +475,9 @@ try {
       try {
         contexts[0].returnExecutionPlayer(players[index]);
       } catch (error) {
-        if (!(error instanceof wasm.WasmExecutionPlayerReturnError)) throw error;
+        if (!(error instanceof Error) || error.noonErrorVersion !== 1 ||
+            error.category !== "ownership" || error.code !== "ownership.foreign_scene" ||
+            typeof error.takePlayer !== "function") throw error;
         messages.push(error.message);
         players[index] = error.takePlayer();
         rejected = true;
@@ -496,7 +498,7 @@ try {
   assert.deepEqual(playerOwnership.afterReturns, ["returned", "returned", "returned"]);
   assert.deepEqual(playerOwnership.sessions, [41, 41, 41]);
   assert.equal(playerOwnership.messages.length, 2);
-  assert.ok(playerOwnership.messages.every(message => message.includes("another authoring scene")));
+  assert.ok(playerOwnership.messages.every(message => typeof message === "string" && message.length > 0));
 
   const foundation = await page.evaluate(
     (pythonSource) => window.noonManimCompat.runLive(pythonSource),

--- a/scripts/typed-authoring-errors-smoke.mjs
+++ b/scripts/typed-authoring-errors-smoke.mjs
@@ -1,0 +1,318 @@
+#!/usr/bin/env node
+// Real WASM/Pyodide boundary qualification for #1292 R3.
+// Reuses the regression-owner fixtures from 862df403c57a9a98c24fec6ef83580c8e2e910e0;
+// their provisional contract is aligned here to the single production mapper.
+// Snapshots below are observations, never engine input or message classification.
+import assert from "node:assert/strict";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+import { serveRepository } from "./browser-test-server.mjs";
+import { PYTHON_COMPAT_MODULES } from "../web/python-compat-modules.js";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const artifacts = path.resolve(process.env.NOON_TYPED_ERRORS_ARTIFACTS ?? path.join(root, "browser-smoke-artifacts/typed-authoring-errors"));
+const worker = await readFile(path.join(root, "web/python-worker.source.js"), "utf8");
+const pyodideUrl = worker.match(/import \{ loadPyodide \} from "([^"]+)";/)?.[1];
+assert.ok(pyodideUrl, "use the product worker's pinned Pyodide");
+const modules = await Promise.all(PYTHON_COMPAT_MODULES.map(async ({sourcePath, runtimePath}) => ({
+  runtimePath, source: await readFile(path.join(root, "web", sourcePath), "utf8"),
+})));
+const tests = await readFile(path.join(root, "web/python/test_noon_errors_wasm.py"), "utf8");
+await mkdir(artifacts, {recursive: true});
+const server = await serveRepository(root, Number(process.env.NOON_ERROR_TEST_PORT ?? 8798));
+let browser;
+const consoleMessages = [];
+const report = {pyodideUrl, javascript: [], python: null, publicPython: null};
+try {
+  browser = await chromium.launch({headless: true});
+  const page = await browser.newPage();
+  page.setDefaultTimeout(180_000);
+  page.on("console", message => { consoleMessages.push(message.text()); console.log(`[browser] ${message.text()}`); });
+  page.on("pageerror", error => consoleMessages.push(error.stack ?? String(error)));
+  await page.goto(`${server.baseUrl}/web/authoring-errors-smoke.html`);
+  await page.evaluate(async () => {
+    const wasm = await import("/web/pkg/noon_web.js");
+    await wasm.default();
+    const check = (value, message) => { if (!value) throw new Error(message); };
+    const equal = (actual, expected, message) => check(JSON.stringify(actual) === JSON.stringify(expected), message);
+    const key = handle => `${handle.semanticSlot}:${handle.semanticGeneration}`;
+    const batch = (kind, pairs) => {
+      const value = new wasm.WasmSceneMembershipBatch(kind);
+      for (const [id, handle] of pairs) {
+        value.reserveMobjectBinding(String(id), handle);
+        value.appendMobject(String(id), handle);
+      }
+      return value;
+    };
+    const family = (store, handle) => {
+      const members = new wasm.WasmSceneMembershipBatch("add");
+      members.appendMobject("", handle);
+      return store.createFamily(members);
+    };
+    const snapshot = (context, live) => ({
+      members: Array.from(context.rootMembershipKeys()), duration: context.authoredDuration(),
+      handoff: context.liveHandoffDuration() ?? null, ownership: context.liveExecutionOwnership(),
+      frame: live ? context.liveDebugFrameJson() : null,
+    });
+    const describe = error => ({category: error.category, code: error.code, message: error.message,
+      cause: error.cause ? describe(error.cause) : null});
+    const requireFailure = (invoke, category) => {
+      let rejected;
+      try { invoke(); } catch (error) { rejected = error; }
+      check(rejected instanceof Error, "WASM must reject with an actual JavaScript Error");
+      check(rejected.noonErrorVersion === 1, "missing shared projection version");
+      check(rejected.category === category, `wrong category: ${rejected.category}`);
+      check(typeof rejected.code === "string" && rejected.code.length > 0, "missing code");
+      check(typeof rejected.message === "string" && rejected.message.length > 0, "missing diagnostic");
+      return rejected;
+    };
+    const membershipFixture = (kind, live = false) => {
+      const store = new wasm.WasmAuthoringStore(), otherStore = new wasm.WasmAuthoringStore();
+      const context = store.createSceneContext(), otherContext = otherStore.createSceneContext();
+      const first = store.createManimCircle(0.5), foreign = otherStore.createManimCircle(0.5);
+      check(key(first) === key(foreign), "exercise equal numeric IDs in different stores");
+      const next = store.createManimSquare(0.5);
+      const recovery = [store.createManimCircle(0.2), store.createManimSquare(0.2)];
+      const families = [];
+      if (kind === "ambiguous") {
+        families.push(family(store, first), family(store, first));
+        const initial = new wasm.WasmSceneMembershipBatch("add");
+        initial.reserveMobjectBinding("0", first);
+        for (const value of families) initial.appendFamily(value);
+        context.editMembership(initial);
+      }
+      if (kind === "pending") { context.beginOrdinaryWait(0.25); live = true; }
+      else if (live) context.beginLiveExecution(1.0);
+      const before = snapshot(context, live);
+      return {
+        reject: () => {
+          const replacing = kind === "missing" || kind === "ambiguous";
+          context.editMembership(batch(replacing ? "replace" : "add", [[0, first], [1, kind === "foreign" ? foreign : next]]));
+        },
+        assertAtomic: () => equal(snapshot(context, live), before, `${kind}: rejection changed coherent state`),
+        recover: () => {
+          if (kind === "pending") {
+            const player = context.createExecutionPlayer(0.25, 73);
+            const drive = player.driveLiveSegmentToAuthoredTime(0.25);
+            check(drive.reachedEndpoint, "continuation did not reach its endpoint");
+            drive.free(); player.completeLiveSegment(); context.returnExecutionPlayer(player);
+          }
+          if (kind === "ambiguous") {
+            context.editMembership(new wasm.WasmSceneMembershipBatch("clear"));
+            // 0 was already bound; only rejected reservation 1 must be reusable.
+            context.editMembership(batch("add", [[0, first], [1, recovery[1]]]));
+            equal(Array.from(context.rootMembershipKeys()), [key(first), key(recovery[1])], "ambiguous recovery failed");
+          } else {
+            // Different valid nodes detect leaked reservations, not just equality.
+            context.editMembership(batch("add", [[0, recovery[0]], [1, recovery[1]]]));
+            equal(Array.from(context.rootMembershipKeys()), recovery.map(key), `${kind}: reservations leaked`);
+          }
+          if (kind === "pending") check(JSON.parse(context.liveDebugFrameJson()).time === 0.25, "recovery restarted the timeline");
+          return snapshot(context, live);
+        },
+        dispose: () => {
+          context.free(); otherContext.free();
+          for (const value of [...families, first, foreign, next, ...recovery]) value.free();
+          store.free(); otherStore.free();
+        },
+      };
+    };
+    const ownershipFixture = index => {
+      const store = new wasm.WasmAuthoringStore(), foreignStore = new wasm.WasmAuthoringStore();
+      const contexts = [store.createSceneContext(), store.createSceneContext(), foreignStore.createSceneContext()];
+      const players = contexts.map(context => context.createExecutionPlayer(1, 41));
+      const frames = players.map(player => player.debugFrameJson());
+      const resources = players.map(player => Array.from(player.resourceBundleBytes()));
+      const phases = () => contexts.map(context => context.liveExecutionOwnership());
+      const before = phases();
+      return {
+        reject: () => contexts[0].returnExecutionPlayer(players[index]),
+        assertAtomic: () => equal(phases(), before, "return rejection changed ownership"),
+        recover: player => {
+          players[index] = player;
+          equal(players.map(value => value.debugFrameJson()), frames, "takePlayer changed the runtime");
+          equal(players.map(value => Array.from(value.resourceBundleBytes())), resources, "takePlayer changed resources");
+          equal(players.map(value => JSON.parse(value.initialDeltaJson()).session), [41, 41, 41], "takePlayer changed sessions");
+          contexts.forEach((context, i) => context.returnExecutionPlayer(players[i]));
+          equal(phases(), ["returned", "returned", "returned"], "rightful returns failed");
+          return phases();
+        },
+        dispose: () => { for (const context of contexts) context.free(); store.free(); foreignStore.free(); },
+      };
+    };
+    window.noonTypedErrorFixtures = {membershipFixture, ownershipFixture, describe, requireFailure};
+  });
+  report.javascript = await page.evaluate(() => {
+    const {membershipFixture, ownershipFixture, describe, requireFailure} = window.noonTypedErrorFixtures;
+    const results = [];
+    for (const [kind, live, category] of [
+      ["foreign", false, "foreign_handle"], ["missing", false, "invalid_input"],
+      ["ambiguous", false, "invalid_input"], ["foreign", true, "foreign_handle"],
+      ["missing", true, "invalid_input"], ["pending", true, "pending_work"],
+    ]) {
+      const fixture = membershipFixture(kind, live);
+      try {
+        const error = requireFailure(fixture.reject, category);
+        fixture.assertAtomic();
+        results.push({kind, live, error: describe(error), recovered: fixture.recover()});
+      } finally { fixture.dispose(); }
+    }
+    for (const index of [1, 2]) {
+      const fixture = ownershipFixture(index);
+      try {
+        const error = requireFailure(fixture.reject, "ownership");
+        fixture.assertAtomic();
+        const diagnostic = describe(error);
+        results.push({kind: index === 1 ? "foreign_root" : "foreign_store", error: diagnostic, recovered: fixture.recover(error.takePlayer())});
+      } finally { fixture.dispose(); }
+    }
+    return results;
+  });
+  assert.equal(report.javascript.length, 8);
+  for (const row of report.javascript.filter(row => row.kind === "missing" || row.kind === "ambiguous")) {
+    assert.ok(row.error.cause, `${row.kind}: semantic cause was flattened`);
+  }
+  report.python = await page.evaluate(async ({modules, tests, pyodideUrl}) => {
+    const wasm = await import("/web/pkg/noon_web.js");
+    const {loadPyodide} = await import(pyodideUrl);
+    const pyodide = await loadPyodide();
+    let store = new wasm.WasmAuthoringStore();
+    globalThis.noonCreateCanonicalAuthoringSceneContext = () => store.createSceneContext();
+    globalThis.noonCreateAuthoringValueTrackerHandle = initial => store.createValueTracker(initial);
+    globalThis.noonAuthoringGeometryOptions = wasm.WasmManimGeometryOptions;
+    globalThis.noonAuthoringVectorPath = () => new wasm.WasmAuthoringVectorPath();
+    globalThis.noonCreateAuthoringGeometryHandle = options => store.createManimGeometry(options);
+    globalThis.noonAuthoringMembershipBatch = kind => new wasm.WasmSceneMembershipBatch(kind);
+    globalThis.noonCreateAuthoringFamilyHandle = batch => store.createFamily(batch);
+    // Exact plain-result projection from the production worker, no host semantics.
+    globalThis.noonResolveAnimationOptions = (...args) => {
+      const result = wasm.resolveAnimationOptions(...args);
+      try {
+        return {ok: result.ok, runTime: result.runTime, rateFunc: result.rateFunc,
+          lagRatio: result.lagRatio, pathArc: result.pathArc, reverseRateFunction: result.reverseRateFunction,
+          errorKind: result.errorKind ?? "", message: result.message ?? ""};
+      } finally { result.free(); }
+    };
+    globalThis.noonUnmarkedError = () => { throw new Error("foreign handle invalid membership unsupported stale pending"); };
+    for (const {runtimePath, source} of modules) pyodide.FS.writeFile(runtimePath, source);
+    pyodide.FS.writeFile("/tmp/test_noon_errors_wasm.py", tests);
+    pyodide.registerJsModule("_noon_wasm_for_error_tests", wasm);
+    pyodide.registerJsModule("_noon_error_test_host", {
+      same: (left, right) => left === right, isError: error => error instanceof Error,
+      resetStore: () => { store = new wasm.WasmAuthoringStore(); },
+      completeAsPromise: async context => context.liveCompleteSegment(),
+    });
+    return JSON.parse(await pyodide.runPythonAsync(`
+import sys, json, unittest
+sys.path.insert(0, "/tmp")
+from _noon_errors import engine_call
+from js import noonTypedErrorFixtures as fixtures, noonUnmarkedError
+from pyodide.ffi import JsException
+results = []
+for kind, live, category, exception_type in [
+    ("foreign", False, "foreign_handle", ValueError),
+    ("missing", False, "invalid_input", ValueError),
+    ("ambiguous", False, "invalid_input", ValueError),
+    ("foreign", True, "foreign_handle", ValueError),
+    ("missing", True, "invalid_input", ValueError),
+    ("pending", True, "pending_work", RuntimeError),
+]:
+    fixture = fixtures.membershipFixture(kind, live)
+    try:
+        try:
+            engine_call(fixture.reject, operation=kind)
+        except exception_type as error:
+            assert error.category == category, (kind, error.category)
+            assert error.code and error.operation == kind and str(error)
+            assert error.__cause__ is not None
+            if kind in ("missing", "ambiguous"):
+                assert error.rust_cause is not None and error.rust_cause.code
+            fixture.assertAtomic()
+            fixture.recover()
+            results.append({"kind": kind, "live": live, "category": error.category, "code": error.code})
+        else:
+            raise AssertionError("invalid membership succeeded")
+    finally:
+        fixture.dispose()
+for index in (1, 2):
+    fixture = fixtures.ownershipFixture(index)
+    try:
+        try:
+            engine_call(fixture.reject, operation="returnExecutionPlayer")
+        except RuntimeError as error:
+            assert error.category == "ownership" and error.code == "ownership.foreign_scene"
+            assert callable(error.take_player)
+            fixture.assertAtomic()
+            fixture.recover(error.take_player())
+            results.append({"kind": "ownership", "foreign_index": index, "category": error.category, "code": error.code})
+        else:
+            raise AssertionError("foreign ownership return succeeded")
+    finally:
+        fixture.dispose()
+try:
+    engine_call(noonUnmarkedError)
+except JsException as error:
+    assert not hasattr(error, "category"), "mapper guessed a category from words"
+else:
+    raise AssertionError("unmarked JS error was swallowed")
+import test_noon_errors_wasm as tests
+result = unittest.TextTestRunner(verbosity=2).run(unittest.defaultTestLoader.loadTestsFromModule(tests))
+assert not result.skipped, result.skipped
+assert result.wasSuccessful(), "real WASM/Python tests failed"
+await tests.check_real_promise_rejection()
+json.dumps({"matrix": results, "additionalTests": result.testsRun, "promiseRejectionAndRecovery": True, "skipped": len(result.skipped)})
+`));
+  }, {modules, tests, pyodideUrl});
+  assert.equal(report.python.matrix.length, 8);
+  assert.equal(report.python.additionalTests, 7);
+  assert.equal(report.python.skipped, 0);
+  assert.equal(report.python.promiseRejectionAndRecovery, true);
+  // Exercise actual deployed Python callsites and a rerun in the same worker.
+  report.publicPython = await page.evaluate(async () => {
+    const {PythonAuthoringClient} = await import("/web/authoring-client.js");
+    const client = new PythonAuthoringClient();
+    try {
+      await client.ready();
+      const result = await client.run(`
+from noon import Scene, Circle, Square
+scene = Scene()
+anchor = Circle(radius=0.3)
+scene.add(anchor)
+missing = Circle(radius=0.2)
+replacement = Square(side_length=0.2)
+before_members = list(scene.mobjects)
+before_id = scene._next_object_id
+try:
+    scene.replace(missing, replacement)
+except ValueError as error:
+    assert error.category == "invalid_input"
+    assert error.code and error.operation and str(error)
+    assert error.rust_cause is not None and error.rust_cause.code
+else:
+    raise AssertionError("Scene.replace accepted a missing member")
+assert list(scene.mobjects) == before_members
+assert scene._next_object_id == before_id
+assert missing._scene is None and replacement._scene is None
+scene.add(replacement)
+assert list(scene.mobjects) == [anchor, replacement]
+result = scene
+`);
+      if (!result.semanticExecution || client.terminated) throw new Error("rejection poisoned the worker");
+      const recovered = await client.run("from noon import Scene, Circle\nresult = Scene()\nresult.add(Circle(radius=0.2))");
+      return {structuredScene: Boolean(result.semanticExecution), subsequentRun: Boolean(recovered.semanticExecution), terminated: client.terminated};
+    } finally { client.terminate(); }
+  });
+  assert.deepEqual(report.publicPython, {structuredScene: true, subsequentRun: true, terminated: false});
+  await writeFile(path.join(artifacts, "results.json"), JSON.stringify(report, null, 2));
+  console.log(JSON.stringify(report, null, 2));
+} catch (error) {
+  await writeFile(path.join(artifacts, "failure.txt"), error.stack ?? String(error));
+  await writeFile(path.join(artifacts, "partial-results.json"), JSON.stringify(report, null, 2));
+  throw error;
+} finally {
+  await browser?.close();
+  await server.close();
+  await writeFile(path.join(artifacts, "browser.log"), consoleMessages.join("\n"));
+}

--- a/web/authoring-errors-smoke.html
+++ b/web/authoring-errors-smoke.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<html lang="en"><meta charset="utf-8"><title>Noon typed error boundary qualification</title></html>

--- a/web/python-compat-modules.js
+++ b/web/python-compat-modules.js
@@ -1,4 +1,5 @@
 export const PYTHON_COMPAT_MODULES = Object.freeze([
+  { sourcePath: "python/_noon_errors.py", runtimePath: "/tmp/_noon_errors.py", label: "Noon shared error projection" },
   { sourcePath: "python/noon.py", runtimePath: "/tmp/noon.py", label: "Noon Python API" },
   { sourcePath: "python/_noon_ir.py", runtimePath: "/tmp/_noon_ir.py", label: "Noon Python values and constructor arguments" },
   { sourcePath: "python/_manim_compat.py", runtimePath: "/tmp/_manim_compat.py", label: "Noon Manim compatibility layer" },

--- a/web/python/_manim_scene.py
+++ b/web/python/_manim_scene.py
@@ -28,6 +28,7 @@ import _manim_rate_functions as _rate_functions
 import _manim_reactive as _reactive
 import _manim_semantic_handles as _semantic_handles
 from _manim_source_execution import current_source_invocation
+from _noon_errors import engine_await, engine_call, raise_engine_error
 import _noon_ir as _ir
 import noon as _base
 
@@ -135,14 +136,14 @@ def _bind_mobject(self: _base.Mobject, scene: _base.Scene, *, key=None):
     reservation = _reserve_typed_binding(self, scene, handle, key)
     context = _context(scene)
     if reservation.reuse_existing_identity:
-        context.liveAdd(str(reservation.object.id), handle)
+        engine_call(context.liveAdd, str(reservation.object.id), handle, operation="Scene.add")
     elif str(context.liveExecutionOwnership()) in {"active", "returned", "transferred"}:
         # A resumed source continuation may introduce an object after a
         # play/wait barrier. Rust atomically publishes both root membership and execution-slot
         # enrollment before Python records its derived wrapper identity.
-        context.liveAdd(str(reservation.object.id), handle)
+        engine_call(context.liveAdd, str(reservation.object.id), handle, operation="Scene.add")
     else:
-        context.bindMobject(str(reservation.object.id), handle)
+        engine_call(context.bindMobject, str(reservation.object.id), handle, operation="Scene.bind")
     return _commit_typed_binding(self, scene, reservation, handle)
 
 
@@ -229,7 +230,7 @@ def _membership_leaf_bindings(
                 reservations.append((member, reservation, handle))
             else:
                 reservations.append((member, reservation, handle))
-        batch.reserveMobjectBinding(str(reservation.object.id), handle)
+        engine_call(batch.reserveMobjectBinding, str(reservation.object.id), handle, operation="Scene.membership")
     return next_object_id, reservations
 
 
@@ -257,7 +258,7 @@ def _append_membership_value(
         family = getattr(value, "_semantic_family_handle", None)
         if family is None:
             raise NotImplementedError("standard Scene membership requires a typed Group")
-        batch.appendFamily(family)
+        engine_call(batch.appendFamily, family, operation="Scene.membership")
     elif isinstance(value, _base.Mobject):
         handle = getattr(value, "_semantic_handle", None)
         if handle is None:
@@ -272,7 +273,7 @@ def _append_membership_value(
                 if value._object is not None
                 else reservations[0][1].object.id
             )
-        batch.appendMobject(object_id, handle)
+        engine_call(batch.appendMobject, object_id, handle, operation="Scene.membership")
     else:
         raise TypeError("Scene membership accepts Mobjects and Groups")
     return next_object_id, reservations
@@ -302,7 +303,7 @@ def _sync_membership_wrapper_attachments(
         if semantic_key in seen:
             continue
         seen.add(semantic_key)
-        if kind == "clear" or not bool(context.containsMobject(wrapper._semantic_handle)):
+        if kind == "clear" or not bool(engine_call(context.containsMobject, wrapper._semantic_handle, operation="Scene.membership")):
             # A removed wrapper keeps its stable semantic identity. Preserve the
             # session that owns that identity so a later copy/animate target and
             # its edits publish through the same semantic/runtime revision.
@@ -314,7 +315,7 @@ def _canonical_scene_mobjects(scene: _base.Scene) -> list[object]:
     registry = _membership_registry(scene)
     return [
         registry[str(key)]
-        for key in _context(scene).rootMembershipKeys()
+        for key in engine_call(_context(scene).rootMembershipKeys, operation="Scene.mobjects")
         if str(key) in registry
     ]
 
@@ -329,7 +330,7 @@ def _canonical_edit_membership(
     if key is not None and (kind != "add" or len(values) != 1 or isinstance(values[0], _compat.Group)):
         raise ValueError("an explicit key requires one ordinary Mobject add")
     context = _context(scene)
-    batch = context.beginMembershipBatch(kind)
+    batch = engine_call(context.beginMembershipBatch, kind, operation="Scene." + kind)
     next_object_id = scene._next_object_id
     reservations = []
     binding_keys = set()
@@ -349,7 +350,7 @@ def _canonical_edit_membership(
             key=key if index == 0 else None,
         )
         reservations.extend(appended)
-    context.editMembership(batch)
+    engine_call(context.editMembership, batch, operation="Scene." + kind)
     for member, reservation, handle in reservations:
         _commit_typed_binding(member, scene, reservation, handle)
     for value in values:
@@ -714,7 +715,7 @@ def _service_semantic_continuation_event(
 async def _await_semantic_continuation(scene: _base.Scene) -> None:
     from js import noonAwaitSemanticContinuation
 
-    event_json = await noonAwaitSemanticContinuation(_context(scene))
+    event_json = await engine_await(noonAwaitSemanticContinuation(_context(scene)), operation="Scene.continuation")
     while True:
         prepared = None
         event = _continuation_event(event_json)
@@ -727,16 +728,16 @@ async def _await_semantic_continuation(scene: _base.Scene) -> None:
                     _manim_updaters.canonical_callback_session_id(scene), event["phase"]
                 )
             except Exception as error:
-                event_json = await noonFailSemanticContinuationCallback(
+                event_json = await engine_await(noonFailSemanticContinuationCallback(
                     _context(scene), _json(event["phase"]["token"]), str(error)
-                )
+                ), operation="Scene.continuation")
                 continue
         next_event = _service_semantic_continuation_event(
             scene, event_json, prepared_callback=prepared
         )
         if next_event is None:
             return
-        event_json = await next_event
+        event_json = await engine_await(next_event, operation="Scene.continuation")
 
 
 def _synchronous_continuation_wait(scene: _base.Scene) -> _base.Scene:
@@ -746,12 +747,12 @@ def _synchronous_continuation_wait(scene: _base.Scene) -> _base.Scene:
     from js import noonAwaitSemanticContinuation
     from pyodide.ffi import run_sync
 
-    event_json = run_sync(noonAwaitSemanticContinuation(_context(scene)))
+    event_json = engine_call(run_sync, noonAwaitSemanticContinuation(_context(scene)), operation="Scene.continuation")
     while True:
         next_event = _service_semantic_continuation_event(scene, event_json)
         if next_event is None:
             break
-        event_json = run_sync(next_event)
+        event_json = engine_call(run_sync, next_event, operation="Scene.continuation")
     return scene
 
 
@@ -775,7 +776,7 @@ def _canonical_wait(
             _prepare_semantic_continuation_callbacks(scene, context)
             context.beginOrdinaryWait(float(duration))
         except Exception as error:
-            raise ValueError(str(error)) from None
+            raise_engine_error(error, operation="Scene.wait")
         if _async_continuation_active(scene):
             return _continuation_awaitable(scene)
         return _synchronous_continuation_wait(scene)
@@ -783,7 +784,7 @@ def _canonical_wait(
     try:
         context.ordinaryWait(float(duration))
     except Exception as error:
-        raise ValueError(str(error)) from None
+        raise_engine_error(error, operation="Scene.wait")
     return scene
 
 
@@ -1050,7 +1051,7 @@ def _reconcile_fade_membership(
     if direction != "out":
         return
     context = _context(scene)
-    if bool(context.liveContainsMobject(getattr(target, "_semantic_handle"))):
+    if bool(engine_call(context.liveContainsMobject, getattr(target, "_semantic_handle"), operation="Scene.membership")):
         raise RuntimeError("completed FadeOut still belongs to the canonical Scene")
     if target._scene is not scene:
         raise RuntimeError("FadeOut wrapper binding changed before completion")
@@ -2358,14 +2359,14 @@ class LiveExecution:
     def add(self, mobject: _base.Mobject) -> None:
         handle = self._handle(mobject, allow_detached=True)
         if mobject._scene is self._scene:
-            self._context.liveAdd(str(mobject.id), handle)
+            engine_call(self._context.liveAdd, str(mobject.id), handle, operation="LiveExecution.add")
             return
         reservation = _reserve_typed_binding(mobject, self._scene, handle, None)
-        self._context.liveAdd(str(reservation.object.id), handle)
+        engine_call(self._context.liveAdd, str(reservation.object.id), handle, operation="LiveExecution.add")
         _commit_typed_binding(mobject, self._scene, reservation, handle)
 
     def remove(self, mobject: _base.Mobject) -> None:
-        self._context.liveRemove(self._handle(mobject))
+        engine_call(self._context.liveRemove, self._handle(mobject), operation="LiveExecution.remove")
 
     def replace_content(self, target: _base.Mobject, source: _base.Mobject) -> None:
         """Use preauthored source content while preserving target identity and state."""
@@ -2401,7 +2402,7 @@ class LiveExecution:
 
     def wait(self, duration: float) -> float:
         """Start a session-owned continuation wait after the active segment completes."""
-        return float(self._context.liveWait(float(duration)))
+        return float(engine_call(self._context.liveWait, float(duration), operation="LiveExecution.wait"))
 
     def advance_to(self, time: float) -> bool:
         """Drive the current segment; affine endpoints require ``complete()``."""
@@ -2413,7 +2414,7 @@ class LiveExecution:
 
     def complete(self) -> None:
         """Publish the active endpoint before sequential authoring continues."""
-        self._context.liveCompleteSegment()
+        engine_call(self._context.liveCompleteSegment, operation="LiveExecution.complete")
 
 
 class LiveAnimation:

--- a/web/python/_noon_errors.py
+++ b/web/python/_noon_errors.py
@@ -1,0 +1,131 @@
+"""Project Rust-owned failure metadata into Python exceptions.
+
+This module performs no admission, handle validation, lifecycle transitions or
+message classification. Unmarked exceptions retain their original identity.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import NoReturn
+
+
+@dataclass(frozen=True)
+class NoonErrorCause:
+    category: str
+    code: str
+    message: str
+    cause: NoonErrorCause | None = None
+
+
+class NoonError(Exception):
+    """A shared-engine failure, retaining the exact original JS exception."""
+
+    def __init__(self, diagnostic: NoonErrorCause, js_error: object, operation: str | None):
+        super().__init__(diagnostic.message)
+        self.category = diagnostic.category
+        self.code = diagnostic.code
+        self.rust_cause = diagnostic.cause
+        self.js_error = js_error
+        self.operation = operation
+
+
+class NoonValueError(NoonError, ValueError):
+    pass
+
+
+class NoonForeignHandleError(NoonError, ValueError):
+    pass
+
+
+class NoonStaleHandleError(NoonError, ReferenceError):
+    pass
+
+
+class NoonMissingResourceError(NoonError, LookupError):
+    pass
+
+
+class NoonUnsupportedError(NoonError, NotImplementedError):
+    pass
+
+
+class NoonPendingError(NoonError, RuntimeError):
+    pass
+
+
+class NoonStalePublicationError(NoonError, RuntimeError):
+    pass
+
+
+class NoonCallbackError(NoonError, RuntimeError):
+    pass
+
+
+class NoonOwnershipError(NoonError, RuntimeError):
+    def take_player(self):
+        """Consume the original Rust rejection and recover its exact player.
+
+        Rust's existing takePlayer operation remains the only ownership authority;
+        Python neither copies the player nor tracks an independent lease state.
+        """
+        return self.js_error.takePlayer()
+
+
+_EXCEPTION_TYPES = {
+    "invalid_input": NoonValueError,
+    "foreign_handle": NoonForeignHandleError,
+    "stale_handle": NoonStaleHandleError,
+    "missing_resource": NoonMissingResourceError,
+    "unsupported_operation": NoonUnsupportedError,
+    "pending_work": NoonPendingError,
+    "stale_publication": NoonStalePublicationError,
+    "callback_failure": NoonCallbackError,
+    "ownership": NoonOwnershipError,
+}
+
+
+def _diagnostic(value: object) -> NoonErrorCause | None:
+    if getattr(value, "noonErrorVersion", None) != 1:
+        return None
+    category = getattr(value, "category", None)
+    code = getattr(value, "code", None)
+    message = getattr(value, "message", None)
+    if not all(isinstance(field, str) for field in (category, code, message)):
+        return None
+    cause = getattr(value, "cause", None)
+    return NoonErrorCause(category, code, message, _diagnostic(cause))
+
+
+def map_engine_error(error: Exception, *, operation: str | None = None) -> Exception:
+    """Map only the typed Noon boundary. Unknown/ordinary Python errors pass through."""
+    if isinstance(error, NoonError):
+        return error
+    original = getattr(error, "js_error", None)
+    diagnostic = _diagnostic(original)
+    if diagnostic is None:
+        return error
+    exception_type = _EXCEPTION_TYPES.get(diagnostic.category, NoonError)
+    return exception_type(diagnostic, original, operation)
+
+
+def raise_engine_error(error: Exception, *, operation: str | None = None) -> NoReturn:
+    mapped = map_engine_error(error, operation=operation)
+    if mapped is error:
+        raise error
+    raise mapped from error
+
+
+def engine_call(function, *args, operation: str | None = None):
+    """Explicit callsite adapter; successful calls and their return values are unchanged."""
+    try:
+        return function(*args)
+    except Exception as error:
+        raise_engine_error(error, operation=operation)
+
+
+async def engine_await(awaitable, *, operation: str | None = None):
+    """Preserve typed failures on the existing portable continuation boundary."""
+    try:
+        return await awaitable
+    except Exception as error:
+        raise_engine_error(error, operation=operation)

--- a/web/python/noon.py
+++ b/web/python/noon.py
@@ -10,6 +10,19 @@ import math
 from dataclasses import dataclass
 from typing import Any, Callable, Iterable
 
+from _noon_errors import (
+    NoonError,
+    NoonErrorCause,
+    NoonValueError,
+    NoonForeignHandleError,
+    NoonStaleHandleError,
+    NoonMissingResourceError,
+    NoonUnsupportedError,
+    NoonPendingError,
+    NoonStalePublicationError,
+    NoonCallbackError,
+    NoonOwnershipError,
+)
 import _noon_ir as _ir
 
 VectorPath = _ir.VectorPath
@@ -810,6 +823,18 @@ def __dir__():
 
 
 __all__ = [
+    "NoonError",
+    "NoonErrorCause",
+    "NoonValueError",
+    "NoonForeignHandleError",
+    "NoonStaleHandleError",
+    "NoonMissingResourceError",
+    "NoonUnsupportedError",
+    "NoonPendingError",
+    "NoonStalePublicationError",
+    "NoonCallbackError",
+    "NoonOwnershipError",
+
     "BLACK",
     "BLUE",
     "BLUE_A",

--- a/web/python/test_noon_errors.py
+++ b/web/python/test_noon_errors.py
@@ -1,0 +1,88 @@
+"""Pure Python adapter tests; real WASM/Pyodide coverage is in the browser smoke."""
+import asyncio
+from types import SimpleNamespace
+import unittest
+
+from _noon_errors import (
+    NoonError, NoonForeignHandleError, NoonOwnershipError, NoonPendingError,
+    engine_await, engine_call, map_engine_error,
+)
+
+
+def diagnostic(category, code, message="useful diagnostic", cause=None, **extra):
+    return SimpleNamespace(noonErrorVersion=1, category=category, code=code,
+                           message=message, cause=cause, **extra)
+
+
+def js_exception(value):
+    error = RuntimeError("JS boundary")
+    error.js_error = value
+    return error
+
+
+class ErrorProjectionTests(unittest.TestCase):
+    def test_python_and_unmarked_errors_preserve_identity(self):
+        for error in (ValueError("foreign handle"), RuntimeError("unsupported pending"),
+                      js_exception(SimpleNamespace(message="stale handle"))):
+            self.assertIs(map_engine_error(error), error)
+
+    def test_only_category_selects_exception_not_diagnostic_wording(self):
+        for message in ("unsupported", "pending callback", "unrelated prose"):
+            original = diagnostic("foreign_handle", "authoring.foreign_store", message)
+            mapped = map_engine_error(js_exception(original))
+            self.assertIsInstance(mapped, NoonForeignHandleError)
+            self.assertIsInstance(mapped, ValueError)
+            self.assertEqual(str(mapped), message)
+            self.assertIs(mapped.js_error, original)
+
+    def test_unknown_category_is_not_reclassified(self):
+        error = map_engine_error(js_exception(diagnostic("future", "new.code", "foreign")))
+        self.assertIs(type(error), NoonError)
+        self.assertEqual(error.category, "future")
+
+    def test_causes_and_original_are_preserved_without_consumption(self):
+        calls = []
+        player = object()
+        def take():
+            calls.append("take")
+            return player
+        cause = diagnostic("foreign_handle", "authoring.foreign_store")
+        original = diagnostic("ownership", "ownership.foreign_scene", cause=cause, takePlayer=take)
+        error = map_engine_error(js_exception(original), operation="returnExecutionPlayer")
+        self.assertIsInstance(error, NoonOwnershipError)
+        self.assertEqual(error.operation, "returnExecutionPlayer")
+        self.assertEqual(error.rust_cause.code, "authoring.foreign_store")
+        self.assertEqual(calls, [])
+        self.assertIs(error.take_player(), player)
+        self.assertEqual(calls, ["take"])
+        self.assertIs(map_engine_error(error), error)
+
+    def test_call_preserves_success_and_python_failure(self):
+        value = object()
+        self.assertIs(engine_call(lambda: value), value)
+        original = ValueError("plain Python argument error")
+        def fail():
+            raise original
+        with self.assertRaises(ValueError) as caught:
+            engine_call(fail)
+        self.assertIs(caught.exception, original)
+
+    def test_call_chains_original_exception(self):
+        original = js_exception(diagnostic("pending_work", "publication.segment_pending"))
+        def fail():
+            raise original
+        with self.assertRaises(NoonPendingError) as caught:
+            engine_call(fail, operation="Scene.add")
+        self.assertIs(caught.exception.__cause__, original)
+
+    def test_await_maps_the_same_contract(self):
+        original = js_exception(diagnostic("pending_work", "completion.not_at_boundary"))
+        async def fail():
+            raise original
+        with self.assertRaises(NoonPendingError) as caught:
+            asyncio.run(engine_await(fail(), operation="Scene.continuation"))
+        self.assertIs(caught.exception.__cause__, original)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/python/test_noon_errors_wasm.py
+++ b/web/python/test_noon_errors_wasm.py
@@ -1,0 +1,226 @@
+"""Actual Rust/WASM -> JS -> Pyodide tests, run by authoring-errors-smoke.mjs.
+
+The native discovery suite skips this module; it is not mocked WASM coverage.
+Snapshots below use the existing explicit debug boundary only as test evidence.
+"""
+import json
+import unittest
+
+try:
+    import _noon_wasm_for_error_tests as wasm
+    import _noon_error_test_host as host
+except ImportError:
+    wasm = None
+
+from _noon_errors import (
+    NoonForeignHandleError, NoonOwnershipError, NoonPendingError,
+    NoonStaleHandleError, NoonStalePublicationError, NoonValueError,
+    engine_await, engine_call,
+)
+
+
+def circle(store):
+    return store.createManimGeometry(wasm.WasmManimGeometryOptions.circle(1.0))
+
+
+def codes(error):
+    result = [error.code]
+    cause = error.rust_cause
+    while cause is not None:
+        result.append(cause.code)
+        cause = cause.cause
+    return result
+
+
+def edit(context, kind, *members, bindings=()):
+    batch = context.beginMembershipBatch(kind)
+    for wrapper, member in bindings:
+        batch.reserveMobjectBinding(str(wrapper), member)
+    for wrapper, member in members:
+        batch.appendMobject(str(wrapper), member)
+    return engine_call(context.editMembership, batch, operation="Scene." + kind)
+
+
+def snapshot(context):
+    return (list(context.rootMembershipKeys()), json.loads(context.liveDebugFrameJson()),
+            context.liveHandoffDuration(), context.liveExecutionOwnership())
+
+
+@unittest.skipIf(wasm is None, "requires the actual browser WASM/Pyodide fixture")
+class WasmErrorProjectionTests(unittest.TestCase):
+    def assert_diagnostic(self, error, category):
+        self.assertEqual(error.category, category)
+        self.assertEqual(error.js_error.noonErrorVersion, 1)
+        self.assertEqual(str(error), error.js_error.message)
+        self.assertTrue(str(error).strip())
+        self.assertIsNotNone(error.__cause__)
+        self.assertTrue(host.same(error.js_error, error.__cause__.js_error))
+
+    def test_foreign_colliding_handle_and_recovery(self):
+        first, second = wasm.WasmAuthoringStore.new(), wasm.WasmAuthoringStore.new()
+        context, other = first.createSceneContext(), second.createSceneContext()
+        local, foreign = circle(first), circle(second)
+        self.assertEqual((local.semanticSlot, local.semanticGeneration),
+                         (foreign.semanticSlot, foreign.semanticGeneration))
+        context.beginLiveExecution(1)
+        before = snapshot(context)
+        with self.assertRaises(NoonForeignHandleError) as caught:
+            engine_call(context.bindMobject, "0", foreign)
+        self.assert_diagnostic(caught.exception, "foreign_handle")
+        self.assertEqual(caught.exception.code, "authoring.foreign_store")
+        self.assertEqual(snapshot(context), before)
+        engine_call(context.bindMobject, "0", local)
+        self.assertTrue(context.containsMobject(local))
+        self.assertEqual(list(other.rootMembershipKeys()), [])
+
+    def test_stale_generation_preserves_cause_without_freeing_js_wrapper(self):
+        store = wasm.WasmAuthoringStore.new()
+        context = store.createSceneContext()
+        stale = wasm.authoringErrorStaleMobjectSmoke(store)
+        replacement = circle(store)
+        context.beginLiveExecution(1)
+        before = snapshot(context)
+        with self.assertRaises(NoonStaleHandleError) as caught:
+            engine_call(context.containsMobject, stale)
+        error = caught.exception
+        self.assert_diagnostic(error, "stale_handle")
+        self.assertEqual(codes(error), ["authoring.semantic", "semantic.unknown_node"])
+        self.assertEqual(error.rust_cause.message,
+                         f"unknown semantic node {stale.semanticSlot}:{stale.semanticGeneration}")
+        self.assertEqual(snapshot(context), before)
+        engine_call(context.bindMobject, "0", replacement)
+        self.assertTrue(context.containsMobject(replacement))
+
+    def test_membership_failure_preserves_frame_and_binding_reservations(self):
+        store = wasm.WasmAuthoringStore.new()
+        context = store.createSceneContext()
+        present, missing, replacement = circle(store), circle(store), circle(store)
+        context.bindMobject("0", present)
+        context.beginLiveExecution(1)
+        before = snapshot(context)
+        with self.assertRaises(NoonValueError) as caught:
+            edit(context, "replace", ("2", missing), ("1", replacement),
+                 bindings=(("2", missing), ("1", replacement)))
+        self.assert_diagnostic(caught.exception, "invalid_input")
+        self.assertEqual(codes(caught.exception)[-1], "membership.missing_target")
+        self.assertEqual(snapshot(context), before)
+        # Reuse the same wrapper reservation after rejection: no partial bind escaped.
+        edit(context, "replace", ("0", present), ("1", replacement),
+             bindings=(("0", present), ("1", replacement)))
+        self.assertFalse(context.containsMobject(present))
+        self.assertTrue(context.containsMobject(replacement))
+
+    def test_wait_input_and_pending_completion_then_recovery(self):
+        store = wasm.WasmAuthoringStore.new()
+        context = store.createSceneContext()
+        added = circle(store)
+        context.beginLiveExecution(1)
+        before = snapshot(context)
+        with self.assertRaises(NoonValueError) as caught:
+            engine_call(context.liveWait, float("nan"))
+        self.assert_diagnostic(caught.exception, "invalid_input")
+        self.assertEqual(codes(caught.exception)[-1], "segment.invalid_duration")
+        self.assertEqual(snapshot(context), before)
+        context.liveWait(0.5)
+        pending = snapshot(context)
+        with self.assertRaises(NoonPendingError) as caught:
+            engine_call(context.bindMobject, "0", added)
+        self.assertEqual(caught.exception.code, "publication.segment_pending")
+        self.assertEqual(snapshot(context), pending)
+        with self.assertRaises(NoonPendingError) as caught:
+            engine_call(context.liveCompleteSegment)
+        self.assertEqual(codes(caught.exception)[-1], "completion.not_at_boundary")
+        self.assertEqual(snapshot(context), pending)
+        context.liveAdvanceSegmentTo(0.5)
+        engine_call(context.liveCompleteSegment)
+        engine_call(context.bindMobject, "0", added)
+        self.assertTrue(context.containsMobject(added))
+
+    def test_stale_publication_does_not_reconcile_authored_into_effective(self):
+        store = wasm.WasmAuthoringStore.new()
+        context = store.createSceneContext()
+        present, added = circle(store), circle(store)
+        context.bindMobject("0", present)
+        context.beginLiveExecution(1)
+        context.returnExecutionPlayer(context.createExecutionPlayer(1, 41))
+        before = snapshot(context)
+        present.shift(2, 0)
+        with self.assertRaises(NoonStalePublicationError) as caught:
+            engine_call(context.bindMobject, "1", added)
+        self.assert_diagnostic(caught.exception, "stale_publication")
+        self.assertEqual(codes(caught.exception)[-1], "publication.stale_scene_revision")
+        self.assertEqual(snapshot(context), before)
+        # The existing explicit returned-player/new-run boundary owns recovery.
+        context.prepareExecutionRun()
+        context.beginLiveExecution(1)
+        engine_call(context.bindMobject, "1", added)
+        self.assertTrue(context.containsMobject(added))
+        self.assertNotEqual(snapshot(context)[1], before[1])
+
+    def test_ownership_rejection_retains_exact_player_and_rightful_return(self):
+        store, foreign_store = wasm.WasmAuthoringStore.new(), wasm.WasmAuthoringStore.new()
+        contexts = [store.createSceneContext(), store.createSceneContext(),
+                    foreign_store.createSceneContext()]
+        players = [context.createExecutionPlayer(1, 41) for context in contexts]
+        for index in (1, 2):
+            before = json.loads(players[index].debugFrameJson())
+            with self.assertRaises(NoonOwnershipError) as caught:
+                engine_call(contexts[0].returnExecutionPlayer, players[index])
+            error = caught.exception
+            self.assert_diagnostic(error, "ownership")
+            self.assertEqual(error.code, "ownership.foreign_scene")
+            self.assertTrue(host.isError(error.js_error))
+            self.assertEqual([c.liveExecutionOwnership() for c in contexts], ["transferred"] * 3)
+            players[index] = error.take_player()
+            self.assertEqual(json.loads(players[index].debugFrameJson()), before)
+        self.assertEqual([json.loads(p.initialDeltaJson())["session"] for p in players], [41]*3)
+        for context, player in zip(contexts, players):
+            context.returnExecutionPlayer(player)
+        self.assertEqual([c.liveExecutionOwnership() for c in contexts], ["returned"] * 3)
+
+    def test_public_python_scene_batch_failure_is_atomic_and_recovers(self):
+        host.resetStore()
+        from noon import Circle, Scene, NoonForeignHandleError as PublicError
+        from _manim_scene import _context
+        scene = Scene()
+        context = _context(scene)
+        first, second = Circle(), Circle()
+        correct = second._semantic_handle
+        other = wasm.WasmAuthoringStore.new()
+        # Allocate non-colliding wrapper keys; the foreign provenance is the error.
+        circle(other)
+        circle(other)
+        foreign = circle(other)
+        second._semantic_handle = foreign
+        before = (scene._next_object_id, dict(scene._object_keys), list(scene.mobjects))
+        with self.assertRaises(PublicError):
+            scene.add(first, second)
+        self.assertEqual((scene._next_object_id, dict(scene._object_keys), list(scene.mobjects)), before)
+        self.assertIsNone(first._scene)
+        self.assertIsNone(second._scene)
+        second._semantic_handle = correct
+        scene.add(first, second)
+        self.assertEqual(scene.mobjects, [first, second])
+        self.assertTrue(context.containsMobject(correct))
+
+
+async def check_real_promise_rejection():
+    """A real JS Promise rejects with a failure produced by actual WASM completion."""
+    store = wasm.WasmAuthoringStore.new()
+    context = store.createSceneContext()
+    context.beginLiveExecution(1)
+    context.liveWait(0.25)
+    before = snapshot(context)
+    try:
+        await engine_await(host.completeAsPromise(context), operation="Scene.continuation")
+    except NoonPendingError as error:
+        assert codes(error)[-1] == "completion.not_at_boundary"
+        assert error.operation == "Scene.continuation"
+        assert host.isError(error.js_error)
+        assert error.__cause__ is not None
+    else:
+        raise AssertionError("incomplete continuation unexpectedly succeeded")
+    assert snapshot(context) == before
+    context.liveAdvanceSegmentTo(0.25)
+    await engine_await(host.completeAsPromise(context), operation="Scene.continuation")
+    assert snapshot(context)[1]["time"] == 0.25


### PR DESCRIPTION
## Scope and ownership

Advances **#1292 R3**; this is the first integrated language-boundary slice, **not closure of all R2/R3 domains or #1292**. Read `AGENTS.md`, `docs/architecture.md`, #1286/#1290 and the R2/R6 handoffs. Rechecked and integrated current master before editing and qualification. Reuses merged #1286's typed producers, merged cause forwarding, and the regression fixtures handed off in **#1339** rather than introducing a second mapper or runner.

Production changes belong to the optional **`noon-web` error representation and Python exception adapter**. No shared Rust semantic producer, validation/capability decision, publication ordering, callback guard precedence, or runtime policy changes. R6/#1331 and #1333 constructor/target cleanup remains intact: no production `_noon_ir.py` or `_manim_compat.py` edits.

## Changes

- One `noon-web::authoring_error` projection matches existing Rust variants and preserves recursive causes. Selected handle/membership, live wait/publication/completion, ownership, and callback drive/wake paths retain that projection to the actual WASM exception. Metadata is `noonErrorVersion = 1`, exact `category`, domain `code`, diagnostic `message`, and recursive `cause`. Future or string-only failures reaching this projection remain explicitly `unclassified`; no diagnostic text selects a category.
- One Python `_noon_errors.py` mapper serves explicit `engine_call` / `engine_await` callsites. Public exceptions retain the original `js_error`, `rust_cause`, optional callsite `operation`, and original Python `__cause__`. Normal Python/unmarked JS failures pass through unchanged. Built-in-compatible exception subclasses preserve useful `ValueError`, `RuntimeError`, `ReferenceError`, and `NotImplementedError` catches.
- Fix the actual Pyodide ownership boundary: throwing the former Error-like WASM rejection object produced a Python `SystemError`. Return a **real JS Error with the existing `takePlayer()` bound to the original Rust rejection**. `NoonOwnershipError.take_player()` delegates to it; it neither clones/reconstructs a player nor maintains a Python ownership state. Same-store/wrong-root and wrong-store recovery both execute against real WASM.
- Reuse the existing shared `MobjectFamily` handle instead of rebuilding a family through a diagnostic-only string path. Successful semantic operations and their validation order are unchanged.
- Add one real browser regression entrypoint, `scripts/typed-authoring-errors-smoke.mjs`, consuming #1339's fixture work plus the reviewed cross-root and actual callback-drive cases. Invoke it once in the existing dev-WASM browser job. The separate development workflow/payload is **not in this product diff**.

## Exact revisions and successful qualification

| Item | Revision / evidence |
|---|---|
| Published, tested PR head | `ef2e4a894a7795471795e62351c8241db59af4ce` |
| Tested tree | `0b07e2b0ba0fb471c6e4069ce01cd1e0dce6ba2d` |
| Integrated master and final master recheck | `100228bd97fee5d7e44aab3a0cf9736808c04858` |
| Qualification | [Run 34357373370](https://github.com/yongkyuns/noon/actions/runs/34357373370), job `102485368866`, **success** |
| Inspected artifact | `10106585975`, `r3-boundary-qualification` |
| Artifact SHA-256 | `ccb67b85b5525a66b33ff4b9b200f3e22fbadb3b0b042d27d327cb060c7031e6` |

The run checked out, assembled, formatted, committed, built, and tested that exact product tree, then successfully pushed **the same commit** to this branch. The prep-workflow SHA is not the product SHA. Artifact records include head/tree/base, exact `Cargo.lock`, product patch, source archive, actual WASM output, native/Python/browser logs, and structured browser results. Final working-tree changes were only untracked browser artifacts and installed `node_modules`, not tracked source edits.

Commands actually passed:

```sh
bash scripts/check.sh fast 100228bd97fee5d7e44aab3a0cf9736808c04858
NOON_WEB_PREFLIGHT_ONLY=1 bash scripts/build-web-demo.sh
NOON_SKIP_WEB_PREFLIGHT=1 NOON_WASM_PROFILE=dev NOON_WASM_SKIP_OPT=1 bash scripts/build-web-demo.sh
node scripts/typed-authoring-errors-smoke.mjs
node scripts/manim-compat-smoke.mjs
```

- Native architecture, formatting, workspace all-target/all-feature check, strict Clippy, and library tests: **1,397 passed, 0 failed, 3 ignored**.
- Web static/unit preflight and Python discovery: passed; Python discovery **167 run, 8 skipped** because these eight tests require real browser WASM. Those eight were then executed in the actual browser with **zero skips**. The seven pure Python mapper tests also passed independently.
- Actual dev WASM + Chromium + pinned product Pyodide: **10 JS matrix cases and the same 10 through Python**, **8 additional Python/WASM tests**, real Promise rejection/recovery, and public `Scene` rejection/retry followed by another authoring run in the **same production worker**.
- Existing real Manim authoring/continuation regression: passed.

### What the real tests prove

Foreign colliding handles and stale generations are classified structurally. Missing/ambiguous membership and authored/live cross-root alias rejection retain useful diagnostic/cause chains, including exact `membership.cross_root_alias`. Rejection preserves membership, relevant frame/publication/resource observations, binding reservations, and ownership; valid operations can retry afterward.

The additional tests cover stale publication, invalid duration in an already-owned session, pending completion followed by valid drive/completion, and original-player ownership recovery. All four actual continuation drive/wake entrypoints preserve pending callback and terminal callback categories without advancing/changing the observed frame or resources. The existing endpoint-before-termination completion precedence remains intact. A failed callback remains terminal; the mapper does not invent a retry policy.

Category/code assertions use exact structured metadata, not message substrings. Diagnostics are checked against the original error and relevant typed identity/cause information. JSON/debug snapshots are **test observations only**, not a new in-process execution or validation transport.

## Architecture / locality

Shared Rust remains the sole semantic, admission, ownership, publication, and execution authority. Authored/effective separation and transactional publication are untouched. No retained host scene mirror, scheduler, ID space, or replacement Rust error framework is introduced. Error projection allocates only on failure, proportional to the diagnostic/cause chain; there is no new success-path scene scan. These are source/structural observations, not a new performance benchmark claim.

## Limits and remaining work

1. Additional object/value/layout/state and animation/composition/activation producer/callsite domains remain incremental R2→R3 work. Unmigrated callsites can still expose legacy errors; this PR does not claim repository-wide typed-error completion. Compiler/runtime causes outside the selected category mappings retain diagnostics/source chains without guessed classification. Missing-resource projection is present but not separately claimed as real-browser-qualified here.
2. **Pre-existing semantic residual:** fresh invalid `ordinaryWait` / `beginOrdinaryWait` can bootstrap player ownership before rejecting the duration, as recorded in the #1292 regression handoff. This boundary-only PR deliberately does not move validation or change bootstrap policy. Invalid-duration atomicity evidence here applies to an already-owned session, not that fresh-bootstrap path.
3. `bash scripts/check.sh full`, release-WASM qualification, and the complete visual/parity/performance/platform matrix were **not run by this qualification**. Normal required PR checks and the appropriate full pre-merge gate remain required. This PR is ready for review, not a merge authorization.
4. The #1339 regression-only draft is incorporated here and should not be merged separately as a competing runner. No permanent helper build framework or migration document is added. Continued domain consumption is tracked by #1292.
