### PR TITLE
fix: preserve accepted public Rust errors through the Python facade

### DIFF
--- a/crates/noon-web/src/authoring_error.rs
+++ b/crates/noon-web/src/authoring_error.rs
@@ -128,18 +128,318 @@ impl From<AuthoringError> for AuthoringFailure {
                 "authoring.missing_text_resource",
                 message,
             ),
+            AuthoringError::Unsupported(cause) => Self::caused_by(
+                "authoring.unsupported",
+                message,
+                Self::new(
+                    "unsupported_operation",
+                    "authoring.unsupported_operation",
+                    cause,
+                ),
+            ),
             AuthoringError::InvalidRenderNumber { .. } => {
                 Self::new("invalid_input", "authoring.invalid_render_number", message)
+            }
+            AuthoringError::NonPositiveNumber { .. } => {
+                Self::new("invalid_input", "authoring.non_positive_number", message)
             }
             AuthoringError::InvalidOpacity { .. } => {
                 Self::new("invalid_input", "authoring.invalid_opacity", message)
             }
+            AuthoringError::InvalidEllipseDimensions { .. } => Self::new(
+                "invalid_input",
+                "authoring.invalid_ellipse_dimensions",
+                message,
+            ),
+            AuthoringError::NonFiniteGeometry => {
+                Self::new("invalid_input", "authoring.non_finite_geometry", message)
+            }
+            AuthoringError::NonFiniteObjectState => Self::new(
+                "invalid_input",
+                "authoring.non_finite_object_state",
+                message,
+            ),
+            AuthoringError::NonFiniteTransform => {
+                Self::new("invalid_input", "authoring.non_finite_transform", message)
+            }
+            AuthoringError::NonFiniteStyle => {
+                Self::new("invalid_input", "authoring.non_finite_style", message)
+            }
             AuthoringError::NegativeStrokeWidth(_) => {
                 Self::new("invalid_input", "authoring.negative_stroke_width", message)
+            }
+            AuthoringError::InvalidStrokeWidthMode(_) => Self::new(
+                "invalid_input",
+                "authoring.invalid_stroke_width_mode",
+                message,
+            ),
+            AuthoringError::InvalidStrokeJoin(_) => {
+                Self::new("invalid_input", "authoring.invalid_stroke_join", message)
+            }
+            AuthoringError::InvalidStrokeCap(_) => {
+                Self::new("invalid_input", "authoring.invalid_stroke_cap", message)
+            }
+            AuthoringError::NonFiniteDirection => {
+                Self::new("invalid_input", "authoring.non_finite_direction", message)
+            }
+            AuthoringError::ZeroDirection => {
+                Self::new("invalid_input", "authoring.zero_direction", message)
+            }
+            AuthoringError::NonFiniteLineEndpoints => Self::new(
+                "invalid_input",
+                "authoring.non_finite_line_endpoints",
+                message,
+            ),
+            AuthoringError::DegenerateLine => {
+                Self::new("invalid_input", "authoring.degenerate_line", message)
+            }
+            AuthoringError::UnorderedBounds(_) => {
+                Self::new("invalid_input", "authoring.unordered_bounds", message)
+            }
+            AuthoringError::InvalidDimension(_) => {
+                Self::new("invalid_input", "authoring.invalid_dimension", message)
+            }
+            AuthoringError::ZeroReplaceExtent => {
+                Self::new("invalid_input", "authoring.zero_replace_extent", message)
+            }
+            AuthoringError::ZeroStretchTarget => {
+                Self::new("invalid_input", "authoring.zero_stretch_target", message)
+            }
+            AuthoringError::ZeroMatchHeight => {
+                Self::new("invalid_input", "authoring.zero_match_height", message)
+            }
+            AuthoringError::ZeroMatchWidth => {
+                Self::new("invalid_input", "authoring.zero_match_width", message)
+            }
+            AuthoringError::MissingLayoutBounds(_) => {
+                Self::new("invalid_input", "authoring.missing_layout_bounds", message)
+            }
+            AuthoringError::InvalidSubmobjectIndex { .. } => Self::new(
+                "invalid_input",
+                "authoring.invalid_submobject_index",
+                message,
+            ),
+            AuthoringError::InvalidGridDimensions { .. } => Self::new(
+                "invalid_input",
+                "authoring.invalid_grid_dimensions",
+                message,
+            ),
+            AuthoringError::InsufficientGridCapacity { .. } => Self::new(
+                "invalid_input",
+                "authoring.insufficient_grid_capacity",
+                message,
+            ),
+            AuthoringError::AlreadyScopedTracker(_) => {
+                Self::new("invalid_input", "authoring.already_scoped_tracker", message)
+            }
+            AuthoringError::EmptyInputName { .. } => {
+                Self::new("invalid_input", "authoring.empty_input_name", message)
+            }
+            AuthoringError::CameraRequiresEmptyScene(_) => Self::new(
+                "invalid_input",
+                "authoring.camera_requires_empty_scene",
+                message,
+            ),
+            AuthoringError::FamilyPairing(cause) => {
+                Self::caused_by("authoring.family_pairing", message, cause.into())
+            }
+            AuthoringError::VectorLowering(cause) => Self::caused_by(
+                "authoring.vector_lowering",
+                message,
+                Self::new("invalid_input", "vector.invalid_coordinates", cause),
+            ),
+            AuthoringError::GeometryResource(cause) => {
+                Self::caused_by("authoring.geometry_resource", message, cause.into())
+            }
+            AuthoringError::GeometryLayout(cause) => Self::caused_by(
+                "authoring.geometry_layout",
+                message,
+                Self::new("invalid_input", "geometry.invalid_layout", cause),
+            ),
+            AuthoringError::Arc(cause) => Self::caused_by(
+                "authoring.arc",
+                message,
+                Self::new("invalid_input", "arc.invalid_input", cause),
+            ),
+            AuthoringError::Elbow(cause) => Self::caused_by(
+                "authoring.elbow",
+                message,
+                Self::new("invalid_input", "elbow.invalid_input", cause),
+            ),
+            AuthoringError::RoundedRectangle(cause) => Self::caused_by(
+                "authoring.rounded_rectangle",
+                message,
+                Self::new("invalid_input", "rounded_rectangle.invalid_input", cause),
+            ),
+            AuthoringError::DashedLine(cause) => Self::caused_by(
+                "authoring.dashed_line",
+                message,
+                Self::new("invalid_input", "dashed_line.invalid_input", cause),
+            ),
+            AuthoringError::Signal(cause) => {
+                Self::caused_by("authoring.signal", message, cause.into())
+            }
+            AuthoringError::SignalBinding(cause) => {
+                Self::caused_by("authoring.signal_binding", message, cause.into())
+            }
+            AuthoringError::ScalarQuery(cause) => {
+                Self::caused_by("authoring.scalar_query", message, cause.into())
             }
             // The public producer is non-exhaustive; future domains must opt in
             // with a reviewed projection, not silently acquire a guessed class.
             other => Self::unclassified("authoring.unclassified", &other),
+        }
+    }
+}
+
+impl From<noon_core::AnimationOptionsError> for AuthoringFailure {
+    fn from(error: noon_core::AnimationOptionsError) -> Self {
+        use noon_core::AnimationOptionsError as E;
+        let (category, code) = match &error {
+            E::UnsupportedPathArc(_) => ("unsupported_operation", "animation.unsupported_path_arc"),
+            E::UnsupportedReverseRateFunction => {
+                ("unsupported_operation", "animation.unsupported_reverse")
+            }
+            E::InvalidRunTime(_) => ("invalid_input", "animation.invalid_run_time"),
+            E::InvalidLagRatio(_) => ("invalid_input", "animation.invalid_lag_ratio"),
+            E::InvalidPathArc(_) => ("invalid_input", "animation.invalid_path_arc"),
+        };
+        Self::new(category, code, error)
+    }
+}
+
+impl From<noon_core::GeometryResourceError> for AuthoringFailure {
+    fn from(error: noon_core::GeometryResourceError) -> Self {
+        use noon_core::GeometryResourceError as E;
+        match error {
+            E::NonFinitePath => Self::new("invalid_input", "geometry.non_finite_path", error),
+            E::UnknownResource(_) => {
+                Self::new("missing_resource", "geometry.unknown_resource", error)
+            }
+            _ => Self::unclassified("geometry.unclassified", &error),
+        }
+    }
+}
+
+impl From<noon_core::SemanticFamilyPairingError> for AuthoringFailure {
+    fn from(error: noon_core::SemanticFamilyPairingError) -> Self {
+        use noon_core::SemanticFamilyPairingError as E;
+        let (category, code) = match &error {
+            E::UnknownNode(_) => ("stale_handle", "family_pairing.unknown_node"),
+            E::RootIsNotFamily(_) => ("invalid_input", "family_pairing.not_family"),
+            E::Empty => ("invalid_input", "family_pairing.empty"),
+            E::TopologyMismatch { .. } => {
+                ("unsupported_operation", "family_pairing.topology_mismatch")
+            }
+            E::UnsupportedLeaf(_) => ("unsupported_operation", "family_pairing.unsupported_leaf"),
+            E::AliasMismatch { .. } => ("unsupported_operation", "family_pairing.alias_mismatch"),
+        };
+        Self::new(category, code, error)
+    }
+}
+
+impl From<noon_core::SemanticSignalError> for AuthoringFailure {
+    fn from(error: noon_core::SemanticSignalError) -> Self {
+        use noon_core::SemanticSignalError as E;
+        let (category, code) = match &error {
+            E::UnknownSignal(_) => ("stale_handle", "signal.unknown_signal"),
+            E::NotSignal(_) => ("invalid_input", "signal.not_signal"),
+            E::NonFiniteValue => ("invalid_input", "signal.non_finite_value"),
+            E::DependencyCycle(_) => ("invalid_input", "signal.dependency_cycle"),
+            E::InvalidNativeInputInitialValue { .. } => {
+                ("invalid_input", "signal.invalid_initial_value")
+            }
+            E::InvalidUnaryExpression { .. } => {
+                ("invalid_input", "signal.invalid_unary_expression")
+            }
+            E::InvalidBinaryExpression { .. } => {
+                ("invalid_input", "signal.invalid_binary_expression")
+            }
+            E::SourceTypeMismatch { .. } => ("invalid_input", "signal.source_type_mismatch"),
+            E::NativeInputRequiresInputSignal { .. } => {
+                ("invalid_input", "signal.native_input_requires_input")
+            }
+            E::NativeInputTypeMismatch { .. } => {
+                ("invalid_input", "signal.native_input_type_mismatch")
+            }
+            E::TimelineOwnedSignal { .. } => ("unsupported_operation", "signal.timeline_owned"),
+            E::NativeOwnedSignal { .. } => ("unsupported_operation", "signal.native_owned"),
+        };
+        Self::new(category, code, error)
+    }
+}
+
+impl From<noon_core::SemanticSignalBindingError> for AuthoringFailure {
+    fn from(error: noon_core::SemanticSignalBindingError) -> Self {
+        use noon_core::SemanticSignalBindingError as E;
+        let message = error.to_string();
+        match error {
+            E::Signal(cause) => Self::caused_by("binding.signal", message, cause.into()),
+            E::Target(cause) => Self::caused_by("binding.target", message, cause.into()),
+            E::TypeMismatch { .. } => Self::new("invalid_input", "binding.type_mismatch", message),
+            E::PropertyAlreadyBound { .. } => {
+                Self::new("invalid_input", "binding.property_already_bound", message)
+            }
+        }
+    }
+}
+
+impl From<noon_core::SemanticScalarSignalQueryError> for AuthoringFailure {
+    fn from(error: noon_core::SemanticScalarSignalQueryError) -> Self {
+        use noon_core::SemanticScalarSignalQueryError as E;
+        let message = error.to_string();
+        match error {
+            E::Signal(cause) => Self::caused_by("scalar_query.signal", message, cause.into()),
+            E::NotInputSignal(_) => Self::new("invalid_input", "scalar_query.not_input", message),
+            E::NonScalarSignal(_) => Self::new("invalid_input", "scalar_query.non_scalar", message),
+            E::InvalidTime => Self::new("invalid_input", "scalar_query.invalid_time", message),
+        }
+    }
+}
+
+impl From<noon::TextAuthoringError> for AuthoringFailure {
+    fn from(error: noon::TextAuthoringError) -> Self {
+        use noon::TextAuthoringError as E;
+        let message = error.to_string();
+        match error {
+            E::InvalidFontSize(_) => Self::new("invalid_input", "text.invalid_font_size", message),
+            E::InvalidOpacity(_) => Self::new("invalid_input", "text.invalid_opacity", message),
+            E::FontUnavailable(_) => {
+                Self::new("missing_resource", "text.font_unavailable", message)
+            }
+            E::MissingGeometryResource => {
+                Self::new("missing_resource", "text.missing_geometry", message)
+            }
+            E::MissingFontResource => Self::new("missing_resource", "text.missing_font", message),
+            E::Semantic(cause) => Self::caused_by("text.authoring", message, cause.into()),
+            E::Import(cause) => Self::caused_by("text.import", message, cause.into()),
+            // Provider diagnostics remain attached, without inventing provider policy.
+            other => Self::unclassified("text.provider", &other),
+        }
+    }
+}
+
+impl From<noon_core::SemanticTextImportError> for AuthoringFailure {
+    fn from(error: noon_core::SemanticTextImportError) -> Self {
+        use noon_core::SemanticTextImportError as E;
+        match error {
+            E::MissingFont(_) => Self::new("missing_resource", "text_import.missing_font", error),
+            E::MissingGeometry(_) => {
+                Self::new("missing_resource", "text_import.missing_geometry", error)
+            }
+            E::NonFiniteGeometry(_) => {
+                Self::new("invalid_input", "text_import.non_finite_geometry", error)
+            }
+            E::Validation(ref cause) => Self::caused_by(
+                "text_import.validation",
+                error.to_string(),
+                Self::new("invalid_input", "text.invalid_resource", cause),
+            ),
+            E::Font(ref cause) => Self::caused_by(
+                "text_import.font",
+                error.to_string(),
+                Self::new("invalid_input", "text.invalid_font", cause),
+            ),
         }
     }
 }
@@ -185,6 +485,7 @@ impl From<SemanticMutationTransactionError> for AuthoringFailure {
         let message = error.to_string();
         match error {
             E::Object { error, .. } => Self::caused_by("transaction.object", message, error.into()),
+            E::Signal { error, .. } => Self::caused_by("transaction.signal", message, error.into()),
             E::Family { error, .. } => Self::caused_by("transaction.family", message, error.into()),
             E::AnimationTarget { error, .. } => {
                 Self::caused_by("transaction.animation_target", message, error.into())
@@ -461,6 +762,8 @@ impl From<LiveSessionError> for AuthoringFailure {
         let message = error.to_string();
         match error {
             E::Authoring(cause) => Self::caused_by("live.authoring", message, cause.into()),
+            E::Callback(cause) => Self::caused_by("live.callback", message, cause.into()),
+            E::Text(cause) => Self::caused_by("live.text", message, cause.into()),
             E::ForeignMobjectStore => Self::new("foreign_handle", "live.foreign_store", message),
             E::Segment(cause) => Self::caused_by("live.segment", message, cause.into()),
             E::Advance(cause) => Self::caused_by("live.advance", message, cause.into()),
@@ -570,12 +873,13 @@ mod tests {
                     .unwrap()
             ));
         }
-        // Unaccepted domains remain explicit, even with category-like input text.
+        // A newly accepted typed input keeps its own category/code even when
+        // the user-supplied value names unrelated error categories.
         let failure = AuthoringFailure::from(AuthoringError::InvalidStrokeCap(
             "invalid opacity; negative stroke width".into(),
         ));
-        assert_eq!(failure.category, "unclassified");
-        assert_eq!(failure.code, "authoring.unclassified");
+        assert_eq!(failure.category, "invalid_input");
+        assert_eq!(failure.code, "authoring.invalid_stroke_cap");
     }
 
     #[test]
@@ -607,5 +911,132 @@ mod tests {
                 .category,
             "pending_work"
         );
+    }
+    fn assert_authoring_projection(error: AuthoringError, category: &str, codes: &[&str]) {
+        let diagnostic = error.to_string();
+        let failure = AuthoringFailure::from(error);
+        assert_eq!(failure.category, category);
+        assert_eq!(failure.message, diagnostic);
+        assert!(!diagnostic.is_empty());
+        let mut projected = Vec::new();
+        let mut current = Some(&failure);
+        while let Some(cause) = current {
+            projected.push(cause.code);
+            assert_eq!(cause.category, category);
+            assert!(!cause.message.is_empty());
+            current = cause.cause.as_deref();
+        }
+        assert_eq!(projected, codes);
+    }
+
+    #[test]
+    fn accepted_public_operations_project_real_rust_causes_and_retry() {
+        use noon::{LayoutAnchor, MobjectFamilyMember, Scene};
+        let scene = Scene::new();
+        let mut first = scene.circle(1.0).unwrap();
+        let second = scene.square(1.0).unwrap();
+        let family = scene.family(&[(&first).into(), (&second).into()]).unwrap();
+        let before = (first.state().unwrap(), second.state().unwrap());
+        let revision = scene.integration_store().borrow().scene_revision();
+        let nodes = scene.integration_store().borrow().len();
+        assert_authoring_projection(
+            scene.circle(0.0).unwrap_err(),
+            "invalid_input",
+            &["authoring.non_positive_number"],
+        );
+        assert_authoring_projection(
+            first.shift(f64::NAN, 0.0).unwrap_err(),
+            "invalid_input",
+            &["authoring.invalid_render_number"],
+        );
+        assert_authoring_projection(
+            first.set_fill_opacity(1.5).unwrap_err(),
+            "invalid_input",
+            &["authoring.invalid_opacity"],
+        );
+        assert_authoring_projection(
+            first.manim_line_endpoints().unwrap_err(),
+            "unsupported_operation",
+            &["authoring.unsupported", "authoring.unsupported_operation"],
+        );
+        assert_authoring_projection(
+            LayoutAnchor::from(&family).member(-3).layout().unwrap_err(),
+            "invalid_input",
+            &["authoring.invalid_submobject_index"],
+        );
+        assert_authoring_projection(
+            family
+                .arrange_in_grid(Some(1), Some(1), 0.1, 0.1)
+                .unwrap_err(),
+            "invalid_input",
+            &["authoring.insufficient_grid_capacity"],
+        );
+        let foreign = Scene::new().circle(1.0).unwrap();
+        assert_authoring_projection(
+            family
+                .copy_with_references(&[MobjectFamilyMember::Mobject(&foreign)])
+                .unwrap_err(),
+            "foreign_handle",
+            &["authoring.foreign_store"],
+        );
+        assert_authoring_projection(
+            scene.value_tracker(f64::NAN).unwrap_err(),
+            "invalid_input",
+            &["authoring.signal", "signal.non_finite_value"],
+        );
+        assert_eq!((first.state().unwrap(), second.state().unwrap()), before);
+        assert_eq!(
+            scene.integration_store().borrow().scene_revision(),
+            revision
+        );
+        assert_eq!(scene.integration_store().borrow().len(), nodes);
+        first.shift(0.5, -0.5).unwrap();
+        first.set_fill_opacity(0.5).unwrap();
+        family.arrange_in_grid(Some(1), Some(2), 0.1, 0.1).unwrap();
+        assert_eq!(first.fill_opacity().unwrap(), 0.5);
+        assert!(family.copy_family().is_ok());
+        assert_eq!(
+            scene
+                .value_tracker_value(&scene.value_tracker(2.0).unwrap())
+                .unwrap(),
+            2.0
+        );
+    }
+
+    #[test]
+    fn accepted_live_projection_preserves_atomic_publication_and_local_retry() {
+        let mut scene = noon::Scene::new();
+        let target = scene.circle(1.0).unwrap();
+        let unrelated = scene.square(1.0).unwrap();
+        scene.add(&target).unwrap();
+        scene.add(&unrelated).unwrap();
+        let mut execution = scene.execution_session().unwrap();
+        execution.take_frame_changes();
+        let before = execution.frame().clone();
+        let publication = execution.publication_context();
+        let authored = target.state().unwrap();
+        let error = scene
+            .live(&mut execution)
+            .set_fill_opacity(&target, 1.5)
+            .unwrap_err();
+        let message = error.to_string();
+        let projected = AuthoringFailure::from(error);
+        assert_eq!(projected.category, "invalid_input");
+        assert_eq!(projected.code, "live.authoring");
+        assert_eq!(
+            projected.cause.as_ref().unwrap().code,
+            "authoring.invalid_opacity"
+        );
+        assert_eq!(projected.message, message);
+        assert_eq!(execution.frame(), &before);
+        assert_eq!(execution.publication_context(), publication);
+        assert_eq!(target.state().unwrap(), authored);
+        assert!(execution.take_frame_changes().is_empty());
+        scene
+            .live(&mut execution)
+            .set_fill_opacity(&target, 0.5)
+            .unwrap();
+        assert_eq!(execution.take_frame_changes().object_indices(), &[0]);
+        assert_eq!(execution.frame().objects[1], before.objects[1]);
     }
 }

