### PR TITLE
refactor: share family frame alignment across Rust and Python

### DIFF
--- a/crates/noon-web/src/authoring_mobject.rs
+++ b/crates/noon-web/src/authoring_mobject.rs
@@ -414,6 +414,18 @@ mod wasm {
             self.layout.height()
         }
 
+        #[wasm_bindgen(js_name = alignOnFrame)]
+        pub fn align_on_frame(
+            &self,
+            direction_x: f64,
+            direction_y: f64,
+            buff: f64,
+        ) -> Result<(), JsValue> {
+            self.layout
+                .align_on_frame((direction_x, direction_y), buff)
+                .map_err(js_error)
+        }
+
         #[wasm_bindgen(js_name = shiftBy)]
         pub fn shift_by(&self, delta_x: f64, delta_y: f64) -> Result<(), JsValue> {
             self.layout.shift(delta_x, delta_y).map_err(js_error)

--- a/crates/noon-web/src/canonical_authoring_scene.rs
+++ b/crates/noon-web/src/canonical_authoring_scene.rs
@@ -5071,6 +5071,22 @@ mod wasm {
                 .map_err(js_error)
         }
 
+        #[wasm_bindgen(js_name = liveAlignFamilyOnFrame)]
+        pub fn live_align_family_on_frame(
+            &mut self,
+            handle: &crate::WasmAuthoringFamilyHandle,
+            direction_x: f64,
+            direction_y: f64,
+            buff: f64,
+        ) -> Result<(), JsValue> {
+            let family = handle.semantic_family()?;
+            self.inner
+                .active_live_player()
+                .map_err(js_error)?
+                .live_align_family_on_frame(&family, (direction_x, direction_y), buff)
+                .map_err(js_error)
+        }
+
         #[wasm_bindgen(js_name = liveAlignFamilyToPoint)]
         #[allow(clippy::too_many_arguments)]
         pub fn live_align_family_to_point(

--- a/crates/noon-web/src/semantic_execution_player.rs
+++ b/crates/noon-web/src/semantic_execution_player.rs
@@ -863,7 +863,7 @@ impl SemanticExecutionPlayer {
             .map(|_| ())
     }
 
-    #[cfg(any(target_arch = "wasm32", test))]
+    #[cfg(target_arch = "wasm32")]
     pub(crate) fn live_align_family_on_frame(
         &mut self,
         family: &noon::MobjectFamily,

--- a/crates/noon-web/src/semantic_execution_player.rs
+++ b/crates/noon-web/src/semantic_execution_player.rs
@@ -864,6 +864,17 @@ impl SemanticExecutionPlayer {
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
+    pub(crate) fn live_align_family_on_frame(
+        &mut self,
+        family: &noon::MobjectFamily,
+        direction: (f64, f64),
+        buff: f64,
+    ) -> Result<(), String> {
+        self.with_live_session(|live| live.align_family_on_frame(family, direction, buff))
+            .map(|_| ())
+    }
+
+    #[cfg(any(target_arch = "wasm32", test))]
     pub(crate) fn live_align_family_to(
         &mut self,
         family: &noon::MobjectFamily,

--- a/crates/noon/src/example_scenes/family_placement.rs
+++ b/crates/noon/src/example_scenes/family_placement.rs
@@ -62,9 +62,39 @@ pub fn session() -> Result<ExecutionSession, String> {
     family
         .layout()?
         .move_to(Target::Family(&target.layout()?), (0.0, 0.0), (1.0, 0.0))?;
+    // Exercise shared frame placement, then restore the demonstration layout.
+    let center = family.layout()?.center();
+    family.layout()?.align_on_frame((2.0, 1.0), 0.25)?;
+    let corner = family.layout()?.critical_point(1.0, 1.0);
+    assert!((corner.0 - (f64::from(noon_core::DEFAULT_FRAME_WIDTH) * 0.5 - 0.5)).abs() < 1e-6);
+    assert!((corner.1 - 3.75).abs() < 1e-6);
+    family
+        .layout()?
+        .move_to(Target::Point(center.0, center.1), (0.0, 0.0), (1.0, 1.0))?;
     family.shift(0.0, 0.2)?;
     for object in [&first, &second, &anchor] {
         scene.add(object).map_err(|error| error.to_string())?;
     }
-    scene.execution_session().map_err(|e| e.to_string())
+    let mut execution = scene.execution_session().map_err(|e| e.to_string())?;
+    {
+        let mut live = scene.live(&mut execution);
+        let center = live
+            .effective_family_layout(&family)
+            .map_err(|e| e.to_string())?
+            .center;
+        live.align_family_on_frame(&family, (0.0, -1.0), 0.5)
+            .map_err(|e| e.to_string())?;
+        let layout = live
+            .effective_family_layout(&family)
+            .map_err(|e| e.to_string())?;
+        assert!((layout.center.1 - layout.height * 0.5 + 3.5).abs() < 1e-6);
+        live.move_family_to(
+            &family,
+            crate::LiveLayoutTarget::Point(center.0, center.1),
+            (0.0, 0.0),
+            (1.0, 1.0),
+        )
+        .map_err(|e| e.to_string())?;
+    }
+    Ok(execution)
 }

--- a/crates/noon/src/family_layout.rs
+++ b/crates/noon/src/family_layout.rs
@@ -214,6 +214,13 @@ impl FamilyLayout {
             .apply(&mut self.store.borrow_mut())
     }
 
+    /// Align selected family edges to the default frame in one transaction.
+    /// Direction magnitude scales the buffer, as with object frame alignment.
+    pub fn align_on_frame(&self, direction: (f64, f64), buff: f64) -> Result<(), String> {
+        let target = frame_alignment_target(direction, buff)?;
+        self.align_to(FamilyLayoutTarget::Point(target.0, target.1), direction)
+    }
+
     pub fn move_to(
         &self,
         target: FamilyLayoutTarget<'_>,
@@ -350,4 +357,24 @@ pub(crate) fn bounds_critical_point(bounds: Option<Bounds2D64>, x: f64, y: f64) 
             (b.min_y + b.max_y) * 0.5
         },
     )
+}
+
+/// Shared frame target; placement owns bounds, alias selection and publication.
+pub(crate) fn frame_alignment_target(
+    direction: (f64, f64),
+    buff: f64,
+) -> Result<(f64, f64), String> {
+    let direction = authoring_xy_f64(direction.0, direction.1)?;
+    let buff = authoring_render_f64("buffer", buff)?;
+    let coordinate = |direction: f64, extent: f32| {
+        if direction == 0.0 {
+            0.0
+        } else {
+            direction.signum() * f64::from(extent) * 0.5 - direction * buff
+        }
+    };
+    Ok((
+        coordinate(direction.x, noon_core::DEFAULT_FRAME_WIDTH),
+        coordinate(direction.y, noon_core::DEFAULT_FRAME_HEIGHT),
+    ))
 }

--- a/crates/noon/src/live_session/family_layout.rs
+++ b/crates/noon/src/live_session/family_layout.rs
@@ -216,6 +216,22 @@ impl LiveSession<'_> {
         self.place_family(family, target, RelativePlacement::Next(args))
     }
 
+    /// Align effective family bounds and publish only the selected leaves.
+    pub fn align_family_on_frame(
+        &mut self,
+        family: &MobjectFamily,
+        direction: (f64, f64),
+        buff: f64,
+    ) -> Result<SemanticMutationTransactionResult, LiveSessionError> {
+        let target = crate::family_layout::frame_alignment_target(direction, buff)
+            .map_err(LiveSessionError::Mobject)?;
+        self.align_family_to(
+            family,
+            LiveLayoutTarget::Point(target.0, target.1),
+            direction,
+        )
+    }
+
     pub fn align_family_to(
         &mut self,
         family: &MobjectFamily,

--- a/crates/noon/src/semantic_mobject/layout.rs
+++ b/crates/noon/src/semantic_mobject/layout.rs
@@ -161,19 +161,8 @@ impl Mobject {
         buff: f64,
     ) -> Result<(), String> {
         self.validate().map_err(|error| error.to_string())?;
-        finite_f32("direction.x", direction_x)?;
-        finite_f32("direction.y", direction_y)?;
-        let point = self.critical_point(direction_x, direction_y)?;
-        let mut shift_x = 0.0;
-        let mut shift_y = 0.0;
-        if direction_x != 0.0 {
-            let target = direction_x.signum() * f64::from(noon_core::DEFAULT_FRAME_WIDTH) * 0.5;
-            shift_x = target - point.0 - direction_x * buff;
-        }
-        if direction_y != 0.0 {
-            let target = direction_y.signum() * f64::from(noon_core::DEFAULT_FRAME_HEIGHT) * 0.5;
-            shift_y = target - point.1 - direction_y * buff;
-        }
-        self.shift(shift_x, shift_y)
+        let target =
+            crate::family_layout::frame_alignment_target((direction_x, direction_y), buff)?;
+        self.align_to_point(target.0, target.1, direction_x, direction_y)
     }
 }

--- a/crates/noon/tests/family_layout.rs
+++ b/crates/noon/tests/family_layout.rs
@@ -154,3 +154,61 @@ fn object_placement_to_family_anchor_is_shared_and_rejects_foreign_targets() {
     );
     assert_eq!(object.center().unwrap(), (2.5, 2.5));
 }
+
+#[test]
+fn frame_alignment_deduplicates_nested_aliases_and_rejects_invalid_input_atomically() {
+    let scene = Scene::new();
+    let first = scene.square(1.0).unwrap();
+    let mut second = scene.square(1.0).unwrap();
+    second.shift(2.0, 0.0).unwrap();
+    let nested = scene.family(&[(&first).into(), (&second).into()]).unwrap();
+    let family = scene.family(&[(&first).into(), (&nested).into()]).unwrap();
+    let before = scene.integration_store().borrow().scene_revision();
+    family
+        .layout()
+        .unwrap()
+        .align_on_frame((2.0, -1.0), 0.25)
+        .unwrap();
+    let bounds = family.layout().unwrap().bounds().unwrap();
+    assert!((bounds.max_x - (f64::from(noon_core::DEFAULT_FRAME_WIDTH) * 0.5 - 0.5)).abs() < 1e-6);
+    assert!((bounds.min_y + f64::from(noon_core::DEFAULT_FRAME_HEIGHT) * 0.5 - 0.25).abs() < 1e-6);
+    assert!((second.center().unwrap().0 - first.center().unwrap().0 - 2.0).abs() < 1e-6);
+    assert_eq!(
+        scene.integration_store().borrow().scene_revision(),
+        before.checked_next().unwrap()
+    );
+
+    let revision = scene.integration_store().borrow().scene_revision();
+    for (direction, buff) in [((f64::NAN, 1.0), 0.0), ((1.0, 0.0), f64::INFINITY)] {
+        assert!(family
+            .layout()
+            .unwrap()
+            .align_on_frame(direction, buff)
+            .is_err());
+    }
+    assert_eq!(
+        scene.integration_store().borrow().scene_revision(),
+        revision
+    );
+    assert_eq!(family.layout().unwrap().bounds().unwrap(), bounds);
+
+    let y = first.center().unwrap().1;
+    family
+        .layout()
+        .unwrap()
+        .align_on_frame((-1.0, 0.0), 0.5)
+        .unwrap();
+    assert_eq!(first.center().unwrap().1, y);
+    assert!(
+        (family.layout().unwrap().bounds().unwrap().min_x
+            + f64::from(noon_core::DEFAULT_FRAME_WIDTH) * 0.5
+            - 0.5)
+            .abs()
+            < 1e-6
+    );
+}
+
+#[test]
+fn paired_frame_placement_example_executes_the_typed_rust_path() {
+    noon::example_scenes::family_placement::session().unwrap();
+}

--- a/crates/noon/tests/live_family_layout.rs
+++ b/crates/noon/tests/live_family_layout.rs
@@ -175,3 +175,53 @@ fn object_move_to_family_anchor_reads_effective_bounds_and_stays_local() {
     }
     assert_eq!(execution.take_frame_changes().object_indices(), &[0]);
 }
