### PR TITLE
Prepare inert rendering/session MCP contracts

### DIFF
--- a/tools/noon-mcp/src/rendering-contract.mjs
+++ b/tools/noon-mcp/src/rendering-contract.mjs
@@ -6,7 +6,6 @@ import * as z from "zod/v4";
 // boundary. Keeping the contract inert prevents a schema-only change from
 // accidentally exposing source execution through MCP.
 export const RENDERING_CONTRACT_VERSION = 1;
-export const RENDERING_TOOL_REGISTRATION_ENABLED = false;
 export const MAX_RENDER_SOURCE_BYTES = 1_000_000;
 export const MAX_RENDER_TIME_SECONDS = 600;
 export const MAX_RENDER_SAMPLES_PER_CALL = 64;

--- a/tools/noon-mcp/src/rendering-contract.mjs
+++ b/tools/noon-mcp/src/rendering-contract.mjs
@@ -77,7 +77,7 @@ export const renderingToolContracts = Object.freeze({
     annotations: Object.freeze({
       readOnlyHint: false,
       destructiveHint: true,
-      idempotentHint: true,
+      idempotentHint: false,
       openWorldHint: false,
     }),
   }),

--- a/tools/noon-mcp/src/rendering-contract.mjs
+++ b/tools/noon-mcp/src/rendering-contract.mjs
@@ -1,0 +1,87 @@
+import { Buffer } from "node:buffer";
+import * as z from "zod/v4";
+
+// Contract preparation only. These schemas are intentionally not imported by
+// server.mjs until #1197 qualifies the shared runner and its isolation/cleanup
+// boundary. Keeping the contract inert prevents a schema-only change from
+// accidentally exposing source execution through MCP.
+export const RENDERING_CONTRACT_VERSION = 1;
+export const RENDERING_TOOL_REGISTRATION_ENABLED = false;
+export const MAX_RENDER_SOURCE_BYTES = 1_000_000;
+export const MAX_RENDER_TIME_SECONDS = 600;
+export const MAX_RENDER_SAMPLES_PER_CALL = 64;
+
+const sessionHandle = z.string()
+  .min(16)
+  .max(128)
+  .regex(/^[A-Za-z0-9._~-]+$/);
+
+const source = z.string()
+  .refine((value) => value.trim().length > 0, "source must be non-empty")
+  .refine((value) => !value.includes("\0"), "source must not contain NUL")
+  .refine((value) => Buffer.byteLength(value, "utf8") <= MAX_RENDER_SOURCE_BYTES,
+    "source exceeds byte limit");
+
+const renderTime = z.number().finite().nonnegative().max(MAX_RENDER_TIME_SECONDS);
+const sampleSchedule = z.array(renderTime).min(1).max(MAX_RENDER_SAMPLES_PER_CALL)
+  .superRefine((values, context) => {
+    for (let index = 1; index < values.length; index += 1) {
+      if (values[index] < values[index - 1]) {
+        context.addIssue({
+          code: "custom",
+          message: "sample times must be nondecreasing for forward-only preview",
+          path: [index],
+        });
+      }
+    }
+  });
+
+const sessionOnly = z.strictObject({ session: sessionHandle });
+
+export const renderingToolContracts = Object.freeze({
+  noon_open_scene: Object.freeze({
+    description: "Open one isolated Noon preview session and return only after its first coherent frame is ready.",
+    inputSchema: z.strictObject({
+      source,
+      loopDurationSeconds: z.number().finite().positive().max(MAX_RENDER_TIME_SECONDS).optional(),
+    }),
+    annotations: Object.freeze({
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+    }),
+  }),
+  noon_sample_frames: Object.freeze({
+    description: "Advance one owned Noon preview session through a forward-only sampling schedule.",
+    inputSchema: z.strictObject({ session: sessionHandle, times: sampleSchedule }),
+    annotations: Object.freeze({
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+    }),
+  }),
+  noon_inspect: Object.freeze({
+    description: "Read the last coherent observations supported by one owned Noon preview session.",
+    inputSchema: sessionOnly,
+    annotations: Object.freeze({
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    }),
+  }),
+  noon_close_scene: Object.freeze({
+    description: "Cancel and close one owned Noon preview session and invalidate its handle.",
+    inputSchema: sessionOnly,
+    annotations: Object.freeze({
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
+    }),
+  }),
+});
+
+export const RENDERING_TOOL_NAMES = Object.freeze(Object.keys(renderingToolContracts));

