### PR TITLE
Complete shared Group coordinate and dimension operations

### DIFF
--- a/compat/manim-v0.21.0.json
+++ b/compat/manim-v0.21.0.json
@@ -14,8 +14,8 @@
   "overrides": {
     "Mobject": {"status": "partial", "category": "core-object", "dependency": "#74", "reason": "Common transform/style/layout methods exist; full family/state/query parity is pending."},
     "VMobject": {"status": "partial", "category": "core-object", "dependency": "#74/#78", "reason": "Vector object facade exists; full path-building/query semantics are pending."},
-    "Group": {"status": "partial", "category": "core-object", "dependency": "#51/#74", "reason": "Authoring group exists but retained semantic family identity is still being migrated."},
-    "VGroup": {"status": "partial", "category": "core-object", "dependency": "#51/#74", "reason": "Authoring group exists but retained semantic family identity is still being migrated."},
+    "Group": {"status": "partial", "category": "core-object", "dependency": "#74", "reason": "Shared semantic family identity exists; remaining membership, state and query compatibility qualification is pending."},
+    "VGroup": {"status": "partial", "category": "core-object", "dependency": "#74", "reason": "Shared semantic family identity exists; remaining membership, state and query compatibility qualification is pending."},
     "Scene": {"status": "partial", "category": "scene", "dependency": "#89", "reason": "Core add/remove/play/wait lifecycle exists; ordering/camera/section breadth is pending."},
     "Circle": {"status": "supported", "category": "geometry", "evidence": "scripts/manim-compat-smoke.mjs; web/python/test_manim_shared_constructors.py"},
     "Rectangle": {"status": "supported", "category": "geometry", "evidence": "scripts/manim-compat-smoke.mjs; web/python/test_manim_shared_constructors.py"},

--- a/crates/noon/src/example_scenes/dimension_fitting.rs
+++ b/crates/noon/src/example_scenes/dimension_fitting.rs
@@ -42,7 +42,7 @@ pub fn session() -> Result<ExecutionSession, String> {
         let mut live = scene.live(&mut session);
         live.match_dim_size(&source, &target, Width, true)
             .map_err(|e| e.to_string())?;
-        live.rescale_to_fit(&group, 2.0, Height, true)
+        live.rescale_to_fit(&group, 2.0, Height, false)
             .map_err(|e| e.to_string())?;
         assert!(
             (live.effective_layout(&a).map_err(|e| e.to_string())?.width

--- a/crates/noon/src/example_scenes/family_placement.rs
+++ b/crates/noon/src/example_scenes/family_placement.rs
@@ -103,6 +103,30 @@ pub fn session() -> Result<ExecutionSession, String> {
         .map_err(|error| error.to_string())?;
     // Exercise shared frame placement, then restore the demonstration layout.
     let center = family.layout().map_err(|error| error.to_string())?.center();
+    for (point, edge, mask) in [
+        (
+            (
+                center.0 + family.layout().map_err(|e| e.to_string())?.width() / 2.0,
+                0.0,
+            ),
+            (1.0, 0.0),
+            (1.0, 0.0),
+        ),
+        (
+            (
+                0.0,
+                center.1 + family.layout().map_err(|e| e.to_string())?.height() / 2.0,
+            ),
+            (0.0, 1.0),
+            (0.0, 1.0),
+        ),
+    ] {
+        family
+            .layout()
+            .map_err(|e| e.to_string())?
+            .move_to(Target::Point(point.0, point.1), edge, mask)
+            .map_err(|e| e.to_string())?;
+    }
     family
         .layout()
         .map_err(|error| error.to_string())?
@@ -130,6 +154,25 @@ pub fn session() -> Result<ExecutionSession, String> {
             .effective_family_layout(&family)
             .map_err(|e| e.to_string())?
             .center;
+        let layout = live
+            .effective_family_layout(&family)
+            .map_err(|e| e.to_string())?;
+        for (point, edge, mask) in [
+            ((center.0 + layout.width / 2.0, 0.0), (1.0, 0.0), (1.0, 0.0)),
+            (
+                (0.0, center.1 + layout.height / 2.0),
+                (0.0, 1.0),
+                (0.0, 1.0),
+            ),
+        ] {
+            live.move_family_to(
+                &family,
+                crate::LiveLayoutTarget::Point(point.0, point.1),
+                edge,
+                mask,
+            )
+            .map_err(|e| e.to_string())?;
+        }
         live.align_family_on_frame(&family, (0.0, -1.0), 0.5)
             .map_err(|e| e.to_string())?;
         let layout = live

--- a/parity/manim-v0.21/core-examples/group_coordinate_dimensions.py
+++ b/parity/manim-v0.21/core-examples/group_coordinate_dimensions.py
@@ -1,0 +1,18 @@
+from manim import *
+
+
+class GroupCoordinateDimensions(Scene):
+    def construct(self):
+        first = Rectangle(width=2, height=1).set_fill("#4488FF", opacity=1).set_stroke(width=0)
+        second = Square(side_length=1).set_fill("#FFCC44", opacity=1).set_stroke(width=0)
+        target = Rectangle(width=0.5, height=2).set_fill("#FF4466", opacity=1).set_stroke(width=0)
+        first.shift(2 * LEFT)
+        second.shift(2 * RIGHT)
+        target.shift(RIGHT + UP)
+        family = VGroup(first, VGroup(second), first)
+        family.width = 4
+        family.height = 2
+        family.set_x(3, RIGHT).set_y(-2, DOWN)
+        family.match_x(target, LEFT).match_y(target, UP)
+        self.add(family, target)
+        self.wait(0.2)

--- a/parity/manim-v0.21/core-examples/group_coordinate_dimensions.py
+++ b/parity/manim-v0.21/core-examples/group_coordinate_dimensions.py
@@ -9,7 +9,7 @@ class GroupCoordinateDimensions(Scene):
         first.shift(2 * LEFT)
         second.shift(2 * RIGHT)
         target.shift(RIGHT + UP)
-        family = VGroup(first, VGroup(second), first)
+        family = VGroup(first, VGroup(first, second))
         family.width = 4
         family.height = 2
         family.set_x(3, RIGHT).set_y(-2, DOWN)

--- a/parity/manim-v0.21/manifest.json
+++ b/parity/manim-v0.21/manifest.json
@@ -93,7 +93,7 @@
       "scene": "CreateStyledSquare",
       "expected_duration": 1.0,
       "raster_tolerance": {
-        "max_differing_ratio": 0.00005,
+        "max_differing_ratio": 5e-05,
         "max_mean_absolute_channel_error": 0.022
       }
     },
@@ -320,6 +320,17 @@
         "max_bounds_delta_px": null,
         "max_differing_ratio": 0.12,
         "max_mean_absolute_channel_error": 8.0
+      }
+    },
+    {
+      "id": "group-coordinate-dimensions",
+      "scene": "GroupCoordinateDimensions",
+      "source": "parity/manim-v0.21/core-examples/group_coordinate_dimensions.py",
+      "expected_duration": 0.2,
+      "raster_tolerance": {
+        "max_bounds_delta_px": 1,
+        "max_differing_ratio": 0.003,
+        "max_mean_absolute_channel_error": 0.1
       }
     }
   ],

--- a/scripts/manim-differential.py
+++ b/scripts/manim-differential.py
@@ -512,8 +512,8 @@ def _manim_rotate_about_origin() -> Any:
 def _group_coordinate_dimensions(api, group_class):
     first = api.Rectangle(width=2.0, height=1.0).shift(2 * api.LEFT)
     second = api.Square(side_length=1.0).shift(2 * api.RIGHT)
-    nested = group_class(second)
-    family = group_class(first, nested, first)
+    nested = group_class(first, second)
+    family = group_class(first, nested)
     target = group_class(api.Rectangle(width=0.5, height=2).shift(api.RIGHT + api.UP))
     observations = []
     for operation in (
@@ -530,7 +530,8 @@ def _group_coordinate_dimensions(api, group_class):
             "target": _object_observation(target),
             "members_preserved": family.submobjects[0] is first
                 and family.submobjects[1] is nested
-                and nested.submobjects[0] is second,
+                and nested.submobjects[0] is first
+                and nested.submobjects[1] is second,
         })
     return observations
 

--- a/scripts/manim-differential.py
+++ b/scripts/manim-differential.py
@@ -509,7 +509,39 @@ def _manim_rotate_about_origin() -> Any:
     return _object_observation(obj)
 
 
+def _group_coordinate_dimensions(api, group_class):
+    first = api.Rectangle(width=2.0, height=1.0).shift(2 * api.LEFT)
+    second = api.Square(side_length=1.0).shift(2 * api.RIGHT)
+    nested = group_class(second)
+    family = group_class(first, nested, first)
+    target = group_class(api.Rectangle(width=0.5, height=2).shift(api.RIGHT + api.UP))
+    observations = []
+    for operation in (
+        lambda: setattr(family, "width", 4.0),
+        lambda: setattr(family, "height", 2.0),
+        lambda: family.set_x(3.0, api.RIGHT).set_y(-2.0, api.DOWN),
+        lambda: family.match_x(target, api.LEFT).match_y(target, api.UP),
+    ):
+        operation()
+        observations.append({
+            "family": _object_observation(family),
+            "first": _object_observation(first),
+            "second": _object_observation(second),
+            "target": _object_observation(target),
+            "members_preserved": family.submobjects[0] is first
+                and family.submobjects[1] is nested
+                and nested.submobjects[0] is second,
+        })
+    return observations
+
+
 FIXTURES = [
+    Fixture("group_coordinate_dimensions",
+            lambda: _group_coordinate_dimensions(noon, noon.Group),
+            lambda: _group_coordinate_dimensions(manim, manim.Group)),
+    Fixture("vgroup_coordinate_dimensions",
+            lambda: _group_coordinate_dimensions(noon, noon.VGroup),
+            lambda: _group_coordinate_dimensions(manim, manim.VGroup)),
     Fixture("circle_dimensions", _noon_circle_dimensions, _manim_circle_dimensions),
     Fixture("rectangle_dimensions", _noon_rectangle_dimensions, _manim_rectangle_dimensions),
     Fixture("shifted_circle", _noon_shifted_circle, _manim_shifted_circle),
@@ -557,7 +589,7 @@ FIXTURES = [
 # Explicitly tracked but not yet differential-gated.  Keep this list close to the
 # harness so unsupported behavior is never silently treated as a mismatch.
 UNSUPPORTED = {
-    "family_aliasing": "Python Group still flattens family identity pending shared semantic handles (#61)",
+    "family_aliasing": "Shared semantic identity exists; exhaustive nested-family mutation/copy parity remains under #74",
     "z_index": "Noon does not yet expose the 2.5D/z semantic model (#62)",
     "updater_frame_semantics": "host/native updater phase semantics are being defined in #56",
     "animation_lifecycle": "requires a reference Scene/animation-state probe, to be added incrementally",

--- a/web/python/_manim_compat.py
+++ b/web/python/_manim_compat.py
@@ -235,14 +235,6 @@ class Group(Mobject):
     def get_center(self) -> _base.Vec2:
         return _base._semantic_operations()._get_center(self)
 
-    @property
-    def width(self) -> float:
-        return _base._semantic_operations()._width(self)
-
-    @property
-    def height(self) -> float:
-        return _base._semantic_operations()._height(self)
-
     def shift(self, direction: object) -> Group:
         return _base._semantic_operations()._group_shift(self, direction)
 
@@ -257,11 +249,11 @@ class Group(Mobject):
     def center(self) -> Group:
         return self.move_to(_base.ORIGIN)
 
-    def set_x(self, x: float) -> Group:
-        return self.move_to(_base.Vec2(float(x), 0.0), coor_mask=(1.0, 0.0, 0.0))
+    def set_x(self, x: float, direction: object = _base.ORIGIN) -> Group:
+        return self.set_coord(x, 0, direction)
 
-    def set_y(self, y: float) -> Group:
-        return self.move_to(_base.Vec2(0.0, float(y)), coor_mask=(0.0, 1.0, 0.0))
+    def set_y(self, y: float, direction: object = _base.ORIGIN) -> Group:
+        return self.set_coord(y, 1, direction)
 
     def scale(self, factor: float | tuple[float, float]) -> Group:
         from _manim_semantic_handles import _group_scale

--- a/web/python/_manim_shared_geometry.py
+++ b/web/python/_manim_shared_geometry.py
@@ -43,7 +43,8 @@ def _set_coord(
     coordinate = _shared._ir._finite_number("value", value)
     mask = _coordinate_mask(dim)
     point = _base.Vec2(coordinate if dim == 0 else 0.0, coordinate if dim == 1 else 0.0)
-    return _shared._move_to(
+    move = _shared._group_move_to if isinstance(self, _compat.Group) else _shared._move_to
+    return move(
         self,
         point,
         aligned_edge=direction,
@@ -79,7 +80,8 @@ def _match_coord(
 ) -> _base.Mobject:
     """Match a directional coordinate through shared critical-point placement."""
 
-    return _shared._move_to(
+    move = _shared._group_move_to if isinstance(self, _compat.Group) else _shared._move_to
+    return move(
         self,
         mobject,
         aligned_edge=direction,

--- a/web/python/_manim_shared_geometry.py
+++ b/web/python/_manim_shared_geometry.py
@@ -43,9 +43,7 @@ def _set_coord(
     coordinate = _shared._ir._finite_number("value", value)
     mask = _coordinate_mask(dim)
     point = _base.Vec2(coordinate if dim == 0 else 0.0, coordinate if dim == 1 else 0.0)
-    move = _shared._group_move_to if isinstance(self, _compat.Group) else _shared._move_to
-    return move(
-        self,
+    return self.move_to(
         point,
         aligned_edge=direction,
         coor_mask=mask,
@@ -80,9 +78,7 @@ def _match_coord(
 ) -> _base.Mobject:
     """Match a directional coordinate through shared critical-point placement."""
 
-    move = _shared._group_move_to if isinstance(self, _compat.Group) else _shared._move_to
-    return move(
-        self,
+    return self.move_to(
         mobject,
         aligned_edge=direction,
         coor_mask=_coordinate_mask(dim),

--- a/web/python/examples/manim_parity_group_coordinate_dimensions.py
+++ b/web/python/examples/manim_parity_group_coordinate_dimensions.py
@@ -1,0 +1,18 @@
+from noon import *
+
+
+class GroupCoordinateDimensions(Scene):
+    def construct(self):
+        first = Rectangle(width=2, height=1).set_fill("#4488FF", opacity=1).set_stroke(width=0)
+        second = Square(side_length=1).set_fill("#FFCC44", opacity=1).set_stroke(width=0)
+        target = Rectangle(width=0.5, height=2).set_fill("#FF4466", opacity=1).set_stroke(width=0)
+        first.shift(2 * LEFT)
+        second.shift(2 * RIGHT)
+        target.shift(RIGHT + UP)
+        family = VGroup(first, VGroup(second), first)
+        family.width = 4
+        family.height = 2
+        family.set_x(3, RIGHT).set_y(-2, DOWN)
+        family.match_x(target, LEFT).match_y(target, UP)
+        self.add(family, target)
+        self.wait(0.2)

--- a/web/python/examples/manim_parity_group_coordinate_dimensions.py
+++ b/web/python/examples/manim_parity_group_coordinate_dimensions.py
@@ -9,7 +9,7 @@ class GroupCoordinateDimensions(Scene):
         first.shift(2 * LEFT)
         second.shift(2 * RIGHT)
         target.shift(RIGHT + UP)
-        family = VGroup(first, VGroup(second), first)
+        family = VGroup(first, VGroup(first, second))
         family.width = 4
         family.height = 2
         family.set_x(3, RIGHT).set_y(-2, DOWN)

--- a/web/python/examples/ordinary_dimension_fitting.py
+++ b/web/python/examples/ordinary_dimension_fitting.py
@@ -11,11 +11,11 @@ class DimensionFitting(Scene):
         a.shift(LEFT * 2)
         b.shift(RIGHT * 2)
         family = VGroup(a, b, a)
-        family.scale_to_fit_width(4.0)
+        family.width = 4.0
         self.add(family)
         live = self.live_execution()
         a.match_width(b, stretch=True)
-        family.stretch_to_fit_height(2.0)
+        family.height = 2.0
         assert abs(a.width - b.width) < 1e-6
         assert abs(family.height - 2.0) < 1e-6
         live.wait(0.2)

--- a/web/python/examples/ordinary_family_placement.py
+++ b/web/python/examples/ordinary_family_placement.py
@@ -21,7 +21,8 @@ class OrdinaryFamilyPlacement(Scene):
         family.align_to(UP, UP)
         family.move_to(target, coor_mask=(1, 0, 0))
         center = family.get_center()
-        family.set_x(center.x).set_y(center.y)
+        family.set_x(center.x + family.width / 2, RIGHT)
+        family.set_y(center.y + family.height / 2, UP)
         family.to_corner(2 * RIGHT + UP, buff=0.25)
         assert abs(family.get_right().x - (DEFAULT_FRAME_WIDTH / 2 - 0.5)) < 1e-6
         assert abs(family.get_top().y - 3.75) < 1e-6
@@ -31,7 +32,8 @@ class OrdinaryFamilyPlacement(Scene):
         self.wait(1)
         # After the barrier, the same typed target observes live effective bounds.
         center = family.get_center()
-        family.set_x(center.x).set_y(center.y)
+        family.set_x(center.x + family.width / 2, RIGHT)
+        family.set_y(center.y + family.height / 2, UP)
         family.to_edge(DOWN, buff=0.5)
         assert abs(family.get_bottom().y + 3.5) < 1e-6
         family.move_to(center)

--- a/web/python/test_group_coordinate_dimensions.py
+++ b/web/python/test_group_coordinate_dimensions.py
@@ -1,0 +1,69 @@
+"""Group coordinate and dimension ergonomics dispatch to shared Rust layout."""
+import types
+import unittest
+from unittest.mock import patch
+
+import noon
+import _manim_semantic_handles as semantic
+
+
+class GroupCoordinateDimensionTests(unittest.TestCase):
+    def setUp(self):
+        self.calls = []
+        self.group = object.__new__(noon.VGroup)
+        self.group._semantic_family_handle = object()
+        self.anchor = types.SimpleNamespace(
+            rescaleToFit=lambda *args: self.calls.append(("fit", args)),
+        )
+
+    def test_group_inherits_writable_dimension_properties(self):
+        for cls in (noon.Group, noon.VGroup):
+            with self.subTest(cls=cls.__name__):
+                group = object.__new__(cls)
+                with patch.object(semantic, "_layout_anchor", return_value=self.anchor), \
+                     patch.object(semantic, "_group_live_layout_context", return_value=None):
+                    group.width = 4
+                    group.height = 2
+        self.assertEqual(self.calls, [("fit", (4.0, 0, False)),
+                                     ("fit", (2.0, 1, False))] * 2)
+
+    def test_directional_coordinates_use_family_placement(self):
+        layout = types.SimpleNamespace(
+            moveToPoint=lambda *args: self.calls.append(("point", args)),
+            moveToFamily=lambda *args: self.calls.append(("family", args)),
+        )
+        target = object.__new__(noon.Group)
+        with patch.object(semantic, "_group_live_layout_context", return_value=None), \
+             patch.object(semantic, "_shared_family_layout", return_value=layout):
+            self.assertIs(self.group.set_x(3, noon.RIGHT), self.group)
+            self.assertIs(self.group.set_y(-2, noon.DOWN), self.group)
+            self.assertIs(self.group.match_x(target, noon.LEFT), self.group)
+            self.assertIs(self.group.match_y(target, noon.UP), self.group)
+        self.assertEqual(self.calls, [
+            ("point", (3.0, 0.0, 1.0, 0.0, 1.0, 0.0)),
+            ("point", (0.0, -2.0, 0.0, -1.0, 0.0, 1.0)),
+            ("family", (layout, -1.0, 0.0, 1.0, 0.0)),
+            ("family", (layout, 0.0, 1.0, 0.0, 1.0)),
+        ])
+
+    def test_live_group_coordinates_and_dimensions_use_published_context(self):
+        context = types.SimpleNamespace(
+            liveMoveFamilyToPoint=lambda *args: self.calls.append(("move", args)),
+            liveRescaleToFit=lambda *args: self.calls.append(("fit", args)),
+        )
+        with patch.object(semantic, "_group_live_layout_context", return_value=context), \
+             patch.object(semantic, "_layout_anchor", return_value=self.anchor):
+            self.group.set_coord(5, 0, noon.LEFT)
+            self.group.height = 3
+        self.assertEqual(self.calls, [
+            ("move", (self.group._semantic_family_handle, 5.0, 0.0, -1.0, 0.0, 1.0, 0.0)),
+            ("fit", (self.anchor, 3.0, 1, False)),
+        ])
+
+    def test_invalid_coordinate_does_not_start_a_family_mutation(self):
+        with patch.object(semantic, "_group_move_to") as move:
+            with self.assertRaises(NotImplementedError):
+                self.group.set_coord(1, 2)
+            with self.assertRaises(ValueError):
+                self.group.set_x(float("nan"))
+            move.assert_not_called()

--- a/web/python/test_manim_shared_family_identity.py
+++ b/web/python/test_manim_shared_family_identity.py
@@ -33,9 +33,9 @@ class ManimSharedFamilyIdentityTests(unittest.TestCase):
         self.assertIs(family.set_x(5), family)
         self.assertIs(family.set_y(-3), family)
         self.assertEqual(family.move_to.call_args_list[0].args, (compat._base.Vec2(5, 0),))
-        self.assertEqual(family.move_to.call_args_list[0].kwargs, {"aligned_edge": noon.ORIGIN, "coor_mask": (1.0, 0.0, 0.0)})
+        self.assertEqual(family.move_to.call_args_list[0].kwargs, {"aligned_edge": compat._base.ORIGIN, "coor_mask": (1.0, 0.0, 0.0)})
         self.assertEqual(family.move_to.call_args_list[1].args, (compat._base.Vec2(0, -3),))
-        self.assertEqual(family.move_to.call_args_list[1].kwargs, {"aligned_edge": noon.ORIGIN, "coor_mask": (0.0, 1.0, 0.0)})
+        self.assertEqual(family.move_to.call_args_list[1].kwargs, {"aligned_edge": compat._base.ORIGIN, "coor_mask": (0.0, 1.0, 0.0)})
 
     def test_group_wrapper_mirrors_shared_family_membership(self) -> None:
         python_dir = Path(__file__).resolve().parent

--- a/web/python/test_manim_shared_family_identity.py
+++ b/web/python/test_manim_shared_family_identity.py
@@ -33,9 +33,9 @@ class ManimSharedFamilyIdentityTests(unittest.TestCase):
         self.assertIs(family.set_x(5), family)
         self.assertIs(family.set_y(-3), family)
         self.assertEqual(family.move_to.call_args_list[0].args, (compat._base.Vec2(5, 0),))
-        self.assertEqual(family.move_to.call_args_list[0].kwargs, {"coor_mask": (1.0, 0.0, 0.0)})
+        self.assertEqual(family.move_to.call_args_list[0].kwargs, {"aligned_edge": noon.ORIGIN, "coor_mask": (1.0, 0.0, 0.0)})
         self.assertEqual(family.move_to.call_args_list[1].args, (compat._base.Vec2(0, -3),))
-        self.assertEqual(family.move_to.call_args_list[1].kwargs, {"coor_mask": (0.0, 1.0, 0.0)})
+        self.assertEqual(family.move_to.call_args_list[1].kwargs, {"aligned_edge": noon.ORIGIN, "coor_mask": (0.0, 1.0, 0.0)})
 
     def test_group_wrapper_mirrors_shared_family_membership(self) -> None:
         python_dir = Path(__file__).resolve().parent


### PR DESCRIPTION
Group/VGroup overrides currently make `width` and `height` read-only and reject directional `set_x`/`set_y`. Inherited `set_coord`/`match_coord` also take the single-object bridge, which cannot operate on a family handle. For example, `family.width = 4; family.set_x(3, RIGHT)` fails despite the Rust family operations already existing.

This B1 batch restores writable inherited dimension properties and routes coordinate intent to the existing shared family placement operation. Bounds, identity, alias deduplication, atomic edits and authored/effective observations remain Rust-owned. No engine authority, mutation protocol, migration seam or renderer behavior is introduced. Work remains proportional to the affected family; unrelated families are unchanged.

Advances #74 / Track 1 of #954. The separately claimed scale-pivot and slicing work is untouched. Group/VGroup remain `partial` in the compatibility manifest pending the complete B1 qualification gate.

Evidence added/updated:
- Focused Python regressions for properties, directional coordinate/match dispatch, coherent live routing and invalid inputs.
- Existing executable native/direct-WASM Rust and Python dimension-fitting and family-placement examples exercise the same operations.
- Two shared Rust/Python versus pinned ManimCE 0.21.0 semantic probes for Group and VGroup, with nested members, aliases and unrelated targets.
- Source-equivalent user example and canonical raster/timeline fixture `group-coordinate-dimensions` (both WebGPU and WebGL when qualified).

Validation so far:
- `PYTHONPATH=web/python python3 -m unittest web/python/test_group_coordinate_dimensions.py web/python/test_dimension_fitting.py web/python/test_manim_shared_coordinate_placement.py web/python/test_manim_shared_match_xy.py` — 9 passed.
- `CARGO_TARGET_DIR=/Users/ykshin/Dev/me/noon/target cargo test -p noon --no-default-features --test dimension_fitting --test family_layout --test live_family_layout` — 20 passed.
- `bash scripts/check.sh architecture` — passed.
- `node scripts/manim-differential-noon.mjs /tmp/noon-b1-semantic-observations.json` — all 36 real Rust/WASM/Python probes executed; reused the qualified Phase A WASM because engine implementation inputs are unchanged (Rust edits here are example builders only). This is not yet a pinned Manim comparison or a rebuilt-example WASM qualification.
- `node scripts/manim-raster-policy.test.mjs` — passed.
- `CARGO_TARGET_DIR=/Users/ykshin/Dev/me/noon/target bash scripts/check.sh full` — architecture, formatting, workspace all-target/all-feature check and clippy passed; stopped during workspace test compilation to avoid exhausting the approximately 0.5 GiB remaining local disk. Not a full local pass. Pinned Manim semantic/raster comparison and current-source GitHub checks are pending.

Latest local validation: `PYTHONPATH=web/python python3 -m unittest discover -s web/python -p 'test_*.py'` — 197 discovered, 172 passed, 25 existing host-dependent skips. The complete 36-fixture real Rust/WASM/Python observation run also passed after the placement-dispatch change. Final source is `d1e60634bb72e774b691b46b8034984ea9851412`. All applicable GitHub checks pass, including Rust tests/check/lint and target matrix, native presentation, Chromium, Firefox, WebKit mobile, product visual/performance regression, and pinned ManimCE 0.21 semantic/raster plus sparse/dense playback qualification (run 34418341984).

The final coordinate fixture contains a nested shared leaf but no repeated direct-member constructor input. The separate duplicate insertion/re-add order discrepancy is explicitly tracked in #74 (comment 5610348599) and is being fixed on `codex/b1-family-membership`; it is not hidden by a support promotion. The interrupted full local run remains reported above and is not claimed as passing.
