### PR TITLE
fix: match callback VMobject opacity to shared paint semantics

### DIFF
--- a/crates/noon-web/src/canonical_authoring_scene.rs
+++ b/crates/noon-web/src/canonical_authoring_scene.rs
@@ -4210,6 +4210,37 @@ mod wasm {
             ))
         }
 
+        /// Apply shared paint opacity while leaving whole-object opacity with its owner.
+        #[wasm_bindgen(js_name = callbackPaintSetOpacity)]
+        #[allow(clippy::too_many_arguments)]
+        pub fn callback_paint_set_opacity(
+            &self,
+            fill_red: Option<f64>,
+            fill_green: Option<f64>,
+            fill_blue: Option<f64>,
+            fill_alpha: Option<f64>,
+            stroke_red: Option<f64>,
+            stroke_green: Option<f64>,
+            stroke_blue: Option<f64>,
+            stroke_alpha: Option<f64>,
+            opacity: f64,
+        ) -> Result<WasmCallbackPaint, JsValue> {
+            let style = callback_paint_style(
+                callback_color("callback fill", fill_red, fill_green, fill_blue, fill_alpha)?,
+                callback_color(
+                    "callback stroke",
+                    stroke_red,
+                    stroke_green,
+                    stroke_blue,
+                    stroke_alpha,
+                )?,
+            );
+            Ok(callback_paint_result(
+                noon::integration::effective_style_with_paint_opacity(style, opacity)
+                    .map_err(js_error)?,
+            ))
+        }
+
         /// Apply shared Manim `set_fill` semantics to callback-local paint.
         #[wasm_bindgen(js_name = callbackPaintSetFill)]
         #[allow(clippy::too_many_arguments)]

