### PR TITLE
refactor: expose animation requests without import-time replacement

### DIFF
--- a/web/python/_manim_animate.py
+++ b/web/python/_manim_animate.py
@@ -14,27 +14,17 @@ import _manim_compat as _compat
 import _manim_rate_functions as _rate_functions
 
 
-_ORIGINAL_TRANSFORM = _base.Transform
-_ORIGINAL_REPLACEMENT_TRANSFORM = _base.ReplacementTransform
-_ORIGINAL_TRANSFORM_FROM_COPY = _base.TransformFromCopy
-_ORIGINAL_TRANSFORM_MATCHING_SHAPES = _base.TransformMatchingShapes
-_ORIGINAL_CREATE = _base.Create
-_ORIGINAL_UNCREATE = _base.Uncreate
-_ORIGINAL_FADE_IN = _base.FadeIn
-_ORIGINAL_FADE_OUT = _base.FadeOut
 _PURE_YELLOW = _base.color_from_hex("#FFFF00")
 
 
 def _store_animation_args(animation: object, kwargs: dict[str, Any]) -> None:
     """Attach Manim Animation kwargs for the shared option resolver.
 
-    Noon's original animation records are frozen/slotted dataclasses. Subclassing them
-    gives the compatibility facade a small Python ``__dict__`` for authoring metadata
-    while preserving the existing low-level fields and isinstance-based lowering.
-    Validation remains centralized in ``_manim_animation_options`` at play time.
+    These inert requests carry Python call-shape metadata only. Validation and
+    execution remain in the shared Rust option/animation operations.
     """
 
