### PR TITLE
refactor: read shared family layout directly from Python

### DIFF
--- a/compat/semantic-ownership-v1.json
+++ b/compat/semantic-ownership-v1.json
@@ -191,7 +191,7 @@
       "surface": "Deterministic Group/VGroup aggregate bounds, center, width/height, and critical-point queries",
       "classification": "shared-rust",
       "owner": {"language": "rust", "path": "crates/noon/src/family_layout.rs", "symbol": "MobjectFamily::layout/FamilyLayout"},
-      "adapters": [{"language": "python", "path": "web/python/_manim_semantic_handles.py", "symbol": "_compat_bounds_for"}],
+      "adapters": [{"language": "python", "path": "web/python/_manim_semantic_handles.py", "symbol": "_group_layout_observation"}],
       "reason": "Rust aggregates semantic family membership using authored bounds or current effective runtime transforms through LiveSession. Python only checks local wrapper eligibility; it cannot feed per-leaf bounds or construct a partial observation."
     },
     {

--- a/web/python/_manim_compat.py
+++ b/web/python/_manim_compat.py
@@ -167,22 +167,6 @@ def _leaf_mobjects(value: object) -> list[Mobject]:
     raise TypeError("expected a Mobject or Group")
 
 
-def _bounds_for(value: object) -> tuple[_base.Vec2, _base.Vec2] | None:
-    return _base._semantic_operations()._compat_bounds_for(value)
-
-
-def _critical_for(value: object, direction: _base.Vec2) -> _base.Vec2:
-    bounds = _bounds_for(value)
-    if bounds is None:
-        return _base.ORIGIN
-    minimum, maximum = bounds
-    center = (minimum + maximum) * 0.5
-    return _base.Vec2(
-        minimum.x if direction.x < 0 else maximum.x if direction.x > 0 else center.x,
-        minimum.y if direction.y < 0 else maximum.y if direction.y > 0 else center.y,
-    )
-
-
 def _rotation_angle_2d(angle: float, axis: object = OUT) -> float:
     try:
         if len(axis) != 3:  # type: ignore[arg-type]
@@ -249,20 +233,15 @@ class Group(Mobject):
         return _group_copy(self)
 
     def get_center(self) -> _base.Vec2:
-        bounds = _bounds_for(self)
-        if bounds is None:
-            return _base.ORIGIN
-        return (bounds[0] + bounds[1]) * 0.5
+        return _base._semantic_operations()._get_center(self)
 
     @property
     def width(self) -> float:
-        bounds = _bounds_for(self)
-        return 0.0 if bounds is None else bounds[1].x - bounds[0].x
+        return _base._semantic_operations()._width(self)
 
     @property
     def height(self) -> float:
-        bounds = _bounds_for(self)
-        return 0.0 if bounds is None else bounds[1].y - bounds[0].y
+        return _base._semantic_operations()._height(self)
 
     def shift(self, direction: object) -> Group:
         return _base._semantic_operations()._group_shift(self, direction)
@@ -279,12 +258,10 @@ class Group(Mobject):
         return self.move_to(_base.ORIGIN)
 
     def set_x(self, x: float) -> Group:
-        center = self.get_center()
-        return self.shift(_base.Vec2(float(x) - center.x, 0.0))
+        return self.move_to(_base.Vec2(float(x), 0.0), coor_mask=(1.0, 0.0, 0.0))
 
     def set_y(self, y: float) -> Group:
-        center = self.get_center()
-        return self.shift(_base.Vec2(0.0, float(y) - center.y))
+        return self.move_to(_base.Vec2(0.0, float(y)), coor_mask=(0.0, 1.0, 0.0))
 
     def scale(self, factor: float | tuple[float, float]) -> Group:
         from _manim_semantic_handles import _group_scale

--- a/web/python/_manim_semantic_handles.py
+++ b/web/python/_manim_semantic_handles.py
@@ -598,6 +598,9 @@ def _target_mobject(self: _base.Mobject) -> _base.Mobject:
 
 
 def _get_center(self: _base.Mobject) -> _base.Vec2:
+    if isinstance(self, _compat.Group):
+        layout = _group_layout_observation(self)
+        return _base.Vec2(float(layout.centerX), float(layout.centerY))
     observed = _bound_layout_observation(self)
     if observed is not None:
         return _base.Vec2(float(observed.centerX), float(observed.centerY))
@@ -611,8 +614,9 @@ def _get_critical_point(self: _base.Mobject, direction: object) -> _base.Vec2:
     """Read a leaf critical point from the authoritative semantic layout."""
     axis = _base._as_vec2(direction)
     if isinstance(self, _compat.Group):
-        # Groups query their shared family handle rather than a leaf binding.
-        return _compat._critical_for(self, axis)
+        layout = _group_layout_observation(self)
+        return _base.Vec2(float(layout.criticalX(axis.x, axis.y)),
+                          float(layout.criticalY(axis.x, axis.y)))
     observed = _bound_layout_observation(self)
     if observed is not None:
         return _base.Vec2(
@@ -623,6 +627,8 @@ def _get_critical_point(self: _base.Mobject, direction: object) -> _base.Vec2:
 
 
 def _width(self: _base.Mobject) -> float:
+    if isinstance(self, _compat.Group):
+        return float(_group_layout_observation(self).width)
     observed = _bound_layout_observation(self)
     if observed is not None:
         return float(observed.width)
@@ -633,6 +639,8 @@ def _width(self: _base.Mobject) -> float:
 
 
 def _height(self: _base.Mobject) -> float:
+    if isinstance(self, _compat.Group):
+        return float(_group_layout_observation(self).height)
     observed = _bound_layout_observation(self)
     if observed is not None:
         return float(observed.height)
@@ -1553,41 +1561,14 @@ def _group_arrange(
     return self
 
 
-def _compat_bounds_for(value: object) -> tuple[_base.Vec2, _base.Vec2] | None:
-    if isinstance(value, _compat.Group):
-        context = _group_live_layout_context(value)
-        if context is not None:
-            layout = context.queryFamilyLayout(value._semantic_family_handle)
-            return (
-                _base.Vec2(float(layout.criticalX(-1.0, 0.0)), float(layout.criticalY(0.0, -1.0))),
-                _base.Vec2(float(layout.criticalX(1.0, 0.0)), float(layout.criticalY(0.0, 1.0))),
-            )
-    # Rust observes the complete semantic family directly. The wrapper list only
-    # selects whether this caller is eligible for the shared query.
-    if isinstance(value, _compat.Group):
-        shared = _shared_family_layout(value)
-        if shared is not None:
-            session = shared
-            return (
-                _base.Vec2(
-                    float(session.criticalX(-1.0, 0.0)),
-                    float(session.criticalY(0.0, -1.0)),
-                ),
-                _base.Vec2(
-                    float(session.criticalX(1.0, 0.0)),
-                    float(session.criticalY(0.0, 1.0)),
-                ),
-            )
-
-    if isinstance(value, _base.Mobject) and not isinstance(value, _compat.Group):
-        observed = _bound_layout_observation(value)
-        if observed is not None:
-            return (
-                _base.Vec2(float(observed.criticalX(-1.0, 0.0)), float(observed.criticalY(0.0, -1.0))),
-                _base.Vec2(float(observed.criticalX(1.0, 0.0)), float(observed.criticalY(0.0, 1.0))),
-            )
-        return _layout_bounds(value)
-    raise RuntimeError("family layout requires a current shared Rust semantic handle")
+def _group_layout_observation(value: _compat.Group):
+    context = _group_live_layout_context(value)
+    if context is not None:
+        return context.queryFamilyLayout(value._semantic_family_handle)
+    layout = _shared_family_layout(value)
+    if layout is None:
+        raise RuntimeError("family layout requires a current shared Rust semantic handle")
+    return layout
 
 
 def _family_member_handle(value: object) -> tuple[str | None, object | None]:

--- a/web/python/examples/ordinary_family_placement.py
+++ b/web/python/examples/ordinary_family_placement.py
@@ -21,6 +21,7 @@ class OrdinaryFamilyPlacement(Scene):
         family.align_to(UP, UP)
         family.move_to(target, coor_mask=(1, 0, 0))
         center = family.get_center()
+        family.set_x(center.x).set_y(center.y)
         family.to_corner(2 * RIGHT + UP, buff=0.25)
         assert abs(family.get_right().x - (DEFAULT_FRAME_WIDTH / 2 - 0.5)) < 1e-6
         assert abs(family.get_top().y - 3.75) < 1e-6
@@ -30,6 +31,7 @@ class OrdinaryFamilyPlacement(Scene):
         self.wait(1)
         # After the barrier, the same typed target observes live effective bounds.
         center = family.get_center()
+        family.set_x(center.x).set_y(center.y)
         family.to_edge(DOWN, buff=0.5)
         assert abs(family.get_bottom().y + 3.5) < 1e-6
         family.move_to(center)

--- a/web/python/test_manim_shared_constructors.py
+++ b/web/python/test_manim_shared_constructors.py
@@ -102,9 +102,9 @@ class ManimSharedConstructorTests(unittest.TestCase):
             public_methods = tuple(getattr(_manim_compat._base.Mobject, name)
                                    for name in ("__init__", "copy", "next_to", "width"))
             group_shift = _manim_compat.Group.shift
-            shared_bounds = _manim_compat._bounds_for
+            group_center = _manim_compat.Group.get_center
             import _manim_geometry
-            assert _manim_compat._bounds_for is shared_bounds
+            assert _manim_compat.Group.get_center is group_center
             import _manim_semantic_handles as handles
             assert not hasattr(handles, "install")
             assert public_methods == tuple(getattr(_manim_compat._base.Mobject, name)

--- a/web/python/test_manim_shared_family_identity.py
+++ b/web/python/test_manim_shared_family_identity.py
@@ -8,6 +8,35 @@ from pathlib import Path
 
 
 class ManimSharedFamilyIdentityTests(unittest.TestCase):
+    def test_live_observations_and_coordinates_delegate_without_python_bounds_math(self):
+        from types import SimpleNamespace
+        from unittest.mock import Mock, patch
+        import _manim_compat as compat
+        import _manim_semantic_handles as handles
+        from _typed_geometry_test_support import identity_only_wrapper
+
+        family = identity_only_wrapper(compat.VGroup, submobjects=[])
+        family._semantic_family_handle = object()
+        layout = SimpleNamespace(centerX=7, centerY=-2, width=99, height=13,
+                                 criticalX=Mock(return_value=42),
+                                 criticalY=Mock(return_value=-17))
+        context = SimpleNamespace(queryFamilyLayout=Mock(return_value=layout))
+        with patch.object(handles, "_group_live_layout_context", return_value=context):
+            self.assertEqual(family.get_center(), compat._base.Vec2(7, -2))
+            self.assertEqual((family.width, family.height), (99, 13))
+            self.assertEqual(family.get_critical_point(compat._base.RIGHT),
+                             compat._base.Vec2(42, -17))
+        layout.criticalX.assert_called_once_with(1.0, 0.0)
+        layout.criticalY.assert_called_once_with(1.0, 0.0)
+        family.move_to = Mock(return_value=family)
+        family.get_center = Mock(side_effect=AssertionError("Python coordinate delta"))
+        self.assertIs(family.set_x(5), family)
+        self.assertIs(family.set_y(-3), family)
+        self.assertEqual(family.move_to.call_args_list[0].args, (compat._base.Vec2(5, 0),))
+        self.assertEqual(family.move_to.call_args_list[0].kwargs, {"coor_mask": (1.0, 0.0, 0.0)})
+        self.assertEqual(family.move_to.call_args_list[1].args, (compat._base.Vec2(0, -3),))
+        self.assertEqual(family.move_to.call_args_list[1].kwargs, {"coor_mask": (0.0, 1.0, 0.0)})
+
     def test_group_wrapper_mirrors_shared_family_membership(self) -> None:
         python_dir = Path(__file__).resolve().parent
         env = os.environ.copy()
@@ -55,6 +84,11 @@ class ManimSharedFamilyIdentityTests(unittest.TestCase):
 
 
             class FakeLayoutObservation:
+                centerX = 1.0
+                centerY = 1.0
+                width = 8.0
+                height = 6.0
+
                 def __init__(self, store):
                     self.store = store
                     store.layout_queries += 1

--- a/web/python/test_manim_shared_family_relative_placement.py
+++ b/web/python/test_manim_shared_family_relative_placement.py
@@ -187,7 +187,8 @@ class ManimSharedFamilyRelativePlacementTests(unittest.TestCase):
             assert store.finishes == 4
 
             # Frame semantics must be delegated without Python bounds or shifts.
-            _manim_compat._critical_for = lambda *_: (_ for _ in ()).throw(AssertionError("Python bounds"))
+            assert not hasattr(_manim_compat, "_critical_for")
+            assert not hasattr(_manim_compat, "_bounds_for")
             family.to_edge(2 * RIGHT, buff=0.25)
             family.to_corner(RIGHT + UP, buff=0.5)
             assert store.frame_calls == [(2.0, 0.0, 0.25), (1.0, 1.0, 0.5)]


### PR DESCRIPTION
Merged as 35658f4a9468ca44cc5dcfb97e7aae8b62e38e08.

Group getters currently reconstruct center, width, height and critical points in Python from shared bounds; set_x/set_y also compute relative shifts there. Consume existing Rust layout observation fields and critical-point methods directly, and send coordinate placement through existing masked move_to semantics.

Advances #61 / Phase A3 under #953. Deletes _bounds_for, _critical_for and _compat_bounds_for instead of keeping compatibility adapters. A single thin selector obtains the existing authored or live Rust observation; callback-phase eligibility remains unchanged. The semantic-ownership inventory follows the surviving adapter. No Rust, WASM API, runtime, scheduler, transport, or dependency change.

Paired ordinary_family_placement already exercises the shared Rust observations and placement; its Python example now also calls public set_x/set_y before authored and live frame placement. Existing identity tests cover shared authored observations; the added live test uses deliberately distinct returned values to prevent Python reconstruction and verifies masked placement without reading the center.

Passed:
- PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s web/python -p 'test_*.py' (175 run,11 browser-only skips)
- bash scripts/check.sh architecture
- git diff --check

Stacked on #1357 for removal of its final _critical_for caller. Full Rust/WASM qualification belongs to that unchanged Rust prerequisite. Complete web preflight passed (175 tests,11 browser-only skips). Actual final-source browser qualification34389865343 passed both existing shared-authoring and Manim compatibility suites. It reused immutable artifact10119099724/run34388726983, binary source1bbae59d558cc176d95d066e936adf2d6f814901, after asserting identical Rust/build inputs and all manifest/lock hashes, and regenerated the worker from final source79a925a866297d2540e64b74ba4d9cba7f21fa6c. WASM SHA256e5056ab548c3620ef28b03ce69049cb2dcb18ec0990ab5a30177a2797ad27b60. Downloaded and inspected evidence10119411964. No Rust build was repeated for this facade cleanup. Callback family shift atomicity remains separate in #61.

Source review confirms the same authored/live eligibility, shared bounds and masked placement ownership, affected-family locality and absence of obsolete helper callers. Prerequisite #1357 full gate has now passed its native/default optimized-WASM step; its additional browser step also passed. Both #1357 and this PR are now merged; the prerequisite full/browser qualification passed.
