### PR TITLE
test: run Manim differential through the shared Rust host

### DIFF
--- a/.github/workflows/manim-differential.yml
+++ b/.github/workflows/manim-differential.yml
@@ -36,9 +36,10 @@ jobs:
             pkg-config
       - name: Install pinned ManimCE reference
         run: python -m pip install --disable-pip-version-check "manim==0.21.0"
-      - name: Compare supported Noon semantics with ManimCE
+      # Public Python semantic probes run in manim-raster-differential.yml,
+      # reusing its Rust/WASM package and browser host.
+      - name: Compare native geometry and frame sampling with ManimCE
         run: |
-          python scripts/manim-differential.py
           python scripts/manim-dot-ellipse-differential.py
           python scripts/manim-sector-differential.py
           python scripts/manim-elbow-differential.py

--- a/.github/workflows/manim-raster-differential.yml
+++ b/.github/workflows/manim-raster-differential.yml
@@ -6,6 +6,8 @@ on:
       - "web/semantic-preview-session*"
       - "web/manim-raster-host.js"
       - "scripts/semantic-preview-*"
+      - "scripts/manim-differential.py"
+      - "scripts/manim-differential-noon.mjs"
       - ".github/workflows/manim-raster-differential.yml"
   push:
     branches:
@@ -87,6 +89,19 @@ jobs:
         run: |
           npm install --no-save --ignore-scripts playwright@1.62.1 pngjs@7.0.0
           npx playwright install chromium
+      - name: Compare public Python semantics with pinned ManimCE
+        timeout-minutes: 5
+        run: |
+          node scripts/manim-differential-noon.mjs browser-smoke-artifacts/manim-differential/noon.json
+          python scripts/manim-differential.py --noon-observations browser-smoke-artifacts/manim-differential/noon.json --json > browser-smoke-artifacts/manim-differential/comparison.json
+      - name: Upload semantic differential observations
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: manim-semantic-differential
+          path: browser-smoke-artifacts/manim-differential
+          if-no-files-found: warn
+          retention-days: 7
       - name: Verify semantic preview frames, cancellation, and fresh-run recovery
         run: timeout --signal=TERM 180s node scripts/semantic-preview-smoke.mjs
       - name: Upload semantic preview evidence

--- a/scripts/manim-differential-noon.mjs
+++ b/scripts/manim-differential-noon.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+// Execute the existing semantic probes through the real Rust/WASM Python facade.
+import assert from "node:assert/strict";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+import { serveRepository } from "./browser-test-server.mjs";
+import { PYTHON_COMPAT_MODULES } from "../web/python-compat-modules.js";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const output = path.resolve(process.argv[2] ?? "browser-smoke-artifacts/manim-differential/noon.json");
+const worker = await readFile(path.join(root, "web/python-worker.source.js"), "utf8");
+const pyodideUrl = worker.match(/import \{ loadPyodide \} from "([^"]+)";/)?.[1];
+assert.ok(pyodideUrl, "use the product worker's pinned Pyodide");
+const modules = await Promise.all(PYTHON_COMPAT_MODULES.map(async ({ sourcePath, runtimePath }) => ({
+  runtimePath, source: await readFile(path.join(root, "web", sourcePath), "utf8"),
+})));
+const probes = await readFile(path.join(root, "scripts/manim-differential.py"), "utf8");
+const server = await serveRepository(root, Number(process.env.NOON_MANIM_DIFFERENTIAL_PORT ?? 8799));
+let browser;
+try {
+  browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+  page.setDefaultTimeout(180_000);
+  page.on("console", message => console.log(`[browser] ${message.text()}`));
+  await page.goto(`${server.baseUrl}/web/authoring-errors-smoke.html`);
+  const observations = await page.evaluate(async ({ modules, probes, pyodideUrl }) => {
+    const wasm = await import("/web/pkg/noon_web.js");
+    await wasm.default();
+    const { loadPyodide } = await import(pyodideUrl);
+    const pyodide = await loadPyodide();
+    const store = new wasm.WasmAuthoringStore();
+    // Only supply the same typed host entrypoints as the production worker.
+    // Geometry, identities, family traversal and all observations remain Rust-owned.
+    globalThis.noonCreateCanonicalAuthoringSceneContext = () => store.createSceneContext();
+    globalThis.noonAuthoringGeometryOptions = wasm.WasmManimGeometryOptions;
+    globalThis.noonAuthoringVectorPath = () => new wasm.WasmAuthoringVectorPath();
+    globalThis.noonCreateAuthoringGeometryHandle = options => store.createManimGeometry(options);
+    globalThis.noonAuthoringMembershipBatch = kind => new wasm.WasmSceneMembershipBatch(kind);
+    globalThis.noonCreateAuthoringFamilyHandle = batch => store.createFamily(batch);
+    for (const { runtimePath, source } of modules) pyodide.FS.writeFile(runtimePath, source);
+    pyodide.FS.writeFile("/tmp/noon_differential.py", probes);
+    return JSON.parse(await pyodide.runPythonAsync(`
+import sys, json
+sys.path.insert(0, "/tmp")
+from noon_differential import noon_observations
+json.dumps(noon_observations(), allow_nan=False)
+`));
+  }, { modules, probes, pyodideUrl });
+  await mkdir(path.dirname(output), { recursive: true });
+  await writeFile(output, `${JSON.stringify(observations, null, 2)}\n`);
+  console.log(`Observed ${Object.keys(observations).length} shared Rust/Python semantic fixtures`);
+} finally {
+  await browser?.close();
+  await server.close();
+}