-    object.__setattr__(animation, "anim_args", dict(kwargs))
+    animation.anim_args = dict(kwargs)
 
 
 def _fade_authoring_options(
@@ -84,13 +74,13 @@ def _store_fade_options(
     point_target: bool,
     point: _base.Vec2 | None,
 ) -> None:
-    object.__setattr__(animation, "_fade_shift_vector", shift_vector)
-    object.__setattr__(animation, "_fade_scale_factor", scale_factor)
-    object.__setattr__(animation, "_fade_point_target", point_target)
-    object.__setattr__(animation, "_fade_point", point)
+    animation._fade_shift_vector = shift_vector
+    animation._fade_scale_factor = scale_factor
+    animation._fade_point_target = point_target
+    animation._fade_point = point
 
 
-class Transform(_ORIGINAL_TRANSFORM):
+class Transform:
     def __init__(
         self,
         source: object,
@@ -98,7 +88,9 @@ class Transform(_ORIGINAL_TRANSFORM):
         key: str | None = None,
         **kwargs: Any,
     ) -> None:
-        super().__init__(source, target, key)
+        self.source = source
+        self.target = target
+        self.key = key
         _store_animation_args(self, kwargs)
 
 
@@ -127,7 +119,7 @@ class Indicate:
         _store_animation_args(self, animation_kwargs)
 
 
-class ReplacementTransform(_ORIGINAL_REPLACEMENT_TRANSFORM):
+class ReplacementTransform:
     def __init__(
         self,
         source: object,
@@ -135,11 +127,13 @@ class ReplacementTransform(_ORIGINAL_REPLACEMENT_TRANSFORM):
         key: str | None = None,
         **kwargs: Any,
     ) -> None:
-        super().__init__(source, target, key)
+        self.source = source
+        self.target = target
+        self.key = key
         _store_animation_args(self, kwargs)
 
 
-class TransformFromCopy(_ORIGINAL_TRANSFORM_FROM_COPY):
+class TransformFromCopy:
     def __init__(
         self,
         source: object,
@@ -147,11 +141,13 @@ class TransformFromCopy(_ORIGINAL_TRANSFORM_FROM_COPY):
         key: str | None = None,
         **kwargs: Any,
     ) -> None:
-        super().__init__(source, target, key)
+        self.source = source
+        self.target = target
+        self.key = key
         _store_animation_args(self, kwargs)
 
 
-class TransformMatchingShapes(_ORIGINAL_TRANSFORM_MATCHING_SHAPES):
+class TransformMatchingShapes:
     def __init__(
         self,
         sources: object,
@@ -159,17 +155,20 @@ class TransformMatchingShapes(_ORIGINAL_TRANSFORM_MATCHING_SHAPES):
         key: str | None = None,
         **kwargs: Any,
     ) -> None:
-        super().__init__(sources, targets, key)
+        self.sources = sources
+        self.targets = targets
+        self.key = key
         _store_animation_args(self, kwargs)
 
 
-class Create(_ORIGINAL_CREATE):
+class Create:
     def __init__(self, target: object, key: str | None = None, **kwargs: Any) -> None:
-        super().__init__(target, key)
+        self.target = target
+        self.key = key
         _store_animation_args(self, kwargs)
 
 
-class Uncreate(_ORIGINAL_UNCREATE):
+class Uncreate(Create):
     def __init__(
         self,
         target: object,
@@ -178,16 +177,18 @@ class Uncreate(_ORIGINAL_UNCREATE):
         remover: bool = True,
         **kwargs: Any,
     ) -> None:
-        super().__init__(target, key, bool(reverse_rate_function), bool(remover))
-        _store_animation_args(self, kwargs)
+        super().__init__(target, key, **kwargs)
+        self.reverse_rate_function = bool(reverse_rate_function)
+        self.remover = bool(remover)
 
 
-class FadeIn(_ORIGINAL_FADE_IN):
+class FadeIn:
     def __init__(self, target: object, key: str | None = None, **kwargs: Any) -> None:
         animation_kwargs, shift_vector, scale_factor, point_target, point = (
             _fade_authoring_options(target, kwargs)
         )
-        super().__init__(target, key)
+        self.target = target
+        self.key = key
         _store_animation_args(self, animation_kwargs)
         _store_fade_options(
             self,
@@ -198,12 +199,13 @@ class FadeIn(_ORIGINAL_FADE_IN):
         )
 
 
-class FadeOut(_ORIGINAL_FADE_OUT):
+class FadeOut:
     def __init__(self, target: object, key: str | None = None, **kwargs: Any) -> None:
         animation_kwargs, shift_vector, scale_factor, point_target, point = (
             _fade_authoring_options(target, kwargs)
         )
-        super().__init__(target, key)
+        self.target = target
+        self.key = key
         _store_animation_args(self, animation_kwargs)
         _store_fade_options(
             self,
@@ -214,24 +216,34 @@ class FadeOut(_ORIGINAL_FADE_OUT):
         )
 
 
-# Replace only the public compatibility classes. Their frozen Noon bases remain the
-# low-level representation and existing code using isinstance(..., noon.Create/etc.)
-# continues to work because the module globals now point at these subclasses.
-for _name, _value in {
-    "Transform": Transform,
-    "Indicate": Indicate,
-    "ReplacementTransform": ReplacementTransform,
-    "TransformFromCopy": TransformFromCopy,
-    "TransformMatchingShapes": TransformMatchingShapes,
-    "Create": Create,
-    "Uncreate": Uncreate,
-    "FadeIn": FadeIn,
-    "FadeOut": FadeOut,
-}.items():
-    setattr(_base, _name, _value)
+class ScaleInPlace:
+    """Defer shared target construction until play begins, like Manim ApplyMethod."""
 
-if "Indicate" not in _base.__all__:
-    _base.__all__.append("Indicate")
+    def __init__(self, mobject: object, scale_factor: float, **kwargs: Any) -> None:
+        if not isinstance(mobject, (_base.Mobject, _compat.Group)):
+            raise TypeError("ScaleInPlace target must be a Mobject or Group")
+        factor = float(scale_factor)
+        if not math.isfinite(factor):
+            raise ValueError("scale factor must be finite")
+        self.source = mobject
+        self.mobject = mobject
+        self.scale_factor = factor
+        self.anim_args = dict(kwargs)
+
+
+class ShrinkToCenter:
+    """Inert request for the shared Rust scale-to-center removal lifecycle."""
+
+    _canonical_affine_lifecycle = "shrink"
+
+    def __init__(self, mobject: object, **kwargs: Any) -> None:
+        if isinstance(mobject, _compat.Group):
+            raise NotImplementedError("ShrinkToCenter currently supports one leaf Mobject")
+        if not isinstance(mobject, _base.Mobject):
+            raise TypeError("ShrinkToCenter target must be a Mobject")
+        self.mobject = mobject
+        self.anim_args = dict(kwargs)
+
 
 
 class _AnimateBuilderMixin:

--- a/web/python/_manim_animation_options.py
+++ b/web/python/_manim_animation_options.py
@@ -3,13 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-import math
 from typing import Any
 
 from js import noonResolveAnimationOptions as _resolve_shared_animation_options
 
-import noon as _base
-import _manim_compat as _compat
 import _manim_rate_functions as _rate_functions
 
 
@@ -103,43 +100,3 @@ def resolve(
         path_arc=float(result.pathArc),
         reverse_rate_function=bool(result.reverseRateFunction),
     )
-
-
-class ScaleInPlace:
-    """Defer shared target construction until play begins, like Manim ApplyMethod."""
-
-    def __init__(self, mobject: object, scale_factor: float, **kwargs: Any) -> None:
-        if not isinstance(mobject, (_base.Mobject, _compat.Group)):
-            raise TypeError("ScaleInPlace target must be a Mobject or Group")
-        factor = float(scale_factor)
-        if not math.isfinite(factor):
-            raise ValueError("scale factor must be finite")
-        self.source = mobject
-        self.mobject = mobject
-        self.scale_factor = factor
-        self.anim_args = dict(kwargs)
-
-
-class ShrinkToCenter:
-    """Inert request for the shared Rust scale-to-center removal lifecycle."""
-
-    _canonical_affine_lifecycle = "shrink"
-
-    def __init__(self, mobject: object, **kwargs: Any) -> None:
-        if isinstance(mobject, _compat.Group):
-            raise NotImplementedError("ShrinkToCenter currently supports one leaf Mobject")
-        if not isinstance(mobject, _base.Mobject):
-            raise TypeError("ShrinkToCenter target must be a Mobject")
-        self.mobject = mobject
-        self.anim_args = dict(kwargs)
-
-
-public = {
-    "ScaleInPlace": ScaleInPlace,
-    "ShrinkToCenter": ShrinkToCenter,
-}
-for _name, _value in public.items():
-    setattr(_base, _name, _value)
-    setattr(_compat, _name, _value)
-    if _name not in _base.__all__:
-        _base.__all__.append(_name)

--- a/web/python/_manim_geometry.py
+++ b/web/python/_manim_geometry.py
@@ -160,7 +160,7 @@ class ApplyMethod:
             raise TypeError("ApplyMethod requires a bound Mobject/Group method")
         name = _public_bound_method_name(source, method)
 
-        # Resolve lazily because _manim_geometry is installed before _manim_animate.
+        # Resolve the defining module lazily to avoid an import cycle.
         import _manim_animate as _animate
 
         builder = (

--- a/web/python/_manim_scene.py
+++ b/web/python/_manim_scene.py
@@ -1466,7 +1466,7 @@ def _build_canonical_composition_candidate(
             nested = build(nested_kind, tuple(animation.animations), animation, {})
             builder.appendComposition(nested)
             return
-        if type(animation) is _options.ScaleInPlace:
+        if type(animation) is _animate.ScaleInPlace:
             # Resolve options before creating a target. Copy/scale and effective
             # play-begin state belong to the shared semantic operations.
             _canonical_composition_child_options(animation, child_kwargs)

--- a/web/python/noon.py
+++ b/web/python/noon.py
@@ -7,8 +7,7 @@ owns authoring syntax, argument conversion, and wrapper identity.
 from __future__ import annotations
 
 import math
-from dataclasses import dataclass
-from typing import Any, Callable, Iterable
+from typing import Any, Callable
 
 from _noon_errors import (
     NoonError,
@@ -527,62 +526,6 @@ class Mobject:
         return deepcopy_semantic_wrapper(self, memo)
 
 
-@dataclass(frozen=True, slots=True)
-class Transform:
-    source: Mobject | _ir.Object
-    target: Mobject | _ir.Mobject | VectorPath
-    key: str | None = None
-
-
-@dataclass(frozen=True, slots=True)
-class ReplacementTransform:
-    source: Mobject | _ir.Object
-    target: Mobject | _ir.Object
-    key: str | None = None
-
-
-@dataclass(frozen=True, slots=True)
-class TransformFromCopy:
-    source: Mobject | _ir.Object
-    target: Mobject | _ir.Object
-    key: str | None = None
-
-
-@dataclass(frozen=True, slots=True)
-class TransformMatchingShapes:
-    sources: Iterable[Mobject | _ir.Object]
-    targets: Iterable[Mobject | _ir.Object]
-    key: str | None = None
-
-
-@dataclass(frozen=True, slots=True)
-class Create:
-    """Progressively draw a shape without changing its steady-state geometry."""
-
-    target: Mobject | _ir.Object
-    key: str | None = None
-
-
-@dataclass(frozen=True, slots=True)
-class Uncreate(Create):
-    """Manim-style Create in reverse, optionally removing the target at completion."""
-
-    reverse_rate_function: bool = True
-    remover: bool = True
-
-
-@dataclass(frozen=True, slots=True)
-class FadeIn:
-    target: Mobject | _ir.Object
-    key: str | None = None
-
-
-@dataclass(frozen=True, slots=True)
-class FadeOut:
-    target: Mobject | _ir.Object
-    key: str | None = None
-
-
 def _scene_operations():
     """Load the shared host adapter lazily, after public wrapper classes exist."""
     try:
@@ -749,6 +692,18 @@ Object = Mobject
 
 # Public wrappers resolve from their defining modules without startup mutation.
 _PUBLIC_EXPORTS = {
+    "Transform": "_manim_animate",
+    "ReplacementTransform": "_manim_animate",
+    "TransformFromCopy": "_manim_animate",
+    "TransformMatchingShapes": "_manim_animate",
+    "Create": "_manim_animate",
+    "Uncreate": "_manim_animate",
+    "FadeIn": "_manim_animate",
+    "FadeOut": "_manim_animate",
+    "Indicate": "_manim_animate",
+    "ScaleInPlace": "_manim_animate",
+    "ShrinkToCenter": "_manim_animate",
+
     "linear": "_manim_rate_functions",
     "smooth": "_manim_rate_functions",
     "rush_into": "_manim_rate_functions",
@@ -843,8 +798,6 @@ __all__ = [
     "BLUE_D",
     "BLUE_E",
     "Color",
-    "Create",
-    "Uncreate",
     "DEGREES",
     "DEFAULT_FRAME_HEIGHT",
     "DEFAULT_FRAME_WIDTH",
@@ -853,8 +806,6 @@ __all__ = [
     "DL",
     "DOWN",
     "DR",
-    "FadeIn",
-    "FadeOut",
     "GOLD",
     "GRAY",
     "GRAY_A",
@@ -896,7 +847,6 @@ __all__ = [
     "RED_D",
     "RED_E",
     "RIGHT",
-    "ReplacementTransform",
     "Scene",
     "TAU",
     "TEAL",
@@ -905,9 +855,6 @@ __all__ = [
     "TEAL_C",
     "TEAL_D",
     "TEAL_E",
-    "Transform",
-    "TransformFromCopy",
-    "TransformMatchingShapes",
     "UL",
     "UP",
     "UR",

--- a/web/python/test_manim_animation_constructor_options.py
+++ b/web/python/test_manim_animation_constructor_options.py
@@ -65,7 +65,19 @@ class ManimAnimationConstructorOptionsTests(unittest.TestCase):
             sys.modules["js"] = fake_js
 
             from _typed_geometry_test_support import identity_only_wrapper as identity
+            import noon
+            names = ("Transform", "ReplacementTransform", "TransformFromCopy",
+                     "TransformMatchingShapes", "Create", "Uncreate", "FadeIn",
+                     "FadeOut", "Indicate", "ScaleInPlace", "ShrinkToCenter")
+            exports = {name: getattr(noon, name) for name in names}
+            # Public requests accept options before Scene/bootstrap imports. Later
+            # imports must preserve class identity and existing instances.
+            early = exports["Create"](object(), run_time=2.0)
+            assert early.anim_args == {"run_time": 2.0}
             import _manim_compat
+            import _manim_animation_options
+            assert all(getattr(noon, name) is value for name, value in exports.items())
+            assert isinstance(early, noon.Create)
 
             import _manim_rate_functions
             from noon import Scene

--- a/web/python/test_manim_scale_in_place.py
+++ b/web/python/test_manim_scale_in_place.py
@@ -69,7 +69,7 @@ class ManimScaleInPlaceTests(unittest.TestCase):
 
             import _manim_rate_functions
             import _manim_animate  # noqa: F401
-            import _manim_animation_options  # installs the public ScaleInPlace request
+            import _manim_animation_options  # shared option resolver
 
             from noon import (
                 BLUE,


### PR DESCRIPTION
Public animation imports previously returned different classes before and after `_manim_animate` loaded; an early `Create(..., run_time=...)` could therefore reject valid options. Define the animation requests directly in their existing module and expose them through Noon's existing static export table. Remove eight captured base classes, their duplicate records, and the two public-export mutation loops. Move ScaleInPlace/ShrinkToCenter requests beside the other animation requests and leave the option module responsible for adapting the shared Rust resolver.

Advances #1292 R6b / #61 under Phase A #953. Python owns signatures, coercion and inert request fields; Rust option resolution, activation, lifecycle and playback are unchanged. No new semantic state, scheduler, protocol, migration seam or runtime work. Public class identity remains stable across subsequent module imports; the ordinary Scene consumer uses the defining request class directly.

Validation:
- `PYTHONPATH=web/python PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s web/python -p 'test_*.py'`: 168 run, nine browser-only skips.
- `bash scripts/check.sh architecture`: passed.
- `NOON_WEB_PREFLIGHT_ONLY=1 bash scripts/build-web-demo.sh`: passed, including the existing web checks and the same Python suite.
- `git diff --check`: passed.

The existing constructor regression now creates an option-bearing public request before Scene/bootstrap imports and verifies class/instance identity afterward. Existing fade, transform, create/uncreate, indication, scale and import-without-host tests pass. Existing paired Rust/Python examples cover unchanged semantics; no new semantic feature requires a duplicate example. Actual browser qualification is now green in PR CI. This Python-only cleanup does not trigger a separate full Rust rebuild or claim that R2/R3 are complete.


Final qualification at `89b014daf972068bee53de271d82b2fbfb1d7576` (tested merge `abcbf56c99d6d5eb447b9a8dd70db0d2696a4441`): all applicable checks passed, including architecture, Rust/web fast gates, production recovery, Chromium/Firefox/mobile WebKit, and product comparison. Source review confirms consumers use the same defining classes directly, preserve all inert request fields/options, and do not depend on the deleted dataclass machinery. No per-frame execution path changes.

Product run34375140530 attempt1 failed FPS49.3→38.4 against floor39.4 despite matching pixels and passing latency checks. One bounded **measurement-only** retry (attempt2) reused the same successful build/artifact job and passed FPS40.2→43.8, fixed-frame pixel diff0.00%, and all latency limits. No source, thresholds, provenance or assertions changed; no further retry was needed. Logs are retained by that run. The first failure is not erased or called a pass.

This completes the animation import-order seam. R6 remains open for the source-level family layout/translation residuals recorded in #61 comment5605218051, and R2/R3 errors remain with their owners.
