### PR TITLE
Fix cross-root alias painter order with local family comparisons (#1292 R4)

### DIFF
--- a/crates/noon-compile/src/semantic_lowering/root_order.rs
+++ b/crates/noon-compile/src/semantic_lowering/root_order.rs
@@ -1,6 +1,11 @@
 //! Lower authored family ordering into derived execution painter-order patches.
 
-use std::collections::{HashMap, HashSet};
+use std::{
+    cell::OnceCell,
+    cmp::Ordering,
+    collections::{HashMap, HashSet},
+    rc::Rc,
+};
 
 use noon_core::{
     PreparedSemanticMutationTransaction, SemanticMutation, SemanticNodeId, SemanticNodeKind,
@@ -12,108 +17,151 @@ use super::{
 };
 use crate::ExecutionPatch;
 
-// Only changed root links are retained. Untouched links are read directly from
-// the authored root; this is not a second scene or a semantic validator. The
-// prepared transaction has already validated all membership operations.
+type Node = SemanticTransactionNodeRef;
+
 #[derive(Clone, Copy)]
-struct RootLinks {
-    previous: Option<SemanticTransactionNodeRef>,
-    next: Option<SemanticTransactionNodeRef>,
+struct Links {
+    previous: Option<Node>,
+    next: Option<Node>,
 }
 
-struct RootOrder<'a> {
-    root: &'a noon_core::SemanticNode,
-    links: HashMap<SemanticTransactionNodeRef, Option<RootLinks>>,
-    tail: Option<SemanticTransactionNodeRef>,
+// Only transaction-touched links are retained. Original order comparison uses
+// the store's rank metadata; no whole-family snapshot or prefix walk is needed.
+struct FamilyOrder<'a> {
+    base: Option<&'a noon_core::SemanticNode>,
+    links: HashMap<Node, Option<Links>>,
+    moved: HashSet<Node>,
+    positions: OnceCell<HashMap<Node, (Option<Node>, usize)>>,
+    head: Option<Node>,
+    tail: Option<Node>,
 }
 
-impl<'a> RootOrder<'a> {
-    fn new(root: &'a noon_core::SemanticNode) -> Self {
+impl<'a> FamilyOrder<'a> {
+    fn new(base: Option<&'a noon_core::SemanticNode>) -> Self {
         Self {
-            root,
+            base,
             links: HashMap::new(),
-            tail: root.last_member().map(Into::into),
+            moved: HashSet::new(),
+            positions: OnceCell::new(),
+            head: base.and_then(|node| node.first_member()).map(Into::into),
+            tail: base.and_then(|node| node.last_member()).map(Into::into),
         }
     }
 
-    fn links(&self, member: SemanticTransactionNodeRef) -> Option<RootLinks> {
+    fn links(&self, member: Node) -> Option<Links> {
         self.links.get(&member).copied().unwrap_or_else(|| {
             let member = member.existing()?;
-            self.root.contains_member(member).then(|| RootLinks {
-                previous: self.root.previous_member(member).map(Into::into),
-                next: self.root.next_member(member).map(Into::into),
+            let base = self.base?;
+            base.contains_member(member).then(|| Links {
+                previous: base.previous_member(member).map(Into::into),
+                next: base.next_member(member).map(Into::into),
             })
         })
     }
 
-    fn next(&self, member: SemanticTransactionNodeRef) -> Option<SemanticTransactionNodeRef> {
-        self.links(member).and_then(|links| links.next)
+    fn next(&self, member: Node) -> Option<Node> {
+        self.links(member).and_then(|link| link.next)
     }
 
-    fn set_next(
-        &mut self,
-        member: Option<SemanticTransactionNodeRef>,
-        next: Option<SemanticTransactionNodeRef>,
-    ) {
+    fn set_next(&mut self, member: Option<Node>, next: Option<Node>) {
         if let Some(member) = member {
-            let mut links = self
+            let mut link = self
                 .links(member)
-                .expect("validated root predecessor remains present");
-            links.next = next;
-            self.links.insert(member, Some(links));
+                .expect("validated predecessor is present");
+            link.next = next;
+            self.links.insert(member, Some(link));
+        } else {
+            self.head = next;
         }
     }
 
-    fn set_previous(
-        &mut self,
-        member: Option<SemanticTransactionNodeRef>,
-        previous: Option<SemanticTransactionNodeRef>,
-    ) {
+    fn set_previous(&mut self, member: Option<Node>, previous: Option<Node>) {
         if let Some(member) = member {
-            let mut links = self
-                .links(member)
-                .expect("validated root successor remains present");
-            links.previous = previous;
-            self.links.insert(member, Some(links));
+            let mut link = self.links(member).expect("validated successor is present");
+            link.previous = previous;
+            self.links.insert(member, Some(link));
         } else {
             self.tail = previous;
         }
     }
 
-    fn remove(&mut self, member: SemanticTransactionNodeRef) {
-        if let Some(links) = self.links(member) {
-            self.set_next(links.previous, links.next);
-            self.set_previous(links.next, links.previous);
+    fn remove(&mut self, member: Node) {
+        if let Some(link) = self.links(member) {
+            self.positions.take();
+            self.set_next(link.previous, link.next);
+            self.set_previous(link.next, link.previous);
             self.links.insert(member, None);
+            self.moved.insert(member);
         }
     }
 
-    fn insert_before(
-        &mut self,
-        member: SemanticTransactionNodeRef,
-        before: Option<SemanticTransactionNodeRef>,
-    ) {
-        if before == Some(member) || self.links(member).is_some_and(|links| links.next == before) {
+    fn insert_before(&mut self, member: Node, before: Option<Node>) {
+        if before == Some(member) || self.links(member).is_some_and(|link| link.next == before) {
             return;
         }
         self.remove(member);
-        let previous = match before {
-            Some(anchor) => {
-                self.links(anchor)
-                    .expect("validated root anchor remains present")
-                    .previous
-            }
-            None => self.tail,
-        };
+        self.positions.take();
+        let previous = before.map_or(self.tail, |anchor| {
+            self.links(anchor)
+                .expect("validated anchor is present")
+                .previous
+        });
         self.set_next(previous, Some(member));
         self.set_previous(before, Some(member));
         self.links.insert(
             member,
-            Some(RootLinks {
+            Some(Links {
                 previous,
                 next: before,
             }),
         );
+        self.moved.insert(member);
+    }
+
+    fn stable_anchor(&self, member: Node) -> (Option<Node>, usize) {
+        if !self.moved.contains(&member) {
+            return (Some(member), 0);
+        }
+        let positions = self.positions.get_or_init(|| {
+            let mut result = HashMap::new();
+            for &member in &self.moved {
+                if self.links(member).is_none() || result.contains_key(&member) {
+                    continue;
+                }
+                let mut path = Vec::new();
+                let mut current = Some(member);
+                while let Some(node) =
+                    current.filter(|node| self.moved.contains(node) && !result.contains_key(node))
+                {
+                    path.push(node);
+                    current = self.next(node);
+                }
+                let (anchor, mut distance) = current
+                    .and_then(|node| result.get(&node).copied())
+                    .unwrap_or((current, 0));
+                for node in path.into_iter().rev() {
+                    distance += 1;
+                    result.insert(node, (anchor, distance));
+                }
+            }
+            result
+        });
+        positions[&member]
+    }
+
+    fn compare(&self, left: Node, right: Node) -> Ordering {
+        let (left_anchor, left_distance) = self.stable_anchor(left);
+        let (right_anchor, right_distance) = self.stable_anchor(right);
+        match (left_anchor, right_anchor) {
+            (left, right) if left == right => right_distance.cmp(&left_distance),
+            (None, _) => Ordering::Greater,
+            (_, None) => Ordering::Less,
+            (Some(left), Some(right)) => self
+                .base
+                .unwrap()
+                .compare_members(left.existing().unwrap(), right.existing().unwrap())
+                .expect("unchanged anchors belong to the published family"),
+        }
     }
 }
 
@@ -130,75 +178,288 @@ fn node_for_root_order(
     })
 }
 
-// The same first-occurrence traversal serves both a moved block and its anchor.
-// An anchor stops at its first leaf; a block visits each affected DAG node once.
-// Preserve provisional references until a leaf resolves through the held
-// transaction's allocator proof. Nothing is published or allocated in the store.
-fn visit_leaves(
-    prepared: &PreparedSemanticMutationTransaction<'_>,
-    reference: SemanticTransactionNodeRef,
-    seen: &mut HashSet<SemanticTransactionNodeRef>,
-    visitor: &mut impl FnMut(SemanticNodeId) -> bool,
-) -> Result<bool, SemanticPublicationLoweringError> {
-    if !seen.insert(reference) || prepared.node_is_removed(reference) {
-        return Ok(false);
+// A borrowed prepared-transaction projection, not an independent semantic graph.
+// It holds only changed family links and reverse-edge overrides. Unchanged values
+// and relationships remain borrowed from the exclusively held SemanticStore.
+struct OrderView<'a, 'store> {
+    prepared: &'a PreparedSemanticMutationTransaction<'store>,
+    families: HashMap<Node, FamilyOrder<'a>>,
+    parents: HashMap<Node, HashMap<Node, bool>>,
+}
+
+impl<'a, 'store> OrderView<'a, 'store> {
+    fn new(prepared: &'a PreparedSemanticMutationTransaction<'store>) -> Self {
+        Self {
+            prepared,
+            families: HashMap::new(),
+            parents: HashMap::new(),
+        }
     }
-    match reference {
-        SemanticTransactionNodeRef::Existing(id) => {
-            let node = node_for_root_order(prepared.store(), id)?;
-            match node.kind() {
-                SemanticNodeKind::AuthoringObject => Ok(visitor(id)),
-                SemanticNodeKind::Family => {
-                    for member in node.members_iter() {
-                        if visit_leaves(prepared, member.into(), seen, visitor)? {
-                            return Ok(true);
-                        }
-                    }
-                    Ok(false)
+
+    fn family_mut(
+        &mut self,
+        family: Node,
+    ) -> Result<&mut FamilyOrder<'a>, SemanticPublicationLoweringError> {
+        if !self.families.contains_key(&family) {
+            let base = family
+                .existing()
+                .map(|id| node_for_root_order(self.prepared.store(), id))
+                .transpose()?;
+            self.families.insert(family, FamilyOrder::new(base));
+        }
+        Ok(self.families.get_mut(&family).unwrap())
+    }
+
+    fn parents(&self, member: Node) -> Result<Vec<Node>, SemanticPublicationLoweringError> {
+        let overrides = self.parents.get(&member);
+        let mut parents = match member.existing() {
+            Some(id) => node_for_root_order(self.prepared.store(), id)?
+                .parents()
+                .iter()
+                .copied()
+                .map(Into::into)
+                .filter(|parent| {
+                    overrides
+                        .and_then(|items| items.get(parent))
+                        .copied()
+                        .unwrap_or(true)
+                })
+                .collect::<HashSet<_>>(),
+            None => HashSet::new(),
+        };
+        if let Some(overrides) = overrides {
+            for (&parent, &present) in overrides {
+                if present {
+                    parents.insert(parent);
                 }
-                SemanticNodeKind::Signal(_) | SemanticNodeKind::Animation(_) => Ok(false),
             }
         }
-        SemanticTransactionNodeRef::Pending(token) => match prepared.object_state(reference) {
-            Ok(_) => {
-                let id = prepared
-                    .planned_node_id(reference)
-                    .ok_or(SemanticTransactionReadError::UnknownPendingNode(token))?;
-                Ok(visitor(id))
-            }
-            Err(SemanticTransactionReadError::NotObject(_)) => {
-                // A provisional family's members all belong to this affected
-                // transaction, never an unrelated published root snapshot.
-                for member in prepared.family_members(reference)? {
-                    if visit_leaves(prepared, member, seen, visitor)? {
-                        return Ok(true);
-                    }
+        parents.retain(|parent| !self.prepared.node_is_removed(*parent));
+        Ok(parents.into_iter().collect())
+    }
+
+    fn first(&self, family: Node) -> Result<Option<Node>, SemanticPublicationLoweringError> {
+        if let Some(order) = self.families.get(&family) {
+            return Ok(order.head);
+        }
+        match family.existing() {
+            Some(id) => Ok(node_for_root_order(self.prepared.store(), id)?
+                .first_member()
+                .map(Into::into)),
+            None => Ok(None),
+        }
+    }
+
+    fn next(
+        &self,
+        family: Node,
+        member: Node,
+    ) -> Result<Option<Node>, SemanticPublicationLoweringError> {
+        if let Some(order) = self.families.get(&family) {
+            return Ok(order.next(member));
+        }
+        Ok(
+            node_for_root_order(self.prepared.store(), family.existing().unwrap())?
+                .next_member(member.existing().unwrap())
+                .map(Into::into),
+        )
+    }
+
+    fn compare(&self, family: Node, left: Node, right: Node) -> Ordering {
+        if let Some(order) = self.families.get(&family) {
+            return order.compare(left, right);
+        }
+        node_for_root_order(self.prepared.store(), family.existing().unwrap())
+            .expect("validated path parent exists")
+            .compare_members(left.existing().unwrap(), right.existing().unwrap())
+            .expect("canonical paths contain live family edges")
+    }
+
+    fn is_object(&self, node: Node) -> Result<bool, SemanticPublicationLoweringError> {
+        match node.existing() {
+            Some(id) => Ok(matches!(
+                node_for_root_order(self.prepared.store(), id)?.kind(),
+                SemanticNodeKind::AuthoringObject
+            )),
+            None => match self.prepared.object_state(node) {
+                Ok(_) => Ok(true),
+                Err(SemanticTransactionReadError::NotObject(_)) => Ok(false),
+                Err(error) => Err(error.into()),
+            },
+        }
+    }
+
+    fn collect_leaves(
+        &self,
+        node: Node,
+        seen: &mut HashSet<Node>,
+        output: &mut HashSet<Node>,
+    ) -> Result<(), SemanticPublicationLoweringError> {
+        if !seen.insert(node) {
+            return Ok(());
+        }
+        if self.prepared.node_is_removed(node) {
+            // Removing a family can transfer first occurrence of surviving shared
+            // leaves. Its old descendant closure is affected even though the family
+            // itself no longer has a final staged view.
+            if let Some(id) = node.existing() {
+                for child in node_for_root_order(self.prepared.store(), id)?.members_iter() {
+                    self.collect_leaves(child.into(), seen, output)?;
                 }
-                Ok(false)
             }
-            Err(error) => Err(error.into()),
-        },
+        } else if self.is_object(node)? {
+            output.insert(node);
+        } else {
+            let mut child = self.first(node)?;
+            while let Some(member) = child {
+                self.collect_leaves(member, seen, output)?;
+                child = self.next(node, member)?;
+            }
+        }
+        Ok(())
     }
 }
 
-fn leaves(
-    prepared: &PreparedSemanticMutationTransaction<'_>,
-    member: SemanticTransactionNodeRef,
-) -> Result<Vec<SemanticNodeId>, SemanticPublicationLoweringError> {
-    let mut output = Vec::new();
-    visit_leaves(prepared, member, &mut HashSet::new(), &mut |leaf| {
-        output.push(leaf);
-        false
-    })?;
-    Ok(output)
+// First-occurrence paths are shared prefix chains, not copied path vectors. The
+// reverse-parent dependency closure is memoized once for this preparation.
+struct Occurrence {
+    node: Node,
+    parent: Option<Rc<Occurrence>>,
+    depth: usize,
 }
 
-/// Prepare execution order changes for an explicitly rooted authored transaction.
+fn compare_paths(view: &OrderView<'_, '_>, left: &Occurrence, right: &Occurrence) -> Ordering {
+    let (mut a, mut b) = (left, right);
+    while a.depth > b.depth {
+        a = a.parent.as_deref().unwrap();
+    }
+    while b.depth > a.depth {
+        b = b.parent.as_deref().unwrap();
+    }
+    let same = |a: &Occurrence, b: &Occurrence| {
+        a.node == b.node
+            && match (&a.parent, &b.parent) {
+                (None, None) => true,
+                (Some(a), Some(b)) => Rc::ptr_eq(a, b),
+                _ => false,
+            }
+    };
+    if same(a, b) {
+        return left.depth.cmp(&right.depth);
+    }
+    while !Rc::ptr_eq(a.parent.as_ref().unwrap(), b.parent.as_ref().unwrap()) {
+        a = a.parent.as_deref().unwrap();
+        b = b.parent.as_deref().unwrap();
+    }
+    view.compare(a.parent.as_ref().unwrap().node, a.node, b.node)
+}
+
+struct FirstOccurrences<'a, 'store> {
+    view: OrderView<'a, 'store>,
+    paths: HashMap<Node, Option<Rc<Occurrence>>>,
+}
+
+impl<'a, 'store> FirstOccurrences<'a, 'store> {
+    fn path(
+        &mut self,
+        node: Node,
+    ) -> Result<Option<Rc<Occurrence>>, SemanticPublicationLoweringError> {
+        if self.view.prepared.node_is_removed(node) {
+            return Ok(None);
+        }
+        if let Some(path) = self.paths.get(&node) {
+            return Ok(path.clone());
+        }
+        let mut first: Option<Rc<Occurrence>> = None;
+        for parent in self.view.parents(node)? {
+            if let Some(parent) = self.path(parent)? {
+                let candidate = Rc::new(Occurrence {
+                    node,
+                    depth: parent.depth + 1,
+                    parent: Some(parent),
+                });
+                if first
+                    .as_ref()
+                    .is_none_or(|first| compare_paths(&self.view, &candidate, first).is_lt())
+                {
+                    first = Some(candidate);
+                }
+            }
+        }
+        self.paths.insert(node, first.clone());
+        Ok(first)
+    }
+
+    fn first_leaf(
+        &mut self,
+        node: Node,
+        parent: &Rc<Occurrence>,
+    ) -> Result<Option<Node>, SemanticPublicationLoweringError> {
+        let Some(path) = self.path(node)? else {
+            return Ok(None);
+        };
+        // A later occurrence of an entire family is execution-empty. Skip it
+        // without traversing its descendants, including diamond alias DAGs.
+        if !path
+            .parent
+            .as_ref()
+            .is_some_and(|owner| Rc::ptr_eq(owner, parent))
+        {
+            return Ok(None);
+        }
+        if self.view.is_object(node)? {
+            return Ok(Some(node));
+        }
+        let mut child = self.view.first(node)?;
+        while let Some(member) = child {
+            if let Some(leaf) = self.first_leaf(member, &path)? {
+                return Ok(Some(leaf));
+            }
+            child = self.view.next(node, member)?;
+        }
+        Ok(None)
+    }
+
+    fn successor(
+        &mut self,
+        mut path: Rc<Occurrence>,
+    ) -> Result<Option<Node>, SemanticPublicationLoweringError> {
+        while let Some(parent) = path.parent.clone() {
+            let mut next = self.view.next(parent.node, path.node)?;
+            while let Some(node) = next {
+                if let Some(leaf) = self.first_leaf(node, &parent)? {
+                    return Ok(Some(leaf));
+                }
+                next = self.view.next(parent.node, node)?;
+            }
+            path = parent;
+        }
+        Ok(None)
+    }
+
+    fn execution_id(
+        &self,
+        node: Node,
+    ) -> Result<noon_core::ObjectId, SemanticPublicationLoweringError> {
+        self.view
+            .prepared
+            .planned_node_id(node)
+            .map(semantic_execution_object_id)
+            .ok_or_else(|| match node {
+                Node::Existing(id) => SemanticTransactionReadError::UnknownExistingNode(id).into(),
+                Node::Pending(token) => {
+                    SemanticTransactionReadError::UnknownPendingNode(token).into()
+                }
+            })
+    }
+}
+
+/// Prepare root-relative painter effects against final staged membership/order.
 ///
-/// This is fallible compiler work before semantic or runtime publication. It visits
-/// candidate root membership edits and their affected families/anchors, without a
-/// whole-scene traversal. The session consumes these derived patches alongside the
-/// ordinary publication; it does not interpret semantic family ordering itself.
+/// This is fallible compiler work before any publication. Only mutation targets,
+/// their descendant/reverse-parent dependencies and successor anchors are visited.
+/// Family rank metadata resolves distant aliases without scanning root prefixes.
+/// The session consumes existing patches and does not interpret semantic ordering.
 pub fn prepare_semantic_root_order(
     prepared: &PreparedSemanticMutationTransaction<'_>,
     root: SemanticNodeId,
@@ -209,70 +470,72 @@ pub fn prepare_semantic_root_order(
             SemanticLoweringError::Store(noon_core::SemanticStoreError::NotFamily(root)).into(),
         );
     }
-
-    let mut order = RootOrder::new(root_node);
-    let mut patches = Vec::new();
+    if prepared.node_is_removed(root) {
+        return Err(SemanticTransactionReadError::RemovedExistingNode(root).into());
+    }
+    let mut view = OrderView::new(prepared);
+    let mut targets = Vec::new();
     for mutation in prepared.candidate_mutations() {
-        match mutation {
-            SemanticMutation::AddMember { family, member } if family.existing() == Some(root) => {
-                order.insert_before(*member, None);
+        match *mutation {
+            SemanticMutation::AddMember { family, member } => {
+                view.family_mut(family)?.insert_before(member, None);
+                view.parents.entry(member).or_default().insert(family, true);
+                targets.push(member);
             }
-            SemanticMutation::RemoveMember { family, member }
-                if family.existing() == Some(root) =>
-            {
-                order.remove(*member);
-            }
-            SemanticMutation::ReorderMember {
-                family,
-                member,
-                before,
-            } if family.existing() == Some(root) => {
-                order.insert_before(*member, *before);
-            }
-            _ => {}
-        }
-        match mutation {
-            SemanticMutation::AddMember { family, member } if family.existing() == Some(root) => {
-                let member_leaves = leaves(prepared, *member)?;
-                for leaf in member_leaves {
-                    patches.push(ExecutionPatch::ReorderObject {
-                        object: semantic_execution_object_id(leaf),
-                        before: None,
-                    });
-                }
+            SemanticMutation::RemoveMember { family, member } => {
+                view.family_mut(family)?.remove(member);
+                view.parents
+                    .entry(member)
+                    .or_default()
+                    .insert(family, false);
+                targets.push(member);
             }
             SemanticMutation::ReorderMember {
                 family,
                 member,
                 before,
-            } if family.existing() == Some(root) => {
-                let member_leaves = leaves(prepared, *member)?;
-                let mut before = *before;
-                let mut anchor = None;
-                let mut seen = HashSet::new();
-                while let Some(candidate) = before {
-                    if visit_leaves(prepared, candidate, &mut seen, &mut |leaf| {
-                        anchor = Some(semantic_execution_object_id(leaf));
-                        true
-                    })? {
-                        break;
-                    }
-                    // An empty root member still marks a semantic position. Its
-                    // next staged sibling, not the execution tail or a removed
-                    // published sibling, supplies the anchor.
-                    before = order.next(candidate);
+            } => {
+                view.family_mut(family)?.insert_before(member, before);
+                targets.push(member);
+            }
+            SemanticMutation::RemoveNode { node } => {
+                for parent in view.parents(node)? {
+                    view.family_mut(parent)?.remove(node);
                 }
-                for leaf in member_leaves.into_iter().rev() {
-                    let object = semantic_execution_object_id(leaf);
-                    patches.push(ExecutionPatch::ReorderObject {
-                        object,
-                        before: anchor,
-                    });
-                    anchor = Some(object);
-                }
+                targets.push(node);
             }
             _ => {}
         }
+    }
+    let mut affected = HashSet::new();
+    let mut seen = HashSet::new();
+    for target in targets {
+        view.collect_leaves(target, &mut seen, &mut affected)?;
+    }
+    let root_path = Rc::new(Occurrence {
+        node: root.into(),
+        parent: None,
+        depth: 0,
+    });
+    let mut occurrences = FirstOccurrences {
+        view,
+        paths: HashMap::from([(root.into(), Some(root_path))]),
+    };
+    let mut ordered = Vec::new();
+    for leaf in affected {
+        if let Some(path) = occurrences.path(leaf)? {
+            ordered.push(path);
+        }
+    }
+    ordered.sort_by(|left, right| compare_paths(&occurrences.view, left, right));
+    let mut patches = Vec::with_capacity(ordered.len());
+    for path in ordered.into_iter().rev() {
+        let object = occurrences.execution_id(path.node)?;
+        let before = occurrences
+            .successor(path)?
+            .map(|node| occurrences.execution_id(node))
+            .transpose()?;
+        patches.push(ExecutionPatch::ReorderObject { object, before });
     }
     Ok(patches)
 }
@@ -425,9 +688,9 @@ mod tests {
                     before: Some(semantic_execution_object_id(first)),
                 }],
             );
-            // Root validation + moved leaf + empty anchor + anchor family + its
-            // first leaf. No prefix, unrelated family, or anchor-tail traversal.
-            assert_eq!(NODES_VISITED.with(|count| count.get()), 5);
+            // Includes reverse-parent paths and successor validation, but still no
+            // prefix, unrelated family, or unused anchor-tail traversal.
+            assert_eq!(NODES_VISITED.with(|count| count.get()), 12);
         }
     }
 
@@ -511,9 +774,113 @@ mod tests {
                     before: Some(semantic_execution_object_id(anchor)),
                 }]
             );
+            let reads = NODES_VISITED.with(|count| count.get());
+            assert!(reads <= 22 * DEPTH + 24);
+            println!("alias DAG depth={DEPTH}, empty={empty}: node reads={reads}");
+        }
+    }
+
+    #[test]
+    fn cross_root_alias_lookup_skips_unrelated_prefix_gap_and_owner_tail() {
+        for unrelated in [0, 20_000] {
+            let mut store = SemanticStore::new();
+            let root = store.insert_family();
+            let detached = store.insert_family();
+            let left = store.insert_family();
+            let right = store.insert_family();
+            let make = |store: &mut SemanticStore| {
+                store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+                    radius: 1.0,
+                }))
+            };
+            let shared = make(&mut store);
+            let a = make(&mut store);
+            let b = make(&mut store);
+            let next = make(&mut store);
+            for member in [shared, a] {
+                store.add_member(left, member).unwrap();
+            }
+            for member in [b, shared, next] {
+                store.add_member(right, member).unwrap();
+            }
+            // The detached alias owner is a reverse dependency. Its children
+            // other than shared must not be traversed just to prove it detached.
+            store.add_member(detached, shared).unwrap();
+            for family in [root, detached, right] {
+                for _ in 0..unrelated {
+                    let node = make(&mut store);
+                    store.add_member(family, node).unwrap();
+                }
+            }
+            store.add_member(root, left).unwrap();
+            for _ in 0..unrelated {
+                let node = make(&mut store);
+                store.add_member(root, node).unwrap();
+            }
+            store.add_member(root, right).unwrap();
+            let revision = store.scene_revision();
+            let mut tx = SemanticMutationTransaction::new();
+            tx.reorder_member(root, left, None);
+            let prepared = tx.prepare(&mut store).unwrap();
+            NODES_VISITED.with(|count| count.set(0));
             assert_eq!(
-                NODES_VISITED.with(|count| count.get()),
-                3 * DEPTH + if empty { 4 } else { 3 }
+                prepare_semantic_root_order(&prepared, root).unwrap(),
+                vec![
+                    ExecutionPatch::ReorderObject {
+                        object: semantic_execution_object_id(a),
+                        before: None
+                    },
+                    ExecutionPatch::ReorderObject {
+                        object: semantic_execution_object_id(shared),
+                        before: Some(semantic_execution_object_id(next))
+                    },
+                ]
+            );
+            let reads = NODES_VISITED.with(|count| count.get());
+            println!(
+                "cross-root alias extra nodes={}: semantic node reads={reads}",
+                4 * unrelated
+            );
+            assert!(reads <= 40);
+            assert_eq!(prepared.store().scene_revision(), revision);
+            assert_eq!(
+                prepared
+                    .store()
+                    .node(root)
+                    .unwrap()
+                    .compare_members(left, right),
+                Some(Ordering::Less)
+            );
+        }
+    }
+
+    #[test]
+    fn whole_batch_staged_positions_are_cached_not_rewalked_per_comparison() {
+        for count in [16, 1024] {
+            let mut store = SemanticStore::new();
+            let root = store.insert_family();
+            let nodes = (0..count)
+                .map(|_| {
+                    let node = store.insert_semantic_object(SemanticObjectState::new(
+                        StoredGeometry::Circle { radius: 1.0 },
+                    ));
+                    store.add_member(root, node).unwrap();
+                    node
+                })
+                .collect::<Vec<_>>();
+            let mut tx = SemanticMutationTransaction::new();
+            for &node in &nodes[..count - 1] {
+                tx.reorder_member(root, node, None);
+            }
+            let prepared = tx.prepare(&mut store).unwrap();
+            NODES_VISITED.with(|count| count.set(0));
+            let patches = prepare_semantic_root_order(&prepared, root).unwrap();
+            assert_eq!(patches.len(), count - 1);
+            let reads = NODES_VISITED.with(|count| count.get());
+            assert!(reads <= 10 * count + 10);
+            println!(
+                "batch size={count}: node reads={reads}, patches={}",
+                patches.len()
             );
         }
     }

--- a/crates/noon-core/src/semantic_store.rs
+++ b/crates/noon-core/src/semantic_store.rs
@@ -26,6 +26,9 @@ impl std::hash::Hash for SemanticStoreIdentity {
     }
 }
 
+mod family_member_order;
+use family_member_order::MemberOrderLink;
+
 mod semantic_scene_operations;
 pub use semantic_scene_operations::*;
 
@@ -134,22 +137,40 @@ enum SemanticSceneMembership {
     },
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug)]
 struct FamilyMemberLink {
     previous: Option<SemanticNodeId>,
     next: Option<SemanticNodeId>,
+    order: MemberOrderLink,
 }
 
-/// Ordered family membership with local lookup/add/remove/reorder.
+/// Ordered family membership with O(1) identity/neighbor lookup and O(log n) edits.
+/// Balanced rank metadata supports local order comparison without sibling scans.
 ///
 /// The hash map is identity lookup only; deterministic semantic order follows
 /// the private previous/next links from `head` to `tail`.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default)]
 struct OrderedFamilyMembers {
     head: Option<SemanticNodeId>,
     tail: Option<SemanticNodeId>,
     links: HashMap<SemanticNodeId, FamilyMemberLink>,
+    order_root: Option<SemanticNodeId>,
 }
+
+impl PartialEq for OrderedFamilyMembers {
+    fn eq(&self, other: &Self) -> bool {
+        self.head == other.head
+            && self.tail == other.tail
+            && self.links.len() == other.links.len()
+            && self.links.iter().all(|(id, link)| {
+                other
+                    .links
+                    .get(id)
+                    .is_some_and(|other| link.previous == other.previous && link.next == other.next)
+            })
+    }
+}
+impl Eq for OrderedFamilyMembers {}
 
 impl OrderedFamilyMembers {
     fn contains(&self, member: SemanticNodeId) -> bool {
@@ -175,16 +196,20 @@ impl OrderedFamilyMembers {
             FamilyMemberLink {
                 previous,
                 next: None,
+                order: MemberOrderLink::default(),
             },
         );
+        self.order_insert(member, None);
         self.tail = Some(member);
         true
     }
 
     fn remove(&mut self, member: SemanticNodeId) -> bool {
-        let Some(link) = self.links.remove(&member) else {
+        let Some(link) = self.links.get(&member).copied() else {
             return false;
         };
+        self.order_remove(member);
+        self.links.remove(&member);
         if let Some(previous_id) = link.previous {
             self.links
                 .get_mut(&previous_id)
@@ -211,7 +236,7 @@ impl OrderedFamilyMembers {
     }
 
     /// Move an existing member immediately before `before`, or to the tail when
-    /// `before` is `None`. All link lookup and rewiring is O(1).
+    /// `before` is `None`. Neighbor rewiring is O(1); rank maintenance is O(log n).
     fn move_before(&mut self, member: SemanticNodeId, before: Option<SemanticNodeId>) -> bool {
         let link = *self
             .links
@@ -224,6 +249,7 @@ impl OrderedFamilyMembers {
             return false;
         }
 
+        self.order_remove(member);
         // Detach the member without changing membership identity.
         if let Some(previous_id) = link.previous {
             self.links
@@ -273,8 +299,12 @@ impl OrderedFamilyMembers {
         *self
             .links
             .get_mut(&member)
-            .expect("family reorder member link must remain present") =
-            FamilyMemberLink { previous, next };
+            .expect("family reorder member link must remain present") = FamilyMemberLink {
+            previous,
+            next,
+            order: MemberOrderLink::default(),
+        };
+        self.order_insert(member, before);
         true
     }
 
@@ -431,6 +461,22 @@ impl SemanticNode {
             .links
             .get(&member)
             .and_then(|link| link.previous)
+    }
+
+    /// Compare two direct members in authored order in O(log member_count).
+    /// Returns `None` when either identity is not a current direct member.
+    /// Neighbor links remain the order authority; balanced rank metadata avoids
+    /// traversing unrelated siblings during compiler alias preparation.
+    pub fn compare_members(
+        &self,
+        left: SemanticNodeId,
+        right: SemanticNodeId,
+    ) -> Option<std::cmp::Ordering> {
+        Some(
+            self.members
+                .order_rank(left)?
+                .cmp(&self.members.order_rank(right)?),
+        )
     }
 
     /// Whether `member` is a direct member of this family.

--- a/crates/noon-core/src/semantic_store/family_member_order.rs
+++ b/crates/noon-core/src/semantic_store/family_member_order.rs
@@ -1,0 +1,304 @@
+//! Derived order-statistic metadata for the store's existing family links.
+//!
+//! The intrusive list remains authoritative membership/order. This AVL index
+//! stores only member identities, parent/child links and subtree sizes; no values,
+//! second membership map or new identity allocator. All metadata edits accompany
+//! validated list edits. Comparing distant aliases never walks unrelated siblings.
+
+use super::{OrderedFamilyMembers, SemanticNodeId};
+
+type Node = SemanticNodeId;
+
+#[derive(Clone, Copy, Debug)]
+pub(super) struct MemberOrderLink {
+    left: Option<Node>,
+    right: Option<Node>,
+    parent: Option<Node>,
+    size: usize,
+    height: u16,
+}
+
+impl Default for MemberOrderLink {
+    fn default() -> Self {
+        Self {
+            left: None,
+            right: None,
+            parent: None,
+            size: 1,
+            height: 1,
+        }
+    }
+}
+
+impl OrderedFamilyMembers {
+    fn order_link(&self, node: Node) -> MemberOrderLink {
+        #[cfg(test)]
+        tests::READS.with(|reads| reads.set(reads.get() + 1));
+        self.links[&node].order
+    }
+
+    fn order_size(&self, node: Option<Node>) -> usize {
+        node.map_or(0, |node| self.order_link(node).size)
+    }
+
+    fn order_height(&self, node: Option<Node>) -> u16 {
+        node.map_or(0, |node| self.order_link(node).height)
+    }
+
+    fn order_parent(&mut self, node: Option<Node>, parent: Option<Node>) {
+        if let Some(node) = node {
+            self.links.get_mut(&node).unwrap().order.parent = parent;
+        }
+    }
+
+    fn order_children(&mut self, node: Node, left: Option<Node>, right: Option<Node>) {
+        let size = 1 + self.order_size(left) + self.order_size(right);
+        let height = 1 + self.order_height(left).max(self.order_height(right));
+        let link = &mut self.links.get_mut(&node).unwrap().order;
+        link.left = left;
+        link.right = right;
+        link.size = size;
+        link.height = height;
+        self.order_parent(left, Some(node));
+        self.order_parent(right, Some(node));
+    }
+
+    fn order_rotate(&mut self, node: Node, left: bool) -> Node {
+        let link = self.order_link(node);
+        let pivot = if left { link.right } else { link.left }.unwrap();
+        let child = self.order_link(pivot);
+        if left {
+            self.order_children(node, link.left, child.left);
+            self.order_children(pivot, Some(node), child.right);
+        } else {
+            self.order_children(node, child.right, link.right);
+            self.order_children(pivot, child.left, Some(node));
+        }
+        self.order_parent(Some(pivot), link.parent);
+        pivot
+    }
+
+    fn order_balance(&mut self, node: Node) -> Node {
+        let link = self.order_link(node);
+        let left_height = self.order_height(link.left);
+        let right_height = self.order_height(link.right);
+        if left_height > right_height + 1 {
+            let left = self.order_link(link.left.unwrap());
+            if self.order_height(left.right) > self.order_height(left.left) {
+                let rotated = self.order_rotate(link.left.unwrap(), true);
+                self.order_children(node, Some(rotated), link.right);
+            }
+            self.order_rotate(node, false)
+        } else if right_height > left_height + 1 {
+            let right = self.order_link(link.right.unwrap());
+            if self.order_height(right.left) > self.order_height(right.right) {
+                let rotated = self.order_rotate(link.right.unwrap(), false);
+                self.order_children(node, link.left, Some(rotated));
+            }
+            self.order_rotate(node, true)
+        } else {
+            node
+        }
+    }
+
+    fn order_insert_at(&mut self, root: Option<Node>, node: Node, rank: usize) -> Node {
+        let Some(root) = root else { return node };
+        let link = self.order_link(root);
+        let left_size = self.order_size(link.left);
+        if rank <= left_size {
+            let left = self.order_insert_at(link.left, node, rank);
+            self.order_children(root, Some(left), link.right);
+        } else {
+            let right = self.order_insert_at(link.right, node, rank - left_size - 1);
+            self.order_children(root, link.left, Some(right));
+        }
+        self.order_balance(root)
+    }
+
+    fn order_remove_at(&mut self, root: Node, rank: usize) -> Option<Node> {
+        let link = self.order_link(root);
+        let left_size = self.order_size(link.left);
+        if rank < left_size {
+            let left = self.order_remove_at(link.left.unwrap(), rank);
+            self.order_children(root, left, link.right);
+        } else if rank > left_size {
+            let right = self.order_remove_at(link.right.unwrap(), rank - left_size - 1);
+            self.order_children(root, link.left, right);
+        } else {
+            let (Some(left), Some(right)) = (link.left, link.right) else {
+                let remaining = link.left.or(link.right);
+                self.order_parent(remaining, link.parent);
+                return remaining;
+            };
+            let mut successor = right;
+            while let Some(left) = self.order_link(successor).left {
+                successor = left;
+            }
+            let right = self.order_remove_at(right, 0);
+            self.order_parent(Some(successor), link.parent);
+            self.order_children(successor, Some(left), right);
+            return Some(self.order_balance(successor));
+        }
+        Some(self.order_balance(root))
+    }
+
+    pub(super) fn order_rank(&self, mut node: Node) -> Option<usize> {
+        if !self.links.contains_key(&node) {
+            return None;
+        }
+        let mut link = self.order_link(node);
+        let mut rank = self.order_size(link.left);
+        while let Some(parent) = link.parent {
+            let parent_link = self.order_link(parent);
+            if parent_link.right == Some(node) {
+                rank += 1 + self.order_size(parent_link.left);
+            }
+            node = parent;
+            link = parent_link;
+        }
+        Some(rank)
+    }
+
+    pub(super) fn order_insert(&mut self, node: Node, before: Option<Node>) {
+        let rank = before.map_or_else(
+            || self.order_size(self.order_root),
+            |before| {
+                self.order_rank(before)
+                    .expect("validated order anchor is a member")
+            },
+        );
+        self.order_root = Some(self.order_insert_at(self.order_root, node, rank));
+        self.order_parent(self.order_root, None);
+    }
+
+    pub(super) fn order_remove(&mut self, node: Node) {
+        let rank = self
+            .order_rank(node)
+            .expect("removed order node is a member");
+        self.order_root = self.order_remove_at(self.order_root.unwrap(), rank);
+        self.order_parent(self.order_root, None);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    std::thread_local! {
+        pub(super) static READS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    }
+
+    fn verify(members: &OrderedFamilyMembers, expected: &[Node]) {
+        fn walk(
+            members: &OrderedFamilyMembers,
+            id: Option<Node>,
+            parent: Option<Node>,
+            out: &mut Vec<Node>,
+        ) -> (usize, u16) {
+            let Some(id) = id else { return (0, 0) };
+            let link = members.order_link(id);
+            assert_eq!(link.parent, parent);
+            let (lc, lh) = walk(members, link.left, Some(id), out);
+            out.push(id);
+            let (rc, rh) = walk(members, link.right, Some(id), out);
+            assert!(lh.abs_diff(rh) <= 1);
+            assert_eq!(link.size, lc + rc + 1);
+            assert_eq!(link.height, lh.max(rh) + 1);
+            (link.size, link.height)
+        }
+        let mut ordered = Vec::new();
+        walk(members, members.order_root, None, &mut ordered);
+        assert_eq!(ordered, expected);
+        assert_eq!(members.iter().collect::<Vec<_>>(), expected);
+        for (index, id) in expected.iter().enumerate() {
+            assert_eq!(members.order_rank(*id), Some(index));
+        }
+    }
+
+    #[test]
+    fn family_order_index_matches_list_after_add_remove_reorder_and_generation_reuse() {
+        let mut members = OrderedFamilyMembers::default();
+        let mut expected = Vec::new();
+        let mut seed = 9181u64;
+        for step in 0..10_000 {
+            seed ^= seed << 13;
+            seed ^= seed >> 7;
+            seed ^= seed << 17;
+            let node = Node::new((seed % 96) as u32, (step / 2000) as u32);
+            match (seed >> 16) % 3 {
+                0 => {
+                    if members.push(node) {
+                        expected.push(node);
+                    }
+                }
+                1 => {
+                    members.remove(node);
+                    expected.retain(|id| *id != node);
+                }
+                _ if expected.contains(&node) => {
+                    let at = (seed as usize >> 24) % (expected.len() + 1);
+                    let anchor = expected.get(at).copied();
+                    members.move_before(node, anchor);
+                    if anchor != Some(node) {
+                        expected.retain(|id| *id != node);
+                        let at = anchor.map_or(expected.len(), |anchor| {
+                            expected.iter().position(|id| *id == anchor).unwrap()
+                        });
+                        expected.insert(at, node);
+                    }
+                }
+                _ => {}
+            }
+            verify(&members, &expected);
+        }
+        for node in expected.clone() {
+            assert!(members.remove(node));
+            expected.retain(|id| *id != node);
+            verify(&members, &expected);
+        }
+    }
+
+    #[test]
+    fn distant_family_member_comparison_and_edits_are_logarithmic() {
+        for count in [16, 65_536] {
+            let mut members = OrderedFamilyMembers::default();
+            for slot in 0..count {
+                members.push(Node::new(slot, 0));
+            }
+            let first = Node::new(0, 0);
+            let last = Node::new(count - 1, 0);
+            READS.with(|reads| reads.set(0));
+            assert_eq!(members.order_rank(first), Some(0));
+            assert_eq!(members.order_rank(last), Some(count as usize - 1));
+            let compare_reads = READS.with(|reads| reads.get());
+            assert!(compare_reads <= 4 * (count.ilog2() as usize + 1));
+            READS.with(|reads| reads.set(0));
+            members.move_before(last, Some(first));
+            let edit_reads = READS.with(|reads| reads.get());
+            assert!(edit_reads <= 50 * (count.ilog2() as usize + 1));
+            let mut expected = vec![last];
+            expected.extend((0..count - 1).map(|slot| Node::new(slot, 0)));
+            verify(&members, &expected);
+            println!("family size={count}: compare reads={compare_reads}, move reads={edit_reads}");
+        }
+    }
+
+    #[test]
+    fn rank_metadata_does_not_make_semantic_equality_depend_on_edit_history() {
+        let mut first = OrderedFamilyMembers::default();
+        let mut second = OrderedFamilyMembers::default();
+        let nodes = (0..40).map(|slot| Node::new(slot, 0)).collect::<Vec<_>>();
+        for &node in &nodes {
+            first.push(node);
+        }
+        for &node in nodes.iter().rev() {
+            second.push(node);
+        }
+        for &node in &nodes {
+            second.move_before(node, None);
+        }
+        verify(&first, &nodes);
+        verify(&second, &nodes);
+        assert_eq!(first, second);
+    }
+}

--- a/crates/noon/tests/root_order_alias_regressions.rs
+++ b/crates/noon/tests/root_order_alias_regressions.rs
@@ -1,0 +1,370 @@
+use noon::integration::{SemanticMutationTransaction, SemanticStore};
+use noon::{ExecutionSession, LiveSession};
+use noon_compile::semantic_execution_object_id;
+use noon_core::{SemanticNodeId, SemanticObjectState, StoredGeometry};
+use std::{cell::RefCell, rc::Rc};
+fn object(store: &mut SemanticStore) -> SemanticNodeId {
+    store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+        radius: 1.0,
+    }))
+}
+fn family(store: &mut SemanticStore, members: &[SemanticNodeId]) -> SemanticNodeId {
+    let family = store.insert_family();
+    for &member in members {
+        store.add_member(family, member).unwrap();
+    }
+    family
+}
+fn check(store: &SemanticStore, root: SemanticNodeId, session: &ExecutionSession) {
+    let actual = session
+        .painter_order()
+        .iter()
+        .map(|&row| session.frame().objects[row as usize].id)
+        .collect::<Vec<_>>();
+    let expected = store
+        .ordered_leaf_nodes(root)
+        .unwrap()
+        .into_iter()
+        .map(semantic_execution_object_id)
+        .collect::<Vec<_>>();
+    assert_eq!(actual, expected);
+}
+#[test]
+fn raw_cross_root_alias_reorder_matches_first_occurrence() {
+    let mut store = SemanticStore::new();
+    let [shared, a, b] = std::array::from_fn(|_| object(&mut store));
+    let left = family(&mut store, &[shared, a]);
+    let right = family(&mut store, &[shared, b]);
+    let root = family(&mut store, &[left, right]);
+    let mut session = ExecutionSession::from_semantic_root(&store, root).unwrap();
+    let owner = Rc::new(RefCell::new(store));
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction.reorder_member(root, left, None);
+    LiveSession::new(&owner, root, &mut session)
+        .apply(transaction)
+        .unwrap();
+    check(&owner.borrow(), root, &session);
+}
+#[test]
+fn raw_append_with_nested_alias_matches_first_occurrence() {
+    let mut store = SemanticStore::new();
+    let [anchor, shared, other] = std::array::from_fn(|_| object(&mut store));
+    let alias = family(&mut store, &[shared]);
+    let group = family(&mut store, &[shared, other, alias]);
+    let root = family(&mut store, &[anchor]);
+    let mut session = ExecutionSession::from_semantic_root(&store, root).unwrap();
+    let owner = Rc::new(RefCell::new(store));
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction.add_member(root, group);
+    LiveSession::new(&owner, root, &mut session)
+        .apply(transaction)
+        .unwrap();
+    check(&owner.borrow(), root, &session);
+}
+
+fn oracle(store: &SemanticStore, root: SemanticNodeId) -> Vec<noon_core::ObjectId> {
+    fn visit(
+        store: &SemanticStore,
+        node: SemanticNodeId,
+        seen: &mut std::collections::HashSet<SemanticNodeId>,
+        out: &mut Vec<noon_core::ObjectId>,
+    ) {
+        if !seen.insert(node) {
+            return;
+        }
+        let value = store.node(node).unwrap();
+        if matches!(value.kind(), noon_core::SemanticNodeKind::AuthoringObject) {
+            out.push(semantic_execution_object_id(node));
+        } else {
+            for member in value.members_iter() {
+                visit(store, member, seen, out);
+            }
+        }
+    }
+    let mut out = Vec::new();
+    visit(store, root, &mut std::collections::HashSet::new(), &mut out);
+    out
+}
+
+fn painter(session: &ExecutionSession) -> Vec<noon_core::ObjectId> {
+    session
+        .painter_order()
+        .iter()
+        .map(|&row| session.frame().objects[row as usize].id)
+        .collect()
+}
+
+fn permutation(index: usize) -> [usize; 5] {
+    let mut rank = index;
+    let mut pool = vec![0, 1, 2, 3, 4];
+    std::array::from_fn(|i| {
+        let block = (1..5 - i).product::<usize>();
+        let element = pool.remove(rank / block);
+        rank %= block;
+        element
+    })
+}
+
+#[test]
+fn all_cross_root_alias_positions_match_independent_reference() {
+    let mut checked = 0;
+    for arrangement in 0..120 {
+        for moved in 0..5 {
+            for before in 0..=5 {
+                let mut store = SemanticStore::new();
+                let [s, a, b, c] = std::array::from_fn(|_| object(&mut store));
+                let nested = family(&mut store, &[s, a]);
+                let left = family(&mut store, &[nested, b]);
+                let right = family(&mut store, &[b, s, c, nested]);
+                let empty = family(&mut store, &[]);
+                let members = [left, right, s, empty, c];
+                let ordered = permutation(arrangement).map(|i| members[i]);
+                let root = family(&mut store, &ordered);
+                let mut session = ExecutionSession::from_semantic_root(&store, root).unwrap();
+                let frame = session.frame().clone();
+                let slots = (0..frame.objects.len())
+                    .map(|row| session.execution_slot_for_frame_index(row))
+                    .collect::<Vec<_>>();
+                let owner = Rc::new(RefCell::new(store));
+                let mut tx = SemanticMutationTransaction::new();
+                tx.reorder_member(root, ordered[moved], ordered.get(before).copied());
+                LiveSession::new(&owner, root, &mut session)
+                    .apply(tx)
+                    .unwrap();
+                assert_eq!(
+                    painter(&session),
+                    oracle(&owner.borrow(), root),
+                    "arrangement={arrangement}, move={moved}, before={before}"
+                );
+                assert_eq!(session.frame(), &frame);
+                for (row, slot) in slots.into_iter().enumerate() {
+                    assert_eq!(session.execution_slot_for_frame_index(row), slot);
+                }
+                assert_eq!(session.last_patch_stats().full_seeks, 0);
+                assert_eq!(session.last_patch_stats().full_group_rebuilds, 0);
+                checked += 1;
+            }
+        }
+    }
+    assert_eq!(checked, 3600);
+    println!("independent-reference alias reorder arrangements: {checked}");
+}
+
+#[test]
+fn compound_alias_reorder_removal_and_readmission_preserve_net_order() {
+    for deleted_node in [false, true] {
+        let mut store = SemanticStore::new();
+        let [shared, a, b, c] = std::array::from_fn(|_| object(&mut store));
+        let left = family(&mut store, &[shared, a]);
+        let right = family(&mut store, &[b, shared]);
+        let third = family(&mut store, &[c, a]);
+        let root = family(&mut store, &[left, right, third]);
+        let mut session = ExecutionSession::from_semantic_root(&store, root).unwrap();
+        let runtime = session.runtime_identity();
+        let owner = Rc::new(RefCell::new(store));
+        let mut tx = SemanticMutationTransaction::new();
+        tx.reorder_member(root, third, Some(left));
+        tx.reorder_member(root, left, None);
+        LiveSession::new(&owner, root, &mut session)
+            .apply(tx)
+            .unwrap();
+        assert_eq!(painter(&session), oracle(&owner.borrow(), root));
+        let mut tx = SemanticMutationTransaction::new();
+        if deleted_node {
+            tx.remove_node(right);
+        } else {
+            tx.remove_member(root, right);
+        }
+        LiveSession::new(&owner, root, &mut session)
+            .apply(tx)
+            .unwrap();
+        assert_eq!(painter(&session), oracle(&owner.borrow(), root));
+        let mut tx = SemanticMutationTransaction::new();
+        tx.add_member(root, b);
+        tx.reorder_member(root, b, Some(left));
+        tx.reorder_member(root, left, Some(third));
+        LiveSession::new(&owner, root, &mut session)
+            .apply(tx)
+            .unwrap();
+        assert_eq!(painter(&session), oracle(&owner.borrow(), root));
+        assert_eq!(session.runtime_identity(), runtime);
+    }
+}
+
+#[test]
+fn alias_transfer_revisions_rejection_recovery_and_seek_are_coherent() {
+    use noon::{ExecutionSessionPublicationError, LiveSessionError};
+    use noon_core::{SemanticObjectProperty, SemanticVec3};
+    let mut store = SemanticStore::new();
+    let [shared, a, b] = std::array::from_fn(|_| object(&mut store));
+    let left = family(&mut store, &[shared, a]);
+    let right = family(&mut store, &[shared, b]);
+    let root = family(&mut store, &[left, right]);
+    let mut session = ExecutionSession::from_semantic_root(&store, root).unwrap();
+    session.take_frame_changes();
+    let owner = Rc::new(RefCell::new(store));
+    // Preserve already-pending renderer dirtiness through a rejected mixed batch.
+    let mut tx = SemanticMutationTransaction::new();
+    tx.set_property(
+        a,
+        SemanticObjectProperty::Translation,
+        SemanticVec3::new(3.0, 0.0, 0.0),
+    );
+    LiveSession::new(&owner, root, &mut session)
+        .apply(tx)
+        .unwrap();
+    let before = session.publication_context();
+    let frame = session.frame().clone();
+    let before_order = painter(&session);
+    let slot = session.execution_slot_for_frame_index(0);
+    let mut invalid = SemanticMutationTransaction::new();
+    invalid.reorder_member(root, left, None);
+    invalid.set_property(b, SemanticObjectProperty::RotationZ, f64::MAX);
+    assert!(matches!(
+        LiveSession::new(&owner, root, &mut session).apply(invalid),
+        Err(LiveSessionError::Publication(
+            ExecutionSessionPublicationError::Lowering(_)
+        ))
+    ));
+    assert_eq!(session.publication_context(), before);
+    assert_eq!(owner.borrow().scene_revision(), before.scene_revision());
+    assert_eq!(
+        owner.borrow().node(root).unwrap().members(),
+        vec![left, right]
+    );
+    assert_eq!(
+        owner
+            .borrow()
+            .node(root)
+            .unwrap()
+            .compare_members(left, right),
+        Some(std::cmp::Ordering::Less)
+    );
+    assert_eq!(session.frame(), &frame);
+    assert_eq!(painter(&session), before_order);
+    assert_eq!(session.execution_slot_for_frame_index(0), slot);
+    let changes = session.take_frame_changes();
+    assert_eq!(changes.object_indices(), &[1]);
+    assert!(!changes.has_painter_order_change());
+    let mut valid = SemanticMutationTransaction::new();
+    valid.reorder_member(root, left, None);
+    LiveSession::new(&owner, root, &mut session)
+        .apply(valid)
+        .unwrap();
+    let after = session.publication_context();
+    assert_eq!(
+        after.scene_revision(),
+        before.scene_revision().checked_next().unwrap()
+    );
+    assert_eq!(
+        after.execution_revision(),
+        before.execution_revision().checked_next().unwrap()
+    );
+    assert_eq!(
+        after.frame_epoch(),
+        before.frame_epoch().checked_next().unwrap()
+    );
+    assert_eq!(session.execution_slot_for_frame_index(0), slot);
+    assert_eq!(painter(&session), oracle(&owner.borrow(), root));
+    session.take_frame_changes();
+    let mut noop = SemanticMutationTransaction::new();
+    noop.reorder_member(root, left, None);
+    LiveSession::new(&owner, root, &mut session)
+        .apply(noop)
+        .unwrap();
+    assert_eq!(session.publication_context(), after);
+    assert!(session.take_frame_changes().is_empty());
+    for time in [1.0, 2.0, 0.0] {
+        session.seek(time).unwrap();
+        assert_eq!(painter(&session), oracle(&owner.borrow(), root));
+        assert_eq!(
+            session.publication_context().scene_revision(),
+            after.scene_revision()
+        );
+        assert_eq!(
+            session.publication_context().execution_revision(),
+            after.execution_revision()
+        );
+    }
+}
+
+#[test]
+fn identical_alias_blocks_reorder_authored_only() {
+    let mut store = SemanticStore::new();
+    let [s, a] = std::array::from_fn(|_| object(&mut store));
+    let left = family(&mut store, &[s, a]);
+    let right = family(&mut store, &[s, a]);
+    let root = family(&mut store, &[left, right]);
+    let mut session = ExecutionSession::from_semantic_root(&store, root).unwrap();
+    session.take_frame_changes();
+    let before = session.publication_context();
+    let owner = Rc::new(RefCell::new(store));
+    let mut tx = SemanticMutationTransaction::new();
+    tx.reorder_member(root, left, None);
+    LiveSession::new(&owner, root, &mut session)
+        .apply(tx)
+        .unwrap();
+    let after = session.publication_context();
+    assert_eq!(
+        after.scene_revision(),
+        before.scene_revision().checked_next().unwrap()
+    );
+    assert_eq!(
+        after.frame_epoch(),
+        before.frame_epoch().checked_next().unwrap()
+    );
+    assert_eq!(after.execution_revision(), before.execution_revision());
+    assert!(session.take_frame_changes().is_empty());
+}
+
+#[test]
+fn repeated_alias_membership_edits_match_reference_after_every_publication() {
+    let mut store = SemanticStore::new();
+    let objects: [SemanticNodeId; 6] = std::array::from_fn(|_| object(&mut store));
+    let first = family(&mut store, &[objects[0], objects[1], objects[2]]);
+    let second = family(&mut store, &[objects[2], objects[0], objects[3]]);
+    let nested = family(&mut store, &[first, objects[4], second]);
+    let last = family(&mut store, &[objects[5], first]);
+    let empty = family(&mut store, &[]);
+    let candidates = [
+        first, second, nested, last, empty, objects[0], objects[1], objects[5],
+    ];
+    let root = family(&mut store, &[first, second, last]);
+    let mut session = ExecutionSession::from_semantic_root(&store, root).unwrap();
+    let owner = Rc::new(RefCell::new(store));
+    let mut seed = 981827u64;
+    for step in 0..4000 {
+        seed ^= seed << 13;
+        seed ^= seed >> 7;
+        seed ^= seed << 17;
+        let target = candidates[(seed as usize >> 8) % candidates.len()];
+        let mut tx = SemanticMutationTransaction::new();
+        let members = owner.borrow().node(root).unwrap().members();
+        match seed % 3 {
+            0 => {
+                tx.add_member(root, target);
+            }
+            1 => {
+                tx.remove_member(root, target);
+            }
+            _ if members.contains(&target) => {
+                let anchor = members
+                    .get((seed >> 32) as usize % (members.len() + 1))
+                    .copied();
+                tx.reorder_member(root, target, anchor);
+            }
+            _ => {
+                tx.add_member(root, target);
+            }
+        }
+        LiveSession::new(&owner, root, &mut session)
+            .apply(tx)
+            .unwrap();
+        assert_eq!(
+            painter(&session),
+            oracle(&owner.borrow(), root),
+            "step={step}"
+        );
+        session.take_frame_changes();
+    }
+}


### PR DESCRIPTION
## Scope and verdict

Follow-up to merged #1340, resolving its last reproduced **cross-root-family alias-order failure** under **#1292 R4 / #957 / #969**. Reuses the existing #1305 compiler extraction; no second lowerer or general `ExecutionSession` rewrite.

Root `[left(shared,A), right(shared,B)]`, followed by moving `left` to the tail, previously succeeded with painter order `[B,shared,A]` instead of authored first-occurrence order `[shared,B,A]`. The new preparation transfers the shared leaf to its correct first owner. The exact failure is reproduced on unchanged current-base production before the correction is applied.

Four source files change: existing `semantic_store.rs`, its new responsibility-owned `family_member_order.rs` child, existing compiler `root_order.rs`, and one new external regression file. No session production, Python/WASM mapper, provider/package/workflow, identity allocator, error framework, scene codec or new patch vocabulary changes. Qualification helpers are outside the product diff.

## Exact revisions and coordination

- #1340 merged during this continuation as `71d8bfac1094e8232ae7f4b89872af2a1baff9db`; its head `a74343c97039e2322a23bb45582f49c829843aeb` is retained in master, not rewritten.
- Rechecked and qualified base: **`0eca24ef7c74478d0810332179a9197f19a1c39c`**.
- Product head: **`44beac791b8d4bdb246012a5b0aca5d45511f9c6`**.
- Product tree: **`583936ab7d4def59d205cc797cb5c42b131145bf`**, exactly matching the hosted qualified staged tree.

Read AGENTS.md, architecture, #1292 and #1305/#1340 handoffs. [Continuation claim](https://github.com/yongkyuns/noon/issues/1292#issuecomment-5603177168) and [necessary core-index coordination](https://github.com/yongkyuns/noon/issues/1292#issuecomment-5603272765) preceded edits. Concurrent R2/R3/R5/R6 and CI changes are preserved; all four modified paths are disjoint from the intervening master changes.

## Implementation and explicit tradeoff

The linked family list lacked local order comparison. Walking root prefixes or distant alias spans would violate locality; the existing shared membership planner also documents this missing primitive. The fix adds derived AVL rank metadata in the **existing per-member links**, not another membership map or scene representation. The list remains authoritative; equality ignores index shape. No semantic values or new identities enter the index.

**Cost changes deliberately:** identity and neighbor lookup remain O(1), but family edits now maintain rank metadata in O(log family size), with increased per-edge memory. This is not a claim of unchanged success-path cost or a universal performance improvement. The logarithmic comparison/maintenance bounds are tested separately from compiler semantic-node reads.

Compiler preparation derives final staged family links and reverse-edge overrides only for transaction-touched relationships. Memoized first-occurrence paths share prefixes; affected leaves are sorted by canonical path and placed before their final successor. Later aliases of whole families are skipped without retraversing descendants. Staged moved-run positions are cached rather than rewalked during every comparison. Removed families retain only their affected old descendant closure for surviving alias transfer. Existing prepared allocator identities, typed errors and `ReorderObject` patches remain the publication boundary.

Only the existing compiler function generates these patches. `ExecutionSession` continues its unchanged preflight/commit coordination; all this preparation precedes semantic publication.

## Acceptance → evidence

| #1292 R4 criterion | Evidence / qualification boundary |
|---|---|
| One compiler owner | Existing `prepare_semantic_root_order` remains sole lowerer; private temporary overlay/path state only. No session traversal/production change. Architecture and dependency guards pass. |
| Membership / nested / alias painter order | Both original raw probes now pass. New external suite checks **3,600 deterministic root arrangements** against an independent DFS oracle and **4,000 sequential membership publications**, plus compound reorder/removal/readmission. Prior empty/provisional/shared-planner regressions remain. Pure reorder preserves frame rows and durable slots. |
| Atomic rejection and recovery | Mixed invalid value plus alias reorder rejects with existing typed lowering category; preserves authored order and rank, revision context, effective frame, slot and previously pending dirty output. Valid retry succeeds. Existing stale-root/provisional-allocation/pending/resource/slot/spatial tests rerun. No new GPU-failure injection claim. |
| Revision behavior / seek | Observable transfer advances S/E/F once; identical alias blocks advance S/F without E; exact no-op/rejection advance none. Forward/backward seeks preserve accepted order and S/E. |
| Locality | **17 semantic-node reads with 0 or 80,000 extra objects** across root prefix/gap, detached alias family and unused owner tail. Family sizes 16/65,536 need **12/48 rank-comparison reads** and **74/326 move-maintenance reads**, bounded logarithmically. Batch positions test covers 16/1,024 members without repeated run walks. |
| Native / direct WASM | **22 external tests**, **8 focused compiler tests**, **3 rank-index tests** pass. All **7 new Rust test bodies execute in an import-free WASM module**, including 3,600 arrangements and 4,000 publications. Node supplies only bootstrap and receives a completion scalar; no scene/runtime state crosses JS. This is actual WASM execution, not browser rendering or Python parity. |
| Paired frontend / normal product gates | Existing shared authoring/browser/product workflows qualify the public paths. New raw root reorder is a Rust integration-level operation, not a newly exposed Python API. Current PR results must be read separately; historical #1340 passes do not qualify this patch. |

The rank-index regression checks **10,000 edits** against authoritative links and a reference vector, asserting every rank, parent pointer, subtree count and AVL balance, plus teardown and generation-distinct identities. A separate test ensures index shape does not change semantic equality.

### Do not reuse old locality counts

The previous empty-anchor fixture now needs **12 rather than 5 node reads**, still independent of 60,000 extra objects; the new algorithm resolves reverse ownership the previous one omitted. The 12-level diamond cases now measure **246 / 177 reads**, one patch, with a linear fixture bound. These higher constants are explicit, not hidden behind old measurements. Path comparisons can walk ancestor depth, and sorting is affected-leaf work; no universal allocation-byte, arbitrary-depth or whole-pipeline performance bound is claimed.

## Executed hosted qualification

**[Run 34365895437](https://github.com/yongkyuns/noon/actions/runs/34365895437), job `102514390487`, attempt 1: all steps passed.** Isolated workflow revision `c0433811e78df2e8434e0a39d51fbbaaabdb22d7` checked out the exact base, reproduced the baseline failure, then staged exactly these four hashed files. Its `git write-tree` equals the product commit tree above. The workflow retains blobs but does not change remote branches/refs.

Rust/Cargo **1.98.0**; Node **22.23.2** for hosted direct-WASM execution.

```sh
# Unchanged base; expected result: nested append passes, cross-root reorder fails.
cargo test -p noon --no-default-features --test root_order_alias_baseline -- --nocapture

# Corrected source, subsequently committed with identical full tree:
cargo fmt --all -- --check
cargo test -p noon-core --no-default-features --lib family_member_order -- --nocapture
cargo test -p noon-compile --no-default-features --lib root_order -- --nocapture
cargo test -p noon --no-default-features \
  --test root_order_acceptance --test root_order_transaction_regressions \
  --test root_order_alias_regressions --no-fail-fast -- --nocapture
bash scripts/check.sh fast 0eca24ef7c74478d0810332179a9197f19a1c39c
cargo check -p noon-web --all-features --target wasm32-unknown-unknown
# Temporary cdylib outside product tree: exact seven test bodies, only #[test]
# annotations removed and a scalar completion export appended; instantiate in Node.
```

| Check | Actual result |
|---|---|
| Unmodified baseline | **1 passed / 1 failed**, expected cross-root assertion, not a compilation failure |
| Corrected external tests | **22 passed**, no failures/ignores |
| Focused compiler / rank-index tests | **8 + 3 passed**; overlap the library suite below |
| Full workspace library gate | **1,407 passed / 3 pre-existing ignored** |
| Architecture / formatting / all-target all-feature check / strict Clippy | **Passed** |
| noon-web direct WASM check | **Passed**, compile-only |
| Seven Rust regressions executed as WASM | **Passed**, zero JS imports, 3,600 arrangements + 4,000 publications |

Artifact **10110023744**, `r4-cross-root-qualification`, retains source, patches, exact base/tree, hashes, Cargo.lock and logs. ZIP SHA-256 **`43d0ce890d78028f2434da187e9d0f35454bbe290b9c5ee0b8d3405d0f4c539c`** was independently verified after download. All four source bytes match local tested files and the final Git blobs:

- core: `fae4b8f49ed4d3a4cd1116bc14855a35e3d7cbcd`
- rank metadata: `d278f071a5e434d78da615761d88082a9ed82172`
- compiler: `ca9c8626646345a9a2d001997ff8687590694744`
- external tests: `62e2455e66d11734d53a5aaadf71d7e199445554`

Hosted executed WASM SHA-256: `5b5ed0513802c9626647a91aa4ac2d830461ae9ebef672b46c7f7b14498bc1b0`. No font, compiler, registry or browser-package artifact is part of this PR.

## Local evidence and limits

Local red/green first reproduced the original cross-root failure on the previous production source. The expanded baseline with the new rank prerequisite but old compiler had 2 passes / 4 failures; it is not mislabeled unchanged production. Corrected seven tests pass locally and in direct WASM, including a portable 32-bit high-bit selection in the churn fixture. That test portability refinement is not an engine defect.

Local fast passed 1,405 library tests on the earlier reconstructed source snapshot. It is supplementary, not a substitute for the complete 1,407-test current-base hosted combination. Source hashes and `git diff --check` passed locally.

This resolves the last counterexample recorded by #1340, not every arbitrary mixed structural transaction or all Phase A/R4 acceptance. Independent review of AVL/list consistency, canonical occurrence/successor handling and the explicit cost tradeoff remains necessary, as do normal current-PR browser/product gates. No full local browser gate, GPU failure injection, allocation-byte benchmark, independent approval, merge/auto-merge or closure of the six-case #1292 issue is claimed.