--- a/scripts/manim-differential.py
+++ b/scripts/manim-differential.py
@@ -2,9 +2,10 @@
 """Differential semantic probes against a pinned ManimCE reference.
 
 This suite intentionally compares small, renderer-independent observables.  It is
-not a screenshot test and it does not require constructing a Manim Scene.  Each
-fixture runs the equivalent operation through Noon and ManimCE, normalizes the
-result to JSON-like data, and reports a structural diff on mismatch.
+not a screenshot test and it does not require constructing a Manim Scene.  Noon probes run in Pyodide with the shared Rust/WASM host; this CPython
+comparison reads their observations and executes the equivalent pinned ManimCE
+probes. It reports a structural diff on mismatch. Serialized observations are a
+test boundary, never engine input.
 
 Add new probes only for behavior Noon claims to support.  Unsupported behavior
 belongs in ``UNSUPPORTED`` below until an implementation PR promotes it to a
@@ -34,11 +35,12 @@ import noon as noon  # noqa: E402
 
 try:
     import manim as manim  # noqa: E402
-except ImportError as exc:  # pragma: no cover - exercised by the CI environment
-    raise SystemExit(
-        "ManimCE is required for the differential suite. "
-        "Install the version pinned by .github/workflows/manim-differential.yml."
-    ) from exc
+except ModuleNotFoundError as exc:
+    if exc.name != "manim":
+        raise
+    # Noon probes run in Pyodide with the real Rust host; the pinned reference
+    # runs separately in CPython. Neither host emulates the other engine.
+    manim = None
 
 PINNED_MANIM_VERSION = "0.21.0"
 
@@ -595,11 +597,29 @@ def _compare(expected: Any, actual: Any, tolerance: float, path: str = "$") -> l
     return errors
 
 
+def noon_observations() -> dict[str, Any]:
+    """Observe the existing probes in a host with shared Rust authoring installed."""
+    return {fixture.name: fixture.noon_probe() for fixture in FIXTURES}
+
+
+def load_noon_observations(path: Path) -> dict[str, Any]:
+    observations = json.loads(path.read_text())
+    expected = {fixture.name for fixture in FIXTURES}
+    if not isinstance(observations, dict) or set(observations) != expected:
+        raise ValueError("Noon observations must contain exactly the supported fixture names")
+    return observations
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--json", action="store_true", help="emit machine-readable results")
+    parser.add_argument("--noon-observations", type=Path, required=True,
+                        help="observations from manim-differential-noon.mjs")
     args = parser.parse_args()
+    observations = load_noon_observations(args.noon_observations)
 
+    if manim is None:
+        raise SystemExit("Install the pinned ManimCE reference to compare observations")
     if manim.__version__ != PINNED_MANIM_VERSION:
         raise SystemExit(
             f"expected ManimCE {PINNED_MANIM_VERSION}, found {manim.__version__}; "
@@ -609,7 +629,7 @@ def main() -> int:
     results: list[dict[str, Any]] = []
     failures = 0
     for fixture in FIXTURES:
-        noon_value = fixture.noon_probe()
+        noon_value = observations[fixture.name]
         manim_value = fixture.manim_probe()
         differences = _compare(noon_value, manim_value, fixture.tolerance)
         status = "pass" if not differences else "mismatch"


### PR DESCRIPTION
Bare CPython can no longer construct Noon objects after the shared Rust facade migration. The existing Manim differential therefore failed before its first comparison. Run the same 34 Noon probes in Pyodide with the real Rust/WASM authoring host and feed their test-only observations to the unchanged pinned ManimCE probes and tolerances. Reject missing or extra fixture observations.

Advances #961 / #953. The semantic differential reuses the existing raster workflow’s Rust package, browser setup and Manim installation, avoiding a separate engine build. Native geometry and frame-sampling comparisons remain in the original differential workflow. No production API, engine authority, semantic behavior, compatibility fallback or migration seam changes. JSON exists only between independent test oracle processes; runtime locality is unchanged.

Validation: actual local Chromium/Pyodide execution produced all 34 observations using the retained qualified #1363 package (WASM bb7d6f131e900ed15874ae4430a3b51cdbc73304abcf15b9288689006b3e1e0e); no Rust rebuild. Python/Node syntax, missing/extra/non-object fixture rejection, mismatch/NaN rejection and git diff checks passed. `bash scripts/check.sh fast` completed the architecture and formatting checks, then was stopped before the unnecessary unchanged workspace compilation; this is not a full/fast pass. Existing full34397963714 covers unchanged engine inputs. Final qualification passed: Manim raster workflow 34405736575 completed successfully, including all 34/34 original semantic comparisons against pinned ManimCE 0.21.0, raster comparisons, and shared sparse/dense playback. Comparison artifact 10125440690 retains the numerical results. All applicable PR checks passed; merged as da1b42a1b2ffbb5f49db0df2df77a4349eda8272. Local Manim was not installed; the actual oracle ran in GitHub CI.

Paired semantics remain the original public-Python/Manim fixtures alongside the existing native Rust geometry oracles. No fixture body or numerical tolerance was weakened.

