### PR TITLE
fix: preserve typed live-transform errors through WASM and Python

### DIFF
--- a/crates/noon-web/src/authoring_error.rs
+++ b/crates/noon-web/src/authoring_error.rs
@@ -161,6 +161,11 @@ impl From<SemanticMutationTransactionError> for AuthoringFailure {
                 Self::caused_by("transaction.animation_target", message, error.into())
             }
             E::Node { error, .. } => Self::caused_by("transaction.node", message, error.into()),
+            E::NonFinitePropertyValue { .. } => Self::new(
+                "invalid_input",
+                "transaction.non_finite_property_value",
+                message,
+            ),
             E::UnsupportedPropertyWrite { .. } => Self::new(
                 "unsupported_operation",
                 "transaction.unsupported_property_write",

--- a/crates/noon-web/src/canonical_authoring_scene.rs
+++ b/crates/noon-web/src/canonical_authoring_scene.rs
@@ -5431,9 +5431,9 @@ mod wasm {
             )?;
             self.inner
                 .active_live_player()
-                .map_err(js_error)?
+                .map_err(typed_js_error)?
                 .live_set_translation(handle.semantic_mobject(), x, y)
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = liveMoveToLayout)]
@@ -5782,9 +5782,9 @@ mod wasm {
             )?;
             self.inner
                 .active_live_player()
-                .map_err(js_error)?
+                .map_err(typed_js_error)?
                 .live_shift(handle.semantic_mobject(), x, y)
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         /// Create a complete detached family through the current live publication.
@@ -6011,9 +6011,9 @@ mod wasm {
             )?;
             self.inner
                 .active_live_player()
-                .map_err(js_error)?
+                .map_err(typed_js_error)?
                 .live_set_scale(handle.semantic_mobject(), x, y)
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = liveScale)]
@@ -6046,9 +6046,9 @@ mod wasm {
             )?;
             self.inner
                 .active_live_player()
-                .map_err(js_error)?
+                .map_err(typed_js_error)?
                 .live_set_rotation(handle.semantic_mobject(), angle)
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = liveRotate)]

--- a/crates/noon-web/src/semantic_execution_player.rs
+++ b/crates/noon-web/src/semantic_execution_player.rs
@@ -398,7 +398,7 @@ impl SemanticExecutionPlayer {
         mobject: &noon::Mobject,
         x: f64,
         y: f64,
-    ) -> Result<(), String> {
+    ) -> Result<(), AuthoringFailure> {
         let semantics = self
             .semantics
             .clone()
@@ -411,7 +411,7 @@ impl SemanticExecutionPlayer {
         )
         .set_translation(mobject, x, y)
         .map(|_| ())
-        .map_err(|error| error.to_string())
+        .map_err(AuthoringFailure::from)
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
@@ -726,7 +726,7 @@ impl SemanticExecutionPlayer {
         mobject: &noon::Mobject,
         x: f64,
         y: f64,
-    ) -> Result<(), String> {
+    ) -> Result<(), AuthoringFailure> {
         let semantics = self
             .semantics
             .clone()
@@ -739,7 +739,7 @@ impl SemanticExecutionPlayer {
         )
         .shift(mobject, x, y)
         .map(|_| ())
-        .map_err(|error| error.to_string())
+        .map_err(AuthoringFailure::from)
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
@@ -874,13 +874,13 @@ impl SemanticExecutionPlayer {
             .map(|_| ())
     }
 
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(any(target_arch = "wasm32", test))]
     pub(crate) fn live_set_scale(
         &mut self,
         mobject: &noon::Mobject,
         x: f64,
         y: f64,
-    ) -> Result<(), String> {
+    ) -> Result<(), AuthoringFailure> {
         let semantics = self
             .semantics
             .clone()
@@ -893,7 +893,7 @@ impl SemanticExecutionPlayer {
         )
         .set_scale(mobject, x, y)
         .map(|_| ())
-        .map_err(|error| error.to_string())
+        .map_err(AuthoringFailure::from)
     }
 
     #[cfg(target_arch = "wasm32")]
@@ -918,12 +918,12 @@ impl SemanticExecutionPlayer {
         .map_err(|error| error.to_string())
     }
 
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(any(target_arch = "wasm32", test))]
     pub(crate) fn live_set_rotation(
         &mut self,
         mobject: &noon::Mobject,
         angle: f64,
-    ) -> Result<(), String> {
+    ) -> Result<(), AuthoringFailure> {
         let semantics = self
             .semantics
             .clone()
@@ -936,7 +936,7 @@ impl SemanticExecutionPlayer {
         )
         .set_rotation(mobject, angle)
         .map(|_| ())
-        .map_err(|error| error.to_string())
+        .map_err(AuthoringFailure::from)
     }
 
     #[cfg(target_arch = "wasm32")]
