### PR TITLE
Route preview CLI through retained artifact service

### DIFF
--- a/.github/workflows/authoring-agent-discovery.yml
+++ b/.github/workflows/authoring-agent-discovery.yml
@@ -126,6 +126,17 @@ jobs:
           else
             echo "Shared runner smoke not present in this revision."
           fi
+      - if: steps.source.outputs.enabled == 'true'
+        name: Verify shared preview CLI when present
+        env:
+          NOON_PREVIEW_RUNTIME_CONFIG: ${{ runner.temp }}/noon-preview/runtime.json
+        working-directory: tools/noon-mcp
+        run: |
+          if [[ -f test/docker-cli-smoke.mjs ]]; then
+            timeout --signal=TERM 180s node test/docker-cli-smoke.mjs | tee "$RUNNER_TEMP/noon-preview-cli.json"
+          else
+            echo "Shared preview CLI smoke not present in this revision."
+          fi
       - name: Upload isolation evidence
         if: always() && steps.source.outputs.enabled == 'true'
         uses: actions/upload-artifact@v7
@@ -135,6 +146,7 @@ jobs:
             ${{ runner.temp }}/noon-preview-setup.json
             ${{ runner.temp }}/noon-preview-isolation.json
             ${{ runner.temp }}/noon-preview-runner.json
+            ${{ runner.temp }}/noon-preview-cli.json
             ${{ runner.temp }}/noon-preview/runtime.json
           if-no-files-found: warn
           retention-days: 14

--- a/tools/noon-mcp/bin/noon-preview.mjs
+++ b/tools/noon-mcp/bin/noon-preview.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { runPreviewCli } from "../src/preview-cli.mjs";
+import { loadPreviewRuntimeConfig } from "../src/preview-isolation.mjs";
+import { AgentPreviewService } from "../src/preview-service.mjs";
+
+const USAGE = `Usage: noon-preview --source <scene.py> [--output <dir>] [--loop-duration <seconds>] [--time <seconds> ...]\n\nRenders through the same isolated preview service used by Noon MCP, including retained PNG provenance. Runtime selection comes from NOON_PREVIEW_RUNTIME_CONFIG or the trusted default created by setup-preview-runtime.mjs.\n`;
+
+async function main() {
+  const argv = process.argv.slice(2);
+  if (argv.includes("--help") || argv.includes("-h")) {
+    process.stdout.write(USAGE);
+    return;
+  }
+  const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+  const repoRoot = path.resolve(packageRoot, "../..");
+  const config = await loadPreviewRuntimeConfig({
+    repoRoot,
+    configPath: process.env.NOON_PREVIEW_RUNTIME_CONFIG,
+  });
+  const result = await runPreviewCli({
+    argv,
+    serviceFactory: () => new AgentPreviewService({ isolationConfig: config }),
+  });
+  process.stdout.write(`${JSON.stringify({ outputDir: result.outputDir, manifestPath: result.manifestPath, samples: result.manifest.samples.length })}\n`);
+}
+
+main().catch((error) => {
+  process.stderr.write(`${String(error?.stack ?? error)}\n`);
+  process.exitCode = 1;
+});

