### PR TITLE
B4: add Rust-owned native Text range colors

### DIFF
--- a/.github/workflows/manim-raster-differential.yml
+++ b/.github/workflows/manim-raster-differential.yml
@@ -7,6 +7,12 @@ on:
       - "parity/manim-v0.21/core-examples/**"
       - "web/semantic-preview-session*"
       - "web/manim-raster-host.js"
+      - "web/python/_manim_typst.py"
+      - "web/python/examples/text_range_colors.py"
+      - "crates/noon-core/src/resources/text*.rs"
+      - "crates/noon/src/text*.rs"
+      - "crates/noon-web/src/text_parts.rs"
+      - "parity/manim-v0.21/text_range_colors*"
       - "scripts/semantic-preview-*"
       - "scripts/agent-preview-capture*.mjs"
       - "scripts/manim-differential.py"
@@ -137,6 +143,21 @@ jobs:
           path: manim-raster-artifacts/retained-typst
           if-no-files-found: warn
           retention-days: 14
+      - name: Register native Text range-color raster fixture
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          manifest_path = Path("parity/manim-v0.21/manifest.json")
+          fixture_path = Path("parity/manim-v0.21/text_range_colors.fixture.json")
+          manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+          fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
+          if any(item.get("id") == fixture["id"] for item in manifest["fixtures"]):
+              raise SystemExit(f"duplicate raster fixture id: {fixture['id']}")
+          manifest["fixtures"].append(fixture)
+          manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+          PY
       - name: Render and compare canonical Manim scenes
         env:
           NOON_MANIM_RASTER_BACKENDS: webgpu,webgl

--- a/crates/noon-core/src/resources/mod.rs
+++ b/crates/noon-core/src/resources/mod.rs
@@ -25,5 +25,8 @@ pub use text::*;
 mod text_parts;
 pub use text_parts::*;
 
+mod text_styles;
+pub use text_styles::*;
+
 mod transaction;
 pub use transaction::*;