@@ -2475,7 +2475,8 @@ mod tests {
     use crate::{RetainedExecutionFrameMirror, TransportObjectContent};
     use noon_core::{
         AnimationOptions, HostCallbackId, RateFunction, SemanticMutationTransaction,
-        SemanticObjectProperty, SemanticObjectState, SemanticStore, StoredGeometry,
+        SemanticMutationTransactionError, SemanticObjectProperty, SemanticObjectState,
+        SemanticStore, StoredGeometry,
     };
 
     fn callback_batch_with_y_and_opacity(phase: &serde_json::Value) -> String {
@@ -2500,6 +2501,80 @@ mod tests {
             ],
         })
         .to_string()
+    }
+
+    #[test]
+    fn live_transform_projection_preserves_atomic_rejection_and_local_retry() {
+        type Edit =
+            fn(&mut SemanticExecutionPlayer, &noon::Mobject, f64) -> Result<(), AuthoringFailure>;
+        let edits: [(Edit, SemanticObjectProperty); 4] = [
+            (
+                |player, object, value| player.live_set_translation(object, value, -1.0),
+                SemanticObjectProperty::Translation,
+            ),
+            (
+                |player, object, value| player.live_shift(object, value, -1.0),
+                SemanticObjectProperty::Translation,
+            ),
+            (
+                |player, object, value| player.live_set_scale(object, value, 0.5),
+                SemanticObjectProperty::Scale,
+            ),
+            (
+                |player, object, value| player.live_set_rotation(object, value),
+                SemanticObjectProperty::RotationZ,
+            ),
+        ];
+        for (edit, property) in edits {
+            let mut scene = noon::Scene::new();
+            let object = scene.circle(0.5).unwrap();
+            scene.add(&object).unwrap();
+            let session = scene.execution_session().unwrap();
+            let mut player = SemanticExecutionPlayer::from_live_session(
+                session,
+                std::rc::Rc::clone(scene.integration_store()),
+                scene.root(),
+                1.0,
+                41,
+            )
+            .unwrap();
+            player.delta(true).unwrap().unwrap();
+            let authored = object.state().unwrap();
+            let publication = player.session.publication_context();
+            let frame = player.debug_frame_json();
+            let resources = player.resource_bundle_bytes();
+            for value in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+                let error = edit(&mut player, &object, value).unwrap_err();
+                assert_eq!(error.category, "invalid_input");
+                assert_eq!(error.code, "live.publication");
+                let cause = error.cause.as_ref().unwrap();
+                assert_eq!(cause.category, "invalid_input");
+                assert_eq!(cause.code, "publication.semantic");
+                let leaf = cause.cause.as_ref().unwrap();
+                assert_eq!(leaf.code, "transaction.non_finite_property_value");
+                assert!(leaf.cause.is_none());
+                let expected = SemanticMutationTransactionError::NonFinitePropertyValue {
+                    index: 0,
+                    object: object.node_id(),
+                    property,
+                };
+                assert_eq!(leaf.message, expected.to_string());
+                assert_eq!(object.state().unwrap(), authored);
+                assert_eq!(player.session.publication_context(), publication);
+                assert_eq!(player.debug_frame_json(), frame);
+                assert_eq!(player.resource_bundle_bytes(), resources);
+                assert!(player.delta(false).unwrap().is_none());
+            }
+            edit(&mut player, &object, 2.0).unwrap();
+            let delta = player.delta(false).unwrap().unwrap();
+            assert!(!delta.retained.snapshot);
+            assert_eq!(delta.retained.objects.len(), 1);
+            assert!(delta.retained.removed_slots.is_empty());
+            assert!(player.delta(false).unwrap().is_none());
+            assert_eq!(player.resource_bundle_bytes(), resources);
+            assert_ne!(object.state().unwrap(), authored);
+            assert_ne!(player.session.publication_context(), publication);
+        }
     }
 
     #[test]