--- a/tools/noon-mcp/src/preview-cli.mjs
+++ b/tools/noon-mcp/src/preview-cli.mjs
@@ -1,0 +1,187 @@
+import { createHash } from "node:crypto";
+import { mkdir, readFile, realpath, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+const MAX_SOURCE_BYTES = 1_000_000;
+// The composed service retains the initial frame too, so 31 requested samples
+// fit its default 32-frame scope without advancing into an unpublishable frame.
+export const MAX_PREVIEW_CLI_SAMPLES = 31;
+const MAX_TIME_SECONDS = 600;
+
+function finiteTime(name, text, { positive = false } = {}) {
+  if (typeof text !== "string" || text.trim() === "") throw new TypeError(`${name} requires a value`);
+  const value = Number(text);
+  if (!Number.isFinite(value) || value < 0 || value > MAX_TIME_SECONDS || (positive && value === 0)) {
+    throw new RangeError(`${name} must be ${positive ? "positive" : "non-negative"}, finite, and <= ${MAX_TIME_SECONDS}`);
+  }
+  return value;
+}
+
+export function parsePreviewCliArgs(argv) {
+  if (!Array.isArray(argv) || argv.some((value) => typeof value !== "string")) {
+    throw new TypeError("preview CLI arguments must be strings");
+  }
+  let sourcePath = null;
+  let outputDir = "noon-preview-output";
+  let loopDurationSeconds = 4;
+  const times = [];
+  let help = false;
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--help" || arg === "-h") { help = true; continue; }
+    const next = () => {
+      index += 1;
+      if (index >= argv.length) throw new TypeError(`${arg} requires a value`);
+      return argv[index];
+    };
+    if (arg === "--source") sourcePath = next();
+    else if (arg === "--output") outputDir = next();
+    else if (arg === "--loop-duration") loopDurationSeconds = finiteTime("--loop-duration", next(), { positive: true });
+    else if (arg === "--time") times.push(finiteTime("--time", next()));
+    else throw new TypeError(`unknown preview CLI argument: ${arg}`);
+  }
+  if (!help && (typeof sourcePath !== "string" || sourcePath.trim() === "")) {
+    throw new TypeError("--source is required");
+  }
+  if (times.length > MAX_PREVIEW_CLI_SAMPLES) {
+    throw new RangeError(`at most ${MAX_PREVIEW_CLI_SAMPLES} --time values are allowed`);
+  }
+  for (let index = 1; index < times.length; index += 1) {
+    if (times[index] < times[index - 1]) throw new RangeError("--time values must be nondecreasing");
+  }
+  if (typeof outputDir !== "string" || outputDir.trim() === "" || outputDir.includes("\0")) {
+    throw new TypeError("--output must be a non-empty path without NUL");
+  }
+  return Object.freeze({ sourcePath, outputDir, loopDurationSeconds, times: Object.freeze(times), help });
+}
+
+async function sourceFile(filename, cwd) {
+  const resolved = await realpath(path.resolve(cwd, filename));
+  const metadata = await stat(resolved);
+  if (!metadata.isFile() || metadata.size > MAX_SOURCE_BYTES) {
+    throw new Error("preview source must be a regular file within the byte limit");
+  }
+  const bytes = await readFile(resolved);
+  if (bytes.length > MAX_SOURCE_BYTES) throw new Error("preview source exceeds byte limit");
+  const source = bytes.toString("utf8");
+  if (source.trim() === "" || source.includes("\0")) throw new Error("preview source must be non-empty UTF-8 text without NUL");
+  return { resolved, source, sha256: createHash("sha256").update(bytes).digest("hex") };
+}
+
+function requireService(service) {
+  const methods = ["openScope", "open", "sampleFrames", "getArtifact", "close", "closeScope", "dispose"];
+  if (!service || methods.some((name) => typeof service[name] !== "function")) {
+    throw new TypeError("preview CLI service factory returned an invalid service");
+  }
+  return service;
+}
+
+function retainedFrame(service, scope, sessionId, descriptor, snapshot, expectedSourceSha256) {
+  if (!descriptor || typeof descriptor !== "object" || typeof descriptor.id !== "string") {
+    throw new Error("preview service returned no artifact descriptor");
+  }
+  const retained = service.getArtifact(scope, sessionId, descriptor.id);
+  if (!retained || !Buffer.isBuffer(retained.png) || !retained.descriptor || retained.descriptor.id !== descriptor.id) {
+    throw new Error("preview service returned no retained PNG artifact");
+  }
+  const actualSha256 = createHash("sha256").update(retained.png).digest("hex");
+  const provenance = retained.descriptor.provenance;
+  if (retained.descriptor.mimeType !== "image/png" ||
+      retained.descriptor.sha256 !== actualSha256 ||
+      retained.descriptor.byteLength !== retained.png.length ||
+      provenance?.sessionId !== sessionId ||
+      provenance?.sourceSha256 !== expectedSourceSha256 ||
+      provenance?.requestedTime !== snapshot?.frame?.requestedTime ||
+      provenance?.backend !== snapshot?.frame?.rendererBackend) {
+    throw new Error("retained preview artifact does not match the coherent service observation");
+  }
+  return retained;
+}
+
+function sampleRecord(snapshot, retained, filename) {
+  return Object.freeze({
+    filename,
+    snapshot,
+    artifact: retained.descriptor,
+  });
+}
+
+function attachCleanupError(primaryError, error) {
+  const message = String(error?.message ?? error);
+  if (primaryError && typeof primaryError === "object") {
+    primaryError.cleanupError = primaryError.cleanupError ? `${primaryError.cleanupError}; ${message}` : message;
+  }
+}
+
+export async function runPreviewCli({ argv, cwd = process.cwd(), serviceFactory }) {
+  const args = parsePreviewCliArgs(argv);
+  if (args.help) return Object.freeze({ help: true });
+  if (typeof serviceFactory !== "function") throw new TypeError("preview CLI requires a service factory");
+  const source = await sourceFile(args.sourcePath, cwd);
+  const outputDir = path.resolve(cwd, args.outputDir);
+  await mkdir(outputDir, { recursive: true });
+
+  const service = requireService(serviceFactory());
+  let scope = null;
+  let sessionId = null;
+  let primaryError = null;
+  let cleanup = null;
+  const samples = [];
+
+  try {
+    scope = service.openScope();
+    const opened = await service.open(scope, source.source, { loopDurationSeconds: args.loopDurationSeconds });
+    sessionId = opened.sessionId;
+    const initial = retainedFrame(service, scope, sessionId, opened.artifact, opened.snapshot, source.sha256);
+    const initialName = "frame-000.png";
+    await writeFile(path.join(outputDir, initialName), initial.png, { flag: "wx" });
+    samples.push(sampleRecord(opened.snapshot, initial, initialName));
+
+    const requestedTimes = args.times.filter((time) => time !== 0);
+    if (requestedTimes.length > 0) {
+      const frames = await service.sampleFrames(scope, sessionId, requestedTimes);
+      let ordinal = 1;
+      for (const frame of frames) {
+        const retained = retainedFrame(service, scope, sessionId, frame.artifact, frame.snapshot, source.sha256);
+        const filename = `frame-${String(ordinal).padStart(3, "0")}.png`;
+        ordinal += 1;
+        await writeFile(path.join(outputDir, filename), retained.png, { flag: "wx" });
+        samples.push(sampleRecord(frame.snapshot, retained, filename));
+      }
+    }
+  } catch (error) {
+    primaryError = error;
+  } finally {
+    if (scope !== null && sessionId !== null) {
+      try { cleanup = await service.close(scope, sessionId, primaryError ? "preview CLI failed" : "preview CLI complete"); }
+      catch (error) {
+        if (!primaryError) primaryError = error;
+        else attachCleanupError(primaryError, error);
+      }
+    }
+    if (scope !== null) {
+      try { await service.closeScope(scope, primaryError ? "preview CLI scope failed" : "preview CLI scope complete"); }
+      catch (error) {
+        if (!primaryError) primaryError = error;
+        else attachCleanupError(primaryError, error);
+      }
+    }
+    try { await service.dispose(primaryError ? "preview CLI service failed" : "preview CLI service complete"); }
+    catch (error) {
+      if (!primaryError) primaryError = error;
+      else attachCleanupError(primaryError, error);
+    }
+  }
+
+  if (primaryError) throw primaryError;
+  const manifest = {
+    schema: 2,
+    source: { path: source.resolved, sha256: source.sha256 },
+    loopDurationSeconds: args.loopDurationSeconds,
+    samples,
+    cleanup,
+  };
+  const manifestPath = path.join(outputDir, "manifest.json");
+  await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, { flag: "wx" });
+  return Object.freeze({ outputDir, manifestPath, manifest: Object.freeze(manifest) });
+}

