### PR TITLE
fix: keep first-wait player publication atomic (#1272 R2)

### DIFF
--- a/crates/noon-web/src/canonical_authoring_scene.rs
+++ b/crates/noon-web/src/canonical_authoring_scene.rs
@@ -9,6 +9,8 @@ pub(crate) use player_ownership::PlayerReturnError;
 use player_ownership::{PlayerOwnership, RejectedPlayerReturn};
 #[cfg(test)]
 mod ownership_tests;
+#[cfg(test)]
+mod wait_bootstrap_tests;
 
 use noon_core::ObjectId;
 #[cfg(any(target_arch = "wasm32", test))]
@@ -795,7 +797,12 @@ impl CanonicalAuthoringScene {
             }
             // A wait has no animation extent, but the presentation clock still needs a
             // positive valid range before its session-derived deadline replaces it.
-            self.live_player(duration.max(1.0))?;
+            let mut player = self.build_live_player(duration.max(1.0), 0)?;
+            let end_time = player.live_wait(duration)?;
+            // Shared admission is fallible. Publish the first runtime only once
+            // it owns a valid segment; rejection leaves this context unstarted.
+            self.player_ownership = PlayerOwnership::Active(player);
+            return Ok(end_time);
         }
         let player = self.active_live_player()?;
         player.live_wait(duration)

