### PR TITLE
feat: prepare callback family paint atomically in shared Rust

### DIFF
--- a/crates/noon-web/src/authoring_error.rs
+++ b/crates/noon-web/src/authoring_error.rs
@@ -74,6 +74,23 @@ impl Error for AuthoringFailure {
         self.cause.as_deref().map(|cause| cause as &dyn Error)
     }
 }
+impl From<noon::FamilyCallbackPaintError> for AuthoringFailure {
+    fn from(error: noon::FamilyCallbackPaintError) -> Self {
+        use noon::FamilyCallbackPaintError::*;
+        match error {
+            Authoring(e) => Self::from(e),
+            Store(e) => Self::from(e),
+            Callback(e) => Self::unclassified("callback.family.read", &e),
+            StaleRevision { .. } => {
+                Self::new("stale_handle", "callback.family.stale_revision", error)
+            }
+            InvalidPaint(message) => {
+                Self::new("invalid_input", "callback.family.invalid_paint", message)
+            }
+        }
+    }
+}
+
 impl From<String> for AuthoringFailure {
     fn from(message: String) -> Self {
         Self::new("unclassified", "unclassified", message)

--- a/crates/noon-web/src/canonical_authoring_scene.rs
+++ b/crates/noon-web/src/canonical_authoring_scene.rs
@@ -4157,7 +4157,9 @@ mod wasm {
                 serde_json::from_str(styles_json).map_err(js_error)?;
             let styles: BTreeMap<_, _> = rows
                 .into_iter()
-                .map(|(slot, generation, style)| (SemanticNodeId::new(slot, generation), style))
+                .map(|(slot, generation, style)| {
+                    (noon_core::SemanticNodeId::new(slot, generation), style)
+                })
                 .collect();
             let changes = family
                 .prepare_callback_paint(revision, operation, |node| {

--- a/crates/noon-web/src/canonical_authoring_scene.rs
+++ b/crates/noon-web/src/canonical_authoring_scene.rs
@@ -4085,6 +4085,95 @@ mod wasm {
             Ok(WasmCallbackTransform { transform })
         }
 
+        /// Resolve a typed family only in this authoring store before a pinned read.
+        #[wasm_bindgen(js_name = callbackFamilyKeys)]
+        pub fn callback_family_keys(
+            &self,
+            handle: &crate::WasmAuthoringFamilyHandle,
+            revision: &str,
+        ) -> Result<Vec<String>, JsValue> {
+            let family = handle.semantic_family()?;
+            if !std::rc::Rc::ptr_eq(
+                self.inner.scene.integration_store(),
+                family.integration_store(),
+            ) {
+                return Err(typed_js_error(noon::AuthoringError::ForeignStore));
+            }
+            let revision =
+                noon_core::SceneRevision::new(revision.parse::<u64>().map_err(js_error)?);
+            family
+                .callback_leaf_nodes(revision)
+                .map(|nodes| {
+                    nodes
+                        .into_iter()
+                        .map(|node| format!("{}:{}", node.slot(), node.generation()))
+                        .collect()
+                })
+                .map_err(typed_js_error)
+        }
+
+        /// One callback-boundary projection of an already prepared effective operation.
+        /// Input rows are the pinned read cache plus preceding ordered overlay writes.
+        #[wasm_bindgen(js_name = callbackFamilyPaint)]
+        #[allow(clippy::too_many_arguments)]
+        pub fn callback_family_paint(
+            &self,
+            handle: &crate::WasmAuthoringFamilyHandle,
+            revision: &str,
+            operation: &str,
+            styles_json: &str,
+            has_color: bool,
+            red: f64,
+            green: f64,
+            blue: f64,
+            alpha: f64,
+            width: Option<f64>,
+            opacity: Option<f64>,
+        ) -> Result<String, JsValue> {
+            self.callback_family_keys(handle, revision)?;
+            let family = handle.semantic_family()?;
+            let color = crate::authoring_mobject::family_color(has_color, red, green, blue, alpha)
+                .map_err(js_error)?;
+            let operation = match operation {
+                "Color" => noon::FamilyPaint::Color(
+                    color.ok_or_else(|| js_error("family color is required"))?,
+                ),
+                "Fill" => noon::FamilyPaint::Fill { color, opacity },
+                "Stroke" => noon::FamilyPaint::Stroke {
+                    color,
+                    width,
+                    opacity,
+                },
+                "Opacity" => noon::FamilyPaint::Opacity(
+                    opacity.ok_or_else(|| js_error("family opacity is required"))?,
+                ),
+                _ => return Err(js_error("unknown family paint operation")),
+            };
+            let revision =
+                noon_core::SceneRevision::new(revision.parse::<u64>().map_err(js_error)?);
+            // This is the existing Python callback view/overlay codec boundary,
+            // never an authored scene or a native/direct-WASM engine boundary.
+            let rows: Vec<(u32, u32, Style)> =
+                serde_json::from_str(styles_json).map_err(js_error)?;
+            let styles: BTreeMap<_, _> = rows
+                .into_iter()
+                .map(|(slot, generation, style)| (SemanticNodeId::new(slot, generation), style))
+                .collect();
+            let changes = family
+                .prepare_callback_paint(revision, operation, |node| {
+                    styles
+                        .get(&node)
+                        .copied()
+                        .ok_or(noon::ExecutionSessionCallbackError::UnknownObject(node))
+                })
+                .map_err(typed_js_error)?;
+            let rows: Vec<_> = changes
+                .into_iter()
+                .map(|(node, style)| (node.slot(), node.generation(), style))
+                .collect();
+            serde_json::to_string(&rows).map_err(js_error)
+        }
+
         /// Apply shared Manim `set_color` semantics to callback-local paint.
         #[wasm_bindgen(js_name = callbackPaintSetColor)]
         #[allow(clippy::too_many_arguments)]

--- a/crates/noon-web/src/semantic_execution_player.rs
+++ b/crates/noon-web/src/semantic_execution_player.rs
@@ -1912,22 +1912,21 @@ struct CallbackPhaseTokenEnvelope {
 enum CallbackReadRequestWire {
     ScalarSignal { node: CallbackNodeWire },
     Object { node: CallbackNodeWire },
-}
-
-impl From<CallbackReadRequestWire> for CallbackReadRequest {
-    fn from(value: CallbackReadRequestWire) -> Self {
-        match value {
-            CallbackReadRequestWire::ScalarSignal { node } => Self::ScalarSignal(node.into()),
-            CallbackReadRequestWire::Object { node } => Self::Object(node.into()),
-        }
-    }
+    Family { node: CallbackNodeWire },
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 enum CallbackReadValueWire {
-    Scalar { value: f32 },
-    Object { object: CallbackPhaseObjectWire },
+    Scalar {
+        value: f32,
+    },
+    Object {
+        object: CallbackPhaseObjectWire,
+    },
+    Family {
+        objects: Vec<CallbackPhaseObjectWire>,
+    },
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize)]
@@ -2252,11 +2251,43 @@ impl SemanticExecutionPlayer {
             .map_err(|error| format!("invalid callback read request JSON: {error}"))?;
         let requested_object = match &request_wire {
             CallbackReadRequestWire::Object { node } => Some(node.clone()),
-            CallbackReadRequestWire::ScalarSignal { .. } => None,
+            CallbackReadRequestWire::ScalarSignal { .. }
+            | CallbackReadRequestWire::Family { .. } => None,
+        };
+        let request = match request_wire {
+            CallbackReadRequestWire::Family { node } => {
+                let store = self
+                    .semantics
+                    .as_ref()
+                    .ok_or("family callback reads require a live semantic store")?;
+                let rows = self
+                    .session
+                    .required_callback_family_read(&store.borrow(), token, node.into())
+                    .map_err(|error| error.to_string())?;
+                let objects = rows
+                    .into_iter()
+                    .map(|(node, properties)| CallbackPhaseObjectWire {
+                        node: node.into(),
+                        transform: properties.transform,
+                        style: properties.style,
+                        appearance: properties.appearance,
+                        presence: properties.presence,
+                        reveal: properties.reveal,
+                        morph: properties.morph,
+                        bounds: properties.bounds,
+                    })
+                    .collect();
+                return serde_json::to_string(&CallbackReadValueWire::Family { objects })
+                    .map_err(|error| error.to_string());
+            }
+            CallbackReadRequestWire::Object { node } => CallbackReadRequest::Object(node.into()),
+            CallbackReadRequestWire::ScalarSignal { node } => {
+                CallbackReadRequest::ScalarSignal(node.into())
+            }
         };
         let value = self
             .session
-            .required_callback_read(token, request_wire.into())
+            .required_callback_read(token, request)
             .map_err(|error| error.to_string())?;
         let wire = match value {
             CallbackReadValue::Scalar(value) => CallbackReadValueWire::Scalar { value },

--- a/crates/noon-web/src/semantic_execution_player.rs
+++ b/crates/noon-web/src/semantic_execution_player.rs
@@ -1,12 +1,12 @@
 //! Transport adapter for an already-lowered semantic session; never parses authoring JSON.
 #[cfg(any(target_arch = "wasm32", test))]
 use crate::authoring_error::AuthoringFailure;
-#[cfg(any(target_arch = "wasm32", test))]
-use noon::integration::TimelineWakeState;
 use noon::integration::{
-    CallbackAdvance, CallbackPhaseToken, CallbackReadRequest, CallbackReadValue,
-    EffectivePropertyBatch, EffectiveSemanticPropertyWrite, RuntimeIdentity,
+    CallbackAdvance, CallbackPhaseToken, EffectivePropertyBatch, EffectiveSemanticPropertyWrite,
+    RuntimeIdentity,
 };
+#[cfg(any(target_arch = "wasm32", test))]
+use noon::integration::{CallbackReadRequest, CallbackReadValue, TimelineWakeState};
 use noon::ExecutionSession;
 use noon_core::{
     ExecutionRevision, FrameEpoch, PublicationContext, Rect, SceneRevision, SemanticNodeId, Style,
@@ -1907,6 +1907,7 @@ struct CallbackPhaseTokenEnvelope {
     token: CallbackTokenWire,
 }
 
+#[cfg(any(target_arch = "wasm32", test))]
 #[derive(Clone, Debug, PartialEq, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 enum CallbackReadRequestWire {
@@ -1915,6 +1916,7 @@ enum CallbackReadRequestWire {
     Family { node: CallbackNodeWire },
 }
 
+#[cfg(any(target_arch = "wasm32", test))]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 enum CallbackReadValueWire {
@@ -2237,6 +2239,7 @@ impl SemanticExecutionPlayer {
     /// Read one typed value from the exact pending callback phase without
     /// committing it. This is the real Python-worker boundary; direct Rust
     /// callbacks call the session API without JSON.
+    #[cfg(any(target_arch = "wasm32", test))]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen(js_name = requiredCallbackReadJson))]
     pub fn required_callback_read_json(
         &mut self,

--- a/crates/noon-web/src/semantic_execution_player.rs
+++ b/crates/noon-web/src/semantic_execution_player.rs
@@ -2108,6 +2108,7 @@ impl SemanticExecutionPlayer {
         }
     }
 
+    #[cfg(any(target_arch = "wasm32", test))]
     fn callback_token_from_json(token_json: &str) -> Result<CallbackPhaseToken, String> {
         let token: CallbackTokenWire = serde_json::from_str(token_json)
             .map_err(|error| format!("invalid callback token JSON: {error}"))?;

--- a/crates/noon/src/example_scenes.rs
+++ b/crates/noon/src/example_scenes.rs
@@ -273,6 +273,8 @@ pub fn live_callback_paint() -> Result<(ExecutionSession, RustHostCallbackTable)
     assert_eq!(source.stroke_opacity()?, 0.75);
     scene.add(&source).map_err(|error| error.to_string())?;
 
+    let nested = scene.family(&[(&source).into()])?;
+    let family = scene.family(&[(&nested).into(), (&source).into()])?;
     let mut target = source.target_editor()?;
     target.set_translation(2.0, 0.0)?;
     let animation = scene.declare_transform_to(
@@ -292,7 +294,7 @@ pub fn live_callback_paint() -> Result<(ExecutionSession, RustHostCallbackTable)
             .set_target_style(style)
             .map_err(|error| std::io::Error::other(error.to_string()))
     })?;
-    callbacks.insert(FILL_AND_COMPOSITE_OPACITY, |context| {
+    callbacks.insert(FILL_AND_COMPOSITE_OPACITY, move |context| {
         let before = context.target_state().style;
         let expected_fill_alpha = if context.time() == 0.0 { 0.25 } else { 0.4 };
         if before.fill.map(|color| color.alpha) != Some(expected_fill_alpha)
@@ -302,9 +304,16 @@ pub fn live_callback_paint() -> Result<(ExecutionSession, RustHostCallbackTable)
                 "ordered paint callback did not observe preserved layer alpha",
             ));
         }
-        let mut style = context
-            .target_style_with_fill_opacity(0.4)
+        context
+            .paint_family(
+                &family,
+                crate::FamilyPaint::Fill {
+                    color: None,
+                    opacity: Some(0.4),
+                },
+            )
             .map_err(std::io::Error::other)?;
+        let mut style = context.target_state().style;
         style.opacity = 0.5;
         context
             .set_target_style(style)
@@ -1336,6 +1345,10 @@ pub fn ordinary_callback_sparse_reads_program() -> Result<
         .value_tracker(0.0)
         .map_err(|error| error.to_string())?;
 
+    let nested = scene.family(&[(&circle).into(), (&anchor).into()])?;
+    let family = scene.family(&[(&nested).into(), (&circle).into()])?;
+    let missing = scene.circle(0.1)?;
+    let invalid_family = scene.family(&[(&circle).into(), (&missing).into()])?;
     let tracker_id = tracker.node_id();
     let anchor_id = anchor.node_id();
     let mut observed_phase_times = Vec::new();
@@ -1349,6 +1362,32 @@ pub fn ordinary_callback_sparse_reads_program() -> Result<
                 )));
             }
             observed_phase_times.push(context.time());
+            context
+                .paint_family(
+                    &family,
+                    crate::FamilyPaint::Fill {
+                        color: None,
+                        opacity: Some(0.6),
+                    },
+                )
+                .map_err(|error| SparseReadExampleError(error.to_string()))?;
+            context
+                .paint_family(
+                    &family,
+                    crate::FamilyPaint::Color(Color::rgba(0.0, 0.4, 1.0, 0.9)),
+                )
+                .map_err(|error| SparseReadExampleError(error.to_string()))?;
+            assert!((context.target_state().style.fill.unwrap().alpha - 0.6).abs() < 1e-6);
+            assert!(context
+                .paint_family(
+                    &invalid_family,
+                    crate::FamilyPaint::Fill {
+                        color: None,
+                        opacity: Some(0.1)
+                    }
+                )
+                .is_err());
+            assert!((context.target_state().style.fill.unwrap().alpha - 0.6).abs() < 1e-6);
             let scalar = context
                 .scalar_signal(tracker_id)
                 .map_err(|error| SparseReadExampleError(error.to_string()))?;

--- a/crates/noon/src/execution_session/callback.rs
+++ b/crates/noon/src/execution_session/callback.rs
@@ -686,6 +686,52 @@ impl PendingCallbackPhase {
 impl ExecutionSession {
     /// Read through the exact unpublished evaluation pinned by `token`.
     /// This does not advance, commit, or mutate callback/runtime state.
+    /// Read unique family leaves through the existing pinned object read path.
+    pub fn required_callback_family_read(
+        &self,
+        store: &noon_core::SemanticStore,
+        token: CallbackPhaseToken,
+        family: SemanticNodeId,
+    ) -> Result<Vec<(SemanticNodeId, EffectiveObjectProperties)>, crate::FamilyCallbackPaintError>
+    {
+        use crate::FamilyCallbackPaintError as Error;
+        let pending = self.pending_callback.as_ref().ok_or(Error::Callback(
+            ExecutionSessionCallbackError::NoPendingPhase,
+        ))?;
+        if pending.token != token {
+            return Err(Error::Callback(ExecutionSessionCallbackError::StaleToken {
+                expected: pending.token,
+                actual: token,
+            }));
+        }
+        if store.identity() != self.store_identity {
+            return Err(Error::Authoring(crate::AuthoringError::ForeignStore));
+        }
+        if store.scene_revision() != token.publication().scene_revision() {
+            return Err(Error::StaleRevision {
+                expected: token.publication().scene_revision(),
+                actual: store.scene_revision(),
+            });
+        }
+        store
+            .semantic_family_checked(family)
+            .map_err(|e| Error::Authoring(e.into()))?;
+        store
+            .ordered_leaf_nodes(family)
+            .map_err(Error::Store)?
+            .into_iter()
+            .map(|node| {
+                match self
+                    .required_callback_read(token, CallbackReadRequest::Object(node))
+                    .map_err(|e| Error::Callback(e.into()))?
+                {
+                    CallbackReadValue::Object(properties) => Ok((node, properties)),
+                    CallbackReadValue::Scalar(_) => unreachable!("object request returns object"),
+                }
+            })
+            .collect()
+    }
+
     pub fn required_callback_read(
         &self,
         token: CallbackPhaseToken,

--- a/crates/noon/src/family_callback_paint.rs
+++ b/crates/noon/src/family_callback_paint.rs
@@ -1,0 +1,130 @@
+//! Atomic family paint preparation over a revision-pinned effective read view.
+use crate::{
+    AuthoringError, Color, ExecutionSessionCallbackError, MobjectFamily, SemanticNodeId, Style,
+};
+use noon_core::SceneRevision;
+
+/// The same paint semantics used by authored families and callback driver writes.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum FamilyPaint {
+    Color(Color),
+    Fill {
+        color: Option<Color>,
+        opacity: Option<f64>,
+    },
+    Stroke {
+        color: Option<Color>,
+        width: Option<f64>,
+        opacity: Option<f64>,
+    },
+    Opacity(f64),
+}
+
+impl FamilyPaint {
+    fn apply(self, style: &mut Style) -> Result<(), String> {
+        match self {
+            Self::Color(c) => crate::semantic_mobject::edit_color(
+                style,
+                c.red.into(),
+                c.green.into(),
+                c.blue.into(),
+                c.alpha.into(),
+            ),
+            Self::Fill { color, opacity } => crate::family_style::fill(style, color, opacity),
+            Self::Stroke {
+                color,
+                width,
+                opacity,
+            } => crate::family_style::stroke(style, color, width, opacity),
+            Self::Opacity(value) => crate::semantic_mobject::edit_manim_opacity(style, value),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum FamilyCallbackPaintError {
+    Authoring(AuthoringError),
+    Store(noon_core::SemanticStoreError),
+    Callback(ExecutionSessionCallbackError),
+    StaleRevision {
+        expected: SceneRevision,
+        actual: SceneRevision,
+    },
+    InvalidPaint(String),
+}
+
+impl std::fmt::Display for FamilyCallbackPaintError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Authoring(e) => e.fmt(f),
+            Self::Store(e) => e.fmt(f),
+            Self::Callback(e) => e.fmt(f),
+            Self::StaleRevision { expected, actual } => write!(
+                f,
+                "family callback expected scene revision {}, found {}",
+                expected.get(),
+                actual.get()
+            ),
+            Self::InvalidPaint(e) => f.write_str(e),
+        }
+    }
+}
+impl std::error::Error for FamilyCallbackPaintError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Authoring(e) => Some(e),
+            Self::Store(e) => Some(e),
+            Self::Callback(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl MobjectFamily {
+    /// Resolve the affected family only while its authored membership matches the phase.
+    pub fn callback_leaf_nodes(
+        &self,
+        revision: SceneRevision,
+    ) -> Result<Vec<SemanticNodeId>, FamilyCallbackPaintError> {
+        self.validate()
+            .map_err(FamilyCallbackPaintError::Authoring)?;
+        let store = self.integration_store().borrow();
+        if store.scene_revision() != revision {
+            return Err(FamilyCallbackPaintError::StaleRevision {
+                expected: revision,
+                actual: store.scene_revision(),
+            });
+        }
+        store
+            .ordered_leaf_nodes(self.node_id())
+            .map_err(FamilyCallbackPaintError::Store)
+    }
+
+    /// Prepare one complete effective operation without mutating the store or read view.
+    /// The read callback must observe the exact phase, including preceding overlay writes.
+    /// Returned changes use unique semantic leaves in first-occurrence order. A failed
+    /// final read or paint edit returns no changes; work is proportional to this family.
+    pub fn prepare_callback_paint(
+        &self,
+        revision: SceneRevision,
+        operation: FamilyPaint,
+        mut read: impl FnMut(SemanticNodeId) -> Result<Style, ExecutionSessionCallbackError>,
+    ) -> Result<Vec<(SemanticNodeId, Style)>, FamilyCallbackPaintError> {
+        let leaves = self.callback_leaf_nodes(revision)?;
+        operation
+            .apply(&mut Style::default())
+            .map_err(FamilyCallbackPaintError::InvalidPaint)?;
+        let mut changes = Vec::with_capacity(leaves.len());
+        for node in leaves {
+            let previous = read(node).map_err(FamilyCallbackPaintError::Callback)?;
+            let mut next = previous;
+            operation
+                .apply(&mut next)
+                .map_err(FamilyCallbackPaintError::InvalidPaint)?;
+            if next != previous {
+                changes.push((node, next));
+            }
+        }
+        Ok(changes)
+    }
+}

--- a/crates/noon/src/family_style.rs
+++ b/crates/noon/src/family_style.rs
@@ -3,13 +3,14 @@ use crate::{
     semantic_mobject::{
         edit_color, edit_disable_fill, edit_disable_stroke, edit_fill_color, edit_fill_opacity,
         edit_manim_opacity, edit_stroke_color, edit_stroke_opacity, edit_stroke_width,
+        PaintStyleEdit,
     },
     Color, MobjectFamily,
 };
 use noon_core::{SemanticMutationTransaction, SemanticStyle};
 
-pub(crate) fn fill(
-    style: &mut SemanticStyle,
+pub(crate) fn fill<S: PaintStyleEdit>(
+    style: &mut S,
     color: Option<Color>,
     opacity: Option<f64>,
 ) -> Result<(), String> {
@@ -30,8 +31,8 @@ pub(crate) fn fill(
     Ok(())
 }
 
-pub(crate) fn stroke(
-    style: &mut SemanticStyle,
+pub(crate) fn stroke<S: PaintStyleEdit>(
+    style: &mut S,
     color: Option<Color>,
     width: Option<f64>,
     opacity: Option<f64>,

--- a/crates/noon/src/host_callbacks.rs
+++ b/crates/noon/src/host_callbacks.rs
@@ -219,6 +219,39 @@ impl RustHostCallbackContext<'_> {
         effective_style_with_stroke_color(self.target_state().style, red, green, blue, alpha)
     }
 
+    /// Apply one family paint operation atomically to this ordered effective overlay.
+    pub fn paint_family(
+        &mut self,
+        family: &crate::MobjectFamily,
+        operation: crate::FamilyPaint,
+    ) -> Result<(), crate::FamilyCallbackPaintError> {
+        let token = self.overlay.token();
+        let rows = self.session.required_callback_family_read(
+            &family.integration_store().borrow(),
+            token,
+            family.node_id(),
+        )?;
+        for (node, properties) in rows {
+            self.overlay.cache_read_object(node, properties);
+        }
+        let changes = family.prepare_callback_paint(
+            token.publication().scene_revision(),
+            operation,
+            |node| {
+                self.overlay
+                    .object(node)
+                    .map(|p| p.style)
+                    .ok_or(ExecutionSessionCallbackError::UnknownObject(node))
+            },
+        )?;
+        for (node, style) in changes {
+            self.overlay
+                .set_style(node, style)
+                .expect("all family rows were read before writing");
+        }
+        Ok(())
+    }
+
     pub fn set_target_style(&mut self, style: Style) -> Result<(), ExecutionSessionCallbackError> {
         self.overlay.set_style(self.target, style)
     }

--- a/crates/noon/src/lib.rs
+++ b/crates/noon/src/lib.rs
@@ -66,6 +66,7 @@ mod execution_session;
 mod family_affine;
 mod family_arrangement;
 mod family_authoring;
+mod family_callback_paint;
 mod family_copy;
 mod family_layout;
 mod family_style;
@@ -100,6 +101,7 @@ pub use execution_session::{
 };
 pub use family_arrangement::FamilyArrangeOptions;
 pub use family_authoring::{MobjectFamily, MobjectFamilyMember};
+pub use family_callback_paint::{FamilyCallbackPaintError, FamilyPaint};
 pub use family_copy::FamilyCopy;
 pub use family_layout::{FamilyLayout, FamilyLayoutTarget, LayoutAnchor};
 pub use focus_on_authoring::FocusOnOptions;

--- a/crates/noon/src/semantic_mobject.rs
+++ b/crates/noon/src/semantic_mobject.rs
@@ -21,7 +21,7 @@ use bounds::{layout_for_content, transform_layout_xy};
 pub(crate) use style::{
     edit_color, edit_disable_fill, edit_disable_stroke, edit_fill, edit_fill_color,
     edit_fill_opacity, edit_manim_opacity, edit_object_opacity, edit_stroke, edit_stroke_color,
-    edit_stroke_opacity, edit_stroke_width, manim_color_from_effective,
+    edit_stroke_opacity, edit_stroke_width, manim_color_from_effective, PaintStyleEdit,
 };
 use style::{parse_stroke_cap, parse_stroke_join, parse_stroke_width_mode};
 

--- a/crates/noon/src/semantic_mobject/style.rs
+++ b/crates/noon/src/semantic_mobject/style.rs
@@ -42,6 +42,10 @@ pub(crate) trait PaintStyleEdit {
     fn set_fill_color(&mut self, color: Color, opacity_when_enabled: f64);
     fn set_stroke_color(&mut self, color: Color, opacity_when_enabled: f64);
     fn set_fill_opacity(&mut self, opacity: f64);
+    fn disable_fill(&mut self);
+    fn disable_stroke(&mut self);
+    fn set_stroke_opacity(&mut self, opacity: f64);
+    fn set_stroke_width(&mut self, width: f64);
 }
 
 // A captured effective solid paint can carry alpha in its color as well as
@@ -98,6 +102,18 @@ impl PaintStyleEdit for SemanticStyle {
     fn set_fill_opacity(&mut self, opacity: f64) {
         set_paint_opacity(&mut self.fill, &mut self.fill_opacity, opacity);
     }
+    fn disable_fill(&mut self) {
+        self.fill = None;
+    }
+    fn disable_stroke(&mut self) {
+        self.stroke = None;
+    }
+    fn set_stroke_opacity(&mut self, opacity: f64) {
+        set_paint_opacity(&mut self.stroke, &mut self.stroke_opacity, opacity);
+    }
+    fn set_stroke_width(&mut self, width: f64) {
+        self.stroke_width = width;
+    }
 }
 
 impl PaintStyleEdit for Style {
@@ -129,6 +145,21 @@ impl PaintStyleEdit for Style {
             ..self.fill.unwrap_or(Color::WHITE)
         });
     }
+    fn disable_fill(&mut self) {
+        self.fill = None;
+    }
+    fn disable_stroke(&mut self) {
+        self.stroke = None;
+    }
+    fn set_stroke_opacity(&mut self, opacity: f64) {
+        self.stroke = Some(Color {
+            alpha: opacity as f32,
+            ..self.stroke.unwrap_or(Color::WHITE)
+        });
+    }
+    fn set_stroke_width(&mut self, width: f64) {
+        self.stroke_width = width as f32;
+    }
 }
 
 pub(crate) fn edit_object_opacity(style: &mut SemanticStyle, opacity: f64) -> Result<(), String> {
@@ -159,8 +190,8 @@ pub(crate) fn edit_color<S: PaintStyleEdit>(
     Ok(())
 }
 
-pub(crate) fn edit_disable_fill(style: &mut SemanticStyle) {
-    style.fill = None;
+pub(crate) fn edit_disable_fill<S: PaintStyleEdit>(style: &mut S) {
+    style.disable_fill();
 }
 
 pub(crate) fn edit_fill_color<S: PaintStyleEdit>(
@@ -199,19 +230,22 @@ pub(crate) fn edit_fill<S: PaintStyleEdit>(
     Ok(())
 }
 
-pub(crate) fn edit_manim_opacity(style: &mut SemanticStyle, opacity: f64) -> Result<(), String> {
+pub(crate) fn edit_manim_opacity<S: PaintStyleEdit>(
+    style: &mut S,
+    opacity: f64,
+) -> Result<(), String> {
     let opacity = unit_opacity("opacity", opacity)?;
-    if style.fill.is_some() {
-        set_paint_opacity(&mut style.fill, &mut style.fill_opacity, opacity);
+    if style.has_fill() {
+        style.set_fill_opacity(opacity);
     }
-    if style.stroke.is_some() {
-        set_paint_opacity(&mut style.stroke, &mut style.stroke_opacity, opacity);
+    if style.has_stroke() {
+        style.set_stroke_opacity(opacity);
     }
     Ok(())
 }
 
-pub(crate) fn edit_disable_stroke(style: &mut SemanticStyle) {
-    style.stroke = None;
+pub(crate) fn edit_disable_stroke<S: PaintStyleEdit>(style: &mut S) {
+    style.disable_stroke();
 }
 
 pub(crate) fn edit_stroke_color<S: PaintStyleEdit>(
@@ -227,9 +261,12 @@ pub(crate) fn edit_stroke_color<S: PaintStyleEdit>(
     Ok(())
 }
 
-pub(crate) fn edit_stroke_opacity(style: &mut SemanticStyle, opacity: f64) -> Result<(), String> {
+pub(crate) fn edit_stroke_opacity<S: PaintStyleEdit>(
+    style: &mut S,
+    opacity: f64,
+) -> Result<(), String> {
     let opacity = unit_opacity("stroke opacity", opacity)?;
-    set_paint_opacity(&mut style.stroke, &mut style.stroke_opacity, opacity);
+    style.set_stroke_opacity(opacity);
     Ok(())
 }
 
@@ -247,15 +284,17 @@ pub(crate) fn edit_stroke(
     Ok(())
 }
 
-pub(crate) fn edit_stroke_width(style: &mut SemanticStyle, width: f64) -> Result<(), String> {
+pub(crate) fn edit_stroke_width<S: PaintStyleEdit>(
+    style: &mut S,
+    width: f64,
+) -> Result<(), String> {
     let width = authoring_render_f64("stroke width", width)?;
     if width < 0.0 {
         return Err("stroke width must be non-negative".to_owned());
     }
-    style.stroke_width = width;
-    if style.stroke.is_none() {
-        style.stroke = Some(SemanticPaint::Solid(Color::WHITE));
-        style.stroke_opacity = 1.0;
+    style.set_stroke_width(width);
+    if !style.has_stroke() {
+        style.set_stroke_color(Color::WHITE, 1.0);
     }
     Ok(())
 }

--- a/crates/noon/tests/family_callback_paint.rs
+++ b/crates/noon/tests/family_callback_paint.rs
@@ -1,0 +1,154 @@
+use noon::integration::HostCallbackId;
+use noon::{Color, FamilyCallbackPaintError, FamilyPaint, RustHostCallbackTable, Scene, Style};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+#[test]
+fn unique_local_family_preparation_and_late_read_failure_are_atomic() {
+    let scene = Scene::new();
+    let a = scene.circle(0.5).unwrap();
+    let b = scene.circle(0.5).unwrap();
+    let nested = scene.family(&[(&a).into(), (&b).into()]).unwrap();
+    let family = scene.family(&[(&nested).into(), (&a).into()]).unwrap();
+    for _ in 0..2000 {
+        scene.circle(0.1).unwrap();
+    }
+    let before = scene.revision();
+    let mut reads = vec![];
+    let changes = family
+        .prepare_callback_paint(
+            before,
+            FamilyPaint::Fill {
+                color: None,
+                opacity: Some(0.4),
+            },
+            |node| {
+                reads.push(node);
+                Ok(Style::default())
+            },
+        )
+        .unwrap();
+    assert_eq!(reads, [a.node_id(), b.node_id()]);
+    assert_eq!(changes.len(), 2);
+    let before_style = a.state().unwrap().style;
+    assert!(family
+        .prepare_callback_paint(before, FamilyPaint::Opacity(0.7), |node| {
+            if node == b.node_id() {
+                Err(noon::ExecutionSessionCallbackError::UnknownObject(node))
+            } else {
+                Ok(Style::default())
+            }
+        })
+        .is_err());
+    assert_eq!(a.state().unwrap().style, before_style);
+    assert_eq!(scene.revision(), before);
+    let empty = scene.family(&[]).unwrap();
+    assert!(matches!(
+        empty.prepare_callback_paint(
+            scene.revision(),
+            FamilyPaint::Opacity(f64::NAN),
+            |_| unreachable!()
+        ),
+        Err(FamilyCallbackPaintError::InvalidPaint(_))
+    ));
+    assert!(matches!(
+        family.prepare_callback_paint(before, FamilyPaint::Opacity(0.2), |_| unreachable!()),
+        Err(FamilyCallbackPaintError::StaleRevision { .. })
+    ));
+}
+
+#[test]
+fn caught_missing_leaf_and_foreign_family_leave_ordered_overlay_intact_then_retry() {
+    let mut scene = Scene::new();
+    let a = scene.circle(0.5).unwrap();
+    let b = scene.circle(0.5).unwrap();
+    let missing = scene.circle(0.5).unwrap();
+    let nested = scene.family(&[(&a).into(), (&b).into()]).unwrap();
+    let family = scene.family(&[(&nested).into(), (&a).into()]).unwrap();
+    let invalid = scene.family(&[(&a).into(), (&missing).into()]).unwrap();
+    scene.add_many(&[(&family).into()]).unwrap();
+    let foreign_scene = Scene::new();
+    let foreign_a = foreign_scene.circle(0.5).unwrap();
+    let foreign = foreign_scene.family(&[(&foreign_a).into()]).unwrap();
+    let ids = [a.node_id(), b.node_id()];
+    let observed = Rc::new(RefCell::new(Vec::new()));
+    let seen = observed.clone();
+    let mut callbacks = RustHostCallbackTable::new();
+    let id = HostCallbackId::new(71);
+    callbacks
+        .insert(id, move |context| -> Result<(), FamilyCallbackPaintError> {
+            let mut prior = context.target_state().style;
+            prior.fill = Some(Color::rgba(1.0, 0.0, 0.0, 0.25));
+            prior.opacity = 0.7;
+            context
+                .set_target_style(prior)
+                .map_err(FamilyCallbackPaintError::Callback)?;
+            assert!(context
+                .paint_family(&invalid, FamilyPaint::Opacity(0.1))
+                .is_err());
+            assert_eq!(context.target_state().style, prior);
+            assert!(matches!(
+                context.paint_family(&foreign, FamilyPaint::Opacity(0.1)),
+                Err(FamilyCallbackPaintError::Authoring(
+                    noon::AuthoringError::ForeignStore
+                ))
+            ));
+            context.paint_family(&family, FamilyPaint::Color(Color::rgba(0.0, 0.4, 1.0, 0.9)))?;
+            assert_eq!(context.target_state().style.fill.unwrap().alpha, 0.25);
+            context.paint_family(
+                &family,
+                FamilyPaint::Fill {
+                    color: None,
+                    opacity: Some(0.6),
+                },
+            )?;
+            context.paint_family(
+                &family,
+                FamilyPaint::Stroke {
+                    color: Some(Color::WHITE),
+                    width: Some(0.03),
+                    opacity: Some(0.2),
+                },
+            )?;
+            for node in ids {
+                let state = context
+                    .read_object(node)
+                    .map_err(FamilyCallbackPaintError::Callback)?;
+                assert!((state.style.fill.unwrap().alpha - 0.6).abs() < 1e-6);
+                assert!((state.style.stroke.unwrap().alpha - 0.2).abs() < 1e-6);
+                seen.borrow_mut().push(node);
+            }
+            assert_eq!(context.target_state().style.opacity, 0.7);
+            Ok(())
+        })
+        .unwrap();
+    callbacks
+        .add_updater(
+            &mut scene.integration_store().borrow_mut(),
+            a.node_id(),
+            id,
+            0.0,
+            None,
+        )
+        .unwrap();
+    let revision = scene.revision();
+    let authored = [a.state().unwrap(), b.state().unwrap()];
+    let mut session = scene.execution_session().unwrap();
+    let publication = session.publication_context();
+    callbacks.advance_to(&mut session, 0.0).unwrap();
+    assert_eq!(*observed.borrow(), ids);
+    assert_eq!(scene.revision(), revision);
+    assert_eq!([a.state().unwrap(), b.state().unwrap()], authored);
+    assert_eq!(
+        session.publication_context().scene_revision(),
+        publication.scene_revision()
+    );
+    assert_eq!(
+        session.publication_context().execution_revision(),
+        publication.execution_revision()
+    );
+    assert_ne!(
+        session.publication_context().frame_epoch(),
+        publication.frame_epoch()
+    );
+}

--- a/scripts/browser-smoke.mjs
+++ b/scripts/browser-smoke.mjs
@@ -435,11 +435,11 @@ async function directExecutionProof(page, expectedBackend) {
     "direct Rust/WASM sparse callback reads did not preserve the shared session time",
   );
   assert.ok(
-    direct.metrics.ordinaryCallbackSparseReads?.initialRead.blue >= 180 &&
+    Math.abs(direct.metrics.ordinaryCallbackSparseReads?.initialRead.blue - 214) <= 16 &&
       direct.metrics.ordinaryCallbackSparseReads?.initialVacatedLuma <= 60 &&
-      direct.metrics.ordinaryCallbackSparseReads?.midpoint.blue >= 180 &&
-      direct.metrics.ordinaryCallbackSparseReads?.persistentHold.blue >= 180 &&
-      direct.metrics.ordinaryCallbackSparseReads?.anchor.blue >= 180,
+      Math.abs(direct.metrics.ordinaryCallbackSparseReads?.midpoint.blue - 153) <= 16 &&
+      Math.abs(direct.metrics.ordinaryCallbackSparseReads?.persistentHold.blue - 153) <= 16 &&
+      Math.abs(direct.metrics.ordinaryCallbackSparseReads?.anchor.blue - 153) <= 16,
     "direct Rust/WASM sparse callback reads did not render initial, midpoint, Hold, and anchor states",
   );
   assert.equal(

--- a/web/direct-execution-smoke-probe.js
+++ b/web/direct-execution-smoke-probe.js
@@ -2036,8 +2036,12 @@ async function directOrdinaryCallbackSparseReadsProof(expectedBackend) {
     throw new Error(`direct sparse-read lifecycle is invalid ${JSON.stringify(metrics)}`);
   }
   for (const [label, color] of Object.entries({ initialRead, midpoint, persistentHold, anchor })) {
-    if (color.blue < 180 || color.green < 60) {
-      throw new Error(`direct sparse-read ${label} is not visibly blue: ${JSON.stringify(metrics)}`);
+    // Both leaves have shared fill alpha 0.6. At the initial anchor they
+    // overlap: 1 - (1 - 0.6)^2 = 0.84. Later samples contain one leaf.
+    const expectedBlue = 255 * (label === "initialRead" ? 0.84 : 0.6);
+    if (Math.abs(color.blue - expectedBlue) > 16 ||
+        Math.abs(color.green - expectedBlue * 0.4) > 16 || color.red > 16) {
+      throw new Error(`direct sparse-read ${label} lost shared paint alpha: ${JSON.stringify(metrics)}`);
     }
   }
   return metrics;

--- a/web/python-worker.source.js
+++ b/web/python-worker.source.js
@@ -353,7 +353,7 @@ function parseContinuationCallbackReadRequest(requestJson) {
   }
   if (!isRecord(request) ||
       !Number.isSafeInteger(request.request_id) || request.request_id < 0 ||
-      !["scalar_signal", "object"].includes(request.kind) || !isRecord(request.node) ||
+      !["scalar_signal", "object", "family"].includes(request.kind) || !isRecord(request.node) ||
       !Number.isSafeInteger(request.node.slot) || request.node.slot < 0 || request.node.slot > 0xffffffff ||
       !Number.isSafeInteger(request.node.generation) || request.node.generation < 0 || request.node.generation > 0xffffffff) {
     throw new TypeError("canonical callback read request must contain a request ID, typed kind, and semantic node");

--- a/web/python/_manim_semantic_handles.py
+++ b/web/python/_manim_semantic_handles.py
@@ -1258,17 +1258,14 @@ def _shared_family_layout(value: object, *, mutation: bool = False):
     return family_handle.layout()
 
 
-def _group_paint(self, operation, arguments, callback_method, callback_arguments):
+def _group_paint(self, operation, arguments):
     handle = getattr(self, "_semantic_family_handle", None)
     if handle is None:
         raise RuntimeError("Group paint requires the shared Rust authoring host")
-    # #955 owns replacing the existing callback overlay's per-leaf dispatch.
-    # Keep callback writes effective; never publish them as authored style edits.
-    from _manim_updaters import _canonical_phase_context
-    leaves = _compat._leaf_mobjects(self)
-    if any(_canonical_phase_context(leaf) is not None for leaf in leaves):
-        for leaf in leaves:
-            getattr(leaf, callback_method)(*callback_arguments)
+    from _manim_updaters import _ACTIVE_CANONICAL_CONTEXT
+    phase = _ACTIVE_CANONICAL_CONTEXT.get()
+    if phase is not None:
+        phase.paint_family(handle, operation, arguments)
         return self
     context = _group_target_context(self)
     try:
@@ -1291,25 +1288,23 @@ def _family_color_arguments(color):
 def _group_set_color(self, color):
     parsed = _compat._as_color("color", color)
     arguments = (parsed.red, parsed.green, parsed.blue, parsed.alpha)
-    return _group_paint(self, "Color", arguments, "set_color", (color,))
+    return _group_paint(self, "Color", arguments)
 
 
 def _group_set_fill(self, color=None, opacity=None):
     alpha = None if opacity is None else _compat._opacity("fill opacity", opacity)
-    return _group_paint(self, "Fill", (*_family_color_arguments(color), alpha),
-                        "set_fill", (color, opacity))
+    return _group_paint(self, "Fill", (*_family_color_arguments(color), alpha))
 
 
 def _group_set_stroke(self, color=None, width=None, opacity=None):
     stroke_width = None if width is None else _compat._manim_stroke_width(width)
     alpha = None if opacity is None else _compat._opacity("stroke opacity", opacity)
-    return _group_paint(self, "Stroke", (*_family_color_arguments(color), stroke_width, alpha),
-                        "set_stroke", (color, width) if opacity is None else (color, width, opacity))
+    return _group_paint(self, "Stroke", (*_family_color_arguments(color), stroke_width, alpha))
 
 
 def _group_set_opacity(self, opacity):
     alpha = _compat._opacity("opacity", opacity)
-    return _group_paint(self, "Opacity", (alpha,), "set_opacity", (opacity,))
+    return _group_paint(self, "Opacity", (alpha,))
 
 
 def _group_arrange_in_grid(self, rows=None, cols=None, buff=_base.MED_SMALL_BUFF):

--- a/web/python/_manim_updaters.py
+++ b/web/python/_manim_updaters.py
@@ -576,7 +576,7 @@ class _CanonicalCallbackContext:
             result = json.loads(str(result_json))
         except Exception as error:
             raise RuntimeError(f"canonical callback sparse read failed: {error}") from None
-        expected_kind = "scalar" if kind == "scalar_signal" else "object"
+        expected_kind = "scalar" if kind == "scalar_signal" else kind
         if not isinstance(result, dict) or result.get("kind") != expected_kind:
             raise RuntimeError("canonical callback sparse read returned the wrong typed value")
         return result
@@ -670,6 +670,56 @@ class _CanonicalCallbackContext:
         row = _PhasePropertyRow.from_wire(self._object_item(key))
         self._rows[key] = row
         return key, row
+
+    def paint_family(self, family, operation, arguments):
+        # Rust selects the unique leaves and reads them against this phase token
+        # in one request. Python only retains the permitted callback read view.
+        from _noon_errors import engine_call
+        revision = str(self.token["publication"]["scene_revision"])
+        keys = [tuple(int(part) for part in str(key).split(":")) for key in
+                engine_call(self._operations.callbackFamilyKeys, family, revision)]
+        if any(node not in self._rows and node not in self._frame_items for node in keys):
+            family_key = (int(family.semanticSlot), int(family.semanticGeneration))
+            result = self._read("family", family_key)
+            items = result.get("objects")
+            if not isinstance(items, list):
+                raise RuntimeError("family callback read did not return object rows")
+            received = {_phase_node_key(item["node"]): item for item in items}
+            if set(received) != set(keys):
+                raise RuntimeError("family callback read returned different membership")
+        else:
+            received = self._frame_items
+        rows = {node: self._rows.get(node) or _PhasePropertyRow.from_wire(received[node])
+                for node in keys}
+        # Row selection preserves preceding writes, including scalar leaf edits.
+        styles = [[*node, row.style.to_wire()] for node, row in rows.items()]
+        if operation == "Color":
+            paint = (True, *arguments, None, None)
+        elif operation == "Fill":
+            paint = (*arguments[:5], None, arguments[5])
+        elif operation == "Stroke":
+            paint = arguments
+        else:
+            paint = (False, 0.0, 0.0, 0.0, 1.0, None, arguments[0])
+        raw = engine_call(self._operations.callbackFamilyPaint, family,
+            str(self.token["publication"]["scene_revision"]), operation,
+            json.dumps(styles, separators=(",", ":")), *paint)
+        # Decode and validate every returned row before exposing any writes, so
+        # user code may catch a failure without a partially changed family.
+        changes = []
+        for slot, generation, style in json.loads(str(raw)):
+            node = (slot, generation)
+            if node not in rows:
+                raise RuntimeError("family paint returned an unread semantic node")
+            changes.append((node, _PhaseStyle.from_wire(style)))
+        self._rows.update(rows)
+        for node, style in changes:
+            row = rows[node]
+            before = row.style
+            row.style = style
+            if style.stroke != before.stroke or style.stroke_width != before.stroke_width:
+                row.invalidate_bounds()
+            self.style_changed(node, before, row)
 
     def transform_changed(
         self, key: tuple[int, int], before: _PhaseTransform, row: _PhasePropertyRow

--- a/web/python/_manim_updaters.py
+++ b/web/python/_manim_updaters.py
@@ -717,7 +717,8 @@ class _CanonicalCallbackContext:
             row = rows[node]
             before = row.style
             row.style = style
-            if style.stroke != before.stroke or style.stroke_width != before.stroke_width:
+            if ((style.stroke is None) != (before.stroke is None) or
+                    (style.stroke is not None and style.stroke_width != before.stroke_width)):
                 row.invalidate_bounds()
             self.style_changed(node, before, row)
 

--- a/web/python/examples/live_callback_paint.py
+++ b/web/python/examples/live_callback_paint.py
@@ -4,7 +4,7 @@ Rust owns preservation of enabled fill/stroke alpha and opacity-only fill
 behavior. Python supplies color coercion and the arbitrary callable bodies.
 """
 
-from noon import Circle, Color, Scene, linear
+from noon import Circle, Color, Scene, VGroup, linear
 
 
 class LiveCallbackPaint(Scene):
@@ -17,6 +17,7 @@ class LiveCallbackPaint(Scene):
         assert circle.get_fill_opacity() == 0.25
         assert circle.get_stroke_opacity() == 0.75
         self.add(circle)
+        family = VGroup(VGroup(circle), circle)
         target = circle.copy().shift((2.0, 0.0, 0.0))
         animation = self.declare_live_transform_to(
             circle,
@@ -33,7 +34,7 @@ class LiveCallbackPaint(Scene):
 
         def fill_and_composite_opacity(mobject, _dt):
             assert mobject.get_stroke_opacity() == 0.75
-            mobject.set_fill(opacity=0.4)
+            family.set_fill(opacity=0.4)
             assert abs(mobject.get_fill_opacity() - 0.4) < 1e-6
             # Callback set_opacity remains the separately qualified object
             # composite domain rather than Manim's ordinary paint-alpha edit.

--- a/web/python/examples/ordinary_callback_sparse_reads.py
+++ b/web/python/examples/ordinary_callback_sparse_reads.py
@@ -7,7 +7,7 @@ restarted to fill either row.
 """
 
 import _manim_updaters
-from noon import Circle, Color, Scene, ValueTracker, linear
+from noon import Circle, Color, Scene, ValueTracker, VGroup, linear
 
 
 class OrdinaryCallbackSparseReads(Scene):
@@ -18,6 +18,8 @@ class OrdinaryCallbackSparseReads(Scene):
             .shift((-1.0, 1.0, 0.0))
         )
         circle = Circle(radius=0.4).set_fill(Color(0.0, 0.4, 1.0), opacity=1.0)
+        family = VGroup(VGroup(circle, anchor), circle)
+        invalid_family = VGroup(circle, Circle(radius=0.1))
         tracker = ValueTracker(0.0)
         phase_counts: dict[float, int] = {}
 
@@ -25,6 +27,19 @@ class OrdinaryCallbackSparseReads(Scene):
             phase_time = _manim_updaters._canonical_callback_time(mobject)
             phase_counts[phase_time] = phase_counts.get(phase_time, 0) + 1
             assert phase_counts[phase_time] == 1
+            # One Rust-selected family read fetches the missing anchor row.
+            # Recolor must observe the preceding family alpha edit, not authored alpha.
+            family.set_fill(opacity=0.6)
+            family.set_color(Color(0.0, 0.4, 1.0, 0.9))
+            assert abs(anchor.get_fill_opacity() - 0.6) < 1e-6
+            assert abs(mobject.get_fill_opacity() - 0.6) < 1e-6
+            try:
+                invalid_family.set_fill(opacity=0.1)
+            except RuntimeError:
+                pass  # The detached final member cannot be read from this phase.
+            else:
+                raise AssertionError("family paint accepted a non-live member")
+            assert abs(mobject.get_fill_opacity() - 0.6) < 1e-6
             anchor_center = anchor.get_center()
             mobject.move_to((anchor_center.x + tracker.get_value(), anchor_center.y, 0.0))
 

--- a/web/python/test_manim_shared_family_paint.py
+++ b/web/python/test_manim_shared_family_paint.py
@@ -38,12 +38,71 @@ class SharedFamilyPaintTests(unittest.TestCase):
         member.set_fill = Mock()
         family = identity_only_wrapper(compat.VGroup, submobjects=[member])
         family._semantic_family_handle = Mock()
-        with patch.object(updaters, "_canonical_phase_context", return_value=Mock()):
+        phase = Mock()
+        token = updaters._ACTIVE_CANONICAL_CONTEXT.set(phase)
+        try:
             family.set_fill(compat._base.RED, 0.5)
-        member.set_fill.assert_called_once_with(compat._base.RED, 0.5)
+        finally:
+            updaters._ACTIVE_CANONICAL_CONTEXT.reset(token)
+        color = compat._base.RED
+        phase.paint_family.assert_called_once_with(family._semantic_family_handle, "Fill",
+            (True, color.red, color.green, color.blue, color.alpha, 0.5))
+        member.set_fill.assert_not_called()
         family._semantic_family_handle.setFill.assert_not_called()
 
     def test_unbacked_family_cannot_mutate(self):
         family = identity_only_wrapper(compat.VGroup, submobjects=[])
         with self.assertRaisesRegex(RuntimeError, "shared Rust"):
             family.set_opacity(0.5)
+
+
+class FamilyCallbackBatchTests(unittest.TestCase):
+    def fixture(self):
+        import copy
+        from types import SimpleNamespace
+        from test_updater_snapshot import CanonicalCallbackPropertyRowTests
+        _, mobject, context = CanonicalCallbackPropertyRowTests._mobject_and_context()
+        context.token["publication"]["scene_revision"] = "9"
+        _, row = context.row(mobject)
+        second = copy.deepcopy(context._frame_items[(11, 3)])
+        second["node"] = {"slot": 12, "generation": 3}
+        context._operations.callbackFamilyKeys = Mock(return_value=["11:3", "12:3"])
+        context._operations.callbackFamilyPaint = Mock()
+        family = SimpleNamespace(semanticSlot=21, semanticGeneration=3)
+        return context, row, second, family
+
+    def test_sparse_family_is_one_read_and_preserves_preceding_overlay_writes(self):
+        import json
+        from dataclasses import replace
+        context, row, second, family = self.fixture()
+        row.style = replace(row.style, opacity=0.25)
+        context._read = Mock(return_value={"kind": "family", "objects": [context._frame_items[(11, 3)], second]})
+        # No changes returned by the Rust operation: verify adaptation, not paint math.
+        context._operations.callbackFamilyPaint.return_value = "[]"
+        context.paint_family(family, "Opacity", (0.5,))
+        context._read.assert_called_once_with("family", (21, 3))
+        forwarded = json.loads(context._operations.callbackFamilyPaint.call_args.args[3])
+        self.assertEqual(forwarded[0][2]["opacity"], 0.25)
+        self.assertEqual(context.effective_batch()["writes"], [])
+        context._read.reset_mock()
+        context.paint_family(family, "Opacity", (0.5,))
+        context._read.assert_not_called()
+
+    def test_failed_bulk_read_or_late_result_decode_cannot_publish_partial_edits(self):
+        import json
+        context, row, second, family = self.fixture()
+        before = row.style
+        context._read = Mock(side_effect=RuntimeError("last member is not live"))
+        with self.assertRaisesRegex(RuntimeError, "last member"):
+            context.paint_family(family, "Opacity", (0.5,))
+        context._operations.callbackFamilyPaint.assert_not_called()
+        self.assertEqual(row.style, before)
+        self.assertEqual(context.effective_batch()["writes"], [])
+        context._read = Mock(return_value={"kind": "family", "objects": [context._frame_items[(11, 3)], second]})
+        changed = {**before.to_wire(), "opacity": 0.5}
+        context._operations.callbackFamilyPaint.return_value = json.dumps([[11, 3, changed], [12, 3, {}]])
+        with self.assertRaises(TypeError):
+            context.paint_family(family, "Opacity", (0.5,))
+        self.assertEqual(row.style, before)
+        self.assertEqual(context.effective_batch()["writes"], [])
+        self.assertNotIn((12, 3), context._rows)

--- a/web/python/test_manim_shared_family_paint.py
+++ b/web/python/test_manim_shared_family_paint.py
@@ -106,3 +106,20 @@ class FamilyCallbackBatchTests(unittest.TestCase):
         self.assertEqual(row.style, before)
         self.assertEqual(context.effective_batch()["writes"], [])
         self.assertNotIn((12, 3), context._rows)
+
+
+    def test_family_recolor_preserves_bounds_but_stroke_width_invalidates_them(self):
+        import json
+        context, row, second, family = self.fixture()
+        context._read = Mock(return_value={"kind": "family", "objects": [context._frame_items[(11, 3)], second]})
+        bounds = row.require_bounds()
+        recolored = row.style.to_wire()
+        recolored["stroke"] = {"red": 0.2, "green": 0.4, "blue": 1.0, "alpha": 0.6}
+        context._operations.callbackFamilyPaint.return_value = json.dumps([[11, 3, recolored]])
+        context.paint_family(family, "Color", (0.2, 0.4, 1.0, 0.6))
+        self.assertEqual(row.require_bounds(), bounds)
+        wider = {**recolored, "stroke_width": 3.0}
+        context._operations.callbackFamilyPaint.return_value = json.dumps([[11, 3, wider]])
+        context.paint_family(family, "Stroke", (False, 0, 0, 0, 1, 3.0, None))
+        with self.assertRaisesRegex(NotImplementedError, "spatial property change"):
+            row.require_bounds()

--- a/web/semantic-engine-endpoint.js
+++ b/web/semantic-engine-endpoint.js
@@ -346,7 +346,7 @@ export async function attachSemanticEngine(
 
   function callbackReadRequestJson(request) {
     if (!request || typeof request !== "object" ||
-        !["scalar_signal", "object"].includes(request.kind) ||
+        !["scalar_signal", "object", "family"].includes(request.kind) ||
         !request.node || typeof request.node !== "object" ||
         !Number.isSafeInteger(request.node.slot) || request.node.slot < 0 || request.node.slot > 0xffffffff ||
         !Number.isSafeInteger(request.node.generation) || request.node.generation < 0 || request.node.generation > 0xffffffff) {

--- a/web/semantic-engine-endpoint.test.mjs
+++ b/web/semantic-engine-endpoint.test.mjs
@@ -418,6 +418,11 @@ test("callback sparse reads are pinned to the pending phase and never publish it
     }]);
     assert.equal(f.stats().committedPhases, 0);
     assert.equal(f.stats().drained, 0, "a sparse read cannot drain a renderer delta");
+    readPhase(token, { request_id: 12, kind: "family", node: { slot: 9, generation: 2 } });
+    assert.equal(f.stats().callbackReads[1].request,
+      JSON.stringify({ kind: "family", node: { slot: 9, generation: 2 } }));
+    assert.equal(f.stats().committedPhases, 0, "a bulk family read cannot publish the phase");
+
 
     assert.throws(
       () => readPhase(JSON.stringify({ ...phase.token, sequence: 5 }), {


### PR DESCRIPTION
Group paint in an active Python callback currently selects wrapper leaves and edits them one at a time, so a caught failure can leave earlier leaves changed. Move leaf selection and complete style preparation into shared Rust, then adapt the prepared result into the existing effective callback batch only after all reads and result decoding succeed.

Advances Phase A3 #61 and its #955 callback handoff, under #953/#961. Semantic family traversal and paint semantics stay in `noon`; `ExecutionSession` validates the existing callback token and supplies a bounded family read using its existing object-read path. A sparse family costs one callback read request, not one per leaf. Cached rows preserve prior ordered overlay edits. Rust callbacks use the same preparation through `RustHostCallbackContext::paint_family`. No authored revision or semantic relowering is introduced for paint driver writes.

The existing paint trait is extended so authored/effective fill, stroke and opacity share the same operations. Families preserve object-composite opacity while editing paint layers. Python's per-leaf callback setter loop is deleted. Callback row JSON remains at the existing explicit Python callback view/overlay boundary; native and direct Rust/WASM execution use typed Rust calls. No new scene/runtime, identity allocator, migration seam or permanent helper workflow.

Paired examples: existing `live_callback_paint` now covers nested aliases and ordered fill edits on native/direct-WASM/Python. Existing `ordinary_callback_sparse_reads` covers a two-leaf nested/aliased family, a bulk read miss, preceding paint alpha, a caught non-live final-member rejection and retry without callback replay; its renderer smoke remains active.

Focused validation before hosted qualification:
- `cargo test -p noon --no-default-features --test family_callback_paint --test family_style` — 5 passed; includes 2,000 unrelated objects, unique reads, missing/foreign family failure, retry, authored state/revision preservation.
- `cargo test -p noon --no-default-features --lib callback` — 30 passed.
- `cargo test -p noon --no-default-features --lib ordinary_sparse_reads` — passed.
- `PYTHONPATH=web/python PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s web/python -p 'test_*.py'` — 169 run, 8 browser-only skips.
- `node --test web/semantic-engine-endpoint.test.mjs` — 40 passed.
- `bash scripts/check.sh architecture`, worker generation, format and diff checks passed.

Cargo commands used the existing `/tmp/noon-geometry-check` cache with incremental/debug output disabled. Local disk is insufficient for another full Typst/WASM build. Hosted full and actual browser qualification are recorded below. Further callback layout and broader typed-error coverage remain separately owned. The R3 callback-read mapper owner is aware of the additive family request and retains error conversion ownership.


Final qualification: head `8b225789b60f87a47a01be2e88349948d7addd97`, tested PR integration `8606315b97b4d146baa724500f5fa2fdcce0c6b2` against master `b4ecbc2e69a4668e5422cf5a7b22b0cbdf070c12`. All applicable final-head checks passed, including native/provider, product comparison, Chromium, Firefox and mobile WebKit.

- `bash scripts/check.sh full 47bfd0b6b20ac4b828607dc32a655dca8060db71` passed in run34370379669 at `beaa4713477e3194de63abe6dc019311886c8c62`: 1,686 Rust test passes, zero failures, three existing ignored, all-target/all-feature strict checks and default optimized release WASM. The later extra browser smoke in that run failed; the overall workflow was not green.
- That browser failure exposed recolor incorrectly invalidating bounds. The final Python correction invalidates bounds only when stroke presence or enabled stroke width changes; its regression verifies recolor permits a subsequent bounds query while width changes invalidate it. Existing pixel assertions now check the example's intended paint alpha0.6 (initial overlap0.84).
- No Rust source changed after the full gate: the final delta is two smoke assertions, the Python cache condition and its regression. Final normal checks qualify the corrected source.
- `node scripts/shared-authoring-smoke.mjs` passed in supplemental run34374549447 using exact-source product artifact10113073424 from run34373164659. Source identity, all package hashes, dependency lock and declared build-input hashes were verified before execution; only the package was reused and the worker was regenerated from the same source. This avoided another unchanged Rust build. Evidence artifact10113443461 retains the verification and complete browser log.
- The local supplemental browser attempt stalled before useful output and was terminated; it is not counted as a pass. Hosted actual browser execution above supplies the qualification.

Review confirms one Rust family selection/preparation implementation, phase-pinned reads, complete preparation before overlay writes, and work proportional to affected family members. There is no new semantic/runtime authority or native/direct-WASM transport. Scalar VMobject callback opacity parity is separately owned by #1351; broader typed error conversion remains #1292 R2/R3.