--- a/tools/noon-mcp/test/docker-cli-smoke.mjs
+++ b/tools/noon-mcp/test/docker-cli-smoke.mjs
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
+
+const execFileAsync = promisify(execFile);
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "../../..");
+const cliPath = path.join(repoRoot, "tools/noon-mcp/bin/noon-preview.mjs");
+const sourcePath = path.join(repoRoot, "web/python/examples/manim_parity_square_to_circle.py");
+const runtimeConfig = process.env.NOON_PREVIEW_RUNTIME_CONFIG;
+if (!runtimeConfig) throw new Error("NOON_PREVIEW_RUNTIME_CONFIG is required for Docker CLI smoke");
+
+const hash = (bytes) => createHash("sha256").update(bytes).digest("hex");
+const sourceBytes = await readFile(sourcePath);
+const sourceSha256 = hash(sourceBytes);
+const runtimeIdentity = JSON.parse(await readFile(path.join(repoRoot, "web/runtime-build-identity.json"), "utf8"));
+const expectedBuild = Object.freeze({
+  engineRevision: runtimeIdentity.sourceRevision ?? null,
+  wasmSha256: runtimeIdentity.files?.wasm?.sha256,
+  workerSha256: runtimeIdentity.files?.worker?.sha256,
+  buildId: runtimeIdentity.buildId,
+});
+for (const [name, value] of Object.entries(expectedBuild)) {
+  if (name === "engineRevision" && value === null) continue;
+  assert.match(value, name === "engineRevision" ? /^[0-9a-f]{40}$/ : /^[0-9a-f]{64}$/,
+    `${name} must come from the generated runtime identity`);
+}
+
+const root = await mkdtemp(path.join(os.tmpdir(), "noon-preview-cli-real-"));
+const outputDir = path.join(root, "frames");
+try {
+  const { stdout } = await execFileAsync(process.execPath, [
+    cliPath,
+    "--source", sourcePath,
+    "--output", outputDir,
+    "--loop-duration", "4",
+    "--time", "1",
+    "--time", "1.5",
+    "--time", "3",
+  ], {
+    cwd: path.join(repoRoot, "tools/noon-mcp"),
+    env: { ...process.env, NOON_PREVIEW_RUNTIME_CONFIG: runtimeConfig },
+    timeout: 150_000,
+    maxBuffer: 1024 * 1024,
+  });
+
+  const summary = JSON.parse(stdout.trim());
+  assert.equal(summary.outputDir, outputDir);
+  assert.equal(summary.manifestPath, path.join(outputDir, "manifest.json"));
+  assert.equal(summary.samples, 4);
+
+  const manifest = JSON.parse(await readFile(summary.manifestPath, "utf8"));
+  assert.equal(manifest.schema, 2);
+  assert.equal(manifest.source.path, sourcePath);
+  assert.equal(manifest.source.sha256, sourceSha256);
+  assert.equal(manifest.loopDurationSeconds, 4);
+  assert.equal(manifest.samples.length, 4);
+  assert.equal(manifest.cleanup?.state, "closed");
+
+  const expectedTimes = [0, 1, 1.5, 3];
+  let sessionId = null;
+  for (let index = 0; index < manifest.samples.length; index += 1) {
+    const sample = manifest.samples[index];
+    const png = await readFile(path.join(outputDir, sample.filename));
+    const pngSha256 = hash(png);
+    assert.equal(sample.artifact.mimeType, "image/png");
+    assert.equal(sample.artifact.sha256, pngSha256);
+    assert.equal(sample.artifact.byteLength, png.length);
+    assert.equal(sample.snapshot.image?.sha256, pngSha256);
+    assert.equal(sample.snapshot.frame?.requestedTime, expectedTimes[index]);
+    assert.equal(sample.snapshot.frame?.publishedTime, expectedTimes[index]);
+    assert.equal(sample.artifact.provenance.requestedTime, expectedTimes[index]);
+    assert.equal(sample.artifact.provenance.publishedTime, expectedTimes[index]);
+    assert.equal(sample.artifact.provenance.backend, sample.snapshot.frame?.rendererBackend);
+    assert.equal(sample.artifact.provenance.sourceSha256, sourceSha256);
+    assert.deepEqual(sample.artifact.provenance.build, expectedBuild);
+    if (sessionId === null) sessionId = sample.artifact.provenance.sessionId;
+    assert.equal(sample.artifact.provenance.sessionId, sessionId);
+  }
+
+  const { stdout: containers } = await execFileAsync("docker", [
+    "ps", "--filter", "label=com.noon.preview=true", "--format", "{{.ID}}",
+  ], { timeout: 10_000, maxBuffer: 64 * 1024 });
+  assert.equal(containers.trim(), "", "CLI completion must leave no owned preview container running");
+
+  console.log(JSON.stringify({
+    ok: true,
+    buildId: expectedBuild.buildId,
+    sourceSha256,
+    frameSha256: manifest.samples.map((sample) => sample.artifact.sha256),
+  }));
+} finally {
+  await rm(root, { recursive: true, force: true });
+}

