### PR TITLE
Preserve build provenance in no-JSPI browser controls

### DIFF
--- a/scripts/playground-gallery-runtime-smoke.mjs
+++ b/scripts/playground-gallery-runtime-smoke.mjs
@@ -66,15 +66,34 @@ try {
     const caseStartedAt = performance.now();
     const context = await browser.newContext({ ...options });
     await runtimeCache.install(context);
+    if (noJspi) {
+      await context.route('**/__noon_no_jspi_worker__.mjs', async route => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'text/javascript',
+          body: [
+            'delete WebAssembly.promising; delete WebAssembly.Suspending;',
+            "if (typeof WebAssembly.promising !== 'undefined' || typeof WebAssembly.Suspending !== 'undefined') throw new Error('JSPI test precondition failed');",
+            'await import("./python-worker.js");',
+            '',
+          ].join('\n'),
+        });
+      });
+    }
     // Observe the existing result envelope without guessing its payload shape.
     // The production parser below validates the semantic descriptor and duration;
     // semantic_execution is an object, not the boolean true.
     // Renderer time may precede completion of an authored static wait.
-    await context.addInitScript(({ channel, protocolVersion }) => {
+    await context.addInitScript(({ channel, protocolVersion, noJspi }) => {
       window.__galleryAuthoringResults = [];
       window.Worker = new Proxy(window.Worker, {
         construct(target, args, newTarget) {
-          const worker = Reflect.construct(target, args, newTarget);
+          let workerArgs = args;
+          if (noJspi && /\/python-worker\.js(?:[?#]|$)/.test(String(args[0]))) {
+            const workerUrl = new URL(String(args[0]), location.href);
+            workerArgs = [new URL('./__noon_no_jspi_worker__.mjs', workerUrl), ...args.slice(1)];
+          }
+          const worker = Reflect.construct(target, workerArgs, newTarget);
           worker.addEventListener('message', ({ data }) => {
             if (data?.channel === channel && data.type === 'result') {
               if (data.protocolVersion !== protocolVersion) {
@@ -87,15 +106,11 @@ try {
           return worker;
         },
       });
-    }, { channel: AUTHORING_CHANNEL, protocolVersion: AUTHORING_PROTOCOL_VERSION });
+    }, { channel: AUTHORING_CHANNEL, protocolVersion: AUTHORING_PROTOCOL_VERSION, noJspi });
     const page = await context.newPage();
     page.setDefaultTimeout(10000);
     const result = { id: entry.id, noJspi, browserName, profile, revision, browserVersion: browser.version(), errors: [], samples: [] };
     const name = `${entry.id}${noJspi ? '-no-jspi' : ''}`;
-    if (noJspi) await context.route('**/python-worker.js', async route => {
-      const response = await route.fetch();
-      await route.fulfill({ response, body: 'delete WebAssembly.promising; delete WebAssembly.Suspending;\n' + await response.text() });
-    });
     page.on('pageerror', error => result.errors.push(String(error)));
     page.on('console', msg => { if (msg.type() === 'error') result.errors.push(msg.text()); });
     try {

--- a/scripts/playground-main-thread-mobile-smoke.mjs
+++ b/scripts/playground-main-thread-mobile-smoke.mjs
@@ -105,24 +105,45 @@ try {
     { name: "automatic-no-jspi", host: null, disableJspi: true },
   ]) {
     const context = await browser.newContext({ ...devices["iPhone 13"] });
-    // Hold only the worker module response while recording the empty canvas.
-    // This preserves the real startup autoplay while making its first execution
-    // observable; clicking Run after preload would measure a replacement whose
-    // metrics wait for the previous Python context to retire.
+    if (variant.disableJspi) {
+      await context.route("**/__noon_no_jspi_worker__.mjs", async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "text/javascript",
+          body: [
+            "delete WebAssembly.promising; delete WebAssembly.Suspending;",
+            "if (typeof WebAssembly.promising !== 'undefined' || typeof WebAssembly.Suspending !== 'undefined') throw new Error('JSPI test precondition failed');",
+            "await import('./python-worker.js');",
+            "",
+          ].join("\n"),
+        });
+      });
+      await context.addInitScript(() => {
+        window.Worker = new Proxy(window.Worker, {
+          construct(target, args, newTarget) {
+            if (/\/python-worker\.js(?:[?#]|$)/.test(String(args[0]))) {
+              const workerUrl = new URL(String(args[0]), location.href);
+              return Reflect.construct(
+                target,
+                [new URL("./__noon_no_jspi_worker__.mjs", workerUrl), ...args.slice(1)],
+                newTarget,
+              );
+            }
+            return Reflect.construct(target, args, newTarget);
+          },
+        });
+      });
+    }
+    // Hold only the immutable worker module response while recording the empty
+    // canvas. The no-JSPI case changes the worker environment via a synthetic
+    // wrapper, never the verified python-worker.js bytes themselves.
     let releaseStartup;
     const startup = new Promise((resolve) => { releaseStartup = resolve; });
     releasePendingStartup = releaseStartup;
     await context.route("**/python-worker.js", async (route) => {
       const response = await route.fetch();
       await startup;
-      if (!variant.disableJspi) {
-        await route.fulfill({ response });
-        return;
-      }
-      await route.fulfill({ response, body:
-        "delete WebAssembly.promising; delete WebAssembly.Suspending;\n" +
-        "if (typeof WebAssembly.promising !== 'undefined' || typeof WebAssembly.Suspending !== 'undefined') throw new Error('JSPI test precondition failed');\n" + await response.text(),
-      });
+      await route.fulfill({ response });
     });
     const page = await context.newPage();
     activePage = page;


### PR DESCRIPTION
Dependent test-only correction for #1377 / #1197 R4c. The production runtime identity, verifier, generated worker, and authoring client are unchanged.

The failing no-JSPI browser controls were rewriting the served `python-worker.js` response bytes. #1377 intentionally binds the runtime identity to the immutable generated worker bytes, so its verifier correctly rejected that test-mutated worker when it later fetched the recorded worker path.

This correction disables JSPI without changing the verified worker bytes: the test replaces only the Worker launch URL with a synthetic module-worker bootstrap, deletes `WebAssembly.promising` / `WebAssembly.Suspending` there, then dynamically imports the untouched `python-worker.js`. The worker and its verifier therefore observe the exact bytes recorded by `runtime-build-identity.json`, while the portable no-JSPI execution path is still exercised before the worker module evaluates.

Changes are limited to the gallery runtime smoke and WebKit mobile fallback smoke. No production semantics, provenance guarantees, renderer behavior, or MCP surface changes. This PR should be qualified by the same browser matrices that failed on #1377. No automated/Codex review is requested or relied upon per `AGENTS.override.md`.