--- a/tools/noon-mcp/test/rendering-contract.test.mjs
+++ b/tools/noon-mcp/test/rendering-contract.test.mjs
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  MAX_RENDER_SAMPLES_PER_CALL,
+  MAX_RENDER_SOURCE_BYTES,
+  MAX_RENDER_TIME_SECONDS,
+  RENDERING_CONTRACT_VERSION,
+  RENDERING_TOOL_NAMES,
+  RENDERING_TOOL_REGISTRATION_ENABLED,
+  renderingToolContracts,
+} from "../src/rendering-contract.mjs";
+
+const session = "scene_0123456789abcdef";
+
+function accepts(name, value) {
+  return renderingToolContracts[name].inputSchema.safeParse(value).success;
+}
+
+test("rendering contract is versioned but deliberately not registered", () => {
+  assert.equal(RENDERING_CONTRACT_VERSION, 1);
+  assert.equal(RENDERING_TOOL_REGISTRATION_ENABLED, false);
+  assert.deepEqual(RENDERING_TOOL_NAMES, [
+    "noon_open_scene", "noon_sample_frames", "noon_inspect", "noon_close_scene",
+  ]);
+});
+
+test("open scene accepts only bounded source and loop duration", () => {
+  assert.equal(accepts("noon_open_scene", { source: "from noon import *\n" }), true);
+  assert.equal(accepts("noon_open_scene", {
+    source: "from noon import *\n", loopDurationSeconds: 4,
+  }), true);
+  for (const invalid of [
+    { source: "" },
+    { source: "   \n" },
+    { source: "x\0y" },
+    { source: "x".repeat(MAX_RENDER_SOURCE_BYTES + 1) },
+    { source: "é".repeat(Math.floor(MAX_RENDER_SOURCE_BYTES / 2) + 1) },
+    { source: "x", loopDurationSeconds: 0 },
+    { source: "x", loopDurationSeconds: Infinity },
+    { source: "x", loopDurationSeconds: MAX_RENDER_TIME_SECONDS + 1 },
+    { source: "x", repoRoot: "/tmp/other" },
+    { source: "x", command: "python" },
+    { source: "x", cwd: "/" },
+  ]) {
+    assert.equal(accepts("noon_open_scene", invalid), false, JSON.stringify(invalid));
+  }
+});
+
+test("sample frames requires an opaque session and monotonic bounded forward schedule", () => {
+  assert.equal(accepts("noon_sample_frames", { session, times: [0, 0.5, 0.5, 4] }), true);
+  for (const invalid of [
+    { session: "short", times: [0] },
+    { session: "scene with spaces 123456789", times: [0] },
+    { session, times: [] },
+    { session, times: [1, 0.5] },
+    { session, times: [-1] },
+    { session, times: [Infinity] },
+    { session, times: [MAX_RENDER_TIME_SECONDS + 0.001] },
+    { session, times: Array(MAX_RENDER_SAMPLES_PER_CALL + 1).fill(0) },
+    { session, times: [0], seek: true },
+    { session, times: [0], backend: "webgpu" },
+  ]) {
+    assert.equal(accepts("noon_sample_frames", invalid), false, JSON.stringify(invalid));
+  }
+});
+
+test("inspect and close accept only the session capability", () => {
+  for (const name of ["noon_inspect", "noon_close_scene"]) {
+    assert.equal(accepts(name, { session }), true);
+    assert.equal(accepts(name, { session, repoRoot: "/" }), false);
+    assert.equal(accepts(name, { session, arbitrarySceneQuery: "all objects" }), false);
+  }
+  assert.equal(renderingToolContracts.noon_inspect.annotations.readOnlyHint, true);
+  assert.equal(renderingToolContracts.noon_close_scene.annotations.destructiveHint, true);
+});

--- a/tools/noon-mcp/test/rendering-contract.test.mjs
+++ b/tools/noon-mcp/test/rendering-contract.test.mjs
@@ -71,4 +71,6 @@ test("inspect and close accept only the session capability", () => {
   }
   assert.equal(renderingToolContracts.noon_inspect.annotations.readOnlyHint, true);
   assert.equal(renderingToolContracts.noon_close_scene.annotations.destructiveHint, true);
+  assert.equal(renderingToolContracts.noon_close_scene.annotations.idempotentHint, false,
+    "a closed handle becomes stale and must be rejected rather than silently reused");
 });

--- a/tools/noon-mcp/test/rendering-contract.test.mjs
+++ b/tools/noon-mcp/test/rendering-contract.test.mjs
@@ -7,7 +7,6 @@ import {
   MAX_RENDER_TIME_SECONDS,
   RENDERING_CONTRACT_VERSION,
   RENDERING_TOOL_NAMES,
-  RENDERING_TOOL_REGISTRATION_ENABLED,
   renderingToolContracts,
 } from "../src/rendering-contract.mjs";
 
@@ -17,9 +16,8 @@ function accepts(name, value) {
   return renderingToolContracts[name].inputSchema.safeParse(value).success;
 }
 
-test("rendering contract is versioned but deliberately not registered", () => {
+test("rendering contract is versioned and names the planned runner operations", () => {
   assert.equal(RENDERING_CONTRACT_VERSION, 1);
-  assert.equal(RENDERING_TOOL_REGISTRATION_ENABLED, false);
   assert.deepEqual(RENDERING_TOOL_NAMES, [
     "noon_open_scene", "noon_sample_frames", "noon_inspect", "noon_close_scene",
   ]);


### PR DESCRIPTION
Advances #1198 while #1197's execution/isolation gate remains unresolved.

This PR defines strict, versioned schemas for the planned `noon_open_scene`, `noon_sample_frames`, `noon_inspect`, and `noon_close_scene` operations and tests their bounded/forward-only/session-capability rules. **It deliberately does not import them into `server.mjs` or register any execution tool.** The real stdio server therefore remains discovery-only until the shared runner is qualified.

Boundaries:
- no source execution exposure;
- no second runner, scene model, scheduler, renderer or transport;
- no model-controlled checkout/command/cwd/backend arguments;
- source byte limit and 600 s forward-sampling horizon match the existing semantic preview boundary;
- per-call sampling is additionally bounded to 64 requested times;
- no arbitrary seek or arbitrary scene-inspection query is advertised.

Validation is via the existing `Agent discovery MCP` Linux/macOS workflow (`npm test`) plus architecture/dependency gates as applicable. No automated/Codex review is requested per `AGENTS.override.md`.

The next activation change must wait for #1197 to qualify process ownership, isolation, cancellation/cleanup and the shared runner/CLI contract. At that point these schemas should wrap that runner rather than create an independent execution path.