### PR TITLE
Add bounded transport-independent preview session registry

### DIFF
--- a/scripts/agent-preview-sessions.mjs
+++ b/scripts/agent-preview-sessions.mjs
@@ -1,0 +1,216 @@
+import { randomUUID } from "node:crypto";
+
+export class AgentPreviewSessionRegistry {
+  #createSession;
+  #scopes = new Map();
+  #sessionCount = 0;
+  #disposed = false;
+  #limits;
+
+  constructor({ createSession, maxScopes = 32, maxSessions = 64, maxSessionsPerScope = 16 } = {}) {
+    if (typeof createSession !== "function") {
+      throw new TypeError("session registry requires a preview-session factory");
+    }
+    for (const [name, value] of Object.entries({ maxScopes, maxSessions, maxSessionsPerScope })) {
+      if (!Number.isSafeInteger(value) || value <= 0 || value > 65_536) {
+        throw new RangeError(`${name} must be a positive bounded integer`);
+      }
+    }
+    if (maxSessionsPerScope > maxSessions) {
+      throw new RangeError("per-scope session limit cannot exceed global session limit");
+    }
+    this.#createSession = createSession;
+    this.#limits = { maxScopes, maxSessions, maxSessionsPerScope };
+  }
+
+  openScope() {
+    this.#assertLive();
+    if (this.#scopes.size >= this.#limits.maxScopes) {
+      throw new RangeError("preview scope limit exceeded");
+    }
+    const capability = Object.freeze(Object.create(null));
+    this.#scopes.set(capability, { closed: false, sessions: new Map() });
+    return capability;
+  }
+
+  async open(scopeCapability, source, options = {}) {
+    const scope = this.#scope(scopeCapability);
+    const { signal, ...openOptions } = options ?? {};
+    this.#assertSignal(signal);
+    if (signal?.aborted) throw abortError(signal.reason);
+    if (scope.sessions.size >= this.#limits.maxSessionsPerScope || this.#sessionCount >= this.#limits.maxSessions) {
+      throw new RangeError("preview session limit exceeded");
+    }
+
+    const session = this.#createSession();
+    assertSession(session);
+    const sessionId = randomUUID();
+    const entry = { session, busy: true, released: false };
+    scope.sessions.set(sessionId, entry);
+    this.#sessionCount += 1;
+
+    let removeAbort = () => {};
+    try {
+      const canceled = cancellation(signal, () => {
+        this.#release(scope, sessionId, entry, abortReason(signal));
+      });
+      removeAbort = canceled.remove;
+      const snapshot = await Promise.race([
+        Promise.resolve(session.open(source, openOptions)),
+        canceled.promise,
+      ]);
+      if (scope.closed || entry.released) throw new Error("preview scope closed during open");
+      entry.busy = false;
+      return Object.freeze({ sessionId, snapshot });
+    } catch (error) {
+      this.#release(scope, sessionId, entry, errorMessage(error, "preview open failed"));
+      throw error;
+    } finally {
+      removeAbort();
+      entry.busy = false;
+    }
+  }
+
+  async sample(scopeCapability, sessionId, timeSeconds, { signal } = {}) {
+    const { scope, entry } = this.#entry(scopeCapability, sessionId);
+    this.#assertSignal(signal);
+    if (signal?.aborted) {
+      const error = abortError(signal.reason);
+      this.#release(scope, sessionId, entry, error.message);
+      throw error;
+    }
+    if (entry.busy) throw new Error("preview session operation already in progress");
+    entry.busy = true;
+    const canceled = cancellation(signal, () => {
+      this.#release(scope, sessionId, entry, abortReason(signal));
+    });
+    try {
+      return await Promise.race([
+        Promise.resolve(entry.session.sample(timeSeconds)),
+        canceled.promise,
+      ]);
+    } finally {
+      canceled.remove();
+      entry.busy = false;
+    }
+  }
+
+  inspect(scopeCapability, sessionId) {
+    const { entry } = this.#entry(scopeCapability, sessionId);
+    if (entry.busy) throw new Error("preview session operation already in progress");
+    return entry.session.snapshot;
+  }
+
+  close(scopeCapability, sessionId, reason = "preview session closed") {
+    const { scope, entry } = this.#entry(scopeCapability, sessionId);
+    return this.#release(scope, sessionId, entry, requireReason(reason));
+  }
+
+  closeScope(scopeCapability, reason = "preview transport disconnected") {
+    this.#assertLive();
+    const scope = this.#scopes.get(scopeCapability);
+    if (!scope || scope.closed) throw new Error("stale preview scope capability");
+    scope.closed = true;
+    const cleanup = [];
+    for (const [sessionId, entry] of [...scope.sessions]) {
+      cleanup.push(this.#release(scope, sessionId, entry, requireReason(reason)));
+    }
+    this.#scopes.delete(scopeCapability);
+    return Object.freeze(cleanup);
+  }
+
+  dispose(reason = "preview registry shutdown") {
+    if (this.#disposed) return;
+    const message = requireReason(reason);
+    this.#disposed = true;
+    for (const [capability, scope] of [...this.#scopes]) {
+      scope.closed = true;
+      for (const [sessionId, entry] of [...scope.sessions]) {
+        this.#release(scope, sessionId, entry, message);
+      }
+      this.#scopes.delete(capability);
+    }
+  }
+
+  get counts() {
+    return Object.freeze({ scopes: this.#scopes.size, sessions: this.#sessionCount });
+  }
+
+  #entry(scopeCapability, sessionId) {
+    const scope = this.#scope(scopeCapability);
+    if (typeof sessionId !== "string" || sessionId.length === 0) {
+      throw new TypeError("preview session ID must be non-empty");
+    }
+    const entry = scope.sessions.get(sessionId);
+    if (!entry || entry.released) throw new Error("stale or cross-scope preview session ID");
+    return { scope, entry };
+  }
+
+  #scope(capability) {
+    this.#assertLive();
+    const scope = this.#scopes.get(capability);
+    if (!scope || scope.closed) throw new Error("stale preview scope capability");
+    return scope;
+  }
+
+  #release(scope, sessionId, entry, reason) {
+    if (entry.released) return null;
+    entry.released = true;
+    if (scope.sessions.get(sessionId) === entry) scope.sessions.delete(sessionId);
+    this.#sessionCount -= 1;
+    try {
+      return entry.session.close(reason);
+    } catch (error) {
+      return Object.freeze({ cleanupError: errorMessage(error, "preview close failed") });
+    }
+  }
+
+  #assertLive() {
+    if (this.#disposed) throw new Error("preview session registry is disposed");
+  }
+
+  #assertSignal(signal) {
+    if (signal !== undefined && !(signal instanceof AbortSignal)) {
+      throw new TypeError("signal must be an AbortSignal");
+    }
+  }
+}
+
+function assertSession(session) {
+  if (!session || typeof session.open !== "function" || typeof session.sample !== "function" ||
+      typeof session.close !== "function" || !("snapshot" in session)) {
+    try { session?.close?.("invalid preview session factory result"); } catch {}
+    throw new TypeError("preview-session factory returned an invalid session");
+  }
+}
+
+function cancellation(signal, onAbort) {
+  if (!signal) return { promise: new Promise(() => {}), remove: () => {} };
+  let rejectCanceled;
+  const promise = new Promise((_, reject) => { rejectCanceled = reject; });
+  const listener = () => {
+    const error = abortError(signal.reason);
+    onAbort();
+    rejectCanceled(error);
+  };
+  signal.addEventListener("abort", listener, { once: true });
+  return { promise, remove: () => signal.removeEventListener("abort", listener) };
+}
+
+function abortError(reason) {
+  if (reason instanceof Error) return reason;
+  return new Error(typeof reason === "string" && reason.trim() ? reason : "preview operation canceled");
+}
+
+function abortReason(signal) {
+  return errorMessage(abortError(signal?.reason), "preview operation canceled");
+}
+
+function errorMessage(error, fallback) {
+  return error instanceof Error && error.message ? error.message : String(error ?? fallback);
+}
+
+function requireReason(reason) {
+  if (typeof reason !== "string" || reason.trim() === "") throw new TypeError("preview close reason must be non-empty");
+  return reason;
+}

--- a/scripts/agent-preview-sessions.mjs
+++ b/scripts/agent-preview-sessions.mjs
@@ -45,19 +45,18 @@ export class AgentPreviewSessionRegistry {
     const session = this.#createSession();
     assertSession(session);
     const sessionId = randomUUID();
-    const entry = { session, busy: true, released: false };
+    const entry = createEntry(session);
     scope.sessions.set(sessionId, entry);
     this.#sessionCount += 1;
 
-    let removeAbort = () => {};
+    const canceled = cancellation(signal, () => {
+      this.#release(scope, sessionId, entry, abortReason(signal));
+    });
     try {
-      const canceled = cancellation(signal, () => {
-        this.#release(scope, sessionId, entry, abortReason(signal));
-      });
-      removeAbort = canceled.remove;
       const snapshot = await Promise.race([
         Promise.resolve(session.open(source, openOptions)),
         canceled.promise,
+        entry.releasedPromise,
       ]);
       if (scope.closed || entry.released) throw new Error("preview scope closed during open");
       entry.busy = false;
@@ -66,7 +65,7 @@ export class AgentPreviewSessionRegistry {
       this.#release(scope, sessionId, entry, errorMessage(error, "preview open failed"));
       throw error;
     } finally {
-      removeAbort();
+      canceled.remove();
       entry.busy = false;
     }
   }
@@ -88,6 +87,7 @@ export class AgentPreviewSessionRegistry {
       return await Promise.race([
         Promise.resolve(entry.session.sample(timeSeconds)),
         canceled.promise,
+        entry.releasedPromise,
       ]);
     } finally {
       canceled.remove();
@@ -108,12 +108,13 @@ export class AgentPreviewSessionRegistry {
 
   closeScope(scopeCapability, reason = "preview transport disconnected") {
     this.#assertLive();
+    const message = requireReason(reason);
     const scope = this.#scopes.get(scopeCapability);
     if (!scope || scope.closed) throw new Error("stale preview scope capability");
     scope.closed = true;
     const cleanup = [];
     for (const [sessionId, entry] of [...scope.sessions]) {
-      cleanup.push(this.#release(scope, sessionId, entry, requireReason(reason)));
+      cleanup.push(this.#release(scope, sessionId, entry, message));
     }
     this.#scopes.delete(scopeCapability);
     return Object.freeze(cleanup);
@@ -158,6 +159,7 @@ export class AgentPreviewSessionRegistry {
     entry.released = true;
     if (scope.sessions.get(sessionId) === entry) scope.sessions.delete(sessionId);
     this.#sessionCount -= 1;
+    entry.rejectReleased(new Error(reason));
     try {
       return entry.session.close(reason);
     } catch (error) {
@@ -176,6 +178,13 @@ export class AgentPreviewSessionRegistry {
   }
 }
 
+function createEntry(session) {
+  let rejectReleased;
+  const releasedPromise = new Promise((_, reject) => { rejectReleased = reject; });
+  releasedPromise.catch(() => {});
+  return { session, busy: true, released: false, releasedPromise, rejectReleased };
+}
+
 function assertSession(session) {
   if (!session || typeof session.open !== "function" || typeof session.sample !== "function" ||
       typeof session.close !== "function" || !("snapshot" in session)) {
@@ -187,13 +196,18 @@ function assertSession(session) {
 function cancellation(signal, onAbort) {
   if (!signal) return { promise: new Promise(() => {}), remove: () => {} };
   let rejectCanceled;
+  let fired = false;
   const promise = new Promise((_, reject) => { rejectCanceled = reject; });
+  promise.catch(() => {});
   const listener = () => {
+    if (fired) return;
+    fired = true;
     const error = abortError(signal.reason);
     onAbort();
     rejectCanceled(error);
   };
   signal.addEventListener("abort", listener, { once: true });
+  if (signal.aborted) listener();
   return { promise, remove: () => signal.removeEventListener("abort", listener) };
 }
 

--- a/scripts/agent-preview-sessions.test.mjs
+++ b/scripts/agent-preview-sessions.test.mjs
@@ -1,0 +1,220 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { AgentPreviewSessionRegistry } from "./agent-preview-sessions.mjs";
+
+function deferred() {
+  let resolve, reject;
+  const promise = new Promise((yes, no) => { resolve = yes; reject = no; });
+  return { promise, resolve, reject };
+}
+
+function fixture(t, overrides = {}, limits = {}) {
+  const created = [];
+  const registry = new AgentPreviewSessionRegistry({
+    createSession: () => {
+      const session = {
+        state: "new",
+        closed: false,
+        openCalls: [],
+        sampleCalls: [],
+        closeCalls: [],
+        snapshotValue: { state: "new" },
+        async open(source, options) {
+          this.openCalls.push([source, options]);
+          this.state = "ready";
+          this.snapshotValue = { state: "ready", frame: { publishedTime: 0 } };
+          return this.snapshotValue;
+        },
+        async sample(time) {
+          this.sampleCalls.push(time);
+          this.snapshotValue = { state: "ready", frame: { publishedTime: time } };
+          return this.snapshotValue;
+        },
+        get snapshot() { return this.snapshotValue; },
+        close(reason) {
+          this.closeCalls.push(reason);
+          this.closed = true;
+          this.state = "closed";
+          this.snapshotValue = { state: "closed" };
+          overrides.onClose?.(this, reason);
+          return this.snapshotValue;
+        },
+        ...overrides.session,
+      };
+      created.push(session);
+      return session;
+    },
+    ...limits,
+  });
+  t.after(() => registry.dispose());
+  return { registry, created };
+}
+
+test("open publishes one opaque session only after first-frame readiness", async (t) => {
+  const gate = deferred();
+  const { registry, created } = fixture(t, { session: {
+    async open(source, options) {
+      this.openCalls.push([source, options]);
+      await gate.promise;
+      this.snapshotValue = { state: "ready", sourceState: "running", authoredDuration: null,
+        frame: { requestedTime: 0, publishedTime: 0 } };
+      return this.snapshotValue;
+    },
+  } });
+  const scope = registry.openScope();
+  const opening = registry.open(scope, "scene", { loopDurationSeconds: 4 });
+  assert.deepEqual(registry.counts, { scopes: 1, sessions: 1 });
+  gate.resolve();
+  const opened = await opening;
+  assert.match(opened.sessionId, /^[0-9a-f-]{36}$/);
+  assert.equal(opened.snapshot.sourceState, "running");
+  assert.equal(opened.snapshot.authoredDuration, null);
+  assert.deepEqual(created[0].openCalls, [["scene", { loopDurationSeconds: 4 }]]);
+});
+
+test("known IDs are still rejected across transport scopes and after close", async (t) => {
+  const { registry } = fixture(t);
+  const scopeA = registry.openScope();
+  const scopeB = registry.openScope();
+  const { sessionId } = await registry.open(scopeA, "scene");
+  assert.throws(() => registry.inspect(scopeB, sessionId), /cross-scope|stale/);
+  registry.close(scopeA, sessionId);
+  assert.throws(() => registry.inspect(scopeA, sessionId), /cross-scope|stale/);
+  assert.deepEqual(registry.counts, { scopes: 2, sessions: 0 });
+});
+
+test("concurrent conflicting samples are rejected before duplicate engine work", async (t) => {
+  const gate = deferred();
+  const entered = deferred();
+  const { registry, created } = fixture(t, { session: {
+    async sample(time) {
+      this.sampleCalls.push(time);
+      entered.resolve();
+      await gate.promise;
+      this.snapshotValue = { state: "ready", frame: { publishedTime: time } };
+      return this.snapshotValue;
+    },
+  } });
+  const scope = registry.openScope();
+  const { sessionId } = await registry.open(scope, "scene");
+  const first = registry.sample(scope, sessionId, 1);
+  await entered.promise;
+  await assert.rejects(registry.sample(scope, sessionId, 2), /already in progress/);
+  assert.deepEqual(created[0].sampleCalls, [1]);
+  gate.resolve();
+  assert.equal((await first).frame.publishedTime, 1);
+  assert.equal((await registry.sample(scope, sessionId, 2)).frame.publishedTime, 2);
+});
+
+test("operation cancellation closes ownership and makes the session ID stale", async (t) => {
+  const gate = deferred();
+  const entered = deferred();
+  const { registry, created } = fixture(t, { session: {
+    async sample(time) {
+      this.sampleCalls.push(time);
+      entered.resolve();
+      await gate.promise;
+      return { state: "ready", frame: { publishedTime: time } };
+    },
+  } });
+  const scope = registry.openScope();
+  const { sessionId } = await registry.open(scope, "scene");
+  const controller = new AbortController();
+  const sampling = registry.sample(scope, sessionId, 1, { signal: controller.signal });
+  await entered.promise;
+  controller.abort("client canceled");
+  await assert.rejects(sampling, /client canceled/);
+  assert.deepEqual(created[0].closeCalls, ["client canceled"]);
+  assert.throws(() => registry.inspect(scope, sessionId), /stale|cross-scope/);
+  gate.resolve();
+});
+
+test("transport disconnect rejects a non-cooperative open immediately and cleans accounting", async (t) => {
+  const gate = deferred();
+  const entered = deferred();
+  const { registry, created } = fixture(t, { session: {
+    async open() {
+      entered.resolve();
+      await gate.promise;
+      return { state: "ready" };
+    },
+  } });
+  const scope = registry.openScope();
+  const opening = registry.open(scope, "scene");
+  await entered.promise;
+  registry.closeScope(scope, "transport disconnected");
+  await assert.rejects(opening, /transport disconnected/);
+  assert.deepEqual(created[0].closeCalls, ["transport disconnected"]);
+  assert.deepEqual(registry.counts, { scopes: 0, sessions: 0 });
+  gate.resolve();
+  assert.throws(() => registry.open(scope, "again"), /stale preview scope/);
+});
+
+test("pre-aborted requests never create a session", async (t) => {
+  const { registry, created } = fixture(t);
+  const scope = registry.openScope();
+  const controller = new AbortController();
+  controller.abort(new Error("already canceled"));
+  await assert.rejects(registry.open(scope, "scene", { signal: controller.signal }), /already canceled/);
+  assert.equal(created.length, 0);
+  assert.deepEqual(registry.counts, { scopes: 1, sessions: 0 });
+});
+
+test("failed open releases quota and a fresh open can recover", async (t) => {
+  let fail = true;
+  const { registry } = fixture(t, { session: {
+    async open() {
+      if (fail) { fail = false; throw new Error("source failed"); }
+      this.snapshotValue = { state: "ready" };
+      return this.snapshotValue;
+    },
+  } }, { maxSessions: 1, maxSessionsPerScope: 1 });
+  const scope = registry.openScope();
+  await assert.rejects(registry.open(scope, "bad"), /source failed/);
+  assert.deepEqual(registry.counts, { scopes: 1, sessions: 0 });
+  assert.match((await registry.open(scope, "good")).sessionId, /^[0-9a-f-]{36}$/);
+});
+
+test("scope and session quotas reject atomically without evicting live ownership", async (t) => {
+  const { registry, created } = fixture(t, {}, { maxScopes: 2, maxSessions: 2, maxSessionsPerScope: 1 });
+  const scopeA = registry.openScope();
+  const scopeB = registry.openScope();
+  assert.throws(() => registry.openScope(), /scope limit/);
+  const a = await registry.open(scopeA, "a");
+  const b = await registry.open(scopeB, "b");
+  await assert.rejects(registry.open(scopeA, "extra"), /session limit/);
+  assert.equal(created.length, 2);
+  assert.equal(registry.inspect(scopeA, a.sessionId).state, "ready");
+  assert.equal(registry.inspect(scopeB, b.sessionId).state, "ready");
+});
+
+test("invalid factories, signals, and close reasons do not corrupt registry state", async (t) => {
+  const invalid = new AgentPreviewSessionRegistry({ createSession: () => ({}) });
+  t.after(() => invalid.dispose());
+  const invalidScope = invalid.openScope();
+  await assert.rejects(invalid.open(invalidScope, "scene"), /invalid session/);
+  assert.deepEqual(invalid.counts, { scopes: 1, sessions: 0 });
+
+  const { registry } = fixture(t);
+  const scope = registry.openScope();
+  await assert.rejects(registry.open(scope, "scene", { signal: {} }), /AbortSignal/);
+  const { sessionId } = await registry.open(scope, "scene");
+  assert.throws(() => registry.close(scope, sessionId, ""), /reason/);
+  assert.equal(registry.inspect(scope, sessionId).state, "ready");
+  assert.throws(() => registry.closeScope(scope, ""), /reason/);
+  assert.equal(registry.inspect(scope, sessionId).state, "ready");
+});
+
+test("registry shutdown closes every session and rejects future operations", async (t) => {
+  const { registry, created } = fixture(t);
+  const scopeA = registry.openScope();
+  const scopeB = registry.openScope();
+  await registry.open(scopeA, "a");
+  await registry.open(scopeB, "b");
+  registry.dispose("server shutdown");
+  assert.deepEqual(created.map((session) => session.closeCalls), [["server shutdown"], ["server shutdown"]]);
+  assert.deepEqual(registry.counts, { scopes: 0, sessions: 0 });
+  assert.throws(() => registry.openScope(), /disposed/);
+  registry.dispose("server shutdown");
+});


### PR DESCRIPTION
Advances #1197 / R3 without touching blocked R1/#1246 or exposing source execution through MCP.

This draft adds an ownership/control registry over an injected preview-session factory compatible with `SemanticPreviewSession`. It owns only transport scopes and opaque session IDs; all rendering/authoring semantics remain delegated to the existing preview session.

Implemented contract:
- bounded global/per-scope sessions and bounded transport scopes;
- private in-process scope capabilities plus opaque UUID session IDs;
- cross-scope and stale session rejection even when an ID is known;
- open returns only after the injected session's first-ready result;
- forward sample and coherent inspect delegate to the owned session;
- conflicting in-flight operations are rejected before duplicate engine work;
- AbortSignal cancellation closes and invalidates the owned session;
- transport disconnect rejects even a non-cooperative pending open and closes all owned sessions;
- registry shutdown closes all scopes/sessions;
- failed opens release quota so a fresh session can recover;
- invalid inputs/factories/reasons do not partially publish ownership.

The committed focused tests cover all of the above. The existing `noon-agent-foundation` workflow is currently being changed by #1268, so this PR intentionally does **not** modify that overlapping file yet. Once #1268 lands, this branch will reconcile onto master and add these tests to the existing agent-foundation job rather than creating a new workflow category.

This is session ownership/control only. It is not the R2 sandbox, browser/process launcher, CLI, MCP registration, scene graph, scheduler, renderer, or source rewriting. No execution surface is safe to expose until R1/R2 qualification. Per `AGENTS.override.md`, no Codex/automated review is requested or relied upon.