--- a/crates/noon-core/src/resources/text_styles.rs
+++ b/crates/noon-core/src/resources/text_styles.rs
@@ -1,0 +1,390 @@
+//! Source-addressed styling over immutable retained text resources.
+//!
+//! Frontends express authored source ranges; this module projects them onto the
+//! existing normalized glyph runs without creating a second text document or
+//! reshaping in a frontend. A styled result is a new immutable `TextResource`.
+//! Glyph, cluster, vector, layout and source identities are preserved.
+
+use std::sync::Arc;
+
+use super::{
+    GlyphRun, PositionedGlyph, TextPartQueryError, TextRenderItem, TextResource,
+    TextResourceValidationError, TextSourceSpan,
+};
+use crate::Color;
+
+/// One authored intrinsic fill override for a UTF-8 source range.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct TextSourceFill {
+    pub source_span: TextSourceSpan,
+    pub color: Color,
+}
+
+impl TextSourceFill {
+    pub const fn new(source_span: TextSourceSpan, color: Color) -> Self {
+        Self { source_span, color }
+    }
+}
+
+/// Failure to project source-addressed style onto an already-shaped resource.
+#[derive(Clone, Debug, PartialEq)]
+pub enum TextSourceStyleError {
+    Query(TextPartQueryError),
+    /// Manim Text treats two overlapping non-default settings for the same style
+    /// property as ambiguous. Preserve that rule instead of relying on map order.
+    AmbiguousFillOverlap {
+        left: TextSourceSpan,
+        right: TextSourceSpan,
+    },
+    /// The requested source range intersects, but does not contain, a shaped cluster.
+    /// Supporting this case requires a shaping-boundary decision by the text backend.
+    SplitsCluster {
+        source_span: TextSourceSpan,
+        cluster_span: TextSourceSpan,
+    },
+    InvalidResource(TextResourceValidationError),
+}
+
+impl std::fmt::Display for TextSourceStyleError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Query(error) => error.fmt(formatter),
+            Self::AmbiguousFillOverlap { left, right } => write!(
+                formatter,
+                "ambiguous text fill overlap {}..{} with {}..{}",
+                left.start, left.end, right.start, right.end
+            ),
+            Self::SplitsCluster {
+                source_span,
+                cluster_span,
+            } => write!(
+                formatter,
+                "text style span {}..{} splits shaped cluster {}..{}",
+                source_span.start, source_span.end, cluster_span.start, cluster_span.end
+            ),
+            Self::InvalidResource(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl std::error::Error for TextSourceStyleError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Query(error) => Some(error),
+            Self::InvalidResource(error) => Some(error),
+            Self::AmbiguousFillOverlap { .. } | Self::SplitsCluster { .. } => None,
+        }
+    }
+}
+
+impl From<TextPartQueryError> for TextSourceStyleError {
+    fn from(error: TextPartQueryError) -> Self {
+        Self::Query(error)
+    }
+}
+
+impl TextResource {
+    /// Return a new immutable resource with intrinsic fills applied to source ranges.
+    ///
+    /// The operation never reshapes. It only splits existing glyph runs when their
+    /// effective intrinsic fill changes, preserving every glyph's source span,
+    /// cluster ordinal, position, advance, bounds, font and affine transform.
+    /// Unstyled segments retain the original run fill and therefore continue to
+    /// inherit the owning mobject color when that fill is `None`.
+    pub fn with_source_fills(
+        &self,
+        fills: &[TextSourceFill],
+    ) -> Result<Self, TextSourceStyleError> {
+        if fills.is_empty() {
+            return Ok(self.clone());
+        }
+
+        let styled_parts = fills
+            .iter()
+            .map(|fill| self.source_part(fill.source_span))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        // Manim's Text setting merge rejects any two explicit values for the
+        // same style property when their authored ranges overlap, even when the
+        // values happen to compare equal. Do this before inspecting shaped
+        // clusters so whitespace-only overlaps behave consistently too.
+        for (index, left) in fills.iter().enumerate() {
+            for right in &fills[index + 1..] {
+                if spans_overlap(left.source_span, right.source_span) {
+                    return Err(TextSourceStyleError::AmbiguousFillOverlap {
+                        left: left.source_span,
+                        right: right.source_span,
+                    });
+                }
+            }
+        }
+
+        // Validate every cluster boundary before allocating the replacement runs.
+        for run in self.runs.iter() {
+            for glyph in run.glyphs.iter() {
+                let cluster_span = glyph.cluster.source_span;
+                for fill in fills {
+                    if spans_overlap(fill.source_span, cluster_span)
+                        && !span_contains(fill.source_span, cluster_span)
+                    {
+                        return Err(TextSourceStyleError::SplitsCluster {
+                            source_span: fill.source_span,
+                            cluster_span,
+                        });
+                    }
+                }
+            }
+        }
+
+        let mut runs = Vec::new();
+        let mut render_items = Vec::with_capacity(self.render_items.len());
+        for item in self.render_items.iter().copied() {
+            match item {
+                TextRenderItem::GlyphRun(index) => {
+                    let run = &self.runs[index as usize];
+                    for styled in split_run_by_fill(run, fills) {
+                        let next_index = u32::try_from(runs.len())
+                            .expect("styled text run count exceeds u32 resource limits");
+                        runs.push(styled);
+                        render_items.push(TextRenderItem::GlyphRun(next_index));
+                    }
+                }
+                TextRenderItem::Vector(index) => render_items.push(TextRenderItem::Vector(index)),
+            }
+        }
+
+        let mut parts = self.parts.to_vec();
+        for part in styled_parts {
+            if !parts
+                .iter()
+                .any(|existing| existing.source_span == part.source_span)
+            {
+                parts.push(part);
+            }
+        }
+
+        let mut styled = self.clone();
+        styled.runs = runs.into();
+        styled.render_items = render_items.into();
+        styled.parts = parts.into();
+        styled
+            .validate()
+            .map_err(TextSourceStyleError::InvalidResource)?;
+        Ok(styled)
+    }
+}
+
+fn split_run_by_fill(run: &GlyphRun, fills: &[TextSourceFill]) -> Vec<GlyphRun> {
+    if run.glyphs.is_empty() {
+        return vec![run.clone()];
+    }
+
+    let mut result = Vec::new();
+    let mut segment_start = 0_usize;
+    let mut current_fill = effective_fill(run.fill, run.glyphs[0].cluster.source_span, fills);
+
+    for index in 1..run.glyphs.len() {
+        let fill = effective_fill(run.fill, run.glyphs[index].cluster.source_span, fills);
+        if fill != current_fill {
+            result.push(run_segment(run, segment_start, index, current_fill));
+            segment_start = index;
+            current_fill = fill;
+        }
+    }
+    result.push(run_segment(
+        run,
+        segment_start,
+        run.glyphs.len(),
+        current_fill,
+    ));
+    result
+}
+
+fn effective_fill(
+    base: Option<Color>,
+    cluster_span: TextSourceSpan,
+    fills: &[TextSourceFill],
+) -> Option<Color> {
+    fills
+        .iter()
+        .find(|fill| span_contains(fill.source_span, cluster_span))
+        .map_or(base, |fill| Some(fill.color))
+}
+
+fn run_segment(run: &GlyphRun, start: usize, end: usize, fill: Option<Color>) -> GlyphRun {
+    let mut segment = run.clone();
+    segment.fill = fill;
+    segment.glyphs = Arc::<[PositionedGlyph]>::from(run.glyphs[start..end].to_vec());
+    segment
+}
+
+fn spans_overlap(left: TextSourceSpan, right: TextSourceSpan) -> bool {
+    left.start < right.end && right.start < left.end
+}
+
+fn span_contains(outer: TextSourceSpan, inner: TextSourceSpan) -> bool {
+    outer.start <= inner.start && inner.end <= outer.end
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        FontFaceIdentity, Rect, TextAffineTransform, TextClusterIdentity, TextDirection,
+        TextSourceKind, Vec2, BLUE, RED,
+    };
+
+    fn glyph(character: char, start: u32, end: u32, ordinal: u32) -> PositionedGlyph {
+        PositionedGlyph {
+            glyph_id: character as u32,
+            cluster: TextClusterIdentity {
+                source_span: TextSourceSpan::new(start, end),
+                cluster_ordinal: ordinal,
+                semantic_key: None,
+            },
+            origin: Vec2::new(ordinal as f32, 0.0),
+            advance: Vec2::new(1.0, 0.0),
+            bounds: Rect::new(
+                Vec2::new(ordinal as f32, -0.2),
+                Vec2::new(ordinal as f32 + 0.8, 0.8),
+            ),
+        }
+    }
+
+    fn resource(source: &str, glyphs: Vec<PositionedGlyph>) -> TextResource {
+        TextResource {
+            source: Arc::from(source),
+            kind: TextSourceKind::Plain,
+            runs: Arc::from([GlyphRun {
+                font: FontFaceIdentity {
+                    family: Arc::from("Test Sans"),
+                    face_key: Arc::from("test-sans-v1"),
+                    face_index: 0,
+                    variation_key: Arc::from(""),
+                },
+                variations: Arc::from([]),
+                font_size: 48.0,
+                direction: TextDirection::LeftToRight,
+                fill: None,
+                stroke: None,
+                transform: TextAffineTransform::IDENTITY,
+                glyphs: glyphs.into(),
+            }]),
+            vector_items: Arc::from([]),
+            render_items: Arc::from([TextRenderItem::GlyphRun(0)]),
+            parts: Arc::from([]),
+            bounds: Rect::new(Vec2::new(0.0, -0.2), Vec2::new(source.len() as f32, 0.8)),
+            baseline: 0.0,
+            layout_artifact: None,
+        }
+    }
+
+    #[test]
+    fn source_fill_splits_runs_without_relayout_or_cluster_identity_changes() {
+        let original = resource(
+            "abcd",
+            vec![
+                glyph('a', 0, 1, 0),
+                glyph('b', 1, 2, 1),
+                glyph('c', 2, 3, 2),
+                glyph('d', 3, 4, 3),
+            ],
+        );
+        let styled = original
+            .with_source_fills(&[TextSourceFill::new(TextSourceSpan::new(1, 3), RED)])
+            .unwrap();
+
+        assert_eq!(styled.runs.len(), 3);
+        assert_eq!(styled.runs[0].fill, None);
+        assert_eq!(styled.runs[1].fill, Some(RED));
+        assert_eq!(styled.runs[2].fill, None);
+        let before = original
+            .runs
+            .iter()
+            .flat_map(|run| run.glyphs.iter())
+            .cloned()
+            .collect::<Vec<_>>();
+        let after = styled
+            .runs
+            .iter()
+            .flat_map(|run| run.glyphs.iter())
+            .cloned()
+            .collect::<Vec<_>>();
+        assert_eq!(before, after);
+        assert_eq!(styled.bounds, original.bounds);
+        assert_eq!(styled.baseline, original.baseline);
+        assert_eq!(styled.parts.len(), 1);
+        assert_eq!(styled.parts[0].source_span, TextSourceSpan::new(1, 3));
+        assert_eq!(
+            styled.parts[0].semantic_key.as_deref(),
+            Some("noon:text:source:1:3")
+        );
+    }
+
+    #[test]
+    fn conflicting_overlapping_fills_are_ambiguous_before_run_changes() {
+        let original = resource(
+            "abc",
+            vec![
+                glyph('a', 0, 1, 0),
+                glyph('b', 1, 2, 1),
+                glyph('c', 2, 3, 2),
+            ],
+        );
+        assert_eq!(
+            original.with_source_fills(&[
+                TextSourceFill::new(TextSourceSpan::new(0, 3), RED),
+                TextSourceFill::new(TextSourceSpan::new(1, 2), BLUE),
+            ]),
+            Err(TextSourceStyleError::AmbiguousFillOverlap {
+                left: TextSourceSpan::new(0, 3),
+                right: TextSourceSpan::new(1, 2),
+            })
+        );
+    }
+
+    #[test]
+    fn equal_overlapping_explicit_fills_are_also_ambiguous() {
+        let original = resource(
+            "abc",
+            vec![
+                glyph('a', 0, 1, 0),
+                glyph('b', 1, 2, 1),
+                glyph('c', 2, 3, 2),
+            ],
+        );
+        assert_eq!(
+            original.with_source_fills(&[
+                TextSourceFill::new(TextSourceSpan::new(0, 3), RED),
+                TextSourceFill::new(TextSourceSpan::new(1, 2), RED),
+            ]),
+            Err(TextSourceStyleError::AmbiguousFillOverlap {
+                left: TextSourceSpan::new(0, 3),
+                right: TextSourceSpan::new(1, 2),
+            })
+        );
+    }
+
+    #[test]
+    fn source_range_that_splits_a_shaped_cluster_is_explicitly_rejected() {
+        let original = resource("fi", vec![glyph('f', 0, 2, 0)]);
+        assert_eq!(
+            original.with_source_fills(&[TextSourceFill::new(TextSourceSpan::new(1, 2), RED,)]),
+            Err(TextSourceStyleError::SplitsCluster {
+                source_span: TextSourceSpan::new(1, 2),
+                cluster_span: TextSourceSpan::new(0, 2),
+            })
+        );
+    }
+
+    #[test]
+    fn source_only_span_adds_identity_without_changing_runs() {
+        let original = resource("a\nb", vec![glyph('a', 0, 1, 0), glyph('b', 2, 3, 1)]);
+        let styled = original
+            .with_source_fills(&[TextSourceFill::new(TextSourceSpan::new(1, 2), RED)])
+            .unwrap();
+        assert_eq!(styled.runs, original.runs);
+        assert_eq!(styled.parts[0].source_span, TextSourceSpan::new(1, 2));
+        assert_eq!(styled.parts[0].cluster_count, 0);
+    }
+}