+
+#[test]
+fn live_frame_alignment_keeps_aliases_local_and_rejects_active_drivers() {
+    let mut scene = Scene::new();
+    let first = scene.square(1.0).unwrap();
+    let mut second = scene.square(1.0).unwrap();
+    second.shift(2.0, 0.0).unwrap();
+    let unrelated = scene.square(1.0).unwrap();
+    let nested = scene.family(&[(&first).into(), (&second).into()]).unwrap();
+    let family = scene.family(&[(&first).into(), (&nested).into()]).unwrap();
+    for object in [&first, &second, &unrelated] {
+        scene.add(object).unwrap();
+    }
+    let mut target = first.target_editor().unwrap();
+    target.shift(1.0, 0.0).unwrap();
+    let animation = scene
+        .declare_transform_to(&first, &target, AnimationOptions::new().run_time(1.0))
+        .unwrap();
+    let mut execution = scene.execution_session().unwrap();
+    execution.take_frame_changes();
+    {
+        let mut live = scene.live(&mut execution);
+        let result = live
+            .align_family_on_frame(&family, (0.0, 1.0), 0.25)
+            .unwrap();
+        assert_eq!(result.impacts().len(), 2);
+        let layout = live.effective_family_layout(&family).unwrap();
+        close(layout.center.1 + layout.height * 0.5, 3.75);
+        close(second.center().unwrap().0 - first.center().unwrap().0, 2.0);
+        assert_eq!(unrelated.center().unwrap(), (0.0, 0.0));
+    }
+    assert_eq!(execution.take_frame_changes().object_indices(), &[0, 1]);
+    let mut live = scene.live(&mut execution);
+    let segment = live.play_animation(&animation).unwrap();
+    live.advance_segment_to(segment, 0.5).unwrap();
+    let before = live.effective_family_layout(&family).unwrap();
+    let revision = scene.integration_store().borrow().scene_revision();
+    assert!(live
+        .align_family_on_frame(&family, (1.0, 0.0), 0.25)
+        .is_err());
+    assert_eq!(live.effective_family_layout(&family).unwrap(), before);
+    assert_eq!(
+        scene.integration_store().borrow().scene_revision(),
+        revision
+    );
+    live.advance_segment_to(segment, 1.0).unwrap();
+    live.complete_segment(segment).unwrap();
+    live.align_family_on_frame(&family, (1.0, 0.0), 0.25)
+        .unwrap();
+}

