### PR TITLE
fix: reject mismatched live execution roots before publication (#1292 R4)

### DIFF
--- a/crates/noon/src/execution_session/publication.rs
+++ b/crates/noon/src/execution_session/publication.rs
@@ -359,6 +359,13 @@ impl ExecutionSession {
             .map(|root| prepare_semantic_root_order(&prepared, root))
             .transpose()
             .map_err(ExecutionSessionPublicationError::Lowering)?;
+        // Compiler validation preserves stale/wrong-kind root diagnostics. A valid
+        // family with the same leaves still cannot select a different execution domain.
+        if let Some(root) = order_root {
+            if !self.reachability.is_execution_root(root) {
+                return Err(ExecutionSessionPublicationError::UnknownObject(root));
+            }
+        }
         let (execution_suffix, execution_prefix): (Vec<_>, Vec<_>) =
             execution_prefix.into_iter().partition(|patch| {
                 matches!(

--- a/crates/noon/tests/root_order_transaction_regressions.rs
+++ b/crates/noon/tests/root_order_transaction_regressions.rs
@@ -262,3 +262,118 @@ fn rejected_provisional_order_preserves_state_then_reuses_unpublished_identity()
         }
     }
 }
+
+#[test]
+fn live_root_must_belong_to_the_execution_domain_before_publication() {
+    use noon::{ExecutionSessionPublicationError, LiveSessionError};
+    use noon_core::{SemanticNodeCreation, SemanticObjectProperty, SemanticVec3};
+
+    for scene_owned in [false, true] {
+        for nested_alias in [false, true] {
+            for pending_dirty in [false, true] {
+                let mut store = SemanticStore::new();
+                let a = object(&mut store);
+                let b = object(&mut store);
+                let wrong_root = family(&mut store, &[a, b]);
+                let root = family(&mut store, &[a, b]);
+                if nested_alias {
+                    store.add_member(root, wrong_root).unwrap();
+                }
+                let mut session = if scene_owned {
+                    store.attach_to_scene(root).unwrap();
+                    ExecutionSession::from_semantic_store(&store).unwrap()
+                } else {
+                    ExecutionSession::from_semantic_root(&store, root).unwrap()
+                };
+                let owner = Rc::new(RefCell::new(store));
+                session.take_frame_changes();
+                if pending_dirty {
+                    let mut tx = SemanticMutationTransaction::new();
+                    tx.set_property(
+                        a,
+                        SemanticObjectProperty::Translation,
+                        SemanticVec3::new(3.0, 0.0, 0.0),
+                    );
+                    LiveSession::new(&owner, root, &mut session)
+                        .apply(tx)
+                        .unwrap();
+                }
+                let context = session.publication_context();
+                let frame = session.frame().clone();
+                let order = session.painter_order().to_vec();
+                let slots = (0..frame.objects.len())
+                    .map(|row| session.execution_slot_for_frame_index(row))
+                    .collect::<Vec<_>>();
+                let count = owner.borrow().len();
+                let root_members = owner.borrow().node(root).unwrap().members();
+                let mutation_stats = owner.borrow().last_mutation_stats();
+                let authored_b = owner
+                    .borrow()
+                    .semantic_object_state_checked(b)
+                    .unwrap()
+                    .clone();
+
+                // Equal leaf membership (even a reachable alias family) does not
+                // make this the root that defines the retained execution domain.
+                let mut tx = SemanticMutationTransaction::new();
+                tx.reorder_member(root, b, Some(a));
+                tx.set_property(b, SemanticObjectProperty::RotationZ, 0.5);
+                tx.create_node(SemanticNodeCreation::family());
+                assert!(matches!(
+                    LiveSession::new(&owner, wrong_root, &mut session).apply(tx),
+                    Err(LiveSessionError::Publication(
+                        ExecutionSessionPublicationError::UnknownObject(rejected)
+                    )) if rejected == wrong_root
+                ));
+
+                assert_eq!(session.publication_context(), context);
+                assert_eq!(owner.borrow().scene_revision(), context.scene_revision());
+                assert_eq!(owner.borrow().len(), count);
+                assert_eq!(owner.borrow().last_mutation_stats(), mutation_stats);
+                assert_eq!(owner.borrow().node(root).unwrap().members(), root_members);
+                assert_eq!(owner.borrow().node(wrong_root).unwrap().members(), [a, b]);
+                assert_eq!(
+                    owner.borrow().node(root).unwrap().compare_members(a, b),
+                    Some(std::cmp::Ordering::Less)
+                );
+                assert_eq!(
+                    owner.borrow().semantic_object_state_checked(b).unwrap(),
+                    &authored_b
+                );
+                assert_eq!(session.frame(), &frame);
+                assert_eq!(session.painter_order(), order);
+                for (row, slot) in slots.iter().enumerate() {
+                    assert_eq!(session.execution_slot_for_frame_index(row), *slot);
+                }
+                let changes = session.take_frame_changes();
+                assert_eq!(changes.painter_order_range(), None);
+                if pending_dirty {
+                    assert_eq!(changes.object_indices(), &[0]);
+                } else {
+                    assert!(changes.is_empty());
+                }
+
+                let mut valid = SemanticMutationTransaction::new();
+                valid.reorder_member(root, b, Some(a));
+                LiveSession::new(&owner, root, &mut session)
+                    .apply(valid)
+                    .unwrap();
+                assert_order(&owner.borrow(), root, &session);
+                assert_eq!(session.frame(), &frame);
+                let after = session.publication_context();
+                assert_eq!(
+                    after.scene_revision(),
+                    context.scene_revision().checked_next().unwrap()
+                );
+                assert_eq!(
+                    after.execution_revision(),
+                    context.execution_revision().checked_next().unwrap()
+                );
+                assert_eq!(
+                    after.frame_epoch(),
+                    context.frame_epoch().checked_next().unwrap()
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Merged review correction

**Merged as `dfaf50673d0784820538d1fe802cc77018d57a2f` at 2026-09-09 17:22:25 UTC**, using the standard GitHub merge action pinned to reviewed head `6ba1656ac0bbb0956c90ae3eba6e519b8ecaeca6`, after the user explicitly requested review, iteration and merge. No force, protection changes or auto-merge was used. The actual merge parents and full tree were verified after merge against the separately tested integration below.

The requested original #1347 had already merged as `b4ecbc2e69a4668e5422cf5a7b22b0cbdf070c12` before this review. All seven of its final-head workflows passed. Its AVL/rank and canonical root-order implementation is retained; no additional defect was demonstrated in those algorithms by the bounded audit. This PR fixes a separate, pre-existing execution-domain admission defect found during that review.

## Finding and bounded correction

Two valid same-store families both contain `[A, B]`. The retained session was lowered from root1; bind `LiveSession` to root2 and submit a reorder of root1. Old code returns success and publishes authored `[B, A]` while painter stays `[A, B]`. In the minimal reorder-only reproducer, scene/frame advance and execution does not. Even a reachable nested alias family cannot substitute for the execution root.

**Exactly two files, +122/-0:** seven production lines in existing `execution_session/publication.rs` and one eight-case regression matrix in existing `root_order_transaction_regressions.rs`. The compiler first preserves stale/wrong-kind-root diagnostics; then `reachability.is_execution_root(root)` must hold before runtime preflight or semantic commit. Reuses existing typed `UnknownObject(root)`, already used for scoped-tracker admission. No new family traversal, allocation, identity, error framework/mapper, patch vocabulary, frontend policy, renderer, callback or session implementation. The extra guard is an indexed metadata lookup.

## Exact revisions and coordination

| Item | Revision |
|---|---|
| Reviewed #1347 head | `44beac791b8d4bdb246012a5b0aca5d45511f9c6` |
| Exact local post-merge audit base | `bc9fa345c0feb9a503cfcfa03fff9057fb328cc4` |
| Independently recomputed local base tree | `c2202b862fd7f7573168d8ae887b8a789ecb300f` |
| Corrective head / original parent | `6ba1656ac0bbb0956c90ae3eba6e519b8ecaeca6` / `b9d6c4cbd82a6333551663358946294538cc3842` |
| Corrective head tree | `f960e238e16e0d8d16c1fc419668de4242b72d0d` |
| Qualified pre-merge integration object | `1691d74309cb08321015a8ed3781b5551a0ec7c0` |
| Actual merge first / second parents | `73af2196f06cc1df2a5d239a007d1c45ce5ebafb` / `6ba1656ac0bbb0956c90ae3eba6e519b8ecaeca6` |
| Qualified AND actual merge tree | **`5f693de5f0a6c4149eee92925f06859f78d64b30`** |
| Actual merge commit | **`dfaf50673d0784820538d1fe802cc77018d57a2f`** |

Both modified Git blobs match locally tested and both hosted archives byte-for-byte: publication `efba41fec2ce4ec5a6899e9f41e61786e5e8452d`, test `c0c6cf7a2e76f8dc17efa004736c3b47043ccaca`.

Read AGENTS.md, architecture and #1292/#1305/#1340/#1347 handoffs. [Review claim](https://github.com/yongkyuns/noon/issues/1292#issuecomment-5605092468) and [specific guard coordination](https://github.com/yongkyuns/noon/issues/1292#issuecomment-5605217029) preceded source publication. Intervening #1346/#1342/#1352/#1351 changes were compared and retained, not overwritten. No helper workflow is in the product diff.

## Acceptance and review evidence

| Criterion | Evidence |
|---|---|
| Compiler ownership | Existing compiler remains the sole root-order patch generator. Session validates only the retained execution domain. |
| Membership/painter behavior | All 23 existing/new external root-order tests pass, retaining earlier empty/provisional/alias/reference fixtures. |
| Atomic rejection/recovery | Eight combinations: explicit/scene-owned bootstrap, sibling/reachable nested alias, clean/pending-dirty output. Rejected batch includes reorder, value edit and provisional allocation; preserves authored order/rank/value, allocation count, mutation counters, revisions, frame, slots and existing dirty output. Correct-root retry succeeds. |
| Revision rules | Rejection advances none; correct-root reorder advances scene/execution/frame once. Existing exact-no-op, empty-only and forward/backward seek tests remain green. |
| Error priority | Existing stale/wrong-kind tests plus a temporary executable pending-callback/foreign-store priority audit pass; acknowledgment and recovery use the same session. |
| Locality | One indexed guard, no scene scan/clone/rebuild. Existing eight compiler and three rank-index locality tests remain green; #1347's explicit O(log family size) maintenance/memory tradeoff is unchanged. |
| Native/direct-WASM/frontends | Native full gate, actual import-free Rust/WASM recovery and all seven normal PR workflows pass, including real WASM/Pyodide boundary and browser/product gates. |

Additional temporary deterministic review fixtures (retained as evidence, not new product APIs) passed **12,000 compound alias publications** and **1,510 provisional/deletion publications**; **1,490 typed invalid attempts** preserved prior publication. Rejections match existing removed-node family-edge/order and prepared-value lowering errors, not arbitrary ignored failures. This is bounded coverage, not an arbitrary-transaction proof.

Authoritative local red/green used a fresh Cargo target on the exact post-merge source. An apparent relocated-cache baseline pass was discarded. Early harness compilation/assertion refinements were test setup, not engine failures. Local correction checks passed 23 external +247 minimal noon-library +3 rank +8 compiler tests, strict focused Clippy, two priority tests and eight-case direct WASM. Counts overlap broader suites. Two broad local fast attempts hit command deadlines during dependency compilation and are not counted as full local passes.

## Exact-head FULL qualification

**[Run 34378390378](https://github.com/yongkyuns/noon/actions/runs/34378390378), job102556868317, attempt1: success.** Read-only helper `5fe1f76467b853459abb4aa7650e55d6a99a79e8` explicitly checked out unmodified head6ba1656… and verified its parent. It first restored unchanged-base production for the new regression: **0 passed /1 assertion failure**, then restored the correction and passed **23 focused tests**.

```sh
cargo test -p noon --no-default-features --test root_order_acceptance \
  --test root_order_transaction_regressions --test root_order_alias_regressions \
  --no-fail-fast -- --nocapture
bash scripts/check.sh full b9d6c4cbd82a6333551663358946294538cc3842
```

Default architecture/fmt/all-target/all-feature check/strict Clippy, all workspace tests and browser build/preflight passed. Across119 Rust suite reports: **1,705 passed, zero failed, three pre-existing ignored**. Focused counts overlap this total. Web preflight and release optimization were not skipped; wasm-opt ran and package validation reports53,179,737-byte WASM plus161 API contracts (build receipt, not a size benchmark).

The exact new Rust test body also executed as import-free WASM on Node22.23.2: **eight wrong-root/recovery combinations passed, zero JS imports**, only a completion scalar crosses JS. Module SHA256 `7883f76b1d168621655daf9cec497959005baab7a2d1dc30841424a7bb71951e`. Toolchain Rust/Cargo1.98.0. Actual WASM execution is distinct from browser-rendering evidence.

Artifact10115578404, `r4-root-domain-final-qualification`, was downloaded and inspected; ZIP SHA256 **`9d7dc817309c44140b622f48d1307158892bb3bf6cab6edbabca7c8b745bdbcd`** verified. Source matches published blobs; tracked worktree clean.

## Separately qualified current-master integration

Master advanced after initial qualification with12 disjoint paths. **[Run34381702253](https://github.com/yongkyuns/noon/actions/runs/34381702253), job102567881594: success**, helper `7f793853684dd7952027ea2ef2d2676e2c66ba5d`, explicitly tested clean integration1691d743… and verified both parents and tree.

```sh
cargo test -p noon --no-default-features --test root_order_acceptance \
  --test root_order_transaction_regressions --test root_order_alias_regressions \
  --no-fail-fast -- --nocapture
bash scripts/check.sh fast 73af2196f06cc1df2a5d239a007d1c45ce5ebafb
cargo check -p noon-web --all-features --target wasm32-unknown-unknown
```

**23 focused tests and1,415 workspace-library tests passed; zero failures, three existing ignores.** Architecture/fmt/check/strict Clippy and direct-WASM compilation pass. This integration check is compile-only for WASM; actual execution and full-release qualification belong to the head run above. Artifact10116336526, ZIP SHA256 **`65613ab151411a3675982e7cdefecf9b399c0fdf44cae1f572dee8d753735aae`**, was downloaded/verified; source hashes and clean worktree inspected. **The final merge has exactly this tested integration tree and parent pair.**

## Normal PR gates and merge receipt

All seven final-head workflows succeeded before merge: [Fast34378174645](https://github.com/yongkyuns/noon/actions/runs/34378174645), [Provider34378174809](https://github.com/yongkyuns/noon/actions/runs/34378174809), [Native34378174707](https://github.com/yongkyuns/noon/actions/runs/34378174707), [Architecture34378174789](https://github.com/yongkyuns/noon/actions/runs/34378174789), [Dependency34378174964](https://github.com/yongkyuns/noon/actions/runs/34378174964), [Product34378174746](https://github.com/yongkyuns/noon/actions/runs/34378174746), [Cross-browser34378174879](https://github.com/yongkyuns/noon/actions/runs/34378174879). Browser Fast includes real typed WASM/Pyodide recovery, deterministic playback, Manim authoring, editor/reset and WebGPU rendering. Existing risk-selected skips were not overridden.

Final review/head/master rechecks preceded the normal expected-head merge. No unresolved inline review threads existed. Reviews submitted by this session are author-side COMMENT records, not independent human approval. Post-merge jobs are not represented as completed; acceptance evidence is the checked head and byte-identical qualified integration tree.

No general session rewrite, new Python raw-root API, GPU-failure/resource-exhaustion proof, arbitrary execution-root/transaction completeness, or closure of the six-case #1292/Phase A roadmap is claimed. The demonstrated finding from this review is fixed and merged.