--- a/crates/noon-web/src/text_parts.rs
+++ b/crates/noon-web/src/text_parts.rs
@@ -1,7 +1,8 @@
-//! Typed WASM projection of shared Rust text-part selections.
+//! Typed WASM projection of shared Rust text-part selection and styling.
 //!
-//! The browser boundary exposes retained part values only. Source matching and
-//! cluster/vector coverage remain Rust-owned in `TextResource`.
+//! The browser boundary exposes retained part values and selector/color intent only.
+//! Source matching, selector interpretation, overlap validation, cluster coverage,
+//! and immutable resource replacement remain Rust-owned.
 
 #![cfg(target_arch = "wasm32")]
 
@@ -9,31 +10,91 @@ use wasm_bindgen::prelude::*;
 
 use crate::{AuthoringFailure, WasmAuthoringMobjectHandle};
 
-fn text_part_js_error(error: noon::TextPartAuthoringError) -> JsValue {
-    let failure = match error {
+fn query_failure(error: noon::TextPartQueryError) -> AuthoringFailure {
+    match error {
+        noon::TextPartQueryError::InvalidSourceSpan => {
+            AuthoringFailure::new("invalid_input", "text_parts.invalid_source_span", error)
+        }
+        noon::TextPartQueryError::NonContiguousClusters => AuthoringFailure::new(
+            "unsupported_operation",
+            "text_parts.non_contiguous_clusters",
+            error,
+        ),
+        noon::TextPartQueryError::NonContiguousVectors => AuthoringFailure::new(
+            "unsupported_operation",
+            "text_parts.non_contiguous_vectors",
+            error,
+        ),
+    }
+}
+
+fn text_part_failure(error: noon::TextPartAuthoringError) -> AuthoringFailure {
+    match error {
         noon::TextPartAuthoringError::Authoring(cause) => AuthoringFailure::from(cause),
         noon::TextPartAuthoringError::NotText(_) => {
             AuthoringFailure::new("unsupported_operation", "text_parts.not_text", error)
         }
-        noon::TextPartAuthoringError::Query(noon::TextPartQueryError::InvalidSourceSpan) => {
-            AuthoringFailure::new("invalid_input", "text_parts.invalid_source_span", error)
+        noon::TextPartAuthoringError::Query(cause) => query_failure(cause),
+    }
+}
+
+fn text_part_js_error(error: noon::TextPartAuthoringError) -> JsValue {
+    crate::authoring_error::js_error(text_part_failure(error))
+}
+
+fn text_style_failure(error: noon::TextStyleAuthoringError) -> AuthoringFailure {
+    match error {
+        noon::TextStyleAuthoringError::Selection(cause) => text_part_failure(cause),
+        noon::TextStyleAuthoringError::UnsupportedSourceKind { .. } => AuthoringFailure::new(
+            "unsupported_operation",
+            "text_style.unsupported_source_kind",
+            error,
+        ),
+        noon::TextStyleAuthoringError::InvalidSelector(_) => {
+            AuthoringFailure::new("invalid_input", "text_style.invalid_selector", error)
         }
-        noon::TextPartAuthoringError::Query(noon::TextPartQueryError::NonContiguousClusters) => {
-            AuthoringFailure::new(
-                "unsupported_operation",
-                "text_parts.non_contiguous_clusters",
-                error,
-            )
+        noon::TextStyleAuthoringError::Style(noon_core::TextSourceStyleError::Query(cause)) => {
+            query_failure(cause)
         }
-        noon::TextPartAuthoringError::Query(noon::TextPartQueryError::NonContiguousVectors) => {
-            AuthoringFailure::new(
-                "unsupported_operation",
-                "text_parts.non_contiguous_vectors",
-                error,
-            )
+        noon::TextStyleAuthoringError::Style(
+            noon_core::TextSourceStyleError::AmbiguousFillOverlap { .. },
+        ) => AuthoringFailure::new("invalid_input", "text_style.ambiguous_fill_overlap", error),
+        noon::TextStyleAuthoringError::Style(noon_core::TextSourceStyleError::SplitsCluster {
+            ..
+        }) => AuthoringFailure::new("unsupported_operation", "text_style.splits_cluster", error),
+        noon::TextStyleAuthoringError::Style(noon_core::TextSourceStyleError::InvalidResource(
+            _,
+        )) => AuthoringFailure::new("unclassified", "text_style.invalid_resource", error),
+        noon::TextStyleAuthoringError::Import(_) => {
+            AuthoringFailure::new("unclassified", "text_style.import", error)
         }
-    };
-    crate::authoring_error::js_error(failure)
+        noon::TextStyleAuthoringError::Font(_) => {
+            AuthoringFailure::new("unclassified", "text_style.font", error)
+        }
+    }
+}
+
+fn text_style_js_error(error: noon::TextStyleAuthoringError) -> JsValue {
+    crate::authoring_error::js_error(text_style_failure(error))
+}
+
+fn text_color(red: f64, green: f64, blue: f64, alpha: f64) -> Result<noon::Color, JsValue> {
+    if ![red, green, blue, alpha]
+        .iter()
+        .all(|component| component.is_finite() && (0.0..=1.0).contains(component))
+    {
+        return Err(crate::authoring_error::js_error(AuthoringFailure::new(
+            "invalid_input",
+            "text_style.invalid_color",
+            "text style color components must be finite and between zero and one",
+        )));
+    }
+    Ok(noon::Color::rgba(
+        red as f32,
+        green as f32,
+        blue as f32,
+        alpha as f32,
+    ))
 }
 
 /// One stable source part selected from a semantic text object.
@@ -114,6 +175,51 @@ impl WasmTextPartList {
     }
 }
 
+/// Typed browser-side builder for one complete Manim `t2c` selector batch.
+///
+/// The builder stores only source selector strings and colors. Rust resolves every
+/// selector and validates the complete overlap set before publishing a replacement
+/// immutable text resource.
+#[wasm_bindgen]
+pub struct WasmTextSourceFillBatch {
+    selectors: Vec<(String, noon::Color)>,
+}
+
+#[wasm_bindgen]
+impl WasmTextSourceFillBatch {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        Self {
+            selectors: Vec::new(),
+        }
+    }
+
+    #[wasm_bindgen(js_name = appendSelector)]
+    pub fn append_selector(
+        &mut self,
+        selector: &str,
+        red: f64,
+        green: f64,
+        blue: f64,
+        alpha: f64,
+    ) -> Result<(), JsValue> {
+        let color = text_color(red, green, blue, alpha)?;
+        self.selectors.push((selector.to_owned(), color));
+        Ok(())
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn length(&self) -> usize {
+        self.selectors.len()
+    }
+}
+
+impl Default for WasmTextSourceFillBatch {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[wasm_bindgen]
 impl WasmAuthoringMobjectHandle {
     /// Select authored substring occurrences through the shared retained text resource.
@@ -123,5 +229,20 @@ impl WasmAuthoringMobjectHandle {
             .text_source_parts_for(needle)
             .map(WasmTextPartList::new)
             .map_err(text_part_js_error)
+    }
+
+    /// Create an inert typed source-style batch beside this semantic handle.
+    #[wasm_bindgen(js_name = textSourceFillBatch)]
+    pub fn text_source_fill_batch(&self) -> WasmTextSourceFillBatch {
+        WasmTextSourceFillBatch::new()
+    }
+
+    /// Apply one complete source-style batch through shared Rust semantics.
+    #[wasm_bindgen(js_name = applyTextSourceFills)]
+    pub fn apply_text_source_fills(&self, batch: &WasmTextSourceFillBatch) -> Result<(), JsValue> {
+        let mut handle = self.semantic_mobject().clone();
+        handle
+            .set_text_fills_for_selectors(&batch.selectors)
+            .map_err(text_style_js_error)
     }
 }

--- a/crates/noon/src/lib.rs
+++ b/crates/noon/src/lib.rs
@@ -99,6 +99,8 @@ mod state_replacement;
 mod text_authoring;
 #[cfg(any(feature = "native-text", feature = "typst"))]
 mod text_part_authoring;
+#[cfg(any(feature = "native-text", feature = "typst"))]
+mod text_style_authoring;
 mod z_index;
 
 pub use animation_authoring::DeclaredAnimation;
@@ -175,6 +177,8 @@ pub use text_authoring::{
 };
 #[cfg(any(feature = "native-text", feature = "typst"))]
 pub use text_part_authoring::TextPartAuthoringError;
+#[cfg(any(feature = "native-text", feature = "typst"))]
+pub use text_style_authoring::TextStyleAuthoringError;
 
 /// Common imports for direct typed semantic authoring and live publication.
 /// Host integration and mutable arena access must be imported explicitly.

--- a/crates/noon/src/text_style_authoring.rs
+++ b/crates/noon/src/text_style_authoring.rs
@@ -1,0 +1,426 @@
+//! Source-addressed styling for retained semantic text resources.
+//!
+//! Source selection remains owned by `text_part_authoring`; this module consumes
+//! those landed queries and owns only immutable content-resource replacement.
+
+use noon_core::{
+    Color, FontResourceArena, FontResourceError, GeometryResourceArena, SemanticNodeId,
+    SemanticTextImportError, TextSourceFill, TextSourceKind, TextSourceSpan, TextSourceStyleError,
+};
+
+use crate::{AuthoringError, Mobject, TextPartAuthoringError};
+
+/// Failure to apply source-addressed styling to one semantic text object.
+#[derive(Clone, Debug, PartialEq)]
+pub enum TextStyleAuthoringError {
+    /// Existing Rust-owned source-part selection failed.
+    Selection(TextPartAuthoringError),
+    /// Source styling is currently owned only by native plain `Text`.
+    UnsupportedSourceKind {
+        node: SemanticNodeId,
+        kind: TextSourceKind,
+    },
+    /// A Manim-style `[start:end]` selector was recognized but invalid.
+    InvalidSelector(String),
+    /// The requested source style cannot be represented without changing shaping.
+    Style(TextSourceStyleError),
+    /// Re-registering the immutable styled resource failed before publication.
+    Import(SemanticTextImportError),
+    /// Rebuilding the exact font dependency set for the styled resource failed.
+    Font(FontResourceError),
+}
+
+impl std::fmt::Display for TextStyleAuthoringError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Selection(error) => error.fmt(formatter),
+            Self::UnsupportedSourceKind { node, kind } => write!(
+                formatter,
+                "semantic object {node:?} has unsupported source kind {kind:?} for native range styling"
+            ),
+            Self::InvalidSelector(selector) => {
+                write!(formatter, "invalid Manim text source selector {selector:?}")
+            }
+            Self::Style(error) => error.fmt(formatter),
+            Self::Import(error) => error.fmt(formatter),
+            Self::Font(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl std::error::Error for TextStyleAuthoringError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Selection(error) => Some(error),
+            Self::Style(error) => Some(error),
+            Self::Import(error) => Some(error),
+            Self::Font(error) => Some(error),
+            Self::UnsupportedSourceKind { .. } | Self::InvalidSelector(_) => None,
+        }
+    }
+}
+
+impl From<AuthoringError> for TextStyleAuthoringError {
+    fn from(error: AuthoringError) -> Self {
+        Self::Selection(TextPartAuthoringError::Authoring(error))
+    }
+}
+
+impl From<TextPartAuthoringError> for TextStyleAuthoringError {
+    fn from(error: TextPartAuthoringError) -> Self {
+        Self::Selection(error)
+    }
+}
+
+impl From<TextSourceStyleError> for TextStyleAuthoringError {
+    fn from(error: TextSourceStyleError) -> Self {
+        Self::Style(error)
+    }
+}
+
+impl From<SemanticTextImportError> for TextStyleAuthoringError {
+    fn from(error: SemanticTextImportError) -> Self {
+        Self::Import(error)
+    }
+}
+
+impl From<FontResourceError> for TextStyleAuthoringError {
+    fn from(error: FontResourceError) -> Self {
+        Self::Font(error)
+    }
+}
+
+impl Mobject {
+    /// Resolve one Manim `t2c` selector against the original authored string.
+    ///
+    /// Substring selectors delegate to the landed Rust source matcher. Slice
+    /// selectors use Unicode character indexes into the original source, then
+    /// project those indexes to the retained UTF-8 byte identity.
+    fn text_source_parts_for_style_selector(
+        &self,
+        selector: &str,
+    ) -> Result<Vec<noon_core::TextPart>, TextStyleAuthoringError> {
+        let source = {
+            let state = self.state()?;
+            let handle = state.content.text().ok_or_else(|| {
+                TextStyleAuthoringError::Selection(TextPartAuthoringError::NotText(self.node_id()))
+            })?;
+            let store = self.integration_store().borrow();
+            store
+                .text_resources()
+                .get(handle)
+                .ok_or(TextStyleAuthoringError::Selection(
+                    TextPartAuthoringError::Authoring(AuthoringError::MissingTextResource(handle)),
+                ))?
+                .source
+                .clone()
+        };
+
+        if let Some(span) = manim_slice_source_span(source.as_ref(), selector)? {
+            Ok(vec![self.text_source_part(span)?])
+        } else {
+            Ok(self.text_source_parts_for(selector)?)
+        }
+    }
+
+    /// Apply one intrinsic color override to an authored UTF-8 source span.
+    pub fn set_text_source_fill(
+        &mut self,
+        source_span: TextSourceSpan,
+        color: Color,
+    ) -> Result<(), TextStyleAuthoringError> {
+        self.set_text_source_fills(&[TextSourceFill::new(source_span, color)])
+    }
+
+    /// Color every non-overlapping occurrence of `needle` using the landed matcher.
+    pub fn set_text_fill_for(
+        &mut self,
+        needle: &str,
+        color: Color,
+    ) -> Result<(), TextStyleAuthoringError> {
+        let fills = self
+            .text_source_parts_for(needle)?
+            .into_iter()
+            .map(|part| TextSourceFill::new(part.source_span, color))
+            .collect::<Vec<_>>();
+        self.set_text_source_fills(&fills)
+    }
+
+    /// Apply one complete Manim `t2c` selector batch as a single validated edit.
+    pub fn set_text_fills_for_selectors(
+        &mut self,
+        selectors: &[(String, Color)],
+    ) -> Result<(), TextStyleAuthoringError> {
+        let mut fills = Vec::new();
+        for (selector, color) in selectors {
+            fills.extend(
+                self.text_source_parts_for_style_selector(selector)?
+                    .into_iter()
+                    .map(|part| TextSourceFill::new(part.source_span, *color)),
+            );
+        }
+        self.set_text_source_fills(&fills)
+    }
+
+    /// Apply source-addressed fill overrides by replacing only immutable text content.
+    ///
+    /// All selectors, overlap rules and cluster boundaries are validated before the
+    /// semantic object state is changed. The styled resource reuses shaped glyphs,
+    /// advances, line metrics, transforms and bounds; only run partitioning/paint changes.
+    pub fn set_text_source_fills(
+        &mut self,
+        fills: &[TextSourceFill],
+    ) -> Result<(), TextStyleAuthoringError> {
+        let state = self.state()?;
+        let handle = state.content.text().ok_or_else(|| {
+            TextStyleAuthoringError::Selection(TextPartAuthoringError::NotText(self.node_id()))
+        })?;
+        if fills.is_empty() {
+            return Ok(());
+        }
+
+        let (styled, fonts) =
+            {
+                let store = self.integration_store().borrow();
+                let resource = store.text_resources().get(handle).ok_or(
+                    TextStyleAuthoringError::Selection(TextPartAuthoringError::Authoring(
+                        AuthoringError::MissingTextResource(handle),
+                    )),
+                )?;
+                if resource.kind != TextSourceKind::Plain {
+                    return Err(TextStyleAuthoringError::UnsupportedSourceKind {
+                        node: self.node_id(),
+                        kind: resource.kind,
+                    });
+                }
+                debug_assert!(resource.vector_items.is_empty());
+
+                // `with_source_fills` validates every source and shaped-cluster boundary
+                // before either the scratch dependency arena or semantic store is touched.
+                let styled = resource.with_source_fills(fills)?;
+                let mut fonts = FontResourceArena::new();
+                for run in styled.runs.iter() {
+                    let font = store
+                        .font_resources()
+                        .get_for_face(&run.font)
+                        .expect("validated semantic text retains its immutable font dependency");
+                    fonts.intern_face(&run.font, font.data.clone())?;
+                }
+                (styled, fonts)
+            };
+
+        let geometry = GeometryResourceArena::new();
+        let replacement = self
+            .integration_store()
+            .borrow_mut()
+            .import_text_resource(styled, &fonts, &geometry)?;
+        let mut next = state;
+        next.content = replacement.into();
+        self.commit_state(next)?;
+        Ok(())
+    }
+}
+
+/// Parse ManimCE v0.21.0's `[start:end]` selector subset.
+fn manim_slice_source_span(
+    source: &str,
+    selector: &str,
+) -> Result<Option<TextSourceSpan>, TextStyleAuthoringError> {
+    let Some(rest) = selector.strip_prefix('[') else {
+        return Ok(None);
+    };
+    let Some(close) = rest.find(']') else {
+        return Ok(None);
+    };
+    let body = &rest[..close];
+    let Some((start_text, end_text)) = body.split_once(':') else {
+        return Ok(None);
+    };
+    if end_text.contains(':')
+        || !start_text
+            .chars()
+            .all(|character| character.is_ascii_digit() || character == '-')
+        || !end_text
+            .chars()
+            .all(|character| character.is_ascii_digit() || character == '-')
+    {
+        return Ok(None);
+    }
+
+    let char_len = isize::try_from(source.chars().count())
+        .map_err(|_| TextStyleAuthoringError::InvalidSelector(selector.to_owned()))?;
+    let parse_endpoint = |value: &str, default: isize| -> Result<isize, TextStyleAuthoringError> {
+        if value.is_empty() {
+            return Ok(default);
+        }
+        let parsed = value
+            .parse::<isize>()
+            .map_err(|_| TextStyleAuthoringError::InvalidSelector(selector.to_owned()))?;
+        Ok(if parsed < 0 {
+            char_len + parsed
+        } else {
+            parsed
+        })
+    };
+    let start = parse_endpoint(start_text, 0)?;
+    let end = parse_endpoint(end_text, char_len)?;
+    if start < 0 || end < 0 || start > end || start > char_len || end > char_len {
+        return Err(TextStyleAuthoringError::InvalidSelector(
+            selector.to_owned(),
+        ));
+    }
+
+    let byte_index = |character_index: isize| -> Result<u32, TextStyleAuthoringError> {
+        let character_index = usize::try_from(character_index)
+            .map_err(|_| TextStyleAuthoringError::InvalidSelector(selector.to_owned()))?;
+        let byte = if character_index == source.chars().count() {
+            source.len()
+        } else {
+            source
+                .char_indices()
+                .nth(character_index)
+                .map(|(byte, _)| byte)
+                .ok_or_else(|| TextStyleAuthoringError::InvalidSelector(selector.to_owned()))?
+        };
+        u32::try_from(byte)
+            .map_err(|_| TextStyleAuthoringError::InvalidSelector(selector.to_owned()))
+    };
+
+    Ok(Some(TextSourceSpan::new(
+        byte_index(start)?,
+        byte_index(end)?,
+    )))
+}
+
+#[cfg(all(test, feature = "native-text", feature = "bundled-fonts"))]
+mod tests {
+    use super::*;
+    use crate::{Scene, Text, BLUE, RED};
+
+    #[test]
+    fn range_fill_changes_paint_only_and_preserves_semantic_geometry() {
+        let scene = Scene::new();
+        let mut label = scene.text(Text::new("Noon blue Noon")).unwrap();
+        let before_state = label.state().unwrap();
+        let before_handle = before_state.content.text().unwrap();
+        let before_layout_bounds = label.layout_bounds().unwrap();
+        let before_width = label.width().unwrap();
+        let before_height = label.height().unwrap();
+        let before_center = label.center().unwrap();
+        let before_resource = {
+            let store = label.integration_store().borrow();
+            store.text_resources().get(before_handle).unwrap().clone()
+        };
+        let before_geometry = before_resource
+            .runs
+            .iter()
+            .flat_map(|run| {
+                run.glyphs.iter().map(|glyph| {
+                    (
+                        run.font.clone(),
+                        run.variations.clone(),
+                        run.font_size,
+                        run.direction,
+                        run.stroke.clone(),
+                        run.transform,
+                        glyph.clone(),
+                    )
+                })
+            })
+            .collect::<Vec<_>>();
+
+        label
+            .set_text_fills_for_selectors(&[("Noon".into(), RED), ("[5:9]".into(), BLUE)])
+            .unwrap();
+
+        let after_state = label.state().unwrap();
+        let after_handle = after_state.content.text().unwrap();
+        assert_ne!(after_handle, before_handle);
+        assert_eq!(after_state.transform, before_state.transform);
+        assert_eq!(after_state.style, before_state.style);
+        assert_eq!(label.layout_bounds().unwrap(), before_layout_bounds);
+        assert_eq!(label.width().unwrap(), before_width);
+        assert_eq!(label.height().unwrap(), before_height);
+        assert_eq!(label.center().unwrap(), before_center);
+
+        let store = label.integration_store().borrow();
+        let resource = store.text_resources().get(after_handle).unwrap();
+        assert_eq!(resource.source, before_resource.source);
+        assert_eq!(resource.kind, before_resource.kind);
+        assert_eq!(resource.bounds, before_resource.bounds);
+        assert_eq!(resource.baseline, before_resource.baseline);
+        assert_eq!(resource.layout_artifact, before_resource.layout_artifact);
+        assert_eq!(resource.vector_items, before_resource.vector_items);
+        let after_geometry = resource
+            .runs
+            .iter()
+            .flat_map(|run| {
+                run.glyphs.iter().map(|glyph| {
+                    (
+                        run.font.clone(),
+                        run.variations.clone(),
+                        run.font_size,
+                        run.direction,
+                        run.stroke.clone(),
+                        run.transform,
+                        glyph.clone(),
+                    )
+                })
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(after_geometry, before_geometry);
+        assert!(resource.runs.iter().any(|run| run.fill == Some(RED)));
+        assert!(resource.runs.iter().any(|run| run.fill == Some(BLUE)));
+    }
+
+    #[test]
+    fn selector_resolution_reuses_landed_source_queries_and_utf8_identity() {
+        let scene = Scene::new();
+        let mut label = scene.text(Text::new("Hé llo World")).unwrap();
+        label
+            .set_text_fills_for_selectors(&[("World".into(), RED), ("[2:7]".into(), BLUE)])
+            .unwrap();
+
+        assert_eq!(
+            label.text_source_parts_for("World").unwrap()[0].source_span,
+            TextSourceSpan::new(8, 13)
+        );
+        assert_eq!(
+            label
+                .text_source_part(TextSourceSpan::new(3, 8))
+                .unwrap()
+                .source_span,
+            TextSourceSpan::new(3, 8)
+        );
+    }
+
+    #[test]
+    fn conflicting_selector_fills_reject_without_object_state_changes() {
+        let scene = Scene::new();
+        let mut label = scene.text(Text::new("abcdef")).unwrap();
+        let before = label.state().unwrap();
+
+        assert!(matches!(
+            label.set_text_fills_for_selectors(&[("[1:5]".into(), RED), ("[3:]".into(), BLUE)]),
+            Err(TextStyleAuthoringError::Style(
+                TextSourceStyleError::AmbiguousFillOverlap { .. }
+            ))
+        ));
+        assert_eq!(label.state().unwrap(), before);
+    }
+
+    #[test]
+    fn cluster_split_rejects_without_object_state_changes() {
+        let scene = Scene::new();
+        let mut label = scene.text(Text::new("é")).unwrap();
+        let before = label.state().unwrap();
+
+        assert!(matches!(
+            label.set_text_source_fill(TextSourceSpan::new(1, 2), RED),
+            Err(TextStyleAuthoringError::Style(TextSourceStyleError::Query(
+                noon_core::TextPartQueryError::InvalidSourceSpan
+            )))
+        ));
+        assert_eq!(label.state().unwrap(), before);
+    }
+}

--- a/parity/manim-v0.21/text_range_colors.fixture.json
+++ b/parity/manim-v0.21/text_range_colors.fixture.json
@@ -1,0 +1,6 @@
+{
+  "id": "text-range-colors",
+  "scene": "TextRangeColors",
+  "source": "parity/manim-v0.21/text_range_colors.py",
+  "expected_duration": 1.0
+}

--- a/parity/manim-v0.21/text_range_colors.py
+++ b/parity/manim-v0.21/text_range_colors.py
@@ -1,0 +1,16 @@
+# Source-equivalent ManimCE v0.21.0 / Noon native Text range-color probe.
+# The raster harness changes only the import line and appends its scene-selection wrapper.
+
+from manim import *
+
+
+class TextRangeColors(Scene):
+    def construct(self):
+        label = Text(
+            "Noon blue Noon",
+            font="DejaVu Sans Mono",
+            font_size=48,
+            t2c={"Noon": RED, "[5:9]": BLUE},
+        )
+        self.add(label)
+        self.wait(1.0)

--- a/scripts/manim-typst-authoring-smoke.mjs
+++ b/scripts/manim-typst-authoring-smoke.mjs
@@ -27,6 +27,22 @@ class MultilineText(Scene):
         self.add(text)
 `;
 
+const rangeColorSource = `from noon import *
+
+
+class RangeColorText(Scene):
+    def construct(self):
+        text = Text(
+            "Noon blue Noon",
+            font="DejaVu Sans Mono",
+            font_size=48,
+            t2c={"Noon": RED, "[5:9]": BLUE},
+        )
+        parts = text.source_parts_for("Noon")
+        assert [(part.source_start, part.source_end) for part in parts] == [(0, 4), (10, 14)]
+        self.add(text)
+`;
+
 const nativeTextLayoutSource = `from noon import *
 
 
@@ -78,6 +94,7 @@ class MixedPainterOrder(Scene):
 const cases = [
   { name: "native-text", source: helloTextSource, count: 1 },
   { name: "multiline", source: multilineTextSource, count: 1 },
+  { name: "range-color", source: rangeColorSource, count: 1 },
   { name: "native-layout", source: nativeTextLayoutSource, count: 2 },
   { name: "typst", source: helloTypstSource, count: 1 },
   { name: "math-typst", source: helloMathTypstSource, count: 1 },

--- a/web/python/_manim_typst.py
+++ b/web/python/_manim_typst.py
@@ -117,6 +117,64 @@ def _as_color(value: object) -> _base.Color:
     raise TypeError("text color must be a Noon/Manim Color")
 
 
+def _as_source_color(value: object) -> _base.Color:
+    """Coerce only color syntax; source selector meaning stays Rust-owned."""
+
+    if isinstance(value, _base.Color):
+        return value
+    if isinstance(value, (str, int)) and not isinstance(value, bool):
+        try:
+            return _base.color_from_hex(value)
+        except (TypeError, ValueError) as error:
+            raise ValueError("invalid t2c color") from error
+    raise TypeError("t2c colors must be Noon/Manim Colors or #RRGGBB values")
+
+
+def _validated_source_colors(value: object) -> tuple[tuple[str, _base.Color], ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, dict):
+        raise TypeError("t2c/text2color must be a dict")
+    items: list[tuple[str, _base.Color]] = []
+    for selector, color in value.items():
+        if not isinstance(selector, str):
+            raise TypeError("t2c/text2color selectors must be strings")
+        items.append((selector, _as_source_color(color)))
+    return tuple(items)
+
+
+def _apply_source_colors(
+    handle: object,
+    items: tuple[tuple[str, _base.Color], ...],
+) -> None:
+    if not items:
+        return
+    if not hasattr(handle, "textSourceFillBatch") or not hasattr(
+        handle, "applyTextSourceFills"
+    ):
+        raise NotImplementedError(
+            "Text t2c requires the shared Rust source-style authoring handle"
+        )
+    batch = engine_call(handle.textSourceFillBatch)
+    try:
+        if not hasattr(batch, "appendSelector"):
+            raise NotImplementedError("Text t2c requires the typed Rust source-style batch")
+        for selector, color in items:
+            engine_call(
+                batch.appendSelector,
+                selector,
+                float(color.red),
+                float(color.green),
+                float(color.blue),
+                float(color.alpha),
+                operation="Text.t2c",
+            )
+        engine_call(handle.applyTextSourceFills, batch, operation="Text.t2c")
+    finally:
+        if hasattr(batch, "free"):
+            batch.free()
+
+
 def _native_layout_handle(handle: object):
     required = ("centerX", "centerY", "width", "height", "criticalX", "criticalY")
     if not all(hasattr(handle, name) for name in required):
@@ -349,9 +407,16 @@ class Text(_RetainedTextMobject):
         font_size: float = 48.0,
         line_spacing: float = -1.0,
         color: _base.Color = _base.WHITE,
+        t2c: dict[str, object] | None = None,
         **kwargs: Any,
     ) -> None:
         opacity = _validated_opacity(kwargs.pop("opacity", 1.0))
+        source_color_value: object = {} if t2c is None else t2c
+        if "text2color" in kwargs:
+            source_color_value = kwargs.pop("text2color")
+            if source_color_value is None:
+                raise AssertionError
+        source_colors = _validated_source_colors(source_color_value)
         if kwargs:
             unsupported = ", ".join(sorted(kwargs))
             raise NotImplementedError(f"unsupported Text option(s): {unsupported}")
@@ -360,6 +425,11 @@ class Text(_RetainedTextMobject):
         )
         color = _as_color(color)
         live_context = _live_text_context()
+        if live_context is not None and source_colors:
+            # Static content replacement must not bypass the owning live session.
+            raise NotImplementedError(
+                "Text t2c is not yet supported for Text constructed after live execution starts"
+            )
         if live_context is None:
             handle = _new_native_text_handle(text, font, font_size, line_spacing)
         else:
@@ -387,6 +457,7 @@ class Text(_RetainedTextMobject):
             opacity,
             presentation_applied=live_context is not None,
         )
+        _apply_source_colors(handle, source_colors)
 
     @property
     def text(self) -> str:

--- a/web/python/examples/text_range_colors.py
+++ b/web/python/examples/text_range_colors.py
@@ -1,0 +1,15 @@
+"""Native Text source-range colors with Manim-compatible ``t2c`` selectors."""
+
+from noon import BLUE, RED, Scene, Text
+
+
+class TextRangeColors(Scene):
+    def construct(self):
+        label = Text(
+            "Noon blue Noon",
+            font="DejaVu Sans Mono",
+            font_size=48,
+            t2c={"Noon": RED, "[5:9]": BLUE},
+        )
+        self.add(label)
+        self.wait(1.0)

--- a/web/python/test_manim_text_range_colors.py
+++ b/web/python/test_manim_text_range_colors.py
@@ -1,0 +1,153 @@
+import unittest
+
+import noon
+import _manim_typst as typst
+
+
+class _FillBatch:
+    def __init__(self):
+        self.selectors = []
+        self.freed = False
+
+    def appendSelector(self, selector, red, green, blue, alpha):
+        self.selectors.append((selector, red, green, blue, alpha))
+
+    def free(self):
+        self.freed = True
+
+
+class _Handle:
+    def __init__(self):
+        self.batches = []
+
+    def textSourceFillBatch(self):
+        batch = _FillBatch()
+        self.batches.append(batch)
+        return batch
+
+    def applyTextSourceFills(self, batch):
+        assert batch is self.batches[-1]
+
+
+def _color_tuple(color):
+    return (
+        float(color.red),
+        float(color.green),
+        float(color.blue),
+        float(color.alpha),
+    )
+
+
+def _install_text_constructor_stub(handle):
+    original_new = typst._new_native_text_handle
+    original_live = typst._live_text_context
+    original_initialize = typst._RetainedTextMobject._initialize_text
+    typst._new_native_text_handle = lambda *args: handle
+    typst._live_text_context = lambda: None
+
+    def initialize(instance, source, font_size, semantic_handle, color, opacity, **kwargs):
+        del color, opacity, kwargs
+        instance._raw = None
+        instance._scene = None
+        instance._object = None
+        instance._source = source
+        instance._font_size = font_size
+        instance._semantic_handle = semantic_handle
+        instance._semantic_handle_fresh = True
+
+    typst._RetainedTextMobject._initialize_text = initialize
+    return original_new, original_live, original_initialize
+
+
+def _restore_text_constructor_stub(originals):
+    (
+        typst._new_native_text_handle,
+        typst._live_text_context,
+        typst._RetainedTextMobject._initialize_text,
+    ) = originals
+
+
+class ManimTextRangeColorTests(unittest.TestCase):
+    def test_t2c_forwards_selectors_and_colors_to_one_typed_rust_batch(self):
+        handle = _Handle()
+        originals = _install_text_constructor_stub(handle)
+        try:
+            label = typst.Text(
+                "source text deliberately irrelevant to Python selector handling",
+                t2c={"[:4]": noon.RED, "opaque-selector": "#58C4DD"},
+            )
+        finally:
+            _restore_text_constructor_stub(originals)
+
+        self.assertIs(label._semantic_handle, handle)
+        self.assertEqual(len(handle.batches), 1)
+        selectors = handle.batches[0].selectors
+        self.assertEqual([entry[0] for entry in selectors], ["[:4]", "opaque-selector"])
+        self.assertEqual(selectors[0][1:], _color_tuple(noon.RED))
+        self.assertEqual(selectors[1][1:], _color_tuple(noon.BLUE))
+        self.assertTrue(handle.batches[0].freed)
+
+    def test_text2color_long_form_overrides_t2c_without_python_selector_resolution(self):
+        handle = _Handle()
+        originals = _install_text_constructor_stub(handle)
+        try:
+            typst.Text(
+                "abcdef",
+                t2c={"[0:1]": noon.RED},
+                text2color={"[-1:]": noon.BLUE},
+            )
+        finally:
+            _restore_text_constructor_stub(originals)
+
+        self.assertEqual(
+            [entry[0] for entry in handle.batches[0].selectors],
+            ["[-1:]"],
+        )
+
+    def test_explicit_none_text2color_matches_manim_non_none_assertion(self):
+        handle = _Handle()
+        originals = _install_text_constructor_stub(handle)
+        try:
+            with self.assertRaises(AssertionError):
+                typst.Text(
+                    "abcdef",
+                    t2c={"[1:3]": noon.RED},
+                    text2color=None,
+                )
+        finally:
+            _restore_text_constructor_stub(originals)
+
+        self.assertEqual(handle.batches, [])
+
+    def test_styled_live_text_creation_rejects_before_bypassing_live_publication(self):
+        class LiveContext:
+            def __init__(self):
+                self.created = False
+
+            def liveCreateManimText(self, *args):
+                self.created = True
+                return _Handle()
+
+        context = LiveContext()
+        original_live = typst._live_text_context
+        typst._live_text_context = lambda: context
+        try:
+            with self.assertRaisesRegex(NotImplementedError, "after live execution"):
+                typst.Text("late", t2c={"late": noon.RED})
+        finally:
+            typst._live_text_context = original_live
+        self.assertFalse(context.created)
+
+    def test_t2c_rejects_invalid_python_color_shape_without_resolving_selector(self):
+        handle = _Handle()
+        originals = _install_text_constructor_stub(handle)
+        try:
+            with self.assertRaises(TypeError):
+                typst.Text("abcdef", t2c={"[1:3]": object()})
+        finally:
+            _restore_text_constructor_stub(originals)
+        self.assertEqual(handle.batches, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Restacked directly on current `master` through prerequisite #1414. Implements the bounded #83 / Roadmap B4 range-color slice for native `Text` while consuming #1371's landed source-part APIs rather than carrying its old stack.

- adds immutable `TextResource::with_source_fills` projection that preserves shaped glyph/cluster/layout identity and splits runs only where intrinsic fill changes
- keeps #1371's `text_part_authoring` implementation untouched; range styling delegates substring/source-span selection to those landed Rust queries
- rejects UTF-8/cluster-cut spans and Manim-ambiguous conflicting overlaps before object publication
- resolves ManimCE v0.21.0 substring and `[start:end]` selectors in Rust against the original source (including whitespace, negative endpoints, UTF-8 byte projection)
- publishes styling as a replacement immutable text resource plus semantic content-handle swap; object transform/style identity is unchanged
- projects one typed selector/color batch through WASM; Python validates only argument/color shape and forwards selectors unchanged
- preserves #1371's WASM-wrapper `free()` ownership cleanup and also frees the new fill-batch wrapper
- exposes `Text(..., t2c=...)` and the v0.21 `text2color` precedence alias
- explicitly rejects styled `Text` construction after live execution starts until content-resource replacement is routed through the owning live session

## Geometry invariant

The Rust semantic regression snapshots object transform/layout bounds/width/height/center plus retained resource bounds, baseline, layout artifact, vector items, run font/stroke/transform and every positioned glyph (source cluster, origin, advance and glyph bounds), then verifies the range-color edit changes paint/run partitioning only.

## Scope / boundaries

This PR does **not** implement `t2f/t2s/t2w/t2g`, `MarkupText`, Typst/Tex part styling, dynamic text, generic resource lifetime, or renderer threshold changes. Native `Text` point sizing was corrected independently in prerequisite #1414; this PR carries no sizing/metrics delta relative to its current base. Raster thresholds remain unchanged.

## Qualification

Focused Rust/WASM/Python, Fast Gate, both renderer backends, and the pinned `text-range-colors` ManimCE v0.21 raster fixture are being rerun on the restacked exact head. The PR is not merge-ready until the existing raster ratchet passes without threshold relaxation.

Refs #83
Part of #954