--- a/tools/noon-mcp/test/preview-cli.test.mjs
+++ b/tools/noon-mcp/test/preview-cli.test.mjs
@@ -1,0 +1,176 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { MAX_PREVIEW_CLI_SAMPLES, parsePreviewCliArgs, runPreviewCli } from "../src/preview-cli.mjs";
+
+const png = Buffer.from([137,80,78,71,13,10,26,10,1,2,3,4]);
+const pngSha256 = createHash("sha256").update(png).digest("hex");
+const build = Object.freeze({
+  engineRevision: "a".repeat(40),
+  wasmSha256: "b".repeat(64),
+  workerSha256: "c".repeat(64),
+  buildId: "d".repeat(64),
+});
+
+function fakeService() {
+  const calls = [];
+  const scope = Object.freeze({ capability: true });
+  const sessionId = "01234567-89ab-cdef-0123-456789abcdef";
+  const artifacts = new Map();
+  let sourceSha256 = null;
+  let nextArtifact = 0;
+
+  const snapshot = (time) => Object.freeze({
+    state: "ready",
+    sourceState: "running",
+    authoredDuration: 4,
+    frame: Object.freeze({ requestedTime: time, publishedTime: time, rendererBackend: "WebGL2" }),
+    image: Object.freeze({ mimeType: "image/png", encodedBytes: png.length, sha256: pngSha256 }),
+  });
+  const put = (time) => {
+    const descriptor = Object.freeze({
+      id: `artifact-${nextArtifact++}`,
+      mimeType: "image/png",
+      width: 1,
+      height: 1,
+      byteLength: png.length,
+      sha256: pngSha256,
+      provenance: Object.freeze({
+        sessionId,
+        sourceSha256,
+        build,
+        requestedTime: time,
+        publishedTime: time,
+        backend: "WebGL2",
+        sceneRevision: null,
+        frameRevision: null,
+      }),
+      retentionMs: 300_000,
+    });
+    artifacts.set(descriptor.id, { descriptor, png: Buffer.from(png) });
+    return { snapshot: snapshot(time), artifact: descriptor };
+  };
+
+  return {
+    calls,
+    openScope() { calls.push(["openScope"]); return scope; },
+    async open(actualScope, source, options) {
+      calls.push(["open", actualScope, source, options]);
+      assert.equal(actualScope, scope);
+      sourceSha256 = createHash("sha256").update(source, "utf8").digest("hex");
+      return Object.freeze({ sessionId, ...put(0) });
+    },
+    async sampleFrames(actualScope, actualSessionId, times) {
+      calls.push(["sampleFrames", actualScope, actualSessionId, [...times]]);
+      assert.equal(actualScope, scope);
+      assert.equal(actualSessionId, sessionId);
+      return Object.freeze(times.map((time) => Object.freeze(put(time))));
+    },
+    getArtifact(actualScope, actualSessionId, artifactId) {
+      calls.push(["getArtifact", actualScope, actualSessionId, artifactId]);
+      assert.equal(actualScope, scope);
+      assert.equal(actualSessionId, sessionId);
+      const retained = artifacts.get(artifactId);
+      if (!retained) throw new Error("artifact unavailable");
+      return Object.freeze({ descriptor: retained.descriptor, png: Buffer.from(retained.png) });
+    },
+    async close(actualScope, actualSessionId, reason) {
+      calls.push(["close", actualScope, actualSessionId, reason]);
+      assert.equal(actualScope, scope);
+      assert.equal(actualSessionId, sessionId);
+      artifacts.clear();
+      return Object.freeze({ state: "closed", cleanup: Object.freeze({ closed: true, cleanup: Object.freeze({ removed: true }) }) });
+    },
+    async closeScope(actualScope, reason) {
+      calls.push(["closeScope", actualScope, reason]);
+      assert.equal(actualScope, scope);
+      return Object.freeze([]);
+    },
+    async dispose(reason) { calls.push(["dispose", reason]); return Object.freeze([]); },
+  };
+}
+
+test("argument parser enforces bounded forward schedules within retained-frame budget", () => {
+  assert.equal(MAX_PREVIEW_CLI_SAMPLES, 31);
+  assert.deepEqual(parsePreviewCliArgs(["--source", "scene.py", "--time", "1", "--time", "1.5", "--loop-duration", "4"]), {
+    sourcePath: "scene.py", outputDir: "noon-preview-output", loopDurationSeconds: 4, times: [1, 1.5], help: false,
+  });
+  assert.throws(() => parsePreviewCliArgs(["--source", "scene.py", "--time", "2", "--time", "1"]), /nondecreasing/);
+  assert.throws(() => parsePreviewCliArgs(["--source", "scene.py", "--time", "601"]), /<= 600/);
+  const tooMany = ["--source", "scene.py"];
+  for (let index = 0; index < 32; index += 1) tooMany.push("--time", String(index));
+  assert.throws(() => parsePreviewCliArgs(tooMany), /at most 31/);
+  assert.throws(() => parsePreviewCliArgs([]), /--source is required/);
+});
+
+test("CLI uses one composed service scope and writes retained PNGs plus provenance manifest", async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "noon-preview-cli-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const sourceText = "from noon import *\n";
+  await writeFile(path.join(root, "scene.py"), sourceText);
+  const service = fakeService();
+  const result = await runPreviewCli({
+    argv: ["--source", "scene.py", "--output", "out", "--time", "0", "--time", "1.5"],
+    cwd: root,
+    serviceFactory: () => service,
+  });
+
+  assert.deepEqual(service.calls.map((entry) => entry[0]),
+    ["openScope", "open", "getArtifact", "sampleFrames", "getArtifact", "close", "closeScope", "dispose"]);
+  assert.deepEqual(service.calls.find((entry) => entry[0] === "sampleFrames")[3], [1.5]);
+  assert.deepEqual(await readFile(path.join(root, "out/frame-000.png")), png);
+  assert.deepEqual(await readFile(path.join(root, "out/frame-001.png")), png);
+
+  const manifest = JSON.parse(await readFile(result.manifestPath, "utf8"));
+  const sourceSha256 = createHash("sha256").update(sourceText).digest("hex");
+  assert.equal(manifest.schema, 2);
+  assert.equal(manifest.samples.length, 2);
+  assert.equal(manifest.samples[1].snapshot.frame.requestedTime, 1.5);
+  assert.equal(manifest.source.sha256, sourceSha256);
+  for (const sample of manifest.samples) {
+    assert.equal(sample.artifact.provenance.sourceSha256, sourceSha256);
+    assert.deepEqual(sample.artifact.provenance.build, build);
+    assert.equal(sample.artifact.sha256, pngSha256);
+    assert.equal(sample.artifact.byteLength, png.length);
+  }
+  assert.equal(manifest.cleanup.cleanup.cleanup.removed, true);
+});
+
+test("CLI always awaits session, scope and service cleanup after sampling failure", async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "noon-preview-cli-fail-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  await writeFile(path.join(root, "scene.py"), "scene\n");
+  const service = fakeService();
+  service.sampleFrames = async (scope, sessionId, times) => {
+    service.calls.push(["sampleFrames", scope, sessionId, [...times]]);
+    throw new Error("sample failed");
+  };
+  await assert.rejects(runPreviewCli({
+    argv: ["--source", "scene.py", "--output", "out", "--time", "1"],
+    cwd: root,
+    serviceFactory: () => service,
+  }), /sample failed/);
+  assert.deepEqual(service.calls.slice(-3).map((entry) => entry[0]), ["close", "closeScope", "dispose"]);
+  assert.equal(service.calls.find((entry) => entry[0] === "close")[3], "preview CLI failed");
+});
+
+test("CLI fails closed if retained bytes disagree with the service artifact descriptor", async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "noon-preview-cli-mismatch-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  await writeFile(path.join(root, "scene.py"), "scene\n");
+  const service = fakeService();
+  const getArtifact = service.getArtifact.bind(service);
+  service.getArtifact = (...args) => {
+    const retained = getArtifact(...args);
+    retained.png[retained.png.length - 1] ^= 0xff;
+    return retained;
+  };
+  await assert.rejects(runPreviewCli({
+    argv: ["--source", "scene.py", "--output", "out"], cwd: root, serviceFactory: () => service,
+  }), /does not match the coherent service observation/);
+  assert.deepEqual(service.calls.slice(-3).map((entry) => entry[0]), ["close", "closeScope", "dispose"]);
+});