--- a/crates/noon-web/src/canonical_authoring_scene/wait_bootstrap_tests.rs
+++ b/crates/noon-web/src/canonical_authoring_scene/wait_bootstrap_tests.rs
@@ -1,0 +1,147 @@
+use super::*;
+
+fn reject_and_recover(
+    operation: fn(&mut CanonicalAuthoringScene, f64) -> Result<f64, AuthoringFailure>,
+    populated: bool,
+) {
+    for duration in [f64::NAN, -1.0, f64::NEG_INFINITY, f64::INFINITY] {
+        let mut scene = CanonicalAuthoringScene::default();
+        let circle = if populated {
+            let object = scene.scene.circle(1.0).unwrap();
+            scene.bind_mobject(ObjectId::new(0), &object).unwrap();
+            Some(object)
+        } else {
+            None
+        };
+        let revision = scene.scene.revision();
+        let root = scene.root_membership_keys().unwrap();
+        let bindings = scene.bindings.clone();
+        let identities = scene.identities.clone();
+        let object_state = circle.as_ref().map(|object| object.state().unwrap());
+        let geometry_count = scene
+            .scene
+            .integration_store()
+            .borrow()
+            .geometry_resources()
+            .len();
+        let text_count = scene
+            .scene
+            .integration_store()
+            .borrow()
+            .text_resources()
+            .len();
+        let error = operation(&mut scene, duration).unwrap_err();
+        // Positive infinity is already rejected by presentation-clock setup.
+        // Preserve that error precedence instead of adding a second validator.
+        if duration != f64::INFINITY {
+            assert_eq!(error.category, "invalid_input");
+            assert_eq!(error.code, "live.segment");
+            assert_eq!(
+                error.cause.as_ref().unwrap().code,
+                "segment.invalid_duration"
+            );
+        }
+        assert!(scene.player_ownership.is_unstarted());
+        assert!(scene.player_ownership.local().is_none());
+        assert_eq!(scene.live_handoff_duration(), None);
+        assert_eq!(scene.scene.time(), 0.0);
+        assert_eq!(scene.scene.revision(), revision);
+        assert_eq!(scene.root_membership_keys().unwrap(), root);
+        assert_eq!(scene.bindings, bindings);
+        assert_eq!(scene.identities, identities);
+        assert_eq!(
+            circle.as_ref().map(|object| object.state().unwrap()),
+            object_state
+        );
+        assert_eq!(
+            scene
+                .scene
+                .integration_store()
+                .borrow()
+                .geometry_resources()
+                .len(),
+            geometry_count
+        );
+        assert_eq!(
+            scene
+                .scene
+                .integration_store()
+                .borrow()
+                .text_resources()
+                .len(),
+            text_count
+        );
+        // Retry on this same context, then continue on its single runtime.
+        let end = scene.begin_ordinary_wait(0.5).unwrap();
+        assert_eq!(end, 0.5);
+        let player = scene.active_live_player().unwrap();
+        let identity = player.ownership_identity();
+        assert_eq!(player.time(), 0.0);
+        player.live_advance_segment_to(end).unwrap();
+        player.live_complete_segment().unwrap();
+        assert_eq!(scene.ordinary_wait(0.25).unwrap(), 0.75);
+        assert_eq!(
+            scene.active_live_player().unwrap().ownership_identity(),
+            identity
+        );
+        assert_eq!(scene.active_live_player().unwrap().time(), 0.75);
+        assert_eq!(scene.root_membership_keys().unwrap(), root);
+    }
+}
+
+#[test]
+fn invalid_first_async_wait_preserves_empty_context_and_retries() {
+    reject_and_recover(CanonicalAuthoringScene::begin_ordinary_wait, false);
+}
+
+#[test]
+fn invalid_first_async_wait_preserves_authored_objects_and_retries() {
+    reject_and_recover(CanonicalAuthoringScene::begin_ordinary_wait, true);
+}
+
+#[test]
+fn invalid_first_endpoint_wait_preserves_empty_context_and_retries() {
+    reject_and_recover(CanonicalAuthoringScene::ordinary_wait, false);
+}
+
+#[test]
+fn invalid_first_endpoint_wait_preserves_authored_objects_and_retries() {
+    reject_and_recover(CanonicalAuthoringScene::ordinary_wait, true);
+}
+
+#[test]
+fn invalid_wait_keeps_transferred_and_returned_runtime_ownership() {
+    let mut scene = CanonicalAuthoringScene::default();
+    let player = scene.take_execution_player(1.0, 41).unwrap();
+    let identity = player.ownership_identity();
+    assert!(scene.begin_ordinary_wait(-1.0).is_err());
+    assert!(scene.player_ownership.is_transferred());
+    scene.return_execution_player(player).unwrap();
+    let error = scene.begin_ordinary_wait(-1.0).unwrap_err();
+    assert_eq!(error.category, "invalid_input");
+    assert!(scene.player_ownership.is_returned());
+    assert_eq!(
+        scene.active_live_player().unwrap().ownership_identity(),
+        identity
+    );
+    assert_eq!(scene.ordinary_wait(0.5).unwrap(), 0.5);
+    assert_eq!(
+        scene.active_live_player().unwrap().ownership_identity(),
+        identity
+    );
+}
+
+#[test]
+fn authored_cursor_guard_and_zero_length_wait_keep_existing_semantics() {
+    let mut timed = CanonicalAuthoringScene::default();
+    timed.authored_wait(0.5).unwrap();
+    let revision = timed.scene.revision();
+    assert!(timed.begin_ordinary_wait(-1.0).is_err());
+    assert!(timed.player_ownership.is_unstarted());
+    assert_eq!(timed.scene.time(), 0.5);
+    assert_eq!(timed.scene.revision(), revision);
+    let mut empty = CanonicalAuthoringScene::default();
+    assert_eq!(empty.ordinary_wait(0.0).unwrap(), 0.0);
+    assert_eq!(empty.live_execution_ownership(), "active");
+    assert_eq!(empty.ordinary_wait(0.25).unwrap(), 0.25);
+}