--- a/web/python/_manim_compat.py
+++ b/web/python/_manim_compat.py
@@ -349,21 +349,8 @@ class Group(Mobject):
         return self._align_on_frame(_base._as_vec2(_base.DL if corner is None else corner), float(buff))
 
     def _align_on_frame(self, direction: _base.Vec2, buff: float) -> Group:
-        point = _critical_for(self, direction)
-        target = _base.Vec2(
-            math.copysign(_base.DEFAULT_FRAME_WIDTH / 2.0, direction.x)
-            if direction.x
-            else point.x,
-            math.copysign(_base.DEFAULT_FRAME_HEIGHT / 2.0, direction.y)
-            if direction.y
-            else point.y,
-        )
-        return self.shift(
-            _base.Vec2(
-                target.x - point.x - (direction.x * buff if direction.x else 0.0),
-                target.y - point.y - (direction.y * buff if direction.y else 0.0),
-            )
-        )
+        return _base._semantic_operations()._group_align_on_frame(self, direction, buff)
+
 
     def arrange(
         self,

--- a/web/python/_manim_semantic_handles.py
+++ b/web/python/_manim_semantic_handles.py
@@ -1462,6 +1462,19 @@ def _group_move_to(
 
 
 
+def _group_align_on_frame(self: _compat.Group, direction: _base.Vec2, buff: float):
+    context = _group_live_layout_context(self)
+    if context is not None:
+        context.liveAlignFamilyOnFrame(self._semantic_family_handle,
+                                       direction.x, direction.y, float(buff))
+    else:
+        layout = _shared_family_layout(self, mutation=True)
+        if layout is None:
+            raise RuntimeError("frame alignment requires current shared Rust semantic handles")
+        layout.alignOnFrame(direction.x, direction.y, float(buff))
+    return self
+
+
 def _group_align_to(
     self: _compat.Group,
     mobject_or_point: object,

--- a/web/python/examples/ordinary_family_placement.py
+++ b/web/python/examples/ordinary_family_placement.py
@@ -20,10 +20,19 @@ class OrdinaryFamilyPlacement(Scene):
                        index_of_submobject_to_align=0)
         family.align_to(UP, UP)
         family.move_to(target, coor_mask=(1, 0, 0))
+        center = family.get_center()
+        family.to_corner(2 * RIGHT + UP, buff=0.25)
+        assert abs(family.get_right().x - (DEFAULT_FRAME_WIDTH / 2 - 0.5)) < 1e-6
+        assert abs(family.get_top().y - 3.75) < 1e-6
+        family.move_to(center)
         family.shift(0.2 * UP)
         self.add(first, second, anchor)
         self.wait(1)
         # After the barrier, the same typed target observes live effective bounds.
+        center = family.get_center()
+        family.to_edge(DOWN, buff=0.5)
+        assert abs(family.get_bottom().y + 3.5) < 1e-6
+        family.move_to(center)
         before = first.get_center()
         first.move_to(target, coor_mask=(0, 0, 0))
         assert abs(first.get_center().x - before.x) < 1e-6

--- a/web/python/test_manim_shared_family_relative_placement.py
+++ b/web/python/test_manim_shared_family_relative_placement.py
@@ -94,6 +94,9 @@ class ManimSharedFamilyRelativePlacementTests(unittest.TestCase):
                     assert len(target.members) == 1
                     return self._apply(-2.0, 0.0)
 
+                def alignOnFrame(self, *args):
+                    self.store.frame_calls.append(tuple(float(value) for value in args))
+
                 def criticalX(self, direction_x, direction_y):
                     raise AssertionError("Python must not derive family relative-placement deltas")
 
@@ -123,6 +126,7 @@ class ManimSharedFamilyRelativePlacementTests(unittest.TestCase):
                 def __init__(self):
                     self.next_identity = 0
                     self.entities = {}
+                    self.frame_calls = []
                     self.next_to_point = []
                     self.next_to_family = []
                     self.align_to_point = []
@@ -182,6 +186,13 @@ class ManimSharedFamilyRelativePlacementTests(unittest.TestCase):
             assert first._semantic_handle.shift_calls[-1] == (-2.0, 0.0)
             assert store.finishes == 4
 
+            # Frame semantics must be delegated without Python bounds or shifts.
+            _manim_compat._critical_for = lambda *_: (_ for _ in ()).throw(AssertionError("Python bounds"))
+            family.to_edge(2 * RIGHT, buff=0.25)
+            family.to_corner(RIGHT + UP, buff=0.5)
+            assert store.frame_calls == [(2.0, 0.0, 0.25), (1.0, 1.0, 0.5)]
+            assert store.finishes == 4
+
             # A stale member must not leave a partially translated family.
             first._semantic_handle_fresh = False
             before = list(store.applied)
@@ -190,6 +201,7 @@ class ManimSharedFamilyRelativePlacementTests(unittest.TestCase):
                 lambda: family.align_to((1, 2)),
                 lambda: family.next_to((1, 2)),
                 lambda: family.arrange(),
+                lambda: family.to_edge(),
             ):
                 try:
                     operation()


### PR DESCRIPTION
Merged as 92008c2be0a2951d7d33131dfaeac800a6bcc320.

Group.to_edge/to_corner currently calculate frame targets and shifts in Python. Route those operations through shared Rust family layout and its existing atomic placement transaction. Ordinary object placement reuses the same frame-target calculation; live family placement uses coherent effective bounds and the existing publication lane.

Advances #61 / Phase A3 under #953. Rust semantic layout owns direction/buffer semantics, bounds, unique leaf selection and validation. Browser exports and Python only adapt arguments. No scene authority, scheduler, transport boundary or compatibility layer is added. Work remains proportional to the selected family; active affine drivers reject before publication.

Paired ordinary_family_placement Rust/Python examples exercise authored corners and live edges, then restore their layout. Focused tests cover nested aliases, nonunit directions, axis masking, atomic invalid-input/active-driver rejection, recovery and exactly the two affected runtime objects. The existing Python dispatch test prevents bounds arithmetic from returning to this operation.

Passed locally:
- CARGO_TARGET_DIR=/tmp/noon-geometry-check CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 cargo test -p noon --no-default-features --test family_layout --test live_family_layout --quiet (12 passed, including executable Rust example)
- PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s web/python -p test_manim_shared_family_relative_placement.py
- bash scripts/check.sh architecture
- cargo fmt --all
- git diff --check

Final sourcec9f1d77acc2f317c688c9b4c419cdc7750d2f006 passed full qualification34388784773: scripts/check.sh full5b561243 with default optimized release WASM, then the existing actual shared-authoring browser suite. Evidence artifact10119591838 retains logs/package/lock identities. All final normal PR checks passed, including native host, provider variants, product, Chromium, Firefox and mobile WebKit. Complete local web preflight passed174 Python tests with11 browser-only skips (distinct from actual browser qualification). The first full run34388475364 failed strict dead_code for a browser-only forwarding method compiled into native tests; final source limits that method to wasm32 and passes the unchanged strict gate. No warnings were suppressed. The existing String-returning layout APIs are being converted by parallel #1354; preserve its typed signatures and this shared helper when integrating. Callback-phase family shifts and shared critical-point queries remain separately tracked in #61. This PR does not claim Phase A completion.

Final source review: shared frame targets feed existing authored/live placement; unique leaf selection, guard-before-publication and local runtime deltas are retained. Rust native/direct-WASM paths stay typed; no new authority, scheduler or engine codec. Development qualification workflow remains outside this PR and is removed after landing.

Downloaded full artifact10119591838 confirms1,711 Rust passes,zero failures,3 existing ignored tests across119 result blocks. The default optimized package validates161 API contracts.