### PR DESCRIPTION
Advances #1197 R4 shared-CLI acceptance over the landed `AgentPreviewService` (#1420), loaded-build provenance (#1422), and retained-frame quota (#1424). The branch was restacked directly onto post-#1422 master `87dfc12010c9d4edd2203fe98a99781bb1a1741e` to remove stale ancestry.

## Behavior

`node tools/noon-mcp/bin/noon-preview.mjs --source scene.py [--output DIR] [--loop-duration SEC] [--time SEC ...]`

- source is a bounded regular file (<=1 MiB) and SHA-256 identified;
- sample times are finite, bounded, nondecreasing, with at most 31 requested times so the initial frame plus samples fit the service's 32-frame retention budget;
- execution goes through one `AgentPreviewService` scope, not directly through `DockerPreviewSession`;
- PNG bytes are read back through the service's scoped artifact capability and verified against the retained descriptor before being written;
- `manifest.json` retains source identity plus service-provided observed build/source/time/backend provenance for every frame;
- output files use exclusive creation; success and failure await session, scope, service, and container cleanup.

## Real qualification

The existing Agent discovery MCP Docker job now conditionally invokes `test/docker-cli-smoke.mjs`. That smoke runs the actual CLI binary against the content-addressed Docker/Chromium runtime, independently re-hashes every PNG, checks manifest/artifact/source/time/backend/build association against `runtime-build-identity.json`, and asserts no owned preview container remains afterward. Evidence is uploaded with the existing preview isolation artifact.

## Boundary

No MCP rendering registration, alternate engine, second session registry, second artifact store, scene model, scheduler, renderer, or transport is introduced. Packaging/setup remains #1199 scope.

Repository CI/self-review only per `AGENTS.override.md`; keep draft until the restacked exact-head gates are green.