--- a/scripts/typed-authoring-errors-smoke.mjs
+++ b/scripts/typed-authoring-errors-smoke.mjs
@@ -149,7 +149,70 @@ try {
         dispose: () => { for (const context of contexts) context.free(); store.free(); foreignStore.free(); },
       };
     };
-    window.noonTypedErrorFixtures = {membershipFixture, ownershipFixture, describe, requireFailure};
+    // The same real Rust operations run directly in JS and through Pyodide below.
+    const livePropertyMethods = [
+      {method: "liveSetTranslation", args: [2, -1], property: "Translation", field: "translation", expected: {x: 2, y: -1}},
+      {method: "liveShift", args: [2, -1], property: "Translation", field: "translation", expected: {x: 2, y: -1}},
+      {method: "liveSetScale", args: [2, 0.5], property: "Scale", field: "scale", expected: {x: 2, y: 0.5}},
+      {method: "liveSetRotation", args: [0.5], property: "RotationZ", field: "rotation", expected: 0.5},
+    ];
+    const livePropertyCases = livePropertyMethods.flatMap(spec => [
+      ...spec.args.flatMap((_, axis) => ["nan", "positive_infinity", "negative_infinity"].map(kind => ({...spec, kind, axis}))),
+      ...["foreign", "stale"].map(kind => ({...spec, kind, axis: 0})),
+    ]);
+    const livePropertyFixture = spec => {
+      const store = new wasm.WasmAuthoringStore(), otherStore = new wasm.WasmAuthoringStore();
+      const context = store.createSceneContext();
+      const object = store.createManimCircle(0.5), foreign = otherStore.createManimCircle(0.5);
+      const stale = spec.kind === "stale" ? wasm.authoringErrorStaleMobjectSmoke(store) : null;
+      context.bindMobject("0", object);
+      context.beginLiveExecution(1);
+      // Ordinary waits permit these property writes. Do not add a Python or
+      // binding-side blanket "pending segment" rejection to make errors uniform.
+      context.liveWait(0.25);
+      const state = () => ({...snapshot(context, true), authored: object.snapshotJson()});
+      const before = state();
+      const args = [...spec.args];
+      const invalid = {nan: NaN, positive_infinity: Infinity, negative_infinity: -Infinity};
+      if (Object.hasOwn(invalid, spec.kind)) args[spec.axis] = invalid[spec.kind];
+      const target = spec.kind === "foreign" ? foreign : spec.kind === "stale" ? stale : object;
+      return {
+        category: spec.kind === "foreign" ? "foreign_handle" : spec.kind === "stale" ? "stale_handle" : "invalid_input",
+        reject: () => context[spec.method](target, ...args),
+        assertDiagnostic: error => {
+          if (Object.hasOwn(invalid, spec.kind)) {
+            equal([error.code, error.cause?.code, error.cause?.cause?.code],
+              ["live.publication", "publication.semantic", "transaction.non_finite_property_value"], "property cause chain was flattened");
+            const leaf = error.cause.cause;
+            check(leaf.cause === undefined, "leaf must not invent a source");
+            equal(leaf.message, `semantic transaction mutation 0 cannot set property ${spec.property} on object ${key(object)} to a non-finite value`, "property diagnostic lost identity/context");
+          } else if (spec.kind === "foreign") {
+            check(error.code === "authoring.foreign_store", "foreign property handle misclassified");
+          } else {
+            equal([error.code, error.cause?.code], ["authoring.semantic", "semantic.unknown_node"], "stale property handle cause lost");
+          }
+        },
+        assertAtomic: () => equal(state(), before, "rejected property changed authored/effective state, publication, roots or ownership"),
+        recover: () => {
+          context[spec.method](object, ...spec.args);
+          const authored = JSON.parse(object.snapshotJson());
+          const effective = JSON.parse(context.liveDebugFrameJson());
+          equal(authored.transform[spec.field], spec.expected, "retry changed the wrong authored coordinate");
+          equal(effective.objects[0].transform[spec.field], spec.expected, "retry was not coherently published");
+          equal(effective.time, 0, "property write advanced the wait clock");
+          const old = JSON.parse(before.frame).publication;
+          equal(effective.publication.scene_revision, old.scene_revision + 1, "retry must commit one semantic revision");
+          equal(effective.publication.execution_revision, old.execution_revision + 1, "retry must commit one execution revision");
+          equal(effective.publication.frame_epoch, old.frame_epoch + 1, "retry must publish one frame epoch");
+          context.liveAdvanceSegmentTo(0.25);
+          context.liveCompleteSegment();
+          equal(JSON.parse(context.liveDebugFrameJson()).time, 0.25, "retry lost the original continuation");
+          return {atomic: true, propertyRetry: true, continuationCompleted: true};
+        },
+        dispose: () => { context.free(); object.free(); foreign.free(); stale?.free(); store.free(); otherStore.free(); },
+      };
+    };
+    window.noonTypedErrorFixtures = {membershipFixture, ownershipFixture, livePropertyFixture, livePropertyCases, describe, requireFailure};
   });
   report.javascript = await page.evaluate(() => {
     const {membershipFixture, ownershipFixture, describe, requireFailure} = window.noonTypedErrorFixtures;
@@ -182,6 +245,19 @@ try {
   for (const row of report.javascript.filter(row => row.kind === "missing" || row.kind === "ambiguous" || row.kind === "cross_root")) {
     assert.ok(row.error.cause, `${row.kind}: semantic cause was flattened`);
   }
+  report.liveProperties = await page.evaluate(() => {
+    const {livePropertyFixture, livePropertyCases, describe, requireFailure} = window.noonTypedErrorFixtures;
+    return livePropertyCases.map(spec => {
+      const fixture = livePropertyFixture(spec);
+      try {
+        const error = requireFailure(fixture.reject, fixture.category);
+        fixture.assertDiagnostic(error);
+        fixture.assertAtomic();
+        return {method: spec.method, kind: spec.kind, axis: spec.axis, error: describe(error), recovered: fixture.recover()};
+      } finally { fixture.dispose(); }
+    });
+  });
+  assert.equal(report.liveProperties.length, 29);
   report.python = await page.evaluate(async ({modules, tests, pyodideUrl}) => {
     const wasm = await import("/web/pkg/noon_web.js");
     const {loadPyodide} = await import(pyodideUrl);
@@ -272,16 +348,39 @@ except JsException as error:
     assert not hasattr(error, "category"), "mapper guessed a category from words"
 else:
     raise AssertionError("unmarked JS error was swallowed")
+property_results = []
+for spec in fixtures.livePropertyCases:
+    fixture = fixtures.livePropertyFixture(spec)
+    try:
+        try:
+            engine_call(fixture.reject, operation=spec.method)
+        except (ValueError, ReferenceError) as error:
+            assert error.category == fixture.category and error.operation == spec.method
+            fixture.assertDiagnostic(error.js_error)
+            assert error.__cause__ is not None and str(error) == error.js_error.message
+            if error.category == "invalid_input":
+                assert error.rust_cause.code == "publication.semantic"
+                assert error.rust_cause.cause.code == "transaction.non_finite_property_value"
+                assert error.rust_cause.cause.cause is None
+            fixture.assertAtomic()
+            fixture.recover()
+            property_results.append({"method": spec.method, "kind": spec.kind, "axis": spec.axis,
+                                     "category": error.category, "code": error.code, "recovered": True})
+        else:
+            raise AssertionError("invalid live property request succeeded")
+    finally:
+        fixture.dispose()
 import test_noon_errors_wasm as tests
 result = unittest.TextTestRunner(verbosity=2).run(unittest.defaultTestLoader.loadTestsFromModule(tests))
 assert not result.skipped, result.skipped
 assert result.wasSuccessful(), "real WASM/Python tests failed"
 await tests.check_real_promise_rejection()
-json.dumps({"matrix": results, "additionalTests": result.testsRun, "promiseRejectionAndRecovery": True, "skipped": len(result.skipped)})
+json.dumps({"matrix": results, "liveProperties": property_results, "additionalTests": result.testsRun, "promiseRejectionAndRecovery": True, "skipped": len(result.skipped)})
 `));
   }, {modules, tests, pyodideUrl});
   assert.equal(report.python.matrix.length, 10);
-  assert.equal(report.python.additionalTests, 8);
+  assert.equal(report.python.liveProperties.length, 29);
+  assert.equal(report.python.additionalTests, 9);
   assert.equal(report.python.skipped, 0);
   assert.equal(report.python.promiseRejectionAndRecovery, true);
   // Exercise actual deployed Python callsites and a rerun in the same worker.

--- a/web/python/_manim_scene.py
+++ b/web/python/_manim_scene.py
@@ -2376,16 +2376,28 @@ class LiveExecution:
         )
 
     def set_translation(self, mobject: _base.Mobject, x: float, y: float) -> None:
-        self._context.liveSetTranslation(self._handle(mobject), float(x), float(y))
+        engine_call(
+            self._context.liveSetTranslation, self._handle(mobject), float(x), float(y),
+            operation="LiveExecution.set_translation",
+        )
 
     def shift(self, mobject: _base.Mobject, x: float, y: float) -> None:
-        self._context.liveShift(self._handle(mobject), float(x), float(y))
+        engine_call(
+            self._context.liveShift, self._handle(mobject), float(x), float(y),
+            operation="LiveExecution.shift",
+        )
 
     def set_scale(self, mobject: _base.Mobject, x: float, y: float) -> None:
-        self._context.liveSetScale(self._handle(mobject), float(x), float(y))
+        engine_call(
+            self._context.liveSetScale, self._handle(mobject), float(x), float(y),
+            operation="LiveExecution.set_scale",
+        )
 
     def set_rotation(self, mobject: _base.Mobject, angle: float) -> None:
-        self._context.liveSetRotation(self._handle(mobject), float(angle))
+        engine_call(
+            self._context.liveSetRotation, self._handle(mobject), float(angle),
+            operation="LiveExecution.set_rotation",
+        )
 
     def effective_center(self, mobject: _base.Mobject) -> _base.Vec2:
         observed = self._context.liveEffectiveMobject(self._handle(mobject))

--- a/web/python/test_noon_errors_wasm.py
+++ b/web/python/test_noon_errors_wasm.py
@@ -225,6 +225,55 @@ class WasmErrorProjectionTests(unittest.TestCase):
         self.assertEqual(caught.exception.category, "callback_failure")
         self.assertEqual(snapshot(context), returned)
 
+    def test_public_live_transform_errors_preserve_python_coercion_and_recover(self):
+        host.resetStore()
+        from noon import Circle, Scene
+        from _manim_scene import _context
+        from _noon_errors import NoonError
+        scene = Scene()
+        target = Circle(radius=0.5)
+        scene.add(target)
+        live = scene.live_execution(1)
+        context = _context(scene)
+        operations = [
+            ("set_translation", (2.0, -1.0), "translation", {"x": 2.0, "y": -1.0}),
+            ("shift", (1.0, 2.0), "translation", {"x": 3.0, "y": 1.0}),
+            ("set_scale", (2.0, 0.5), "scale", {"x": 2.0, "y": 0.5}),
+            ("set_rotation", (0.5,), "rotation", 0.5),
+        ]
+        live.wait(0.25)
+        for name, valid, field, expected in operations:
+            with self.subTest(operation=name):
+                method = getattr(live, name)
+                before = (snapshot(context), target._semantic_handle.snapshotJson())
+                # All argument coercion stays outside the shared engine call.
+                sentinel = ValueError("foreign stale pending unsupported")
+                class BadFloat:
+                    def __float__(self):
+                        raise sentinel
+                with self.assertRaises(ValueError) as caught:
+                    method(target, BadFloat(), *valid[1:])
+                self.assertIs(caught.exception, sentinel)
+                self.assertNotIsInstance(caught.exception, NoonError)
+                self.assertEqual((snapshot(context), target._semantic_handle.snapshotJson()), before)
+                with self.assertRaises(NoonValueError) as caught:
+                    method(target, float("nan"), *valid[1:])
+                error = caught.exception
+                self.assert_diagnostic(error, "invalid_input")
+                self.assertEqual(error.operation, "LiveExecution." + name)
+                self.assertEqual(codes(error), ["live.publication", "publication.semantic",
+                                               "transaction.non_finite_property_value"])
+                self.assertEqual((snapshot(context), target._semantic_handle.snapshotJson()), before)
+                method(target, *valid)
+                authored = json.loads(target._semantic_handle.snapshotJson())
+                effective = snapshot(context)[1]
+                self.assertEqual(authored["transform"][field], expected)
+                self.assertEqual(effective["objects"][0]["transform"][field], expected)
+                self.assertEqual(effective["time"], 0)
+        live.advance_to(0.25)
+        live.complete()
+        self.assertEqual(snapshot(context)[1]["time"], 0.25)
+
     def test_public_python_scene_batch_failure_is_atomic_and_recovers(self):
         host.resetStore()
         from noon import Circle, Scene, NoonForeignHandleError as PublicError


### PR DESCRIPTION
## Stack and ownership

**Six-file follow-on to #1343, ready for review, not whole-R3 completion.** This PR targets `codex/1292-r3-typed-boundary` to keep its incremental diff reviewable. **Land #1343 first, then retarget this PR to master.** No merge authorization is implied. Advances #1292's incremental R2→R3 error projection.

Read `AGENTS.md`, the relevant `docs/architecture.md` frontend/publication/locality sections, and R2/R3/R6 handoffs. Initial and immediately-pre-edit master was `100228bd97fee5d7e44aab3a0cf9736808c04858`. R2a/b retain shared producer ownership. This patch consumes the already-existing `LiveSessionError` → `ExecutionSessionPublicationError::Semantic` → `SemanticMutationTransactionError::NonFinitePropertyValue`; **none of those shared producer files changes**.

Master subsequently advanced to `71d8bfac1094e8232ae7f4b89872af2a1baff9db` with #1340's root-order correction. Its four changed files are disjoint. **The actual combined tree has now passed a separate compatibility qualification**, including the new root-order tests and real WASM/Pyodide suite; exact evidence is below. Neither product branch was changed by that compatibility run.

## Demonstrated residual and fix

The actual WASM from #1343 head `ef2e4a894a7795471795e62351c8241db59af4ce` still threw plain strings for non-finite inputs to `LiveExecution.set_translation`, `shift`, `set_scale`, and `set_rotation`. Shared Rust already rejected these atomically; the forwarding layers discarded the typed cause and the Python callsites did not use the existing mapper.

The same 29 fixtures were executed locally against that real baseline WASM: 21 scalar cases (NaN/±infinity at all seven argument positions), four foreign handles, and four genuinely retired semantic generations. All rejected atomically and recovered on the original wait timeline. The 21 scalar failures were strings; the eight handle failures already had typed JS metadata. Baseline WASM SHA-256: `6f13a7a31b61b3f097c2b2c9aa0b1f1fc8999a72fddb15dd62d90de5f15263f2`.

This patch retains `AuthoringFailure` through four private noon-web forwarders and their existing WASM wrappers, and calls the unchanged Python `engine_call` from those four public methods. Exactly one existing Rust variant is added to the current projection:

```text
category: invalid_input
live.publication
  → publication.semantic
    → transaction.non_finite_property_value
```

The original diagnostic retains mutation index, generational object identity, and property. Foreign and stale handles remain distinct. Python retains the original JS exception, recursive Rust causes, exception chaining, and operation. Python coercion failures remain the identical Python exception object, even when their message contains category-like words. Category assertions use exact metadata, not message substrings; diagnostic equality is checked separately.

**No semantic validation or guard order changes.** Ordinary waits permit these live property edits in shared Rust, and the tests preserve that behavior rather than inventing a blanket pending-segment rejection. Existing untyped active-player lifecycle guards remain explicitly `unclassified` when projected.

No new mapper/class, Rust error framework, crate/dependency, public raw-ID API, runner, or product workflow is added. Ownership `takePlayer()` / `take_player()` implementation and R6 constructor/target cleanup are untouched. Development-helper files are outside this PR.

## Exact qualification

| Item | Published PR-head qualification | New-master compatibility qualification |
|---|---|---|
| Tested commit | `166b166f25e27a13d2d940f8ac802d0e59fc2f8f` | `843ac495c5e51e5f3435a22f1506be1b35850169` (temporary merge, not PR head) |
| Tested tree | `b22961399f3f61cc0fe6e9f142ea5c9cef361198` | `d9ba3f71266c644d9921b296de383594665ca357` |
| Parent(s) | #1343 `ef2e4a894a7795471795e62351c8241db59af4ce` | PR head `166b166f...` + master `71d8bfac1094e8232ae7f4b89872af2a1baff9db` |
| Successful run | [34361452592](https://github.com/yongkyuns/noon/actions/runs/34361452592), job `102499193714` | [34362448333](https://github.com/yongkyuns/noon/actions/runs/34362448333), job `102502589011` |
| Inspected artifact | `10108307513`, `r3-live-property-qualification` | `10108694119`, `r3-live-properties-current-master` |
| Artifact SHA-256 | `6e91360e2c5bb5dd81945ee4a3ce7ec0a30c3a1f0f22fa1165710daacb0c9664` | `03c3467f7264b34d5a0f0c3348656291db3bc309a7569599ad626b938e76d62c` |

Both artifacts were downloaded and inspected; both source archive Git trees were independently recomputed and match the recorded trees. The first run pushed the exact tested commit to the PR branch. The compatibility run did not publish or alter either branch. Neither run had tracked-source edits after testing; only untracked browser artifacts and `node_modules` remained.

### Commands and results

Published head:

```sh
cargo test -p noon-web --lib live_transform_projection_preserves_atomic_rejection_and_local_retry -- --nocapture
bash scripts/check.sh fast ef2e4a894a7795471795e62351c8241db59af4ce
NOON_WEB_PREFLIGHT_ONLY=1 bash scripts/build-web-demo.sh
NOON_SKIP_WEB_PREFLIGHT=1 NOON_WASM_PROFILE=dev NOON_WASM_SKIP_OPT=1 bash scripts/build-web-demo.sh
node scripts/typed-authoring-errors-smoke.mjs
node scripts/manim-compat-smoke.mjs
```

Compatibility repeats the web/build/browser commands and additionally runs:

```sh
cargo test -p noon --test root_order_acceptance --test root_order_transaction_regressions
bash scripts/check.sh fast 71d8bfac1094e8232ae7f4b89872af2a1baff9db
```

- **Native:** focused regression passes. Fast gate passes architecture, formatting, workspace all-target/all-feature check, strict Clippy, and **1,398 library tests on the PR head / 1,403 on the combined tree**, zero failures and three ignored in each. Combined-tree root-order integration tests: **7 + 8 passed**.
- **Failure atomicity/locality:** native test preserves authored state, publication context, frame/resources and emits no retained delta for rejected edits. Valid retry emits a non-snapshot delta for exactly one object, no removals or changed resources, and no second delta.
- **Real WASM + product-pinned Pyodide on both trees:** **29 new JavaScript cases and the same 29 Python cases** pass; all seven scalar positions are covered. Rejection preserves authored/effective state, membership, ownership and revisions. Valid retry updates the correct coordinate, advances semantic/execution/frame revision once, and the original 0.25-second continuation subsequently completes.
- **Public Python:** the ninth actual WASM/Python unit test exercises all four ordinary `LiveExecution` methods, exact coercion-error identity, `NoonValueError` mapping and coherent retry during a wait.
- **Regression suite on both trees:** original **10 JavaScript + 10 Python membership/ownership cases**, **nine additional actual Python/WASM tests with zero skips**, Promise rejection/recovery, public Scene retry and another run in the same production worker, and existing Manim compatibility smoke all pass. Ownership tests still recover the original player.
- **Python discovery:** local and hosted **168 tests run, nine skipped** because those nine require actual WASM; the hosted browser then executes all nine with zero skips. The seven pure Python mapper tests also passed locally.

## Limits and remaining work

The one-object delta test is focused locality evidence, not a large-scene complexity benchmark. The patch adds no success-path scene traversal or clone; projection is failure-only. Authored/effective separation, semantic authority and atomic publication remain in shared Rust.

This is not every authored/object/value/layout/state or animation/composition/activation domain. Other mixed/string forwarders (content replacement, layout, relative scale/rotation, animation activation and additional drive/query callsites) remain incremental work as their R2 contracts settle. No new pending-callback property recovery claim is made beyond the existing callback-drive/ownership regressions. The pre-existing fresh-invalid-wait bootstrap ownership residual remains outside this representation patch.

These qualifications are fast-gate/dev-WASM runs, not `scripts/check.sh full`, release-WASM or the complete visual/platform/performance matrix on the new head. Normal PR checks and final pre-merge qualification still apply. #1343's original 12 PR workflows are all green after a targeted retry of an HTTP500 cache-tool download failure; that is separate evidence, not a substitute for this PR's checks.