--- a/crates/noon/src/example_scenes.rs
+++ b/crates/noon/src/example_scenes.rs
@@ -297,8 +297,9 @@ pub fn live_callback_paint() -> Result<(ExecutionSession, RustHostCallbackTable)
     callbacks.insert(FILL_AND_COMPOSITE_OPACITY, move |context| {
         let before = context.target_state().style;
         let expected_fill_alpha = if context.time() == 0.0 { 0.25 } else { 0.4 };
+        let expected_stroke_alpha = if context.time() == 0.0 { 0.75 } else { 0.4 };
         if before.fill.map(|color| color.alpha) != Some(expected_fill_alpha)
-            || before.stroke.map(|color| color.alpha) != Some(0.75)
+            || before.stroke.map(|color| color.alpha) != Some(expected_stroke_alpha)
         {
             return Err(std::io::Error::other(
                 "ordered paint callback did not observe preserved layer alpha",
@@ -313,7 +314,13 @@ pub fn live_callback_paint() -> Result<(ExecutionSession, RustHostCallbackTable)
                 },
             )
             .map_err(std::io::Error::other)?;
-        let mut style = context.target_state().style;
+        let mut style = crate::integration::effective_style_with_paint_opacity(
+            context.target_state().style,
+            0.4,
+        )
+        .map_err(std::io::Error::other)?;
+        assert_eq!(style.fill.map(|color| color.alpha), Some(0.4));
+        assert_eq!(style.stroke.map(|color| color.alpha), Some(0.4));
         style.opacity = 0.5;
         context
             .set_target_style(style)
@@ -3095,7 +3102,7 @@ mod callback_paint_tests {
         let initial_style = initial.style;
         assert_eq!(initial.transform.translation, Vec2::ZERO);
         assert_eq!(initial.style.fill, Some(Color::rgba(0.8, 0.4, 0.2, 0.4)));
-        assert_eq!(initial.style.stroke, Some(Color::rgba(0.8, 0.4, 0.2, 0.75)));
+        assert_eq!(initial.style.stroke, Some(Color::rgba(0.8, 0.4, 0.2, 0.4)));
         assert_eq!(initial.style.stroke_width, 0.12);
         assert_eq!(initial.style.opacity, 0.5);
 

--- a/crates/noon/src/host_callbacks.rs
+++ b/crates/noon/src/host_callbacks.rs
@@ -321,6 +321,12 @@ pub fn effective_style_with_fill_color(
     Ok(style)
 }
 
+/// Apply shared Manim paint opacity without changing the object-composite multiplier.
+pub fn effective_style_with_paint_opacity(mut style: Style, opacity: f64) -> Result<Style, String> {
+    crate::semantic_mobject::edit_manim_opacity(&mut style, opacity)?;
+    Ok(style)
+}
+
 /// Apply shared Manim opacity-only fill semantics to an effective runtime style.
 pub fn effective_style_with_fill_opacity(mut style: Style, opacity: f64) -> Result<Style, String> {
     crate::semantic_mobject::edit_fill_opacity(&mut style, opacity)?;
@@ -689,6 +695,38 @@ mod tests {
 
         assert!(effective_style_with_fill_opacity(style, f64::NAN).is_err());
         assert_eq!(style.fill.unwrap().alpha, 0.25);
+    }
+
+    #[test]
+    fn callback_paint_opacity_matches_authored_style_and_preserves_composite_domain() {
+        let mut scene = Scene::new();
+        let mut object = scene.circle(0.5).unwrap();
+        object.set_fill(0.1, 0.2, 0.3, 0.25).unwrap();
+        object.set_stroke_color(0.4, 0.5, 0.6, 0.75).unwrap();
+        object.set_stroke_width(3.0).unwrap();
+        object.set_object_opacity(0.6).unwrap();
+        scene.add(&object).unwrap();
+        let before = scene.execution_session().unwrap().frame().objects[0].style;
+        let effective = effective_style_with_paint_opacity(before, 0.4).unwrap();
+        object.set_opacity(0.4).unwrap();
+        let authored = scene.execution_session().unwrap().frame().objects[0].style;
+        assert_eq!(effective, authored);
+        assert_eq!(effective.fill.unwrap().alpha, 0.4);
+        assert_eq!(effective.stroke.unwrap().alpha, 0.4);
+        assert_eq!(effective.opacity, before.opacity);
+        assert_eq!(effective.stroke_width, before.stroke_width);
+        for opacity in [-1.0, 2.0, f64::NAN, f64::INFINITY] {
+            assert!(effective_style_with_paint_opacity(before, opacity).is_err());
+        }
+        let unpainted = Style {
+            fill: None,
+            stroke: None,
+            ..before
+        };
+        assert_eq!(
+            effective_style_with_paint_opacity(unpainted, 0.4).unwrap(),
+            unpainted
+        );
     }
 
     #[test]

--- a/crates/noon/src/integration.rs
+++ b/crates/noon/src/integration.rs
@@ -35,8 +35,8 @@ pub use crate::execution_session::{
 };
 pub use crate::host_callbacks::{
     effective_style_with_color, effective_style_with_fill, effective_style_with_fill_color,
-    effective_style_with_fill_opacity, effective_style_with_stroke_color,
-    rotate_effective_transform_about_point,
+    effective_style_with_fill_opacity, effective_style_with_paint_opacity,
+    effective_style_with_stroke_color, rotate_effective_transform_about_point,
 };
 pub use crate::semantic_mobject::{authoring_render_f64, authoring_xy_f64, line_match_transform};
 #[cfg(feature = "native-text")]

--- a/scripts/shared-authoring-smoke.mjs
+++ b/scripts/shared-authoring-smoke.mjs
@@ -3174,7 +3174,7 @@ result = scene
   assert.equal(paintResult.observation.outcome, "presented");
   const paintStyle = paintResult.observation.committed.style;
   assert.ok(Math.abs(paintStyle.fill.alpha - 0.4) < 1e-6);
-  assert.ok(Math.abs(paintStyle.stroke.alpha - 0.75) < 1e-6);
+  assert.ok(Math.abs(paintStyle.stroke.alpha - 0.4) < 1e-6);
   assert.equal(paintStyle.opacity, 0.5);
   const paintPixel = renderedWorldPixel(
     await page.locator(`#${paintResult.canvasId}`).screenshot(), 1, 0,

--- a/web/python/_manim_updaters.py
+++ b/web/python/_manim_updaters.py
@@ -775,6 +775,15 @@ class _CanonicalCallbackContext:
             _phase_callback_paint_color(result, "stroke"),
         )
 
+    def paint_set_opacity(self, style: _PhaseStyle, opacity: float):
+        from _noon_errors import engine_call
+        result = engine_call(self._operations.callbackPaintSetOpacity,
+            *_phase_optional_color_args(style.fill),
+            *_phase_optional_color_args(style.stroke), opacity,
+            operation="VMobject.set_opacity")
+        return (_phase_callback_paint_color(result, "fill"),
+                _phase_callback_paint_color(result, "stroke"))
+
     def paint_set_fill(
         self,
         style: _PhaseStyle,
@@ -1215,11 +1224,18 @@ def _canonical_vmobject_set_opacity(
     opacity: float,
     family: bool = True,
 ) -> _base.Mobject:
-    if _canonical_phase_context(self) is not None:
+    context = _canonical_phase_context(self)
+    if context is not None:
         del family
         from _manim_compat import _opacity
 
-        return _canonical_set_opacity(self, _opacity("opacity", opacity))
+        opacity = _opacity("opacity", opacity)
+        key, row = context.row(self)
+        before = row.style
+        fill, stroke = context.paint_set_opacity(before, opacity)
+        row.style = replace(before, fill=fill, stroke=stroke)
+        context.style_changed(key, before, row)
+        return self
     return _base._semantic_operations()._set_opacity(self, opacity, family=family)
 
 

--- a/web/python/examples/live_affine_callbacks.py
+++ b/web/python/examples/live_affine_callbacks.py
@@ -31,7 +31,7 @@ class LiveAffineCallbacks(Scene):
 
         def style_after_lift(mobject, _dt):
             assert mobject.get_center().y == 1.0
-            mobject.set_opacity(0.5)
+            mobject.set_object_opacity(0.5)
 
         def accumulate_drift(mobject, dt):
             mobject.shift((0.0, dt, 0.0))

--- a/web/python/examples/live_callback_paint.py
+++ b/web/python/examples/live_callback_paint.py
@@ -28,17 +28,18 @@ class LiveCallbackPaint(Scene):
 
         def recolor(mobject, _dt):
             before_fill = mobject.get_fill_opacity()
+            before_stroke = mobject.get_stroke_opacity()
             mobject.set_color(Color(0.8, 0.4, 0.2, 0.9))
             assert abs(mobject.get_fill_opacity() - before_fill) < 1e-6
-            assert mobject.get_stroke_opacity() == 0.75
+            assert mobject.get_stroke_opacity() == before_stroke
 
         def fill_and_composite_opacity(mobject, _dt):
-            assert mobject.get_stroke_opacity() == 0.75
             family.set_fill(opacity=0.4)
             assert abs(mobject.get_fill_opacity() - 0.4) < 1e-6
-            # Callback set_opacity remains the separately qualified object
-            # composite domain rather than Manim's ordinary paint-alpha edit.
-            mobject.set_opacity(0.5)
+            mobject.set_opacity(0.4)
+            assert abs(mobject.get_fill_opacity() - 0.4) < 1e-6
+            assert abs(mobject.get_stroke_opacity() - 0.4) < 1e-6
+            mobject.set_object_opacity(0.5)
 
         circle.add_updater(recolor)
         circle.add_updater(fill_and_composite_opacity)

--- a/web/python/examples/live_callback_paint.py
+++ b/web/python/examples/live_callback_paint.py
@@ -31,7 +31,7 @@ class LiveCallbackPaint(Scene):
             before_stroke = mobject.get_stroke_opacity()
             mobject.set_color(Color(0.8, 0.4, 0.2, 0.9))
             assert abs(mobject.get_fill_opacity() - before_fill) < 1e-6
-            assert mobject.get_stroke_opacity() == before_stroke
+            assert abs(mobject.get_stroke_opacity() - before_stroke) < 1e-6
 
         def fill_and_composite_opacity(mobject, _dt):
             family.set_fill(opacity=0.4)

--- a/web/python/examples/ordinary_affine_callback_continuation.py
+++ b/web/python/examples/ordinary_affine_callback_continuation.py
@@ -35,7 +35,7 @@ class OrdinaryAffineCallbackContinuation(Scene):
         def dim_after_lift(mobject, _dt):
             assert mobject.get_center().y == 1.0
             mobject.set_fill(opacity=0.75)
-            mobject.set_opacity(0.5)
+            mobject.set_object_opacity(0.5)
 
         circle.add_updater(lift)
         circle.add_updater(dim_after_lift)

--- a/web/python/examples/perf_host_updater.py
+++ b/web/python/examples/perf_host_updater.py
@@ -14,7 +14,7 @@ class HostUpdaterPerfScene(Scene):
             # style work. The unrelated anchor must never enter the sparse phase.
             center = mobject.get_center()
             mobject.move_to((center.x, dt, 0.0))
-            mobject.set_opacity(0.5 + dt)
+            mobject.set_object_opacity(0.5 + dt)
 
         follower.add_updater(removed)
         follower.remove_updater(removed)

--- a/web/python/noon.py
+++ b/web/python/noon.py
@@ -442,7 +442,7 @@ class Mobject:
 
     def set_object_opacity(self, opacity: float) -> Mobject:
         """Set whole-object opacity independently of fill/stroke paint alpha."""
-        return _semantic_operations()._set_object_opacity(self, opacity)
+        return _callback_operations()._canonical_set_opacity(self, opacity)
 
     def next_to(
         self,

--- a/web/python/test_updater_snapshot.py
+++ b/web/python/test_updater_snapshot.py
@@ -174,6 +174,16 @@ class CanonicalCallbackPropertyRowTests(unittest.TestCase):
                 stroke = (*color[:3], stroke[3] if has_stroke else color[3])
                 return self._paint_result(fill, stroke, has_fill, True)
 
+            def callbackPaintSetOpacity(self, *values: object):
+                self.paint_edits.append(("opacity", values))
+                fill, stroke, opacity = values[:4], values[4:8], values[8]
+                has_fill, has_stroke = fill[0] is not None, stroke[0] is not None
+                if has_fill:
+                    fill = (*fill[:3], opacity)
+                if has_stroke:
+                    stroke = (*stroke[:3], opacity)
+                return self._paint_result(fill, stroke, has_fill, has_stroke)
+
             @staticmethod
             def _paint_result(fill, stroke, has_fill: bool, has_stroke: bool):
                 return SimpleNamespace(
@@ -210,7 +220,7 @@ class CanonicalCallbackPropertyRowTests(unittest.TestCase):
             self.assertEqual(row.style.fill, (0.8, 0.4, 0.2, 0.4))
             self.assertEqual(row.style.stroke, (0.8, 0.4, 0.2, 0.75))
             self.assertEqual(row.style.opacity, 1.0)
-            mobject.set_opacity(0.5)
+            mobject.set_object_opacity(0.5)
         finally:
             updaters._ACTIVE_CONTEXTS.pop(id(scene), None)
 
@@ -222,6 +232,31 @@ class CanonicalCallbackPropertyRowTests(unittest.TestCase):
             [kind for kind, _ in context._operations.paint_edits],
             ["color", "fill"],
         )
+
+    def test_vmobject_callback_opacity_uses_shared_paint_and_preserves_composite(self) -> None:
+        scene, mobject, context = self._mobject_and_context()
+        updaters._ACTIVE_CONTEXTS[id(scene)] = context
+        try:
+            mobject.set_fill(opacity=0.25)
+            mobject.set_object_opacity(0.6)
+            mobject.set_opacity(0.4)
+            _, row = context.row(mobject)
+            self.assertEqual(row.style.fill[3], 0.4)
+            self.assertEqual(row.style.stroke[3], 0.4)
+            self.assertEqual(row.style.opacity, 0.6)
+            self.assertEqual(context._operations.paint_edits[-1][0], "opacity")
+            before, writes = row.style, list(context.effective_batch()["writes"])
+            failure = RuntimeError("shared paint rejected")
+            def reject(*_args):
+                raise failure
+            context._operations.callbackPaintSetOpacity = reject
+            with self.assertRaises(RuntimeError) as caught:
+                mobject.set_opacity(0.2)
+            self.assertIs(caught.exception, failure)
+            self.assertEqual(row.style, before)
+            self.assertEqual(context.effective_batch()["writes"], writes)
+        finally:
+            updaters._ACTIVE_CONTEXTS.pop(id(scene), None)
 
     def test_unsupported_callback_stroke_opacity_fails_before_row_mutation(self) -> None:
         scene, mobject, context = self._mobject_and_context()
@@ -291,7 +326,7 @@ class CanonicalCallbackPropertyRowTests(unittest.TestCase):
             self.assertEqual(updaters._canonical_callback_time(mobject), 0.5)
             self.assertEqual(mobject.get_center(), updaters._base.Vec2(2.0, -1.0))
             mobject.move_to((4.0, 3.0))
-            mobject.set_opacity(0.5)
+            mobject.set_object_opacity(0.5)
             mobject.set_color(updaters._base.BLUE)
             self.assertEqual(mobject.get_center(), updaters._base.Vec2(4.0, 3.0))
             mobject.shift((1.0, 0.0))


### PR DESCRIPTION
Callback VMobject.set_opacity now changes enabled fill/stroke alpha, matching shared authored/live Rust semantics. set_object_opacity explicitly changes the independent composite multiplier through the same callback overlay. This closes the scalar paint/composite mismatch under #61/#961 and advances #953.

Rust's existing edit_manim_opacity operation owns the behavior. One effective-style helper and the existing WASM paint-result adapter expose it; Python forwards arguments and installs the prepared result after success. No new scene authority, traversal, callback protocol, migration seam or relowering. Work is constant per edited object.

The paired live_callback_paint Rust/Python example exercises both domains: fill/stroke alpha0.4 and composite0.5. The native/direct-WASM/Python paths use the same engine semantics. Three existing composite-intent callback demos now spell that operation set_object_opacity, preserving their established Rust/performance expectations. Paint-alpha comparisons allow the same float32 precision tolerance for fill and stroke.

Validation and exact scope:
- Full gate34375251860 at18cee9ec05ac38cd64b29021a51d13c74a18f098: bash scripts/check.sh full bc9fa345c0feb9a503cfcfa03fff9057fb328cc4 passed; 1,699 Rust tests passed, zero failures, three existing ignored, strict checks/preflight and default optimized release WASM. Artifact10114628529 retains complete evidence.
- All normal PR checks at18cee passed. Final64f4e907d83fab917714a44b32089191a2fb3d54 changes only four Python examples after that source; crate/build-input diff is empty.
- Corrected-source browser-only34379333987 passed BOTH node scripts/shared-authoring-smoke.mjs and node scripts/updater-callback-smoke.mjs. Artifact10115309815 retains logs and verification. It reuses immutable product package10113963737/run34375191810, binary sourcefe3e4b852c28ad0cbba2a092019a5ec84b2981b2, after explicit unchanged Rust/build-input and manifest/lock hash checks. The Python worker is regenerated from final64f4 source; binary provenance is not relabeled.
- Final NOON_WEB_PREFLIGHT_ONLY=1 bash scripts/build-web-demo.sh passed, including172 Python tests with9 browser-only skips. bash scripts/check.sh architecture 18cee9ec05ac38cd64b29021a51d13c74a18f098, worker generation and diff checks passed. Focused callback Rust31/Python25 tests protect parity, prior-write preservation and atomic rejection.

The first extra browser run caught old composite-intent demo syntax; the next caught an exact0.4 comparison across float32 serialization. Both were example corrections, not hidden passes. The final browser run above passes without changing engine behavior or weakening a visual/performance threshold.

At landing, final64f4 general CI jobs remain in progress with no reported failures. The repository has no mandatory status checks or branch rules configured. Merge qualification uses the completed full gate on identical Rust, all earlier unchanged-engine checks, final web/architecture preflight and actual final-source browser execution; it does not claim pending jobs passed. Broader typed-error producer/mapping coverage and remaining family layout/translation ownership stay open in #1292/#61.