--- a/crates/noon-web/src/authoring_error.rs
+++ b/crates/noon-web/src/authoring_error.rs
@@ -947,7 +947,7 @@ mod tests {
         assert_authoring_projection(
             first.shift(f64::NAN, 0.0).unwrap_err(),
             "invalid_input",
-            &["authoring.invalid_render_number"],
+            &["authoring.vector_lowering", "vector.invalid_coordinates"],
         );
         assert_authoring_projection(
             first.set_fill_opacity(1.5).unwrap_err(),

--- a/crates/noon-web/src/authoring_error.rs
+++ b/crates/noon-web/src/authoring_error.rs
@@ -53,7 +53,7 @@ impl AuthoringFailure {
 
     /// Preserve diagnostics/sources for a producer outside this slice, without
     /// pretending that wording proves an input, capability or lifecycle category.
-    fn unclassified(code: &'static str, error: &(dyn Error + 'static)) -> Self {
+    pub(crate) fn unclassified(code: &'static str, error: &(dyn Error + 'static)) -> Self {
         Self {
             category: "unclassified",
             code,

--- a/crates/noon-web/src/authoring_geometry.rs
+++ b/crates/noon-web/src/authoring_geometry.rs
@@ -4,9 +4,7 @@
 use noon_core::{Vec2, VectorPath};
 use wasm_bindgen::prelude::*;
 
-fn js_error(error: impl std::fmt::Display) -> JsValue {
-    JsValue::from_str(&error.to_string())
-}
+use crate::authoring_error::js_error;
 
 /// Constructor values own no semantic store, identity, or execution state.
 #[wasm_bindgen]

--- a/crates/noon-web/src/authoring_mobject.rs
+++ b/crates/noon-web/src/authoring_mobject.rs
@@ -32,10 +32,13 @@ pub(crate) fn family_color(
 }
 
 #[cfg(target_arch = "wasm32")]
-pub(crate) fn text_authoring_f32(field: &str, value: f64) -> Result<f32, String> {
-    let value = render_f64(field, value).map_err(|error| error.to_string())? as f32;
+pub(crate) fn text_authoring_f32(
+    field: &str,
+    value: f64,
+) -> Result<f32, crate::authoring_error::AuthoringFailure> {
+    let value = render_f64(field, value)? as f32;
     if !value.is_finite() {
-        return Err(format!("{field} is outside the supported range"));
+        return Err(format!("{field} is outside the supported range").into());
     }
     Ok(value)
 }
@@ -46,11 +49,11 @@ pub(crate) fn manim_text(
     font_family: &str,
     font_size: f64,
     line_spacing: f64,
-) -> Result<noon::Text, String> {
+) -> Result<noon::Text, crate::authoring_error::AuthoringFailure> {
     let font_size = text_authoring_f32("font size", font_size)?;
     let line_spacing = text_authoring_f32("line spacing", line_spacing)?;
     if line_spacing != -1.0 && line_spacing <= -1.0 {
-        return Err("line spacing must be -1 or greater than -1".to_owned());
+        return Err("line spacing must be -1 or greater than -1".into());
     }
     Ok(noon::Text::new(source)
         .with_font(font_family)
@@ -69,9 +72,7 @@ mod wasm {
 
     use super::{Mobject, SemanticNodeId, SemanticStore};
 
-    fn js_error(error: impl std::fmt::Display) -> JsValue {
-        JsValue::from_str(&error.to_string())
-    }
+    use crate::authoring_error::js_error;
 
     type SharedSemanticStore = Rc<RefCell<SemanticStore>>;
 
@@ -174,7 +175,7 @@ mod wasm {
                 .map_err(js_error)?;
             Mobject::from_text(Rc::clone(&self.semantics), text)
                 .map(|handle| WasmAuthoringMobjectHandle { handle })
-                .map_err(|error| js_error(error.to_string()))
+                .map_err(js_error)
         }
 
         /// Compile Typst or MathTypst into the same semantic store as geometry handles.
@@ -199,7 +200,7 @@ mod wasm {
             };
             handle
                 .map(|handle| WasmAuthoringMobjectHandle { handle })
-                .map_err(|error| js_error(error.to_string()))
+                .map_err(js_error)
         }
 
         #[wasm_bindgen(js_name = createFamily)]

--- a/crates/noon-web/src/authoring_options.rs
+++ b/crates/noon-web/src/authoring_options.rs
@@ -1,79 +1,9 @@
 use noon_core::{
     resolve_animation_options as resolve_core_animation_options, AnimationDefaults,
-    AnimationOptions, AnimationOptionsError, RateFunction, ResolvedAnimationOptions,
+    AnimationOptions, RateFunction, ResolvedAnimationOptions,
 };
 
-#[derive(Clone, Debug, PartialEq)]
-pub struct FrontendAnimationOptionsResolution {
-    ok: bool,
-    run_time: f64,
-    rate_func: String,
-    lag_ratio: f64,
-    path_arc: f64,
-    reverse_rate_function: bool,
-    error_kind: Option<String>,
-    message: Option<String>,
-}
-
-impl FrontendAnimationOptionsResolution {
-    fn success(options: ResolvedAnimationOptions) -> Self {
-        Self {
-            ok: true,
-            run_time: options.run_time,
-            rate_func: options.rate_func.semantic_id().to_owned(),
-            lag_ratio: options.lag_ratio,
-            path_arc: options.path_arc,
-            reverse_rate_function: options.reverse_rate_function,
-            error_kind: None,
-            message: None,
-        }
-    }
-
-    fn failure(kind: &str, message: impl Into<String>) -> Self {
-        Self {
-            ok: false,
-            run_time: 0.0,
-            rate_func: String::new(),
-            lag_ratio: 0.0,
-            path_arc: 0.0,
-            reverse_rate_function: false,
-            error_kind: Some(kind.to_owned()),
-            message: Some(message.into()),
-        }
-    }
-
-    pub const fn ok(&self) -> bool {
-        self.ok
-    }
-
-    pub const fn run_time(&self) -> f64 {
-        self.run_time
-    }
-
-    pub fn rate_func(&self) -> String {
-        self.rate_func.clone()
-    }
-
-    pub const fn lag_ratio(&self) -> f64 {
-        self.lag_ratio
-    }
-
-    pub const fn path_arc(&self) -> f64 {
-        self.path_arc
-    }
-
-    pub const fn reverse_rate_function(&self) -> bool {
-        self.reverse_rate_function
-    }
-
-    pub fn error_kind(&self) -> Option<String> {
-        self.error_kind.clone()
-    }
-
-    pub fn message(&self) -> Option<String> {
-        self.message.clone()
-    }
-}
+use crate::authoring_error::AuthoringFailure;
 
 fn optional_number(value: f64) -> Option<f64> {
     (!value.is_nan()).then_some(value)
@@ -88,13 +18,19 @@ fn optional_bool(value: i32) -> Option<bool> {
     }
 }
 
-fn parse_optional_rate_func(value: &str) -> Result<Option<RateFunction>, String> {
+fn parse_optional_rate_func(value: &str) -> Result<Option<RateFunction>, AuthoringFailure> {
     if value.is_empty() {
         return Ok(None);
     }
     RateFunction::from_semantic_id(value)
         .map(Some)
-        .ok_or_else(|| format!("unsupported rate function semantic id: {value}"))
+        .ok_or_else(|| {
+            AuthoringFailure::new(
+                "invalid_input",
+                "animation.invalid_rate_function",
+                format!("unsupported rate function semantic id: {value}"),
+            )
+        })
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -108,19 +44,9 @@ pub fn resolve_frontend_animation_options(
     play_run_time: f64,
     play_rate_func: &str,
     play_lag_ratio: f64,
-) -> FrontendAnimationOptionsResolution {
-    let animation_rate_func = match parse_optional_rate_func(animation_rate_func) {
-        Ok(value) => value,
-        Err(message) => {
-            return FrontendAnimationOptionsResolution::failure("invalid_rate_func", message)
-        }
-    };
-    let play_rate_func = match parse_optional_rate_func(play_rate_func) {
-        Ok(value) => value,
-        Err(message) => {
-            return FrontendAnimationOptionsResolution::failure("invalid_rate_func", message)
-        }
-    };
+) -> Result<ResolvedAnimationOptions, AuthoringFailure> {
+    let animation_rate_func = parse_optional_rate_func(animation_rate_func)?;
+    let play_rate_func = parse_optional_rate_func(play_rate_func)?;
 
     let animation = AnimationOptions {
         run_time: optional_number(animation_run_time),
@@ -137,74 +63,49 @@ pub fn resolve_frontend_animation_options(
         ..AnimationOptions::new()
     };
 
-    match resolve_core_animation_options(
+    resolve_core_animation_options(
         AnimationDefaults::MANIM.lag_ratio(default_lag_ratio),
         animation,
         play,
-    ) {
-        Ok(options) => FrontendAnimationOptionsResolution::success(options),
-        Err(error) => {
-            let kind = match error {
-                AnimationOptionsError::UnsupportedPathArc(_)
-                | AnimationOptionsError::UnsupportedReverseRateFunction => "unsupported",
-                AnimationOptionsError::InvalidRunTime(_)
-                | AnimationOptionsError::InvalidLagRatio(_)
-                | AnimationOptionsError::InvalidPathArc(_) => "value_error",
-            };
-            FrontendAnimationOptionsResolution::failure(kind, error.to_string())
-        }
-    }
+    )
+    .map_err(AuthoringFailure::from)
 }
 
 #[cfg(target_arch = "wasm32")]
 mod wasm {
     use wasm_bindgen::prelude::*;
 
-    use super::{resolve_frontend_animation_options, FrontendAnimationOptionsResolution};
+    use super::{resolve_frontend_animation_options, ResolvedAnimationOptions};
+    use crate::authoring_error::js_error;
 
     #[wasm_bindgen]
-    pub struct WasmAnimationOptionsResolution(FrontendAnimationOptionsResolution);
+    pub struct WasmAnimationOptionsResolution(ResolvedAnimationOptions);
 
     #[wasm_bindgen]
     impl WasmAnimationOptionsResolution {
-        #[wasm_bindgen(getter)]
-        pub fn ok(&self) -> bool {
-            self.0.ok()
-        }
-
         #[wasm_bindgen(getter, js_name = runTime)]
         pub fn run_time(&self) -> f64 {
-            self.0.run_time()
+            self.0.run_time
         }
 
         #[wasm_bindgen(getter, js_name = rateFunc)]
         pub fn rate_func(&self) -> String {
-            self.0.rate_func()
+            self.0.rate_func.semantic_id().to_owned()
         }
 
         #[wasm_bindgen(getter, js_name = lagRatio)]
         pub fn lag_ratio(&self) -> f64 {
-            self.0.lag_ratio()
+            self.0.lag_ratio
         }
 
         #[wasm_bindgen(getter, js_name = pathArc)]
         pub fn path_arc(&self) -> f64 {
-            self.0.path_arc()
+            self.0.path_arc
         }
 
         #[wasm_bindgen(getter, js_name = reverseRateFunction)]
         pub fn reverse_rate_function(&self) -> bool {
-            self.0.reverse_rate_function()
-        }
-
-        #[wasm_bindgen(getter, js_name = errorKind)]
-        pub fn error_kind(&self) -> Option<String> {
-            self.0.error_kind()
-        }
-
-        #[wasm_bindgen(getter)]
-        pub fn message(&self) -> Option<String> {
-            self.0.message()
+            self.0.reverse_rate_function
         }
     }
 
@@ -220,8 +121,8 @@ mod wasm {
         play_run_time: f64,
         play_rate_func: &str,
         play_lag_ratio: f64,
-    ) -> WasmAnimationOptionsResolution {
-        WasmAnimationOptionsResolution(resolve_frontend_animation_options(
+    ) -> Result<WasmAnimationOptionsResolution, JsValue> {
+        resolve_frontend_animation_options(
             default_lag_ratio,
             animation_run_time,
             animation_rate_func,
@@ -231,7 +132,9 @@ mod wasm {
             play_run_time,
             play_rate_func,
             play_lag_ratio,
-        ))
+        )
+        .map(WasmAnimationOptionsResolution)
+        .map_err(js_error)
     }
 }
 
@@ -256,10 +159,10 @@ mod tests {
             f64::NAN,
         );
 
-        assert!(resolved.ok());
-        assert_eq!(resolved.run_time(), 0.4);
-        assert_eq!(resolved.rate_func(), "smooth");
-        assert_eq!(resolved.lag_ratio(), 0.5);
+        let resolved = resolved.unwrap();
+        assert_eq!(resolved.run_time, 0.4);
+        assert_eq!(resolved.rate_func.semantic_id(), "smooth");
+        assert_eq!(resolved.lag_ratio, 0.5);
     }
 
     #[test]
@@ -275,8 +178,11 @@ mod tests {
             "",
             f64::NAN,
         );
-        assert!(!unsupported.ok());
-        assert_eq!(unsupported.error_kind().as_deref(), Some("unsupported"));
+        let error = unsupported.unwrap_err();
+        assert_eq!(
+            (error.category, error.code),
+            ("unsupported_operation", "animation.unsupported_path_arc")
+        );
 
         let invalid = resolve_frontend_animation_options(
             0.0,
@@ -289,7 +195,10 @@ mod tests {
             "",
             f64::NAN,
         );
-        assert!(!invalid.ok());
-        assert_eq!(invalid.error_kind().as_deref(), Some("invalid_rate_func"));
+        let error = invalid.unwrap_err();
+        assert_eq!(
+            (error.category, error.code),
+            ("invalid_input", "animation.invalid_rate_function")
+        );
     }
 }

--- a/crates/noon-web/src/canonical_authoring_scene.rs
+++ b/crates/noon-web/src/canonical_authoring_scene.rs
@@ -46,23 +46,22 @@ impl SceneMembershipBatch {
     fn create_family(
         &self,
         store: std::rc::Rc<std::cell::RefCell<noon_core::SemanticStore>>,
-    ) -> Result<noon::MobjectFamily, String> {
+    ) -> Result<noon::MobjectFamily, AuthoringFailure> {
         if self.kind != SceneMembershipBatchKind::Add {
             return Err("family creation requires an add batch".into());
         }
-        noon::MobjectFamily::create(store, &self.family_members()?)
-            .map_err(|error| error.to_string())
+        noon::MobjectFamily::create(store, &self.family_members()?).map_err(AuthoringFailure::from)
     }
 
-    fn edit_family(&self, family: &noon::MobjectFamily) -> Result<Vec<bool>, String> {
+    fn edit_family(&self, family: &noon::MobjectFamily) -> Result<Vec<bool>, AuthoringFailure> {
         let members = self.family_members()?;
         match self.kind {
             SceneMembershipBatchKind::Add => {
-                family.add_many(&members).map_err(|error| error.to_string())
+                family.add_many(&members).map_err(AuthoringFailure::from)
             }
-            SceneMembershipBatchKind::Remove => family
-                .remove_many(&members)
-                .map_err(|error| error.to_string()),
+            SceneMembershipBatchKind::Remove => {
+                family.remove_many(&members).map_err(AuthoringFailure::from)
+            }
             _ => Err("family membership requires add or remove".into()),
         }
     }
@@ -273,14 +272,11 @@ impl CanonicalAuthoringScene {
     ///
     /// The returned handle is only an alias of the scene-owned semantic identity. It carries no
     /// camera state or frontend allocation authority.
-    pub fn create_camera_frame(&mut self, id: ObjectId) -> Result<noon::Mobject, String> {
+    pub fn create_camera_frame(&mut self, id: ObjectId) -> Result<noon::Mobject, AuthoringFailure> {
         if self.bindings.contains_key(&id) {
-            return Err(format!("canonical object {} is already bound", id.get()));
+            return Err(format!("canonical object {} is already bound", id.get()).into());
         }
-        let frame = self
-            .scene
-            .camera_frame()
-            .map_err(|error| error.to_string())?;
+        let frame = self.scene.camera_frame().map_err(AuthoringFailure::from)?;
         let node = frame.node_id();
         debug_assert!(!self.identities.contains_key(&node));
         self.bindings.insert(id, node);
@@ -470,19 +466,23 @@ impl CanonicalAuthoringScene {
     /// Route bound observations through the single owner of current execution.
     /// Detached handles are queried directly by their language wrapper.
     #[cfg(any(target_arch = "wasm32", test))]
-    fn mobject_observation<T, E: std::fmt::Display>(
+    fn mobject_observation<T, E: Into<AuthoringFailure>>(
         &mut self,
         handle: &noon::Mobject,
         authored: impl FnOnce(&noon::Mobject) -> Result<T, E>,
-        effective: impl FnOnce(&mut crate::SemanticExecutionPlayer, &noon::Mobject) -> Result<T, String>,
-    ) -> Result<T, String> {
+        effective: impl FnOnce(
+            &mut crate::SemanticExecutionPlayer,
+            &noon::Mobject,
+        ) -> Result<T, AuthoringFailure>,
+    ) -> Result<T, AuthoringFailure> {
         if self.player_ownership.is_transferred() {
             return Err("live execution session is running in the semantic engine".into());
         }
         if !std::rc::Rc::ptr_eq(self.scene.integration_store(), handle.integration_store()) {
-            return Err("mobject belongs to another authoring store".into());
+            return Err(AuthoringFailure::from(noon::AuthoringError::ForeignStore)
+                .with_message("mobject belongs to another authoring store"));
         }
-        handle.validate().map_err(|error| error.to_string())?;
+        handle.validate().map_err(AuthoringFailure::from)?;
         if !self.identities.contains_key(&handle.node_id()) {
             return Err("mobject is not bound to this canonical Scene".into());
         }
@@ -491,11 +491,14 @@ impl CanonicalAuthoringScene {
                 return effective(player, handle);
             }
         }
-        authored(handle).map_err(|error| error.to_string())
+        authored(handle).map_err(Into::into)
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
-    fn mobject_layout(&mut self, handle: &noon::Mobject) -> Result<(f64, f64, f64, f64), String> {
+    fn mobject_layout(
+        &mut self,
+        handle: &noon::Mobject,
+    ) -> Result<(f64, f64, f64, f64), AuthoringFailure> {
         self.mobject_observation(handle, authored_mobject_layout, |player, handle| {
             let observed = player.live_effective_layout(handle)?;
             Ok((
@@ -511,7 +514,7 @@ impl CanonicalAuthoringScene {
     fn mobject_line_endpoints(
         &mut self,
         handle: &noon::Mobject,
-    ) -> Result<noon::ManimLineEndpoints, String> {
+    ) -> Result<noon::ManimLineEndpoints, AuthoringFailure> {
         self.mobject_observation(
             handle,
             noon::Mobject::manim_line_endpoints,
@@ -520,7 +523,10 @@ impl CanonicalAuthoringScene {
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
-    fn mobject_color(&mut self, handle: &noon::Mobject) -> Result<noon_core::Color, String> {
+    fn mobject_color(
+        &mut self,
+        handle: &noon::Mobject,
+    ) -> Result<noon_core::Color, AuthoringFailure> {
         self.mobject_observation(
             handle,
             noon::Mobject::manim_color,
@@ -529,26 +535,20 @@ impl CanonicalAuthoringScene {
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
-    fn mobject_fill_opacity(&mut self, handle: &noon::Mobject) -> Result<f64, String> {
+    fn mobject_fill_opacity(&mut self, handle: &noon::Mobject) -> Result<f64, AuthoringFailure> {
         self.mobject_observation(handle, noon::Mobject::fill_opacity, |player, handle| {
             // Reject resource paints before reading their lowered scalar projection.
-            handle.fill_opacity().map_err(|error| error.to_string())?;
-            Ok(player
-                .live_effective(handle)
-                .map_err(|error| error.to_string())?
-                .fill_opacity())
+            handle.fill_opacity().map_err(AuthoringFailure::from)?;
+            Ok(player.live_effective(handle)?.fill_opacity())
         })
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
-    fn mobject_stroke_opacity(&mut self, handle: &noon::Mobject) -> Result<f64, String> {
+    fn mobject_stroke_opacity(&mut self, handle: &noon::Mobject) -> Result<f64, AuthoringFailure> {
         self.mobject_observation(handle, noon::Mobject::stroke_opacity, |player, handle| {
             // Reject resource paints before reading their lowered scalar projection.
-            handle.stroke_opacity().map_err(|error| error.to_string())?;
-            Ok(player
-                .live_effective(handle)
-                .map_err(|error| error.to_string())?
-                .stroke_opacity())
+            handle.stroke_opacity().map_err(AuthoringFailure::from)?;
+            Ok(player.live_effective(handle)?.stroke_opacity())
         })
     }
 
@@ -559,17 +559,18 @@ impl CanonicalAuthoringScene {
         &mut self,
         handle: &noon::Mobject,
         buff: f64,
-    ) -> Result<noon::ManimGeometryOptions, String> {
+    ) -> Result<noon::ManimGeometryOptions, AuthoringFailure> {
         if self.player_ownership.is_transferred() {
             return Err("live execution session is running in the semantic engine".into());
         }
         if !std::rc::Rc::ptr_eq(self.scene.integration_store(), handle.integration_store()) {
-            return Err("mobject belongs to another authoring store".into());
+            return Err(AuthoringFailure::from(noon::AuthoringError::ForeignStore)
+                .with_message("mobject belongs to another authoring store"));
         }
-        handle.validate().map_err(|error| error.to_string())?;
+        handle.validate().map_err(AuthoringFailure::from)?;
         let mut bounds = handle
             .layout_bounds()
-            .map_err(|error| error.to_string())?
+            .map_err(AuthoringFailure::from)?
             .ok_or("Underline target has no layout bounds")?;
         if self.identities.contains_key(&handle.node_id()) {
             let (x, y, width, height) = self.mobject_layout(handle)?;
@@ -580,7 +581,7 @@ impl CanonicalAuthoringScene {
                 max_y: y + height * 0.5,
             };
         }
-        noon::ManimGeometryOptions::underline(bounds, buff).map_err(|error| error.to_string())
+        noon::ManimGeometryOptions::underline(bounds, buff).map_err(AuthoringFailure::from)
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
@@ -596,7 +597,10 @@ impl CanonicalAuthoringScene {
 
     /// Create one scalar signal in this context's shared semantic store.
     #[cfg(any(target_arch = "wasm32", test))]
-    fn create_value_tracker(&mut self, initial: f64) -> Result<noon::ValueTracker, String> {
+    fn create_value_tracker(
+        &mut self,
+        initial: f64,
+    ) -> Result<noon::ValueTracker, AuthoringFailure> {
         if self.player_ownership.is_transferred() {
             return Err("live execution session is running in the semantic engine".into());
         }
@@ -605,13 +609,16 @@ impl CanonicalAuthoringScene {
             None => self
                 .scene
                 .value_tracker(initial)
-                .map_err(|error| error.to_string()),
+                .map_err(AuthoringFailure::from),
         }
     }
 
     /// Associate one store-owned detached tracker with this Scene.
     #[cfg(any(target_arch = "wasm32", test))]
-    fn associate_value_tracker(&mut self, tracker: &noon::ValueTracker) -> Result<(), String> {
+    fn associate_value_tracker(
+        &mut self,
+        tracker: &noon::ValueTracker,
+    ) -> Result<(), AuthoringFailure> {
         if self.player_ownership.is_transferred() {
             return Err("live execution session is running in the semantic engine".into());
         }
@@ -620,32 +627,32 @@ impl CanonicalAuthoringScene {
             None => self
                 .scene
                 .associate_value_tracker(tracker)
-                .map_err(|error| error.to_string()),
+                .map_err(AuthoringFailure::from),
         }
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
-    fn pointer_position_signal(&self) -> Result<noon::NativeVectorSignal, String> {
+    fn pointer_position_signal(&self) -> Result<noon::NativeVectorSignal, AuthoringFailure> {
         self.require_pre_execution_signal_authoring()?;
         self.scene
             .pointer_position_signal()
-            .map_err(|error| error.to_string())
+            .map_err(AuthoringFailure::from)
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
-    fn viewport_size_signal(&self) -> Result<noon::NativeVectorSignal, String> {
+    fn viewport_size_signal(&self) -> Result<noon::NativeVectorSignal, AuthoringFailure> {
         self.require_pre_execution_signal_authoring()?;
         self.scene
             .viewport_size_signal()
-            .map_err(|error| error.to_string())
+            .map_err(AuthoringFailure::from)
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
-    fn wheel_delta_signal(&self) -> Result<noon::NativeVectorSignal, String> {
+    fn wheel_delta_signal(&self) -> Result<noon::NativeVectorSignal, AuthoringFailure> {
         self.require_pre_execution_signal_authoring()?;
         self.scene
             .wheel_delta_signal()
-            .map_err(|error| error.to_string())
+            .map_err(AuthoringFailure::from)
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
@@ -653,41 +660,45 @@ impl CanonicalAuthoringScene {
         &self,
         code: String,
         initial: bool,
-    ) -> Result<noon::NativeBoolSignal, String> {
+    ) -> Result<noon::NativeBoolSignal, AuthoringFailure> {
         self.require_pre_execution_signal_authoring()?;
         self.scene
             .key_state_signal(code, initial)
-            .map_err(|error| error.to_string())
+            .map_err(AuthoringFailure::from)
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
-    fn control_signal(&self, name: String, initial: f64) -> Result<noon::ValueTracker, String> {
+    fn control_signal(
+        &self,
+        name: String,
+        initial: f64,
+    ) -> Result<noon::ValueTracker, AuthoringFailure> {
         self.require_pre_execution_signal_authoring()?;
         self.scene
             .control_signal(name, initial)
-            .map_err(|error| error.to_string())
+            .map_err(AuthoringFailure::from)
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
-    fn pointer_down_events(&self, button: u8) -> Result<noon::ValueTracker, String> {
+    fn pointer_down_events(&self, button: u8) -> Result<noon::ValueTracker, AuthoringFailure> {
         self.require_pre_execution_signal_authoring()?;
         self.scene
             .pointer_down_events(button)
-            .map_err(|error| error.to_string())
+            .map_err(AuthoringFailure::from)
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
-    fn wheel_events(&self) -> Result<noon::ValueTracker, String> {
+    fn wheel_events(&self) -> Result<noon::ValueTracker, AuthoringFailure> {
         self.require_pre_execution_signal_authoring()?;
-        self.scene.wheel_events().map_err(|error| error.to_string())
+        self.scene.wheel_events().map_err(AuthoringFailure::from)
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
-    fn control_commit_events(&self, name: String) -> Result<noon::ValueTracker, String> {
+    fn control_commit_events(&self, name: String) -> Result<noon::ValueTracker, AuthoringFailure> {
         self.require_pre_execution_signal_authoring()?;
         self.scene
             .control_commit_events(name)
-            .map_err(|error| error.to_string())
+            .map_err(AuthoringFailure::from)
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
@@ -695,11 +706,11 @@ impl CanonicalAuthoringScene {
         &self,
         object: &noon::Mobject,
         signal: &noon::NativeVectorSignal,
-    ) -> Result<(), String> {
+    ) -> Result<(), AuthoringFailure> {
         self.require_pre_execution_signal_authoring()?;
         self.scene
             .bind_native_translation(object, signal)
-            .map_err(|error| error.to_string())
+            .map_err(AuthoringFailure::from)
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
@@ -707,11 +718,11 @@ impl CanonicalAuthoringScene {
         &self,
         object: &noon::Mobject,
         signal: &noon::ValueTracker,
-    ) -> Result<(), String> {
+    ) -> Result<(), AuthoringFailure> {
         self.require_pre_execution_signal_authoring()?;
         self.scene
             .bind_rotation(object, signal)
-            .map_err(|error| error.to_string())
+            .map_err(AuthoringFailure::from)
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
@@ -719,11 +730,11 @@ impl CanonicalAuthoringScene {
         &self,
         object: &noon::Mobject,
         signal: &noon::ValueTracker,
-    ) -> Result<(), String> {
+    ) -> Result<(), AuthoringFailure> {
         self.require_pre_execution_signal_authoring()?;
         self.scene
             .bind_opacity(object, signal)
-            .map_err(|error| error.to_string())
+            .map_err(AuthoringFailure::from)
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
@@ -731,11 +742,11 @@ impl CanonicalAuthoringScene {
         &self,
         object: &noon::Mobject,
         signal: &noon::NativeBoolSignal,
-    ) -> Result<(), String> {
+    ) -> Result<(), AuthoringFailure> {
         self.require_pre_execution_signal_authoring()?;
         self.scene
             .bind_presence(object, signal)
-            .map_err(|error| error.to_string())
+            .map_err(AuthoringFailure::from)
     }
 
     /// Build only the common `offset + tracker * direction` semantic expression.
@@ -745,11 +756,11 @@ impl CanonicalAuthoringScene {
         tracker: &noon::ValueTracker,
         direction: SemanticVec3,
         offset: SemanticVec3,
-    ) -> Result<noon::TrackerPosition, String> {
+    ) -> Result<noon::TrackerPosition, AuthoringFailure> {
         self.require_pre_execution_signal_authoring()?;
         self.scene
             .position_from_tracker(tracker, direction, offset)
-            .map_err(|error| error.to_string())
+            .map_err(AuthoringFailure::from)
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
@@ -757,15 +768,15 @@ impl CanonicalAuthoringScene {
         &self,
         object: &noon::Mobject,
         position: &noon::TrackerPosition,
-    ) -> Result<(), String> {
+    ) -> Result<(), AuthoringFailure> {
         self.require_pre_execution_signal_authoring()?;
         self.scene
             .bind_position(object, position)
-            .map_err(|error| error.to_string())
+            .map_err(AuthoringFailure::from)
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
-    fn tracker_value(&mut self, tracker: &noon::ValueTracker) -> Result<f64, String> {
+    fn tracker_value(&mut self, tracker: &noon::ValueTracker) -> Result<f64, AuthoringFailure> {
         if self.player_ownership.is_transferred() {
             return Err("semantic execution session is running in the semantic engine".into());
         }
@@ -774,7 +785,7 @@ impl CanonicalAuthoringScene {
             None => self
                 .scene
                 .value_tracker_value(tracker)
-                .map_err(|error| error.to_string()),
+                .map_err(AuthoringFailure::from),
         }
     }
 
@@ -783,7 +794,7 @@ impl CanonicalAuthoringScene {
         &mut self,
         tracker: &noon::ValueTracker,
         value: f64,
-    ) -> Result<(), String> {
+    ) -> Result<(), AuthoringFailure> {
         if self.player_ownership.is_transferred() {
             return Err("semantic execution session is running in the semantic engine".into());
         }
@@ -792,7 +803,7 @@ impl CanonicalAuthoringScene {
             None => self
                 .scene
                 .set_value(tracker, value)
-                .map_err(|error| error.to_string()),
+                .map_err(AuthoringFailure::from),
         }
     }
 
@@ -1887,13 +1898,17 @@ impl CanonicalAuthoringScene {
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
-    fn live_target_editor(&mut self, source: &noon::Mobject) -> Result<noon::Mobject, String> {
+    fn live_target_editor(
+        &mut self,
+        source: &noon::Mobject,
+    ) -> Result<noon::Mobject, AuthoringFailure> {
         if !std::rc::Rc::ptr_eq(self.scene.integration_store(), source.integration_store()) {
-            return Err("mobject belongs to another authoring store".into());
+            return Err(AuthoringFailure::from(noon::AuthoringError::ForeignStore)
+                .with_message("mobject belongs to another authoring store"));
         }
-        source.validate().map_err(|error| error.to_string())?;
+        source.validate().map_err(AuthoringFailure::from)?;
         match &mut self.player_ownership {
-            PlayerOwnership::Unstarted => source.target_editor().map_err(|error| error.to_string()),
+            PlayerOwnership::Unstarted => source.target_editor().map_err(AuthoringFailure::from),
             PlayerOwnership::Active(_) | PlayerOwnership::Returned(_) => {
                 self.active_live_player()?.live_target_editor(source)
             }
@@ -1907,7 +1922,7 @@ impl CanonicalAuthoringScene {
     fn live_family(
         &mut self,
         members: &[noon::MobjectFamilyMember<'_>],
-    ) -> Result<noon::MobjectFamily, String> {
+    ) -> Result<noon::MobjectFamily, AuthoringFailure> {
         match &mut self.player_ownership {
             PlayerOwnership::Active(_) | PlayerOwnership::Returned(_) => {
                 self.active_live_player()?.live_family(members)
@@ -1927,7 +1942,7 @@ impl CanonicalAuthoringScene {
         family: &noon::MobjectFamily,
         x: f64,
         y: f64,
-    ) -> Result<(), String> {
+    ) -> Result<(), AuthoringFailure> {
         match &mut self.player_ownership {
             PlayerOwnership::Active(_) | PlayerOwnership::Returned(_) => {
                 self.active_live_player()?.live_shift_family(family, x, y)
@@ -1947,7 +1962,7 @@ impl CanonicalAuthoringScene {
         &mut self,
         family: &noon::MobjectFamily,
         options: &noon::FamilyArrangeOptions,
-    ) -> Result<(), String> {
+    ) -> Result<(), AuthoringFailure> {
         self.active_live_player()?
             .live_arrange_family(family, options)
     }
@@ -1977,13 +1992,13 @@ impl CanonicalAuthoringScene {
         target: &noon::Mobject,
         other: &noon::Mobject,
         options: noon::ManimBecomeOptions,
-    ) -> Result<(), String> {
+    ) -> Result<(), AuthoringFailure> {
         for object in [target, other] {
             if !std::rc::Rc::ptr_eq(self.scene.integration_store(), object.integration_store()) {
-                return Err(
-                    "become objects and canonical context belong to different authoring stores"
-                        .into(),
-                );
+                return Err(AuthoringFailure::from(noon::AuthoringError::ForeignStore)
+                    .with_message(
+                        "become objects and canonical context belong to different authoring stores",
+                    ));
             }
         }
         match &mut self.player_ownership {
@@ -2003,7 +2018,7 @@ impl CanonicalAuthoringScene {
     fn live_create_manim_geometry(
         &mut self,
         options: noon::ManimGeometryOptions,
-    ) -> Result<noon::Mobject, String> {
+    ) -> Result<noon::Mobject, AuthoringFailure> {
         match &mut self.player_ownership {
             PlayerOwnership::Active(_) | PlayerOwnership::Returned(_) => self
                 .active_live_player()?
@@ -2018,7 +2033,7 @@ impl CanonicalAuthoringScene {
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
-    fn live_create_text(&mut self, text: noon::Text) -> Result<noon::Mobject, String> {
+    fn live_create_text(&mut self, text: noon::Text) -> Result<noon::Mobject, AuthoringFailure> {
         match &mut self.player_ownership {
             PlayerOwnership::Active(_) | PlayerOwnership::Returned(_) => {
                 self.active_live_player()?.live_create_text(text)
@@ -2033,7 +2048,7 @@ impl CanonicalAuthoringScene {
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
-    fn live_create_typst(&mut self, text: noon::Typst) -> Result<noon::Mobject, String> {
+    fn live_create_typst(&mut self, text: noon::Typst) -> Result<noon::Mobject, AuthoringFailure> {
         match &mut self.player_ownership {
             PlayerOwnership::Active(_) | PlayerOwnership::Returned(_) => {
                 self.active_live_player()?.live_create_typst(text)
@@ -2048,7 +2063,10 @@ impl CanonicalAuthoringScene {
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
-    fn live_create_math_typst(&mut self, text: noon::MathTypst) -> Result<noon::Mobject, String> {
+    fn live_create_math_typst(
+        &mut self,
+        text: noon::MathTypst,
+    ) -> Result<noon::Mobject, AuthoringFailure> {
         match &mut self.player_ownership {
             PlayerOwnership::Active(_) | PlayerOwnership::Returned(_) => {
                 self.active_live_player()?.live_create_math_typst(text)
@@ -2457,9 +2475,7 @@ mod wasm {
         }
     }
 
-    fn js_error(error: impl ToString) -> JsValue {
-        JsValue::from_str(&error.to_string())
-    }
+    use crate::authoring_error::js_error;
 
     fn parse_object_id(label: &str, value: &str) -> Result<ObjectId, JsValue> {
         value
@@ -3973,12 +3989,14 @@ mod wasm {
 
         #[wasm_bindgen(js_name = detachedValue)]
         pub fn detached_value(&self) -> Result<f64, JsValue> {
-            self.tracker.detached_value().map_err(js_error)
+            self.tracker.detached_value().map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = setDetachedValue)]
         pub fn set_detached_value(&self, value: f64) -> Result<(), JsValue> {
-            self.tracker.set_detached_value(value).map_err(js_error)
+            self.tracker
+                .set_detached_value(value)
+                .map_err(typed_js_error)
         }
     }
 
@@ -4537,7 +4555,7 @@ mod wasm {
             self.inner
                 .create_camera_frame(id)
                 .map(crate::WasmAuthoringMobjectHandle::from_semantic_mobject)
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = createValueTracker)]
@@ -4545,7 +4563,10 @@ mod wasm {
             &mut self,
             initial: f64,
         ) -> Result<WasmValueTrackerHandle, JsValue> {
-            let tracker = self.inner.create_value_tracker(initial).map_err(js_error)?;
+            let tracker = self
+                .inner
+                .create_value_tracker(initial)
+                .map_err(typed_js_error)?;
             Ok(WasmValueTrackerHandle::from_tracker(
                 tracker,
                 std::rc::Rc::clone(self.inner.scene.integration_store()),
@@ -4560,12 +4581,15 @@ mod wasm {
             let tracker = tracker.tracker_in(self.inner.scene.integration_store())?;
             self.inner
                 .associate_value_tracker(tracker)
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = pointerPositionSignal)]
         pub fn pointer_position_signal(&mut self) -> Result<WasmNativeVectorSignalHandle, JsValue> {
-            let signal = self.inner.pointer_position_signal().map_err(js_error)?;
+            let signal = self
+                .inner
+                .pointer_position_signal()
+                .map_err(typed_js_error)?;
             Ok(WasmNativeVectorSignalHandle {
                 signal,
                 store: std::rc::Rc::clone(self.inner.scene.integration_store()),
@@ -4574,7 +4598,7 @@ mod wasm {
 
         #[wasm_bindgen(js_name = viewportSizeSignal)]
         pub fn viewport_size_signal(&mut self) -> Result<WasmNativeVectorSignalHandle, JsValue> {
-            let signal = self.inner.viewport_size_signal().map_err(js_error)?;
+            let signal = self.inner.viewport_size_signal().map_err(typed_js_error)?;
             Ok(WasmNativeVectorSignalHandle {
                 signal,
                 store: std::rc::Rc::clone(self.inner.scene.integration_store()),
@@ -4583,7 +4607,7 @@ mod wasm {
 
         #[wasm_bindgen(js_name = wheelDeltaSignal)]
         pub fn wheel_delta_signal(&mut self) -> Result<WasmNativeVectorSignalHandle, JsValue> {
-            let signal = self.inner.wheel_delta_signal().map_err(js_error)?;
+            let signal = self.inner.wheel_delta_signal().map_err(typed_js_error)?;
             Ok(WasmNativeVectorSignalHandle {
                 signal,
                 store: std::rc::Rc::clone(self.inner.scene.integration_store()),
@@ -4599,7 +4623,7 @@ mod wasm {
             let signal = self
                 .inner
                 .key_state_signal(code, initial)
-                .map_err(js_error)?;
+                .map_err(typed_js_error)?;
             Ok(WasmNativeBoolSignalHandle {
                 signal,
                 store: std::rc::Rc::clone(self.inner.scene.integration_store()),
@@ -4612,7 +4636,10 @@ mod wasm {
             name: String,
             initial: f64,
         ) -> Result<WasmValueTrackerHandle, JsValue> {
-            let tracker = self.inner.control_signal(name, initial).map_err(js_error)?;
+            let tracker = self
+                .inner
+                .control_signal(name, initial)
+                .map_err(typed_js_error)?;
             Ok(WasmValueTrackerHandle {
                 tracker,
                 store: std::rc::Rc::clone(self.inner.scene.integration_store()),
@@ -4627,7 +4654,7 @@ mod wasm {
             let tracker = self
                 .inner
                 .pointer_down_events(parse_button(button)?)
-                .map_err(js_error)?;
+                .map_err(typed_js_error)?;
             Ok(WasmValueTrackerHandle {
                 tracker,
                 store: std::rc::Rc::clone(self.inner.scene.integration_store()),
@@ -4636,7 +4663,7 @@ mod wasm {
 
         #[wasm_bindgen(js_name = wheelEvents)]
         pub fn wheel_events(&mut self) -> Result<WasmValueTrackerHandle, JsValue> {
-            let tracker = self.inner.wheel_events().map_err(js_error)?;
+            let tracker = self.inner.wheel_events().map_err(typed_js_error)?;
             Ok(WasmValueTrackerHandle {
                 tracker,
                 store: std::rc::Rc::clone(self.inner.scene.integration_store()),
@@ -4648,7 +4675,10 @@ mod wasm {
             &mut self,
             name: String,
         ) -> Result<WasmValueTrackerHandle, JsValue> {
-            let tracker = self.inner.control_commit_events(name).map_err(js_error)?;
+            let tracker = self
+                .inner
+                .control_commit_events(name)
+                .map_err(typed_js_error)?;
             Ok(WasmValueTrackerHandle {
                 tracker,
                 store: std::rc::Rc::clone(self.inner.scene.integration_store()),
@@ -4668,7 +4698,7 @@ mod wasm {
             let signal = signal.signal_in(self.inner.scene.integration_store())?;
             self.inner
                 .bind_native_translation(object.semantic_mobject(), signal)
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = bindRotation)]
@@ -4681,7 +4711,7 @@ mod wasm {
             let signal = signal.tracker_in(self.inner.scene.integration_store())?;
             self.inner
                 .bind_rotation(object.semantic_mobject(), signal)
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = bindOpacity)]
@@ -4694,7 +4724,7 @@ mod wasm {
             let signal = signal.tracker_in(self.inner.scene.integration_store())?;
             self.inner
                 .bind_opacity(object.semantic_mobject(), signal)
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = bindPresence)]
@@ -4707,7 +4737,7 @@ mod wasm {
             let signal = signal.signal_in(self.inner.scene.integration_store())?;
             self.inner
                 .bind_presence(object.semantic_mobject(), signal)
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = trackerPosition)]
@@ -4727,7 +4757,7 @@ mod wasm {
                     SemanticVec3::new(direction_x, direction_y, 0.0),
                     SemanticVec3::new(offset_x, offset_y, 0.0),
                 )
-                .map_err(js_error)?;
+                .map_err(typed_js_error)?;
             Ok(WasmTrackerPositionHandle {
                 position,
                 store: std::rc::Rc::clone(self.inner.scene.integration_store()),
@@ -4747,7 +4777,7 @@ mod wasm {
             let position = position.position_in(self.inner.scene.integration_store())?;
             self.inner
                 .bind_tracker_position(object.semantic_mobject(), position)
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = valueTrackerValue)]
@@ -4756,7 +4786,7 @@ mod wasm {
             tracker: &WasmValueTrackerHandle,
         ) -> Result<f64, JsValue> {
             let tracker = tracker.tracker_in(self.inner.scene.integration_store())?;
-            self.inner.tracker_value(tracker).map_err(js_error)
+            self.inner.tracker_value(tracker).map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = setValueTracker)]
@@ -4768,7 +4798,7 @@ mod wasm {
             let tracker = tracker.tracker_in(self.inner.scene.integration_store())?;
             self.inner
                 .set_tracker_value(tracker, value)
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = authoredDuration)]
@@ -4963,7 +4993,7 @@ mod wasm {
             self.inner
                 .begin_underline(handle.semantic_mobject(), buff)
                 .map(crate::WasmManimGeometryOptions::from_options)
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = queryMobjectLayout)]
@@ -4974,7 +5004,7 @@ mod wasm {
             let (center_x, center_y, width, height) = self
                 .inner
                 .mobject_layout(handle.semantic_mobject())
-                .map_err(js_error)?;
+                .map_err(typed_js_error)?;
             Ok(WasmMobjectLayoutObservation {
                 center_x,
                 center_y,
@@ -4993,9 +5023,9 @@ mod wasm {
             let layout = self
                 .inner
                 .active_live_player()
-                .map_err(js_error)?
+                .map_err(typed_js_error)?
                 .live_family_layout(&family)
-                .map_err(js_error)?;
+                .map_err(typed_js_error)?;
             Ok(WasmMobjectLayoutObservation {
                 center_x: layout.center.0,
                 center_y: layout.center.1,
@@ -5020,14 +5050,14 @@ mod wasm {
 
             self.inner
                 .active_live_player()
-                .map_err(js_error)?
+                .map_err(typed_js_error)?
                 .live_move_family_to(
                     &family,
                     noon::LiveLayoutTarget::Point(x, y),
                     (edge_x, edge_y),
                     (mask_x, mask_y),
                 )
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = liveMoveFamilyToMobject)]
@@ -5045,14 +5075,14 @@ mod wasm {
 
             self.inner
                 .active_live_player()
-                .map_err(js_error)?
+                .map_err(typed_js_error)?
                 .live_move_family_to(
                     &family,
                     noon::LiveLayoutTarget::Mobject(target.semantic_mobject()),
                     (edge_x, edge_y),
                     (mask_x, mask_y),
                 )
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = liveMoveFamilyToFamily)]
@@ -5070,14 +5100,14 @@ mod wasm {
             let target = target.semantic_family()?;
             self.inner
                 .active_live_player()
-                .map_err(js_error)?
+                .map_err(typed_js_error)?
                 .live_move_family_to(
                     &family,
                     noon::LiveLayoutTarget::Family(&target),
                     (edge_x, edge_y),
                     (mask_x, mask_y),
                 )
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = liveRescaleToFit)]
@@ -5090,14 +5120,14 @@ mod wasm {
         ) -> Result<(), JsValue> {
             self.inner
                 .active_live_player()
-                .map_err(js_error)?
+                .map_err(typed_js_error)?
                 .live_rescale_to_fit(
                     &source.anchor,
                     length,
-                    dimension.try_into().map_err(js_error)?,
+                    dimension.try_into().map_err(typed_js_error)?,
                     stretch,
                 )
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = liveMatchDimSize)]
@@ -5110,14 +5140,14 @@ mod wasm {
         ) -> Result<(), JsValue> {
             self.inner
                 .active_live_player()
-                .map_err(js_error)?
+                .map_err(typed_js_error)?
                 .live_match_dim_size(
                     &source.anchor,
                     &target.anchor,
-                    dimension.try_into().map_err(js_error)?,
+                    dimension.try_into().map_err(typed_js_error)?,
                     stretch,
                 )
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = liveNextLayoutTo)]
@@ -5137,7 +5167,7 @@ mod wasm {
         ) -> Result<(), JsValue> {
             self.inner
                 .active_live_player()
-                .map_err(js_error)?
+                .map_err(typed_js_error)?
                 .live_next_layout_to_aligned(
                     &source.anchor,
                     noon::LiveLayoutTarget::Anchor(&target.anchor),
@@ -5149,7 +5179,7 @@ mod wasm {
                         mask: (mask_x, mask_y),
                     },
                 )
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = liveNextLayoutToPoint)]
@@ -5170,7 +5200,7 @@ mod wasm {
         ) -> Result<(), JsValue> {
             self.inner
                 .active_live_player()
-                .map_err(js_error)?
+                .map_err(typed_js_error)?
                 .live_next_layout_to_aligned(
                     &source.anchor,
                     noon::LiveLayoutTarget::Point(x, y),
@@ -5182,7 +5212,7 @@ mod wasm {
                         mask: (mask_x, mask_y),
                     },
                 )
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = liveAlignFamilyOnFrame)]
@@ -5196,9 +5226,9 @@ mod wasm {
             let family = handle.semantic_family()?;
             self.inner
                 .active_live_player()
-                .map_err(js_error)?
+                .map_err(typed_js_error)?
                 .live_align_family_on_frame(&family, (direction_x, direction_y), buff)
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = liveAlignFamilyToPoint)]
@@ -5215,13 +5245,13 @@ mod wasm {
 
             self.inner
                 .active_live_player()
-                .map_err(js_error)?
+                .map_err(typed_js_error)?
                 .live_align_family_to(
                     &family,
                     noon::LiveLayoutTarget::Point(x, y),
                     (axis_x, axis_y),
                 )
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = liveAlignFamilyToMobject)]
@@ -5237,13 +5267,13 @@ mod wasm {
 
             self.inner
                 .active_live_player()
-                .map_err(js_error)?
+                .map_err(typed_js_error)?
                 .live_align_family_to(
                     &family,
                     noon::LiveLayoutTarget::Mobject(target.semantic_mobject()),
                     (axis_x, axis_y),
                 )
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = liveAlignFamilyToFamily)]
@@ -5259,13 +5289,13 @@ mod wasm {
             let target = target.semantic_family()?;
             self.inner
                 .active_live_player()
-                .map_err(js_error)?
+                .map_err(typed_js_error)?
                 .live_align_family_to(
                     &family,
                     noon::LiveLayoutTarget::Family(&target),
                     (axis_x, axis_y),
                 )
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = queryMobjectLineEndpoints)]
@@ -5276,7 +5306,7 @@ mod wasm {
             self.inner
                 .mobject_line_endpoints(handle.semantic_mobject())
                 .map(crate::WasmManimLineEndpoints::from_endpoints)
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = queryMobjectFillOpacity)]
@@ -5286,7 +5316,7 @@ mod wasm {
         ) -> Result<f64, JsValue> {
             self.inner
                 .mobject_fill_opacity(handle.semantic_mobject())
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = queryMobjectStrokeOpacity)]
@@ -5296,7 +5326,7 @@ mod wasm {
         ) -> Result<f64, JsValue> {
             self.inner
                 .mobject_stroke_opacity(handle.semantic_mobject())
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = queryMobjectColor)]
@@ -5307,7 +5337,7 @@ mod wasm {
             self.inner
                 .mobject_color(handle.semantic_mobject())
                 .map(crate::WasmManimColor::from_color)
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = declareLiveTransformTo)]
@@ -5486,7 +5516,7 @@ mod wasm {
             self.inner
                 .live_target_editor(source.semantic_mobject())
                 .map(crate::WasmAuthoringMobjectHandle::from_semantic_mobject)
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         /// Copy the complete family through one coherent live publication.
@@ -5499,10 +5529,13 @@ mod wasm {
             let source = source.semantic_family()?;
             self.inner
                 .active_live_player()
-                .map_err(js_error)?
-                .live_copy_family(&source, &references.copy_references().map_err(js_error)?)
+                .map_err(typed_js_error)?
+                .live_copy_family(
+                    &source,
+                    &references.copy_references().map_err(typed_js_error)?,
+                )
                 .map(crate::WasmFamilyCopy::from_copy)
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         /// Replace one object's content and presentation through the shared semantic owner.
@@ -5527,7 +5560,7 @@ mod wasm {
                         stretch,
                     },
                 )
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         /// Publish a fully configured geometry through the current live session.
@@ -5539,7 +5572,7 @@ mod wasm {
             self.inner
                 .live_create_manim_geometry(candidate.options)
                 .map(crate::WasmAuthoringMobjectHandle::from_semantic_mobject)
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         /// Shape and publish one detached plain Text object through the current
@@ -5560,7 +5593,7 @@ mod wasm {
         ) -> Result<crate::WasmAuthoringMobjectHandle, JsValue> {
             let text =
                 crate::authoring_mobject::manim_text(source, font_family, font_size, line_spacing)
-                    .map_err(js_error)?
+                    .map_err(typed_js_error)?
                     .color(Color::rgba(
                         checked_f32("text red", red)?,
                         checked_f32("text green", green)?,
@@ -5571,7 +5604,7 @@ mod wasm {
             self.inner
                 .live_create_text(text)
                 .map(crate::WasmAuthoringMobjectHandle::from_semantic_mobject)
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         /// Compile and publish one detached Typst or MathTypst object through
@@ -5589,7 +5622,7 @@ mod wasm {
             opacity: f64,
         ) -> Result<crate::WasmAuthoringMobjectHandle, JsValue> {
             let font_size = crate::authoring_mobject::text_authoring_f32("font size", font_size)
-                .map_err(js_error)?;
+                .map_err(typed_js_error)?;
             let color = Color::rgba(
                 checked_f32("text red", red)?,
                 checked_f32("text green", green)?,
@@ -5614,7 +5647,7 @@ mod wasm {
             };
             result
                 .map(crate::WasmAuthoringMobjectHandle::from_semantic_mobject)
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = livePlayAnimation)]
@@ -5715,14 +5748,14 @@ mod wasm {
             )?;
             self.inner
                 .active_live_player()
-                .map_err(js_error)?
+                .map_err(typed_js_error)?
                 .live_move_to(
                     handle.semantic_mobject(),
                     noon::LiveLayoutTarget::Anchor(&target.anchor),
                     (edge_x, edge_y),
                     (mask_x, mask_y),
                 )
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = liveMoveToPoint)]
@@ -5743,14 +5776,14 @@ mod wasm {
             )?;
             self.inner
                 .active_live_player()
-                .map_err(js_error)?
+                .map_err(typed_js_error)?
                 .live_move_to(
                     handle.semantic_mobject(),
                     noon::LiveLayoutTarget::Point(x, y),
                     (edge_x, edge_y),
                     (mask_x, mask_y),
                 )
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = liveMoveToMobject)]
@@ -5773,14 +5806,14 @@ mod wasm {
             )?;
             self.inner
                 .active_live_player()
-                .map_err(js_error)?
+                .map_err(typed_js_error)?
                 .live_move_to(
                     handle.semantic_mobject(),
                     noon::LiveLayoutTarget::Mobject(target.semantic_mobject()),
                     (edge_x, edge_y),
                     (mask_x, mask_y),
                 )
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = liveSetFill)]
@@ -5798,9 +5831,9 @@ mod wasm {
             )?;
             self.inner
                 .active_live_player()
-                .map_err(js_error)?
+                .map_err(typed_js_error)?
                 .live_set_fill(handle.semantic_mobject(), red, green, blue, opacity)
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = liveSetFillColor)]
@@ -5818,9 +5851,9 @@ mod wasm {
             )?;
             self.inner
                 .active_live_player()
-                .map_err(js_error)?
+                .map_err(typed_js_error)?
                 .live_set_fill_color(handle.semantic_mobject(), red, green, blue, alpha)
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = liveDisableFill)]
@@ -5834,9 +5867,9 @@ mod wasm {
             )?;
             self.inner
                 .active_live_player()
-                .map_err(js_error)?
+                .map_err(typed_js_error)?
                 .live_disable_fill(handle.semantic_mobject())
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = liveSetFillOpacity)]
@@ -5851,9 +5884,9 @@ mod wasm {
             )?;
             self.inner
                 .active_live_player()
-                .map_err(js_error)?
+                .map_err(typed_js_error)?
                 .live_set_fill_opacity(handle.semantic_mobject(), opacity)
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = liveSetColor)]
@@ -5871,9 +5904,9 @@ mod wasm {
             )?;
             self.inner
                 .active_live_player()
-                .map_err(js_error)?
+                .map_err(typed_js_error)?
                 .live_set_color(handle.semantic_mobject(), red, green, blue, alpha)
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = liveSetStroke)]
@@ -5891,9 +5924,9 @@ mod wasm {
             )?;
             self.inner
                 .active_live_player()
-                .map_err(js_error)?
+                .map_err(typed_js_error)?
                 .live_set_stroke(handle.semantic_mobject(), red, green, blue, opacity)
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = liveSetStrokeColor)]
@@ -5911,9 +5944,9 @@ mod wasm {
             )?;
             self.inner
                 .active_live_player()
-                .map_err(js_error)?
+                .map_err(typed_js_error)?
                 .live_set_stroke_color(handle.semantic_mobject(), red, green, blue, alpha)
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = liveDisableStroke)]
@@ -5927,9 +5960,9 @@ mod wasm {
             )?;
             self.inner
                 .active_live_player()
-                .map_err(js_error)?
+                .map_err(typed_js_error)?
                 .live_disable_stroke(handle.semantic_mobject())
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = liveSetStrokeOpacity)]
@@ -5944,9 +5977,9 @@ mod wasm {
             )?;
             self.inner
                 .active_live_player()
-                .map_err(js_error)?
+                .map_err(typed_js_error)?
                 .live_set_stroke_opacity(handle.semantic_mobject(), opacity)
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = liveSetOpacity)]
@@ -5961,9 +5994,9 @@ mod wasm {
             )?;
             self.inner
                 .active_live_player()
-                .map_err(js_error)?
+                .map_err(typed_js_error)?
                 .live_set_opacity(handle.semantic_mobject(), opacity)
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = liveSetObjectOpacity)]
@@ -5978,9 +6011,9 @@ mod wasm {
             )?;
             self.inner
                 .active_live_player()
-                .map_err(js_error)?
+                .map_err(typed_js_error)?
                 .live_set_object_opacity(handle.semantic_mobject(), opacity)
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = liveAdd)]
@@ -6057,13 +6090,13 @@ mod wasm {
             batch: WasmSceneMembershipBatch,
         ) -> Result<crate::WasmAuthoringFamilyHandle, JsValue> {
             if batch.inner.kind != SceneMembershipBatchKind::Add {
-                return Err(js_error("family creation requires an add batch"));
+                return Err(typed_js_error("family creation requires an add batch"));
             }
-            let members = batch.inner.family_members().map_err(js_error)?;
+            let members = batch.inner.family_members().map_err(typed_js_error)?;
             self.inner
                 .live_family(&members)
                 .map(crate::WasmAuthoringFamilyHandle::from_semantic_family)
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         /// Commit all requested direct-member edits before returning wrapper decisions.
@@ -6076,16 +6109,16 @@ mod wasm {
             let adding = match batch.inner.kind {
                 SceneMembershipBatchKind::Add => true,
                 SceneMembershipBatchKind::Remove => false,
-                _ => return Err(js_error("family membership requires add or remove")),
+                _ => return Err(typed_js_error("family membership requires add or remove")),
             };
             let family = handle.semantic_family()?;
-            let members = batch.inner.family_members().map_err(js_error)?;
+            let members = batch.inner.family_members().map_err(typed_js_error)?;
             self.inner
                 .active_live_player()
-                .map_err(js_error)?
+                .map_err(typed_js_error)?
                 .live_edit_family_members(&family, &members, adding)
                 .map(|changed| changed.into_iter().map(u8::from).collect())
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = liveShiftFamily)]
@@ -6100,13 +6133,13 @@ mod wasm {
                 self.inner.scene.integration_store(),
                 family.integration_store(),
             ) {
-                return Err(js_error(
+                return Err(typed_js_error(
                     "family and canonical context belong to different authoring stores",
                 ));
             }
             self.inner
                 .live_shift_family(&family, x, y)
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = liveSetFamilyColor)]
@@ -6123,9 +6156,9 @@ mod wasm {
 
             self.inner
                 .active_live_player()
-                .map_err(js_error)?
+                .map_err(typed_js_error)?
                 .live_set_family_color(&family, red, green, blue, alpha)
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = liveSetFamilyFill)]
@@ -6142,12 +6175,12 @@ mod wasm {
         ) -> Result<(), JsValue> {
             let family = handle.semantic_family()?;
             let color = crate::authoring_mobject::family_color(has_color, red, green, blue, alpha)
-                .map_err(js_error)?;
+                .map_err(typed_js_error)?;
             self.inner
                 .active_live_player()
-                .map_err(js_error)?
+                .map_err(typed_js_error)?
                 .live_set_family_fill(&family, color, opacity)
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = liveSetFamilyStroke)]
@@ -6165,12 +6198,12 @@ mod wasm {
         ) -> Result<(), JsValue> {
             let family = handle.semantic_family()?;
             let color = crate::authoring_mobject::family_color(has_color, red, green, blue, alpha)
-                .map_err(js_error)?;
+                .map_err(typed_js_error)?;
             self.inner
                 .active_live_player()
-                .map_err(js_error)?
+                .map_err(typed_js_error)?
                 .live_set_family_stroke(&family, color, width, opacity)
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = liveSetFamilyOpacity)]
@@ -6184,9 +6217,9 @@ mod wasm {
 
             self.inner
                 .active_live_player()
-                .map_err(js_error)?
+                .map_err(typed_js_error)?
                 .live_set_family_opacity(&family, opacity)
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = liveArrangeFamilyInGrid)]
@@ -6201,7 +6234,7 @@ mod wasm {
             let family = handle.semantic_family()?;
             self.inner
                 .active_live_player()
-                .map_err(js_error)?
+                .map_err(typed_js_error)?
                 .live_arrange_family_in_grid(
                     &family,
                     rows.map(|v| v as usize),
@@ -6209,7 +6242,7 @@ mod wasm {
                     gap_x,
                     gap_y,
                 )
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = liveScaleFamily)]
@@ -6222,9 +6255,9 @@ mod wasm {
             let family = handle.semantic_family()?;
             self.inner
                 .active_live_player()
-                .map_err(js_error)?
+                .map_err(typed_js_error)?
                 .live_scale_family(&family, x, y)
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = liveRotateFamily)]
@@ -6244,9 +6277,9 @@ mod wasm {
             };
             self.inner
                 .active_live_player()
-                .map_err(js_error)?
+                .map_err(typed_js_error)?
                 .live_rotate_family(&family, angle, pivot)
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = liveArrangeFamily)]
@@ -6258,7 +6291,7 @@ mod wasm {
             let family = handle.semantic_family()?;
             self.inner
                 .live_arrange_family(&family, &options.options)
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = liveSetScale)]
@@ -6292,9 +6325,9 @@ mod wasm {
             )?;
             self.inner
                 .active_live_player()
-                .map_err(js_error)?
+                .map_err(typed_js_error)?
                 .live_scale(handle.semantic_mobject(), x, y)
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = liveSetRotation)]
@@ -6326,9 +6359,9 @@ mod wasm {
             )?;
             self.inner
                 .active_live_player()
-                .map_err(js_error)?
+                .map_err(typed_js_error)?
                 .live_rotate(handle.semantic_mobject(), angle)
-                .map_err(js_error)
+                .map_err(typed_js_error)
         }
 
         #[wasm_bindgen(js_name = liveEffectiveMobject)]
@@ -8998,10 +9031,17 @@ mod tests {
         );
 
         let player = context.take_execution_player(2.0, 17).unwrap();
-        assert!(context
-            .mobject_layout(&circle)
-            .unwrap_err()
-            .contains("running in the semantic engine"));
+        {
+            let error = context.mobject_layout(&circle).unwrap_err();
+            assert_eq!(
+                (error.category, error.code),
+                ("unclassified", "unclassified")
+            );
+            assert_eq!(
+                error.message,
+                "live execution session is running in the semantic engine"
+            );
+        }
         context.return_execution_player(player).unwrap();
         assert_eq!(
             context.mobject_layout(&circle).unwrap(),
@@ -9060,22 +9100,50 @@ mod tests {
         assert_eq!(line.manim_line_endpoints().unwrap().start, (-1.0, 0.0));
 
         let player = context.take_execution_player(2.0, 17).unwrap();
-        assert!(context
-            .mobject_line_endpoints(&line)
-            .unwrap_err()
-            .contains("running in the semantic engine"));
-        assert!(context
-            .mobject_color(&line)
-            .unwrap_err()
-            .contains("running in the semantic engine"));
-        assert!(context
-            .mobject_fill_opacity(&line)
-            .unwrap_err()
-            .contains("running in the semantic engine"));
-        assert!(context
-            .mobject_stroke_opacity(&line)
-            .unwrap_err()
-            .contains("running in the semantic engine"));
+        {
+            let error = context.mobject_line_endpoints(&line).unwrap_err();
+            assert_eq!(
+                (error.category, error.code),
+                ("unclassified", "unclassified")
+            );
+            assert_eq!(
+                error.message,
+                "live execution session is running in the semantic engine"
+            );
+        }
+        {
+            let error = context.mobject_color(&line).unwrap_err();
+            assert_eq!(
+                (error.category, error.code),
+                ("unclassified", "unclassified")
+            );
+            assert_eq!(
+                error.message,
+                "live execution session is running in the semantic engine"
+            );
+        }
+        {
+            let error = context.mobject_fill_opacity(&line).unwrap_err();
+            assert_eq!(
+                (error.category, error.code),
+                ("unclassified", "unclassified")
+            );
+            assert_eq!(
+                error.message,
+                "live execution session is running in the semantic engine"
+            );
+        }
+        {
+            let error = context.mobject_stroke_opacity(&line).unwrap_err();
+            assert_eq!(
+                (error.category, error.code),
+                ("unclassified", "unclassified")
+            );
+            assert_eq!(
+                error.message,
+                "live execution session is running in the semantic engine"
+            );
+        }
         context.return_execution_player(player).unwrap();
         assert_eq!(context.mobject_line_endpoints(&line).unwrap(), observed);
         assert_eq!(context.mobject_color(&line).unwrap(), color);
@@ -9128,15 +9196,23 @@ mod tests {
         let detached_underline = context.live_create_manim_geometry(options).unwrap();
         assert_eq!(detached_underline.center().unwrap(), (8.0, 6.35));
         let foreign = noon::Scene::new().circle(1.0).unwrap();
-        assert!(context
-            .begin_underline(&foreign, 0.15)
-            .unwrap_err()
-            .contains("another authoring store"));
+        let error = context.begin_underline(&foreign, 0.15).unwrap_err();
+        assert_eq!(
+            (error.category, error.code),
+            ("foreign_handle", "authoring.foreign_store")
+        );
         let _player = context.take_execution_player(2.0, 17).unwrap();
-        assert!(context
-            .begin_underline(&circle, 0.15)
-            .unwrap_err()
-            .contains("running in the semantic engine"));
+        {
+            let error = context.begin_underline(&circle, 0.15).unwrap_err();
+            assert_eq!(
+                (error.category, error.code),
+                ("unclassified", "unclassified")
+            );
+            assert_eq!(
+                error.message,
+                "live execution session is running in the semantic engine"
+            );
+        }
     }
 
     #[test]
@@ -9390,18 +9466,45 @@ mod tests {
         );
 
         let leased = context.take_execution_player(end, 18).unwrap();
-        assert!(context
-            .live_create_text(noon::Text::new("Rejected"))
-            .unwrap_err()
-            .contains("running in the semantic engine"));
-        assert!(context
-            .live_create_typst(noon::Typst::new("Rejected"))
-            .unwrap_err()
-            .contains("running in the semantic engine"));
-        assert!(context
-            .live_create_math_typst(noon::MathTypst::new("Rejected"))
-            .unwrap_err()
-            .contains("running in the semantic engine"));
+        {
+            let error = context
+                .live_create_text(noon::Text::new("Rejected"))
+                .unwrap_err();
+            assert_eq!(
+                (error.category, error.code),
+                ("unclassified", "unclassified")
+            );
+            assert_eq!(
+                error.message,
+                "live execution session is running in the semantic engine"
+            );
+        }
+        {
+            let error = context
+                .live_create_typst(noon::Typst::new("Rejected"))
+                .unwrap_err();
+            assert_eq!(
+                (error.category, error.code),
+                ("unclassified", "unclassified")
+            );
+            assert_eq!(
+                error.message,
+                "live execution session is running in the semantic engine"
+            );
+        }
+        {
+            let error = context
+                .live_create_math_typst(noon::MathTypst::new("Rejected"))
+                .unwrap_err();
+            assert_eq!(
+                (error.category, error.code),
+                ("unclassified", "unclassified")
+            );
+            assert_eq!(
+                error.message,
+                "live execution session is running in the semantic engine"
+            );
+        }
         context.return_execution_player(leased).unwrap();
     }
 
@@ -9527,9 +9630,10 @@ mod tests {
         circle.shift(3.0, -1.0).unwrap();
 
         let query_error = context.mobject_layout(&circle).unwrap_err();
-        assert!(
-            query_error.contains("has not been published"),
-            "{query_error}"
+        assert_eq!(query_error.category, "stale_publication");
+        assert_eq!(
+            query_error.cause.as_ref().unwrap().code,
+            "publication.stale_scene_revision"
         );
         let run_error = context.prepare_execution_run().unwrap_err();
         assert!(run_error.contains("authored scene changed while live execution is active"));

--- a/crates/noon-web/src/canonical_authoring_scene.rs
+++ b/crates/noon-web/src/canonical_authoring_scene.rs
@@ -2477,6 +2477,12 @@ mod wasm {
 
     use crate::authoring_error::js_error;
 
+    // The callback overlay is an explicit codec boundary. Preserve codec causes
+    // without assigning them an authoring category based on their diagnostics.
+    fn callback_codec_error(error: impl std::error::Error + 'static) -> JsValue {
+        typed_js_error(AuthoringFailure::unclassified("callback.codec", &error))
+    }
+
     fn parse_object_id(label: &str, value: &str) -> Result<ObjectId, JsValue> {
         value
             .parse::<u64>()
@@ -2630,14 +2636,14 @@ mod wasm {
         pub(crate) fn create_family(
             &self,
             store: std::rc::Rc<std::cell::RefCell<noon_core::SemanticStore>>,
-        ) -> Result<noon::MobjectFamily, String> {
+        ) -> Result<noon::MobjectFamily, AuthoringFailure> {
             self.inner.create_family(store)
         }
 
         pub(crate) fn edit_family(
             &self,
             family: &noon::MobjectFamily,
-        ) -> Result<Vec<bool>, String> {
+        ) -> Result<Vec<bool>, AuthoringFailure> {
             self.inner.edit_family(family)
         }
     }
@@ -4183,8 +4189,9 @@ mod wasm {
             ) {
                 return Err(typed_js_error(noon::AuthoringError::ForeignStore));
             }
-            let revision =
-                noon_core::SceneRevision::new(revision.parse::<u64>().map_err(js_error)?);
+            let revision = noon_core::SceneRevision::new(
+                revision.parse::<u64>().map_err(callback_codec_error)?,
+            );
             family
                 .callback_leaf_nodes(revision)
                 .map(|nodes| {
@@ -4233,12 +4240,13 @@ mod wasm {
                 ),
                 _ => return Err(js_error("unknown family paint operation")),
             };
-            let revision =
-                noon_core::SceneRevision::new(revision.parse::<u64>().map_err(js_error)?);
+            let revision = noon_core::SceneRevision::new(
+                revision.parse::<u64>().map_err(callback_codec_error)?,
+            );
             // This is the existing Python callback view/overlay codec boundary,
             // never an authored scene or a native/direct-WASM engine boundary.
             let rows: Vec<(u32, u32, Style)> =
-                serde_json::from_str(styles_json).map_err(js_error)?;
+                serde_json::from_str(styles_json).map_err(callback_codec_error)?;
             let styles: BTreeMap<_, _> = rows
                 .into_iter()
                 .map(|(slot, generation, style)| {
@@ -4257,7 +4265,7 @@ mod wasm {
                 .into_iter()
                 .map(|(node, style)| (node.slot(), node.generation(), style))
                 .collect();
-            serde_json::to_string(&rows).map_err(js_error)
+            serde_json::to_string(&rows).map_err(callback_codec_error)
         }
 
         /// Prepare a family translation over the existing callback read/overlay
@@ -4274,10 +4282,11 @@ mod wasm {
         ) -> Result<String, JsValue> {
             self.callback_family_keys(handle, revision)?;
             let family = handle.semantic_family()?;
-            let revision =
-                noon_core::SceneRevision::new(revision.parse::<u64>().map_err(js_error)?);
+            let revision = noon_core::SceneRevision::new(
+                revision.parse::<u64>().map_err(callback_codec_error)?,
+            );
             let rows: Vec<(u32, u32, Transform2D, Option<noon_core::Rect>)> =
-                serde_json::from_str(rows_json).map_err(js_error)?;
+                serde_json::from_str(rows_json).map_err(callback_codec_error)?;
             let rows: BTreeMap<_, _> = rows
                 .into_iter()
                 .map(|(slot, generation, transform, bounds)| {
@@ -4316,7 +4325,7 @@ mod wasm {
                     )
                 })
                 .collect();
-            serde_json::to_string(&rows).map_err(js_error)
+            serde_json::to_string(&rows).map_err(callback_codec_error)
         }
 
         /// Apply shared Manim `set_color` semantics to callback-local paint.
@@ -7169,10 +7178,13 @@ mod tests {
         let handed_off = context.take_execution_player(1.0, 41).unwrap();
         let revision = context.scene.integration_store().borrow().scene_revision();
         let before = source.state().unwrap();
-        assert!(context
+        let error = context
             .live_become_mobject(&source, &target, Default::default())
-            .unwrap_err()
-            .contains("semantic engine"));
+            .unwrap_err();
+        assert_eq!(
+            (error.category, error.code),
+            ("unclassified", "unclassified")
+        );
         assert_eq!(
             context.scene.integration_store().borrow().scene_revision(),
             revision

--- a/crates/noon-web/src/manim_shape_matcher_handle_bridge.rs
+++ b/crates/noon-web/src/manim_shape_matcher_handle_bridge.rs
@@ -7,9 +7,7 @@ use wasm_bindgen::prelude::*;
 
 use crate::{WasmAuthoringFamilyLayout, WasmAuthoringMobjectHandle, WasmManimGeometryOptions};
 
-fn js_error(error: impl std::fmt::Display) -> JsValue {
-    JsValue::from_str(&error.to_string())
-}
+use crate::authoring_error::js_error;
 
 fn mobject_bounds(handle: &WasmAuthoringMobjectHandle) -> Result<Bounds2D64, JsValue> {
     let object = handle.semantic_mobject();

--- a/crates/noon-web/src/semantic_execution_player.rs
+++ b/crates/noon-web/src/semantic_execution_player.rs
@@ -420,7 +420,7 @@ impl SemanticExecutionPlayer {
         target: noon::LiveLayoutTarget<'_>,
         edge: (f64, f64),
         mask: (f64, f64),
-    ) -> Result<(), String> {
+    ) -> Result<(), AuthoringFailure> {
         self.with_live_session(|live| live.move_to(mobject, target, edge, mask))
             .map(|_| ())
     }
@@ -431,7 +431,7 @@ impl SemanticExecutionPlayer {
         target: &noon::Mobject,
         other: &noon::Mobject,
         options: noon::ManimBecomeOptions,
-    ) -> Result<(), String> {
+    ) -> Result<(), AuthoringFailure> {
         let semantics = self
             .semantics
             .clone()
@@ -444,14 +444,14 @@ impl SemanticExecutionPlayer {
         )
         .become_mobject(target, other, options)
         .map(|_| ())
-        .map_err(|error| error.to_string())
+        .map_err(AuthoringFailure::from)
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
     pub(crate) fn live_create_manim_geometry(
         &mut self,
         options: noon::ManimGeometryOptions,
-    ) -> Result<noon::Mobject, String> {
+    ) -> Result<noon::Mobject, AuthoringFailure> {
         let semantics = self
             .semantics
             .clone()
@@ -463,11 +463,14 @@ impl SemanticExecutionPlayer {
             &mut self.session,
         )
         .create_manim_geometry(options)
-        .map_err(|error| error.to_string())
+        .map_err(AuthoringFailure::from)
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
-    pub(crate) fn live_create_text(&mut self, text: noon::Text) -> Result<noon::Mobject, String> {
+    pub(crate) fn live_create_text(
+        &mut self,
+        text: noon::Text,
+    ) -> Result<noon::Mobject, AuthoringFailure> {
         let semantics = self
             .semantics
             .clone()
@@ -479,11 +482,14 @@ impl SemanticExecutionPlayer {
             &mut self.session,
         )
         .create_text(text)
-        .map_err(|error| error.to_string())
+        .map_err(AuthoringFailure::from)
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
-    pub(crate) fn live_create_typst(&mut self, text: noon::Typst) -> Result<noon::Mobject, String> {
+    pub(crate) fn live_create_typst(
+        &mut self,
+        text: noon::Typst,
+    ) -> Result<noon::Mobject, AuthoringFailure> {
         let semantics = self
             .semantics
             .clone()
@@ -495,14 +501,14 @@ impl SemanticExecutionPlayer {
             &mut self.session,
         )
         .create_typst(text)
-        .map_err(|error| error.to_string())
+        .map_err(AuthoringFailure::from)
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
     pub(crate) fn live_create_math_typst(
         &mut self,
         text: noon::MathTypst,
-    ) -> Result<noon::Mobject, String> {
+    ) -> Result<noon::Mobject, AuthoringFailure> {
         let semantics = self
             .semantics
             .clone()
@@ -514,7 +520,7 @@ impl SemanticExecutionPlayer {
             &mut self.session,
         )
         .create_math_typst(text)
-        .map_err(|error| error.to_string())
+        .map_err(AuthoringFailure::from)
     }
 
     #[cfg(target_arch = "wasm32")]
@@ -525,7 +531,7 @@ impl SemanticExecutionPlayer {
         green: f64,
         blue: f64,
         alpha: f64,
-    ) -> Result<(), String> {
+    ) -> Result<(), AuthoringFailure> {
         self.with_live_session(|live| live.set_family_color(family, red, green, blue, alpha))
             .map(|_| ())
     }
@@ -536,7 +542,7 @@ impl SemanticExecutionPlayer {
         family: &noon::MobjectFamily,
         color: Option<noon::Color>,
         opacity: Option<f64>,
-    ) -> Result<(), String> {
+    ) -> Result<(), AuthoringFailure> {
         self.with_live_session(|live| live.set_family_fill(family, color, opacity))
             .map(|_| ())
     }
@@ -548,7 +554,7 @@ impl SemanticExecutionPlayer {
         color: Option<noon::Color>,
         width: Option<f64>,
         opacity: Option<f64>,
-    ) -> Result<(), String> {
+    ) -> Result<(), AuthoringFailure> {
         self.with_live_session(|live| live.set_family_stroke(family, color, width, opacity))
             .map(|_| ())
     }
@@ -558,7 +564,7 @@ impl SemanticExecutionPlayer {
         &mut self,
         family: &noon::MobjectFamily,
         opacity: f64,
-    ) -> Result<(), String> {
+    ) -> Result<(), AuthoringFailure> {
         self.with_live_session(|live| live.set_family_opacity(family, opacity))
             .map(|_| ())
     }
@@ -571,7 +577,7 @@ impl SemanticExecutionPlayer {
         green: f64,
         blue: f64,
         opacity: f64,
-    ) -> Result<(), String> {
+    ) -> Result<(), AuthoringFailure> {
         self.with_live_session(|live| live.set_fill(mobject, red, green, blue, opacity))
             .map(|_| ())
     }
@@ -584,13 +590,16 @@ impl SemanticExecutionPlayer {
         green: f64,
         blue: f64,
         alpha: f64,
-    ) -> Result<(), String> {
+    ) -> Result<(), AuthoringFailure> {
         self.with_live_session(|live| live.set_fill_color(mobject, red, green, blue, alpha))
             .map(|_| ())
     }
 
     #[cfg(target_arch = "wasm32")]
-    pub(crate) fn live_disable_fill(&mut self, mobject: &noon::Mobject) -> Result<(), String> {
+    pub(crate) fn live_disable_fill(
+        &mut self,
+        mobject: &noon::Mobject,
+    ) -> Result<(), AuthoringFailure> {
         self.with_live_session(|live| live.disable_fill(mobject))
             .map(|_| ())
     }
@@ -600,7 +609,7 @@ impl SemanticExecutionPlayer {
         &mut self,
         mobject: &noon::Mobject,
         opacity: f64,
-    ) -> Result<(), String> {
+    ) -> Result<(), AuthoringFailure> {
         self.with_live_session(|live| live.set_fill_opacity(mobject, opacity))
             .map(|_| ())
     }
@@ -613,7 +622,7 @@ impl SemanticExecutionPlayer {
         green: f64,
         blue: f64,
         alpha: f64,
-    ) -> Result<(), String> {
+    ) -> Result<(), AuthoringFailure> {
         self.with_live_session(|live| live.set_color(mobject, red, green, blue, alpha))
             .map(|_| ())
     }
@@ -626,7 +635,7 @@ impl SemanticExecutionPlayer {
         green: f64,
         blue: f64,
         opacity: f64,
-    ) -> Result<(), String> {
+    ) -> Result<(), AuthoringFailure> {
         self.with_live_session(|live| live.set_stroke(mobject, red, green, blue, opacity))
             .map(|_| ())
     }
@@ -639,13 +648,16 @@ impl SemanticExecutionPlayer {
         green: f64,
         blue: f64,
         alpha: f64,
-    ) -> Result<(), String> {
+    ) -> Result<(), AuthoringFailure> {
         self.with_live_session(|live| live.set_stroke_color(mobject, red, green, blue, alpha))
             .map(|_| ())
     }
 
     #[cfg(target_arch = "wasm32")]
-    pub(crate) fn live_disable_stroke(&mut self, mobject: &noon::Mobject) -> Result<(), String> {
+    pub(crate) fn live_disable_stroke(
+        &mut self,
+        mobject: &noon::Mobject,
+    ) -> Result<(), AuthoringFailure> {
         self.with_live_session(|live| live.disable_stroke(mobject))
             .map(|_| ())
     }
@@ -655,7 +667,7 @@ impl SemanticExecutionPlayer {
         &mut self,
         mobject: &noon::Mobject,
         opacity: f64,
-    ) -> Result<(), String> {
+    ) -> Result<(), AuthoringFailure> {
         self.with_live_session(|live| live.set_stroke_opacity(mobject, opacity))
             .map(|_| ())
     }
@@ -665,7 +677,7 @@ impl SemanticExecutionPlayer {
         &mut self,
         mobject: &noon::Mobject,
         opacity: f64,
-    ) -> Result<(), String> {
+    ) -> Result<(), AuthoringFailure> {
         self.with_live_session(|live| live.set_opacity(mobject, opacity))
             .map(|_| ())
     }
@@ -675,7 +687,7 @@ impl SemanticExecutionPlayer {
         &mut self,
         mobject: &noon::Mobject,
         opacity: f64,
-    ) -> Result<(), String> {
+    ) -> Result<(), AuthoringFailure> {
         self.with_live_session(|live| live.set_object_opacity(mobject, opacity))
             .map(|_| ())
     }
@@ -684,7 +696,7 @@ impl SemanticExecutionPlayer {
     fn with_live_session<T>(
         &mut self,
         operation: impl FnOnce(&mut noon::LiveSession<'_>) -> Result<T, noon::LiveSessionError>,
-    ) -> Result<T, String> {
+    ) -> Result<T, AuthoringFailure> {
         let semantics = self
             .semantics
             .clone()
@@ -695,7 +707,7 @@ impl SemanticExecutionPlayer {
                 .expect("live semantic store has one scene root"),
             &mut self.session,
         ))
-        .map_err(|error| error.to_string())
+        .map_err(AuthoringFailure::from)
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
@@ -747,7 +759,7 @@ impl SemanticExecutionPlayer {
         family: &noon::MobjectFamily,
         x: f64,
         y: f64,
-    ) -> Result<(), String> {
+    ) -> Result<(), AuthoringFailure> {
         self.with_live_session(|session| session.shift_family(family, x, y))
             .map(|_| ())
     }
@@ -760,7 +772,7 @@ impl SemanticExecutionPlayer {
         columns: Option<usize>,
         gap_x: f64,
         gap_y: f64,
-    ) -> Result<(), String> {
+    ) -> Result<(), AuthoringFailure> {
         self.with_live_session(|live| {
             live.arrange_family_in_grid(family, rows, columns, gap_x, gap_y)
         })
@@ -774,7 +786,7 @@ impl SemanticExecutionPlayer {
         length: f64,
         dimension: noon::LayoutDimension,
         stretch: bool,
-    ) -> Result<(), String> {
+    ) -> Result<(), AuthoringFailure> {
         self.with_live_session(|live| live.rescale_to_fit(source, length, dimension, stretch))
     }
 
@@ -785,7 +797,7 @@ impl SemanticExecutionPlayer {
         target: &noon::LayoutAnchor,
         dimension: noon::LayoutDimension,
         stretch: bool,
-    ) -> Result<(), String> {
+    ) -> Result<(), AuthoringFailure> {
         self.with_live_session(|live| live.match_dim_size(source, target, dimension, stretch))
     }
 
@@ -795,7 +807,7 @@ impl SemanticExecutionPlayer {
         family: &noon::MobjectFamily,
         x: f64,
         y: f64,
-    ) -> Result<(), String> {
+    ) -> Result<(), AuthoringFailure> {
         self.with_live_session(|session| session.scale_family(family, x, y))
             .map(|_| ())
     }
@@ -806,7 +818,7 @@ impl SemanticExecutionPlayer {
         family: &noon::MobjectFamily,
         angle: f64,
         pivot: noon::ManimRotationPivot,
-    ) -> Result<(), String> {
+    ) -> Result<(), AuthoringFailure> {
         self.with_live_session(|session| session.rotate_family(family, angle, pivot))
             .map(|_| ())
     }
@@ -816,7 +828,7 @@ impl SemanticExecutionPlayer {
         &mut self,
         family: &noon::MobjectFamily,
         options: &noon::FamilyArrangeOptions,
-    ) -> Result<(), String> {
+    ) -> Result<(), AuthoringFailure> {
         self.with_live_session(|session| session.arrange_family_with_options(family, options))
             .map(|_| ())
     }
@@ -826,7 +838,7 @@ impl SemanticExecutionPlayer {
         &mut self,
         source: &noon::MobjectFamily,
         references: &[noon::MobjectFamilyMember<'_>],
-    ) -> Result<noon::FamilyCopy, String> {
+    ) -> Result<noon::FamilyCopy, AuthoringFailure> {
         self.with_live_session(|live| live.copy_family_with_references(source, references))
     }
 
@@ -834,7 +846,7 @@ impl SemanticExecutionPlayer {
     pub(crate) fn live_family_layout(
         &mut self,
         family: &noon::MobjectFamily,
-    ) -> Result<noon::EffectiveMobjectLayout, String> {
+    ) -> Result<noon::EffectiveMobjectLayout, AuthoringFailure> {
         self.with_live_session(|live| live.effective_family_layout(family))
     }
 
@@ -845,7 +857,7 @@ impl SemanticExecutionPlayer {
         target: noon::LiveLayoutTarget<'_>,
         edge: (f64, f64),
         mask: (f64, f64),
-    ) -> Result<(), String> {
+    ) -> Result<(), AuthoringFailure> {
         self.with_live_session(|live| live.move_family_to(family, target, edge, mask))
             .map(|_| ())
     }
@@ -857,7 +869,7 @@ impl SemanticExecutionPlayer {
         target: noon::LiveLayoutTarget<'_>,
         aligner: &noon::LayoutAnchor,
         args: noon::ManimNextToArgs,
-    ) -> Result<(), String> {
+    ) -> Result<(), AuthoringFailure> {
         self.with_live_session(|live| live.next_layout_to_aligned(source, target, aligner, args))
             .map(|_| ())
     }
@@ -868,7 +880,7 @@ impl SemanticExecutionPlayer {
         family: &noon::MobjectFamily,
         direction: (f64, f64),
         buff: f64,
-    ) -> Result<(), String> {
+    ) -> Result<(), AuthoringFailure> {
         self.with_live_session(|live| live.align_family_on_frame(family, direction, buff))
             .map(|_| ())
     }
@@ -879,7 +891,7 @@ impl SemanticExecutionPlayer {
         family: &noon::MobjectFamily,
         target: noon::LiveLayoutTarget<'_>,
         axis: (f64, f64),
-    ) -> Result<(), String> {
+    ) -> Result<(), AuthoringFailure> {
         self.with_live_session(|live| live.align_family_to(family, target, axis))
             .map(|_| ())
     }
@@ -912,7 +924,7 @@ impl SemanticExecutionPlayer {
         mobject: &noon::Mobject,
         x: f64,
         y: f64,
-    ) -> Result<(), String> {
+    ) -> Result<(), AuthoringFailure> {
         let semantics = self
             .semantics
             .clone()
@@ -925,7 +937,7 @@ impl SemanticExecutionPlayer {
         )
         .scale(mobject, x, y)
         .map(|_| ())
-        .map_err(|error| error.to_string())
+        .map_err(AuthoringFailure::from)
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
@@ -954,7 +966,7 @@ impl SemanticExecutionPlayer {
         &mut self,
         mobject: &noon::Mobject,
         angle: f64,
-    ) -> Result<(), String> {
+    ) -> Result<(), AuthoringFailure> {
         let semantics = self
             .semantics
             .clone()
@@ -967,7 +979,7 @@ impl SemanticExecutionPlayer {
         )
         .rotate(mobject, angle)
         .map(|_| ())
-        .map_err(|error| error.to_string())
+        .map_err(AuthoringFailure::from)
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
@@ -993,7 +1005,7 @@ impl SemanticExecutionPlayer {
     pub(crate) fn live_effective_layout(
         &mut self,
         mobject: &noon::Mobject,
-    ) -> Result<noon::EffectiveMobjectLayout, String> {
+    ) -> Result<noon::EffectiveMobjectLayout, AuthoringFailure> {
         let semantics = self
             .semantics
             .clone()
@@ -1005,14 +1017,14 @@ impl SemanticExecutionPlayer {
             &mut self.session,
         )
         .effective_layout(mobject)
-        .map_err(|error| error.to_string())
+        .map_err(AuthoringFailure::from)
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
     pub(crate) fn live_effective_line_endpoints(
         &mut self,
         mobject: &noon::Mobject,
-    ) -> Result<noon::ManimLineEndpoints, String> {
+    ) -> Result<noon::ManimLineEndpoints, AuthoringFailure> {
         let semantics = self
             .semantics
             .clone()
@@ -1024,14 +1036,14 @@ impl SemanticExecutionPlayer {
             &mut self.session,
         )
         .effective_line_endpoints(mobject)
-        .map_err(|error| error.to_string())
+        .map_err(AuthoringFailure::from)
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
     pub(crate) fn live_effective_manim_color(
         &mut self,
         mobject: &noon::Mobject,
-    ) -> Result<noon_core::Color, String> {
+    ) -> Result<noon_core::Color, AuthoringFailure> {
         let semantics = self
             .semantics
             .clone()
@@ -1043,7 +1055,7 @@ impl SemanticExecutionPlayer {
             &mut self.session,
         )
         .effective_manim_color(mobject)
-        .map_err(|error| error.to_string())
+        .map_err(AuthoringFailure::from)
     }
 
     /// Publish one already validated scene-membership batch through the active
@@ -1243,9 +1255,8 @@ impl SemanticExecutionPlayer {
     pub(crate) fn live_value_tracker(
         &mut self,
         initial: f64,
-    ) -> Result<noon::ValueTracker, String> {
-        self.require_completed_live_segment()
-            .map_err(|error| error.to_string())?;
+    ) -> Result<noon::ValueTracker, AuthoringFailure> {
+        self.require_completed_live_segment()?;
         let semantics = self
             .semantics
             .clone()
@@ -1257,7 +1268,7 @@ impl SemanticExecutionPlayer {
             &mut self.session,
         )
         .value_tracker(initial)
-        .map_err(|error| error.to_string())
+        .map_err(AuthoringFailure::from)
     }
 
     /// Associate and sparsely enroll one pre-existing tracker in this live root.
@@ -1265,9 +1276,8 @@ impl SemanticExecutionPlayer {
     pub(crate) fn live_associate_value_tracker(
         &mut self,
         tracker: &noon::ValueTracker,
-    ) -> Result<(), String> {
-        self.require_completed_live_segment()
-            .map_err(|error| error.to_string())?;
+    ) -> Result<(), AuthoringFailure> {
+        self.require_completed_live_segment()?;
         let semantics = self
             .semantics
             .clone()
@@ -1279,7 +1289,7 @@ impl SemanticExecutionPlayer {
             &mut self.session,
         )
         .associate_value_tracker(tracker)
-        .map_err(|error| error.to_string())
+        .map_err(AuthoringFailure::from)
     }
 
     /// Create a detached target through the retained session so its semantic
@@ -1289,7 +1299,7 @@ impl SemanticExecutionPlayer {
     pub(crate) fn live_target_editor(
         &mut self,
         source: &noon::Mobject,
-    ) -> Result<noon::Mobject, String> {
+    ) -> Result<noon::Mobject, AuthoringFailure> {
         let semantics = self
             .semantics
             .clone()
@@ -1301,7 +1311,7 @@ impl SemanticExecutionPlayer {
             &mut self.session,
         )
         .target_editor(source)
-        .map_err(|error| error.to_string())
+        .map_err(AuthoringFailure::from)
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
@@ -1310,7 +1320,7 @@ impl SemanticExecutionPlayer {
         family: &noon::MobjectFamily,
         members: &[noon::MobjectFamilyMember<'_>],
         adding: bool,
-    ) -> Result<Vec<bool>, String> {
+    ) -> Result<Vec<bool>, AuthoringFailure> {
         let semantics = self
             .semantics
             .clone()
@@ -1325,7 +1335,7 @@ impl SemanticExecutionPlayer {
         } else {
             live.remove_family_members(family, members)
         }
-        .map_err(|e| e.to_string())
+        .map_err(AuthoringFailure::from)
     }
 
     /// Create one detached family through the retained session so its node and
@@ -1334,7 +1344,7 @@ impl SemanticExecutionPlayer {
     pub(crate) fn live_family(
         &mut self,
         members: &[noon::MobjectFamilyMember<'_>],
-    ) -> Result<noon::MobjectFamily, String> {
+    ) -> Result<noon::MobjectFamily, AuthoringFailure> {
         let semantics = self
             .semantics
             .clone()
@@ -1346,7 +1356,7 @@ impl SemanticExecutionPlayer {
             &mut self.session,
         )
         .family(members)
-        .map_err(|error| error.to_string())
+        .map_err(AuthoringFailure::from)
     }
 
     /// Apply subset-display constructor preparation through the active retained
@@ -1637,7 +1647,7 @@ impl SemanticExecutionPlayer {
     pub(crate) fn live_effective_signal(
         &self,
         tracker: &noon::ValueTracker,
-    ) -> Result<f64, String> {
+    ) -> Result<f64, AuthoringFailure> {
         match self
             .session
             .effective_signal_value(tracker.node_id())
@@ -1653,7 +1663,7 @@ impl SemanticExecutionPlayer {
         &mut self,
         tracker: &noon::ValueTracker,
         value: f64,
-    ) -> Result<(), String> {
+    ) -> Result<(), AuthoringFailure> {
         if !value.is_finite() {
             return Err("ValueTracker value must be finite".into());
         }
@@ -1668,7 +1678,7 @@ impl SemanticExecutionPlayer {
             &mut self.session,
         )
         .set_value(tracker, value)
-        .map_err(|error| error.to_string())
+        .map_err(AuthoringFailure::from)
     }
 
     #[cfg(any(target_arch = "wasm32", test))]

--- a/crates/noon-web/src/semantic_execution_player.rs
+++ b/crates/noon-web/src/semantic_execution_player.rs
@@ -3705,7 +3705,7 @@ mod tests {
     }
 
     fn assert_late_text_resource_admission(
-        create: impl FnOnce(&mut SemanticExecutionPlayer) -> Result<noon::Mobject, String>,
+        create: impl FnOnce(&mut SemanticExecutionPlayer) -> Result<noon::Mobject, AuthoringFailure>,
     ) {
         let scene = noon::Scene::new();
         let mut player = SemanticExecutionPlayer::from_live_session(

--- a/scripts/manim-compat-smoke.mjs
+++ b/scripts/manim-compat-smoke.mjs
@@ -413,19 +413,20 @@ try {
     const copy = circle.cloneHandle();
     const target = circle.targetEditor();
     const identity = (handle) => `${handle.semanticSlot}:${handle.semanticGeneration}`;
-    // These three forwarding sites are still diagnostic-only R3 inventory.
-    // This fixture proves rejection/atomicity/lifetime; typed categories are
-    // checked by the independent Rust consumer and the typed-boundary runner.
-    // Do not classify human wording or accept an unrelated JS TypeError.
-    const rejectsUnmappedAuthoring = (operation) => {
+    // These public operations share the Rust foreign-store cause. Check the
+    // structured boundary while preserving the atomicity and lifetime evidence.
+    const rejectsForeignAuthoring = (operation) => {
       try { operation(); } catch (error) {
-        if (typeof error !== "string" || error.length === 0) throw error;
+        if (!(error instanceof Error) || error.noonErrorVersion !== 1 ||
+            error.category !== "foreign_handle" || error.code !== "authoring.foreign_store") {
+          throw error;
+        }
         return true;
       }
       return false;
     };
     const sameNumericId = identity(circle) === identity(foreign);
-    const foreignAddRejected = rejectsUnmappedAuthoring(() => family.editMembership(batch(circle, foreign)));
+    const foreignAddRejected = rejectsForeignAuthoring(() => family.editMembership(batch(circle, foreign)));
     if (family.memberCount !== 0) throw new Error("failed authored batch partially committed");
     family.editMembership(batch(circle, copy, target));
     const layout = family.layout();
@@ -438,9 +439,9 @@ try {
         throw new Error("rejected foreign placement changed local state");
       }
     };
-    const foreignObjectPlacementRejected = rejectsUnmappedAuthoring(() => layout.moveToMobject(foreign, 0, 0, 1, 1));
+    const foreignObjectPlacementRejected = rejectsForeignAuthoring(() => layout.moveToMobject(foreign, 0, 0, 1, 1));
     requireUnchangedLayout();
-    const foreignFamilyPlacementRejected = rejectsUnmappedAuthoring(() => layout.moveToFamily(foreignLayout, 0, 0, 1, 1));
+    const foreignFamilyPlacementRejected = rejectsForeignAuthoring(() => layout.moveToFamily(foreignLayout, 0, 0, 1, 1));
     requireUnchangedLayout();
     // Retry both exact placement entrypoints with valid local targets. The
     // copies start at the same center, so these controls preserve the layout.

--- a/scripts/shared-authoring-smoke.mjs
+++ b/scripts/shared-authoring-smoke.mjs
@@ -1603,8 +1603,9 @@ class ArrangedOptions(Scene):
         self.wait(0.1)
         try:
             invalid.arrange(center=False, index_of_submobject_to_align=0)
-        except IndexError:
-            pass
+        except NoonValueError as error:
+            assert error.category == "invalid_input"
+            assert (error.rust_cause or error).code == "authoring.invalid_submobject_index"
         else:
             raise AssertionError("late invalid arrangement index was accepted")
         assert abs(first.get_center().x + 1) < 1e-6
@@ -1651,8 +1652,9 @@ class SelectedAlignment(Scene):
         assert abs(second.get_center().x - 0.75) < 1e-6
         try:
             family.next_to(ORIGIN, index_of_submobject_to_align=-3)
-        except IndexError:
-            pass
+        except NoonValueError as error:
+            assert error.category == "invalid_input"
+            assert (error.rust_cause or error).code == "authoring.invalid_submobject_index"
         else:
             raise AssertionError("invalid family index was accepted")
         assert abs(first.get_center().x + 1.25) < 1e-6

--- a/scripts/typed-authoring-errors-smoke.mjs
+++ b/scripts/typed-authoring-errors-smoke.mjs
@@ -479,9 +479,8 @@ try {
     globalThis.noonResolveAnimationOptions = (...args) => {
       const result = wasm.resolveAnimationOptions(...args);
       try {
-        return {ok: result.ok, runTime: result.runTime, rateFunc: result.rateFunc,
-          lagRatio: result.lagRatio, pathArc: result.pathArc, reverseRateFunction: result.reverseRateFunction,
-          errorKind: result.errorKind ?? "", message: result.message ?? ""};
+        return {runTime: result.runTime, rateFunc: result.rateFunc,
+          lagRatio: result.lagRatio, pathArc: result.pathArc, reverseRateFunction: result.reverseRateFunction};
       } finally { result.free(); }
     };
     globalThis.noonUnmarkedError = () => { throw new Error("foreign handle invalid membership unsupported stale pending"); };
@@ -644,7 +643,7 @@ json.dumps({"matrix": results, "liveProperties": property_results, "advancement"
   assert.equal(report.python.liveProperties.length, 29);
   assert.equal(report.python.advancement.length, 9);
   assert.equal(report.python.contentObservations.length, 11);
-  assert.equal(report.python.additionalTests, 13);
+  assert.equal(report.python.additionalTests, 17);
 
 
   assert.equal(report.python.callbackTests, 8);

--- a/web/python-worker.source.js
+++ b/web/python-worker.source.js
@@ -212,14 +212,11 @@ function resolveAnimationOptionsPlain(...args) {
   const result = resolveAnimationOptions(...args);
   try {
     return {
-      ok: result.ok,
       runTime: result.runTime,
       rateFunc: result.rateFunc,
       lagRatio: result.lagRatio,
       pathArc: result.pathArc,
       reverseRateFunction: result.reverseRateFunction,
-      errorKind: result.errorKind ?? "",
-      message: result.message ?? "",
     };
   } finally {
     result.free();

--- a/web/python/_manim_animation_options.py
+++ b/web/python/_manim_animation_options.py
@@ -8,6 +8,7 @@ from typing import Any
 from js import noonResolveAnimationOptions as _resolve_shared_animation_options
 
 import _manim_rate_functions as _rate_functions
+from _noon_errors import engine_call
 
 
 _SUPPORTED_BUILDER_ARGS = {
@@ -75,7 +76,8 @@ def resolve(
     elif play_rate_func is not None:
         play_rate_id = _rate_functions.easing_from_rate_func(play_rate_func)
 
-    result = _resolve_shared_animation_options(
+    result = engine_call(
+        _resolve_shared_animation_options,
         float(default_lag_ratio),
         _optional_number(builder_args, "run_time"),
         _optional_rate_func(builder_args),
@@ -85,13 +87,8 @@ def resolve(
         float("nan") if play_run_time is None else float(play_run_time),
         play_rate_id,
         float("nan") if play_lag_ratio is None else float(play_lag_ratio),
+        operation="animation.options",
     )
-
-    if not bool(result.ok):
-        message = str(result.message)
-        if str(result.errorKind) == "unsupported":
-            raise NotImplementedError(message)
-        raise ValueError(message)
 
     return ResolvedAnimationOptions(
         run_time=float(result.runTime),

--- a/web/python/_manim_geometry.py
+++ b/web/python/_manim_geometry.py
@@ -7,6 +7,8 @@ for unsupported glyph rendering.
 
 from __future__ import annotations
 
+from _noon_errors import engine_call
+
 import copy
 import math
 from typing import Any
@@ -205,8 +207,5 @@ def match_points(self: _base.Mobject, mobject: object) -> _base.Mobject:
         raise NotImplementedError(
             "Line.match_points requires opaque shared semantic Line handles"
         )
-    try:
-        source_handle.matchLine(target_handle)
-    except Exception as error:
-        raise ValueError(str(error)) from None
+    engine_call(source_handle.matchLine, target_handle, operation="Line.match_points")
     return self

--- a/web/python/_manim_reactive.py
+++ b/web/python/_manim_reactive.py
@@ -6,6 +6,8 @@ Scalar values, signal identity, graph declarations and playback belong to Rust.
 
 from __future__ import annotations
 
+from _noon_errors import engine_call, raise_engine_error
+
 import math
 from contextvars import ContextVar
 from typing import Any
@@ -107,7 +109,7 @@ class ValueTracker:
         if _create_tracker_handle is not None:
             self._scene = None
             self._canonical_context = None
-            self._canonical_handle = _create_tracker_handle(value)
+            self._canonical_handle = engine_call(_create_tracker_handle, value)
             return
         raise RuntimeError("ValueTracker requires the shared Rust authoring context")
 
@@ -152,9 +154,9 @@ class ValueTracker:
         if handle is None:
             raise ValueError("ValueTracker has no detached shared semantic handle")
         try:
-            context.associateValueTracker(handle)
+            engine_call(context.associateValueTracker, handle)
         except Exception as error:
-            raise ValueError(str(error)) from None
+            raise_engine_error(error)
         self._commit_canonical_association(scene, context)
 
     def _commit_canonical_association(self, scene: _base.Scene, context: object) -> None:
@@ -173,13 +175,13 @@ class ValueTracker:
             return _manim_updaters.canonical_callback_scalar_value(self._scene, canonical[1])
         if canonical is not None:
             context, handle = canonical
-            return float(context.valueTrackerValue(handle))
+            return float(engine_call(context.valueTrackerValue, handle))
         detached = self._detached_canonical_handle()
         if detached is not None:
             try:
-                return float(detached.detachedValue())
+                return float(engine_call(detached.detachedValue))
             except Exception as error:
-                raise ValueError(str(error)) from None
+                raise_engine_error(error)
         raise RuntimeError("ValueTracker has no shared semantic handle")
 
     def set_value(self, value: float) -> ValueTracker:
@@ -194,16 +196,16 @@ class ValueTracker:
                 )
             context, handle = canonical
             try:
-                context.setValueTracker(handle, value)
+                engine_call(context.setValueTracker, handle, value)
             except Exception as error:
-                raise ValueError(str(error)) from None
+                raise_engine_error(error)
             return self
         detached = self._detached_canonical_handle()
         if detached is not None:
             try:
-                detached.setDetachedValue(value)
+                engine_call(detached.setDetachedValue, value)
             except Exception as error:
-                raise ValueError(str(error)) from None
+                raise_engine_error(error)
             return self
         raise RuntimeError("ValueTracker has no shared semantic handle")
 

--- a/web/python/_manim_scene.py
+++ b/web/python/_manim_scene.py
@@ -369,7 +369,7 @@ def _bind_camera_frame(scene: _base.Scene, mobject: _base.Mobject) -> _ir.Object
     reservation = _TypedBindingReservation(
         _ir.Object(object_id, scene._owner), authoring_key
     )
-    handle = _context(scene).createCameraFrame(str(object_id))
+    handle = engine_call(_context(scene).createCameraFrame, str(object_id), operation="Scene.camera")
     _semantic_handles._attach_shared_handle(mobject, handle)
     return _commit_typed_binding(mobject, scene, reservation, handle)
 
@@ -2051,7 +2051,7 @@ def _play(self, *args, **kwargs):
 def _canonical_value_tracker(self: _base.Scene, value: float = 0.0) -> _reactive.ValueTracker:
     context = _context(self)
     return _reactive.ValueTracker._from_canonical(
-        self, context, context.createValueTracker(float(value))
+        self, context, engine_call(context.createValueTracker, float(value), operation="Scene.value_tracker")
     )
 
 
@@ -2060,7 +2060,7 @@ def _canonical_vector_signal(scene: _base.Scene, method: str) -> _reactive.Nativ
     try:
         handle = getattr(context, method)()
     except Exception as error:
-        raise ValueError(str(error)) from None
+        raise_engine_error(error)
     return _reactive.NativeVectorSignal._from_canonical(scene, context, handle)
 
 
@@ -2071,7 +2071,7 @@ def _canonical_tracker_signal(
     try:
         handle = getattr(context, method)(*args)
     except Exception as error:
-        raise ValueError(str(error)) from None
+        raise_engine_error(error)
     return _reactive.ValueTracker._from_canonical(scene, context, handle)
 
 
@@ -2097,7 +2097,7 @@ def _canonical_key_state_signal(
     try:
         handle = context.keyStateSignal(code, initial)
     except Exception as error:
-        raise ValueError(str(error)) from None
+        raise_engine_error(error)
     return _reactive.NativeBoolSignal._from_canonical(self, context, handle)
 
 
@@ -2173,7 +2173,7 @@ def _canonical_bind_signal(
     try:
         getattr(context, method)(handle, signal_handle)
     except Exception as error:
-        raise ValueError(str(error)) from None
+        raise_engine_error(error)
     return self
 
 
@@ -2301,14 +2301,14 @@ def _canonical_bind_position(
     context, tracker_handle = canonical
     if context is not _context(self):
         raise ValueError("ValueTracker belongs to another canonical Scene context")
-    position = context.trackerPosition(
+    position = engine_call(context.trackerPosition,
         tracker_handle,
         float(direction_ir["x"]),
         float(direction_ir["y"]),
         float(offset_ir["x"]),
         float(offset_ir["y"]),
     )
-    context.bindTrackerPosition(handle, position)
+    engine_call(context.bindTrackerPosition, handle, position, operation="Scene.bind_position")
     return self
 
 

--- a/web/python/_manim_semantic_handles.py
+++ b/web/python/_manim_semantic_handles.py
@@ -6,6 +6,8 @@ uses its explicit staged property view; this module installs no public methods.
 
 from __future__ import annotations
 
+from _noon_errors import engine_call, raise_engine_error
+
 import copy
 import json
 import sys
@@ -101,7 +103,7 @@ def _live_mutation_context(value: object):
         context = getattr(scene, "_canonical_authoring_context", None)
     if context is None:
         return None
-    ownership = str(context.liveExecutionOwnership())
+    ownership = str(engine_call(context.liveExecutionOwnership))
     # Returning the player keeps its runtime alive for the next source operation.
     # Mutations and target creation must publish through that same session too.
     # A transferred runtime retains this context so its typed call rejects before
@@ -137,12 +139,12 @@ def _typed_manim_observation(
             raise NotImplementedError(
                 "typed Mobject observation is unavailable in this authoring phase"
             )
-        return query(semantic_handle)
+        return engine_call(query, semantic_handle)
     handle = _handle_for(value)
     if handle is None:
         raise NotImplementedError("typed Mobject observation is unavailable in this authoring phase")
-    observation = getattr(handle, handle_method)
-    return observation if handle_property else observation()
+    observation = engine_call(getattr, handle, handle_method)
+    return observation if handle_property else engine_call(observation)
 
 
 def _manim_line_endpoints_observation(value: object):
@@ -162,19 +164,7 @@ def _require_typed_manim_line(value: object) -> bool:
     semantic_handle = getattr(value, "_semantic_handle", None)
     if semantic_handle is None or not bool(getattr(value, "_semantic_handle_fresh", False)):
         raise NotImplementedError("exact Line admission requires a valid semantic handle")
-    try:
-        _manim_line_endpoints_observation(value)
-    except Exception:
-        # Preserve ownership/effective-driver failures for an authored Line. A
-        # direct authored query is used only to classify wrong semantic content.
-        try:
-            semantic_handle.manimLineEndpoints()
-        except Exception as content_error:
-            raise NotImplementedError(
-                "ShowPassingFlash currently qualifies the exact Line subset; "
-                "general VMobject path windows remain partial"
-            ) from content_error
-        raise
+    engine_call(_manim_line_endpoints_observation, value, operation="ShowPassingFlash")
     return True
 
 
@@ -186,12 +176,12 @@ def _layout_bounds(value: _base.Mobject) -> tuple[_base.Vec2, _base.Vec2] | None
         raise RuntimeError("Mobject layout requires a current shared Rust semantic handle")
     return (
         _base.Vec2(
-            float(handle.criticalX(-1.0, 0.0)),
-            float(handle.criticalY(0.0, -1.0)),
+            float(engine_call(handle.criticalX, -1.0, 0.0)),
+            float(engine_call(handle.criticalY, 0.0, -1.0)),
         ),
         _base.Vec2(
-            float(handle.criticalX(1.0, 0.0)),
-            float(handle.criticalY(0.0, 1.0)),
+            float(engine_call(handle.criticalX, 1.0, 0.0)),
+            float(engine_call(handle.criticalY, 0.0, 1.0)),
         ),
     )
 
@@ -216,7 +206,7 @@ def _bound_layout_observation(value: _base.Mobject):
         return None
     context = getattr(value._scene, "_canonical_authoring_context", None)
     query = getattr(context, "queryMobjectLayout", None)
-    return None if query is None else query(handle)
+    return None if query is None else engine_call(query, handle)
 
 
 _CONSTRUCTOR_MISSING = object()
@@ -263,22 +253,22 @@ def _apply_shared_constructor_options(handle: object, kwargs: dict[str, Any]) ->
 
     if "position" in options:
         value = _ir._vec2("position", options["position"])
-        handle.setTranslation(value["x"], value["y"])
+        engine_call(handle.setTranslation, value["x"], value["y"])
     if "rotation" in options:
-        handle.setRotation(_ir._finite_number("rotation", options["rotation"]))
+        engine_call(handle.setRotation, _ir._finite_number("rotation", options["rotation"]))
     if "scale" in options:
         value = _ir._vec2("scale", options["scale"])
-        handle.setScale(value["x"], value["y"])
+        engine_call(handle.setScale, value["x"], value["y"])
     if "stroke_width" in options:
-        handle.setStrokeWidth(_compat._manim_stroke_width(options["stroke_width"]))
+        engine_call(handle.setStrokeWidth, _compat._manim_stroke_width(options["stroke_width"]))
     if "stroke_width_mode" in options:
-        handle.setStrokeWidthMode(_ir._stroke_width_mode(options["stroke_width_mode"]))
+        engine_call(handle.setStrokeWidthMode, _ir._stroke_width_mode(options["stroke_width_mode"]))
     if "stroke_join" in options:
-        handle.setStrokeJoin(_ir._stroke_join(options["stroke_join"]))
+        engine_call(handle.setStrokeJoin, _ir._stroke_join(options["stroke_join"]))
     if "stroke_cap" in options:
-        handle.setStrokeCap(_ir._stroke_cap(options["stroke_cap"]))
+        engine_call(handle.setStrokeCap, _ir._stroke_cap(options["stroke_cap"]))
     if "opacity" in options:
-        handle.setObjectOpacity(_ir._finite_number("opacity", options["opacity"]))
+        engine_call(handle.setObjectOpacity, _ir._finite_number("opacity", options["opacity"]))
 
     fill = options.get("fill", _CONSTRUCTOR_MISSING)
     fill_color = options.get("fill_color", _CONSTRUCTOR_MISSING)
@@ -286,10 +276,10 @@ def _apply_shared_constructor_options(handle: object, kwargs: dict[str, Any]) ->
         fill = _compat._as_color("fill_color", fill_color)
     if fill is not _CONSTRUCTOR_MISSING:
         if fill is None:
-            handle.disableFill()
+            engine_call(handle.disableFill)
         else:
             parsed = _constructor_color("fill", fill)
-            handle.setFill(parsed.red, parsed.green, parsed.blue, parsed.alpha)
+            engine_call(handle.setFill, parsed.red, parsed.green, parsed.blue, parsed.alpha)
 
     stroke = options.get("stroke", _CONSTRUCTOR_MISSING)
     stroke_color = options.get("stroke_color", _CONSTRUCTOR_MISSING)
@@ -297,16 +287,16 @@ def _apply_shared_constructor_options(handle: object, kwargs: dict[str, Any]) ->
         stroke = _compat._as_color("stroke_color", stroke_color)
     if stroke is not _CONSTRUCTOR_MISSING:
         if stroke is None:
-            handle.disableStroke()
+            engine_call(handle.disableStroke)
         else:
             parsed = _constructor_color("stroke", stroke)
-            handle.setStrokeColor(parsed.red, parsed.green, parsed.blue, parsed.alpha)
-            handle.setStrokeOpacity(parsed.alpha)
+            engine_call(handle.setStrokeColor, parsed.red, parsed.green, parsed.blue, parsed.alpha)
+            engine_call(handle.setStrokeOpacity, parsed.alpha)
 
     if options.get("fill_opacity") is not None:
-        handle.setFillOpacity(_compat._opacity("fill_opacity", options["fill_opacity"]))
+        engine_call(handle.setFillOpacity, _compat._opacity("fill_opacity", options["fill_opacity"]))
     if options.get("stroke_opacity") is not None:
-        handle.setStrokeOpacity(_compat._opacity("stroke_opacity", options["stroke_opacity"]))
+        engine_call(handle.setStrokeOpacity, _compat._opacity("stroke_opacity", options["stroke_opacity"]))
 
 
 def _apply_shared_constructor_kwargs(self: _base.Mobject, kwargs: dict[str, Any]) -> None:
@@ -316,7 +306,7 @@ def _apply_shared_constructor_kwargs(self: _base.Mobject, kwargs: dict[str, Any]
 def _apply_constructor_color(handle: object, color: _base.Color | None) -> None:
     if color is not None:
         parsed = _constructor_color("color", color)
-        handle.setColor(parsed.red, parsed.green, parsed.blue, parsed.alpha)
+        engine_call(handle.setColor, parsed.red, parsed.green, parsed.blue, parsed.alpha)
 
 
 def _live_constructor_context(kind: str = "primitive"):
@@ -336,7 +326,7 @@ def _live_constructor_context(kind: str = "primitive"):
     context = getattr(scene, "_canonical_authoring_context", None)
     if context is None:
         return None
-    ownership = str(context.liveExecutionOwnership())
+    ownership = str(engine_call(context.liveExecutionOwnership))
     if ownership in {"active", "returned"}:
         return context
     if ownership == "transferred":
@@ -349,41 +339,41 @@ def _live_constructor_context(kind: str = "primitive"):
 def _vector_path_options(path: dict[str, Any]):
     if set(path) != {"commands"}:
         raise ValueError("shared vector path supports commands only")
-    candidate = _authoring_vector_path()
+    candidate = engine_call(_authoring_vector_path)
     for command in path["commands"]:
         if command == "close":
-            candidate.close()
+            engine_call(candidate.close)
         elif isinstance(command, dict) and set(command) == {"move_to"}:
             point = command["move_to"]["to"]
-            candidate.moveTo(float(point["x"]), float(point["y"]))
+            engine_call(candidate.moveTo, float(point["x"]), float(point["y"]))
         elif isinstance(command, dict) and set(command) == {"line_to"}:
             point = command["line_to"]["to"]
-            candidate.lineTo(float(point["x"]), float(point["y"]))
+            engine_call(candidate.lineTo, float(point["x"]), float(point["y"]))
         elif isinstance(command, dict) and set(command) == {"quadratic_to"}:
             values = command["quadratic_to"]
             control, point = values["control"], values["to"]
-            candidate.quadraticTo(
+            engine_call(candidate.quadraticTo,
                 float(control["x"]), float(control["y"]),
                 float(point["x"]), float(point["y"]),
             )
         elif isinstance(command, dict) and set(command) == {"cubic_to"}:
             values = command["cubic_to"]
             first, second, point = values["control1"], values["control2"], values["to"]
-            candidate.cubicTo(
+            engine_call(candidate.cubicTo,
                 float(first["x"]), float(first["y"]),
                 float(second["x"]), float(second["y"]),
                 float(point["x"]), float(point["y"]),
             )
         else:
             raise ValueError("unsupported vector path command")
-    return _geometry_options.path(candidate)
+    return engine_call(_geometry_options.path, candidate)
 
 
 def _consume_geometry_options(options: object, kind: str = "geometry"):
     context = _live_constructor_context(kind)
     if context is None:
-        return _create_geometry_handle(options), None
-    return context.liveCreateManimGeometry(options), context
+        return engine_call(_create_geometry_handle, options), None
+    return engine_call(context.liveCreateManimGeometry, options), context
 
 
 def _attach_geometry_options(
@@ -405,7 +395,7 @@ def _circle_init(
     if _create_geometry_handle is None:
         raise RuntimeError("Mobject construction requires the shared Rust authoring host")
     value = _ir._positive_number("radius", radius)
-    options = _geometry_options.circle(value)
+    options = engine_call(_geometry_options.circle, value)
     _apply_shared_constructor_options(options, kwargs)
     _apply_constructor_color(options, color)
     _attach_geometry_options(self, options, "Circle")
@@ -424,7 +414,7 @@ def _rectangle_init(
         raise RuntimeError("Mobject construction requires the shared Rust authoring host")
     width_value = _ir._positive_number("width", width)
     height_value = _ir._positive_number("height", height)
-    options = _geometry_options.rectangle(width_value, height_value)
+    options = engine_call(_geometry_options.rectangle, width_value, height_value)
     _apply_shared_constructor_options(options, kwargs)
     _apply_constructor_color(options, color)
     _attach_geometry_options(self, options, "Rectangle")
@@ -442,7 +432,7 @@ def _square_init(
     if _create_geometry_handle is None:
         raise RuntimeError("Mobject construction requires the shared Rust authoring host")
     value = _ir._positive_number("side_length", side_length)
-    options = _geometry_options.square(value)
+    options = engine_call(_geometry_options.square, value)
     _apply_shared_constructor_options(options, kwargs)
     _apply_constructor_color(options, color)
     _attach_geometry_options(self, options, "Square")
@@ -506,7 +496,7 @@ def _line_init(
         return
     if _create_geometry_handle is None:
         raise RuntimeError("Mobject construction requires the shared Rust authoring host")
-    options = _geometry_options.line(
+    options = engine_call(_geometry_options.line,
         start_value.x, start_value.y, end_value.x, end_value.y
     )
     _apply_shared_constructor_options(options, kwargs)
@@ -523,7 +513,7 @@ def _current_raw(self: _base.Mobject) -> _ir.Mobject:
         )
     handle = _handle_for(self)
     if handle is not None:
-        return _raw_from_json(str(handle.snapshotJson()))
+        return _raw_from_json(str(engine_call(handle.snapshotJson)))
     raise RuntimeError("Mobject queries require a current shared Rust semantic handle")
 
 
@@ -552,9 +542,9 @@ def _clone_mobject(
     clone._scene = None
     clone._object = None
     clone._semantic_handle = (
-        context.liveTargetEditor(handle)
+        engine_call(context.liveTargetEditor, handle)
         if context is not None
-        else handle.targetEditor() if target_state else handle.cloneHandle()
+        else engine_call(handle.targetEditor) if target_state else engine_call(handle.cloneHandle)
     )
     clone._semantic_handle_fresh = True
     if context is not None:
@@ -615,13 +605,13 @@ def _get_critical_point(self: _base.Mobject, direction: object) -> _base.Vec2:
     axis = _base._as_vec2(direction)
     if isinstance(self, _compat.Group):
         layout = _group_layout_observation(self)
-        return _base.Vec2(float(layout.criticalX(axis.x, axis.y)),
-                          float(layout.criticalY(axis.x, axis.y)))
+        return _base.Vec2(float(engine_call(layout.criticalX, axis.x, axis.y)),
+                          float(engine_call(layout.criticalY, axis.x, axis.y)))
     observed = _bound_layout_observation(self)
     if observed is not None:
         return _base.Vec2(
-            float(observed.criticalX(axis.x, axis.y)),
-            float(observed.criticalY(axis.x, axis.y)),
+            float(engine_call(observed.criticalX, axis.x, axis.y)),
+            float(engine_call(observed.criticalY, axis.x, axis.y)),
         )
     return _critical(self, axis)
 
@@ -666,11 +656,11 @@ def _shift(self: _base.Mobject, direction: object) -> _base.Mobject:
     context = _live_mutation_context(self)
     if context is not None:
         try:
-            context.liveShift(handle, offset.x, offset.y)
+            engine_call(context.liveShift, handle, offset.x, offset.y)
         except Exception as error:
-            raise ValueError(str(error)) from None
+            raise_engine_error(error)
         return self
-    handle.shift(offset.x, offset.y)
+    engine_call(handle.shift, offset.x, offset.y)
     return self
 
 
@@ -692,23 +682,23 @@ def _move_to(
         if target is None:
             raise RuntimeError("placement target requires a current shared Rust semantic handle")
         if context is None:
-            handle.layoutAnchor(None).moveTo(target, *args)
+            engine_call(engine_call(handle.layoutAnchor, None).moveTo, target, *args)
         else:
-            context.liveMoveToLayout(handle, target, *args)
+            engine_call(context.liveMoveToLayout, handle, target, *args)
     elif _alignment_is_mobject(point_or_mobject):
         target = _handle_for(point_or_mobject)
         if target is None:
             raise RuntimeError("placement target requires a current shared Rust semantic handle")
         if context is None:
-            handle.manimMoveToHandle(target, *args)
+            engine_call(handle.manimMoveToHandle, target, *args)
         else:
-            context.liveMoveToMobject(handle, target, *args)
+            engine_call(context.liveMoveToMobject, handle, target, *args)
     else:
         point = _base._as_vec2(point_or_mobject)
         if context is None:
-            handle.manimMoveToPoint(point.x, point.y, *args)
+            engine_call(handle.manimMoveToPoint, point.x, point.y, *args)
         else:
-            context.liveMoveToPoint(handle, point.x, point.y, *args)
+            engine_call(context.liveMoveToPoint, handle, point.x, point.y, *args)
     return self
 
 
@@ -731,11 +721,11 @@ def _rescale_to_fit(self, length, dim, stretch=False, **kwargs):
     length = float(length)
     try:
         if context is None:
-            anchor.rescaleToFit(length, dim, bool(stretch))
+            engine_call(anchor.rescaleToFit, length, dim, bool(stretch))
         else:
-            context.liveRescaleToFit(anchor, length, dim, bool(stretch))
+            engine_call(context.liveRescaleToFit, anchor, length, dim, bool(stretch))
     except Exception as error:
-        raise ValueError(str(error)) from None
+        raise_engine_error(error)
     return self
 
 
@@ -748,11 +738,11 @@ def _match_dim_size(self, mobject, dim, stretch=False, **kwargs):
         raise RuntimeError("dimension matching requires a shared Rust target")
     try:
         if context is None:
-            anchor.matchDimSize(target, dim, bool(stretch))
+            engine_call(anchor.matchDimSize, target, dim, bool(stretch))
         else:
-            context.liveMatchDimSize(anchor, target, dim, bool(stretch))
+            engine_call(context.liveMatchDimSize, anchor, target, dim, bool(stretch))
     except Exception as error:
-        raise ValueError(str(error)) from None
+        raise_engine_error(error)
     return self
 
 
@@ -768,11 +758,11 @@ def _scale(self: _base.Mobject, factor: object) -> _base.Mobject:
     context = _live_mutation_context(self)
     if context is not None:
         try:
-            context.liveScale(handle, value.x, value.y)
+            engine_call(context.liveScale, handle, value.x, value.y)
         except Exception as error:
-            raise ValueError(str(error)) from None
+            raise_engine_error(error)
         return self
-    handle.scale(value.x, value.y)
+    engine_call(handle.scale, value.x, value.y)
     return self
 
 
@@ -811,9 +801,9 @@ def _rotate(
                 "canonical live affine rotation supports only rotation about the current center"
             )
         try:
-            context.liveRotate(handle, _compat._rotation_angle_2d(angle, axis))
+            engine_call(context.liveRotate, handle, _compat._rotation_angle_2d(angle, axis))
         except Exception as error:
-            raise ValueError(str(error)) from None
+            raise_engine_error(error)
         return self
     if kwargs:
         unsupported = ", ".join(sorted(kwargs))
@@ -826,10 +816,10 @@ def _rotate(
     else:
         edge = _base._as_vec2(about_edge)
         pivot = _base.Vec2(
-            float(handle.criticalX(edge.x, edge.y)),
-            float(handle.criticalY(edge.x, edge.y)),
+            float(engine_call(handle.criticalX, edge.x, edge.y)),
+            float(engine_call(handle.criticalY, edge.x, edge.y)),
         )
-    handle.rotateAboutPoint(signed_angle, pivot.x, pivot.y)
+    engine_call(handle.rotateAboutPoint, signed_angle, pivot.x, pivot.y)
     return self
 
 
@@ -842,14 +832,14 @@ def _set_color(self: _base.Mobject, color: _base.Color) -> _base.Mobject:
     live_context = _live_mutation_context(self)
     if live_context is not None:
         try:
-            live_context.liveSetColor(
+            engine_call(live_context.liveSetColor,
                 handle, color.red, color.green, color.blue, color.alpha
             )
         except Exception as error:
-            raise ValueError(str(error)) from None
+            raise_engine_error(error)
         return self
 
-    handle.setColor(color.red, color.green, color.blue, color.alpha)
+    engine_call(handle.setColor, color.red, color.green, color.blue, color.alpha)
     return self
 
 
@@ -898,9 +888,9 @@ def _become(
             # Rust validates that both operands belong to the session's store.
             context = _live_constructor_context("become")
         if context is not None:
-            context.liveBecomeMobject(handle, other_handle, *flags)
+            engine_call(context.liveBecomeMobject, handle, other_handle, *flags)
         else:
-            handle.becomeHandle(other_handle, *flags)
+            engine_call(handle.becomeHandle, other_handle, *flags)
         return self
 
     raise NotImplementedError(
@@ -925,7 +915,7 @@ def _replace(
     other_handle = _handle_for(mobject)
     if handle is None or other_handle is None:
         raise NotImplementedError("replace requires valid shared semantic handles for both Mobjects")
-    handle.replaceHandle(other_handle, int(dim_to_match), bool(stretch))
+    engine_call(handle.replaceHandle, other_handle, int(dim_to_match), bool(stretch))
     return self
 
 
@@ -933,8 +923,8 @@ def _critical(value: _base.Mobject, direction: _base.Vec2) -> _base.Vec2:
     handle = _handle_for(value)
     if handle is not None:
         return _base.Vec2(
-            float(handle.criticalX(direction.x, direction.y)),
-            float(handle.criticalY(direction.x, direction.y)),
+            float(engine_call(handle.criticalX, direction.x, direction.y)),
+            float(engine_call(handle.criticalY, direction.x, direction.y)),
         )
     raise RuntimeError("Mobject layout requires a current shared Rust semantic handle")
 
@@ -973,7 +963,7 @@ def _layout_anchor(value, index=None):
         handle = _layout_reference_handle(value)
     if handle is None:
         return None
-    return handle.layoutAnchor(_semantic_member_index(index))
+    return engine_call(handle.layoutAnchor, _semantic_member_index(index))
 
 
 def _shared_next_to(self, target, direction, buff, aligned_edge,
@@ -998,19 +988,19 @@ def _shared_next_to(self, target, direction, buff, aligned_edge,
     try:
         if target_anchor is not None:
             if context is None:
-                source.nextTo(target_anchor, aligner, *arguments)
+                engine_call(source.nextTo, target_anchor, aligner, *arguments)
             else:
-                context.liveNextLayoutTo(source, target_anchor, aligner, *arguments)
+                engine_call(context.liveNextLayoutTo, source, target_anchor, aligner, *arguments)
         else:
             point = _base._as_vec2(target)
             if context is None:
-                source.nextToPoint(point.x, point.y, aligner, *arguments)
+                engine_call(source.nextToPoint, point.x, point.y, aligner, *arguments)
             else:
-                context.liveNextLayoutToPoint(source, point.x, point.y, aligner, *arguments)
+                engine_call(context.liveNextLayoutToPoint, source, point.x, point.y, aligner, *arguments)
     except Exception as error:
         if "alignment submobject index" in str(error):
             raise IndexError(str(error)) from None
-        raise ValueError(str(error)) from None
+        raise_engine_error(error)
 
 
 def _next_to(
@@ -1045,15 +1035,15 @@ def _align_to(
         target = _layout_anchor(mobject_or_point)
         if target is None:
             raise RuntimeError("alignment requires current shared Rust semantic handles")
-        handle.layoutAnchor(None).alignTo(target, axis.x, axis.y)
+        engine_call(engine_call(handle.layoutAnchor, None).alignTo, target, axis.x, axis.y)
     elif _alignment_is_mobject(mobject_or_point):
         target_handle = _handle_for(mobject_or_point)
         if target_handle is None:
             raise RuntimeError("alignment requires current shared Rust semantic handles")
-        handle.alignToHandle(target_handle, axis.x, axis.y)
+        engine_call(handle.alignToHandle, target_handle, axis.x, axis.y)
     else:
         point = _base._as_vec2(mobject_or_point)
-        handle.alignToPoint(point.x, point.y, axis.x, axis.y)
+        engine_call(handle.alignToPoint, point.x, point.y, axis.x, axis.y)
     return self
 
 
@@ -1069,7 +1059,7 @@ def _align_on_frame(
         raise NotImplementedError(
             "canonical live affine targets do not support frame alignment"
         )
-    handle.alignOnFrame(direction.x, direction.y, float(buff))
+    engine_call(handle.alignOnFrame, direction.x, direction.y, float(buff))
     return self
 
 
@@ -1087,7 +1077,7 @@ def _set_fill(
         try:
             if color is not None and opacity is not None:
                 parsed = _compat._as_color("fill color", color)
-                live_context.liveSetFill(
+                engine_call(live_context.liveSetFill,
                     handle,
                     parsed.red,
                     parsed.green,
@@ -1096,21 +1086,21 @@ def _set_fill(
                 )
             elif color is not None:
                 parsed = _compat._as_color("fill color", color)
-                live_context.liveSetFillColor(
+                engine_call(live_context.liveSetFillColor,
                     handle, parsed.red, parsed.green, parsed.blue, parsed.alpha
                 )
             elif opacity is None:
-                live_context.liveDisableFill(handle)
+                engine_call(live_context.liveDisableFill, handle)
             if opacity is not None and color is None:
-                live_context.liveSetFillOpacity(
+                engine_call(live_context.liveSetFillOpacity,
                     handle, _compat._opacity("fill opacity", opacity)
                 )
         except Exception as error:
-            raise ValueError(str(error)) from None
+            raise_engine_error(error)
         return self
     if color is not None and opacity is not None:
         parsed = _compat._as_color("fill color", color)
-        handle.setFill(
+        engine_call(handle.setFill,
             parsed.red,
             parsed.green,
             parsed.blue,
@@ -1119,11 +1109,11 @@ def _set_fill(
         return self
     if color is not None:
         parsed = _compat._as_color("fill color", color)
-        handle.setFillColor(parsed.red, parsed.green, parsed.blue, parsed.alpha)
+        engine_call(handle.setFillColor, parsed.red, parsed.green, parsed.blue, parsed.alpha)
     elif opacity is None:
-        handle.disableFill()
+        engine_call(handle.disableFill)
     if opacity is not None:
-        handle.setFillOpacity(_compat._opacity("fill opacity", opacity))
+        engine_call(handle.setFillOpacity, _compat._opacity("fill opacity", opacity))
     return self
 
 
@@ -1146,7 +1136,7 @@ def _set_stroke(
         try:
             if color is not None and opacity is not None:
                 parsed = _compat._as_color("stroke color", color)
-                live_context.liveSetStroke(
+                engine_call(live_context.liveSetStroke,
                     handle,
                     parsed.red,
                     parsed.green,
@@ -1155,27 +1145,27 @@ def _set_stroke(
                 )
             elif color is not None:
                 parsed = _compat._as_color("stroke color", color)
-                live_context.liveSetStrokeColor(
+                engine_call(live_context.liveSetStrokeColor,
                     handle, parsed.red, parsed.green, parsed.blue, parsed.alpha
                 )
             elif opacity is None:
-                live_context.liveDisableStroke(handle)
+                engine_call(live_context.liveDisableStroke, handle)
             else:
-                live_context.liveSetStrokeOpacity(
+                engine_call(live_context.liveSetStrokeOpacity,
                     handle, _compat._opacity("stroke opacity", opacity)
                 )
         except Exception as error:
-            raise ValueError(str(error)) from None
+            raise_engine_error(error)
         return self
     if color is not None:
         parsed = _compat._as_color("stroke color", color)
-        handle.setStrokeColor(parsed.red, parsed.green, parsed.blue, parsed.alpha)
+        engine_call(handle.setStrokeColor, parsed.red, parsed.green, parsed.blue, parsed.alpha)
     elif width is None and opacity is None:
-        handle.disableStroke()
+        engine_call(handle.disableStroke)
     if width is not None:
-        handle.setStrokeWidth(_compat._manim_stroke_width(width))
+        engine_call(handle.setStrokeWidth, _compat._manim_stroke_width(width))
     if opacity is not None:
-        handle.setStrokeOpacity(_compat._opacity("stroke opacity", opacity))
+        engine_call(handle.setStrokeOpacity, _compat._opacity("stroke opacity", opacity))
     return self
 
 
@@ -1190,11 +1180,11 @@ def _set_opacity(
     live_context = _live_mutation_context(self)
     if live_context is not None:
         try:
-            live_context.liveSetOpacity(handle, _compat._opacity("opacity", opacity))
+            engine_call(live_context.liveSetOpacity, handle, _compat._opacity("opacity", opacity))
         except Exception as error:
-            raise ValueError(str(error)) from None
+            raise_engine_error(error)
         return self
-    handle.setOpacity(_compat._opacity("opacity", opacity))
+    engine_call(handle.setOpacity, _compat._opacity("opacity", opacity))
     return self
 
 
@@ -1211,11 +1201,11 @@ def _set_object_opacity(
     live_context = _live_mutation_context(self)
     try:
         if live_context is not None:
-            live_context.liveSetObjectOpacity(handle, alpha)
+            engine_call(live_context.liveSetObjectOpacity, handle, alpha)
         else:
-            handle.setObjectOpacity(alpha)
+            engine_call(handle.setObjectOpacity, alpha)
     except Exception as error:
-        raise ValueError(str(error)) from None
+        raise_engine_error(error)
     return self
 
 
@@ -1263,7 +1253,7 @@ def _shared_family_layout(value: object, *, mutation: bool = False):
     ]
     if not all(handle is not None for handle in leaf_handles):
         return None
-    return family_handle.layout()
+    return engine_call(family_handle.layout)
 
 
 def _group_paint(self, operation, arguments):
@@ -1278,11 +1268,11 @@ def _group_paint(self, operation, arguments):
     context = _group_target_context(self)
     try:
         if context is None:
-            getattr(handle, f"set{operation}")(*arguments)
+            engine_call(getattr(handle, f"set{operation}"), *arguments)
         else:
-            getattr(context, f"liveSetFamily{operation}")(handle, *arguments)
+            engine_call(getattr(context, f"liveSetFamily{operation}"), handle, *arguments)
     except Exception as error:
-        raise ValueError(str(error)) from None
+        raise_engine_error(error)
     return self
 
 
@@ -1326,7 +1316,7 @@ def _group_arrange_in_grid(self, rows=None, cols=None, buff=_base.MED_SMALL_BUFF
             raise ValueError("grid dimensions must be positive 32-bit integers")
         return value
 
-    rows, cols = dimension(rows), dimension(cols)
+    rows, cols = engine_call(dimension, rows), engine_call(dimension, cols)
     gap = (_base._as_vec2(buff) if isinstance(buff, (tuple, list, _base.Vec2))
            else _base.Vec2(float(buff), float(buff)))
     handle = getattr(self, "_semantic_family_handle", None)
@@ -1335,11 +1325,11 @@ def _group_arrange_in_grid(self, rows=None, cols=None, buff=_base.MED_SMALL_BUFF
     context = _group_live_layout_context(self)
     try:
         if context is None:
-            handle.arrangeInGrid(rows, cols, gap.x, gap.y)
+            engine_call(handle.arrangeInGrid, rows, cols, gap.x, gap.y)
         else:
-            context.liveArrangeFamilyInGrid(handle, rows, cols, gap.x, gap.y)
+            engine_call(context.liveArrangeFamilyInGrid, handle, rows, cols, gap.x, gap.y)
     except Exception as error:
-        raise ValueError(str(error)) from None
+        raise_engine_error(error)
     return self
 
 
@@ -1352,11 +1342,11 @@ def _group_scale(self: _compat.Group, factor: object) -> _compat.Group:
     context = _group_live_layout_context(self)
     try:
         if context is not None:
-            context.liveScaleFamily(handle, scale.x, scale.y)
+            engine_call(context.liveScaleFamily, handle, scale.x, scale.y)
         else:
-            handle.scale(scale.x, scale.y)
+            engine_call(handle.scale, scale.x, scale.y)
     except Exception as error:
-        raise ValueError(str(error)) from None
+        raise_engine_error(error)
     return self
 
 
@@ -1371,11 +1361,11 @@ def _group_rotate(self: _compat.Group, angle: float, axis: object = _compat.OUT,
     context = _group_live_layout_context(self)
     try:
         if context is not None:
-            context.liveRotateFamily(handle, signed_angle, point.x, point.y, about_point is not None)
+            engine_call(context.liveRotateFamily, handle, signed_angle, point.x, point.y, about_point is not None)
         else:
-            handle.rotate(signed_angle, point.x, point.y, about_point is not None)
+            engine_call(handle.rotate, signed_angle, point.x, point.y, about_point is not None)
     except Exception as error:
-        raise ValueError(str(error)) from None
+        raise_engine_error(error)
     return self
 
 
@@ -1392,16 +1382,16 @@ def _group_shift(self: _compat.Group, direction: object) -> _compat.Group:
     if context is not None:
         offset = _base._as_vec2(direction)
         try:
-            context.liveShiftFamily(self._semantic_family_handle, offset.x, offset.y)
+            engine_call(context.liveShiftFamily, self._semantic_family_handle, offset.x, offset.y)
         except Exception as error:
-            raise ValueError(str(error)) from None
+            raise_engine_error(error)
         return self
     shared = _shared_family_layout(self, mutation=True)
     if shared is None:
         raise RuntimeError("Group shift requires the shared Rust authoring host")
     session = shared
     offset = _base._as_vec2(direction)
-    session.shiftBy(offset.x, offset.y)
+    engine_call(session.shiftBy, offset.x, offset.y)
     return self
 
 
@@ -1427,14 +1417,14 @@ def _group_live_layout_context(value: _compat.Group):
 def _live_family_placement(context, family, target, operation, *arguments):
     if isinstance(target, _compat.Group):
         method = getattr(context, f"live{operation}FamilyToFamily")
-        method(family, target._semantic_family_handle, *arguments)
+        engine_call(method, family, target._semantic_family_handle, *arguments)
     elif isinstance(target, _base.Mobject):
         method = getattr(context, f"live{operation}FamilyToMobject")
-        method(family, target._semantic_handle, *arguments)
+        engine_call(method, family, target._semantic_handle, *arguments)
     else:
         point = _base._as_vec2(target)
         method = getattr(context, f"live{operation}FamilyToPoint")
-        method(family, point.x, point.y, *arguments)
+        engine_call(method, family, point.x, point.y, *arguments)
 
 
 def _group_move_to(
@@ -1461,15 +1451,15 @@ def _group_move_to(
         target = _shared_family_layout(point_or_mobject)
         if target is None:
             raise RuntimeError("placement target requires a current shared Rust semantic handle")
-        session.moveToFamily(target, edge.x, edge.y, mask.x, mask.y)
+        engine_call(session.moveToFamily, target, edge.x, edge.y, mask.x, mask.y)
     elif _alignment_is_mobject(point_or_mobject):
         target = _family_layout_leaf_adapter(point_or_mobject)
         if target is None:
             raise RuntimeError("placement target requires a current shared Rust semantic handle")
-        session.moveToMobject(target, edge.x, edge.y, mask.x, mask.y)
+        engine_call(session.moveToMobject, target, edge.x, edge.y, mask.x, mask.y)
     else:
         point = _base._as_vec2(point_or_mobject)
-        session.moveToPoint(point.x, point.y, edge.x, edge.y, mask.x, mask.y)
+        engine_call(session.moveToPoint, point.x, point.y, edge.x, edge.y, mask.x, mask.y)
 
     return self
 
@@ -1479,13 +1469,13 @@ def _group_move_to(
 def _group_align_on_frame(self: _compat.Group, direction: _base.Vec2, buff: float):
     context = _group_live_layout_context(self)
     if context is not None:
-        context.liveAlignFamilyOnFrame(self._semantic_family_handle,
+        engine_call(context.liveAlignFamilyOnFrame, self._semantic_family_handle,
                                        direction.x, direction.y, float(buff))
     else:
         layout = _shared_family_layout(self, mutation=True)
         if layout is None:
             raise RuntimeError("frame alignment requires current shared Rust semantic handles")
-        layout.alignOnFrame(direction.x, direction.y, float(buff))
+        engine_call(layout.alignOnFrame, direction.x, direction.y, float(buff))
     return self
 
 
@@ -1509,15 +1499,15 @@ def _group_align_to(
         target = _shared_family_layout(mobject_or_point)
         if target is None:
             raise RuntimeError("alignment target requires a current shared Rust semantic handle")
-        session.alignToFamily(target, axis.x, axis.y)
+        engine_call(session.alignToFamily, target, axis.x, axis.y)
     elif _alignment_is_mobject(mobject_or_point):
         target = _family_layout_leaf_adapter(mobject_or_point)
         if target is None:
             raise RuntimeError("alignment target requires a current shared Rust semantic handle")
-        session.alignToMobject(target, axis.x, axis.y)
+        engine_call(session.alignToMobject, target, axis.x, axis.y)
     else:
         point = _base._as_vec2(mobject_or_point)
-        session.alignToPoint(point.x, point.y, axis.x, axis.y)
+        engine_call(session.alignToPoint, point.x, point.y, axis.x, axis.y)
 
     return self
 
@@ -1542,7 +1532,7 @@ def _group_arrange(
     edge = _base._as_vec2(kwargs.get("aligned_edge", _base.ORIGIN))
     mask = _alignment_mask2(kwargs.get("coor_mask", (1, 1, 1)))
     index = _semantic_member_index(kwargs.get("index_of_submobject_to_align"))
-    options = family_handle.arrangeOptions(axis.x, axis.y, float(buff), bool(center),
+    options = engine_call(family_handle.arrangeOptions, axis.x, axis.y, float(buff), bool(center),
                                            edge.x, edge.y, mask.x, mask.y, index)
     aligner = kwargs.get("submobject_to_align")
     if aligner is not None:
@@ -1553,24 +1543,24 @@ def _group_arrange(
     context = _group_live_layout_context(self)
     try:
         if context is not None:
-            context.liveArrangeFamily(family_handle, options)
+            engine_call(context.liveArrangeFamily, family_handle, options)
             return self
         leaves = _compat._leaf_mobjects(self)
         leaf_handles = [_family_layout_leaf_adapter(member, mutation=True) for member in leaves]
         if any(handle is None for handle in leaf_handles):
             raise RuntimeError("arrange requires current shared Rust semantic handles")
-        family_handle.arrange(options)
+        engine_call(family_handle.arrange, options)
     except Exception as error:
         if "alignment submobject index" in str(error):
             raise IndexError(str(error)) from None
-        raise ValueError(str(error)) from None
+        raise_engine_error(error)
     return self
 
 
 def _group_layout_observation(value: _compat.Group):
     context = _group_live_layout_context(value)
     if context is not None:
-        return context.queryFamilyLayout(value._semantic_family_handle)
+        return engine_call(context.queryFamilyLayout, value._semantic_family_handle)
     layout = _shared_family_layout(value)
     if layout is None:
         raise RuntimeError("family layout requires a current shared Rust semantic handle")
@@ -1595,18 +1585,18 @@ def _validate_group_members(owner: _compat.Group, mobjects: tuple[object, ...]) 
 
 def _family_membership_batch(context: object, kind: str, mobjects: tuple[object, ...]):
     batch = (
-        context.beginMembershipBatch(kind)
+        engine_call(context.beginMembershipBatch, kind)
         if context is not None
-        else _new_membership_batch(kind)
+        else engine_call(_new_membership_batch, kind)
     )
     for value in mobjects:
         member_kind, handle = _family_member_handle(value)
         if handle is None:
             raise RuntimeError("family member has no shared semantic identity")
         if member_kind == "family":
-            batch.appendFamily(handle)
+            engine_call(batch.appendFamily, handle)
         else:
-            batch.appendMobject("", handle)
+            engine_call(batch.appendMobject, "", handle)
     return batch
 
 
@@ -1617,9 +1607,9 @@ def _group_init(self: _compat.Group, *mobjects: object) -> None:
     context = _live_constructor_context("family")
     batch = _family_membership_batch(context, "add", mobjects)
     family = (
-        context.liveCreateFamily(batch)
+        engine_call(context.liveCreateFamily, batch)
         if context is not None
-        else _create_family_handle(batch)
+        else engine_call(_create_family_handle, batch)
     )
     # Rust selects the authoritative ordered members; this map retains Python identity.
     wrappers = {}
@@ -1628,7 +1618,7 @@ def _group_init(self: _compat.Group, *mobjects: object) -> None:
         key = f"{int(handle.semanticSlot)}:{int(handle.semanticGeneration)}"
         wrappers.setdefault(key, value)
     self._semantic_family_handle = family
-    self.submobjects = [wrappers[str(key)] for key in family.memberKeys()]
+    self.submobjects = [wrappers[str(key)] for key in engine_call(family.memberKeys)]
 
 
 def _group_add(self: _compat.Group, *mobjects: object) -> _compat.Group:
@@ -1639,9 +1629,9 @@ def _group_add(self: _compat.Group, *mobjects: object) -> _compat.Group:
     context = _live_constructor_context("family")
     batch = _family_membership_batch(context, "add", mobjects)
     changed = (
-        context.liveEditFamilyMembership(family_handle, batch)
+        engine_call(context.liveEditFamilyMembership, family_handle, batch)
         if context is not None
-        else family_handle.editMembership(batch)
+        else engine_call(family_handle.editMembership, batch)
     )
     accepted = tuple(value for value, changed in zip(mobjects, changed) if changed)
     if accepted:
@@ -1656,9 +1646,9 @@ def _group_remove(self: _compat.Group, *mobjects: object) -> _compat.Group:
     context = _live_constructor_context("family")
     batch = _family_membership_batch(context, "remove", mobjects)
     changed = (
-        context.liveEditFamilyMembership(family_handle, batch)
+        engine_call(context.liveEditFamilyMembership, family_handle, batch)
         if context is not None
-        else family_handle.editMembership(batch)
+        else engine_call(family_handle.editMembership, batch)
     )
     accepted = tuple(value for value, changed in zip(mobjects, changed) if changed)
     if accepted:
@@ -1724,17 +1714,17 @@ def _group_copy(self: _compat.Group) -> _compat.Group:
                 if handle is None:
                     raise RuntimeError("family member has no shared semantic identity")
                 keys.append(f"{int(handle.semanticSlot)}:{int(handle.semanticGeneration)}")
-            if keys != [str(key) for key in source._semantic_family_handle.memberKeys()]:
+            if keys != [str(key) for key in engine_call(source._semantic_family_handle.memberKeys)]:
                 raise RuntimeError("Group wrapper mirror diverged from shared family membership")
     references = _family_membership_batch(context, "add", tuple(source for source, _ in pairs))
-    copied = (context.liveCopyFamily(self._semantic_family_handle, references)
-              if context is not None else self._semantic_family_handle.copyFamily(references))
+    copied = (engine_call(context.liveCopyFamily, self._semantic_family_handle, references)
+              if context is not None else engine_call(self._semantic_family_handle.copyFamily, references))
     for source, target in pairs:
         if isinstance(source, _compat.Group):
-            target._semantic_family_handle = copied.familyFor(source._semantic_family_handle)
+            target._semantic_family_handle = engine_call(copied.familyFor, source._semantic_family_handle)
         else:
             _initialize_shared_wrapper(target)
-            target._semantic_handle = copied.mobjectFor(source._semantic_handle)
+            target._semantic_handle = engine_call(copied.mobjectFor, source._semantic_handle)
             target._semantic_handle_fresh = True
             if context is not None:
                 target._canonical_live_target_context = context

--- a/web/python/_manim_semantic_handles.py
+++ b/web/python/_manim_semantic_handles.py
@@ -998,8 +998,6 @@ def _shared_next_to(self, target, direction, buff, aligned_edge,
             else:
                 engine_call(context.liveNextLayoutToPoint, source, point.x, point.y, aligner, *arguments)
     except Exception as error:
-        if "alignment submobject index" in str(error):
-            raise IndexError(str(error)) from None
         raise_engine_error(error)
 
 
@@ -1551,8 +1549,6 @@ def _group_arrange(
             raise RuntimeError("arrange requires current shared Rust semantic handles")
         engine_call(family_handle.arrange, options)
     except Exception as error:
-        if "alignment submobject index" in str(error):
-            raise IndexError(str(error)) from None
         raise_engine_error(error)
     return self
 

--- a/web/python/_manim_shared_geometry.py
+++ b/web/python/_manim_shared_geometry.py
@@ -6,6 +6,8 @@ and argument conversion.
 
 from __future__ import annotations
 
+from _noon_errors import engine_call
+
 import operator
 from typing import Any
 
@@ -102,7 +104,7 @@ def _dot_init(
     options = dict(kwargs)
     options["stroke_width"] = stroke_width
     options["fill_opacity"] = fill_opacity
-    candidate = _shared._geometry_options.dot(
+    candidate = engine_call(_shared._geometry_options.dot,
         point_value.x, point_value.y, radius_value
     )
     _shared._apply_shared_constructor_options(candidate, options)
@@ -117,7 +119,7 @@ def _triangle_init(self: _geometry.Triangle, **kwargs: Any) -> None:
 
     options = dict(kwargs)
     color = options.pop("color", None)
-    candidate = _shared._geometry_options.triangle()
+    candidate = engine_call(_shared._geometry_options.triangle)
     _shared._apply_shared_constructor_options(candidate, options)
     _apply_candidate_color(candidate, color)
     _shared._attach_geometry_options(self, candidate, "Triangle")
@@ -137,11 +139,11 @@ def _ellipse_init(
     options = dict(kwargs)
     color = options.pop("color", None)
     scale = options.pop("scale", None)
-    candidate = _shared._geometry_options.ellipse(width_value, height_value)
+    candidate = engine_call(_shared._geometry_options.ellipse, width_value, height_value)
     _shared._apply_shared_constructor_options(candidate, options)
     if scale is not None:
         scale_value = _shared._ir._vec2("scale", scale)
-        candidate.scaleBy(scale_value["x"], scale_value["y"])
+        engine_call(candidate.scaleBy, scale_value["x"], scale_value["y"])
     _apply_candidate_color(candidate, color)
     _shared._attach_geometry_options(self, candidate, "Ellipse")
 
@@ -157,7 +159,7 @@ class Elbow(_compat.VMobject):
         angle_value = _shared._ir._finite_number("angle", angle)
         options = dict(kwargs)
         color = options.pop("color", None)
-        candidate = _shared._geometry_options.elbow(width_value, angle_value)
+        candidate = engine_call(_shared._geometry_options.elbow, width_value, angle_value)
         _shared._apply_shared_constructor_options(candidate, options)
         _apply_candidate_color(candidate, color)
         _shared._attach_geometry_options(self, candidate, "Elbow")
@@ -179,7 +181,7 @@ class RoundedRectangle(_compat.Rectangle):
         height = _shared._ir._positive_number("height", options.pop("height", 2.0))
         radius = _shared._ir._finite_number("corner_radius", corner_radius)
         color = options.pop("color", None)
-        candidate = _shared._geometry_options.roundedRectangle(width, height, radius)
+        candidate = engine_call(_shared._geometry_options.roundedRectangle, width, height, radius)
         _shared._apply_shared_constructor_options(candidate, options)
         _apply_candidate_color(candidate, color)
         _shared._attach_geometry_options(self, candidate, "RoundedRectangle")
@@ -226,7 +228,7 @@ def _shape_matcher_options(target: object, method: str, *args: float):
         raise NotImplementedError(
             "shape matcher target bridge does not expose shared matcher construction"
         )
-    return constructor(*args)
+    return engine_call(constructor, *args)
 
 
 class SurroundingRectangle(RoundedRectangle):
@@ -318,9 +320,9 @@ class Underline(_compat.Line):
         color = options.pop("color", None)
         context = _shared._live_constructor_context("Underline")
         candidate = (
-            target_handle.beginUnderline(buff_value)
+            engine_call(target_handle.beginUnderline, buff_value)
             if context is None
-            else context.beginUnderline(target_handle, buff_value)
+            else engine_call(context.beginUnderline, target_handle, buff_value)
         )
         _shared._apply_shared_constructor_options(candidate, options)
         _apply_candidate_color(candidate, color)
@@ -388,7 +390,7 @@ class AnnularSector(_compat.VMobject):
         outer = _shared._ir._finite_number("outer_radius", outer_radius)
         angle_value = _shared._ir._finite_number("angle", angle)
         start_value = _shared._ir._finite_number("start_angle", start_angle)
-        candidate = _shared._geometry_options.annularSector(
+        candidate = engine_call(_shared._geometry_options.annularSector,
                 inner,
                 outer,
                 angle_value,
@@ -430,7 +432,7 @@ class Sector(AnnularSector):
         radius_value = _shared._ir._finite_number("radius", radius)
         angle_value = _shared._ir._finite_number("angle", angle)
         start_value = _shared._ir._finite_number("start_angle", start_angle)
-        candidate = _shared._geometry_options.sector(
+        candidate = engine_call(_shared._geometry_options.sector,
                 radius_value,
                 angle_value,
                 start_value,
@@ -473,7 +475,7 @@ class Annulus(_compat.VMobject):
         options, component_count, center = _sector_options(kwargs)
         inner = _shared._ir._finite_number("inner_radius", inner_radius)
         outer = _shared._ir._finite_number("outer_radius", outer_radius)
-        candidate = _shared._geometry_options.annulus(
+        candidate = engine_call(_shared._geometry_options.annulus,
                 inner,
                 outer,
                 component_count,

--- a/web/python/_manim_typst.py
+++ b/web/python/_manim_typst.py
@@ -8,6 +8,8 @@ store rather than from a Python-owned text document.
 
 from __future__ import annotations
 
+from _noon_errors import engine_call
+
 import math
 from typing import Any
 
@@ -56,7 +58,7 @@ def _new_typst_handle(source: str, math_mode: bool, font_size: float):
     font_size = _validated_font_size(font_size)
     if _create_authoring_typst_handle is None:
         raise RuntimeError("Typst requires Noon's shared Rust authoring runtime")
-    return _create_authoring_typst_handle(source, bool(math_mode), font_size)
+    return engine_call(_create_authoring_typst_handle, source, bool(math_mode), font_size)
 
 
 def _validated_native_text_options(
@@ -87,7 +89,7 @@ def _new_native_text_handle(
     )
     if _create_authoring_text_handle is None:
         raise RuntimeError("Text requires Noon's shared Rust authoring runtime")
-    return _create_authoring_text_handle(source, font_family, font_size, line_spacing)
+    return engine_call(_create_authoring_text_handle, source, font_family, font_size, line_spacing)
 
 
 def _as_color(value: object) -> _base.Color:
@@ -255,7 +257,7 @@ class _RetainedTypstMobject(_RetainedTextMobject):
         if live_context is None:
             handle = _new_typst_handle(source, self._math_mode, font_size)
         else:
-            handle = live_context.liveCreateManimTypst(
+            handle = engine_call(live_context.liveCreateManimTypst,
                 source, bool(self._math_mode), font_size, float(color.red),
                 float(color.green), float(color.blue), float(color.alpha), opacity,
             )
@@ -299,7 +301,7 @@ class Text(_RetainedTextMobject):
         if live_context is None:
             handle = _new_native_text_handle(text, font, font_size, line_spacing)
         else:
-            handle = live_context.liveCreateManimText(
+            handle = engine_call(live_context.liveCreateManimText,
                 text,
                 font,
                 font_size,
@@ -378,6 +380,6 @@ class Text(_RetainedTextMobject):
         axis = _base._as_vec2(direction)
         handle = _native_layout_handle(self._semantic_handle)
         return _base.Vec2(
-            float(handle.criticalX(float(axis.x), float(axis.y))),
-            float(handle.criticalY(float(axis.x), float(axis.y))),
+            float(engine_call(handle.criticalX, float(axis.x), float(axis.y))),
+            float(engine_call(handle.criticalY, float(axis.x), float(axis.y))),
         )

--- a/web/python/_noon_errors.py
+++ b/web/python/_noon_errors.py
@@ -33,6 +33,10 @@ class NoonValueError(NoonError, ValueError):
     pass
 
 
+class NoonIndexError(NoonValueError, IndexError):
+    """A structured invalid-input failure that also satisfies Python index semantics."""
+
+
 class NoonForeignHandleError(NoonError, ValueError):
     pass
 
@@ -83,6 +87,10 @@ _EXCEPTION_TYPES = {
     "ownership": NoonOwnershipError,
 }
 
+_CODE_EXCEPTION_TYPES = {
+    "authoring.invalid_submobject_index": NoonIndexError,
+}
+
 
 def _diagnostic(value: object) -> NoonErrorCause | None:
     if getattr(value, "noonErrorVersion", None) != 1:
@@ -104,7 +112,10 @@ def map_engine_error(error: Exception, *, operation: str | None = None) -> Excep
     diagnostic = _diagnostic(original)
     if diagnostic is None:
         return error
-    exception_type = _EXCEPTION_TYPES.get(diagnostic.category, NoonError)
+    exception_type = _CODE_EXCEPTION_TYPES.get(
+        diagnostic.code,
+        _EXCEPTION_TYPES.get(diagnostic.category, NoonError),
+    )
     return exception_type(diagnostic, original, operation)
 
 

--- a/web/python/_noon_errors.py
+++ b/web/python/_noon_errors.py
@@ -33,10 +33,6 @@ class NoonValueError(NoonError, ValueError):
     pass
 
 
-class NoonIndexError(NoonValueError, IndexError):
-    """A structured invalid-input failure that also satisfies Python index semantics."""
-
-
 class NoonForeignHandleError(NoonError, ValueError):
     pass
 
@@ -87,10 +83,6 @@ _EXCEPTION_TYPES = {
     "ownership": NoonOwnershipError,
 }
 
-_CODE_EXCEPTION_TYPES = {
-    "authoring.invalid_submobject_index": NoonIndexError,
-}
-
 
 def _diagnostic(value: object) -> NoonErrorCause | None:
     if getattr(value, "noonErrorVersion", None) != 1:
@@ -112,10 +104,7 @@ def map_engine_error(error: Exception, *, operation: str | None = None) -> Excep
     diagnostic = _diagnostic(original)
     if diagnostic is None:
         return error
-    exception_type = _CODE_EXCEPTION_TYPES.get(
-        diagnostic.code,
-        _EXCEPTION_TYPES.get(diagnostic.category, NoonError),
-    )
+    exception_type = _EXCEPTION_TYPES.get(diagnostic.category, NoonError)
     return exception_type(diagnostic, original, operation)
 
 

--- a/web/python/examples/ordinary_affine_callback_continuation.py
+++ b/web/python/examples/ordinary_affine_callback_continuation.py
@@ -7,7 +7,7 @@ when the segment has completed and its player lease was returned.
 """
 
 import _manim_updaters
-from noon import Circle, Color, RIGHT, Scene, Square, Transform, VGroup, linear
+from noon import Circle, Color, NoonUnsupportedError, RIGHT, Scene, Square, Transform, VGroup, linear
 
 
 class OrdinaryAffineCallbackContinuation(Scene):
@@ -79,8 +79,13 @@ class OrdinaryAffineCallbackContinuation(Scene):
         before = circle.get_center()
         try:
             circle.next_to(probe, RIGHT, buff=0.1)
-        except ValueError as error:
-            assert "active effective affine driver" in str(error)
+        except NoonUnsupportedError as error:
+            assert error.category == "unsupported_operation"
+            cause = error.rust_cause
+            assert cause is not None
+            while cause.cause is not None:
+                cause = cause.cause
+            assert cause.code == "authoring.unsupported_operation"
         else:
             raise AssertionError("placement bypassed the active affine driver")
         assert circle.get_center() == before

--- a/web/python/test_manim_shared_family_arrange.py
+++ b/web/python/test_manim_shared_family_arrange.py
@@ -128,7 +128,7 @@ class ManimSharedFamilyArrangeTests(unittest.TestCase):
             try:
                 family.arrange()
                 raise AssertionError("shared rejection was swallowed")
-            except ValueError as error:
+            except RuntimeError as error:
                 assert str(error) == "invalid shared arrangement"
             store.reject_arrange = False
 

--- a/web/python/test_manim_shared_object_observations.py
+++ b/web/python/test_manim_shared_object_observations.py
@@ -19,6 +19,7 @@ class ManimSharedObjectObservationTests(unittest.TestCase):
         source = textwrap.dedent(
             r"""
             import json
+            from test_noon_errors import diagnostic, js_exception
             from types import SimpleNamespace
             import sys
             import types
@@ -35,7 +36,9 @@ class ManimSharedObjectObservationTests(unittest.TestCase):
 
                 def manimLineEndpoints(self):
                     if "line" not in self.snapshot["geometry"]:
-                        raise ValueError("mobject content is not an analytic Line")
+                        raise js_exception(diagnostic("unsupported_operation", "authoring.unsupported",
+                            "Line endpoint queries require an analytic Line",
+                            cause=diagnostic("unsupported_operation", "authoring.unsupported_operation")))
                     return SimpleNamespace(startX=1.25, startY=-2.5, endX=4.5, endY=3.75)
 
                 @property
@@ -93,7 +96,8 @@ class ManimSharedObjectObservationTests(unittest.TestCase):
             try:
                 _manim_indication.ShowPassingFlash(Square())
             except NotImplementedError as error:
-                assert "exact Line subset" in str(error)
+                assert error.category == "unsupported_operation"
+                assert error.code == "authoring.unsupported"
             else:
                 raise AssertionError("typed non-Line passed ShowPassingFlash admission")
 

--- a/web/python/test_manim_show_passing_flash.py
+++ b/web/python/test_manim_show_passing_flash.py
@@ -19,6 +19,7 @@ class ManimShowPassingFlashTests(unittest.TestCase):
         source = textwrap.dedent(
             r"""
             import json
+            from test_noon_errors import diagnostic, js_exception
             from types import SimpleNamespace
             import sys
             import types
@@ -35,7 +36,9 @@ class ManimShowPassingFlashTests(unittest.TestCase):
 
                 def manimLineEndpoints(self):
                     if "line" not in self.snapshot["geometry"]:
-                        raise ValueError("mobject content is not an analytic Line")
+                        raise js_exception(diagnostic("unsupported_operation", "authoring.unsupported",
+                            "Line endpoint queries require an analytic Line",
+                            cause=diagnostic("unsupported_operation", "authoring.unsupported_operation")))
                     line = self.snapshot["geometry"]["line"]
                     return SimpleNamespace(
                         startX=line["start"]["x"], startY=line["start"]["y"],

--- a/web/python/test_noon_errors_wasm.py
+++ b/web/python/test_noon_errors_wasm.py
@@ -558,8 +558,7 @@ class WasmErrorProjectionTests(unittest.TestCase):
     def test_accepted_direct_handle_errors_preserve_paint_and_recover(self):
         store = wasm.WasmAuthoringStore.new()
         with self.assertRaises(NoonValueError) as caught:
-            engine_call(store.createManimGeometry,
-                        wasm.WasmManimGeometryOptions.circle(float("nan")))
+            engine_call(wasm.WasmManimGeometryOptions.circle, float("nan"))
         self.assert_diagnostic(caught.exception, "invalid_input")
         self.assertIn("authoring.invalid_render_number", codes(caught.exception))
         target = circle(store)
@@ -593,7 +592,7 @@ class WasmErrorProjectionTests(unittest.TestCase):
         host.resetStore()
         from noon import Circle, Square, VGroup
         first, second = Circle(), Square()
-        group = VGroup(first, second)
+        group = VGroup(VGroup(first), VGroup(second))
         def state():
             return (first._semantic_handle.snapshotJson(), second._semantic_handle.snapshotJson())
         before = state()
@@ -612,7 +611,8 @@ class WasmErrorProjectionTests(unittest.TestCase):
         self.assertEqual(state(), before)
         with self.assertRaises(NoonValueError) as caught:
             first.shift((1e40, 0))
-        self.assertEqual(caught.exception.code, "authoring.invalid_render_number")
+        self.assertEqual(codes(caught.exception),
+                         ["authoring.vector_lowering", "vector.invalid_coordinates"])
         self.assertEqual(state(), before)
         group.next_to((1, 0), index_of_submobject_to_align=0)
         group.arrange()

--- a/web/python/test_noon_errors_wasm.py
+++ b/web/python/test_noon_errors_wasm.py
@@ -597,6 +597,15 @@ class WasmErrorProjectionTests(unittest.TestCase):
         def state():
             return (first._semantic_handle.snapshotJson(), second._semantic_handle.snapshotJson())
         before = state()
+        for reject in (
+            lambda: group.next_to((0, 0), index_of_submobject_to_align=99),
+            lambda: group.arrange(index_of_submobject_to_align=99),
+        ):
+            with self.assertRaises(NoonValueError) as caught:
+                reject()
+            self.assert_diagnostic(caught.exception, "invalid_input")
+            self.assertEqual(caught.exception.code, "authoring.invalid_submobject_index")
+            self.assertEqual(state(), before)
         with self.assertRaises(NoonValueError) as caught:
             group.arrange_in_grid(rows=1, cols=1)
         self.assertEqual(caught.exception.code, "authoring.insufficient_grid_capacity")
@@ -605,6 +614,8 @@ class WasmErrorProjectionTests(unittest.TestCase):
             first.shift((1e40, 0))
         self.assertEqual(caught.exception.code, "authoring.invalid_render_number")
         self.assertEqual(state(), before)
+        group.next_to((1, 0), index_of_submobject_to_align=0)
+        group.arrange()
         group.arrange_in_grid(rows=1, cols=2)
         first.shift((0.5, 0))
         self.assertNotEqual(state(), before)

--- a/web/python/test_noon_errors_wasm.py
+++ b/web/python/test_noon_errors_wasm.py
@@ -14,7 +14,7 @@ except ImportError:
 
 from _noon_errors import (
     NoonError, NoonForeignHandleError, NoonOwnershipError, NoonPendingError, NoonCallbackError,
-    NoonStaleHandleError, NoonStalePublicationError, NoonValueError,
+    NoonStaleHandleError, NoonStalePublicationError, NoonValueError, NoonUnsupportedError,
     engine_await, engine_call,
 )
 
@@ -553,6 +553,86 @@ class WasmErrorProjectionTests(unittest.TestCase):
         context.returnExecutionPlayer(player)
         self.assertEqual(context.liveExecutionOwnership(),"returned")
         self.assertEqual(json.loads(context.liveDebugFrameJson())["time"],0.25)
+
+
+    def test_accepted_direct_handle_errors_preserve_paint_and_recover(self):
+        store = wasm.WasmAuthoringStore.new()
+        with self.assertRaises(NoonValueError) as caught:
+            engine_call(store.createManimGeometry,
+                        wasm.WasmManimGeometryOptions.circle(float("nan")))
+        self.assert_diagnostic(caught.exception, "invalid_input")
+        self.assertIn("authoring.invalid_render_number", codes(caught.exception))
+        target = circle(store)
+        before = target.snapshotJson()
+        with self.assertRaises(NoonValueError) as caught:
+            engine_call(target.setOpacity, 1.5)
+        self.assertEqual(caught.exception.code, "authoring.invalid_opacity")
+        self.assertEqual(target.snapshotJson(), before)
+        engine_call(target.setOpacity, 0.5)
+        self.assertAlmostEqual(target.fillOpacity, 0.5)
+        self.assertAlmostEqual(target.strokeOpacity, 0.5)
+        self.assertEqual(json.loads(target.snapshotJson())["style"]["opacity"], 1.0)
+
+    def test_public_line_match_retains_unsupported_cause_and_recovers(self):
+        host.resetStore()
+        from noon import Line
+        source = Line((-1, 0), (1, 0))
+        target = Line((-1, 0), (1, 0)).scale((2, 1))
+        before = source._semantic_handle.snapshotJson()
+        with self.assertRaises(NoonUnsupportedError) as caught:
+            source.match_points(target)
+        self.assert_diagnostic(caught.exception, "unsupported_operation")
+        self.assertEqual(caught.exception.operation, "Line.match_points")
+        self.assertEqual(codes(caught.exception),
+                         ["authoring.unsupported", "authoring.unsupported_operation"])
+        self.assertEqual(source._semantic_handle.snapshotJson(), before)
+        source.match_points(Line((0, 0), (0, 2)))
+        self.assertAlmostEqual(source.get_end()[1], 2.0)
+
+    def test_public_family_and_property_rejections_preserve_shared_state(self):
+        host.resetStore()
+        from noon import Circle, Square, VGroup
+        first, second = Circle(), Square()
+        group = VGroup(first, second)
+        def state():
+            return (first._semantic_handle.snapshotJson(), second._semantic_handle.snapshotJson())
+        before = state()
+        with self.assertRaises(NoonValueError) as caught:
+            group.arrange_in_grid(rows=1, cols=1)
+        self.assertEqual(caught.exception.code, "authoring.insufficient_grid_capacity")
+        self.assertEqual(state(), before)
+        with self.assertRaises(NoonValueError) as caught:
+            first.shift((1e40, 0))
+        self.assertEqual(caught.exception.code, "authoring.invalid_render_number")
+        self.assertEqual(state(), before)
+        group.arrange_in_grid(rows=1, cols=2)
+        first.shift((0.5, 0))
+        self.assertNotEqual(state(), before)
+
+    def test_public_options_and_value_errors_use_the_existing_mapper(self):
+        host.resetStore()
+        from noon import Scene
+        from _manim_animation_options import resolve
+        from _manim_scene import _context
+        def options(run_time):
+            return resolve(builder_args={"run_time": run_time}, default_lag_ratio=0,
+                           play_run_time=None, play_easing=None, play_rate_func=None,
+                           play_lag_ratio=None)
+        with self.assertRaises(NoonValueError) as caught:
+            options(-1)
+        self.assert_diagnostic(caught.exception, "invalid_input")
+        self.assertEqual(caught.exception.operation, "animation.options")
+        self.assertEqual(options(0.5).run_time, 0.5)
+        scene = Scene()
+        context = _context(scene)
+        before = (list(context.rootMembershipKeys()), context.authoredDuration())
+        with self.assertRaises(NoonValueError) as caught:
+            scene.value_tracker(float("nan"))
+        self.assertIn("signal.non_finite_value", codes(caught.exception))
+        self.assertEqual((list(context.rootMembershipKeys()), context.authoredDuration()), before)
+        tracker = scene.value_tracker(2.0)
+        tracker.set_value(3.0)
+        self.assertEqual(tracker.get_value(), 3.0)
 
 
 async def check_real_promise_rejection():

--- a/web/python/test_ordinary_tracker_scope.py
+++ b/web/python/test_ordinary_tracker_scope.py
@@ -91,7 +91,7 @@ class OrdinaryTrackerScopeTests(unittest.TestCase):
                     self.assertEqual(tracker.get_value(), 2.0)
 
                     rejected = Scene(Context(reject=True))
-                    with self.assertRaisesRegex(ValueError, "association rejected"):
+                    with self.assertRaisesRegex(RuntimeError, "association rejected"):
                         tracker._associate_canonical(rejected, rejected.context)
                     self.assertIsNone(tracker._scene)
                     self.assertIsNone(tracker._canonical_context)


### PR DESCRIPTION
Supported public authoring failures were flattened to strings or replaced by generic Python exceptions after Rust had produced a typed cause. Preserve those causes through the existing AuthoringFailure and Python engine_call/raise_engine_error adapters. Animation options now use the same failure path, deleting their separate ok/errorKind/message protocol. Invalid family member indices expose NoonValueError with the shared invalid-input code; the former message-dependent plain IndexError conversion is removed.

Advances the finite #61 / #953 closeout. The optional language boundary owns this representation; shared Rust semantics, validation, scheduling, atomic publication and locality remain unchanged. Successful calls forward the same arguments/results; Python coercion and unmarked exceptions retain their own behavior. No new mapper framework, engine authority, compatibility adapter or migration seam. The closed #1353 / stopped R2b producer work is not replayed, and composition policy is unchanged.

The settled producer stage is integrated with merged callback family translation, resource admission and error causes. Public calls cover constructor/geometry, authored and live object/family edits, layout/copy/target/state, observations, value/signal/camera and animation options. Existing native and Python cases prove atomic rejection, preserved nested causes, same-session recovery and one affected execution slot. Four additional browser scenarios cover constructor/paint, unsupported Line matching, nested family layout/property rejection and options/value recovery. Existing paired Rust/Python scenes remain the shared semantic proofs.

## Final Phase A qualification and landing

#1368 merged as 995d18f9bb6da4af6a9e98f1ed33042d9bb42f04 from reviewed head9915378c3ffd5a0732d7e8f6301e074fc9edca42. This completes the finite supported public Rust-to-Python error inventory through the existing mapper; shared semantic authority, publication and runtime policy are unchanged.

- Exact `bash scripts/check.sh full` step in34409490041 passed: **1,732 Rust tests,0 failures,3 existing ignores**, all-target checks/lint, default optimized WASM and161 public API contracts. Immutable release artifact10127079879 has WASM SHA256 `ae1a8f5bc425e6995e3f4da188874b3e0efa5a68598d420f7f574f0beeb5cb27`.
- Final release-browser qualification **34411664969 passed completely** on exact final source9915378c, reusing that verified package without rebuilding Rust. It checks unchanged compiled/frontend inputs and runs the amended shared authoring/continuation and Manim consumers. Evidence artifact10127578520 includes both successful logs. Transferable/WebGPU and shared/WebGPU, paired live membership, persisted Scene reuse, synchronous JSPI continuation and required callbacks pass.
- Current-source Fast Gate and architecture/layer checks passed. The actual typed error boundary passes **17 general+8 callback tests,zero skips**,59 cases per language and same-worker recovery. The four added cases use real Rust/WASM/Pyodide operations; native cases prove atomic rejection/retry and one affected execution slot.
- Existing Rust/Python paired scenes remain the semantic proofs. The callback example now catches the actual typed unsupported cause; two layout and three Manim ownership assertions were updated to the settled structured contracts without weakening state/lifetime/retry assertions.

The first full workflow's trailing browser stage failed on the old layout exception assertion; it is not described as an entirely successful workflow. Its successful full-gate/build step is combined with the successful final browser-only run above. A local synchronous-JSPI observation failed before the final GitHub run passed unchanged; no timing assertion or engine policy was weakened. Additional automatic product/platform jobs were still running at merge and are not falsely listed as passed; no required status-check contexts were configured. Qualified immutable inputs were reused instead of restarting another full build.

A1/A2/A4/A5/A6 and direct host/settle ownership are already reconciled/closed. #1360 callback family translation, #1363 atomic resource admission, #1364 settle/resize, and #1365's34/34 pinned-Manim comparisons are landed. **The finite Phase A acceptance is complete.** WebGPU device replacement/diagnostic delivery remains explicitly open in #1366; broader interaction/reclamation/hot-reload work remains Phase C#955. Those capabilities are not claimed implemented by this closeout. No Codex GitHub review bot was invoked.