--- a/scripts/typed-authoring-errors-smoke.mjs
+++ b/scripts/typed-authoring-errors-smoke.mjs
@@ -281,7 +281,7 @@ json.dumps({"matrix": results, "additionalTests": result.testsRun, "promiseRejec
 `));
   }, {modules, tests, pyodideUrl});
   assert.equal(report.python.matrix.length, 10);
-  assert.equal(report.python.additionalTests, 8);
+  assert.equal(report.python.additionalTests, 9);
   assert.equal(report.python.skipped, 0);
   assert.equal(report.python.promiseRejectionAndRecovery, true);
   // Exercise actual deployed Python callsites and a rerun in the same worker.

--- a/web/python/test_noon_errors_wasm.py
+++ b/web/python/test_noon_errors_wasm.py
@@ -13,7 +13,7 @@ except ImportError:
     wasm = None
 
 from _noon_errors import (
-    NoonForeignHandleError, NoonOwnershipError, NoonPendingError, NoonCallbackError,
+    NoonError, NoonForeignHandleError, NoonOwnershipError, NoonPendingError, NoonCallbackError,
     NoonStaleHandleError, NoonStalePublicationError, NoonValueError,
     engine_await, engine_call,
 )
@@ -249,6 +249,51 @@ class WasmErrorProjectionTests(unittest.TestCase):
         scene.add(first, second)
         self.assertEqual(scene.mobjects, [first, second])
         self.assertTrue(context.containsMobject(correct))
+
+    def test_invalid_first_wait_does_not_publish_a_player_and_retries(self):
+        # Existing-player failures are covered separately; these are fresh contexts.
+        for method in ("ordinaryWait", "beginOrdinaryWait"):
+            for populated in (False, True):
+                for duration in (float("nan"), -1.0, float("-inf"), float("inf")):
+                    with self.subTest(method=method, populated=populated, duration=duration):
+                        store = wasm.WasmAuthoringStore.new()
+                        context = store.createSceneContext()
+                        target = circle(store) if populated else None
+                        if target is not None:
+                            context.bindMobject("0", target)
+
+                        def state():
+                            return (context.liveExecutionOwnership(), context.authoredDuration(),
+                                    list(context.rootMembershipKeys()), context.liveHandoffDuration())
+
+                        before = state()
+                        expected = NoonError if duration == float("inf") else NoonValueError
+                        with self.assertRaises(expected) as caught:
+                            engine_call(getattr(context, method), duration, operation="Scene.wait")
+                        self.assert_diagnostic(caught.exception, "unclassified" if duration == float("inf") else "invalid_input")
+                        if duration != float("inf"):
+                            self.assertEqual(codes(caught.exception)[-1], "segment.invalid_duration")
+                        self.assertEqual(state(), before)
+                        self.assertEqual(context.liveExecutionOwnership(), "none")
+                        # Reuse the authored context and its binding reservations.
+                        added = circle(store)
+                        engine_call(context.bindMobject, "1", added)
+                        endpoint = engine_call(context.beginOrdinaryWait, 0.5)
+                        self.assertEqual(endpoint, 0.5)
+                        player = context.createExecutionPlayer(0.5, 73)
+                        drive = player.driveLiveSegmentToAuthoredTime(endpoint)
+                        self.assertTrue(drive.reachedEndpoint)
+                        drive.free()
+                        engine_call(player.completeLiveSegment)
+                        context.returnExecutionPlayer(player)
+                        self.assertEqual(engine_call(context.ordinaryWait, 0.25), 0.75)
+                        self.assertEqual(json.loads(context.liveDebugFrameJson())["time"], 0.75)
+                        self.assertTrue(context.containsMobject(added))
+                        context.free()
+                        added.free()
+                        if target is not None:
+                            target.free()
+                        store.free()
 
 
 async def check_real_promise_rejection():


### PR DESCRIPTION
## Final status — merged

**Merged into master as `406944f8a58218629c14ff247894b3fd2e8c471a`.** Final source head **`446a40d36c4ccb52194e51a364161bb773b96a4a`**, tested tree **`82ef974c20bd0cbd50afd5672923eca73ee855a1`**. All ten final-head PR workflows and the full integration qualification passed. This supersedes the earlier pending-check description.

Fixes the **fresh invalid-duration first-wait publication** residual from #1343/#1292, under #1272 R2. It does not complete the remaining typed-producer/mapping program and is unrelated to the blocked composition candidate.

## Correction and scope

`CanonicalAuthoringScene::begin_ordinary_wait` used to install its first execution player before shared `live_wait` could reject the duration. NaN, negative and negative-infinite waits returned errors but left ownership active.

The first unstarted branch now builds a private player, invokes the **same existing shared wait admission**, and publishes `PlayerOwnership::Active` only on success. Authored-cursor and presentation-clock guard order, transport session 0, active/returned/transferred ownership, zero duration, callback/segment policy and valid runtime identity remain unchanged. Positive infinity still fails at the presentation clock and remains explicitly unclassified. There is no second duration validator, scene clone, rollback protocol, Python semantic state or compatibility alias.

Exactly four changed files (+202/-3): the narrow Rust publication change and test-module declaration; six native regressions; an additional real Python/WASM test; the existing runner's discovered-test count. Shared semantic producers, error enums/projection, Python production, manifests and product workflows are unchanged.

## Reviewed source and integration

The final head preserves initial fix `03cd6b03ed2de0f45a89cbebb87ef6459c498641` and integrated master `47bfd0b6b20ac4b828607dc32a655dca8060db71` as parents. Branch publication was a fast-forward, not a force push. The integration retains every #1345 transform fixture and both additional Python methods (count9→10).

Independent Codex reviews of both initial and final heads reported no major issues; these are not formal GitHub APPROVED reviews. [Final author/landing review](https://github.com/yongkyuns/noon/pull/1346#pullrequestreview-5157009788) inspected the actual patch, construction/admission/ownership paths, full tests and immutable evidence. Fresh master `bc9fa345...` had separate family-callback changes but an unchanged first-wait body and no edits to this runner/test file; no current-base rollback or duplicate implementation was introduced. Post-merge qualification is distinct from the source-head evidence below.

## Full final-head qualification — passed

[Run34368140697](https://github.com/yongkyuns/noon/actions/runs/34368140697), job **102522099891**, attempt1. Inspected artifact **10111632937**, `integrated-wait-full-qualification`, ZIP SHA-256 **`02e99a131f260de179e167f39d1887db71d8ba639ca07fe394a1f8075c2a3abf`**. Its 1,090 source files independently reconstruct exactly the published Git tree above. The retained dependency lock is unchanged before/after.

```
bash scripts/check.sh full 47bfd0b6b20ac4b828607dc32a655dca8060db71
NOON_SKIP_WEB_PREFLIGHT=1 NOON_WASM_PROFILE=dev NOON_WASM_SKIP_OPT=1 bash scripts/build-web-demo.sh
node scripts/typed-authoring-errors-smoke.mjs
node scripts/manim-compat-smoke.mjs
```

Results:

- **1,690 native/integration/doc tests passed; zero failed; three pre-existing ignored** in the full-gate log. Architecture, formatting, all-target/all-feature check, strict Clippy and preflight passed.
- Optimized release-WASM build/package validation passed: WASM SHA-256 `4864f9dd7755c21a6ff57426013e3fe3876f1509f0c158dd2f85cce3334ce406`.
- The diagnostic-enabled dev package then passed **10 JS + 10 Pyodide membership/ownership cases, 29 + 29 transform cases, 10 additional real Python/WASM tests with zero skips**, Promise rejection/recovery, public Scene retry and a successful subsequent run in the same production worker. Manim smoke passed. Dev-WASM SHA-256 `667ba28e02db707da0f1d90d1aa22e0a73d82e626a09cdc6bfb634d482a9da89`.

The release build and dev fixture execution are separate evidence: the pre-existing stale-generation diagnostic fixture is debug-only. No release execution of that absent fixture is claimed. Rust/browser execution was hosted; the editing container inspected artifacts and source rather than claiming local Rust runs.

### Final-head normal PR workflows — all passed

Fast34368423912; agent foundation34368423922; shared text34368423961; recovery34368423973; discovery34368424024; layer34368423976; architecture34368423949; provider34368424035; product34368423938; cross-browser34368423986. Conditional skips are not extra passes. No protection or failing check was waived.

## Original red/green evidence

[Run34364118635](https://github.com/yongkyuns/noon/actions/runs/34364118635), job102510183117, artifact10109945590, retains the initial baseline/correction evidence. Four fresh-context tests failed unchanged production at ownership preservation; two controls passed. After correction, all85 canonical-authoring tests passed. The six new tests cover both synchronous/asynchronous paths, empty/populated contexts, NaN/negative/±infinite durations, returned/transferred ownership, authored-cursor precedence and zero duration. Rejection preserves authored state/revision, resources, membership and bindings; successful retry retains the same valid runtime afterward. The real Python test exercises16 fresh contexts and completes a0.5s+0.25s sequence after rejection.

Initial development/integration attempts caught an outdated discovered-test count and adjacent runner conflict. They did not count as successful qualification; corrected final-head results above supersede them without weakening zero-skip/count assertions.

## Remaining work and boundaries

This fixes rejection **inside first shared wait admission**, not every later endpoint-only execution failure. A separate pre-existing fresh valid `ordinaryWait` with required callbacks may publish a segment and then fail the endpoint-only guard; asynchronous continuation must continue to support callbacks. The scoped endpoint pre-admission follow-up remains with its existing owner and needs separate native/WASM qualification.

Broader object/value/layout/state and animation/composition producers, additional language mapping and R2/R3 umbrella acceptance remain open under #1292. AGENTS and architecture remain authoritative; no new authority, permanent helper workflow or migration layer is introduced. The blocked composition publication remains stopped and was not routed through this patch.